### PR TITLE
Add particDesc and reference speakers

### DIFF
--- a/tei/alamanni-tragedia-di-antigone.xml
+++ b/tei/alamanni-tragedia-di-antigone.xml
@@ -80,6 +80,40 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="antigone">
+            <persName>Antigone</persName>
+          </person>
+          <person xml:id="ismene">
+            <persName>Ismene</persName>
+          </person>
+          <personGrp xml:id="coro">
+            <name>Coro</name>
+          </personGrp>
+          <person xml:id="creonte">
+            <persName>Creonte</persName>
+          </person>
+          <person xml:id="messo">
+            <persName>Messo</persName>
+          </person>
+          <person xml:id="emone">
+            <persName>Emone</persName>
+          </person>
+          <person xml:id="tiresia">
+            <persName>Tiresia</persName>
+          </person>
+          <person xml:id="nunzio">
+            <persName>Nunzio</persName>
+          </person>
+          <person xml:id="euridice">
+            <persName>Euridice</persName>
+          </person>
+          <person xml:id="servo">
+            <persName>Servo</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT-Roma</name>Digitalizzazione - OCR</change>
@@ -145,7 +179,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
     </front>
     <body>
       <div type="act">
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
@@ -163,7 +197,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>L'alto disnor che dei nimici nostri</l>
           <l>I nostri amici con tal forza ingombra?</l>
         </sp>
-        <sp>
+        <sp who="#ismene">
           <speaker>
             <emph>Ismene</emph>
           </speaker>
@@ -176,7 +210,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Fu in quella notte, non ho cosa udita</l>
           <l>Che più lieta mi faccia, o più dolente.</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
@@ -184,7 +218,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Fe' ch'io ti trassi qua fuor della porta,</l>
           <l>Acciò che senz'altrui tu sola udissi.</l>
         </sp>
-        <sp>
+        <sp who="#ismene">
           <speaker>
             <emph>Ismene</emph>
           </speaker>
@@ -192,7 +226,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Mostri dipinti di soverchio sdegno,</l>
           <l>E parmi il ragionar doglioso e grave?</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
@@ -224,7 +258,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Porti l'alto valore, o se viltade</l>
           <l>Dentr'a sì nobil petto albergo truova.</l>
         </sp>
-        <sp>
+        <sp who="#ismene">
           <speaker>
             <emph>Ismene</emph>
           </speaker>
@@ -233,32 +267,32 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Di trapassar le leggi e sotterrarlo,</l>
           <l>S'e vero appunto quel che m'hai narrato?</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
           <l>Pensa pur se tu vuoi porgermi aiuto,</l>
         </sp>
-        <sp>
+        <sp who="#ismene">
           <speaker>
             <emph>Ismene</emph>
           </speaker>
           <l>O che pericol greve! ov'hai la mente?</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
           <l>E 'l corpo morto alzar con questa mano.</l>
         </sp>
-        <sp>
+        <sp who="#ismene">
           <speaker>
             <emph>Ismene</emph>
           </speaker>
           <l>Speri tu seppellirlo e che no 'l senta</l>
           <l>Questa città nimica e t'interrompa?</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
@@ -266,19 +300,19 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Al tuo fratello e mio sepolcro dare,</l>
           <l>Né cosa curo ch'avvenir mi possa.</l>
         </sp>
-        <sp>
+        <sp who="#ismene">
           <speaker>
             <emph>Ismene</emph>
           </speaker>
           <l>Contr'alla voglia, ahi lassa, di Creonte ?</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
           <l>A lui non lice il mio dever vietarmi.</l>
         </sp>
-        <sp>
+        <sp who="#ismene">
           <speaker>
             <emph>Ismene</emph>
           </speaker>
@@ -318,7 +352,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Ché stimar non si dee saggio colui</l>
           <l>Che quel ch'esser non puote indarno tenta.</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
@@ -338,40 +372,40 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>E s'a te par, di quel che 'l ciel fa stima</l>
           <l>Tien poca cura e resta, io v'andrò sola.</l>
         </sp>
-        <sp>
+        <sp who="#ismene">
           <speaker>
             <emph>Ismene</emph>
           </speaker>
           <l>Di questo non tengo io già poca cura,</l>
           <l>Ma 'l mio nulla sperar mi tira indietro.</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
           <l>Rimanti adunque; et io così m'invio</l>
           <l>A procacciar sepolcro al mio fratello.</l>
         </sp>
-        <sp>
+        <sp who="#ismene">
           <speaker>
             <emph>Ismene</emph>
           </speaker>
           <l>Oh che freddo timor m'agghiaccia il core!</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
           <l>Or non mi spaventar, pensa a te sola.</l>
         </sp>
-        <sp>
+        <sp who="#ismene">
           <speaker>
             <emph>Ismene</emph>
           </speaker>
           <l>Non aprir con altrui cotal pensiero,</l>
           <l>Ma tienlo ascoso; et io lo taccio ancora.</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
@@ -379,39 +413,39 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Sarai tacendo, che se 'l narri a molti,</l>
           <l>Ché l'opre pie non den tenersi ascose.</l>
         </sp>
-        <sp>
+        <sp who="#ismene">
           <speaker>
             <emph>Ismene</emph>
           </speaker>
           <l>Come nel proprio mal t'allegri e godi!</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
           <l>Anzi conosco ben quanto far deggio</l>
           <l>Volendo a quei piacer ch'io soli apprezzo.</l>
         </sp>
-        <sp>
+        <sp who="#ismene">
           <speaker>
             <emph>Ismene</emph>
           </speaker>
           <l>Pur di nuovo il dirò: tu tenti invano.</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
           <l>Quando più non potrò, starommi in posa.</l>
         </sp>
-        <sp>
+        <sp who="#ismene">
           <speaker>
             <emph>Ismene</emph>
           </speaker>
           <l>Non si convien l'incominciar quell'opra</l>
           <l>Che poi s'abbia a lasciar non giunta a fine.</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
@@ -424,7 +458,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Possa sentir più greve un cor gentile</l>
           <l>Che non morir con fama eterna e lode.</l>
         </sp>
-        <sp>
+        <sp who="#ismene">
           <speaker>
             <emph>Ismene</emph>
           </speaker>
@@ -433,7 +467,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Sia drittamente ai cari amici nostri,</l>
           <l>Poco sei saggia in sì dubbiosa impresa.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
@@ -534,7 +568,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Che noi qui tutti insieme</l>
           <l>Venissimo in quest'ora a lui dinanzi.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
@@ -604,7 +638,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Di questa patria, da me sempre aspetti</l>
           <l>E vivendo e morendo onore e pregio.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
@@ -613,44 +647,44 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>È lecito il dispor così dei morti</l>
           <l>Come di noi che qui viviamo ancora.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Gitene or dunque dove 'l morto giace</l>
           <l>A far che 'l mio voler non torni vano.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
           <l>Da più giovini spalle è questo incarco.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Altri son là che vi saranno aita.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
           <l>Or che bisogna dar tal cura a tanti ?</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Per non fidarla a chi non abbia fede.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
           <l>Qual sì stolto sarà che cerchi morte ?</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
@@ -658,7 +692,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Che 'l soverchio sperar d'assai guadagno</l>
           <l>Conduce l'uom ch'ei non si sente al fine.</l>
         </sp>
-        <sp>
+        <sp who="#messo">
           <speaker>
             <emph>Messo</emph>
           </speaker>
@@ -685,13 +719,13 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Di bene o mal sentir che quello stesso</l>
           <l>Ch'i fati destinar nel dì ch'io nacqui.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Che vuoi tu dir ond'hai tanto timore ?</l>
         </sp>
-        <sp>
+        <sp who="#messo">
           <speaker>
             <emph>Messo</emph>
           </speaker>
@@ -700,26 +734,26 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Ch'io vi prometto ben che premio alcuno</l>
           <l>Non m'aria fatto far sì greve errore.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Or di' tosto oramai, che cosa è questa ?</l>
         </sp>
-        <sp>
+        <sp who="#messo">
           <speaker>
             <emph>Messo</emph>
           </speaker>
           <l>Soglion l'avverse nuove a chi le porta</l>
           <l>Porger sempre nel dir tardezza e tema.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Dillo omai tosto; e ti nascondi e fuggi.</l>
         </sp>
-        <sp>
+        <sp who="#messo">
           <speaker>
             <emph>Messo</emph>
           </speaker>
@@ -727,13 +761,13 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Ad onorar quel morto, e netto e puro</l>
           <l>L'ha sotterra riposto in poca fossa.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Or che mi narri tu ? chi fu costui ?</l>
         </sp>
-        <sp>
+        <sp who="#messo">
           <speaker>
             <emph>Messo</emph>
           </speaker>
@@ -776,7 +810,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Ché nessun vede volentier quel messo</l>
           <l>Che gli viene a portar novelle avverse.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
@@ -784,7 +818,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Che tutto quel ch'udite non sia stato</l>
           <l>Senza certo voler degli alti Dei.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
@@ -831,25 +865,25 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Che dei peccati lor riporton pena,</l>
           <l>Che gli altri che ne son gioiosi e lieti.</l>
         </sp>
-        <sp>
+        <sp who="#messo">
           <speaker>
             <emph>Messo</emph>
           </speaker>
           <l>Deggio io dir altro, o mi ritorno indietro ?</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Va', che fortuna ria ti faccia scorta.</l>
         </sp>
-        <sp>
+        <sp who="#messo">
           <speaker>
             <emph>Messo</emph>
           </speaker>
           <l>Basta a me ch'io non ho commesso fallo.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
@@ -859,7 +893,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Quei ch'han fallito, allor saprete come</l>
           <l>I malvagi guadagni arrecon doglia.</l>
         </sp>
-        <sp>
+        <sp who="#messo">
           <speaker>
             <emph>Messo</emph>
           </speaker>
@@ -870,7 +904,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Fuor d'ogni opinion, fuor d'ogni spene,</l>
           <l>Salvo (e ringrazio Dio) mi torno indietro.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
@@ -942,26 +976,26 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Forse essendo colei ch'ei disse dianzi</l>
           <l>Or viene innanzi al re per pianto eterno.</l>
         </sp>
-        <sp>
+        <sp who="#messo">
           <speaker>
             <emph>Messo</emph>
           </speaker>
           <l>Questa è colei che ricopriva il morto,</l>
           <l>Costei trovammo; ma dov'è Creonte ?</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
           <l>Eccol che verso noi ritorna appunto.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Hai tu trovato ancor chi fusse quello ?</l>
         </sp>
-        <sp>
+        <sp who="#messo">
           <speaker>
             <emph>Messo</emph>
           </speaker>
@@ -978,25 +1012,25 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Riprendete e punite, ch'io mi truovo</l>
           <l>D'ogni sospetto omai purgato in tutto.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Or come e d'onde vien costei ch'io veggio ?</l>
         </sp>
-        <sp>
+        <sp who="#messo">
           <speaker>
             <emph>Messo</emph>
           </speaker>
           <l>Costei coperse il morto, indi la meno.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Sai tu ben certo quel ch'affermi e narri ?</l>
         </sp>
-        <sp>
+        <sp who="#messo">
           <speaker>
             <emph>Messo</emph>
           </speaker>
@@ -1004,13 +1038,13 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Quel morto istesso che bandito avete:</l>
           <l>Or dico io cose manifeste e conte ?</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Come il vedesti tu? come fu presa?</l>
         </sp>
-        <sp>
+        <sp who="#messo">
           <speaker>
             <emph>Messo</emph>
           </speaker>
@@ -1058,7 +1092,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Pur ogni cosa alfin men dura viene</l>
           <l>Che 'l sentirsi vicin l'estremo giorno.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
@@ -1066,13 +1100,13 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Dimmi or tu, stolta, che sì ardita ascolti,</l>
           <l>Confessi quel ch'ei disse, o neghi 'l vero ?</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
           <l>Confesso sì, perché negar lo deggio ?</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
@@ -1081,19 +1115,19 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Tu con brevi parole dimmi ancora:</l>
           <l>Sapevi tu d'oprar contra 'l mio bando ?</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
           <l>Sapevo sì, ché lo sapea ciascuno.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Ardisti adunque a trapassar le leggi ?</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
@@ -1123,7 +1157,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>E chi di tal pensier mi tiene stolta,</l>
           <l>Ben lo potrei chiamar vile e crudele.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
@@ -1131,7 +1165,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Del duro padre, che per nulla vuole</l>
           <l>Rendersi vinta alla Fortuna avversa.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
@@ -1165,19 +1199,19 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Come folle è da dir chi lode e pregio</l>
           <l>Vuol riportar d'un suo commesso errore !</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
           <l>Ch'altro volete voi che la mia morte ?</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Null'altro cerco, ché ragione il vuole.</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
@@ -1194,110 +1228,110 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Che può far sempre e dir quant'a lui piace,</l>
           <l>Né si sente biasmar com'altri suole.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Sei tu tra tanti a veder questo sola ?</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
           <l>Ogni altro 'l vede ancor, ma teme e tace.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>L'ardir più di costor non t'è vergogna ?</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
           <l>L'onorare i fratei non merta biasmo.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Non era tuo fratel quel ch'egli ancise ?</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
           <l>D'un padre uscimmo e della stessa madre.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Perch'adunque sei grata a quel crudele ?</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
           <l>Non si può dir crudel poi ch'uno è morto.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Non cancella il morir gli altrui peccati.</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
           <l>Or non fur questi due fratelli insieme ?</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>L'un nimico alla patria, e l'altro amico.</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
           <l>Pur vuol Pluton che si sotterri un morto.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Non con equale onor l'ingiusto e 'l giusto.</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
           <l>Che viltade è punir chi morto giace ?</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>E dopo morte ancor s'odia il nimico.</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
           <l>Per ambe amar non per odiargli nacqui.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Andrai dunque ad amarlo nell'inferno,</l>
           <l>Ché qui non l'amerai sotto 'l mio impero.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
@@ -1307,7 +1341,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Le guance e 'l bel colore</l>
           <l>Macchion di tristo umore.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
@@ -1318,28 +1352,28 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Dimmi, confessi tu d'aver saputo</l>
           <l>Del seppellir quel morto, o vuoi negarlo ?</l>
         </sp>
-        <sp>
+        <sp who="#ismene">
           <speaker>
             <emph>Ismene</emph>
           </speaker>
           <l>Ciò che fece costei feci ancor io;</l>
           <l>E seppi 'l tutto, e fui presente all'opra.</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
           <l>Cessin gli Dei ch'io t'acconsenta questo,</l>
           <l>Ch'a sì lodato ben lontana fusti.</l>
         </sp>
-        <sp>
+        <sp who="#ismene">
           <speaker>
             <emph>Ismene</emph>
           </speaker>
           <l>Deh fammi degna in sì misera sorte</l>
           <l>D'esser compagna de' tuoi duri affanni.</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
@@ -1347,101 +1381,101 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Come sempre spregiai quei falsi amici</l>
           <l>Che pur sono in parole amici altrui.</l>
         </sp>
-        <sp>
+        <sp who="#ismene">
           <speaker>
             <emph>Ismene</emph>
           </speaker>
           <l>Deh non mi dinegar, sorella cara,</l>
           <l>Il morir teco e l'onorar quel morto.</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
           <l>Meco non morrai tu, né tuo farai</l>
           <l>Quel ch'è d'altrui, ch'è mia la morte e l'opra.</l>
         </sp>
-        <sp>
+        <sp who="#ismene">
           <speaker>
             <emph>Ismene</emph>
           </speaker>
           <l>E senza te che mi fia dolce in vita ?</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
           <l>Dimandane il signor qui tuo Creonte.</l>
         </sp>
-        <sp>
+        <sp who="#ismene">
           <speaker>
             <emph>Ismene</emph>
           </speaker>
           <l>Perché senza cagion m'offendi e pungi ?</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
           <l>A me ne pesa e duol d'averlo a dirti.</l>
         </sp>
-        <sp>
+        <sp who="#ismene">
           <speaker>
             <emph>Ismene</emph>
           </speaker>
           <l>Deh dimmi, in che potrei giovarti ancora ?</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
           <l>In salvar te, perché 'l tuo scampo bramo.</l>
         </sp>
-        <sp>
+        <sp who="#ismene">
           <speaker>
             <emph>Ismene</emph>
           </speaker>
           <l>Deggio, lassa, perciò non morir teco ?</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
           <l>Tu la vita cercasti, et io la morte.</l>
         </sp>
-        <sp>
+        <sp who="#ismene">
           <speaker>
             <emph>Ismene</emph>
           </speaker>
           <l>Io pur del nostro mal presaga fui.</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
           <l>Costui te saggia, e questi me diranno.</l>
         </sp>
-        <sp>
+        <sp who="#ismene">
           <speaker>
             <emph>Ismene</emph>
           </speaker>
           <l>Pur fu d'ambe due noi comune il fallo.</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
           <l>Non ti doler che vivi; e queste membra</l>
           <l>Son morte tal che già tra i morti stanno.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>L'una di queste due conosco stolta</l>
           <l>Novellamente, e l'altra il dì che nacque.</l>
         </sp>
-        <sp>
+        <sp who="#ismene">
           <speaker>
             <emph>Ismene</emph>
           </speaker>
@@ -1451,74 +1485,74 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Alfin matura, il tempo cangia e spegne</l>
           <l>Ogni altero desir ch'a ciò ne spinge.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Non s'è spento anco in te, ch'esser vorresti</l>
           <l>Compagna stata di chi male adopra.</l>
         </sp>
-        <sp>
+        <sp who="#ismene">
           <speaker>
             <emph>Ismene</emph>
           </speaker>
           <l>S'io son senza costei, che fo nel mondo ?</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Allor lo sentirai che morta fia.</l>
         </sp>
-        <sp>
+        <sp who="#ismene">
           <speaker>
             <emph>Ismene</emph>
           </speaker>
           <l>La sposa anciderai d'un tuo figliuolo ?</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Molt'altre ce ne fia da dargli spose.</l>
         </sp>
-        <sp>
+        <sp who="#ismene">
           <speaker>
             <emph>Ismene</emph>
           </speaker>
           <l>Ma non come costei chiara e gentile.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Non cerca il mio figliuol sì fatte donne.</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
           <l>Deh perché non sei qui, mio caro Emone !</l>
         </sp>
-        <sp>
+        <sp who="#ismene">
           <speaker>
             <emph>Ismene</emph>
           </speaker>
           <l>Vorrai però privar di questa il figlio?</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Omai le nozze sue tra i morti fieno.</l>
         </sp>
-        <sp>
+        <sp who="#ismene">
           <speaker>
             <emph>Ismene</emph>
           </speaker>
           <l>Adunque ella morrà ? Dio no 'l consenta.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
@@ -1529,7 +1563,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Che gli arditi anco fuggon quando appresso</l>
           <l>Senton venir la morte, e cercon vita.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
@@ -1602,7 +1636,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Vista irata e dogliosa,</l>
           <l>Fors'a cagion d'Antigone sua sposa.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
@@ -1611,7 +1645,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Della tua sposa quel che far si deggia ?</l>
           <l>O pur vuoi consentir quel ch'a me piace ?</l>
         </sp>
-        <sp>
+        <sp who="#emone">
           <speaker>
             <emph>Emone</emph>
           </speaker>
@@ -1620,7 +1654,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Né potrò mai gradir nozze né sposa</l>
           <l>Più ch'i vostri paterni e buon consigli.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
@@ -1670,7 +1704,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Un uom, ché pur vergogna troppa fora</l>
           <l>L'esser chiamati noi di donna servi.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
@@ -1678,7 +1712,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Consumato non è, nessun porria</l>
           <l>Con più sagge parole aprirne il vero.</l>
         </sp>
-        <sp>
+        <sp who="#emone">
           <speaker>
             <emph>Emone</emph>
           </speaker>
@@ -1741,7 +1775,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Un tal dono a' mortai, sempre conviensi</l>
           <l>Ricorrer (dico) ai buon consigli altrui.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
@@ -1749,189 +1783,189 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Signor, se cosa alcuna util vi mostra,</l>
           <l>Né tu da lui, ché l'uno e altro è saggio.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Degg'io per tanta età nel mondo avvezzo</l>
           <l>In sì giovine scuola apprender senno ?</l>
         </sp>
-        <sp>
+        <sp who="#emone">
           <speaker>
             <emph>Emone</emph>
           </speaker>
           <l>Torto questo saria, che l'età sola</l>
           <l>Non si dee riguardar, ma l'opre ancora.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>L'onorar donna ingiusta è sì degna opra ?</l>
         </sp>
-        <sp>
+        <sp who="#emone">
           <speaker>
             <emph>Emone</emph>
           </speaker>
           <l>Io non cerco onorar chi ingiusta sia.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Or non fu 'l suo fallir di pena degno ?</l>
         </sp>
-        <sp>
+        <sp who="#emone">
           <speaker>
             <emph>Emone</emph>
           </speaker>
           <l>Non dicon quei miglior che Tebe onora.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Il popol non dà leggi al suo signore.</l>
         </sp>
-        <sp>
+        <sp who="#emone">
           <speaker>
             <emph>Emone</emph>
           </speaker>
           <l>Non è d'un re questa sentenzia degna.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Altri è dunque signor d'esta cittade ?</l>
         </sp>
-        <sp>
+        <sp who="#emone">
           <speaker>
             <emph>Emone</emph>
           </speaker>
           <l>Non si truova città che sia d'un solo.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Non son di noi signor le città serve ?</l>
         </sp>
-        <sp>
+        <sp who="#emone">
           <speaker>
             <emph>Emone</emph>
           </speaker>
           <l>Sì, mentre sete voi servi alle leggi.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Che quistion prendi tu per una donna ?</l>
         </sp>
-        <sp>
+        <sp who="#emone">
           <speaker>
             <emph>Emone</emph>
           </speaker>
           <l>Sì, sendo donna voi, ché per voi parlo.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>O scelerato ! e contro al padre istesso !</l>
         </sp>
-        <sp>
+        <sp who="#emone">
           <speaker>
             <emph>Emone</emph>
           </speaker>
           <l>Perch'io vi veggio oprare ingiusti effetti.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Non è giusto 'l servar dritto 'l mio impero ?</l>
         </sp>
-        <sp>
+        <sp who="#emone">
           <speaker>
             <emph>Emone</emph>
           </speaker>
           <l>Ma non privar gli Dei del dritto onore.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>O pensier femminile ! o basso spirto !</l>
         </sp>
-        <sp>
+        <sp who="#emone">
           <speaker>
             <emph>Emone</emph>
           </speaker>
           <l>Non fui da cosa vil macchiato ancora.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Non è sol d'una donna il tuo parlare ?</l>
         </sp>
-        <sp>
+        <sp who="#emone">
           <speaker>
             <emph>Emone</emph>
           </speaker>
           <l>Di voi, di me, dei santi Dei ragiono.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Non sarà già costei tua sposa in vita.</l>
         </sp>
-        <sp>
+        <sp who="#emone">
           <speaker>
             <emph>Emone</emph>
           </speaker>
           <l>Se così dee morir, non morrà sola.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Sei tu sì stolto che minacci il padre ?</l>
         </sp>
-        <sp>
+        <sp who="#emone">
           <speaker>
             <emph>Emone</emph>
           </speaker>
           <l>Che giova il minacciar le menti inique ?</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Tu stolto diverrai piangendo saggio.</l>
         </sp>
-        <sp>
+        <sp who="#emone">
           <speaker>
             <emph>Emone</emph>
           </speaker>
           <l>Ancor direi, se voi non fusse padre.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Non mi molestar più, servo di donna.</l>
         </sp>
-        <sp>
+        <sp who="#emone">
           <speaker>
             <emph>Emone</emph>
           </speaker>
           <l>Volete voi parlar ch'io sempre taccia ?</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
@@ -1940,7 +1974,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Menate quella a me, ch'avanti agli occhi</l>
           <l>Del folle sposo suo morrà la sposa.</l>
         </sp>
-        <sp>
+        <sp who="#emone">
           <speaker>
             <emph>Emone</emph>
           </speaker>
@@ -1949,14 +1983,14 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Né tu mai più vedrai questo tuo figlio,</l>
           <l>Ma con gli adulator ti resta e parla.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
           <l>Il vecchio re di soverchia ira è carco,</l>
           <l>E di doglia soverchia il giovin figlio.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
@@ -1964,25 +1998,25 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Ch'offender me, né queste due sorelle</l>
           <l>Dal destinato fin potrà scampare.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
           <l>Volete voi che l'una e l'altra mora ?</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Chi non ha colpa in ciò non porti pena.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
           <l>Che modo al morir suo pensato avete ?</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
@@ -1996,7 +2030,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>E vedrà certo allor quanto sia folle</l>
           <l>Colei ch'i morti onora, e i vivi offende.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
@@ -2056,7 +2090,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>L'angelica figura</l>
           <l>Da questa tomba oscura?</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
@@ -2073,7 +2107,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Ma prendo in nuovo sposo</l>
           <l>L'inferno a cui sarò congiunta in breve.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
@@ -2084,7 +2118,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Ma viva e sciolta sola infra i mortali</l>
           <l>Discendi dove al fin discende ogni uomo.</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
@@ -2100,7 +2134,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Lassa, ch'a questo uguale</l>
           <l>Misero stato mi riserba il cielo !</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
@@ -2109,7 +2143,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Sì ch'è ben da pregiar s'ad uom mortale</l>
           <l>Simil sorte agli Dei nel mondo incontra.</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
@@ -2126,7 +2160,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Né sarò, lassa, ohimè misera al tutto</l>
           <l>Tra i morti, né tra i vivi.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
@@ -2137,7 +2171,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Ma in cotal guisa forse</l>
           <l>Sostien' la pena dei paterni falli.</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
@@ -2162,7 +2196,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Quand'io ti vidi in terra</l>
           <l>Or, lassa, è che m'ancide.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
@@ -2172,7 +2206,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Ma l'alta aspra durezza</l>
           <l>Innata entro 'l tuo cor t'indusse a questo.</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
@@ -2187,7 +2221,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Struggersi in pianto, alcun non veggio intorno</l>
           <l>Ch'almen si doglia alquanto.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
@@ -2201,7 +2235,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Noi siam purgati d'ogni colpa ria,</l>
           <l>E lei privata avrem di questa luce.</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
@@ -2251,35 +2285,35 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Pena maggior che quella stessa ch'ora,</l>
           <l>Lassa, contra 'l dever mi sta davanti.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
           <l>Ancor vivono in lei gli spirti interi,</l>
           <l>E l'alma è scarca e non da tema oppressa.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Ben veggio omai che 'l tardar vostro fia</l>
           <l>Cagione al fin di pianto a tutti voi.</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
           <l>A tostissima morte mi conduce</l>
           <l>Questa minaccia acerba.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Io ti conforto a non aver più spene</l>
           <l>Ch'altro deggia seguir che quanto è detto.</l>
         </sp>
-        <sp>
+        <sp who="#antigone">
           <speaker>
             <emph>Antigone</emph>
           </speaker>
@@ -2292,7 +2326,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Che morte acerba e da qual uom sostiene</l>
           <l>Perché fu giusta e pia!</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
@@ -2360,7 +2394,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Io prego umile il ciel ch'omai ne mostri</l>
           <l>Vicino il fin dei lunghi affanni nostri.</l>
         </sp>
-        <sp>
+        <sp who="#tiresia">
           <speaker>
             <emph>Tiresia</emph>
           </speaker>
@@ -2368,49 +2402,49 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Per un sol veggiam lume, perch'ai ciechi</l>
           <l>Convien che d'altrui sia la strada scorta.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Che nuove apporti, o mio Tiresia antico ?</l>
         </sp>
-        <sp>
+        <sp who="#tiresia">
           <speaker>
             <emph>Tiresia</emph>
           </speaker>
           <l>Io tel dirò, ma fa' quant'io ti mostro.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Io non fui mai dal tuo voler lontano.</l>
         </sp>
-        <sp>
+        <sp who="#tiresia">
           <speaker>
             <emph>Tiresia</emph>
           </speaker>
           <l>E per ciò sei venuto in questo impero.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Sempre m'affaticai nel ben di quello.</l>
         </sp>
-        <sp>
+        <sp who="#tiresia">
           <speaker>
             <emph>Tiresia</emph>
           </speaker>
           <l>Fa' pur d'esser or saggio al gran bisogno.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Ohimè che 'l tuo parlar mi dà spavento!</l>
         </sp>
-        <sp>
+        <sp who="#tiresia">
           <speaker>
             <emph>Tiresia</emph>
           </speaker>
@@ -2456,7 +2490,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Pensala ben, ti dico, e gran guadagno</l>
           <l>È l'imparar da chi t'insegna 'l bene.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
@@ -2477,103 +2511,103 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Quel rovinar cui vil guadagno muove</l>
           <l>All'altrui confortar nell'opre ingiuste.</l>
         </sp>
-        <sp>
+        <sp who="#tiresia">
           <speaker>
             <emph>Tiresia</emph>
           </speaker>
           <l>Chi 'l vide mai di me, chi 'l pensò mai?</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Non bisogna cercar chi 'l vide, o seppe.</l>
         </sp>
-        <sp>
+        <sp who="#tiresia">
           <speaker>
             <emph>Tiresia</emph>
           </speaker>
           <l>Quant'è nobil più d'altro il buon consiglio!</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Quanto l'essere stolto è maggior peste.</l>
         </sp>
-        <sp>
+        <sp who="#tiresia">
           <speaker>
             <emph>Tiresia</emph>
           </speaker>
           <l>Da tale infermità sei tu compreso.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Non voglio ad un profeta oltraggio dire.</l>
         </sp>
-        <sp>
+        <sp who="#tiresia">
           <speaker>
             <emph>Tiresia</emph>
           </speaker>
           <l>Qual oltraggio maggior che dir bugiardo?</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Sempre l'uom ch'indivina ama l'argento.</l>
         </sp>
-        <sp>
+        <sp who="#tiresia">
           <speaker>
             <emph>Tiresia</emph>
           </speaker>
           <l>E gl'ingiusti guadagni ama 'l tiranno.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Sai tu ben che tu parli al tuo signore?</l>
         </sp>
-        <sp>
+        <sp who="#tiresia">
           <speaker>
             <emph>Tiresia</emph>
           </speaker>
           <l>So, perch'a mia cagion venisti tale.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Tu sei saggio profeta, ma non giusto.</l>
         </sp>
-        <sp>
+        <sp who="#tiresia">
           <speaker>
             <emph>Tiresia</emph>
           </speaker>
           <l>Cosa dir mi farai ch'io non volea.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Di' pur, che 'l premio più che 'l ver ti spinge.</l>
         </sp>
-        <sp>
+        <sp who="#tiresia">
           <speaker>
             <emph>Tiresia</emph>
           </speaker>
           <l>Part'ei ch'ora 'l mio dir risguardi a prezzo?</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Non or che sai ch'ogni tuo inganno è vano.</l>
         </sp>
-        <sp>
+        <sp who="#tiresia">
           <speaker>
             <emph>Tiresia</emph>
           </speaker>
@@ -2608,7 +2642,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>A più tener la lingua a sé ristretta,</l>
           <l>Et anco esser più saggio ch'ei non mostra.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
@@ -2618,7 +2652,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>D'altro giovin color si fer d'argento,</l>
           <l>Non trovammo il suo dir fallace e vano.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
@@ -2627,52 +2661,52 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>E 'l contrastar quando 'l periglio è sopra</l>
           <l>È solo un ricercar fatiche e danni.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
           <l>A voi convien usar consiglio e senno.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Di' pur, ch'io sono alle tue voglie presto.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
           <l>Mandate a trar colei fuor del sepolcro,</l>
           <l>E sepolcro da poi donate al morto.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Part'ei perciò che così deggia fare ?</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
           <l>Tosto quanto si può, ché la vendetta</l>
           <l>Dal ciel dopo 'l fallir veloce viene.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Deh con che greve duol m'induco a questo!</l>
           <l>Ma la necessità vince ogn'impresa.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
           <l>Gite voi stesso e non mandate altrui.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
@@ -2684,7 +2718,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>E confesso oramai ch'i nostri sdegni</l>
           <l>Non devrien sormontar l'antiche leggi.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
@@ -2731,7 +2765,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Seguir sol quella strada</l>
           <l>Ch'a quest'altera aggrada.</l>
         </sp>
-        <sp>
+        <sp who="#nunzio">
           <speaker>
             <emph>Nunzio</emph>
           </speaker>
@@ -2756,55 +2790,55 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Ché 'l diletto medesmo indi ne tragge</l>
           <l>Che dal dolce sapore il gusto infermo.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
           <l>Che nuovo danno avvien nei signor nostri?</l>
         </sp>
-        <sp>
+        <sp who="#nunzio">
           <speaker>
             <emph>Nunzio</emph>
           </speaker>
           <l>Son morti, e vive sol chi n'ha cagione.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
           <l>Chi è morto? chi ancise? dinnel tosto.</l>
         </sp>
-        <sp>
+        <sp who="#nunzio">
           <speaker>
             <emph>Nunzio</emph>
           </speaker>
           <l>Emone è morto, che se stesso ancise.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
           <l>Per man paterna, o per la stessa è morto ?</l>
         </sp>
-        <sp>
+        <sp who="#nunzio">
           <speaker>
             <emph>Nunzio</emph>
           </speaker>
           <l>Per man sua stessa, e per cagion del padre.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
           <l>Pur conoscesti 'l ver, santo profeta.</l>
         </sp>
-        <sp>
+        <sp who="#nunzio">
           <speaker>
             <emph>Nunzio</emph>
           </speaker>
           <l>Consiglio or ne bisogna all'altre cose.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
@@ -2812,7 +2846,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Sposa infelice, che fuor ratta scende,</l>
           <l>O per piangere 'l figlio, o forse a caso.</l>
         </sp>
-        <sp>
+        <sp who="#euridice">
           <speaker>
             <emph>Euridice</emph>
           </speaker>
@@ -2828,7 +2862,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Che 'l narrerete a chi per lunga usanza</l>
           <l>Ha nell'avverse cose avvezza l'alma.</l>
         </sp>
-        <sp>
+        <sp who="#nunzio">
           <speaker>
             <emph>Nunzio</emph>
           </speaker>
@@ -2904,14 +2938,14 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Quant'è d'ogni altro più dannoso errore</l>
           <l>Il non dar fede ai buon consigli altrui.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
           <l>Che debbian noi pensar? l'alta regina</l>
           <l>Senz'altra sua risposta torna indietro.</l>
         </sp>
-        <sp>
+        <sp who="#nunzio">
           <speaker>
             <emph>Nunzio</emph>
           </speaker>
@@ -2922,14 +2956,14 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Ella è pur saggia, onde temer non posso</l>
           <l>Che soverchio dolor l'induca a morte.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
           <l>Sempr'è più greve 'l duol quand'altri 'l preme,</l>
           <l>Che quel che si disfoga in pianti e 'n voci.</l>
         </sp>
-        <sp>
+        <sp who="#nunzio">
           <speaker>
             <emph>Nunzio</emph>
           </speaker>
@@ -2937,7 +2971,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Se questa afflitta per soverchio affanno</l>
           <l>In sé disfoga il chiuso duol che porta.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
@@ -2946,7 +2980,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Ma se lecito m'è, cagion n'è stato</l>
           <l>Il proprio suo, non già l'altrui difetto.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
@@ -2964,13 +2998,13 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Or t'ha condotto a tale,</l>
           <l>Ma i miei consigli stolti.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
           <l>Deh, come or conoscete indarno 'l vero!</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
@@ -2985,7 +3019,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Ahi fatiche mondane,</l>
           <l>Come al più sete voi dannose e grevi!</l>
         </sp>
-        <sp>
+        <sp who="#servo">
           <speaker>
             <emph>Servo</emph>
           </speaker>
@@ -2993,20 +3027,20 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Lasso, vi reco, e nuovo danno acerbo</l>
           <l>Tosto udirete, e non minor del primo.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Che mal può più venir?che danno è questo?</l>
         </sp>
-        <sp>
+        <sp who="#servo">
           <speaker>
             <emph>Servo</emph>
           </speaker>
           <l>La madre di quel morto e vostra sposa</l>
           <l>Ha per soverchio duol se stessa ancisa.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
@@ -3024,13 +3058,13 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Del mio caro figliuol congiunta sia</l>
           <l>La morte ancor della mia dolce sposa?</l>
         </sp>
-        <sp>
+        <sp who="#servo">
           <speaker>
             <emph>Servo</emph>
           </speaker>
           <l>Veder si può, ch'ivi entro morta giace.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
@@ -3043,7 +3077,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Or della donna mia la morte intendo:</l>
           <l>Oh, oh madre infelice! oh miser figlio!</l>
         </sp>
-        <sp>
+        <sp who="#servo">
           <speaker>
             <emph>Servo</emph>
           </speaker>
@@ -3055,7 +3089,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Pregò che l'ira sua volgesse in voi,</l>
           <l>Come in sola cagion ch'uccise 'l figlio.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
@@ -3070,27 +3104,27 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Viver non voglio, e pure</l>
           <l>Temo (e non so perché), morte, i tuoi colpi.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
           <l>Or ch'ha condotto a tal la donna e 'l figlio,</l>
           <l>Stolto invan si riprende e di sé teme.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Dimmi di nuovo com'a morte venne.</l>
         </sp>
-        <sp>
+        <sp who="#servo">
           <speaker>
             <emph>Servo</emph>
           </speaker>
           <l>Nel ventre suo con rabbia un coltel misse</l>
           <l>Tosto ch'udì del figlio il caso acerbo.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
@@ -3102,14 +3136,14 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Là dov'occhio mortal mai più non scerna,</l>
           <l>Ch'io non son più Creonte, io son la morte.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>
           <l>Al miser uom non giova andar lontano,</l>
           <l>Che la Fortuna il segue ovunqu'ei fugge.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
@@ -3119,7 +3153,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Venga venga oramai,</l>
           <l>Sì ch'altro nuovo sol mai più non veggia.</l>
         </sp>
-        <sp>
+        <sp who="#servo">
           <speaker>
             <emph>Servo</emph>
           </speaker>
@@ -3127,20 +3161,20 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>S'aspetta il provveder quel ch'esser deve;</l>
           <l>Pensiam rimedio a quanto n'è presente.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
           <l>Io vo pregando quel che più vorrei.</l>
         </sp>
-        <sp>
+        <sp who="#servo">
           <speaker>
             <emph>Servo</emph>
           </speaker>
           <l>Vano è 'l pregar, perciò che ferma e certa</l>
           <l>Sua ventura ha ciascun dal dì ch'ei nacque.</l>
         </sp>
-        <sp>
+        <sp who="#creonte">
           <speaker>
             <emph>Creonte</emph>
           </speaker>
@@ -3161,7 +3195,7 @@ piangendo la morte del figliuolo e della moglie amaramente</p>
           <l>Il morir mi dà tema, il viver doglia,</l>
           <l>Né posso altro sperar che peggio ognora.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <emph>Coro</emph>
           </speaker>

--- a/tei/alfieri-agamennone.xml
+++ b/tei/alfieri-agamennone.xml
@@ -82,6 +82,22 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="egisto">
+            <persName>Egisto</persName>
+          </person>
+          <person xml:id="clitennestra">
+            <persName>Clitennestra</persName>
+          </person>
+          <person xml:id="elettra">
+            <persName>Elettra</persName>
+          </person>
+          <person xml:id="agamennone">
+            <persName>Agamennone</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione - OCR</change>
@@ -125,7 +141,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>EGISTO</stage>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -154,7 +170,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>EGISTO, CLITENNESTRA</stage>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -163,7 +179,7 @@
             <l>a me tu celi, a me?... degg'io vederti</l>
             <l>sfuggendo andar chi sol per te respira?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -175,7 +191,7 @@
             <l>già già si appressa il giorno doloroso,</l>
             <l>in cui partir tu men farai,... tu stessa.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -184,7 +200,7 @@
             <l>s'altro pensier, che di te solo, io serri</l>
             <l part="I">nell'infiammato petto.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -206,7 +222,7 @@
             <l>in Argo mai l'abbominato figlio</l>
             <l>dell'implacabil suo mortal nemico?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -215,7 +231,7 @@
             <l>re vincitor non serba odio a nemico,</l>
             <l part="I">di cui non teme.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -225,14 +241,14 @@
             <l>ma dispregiar mi puote: a oltraggio tale</l>
             <l>vuoi ch'io rimanga? a me il consigli, e m'ami?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l>Tu m'ami, e il rio pensier pur volger puoi</l>
             <l part="I">d'abbandonarmi?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -254,7 +270,7 @@
             <l>darti bensì questa terribil prova</l>
             <l>deggio, e salvarti con l'onor la vita.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -268,7 +284,7 @@
             <l>che al fin vendetta, ancor che tarda, intera</l>
             <l>della svenata figlia mia darammi.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -279,7 +295,7 @@
             <l>misero gioco? a me, di gloria privo,</l>
             <l>d'oro, d'armi, di sudditi, di amici?...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -302,7 +318,7 @@
             <l>d'un cotal padre. — Io più nol vidi; e s'oggi</l>
             <l part="I">al fin Fortuna lo tradisse...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -322,7 +338,7 @@
             <l>dileguerassi, come al sole nebbia,</l>
             <l>il basso amor che per me in petto or nutri.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -334,7 +350,7 @@
             <l>Non l'amo io, no. — Ben altro padre, Egisto,</l>
             <l part="I">stato saresti ai figli miei.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -348,7 +364,7 @@
             <l>se tuo divien, cader vittima sola</l>
             <l>ben io saprò di un infelice amore.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -363,7 +379,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>ELETTRA, CLITENNESTRA</stage>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -375,14 +391,14 @@
             <l>se insorgon nuovi ognor perigli a torre</l>
             <l>che il trionfante Agamennón qui rieda?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l>Si accerta dunque il grido, che dispersi</l>
             <l>vuole, e naufraghi, i legni degli Achei?</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -398,7 +414,7 @@
             <l>prestare omai? come di dubbio trarci?</l>
             <l part="I">come cessar dal rio timore?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -410,7 +426,7 @@
             <l>al fianco mio! per voi tremare almeno,</l>
             <l>come già son due lustri, oggi non deggio.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -422,14 +438,14 @@
             <l>io; per salvare a te il consorte, ai Greci</l>
             <l>il duce, ad Argo il suo regal splendore.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l>So, che il padre t'è caro: amassi tanto</l>
             <l part="I">la madre tu!</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -439,13 +455,13 @@
             <l>né cangiar pur veggo il tuo aspetto? O madre,</l>
             <l part="I">lo amassi tu quant'io!...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Troppo il conosco.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -463,7 +479,7 @@
             <l>ah! sì, novella havvi ragion, che il pinge</l>
             <l>agli occhi tuoi da quel di pria diverso.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -472,21 +488,21 @@
             <l>Che dico?... O figlia, i più nascosi arcani</l>
             <l part="I">di questo cor, s'io ti svelassi...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="F">Oh madre!</l>
             <l part="I">così non li sapessi!</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Oimè! che ascolto?</l>
             <l part="I">Avria fors'ella penetrato?...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -500,14 +516,14 @@
             <l>sia ciò, che mal nascondi, e che a te sola</l>
             <l part="I">dir non si ardisce. — Amor t'acceca.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Amore?</l>
             <l part="I">Misera me! chi mi tradia?...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -537,13 +553,13 @@
             <l>piangi d'Atride i casi: ai templi vieni</l>
             <l>il suo ritorno ad implorar dai Numi.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="I">Lungi Egisto?</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -551,19 +567,19 @@
             <l>mio genitor, tradito esser non merta;</l>
             <l part="I">né il soffrirà.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Ma; s'ei... più non vivesse?...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l>Inorridir, raccappricciar mi fai.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -573,7 +589,7 @@
             <l>d'un marito crudel,... d'Egisto i pregi,...</l>
             <l part="I">il mio fatal destino...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -585,7 +601,7 @@
             <l>in tuo pensier tal successor disegni</l>
             <l part="I">al re dei re?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -595,7 +611,7 @@
             <l>Voler d'irati Numi, ignota forza</l>
             <l part="I">mal mio grado mi tragge...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -608,7 +624,7 @@
             <l>non pur te stessa, ma lo scettro, i figli,</l>
             <l part="I">nelle man d'un Egisto?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -619,7 +635,7 @@
             <l>re non saria perciò; saria d'Oreste</l>
             <l part="I">un nuovo padre, un difensore...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -637,7 +653,7 @@
             <l>qual figlia il dee pietosa, in petto sempre</l>
             <l>premer ti giuro l'importante arcano.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -652,7 +668,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>CLITENNESTRA, EGISTO</stage>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -669,7 +685,7 @@
             <l>e di dolor morire. — A che ridotto</l>
             <l>m'abbia il soverchio tuo sperare, or mira.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -677,7 +693,7 @@
             <l>tremar, perché? Rea ben son io: ma in core</l>
             <l>soltanto il son; né sa il mio core Atride.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -685,7 +701,7 @@
             <l>già pur troppo è palese. Or come speri,</l>
             <l part="I">ch'abbia a ignorarlo il re?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -707,14 +723,14 @@
             <l>esplorerò del re. Tu forse in Argo</l>
             <l part="I">starti potresti ignoto...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">In Argo, ignoto,</l>
             <l part="I">io di Tieste figlio?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -725,7 +741,7 @@
             <l>ferma son di seguir d'Elena i passi,</l>
             <l part="I">che abbandonarti mai...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -752,7 +768,7 @@
             <l>rendi al consorte tuo: di te più degno</l>
             <l>se amor nol vuol, fortuna, i Numi il vonno.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -767,26 +783,26 @@
             <l>dalla tua sorte speri la mia sorte:</l>
             <l>se fuggi, io fuggo; se perisci, io pero.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="I">Oh sfortunato Egisto!</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Or via, rispondi.</l>
             <l>Puoi tu negare ad amor tanto, un giorno?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="I">Chieder mel puoi? Che far degg'io?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -794,7 +810,7 @@
             <l>di non lasciar d'Argo le mura, innanzi</l>
             <l part="I">che il sol tramonti.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -804,7 +820,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>ELETTRA, CLITENNESTRA, EGISTO</stage>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -821,28 +837,28 @@
             <l>ver Argo, e già quasi alle porte è giunto.</l>
             <l part="I">O madre, e ancor qui stai?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Rimembra, Egisto,</l>
             <l part="I">il giuramento.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="F">Egisto esce fors'anco</l>
             <l>ad incontrare il re dei re con noi?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l>Punger d'amari detti un infelice,</l>
             <l part="I">ella è pur lieve gloria, o figlia...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -850,7 +866,7 @@
             <l>d'Egisto spiace a Elettra troppo: ancora</l>
             <l part="I">d'Egisto il cor noto non l'è.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -858,7 +874,7 @@
             <l>che tu nol pensi: all'accecata madre</l>
             <l part="I">così tu il fossi!</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -871,13 +887,13 @@
             <l>volea pur ora; e alla superba vista</l>
             <l>del trionfante Agamennón sottrarsi.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="I">Or, che nol fece? a che rimane?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -888,7 +904,7 @@
             <l>per sempre. Elettra, io lo giurai poc'anzi</l>
             <l part="I">alla regina; e l'atterrò.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -897,7 +913,7 @@
             <l>onde aspergi tuoi detti, ei nulla oppone,</l>
             <l part="I">che umiltà, pazienza...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -915,7 +931,7 @@
             <l>Omai che tardi? andiamo. In noi delitto</l>
             <l part="I">ogni indugiar si fa.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -924,7 +940,7 @@
             <l>e sì pur godi in trafiggermi il core,</l>
             <l part="I">con replicati colpi.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -935,7 +951,7 @@
             <l>ti trovi il re? Ciò che celar tu speri,</l>
             <l part="I">col più tardar, palesi: andiamo.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -943,7 +959,7 @@
             <l>ten prego, io pur; deh! va'; non ostinarti</l>
             <l part="I">in tuo danno.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -957,7 +973,7 @@
             <l>Fingere amor, non so, né voglio... Oh giorno</l>
             <l part="I">per me tremendo!</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -965,7 +981,7 @@
             <l>Non lunge io son dal racquistar la madre.</l>
             <l>Rimorso senti? omai più rea non sei.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -978,7 +994,7 @@
             <l>rimorso in sen della tua uccisa figlia.</l>
             <l>Di securtà prendi da lui l'esemplo.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -987,26 +1003,26 @@
             <l>questi gli estremi fian consigli iniqui,</l>
             <l part="I">che udrai da lui; vieni.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Giurasti, Egisto;</l>
             <l part="I">rimembrati; giurasti.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Un dì rimane.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="I">Oh cielo! un dì?...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1016,7 +1032,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>EGISTO</stage>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -1046,7 +1062,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage><emph>Popolo</emph>, AGAMENNONE, ELETTRA, CLITENNESTRA, <emph>soldati</emph></stage>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -1069,13 +1085,13 @@
             <l>pari alla gioia mia non è la vostra,</l>
             <l part="I">nel ritornar fra le mie braccia?</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="F">Oh padre!...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -1085,7 +1101,7 @@
             <l>a inaspettato gaudio... Il cor mal regge</l>
             <l>a sì diversi repentini affetti.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1109,7 +1125,7 @@
             <l>il riveder, riabbracciar l'amata</l>
             <l>ubbidiente sua cresciuta prole.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -1140,13 +1156,13 @@
             <l>al mesto aspetto, al lagrimoso ciglio,</l>
             <l part="I">più non ravviso.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="M">Io mesta?...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1156,25 +1172,25 @@
             <l>gli spirti suoi rinfranchi. Assai più dirti</l>
             <l>vorria di me, quindi assai men ti dice.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
             <l part="I">Né ancor d'Oreste a me parlò...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">D'Oreste?...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="I">Deh! padre, vieni ad abbracciarlo.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -1193,13 +1209,13 @@
             <l>al lampeggiar d'un brando, impaziente</l>
             <l>nobile ardor dagli occhi suoi sfavilla?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="I">Più rattener non posso il pianto...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1213,7 +1229,7 @@
             <l>con fanciullesco vezzo ei stesso agogna</l>
             <l>correre armato ad affrontar perigli.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -1227,7 +1243,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>AGAMENNONE, ELETTRA</stage>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -1250,7 +1266,7 @@
             <l>del ritornare, ah! dimmi, or perché tutti,</l>
             <l>e in maggior copia, in lei più non li trovo?</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1261,7 +1277,7 @@
             <l>breve è pur troppo a ristorare i lunghi</l>
             <l part="I">sofferti affanni. Il suo silenzio...</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -1280,7 +1296,7 @@
             <l>col sudor compri; s'io per essi ho data,</l>
             <l>più sommo bene, del mio cor la pace?</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1288,7 +1304,7 @@
             <l>avrai fra noi, per quanto è in me, per quanto</l>
             <l part="I">sta nella madre.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -1309,7 +1325,7 @@
             <l>non di tenera madre eran gli affetti;</l>
             <l>non i trasporti di consorte amante.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1324,7 +1340,7 @@
             <l>e in un crudel, ma necessario inganno,</l>
             <l>per cui dal sen la figlia le strappasti.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -1345,7 +1361,7 @@
             <l>natura tace, ed innocenza il grido</l>
             <l>innalza invan: solo si ascolta il cielo.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1371,7 +1387,7 @@
             <l>Deh! padre, il credi: in lei vedrai, fra breve,</l>
             <l>tenerezza, fidanza, amor, risorti.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -1383,7 +1399,7 @@
             <l>Qui sol sepp'io, ch'ei v'era; parmi ch'abbia</l>
             <l>ciascuno, anco in nomarmelo, ribrezzo.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1392,7 +1408,7 @@
             <l>qui venne asilo a ricercar: nimici</l>
             <l part="I">egli ha i propri fratelli.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -1405,7 +1421,7 @@
             <l>dinanzi a me; vederlo, udire io voglio</l>
             <l part="I">de' casi suoi, de' suoi disegni.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1414,7 +1430,7 @@
             <l>Ma tu, che indaghi a primo aspetto ogni alma,</l>
             <l>per te vedrai, se d'esser tale ei merti.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -1425,7 +1441,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>AGAMENNONE, ELETTRA, EGISTO</stage>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -1444,7 +1460,7 @@
             <l>che a scamparmi valesse da' crudeli</l>
             <l>nemici miei, che a me pur son fratelli.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -1461,7 +1477,7 @@
             <l>no, mirar non poss'io, né udir la voce,</l>
             <l>la voce pur del figlio di Tieste.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -1488,21 +1504,21 @@
             <l>entro il regal tuo petto generoso</l>
             <l>alta trovar di me pietà dovresti.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
             <l>E s'io 'l volessi pure, o tu, pietade</l>
             <l part="I">soffriresti da me?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="M">Ma, e chi son io,</l>
             <l>da osar spregiare un dono tuo?...</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -1526,7 +1542,7 @@
             <l>de' tuoi fratelli vedi, oh! puoi tu starti,</l>
             <l>senza ch'entro ogni vena il tuo ribolla?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -1552,14 +1568,14 @@
             <l>come pria le sostanze, or voglion tormi.</l>
             <l part="I">Vedi, se a torto io fuggo.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
             <l part="F">A ragion fuggi;</l>
             <l part="I">ma qui mal fuggi.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -1577,7 +1593,7 @@
             <l>faccia Atride di me, ciò ch'ei vorria</l>
             <l>ch'altri fesse di lui, se Egisto ei fosse.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -1597,26 +1613,26 @@
             <l>Forse di Grecia entro al confin, vicini</l>
             <l part="I">pur troppo ancor siam noi.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Tu pur mi scacci?</l>
             <l part="I">E che mi apponi?</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
             <l part="M">Il padre.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="M">E basta?</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -1628,7 +1644,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>AGAMENNONE, ELETTRA</stage>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -1636,7 +1652,7 @@
             <l>un non so qual terrore in me sentiva,</l>
             <l part="I">non mai sentito pria.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1644,7 +1660,7 @@
             <l>d'accomiatarlo: ed io neppur nol veggo,</l>
             <l part="I">senza ch'io frema.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -1657,7 +1673,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>CLITENNESTRA, AGAMENNONE, ELETTRA</stage>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -1668,7 +1684,7 @@
             <l>di gente innumerabile, che il nome</l>
             <l>d'Agamennón fa risuonare al cielo.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -1677,13 +1693,13 @@
             <l>che nol voleva io forse, rattenuto</l>
             <l part="I">me non avesse Egisto.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="M">Egisto?...</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -1691,14 +1707,14 @@
             <l>Ch'egli era in Argo, or di', perché nol seppi</l>
             <l part="I">da te?</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="M">Signor,... fra tue tant'altre cure...</l>
             <l>io non credea, ch'ei loco...</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -1720,13 +1736,13 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>ELETTRA, CLITENNESTRA</stage>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="I">Odi buon re, miglior consorte.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -1735,7 +1751,7 @@
             <l>Così tua fé mi serbi? Al re svelasti</l>
             <l part="I">Egisto; ond'ei...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1745,7 +1761,7 @@
             <l>util vuol farsi al re: ben maraviglia</l>
             <l>prender ti può, che nol sapesse ei pria.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -1753,7 +1769,7 @@
             <l>i detti lor? perché lo scaccia? ed egli</l>
             <l>che rispondea? Di me parlogli Atride?</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1763,14 +1779,14 @@
             <l>Non di nemico con Egisto furo</l>
             <l part="I">le sue parole.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Ma pur d'Argo in bando</l>
             <l part="I">tosto ei lo vuole.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1778,13 +1794,13 @@
             <l>dall'orlo sei del precipizio, innanzi</l>
             <l part="I">che più t'inoltri.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="M">Ei partirà?</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1802,33 +1818,33 @@
             <l>muovati, deh! — Fuor d'Argo, in salvo ei fia</l>
             <l part="I">dallo sdegno del re...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Se Egisto io perdo,</l>
             <l part="I">che mi resta a temer?</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="M">La infamia...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Oh cielo!...</l>
             <l>omai mi lascia al mio terribil fato.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="I">Deh, no. Che speri? e che farai?...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -1839,13 +1855,13 @@
             <l>a parte entrar de' miei sospiri iniqui</l>
             <l part="I">l'infelice mia figlia.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="M">Ah madre!...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -1857,7 +1873,7 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>ELETTRA</stage>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1872,7 +1888,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>EGISTO, CLITENNESTRA</stage>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -1885,7 +1901,7 @@
             <l>dolor m'è al cor, lasciarti; e non più mai</l>
             <l>speranza aver di rivederti io, mai.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -1899,7 +1915,7 @@
             <l>tempo è d'oprar. — Ch'io mai ti lasci? ah! pensa</l>
             <l part="I">ch'esser non può, finch'io respiro.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -1910,7 +1926,7 @@
             <l>possanza. Il sai; la ragion sua son l'armi;</l>
             <l>né ragion ode, altra che l'armi altrui.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -1919,7 +1935,7 @@
             <l>egli ha prefisso; e il nuovo sol vedrammi</l>
             <l part="I">al tuo partir compagna.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -1935,7 +1951,7 @@
             <l>che udir, misero me! mai dal tuo labro</l>
             <l part="I">cotal rampogna.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -1944,7 +1960,7 @@
             <l>della mia infamia? tu, che in sen lo stile</l>
             <l>m'immergi, ov'abbi il cor di abbandonarmi...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -1970,14 +1986,14 @@
             <l>di rapitor ne avrei: la sorte è questa,</l>
             <l>ch'or ne sovrasta, se al fuggir ti ostini.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l>Tu vedi appien gli ostacoli, e null'altro:</l>
             <l part="I">verace amor mai li conobbe?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -1998,13 +2014,13 @@
             <l>per me vederti e vita esporre, e fama,...</l>
             <l>più certi almen trovane i mezzi, o donna.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="I">Più certi?... Altri ve n'ha?...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2019,58 +2035,58 @@
             <l>dar non ti posso del mio amor, che il mio</l>
             <l>partir;... terribil, dura, ultima prova.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l>Morir, sta in noi; dove il morir fia d'uopo. —</l>
             <l>Ma che? null'altro resta a tentar pria?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l>Altro partito, forse, or ne rimane;...</l>
             <l part="I">ma indegno...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="M">Ed è?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="M">Crudo.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="M">Ma certo?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Ah! certo,</l>
             <l part="I">pur troppo!...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="M">E a me tu il taci?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">— E a me tu il chiedi?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -2083,7 +2099,7 @@
             <l>deh! tu m'insegna, e sia qual vuolsi, un mezzo,</l>
             <l part="I">onde per sempre a lui sottrarmi.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2091,20 +2107,20 @@
             <l>sottrarti? io già tel dissi, ella è del tutto</l>
             <l part="I">ora impossibil cosa.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">E che mi avanza</l>
             <l part="I">dunque a tentar?...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="M">— Nulla.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -2115,19 +2131,19 @@
             <l>crudo rimedio,... e sol rimedio,... è il sangue</l>
             <l part="I">di Atride.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="M">Io taccio...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Ma, tacendo, il chiedi.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2141,7 +2157,7 @@
             <l>a sospetto dar loco. — Al fin ricevi...</l>
             <l part="I">l'ultimo addio... d'Egisto.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -2150,47 +2166,47 @@
             <l>altro ostacolo v'ha: pur troppo a noi</l>
             <l part="I">il suo vivere è morte!</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">A mie parole,</l>
             <l part="I">deh, non badare: amor fe' dirle.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">E amore</l>
             <l part="I">a me intender le fa.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">D'orror compresa</l>
             <l part="I">l'alma non hai?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">D'orror?... sì; ... ma lasciarti!...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="I">E cor bastante avresti?...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Amor bastante,</l>
             <l part="I">da non temer cosa del mondo.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2198,25 +2214,25 @@
             <l>de' suoi sta il re: qual man, qual ferro, strada</l>
             <l part="I">può farsi al petto suo?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Qual man?... qual ferro?...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l>Saria qui vana, il vedi, aperta forza.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="I">Ma,... il tradimento... pure...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2227,13 +2243,13 @@
             <l>Cassandra trae, mentr'ei n'è amante, e schiavo</l>
             <l part="I">ei stesso, sì...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="M">Che ascolto!</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2244,32 +2260,32 @@
             <l>non ti sdegnar di ciò che a sdegno muove</l>
             <l part="I">Argo tutta.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Cassandra a me far pari?...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="I">Atride il vuole.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="M">Atride pera.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Or come?</l>
             <l part="I">di qual mano?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -2277,38 +2293,38 @@
             <l>entro a quel letto, ch'ei divider spera</l>
             <l part="I">con l'abborrita schiava.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Oh ciel! ma pensa...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="I">Ferma son già...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="M">Ma, se pentita?...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Il sono</l>
             <l part="I">d'aver tardato troppo.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="M">Eppure...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -2319,13 +2335,13 @@
             <l>Doman, tel giuro, il re sarai tu in Argo.</l>
             <l>Né man, né cor, mi tremerà... Chi viene?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="I">Elettra...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -2335,7 +2351,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>ELETTRA</stage>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -2359,14 +2375,14 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>ELETTRA, AGAMENNONE</stage>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="F">O padre,</l>
             <l part="I">dimmi: veduto hai Clitennestra?</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -2374,13 +2390,13 @@
             <l>stanze trovarla io già credea — Ma in breve</l>
             <l part="I">ella verravvi.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="M">Assai lo bramo.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -2388,14 +2404,14 @@
             <l>io ve l'aspetto: ella ben sa, ch'io voglio</l>
             <l part="I">qui favellarle.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="F">O padre; Egisto ancora</l>
             <l part="I">sta in Argo.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -2407,7 +2423,7 @@
             <l>Che fia? D'Egisto mille volte imprendi</l>
             <l part="I">a parlarmi, e poi taci...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2420,7 +2436,7 @@
             <l>te ne scongiuro, fa che d'Argo in bando</l>
             <l part="I">Egisto vada.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -2428,7 +2444,7 @@
             <l>ei dunque m'è? tu il sai? dunque egli ordisce</l>
             <l part="I">trame...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -2448,7 +2464,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>AGAMENNONE</stage>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -2470,7 +2486,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>AGAMENNONE, CLITENNESTRA</stage>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -2478,7 +2494,7 @@
             <l>che il puoi tu sola, ogni spiacevol dubbio,</l>
             <l part="I">ch'Elettra in cor lasciommi.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -2487,19 +2503,19 @@
             <l>e in questo giorno funestar ti vuole</l>
             <l part="I">con falsi dubbi?... Eppur, quai dubbi?...</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
             <l part="F">Egisto...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="I">Che sento?</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -2507,14 +2523,14 @@
             <l>parlar, d'Elettra la quiete e il senno</l>
             <l part="I">par che conturbi.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">... E nol cacciasti in bando?...</l>
             <l part="I">di lui che teme Elettra?</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -2538,14 +2554,14 @@
             <l>stan, di lagrime pregni... Oimè! pur troppo</l>
             <l part="I">mi disse Elettra il vero.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Il vero?... Elettra?...</l>
             <l part="I">Di me parlò?... Tu credi?...</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -2553,7 +2569,7 @@
             <l>tradita, sì. Del tuo dolor la fonte</l>
             <l part="I">ella mi aperse...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -2561,7 +2577,7 @@
             <l>dubbia forse?... Ah! ben veggio; Elettra sempre</l>
             <l part="I">poco amommi.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -2570,13 +2586,13 @@
             <l>parlava ella di te: se in altra guisa,</l>
             <l part="I">ascoltata l'avrei?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Che dunque disse?</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -2585,14 +2601,14 @@
             <l>aspra memoria della uccisa figlia</l>
             <l part="I">tuttor ti sta.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">D'Ifigenìa?... Respiro... —</l>
             <l>Fatale ognor, sì, mi sarà quel giorno...</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -2609,7 +2625,7 @@
             <l>s'anco tu m'odi, a me tu 'l di': più cara</l>
             <l>l'ira aperta mi fia, che il finto affetto.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -2619,7 +2635,7 @@
             <l>Cassandra, sì, Cassandra forse, è quella</l>
             <l part="I">che men gradita a te mi rende...</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -2640,7 +2656,7 @@
             <l>figlia infelice; e che infierir contr'essa</l>
             <l>d'alma regal saria cosa non degna.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -2649,7 +2665,7 @@
             <l>tua preda? Ah! no: ben ti s'aspetta: troppo</l>
             <l>tempo e sudor ti costa, e affanno, e sangue.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
@@ -2669,7 +2685,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>CLITENNESTRA</stage>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -2714,19 +2730,19 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>EGISTO, CLITENNESTRA</stage>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="M">L'opra compiesti?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Egisto...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2734,7 +2750,7 @@
             <l>Intempestivo è il pianto; è tardo; è vano:</l>
             <l part="I">caro costar ne può.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -2742,7 +2758,7 @@
             <l>misera me! che ti promisi? quale</l>
             <l part="I">consiglio iniquo?...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2762,14 +2778,14 @@
             <l>già consecrata irrevocabilmente</l>
             <l part="I">alla vendetta del tuo re...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Che parli?</l>
             <l part="I">e donde il sai?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2781,14 +2797,14 @@
             <l>Ma, non temer, che ad incolpar me solo</l>
             <l part="I">ogni arte adoprerò.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Che ascolto? Atride</l>
             <l part="I">tutto sa?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2803,7 +2819,7 @@
             <l>più non ti prenda: io son felice assai,</l>
             <l>se di mia man per te morir mi è dato.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -2811,25 +2827,25 @@
             <l>furor nel petto, al parlar tuo!... Fia vero?...</l>
             <l part="I">Tua morte?...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="M">È più che certa...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Ed io t'uccido!...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="I">Te salva io vo'.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -2844,7 +2860,7 @@
             <l>e fia pur ver; null'altro a far ne resta?...</l>
             <l part="I">Ma chi svelava il nostro amor?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2854,21 +2870,21 @@
             <l>t'immerge in sen l'empia tua figlia; e torre</l>
             <l part="I">ti vuol l'onor pria della vita.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">E deggio</l>
             <l part="I">credere?... oimè...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Credi al mio brando dunque,</l>
             <l>se a me non credi. Almen, che in tempo io pera...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -2876,7 +2892,7 @@
             <l>Oh fera notte!... Ascolta... Atride in mente,</l>
             <l part="I">forse non ha...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2891,14 +2907,14 @@
             <l>dal dubbio fero: io non l'attendo: ho fermo</l>
             <l part="I">di pria morir... — Per sempre... addio.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">T'arresta...</l>
             <l part="I">no, non morrai.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2909,14 +2925,14 @@
             <l>semivivo, spirante: alta discolpa</l>
             <l part="I">il mio sangue ti fia.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Che parli?... ahi lassa!</l>
             <l part="I">misera me!... che a perder t'abbia?...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2925,78 +2941,78 @@
             <l>né chi più t'ama, né chi più ti abborre?</l>
             <l part="I">La mia supplir de' dunque...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="M">Ah!... no...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Vuoi spento</l>
             <l part="I">Atride, o me?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="M">Qual scelta!...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">E dei pur scerre.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="I">Io dar morte?...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">O riceverla: e vedermi</l>
             <l part="I">pria di te trucidato.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">... Ah, che pur troppo</l>
             <l part="I">necessario è il delitto!</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">E stringe il tempo.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="I">Ma,... la forza,... l'ardire?...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Ardire, forza,</l>
             <l part="I">tutto, amor ti darà.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Con man tremante</l>
             <l part="I">io... nel... marito... il ferro...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -3004,14 +3020,14 @@
             <l>trucidator della tua figlia i colpi</l>
             <l part="I">addoppierai con man sicura.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">... Io... lungi</l>
             <l part="I">da me... scagliava... il ferro...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -3031,7 +3047,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>EGISTO, AGAMENNONE <emph>dentro</emph></stage>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -3049,14 +3065,14 @@
             <l>sdegno, e timore, al necessario fallo</l>
             <l part="I">menan la iniqua donna. —</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>
               <emph>Agamennone</emph>
             </speaker>
             <l part="F">Oh tradimento!...</l>
             <l>tu, sposa?... Oh cielo!... Io moro... Oh tradimento!...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -3070,19 +3086,19 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>CLITENNESTRA, EGISTO</stage>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Ove son io?... che feci?...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l>Spento hai l'iniquo: al fin di me sei degna.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -3094,7 +3110,7 @@
             <l>vacillo... Oimè!... forza mi manca,... e voce,...</l>
             <l>e lena.... Ove son io?... che feci?... Ahi lassa!...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -3107,7 +3123,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>ELETTRA, EGISTO, CLITENNESTRA</stage>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -3117,7 +3133,7 @@
             <l>Iniqua donna, in man tu il ferro tieni?</l>
             <l part="I">tu il parricidio festi? oh vista!</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -3130,19 +3146,19 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>CLITENNESTRA, ELETTRA</stage>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l>Oreste?... oh cielo!... Or ti conosco, Egisto...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="I">Dammi, dammi quel ferro.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -3153,7 +3169,7 @@
         <div type="scene">
           <head>SCENA VII</head>
           <stage>ELETTRA</stage>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>

--- a/tei/alfieri-antigone.xml
+++ b/tei/alfieri-antigone.xml
@@ -82,6 +82,22 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="argia">
+            <persName>Argia</persName>
+          </person>
+          <person xml:id="antigone">
+            <persName>Antigone</persName>
+          </person>
+          <person xml:id="creonte">
+            <persName>Creonte</persName>
+          </person>
+          <person xml:id="emone">
+            <persName>Emone</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione - OCR</change>
@@ -138,7 +154,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>ARGIA</stage>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
@@ -181,7 +197,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>ANTIGONE</stage>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -216,27 +232,27 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>ARGIA, ANTIGONE</stage>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
             <l part="I">Una infelice io sono.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="F">In queste soglie</l>
             <l part="I">che fai? che cerchi in sì tard'ora?</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
             <l part="F">Io... cerco...</l>
             <l part="I">... d'Antigone...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -244,13 +260,13 @@
             <l>Antigone conosci? a lei se' nota?</l>
             <l>che hai seco a far? che hai tu comun con essa?</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
             <l part="I">Il dolor, la pietà...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -259,20 +275,20 @@
             <l>regna in Tebe, nol sai? noto a te forse</l>
             <l part="I">non è Creonte?</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
             <l part="F">Or dianzi io qui giungea...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l>E in questa reggia il piè straniera ardisci</l>
             <l part="I">por di soppiatto? a che?...</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
@@ -280,20 +296,20 @@
             <l>straniera io son, colpa è di Tebe: udirmi</l>
             <l part="I">nomar qui tale io non dovrei.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="F">Che parli?</l>
             <l part="I">Ove nascesti?</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
             <l part="M">In Argo.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -301,14 +317,14 @@
             <l>orror m'inspira! A me pur sempre ignoto,</l>
             <l>deh, stato fosse! io non vivria nel pianto.</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
             <l>Argo a te costa lagrime? di eterno</l>
             <l part="I">pianto cagion mi è Tebe.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -320,20 +336,20 @@
             <l>quanto il narrarla, a te: ma, non è il tempo,</l>
             <l part="I">or che un fratello io piango...</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
             <l part="F">Ah! tu se' dessa;</l>
             <l part="I">Antigone tu sei...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="M">... Ma... tu...</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
@@ -341,13 +357,13 @@
             <l>Argìa son io; la vedova infelice</l>
             <l part="I">del tuo fratel più caro.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="F">Oimè!... che ascolto?...</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
@@ -360,7 +376,7 @@
             <l>pianto, deh! lascia ch'io, tra' dolci amplessi,</l>
             <l>libero sfogo entro al tuo sen conceda.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -369,7 +385,7 @@
             <l>Creonte?... Oh vista inaspettata! oh vista</l>
             <l part="I">cara non men che dolorosa!</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
@@ -377,7 +393,7 @@
             <l>reggia, in cui me sperasti aver compagna,</l>
             <l>(e lo sperai pur io) così mi accogli?</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -390,7 +406,7 @@
             <l>mai non volea; né il vo'... Mille funesti</l>
             <l part="I">perigli (ah! trema) hai qui dintorno.</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
@@ -399,14 +415,14 @@
             <l>Che perder più, che desiar mi resta?</l>
             <l part="I">Abbracciarti, e morire.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="F">Aver puoi morte</l>
             <l part="I">qui non degna di te.</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
@@ -414,7 +430,7 @@
             <l>dov'io pur l'abbia in su l'amata tomba</l>
             <l part="I">del mio sposo.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -423,26 +439,26 @@
             <l>al tuo marito, al mio fratello, in Tebe,</l>
             <l part="I">nella sua reggia.</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
             <l part="F">Oh ciel! Ma il corpo esangue...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="I">Preda alle fiere in campo ei giace...</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
             <l part="F">Al campo</l>
             <l part="I">io corro.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -453,7 +469,7 @@
             <l>ai figli d'Argo, ei dà barbara morte</l>
             <l part="I">a chi dà lor la tomba.</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
@@ -466,7 +482,7 @@
             <l>dalla reggia paterna escluse a forza</l>
             <l part="I">stanno? e il soffre una madre?...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -500,7 +516,7 @@
             <l>Per lui sofferta ho l'abborrita luce;</l>
             <l>serbata io m'era a sua tremula etade...</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
@@ -508,7 +524,7 @@
             <l>in lui l'orror del suo misfatto. Ei vive?</l>
             <l part="I">e Polinice muore?</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -530,7 +546,7 @@
             <l>Creonte in Tebe promulgò. Chi ardiva</l>
             <l part="I">romperla qui; chi, se non io?</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
@@ -545,7 +561,7 @@
             <l>l'ombra vagante... Or, che tardiam? Sorella,</l>
             <l part="I">andianne; io prima...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -559,7 +575,7 @@
             <l>sola una fiamma anco le morte nostre</l>
             <l>spoglie consumi, e in una polve unisca.</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
@@ -568,7 +584,7 @@
             <l>noi fummo; pari; o maggior io. Di moglie</l>
             <l part="I">altro è l'amor, che di sorella.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -591,7 +607,7 @@
             <l>soglie null'uom ti vide; ancor n'hai tempo.</l>
             <l part="I">Contro al divieto io sola basto.</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
@@ -606,14 +622,14 @@
             <l>O Polinice mio, ch'altra ti renda</l>
             <l part="I">gli ultimi onori?...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="F">Alla tebana scure</l>
             <l part="I">porger tu il collo vuoi?</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
@@ -622,14 +638,14 @@
             <l>sarà l'infame: del suo nome ogni uomo</l>
             <l part="I">sentirà orror, pietà del nostro...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="F">E tormi</l>
             <l part="I">tal gloria vuoi?</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
@@ -638,7 +654,7 @@
             <l>di contendermi il mio? tu, che il vedesti</l>
             <l part="I">morire, e ancor pur vivi...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -648,7 +664,7 @@
             <l>del femminil timor: del dolor tuo</l>
             <l>non era io dubbia; del valore io l'era.</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
@@ -656,7 +672,7 @@
             <l>Ma, s'io l'amor del tuo fratel mertava,</l>
             <l part="I">donna volgare esser potea?</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -672,26 +688,26 @@
             <l>nulla ci scopra a lor, pria della fiamma</l>
             <l>divoratrice dell'esangue busto.</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
             <l>Non piangerò;... ma tu,... non piangerai?</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="I">Sommessamente piangeremo.</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
             <l part="F">In campo,</l>
             <l part="I">sai tu in qual parte ei giace?</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -708,7 +724,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>CREONTE, EMONE</stage>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -718,7 +734,7 @@
             <l>questo mio scettro. Onde i lamenti? duolti</l>
             <l>d'Edippo forse, o di sua stirpe rea?</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -729,7 +745,7 @@
             <l>chiuda ogni via. Tu stesso un dì potresti</l>
             <l>pentito pianger l'acquistato regno.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -743,7 +759,7 @@
             <l>tornar più miti: or sì, sperar ne giova</l>
             <l part="I">più lieti dì.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -761,7 +777,7 @@
             <l>ecco gli auspici, onde a regnar salisti.</l>
             <l part="I">Ahi padre! esser puoi lieto?</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -786,7 +802,7 @@
             <l>obliar dessi, e di Fortuna il crine</l>
             <l part="I">forte afferrare.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -806,14 +822,14 @@
             <l>di tutti i suoi l'ultimo eccidio, in dono</l>
             <l>concedi il corpo del fratel suo amato.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l>Al par degli empi suoi fratelli, figlia</l>
             <l part="I">non è costei di Edippo?</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -821,27 +837,27 @@
             <l>dritto ha di Tebe al trono. Esangue corpo</l>
             <l part="I">ben puoi dar per un regno.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="F">A me nemica</l>
             <l part="I">ell'è...</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
             <l part="M">Nol creder.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="F">Polinice ell'ama,</l>
             <l>e il genitor; Creonte dunque abborre.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -849,7 +865,7 @@
             <l>vuoi tu ch'ella non senta? In pregio forse</l>
             <l>più la terresti, ove spietata fosse?</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -867,7 +883,7 @@
             <l>Ti fia poi nota; e, benché dura legge,</l>
             <l part="I">vedrai, ch'ella era necessaria.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -881,7 +897,7 @@
             <l>e assai ne sparla e la vorria delusa;</l>
             <l part="I">e rotta la vorrà.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -889,14 +905,14 @@
             <l>non bramo io, no; purché la vita io m'abbia</l>
             <l part="I">di qual primier la infrangerà.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
             <l part="F">Qual fero</l>
             <l>nemico a danno tuo ciò ti consiglia?</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -906,14 +922,14 @@
             <l>è il cittadin; che può far altro omai,</l>
             <l part="I">che obbedirmi, e tacersi?</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
             <l part="F">Acchiusa spesso</l>
             <l part="I">nel silenzio è vendetta...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -927,14 +943,14 @@
             <l>farti al tuo padre, innanzi tempo, ingrato? —</l>
             <l>Ma, qual di armati, e di catene suono?...</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
             <l>Oh! chi mai viene?... In duri lacci avvolte</l>
             <l>donne son tratte?... Antigone! che miro?...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -945,27 +961,27 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage><emph>Guardie con le fiaccole</emph>, ANTIGONE, ARGIA, CREONTE, EMONE</stage>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="F">Che fia? quale han delitto</l>
             <l part="I">queste donzelle?</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="M">Il vo' dir io.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="F">Più innanzi</l>
             <l part="I">si lascin trarre il piede.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -973,7 +989,7 @@
             <l>ecco, mi sto. Rotta ho tua legge: io stessa</l>
             <l>tel dico: inceso al mio fratello ho il rogo.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -981,13 +997,13 @@
             <l>da me; lo avrai. — Ma tu, ch'io non ravviso,</l>
             <l>donna, chi sei? straniere fogge io miro...</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
             <l part="I">L'emula son di sua virtude.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -995,7 +1011,7 @@
             <l>lo sdegno tuo rattempra: ira non merta</l>
             <l part="I">di re donnesca audacia.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1005,7 +1021,7 @@
             <l>sveli costei; poi la cercata pena</l>
             <l part="I">s'abbiano entrambe.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -1021,7 +1037,7 @@
             <l>ad arder no, ma ad abbracciar pietosa</l>
             <l part="I">veniva...</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
@@ -1031,13 +1047,13 @@
             <l>osassi. — Iniquo re, sappi il mio nome;</l>
             <l part="I">godine, esulta...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="M">Ah! taci...</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
@@ -1045,13 +1061,13 @@
             <l>figlia; sposa son io di Polinice;</l>
             <l part="I">Argìa...</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
             <l part="M">Che sento?</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1064,7 +1080,7 @@
             <l>di Tebe: ov'è? d'Edippo è sangue anch'egli:</l>
             <l part="I">Tebe lo aspetta.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -1074,7 +1090,7 @@
             <l>Piange l'una il fratel, l'altra il marito;</l>
             <l part="I">tu le deridi? Oh cielo!</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -1084,7 +1100,7 @@
             <l>d'alta innocenza, esser di morte afflitte</l>
             <l part="I">dove Creonte è il re.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1092,7 +1108,7 @@
             <l>esala pur; me non offendi: sprezza,</l>
             <l part="I">purché l'abbi, la morte.</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
@@ -1108,7 +1124,7 @@
             <l>d'un delitto è chi 'l pensa: a chi l'ordisce</l>
             <l part="I">la pena spetta...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -1134,7 +1150,7 @@
             <l>ch'è mio l'ardir, mia la fierezza; e tutta</l>
             <l>la rabbia, ond'ella or si riveste, è mia.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1145,7 +1161,7 @@
             <l>sorger farà gara tra voi, di preghi</l>
             <l part="I">e pianti...</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -1156,7 +1172,7 @@
             <l>di re possente: Adrasto, il sai, di Tebe</l>
             <l>la via conosce, e ricalcarla puote.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1164,7 +1180,7 @@
             <l>Argìa s'immoli. — E che? pietoso farmi</l>
             <l part="I">tu per timor vorresti?</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
@@ -1179,7 +1195,7 @@
             <l>vendicatori insorgeranno in Tebe,</l>
             <l part="I">che a pro di lei...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -1192,7 +1208,7 @@
             <l>Vittima a lui l'ambizione addita</l>
             <l part="I">me sola, me...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1202,7 +1218,7 @@
             <l>di ciò non fer gli empi fratelli, or dianzi</l>
             <l part="I">l'un dell'altro uccisore?...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -1218,14 +1234,14 @@
             <l>La via così tu ti sgombrasti al soglio,</l>
             <l part="I">ed alla infamia.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
             <l part="F">A viva forza vuoi</l>
             <l part="I">perder te stessa, Antigone?</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -1240,7 +1256,7 @@
             <l>nell'inquieto sogguardar, scolpito</l>
             <l part="I">e il delitto, e la pena.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1249,7 +1265,7 @@
             <l>mestier non eran tradimenti miei:</l>
             <l>tutti a prova il volean gl'irati Numi.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -1258,7 +1274,7 @@
             <l>ad immolar, e amici, e figli, e fama;</l>
             <l part="I">se tu l'avessi.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1267,7 +1283,7 @@
             <l>Vittima tu, già sacra agli infernali,</l>
             <l>degna ed ultima andrai d'infame prole.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -1275,7 +1291,7 @@
             <l>Deh! sospendi per poco: assai ti debbo</l>
             <l part="I">cose narrar, molto importanti...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1285,7 +1301,7 @@
             <l>prefisso è in me; fin che rinasca il sole,</l>
             <l part="I">udrotti...</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
@@ -1293,27 +1309,27 @@
             <l>or sì, ch'io tremo. E me con essa a morte</l>
             <l part="I">non manderai?</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="F">Più non s'indugi: entrambe</l>
             <l part="I">entro all'orror d'atra prigione...</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
             <l part="F">Insieme</l>
             <l part="I">con te, sorella...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="M">Ah!... sì...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1322,25 +1338,25 @@
             <l>a sì gran pegno: andiam. — Guardie, si tragga</l>
             <l part="I">in altro carcer l'altra.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
             <l part="M">Oh ciel!...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="F">Si vada.</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
             <l part="I">Ahi lassa me!...</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -1353,7 +1369,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>CREONTE, EMONE</stage>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1362,7 +1378,7 @@
             <l>dicesti; e udirne potrai forse a un tempo</l>
             <l part="I">tali da me.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -1375,14 +1391,14 @@
             <l>Tua legge infranto han le pietose donne;</l>
             <l>ma chi tal legge rotta non avrebbe?...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l>Qual mi ardiria pregar per chi la infranse,</l>
             <l part="I">altri che tu?</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -1391,7 +1407,7 @@
             <l>estimi; ah! no; sì ingiusto, snaturato</l>
             <l part="I">non ti credo, né il sei.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1405,7 +1421,7 @@
             <l>del non sempre obbedir. Pochi impuniti</l>
             <l part="I">danno ai molti licenza.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -1415,7 +1431,7 @@
             <l>una sorella, a gara entrambe fatte</l>
             <l part="I">del sesso lor maggiori?...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1429,13 +1445,13 @@
             <l>rea s'è fatt'ella; omai la inutil legge</l>
             <l part="I">fia tolta...</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
             <l part="F">Oh cielo!... E tu, di me sei padre?...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1444,7 +1460,7 @@
             <l>padre ti sono: e se tu m'hai per reo,</l>
             <l part="I">il son per te.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -1453,7 +1469,7 @@
             <l>mio non sarai tu mai, se mio de' farti</l>
             <l part="I">sì orribil mezzo.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1461,7 +1477,7 @@
             <l>mio questo trono, che non vuoi. — Se al padre</l>
             <l>qual figlio il dee non parli, al re tu parli.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -1474,7 +1490,7 @@
             <l>ed abborrita, e non sofferta forse</l>
             <l part="I">sarà tal arte dai Tebani.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1486,20 +1502,20 @@
             <l>ogni altro affetto, che il terrore, io tosto</l>
             <l part="I">tacer farò.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
             <l part="F">Vani i miei preghi adunque?</l>
             <l part="I">il mio sperar di tua pietade?...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="F">Vano.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -1507,14 +1523,14 @@
             <l>perché al fratello, ed al marito, hann'arso</l>
             <l part="I">dovuto rogo?</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="F">Una v'andrà. — Dell'altra</l>
             <l part="I">poco rileva; ancor nol so.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -1525,21 +1541,21 @@
             <l>E pria che tormi Antigone, t'è forza</l>
             <l part="I">tormi la vita.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="F">Iniquo figlio!... Il padre</l>
             <l part="I">ami così?</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
             <l part="F">T'amo quant'essa; e il cielo</l>
             <l part="I">ne attesto.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1556,7 +1572,7 @@
             <l>di questo trono, oggi mia cura, in quanto</l>
             <l part="I">ei poscia un dì fia tuo.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -1594,14 +1610,14 @@
             <l>deh, lo fosse ella al mio! Del mondo il trono</l>
             <l part="I">darìa per lei, non che di Tebe.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="F">— Or, dimmi:</l>
             <l part="I">sei parimente riamato?</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -1611,13 +1627,13 @@
             <l>basta al mio cor; di più non spero: è troppo,</l>
             <l>al cor di lei, che odiar pur me dovrebbe.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l>Di'; potrebb'ella a te dar man di sposa?</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -1628,14 +1644,14 @@
             <l>a lei fatale, e a' suoi? Ch'io tanto ardissi?</l>
             <l part="I">la mano offrirle, io, di te figlio?...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="F">Ardisci;</l>
             <l>tua man le rende in un la vita, e il trono.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -1645,7 +1661,7 @@
             <l>risorgerà poi forse, e avverso meno</l>
             <l part="I">al mio amor; tu il potrai poscia...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1661,26 +1677,26 @@
             <l>s'ella esser tua consente. Or, fia la scelta</l>
             <l>dubbia, fra morte e fra regali nozze?</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
             <l part="I">Dubbia? ah! no: morte, ella scerrà.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="F">Ti abborre</l>
             <l part="I">dunque.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
             <l part="M">Tropp'ama suoi.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1693,7 +1709,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>ANTIGONE, CREONTE, EMONE, <emph>guardie</emph></stage>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1706,20 +1722,20 @@
             <l>grazia, e l'ottien, per te; dove tu presta</l>
             <l part="I">fossi...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="M">A che presta?</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="F">A dargli, al mio cospetto,</l>
             <l>in meritato guiderdon,... la mano.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -1727,13 +1743,13 @@
             <l>tanta mercé: darmiti ei vuol: salvarti</l>
             <l part="I">vogl'io, null'altro.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="F">Io, perdonar ti voglio.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -1747,7 +1763,7 @@
             <l>cui spesso ei niega a chi verace ardente</l>
             <l part="I">desio n'ha in cor...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1755,14 +1771,14 @@
             <l>Sempre implacabil tu, superba sempre,</l>
             <l>o ch'io ti danni, o ch'io ti assolva, sei?</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l>Cangiar io teco stil?... cangiar tu il core,</l>
             <l part="I">fora possibil più.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -1770,7 +1786,7 @@
             <l>se a lui favelli, Antigone, in tal guisa,</l>
             <l part="I">l'alma trafiggi a me.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -1778,7 +1794,7 @@
             <l>pregio ei non ha; né scorgo io macchia alcuna,</l>
             <l part="I">Emone, in te, ch'essergli figlio.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1787,7 +1803,7 @@
             <l>rea di soverchio sei; né omai fa d'uopo,</l>
             <l part="I">che il tuo parlar nulla vi aggiunga...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -1802,7 +1818,7 @@
             <l>nulla a far mi riman: se vuoi ch'io viva,</l>
             <l part="I">rendimi il padre.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1811,7 +1827,7 @@
             <l>Emon, che t'ama più che non mi abborri;</l>
             <l>che t'ama più, che il proprio padre, assai.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -1824,7 +1840,7 @@
             <l>tranquilla, in braccio del figliuol del crudo</l>
             <l part="I">estirpator del sangue mio?...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1833,7 +1849,7 @@
             <l>figliuol v'avesse! ei di tua mano illustre,</l>
             <l part="I">degno ei solo sarebbe...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -1841,7 +1857,7 @@
             <l>di Edippo figlia! — ma, più infame nome</l>
             <l part="I">fia, di Creonte nuora.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -1862,7 +1878,7 @@
             <l>Ferisci; a me più assai trafiggi il core,</l>
             <l part="I">coll'insultarmi il padre.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1883,14 +1899,14 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>ANTIGONE, EMONE, <emph>guardie</emph></stage>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l>Deh! perché figlio di Creonte nasci?</l>
             <l part="I">O perché almen, lui non somigli?...</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -1911,7 +1927,7 @@
             <l>almen potessi una morte ottenerti</l>
             <l part="I">non infame!...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -1919,7 +1935,7 @@
             <l>madre e fratelli miei. Mi fia la scure</l>
             <l part="I">trionfo quasi.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -1930,7 +1946,7 @@
             <l>né il vuoi, né il vo', che la tua fama in parte</l>
             <l part="I">né pur si offenda...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -1940,7 +1956,7 @@
             <l>or per salvarmi? ah! potrei forse oprarla</l>
             <l part="I">ove affrettasse il morir mio...</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -1952,7 +1968,7 @@
             <l>viver, senza tua infamia; e che? sì cruda</l>
             <l>contro a te stessa, e contra me sarai?</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -1960,7 +1976,7 @@
             <l>figlia d'Edippo io sono. — Di te duolmi;</l>
             <l part="I">ma pure...</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -1995,7 +2011,7 @@
             <l>di amaro pianto, a' tuoi piedi si prostra,</l>
             <l part="I">... e ti scongiura Emone...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -2006,14 +2022,14 @@
             <l>(e che non puoi tu in me?)... mia fama salva;</l>
             <l>lascia ch'io mora, se davver tu m'ami.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
             <l>... Me misero!... Pur io non ti lusingo...</l>
             <l part="I">Quanto a te dissi, esser potria.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -2032,7 +2048,7 @@
             <l>non ti vedrò, mai più:... ma, de' tuoi figli</l>
             <l>ultima, e sola, io almen morrò non rea...</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -2044,7 +2060,7 @@
             <l>pria che nel tuo, cadrà: così vendetta</l>
             <l>in parte avrai dell'inuman Creonte.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -2052,7 +2068,7 @@
             <l>delitto è tal, ch'io col morir lo ammendo;</l>
             <l part="I">col viver, tu.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -2061,7 +2077,7 @@
             <l>le voci estreme disperate udrai</l>
             <l part="I">di un forsennato figlio.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -2069,52 +2085,52 @@
             <l>ribelle al padre tuo?... Sì orribil taccia</l>
             <l part="I">sfuggila ognora, o ch'io non t'amo.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
             <l part="F">Or, nulla</l>
             <l>piegar ti può dal tuo fero proposto?</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="I">Nulla; se tu nol puoi.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
             <l part="F">Ti appresti dunque?...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="I">A non più mai vederti.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
             <l part="F">In breve, io 'l giuro,</l>
             <l part="I">mi rivedrai.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="F">T'arresta. Ahi lassa!... M'odi...</l>
             <l part="I">che far vuoi tu?</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
             <l part="F">Mal grado tuo, salvarti.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -2124,7 +2140,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>ANTIGONE, <emph>guardie</emph></stage>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -2138,31 +2154,31 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>CREONTE, ANTIGONE, <emph>guardie</emph></stage>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="I">Scegliesti?</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="M">Ho scelto.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="M">Emon?</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="M">Morte.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -2181,14 +2197,14 @@
             <l>Doleami già d'averti dato io scelta,</l>
             <l part="I">fra la tua morte e l'onta mia.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="F">Dicesti? —</l>
             <l part="I">Che tardi or più? Taci, ed adopra.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -2204,32 +2220,32 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>EMONE, ANTIGONE, CREONTE, <emph>guardie</emph></stage>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
             <l part="F">Al palco? Arresta...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l>Oh vista!... Or, guardie, or vi affrettate; a morte</l>
             <l>strascinatemi. Emon,... lasciami;... addio.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
             <l>Trarla oltre più nessun di voi si attenti.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="I">E che? minacci, ove son io?...</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -2237,14 +2253,14 @@
             <l>così tu m'ami? così spendi il giorno</l>
             <l part="I">concesso a lei?...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="F">Precipitar vuol ella;</l>
             <l part="I">negargliel posso?</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -2267,7 +2283,7 @@
             <l>giaccion, chi estinto in tomba, e chi mal vivo</l>
             <l part="I">in sanguinoso letto.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -2281,7 +2297,7 @@
             <l>riman secura; io non vo' guerra. — Or, lascia,</l>
             <l part="I">che al suo destin vada costei.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -2298,7 +2314,7 @@
             <l>minacce, ed armi risuonar già s'ode;</l>
             <l part="I">già dubbio...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -2313,7 +2329,7 @@
             <l>la diè; nel campo l'abbia: ivi sepolta</l>
             <l part="I">sia, viva...</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -2323,7 +2339,7 @@
             <l>Viva in campo sepolta? Iniquo;... innanzi</l>
             <l>estinto io qui; ridotto in cener io...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -2333,7 +2349,7 @@
             <l>il mio destino: or, che rileva il loco,</l>
             <l part="I">il tempo, il modo, ond'io morrò?...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -2342,7 +2358,7 @@
             <l>né a te giovare... Un infelice padre</l>
             <l part="I">di me farai; null'altro puoi...</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -2357,7 +2373,7 @@
             <l>può torti: — regna; io nol darò; ma, trema,</l>
             <l part="I">se a lei...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -2368,7 +2384,7 @@
             <l>che instigatrice all'ira atroce io fossi</l>
             <l part="I">del figlio contro al padre!...</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -2382,14 +2398,14 @@
             <l>non dar tu mai; ma, che pentir può farti</l>
             <l part="I">di un tal don, oggi.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="F">Non è voce al mondo,</l>
             <l part="I">che basti a impor legge a Creonte.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -2397,19 +2413,19 @@
             <l>brando v'ha dunque, che le inique leggi</l>
             <l part="I">può troncar di Creonte.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="M">Ed è?</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
             <l part="F">Il mio brando.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -2425,7 +2441,7 @@
             <l>alla ragione alta di stato, ai dritti</l>
             <l part="I">sacrosanti del sangue...</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -2443,7 +2459,7 @@
             <l>Delitti, il primo costa; al primo, mille</l>
             <l>ne tengon dietro, e crescon sempre; — e il sai.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -2460,7 +2476,7 @@
             <l>di me non oda. — Ossequioso figlio</l>
             <l>vivi tu dunque a scellerato padre.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -2475,14 +2491,14 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>CREONTE, EMONE, <emph>guardie</emph></stage>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
             <l>— Pria dell'ora prefissa, in campo udrassi</l>
             <l part="I">di me novella.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -2493,7 +2509,7 @@
             <l>gran cor fidarmi, e in tua virtù primiera,</l>
             <l part="I">ch'io spenta in te non credo.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -2504,7 +2520,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>CREONTE, <emph>guardie</emph></stage>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -2529,7 +2545,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>CREONTE, ARGIA, <emph>guardie</emph></stage>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -2538,13 +2554,13 @@
             <l>ebberti in Tebe, ove il divieto mio</l>
             <l>romper tu sola osato non avresti...</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
             <l part="I">T'inganni, io sola.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -2558,7 +2574,7 @@
             <l>scorta al venir ti furo; al sol cadente,</l>
             <l>ti rimenino al padre in Argo l'ombre.</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
@@ -2567,21 +2583,21 @@
             <l>giacciono in Tebe; in Tebe, o viva, o morta,</l>
             <l part="I">io rimanermi vo'.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="F">La patria, il padre,</l>
             <l>il pargoletto tuo, veder non brami?</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
             <l>D'amato sposo abbandonar non posso</l>
             <l part="I">il cener sacro.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -2592,7 +2608,7 @@
             <l>Vanne; all'amato sposo, ivi fra' tuoi,</l>
             <l>degna del tuo dolore ergi la tomba.</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
@@ -2600,7 +2616,7 @@
             <l>come, perché? Da quel di pria diverso</l>
             <l part="I">esser puoi tanto, e non t'infinger?...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -2609,7 +2625,7 @@
             <l>ma, l'ira ognor me non governa; il tempo,</l>
             <l part="I">la ragion la rintuzza.</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
@@ -2623,41 +2639,41 @@
             <l>e l'opra, a cui tu ne spingevi a forza,</l>
             <l part="I">a noi perdoni...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="M">A te perdono.</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
             <l part="F">Oh! salva</l>
             <l part="I">Antigone non fia?</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="F">L'altrui fallire</l>
             <l part="I">non confondo col tuo.</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
             <l part="F">Che sento? Oh cielo!</l>
             <l part="I">ancor fra lacci geme?...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="F">E dei tant'oltre</l>
             <l part="I">cercar? ti appresta al partir tuo.</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
@@ -2669,7 +2685,7 @@
             <l>a lei si appresta? io voglio ceppi; io voglio</l>
             <l part="I">più cruda ancor la pena...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -2682,14 +2698,14 @@
             <l>che ardisci più? Dell'oprar mio vuoi conto</l>
             <l part="I">da me, tu?...</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
             <l part="F">Prego; almen grazia concedi,</l>
             <l part="I">ch'io la rivegga ancora.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -2699,7 +2715,7 @@
             <l>irne libera in Argo ove non vogli,</l>
             <l part="I">a forza andrai.</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
@@ -2710,7 +2726,7 @@
             <l>D'Antigone son io meno innocente,</l>
             <l part="I">ch'io pur non merti il tuo furore?...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -2722,14 +2738,14 @@
             <l>andar negasse, a forza si strascini. —</l>
             <l part="I">Torni intanto al suo carcere.</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
             <l part="F">Mi ascolta...</l>
             <l part="I">abbi pietade...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -2739,7 +2755,7 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>CREONTE</stage>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -2754,7 +2770,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>ANTIGONE <emph>tra le guardie</emph></stage>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -2771,7 +2787,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>ANTIGONE, ARGIA <emph>tra guardie</emph></stage>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
@@ -2781,26 +2797,26 @@
             <l>principio, e fin;... ma, alla fedel compagna</l>
             <l part="I">neppur l'ultimo addio!...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="F">Qual odo io voce</l>
             <l part="I">di pianto?...</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
             <l part="M">Oh ciel! chi veggio?</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="M">Argìa!</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
@@ -2808,33 +2824,33 @@
             <l>oh me felice! oh dolce incontro! — Ahi vista!</l>
             <l part="I">carche hai le man di ferro?...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="F">Ove sei tratta?</l>
             <l part="I">deh! tosto dimmi.</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
             <l part="F">A forza in Argo, al padre.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="I">Respiro.</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
             <l part="F">A vil tanto mi tien Creonte,</l>
             <l part="I">che me vuol salva: ma, di te...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -2861,7 +2877,7 @@
             <l>e a lagrimar sovr'essa; e, fra... i tuoi... pianti...</l>
             <l part="I">anco rimembra... Antigone...</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
@@ -2869,7 +2885,7 @@
             <l>il cor... Mie voci... tronche... dai... sospiri...</l>
             <l part="I">Ch'io viva,... mentre... a morte?...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -2879,13 +2895,13 @@
             <l>essermi tomba; ivi sepolta viva</l>
             <l part="I">mi vuol Creonte.</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
             <l part="M">Ahi scellerato!...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -2897,7 +2913,7 @@
             <l>orribili delitti di mia stirpe,</l>
             <l part="I">bastasse pur mia lunga morte!...</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
@@ -2906,14 +2922,14 @@
             <l>coraggio addoppia il mio; tua pena in parte</l>
             <l part="I">fia scema forse...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="F">Oh! che di' tu? Più grave</l>
             <l part="I">mille volte saria.</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
@@ -2921,7 +2937,7 @@
             <l>potremmo almen di Polinice il nome</l>
             <l part="I">profferire; esortarci, e pianger...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -2930,14 +2946,14 @@
             <l>ultima or fo di mia costanza. — Il pianto</l>
             <l part="I">più omai non freno...</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
             <l part="F">Ahi lassa me! non posso</l>
             <l part="I">salvarti? oh ciel! né morir teco?...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -2955,7 +2971,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>CREONTE, ANTIGONE, ARGIA, <emph>guardie</emph></stage>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -2964,7 +2980,7 @@
             <l>seco è? che fu? chi le accoppiò? — Di voi</l>
             <l part="I">qual mi tradisce?</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -2974,54 +2990,54 @@
             <l>non t'irritar, Creonte. Opra pietosa,</l>
             <l>giust'opra fai, serbando in vita Argìa.</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
             <l part="I">Creonte, deh! seco mi lascia...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="F">Ah! fuggi,</l>
             <l part="I">pria che in lui cessi la pietà.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="F">Si tragga</l>
             <l part="I">Argìa primiera al suo destino...</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
             <l part="F">Ahi crudi!</l>
             <l part="I">svellermi voi?...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="F">L'ultimo amplesso dammi.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l>Stacchisi a forza; si strappi, strascinisi:</l>
             <l part="I">tosto, obbedite, io 'l voglio. Itene.</l>
           </sp>
-          <sp>
+          <sp who="#argia">
             <speaker>
               <emph>Argia</emph>
             </speaker>
             <l part="F">Oh cielo!</l>
             <l part="I">non ti vedrò più mai?...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -3031,7 +3047,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>CREONTE, ANTIGONE, <emph>guardie</emph></stage>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -3043,7 +3059,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>CREONTE</stage>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -3073,13 +3089,13 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>CREONTE, EMONE, <emph>seguaci d'Emone</emph></stage>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="M">Figlio, che fai?</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -3091,7 +3107,7 @@
             <l>per risparmiar nuovi delitti a Tebe,</l>
             <l part="I">snudato in man mi sta.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -3102,7 +3118,7 @@
             <l>figlio!... mal grado tuo, pur caro al padre! —</l>
             <l>Ma di': che cerchi? innanzi tempo, scettro?</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -3112,7 +3128,7 @@
             <l>braccio, ed a forza, il mio. Trar di tue mani</l>
             <l part="I">Antigone ed Argìa...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -3125,33 +3141,33 @@
             <l>e a ciò finor non mi movea, ben vedi,</l>
             <l part="I">il terror del tuo brando.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
             <l part="F">E qual destino</l>
             <l part="I">ebbe Antigone?...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="F">Anch'ella or or fu tratta</l>
             <l>dallo squallor del suo carcere orrendo.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
             <l part="I">Ov'è? vederla voglio.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="F">Altro non brami?</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -3162,7 +3178,7 @@
             <l>regal donzella, a cui tutt'altro in Tebe</l>
             <l part="I">si dee, che pena.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -3173,7 +3189,7 @@
             <l>qui fra tuoi forti umìle, infin che il prode</l>
             <l part="I">liberator n'esca, e trionfi.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -3181,20 +3197,20 @@
             <l>tu parli forse; ma davvero io parlo.</l>
             <l>Mira, ben mira, s'io pur basto a tanto.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l>Va', va': <note resp="#aut" place="foot" anchored="true">S'apre la scena, e si vede il corpo di Antigone.</note> Creonte ad atterrir non basti.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
             <l>Che veggio?... Oh cielo!... Antigone.., svenata! —</l>
             <l part="I">Tiranno infame,... a me tal colpo?</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -3202,20 +3218,20 @@
             <l>così l'orgoglio: io fo così mie leggi</l>
             <l>servar; così, fo ravvedersi un figlio.</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
             <l>Ravvedermi? Ah! pur troppo a te son figlio!</l>
             <l>Così nol fossi! in te il mio brando.<note resp="#aut" place="foot" anchored="true">Si avventa al padre col brando, ma istantaneamente lo ritorce in se stesso, e cade trafitto.</note> — Io... moro...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="I">Figlio, che fai? t'arresta. —</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -3225,7 +3241,7 @@
             <l>Ecco, a te rendo il sangue tuo; meglio era</l>
             <l part="I">non darmel mai.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -3233,7 +3249,7 @@
             <l>mai non credei, che un folle amor ti avria</l>
             <l part="I">contro a te stesso...</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -3242,13 +3258,13 @@
             <l>finir miei giorni... Io... ti fui figlio in vita...</l>
             <l part="I">tu, padre a me,... mai non lo fosti...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="F">Oh figlio!...</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -3258,7 +3274,7 @@
             <l>traggasi;... là, voglio esalar l'estremo</l>
             <l part="I">vital... mio... spirto...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -3266,7 +3282,7 @@
             <l>e abbandonar ti deggio? orbo per sempre</l>
             <l part="I">rimanermi?...</l>
           </sp>
-          <sp>
+          <sp who="#emone">
             <speaker>
               <emph>Emone</emph>
             </speaker>
@@ -3274,7 +3290,7 @@
             <l>un'altra volta il ferro,... o a lei dappresso</l>
             <l part="I">trar... mi... lascia,... e morire...<note resp="#aut" place="foot" anchored="true">Viene lentamente strascinato da' suoi seguaci verso il corpo d'Antigone.</note></l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -3285,7 +3301,7 @@
         <div type="scene">
           <head>SCENA VII</head>
           <stage>CREONTE</stage>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>

--- a/tei/alfieri-bruto-primo.xml
+++ b/tei/alfieri-bruto-primo.xml
@@ -82,6 +82,31 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="collatino">
+            <persName>Collatino</persName>
+          </person>
+          <person xml:id="bruto">
+            <persName>Bruto</persName>
+          </person>
+          <personGrp xml:id="popolo">
+            <name>Popolo</name>
+          </personGrp>
+          <person xml:id="tito">
+            <persName>Tito</persName>
+          </person>
+          <person xml:id="tiberio">
+            <persName>Tiberio</persName>
+          </person>
+          <person xml:id="valerio">
+            <persName>Valerio</persName>
+          </person>
+          <person xml:id="mamilio">
+            <persName>Mamilio</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione - OCR</change>
@@ -149,7 +174,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>BRUTO, COLLATINO</stage>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -158,7 +183,7 @@
             <l>quel mio pugnal, che dell'amato sangue</l>
             <l part="I">gronda pur anco... Entro al mio petto...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -169,7 +194,7 @@
             <l>che intero scoppi e il tuo dolore immenso,</l>
             <l part="I">ed il furor mio giusto.</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -178,7 +203,7 @@
             <l>mio caso, è vano ogni sollievo: il ferro,</l>
             <l>quel ferro sol fia del mio pianger fine.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -188,7 +213,7 @@
             <l>Romana donna, alto principio a Roma</l>
             <l part="I">oggi sarai.</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -196,7 +221,7 @@
             <l>sperare ancora! universal vendetta</l>
             <l part="I">pria di morir...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -212,7 +237,7 @@
             <l>Patria, sì; cui creare oggi vuol teco,</l>
             <l>o morir teco in tanta impresa Bruto.</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -220,7 +245,7 @@
             <l>Sol per la patria vera, alla svenata</l>
             <l>moglie mia sopravvivere potrei.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -229,7 +254,7 @@
             <l>che in cor mi grida: «A Collatino, e a Bruto,</l>
             <l>spetta il dar vita e libertade a Roma».</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -239,7 +264,7 @@
             <l>abbia or da noi vita novella; o noi</l>
             <l>(ma vendicati pria) cadiam con essa.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -268,7 +293,7 @@
             <l>atta a destar compassionevol rabbia</l>
             <l part="I">fia nella plebe oppressa...</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -283,7 +308,7 @@
             <l>lavar poss'io la macchia anco del nome,</l>
             <l part="I">cui comune ho con essi.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -301,21 +326,21 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>BRUTO, COLLATINO, POPOLO</stage>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l>Romani, a me: Romani, assai gran cose</l>
             <l part="I">narrar vi deggio; a me venite.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="F">O Bruto,</l>
             <l part="I">e fia pur ver, quel che si udì?...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -332,14 +357,14 @@
             <l>che dei Tarquini tutti appien disgombra</l>
             <l part="I">Roma libera io vegga.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="F">Oh non più intesa</l>
             <l part="I">dolorosa catastrofe!...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -368,7 +393,7 @@
             <l>sol di morir per voi; pur ch'io primiero</l>
             <l>libero muoia, e cittadino in Roma.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
@@ -376,7 +401,7 @@
             <l>hanno i suoi detti!... Oh ciel! ma inermi siamo;</l>
             <l>come affrontare i rei tiranni armati?...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -407,7 +432,7 @@
             <l>ceder forse l'onor dell'armi prime</l>
             <l>contra i tiranni, assentirestel voi?</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
@@ -415,7 +440,7 @@
             <l>i nostri petti! — E che temiam, se tutti</l>
             <l part="I">vogliam lo stesso?</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -430,14 +455,14 @@
             <l>Primi a seguirmi, o voi, mariti e padri...</l>
             <l part="I">Ma, qual spettacol veggio!...<note resp="#aut" place="foot" anchored="true">Nel fondo della scena si vede il corpo di Lucrezia portato e seguìto da una gran moltitudine.</note></l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="F">Oh vista atroce!</l>
             <l>Della svenata donna, ecco nel foro...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -449,14 +474,14 @@
             <l>«Oggi, o tornarvi in libertade, o morti</l>
             <l part="I">cader dovrete. Altro non resta».</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="F">Ah! tutti</l>
             <l>liberi, sì, sarem noi tutti, o morti.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -477,7 +502,7 @@
             <l>io cittadino, e nulla più: le leggi</l>
             <l>sole avran regno, e obbedirolle io primo.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
@@ -486,7 +511,7 @@
             <l>ne avvenga a noi, che a Collatin, se siamo</l>
             <l part="I">spergiuri mai.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -498,7 +523,7 @@
             <l>poiché fortuna a noi propizia esclusi</l>
             <l part="I">gli ebbe da Roma pria.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
@@ -507,7 +532,7 @@
             <l>Il senno voi, noi presteremvi il braccio,</l>
             <l part="I">il ferro, il core...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -524,7 +549,7 @@
             <l>plebe e patrizi aduneremci: e data</l>
             <l>fia stabil base a libertà per noi.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
@@ -537,7 +562,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>BRUTO, TITO</stage>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
@@ -548,7 +573,7 @@
             <l>entro la mente attonita il vederti</l>
             <l part="I">signor di Roma quasi...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -569,7 +594,7 @@
             <l>per la patria quel dì che in Roma io lascio</l>
             <l>fra cittadini liberi i miei figli.</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
@@ -582,7 +607,7 @@
             <l>mobil cosa la plebe: oh quanti aiuti</l>
             <l part="I">ai Tarquini ancor restano!...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -601,7 +626,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>TIBERIO, BRUTO, TITO</stage>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
@@ -614,19 +639,19 @@
             <l>Visti ho dappresso i rei Tarquini or ora;</l>
             <l part="I">e non tremai...</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
             <l part="M">Che fu?</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l part="M">Dove?...</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
@@ -639,14 +664,14 @@
             <l>con stuolo eletto: e giunti eran già quivi</l>
             <l part="I">presso alla porta Carmentale...</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
             <l part="F">Appunto</l>
             <l part="I">v'eri tu a guardia.</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
@@ -670,7 +695,7 @@
             <l>e, caldo ancor della vittoria, ratto</l>
             <l part="I">a narrartela vengo.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -683,7 +708,7 @@
             <l>tutto adoprare a un tempo? Ma, ben posso,</l>
             <l>con tai figli, adempir più parti in una.</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
@@ -700,7 +725,7 @@
             <l>l'ingresso in Roma. A propor patti e scuse</l>
             <l part="I">viene a Bruto, e al senato...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -708,7 +733,7 @@
             <l>che, o nulla è Bruto; o egli è del popol parte.</l>
             <l part="I">Ed era il messo?...</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
@@ -716,7 +741,7 @@
             <l>ben da' miei custodir fuor della porta;</l>
             <l>quindi a saper che far sen debba io venni.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -728,7 +753,7 @@
             <l>a Roma tutta in faccia: e udrà risposta</l>
             <l part="I">degna di Roma, io spero.</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
@@ -738,7 +763,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>BRUTO, TITO</stage>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -752,7 +777,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>BRUTO, POPOLO, <emph>Senatori</emph>, <emph>e Patrizi</emph>, <emph>che si van collocando nel Foro</emph></stage>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -769,7 +794,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>BRUTO <emph>salito in ringhiera</emph>, VALERIO, TITO, POPOLO, <emph>Senatori</emph>, <emph>Patrizi</emph></stage>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -790,7 +815,7 @@
             <l>me pur soverchi in tale gara eccelsa;</l>
             <l part="I">ch'altro non bramo.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
@@ -799,7 +824,7 @@
             <l>tutto, sì, tutto in te ci annuncia il padre</l>
             <l part="I">dei Romani, e di Roma.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -834,7 +859,7 @@
             <l>cader dell'ira lor vittime infauste,</l>
             <l>se in voi l'ardir di opporci invan, sorgea.</l>
           </sp>
-          <sp>
+          <sp who="#valerio">
             <speaker>
               <emph>Valerio</emph>
             </speaker>
@@ -859,7 +884,7 @@
             <l>sul sangue nostro e quel dei figli nostri,</l>
             <l>tutti il giuriam ferocemente, a un grido.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
@@ -870,7 +895,7 @@
             <l>qual popol, quale, imprenderia far fronte</l>
             <l>a noi Romani e cittadini a prova?</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -886,14 +911,14 @@
             <l>finché, deposte l'armi, in piena pace</l>
             <l>darete voi stabil governo a Roma.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l>Romper, disfar, spegner del tutto in pria</l>
             <l part="I">tiranni fa d'uopo.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -913,20 +938,20 @@
             <l>ambasciator Mamilio. I patti indegni</l>
             <l part="I">piacevi udir quai sieno?</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="F">Altro non havvi</l>
             <l>patto fra noi, che il morir loro, o il nostro.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l part="I">Ciò dunque egli oda, e il riferisca.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
@@ -938,7 +963,7 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>BRUTO, TITO, MAMILIO, VALERIO, POPOLO, <emph>Senatori</emph>, <emph>Patrizi</emph></stage>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -948,7 +973,7 @@
             <l>mirala; è questa. Eccola intera, e in atto</l>
             <l part="I">di ascoltarti. Favella.</l>
           </sp>
-          <sp>
+          <sp who="#mamilio">
             <speaker>
               <emph>Mamilio</emph>
             </speaker>
@@ -956,7 +981,7 @@
             <l>dirti, o Bruto, dovrei: ma, in questo immenso</l>
             <l part="I">consesso,... esporre... all'improvviso...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -966,7 +991,7 @@
             <l>alla plebe gli esponi: in un con gli altri,</l>
             <l part="I">Bruto anch'egli ti ascolta.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
@@ -978,40 +1003,40 @@
             <l>e sia breve il tuo dire: aperto e intero</l>
             <l part="I">sarà il risponder nostro.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l part="M">Udisti?</l>
           </sp>
-          <sp>
+          <sp who="#mamilio">
             <speaker>
               <emph>Mamilio</emph>
             </speaker>
             <l part="F">Io tremo.</l>
             <l part="I">— Tarquinio re...</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="M">Di Roma no.</l>
           </sp>
-          <sp>
+          <sp who="#mamilio">
             <speaker>
               <emph>Mamilio</emph>
             </speaker>
             <l part="F">— Di Roma</l>
             <l part="I">Tarquinio amico, e padre...</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="F">Egli è di Sesto</l>
             <l part="I">l'infame padre, e non di noi...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -1019,7 +1044,7 @@
             <l>quai che sian i suoi detti, udirlo in pieno</l>
             <l part="I">dignitoso silenzio.</l>
           </sp>
-          <sp>
+          <sp who="#mamilio">
             <speaker>
               <emph>Mamilio</emph>
             </speaker>
@@ -1034,20 +1059,20 @@
             <l>a perder abbia oggi ei di Roma il trono</l>
             <l part="I">a lui da voi concesso...</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="F">Oh rabbia! Oh ardire!</l>
             <l>Spenta è Lucrezia, e del delitto ei chiede?...</l>
           </sp>
-          <sp>
+          <sp who="#mamilio">
             <speaker>
               <emph>Mamilio</emph>
             </speaker>
             <l part="I">Fu Sesto il reo, non egli...</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
@@ -1056,7 +1081,7 @@
             <l>e se con lui volto non era in fuga,</l>
             <l part="I">voi qui vedreste.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
@@ -1064,7 +1089,7 @@
             <l>lor si vietò? già in mille brani e in mille</l>
             <l part="I">fatti entrambi gli avremmo.</l>
           </sp>
-          <sp>
+          <sp who="#mamilio">
             <speaker>
               <emph>Mamilio</emph>
             </speaker>
@@ -1073,7 +1098,7 @@
             <l>più re che padre, il suo figliuol traea,</l>
             <l>per sottoporlo alla dovuta pena.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -1106,20 +1131,20 @@
             <l>Lucrezia uccisa; e oltr'esso omai non varca,</l>
             <l>né la loro empietà, né il soffrir nostro.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l>L'ultimo è questo; ah! Roma tutta il giura...</l>
           </sp>
-          <sp>
+          <sp who="#valerio">
             <speaker>
               <emph>Valerio</emph>
             </speaker>
             <l>Il giuriam tutti: morti cadrem tutti,</l>
             <l>pria che in Roma Tarquinio empio mai rieda.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -1128,13 +1153,13 @@
             <l>Vanne; recala or dunque al signor tuo,</l>
             <l>poich'esser servo all'esser uom preponi.</l>
           </sp>
-          <sp>
+          <sp who="#mamilio">
             <speaker>
               <emph>Mamilio</emph>
             </speaker>
             <l>— Ragioni molte addur potrei;... ma, niuna...</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
@@ -1144,7 +1169,7 @@
             <l>udiva ei forse allor ragioni, o preghi?</l>
             <l>Non rideva egli allor del pianger nostro?</l>
           </sp>
-          <sp>
+          <sp who="#mamilio">
             <speaker>
               <emph>Mamilio</emph>
             </speaker>
@@ -1155,14 +1180,14 @@
             <l>ch'oltre l'onore, oltre la patria e il seggio,</l>
             <l part="I">gli si tolgan gli averi?</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="F">— A ciò risponda</l>
             <l part="I">Bruto per noi.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -1185,7 +1210,7 @@
             <l>degni ne stima oggi i Tarquini soli;</l>
             <l part="I">e a lor li dona interi.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
@@ -1194,7 +1219,7 @@
             <l>favella in Bruto. Il suo voler si adempia...</l>
             <l part="I">Abbia Tarquinio i rei tesori...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -1208,7 +1233,7 @@
         <div type="scene">
           <head>SCENA VII</head>
           <stage>BRUTO, POPOLO, VALERIO, <emph>Senatori</emph>, <emph>Patrizi</emph></stage>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -1217,13 +1242,13 @@
             <l>Vediam, vediam, s'altra risposta forse</l>
             <l>chiederci ardisce or di Tarquinio il brando.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l>Ecco i tuoi scelti, a tutto presti, o Bruto.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -1236,7 +1261,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>TIBERIO, MAMILIO</stage>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
@@ -1245,7 +1270,7 @@
             <l>che ciò m'impone: al tramontar del sole</l>
             <l part="I">fuori esser dei di Roma.</l>
           </sp>
-          <sp>
+          <sp who="#mamilio">
             <speaker>
               <emph>Mamilio</emph>
             </speaker>
@@ -1253,7 +1278,7 @@
             <l>ei rivocar ciò che con Roma intera</l>
             <l part="I">mi concedea stamane ei stesso?...</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
@@ -1262,7 +1287,7 @@
             <l>ti seguiran fuor delle porte i chiesti</l>
             <l part="I">e accordati tesori. Andiam...</l>
           </sp>
-          <sp>
+          <sp who="#mamilio">
             <speaker>
               <emph>Mamilio</emph>
             </speaker>
@@ -1270,7 +1295,7 @@
             <l>dunque recare all'infelice Aronte</l>
             <l part="I">in nome tuo?</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
@@ -1280,19 +1305,19 @@
             <l>sento del suo destin pietà non poca.</l>
             <l part="I">Nulla per lui poss'io...</l>
           </sp>
-          <sp>
+          <sp who="#mamilio">
             <speaker>
               <emph>Mamilio</emph>
             </speaker>
             <l part="F">Per te, puoi molto.</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
             <l part="I">Che dir vuoi tu?</l>
           </sp>
-          <sp>
+          <sp who="#mamilio">
             <speaker>
               <emph>Mamilio</emph>
             </speaker>
@@ -1300,13 +1325,13 @@
             <l>l'ingresso ottiene entro al tuo giovin petto,</l>
             <l>dei di te stesso, e in un de' tuoi, sentirla.</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
             <l part="I">Che parli?</l>
           </sp>
-          <sp>
+          <sp who="#mamilio">
             <speaker>
               <emph>Mamilio</emph>
             </speaker>
@@ -1318,7 +1343,7 @@
             <l>questo novello, e neppur nato appieno,</l>
             <l>mero ideale popolar governo?</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
@@ -1326,7 +1351,7 @@
             <l>poiché tu servi, io 'l credo. Ma, di Roma</l>
             <l part="I">il concorde voler...</l>
           </sp>
-          <sp>
+          <sp who="#mamilio">
             <speaker>
               <emph>Mamilio</emph>
             </speaker>
@@ -1341,19 +1366,19 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>TITO, MAMILIO, TIBERIO</stage>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
             <l>Te rintracciando andava; io favellarti</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
             <l part="I">Per or nol posso.</l>
           </sp>
-          <sp>
+          <sp who="#mamilio">
             <speaker>
               <emph>Mamilio</emph>
             </speaker>
@@ -1362,7 +1387,7 @@
             <l>comando il vuol del vostro padre. — Oh quanto</l>
             <l part="I">di voi mi duole, o giovinetti!...</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
@@ -1370,27 +1395,27 @@
             <l>andiam frattanto. — Ad ascoltarti, o Tito,</l>
             <l part="I">or ora io riedo.</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
             <l part="F">E che vuol dir costui?</l>
           </sp>
-          <sp>
+          <sp who="#mamilio">
             <speaker>
               <emph>Mamilio</emph>
             </speaker>
             <l>Andiam: narrarti io potrò forse in via</l>
             <l part="I">quanto il fratel dirti or volea.</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
             <l part="F">T'arresta.</l>
             <l part="I">Saper da te...</l>
           </sp>
-          <sp>
+          <sp who="#mamilio">
             <speaker>
               <emph>Mamilio</emph>
             </speaker>
@@ -1398,39 +1423,39 @@
             <l>Tutto sta in me: da gran perigli io posso</l>
             <l part="I">scamparvi, io solo...</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
             <l part="F">Artificiosi detti</l>
             <l part="I">tu muovi...</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
             <l part="M">E che sta in te?</l>
           </sp>
-          <sp>
+          <sp who="#mamilio">
             <speaker>
               <emph>Mamilio</emph>
             </speaker>
             <l part="F">Tiberio, e Tito,</l>
             <l>e Bruto vostro, e Collatino, e Roma.</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
             <l part="I">Folle, che parli?</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
             <l part="F">Io so che la iniqua speme...</l>
           </sp>
-          <sp>
+          <sp who="#mamilio">
             <speaker>
               <emph>Mamilio</emph>
             </speaker>
@@ -1441,13 +1466,13 @@
             <l>e cento e cento altri patrizi; e molti,</l>
             <l>e i più valenti, infra la plebe istessa...</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
             <l part="I">Oh ciel! che ascolto?...</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
@@ -1459,7 +1484,7 @@
             <l>ne rimanea pur io. Grave sospetto</l>
             <l part="I">quindi in me nacque...</l>
           </sp>
-          <sp>
+          <sp who="#mamilio">
             <speaker>
               <emph>Mamilio</emph>
             </speaker>
@@ -1468,20 +1493,20 @@
             <l>la congiura, e sì forte, ch'io non temo</l>
             <l part="I">di svelarvela.</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
             <l part="M">Perfido...</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
             <l part="F">Le vili</l>
             <l part="I">arti tue v'adoprasti...</l>
           </sp>
-          <sp>
+          <sp who="#mamilio">
             <speaker>
               <emph>Mamilio</emph>
             </speaker>
@@ -1518,7 +1543,7 @@
             <l>per voi salvar; e per salvare a un tempo,</l>
             <l>ov'ei pur voglia, il vostro padre istesso.</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
@@ -1528,7 +1553,7 @@
             <l>il comando di espellerti; ma tardo</l>
             <l part="I">pur mi giungea...</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
@@ -1538,7 +1563,7 @@
             <l>de' Vitelli cugini: io fuor di Roma</l>
             <l>volo, il ritorno ad affrettar del padre.</l>
           </sp>
-          <sp>
+          <sp who="#mamilio">
             <speaker>
               <emph>Mamilio</emph>
             </speaker>
@@ -1559,14 +1584,14 @@
             <l>appo i Vitelli traggi: ivi securo,</l>
             <l part="I">più assai che tu, fra lor starommi.</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
             <l part="F">Or quale</l>
             <l part="I">empio sospetto?...</l>
           </sp>
-          <sp>
+          <sp who="#mamilio">
             <speaker>
               <emph>Mamilio</emph>
             </speaker>
@@ -1577,20 +1602,20 @@
             <l>eran quanto di sangue, anch'essi or vonno</l>
             <l part="I">ripor Tarquinio in seggio.</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
             <l part="M">Oh ciel!...</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
             <l part="F">Menzogna</l>
             <l part="I">fia questa...</l>
           </sp>
-          <sp>
+          <sp who="#mamilio">
             <speaker>
               <emph>Mamilio</emph>
             </speaker>
@@ -1600,26 +1625,26 @@
             <l>leggete or voi, sotto agli Aquili appunto,</l>
             <l part="I">scritti i quattro lor nomi.</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
             <l part="M">Ahi vista!</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
             <l part="F">Oh cielo!</l>
             <l part="I">che mai sarà del padre?...</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
             <l part="F">Oh giorno! Oh Roma!...</l>
           </sp>
-          <sp>
+          <sp who="#mamilio">
             <speaker>
               <emph>Mamilio</emph>
             </speaker>
@@ -1641,33 +1666,33 @@
             <l>a certa morte il genitor trarrete:</l>
             <l>e il re fia ognor Tarquinio poscia in Roma.</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
             <l>Ah! ch'io pur troppo antivedea per tempo</l>
             <l part="I">quant'ora ascolto. Al padre io 'l dissi...</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
             <l part="F">A scabro</l>
             <l>passo siam noi. Che far si dee? deh! parla...</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
             <l>Grave periglio al genitor sovrasta...</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
             <l part="I">E assai più grave a Roma...</l>
           </sp>
-          <sp>
+          <sp who="#mamilio">
             <speaker>
               <emph>Mamilio</emph>
             </speaker>
@@ -1680,19 +1705,19 @@
             <l>voi stessi, e il padre in un salvate, e Roma.</l>
             <l part="I">Ciò tutto è in voi.</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
             <l part="M">Come?...</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
             <l part="M">Che speri?...</l>
           </sp>
-          <sp>
+          <sp who="#mamilio">
             <speaker>
               <emph>Mamilio</emph>
             </speaker>
@@ -1700,14 +1725,14 @@
             <l>di propria mano i nomi vostri a questi,</l>
             <l part="I">fia salvo il tutto.</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
             <l part="F">Oh ciel! la patria, il padre</l>
             <l part="I">noi tradirem?...</l>
           </sp>
-          <sp>
+          <sp who="#mamilio">
             <speaker>
               <emph>Mamilio</emph>
             </speaker>
@@ -1721,14 +1746,14 @@
             <l>col più persister voi trarrete, e invano,</l>
             <l>la patria e il padre a fere stragi, e voi.</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
             <l>Ma dimmi; aggiunto ai tanti nomi il nostro,</l>
             <l>a che ci mena? a che s'impegnan gli altri?</l>
           </sp>
-          <sp>
+          <sp who="#mamilio">
             <speaker>
               <emph>Mamilio</emph>
             </speaker>
@@ -1744,27 +1769,27 @@
             <l>voi d'amistade infra Tarquinio e Bruto;</l>
             <l>nodo, che sol porre or può in salvo Roma.</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
             <l part="I">Certo, a ciò far noi pur potremmo...</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
             <l part="F">Ah! pensa...</l>
             <l part="I">Chi sa?... Forse altro...</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
             <l part="F">E ch'altro a far ci resta?</l>
             <l part="I">Possente troppo è la congiura...</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
@@ -1774,7 +1799,7 @@
             <l>troppo ognora ti amai: ma orribil sento</l>
             <l part="I">presagio al core...</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
@@ -1785,7 +1810,7 @@
             <l>stretti noi siam per ogni parte: almeno</l>
             <l part="I">per or ci è forza il re placare...</l>
           </sp>
-          <sp>
+          <sp who="#mamilio">
             <speaker>
               <emph>Mamilio</emph>
             </speaker>
@@ -1799,7 +1824,7 @@
             <l>tosto farete, affin che tosto in Roma</l>
             <l part="I">rieda la pace.</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
@@ -1807,32 +1832,32 @@
             <l>nel cor mio puro; ei sa, che a ciò mi sforza</l>
             <l part="I">solo il bene di tutti.</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
             <l part="F">Oh ciel! Che fai?...</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
             <l part="I">Ecco il mio nome.</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
             <l part="F">— E sia, se il vuoi. — Firmato,</l>
             <l part="I">ecco, o Mamilio, il mio.</l>
           </sp>
-          <sp>
+          <sp who="#mamilio">
             <speaker>
               <emph>Mamilio</emph>
             </speaker>
             <l part="F">Contento io parto.</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
@@ -1842,27 +1867,27 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage><emph>Littori</emph>, COLLATINO <emph>con numerosi soldati</emph>, TITO, MAMILIO, TIBERIO</stage>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
             <l part="F">Che veggo?</l>
             <l part="I">Ancor Mamilio in Roma?</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
             <l part="M">Oh cielo!...</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
             <l part="F">Oh vista!</l>
             <l part="I">Oh fero inciampo!</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -1874,13 +1899,13 @@
             <l>Tito e Tiberio infra catene avvinti</l>
             <l part="I">sian tosto...</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
             <l part="M">Deh! ci ascolta...</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -1889,7 +1914,7 @@
             <l>magion traete i due fratelli; e quivi</l>
             <l part="I">su lor vegliate.</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
@@ -1899,21 +1924,21 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>COLLATINO, MAMILIO, <emph>Soldati</emph></stage>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
             <l part="F">E voi, costui</l>
             <l part="I">fuor delle porte accompagnate...</l>
           </sp>
-          <sp>
+          <sp who="#mamilio">
             <speaker>
               <emph>Mamilio</emph>
             </speaker>
             <l part="F">Io venni</l>
             <l part="I">sotto pubblica fede...</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -1925,7 +1950,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>COLLATINO</stage>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -1941,7 +1966,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage><emph>Littori</emph>, BRUTO, <emph>Soldati</emph></stage>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -1957,7 +1982,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>COLLATINO, BRUTO, <emph>Littori</emph>, <emph>Soldati</emph></stage>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -1965,7 +1990,7 @@
             <l>Già, del tuo non tornare ansio, veniva</l>
             <l part="I">io fuor di Roma ad incontrarti.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -1984,7 +2009,7 @@
             <l>Dal più incalzarli poscia i miei rattenni,</l>
             <l>per le già sorte tenebre, a gran stento.</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -2001,7 +2026,7 @@
             <l>da me scortati, or gli ha raccolti Roma;</l>
             <l>e veglian tutti in sua difesa a gara.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2012,7 +2037,7 @@
             <l>ci rivedrà; che d'alte cose a lungo</l>
             <l part="I">trattar col popol dessi.</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -2021,19 +2046,19 @@
             <l>ma in armi stare i tuoi soldati: io deggio</l>
             <l part="I">a solo a sol qui favellarti.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l part="F">E quale?...</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
             <l part="I">L'util di Roma il vuol; ten prego...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2042,7 +2067,7 @@
             <l>voi, soldati, aspettatemi. — Littori,</l>
             <l part="I">scostatevi d'alquanto.</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -2050,14 +2075,14 @@
             <l>ancorché breve, infra i tuoi Lari, in questa</l>
             <l>orribil notte, il cercheresti indarno.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l>Che mai mi annunzi?... Oh cielo! onde turbato,</l>
             <l>inquieto, sollecito,... tremante?...</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -2075,7 +2100,7 @@
             <l>saratti!... Eppur; né a te tacerla io deggio;...</l>
             <l part="I">né indugiartela posso.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2088,7 +2113,7 @@
             <l>purché Roma sia libera del tutto,</l>
             <l part="I">udir poss'io: favella.</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -2104,7 +2129,7 @@
             <l>Fera, possente, numerosa, bolle</l>
             <l part="I">una congiura in Roma.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2114,7 +2139,7 @@
             <l>pria di nona, a Tiberio ebbi spedito,</l>
             <l part="I">di farlo uscir tosto di Roma.</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -2124,13 +2149,13 @@
             <l>ritrovava Mamilio. — Il dirtel duolmi;</l>
             <l>ma vero è pur; male obbedito fosti.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l>Oh! qual desti in me sdegno a terror misto?...</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -2141,14 +2166,14 @@
             <l>anima son del tradimento, e parte,</l>
             <l part="I">primi i Vitelli stessi...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l part="F">Oimè! i germani</l>
             <l part="I">della consorte mia?...</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -2156,7 +2181,7 @@
             <l>da lor sedotta or contra te non sia?</l>
             <l part="I">E,... gli stessi... tuoi figli?...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2164,7 +2189,7 @@
             <l>Mi agghiacci il sangue entro ogni vena... I figli</l>
             <l part="I">miei, traditori?... Ah! no, nol credo...</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -2174,7 +2199,7 @@
             <l>forza (oimè!) ch'io 'l credessi. — È questo un foglio</l>
             <l part="I">fatal per noi: leggilo.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2189,7 +2214,7 @@
             <l>Littori, olà, Tito e Tiberio tosto</l>
             <l part="I">guidinsi avanti al mio cospetto.</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -2197,14 +2222,14 @@
             <l>meglio era, o Bruto, che morir me solo</l>
             <l part="I">lasciassi tu...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l part="F">Ma come in man ti cadde</l>
             <l part="I">questo terribil foglio?</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -2223,7 +2248,7 @@
             <l>ma forza è pur, che te lo sveli io pria,</l>
             <l part="I">che in tua magion tu il piede...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2232,7 +2257,7 @@
             <l>fuorché il foro, e la tomba. — È dover mio,</l>
             <l>dar vita a Roma, anzi che a Bruto morte.</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -2245,7 +2270,7 @@
             <l>ch'uom non si muova in questa notte: all'alba</l>
             <l>convocato ho nel foro il popol tutto...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2253,14 +2278,14 @@
             <l>il vero appien, qual ch'esser possa, e il solo</l>
             <l part="I">vero saprà, per bocca mia.</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
             <l part="F">Già i passi</l>
             <l part="I">dei giovinetti miseri...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2272,20 +2297,20 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>TITO, TIBERIO <emph>fra Littori</emph>, BRUTO, COLLATINO</stage>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l>In disparte ognun traggasi: voi soli</l>
             <l part="I">inoltratevi.</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
             <l part="M">Ah padre!...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2293,28 +2318,28 @@
             <l>di Roma sono. — Io chieggo a voi, se siete</l>
             <l part="I">cittadini di Roma.</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
             <l part="F">Il siamo; e figli</l>
             <l part="I">ancor di Bruto...</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
             <l part="F">E il proverem, se udirci</l>
             <l part="I">il consol degna.</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
             <l part="F">Ai loro detti, agli atti,</l>
             <l part="I">sento il cor lacerarmi.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2326,7 +2351,7 @@
             <l>siete, non più di Bruto figli omai;</l>
             <l>figli voi de' tiranni infami siete.</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
@@ -2337,7 +2362,7 @@
             <l>sia qual si vuol, soltanto a me si debbe.</l>
             <l part="I">Mi sconsigliava ei sempre...</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
@@ -2355,7 +2380,7 @@
             <l>(l'odio paterno) il ciel ne attesto, e giuro,</l>
             <l part="I">che niun di noi la merta.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2363,14 +2388,14 @@
             <l>riporre il re, voi, con quest'altri infami,</l>
             <l part="I">pur prometteste?</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
             <l part="F">Io, col firmar, sperava</l>
             <l part="I">render Tarquinio a te più mite...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2381,13 +2406,13 @@
             <l>voi non giuraste morir meco entrambi,</l>
             <l>pria ch'a niun re mai più sopporci noi?</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
             <l part="I">Nol niego io, no...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2395,7 +2420,7 @@
             <l>e traditori... In questo foglio a un tempo</l>
             <l>firmato avete il morir vostro;... e il mio!...</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
@@ -2405,14 +2430,14 @@
             <l>di tua pietà non siam, per Roma lieti</l>
             <l part="I">morremo noi.</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
             <l part="F">Ma, benché reo, non era</l>
             <l part="I">né vil, né iniquo Tito...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2437,7 +2462,7 @@
             <l>A morte certa, e lunga, e obbrobriosa,</l>
             <l>voi, per salvarlo, or serbavate il padre.</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
@@ -2458,7 +2483,7 @@
             <l>il padre almeno: e in larghi detti, astuto</l>
             <l part="I">Mamilio a noi ciò promettea.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2469,7 +2494,7 @@
             <l>eri tu allor poiché il suo onor vendevi</l>
             <l>al prezzo infame dei comuni ceppi.</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
@@ -2479,14 +2504,14 @@
             <l>da noi fu il padre, che la patria nostra:</l>
             <l>sì, padre, il nostro unico error fu questo.</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
             <l>Ahi giovinetti miseri!... Oh infelice</l>
             <l part="I">padre!...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2512,7 +2537,7 @@
             <l>Ed ei lo aveva; ed il sapean suoi figli:</l>
             <l>tremar potean mai quindi essi pel padre?</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -2520,7 +2545,7 @@
             <l>acqueta, o Bruto: ancor, chi sa?... salvarli</l>
             <l part="I">forse....</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
@@ -2531,7 +2556,7 @@
             <l>Ma il tristo esemplo mio bensì discolpi</l>
             <l>l'innocente minor fratello; ei salvo...</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
@@ -2542,7 +2567,7 @@
             <l>volea, che base a libertà perenne</l>
             <l part="I">fosse il severo esempio nostro.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2572,25 +2597,25 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>COLLATINO, TITO, TIBERIO, <emph>Littori</emph></stage>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
             <l part="I">Necessità fatal.</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
             <l part="F">Misero padre!...</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
             <l part="I">Purché salva sia Roma!</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -2603,7 +2628,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>POPOLO, VALERIO, <emph>Senatori</emph>, <emph>Patrizi</emph>, <emph>tutti collocati</emph>, COLLATINO <emph>e</emph> BRUTO <emph>in ringhiera</emph></stage>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -2628,7 +2653,7 @@
             <l>han contra Roma, e contro a sé (pur troppo!)</l>
             <l part="I">congiurato pel re.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
@@ -2637,7 +2662,7 @@
             <l>d'esser Romani? Or via; nomali; spenti</l>
             <l part="I">li vogliam tutti...</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -2653,7 +2678,7 @@
             <l>di tirannia gustato han l'esca dolce,</l>
             <l>ignari appien dell'atroce suo fiele.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
@@ -2663,7 +2688,7 @@
             <l>vuol libertà che tronchi sieno i primi.</l>
             <l part="I">Nomali. Udiamo...</l>
           </sp>
-          <sp>
+          <sp who="#valerio">
             <speaker>
               <emph>Valerio</emph>
             </speaker>
@@ -2687,7 +2712,7 @@
             <l>ad alta prova ravvisar, qual fera</l>
             <l>brama ardente d'onor noi tutti invada.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
@@ -2697,7 +2722,7 @@
             <l>abbian da noi! Chi è traditor spergiuro,</l>
             <l part="I">cessò d'esser Romano.</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -2707,14 +2732,14 @@
             <l>ma da Mamilio iniquo in guise mille</l>
             <l part="I">raggirati, ingannati...</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="F">Ov'è l'infame?</l>
             <l part="I">Oh rabbia! ov'è?</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -2725,7 +2750,7 @@
             <l>di Roma, osserva ogni diritto: è base</l>
             <l>di nostra sacra libertà, la fede.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
@@ -2737,7 +2762,7 @@
             <l>il tradimento, la viltade, e l'ira</l>
             <l part="I">giusta del ciel...</l>
           </sp>
-          <sp>
+          <sp who="#valerio">
             <speaker>
               <emph>Valerio</emph>
             </speaker>
@@ -2747,7 +2772,7 @@
             <l>fia da temersi or dei tiranni in mano,</l>
             <l part="I">che non il ferro.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
@@ -2757,7 +2782,7 @@
             <l>a noi, che al fianco brando, e al petto usbergo</l>
             <l part="I">di libertade abbiamo?...</l>
           </sp>
-          <sp>
+          <sp who="#valerio">
             <speaker>
               <emph>Valerio</emph>
             </speaker>
@@ -2765,42 +2790,42 @@
             <l>tutti i tesori dei tiranni; o assorti</l>
             <l part="I">sien del Tebro fra l'onde...</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="F">E in un perisca</l>
             <l part="I">ogni memoria dei tiranni...</l>
           </sp>
-          <sp>
+          <sp who="#valerio">
             <speaker>
               <emph>Valerio</emph>
             </speaker>
             <l part="F">E pera</l>
             <l>del servir nostro ogni memoria a un tempo.</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
             <l>— Degno è di voi, magnanimo, il partito;</l>
             <l>eseguirassi il voler vostro, in breve.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l>Sì: ma frattanto, e la congiura, e i nomi</l>
             <l part="I">dei congiurati esponi.</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
             <l part="F">... Oh cielo!... Io tremo</l>
             <l part="I">nel dar principio a sì cruda opra...</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
@@ -2810,13 +2835,13 @@
             <l>lo sguardo in terra affisso ei tenga. — Or via,</l>
             <l part="I">parla tu dunque, o Collatino.</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
             <l part="F">... Oh cielo!...</l>
           </sp>
-          <sp>
+          <sp who="#valerio">
             <speaker>
               <emph>Valerio</emph>
             </speaker>
@@ -2826,7 +2851,7 @@
             <l>dei traditor saresti? in te pietade,</l>
             <l>per chi non l'ebbe della patria, senti?</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -2842,21 +2867,21 @@
             <l>di aprire al re nella futura notte</l>
             <l part="I">della città le porte...</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="F">Oh tradimento!</l>
             <l part="I">Muoiano i rei, muoiano...</l>
           </sp>
-          <sp>
+          <sp who="#valerio">
             <speaker>
               <emph>Valerio</emph>
             </speaker>
             <l part="F">Al rio misfatto</l>
             <l part="I">lieve pena è la morte.</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -2865,7 +2890,7 @@
             <l>Eccolo; il prendi: io profferir non posso</l>
             <l part="I">questi nomi.</l>
           </sp>
-          <sp>
+          <sp who="#valerio">
             <speaker>
               <emph>Valerio</emph>
             </speaker>
@@ -2875,7 +2900,7 @@
             <l>figli suoi, son della congiura i capi:</l>
             <l part="I">scritti son primi. Oh cielo!...</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -2884,54 +2909,54 @@
             <l>già in ceppi stanno; e a voi davanti, or ora,</l>
             <l part="I">trar li vedrete...</l>
           </sp>
-          <sp>
+          <sp who="#valerio">
             <speaker>
               <emph>Valerio</emph>
             </speaker>
             <l part="M">... Oimè! .. Seguon...</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="F">Chi segue?</l>
             <l part="I">Favella.</l>
           </sp>
-          <sp>
+          <sp who="#valerio">
             <speaker>
               <emph>Valerio</emph>
             </speaker>
             <l part="F">... Oimè!... Creder nol posso... Io leggo...</l>
             <l part="I">quattro nomi...</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="M">Quai son? su via...</l>
           </sp>
-          <sp>
+          <sp who="#valerio">
             <speaker>
               <emph>Valerio</emph>
             </speaker>
             <l part="M">Fratelli</l>
             <l part="M">della consorte eran di Bruto...</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="F">Oh cielo!</l>
             <l part="I">i Vitelli?</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
             <l part="F">Ah!... ben altri or or ne udrete.</l>
             <l>Ad uno ad uno, a voi davante, or ora...</l>
           </sp>
-          <sp>
+          <sp who="#valerio">
             <speaker>
               <emph>Valerio</emph>
             </speaker>
@@ -2941,13 +2966,13 @@
             <l>raccapricciar d'orror... Di mano... il foglio...</l>
             <l part="I">a tal vista... mi cade...</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="F">Oh! chi mai fieno?</l>
           </sp>
-          <sp>
+          <sp who="#valerio">
             <speaker>
               <emph>Valerio</emph>
             </speaker>
@@ -2956,21 +2981,21 @@
           <stage rend="align: center">
             <emph>Silenzio universale</emph>
           </stage>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l part="F">— I nomi</l>
             <l>ultimi inscritti, eran Tiberio e Tito.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l>I figli tuoi?... Misero padre! Oh giorno</l>
             <l part="I">infausto!...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2981,7 +3006,7 @@
             <l>ieri giurai; presto a ciò far son oggi:</l>
             <l part="I">e ad ogni costo...</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
@@ -2990,7 +3015,7 @@
           <stage rend="align: center">
             <emph>Silenzio universale</emph>
           </stage>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -3022,7 +3047,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>BRUTO <emph>e</emph> COLLATINO <emph>in ringhiera</emph> VALERIO, POPOLO, <emph>Senatori</emph>, <emph>Patrizi</emph>. <emph>I Congiurati tutti in catene fra Littori; ultimi d'essi</emph> TITO <emph>e</emph> TIBERIO</stage>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
@@ -3030,14 +3055,14 @@
             <l>quanti mai fieno i traditori?... Oh cielo!</l>
             <l part="I">Ecco i figli di Bruto.</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
             <l part="F">Oimè!... non posso</l>
             <l part="I">rattener più mie lagrime...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -3055,7 +3080,7 @@
           <stage rend="align: center">
             <emph>Silenzio universale</emph>
           </stage>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -3067,7 +3092,7 @@
           <stage rend="align: center">
             <emph>Silenzio universale</emph>
           </stage>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -3075,28 +3100,28 @@
             <l>piange il collega mio?... tace il senato?...</l>
             <l part="I">Il popol tace?</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="F">Oh fatal punto!... Eppure,</l>
             <l>e necessaria è la lor morte, e giusta.</l>
           </sp>
-          <sp>
+          <sp who="#tito">
             <speaker>
               <emph>Tito</emph>
             </speaker>
             <l>Sol, fra noi tutti, uno innocente or muore:</l>
             <l part="I">ed è questi.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="F">Oh pietà! Del fratel suo,</l>
             <l part="I">mirate, ei parla.</l>
           </sp>
-          <sp>
+          <sp who="#tiberio">
             <speaker>
               <emph>Tiberio</emph>
             </speaker>
@@ -3104,7 +3129,7 @@
             <l>siam del pari innocenti, o rei del pari:</l>
             <l>scritto è nel foglio, appo il suo nome, il mio.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -3121,7 +3146,7 @@
             <l>leggi soggiace, al giudicar, non d'altro</l>
             <l>mai si preval, che della ignuda legge.</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
@@ -3134,7 +3159,7 @@
             <l>quindi aggiunsero anch'essi, (il credereste?)</l>
             <l part="I">sol per sottrar da morte il padre...</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
@@ -3142,7 +3167,7 @@
             <l>E fia vero? Salvar dobbiam noi dunque</l>
             <l part="I">questi duo soli...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -3182,14 +3207,14 @@
             <l>non ho...<note resp="#aut" place="foot" anchored="true">Bruto cade seduto, e rivolge gli occhi dallo spettacolo.</note> Deh! Collatino, è questo il tempo</l>
             <l>di tua pietà: per me tu il resto adempi.<note resp="#aut" place="foot" anchored="true">Collatino fa disporre in ordine e legare i congiurati ai pali.</note></l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l>Oh fera vista!... Rimirar non gli osa,</l>
             <l>misero! il padre... Eppur, lor morte è giusta.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -3202,26 +3227,26 @@
             <l>Ma voi, fissate in lor lo sguardo: eterna,</l>
             <l>libera sorge or da quel sangue Roma.</l>
           </sp>
-          <sp>
+          <sp who="#collatino">
             <speaker>
               <emph>Collatino</emph>
             </speaker>
             <l part="I">Oh sovrumana forza!...</l>
           </sp>
-          <sp>
+          <sp who="#valerio">
             <speaker>
               <emph>Valerio</emph>
             </speaker>
             <l part="F">Il padre, il Dio</l>
             <l part="I">di Roma, è Bruto...</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="M">È il Dio di Roma...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>

--- a/tei/alfieri-bruto-secondo.xml
+++ b/tei/alfieri-bruto-secondo.xml
@@ -82,6 +82,37 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="cesare">
+            <persName>Cesare</persName>
+          </person>
+          <person xml:id="cimbro">
+            <persName>Cimbro</persName>
+          </person>
+          <person xml:id="antonio">
+            <persName>Antonio</persName>
+          </person>
+          <person xml:id="cassio">
+            <persName>Cassio</persName>
+          </person>
+          <person xml:id="cicerone">
+            <persName>Cicerone</persName>
+          </person>
+          <person xml:id="bruto">
+            <persName>Bruto</persName>
+          </person>
+          <personGrp xml:id="alcuni_senatori">
+            <name>Alcuni Senatori</name>
+          </personGrp>
+          <personGrp xml:id="altri_senatori">
+            <name>Altri Senatori</name>
+          </personGrp>
+          <personGrp xml:id="popolo">
+            <name>Popolo</name>
+          </personGrp>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione - OCR</change>
@@ -153,7 +184,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
         <div type="scene">
           <head>SCENA I</head>
           <stage>CESARE, ANTONIO, CICERONE, BRUTO, CASSIO, CIMBRO <emph>Senatori</emph>. <emph>Tutti seduti</emph></stage>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
@@ -208,7 +239,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>quell'unanime assenso, al cui rimbombo</l>
             <l>sperso fia tosto ogni nemico, o spento.</l>
           </sp>
-          <sp>
+          <sp who="#cimbro">
             <speaker>
               <emph>Cimbro</emph>
             </speaker>
@@ -242,7 +273,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>tornar si debba; e pria rifarsi Roma,</l>
             <l>poi vendicarla. Il che ai Romani è lieve.</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <emph>Antonio</emph>
             </speaker>
@@ -294,7 +325,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>picciola causa, la comun grandezza</l>
             <l>e securtà posporre, invido, ardisce.</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
@@ -335,7 +366,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>a far gli ultimi sforzi; or che i suoi tanti</l>
             <l>nemici fan gli ultimi lor contr'essa.</l>
           </sp>
-          <sp>
+          <sp who="#cicerone">
             <speaker>
               <emph>Cicerone</emph>
             </speaker>
@@ -392,7 +423,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>Parti, e quanti altri abbia nemici estrani,</l>
             <l>spariscon tutti, come nebbia al vento.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -455,14 +486,14 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>esser già fatto a noi signor, non io</l>
             <l>suddito a te per anco esser mi estimo.</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <emph>Antonio</emph>
             </speaker>
             <l>Del temerario tuo parlar la pena,</l>
             <l part="I">in breve, io 'l giuro...</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
@@ -494,14 +525,14 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
         <div type="scene">
           <head>SCENA I</head>
           <stage>CICERONE, CIMBRO</stage>
-          <sp>
+          <sp who="#cicerone">
             <speaker>
               <emph>Cicerone</emph>
             </speaker>
             <l>Securo asilo, ove di Roma i casi</l>
             <l part="I">trattar, non resta, altro che questo...</l>
           </sp>
-          <sp>
+          <sp who="#cimbro">
             <speaker>
               <emph>Cimbro</emph>
             </speaker>
@@ -513,7 +544,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>corre (ahi pur troppo!) il suo periglio estremo</l>
             <l part="I">la patria nostra.</l>
           </sp>
-          <sp>
+          <sp who="#cicerone">
             <speaker>
               <emph>Cicerone</emph>
             </speaker>
@@ -540,7 +571,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>da quanto stiam noi per risolver, pende</l>
             <l part="I">il destino di Roma.</l>
           </sp>
-          <sp>
+          <sp who="#cimbro">
             <speaker>
               <emph>Cimbro</emph>
             </speaker>
@@ -551,20 +582,20 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
         <div type="scene">
           <head>SCENA II</head>
           <stage>CASSIO, CICERONE, CIMBRO</stage>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
             <l part="F">Tardo venn'io? Ma pure,</l>
             <l part="I">non v'è per anco Bruto.</l>
           </sp>
-          <sp>
+          <sp who="#cimbro">
             <speaker>
               <emph>Cimbro</emph>
             </speaker>
             <l part="F">In breve, ei giunge.</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
@@ -580,7 +611,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>puossi unir mai, meglio temprato, ed atto</l>
             <l>quindi a meglio adoprarsi a pro di Roma?</l>
           </sp>
-          <sp>
+          <sp who="#cicerone">
             <speaker>
               <emph>Cicerone</emph>
             </speaker>
@@ -597,7 +628,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>a cui, se estinta infra suoi ceppi or cade,</l>
             <l>né sopravviver pur d'un giorno, io giuro.</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
@@ -608,7 +639,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>son tutti omai; né intenderebber pure</l>
             <l part="I">sublimi tuoi sensi...</l>
           </sp>
-          <sp>
+          <sp who="#cicerone">
             <speaker>
               <emph>Cicerone</emph>
             </speaker>
@@ -650,7 +681,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>che romani per breve almen li torni.</l>
             <l>Svelato appien, Cesare vinto è appieno.</l>
           </sp>
-          <sp>
+          <sp who="#cimbro">
             <speaker>
               <emph>Cimbro</emph>
             </speaker>
@@ -687,7 +718,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>tutti ardiran tiranno empio nomarlo,</l>
             <l part="I">e come tal proscriverlo.</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
@@ -726,27 +757,27 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
         <div type="scene">
           <head>SCENA III</head>
           <stage>BRUTO, CICERONE, CASSIO, CIMBRO</stage>
-          <sp>
+          <sp who="#cicerone">
             <speaker>
               <emph>Cicerone</emph>
             </speaker>
             <l>Sì tardo giunge a cotant'alto affare</l>
             <l part="I">Bruto?...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l part="F">Ah! primiero io vi giungea, se tolto</l>
             <l part="I">finor non m'era...</l>
           </sp>
-          <sp>
+          <sp who="#cimbro">
             <speaker>
               <emph>Cimbro</emph>
             </speaker>
             <l part="M">E da chi mai?</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -754,13 +785,13 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>nullo il potria di voi. Parlarmi a lungo</l>
             <l part="I">volle Antonio finora.</l>
           </sp>
-          <sp>
+          <sp who="#cicerone">
             <speaker>
               <emph>Cicerone</emph>
             </speaker>
             <l part="M">Antonio?</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
@@ -768,7 +799,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>satellite di Cesare otteneva</l>
             <l part="I">udienza da Bruto?</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -777,14 +808,14 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>vuol meco, ad ogni patto: a lui venirne</l>
             <l part="I">m'offre, s'io il voglio; o ch'egli a me...</l>
           </sp>
-          <sp>
+          <sp who="#cimbro">
             <speaker>
               <emph>Cimbro</emph>
             </speaker>
             <l part="F">Certo, ebbe</l>
             <l part="I">da te ripulsa...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -793,33 +824,33 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>che Cesare nemico. Udirlo io quindi</l>
             <l>voglio, e fra breve, e in questo tempio stesso.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l part="I">Ma, che mai vuol da te?</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
             <l part="F">Comprarmi; forse.</l>
             <l>Ma in Bruto ancor, voi vi affidate, io spero.</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
             <l part="I">Più che in noi stessi.</l>
           </sp>
-          <sp>
+          <sp who="#cimbro">
             <speaker>
               <emph>Cimbro</emph>
             </speaker>
             <l part="F">Affidan tutti in Bruto;</l>
             <l part="I">anco i più vili.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -831,21 +862,21 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>a ciò che vuol Roma da me. Nol sono;</l>
             <l part="I">ed ogni spron mi è vano.</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
             <l part="F">Ma, che speri</l>
             <l part="I">dal favellar con Cesare?...</l>
           </sp>
-          <sp>
+          <sp who="#cicerone">
             <speaker>
               <emph>Cicerone</emph>
             </speaker>
             <l part="F">Cangiarlo</l>
             <l part="I">tu speri forse...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -853,7 +884,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>del magnanimo Tullio, al mio disegno</l>
             <l part="I">si apponga in parte.</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
@@ -868,7 +899,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>svenar Cesare in Roma; or di', qual fora</l>
             <l part="I">il partito di Bruto?</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -876,14 +907,14 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>per or, di questi. Ove fia vano poscia</l>
             <l part="I">il mio, scerrò pur sempre il terzo.</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
             <l part="F">Il tuo?</l>
             <l part="I">E qual altro ne resta?</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -904,14 +935,14 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>d'esser tiranni. A lui succeder vonno;</l>
             <l part="I">lo abborriscon perciò.</l>
           </sp>
-          <sp>
+          <sp who="#cicerone">
             <speaker>
               <emph>Cicerone</emph>
             </speaker>
             <l part="F">Così non fosse</l>
             <l part="I">come vero è, pur troppo!</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -925,7 +956,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>a sua rovina, e innalzar sé sovr'esso.</l>
             <l part="I">Tali amici ha il tiranno.</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
@@ -933,7 +964,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>la iniqua brama di regnar sempr'ebbe</l>
             <l part="I">Cesare...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -951,14 +982,14 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>d'ir contra i Parti, e abbandonar pur Roma,</l>
             <l part="I">ove tanti ha nemici?</l>
           </sp>
-          <sp>
+          <sp who="#cimbro">
             <speaker>
               <emph>Cimbro</emph>
             </speaker>
             <l part="F">Ei mercar spera</l>
             <l>con l'alloro dei Parti il regio serto.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -966,14 +997,14 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>del regio serto esser tenuto: ei dunque</l>
             <l part="I">ambizioso è più che reo...</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
             <l part="F">Sue laudi</l>
             <l part="I">a noi tu intessi?...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -996,7 +1027,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>è il mio vivere a Bruto; ma saprolla</l>
             <l>io scancellar, senza esser vil, né ingrato.</l>
           </sp>
-          <sp>
+          <sp who="#cicerone">
             <speaker>
               <emph>Cicerone</emph>
             </speaker>
@@ -1008,7 +1039,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>per grazia espressa, e vieppiù espresso errore,</l>
             <l part="I">non ricevea da Silla?</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -1049,7 +1080,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>ecco il pugnal, ch'a uccider lui fia ratto,</l>
             <l part="I">più che il tuo brando...</l>
           </sp>
-          <sp>
+          <sp who="#cicerone">
             <speaker>
               <emph>Cicerone</emph>
             </speaker>
@@ -1057,7 +1088,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>Grande sei troppo tu; mal da te stesso</l>
             <l>tu puoi conoscer Cesare tiranno.</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
@@ -1066,7 +1097,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>tentarla puoi. Non io mi oppongo: ah! trarti</l>
             <l>d'inganno appien, Cesare solo il puote.</l>
           </sp>
-          <sp>
+          <sp who="#cimbro">
             <speaker>
               <emph>Cimbro</emph>
             </speaker>
@@ -1074,7 +1105,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>questa tua speme generosa, è prova</l>
             <l>ch'esser tu mai tiranno non potresti.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -1091,7 +1122,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
         <div type="scene">
           <head>SCENA I</head>
           <stage>CESARE, ANTONIO</stage>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <emph>Antonio</emph>
             </speaker>
@@ -1101,7 +1132,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>e tollerarli. Il riudrai fra breve</l>
             <l part="I">da solo a sol, poiché tu il vuoi.</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
@@ -1111,7 +1142,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>né ad altri mai, fuorché ad Antonio, darne</l>
             <l part="I">osato avrei lo incarco.</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <emph>Antonio</emph>
             </speaker>
@@ -1124,7 +1155,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>che mortal tuo nemico a certa prova</l>
             <l>esser conosco, e come tale abborro.</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
@@ -1132,7 +1163,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>nemico io conto, che di me sia degno:</l>
             <l part="I">e Bruto egli è.</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <emph>Antonio</emph>
             </speaker>
@@ -1140,7 +1171,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>ma Bruto prima, e i Cassi, e i Cimbri poscia,</l>
             <l>e i Tulli, e tanti uccider densi, e tanti.</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
@@ -1155,7 +1186,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>contro a degno nemico è la vendetta</l>
             <l part="I">la più illustre; e la mia.</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <emph>Antonio</emph>
             </speaker>
@@ -1170,21 +1201,21 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>che non la vera della patria; e poco</l>
             <l>mostri curar la securtà di entrambi.</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
             <l>E atterrir tu con vil sospetto forse</l>
             <l part="I">Cesare vuoi?</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <emph>Antonio</emph>
             </speaker>
             <l part="F">Se non per sé, per Roma</l>
             <l>tremar ben può Cesare anch'egli, e il debbe.</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
@@ -1210,13 +1241,13 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>Bruto all'impresa, in cui riposta a un tempo</l>
             <l>fia la gloria di Cesare e di Roma.</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <emph>Antonio</emph>
             </speaker>
             <l part="I">Puoi tu accrescerti fama?</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
@@ -1233,14 +1264,14 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>benché a frenarla sia tal mezzo il certo.</l>
             <l part="I">Bruto può sol tutto appianarmi...</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <emph>Antonio</emph>
             </speaker>
             <l part="F">E un nulla</l>
             <l part="I">reputi Antonio dunque?</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
@@ -1250,7 +1281,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>al fianco mio. Giovarmi in altra guisa</l>
             <l part="I">di Bruto io penso.</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <emph>Antonio</emph>
             </speaker>
@@ -1258,7 +1289,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>sono a servirti; e il sai. Ma, cieco troppo</l>
             <l part="I">sei, quanto a Bruto.</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
@@ -1267,20 +1298,20 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>che il potrò tor d'inganno: oggi mi è forza</l>
             <l part="I">ciò almen tentare...</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <emph>Antonio</emph>
             </speaker>
             <l part="M">Eccolo appunto.</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
             <l part="F">Or, seco</l>
             <l part="I">lasciami; in breve a te verronne.</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <emph>Antonio</emph>
             </speaker>
@@ -1292,7 +1323,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
         <div type="scene">
           <head>SCENA II</head>
           <stage>BRUTO, CESARE</stage>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -1308,7 +1339,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>ed io pure alte cose a dirti vengo,</l>
             <l part="I">se ascoltarle tu ardisci.</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
@@ -1327,7 +1358,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>Qui non udrai, né il dittator di Roma,</l>
             <l part="I">né il vincitor del gran Pompeo...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -1339,7 +1370,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>ed i rimorsi e il perpetuo terrore,</l>
             <l part="I">di un dittator perpetuo!</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
@@ -1347,7 +1378,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>Non che al mio cor, non è parola questa,</l>
             <l part="I">nota pure al mio orecchio.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -1371,7 +1402,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>unica omai; né il sai tu stesso forse;</l>
             <l part="I">o di saperlo sfuggi.</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
@@ -1379,7 +1410,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>di Farsaglia nei campi a te la vita,</l>
             <l part="I">forse in mia man non stette?</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -1391,7 +1422,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>che tu, freddo pacifico tiranno</l>
             <l part="I">mai non nascesti, io te l'affermo...</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
@@ -1400,7 +1431,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>T'amo; ti estimo: io vorrei solo al mondo</l>
             <l>esser Bruto, s'io Cesare non fossi.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -1461,7 +1492,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>se togli, in somma, che in eterno in Roma</l>
             <l>nullo Cesare mai, né Silla, rieda.</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
@@ -1496,7 +1527,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>Io, qual padre, ti parlo;... e, più che figlio,</l>
             <l part="I">o Bruto mio, mi sei.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -1507,7 +1538,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>di Roma già, quasi d'un tuo paterno</l>
             <l part="I">retaggio?...</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
@@ -1515,7 +1546,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>nasconder cosa, che a te nota, or debbe</l>
             <l part="I">cangiarti affatto in favor mio.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -1523,21 +1554,21 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>puoi, se ti cangi; e se te stesso vinci;</l>
             <l part="I">trionfo sol, che a te rimanga...</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
             <l part="F">Udito</l>
             <l part="I">che avrai l'arcano, altro sarai.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l part="F">Romano</l>
             <l part="I">sarò pur sempre. Ma, favella.</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
@@ -1547,7 +1578,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>di', non ti par che un smisurato affetto</l>
             <l part="I">per te mi muova e mi trasporti?</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -1557,14 +1588,14 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>creder nol posso; e schietto, attribuirlo</l>
             <l part="I">a che non so.</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
             <l part="F">... Ma tu, per me quai senti</l>
             <l part="I">moti entro al petto?</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -1576,7 +1607,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>m'inspiri amor di maraviglia misto.</l>
             <l part="I">Qual vuoi dei due da Bruto?</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
@@ -1584,39 +1615,39 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>e a me tu il dei... Sacro, infrangibil nodo</l>
             <l part="I">a me ti allaccia.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l part="M">A te? qual fia?...</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
             <l part="F">Tu nasci</l>
             <l part="I">vero mio figlio.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l part="M">Oh ciel! che ascolto?...</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
             <l part="F">Ah! vieni,</l>
             <l part="I">figlio, al mio seno...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l part="M">Esser potria?...</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
@@ -1626,7 +1657,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>in Farsaglia, poche ore anzi alla pugna.</l>
             <l>Mira; a te nota è la sua mano: ah! leggi.</l>
           </sp>
-          <sp>
+          <sp who="#brutolegge il foglio">
             <speaker>
               <emph>Bruto<note resp="#aut" place="foot" anchored="true">Legge il foglio</note></emph>
             </speaker>
@@ -1644,14 +1675,14 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>Servilia.» — Oh colpo inaspettato e fero!</l>
             <l part="I">Io di Cesare figlio?</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
             <l part="F">Ah! sì, tu il sei.</l>
             <l part="I">Deh! fra mie braccia vieni.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -1661,7 +1692,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>né sorgerà, se in te di Roma a un tempo</l>
             <l part="I">ei non abbraccia il padre.</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
@@ -1670,7 +1701,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>rinserri il cor, che alcun privato affetto</l>
             <l part="I">nulla in te possa?</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -1693,7 +1724,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>per bocca mia le voci; e Bruto, e Roma,</l>
             <l part="I">per te sien uno.</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
@@ -1705,7 +1736,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>altri terralla, ove tenerla nieghi</l>
             <l part="I">Bruto di man di Cesare...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -1716,33 +1747,33 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>vil nascimento, era pietà più espressa</l>
             <l part="I">me trucidar, tu, di tua mano...</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
             <l part="F">Oh figlio!...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l part="I">Cedi, o Cesare...</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
             <l part="F">Ingrato, ... snaturato...</l>
             <l part="I">che far vuoi dunque?</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l part="F">O salvar Roma io voglio,</l>
             <l part="I">o perir seco.</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
@@ -1756,7 +1787,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>meco divider tutto; al dì novello,</l>
             <l part="I">signor mi avrai.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -1773,7 +1804,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>Qual gioia allor, quanta dolcezza, e quanto</l>
             <l part="I">orgoglio avrò d'esserti figlio!...</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
@@ -1781,7 +1812,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>qual ch'io mi sia: né mai contro al tuo padre</l>
             <l part="I">volger ti puoi, senza esser empio...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -1796,7 +1827,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
         <div type="scene">
           <head>SCENA III</head>
           <stage>CESARE</stage>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
@@ -1811,7 +1842,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
         <div type="scene">
           <head>SCENA I</head>
           <stage>CASSIO, CIMBRO</stage>
-          <sp>
+          <sp who="#cimbro">
             <speaker>
               <emph>Cimbro</emph>
             </speaker>
@@ -1821,7 +1852,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>ver le sue case. Oh! potrebbe egli mai</l>
             <l part="I">cangiarsi?...</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
@@ -1832,13 +1863,13 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>d'alto cor nasce; ei della patria sola</l>
             <l part="I">l'util pondera, e vede.</l>
           </sp>
-          <sp>
+          <sp who="#cimbro">
             <speaker>
               <emph>Cimbro</emph>
             </speaker>
             <l part="F">Eccolo appunto.</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
@@ -1848,25 +1879,25 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
         <div type="scene">
           <head>SCENA II</head>
           <stage>BRUTO, CASSIO, CIMBRO</stage>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l part="F">Che fia? voi soli trovo?</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
             <l>E siam noi pochi, ove tu a noi ti aggiungi?</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l part="I">Tullio manca...</l>
           </sp>
-          <sp>
+          <sp who="#cimbro">
             <speaker>
               <emph>Cimbro</emph>
             </speaker>
@@ -1874,14 +1905,14 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>ei con molti altri senatori usciva</l>
             <l part="I">di Roma or dianzi.</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
             <l part="F">Il gel degli anni in lui</l>
             <l>l'ardir suo prisco, e la virtude agghiaccia...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -1890,7 +1921,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>che a miglior uopo, a pro di Roma, ei serba</l>
             <l part="I">e libertade e vita.</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
@@ -1900,7 +1931,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>liberi; o certi, di perir con Roma,</l>
             <l part="I">nel fior degli anni.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -1908,20 +1939,20 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>Nol son io, no; cui riman scelta orrenda</l>
             <l>fra il morir snaturato, o il viver servo.</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
             <l part="I">Che dir vuoi tu?</l>
           </sp>
-          <sp>
+          <sp who="#cimbro">
             <speaker>
               <emph>Cimbro</emph>
             </speaker>
             <l part="F">Dal favellar tuo lungo</l>
             <l part="I">col dittator, che ne traesti?</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -1930,32 +1961,32 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>per me; stupor per voi, misto fors'anco</l>
             <l part="I">di un giusto sprezzo.</l>
           </sp>
-          <sp>
+          <sp who="#cimbro">
             <speaker>
               <emph>Cimbro</emph>
             </speaker>
             <l part="M">E per chi mai?</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l part="F">Per Bruto.</l>
           </sp>
-          <sp>
+          <sp who="#cimbro">
             <speaker>
               <emph>Cimbro</emph>
             </speaker>
             <l part="I">Spregiarti noi?</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
             <l part="F">Tu, che di Roma sei,</l>
             <l part="I">e di noi, l'alma?...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -1964,13 +1995,13 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>del divin Cato il genero, e il nipote;...</l>
             <l>e del tiranno Cesare io son figlio.</l>
           </sp>
-          <sp>
+          <sp who="#cimbro">
             <speaker>
               <emph>Cimbro</emph>
             </speaker>
             <l part="I">Che ascolto? Esser potrebbe?...</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
@@ -1978,7 +2009,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>che il più fero nemico del tiranno</l>
             <l>non sia Bruto pur sempre: ah! Cassio il giura.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -1986,21 +2017,21 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>nel mio sangue; a lavarla, io tutto il deggio</l>
             <l part="I">versar per Roma.</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
             <l part="F">O Bruto, di te stesso</l>
             <l part="I">figlio esser dei.</l>
           </sp>
-          <sp>
+          <sp who="#cimbro">
             <speaker>
               <emph>Cimbro</emph>
             </speaker>
             <l part="F">Ma pur, quai prove addusse</l>
             <l part="I">Cesare a te? Come a lui fede?...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2023,7 +2054,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>ella scongiura Cesare a non farsi</l>
             <l part="I">trucidator del proprio figlio.</l>
           </sp>
-          <sp>
+          <sp who="#cimbro">
             <speaker>
               <emph>Cimbro</emph>
             </speaker>
@@ -2031,7 +2062,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>funesto arcano! entro all'eterna notte</l>
             <l part="I">che non restasti?...</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
@@ -2043,7 +2074,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>ne riportasti omai, che nulla al mondo</l>
             <l>Cesare può dal vil suo fango trarre.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2054,14 +2085,14 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>stima il sommo poter; quindi ei s'ostina</l>
             <l part="I">a voler regno, o morte.</l>
           </sp>
-          <sp>
+          <sp who="#cimbro">
             <speaker>
               <emph>Cimbro</emph>
             </speaker>
             <l part="F">E morte egli abbia</l>
             <l part="I">tal mostro dunque.</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
@@ -2069,13 +2100,13 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>tiranno egli è. Pensa omai dunque, o Bruto,</l>
             <l>che un cittadin di Roma non ha padre...</l>
           </sp>
-          <sp>
+          <sp who="#cimbro">
             <speaker>
               <emph>Cimbro</emph>
             </speaker>
             <l>E che un tiranno non ha figli mai...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2105,21 +2136,21 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>Porzia di Cato figlia, a Cato pari,</l>
             <l part="I">moglie alberga di Bruto...</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
             <l part="F">E d'ambo degna</l>
             <l part="I">è la gran donna.</l>
           </sp>
-          <sp>
+          <sp who="#cimbro">
             <speaker>
               <emph>Cimbro</emph>
             </speaker>
             <l part="F">Ah! così stata il fosse</l>
             <l part="I">anco Servilia!</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2143,20 +2174,20 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>fammi e d'udire, e di tacer, gli arcani</l>
             <l part="I">di Bruto mio».</l>
           </sp>
-          <sp>
+          <sp who="#cimbro">
             <speaker>
               <emph>Cimbro</emph>
             </speaker>
             <l part="M">Qual donna!</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
             <l part="F">A lei qual puossi</l>
             <l part="I">uom pareggiare?</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2182,7 +2213,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>il disperato dolor mio torrammi</l>
             <l>poscia, pur troppo! e per sempre, a me stesso.</l>
           </sp>
-          <sp>
+          <sp who="#cimbro">
             <speaker>
               <emph>Cimbro</emph>
             </speaker>
@@ -2191,7 +2222,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>ferocia in noi stupida fora... Oh Bruto!...</l>
             <l>Il tuo parlar strappa a me pure il pianto.</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
@@ -2201,7 +2232,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>o, se pur parlan, l'ascoltargli a ogni uomo,</l>
             <l part="I">fuor che a Bruto, si dona.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2216,21 +2247,21 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>chieggo da voi, fuor che aspettiate il cenno</l>
             <l part="I">da me soltanto.</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
             <l part="F">Ah! dei Romani il primo</l>
             <l part="I">davver sei tu. — Ma, chi mai vien?...</l>
           </sp>
-          <sp>
+          <sp who="#cimbro">
             <speaker>
               <emph>Cimbro</emph>
             </speaker>
             <l part="F">Che veggio?</l>
             <l part="I">Antonio!</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2241,41 +2272,41 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
         <div type="scene">
           <head>SCENA III</head>
           <stage>ANTONIO, CASSIO, BRUTO, CIMBRO</stage>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <emph>Antonio</emph>
             </speaker>
             <l part="F">In traccia, o Bruto, io vengo</l>
             <l part="I">di te: parlar teco degg'io.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l part="F">Favella:</l>
             <l part="I">io t'ascolto.</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <emph>Antonio</emph>
             </speaker>
             <l part="F">Ma, dato emmi l'incarco</l>
             <l part="I">dal dittatore...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l part="M">E sia ciò pure.</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <emph>Antonio</emph>
             </speaker>
             <l part="F">Io debbo</l>
             <l part="I">favellare a te solo.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2288,14 +2319,14 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>Cesare mai, che nol ridica ei tosto</l>
             <l part="I">a Cassio, e a Cimbro.</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <emph>Antonio</emph>
             </speaker>
             <l part="F">Hai tu comun con essi</l>
             <l part="I">anco il padre?</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2313,7 +2344,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>le sue per me vere paterne mire;</l>
             <l>ch'io benedica il dì, che di lui nacqui.</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <emph>Antonio</emph>
             </speaker>
@@ -2323,14 +2354,14 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>pur vuol, che arrender ti potresti al grido</l>
             <l part="I">possente e sacro di natura.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l part="F">E in quale</l>
             <l>guisa arrendermi debbo? a che piegarmi?...</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <emph>Antonio</emph>
             </speaker>
@@ -2342,7 +2373,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>a mertar quei, ch'egli a te nuovi appresta. —</l>
             <l>Troppo esser temi uman, se a ciò ti pieghi?</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2359,13 +2390,13 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>Questi son, questi, i benefizi espressi,</l>
             <l>cui far può a Bruto il genitor suo vero.</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <emph>Antonio</emph>
             </speaker>
             <l part="I">Sta bene. — Altro hai che dirmi?</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2384,14 +2415,14 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>come di far rivivere per essa</l>
             <l part="I">Cesare...</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <emph>Antonio</emph>
             </speaker>
             <l part="F">Intendo. — A lui dirò quant'io,</l>
             <l>(pur troppo invan!) gran tempo è già, gli dissi.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2399,7 +2430,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>infra Cesare e Bruto: ma, s'ei pure</l>
             <l>a ciò te scelse, a te risposta io diedi.</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <emph>Antonio</emph>
             </speaker>
@@ -2411,26 +2442,26 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
         <div type="scene">
           <head>SCENA IV</head>
           <stage>BRUTO, CASSIO, CIMBRO</stage>
-          <sp>
+          <sp who="#cimbro">
             <speaker>
               <emph>Cimbro</emph>
             </speaker>
             <l part="I">Udiste?...</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
             <l part="F">Oh Bruto!... il Dio tu sei di Roma.</l>
           </sp>
-          <sp>
+          <sp who="#cimbro">
             <speaker>
               <emph>Cimbro</emph>
             </speaker>
             <l>Questo arrogante iniquo schiavo, anch'egli</l>
             <l part="I">punir si debbe...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2440,7 +2471,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>io di dar cenno, e di aspettarlo voi:</l>
             <l part="I">v'affiderete in me?</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
@@ -2449,7 +2480,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>che noi scegliemmo; e che a morir per Roma</l>
             <l part="I">doman con noi si apprestano.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2465,28 +2496,28 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <emph>La scena è nella curia di Pompeo</emph>
           </stage>
           <stage>BRUTO, CASSIO, <emph>Senatori</emph>, <emph>che si vanno collocando ai lor luoghi</emph></stage>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
             <l>Scarsa esser vuol questa adunanza, parmi;</l>
             <l part="I">minor dell'altra assai...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l part="F">Pur che minore</l>
             <l>non sia il cor di chi resta; a noi ciò basta.</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
             <l>Odi tu, Bruto, la inquieta plebe,</l>
             <l>come già di sue grida assorda l'aure?</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2494,27 +2525,27 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>lasciala; anch'essa in questo dì giovarne</l>
             <l part="I">forse potrà.</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
             <l part="F">Mai non ti vidi io tanto</l>
             <l part="I">securo, e in calma.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l part="M">Arde il periglio.</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
             <l part="F">Oh Bruto!...</l>
             <l part="I">Bruto, a te solo io cedo.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2523,34 +2554,34 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>par ch'or presieda, omai securo fammi,</l>
             <l part="I">quanto il vicin periglio.</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
             <l part="F">Ecco, appressarsi</l>
             <l part="I">del tiranno i littori.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l part="F">E Casca, e Cimbro?...</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
             <l>Feri scelto hanno il primo loco, a forza:</l>
             <l part="I">sieguon dappresso Cesare.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l part="F">Pensasti</l>
             <l part="I">ad impedir che l'empio Antonio?...</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
@@ -2559,7 +2590,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>Fulvio e Macrin; s'anco impedirlo è d'uopo,</l>
             <l part="I">con la forza il faranno.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2571,7 +2602,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>sforzi di un figlio; ma vedrai tu poscia</l>
             <l part="I">di un cittadin gli ultimi sforzi.</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
@@ -2582,7 +2613,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
         <div type="scene">
           <head>SCENA II</head>
           <stage>SENATORI <emph>seduti</emph>. BRUTO <emph>e</emph> CASSIO <emph>ai lor luoghi</emph>. CESARE, <emph>preceduto dai littori</emph>, <emph>che poscia lo lasciano</emph>; CASCA, CIMBRO, <emph>e molti altri</emph>, <emph>lo seguono</emph>. <emph>Tutti sorgono all'entrar di Cesare</emph>, <emph>finch'egli seduto non sia</emph></stage>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
@@ -2596,7 +2627,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
           <stage rend="align: center">
             <emph>Silenzio universale</emph>
           </stage>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2607,7 +2638,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>il terror gli adunò; quei che non vedi,</l>
             <l part="I">gli ha dispersi il terrore.</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
@@ -2617,7 +2648,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>generosa di Cesare. — Ma invano;</l>
             <l part="I">che ad altercar qui non venn'io...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2646,13 +2677,13 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>infra gli uomini tutti al mondo stati,</l>
             <l>mai non ebbe, né avrà. Cesare il pari.</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
             <l part="I">Troncar potrei. Bruto, il tuo dir...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2669,7 +2700,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
           <stage rend="align: center">
             <emph>Grido universale di stupore</emph>
           </stage>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2681,7 +2712,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
           <stage rend="align: center">
             <emph>Grido universale di gioia</emph>
           </stage>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
@@ -2697,7 +2728,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>mia possanza lasciar, disegno; in esso</l>
             <l>fondata io l'ho: Cesare avrete in lui...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2713,7 +2744,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
           <stage rend="align: center">
             <emph>Grido universale di gioia</emph>
           </stage>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
@@ -2737,7 +2768,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
           <stage rend="align: center">
             <emph>Silenzio universale</emph>
           </stage>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2753,7 +2784,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>a' piedi tuoi. Di Bruto esser vuoi padre,</l>
             <l part="I">e non l'esser di Roma?</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
@@ -2769,7 +2800,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>è di Roma nemico; e lei rubello,</l>
             <l part="I">traditor empio egli è.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2777,63 +2808,63 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>da cittadini veri, omai noi tutti</l>
             <l part="I">obbediam dunque al dittatore.<note resp="#aut" place="foot" anchored="true">Bruto snuda, e brandisce il pugnale; i congiurati si avventano a Cesare coi ferri.</note></l>
           </sp>
-          <sp>
+          <sp who="#cimbro">
             <speaker>
               <emph>Cimbro</emph>
             </speaker>
             <l part="F">Muori,</l>
             <l part="I">tiranno, muori.</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
             <l part="F">E ch'io pur anco il fera.</l>
           </sp>
-          <sp>
+          <sp who="#cesare">
             <speaker>
               <emph>Cesare</emph>
             </speaker>
             <l part="I">Traditori...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l part="F">E ch'io sol ferir nol possa?...</l>
           </sp>
-          <sp>
+          <sp who="#alcuni_senatori">
             <speaker>
               <emph>Alcuni Senatori</emph>
             </speaker>
             <l part="I">Muoia, muoia, il tiranno.</l>
           </sp>
-          <sp>
+          <sp who="#altri_senatori">
             <speaker>
               <emph>Altri Senatori</emph>
             </speaker>
             <l part="F">Oh vista! oh giorno!</l>
           </sp>
-          <sp>
+          <sp who="#cesarecarco di ferite #trascinandosi fino alla statua di pompeo #dove #copertosi il volto col manto #egli spira">
             <speaker>
               <emph>Cesare<note resp="#aut" place="foot" anchored="true">Carco di ferite, trascinandosi fino alla statua di Pompeo, dove, copertosi il volto col manto, egli spira.</note></emph>
             </speaker>
             <l part="I">Figlio,... e tu pure?... Io moro...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l part="F">Oh padre!... Oh Roma!...</l>
           </sp>
-          <sp>
+          <sp who="#cimbro">
             <speaker>
               <emph>Cimbro</emph>
             </speaker>
             <l>Ma, dei fuggenti al grido, accorre in folla</l>
             <l part="I">il popol già...</l>
           </sp>
-          <sp>
+          <sp who="#cassio">
             <speaker>
               <emph>Cassio</emph>
             </speaker>
@@ -2845,7 +2876,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
         <div type="scene">
           <head>SCENA III</head>
           <stage>POPOLO, BRUTO, CESARE, <emph>morto</emph></stage>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
@@ -2853,7 +2884,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>qual sangue è questo? Oh! col pugnale in alto</l>
             <l part="I">Bruto immobile sta?</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2861,14 +2892,14 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>(se ancora il sei) là, là rivolgi or gli occhi:</l>
             <l>mira chi appiè del gran Pompeo sen giace...</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l>Cesare? oh vista! Ei nel suo sangue immerso?...</l>
             <l part="I">Oh rabbia!...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2877,13 +2908,13 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>di sangue in man voi mi vediate il ferro,</l>
             <l>io pur cogli altri, io pur, Cesare uccisi...</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="I">Ah traditor! tu pur morrai...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2891,13 +2922,13 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>sta dell'acciaro al petto mio la punta:</l>
             <l>morire io vo': ma, mi ascoltate pria.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l>Si uccida pria chi Cesare trafisse...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2913,13 +2944,13 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>a piena gioia aprite: è spento al fine,</l>
             <l part="I">è spento là, di Roma il re.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="F">Che parli?</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2950,13 +2981,13 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>Ma, chi uccidermi niega, omai seguirmi</l>
             <l>debbe, ed a forza terminar la impresa.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="I">Qual dir fia questo. Un Dio lo inspira...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2969,13 +3000,13 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>per disvelare a voi? — Vero mio padre</l>
             <l part="I">Cesare m'era...</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="F">Oh ciel! che mai ci narri?...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -2985,27 +3016,27 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>voleva un dì, quasi tranquillo e pieno</l>
             <l>proprio retaggio suo, Roma lasciarmi.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="I">Oh ria baldanza!...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l part="F">E le sue mire inique</l>
             <l>tutte a me quindi ei discoprire ardiva...</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l>Dunque (ah pur troppo!) ei disegnava al fine</l>
             <l part="I">vero tiranno appalesarsi...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -3022,13 +3053,13 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>a pochi e forti: ma in alto frattanto</l>
             <l>sospeso stava il tremante mio braccio...</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="I">Oh virtù prisca! oh vero Bruto!</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -3046,7 +3077,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>si aspetta all'empio parricida figlio</l>
             <l part="I">del gran Cesare poscia.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
@@ -3055,7 +3086,7 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>moti proviamo?... Oh vista! in pianto anch'egli,</l>
             <l part="I">tra il suo furor, Bruto si stempra?...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -3067,13 +3098,13 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>Ma, chi ardisce bramarlo omai pur vivo,</l>
             <l part="I">Roman non è.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="F">Fiamma è il tuo dire, o Bruto...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -3081,14 +3112,14 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>degna è di noi: seguitemi; si renda</l>
             <l>piena ed eterna or libertade a Roma.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l>Per Roma, ah! sì, su l'orme tue siam presti</l>
             <l part="I">a tutto, sì...</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
@@ -3097,21 +3128,21 @@ che frutti <emph>onore a chi da morte io desto</emph>;</p>
             <l>di libertade, sacro: in man lasciarlo</l>
             <l part="I">dei traditor vorreste?</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="F">Andiam: si tolga</l>
             <l part="I">la sacra rocca ai traditori.</l>
           </sp>
-          <sp>
+          <sp who="#bruto">
             <speaker>
               <emph>Bruto</emph>
             </speaker>
             <l part="F">A morte,</l>
             <l part="I">a morte andiam, o a libertade.<note resp="#aut" place="foot" anchored="true">Si muove Bruto, brandendo ferocemente la spada; il popolo tutto a furore lo segue.</note></l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>

--- a/tei/alfieri-don-garzia.xml
+++ b/tei/alfieri-don-garzia.xml
@@ -82,6 +82,25 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="cosimo">
+            <persName>Cosimo</persName>
+          </person>
+          <person xml:id="diego">
+            <persName>Diego</persName>
+          </person>
+          <person xml:id="piero">
+            <persName>Piero</persName>
+          </person>
+          <person xml:id="garzia">
+            <persName>Garzia</persName>
+          </person>
+          <person xml:id="eleonora">
+            <persName>Eleonora</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -125,7 +144,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>COSIMO, DIEGO, PIERO, GARZIA</stage>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -136,25 +155,25 @@
             <l>dir vero, e asconder sempre nel profondo</l>
             <l>del cor l'arcano, che a svelarvi imprendo.</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
             <l part="I">Per questa spada io 'l giuro.</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
             <l part="F">Ed io pel padre.</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="I">Sovra il mio onore io 'l giuro.</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -184,13 +203,13 @@
             <l>ma, nell'intimo cor, di rabbia pieno,</l>
             <l part="I">di rei disegni...</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
             <l part="M"> Ed è?</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -222,7 +241,7 @@
             <l>e il migliore e il più ratto a un tanto effetto,</l>
             <l>liberamente ognun di voi mi mostri.</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
@@ -258,7 +277,7 @@
             <l>timida nube i maestosi raggi</l>
             <l>del tuo potere illimitato adombri.</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -312,13 +331,13 @@
             <l>e a chi ti spiace, e alla tua fama, o padre,</l>
             <l part="I">deh! tu perdona.</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
             <l part="F">Ei da me ognor dissente.</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -353,7 +372,7 @@
             <l>di giusta pena; in un così s'ottiene</l>
             <l>di prence il frutto, e d'uman sire il nome.</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -372,7 +391,7 @@
             <l>come il mortal nemico mio si spenga,</l>
             <l>com'io deggia salvarlo a me tu insegni?</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
@@ -381,7 +400,7 @@
             <l>l'animo in sé non serra; e s'ei private</l>
             <l part="I">virtù professa, o finge...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -393,7 +412,7 @@
             <l>come tu il dici, all'obbedire, io voglio</l>
             <l>pur obbedir, ma a tal, che imperar sappia...</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -408,7 +427,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>DIEGO, PIERO, GARZIA</stage>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -419,7 +438,7 @@
             <l>correr dovrebbe; ma finor quest'arte</l>
             <l>la mia non è; né più l'apprendo omai.</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
@@ -427,7 +446,7 @@
             <l>tra i propri figli alto un censore ei trova,</l>
             <l part="I">che a regnare gl'insegna.</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -436,7 +455,7 @@
             <l>Il più gradito al re fia quei, che porre</l>
             <l>suo consiglio e ragion più sa nel brando.</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -446,7 +465,7 @@
             <l>Fratelli, figli e sudditi d'un padre</l>
             <l part="I">noi siam pur tutti: or via...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -459,7 +478,7 @@
             <l>lo sprezzo altrui, l'ira dell'altra nasce;</l>
             <l part="I">la vendetta da entrambe.</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
@@ -472,7 +491,7 @@
             <l>ma, poiché nulla al chiaror nostro aggiungi,</l>
             <l>non ci far di te almen spiacevol ombra.</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -484,14 +503,14 @@
             <l>stranier fra voi; ma, poi ch'io pur vi nasco,</l>
             <l>non mai sperate ch'io a voi taccia il vero.</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
             <l>No, tu non sei, Garzìa, nemico al padre:</l>
             <l>dunque, perché di chi l'offende amico?</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -506,7 +525,7 @@
             <l>Se nulla in lui giammai varran miei preghi,</l>
             <l>tutti a scemar la tirannia fien volti.</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
@@ -515,26 +534,26 @@
             <l>tacciar d'ingiusto, io volgerò pur tutti</l>
             <l part="I">gli sforzi miei.</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="F">Degna è di te la impresa.</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
             <l part="I">Mi oltraggi tu? Ben ti farò...</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
             <l part="F">T'arresta:</l>
             <l part="I">oh ciel! riponi il brando...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -543,20 +562,20 @@
             <l>degno di lui. Contro il german la spada,</l>
             <l>sublime indizio è di futuro regno.</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
             <l part="I">Deh! ti raffrena... E tu, deh taci!</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
             <l part="F">O cangia</l>
             <l part="I">tuo stile, o ch'io...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -564,7 +583,7 @@
             <l>fa di ragion lo sdegno. Io non mi adiro,</l>
             <l part="I">io, cui ragion sol muove.</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
@@ -572,20 +591,20 @@
             <l>più che al parlar, forse ti senti alquanto;</l>
             <l part="I">quindi sdegno non hai.</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="F">Più assai che all'opre,</l>
             <l part="I">tardo al temer son io.</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
             <l part="M">Chi 'l sa?</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -596,14 +615,14 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>DIEGO, PIERO</stage>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
             <l>A me fratello, tu? Diversi troppo</l>
             <l part="I">noi fummo ognora...</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -612,7 +631,7 @@
             <l>Non che arrossirne, udisti, come altero</l>
             <l part="I">nel tradimento ei gode?</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
@@ -620,7 +639,7 @@
             <l>se il suo stolido orgoglio a lui fia tolto:</l>
             <l part="I">lascia ch'io regni, e tosto...</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -636,7 +655,7 @@
             <l>della madre il diletto: ella n'è cieca;</l>
             <l part="I">e noi poco ama, il sai...</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
@@ -645,13 +664,13 @@
             <l>Anco mel tolga, a ripigliarlo io basto.</l>
             <l part="I">Ben ci conosce il padre.</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
             <l part="F">È ver; ma l'arte...</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
@@ -660,27 +679,27 @@
             <l>che a Cosmo il fosse; e che men cal? non temo,</l>
             <l>non invidio, non odio il fratel mio.</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
             <l>Ma, tu non sai, qual reo disegno asconda</l>
             <l part="I">entro il suo cor Garzìa...</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
             <l part="F">Gli altrui disegni</l>
             <l part="I">indago io mai?</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
             <l part="M">Ma ignoti al padre...</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
@@ -704,7 +723,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>COSIMO, ELEONORA</stage>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -714,7 +733,7 @@
             <l>e la quiete universale. Io n'ebbi</l>
             <l>dal suo parlar non dubbie prove or dianzi.</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
@@ -722,7 +741,7 @@
             <l>indole trovi, né pieghevol core</l>
             <l part="I">nel mio Garzìa?</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -736,14 +755,14 @@
             <l>dianzi in udirlo! I miei sospetti fansi</l>
             <l part="I">omai certezza: e quel Garzìa...</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
             <l part="F">Che fece?</l>
             <l part="I">che disse? in che ti spiacque? Oimè!</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -754,7 +773,7 @@
             <l>quant'io l'abborro? I miei nemici adunque</l>
             <l part="I">suoi nemici non sono?</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
@@ -767,7 +786,7 @@
             <l>Garzìa l'osò: ch'altro vuol dir, fuor ch'egli</l>
             <l>benigno è più, né l'altrui sangue anela?</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -781,7 +800,7 @@
             <l>opra grata farai, se in cor ben dentro</l>
             <l>sì parziale ingiusto amor rinserri.</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
@@ -789,7 +808,7 @@
             <l>provar mel possa, io cangerommi. All'opre</l>
             <l>finor mi attenni, e non de' figli ai detti.</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -800,14 +819,14 @@
             <l>tal virtute finora: a te si aspetta</l>
             <l>l'insegnargliela; a te;... se davver l'ami.</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
             <l>E a' cenni tuoi non inchinò pur sempre</l>
             <l part="I">Garzìa la fronte?</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -830,14 +849,14 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>COSIMO, ELEONORA, PIERO</stage>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
             <l>Padre, altissimo affare a te mi mena:</l>
             <l part="I">teco esser deggio a lungo.</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -845,14 +864,14 @@
             <l>sul volto afflitto strano turbamento?</l>
             <l part="I">Parla; che avvenne? di'.</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
             <l part="F">Narrar nol posso,</l>
             <l part="I">se non a te.</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
@@ -860,7 +879,7 @@
             <l>narrar può un figlio al genitor, che udirla</l>
             <l part="I">una madre non possa?</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -870,7 +889,7 @@
             <l>donna, finor; né il vuoi tu assumer, s'io</l>
             <l part="I">ben scerno...</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
@@ -894,7 +913,7 @@
             <l>Io mal gradito testimon, per certo,</l>
             <l part="I">son dell'arti sue note.</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -912,7 +931,7 @@
             <l>Ma il mio dovere io so; soffrir, tacermi</l>
             <l part="I">deggio; e soffro, e mi taccio.</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -920,7 +939,7 @@
             <l>con questi modi in iscompiglio porre</l>
             <l part="I">la reggia nostra?</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
@@ -934,13 +953,13 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>COSIMO, PIERO</stage>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
             <l part="I">Or parla, Piero.</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -948,7 +967,7 @@
             <l>son della madre veri. Infra noi sorge</l>
             <l part="I">abbominevol peste.</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -956,7 +975,7 @@
             <l>peste non v'ha, che allignar possa: svelta</l>
             <l part="I">fin da radice fia: parla.</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -973,14 +992,14 @@
             <l>esce dell'altro a provocarlo; oh cielo!</l>
             <l>Tremo in pensar ciò che seguir ne puote.</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
             <l>Discordi sempre; io già 'l sapea: ma quale</l>
             <l>nuova cagion tant'oltre ora gli spinse?</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -1005,7 +1024,7 @@
             <l>che tuonar s'oda la paterna voce</l>
             <l>sì, che più non trascorra oltre tal rissa.</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -1021,46 +1040,46 @@
             <l>ch'ei nutre in cor già da gran tempo: e ascosi</l>
             <l>non mi son, no, quant'ei, stolto, sel crede.</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
             <l>Tu dunque pure il sai, ch'ei di Salviati</l>
             <l part="I">celatamente?...</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
             <l part="F">Il so; convinto appieno...</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
             <l part="I">S'è, mal suo grado, ei stesso...</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
             <l part="F">E voi finora</l>
             <l part="I">perché il taceste?</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
             <l part="M">Ei c'è fratello...</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
             <l part="F">E il padre</l>
             <l part="I">non son io di voi tutti?</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -1071,7 +1090,7 @@
             <l>Ciascun di noi potria, colto a tai lacci,</l>
             <l part="I">reo divenir di un simil fallo.</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -1079,7 +1098,7 @@
             <l>nulla potrebbe traditori mai:</l>
             <l part="I">che Diego, e tu...</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -1088,33 +1107,33 @@
             <l>finch'ei rimane in sé. Ma poi, che fia,</l>
             <l>se di ragion nemico amor lo sforza?</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
             <l part="I">Amor! Che parli?</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
             <l part="F">Il suo fallir men grave,</l>
             <l part="I">se pensi a ciò, parratti.</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
             <l part="F">Amor, dicesti?</l>
             <l part="I">Amor di chi?</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
             <l part="M">Padre, tu il sai.</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -1124,21 +1143,21 @@
             <l>osa abboccarsi: ma, che amor l'induca,</l>
             <l>nol seppi io mai. Qual fia l'amor? favella.</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
             <l>Ahi lasso me!... Scusare il volli; ed io,</l>
             <l part="I">io l'accusai.</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
             <l part="F">Parla: l'impongo; e nulla</l>
             <l part="I">mi taci, o ch'io...</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -1156,7 +1175,7 @@
             <l>poi maraviglia, che d'amata donna</l>
             <l>il genitor, non reo paia all'amante?</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -1166,14 +1185,14 @@
             <l>certo sarà di un tale iniquo arcano;</l>
             <l part="I">e lo seconda forse...</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
             <l part="F">In ver, nol credo...</l>
             <l part="I">ma pur, nol so.</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -1188,7 +1207,7 @@
             <l>di sue vendette; io non m'inganno. E il mio</l>
             <l part="I">proprio figlio?...</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -1208,7 +1227,7 @@
             <l>padre, lo svolgi; e la sua rabbia ingiusta</l>
             <l>contro i propri fratelli a un tempo acqueta.</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -1220,14 +1239,14 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>DIEGO, COSIMO, PIERO</stage>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
             <l part="F">O figlio mio, che brami?</l>
             <l part="I">Ragion? l'avrai.</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
@@ -1241,7 +1260,7 @@
             <l>Me non reputo offeso; io sol compiango</l>
             <l>l'offenditor: la mia vendetta è questa.</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -1260,14 +1279,14 @@
             <l>l'opre, gli affetti, le parole, i passi,</l>
             <l>anco i pensier, tutto il saperne importa.</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
             <l>Pure, a delitto or non gli appor, ten prego,</l>
             <l>ciò ch'egli or dianzi irato a me dicea.</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -1275,7 +1294,7 @@
             <l>l'alma Garzìa, tra lor ferma la pace</l>
             <l part="I">già fora; e Diego non s'infinge...</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
@@ -1298,32 +1317,32 @@
             <l>te indisposto contr'esso il parlar mio,</l>
             <l>a tor tal falsa impression sinistra.</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
             <l>Certo, assai meno è traditor Garzìa,</l>
             <l part="I">di quel che tu sii grande.</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
             <l part="F">A te siam figli...</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
             <l>Tu il sei davver: Piero, e tu pure il sei.</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
             <l part="I">Men pregio, almeno.</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
@@ -1334,7 +1353,7 @@
             <l>forza si faccia or di consiglio; e mai</l>
             <l>non gli mostrar, che tu di noi men l'ami.</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -1348,7 +1367,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>COSIMO</stage>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -1374,7 +1393,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>COSIMO, GARZIA</stage>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -1393,7 +1412,7 @@
             <l>dovea trovare in me, che ossequioso</l>
             <l>silenzio pieno, e pazienza, e pace.</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -1426,7 +1445,7 @@
             <l>non niegherei fors'io: forse anco aprirlo</l>
             <l part="I">alla pietà potrei...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -1443,14 +1462,14 @@
             <l>svellergli appien dall'altrui core, e a un tempo</l>
             <l>dal suo! ma, il niega ai regnatori il fato.</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
             <l>Ma, che fora, se un dì dolcezza troppa</l>
             <l part="I">ad increscer mi avesse?</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -1468,7 +1487,7 @@
             <l>vie per servire al tuo rancor non tieni,</l>
             <l>perder nol puoi mai per diritta via.</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -1478,7 +1497,7 @@
             <l>e si fa ognun di mia possanza velo</l>
             <l part="I">a sue private mire...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -1487,7 +1506,7 @@
             <l>quindi a gara ciascun ten pinge il figlio,</l>
             <l part="I">rubello, infame, scellerato.</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -1502,20 +1521,20 @@
             <l>che diresti che in petto alti ei rinserra</l>
             <l>gravi pensieri; e ch'ei d'ogni uom diffida.</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="I">Direi, se il dir lecito fosse...</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
             <l part="F">Or, parla:</l>
             <l part="I">mi piace il ver; godo in udirti.</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -1533,35 +1552,35 @@
             <l>veri a virtù nemici; e in te i sospetti</l>
             <l part="I">non crede tuoi...</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
             <l part="F">Ma pure, ei sa, che figlio</l>
             <l part="I">a me tu sei; come narrarti?...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="F">Ei forse</l>
             <l part="I">me di pietà crede capace...</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
             <l part="F">Intendo:</l>
             <l part="I">in suo favor, tu presso me...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="F">I miei detti</l>
             <l part="I">appo te vani ei troppo sa...</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -1573,7 +1592,7 @@
             <l>a' tuoi, non odia il sangue mio del tutto?</l>
             <l>Egli ti ascolta, e parla? assai diverso...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -1589,7 +1608,7 @@
             <l>S'ei tal pur è nel suo squallore, or pensa</l>
             <l part="I">qual ei fora, se in pregio.</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -1600,7 +1619,7 @@
             <l>già tu mentir non sai: t'incende or sola</l>
             <l part="I">sua virtude a laudarlo?</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -1610,40 +1629,40 @@
             <l>anco l'amore: ardo per Giulia; e quindi</l>
             <l part="I">doppia ho pietà del genitore.</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
             <l part="F">Ed egli</l>
             <l part="I">il sa?</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="M">Gliel dissi.</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
             <l part="M">E, ti seconda?</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="F">E il danna;</l>
             <l part="I">e il danno io pur. Deh! qual mi credi?</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
             <l part="F">Accorto;</l>
             <l part="I">ma, non a tempo.</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -1664,7 +1683,7 @@
             <l>che tale il so; ma, s'ei nol fosse, amore</l>
             <l>mai traditor non mi faria del mio.</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -1672,14 +1691,14 @@
             <l>tutto volli: — ma, il tutto a me non narri.</l>
             <l>Giulia è il minor de' tradimenti tuoi.</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l>Che ascolto? Oh ciel! creder dovea verace</l>
             <l part="I">mai la bontade in te?</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -1700,13 +1719,13 @@
             <l>e tu, (guai se a me 'l nieghi) entro il suo petto,</l>
             <l part="I">là, questo ferro immergi.</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="M">Oh cielo!...</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -1715,26 +1734,26 @@
             <l>l'ammenda è questa. E che? quand'io comando,</l>
             <l part="I">resister osi?</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="F">Ed altra man più infame</l>
             <l part="I">ti manca a ciò?</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
             <l part="F">Scelta ho la tua: ciò basta.</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="I">Perir vo' pria.</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -1745,7 +1764,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>GARZIA</stage>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -1759,7 +1778,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>ELEONORA, GARZIA</stage>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
@@ -1767,14 +1786,14 @@
             <l>deh! mi spiega di Cosmo. Ei mi t'invia,</l>
             <l part="I">in soccorso; perché qual caso?...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="F">Oh madre!...</l>
             <l part="I">che ti diss'egli?</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
@@ -1784,21 +1803,21 @@
             <l>turbato, qual mai non lo vidi. Or parla;</l>
             <l part="I">non m'indugiar; che fu?</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="F">Madre, conosci</l>
             <l part="I">tu questo ferro?</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
             <l part="F">Del tuo padre al fianco</l>
             <l part="I">io sempre il veggo: e che per ciò?...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -1809,14 +1828,14 @@
             <l>in man mel reca ei stesso; e vuol che in petto</l>
             <l>io di Salviati a tradimento il vibri.</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
             <l>Che ascolto? Oh ciel!... Ma, perché a te commessa</l>
             <l part="I">vien sì atroce vendetta?</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -1826,14 +1845,14 @@
             <l>perch'io la figlia, la infelice figlia</l>
             <l part="I">di quel padre infelice, amo...</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
             <l part="F">Che ascolto?</l>
             <l part="I">Giulia!</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -1848,7 +1867,7 @@
             <l>sol ti dico, ch'io n'ardo, e che me stesso,</l>
             <l part="I">pria che il suo padre, io svenerò.</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
@@ -1857,7 +1876,7 @@
             <l>amor!... Per quanto oltre ogni cosa io t'ami,</l>
             <l part="I">lodar nol posso.</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -1879,14 +1898,14 @@
             <l>deh! s'io mai ti fui caro, or vanne, veglia</l>
             <l part="I">su l'amor mio. Chi sa?...</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
             <l part="F">Temer soverchio</l>
             <l part="I">l'amor ti fa.</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -1909,7 +1928,7 @@
             <l>mio braccio il verserà. Più non conosco</l>
             <l>ragione allor; più non m'estimo io figlio...</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
@@ -1917,7 +1936,7 @@
             <l>lunge da te di sì fatale eccesso</l>
             <l part="I">anco il pensier...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -1926,7 +1945,7 @@
             <l>passo, a cui tratto il padre m'ha, deh! cerca</l>
             <l>scampo a me tal, ch'io traditor non sia.</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
@@ -1940,7 +1959,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>GARZIA</stage>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -1958,45 +1977,45 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>PIERO, GARZIA</stage>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
             <l part="I">Fratel, che festi? Oimè!...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="M">Che fu?</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
             <l part="F">Ben ora</l>
             <l part="I">ti compiango davvero.</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="F">Ora!... Che avvenne?</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
             <l>Misero te! Minaccia Cosmo, e freme,</l>
             <l part="I">e traditor ti appella.</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="F">Io tal non sono.</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -2004,27 +2023,27 @@
             <l>aspre catene carca innanzi trarre</l>
             <l part="I">si fea la figlia di Salviati...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="F">Oh cielo!</l>
             <l part="I">Tiranno vile... Io corro.</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
             <l part="F">Ahi!... dove?</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="F">A trarla</l>
             <l part="I">d'indegni ceppi.</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -2035,26 +2054,26 @@
             <l>da chi che sia tentar, di propria mano</l>
             <l part="I">Geri tosto svenarla...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="F">Or or vedrassi...</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
             <l part="I">Deh! t'arresta; che fai?</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="F">... Svenarla? Oh rabbia!...</l>
             <l part="I">Ma, non giungea la madre a lui?...</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -2066,7 +2085,7 @@
             <l>di scolparsi del tutto, io stesso il diedi</l>
             <l part="I">al tuo Garzìa».</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -2079,14 +2098,14 @@
             <l>mezzo, e il migliore a discolparmi, il ferro.</l>
             <l part="I">Ma in te nol posso; oh rabbia!... In me...</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
             <l part="F">Che fai?</l>
             <l part="I">Che tenti? Ah! cessa...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -2095,7 +2114,7 @@
             <l>farmi del sangue del suo padre, io voglio</l>
             <l part="I">svenarmi, io qui.</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -2107,13 +2126,13 @@
             <l>delusa in Cosmo scemi. E l'innocente</l>
             <l part="I">sua figlia, anch'essa forse...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="M">Oh ciel!...</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -2121,7 +2140,7 @@
             <l>Certo è, pur troppo! Ove obbedir tu nieghi,</l>
             <l part="I">e padre e figlia ei svenerà.</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -2132,7 +2151,7 @@
             <l>trar qui, di notte, e sotto infame velo</l>
             <l part="I">d'amistà finta?...</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -2142,13 +2161,13 @@
             <l>ch'altro puoi far? tutto fia peggio. Un solo</l>
             <l part="I">pera; fia 'l meglio...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="M">Ed io vivrommi?...</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -2160,7 +2179,7 @@
             <l>Risolvi; omai risolvi: ah! pensa in quanta</l>
             <l>mortale angoscia or la tua Giulia vive...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -2172,13 +2191,13 @@
             <l>il duol, la rabbia, il disperato amore,</l>
             <l part="I">altra via m'apriranno.</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
             <l part="M">Ah! no...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -2197,7 +2216,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>PIERO, DIEGO</stage>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
@@ -2205,13 +2224,13 @@
             <l>che andar, correr, tornar, com'uomo che l'orme</l>
             <l>perduto ha di ragion, poc'anzi io 'l vidi?</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
             <l part="I">Oh! non sai ch'egli...?</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
@@ -2224,7 +2243,7 @@
             <l>come saetta. Or di', qual nuova rabbia</l>
             <l part="I">il cor gl'invade?</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -2238,7 +2257,7 @@
             <l>a sogguardarti con dileggio. Ei danna</l>
             <l part="I">tutto in altrui, ciò ch'ei non fa.</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
@@ -2249,7 +2268,7 @@
             <l>del suo dileggio. — Ma, quel tanto a fretta</l>
             <l part="I">muoversi, or donde?...</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -2275,7 +2294,7 @@
             <l>difendere, innalzare; e fia, fors'anco,</l>
             <l part="I">che premiato ei si veggia.</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
@@ -2284,7 +2303,7 @@
             <l>torni il fratello? A ravvedersi, forse</l>
             <l part="I">ciò sol può trarlo.</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -2293,25 +2312,25 @@
             <l>l'inganno, e più l'alta feral rovina,</l>
             <l>che a nostra stirpe, al padre, e a te sovrasta.</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
             <l>Al padre? a me? Che vuol Garzìa? che puote?</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
             <l part="I">Regnar vuol egli; e il potrà pur, se taci.</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
             <l>Regnar?... Ma, un brando io non ho forse?</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -2323,7 +2342,7 @@
             <l>se fervid'atra ira nascosa bolle</l>
             <l part="I">sì, che a scoppiar lunge non sia...</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
@@ -2331,20 +2350,20 @@
             <l>in alto oblio non ha l'empia contesa</l>
             <l part="I">sepolta?...</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
             <l part="F">Il crede; ma Garzìa nol crede.</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
             <l>— Ma tu, mi par, che eccitator di risse</l>
             <l>ne venghi a me. — Che mi può far costui?</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -2358,13 +2377,13 @@
             <l>padre ne andrei: ma ben v'andrò, se nieghi</l>
             <l part="I">di udirmi tu.</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
             <l part="F">Che dunque fia? favella.</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -2386,7 +2405,7 @@
             <l>den farti i propri orecchi tuoi: vo' tutto</l>
             <l part="I">farti veder con gli occhi tuoi.</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
@@ -2395,7 +2414,7 @@
             <l>i passati delitti a lui perdona,</l>
             <l>si accinge a nuovi? — A gran rovina ei corre.</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -2413,7 +2432,7 @@
             <l>Ei testimon del tradimento infame</l>
             <l part="I">meco verranne.</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
@@ -2423,7 +2442,7 @@
             <l>Qual fren vuoi tu, che al traditore io ponga?</l>
             <l part="I">Parla, il farò.</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -2438,7 +2457,7 @@
             <l>grotta or t'ascondi; e inaspettate cose</l>
             <l part="I">ivi entro udrai.</l>
           </sp>
-          <sp>
+          <sp who="#diego">
             <speaker>
               <emph>Diego</emph>
             </speaker>
@@ -2447,7 +2466,7 @@
             <l>là il genitor da te non sia: vendetta</l>
             <l part="I">troppa ei farebbe.</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -2461,7 +2480,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>PIERO</stage>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -2473,7 +2492,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>GARZIA</stage>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -2502,33 +2521,33 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>ELEONORA, GARZIA</stage>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
             <l part="F">Oh figlio!...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l>Madre, a che vieni? a mi sottrar tu forse</l>
             <l part="I">dall'imposto delitto!</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
             <l part="F">Oh ciel! mi manda</l>
             <l part="I">il crudo padre a te.</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="M">Che vuol?</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
@@ -2539,7 +2558,7 @@
             <l>sceglieva... ahi lassa! E fra momenti io deggio</l>
             <l part="I">tornarne a lui; che gli dirò?</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -2548,7 +2567,7 @@
             <l>Ma, s'io il promisi, io d'obbedire or niego.</l>
             <l part="I">Va, digli...</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
@@ -2556,40 +2575,40 @@
             <l>ciò riportarne, a orribile periglio</l>
             <l part="I">io t'esporrei. Cieco è di rabbia...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="F">E il sia.</l>
             <l part="I">e mi uccida; io l'aspetto.</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
             <l part="M">E Giulia?</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="F">Oh nome!</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
             <l>Abbi di lei pietà; se averla nieghi</l>
             <l>di tua misera madre, e di te stesso.</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l>— Va dunque, e digli,... che obbedisco: intanto,</l>
             <l part="I">Giulia in salvo a gran fretta...</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
@@ -2598,27 +2617,27 @@
             <l>veder vorrà, cogli occhi suoi. Deh! figlio,</l>
             <l>duolmi a mal'opra spingerti;... eppur,... pensa...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="I">Dunque impossibil fia Giulia?...</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
             <l part="F">Non oso</l>
             <l part="I">il tutto dirti;... eppur, s'io il taccio...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="F">Ah! parla:</l>
             <l part="I">misero me! tremar mi fai.</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
@@ -2627,7 +2646,7 @@
             <l>tiene in alto un pugnal sovra il tremante</l>
             <l part="I">seno di Giulia...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -2641,7 +2660,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>PIERO</stage>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -2662,45 +2681,45 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>GARZIA, PIERO</stage>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l>Chi sei tu?... chi... mi s'appresenta innanzi...</l>
             <l part="I">su le soglie di morte?</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
             <l part="F">Il fratel tuo,</l>
             <l part="I">Piero...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="M">Il figlio di Cosmo?</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
             <l part="F">E tu, nol sei?</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l>Io 'l sono,... or sì;... che un traditor son io.</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
             <l part="I">Ucciso l'hai?</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -2708,20 +2727,20 @@
             <l>alla tremante voce,... al terror nuovo...</l>
             <l part="I">che il cor mi scuote?...</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
             <l part="F">Io ti compiansi pria,</l>
             <l>ed or vie più. — Ma, la tua Giulia hai salva.</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="I">Oh ciel! chi sa, se il padre?...</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -2729,7 +2748,7 @@
             <l>Giulia in salvo fia tosto, ov'io gli arrechi</l>
             <l>prova che cadde per tua man Salviati.</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -2737,14 +2756,14 @@
             <l>sangue. Va, il reca... Oimè!... se mai la figlia</l>
             <l part="I">il vede,... oh ciel!</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
             <l part="F">Ma, certo sei, che il colpo?...</l>
             <l part="I">Cadde al primier? nulla parlò?...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -2771,7 +2790,7 @@
             <l>di quella tomba orribile... a gran pena</l>
             <l>trovo, con man tentando... Udisti? — Or, godi.</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -2785,7 +2804,7 @@
             <l>vorrà celarlo sempre. — Or, deh! ti acqueta:</l>
             <l>lieve è il delitto, che a null'uom fia conto.</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -2807,7 +2826,7 @@
             <l>traditor mai; benché a voi caro... Oh rabbia!...</l>
             <l part="I">Oh terribil vergogna!...</l>
           </sp>
-          <sp>
+          <sp who="#piero">
             <speaker>
               <emph>Piero</emph>
             </speaker>
@@ -2817,7 +2836,7 @@
             <l>a Diego sempre, ed a tutt'altri, io spero</l>
             <l part="I">sia per esser tuo fallo.</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -2835,7 +2854,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>COSIMO, GARZIA</stage>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -2843,7 +2862,7 @@
             <l>mercede merti, o pena? Or via, che festi?</l>
             <l part="I">narrami; parla.</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -2861,14 +2880,14 @@
             <l>Viva e secura rimarrassi almeno</l>
             <l part="I">quella infelice?...</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
             <l part="F">Io vo', non sol disciorla,</l>
             <l>ma teco unirla, se compiuta hai l'opra.</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -2877,7 +2896,7 @@
             <l>ma tanto, no. Se un tradimento io feci,</l>
             <l part="I">sa il ciel perché...</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -2885,7 +2904,7 @@
             <l>l'insano ardir, l'orgoglio, il parlar fero,</l>
             <l part="I">or si addoppiano in te?</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -2895,14 +2914,14 @@
             <l>Non son io de' tuoi figli a te il più caro,</l>
             <l part="I">da che il più reo mi sono?</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
             <l part="F">Or or, fellone,</l>
             <l part="I">pur tremerai...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -2911,7 +2930,7 @@
             <l>che adempi la tua fé. Fermo, e per sempre,</l>
             <l part="I">ho il mio destino già.</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -2923,14 +2942,14 @@
             <l>ch'io recar lasci ad altro sposo in dote?</l>
             <l part="I">A lei tu solo...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="F">Ahi lasso me! che feci?...</l>
             <l part="I">Oh! qual sei tu?... No... mai...</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -2939,7 +2958,7 @@
             <l>ben accertarmi, che Salviati hai spento. —</l>
             <l>Come il sai tu? quai me n'apporti prove?</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -2953,7 +2972,7 @@
             <l>son dal capo alle piante, ancor vermiglio,</l>
             <l part="I">fumante ancora?...</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -2961,7 +2980,7 @@
             <l>questo sangue, nol so. Certezza intera</l>
             <l>ho sol, ch'ei non è il sangue ch'io ti chiesi.</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -2983,7 +3002,7 @@
             <l>figlio di Cosmo io sono; ed innocente</l>
             <l part="I">me Cosmo vuole?</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -2995,7 +3014,7 @@
             <l>altro non so; ma saprò il tutto in breve;</l>
             <l part="I">or or vedrò, con gli occhi miei...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -3003,7 +3022,7 @@
             <l>non venne a te? non ti diss'ei, ch'ivi entro</l>
             <l>per opra sua già prima era Salviati?...</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -3019,7 +3038,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>GARZIA</stage>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -3057,26 +3076,26 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>ELEONORA, GARZIA</stage>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
             <l part="F">O Figlio, oh ciel! che festi?...</l>
             <l part="I">Oimè! fuggi...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="F">Fuggir? io? perché? dove?</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
             <l part="I">Deh! fuggi, o figlio...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -3084,7 +3103,7 @@
             <l>spietato il padre a me ordinò il delitto;</l>
             <l part="I">non fuggo io, no.</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
@@ -3092,14 +3111,14 @@
             <l>di me ti cal, ratto sottratti al fero</l>
             <l>del paterno furore impeto primo.</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l>Furor? che feci? e qual furor si aggiunge</l>
             <l part="I">alla natìa sua rabbia?</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
@@ -3113,7 +3132,7 @@
             <l>Oh qual fragore! Udisti! eccheggia un grido:</l>
             <l>«Al tradimento, al traditore»... Oh figlio!...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -3121,7 +3140,7 @@
             <l>il traditor: ma in me il punisca; io 'l merto.</l>
             <l part="I">Venga ei, non tremo.</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
@@ -3132,7 +3151,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>ELEONORA, GARZIA, COSIMO <emph>con brando ignudo, guardie con fiaccole ed armi</emph></stage>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
@@ -3140,99 +3159,99 @@
             <l>d'ogni intorno si serri. — Ov'è l'iniquo?</l>
             <l part="I">Fra le materne braccia? Invano...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="F">Io sciolto,</l>
             <l>ecco, men son. Che vuoi da me? Che feci?</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
             <l part="I">Pietà! sei padre...</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
             <l part="M">Io l'era.</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
             <l part="M">Oh ciel!...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="F">Che feci?</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
             <l part="I">Diego uccidesti, e il chiedi?...</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
             <l part="M">Il figlio?...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="F">Io?... Diego?</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
             <l part="I">Togliti, donna...</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
             <l part="M">Ei pur t'è figlio...</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
             <l part="F">Il petto</l>
             <l part="I">eccoti...</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
             <l part="M">Ah! ferma...</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
             <l part="M">Muori.</l>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>
               <emph>Eleonora</emph>
             </speaker>
             <l part="F">Il figlio?... Oh colpo...<note resp="#aut" place="foot" anchored="true"><p>Cade tramortita.</p></note></l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>
             <l>Empia, t'è figlio chi ti uccide un figlio?</l>
           </sp>
-          <sp>
+          <sp who="#garzia">
             <speaker>
               <emph>Garzia</emph>
             </speaker>
@@ -3242,7 +3261,7 @@
             <l>Dell'esecrando error... Piero... è.... l'autore...</l>
             <l>Padre... io... moro; e non... mento: il ciel ne attesto.</l>
           </sp>
-          <sp>
+          <sp who="#cosimo">
             <speaker>
               <emph>Cosimo</emph>
             </speaker>

--- a/tei/alfieri-filippo.xml
+++ b/tei/alfieri-filippo.xml
@@ -76,6 +76,28 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="isabella">
+            <persName>Isabella</persName>
+          </person>
+          <person xml:id="carlo">
+            <persName>Carlo</persName>
+          </person>
+          <person xml:id="perez">
+            <persName>Perez</persName>
+          </person>
+          <person xml:id="filippo">
+            <persName>Filippo</persName>
+          </person>
+          <person xml:id="gomez">
+            <persName>Gomez</persName>
+          </person>
+          <person xml:id="leonardo">
+            <persName>Leonardo</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -125,7 +147,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>ISABELLA</stage>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -158,7 +180,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>CARLO, ISABELLA</stage>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -166,13 +188,13 @@
             <l>Regina, e che? tu pure a me t´involi?</l>
             <l>sfuggi tu pure uno infelice oppresso?</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="I">Prence...</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -188,7 +210,7 @@
             <l>crederò che nemica anima alberghi</l>
             <l part="I">tu di pietade?</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -200,7 +222,7 @@
             <l>So le tue pene, e i non mertati oltraggi</l>
             <l part="I">che tu sopporti; e duolmene...</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -211,7 +233,7 @@
             <l>lascio in disparte; e di tua dura sorte</l>
             <l part="I">piango; e vorrei...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -220,21 +242,21 @@
             <l>da pareggiarsi a´ tuoi; dolor sì caldo</l>
             <l part="I">dunque non n´abbi.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
             <l part="F">In me pietà ti offende,</l>
             <l part="I">quando la tua mi è vita?</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="F">In pregio hai troppo</l>
             <l part="I">la mia pietà.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -246,7 +268,7 @@
             <l>infelici color, che al comun duolo</l>
             <l>porgon sollievo di comune pianto.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -255,7 +277,7 @@
             <l>per l´innocente figlio al padre irato</l>
             <l part="I">parlar, vedresti...</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -265,14 +287,14 @@
             <l>cagion sei tu, benché innocente, sola:</l>
             <l part="I">eppur, tu nulla a favor mio...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="F">Cagione</l>
             <l part="I">io delle angosce tue?</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -280,14 +302,14 @@
             <l>principio han tutte dal funesto giorno,</l>
             <l>che sposa in un data mi fosti, e tolta.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l>Deh! che rimembri?... Passeggera troppo</l>
             <l part="I">fu quella speme.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -296,13 +318,13 @@
             <l>quel padre sì, cui piacque romper poscia</l>
             <l part="I">nodi solenni...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="M">E che?...</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -322,7 +344,7 @@
             <l>che pro? l´odio di me nel cor del padre,</l>
             <l>quanto il dolore entro al mio cor, crescea.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -332,7 +354,7 @@
             <l>quanto più il merta, entro al paterno seno</l>
             <l part="I">forse versò il sospetto...</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -354,14 +376,14 @@
             <l>d´altro maggior mio danno io mi dorrei...</l>
             <l>Tutto ei mi ha tolto il dì, che te mi tolse.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l>Prence, ch´ei t´è padre e signor rammenti</l>
             <l part="I">sì poco?...</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -369,14 +391,14 @@
             <l>di un cor ripieno troppo: intera aprirti</l>
             <l part="I">l´alma pria d´or, mai nol potea...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="F">Né aprirla</l>
             <l part="I">tu mai dovevi a me; né udir...</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -384,74 +406,74 @@
             <l>deh! se del mio dolore udito hai parte,</l>
             <l part="I">odilo tutto. A dir mi sforza...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="F">Ah! taci;</l>
             <l part="I">lasciami.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
             <l part="F">Ahi lasso! Io tacerò; ma, ho quanto</l>
             <l part="I">a dir mi resta! Ultima speme...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="F">E quale</l>
             <l part="I">speme ha, che in te non sia delitto?</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
             <l part="F">... Speme,...</l>
             <l part="I">che tu non m´odi.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="F">Odiarti deggio, e il sai,...</l>
             <l part="I">se amarmi ardisci.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
             <l part="F">Odiami dunque; innanzi</l>
             <l>al tuo consorte accusami tu stessa...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l>Io profferire innanzi al re il tuo nome?</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
             <l part="I">Sì reo m´hai tu?</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="M">Sei reo tu solo?</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
             <l part="F">In core</l>
             <l part="I">dunque tu pure?...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -461,7 +483,7 @@
             <l>L´ira del re mertiamo; io, se ti ascolto;</l>
             <l part="I">tu, se prosiegui.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -474,7 +496,7 @@
             <l>qual io mi fo, di pochi accenti un breve</l>
             <l>sfogo innocente all´affannato core.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -482,7 +504,7 @@
             <l>fin ch´io respiro, anco abbandona; e fia</l>
             <l part="I">per poco...</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -492,13 +514,13 @@
             <l>mi appone il padre. Il solo, ond´io son reo,</l>
             <l part="I">nol sa.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="M">Nol sapess´io!</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -511,7 +533,7 @@
             <l>pur cara a me poiché ti alberga, ah! soffri,</l>
             <l part="I">che l´alma io spiri a te dappresso...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -523,13 +545,13 @@
             <l>ch´io ti chieggio, se m´ami; al crudo padre</l>
             <l part="I">sottratti.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
             <l part="F">Oh donna!... ell´è impossibil cosa.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -547,7 +569,7 @@
             <l>a noi si asconda: e dal tuo cor ne svelli</l>
             <l>fin da radice il sovvenir,... se il puoi.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -557,7 +579,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>CARLO</stage>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -569,7 +591,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>CARLO, PEREZ</stage>
-          <sp>
+          <sp who="#perez">
             <speaker>
               <emph>Perez</emph>
             </speaker>
@@ -580,7 +602,7 @@
             <l>non ti crebb´io da´ tuoi più teneri anni?</l>
             <l part="I">Amico ognor non mi nomasti?...</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -593,7 +615,7 @@
             <l>la mobil turba; e all´idolo sovrano</l>
             <l>porgi con essa utili incensi e voti.</l>
           </sp>
-          <sp>
+          <sp who="#perez">
             <speaker>
               <emph>Perez</emph>
             </speaker>
@@ -605,7 +627,7 @@
             <l>per te affrontar periglio? ov´è il nemico</l>
             <l part="I">che più ti offende? parla.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -614,7 +636,7 @@
             <l>nome i suoi vili or non vogl´io, né il deggio.</l>
             <l>Silenzio al padre, agli altri sprezzo oppongo.</l>
           </sp>
-          <sp>
+          <sp who="#perez">
             <speaker>
               <emph>Perez</emph>
             </speaker>
@@ -623,7 +645,7 @@
             <l>altri vel desta. In alto suono, io primo,</l>
             <l part="I">io gliel dirò per te...</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -632,14 +654,14 @@
             <l>più ch´ei nol sa: né in mio favore egli ode</l>
             <l part="I">voce nessuna...</l>
           </sp>
-          <sp>
+          <sp who="#perez">
             <speaker>
               <emph>Perez</emph>
             </speaker>
             <l part="F">Ah! di natura è forza,</l>
             <l part="I">ch´ei l´oda.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -651,7 +673,7 @@
             <l>non sdegnerei: qual di amistade prova</l>
             <l part="I">darti maggior poss´io?</l>
           </sp>
-          <sp>
+          <sp who="#perez">
             <speaker>
               <emph>Perez</emph>
             </speaker>
@@ -660,14 +682,14 @@
             <l>tant´io chieggo, e non più: qual altro resta</l>
             <l>illustre incarco in così orribil reggia?</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
             <l>Ma il mio destin, (qual ch´egli sia) nol sai,</l>
             <l part="I">ch´esser non può mai lieto?</l>
           </sp>
-          <sp>
+          <sp who="#perez">
             <speaker>
               <emph>Perez</emph>
             </speaker>
@@ -676,7 +698,7 @@
             <l>che il duol diviso scemi, avrai compagno</l>
             <l>inseparabil me d´ogni tuo pianto.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -692,7 +714,7 @@
             <l>non sai, ch´è il serbar fede ad uom, cui serba</l>
             <l part="I">odio il suo re?</l>
           </sp>
-          <sp>
+          <sp who="#perez">
             <speaker>
               <emph>Perez</emph>
             </speaker>
@@ -705,7 +727,7 @@
             <l>che a morir teco il tuo dolor mi tragga,</l>
             <l>duramente negarmelo potresti?</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -726,48 +748,48 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>FILIPPO, GOMEZ</stage>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
             <l>Gomez, qual cosa sovra ogni altra al mondo</l>
             <l part="I">in pregio hai tu?</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
             <l part="M">La grazia tua.</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
             <l part="F">Qual mezzo</l>
             <l part="I">stimi a serbarla?...</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
             <l part="F">Il mezzo, ond´io la ottenni;</l>
             <l part="I">obbedirti, e tacermi.</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
             <l part="F">Oggi tu dunque</l>
             <l part="I">far l´uno e l´altro dei.</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
             <l part="F">Novello incarco</l>
             <l part="I">non m´è: sai, ch´io...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -778,14 +800,14 @@
             <l>cura dovrò, che il tuo dover mi piacque</l>
             <l>in brevi detti or rammentarti pria.</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
             <l>Meglio dunque potrammi il gran Filippo</l>
             <l part="I">conoscer oggi.</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -804,26 +826,26 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>FILIPPO, ISABELLA, GOMEZ</stage>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="I">Signor, io vengo ai cenni tuoi.</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
             <l part="F">Regina,</l>
             <l part="I">alta cagion vuol ch´io ti appelli.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="F">Oh! quale?...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -831,13 +853,13 @@
             <l>Ma, qual v´ha dubbio? imparzial consiglio</l>
             <l>chi più di te potria sincero darmi?</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="I">Io, consigliarti?...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -857,13 +879,13 @@
             <l>se più tremendo, venerabil, sacro</l>
             <l>di padre il nome, o quel di re, tu stimi.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="I">Del par son sacri; e chi nol sa?...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -873,13 +895,13 @@
             <l>e dimmi il ver: Carlo, il mio figlio,... l´ami?...</l>
             <l part="I">o l´odi tu?...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="M">... Signor...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -888,13 +910,13 @@
             <l>di tua virtude ascolti, a lui tu senti</l>
             <l part="I">d´esser... madrigna.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="F">Ah! no; t´inganni: il prence...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -903,7 +925,7 @@
             <l>pur di Filippo il figlio ami d´amore...</l>
             <l part="I">materno.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -911,7 +933,7 @@
             <l>Tu l´ami,... o il credo almeno; ... e in simil guisa</l>
             <l part="I">anch´io... l´amo.</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -920,13 +942,13 @@
             <l>né il cieco amor senti di madre, io voglio</l>
             <l part="I">giudice te del mio figliuol...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="M">Ch´io?...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -965,13 +987,13 @@
             <l>nemici felli, il proprio figlio, il solo</l>
             <l part="I">mio figlio, ahi lasso! aggiunger deggia...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="F">Il prence?...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -984,14 +1006,14 @@
             <l>qual sorte a giusto dritto omai si aspetti,</l>
             <l part="I">per me tu il di´.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="F">... Misera me!... Vuoi, ch´io</l>
             <l part="I">del tuo figlio il destino?...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -999,7 +1021,7 @@
             <l>tu, sì, ne sei; né il re temer, né il padre</l>
             <l part="I">dei lusingar: pronunzia.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -1007,7 +1029,7 @@
             <l>che di offendere il giusto. Innanzi al trono</l>
             <l>spesso indistinti e l´innocente e il reo...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -1015,13 +1037,13 @@
             <l>puoi tu? Chi più di me non reo lo brama?</l>
             <l>Deh, pur mentisser le inaudite accuse!</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="I">Già convinto l´hai dunque?...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -1036,7 +1058,7 @@
             <l>in me non tace... Oh ciel! ma voce anch´odo</l>
             <l part="I">di padre in me...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -1077,7 +1099,7 @@
             <l>basso terror di tradimento infame,</l>
             <l>a re, che merti esser tradito, il lascia.</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -1098,7 +1120,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>FILIPPO, ISABELLA</stage>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -1106,20 +1128,20 @@
             <l>più che a lui mi dorria, se un dì dovessi</l>
             <l>in maestà di offeso re mostrarmi.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l>Ben tel credo. Ma ei vien: soffri, che il piede</l>
             <l part="I">altrove io porti.</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
             <l part="M">Anzi, rimani.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -1128,7 +1150,7 @@
             <l>a che rimango omai? testimon vano</l>
             <l>tra il figlio e il padre una madrigna fora...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -1143,7 +1165,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>FILIPPO, ISABELLA, CARLO, GOMEZ</stage>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -1154,7 +1176,7 @@
             <l>e di padre e di re: ma, perché almeno,</l>
             <l>da che il padre non ami, il re non temi?</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -1168,7 +1190,7 @@
             <l>o, se a te piace più, de´ falli miei,</l>
             <l part="I">saper la cagion vera!</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -1177,7 +1199,7 @@
             <l>e il troppo udir lusingatori astuti;...</l>
             <l>non cercar de´ tuoi falli altra cagione.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -1189,7 +1211,7 @@
             <l>con cui sbandir gli adulator, che tanti</l>
             <l>te insidian più, quanto hai di me più possa.</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -1202,13 +1224,13 @@
             <l>io ´l nomerò, benché attempata mostri</l>
             <l part="I">malizia forse...</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
             <l part="M">Error!... ma quale?...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -1219,14 +1241,14 @@
             <l>non l´esser, no, ma il non sentirsi ei reo,</l>
             <l part="I">fia il peggio in lui.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
             <l part="F">Padre, ma trammi al fine</l>
             <l part="I">di dubbio: or che fec´io?</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -1242,7 +1264,7 @@
             <l>viene a mercé; ma in cor, perfidia arreca,</l>
             <l>e d´impunito tradimento speme.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -1271,7 +1293,7 @@
             <l>del mio gastigo. Altro da te non chieggo,</l>
             <l>che di non esser traditor nomato.</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -1301,13 +1323,13 @@
             <l>che a te mi arrendo; e che da te ne imparo,</l>
             <l>non che a scusare, a ben amar mio figlio.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="I">... Signor...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -1321,7 +1343,7 @@
             <l>più spesso il vedi,... e a lui favella,... e il guida. —</l>
             <l>E tu, la udrai, senza sfuggirla. — Io ´l voglio.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -1331,7 +1353,7 @@
             <l>il mio destin (ch´è il sol mio fallo) a tale</l>
             <l>vergogna più non mi far scender mai.</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -1346,57 +1368,57 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>FILIPPO, GOMEZ</stage>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
             <l part="I">Udisti?</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
             <l part="M">Udii.</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
             <l part="M">Vedesti?</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
             <l part="M">Io vidi.</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
             <l part="F">Oh rabbia!</l>
             <l part="I">Dunque il sospetto?...</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
             <l part="M">... È omai certezza...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
             <l part="F">E inulto</l>
             <l part="I">Filippo è ancor?</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
             <l part="M">Pensa...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -1409,7 +1431,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>CARLO, ISABELLA</stage>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -1418,7 +1440,7 @@
             <l>dalla tua Elvira in ora tarda e strana,</l>
             <l part="I">alta cagion mi vi stringea.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -1426,7 +1448,7 @@
             <l>Perché a me non mi lasci? a che più tormi,</l>
             <l>la pace ch´io non ho?... Perché venn´io?</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -1448,7 +1470,7 @@
             <l>mostrava affetto insolito. Deh! mai,</l>
             <l part="I">mai più di me non gli parlare.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -1465,7 +1487,7 @@
             <l>che allignar non vi può... Cagion son io,</l>
             <l part="I">misera me! che tu non l´ami.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -1476,7 +1498,7 @@
             <l>no, non ne sente. Ah, fossi tu felice!</l>
             <l part="I">men mi dorrei.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -1491,7 +1513,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>CARLO</stage>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -1502,13 +1524,13 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>GOMEZ, CARLO</stage>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
             <l part="F">Che vuoi?</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
@@ -1523,7 +1545,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>GOMEZ</stage>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
@@ -1533,7 +1555,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>FILIPPO, LEONARDO, PEREZ, GOMEZ <emph>consiglieri, guardie</emph></stage>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -1553,19 +1575,19 @@
             <l>già inorridir ciascun... Che fia poi, quando</l>
             <l>di Carlo il nome profferir mi udrete?</l>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>
               <emph>Leonardo</emph>
             </speaker>
             <l part="I">L´unico figlio tuo?</l>
           </sp>
-          <sp>
+          <sp who="#perez">
             <speaker>
               <emph>Perez</emph>
             </speaker>
             <l part="F">Di che mai reo?...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -1609,7 +1631,7 @@
             <l>ben libratela, o giudici: da voi</l>
             <l>del figlio io chieggo,... e in un di me, sentenza.</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
@@ -1618,7 +1640,7 @@
             <l>di un padre immerger potrem noi l´acciaro?</l>
             <l part="I">Deh! non ci trarre al fero passo.</l>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>
               <emph>Leonardo</emph>
             </speaker>
@@ -1627,20 +1649,20 @@
             <l>troppo t´incresca; e a noi, che a te il dicemmo,</l>
             <l part="I">farlo tu vogli increscer anco.</l>
           </sp>
-          <sp>
+          <sp who="#perez">
             <speaker>
               <emph>Perez</emph>
             </speaker>
             <l part="F">Il vero</l>
             <l>nuocer non de´. Chiesto n´è il ver; si dica.</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
             <l>Qui non vi ascolta il padre; il re qui v´ode.</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
@@ -1682,19 +1704,19 @@
             <l>aggiunto io ´l veggo a sì inauditi eccessi,</l>
             <l>che pronunziare altro poss´io, che morte?</l>
           </sp>
-          <sp>
+          <sp who="#perez">
             <speaker>
               <emph>Perez</emph>
             </speaker>
             <l part="I">Morte! Che ascolto?</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
             <l part="M">Oh ciel!...</l>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>
               <emph>Leonardo</emph>
             </speaker>
@@ -1705,13 +1727,13 @@
             <l>troppo esecrabil più; tal ch´uom non l´osa</l>
             <l part="I">profferir quasi.</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
             <l part="M">Ed è?</l>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>
               <emph>Leonardo</emph>
             </speaker>
@@ -1760,7 +1782,7 @@
             <l>leggila; e omai, non la indugiar... Ritorce</l>
             <l>le sue vendette in chi le sturba, il cielo.</l>
           </sp>
-          <sp>
+          <sp who="#perez">
             <speaker>
               <emph>Perez</emph>
             </speaker>
@@ -1822,7 +1844,7 @@
             <l>che ognun qui ´l grida, ei fosse; a morte il figlio</l>
             <l>mai condannar nol può, né il debbe, un padre.</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -1836,7 +1858,7 @@
             <l>pera Filippo pria, ma il figlio viva;</l>
             <l part="I">lo assolvo io già.</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
@@ -1846,7 +1868,7 @@
             <l>Assolvi, assolvi; ma, se un dì funesta</l>
             <l part="I">la pietà poi ti fosse...</l>
           </sp>
-          <sp>
+          <sp who="#perez">
             <speaker>
               <emph>Perez</emph>
             </speaker>
@@ -1865,25 +1887,25 @@
             <l>che il tace ognuno? e che l´udirlo, e il dirlo,</l>
             <l>qui da gran tempo è capital delitto?</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
             <l part="I">A chi favelli tu?</l>
           </sp>
-          <sp>
+          <sp who="#perez">
             <speaker>
               <emph>Perez</emph>
             </speaker>
             <l part="F">Di Carlo al padre...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
             <l part="I">Ed al tuo re.</l>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>
               <emph>Leonardo</emph>
             </speaker>
@@ -1897,7 +1919,7 @@
             <l>colpevol ei, gli altri innocenti tutti:</l>
             <l>fra il salvar uno, o tutti, incerto stai?</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -1916,7 +1938,7 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>FILIPPO</stage>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -1933,7 +1955,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>CARLO</stage>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -1970,14 +1992,14 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>FILIPPO, CARLO</stage>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
             <l>Oh cielo!</l>
             <l>da tante spade preceduto il padre?</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -1985,7 +2007,7 @@
             <l>che fai, che pensi tu? gl´incerti passi</l>
             <l part="I">ove porti? Favella.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -1998,7 +2020,7 @@
             <l>Ah padre! indegni son di un re i pretesti; —</l>
             <l>ma le discolpe son di me più indegne.</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -2012,7 +2034,7 @@
             <l>audacemente ogni pensier tuo fello,</l>
             <l>degno di te, magnanimo confessa.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -2020,7 +2042,7 @@
             <l>i vani oltraggi: ogni più cruda pena</l>
             <l>dammi; giusta ella fia, se a te grata.</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -2030,21 +2052,21 @@
             <l>che, dal tuo re colto in sì orribil fallo,</l>
             <l part="I">né pur di aspetto cangi?</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
             <l part="F">Ove l´appresi?</l>
             <l part="I">Nato in tua reggia...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
             <l part="F">Il sei, fellon, per mia</l>
             <l part="I">sventura ed onta...</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -2052,19 +2074,19 @@
             <l>che tardi or più? che non ti fai felice</l>
             <l>col versar tu del proprio figlio il sangue?</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
             <l part="I">Mio figlio tu?</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
             <l part="M">Ma, che fec´io?</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -2074,7 +2096,7 @@
             <l>nullo più ne conosci; o il sol che senti,</l>
             <l>del non compiuto parricidio il senti.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -2082,14 +2104,14 @@
             <l>Ma, né tu stesso il credi, no. — Qual prova,</l>
             <l part="I">quale indizio, o sospetto?...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
             <l part="F">Indizio, prova,</l>
             <l>certezza, io tutto dal livor tuo traggo.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -2098,7 +2120,7 @@
             <l>che tra suddito e re, tra figlio e padre,</l>
             <l>le leggi, il cielo, e la natura, han posto.</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -2112,7 +2134,7 @@
             <l>Se il vero parli, e nulla ascondi, spera;</l>
             <l part="I">se il taci, o ammanti, trema.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -2129,14 +2151,14 @@
             <l>morte non v´ha, che ad avvilir me vaglia.</l>
             <l>Te sol, te sol, non me compiango, o padre.</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
             <l>Temerario, in tal guisa al signor tuo</l>
             <l>ragion de´ tuoi misfatti render osi?</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -2144,13 +2166,13 @@
             <l>sete hai di sangue; ecco ogni mia discolpa:</l>
             <l>tuo dritto solo, è l´assoluto regno.</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
             <l part="I">Guardie, si arresti; olà.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -2162,7 +2184,7 @@
             <l>Il tuo regnar, giorno per giorno, in note</l>
             <l part="I">atre di sangue è scritto già...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -2171,14 +2193,14 @@
             <l>entro al più nero carcere si chiuda.</l>
             <l>Guai, se pietade alcun di voi ne sente.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
             <l>Ciò non temer, che in crudeltà son pari</l>
             <l part="I">i tuoi ministri a te.</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -2189,20 +2211,20 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>ISABELLA, FILIPPO</stage>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="F">Oh cielo!</l>
             <l part="I">che miro? oimè!...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
             <l part="M">Donna, che fia? —</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -2210,46 +2232,46 @@
             <l>tutta di meste grida dolorose</l>
             <l part="I">udia dintorno risuonare...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
             <l part="F">Udisti</l>
             <l part="I">flebile suono; è ver...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="F">Dal tuo cospetto</l>
             <l>non vidi io il prence strascinato a forza?</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
             <l part="I">Tu ben vedesti; è desso.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="F">Il figliuol tuo?...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
             <l>La mia consorte impallidisce, e trema,</l>
             <l part="I">nel veder trarre?...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="M">Io tremo?</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -2258,38 +2280,38 @@
             <l>indizio m´è... Pel tuo... consorte or tremi:</l>
             <l>ma, riconforta il cor; svanì il periglio.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="I">Periglio!... e quale?</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
             <l part="F">Alto periglio io corsi:</l>
             <l part="I">ma omai mia vita in securtà...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="F">Tua vita?...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
             <l>A te sì cara e necessaria, è in salvo.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="I">Ma il traditor?...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -2299,14 +2321,14 @@
             <l>Passò stagione; or di giustizia il solo</l>
             <l part="I">terribil grido ascolterò.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="F">Ma quale,</l>
             <l part="I">qual trama?...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -2316,14 +2338,14 @@
             <l>del padre al par) nulla parrebbe il sangue</l>
             <l part="I">versar della madrigna...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="F">In me?... Che parli?...</l>
             <l part="I">Ahi lassa!... Il prence...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -2337,7 +2359,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>ISABELLA</stage>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -2357,7 +2379,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>GOMEZ, ISABELLA</stage>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
@@ -2365,13 +2387,13 @@
             <l>l´ardir mio troppo; io teco il re pur anco</l>
             <l part="I">stimava.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="M">... Or dianzi ei mi lasciò.</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
@@ -2379,13 +2401,13 @@
             <l>dunque m´è forza altrove. Impaziente</l>
             <l>per certo ei sta di udir l´evento al fine...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="I">L´evento?... Arresta il piè: dimmi...</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
@@ -2394,39 +2416,39 @@
             <l>l´espettazion sua dubbia della estrema</l>
             <l part="I">sentenza...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="F">No: di un tradimento in foschi</l>
             <l part="I">ambigui detti a me parlò; ma...</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
             <l part="F">Il nome</l>
             <l part="I">del traditor non ti dicea?</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="F">Del prence...</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
             <l>Tutto sai dunque. Io del consiglio arreco...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="I">Di qual consiglio? Oimè! che rechi?</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
@@ -2434,13 +2456,13 @@
             <l>l´alto affar discuteasi; e al fin conchiuso</l>
             <l part="I">ad una s´è...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="M">Che mai? Parla.</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
@@ -2448,58 +2470,58 @@
             <l>in questo foglio la sentenza: ad essa</l>
             <l>null´altro manca, che del re l´assenso.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="I">E il tenor n´è?</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
             <l part="M">Morte pronunzia.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="F">Morte?</l>
             <l>Iniqui! morte? E qual delitto è in lui?</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
             <l part="I">Tel tacque il re?</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="M">Mel tacque, sì.</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
             <l part="F">... Tentato</l>
             <l part="I">ha il parricidio.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="M">Oh ciel! Carlo?...</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
             <l part="F">Lo accusa</l>
             <l part="I">il padre stesso; e prove...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -2508,7 +2530,7 @@
             <l>altra ragion, che a me si asconde, avravvi.</l>
             <l>Deh! mi appalesa il suo vero delitto.</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
@@ -2516,14 +2538,14 @@
             <l>se tu nol sai?... Può il dirtelo costarmi</l>
             <l part="I">la vita.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="F">Oh! che di´ tu? Ma che? paventi</l>
             <l part="I">ch´io tradire ti possa?</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
@@ -2531,13 +2553,13 @@
             <l>s´io nulla dico; il re. — Ma, qual ti punge</l>
             <l>stimol sì caldo ad indagarne il vero?</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l>Io?... Sol mi punge curiosa brama.</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
@@ -2550,13 +2572,13 @@
             <l>sgombrar così. Credi; la origin vera</l>
             <l>dei misfatti di Carlo, è in parte, amore...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="I">Che parli?</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
@@ -2564,14 +2586,14 @@
             <l>più fora assai di un successor tuo figlio,</l>
             <l>che non di Carlo sia per l´esser mai.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l>Respiro. — In me quai basse mire inique</l>
             <l part="I">supporre ardisci?</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
@@ -2579,7 +2601,7 @@
             <l>dire i pensier; non son, no, tali i miei;</l>
             <l part="I">ma...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -2587,7 +2609,7 @@
             <l>mai non credea; che il padre, il padre stesso,</l>
             <l part="I">il proprio figlio abborre...</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
@@ -2595,13 +2617,13 @@
             <l>io ti compiango, se finor conosci</l>
             <l part="I">sì poco il re!</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="F">Ma, in chi cred´io? Tu pure...</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
@@ -2611,13 +2633,13 @@
             <l>(misero!) non è reo d´altro delitto,</l>
             <l>che d´esser figlio di un orribil padre.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="I">Raccapricciar mi fai.</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
@@ -2630,7 +2652,7 @@
             <l>ei dissimile il vede; ed, empio, ei vuole</l>
             <l>pria spento il figlio, che di sé maggiore.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -2638,7 +2660,7 @@
             <l>il consiglio che il re, perché condanna</l>
             <l part="I">un innocente a morte?</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
@@ -2651,7 +2673,7 @@
             <l>fremendo il siam; ma invan: chi lo negasse,</l>
             <l>del suo furor cadria vittima tosto.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -2659,7 +2681,7 @@
             <l>muta rimango... E non resta più speme?</l>
             <l part="I">Ingiustamente ei perirà?</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
@@ -2672,7 +2694,7 @@
             <l>o che in quel cor, per indugiar di tempo,</l>
             <l>l´ira profonda scemasse mai dramma.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -2680,19 +2702,19 @@
             <l>l´alma indurata ancor non hai, deh! senti,</l>
             <l part="I">Gomez, pietade...</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
             <l part="M">E che poss´io?</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="F">Tu, forse...</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
@@ -2700,14 +2722,14 @@
             <l>onorar la memoria di quel giusto:</l>
             <l part="I">null´altro io posso.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="F">Oh! chi udì mai, chi vide</l>
             <l part="I">sì atroce caso?</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
@@ -2718,7 +2740,7 @@
             <l>la funesta amistà, roder già sento,</l>
             <l part="I">già straziarmi il cor; ma...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -2732,7 +2754,7 @@
             <l>d´uom, che sua gloria a lui salvò col figlio,</l>
             <l part="I">premiar potrebbe.</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
@@ -2747,7 +2769,7 @@
             <l>e odioso sarebbe. Al re simìle</l>
             <l part="I">crede egli me.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -2763,7 +2785,7 @@
             <l>andiamo; il cielo avrai propizio ognora:</l>
             <l part="I">io ti scongiuro, andiamvi...</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
@@ -2779,7 +2801,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>CARLO</stage>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -2818,7 +2840,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>ISABELLA, CARLO</stage>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -2827,7 +2849,7 @@
             <l>ragion ti mena? amor, dover, pietade?</l>
             <l part="I">Come l´accesso avesti?</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -2838,20 +2860,20 @@
             <l>ti danna; ed altro all´eseguir non manca,</l>
             <l part="I">che l´assenso del re.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
             <l part="F">S´altro non manca,</l>
             <l part="I">eseguirassi tosto.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="F">E che? non fremi?</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -2862,14 +2884,14 @@
             <l>ma inaspettata no. Morir m´è forza;</l>
             <l>fremerne posso, ove tu a me lo annunzi?</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l>Deh! non parlarmi di morte, se m´ami.</l>
             <l part="I">Cedi per poco all´impeto...</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -2878,14 +2900,14 @@
             <l>il crudo incarco; il genitore iniquo</l>
             <l part="I">a te il commette...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="F">E il puoi tu creder, prence?</l>
             <l part="I">Ministra all´ire io di Filippo?...</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -2894,14 +2916,14 @@
             <l>Ma, come or dunque a me venirne in questo</l>
             <l part="I">carcer ti lascia?</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="F">E il sa Filippo? Oh cielo!</l>
             <l part="I">guai, se il sapesse!...</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -2909,13 +2931,13 @@
             <l>qui tutto sa: chi mai rompere i duri</l>
             <l part="I">comandi suoi?...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="M">Gomez.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -2923,14 +2945,14 @@
             <l>qual profferisti abbominevol nome,</l>
             <l part="I">terribile, funesto!...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="F">A te nemico</l>
             <l part="I">non è, qual pensi...</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -2938,7 +2960,7 @@
             <l>amico mai, più di vergogna in volto</l>
             <l part="I">avvamperei, che d´ira.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -2946,7 +2968,7 @@
             <l>sente or di te pietà. L´atroce trama</l>
             <l part="I">ei del padre svelommi.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -2956,7 +2978,7 @@
             <l>dell´empio re l´empissimo ministro,</l>
             <l part="I">ei col ver t´ingannò.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -2968,7 +2990,7 @@
             <l>Deh! non tardar, t´invola: il padre sfuggi,</l>
             <l part="I">la morte, e me.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -2980,7 +3002,7 @@
             <l>Filippo appien già penetrò l´arcano</l>
             <l part="I">dell´amor nostro...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -2995,7 +3017,7 @@
             <l>ch´ei ti tacciò d´insidiar fors´anco,</l>
             <l part="I">oltre i suoi giorni, i miei.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -3012,14 +3034,14 @@
             <l>Gomez per me: più indarno ancor tu speri,</l>
             <l>s´anco egli il vuol, che gliel consenta io mai.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l>E fra pur ver, ch´infra tal gente io tragga</l>
             <l part="I">gl´infelici miei dì?</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -3029,26 +3051,26 @@
             <l>pietade in te, se di te non la senti...</l>
             <l part="I">Va´, se hai cara la vita...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="F">A me la vita</l>
             <l part="I">cara?...</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
             <l part="F">Il mio onor, dunque, e la fama tua.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="I">Ch´io t´abbandoni in tal periglio?</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -3077,28 +3099,28 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>FILIPPO, ISABELLA, CARLO</stage>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
             <l part="F">Ora di morte è giunta:</l>
             <l part="I">perfido, è giunta: io te l´arreco.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="F">Oh vista!</l>
             <l part="I">oh tradimento!...</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
             <l part="F">Ed io son presto a morte:</l>
             <l part="I">dammela tu.</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -3134,7 +3156,7 @@
             <l>vedeva, e veggo. — Or, che più parlo? eguale</l>
             <l>fu in voi la colpa; ugual fia in voi la pena.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -3144,7 +3166,7 @@
             <l>non arse, io ´l giuro: appena ella il mio amore</l>
             <l part="I">seppe, il dannò...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -3156,7 +3178,7 @@
             <l>bocca ne uscì d´orrido amor parola;</l>
             <l part="I">essa l´udìa; ciò basta.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -3176,7 +3198,7 @@
             <l>la rabbia in me del tuo geloso orgoglio:</l>
             <l>ma lei risparmia; ella innocente appieno...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -3192,7 +3214,7 @@
             <l>men di lui forse il tuo dover tradisti,</l>
             <l part="I">l´onor, le leggi?</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -3206,14 +3228,14 @@
             <l>in faccia al prence, io non son rea: nel mio</l>
             <l part="I">petto bensì...</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
             <l part="F">Pietà di me fallace</l>
             <l part="I">muove i suoi detti: ah! non udirla...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -3239,7 +3261,7 @@
             <l>Agli anni poscia, a mia virtude, e forse</l>
             <l part="I">a te spettava lo estirparla...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -3248,7 +3270,7 @@
             <l>ben io il farò: sì, nel tuo sangue infido</l>
             <l part="I">io spegnerò la impura fiamma...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -3263,7 +3285,7 @@
             <l>la riputava in me: palese or sia,</l>
             <l>or ch´io te scorgo assai più ch´essa iniquo.</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -3275,27 +3297,27 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>GOMEZ, FILIPPO, ISABELLA, CARLO</stage>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
             <l part="F">Gomez; compiuti</l>
             <l>mie´ cenni hai tu? Quant´io t´ho imposto arrechi?</l>
           </sp>
-          <sp>
+          <sp who="#gomez">
             <speaker>
               <emph>Gomez</emph>
             </speaker>
             <l>Perez trafitto muore: ecco l´acciaro,</l>
             <l>che gronda ancor del suo sangue fumante.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
             <l part="I">Oh vista!</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -3303,7 +3325,7 @@
             <l>spenta pur non è tutta... Ma tu, intanto,</l>
             <l>mira qual merto a´ tuoi fedeli io serbo.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -3314,14 +3336,14 @@
             <l>mio sangue sol spegner la sete ardente</l>
             <l part="I">di questo tigre!</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="F">Oh! saziar io sola</l>
             <l>potessi, io sola, il suo furor malnato!</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -3329,7 +3351,7 @@
             <l>quel pugnale, o quel nappo. O tu, di morte</l>
             <l part="I">dispregiator, scegli tu primo.</l>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>
               <emph>Carlo</emph>
             </speaker>
@@ -3344,28 +3366,28 @@
             <l>Segui il mio esempio. — Il fatal nappo afferra...</l>
             <l part="I">non indugiare...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="F">Ah! sì; ti seguo. O morte,</l>
             <l part="I">tu mi sei gioia; in te...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
             <l part="F">Vivrai tu dunque;</l>
             <l part="I">mal tuo grado vivrai.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="F">Lasciami... Oh reo</l>
             <l part="I">supplizio! ei muore; ed io?...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
@@ -3375,7 +3397,7 @@
             <l>Quando poi, scevra dell´amor tuo infame,</l>
             <l>viver vorrai, darotti allora io morte.</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -3383,25 +3405,25 @@
             <l>Non fia mai, no... Morir vogl´io... Supplisca</l>
             <l part="I">al tolto nappo<note resp="#aut" place="foot" anchored="true">Rapidissimamente avventatasi al pugnale di Filippo, se ne trafigge.</note>... il tuo pugnal...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
             <l part="F">T´arresta...</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
             <l part="I">Io moro...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>
             <l part="M">Oh ciel! che veggio?</l>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>
               <emph>Isabella</emph>
             </speaker>
@@ -3409,7 +3431,7 @@
             <l>la sposa,... e il figlio,... ambo innocenti,... ed ambo</l>
             <l>per mano tua... — Ti sieguo, amato Carlo...</l>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>
               <emph>Filippo</emph>
             </speaker>

--- a/tei/alfieri-la-congiura-de-pazzi.xml
+++ b/tei/alfieri-la-congiura-de-pazzi.xml
@@ -82,6 +82,28 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="raimondo">
+            <persName>Raimondo</persName>
+          </person>
+          <person xml:id="guglielmo">
+            <persName>Guglielmo</persName>
+          </person>
+          <person xml:id="bianca">
+            <persName>Bianca</persName>
+          </person>
+          <person xml:id="lorenzo">
+            <persName>Lorenzo</persName>
+          </person>
+          <person xml:id="giuliano">
+            <persName>Giuliano</persName>
+          </person>
+          <person xml:id="salviati">
+            <persName>Salviati</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -138,7 +160,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>GUGLIELMO, RAIMONDO</stage>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -147,7 +169,7 @@
             <l>schiavo or così, che del medìceo giogo</l>
             <l>non senti il peso, e i gravi oltraggi, e il danno?</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
@@ -159,7 +181,7 @@
             <l>fia propizio ai tiranni. Infermo stato,</l>
             <l>cangiar nol puoi (pur troppo è ver!) che in peggio.</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -177,7 +199,7 @@
             <l>deplorando, piangevi; al giogo, al pari</l>
             <l>d'ogni uom del volgo, or la cervice inchini?</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
@@ -201,7 +223,7 @@
             <l>sotto le audaci spaziose penne</l>
             <l>delle tiranniche ali in salvo porre.</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -220,7 +242,7 @@
             <l>non ci odian più, ci sprezzano i tiranni;</l>
             <l>e il mertiam noi, che cittadin non fummo.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
@@ -241,28 +263,28 @@
             <l>nol fossi io mai! visto per lei mi avrebbe</l>
             <l>la mia patria morire, o in un con essa.</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
             <l>E, dove l'esser padre esser fa servo,</l>
             <l part="I">farmi padre tu osavi?</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
             <l part="F">Era per anco</l>
             <l part="I">dubbio allora il servaggio...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
             <l part="F">Era men dubbia</l>
             <l part="I">la viltà nostra allora...</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
@@ -271,7 +293,7 @@
             <l>al comun danno omai, tu fra gli affetti</l>
             <l>di marito e di padre, il viver queto...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -286,14 +308,14 @@
             <l>Fu il vestirmele infamia; e infamia al pari</l>
             <l>lo spogliarmele or fia: mira destino.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
             <l>Fama ne corre, anch'io l'udii; ma pure</l>
             <l part="I">nol credo io, no...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -304,7 +326,7 @@
             <l>noi vie più sempre, da che a lor congiunti</l>
             <l part="I">noi vilmente ci femmo.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
@@ -328,7 +350,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>RAIMONDO</stage>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -349,14 +371,14 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>BIANCA, RAIMONDO</stage>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l>Sposo, al fin ti ritrovo. Ah! con chi stai,</l>
             <l part="I">s'anco me sfuggi?</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -364,7 +386,7 @@
             <l>dianzi col padre: ma non ho pur quindi</l>
             <l part="I">tratto sollievo a' mali miei.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
@@ -376,7 +398,7 @@
             <l>la sua fierezza in lui: ch'io tel ridica,</l>
             <l part="I">deh! soffri; egli è buon padre.</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -393,7 +415,7 @@
             <l>irne dovrem da questo ostel, già sacro</l>
             <l>di libertade pubblica ricetto?</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
@@ -401,28 +423,28 @@
             <l>chi non risponde, ed opra? Assai può meglio,</l>
             <l>che tue minacce, il tuo tacer placarli.</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
             <l>E placarli vogl'io?... — Ma, nulla vale</l>
             <l part="I">a placargli oramai...</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l part="F">Nulla? d'un sangue</l>
             <l part="I">non io con loro?...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
             <l part="F">Il so; duolmene; taci;</l>
             <l part="I">nol rimembrare.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
@@ -435,28 +457,28 @@
             <l>a favellar, pianger, pregare, ed anco</l>
             <l>a far, se il deggio, a' miei fratelli forza?</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
             <l>Per me pregare? e chi pregar? tiranni? —</l>
             <l>tu il pensi, o donna? e ch'io il consenta, speri?</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l>Possanza hai tu, ricchezze, armi, seguaci,</l>
             <l>onde a lor far tu apertamente fronte?...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
             <l>Pari a lor odio, in petto io l'odio nutro;</l>
             <l part="I">maggior d'assai l'ardire.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
@@ -490,7 +512,7 @@
             <l>Son madre, e moglie, e suora; in chi ti affidi,</l>
             <l part="I">se in me non fidi?</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -502,13 +524,13 @@
             <l>ch'io non soffro le ingiurie? a che far noto</l>
             <l>ciò che dal sol mio labro saper denno?</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l part="I">Ah!... Se a loro tu parli,... oimè!...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -520,7 +542,7 @@
             <l>non perciò mai motto né cenno a caso</l>
             <l part="I">io fo: ti acqueta; anch'io vo' pace.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
@@ -529,27 +551,27 @@
             <l>sbattuto il core... Ah! non vegg'io forieri</l>
             <l part="I">di pace in te.</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
             <l part="F">Lieto non son; ma crudi</l>
             <l part="I">disegni in me non sospettare.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l part="F">Io tremo;</l>
             <l part="I">né so perché...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
             <l part="M">Perché tu m'ami.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
@@ -560,13 +582,13 @@
             <l>l'amar se stesso. Or, che vuoi tu? cangiarci</l>
             <l>uom sol non puote; e altr'uom che te, non conti.</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
             <l part="I">Perciò mi rodo, e perciò... taccio.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
@@ -575,7 +597,7 @@
             <l>porre tal volta il seggio lor son usi</l>
             <l part="I">miei fratelli...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -583,7 +605,7 @@
             <l>ove l'orecchio a menzognere lodi</l>
             <l>s'apre, ed il core alla pietà si serra.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
@@ -594,7 +616,7 @@
             <l>con gl'innocenti taciti lor baci,</l>
             <l>meglio ch'io col parlar, che pur sei padre.</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -613,7 +635,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>GIULIANO, LORENZO</stage>
-          <sp>
+          <sp who="#lorenzo">
             <speaker>
               <emph>Lorenzo</emph>
             </speaker>
@@ -623,7 +645,7 @@
             <l>uomini a freno: e il son costor? se tali</l>
             <l>fossero, di'; ciò che siam noi, saremmo?</l>
           </sp>
-          <sp>
+          <sp who="#giuliano">
             <speaker>
               <emph>Giuliano</emph>
             </speaker>
@@ -639,7 +661,7 @@
             <l>apparenze lasciamo. Il poter sommo</l>
             <l>più si rafferma, quanto men lo mostri.</l>
           </sp>
-          <sp>
+          <sp who="#lorenzo">
             <speaker>
               <emph>Lorenzo</emph>
             </speaker>
@@ -660,7 +682,7 @@
             <l>di Cosmo a compier la magnanim'opra</l>
             <l>c'invita, inciampo or ne faria viltade?</l>
           </sp>
-          <sp>
+          <sp who="#giuliano">
             <speaker>
               <emph>Giuliano</emph>
             </speaker>
@@ -675,7 +697,7 @@
             <l>non gli estingue, li preme; e assai più feri</l>
             <l part="I">rigermoglian talor dal sangue...</l>
           </sp>
-          <sp>
+          <sp who="#lorenzo">
             <speaker>
               <emph>Lorenzo</emph>
             </speaker>
@@ -684,7 +706,7 @@
             <l>Silla adoprò; ma qui, la verga è troppo:</l>
             <l>a far tremarli, della voce io basto.</l>
           </sp>
-          <sp>
+          <sp who="#giuliano">
             <speaker>
               <emph>Giuliano</emph>
             </speaker>
@@ -713,7 +735,7 @@
             <l>il modo poscia di chi regna; e in fine,</l>
             <l>quel che riman solo a cangiarsi, il nome.</l>
           </sp>
-          <sp>
+          <sp who="#lorenzo">
             <speaker>
               <emph>Lorenzo</emph>
             </speaker>
@@ -724,14 +746,14 @@
             <l>Apertamente, in somma, un sol si attenta</l>
             <l>di resisterci, un solo; e temer dessi?</l>
           </sp>
-          <sp>
+          <sp who="#giuliano">
             <speaker>
               <emph>Giuliano</emph>
             </speaker>
             <l>Feroce figlio di mal fido padre,</l>
             <l part="I">da temersi è Raimondo...</l>
           </sp>
-          <sp>
+          <sp who="#lorenzo">
             <speaker>
               <emph>Lorenzo</emph>
             </speaker>
@@ -739,13 +761,13 @@
             <l>schernire, e a ciò mi appresto: è dolce anch'ella</l>
             <l part="I">cotal vendetta...</l>
           </sp>
-          <sp>
+          <sp who="#giuliano">
             <speaker>
               <emph>Giuliano</emph>
             </speaker>
             <l part="M">E mal sicura.</l>
           </sp>
-          <sp>
+          <sp who="#lorenzo">
             <speaker>
               <emph>Lorenzo</emph>
             </speaker>
@@ -755,7 +777,7 @@
             <l>spargere invan sediziosi detti:</l>
             <l>così vedrassi, in che vil conto io 'l tenga.</l>
           </sp>
-          <sp>
+          <sp who="#giuliano">
             <speaker>
               <emph>Giuliano</emph>
             </speaker>
@@ -772,7 +794,7 @@
             <l>a ciò il sospetto? a tor quiete ei basta,</l>
             <l part="I">non a dar sicurezza.</l>
           </sp>
-          <sp>
+          <sp who="#lorenzo">
             <speaker>
               <emph>Lorenzo</emph>
             </speaker>
@@ -787,7 +809,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>LORENZO, GIULIANO, GUGLIELMO, RAIMONDO</stage>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
@@ -811,14 +833,14 @@
             <l>voi vi apprestiate. Ma, se ciò fia vero,</l>
             <l>chiederne lice a voi ragion pur anco?</l>
           </sp>
-          <sp>
+          <sp who="#giuliano">
             <speaker>
               <emph>Giuliano</emph>
             </speaker>
             <l>Perché al tuo figlio pria ragion non chiedi</l>
             <l part="I">del suo parlar, dell'opre sue?...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -827,7 +849,7 @@
             <l>testimoni poss'io mai de' miei sensi</l>
             <l part="I">trovar di voi...</l>
           </sp>
-          <sp>
+          <sp who="#lorenzo">
             <speaker>
               <emph>Lorenzo</emph>
             </speaker>
@@ -837,7 +859,7 @@
             <l>e, non men pari all'alto ardir, la forza.</l>
             <l part="I">Di'; tal sei tu?</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
@@ -850,7 +872,7 @@
             <l>Ma se tal dritto è in voi, perch'uomo impari</l>
             <l>meglio a temer; che siete or voi? vel chieggo.</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -859,7 +881,7 @@
             <l>non tel dicon lor volti? — Essi son tutto;</l>
             <l part="I">e nulla noi.</l>
           </sp>
-          <sp>
+          <sp who="#giuliano">
             <speaker>
               <emph>Giuliano</emph>
             </speaker>
@@ -868,7 +890,7 @@
             <l>fuoco del ciel distruggitor siam noi;</l>
             <l>sole ai buoni benefico ridente.</l>
           </sp>
-          <sp>
+          <sp who="#lorenzo">
             <speaker>
               <emph>Lorenzo</emph>
             </speaker>
@@ -878,7 +900,7 @@
             <l>D'immeritato onor per noi vestito,</l>
             <l>dimmi, a qual dritto ei ti si diè, chiedesti?</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -896,7 +918,7 @@
             <l>Ardite omai: fatevi pari ai tanti</l>
             <l>tiranni, ond'è la serva Italia infetta...</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
@@ -905,7 +927,7 @@
             <l>tratto non s'hanno, a ciascun uomo esporre</l>
             <l part="I">il suo pensier; ma noi...</l>
           </sp>
-          <sp>
+          <sp who="#lorenzo">
             <speaker>
               <emph>Lorenzo</emph>
             </speaker>
@@ -914,7 +936,7 @@
             <l>Non ten doler; suoi detti, opra son tua.</l>
             <l>Lascia or ch'ei dica: ognor sta in noi l'udirlo.</l>
           </sp>
-          <sp>
+          <sp who="#giuliano">
             <speaker>
               <emph>Giuliano</emph>
             </speaker>
@@ -924,7 +946,7 @@
             <l>il gonfalon, che ad onta nostra invano</l>
             <l part="I">serbar vorresti; il vedi...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -946,7 +968,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>LORENZO, GIULIANO, GUGLIELMO</stage>
-          <sp>
+          <sp who="#lorenzo">
             <speaker>
               <emph>Lorenzo</emph>
             </speaker>
@@ -961,7 +983,7 @@
             <l>a codesto tuo finto picciol Bruto,</l>
             <l>che il vero Bruto invan con Roma ei cadde.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
@@ -980,39 +1002,39 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>LORENZO, GIULIANO</stage>
-          <sp>
+          <sp who="#giuliano">
             <speaker>
               <emph>Giuliano</emph>
             </speaker>
             <l part="I">Odi tu come a noi favellan?...</l>
           </sp>
-          <sp>
+          <sp who="#lorenzo">
             <speaker>
               <emph>Lorenzo</emph>
             </speaker>
             <l part="F">Odo.</l>
             <l>Favellan molto, indi ognor men li temo.</l>
           </sp>
-          <sp>
+          <sp who="#giuliano">
             <speaker>
               <emph>Giuliano</emph>
             </speaker>
             <l part="I">Tramar può ognun...</l>
           </sp>
-          <sp>
+          <sp who="#lorenzo">
             <speaker>
               <emph>Lorenzo</emph>
             </speaker>
             <l part="M">Pochi eseguir...</l>
           </sp>
-          <sp>
+          <sp who="#giuliano">
             <speaker>
               <emph>Giuliano</emph>
             </speaker>
             <l part="F">Quell'uno</l>
             <l part="I">esser potria Raimondo.</l>
           </sp>
-          <sp>
+          <sp who="#lorenzo">
             <speaker>
               <emph>Lorenzo</emph>
             </speaker>
@@ -1027,7 +1049,7 @@
             <l>poco innante si va: di nostra altezza</l>
             <l>fia il periglio primier l'ultima meta.</l>
           </sp>
-          <sp>
+          <sp who="#giuliano">
             <speaker>
               <emph>Giuliano</emph>
             </speaker>
@@ -1046,7 +1068,7 @@
             <l>né il poter nostro, né l'altrui vendetta.</l>
             <l part="I">A me ti arrendi.</l>
           </sp>
-          <sp>
+          <sp who="#lorenzo">
             <speaker>
               <emph>Lorenzo</emph>
             </speaker>
@@ -1059,7 +1081,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>BIANCA, LORENZO, GIULIANO</stage>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
@@ -1070,7 +1092,7 @@
             <l>a Raimondo mi deste: ed or voi primi</l>
             <l part="I">l'oltraggiate così?</l>
           </sp>
-          <sp>
+          <sp who="#lorenzo">
             <speaker>
               <emph>Lorenzo</emph>
             </speaker>
@@ -1084,7 +1106,7 @@
             <l>benigni assai, più ch'ei nol merta, i mezzi</l>
             <l part="I">da noi si adopran; credilo.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
@@ -1094,21 +1116,21 @@
             <l>in moglie a lui, se v'era ei già nemico;</l>
             <l>perché oltraggiarlo, se a lui poi mi deste?</l>
           </sp>
-          <sp>
+          <sp who="#giuliano">
             <speaker>
               <emph>Giuliano</emph>
             </speaker>
             <l>Che alla baldanza sua freno saresti</l>
             <l part="I">sperammo noi...</l>
           </sp>
-          <sp>
+          <sp who="#lorenzo">
             <speaker>
               <emph>Lorenzo</emph>
             </speaker>
             <l part="F">Ma invan: tale è Raimondo,</l>
             <l>da potersi pria spegner che cangiarlo.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
@@ -1117,7 +1139,7 @@
             <l>Se il non essere amati a voi pur duole,</l>
             <l part="I">chi vel contende, altri che voi?</l>
           </sp>
-          <sp>
+          <sp who="#lorenzo">
             <speaker>
               <emph>Lorenzo</emph>
             </speaker>
@@ -1127,7 +1149,7 @@
             <l>te nostra suora; or, se opreran suoi detti</l>
             <l part="I">in cor d'altrui, tu il pensa.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
@@ -1143,7 +1165,7 @@
             <l>cara pur troppo e numerosa prole: —</l>
             <l>Raimondo, a cui tutto a donar son presta.</l>
           </sp>
-          <sp>
+          <sp who="#giuliano">
             <speaker>
               <emph>Giuliano</emph>
             </speaker>
@@ -1152,7 +1174,7 @@
             <l>Anzi, tu prima indurlo ora dovresti</l>
             <l part="I">a rinunziarlo...</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
@@ -1167,7 +1189,7 @@
             <l>Perché nol seppi (oimè!) pria d'esser madre?...</l>
             <l>Ma in somma il sono; e sposa, e amante io sono...</l>
           </sp>
-          <sp>
+          <sp who="#lorenzo">
             <speaker>
               <emph>Lorenzo</emph>
             </speaker>
@@ -1181,7 +1203,7 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>BIANCA</stage>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
@@ -1203,7 +1225,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>RAIMONDO, SALVIATI</stage>
-          <sp>
+          <sp who="#salviati">
             <speaker>
               <emph>Salviati</emph>
             </speaker>
@@ -1215,7 +1237,7 @@
             <l>da noi di sangue il cenno. Or dimmi, hai presta</l>
             <l>fra queste mura ogni promessa cosa?</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -1231,7 +1253,7 @@
             <l>della congiura a lui rivelar nulla,</l>
             <l part="I">se tu pria non giungevi.</l>
           </sp>
-          <sp>
+          <sp who="#salviati">
             <speaker>
               <emph>Salviati</emph>
             </speaker>
@@ -1240,7 +1262,7 @@
             <l>compiere al nuovo sol, ti par ch'ei l'abbia</l>
             <l part="I">ad ignorare, al sol cadente?</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -1256,14 +1278,14 @@
             <l>l'impresa, il tempo si consuma, e l'ira,</l>
             <l>per poi restar con ria vergogna oppressi.</l>
           </sp>
-          <sp>
+          <sp who="#salviati">
             <speaker>
               <emph>Salviati</emph>
             </speaker>
             <l>Ma che? non odia ei pur l'orribil giogo?</l>
             <l>non entra a parte dei comuni oltraggi?...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -1290,14 +1312,14 @@
             <l>tutto esporrai. Qui lo aspettiam; ch'io soglio</l>
             <l part="I">qui favellargli.</l>
           </sp>
-          <sp>
+          <sp who="#salviati">
             <speaker>
               <emph>Salviati</emph>
             </speaker>
             <l part="F">E dei tiranni stanza</l>
             <l part="I">anco talvolta non è questa?</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -1315,7 +1337,7 @@
             <l>d'infiammarlo. Ma intanto, egli oda a un punto,</l>
             <l>che può farsi, e che fatta è la congiura.</l>
           </sp>
-          <sp>
+          <sp who="#salviati">
             <speaker>
               <emph>Salviati</emph>
             </speaker>
@@ -1334,7 +1356,7 @@
             <l>dei tiranni è nemico, oggi ne vaglia,</l>
             <l>pria d'ogni altr'arme, il successor di Piero.</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -1349,7 +1371,7 @@
             <l>acceso; ed anco, invidioso forse</l>
             <l>del poter dei tiranni. — O ciel, tu il sai...</l>
           </sp>
-          <sp>
+          <sp who="#salviati">
             <speaker>
               <emph>Salviati</emph>
             </speaker>
@@ -1357,7 +1379,7 @@
             <l>dalle nostr'opre tratto fia d'inganno</l>
             <l part="I">il volgo stolto.</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -1369,7 +1391,7 @@
             <l>da natura il servir; più forza è d'uopo,</l>
             <l part="I">più che a stringergli, a sciorli.</l>
           </sp>
-          <sp>
+          <sp who="#salviati">
             <speaker>
               <emph>Salviati</emph>
             </speaker>
@@ -1381,7 +1403,7 @@
             <l>e a libertà tornar, ben fia codesto,</l>
             <l part="I">ben altro ardire.</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -1395,21 +1417,21 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>GUGLIELMO, SALVIATI, RAIMONDO</stage>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
             <l>Tu qui, Salviati? Io ti credea sul Tebro</l>
             <l part="I">tuttor mercando onori.</l>
           </sp>
-          <sp>
+          <sp who="#salviati">
             <speaker>
               <emph>Salviati</emph>
             </speaker>
             <l part="F">Al suol natìo</l>
             <l part="I">cura maggior mi torna.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
@@ -1427,14 +1449,14 @@
             <l>Roma del sacro ministero: il solo</l>
             <l>lor supremo volere è omai qui sacro.</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
             <l>Padre, e il sai tu, s'egli or qui venga armato</l>
             <l>di sofferenza, o di men vile usbergo?</l>
           </sp>
-          <sp>
+          <sp who="#salviati">
             <speaker>
               <emph>Salviati</emph>
             </speaker>
@@ -1446,7 +1468,7 @@
             <l>spero destarvi, or che con me, col mio</l>
             <l>furor, di Sisto il furor santo io reco.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
@@ -1454,7 +1476,7 @@
             <l>il furor no; forza ne manca; e forza</l>
             <l part="I">or ci abbisogna, o sofferenza.</l>
           </sp>
-          <sp>
+          <sp who="#salviati">
             <speaker>
               <emph>Salviati</emph>
             </speaker>
@@ -1482,7 +1504,7 @@
             <l>le speranze, i timori, e l'onte, e i danni,</l>
             <l part="I">tutto ben libra; e al fin risolvi.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
@@ -1493,7 +1515,7 @@
             <l>lenti amici ne fur Fernando e Sisto:</l>
             <l part="I">or chi li muove? chi?...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -1522,7 +1544,7 @@
             <l>e di falsa pietà per me, ch'io abborro,</l>
             <l>la obbrobriosa tua temenza adombra.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
@@ -1532,7 +1554,7 @@
             <l>non io son vil, né tu che il dici, il credi;</l>
             <l part="I">ma, più non opro a caso.</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -1543,13 +1565,13 @@
             <l>che il dubbio stato irrequieto, in cui</l>
             <l part="I">viviam tremanti?</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
             <l part="F">Il sai, per me non tremo...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -1577,20 +1599,20 @@
             <l>tranne il solenne inesorabil giuro,</l>
             <l>di estirpar la tirannide, e i tiranni.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
             <l>Due, ne torrai: mancan tiranni a schiavi?</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
             <l>Manca ai liberi il ferro? Insorgan mille,</l>
             <l part="I">mille cadranno; od io cadrò.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
@@ -1605,7 +1627,7 @@
             <l>di qui potrà? Di libertà non parmi</l>
             <l>nunzia, d'un re la mercenaria gente.</l>
           </sp>
-          <sp>
+          <sp who="#salviati">
             <speaker>
               <emph>Salviati</emph>
             </speaker>
@@ -1630,7 +1652,7 @@
             <l>si fan di noi. S'altro motor v'avesse,</l>
             <l>dirti oserei giammai, che in re ti affidi?</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -1667,7 +1689,7 @@
             <l>accenna sol: già nei devoti petti</l>
             <l>piombar li vedi, e a libertà dar via.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
@@ -1687,21 +1709,21 @@
             <l>m'insegnerai, quando fia presto il tutto.</l>
             <l>In te, nell'ira tua dotta mi affido.</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
             <l>Ma, il punto,... assai, più che nol credi,... è presso.</l>
             <l part="I">Già tu pensier non cangi?</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
             <l part="F">A te son padre:</l>
             <l part="I">il cangi tu?</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -1715,7 +1737,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>GUGLIELMO, BIANCA</stage>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
@@ -1725,7 +1747,7 @@
             <l>alto pensiero? oimè! parla: sovrasta</l>
             <l part="I">sventura forse?... A qual di noi?...</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
@@ -1735,20 +1757,20 @@
             <l>e chi non trema? Il mio squallore istesso,</l>
             <l>se intorno miri, in ciascun volto è pinto.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l part="I">Ma, di tremar qual cagion nuova?</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
             <l part="F">O figlia,</l>
             <l part="I">nuova non è.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
@@ -1766,7 +1788,7 @@
             <l>a me tu il celi? Il padre mio, lo sposo</l>
             <l>mi deludono a prova? Il ciel, deh! voglia...</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
@@ -1790,7 +1812,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>GIULIANO, <emph>un uomo d'arme</emph></stage>
-          <sp>
+          <sp who="#giuliano">
             <speaker>
               <emph>Giuliano</emph>
             </speaker>
@@ -1800,7 +1822,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>GIULIANO</stage>
-          <sp>
+          <sp who="#giuliano">
             <speaker>
               <emph>Giuliano</emph>
             </speaker>
@@ -1823,7 +1845,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>GUGLIELMO, GIULIANO</stage>
-          <sp>
+          <sp who="#giuliano">
             <speaker>
               <emph>Giuliano</emph>
             </speaker>
@@ -1837,7 +1859,7 @@
             <l>e dubbi i doni della instabil sorte:</l>
             <l part="I">so...</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
@@ -1848,7 +1870,7 @@
             <l>Forse a popol ben servo è assai più a grado</l>
             <l>chi lo sforza a obbedir, che chi nel prega.</l>
           </sp>
-          <sp>
+          <sp who="#giuliano">
             <speaker>
               <emph>Giuliano</emph>
             </speaker>
@@ -1860,7 +1882,7 @@
             <l>di libertà il soverchio; onde poi fosse</l>
             <l>la miglior parte eternamente intatta...</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
@@ -1868,7 +1890,7 @@
             <l>di senso vuote? Ha servitù il suo nome.</l>
             <l part="I">Chiama il servir, servaggio.</l>
           </sp>
-          <sp>
+          <sp who="#giuliano">
             <speaker>
               <emph>Giuliano</emph>
             </speaker>
@@ -1876,14 +1898,14 @@
             <l>tu libertade appella: io qui non venni</l>
             <l part="I">a disputar tai cose...</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
             <l part="F">È ver, che sempre</l>
             <l part="I">mal sen contende in detti.</l>
           </sp>
-          <sp>
+          <sp who="#giuliano">
             <speaker>
               <emph>Giuliano</emph>
             </speaker>
@@ -1909,14 +1931,14 @@
             <l>ne fia pago Lorenzo. Ogni alto danno</l>
             <l>con un tuo detto antivenir t'è dato.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
             <l>Chi può piegar Raimondo? e degg'io farlo,</l>
             <l part="I">s'anco il potessi?</l>
           </sp>
-          <sp>
+          <sp who="#giuliano">
             <speaker>
               <emph>Giuliano</emph>
             </speaker>
@@ -1925,7 +1947,7 @@
             <l>tolto a scherno da noi, com'egli ha il nostro,</l>
             <l>vedessi tu; che allor di noi faresti?</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
@@ -1948,20 +1970,20 @@
             <l>di tirannide a te l'arti, le leggi</l>
             <l>prescrivo, e l'opre, e la ragion sublime.</l>
           </sp>
-          <sp>
+          <sp who="#giuliano">
             <speaker>
               <emph>Giuliano</emph>
             </speaker>
             <l>Che vuoi tu dirmi? e nol conosco io forse</l>
             <l part="I">al par di te, questo tuo figlio?</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
             <l part="F">E il temi?</l>
           </sp>
-          <sp>
+          <sp who="#giuliano">
             <speaker>
               <emph>Giuliano</emph>
             </speaker>
@@ -1989,7 +2011,7 @@
             <l>pur viver brami; e sopportata l'hai...</l>
             <l part="I">Vuoi tu serbarla? di'.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
@@ -2008,14 +2030,14 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>LORENZO, GIULIANO, GUGLIELMO</stage>
-          <sp>
+          <sp who="#lorenzo">
             <speaker>
               <emph>Lorenzo</emph>
             </speaker>
             <l>Giulian, che fai? Spendi in parole il tempo,</l>
             <l part="I">quando altri in opre?...</l>
           </sp>
-          <sp>
+          <sp who="#giuliano">
             <speaker>
               <emph>Giuliano</emph>
             </speaker>
@@ -2023,7 +2045,7 @@
             <l>del mio parlare omai costui si arrende:</l>
             <l>duolti la pace, anzi che ferma io l'abbia?</l>
           </sp>
-          <sp>
+          <sp who="#lorenzo">
             <speaker>
               <emph>Lorenzo</emph>
             </speaker>
@@ -2031,13 +2053,13 @@
             <l>d'ogni raggiro il rio motor, Salviati</l>
             <l part="I">giunge...</l>
           </sp>
-          <sp>
+          <sp who="#giuliano">
             <speaker>
               <emph>Giuliano</emph>
             </speaker>
             <l part="M">Il so; ma frattanto...</l>
           </sp>
-          <sp>
+          <sp who="#lorenzo">
             <speaker>
               <emph>Lorenzo</emph>
             </speaker>
@@ -2049,7 +2071,7 @@
             <l>fia lor nebbia palustre. Ardir qual altro</l>
             <l>può Roma aver, fuor che l'altrui temenza?</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
@@ -2059,7 +2081,7 @@
             <l>or si armerebbe Roma, che sì rado</l>
             <l>l'armi, e sì mal, solo a difesa, impugna?</l>
           </sp>
-          <sp>
+          <sp who="#lorenzo">
             <speaker>
               <emph>Lorenzo</emph>
             </speaker>
@@ -2087,7 +2109,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>GUGLIELMO</stage>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
@@ -2109,27 +2131,27 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>RAIMONDO, SALVIATI, GUGLIELMO</stage>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
             <l part="F">Oh! dimmi,</l>
             <l part="I">a che ne siamo?</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
             <l part="M">Al compier, quasi.</l>
           </sp>
-          <sp>
+          <sp who="#salviati">
             <speaker>
               <emph>Salviati</emph>
             </speaker>
             <l part="F">A noi</l>
             <l>arride il ciel: mai non sperava io tanto.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
@@ -2155,7 +2177,7 @@
             <l>fia dunque appien? qual feritor, qual'armi,</l>
             <l part="I">quai mezzi, dove, quando?...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -2179,13 +2201,13 @@
             <l>Rinato vil, di nostra stirpe ad onta,</l>
             <l>d'esser niegommi del bel numer uno.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
             <l part="I">Codardo! E s'egli or ci tradisse?</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -2199,7 +2221,7 @@
             <l>vie là fan capo; indi appellar la plebe</l>
             <l>a libertà: noi giungeremo intanto...</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
@@ -2207,7 +2229,7 @@
             <l>pensastel voi? Guai se l'un colpo all'altro</l>
             <l part="I">tardo succede, anco d'un punto.</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -2217,13 +2239,13 @@
             <l>all'armi lor tiranniche ne andranno:</l>
             <l part="I">là fien morti.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
             <l part="F">Che ascolto? Oimè! nel sacro?...</l>
           </sp>
-          <sp>
+          <sp who="#salviati">
             <speaker>
               <emph>Salviati</emph>
             </speaker>
@@ -2232,14 +2254,14 @@
             <l>Primo ei forse non è, che a scherno iniquo</l>
             <l>l'uom, le leggi, e natura, e Iddio si prende?</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
             <l>Vero parli; ma pur,... di umano sangue</l>
             <l part="I">contaminar gli altari...</l>
           </sp>
-          <sp>
+          <sp who="#salviati">
             <speaker>
               <emph>Salviati</emph>
             </speaker>
@@ -2251,7 +2273,7 @@
             <l>Non io l'acciaro tratterrei, se avvinti</l>
             <l>fosser del Nume al simulacro entrambi.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
@@ -2261,7 +2283,7 @@
             <l>o rovinar l'impresa or può quest'una</l>
             <l part="I">universale opinion...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -2275,7 +2297,7 @@
             <l>che al punto stesso, in cui trarremo il ferro,</l>
             <l>di Roma eccheggi entro il gran tempio il nome. —</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
@@ -2292,7 +2314,7 @@
             <l>anco un pensier, può torre al sir fidanza,</l>
             <l>tempo all'impresa, e al feritor coraggio.</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -2310,7 +2332,7 @@
             <l>man pronta e ferma? Il ferro pria verranne</l>
             <l>manco doman, che a me la destra e il core.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
@@ -2326,7 +2348,7 @@
             <l>vittime impure insanguinar tua destra</l>
             <l part="I">sacerdotal tu negheresti...</l>
           </sp>
-          <sp>
+          <sp who="#salviati">
             <speaker>
               <emph>Salviati</emph>
             </speaker>
@@ -2346,25 +2368,25 @@
             <l>il braccio arrechi, oggi dal ciel fia scorto</l>
             <l>dentro al cor empio, che a trafigger scelsi.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
             <l part="I">E scelto hai tu?...</l>
           </sp>
-          <sp>
+          <sp who="#salviati">
             <speaker>
               <emph>Salviati</emph>
             </speaker>
             <l part="M">Lorenzo.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
             <l part="F">Il più feroce?</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -2385,7 +2407,7 @@
             <l>squillo uscirai repente; e allora pensa</l>
             <l>ch'ella è perfetta, o che fallita è l'opra.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
@@ -2405,39 +2427,39 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>RAIMONDO, BIANCA</stage>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
             <l>Or via, che vuoi? Torna a tue stanze, torna:</l>
             <l part="I">lasciami; tosto io riedo.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l part="F">Ed io non posso</l>
             <l part="I">teco venirne?</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
             <l part="M">No.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l part="M">Perché?...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
             <l part="F">Nol puoi.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
@@ -2451,19 +2473,19 @@
             <l>più non penètra entro il tuo core? Ahi lassa!...</l>
             <l>pur ti vogl'io seguir, da lungi almeno...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
             <l part="I">Ma, di che temi? o che supponi?...</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l part="F">Il sai.</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -2474,13 +2496,13 @@
             <l>il fo, perché d'ogni mio affanno a parte</l>
             <l>men ti vorrei:... qual puoi sollievo darmi?</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l part="I">Pianger non posso io teco?</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -2489,20 +2511,20 @@
             <l>e in pianto vano. Ogni uomo io sfuggo, il vedi;</l>
             <l part="I">ed a me stesso incresco.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l part="F">Altro ben veggio;</l>
             <l>pur troppo io veggio, che di me diffidi.</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
             <l part="I">Ogni mio male io non ti narro?...</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
@@ -2513,14 +2535,14 @@
             <l>sol di seguirti; e il nieghi? Io forse posso</l>
             <l>a te giovar; ma nuocerti, non mai.</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
             <l>... Che vai dicendo?... In cor, nulla rinserro,...</l>
             <l>tranne l'antica al par che inutil rabbia.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
@@ -2536,7 +2558,7 @@
             <l>tutto osservai, che meco amor vegliava:</l>
             <l part="I">e non m'inganno, e invan ti ascondi...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -2549,7 +2571,7 @@
             <l>da lieve filo un ferro. Altr'uom non dorme</l>
             <l part="I">qui, che lo stolto.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
@@ -2570,25 +2592,25 @@
             <l>asciutto ognora?... E crederò, che cosa</l>
             <l>or d'altissimo affare in cor non serri?</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
             <l part="I">... Io piansi?...</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l part="M">E il nieghi?</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
             <l part="M">... Io piansi?...</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
@@ -2596,7 +2618,7 @@
             <l>di pianto hai le pupille. Ah! se nol versi</l>
             <l part="I">in questo sen, dove?...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -2618,13 +2640,13 @@
             <l>fa che non sien simìli, se a te giova,</l>
             <l>più che a virtude, a servitù serbarli.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l>Oh ciel!... quai detti!... I figli... oimè!... in periglio?...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -2632,7 +2654,7 @@
             <l>S'uopo mai fosse, dei tiranni all'ira</l>
             <l part="I">pensa a sottrarli tu.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
@@ -2641,7 +2663,7 @@
             <l>giunto pur sei; maturo è il gran disegno:</l>
             <l part="I">tu vuoi cangiar lo stato.</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -2649,7 +2671,7 @@
             <l>ho in me forza da tanto? Il vorrei forse;</l>
             <l part="I">ma, sogni son d'infermo...</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
@@ -2675,7 +2697,7 @@
             <l>svenami; se in me credi, ah! perché taci?</l>
             <l>Son moglie a te; null'altro io son: deh! parla.</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -2685,20 +2707,20 @@
             <l>e statti ai figli appresso: a lor tra breve</l>
             <l part="I">anch'io verrò: lasciami.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l part="M">Ah! no...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
             <l part="F">Mi lascia;</l>
             <l part="I">io tel comando.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
@@ -2706,31 +2728,31 @@
             <l>svenami tu: da me in null'altra guisa</l>
             <l part="I">sciolto ne andrai...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
             <l part="M">Cessa.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l part="M">Deh!...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
             <l part="F">Cessa; o ch'io...</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l part="I">Ti seguirò.</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -2741,14 +2763,14 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>GUGLIELMO, RAIMONDO, BIANCA</stage>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
             <l part="F">Che fai? v'ha chi t'aspetta</l>
             <l part="I">al tempio; e intanto inutil qui?...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -2761,7 +2783,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>GUGLIELMO, BIANCA</stage>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
@@ -2769,14 +2791,14 @@
             <l>ei corre! E a me tu di seguirlo vieti?</l>
             <l part="I">crudo...</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
             <l part="F">Arrestati; placati; fra breve</l>
             <l part="I">ei tornerà.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
@@ -2786,13 +2808,13 @@
             <l>Se tu il puoi, l'abbandona; ma i miei passi</l>
             <l>non rattener; mi lascia, irne vogl'io...</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
             <l>Fora il tuo andare intempestivo, e tardo.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
@@ -2808,7 +2830,7 @@
             <l>che pria ch'a lor non tolga egli lo stato,</l>
             <l part="I">non tolgan essi a lui la vita.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
@@ -2816,40 +2838,40 @@
             <l>non temi; e poiché pur tant'oltre sai;</l>
             <l>men dubbia, or sappi, è dell'altrui, sua vita.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l>Oh ciel! di vita anco in periglio stanno</l>
             <l part="I">i fratelli?...</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
             <l part="F">I tiranni ognor vi stanno.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l part="I">Che ascolto? oimè!...</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
             <l part="F">Ti par, che tor lo stato</l>
             <l part="I">altrui si possa, e non la vita?</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l part="F">Il mio</l>
             <l>consorte or dunque,... a tradimento,... i miei?</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
@@ -2863,14 +2885,14 @@
             <l>oggi all'antico fianco il ferro io cingo</l>
             <l part="I">da tanti anni deposto.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l part="F">Alme feroci!</l>
             <l>cor simulati! io non credea che tale...</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
@@ -2888,7 +2910,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>BIANCA, <emph>uomini d'arme</emph></stage>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
@@ -2915,7 +2937,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>RAIMONDO, BIANCA</stage>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
@@ -2926,7 +2948,7 @@
             <l>Che miro? oimè! dallo stesso tuo fianco</l>
             <l part="I">spiccia il sangue a gran gorghi?... Ah! sposo...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -2935,26 +2957,26 @@
             <l>quello, che gronda dal mio ferro, è il sangue</l>
             <l part="I">del tiranno; ma...</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l part="M">Oimè!...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
             <l part="F">Questo è mio sangue;...</l>
             <l part="I">io... nel mio fianco...</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l part="M">Oh! piaga immensa...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -2964,14 +2986,14 @@
             <l>lo empiei di tante e di tante ferite,</l>
             <l>che d'una... io stesso... il mio fianco... trafissi.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l>Oh rio furore!... Oh mortal colpo!... Oh quanti</l>
             <l part="I">ne uccidi a un tratto!</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -2985,14 +3007,14 @@
             <l>libertade eccheggiar vieppiù dintorno?</l>
             <l part="I">E oprar non posso!...</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l part="F">Oh cielo! E... cadde... anch'egli...</l>
             <l part="I">Lorenzo?...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -3001,14 +3023,14 @@
             <l>se in libertà lascio, e securi,... il padre,...</l>
             <l>la sposa,... i figli,... i cittadini miei...</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l>Me lasci al pianto... Ma, restar vogl'io?</l>
             <l part="I">Dammi il tuo ferro...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -3017,14 +3039,14 @@
             <l>Viver tu dei pe' nostri figli; ai nostri</l>
             <l part="I">figli or ti serba,... se mi amasti...</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l part="F">Oh figli!...</l>
             <l part="I">Ma il fragor cresce?...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -3034,7 +3056,7 @@
             <l>al fianco loro. — Omai,... per me... non resta...</l>
             <l>speme. — Tu il vedi,... che... a momenti... io passo.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
@@ -3042,7 +3064,7 @@
             <l>«Al traditore, al traditor; si uccida».</l>
             <l part="I">Qual traditore?...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -3052,26 +3074,26 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>LORENZO, GUGLIELMO, BIANCA, RAIMONDO, <emph>altri uomini d'arme</emph></stage>
-          <sp>
+          <sp who="#lorenzo">
             <speaker>
               <emph>Lorenzo</emph>
             </speaker>
             <l part="I">Si uccida.</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
             <l part="M">Oh vista!</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l part="F">O fratel mio, tu vivi?</l>
             <l part="I">Abbi pietà...</l>
           </sp>
-          <sp>
+          <sp who="#lorenzo">
             <speaker>
               <emph>Lorenzo</emph>
             </speaker>
@@ -3079,26 +3101,26 @@
             <l>infra le braccia di sua donna ei fugge;</l>
             <l part="I">ma invan. Svelgasi a forza...</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l part="F">Il mio consorte!...</l>
             <l part="I">figli miei!...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
             <l part="F">Tu in ferrei lacci, o padre?...</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
             <l part="I">E tu piagato?</l>
           </sp>
-          <sp>
+          <sp who="#lorenzo">
             <speaker>
               <emph>Lorenzo</emph>
             </speaker>
@@ -3106,7 +3128,7 @@
             <l>versi il tuo sangue infido? Or, chi 'l mio braccio</l>
             <l part="I">prevenne?</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -3114,7 +3136,7 @@
             <l>vibrato al cor del fratel tuo. Ma, ei n'ebbe</l>
             <l part="I">da me molti altri.</l>
           </sp>
-          <sp>
+          <sp who="#lorenzo">
             <speaker>
               <emph>Lorenzo</emph>
             </speaker>
@@ -3126,39 +3148,39 @@
             <l>sol ti serbai, perché in veder tua morte,</l>
             <l>pria d'ottener la sua, doppia abbia pena.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l>L'incrudelir che vale? a morte presso</l>
             <l part="I">ei langue...</l>
           </sp>
-          <sp>
+          <sp who="#lorenzo">
             <speaker>
               <emph>Lorenzo</emph>
             </speaker>
             <l part="F">E semivivo, anco mi giova...</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l part="I">Pena ha con sé del fallir suo.</l>
           </sp>
-          <sp>
+          <sp who="#lorenzo">
             <speaker>
               <emph>Lorenzo</emph>
             </speaker>
             <l part="F">Che veggio!</l>
             <l>lo abbracci tinto del fraterno sangue?</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l part="I">Ei m'è consorte;... ei muore...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
@@ -3166,39 +3188,39 @@
             <l>Se a me commessa era tua morte, mira,</l>
             <l part="I">se tu vivresti.<note resp="#aut" place="foot" anchored="true">Si pianta nel cuore lo stile, che aveva nascosto al giunger di Lorenzo.</note></l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l part="M">Oh ciel! che fai?...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
             <l part="F">Non fero</l>
             <l part="I">invano... io... mai.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
             <l part="M">Figlio!...</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
             <l part="F">M'imìta, o padre.</l>
             <l part="I">Ecco il ferro.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l part="M">A me il dona...</l>
           </sp>
-          <sp>
+          <sp who="#lorenzo">
             <speaker>
               <emph>Lorenzo</emph>
             </speaker>
@@ -3206,26 +3228,26 @@
             <l>trucidator del fratel mio, quant'altre</l>
             <l part="I">morti darai!</l>
           </sp>
-          <sp>
+          <sp who="#raimondo">
             <speaker>
               <emph>Raimondo</emph>
             </speaker>
             <l part="F">Sposa,... per sempre... addio.</l>
           </sp>
-          <sp>
+          <sp who="#bianca">
             <speaker>
               <emph>Bianca</emph>
             </speaker>
             <l part="I">Ed io vivrò?...</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>
               <emph>Guglielmo</emph>
             </speaker>
             <l part="M">Terribil vista! — Or tosto,</l>
             <l>fammi svenar: che più m'indugi?</l>
           </sp>
-          <sp>
+          <sp who="#lorenzo">
             <speaker>
               <emph>Lorenzo</emph>
             </speaker>

--- a/tei/alfieri-maria-stuarda.xml
+++ b/tei/alfieri-maria-stuarda.xml
@@ -82,6 +82,25 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="lamorre">
+            <persName>Lamorre</persName>
+          </person>
+          <person xml:id="maria">
+            <persName>Maria</persName>
+          </person>
+          <person xml:id="ormondo">
+            <persName>Ormondo</persName>
+          </person>
+          <person xml:id="botuello">
+            <persName>Botuello</persName>
+          </person>
+          <person xml:id="arrigo">
+            <persName>Arrigo</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -122,7 +141,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>MARIA, LAMORRE</stage>
-          <sp>
+          <sp who="#lamorre">
             <speaker>
               <emph>Lamorre</emph>
             </speaker>
@@ -133,7 +152,7 @@
             <l>fiamma, cui non son esca umani affetti,</l>
             <l>ma che tutta arde in Dio, libera io nutro.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -146,7 +165,7 @@
             <l>che udir non temo io 'l ver, più che tu dirlo,</l>
             <l part="I">io t'ascolto; favella.</l>
           </sp>
-          <sp>
+          <sp who="#lamorre">
             <speaker>
               <emph>Lamorre</emph>
             </speaker>
@@ -162,7 +181,7 @@
             <l>tu stessa in trono al fianco tuo, che ha nome</l>
             <l>di re, ti è sposo? ovver nemico, o schiavo?</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -170,7 +189,7 @@
             <l>Amante e sposo ei nel mio cuore è sempre;</l>
             <l part="I">ma nel suo, chi 'l può dire?</l>
           </sp>
-          <sp>
+          <sp who="#lamorre">
             <speaker>
               <emph>Lamorre</emph>
             </speaker>
@@ -178,7 +197,7 @@
             <l>tuoi veri sensi interpretar mal puote;</l>
             <l part="I">e men tu i suoi.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -198,7 +217,7 @@
             <l>non giusti oltraggi a me da Arrigo fatti,</l>
             <l>se in lui duol ne vedessi, almen pur finto.</l>
           </sp>
-          <sp>
+          <sp who="#lamorre">
             <speaker>
               <emph>Lamorre</emph>
             </speaker>
@@ -209,7 +228,7 @@
             <l>atte a scacciar, non ch'uom che re si nomi,</l>
             <l>ma qual più umìle e sofferente fora.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -233,7 +252,7 @@
             <l>con empia man traea quel Rizio a morte;</l>
             <l part="I">macchia eterna ad entrambi...</l>
           </sp>
-          <sp>
+          <sp who="#lamorre">
             <speaker>
               <emph>Lamorre</emph>
             </speaker>
@@ -242,7 +261,7 @@
             <l>in soverchio poter salito, ei spiacque</l>
             <l part="I">al tuo consorte: e al popol tuo...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -271,7 +290,7 @@
             <l>la mensa, il suolo, e le mie vesti, e il volto</l>
             <l>contaminarmi, e in un mia fama, egli osa.</l>
           </sp>
-          <sp>
+          <sp who="#lamorre">
             <speaker>
               <emph>Lamorre</emph>
             </speaker>
@@ -300,7 +319,7 @@
             <l>Senza velen di menzognera lingua,</l>
             <l>di cor verace, arditamente io parlo.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -319,7 +338,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>MARIA</stage>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -335,7 +354,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>MARIA, ORMONDO</stage>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
@@ -344,27 +363,27 @@
             <l>Elisabetta; il cui possente aiuto</l>
             <l>ad ogni impresa tua t'offro in suo nome.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l>A prova io già l'amistà sua conobbi;</l>
             <l>la mia per essa argomentar puoi quindi.</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
             <l>Perciò fidanza, e di pregarti ardire</l>
             <l part="I">prendo io...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="M">Di che?</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
@@ -379,7 +398,7 @@
             <l>sposo il volesti; ed or, fia ver che in breve</l>
             <l part="I">ten diparta il divorzio?...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -392,7 +411,7 @@
             <l>ch'ebbi già un dì sì caldamente avversa</l>
             <l part="I">alle mie nozze?</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
@@ -407,7 +426,7 @@
             <l>del tuo saldo voler, tacque; né, credo,</l>
             <l>resta or per lei, che appien non sii tu lieta.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -428,7 +447,7 @@
             <l>private cure investigar non seppi</l>
             <l part="I">giammai; né il so.</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
@@ -442,7 +461,7 @@
             <l>e di temenza piena ognor, la vita</l>
             <l part="I">di un sol fanciullo...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -457,20 +476,20 @@
             <l>non che mia reggia, in tutta pace io spero</l>
             <l part="I">veder fra breve.</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
             <l part="F">Ad ottener tal pace,</l>
             <l>primo mezzo in suo nome oso proporti...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="I">Ed è?</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
@@ -487,7 +506,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>MARIA, ORMONDO, BOTUELLO</stage>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -499,7 +518,7 @@
             <l>sempre indiviso dal mio fianco brama;</l>
             <l>e che fra noi segua il divorzio, teme.</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -509,20 +528,20 @@
             <l>profferir oggi di divorzio il nome?</l>
             <l>oggi, nel dì, che a te ritorna Arrigo...</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
             <l part="I">Oggi ei ritorna?</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="F">Sì. Ben vedi; io prima</l>
             <l>di Elisabetta ogni desir prevengo.</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
@@ -537,7 +556,7 @@
             <l>finché a te presso, col piacer d'entrambe,</l>
             <l>grata m'avrò quanto onorata stanza.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -553,7 +572,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>MARIA, BOTUELLO</stage>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -571,7 +590,7 @@
             <l>Sue finte brame or compiacendo, io voglio</l>
             <l>crucciar più sempre il suo maligno core.</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -582,7 +601,7 @@
             <l>di uscir del regno tuo, torgliene i mezzi</l>
             <l>parmi sen deggia, col vegliar sovr'esso.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -593,7 +612,7 @@
             <l>Favola al mondo io non sarò; pria scelgo</l>
             <l part="I">ogni mio danno.</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -603,7 +622,7 @@
             <l>alle tue istanze, a cui finor fu sordo,</l>
             <l part="I">sperar tu puoi.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -613,14 +632,14 @@
             <l>Ei mi ritrova ognor per lui la stessa:</l>
             <l>io perdono a lui tutto, pur ch'io il vegga.</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
             <l>Deh, pentito ei pur fosse! Il sai per prova</l>
             <l part="I">s'io felice ti vo'.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -634,14 +653,14 @@
             <l>schernir d'Arrigo le imprudenti trame,</l>
             <l>e rimembrar ch'era mio sposo Arrigo.</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
             <l>Fatal maneggio! Omai, deh più non sia</l>
             <l part="I">qui d'uopo usarlo!</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -653,7 +672,7 @@
             <l>può assai... Ma dove arte o consiglio or vaglia,</l>
             <l>tu più d'ogni altri a mio favor potrai.</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -667,7 +686,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>ARRIGO, LAMORRE</stage>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -675,7 +694,7 @@
             <l>de' miei nemici io vengo, o a queste mura</l>
             <l part="I">io vengo a dar l'eterno addio.</l>
           </sp>
-          <sp>
+          <sp who="#lamorre">
             <speaker>
               <emph>Lamorre</emph>
             </speaker>
@@ -694,7 +713,7 @@
             <l>La prima è questa, pur troppo! e la sola</l>
             <l>cagion terribil d'ogni tua sventura.</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -708,7 +727,7 @@
             <l>e un benefizio, quanto è grave incarco,</l>
             <l>se da chi far nol sappia ei si riceve.</l>
           </sp>
-          <sp>
+          <sp who="#lamorre">
             <speaker>
               <emph>Lamorre</emph>
             </speaker>
@@ -725,7 +744,7 @@
             <l>nebbia sgombrar, che pestilente sorge</l>
             <l>dal servo Tebro, ove ogni inganno ha seggio.</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -734,7 +753,7 @@
             <l>il tempo, allor che del mio grado io debbo</l>
             <l part="I">contender?...</l>
           </sp>
-          <sp>
+          <sp who="#lamorre">
             <speaker>
               <emph>Lamorre</emph>
             </speaker>
@@ -744,14 +763,14 @@
             <l>perché tacerlo? Alto il vessillo spiega;</l>
             <l>sostegni avrai quanti qui abborron Roma.</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
             <l>Di civil sangue io non mi pasco: altrove</l>
             <l part="I">pace trovar, ch'io qui non ho...</l>
           </sp>
-          <sp>
+          <sp who="#lamorre">
             <speaker>
               <emph>Lamorre</emph>
             </speaker>
@@ -799,7 +818,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>ARRIGO</stage>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -815,7 +834,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>ARRIGO, MARIA</stage>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -826,39 +845,39 @@
             <l>sai ch'ella è sempre tua, benché ti piaccia</l>
             <l>starne sì a lungo in volontario bando.</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
             <l part="I">Regina...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="F">Ahi nome! Or, che non di' consorte?</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
             <l part="I">Pari è fra noi la sorte?</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="F">Ah! no; che in pianto</l>
             <l part="I">viver mi fai miei lunghi giorni...</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
             <l part="F">Il pianto</l>
             <l part="I">mio, tu nol vedi...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -866,14 +885,14 @@
             <l>la guancia, è ver, di lagrime di sdegno,</l>
             <l part="I">ma d'amor no.</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
             <l part="F">Sia che si voglia, io piansi;</l>
             <l part="I">e tuttor piango.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -882,7 +901,7 @@
             <l>render mi può pura e verace gioia,</l>
             <l part="I">chi, se non tu?</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -890,7 +909,7 @@
             <l>chiaro or tosto sarà. Ti dico intanto</l>
             <l part="I">ch'oggi io non vengo a nuovi oltraggi...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -916,7 +935,7 @@
             <l>del regno, in quanto suo di legge il soffre,</l>
             <l>di me, senza alcun limite, signore.</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -942,7 +961,7 @@
             <l>tradito è quei, che mal tu scelto hai sposo;</l>
             <l>ma, che pur scelto, aver nol puoi tu a vile.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -978,7 +997,7 @@
             <l>regale aringo. Ah! così, pure io fossi,</l>
             <l>come in amarti il sono, in regnar dotta!</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -987,7 +1006,7 @@
             <l>è pure il solo, in cui private mire</l>
             <l part="I">non si ponno albergare...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -1007,20 +1026,20 @@
             <l>mi stai tu sempre, in chi altri mai poss'io</l>
             <l part="I">più affidarmi, che in te?</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
             <l part="F">Dolci parole</l>
             <l>odo, ma fatti ognor più duri io provo.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="I">Ma, che vuoi? parla: io farò tutto...</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -1028,7 +1047,7 @@
             <l>re, padre, sposo, essere in fatti; o i nomi</l>
             <l part="I">spogliarmen vo'...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -1046,7 +1065,7 @@
             <l>agli amplessi paterni: ei ti rammenti</l>
             <l>che re, consorte, e genitor tu sei.</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -1062,7 +1081,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>MARIA, BOTUELLO</stage>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -1070,7 +1089,7 @@
             <l>testimon lieto? Il ricovrato sposo,</l>
             <l part="I">di', qual ti par? migliore assai...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -1083,25 +1102,25 @@
             <l>l'oltraggiata, ei si duole. Invaso e guasto</l>
             <l>d'ambizion, ma non sublime, ha il core.</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
             <l part="I">Ma pur, che chiede?</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="F">Illimitata possa.</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
             <l part="I">L'hai tu, per darla?</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -1110,7 +1129,7 @@
             <l>a ripigliarla. Appien dato all'oblio</l>
             <l part="I">ha i perigli, ond'io 'l trassi.</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -1120,7 +1139,7 @@
             <l>ciò che a lui dan le leggi, anco a tuo costo,</l>
             <l part="I">tutto render gli dei.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -1138,7 +1157,7 @@
             <l>in cui forse gli error potrian del padre</l>
             <l part="I">cadere un dì!... più allor non so...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -1148,13 +1167,13 @@
             <l>l'amor di madre coll'amor di sposa.</l>
             <l>Tranne il figlio, dar tutto a Arrigo dei.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l>E il figlio appunto, oltre ogni cosa, ei chiede.</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -1162,42 +1181,42 @@
             <l>pegno ei forse non è? Qual maraviglia,</l>
             <l>se reo marito, peggior padre or fosse?</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l>Pure, a placar la sempre torbid'alma,</l>
             <l part="I">io gli promisi...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
             <l part="F">Il figlio? Egli disporne?</l>
             <l part="I">Bada.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="F">Ei disporne? non l'ardisco io stessa:</l>
             <l part="I">pensa, se il lascio altrui.</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
             <l part="F">Dunque antivedi,</l>
             <l part="I">ch'altri nol tolga a te.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="F">— Ma, dove or vanno</l>
             <l part="I">i tuoi detti a ferir? sai forse?...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -1212,7 +1231,7 @@
             <l>ad ogni rischio allor fia di svelarti,</l>
             <l>non ciò ch'ei dice, ciò che oprar si attenta.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -1221,7 +1240,7 @@
             <l>qualche doppia sua mira oggi il potrebbe</l>
             <l part="I">ritrarre in corte?</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -1235,7 +1254,7 @@
             <l>tutto esser può: nulla sarà; ma in trono</l>
             <l>cieca fidanza, è inescusabil fallo.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -1243,7 +1262,7 @@
             <l>ognor dovrò? Fatal destino!... Eppure,</l>
             <l part="I">che far poss'io?</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -1262,7 +1281,7 @@
             <l>Così al ben far gli apri ogni strada; e togli</l>
             <l>sol ch'ei non possa, né a sé pur, far danno.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -1278,7 +1297,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>ARRIGO</stage>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -1298,14 +1317,14 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>ARRIGO, ORMONDO</stage>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
             <l>Ben venga Ormondo alla novella corte,</l>
             <l part="I">cui niuna havvi simìle.</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
@@ -1315,7 +1334,7 @@
             <l>ma, piena il cor per te di doglia, vuolmi</l>
             <l>fra voi stromento d'una intera pace.</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -1323,14 +1342,14 @@
             <l>Men lusingai più volte anch'io, ma sempre</l>
             <l part="I">deluso fui.</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
             <l part="F">Pur, questo giorno a pace</l>
             <l part="I">sacro parmi...</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -1338,14 +1357,14 @@
             <l>scelto a varcar meco ogni meta: e questo</l>
             <l>a un tempo è il dì, ch'oltre soffrir più niego.</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
             <l>Ma che? non credi che sincera in core</l>
             <l part="I">sia ver te la regina?</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -1353,7 +1372,7 @@
             <l>Ma, né pur detti, onde affidar mi deggia,</l>
             <l part="I">odo da lei.</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
@@ -1363,7 +1382,7 @@
             <l>Elisabetta, ove fia d'uopo) offrirti</l>
             <l>qual più brami, o consiglio, o aiuto, o scorta.</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -1381,21 +1400,21 @@
             <l>fra quanto imprender pur potrei, mi appiglio:</l>
             <l>e spontaneo prescelgo irmene in bando.</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
             <l>Che vuoi tu fare, o re? S'io dir tel debbo,</l>
             <l>peggior del mal questo rimedio parmi.</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
             <l>Tal non mi pare: e spero abbia a tornarne</l>
             <l>più danno altrui, che non a me vergogna.</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
@@ -1403,7 +1422,7 @@
             <l>più che a pietà, vien preso a scherno? E ov'egli</l>
             <l>pietà pur desti, può appagarsen mai?</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -1411,7 +1430,7 @@
             <l>Non obbedito re, minor d'ogni uomo</l>
             <l part="I">io son qui omai.</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
@@ -1431,14 +1450,14 @@
             <l>datti preso tu stesso: e reo sapranno</l>
             <l part="I">farti essi tosto...</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
             <l part="F">Ed agli amici in mezzo</l>
             <l part="I">fors'io qui sto?</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
@@ -1450,7 +1469,7 @@
             <l>dal ricovrarti a Elisabetta appresso,</l>
             <l part="I">io primier ti sconsiglio.</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -1459,7 +1478,7 @@
             <l>Ciò non mi cade in mente: ivi rattiensi</l>
             <l part="I">a forza ancor la madre mia...</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
@@ -1490,13 +1509,13 @@
             <l>annichilar: ciò tutto, ove tu il vogli,</l>
             <l part="I">tosto il potrai.</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
             <l part="M">Che parli?</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
@@ -1505,13 +1524,13 @@
             <l>Il regio erede, il tuo figliuol fia 'l mezzo</l>
             <l part="I">di tua grandezza, e in un di pace...</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
             <l part="F">Or, come?...</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
@@ -1531,7 +1550,7 @@
             <l>ei salirà: non fia 'l miglior per tutti</l>
             <l>ch'egli in error, cui dee lasciar, non cresca?</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -1540,7 +1559,7 @@
             <l>cui pur anco il vedere a me si vieta,</l>
             <l part="I">come educarlo a senno mio?...</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
@@ -1548,40 +1567,40 @@
             <l>tutto otterresti, se in poter tuo pieno</l>
             <l part="I">lo avessi tu.</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
             <l part="M">Quindi ei m'è tolto.</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
             <l part="F">E quindi</l>
             <l part="I">ritor tu il dei.</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
             <l part="M">Veglian custodi.</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
             <l part="F">E' puonsi</l>
             <l part="I">deludere, comprare...</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
             <l part="F">E pon, ch'io l'abbia;</l>
             <l part="I">poscia il serbarlo...</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
@@ -1597,46 +1616,46 @@
             <l>dare qual più vorrai; quella che appunto</l>
             <l part="I">mertar parratti...</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
             <l part="F">— Assai gran trama è questa.</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
             <l part="I">Spiaceti?</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
             <l part="M">No; ma scabra parmi.</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
             <l part="F">Ardisci;</l>
             <l part="I">lieve si fa.</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
             <l part="F">Troppo parlammo. Or vanne:</l>
             <l part="I">vo' meditarvi a posta mia.</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
             <l part="F">Fra poco</l>
             <l part="I">dunque a te riedo: il tempo stringe...</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -1644,7 +1663,7 @@
             <l>già ben oltre avanzata, a me ritorna,</l>
             <l part="I">quanto più 'l puoi, non osservato.</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
@@ -1658,7 +1677,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>ARRIGO</stage>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -1672,14 +1691,14 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>ARRIGO, BOTUELLO</stage>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
             <l>Che vuoi da me? Forse gli usati omaggi</l>
             <l part="I">rechi al non tuo signore?</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -1692,7 +1711,7 @@
             <l>teco in breve disegna: a un tempo dirti</l>
             <l part="I">deggio...</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -1705,7 +1724,7 @@
             <l>dalla sua propria bocca la discolpa;</l>
             <l part="I">e non per via di nunzio...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -1715,14 +1734,14 @@
             <l>né scelto io fora messagger: ma, teme</l>
             <l part="I">ella, che a te i suoi detti...</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
             <l part="F">Ella co' detti</l>
             <l>spiacermi teme; e in un, coll'opre, il brama.</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -1737,14 +1756,14 @@
             <l>se detta vien, qual me l'impone, in guisa</l>
             <l part="I">di amichevol rampogna.</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
             <l part="F">Arbitro vieni</l>
             <l>d'ascosi arcani tu? — Ma tu, chi sei?</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -1753,25 +1772,25 @@
             <l>qui ricondussi in vostro seggio; io sono</l>
             <l>tal, ch'or favella, perché il dir gli è imposto.</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
             <l part="I">Non mi è l'udirti imposto.</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
             <l part="F">Altri pur odi.</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
             <l part="I">Che parli? Altri?... Che ardire?...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -1783,7 +1802,7 @@
             <l>Messo di pace a noi non viene Ormondo;</l>
             <l part="I">e a lungo pur tu l'odi; e a lui...</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -1794,7 +1813,7 @@
             <l>chiesta udienza ottenne: io nol cercai;</l>
             <l part="I">messo ei non viene a me...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -1812,7 +1831,7 @@
             <l>arrecar vogli ai traditor vantaggio,</l>
             <l part="I">danno a chi t'ama.</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -1822,7 +1841,7 @@
             <l>traditor siete, io mal fra voi ravviso</l>
             <l part="I">qual mi tradisca.</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -1831,7 +1850,7 @@
             <l>invida ognora aspra nemica vostra,</l>
             <l>pace teme fra voi. Da lei che speri?</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -1839,7 +1858,7 @@
             <l>Ma tu, che sai? che mi si appon? che crede</l>
             <l part="I">Maria? che dice?...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -1850,14 +1869,14 @@
             <l>per l'innocente figlio, or ti scongiura</l>
             <l part="I">Maria, piangendo...</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
             <l part="F">Oh! di che piange?... Lacci,</l>
             <l part="I">tendi a me tu...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -1867,59 +1886,59 @@
             <l>pria traspirò quell'empio tradimento,</l>
             <l part="I">ch'egli a propor ti venne...</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
             <l part="F">A me?... Che dirmi</l>
             <l>osi, ribaldo?... Or, se prosiegui, io farti...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
             <l part="I">Signor, compiuto ho il dover mio.</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
             <l part="F">Compiuto</l>
             <l part="I">ho il mio soffrir.</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
             <l part="F">Parlai, perch'io 'l dovea...</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
             <l part="I">Più del dover parlasti. Esci.</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
             <l part="F">Che deggio</l>
             <l part="I">alla regina dire?</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
             <l part="F">Esci; va'; dille,...</l>
             <l part="I">che un temerario sei.</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
             <l part="M">Signor...</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -1929,7 +1948,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>ARRIGO</stage>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -1942,33 +1961,33 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>ARRIGO, ORMONDO</stage>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
             <l part="M">Oh! già ritorni?</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
             <l part="F">Un solo</l>
             <l>dubbio ancor mi rimane: onde a te riedo...</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
             <l>Traditor malaccorto; osi tu, vile,</l>
             <l part="I">venirmi innanzi?</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
             <l part="M">Or, che mai fu?...</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -1977,14 +1996,14 @@
             <l>moveano? e speri, che impunita ell'abbia</l>
             <l part="I">a rimaner tua fraude?</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
             <l part="F">Onde improvviso</l>
             <l part="I">ti cangi? Or dianzi favellavi...</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -1996,14 +2015,14 @@
             <l>a me soccorso, alla mia prole asilo,</l>
             <l part="I">volessi io mai?</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
             <l part="F">... Se fabro io fui d'inganni</l>
             <l part="I">teco, or di me colpa tu il credi?</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -2011,7 +2030,7 @@
             <l>di te, di chi t'invia, dell'abborrito</l>
             <l part="I">tuo ministero...</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
@@ -2033,7 +2052,7 @@
         <div type="scene">
           <head>SCENA VII</head>
           <stage>ARRIGO</stage>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -2051,7 +2070,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>ARRIGO, MARIA</stage>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -2063,14 +2082,14 @@
             <l>Norma imparar da me dovevi almeno,</l>
             <l>come un tuo pari offendere si debba.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l>Qual favellar? Che fu? già, pria che salda</l>
             <l>fra noi concordia si rinnovi, ascolto...</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -2082,14 +2101,14 @@
             <l>più finzioni, e più lusinghe omai;</l>
             <l part="I">e più delitti.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="F">Oh cielo! e tal rampogna</l>
             <l part="I">merto io da te?</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -2111,7 +2130,7 @@
             <l>tuoi consiglieri, e a' tuoi rimorsi in mezzo,</l>
             <l part="I">(se pur ten resta) omai ti lascio.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -2131,7 +2150,7 @@
             <l>capace, o almen di gratitudin lieve,</l>
             <l part="I">il duro petto?</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -2143,7 +2162,7 @@
             <l>che sconsigliato, debile, atterrito</l>
             <l>non son, qual pensi; e che vostre arti vili...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -2152,7 +2171,7 @@
             <l>per me oltraggiosi, indi egualmente indegni</l>
             <l part="I">di chi gli ascolta, e di chi gli usa.</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -2160,7 +2179,7 @@
             <l>t'offendo io sempre; e me tu in fatti offendi.</l>
             <l part="I">Fuor di memoria già?...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -2183,7 +2202,7 @@
             <l>qual ch'ella sia, narrarmi or la cagione</l>
             <l part="I">del novello tuo sdegno? Io tosto...</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -2203,13 +2222,13 @@
             <l>che ordisci ognora a danno mio, tu chiami</l>
             <l>anco la iniqua Elisabetta a parte?</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="I">Che mai mi apponi? Oh ciel! qual prova?...</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -2221,14 +2240,14 @@
             <l>far traditore? onde ritrar pretesti</l>
             <l part="I">poi di velata iniquità...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="F">Che ascolto?</l>
             <l part="I">M'incenerisca il ciel, s'io mai...</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -2242,14 +2261,14 @@
             <l>ella a biasmarti, ella a gridar fia prima</l>
             <l>que' tuoi stessi delitti, a cui t'ha spinto.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l>Vile impostura ell'è. Chi spender osa</l>
             <l part="I">così il mio nome?...</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -2260,7 +2279,7 @@
             <l>spiar volendo nel mio cor tropp'entro,</l>
             <l>troppo hanno il loro, e troppo aperto il tuo.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -2269,14 +2288,14 @@
             <l>chiarir qui tosto il tutto: entrambi insieme</l>
             <l part="I">chiamarli; udire...</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
             <l part="F">A paragon venirne</l>
             <l part="I">io di costoro?...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -2284,7 +2303,7 @@
             <l>poss'io del ver convincerti? la benda</l>
             <l part="I">come dagli occhi trarti?</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -2296,7 +2315,7 @@
             <l>d'Ormondo il bando immantinente. — A tanto,</l>
             <l part="I">di' sei tu presta?</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -2317,7 +2336,7 @@
             <l>a dispotica voglia anco il più vile</l>
             <l>sottoporre ardirò del popol mio?</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -2325,13 +2344,13 @@
             <l>pe' buoni stassi: ecco il regnar, che giova. —</l>
             <l part="I">Ti lascio; addio.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="M">Deh! m'odi...</l>
           </sp>
-          <sp>
+          <sp who="#arrigo">
             <speaker>
               <emph>Arrigo</emph>
             </speaker>
@@ -2349,7 +2368,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>MARIA</stage>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -2373,7 +2392,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>MARIA, BOTUELLO</stage>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -2381,19 +2400,19 @@
             <l>tu di consiglio or non soccorri, io forse</l>
             <l>di precipizio orribile sto all'orlo.</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
             <l>Da gran tempo vi stai; ma or più che pria...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="I">E che? tu pur d'Arrigo i sensi?...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -2403,13 +2422,13 @@
             <l>accusatore io mai venirne? Eppure</l>
             <l>necessitade oggi a ciò far mi astringe.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="I">Dunque trama si ordisce?</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -2424,28 +2443,28 @@
             <l>quindi attentossi ei di proporgli, e ottenne,</l>
             <l part="I">che a lui si desse il figliuol tuo...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="F">Che sento?</l>
             <l part="I">a Ormondo?...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
             <l part="F">Sì; perché il trafughi in corte</l>
             <l part="I">d'Elisabetta.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="F">Ahi traditor!... Mio figlio</l>
             <l part="I">tormi?... Ed in man darlo a colei?...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -2456,7 +2475,7 @@
             <l>il proprio figlio in perdizion mandarne,</l>
             <l part="I">(vedi padre!) ei disegna...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -2467,7 +2486,7 @@
             <l>indotto Ormondo a ordir la trama; e tesi</l>
             <l part="I">da me tai lacci: iniquo!...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -2496,7 +2515,7 @@
             <l>d'ogni cosa or ne viene. Udirlo vuoi?</l>
             <l part="I">Egli attende...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -2506,7 +2525,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>MARIA</stage>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -2522,21 +2541,21 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>MARIA, BOTUELLO, ORMONDO</stage>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="F">Parla; e di' vero;</l>
             <l part="I">che favellotti Arrigo?</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
             <l part="F">Ei... si... dolea...</l>
             <l>del lieve conto, in che ciascun qui il tiene.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -2544,14 +2563,14 @@
             <l>togli ogni vel; sue temerarie inchieste,</l>
             <l>e tue promesse temerarie, narra.</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
             <l>... È vero,... ei... mi chiedea... d'Elisabetta,</l>
             <l part="I">in suo favor, l'aìta.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -2563,7 +2582,7 @@
             <l>e sé tradito: ma di propria tua</l>
             <l part="I">bocca udir voglio...</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
@@ -2573,14 +2592,14 @@
             <l>darlo in ostaggio, di sua fede in pegno,</l>
             <l part="I">sceglieva ei stesso...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="F">Oh non mai visto padre!</l>
             <l part="I">E v'assentivi tu?</l>
           </sp>
-          <sp>
+          <sp who="#ormondo">
             <speaker>
               <emph>Ormondo</emph>
             </speaker>
@@ -2588,7 +2607,7 @@
             <l>nol volli a prima io disperar del tutto...</l>
             <l>perch'ei null'altro disegnasse, io finsi...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -2603,7 +2622,7 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>MARIA, BOTUELLO</stage>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -2611,7 +2630,7 @@
             <l>passa ei tra 'l vero e la menzogna! In tempo</l>
             <l part="I">conoscerlo giovò.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -2621,7 +2640,7 @@
             <l>e dal timore; e, il crederai? pur anco</l>
             <l part="I">da non so qual speranza...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -2629,7 +2648,7 @@
             <l>ch'ora, ita a vuoto la scoperta trama,</l>
             <l part="I">null'altro mal sia per seguirne.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -2637,13 +2656,13 @@
             <l>Arrigo è tal, ch'or che scoperta ei vede</l>
             <l part="I">sua folle impresa...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
             <l part="M">E che può far?</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -2651,7 +2670,7 @@
             <l>fuor del mio regno. Il duro ultimo addio</l>
             <l part="I">ei già...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -2662,13 +2681,13 @@
             <l>de' già mal tesi aguati, altri ne andrebbe</l>
             <l>a ritentar con più felice ardire.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="I">Ciò penso anch'io; ma pure...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -2679,13 +2698,13 @@
             <l>fido appoggio egli avrà. — Scegliere or dessi</l>
             <l part="I">il mal minor...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="F">Ma il minor mal qual fia?</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -2695,7 +2714,7 @@
             <l>vuoi che Arrigo ricovri? E se in persona</l>
             <l>con essa ei tratta, allor, trame ben altre...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -2707,35 +2726,35 @@
             <l>or io la forza adoprerei?.... Nol posso...</l>
             <l part="I">e, sia che vuol, mai nol faro.</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
             <l part="F">Ma, pensa,</l>
             <l part="I">ch'ei nuocer molto...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="F">E qual può danno ei farmi,</l>
             <l part="I">che il non amarmi agguagli?</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
             <l part="F">Ove ei partisse,</l>
             <l part="I">certo, mai più nol rivedresti...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="F">Oh cielo!...</l>
             <l part="I">Pur ch'io nol perda affatto...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -2745,14 +2764,14 @@
             <l>empio eretico error sovrasta, il sai,</l>
             <l part="I">alla innocenza sua.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="F">Pur troppo io deggio...</l>
             <l part="I">Ma,... come mai?...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -2761,7 +2780,7 @@
             <l>di forza usato alla real sua sacra</l>
             <l part="I">persona fosse?...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -2771,7 +2790,7 @@
             <l>Fautori avrà, quanti ho nemici e infidi</l>
             <l part="I">sudditi rei.</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -2790,40 +2809,40 @@
             <l>aperto lascia alle ragion tue giuste;</l>
             <l>e a lui, se il può, campo a impugnarle lascia.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="I">Parmi il men reo partito; eppure...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
             <l part="F">Ah! credi,</l>
             <l part="I">ch'altro non n'hai.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="M">Ma, in eseguirlo...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
             <l part="F">Io cura</l>
             <l part="I">ne prenderò, se il brami...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="F">E se i comandi</l>
             <l part="I">si oltrepassasser mai?... Bada...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -2831,26 +2850,26 @@
             <l>Ch'io nol sappia eseguir? Ma, breve è il tempo;</l>
             <l part="I">pria che ne manchi, io corro...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="F">Ah no;... t'arresta...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
             <l>Farti or vo' forza: io ti salvai, rimembra,</l>
             <l part="I">già un'altra volta...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="M">Il so; ma...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -2860,7 +2879,7 @@
         <div type="scene">
           <head>SCENA VII</head>
           <stage>MARIA</stage>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -2874,7 +2893,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>MARIA, LAMORRE</stage>
-          <sp>
+          <sp who="#lamorre">
             <speaker>
               <emph>Lamorre</emph>
             </speaker>
@@ -2882,13 +2901,13 @@
             <l>ansio, anelante, alle tue stanze, in ora</l>
             <l part="I">strana. Oh qual notte!...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="M">Or, che vuoi tu?</l>
           </sp>
-          <sp>
+          <sp who="#lamorre">
             <speaker>
               <emph>Lamorre</emph>
             </speaker>
@@ -2898,7 +2917,7 @@
             <l>mentre il consorte tuo di grida e d'armi</l>
             <l part="I">cinto?</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -2906,7 +2925,7 @@
             <l>al nuovo dì, ch'io nulla a lui togliea,</l>
             <l part="I">che di nuocere a sé.</l>
           </sp>
-          <sp>
+          <sp who="#lamorre">
             <speaker>
               <emph>Lamorre</emph>
             </speaker>
@@ -2923,7 +2942,7 @@
             <l>schierati in cerchio, ogni uom lontano a forza</l>
             <l part="I">feri tenendo?</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -2932,7 +2951,7 @@
             <l>e li saprà chi pur saper li debbe.</l>
             <l>Ti affidi tu nella insolente plebe?</l>
           </sp>
-          <sp>
+          <sp who="#lamorre">
             <speaker>
               <emph>Lamorre</emph>
             </speaker>
@@ -2942,14 +2961,14 @@
             <l>libero dire... Al tuo marito accanto,</l>
             <l>se il vuoi, mi uccidi; ma mi ascolta pria.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l>Che parli? Oh cielo!... e bramo io forse il sangue</l>
             <l part="I">del mio consorte? e chi 'l può dire?...</l>
           </sp>
-          <sp>
+          <sp who="#lamorre">
             <speaker>
               <emph>Lamorre</emph>
             </speaker>
@@ -2969,7 +2988,7 @@
             <l>entro il vedovo ancor tiepido letto?</l>
             <l part="I">Ahi donna iniqua! e il soffri tu?...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -2978,7 +2997,7 @@
             <l>Presagi orrendi... Ei non mi ascolta; in volto</l>
             <l part="I">gli arde una fiamma inusitata...</l>
           </sp>
-          <sp>
+          <sp who="#lamorre">
             <speaker>
               <emph>Lamorre</emph>
             </speaker>
@@ -2989,13 +3008,13 @@
             <l>Ma tu, che in trono usurpator ti assidi,</l>
             <l>figlio d'iniquità, tu regni, e vivi?</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l>Fero un Nume lo invade!... Oh ciel!... Deh! m'odi...</l>
           </sp>
-          <sp>
+          <sp who="#lamorre">
             <speaker>
               <emph>Lamorre</emph>
             </speaker>
@@ -3009,13 +3028,13 @@
             <l>ecco traditi i traditori... Oh gioia!</l>
             <l>Disgiunti sono,... e straziati,... e morti.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l>Tremar mi fai... Deh!... di chi parli?... Io manco.</l>
           </sp>
-          <sp>
+          <sp who="#lamorre">
             <speaker>
               <emph>Lamorre</emph>
             </speaker>
@@ -3036,7 +3055,7 @@
             <l>del re dei re la giusta orribil ira</l>
             <l part="I">scorre trasfusa...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -3044,7 +3063,7 @@
             <l>del ciel, qual luce or ti rischiara? Ah! taci...</l>
             <l part="I">deh! taci... Io moro...</l>
           </sp>
-          <sp>
+          <sp who="#lamorre">
             <speaker>
               <emph>Lamorre</emph>
             </speaker>
@@ -3069,14 +3088,14 @@
             <l>quivi favola al mondo, onta del trono,</l>
             <l>scherno di tutti, orribilmente vivi...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l>Che sento?... Oimè!... Quale incognita possa</l>
             <l part="I">han sul mio cor quei detti!...</l>
           </sp>
-          <sp>
+          <sp who="#lamorre">
             <speaker>
               <emph>Lamorre</emph>
             </speaker>
@@ -3088,20 +3107,20 @@
             <l>La reggia?... O stanza di dolore e morte,</l>
             <l part="I">io per sempre ti lascio.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="M">Arresta...</l>
           </sp>
-          <sp>
+          <sp who="#lamorre">
             <speaker>
               <emph>Lamorre</emph>
             </speaker>
             <l part="F">O donna,</l>
             <l part="I">di'; consiglio cangiasti?</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -3109,7 +3128,7 @@
             <l>Omai... respiro... appena. Io dunque deggio</l>
             <l part="I">dar di nuocermi il campo?...</l>
           </sp>
-          <sp>
+          <sp who="#lamorre">
             <speaker>
               <emph>Lamorre</emph>
             </speaker>
@@ -3120,7 +3139,7 @@
             <l>quel rio fellon, da stupir quanti iniqui</l>
             <l part="I">abbiavi al mondo.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -3137,7 +3156,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>MARIA</stage>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -3152,7 +3171,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>MARIA, BOTUELLO</stage>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -3160,21 +3179,21 @@
             <l>Ove mi hai tratta? Ancor d'ammenda è tempo:</l>
             <l part="I">vanne, e gli armati tuoi...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
             <l part="F">Ma che? tu cangi</l>
             <l part="I">or consiglio altra volta?</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="F">Io mai non dissi...</l>
             <l part="I">tu primo osasti...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -3194,14 +3213,14 @@
             <l>sì giusto, io sono: ma di te, che fora?</l>
             <l part="I">Arrigo offeso...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="F">Ah! dimmi: or or Lamorre</l>
             <l part="I">non ne andava ad Arrigo?...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -3209,7 +3228,7 @@
             <l>Di quel ministro di menzogna hai forse</l>
             <l part="I">udito i detti ancora?</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -3224,7 +3243,7 @@
             <l>forse è Lamor stromento suo. Va', corri;</l>
             <l part="I">fa' ch'ei parli col re.</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -3246,13 +3265,13 @@
             <l>de' tuoi, vi si appresenta; invan ci andava</l>
             <l part="I">in tuo nome Lamorre...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="F">E che? tant'osi?...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -3261,7 +3280,7 @@
             <l>tu non convinci Arrigo, or che a lui festi</l>
             <l>aperto oltraggio, a mal partito sei.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -3272,27 +3291,27 @@
             <l>Qual lampo orrendo!... Ah!... quale scoppio! Trema,</l>
             <l part="I">s'apre la terra...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
             <l part="F">Oh!... di squarciata nube...</l>
             <l>scende dal ciel... divoratrice... fiamma?...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="I">... Si spalancan le porte!...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
             <l part="F">Oh! qual rimugge</l>
             <l part="I">l'aura infuocata!...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -3302,60 +3321,60 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>LAMORRE, MARIA, BOTUELLO</stage>
-          <sp>
+          <sp who="#lamorre">
             <speaker>
               <emph>Lamorre</emph>
             </speaker>
             <l part="F">E dove,</l>
             <l part="I">dove fuggir potrai?</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="F">Lamor!... che fia?...</l>
             <l part="I">Tu... già ritorni?...</l>
           </sp>
-          <sp>
+          <sp who="#lamorre">
             <speaker>
               <emph>Lamorre</emph>
             </speaker>
             <l part="F">E tu qui stai? Va', corri;</l>
             <l part="I">vedi ucciso il marito...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="F">Oimè!... che sento?...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
             <l part="I">Ucciso il re? come? da chi?...</l>
           </sp>
-          <sp>
+          <sp who="#lamorre">
             <speaker>
               <emph>Lamorre</emph>
             </speaker>
             <l part="F">Fellone,</l>
             <l part="I">da te.</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
             <l part="M">Ch'osi tu dirmi?...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="F">Ucciso Arrigo!...</l>
             <l part="I">Ma, come?... Oh cielo!... Il rio fragor?...</l>
           </sp>
-          <sp>
+          <sp who="#lamorre">
             <speaker>
               <emph>Lamorre</emph>
             </speaker>
@@ -3364,13 +3383,13 @@
             <l>fin da radice, dalla incesa polve:</l>
             <l>ei fra l'alte rovine ha orribil tomba.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="I">Che ascolto!...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -3378,19 +3397,19 @@
             <l>che serbavasi chiusa a mezzo il colle,</l>
             <l>Arrigo, ei stesso, disperato incese.</l>
           </sp>
-          <sp>
+          <sp who="#lamorre">
             <speaker>
               <emph>Lamorre</emph>
             </speaker>
             <l>Te grida ognun, te traditor, Botuello.</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
             <l part="I">Malvagio, avresti?...</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
@@ -3399,14 +3418,14 @@
             <l>grazia, o regina: alta, spedita, e intera</l>
             <l part="I">giustizia chieggo.</l>
           </sp>
-          <sp>
+          <sp who="#lamorre">
             <speaker>
               <emph>Lamorre</emph>
             </speaker>
             <l part="F">Ei non si uccise. Infame</l>
             <l part="I">gente lo uccise...</l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>
               <emph>Maria</emph>
             </speaker>
@@ -3418,14 +3437,14 @@
             <l>di un tal misfatto. Alla vendetta io vivo;</l>
             <l part="I">ed a null'altro.</l>
           </sp>
-          <sp>
+          <sp who="#botuello">
             <speaker>
               <emph>Botuello</emph>
             </speaker>
             <l part="F">Il tuo dolor, regina,</l>
             <l>rispetto io sì; ma per me pur non tremo.</l>
           </sp>
-          <sp>
+          <sp who="#lamorre">
             <speaker>
               <emph>Lamorre</emph>
             </speaker>

--- a/tei/alfieri-merope.xml
+++ b/tei/alfieri-merope.xml
@@ -82,6 +82,28 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="merope">
+            <persName>Merope</persName>
+          </person>
+          <person xml:id="polifonte">
+            <persName>Polifonte</persName>
+          </person>
+          <person xml:id="egisto">
+            <persName>Egisto</persName>
+          </person>
+          <person xml:id="polidoro">
+            <persName>Polidoro</persName>
+          </person>
+          <personGrp xml:id="soldati">
+            <name>Soldati</name>
+          </personGrp>
+          <personGrp xml:id="popolo">
+            <name>Popolo</name>
+          </personGrp>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -136,7 +158,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>MEROPE</stage>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -173,20 +195,20 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>POLIFONTE, MEROPE</stage>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
             <l part="F">T´arresta.</l>
             <l>Perché sfuggirmi? Io gravi cose a dirti...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="I">Io niuna udirne da te voglio....</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -217,7 +239,7 @@
             <l>Qual si può far d´error guerriero ammenda,</l>
             <l part="I">ch´io tutto dì teco non faccia?</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -226,14 +248,14 @@
             <l>del non m´aver tu tolto altro che il regno,</l>
             <l part="I">e il mio consorte, e i figli?...</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
             <l part="F">I figli? In vita</l>
             <l part="I">uno ten resta...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -258,7 +280,7 @@
             <l>cogli occhi tuoi vedesti; con l´iniqua</l>
             <l part="I">tua man palpasti... Ahi scellerato!</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -275,19 +297,19 @@
             <l>spento tu assèvri, e il credo;... almen ti posso,</l>
             <l>se il figlio no, render consorte, e trono...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="I">Che ascolto! Di chi parli?</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
             <l part="F">Di me parlo.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -303,7 +325,7 @@
             <l>quindi, a mi accrescer doglia, osi spiegarmi</l>
             <l part="I">tai sensi rei.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -321,13 +343,13 @@
             <l>letizia può: dunque cacciata in bando</l>
             <l part="I">non hai per anco ogni speranza.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="F">Io?... Nulla...</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -335,7 +357,7 @@
             <l>vedrai, che forse il riavere... il... regno,</l>
             <l part="I">men trista vita a te potria...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -345,7 +367,7 @@
             <l>e il mio consorte oltre ogni trono amai;...</l>
             <l part="I">e abborro te...</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -358,14 +380,14 @@
             <l>Forse anco giusto, mansueto, umano</l>
             <l part="I">nel breve regno ei si mostrò...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="F">Tal era:</l>
             <l part="I">non s´infinse ei, com´altri.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -400,7 +422,7 @@
             <l>puoi, tel confesso, or più gradito forse</l>
             <l part="I">far mio giogo ai Messeni.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -421,7 +443,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>POLIFONTE</stage>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -456,7 +478,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>POLIFONTE, <emph>soldati</emph></stage>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -466,14 +488,14 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>POLIFONTE, EGISTO</stage>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
             <l>Vieni; ti appressa... Oh! giovinetto assai</l>
             <l>tu se´, per uomo di corrucci e sangue.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -481,56 +503,56 @@
             <l>di sangue, e forse, d´innocente sangue:</l>
             <l>mira destino! ed innocente anch´io.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
             <l part="I">Di qual terra se´ tu?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="M">D´Elide.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
             <l part="F">Il nome?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="I">Egisto.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
             <l part="M">Il padre?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Oscuro, ma non servo.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
             <l part="I">A che venivi?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Giovenil talento,</l>
             <l part="I">vaghezza mi spingea.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -539,7 +561,7 @@
             <l>a eccesso tanto. Ove a sperar ti avanzi</l>
             <l>più nulla omai, se ingenuo parli, spera.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -587,14 +609,14 @@
             <l>di man gli strappo il rio pugnal;... trafitto</l>
             <l part="I">nel sangue ei giace.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
             <l part="F">Assai tu se´ valente,</l>
             <l part="I">se veritiero sei.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -611,7 +633,7 @@
             <l>Ivi da´ tuoi, ch´io non fuggia, fui preso;</l>
             <l>e qui m´han tratto. — Io nulla tacqui; il giuro.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -629,7 +651,7 @@
             <l>meglio era assai per te. Forse a salvarti</l>
             <l>sol basterebbe or dell´ucciso il nome.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -652,7 +674,7 @@
             <l>supplizio ebbi in Messene? Ah! tal pensiero</l>
             <l part="I">m´è più che morte duro.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -668,14 +690,14 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>MEROPE, POLIFONTE, EGISTO</stage>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
             <l part="F">Merope?... Che fia?</l>
             <l part="I">Tu vieni a me? Cagion qual mai?...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -684,21 +706,21 @@
             <l>fu dianzi un uomo, e che nell´onda ei poscia</l>
             <l part="I">dall´uccisor scagliato?</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
             <l part="F">È ver, pur troppo:</l>
             <l part="I">e l´uccisor n´era costui...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="F">Che miro?...</l>
             <l>Questi?... Oh qual strana somiglianza io veggo!</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -706,7 +728,7 @@
             <l>mi prema, il sai: pur, se il rimiri o ascolti,</l>
             <l part="I">quasi innocente il credi.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -714,7 +736,7 @@
             <l>di malvagio ei non ha: nobil sembianza...</l>
             <l>ma, oimè! di sangue egli è grondante ancora.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -732,26 +754,26 @@
             <l>fui sforzato adoprar, di man gliel trassi...</l>
             <l>Ah! credi; al sangue non son io cresciuto.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="I">Era l´ucciso un giovinetto?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Ei pari</l>
             <l part="I">m´era d´età.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="M">Che sento?...</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -759,21 +781,21 @@
             <l>non ben dritt´uom, se dice il ver costui.</l>
             <l>Fuggia correndo per romito calle...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l>Anzi, or sovviemmi, ch´ei da pria celava</l>
             <l part="I">col pallio il volto in parte...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="F">Ei s´ascondeva?...</l>
             <l part="I">Fuggia?... — Ma tu, nol conoscervi?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -783,55 +805,55 @@
             <l>ai panni almen, che d´Elide le fogge</l>
             <l part="I">mostravan più che di Messene.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="F">Oh cielo!...</l>
             <l part="I">d´Elide?...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Sì; pari alle mie; ch´io sono</l>
             <l part="I">pur d´Elide...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="M">Tu sei?...</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
             <l part="F">Ma, perché tanto</l>
             <l part="I">bramosa tu, sollecita?...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="F">Che parli?...</l>
             <l part="I">io sollecita?...</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
             <l part="F">Parmi. — In somma, un vile</l>
             <l>stranier, cui svena altro straniero oscuro...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l>Chi sa qual fosse?... È ver... Non è ch´io prenda</l>
             <l part="I">pensier di ciò...</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -840,7 +862,7 @@
             <l>d´ogni affetto, stupore in ciò non poco</l>
             <l part="I">mi arrechi: or che ti cale?...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -851,7 +873,7 @@
             <l>ver l´uccisor, che tanto in sé securo</l>
             <l part="I">stassi... Non so...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -862,7 +884,7 @@
             <l>ma tanto or più, che te dolente io veggio,</l>
             <l part="I">dubbia, e tremante per l´ucciso...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -870,7 +892,7 @@
             <l>io tremante?... Nol son... Ma, gl´infelici</l>
             <l>pietade han tosto delle altrui sventure.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -883,7 +905,7 @@
             <l>non mi vien tolta, a cor gentil qual puossi</l>
             <l>dar pena mai, che la vergogna agguagli?</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -891,7 +913,7 @@
             <l>quasi il tuo dir fa forza... Eppur,... se a luce</l>
             <l part="I">l´ucciso, o il nome almeno...</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -901,14 +923,14 @@
             <l>freno al tuo favellar l´aspetto mio,</l>
             <l part="I">né so perché...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="F">Freno?... Che dici... Io teco</l>
             <l part="I">il lascio.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -921,13 +943,13 @@
             <l>l´indizio primo, che da me non sdegni</l>
             <l part="I">ogni mio dono.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="M">E che?...</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -938,7 +960,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>MEROPE, EGISTO</stage>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -949,7 +971,7 @@
             <l>in cui miei genitori?... oimè!... Non fosti</l>
             <l part="I">madre anco tu? deh! della mia...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -958,51 +980,51 @@
             <l>dunque ancor la tua madre?... E il padre tuo</l>
             <l part="I">d´Elide è pure?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Ei di Messene è figlio.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="I">Di Messene? che ascolto?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Io da bambino</l>
             <l part="I">dir gliel´udiva.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="F">È Polidoro il nome</l>
             <l part="I">forse?...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="M">Cefiso è il nome.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="M">E l´età?...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Molta.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -1010,7 +1032,7 @@
             <l>di quai parenti era in Messene? il sai?</l>
             <l part="I">nobile?...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -1020,7 +1042,7 @@
             <l>vivea felice, del suo aver contento,</l>
             <l part="I">colla consorte e i figli.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -1028,7 +1050,7 @@
             <l>vita chi ´l trasse; e perché mai sua stanza</l>
             <l part="I">cangiava?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -1040,7 +1062,7 @@
             <l>per la sua prole... Oh quante volte io ´l vidi,</l>
             <l part="I">ciò rammentando, piangere!</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -1048,7 +1070,7 @@
             <l>dunque in Messene sei? Tuo padre seco</l>
             <l part="I">ti trafugava in Elide?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -1063,7 +1085,7 @@
             <l>di Messene veder, quasi mia culla,</l>
             <l part="I">poiché il padre vi nacque.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -1073,55 +1095,55 @@
             <l>eppur non è. — Ma dianzi anco dicevi,</l>
             <l part="I">che l´ucciso era d´Elide.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Mel parve.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="I">Ei s´ascondeva?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="M">Sì.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="M">Di cor?...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Superbo.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="I">Di vesti?...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="M">Abbiette.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="M">Fuggitivo?...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -1129,39 +1151,39 @@
             <l>quasi inseguito. e di sospetto pieno</l>
             <l part="I">venìa ver me.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="F">Barbaro, e tu l´hai morto?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="I">Uccider me volea.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="F">Ti disse ei nulla</l>
             <l part="I">morendo?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Io stetti un cotal po´ sovr´esso,</l>
             <l>piangendo... Ei fra i singulti era di morte...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="I">Ahi misero!...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -1170,7 +1192,7 @@
             <l>di pianto, singhiozzando, ei domandava</l>
             <l part="I">la madre sua.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -1178,7 +1200,7 @@
             <l>perfido, e tu pur l´uccidevi? e il corpo</l>
             <l>ne scagliavi nell´onda? Oimè!... Perduto...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -1203,7 +1225,7 @@
             <l>Se tu il compiangi, egli è innocente; il tristo</l>
             <l>io solo il son; deh! fanne in me vendetta.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -1211,7 +1233,7 @@
             <l>Mal mio grado ei mi tragge a pianger seco. —</l>
             <l part="I">Di me il tuo padre ti parlava?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -1219,13 +1241,13 @@
             <l>volte di te, del tuo trafitto sposo,</l>
             <l part="I">de´ figli tuoi narrommi!</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="F">Oh ciel! de´ figli?...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -1234,7 +1256,7 @@
             <l>fremer mi fea qui dianzi. Assai più grato</l>
             <l>m´è in te il rigor, qual sia, che in lui pietade.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -1244,7 +1266,7 @@
             <l>tacer pietade, ecco, s´io ´l miro, o l´odo,</l>
             <l part="I">a lagrimar son risospinta.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -1252,7 +1274,7 @@
             <l>quale hai battaglia? Infra te stessa parli?</l>
             <l part="I">Pietà ti fo? che non l´ascolti?</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -1268,7 +1290,7 @@
             <l>Ma, sei tu certo che il buon vecchio il nome</l>
             <l part="I">mai non cangiasse? di´.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -1282,7 +1304,7 @@
             <l>Ch´egli è Messenio a te svelai; ma nulla</l>
             <l part="I">poteva io mai nasconderti?</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -1300,7 +1322,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>EGISTO</stage>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -1337,7 +1359,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>POLIDORO</stage>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -1380,13 +1402,13 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>MEROPE, POLIDORO</stage>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l part="M">Regina</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -1395,20 +1417,20 @@
             <l>Ma che veggio? se´ tu?... non m´inganno io?...</l>
             <l part="I">Polidoro?</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l part="M">Sì...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="F">Parla: il figlio... Arrechi</l>
             <l part="I">a me tu vita,... o morte?</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -1416,19 +1438,19 @@
             <l>io ti riveggo... Al fine un bacio imprimo</l>
             <l part="I">sulla sacra tua destra.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="F">Il figlio, dimmi...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l part="I">Oh ciel!... — Parlar qui posso?</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -1437,7 +1459,7 @@
             <l>pria del sole, ogni giorno, a lagrimare</l>
             <l part="I">là, di Cresfonte in su la tomba.</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -1445,7 +1467,7 @@
             <l>del miglior re, che fosse mai! Deh, possa</l>
             <l part="I">io là spirar sovr´essa!</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -1456,7 +1478,7 @@
             <l>son, che partisti d´Elide; ed or l´anno,</l>
             <l part="I">che ogni giorno io mi moro.</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -1464,13 +1486,13 @@
             <l>pensa qual pianto è il mio... Tu non ne udisti</l>
             <l part="I">mai dunque?...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="M">No... Ma tu?...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -1489,7 +1511,7 @@
             <l>fossi a te stesso, ogni tuo senso, ogni atto,</l>
             <l part="I">pur ti svelava...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -1498,7 +1520,7 @@
             <l>dove sei, figlio?... E il ver mi narri? ei degno</l>
             <l part="I">crescea degli avi?</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -1518,7 +1540,7 @@
             <l>Ah! mio figliuol, rimembrar non ti posso,</l>
             <l>senza che il pianto dagli occhi trabocchi.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -1528,7 +1550,7 @@
             <l>degg´io saper tuoi pregi tanti, or mentre</l>
             <l part="I">saper non posso ove ti aggiri?</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -1540,7 +1562,7 @@
             <l>per farti udir ch´ei me lasciato avea,</l>
             <l part="I">e ch´io poscia il cercava.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -1574,14 +1596,14 @@
             <l>dall´uccisor, turbò miei spirti; e ancora</l>
             <l part="I">li turba. Era straniero...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l part="F">Ucciso?... Ieri?...</l>
             <l part="I">Straniero?... in riva?... Oh ciel!...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -1589,13 +1611,13 @@
             <l>Dimmi,... forse il mio dubbio?... Oimè!... tu piangi?...</l>
             <l>impallidisci?... in piè ti reggi appena?...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l>— Misero me! che far degg´io? che dirle?...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -1603,14 +1625,14 @@
             <l>che sai? che temi? Udir vogl´io: deh! trammi</l>
             <l part="I">di dubbio; su...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l part="F">Parlar non posso;... e voce...</l>
             <l part="I">mi manca,... e lena...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -1620,25 +1642,25 @@
             <l>se madre omai non sono? Or di´; tu il sai,</l>
             <l part="I">l´ucciso...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l part="M">Io nulla so.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="F">Parla; l´impongo.</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l part="I">... Donna,... conosci... questo... cinto?</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -1646,7 +1668,7 @@
             <l>di fresco sangue egli è stillante?... Oh cielo!</l>
             <l>è di Cresfonte il cinto... Intendo... Io... manco...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -1655,7 +1677,7 @@
             <l>uom fuvvi ucciso; ah! non v´ha dubbio; egli era</l>
             <l part="I">il figlio tuo.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -1671,7 +1693,7 @@
             <l>del fato è sol; deh! mi perdona: io sono</l>
             <l part="I">madre... Ah no! più nol son... Morire...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -1679,7 +1701,7 @@
             <l>misero me! tutto il tuo sdegno... Eppure</l>
             <l part="I">sa il ciel, s´io colpa...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -1700,7 +1722,7 @@
             <l>dato mi fosse! Infra gli amplessi, e il pianto,</l>
             <l>potessi almen... sul tuo corpo morire!...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -1709,7 +1731,7 @@
             <l>a trafiggerti il core... Eppur,... tacerlo</l>
             <l part="I">tel poteva io?</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -1719,7 +1741,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>POLIFONTE, MEROPE, POLIDORO</stage>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -1727,7 +1749,7 @@
             <l>io vengo al suon: che fia? — Chi sei tu, vecchio?</l>
             <l part="I">Che mai recasti?</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -1738,14 +1760,14 @@
             <l>dell´altrui pianto, or godi: al fin del tutto</l>
             <l part="I">orba mi vedi.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
             <l part="F">Ah! — Rimaneati dunque</l>
             <l part="I">quel figlio, che negavi?</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -1763,7 +1785,7 @@
             <l>quando offri pace ed esecrande nozze,</l>
             <l>che in minacciarmi aspro servaggio, e morte?</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -1778,7 +1800,7 @@
             <l>che messaggero?... Oh! non m´è nuovo affatto</l>
             <l part="I">il tuo volto; mi pare...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -1807,7 +1829,7 @@
             <l>al sangue de´ miei re; ma, tal ch´io l´offro,</l>
             <l>questo mio tremolante capo, il prendi.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -1824,7 +1846,7 @@
             <l>non rechi ad arte forse? Or narra, quando,</l>
             <l part="I">dove, come ei morìa..</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -1840,14 +1862,14 @@
             <l>estinto gli abbia; va´. Quei, che trafitto</l>
             <l part="I">fu dianzi, era il mio figlio.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
             <l part="F">E fia ch´io ´l creda?</l>
             <l part="I">eri tu seco? di´. Come?...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -1855,14 +1877,14 @@
             <l>giungeva io tardi! Ah! me con esso ucciso</l>
             <l part="I">avria colui. Più nol vid´io...</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
             <l part="F">Ma come</l>
             <l part="I">il sai tu dunque?</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -1874,7 +1896,7 @@
             <l>stranier, d´Elide... Oh ciel!... così non fosse,</l>
             <l part="I">com´è pur desso!</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -1887,7 +1909,7 @@
             <l>se di crudel desio figlia non era?</l>
             <l part="I">Ah! sì; tuo messo era colui...</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -1904,7 +1926,7 @@
             <l>non l´hai tu stessa interrogato? donna</l>
             <l part="I">del suo destin non ti fec´io?</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -1918,7 +1940,7 @@
             <l>alma spirar fra mille strazi e mille</l>
             <l part="I">fa´ ch´io ´l vegga: ed allora...</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -1930,7 +1952,7 @@
             <l>io stesso voglio: e ten prometto intera</l>
             <l part="I">giustizia in breve...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -1957,7 +1979,7 @@
             <l>io stessa, or or: tu il promettesti; dimmi:</l>
             <l part="I">l´atterrai tu?</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -1977,7 +1999,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>POLIDORO, MEROPE</stage>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -1992,7 +2014,7 @@
             <l>né la vendetta, che pur tanto brami,</l>
             <l part="I">a veder giungerai.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -2005,7 +2027,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>EGISTO</stage>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2029,7 +2051,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>POLIDORO, EGISTO</stage>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -2037,32 +2059,32 @@
             <l>aspettando il tiranno: a quella tomba</l>
             <l part="I">frattanto andrò...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="M">Qual voce!...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l part="F">Ivi i miei voti...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="I">Oh ciel! fia ver? Quel vecchio...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l part="F">Ivi mi giova</l>
             <l part="I">versare il pianto...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2070,19 +2092,19 @@
             <l>suo crin; suoi passi; i panni suoi... Deh, volgi</l>
             <l part="I">ver me, buon vecchio...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l part="M">Oh! chi mi chiama?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Ah padre!</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -2090,7 +2112,7 @@
             <l>ti trovo io mai! deh! ti nascondi. Io tremo...</l>
             <l part="I">misero te!... Perduto sei.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2102,7 +2124,7 @@
             <l>un figlio empio son io; tanto non merto:</l>
             <l part="I">troppo in lasciarti errai.</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -2111,7 +2133,7 @@
             <l>fuggi... Tu sei... — Grave periglio è il tuo...</l>
             <l part="I">come in Messene, in questa reggia?...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2125,27 +2147,27 @@
             <l>benché omicida, io sono... Oimè! qual figlio</l>
             <l part="I">in me ritrovi!</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l part="F">Oh inaspettato evento!</l>
             <l>tu forse ucciso hai lo stranier, che in riva?...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l>L´uccisi io, sì; ma in mia difesa, il giuro.</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l>Oh fatal sorte!... Oh mie cure paterne!</l>
             <l>Deh, dimmi;... osserva, se nessun qui c´ode.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2164,14 +2186,14 @@
             <l>madre, che fa?... piange di me;... ben l´odo;...</l>
             <l part="I">la veggio;... e piango...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l part="F">Oh figlio!... Or non sforzarmi</l>
             <l>a lagrimar... Tempo non è... Vorrei...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2189,7 +2211,7 @@
             <l>quindi sperar mi lice ancor perdono</l>
             <l part="I">del mio delitto involontario.</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -2199,7 +2221,7 @@
             <l>che fo?... che dirgli?... e che tacergli? — Ascondi</l>
             <l part="I">te stesso almeno per brev´ora...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2207,7 +2229,7 @@
             <l>il tenterei; cercato io fora; imposto</l>
             <l>m´è l´aspettare. Ma, perché celarmi?...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -2219,7 +2241,7 @@
             <l>morte; uccisor dell´unico suo figlio</l>
             <l part="I">crede Merope te.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2229,25 +2251,25 @@
             <l>perfido cor l´ira tua giusta appaga</l>
             <l>Qual morte, e strazio, e infamia a me non dessi?</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l>Ma,... del suo figlio... l´uccisor... non sei.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="I">Dunque?</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l part="M">Nol sei...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2255,58 +2277,58 @@
             <l>priva è del figlio: al suo dolor sollievo</l>
             <l part="I">fia l´uccidermi; e venga...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l part="F">Ah no!... Del figlio</l>
             <l part="I">priva non è.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Ma quel ch´io uccisi... — Io voglio</l>
             <l part="I">a ogni costo vederla; udirla...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l part="F">Ah!... Fuggi...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="I">Né il vo´; né il posso.</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l part="M">O almen...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Ma s´io non sono...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l>Tu sei... quel figlio, ch´ella estinto piange.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l>Io? che mi narri? io son?... Non mi sei padre?</l>
             <l part="I">Sangue son io d´Alcide?</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -2316,7 +2338,7 @@
             <l>sotto il nome d´Egisto; io ti serbava,</l>
             <l>misero me! forse a peggior destino.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2329,7 +2351,7 @@
             <l>or rammento, or comprendo. Il nome tuo</l>
             <l part="I">non è Cefiso.</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -2340,7 +2362,7 @@
             <l>l´ora passa, e fra poco... Ah! s´io potessi</l>
             <l part="I">dire a Merope in tempo...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2356,7 +2378,7 @@
             <l>forse atterrir mi lascierò da un vile</l>
             <l part="I">tiranno?...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -2371,27 +2393,27 @@
             <l>ad incontrar Merope volo: io forse</l>
             <l part="I">ancor potrò... Deh! s´io giungessi!...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Io veggio</l>
             <l part="I">venir ver noi soldati...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l part="F">Oimè! che miro?</l>
             <l>Merope vien con Polifonte... Ahi lasso!...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l>E a lor vien dopo un numeroso stuolo...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -2402,7 +2424,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>POLIFONTE, MEROPE, EGISTO, POLIDORO <emph>popolo, soldati</emph></stage>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -2410,7 +2432,7 @@
             <l>uccisor del tuo figlio. Avvinto ei sia</l>
             <l>d´aspre catene; e a un sol suo cenno, ei cada.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -2428,7 +2450,7 @@
             <l>mille vo´ dargli io stessa orride morti. —</l>
             <l>Ahi lassa! e ciò ti renderà il tuo figlio?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2440,7 +2462,7 @@
             <l>Giusto è il tuo sdegno... Eppur, sai ch´io non reo.</l>
             <l>e degno or dianzi di pietà, ti parvi.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -2452,7 +2474,7 @@
             <l>del suo sangue si appaghino;... e la mia;</l>
             <l part="I">ch´io seguirolli in breve.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -2470,27 +2492,27 @@
             <l>Merope or tosto si obbedisca: è poco</l>
             <l>una vittima sola a dolor tanto.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l>Ah! di Cresfonte all´ombra altra si debbe</l>
             <l part="I">vittima omai.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="M">Che parli? Andiam...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l part="F">Deh!... Prego;</l>
             <l>indugia alquanto... Io vorrei dirti... Ah! m´odi...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -2500,7 +2522,7 @@
             <l>t´incresce? E che? dell´uccisor ti duole?...</l>
             <l>Pietà ne senti?... Osi pregar, che il colpo?...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -2508,14 +2530,14 @@
             <l>Udir più a lungo or da lui stesso dei</l>
             <l part="I">cose assai del tuo figlio.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
             <l part="F">Costui dunque</l>
             <l part="I">il conoscea?...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -2525,14 +2547,14 @@
             <l>e non mel dice, grondante di sangue,</l>
             <l>questo suo cinto, che tu in man m´hai posto?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l>Quel cinto è mio, tel giuro. Dal mio fianco</l>
             <l part="I">cadea sfibbiato...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -2540,7 +2562,7 @@
             <l>simile a quello... E quell´ucciso... forse</l>
             <l part="I">non era il figlio tuo...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -2551,14 +2573,14 @@
             <l>vuoi l´assassin del mio figliuolo, e fingi</l>
             <l part="I">volerlo spento? e mezzi tali?...</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
             <l part="F">O donna,</l>
             <l>tu pel dolor vaneggi. Or, chi non vede?...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -2571,111 +2593,111 @@
             <l>tosto ei si appaghi. — A me quel ferro; io stessa,...</l>
             <l part="I">io sì, svenarlo or di mia mano...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Il petto</l>
             <l part="I">eccoti ignudo. Ahi madre!</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l part="M">Arresta...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="F">Muori.</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l part="I">Deh! ferma...</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
             <l part="M">Osi tu tanto?</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="F">Iniquo... O vista!</l>
             <l>tu piangi, e tremi?... Ed io, ferir nol posso!...</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
             <l>Qual havvi arcano? Or via, vecchio, favella.</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l part="I">Deh! per pietà...</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
             <l part="M">Parla.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="M">Ch´io ´l fera...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l part="F">È questi...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="I">Chi mai?</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
             <l part="M">Su, svela...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l part="M">È... il figlio mio.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="F">Deh! come?...</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
             <l part="I">Costui tuo figlio?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="M">Ei mi fu padre.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -2683,76 +2705,76 @@
             <l>ma, s´anco il fosse, il mio figliuol mi ha spento.</l>
             <l part="I">Muori.</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l part="M">Ah! ferma... È il tuo figlio.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="M">O madre...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="F">Oh cielo!</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
             <l part="I">Costui?...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l part="M">Sei madre; salvalo.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="F">Il mio figlio!...</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
             <l>Qual tradimento è questo? Olà, soldati...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l>Io ti son scudo, o figlio... Ah! il cor mel dice;</l>
             <l part="I">son madre ancor...</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
             <l part="M">Soldati...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="F">A lui non giunge</l>
             <l part="I">ferro, che me pria non trafigga...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">O madre,</l>
             <l part="I">fra mie braccia ti stringo!</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -2762,14 +2784,14 @@
             <l>sarà suo figlio? e il crederò? Soldati,</l>
             <l part="I">si uccida tosto.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="F">Infame tu... Ma salvo,</l>
             <l part="I">finch´io respiro, è il figlio.</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -2778,7 +2800,7 @@
             <l>l´error da ciò. Messeni, a voi son noto.</l>
             <l part="I">io spergiuro non sono...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2787,19 +2809,19 @@
             <l>del vostro re son io. Tra voi non havvi</l>
             <l part="I">guerrier de´ suoi?...</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
             <l part="F">Mente costui. Si uccida...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="I">Me pria... No, mai...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2807,7 +2829,7 @@
             <l>un brando, un brando a me si porga: ai colpi</l>
             <l part="I">riconoscer farommi.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -2825,7 +2847,7 @@
             <l>questo figlio mi avanza; altro non chieggo;</l>
             <l part="I">deh! tu mel dona; deh!...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -2837,7 +2859,7 @@
             <l>con pompa tanta, sperandolo estinto;</l>
             <l part="I">ei vive, e ucciso il vuoi?</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -2856,7 +2878,7 @@
             <l>il rendo a te: quindi piegarti io spero</l>
             <l part="I">alle da me proposte nozze...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2865,7 +2887,7 @@
             <l>contaminar tu il talamo?... Su, fammi</l>
             <l part="I">tosto svenar; minor fia ´l danno...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -2873,7 +2895,7 @@
             <l>non l´irritare omai. Chi sa, qual volge</l>
             <l part="I">crudo pensier?... Deh! Polifonte...</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -2886,13 +2908,13 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>POLIFONTE, MEROPE, POLIDORO, EGISTO, <emph>guardie</emph></stage>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="I">Che mai gli disse?... Io tremo... Oh cielo!</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -2909,13 +2931,13 @@
             <l>a me la mano; o qui, su gli occhi tuoi,</l>
             <l part="I">ucciso io stesso avrò costui.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="F">Deh!... m´odi...</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -2928,7 +2950,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>MEROPE, POLIDORO, EGISTO, <emph>guardie nel fondo della scena</emph></stage>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -2939,7 +2961,7 @@
             <l>duri patti a me il rendono?... Che dico?</l>
             <l>dolce ogni patto, che il figliuol mi rende.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2947,7 +2969,7 @@
             <l>ch´io perissi bambino! O madre, or dove,</l>
             <l part="I">dove ti traggo!...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -2963,19 +2985,19 @@
             <l>madre, e non altro. Di te stessa orrendo</l>
             <l>sagrificio tu fai; ma il fai pel figlio...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="I">Che non farei per lui? Qual dubbio?...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Ah madre!...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -2988,13 +3010,13 @@
             <l>E se il vedran, che fia! Nulla lor manca,</l>
             <l part="I">che un capo...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="M">Ed io ´l sarò.</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -3013,7 +3035,7 @@
             <l>dalla misera madre per te presi</l>
             <l part="I">romper ti cale.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -3022,7 +3044,7 @@
             <l>occorre un ferro. Altro più allor non odo,</l>
             <l part="I">che il padre estinto, e il valor mio.</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -3040,13 +3062,13 @@
             <l>ma inoltre n´ho di padre il senno, e lunga</l>
             <l part="I">esperienza: in me si creda.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Oh padre!...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -3057,14 +3079,14 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>MEROPE, EGISTO</stage>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l>Ch´io d´abbracciarti almeno, e di baciarti</l>
             <l part="I">mi sazi!...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -3077,7 +3099,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>POLIFONTE, <emph>soldati</emph></stage>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -3093,7 +3115,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>POLIFONTE</stage>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -3125,7 +3147,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>MEROPE, EGISTO, POLIDORO, POLIFONTE, <emph>soldati, popolo, sacerdoti, vittima</emph></stage>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -3140,7 +3162,7 @@
             <l>suo prisco stato; e che sublime ammenda</l>
             <l>io fo in tal guisa d´ogni antico oltraggio.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -3149,7 +3171,7 @@
             <l>E a qual prezzo la vita del mio figlio</l>
             <l part="I">mi vendi?...</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -3177,7 +3199,7 @@
             <l>Ecco or colui, ch´ella suo figlio noma;</l>
             <l>eccolo: udite in quale aspetto ei viene.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -3185,14 +3207,14 @@
             <l>a tal ridotto... Ahi traditor! chi ´l trasse</l>
             <l part="I">a così infame stato?</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l part="F">O figlio, affrena</l>
             <l part="I">il tuo furor...</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -3224,7 +3246,7 @@
             <l>che nullo, o tristo saggio ha di sé dato;</l>
             <l>che ignaro appieno d´ogni pubblic´arte?...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -3232,7 +3254,7 @@
             <l>no, dell´arti d´Alcide: e prova farne</l>
             <l part="I">saprei...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -3240,7 +3262,7 @@
             <l>satelliti suoi son troppi: ogni uomo,</l>
             <l part="I">vedi, qui muto è dal terrore.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -3256,7 +3278,7 @@
             <l>da te soltanto io pendo: ebbi il tuo assenso</l>
             <l>pur dianzi già; ritormel forse or vuoi?</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -3272,13 +3294,13 @@
             <l>O voi, già un dì, sudditi fidi al padre,</l>
             <l part="I">a tal ridotti or ci vedreste?</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
             <l part="F">Or via...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -3296,7 +3318,7 @@
             <l>vedrai tra breve: in mente accogli intanto,</l>
             <l>duri a serbar, questi suoi detti estremi.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -3305,7 +3327,7 @@
             <l>non m´è il servir. Tu vivi, o madre; e lascia</l>
             <l>che degno almen dell´alto padre io pera.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
@@ -3321,7 +3343,7 @@
             <l>la tua, per cenno d´immolare ai Numi</l>
             <l part="I">la vittima.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -3332,13 +3354,13 @@
             <l>Ahi!... dove fuggo?... Ove son io?... Pietade,</l>
             <l part="I">Messeni...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="M">Oh rabbia! E soffrirò?...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -3346,70 +3368,70 @@
             <l>Già già il tiranno l´efferato sguardo</l>
             <l part="I">su te...</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
             <l part="F">Non più. Donna, una volta ancora</l>
             <l part="I">te l´offro: ecco mia destra.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="F">Oh ciel!... La mia...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l>Muori.<note resp="#aut" place="foot" anchored="true">Strappata di mano al sacerdote la scure, si avventa a Polifonte, e lo atterra d´un colpo.</note> La destra a te dovuta, è questa.</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l part="I">Oh ardir!</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="M">Che veggio?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="M">Muori.<note resp="#aut" place="foot" anchored="true">Raddoppia il colpo.</note></l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>
               <emph>Polifonte</emph>
             </speaker>
             <l part="F">Oh tradimento!</l>
             <l part="I">Soldati... Io moro...</l>
           </sp>
-          <sp>
+          <sp who="#soldati">
             <speaker>
               <emph>SOLDATI</emph>
             </speaker>
             <l part="F">È un traditor; si uccida.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>POPOLO</emph>
             </speaker>
             <l part="I">Ah! no; si salvi; è il nostro re.<note resp="#aut" place="foot" anchored="true">Il popolo si azzuffa co´soldati.</note></l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="F">Il mio figlio</l>
             <l part="I">egli è, vel giuro; è il vostro re...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -3417,26 +3439,26 @@
             <l>prova darovvi io stesso: e brandi, ed aste,</l>
             <l>sparir farà questa mia sola scure.<note resp="#aut" place="foot" anchored="true">Si slancia fra i combattenti.</note></l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="I">Messeni, ah! difendetelo...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l part="F">Respiro...</l>
             <l>Ecco già in rotta del fellon gli sgherri...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="I">Deh! riedi, o figlio... Ahi lassa me!...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -3446,7 +3468,7 @@
             <l>riedi: sì addentro or non scagliarti; ah! lascia,</l>
             <l part="I">che per te mora io solo...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -3456,7 +3478,7 @@
             <l>da me svenato; i cittadini in folla</l>
             <l part="I">crescon vie più...</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -3465,7 +3487,7 @@
             <l>alla voce, agli sguardi, alle inaudite</l>
             <l>alte sue prove, ed al mio immenso amore?...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -3477,7 +3499,7 @@
             <l>fede al mio dire. Io lo sottrassi, io stesso;</l>
             <l part="I">io l´educai...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -3492,26 +3514,26 @@
             <l>e in man di voi: se ingiustamente il sangue</l>
             <l>io versai di costoro, il mio si versi.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>POPOLO</emph>
             </speaker>
             <l>Oh generoso! Oh bello! È in tutto il padre.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
             <l part="I">Cresfonte in lui rivive...</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>POPOLO</emph>
             </speaker>
             <l part="F">Oh lieta speme!</l>
             <l part="I">Re nostro vero...</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
@@ -3519,7 +3541,7 @@
             <l>prostrato ai piedi, alto a lui renda omaggio!</l>
             <l part="I">e meco tutti or vi atterrate.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>POPOLO</emph>
             </speaker>
@@ -3527,21 +3549,21 @@
             <l>fé ti giuriam noi tutti: al par che prode</l>
             <l>giusto sarai: mentir non può il tuo aspetto.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l>D´esserlo giuro. Ma, s´io pur nol fossi,</l>
             <l>ch´io pur svenato, come costui, cada.</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>
               <emph>Polidoro</emph>
             </speaker>
             <l>Deh! che non muoio in questo dì! più lieto</l>
             <l part="I">mai non morrei.</l>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>
               <emph>Merope</emph>
             </speaker>
@@ -3549,7 +3571,7 @@
             <l>ma oimè!... mi sento... dalla troppa... gioia...</l>
             <l part="I">mancare...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>

--- a/tei/alfieri-mirra.xml
+++ b/tei/alfieri-mirra.xml
@@ -82,6 +82,28 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="cecri">
+            <persName>Cecri</persName>
+          </person>
+          <person xml:id="euriclea">
+            <persName>Euriclea</persName>
+          </person>
+          <person xml:id="ciniro">
+            <persName>Ciniro</persName>
+          </person>
+          <person xml:id="pereo">
+            <persName>Pereo</persName>
+          </person>
+          <person xml:id="mirra">
+            <persName>Mirra</persName>
+          </person>
+          <personGrp xml:id="coro">
+            <name>Coro</name>
+          </personGrp>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -163,7 +185,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>CECRI, EURICLEA</stage>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
@@ -174,7 +196,7 @@
             <l>Già l´afflitto tuo volto, e i mal repressi</l>
             <l part="I">tuoi sospiri, mi annunziano...</l>
           </sp>
-          <sp>
+          <sp who="#euriclea">
             <speaker>
               <emph>Euriclea</emph>
             </speaker>
@@ -186,7 +208,7 @@
             <l>tu madre, il puoi. Quindi a te vengo; e prego,</l>
             <l part="I">che udir mi vogli.</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
@@ -202,7 +224,7 @@
             <l>niega ella il duol; mentre di giorno in giorno</l>
             <l part="I">io dal dolor strugger la veggio.</l>
           </sp>
-          <sp>
+          <sp who="#euriclea">
             <speaker>
               <emph>Euriclea</emph>
             </speaker>
@@ -219,7 +241,7 @@
             <l>e contra me si adira... Ma pur, meco</l>
             <l>spesso, malgrado suo, prorompe in pianto.</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
@@ -253,7 +275,7 @@
             <l>la travaglia ogni dì?... Squarciar mi sento</l>
             <l>a brani a brani a una tal vista il core.</l>
           </sp>
-          <sp>
+          <sp who="#euriclea">
             <speaker>
               <emph>Euriclea</emph>
             </speaker>
@@ -307,7 +329,7 @@
             <l>va la donzella, accertati. — Sei madre;</l>
             <l part="I">nulla più dico.</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
@@ -321,7 +343,7 @@
             <l>altra fiamma, perché scegliea fra tanti</l>
             <l part="I">ella stessa Perèo?</l>
           </sp>
-          <sp>
+          <sp who="#euriclea">
             <speaker>
               <emph>Euriclea</emph>
             </speaker>
@@ -358,7 +380,7 @@
             <l>Almen così, struggersi a lento fuoco</l>
             <l part="I">non la vedrei!...</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
@@ -369,7 +391,7 @@
             <l>Colà verrò, tosto che asciutto il ciglio</l>
             <l>io m´abbia, e in calma ricomposto il volto.</l>
           </sp>
-          <sp>
+          <sp who="#euriclea">
             <speaker>
               <emph>Euriclea</emph>
             </speaker>
@@ -382,7 +404,7 @@
             <l>deh! non tardare; or, quanto indugi meno,</l>
             <l>più ben farai...</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
@@ -400,7 +422,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>CECRI</stage>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
@@ -423,7 +445,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>CINIRO, CECRI</stage>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -438,7 +460,7 @@
             <l>la gloria mia pur anco, ov´io non vegga</l>
             <l>felice appien la nostra unica prole.</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
@@ -450,7 +472,7 @@
             <l>noi ci estimiam beati: ella non puote</l>
             <l part="I">quindi, no mai, pentirsene.</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -491,7 +513,7 @@
             <l>dorria, che a lui. Ma pur, se il vuole il fato,</l>
             <l>breve omai resta ad arretrarci l´ora.</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
@@ -506,7 +528,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>CINIRO, PEREO</stage>
-          <sp>
+          <sp who="#pereo">
             <speaker>
               <emph>Pereo</emph>
             </speaker>
@@ -514,7 +536,7 @@
             <l>spero, o re, non è l´ora, in cui chiamarti</l>
             <l part="I">padre amato potrò...</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -534,7 +556,7 @@
             <l>tue veramente, onde maggior saresti</l>
             <l part="I">d´ogni re sempre, anco privato...</l>
           </sp>
-          <sp>
+          <sp who="#pereo">
             <speaker>
               <emph>Pereo</emph>
             </speaker>
@@ -550,7 +572,7 @@
             <l>senso dovizia aver degg´io: ne accetto</l>
             <l part="I">da te l´augurio.</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -562,7 +584,7 @@
             <l>se indiscreto il mio chieder non è troppo,...</l>
             <l part="I">sei parimente riamato?</l>
           </sp>
-          <sp>
+          <sp who="#pereo">
             <speaker>
               <emph>Pereo</emph>
             </speaker>
@@ -606,7 +628,7 @@
             <l>all´imenèo prefiggere... Deh! fossi</l>
             <l>vittima almen di dolor tanto io solo!</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -622,7 +644,7 @@
             <l>ma, se pur onta, o timor di donzella...</l>
             <l>se Mirra, in somma, a torto or si pentisse?...</l>
           </sp>
-          <sp>
+          <sp who="#pereo">
             <speaker>
               <emph>Pereo</emph>
             </speaker>
@@ -638,7 +660,7 @@
             <l>del mio pianger foss´ella!... A me fia dolce</l>
             <l>anco il morir, pur ch´ella sia felice.</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -660,14 +682,14 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>MIRRA, PEREO</stage>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
             <l>Ei con Perèo mi lascia?... Oh rio cimento!</l>
             <l part="I">vieppiù il cor mi si squarcia...</l>
           </sp>
-          <sp>
+          <sp who="#pereo">
             <speaker>
               <emph>Pereo</emph>
             </speaker>
@@ -702,7 +724,7 @@
             <l>come mertai tua scelta? e s´io il divenni</l>
             <l part="I">dopo, deh! dimmi; in che ti spiacqui?</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -724,7 +746,7 @@
             <l>quell´ostinato interrogar d´altrui,</l>
             <l>senza chiarirne il fonte, in noi l´addoppia.</l>
           </sp>
-          <sp>
+          <sp who="#pereo">
             <speaker>
               <emph>Pereo</emph>
             </speaker>
@@ -746,7 +768,7 @@
             <l>e ch´io forse mertavati, tel debbo</l>
             <l part="I">provare or, ricusandoti...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -778,7 +800,7 @@
             <l>ch´esser mai d´altri non vogl´io, che tua.</l>
             <l part="I">Che ti poss´io più dire?</l>
           </sp>
-          <sp>
+          <sp who="#pereo">
             <speaker>
               <emph>Pereo</emph>
             </speaker>
@@ -789,7 +811,7 @@
             <l>non sdegni adunque? e non ten penti? e nullo</l>
             <l part="I">indugio omai?...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -798,7 +820,7 @@
             <l>daremo ai venti, e lascerem per sempre</l>
             <l part="I">dietro noi queste rive.</l>
           </sp>
-          <sp>
+          <sp who="#pereo">
             <speaker>
               <emph>Pereo</emph>
             </speaker>
@@ -808,14 +830,14 @@
             <l>tanto t´incresce abbandonare; e vuoi</l>
             <l part="I">ratta così, per sempre?...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
             <l part="F">Il vo´;... per sempre</l>
             <l>abbandonarli;... e morir... di dolore...</l>
           </sp>
-          <sp>
+          <sp who="#pereo">
             <speaker>
               <emph>Pereo</emph>
             </speaker>
@@ -824,7 +846,7 @@
             <l>ch´io non sarò del tuo morir stromento;</l>
             <l part="I">no, mai; del mio bensì...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -834,7 +856,7 @@
             <l>al dolor preparata, assai men crudo</l>
             <l part="I">mi fia il partir: sollievo in te...</l>
           </sp>
-          <sp>
+          <sp who="#pereo">
             <speaker>
               <emph>Pereo</emph>
             </speaker>
@@ -852,7 +874,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>MIRRA</stage>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -865,21 +887,21 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>EURICLEA, MIRRA</stage>
-          <sp>
+          <sp who="#euriclea">
             <speaker>
               <emph>Euriclea</emph>
             </speaker>
             <l>Ove sì ratti i passi tuoi rivolgi,</l>
             <l part="I">o mia dolce figliuola?</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
             <l part="F">Ove conforto,</l>
             <l>se non in te, ritrovo?... A te venìa...</l>
           </sp>
-          <sp>
+          <sp who="#euriclea">
             <speaker>
               <emph>Euriclea</emph>
             </speaker>
@@ -891,7 +913,7 @@
             <l>liberamente il tuo pianto abbia sfogo</l>
             <l part="I">entro il mio seno.</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -899,14 +921,14 @@
             <l>io posso teco, almeno pianger... Sento</l>
             <l>scoppiarmi il cor dal pianto rattenuto...</l>
           </sp>
-          <sp>
+          <sp who="#euriclea">
             <speaker>
               <emph>Euriclea</emph>
             </speaker>
             <l>E in tale stato, o figlia, ognor venirne</l>
             <l part="I">all´imenèo persisti?</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -916,7 +938,7 @@
             <l>ed in non molto... Morire, morire,</l>
             <l>null´altro io bramo;... e sol morire, io merto.</l>
           </sp>
-          <sp>
+          <sp who="#euriclea">
             <speaker>
               <emph>Euriclea</emph>
             </speaker>
@@ -924,14 +946,14 @@
             <l>squarciar non ponno in sì barbara guisa,</l>
             <l part="I">fuor che furie d´amor...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
             <l part="F">Ch´osi tu dirmi?</l>
             <l part="I">qual ria menzogna?...</l>
           </sp>
-          <sp>
+          <sp who="#euriclea">
             <speaker>
               <emph>Euriclea</emph>
             </speaker>
@@ -943,14 +965,14 @@
             <l>Né so ben, s´io mel creda; anzi, alla madre</l>
             <l>io fortemente lo negai pur sempre.</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
             <l>Che sento? oh ciel! ne sospettava forse</l>
             <l part="I">anch´essa?...</l>
           </sp>
-          <sp>
+          <sp who="#euriclea">
             <speaker>
               <emph>Euriclea</emph>
             </speaker>
@@ -966,7 +988,7 @@
             <l>innanzi al santo simulacro, il nome</l>
             <l part="I">tuo pronunziava...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -975,7 +997,7 @@
             <l>della implacabil Dea... Che dico?... Ahi lassa!...</l>
             <l part="I">inorridisco,... tremo...</l>
           </sp>
-          <sp>
+          <sp who="#euriclea">
             <speaker>
               <emph>Euriclea</emph>
             </speaker>
@@ -992,7 +1014,7 @@
             <l>dal terrore arricciarmisi di nuovo,</l>
             <l part="I">in ciò narrar, le chiome.</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -1007,13 +1029,13 @@
             <l>tu sola il puoi, trammi d´angoscia: è lento,</l>
             <l>è lento troppo, ancor che immenso, il duolo.</l>
           </sp>
-          <sp>
+          <sp who="#euriclea">
             <speaker>
               <emph>Euriclea</emph>
             </speaker>
             <l part="I">Tremar mi fai... Che mai poss´io?</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -1025,14 +1047,14 @@
             <l>scampar non posso: amor, pietà verace,</l>
             <l>fia ´l procacciarmi morte; a te la chieggio...</l>
           </sp>
-          <sp>
+          <sp who="#euriclea">
             <speaker>
               <emph>Euriclea</emph>
             </speaker>
             <l>Oh cielo!... a me?... Mi manca la parola,...</l>
             <l part="I">la lena,... i sensi...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -1048,14 +1070,14 @@
             <l>dal dolore,... nol so: deh! mi perdona;</l>
             <l>deh! madre mia seconda, in te ritorna.</l>
           </sp>
-          <sp>
+          <sp who="#euriclea">
             <speaker>
               <emph>Euriclea</emph>
             </speaker>
             <l>... Oh figlia! oh figlia!... A me la morte chiedi?</l>
             <l part="I">la morte a me?</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -1065,7 +1087,7 @@
             <l>non vuoi vedermi? in breve udrai tu dunque,</l>
             <l>ch´io né pur viva pervenni in Epìro.</l>
           </sp>
-          <sp>
+          <sp who="#euriclea">
             <speaker>
               <emph>Euriclea</emph>
             </speaker>
@@ -1073,7 +1095,7 @@
             <l>presumi adunque. Ai genitori il tutto</l>
             <l part="I">corro a narrar...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -1101,7 +1123,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>CINIRO, CECRI</stage>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
@@ -1111,7 +1133,7 @@
             <l>certezza io n´ebbi; e andando ella a tai nozze,</l>
             <l>corre (pur troppo!) ad infallibil morte.</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -1125,7 +1147,7 @@
             <l>impossibile; a noi, che di noi stessi,</l>
             <l>non che di sé, la femmo arbitra e donna.</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
@@ -1139,21 +1161,21 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>MIRRA, CECRI, CINIRO</stage>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
             <l part="F">Amata figlia,</l>
             <l>deh! vieni a noi; deh! vieni.</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
             <l part="F">Oh ciel! che veggo?</l>
             <l part="I">anco il padre!...</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -1190,7 +1212,7 @@
             <l>questo presente tuo voler, lo svela,</l>
             <l part="I">come a fratelli, a noi.</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
@@ -1199,21 +1221,21 @@
             <l>più amoroso, più tenero, più mite</l>
             <l part="I">parlar, di questo.</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
             <l part="F">... Havvi tormento al mondo,</l>
             <l part="I">che al mio si agguagli?...</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
             <l part="F">Ma, che fia? tu parli</l>
             <l part="I">sospirando infra te?</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -1221,13 +1243,13 @@
             <l>che il tuo cor ci favelli: altro linguaggio</l>
             <l>non adopriam noi teco. — Or via; rispondi.</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
             <l part="I">... Signor...</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -1235,34 +1257,34 @@
             <l>signor; padre son io: puoi tu chiamarmi</l>
             <l part="I">con altro nome, o figlia?</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
             <l part="F">O Mirra, è questo</l>
             <l part="I">l´ultimo sforzo. — Alma, coraggio...</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
             <l part="F">Oh cielo!</l>
             <l part="I">Pallor di morte in volto...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
             <l part="M">A me?...</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
             <l part="F">Ma donde,</l>
             <l part="I">donde il tremar? del padre tuo?...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -1305,21 +1327,21 @@
             <l>ch´io, suggendo tue lagrime, conceda</l>
             <l part="I">un breve sfogo anco alle mie?...</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
             <l part="F">Diletta</l>
             <l>figlia, chi può non piangere al tuo pianto?...</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
             <l>Squarciare il cor mi sento da´ suoi detti...</l>
             <l part="I">Ma in somma pur, che far si dee?...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -1344,14 +1366,14 @@
             <l>l´ultima prova. Oggi a Perèo son io</l>
             <l>sposa, o questo esser demmi il giorno estremo.</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
             <l>Che sento?... Oh figlia!... E alle ferali nozze</l>
             <l part="I">ostinarti tu vuoi?...</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -1359,7 +1381,7 @@
             <l>Perèo non ami; e mal tuo grado, indarno,</l>
             <l part="I">vuoi darti a lui...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -1386,21 +1408,21 @@
             <l>vengo in breve alle nozze: e voi, beati</l>
             <l part="I">ve ne terrete un giorno.</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
             <l part="F">Oh rara figlia!</l>
             <l part="I">quanti mai pregi aduni!</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
             <l part="F">Un po´ mi acqueta</l>
             <l part="I">il tuo parlar; ma tremo...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -1410,20 +1432,20 @@
             <l>(ove il voglian gli Dei) pur che soccorso</l>
             <l part="I">voi men prestiate.</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
             <l part="M">E qual soccorso?</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
             <l part="F">Ah! parla.</l>
             <l part="I">Tutto faremo.</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -1441,7 +1463,7 @@
             <l>generoso mio sforzo, e vita, e pace,</l>
             <l part="I">e letizia dovrò.</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
@@ -1449,7 +1471,7 @@
             <l>parli? e il vuoi tosto; e in un lo temi e il brami?</l>
             <l part="I">Ma qual fia mai?...</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -1458,7 +1480,7 @@
             <l>irne al padre dovrai; ma intanto pria</l>
             <l>lieta con noi qui lungamente ancora....</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -1493,13 +1515,13 @@
             <l>ed anco (oh cielo! io fremo) il destin vostro;</l>
             <l>dal mio partir, tutto, purtroppo! or pende.</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
             <l part="I">Oh figlia!...</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -1510,7 +1532,7 @@
             <l>E tu, dolce consorte, in pianto muta</l>
             <l part="I">ti stai?... Consenti al suo desio?</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
@@ -1522,7 +1544,7 @@
             <l>Ma, poich´è tale il suo strano pensiero,</l>
             <l part="I">pur ch´ella viva, seguasi.</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -1539,13 +1561,13 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>CINIRO, CECRI</stage>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
             <l part="I">Miseri noi! misera figlia!</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -1553,14 +1575,14 @@
             <l>di vederla ogni giorno più infelice,</l>
             <l>no, non mi basta il core. Invan l´opporci...</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
             <l>Oh sposo!... io tremo, che ai nostri occhi appena</l>
             <l>toltasi, il fero suo dolor la uccida.</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -1568,7 +1590,7 @@
             <l>par che la invasi orribilmente alcuna</l>
             <l part="I">sovrumana possanza.</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
@@ -1579,14 +1601,14 @@
             <l>Ma, la mia figlia era innocente; io sola,</l>
             <l part="I">l´audace io fui; la iniqua, io sola...</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
             <l part="F">Oh cielo!</l>
             <l part="I">che osasti mai contro alla Dea?...</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
@@ -1606,13 +1628,13 @@
             <l>che non mai tratta per l´addietro in Cipro</l>
             <l>dal sacro culto della Dea ne fosse.</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
             <l part="I">Oh! che mi narri?...</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
@@ -1624,7 +1646,7 @@
             <l>per placar poi la Dea? quanti non porsi</l>
             <l>e preghi, e incensi, e pianti? indarno sempre.</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -1643,7 +1665,7 @@
             <l>Ma, vien Perèo: ben venga: ei sol serbarci</l>
             <l part="I">può la figlia, col torcela.</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
@@ -1653,7 +1675,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>CINIRO, PEREO, CECRI</stage>
-          <sp>
+          <sp who="#pereo">
             <speaker>
               <emph>Pereo</emph>
             </speaker>
@@ -1668,7 +1690,7 @@
             <l>fatal si rompa; e de´ miei giorni a un tempo</l>
             <l part="I">rompasi il filo.</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -1694,7 +1716,7 @@
             <l>vuole ella stessa; e per ragion ne assegna,</l>
             <l>l´esser più teco, il divenir più tua.</l>
           </sp>
-          <sp>
+          <sp who="#pereo">
             <speaker>
               <emph>Pereo</emph>
             </speaker>
@@ -1703,7 +1725,7 @@
             <l>che in suo pensier disegni ella stromento</l>
             <l part="I">della sua morte farmi.</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
@@ -1719,14 +1741,14 @@
             <l>e, col non mai del suo dolor parlarle,</l>
             <l>vedrai che in lei presso a finir fia ´l duolo.</l>
           </sp>
-          <sp>
+          <sp who="#pereo">
             <speaker>
               <emph>Pereo</emph>
             </speaker>
             <l>Creder dunque poss´io, creder davvero</l>
             <l part="I">che non mi abborre Mirra?</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -1745,7 +1767,7 @@
             <l>ostacol fora. In questa reggia, gl´inni</l>
             <l part="I">d´Imenèo canteremo.</l>
           </sp>
-          <sp>
+          <sp who="#pereo">
             <speaker>
               <emph>Pereo</emph>
             </speaker>
@@ -1759,7 +1781,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>EURICLEA, MIRRA</stage>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -1767,7 +1789,7 @@
             <l>cara Euriclèa, mi vedi; e lieta, quasi,</l>
             <l part="I">del mio certo partire.</l>
           </sp>
-          <sp>
+          <sp who="#euriclea">
             <speaker>
               <emph>Euriclea</emph>
             </speaker>
@@ -1779,13 +1801,13 @@
             <l>se priva io resto della dolce figlia?</l>
             <l>solo in pensarvi, oimè! morir mi sento...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
             <l part="I">Deh! taci... Un dì ritornerò...</l>
           </sp>
-          <sp>
+          <sp who="#euriclea">
             <speaker>
               <emph>Euriclea</emph>
             </speaker>
@@ -1794,7 +1816,7 @@
             <l>durezza in te, no, non creda: sperato</l>
             <l>avea pur sempre di morirmi al tuo fianco...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -1802,13 +1824,13 @@
             <l>acconsentir potea, eri tu sola,</l>
             <l>quella ch´io chiesta avrei... Ma, in ciò son salda...</l>
           </sp>
-          <sp>
+          <sp who="#euriclea">
             <speaker>
               <emph>Euriclea</emph>
             </speaker>
             <l part="I">E al nuovo di tu parti?...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -1816,7 +1838,7 @@
             <l>dai genitor ne ottenni; e scior vedrammi</l>
             <l>da questo lido la nascente aurora.</l>
           </sp>
-          <sp>
+          <sp who="#euriclea">
             <speaker>
               <emph>Euriclea</emph>
             </speaker>
@@ -1826,7 +1848,7 @@
             <l>Pur, se a te giova, io piangerò, ma muta</l>
             <l part="I">con la dolente genitrice...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -1834,7 +1856,7 @@
             <l>muovi tu assalto al mio mal fermo cuore?...</l>
             <l part="I">perché sforzarmi al pianto?...</l>
           </sp>
-          <sp>
+          <sp who="#euriclea">
             <speaker>
               <emph>Euriclea</emph>
             </speaker>
@@ -1847,7 +1869,7 @@
             <l>alla memoria... della tua Euriclèa...</l>
             <l part="I">almen darai...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -1864,7 +1886,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>PEREO, MIRRA, EURICLEA</stage>
-          <sp>
+          <sp who="#pereo">
             <speaker>
               <emph>Pereo</emph>
             </speaker>
@@ -1878,7 +1900,7 @@
             <l>genitori tuoi: per me non altra</l>
             <l>gioia esser può, che di appagar tue brame.</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -1907,7 +1929,7 @@
             <l>rimedio, il sol, che asciugherà per sempre</l>
             <l>il mio finor perenne orribil pianto.</l>
           </sp>
-          <sp>
+          <sp who="#pereo">
             <speaker>
               <emph>Pereo</emph>
             </speaker>
@@ -1935,7 +1957,7 @@
             <l>parmi esser certo, che odiarmi almeno</l>
             <l part="I">neppur potrai.</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -1951,7 +1973,7 @@
             <l>ch´io stimo te, ch´io ad alta voce appello,</l>
             <l>Perèo, te sol liberator mio vero.</l>
           </sp>
-          <sp>
+          <sp who="#pereo">
             <speaker>
               <emph>Pereo</emph>
             </speaker>
@@ -1968,7 +1990,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage><emph>Sacerdoti</emph>, CORO <emph>di fanciulli, donzelle, e vecchi</emph>; CINIRO, CECRI, <emph>popolo</emph>, MIRRA PEREO, EURICLEA</stage>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -1983,7 +2005,7 @@
             <l>schiudasi il canto; al ciel rimbombin grati</l>
             <l>devoti inni vostri alti-sonanti.</l>
           </sp>
-          <sp>
+          <sp who="#coroove il coro non cantasse #precederà ad ogni stanza una breve sinfonia adattata alle parole #che stanno per recitarsi poi">
             <speaker>
               <emph>Coro<note resp="#aut" place="foot"><p>Ove il coro non cantasse, precederà ad ogni stanza una breve sinfonia adattata alle parole, che stanno per recitarsi poi.</p></note></emph>
             </speaker>
@@ -1993,60 +2015,60 @@
             <l>fra i lieti sposi accendi</l>
             <l>fiamma, cui nulla estingua, altro che morte. —</l>
           </sp>
-          <sp>
+          <sp who="#fanc">
             <speaker>
               <emph>Fanc.</emph>
             </speaker>
             <l>Benigno a noi, lieto Imenèo, deh! vola</l>
             <l>del tuo german su i vanni;</l>
           </sp>
-          <sp>
+          <sp who="#donz">
             <speaker>
               <emph>Donz.</emph>
             </speaker>
             <l>e co´ suoi stessi inganni</l>
             <l>a lui tu l´arco, — e la farètra invola:</l>
           </sp>
-          <sp>
+          <sp who="#vecchi">
             <speaker>
               <emph>Vecchi</emph>
             </speaker>
             <l>ma scendi scarco</l>
             <l>di sue lunghe querele e tristi affanni: —</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>
               <emph>Coro</emph>
             </speaker>
             <l>de´ nodi tuoi, bello Imenèo giocondo,</l>
             <l>stringi la degna coppia unica al mondo».</l>
           </sp>
-          <sp>
+          <sp who="#euriclea">
             <speaker>
               <emph>Euriclea</emph>
             </speaker>
             <l part="I">Figlia, che fia? tu tremi?... oh cielo!...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
             <l part="F">Taci:</l>
             <l part="I">deh! taci...</l>
           </sp>
-          <sp>
+          <sp who="#euriclea">
             <speaker>
               <emph>Euriclea</emph>
             </speaker>
             <l part="M">Eppur...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
             <l part="F">No, non è ver; non tremo. —</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>
               <emph>Coro</emph>
             </speaker>
@@ -2057,28 +2079,28 @@
             <l>dalle olimpiche cime,</l>
             <l>se sacri mai ti fur di Cipro i lidi.</l>
           </sp>
-          <sp>
+          <sp who="#fanc">
             <speaker>
               <emph>Fanc.</emph>
             </speaker>
             <l>Tutta è tuo don questa beltà sovrana,</l>
             <l>onde Mirra è vestita, e non altera;</l>
           </sp>
-          <sp>
+          <sp who="#donz">
             <speaker>
               <emph>Donz.</emph>
             </speaker>
             <l>lasciarci in terra la tua immagin vera</l>
             <l>piacciati, deh! col farla allegra e sana,</l>
           </sp>
-          <sp>
+          <sp who="#vecchi">
             <speaker>
               <emph>Vecchi</emph>
             </speaker>
             <l>e madre in breve di sì nobil prole,</l>
             <l>che il padre, e gli avi, e i regni lor, console. —</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>
               <emph>Coro</emph>
             </speaker>
@@ -2089,7 +2111,7 @@
             <l>gli sposi all´ara tua prostràti ammanta;</l>
             <l>e in due corpi una sola alma traspianta».</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
@@ -2098,7 +2120,7 @@
             <l>tutta d´aspetto?... Oimè! vacilli? e appena</l>
             <l part="I">su i piè tremanti?...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -2107,21 +2129,21 @@
             <l>del sembiante non so;... ma il cor, la mente,</l>
             <l part="I">salda stommi, immutabile.</l>
           </sp>
-          <sp>
+          <sp who="#euriclea">
             <speaker>
               <emph>Euriclea</emph>
             </speaker>
             <l part="F">Per essa</l>
             <l part="I">morir mi sento.</l>
           </sp>
-          <sp>
+          <sp who="#pereo">
             <speaker>
               <emph>Pereo</emph>
             </speaker>
             <l part="F">Oimè! vieppiù turbarsi</l>
             <l>la veggo in volto?... Oh qual tremor mi assale! —</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>
               <emph>Coro</emph>
             </speaker>
@@ -2135,7 +2157,7 @@
             <l>e, invan rabbiosa</l>
             <l>se stessa roda la feral Discordia...».</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -2145,26 +2167,26 @@
             <l>stan le rabide Erinni: ecco quai merta</l>
             <l part="I">questo imenèo le faci...</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
             <l part="F">Oh ciel! che ascolto?</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
             <l part="I">Figlia, oimè! tu vaneggi..</l>
           </sp>
-          <sp>
+          <sp who="#pereo">
             <speaker>
               <emph>Pereo</emph>
             </speaker>
             <l part="F">Oh infauste nozze!</l>
             <l part="I">Non fia, no mai...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -2172,7 +2194,7 @@
             <l>Chi al sen mi stringe? Ove son io? Che dissi?</l>
             <l part="I">Son io già sposa? Oimè!...</l>
           </sp>
-          <sp>
+          <sp who="#pereo">
             <speaker>
               <emph>Pereo</emph>
             </speaker>
@@ -2198,7 +2220,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>CINIRO, MIRRA, CECRI, EURICLEA, <emph>sacerdoti, coro, popolo</emph></stage>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -2211,7 +2233,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>CINIRO, MIRRA, CECRI, EURICLEA</stage>
-          <sp>
+          <sp who="#euriclea">
             <speaker>
               <emph>Euriclea</emph>
             </speaker>
@@ -2219,7 +2241,7 @@
             <l>stassi: il vedete, ch´io a stento la reggo?</l>
             <l part="I">Oh figlia!...</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -2235,7 +2257,7 @@
             <l>noi severi non fummo, è giunto il giorno</l>
             <l part="I">d´esserlo al fine.</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -2252,13 +2274,13 @@
             <l>me non uccidi, a morir della mia</l>
             <l part="I">omai mi serbi, ed a null´altro.</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
             <l part="F">Oh figlia!...</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
@@ -2268,7 +2290,7 @@
             <l>mal di se stessa è donna; ad ogni istante</l>
             <l part="I">fuor di se stessa è dal dolore...</l>
           </sp>
-          <sp>
+          <sp who="#euriclea">
             <speaker>
               <emph>Euriclea</emph>
             </speaker>
@@ -2276,7 +2298,7 @@
             <l>figlia,... e non m´odi?... Parlar,... pel gran pianto,...</l>
             <l part="I">non posso...</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -2292,13 +2314,13 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>CECRI, MIRRA, EURICLEA</stage>
-          <sp>
+          <sp who="#euriclea">
             <speaker>
               <emph>Euriclea</emph>
             </speaker>
             <l>Ecco, di nuovo ella i sensi ripiglia...</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
@@ -2309,7 +2331,7 @@
         <div type="scene">
           <head>SCENA VII</head>
           <stage>CECRI, MIRRA</stage>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -2323,7 +2345,7 @@
             <l>n´è tempo ancor: ti pentirai, ma indarno,</l>
             <l>del non mi aver d´un ferro oggi soccorsa.</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
@@ -2346,7 +2368,7 @@
             <l>e di abbracciarmi nieghi? e gl´infuocati</l>
             <l part="I">sguardi?... Oimè! figlia,... anco alla madre?...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -2359,7 +2381,7 @@
             <l>o se di me vera pietà tu senti,</l>
             <l part="I">io tel ridico, uccidimi.</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
@@ -2369,7 +2391,7 @@
             <l>così acerbe parole? — Anzi, vo´ sempre</l>
             <l>d´ora in poi sul tuo viver vegliar io.</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -2380,7 +2402,7 @@
             <l>con queste man mie stesse, io stessa pria</l>
             <l part="I">me li vo´ sverre, io, dalla fronte...</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
@@ -2388,7 +2410,7 @@
             <l>che ascolto?... Oh ciel!... Rabbrividir mi fai.</l>
             <l part="I">Me dunque abborri?...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -2396,14 +2418,14 @@
             <l>tu sempiterna cagione funesta</l>
             <l part="I">d´ogni miseria mia...</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
             <l part="F">Che parli?... Oh figlia!...</l>
             <l>Io la cagion?... Ma già il tuo pianto a rivi...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -2411,14 +2433,14 @@
             <l>una incognita forza in me favella...</l>
             <l part="I">Madre, ah! troppo tu m´ami; ed io...</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
             <l part="F">Me nomi</l>
             <l part="I">cagion?...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -2430,7 +2452,7 @@
             <l>a tante furie... il languente... mio... corpo...</l>
             <l part="I">mancano i piè,... mancano... i sensi...</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
@@ -2447,7 +2469,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>CINIRO</stage>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -2492,7 +2514,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>CINIRO, MIRRA</stage>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -2504,7 +2526,7 @@
             <l>all´obbedir tu sii, più nuovo ancora</l>
             <l part="I">questo a me giunge.</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -2514,7 +2536,7 @@
             <l>or dianzi,... qui... — Presente era la madre;...</l>
             <l part="I">deh! perché allor... non mi uccidevi?...</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -2532,13 +2554,13 @@
             <l>e inorridisci?... e taci? — A te fia dunque</l>
             <l>l´ira del padre insopportabil pena?</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
             <l part="I">Ah!... peggior... d´ogni morte...</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -2549,13 +2571,13 @@
             <l>Già l´oltraggio tuo crudo i giorni ha tronchi</l>
             <l part="I">del misero Perèo...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
             <l part="F">Che ascolto? Oh cielo!</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -2570,14 +2592,14 @@
             <l>e, fra i singulti estremi, dal suo labro</l>
             <l>usciva ancor di Mirra il nome. — Ingrata...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
             <l>Deh! più non dirmi... Io sola, io degna sono,</l>
             <l part="I">di morte... E ancor respiro?...</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -2602,13 +2624,13 @@
             <l>sì tutto in te mel dice, e invan tu il nieghi;...</l>
             <l>son figlie in te le furie tue... d´amore.</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
             <l>Io?... d´amor?... Deh! nol credere... T´inganni.</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -2617,7 +2639,7 @@
             <l>ch´esser non puote altro che oscura fiamma,</l>
             <l part="I">quella cui tanto ascondi.</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -2625,7 +2647,7 @@
             <l>Non vuoi col brando uccidermi;... e coi detti...</l>
             <l part="I">mi uccidi intanto...</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -2640,7 +2662,7 @@
             <l>ti si scolpiscon sì forte sul volto;</l>
             <l part="I">che indarno il labro negheria...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -2648,7 +2670,7 @@
             <l>farmi... al tuo aspetto... morir... di vergogna?...</l>
             <l part="I">E tu sei padre?</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -2670,7 +2692,7 @@
             <l>che tel comanda, e ten scongiura, indegna</l>
             <l part="I">d´ogni scusa ti rende.</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -2678,7 +2700,7 @@
             <l>cui tanto invoco, al mio dolor tu sorda</l>
             <l part="I">sempre sarai?...</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -2689,7 +2711,7 @@
             <l>Parlami deh! come a fratello. Anch´io</l>
             <l part="I">conobbi amor per prova: il nome.</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -2700,7 +2722,7 @@
             <l>né persona il saprà: lo ignora ei stesso...</l>
             <l part="I">ed a me quasi io ´l niego.</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -2721,7 +2743,7 @@
             <l>Te ne scongiuro, parla: io ti vo´ salva,</l>
             <l part="I">ad ogni costo mio.</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -2730,7 +2752,7 @@
             <l>Lascia, deh! lascia, per pietà, ch´io tosto</l>
             <l part="I">da te... per sempre... il piè... ritragga...</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -2741,14 +2763,14 @@
             <l>dunque abborrisci? e di sì vile fiamma</l>
             <l part="I">ardi, che temi...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
             <l part="F">Ah! non è vile;... è iniqua</l>
             <l part="I">la mia fiamma; né mai...</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -2756,20 +2778,20 @@
             <l>ove primiero il genitor tuo stesso</l>
             <l>non la condanna, ella non fia: la svela.</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
             <l>Raccapricciar d´orror vedresti il padre,</l>
             <l part="I">se la sapesse.. Ciniro...</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
             <l part="F">Che ascolto!</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -2778,7 +2800,7 @@
             <l>te ne scongiuro per l´ultima volta,</l>
             <l part="I">lasciami il piè ritrarre.</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -2787,7 +2809,7 @@
             <l>del mio dolore gioco, omai per sempre</l>
             <l part="I">perduto hai tu l´amor del padre.</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -2799,14 +2821,14 @@
             <l>Oh madre mia felice!... almen concesso</l>
             <l>a lei sarà... di morire... al tuo fianco...</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
             <l>Che vuoi tu dirmi?... Oh! qual terribil lampo,</l>
             <l part="I">da questi accenti!... Empia, tu forse?...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -2815,20 +2837,20 @@
             <l>Ove mi ascondo?... Ove morir? — Ma il brando</l>
             <l part="I">tuo mi varrà...<note resp="#aut" place="foot"><p>Rapidissimamente avventatasi al brando del padre, se ne trafigge.</p></note></l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
             <l part="F">Figlia... Oh! che festi? il ferro...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
             <l>Ecco,... or... tel rendo... Almen la destra io ratta</l>
             <l part="I">ebbi al par che la lingua.</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -2836,7 +2858,7 @@
             <l>e d´orror pieno, e d´ira,... e di pietade,...</l>
             <l part="I">immobil resto.</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
@@ -2847,21 +2869,21 @@
             <l>ma, poiché sol colla mia vita... egli esce...</l>
             <l part="I">dal labro mio,... men rea... mi moro...</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
             <l part="F">Oh giorno!</l>
             <l>Oh delitto!... Oh dolore! — A chi il mio pianto?...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
             <l>Deh! più non pianger;... ch´io nol merto... Ah! sfuggi</l>
             <l>mia vista infame;... e a Cecri... ognor... nascondi...</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -2875,58 +2897,58 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>CECRI, EURICLEA, CINIRO, MIRRA</stage>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
             <l part="I">Al suon d´un mortal pianto...</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
             <l part="F">Oh cielo!<note resp="#aut" place="foot"><p>Corre incontro a Cecri, e impedendola d´inoltrarsi, le toglie la vista di Mirra morente</p></note></l>
             <l part="I">non t´inoltrar...</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
             <l part="M">Presso alla figlia...</l>
           </sp>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>
             <l part="F">Oh voce!</l>
           </sp>
-          <sp>
+          <sp who="#euriclea">
             <speaker>
               <emph>Euriclea</emph>
             </speaker>
             <l>Ahi vista! nel suo sangue a terra giace</l>
             <l part="I">Mirra?...</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
             <l part="M">La figlia?...</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
             <l part="M">Arretrati...</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
             <l part="F">Svenata!...</l>
             <l part="I">Come? da chi?... Vederla vo´...</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -2934,14 +2956,14 @@
             <l>Inorridisci... Vieni... Ella... trafitta,</l>
             <l part="I">di propria man, s´è col mio brando...</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
             <l part="F">E lasci</l>
             <l part="I">così tua figlia?... Ah! la vogl´io...</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
@@ -2949,33 +2971,33 @@
             <l>non c´è costei. D´infame orrendo amore</l>
             <l part="I">ardeva ella per... Ciniro...</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
             <l part="F">Che ascolto? —</l>
             <l part="I">Oh delitto!...</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
             <l part="F">Deh! vieni: andiam, ten priego,</l>
             <l>a morir d´onta e di dolore altrove.</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
             <l part="I">Empia... — Oh mia figlia!...</l>
           </sp>
-          <sp>
+          <sp who="#ciniro">
             <speaker>
               <emph>Ciniro</emph>
             </speaker>
             <l part="M">Ah! vieni...</l>
           </sp>
-          <sp>
+          <sp who="#cecri">
             <speaker>
               <emph>Cecri</emph>
             </speaker>
@@ -2986,7 +3008,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>MIRRA, EURICLEA</stage>
-          <sp>
+          <sp who="#mirra">
             <speaker>
               <emph>Mirra</emph>
             </speaker>

--- a/tei/alfieri-oreste.xml
+++ b/tei/alfieri-oreste.xml
@@ -82,6 +82,25 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="elettra">
+            <persName>Elettra</persName>
+          </person>
+          <person xml:id="clitennestra">
+            <persName>Clitennestra</persName>
+          </person>
+          <person xml:id="egisto">
+            <persName>Egisto</persName>
+          </person>
+          <person xml:id="oreste">
+            <persName>Oreste</persName>
+          </person>
+          <person xml:id="pilade">
+            <persName>Pilade</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -131,7 +150,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>ELETTRA</stage>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -164,19 +183,19 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>CLITENNESTRA, ELETTRA</stage>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="I">Figlia.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="M">Qual voce? Oh ciel! tu vieni?...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -186,20 +205,20 @@
             <l>ei nol saprà. Deh! vieni; andiam compagne</l>
             <l part="I">alla tomba.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="M">Di chi?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">... Del... tuo... infelice...</l>
             <l part="I">padre.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -208,7 +227,7 @@
             <l>come ardirai tu volgere? tu lorda</l>
             <l part="I">ancor del sangue suo?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -216,7 +235,7 @@
             <l>son da quel dì fatale; il mio delitto</l>
             <l part="I">due lustri interi or piango.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -234,7 +253,7 @@
             <l>Già già l'irata sua terribil ombra</l>
             <l>sorge a noi contro, e te respinge addietro.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -242,7 +261,7 @@
             <l>Oh rimorsi!... oh dolore!... ahi lassa!... E pensi,</l>
             <l>ch'io con Egisto sia felice forse?</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -259,7 +278,7 @@
             <l>lo inesorabil giudice dolersi,</l>
             <l>che niun tormento al tuo fallir si adegui.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -289,7 +308,7 @@
             <l>così men vivo. — O figlia, (qual ch'io sia,</l>
             <l>mi sei pur tale) al pianger mio non piangi?</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -301,7 +320,7 @@
             <l>credere al pianger tuo. Vanne, rientra;</l>
             <l part="I">lascia ch'io sola a compier vada...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -319,7 +338,7 @@
             <l>ma, a tal son io, che omai qual posso ammenda</l>
             <l>far del misfatto, che non sia misfatto?</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -332,14 +351,14 @@
             <l>di quell'empio, che a te l'onor, la pace,</l>
             <l>la fama toglie, ed al tuo Oreste il regno?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l>Oreste?... oh nome! Entro mie vene il sangue</l>
             <l part="I">tutto in udirlo agghiacciasi.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -348,7 +367,7 @@
             <l>Di madre amor, qual dee tal madre, or provi.</l>
             <l part="I">Ma, Oreste vive.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -360,7 +379,7 @@
             <l>porger voti, affinché mai più davanti</l>
             <l part="I">non mel traggano.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -374,7 +393,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>EGISTO, CLITENNESTRA, ELETTRA</stage>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -384,7 +403,7 @@
             <l>il passato all'obblio; fa' che più lieti</l>
             <l part="I">teco io viva i miei dì.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -393,7 +412,7 @@
             <l>di mie cure pensiero? Eterno è il duolo</l>
             <l part="I">entro il mio core; il sai.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -405,7 +424,7 @@
             <l>vo' torti omai dagli occhi: omai la reggia</l>
             <l>vo' serenar; con lei sbandirne il pianto.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -415,26 +434,26 @@
             <l>Ma, viva gioia di Tieste al figlio</l>
             <l>fia, il veder lagrimar figli d'Atrèo.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l>O figlia,... ei m'è consorte. — Egisto, ah! pensa</l>
             <l part="I">ch'ella m'è figlia...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Ella? d'Atride è figlia.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="I">Costui? d'Atride è l'uccisore.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -442,7 +461,7 @@
             <l>Egisto, abbi pietà... La tomba... vedi,</l>
             <l part="I">la orribil tomba,... e non sei pago?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -450,7 +469,7 @@
             <l>men da te stessa omai discorda. Atride,</l>
             <l>di', per qual mano in quella tomba giace?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -458,7 +477,7 @@
             <l>alla infelice misera mia vita?</l>
             <l>Chi mi vi ha spinto, or mi rimorde il fallo.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -471,14 +490,14 @@
             <l>conosce omai. Possa lo sprezzo trarvi</l>
             <l part="I">all'odio; e l'odio a nuovo sangue.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Oh fero,</l>
             <l>ma meritato augurio! oh ciel!... Deh,... figlia...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -493,7 +512,7 @@
             <l>d'infame povertà, dote gli arreca</l>
             <l part="I">le tue lagrime eterne.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -502,13 +521,13 @@
             <l>Qual mai tuo servo fia di te più vile?</l>
             <l part="I">Più scellerato, quale?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="M">Esci.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -517,21 +536,21 @@
             <l>ma, sia che vuol, questa mia man, che il cielo</l>
             <l part="I">forse destina ad alta impresa...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Or esci;</l>
             <l part="I">tel ridico.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Per or, deh!... taci,... o figlia:...</l>
             <l part="I">esci, ten prego:... io poscia...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -542,7 +561,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>EGISTO, CLITENNETRA</stage>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -550,7 +569,7 @@
             <l>e meritarle!... Oh vita! a te qual morte</l>
             <l part="I">fu pari mai?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -564,7 +583,7 @@
             <l>cessa di opporti: io 'l voglio, e indarno affatto</l>
             <l part="I">vi ti opporresti.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -575,7 +594,7 @@
             <l>trarrem noi sempre incerta orrida vita.</l>
             <l part="I">Altra sperar ne lice?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -586,7 +605,7 @@
             <l>l'odio per noi cresce cogli anni; ei vive</l>
             <l>del feroce desio d'alta vendetta.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -594,7 +613,7 @@
             <l>oscuro, inerme. — Ahi crudo! ad una madre</l>
             <l>ti duoli tu, che il suo figliuol respiri?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -603,7 +622,7 @@
             <l>amor; non dei questo immolar del pari</l>
             <l part="I">alla mia sicurezza?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -618,7 +637,7 @@
             <l>unico figlio mio. Qual cor sì atroce</l>
             <l part="I">può non pianger di lui?...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -631,7 +650,7 @@
             <l>Ma che perciò? nomi innocente un figlio,</l>
             <l>cui tu pria 'l padre, e il regno poscia hai tolto?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -639,7 +658,7 @@
             <l>privo di tutto, a chi tutto ti spoglia</l>
             <l>nulla tu desti, se non dai tua vita?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -657,13 +676,13 @@
             <l>ove il pur possa, accelerar sua morte;</l>
             <l part="I">tu soffrirlo, e tacerti.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Oimè!... il mio sangue...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -677,7 +696,7 @@
             <l>troppo pietosa madre! Il figlio in atto</l>
             <l>già di ferirti sta: miralo; trema...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -694,7 +713,7 @@
             <l>il ciel vel tragge; e contro il ciel chi vale?</l>
             <l>Qual dubbio allor? vittima chiesta io sono.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -711,7 +730,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>ORESTE, PILADE</stage>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -720,14 +739,14 @@
             <l>pur sorge il dì, ch'io ristorar ti possa</l>
             <l>de' lunghi tuoi per me sofferti affanni.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l>Amami, Oreste; i miei consigli ascolta;</l>
             <l>questo è il ristoro, ch'io per me ti chieggo.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -759,7 +778,7 @@
             <l>torno ripieno, e di vendetta, donde</l>
             <l>fanciullo inerme lagrimando io mossi.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -773,7 +792,7 @@
             <l>dei voti tanti, e dell'errar sì lungo,</l>
             <l>che a questi lidi al fin ci tragge a stento.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -792,7 +811,7 @@
             <l>forse a prova non dubbia il ciel volea</l>
             <l>porre in me l'ardimento, in te la fede.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -807,7 +826,7 @@
             <l>faremo al venir nostro: a tanta mole</l>
             <l part="I">convien dar base.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -816,7 +835,7 @@
             <l>ond'io vengo assetato. — Il miglior mezzo?</l>
             <l part="I">Eccolo; il brando.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -824,7 +843,7 @@
             <l>sete di sangue? altri pur l'ha del tuo;</l>
             <l part="I">ma brandi ha mille.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -833,7 +852,7 @@
             <l>troppo è il mio nome. E di qual ferro usbergo,</l>
             <l>qual scudo avrà, ch'io nol trapassi, Egisto?</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -842,14 +861,14 @@
             <l>in copia avrà satelliti: tremante,</l>
             <l part="I">ma salvo, ei stassi in mezzo a lor...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Nomarmi,</l>
             <l>ed ogni vil disperdere, fia un punto.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -858,13 +877,13 @@
             <l>lor fede, e ardire: han dal tiranno l'esca;</l>
             <l>né spento il vonno, ove nol spengan essi.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="I">Il popol dunque a favor mio...</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -876,7 +895,7 @@
             <l>e a tutti serve; ed un Atride obblia,</l>
             <l part="I">e d'un Egisto trema.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -885,7 +904,7 @@
             <l>un padre ucciso, sanguinoso, inulto,</l>
             <l>che anela, e chiede, e attende, e vuol vendetta.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -897,28 +916,28 @@
             <l>visti appena, trarranci a Egisto innanzi:</l>
             <l part="I">dirgli...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Ferir; centuplicare i colpi</l>
             <l part="I">dobbiam nell'empio; e nulla dirgli.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="F">A morte</l>
             <l>certa venisti, od a vendetta certa?</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l>Purché sian certe entrambe; uccider prima,</l>
             <l part="I">e morir poscia.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -930,13 +949,13 @@
             <l>Messi del padre mio ne creda Egisto,</l>
             <l>e di tua morte apportatori in Argo.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="I">Mentir mio nome? ad un Egisto? io?</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -946,7 +965,7 @@
             <l>udrem che dica Egisto: intanto chiaro</l>
             <l part="I">ne fia il destin d'Elettra.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -955,7 +974,7 @@
             <l>mai più novella io, mai. Sangue d'Atride,</l>
             <l part="I">certo, costui nol risparmiò.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -976,13 +995,13 @@
             <l>nol rompere. Chi sa? pentita forse</l>
             <l part="I">la madre tua...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Di lei, deh, non parlarmi.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -990,7 +1009,7 @@
             <l>che d'ascoltar mio senno. Il ciel, che vuolmi</l>
             <l>a te compagno, avverso avrai, se il nieghi.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -1000,7 +1019,7 @@
             <l>di mia virtude il primo sforzo, o padre,</l>
             <l part="I">che a te consacro.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -1009,7 +1028,7 @@
             <l>esce una donna della reggia. Or vieni</l>
             <l part="I">meco in disparte.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -1019,7 +1038,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>ELETTRA, ORESTE, PILADE</stage>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1028,20 +1047,20 @@
             <l>Due, che all'abito, al volto io non ravviso...</l>
             <l part="I">osservan me; paion stranieri.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Udisti?</l>
             <l part="I">Nomato ha Egisto.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="M">Ah! taci.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1049,7 +1068,7 @@
             <l>(tali v'estimo) dite; a queste mura</l>
             <l part="I">che vi guida?</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -1057,20 +1076,20 @@
             <l>Stranieri, è ver, siam noi; d'alta novella</l>
             <l part="I">qui ne veniamo apportatori.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="F">A Egisto</l>
             <l part="I">voi la recate?</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="M">Sì.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1079,13 +1098,13 @@
             <l>infin ch'ei torni, entro la reggia starvi</l>
             <l part="I">potrete ad aspettarlo.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="F">E il tornar suo?...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1093,7 +1112,7 @@
             <l>grazie, onori, mercé, qual vi si debbe,</l>
             <l part="I">darà, se grata è la novella.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -1101,14 +1120,14 @@
             <l>Egisto avralla, benché assai pur sia</l>
             <l part="I">per se stessa funesta.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="F">Il cor mi balza. —</l>
             <l>Funesta?... È tale, ch'io saper la possa?</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -1118,13 +1137,13 @@
             <l>turbar ti veggio?... e che? potria spettarti</l>
             <l>nuova recata di lontana terra?</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l>Spettarmi?... no... Ma, di qual terra sete?</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -1133,7 +1152,7 @@
             <l>ai detti io l'orme d'alto duol ravviso.</l>
             <l part="I">Chieder poss'io?...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1144,14 +1163,14 @@
             <l>vorrei; ma udita, mi dorrebbe poscia.</l>
             <l part="I">Umano core!</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="F">Ardito troppo io forse</l>
             <l part="I">sarei, se a te il tuo nome?...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1170,27 +1189,27 @@
             <l>del venir vostro. Entrate: i passi miei</l>
             <l part="I">proseguirò ver quella tomba.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Tomba!</l>
             <l part="I">quale? dove? di chi?</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="F">Non vedi? a destra?</l>
             <l part="I">d'Agamennón la tomba.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="M">Oh vista!</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1199,13 +1218,13 @@
             <l>dunque a voi giunse della orribil morte,</l>
             <l part="I">che in Argo egli ebbe?</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="M">Ove non giunse?</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -1213,19 +1232,19 @@
             <l>tomba del re dei re, vittima aspetti?</l>
             <l part="I">L'avrai.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="M">Che dice?</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="M">Io non l'intesi.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1233,7 +1252,7 @@
             <l>di vittima? perché? Sacra d'Atride</l>
             <l part="I">gli è la memoria?</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -1243,7 +1262,7 @@
             <l>spesso ei vaneggia. — In te rientra. — Ahi folle!</l>
             <l part="I">in te fidar doveva io mai?</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1252,14 +1271,14 @@
             <l>e terribile in atto... — O tu, chi sei,</l>
             <l part="I">che generoso ardisci?...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">A me la cura</l>
             <l part="I">lasciane, a me.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -1268,7 +1287,7 @@
             <l>non badar punto: è fuor di sé. — Scoprirti</l>
             <l part="I">vuoi dunque a forza?</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -1277,46 +1296,46 @@
             <l>quante versasti dalla orribil piaga</l>
             <l part="I">stille di sangue.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="F">Ei non vaneggia. Un padre...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l>Sì, mi fu tolto un padre. Oh rabbia! E inulto</l>
             <l part="I">rimane ancora?</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="F">E chi sarai tu dunque,</l>
             <l part="I">se Oreste non sei tu?</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="M">Che ascolto?</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Oreste!</l>
             <l part="I">Chi, chi mi appella?</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="M">Or sei perduto.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1324,14 +1343,14 @@
             <l>ti appella; Elettra io son, che al sen ti stringo</l>
             <l part="I">fra le mie braccia...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Ove son io? Che dissi?...</l>
             <l part="I">Pilade oimè!...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1341,20 +1360,20 @@
             <l>al duolo, al pianto, all'amor mio, conosci</l>
             <l part="I">Elettra tu.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Sorella; oh ciel!... tu vivi?</l>
             <l part="I">tu vivi? ed io t'abbraccio?</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="M">Oh giorno!...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -1362,13 +1381,13 @@
             <l>te dunque io stringo? Oh inesplicabil gioia! —</l>
             <l>Oh fera vista! la paterna tomba?...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="I">Deh! ti acqueta per ora.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -1377,14 +1396,14 @@
             <l>Oreste m'hai, che di me stesso è parte;</l>
             <l part="I">pensa s'io t'amo.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="F">E tu cresciuto l'hai;</l>
             <l part="I">fratel secondo a me tu sei.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -1397,7 +1416,7 @@
             <l>qui ci han scorti pietate, amor, vendetta;</l>
             <l part="I">ma, se così prosiegui...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -1420,7 +1439,7 @@
             <l>non serberà dentro a sue vene stilla:</l>
             <l>tu il berai tutto, ombra assetata; e tosto.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1432,7 +1451,7 @@
             <l>ti fia mirarle con asciutto ciglio,</l>
             <l>finché con nuovo sangue non l'hai tolte.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -1446,7 +1465,7 @@
             <l>ti credea dal tiranno: a vendicarti,</l>
             <l>più che a stringerti al sen, presto veniva.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1458,7 +1477,7 @@
             <l>che tu di Strofio l'ospitale albergo</l>
             <l part="I">lasciato avevi, oh qual tremore!...</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -1468,20 +1487,20 @@
             <l>così vieppiù sicuro. Io mai pertanto,</l>
             <l part="I">mai nol lasciai, né il lascierò.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Sol morte</l>
             <l part="I">partir ci può.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="F">Né lo potria pur morte.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1490,7 +1509,7 @@
             <l>tiranno, or come appresentarvi innanzi?</l>
             <l part="I">Celarvi qui, già nol potreste.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -1498,13 +1517,13 @@
             <l>mostrar vogliamci apportator mentiti</l>
             <l part="I">della morte d'Oreste.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">È vile il mezzo.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1517,7 +1536,7 @@
             <l>vibrò colei, cui non osiam più madre</l>
             <l part="I">nomar dappoi.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -1525,7 +1544,7 @@
             <l>stato viv'ella? ed il non tuo delitto</l>
             <l>come a te fa scontar, d'esserle figlia?</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1543,7 +1562,7 @@
             <l>squarcianle il dì; notturne orride larve</l>
             <l part="I">tolgonle i sonni. — Ecco qual vive.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -1555,21 +1574,21 @@
             <l>cader vedrà da me trafitto il reo</l>
             <l part="I">vile adultero suo.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="F">Misera madre!</l>
             <l part="I">vista non l'hai;... chi sa?... in vederla...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Udito</l>
             <l part="I">ho il padre; e basta.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1587,27 +1606,27 @@
             <l>ch'oggi Egisto, per torre a sé il mio aspetto,</l>
             <l>mi vuol d'un de' suoi schiavi a forza sposa.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l>Non invitato, all'empie nozze io vengo:</l>
             <l>vittima avran non aspettata i Numi.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="I">Si oppon, ma invano, Clitennestra.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">In lei,</l>
             <l part="I">dimmi, fidar nulla potremmo?</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1619,27 +1638,27 @@
             <l>ma, col tiranno sta. Sua vista sfuggi,</l>
             <l part="I">finché non torni Egisto.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="F">E dove i passi</l>
             <l part="I">portò quel vile?</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="F">Empio, ei festeggia il giorno</l>
             <l part="I">della morte d'Atride.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="M">Oh rabbia!</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1665,14 +1684,14 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>CLITENNESTRA, ELETTRA</stage>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l>Lasciami, Elettra; alle tue stanze riedi:</l>
             <l part="I">ir voglio, sì, d'Egisto in traccia...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1683,13 +1702,13 @@
             <l>Nol temer, no; che il ciel finora arride</l>
             <l part="I">agli empi qui.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="M">Taci d'Egisto...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1699,13 +1718,13 @@
             <l>porger meco di furto al sacro avello</l>
             <l part="I">lagrime, e voti?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Cessa; andarne io voglio...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1713,7 +1732,7 @@
             <l>labro più volte udia nomar stromento</l>
             <l part="I">d'ogni tuo danno?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -1721,19 +1740,19 @@
             <l>non sono io mai: ma né senz'esso il sono.</l>
             <l part="I">Lasciami.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="M">Almen,... soffri...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="M">Che più?</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -1744,7 +1763,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>CLITENNESTRA</stage>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -1754,46 +1773,46 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>CLITENNESTRA, ORESTE, PILADE <emph>in disparte</emph></stage>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Non giunge,</l>
             <l part="I">mai non giunge costui?</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="F">Dove t'inoltri?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="I">Amo Egisto, pur troppo!...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Egisto? Oh voce!</l>
             <l>chi veggio? è dessa: io la rimembro ancora.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="I">Vieni; che fai? t'arrètra.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Agli occhi miei</l>
             <l part="I">chi si appresenta? Oh! chi se' tu?</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -1802,45 +1821,45 @@
             <l>veniamo or forse: al non saper lo ascrivi,</l>
             <l part="I">ad altro no.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="M">Chi siete?</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="M">In Argo...</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="F">Nati</l>
             <l part="I">non siamo...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="M">E non d'Egisto...</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="F">Al re ci manda</l>
             <l part="I">di Focida il signor...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="M">Se qui re...</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -1848,93 +1867,93 @@
             <l>se tu il concedi, entro la reggia il piede,</l>
             <l part="I">di lui cercando, inoltreremo.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">In Argo</l>
             <l part="I">qual vi guida cagione?</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="M">Alta.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="F">Narrarla</l>
             <l part="I">dobbiamo al re.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Del pari a me narrarla</l>
             <l>potrete; or sta fuor della reggia Egisto.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="I">Ma torneravvi...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="M">Spero.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Intanto, il tutto</l>
             <l part="I">a me si esponga.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="M">Io tel vo' dir...</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="F">Se pure</l>
             <l part="I">tu ce l'imponi; ma...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Sul trono io seggo</l>
             <l part="I">d'Egisto al fianco.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">E il sa ciascun, che degna</l>
             <l part="I">tu sei di lui.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="F">Sarebbe a te men grata,</l>
             <l part="I">che ad Egisto, la nuova.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="M">E qual?...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -1942,7 +1961,7 @@
             <l>Qual può il consorte udir grata novella,</l>
             <l part="I">che alla moglie nol sia?</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -1950,124 +1969,124 @@
             <l>assoluto signore a Egisto solo</l>
             <l part="I">c'impon di darla.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Egisto ed essa, un'alma</l>
             <l part="I">sono in duo corpi.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">A che così tenermi</l>
             <l part="I">sospesa? Or via, parlate.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="F">Acerbo troppo</l>
             <l>ti fia l'annunzio; e tolga il ciel, che noi...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l>Assai t'inganni: a lei rechiamo intera</l>
             <l part="I">e sicurezza, e pace.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Omai dovreste</l>
             <l part="I">por fin...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Regina, arrechiam noi la morte...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="I">Di chi?</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="M">Taci.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="M">Di chi? Parla.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">... D'Oreste.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l>Oimè! che sento? del mio figlio?... Oh cielo!...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l>Del figlio, sì, d'Agamennón trafitto...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="I">Che dici?</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="F">Ei dice, che trafitto Oreste</l>
             <l part="I">non fu.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="M">Del figlio del trafitto...</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="F">Insano,</l>
             <l>spergiuro, a me serbi così tua fede?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l>Misera me! dell'unico mio figlio</l>
             <l part="I">orba...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Ma forse, il più mortal nemico</l>
             <l part="I">non era Oreste del tuo Egisto?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -2075,7 +2094,7 @@
             <l>barbaro! in guisa tal la morte annunzi</l>
             <l part="I">d'unico figlio ad una madre?</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -2088,28 +2107,28 @@
             <l>dovuto avresti; e il mio pensier tal era.</l>
             <l part="I">Ma, s'egli...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Errai fors'io; ma, spento il figlio,</l>
             <l part="I">secura omai col tuo consorte...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Ah! taci.</l>
             <l part="I">D'Oreste pria fui madre.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Egisto forse</l>
             <l part="I">t'è men caro d'Oreste?</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -2119,14 +2138,14 @@
             <l>Lasciala; vieni; il lagrimare, e il tempo,</l>
             <l part="I">sollievo solo al suo dolore...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Egisto</l>
             <l part="I">alleviar gliel può.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -2134,7 +2153,7 @@
             <l>dal suo cospetto, che odiosi troppo</l>
             <l part="I">noi le siam fatti omai.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -2145,34 +2164,34 @@
             <l>tutto saper di te vogl'io; né cosa</l>
             <l part="I">niuna udir più, fuor che di te.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Lo amavi</l>
             <l part="I">tu dunque molto ancora?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">O giovinetto,</l>
             <l part="I">non hai tu madre?</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="M">... Io?... L'ebbi.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="F">Oh ciel! Regina,</l>
             <l>soggiacque al fato il figliuol tuo: la vita...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -2180,20 +2199,20 @@
             <l>ai replicati tradimenti atroci,</l>
             <l part="I">no, non soggiacque...</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="F">E ciò saper ti basti.</l>
             <l>Chi ad una madre altro narrar potrebbe?</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="I">Ma, se una madre udir pur vuole...</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -2201,13 +2220,13 @@
             <l>che la storia dolente al re soltanto</l>
             <l part="I">si esponga appien da noi.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Godranne Egisto.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -2219,7 +2238,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>CLITENNESTRA</stage>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -2258,13 +2277,13 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>EGISTO, CLITENNESTRA</stage>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l>Che fia? qual pianto? onde cagion novella?...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -2276,14 +2295,14 @@
             <l>che mai pertanto a te non nocque; è spento.</l>
             <l>L'unico figlio mio più non respira.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l>Che dici? Oreste spento? a te l'avviso</l>
             <l>donde? chi l'arrecava?... Io non tel credo.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -2294,14 +2313,14 @@
             <l>tutto, sì tutto, il non mai spento affetto</l>
             <l part="I">mi si ridesta.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Altra non hai tu prova,</l>
             <l part="I">ond'io?...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -2312,7 +2331,7 @@
             <l>Gente in Argo vedrai, che l'inumano</l>
             <l part="I">tuo desir farà sazio.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2320,7 +2339,7 @@
             <l>gente, senza ch'io 'l sappia? a me primiero</l>
             <l part="I">non si parlò?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -2331,7 +2350,7 @@
             <l>a una consorte madre Egisto darla</l>
             <l part="I">dovea, non altri.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2339,7 +2358,7 @@
             <l>ira è la tua? Cotanto ami l'estinto</l>
             <l>figlio, cui vivo rammentavi appena?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -2353,14 +2372,14 @@
             <l>che m'era e ognor caro sarammi Oreste</l>
             <l part="I">più assai di te...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Poco tu di'. Più caro</l>
             <l part="I">io ti fui che tua fama: onde...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -2393,7 +2412,7 @@
             <l>tu m'uccidesti il figlio... Egisto, ah! scusa;...</l>
             <l part="I">fui madre;... e più nol sono...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2405,7 +2424,7 @@
             <l>messaggeri di re? pria d'ogni cosa,</l>
             <l>chiesto non hanno essi d'Egisto in Argo?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -2420,7 +2439,7 @@
             <l>non minor gioia proverà in narrarti,</l>
             <l>che tu in udire il lagrimevol caso.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2430,7 +2449,7 @@
             <l>trafugato il tuo figlio? a lui ricetto</l>
             <l part="I">non diede egli in sua corte?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -2438,7 +2457,7 @@
             <l>ma or già molti anni, assente ei n'era; e poscia</l>
             <l part="I">mai non ne udimmo più.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2450,7 +2469,7 @@
             <l>Nemico sempre erami Strofio in somma:</l>
             <l part="I">come cangiossi?...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -2472,7 +2491,7 @@
             <l>e fede, e onore, in voi mutabil cosa,</l>
             <l part="I">giusta ogni evento, sono.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2483,7 +2502,7 @@
             <l>scontar mi fai tua scelta? Io t'amo, quanto</l>
             <l part="I">tu il merti.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -2498,7 +2517,7 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>EGISTO</stage>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2511,7 +2530,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>ORESTE, PILADE</stage>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -2523,7 +2542,7 @@
             <l>Altro non dico. A tuo piacer vaneggia;</l>
             <l>come al ferir, presto al morire io vengo.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -2539,14 +2558,14 @@
             <l>d'ira e pietade, onde me tutto empiea</l>
             <l part="I">di tal madre la vista.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="F">Ad essa incontro</l>
             <l part="I">chi ti spingea? non io.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -2557,21 +2576,21 @@
             <l>quindi entrambe a vicenda. — Oh vista! oh stato</l>
             <l part="I">terribil, quanto inesplicabil!...</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="F">Taci.</l>
             <l part="I">Ecco Egisto.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Che veggo? e con lui viene</l>
             <l part="I">anco la madre?...</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -2581,20 +2600,20 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>EGISTO, CLITENNESTRA, ORESTE, PILADE, <emph>soldati</emph></stage>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l>Vieni, consorte, vieni; udir ben puoi</l>
             <l>cosa, cui fede ancor non presto intera.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="I">Barbaro, a ciò mi sforzi?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2602,34 +2621,34 @@
             <l>voi di Focida il re veraci messi</l>
             <l part="I">dunque a me manda?</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="M">Sì.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Certa novella</l>
             <l part="I">recate voi?</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="F">Signore, un re c'invia;</l>
             <l>a un re parliam: loco può aver menzogna?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l>Ma, Strofio vostro a me non diè mai pegno</l>
             <l part="I">finora d'amistà.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -2641,7 +2660,7 @@
             <l>aiuto, ed armi; e a te giammai non volle</l>
             <l part="I">Strofio far guerra.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2649,27 +2668,27 @@
             <l>non ardì forse. Ma, di ciò non calmi.</l>
             <l part="I">Dove perìa colui?</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="M">Colui!</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="F">Di Creta</l>
             <l part="I">gli è tomba il suolo.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">E come estinto il seppe</l>
             <l part="I">Strofio anzi me?</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -2677,14 +2696,14 @@
             <l>portò tal nuova: al duro caso egli era</l>
             <l part="I">presente.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">E quivi ad immatura morte</l>
             <l part="I">che il trasse?</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -2700,13 +2719,13 @@
             <l>troppo a vincere intento, ivi la vita</l>
             <l part="I">per la vittoria ei dà.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Ma come? Narra.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -2727,14 +2746,14 @@
             <l>a marmorea colonna il fervid'asse,</l>
             <l part="I">riverso Oreste cade...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Ah! non più; taci:</l>
             <l part="I">una madre ti ascolta.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -2744,13 +2763,13 @@
             <l>Pilade accorse;... invan;... fra le sue braccia</l>
             <l part="I">spirò l'amico.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="M">Oh morte ria!...</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -2758,7 +2777,7 @@
             <l>in Creta ogni uom; tanta nel giovin era</l>
             <l part="I">beltade, grazia, ardire...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -2772,7 +2791,7 @@
             <l>sì, son io, che vi uccisi... Oh madre infame!</l>
             <l>oh rea consorte! — Or, sei tu pago, Egisto?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2781,21 +2800,21 @@
             <l>statevi intanto; e guiderdon qual dessi,</l>
             <l part="I">pria del partir v'avrete.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="F">A' cenni tuoi</l>
             <l part="I">staremci. — Vieni.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Andiamo, andiam; che omai</l>
             <l part="I">più non poss'io tacermi.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -2807,7 +2826,7 @@
             <l>Funesto, eppur gradito dono! ei spetta,</l>
             <l part="I">più che a niun'altri, a me.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -2819,7 +2838,7 @@
             <l>forte, e santa amistà che al mondo fosse,</l>
             <l>ei sel riserba: e a lui chi fia che il tolga?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2831,13 +2850,13 @@
             <l>sola una tomba, di tal coppia eletta</l>
             <l>non racchiudesse le reliquie estreme,</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="I">Oh rabbia; e tacer deggio?</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -2847,21 +2866,21 @@
             <l>mal suo grado il serbò. Spesso è da forte,</l>
             <l part="I">più che il morire, il vivere.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Mi abborre</l>
             <l>Pilade al par che m'abborriva Oreste.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l>Noi siam del padre messaggeri: ei brama</l>
             <l>piena amistade or rinnovar con Argo.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2869,33 +2888,33 @@
             <l>qual proprio figlio Oreste; ei dal mio sdegno</l>
             <l part="I">il difese, il sottrasse.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="F">Oreste spento,</l>
             <l part="I">non scema in te lo sdegno?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">E qual d'Oreste</l>
             <l part="I">era il delitto?</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Esser figliuol d'Atride.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="I">Che ardisci tu?...</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -2905,7 +2924,7 @@
             <l>t'insidiò; che perseguirne il figlio</l>
             <l part="I">dovevi...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -2914,39 +2933,39 @@
             <l>a morte infame; e sa, che al sol suo aspetto</l>
             <l part="I">tremato avresti...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Oh! che di' tu? Chi sei?</l>
             <l part="I">Parla.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="M">Son tale...</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="F">Egli è... Deh! non sdegnarti,</l>
             <l part="I">Egisto;... egli è...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="M">Chi?</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="M">Tal...</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -2963,14 +2982,14 @@
             <l>Deh! tu nol vogli or d'inesperti detti</l>
             <l>reo tener; né stimar, ch'altro qui 'l tragga.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l>Oh ciel! Pilade questi? Oh! vieni; dimmi,</l>
             <l part="I">novel mio figlio;... almen ch'io sappia...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -2983,7 +3002,7 @@
             <l>voi mentitori, traditor voi sete.</l>
             <l part="I">Soldati, or tosto in ceppi...</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -2991,34 +3010,34 @@
             <l>E fia pur ver, che un sol sospetto vano</l>
             <l>romper ti faccia or delle genti il dritto?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l>Sospetto? In volto la menzogna stavvi,</l>
             <l part="I">ed il timor scolpito.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">In cor scolpito</l>
             <l part="I">il rio timor ti sta.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Dite: non vera</l>
             <l part="I">potria forse la nuova?...</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="M">Ah! così...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -3026,7 +3045,7 @@
             <l>tremi tu già, che il figlio tuo riviva,</l>
             <l part="I">novella madre?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -3034,13 +3053,13 @@
             <l>sotto que' detti alcun feroce arcano.</l>
             <l part="I">Pria che tu n'abbi pena...</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="F">Oh ciel! deh! m'odi.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -3055,40 +3074,40 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>ELETTRA, CLITENNESTRA, EGISTO</stage>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l>Oreste a morte? oh ciel, che veggio! O madre,</l>
             <l part="I">a morte trar lasci il tuo figlio?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Il figlio?...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l>Oreste? in Argo? in mio poter? tra quelli?</l>
             <l part="I">Oreste? Oh gioia! Guardie...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="M">Il figlio!</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="F">Ahi lassa!</l>
             <l part="I">ah! che diss'io?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -3096,20 +3115,20 @@
             <l>ritornin tosto; ite, affrettate il piede,</l>
             <l part="I">volate. Oh gioia!</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="F">Io l'ho tradito! io stessa!</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l>Il figlio mio! — Crudel, se tu me pria</l>
             <l part="I">non sveni, trema...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -3117,28 +3136,28 @@
             <l>perfida donna, il mio mortal nemico</l>
             <l part="I">introduci, nascondi?</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="F">Erale ignoto</l>
             <l part="I">non men che a te: fu mio l'inganno.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">E d'ambe</l>
             <l part="I">sarà la pena.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Ah! no; me sola togli</l>
             <l part="I">di vita, me; ma i figli miei...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -3152,59 +3171,59 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>ORESTE, PILADE <emph>incatenati</emph>, EGISTO, CLITENNESTRA ELETTRA, <emph>soldati</emph></stage>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l>So tutto già; sol qual di voi sia Oreste,</l>
             <l part="I">dite...</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="M">Son io.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Menzogna: Oreste io sono.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l>Qual m'è figlio di voi? ditelo: scudo</l>
             <l part="I">a lui son io.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Tu parla, Elettra; e bada</l>
             <l part="I">a non mentir; qual è il fratello?</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="F">È questi;<note resp="#aut" place="foot" anchored="true">Correndo verso Pilade.</note></l>
             <l part="I">questi è, pur troppo!</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="M">Io, sì...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="M">Nol creder.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -3212,7 +3231,7 @@
             <l>Poiché scoperta è l'alta trama, omai</l>
             <l>del mio furor non osi altri vestirsi.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -3222,14 +3241,14 @@
             <l>ch'entro il codardo tuo petto trasfonde</l>
             <l part="I">sol la mia voce.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Traditor, codardo,</l>
             <l part="I">tu il sei; morrai tu di mia mano.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -3238,7 +3257,7 @@
             <l>per altra via non giungi. Arresta... oh cielo!...</l>
             <l>Deh! mi ti svela, Oreste. Ah sì; tu il sei.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -3247,14 +3266,14 @@
             <l>nessun ti è figlio, se abbracciar tal madre</l>
             <l part="I">da noi si debbe.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Oh feri detti! Eppure,...</l>
             <l part="I">no, te non lascio.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -3263,33 +3282,33 @@
             <l>alla tua filial pietà. Son degni</l>
             <l>di re i tuoi detti, e di tua stirpe infame.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l>Da parricida madre udir nomarsi</l>
             <l>figlio, e tacer, può chi di lei non nasce?</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="I">Cessate...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="F">Egisto, or non t'avvedi? è quegli</l>
             <l>Pilade e mente, per salvar l'amico...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l>Salvar l'amico? E qual di voi fia salvo?</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -3299,14 +3318,14 @@
             <l>più con man non ti posso, abbiti questo</l>
             <l part="I">palesator dell'esser mio.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="F">Deh! cela</l>
             <l part="I">quel ferro. Oh cielo!</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -3316,7 +3335,7 @@
             <l>che tu con mano empia tremante in petto</l>
             <l part="I">piantasti al padre mio.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -3330,7 +3349,7 @@
             <l>morire. Oh figlio!... Ancor son madre: e t'amo...</l>
             <l part="I">deh, fra mie braccia!...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -3338,7 +3357,7 @@
             <l>A un figlio parricida?... Olà: di mano,</l>
             <l part="I">guardie, il ferro...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -3354,14 +3373,14 @@
             <l>e sei madre d'Oreste? Oh rabbia! Vanne,</l>
             <l part="I">ch'io mai più non ti vegga.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Oimè!... mi sento...</l>
             <l part="I">morire...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -3383,14 +3402,14 @@
             <l>che al mio padre imbandì l'avo tuo crudo,</l>
             <l part="I">pareggi mai?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Morte al mio figlio? morte</l>
             <l part="I">avrai tu primo.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -3398,19 +3417,19 @@
             <l>anco per te, donna, sei omai... Dal fianco</l>
             <l part="I">mio non scostarti.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="M">Invan.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="M">Trema.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -3418,14 +3437,14 @@
             <l>in me tua sete, Egisto: io pur son figlia</l>
             <l part="I">d'Atride, io pur. Mira, a' tuoi piedi...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Elettra,</l>
             <l part="I">che fai?</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -3435,14 +3454,14 @@
             <l>incrudelir tu puoi. D'Oreste il sangue</l>
             <l>versar non puoi senza tuo rischio in Argo...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l>Pilade, Elettra, Oreste, a morte tutti:</l>
             <l>e tu pur, donna, ove il furor non tempri.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -3457,7 +3476,7 @@
             <l>e raffrenarmi, era impossibil cosa...</l>
             <l>Tanto a salvarmi feste; ed io vi uccido!</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -3466,26 +3485,26 @@
             <l>cadangli, Elettra pria, Pilade poscia;</l>
             <l part="I">quindi ei sovr'essi cada.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="M">Iniquo...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="F">O madre,</l>
             <l part="I">così uccider ne lasci?</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="M">Oreste!</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -3494,14 +3513,14 @@
             <l>già sì ardita al delitto, or debil tanto</l>
             <l part="I">all'ammenda sei tu?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Sol ch'io potessi</l>
             <l part="I">trarmi dall'empie mani; oh figlio!...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -3515,7 +3534,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>EGISTO, CLITENNESTRA</stage>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -3529,7 +3548,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>EGISTO, <emph>soldati</emph></stage>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -3540,47 +3559,47 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>CLITENNESTRA, EGISTO</stage>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Deh! volgi</l>
             <l part="I">addietro i passi.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Ah scellerata! all'armi</l>
             <l part="I">corri tu pure?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Io vo' salvarti: ah! m'odi;</l>
             <l part="I">non son più quella...</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="M">Perfida...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">T'arresta.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l>Darmi, perfida, vivo promettesti</l>
             <l part="I">a quel fellon tu forse?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -3589,7 +3608,7 @@
             <l>in securo ti cela; al furor suo</l>
             <l part="I">argin son io frattanto.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -3597,19 +3616,19 @@
             <l>argin miglior fian l'armi. Or va'; mi lascia.</l>
             <l part="I">Io corro...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="M">Ahi! dove?</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="M">A trucidarlo.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -3618,7 +3637,7 @@
             <l>non odi gli urli, il minacciar? t'arresta;</l>
             <l part="I">io non ti lascio.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -3626,7 +3645,7 @@
             <l>speri a morte sottrar. Scostati, taci,</l>
             <l part="I">lasciami, o ch'io...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -3637,7 +3656,7 @@
             <l>se tu in periglio stai: contro il mio sangue</l>
             <l part="I">già ridivengo io cruda.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -3648,26 +3667,26 @@
             <l>tu la cagion: per te indugiai vendetta,</l>
             <l part="I">ch'or torna in me.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="M">Me dunque uccidi.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
             <l part="F">Scampo</l>
             <l part="I">io troverò per altra via.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Ti sieguo.</l>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>
               <emph>Egisto</emph>
             </speaker>
@@ -3678,7 +3697,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>CLITENNESTRA</stage>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -3692,21 +3711,21 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>ELETTRA, CLITENNESTRA</stage>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l>Madre, ove vai? deh! nella reggia il piede</l>
             <l part="I">ritorci: alto periglio...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Oreste, narra,</l>
             <l part="I">dov'è? che fa?</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -3716,13 +3735,13 @@
             <l>grida primier Dimante; il popol quindi:</l>
             <l>«Oreste viva; Egisto, Egisto muoia».</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="I">Che sento!</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -3730,13 +3749,13 @@
             <l>rivedrai tosto; e delle spoglie infami</l>
             <l part="I">del tiranno...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Ahi crudel! Lasciami, io volo...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -3752,38 +3771,38 @@
             <l>trascorron ratti in ogni parte intanto</l>
             <l>Pilade ed egli, in armi. Ov'è l'iniquo?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="I">L'iniquo è Oreste.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="M">Oh ciel! che ascolto?</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Io corro</l>
             <l>a salvarlo; o a morir con esso io corro.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l>No, madre, non v'andrai. Fremon gli spirti...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="I">Mi è dovuta la pena; androvvi...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -3791,7 +3810,7 @@
             <l>quel vil, che i figli tuoi poc'anzi a morte</l>
             <l part="I">traea, tu vuoi?...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -3807,7 +3826,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>ELETTRA</stage>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -3826,13 +3845,13 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>PILADE, ELETTRA, <emph>seguaci di Pilade</emph></stage>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="F">Deh! dimmi: Oreste?...</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -3840,7 +3859,7 @@
             <l>la preda nostra. Ove si appiatta Egisto?</l>
             <l part="I">Vedestil tu?</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -3850,7 +3869,7 @@
             <l>che volea di sé fare a Egisto scudo.</l>
             <l>Ito era dunque ei pria fuor della reggia.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -3859,13 +3878,13 @@
             <l>chi primiero il ferìa! — Ma, più dappresso,</l>
             <l part="I">maggiori odo le strida...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="F">«Oreste»? Ah fosse!...</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -3875,7 +3894,7 @@
         <div type="scene">
           <head>SCENA VII</head>
           <stage>ORESTE, PILADE, ELETTRA, <emph>seguaci d'Oreste e di Pilade</emph></stage>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -3889,27 +3908,27 @@
             <l>Erebo il centro asil ti fia. Vedrai,</l>
             <l>tosto il vedrai, s'io son d'Atride il figlio.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="I">... Ei... qui non è.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Perfidi, voi, voi forse</l>
             <l part="I">senza me l'uccideste?</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="F">Ei della reggia</l>
             <l part="I">fuggì, pria ch'io venissi.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -3922,26 +3941,26 @@
             <l>col vil tuo corpo: ivi a versar trarrotti,</l>
             <l>tutto a versar l'adultero tuo sangue.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="I">Oreste, a me non credi? a me?...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Chi sei?</l>
             <l part="I">Egisto io voglio.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="M">Ei fugge.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -3952,34 +3971,34 @@
         <div type="scene">
           <head>SCENA VIII</head>
           <stage>CLITENNESTRA, ELETTRA, PILADE, ORESTE, <emph>seguaci d'Oreste e di Pilade</emph></stage>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="I">Figlio, pietà.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Pietà?... Di chi son figlio?</l>
             <l part="I">Io son d'Atride figlio.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">È di catene</l>
             <l part="I">già carco Egisto.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Ancor respira? oh gioia!</l>
             <l part="I">a trucidarlo vo.</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -3987,7 +4006,7 @@
             <l>il tuo padre svenai; svenami:... Egisto</l>
             <l part="I">reo non ne fu.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -3995,14 +4014,14 @@
             <l>chi mi rattiene? oh rabbia! Egisto... io 'l veggo;</l>
             <l part="I">qui strascinato ei vien;... togliti...</l>
           </sp>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
             <l part="F">Oreste,</l>
             <l part="I">non conosci la madre?</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -4013,7 +4032,7 @@
         <div type="scene">
           <head>SCENA IX</head>
           <stage>CLITENNESTRA, ELETTRA, PILADE, <emph>seguaci di Pilade</emph></stage>
-          <sp>
+          <sp who="#clitennestra">
             <speaker>
               <emph>Clitennestra</emph>
             </speaker>
@@ -4023,7 +4042,7 @@
         <div type="scene">
           <head>SCENA X</head>
           <stage>ELETTRA, PILADE, <emph>seguaci di Pilade</emph></stage>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -4034,7 +4053,7 @@
         <div type="scene">
           <head>SCENA XI</head>
           <stage>ELETTRA</stage>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -4058,7 +4077,7 @@
         <div type="scene">
           <head>SCENA XII</head>
           <stage>ELETTRA, ORESTE</stage>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -4066,7 +4085,7 @@
             <l>vendicator del re dei re, del padre,</l>
             <l part="I">d'Argo, di me; vieni al mio sen...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -4079,14 +4098,14 @@
             <l>tremante cor fitto e rifitto ho il brando: —</l>
             <l>pur non ho sazia la mia lunga sete.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l>In tempo dunque a rattenerti il braccio</l>
             <l part="I">non giungea Clitennestra.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -4097,7 +4116,7 @@
             <l>quel pianto infame. Ah padre! uom che non osa</l>
             <l part="I">morir, ti uccise?</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -4105,7 +4124,7 @@
             <l>tuoi spirti acqueta; e dimmi: agli occhi tuoi</l>
             <l part="I">Pilade non occorse?</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -4113,27 +4132,27 @@
             <l>null'altro. — Ov'è Pilade amato? e come</l>
             <l>a tanta impresa non l'ebb'io secondo?</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l>A lui la disperata madre insana</l>
             <l part="I">dianzi affidai.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Nulla di loro io seppi.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l>Ecco, Pilade torna;... oh ciel! che veggio?</l>
             <l part="I">Solo ei ritorna?</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -4143,7 +4162,7 @@
         <div type="scene">
           <head>SCENA ULTIMA</head>
           <stage>ORESTE, PILADE, ELETTRA</stage>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -4154,72 +4173,72 @@
             <l>meco i colpi non hai! pasciti dunque</l>
             <l part="I">di questa vista gli occhi.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="F">Oh vista! — Oreste,</l>
             <l part="I">dammi quel brando.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="M">A che?</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="M">Dammelo.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Il prendi.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l>Odimi. — A noi non lice in questa terra</l>
             <l part="I">più rimaner: vieni...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="M">Ma qual?...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="F">Deh! parla:</l>
             <l part="I">Clitennestra dov'è?</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Lasciala: or forse</l>
             <l>al traditor marito ella arde il rogo.</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l>Più che compiuta hai la vendetta: or vieni;</l>
             <l part="I">non cercar oltre...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="M">Oh! che di' tu?...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -4227,68 +4246,68 @@
             <l>ti ridomando, Pilade. — Oh, qual m'entra</l>
             <l part="I">gel nelle vene!</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="M">Il cielo...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="F">Ah! spenta forse...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l>Volte in se stessa infuriata ha l'armi?...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="I">— Pilade; oimè!... tu non rispondi?</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="F">Narra;</l>
             <l part="I">che fu?</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="M">Trafitta...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="M">E da qual mano?</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="F">— Ah! vieni...</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="I">Tu la uccidesti.</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
             <l part="M">Io parricida?...</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
@@ -4296,7 +4315,7 @@
             <l>vibrasti in lei, senza avvederten, cieco</l>
             <l part="I">d'ira, correndo a Egisto incontro...</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -4304,25 +4323,25 @@
             <l>orror mi prende! Io parricida? — Il brando,</l>
             <l part="I">Pilade, dammi: io 'l vo'...</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="M">Non fia.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
             <l part="F">Fratello...</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>
             <l part="I">Misero Oreste!</l>
           </sp>
-          <sp>
+          <sp who="#oreste">
             <speaker>
               <emph>Oreste</emph>
             </speaker>
@@ -4335,7 +4354,7 @@
             <l>torvo mi guardi? a me chiedesti sangue:</l>
             <l>e questo è sangue;... e sol per te il versai.</l>
           </sp>
-          <sp>
+          <sp who="#elettra">
             <speaker>
               <emph>Elettra</emph>
             </speaker>
@@ -4343,7 +4362,7 @@
             <l>Già più non ci ode;... è fuor di sé... Noi sempre,</l>
             <l part="I">Pilade, al fianco a lui staremo...</l>
           </sp>
-          <sp>
+          <sp who="#pilade">
             <speaker>
               <emph>Pilade</emph>
             </speaker>

--- a/tei/alfieri-ottavia.xml
+++ b/tei/alfieri-ottavia.xml
@@ -82,6 +82,25 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="seneca">
+            <persName>Seneca</persName>
+          </person>
+          <person xml:id="nerone">
+            <persName>Nerone</persName>
+          </person>
+          <person xml:id="poppea">
+            <persName>Poppea</persName>
+          </person>
+          <person xml:id="tigellino">
+            <persName>Tigellino</persName>
+          </person>
+          <person xml:id="ottavia">
+            <persName>Ottavia</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -122,25 +141,25 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>NERONE, SENECA</stage>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
             <l part="I">Signor del mondo, a te che manca?</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l part="F">Pace.</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
             <l part="I">L'avrai, se ad altri non la togli.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -148,7 +167,7 @@
             <l>l'avria Neron, se di abborrito nodo</l>
             <l>stato non fosse a Ottavia avvinto mai.</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
@@ -160,7 +179,7 @@
             <l>di te così, benché a rival superba</l>
             <l>ti sappia in braccio, (ahi misera!) ancor t'ama.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -175,7 +194,7 @@
             <l>sommessamente infra tremanti labra,</l>
             <l>mai profferire; — o ch'io Neron non sono.</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
@@ -192,7 +211,7 @@
             <l>di Burro, a lei sì feramente espulsa</l>
             <l part="I">con tristo augurio dati: e dissi...</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -205,7 +224,7 @@
             <l>fu l'espeller colei, che mai non debbe,</l>
             <l part="I">mai stanza aver lungi da me...</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
@@ -213,25 +232,25 @@
             <l>dunque? ed è ver quanto ascoltai? ritorna</l>
             <l part="I">Ottavia?</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l part="M">Sì.</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
             <l part="F">Pietà di lei ti prese?</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l part="I">Pietade?... Sì: pietà men prese.</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
@@ -239,7 +258,7 @@
             <l>compagna e al regal talamo tornarla,</l>
             <l part="I">forse?...</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -251,7 +270,7 @@
             <l>tu non vorrai da quel di pria diverso</l>
             <l part="I">mostrarmiti.</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
@@ -261,7 +280,7 @@
             <l>noto or non m'è; ma per Ottavia io tremo,</l>
             <l part="I">udendo il parlar tuo.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -272,7 +291,7 @@
             <l>madre mia, che nemica erati fera,</l>
             <l part="I">tremavi tu?</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
@@ -292,7 +311,7 @@
             <l>parran tuoi doni: ah! li ripiglia; e lascia</l>
             <l>a me la stima di me stesso intera.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -316,7 +335,7 @@
             <l>tal di mia reggia addobbo sei, che biasmo</l>
             <l>di me non fai, che più di te nol facci.</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
@@ -328,21 +347,21 @@
             <l>Qual mi puoi nuova infame cura imporre,</l>
             <l part="I">che aggiunga?...</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l part="F">Ei t'è mestier dal cor del volgo</l>
             <l part="I">trarre Ottavia.</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
             <l part="F">Non cangia il volgo affetti,</l>
             <l part="I">come il signore; e mal s'infinge.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -360,7 +379,7 @@
             <l>Torne a te più, che non ten resta, io posso.</l>
             <l>Taci omai dunque, e va'; per me t'adopra.</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
@@ -374,7 +393,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>NERONE</stage>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -395,7 +414,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>NERONE, POPPEA</stage>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
@@ -404,7 +423,7 @@
             <l>me tieni in fera angoscia. E che? non fia,</l>
             <l>ch'io lieto mai del nostro amor ti vegga?</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -414,7 +433,7 @@
             <l>travagliarmi in serbarti: il sai, che a costo</l>
             <l part="I">anco del trono, io ti vo' mia...</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
@@ -425,7 +444,7 @@
             <l>tu a me ti togli; e il puoi tu appien; com'io</l>
             <l>sopravvivere al perderti non posso.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -435,14 +454,14 @@
             <l>gli affetti del cor mio: quindi m'è forza,</l>
             <l part="I">che antivedendo io tolga...</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
             <l part="F">E al grido badi</l>
             <l part="I">del popolo?</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -464,7 +483,7 @@
             <l>di Claudio inetto, e sospirar pur sempre</l>
             <l part="I">ciò che più aver non puote.</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
@@ -472,7 +491,7 @@
             <l>Roma nol sa; ma, e ch'altro omai sa Roma,</l>
             <l part="I">che cinguettar? Dei tu temerne?</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -487,7 +506,7 @@
             <l>Io mal colà bando a lei diedi, e peggio</l>
             <l part="I">farei quivi lasciandola.</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
@@ -500,7 +519,7 @@
             <l>da lei, che darsi il folle vanto ardisce</l>
             <l part="I">d'averti dato il trono?</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -509,39 +528,39 @@
             <l>stanza più assai per me secura ell'abbia</l>
             <l part="I">Roma, e la reggia mia.</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
             <l part="F">Che ascolto? In Roma</l>
             <l part="I">Ottavia riede!</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l part="F">A mie ragion dà loco...</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
             <l part="I">Ove son io, colei?...</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l part="M">Deh! m'odi...</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
             <l part="F">Intendo;</l>
             <l part="I">ben veggo;... io tosto sgombrerò...</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -549,7 +568,7 @@
             <l>Ottavia in Roma a danno tuo non torna;</l>
             <l part="I">a suo danno bensì...</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
@@ -576,7 +595,7 @@
             <l>appien così strappar la immagin tua,</l>
             <l part="I">come da te svellermi spero!...</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -585,7 +604,7 @@
             <l>quant'io già fei; quanto a più far mi appresto.</l>
             <l part="I">Ma tu...</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
@@ -595,7 +614,7 @@
             <l>che amar Neron, né può, né sa, né vuole;</l>
             <l part="I">e sì pur finger l'osa.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -612,7 +631,7 @@
             <l>Chi me più teme ed obbedisce, sappi,</l>
             <l part="I">ch'ei m'ama più.</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
@@ -621,7 +640,7 @@
             <l>danno! il tuo amor tu mi puoi torre... Ah! pria</l>
             <l>mia vita prendi, assai minor fia il danno.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -642,7 +661,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>POPPEA, TIGELLINO</stage>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
@@ -650,13 +669,13 @@
             <l>oggi cercare, o Tigellin, dobbiamo</l>
             <l part="I">comun riparo.</l>
           </sp>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
             <l part="F">E che? d'Ottavia temi?...</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
@@ -667,7 +686,7 @@
             <l>e della plebe gl'impeti; e i rimorsi</l>
             <l part="I">dello stesso Nerone.</l>
           </sp>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
@@ -679,7 +698,7 @@
             <l>giunto al rio nuziale odio primiero.</l>
             <l>Questo è il riparo al comun nostro danno.</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
@@ -698,7 +717,7 @@
             <l>capace il credo. Or, se vi aggiungi gli urli,</l>
             <l part="I">le minacce di Roma...</l>
           </sp>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
@@ -712,7 +731,7 @@
             <l>meglio assottiglia, che il timor suo immenso.</l>
             <l>Roma, Ottavia chiamando, Ottavia uccide.</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
@@ -724,7 +743,7 @@
             <l>solo basta un istante; a noi che giova,</l>
             <l>se cader dobbiam pria, ch'ella poi cada?</l>
           </sp>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
@@ -737,7 +756,7 @@
             <l>l'abborre in lei. — Ma pur, s'io nulla posso,</l>
             <l part="I">che far debb'io? favella.</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
@@ -751,7 +770,7 @@
             <l>aggirarlo, acciecarlo; e vegliar sempre: —</l>
             <l part="I">ciò far tu dei.</l>
           </sp>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
@@ -761,7 +780,7 @@
             <l>di vendetta è maestro: e, il sai, si sdegna</l>
             <l part="I">s'altri quant'ei mostra saperne.</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
@@ -770,7 +789,7 @@
             <l>del soverchio amor mio poc'anzi; e fero</l>
             <l>signor già favellava a me dal trono.</l>
           </sp>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
@@ -781,7 +800,7 @@
             <l>meco in quest'ora ei favellar qui suole:</l>
             <l part="I">ogni tua cura affida in me.</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
@@ -793,7 +812,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>TIGELLINO</stage>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
@@ -816,7 +835,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>NERONE, TIGELLINO</stage>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
@@ -827,14 +846,14 @@
             <l>dubbio, temenza, amore. Ah! puoi tu tanto</l>
             <l>affligger donna, che così t'adora?</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l>Cieca ella ognor di gelosia non giusta,</l>
             <l>veder non vuole il vero. Amo lei sola...</l>
           </sp>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
@@ -850,7 +869,7 @@
             <l>bench'io nol sappia, in Roma Ottavia appelli;</l>
             <l part="I">ma non a danno di Poppea.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -861,7 +880,7 @@
             <l>compiuto forse non sarà, che fermo</l>
             <l>fia d'Ottavia il destino, e appien per sempre.</l>
           </sp>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
@@ -869,7 +888,7 @@
             <l>ove mostrar pur vogli Ottavia al volgo</l>
             <l part="I">rea, quanto ell'è.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -877,7 +896,7 @@
             <l>quanto il possa esser mai. Degg'io di prove</l>
             <l part="I">avvalorare il voler mio?</l>
           </sp>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
@@ -889,7 +908,7 @@
             <l>d'Ottavia piange, e mormorar si attenta.</l>
             <l>Svela i falli d'Ottavia, e ogni uom fia muto.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -903,7 +922,7 @@
             <l>Roma saprà, ch'ella cessava: ed ecco</l>
             <l>qual conto a Roma del mio oprare io debbo.</l>
           </sp>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
@@ -915,13 +934,13 @@
             <l>il maggior, non fia 'l meglio? e rea chiarirla,</l>
             <l>qual ella è pur, mentre innocente tiensi?</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l part="I">Delitti... altri... maggiori?...</l>
           </sp>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
@@ -939,13 +958,13 @@
             <l>prostituire a citarista infame,</l>
             <l part="I">ch'ella adocchiando andava...</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l part="F">Oh infamia! Oh ardire!...</l>
           </sp>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
@@ -963,7 +982,7 @@
             <l>alternate col canto: indi l'altezza</l>
             <l>già non t'invidia del primier suo grado.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -971,7 +990,7 @@
             <l>chi d'essa nasce? — Or di'; possibil fora</l>
             <l part="I">prove adunar di ciò?</l>
           </sp>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
@@ -987,26 +1006,26 @@
             <l>ben si conobbe, e quindi il cor suo basso</l>
             <l part="I">bassamente locò.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l part="F">Ma oscuro fallo,</l>
             <l>temo, che il trarlo a obbrobriosa luce...</l>
           </sp>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
             <l part="I">L'infamia è di chi 'l fece.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l part="M">È ver...</l>
           </sp>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
@@ -1014,7 +1033,7 @@
             <l>abbia ognun dunque: ella di rea; di giusto</l>
             <l>tu, che senza tuo danno esserlo puoi.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -1024,7 +1043,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>SENECA, NERONE, TIGELLINO</stage>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
@@ -1034,7 +1053,7 @@
             <l>invido niun di tale onore: a tristo</l>
             <l part="I">augurio il tengo.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -1047,7 +1066,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>NERONE</stage>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -1063,7 +1082,7 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>NERONE, OTTAVIA</stage>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -1073,7 +1092,7 @@
             <l>sveller mi vidi a viva forza. Or, lice</l>
             <l>ch'io la cagione al mio signor ne chiegga?</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -1091,7 +1110,7 @@
             <l>m'era, per te, di padre il dolce nome. —</l>
             <l part="I">Ti repudiai perciò.</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -1106,7 +1125,7 @@
             <l>e riverenza, e silenzio, e sospiri,</l>
             <l part="I">forse da me s'udia giammai?</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -1117,7 +1136,7 @@
             <l>e celasti assai meno altre superbe</l>
             <l>tue ricordanze di non veri dritti.</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -1132,7 +1151,7 @@
             <l>Ma, che ti chiesi? e che ti chieggo? oscura</l>
             <l>solinga vita, e libertà del pianto.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -1140,7 +1159,7 @@
             <l>ti appagheresti meglio, a te prescritta</l>
             <l part="I">l'avea; ma poi...</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -1161,7 +1180,7 @@
             <l>d'un fratello non hai, più ch'io nol fea,</l>
             <l part="I">ti fa beato?</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -1169,7 +1188,7 @@
             <l>il cor tenersi del signor del mondo,</l>
             <l part="I">mai nol sapesti; e il sa Poppea.</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -1179,14 +1198,14 @@
             <l>meco venirne ella in amarti. Ottiene</l>
             <l part="I">ella il tuo cor; ma il merto io sola.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l part="F">Amarmi,</l>
             <l part="I">no, tu non puoi.</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -1200,31 +1219,31 @@
             <l>da te svenati io non rimembro, ardisci</l>
             <l>tu a delitto il fratello e il padre appormi?</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l>A delitto ti appongo Eucero vile...</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
             <l part="I">Eucero! a me?...</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l part="F">Sì; l'amator, che merti.</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
             <l part="I">Ahi giusto ciel! tu l'odi?...</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -1234,7 +1253,7 @@
             <l>O a smentirlo, o a riceverne la pena,</l>
             <l part="I">a qual più vuoi, ti appresta.</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -1243,7 +1262,7 @@
             <l>accusator?... Ma, oimè! stolta, che chieggo? —</l>
             <l>Nerone accusa, e giudica, ed uccide.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -1251,7 +1270,7 @@
             <l>dal petto al fin non ti trabocca; or, ch'io</l>
             <l>le tue arcane laidezze in parte scopro.</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -1288,7 +1307,7 @@
             <l>morte a placarti basti: or macchia infame</l>
             <l>perché mi apporre, ov'io morte sol chieggo?</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -1301,7 +1320,7 @@
         <div type="scene">
           <head>SCENA VII</head>
           <stage>OTTAVIA</stage>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -1315,20 +1334,20 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>OTTAVIA, SENECA</stage>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
             <l>Vieni, o Seneca, vieni; almen ch'io pianga</l>
             <l>con te: niun con chi piangere mi resta.</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
             <l>Donna, e fia ver? mentita accusa infame...</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -1336,7 +1355,7 @@
             <l>ultimo oltraggio; e sol quest'uno avanza</l>
             <l part="I">ogni mia sofferenza.</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
@@ -1355,7 +1374,7 @@
             <l>sia l'amarezza del tuo pianto: io tutto</l>
             <l part="I">sento e divido il dolor tuo...</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -1376,7 +1395,7 @@
             <l>per me il vederlo d'altra donna amante</l>
             <l>è il rio dolor, che ogni dolor sorpassa.</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
@@ -1396,7 +1415,7 @@
             <l>risparmiarti l'infamia! Oh come lieto</l>
             <l part="I">morrei di ciò!</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -1407,13 +1426,13 @@
             <l>eppur la bramo; e sospiroso il guardo</l>
             <l>a te, maestro del morire, io volgo.</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
             <l part="I">Deh!... pensa... Il cor mi squarci... Oimè!...</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -1422,14 +1441,14 @@
             <l>L'infamia! or vedi, onde a me vien: Poppea</l>
             <l part="I">bassi amori mi appone.</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
             <l part="F">Oh degna sposa</l>
             <l part="I">di Neron fero!</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -1446,7 +1465,7 @@
             <l>crederlo finsi: invan. Ognor spiacergli,</l>
             <l part="I">era il destin mio crudo.</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
@@ -1464,40 +1483,40 @@
             <l>Fero è, superbo; eppur mal fermo in trono</l>
             <l part="I">finor vacilla: e forse un dì...</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
             <l part="F">Qual odo</l>
             <l part="I">alto fragore?...</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
             <l part="M">Il popol, parmi...</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
             <l part="F">Oh cielo!</l>
             <l part="I">alla reggia appressarsi...</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
             <l part="F">Odo le grida</l>
             <l part="I">di mossa plebe.</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
             <l part="M">Oimè! che fia?</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
@@ -1505,7 +1524,7 @@
             <l>soli noi siam, che in questa orribil reggia</l>
             <l part="I">paventar non dobbiamo...</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -1513,14 +1532,14 @@
             <l>il tumulto. Ahi me misera! in periglio </l>
             <l part="I">forse è Neron... Ma chi vegg'io?</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
             <l part="F">Nerone; </l>
             <l part="I">eccolo, ei viene.</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -1531,7 +1550,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>NERONE, OTTAVIA, SENECA</stage>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -1543,7 +1562,7 @@
             <l>vederti chiede. Ah! se mostrarti io deggio,</l>
             <l>spero, qual merti, almen mostrarti; estinta.</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -1554,21 +1573,21 @@
             <l>nuocerti pur, mal grado mio, potessi,</l>
             <l>col mio supplizio il non mio error previeni.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l>Rea, qual ti sei, pria di punirti, io voglio</l>
             <l part="I">che ogni uom te sappia.</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
             <l part="F">Ed ingannar tu speri</l>
             <l>con sì turpe menzogna il popol tutto?</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -1581,19 +1600,19 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>TIGELLINO, NERONE, OTTAVIA, SENECA</stage>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
             <l part="I">Signor...</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l part="F">Che rechi, o Tigellin? favella.</l>
           </sp>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
@@ -1624,14 +1643,14 @@
             <l>invan; disgiunti, sbaragliati, o uccisi,</l>
             <l>è un sol momento. — Omai, che far? Che imponi?</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l>Che far?... Si mostri or questa Ottavia al volgo;</l>
             <l part="I">su via, si mostri; — indi si sveni.</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -1646,20 +1665,20 @@
             <l>sepolcro avrai. Perché più indugi? or questo</l>
             <l>mio capo prendi; al tuo furore il debbo.</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
             <l>Se perder vuoi seggio ad un tempo e vita,</l>
             <l>Neron, sicuro è il mezzo; Ottavia uccidi.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l part="I">Vendetta avronne ad ogni costo.</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -1667,7 +1686,7 @@
             <l>morti vogl'io, non ch'una, anzi che danno</l>
             <l part="I">lieve arrecare al signor mio.</l>
           </sp>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
@@ -1677,7 +1696,7 @@
             <l>meno affrontabil, chi di gioia è figlio.</l>
             <l part="I">Sceglier partito è forza.</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -1698,7 +1717,7 @@
             <l>tempo così di sguainar tua spada,</l>
             <l>e di segnar tue vittime t'acquisti.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -1710,7 +1729,7 @@
             <l>sovra gli audaci; e i passi tuoi sien morte</l>
             <l part="I">di quanto incontri.</l>
           </sp>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
@@ -1722,14 +1741,14 @@
             <l>ch'io co' miei forti cada; in tua difesa</l>
             <l part="I">chi resta allora?</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l part="F">È ver... Ma, il ceder pure</l>
             <l part="I">parrebbe...</l>
           </sp>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
@@ -1737,7 +1756,7 @@
             <l>non far di lieve: il sol tuo aspetto forse</l>
             <l part="I">può dissiparli appieno.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -1753,7 +1772,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>NERONE, OTTAVIA, SENECA</stage>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -1763,7 +1782,7 @@
             <l>fare a tua posta puoi; spera, desia;</l>
             <l part="I">già già si appressa anco il tuo dì.</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
@@ -1773,14 +1792,14 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>NERONE, OTTAVIA</stage>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l>E tu, fia questo il tuo trionfo estremo,</l>
             <l part="I">godine pur; che breve...</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -1791,7 +1810,7 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>POPPEA, NERONE, OTTAVIA</stage>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
@@ -1804,7 +1823,7 @@
             <l>signor del mondo egli è Nerone! il volgo</l>
             <l part="I">pur la sua donna a lui prefigge.</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -1816,7 +1835,7 @@
             <l>le tue superbe lagrime rasciutte</l>
             <l>tosto saranno con tutto il mio sangue.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -1825,7 +1844,7 @@
             <l>Gli avuti oltraggi, a te, Poppea, verranno</l>
             <l>ascritti a onor; a infamia sua gli onori.</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -1839,14 +1858,14 @@
             <l>tu, che sì altera in tua virtù ti stai;</l>
             <l>tu, né pur osi or sostener miei sguardi.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l>Che ardisci tu? Del tuo signor rispetta</l>
             <l part="I">la sposa; trema...</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
@@ -1861,7 +1880,7 @@
             <l>d'Eucero amante, degnamente io farti</l>
             <l part="I">d'Eucero voglio sposa.</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -1870,7 +1889,7 @@
             <l>io non contendo: a ciò non nacqui: ardita</l>
             <l part="I">non son io tanto...</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -1879,7 +1898,7 @@
             <l>tua turpe fiamma: appien dal prisco grado,</l>
             <l>dalla tua stirpe appien scaduta sei.</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -1894,13 +1913,13 @@
             <l>costei: tuo grado, il trono, e quanto intorno</l>
             <l>ti sta, ciò tutto, e non Nerone ell'ama.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l part="I">Perfida, or ora...</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -1915,13 +1934,13 @@
             <l>miei, che i minori fieno: ma sanguigno</l>
             <l>corre il Tebro per te; fratello, e madre...</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l part="I">Cessa, taci, ritratti, o ch'io...</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
@@ -1933,7 +1952,7 @@
             <l>punto m'avria. Che disse? ch'io non t'amo?</l>
             <l part="I">Tu sai...</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -1945,14 +1964,14 @@
             <l>di oscuro sangue! a te spiacevol meno,</l>
             <l>meno odiosa, e men sospetta io t'era.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l>Meno odiosa a me? tu sempre il fosti;</l>
             <l part="I">e il sei vieppiù: ma, omai per poco.</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
@@ -1962,7 +1981,7 @@
             <l>il fossi pur, non figlia esser mi basta</l>
             <l part="I">di Messalina.</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -1974,7 +1993,7 @@
             <l>gli scambiati mariti? avanzo forse</l>
             <l part="I">son io d'un Rufo, o d'un Ottone?</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -1988,7 +2007,7 @@
         <div type="scene">
           <head>SCENA VII</head>
           <stage>NERONE, POPPEA</stage>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -2000,14 +2019,14 @@
             <l>ella fia tratta mai. — Ti acqueta; in calma</l>
             <l part="I">ritorna; in me ti affida...</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
             <l part="F">Altro non temo,</l>
             <l part="I">che di morir non tua...</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -2024,20 +2043,20 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>POPPEA, SENECA</stage>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
             <l part="I">Da me che vuoi?</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
             <l part="F">Scusa, importuno io vengo:</l>
             <l part="I">ma forse, io vengo in tuo vantaggio...</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
@@ -2046,7 +2065,7 @@
             <l>amico mai, né il sei? Cagion qual altra,</l>
             <l part="I">che di volermi nuocere?...</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
@@ -2059,14 +2078,14 @@
             <l>parlar mi fanno: ad ascoltar ti muova</l>
             <l part="I">tuo interesse, e null'altro.</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
             <l part="F">Udiam: che dirmi</l>
             <l part="I">puoi tu?</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
@@ -2076,14 +2095,14 @@
             <l>ti dico in ciò: sai ch'io Neron conosco,</l>
             <l part="I">Roma, i tempi, e Poppea.</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
             <l part="F">Tutto conosci,</l>
             <l part="I">fuorché te stesso.</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
@@ -2109,7 +2128,7 @@
             <l>ch'ei non ti tiene. E guai, se a tale eletta</l>
             <l part="I">lo sforza Roma.</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
@@ -2121,7 +2140,7 @@
             <l>pien di temenza, che a Tiberio, a Caio</l>
             <l part="I">muto obbedia?...</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
@@ -2152,13 +2171,13 @@
             <l>quella, onde avaro mai Neron non fia;</l>
             <l>a chi più l'ama più crudel la morte.</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
             <l part="I">Ecco Neron; prosiegui.</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
@@ -2168,20 +2187,20 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>NERONE, POPPEA, SENECA</stage>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l part="I">Perfido; ed osi al mio divieto?...</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
             <l part="F">Ah! vieni;</l>
             <l part="I">vieni, ed udrai...</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -2196,7 +2215,7 @@
             <l>ma d'atro sangue intriso, strascinate</l>
             <l part="I">vedrai le altrui.</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
@@ -2215,7 +2234,7 @@
             <l>stimai che pena ella ben ampia avesse,</l>
             <l part="I">nel perder te: pena, qual io...</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -2223,7 +2242,7 @@
             <l>parlar Seneca, e il volgo. A Roma or ora</l>
             <l>chiaro farò, qual sia quest'idol suo.</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
@@ -2231,7 +2250,7 @@
             <l>Roma atterrir: l'uno assai volte festi;</l>
             <l part="I">l'altro non mai.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -2239,20 +2258,20 @@
             <l>ad ingannarla io spesso; e a ciò pur eri</l>
             <l part="I">arrendevole tu...</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
             <l part="F">Colpevol spesso</l>
             <l>anch'io: ma in corte di Nerone io stava.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l part="I">Vil servo...</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
@@ -2262,14 +2281,14 @@
             <l>fian lieve i detti, è ver; ma in fama forse</l>
             <l part="I">tornar potrammi alto morire.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l part="F">In fama</l>
             <l part="I">io ti porrò, qual merti...</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
@@ -2306,13 +2325,13 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>NERONE, POPPEA</stage>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
             <l part="I">Signor, deh! frena il furor tuo...</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -2324,7 +2343,7 @@
             <l>costor che a un tratto io svenerei, m'è forza,</l>
             <l>con lunghi indugi, ad uno ad un svenarli.</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
@@ -2332,14 +2351,14 @@
             <l>meco mi adiro! Io son la ria cagione</l>
             <l part="I">d'ogni tuo affanno, io sola.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l part="F">A me più cara</l>
             <l part="I">sei, quanto più mi costi.</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
@@ -2358,7 +2377,7 @@
             <l>che altronde vien, pure in mio core ho fermo,...</l>
             <l part="I">ahi, sì, pur troppo!... e il deggio, e il voglio...</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -2367,7 +2386,7 @@
             <l>e già ne ottenni alquanto. Omai, che temi?</l>
             <l part="I">trionferemo, accertati...</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
@@ -2375,14 +2394,14 @@
             <l>che, s'io pure a' tuoi piedi ora non spiro,...</l>
             <l part="I">l'ultimo addio ti doni...</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l part="F">Oh! che favelli?</l>
             <l part="I">deh! sorgi. Io mai lasciarti?...</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
@@ -2397,13 +2416,13 @@
             <l>fosti, al tornar di Ottavia; or, crescer odi</l>
             <l part="I">l'ardire; onde atterrito...</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l part="F">Atterrito io?...</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
@@ -2414,13 +2433,13 @@
             <l>per anco udir di un Seneca t'è forza:</l>
             <l part="I">ben vedi...</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l part="M">Atterrito io?</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
@@ -2437,13 +2456,13 @@
             <l>perder ti vo', per conservarti il core</l>
             <l part="I">del popol tuo.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l part="M">Ma che? mi credi?...</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
@@ -2462,7 +2481,7 @@
             <l>bastante a me sollievo fia, l'averti,</l>
             <l part="I">col mio partir, tolto ogni danno...</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -2477,7 +2496,7 @@
             <l>son lenti; e il paion più: ma il venir tarda</l>
             <l part="I">nocque a vendetta mai?</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
@@ -2492,13 +2511,13 @@
             <l>scambiar Poppea pel trono? Ah! Neron, prendi</l>
             <l part="I">l'ultimo addio...</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l part="F">Non più: troppo m'irrìta...</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
@@ -2513,7 +2532,7 @@
             <l>io da te morrò pria;... ma intero almeno</l>
             <l>così il tuo amor ne porto io meco in tomba...</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -2526,13 +2545,13 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>TIGELLINO, NERONE, POPPEA</stage>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
             <l part="I">Viva Neron.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -2540,7 +2559,7 @@
             <l>Signor son io di Roma? — E che? tu torni</l>
             <l part="I">senza sangue sul brando?</l>
           </sp>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
@@ -2556,21 +2575,21 @@
             <l>di pace in Roma apportatrice riede,</l>
             <l part="I">non di scompiglio...</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
             <l part="F">E crede il popol stolto,</l>
             <l part="I">ch'io la di lei pietà?</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l part="F">Sempre arte, sempre?</l>
             <l part="I">non ferro mai?...</l>
           </sp>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
@@ -2593,13 +2612,13 @@
             <l>mai non verresti del tuo intento a fine.</l>
             <l part="I">Tutti uccider non puoi...</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l part="M">Men duol.</l>
           </sp>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
@@ -2607,7 +2626,7 @@
             <l>convincer puoi. L'ultima strage è questa,</l>
             <l part="I">ove adoprar l'arte omai debbi.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -2625,7 +2644,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>OTTAVIA</stage>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -2659,7 +2678,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>OTTAVIA, SENECA</stage>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -2667,7 +2686,7 @@
             <l>Vieni, o mio più che padre... E che? nel volto</l>
             <l part="I">men tristo sembri: oh! che mi arrechi?</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
@@ -2688,7 +2707,7 @@
             <l>di tua santa onestà cantando, salda</l>
             <l>ella ai tormenti, da forte spirava.</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -2696,7 +2715,7 @@
             <l>Ma ciò, che vale? A ricomprar mio sangue,</l>
             <l part="I">havvi sangue che basti?</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
@@ -2718,14 +2737,14 @@
             <l>trattengon, mal lor grado. In fretta io vengo</l>
             <l part="I">il grato avviso a dartene.</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
             <l part="F">Deh! mira,</l>
             <l part="I">chi viene a me: miralo, e spera.</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
@@ -2735,13 +2754,13 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>TIGELLINO, OTTAVIA, SENECA</stage>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
             <l part="I">Il tuo signor ver te m'invia.</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -2749,7 +2768,7 @@
             <l>tu almen mia morte? Or che innocente io sono,</l>
             <l part="I">grata sarammi.</l>
           </sp>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
@@ -2761,14 +2780,14 @@
             <l>tolti ai tormenti, ma a te stessa il mezzo</l>
             <l part="I">di scolparti toglievi...</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
             <l part="F">Or, qual novella</l>
             <l part="I">menzogna?...</l>
           </sp>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
@@ -2778,31 +2797,31 @@
             <l>non fra' martìr, ma libero, e non chiesto,</l>
             <l part="I">viene a mercé.</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
             <l part="M">Qual reo? Parla.</l>
           </sp>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
             <l part="F">Aniceto.</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
             <l part="I">D'Agrippina il carnefice!</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
             <l part="F">Che sento?</l>
           </sp>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
@@ -2813,13 +2832,13 @@
             <l>e tutto svela: ma non men sua pena</l>
             <l part="I">ne avrà perciò.</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
             <l part="M">Quale impostura?...</l>
           </sp>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
@@ -2828,14 +2847,14 @@
             <l>tuo ribellar non prometteati? — E dirti</l>
             <l part="I">deggio, a qual patto?</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
             <l part="F">Ahi! lassa me! Che ascolto?</l>
             <l part="I">oh scellerata gente! oh tempi!...</l>
           </sp>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
@@ -2848,7 +2867,7 @@
             <l>che rea ti accusi: a ciò ti dona intero</l>
             <l part="I">questo venturo dì.</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -2863,32 +2882,32 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>OTTAVIA, SENECA</stage>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
             <l part="I">E che vuoi far?</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
             <l part="F">Morir; sugli occhi loro.</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
             <l>Che parli?... Oimè! tel vieterà, se il brami...</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
             <l>E un sì gran dono da Neron vogl'io? —</l>
             <l part="I">Ad altri il chieggo; e spero...</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
@@ -2897,7 +2916,7 @@
             <l>d'atro stupor compreso. Ognor più fero</l>
             <l part="I">ch'altri nol pensa, egli è.</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -2909,14 +2928,14 @@
             <l>di necessaria morte esser mi dei</l>
             <l part="I">or tu ministro.</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
             <l part="F">Oh ciel!... Che ascolto?... Morte</l>
             <l part="I">d'impeto insano esser de' figlia?</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -2926,26 +2945,26 @@
             <l>morte il minor dei minacciati danni?</l>
             <l part="I">ch'altro mi resta? di'. — Tu taci?</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
             <l part="F">...Oh giorno!</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
             <l>Su via, rispondi: altro che far mi avanza?</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
             <l>...Mi squarci il cor... Ma, poss'io mai sì crudo</l>
             <l part="I">esser da ciò?...</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -2958,26 +2977,26 @@
             <l>d'ogni ribaldo hai core? alla efferata</l>
             <l>del rio Nerone insaziabil ira?</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
             <l>...Oh giorno infausto! Or perché vissi io tanto?</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
             <l>Ma, e che t'arresta?... e che paventi?... Ancora</l>
             <l part="I">forse hai speme?</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
             <l part="M">Chi sa?...</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -3002,7 +3021,7 @@
             <l>per te, se il vuoi, fuggir poss'io di vita;</l>
             <l>ma, di aspettar la morte io non ho forza.</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
@@ -3015,7 +3034,7 @@
             <l>mi è vietato l'uscire... Oh ciel! chi vale</l>
             <l part="I">contro empio sir, s'empio non è?</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -3024,7 +3043,7 @@
             <l>da morte, il vedi, ogni sperarlo è vano.</l>
             <l part="I">Salvami, deh! pietade il vuole...</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
@@ -3033,20 +3052,20 @@
             <l>Meco un ferro non ho; giunge a momenti</l>
             <l part="I">Nerone...</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
             <l part="F">Hai teco il velen sempre: usbergo</l>
             <l>solo dei giusti in queste infami soglie.</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
             <l part="I">Io,... con me?...</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -3065,7 +3084,7 @@
             <l>mi accuserà Nerone: e ad inaudita</l>
             <l part="I">morte dannar tu mi vedrai...</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
@@ -3074,34 +3093,34 @@
             <l>Per me il vorrei... Ma,... t'ingannasti; io meco</l>
             <l part="I">non ho veleno...</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
             <l part="F">...E ognor non rechi in dito</l>
             <l part="I">un fido anello? eccolo; il voglio...</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
             <l part="F">Ah! lascia...</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
             <l>Invano... Io 'l tengo. Io ne so l'uso: ei morte</l>
             <l part="I">ratta, e dolce rinserra...</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
             <l part="F">Il ciel ne attesto...</l>
             <l>deh! ten prego,... mel rendi... Or, s'altra via...</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -3109,13 +3128,13 @@
             <l>già sorbita ho coll'alito la polve</l>
             <l part="I">mortifera...</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
             <l part="M">Me misero!...</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -3128,7 +3147,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>NERONE, POPPEA, TIGELLINO, OTTAVIA, SENECA</stage>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -3141,13 +3160,13 @@
             <l>me discolpar presso al mio popol, darti</l>
             <l>qual t'è dovuta, con infamia, morte.</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
             <l>Più non mi pento, e fu opportuno il punto.</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -3155,45 +3174,45 @@
             <l>Già d'esser stata tua, d'averti amato,</l>
             <l>data men son debita pena io stessa.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l part="I">Pena? Che festi?</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
             <l part="F">Entro mie vene serpe</l>
             <l part="I">già un fero tosco...</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l part="M">E donde?...</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
             <l part="F">Or mio davvero,</l>
             <l part="I">Nerone, tu sei.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l part="F">Donde il velen?... Tu menti.</l>
           </sp>
-          <sp>
+          <sp who="#tigellino">
             <speaker>
               <emph>Tigellino</emph>
             </speaker>
             <l part="I">Creder nol dei; severa guardia...</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
@@ -3201,7 +3220,7 @@
             <l>deluder guardia; e il fu la tua. Gli Dei</l>
             <l part="I">scampo ai giusti non niegano.</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -3214,7 +3233,7 @@
             <l>il dì delle mortali nozze nostre,</l>
             <l part="I">tal gemma tu darmi dovevi...</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -3223,7 +3242,7 @@
             <l>per far che Roma mi abborrisca. Iniquo,</l>
             <l part="I">tu l'ordisti; ma or ora...</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
@@ -3231,7 +3250,7 @@
             <l>ti sottraesti, Ottavia; invan sottrarti</l>
             <l part="I">speri all'infamia.</l>
           </sp>
-          <sp>
+          <sp who="#ottavia">
             <speaker>
               <emph>Ottavia</emph>
             </speaker>
@@ -3261,27 +3280,27 @@
             <l>ombra dolente... a disturbar... tuoi... sonni...</l>
             <l>Conoscerai frattanto un dì costei. —</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
             <l>Più la conosco, più l'amo; e più sempre</l>
             <l part="I">di amarla io giuro.</l>
           </sp>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>
             <l part="F">In cor l'ultimo stile</l>
             <l>questi detti le piantano: ella spira...</l>
           </sp>
-          <sp>
+          <sp who="#poppea">
             <speaker>
               <emph>Poppea</emph>
             </speaker>
             <l>Vieni; lasciam questa funesta stanza.</l>
           </sp>
-          <sp>
+          <sp who="#nerone">
             <speaker>
               <emph>Nerone</emph>
             </speaker>
@@ -3293,7 +3312,7 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>SENECA</stage>
-          <sp>
+          <sp who="#seneca">
             <speaker>
               <emph>Seneca</emph>
             </speaker>

--- a/tei/alfieri-polinice.xml
+++ b/tei/alfieri-polinice.xml
@@ -82,6 +82,25 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="giocasta">
+            <persName>Giocasta</persName>
+          </person>
+          <person xml:id="antigone">
+            <persName>Antigone</persName>
+          </person>
+          <person xml:id="eteocle">
+            <persName>Eteocle</persName>
+          </person>
+          <person xml:id="creonte">
+            <persName>Creonte</persName>
+          </person>
+          <person xml:id="polinice">
+            <persName>Polinice</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -131,7 +150,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>GIOCASTA, ANTIGONE</stage>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -148,7 +167,7 @@
             <l>io pregherei, che in me volgesser sola,</l>
             <l>in me, la giusta loro ira tremenda.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -164,7 +183,7 @@
             <l>dato Eteòcle e Polinice han saggio</l>
             <l part="I">finor di sé...</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -180,7 +199,7 @@
             <l>forza è, per lor, che doppio orrore ei senta</l>
             <l>d'esser de' propri suoi fratelli il padre.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -199,7 +218,7 @@
             <l>già son gli sdegni; e in lor qual sia più sete,</l>
             <l>se di regno, o di sangue, mal diresti.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -210,7 +229,7 @@
             <l>quella, che tra' miei figli arde, funesta</l>
             <l part="I">discorde fiamma...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -218,14 +237,14 @@
             <l>Uno è lo scettro, i regnator son duo:</l>
             <l part="I">che speri tu?</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l part="F">Che il giuramento alterno</l>
             <l part="I">si osservi.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -238,7 +257,7 @@
             <l>qual fin, s'ei non ha regno? E a forza darlo</l>
             <l>come vorrà chi può tenerlo a forza?</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -260,7 +279,7 @@
             <l>troveran via fra lor, se non pria tinte</l>
             <l part="I">entro al sangue materno.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -270,7 +289,7 @@
             <l>aver può guasto mai, quanto il fratello</l>
             <l part="I">dal regnar lungo...</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -281,7 +300,7 @@
             <l>senza il mio assenso, data; egli di Tebe</l>
             <l part="I">non ricorre ai nemici...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -294,7 +313,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>ETEOCLE, GIOCASTA, ANTIGONE</stage>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -315,14 +334,14 @@
             <l>di sacro, e caro. — Ogni ragion riposta,</l>
             <l>ogni legge, ogni speme, egli ha nel ferro.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l>Vera è la fama dunque? Oh cielo! in armi</l>
             <l part="I">al suol natìo...</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -335,14 +354,14 @@
             <l>di un tuo figlio le insegne; ampio torrente</l>
             <l>vedi il piano inondar d'armi straniere.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l>Non tel diss'io più volte? a ciò lo traggi</l>
             <l part="I">a viva forza tu.</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -350,7 +369,7 @@
             <l>assalitor me non vedrai: di Tebe</l>
             <l part="I">ben la difesa io piglierò.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -358,7 +377,7 @@
             <l>credo che nulla ei chiegga. A te con l'armi</l>
             <l>chied'egli or ciò, che già negasti ai preghi.</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -371,7 +390,7 @@
             <l>ai nemici di Tebe, omai disciolto</l>
             <l part="I">l'ha dai più antichi vincoli.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -385,7 +404,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>CREONTE, ETEOCLE, GIOCASTA, ANTIGONE</stage>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -404,14 +423,14 @@
             <l>la madre noma, e di abbracciarla ei mostra</l>
             <l part="I">impaziente brama.</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
             <l part="F">Oh! nuova brama!...</l>
             <l>Col ferro in man, chiede i materni amplessi?</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -421,7 +440,7 @@
             <l>soffrir potrei, non che abbracciare un figlio,</l>
             <l>che minacciar col brando osa il fratello.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -436,7 +455,7 @@
             <l>dal campo un misto mormorìo, che grida:</l>
             <l part="I">«Pace ai Tebani, e a Tebe».</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -445,14 +464,14 @@
             <l>dunque a me sol reca il german la guerra?</l>
             <l part="I">Sta ben: l'accetto io solo.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="F">Ma, s'ei parla</l>
             <l part="I">di pace pure?... Udiamlo pria...</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -460,20 +479,20 @@
             <l>in Tebe; udire il vo'; né tu vietarlo</l>
             <l part="I">a me il potrai.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="F">Pur ch'ei l'inganno in Tebe</l>
             <l part="I">con sé non porti.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="F">Ah! nol conobbe ei mai.</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -481,7 +500,7 @@
             <l>gl'intimi sensi suoi; simìli forse</l>
             <l part="I">siete fra voi...</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -507,7 +526,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>ETEOCLE, CREONTE</stage>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -517,7 +536,7 @@
             <l>verrà, quasi in mio scherno? E che? fors'egli,</l>
             <l>sol col mostrarsi, or di aver vinto estima?</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -533,7 +552,7 @@
             <l>e ad ogni costo il vuole; anco dovesse</l>
             <l>l'infame via sgombrarsen col tuo sangue.</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -547,7 +566,7 @@
             <l>sotto l'alte rovine, ivi sol, trova</l>
             <l>morte onorata, ed onorata tomba.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -558,19 +577,19 @@
             <l>Re vincitor, fama null'altra ei lascia</l>
             <l part="I">di sé, che il vincer suo.</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
             <l part="F">Ma, ancor non vinsi.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l>T'inganni assai; già, non temendo, hai vinto.</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -579,7 +598,7 @@
             <l>altro di certo, che il coraggio mio;</l>
             <l>né a sperar altro, che vendetta, resta.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -598,7 +617,7 @@
             <l>ma, parer men crudele, o ingiusta meno,</l>
             <l>lunga feroce guerra a un re potrebbe?</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -607,7 +626,7 @@
             <l>all'arme io stesso? In me quest'odio è antico</l>
             <l>quanto mia vita; e assai più ch'essa io 'l curo.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -622,7 +641,7 @@
             <l>Gran macchinar vegg'io. — Deh! tante fraudi</l>
             <l part="I">non preverrai?</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -633,14 +652,14 @@
             <l>dovuta ell'è. Qual ira, entro quel petto</l>
             <l>ferir può addentro, quanto l'ira mia?</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l>L'odio tuo immenso alla certezza or ceda</l>
             <l part="I">di più intera vendetta.</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -648,7 +667,7 @@
             <l>i più feroci, i più funesti mezzi,</l>
             <l part="I">piacciono soli a me.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -656,13 +675,13 @@
             <l>i più ascosi adoprar. Possente in armi</l>
             <l part="I">sta Polinice...</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
             <l part="F">Ha i suoi guerrier pur Tebe.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -670,14 +689,14 @@
             <l>ratta, pur troppo: ah! noi morir, non altro,</l>
             <l part="I">possiam per te.</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
             <l part="F">Ma, di guerrier che parlo?</l>
             <l part="I">Uno è il fratello, ed un son io.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -685,14 +704,14 @@
             <l>hai di sfidarlo? A lui la madre intorno</l>
             <l part="I">e la sorella, e tutti...</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
             <l part="F">E aprirmi strada</l>
             <l part="I">non saprà il brando infino a lui?</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -700,14 +719,14 @@
             <l>perderesti coll'opra. Un tanto eccesso</l>
             <l part="I">biasmato fora anche da Tebe.</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
             <l part="F">E Tebe</l>
             <l part="I">non biasmeria la fraude?</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -717,13 +736,13 @@
             <l>assalitor, fu Polinice; e tale</l>
             <l part="I">l'arte il mantenga.</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
             <l part="M">Arte? ma quale?...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -735,7 +754,7 @@
             <l>restar, senza gli Argivi. Allor fia lieve</l>
             <l>che il traditor di tradimento pera.</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -743,7 +762,7 @@
             <l>breve stagion, l'odio e il furor nel petto</l>
             <l part="I">racchiuder vo'.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -761,7 +780,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>GIOCASTA, CREONTE</stage>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -775,7 +794,7 @@
             <l>fermo egli ha; dove il fratel suo pur cangi</l>
             <l part="I">minacce in preghi.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -793,7 +812,7 @@
             <l>pari all'altre; né vuol ragion, ch'io speri</l>
             <l>quel, ch'io non merto, filial rispetto.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -806,7 +825,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>GIOCASTA, ETEOCLE</stage>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -818,7 +837,7 @@
             <l>quel sacro nome di fratel, che omai</l>
             <l part="I">più non rammenti.</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -827,7 +846,7 @@
             <l>qual figlio egli è, qual suddito: del pari</l>
             <l part="I">ogni dovere ei compie.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -839,7 +858,7 @@
             <l>Ma dimmi, di'; più chiaro è il titol forse</l>
             <l part="I">di re spergiuro?</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -851,7 +870,7 @@
             <l>trono ov'io mai per mia viltà lasciassi,</l>
             <l>come ardirei ridomandarlo io poscia?</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -862,7 +881,7 @@
             <l>madre non vuol dal figlio altra virtude:</l>
             <l>forse a te par virtù di un re non degna?</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -876,7 +895,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>POLINICE, GIOCASTA, ETEOCLE</stage>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -889,7 +908,7 @@
             <l>Deh! dimmi; a me, consolator ne vieni,</l>
             <l>o troncator de' miei giorni cadenti?</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -899,7 +918,7 @@
             <l>l'ira del cielo. Ancor, pur troppo! o madre,</l>
             <l>lagrime assai dovrò fors'io costarti.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -909,7 +928,7 @@
             <l>ami la madre, placido a lui parla;</l>
             <l part="I">porgigli amica destra; e al seno...</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -920,7 +939,7 @@
             <l>non son gli addobbi, onde vestito venga</l>
             <l part="I">al fratello il fratello.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -937,7 +956,7 @@
             <l>Quanto accadde al mio messo, assai mi accenna,</l>
             <l>che in questa reggia alta ragion fian l'arme.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -949,7 +968,7 @@
             <l>caldi amplessi ei s'oppon; tacito dirne</l>
             <l>par, che nemico infra nemici stai.</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -958,7 +977,7 @@
             <l>pria non esponi, onde ti attenti in Tebe</l>
             <l>suddito cittadin tornarne in armi.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -967,13 +986,13 @@
             <l>Grecia il sa tutta; e tu nol sai? tu il chiedi? —</l>
             <l>Io dirtel vo': regnasti; e or più non regni.</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
             <l part="I">Folle, il saprai, s'io regno.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -991,7 +1010,7 @@
             <l>seconderà questo mio brando, io spero;</l>
             <l part="I">e lo spergiuro ei punirà.</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -1000,7 +1019,7 @@
             <l>L'armi fraterne hanno in orror: fia segno</l>
             <l>a lor vendetta chi primier le strinse.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -1012,7 +1031,7 @@
             <l>primo le stringe. È tua la guerra; è tuo,</l>
             <l part="I">di te solo è il delitto...</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -1020,7 +1039,7 @@
             <l>questa è la pace? — Uditemi, ven priego,</l>
             <l part="I">udite...</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -1030,7 +1049,7 @@
             <l>proposta niuna; e te non soffro innanzi</l>
             <l part="I">al mio regio cospetto.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -1040,7 +1059,7 @@
             <l>ed io con lor, se non attieni pria</l>
             <l part="I">tuo giuramento tu.</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -1048,7 +1067,7 @@
             <l>odi mercé, che a' suoi delitti implora. —</l>
             <l part="I">Che fai tu in Tebe? Escine dunque.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -1056,7 +1075,7 @@
             <l>me rivedrai; ma in altro aspetto: agli empi</l>
             <l>apportator d'inevitabil morte.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -1071,20 +1090,20 @@
             <l>non il fratel, da voi la madre uccisa;</l>
             <l>ben altro è il fallo; è ben di voi più degno.</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
             <l part="I">Strano a te par quanto a lui chieggo?</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l part="M">E ingiusto</l>
             <l>nomi il mio diffidare?</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -1098,7 +1117,7 @@
             <l>se giuro io ciò che già voi pria giuraste,</l>
             <l part="I">chi smentirmi ardirà?</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -1119,7 +1138,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>GIOCASTA, POLINICE</stage>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -1127,14 +1146,14 @@
             <l>piombi sul capo mio, se in me sincero</l>
             <l part="I">non è il desio di pace!...</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l part="M">Amato figlio,</l>
             <l>creder tel deggio?</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -1145,45 +1164,45 @@
             <l>se pria tener non mi vedesse in Tebe</l>
             <l part="I">l'avìto scettro.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l part="M">Oimè! Primier tu dunque</l>
             <l>ceder non vuoi?</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l part="M">Nol posso.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l part="F">A te chi 'l vieta?</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l part="I">Prudenza.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l part="M">In me non fidi?...</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l part="M">In lui, non fido:</l>
             <l>già m'ingannò.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -1194,7 +1213,7 @@
             <l>di sangue hai stretti; e che funesta dote</l>
             <l>tu richiedesti al suocero, la guerra.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -1211,14 +1230,14 @@
             <l>pel suo superbo onore? Ei lunge (il credi)</l>
             <l>la forza vuol, perché sol forza il doma.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l>E tu adoprarla vuoi, perché ti assolve</l>
             <l part="I">la forza poi da ogni altro patto.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -1232,7 +1251,7 @@
             <l>soffrir suoi scherni, e Grecia non mi vegga</l>
             <l>vil sostener tacendo oltraggi tanti.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -1258,7 +1277,7 @@
             <l>ch'io non sarei madre or d'Edippo, e moglie;</l>
             <l>ch'io non sarei di voi, perfidi, madre.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -1273,7 +1292,7 @@
             <l>scettro m'offre: se regno io sol volessi,</l>
             <l part="I">già regnerei.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -1286,26 +1305,26 @@
             <l>della infelice patria tua: vorresti,</l>
             <l>pria che in Tebe regnar, distrugger Tebe?</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l>Tel dissi io già: guerra non vo'; ma giova,</l>
             <l>più certa pace ad ottener, la forza.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l part="I">Ami la madre tu?</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l part="F">Più di me l'amo.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -1315,7 +1334,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>CREONTE, GIOCASTA, POLINICE</stage>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -1328,7 +1347,7 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>POLINICE, CREONTE</stage>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1337,7 +1356,7 @@
             <l>pendesse pur! lieta ella fora. — Or, dimmi;</l>
             <l>tu dunque cedi: al tuo fratel ti affidi...</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -1347,20 +1366,20 @@
             <l>l'eccitator parervi: eppur, che deggio,</l>
             <l part="I">che farmi omai?</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="M">Regnare.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l part="M">E aver poss'io</l>
             <l>qui, senza sangue, regno?</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1372,20 +1391,20 @@
             <l>or d'ingannarti, no. — Non avrai regno</l>
             <l part="I">qui, senza sangue.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l part="M">Oh ciel!...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="M">Ma sceglier puoi:</l>
             <l>sta in te; poco versarne, o assai...</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -1398,7 +1417,7 @@
             <l>a ragion giusta. In Argo torni Adrasto;</l>
             <l>solo, ed inerme, io rimarrommi in Tebe.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1406,19 +1425,19 @@
             <l>io ben commendo: ma, poss'io lasciarti</l>
             <l part="I">sceglier tuo danno, e il nostro?</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l part="F">E certo è il danno?</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="I">Di': conosci Eteòcle?</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -1430,7 +1449,7 @@
             <l>Tebe avremo, e la madre, e Adrasto, e il mondo</l>
             <l part="I">qui testimoni oggi fra noi...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1448,14 +1467,14 @@
             <l>sul soglio avìto... Or, che sperar?... Quel giorno</l>
             <l part="I">mai non verrà.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l part="F">Mai non verrà? Fia questo,</l>
             <l part="I">fia questo il dì.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1465,7 +1484,7 @@
             <l>già ti si ascrive il chiederlo, a delitto:</l>
             <l part="I">già...</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -1473,14 +1492,14 @@
             <l>quando a gran pena a mitigar l'antico</l>
             <l part="I">io cominciava?</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="F">Il re giurò poc'anzi,</l>
             <l>ed io l'udii, ch'ei non morria che in trono.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -1488,7 +1507,7 @@
             <l>questa fiata; io tel prometto. — Iniquo,</l>
             <l part="I">vivrai, ma non sul trono.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1496,7 +1515,7 @@
             <l>via non ti resta a risalirvi omai,</l>
             <l>se non calcando il tuo fratello estinto.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -1505,7 +1524,7 @@
             <l>corona infame, oh! sei tu grande tanto,</l>
             <l>che a comprar t'abbia così gran misfatto?</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1515,19 +1534,19 @@
             <l>che all'un di voi, vita per vita è forza</l>
             <l part="I">pigliarsi, o dar...</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l part="F">Non la sua vita io voglio...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="I">La tua darai.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -1536,21 +1555,21 @@
             <l>né a lui facile impresa aver mia vita</l>
             <l part="I">fora...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
             <l part="F">Il valor contro all'iniqua fraude</l>
             <l>che può? Qui aspetti generoso sdegno?</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l>Insidie a me si tendon dunque? Oh! parla;</l>
             <l part="I">svelami...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1558,7 +1577,7 @@
             <l>e nol previeni tu, vittima cado</l>
             <l part="I">io del tiranno, e te non salvo.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -1568,7 +1587,7 @@
             <l>onde salvarmi; o ch'io cadrò; ma solo,</l>
             <l part="I">io sol cadrò.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1576,14 +1595,14 @@
             <l>Osi tu sacra a me giurar tua fede</l>
             <l>d'orrido arcano, ch'io mi appresto a dirti?</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l>Sì; per la vita della madre io 'l giuro;</l>
             <l part="I">mi è sacra, il sai: parla.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1592,14 +1611,14 @@
             <l>qui troppo io già ti favellai... Me siegui;</l>
             <l part="I">altrove andianne...</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l part="F">E dal tiranno in Tebe</l>
             <l part="I">havvi loco securo?</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1609,7 +1628,7 @@
             <l>che al tempio giva, or disusato; andiamvi.</l>
             <l part="I">Tutto colà saprai: vieni.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -1622,7 +1641,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>ETEOCLE, POLINICE</stage>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -1630,7 +1649,7 @@
             <l>ch'ei, quant'io l'odio, m'odi? Ah! no; ch'io troppo,</l>
             <l part="I">troppo lo avanzo in ogni cosa.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1649,7 +1668,7 @@
             <l>util finor soltanto, or ti s'è fatta</l>
             <l part="I">necessaria sua morte.</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -1661,7 +1680,7 @@
             <l>all'assedio di Tebe; il vedrai tosto,</l>
             <l>com'io nel campo un tradimento ammendi.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1671,7 +1690,7 @@
             <l>Orrido dubbio a lor timore aggiunga:</l>
             <l part="I">nulla sapran di Polinice...</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -1682,7 +1701,7 @@
             <l>d'infausto augurio a lor soltanto; a noi,</l>
             <l>presagio, e pegno, di compiuta palma.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1700,7 +1719,7 @@
             <l>dell'altra arrechi inaspettato, a un tratto,</l>
             <l>guerra, terror, confusion, rovina.</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -1709,7 +1728,7 @@
             <l>pace... Ma vien la madre: andiam; se d'uopo</l>
             <l part="I">fu mai sfuggirla, è questo il dì.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -1719,21 +1738,21 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>GIOCASTA, ANTIGONE</stage>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l>Vedi? ei da me s'invola: or, della madre</l>
             <l part="I">anco diffida?...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="F">Usurpator diffida</l>
             <l part="I">di tutti sempre.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -1741,7 +1760,7 @@
             <l>ognor mi par, da che il fratello ei vide:</l>
             <l part="I">che mai pensar degg'io?</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -1749,7 +1768,7 @@
             <l>ch'odio ei cova, e rancore, e sangue, e morte,</l>
             <l part="I">nel simulato petto.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -1761,7 +1780,7 @@
             <l>non veggio allor, qual mendicar pretesto</l>
             <l>potrebbe il re, per non serbar sua fede.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -1774,7 +1793,7 @@
             <l>parte di sé miglior, vita seconda,</l>
             <l part="I">reputa il trono.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -1783,7 +1802,7 @@
             <l>che il regno: in somma, le minacce prime</l>
             <l part="I">da Polinice usciro.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -1812,7 +1831,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>GIOCASTA, ANTIGONE, POLINICE</stage>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -1824,13 +1843,13 @@
             <l>buon cittadin, miglior fratel non sei?</l>
             <l>Adrasto in Argo a ritornar si appresta?</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l>Eteòcle di Tebe a uscir si appresta?</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -1844,7 +1863,7 @@
             <l>pianto materno? Ah! di': non eri dianzi</l>
             <l part="I">tutto in parole pace?</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -1863,21 +1882,21 @@
             <l>trovar la tomba anco poss'io; né duolmi;</l>
             <l part="I">purch'io non cada invendicato.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l part="F">Ahi lassa!</l>
             <l part="I">E qual vendetta? e contro a chi?</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l part="F">Vendetta</l>
             <l part="I">d'un traditore.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -1885,21 +1904,21 @@
             <l>ch'empio in te nutre con supposte trame</l>
             <l>lo sdegno, il diffidar: me sola credi...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l>Madre, fratello, al mio terror soltanto</l>
             <l part="I">crediate or voi.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l part="F">Che parli?... Al terror tuo?</l>
             <l part="I">a qual terrore?</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -1907,13 +1926,13 @@
             <l>sta consiglier Creonte; alto terrore</l>
             <l part="I">quindi a ragion...</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l part="M">Creonte?</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -1921,7 +1940,7 @@
             <l>che a lui consigli!... Io ben mel so... Creonte...</l>
             <l part="I">senz'esso,... ah! forse,... a ria vendetta...</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -1929,7 +1948,7 @@
             <l>Qual parlar rotto! qual bollor di sdegno!</l>
             <l part="I">Che mi nascondi? parla.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -1944,7 +1963,7 @@
             <l>L'amistà di Creonte un don mi fea</l>
             <l part="I">funesto...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -1952,7 +1971,7 @@
             <l>compiango io te. Che di'? nunzia è di morte</l>
             <l part="I">del rio Creonte l'amistà.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -1960,7 +1979,7 @@
             <l>per Polinice, è ver, pender nol vidi:</l>
             <l part="I">ma che perciò? Figlia, osi tu?...</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -1968,7 +1987,7 @@
             <l>pende per me, per la mia giusta causa,</l>
             <l part="I">assai più ch'altri.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -1976,7 +1995,7 @@
             <l>ed io vel giuro: ei si fa giuoco, il crudo,</l>
             <l part="I">di voi, de' dritti vostri.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -1984,7 +2003,7 @@
             <l>Che ardisci tu? Non m'è fratel Creonte?...</l>
             <l part="I">E a' suoi nepoti?...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -1996,14 +2015,14 @@
             <l>al trono aspira; e qual, qual v'ha misfatto,</l>
             <l>che al trono adduca, e non s'imprenda in Tebe?</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l>Nol creder, no... Ma pur, chi sa?... Mancava</l>
             <l part="I">questo a tant'altri orrori!...</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -2038,7 +2057,7 @@
             <l>me dall'Averno respingete, o Erinni,</l>
             <l>perch'io finor men empio son di Edippo?</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -2046,26 +2065,26 @@
             <l>di tradimento incolpi? Invocar osi</l>
             <l part="I">del tuo natal le Furie?...</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l part="F">Altri si denno</l>
             <l part="I">Numi in Tebe invocar?...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="M">Fratello...</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l part="F">Figlio...</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -2074,7 +2093,7 @@
             <l>securo là, dove nomar non mi odo</l>
             <l part="I">fratel, né figlio.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -2082,7 +2101,7 @@
             <l>in Argo dunque; e sol ti affida in Tebe</l>
             <l part="I">a chi t'inganna.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -2100,7 +2119,7 @@
             <l>pace non goda ei fra delitti; pace,</l>
             <l part="I">che a me si vieta.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -2109,7 +2128,7 @@
             <l>Quanto più mai figlio e fratel si amasse,</l>
             <l part="I">ti amiamo entrambe.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -2119,7 +2138,7 @@
             <l>di me pietà. L'orrido arcano svela,</l>
             <l part="I">che nel petto rinserri; io forse...</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -2129,7 +2148,7 @@
             <l>virtù parrà: tal non mi par: di Tebe</l>
             <l part="I">non vo' i suffragi; i miei vogl'io.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -2141,27 +2160,27 @@
             <l>qual serberà, qual perderà de' figli:</l>
             <l>niegale tu d'ambo salvargli il mezzo.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l>Più antico e sacro è di natura il dritto,</l>
             <l part="I">e inviolabil più.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l part="F">Chi primo il rompe?</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l>Ti assolve il ciel d'ogni tua fé, se rotta</l>
             <l part="I">può risparmiar sangue, e delitti.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -2171,7 +2190,7 @@
             <l>lo ingannator, che ben gli sta: brev'ora</l>
             <l part="I">gli avanza a tesser frodi.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -2185,7 +2204,7 @@
             <l>contaminato? ah! non puoi sangue in Tebe</l>
             <l part="I">versar, che tuo non sia.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -2199,21 +2218,21 @@
             <l>qual sia il delitto, nel fraterno sangue</l>
             <l part="I">mai non si ammenda.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l part="F">E di costui fratello</l>
             <l part="I">perché mi festi?</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l part="F">E perché assai più iniquo</l>
             <l part="I">esser di lui vuoi tu?</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -2222,13 +2241,13 @@
             <l>fors'anco è doppio tradimento;... forse...</l>
             <l part="I">chi creder qui?... Vi lascio. — Addio.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l part="F">T'arresta.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -2238,7 +2257,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>CREONTE, GIOCASTA, ANTIGONE, POLINICE</stage>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -2246,7 +2265,7 @@
             <l>dubbio orribile trammi... Esser può mai?...</l>
             <l part="I">Dimmi...</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -2255,20 +2274,20 @@
             <l>il nostro re. — Primo a prestarten vengo</l>
             <l part="I">l'omaggio...</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l part="F">A me ne fia lo augurio lieto:</l>
             <l>chi, più di te, vedermi brama in trono?</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l part="I">Vero parli?</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -2276,14 +2295,14 @@
             <l>cacciato io pure ogni sospetto ho in bando:</l>
             <l part="I">Eteòcle cangiossi; e omai...</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l part="F">Cangiossi</l>
             <l>Eteòcle? — Creonte, a me tu il dici?</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -2297,14 +2316,14 @@
             <l>dalla necessità; pur d'alti sensi</l>
             <l part="I">velarla vuole.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l part="F">Assai ti udia diverso</l>
             <l part="I">già favellar di lui.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -2322,7 +2341,7 @@
             <l>de' sommi Dei: qui, tra gran pompa, in trono</l>
             <l part="I">riporti ei stesso...</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -2331,7 +2350,7 @@
             <l>mille volte la speme, e mille volte</l>
             <l part="I">delusa m'ebbe.</l>
           </sp>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -2343,38 +2362,38 @@
             <l>ciò che a lui toglie il susurrar di Tebe,</l>
             <l part="I">vuol parer darti; e in ciò il compiaci.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l part="F">— Io 'l voglio.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l>Ah! no; diffida. In cor sento un orrendo</l>
             <l part="I">presagio...</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l part="F">In breve, tornerem qui tutti.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l part="I">Ed io pur tremo...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="M">Ahi lassa me!</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -2390,7 +2409,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>ETEOCLE, GIOCASTA, POLINICE, ANTIGONE, <emph>sacerdoti, popolo, soldati</emph></stage>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -2400,7 +2419,7 @@
             <l>e il mio sperar soverchio anco di questo...</l>
             <l part="I">ma, Creonte?...</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -2423,7 +2442,7 @@
             <l>mio seggio, ch'oggi; oggi, nel punto istesso,</l>
             <l>in cui dal trono io volontario scendo.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -2438,7 +2457,7 @@
             <l>Se in Argo ancor non rimandai gli Argivi,</l>
             <l part="I">tu la cagion appien ne sai...</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -2457,7 +2476,7 @@
             <l>e, in qual sia terra il ciel mi ponga, i Numi</l>
             <l>offrir pel regno tuo voti mi udranno.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -2471,7 +2490,7 @@
             <l>appellar tu suddito mio, qui, dove</l>
             <l>regnasti a lungo, al tuo gran cor fia troppo...</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -2492,7 +2511,7 @@
             <l>spero imitarti; ma in tutt'altra guisa,</l>
             <l part="I">che tu nol fai, tornarvi.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -2502,7 +2521,7 @@
             <l>e che ben sai, che a rammentar mia fede</l>
             <l part="I">d'uopo il brando non è.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -2524,7 +2543,7 @@
             <l>Or via, che vale il differir, se tali</l>
             <l part="I">non sete voi?</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -2545,7 +2564,7 @@
             <l>non distruttor, salirne; e render giura,</l>
             <l>compiuto l'anno, al fratel tuo lo scettro.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -2553,7 +2572,7 @@
             <l>Giurar dei tu, di darmel pria; secondo</l>
             <l part="I">io, di renderlo.</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -2568,33 +2587,33 @@
             <l>sporgono a te. — Che indugi omai? ben vedi,</l>
             <l>che aspettiam tutti, e sol da te, la pace.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l>Questo, che or m'offri, è di amistà fraterna</l>
             <l part="I">il pegno adunque,... e di tua fede?</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
             <l part="F">Il pegno,</l>
             <l part="I">sì, d'amistade sacro...</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l part="F">Osi accertarlo?</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
             <l part="I">Tu dubitarne?</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -2606,20 +2625,20 @@
             <l>Antigone, Tebani, ecco la fede</l>
             <l>d'Eteòcle: veleno è questo nappo.</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
             <l part="I">Oh vil sospetto! Ahi mentitor!...</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l part="F">Che ascolto?</l>
             <l>Dare al fratel sì atroce taccia ardisci?</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -2630,7 +2649,7 @@
             <l>osa libar la tazza: eccola: assento</l>
             <l>io di berla secondo, e perir teco.</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -2647,7 +2666,7 @@
             <l>te chi potrebbe alla terribil ira</l>
             <l part="I">del tuo signor sottrarre?...</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -2658,7 +2677,7 @@
             <l>i vili tuoi... Ma, di te conscio, ardire</l>
             <l>non hai tu, no, di provocarmi a guerra...</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -2669,7 +2688,7 @@
             <l>eterna guerra, odio mortal, giurasti;</l>
             <l>eterna guerra, odio mortal, ti giuro.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -2686,13 +2705,13 @@
             <l>tutti i miei voti a voi: sta in quella tazza</l>
             <l>il ver; sappiasi: dona; il dubbio cessi...</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l part="I">Non fia, no, mai...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -2702,7 +2721,7 @@
             <l>Creonte; ei sa tutti i delitti;... ei primo</l>
             <l part="I">ministro né...</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -2713,20 +2732,20 @@
             <l>silenzio, io leggo la mia morte. — Godi;</l>
             <l part="I">ecco, ti appago.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="M">Ah! cessa...</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l part="F">O madre, indarno</l>
             <l part="I">speri il nappo da me...</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -2736,26 +2755,26 @@
             <l>ogni pace fra noi. — Le infami accuse</l>
             <l>smentir saprò, col brando mio, nel campo.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l>Uso al velen, mal tratterai tu il brando.</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
             <l part="I">Troppa ho la sete del tuo sangue.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l part="F">Il tuo</l>
             <l part="I">sparger primo potresti.</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -2766,7 +2785,7 @@
             <l>beremci il sangue; e giurerem sovr'esso,</l>
             <l>anco oltre morte di abborrirci noi.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -2777,14 +2796,14 @@
             <l>strugger così della esecrabil nostra</l>
             <l part="I">orrida stirpe ogni memoria!...</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
             <l part="F">Or, vero</l>
             <l part="I">fratello mio sei tu.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -2797,7 +2816,7 @@
             <l>Che più s'indugia, o prodi? a che ristarvi</l>
             <l part="I">dall'ire vostre omai?...</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -2807,13 +2826,13 @@
             <l>Finché n'hai tempo tu, da me sottratti;</l>
             <l part="I">tosto, pria che il mio braccio...</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l part="F">E ch'è il tuo braccio?</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -2824,7 +2843,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>CREONTE, ETEOCLE, POLINICE, ANTIGONE, <emph>sacerdoti, popolo, soldati</emph></stage>
-          <sp>
+          <sp who="#creonte">
             <speaker>
               <emph>Creonte</emph>
             </speaker>
@@ -2834,7 +2853,7 @@
             <l>immantinente in libertà riposto</l>
             <l part="I">fuor delle porte Polinice.</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -2852,26 +2871,26 @@
             <l>— Tra il ferro argivo e la tebana scure,</l>
             <l part="I">scelta ti lascio. Vieni.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l part="M">Oh figlio!...</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
             <l part="F">Indarno</l>
             <l part="I">ti opponi.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l part="M">Odimi,... deh!...</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -2883,33 +2902,33 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>GIOCASTA, POLINICE, ANTIGONE</stage>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l part="F">Al campo</l>
             <l part="I">io vengo. Trema.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l part="F">Ei t'è fratello. Ascolta...</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l>Ei m'è nemico; ei mi tradì... Il mio onore...</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l>L'onor, vieta i misfatti. Oh figlio! cessa...</l>
             <l part="I">Che imprendi?... Oh cielo!</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -2917,14 +2936,14 @@
             <l>corre Adrasto per me, qui degg'io starmi</l>
             <l part="I">fra i vostri pianti? Invan lo speri.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l part="F">Il ferro,...</l>
             <l part="I">tu,... di tua man,... nel tuo fratello?...</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -2934,39 +2953,39 @@
             <l>non cerco io là, né d'incontrarvel spero.</l>
             <l part="I">Tanto prometto. Addio.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l part="F">Morir mi sento.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="I">Di te, di noi, pietade abbi...</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l part="F">Mi è forza</l>
             <l part="I">esser sordo a pietade: io corro....</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l part="F">Ah! dove?...</l>
             <l part="I">Ti arresta...</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l part="M">A morte.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -2976,7 +2995,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>GIOCASTA, ANTIGONE</stage>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -2992,7 +3011,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>GIOCASTA</stage>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -3039,7 +3058,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>ANTIGONE, GIOCASTA</stage>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -3047,33 +3066,33 @@
             <l>ti sta il pallor di morte... Ahi!... tutto intesi:</l>
             <l part="I">quell'orribil silenzio...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="M">A orribil pugna</l>
             <l>diè loco.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l part="M">E, spenti i figli?</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="M">Un sol...</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l part="F">Qual vive?</l>
             <l part="I">Ahi traditor! ti voglio io stessa...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -3081,19 +3100,19 @@
             <l>lor duello vid'io dall'alte torri:</l>
             <l>a terra immerso nel sangue cadeva...</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l part="I">Quale?... Oimè!... Parla.</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="F">Eteòcle cadeva.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -3104,21 +3123,21 @@
             <l>ma, trema: io vivo ancor: quell'empio cuore</l>
             <l>ch'io a te donai, strappar tel posso io stessa...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l>Tutto ancora non sai: solo incolparne</l>
             <l part="I">Polinice non dei...</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l part="F">Ne incolpo il vivo;</l>
             <l part="I">ch'è reo sol ei...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -3146,14 +3165,14 @@
             <l>«A Polinice». A rintracciarlo ei corre</l>
             <l part="I">precipitoso; e il trova al fine...</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l part="F">Ahi lassa!</l>
             <l part="I">misera me!... L'altro nol fugge?...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -3173,7 +3192,7 @@
             <l>l'odio, lo sdegno, il ferro». — E il dire, e addosso</l>
             <l part="I">a lui scagliarsi, è un punto solo.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -3181,7 +3200,7 @@
             <l>Ma che? libero dassi a tal duello</l>
             <l part="I">fra tante squadre il campo?</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -3211,7 +3230,7 @@
             <l>mal sicuri, a te vengo... — Oimè! qual fia</l>
             <l>del lagrimevol caso, o madre, il fine?...</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -3220,21 +3239,21 @@
             <l>Ma, chi ver noi?... Che miro?... Oh ciel! vien tratto</l>
             <l part="I">il morente Eteòcle...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="F">Al debil fianco</l>
             <l part="I">gli fan colonna i suoi guerrieri!...</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l part="F">Oh! come</l>
             <l>a lenti passi di morte ei si avanza!</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -3244,21 +3263,21 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>ETEOCLE, POLINICE, GIOCASTA, ANTIGONE, <emph>soldati d'Eteocle</emph></stage>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="F">Ah! salvo</l>
             <l part="I">almen tu sei...</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l part="F">Scostati: va': non vedi?</l>
             <l>tinto son tutto del fraterno sangue.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -3266,7 +3285,7 @@
             <l>al cospetto venirne osi di madre,</l>
             <l part="I">cui trafiggesti un figlio?</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -3275,19 +3294,19 @@
             <l>che tronca a lui la vita, in me ritorto</l>
             <l>l'aveva io già con più adirata mano...</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l part="I">Ma tu pur vivi; ahi vile!...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="F">Oh ciel! Qual vita!...</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -3299,7 +3318,7 @@
             <l>or via, che tardi? Io non ti son più figlio;</l>
             <l part="I">io, che ti orbai d'un figlio...</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -3312,27 +3331,27 @@
             <l>e lo squarciato petto. Or, deh! riapri</l>
             <l part="I">una fiata i lumi ancora...</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
             <l part="F">Oh madre!...</l>
             <l part="I">dimmi;... in Tebe son io?</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l part="F">Nella tua reggia...</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
             <l>Di';... moro io re?... Quel traditor?... Che miro?</l>
             <l part="I">Fellon, tu vivi; ed io mi moro?...</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -3352,7 +3371,7 @@
             <l>del tuo sangue... Me misero! ben veggo,</l>
             <l part="I">che il mio pregar ti offende.</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -3360,14 +3379,14 @@
             <l>Figliuol di Edippo, a me perdon tu chiedi?</l>
             <l>Perdon tu speri da un figliuol d'Edippo?</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l>O figlio, e che? nell'egro petto alberghi</l>
             <l part="I">tant'ira ancora?</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -3379,7 +3398,7 @@
             <l>e premerai tu il seggio mio? — Deh! morte,</l>
             <l part="I">fa', ch'io nol vegga; affrettati...</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
@@ -3394,7 +3413,7 @@
             <l>Sol del perdono, anzi che a morte io corra,</l>
             <l part="I">ti scongiuro...</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -3403,7 +3422,7 @@
             <l>Col perdonargli, rendilo più reo:</l>
             <l>le tue vendette ai suoi rimorsi lascia...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
@@ -3411,7 +3430,7 @@
             <l>ai preghi, al duolo, al pianto disperato</l>
             <l part="I">di quanto aver dei caro?</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -3420,7 +3439,7 @@
             <l>Breve n'hai tempo; alla tua fama togli</l>
             <l part="I">tal macchia...</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
@@ -3430,38 +3449,38 @@
             <l>vieni,... e ricevi in quest'ultimo amplesso...</l>
             <l>fratel,... da me... la meritata<note resp="#aut" place="foot" anchored="true"><p>Fingendo abbracciarlo, con uno stile lo trafigge</p></note> morte.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
             <l part="I">Oh tradimento!</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="F">Oh vista!... Polinice!...</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l part="I">Sei pago tu?...</l>
           </sp>
-          <sp>
+          <sp who="#eteocle">
             <speaker>
               <emph>Eteocle</emph>
             </speaker>
             <l part="F">Son vendicato. — Io moro;...</l>
             <l part="I">e ancor ti abborro...</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>
               <emph>Polinice</emph>
             </speaker>
             <l part="F">Io moro;... e a te perdono.</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -3473,13 +3492,13 @@
             <l>Ma che veggio?... uno immenso orrido abisso</l>
             <l part="I">s'apre a miei piè?...</l>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>
               <emph>Antigone</emph>
             </speaker>
             <l part="M">Madre!...</l>
           </sp>
-          <sp>
+          <sp who="#giocasta">
             <speaker>
               <emph>Giocasta</emph>
             </speaker>
@@ -3505,7 +3524,7 @@
             <l>che incestuoso a tai mostri diè vita.</l>
             <l part="I">Furia, che tardi?... Io mi t'avvento...</l>
           </sp>
-          <sp>
+          <sp who="#antigonela rattiene #giocasta cade fra le sue braccia">
             <speaker>
               <emph>Antigone<note resp="#aut" place="foot" anchored="true"><p>La rattiene; e Giocasta cade fra le sue braccia</p></note></emph>
             </speaker>

--- a/tei/alfieri-rosmunda.xml
+++ b/tei/alfieri-rosmunda.xml
@@ -82,6 +82,22 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="rosmunda">
+            <persName>Rosmunda</persName>
+          </person>
+          <person xml:id="romilda">
+            <persName>Romilda</persName>
+          </person>
+          <person xml:id="almachilde">
+            <persName>Almachilde</persName>
+          </person>
+          <person xml:id="ildovaldo">
+            <persName>Ildovaldo</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -125,7 +141,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>ROSMUNDA, ROMILDA</stage>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -138,7 +154,7 @@
             <l>l'alta virtù guerriera appien certezza</l>
             <l part="I">del vincer dammi.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -156,7 +172,7 @@
             <l>e delle infrante Longobarde leggi</l>
             <l>sostien coll'armi; e vincitor lo spero.</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -170,7 +186,7 @@
             <l>che veder vogli la regal possanza</l>
             <l part="I">col trono a terra?</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -180,7 +196,7 @@
             <l>fosti di re? tu, che di sposa osasti</l>
             <l>a un traditor tuo suddito dar mano?</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -201,14 +217,14 @@
             <l>te vo' sgombrar dagli occhi miei per sempre.</l>
             <l part="I">Sposa ti mando ad Alarico.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
             <l part="F">Io sposa?...</l>
             <l part="I">io, d'Alarico?...</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -227,7 +243,7 @@
             <l>Felice te, quanto Alboìn mi fea,</l>
             <l part="I">Alarico farà.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -242,7 +258,7 @@
             <l>martiri orrendi, e infami strazi darle.</l>
             <l part="I">Ma, tu dispor della mia destra?...</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -253,7 +269,7 @@
             <l>punisco io quei che in un pavento e abborro:</l>
             <l>te, cui non temo, io vo' punir di vita.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -267,14 +283,14 @@
             <l>recando, fargli le mie chieste nozze</l>
             <l>caro costare: ma, son io Rosmunda?</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
             <l>Io 'l sono; e assai men pregio. Al mondo è noto,</l>
             <l part="I">ch'a incrudelir prima non fui.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -282,7 +298,7 @@
             <l>fu il mio padre con te, dritto di guerra</l>
             <l part="I">tale il fea; ma tu poi...</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -320,7 +336,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>ROSMUNDA</stage>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -349,7 +365,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>ROSMUNDA, ALMACHILDE, <emph>soldati</emph></stage>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -357,7 +373,7 @@
             <l>bandiere al vento, e il militar contegno,</l>
             <l>tutto mel dice; il vincitor tu sei.</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -369,7 +385,7 @@
             <l>fea di valore egli per me, che il merto</l>
             <l>mai pareggiar col guiderdon non posso.</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -385,7 +401,7 @@
             <l>che sarei senza te? nulla m'è il trono,</l>
             <l>nulla il viver, se teco io nol divido.</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -396,14 +412,14 @@
             <l>Come ammendar, se non col brando, in campo,</l>
             <l>quel fatal colpo, che di man mi uscia?...</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
             <l>E che? d'avermi vendicata ardisci</l>
             <l part="I">pentirti?...</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -441,7 +457,7 @@
             <l>campal giornata in sanguinoso orrendo</l>
             <l>total macello in un momento è volta.</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -451,7 +467,7 @@
             <l>già fra i maggior di questo regno; or fia</l>
             <l part="I">soltanto a te secondo.</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -473,7 +489,7 @@
             <l>la lor sconfitta. In lui mi affido; ei svelta</l>
             <l>fin da radice ha in questo dì tal guerra.</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -486,14 +502,14 @@
             <l>io già l'annunzio. — Il crederesti? ell'osa</l>
             <l part="I">niegar sua mano ad Alarico.</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="F">Oh! tanto</l>
             <l>sperar io?... Tanto ella sperare ardisce?...</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -501,13 +517,13 @@
             <l>le intimai la partita. Il trono pria</l>
             <l>io perder vo', che mai tradir mia fede.</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l>Ma pur,... pietà della infelice figlia...</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -515,7 +531,7 @@
             <l>Dell'uccisor del padre mio la figlia</l>
             <l>altro esser mai, fuorché infelice, debbe?</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -541,7 +557,7 @@
             <l>chi di lor ne risponde? E noi senz'esse,</l>
             <l part="I">dimmi, che siamo?</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -562,7 +578,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>ALMACHILDE, ILDOVALDO</stage>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -571,7 +587,7 @@
             <l>vinto il confesso, guiderdon non havvi,</l>
             <l>che lor pareggi: ma, se pure io valgo...</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -583,7 +599,7 @@
             <l>sacra parer la causa di chi regna,</l>
             <l part="I">qual ch'ella fosse.</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -597,7 +613,7 @@
             <l>in tua man li lasciai: sapea ch'ei fora,</l>
             <l>dove adopravi il tuo, vano il mio brando.</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -608,7 +624,7 @@
             <l>in cor de' suoi, tosto si spense; e cadde</l>
             <l part="I">ogni orgoglio col duce.</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -619,7 +635,7 @@
             <l>altri che tu?) dirmi qual sia mercede,</l>
             <l part="I">che offenda men la tua virtù.</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -636,7 +652,7 @@
             <l>Nulla mi dei tu dunque; e dall'incarco</l>
             <l>di gratitudin grave io già t'ho sciolto,</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -663,7 +679,7 @@
             <l>di traditor (mai non si perde intera)</l>
             <l part="I">togliermi spero.</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -671,33 +687,33 @@
             <l>di re più assai corrotto il cor: ma sano,</l>
             <l>pure non l'hai. Sentir rimorsi, e starsi...</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="I">E starmi omai vogl'io? Già già...</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l part="F">Ma, questo</l>
             <l part="I">trono, tu il sai...</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="F">So, che ad altrui s'aspetta;</l>
             <l part="I">che mio non è...</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l part="M">Dunque...</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -709,7 +725,7 @@
             <l>guiderdon non trovava, ed or già ardisco</l>
             <l part="I">chiederne a te de' nuovi?</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -718,7 +734,7 @@
             <l>da non cercarne alle magnanim'opre.</l>
             <l part="I">Che poss'io far? Favella.</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -738,7 +754,7 @@
             <l>perch'io ti giovi un poco, or che puoi tanto,</l>
             <l>gli altrui dritti servendo, in un giovarmi.</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -750,13 +766,13 @@
             <l>Ciò ch'io sol bramo, or nulla a te torrebbe,</l>
             <l part="I">e vita fora a me.</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="F">Nomalo; è tuo.</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -764,45 +780,45 @@
             <l>sol può Rosmunda all'amor mio; tu puoi</l>
             <l part="I">solo da ciò distorla.</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="F">Ed è tua fiamma?...</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l part="I">Romilda ell'è...</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="F">Che sento!... Ami Romilda?</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l part="I">Sì... Ma stupor donde in te tanto?...</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="F">Ignoto</l>
             <l part="I">m'era appieno il tuo amore.</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l part="F">Or ch'io tel dico,</l>
             <l part="I">perché turbarti? Incerto...</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -810,7 +826,7 @@
             <l>Stupor non è... — Romilda! E da gran tempo</l>
             <l part="I">tu l'ami?</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -820,7 +836,7 @@
             <l>di te pur ella, e non sdegnò di sposa</l>
             <l part="I">dar mano a te mio uguale.</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -828,7 +844,7 @@
             <l>alta cosa per te?... Ma, il sai;... Rosmunda</l>
             <l part="I">di Romilda dispone;... ed io...</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -839,14 +855,14 @@
             <l>mi hai già guiderdonato regalmente,</l>
             <l part="I">promettendo.</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="F">Deh, no; nol creder;... voglio...</l>
             <l>Ma di'... — Romilda!... E riamato sei?</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -856,7 +872,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>ALMACHILDE, ROMILDA, ILDOVALDO</stage>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -869,7 +885,7 @@
             <l>spendi a pro di costui? virtù cotanta</l>
             <l>dovea mai farsi a tanta infamia scudo?</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -886,7 +902,7 @@
             <l>non diemmi invan lustro, e vittoria, ov'io</l>
             <l part="I">morte cercai.</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -896,7 +912,7 @@
             <l>distruggitor del trono ad alta voce</l>
             <l>ei s'appellava; io combattea pel trono.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -910,7 +926,7 @@
             <l>vuoto mio soglio usurparor salisse,</l>
             <l>dovea toccare al più valente almeno.</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -926,7 +942,7 @@
             <l>Per quanto è in me, già lo terresti. Il preme</l>
             <l part="I">Rosmunda, ed è...</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -944,33 +960,33 @@
             <l>l'empia Rosmunda, or per più strazio darmi,</l>
             <l>in vita vuolmi, e ad Alarico sposa.</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l part="I">Che ascolto?</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="F">Odi, Ildovaldo? ah! per te il vedi,</l>
             <l part="I">s'io con ragion teco era in dubbio...</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l part="F">Sposa</l>
             <l part="I">del barbaro Alarico?</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="M">Ah! no...</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -987,21 +1003,21 @@
             <l>all'uccisor del padre mio; deh! tenta</l>
             <l part="I">di opporti almeno...</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="F">Ch'io tenti? io ben ti giuro,</l>
             <l part="I">che non v'andrai.</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l part="F">Per questo brando io 'l giuro.</l>
             <l part="I">Mi udrà Rosmunda...</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -1011,7 +1027,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>ROSMUNDA, ALMACHILDE, ROMILDA, ILDOVALDO</stage>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -1025,26 +1041,26 @@
             <l>per guidarti ove trono altro più illustre</l>
             <l>ti aspetta, e lieta marital ventura.</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="I">Ma, d'Alarico...</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
             <l part="F">E che? non degno forse</l>
             <l part="I">fia di sua man tal re?</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="M">Sì crudo...</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -1053,45 +1069,45 @@
             <l>cui mai novella crudeltà non giunge,</l>
             <l part="I">qual ch'ella sia.</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l part="M">Tai nozze...</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="F">A tutti infauste...</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
             <l part="I">Spiaccionti?</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="M">Niega ella il consenso...</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
             <l part="F">E il nieghi:</l>
             <l part="I">io v'acconsento.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
             <l part="F">Ch'ei di te sia meno</l>
             <l part="I">spietato, duolti?</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -1099,7 +1115,7 @@
             <l>pietoso a te? ch'osi tu dir? Non sente</l>
             <l part="I">di te pietà: mal ti lusinghi...</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -1109,13 +1125,13 @@
             <l>strazio chi può d'una regal donzella</l>
             <l>mirar, chi 'l può, senza pietà sentirne?...</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
             <l>Pietade ogni uom, tranne Almachilde, n'abbia.</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -1124,19 +1140,19 @@
             <l>il mio consiglio udrai. Danno tornarti</l>
             <l part="I">può, se Romilda oltraggi.</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="F">E assai gran danno.</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l part="I">Saggia sei, se nol fai...</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -1158,14 +1174,14 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>ILDOVALDO, ROMILDA</stage>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l>Strascinarla?... Che sento! Ah! pria svenarmi...</l>
             <l part="I">Romilda, oh ciel! che a perder t'abbia?...</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -1175,13 +1191,13 @@
             <l>niun'altra speme entro il mio petto accolsi,</l>
             <l part="I">se non di morte.</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l part="F">Ma, finch'io respiro...</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -1190,7 +1206,7 @@
             <l>di vederti una volta ancor bramava;</l>
             <l part="I">darti d'amor l'estremo addio...</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -1200,21 +1216,21 @@
             <l>Colma ho ben l'alma di dolor; ma nulla</l>
             <l part="I">ancor dispero.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
             <l part="F">E donde mai salvezza</l>
             <l part="I">può a me venirne?</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l part="F">E non son io da tanto,</l>
             <l part="I">che di man di costor trarti?...</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -1231,7 +1247,7 @@
             <l>a vendicare un re tradito, un padre,</l>
             <l part="I">e la tua fida amante.</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -1257,7 +1273,7 @@
             <l>io che solo a un tuo cenno a morte corro;</l>
             <l part="I">a riceverla, o darla.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -1266,7 +1282,7 @@
             <l>il tuo amore a combatter l'efferato</l>
             <l part="I">odio di lei...</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -1275,13 +1291,13 @@
             <l>ch'anco Almachilde all'empie nozze opporsi,</l>
             <l part="I">come l'udisti, ardisce.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
             <l part="F">E in lui che speri?</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -1296,7 +1312,7 @@
             <l>L'ardir suo mezzo con l'ardir mio intero</l>
             <l part="I">ben rinfrancar poss'io.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -1310,7 +1326,7 @@
             <l>tutto debbe quant'è, né ad altro il debbe,</l>
             <l part="I">mi aiuterà contr'essa?</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -1330,13 +1346,13 @@
             <l>che di nostra rovina altri mai goda?</l>
             <l>Fra il trono e te, Rosmunda sola io veggo.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
             <l part="I">E Almachilde?...</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -1347,7 +1363,7 @@
             <l>l'eterna fede mia, l'alta vendetta</l>
             <l>del tuo trafitto genitor, ti giuro.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -1359,7 +1375,7 @@
             <l>lusinga farmi?... Al ritornar, ten prego,</l>
             <l part="I">non esser tardo.</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -1368,13 +1384,13 @@
             <l>sol d'indugiar finché il morir sia d'uopo.</l>
             <l part="I">Giuralo.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
             <l part="M">Il giuro.</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -1388,7 +1404,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>ALMACHILDE, ROMILDA</stage>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -1398,7 +1414,7 @@
             <l>l'appalesarti quanto in cor diverso</l>
             <l>io son per te dalla tua ria madrigna.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -1409,7 +1425,7 @@
             <l>fa' che mai più non si favelli: io forse</l>
             <l part="I">a te dovrò la pace mia.</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -1432,21 +1448,21 @@
             <l>tu in questa reggia i giorni, o perder debbo</l>
             <l part="I">io col regno la vita.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
             <l part="F">Or donde tanto</l>
             <l part="I">generoso ver me?...</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="F">Più fera pena</l>
             <l part="I">non ebbi io mai, che l'odio tuo.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -1454,14 +1470,14 @@
             <l>cessare io mai d'odiarti? in suon di sdegno</l>
             <l part="I">l'inulto padre?...</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="F">Oh ciel! non io l'uccisi:</l>
             <l part="I">il trucidò Rosmunda.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -1490,14 +1506,14 @@
             <l>liberator parrai. Ma, se a te penso,</l>
             <l>ch'altro mi sei, che l'uccisor del padre?</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l>E i rimorsi, e il pentire, e il pianger, nulla</l>
             <l part="I">fia che mi vaglia?</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -1506,7 +1522,7 @@
             <l>l'odio mio, che t'importa? inerme figlia</l>
             <l>di spento re, che giova il lusingarla?</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -1521,7 +1537,7 @@
             <l>sì duro cor, che di pietà non senta</l>
             <l part="I">moti per te?</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -1529,7 +1545,7 @@
             <l>troppo il soffrirla... Ahi lassa me!... Spregiarla</l>
             <l part="I">pur non poss'io del tutto.</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -1538,7 +1554,7 @@
             <l>del non andarne ad Alarico, il nome</l>
             <l part="I">ch'egli ha di crudo?</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -1547,7 +1563,7 @@
             <l>non tradisce abbastanza? anco del core</l>
             <l part="I">vuoi ch'ella schiuda i sensi a te?</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -1555,7 +1571,7 @@
             <l>ragion, che parti da tacermi? Il modo</l>
             <l part="I">forse così d'appien servirti...</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -1567,7 +1583,7 @@
             <l>qui men cruda la morte: indi vi chieggo</l>
             <l>questo, a voi lieve, a me importante dono.</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -1580,14 +1596,14 @@
             <l>profondamente... entro vi porti impressa...</l>
             <l part="I">la imagin tua...</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
             <l part="F">Che ascolto? Oimè! che sguardi?...</l>
             <l part="I">che dirmi intendi?</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -1596,7 +1612,7 @@
             <l>sul mio volto tremante... Ardo, è gran tempo,...</l>
             <l part="I">d'amor... per te.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -1604,14 +1620,14 @@
             <l>che dirmi ardisci? O rio destin, serbata</l>
             <l part="I">a un tale oltraggio m'hai?</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="F">Se l'amor mio</l>
             <l part="I">reputi oltraggio, io ben punirmi...</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -1619,7 +1635,7 @@
             <l>e di virtù la passion tua iniqua</l>
             <l part="I">tu colorire ardivi?</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -1628,7 +1644,7 @@
             <l>vedrai... Per te, tutto farò; ma nulla</l>
             <l part="I">chieggio da te.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -1637,7 +1653,7 @@
             <l>Amor, tu a me? — Sei di Rosmunda sposo;</l>
             <l part="I">e di null'altra degno.</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -1646,14 +1662,14 @@
             <l>irresistibil forza. Io, no, non sorgo</l>
             <l part="I">de' piedi tuoi, se pria...</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
             <l part="F">Scostati, taci,</l>
             <l>esci... Ma, vien chi spegnerà tal fiamma.</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -1663,7 +1679,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>ROSMUNDA, ALMACHILDE, ROMILDA</stage>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -1675,7 +1691,7 @@
             <l>tal mi rendi mercede? — E tu, con finta</l>
             <l part="I">virtude...</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -1687,7 +1703,7 @@
             <l>Non son io l'empia; egli ad udir suoi detti</l>
             <l part="I">empio mi trasse or con inganno...</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -1711,7 +1727,7 @@
             <l>e all'amor mio Romilda il cor sì chiuso</l>
             <l part="I">or non avrebbe.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -1734,32 +1750,32 @@
             <l>Presta a morir, non a cessar, no mai,</l>
             <l part="I">son io d'amare...</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="M">Ami?</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
             <l part="M">Ildovaldo.</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="F">Ah! questo,</l>
             <l>è questo il colpo, che davver mi uccide.</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
             <l>Vero parli, o menzogna? ami Ildovaldo?</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -1783,7 +1799,7 @@
             <l>morte avrem noi più mille volte dolce,</l>
             <l>che la tremante orribil vita vostra.</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -1793,7 +1809,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>ROSMUNDA, ALMACHILDE</stage>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -1811,7 +1827,7 @@
             <l>Or parla,... di';... ma che dirai, che vaglia</l>
             <l part="I">a scolparti?</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -1820,14 +1836,14 @@
             <l>quanta il ciel mai ne acchiuse in cor di donna,</l>
             <l part="I">gloria m'è, gloria; e non delitto.</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
             <l part="F">Accoppi</l>
             <l part="I">al tradimento anco gli oltraggi?</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -1853,7 +1869,7 @@
             <l>di vero amor figlia estimar la fede</l>
             <l>chiesta, e donata, in così orribil punto?</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -1867,7 +1883,7 @@
             <l>non il talamo mio, non il mio trono;...</l>
             <l part="I">non il mio core.</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -1894,7 +1910,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>ROSMUNDA</stage>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -1917,7 +1933,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>ROSMUNDA, ILDOVALDO</stage>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -1934,14 +1950,14 @@
             <l>quello stesso Almachilde a me spergiuro,</l>
             <l part="I">ingrato a te, Romilda egli ama.</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l part="F">Ahi vile!</l>
             <l part="I">Ei di mia man morrà.</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -1964,7 +1980,7 @@
             <l>teco sia lieta; prendila; e per sempre</l>
             <l part="I">dagli occhi miei la invola.</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -1972,7 +1988,7 @@
             <l>Oh gioia! or donde io non trarrolla?... È mia?... —</l>
             <l>Ma, le vendette mie chi compie intanto?</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -1984,27 +2000,27 @@
             <l>la vegga ei prima al suo rivale in braccio;</l>
             <l>e se n'irrìti, e sen disperi, e indarno...</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l>Ma che? già forse in man di lui Romilda?...</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
             <l>Antiveduto ei sta; né ardito meno,</l>
             <l part="I">né amante meno egli è di te...</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l part="F">Minore</l>
             <l part="I">in tutto ei m'è.</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -2013,7 +2029,7 @@
             <l>i mezzi tutti: a dubbio evento esporre</l>
             <l part="I">l'amor tuo non vorrai.</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -2023,7 +2039,7 @@
             <l>la mia forza raduno, e in brevi istanti</l>
             <l part="I">riedo a Romilda...</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -2035,7 +2051,7 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>ROSMUNDA</stage>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -2050,13 +2066,13 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>ROMILDA, ILDOVALDO</stage>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
             <l>Vista ho Rosmunda. Or creder posso?... Oh cielo!...</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -2066,7 +2082,7 @@
             <l>usciti appena, troverem di prodi</l>
             <l>scorta eletta; il dì più fia lieve poscia.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -2080,7 +2096,7 @@
             <l>Io teco unita? io libera, secura?...</l>
             <l part="I">E fia vero!</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -2093,7 +2109,7 @@
             <l>pur ch'io ti vegga, in altro aspetto un giorno</l>
             <l>poi ricondurti entro il tuo regno io spero.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -2106,7 +2122,7 @@
             <l>all'innocente orecchio mio; ma giunto</l>
             <l part="I">evvi pure; né in lui...</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -2117,7 +2133,7 @@
             <l>far sì ch'ei sconti. Ma sfuggirlo io deggio</l>
             <l>per ora, e il vo', fin che non sii tu in salvo.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -2137,7 +2153,7 @@
             <l>per minor male io scelgo, che l'amarmi</l>
             <l part="I">di quel suo vile, e osarmel dire...</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -2145,7 +2161,7 @@
             <l>ardir ben ei ne pagherà: ti acqueta;</l>
             <l part="I">non fu tua colpa udirlo.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -2159,7 +2175,7 @@
             <l>e il cor di doglia; indi il suo ardir ne nacque;...</l>
             <l>di ciò son rea; di ciò dorrommi io sempre...</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -2175,27 +2191,27 @@
             <l>meglio è così. Sfuggi del par Rosmunda,</l>
             <l part="I">ch'ella potria...</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
             <l part="F">T'intendo; anzi che nasca</l>
             <l part="I">rimorso in lei d'opra pietosa.</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l part="F">Addio.</l>
             <l part="I">Più lungo star, nuocer ne può.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
             <l part="F">Mi lasci?...</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -2205,31 +2221,31 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>ALMACHILDE, ROMILDA, ILDOVALDO, <emph>soldati</emph></stage>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="I">T'arresta.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
             <l part="M">Oh ciel!</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l part="F">Chi mi ti mena innante?</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
             <l part="I">Cinto d'armati!...</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -2241,7 +2257,7 @@
             <l>dimmi; perché? Forse in un giorno istesso</l>
             <l>scudo al tuo prence e traditor vuoi farti?</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -2250,7 +2266,7 @@
             <l>lavarla può, certo il puoi tu, col darmi</l>
             <l part="I">la mercé, che mi dai.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -2258,7 +2274,7 @@
             <l>venirne in armi al mio cospetto, e fingi</l>
             <l part="I">pur moderata voglia?</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -2266,20 +2282,20 @@
             <l>Poiché co' detti invan, forza è coll'opre</l>
             <l part="I">ch'io ti provi il mio amore.</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l part="M">Iniquo...</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
             <l part="F">Ed osi</l>
             <l part="I">ancora?...</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -2295,7 +2311,7 @@
             <l>strada miglior; presto son io, tel giuro,</l>
             <l>a non mi far di mia possanza schermo.</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -2305,7 +2321,7 @@
             <l>osi tu far, qui d'ogni intorno cinto</l>
             <l part="I">di satelliti infami?</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -2317,13 +2333,13 @@
             <l>a un mio cenno, se l'osi. Or via: la prova</l>
             <l>te n'offro; il più valente abbia Romilda.</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l part="I">Muori tu dunque or di mia mano...</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -2331,14 +2347,14 @@
             <l>Che fate?... Oh ciel!... Cessa Ildovaldo; or merta</l>
             <l>di venir teco al paragon costui?</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l>— Ben parli. A che voll'io, caldo di sdegno,</l>
             <l part="I">abbassar me?</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -2349,14 +2365,14 @@
             <l>ch'io più assai di me stessa amo Ildovaldo,</l>
             <l>e che ti abborro più ancor che non l'amo?</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l>Averla or debbe il più valente in arme,</l>
             <l part="I">o in tradimenti? Parla.</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -2378,7 +2394,7 @@
             <l>io ristorarla, io 'l posso; e tu nol puoi,</l>
             <l part="I">né il può persona.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -2393,7 +2409,7 @@
             <l>in preda sempre anzi starei, che averti</l>
             <l part="I">né difensor mio pure.</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -2413,7 +2429,7 @@
             <l>macchiato il brando mio, sì che al tuo brando</l>
             <l part="I">or misurarlo io possa?</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -2422,13 +2438,13 @@
             <l>rival non vuoi? Re ti sarò. — Soldati</l>
             <l part="I">si disarmi, s'arresti.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
             <l part="M">Ah! no...</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -2436,7 +2452,7 @@
             <l>che un tiranno salvasti, a terra vanne.</l>
             <l part="I">Inerme io fommi; altri non mai...</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -2444,21 +2460,21 @@
             <l>il duce vostro? Ahi vili!... Or tu m'ascolta;</l>
             <l>sospendi... Io forse... Oh stato orribil!... M'odi...</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l>Che fai? chi preghi? — Io t'amo; al par tu m'ami:</l>
             <l part="I">ch'havvi a temer da noi?</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="F">Su via, si tragga</l>
             <l part="I">dal mio cospetto.</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -2472,7 +2488,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>ROMILDA, ALMACHILDE</stage>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -2480,33 +2496,33 @@
             <l>cadrotti al fianco... Il vo' seguire... Infame,</l>
             <l part="I">tu mel contendi? Ad ogni costo...</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="F">Ah! soffri,</l>
             <l part="I">ch'io, sol per poco, or ti rattenga.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
             <l part="F">Oh rabbia!</l>
             <l part="I">oh dolor!... Lascia, al fianco suo...</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="F">Mi ascolta.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
             <l part="I">Troppo già t'ascoltai... L'amante...</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -2520,14 +2536,14 @@
             <l>gli vien fatta. — Ma,... oh ciel!... lasciar rapirmi,</l>
             <l>sol ben ch'io m'abbia al mondo, la tua vista!...</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
             <l>Ancor d'amore?... Ah! che non ho qui un ferro,</l>
             <l part="I">onde sottrarmi a' detti tuoi?</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -2537,7 +2553,7 @@
             <l>(ahi nome!) e spero in un seco disciormi</l>
             <l part="I">di quanto mai gli deggia.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -2547,7 +2563,7 @@
             <l>innanzi a noi, mai più; sol dono è questo,</l>
             <l part="I">che far tu possa a me.</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -2555,7 +2571,7 @@
             <l>nol posso io no: ma possederti forse</l>
             <l part="I">mal tuo grado vogl'io?</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -2564,7 +2580,7 @@
             <l>Ingannarmi, o indugiarmi, invan tu speri.</l>
             <l part="I">Col mio amante indivisa...</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -2583,7 +2599,7 @@
             <l>(fin ch'io il divido) agli occhi altrui più reo,</l>
             <l part="I">più vile a' miei. Tempo omai giunto...</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -2599,7 +2615,7 @@
             <l>al tuo parlar, che a spingerti a' misfatti</l>
             <l part="I">non è mestier gran forza.</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -2624,7 +2640,7 @@
             <l>avrò così, per quanto in me il potea,</l>
             <l part="I">espiato; e...</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -2633,7 +2649,7 @@
             <l>che più lo apprezzo, ed è più mio. Se il nieghi,</l>
             <l part="I">me di mia man cader vedrai.</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -2658,7 +2674,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>ROSMUNDA</stage>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -2676,20 +2692,20 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>ROSMUNDA, ROMILDA</stage>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
             <l>Dov'è, dov'è, quel traditore? — Ah! teco</l>
             <l>qui dianzi egli era... Ove fuggia l'iniquo?...</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
             <l part="I">Or sappi...</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -2698,7 +2714,7 @@
             <l>che regal possa entro mia reggia usurpa?</l>
             <l part="I">Perfida, ei teco era finora...</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -2710,14 +2726,14 @@
             <l>scempio di me: sol di sue mani or traggi</l>
             <l part="I">senza indugio Ildovaldo; indi...</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
             <l part="F">S'io 'l traggo?</l>
             <l part="I">Tosto il vedrai.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -2737,7 +2753,7 @@
             <l>non d'altra man che della mia, qui caddi;</l>
             <l>e qui, chiamandolo a nome, spirai.</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -2748,7 +2764,7 @@
             <l>tu sei di me; misera io resto, e farti</l>
             <l part="I">deggio felice... E il deggio?</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -2761,21 +2777,21 @@
             <l>la vita forse: e in dono infame egli osa</l>
             <l part="I">offrirti a me...</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
             <l part="F">Tu scellerato il fai;</l>
             <l part="I">perfida, tu...</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
             <l part="F">Me dunque uccidi; e salva,</l>
             <l part="I">senza indugiar, solo Ildovaldo.</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -2788,13 +2804,13 @@
             <l>ch'io più non oda di te mai: felice</l>
             <l part="I">fa' ch'io mai non ti vegga... Esci.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
             <l part="M">Ma...</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -2804,7 +2820,7 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>ROSMUNDA</stage>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -2818,19 +2834,19 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>ROSMUNDA, ALMACHILDE, <emph>soldati</emph></stage>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
             <l part="I">Al campo vai?</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="M">Ma torneronne...</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -2838,7 +2854,7 @@
             <l>re qui dal campo vincitore aspetto:</l>
             <l part="I">qui tua preda ti serbo.</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -2846,7 +2862,7 @@
             <l>ch'io a te risponda. Ad Ildovaldo pria</l>
             <l part="I">mostrarmi voglio.</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -2857,7 +2873,7 @@
             <l>avea le man, come pugnava? — Sciolto</l>
             <l>ei già ti attende; a trionfarne corri.</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -2868,14 +2884,14 @@
             <l>nemico esserti aperto: or da' tuoi lacci</l>
             <l part="I">sciolto appieno m'hai tu.</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
             <l part="F">Va', vinci, riedi;</l>
             <l part="I">e poi minaccia.</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -2886,7 +2902,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>ROSMUNDA</stage>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -2914,7 +2930,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>ROSMUNDA, ROMILDA</stage>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -2923,7 +2939,7 @@
             <l>fin che per te nel campo si combatte.</l>
             <l part="I">Vieni, t'accosta... Tremi?</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -2936,7 +2952,7 @@
             <l>sol, che sciolto Ildovaldo... Ah! pur ch'ei viva!...</l>
             <l part="I">deh! prego, trammi or di tal dubbio.</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -2954,7 +2970,7 @@
             <l>regina tu; vieni; or si pugna in campo</l>
             <l part="I">per darti regno... o morte.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -2962,7 +2978,7 @@
             <l>anco mi vuoi? di farmi oltraggi tanti</l>
             <l part="I">sazia non sei?</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -2981,7 +2997,7 @@
             <l>or compie ei già le mie vendette; e a un tempo...</l>
             <l part="I">le tue, pur troppo!</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -2993,7 +3009,7 @@
             <l>sta in armi in campo! Ah! men turbata vita</l>
             <l part="I">t'accordi il cielo...</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -3007,7 +3023,7 @@
             <l>dov'io misera sono? — Or or vedrassi...</l>
             <l part="I">Ma, chi s'appressa?</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
@@ -3018,21 +3034,21 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>ROMILDA, ILDOVALDO, ROSMUNDA, <emph>seguaci d'Ildovaldo</emph></stage>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
             <l part="F">Ah! vieni;</l>
             <l part="I">di'; vincesti? son tua?</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
             <l part="F">Ciò ch'io t'imposi,</l>
             <l>compiuto hai tu? quel traditore hai spento?</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -3046,7 +3062,7 @@
             <l>ch'io pria ti tragga. Aprir sapremti strada</l>
             <l>miei forti, ed io. Vien meco, or sei ben mia.</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -3061,14 +3077,14 @@
             <l>Qui per mercé non meritata vieni,</l>
             <l part="I">lui vivo, tu?</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
             <l part="F">Deh! di sue mani or trammi</l>
             <l part="I">tosto, Ildovaldo.</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -3079,26 +3095,26 @@
             <l>non niegherà nel vil suo sangue, e tosto.</l>
             <l part="I">Non ti smarrir, Rosmunda.</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
             <l part="F">E che? tu pensi</l>
             <l part="I">schernirmi? tu?</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
             <l part="M">Lasciami...</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l part="F">Cessa, o ch'io...</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -3106,19 +3122,19 @@
             <l>odo le grida,... e più feroci, e presso;...</l>
             <l>oh gioia! oh, fosse il tuo sperar deluso!</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
             <l part="I">Ahi lassa me!...</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l part="M">Chi viene in armi?</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -3130,14 +3146,14 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>ALMACHILDE, ILDOVALDO, ROSMUNDA, ROMILDA <emph>soldati e seguaci d'Ildovaldo</emph></stage>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l part="F">In traccia vieni</l>
             <l part="I">di me tu forse? eccomi...</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -3145,20 +3161,20 @@
             <l>miei prodi, a freno: assai già strage femmo.</l>
             <l part="I">Dal più ferir si resti.</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l part="F">Ancor ti avanza</l>
             <l part="I">da uccider me: ma pria...</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
             <l part="M">Svenalo.</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
@@ -3175,86 +3191,86 @@
             <l>te stessa; e di noi donna, e di costei.</l>
             <l>S'io ingannarti pensassi, omai tu il vedi.</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
             <l>Donna di me costei? di me? Nel petto</l>
             <l part="I">io questo stil già già le immergo...</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l part="F">Ah! ferma...</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="I">T'arresta, deh!...</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
             <l part="F">Nullo appressarsi ardisca,</l>
             <l part="I">o il ferro io vibro.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
             <l part="F">E vibralo: morrommi</l>
             <l part="I">così almen d'Ildovaldo...</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
             <l part="F">Or, qual di noi</l>
             <l part="I">è donna qui?</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="M">Tu il sei... Deh!... cessa...</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l part="F">Oh rabbia!...</l>
             <l>Romilda... Oh cielo! e non ti posso io trarre?...</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
             <l>Re sol di nome tu, depon quel brando. —</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="I">Eccomi inerme...</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
             <l part="F">Or tuoi soldati tutti</l>
             <l part="I">fuor della reggia manda.</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="F">Ite, sgombrate,</l>
             <l part="I">affrettatevi, tutti...</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -3262,40 +3278,40 @@
             <l>con un delitto d'acquistar l'amata,</l>
             <l>freddo amator, tosto il tuo stuol disperdi.</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l part="I">Ecco, spariro...</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
             <l part="F">Or ben così. — Ragauso</l>
             <l>tosto or qui rieda, e le mie guardie in armi...</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="I">Venga, deh! tosto...</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
             <l part="F">Ecco Ragauso. — Io sono,</l>
             <l part="I">io son qui dunque ancor regina?</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="F">Il sei</l>
             <l part="I">tu sola. Deh!...</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
@@ -3304,7 +3320,7 @@
             <l>vuoi tu ch'io pera? ecco al mio petto il ferro</l>
             <l part="I">rivolgo io già...</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
@@ -3323,83 +3339,83 @@
             <l>volli all'amante riamato? a vita</l>
             <l>te riserbar, che dai morti a me mille?</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l part="I">Deh! per pietà!...</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
             <l part="M">Trema.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
             <l part="M">Ildovaldo!...</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="F">Morte</l>
             <l part="I">spiran suoi sguardi!... A me quel ferro...</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
             <l part="F">A lei</l>
             <l part="I">pria il ferro, in lei. Muori.</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l part="F">Ah!... Tu pur morrai.<note resp="#aut" place="foot" anchored="true">In atto d'avventarsi col brando a Rosmunda.</note></l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>
             <l part="I">Guardie, entrambi si accerchino.</l>
           </sp>
-          <sp>
+          <sp who="#romilda">
             <speaker>
               <emph>Romilda</emph>
             </speaker>
             <l part="F">Ildovaldo...</l>
             <l part="I">moro.. almen... tua...</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l part="M">Seguirti...</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="F">Vendicarti...</l>
           </sp>
-          <sp>
+          <sp who="#ildovaldo">
             <speaker>
               <emph>Ildovaldo</emph>
             </speaker>
             <l>Sopravviver non posso.<note resp="#aut" place="foot" anchored="true">Si uccide.</note> O tu, che resti,...</l>
             <l part="I">fanne vendetta...</l>
           </sp>
-          <sp>
+          <sp who="#almachilde">
             <speaker>
               <emph>Almachilde</emph>
             </speaker>
             <l part="F">Io vendicarla giuro.</l>
           </sp>
-          <sp>
+          <sp who="#rosmunda">
             <speaker>
               <emph>Rosmunda</emph>
             </speaker>

--- a/tei/alfieri-saul.xml
+++ b/tei/alfieri-saul.xml
@@ -82,6 +82,28 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="david">
+            <persName>David</persName>
+          </person>
+          <person xml:id="gionata">
+            <persName>Gionata</persName>
+          </person>
+          <person xml:id="micol">
+            <persName>Micol</persName>
+          </person>
+          <person xml:id="saul">
+            <persName>Saul</persName>
+          </person>
+          <person xml:id="abner">
+            <persName>Abner</persName>
+          </person>
+          <person xml:id="achimelech">
+            <persName>Achimelech</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -142,7 +164,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>DAVID</stage>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -181,14 +203,14 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>GIONATA, DAVID</stage>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>GIONATA</emph>
             </speaker>
             <l>Oh! qual voce mi suona? odo una voce,</l>
             <l part="I">cui del mio cor nota è la via.</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>DAVID</emph>
             </speaker>
@@ -196,14 +218,14 @@
             <l>Deh, raggiornasse! Io non vorria mostrarmi,</l>
             <l part="I">qual fuggitivo...</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>GIONATA</emph>
             </speaker>
             <l part="F">Olà. Chi sei? che fai</l>
             <l>dintorno al regio padiglion? favella.</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>DAVID</emph>
             </speaker>
@@ -211,33 +233,33 @@
             <l>viva Israèl, son io. Me ben conosce</l>
             <l part="I">il Filisteo.</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>GIONATA</emph>
             </speaker>
             <l part="F">Che ascolto? Ah! David solo</l>
             <l part="I">così risponder può.</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>DAVID</emph>
             </speaker>
             <l part="M">Gionata...</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>GIONATA</emph>
             </speaker>
             <l part="F">Oh cielo!</l>
             <l part="I">David,... fratello...</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>DAVID</emph>
             </speaker>
             <l part="M">Oh gioia!... A te...</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>GIONATA</emph>
             </speaker>
@@ -245,7 +267,7 @@
             <l>tu in Gelboè? Del padre mio non temi?</l>
             <l part="I">Io per te tremo; oimè!...</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>DAVID</emph>
             </speaker>
@@ -263,7 +285,7 @@
             <l>per la patria, da forte; e per l´ingrato</l>
             <l>stesso Saùl, che la mia morte or grida.</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>GIONATA</emph>
             </speaker>
@@ -275,7 +297,7 @@
             <l>squadre ei ti crede, o il finge; ei ti dà taccia</l>
             <l part="I">di traditor ribelle.</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>DAVID</emph>
             </speaker>
@@ -286,7 +308,7 @@
             <l>finché sian vinti. Il guiderdon mio prisco</l>
             <l>men renda ei poscia; odio novello, e morte.</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>GIONATA</emph>
             </speaker>
@@ -301,7 +323,7 @@
             <l>ei glie la pinge e mal sicura, e incerta.</l>
             <l part="I">Invan tua sposa ed io, col padre...</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>DAVID</emph>
             </speaker>
@@ -309,20 +331,20 @@
             <l>oh dolce nome! ov´è Micol mia fida?</l>
             <l>M´ama ella ancor, mal grado il padre crudo?...</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>GIONATA</emph>
             </speaker>
             <l part="I">Oh! s´ella t´ama?... è in campo anch´essa...</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
             <l part="F">Oh cielo!</l>
             <l part="I">vedrolla? oh gioia! Or, come in campo?...</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
@@ -333,7 +355,7 @@
             <l>benché ognor mesta. Ah! la magion del pianto</l>
             <l>ella è la nostra, da che tu sei lungi.</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -341,7 +363,7 @@
             <l>torrà il pensier d´ogni passata angoscia;</l>
             <l>torrà il pensier d´ogni futuro danno.</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
@@ -359,13 +381,13 @@
             <l>che tramortita come ell´è si strappi</l>
             <l part="I">dai piè del padre.</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
             <l part="F">Oh vista! Oh! che mi narri?</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
@@ -388,14 +410,14 @@
             <l>per la sposa, pe´ figli: a me tu caro,</l>
             <l>più assai che regno, e padre, e sposa, e figli...</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
             <l>M´ami e più che nol merto: ami te Dio</l>
             <l part="I">così...</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
@@ -415,7 +437,7 @@
             <l>eccheggi il monte. Oggi, a battaglia stimo</l>
             <l part="I">venir fia forza.</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -455,7 +477,7 @@
             <l>del par la mala infetta pianta, e i fiori,</l>
             <l part="I">ed i pomi, e le foglie.</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
@@ -471,7 +493,7 @@
             <l>si bee talor nell´oro infido morte.</l>
             <l part="I">Deh! chi ten guarda?</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -481,7 +503,7 @@
             <l>veder poss´io la sposa? Entrar non debbo</l>
             <l part="I">là, fin che albeggi...</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
@@ -493,7 +515,7 @@
             <l>forse, ch´ella è: scostati alquanto; e l´odi:</l>
             <l>ma, se altri fosse, or non mostrarti, prego.</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -503,7 +525,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>MICOL, GIONATA</stage>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>MICOL</emph>
             </speaker>
@@ -526,7 +548,7 @@
             <l>a rintracciarlo io sola: io David voglio</l>
             <l part="I">incontrare, o la morte.</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
@@ -534,14 +556,14 @@
             <l>e il pianto acqueta: il nostro David forse</l>
             <l part="I">in Gelboè verrà...</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
             <l part="F">Che parli? in loco,</l>
             <l part="I">dov´è Saùl, David venirne?...</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
@@ -552,7 +574,7 @@
             <l>che il timor possa? E maraviglia avresti,</l>
             <l part="I">s´ei qui venirne ardisse?</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -560,7 +582,7 @@
             <l>io tremerei... Ma pure, il sol vederlo</l>
             <l part="I">fariami...</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
@@ -576,21 +598,21 @@
             <l>che a lui non siede la vittoria in core.</l>
             <l>Forse in punto ei verrebbe ora il tuo sposo.</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
             <l>Sì, forse è ver: ma lungi egli è;... deh! dove?...</l>
             <l part="I">e in quale stato?... Oimè!...</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
             <l part="F">Più che nol pensi,</l>
             <l part="I">ei ti sta presso.</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -600,13 +622,13 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>DAVID, MICOL, GIONATA</stage>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
             <l part="I">Teco è il tuo sposo.</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -614,7 +636,7 @@
             <l>Parlar... non... posso. — Oh maraviglia!... E fia...</l>
             <l part="I">ver, ch´io t´abbraccio?...</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -629,7 +651,7 @@
             <l>coperte l´ossa; e di lagrime vere</l>
             <l part="I">da lei bagnate.</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -649,7 +671,7 @@
             <l>potria del re genero dirti? All´armi</l>
             <l part="I">volgar guerrier sembri, e non altro.</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -662,7 +684,7 @@
             <l>nel gran Dio d´Israèl, che me sottrarre</l>
             <l>può dall´eccidio, s´io morir non merto.</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
@@ -683,7 +705,7 @@
             <l>guerrier ti mesci, e inosservato aspetta,</l>
             <l part="I">ch´io per te rieda, o mandi...</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -705,7 +727,7 @@
             <l>aspergo: ivi ti cela, infin che il tempo,</l>
             <l part="I">sia di mostrarti.</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -721,7 +743,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>SAUL, ABNER</stage>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -733,7 +755,7 @@
             <l>che vincitor la sera ricorcarsi</l>
             <l part="I">certo non fosse.</l>
           </sp>
-          <sp>
+          <sp who="#abner">
             <speaker>
               <emph>Abner</emph>
             </speaker>
@@ -743,7 +765,7 @@
             <l>quanto più tardi viensi, Abner tel dice,</l>
             <l>tanto ne avrai più intera, e nobil palma.</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -758,7 +780,7 @@
             <l>d´Iddio possente!... o meco fosse almeno</l>
             <l part="I">David, mio prode!</l>
           </sp>
-          <sp>
+          <sp who="#abner">
             <speaker>
               <emph>Abner</emph>
             </speaker>
@@ -768,7 +790,7 @@
             <l>che per trafigger me. David, ch´è prima,</l>
             <l>sola cagion d´ogni sventura tua...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -804,7 +826,7 @@
             <l>uom menzogner di corte, invido, astuto</l>
             <l part="I">nemico, traditore...</l>
           </sp>
-          <sp>
+          <sp who="#abner">
             <speaker>
               <emph>Abner</emph>
             </speaker>
@@ -839,7 +861,7 @@
             <l>è d´Abner lustro: ma non può innalzarsi</l>
             <l>David, no mai, s´ei pria Saùl non calca.</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -878,7 +900,7 @@
             <l>Chi sei?... Chi n´ebbe anco il pensiero, pera... —</l>
             <l part="I">Ahi lasso me! ch´io già vaneggio!...</l>
           </sp>
-          <sp>
+          <sp who="#abner">
             <speaker>
               <emph>Abner</emph>
             </speaker>
@@ -890,19 +912,19 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>GIONATA, MICOL, SAUL, ABNER</stage>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
             <l>Col re sia pace.</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
             <l part="I">E sia col padre Iddio.</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -914,7 +936,7 @@
             <l>peggio è che averla; ed abbiasi una volta.</l>
             <l part="I">Oggi si pugni, io ´l voglio.</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
@@ -926,7 +948,7 @@
             <l>fia questo campo; ai predatori alati</l>
             <l part="I">noi lasceremo orribil esca...</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -937,7 +959,7 @@
             <l>tornare a vita anco vorrai, lo sposo</l>
             <l part="I">rendendole...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -948,7 +970,7 @@
             <l>sei tu così? Figlia del pianto, vanne;</l>
             <l part="I">esci; lasciami, scostati.</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -957,7 +979,7 @@
             <l>Padre, e chi l´alma in lagrime sepolta</l>
             <l part="I">mi tiene or, se non tu?...</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
@@ -969,7 +991,7 @@
             <l>dal ciel discese. Anco in tuo cor, ben tosto,</l>
             <l part="I">verrà certezza di vittoria.</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -984,7 +1006,7 @@
             <l>di cener vil si aspergano. Sì, questo</l>
             <l>giorno, è finale; a noi l´estremo, è questo.</l>
           </sp>
-          <sp>
+          <sp who="#abner">
             <speaker>
               <emph>Abner</emph>
             </speaker>
@@ -992,21 +1014,21 @@
             <l>vostro importuno ognor sue fere angosce</l>
             <l part="I">raddoppia.</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
             <l part="F">E che? lascierem noi l´amato</l>
             <l part="I">genitor nostro?...</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
             <l part="F">Al fianco suo, tu solo</l>
             <l part="I">starti pretendi? e che in tua man?...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -1015,14 +1037,14 @@
             <l>Chi, chi gli oltraggia? Abner, tu forse? Questi</l>
             <l>son sangue mio; nol sai?... Taci: rimembra...</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
             <l>Ah! sì; noi siam tuo sangue; e per te tutto</l>
             <l part="I">il nostro sangue a dar siam presti...</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -1037,7 +1059,7 @@
             <l>col celeste suo canto? or di´: non era</l>
             <l>ei, quasi raggio alle tenèbre tue?</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
@@ -1047,7 +1069,7 @@
             <l>ai passi miei? Si parleria di pugna,</l>
             <l>se David qui? vinta saria la guerra.</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -1062,13 +1084,13 @@
             <l>muto è il mio labro... Ov´è mia gloria? dove,</l>
             <l>dov´è de´ miei nemici estinti il sangue?...</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
             <l part="I">Tutto avresti in Davìd.</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -1080,7 +1102,7 @@
             <l>nell´obbedirti; ed in amarti caldo,</l>
             <l>più che i propri tuoi figli. Ah! padre, lascia...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -1088,7 +1110,7 @@
             <l>inusitato, or chi mi sforza?... Asciutto</l>
             <l part="I">lasciate il ciglio mio.</l>
           </sp>
-          <sp>
+          <sp who="#abner">
             <speaker>
               <emph>Abner</emph>
             </speaker>
@@ -1102,55 +1124,55 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>DAVID, SAUL, ABNER, GIONATA, MICOL</stage>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
             <l part="F">La innocenza tranne.</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
             <l part="I">Che veggio?</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
             <l part="M">Oh ciel!</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
             <l part="M">Che festi?</l>
           </sp>
-          <sp>
+          <sp who="#abner">
             <speaker>
               <emph>Abner</emph>
             </speaker>
             <l part="M">Audace...</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
             <l part="F">Ah! padre...</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
             <l part="I">Padre, ei m´è sposo; e tu mel desti.</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
             <l part="F">Oh vista!</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -1158,7 +1180,7 @@
             <l>già da gran tempo il cerchi; ecco, io tel reco;</l>
             <l part="I">troncalo, è tuo.</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -1166,7 +1188,7 @@
             <l>Un Iddio parla in te: qui mi t´adduce</l>
             <l part="I">oggi un Iddio...</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -1205,7 +1227,7 @@
             <l>per lui s´udia il mio nome, ei lo disperde:</l>
             <l part="I">ei mi fea grande, ei mi fa nulla.</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -1227,7 +1249,7 @@
             <l>le migliaia abbatteva: egli è il guerriero;</l>
             <l part="I">ei mi creò».</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -1241,7 +1263,7 @@
             <l>troppo è miglior di me; quindi io lo abborro;</l>
             <l>quindi lo invidio, e temo; e spento io ´l voglio».</l>
           </sp>
-          <sp>
+          <sp who="#abner">
             <speaker>
               <emph>Abner</emph>
             </speaker>
@@ -1257,7 +1279,7 @@
             <l>ti pose? A farti genero, chi ´l mosse?</l>
             <l part="I">Abner fu solo...</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -1270,7 +1292,7 @@
             <l>sempre al mio cor giovato avria più David,</l>
             <l>ch´ogni alto re, cui l´oriente adori.</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -1282,7 +1304,7 @@
             <l>secondo padre, insidiata forse</l>
             <l part="I">non l´hai più volte?</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -1290,14 +1312,14 @@
             <l>questo, già lembo del regal tuo manto.</l>
             <l part="I">Conoscil tu? Prendi; il raffronta.</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
             <l part="F">Dammi.</l>
             <l>Che veggio? è mio; nol niego... Onde l´hai tolto?...</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -1329,38 +1351,38 @@
             <l>invida rabbia, e della guardia infida</l>
             <l part="I">di questo Abner?...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
             <l part="F">Mio figlio, hai vinto;... hai vinto.</l>
             <l part="I">Abner, tu mira; ed ammutisci.</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
             <l part="F">Oh gioia!</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
             <l part="I">Oh padre!...</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
             <l part="M">Oh dì felice!</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
             <l part="M">Oh sposo!...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -1373,19 +1395,19 @@
             <l>combatterai: mallevador mi è David</l>
             <l>della tua vita; e della sua tu il sei.</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
             <l>Duce Davìd, mallevadore è Iddio.</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
             <l part="I">Dio mi ti rende: ei salveratti...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -1405,28 +1427,28 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>DAVID, ABNER</stage>
-          <sp>
+          <sp who="#abner">
             <speaker>
               <emph>Abner</emph>
             </speaker>
             <l>Eccomi: appena dal convito or sorge</l>
             <l part="I">il re, ch´io vengo a´ cenni tuoi.</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
             <l part="F">Parlarti</l>
             <l part="I">a solo a solo io volli.</l>
           </sp>
-          <sp>
+          <sp who="#abner">
             <speaker>
               <emph>Abner</emph>
             </speaker>
             <l part="F">Udir vuoi forse</l>
             <l part="I">della prossima pugna?...</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -1436,7 +1458,7 @@
             <l>Dio d´Israèl serviamo. Altro pensiero</l>
             <l part="I">in noi, deh! no, non entri.</l>
           </sp>
-          <sp>
+          <sp who="#abner">
             <speaker>
               <emph>Abner</emph>
             </speaker>
@@ -1445,7 +1467,7 @@
             <l>sanguinoso rotai, già pria che il fischio</l>
             <l part="I">ivi si udisse di tua fionda...</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -1457,7 +1479,7 @@
             <l>emulo di te stesso, oggi tu imprendi</l>
             <l part="I">a superar solo te stesso.</l>
           </sp>
-          <sp>
+          <sp who="#abner">
             <speaker>
               <emph>Abner</emph>
             </speaker>
@@ -1490,7 +1512,7 @@
             <l>dalle spalle, e dai lati, eccolo, è chiuso;</l>
             <l>eccone fatto aspro macello intero.</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -1500,7 +1522,7 @@
             <l>e alla tua pugna il mio venir null´altro</l>
             <l part="I">aggiungerà, che un brando.</l>
           </sp>
-          <sp>
+          <sp who="#abner">
             <speaker>
               <emph>Abner</emph>
             </speaker>
@@ -1508,7 +1530,7 @@
             <l>di guerra il mastro è David. Chi combatte,</l>
             <l part="I">fuorch´egli, mai?</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -1521,14 +1543,14 @@
             <l>salirà il giogo; e tu, coi più, terrai</l>
             <l part="I">della battaglia il corpo.</l>
           </sp>
-          <sp>
+          <sp who="#abner">
             <speaker>
               <emph>Abner</emph>
             </speaker>
             <l part="F">A te si aspetta;</l>
             <l part="I">loco è primiero.</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -1540,13 +1562,13 @@
             <l>il sol negli occhi, e la sospinta polve,</l>
             <l>anco per noi combatteran da sera.</l>
           </sp>
-          <sp>
+          <sp who="#abner">
             <speaker>
               <emph>Abner</emph>
             </speaker>
             <l part="I">Ben dici.</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -1558,7 +1580,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>DAVID</stage>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -1575,7 +1597,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>MICOL, DAVID</stage>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -1584,13 +1606,13 @@
             <l>e un istante parlavagli: io m´inoltro,</l>
             <l>egli esce; il re già quel di pria non trovo.</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
             <l part="I">Ma pur, che disse? in che ti parve?...</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -1601,7 +1623,7 @@
             <l>quasi alla sua sostegno; ei più che padre</l>
             <l>pareane ai detti: or, più che re mi apparve.</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -1619,7 +1641,7 @@
             <l>padre puoi far me tuo consorte errante,</l>
             <l part="I">e fuggitivo sempre...</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -1648,14 +1670,14 @@
             <l>poss´io ridir? — Mai più, no, non ti lascio;</l>
             <l part="I">mai più...</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
             <l part="F">Mi strappi il cor: deh! cessa... Al sangue,</l>
             <l>e non al pianto, questo giorno è sacro.</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -1665,14 +1687,14 @@
             <l>dal perfid´Abner impedita, o guasta,</l>
             <l part="I">non ti sia la vittoria.</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
             <l part="F">E che? ti parve</l>
             <l>dubbio il re d´affidarmi oggi l´impresa?</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -1684,13 +1706,13 @@
             <l>tremende, a chi di David è consorte,</l>
             <l part="I">e di Saulle è figlia.</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
             <l part="F">Eccolo: si oda.</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -1702,7 +1724,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>SAUL, GIONATA, MICOL, DAVID</stage>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
@@ -1711,19 +1733,19 @@
             <l>ti fia ristoro; vieni: alquanto siedi</l>
             <l part="I">tra i figli tuoi.</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
             <l part="M">... Che mi si dice?</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
             <l part="F">Ah! padre!...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -1737,7 +1759,7 @@
             <l>che me percuote, e a lagrimar mi sforza...</l>
             <l part="I">Ma che? Voi pur, voi pur piangete?...</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
@@ -1746,7 +1768,7 @@
             <l>dal re Saùl così? lui, già tuo servo,</l>
             <l>lasci or così dell´avversario in mano?</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -1755,14 +1777,14 @@
             <l>se piangi tu... Ma, di che pianger ora?</l>
             <l part="I">gioia tornò.</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
             <l part="F">David, vuoi dire. Ah!... David...</l>
             <l>deh! perché non mi abbraccia anch´ei co´ figli?</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -1770,13 +1792,13 @@
             <l>di non t´esser molesto. Ah! nel mio core</l>
             <l>perché legger non puoi? son sempre io teco.</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
             <l>Tu... di Saulle... ami la casa dunque?</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -1786,14 +1808,14 @@
             <l>dica, se il può, ch´io nol potrei, di quanto,</l>
             <l part="I">di quale amore io l´amo...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
             <l part="F">Eppur, te stesso</l>
             <l part="I">stimi tu molto...</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -1801,7 +1823,7 @@
             <l>non vil soldato, e tuo genero in corte</l>
             <l>mi tengo; e innanzi a Dio, nulla mi estimo.</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -1810,7 +1832,7 @@
             <l>da Dio l´astuta ira crudel tremenda</l>
             <l>de´ sacerdoti. Ad oltraggiarmi, il nomi?</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -1821,7 +1843,7 @@
             <l>Ei sul soglio chiamotti; ei vi ti tiene:</l>
             <l>sei suo, se in lui, ma se in lui sol, ti affidi.</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -1833,7 +1855,7 @@
             <l>Qual brando è questo? ei non è già lo stesso</l>
             <l part="I">ch´io di mia man ti diedi...</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -1845,7 +1867,7 @@
             <l>Goliàt gigante: ei lo stringea: ma stavvi</l>
             <l>rappreso pur, non già il mio sangue, il suo.</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -1855,20 +1877,20 @@
             <l>e così tolto a ogni profana vista?</l>
             <l>consecrato in eterno al Signor primo?...</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
             <l part="I">Vero è; ma...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
             <l part="F">Dunque, onde l´hai tu? Chi ardiva</l>
             <l part="I">dartelo? chi?...</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -1883,31 +1905,31 @@
             <l>potea, quell´uno esser potea ben David)</l>
             <l part="I">la chiesi io stesso al sacerdote.</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
             <l part="F">Ed egli?...</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
             <l part="I">Diemmela.</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
             <l part="F">Ed era?</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
             <l part="I">Achimelèch.</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -1919,13 +1941,13 @@
             <l>Ov´è l´altar? si atterri... Ov´è l´offerta?</l>
             <l part="I">svenarla io voglio...</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
             <l part="M">Ah padre!</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
@@ -1934,20 +1956,20 @@
             <l>non havvi altar; non vittima; rispetta</l>
             <l>nei sacerdoti Iddio, che sempre t´ode.</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
             <l>Chi mi rattien?... Chi di seder mi sforza?...</l>
             <l part="I">Chi a me resiste?...</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
             <l part="M">Padre...</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -1955,7 +1977,7 @@
             <l>alto Iddio d´Israèle: a te si prostra,</l>
             <l part="I">te ne scongiura il servo tuo.</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -1973,7 +1995,7 @@
             <l>tremolante del padre... Ahi fero stato!</l>
             <l part="I">meglio è la morte. Io voglio morte...</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -1981,7 +2003,7 @@
             <l>noi vogliam tutti la tua vita: a morte</l>
             <l>ognun di noi, per te sottrarne, andrebbe...</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
@@ -1990,7 +2012,7 @@
             <l>muovi, o fratello. In dolce oblio l´hai ratto</l>
             <l>già tante volte con celesti carmi.</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -1999,7 +2021,7 @@
             <l>nuota in lagrime: or tempo è di prestargli</l>
             <l part="I">l´opra tua.</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -2027,7 +2049,7 @@
             <l>nubi–fendente or manda a noi dal polo.</l>
             <l>Tenebre e pianto siamo...»</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -2035,7 +2057,7 @@
             <l>di David?... Trammi di mortal letargo:</l>
             <l>folgor mi mostra di mia verde etade.</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -2070,7 +2092,7 @@
             <l>Saùl, torrente al rinnovar dell´anno,</l>
             <l>tutto inonda, scompon, schianta, travolve».</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -2081,7 +2103,7 @@
             <l>si addice omai?... L´ozio, l´oblio, la pace,</l>
             <l part="I">chiamano il veglio a sé.</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -2141,7 +2163,7 @@
             <l>e in sonno placido</l>
             <l>sopito è il re». —</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -2152,7 +2174,7 @@
             <l>infra i domestich´ozi? Il pro´ Saulle</l>
             <l>di guerra or forse arnese inutil giace?</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -2192,7 +2214,7 @@
             <l>e incalzo, e atterro, e sperdo; e assai ben mostro</l>
             <l>che due spade ha nel campo il popol nostro».</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -2200,25 +2222,25 @@
             <l>che questa mia, ch´io snudo? Empio è, si uccida,</l>
             <l part="I">pera, chi la sprezzò.</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
             <l part="F">T´arresta: oh cielo!...</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
             <l part="I">Padre! che fai?...</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
             <l part="M">Misero re!</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -2229,26 +2251,26 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>GIONATA, SAUL, MICOL</stage>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
             <l part="I">O padre amato,... arrestati...</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
             <l part="F">T´arresta...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
             <l>Chi mi rattien? chi ardisce?... Ov´è il mio brando?</l>
             <l part="I">Mi si renda il mio brando...</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
@@ -2259,7 +2281,7 @@
             <l>or di quiete. Ah! vieni: ogni ira cessi;</l>
             <l part="I">stai co´ tuoi figli...</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -2272,14 +2294,14 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>GIONATA, MICOL</stage>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
             <l>Gionata, dimmi; al padiglion del padre</l>
             <l part="I">può tornare il mio sposo?</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
@@ -2289,7 +2311,7 @@
             <l>in lui la invidia; e fia il sanarla lungo.</l>
             <l part="I">Torna al tuo sposo, e nol lasciare.</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -2298,14 +2320,14 @@
             <l>sì ben, ch´uom mai nol troveria: men riedo</l>
             <l part="I">ver esso dunque.</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
             <l part="F">Oh cielo! ecco, sen viene</l>
             <l>turbato il padre: ei mai non trova stanza.</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -2316,55 +2338,55 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>SAUL, MICOL, GIONATA</stage>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
             <l part="F">Chi fugge al venir mio? Tu, donna?</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
             <l part="I">Signor...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
             <l part="M">Davide ov´è?</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
             <l part="M">... Nol so...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
             <l part="F">Nol sai?</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
             <l part="I">Padre...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
             <l part="F">Cercane; va´; qui tosto il traggi.</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
             <l part="I">Io rintracciarlo?... or,... dove?</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -2375,13 +2397,13 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>SAUL, GIONATA</stage>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
             <l part="F">... Gionata, m´ami?...</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
@@ -2390,7 +2412,7 @@
             <l>impeti tuoi, qual figlio opporsi il puote,</l>
             <l part="I">io mi oppongo talvolta.</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -2402,7 +2424,7 @@
             <l>Voce non odi entro il tuo cor, che grida?</l>
             <l>«David fia ´l re.» — David? fia spento innanzi.</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
@@ -2422,7 +2444,7 @@
             <l>tu stesso in pianto a´ piedi suoi; tu padre,</l>
             <l part="I">pentito, sì: ch´empio, nol sei...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -2449,7 +2471,7 @@
             <l>non ha il fellon su la nemica testa?</l>
             <l>Forse tu il sai... Parla... Ah! sì, il sai: favella.</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
@@ -2480,7 +2502,7 @@
             <l>donde ti vien, Saulle? Havvi possanza</l>
             <l part="I">d´uom, che a ciò basti?...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -2497,7 +2519,7 @@
             <l>la consorte il marito; il figlio il padre...</l>
             <l>Seggio è di sangue, e d´empietade, il trono.</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
@@ -2510,7 +2532,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>SAUL, GIONATA, ABNER, ACHIMELECH, <emph>soldati</emph></stage>
-          <sp>
+          <sp who="#abner">
             <speaker>
               <emph>Abner</emph>
             </speaker>
@@ -2534,13 +2556,13 @@
             <l>si appiattava tremante. Eccolo; n´odi</l>
             <l>l´alta cagion, che a tal periglio il guida.</l>
           </sp>
-          <sp>
+          <sp who="#achimelech">
             <speaker>
               <emph>Achimelech</emph>
             </speaker>
             <l>Cagion dirò, s´ira di re nol vieta...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -2549,7 +2571,7 @@
             <l>Del fantastico altero gregge sei</l>
             <l part="I">de´ veggenti di Rama?</l>
           </sp>
-          <sp>
+          <sp who="#achimelech">
             <speaker>
               <emph>Achimelech</emph>
             </speaker>
@@ -2573,7 +2595,7 @@
             <l>più Saùl non si vede. Il nome io porto</l>
             <l part="I">d´Achimelèch.</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -2591,7 +2613,7 @@
             <l>fellone, in campo a´ tradimenti or vieni:</l>
             <l part="I">qual dubbio v´ha?</l>
           </sp>
-          <sp>
+          <sp who="#achimelech">
             <speaker>
               <emph>Achimelech</emph>
             </speaker>
@@ -2615,7 +2637,7 @@
             <l>della rotta, che in cor ti ha posta Iddio? —</l>
             <l>Se danni me, te stesso danni a un tempo</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -2650,7 +2672,7 @@
             <l>con verga vil, con studiati carmi,</l>
             <l>frenar vorreste e i brandi nostri, e noi?</l>
           </sp>
-          <sp>
+          <sp who="#achimelech">
             <speaker>
               <emph>Achimelech</emph>
             </speaker>
@@ -2683,7 +2705,7 @@
             <l>fondata ei l´ha; già già crolla; già cade;</l>
             <l part="I">già in cener torna: è nulla già. —</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -2706,28 +2728,28 @@
             <l>Abner, costui dal mio cospetto or tosto</l>
             <l part="I">traggi, e si uccida...</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
             <l part="F">Oh ciel! padre, che fai?</l>
             <l part="I">Padre...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
             <l part="F">Taci. — Ei si sveni; e il vil suo sangue</l>
             <l part="I">su´ Filistei ricada.</l>
           </sp>
-          <sp>
+          <sp who="#abner">
             <speaker>
               <emph>Abner</emph>
             </speaker>
             <l part="F">è già con esso</l>
             <l part="I">morte...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -2741,7 +2763,7 @@
             <l>non percoteavi mai: quindi sol, quindi,</l>
             <l part="I">lo scherno d´essa.</l>
           </sp>
-          <sp>
+          <sp who="#achimelech">
             <speaker>
               <emph>Achimelech</emph>
             </speaker>
@@ -2756,7 +2778,7 @@
             <l>e sordo ei fu: compiuto egli è il mio incarco:</l>
             <l part="I">ben ho spesa la vita.</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -2767,13 +2789,13 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>SAUL, GIONATA</stage>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
             <l>Ahi sconsigliato re! che fai? t´arresta...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -2784,7 +2806,7 @@
             <l>degno di viver tu, non fra´ tumulti</l>
             <l part="I">di guerra; e non fra regie cure...</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
@@ -2794,7 +2816,7 @@
             <l>sacerdotal, non Filisteo. Tu resti</l>
             <l part="I">solo a tal empia pugna.</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -2804,7 +2826,7 @@
             <l>Saùl sarò. Che Gionata? che David?</l>
             <l part="I">duce è Saùl.</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
@@ -2813,7 +2835,7 @@
             <l>pria di veder ciò che sovrasta al tuo</l>
             <l part="I">sangue infelice!</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -2824,32 +2846,32 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>MICOL, SAUL, GIONATA</stage>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
             <l part="I">Tu, senza David?...</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
             <l part="F">Ritrovar nol posso...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
             <l part="I">Io ´l troverò.</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
             <l part="F">Lungi è fors´egli; e sfugge</l>
             <l part="I">tuo sdegno...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -2858,19 +2880,19 @@
             <l>guai, se doman, vinta da me la guerra,</l>
             <l part="I">tu innanzi a me nol traggi.</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
             <l part="M">Oh cielo!</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
             <l part="F">Ah! padre...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -2878,26 +2900,26 @@
             <l>Gionata tosto. — E tu, ricerca, e trova</l>
             <l part="I">colui.</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
             <l part="M">Deh!... teco...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
             <l part="M">Invan.</l>
           </sp>
-          <sp>
+          <sp who="#gionata">
             <speaker>
               <emph>Gionata</emph>
             </speaker>
             <l part="F">Padre, ch´io pugni</l>
             <l part="I">lungi da te?</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -2909,7 +2931,7 @@
         <div type="scene">
           <head>SCENA VII</head>
           <stage>SAUL</stage>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -2923,7 +2945,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>DAVID, MICOL</stage>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -2937,7 +2959,7 @@
             <l>su noi qui veglia, andiam; per questa china</l>
             <l>scendiamo il monte, e ci accompagni Iddio.</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -2948,7 +2970,7 @@
             <l>Saùl, se il vuol; pur ch´io nemici pria</l>
             <l part="I">in copia uccida.</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -2957,7 +2979,7 @@
             <l>Achimelèch, qui ritrovato, cadde</l>
             <l part="I">vittima già del furor suo.</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -2965,7 +2987,7 @@
             <l>Ne´ sacerdoti egli ha rivolto il brando?</l>
             <l part="I">Ahi misero Saùl! ei fia...</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -2975,14 +2997,14 @@
             <l>tu ti mostrassi, in te convertan l´armi</l>
             <l part="I">campion nostri.</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
             <l part="F">E Gionata mio fido</l>
             <l part="I">il soffre?</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -2999,7 +3021,7 @@
             <l>di rimaner per sempre col mio sposo...</l>
             <l part="I">Deh! vieni or dunque; andiamo...</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -3015,14 +3037,14 @@
             <l>emmi mestiero, ed all´amor tuo scaltro. —</l>
             <l>Ma tu, pur cedi al mio... Deh! sol mi lascia...</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
             <l>Ch´io ti lasci? Pel lembo, ecco ti afferro.</l>
             <l part="I">da te mai più, no, non mi stacco...</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -3056,7 +3078,7 @@
             <l>di abbandonarti, il pensa... Eppure,... ahi lasso!</l>
             <l part="I">come?...</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -3067,7 +3089,7 @@
             <l>teco almen fossi!... i mali tuoi più lievi</l>
             <l part="I">pur farei,... dividendoli...</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -3084,14 +3106,14 @@
             <l>Dio teco resti; e tu, rimani al padre,</l>
             <l>fin che al tuo sposo ti raggiunga il cielo...</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
             <l>L´ultimo amplesso?... E ch´io non muoia?... Il core</l>
             <l part="I">strappar mi sento...</l>
           </sp>
-          <sp>
+          <sp who="#david">
             <speaker>
               <emph>David</emph>
             </speaker>
@@ -3102,7 +3124,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>MICOL</stage>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -3132,7 +3154,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>SAUL, MICOL</stage>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -3144,14 +3166,14 @@
             <l>vivo m´inghiotti... Ah! pur che il truce sguardo</l>
             <l>non mi saetti della orribil ombra...</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
             <l>Da chi fuggir? niun ti persegue. O padre,</l>
             <l>me tu non vedi? me più non conosci?</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -3167,7 +3189,7 @@
             <l>non da me, no, ma da´ miei figli. I figli,</l>
             <l part="I">del mio fallir sono innocenti...</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -3175,7 +3197,7 @@
             <l>cui non fu il pari mai! — Dal ver disgiunto,</l>
             <l part="I">padre, è il tuo sguardo: a me ti volgi...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -3195,7 +3217,7 @@
             <l>Già tocco m´ha; già m´arde: ahi! dove fuggo?...</l>
             <l part="I">per questa parte io scamperò.</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -3203,7 +3225,7 @@
             <l>ch´io rattener ti possa, né ritrarti</l>
             <l part="I">al vero? Ah! m´odi: or sei...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -3229,26 +3251,26 @@
             <l>tosto or via, mi si rechi: or tosto l´arme,</l>
             <l>l´arme del re. Morir vogl´io, ma in campo.</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
             <l>Padre, che fai? Ti acqueta... Alla tua figlia...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
             <l>L´armi vogl´io; che figlia? Or, mi obbedisci.</l>
             <l>L´asta, l´elmo, lo scudo; ecco i miei figli</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
             <l part="I">Io non ti lascio, ah! no...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -3262,20 +3284,20 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>SAUL, MICOL, ABNER, <emph>con pochi soldati fuggitivi</emph></stage>
-          <sp>
+          <sp who="#abner">
             <speaker>
               <emph>Abner</emph>
             </speaker>
             <l part="F">Oh re infelice!... Or dove,</l>
             <l>deh! dove corri? Orribil notte è questa.</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
             <l part="I">Ma, perché la battaglia?...</l>
           </sp>
-          <sp>
+          <sp who="#abner">
             <speaker>
               <emph>Abner</emph>
             </speaker>
@@ -3283,13 +3305,13 @@
             <l>il nemico ci assale: appien sconfitti</l>
             <l part="I">siam noi...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
             <l part="F">Sconfitti? E tu fellon, tu vivi?</l>
           </sp>
-          <sp>
+          <sp who="#abner">
             <speaker>
               <emph>Abner</emph>
             </speaker>
@@ -3299,52 +3321,52 @@
             <l>Te più all´erta quassù, fra i pochi miei,</l>
             <l part="I">trarrò...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
             <l part="F">Ch´io viva, ove il mio popol cade?</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
             <l>Deh! vieni... Oimè! cresce il fragor: s´inoltra...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
             <l>Gionata,... e i figli miei,... fuggono anch´essi?</l>
             <l part="I">mi abbandonano?...</l>
           </sp>
-          <sp>
+          <sp who="#abner">
             <speaker>
               <emph>Abner</emph>
             </speaker>
             <l part="F">Oh cielo!... I figli tuoi,...</l>
             <l part="I">no, non fuggiro... Ahi miseri!...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
             <l part="F">T´intendo:</l>
             <l part="I">morti or cadono tutti...</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
             <l part="F">Oimè!... I fratelli?...</l>
           </sp>
-          <sp>
+          <sp who="#abner">
             <speaker>
               <emph>Abner</emph>
             </speaker>
             <l part="I">Ah! più figli non hai.</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -3355,7 +3377,7 @@
             <l>de´ miei comandi. Or la mia figlia scorgi</l>
             <l part="I">in securtà.</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -3363,7 +3385,7 @@
             <l>mi avvinghierò: contro a donzella il ferro</l>
             <l part="I">non vibrerà il nemico.</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -3375,7 +3397,7 @@
             <l>tosto di´ lor, ch´ella è di David sposa;</l>
             <l part="I">rispetteranla. Va´; vola...</l>
           </sp>
-          <sp>
+          <sp who="#abner">
             <speaker>
               <emph>Abner</emph>
             </speaker>
@@ -3383,14 +3405,14 @@
             <l>valgo, fia salva, il giuro; ma ad un tempo</l>
             <l part="I">te pur...</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
             <l part="F">Deh!... padre... Io non ti vo´, non voglio</l>
             <l part="I">lasciarti...</l>
           </sp>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>
@@ -3398,7 +3420,7 @@
             <l>Ma già si appressan l´armi: Abner, deh! vola:</l>
             <l>teco, anco a forza, s´è mestier, la traggi.</l>
           </sp>
-          <sp>
+          <sp who="#micol">
             <speaker>
               <emph>Micol</emph>
             </speaker>
@@ -3408,7 +3430,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>SAUL</stage>
-          <sp>
+          <sp who="#saul">
             <speaker>
               <emph>Saul</emph>
             </speaker>

--- a/tei/alfieri-sofonisba.xml
+++ b/tei/alfieri-sofonisba.xml
@@ -82,6 +82,22 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="siface">
+            <persName>Siface</persName>
+          </person>
+          <person xml:id="scipione">
+            <persName>Scipione</persName>
+          </person>
+          <person xml:id="massinissa">
+            <persName>Massinissa</persName>
+          </person>
+          <person xml:id="sofonisba">
+            <persName>Sofonisba</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -133,7 +149,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>SIFACE <emph>fra Centurioni romani</emph></stage>
-          <sp>
+          <sp who="#siface">
             <speaker>
               <emph>Siface</emph>
             </speaker>
@@ -149,7 +165,7 @@
           <stage>
             <emph>SIFACE</emph>
           </stage>
-          <sp>
+          <sp who="#siface">
             <speaker>
               <emph>Siface</emph>
             </speaker>
@@ -173,7 +189,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>SCIPIONE, SIFACE</stage>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -199,7 +215,7 @@
             <l>cedilo a me; lo sconsolato viso</l>
             <l>innalza; e in un, mira Scipione in volto.</l>
           </sp>
-          <sp>
+          <sp who="#siface">
             <speaker>
               <emph>Siface</emph>
             </speaker>
@@ -216,7 +232,7 @@
             <l>ch'io agli occhi mai del vincitor nemico</l>
             <l part="I">ergerli non potrei.</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -229,7 +245,7 @@
             <l>ecco i tuoi ceppi indegni: a solo a solo,</l>
             <l>pari con pari, or con Scipion favella.</l>
           </sp>
-          <sp>
+          <sp who="#siface">
             <speaker>
               <emph>Siface</emph>
             </speaker>
@@ -241,7 +257,7 @@
             <l>parer ti possa? E a te, che resta a dirmi,</l>
             <l part="I">ch'io già nol sappia?</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -250,7 +266,7 @@
             <l>ch'io non dubito chiedere a te stesso</l>
             <l>del tuo cangiarti la cagion verace.</l>
           </sp>
-          <sp>
+          <sp who="#siface">
             <speaker>
               <emph>Siface</emph>
             </speaker>
@@ -284,7 +300,7 @@
             <l>dopo le ispane alte vittorie vostre,</l>
             <l part="I">era il mio senno.</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -292,7 +308,7 @@
             <l>Romane a prova conosciuto avevi;</l>
             <l>perché tua fede non serbar tu a Roma?</l>
           </sp>
-          <sp>
+          <sp who="#siface">
             <speaker>
               <emph>Siface</emph>
             </speaker>
@@ -314,7 +330,7 @@
             <l>che sei, più ch'odio o spregio, pietà tranne;</l>
             <l>ch'io da Scipion soltanto non la sdegno.</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -331,7 +347,7 @@
             <l>che tornar ten dovea nel darne il tergo,</l>
             <l part="I">tu preveder potevi.</l>
           </sp>
-          <sp>
+          <sp who="#siface">
             <speaker>
               <emph>Siface</emph>
             </speaker>
@@ -380,7 +396,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>SCIPIONE</stage>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -406,7 +422,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>SOFONISBA, MASSINISSA, <emph>Soldati numidi</emph></stage>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -415,7 +431,7 @@
             <l>Scipione avrai, che dal tuo cor disgombro</l>
             <l part="I">ogni sospetto fia.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
@@ -426,7 +442,7 @@
             <l>ma, ch'io sostenga l'abborrito aspetto</l>
             <l part="I">del roman duce?... ah! troppo vuoi...</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -439,7 +455,7 @@
             <l>vedova più, da che promessa sposa</l>
             <l part="I">di Massinissa sei.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
@@ -461,7 +477,7 @@
             <l>nutra ei di trarmi al carro avvinta in Roma?</l>
             <l part="I">Pur, ciò non temo; ancor che donna...</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -471,7 +487,7 @@
             <l>Ah! no; nol credo; or l'odio tuo t'inganna;</l>
             <l part="I">tu Scipion non conosci.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
@@ -484,14 +500,14 @@
             <l>mia fama, in Cirta mi volean sepolta</l>
             <l part="I">fra le rovine sue.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
             <l part="F">Ti duol d'avermi</l>
             <l>seguìto? Oimè! dunque il mio viver duolti.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
@@ -511,7 +527,7 @@
             <l>farti ai Romani amico: allor disgiunti</l>
             <l part="I">c'ebbe il destino...</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -537,7 +553,7 @@
             <l>amo; te sola or più di lui; ch'io t'amo</l>
             <l part="I">più di me stesso assai.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
@@ -546,7 +562,7 @@
             <l>giurami or tu, che mai d'Affrica trarre</l>
             <l part="I">non lascerai me viva.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -561,7 +577,7 @@
             <l>quind'io, nemico d'ogni velo ed arte,</l>
             <l part="I">tale or mostrarti voglio.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
@@ -570,7 +586,7 @@
             <l>mi acqueto... Ma, vien gente: infra i Numìdi,</l>
             <l>alle tue tende io mi ritraggo intanto.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -581,7 +597,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>SCIPIONE, MASSINISSA</stage>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -589,7 +605,7 @@
             <l>che quando io riedo vincitor: più degno</l>
             <l part="I">mi pare allor d'esser di te.</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -601,7 +617,7 @@
             <l>or non favelli; al tuo Scipion favelli)</l>
             <l>riedi tu, dimmi, vincitor davvero?</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -609,20 +625,20 @@
             <l>rotto e disperso ogni guerriero avanzo</l>
             <l part="I">del morto re...</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
             <l part="F">Che parli? e ignori ancora,</l>
             <l part="I">che respira Siface?...</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
             <l part="F">Oh ciel! che ascolto?</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -631,13 +647,13 @@
             <l>ma non grave era il colpo; e preso quindi</l>
             <l>da Lelio, entro al mio campo ei prigioniero...</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
             <l part="I">Vivo è Siface? in questo campo?</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -645,7 +661,7 @@
             <l>migliore egli è della vittoria nostra. —</l>
             <l part="I">Ma, che fia? Tu ten duoli?...</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -654,7 +670,7 @@
             <l>in sì freddo contegno?... Entro il tuo petto</l>
             <l part="I">che mai rinserri?</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -679,7 +695,7 @@
             <l>in cor soltanto al tuo Scipion le fere</l>
             <l part="I">tempeste del tuo core.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -711,7 +727,7 @@
             <l>debba accrescersi a Roma, e gloria a noi;</l>
             <l>e come, in fin, me far felice io possa.</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -732,7 +748,7 @@
             <l>di Siface or condanna, e rompe, e annulla</l>
             <l part="I">questo amor tuo: né mai...</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -744,7 +760,7 @@
             <l>brando svenarmi; o per mia man svenato</l>
             <l part="I">ei cader oggi.</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -760,7 +776,7 @@
             <l>quindi sii tu di Sofonisba; a quale</l>
             <l part="I">partito allor pensi appigliarti?</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -768,21 +784,21 @@
             <l>e al mio Scipione eternamente avvinto,</l>
             <l part="I">nulla mi può...</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
             <l part="F">Ma, più di Roma, or dimmi,</l>
             <l part="I">Sofonisba non ami?</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
             <l part="F">— Io?... Ciò non voglio</l>
             <l part="I">saper, per ora.</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -814,7 +830,7 @@
             <l>verrà in mia vece; e rammentar faratti</l>
             <l>la mal serbata tua fede giurata.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -830,20 +846,20 @@
             <l>ella è regina qui, s'ella m'è sposa,</l>
             <l part="I">o s'ella è pur schiava di Roma.</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
             <l part="F">— Ell'era,</l>
             <l>e ancor (pur troppo!) di Siface è moglie.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
             <l part="I">T'intendo. Oh rabbia!... E speri tu?...</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -862,7 +878,7 @@
             <l>dell'amistà ch'ebbi per te non vera,</l>
             <l part="I">la vera infamia mia.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -884,7 +900,7 @@
             <l>immutabil partito al fin si appiglia</l>
             <l part="I">il re numìda Massinissa.</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -894,7 +910,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>SCIPIONE</stage>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -909,7 +925,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>SOFONISBA</stage>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
@@ -940,7 +956,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>SIFACE, SOFONISBA</stage>
-          <sp>
+          <sp who="#siface">
             <speaker>
               <emph>Siface</emph>
             </speaker>
@@ -949,7 +965,7 @@
             <l>benigna in ciò la fama ebbi, ma avversa</l>
             <l part="I">la fortuna, pur troppo!</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
@@ -957,7 +973,7 @@
             <l>terribil vista! Or mi è palese appieno</l>
             <l part="I">l'orrendo arcano...</l>
           </sp>
-          <sp>
+          <sp who="#siface">
             <speaker>
               <emph>Siface</emph>
             </speaker>
@@ -969,14 +985,14 @@
             <l>della bramata tomba il piè rattengo,</l>
             <l part="I">per saper di tua sorte.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
             <l part="F">Oh detti!... Ahi! dove,</l>
             <l part="I">dove mi ascondo?...</l>
           </sp>
-          <sp>
+          <sp who="#siface">
             <speaker>
               <emph>Siface</emph>
             </speaker>
@@ -1019,7 +1035,7 @@
             <l>per te strascìno gli ultimi momenti</l>
             <l>del viver lungo e obbrobrioso mio.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
@@ -1042,7 +1058,7 @@
             <l>qual ch'ei lo elegga, inseparabil io</l>
             <l>compagna riedo, e non del tutto indegna.</l>
           </sp>
-          <sp>
+          <sp who="#siface">
             <speaker>
               <emph>Siface</emph>
             </speaker>
@@ -1061,7 +1077,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>SCIPIONE, SOFONISBA, SIFACE</stage>
-          <sp>
+          <sp who="#siface">
             <speaker>
               <emph>Siface</emph>
             </speaker>
@@ -1077,7 +1093,7 @@
             <l>tremar per me; per altri or scendo ai preghi;</l>
             <l part="I">a forza io 'l fo...</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
@@ -1088,7 +1104,7 @@
             <l>e prigioniera entro il romano campo,</l>
             <l part="I">io pur secura sto...</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -1105,7 +1121,7 @@
             <l>gl'invidio e ammiro ognor; vinti, gli aiuto,</l>
             <l part="I">e li compiango.</l>
           </sp>
-          <sp>
+          <sp who="#siface">
             <speaker>
               <emph>Siface</emph>
             </speaker>
@@ -1113,7 +1129,7 @@
             <l>ciò che a null'uom non avrei detto io mai,</l>
             <l part="I">dir mi affido...</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
@@ -1132,7 +1148,7 @@
             <l>deggio in Scipion più maraviglia or dunque,</l>
             <l part="I">che non pietà, destare.</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -1140,7 +1156,7 @@
             <l>ch'abbia avversa la sorte, a me fa quasi</l>
             <l part="I">abborrir la mia prospera.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
@@ -1183,7 +1199,7 @@
             <l>campo or mi s'apre a dimostrare a Roma,</l>
             <l>qual alma ha in sen donna in Cartagin nata.</l>
           </sp>
-          <sp>
+          <sp who="#siface">
             <speaker>
               <emph>Siface</emph>
             </speaker>
@@ -1198,7 +1214,7 @@
             <l>dovevi aprirti; a vendicarmi degna</l>
             <l part="I">io ti lasciava; e lascio...</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
@@ -1210,7 +1226,7 @@
             <l>mi udia Scipion; cui vil nemica io fora,</l>
             <l>se in altra guisa io favellato avessi.</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -1218,35 +1234,35 @@
             <l>che me nemico non volgare estimi.</l>
             <l part="I">Deh, pur potessi!</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
             <l part="F">Assai diss'io. — Siface,</l>
             <l part="I">or ritrarci dobbiamo...</l>
           </sp>
-          <sp>
+          <sp who="#siface">
             <speaker>
               <emph>Siface</emph>
             </speaker>
             <l part="F">In breve, io seguo</l>
             <l part="I">i passi tuoi...</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
             <l part="F">No: dal tuo fianco omai</l>
             <l part="I">non mi scompagno.</l>
           </sp>
-          <sp>
+          <sp who="#siface">
             <speaker>
               <emph>Siface</emph>
             </speaker>
             <l part="F">E abbandonarmi pure</l>
             <l part="I">dovrai...</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
@@ -1261,7 +1277,7 @@
             <l>il sopportar le avversità; ma fora</l>
             <l>vil stupidezza il non sentirne il carco.</l>
           </sp>
-          <sp>
+          <sp who="#siface">
             <speaker>
               <emph>Siface</emph>
             </speaker>
@@ -1271,7 +1287,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>SCIPIONE</stage>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -1285,7 +1301,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>MASSINISSA, <emph>Soldati numidi</emph></stage>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -1302,7 +1318,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>MASSINISSA</stage>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -1318,7 +1334,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>SOFONISBA, MASSINISSA</stage>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
@@ -1326,13 +1342,13 @@
             <l>più nol dovea: ma il volle (il crederesti?)</l>
             <l part="I">Siface istesso...</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
             <l part="F">E fu pietade, o scherno?</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
@@ -1341,33 +1357,33 @@
             <l>vuolsi abboccar: ma ch'io il preceda impone;</l>
             <l part="I">e che...</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
             <l part="M">Tal vista io sostener?...</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
             <l part="F">Men grande</l>
             <l part="I">sei tu di lui? Teme ei la tua?</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
             <l part="F">Né posso</l>
             <l part="I">dirti pria...?</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
             <l part="F">Che dirai, che udire io 'l possa?</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -1375,7 +1391,7 @@
             <l>ch'io qui ti trassi, e che sottrarten voglio,</l>
             <l part="I">ad ogni costo, io stesso.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
@@ -1389,7 +1405,7 @@
             <l>ed io vi sto, d'Astrùbal figlia: or dimmi;</l>
             <l>vuoi forse tu, che amor volgar sia il nostro?</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -1401,7 +1417,7 @@
             <l>non conosco, né temo. A tutto io presto,</l>
             <l part="I">fuor che a perderti, sono; e pria...</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
@@ -1412,7 +1428,7 @@
             <l>vinto, e cattivo, eppur sereno e forte,</l>
             <l>fia bastante a tornarti ora in te stesso.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -1421,13 +1437,13 @@
             <l>ben altro amante io sono; e nobil prova</l>
             <l part="I">darne mi appresto...</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
             <l part="M">Ecco Siface.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -1439,7 +1455,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>SIFACE, SOFONISBA, MASSINISSA</stage>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -1448,7 +1464,7 @@
             <l>ma in tale stato il vedi, ch'ei non merta</l>
             <l part="I">nullo tuo sdegno omai.</l>
           </sp>
-          <sp>
+          <sp who="#siface">
             <speaker>
               <emph>Siface</emph>
             </speaker>
@@ -1461,7 +1477,7 @@
             <l>che fermo volto e imperturbabil core.</l>
             <l>Quindi or pacato mi udrai favellarti.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -1480,14 +1496,14 @@
             <l>di me ti dà questa sublime donna,</l>
             <l>ch'or ben due volte a Massinissa hai tolta.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
             <l>E vuoi, ch'io pur del debil tuo coraggio</l>
             <l part="I">arrossisca?...</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -1509,21 +1525,21 @@
             <l>come può udir, che l'amata sua donna</l>
             <l part="I">abbia a perire?...</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
             <l part="F">E potrebb'egli or tormi</l>
             <l part="I">dal mio dover, s'anco il volesse?</l>
           </sp>
-          <sp>
+          <sp who="#siface">
             <speaker>
               <emph>Siface</emph>
             </speaker>
             <l part="F">E donde</l>
             <l part="I">noto esser puovvi il pensier mio?</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -1554,14 +1570,14 @@
             <l>che per sottrarla a misera immatura</l>
             <l part="I">orribil morte.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
             <l part="F">Ineseguibil cosa</l>
             <l part="I">proponi, e invano...</l>
           </sp>
-          <sp>
+          <sp who="#siface">
             <speaker>
               <emph>Siface</emph>
             </speaker>
@@ -1571,7 +1587,7 @@
             <l>più lieve a lui, men di Siface indegno;</l>
             <l part="I">e in un...</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -1607,7 +1623,7 @@
             <l>Ecco ignudo il mio brando; in me il ritorci. —</l>
             <l part="I">O me uccidi, o me segui.</l>
           </sp>
-          <sp>
+          <sp who="#siface">
             <speaker>
               <emph>Siface</emph>
             </speaker>
@@ -1636,13 +1652,13 @@
             <l>quindi pria sposa ad altri dare io stesso,</l>
             <l>pria che per me vederti estinta invano.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
             <l part="I">Che ascolto? Oimè!... Ch'osi tu dirmi?...</l>
           </sp>
-          <sp>
+          <sp who="#siface">
             <speaker>
               <emph>Siface</emph>
             </speaker>
@@ -1653,13 +1669,13 @@
             <l>tu qui venisti:... a Massinissa sposa</l>
             <l part="I">io qui ti rendo.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
             <l part="M">Ah! no...</l>
           </sp>
-          <sp>
+          <sp who="#siface">
             <speaker>
               <emph>Siface</emph>
             </speaker>
@@ -1672,7 +1688,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>MASSINISSA, SOFONISBA</stage>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
@@ -1684,7 +1700,7 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>MASSINISSA</stage>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -1699,7 +1715,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>SCIPIONE, <emph>Centurioni</emph></stage>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -1714,7 +1730,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>SCIPIONE</stage>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -1730,14 +1746,14 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>SCIPIONE, MASSINISSA, <emph>Soldato numida in disparte</emph></stage>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
             <l>Qui mi attendi, o Guludda. — A questo incontro</l>
             <l part="I">non era io presto.</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -1746,7 +1762,7 @@
             <l>cerchi or te stesso altrove; io sol ti posso</l>
             <l part="I">rendere a te.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -1757,7 +1773,7 @@
             <l>faronne io forse; e fia sublime. Allora</l>
             <l>vedrai, che appien tornato in me son io.</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -1765,13 +1781,13 @@
             <l>anco tu puoi: ma, fin ch'io spiro, è forza</l>
             <l part="I">che tu mi ascolti.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
             <l part="F">A ciò mi manca or tempo...</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -1781,7 +1797,7 @@
             <l>tuoi Numìdi; impreso hai di sottrarre</l>
             <l part="I">Siface e in un...</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -1792,7 +1808,7 @@
             <l>poiché più armati hai tu. Presto me vedi</l>
             <l>a morir, sempre; a mi cangiar, non mai.</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -1803,13 +1819,13 @@
             <l>ella stessa svelare a me tue trame</l>
             <l part="I">appieno or dianzi fea...</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
             <l part="F">Che ascolto? oh cielo!...</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -1825,14 +1841,14 @@
             <l>la fama perderò. Ma, il ciel, deh! voglia,</l>
             <l>che a te maggior poscia non tocchi il danno!</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
             <l>E Sofonisba istessa,... a favor tuo...</l>
             <l>vuol contra me?... Creder nol posso. Or donde?...</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -1842,7 +1858,7 @@
             <l>al suo gran cor sprone si aggiunge il forte</l>
             <l part="I">ultimo esempio di Siface.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -1850,7 +1866,7 @@
             <l>ambigui detti?... Di qual prova parli?</l>
             <l part="I">Qual di Siface esemplo?...</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -1861,7 +1877,7 @@
             <l>l'elsa ei ne pianta, ed a furor sovr'esso</l>
             <l part="I">si precipita tutto...</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -1869,7 +1885,7 @@
             <l>felice lui! dalla esecrabil Roma</l>
             <l part="I">così sottratto...</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -1877,7 +1893,7 @@
             <l>ch'ivi l'ingresso a Sofonisba a forza</l>
             <l part="I">vietato venga.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -1888,7 +1904,7 @@
             <l>io, non vinto per anco, esser vo' spento</l>
             <l>da un roman brando, ma col brando in pugno.</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -1896,7 +1912,7 @@
             <l>Più che il morire, assai di te più degno,</l>
             <l>sublime sforzo ora il tuo viver fia.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -1904,7 +1920,7 @@
             <l>Ma, ch'io salvarla in nessun modo?... Io voglio</l>
             <l part="I">vederla ancor, sola una volta.</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -1923,21 +1939,21 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>SOFONISBA, SCIPIONE, MASSINISSA</stage>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
             <l part="F">Ah! ferma il piede. Io vengo</l>
             <l>a te, Scipione; e tu da me ti togli?</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
             <l>Sacro dover vuol che pomposo rogo</l>
             <l part="I">al morto re si appresti...</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
@@ -1949,20 +1965,20 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>SOFONISBA, MASSINISSA</stage>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
             <l>Perfida! ed anco all'inumano orgoglio</l>
             <l part="I">il tradimento aggiungi?</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
             <l part="F">Il tradimento?</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -1970,19 +1986,19 @@
             <l>a voi salvare, a morir io per voi,</l>
             <l>a Scipio sveli il mio pensier tu stessa?</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
             <l>— Siface seco non mi volle estinta.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
             <l part="I">Meco salva ei ti volle.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
@@ -1997,7 +2013,7 @@
             <l>ho tolto a te, che la funesta possa</l>
             <l>di tradir la mia fama e l'onor tuo.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -2006,21 +2022,21 @@
             <l>scorrer farò: versare il mio vo' tutto,</l>
             <l part="I">pria che schiava lasciarti...</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
             <l part="F">E son io schiava?</l>
             <l part="I">Tal mi reputi or tu?</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
             <l part="F">Di Roma in mano</l>
             <l part="I">ti stai...</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
@@ -2028,7 +2044,7 @@
             <l>per anco stommi: o in mano tua, se in core</l>
             <l>regal pietà per me tu ancor rinserri.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -2036,7 +2052,7 @@
             <l>di risoluta morte alta foriera</l>
             <l>veggo, una orribil securtà... Ma, trarti...</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
@@ -2059,7 +2075,7 @@
             <l>pregni di pianto affiggi al suolo?... Ah! credi,</l>
             <l part="I">che il mio dolor si agguaglia al tuo...</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -2067,7 +2083,7 @@
             <l>n'è assai l'effetto: io, di coraggio privo,</l>
             <l part="I">men che donna rimango; e tu...</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
@@ -2094,14 +2110,14 @@
             <l>ciò tutto or puote, e sol mia morte il puote.</l>
             <l part="I">Più che il mio ben, mi sforza il tuo...</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
             <l part="F">Mi credi</l>
             <l>dunque sì vil, ch'io a te sorviver osi?</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
@@ -2124,13 +2140,13 @@
             <l>giurasti procacciarmela... Ahi me stolta!</l>
             <l>che in te solo affidandomi, qui venni...</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
             <l part="I">Tu dunque hai fermo il morir nostro...</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
@@ -2143,14 +2159,14 @@
             <l>a noi Scipione, in libertade appieno</l>
             <l>tornami or tu; se non sei tu spergiuro.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
             <l>Che chiedi?... oh ciel!... Del brando mio non posso</l>
             <l part="I">armar tua mano... Incerto il colpo...</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
@@ -2161,7 +2177,7 @@
             <l>vegg'io non lungi; ei per te stesso il reca</l>
             <l part="I">sempre con sé: chiamalo; il voglio.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -2178,7 +2194,7 @@
             <l>ecco, appresento... A patto sol, che in fondo</l>
             <l part="I">mia parte io n'abbia...</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
@@ -2186,35 +2202,35 @@
             <l>Or dell'alto amor mio sei degno al fine.</l>
             <l part="I">Donami dunque il nappo.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
             <l part="F">Oh ciel! mi trema</l>
             <l part="I">la mano, il core...</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
             <l part="F">A che indugiare? è forza,</l>
             <l part="I">pria che giunga Scipione...</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
             <l part="F">Eccoti il nappo.</l>
             <l part="I">Ahi! che feci? me misero!...</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
             <l part="F">Consunto</l>
             <l>ho il licor tutto: e già Scipion qui riede.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -2225,20 +2241,20 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>SCIPIONE, MASSINISSA, SOFONISBA</stage>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
             <l part="F">Ah! no; fin ch'io respiro...</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
             <l>Ahi traditor! dentro al tuo petto io dunque</l>
             <l>della uccisa mia donna avrò vendetta.</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -2246,14 +2262,14 @@
             <l>sprigionerotti, affin che me tu sveni;</l>
             <l part="I">ad altro, invan lo speri.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
             <l part="F">O Massinissa,</l>
             <l part="I">ti abborrisco se omai...</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>
@@ -2261,7 +2277,7 @@
             <l>uccider puoi; ma fin ch'io vivo, il ferro</l>
             <l part="I">non torcerai nel petto tuo.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -2269,7 +2285,7 @@
             <l>al fine in me. — Scipion, tutto mi hai tolto;</l>
             <l part="I">perfin l'altezza de' miei sensi.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
@@ -2283,7 +2299,7 @@
             <l>cedi a Scipion; fratello, amico, padre</l>
             <l part="I">egli è per te.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -2291,7 +2307,7 @@
             <l>il furor mio rattieni. Morte,... morte...</l>
             <l part="I">io pur...</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>
               <emph>Sofonisba</emph>
             </speaker>
@@ -2306,7 +2322,7 @@
             <l>ten prego;... e me... lascia or morir,... qual debbe</l>
             <l>d'Asdrubal figlia,... entro al... romano campo.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>
               <emph>Massinissa</emph>
             </speaker>
@@ -2314,7 +2330,7 @@
             <l>ogni mia possa... Io... respirare... appena,...</l>
             <l part="I">non che... ferir...</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>
               <emph>Scipione</emph>
             </speaker>

--- a/tei/alfieri-timoleone.xml
+++ b/tei/alfieri-timoleone.xml
@@ -82,6 +82,22 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="timofane">
+            <persName>Timofane</persName>
+          </person>
+          <person xml:id="echilo">
+            <persName>Echilo</persName>
+          </person>
+          <person xml:id="demarista">
+            <persName>Demarista</persName>
+          </person>
+          <person xml:id="timoleone">
+            <persName>Timoleone</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -133,7 +149,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>TIMOFANE, ECHILO</stage>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -143,7 +159,7 @@
             <l>ma il ben di tutti a ciò mi spinge, e il lustro</l>
             <l>di Corinto, che in sua possa affida.</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -164,7 +180,7 @@
             <l>non ti estimo finor; ma immensa doglia</l>
             <l part="I">in udir ciò mi accora.</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -184,7 +200,7 @@
             <l>a lor pratiche infide è il poter mio;</l>
             <l>quindi ogni astio, ogni grido, ogni querela.</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -198,7 +214,7 @@
             <l>a raffermar la interna pace, assai</l>
             <l>più grati avrei, se men costasser sangue.</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -216,7 +232,7 @@
             <l>esecutrice è del voler dei molti:</l>
             <l part="I">dolgonsi i pochi; e che rileva?</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -233,7 +249,7 @@
             <l>perigli ognora; e il più terribil parmi;</l>
             <l>poter mal far; grande al mal fare invito.</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -246,7 +262,7 @@
             <l>da pria mestier farsi tiranno? Ah! sola</l>
             <l>può la forza al ben far l'uom guasto trarre.</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -257,7 +273,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>DEMARISTA, TIMOFANE, ECHILO</stage>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
@@ -270,7 +286,7 @@
             <l>anco a torto, abborrire un uom ti possa.</l>
             <l part="I">Ansia, pur troppo, io per te vivo.</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -280,7 +296,7 @@
             <l>ma tale è pur l'ufficio in noi discorde;</l>
             <l part="I">temer tu donna, e imprender io.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
@@ -293,7 +309,7 @@
             <l>che a te veder Timoleone al fianco</l>
             <l>d'accordo oprar col tuo valor suo senno.</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -303,7 +319,7 @@
             <l>niega addossarsi; e me frattanto ei lascia</l>
             <l>solo sudar nel periglioso aringo.</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -311,7 +327,7 @@
             <l>egli il tuo oprar; se il fesse, avresti meno</l>
             <l part="I">nimici assai.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
@@ -333,7 +349,7 @@
             <l>amati passi; e benedir me s'oda</l>
             <l part="I">d'esservi madre.</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -349,20 +365,20 @@
             <l>n'abbia chi 'l fa. Mi duol, che il fratel mio,</l>
             <l>più merco io gloria, meno amor mi porti.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l part="I">Invido vil pensiero in lui?...</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
             <l part="F">Nol credo;</l>
             <l part="I">ma pur...</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -370,7 +386,7 @@
             <l>condur tu puoi, se caldamente ei teco</l>
             <l part="I">senno e man non v'adopra.</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -379,7 +395,7 @@
             <l>ritroso ei fu. Secondator, nol sdegno;</l>
             <l part="I">ma sturbator, nol soffro.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
@@ -397,7 +413,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>DEMARISTA, TIMOFANE</stage>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -406,7 +422,7 @@
             <l>me sfugge. Udrai, come maligno adombri</l>
             <l>ogni disegno mio d'atri colori.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
@@ -427,7 +443,7 @@
             <l>non serbò forse ei solo, a' tuoi l'onore,</l>
             <l>la vittoria a Corinto, a te la vita?</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -449,14 +465,14 @@
             <l>crudel serbarmi, se m'insidia ei poscia</l>
             <l>più preziosa cosa assai; la fama?</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l>Non creder pure che a malizia, o a caso,</l>
             <l part="I">egli opri. Udiamlo pria.</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -466,7 +482,7 @@
             <l>Sai, che il poter ch'ei già mi ottenne, or vuole</l>
             <l part="I">tormi ei stesso; e che il dice?</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
@@ -479,7 +495,7 @@
             <l>se d'una gloria, e d'un poter splendenti,</l>
             <l>fratelli, eroi, duci vi veggio, e amici?</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -492,7 +508,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>TIMOFANE, ECHILO</stage>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -500,7 +516,7 @@
             <l>tuoi preghi, e miei, mal s'arrendea; null'altro</l>
             <l>forza gli fe', che le materne istanze.</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -510,7 +526,7 @@
             <l>oggi fia 'l dì, che il suo rigor si arrenda</l>
             <l>a mie ragioni; o il dì mai più non sorge.</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -524,7 +540,7 @@
             <l>me, mie sostanze, il cor, la mente, il brando,</l>
             <l>deh! non vogliate disdegnar ministri.</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -537,7 +553,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>TIMOLEONE, TIMOFANE</stage>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -547,20 +563,20 @@
             <l>sol della madre, e non spontanea tua</l>
             <l>voglia, al fratel ti riconducan oggi.</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
             <l part="I">Timofane...</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
             <l part="F">Che sento? or più non chiami</l>
             <l>fratello me? tel rechi forse ad onta?</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -568,7 +584,7 @@
             <l>Timofane, siam nati: a te fratello,</l>
             <l>finora io 'l son; ma tu, fratel mi nomi.</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -590,7 +606,7 @@
             <l>sperando ognor di raddolcirti, e a parte</l>
             <l>pur farti entrar del mio gioioso stato...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -599,7 +615,7 @@
             <l>scorso hai lo stadio insultator di regno!</l>
             <l>Spander sangue ogni dì, gioioso stato?</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -613,7 +629,7 @@
             <l>sparso da un sol; giusto nomar quant'altro</l>
             <l part="I">si dividono in molti?</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -624,7 +640,7 @@
             <l>che il moderato comandar ti toglie;</l>
             <l>tal fosti, e in casa, ed in Corinto, e in campo.</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -632,7 +648,7 @@
             <l>al tuo saggio valore in campo farmi,</l>
             <l part="I">della vittoria e vita?</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -656,7 +672,7 @@
             <l>e per la patria più: né in cor mi entrava</l>
             <l>invidia, no; sol del tuo lustro io piansi.</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -665,7 +681,7 @@
             <l>se tu il volevi? e s'io l'ardir, tu il senno</l>
             <l>adopravam, di che temevi allora?</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -703,7 +719,7 @@
             <l>a reo poter, ma per lasciartene una</l>
             <l part="I">al pentimento.</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -711,7 +727,7 @@
             <l>scegliesti in vece mia nuovi fratelli</l>
             <l part="I">fra miei più aperti aspri nemici...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -745,7 +761,7 @@
             <l>o ti è forza arretrarti, o a me fratello</l>
             <l part="I">cessar d'esser, per sempre.</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -756,35 +772,35 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>DEMARISTA, TIMOLEONE, TIMOFANE</stage>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
             <l>Deh! vieni, o madre; tua mercé mi vaglia</l>
             <l>del mio fratello a piegar l'alma alquanto...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
             <l>Sì, vieni, o madre; e tua mercé mi vaglia</l>
             <l>a racquistarmi un vero mio fratello.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l>Voi, l'un l'altro v'amate: or perché dunque</l>
             <l part="I">sturbar vostra amistà?...</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
             <l part="F">La troppo austera</l>
             <l part="I">sua virtù, non de' tempi...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -792,7 +808,7 @@
             <l>superbo troppo, e in ver de' tempi degno;</l>
             <l>ma indegno appien di chi fratel mi nasce.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
@@ -801,7 +817,7 @@
             <l>indistinto vorresti, oscuro, nullo</l>
             <l part="I">chi la patria salvò?</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -820,7 +836,7 @@
             <l>convenienti al labbro stolto appena</l>
             <l>d'oriental dispotica reina?</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -828,7 +844,7 @@
             <l>Odi, fallace sconsigliato zelo,</l>
             <l>come si fa sordo di natura al grido.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
@@ -836,7 +852,7 @@
             <l>biasmar questa città? Guasti i costumi,</l>
             <l part="I">i magistrati compri...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -852,13 +868,13 @@
             <l>degna di grande cittadin, ti resta;</l>
             <l part="I">generosissim'opra.</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
             <l part="M">Ed è?</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
@@ -867,7 +883,7 @@
             <l>entro al tuo petto generoso. Or, via,</l>
             <l part="I">a lui l'addita.</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -875,14 +891,14 @@
             <l>tu stesso fai coll'abusarne, intero</l>
             <l part="I">tu spontaneo il rinunzia.</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
             <l part="F">— A te il rinunzio,</l>
             <l part="I">se il vuoi per te.</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -893,7 +909,7 @@
             <l>privo ne fora ei da gran tempo. Pensa,</l>
             <l part="I">ch'io finor teco aperti mezzi...</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -902,14 +918,14 @@
             <l>solo il possono i più. Forza di legge</l>
             <l>creato m'ha; legge mi sfaccia, io cesso.</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
             <l>E di leggi tu parli, ove insolente</l>
             <l>stuol mercenario fa di forza dritto?</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -918,7 +934,7 @@
             <l>d'Archida, o d'altri al par di lui maligni,</l>
             <l part="I">cui sol raffrena il lor timore?</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -929,7 +945,7 @@
             <l>d'Archida l'ira, ma il furor di tutti</l>
             <l part="I">temi; — ed il mio.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
@@ -937,7 +953,7 @@
             <l>di discordia si accende esca novella,</l>
             <l part="I">mentr'io vi traggo a pace? Ahi lassa!</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -952,7 +968,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>DEMARISTA, TIMOLEONE</stage>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -962,14 +978,14 @@
             <l>del finger già: della sua rabbia è donno,</l>
             <l>or che incomincia nel sangue a tuffarla.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l>Figlio, ma in ciò, preoccupata troppo,</l>
             <l part="I">la tua mente t'inganna.</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -980,13 +996,13 @@
             <l>al fianco sempre ti saria mestiero,</l>
             <l>per farti sano il core. A te fui caro...</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l part="I">E ognora il sei; credilo...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -998,13 +1014,13 @@
             <l>tu in lui puoi molto; e il dei risolver prima</l>
             <l>al necessario e in un magnanim'atto...</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l part="I">A ritornar privato?</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -1031,14 +1047,14 @@
             <l>atroce, intera, e meritata, debbe</l>
             <l part="I">in voi piombar, su i vostri capi...</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l part="F">Ah figlio!...</l>
             <l part="I">Tremar mi fai...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -1057,14 +1073,14 @@
             <l>me vedi presso; or fé prestami dunque,</l>
             <l>finché qual figlio, e qual fratello io parlo.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l>Oh! qual Dio parla in te?... Farò, ch'ei m'oda,</l>
             <l part="I">il tuo fratello...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -1083,7 +1099,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>DEMARISTA, ECHILO</stage>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -1091,25 +1107,25 @@
             <l>è che ti dolga un cotal figlio: al fine</l>
             <l>ignudo ei mostra di tiranno il volto.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l>Che fu? dov'è, ch'io rintracciar nol posso?</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
             <l part="I">E che? non sai?...</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l part="M">Non so; narra.</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -1117,13 +1133,13 @@
             <l>d'infami suoi satelliti, la vita</l>
             <l part="I">ei toglie...</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l part="M">A chi?</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -1141,7 +1157,7 @@
             <l>l'emulator di sue virtù, l'amico</l>
             <l part="I">intimo, il solo...</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
@@ -1150,7 +1166,7 @@
             <l>fia la pace; o in eterno è rotta forse.</l>
             <l part="I">Misera me!... Che mai farò?...</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -1168,13 +1184,13 @@
             <l>nella nuova tirannide di sangue,</l>
             <l part="I">trema per esso tu.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l part="M">Che sento?</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -1184,7 +1200,7 @@
             <l>Benché tardi, mi avveggo al fin ch'è l'ora,</l>
             <l>ch'io seco cangi opre, linguaggio, e affetti.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
@@ -1198,7 +1214,7 @@
             <l>perché ogni legge al lor cospetto è muta:</l>
             <l part="I">tal fu finora; il sai...</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -1206,7 +1222,7 @@
             <l>temo che udrai ragion più scellerata</l>
             <l part="I">che non è il fatto.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
@@ -1216,7 +1232,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>TIMOFANE, DEMARISTA, ECHILO</stage>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
@@ -1234,7 +1250,7 @@
             <l>la benda, ond'era a tuo favor sì cieca,</l>
             <l part="I">mi tagli al fin tu stesso.</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -1244,20 +1260,20 @@
             <l>t'era stretto! Ben vedi, or del non tuo</l>
             <l part="I">dolor ti duoli.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l part="F">A me qual danno? Quanti</l>
             <l part="I">tornar ten ponno...</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
             <l part="F">E assai tornar glien denno.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
@@ -1267,7 +1283,7 @@
             <l>l'odio acquistar per te? fra voi nemici</l>
             <l part="I">in eterno vedervi?...</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -1281,7 +1297,7 @@
             <l>sì, m'usurpava. Al fin mi parve questo</l>
             <l>sol, fra' suoi tanti, il capital delitto.</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -1298,7 +1314,7 @@
             <l>aspro nemico di virtù mentita,</l>
             <l part="I">mirami ben, son io.</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -1313,50 +1329,50 @@
             <l>che nuovo fren vuolsi a Corinto imporre.</l>
             <l>Ch'io non v'abbia a placare a un tempo tutti?...</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l part="I">Offesa io son, pel fratel tuo...</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
             <l part="F">Che ascolto?</l>
             <l>Tu inoffendibil per la patria sei?</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l part="I">Son madre...</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
             <l part="M">Di Timofane.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l part="F">D'entrambi...</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
             <l>No, di Timoleon madre non sei.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l part="I">Tu l'odi?... Ahi lassa me!...</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -1375,7 +1391,7 @@
             <l>convincer prima: a parte poscia in breve</l>
             <l part="I">tu tornerai di nostra gioia.</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -1385,7 +1401,7 @@
             <l>fermo sei di seguir tua folle impresa?</l>
             <l part="I">Pensaci; parla...</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
@@ -1394,7 +1410,7 @@
             <l>ten priego; almen non muover passo omai,</l>
             <l part="I">ch'io pria nol sappia.</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -1408,7 +1424,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>TIMOFANE, ECHILO</stage>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -1416,14 +1432,14 @@
             <l>nol vincerai, come costei, già vinta</l>
             <l part="I">da sua donnesca ambizione.</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
             <l part="F">I mezzi</l>
             <l>di vincer tutti, in me stan tutti: il credi.</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -1436,7 +1452,7 @@
             <l>deluso tu: se avessi io te deluso</l>
             <l>dorriami assai, ch'uom veritier son io.</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -1454,7 +1470,7 @@
             <l>ma, non men erri in questo dì, se cessi</l>
             <l>d'esserlo, or quando è il mio poter già tanto.</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -1483,7 +1499,7 @@
             <l>all'abborrirti, è più d'un passo:... e forte</l>
             <l>mi costa il farlo... A ciò, deh! non sforzarmi.</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -1495,7 +1511,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>TIMOLEONE, ECHILO, TIMOFANE</stage>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -1503,7 +1519,7 @@
             <l>deh! mi concedi, ch'io primier ti dica:</l>
             <l part="I">dirai tu poi...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -1519,7 +1535,7 @@
             <l>Me, me trafiggi; e taci: a dirmi omai</l>
             <l>nulla ti avanza; a uccider me ti avanza.</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -1537,7 +1553,7 @@
             <l>niun uomo al mondo omai può tormel: solo</l>
             <l>puoi tu la vita, e impunemente, tormi.</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -1548,7 +1564,7 @@
             <l>per questo solo petto mio si sale:</l>
             <l part="I">altra via qui non è.</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -1567,7 +1583,7 @@
             <l>Corinto in te quant'io le tolsi acquisti;</l>
             <l>io pregierommi d'esserti secondo.</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -1582,7 +1598,7 @@
             <l>ma il sangue ognor qui si lavò col sangue;</l>
             <l>né acciar mancò vendicator qui mai.</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -1596,7 +1612,7 @@
             <l>tremendo altrui, per l'eseguir più ratto;</l>
             <l>forte in se stesso, invidiato, grande...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -1625,7 +1641,7 @@
             <l>e minor di ciascuno... Ah! trema; trema:</l>
             <l>tal tu sarai: se tal pur già non sei.</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -1637,7 +1653,7 @@
             <l>alla immagine viva, e orribil tanto,</l>
             <l part="I">della empia vita, in cui t'immergi?</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -1651,7 +1667,7 @@
             <l>tel dissi io già: corregger me sol puoi</l>
             <l part="I">col ferro: invano ogni altro mezzo...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -1659,7 +1675,7 @@
             <l>a te il ridico: non avrai mai regno,</l>
             <l part="I">se me tu pria non sveni.</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -1677,7 +1693,7 @@
             <l>e se fia vana ogni nostr'opra, ad essa</l>
             <l>né un sol momento sapravviver giuro.</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -1686,7 +1702,7 @@
             <l>t'è ancor di sangue, che faran tanti altri</l>
             <l part="I">oltraggiati da te?</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -1699,7 +1715,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>TIMOLEONE, ECHILO</stage>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -1707,7 +1723,7 @@
             <l>te potessi salvar, com'io son certo</l>
             <l part="I">di salvar la mia patria!</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -1715,7 +1731,7 @@
             <l>mercenari ei si affida; ei sa, che altr'armi</l>
             <l>or da opporre alle sue non ha Corinto.</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -1732,14 +1748,14 @@
             <l>la libertà... Ma pure... ei m'è fratello;</l>
             <l>n'ha ancor pietà... Se alcun piegarlo alquanto...</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
             <l>Il potrebbe la madre, ove non guasto</l>
             <l part="I">serbasse il cor: ma troppo...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -1765,7 +1781,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>DEMARISTA, TIMOLEONE</stage>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -1781,7 +1797,7 @@
             <l>cocenti interni, al fin di madre il fanno</l>
             <l>virtuosi ed assoluti preghi.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
@@ -1799,13 +1815,13 @@
             <l>a impetuosa irresistibil piena:</l>
             <l part="I">forse poi...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
             <l part="M">Donna, a me favelli?</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
@@ -1825,7 +1841,7 @@
             <l>fors'anco: tu, se a me ti arrendi, nulla</l>
             <l part="I">perdi...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -1835,7 +1851,7 @@
             <l>temi pel viver suo? — ma dimmi; e credi</l>
             <l>ch'ei viver possa, ove tiranno ei resti?</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
@@ -1847,7 +1863,7 @@
             <l>in guerra, or vuol che in pace anco maggiore</l>
             <l part="I">l'abbia da te. Ciò mi giurava...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -1872,7 +1888,7 @@
             <l>Più che a me cittadino, a lui tiranno</l>
             <l>esser madre ti giova: assai m'è chiaro.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
@@ -1880,7 +1896,7 @@
             <l>l'amor non so del sangue mio; che madre</l>
             <l>pur sempre io son... Fratel così tu fossi!</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -1905,7 +1921,7 @@
             <l>per lui fai solo risuonar di madre;</l>
             <l part="I">per me, tu il taci?</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
@@ -1914,7 +1930,7 @@
             <l>sta per te la ragion; ma, il sai, per esso</l>
             <l>milita forza, che ragion non ode...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -1931,14 +1947,14 @@
             <l>minacciosa tuonar t'udia fors'egli?</l>
             <l part="I">Ti udia?...</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l part="F">Fin dove cimentarsi ardisce</l>
             <l part="I">debil madre, l'osai; ma...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -1957,14 +1973,14 @@
             <l>e di Corinto legge, arbitra donna</l>
             <l part="I">d'ogni aver nostro or non ti fanno?</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l part="F">Io dirlo,</l>
             <l part="I">è vero, potea;... ma, s'ei...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -1989,19 +2005,19 @@
             <l>Certo ei sprezzò, che dispregiar dovea,</l>
             <l>lagrime imbelli, e femminil lamento.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l part="I">Figlio,... temei... Deh! m'odi...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
             <l part="F">Udirti ei debbe...</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
@@ -2010,7 +2026,7 @@
             <l>a te, cui danno può maggior tornarne;</l>
             <l part="I">a te...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -2020,13 +2036,13 @@
             <l>a lui sovrasta, e non a me; che solo,</l>
             <l>sol questo dì, se il vuoi salvar, ti avanza.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l part="I">Che sento?... Oimè!...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -2056,47 +2072,47 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>DEMARISTA, TIMOFANE</stage>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
             <l part="I">Timoleon mi sfugge?</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l part="M">Ah figlio!...</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
             <l part="F">E tanto</l>
             <l>ei ti turbò? Tu nol cangiasti dunque?</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l>Oh cielo! al cor suoi detti m'eran morte...</l>
             <l>Trema; un sol dì, questo sol dì, ti avanza...</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
             <l>Ch'io tremi? è tardi; or ch'io l'impresa ho tratta</l>
             <l part="I">a fine omai.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l part="F">Quanto t'inganni!... Ah! forse,</l>
             <l>senza il fratello tuo, più non saresti...</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -2116,14 +2132,14 @@
             <l>rabbia; ma volto hanno alla fraude il core?</l>
             <l>Della lor fraude vittime cadranno.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l>Oimè!... sei tu sì snaturato forse,</l>
             <l part="I">che il fratel tuo?... Crudele!...</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -2136,7 +2152,7 @@
             <l>salvi ne andranno dalla intera strage,</l>
             <l part="I">che sta per farsi...</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
@@ -2147,7 +2163,7 @@
             <l>rea pur mi fa; meco a ragion si accende</l>
             <l part="I">Timoleon di giusto sdegno...</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -2167,7 +2183,7 @@
             <l>convenuto con Echilo: securi</l>
             <l part="I">saran qui solo appieno...</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
@@ -2176,7 +2192,7 @@
             <l>la strage udrà,... forse,... oh terribil giorno!...</l>
             <l part="I">ei di vendetta allora...</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -2192,7 +2208,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>ECHILO, DEMARISTA, TIMOFANE</stage>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -2202,7 +2218,7 @@
             <l>liberamente, che a momenti piomba</l>
             <l part="I">un mortal colpo entro al tuo seno.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
@@ -2210,14 +2226,14 @@
             <l>io non ti lascio... Al fianco tuo... T'arrendi?...</l>
             <l>Deh! credi a quest'uom prode... Oh ciel!... che fai?...</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
             <l>Tutto ho d'acciar contra ogni strale il petto.</l>
             <l part="I">Intrepido vi attendo.</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -2233,7 +2249,7 @@
             <l>al tuo petto ritorcere. Deh! credi,</l>
             <l>a me sol credi. O cangia, o uccidi, o trema.</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -2248,7 +2264,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>ECHILO, DEMARISTA</stage>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -2268,7 +2284,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>TIMOLEONE</stage>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -2291,66 +2307,66 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>TIMOLEONE, ECHILO</stage>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
             <l part="I">Perché qui trarmi, or che si annotta?</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
             <l part="F">Ah! vieni:</l>
             <l part="I">la madre udrai...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
             <l part="F">Che udrò, ch'io già nol sappia?</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
             <l part="I">Veder ti vuole, a te gran cose...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
             <l part="F">Unirti</l>
             <l>forse or con essa ad ingannarmi ardisci?</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
             <l>Io? — Ciò che far m'elessi, or or l'udisti.</l>
             <l part="I">Sol che tu scampi! e salvo or sei.</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
             <l part="F">Che parli?</l>
             <l part="I">Salvo, da che? Ti spiega.</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
             <l part="F">A me perdona,</l>
             <l part="I">se una cosa ti tacqui...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
             <l part="F">Ah! forse osasti?...</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -2364,7 +2380,7 @@
             <l>che mai da loro a patto alcun spiccarti</l>
             <l part="I">io non potrei, se a te il dicea.</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -2372,20 +2388,20 @@
             <l>A comune periglio osi tu schermo</l>
             <l>farmi d'infame ostello? Ah! mal cominci.</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
             <l>Ammenderò con miglior fin, tel giuro,</l>
             <l>cotal principio: ma, te salvo io volli.</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
             <l>Or, che sai dunque tu?... qual è il periglio?...</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -2400,7 +2416,7 @@
             <l>Scoperto è pure il convenuto loco</l>
             <l part="I">dell'adunanza nostra.</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -2412,7 +2428,7 @@
             <l>mostrarci, ch'oggi; e, che peggio è, mostrarci</l>
             <l>finti, com'oggi, non fu forza mai.</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -2423,7 +2439,7 @@
             <l>ed ansietà di te primier sottrarre,</l>
             <l part="I">m'han fatto incauto.</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -2434,7 +2450,7 @@
             <l>Misero me!... Perché salvarmi? a quale</l>
             <l part="I">dura vicenda resto?</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -2442,7 +2458,7 @@
             <l>e dobbiam noi salvar la patria. S'oda</l>
             <l part="I">Demarista frattanto.</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -2452,20 +2468,20 @@
             <l>spiar le menti; ed atterrire altrui</l>
             <l part="I">quanto atterrito egli è.</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
             <l part="F">Ma ancor ben tutto</l>
             <l part="I">antiveder non sa.</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
             <l part="M">Misero!...</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -2473,7 +2489,7 @@
             <l>ei stesso il volle: ogni pietà m'ha tolta.</l>
             <l>Oh ciel! chi sa?... forse or gli amici nostri...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -2481,21 +2497,21 @@
             <l>vedea venire: Ortàgora, e Timèo:</l>
             <l part="I">ma fei lor cenno di ritrarsi.</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
             <l part="F">Errasti.</l>
             <l part="I">Che non li vidi anch'io!</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
             <l part="F">Se a morte viensi,</l>
             <l part="I">bastiam qui noi.</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -2503,26 +2519,26 @@
             <l>a sforzata vendetta, è ver; ma gli altri</l>
             <l>per lor mezzo avvisar poteansi forse.</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
             <l>Perché nulla tacermi? Uscir fia 'l meglio...</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
             <l part="I">Vien gente, o parmi: odi tu?</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
             <l part="F">L'odo; e i passi</l>
             <l part="I">di donna son: forse è la madre.</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -2532,7 +2548,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>DEMARISTA, TIMOLEONE, ECHILO</stage>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
@@ -2541,7 +2557,7 @@
             <l>pietoso ufficio! il mio figliuol riveggo...</l>
             <l part="I">e il debbo a te.</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -2552,7 +2568,7 @@
             <l>Ah, no! che ancor ti veggio in volto sculta</l>
             <l>regal superbia. Or, di che godi? Ahi folle!...</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
@@ -2560,7 +2576,7 @@
             <l>Più non sperava, che i tuoi passi omai</l>
             <l part="I">rivolgeresti alla mia stanza...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -2572,27 +2588,27 @@
             <l>del racquistar la patria poi, mi sia</l>
             <l part="I">felice augurio.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l part="F">... O figlio, ognor persisti</l>
             <l part="I">duro così?...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
             <l part="F">Donna, persisti ognora</l>
             <l>di così picciol core? Altro hai che dirmi?</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l part="I">Dir ti vorrei; ma...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -2606,14 +2622,14 @@
             <l>ch'io non ti son più figlio. — Echilo, vieni;</l>
             <l part="I">d'iniquo loco usciamo.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l part="F">Ah! no... T'arresta...</l>
             <l part="I">uscir non dei.</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -2622,21 +2638,21 @@
             <l>ed onta, e strazi io voglio, anzi che serva</l>
             <l part="I">veder Corinto... Echilo, andiam...</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
             <l part="F">Corinto</l>
             <l part="I">or qui ci vuol; non dei tu uscirne...</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l part="F">Uscirne</l>
             <l part="I">omai non puoi.</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -2646,7 +2662,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>TIMOFANE, DEMARISTA, TIMOLEONE, ECHILO</stage>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -2656,7 +2672,7 @@
             <l>che al fato, ai Numi, ad Echilo, alla madre</l>
             <l part="I">d'averti salvo io renda grazie.</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -2665,7 +2681,7 @@
             <l>l'uccision recente ti si legge.</l>
             <l>Ahi crudo tu!... — Mal di salvarmi festi.</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -2673,14 +2689,14 @@
             <l>dove né a voi nuocer persona al mondo,</l>
             <l part="I">né a me il potete voi.</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
             <l part="F">— Pensa, deh! pensa,</l>
             <l>se ancor giovarti non possiam noi forse.</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -2688,19 +2704,19 @@
             <l>al mio poter; col dar voi primi agli altri</l>
             <l part="I">di obbedirmi l'esemplo.</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
             <l part="F">D'obbedirti?</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
             <l part="I">Noi primi?</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -2710,7 +2726,7 @@
             <l>oprai con voi; la mia schiettezza farvi</l>
             <l part="I">schietti dovea...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -2720,7 +2736,7 @@
             <l>cittadino, adoprar dovea da prima</l>
             <l part="I">teco la forza, e non mai l'arte.</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -2733,7 +2749,7 @@
             <l>guardarti ognor? — Men generosi fummo,</l>
             <l part="I">o siam, di te?</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -2752,19 +2768,19 @@
             <l>si radunano, a tutti a un tempo tomba</l>
             <l part="I">s'è fatto or già.</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
             <l part="M">Che ascolto?</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
             <l part="M">Oh ciel!...</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -2782,7 +2798,7 @@
             <l>che a me nemici rimanete soli;</l>
             <l>che vili altrui, non men che a me, vi ho fatti.</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -2790,21 +2806,21 @@
             <l>mai non dovevi. Io tel ripeto ancora:</l>
             <l>nulla tu festi, se noi non uccidi.</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
             <l>Mai non sperar di riaverne amici.</l>
             <l>Né lusinga, né tempo il può, né forza...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
             <l>Né madre il può, qual io la veggio starsi</l>
             <l>tacita, e piena di superbia e d'onta.</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -2814,7 +2830,7 @@
             <l>ti aggradirà: — né sangue altro ti resta</l>
             <l>più necessario a spargere, che il mio.</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -2823,7 +2839,7 @@
             <l>cosa m'hai tolto: io son per te cosperso</l>
             <l>d'eterna infamia: a che tardar? mi uccidi.</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -2831,94 +2847,94 @@
             <l>cuori ostinati: il rimirarmi in trono;</l>
             <l part="I">e l'obbedirmi.</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
             <l part="F">— Hai risoluto dunque</l>
             <l part="I">di non uccider noi?</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
             <l part="F">Di non curarvi</l>
             <l part="I">ho risoluto.</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
             <l part="M">E regnerai?</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
             <l part="F">Già regno.</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
             <l>Misero me!... Tu il vuoi... Ch'io almen nol vegga<note resp="#aut" place="foot" anchored="true">Si copre il volto con il pallio.</note>.</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
             <l part="I">Muori, tiranno, dunque.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l part="F">Oh cielo! ah figlio!...</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
             <l part="I">Ah traditore!... Io... moro...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
             <l part="F">A me quel ferro:</l>
             <l part="I">la patria è salva.</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
             <l part="F">Ah! per la patria vivi.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l part="I">Guardia, accorrete...<note resp="#aut" place="foot" anchored="true">Accorrono i soldati.</note> Al traditor.</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
             <l part="F">No, madre...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
             <l part="I">Dammi quel ferro; in me...</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
             <l part="M">No, mai...</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -2926,13 +2942,13 @@
             <l>scostatevi; l'impongo;... omai più sangue</l>
             <l part="I">versar non dessi.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l part="M">Echilo pera...</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -2940,14 +2956,14 @@
             <l>si volgan l'armi;... espressamente io 'l vieto...</l>
             <l part="I">itene: il voglio.<note resp="#aut" place="foot" anchored="true">I soldati si ritirano.</note></l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l part="F">E tu, crudel fratello,</l>
             <l part="I">scellerato... Ma, oh ciel! tu piangi?...</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -2957,7 +2973,7 @@
             <l>trarmi il tuo braccio, che già un dì scampommi:</l>
             <l part="I">per te il morir m'era men duro...</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -2965,13 +2981,13 @@
             <l>a te fratel, non io: soltanto ad esso</l>
             <l>spettava il cenno; il ferro a me spettava.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l>Barbari!... Voi; ch'ei trucidar non volle..</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -2989,7 +3005,7 @@
             <l>io raccomando... In lui, tu madre, un vero</l>
             <l>figliuol ravvisa,... e un uom... più che mortale. —</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -2997,19 +3013,19 @@
             <l>qui tratto a forza... O fratel mio, ben tosto</l>
             <l part="I">ti seguirò.</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
             <l part="M">Deh!...</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l part="M">Figlio!...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
@@ -3018,7 +3034,7 @@
             <l>le agitatrici furie orride sento...</l>
             <l part="I">Pace per me non v'ha più mai...</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>
@@ -3026,7 +3042,7 @@
             <l>gli aiuti primi all'egra patria almeno</l>
             <l part="I">negar non dei...</l>
           </sp>
-          <sp>
+          <sp who="#timofane">
             <speaker>
               <emph>Timofane</emph>
             </speaker>
@@ -3034,20 +3050,20 @@
             <l>deggio; e del sole ognor sfuggir la luce...</l>
             <l>di duol morir, se non di ferro, io deggio.</l>
           </sp>
-          <sp>
+          <sp who="#demarista">
             <speaker>
               <emph>Demarista</emph>
             </speaker>
             <l>Misera!... Oh ciel!... che fo? Perduto ho un figlio...</l>
             <l part="I">e l'altro a me non resta...</l>
           </sp>
-          <sp>
+          <sp who="#timoleone">
             <speaker>
               <emph>Timoleone</emph>
             </speaker>
             <l part="M">Oh madre!...</l>
           </sp>
-          <sp>
+          <sp who="#echilo">
             <speaker>
               <emph>Echilo</emph>
             </speaker>

--- a/tei/alfieri-virginia.xml
+++ b/tei/alfieri-virginia.xml
@@ -82,6 +82,31 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="numitoria">
+            <persName>Numitoria</persName>
+          </person>
+          <person xml:id="virginia">
+            <persName>Virginia</persName>
+          </person>
+          <person xml:id="marco">
+            <persName>Marco</persName>
+          </person>
+          <person xml:id="icilio">
+            <persName>Icilio</persName>
+          </person>
+          <person xml:id="popolo">
+            <persName>Popolo</persName>
+          </person>
+          <person xml:id="appio">
+            <persName>Appio Claudio</persName>
+          </person>
+          <person xml:id="virginio">
+            <persName>Virginio</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -144,14 +169,14 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>NUMITORIA, VIRGINIA</stage>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
             <l>Che più t'arresti? Vieni: ai lari nostri</l>
             <l part="I">tornar si vuole.</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
@@ -163,7 +188,7 @@
             <l>assoluta possanza. Oh, quanto è in lui</l>
             <l part="I">giusto il dolore e l'ira!</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
@@ -171,13 +196,13 @@
             <l>forse alcun dolce ai tanti amari suoi</l>
             <l part="I">mescer potrà.</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
             <l part="F">S'ei m'ama?... Oggi?... Che sento!</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
@@ -185,14 +210,14 @@
             <l>ed esaudisce il genitore: ei scrive</l>
             <l>dal campo, e affretta le tue nozze ei stesso.</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
             <l>Al mio sì lungo sospirar, fia vero,</l>
             <l>che il fin pur giunga? Oh quanto or me fai lieta!</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
@@ -205,7 +230,7 @@
             <l>pari in te la virtù; d'Icilio degna,</l>
             <l>pria che d'Icilio sposa, ei ti volea.</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
@@ -214,7 +239,7 @@
             <l>pareami il primo d'ogni ben; ma un bene</l>
             <l part="I">maggior d'assai fia il meritarlo.</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
@@ -228,7 +253,7 @@
             <l>giova, e tradirle! In cor d'Icilio han seggio</l>
             <l>virtù, valor, senno, incorrotta fede...</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
@@ -245,7 +270,7 @@
             <l>piangerei d'esser nata in nobil cuna,</l>
             <l part="I">di lui minor pur troppo.</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
@@ -255,7 +280,7 @@
             <l>a seconda dell'aura o lieta, o avversa,</l>
             <l>or superbi, ora umìli, e infami sempre.</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
@@ -264,13 +289,13 @@
             <l>Privati miei, finor taciuti, oltraggi</l>
             <l part="I">ti narrerò.</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
             <l part="M">Vadasi intanto.</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
@@ -282,7 +307,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>VIRGINIA, NUMITORIA, MARCO, <emph>schiavi</emph></stage>
-          <sp>
+          <sp who="#marco">
             <speaker>
               <emph>Marco</emph>
             </speaker>
@@ -291,14 +316,14 @@
             <l>schiavi, presa si tragga: ella è mia serva</l>
             <l part="I">nata, qual voi.</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
             <l part="F">Che ascolto?... E tu, chi sei,</l>
             <l>ch'osi serva appellar romana donna?</l>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>
               <emph>Marco</emph>
             </speaker>
@@ -309,13 +334,13 @@
             <l>le temo, e osservo; e dalle leggi or traggo</l>
             <l>di ripigliar ciò, che a me spetta, ardire.</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
             <l part="I">Io schiava? Io di te schiava?</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
@@ -332,7 +357,7 @@
             <l>or sotto l'armi suda;... e ch'ei fia troppo</l>
             <l part="I">a rintuzzar tua vil baldanza...</l>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>
               <emph>Marco</emph>
             </speaker>
@@ -346,21 +371,21 @@
             <l>né di Virginio tremo: all'ombra sacra</l>
             <l>securo io sto d'inviolabil legge.</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
             <l>Madre, e fia ch'io ti perda? e teco, a un tratto,</l>
             <l part="I">e padre, e sposo, e libertà?...</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
             <l part="F">Ne attesto</l>
             <l part="I">il cielo, e Roma; ell'è mia figlia.</l>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>
               <emph>Marco</emph>
             </speaker>
@@ -371,7 +396,7 @@
             <l>se il vuoi tu poscia, ampia ragion son presto</l>
             <l part="I">a dar dell'opra mia.</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
@@ -383,7 +408,7 @@
             <l>a nostre grida accorrerà: fien mille</l>
             <l>i difensor di vergine innocente.</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
@@ -395,7 +420,7 @@
             <l>altra l'avrei, ben altra, ove pur nata</l>
             <l>d'un vil tuo par schiava più vil foss'io.</l>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>
               <emph>Marco</emph>
             </speaker>
@@ -404,21 +429,21 @@
             <l>destino e stile avrai. Ma intanto il tempo</l>
             <l part="I">scorre in vane contese: or via...</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
             <l part="F">Menarmi</l>
             <l part="I">presa dovrete in un con essa.</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
             <l part="F">O madre,</l>
             <l part="I">forza non v'ha, che a te mi svelga.</l>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>
               <emph>Marco</emph>
             </speaker>
@@ -426,14 +451,14 @@
             <l>Disgiunta sia, strappata dalla falsa</l>
             <l part="I">madre la schiava fuggitiva.</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
             <l part="F">O prodi</l>
             <l part="I">Romani, a me, s'è in voi pietade...</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
@@ -448,20 +473,20 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>ICILIO, <emph>popolo</emph>, NUMITORIA, VIRGINIA, MARCO</stage>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
             <l>Qual tumulto? Quai grida? — Oh ciel! che veggio?</l>
             <l part="I">Virginia!... e a lei...</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
             <l part="M">Deh! vieni...</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
@@ -469,7 +494,7 @@
             <l>corri, affrettati, vola. Alto periglio</l>
             <l part="I">sovrasta alla tua sposa.</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
@@ -477,7 +502,7 @@
             <l>alla madre, ed a me. Costui di schiava</l>
             <l part="I">tacciata m'ha.</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -487,7 +512,7 @@
             <l>schiavo peggior, tu questa vergin osi</l>
             <l part="I">appellar serva?</l>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>
               <emph>Marco</emph>
             </speaker>
@@ -503,7 +528,7 @@
             <l>simili a te fremon qui in suon di sdegno,</l>
             <l part="I">di me giudici siete.</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -541,7 +566,7 @@
             <l>Tra Icilio, e Marco, il mentitor qual sia,</l>
             <l>danne sentenza tu, popol di Roma.</l>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>
               <emph>Marco</emph>
             </speaker>
@@ -558,7 +583,7 @@
             <l>al suo signor sottrar l'antica schiava</l>
             <l part="I">qual di voi l'ardirebbe?</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -586,14 +611,14 @@
             <l>e i forti sensi. Io l'amo; esser de' mia;</l>
             <l part="I">la perderò così?</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="F">Misero sposo!</l>
             <l part="I">Costui, chi sa, chi 'l muova?</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -623,13 +648,13 @@
             <l>Ma i tempi, spero, cangieransi; e forse</l>
             <l part="I">n'è presso il dì...</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="M">Deh, il fosse pur! Ma...</l>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>
               <emph>Marco</emph>
             </speaker>
@@ -651,7 +676,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>ICILIO, VIRGINIA, NUMITORIA, POPOLO</stage>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -666,14 +691,14 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>ICILIO, VIRGINIA, NUMITORIA, POPOLO</stage>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
             <l>Oh rei costumi! Oh iniquità di tempi!...</l>
             <l part="I">Misere madri!...</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
@@ -682,7 +707,7 @@
             <l>priva di lui, come ardirò nomarmi</l>
             <l part="I">tua sposa?</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -696,21 +721,21 @@
             <l>Ma, la cagion, che a farti oltraggio spinge</l>
             <l part="I">quel vil, sapreste voi?</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
             <l part="F">Ch'egli è, dicevi,</l>
             <l part="I">d'Appio tiranno il rio ministro.</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
             <l part="F">Schiavo</l>
             <l part="I">d'ogni sua voglia egli è...</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
@@ -718,20 +743,20 @@
             <l>m'è la cagione dunque. Appio, è gran tempo,</l>
             <l part="I">d'iniquo amore arde per me...</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
             <l part="F">Che ascolto?...</l>
             <l part="I">Oh rabbia!</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
             <l part="M">Oh ciel! perduti siamo.</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -739,7 +764,7 @@
             <l>ho un ferro ancor. — Non paventate, o donne,</l>
             <l part="I">fin ch'io respiro.</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
@@ -764,7 +789,7 @@
             <l>pria d'esser tua: deh! almeno in guisa niuna</l>
             <l part="I">ei non m'abbia, che morta.</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -775,14 +800,14 @@
             <l>Ch'altro è quest'Appio, a chi morir ben vuole,</l>
             <l part="I">che un sol, minor di tutti?</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
             <l part="F">Appio t'avanza</l>
             <l part="I">d'arte pur troppo.</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -806,7 +831,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>APPIO</stage>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -840,21 +865,21 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>APPIO, ICILIO, VIRGINIA, NUMITORIA, POPOLO, <emph>littori</emph></stage>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
             <l>Quai grida ascolto? Al rispettabil seggio</l>
             <l part="I">decemviral viensi così?</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="F">Ti chiede</l>
             <l part="I">Roma giustizia.</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -869,7 +894,7 @@
             <l>tutta non è da voi? — Piacciavi dunque</l>
             <l>in me, ven prego, rispettar voi stessi.</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
@@ -889,7 +914,7 @@
             <l>di Roma intera io tel richieggo a nome;</l>
             <l>rispondi, Appio: son nostri i figli nostri?</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -903,7 +928,7 @@
             <l>Ma voi, chi sete? o vero, o finto, il padre</l>
             <l part="I">qual è della donzella?</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
@@ -916,14 +941,14 @@
             <l>dello schietto suo nascer ti sia,</l>
             <l>l'averla a sé prescelta Icilio sposa.</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
             <l>Sappi, oltre ciò, ch'ella ad Icilio è cara</l>
             <l>più assai che vita, e quanto libertade.</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -938,7 +963,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>MARCO, APPIO, VIRGINIA, NUMITORIA, ICILIO, POPOLO, <emph>littori</emph></stage>
-          <sp>
+          <sp who="#marco">
             <speaker>
               <emph>Marco</emph>
             </speaker>
@@ -953,21 +978,21 @@
             <l>rotto ogni uso di legge; e pria risposto,</l>
             <l part="I">che la domanda io fessi.</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
             <l part="F">È ver; novello</l>
             <l part="I">questo proceder fu.</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
             <l part="F">Ma udiamo: narra;</l>
             <l part="I">questo tuo dritto esponi.</l>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>
               <emph>Marco</emph>
             </speaker>
@@ -984,7 +1009,7 @@
             <l>condotta ho meco; e son mia sola scorta.</l>
             <l>Quant'io ti narro, ecco, a giurar son presti.</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
@@ -998,7 +1023,7 @@
             <l>all'affetto, al dolore, ai moti, ai detti,</l>
             <l>giudicherà se madre vera io sono.</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -1008,7 +1033,7 @@
             <l>van parteggiando; e intorbidata, e guasta</l>
             <l>finor purtroppo han la giustizia in Roma.</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -1016,7 +1041,7 @@
             <l>Ciò che a null'uom si vieta, ad una madre</l>
             <l part="I">vietar vuoi tu?</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -1032,7 +1057,7 @@
             <l>Forza di legge ell'è:... ma voi la speme</l>
             <l>non riponeste or nelle leggi; io 'l veggo.</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -1043,21 +1068,21 @@
             <l>che della figlia giudicar non lice,</l>
             <l part="I">s'anco il padre non v'è.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="F">Ben dice: il padre</l>
             <l part="I">è necessario.</l>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>
               <emph>Marco</emph>
             </speaker>
             <l part="F">Non è conscio il padre,</l>
             <l>vel dissi io già, della materna fraude.</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -1065,7 +1090,7 @@
             <l>tu dall'impresa tosto, or tosto udrammi</l>
             <l>Roma svelar gli empi maneggi vostri.</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -1079,7 +1104,7 @@
             <l>me il lor garrir non move; ira non temo,</l>
             <l>e rie lusinghe di tal gente io sprezzo.</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -1097,13 +1122,13 @@
             <l>pur de' tuoi pari esser virtù primiera,</l>
             <l>prudenza, base a tirannia nascente.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="I">Troppo ei dice, ma vero.</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -1112,7 +1137,7 @@
             <l>ma, ben mi avveggo, giudicar m'è forza</l>
             <l part="I">d'un temerario pria.</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -1123,14 +1148,14 @@
             <l>felice me, se del mio sangue a costo</l>
             <l part="I">oggi a difender valgo!</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="F">Oh forti detti!</l>
             <l part="I">Oh nobil cor! Romano egli è.</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -1139,7 +1164,7 @@
             <l>pendan sospese la mannaie vostre;</l>
             <l part="I">e ad ogni picciol moto...</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
@@ -1150,7 +1175,7 @@
             <l>nulla il morir; purché sia illeso il prode,</l>
             <l part="I">il sol di Roma difensor...</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -1158,7 +1183,7 @@
             <l>costei dal fianco suo. Terribil trama</l>
             <l>qui si nasconde, e sta in periglio Roma.</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -1166,13 +1191,13 @@
             <l>fatta ci viene: a noi, fin ch'io respiro,</l>
             <l part="I">uom non s'accosti.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="M">Ei nulla teme!</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -1184,13 +1209,13 @@
             <l>me trucidar lasciate. Arde d'infame</l>
             <l part="I">amor quest'Appio per Virginia...</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="F">Oh ardire!</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -1207,25 +1232,25 @@
             <l>E a che più vita; ove l'onor, la prole,</l>
             <l>la patria, il cor, la libertà v'è tolta?</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l>Per noi, pe' figli, o libertade, o morte.</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
             <l part="I">Menzogna è questa...</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="F">O libertade, o morte.</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
@@ -1238,7 +1263,7 @@
             <l>ed a voi tutti, discolpar saprommi</l>
             <l>della mentita non soffribil taccia.</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -1263,14 +1288,14 @@
             <l>e a un cenno, a un motto del peggior di Roma,</l>
             <l>a turbarla degg'io presti vedervi?</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l>È ver; giudice egli è: ma udiam, quel prode</l>
             <l part="I">che gli risponda.</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -1287,13 +1312,13 @@
             <l>trafitto in pugna simulata a tergo,</l>
             <l part="I">dal traditor decemviral coltello?</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
             <l>Siccio ribelle, ivi...</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -1324,7 +1349,7 @@
             <l>vivo o morto, son io. Mira, io non fuggo,</l>
             <l part="I">non mi arretro, non tremo: eccomi...</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
@@ -1335,7 +1360,7 @@
             <l>minacci tu: me fa' perir; fia il danno</l>
             <l part="I">minore a Roma, e a te...</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -1346,7 +1371,7 @@
             <l>dar qui, la vita, in don tu la ricevi,</l>
             <l>da Romana qual sei, d'Icilio sposa.</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
@@ -1354,14 +1379,14 @@
             <l>un'altra volta ancor; Virginio torni,</l>
             <l part="I">e s'aspetti, e s'ascolti.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="F">Appio, deh! torni</l>
             <l part="I">Virginio; il vogliam tutti...</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -1376,14 +1401,14 @@
             <l>e di lui poscia. A veder qui v'invito,</l>
             <l>che in sua virtù securo Appio non trema.</l>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>
               <emph>Marco</emph>
             </speaker>
             <l>Ma vuol la legge, che appo me frattanto</l>
             <l part="I">resti la dubbia schiava.</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -1392,19 +1417,19 @@
             <l>d'onesta vergin mai? Legge non havvi</l>
             <l>iniqua tanto; o, se pur v'ha, si rompa.</l>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>
               <emph>Marco</emph>
             </speaker>
             <l>Mallevador chi fia della donzella?</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="I">Mallevador noi tutti.</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -1416,7 +1441,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>APPIO, MARCO</stage>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -1425,14 +1450,14 @@
             <l>Va', temerario, or nella plebe affida,</l>
             <l part="I">mentr'io...</l>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>
               <emph>Marco</emph>
             </speaker>
             <l part="F">La plebe a ribellar più pronta,</l>
             <l part="I">più accesa mai vedesti?</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -1448,7 +1473,7 @@
             <l>son ciò ch'io sono; e più ch'uom mai qui fosse</l>
             <l part="I">farommi.</l>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>
               <emph>Marco</emph>
             </speaker>
@@ -1459,7 +1484,7 @@
             <l>esca possente a non estinto foco,</l>
             <l>che nei petti già liberi ribolle.</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -1472,14 +1497,14 @@
             <l>torneran d'arme sue; di sua rovina</l>
             <l>primo stromento fia la plebe stessa.</l>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>
               <emph>Marco</emph>
             </speaker>
             <l>Ma, il tornar di Virginio, oh quanto aggiunge</l>
             <l>ardimento alla plebe, a Icilio forza!...</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -1494,7 +1519,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>VIRGINIO</stage>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -1510,7 +1535,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>ICILIO, VIRGINIO</stage>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -1518,7 +1543,7 @@
             <l>a noi ti mena. Il tuo venir sì tosto,</l>
             <l part="I">mi è fausto augurio.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -1526,20 +1551,20 @@
             <l>volai;... deh, dimmi, in tempo giungo? Appena</l>
             <l>chiederlo ardisco; son io padre ancora?</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
             <l>Finor tua figlia è libera, ed illesa.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
             <l>Oh inaspettata gioia! oh figlia!... al fine...</l>
             <l part="I">respiro.</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -1549,7 +1574,7 @@
             <l>stanno; del venir tuo nell'ansio petto</l>
             <l>bramano il punto, e il temono a vicenda.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -1559,7 +1584,7 @@
             <l>o di salvar l'unica figlia mia,</l>
             <l part="I">o di morir per essa.</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -1568,14 +1593,14 @@
             <l>un'arme hai tu, che non m'è data, e molto</l>
             <l part="I">nel popol può; le lagrime.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
             <l part="F">Ma dimmi:</l>
             <l part="I">a che siam noi?</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -1608,7 +1633,7 @@
             <l>render la figlia al padre, a me la sposa,</l>
             <l>a sé l'onor, la libertade a Roma.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -1622,14 +1647,14 @@
             <l>Ma, il tuo bollente ardir, l'alma che troppo</l>
             <l part="I">magnanima rinserri...</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
             <l part="F">E quando troppa</l>
             <l part="I">si reputò virtude?</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -1640,7 +1665,7 @@
             <l>la patria oppressa, e l'oltraggiata figlia:</l>
             <l part="I">cause...</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -1649,7 +1674,7 @@
             <l>tu allor v'hai figlia, io vi ho consorte, e vita;</l>
             <l>o è serva, e allor nulla v'abbiam, che il brando.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -1661,7 +1686,7 @@
             <l>salvar la figlia, e non turbar la pace</l>
             <l part="I">della patria si può...</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -1685,7 +1710,7 @@
             <l>quei già superbi cittadin di Roma,</l>
             <l>terror finora, oggi d'Italia scherno.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -1694,14 +1719,14 @@
             <l>Ma, e che potrian due sole alme romane</l>
             <l part="I">a tanti vili in mezzo?</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
             <l part="F">Aspra vendetta</l>
             <l part="I">fare, e morir.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -1717,7 +1742,7 @@
             <l>non tu così; se muori, a vendicarne</l>
             <l part="I">chi resta allor? chi salva Roma?</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -1735,7 +1760,7 @@
             <l>l'evento pur, certa è la gloria: or deggio</l>
             <l part="I">più dirti?</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -1757,7 +1782,7 @@
             <l>avviluppar nella mia fera sorte</l>
             <l part="I">tanti innocenti, e invano...</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -1777,7 +1802,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>NUMITORIA, VIRGINIA, ICILIO, VIRGINIO</stage>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
@@ -1785,13 +1810,13 @@
             <l>no, non m'inganno; è desso, è desso; oh gioia!</l>
             <l part="I">Virginio!</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
             <l part="M">Padre!</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -1799,14 +1824,14 @@
             <l>Consorte!... al sen vi stringo? Oimè... mi sento...</l>
             <l part="I">mancar...</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
             <l part="F">Ti abbraccio sì, finché nomarti</l>
             <l part="I">padre a me lice.</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
@@ -1814,7 +1839,7 @@
             <l>del tuo venir, n'era ogni stanza morte.</l>
             <l>Quindi t'uscimmo impazienti incontro...</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
@@ -1822,14 +1847,14 @@
             <l>or non morrò da te. Più non sperava</l>
             <l part="I">di rivederti mai.</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
             <l part="F">Misero padre!</l>
             <l>non che parlar, può respirare appena.</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
@@ -1843,7 +1868,7 @@
             <l>per cui cara la gloria e il viver t'era)</l>
             <l>or non vorresti aver tu avute mai.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -1869,7 +1894,7 @@
             <l>strappan dal suo non molle core il pianto;...</l>
             <l part="I">ma, col pianger non s'opra.</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
@@ -1880,7 +1905,7 @@
             <l>Ma, donna, e inerme sono; e padre, e sposo,</l>
             <l part="I">e tutto io perdo...</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -1898,7 +1923,7 @@
             <l>e sposa mia. — Pensier, che il cor mi agghiaccia,</l>
             <l part="I">intempestivo egli è finora.</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
@@ -1913,14 +1938,14 @@
             <l>e in veder l'alma in te romana tanto,</l>
             <l part="I">or che più non è Roma.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
             <l part="F">E tu non sei</l>
             <l part="I">mia figlia, tu? l'oda chi 'l niega.</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
@@ -1929,7 +1954,7 @@
             <l>vita. O figlia, morir ben mille volte,</l>
             <l part="I">pria che perderti, voglio.</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -1941,7 +1966,7 @@
             <l>d'amor paterno e coniugal sol pegno</l>
             <l>fia la promessa di scambievol morte.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -1953,7 +1978,7 @@
             <l>perisce il seme, col perir di queste</l>
             <l>libere, altere, generose piante!</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -1963,7 +1988,7 @@
             <l>schiavo il mio sangue!... Ah! trucidarli pria. —</l>
             <l part="I">Padre io non son; se il fossi...</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -1971,7 +1996,7 @@
             <l>tralucer fammi il parlar tuo: deh! taci...</l>
             <l part="I">deh! ten prego.</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
@@ -1980,7 +2005,7 @@
             <l>che non abbiam, misere madri, uguale</l>
             <l part="I">al dolore la forza!</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -1991,7 +2016,7 @@
             <l>ma noi bastiam soli a dar vita e sdegno</l>
             <l part="I">ad un popolo intero.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -2005,7 +2030,7 @@
             <l>contaminata, cadesse trafitta</l>
             <l>di propria mano al suol nel sangue immersa.</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
@@ -2022,14 +2047,14 @@
             <l>tingan lor brando a gara, e infino all'elsa</l>
             <l>lo immergan tutti a' rei tiranni in petto.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
             <l>Deh, figlia,... or, qual mi fai provar novello</l>
             <l part="I">terrore!... oimè!...</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -2044,14 +2069,14 @@
             <l>ti si concede. Oh sventurato padre!</l>
             <l>brevi hai momenti a così immenso affetto.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
             <l>Oh fera notte!... Andiam: doman col sole,</l>
             <l part="I">Icilio, qui mi rivedrai.</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -2062,7 +2087,7 @@
             <l>non v'ha che il mio; di sangue. — O estinti, o vivi,</l>
             <l>felici appien sarem domani, o sposa.</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
@@ -2075,33 +2100,33 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>APPIO, MARCO</stage>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
             <l part="I">Virginio in Roma?</l>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>
               <emph>Marco</emph>
             </speaker>
             <l part="M">Ei v'è pur troppo.</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
             <l part="F">Visto</l>
             <l part="I">l'hai tu?</l>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>
               <emph>Marco</emph>
             </speaker>
             <l part="F">Cogli occhi miei. Tu stesso in breve</l>
             <l part="I">anco il vedrai, ch'ei di te cerca.</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -2109,7 +2134,7 @@
             <l>del campo uscì, se un mio comando espresso</l>
             <l part="I">ritener vel dovea?</l>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>
               <emph>Marco</emph>
             </speaker>
@@ -2117,7 +2142,7 @@
             <l>forse il divieto tuo; forse anco i duci</l>
             <l part="I">a obbedirti eran lenti...</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -2130,7 +2155,7 @@
             <l>cangia l'affar d'aspetto, al venir suo:</l>
             <l part="I">ma pur, non io...</l>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>
               <emph>Marco</emph>
             </speaker>
@@ -2149,7 +2174,7 @@
             <l>terribil esca a più terribil fiamma</l>
             <l part="I">stanno per esser; bada.</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -2162,7 +2187,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>APPIO, VIRGINIO</stage>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -2170,7 +2195,7 @@
             <l>osi così? Di Roma oggi i soldati</l>
             <l>dunque a lor posta van, tornano, stanno?</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -2180,7 +2205,7 @@
             <l>Chiesto commiato ottenni. In Roma torno</l>
             <l part="I">per la mia figlia;... e il sai.</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -2188,7 +2213,7 @@
             <l>dir tu, che in suon più forte a me nol dica</l>
             <l part="I">la legge?</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -2204,7 +2229,7 @@
             <l>concesso t'è: ma pensa anco, deh! pensa,</l>
             <l>che in un te stesso a immenso rischio esponi...</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -2244,7 +2269,7 @@
             <l>Sol si cela da te; ma a lor non teme,</l>
             <l>qual è, mostrarsi l'oppressor di Roma.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -2254,7 +2279,7 @@
             <l>tremendi a noi, più che i nemici: or come</l>
             <l>temere omai d'altro oppressor può Roma?</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -2266,21 +2291,21 @@
             <l>ne son l'amante, io 'l rapitore. Or odi</l>
             <l part="I">ragion novella!</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
             <l part="F">È Icilio sol, che il dica?</l>
             <l part="I">Altri ha, che il dice.</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
             <l part="F">La donzella forse,</l>
             <l part="I">vinta da lui.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -2289,34 +2314,34 @@
             <l>poter narrare. Una ne fia, non lieve,</l>
             <l part="I">il tuo scolparten meco.</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
             <l part="F">Hai fermo dunque</l>
             <l part="I">d'unirti pure co' ribelli?</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
             <l part="F">Ho fermo</l>
             <l part="I">d'aver mia figlia, o perder me.</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
             <l part="F">Te salvo</l>
             <l part="I">vorrei, ch'io t'amo.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
             <l part="M">E perché m'ami?</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -2325,14 +2350,14 @@
             <l>che solo Icilio pera; il merta ei solo.</l>
             <l part="I">Degno di viver tu...</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
             <l part="F">Degno, t'intendo,</l>
             <l part="I">me di servir tu credi...</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -2342,7 +2367,7 @@
             <l>ch'io d'innalzarti a militar comando</l>
             <l part="I">avrò...</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -2367,7 +2392,7 @@
             <l>e finché Roma il soffre, il soffro anch'io:</l>
             <l part="I">ma la mia figlia...</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -2382,26 +2407,26 @@
             <l>la vuoi d'Icilio sposa, e involger teco</l>
             <l>nella rovina di un fellon tua figlia.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
             <l part="I">Me la puoi... render... tu?</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
             <l part="F">Se a Icilio torla</l>
             <l part="I">tu vuoi.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
             <l part="M">Glie la giurai.</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -2411,7 +2436,7 @@
             <l>se d'Icilio non è: d'Icilio sposa,</l>
             <l>far io non posso che con lui non pera.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -2421,7 +2446,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>APPIO</stage>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -2440,7 +2465,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>APPIO, NUMITORIA, VIRGINIA</stage>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -2452,20 +2477,20 @@
             <l>Virginia: vieni; in altro aspetto forse</l>
             <l part="I">me qui vedrai.</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
             <l part="F">Col padre favellasti?</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
             <l>Pentito sei? preso hai miglior consiglio</l>
             <l part="I">al fin dal timor tuo?</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -2476,14 +2501,14 @@
             <l>che a me ti tolga, esser non può; ragioni,</l>
             <l part="I">che a me ti pieghin, ve n'ha molte...</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
             <l part="F">È questo</l>
             <l part="I">il cangiar tuo? Deh! madre, andiam...</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -2498,14 +2523,14 @@
             <l>suddito lui, co' pari suoi, disegno;</l>
             <l part="I">mentr'essi a me obbediscono...</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
             <l part="F">Ed ardisci</l>
             <l part="I">svelar così?...</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -2517,19 +2542,19 @@
             <l>d'esser d'Icilio sposa, io la richiesta</l>
             <l part="I">fo cessar tosto.</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
             <l part="F">Abbandonarlo?... Ah, pria...</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
             <l part="I">Oh rea baldanza! Oh scellerato!...</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -2547,7 +2572,7 @@
             <l>dare ad amor; tutto ricever spera</l>
             <l part="I">da amore Icilio.</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
@@ -2561,33 +2586,33 @@
             <l>ma, né in pensiero pure a te mai cadde</l>
             <l part="I">di richiedermi sposa?...</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
             <l part="F">Un dì, fors'io...</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
             <l part="I">Non creder già, ch'io mai...</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
             <l part="F">Di noi stimavi</l>
             <l part="I">far gioco: oh rabbia!...</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
             <l part="F">Infame; a nessun patto</l>
             <l part="I">piegarmi tu...</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -2595,32 +2620,32 @@
             <l>in poter mio, del sangue del tuo amante</l>
             <l part="I">cospersa tutta.</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
             <l part="M">Oh ciel!...</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
             <l part="F">Sì, del tuo amante;...</l>
             <l part="I">e del tuo padre.</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
             <l part="M">Oh crudo!...</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
             <l part="M">Il padre!</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -2629,14 +2654,14 @@
             <l>Siccio per me vel dica. Un'ora manca</l>
             <l part="I">a dar segno al macello.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
             <l part="F">Icilio!... Un'ora!...</l>
             <l part="I">Appio, pietà... L'amante... il padre...</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
@@ -2644,7 +2669,7 @@
             <l>due tali prodi ad un tuo cenno? E credi</l>
             <l part="I">te nel tuo seggio indi securo?...</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -2653,27 +2678,27 @@
             <l>Virginio, Icilio, ricondotti a vita</l>
             <l part="I">foran perciò?</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
             <l part="M">Tremar mi fai...</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
             <l part="F">... Deh!... m'odi.</l>
             <l part="I">Né fia, che priego?...</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
             <l part="F">Con un sol suo detto,</l>
             <l part="I">ella entrambi li salva.</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
@@ -2694,7 +2719,7 @@
             <l>lor trafitti, mi resta. In tempo un ferro</l>
             <l part="I">non mi darai tu, madre?</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
@@ -2702,7 +2727,7 @@
             <l>Numi v'ha in ciel dell'innocenza oppressa</l>
             <l part="I">vindici; in lor speriam: vieni...</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
@@ -2713,7 +2738,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>APPIO</stage>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -2735,7 +2760,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>VIRGINIO, ICILIO <emph>con seguaci</emph></stage>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -2743,26 +2768,26 @@
             <l>per ogni via sboccare armi nel foro?</l>
             <l part="I">e in cerchio...</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
             <l part="F">Io veggo a me dattorno schiera,</l>
             <l>benché minor, d'altro coraggio,... forse.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
             <l part="I">In lor ti affidi?</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
             <l part="M">— In me mi affido.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -2775,7 +2800,7 @@
             <l>decemvirali, di', qual debbo io poscia</l>
             <l>nomarti? qual, quanto rimani in Roma?</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -2786,7 +2811,7 @@
             <l>ma, non mi offende: in te il sospetto vile</l>
             <l>nascer, no, mai non può, s'Appio nol desta.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -2799,7 +2824,7 @@
             <l>possibil tanto è ch'io ti manchi mai,</l>
             <l>quanto, che a te manchi il tuo brando, o il core.</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
@@ -2822,7 +2847,7 @@
             <l>certa mi par. Tutto il periglio io veggio:</l>
             <l part="I">perciò lo affronto.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -2837,14 +2862,14 @@
             <l>forse è mestier da pria finger dolcezza:</l>
             <l>norma da me, prego, al tuo oprar, deh! prendi.</l>
           </sp>
-          <sp>
+          <sp who="#icilio">
             <speaker>
               <emph>Icilio</emph>
             </speaker>
             <l>Or sei Romano, e padre. Accenna dunque;</l>
             <l>ratto al ferir me più che lampo avrai.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -2862,7 +2887,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>VIRGINIO</stage>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -2873,57 +2898,57 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>APPIO, VIRGINIO</stage>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
             <l part="I">Di'; risolvesti al fine?</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
             <l part="F">È già gran tempo.</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
             <l part="I">Qual padre il de'?</l>
             <l part="F">Qual roman padre il debbe.</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
             <l>Rotto ogni nodo hai con Icilio dunque?</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
             <l part="I">Stringonmi a lui tre forti nodi.</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
             <l part="F">E sono?</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
             <l part="I">Sangue, amistà, virtù.</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
             <l part="F">Perfido! il sangue</l>
             <l part="I">scorrerà dunque ad eternarli.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -2934,7 +2959,7 @@
             <l>ir m'apparecchio; altro non posso: i Numi,</l>
             <l>un dì faran poi mie vendette, spero.</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -2957,19 +2982,19 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>NUMITORIA, VIRGINIA, APPIO, VIRGINIO, MARCO, POPOLO, <emph>littori</emph></stage>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
             <l part="I">Oh tradimento!</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="M">Oh infausto giorno!</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
@@ -2977,25 +3002,25 @@
             <l>tu vivi almen; tu vivi. Ah! tu non sai...</l>
             <l part="I">Icilio... oimè!...</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
             <l part="F">Dite; che fia? Nol veggo.</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
             <l part="I">Icilio muore.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
             <l part="M">Oh ciel! che ascolto?</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -3004,7 +3029,7 @@
             <l>che il reo punì, senza aspettar che il danni</l>
             <l part="I">giusto rigor di legge?</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
@@ -3028,14 +3053,14 @@
             <l>che da tergo e da fianco ognun lo assale,</l>
             <l part="I">ed imminente è il morir suo.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
             <l part="F">Qual morte</l>
             <l part="I">per uom sì prode!</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
@@ -3045,7 +3070,7 @@
             <l>servir, non vo'. Libera morte impara,</l>
             <l part="I">sposa, da me»...</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
@@ -3056,20 +3081,20 @@
             <l>la non tremante mia destra al tuo ferro...</l>
             <l part="I">ma... invan...</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
             <l part="F">La folla, e il suo ondeggiar, ritratte</l>
             <l>ci ha dall'orribil vista, e qui sospinte.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
             <l>Cade Icilio, o Romani... Appio già regna...</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -3085,7 +3110,7 @@
             <l>di tiranno tacciarmi; e sì pur degno</l>
             <l>parve ei di morte a' suoi seguaci istessi.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -3097,7 +3122,7 @@
             <l>chi non la legge in queste armate schiere?...</l>
             <l>e nel silenzio di Roma tremante?</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -3119,19 +3144,19 @@
             <l>qui vien: ragioni, ov'ei pur n'abbia, esponga;</l>
             <l part="I">ma il tentar forza, a lui si vieti.</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
             <l part="F">Ahi lassa!</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
             <l part="I">Me misera! Anco il padre?...</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -3148,7 +3173,7 @@
             <l>peggio che morte assai. Per me non prego;</l>
             <l>io tremo sol per lei; per lei sol piango.</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
@@ -3163,7 +3188,7 @@
             <l>se il loro onor vi cale, al nascer loro,</l>
             <l part="I">vibrate un ferro entro ai lor petti.</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -3184,14 +3209,14 @@
             <l>Marco, Virginia è tua; ragion non posso</l>
             <l part="I">negare a te nella tua schiava.</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
             <l part="F">Oh! dove</l>
             <l>tal giudicio s'intese? E niun mi ascolta?</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
@@ -3201,7 +3226,7 @@
             <l>tu l'hai; tu il promettesti: a me lo sposo</l>
             <l>è tolto già; l'onor vuoi ch'anco io perda?</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -3218,7 +3243,7 @@
             <l>la non ben vostra orrida vita infame,</l>
             <l>ch'or voi serbate a così infame costo.</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -3228,25 +3253,25 @@
             <l>sedizioso duol di finta madre:</l>
             <l>la non sua figlia a lei dal sen si svelga.</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
             <l part="I">Me svenerete prima.</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
             <l part="M">Oh madre!</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="F">Oh giorno!</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -3256,7 +3281,7 @@
             <l>finor l'amai: se pur mentìa la moglie,</l>
             <l part="I">son di tal fraude ignaro...</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
@@ -3264,7 +3289,7 @@
             <l>Tanto avvilir tu la consorte tua?...</l>
             <l part="I">or quel di pria sei tu?</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
@@ -3272,7 +3297,7 @@
             <l>in questo punto? e non più tua mi credi?</l>
             <l part="I">Misera me!</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -3287,7 +3312,7 @@
             <l>stato di vita parte, in un sol giorno</l>
             <l part="I">poss'io spogliarmi, in un istante?...</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
@@ -3298,7 +3323,7 @@
             <l>or ti rispondo. A lui la via, littori,</l>
             <l part="I">s'apra.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
@@ -3307,79 +3332,79 @@
             <l>di tal nome,... una volta. — Ultimo pegno</l>
             <l>d'amor ricevi — libertade, e morte.</l>
           </sp>
-          <sp>
+          <sp who="#virginia">
             <speaker>
               <emph>Virginia</emph>
             </speaker>
             <l part="I">Oh... vero... padre!...</l>
           </sp>
-          <sp>
+          <sp who="#numitoria">
             <speaker>
               <emph>Numitoria</emph>
             </speaker>
             <l part="M">Oh ciel! figlia...</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
             <l part="F">Che festi?...</l>
             <l part="I">Littori, ah! tosto...</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
             <l part="F">Agli infernali Dei</l>
             <l>con questo sangue il capo tuo consacro.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l>Oh spettacolo atroce! Appio è tiranno...</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
             <l>Romani, all'ira or vi movete? è tarda:</l>
             <l>più non si rende agli innocenti vita.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>
             <l part="I">Appio è tiranno; muoia.</l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
             <l part="F">Il parricida</l>
             <l part="I">muoia, e i ribelli.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
             <l part="F">Alla vendetta tempo,</l>
             <l part="I">pria di morir, prodi, ne resta.<note resp="#aut" place="foot" anchored="true">Virginio e il popolo in atto d'assalire i littori e i satelliti d'Appio.</note></l>
           </sp>
-          <sp>
+          <sp who="#appio">
             <speaker>
               <emph>Appio</emph>
             </speaker>
             <l part="F">Tempo<note resp="#aut" place="foot" anchored="true">Appio ed i suoi in atto di respingere il popolo e Virginio.</note></l>
             <l>a punir te, pria di morir, mi avanza.</l>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker>
               <emph>Virginio</emph>
             </speaker>
             <l part="I">Appio è tiranno; muoia.<note resp="#aut" place="foot" anchored="true">Cade il sipario.</note></l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>
               <emph>Popolo</emph>
             </speaker>

--- a/tei/andreini-lo-schiavetto.xml
+++ b/tei/andreini-lo-schiavetto.xml
@@ -84,6 +84,79 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="rampino">
+            <persName>Rampino</persName>
+          </person>
+          <person xml:id="nottola">
+            <persName>Nottola</persName>
+          </person>
+          <person xml:id="scrocco">
+            <persName>Scrocco</persName>
+          </person>
+          <person xml:id="succiola">
+            <persName>Succiola</persName>
+          </person>
+          <person xml:id="fulgenzio">
+            <persName>Fulgenzio</persName>
+          </person>
+          <person xml:id="prudenza">
+            <persName>Prudenza</persName>
+          </person>
+          <person xml:id="orazio">
+            <persName>Orazio</persName>
+          </person>
+          <person xml:id="alberto">
+            <persName>Alberto</persName>
+          </person>
+          <person xml:id="grillo">
+            <persName>Grillo</persName>
+          </person>
+          <person xml:id="altro_paggio">
+            <persName>Altro Paggio</persName>
+          </person>
+          <person xml:id="cicala">
+            <persName>Cicala</persName>
+          </person>
+          <person xml:id="schiavetto">
+            <persName>Schiavetto</persName>
+          </person>
+          <person xml:id="rondone">
+            <persName>Rondone</persName>
+          </person>
+          <person xml:id="scemoel">
+            <persName>Scemoel</persName>
+          </person>
+          <person xml:id="facchino">
+            <persName>Facchino</persName>
+          </person>
+          <person xml:id="sensale">
+            <persName>Sensale</persName>
+          </person>
+          <person xml:id="leon">
+            <persName>Leon</persName>
+          </person>
+          <person xml:id="caino">
+            <persName>Caino</persName>
+          </person>
+          <person xml:id="paggio">
+            <persName>Paggio</persName>
+          </person>
+          <person xml:id="bargello">
+            <persName>Bargello</persName>
+          </person>
+          <person xml:id="facceto">
+            <persName>Facceto</persName>
+          </person>
+          <person xml:id="solfanello">
+            <persName>Solfanello</persName>
+          </person>
+          <person xml:id="belisario">
+            <persName>Belisario</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Siena</name>Digitalizzazione</change>
@@ -145,7 +218,7 @@
         <castItem type="role">
           <role>SBIRRI</role>
         </castItem>
-        <castItem type="list"><role>SCEMOEL</role>, <role>CAINO</role>, <role>LION></role>, <role>SENSALE</role>, <roleDesc><emph>ebrei</emph></roleDesc></castItem>
+        <castItem type="list"><role>SCEMOEL</role>, <role>CAINO</role>, <role>LION&gt;</role>, <role>SENSALE</role>, <roleDesc><emph>ebrei</emph></roleDesc></castItem>
         <pb n="63"/>
         <castItem type="role"><role>BELISARIO</role>, <roleDesc><emph>vecchio decrepito e gioieliere</emph></roleDesc></castItem>
         <castItem type="role">
@@ -168,103 +241,103 @@
         <div type="scene">
           <head rend="italic">SCENA PRIMA</head>
           <stage><hi rend="sc">nottola, rampino</hi>, <hi rend="italic">e molti</hi><hi rend="sc">scrocchi</hi><hi rend="italic">malamente vestiti</hi></stage>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Vi dico, messer Nottola, che l'andar giravoltando tutto il mondo, senza un guadagno alcuno, non fa per me, né per questi tanti poveri uomini, che avete con voi. E per dirvela a lettera di scatole: voi sapete, che la mia casa era di pegolotto e ch'io m'andava buscando la vita, e ch'ogni sera io m'andava riducendo a i cagnardi, dove con le sfoiose spillava, ora perdendo, ora guadagnando. Vedete, io non ho più monacchie, le tiranti sono in pezzi, il pietro l'ho sbasito, il fongo è tutto mangiato da i taruoli, la lima è negra e piena di gualdi, sì che a peggio non posso venire.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Or sù, che vuoi concludere, Rampino?</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Che voglio concludere? Voglio dire che almeno, quando io non era con voi, tra la calca, e tra lo spillare, io mi buscava il mio occhio di civetta il giorno, e ora c'ho trovato voi (che dite mi volete far ricco) ho lasciato ogni utile e sono divenuto il più povero scroccone del mondo.<pb n="67"/></p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Mo, che 'l Rabbino ti scarpisca dal cofano la perpetua, e in ogni azione ti sia contrario santalto! Abbi pacienza, partiamo da questa città di Pesaro, e poi quanto ho promesso, a te e a tutti voi, manterrò di sicuro.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p><foreign xml:lang="lat">Promitto promittis</foreign> sta per inzavagliare, da tutti i fanciulli ho udito dire quando, dalle scuole tornando, si disciplinano con le saccoccie piene di libri senza coperte. In nome di tutti costoro io dico, adunque, che non vogliono passar Pesaro. E di più, ecco, vi danno i fardelli, che tanto addosso gli avete fatto portare, ogni sera volendoli appresso di voi, come se fossero stati groppi di gemme. Eccoli qua, gettateli per terra, o così.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Fermatevi, la canaglia! Che modo di fare è questo?</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Sì, di grazia, fate piano, che qualche gualdo non si rompa il guindo. Un manigoldo se' tu, che n'hai tutti trappolati, facendo ad ogn'uno lasciare il suo camino dicendo: «Vien meco, ch'io ti farò ricco!». L'uomo, non sapendo altro, s'è fidato ed è venuto e ancora molto teco più averebbe trascorso, ma il sentir dir: «Venite allegramente, ché come siamo a Roma mi voglio fermare», poi, a Roma giunti, dire: «Andiamo, ché vi prometto, come siamo a Viterbo, che colà riposarmi intendo», come siamo a Viterbo dire: «Andiamo, ché dadovero come siamo a Siena si rinfrancheremo del viaggio» e così menarne a Pesaro, voler ancora più oltre passare. Insomma, alcun di noi non la vuole intendere. Ed io, che so che la serpentina mi sta meglio ne i merli che a quest'altri, fecimi cura il canzonare.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Do', furfante vituperoso, che non so come il manico non t'abbia ogimai gettata al collo una margherita. Va' alle<pb n="68"/> forche, tu e gli altri, ché più non vi voglio meco, come non mi volete ubbidire.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Carne da boia se' tu, traditore! Addosso, compagni, con le pugna!</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Ohimè, ohimè! non più! perdono! Amici, fratelli, signori, perdono!</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Che perdono? ma che suono di scudi?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Che scudi? Guardate per terra! Udite il suono di questi altri, che pur dal seno levandomi, in terra i' getto? che vi pare?</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Ohimè, che vuol dir questo?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Raccoglieteli pur tutti. Tu raccogli quelli, tu quelli, tu quelli. Voi altri fate presto.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>O quanti scudi! Voglia il Cielo, che non abbiamo fatto qualche errore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Or sù vedete, furfanti, quanto avete me caricato di pugna, tanto ho voluto caricar voi altri d'oro. Ora andate alle forche, canaglia, ché bene solamente siete degni d'abitare i cagnardi, le bettole, e di morire su la paglia, cibo di piattole e di gualdi! Non meritavate di stare appresso un principe come io sono; ma giuro per la nobiltà del mio sangue, che da cinquecento re di Spagna discende, ch'io ve ne farò pentire. A me? a me? a me pugna, figli di puttane? cospettaccio, puttanaccia, rinego il diavolo, che me la pagherete!</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>O come passeggia sbattendo il capo e sbuffando! Figlioli, inginocchiamoci.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Che saprete dire?</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Signore, dirò solo, a mio nome e a nome di tutti questi sbigottiti e impalliditi servi suoi, che non lo conoscendo errammo, ma che tante lagrime spargeremo, quante pugna abbiamo a vostra signorìa date.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O bella ricompensa, una lagrima per un pugno. Siete voi pentiti?</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Dico per tutti di sì, mio signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Sì? Piangete tutti, e tutti forte! più forte! più ancora! Or sù, fermatevi! Avete voi caro di rallegrarmi?</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Come, signore, altro non bramano questi sconsolati!<pb n="69"/></p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Sù, dunque, ridete tutti! ancòra! ancòra! sù, presto, insieme tutti rizzatevi! cantate e ballate! sù, presto.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Adesso signore.</p>
             <p>
@@ -278,91 +351,91 @@
               </quote>
             </p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Fermatevi, non più! Vien qua, Rampino, voglio tutti or ora mutar di camisia. Taglia questo fardello.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Ecco appunto il cortello, co 'l quale vado a ciavatte. Ecco ch'io taglio.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Guarda che v'è dentro.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Oh che belle camisie! oh come sono sottili, oh che belle cose, oh come candide!</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Portamele qua. To' tu! tu, ancor tu! vien qua tu! tu fatti innanzi! tu prendi questa! tu questa, tu questa, tu pure questa, questa e così ancor tu! Tu, benché picciolo, to' questa, ci farai duo fazzoletti ancòra! e così ancor tu di quest'altra.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>O che caro signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Figlioli, io vi perdono, poiché noi altri principi dobbiamo più perdonare e donare, che vendicare e pelare. E benché ch'io sia guercio, e gobbo, sappiate che, quanto la Natura ne fa più brutti nel corpo, tanto più il Cielo ne fa belli nel cuore. Sì che vi perdono, e sappiate che questi fardelli, che voi stimavate nulla, sono pieni di tesoro; e che sia vero, guardatene uno e guardateli tutti. Mirate, che dite? il folgorar dell'oro e delle gemme non v'abbagliano? non vi par di mirare (disceso in terra) il sole?<pb n="70"/></p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>O quant'oro, o quante gemme, o quanto splendore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Nascondete, nascondete! Sù, sù, inviluppate e legate alla peggio. Or sapete voi perché v'ho detto di città in città fermarmi e giamai non mi son fermato? Perché sono tutte città di miei nemici e per passar sicuro, accioché i postiglioni né per le osterie, né per le poste mi potessero riconoscere, sono andato in questa maniera, né ancora voleva fermarmi qui in Pesaro, ma mi contento per amor vostro e di quattro pugna datemi.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Se non gli agrada il partire, mio signore, non parta, poi che noi tutti pendiamo dalle voglie sue, dal solo suo imporre con lo sguardo.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Or sù, per segno di pace ogn'uno venga a baciar questa mano, e m'inchini per suo principe.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Io sarò il primo, o generosissimo signore.</p>
           </sp>
-          <sp>
+          <sp who="#scrocco">
             <speaker><emph rend="sc">scrocco</emph>.</speaker>
             <p>E io il secondo.</p>
           </sp>
-          <sp>
+          <sp who="#scrocco">
             <speaker><emph rend="sc">scrocco</emph>.</speaker>
             <p>E io il terzo.</p>
           </sp>
-          <sp>
+          <sp who="#scrocco">
             <speaker><emph rend="sc">scrocco</emph>.</speaker>
             <p>E io il quarto.</p>
           </sp>
-          <sp>
+          <sp who="#scrocco">
             <speaker><emph rend="sc">scrocco</emph>.</speaker>
             <p>E io il quinto.</p>
           </sp>
-          <sp>
+          <sp who="#scrocco">
             <speaker><emph rend="sc">scrocco</emph>.</speaker>
             <p>E io il sesto.</p>
           </sp>
-          <sp>
+          <sp who="#scrocco">
             <speaker><emph rend="sc">scrocco</emph>.</speaker>
             <p>E io il settimo.</p>
           </sp>
-          <sp>
+          <sp who="#scrocco">
             <speaker><emph rend="sc">scrocco</emph>.</speaker>
             <p>E io l'ottavo.</p>
           </sp>
-          <sp>
+          <sp who="#scrocco">
             <speaker><emph rend="sc">scrocco</emph>.</speaker>
             <p>E io il nono.</p>
           </sp>
-          <sp>
+          <sp who="#scrocco">
             <speaker><emph rend="sc">scrocco</emph>.</speaker>
             <p>E io il decimo.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Or poi, che avete onorato il vostro principe Nottola, battete a questa osteria, ché colà dentro dispenserò i gradi conforme il valore, e sapere, di voi altri, e della nostra generositade. Ma chi canta nell'osteria? Buon augurio.</p>
           </sp>
@@ -372,7 +445,7 @@
           <stage>
             <hi rend="sc">succiola, nottola, rampino, scrocchi</hi>
           </stage>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>
               <quote>
@@ -386,175 +459,175 @@
               </quote>
             </p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O buono! o buono! Rampino, batti.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>O dall'osteria, olà, alcuno non risponde?</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Oh, corpo di sanpuccio, e chi bussa così alla sbardellata? e che sì, che vi getto del ranno caldo su 'l capo? Oh vedete che bel briccone! A quest'otta sono fatte le mie limosine? Va' a lavorà, dappocaccio.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Che cosa ha detto, che non così tosto apparì alla finestra, che se ne sparì?</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Ch'io vada in buon ora, ch'è fatta la elemosina.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Eh? Veramente tu hai l'aria, non sol che l'abito, da poverissimo uomo; lascia battere a me. O dall'osteria?</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>O sudicio, o forestico, o sbandeggiato, ascolta: e' ti darò d'una pentola su 'l capo se di qui non ti levi, ve'? O tornami a stuzzicare, manigoldo.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Ah, Rampino, ha pur tolto me per guidone! Di' pur il vero, all'aria ho più del guidone, che non hai tu del sicuro, non è così? di', sì, dillo dico! dillo, fa' presto.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Poi che vuol che così dica: signor sì.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Dammi la mano, tu l'hai indovinata. Or sù torna a battere! Ma eccola ch'esce su la strada.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>O raviggioli freschi, vo' siete i be' buacci! Levatevimi d'andar ronzando intorno a cotesto albergo, ché albergare non vo' di cotesti sudici! se non, che per il corpo di<pb n="72"/> mene i' vi darò de' frugoni, vedete? Che è cotesto, povera mee?</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>O povera voi, certo, questi è un principe incognito e voi non lo conoscete.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>E se non è incognito non ci si torni! La disgrazia li ha cavato un occhio e la Natura hallo fatto gobbo perché vada incognito bene bene.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Vi dico ch'è prencipe, madonna.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Oh? A quell'otta stessi tu a manucare, che l'entrate vengono a questo principe. O che bamboccierìe, il mio bel bamboccio! Con coteste pattocchierìe mi voreste impastocchiare, ma non m'impastocchierete.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Piano, piano, madonna! Imparate a praticare co' prìncipi bizzarri.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Signor principe mio ascoltate: io non voglio che alcuna fiata, per bizarìa, vo' mi portaste via le lenzuola del letto e la coltrice. Per questo i' non voglio alla lunga bazzicar con voi.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Siete povera?</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Sonla. Ma non voglio che voi più m'impoveriate.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Adagio. Avete padre?</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Hollo.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Dove sta, come ha nome, che mestiere è 'l suo?</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Sta a Pogibonci, ha nome Ceccobimbi, è mercante da fichi secchi.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Piano un poco, fermatevi. Avete madre? com'ha nome?</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Holla, e ha nome la Ceccabimba. Ho una sirocchia, che pur si chiama Ceccabimba, una Ceccobimbetta, un'altra Ceccobimbotta. Ora ne volete più di cotesta Ceccobimbaria? O come ride cotesto principe de' Scrocchi, o come si getta via, o come strabuzza que'gli occhi di struzzolo!<pb n="73"/></p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Ohimè, questa Ceccobimbata m'ha fatto tanto ridere, ch'io mi sono pisciato addosso! Rampino?</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Donategli una catena d'oro di quelle grosse.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Adesso, signore.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>I' voglio pur istare a vedere che cicciurlaia ha da essere cotesta.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Pigliate, madonna, quest'è la vostra ventura, riconoscetela e pelatela, fate come fanno i cortegiani con i prìncipi, che chi non sa adular non sa regnare. Così vidi scritto sovra il limitare d'uno che s'era fatto ricco la corte servendo.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Ma cappari con l'asceto, coteste non sono frascherìe, né pappolate, va' daddovero. Signor principe?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Ah, ah, si cala. Donagli venticinque piastre fiorentine.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Pigliate. Da' qua quel sacchetto di dinari d'argento.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Questo è ben altro che rumore di craice.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Pigliate.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Uh, quante piastre! o che siate vo' benedetto! gnene rendo grazie! Perdonatemi, vedete, signore, se non la conoscendo la strapazzai: fui iscema, lo confesso; un'altra volta non sarò così sboccataccia. Vuol ella degnarsi di venire con cotestoro a soiare in casa mia? Sì, sì, di grazia. Craldio, Cencio, Bista, Meo, Pippo, Tonio, Maso, Beco, Sandro, Cecco; Bita, Pippa, Ghita, Nena, Tea, Tina, Tancia, Cecca, Sandra, Cece, Beca, uscite, uscite.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Non chiamate, non chiamate! Voglio sì desinar con voi, ma pigliate. Questi, per ora, sono ducento scudi, parecchiatemi un poco di collazioncella. Pigliate questi quattrocento, parecchiate il desinare. Pigliate questi cinquecento, darete ordine per la cena. E s'inviti tutta questa città in questa osteria a corte bandita per tre giorni. Entriamo figlioli.<pb n="74"/></p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>O care mane vi bascio e ribascio, anzi i' vi vorrei potere ingollare. Signore, per tutto iscendete e ascendete, ché di tutta casa mia siete signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O pigliate questo anellino. Di grazia, cantate una canzone alla fiorentinesca, poiché vi ho sentita poco fa in casa a cantare.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Di grazia, cotesta canzona appunto è storia vera, poscia ch'un bello spirito fiorentino per mene già la compose.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Cheti tutti, figlioli! Di' sù, e poi con questo appetito andiamo a mangiare.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Or m'udite signore, che per amor vostro i' la vuo' ancora cantare.</p>
             <p>
@@ -572,11 +645,11 @@
               </quote>
             </p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Eh, eh, eh, eh, o bene, o bene, viva Succiola, cridi ciascuno.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Viva Succiola! Viva Succiola! Viva Succiola!</p>
           </sp>
@@ -586,39 +659,39 @@
           <stage>
             <hi rend="sc">fulgenzio, prudenza</hi>
           </stage>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Come provo che 'l fuoco amoroso arde, e non consuma, poiché se consumasse, Fulgenzio, ch'è, omai stato tan<pb n="75"/>to tempo materia a questo fuoco, sarebbe arso e incenerito. Ma che? O stolto, dovrai tu sempre in questo fuoco ardere senza procurar modo (se non di spegnerlo, ché questo non brami) almeno di temperare l'ardor suo, ch'è così grande? Pur sai che chiuso fuoco è più ardente; per farlo adunque meno cocente, aprigli il varco con le parole, fa' che essali omai fuori dal seno. Voglio farlo per certo, poiché Amore molto mi promette in questo giorno, e ben ch'io non parlasse giamai alla signora Prudenza di questo amore, se non con gesti, e saluti, voglio nondimeno oggi tanto avanzarmi, che le ne mostri maggior certezza. O dalla casa?</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Che mi commanda vostra signorìa, mio signor? che vuole, che ha battuto a questa casa?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>O Fulgenzio, o Fulgenzio, chiedi, che indugi? Molto ottiene chi presto chiede, non temere! Mia signora, avendo io da cento lingue, e cento, inteso che le piaghe amorose sono di così fatta natura, che alcuno sanar non le può, se non colui che fu cagion di quelle, a voi, sagittaria infallibile, se ne viene questo misero amante saettato, piagato da gli sguardi suoi, anzi da i suoi animati strali, per ottenere da quelli oportuna medicina.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Oh, oh? Questa è buona da intendere. Signore, se io con uno sguardo v'ho ferito, e or con uno sguardo vi risano; però vi lascio. Ma per l'avenire guardatevi da gli sguardi miei saettatori.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Deh, per grazia, se ha la beltà nel volto, Diana nel petto, Minerva nella lingua, abbia la gentilezza nel cuore ancora. Fermisi alquanto, e m'ascolti. Ohimè, sarà aspide a così care preghiere? Oda, in grazia: ella stima d'avermi sanato, e più profonda hammi fatta nel cuore la piaga.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Mi si conceda, adunque, ch'io vada a studiare alquanto, per renderla sana, ond'io micidiale non abbia da esser da tutti reputata.<pb n="76"/></p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Eh non parta, mia vita, se di levarmi la vita forse non è vogliosa! Sappia che due parolette sole sole, ben che morto, mi potrebbero fare alzar la fronte dal sepolcro.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Signore, ben ch'io sia poco pratica in amore, nondimeno il mondo non è così fanciullo, né io così semplice, che non intenda e conosca chiaramente l'amorosa passione, che nel tacer della lingua efficacemente per gli occhi ragiona. Con tutto ciò, avend'io assai ben appreso, con l'esempio di molti infelici donne, quanto sia cosa misera il sottoporsi all'amoroso imperio, ho fatto ferma resoluzione di non voler di modo alcuno ricevere nel seno mio le sue fiamme; assicurandolo però che, quando altrimente fosse, io mi terrei fortunata d'aver il signor Fulgenzio per amante, poiché, e per costumi e per virtù e per costanza, lo reputai sempre degno d'esser da qualunque donna riamato. Né, di grazia, mi vada ponendo in dubio s'io fo bene, o no, a fuggire questo amore, poiché la cosa anderebbe in infinito, e a me non è lecito di stare tanto affacciata alla finestra, né tampoco lo star con uomini in simili ragionamenti.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Certo, signora, ch'io armava la lingua di mille pungentissime ragioni per diffender la causa mia, e farle conoscere come sia disdicevole ad anima gentile lo sdegnare l'amoroso giogo. Ma perché ella assolutamente in questo mi impone silenzio, tacerò, dicendo solo che per l'avenire penerò contento, benedicendo le lagrime, i sospiri, che per lei io spargo; poiché, benché ora amando non venga ad essere amato, vivo sicuro, almeno, che questo non mi accade per merito d'altro più fortunato rivale, ma per solo compiacimento della mia bella Prudenza, la quale forse ancor pentita un giorno e desiderosa d'abbandonar le selvatichezze di Diana, per seguir le dolcezze di Venere, anteponendomi a tutti gli altri, mi potrà fare per sempre felice.<pb n="77"/></p>
           </sp>
@@ -628,297 +701,297 @@
           <stage>
             <hi rend="sc">orazio, fulgenzio, prudenza</hi>
           </stage>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Ohimè, che vedo? e Prudenza mi ama? Voglio celarmi. Ohimè, ella mi ha scoperto! Io voglio minacciarla. E' ride? o misero, o me tradito.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Ah, mia signora, so ben perché ride! Ride perché vede che partir da lei io non so, ben che di partire più volte abbia fatto mostra; non è così?</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>È più che vero.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Ah traditrice!</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Facciasi più avanti, caro il mio signore.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Sì, signora, eccomi.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Ella ha detto a me co 'l gesto, voglio farlo.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Vuole forse che più mi faccia avanti?</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>No, no, signore, ella sta bene dove è. M'ode pure, non è così?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Sì signora, e anche intendeva colà dov'io era, ben ch'io fosse un poco più lontanetto.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Eh? Ho veduto ch'ella era in collera, e questo perché certo ella non aveva inteso. Ma ora stia un poco più attento, poiché l'esser vicino lo concede.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Voglio pur vedere che saprà dire.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Che sarà questo, Amore? Ohimè, tutto diletto sono, tutto gioia.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Caro signor Fulgenzio, risponda a colei della cui tanto brama udir le voci: già prima d'ora non s'è discoperta di Prudenza amatore, non è così?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>No, mia signora, poi ch'oggi solo, e in questo punto appunto, cortese commodità dal Cielo mi fu conceduta di richiederla dell'amor suo.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Pur sa ch'io risposi di non poterla amare.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>È verissimo, negar no'l posso.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>O me contento, errava, errava Amore.<pb n="78"/></p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Or si consoli, ché tanto ha potuto il merito suo, ch'io le giuro, per gli strali d'Amore, che solo vostra signorìa io amo.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Sì sì, mia vita, purtroppo il so.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Ohimè, che ascolto?</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Sì, mio cuore, sì, mia anima, che Prudenza, con matura prudenza, elesse ella sola d'amare.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Ohimè, che dalla dolcezza mi liquefaccio.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>O balordo, o cieco.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Signor Fulgenzio, perché più caro le sia l'amor mio, e la sua Prudenza, sappia che pur io sono amata.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Ben lo so. Ecco il tuo amatore.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Da altri che da me ell'è amata? Se non è Giove per novella Leda, se non è Pluto per più bella Proserpina, se non è Nettuno per più vezzosa Teti, egli è morto.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Giove non è, non è Pluto, non il Nettuno, poiché di questi così grandi amori meritevole non sono, ma un certo ganimeduccio spelatello, ch'io odio come odia ogni reo la morte. È appunto grande come vostra signorìa, ma non ha poi la grazia sua. Ha due occhi, come i vivaci occhi suoi, ma non sono poi così risplendenti e predatori come quelli, ch'io abbagliandomi vagheggio, fatta aquila amorosa. Ha una barbettina del color della sua, ma non è poi così beneaffettata, contesta e arricciata. Insomma, somiglia tutto il mio signore, eccetto che l'uno è tutto grazia e l'altro tutto disgrazia.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>O buono, o buono.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Gentilissima signora, s'è vero che nulla ad umile intercessore si nieghi, supplicola, mia speme, a far sì che<pb n="79"/> come costui con la solita arditezza sua le comparisce avanti, che da lei ancora sia discacciato con quelle parole, ch'ad un par suo più si convengono.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>S'io lo farò, altro appunto questo cuore non bramava, e per ora poi che intendo che tale è la sua brama ancora, altro non desidero se non di vederlo. Oh perché non è alla presenza mia e vostra signorìa in un cantoncino? perché non lo veggh'io? o come bene lo vorrei trattare! Oda, in grazia, come dir m'agradirebbe.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Ben ascolto.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Per udirla già sono fatto l'attenzione istessa.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Così parlar seco vorrei. Gentil uomo selvatico, tanto per l'appunto è meritevole del nome d'amante, quanto di gentil uomo, poiché nell'uno ell'è materia solo da essere odiato da tutte le donne, nell'altro suggetto da esser lapidato da tutti i gentiluomini. Or non vede come quegli abiti tanto gli piangono intorno, quanto un'aera rusticità nel volto gli ride? Deponeteli in grazia e ad una tanta disgrazia s'aggiunghi la zappa e non più tra cavalieri per le piazze spaciando si veda, ma fra i campi con istormo di villani zappando si sudi.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Buono, per mia fé.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>O come dice bene.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Soggiungerò poi: levatevi di qui furfantone affamato, ché ben so che fate l'amore solo con la mia dote, poi che con quella vi vorreste spoverire e disfamare.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Signora, ella non può dir meglio.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>E di che sorte.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Or che dice, non l'ho al presente così consolata, come poco fa io l'aveva sconsolata? Avverta, che non voglio che me lo dica con un sì solo, ma con un gesto affettuosissimo e amoroso.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Così vuole? Eccolo.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Un altro maggiore.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Eccone uno maggiore.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>E io pure l'immito.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Orsù, più non si parli. Le piace di farmi una grazia? Chini il capo.</p>
             <p>Oh, così bramo.<pb n="80"/> O misero, questo balordo non s'avede che con Orazio parlo e a lui mi godo di far fare il mattacino.</p>
             <p>Vorrei di più, poiché or ora l'ho pensato, che fra due ore ella facesse da me ritorno.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Signora io verrò.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Alzi la mano e mostri se vede, stando in istrada, il numero dell'ore che con le dita dalla finestra le addito.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Ecco io l'inalzo.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Ecco signora due dita, che dico a due ore.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Per mia fé, vostra signorìa l'ha intesa. O caro amante, o accorto signore pigli, per vita sua, per far più dolce questa dipartenza amorosa, questo amoroso bacio, ch'io le getto.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Oh com'è dolce.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Oh come l'ho caro, io lo ripongo nell'errario del mio cuore.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Pigli quest'altro.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>L'aspetto.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Precipiti or mai da quella bella mano.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Eccolo.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>O caro bacio.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>In vero, questo passa bene, ogni bacio, che da bella bocca baciatrice e baciata baciatore fosse. Pigli ancor lei, mia vita, questo, quanto umile, tanto amoroso e alato.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Il mio non il suo.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>O caro bacio, ti bacio.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Questo in vero è bene un segnalato favore. Pigli quest'altro ancora.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Questo, questo.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Questo lo ripongo nel seno.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>O baci fortunati.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>O balordone.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Cuor mio li fo riverenza.<pb n="81"/></p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Io lo stesso.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Io pure.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Addio mio signore.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Addio mia speme.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Addio, addio.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>O Fulgenzio, o Fulgenzio, che allegrezza è questa tua, che fortuna, quale stella benigna al tuo natale si dimostrò tanto lucente? Prudenza è la tua. Pàrtiti, fuggi, vola, e poi ritorna, correndo, volando, alle gioie, a i contenti, poiché tanti te ne dispensa oggi benignissimo Amore; ché in vero chi è talpa al suo bene, non si dee poi dolere s'alcuna volta divien Argo al suo male. Amor, tu movi il piede, tu meco sempre alle gioie assisti.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Vattene pure, tanto Argo senz'occhi, quanto talpa priva di luce. Fuggi, vola, che ben da te fugge ancora ogni gioia, ogni contento, ch'è a te vicino. Or credi sagacissima amante, prudentissima Prudenza, che imprudentissimo giovinaccio così bene ha burlato. Ben so che Orazio solo è quegli, ch'è prudentemente da Prudenza amato; ad Orazio è serbato ogni gusto, ogni piacere, che benigno Amore, nel regno suo, dispensi a fortunato amante. Ohimè che quasi, dalla dolcezza, pare ch'io stesso in me medesmo capir non possa! Tu parti omai, tu consumate le due ore ritorna. E per ubidir poscia a colei, alla quale dolce sarebbe l'ubidir gl'istessi dei, l'ali t'impenna a gli omeri, a i piedi. Oh che solazzo è stato il mio, dolce in ramemorare sì, ma via più dolce a cari amici in palesare.</p>
           </sp>
@@ -928,161 +1001,161 @@
           <stage>
             <hi rend="sc">succiola, alberto, facchini</hi>
           </stage>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Deh, di grazia, non mi date, messer Alberto, noia, non mi fate logorare il tempo col cicalar con voi, oh? Vo' non vedete quanti zanaioli ho meco carichi di polli, di<pb n="82"/> vitella, d'agnelli, d'arista, di salciccia, di tordi, di fegatelli, di migliacci, di peducci, di bassotti, di colombacci, di starne, di fagiani, di lepri, di caprioli, di gelatina, di raviggioli, di marciolini, di gobbi, di seleni d'ulive, di pignoli, di mandorle pelate e di finocchio forte? non vedete qui gli aitti carichi di grechi, di verdee e del vin di Chianti? non vedete quegli altri pure carichi di pentole, pentolini, schidoni, capi fuochi, gratelle, padelle e caldaie? Di grazia, non mi date più mattana, ché meno un tantolino posso istare più con voi. Egli è otta di manucare, più cinguettar non posso, iscusatemi.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>E perché io vi ho veduta in questo giorno con tanto insolito apparecchio, mosso mi sono a farvi richiesta di che far vogliate di cotanta roba. Vedete, non vi è la maggior cortesia che con vecchi esser cortese, costume già da gli antichi molto osservato.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Or sù, zanaioli, entratevene in quell'albergo, che testè sarò da voi.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O che siate per mille volte ben bene detta Succiola cortese. Or ditemi: e che tanto apparecchio è questo? per chi lo fate?</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Per chi? O càzzica, la fortuna a cotesta otta m'è venuta in casa, e tutta cotesta robba me ne ha servito il pizzicagnolo, che serve la corte qui del duca.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O Fortuna forfantissima, tanto è ch'io ti cerco, e tu sempre da me fuggi! Ma che fortuna è questa? come l'alloggi tu in casa?</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>O vo' siete (e perdonatemi) il bel scimunito! Credete forse che la fortuna mi sia venuta a cotest'otta in casa? Voglio dire che avendo in casa un prencipe di gran laude, con molta corte, con molt'oro, ho trovata la fortuna, che dorme in casa mia.</p>
             <p>O che avaraccio, adesso gli ho dato una stoccata.<pb n="83"/></p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>T'aveva pur troppo inteso, che ben so che sia Fortuna insieme e la volubiltà sua, tratta da quella ruota, ch'ella nella mano porta. Ma s'io la biasimai, s'io mi infinsi di non conoscerla, dissi solo per dimostrarti che giamai così cortese non la conversai, né così dispensatrice d'oro, poiché sempre verso me de' suoi tesori fu discortese e avara.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Eh? Voi dovereste pur amarla, poiché s'ella è avara, è vostra prossimana.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Or ne lasciamo questo; poiché 'l praticar troppo spesso con medesime persone, e il parlare troppo a lungo di medesime materie par che finalmente affastidisca.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Oh? Cotesta corda sapevo io bene che non faceva per il vostro ceterino! Bisogna che io dica il vero, se ve n'andasse bene il fegato, i' non so andar dietro a quelle moine, come vanno cotesti moieri, ch'oggi dì imbrogliano il mondo, e s'io lo sapessi fare, crediatemi pure che a cotest'otta il mio varrebbe più di quattro giuli gigliati.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Succiola certo, certo, che tu fa' bene a non essere imbrattata di cotesta pece; poiché è meglio con le cose vere offendere, che piacere lusingando. E certo che quelli che giornalmente lusingano sono uomini di pochissima fede, poiché amando non l'amico, ma più tosto la fortuna e la ricchezza dell'amico, spesse volte ad ultima rovina lo conducono; ed io per me quando fossi da necessità sospinto, vorrei più tosto abbattermi ne' corvi, che ne gli adulatori.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Signor Alberto, s'ho detto per offenderla, mi venga la rabbia, mi poss'io sfondolare! Or per non la tenere a bada,<pb n="84"/> sappia che dell'apparecchio, da quest'otta sino all'oscurare, ch'i' debbo far di vivere, ho avuto alla mano mille e cento scudi d'oro. Alla sfuggiasca intoppare in cotesta ventura, non è istato assai? non posso dire che di quadragesima io goda il Berlingaccio?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Certo che tu hai la luna in quintadecima.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>E si favella di istare non a settimane, ma a mesi in casa mia. Or guatisi un poco che sguazzare ha da esser cotesto mio!</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Do', che sento? O perché non poss'io vestirmi da sguattaro e stare in quella osteria a mangiare per nulla e avanzare tutti questi pasti, non solo io, ma la mia famigliola ancora, poiché non potrebbe tanto poco portare a casa, che in una volta sola non si portasse la provisione di tutta una grossa settimana.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Signor Alberto, vo' fate un gran cicalamento con esso voi. Volete voi alcuna cosa? Commandate, fate presto, poiché or ora io debbo andare dal calzolaio, dal fornaio, dal mugnaio, dal pecoraio, dal fornacciaio, dall'erbolaio, per iscarpe, per pane, per farina, per ricotta, per bicchieri e per erbaggi.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Di grazia, ancora non vi partite. Sappiate che, da me ragionando, io stava in forse di chiedervi un favore.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Oh? ch'indugiate? Comandatemi, ché vi sono ubrigata.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Chieder vi voleva di quell'ossa di capponi, di pavoni, di vitella, allesse, arrosto, scorci di pasticci, e così altre cosette da nulla; poiché sei cani levrieri mi sono stati mandati a donare e per lo viaggio hanno patito molto e sono secchi, secchi, secchi; ma sopra il tutto, non gli spolpate troppo, acciò che ci sia qualche cosetta intorno da piluccare.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>O che avarone, di sicuro vuol cotestui manucarli! Sono cani da giugnere? Oh come gli vo' bene! Dell'ossa tante darognene, che le sacca gl'empieronne.<pb n="85"/></p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O cortese Succiola vi ringrazio. E io mangierò la carne, e che forse non sarà buona? Dell'ossa de' polli, poi, farò de' flautini e de' quagliaruoli, e sottomano caveronne dinari. In somma, ogni poco remo spigne la barca, ogni poco aiuta e molti pochi fanno uno assai.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Fa un gran cinguettamento cotesto gocciolone da sé.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Oh s'io potessi con questo mezo farmi una buona pignatta di grasso, come buono sarebbe, per tutto questo anno; e che grasso e che elesirvite!</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Voglio stuccicarlo a cicalare.</p>
             <p>O signor Alberto, non la sminucciolate po' tanto da voi, sapete? E che domine pensate vo' di fare?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Io l'ho pensata ed è bellissima. Da me sono andato pensando d'esser grato a quella cortesia che far mi volete e voglio prestarvi perciò tutte le pentole, caldare, tegghie, piatti grandi e piatti piccioli, che di bisogno vi faranno nel cocinar a questo prencipe. Che ne dite, non è bene ad esser grato al benefizio ricevuto?</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>E di che sorte! Accetto il tutto. Che ben d'una marra i' meriterei nella collottola, quanto coteste cose i' rifiutassi! Renderognene poi com'è partito il signore e 'l tutto polito come specchi, vedete, perché nella politezza non voglio ballate, e quante vi sono serve fiorentine si disfiorentinino pure, che appo di me non vagliano un fico, un lupino.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O questo no, né mia figliola, né le fanti di casa così non l'intenderebbono. Mandate pure il tutto di pasto in pasto, e così sporco e unto, ché non importa.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Così sudicio? Oh non mi state a dar mattana, ché cotesto non farò io giamai.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Fermatevi, ché non sapete il tutto. Giuramento hanno le donne di casa di non mai dar da lavare i loro piatti ad alcuno, poi che stimano, queste sciocche, che altri non fosse<pb n="86"/> bastante di renderli lavando sì belli, come elle stesse fanno. Così voglio; in somma, non dite altro.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Vo' m'andate tanto sermonando nel capo, che per non vi parer perfidiosa e astiosa, i' mi contento.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Vi darò di più i candellieri. E pur quelli potrete di volta in volta mandarli, e ben che vi fosse il sego di quattro dita alto, non importa; i candellieri non sono fatti per questo? Eh, madonna Succiola, bisogna far servizio alle genti e non aver l'avarizia ficcata nell'ossa.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Or poi, ch'io la veggo tanto amorevole, non voglio tacervi quello che in casa cotesto principe mi disse. Sappia che vuole un palazzo ad affitto; or che ho pensato?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Dillo, di grazia.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Che vostra signorìa gli dia il suo, che ve lo potrebbe tutto fornire e donarvi poi l'addobbamento e tutte le massarizie.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Datemi la mano.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Eccovi la mano.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Io mi contento, ho poca famiglia, retorerommi in ogni piccolo cantoncino e così accomoderò questo signore. Oh che ventura inaspettata, oh che bel porre in avanzo! Dov'è? Battete, battete, battete! Chiamatelo, in grazia, madonna Succiola mia cara.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>O che cotennone!</p>
             <p>Adesso io picchio, perché fa istare chiuse tutte le porte, vedete, per lo sospetto. O di casa ? o da l'osteria? I' son Succiola. Mi vedete voi, signore?</p>
@@ -1093,135 +1166,135 @@
           <stage>
             <hi rend="sc">rampino, alberto, succiola</hi>
           </stage>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Madonna Succiola? Affé che avete mandata una bellissima robba.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Fo riverenza a vostra signoria, signor maggior domo. Sono istata, vedete, per tutto, per aver del buono.<pb n="87"/></p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Ah Succiola, chi è colui al quale hai fatto così profonda inchinata?</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>E non mi state a stranare! Chi è cotesto, eh? È 'l maggior domo, il più caro, che abbia il signore.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Or sì che bisogna ch'io rida.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>O vedi, che testè gli è tocco la fregola del ridere! Che domine, non vi chetate?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Ch'io mi cheti eh? Bisogna veder se si può, eh, eh, eh.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Domine, acchetisi cotesto arrovellato.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>O madonna Succiola, e di che ride quel vecchio fratello di Caronte? Ride forse perché vede in panni vili persona nobile? Lascia un poco ch'io li parli. O grimo, che canzonamento era quello che vostr'odene faceva con la taschiera?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Non posso più, eh, eh, eh, ohimè, mi piscio addosso.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Che tanto ridere? O Succiola, è un guasco costui, sì o no? Perché mi vien voglia di darli un pugno ne i merli, vedi!</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Gettate via questa lingua, signor maggior domo, perch'io non l'intendo punto, punto. E che forse m'uccellate voi ?</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Dico s'è gentiluomo.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Così tutti, e 'l principale di cotesti terrazzani pesaresi.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Sì? O lascia fare a me. Signore, ben che toccar dovrebbe al gentiluomo della città sempre ad essere il primo nell'usar termini cortesi verso il gentiluomo forestiero, nondimeno, il primo voglio essere io, e con ragione, perché veramente il vedermi in questi panni non ben corrisponde all'udir ch'io sia gentiluomo.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Certo che all'abito io non l'aveva per tale. Ah? Succiola, non posso tenermi dalle risa! Scoppio, scoppio.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Possiate voi scoppiare da dovero! O che spiritato.<pb n="88"/></p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Ma in che linguaggio mi parlò prima vo' signorìa?</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>In piccardo.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Stia pur nel suo paese, perché mentre favellerà in questo linguaggio non sarà intesa al sicuro in queste parti.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Mio signore, ho molte lingue, ond'ha che s'io sono in Francia, parlo in lingua francesca, se in Ispagna in ispagnola, e in Isvevia in tedesca. In somma se in Argo mi trovo sono argolico, se in Candia candito; se in Barberia punico sono; se in Pisaro pisaureo sembro; e se in Piccardia tutto piccardo mi si vede.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>In fine quel parlare piccardo è 'l più goloso di tutti.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Ma che vorrebbe, vostra signorìa, forse qualche grazia dal nostro prencipe?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Succiola, sai tu che grazia vorrei da questo suo prencipe? che comandasse a questo suo maggiordomo che quando parla meco tanto non mi s'avicinasse, poich'io temo che tutto m'impidocchi.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Sù sù, chiedete! Non vi consigliate tanto con Succiola. Succiola ?</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Signore.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Non vuol già cosa alcuna, eh?</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Maisì. Ditegnelo. O vo' siete il bello scotennato, non si sta così a mano spenzolate. Vo' mi fate infantastichire se dir ve la debbo. Vedete, ancor vi pensa! O cotestui è 'l bel buaccio, non vo' dir briccone. Lo vo' dir io. Signore, e' vi vorebbe dare per albergo il suo palazzo.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Eh? Ch'io scherzava seco illustrissimo e stracciosissimo, dico e straillustrissimo, mio signore.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Or sù, vedo ben io che quel gentiluomo sta in dubbio della mia nobiltà, e vi è più di quella dell'illustrissimo ed<pb n="89"/> eccellentissimo mio prencipe. Dite, se siete uomo d'onore non m'avete voi per un guidone? Ditelo, che non m'addiro, ditelo, che l'ho per favore.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Ma non voglio giamai per bugie andare a casa del diavolo. È pur troppo il vero, e ogni losco, mirandovi, tale vi stimerebbe.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Ancora de gli altri sono di questo parere, ma aspettate.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Che dite vo' voi, non siete ora un uccellaccio?</p>
           </sp>
@@ -1229,381 +1302,381 @@
         <div type="scene">
           <head rend="italic">SCENA SETTIMA</head>
           <stage><hi rend="sc">nottola, grillo</hi>, <hi rend="italic">doi</hi><hi rend="sc">paggi, rampino, alberto, succiola</hi></stage>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Olà, olà! a chi dich'io? canaglia, canaglia, venitemi a slacciare or ora le calce! presto, presto, ché mi si è mosso il corpo!</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Son qui, son qui, signore.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Vedete, signore, questo, che in casa parla, è il principe tanto glorioso.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Furfante, adesso se' venuto, eh?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Vostra signorìa s'è cacato addosso, non è così, signore?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Non lo senti? Piglia qua, ché ti dono questi calzoni.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>In somma signore, egli è il più liberale uomo del mondo.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>E che bei doni profumati.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Da' qua quegli altri bragoni.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Eccoli signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>E pure in questi cacai l'altro giorno ancora! To', non li voglio.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Signor maggiordomo, dicami, in grazia, come s'addimanda questo prencipe? il prencipe cacone?</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Che cacone? Il suo nome non si può dire; bastivi ch'è detto Nottola. Oh, vedete che i paggi vengono, verrà anch'egli del sicuro.<pb n="90"/></p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Oh che servitù, oh che paggi, oh che ridicolose cose, atte a far ridere Eraclito e a far dire ad Arpocrate: «Furfantoni andate alla galea».</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Ponete colà quella seggiola. State voi duo, uno di qua, uno di là, con quelle due ventaiole in mano. Cavatevi que' capelli e tutti siate riverenti, ché ben sapete che il signore di voi m'ha dichiarato il maggiore.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Grillo?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Mio signore, che commanda vostra signorìa?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Si onorano fra di loro, questa canaglia, ch'è uno spasso.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Vuole il signore venire al fresco?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Sì signore, e io lo vado or ora a tôrre. E voi, galant'uomo, che domandate? Qui non ci stanno scrocchi, vedete?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Sì, perché da voi soli volete occupare il luogo. O che furbetto.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Che modo di parlare è questo, con gentiluomini?</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Fermati Grillo.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Uh? una guanciata? Férmati, stàccati.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Furbo, pugna nel ventre? morsiconi nelle mani?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Furbaccio.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Sta' fermo, cheti.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Fermati, serpentello.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Alberto, avertite, ché cotesta è una razza di nobiltà molto fantastica, vedete? Vi daranno delle busse e ve le terrete.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Tu se' un fanciullo, e questo basta.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Te ne darò un'altra frotta! Va', impara a conoscere figli di cavalieri.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Che domine avete vo' nel gozzo? Mi fate venir voglia a me ancora di sgozzarvi, con un sorgozzo. Siete ben zotico daddovero.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Cheti, cheti. Ecco il signore.<pb n="91"/></p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Mo che foggia d'uomo è questa? Io sono confuso.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Maggiordomo, olà?</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Mio prencipe.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Chi è stato quello che ha fatto rumore?</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Grillo.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Grillo? Vien qua. Tu, paggio, lèvelo un po' a cavallo.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O questo è 'l pazzo umore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Paggio, tu pure gli disciogli le stringhe delle calze.</p>
           </sp>
-          <sp>
+          <sp who="#altro_paggio">
             <speaker><emph rend="sc">altro paggio</emph>.</speaker>
             <p>Ecco signore.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Signore, domando all'eccellenza vostra perdono, o, se almeno perdonar non mi vuole, non comporti che mi si levino le calze, poi ch'io ho un poco di rogna su le natiche.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Furfante, né per questo perdonar ti voglio. Dislacciatelo pure. Oh? Ora che hai le calze su le calcagna, alzolo a cavallo.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Uh, uh, uh.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Eh? Perdonategliela, signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>E chi è costui che commanda a prìncipi? Bastonatelo.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Mio signore, son servo suo anch'io, in grazia, non tanto male.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>In cervello, corpo di santanulla, allerta, signor Alberto, che vi so dire che testè vi siete accozzato bene.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Incomincio aver paura di questa bestia, io.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Or sù, perché vedo che pure a Succiola dispiace ch'io faccia staffilar Grillo, gli perdono.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>O che non possiate vo' meno morto fracidire, i' vi ringrazio, e la mano vi bascio.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Datemi da sedere.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Fatevi in là, bricconi, ch'io vo' esser quella. Fatti in là tu, pecorone, se non, con un sputo tutto ti schicchero.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O Succiola galante.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O con che gravità siede.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Madonna Succiola, e che diavolo di puzzore è questo ch'è per questa contrada? Pigliate qua questo borsellino. Andate a comperar venti secchi d'acqua di cedro e venti altri d'acqua rosa, e due volte al giorno, con iscope di mortella fiorita e di gelsomini di Spagna, fate che tutta questa contrada sia spazzata.<pb n="92"/></p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O che sento! Al sicuro debbe aver quella gobba non d'oro, ma di diamanti e di carbonchi.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Maggiordomo, queste non sono ventaiole da pari nostri. Che si ponghino or ora quattro su le poste, con cento milla scudi per uno, perché voglio che si trovi la Fenice, quel bell'uccellino, che tanto si nomina, e, ritrovato, far di modo ch'io abbia le sue ale e con quelle mi si faccia vento. Anzi, i manichi di queste ventaiole voglio che siano di duo pezzi di grosissimo rubino, che ben molti honne nel mio tesoro.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Or che dite? Adesso è 'l tempo di levarsi la zacchera alla veste? Oh sennuccio mio caro, o principuccio mio bello.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Sta ferma pazzarella, tieni a te le mani! Se te l'ho da dire, mi paiono scherzi e novelle queste sue.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Che canta favole? che studio vogliato? Anch'io lo credeva.</p>
             <p>Eccellentissimo signore, tanto spiando andai, che il palazzo ritrovai alla fine.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Sì?</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>E cotesto messere n'è il padrone. Fatevi innanzi. Uh?</p>
             <p>Che omaccio tondo, ci vogliono e' pungoli! o che sguaiato.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>È vero, signore, io ho il palazzo.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Piano, non vi accostate tanto, fatevi indietro duo gran passi.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Ecco, signore, uno e dua, a quest'altro passo a rivedersi in piazza.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Saido, saido, Alberto.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Mastro di casa?</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Signore?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Cercategli un poco addosso.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Ecco, lo fo, signore. State fermo, messere.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>E perché questo a me, signore?<pb n="93"/></p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Piano, piano, non v'alterate! Abbiamo nemicizia e vogliamo a chi parla con noi sia guardato addosso.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Non ha ferro micidiale alcuno, signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Messere, io non tratterò con voi di prezzo, ma con doni e favori. Accostatevi, ché vi diamo l'auttorità.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Eccomi avanti, ch'io m'avvicini più?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Sì, più ancora. Ancora, ancora. Ora inginocchiatevi qui da me.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Io voglio vederne il fine. Eccomi inginocchiato.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Chinate il collo.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Succiola ?</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Olà?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Che questo non fosse il boia. Eccolo chino.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Vi getto al collo questa catena di cinquecento scudi d'oro.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Or che dite, non siete ora un baccellone? Bisogna ch'i' ve lo dica, son libera vedete.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Signore, d'ogni considerazione cattiva, che tante state sono, che di vostra signorìa ho fatto, le ne chiedo umilissimo perdono.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Orsù, che vediamo il palazzo. E pregate il Cielo che ne piaccia, perché lo potressimo volere in dono.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Il Cielo no'l voglia! Ohimè, questa catena mi tira giù il collo. Ma caro signore, perché andare così in abiti vili? Perdoni, se tanto si ricerca.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Eh? Volete troppo. Vi darò delle pugnalate, io!</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Mi perdoni, signore, se troppo ho osato.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Le sue grandi nemicizie non comportano che s'intendino cotai fatti. Non vedete com'è in collera?</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Signor Alberto, l'avete errata cotesta fiata. Che domine vi far andar cercando se per via di lardo o di cascio va il topo alla trappola?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Or via, fatemi vedere il palazzo, ché m'è passata la collera.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Sì signore è qui. Or ora gli lo fo vedere.<pb n="94"/></p>
           </sp>
@@ -1613,214 +1686,214 @@
           <stage>
             <hi rend="sc">prudenza, nottola, alberto, rampino, succiola grillo, paggio, paggi</hi>
           </stage>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>E tanto, signor padre, ella sta a tornarsene a casa? Sa pure ch'io sono tanto paurosa che niente più!</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Poveruccia! Come vede un uomo, ella debbe aver paura che subito le cada addosso, non è così?</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Sì, per certo, ma che fa con questi scrocchi? Entriamo in casa, ch'è vergogna. Uh? Che gentaglia!</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Cheta, cheta figliola.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Che credete (dico a voi) ch'oggi sia il dì de' morti?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Cheta dico, in buon punto, quegli è un prencipe grandissimo.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>O poveri prìncipi, a che passo sono condotti, passo di compassione invero.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Meser Alberto?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Vengo signore, adesso, adesso. Questi è principe, e hollo tolto a star in casa nostra.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>In casa nostra? Signor padre, signor padre, si vuol far rider dietro, eh? che umore è questo suo?</p>
             <p>Scrocconacci, andate alla mal'ora, m'intendete? con chi parlo?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Taci, taci, taci, ohimè tu vuoi che m'amazzi al sicuro.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>O poveretta voi! Scrocchi a i prìncipi, eh? O cicaloncella de' cianciarolucci.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Eh? Di grazia, tendete a i fatti vostri, chiacchiarone sboccato.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Giovinetta, vi scusiamo. Ma, affé da principe sconosciuto, che, se non foste così bella, vorrei che vi ricordaste di me.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Do' s'io mi cavo!</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Che fai? Chiudi quella bocca, o miserissima te.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Uh? Scimunitaccia.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Alberto, chi è questa giovinaccia, anzi questa Marfisa bizarra?<pb n="95"/></p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>È mia figlia, signore, e serva sua.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Vostra figlia? Oh! Mi accosterò.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Via, moviti, vallo ad incontrare, va' a farle inchino.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>O questo non farò io giamai, levimisi più tosto la vita.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Lasciate fare a me, ché tocca sempre al cavaliere a riverir la dama. Signora, vi fo riverenza e di più vi bacio.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Signor padre, e che dite? e che umore è questo? Affé, affé, che mi farete sdegnare da dovero.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>È umor di principe, cara figliola; che vuoi tu farci ?</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Vi dico che andate a fare i fatti vostri. E tu in particolare, o gobbaccio poltrone.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Signor Alberto, io sono di razza di francese, e ho il costume nell'ossa di baciar le femmine. Or pigliate questa catenuccia di diamanti, con questo gioiello di settanta libre, gettateglielo al collo.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Oh come traluce, caro signor padre, com'è bello, o come allegra sono!</p>
             <p>Signore, con le ginocchia quasi a terra le chiedo perdono d'ogni atto, d'ogni parola, che offeso l'avesse.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Sia perdonato. Maggiordomo, andate per tutto il nostro tesoro, e di quei primi argenti, ch'io vi mostrai, se ne faccia dono a questa signora.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Succiola, e voi, tutti venite meco.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Andatevene, ch'oggi mai per cotesta liberalità i' son fatta balorda e gli occhi io straluno.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Signor Alberto, quanto ora far vogliamo è poco rispetto quello che pur far vorremo. E perché sappiate il tutto: le nemicizie, ch'io ho con Francia e con Ispagna, mi fanno andare così, godendomi di visitare i luoghi de' nemici, per saper poi che esercito, che alteglierìa dovrò movere contro queste città per isfondamentarle. Voglio però mutarmi d'abiti; ditemi, sonovi Ebrei in questa città di Pesaro?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Molti ve ne sono, signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Sì? Or fate che venghino cinquanta o sessanta Ebrei, con nobilissimi e superbissimi panni per me e per la mia<pb n="96"/> famiglia: in somma robba da spendere per ora due centinara di migliaia di doble.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Signor padre, che sento?</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Signore, ecco qua il tesoro, in mille fardelli vilissimi sepolto, ed ecco l'argenteria, che nel primo fardello che si sciolse noi trovammo.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Mettete colà a' piedi suoi tutto quello argento, o così. Signora Prudenza, tutto quello argento, che raccogliendo da terra potrete portare in casa, tutto è vostro, tutto io vi dono.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Figlia, ingégnati di tôrlo tutto. Fatti larga d'avanti.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>O come pesa, o quante belle cose! Ohimè, che non posso più tenere.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Dite, signora, non vi duole in questa occasione di non aver cento braccia, per non lasciare quel rimanente d'argentaria in terra?</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Certo sì, signore.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Oh come averei caro, ch'ella fosse un Gige, un Briareo.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Orsù, voi Alberto, in vece sua, pigliate il rimanente, ch'io ve lo dono.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Corpo di sanpuccio, o cotesto è bene un caso da rescitare in iscena, per fare istuppire la brigata.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Taccia pure, signore, chi più al mondo ebbe di generoso il nome, poi che pareggiare non si può la nobiltà del vostro sangue, né la liberalità della vostra mano.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Bene bene, alfine, voi nasceste per esser solo di me lodatore e io per esser solo di voi guiderdonatore. Seguitatemi, paggi, caminate voi altri! Signori, datemi la mano in mano, ch'io come se ballassi un passo e mezo movo il passo.<pb n="97"/></p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Ecco la mano, e con la mano la fede d'esserle umilissima e fida serva.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O come questo atto di umiliazione piace a noi altri prìncipi!</p>
             <p>Avete la grazia nostra, entriamo.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O me felice.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Or che dire? Vi si potrà oggi più parlare? In somma Fortuna e' dormi. Sù, bricconcelli, entrate tutti meco.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Eccoci, eccoci, entrate.</p>
           </sp>
-          <sp>
+          <sp who="#cicala">
             <speaker><emph rend="sc">cicala</emph>.</speaker>
             <p>Entrate pur, che vi seguitiamo, io che Cicala sono per assordarvi, e questo ch'è Grillo, per trovare il buco della cucina.<pb n="98"/></p>
           </sp>
@@ -1833,7 +1906,7 @@
           <stage>
             <hi rend="sc">orazio</hi>
           </stage>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>O come bene disse il saggio, quando in queste voci proruppe, cioè, che solo l'amante è quegli che meglio sa misurare i giorni e l'ore d'ogni altro vivente. E io lo provo, poiché non credo che tempo alcuno sia passato, ch'io co' miei sospiri prima non le abbia dato il moto; né ora, che prima non le abbia dato il colpo con il cuore. O felicissimo Orazio, servo fatto d'Amore, di quell'alato dio che sforza il tutto, che vince gli uomini e gli dei. Ben del tuo gran valore, o picciolo nume, segno manifesto ne danno le antiche carte e narrano come alle care fiamme delle tue facelle si rendessero ubbidienti Giove, Marte, Apollo, Mercurio, e la tua bellissima madre. E che altro vogliono dinotare l'ali tue, se non che in ogni parte tu voli, tu saetti, e tu mostri l'estranio valore delle pargolette sì, ma grandi, forze tue? Dolce fuoco, e possente, poiché nel profondo e salso mare e nelle dolci e limpide acque, le marine deitadi provano il caldo loro, o quanta allegrezza e dolcezza porgono i pesci all'acque amorosamente guizzando, quanta gioia i vaghi e dipinti augelletti, quando tra le verdi frondi, di ramo in ramo volando, riempiono l'aere d'amorosi accenti. Ecco in un olmo giocar baciandosi innamorate le semplici colombe e le caste<pb n="99"/> tortorelle. Chi dir puote i cotanti beni, i cotanti vivaci effetti, che da te derivano? Chi vinto avrebbe il Toro, il Drago, Anteo, Cacco, i Centauri, Gerione, il leon Nemeo, l'Arpìe, l'erimanto Cinghiale, Acheloo, Diomede, Bussiti e altri mostri, se tu, trionfante dio, non avessi delle bellezze d'Alchemena acceso Giove, dal cui dolce congiungimento nacque il famoso e invitto Ercole, de' mostri domatore e vincitore. In somma, in questo gran mare per trovare il lido, concludi che quanto ha la terra, il mare, e quanto nel grembo porta di bello il cielo, opra è del bellissimo Amore. Non consumar più il tempo, o Orazio, in lodare questo arciero infallibile, benché altra cagione tu ne abbia. Serba, serba il profluvio delle grazie all'ora quando goduto avrai della tua bella Prudenza, della quale ben sai che è espressa voglia, consumate le due ore, a lei ritorni. Eccoti apunto soletto, come soletto esser debbe amante, ecco spopulate le contrade, l'ora essendo, che ogn'uomo co'l cibo nudrimento a sé medesmo porga. Vedi che vuole, che agevole le sarà il dirtelo, l'importelo, poiché tale ordine di parlarti dato non l'avrebbe se di non poterti parlare ella avesse saputo. O dalla casa?</p>
           </sp>
@@ -1843,103 +1916,103 @@
           <stage>
             <hi rend="sc">prudenza, orazio, fulgenzio</hi>
           </stage>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Chi è là? chi batte?</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Orazio suo, mia signora, il suo servo.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>O mio caro Orazio, o esempio di fedeltà inaudita! Sia per mille volte il ben venuto colui, per lo quale cara m'è quest'aria e questo cielo.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>O mia cara Prudenza, o vero seggio della beltade e d'amore! Pur ella sia per infinite volte la ben trovata, come per infinite volte per lei in istato di somma felicità Orazio si trova.<pb n="100"/></p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Taccia pur colui, che scrisse che la fede, il sonno e il vento cose fallaci erano, poi che la fede, che in Orazio è sempre stabile, fa chiaro conoscere che la fede in vero amatore fonda le radici, come robusta quercia in altissimo monte.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Taccia pur per sempre colui che disse che soavissima e gioconda cosa era il guardare la donna bella, ma il toccarla pericolosissima, poiché Prudenza nel mirarla porge contento a gli occhi, ma provasi poi tutto il contento che nel regno d'Amore gustar si puote, se nel seno la stringi; come sper'io di fare in breve, se dalla sua pietà non mi verrà un tanto bene vietato.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Sarà di sicuro, e sarà in breve; poiché assai più caro mi fia che 'l mio Orazio mi cinga al seno delle sue braccia amoroso monile, che se quello cinto mi fosse dalle più lucide e preziose gemme dell'Oriente.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Ohimè, che veggio? Voglio qui in disparte farmi osservatore d'ogni parola, d'ogni atto.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Certo mio bene, che debbo io fare, che m'impone, onde Prudenza rimanga ubbidita, servita, e quello sciocco di Fulgenzio burlato?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>O traditrice, o traditore.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>L'ordine è questo; e credami pure, che tale già io non istimava ch'esser dovesse.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Perché non tale?</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Perché dall'avere mio padre a caso ricettato un principe in casa, ho preso anch'io partito novo, di quanto intenderà.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Di' pur, ché sordo non sarò per isturbarti.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Impose questo principe che per vestir sé medesmo, e tutta la sua famiglia, si ritrovassero molti Ebrei, che carichi di belle vestimenta qui a casa venissero. Ora intendo che, per goder d'amore, ella non si sdegni di fingere uno di questi Ebrei; così ella se ne verrà in casa, e, mentre mio padre e questo principe e altri intenti saranno al vestirsi, e noi prontissimi allo spogliarsi (per dir così), in qualche parte sicura godremmo de' nostri amori, i quali tanto più saranno dolci e grati, quanto più erano disperati.<pb n="101"/></p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Certo, che sola questa invenzione mi poteva far degno di ricevere così cari doni, poiché più è custodita questa sua entrata, che da Cerbero custodita non è la porta d'Averno; o vero le poma d'oro dall'esperido Dragone. Pur sa che più volte holla al padre suo fatta chiedere per mia signora e consorte, ma egli avendo più risguardo alla molta mia povertà, che alla molta nobiltà mia, sempre hammi fatto intendere che per falliti non è sua figlia.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Né sarà di sicuro.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Or sia ricco d'inganni Orazio tanto, quanto è povero di beni di fortuna e abbondantissimo di nobiltade. Ingannisi pur questo Mida, e quel ganimeduccio di Fulgenzio, cui credendo meco di parlare (goffo), non s'avedeva ch'amendue solazzar faceva, non a lui, ma a lei essendo tutti indirizzati i concetti del mio cuore, dell'anima mia.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Ben goffo da vero io fui, nol nego.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>E forse che non istringeva que' baci al seno? e forse che i baci non ribaciava? Ma il pazzo stringeva il vento e l'aria baciava; poiché solo al cielo della sua bella bocca rapidamente con i baci colà volava la innamorata e baciatrice anima mia.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>O fidati poi di donne.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Mia vita, perché dar tempo al tempo non si dee, quando a fine trar si vuole cosa di grande affare, da lei partendomi, m'anderò a porre nell'abito ch'ella cotanto brama.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Parta, mio cuore, poiché 'l tempo ha per costume di non ritornare giamai, se una sol volta da noi fugge. Addio mio corpo, addio mio spirito, addio mio cuore, addio mia ala, addio.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Pur, mio bene, baciandole quelle belle labra, che servono a me per duo rubini animati, per que' duo oli che sono il fondamento della vita mia, le dico partendo addio, ma però addio d'un breve addio.<pb n="102"/></p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Ah Prudenza imprudente, or t'avedrai, se così facile ti sarà il beffar il misero Fulgenzio! Tu, tu sarai la schernita, tu l'ingannata! E che stimi forse che non saprò io tanto ingannatore ingannare, quanto tu ingannatrice ingannasti? O fortuna, ben dir poss'io che se' come il mare, ch'ora in calma prometti gioie, or turbato ministri noie. Anzi, che per questa instabilità tua dir possiamo ch'a noi intervenga come al marinaro nel mare del vento, perché sì come ora l'ha secondo e ora del tutto contrario, così ancor tu a' pensieri umani or se' seconda, or tutta aversa. Però sì come quegli spiega la vela ove spira il buon vento, quello ricevendo or a pioggia, or ad orza e superando ogni duro incontro in porto si ricovra, così parimente, quando l'uomo ha la fortuna amica, pigliare la dee, e la vela concederle de i desiri suoi; ma se contraria spira, debbe raccôrre il lino, e con tal forza all'empito suo opporsi, e al suo furore, che quantunque ella lo combatta sempre, egli contro di lei si mostri fermo e costante, e cerchi mal suo grado andare al porto al quale ha già drizzato il suo pensiero. Animo, ardire e core, che colà molta lode s'acquista dove l'arditezza è molta! Io, io quegli sarò che, da ebreo vestito, quello rapirò che conceder volevi ad Orazio! Io già lo precorro, io già primo la soglia, già nelle braccia ti stringo, già di nemica ti fo amante! Duolmi d'usar questo termine, e vorrei certo sì chiederti al padre, ma so che se tu se' stata negata in consorte ad Orazio, per esser povero, ch'a me conceduta meno saresti, pur gentiluomo poverissimo anch'io essendo. Or sù.</p>
             <p>
@@ -1951,91 +2024,91 @@
         <div type="scene">
           <head rend="italic">SCENA TERZA</head>
           <stage><hi rend="sc">schiavetto</hi>, <hi rend="italic">e</hi><hi rend="sc">rondone</hi></stage>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>O Rondone, Rondone, si suol dire che 'l rondone è uccello inestancabile, sempre per l'aria agitandosi; ma tu hai il nome di Rondone e il volo da poltrone, e stracco se', per così poco viaggio? Da Fano a Pesaro v'è pur molto poco.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Tu vuoi la burla, pare a me. Ti dico che ho nome Rondone, ma non Rozzone, o cavalaccio da soma! Tu vuoi ch'io porti questo cofanetto de gl'imbonimenti su le spalle, e mi pesa; e quel camminar dietro alla marina per quella arena, oltre ch'io sono zoppo, m'ha segate le gambe. E poi non ho altro che questa camisioletta rossa su la carne, e il vento mi s'è ficcato così nelle coste, che ti so dire che per ismaltirlo ci vorranno molti sospiri selvatichi.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Pur io sono vestito da schiavo, come te, ben che un poco più nobilmente, e tanto il vento non m'ha traffitto.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Oh ? Sta' cheto, ch'io voglio questa sera toccar tanti dinari, che voglio che i fazzoletti, tirati e annodati, facciano parer l'aere ingombrato di neve, quando al verno ella cade dal cielo a lenzuola stracciate.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>O che Rondone astuto! E come vuoi fare?</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Io voglio avere un poco di polvere in un cartoccino e voglio dire (con i nostri giuramenti soliti) che quella bevuta fa tirar coreggie; e soggiongendo dirò: «Signori, voglio che l'esperienza parli!». Ciò detto, io la berrò. Ora, perch'io sono pregno di quel vento preso dietro alla marina, e che le coreggie nel (voi mi intendete) mi fanno come i fagioli nella pentola quando bollono, non così tosto, ch'io l'averò bevuta, comincieranno a voler uscire. Io allora darò loro licenza e,<pb n="104"/> con riverenza, a tempo a tempo, e ad una ad una, e ora a dua a dua, e anche a tre a tre, darò a credere d'avere una mano di moschettieri nel culo.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Affé, già sento che la polvere del moschetto puzza.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Eh? Tu t'inganni! Voleva ben io scaricare, ma la canna non ha preso fuoco, è stato solo il polverino. Ma odi, di grazia: allora, dico, che gli ascoltanti sentiranno l'effetto e che testimonianza piena n'avranno da duo sensi principali, naso e orecchie, allora, dico, alcuno non sarà che crepando dalle risa non annodi il fazzoletto per comperarne.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>O caro Rondone, se tu con le tue molte facezie non mi apportassi qualche gusto, io sarei ormai per tanto disperarmi divenuto la disperazione istessa.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Or non sai qual mezo senza di me è bastante a trar la disperazione da i cuori disperati? Tre braccia di fune attaccato ad un trave, legatoselo al collo e tirar tanto, che la disperazione, non potendo di sopra, di sotto se n'esca. E sai come io ti posso servire? Guarda questo staffile di canapo, è la vera triacca per ogni goloso; e io per amor tuo il boia con ogni maggior delicatezza ti prometto di fare.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>In vero, ch'altro che di carnefice tu non hai aspetto.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Saper bisogna ancora che far torto non posso al mio parentado, nel quale discende per trentasei gradi questo ordine di boia, e per dirtela, mio padre era boia, e boia sono stati tutti i miei signori fratelli maggiori.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Per vita mia, che s'io ti credesi tale, che in oltre il caricarti di villanìe, vorrei con questa freccia passarti da un canto all'altro.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Dico che parlo su'l saldo, e aggiungo che più volte, per non mi domenticare l'ufficio, m'è saltato chiribizzo d'appiccarti! Oh polastrotto da essere empiuto, si vede bene che tu le tò su, come l'uomo te l'appresenta! Io burlo, io burlo, so che tu l'avevi creduto, eh?<pb n="105"/></p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Piano, piano, parla con la lingua, e non mi toccar il volto con la mano.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Uh? Salvaticotto senza pelo, e che, avete paura?</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Non ho paura, ma non istà bene.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Lasciamo questo, poiché vuoi così; non tocchiamo, ma parliamo. Dimmi un poco, e quando ti vuoi risolvere di dormir meco? Sono tanto pauroso, ch'ogni topo mi sgomenta.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>O che sempliciotto! Ditemi, in grazia, e' vi pare, o 'l mio furfantone, ch'io debba dormir con voi?</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Ma caro signor gentiluomo senza giuppone, vi dirò: s'io parlo in questa guisa, lo fo solo perché, quando arriviamo tardi a gli alloggiamenti e che perciò sono piene le letta, o che uno per lo meno vòto si ritrova, subito dite: Rondone alla paglia! Vi arricordo che anch'io sono di carne tenerella, vedete.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Rondone, me n'avvedo, questo è uno andare in infinito. Qui v'è una osteria, e dal di fuori mostra d'essere nel di dentro molto capace; qui senz'altro si averà un buon letto per uno, stattene allegro.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Oh? Adesso discorete bene, mentre ne' riposi così mi chiamate, come nelle fatiche. O dall'osteria! olà, o dall'osteria, dico!</p>
           </sp>
@@ -2045,143 +2118,143 @@
           <stage>
             <hi rend="sc">succiola, schiavetto, rondone</hi>
           </stage>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Oh? che domine sarà cotesto sguaiato? Poss'io morire dalle formiche manucata, s'in quest'otta i' non fo dir di mene! Oh? che gente è cotesta?</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>O questa è una bella massarotta! Mi piace, da quello ch'io sono.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Saiviastrella col sale, cotesto è un bel colombaccio, non so se vada cercando la fava. Ohimène, come tutta mi ringalluzzo.<pb n="106"/></p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Uh uh? La cavalaccia ha veduta la biada, non è così, monna Ghita dalle poppe sudice?</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Do', zoppo spiritato, che ti sia fritto il fegato! Che ha' tu detto? di', sù, scarpello da intagliare i piè di' bue.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Meglio era dire, da intagliare i piè di vacca, che con i vostri mi davi occasione di farmi eterno.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>O bel contrasto.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Sa' tu, che se non chiudi quella boccaccia fetida che ci cacherò dentro?</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Do', visaccio da venire a capo, che sì che sì, che ti do il taglio con le pugna?</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Or sù, non più, dich'io!</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Eh? Lasciate pur che m'uccelli. Vedete, egli l'ha errata a cotesta fiata. I' son da Firenze e ho la lingua arrotata di fresco, dica pure, i' so cicalare quanto lui.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>E io holla pure or ora arrotata e datole di più il filo con la pietra da olio.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Or sù chetati, arrovelato! chetati, sudicio! chetati, baccelone! chetati, popon frasido! chetati, manico di pinco!</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Oh? Vedi, adesso non ti risponderò, perché non t'ho intesa.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>E madonna, non parlate seco, ch'è così burlevole, ma attendete a me.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>S'è treschevole fiasi per sé, che, per monna Sandra, se mi fa infantastichire e infreneticare, si sarano raccozzati in mal punto. E credami che averà trovato sonaglio per la sua gatta.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>O che scommunicati proverbi.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Iscomunicato se' tu briccone, nato di becco.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>O ruffiana poltrona, una pianellata, eh?</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Che poltrona? To' cotest'altra.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Ferma, ferma Rondone! Poni giù quella pianella.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Lasciatelo pur fare, cotesto bue selvatico. Che non mi stia a stranare, perché del sicuro cotestui la perderae.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Madonna, se voi lo conosceste, non v'adirereste seco, poi ch'egli è pazzo sperticato.<pb n="107"/></p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>È verissimo. E pazzo pure è un mio fratello. Or ditemi, non darebbe a voi l'animo di cavargli il pazzo dal capo ?</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Affé, ch'io t'ho per un pazzo vizioso e bene.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Tu se' indovina, o furbetta, e che dite, non vi comincia a piacere questo mio umore? Crediate certo che a poco a poco v'entrerà, se vi slargate niente nel dovere.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Or sù non piue, l'intendi tu?</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Madonna, crediate che farebbe rallegrar la mestizia istessa, ma mi piace che siete donna, che gli tiene (come si suol dire) il bacile alla barba.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Così potess'io tenergli la margherita al guindo ancora.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Do', landra sfazzonata, intendo bene il parlar latino, sì?</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Or sù, non andiamo dietro più a coteste frascherìe.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Via via, datemi la mano, terminiamo questa lite, entriamo nell'osteria, ché vi prometto, madonna Succiola, che gusto avrete in alloggiare questi virtuosi.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Or sù entriamo, entriamo, non si perda il tempo, in grazia io vi chiedo, anch'io rimetto ogni offesa.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Or sue, per vostro amore entriamo.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>O che bello spasso! Per mia fé, ch'io non poteva desiderare il più felice! O ve', che la malinconia non affligerà più Schiavetto? Voglio andare studiando modo novo di onorare costei con nove villanìe.</p>
           </sp>
@@ -2191,7 +2264,7 @@
           <stage>
             <hi rend="sc">fulgenzio</hi>
           </stage>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Amor mi ha fatto diventar ebreo. In vero colui che disse che l'uomo adirato era simile alla lucerna, la quale, per<pb n="108"/> soverchia abbondanza d'olio, non luce, ma getta fuori delle fiamme, non errò punto; poich'è tanta la trabbocchevole ira, c'ho nel petto, che da gli occhi e dalla bocca quasi getto fiamme d'ardentissimo fuoco. Disprezzarmi? beffarmi e Orazio e Prudenza con tanto gusto di me ridersi? Tollerarla non posso, non che immaginarmela. Spentosi certo questo amore in me si sarebbe, perché alla fine un giusto sdegno ogni gran fuoco ammorza; ma il gusto che prender dovrò, ingannando chi ingannar altri godeva, fa che, stando con il piede in terra, tocchi con la mano il cielo. E fa in uno ch'io vesta questo abito da ebreo, intento solo (quando altro non sia) a viva forza di goder questa sprezzatrice di me, misero amante. Ma ecco uno ebreo. Sarebbe egli giamai Orazio? O non lo voglia benignissimo Amore! Voglio indisparte osservarlo.</p>
           </sp>
@@ -2199,19 +2272,19 @@
         <div type="scene">
           <head rend="italic">SCENA SESTA</head>
           <stage><hi rend="sc">scemoel, facchino</hi>, <hi rend="italic">e</hi><hi rend="sc">fulgenzio</hi></stage>
-          <sp>
+          <sp who="#scemoel">
             <speaker><emph rend="sc">scemoel</emph>.</speaker>
             <p>In effetto fino da fanciullo intese a dire che chi dorme non piglia pesce. Scimison, tu sai che se' stimato il più vituperoso giudeo che sia di qua e di là da i monti Caspi; e di più, dicesi che chi la fa a te, per la Torrà, convien che sia della tribù de' più fini, e come a lo Gohim ho giurato di fraccarla, scappi se può. Affé, che questo signor Alberto ha da passar per queste mani anch'esso, se vorrà spender i<pb n="109"/> zevvin traboccanti; poi che la robba mia, per mirarla, farebbe aprir gli occhi ad un morto. Che di' tu, come pesa questo forziero?</p>
           </sp>
-          <sp>
+          <sp who="#facchino">
             <speaker>facchino</speaker>
             <p>Che diavolo vi avete dentro? sonovi forse tutte le lucerne delle sinagoghe? o tutti i coltelli della saggattaria? Fate presto, ch'io non posso più.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Questi non è Orazio.</p>
           </sp>
-          <sp>
+          <sp who="#scemoel">
             <speaker><emph rend="sc">scemoel</emph>.</speaker>
             <p>O taci, taci, ché di qua vedo che se ne viene il maggior scellerato di tutto il giudaesmo.</p>
           </sp>
@@ -2221,23 +2294,23 @@
           <stage>
             <hi rend="sc">sensale, ebreo, facchino, scemoel, fulgenzio</hi>
           </stage>
-          <sp>
+          <sp who="#sensale">
             <speaker>sensale</speaker>
             <p>In somma, gli uomini valenti nelle avversità, e non nelle felicità (come disse colui), si conoscono: perché ogn'uno par che giochi bene quando gli dice buono il dado. Io sono (ed è così) il più ruvinato Hiechodì che sia fra tutti li Hiechodì, onde essendomi mancate le facoltà, dato mi sono all'ofizio di Sensale. Vada come vuole, all'ultimo voglio fare un bel tiro, tôr molta roba e legare il paletto.</p>
           </sp>
-          <sp>
+          <sp who="#scemoel">
             <speaker><emph rend="sc">scemoel</emph>.</speaker>
             <p>Oh costui è pure il fino furfante! Vedi come si strugge in pensar mille furberie.</p>
           </sp>
-          <sp>
+          <sp who="#sensale">
             <speaker><emph rend="sc">sensale</emph>.</speaker>
             <p>Cànchero venga a chi crede più di me a questa razza guidaica, a questi Rabini arrabbiati, pieni di mormorazzione, di falsità, e d'ignoranze (ché pure anch'io sopra la legge ho scartabellato qualche poco). Tutto il dì non conversar con cristiani? né io trovo la più cara conversazione, poiché se non fossero questi, come viveremmo? Non mangiar con cristiani? ne troviamo il maggior gusto. Questi balordi non vogliono sentire nominare la illustrissima carne del signor<pb n="110"/> porco? e io colà corro dove nominar sento braciole, sanguinacci, salami, fegatelli e salciccie. Gli altri, mangiando carne, conviene che stiano un gran pezzo, se mangiar formaggio vogliono, la legge vietando che carne e formaggio insieme mangiar non si possa. E io gusto grandissimo prendo nel brodo di grasso manzo, di buona e tenera vitella, e di vecchi capponi, dove pur sia il grugnetto e il zampetto di porcello giovine, d'attuffare la spugna d'un fresco pane buffetto che fatto quasi Sione, assorba il brodo. E così gonfio di questa quinta essenza manzatica, vitellatica, capponatica e porcatica, far, di più, che sopra gli fiocchi il buon formaggio piacentino, sì che, coperto tutto, sembri un pane di formaggio grattato. Lo vuoi odoroso poi? Recipe polvere di pepe e di canella tantum quantum suffìcit e sarà fatto il becco alla papera di madonna Rosa! O sono bene un vituperoso, se mentre il nostro Rabì è in sinagoga a sbragliare, s'io gli porto sotto il naso e sotto gli occhi questo impiastro da stomaco, non mi fo seguitare fino in piazza. Fummo sempre golosi, noi altri manigoldi, e bene lo narrano le carte antiche. In somma i' mi voglio disgiudeare certo, certo, poiché il vederne così lebbrosi, così fetenti, con così brutti visi, così odiati, così privi di casa, di vitto, di religione, di reame, mi dà a credere che poco, anzi nulla, chi si debbe arricordar di tutti, di noi s'arricordi. Oh? Questa è disciplina de' peccati vostri. Canzoni, è proprio del Cielo aver misericordia e perdonare, come pur veggiamo che ogn'altro nostro enorme peccato ne fu punito sì, ma poi perdonato, e giamai non perdemmo le nostre dignità maggiori, ancor che peccando. Ma ora, che diavolo di peccato è questo, che ne priva di non aver giamai perdono e che di tutte le grandezze ne dispoglia? e poi chi le possede? chi séguita le bibie nostre? i<pb n="111"/> nostri auttori più preclari? Il cristiano. Tal che possumus dicere che se quello ch'è in grazia del principe gode del prencipe i favori, e colui che n'è in disgrazia, de' favori vien privato, da tutta la corte, da tutta la città odiato, anzi dallo Stato sbandito, che così il Cielo, al cristiano, ch'è in grazia, comparta i favori (come pur tanti si vede, che ne gode) e al giudeo, come quello ch'è in disgrazia, i favori levi, facendolo odiar da tutto il mondo. Ma ecco qui miser Scemoel. Chi causa facit miser Simon?</p>
           </sp>
-          <sp>
+          <sp who="#scemoel">
             <speaker><emph rend="sc">scemoel</emph>.</speaker>
             <p>Oh oh? L'è qui sto ganan firsur.</p>
           </sp>
-          <sp>
+          <sp who="#sensale">
             <speaker><emph rend="sc">sensale</emph>.</speaker>
             <p>Sempre miser Scemoel me becemit, ma pacienza. Voglio pur anch'io vedere di ganavar qual cosa a questo prencipe. Ma ecco miser Leon, che vien con del mamon.</p>
           </sp>
@@ -2247,47 +2320,47 @@
           <stage>
             <hi rend="sc">leon, scemoel, sensale, facchini</hi>
           </stage>
-          <sp>
+          <sp who="#leon">
             <speaker>leon</speaker>
             <p>Dica chi vuole. Questa mattina mi sono levato con buona ventura, per avere, a pena vestito, inteso come un principe, ch'è in casa del signor Alberto, vuol comperare delli beghadim, da vestire e lui e la sua corte; ond'io n'ho portato carico questo saballo prima che altri di noi gli venda cosa alcuna, poiché non v'è razza al mondo più invidiosa della giudaica. Ma che vedo? Ecco qui tutta la sinagoga! O che siate maledetti più di quello che siete, razza scomunicata, dannata, indiavolata!<pb n="112"/></p>
           </sp>
-          <sp>
+          <sp who="#sensale">
             <speaker><emph rend="sc">sensale</emph>.</speaker>
             <p>Alla fé, messer Leon e, che si' stat molt charif.</p>
           </sp>
-          <sp>
+          <sp who="#scemoel">
             <speaker><emph rend="sc">scemoel</emph>.</speaker>
             <p>Baruchabà miser Leon.</p>
           </sp>
-          <sp>
+          <sp who="#leon">
             <speaker><emph rend="sc">leon</emph>.</speaker>
             <p>E voi siate il ben trovato: a non se darne zech fra noi.</p>
           </sp>
-          <sp>
+          <sp who="#scemoel">
             <speaker><emph rend="sc">scemoel</emph>.</speaker>
             <p>Io non son qua, per dar danno ad alcuno; sono anch'io qui per far bene, ma dov'è questo Sensale ci arriva la mala fortuna o arur abà.</p>
           </sp>
-          <sp>
+          <sp who="#sensale">
             <speaker><emph rend="sc">sensale</emph>.</speaker>
             <p>Sempre, sempre miser Leon, me perseguitite, chi causa ve hai fat io?</p>
           </sp>
-          <sp>
+          <sp who="#leon">
             <speaker><emph rend="sc">leon</emph>.</speaker>
             <p>Io burlo, io burlo. Po' non si può infine scherzar teco. Orsù, andiamo dal signor Alberto prima che altri vengo a sturbarci. O venga il canchero a Caìn! Vedete che di qua viene, con quattro facchini carichi di robba.</p>
           </sp>
-          <sp>
+          <sp who="#scemoel">
             <speaker><emph rend="sc">scemoel</emph>.</speaker>
             <p>Dov'è dov'è?</p>
           </sp>
-          <sp>
+          <sp who="#sensale">
             <speaker><emph rend="sc">sensale</emph>.</speaker>
             <p>Vedilo bacan, che vien.</p>
           </sp>
-          <sp>
+          <sp who="#leon">
             <speaker><emph rend="sc">leon</emph>.</speaker>
             <p>Per la Torrà, che costui ne darà nezech.</p>
           </sp>
-          <sp>
+          <sp who="#scemoel">
             <speaker><emph rend="sc">scemoel</emph>.</speaker>
             <p>Il Ciel ne dia buon mazàl a giom.</p>
           </sp>
@@ -2295,100 +2368,100 @@
         <div type="scene">
           <head rend="italic">SCENA NONA</head>
           <stage><hi rend="sc">caino</hi>, <hi rend="italic">con quattro</hi><hi rend="sc">facchini, scemoel, leon, sensale, fulgenzio</hi>, <hi rend="italic">e duo altri</hi><hi rend="sc">fachini</hi></stage>
-          <sp>
+          <sp who="#caino">
             <speaker><emph rend="sc">caino</emph>.</speaker>
             <p>Affé, che questo giorno il topo dovrà correre al lardo! Dica chi vuole, ogn'uno dice: «Siete avaro miser Caino, giamai non volete vender le cose vostre, se non vi sono strapagate, e ciò v'interviene perché avete la sacca di buone piastre, da mantenervi su questo proposito; ma un giorno, un giorno la robba vi si marcirà in bottega!». Ma dirò come<pb n="113"/> dice quello: in tuchal dice la quaglia. O vediamo un poco se la robba s'è marcita in bottega! Ho toccato poco fa dinari freschi, e ora ne toccherò de gli altri. Uh, uh? L'è qui questi mischadin che non han mammon tov, seno chinochem.</p>
           </sp>
-          <sp>
+          <sp who="#leon">
             <speaker><emph rend="sc">leon</emph>.</speaker>
             <p>Bondì a vostra manalà! Siamo qui ancora noi, per far bene, se la ne potrà aiutare ne farà favore, poich'ella tanto bisogno non ha, come noi; però ne favorisca che prima gli mostriamo le nostre robbe.</p>
           </sp>
-          <sp>
+          <sp who="#caino">
             <speaker><emph rend="sc">caino</emph>.</speaker>
             <p>Io mi contento figlioli, fate bene, ch'io vi do campofranco.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Adesso è tempo ch'io mi cacci fra la turba; ma non sapendo parlare ebraico fingerò il mutolo.</p>
             <p>Ba, ba ba, ba?</p>
           </sp>
-          <sp>
+          <sp who="#leon">
             <speaker><emph rend="sc">leon</emph>.</speaker>
             <p>Questo è muto e ne saluta, per quanto ne dimostra il gesto cortese; e di più convien che sia forestiero, non l'avendo qui giamai in Pesaro veduto.</p>
           </sp>
-          <sp>
+          <sp who="#sensale">
             <speaker><emph rend="sc">sensale</emph>.</speaker>
             <p>Lasciate, ch'io l'intenderò, c'ho lingua muta, e in quel linguaggio parlo molto bene.</p>
           </sp>
-          <sp>
+          <sp who="#caino">
             <speaker><emph rend="sc">caino</emph>.</speaker>
             <p>Tu mi vuoi far ridere; che lingua muta?</p>
           </sp>
-          <sp>
+          <sp who="#sensale">
             <speaker><emph rend="sc">sensale</emph>.</speaker>
             <p>Che lingua muta? O state a sentire. Be, be, be, be? Vedete voi, costui, co'l suo ba ba ba ba, n'ha detto buon dì a tutti e io, co'l mio be, be, be, be, gli ho detto che tutti noi gli rendiamo il buon giorno.</p>
           </sp>
-          <sp>
+          <sp who="#scemoel">
             <speaker><emph rend="sc">scemoel</emph>.</speaker>
             <p>Bene, per la Torrà, séguita, séguita, io stupisco di simil cosa.<pb n="114"/></p>
           </sp>
-          <sp>
+          <sp who="#leon">
             <speaker><emph rend="sc">leon</emph>.</speaker>
             <p>E io.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Barau, babbù; gnaù, gnargnaù, gnaù gnaù?</p>
           </sp>
-          <sp>
+          <sp who="#sensale">
             <speaker><emph rend="sc">sensale</emph>.</speaker>
             <p>Oh? Vedete, questa è mo lingua gattesina, con la mutosina mescolata.</p>
           </sp>
-          <sp>
+          <sp who="#caino">
             <speaker><emph rend="sc">caino</emph>.</speaker>
             <p>E come gli risponderai? Eh, eh, eh.</p>
           </sp>
-          <sp>
+          <sp who="#sensale">
             <speaker><emph rend="sc">sensale</emph>.</speaker>
             <p>Non ridete, perché la cosa va così.</p>
           </sp>
-          <sp>
+          <sp who="#leon">
             <speaker><emph rend="sc">leon</emph>.</speaker>
             <p>Ma come risponderai?</p>
           </sp>
-          <sp>
+          <sp who="#sensale">
             <speaker><emph rend="sc">sensale</emph>.</speaker>
             <p>O vi dirò: a questa lingua gattesina, risponderò con lingua sorzolina. Ma sapete voi quello che gattesinescamente, e mutescamente, ha detto? Vuoi che lo dica, muto? Bene, non intende questo linguaggio, e vedete che non s'è mosso, né ha risposto. Aspettate, che gle lo dirò. Barabam, barabam, bi, be, ba?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Fi, fe, fo, fu.</p>
           </sp>
-          <sp>
+          <sp who="#sensale">
             <speaker><emph rend="sc">sensale</emph>.</speaker>
             <p>Dice di sì, che ve lo dica.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Qua qui, quara, qui, qua, que qui?</p>
           </sp>
-          <sp>
+          <sp who="#sensale">
             <speaker><emph rend="sc">sensale</emph>.</speaker>
             <p>Di più, dice che vorrebbe vendere anch'egli, poiché se, per fare il mercante, ha perduto in man di Turchi la lingua, vuole anche, mercantando, perder la vita.</p>
           </sp>
-          <sp>
+          <sp who="#caino">
             <speaker><emph rend="sc">caino</emph>.</speaker>
             <p>Tu mi fa stuppire, né so chi t'abbia insegnata questa lingua.</p>
           </sp>
-          <sp>
+          <sp who="#sensale">
             <speaker><emph rend="sc">sensale</emph>.</speaker>
             <p>Chi me l'ha insegnata? Un muto, che teneva scuola in questa lingua.</p>
           </sp>
-          <sp>
+          <sp who="#leon">
             <speaker><emph rend="sc">leon</emph>.</speaker>
             <p>Or sù, muto, si contentiamo che tu facci bene. Ma a che dimena il capo?</p>
           </sp>
-          <sp>
+          <sp who="#sensale">
             <speaker><emph rend="sc">sensale</emph>.</speaker>
             <p>Se vi dissi che non intende, se non il mio linguaggio?</p>
             <p>O questa è bella, io non so che mi dica, e costui m'intende.</p>
@@ -2396,15 +2469,15 @@
             <p>O cànchero, questa è bella! Non volendo io parlo muto.</p>
             <p>Or sù: stipin, bipin, ripin? Ho detto che stia cheto.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Rispin, rispin.</p>
           </sp>
-          <sp>
+          <sp who="#sensale">
             <speaker><emph rend="sc">sensale</emph>.</speaker>
             <p>Sentite? Dice che tacerà. Or che dite, non sono un gran valent'uomo?</p>
           </sp>
-          <sp>
+          <sp who="#caino">
             <speaker><emph rend="sc">caino</emph>.</speaker>
             <p>Tu n'hai fatto tutti stupire, e vogliosi di questa lingua mutesina, gattesina e sorzolina.<pb n="115"/></p>
           </sp>
@@ -2412,51 +2485,51 @@
         <div type="scene">
           <head rend="italic">SCENA DECIMA</head>
           <stage><hi rend="sc">orazio, sensale, caino, leon, scemoel, fulgenzio</hi>, <hi rend="italic">sei</hi><hi rend="sc">facchini</hi></stage>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Eccoti Orazio formato in ebreo.O corpo del mondo, è qui tutta la turba israelittica.</p>
           </sp>
-          <sp>
+          <sp who="#caino">
             <speaker><emph rend="sc">caino</emph>.</speaker>
             <p>Ma chi è costui?</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Bisogna far buon cuore. Ma se mi parlano in ebraico sono spedito. Farò il muto. Ba, be, bi, bo, bu?</p>
           </sp>
-          <sp>
+          <sp who="#sensale">
             <speaker><emph rend="sc">sensale</emph>.</speaker>
             <p>Biribi, be, be.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Ba, be, bu.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Ba be, ba be.</p>
           </sp>
-          <sp>
+          <sp who="#sensale">
             <speaker><emph rend="sc">sensale</emph>.</speaker>
             <p>Bif, bif, bif.</p>
           </sp>
-          <sp>
+          <sp who="#caino">
             <speaker><emph rend="sc">caino</emph>.</speaker>
             <p>Uh, uh? Finiamola, se un terzo tra voi s'appiccia, mai più non si finisce. O di casa? Signor Alberto, gli Ebrei, gli Ebrei, con bellissime cose.</p>
           </sp>
-          <sp>
+          <sp who="#sensale">
             <speaker><emph rend="sc">sensale</emph>.</speaker>
             <p>Lasciate, chè 'l nuovo muto vuol battere a casa.</p>
           </sp>
-          <sp>
+          <sp who="#scemoel">
             <speaker><emph rend="sc">scemoel</emph>.</speaker>
             <p>Batti, batti.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Nacà, nacà, nacà.</p>
           </sp>
-          <sp>
+          <sp who="#sensale">
             <speaker><emph rend="sc">sensale</emph>.</speaker>
             <p>Vedete, nacà nacà vuol dire: o dalla casa? Ma ecco gente. Or sù, questo è 'l signore, guarda che umore, ed è così ricco e nobile.</p>
           </sp>
@@ -2464,187 +2537,187 @@
         <div type="scene">
           <head rend="italic">SCENA UNDECIMA</head>
           <stage><hi rend="sc">nottola, rampino, paggio, paggi, orazio, fulgenzio, sensale, leon, scemoel, caino</hi>, <hi rend="italic">e sei</hi><hi rend="sc">fachini</hi></stage>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Olà, Rampino, domanda chi sono costoro, e poni colà quello scagno, ch'io voglio sedere per dar loro udienza; in ogni modo questa contrada è molto remota e tutti appunto su quest'ora intenti al desinare sono.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Siete voi quegli Ebrei venuti per vestire il mio signore?<pb n="116"/></p>
           </sp>
-          <sp>
+          <sp who="#caino">
             <speaker><emph rend="sc">caino</emph>.</speaker>
             <p>Signor sì.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Aspettate. Signore, questi sono gli Ebrei venuti per conto suo.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Sì? Fatti innanzi tu.</p>
           </sp>
-          <sp>
+          <sp who="#leon">
             <speaker><emph rend="sc">leon</emph>.</speaker>
             <p>Eccomi signore, che con ogni riverenza le m'inchino.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Com'è 'l tuo nome?</p>
           </sp>
-          <sp>
+          <sp who="#leon">
             <speaker><emph rend="sc">leon</emph>.</speaker>
             <p>Leone.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Re delle bestie, non è così?</p>
           </sp>
-          <sp>
+          <sp who="#leon">
             <speaker><emph rend="sc">leon</emph>.</speaker>
             <p>Eh, so che vostra eccellenza burla.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Che robba è questa, mostra un poco. Apri la cassa e getta qui ogni cosa.</p>
           </sp>
-          <sp>
+          <sp who="#leon">
             <speaker><emph rend="sc">leon</emph>.</speaker>
             <p>Oh signore, vuole ch'io imbratti la robba?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Do', furfante.</p>
           </sp>
-          <sp>
+          <sp who="#leon">
             <speaker><emph rend="sc">leon</emph>.</speaker>
             <p>O signore, un mustaccione! Che vi feci?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Ti farò ammazzare, ve' furfante, se tu non mi ubidisce. Getta lì quella robba.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Fa' presto, mastino, ché ti amazzo con le pugna, ve'? Fa' presto, presto, presto.</p>
           </sp>
-          <sp>
+          <sp who="#leon">
             <speaker><emph rend="sc">leon</emph>.</speaker>
             <p>Adesso, signore?</p>
           </sp>
-          <sp>
+          <sp who="#caino">
             <speaker><emph rend="sc">caino</emph>.</speaker>
             <p>O siamo intricati.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Eh? Questa è robba da buon mercato, lasciela così in terra.</p>
           </sp>
-          <sp>
+          <sp who="#leon">
             <speaker><emph rend="sc">leon</emph>.</speaker>
             <p>Ve la lascio signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Tu come ti chiami?</p>
           </sp>
-          <sp>
+          <sp who="#scemoel">
             <speaker><emph rend="sc">scemoel</emph>.</speaker>
             <p>Scemoel, Scemoel.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Che?</p>
           </sp>
-          <sp>
+          <sp who="#scemoel">
             <speaker><emph rend="sc">scemoel</emph>.</speaker>
             <p>Simon.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Do', razza di becco, e non sapevi così dirmi alla prima, senza in Scemescionarmela? Vien qui; getta la tua robba qui ancor tu, e ve' non replicar parola, ché ti farò dar delle staffilate a cul nudo da cavaliere.</p>
           </sp>
-          <sp>
+          <sp who="#scemoel">
             <speaker><emph rend="sc">scemoel</emph>.</speaker>
             <p>No no, signore, non voglio staffilate, così il Rabì nostro non commanda.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O vedi Lione, questo è galantuomo.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Oh? Questo non è ebreo tanto ostinato. Ancor fra questi panni v'è poco di buono, lascia qui ancor tu.<pb n="117"/></p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>E tu che nome hai?</p>
           </sp>
-          <sp>
+          <sp who="#caino">
             <speaker><emph rend="sc">caino</emph>.</speaker>
             <p>Ho nome Caino, e il signor Alberto hammi da sua eccellenza illustrissima mandato poiché quello sono, che serve la sua casa; e questi quattro facchini sono carichi tutti di mia robba; ma perché ell'è robba di molto rispetto, supplicola con le ginocchia a terra a non la far gettar per terra, ma farmi grazia di vederla in casa.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Leva su, bacia questa mano, bacia quest'altra. Oh? Retìrati sei passi a dietro. Vedete, canaglia, così si procede. Caino ?</p>
           </sp>
-          <sp>
+          <sp who="#caino">
             <speaker><emph rend="sc">caino</emph>.</speaker>
             <p>Mio signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Entra meco, con i tuoi facchini, in casa. E voi, paggi, e tu Rampino, per l'affronto che questa canaglia m'ha fatto in portar robba sì vile, per vestir prìncipi e corte così nobile, abbotinate, ché tutto vi dono, e dalla finestra vado a vedere il tutto.</p>
           </sp>
-          <sp>
+          <sp who="#paggio">
             <speaker><emph rend="sc">paggio</emph>.</speaker>
             <p>A Ebrei traditori! Addosso, compagni.</p>
           </sp>
-          <sp>
+          <sp who="#scemoel">
             <speaker><emph rend="sc">scemoel</emph>.</speaker>
             <p>Fermatevi! A questa foggia?</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Sta' indietro furfante.</p>
           </sp>
-          <sp>
+          <sp who="#sensale">
             <speaker><emph rend="sc">sensale</emph>.</speaker>
             <p>Ah traditori.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Giudeo ladro, sta' indietro.</p>
           </sp>
-          <sp>
+          <sp who="#leon">
             <speaker><emph rend="sc">leon</emph>.</speaker>
             <p>Lasciate questa robba.</p>
           </sp>
-          <sp>
+          <sp who="#sensale">
             <speaker><emph rend="sc">sensale</emph>.</speaker>
             <p>Aiuto, aiuto, aiuto.</p>
           </sp>
-          <sp>
+          <sp who="#paggio">
             <speaker><emph rend="sc">paggio</emph>.</speaker>
             <p>To' questi pugni.</p>
           </sp>
-          <sp>
+          <sp who="#sensale">
             <speaker><emph rend="sc">sensale</emph>.</speaker>
             <p>Tu questi.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Tu questi.</p>
           </sp>
-          <sp>
+          <sp who="#scemoel">
             <speaker><emph rend="sc">scemoel</emph>.</speaker>
             <p>Tu pur questi.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O bella scaramuccia! Ah valent'uomini, così, così! menate delle mani, o così, o così! corri, corri, dalli, dalli, poltrone! o robba saccheggiata, come tutti se la stracciano dalle mani! In casa, in casa, in casa.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Vittoria, vittoria, vittoria! Sù, tutti cridate: vittoria, vittoria, vittoria!<pb n="118"/></p>
           </sp>
@@ -2657,7 +2730,7 @@
           <stage>
             <hi rend="sc">alberto</hi>
           </stage>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O com'è vero il detto del savio, quando disse che quanto più l'uomo dalla felicità si crede lontano, allora con passo improviso si vede entrato in quella. E io ho pur veduto che molte navi, scorrendo felicemente per l'alto mare, ruppero poi e abissarono nell'entrare di sicuro porto, e altre, sdrucite e agitate dall'onde, sicure alla fine al porto si condussero. Che più? Faggio, pino, cipresso, percosso dal folgore, quasi incenerito ne rimase, e pure in breve si ritornò a rivestire de' suoi frondosi onori. Alfine concludo che intervengono più presto le cose disperate che le sperate. E di qui vedi ancor tu, o Alberto, come ti s'è offerta la ventura di questo prencipe incognito, il quale non solo t'ha da far del bene per istarte in casa, ma perché, forse forse, tu potresti pettargli alle spalle Prudenza per moglie. Oh lo volesse il Cielo! Allora sì, che tutti saluterebbero, e meco parlando, ad ogni ora e tenendo il cappello in mano, ci caccierebbero l'illustrissimo signor sì e l'illustrissimo signor no, per far più sonora la musica. Altra volta fu detto che la vera nobiltà da virtù dipendeva, e l'altre cose tutte dalla fortuna; altra volta si disse che la nobiltà non debbe esser considerata dal sangue, ma da i costumi, e che la vera nobiltà non da l'altrui splendore si riceve, ma con la<pb n="119"/> propria fatica virtuosa, mentre operando s'acquista. Ma ogni età ha 'l suo costume; adesso non è così: chi ha più quattrini, quello è più nobile. Ed è pur vero, ché alcuna fiata i' sento ad un tale ignorante dar dell'illustrissimo perché ha quattro quattrinnucci, che mi fa crepar dalle risa, ricordandomi che l'altro giorno lo vidi andar mendicando il solo messere. Orsù Alberto, segui il costume del mondo immondo! Appìgliati pure al quattrino, poi che, per dire il vero, rallegra più uno scrittoio di doble mal tondate, che la più bella libreria del mondo. Riprèndanmi pur questi sciocchi dicendo: «Alberto, marita la figliola! Che vuoi tu fare? Stai troppo!». O goffi, guardino un poco; questo è il colpo, che per sé tiene ogni buono schermitore: maritarla senza dote era il mio disegno, ed ecco che vicino sono a far che la cosa riuscisca. Rimane solo ch'io disponga la figliola, la quale mi credo che in rimirare il suo bene non sarà cieca talpa.</p>
           </sp>
@@ -2667,149 +2740,149 @@
           <stage>
             <hi rend="sc">prudenza, alberto, caino</hi>
           </stage>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Appunto, signor padre, io la desiderava. E che vuol dire che tanto sta a far ritorno a casa? Pur sa che sono fanciulla, e pur non gli è celato che, in oltre, questo principe ha tanta ciurma da galea in casa ancora. Consola la presenza del padre il figliolo in quella guisa, che consola il mondo il sole, quando, la caligine fugando, luminoso appare. Se dunque non brama di veder sempre la sua figlia tra mille orrori di strane congetture sommersa, torni spesse volte a rallegrarla con la luminosa sua paterna fronte.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Se rallegra la fronte del padre il figliolo, in quella guisa che 'l sole il mondo consola, quando avviene che fra densa caligene involto ei sia; consola parimente la vista del figliolo l'occhio del padre, in quella guisa che il lume in non lontano porto rallegrar suole nocchiero, che naufrago vada portato dall'onde, or dal feretro al sepolcro, né io senza te contento vivo. Ma le gravi occupazioni, nelle quali hammi posto questo principe, hanno cagionato che prima non ho<pb n="120"/> potuto da te far ritorno. Ma dimmi, non venne Caino, nostro ebreo? non ha egli portato (come m'è stato detto) cose bellissime?</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Venne signor sì. Ma già non venne il mio caro Orazio. Ma di più seco venne, eziandio, una gran turba d'altri Ebrei, chi con delle sacca piene di robba, e chi con delle casse. Ecco appunto Caino ch'esce di casa, con quattro facchini.</p>
           </sp>
-          <sp>
+          <sp who="#caino">
             <speaker><emph rend="sc">caino</emph>.</speaker>
             <p>Che dite voi galant'uomini, o non è la stessa cortesia, questo principe?</p>
           </sp>
-          <sp>
+          <sp who="#facchino">
             <speaker><emph rend="sc">facchino</emph>.</speaker>
             <p>Egli è amorevolissimo, e ben ve lo narra quel gran borsone di doble, che avete fatto traboccante.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Messer Caino? Alfine, è bene avere amici. Se voi non eravate amico d'Alberto, non empievate del più nobile metallo quel bel borsellone, o come pesa!</p>
           </sp>
-          <sp>
+          <sp who="#caino">
             <speaker><emph rend="sc">caino</emph>.</speaker>
             <p>Per voi, signor Alberto, ho questo bene per voi. Mirate qua, coteste quattro sacca piene piene si sono convertite in questo borsellotto solo!</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Così fanno i buoni distillatori, da un fascio di robba ne traggono una sola stilla preziosa. Or sù, andate alle faccende, Caino.</p>
           </sp>
-          <sp>
+          <sp who="#caino">
             <speaker><emph rend="sc">caino</emph>.</speaker>
             <p>Vostro, signor Alberto; voglio andare or ora a cercar tra certe mie belle cosette, per fare un regalo alla vostra signora figliola.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>D'un arbore feconda, caro è altrui di godere la fronda, il fiore, il frutto; sì che porti Caino o poco, o assai, che dalla sua mano venendo non potrà se non esser gratissimo, anzi che appresso di noi convertirassi la fronda in fiore, il ramo in frutto.</p>
           </sp>
-          <sp>
+          <sp who="#caino">
             <speaker><emph rend="sc">caino</emph>.</speaker>
             <p>Di questa lode godo più che di questo borsone d'oro.</p>
           </sp>
-          <sp>
+          <sp who="#facchino">
             <speaker>FACCHINO</speaker>
             <p>È bene un porco, chi te lo crede.</p>
           </sp>
-          <sp>
+          <sp who="#caino">
             <speaker><emph rend="sc">caino</emph>.</speaker>
             <p>Addio.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Andate felice e siate di presto ritorno, né già questo dico perché avaro io sia, e se pure avaro, avaro di rivedervi. Appunto, amata figliola, solo spirito di questo cuore, solo cuore di questo petto, e solo occhio di questa fronte, io bramava lontano da ogni altro orecchio raggionarti. Dimmi, non ti par egli tempo oggi mai d'essere fatta la sposa?</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Certo, signor padre.<pb n="121"/></p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>No no, non parlare co 'l dimenarti, ma con la lingua; non lo tacere, ché il tutto al medico e al padre dir si debbe, non l'averesti caro?</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Signor sì io.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>E in particolare poi, quando io t'avessi proveduto d'un ricco signore, non è così?</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Oh cuore, che mi predici di male? Certo, che vuol egli parlarmi di questo principe.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>No no, non parlar da te, parla pur meco; dillo a chi più d'ogn'altro al tuo bene aspira.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Dirolli, padre e mio signore. Quando pur maritar mi dovessi, tôrrei più tosto un giovine dotto, e con poca robba, che un ricco molto di dinari, e povero di sapere.</p>
             <p>Affé, s'egli parla del prencipe, e io parlerò di Orazio.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Piacemi questa grave risposta in non grave età, da quella iscorgendosi che tu leggendo hai immitato nelle virtù tuo padre. Ma sappi, amata figliola, che interogato Simonide poeta che cosa egli volesse più tosto, ricchezza o sapienza, rispose: «Io non lo so certamente, ma veggio i savi sempre appo le porte de' ricchi».</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Non so io. Anacreonte pure, avendo avuto in dono da Olicrate cinque talenti, ed essendo stato senza dormire due notti cogitabondo di che far ne dovesse, riportò i cinque talenti, dicendo: «Prendi, signore, ché non sono questi dinari di così gran pregio, ch'io debba essere per colpa d'essi molestato nella mente e ne gli occhi». E se i virtuosi stanno alle porte de' ricchi, non istanno per entrare, ma per uscire, poi che Diogine disse la virtù non potere abitare in case ricche.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Figliola, chètati. I danari tra' mortali sono sangue e anima; e chi non ne ha, morto tra i vivi camina. Odi<pb n="122"/> Euripide, quando parlando con suo padre dice: «Deh, per Dio, non mi parlate di nobiltà, perché certo cotesta è posta nelle ricchezze, lasciatemi l'oro in casa, e di servo incontanente diverrò nobile».</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Signor padre, crediatemi, che la vita del ricco è misera, e le troppe ricchezze sono come i timoni delle gran navi poste alle picciole barche, i quali non le possono governare; sì che le ricchezze più tosto ruvinano, che aiutino. Guardi una pianta che, per esser troppo carica e ricca di frutti, per la troppa fertilità piegando i rami a terra tutta s'incurva, e spezza.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Or sù, terminiamoli. Io non so come la ricchezza ruvini, pare a me che un ruvinato sollevi; e che i dinari trovino amici infiniti, e sedie appresso gl'istessi regi. Né più qui facciamo il buon pedagogo e tu la buona discepola.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Di grazia, dunque, veniamo alla cagione principale, che ci ha fatto movere questo ragionamento. Qual'è? E a che fine fu detto di sposo meco?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Già ti dissi, che era per maritarti; e perché più facilmente ti disponessi a giovare a te stessa e a me dar gusto, ti lodai la ricchezza, per dirti poi che 'l tuo consorte è 'l più ricco che sia in questa città. E sai chi è?</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Certo no signore.</p>
             <p>Lassa, ben lo indovina il cuore.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Questi è quel principe, ch'è in casa nostra. Or non ti pare che la fortuna ti sia favorevole?</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Certo sì signore, ma allora si debbe temer la fortuna, ch'ella ci mostra giocondo il volto.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Sua ventura ha ciascun dal dì che nasce, disse colui, e fortunatissima chi sua fortuna conosce.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>S'arricordi, o caro padre, che quel savio Apelle, pittore ateniese, essendo interrogato per qual cagione aveva dipinta la fortuna in piedi, che egli rispose: «Perché ella<pb n="123"/> non sa sedere». Non si fidi della fortuna e credami che perde il cervello chi troppo è dalla fortuna accarezzato; e più saper conviene ch'ella è detta rea, superba, temeraria e audace.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Tutto bene, per uno che voglia dir male della fortuna. Ma Curzio istorico, che ne vuol dir bene, disse: «Chi rifiuta la sua fortuna è degno d'ogni male». Sì che acquètati, né parlar più, ché dove tu cerchi di dimostrarti virtuosa, tu non fossi reputata baldanzosa; e sappi che la natura due orecchie ne dette e una sola lingua, perché più dovessimo udire che parlare.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Padre, m'acqueto.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Ma ecco appunto i paggi, e altri superbamente vestiti. A questi abbagliamenti d'oro, o come tutto mi consolo.</p>
           </sp>
@@ -2819,43 +2892,43 @@
           <stage>
             <hi rend="sc">grillo, cicala, corte, alberto, prudenza</hi>
           </stage>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Signore Alberto? signora Prudenza? Slargatevi, ché 'l signore vuole pigliare un poco d'aria. Cicala, fa' porre qui la seggiola.</p>
           </sp>
-          <sp>
+          <sp who="#cicala">
             <speaker><emph rend="sc">cicala</emph>.</speaker>
             <p>Ecco qua la carriega del signore. È spazata e lucente?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Oh? Così sta bene. Sù, che si vada a tôrne un'altra per la signora.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>E che, non occorre, bel paggetto.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Lascia che faccino tutto quello che vogliono, così debbe esser espresso volere del loro principe.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Il signor Alberto l'intende; so ben io quello che n'ha imposto il signore sotto pena di sferzate e della disgrazia sua. Càppari, signor Alberto, è bella questa vostra figliola.<pb n="124"/></p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Ti piace?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Se mi piace? Sono un furfante, se Grillo non si contentasse cantando di morirle su 'l buco.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Oh? Signor padre, sentite, sentite, che cosaccie dice questo furbetto.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Perdonatemi, signora, perché sono così allegruccio di natura; e ho detto così per farla ridere, vedendola stare tanto di malavoglia.</p>
           </sp>
@@ -2865,71 +2938,71 @@
           <stage>
             <hi rend="sc">rampino, grillo, paggio, paggi, alberto, prudenza</hi>
           </stage>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Ti colsi eh? To' questo.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Ohimè, che scopelotto, ohimè ch'io sono balordo.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Povero Grillo, io ti tengo, io ti tengo.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Furfante, furfante, e così si serve il signore? E forse, che non l'ha fatto maggiore sopra gli altri paggi?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>V'è passata la collera ancora, signore?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Sì sì, gli è passata; sta allegro.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>M'è passata; ma stupisco come t'ho fatto tanto male, se non sono state queste grosse anella d'oro, che più del solito m'abbiano fatto la mano pesante.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>O siete pur buono signor maggiordomo, se vi credete di farla a Grillo. Venghi pur uno e me pisci nel buco, per vedere s'io sono nella tana, ché per questo non darò fuora. Credete voi di avermi fatto male? Signor no, ma perch'io stimava che con voi aveste un pezzo di legno e doppo lo scopelottare mi voleste anche bastonare, ho fatto quella finta per movervi a pietade. O che gle l'ho fraccata! Dalli, dalli, dalli!</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Che tristerello! Or sù, signor maggiordomo, questa è facezia e se li può comportare, anzi che per quella dee molto Grillo meritare.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Per amore del signor Alberto, accetto la furberia per galanteria, e vi perdono.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Ha fatto bene a perdonarmi, perché s'ella non mi perdonava, da me perdonar mi voleva. O ecco l'altra carriega.<pb n="125"/> Da' qui, ponla qui. Oh? Qui voi, visetto di rosa, dovrete sentare.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Che dite signor Alberto?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Mi piace, ch'egli è tutto spiritoso.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>A signora, m'è stato detto che avete le labbra di mèle. Voi sapete che i putti delle cose dolci sono golosi, mi volete far grazia, ch'io le dia due leccatelle?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O buono, o buono, o buono! Ridi, Prudenza, non vedi se per far rider te farebbe ridere la mestizia istessa?</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Signor padre, queste cose punto punto non mi ponno movere a riso, ma a collera.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Cheti. Signora ecco la corte, viene il principe, del sicuro.</p>
           </sp>
@@ -2939,275 +3012,275 @@
           <stage>
             <hi rend="sc">nottola, cicala, corte, rampino, grillo, alberto, prudenza</hi>
           </stage>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Paggi, immaginatevi ch'io sia un cielo, nel cielo vi è il sole, ch'è giallo, e la luna, ch'è bianca. Dal cielo nè il sole nè la luna giamai si partono, similmente voi altri da me non v'allontanate giamai, ma l'uno alla destra, l'altro alla sinistra mi stia, con queste due sottocoppe grandi, larghe e pesanti. L'un sarà il tondo del sole, e sarà questa dove sono gli scudi d'oro, l'altra sarà il tondo della luna, e sarà questa con tanta moneta d'argento.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>All'eccellenza sua umilmente a terra si china Alberto, suo devotissimo servo.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O miser Alberto nostro, vi vogliamo fare una grazia.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>E che, signore?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Che mi veniate a dar da sedere. Via, presto, camminate.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Eccomi signore. Sua eccellenza lasci ch'io la stropicci un poco.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Basta, basta, che in ogni modo noi portiamo un vestimento se non un giorno solo. Rampino?</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Eccomi umile e riverente, signore.<pb n="126"/></p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Da' da sedere alla signora Prudenza, che voglio che mi stia appresso.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Tanto alto luogo non merita, o mio signore (e mi perdoni) così bassa serva.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Vogliamo così perché possiamo, possiamo perché vogliamo, e il volere e il potere è al piacere congiunto; sì che vogliamo perché ne diletta e piace.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Sù, dunque, fa' una bella riverenza e siedi.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Sedete sedete, signora Prudenza, non abbiate rispetto; sù, cavatevi il guanto, datemi la mano in mano. O signor Alberto, che modo di procedere è questo? che muso storto mi fa la vostra figliola? non si vuol cavare il guanto? Al cospettaccio della mia generosità, ch'io le fo tagliar quella mano! Potta, rinego, al cospetto, se me la fa attaccare.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Càvati quel guanto! Oh mio signore, le rimembri ch'è verginella ancora e solo avezza ad ubbidire i commandi paterni.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Prudenza, ditemi: non vi dispiace già di sedermi appresso, non è così?</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Signor no.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Eh? Un eccellentissimo avanti quel signor no, non averebbe detto male; ché quel signor no così solo è un poco languido, ma con quell'eccellentissimo signor no, oh come diceva buono.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Eccellentissimo signor no.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Oh? Adesso avete cervello. O pigliate, ché per levarvi da quelle tenebre d'errori, che vi fece errare, vi dono un gran pugno di luce, ch'ora dal mio sole io levo.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Se gli errori di mia figlia debbono esser corretti con questi flagelli, poss'ella sempre errare.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Sì? Ma voi non l'intendete; come più di due fiate uno dei miei erra, io li fo tagliar la testa. Vedete, signora, io sono il più dolce pastone che con zucchero e mèle fosse giamai impastato, ma quando m'incollero poi, divento una serpe. Baciatemi questa mano.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Ecco, signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Un'altra volta; un'altra volta pigliate queste due brancate di luna, pigliate pure questo piccicotto di sole.<pb n="127"/></p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O me contentissimo, potrò ben dire, signor principe, che per sempre dovrò godere eterno giorno, se di tanti raggi, e di luna e di sole, sua eccellenza illumina le tenebre della povertà mia.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Signora. Volete voi che appieno vi faccia signora e della mia luna e del mio sole?</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Ohimè. Che a tanta luce confusa io non rimanga poi, mio signore; pure porga la mano, quello che alla mano offre il generoso suo core.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Chiudete gli occhi, o così.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Signore?</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Olà, un bacio?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Dirolle. Per fare che il sole e la luna abbiano sempre da stare con eterna pace con voi, gli ho per sicurtà posto questo bacio di mezo.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Oh figliola, ha fatto molto bene.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>S'è così, sole e luna, m'acqueto.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Or prendete e la luna e il sole.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Caro signor padre, non ho grembo per tanto lucido tesoro.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Or sù. Oggi intendiamo, per far che il giorno sii solenne, di conceder grazie; però s'alcuno v'è di quelle voglioso, sia, parli, chieda. Fate vento canaglia, che vi fo scorticar vivi, vivi, e così scorticati vorrò che per penitenza mi facciate vento con le vostre pelli, vedete. Ma che vuol dire, signor Alberto, che a questo suono di chieder grazie tutto bullicate? Volete forse alcuna cosa? Volete forse ch'io vi faccia far vento con le mie ventaiole? Andate là, presto, servitelo.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>No no signore, fermatevi paggi, non voglio vento.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Fate vento a me. Che volete? Dite presto, ché mi vien sonno. Dite pure, ché ben che si riposiamo sopra questa mano, vi sentiremo però.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O caro signor maggiordomo, debbe io tacere o parlare? Mi pare che gli occhi abbia agravati di sonno.<pb n="128"/></p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Uh? Signor padre, sentite come sornacchia forte, mi fa paura. Caro signore?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Sta' cheta, ché si desta.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Seguitate signor Alberto, da gentiluomo, ch'io ho sonno. E voi, canaglia, mentre parla il signor Alberto, non isputate meno, acciò ch'io possa ascoltarlo bene. Dite signor Alberto, che non dormo no, ben ch'io m'appoggi alquanto alla sedia; questo è costume di tutte le persone grandi, doppo che hanno desinato, di star così stravaccate.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Questa sera sua eccellenza starà meglio, e quello che madonna Succiola doveva far per desinare, servirà per la cena, poi che l'ora è tarda e l'eccellenza sua s'è compiaciuta solo d'una poca di colazioncella da me fattale. Ora signore... Ma mi par che dorma al sicuro, s'io pur non erro.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Eh? Non dorme no, sente bene sì, parlate pure.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Non sente, vostra signorìa, che gli è tornato il sornacchio? Aiuto, aiuto, cade!</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O poverino me, o servitori infedeli, a seguaci traditori, a cotesta foggia lasciar cader la nobiltà? Ohimè questo fianco! Ohimè, ohimè! A Rampino, così eh? così mi custodisci?</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Mi scusi, e m'interceda il perdono l'aver sua eccellenza detto che non dormiva.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>È così, signora Prudenza? Hollo detto?</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Sì signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Sia perdonato a tutti. Or torno a sedere, né più ho sonno, poiché la caduta giù della seggiola hammi cavato il sonno dal capo. Che volete signor Alberto? Vedete, in quattro parole chiedetelo, se non, m'addormento.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Vorrei.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Una.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Prudenza.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Due.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Sua.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Tre.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Sposa.<pb n="129"/></p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>E quattro. Io mi contento, ecco le tocco la mano; e le fo contradote di tre milioni d'oro, d'un sacco di perle, e d'uno staio di diamanti. Andiamo a consumare il matrimonio.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Signor padre, signor padre, aiuto, aiuto.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Signor gennero, e che fa?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Che padre, che genero? Ora m'è venuto voglia di matrimoniare e voglio matrimoniare, al sicuro.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Eh, caro signore, per amor del vulgo, in grazia, prima si vada al palazzo, e poi al letto.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Da vero sposo, e da illustrissimo cavaliere, che avete ragione. Or sù, mi si scusi, andiamo al palazzo.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>O me misera, o Orazio mio.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Vi accettiamo per nostro amato suocero; e più non vi si chiami con quel nome umile d'Alberto schietto, ma del signor conte Alberto, e noi vi doniamo la contea, la quale ora è in potere del Gran Turco, ma gle la piglieremo bene fra poco.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Pur troppo sono signore essendo servo di sua eccellenza e la mia figlia è serva e sposa.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Fatevi in qua; lasciate ch'io vi cinga questa spada. O così, cacciate la mano, ponetela dentro, slacciatela da voi, baciate il pomolo, inginocchiatevi, dàtemela, siete creato conte. Gridisi viva Alberto conte.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Sù tutti cridate: viva Alberto conte! viva Alberto conte!</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Levatevi in piè, fate una riverenza in giro, copritevi. Oh? Ora siete ordinato conte.</p>
           </sp>
@@ -3217,67 +3290,67 @@
           <stage>
             <hi rend="sc">succiola, nottola, cicala, grillo, corte, rampino, alberto, prudenza</hi>
           </stage>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>O corpo di santanulla, or vedi se amore ha ritrovata la via di fare uscire la lucertola fuora della fessura? Vedi, vedi dico, come m'ha fatto incapriccire e imbestialire di quel bello schiavottolo. Ho a cotestui promesso di far aver licenza<pb n="130"/> di salire in banco, e voglio farlo, per esser quella io, che lava e' panni sudici quasi di tutta la Corte.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Dove, dove così in fretta, madonna Succiola?</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Oh? I' vado con cotesto panerino d'acque nanfe, di pallottole da lavar le mani e di moscardini, al signor governatore, per dargnelo in dono, acciò che si contenti di dar licenza a' duo schiavi, c'ho in casa, di salire in banco; e l'otterrò di sicuro, a cotesto signore facendo il bucato, né altro avendo che Succiola, per bucataia.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Accòstati; lascia vedere il presentino.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>È ben buona robba. Fiuti, e rifiuti pure, ché non ha fieto alcuno.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Oibò, che cosa fetente! e quest'altra? peggio. Questa? questa? infine, tutte sono lo stesso.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>O signore, e che vuole, che cotestoro mi diano delle busse? Sono poverini, e 'l Cielo sa, se hanno altretanti quattrini come quelli che hanno ispeso in far coteste galanterie, che sua eccellenza gettando a terra ha rotte.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Che parlare è questo? che ho ruvinato? O to' questa cestellata, corpo del corpo della mia nobilissima madre se non fosse.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Fui iscema, lo confesso, perdonatemi. Or sue, non lo dirò piue, ho errato, confessolo, perdonisi.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Chiama questi schiavi. Sù presto, moviti, se non, che ti fo bastonare con cento verghe d'oro.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Ecco, i' volo, i' chiamo. Schiavetto, Schiavetto, Rondone, Rondone! Schiavetto, fuora, fuora! Presto, presto, presto!</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>E come, uno di costoro ha nome Rondone? O che ridicoloso nome! Certo, certo costui ne farà ridere tanto, tanto, tanto; già incominciò. Eh, eh, eh, o che ridere, ohimè, ohimè, dite che non mi faccia più ridere, ohimè, ohimè, ohimè!<pb n="131"/></p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Vuole che si chiami?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Sì dico, presto, ché lo voglio vedere, presto, ché mi torna la ridaruola.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>O Rondone, non senti eh? Dove domine se' tu ficcato, ne' buchi de' campanili? Voglio entrare e farlo uscire.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Fa' che venga or ora. Ohimè, un'ora mi pare un anno, che costui venga, tanto ho voglia di vederlo.</p>
           </sp>
@@ -3287,236 +3360,236 @@
           <stage>
             <hi rend="sc">rondone, succiola, nottola, cicala, grillo, corte, rampino, alberto, prudenza</hi>
           </stage>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Uh uh? E che dischene sarà con questo Rondone? che vuoi? chi mi vuole?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>E questo è Rondone? Da gentiluomo, che mi piace! O che bello e ridicoloso Rondone, eh, eh, eh.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>E che diavolo ha costui?</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Chètati, chètati, cotesto è un principe, vedi.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Oh? Non mi era di più accorto: Rondone è zoppo ancora.</p>
             <p>E che, t'hanno voluto cogliere al laccio, che se' storpiato?</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Eh messere, gli uccellatori solo a gli uccelli grossi uccellano con il laccio, e non a i piccoli.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O che becco cornuto! Questa viene a me del sicuro, buono, buono, buono.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Do', gobbo boia, tu non fa' altro che riderti di me? e che hai nella gola?</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Che l'ammazzi signore.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Che ammazzare? Son io una pecora, razza di becchi?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Lasciatelo stare, ch'è il mio spasso. O come m'ha piaciuto quel dirmi razza di becco!</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>O piàcciati, o non piàcciati, non ho paura d'esser da costui ammazzato.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>E perché?</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Che giorno è oggi?<pb n="132"/></p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Che proposito, bisogna ben tanto ridere, eh, eh, eh, eh.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>E sua eccellenza non va in collera di coteste parole vituperose?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Si vede bene che non sapete che siano persone grandi: questo è 'l nostro gusto, in farci così dir villanìa, perché sì come non può essere quello che costoro dicono, così ne ridiamo. E più cresce in noi il riso in veggendo che quanto più le villanìe a noi si disconvenghino, ch'uno poi sia tanto sciocco, che non lo conoscendo dica cose tanto allo stato sproporzionate, sì che stimandolo pazzo (come pazzo sarebbe chi dicesse, per far onta al sole, ch'egli sia oscuro) per questa cagione ne fa ridere, e straridere.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>In effetto i grandi sono grandi per più capi: grandi perché nascono grandi per nobiltà, per tesoro e per sapere. Che risposta è stata quella, eh?</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Tanto che vi piace esser caricato di villanìa?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Sì, da' pari tuoi.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Eh? Io vuo' anche, per uomo tanto ridicoloso, che per ridere tollerereste che vi fosse ancora detto villanìa da un commune di villani.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O questo no, da gentiluomo.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Eh, non bestemmiate! Voi gentiluomo? Di tali gentiluomini abbonda l'ospitale ancor de gli Incurabili.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O che furfante, eh, eh, eh, ohimè, mi scoppia la vescica! Un orinale, presto, presto, presto! Non farete a tempo. Or sù, con licenza, piscierò qui io a questo muro.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O che signore ridicoloso.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Di' pur vituperoso, ché dirai meglio. Non ho veduto mai il più porco io.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Che cosa ha detto? Rampino, dillo.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Il signor Alberto ha detto che sua eccellenza è un signor ridicoloso.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>E che ha detto Rondone a quel ridicoloso?</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Che sua eccellenza è un signor vituperoso, e che non ha giamai veduto il maggior porco.<pb n="133"/></p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Porco? Tu sta' meco. Voglio ora accoppiare il porco e l'asino in una sola stalla.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Durerete fatica.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Perché?</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Sono un asino spiritato, tiro calci a tutti.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Ferma.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Non fare.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O buono.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Ohimè.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Va' dietro.</p>
           </sp>
-          <sp>
+          <sp who="#cicala">
             <speaker><emph rend="sc">cicala</emph>.</speaker>
             <p>O traditore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Eh, eh, eh.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>To' questi tu, gobbo porco.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Non fare, ferma ferma.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Ferma, che fai?</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Che fo, e che diavolo, sète guerci, non avete veduto? Ho dato quattro piedi nel culo al mio compagno signor porco.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Or sù, questo vestimento è tuo, poiché con i piedi l'hai tutto sporcato.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Spogliati, sù.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Ferma là, furfante.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Lasciatelo fare, in ogni modo sono di sotto vestito pur nobilmente.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>O quanti, che ho isporcati con i piedi, ho spogliati con le mani! Era boia io, signore, e per questo la fortuna ha voluto ch'io vi ponga le mani intorno, per farvi conoscere che ancor voi siete carne da carnefice e da corbi. Or sù, ora che v'ho spogliato, entro a vestirmi, e vengo or ora, più d'oro carico, che giamai fosse, o lo scotto o 'l fortunato. E con un trattenimentino poi d'un giovinotto di sedici anni in circa da rallegrare ogni svogliato. Così si fa, poltronacci, non bisogna sempre essere intento a vestire il signore, e a serrare i suoi tesori sotto mille chiavi. Imparate da me a spogliarli e a rubargli; in ogni modo sono così galanti, che non vi fanno altro, o vero che per farvi paura vi fanno una sol volta appiccare.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O signore, qual meccenate fu giamai più di sua eccellenza glorioso?<pb n="134"/></p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Rampino, portami una di quelle cimarre da camera di quelle sessantaquattro ch'io ho comperate.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Vado, signore, e or ora ritorno.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O poeti, o istorici, se bramate fatti gloriosi, per li quali farvi eterni possiate, pigliate la penna, che con poca pena direte che vana fu questa voce di liberalità ne' tempi trascorsi, e che realmente allora si ritrovò quando nacque il liberalissimo principe Nottola, esempio di gloria a i prìncipi presenti, e di scorno a prìncipi passati. Dichino pure ch'uomo al mondo più potente non è quanto il liberale, poiché donando viene a conservare gli amici, viene a confondere gl'inimici, e farsi immortalare. Dichino che uomo più simile al Sommo Fabro non è quanto il liberale, in altro quel sommo amore non dilettandosi che nell'amare e che nel giovar donando. E che forse non ne dona egli la luce del sole, con la quale dalle tenebre alzando la fronte ne rallegra? non egli (tutte le cose liberali bramando) che la terra doppo aver dimostrato la ruvidezza sua, la sua rustichezza, con lo stare infeconda e pigra, tra mille nevi coperta, che in larga copia doni a ciascun che vive alimenti vitali? Il mare anch'egli, deposto il natìo furore, non ti porge quello che nel seno chiude, con mano tranquilla, che pria con piede ondoso fuggendo si ti negò? Ma se lungo esser volessi, non trovarei, che stella non è, ch'elemento non ispira, ch'arbore non frondeggia, che serpe non istriscia, che animale non corre, che uccello non vola, che tutto intento al giovare, liberale fatto non sia? Adunque il liberale è senza, è uccello che vola, animale che corre, serpe che striscia, arbore che frondeggia, elemento che spira, stella che ruota, mare che è in calma, terra feconda, Giove che giova. E per lo contrario, chi liberale non è, non è Giove, non è terra, non è stella, non è elemento, non è arbore, non è serpe, non è animale, non è uccello, alfin terminiamola: non è nulla. Voi dunque, o signore, il tutto siete, poiché di tanta liberalità andate adorno.<pb n="135"/></p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Ecco la sopraveste, signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Oh? Questa è buona. O Rampino, se tu fussi istato qui, averesti sentito il mio signor Alberto che ha fatto una bella infilzata di Giovi, di soli, di terre, di mare, di stelle, d'elementi, d'arbori, di serpi, d'animali, d'uccelli, di tarantole, di ragni, di scarpioni, di grilli, cose tutte da star grassi. Or sù, Alberto, vi facciamo nostro secretario.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>E questa è somma grazia ancora.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Oh? Cheti, cheti, ecco Rondone ben vestito, ecco il compagno e Succiola. O come è ridicoloso, eh, eh, eh. Ma che rumore di sonatori? Una bella armonia è questa, per certo.</p>
           </sp>
@@ -3524,75 +3597,75 @@
         <div type="scene">
           <head rend="italic">SCENA OTTAVA</head>
           <stage><hi rend="sc">rondone, schiavetto, succiola, sonatori</hi><hi rend="italic">da pastori vestiti</hi>, <hi rend="sc">nottola, grillo, cicala, alberto, prudenza, corte, rampino</hi></stage>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Signore, questi sono sonatori della città, così da pastore vestiti, e vogliamo, Schiavetto, Succiola e io, farli un villan di spagna concertato poco fa in casa.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Or sù via, incominciate, ch'io in tanto apparecchio il borsone da premiarvi.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Sonatori, via, date principio, o buono! O che bel suono. Signore, state intento e tacete.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O che belle riverenze, che dite meser Alberto?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Bellissime.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O come Rondone sgambetta bene, e Succiola? Càppari, so ch'ella è su 'l menare daddovero! Figlioli, vi siete portati molto bene, ora sta a me di portarmi bene con voi altri, razza di grilli e di cavalette, poiché così bene ballando saltavate. Rampino?</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Donagli diece scudi d'oro per uno e di quelli pesati.<pb n="136"/></p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Casasego! Oh? A cotesta foggia si potrem salvare.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Rondone, questo è un liberal signore, questa è la nostra ventura.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Holla conosciuta, ch'è la mia buona fortuna, e però l'ho incominciata a pelare. Ma signor principe, non volete un poco sentire ancor cantare?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Certo sì, e chi canta?</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Chi canta? Io, e Schiavetto.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Canta un poco.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Fa, la, la, la.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O questo fa la la la lela, lo so cantare anch'io, non v'è altro che te, che canti?</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Eh? Che v'è Schiavetto, che non si può sentir meglio.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>E mene, dove lasciate? Suona, Schiavetto. Udite un poco. Suona la calata.</p>
             <p>
@@ -3606,19 +3679,19 @@
               </quote>
             </p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O che Succiola valente, càntene un'altra tu pure, ché per ora non voglio guastarmi con altri canti il gusto.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Or sù, i' mi contento, ma ad ogni duo versi, per ripresa, fatemi la sfessaina, ch'io ballandola brevemente arrecherò gusto all'occhio danzando, gusto all'orecchio cantando.<pb n="137"/></p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Succiola, tu vali un milion d'oro, ma non bisognerebbe che la Succiola avesse spine.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Crediatemi signore, che ve ne sono molte poche, ché ogni quindisci giorni, io me le abbruscio. Or sù sonate.</p>
             <p>
@@ -3636,91 +3709,91 @@
               </quote>
             </p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Tu ha' ballato e cantato molto bene; or entrane con Rondone e Schiavetto, che teco hanno ballato così bella bergamasca; e come torno dal giardino fa' che apparecchino alcuna cosa bella da fare, ch'io pure anderò pensando modo d'esser loro grati.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Signore, se forse e' non sa, i' voglio ire a rasciugarmi, ché sono più molle che s'avessi fatto diesce miggia. Stia sicuro, di buona voggia, ché fra Rondone e Schiavetto, e' sarà fatto ogni cosa.<pb n="138"/></p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Signore, addio.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Addio figlioli. Entrate, sonatori. State qui, voi. Oh? Di grazia, signor Alberto, la seggetta che avete in casa. Rampino, valla a tôrre.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Vado signore, e or ora son da lei.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Sono bene stato sciocco da vero a non la fare arrecar prima.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Signor Alberto, mandate in casa la figliola vostra, e mia signora consorte. Anzi, lasciate che fino alla porta io l'accompagni. Datemi la mano.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Eccola, signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Andiamo, entri felice. Or vostra signorìa illustrissima ed eccellentissima se n'entri.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Illustrissima ed eccellentissima, o che gusto.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Ohimè son morto, ah traditori.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O signore, sù sù, ché l'aiuto.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>E io, signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Rampino, se' morto!</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Eh, signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Non mi tenete.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Signore m'ascolti, con le ginocchia a terra lo prego: s'è caduto è stato perch'ella era avanti la porta, e io (per venir presto) uscendo con le spalle a dietro da la stessa porta, l'urtai, ond'ella cadde; sì che mi scusi il desiderio di servirla tosto, e del non sapere che fusse su la porta.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>È così? Ti sia perdonato. Apri la seggetta. Signora, entrate.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Le fo riverenza, signore e consorte.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Addio. Sonatori, mentre entro in seggiola sonate, e sonando seguitatemi fino al giardino.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Sù presto, sonate. O buono.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Alberto, andiamo.<pb n="139"/></p>
           </sp>
@@ -3731,63 +3804,63 @@
         <div type="scene">
           <head rend="italic">SCENA PRIMA</head>
           <stage><hi rend="sc">orazio</hi>, <hi rend="italic">e</hi><hi rend="sc">prudenza</hi></stage>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Orazio, infelice Tantalo amoroso. Tu sitibondo, tu famelico se' tra le poma e l'acque dell'esca, e della bevanda amorosa, che ti porge in cara mensa Amore. E quando di quelle, e di questi, gustar vuoi, ecco che fiero tenore d'ingiuriosa stella fa che dalle tue labra fuggono l'acque, e dalla tua mano s'involano i frutti. Pur io era da ebreo vestito, pur io era vicino alla casa di Prudenza, pur io premeva la soglia di quella, pure quasi io era in casa. Ed ecco come fortuna, parca nel mio bene e prodiga ne' miei danni, fe' sì, ch'io non potessi tanto avanzarmi, ch'io giungessi alla bella cagione dell'ardor mio. Ma perché Prudenza non s'attristi, perché non mi tenga amante di fede indegno, ne gli abiti miei da lei fo ritorno, per farla a parte del fiero accidente, che sturbatore, che involatore, che rapitore fu d'ogni nostra gioia. Ma s'io non erro, ecco de' raggi suoi tutta luminosa quella finestra, certo questi sono i raggi messaggieri dell'arrivo del mio bel sole. Ecco ch'io non mento. Sù, sù, fatto aquila<pb n="141"/> amorosa, vagheggia del tuo sole que' raggi che a faccia a faccia abbaglierebbono lo stesso sole.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>O caro Orazio, o cara vita mia, se la mia morte ella forse non mi procura, mi levi da tante miserie.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>E pur piange, e che vuol dire? Deh, manchino le lagrime a gli occhi suoi, se brama che non abbondino i tormenti al mio cuore. Tutte sono lagrime mie quelle che da duo begli occhi, anzi quelle che da due luminose pleiadi ora scendere i' veggio in così acerba pioggia. Questi, questi miei lumi sono i duo lagrimosi fonti che formano que' duo rivi, ch'ora le innondano il seno. Rasciughinsi, rasciughinsi le lagrime, pria che in mar di pianto seco i' mi sommerga.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Ben che, amato mio signore, ne' miei tormenti avanzino l'angoscie al cuore, e manchino le parole alla lingua per far nota la cagione de' miei affanni, pur legge facendo a me medesma, lo dirò. Sappia che 'l mio crudelissimo padre, il Mida novello, per la sete, per la fame, che ha dell'oro, non solo ricevette in casa quel principe, ma di più violentemente ha fatto ch'io le abbia data la fede di consorte.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>O che ascolto! O maledetta avarizia d'ogni mio danno fieri cagionatrice. Ed è possibile, o avarissimo padre, che per arricchire te stesso, tu abbia ne' satanici tuoi fatti destinato d'impoverire la tua figlia di libertà? di quella libertà onde benigno Cielo halla arricchita? A che procuri d'accumular tesori, se all'avaro tanto manca quello che ha, quanto quello che non possede? O avarizia, fonte d'ogni crudeltà e d'ogni miseria, perché non sono io Giove, che stillandomi indorata pioggia potessi al presente saziar le tue voglie instabili e acquistar con quello voi, mio lucidissimo tesoro? Perché non sono io il famosissimo Gange, o la celebrata fonte d'Afri<pb n="142"/>ca, acciò che rivolgendo fra le onde mie vastissime cumuli d'arene d'oro, io potessi con simile prezzo acquistar quello che alla sola fede sarebbe dovuto?</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Pur troppo è vero, mio bene, pur troppo è possibile che quest'oro maledetto con la sua pallidezza abbia accicato gli occhi di mio padre, che non sapendo che tener si dee più caro i tesori della virtù, che tutti i tesori del mondo, per apprezzar l'oro disprezza lei, ch'è vero erario d'ogni virtù maggiore.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Il nostro vicino bisogno, amorosa mia signora, ricerca che più si pensi modo di far noi contenti, che con parole dilacerare la cieca avarizia del suo padre crudele. Qui, mia signora, con una fuga generosa bisogna sottrarsi dalla tirannide del padre e del principe.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Sì sì , che ciò far si debbe, sì ch'è dovuto fuggir dal padre per seguire il consorte. Ma se (oh non lo volesse il Cielo) venisse questo principe a casa, né volendo il tempo della notte aspettare mi violentasse alle sue voglie? Creda pure che prima che un torto a lei, che con un ferro finir la vita io vorrei.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>O qui premere bisogna, poiché fa di mestieri pensare e ripensare ben bene quelle cose, che fondate sono in evidente pericolo. O Amore, soccorso, aìta cortesissimo inamorato nume.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>O Cielo aìta.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Deh, s'egli è vero che tu, o potente nume, assotigli l'ingegno a' tuoi seguaci, pregoti che tu a questi amanti concedi modo di fargli felici, e che tu, benigna madre di lui, o Venere potente, per quelle dolci faci che del bellicoso Marte t'accesero, ti prego che da questo inestricabile laberinto felici usciamo. Porgi tu, novella Arianna, il filo a questo nuovo Teseo, acciò, co 'l favor tuo, nulla tema de gl'intricati sentieri, e possa atterrare insieme il crudo Minotauro del padre di<pb n="143"/> Prudenza mia. Ma ahimè, che le angustie del tempo e la grandezza del pericolo non mi lasciano sovenire rimedio opportuno.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Deh, imponga omai, ché in così fatto indugio mi struggo.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Come viene costui (dato che fosse di tal rabbia ripieno), vadalo co 'l maturo giudizio suo affrenando con piacevoli vezzi, con parole cortesi, pregandolo che sino alla sera non voglia molestare il castissimo animo suo; ché, ciò facendo credo che non potrà tanto aver munito il cuore di discortesia, che a gli assalti cortesissimi suoi non rimanga abbattuto. E s'egli pur nell'esser più pregato, più ingrato si dimostrasse, finga qualche faccenda; e, per la via del giardino suo, a qualche scampo sicuro volga il passo, ch'io avisato poi verrò a trar lei di guai e a far me contento.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Viva pur certo, amatissimo mio bene, che più mi lascia consolata per vedermi (mercè de' suoi maturi pensieri) lontano dalla rabbia amorosa di costui, che lieta allora non si rimira tortorella che partirsi vega dal fianco grifagno animale, che bramoso fosse di darle la morte. Addio, mio bene.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Vada felice, mia vita. Sferza, sferza pur tu, Apollo, i tuoi destrieri, acciò che venga quest'ora tanto bramata, che ben io pronto qui d'intorno al suo tempo troverommi, per non mi mostrare a così lucido sole talpa troppo cieca.</p>
           </sp>
@@ -3797,7 +3870,7 @@
           <stage>
             <hi rend="sc">fulgenzio</hi>
           </stage>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Certo che sì come non mai si vide il giorno senza sole, la notte senza stelle, il mar senz'onde, i fiumi senza arene, e i boschi senza frondi, che così non si vedrà giamai amante senza martirii, senza sospiri e pianto. O come Amore a questi miseri amatori, sovente, facendo loro vedere il falso per lo vero, alcuna fiata gl'innalza a somma felicità, e ora gli affonda al centro d'ogni calamità. Ecco, me misero, come il precorrere l'amante da ebreo vestito mi fe' poggiare al cielo d'amore con ali di vana speranza. Ecco come, non<pb n="144"/> avendo avuto effetto i miei pensieri, mi trovai caduto all'inferno d'un cieco furore. Ed ecco alfine come qui mi trovo con certa tema che Orazio abbia goduto quello, con reciproco amore, ch'io con inganno di goder sperava. Ah, che così fattamente in interno in questo pensiero crudelissimo amore che ben conosco che a così gran battaglia dolorosa è picciolo campo il petto. Ma poi, che nell'oriente della mia giovinezza per crudel sentenza debbo veder l'occaso della mia vita, né, in questo mio estremo, mi viene conceduto di poter mirare un raggio di speranza, che allo stato mio compassionando sgombri quel velo oscuro di morte che dee tenebrar queste mie luci, non mi sia tolto almeno che l'infelicità di questo misero amante giunga all'orecchio della cagione d'ogni mio martire. E s'altro non sarà qui d'intorno, che messaggiero funesto arrechi all'orecchie di costei la mia morte, l'aure pietose almeno faccino questo dolente ufficio. O virtù del sangue, che in larga copia m'apparecchio a spargere, scorrendo per lo terreno formi caratteri dolentissimi, che narrino della mia vita il traggico caso.</p>
             <p>Ecco il ferro, me fero della mia fera selvaggia, poich'ei dovrà una sol volta la morte darmi, ma la mia dispietata maga più volte si trastullò, doppo avermi ucciso, di richiamarmi alla vita, per farmi poi con nuovi straccii nuovamente morire. Ecco, ecco dico, come vittima dolente al grande altare della tua ferità ch'io mi piego, e sospiroso, e lagrimoso attendo il colpo. Ecco già che il crudelissimo Amore sacerdote fatto alza il ferro, intento a miserabile, a mortale colpo.</p>
@@ -3808,299 +3881,299 @@
           <stage>
             <hi rend="sc">nottola, rampino, grillo, cicala, paggi, fulgenzio</hi>
           </stage>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Tienilo, Rampino, tienilo, tienilo.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Olà? Che cosa è questo?<pb n="145"/></p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Lasciatemi morire.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Fermatevi là, dico. Pur troppo a i danni della vita corre frettolosa la morte, senza che voi gli accelleriate il passo.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Olà gentiluomo, fermatevi, quando i prìncipi commandano.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Signore, ella mi nega che con questo ferro si ferisca questa carne, e con queste parole di mantenermi in vita mi ferisce l'alma. Vuole il Cielo ch'io muoia; or noi, che figli siamo del Cielo, ubidir lo dobbiamo e sappiate che quello che negate che faccia in me il ferro, lo farà alfine il dolore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Or sù non più, dico, ché la morte incresce in sino a i pollastri e che sia vero, que' tanti saltarelli che fanno dopo aver loro alcuno tirato il collo, che vogliano dire? Altro non dicono se non che gli rincresce di lasciar questo giardino mondano, dove con tanto gusto andavano ruspando e beccolando. Io per me vorrei più tosto vivere servendo all'uomo mendico, al quale mancasse il vitto cotidiano, che commandare a tutti i morti.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Signore, niuna cosa è migliore all'uomo che 'l nascere e niuna più fortunata che 'l presto morire.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Eh? Noi altri prìncipi abbiamo ancora sopra la morte scartabellato qualche cosetta, fin a Grillo dispiacerebbe il morire, non è così?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Egli è certissimo signore, e apunto in certo tempo io serviva un vecchio, molto carico d'anni, il quale altro non faceva che dire: «Oh Cielo nemico, perché riserbarmi a questa età, che dovrebbe esser di riposo, per far ch'io abbia tanti travagli come quelli dove io mi vivo involto? Meglio pur m'era il morir giovinetto!». Al corpo di me, che questo buon vecchio s'infermò, e gravemente io dissi allora: «Certo, che il Cielo vuole esaudire le sue preghiere co 'l mandarli la morte», ma dindi a poco, io vedo venir da lui tanti medici, tanti barbieri, serviziali, medicine, siloppi, pitti<pb n="146"/>me, profumi, impiastri, gargarismi, e mille altre triacche da vòtar ventri e borse, né cosa alcuna li giovava. Di più sento il prefato vecchio, che un giorno quasi piangendo dice: «Vedete, o signori della mia salute gelosi, non guardate a cosa alcuna, né a diligenza, né a spesa, purch'io guarisca, ché a ciascuno darò grato riconoscimento d'aver molto conosciuto il beneficio fattomi». Così un giorno, avicinatomi al suo letto, fatto cuore io li dissi: «O mio signore, voi l'altro giorno non facevate altro che querelarvi della vita, invocando la morte, e ora ch'ell'è in viaggio per venir da voi, altro non fate che mostrar di volerla mal gradire; e perché questo, caro signore?». Allora il vecchio a me rivolto così disse: «Figliolo mio, sappi che non v'è la più facil cosa che il chiamar la morte, e la più dificile, che 'l riceverla in casa; e io per me mi contento più tosto, vivendo, di provar tutti i travagli della vita, che gustare una mez'ora un solazzo solo della morte!». Sì che mi credo che ancor voi, o cavaliere disperato, con la stessa facilità al presente la chiamiate, ma che con la stessa dificultà (quand'ella fosse in cammino) la ricevereste poi.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Credimi fanciullo, credami ciascuno di più maturo senno, ch'io certo morrei, se la morte negata non mi fosse.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Con licenza, signor principe.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Séguita, ché gustiamo del tuo spirito vivace.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>O son ben nato d'un asino più grande della signorìa vostra s'io ve lo credo! Pigliate questo mio pugnalino, amazzatevi.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Non fare, ché si ucciderà.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Che si ucciderà? Questi polmoni fracidi! State a vedere: pigliate.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Da' qui.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Datevi.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Ch'io mi dia?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Sì presto, presto, che fate? Non s'indugia.<pb n="147"/></p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Io mi darei...</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>O qui ci entra il ma, come la cotenna ne' cavoli.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Io mi darei, dico...</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Ma...</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Ma...</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Non lo diss'io? ma, che? ma, ho paura di farmi male!</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Ma, considerando la forza de' prieghi e commandi di questo generoso principe, non debbo farlo.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Sì sì, porri co 'l sale! Quanto a me non vi stimerò giamai più gentiluomo di parola. Bella cosa, uh? Dalli, dalli, dalli.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Sta' cheto; olà, non più, dico.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Certo che Grillo questa fiata l'ha intesa.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Signor principe, io sapeva certissimo che averebbe mancato di parola, poiché nel più de' gentiluomini è questo costume di mancar volentieri e di prometter molto.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Or sù, poiché voi per me non vi siete tolto la vita, voglio farvi de' miei gentiluomini più cari; ma diteme, perché d'uccidervi v'era caduto nel cuore disperato pensiero?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>A così caro signore sarà ch'io celi cosa alcuna? Certo no. Sappia l'eccellenza sua ch'io vivo amante d'una bellissima fanciulla detta Prudenza. Per ottenerla ho tentate mille stratageme, alfine fu il tutto un cercare di levar la luna alla notte, e 'l sole al giorno. Ma quello che più mi accorra è in pensando che altro amante me l'abbia rapita.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Rampino.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Senz'altro questo amante parla di me, se pure questa Prudenza è la figliola di meser Alberto. Ditemi, gentiluomo, come ha nome l'amante che possede Prudenza?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Orazio.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Or sù Rampino, non son io.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Eh? Signore, vi sono molte Prudenze.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Questa Prudenza di chi è figliola?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>D'un certo signor Alberto, gentiluomo di facoltà e d'anni assai carico, e d'avarizia assai più dovizioso.<pb n="148"/></p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Se questa Prudenza è figliola di questo Alberto, rallegratevi, ché vi do, una buona nova.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>E qual è, signore? Ohimè, di già tutto gioisco.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Questo Orazio non ha goduto Prudenza, né sia giamai che la goda.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>O lieta nuova! o fortunata quell'ora, che un tal signore mi tolse dal grembo della morte, riponendomi nel seno di somma vita felice.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Or non è questa una buona nuova?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Certo sì, signore, ch'è buonissima.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Or apparecchiatevi a riceverne un'altra, ma cattivissima.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>E che sarà mai?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Sarà che Prudenza è mia consorte.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Ohimè.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Càppari, guarda mo, Rampino, se s'è fatto smorto e quasi di pietra?</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>O poverino.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>O pessima nuova, o dolorosa nuova mortale.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Che sì, che torna su 'l chiribizzo di morire?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Credo pure che abbiate sentito il gran travaglio, eh?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Tale, signore, che non ho lingua per narrarlo, né cuore per soffrirlo.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Or sù, apparecchiatevi a sentire un'altra buona nuova.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Signore, per me ora sono perdute tutte le gioie, e i contenti, poi che ho perduta Prudenza mia.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Anzi, voglio che sia tutto al contrario.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>E come sarà mai questo?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Come? co 'l darvi Prudenza per moglie.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Deh, per grazia, non cerchi più di traffigermi con questo schernirmi di più ancora.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Dico che da vero io ragiono, per la nobiltà mia incognita e non conosciuta. È vero che dovrebbe esser mia, ma perché vedo che tanto l'amate e perché v'ho fatto mio gentiluomo mi contento di cedervela.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Amore, che ascolto? e Prudenza sarà mia?<pb n="149"/></p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Vostrissima, vostrissima. Eccovi la fede.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>O Cielo benigno, che dirò? Deh, se gli oblighi, che con sì caro signore tengo, avanzano di cotanto ogni umano ringraziamento, in vece mia parlino gl'istessi favori a me fatti e quelli siano che accusino quanto a così glorioso signore io mi viva obligato.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Non più parole; vi dico ch'è vostra, e di più le fo contradote di cinquanta fili di perle e di dugento rubini slegati e di trecento rubinotti legati in un gioiello. Vi fo dono di carozza, di cavalli, di lettica, e di muli; vi dono dodici molini e sessantaquattro paia d'asini.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>O che ventura, gentiluomo.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Or sì che tanto certo sono d'ottenerla, quanto io già viveva fuora di speranza di non la possedere, colpa solo della mia gran povertà e dell'avarizia grande del signor Alberto; ché certo, s'io fosse stato ricco, l'averei fin ora avuta dal padre suo, e Orazio ne sarebbe rimasto senza, per essere anch'egli poverissimo gentiluomo.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Basti, che vostra sia, non si cerchi altro. Rampino?</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Mio principe, mio nume, che vuole, che impone.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Batti a quella porta.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Io batto. O dalla casa, o dalla casa! Olà, dich'io.</p>
           </sp>
@@ -4110,95 +4183,95 @@
           <stage>
             <hi rend="sc">prudenza, nottola, fulgenzio, rampino, grillo, cicala</hi>
           </stage>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Chi batte?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>La nobiltà di tutti i prìncipi di Spagna e di tutti i baroni di Francia. O ecco Prudenza.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Ecco ogni noia per me, ma bisogna simularlo, conforme quello che mi disse il mio amoroso precettore. Con ogni debita riverenza, mio consorte e signore, le m'inchino.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Signora, non è vero principe quello che sta più d'un'ora fermo in un proponimento; per tanto dirò (a dirvela a<pb n="150"/> lettere maiuscole) che mi siete omai venuta in fastidio; sì che prevedetevi pure d'altro marito.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>O Signore, il principe che, ne' gravi e degni pensieri, esser dee più ben fondato che duro scoglio nel mare e noderosa quercia in monte, oggi adunque dovrà mostrare tanta leggerezza.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Ben si vede che siete una femminuccia, poi che leggerezza chiamate quello ch'esser dee nomato sommo sapere. Ma non più parole, tocca la mano a questo mio gentiluomo.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Come? O questa sì che sarebbe piacevole.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Or sù, m'intendete voi? Date qui questa mano, fate presto.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Dico che non voglio. Fermatevi signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Do' sfacciata, piglia questo.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>O poverina me, una guanciata? Uh uh uh.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Eh, vostra signorìa non le dia.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Tu mi commandi? To' questo. A chi ti pensi di parlare?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Sua eccellenza mi scusi e mi perdoni.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Da' qui questa mano.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>O me misera, a questa foggia? Non lo voglio, no no nonò.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Tu lo piglierai rabbiosaccia, sì, sì, sì, sì! Tocca qui dico. O fa' un poco ch'ora ei non sia tuo!</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>No, che non sarà.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>No? Tu lo vedrai. Fa' che alla più lunga alle ventiquattro tu sia in guardia di ricevere il marito, perché come io torno voglio che si consumi il matrimonio. Fulgenzio vien meco, al palazzo. Tenetemi dietro, canaglia, e guardatevi, ché sono in collera, perché tanto offendo con le parti di dietro, quanto con quelle dinanzi, quasi toro bavoso e mugghiante, che tanto co 'l calcio, quanto co 'l corno offende.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Addio, mia cara consorte.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Io vostra consorte? Più tosto mi voglio levar la vita.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Voglio ben che moriate, ma di quella morte maritale, sì onesta e sì gradita, che morendo dà vita. Addio, mia cara sposa addirata.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Misera, ancor mi beffa, il traditore. Oh addolorata anima mia, e a qual maggior dolore aspetti di uscire da<pb n="151"/> questo tuo mortale? Or sì, Orazio mio, che disperate sono le mie speranze di teco fuggire, poiché invidiosa fortuna, prima che tu m'involi, vuole ch'a te involata io sia. E sarà vero? e solo in pensarlo non mi leva da i vivi e non mi dà in preda a i morti? Ahi che affanno, ahi che lagrime, ahi che sospiri, ahi che umor freddo mi sento scorrer per l'ossa! ohimè qual tenebroso velo gli occhi mi ammanta? ahi che lassezza, ohimè ch'io manco, io cado, io moro.</p>
           </sp>
@@ -4208,163 +4281,163 @@
           <stage>
             <hi rend="sc">succiola, rondone, schiavetto, prudenza</hi>
           </stage>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Guarda, guarda.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Corri, Rondone, corri.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Che poca discrezione, non mi aspettare! È caduta lei.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>O arcolaio, e che diss'io, delle nostre baccelate, eh?</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Oh? delle nostre Succiolate! Sempre tu se' su' tuoi proverbi.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Oh? Udite il bue delle maremme.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Uh? Udite la vacca trentina.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Eh? Rizziamo questa povera signora ch'è caduta in terra.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Ma vi dirò il vero io. Ho tanto bello umore quanto costei s'abbia; per tanto, sì come gli è piaciuto di gettarsi a terra da lei sola, così le piaccia da lei sola di rizzarsi in piedi.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>E tu non vedi che per isvenimento ell'è caduta?</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Oh? S'è così, l'aiuto. Cànchero, pesa! Ho paura che tutti i morti le siano entrati addosso per farla più pesante, io.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>I' ti vo pur anche a cotest'otta aiutare, sudiciaccio.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>E io pur t'aiuto, sù via.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Sù via, issa, issa, issa.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Cotestui è stato aguzino di galea al sicuro.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Lodato il Cielo, ella riviene. Rondone, tu corri in casa per quelle mie acque odorose, per consolarla. E tu non parti ? tu non camini?<pb n="152"/></p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Siete pur buono, non sapete che il Rondone ha pochi piedi? Non si dice mai va', ma vola o balotta.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Oh com'è faticoso il viaggio della morte! Sfortunata Prudenza, se' pur di nuovo ritornata in vita, per di nuovo morire, acciò che sia doppio il dolore, doppia la morte.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Signora, s'è vero che cosa alcuna non si neghi a chi con non finta umiltà chiede grazia, richiedo, pregola, de gli affannosi suoi contrasti a darmi parte, ché come un peso è più leggiero a duo, che ad un solo, così il peso de' travagli communicato ad orecchio amico viene in gran parte a far minore la soma delle noie; né mi sdegni credendo che da abito così vile uscir non possano se non vili pensieri, perché da le siepi di sole spine spuntano ancor le rose e dalle rustiche conche si traggono le perole.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Il mio male è così disperato, che speranza alcuna non ha di bene.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>E disperata nave sovente in porto sicura e lieta ricovrossi.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Ohimè, ché troppo la nave di questa mia vita è carica d'affanni e di tormenti, uop'è che l'onde di morte l'inghiotischino.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Le mani della prudenza la scarichino di tanto pondo. Ah signora, non si fugga la vita, che se ben è d'affanni ripiena, nondimeno è cara e desiderata.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Felice è la vita di coloro che nella Trapobana isola vivono, poi che saggia lingua riferisce che colà solo gli uomini vivono senza travaglio. Ma chi mira questo cielo, sotto questo clima forz'è che s'addolori, nato essendo alle angoscie, a gli affanni, al pianto.<pb n="153"/></p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Or sù signora, in grazia, si termini questo certame lagrimoso, e basti che ogn'un che vive dee cercar di menar vita allegra. In grazia, mi palesi il suo male, ché ogni male ha rimedio.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Sentomi così dalle vostre preghiere in queste mie amarezze far una dolce violenza, che forzata sono, cangiando l'assenzio in mèle, a dir quello ch'io bramava di palesare solo alla morte, oggi secretaria fatta delle mie passioni.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Sì sì signora, disce bene, islargatevi un pocolino, un tantolino, ché giova molto, vedete, ne' travagli e smisurati.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Or m'udite, cortesissimo giovine, che a tesser comincio, sopra le fila del dolore, la mia miserabile tela. Io amo un gentilissimo garzone, detto Orazio Cortesi, e in dolce trasformazione amorosa ambi viviamo congiunti. Ora nemico padre, intendendo far di noi amarissima separazione, terminò di darmi ad un principe sconosciuto per moglie, e questi non così tosto mi toccò la mano, che li cadde in mente di rinunziarmi ad uno ch'odio al paro (non dirò della morte, poiché solo per colpa di costui la morte apprezzo) ma dirò bene che l'odio quanto l'odio istesso odiar possa. Ma se pur questo principe d'ogni volubiltà e ignobiltà m'avesse conceduto un poco di dilazione di tempo, non sarei sì mesta, perché, avertito il mio caro Orazio, avrei seco potuto fare di quelle ultime resoluzioni che suol fare generoso cuore inamorato. Ma il peggio è che mi ha detto che come torna vuole che meco goda de' frutti maritali, o vero, alla più lunga, al tocco delle ventiquattro ore.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Chèti tutti. Non guadagno io un chicchirillò se senza andare da' giudici a squittinare, i' do la sentenza in vostra lalde? Ho la gozzaia anch'io, per dirla con quel miser Fulgenzio, che ad ogn'ora va qui dintorno ronzando; ma l'avrà errata questa fiata. Ditemi, non disse il principe che<pb n="154"/> alla più lunga si doveva logorare il matrimonio alle ventiquattro?</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Sì.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Oh? Mi servirei del motto di monna pippa gobba dalle poppe sudisce, che disse: «Se non ti piasce il parer d'aitri fa' a tuo mo'». Se non vi gusta all'otta delle ventiquattro godervi con cotestui, e voi alle ventidue godetevi con chi vi piasce.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Tu di' bene, ma questo non puote essere.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>E perché? La donna non è come il pignattaio? Come ell'ha fatta la pentola, è ben pazza se non gli pone il manico a suo mo'! I' vi vo' salvare dalle mani di cotestui ad ogni modo, si dovessi fare alle pugna seco, e riportarne il naso pieno di bitorzoli.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>D'ogni tuo affetto pronto al giovarmi io ti ringrazio, ma sappi che 'l tutto è vano per questa cagione, attendi. Già desiderosa io d'esser d'Orazio mio, oggi seco posi ordine di fuggirmene dal padre alle due ore di notte; or di veder Orazio mio, fino a quest'ora non bisogna già ch'io speri. Verrà in questo tempo Fulgenzio, verrà il principe, verrà mio padre, e temo che, dalla maggior forza superata la minore, far io debba quello che far già non vorrei.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Cicala un poco ancor tu Schiavottolo, e fa' che malgrado di cotestoro si vegga il bel gamurrino sciorinato, fatta isposa la signora Prudenza, e facendole moite gentildonne dietro un bel corredo, ella con gravità si cacci con la rosta le mosche dal viso.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Tu di' bene. Mia signora, perch'io so ch'ad un piagato d'amore tosto dar soccorso si dee, prima che lo spasimo amoroso li giunga al cuore, m'attenda, che l'alpestre viaggio di tanti affanni appianar le voglio.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>O lo consenta Amore.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Or ora per amor suo andare alla piazza i' voglio, ché ben questo Orazio conosco; colà voglio in eminente banco salire, e con il canto e con il suono ivi tirare ogni<pb n="155"/> occhio, ogni orecchio, a rimirarmi, ad udirmi. Non potrà fare che affaccendato Orazio per questa fuga non passi a caso per la piazza, subbito ch'io lo vedrò, farolli cenno e, avisatelo del tutto, delle gioie d'amore farò che s'arricchisca.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>O gentilissimo Schiavetto, che la libertade ad altri comparti, o come già m'hai ravvivato il core, vicino a sommergersi nel profondissimo Egeo del mio pianto! Io me n'entro tanto consolata, quanto già sconsolatissima a questo aperto cielo io venni.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Or sue, caro erbolaio amoroso, se fino a cotest'otta avete pasciuta la mia signora di verde lattuca, arrecàtele, vi prego, ancora il baccello, accioché possa mangiar tanta fava, che se le gonfi il ventre, anzi che nel ventre gli nasca. Addio.</p>
           </sp>
@@ -4372,31 +4445,31 @@
         <div type="scene">
           <head rend="italic">SCENA SESTA</head>
           <stage><hi rend="sc">rondone</hi>, <hi rend="italic">e</hi><hi rend="sc">schiavetto</hi></stage>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Ecco l'ampolla dell'acqua consolatoria. Che dite, non sono stato presto? non ho volato?</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Se hai volato eh? Tanto vola ancora la testuggine! E che cosa hai fatto tanto in casa?</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Ho pisciato un poco e ho cacato una voltarella e poi ho fatto il servizio.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Tu dèi essere molto stitico del corpo e dèi ancora patir di renella, in altra guisa non può essere.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Che patir di renella e di stitichezza di ventre? Io piscio come uno schizzetto e caco come un papero.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Or sù, lasciamo questo. Io vado nell'osteria per far della robba da vendere in piazza; tu va' per un poco<pb n="156"/> d'arsenico, ché voglio che facciamo una composizione per ammazzar de' topi.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Se questo veleno si doveva comparare per amazzare i lupi, io voleva vòtar le spezierìe di marzapani e attossicar me solo, come re di tutti i lupi, ma poi che la cosa sta ne' topi, traditori e roditori di quanto formaggio nelle mie saccoccie nascondo, io mi contento, e or ora vado per veleno per attosicar questa razza vituperosa.</p>
           </sp>
@@ -4406,49 +4479,49 @@
           <stage>
             <hi rend="sc">alberto, nottola, fulgenzio, rampino, grillo, cicala, corte, rondone</hi>
           </stage>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Contentissimo sono, o mio signore, di far quant'ella vuole; ch'è sommo giudizio ad ubidire a chi molto merita.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Or poi che vi contentate che Prudenza vostra figlia sia sposa non mia ma del signor Fulgenzio, quanto già fallito, tanto ora de me arricchito, chiamiamola. Ma chi è questo? Per mia fé, ch'egli è Rondone.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>O che arsenico fino, disse di averti dato lo speziale!</p>
             <p>Ma ecco sua eccellenza.</p>
             <p>Le fo riverenza, mio signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Rondone? Sù, ch'è tempo d'allegrezza! Chiama il tuo compagno, che m'è tornata la voglia di ridere, ma rider non posso, se da voi altri io non vengo alle risa provocato, sì come appunto la pignata non può rider bollendo se tutta dal fuoco cinta non viene, onde se ne tragga poi quel pentolesco gorgogliamento.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Sì signore, lasciate che or ora lo chiamo e spero che tanto riderete che creperete.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>No no, averò più caro che, per darmi occasione di ridere, tutti duo ridendo crepiate! E che dirai, furfante?</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Eh? Non vedete, signore, che dico così per parlar conforme al proverbio? Or sù lo chiamo, ma meglio sarà ch'io entri, perché li debbo arrecar questa polvere per far bianchi i denti, vostra signorìa vuol provare?<pb n="157"/></p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>No, ché noi altri si facciamo da' nostri barbieri nettarseli quando se l'arricordiamo. Vanne, ma presto ritorna.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Sì signore, or ora vado con quella vellocità che suole andare bue scompagnato al macello.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O che solenne furfante! Affé da cavaliere che mi piace questo suo umore. Ma chiamate in tanto, o meser Alberto, Prudenza.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Io la chiamo, signore. O dalla casa? Prudenza, tu non odi?</p>
           </sp>
@@ -4458,196 +4531,196 @@
           <stage>
             <hi rend="sc">prudenza, alberto, nottola, fulgenzio, rampino, grillo, cicala, corte, schiavetto, rondone, orazio</hi>
           </stage>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Chi è là? chi picchia? Il signor padre non è in casa, non posso aprire.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O che buona figliola.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Prudenza, io son tuo padre, apri.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>O caro signor padre perdonatemi, io non l'aveva conosciuta.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Qui, signora, s'ha da fare la pace della guanciata ch'io le diedi e si ha da stare allegramente. Sù Grillo, Rampino, Cicala, e voi altri, pigliar carrieghe e scagni.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Grillo, Cicala.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Signore.</p>
           </sp>
-          <sp>
+          <sp who="#cicala">
             <speaker><emph rend="sc">cicala</emph>.</speaker>
             <p>Che vuole.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Sù presto, fa' venir da sedere; vosco menate la corte.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Su, corte, tutti venite meco; sù presto, dico.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O ecco qua Schiavetto e Rondone.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Eccellentissimo principe, io son qua e ho apparecchiato cose meravigliosissime per farla stare allegra.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Così appunto bramiamo. Ma chi è colui che spunta da quel canto di strada? Ammazzàtelo. Olà, a chi dico?</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Cacciate mano meco tutti, signori.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Mio signore, con le ginocchia a terra le parlo. E che offesa le ho fatt'io?</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Invitissimo signore, la Prudenza seco sia e si ricordi che sì come il sole è adornamento del giorno, la luna della<pb n="158"/> notte, che così la Prudenza è adornamento del grande. Che dispiacere le ha fatto questo povero gentiluomo?</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Ah signore, non si mescoli (in grazia lo chiedo) il pianto, dove solo si attende il riso.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Gentiluomo, vi sia salvata la vita. Venite qua.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Son qui con ogni riverenza maggiore, mio signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Baciate questa mano, questa spada; ringraziate e l'una e l'altra, che dalla vita non vi abbiano condotto alla morte.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>O che pazzo umore!</p>
             <p>Così ho fatto eccellentissimo signore, con la lingua del cuore e dell'alma, da lei riconoscendo una nuova vita.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O ecco da sedere. Sù presto, senza parlare s'accomodi il tutto. O buono, o buono. Sedetemi appresso, ché vi do licenza.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O che cortese signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Pigliate, vi dono questa catena.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Troppo di favore carica il mio debolissimo merito, invitissimo prencipe.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Piglia questo anello, co 'l quale ho sposato sette duchesse.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>O cortese signore, e che grazie sono queste?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Baciami nella guancia.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Tanto, signore, a me si concede?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Fa' presto dico, non più parole.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Con ogni maggior riverenza la bacio.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Bacia la bocca.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>La bocca?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Sì, fa' presto.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Ecco, signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Baciami questa scarpa, presto; a chi dico? Puttanaccia, cospettaccio, ti darò delle pugnalate! Bacia questa scarpa, che rizza il tulpante in capo al gran turco prima che gran turco possa esser detto. Nettela prima con il mio feraiolo, to'.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Ecco, che co 'l mio la netto, benché così la baccierò ancora.<pb n="159"/></p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Non voglio che tu la baci così, né che tu la netti co 'l tuo feraiolo, ma con il mio. To', piglialo e nettela.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Per ubidirla, ecco che lo fo.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Or pìgliatelo, ché te lo dono; bacia ora e fa' presto.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Ecco ch'io la bacio.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Oh? Adesso i' son contento e se vi ho dato del tu, perdonatemi, perché quando vo in collera, così parlo co 'l re di Francia e con il re di Spagna. Ora sedete tutti. E tu Schiavetto, e tu Rondone, date principio.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Adesso, signore, mi lasci accomodar questa valige; poscia state tutti attenti, che adesso è 'l tempo d'allegrezza, e della maggiore che abbia l'allegrezza nel suo salvadinari.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Or sù, allegramente figlioli, incominciate a sonar voi con i vostri stromenti, ch'io pure incomincierò sonare con i miei sacchetti di doble mal tosate.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Signori, silenzio, ch'io voglio darvi un poco della mia mercanzia.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Oh? Signori, della sua mercanzia n'ha pur data tanto a Fiorenza, così ne dia in questa città, che si faremo ricchi.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Eh? Sarò ben uomo io di pigliarne tanta quanto tutti i fiorentini.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Sì? Orsù io comincio.</p>
             <p>
@@ -4670,235 +4743,235 @@
               <pb n="160"/>
             </p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Buono, buono certo.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Eccellentissimo principe, e voi altri illustrissimi signori, questo è un presentino tutto musco, tutto ambra. E di queste cose n'ho fatto una composizioncella, per tenere nella bocca, che per mia fé aprendola, n'uscirà un odore così grato, che né il popolo arabo, né 'l sabeo sentì giamai così soave refraganza d'odori. E perché io bramo che si conoschino gli effetti conformi alle parole, già io alla roba fo il prezzo, per tanto mandi ciascuno una dobla della cartella, che questo è 'l minor premio.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Grillo vien qua, di' che me ne mandi per tre mila doble.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Ma caro il mio signore, tanta mercanzia io non ho. Se vuol questa poca, è tutta sua, come pur suo è Schiavetto. Ma prima (in grazia) si compiaccia, sua eccellenza, che quel gentiluomo detto Orazio ne facci il saggio, e poi sua eccellenza faccia della mia mercanzia quello che più le aggrada.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Di grazia, eccellentissimo signore, io ne farò il saggio. Gettate, eccovi il fazzoletto.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Caro signore, dica quello che ne sente; ecco c'ho annodato il fazzoletto. Pigli, giovine innamorato e leggiadro.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Adesso dirò quello ch'io ne sento. O come sono delicati! Certo, signore, ch'è una composizione nobilissima.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Sì? Date qua tutte quelle che avete.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Eccole signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Pigliate signori fra tutti voi, ch'a tutti di questi odori fo dono.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Signori, cheti, ché adesso è tempo ch'io venda della mia mercanzia.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Signori, Rondone dice benissimo, ascoltiamolo.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Sì, di grazia, perch'è già pronto a darne sommo gusto.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Onorati signori, se Schiavetto vi ha dato della mercanzia e l'avete gradita, Rondone pure vuol darvi della sua, sapendo che non vi dovrà esser men cara dell'altra, per<pb n="161"/> tanto, onorati padroni, non aspettate da me scongiuri, né calatina, né ch'io dica male d'alcuno, perch'io non so farlo. Io adunque, signori, ho una ricettina da far fallire uno che sii il più ricco uomo del mondo, in termine d'un mese solo.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O buono, o buono! Alla fé, ch'io incomincio a ridere, eh, eh, eh.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>È grazioso costui, eh, eh, eh.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Una ricetta poi da far pigliare il più solenne mal francese del mondo? Io l'ho appresso di me, e così rara, che per farne la prova mi son pelato sette volte.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O questa è più bella, eh, eh, eh.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Ma adagio signori, questo è nulla. Guardate un poco questo invoglio di carta; non è bello? Sì, mo crediate pur certissimo che 'l bello di fuori argumenta eziandìo il buono che v'è dentro. Ma che, tante chiacchiere? Leviamo questa carta, quest'altra, quest'altra, questa, questa, questa pure, e pur questa. Eccola qua, signori. Ah golosi, correte a questo boccone, che così vi fuggirà la voglia di farvi appiccare per la gola! E se non è così, giuro, rinego, dispetto. Or sù venitevi a servire. Che fate? Via, presto, signori, ché non ho altro che questi quattro, vedete?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O questa ricetta tienila per te! Qualche goffo compererebbe della tua mercanzìa, del tuo unguento da rompere gli strangoglioni, o che ghittone, quelli sono quattro capestri d'appiccato!</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>È che burlo, signori, e questo fo solo per tenervi allegri. Questo invoglio di candidissima carta è quello che nasconde il tesoro ch'io m'intendo di darvi; né si creda che questo sia unguento per dolori, né pasta per conservare den<pb n="162"/>ti, ma una ricetta per giovare a tutto il genere umano. Queste, signori, non sono fandonie. Siete forse travagliati per colpa d'una grossa famiglia? Levate questa carta, quest'altra, questa. Guardate, signori, questa si domanda una fugaccia; e dato che fosse carestìa grande, e che non si trovasse pane, pigli un galant'uomo quattro di questi miei elettuari, e per via di zuppa, o di bocconi, o in altro miglior modo, pur che vada nel corpo, ch'io l'assicuro che se per tutto quel giorno sente fame, io n'incaco a Cerere se con le sue spiche pungenti non mi punge il preferito, quando io vado in campagna a vacuare.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O che bello umore, e dove domine trova costui queste cose?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Stupisco, signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Séguita, caro il mio Rondone.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Vedete voi questa inghistara e acqua? Ponetene in questo bicchiere, e acqua. O questa è l'importanza: verrà un ciarlatano, e con un poco di polvere di verzino, ponendovela nel bicchiere gli darà il color di vino; parerà all'occhio, che sia vino, ma saggiàtelo, sarà poi acqua. Ma io non fo così. La mia ricetta è di far quest'acqua parer vino al colore, e vino proprio al sapore. Che sia vero guardate, questo è un boccale, qui si ritrova il liquido, atto a dare a quest'acqua la perfezione. Or mirate, che dite? Qual è quel balordo che non dica che questo sia vino al colore? Vedete, io bevo. Or qual è quel testa di cavaletta campagnola che non dica ancora che sia vino al sapore?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Mo costui per far ridere è meraviglioso, eh, eh, eh.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Ma signori non cessa qui la cosa. Il terzo segreto è quello che vale. Ho venduto fino ad ora per gli uomini, ora vender per le donne io voglio. Signori, che credete ch'io<pb n="163"/> serbi appresso di me per donarvi? Io voglio donarvi una palla muschiata, composta di testicoli di Castore e impastata del sudore che si leva fra le gambe di que' gattoni che fanno il zibetto. Questa palla è di sapone così fino e purgato, che per mia fede si potrebbe mangiare. E perché non crediate che ci sia calcina, cenere ed altre sporcizie, guardate, ch'io la levo dalla carta. Mirate signori, questa è la bambagia, la quale dalla palla io levo perché non si creda che in essa sia l'odore; ecco la palla, ecco ch'io la pongo in bocca, ch'io la mastico, io la mando abbasso; e se io non sento tanto giovamento quanto s'io mangiasse un torlo d'ovo, reputatemi un furfante.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Mo se vuoi ch'io ti dica il vero, tengo che appunto sia un torlo d'ovo. Lasciami un poco vedere la bambagia che gli levasti d'intorno.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Eccola signore; che fa, signore, se la mangia?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O furfante, questa è bambagia, poi? Questa è chiara d'ovo appresa.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>E la palla ch'io ho mangiato era il suo torlo.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>E che virtù ha questa palla?</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Di far l'uomo indovino.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>E come?</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Non ha ella indovinato che questa non era bambagia, ma chiaro d'ovo?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Sì.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>O vedete che siate indovino.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Eh, eh, eh, o che ridicolosa cosa, eh, eh, eh, ohimè, non posso più, dal tanto ridere.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Ohimè, che cosa è questa?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Signor Orazio, che vuol dir, ch'è così pallido?</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Ohimè.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Perché vi slacciate il seno?</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Signor io mi muoro.<pb n="164"/></p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Aiuto, ch'ei muore daddovero. Olà Schiavetto, hai qualche rimedio contra veleno?</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Ogni rimedio è tardo per lui.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>E perché? Ohimè, Orazio è venuto meno! Sostenetelo. Oh povero gentiluomo.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>O Prudenza sfortunata, che miri?</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Sappiasi che per commissione d'un suo capitalissimo nemico sono andato gran tempo cercando costui, per tôrgli la vita; e oggi appunto con que' moscardini hollo avelenato.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Ohimè, e io sono avelenato?</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>No, poi ch'egli solo avelenai.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Ah traditore.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Ah crudo avelenatore.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Ah furbaccio.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Ti voglio ammazzare.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>E no, signore, e no.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Non mi tenete, non mi tenete.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Lasciate, signore, questo carico a me. Ah furbaccio.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Ferma là, che ti do di questa valige ch'io ruoto nel capo, ve'? Ferma, ferma.</p>
           </sp>
@@ -4910,127 +4983,127 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">sbirri, alberto, nottola, fulgenzio, rampino, grillo, cicala, corte, rondone</hi>
           </stage>
-          <sp>
+          <sp who="#bargello">
             <speaker><emph rend="sc">bargello</emph>.</speaker>
             <p>Olà, che romore è questo? olà, che armi ignude?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Che vuoi tu, furfante?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Signor principe, questo è 'l Bargello, con la Corte.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Sì? Perdonami, Bargello, io non ti conosceva.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Si facci pur presto quello che s'ha da fare, ché io non voglio fuggire, ben ch'io potessi.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Vedete, io non so nulla, e se vi manca boia lo farò io.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Basta, basta. Bargello, piglia quello schiavo e quel suo compagno, che tramendue hanno avelenato questo gentiluomo.<pb n="165"/></p>
           </sp>
-          <sp>
+          <sp who="#bargello">
             <speaker><emph rend="sc">bargello</emph>.</speaker>
             <p>Sì? Piglia, piglia, che scappa.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Io non iscapperò, pigliatemi pure.</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>Piglia, piglia.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Salva, salva.</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>Corri, corri.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Fuggi, fuggi.</p>
           </sp>
-          <sp>
+          <sp who="#bargello">
             <speaker><emph rend="sc">bargello</emph>.</speaker>
             <p>Tenetelo, tenetelo.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>S'io lo so. E duo a terra. Fuggi Schiavetto! Vieni a cavaluccio.</p>
           </sp>
-          <sp>
+          <sp who="#bargello">
             <speaker><emph rend="sc">bargello</emph>.</speaker>
             <p>A furbo.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>To' questo calcio.</p>
           </sp>
-          <sp>
+          <sp who="#bargello">
             <speaker><emph rend="sc">bargello</emph>.</speaker>
             <p>Ohimè il ventre, ohimè ohimè! Dietro furfanti.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O che furbo, porta via colui a cavaluccio, eccolo.</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>A furbo.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Menti per la gola, to'.</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>Ohimè, calci.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>To'.</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>Ah ah? Tu cadesti alfine! Vedi, che nel tirarmi io ti presi la gamba, né ti ha giovato l'esser di razza di mulo.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>È meglio esser razza di mulo come me, che di becco come voi altri. Or sù, ci sono. Andiamo pure in prigione, fate presto canaglia, ch'io mi voglio mutar di camisia. O via finitela.</p>
           </sp>
-          <sp>
+          <sp who="#bargello">
             <speaker><emph rend="sc">bargello</emph>.</speaker>
             <p>Sì sì, va' pur là furbacchiotto, tu ci sei adesso, né fuggirai al sicuro, se teco non fugge questo braccio spiccandomelo dal busto.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Tienlo sicuro ve', Bargello, e quell'altro furbo ancora.</p>
           </sp>
-          <sp>
+          <sp who="#bargello">
             <speaker><emph rend="sc">bargello</emph>.</speaker>
             <p>Sua eccellenza lasci pur la cura a me di questa carnaccia da corbi.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O che traditori! Signor Alberto, portiamo in casa il signor Orazio, poiché disperata è la salute sua. Oh povero gentiluomo.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O misero giovine.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>O più sfortunata Prudenza, o giorno infausto.<pb n="166"/></p>
           </sp>
@@ -5045,27 +5118,27 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">fulgenzio</hi>
           </stage>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Signor Fulgenzio diasi pace, ché in somma le cose fatte con poco fondamento in breve ruvinano; per dirgliela, mia figliola confessa il merito suo, la sua virtù, la sua nobiltà, ma non lo vuole per consorte.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Ben so il perché, ma basta.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Perché, di grazia?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Non lo voglio già tacere. Perché è d'Orazio amante, e ora ch'egli è morto, sprezzatrice è fatta anch'ella della vita.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Veda signor Fulgenzio, già si sa ch'io stimava di dover dar mia figlia ad un uomo ricco, sì che perciò, e vostra signoria e il signor Orazio dovevano viver lontani da questa speranza, colpa della povertà loro; e s'io mi era indotto a darla al signor Fulgenzio, questo io faceva perché il principe mi prometteva gran cose. Ma ora, che in casa se n'è lavate le mani, anch'io ritorno nel mio primo pensiero; né speri giamai d'averla. Addio signor Fulgenzio, io vado a chiamar colui che piglia in nota le denunzie de' morti. Mi perdoni se forse la risposta le pare acerba; addolciscasi co 'l sapere che ogni padre desidera più che può il maritar bene la sua figlia.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>O sfortunato Fulgenzio, privo d'ogni speranza di godere quanto di bello il Cielo concede a' mortali, che in terra goder si possa! Ma a che disperi? non sai che quando<pb n="167"/> fortuna al mortale mostra minaccioso il volto, che allora pensa il modo di farlo felice? Odi l'inganno ch'ella ti narra? Non va Alberto a trovar colui che piglia in consegna i morti? Sì non impose a Prudenza che non dovesse aprire ad altri uomo che a costui, caso che senza di Alberto venuto fosse? Sì pur, celato non t'è che questo tale da veruno della casa d'Alberto è conosciuto. Or via, amante coraggioso, fingi tu con abiti e barba mentita questo tale, prima che Alberto lo trovi e seco lo guidi. Vieni a questa casa, picchia, entrane; poscia retira Prudenza in parte segreta fingendo d'essere a parte de' suoi amori, mercè d'aver ciò dettogli Orazio, e quando colà soletta l'avrai e che altri discorreranno sopra il morto giovine, tu cogli a forza da lei l'amorosa messe, che nel campo d'amore sovente raccoglie falciatore amante e accorto. O come già mi pare d'averti nel seno, dolcissimo cuor mio! Alle fraudi, a gl'inganni, a i bei furti d'amore!</p>
           </sp>
@@ -5075,147 +5148,147 @@
           <stage>
             <hi rend="sc">facceto, solfanello, succiola</hi>
           </stage>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Solfanello, che ti pare di questa bella e nobile città di Pesaro, e di questo popolo così cortese e amator di forastieri?</p>
           </sp>
-          <sp>
+          <sp who="#solfanello">
             <speaker><emph rend="sc">solfanello</emph>.</speaker>
             <p>È bellissima questa città certo, e credo che della cosa delle comedie farete molto bene, e in particolar voi, che, solo, fate tutta una comedia; invero che ogn'uno si suol maravigliare. Ma ecco un'osteria, c'ha per insegna una castagna fruttifera. Meser Facceto, che vi pare?</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Eh? Ogn'uno conforme la sua bizaria si governa. Batti un poco, ché tu dèi essere stracco, dalla porta a qui avendo portata questa valige in ispalla.</p>
           </sp>
-          <sp>
+          <sp who="#solfanello">
             <speaker><emph rend="sc">solfanello</emph>.</speaker>
             <p>Lasciate ch'io la pongo in terra, e or ora batto. Corpo di me, che l'aria dee esser molto sottile in questo Pesaro, perché mi sento le budella che dentro mi mangiano. O dall'osteria? Olà olà rispondete, se non, che con le sassate scoteremo dalla insegna tutte le castagne al sicuro! Olà, olà dich'io.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Che domine di picchiare alla sbardellata è cotesto?<pb n="168"/></p>
           </sp>
-          <sp>
+          <sp who="#solfanello">
             <speaker><emph rend="sc">solfanello</emph>.</speaker>
             <p>Oh? Càzzica, è da Firenze non è oggi, vero monna Pippa gobba?</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Do' briccone, e che m'uccelli tu forse, che ti stiaccio il naso, che sie?</p>
           </sp>
-          <sp>
+          <sp who="#solfanello">
             <speaker><emph rend="sc">solfanello</emph>.</speaker>
             <p>Oh? no daddovero. Oh? no al corpo di sampuccio, oh? no al corpo di santanulla! Ne volete vo' più di questi vostri, oh, oh, oh?</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Oh? Ti dia!</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Madonna, datevi pace, perché costui è 'l più bello umore che viva al mondo.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Sin a cotest'otta, non mi piace punto, punto. Or che volete voi albergare? Che mestieri è 'l vostro?</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Di far comedie.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Comedie? Oh? Cotesta è bene la mia ventura! E sapete se mi piacciono! E che parte fa cotestui?</p>
           </sp>
-          <sp>
+          <sp who="#solfanello">
             <speaker><emph rend="sc">solfanello</emph>.</speaker>
             <p>Io? Impiccio le candele e le torcie; e per questo mi chiamano Solfanello.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Eh? Non è maraviglia, se per accendere le torcie e le candele si chiama cotestui Solfanello, ché pur anch'io per far l'osteria, c'ha impresa l'albore della castagna fruttuosa, mi chiamo monna Succiola.</p>
           </sp>
-          <sp>
+          <sp who="#solfanello">
             <speaker><emph rend="sc">solfanello</emph>.</speaker>
             <p>Ma canchero! Pochi forastieri toccheranno la vostra osteria, e questo perché avete la castagna molto spinosa.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Sì, ma le punte sono novelline, che più tosto ti solleticano, che ti punghino! Ma da te, Solfanello, bisogna istar lontano, ché da ogni canto scotti.</p>
           </sp>
-          <sp>
+          <sp who="#solfanello">
             <speaker><emph rend="sc">solfanello</emph>.</speaker>
             <p>Sì, quando sono acceso scotto, ma adesso no. Toccami, e da i capi e nel mezo, e vedrai ch'io non mento.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Or sue, se non iscotti, tu puzzi da ogni capo almeno.</p>
           </sp>
-          <sp>
+          <sp who="#solfanello">
             <speaker><emph rend="sc">solfanello</emph>.</speaker>
             <p>Che volete, il Solfanello puzza dal capo e Succiola nel mezo.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>O che tristo, dove domine è andato a quest'otta a ficcare il naso. Ma ascoltatemi, né andian dietro alle novelle. Mi volete vo' voi per fare una ruffiana nella comedia?<pb n="169"/></p>
           </sp>
-          <sp>
+          <sp who="#solfanello">
             <speaker><emph rend="sc">solfanello</emph>.</speaker>
             <p>Sì, ma bisogna sfrisarti.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>O nato di becco, guata come tu parli ve', ch'i' ti darò d'un zoccolo nel capo, e ti coglieroe.</p>
           </sp>
-          <sp>
+          <sp who="#solfanello">
             <speaker><emph rend="sc">solfanello</emph>.</speaker>
             <p>O via, che burlo, gatta inzoccolata!</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>E pur Fiesoli.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>O che spasso.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Non mi fare instizzire, perché andrà male, ve'?</p>
           </sp>
-          <sp>
+          <sp who="#solfanello">
             <speaker><emph rend="sc">solfanello</emph>.</speaker>
             <p>Burlo, burlo. Potta di me, la Succiola s'era bene riscaldata, bastava ora che io vi accostasse il solfanello, ed era fatto il becco dell'oca.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>O che forca, sallo dir meglio? Or sue, andianne ch'i' ti voglio albergare, perché i' non sono quella capassonaccia che tu t'andavi immaginando. Entrianne.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>O che cara Succiolina.</p>
           </sp>
-          <sp>
+          <sp who="#solfanello">
             <speaker><emph rend="sc">solfanello</emph>.</speaker>
             <p>O che gentil Succiolaccia.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Diavolo accòrdela, oh? Vo' mi tritellate così il nome! Io non sono né Succiolina, né Succiolaccia, ma la Succiuluccietta, figlia della Succiulucciotta.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>O bene, o bene, o bene, andiamo! Voi siete una Succiola d'oro.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Non dite così, càzzica, che i cerchieri non mi martellassero tutta la Succiola.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>O che furbetta, entriamo.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Andianne.</p>
           </sp>
@@ -5227,33 +5300,33 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">prudenza</hi>
           </stage>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Fortuna, se giamai favoristi gli arditi, favoritrice oggi di Fulgenzio ti mostra! Tu pur, cortese Amore, a gli<pb n="170"/> amori miei tutto amore divenuto, impetrami il valore di vincer la bella e cruda nemica mia! Ecco che, fatto per te Proteo amoroso, vesto questa veste, anzi, con questa barba quasi a me medesmo dificultà rendo s'io mi sia Fulgenzio. Voglio assicurarmi di battere per scemare i colpi del dolore, del timore, che il cuore mi percotono; anzi, che mutar la voce alquanto io voglio.</p>
             <p>O di casa? o signori, chi è che di voi in questa casa mi risponda?</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Chi è lì? Siete voi forse quello che, per mia morte, piglia in nota i morti?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Sì signora, quegli sono: ma per vostra morte poi già tale non sono.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>E messere, perdonatemi, so ben io qual duolo così sforza a ragionar la lingua. Or sù, vengo ad aprirvi la porta, acciò che 'l morto a riconoscer veniate. Così volesse il Cielo che prima che da voi mi conducesse il piede, Morte le porte sue mi spalancasse, per venire a vedere come disdica che una malviva tanto oggi viva. Questa cura di veder chi picchia, e di aprire, solo mia cura feci, odiando un certo spelatuccio detto Fulgenzio, temendo mio signor padre ch'egli con la sua prosonzione tanto non s'avanzasse, che di questa casa si facesse dominatore. Aspettatemi ch'io vengo.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>V'aspetto signora.</p>
             <p>Ah discortese, io sono un Fulgenzio spelatuccio, eh? Se tu avessi guardato ben bene questa barbaccia, m'averesti conosciuto per un Fulgenzio pelosaccio. Ma ben so che lo strale delle tue parole s'indirizza al ferire il bianco della povertà mia. Ma in te, o minera d'ogni tesoro, arricchirò (e bene in breve) la mia povertade. Eccola appunto.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Per vita vostra entrate, fate presto, ché da ogni canto mi pare di vedere spuntare questo ganimede senza camisia, questo ch'odio più della morte.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Ecco, signora, che frettoloso, per ubidirla io entro.<pb n="171"/></p>
           </sp>
@@ -5261,92 +5334,92 @@
         <div type="scene">
           <head rend="italic">SCENA QUARTA</head>
           <stage><hi rend="sc">belisario</hi>, <hi rend="italic">e</hi><hi rend="sc">succiola</hi></stage>
-          <sp>
+          <sp who="#belisario">
             <speaker><emph rend="sc">belisario</emph>.</speaker>
             <p>E in questa età cadente d'ogni quiete, d'ogni riposo desiderosa, e di più, doppo grave e lunga infermità, ti conviene, o Belisario, a forza andar viaggiando? Basta, basta! Ancor, ch'io sia vecchio, e mi regga a pena sovra questo bastone, non dimeno il desiderio di vendetta mi fa credere che questo non sia bastone semplice, ma una gamba di più de gli altri uomini, dalla natura concedutami, accioché nel seguitare gl'inimici miei io sia più veloce. Ma perché tu se' (o povero vecchio) alquanto stracco, ti ricovrerai, e reficierai a questa osteria, e domani poi, per tempo levandoti, commodo spazio conceduto ti sarà d'andar terminando l'interminate miserie tue.</p>
             <p>O dall'albergo? o là, v'è alcuno in questa abitazione? o là, o là, dich'io!</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>O che ti venga il gavàcciolo, pinchellone! Che bussare è cotesto di bastone? I' vo' pur vederlo.</p>
           </sp>
-          <sp>
+          <sp who="#belisario">
             <speaker><emph rend="sc">belisario</emph>.</speaker>
             <p>O di casa.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Ohimène, ohimène i' son morta.</p>
           </sp>
-          <sp>
+          <sp who="#belisario">
             <speaker><emph rend="sc">belisario</emph>.</speaker>
             <p>O povera donna! Perdonatemi, io son un poco sordotto, e non avendo udito rispondermi, i' volli battere di novo co 'l bastone, e vi detti su 'l capo.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Che ti venga l'anticuore, vecchio cucco! E che domine, va' tu forse per viaggio rompendo il capo a le femine?</p>
           </sp>
-          <sp>
+          <sp who="#belisario">
             <speaker><emph rend="sc">belisario</emph>.</speaker>
             <p>Già io vi ho detto la cosa come sta, e di novo vi chiedo mille perdoni.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>S'il mio capellino di paglia non mi riparava gran parte della botta, i' stava fresca! Nondimeno il colpo molto ben passoe. Che voresti vo' voi?</p>
           </sp>
-          <sp>
+          <sp who="#belisario">
             <speaker><emph rend="sc">belisario</emph>.</speaker>
             <p>Alloggiare.<pb n="172"/></p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Uh uh? Bisognerebbe ch'io avessi l'osteria molto larga a tanti forestieri. Ci vorrebbero pentole, ci vorrebbero mestole: insomma i' non v'ho tanto buco, che v'entrasse una lucertola. E creditemi messere, ch'io non vi uccello, tutt'oggi ho cuscinato, e per via viscina e per via segreta, mandate alcune coselle al fornaio, per far cuoscere; perché cotesta sera si farà ad un prencipe, ch'io alloggio, la cena. E ora voglio andar per delle susine secche e per un po' di sapa.</p>
           </sp>
-          <sp>
+          <sp who="#belisario">
             <speaker><emph rend="sc">belisario</emph>.</speaker>
             <p>Come si chiama?</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>M'uccellate vo' forse? O cotesta fagiolata non farò no, a darvi il suo nome! Non vuol esser mentoato. Bastivi ch'egli è principe di mezo il mondo. Non è troppo bello, ma ricco tanto, tanto che istupisco! Egli è mezo zoppo, va caminando a tentone, a tentone; ha un certo viso di grifo; egli è zacconato e caputo; è gozzuto e naticuto come una mosca culaia; si scorubbia per nulla; ha un certo tintinno d'una voce fastidioso; è lercio, e più che isciudicio; ha il piede bovino, la mano ad uncino, l'orecchio caprino, l'occhio porcino, e le ciglia congiunte; è gobbo, guercio e ha quattro fontanelle e il brachiere. Senza quegli abiti pare uno che nato sia per guardar le zèbe, ma con que' panni d'oro, pare il Berlingaccio vestito da festa.</p>
           </sp>
-          <sp>
+          <sp who="#belisario">
             <speaker><emph rend="sc">belisario</emph>.</speaker>
             <p>In effetto, ne gli Esopi regnano le virtù, e ne' brutti Sardanapali le ricchezze.<pb n="173"/></p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Egli è ben poi il più liberale che sia nel mondo. Hammi donati duo fili di catena moito belli, eccogli. Or guatisi un pocolino se regnoe giamai animo tale in alcun Rene?.</p>
           </sp>
-          <sp>
+          <sp who="#belisario">
             <speaker><emph rend="sc">belisario</emph>.</speaker>
             <p>O com'è bella.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Che volete vo' di piue? Per ischerzo mi piccica una mela, e mi dona cotesto anello; mi solletica ne' fianchi, e mi dona cotesto gioielletto. In somma, non ho pigliato erro, cotesta è la mia fortuna, anch'io ho paglia in becco.</p>
           </sp>
-          <sp>
+          <sp who="#belisario">
             <speaker><emph rend="sc">belisario</emph>.</speaker>
             <p>In vero, che quanto costui è brutto di corpo, è bello d'animo.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Vi so dire ch'egli è un gallo, che canta male e razza bene. Dinari poi? Io n'ho di già empito un mocchichino di bucato.</p>
           </sp>
-          <sp>
+          <sp who="#belisario">
             <speaker><emph rend="sc">belisario</emph>.</speaker>
             <p>Madonna, mi dispiace di non poter alloggiare in casa vostra, ma che si può fare? Or sù, prima che la sera giunga, io voglio andarmi a provedere d'alloggiamento, poi che appunto in quest'ora ogn'animale, chi alla tana, e chi al nido si riduce.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Or sue, in altra occasione l'albergo è vostro. Addio.</p>
           </sp>
-          <sp>
+          <sp who="#belisario">
             <speaker><emph rend="sc">belisario</emph>.</speaker>
             <p>Arrivedersi.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>O vecchio muccicone, se ti credevi ch'i' ti volessi albergare! Mi venga il bene, se l'altra notte un certo meser Zambarda vecchio, albergando non m'ebbe ad assordare con il tossire e con lo spetezzare. I' voglio tornar da meser Facceto comico, che tanto gusto mi dà nel scicalare.</p>
           </sp>
@@ -5357,36 +5430,36 @@
           <stage>
             <hi rend="sc">prudenza, fulgenzio, alberto</hi>
           </stage>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Fuggi pure; ti vuo' levar la vita, s'a me levasti l'onore.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Fermatevi signora, non s'affatichi correndo di tôr la vita a chi la vita dar le vuole in potere, se d'ascoltar due parole sole si farà degno chi, per sentenza sua, debbe morire.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Il mio rapito onore non merita tanta dilazion di tempo. Ah rapitore di femminil pudicizia, tu fuggi?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Non fuggo per tema ch'io m'abbia d'essere piagato, ma per lo disgusto ch'io sento di non esser da lei ascoltato.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Pur bene sarà ch'io l'ascolti, e poi che 'l ferro nel l'empio io rivolti.</p>
             <p>Or che saprai dire, che dir vuoi? Ohimè comincia, che tanto m'è caro l'indugio, quanto che doppo l'aver ragionato precipitosa esser dovrà la mia vendetta.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Eccomi a' piedi suoi, con il ginocchio del core assai più chino, che con le ginocchia del corpo. Ah Prudenza, ad altro fine (e mi si creda) adornata di tal nome di Prudenza non fu, se non perché, dal nome suo ella fatta oggi prudente, dovesse dal petto sbandire l'ira, il furore; e considerare che pure, me uccidendo, uccideva con un colpo solo e 'l servo suo, e 'l suo amante, e 'l suo consorte. Sù, Prudenza, che s'indugia? m'è caro per lo suo ferro, per la sua mano, di morire! Ecco ch'io m'apro il seno, ecco ch'io le facilito, ecco ch'io le agevolo la via, acciò che mi conduca a morte. Trafigga, e m'apra pur questo petto, ché ben so che rimirandosi ella stessa nel mio cuore, non sarà così cruda, che non si dolga d'aver atterrato quel petto che natura fece erario della imagine bellissima sua. Non meritava, così pregiata effige, d'essere scolpita in oro, overo in gemma, ma in un côr vivo e inamorato, e perciò cortese natura il mio elesse fra molti amatori, come il più puro nelle fiamme de' miei sospiri purgato, e nell'acque del mio pianto lavato. Or se nemica alla natura, ad Amore e a lei stessa esser vuole, atterri questo corpo, laceri la bella imagine sua. Sù, che s'indugia? Prudenza, m'è caro il morire, per non vivere in<pb n="175"/> disgrazia sua ogn'or morendo. Ecco le testimonie del dolore, che a mille a mille da gli occhi io spargo! Pure la vindice mano è di ferro e di vendetta armata, pure la vittima a' piedi suoi mirasi prostrata.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>O Prudenza, o Prudenza, da quanti varii affetti combattuta se'! Pietade e vendetta in te ragionano, ciascuna oratrice faconda, e ti persuade alla vendetta e dalla vendetta ti dissuade. Or l'una t'acquista, or l'altra dall'acquistante ti ruba; or questa fuggi, or questa segui; or vuoi, or disvuoi; or obliando in tutta la pietà, movi la mano, drizzi il ferro, vibri il colpo; ma mentre l'acuta punta precipitar nell'inimico seno vedi, ecco Imeneo che fa il colpo arrestar così dicendomi: «Che farai micidiale? Al fine dura forza ti sforza a chiamarlo consorte, e come tale a bramar anche la salute sua; ond'ha che prima il ferro giunga al suo petto, tu il colpo nel mezo del cuore senti». Lassa, che far mi deggia non so. Vendetta di nemico, voglia dell'amante mio ingiuriato, vorrebbe che sparger li facessi il sangue. Pietà poi di colui, che consorte oggi chiamar debbo, m'impone ch'io, lagrime spargendo, da terra lo sollevi e mio consorte il chiami. Nell'uno avampo d'amore, nell'altro per l'odio aghiaccio; nell'uno tutto mèle d'Ibla, nell'altro tutto veleno libico i' sono. E in queste mie strane e tante irresoluzioni, né cedo, né m'avaloro; né perdono, né vendico; né getto il ferro, né ferisco; né do vita, né uccido; ma io sola, piena di pace e di guerra sono, e io sola ferita. Tale è cacciatore, che la foresta scorrendo, scorge la fèra. Ella sorge e lo fugge, ei la segue, ambe le mani di dardo acuto armate avendo, ed eguali al ferrire esperte. Qua la fiera s'incespa, là subito smacchia, qua alla diritta corre, là alla sinistra fa mille volte, e tanto qua e là s'aggira, ch'or bramoso il cacciatore con la destra, or con la sinistra di ferirla, mai non la ferisce,<pb n="176"/> ond'ella libera al fine sen' fugge. La fiera se' tu, la cacciatrice io sono, i duo dardi acuti, che nella destra, che nella sinistra mano io stringo, l'uno è 'l dardo della pietà, l'altro della vendetta. Ferir ti vorrei, ma qua t'aggiri alla sinistra con diversi giri d'una profonda umiltà, colà alla destra fuggi e inselvi come fèra da me odiata; qua alla sinistra ti dimostri ingannatore, colà alla destra ti discopri amatore; or qua nemico, or là consorte, sì che l'una mano all'altra il colpo cedendo, e l'altra all'una, fa ch'io giamai ferisca, e tu illeso ti trovi. Ma perché è meglio che donna rimanga più tosto onorata e invendicata, che vendicata e disonorata, Fulgenzio, pace trovando ne' miei interni contrasti, io ti perdono. Ed ecco, che la mano disarmata tanto ora verso di te io movo, nunzia di pace, di vita e di fede maritale, quanto già contro di te la spinsi, ministra di guerra e di morte.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>O cuore generoso, o anima gentile! Scusa, scusa l'amoroso fallire, cagionato da quella dolce violenza che da te ne' cuori far si sente, con isforzo irreparabile.</p>
           </sp>
@@ -5396,131 +5469,131 @@
           <stage>
             <hi rend="sc">alberto, prudenza, fulgenzio</hi>
           </stage>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Olà? Chi v'ha dato questa licenza, o signora Prudenza? e a voi, o signor Fulgenzio inzamarato? Così, signor Fulgenzio, a procedere v'insegnano que' nobili costumi, che vosco diceste di trar dalle fasce? e qui, credete forse che terminar si dovrà questo negozio? questo affronto? E tu, malvagia, dicevi poi di non voler Fulgenzio e ora seco abbracciata (e su la strada) i' ti ritrovo? Ah, ben è vero che tutto il mondo non terrebbe a freno una femmina allor ch'ell'è disposta di voler far la sua lascivia sazia! Ma perché, con il discoprirmi nella strada il fallo tuo, mi discopri ancora il modo con ch'io debba castigarlo, dammi questo ferro, ti voglio morta alla vita, come se' morta all'onore.<pb n="177"/></p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Pietà, signor padre! Ohimè, i' fuggo.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Deh fermatevi, o mio signore, o mio caro suocero, o mio solo padre.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Tuo solo padre? E' ne mente, vicini. O che furbo, per far ch'io paghi i suoi debiti, suo padre mi chiama! Né suocero, né padre di fallito io sono. Puttana di me, non lo voglio comportare! Di' sù, furfantella, v'è altro, che questo abbracciamento ch'io ho veduto? Di' sù, fa' presto, non occorre fare il viso lungo, e 'l viaggio del gambero con l'andar indietro. Di' sù, ché te lo ficco, ve'?</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Uh? Non fate.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Lo dirà, lo dirà, signore.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>State cheto voi, meser Cicciapottolo nell'agresto! Di' sù, v'è altro?</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Signor sì.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Che cosa, un bacio?</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Signor sì.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Altro?</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Signor sì.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Che cosa, un toccamento di tette?</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Signor sì.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>V'è altro?</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Signor sì.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Che cosa?</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>M'ha fatto la gambaruola.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>La gambaruola? Or sù, so il rimanente: ella è caduta, lui gli è caduto sopra e l'ha impregnata. A porca, a sfacciata! La voglio ammazzare.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Eh no signore, pungavi più la pietà figliale, che punger ella non procura di ferro acuto le proprie carni sue.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Deh caro padre, se pur brama di ferirmi, ond'io ne muoia, il ferro, che dal fianco io tolsi a Fulgenzio, sia quello che mi ferisca, che m'uccida, ché contenta morrò per mezo delle cose sue.<pb n="178"/></p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O temeraria, e mi burli? credi che non intenda questo anfibologico tuo parlare? Or che tu brami per lo pugnale di Fulgenzio morire, Fulgenzio voi, che sapete doprare il vostro pugnale, poi che i giovini sempre l'hanno in mano, a voi tocchi a far quel colpo che al presente a costei tanto piace.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Non sia mai vero, ch'io debba dar la morte a chi è la vita mia.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Eh? Che non m'intendete.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>L'intendo ben io, signor padre.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Sì? O come la donna è saggia, quando si parla del suo interesse. Or sù, perché voglio più come padre perdonare, che come adirato vendicare, vi perdono. Abbracciatevi, baciatevi.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Uh? Signor padre.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Do' furfantella, tu fusti prosuntuosa e golosa, tu me lo fara' dire! e ora in questo, tu vuoi essere onesta e senza apetito! Baciatevi, dico, se non, che vi ammazzo tramendue.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Ecco, signore.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O così, bon pro vi faccia, mi si dirà poi l'inganno com'è stato. Or che per voi ho inteso cose nuove, e di non volgare stima, e voi per me pur dovrete intender cose di grandissima maraviglia. Sappiate adunque che una donna detta Florinda, che in Napoli tra Orazio e lei passò fede di matrimonio e godimento, è quella che in abito di schiavo e sotto nome apposito di Schiavetto, schiava di fortuna andava errando, per far tanto schiavo di morte Orazio, quanto Orazio aveva di lei fatta schiava del disonore. E oggi appunto teco parlando, e inteso che Orazio di Florinda (ch'è l'ingannata) s'era dimenticato, per ricordarsi di Prudenza, tanto lo sdegno la dominò, che più pronta all'odiare che all'amare, s'appigliò come sdegnata, come infuriata, di vendicarsi, ma non contro di te, ma contro di colui che in istato così misero posta l'avea. E qui mandato un certo suo Rondone per veleno, dandoli a credere che composizione contro i topi far volea, se ne tornò da lei; ma non già con veleno, ben che per<pb n="179"/> veleno lo speziale (al balordo) creder lo facesse. E questo ben creder dobbiamo che sia stata providenza del Cielo, co 'l porre in mente allo speziale di non dar veleno a costui, che avendo aspetto e azioni di pazzo, cosa da pazzo fatto non avesse ancora. Ma solo li dette una certa composizione che 'l vomito moveva, la quale quella fu che gustata da Orazio, ch'è gentile, gli pose quella nausea, ed egli, vergognoso alla presenza di tanti gettar fuori, si ritenne e li cagionò lo svenimento.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>O caro signor padre, come sapete questo? Ma la giovine ha patito cosa alcuna? O forza d'amore e d'onore.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>È rimasta illesa dalla giust'ira della giustizia, poi che lo speziale stesso, mescolato con la turba che seguiva questo Schiavetto mentre andava inanzi al signor governatore, udendola (ben che scoperta donna) condannarla a morte, forte cridando d'essere ascoltato, il signor governatore gli fece far adito fra la calca; e comparsoli avanti manifestò quanto a voi ho già palesato. In questo mentre, «Grazia grazia!» tutto il popolo chiamando, alle voci di tanti commosso, il signore grazia disse, e grazia le fece. Ed eccola apunto di qui comparire, con quel suo Rondone.</p>
           </sp>
@@ -5530,139 +5603,139 @@
           <stage>
             <hi rend="sc">rondone, schiavetto, alberto, fulgenzio, prudenza, grillo, cicala</hi>
           </stage>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Oh Schiavetto, voi siete donna? Eh vi vedeva ben io caminar molto larga! Oh perché non l'ho prima saputo.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Generosa Florinda stii lieta, ché in casa ho il suo amatore, il quale perché doveva esser suo, poiché con tanto sudore e lunga peregrinazione l'acquistò, il Cielo ha fatto con gran prudenza ch'ei non sia di Prudenza, e che 'l vero sia, ell'è moglie di questo gentiluomo.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Signore, la soverchia e trabocchevole passione amorosa m'indusse a far l'azione più d'infuriata, che d'innamorata; ma lodato il Cielo, che, rimirato l'affetto della fedeltà mia contro questo infedele, quanto fida felice mi fece.<pb n="180"/></p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Allegrezza allegrezza.</p>
           </sp>
-          <sp>
+          <sp who="#cicala">
             <speaker><emph rend="sc">cicala</emph>.</speaker>
             <p>Allegrezza allegrezza.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Ora sì che stridente sarà il Grillo.</p>
           </sp>
-          <sp>
+          <sp who="#cicala">
             <speaker><emph rend="sc">cicala</emph>.</speaker>
             <p>Or sì che assordante sarà la Cicala.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Grillo, Cicala, che cosa, eh?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Lo voglio dir io.</p>
           </sp>
-          <sp>
+          <sp who="#cicala">
             <speaker><emph rend="sc">cicala</emph>.</speaker>
             <p>S'io lo so. Lo vuo' dir io signore.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Signore saprà...</p>
           </sp>
-          <sp>
+          <sp who="#cicala">
             <speaker><emph rend="sc">cicala</emph>.</speaker>
             <p>Saprà...</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Come...</p>
           </sp>
-          <sp>
+          <sp who="#cicala">
             <speaker><emph rend="sc">cicala</emph>.</speaker>
             <p>Come...</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>O Cicala, il tuo cantar m'assorda.</p>
           </sp>
-          <sp>
+          <sp who="#cicala">
             <speaker><emph rend="sc">cicala</emph>.</speaker>
             <p>O Grillo, lo stridor tuo m'annoia.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Che diferenza è questa! Or sù, sia che si voglia, eguale mancia tramendue avrete, sì che o parli l'uno, o l'altro taccia, ciascuno del parlare e del tacere avrà premio eguale.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Questa è stata nobilissima pensata, poi che io mirava la cosa molto vicina per fare alle pugna.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Or, che s'indugia? Cicala, Grillo, chi di voi dà principio?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Signore, come per tacere s'ha tanto da guadagnare come per parlare, io, che più di lui voleva mostrare di saper parlare, voglio mostrare ancora di saper più di lui tacere; per avanzarlo così tacendo come parlando.</p>
           </sp>
-          <sp>
+          <sp who="#cicala">
             <speaker><emph rend="sc">cicala</emph>.</speaker>
             <p>E io poi, che con questo pensiero teco m'azzuffai, bramoso di vincerti nell'impresa del parlare, vincerti voglio anche nell'impresa del tacere, acciò che, tuo malgrado, mia sia la vittoria, che contro di te o tacendo o parlando io desiderava.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Grillo, di' sù tu, figliolo. Che cos'è?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>O s'io parlo, sono figlio del marito della capra.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Dillo tu, Cicala.</p>
           </sp>
-          <sp>
+          <sp who="#cicala">
             <speaker><emph rend="sc">cicala</emph>.</speaker>
             <p>O s'io lo dico, sono figlio anch'io della moglie del toro.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Grillo?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>S'io lo so.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Cicala?</p>
           </sp>
-          <sp>
+          <sp who="#cicala">
             <speaker><emph rend="sc">cicala</emph>.</speaker>
             <p>Sì sì.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Non lo volete dire eh?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Oh che furbetti, alcun non parla.<pb n="181"/></p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Olà, se' tu di sasso, Grillo? Né si move.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>E tu, Cicala, che fai?</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>E questo pare un marmo.</p>
           </sp>
@@ -5672,127 +5745,127 @@
           <stage>
             <hi rend="sc">paggio, nottola, rampino, orazio, rondone, schiavetto, alberto, fulgenzio, prudenza</hi>
           </stage>
-          <sp>
+          <sp who="#paggio">
             <speaker><emph rend="sc">paggio</emph>.</speaker>
             <p>Signori, il signor Orazio è sano e allegro.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Sì? O piglia quello che doveva esser di questi duo muti.</p>
           </sp>
-          <sp>
+          <sp who="#paggio">
             <speaker><emph rend="sc">paggio</emph>.</speaker>
             <p>Ventura e' siedi! Io li ringrazio.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Da' qua que' dinari.</p>
           </sp>
-          <sp>
+          <sp who="#paggio">
             <speaker><emph rend="sc">paggio</emph>.</speaker>
             <p>Dico che sono miei!</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O questa è bella.</p>
           </sp>
-          <sp>
+          <sp who="#cicala">
             <speaker><emph rend="sc">cicala</emph>.</speaker>
             <p>Lasciagli star que' dinari, che sono suoi.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Venivano a me.</p>
           </sp>
-          <sp>
+          <sp who="#cicala">
             <speaker><emph rend="sc">cicala</emph>.</speaker>
             <p>Pur a me venivano.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Tu menti.</p>
           </sp>
-          <sp>
+          <sp who="#paggio">
             <speaker><emph rend="sc">paggio</emph>.</speaker>
             <p>Menti tu, to' questo.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>A furbo, to' pur tu.</p>
           </sp>
-          <sp>
+          <sp who="#paggio">
             <speaker><emph rend="sc">paggio</emph>.</speaker>
             <p>Signori, mentre che si danno addio, e io vo a porre in governo i dinari.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Eh, eh, eh, come i taciturni sono rimasti più carichi di pugna, che di mancia. Si dettero di forti pugna, e dandosi partirono.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Certo ch'è stata una cosa di spasso. Ma ecco il signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Signore Alberto, il signor Orazio non ha male alcuno, eccolo; di più, gli è venuta una così fatta fame, che mangiarebbe un lupo.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>O come, caro signor Alberto, come, o cara Prudenza mia, con gioia inusitata ambo vi miro.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Poverino, non sa, non sa. Sappiate, signor Orazio, che tanto il sole il mondo non rallegra all'or che dal notturno orrore lo disgombra, quanto la presenza sua allegrezza pone ne i cori nostri, per la ricevuta sua salute.<pb n="182"/></p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Io la ringrazio. E ben da questo risorger mio conoscer si può il merito della mia fede, del mio amore, avendomi lo stesso Amore , la stessa fede tratto da' morti, solo perché tra i vivi Prudenza mia goder in nodo strettissimo di matrimonio potessi, come appunto questo invitissimo mio signore hammi promesso, fattolo a parte, doppo il risorger mio, dell'amor ch'entrambi si portavamo. Di più, con generosa mano promesso avendomi di suffragare la mia molta nobiltà, in molta calamità caduta.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>È verissimo, e così confermando giuriamo.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>Orazio, concedo che per quello che s'aspetta all'amor nostro, per quello che s'aspetta alla generosità di così invitto signore, possa esser quello che dice; ma nego poi, per la parte che a me s'aspetta, ch'esser possa questo, essend'io di Fulgenzio, al presente, consorte.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Così, Fulgenzio, ti insegna l'esser nobilmente nato a tradire l'amico? Procàcciati d'armi, ché or ora teco far quistione intendo.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Se a voi gustoso e lecito fu il burlarmi, quando dietro alle mie spalle con Prudenza parlavate, non ben conosco che in tutto sia indegno l'aver burlato voi, poi che voi questo modo m'insegnaste. Ma poi che di far quistione desiderio avete, cacciate mano, ché ben meco ho dell'armi.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Sì? Caccia mano, difenditi.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Queste sono l'armi che meco porto, per offendervi, o Orazio. Queste chiome d'oro sparse sopra gli omeri di questa che piange a' piedi vostri, è quella ferza che sferzar vi debbe, in guisa che sforzato siate a far palese il vostro fallo. Ah già ben miro che sostenete i colpi, e che al vivo vi trafiggono, or in pallido, ed or in vermiglio il volto cangiando. Or via, si mova il piede, s'alzi il ferro, s'indirizzi il colpo; così coraggioso eravate innante, e ora così avilito siete? e quali armi contro di voi adopro? una ferza alfine, flagello di fanciulli.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Ahi, che vidi?<pb n="183"/></p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Senza, o crudo Orazio, che a ragionar si mova questa lingua, ben sai, ben sai, ch'altro accusar non dee se non ch'io sono Florinda e tu Orazio sei. Io quella Florinda che, per troppo teneramente amarti, a termine di tanta calamità son giunta, ch'a pietà di me si move l'impietade istessa. E tu quell'Orazio di cui, per accusar l'infedeltà grande, del silenzio il dio parole oggi trova che dicono: Orazio fra tutti i più disleali amanti è il più disleale. Quella son io, che colà in Napoli ne gli agii maggiori (lassa, che più dirò?), nelle felicità dello stato felicissimo verginale felice vivendo, fiera stella volle che, di te predatore, preda io rimanessi. E (ohimè) quante fiate più felice mi tenni da te amata, che felice Psiche non si tenne, quando degna fu d'esser d'Amore amante! Folle credendomi vie più, che sotto angelica spoglia non si potessero giamai amantare costumi d'orso rabbioso, o di Leon e superbo. Ond'ecco apunto, ch'altro di te non pensando, vigilava le notti, e i giorni digiunando io passava, bastandomi solo che, a gli occhi in ricompensa di sonno, e alle viscere digiuno per compensa di fame, cibo e riposo apportasse loro il vederti una sol volta passeggiatore per le contrade di Florinda e rimirator delle finestre sue. Pur sai, pur sai, che tutta già trasformata ne' tuoi desideri, da gli sguardi tuoi io pendeva, come pender suole da precettore fanciullo; onde perciò alle tue lettere, a i tuoi favori, con lettere e favori io rispondeva. E tu stessa, chioma incolta, il sai, che forse qui disciolta su 'l petto mi cadi per accusare quante volte dalla fronte io ti recisi e in treccia accolsi, caro essendomi che tempestata di perle e rubini in dono se n'andasse al mio signore, solo per noto fare al crudele che la treccia erano i lacci ond'io (colpa sua) stava prigioniera; le perle tante le lagrime mie, quali in rubini di sangue cangiate si sarebbero, se tosto soccorso dato non avesse all'amor mio fedele. Quella son io, che, rotto ogni freno d'onorato ritegno, sicuro loco t'elessi (troppo pesandomi il vederti languire) dove tu potesti da me côrre quel più, che ragguardevole<pb n="184"/> nel cospetto del sole, render può donna ben nata. E quella (o crudo) alfin son io, che tu lusingando invaghisti, che falseggiando tradisti, che violando uccidesti. Quind'ha che in odio a me medesma fatta, e in disprezzo (poiché cosa non è più vile e biasimevole che donna d'onor priva), elessi te Bireno ingrato di seguitare: ed ecco come, quasi sesso cangiando, abito virile io vesto. Considera or tu, con quanto pianto prima vestii queste membra, che di queste vestimenta io m'appagassi di ricoprirle. Considera tu (e se conoscenza non hai, la pietà te l'impetri), con quanti sospiri le paterne case d'abbandonare elessi. Considera tu, quelle abbandonando alfine, quante volte (ahimè) a quelle la fronte io rivolsi, dir loro potendo a pena addio. Pensa deh, pensa or tu, a quante calamità di lunga e incerta peregrinazione si avventurò donna, che per natura altro conoscer non dee che gli angusti confini della sua casa! Ahi quante volte (o crudo) inaccessibil monte incontrandomi, tutta mi sgomentai, divenni sasso dal piede al capo in rimirarlo, misera creder non potendo di colà su poter portare questa mia vita inferma. Pensa, pensa, come dalla pioggia molle, dalla grandine percossa, dal vento trafitta, da i lampi abbagliata, da i tuoni assorda, dalle tenebre tenebrata, più volte fu la misera peregrina Florinda, la quale, in tanta fiera sventura, il ricovrarsi sotto un'arbore fronzuta fu gran ventura. Pensa, pensa, o spensierato, quante fiate l'ira de' ladroni, l'ulular de' lupi, il corso de' rapidi torrenti, le aricciasse il crine, tremar la facesse dal capo alle piante! Tutto, tutto per te superò alla fine, a tutto generosamente s'offerse, per tutto cercò, per ritrovarti, folle me credendo di ritrovarti, quanto già infido, ora fedele. Ma che? Ahi, mia folle credenza, a pena ti trovo, che lassa me pur sento che, d'altra donna invaghito, più di Florinda non ricordi. Ond'io perciò, dall'acerba passione vinta, e vinta dalla violata fede e dall'onor rapitomi, terminai di levarti la vita. Ma benigno Cielo che 'l tutto vede, e alle cose più disordinate certo ordine concede, fece sì che andò a vòto il mio pensiero, poi che questa parte dell'uccidere a te<pb n="185"/> s'aspetta, e a me dell'essere uccisa. Però eccomi a' piedi tuoi, se di vita e di mercede mi giudichi non indegna, dammi mercede e vita; e se morta mi vuoi, di' solo muori, ché tanto è omai per te vicina alla morte questa mia vita, che solo co 'l dir muori sarai felice.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>O mia cara Florinda levatevi, ché non a voi, ma sì bene a me questo atto di perdono (ben che indegno di perdono io sia) si conviene. E come non ti poteva io conoscere, se in quel punto, che voi cadeste a' miei piedi, vidi con l'umiltà vostra abbattuta la superbia mia, palese la vostra fedeltà, nota l'infideltà mia, voi degna di mille vanti, io a parte di mille accuse. Patiste, Florinda, affaticaste, mio bene; ma quanto sudore in lungo peregrinare stillò la vostra fronte. tante lagrime ora da gli occhi io spargo; e quanto disagio già soffristi, tanto ora duro pentimento lacera questo cuore. Ma se vera umiltà, se caldo e acerbo pianto, se vero dolore di commesso fallo ognor trovò mercede, deh la mercede oggi a me non si neghi. Florinda pietade, consorte aìta, donna offesa perdono! Errai, errai no 'l nego; ed errando feci che, dalla mia incostanza, della costanza vostra altrui fosse a parte, e, per la mia ignoranza, del saper vostro altri pur contezza avesse. Or se, per gli errori miei, tanto sagace si dimostrò Florinda, non dovranno quelli più lode che biasimo meritare? Certo sì, che molto merita chi fu cagione che di gran tesoro si venisse a parte.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Cari amanti, non più, ché già tutte le membra mi piangono.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Oh gran forza d'amore, o grande amor di donna.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Da vero principe, che sono tutto tenero come pasta, per la pietà di questi amanti.</p>
           </sp>
@@ -5802,835 +5875,835 @@
           <stage>
             <hi rend="sc">succiola, facceto, solfanello, paggio, nottola, rampino, orazio, rondone, schiavetto, alberto, fulgenzio, prudenza</hi>
           </stage>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>Io m'addimando Grillo, e perciò fuora da questo canto io ficco il capo, e mi rallegro di questi amori, anzi vi<pb n="186"/> prometto che la prima notte del <foreign xml:lang="lat" rend="italic">gaudeamus</foreign>, voglio sotto il capezzale vostro tanto cantare, che giamai il sonno v'entri ne gli occhi, onde meglio possa alla sposa lo sposo dilettare.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O che furbetto, eh, eh, eh.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Così li voglio, eh, eh, eh.</p>
           </sp>
-          <sp>
+          <sp who="#cicala">
             <speaker><emph rend="sc">cicala</emph>.</speaker>
             <p>Ecco pure, che da quest'altro canto con il capo spunto. Altro non dirò, salvo, o signori sposi, ch'io sono Cicala, e a voi pur prometto che a mezo di quando sarete all'ombra di qualche pianta (voi m'intendete) voglio anch'io forte più del solito cantare, perché non si senta il rumor de' vostri baciucci inzuccherati.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Eh, eh, eh, è costui pur al peso.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>O caro Grillo, o caro Cicala, quanto mi hanno piaciute queste vostre fanciullesche accortezze.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Sì? Poi che tanto v'hanno amendue piaciuti, signora io ve gli dono. Di più, con cento livree per ciascuno appresso.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Ohimè qual Cesare, qual Creso, qual Traiano furono giamai di vostra eccellenza invittissima più grandi e più invitti?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Invittisima, invitti? Sei mila scudi vi dono, da far loro le spese e da mandargli qualche volta alla stufa e a far tosare.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>O generoso eroe.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Generoso eroe? Vi dono una braghetta alla tedesca, tutta ricamata di rubini e di diamanti in punta.<pb n="187"/></p>
           </sp>
-          <sp>
+          <sp who="#cicala">
             <speaker><emph rend="sc">cicala</emph>.</speaker>
             <p>Ho paura, signora, che vi piacerà più tosto il braghetto che tutti gli adornamenti, io, non è così? Dite il vero. Ah, ah, ridete? A signora Schiavetta furbetta, amorosetta, ninetta, buffetta, atta a farvi star sempre l'uomo inanzi senza beretta.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>O ghiottoncello.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Ma ecco Succiola con duo uomini. Che diavolo di fantaccini proibiti sono questi?</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Or sù Facceto, andianne da cotesto principe, ché ti vo' far ricco, e di poi me ne voggio andare sino al vinaio a imbiancar de' panni. Oh? Eccolo appunto. Che di' tu Facceto, non par oggi il carnasciale?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Succiola.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Oh? Signore, i' son quie, e di piue le arreco una buona novella, qual è che in coteste nozze da cotestui i' vi prometto una bella comedia.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Comedia eh? E apunto noi altri prìncipi non si dilettiamo d'altro.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Come d'altro non si diletta, ecco chi gnene caverà la voggia.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Vien qua, comediante. Com'è 'l tuo nome?</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Facceto, per inchinarmi (com'or fo con quattro inchini) a chi merita che tutto il mondo se l'inchini.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O come ha fatto presto, e leggiadre, quelle quattro riverenze, eh, eh, eh, mi fa ridere il comediante e ancor non lo vedo a comediare.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Pensa poi vostra eccellenza quando nel teatro lo vedremo diverse persone e abiti fingere, se diveremo d'Agelasti Democriti.<pb n="188"/></p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Accòstati.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Eccomi, signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Baciami la mano.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Ecco, signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Costui conosce ch'è gran virtù subito ubidire ai prìncipi. Olà?</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Signore?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Donagli una collana.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Adesso, signore. Pigliate, fate animo, e di più apparecchiatevi di fare una bella comedia.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Signore, per certo che mercè sua dir si puote che sia tornato il tempo dove più abbondavano i meccenati.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Or sù, mentre, o Facceto, teco parlo, fa' porre in ordine la tua comedia.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Solfanello.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O che nome.</p>
           </sp>
-          <sp>
+          <sp who="#solfanello">
             <speaker><emph rend="sc">solfanello</emph>.</speaker>
             <p>Signore, che vuole?</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Tira le tele.</p>
           </sp>
-          <sp>
+          <sp who="#solfanello">
             <speaker><emph rend="sc">solfanello</emph>.</speaker>
             <p>Sì signore, or ora ammanisco il tutto.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Facceto.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Vi date del signore tra voi altri, ch'egli è uno spasso! Ma gli abiti poi, pare a me che non sieno conformi a quelle tante signorìe.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>La virtù, altissimo signore, è quella che fa l'uomo meritevole del nome del signore; anzi la virtù è quella che rende pari al maggiore del mondo il più basso uomo che viva. Pendono da un solo e da una istessa fonte tutti i viventi; e cadano dal Cielo pari di nobiltà l'anime ne' nostri corpi. Tutti i virgulti della vita umana vengono da un<pb n="189"/> ceppo, tutti siamo frondi d'una istessa pianta, che cadiamo egualmente nel generale autunno della morte.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Oh come discorre altramente. Dove fai lo studio tuo, su i campanilli?</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Parerà, appresso gl'indotti, che l'eccellenza sua scherzi, così udendola favellare, ma con questo detto Facceto vuol dinotare quei nobilissimi studii che sovra gli alti monti facevano i filosofi antichi, quando nella polvere d'essi monti scrivevano e ritornandovi vi ritrovavano l'istesse cose scritte. E questo perché andavano tant'alto che quasi passavano la seconda region dell'aria, dove si formano tuoni, saette, tempesta, e simili, il tutto colà sovra trovando purissimo.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Alla fé, che l'ha indovinata. E che ti credi ch'io sia qualche goffo? Or sù, quanti personaggi entrano in questa tua comedia?</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Diece, signore.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>O che cicalone.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>State cheta madonna, che vi farà dar tre tratti di corda, vedete.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Fune a me?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>A voi.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Eh? L'ha errata cotesta fiata. Non mi si può dar di fune, né a me né a l'altre donne.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Perché?</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Oh? Perché siamo aperte dal di sotto.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Eh, eh, eh, questa certo è stata bella, che ne dite signori?<pb n="190"/></p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Costei è scaltrissima.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Anzi isguaidrinissima.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Or sù a noi. Voi siete diece personaggi eh?</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Diece signore, così è.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Sì? Or sù chiameli.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Mo sua eccellenza guardi me, e in me tutti gli scorga.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>So che tu se' il capo, ma solo non puoi far la comedia.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Dico solo, signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>E come solo, se diece v'intervengono? Di' beccaccio, tu mi burli?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O signore, che fate?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Non mi tenete, lasciatemi.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Piano, piano signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Non mi si tenga dico, ché con questo pugnale lo voglio ammazzare.</p>
           </sp>
-          <sp>
+          <sp who="#solfanello">
             <speaker><emph rend="sc">solfanello</emph>.</speaker>
             <p>Eh? Vostra signorìa non l'intende.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Do' becco, io non l'intendo? Aspetta, aspetta.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Eh, fermatevi signori.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Fermatevi? Teco la voglio.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>O che spiritato, che gli sia fritto i granelli! Signore, deh mi si ascolti. O che sgraziato! Odami caro signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Parli Succiola, e gli altri stiano cheti, se non, ch'io gli fo cavar le lingue e le fo salare per memoria de' disubidienti, e ispavento.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>O come e' mi guata stralocchio, mi fa paura. Signore, a cotest'otta è ammanito il palco, per dir cosìe, sono le tele tirate, e alla comedia principio dar non si puoe. O che domine di baccellate e fagiolate sono coteste?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Comedia? palco posto? tele tirate? M'è passata la collera, virtù tenendo la comedia di rallegrare. Càppari, so che noi altri prìncipi come cacciamo mano all'arme facciamo paura. Voi mi parete tante galline fuggite dalla volpe.<pb n="191"/></p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Si debbono temere le persone grandi, perché cose grandi possono fare, senza chiedere ad alcuno licenza, né consiglio; e poi, voce adirata di principe, squilla di morte dir si suole.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Tu di' bene.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Ma perché sappia sua eccellenza come diece e solo io sia, sappia ch'io solo tutte queste diece parti rappresento.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Questa è cosa molto grande. Pure dalle parole veniamo a' fatti; il tuo apparato è già all'ordine. Sentiamoci noi signori, e tu va' ad incominciare.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Appunto a questo fine di darle spasso presi una coppia di galanti sonatori e or mi parto. Sù sonatori, alle gioie, a i piaceri, sonate! Sù, che s'indugia?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>A sedere signori, dove sono gli scagni e le seggiole? Sù presto, canaglia, andate per esse.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>O potta di santanulla, lasciate la cura a mene! Vien qua tue, tue; movetevi ancor voi bel cero, oh? tu non vedi? e che sì, che ci vogliono e' pungoli?</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Via presto, meco tutti.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O che bel concerto di suono. Meser Alberto?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Andate a darli quattrocento scudi di caparra, che stanno tutti meco.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Vado signore, e gli proferirò per ora il dinaro per non istare tanto co 'l contargli.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Or sù tornate in qua.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Vengo signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Tamen andate là.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Vado.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Non andate.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Non vado. O che umore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Ecco da sedere. Sù sù, sentiamosi tutti.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Eccone, eccone, eccogi qua, eccogi qua, i be' scanni.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Ecco qui, signore, tutto per ordine.<pb n="192"/></p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Accomodiamoci. Fermatevi sonatori, finché s'è accomodato ogn'uno signore. Sù sù, sedete sedete, non più cerimonie. Oh? Sù figlioli, battete de' piedi, fischiate, cridate, e dite: «Fuora, fuora canaglia!».</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Ah signore, queste azioni cadino lontane da gli animi ben nati e solo quelli questi strepiti faccino, che, non conoscendo che sia virtù, a tali insolenze si volgono.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Ma ve la dirò io. In ogni città ho udito sempre far cotesto baccano a i comedianti, e perciò lo faceva anch'io.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>E questa gente, appunto, è la fecce de' più furfanti delle cittadi, ch'ad altro intenta non è che a fare insolenze, e quando in altro luogo far non le ponno, nelle stesse loro povere case alla presenza delle loro mogli e figli, così sfacciati similmente essendo, danno occasione di lasciar eredi (se non di virtù) di prosunzione almeno i loro poveri figlioli, quali co 'l crescer della insolenza del padre, crescend'essi in cattivi e vituperosi costumi, fatti sono alfine gemme da legar con le manette alla bottega de gli sbirri, cocconi da turare i buchi alla berlina, e pendenti da rendere adorno il seno di madonna forca.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Certo ch'ell'è così. Or sù, che si torni a sonare, e poi si dia principio e alcuno non faccia strepito. Oh questi suoni mi piacciono pur tanto, tanto, tanto. Oh? Ecco il prologo.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Gentilissimi signori, io sono il prologo, a così degna presenza comparso per chiedere il silenzio.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Olà, chi è quello che parla di voi altri?</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Niuno, mio signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Come niuno? Do' puttanaccia! Non senti che dice che si faccia silenzio?</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Eh signore, ch'è così costume del prologo di chieder il silenzio, ben che si faccia silenzio.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Non so tanti prologhi io! Si può far la comedia senza prologo?</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Signor sì.<pb n="193"/></p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Or falla. Via, presto.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Ecco, signore, ch'io le vo a dar principio.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Sua eccellenza ha fatto molto bene, in ogni modo al tempo nostro il prologo è corpo, o per meglio dire, membro separato dalla comedia.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Or sù cheti, cheti di grazia, ché già comincio a ridere, eh, eh eh.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Zuane? Missir. Dov'estu? A su in cantina. Che fastu? A tragh dol vì. Dove xe Nespola? Col cul su la paia. A bestia su i grizzoli; dove xela digo? Nel zardì sagnur. A che far? A che fà? Intat che l'ortolà se lava el ravanel, ela se tosa la pimpinella. Eh, ehe, eh! El xe forza che mi rida. Mo signor Pianelon (potta de zuda) vegnerà mai ste vin? Signor Dottor el vegnerà adesso. Mo ste ales no vien mai lu? L'alesso non vegnerà mai certo per la signorìa vostra, perché a vu xe destinà solo el rosto, che de i fatti vostri in sabo de mattina se aspetta. Mo che ho da far de l'ost mi? Mo te no vi? Tuò tuò tuò! Doh garbantouna, mo ti è qui nespolountina. Oh? Son qui signore, e vi do nova com'i' son fatta la sposa.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Oh? Cotesto bel cero uccella e' fiorentini, per quanto ascolto.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Sta' cheta Succiola, la comedia va così.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Or sue, non diroe più nulla; i' staroe ad udire. Scicali pure.<pb n="194"/></p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Càncaro, si' donca fatta la spinosa? Signor sìe, i' sono la spinosa venuta or ora da via Pentolini. O che furba, saveu che cos'è, Dottor, via Pentolini? Borg non int'el miè paes. Giusto giusto el xe l'istesso. Ma, car signor Pianelon, mutamos verba. Mo, caro signor stivalon, no me secché pì co ste fiabe. O ben vegnud, messier Zan! Com'è, bon sto voster vin? L'è lu ol plù bon vì, che se sia mai bevut. Lassademel mo sentir! Oh l'è pur bon. Un'altra sorsadina. Fermef, fermef e che intendif de fà? Mo me vot far anegar biestia? O scornadù! Te te ment per la gola. Ohimè. Che xelo signor mef e che intendif de fà? Mo me vot far anegar, biestia? O quanto sangue, ohimene. A marmirol, to' sto pugn. To' ti an quest. Fermève là, a chi digo? To' sarafins. To' an ti gaiof. To' ti. To' ti. E fermàtivi! Ohimène, un calcio nel ventre, ohimène! E destacchève, Zane a chi digh'io? Potta de zuda tirév in là! Ohimèi un pugno a mi, porco salvadego? Ammazzève, bestiazze! E me tiogo de sotto.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O che rumor fa colui, ed è solo. Alla fé che questo è un bel comediare. O eccolo.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>O poverazzo mi, me forbo el naso e mel reforbo, ma no vedo zà sangue. Inefetto la xe cusì: chi sparte la quistion combate con cento. Mi ho arlevà un pugno, che averave buttà via el scartozzo d'un campanil, e pur el naso si xe al so liogo. Che vustu mo far? Bisogna al seguro che ti vada dal barbier per far guarir Grazian, daspò che Zanne, to servidor, ghe ha pettà del boccal su'l cao, e per zò nel romperse ghe si xe piantà el manego int'el fronte, sì che el par un lioncorno todesco.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>A Pantalone, potresti far una pastoralina?</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Signor sì.<pb n="195"/></p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Di grazia, una pastorale, ché questo rumor di boccali e di ferite non mi piace! Mi ricordo de' miei nemici e, in cambio di movermi a diletto, tu mi disgusti dal pelo del capo fino alle ugne de' piedi.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Di grazia, signore, farò sonare di nuovo e senza prologo darò principio ad una pastorale.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Sì, di grazia.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Oh la pastorale è cosa molto lieta per l'apparato verde e fiorito, e per vedere pastori e ninfe trattare puri e dolci amori, quali appunto le città trattar dovrebbono, per goder (malgrado del ferro) la età dell'oro.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>O quanto m'è caro, signori, di sentire una pastorale.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>E io pure signore, ché ho inteso a dire che sono cose così belle.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>E io poi? Con un orliccio di pane, i' ne sentirei quattro in fila, i' non ho aitro gusto.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O veda, sua eccellenza, che sopra la tela della comedia ha lasciato cader per di sopra un'altra tela dipinta, che sembra un luogo boscareccio e di prati fioriti.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Bello da vero, or sù silenzio.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Be, be, be, be.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O che sporco principio è questo? Pare a me che solo questa pastorale s'abbia da recitar fra becchi e pecore, e che rumore di be, be, be? Se tutte le pastorali sono così, si ponno recitare nelle stalle.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Be, be, be.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Facceto?</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>E che vogliono dire queste pecore?</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Miri, sua eccellenza, io sono da pastore vestito, e fingo qui d'intorno di guardare la greggia; onde per questo ne succederanno altre belle cose.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>E gli è un brutto principio, per averne a seguitar poi cose belle.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Brutto ancora era colà nelle deformità sue prime il caos. E ora vediamo da quel deforme principio che cose belle ne sieno seguite.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Or sù, a dar principio.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Io vado e m'inchino.<pb n="196"/></p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O come que' saltarelli nel partire che fa mi piacciono.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Egli è certo molto ridicoloso.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>I' non posso punto punto ridere; o che sciudice cose.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Orsù, cheto ogn'uno.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Be, be, be, be, guarda il lupo.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Ohimè.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Il lupo il lupo.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Il lupo? Salva, salva.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Dove signore?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Che vuol dire?</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Il lupo, il lupo, il lupo.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Non mi tenete, ohimè ch'io perdo la voce.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>E che vuol dire signore?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Traditore, tu vuoi essere cagione della mia ruvina eh? M'hai fatta una paura con quello «al lupo, al lupo» ch'io ho ruinate tutte le calze.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Eh? Ch'è cosa finta, signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Se la tua è stata finta, è bene stata verace la mia.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Ma perché tanto spavento di cosa mentita? Io stupisco.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>E io putisco. Or ti dirò. Sappi, che la mia navità disse ch'io portava gran pericolo d'esser mangiato da' lupi; e come sento quel nome, parmi di vederlo con gli occhi di fuoco, co 'l ventre asciutto e con la bocca armata di denti, che mi si lanci. Lascia pure questa tua pastorale intitolata la Be, be, be. Sai far altro?</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>So far delle tragedie.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Sì? O va' a tragediare, via presto.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Adesso, adesso.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>O questa sarà bene una degna rappresentazione.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Non v'intervengono già pecore? Dite il vero, meser Alberto.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>No signore, le pecore non hanno che fare con le persone tragiche.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O così le bramo. Ma che panno nero è quello che ha lasciato cadere sopra quel verde e fiorito?<pb n="197"/></p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Eh? Va così signore, questa s'addimanda tragica pompa.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>E questi suoni hanno da sonar così mesti ancora?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Sì signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Queste trombe e tamburi ancora, e sorde e scordati ci vanno?</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Questi sono principii di cose tragiche, che suspendono gli animi alla maraviglia.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Ohimè, che fiamme son queste? Acqua, acqua, si brucia la tragedia, si brucia la tragedia!</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>No no, signore, non tema; questi sono fuochi finti.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Fuochi finti? Oh? Com'è così, torniamo a sedere.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Riposi pur l'animo suo, e lo prepari a cose degne.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Ma sì, che cosa è questo? Questo è bene il diavolo. Ohimè, ohimè.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>No signore, non è il diavolo, è un'ombra, un'ombra.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>L'intendo, l'intendo messere; ma pare a me che un'ombra e il diavolo sia una cosa istessa. Ohimè fatelo levar di là, ché mi vien fastidio.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Eh? Signore, ché son io.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Alla fé, che se tu ti usi a farmi di queste comedie, io ti farò impiccare per la gola! Non voglio più comedie, anzi gli voglio esser più nemico che 'l polcino del nibio. Olà?</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Signore.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Donagli cinquanta scudi e che vada a far comedie nella comediarìa.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Mio signore, mi concede in grazia ch'io dia a costui da fare un bel suggetto di comedia amoroso, per doppo cena, che al lume di torchi e con un poco di palco posticcio, averà più maestà la comedia?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Sì, caro signor Orazio, dateglielo, e si mandi a chiamare sessanta marangoni e s'incominci a far fare il palco; e venghino or ora trenta carra di tavole e di travi.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Lasci il carico a me del palco, che si farà con assai meno roba; e il carico del suggetto al signor Orazio.<pb n="198"/></p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Io mi contento. Dite il suggetto; e nota bene, ve? ché ogni errore ha da essere una pugnalata.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Io non temo d'errare, signore. Dica pure questo signore, ché ben farò un suggettino che starà ne gli ordini della Poetica; e ben ch'ei non sia d'un filosofo non importerà, poi che 'l costume d'oggi così comporta.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Or dunque, ascolta. Voglio che 'l suggetto si finga qui in Pesaro (e sarà bello di sicuro, perché è caso amoroso e occorso appunto oggi). Fingerai che un giovine, nomato Orazio, amasse una Prudenza e fosse riamato; ma per esser questi Orazio povero, il padre di Prudenza detto Alberto gle la neghi in consorte. Farai di più che questi Orazio, da Prudenza riamato, avesse un abito e mantello in modo tale, il quale faccia sì che, ora da ebreo, ora da quello che riceve in nota i morti vestito, ottenga con inganno Prudenza. In questo tempo che Orazio ama Prudenza, farai che una giovine bellissima, in abito da uomo, si finga uno schiavo, il quale vendendo segreti vada per lo mondo, e giunta in questa città trovi Orazio inamorato di questa Prudenza. E perch'ella, fino in Napoli, da quest'Orazio sotto fede maritale perdette l'onore, termini perciò di tôrgli la vita e qui mandi un suo, detto Rondone, per veleno allo speziale, farci con quello de' moscardini e aveleni l'amante. Farai che la Corte sopragiunga, la pigli e condannata sia a morte. Ma inteso poi che non è veleno, s'intenerisca la giustizia, se le perdoni e così rimanga questa giovine consorte di Orazio.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O potta di me, questo sarà il bel commediaccione Ma mettimici dentro me ancora e con miei doni s'aggrandisca questo suggetto; e fa' di più ch'io volessi pur questa Prudenza per moglie e che, stufatomi, da me sia rinunziata a Fulgenzio.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Bello aggiunto, in vero. E qual è questa donna tanto generosa? com'ha nome?</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Ha nome Florinda, ed eccola colà.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Ah scellerata, se' morta!<pb n="199"/></p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Olà, dinanzi a prìncipi?</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Ferma là dico.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>A questa foggia?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Barba posticcia?</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Deh, si fermi ciascuno! Signori, questi è mio fratello.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Suo fratello?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Signori, ascoltisi le sue ragioni e poi voi, signor fratello, in grazia mia (e basta) se le perdoni, perché questo è caso amoroso e ne seguita il matrimonio.</p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Di già, signore, senza che più rinovelli il caso della sorella sua Florinda, l'ha inteso; e in uno è fatto a parte della sua molta generosità e onestà, che non volendo lasciarla invendicata tanto peregrinò, tanto patì e tanto fece. Io solo il colpevole fui, io solo il reo; ma quanto errai fuggendo, nemico da Florinda, morte meritando, ora Florinda seguendo, amante e consorte vero, mi dovrà esser conceduta. E se pur solo con il sangue lavar s'intende questa macchia, il ferro già ignudo hai nella mano e io a' piedi tuoi mi trovo, il colpo aspettando.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Orazio, tanto seco di forza hanno portato le sue poche parole, e questo atto suo così umile, che altro ragionando dir non può questa lingua, se non che errore, con umiltà confessato subito, perdonato sia. Scòrdinsi le offese, i desiderii di vendetta; e l'aver io vestito questo abito con supposito nome, per poter con questo mezo di comico, e comico solo, esser chiamato in tutte le case, e colà dov'io trovava Florinda farne anche dovuto scempio. V'abbraccio, mio signore e cognato, e tu Florinda nella mia grazia rintegro.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>O caro fratello, mille perdoni si concedino a questo mio amoroso fallire.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>Avrei ben te potuta seguitare, per forza delle ricchezze nostre, con molta gente e con nome diverso da Lelio Fedele, ma che? Ben sapeva che per le osterie ritrovata io non t'avrei, né che per le città tu saresti (come già per Napoli) andata con serve errando, certo essendo che l'errore tuo<pb n="200"/> comportava che sempre da gli occhi del sole, non che de gli uomini, ti fossi andata nascondendo. Onde, per consolarti alcuna fiata pur fra me stimando che di qualche spasso saresti stata col tuo amante vogliosa, terminai con il dolce trattenimento di comedia per ogni castello e città andando, far porre cartelli che dicessero: Oggi Facceto, solo comico, invita a comedie private. E questo non solo per andare in ogni villa, castello e città, ma per entrare in ogni casa di detti luoghi e, colà a caso trovandosi, far quello che di già più non dico, poiché in tutto di già ho obliato.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O che stravagante caso, inefetto bisogna esser uomo da bene. Ohimè, che cosa è questo? È la Corte, ch'io vedo dalla lontana? Signori, con licenza, mi s'è mosso il corpo.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>E non parta caro signore, veniamo ancor noi.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Ho un certo freddo, cari signori, pigliatemi tutti nel mezo vostro, e tutti insieme stringetevi.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>E che? Non impiccieremo del fuoco?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Non mi scaldo con fassine quando ho freddo, ma co 'l caldo umano in questa maniera detta loro.</p>
           </sp>
@@ -6638,415 +6711,415 @@
         <div type="scene">
           <head rend="italic">SCENA DECIMA</head>
           <stage><hi rend="sc">caino, belisario, corte</hi>, <hi rend="italic">e tutti quelli della scena di sopra</hi></stage>
-          <sp>
+          <sp who="#caino">
             <speaker><emph rend="sc">caino</emph>.</speaker>
             <p>Non dicit tante paraule. Ch'io abbia il mio, ben condizionat, ché li vostri zevvin sono qui; avete trovat un hichudi molt galant'uomo.</p>
           </sp>
-          <sp>
+          <sp who="#belisario">
             <speaker><emph rend="sc">belisario</emph>.</speaker>
             <p>Basta.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O che dolor di denti, bisogna con questo fazzoletto mi tenga calde le gote, anzi che vada in casa, per aceto da sacquarmeli.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>La seguito signore anch'io.</p>
           </sp>
-          <sp>
+          <sp who="#belisario">
             <speaker><emph rend="sc">belisario</emph>.</speaker>
             <p>Come vi dico è quello, pigliàtelo.<pb n="201"/></p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>Che vuol dir tanta gente? S'è forse fatto qualche rumore?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Anzi, allegrezza vi s'è fatto, mercè d'una comedia, che ha fatta recitar un generoso signore.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Oh, i' la vedo imbrogliata cotesta ciuciurlaia.</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>E dov'è questo signore, questo conte?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Se gli è mosso il corpo, per lo freddo che improviso gli è venuto; gli è saltato il dolor ne' denti ed è andato in casa per aceto con un suo caro.</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>In qual casa entrò?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>In questa, ch'è mia.</p>
           </sp>
-          <sp>
+          <sp who="#belisario">
             <speaker><emph rend="sc">belisario</emph>.</speaker>
             <p>Sù, entrate tutti colà.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>A beccacci.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>A furbi.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Guarda guarda.</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>Su i tetti? e da quelli gettate i tetti stessi?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Sì becco, to'.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>To'.</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>Sotto figlioli, con taburri in capo.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Sotto? To' quella.</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>Rotelle in capo, rotelle in capo!</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Sassate in capo, sassate in capo, to' pure! Ti so dir che piovono.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O povera mia casa.</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>Sparate delle archibugiate.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Eh no.</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>Che no? Sparate, dico.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O poveracci, son morti al certo.</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>Dentro, dentro, dentro.</p>
           </sp>
-          <sp>
+          <sp who="#belisario">
             <speaker><emph rend="sc">belisario</emph>.</speaker>
             <p>Entrate pur, ch'entro anch'io.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O povero me, voglio entrare anch'io.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>E no, caro signor padre, che fra queste archibugiate voi alcuna fiata pericolaste.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Che romore è questo, Caino?</p>
           </sp>
-          <sp>
+          <sp who="#caino">
             <speaker><emph rend="sc">caino</emph>.</speaker>
             <p>Il conte è un ladro. Sì, per la Torà.<pb n="202"/></p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O povero me, ché mi spezzano e casse e usci e finestre.</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>Piglia, piglia, piglia.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>O poveraccio.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>S'io lo so? A beccacci.</p>
           </sp>
-          <sp>
+          <sp who="#belisario">
             <speaker><emph rend="sc">belisario</emph>.</speaker>
             <p>Piglia il traditore.</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>Là, là! Guarda, che fugge! Spara, spara, un'altra, un'altra. Addosso, addosso!</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Or sù ci sono. Andiamo in prigione, sù via che diavolo fate?</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>A furbo, tu ci se' eh? Alla forca, alla forca! S'era chiuso in un casson di farina.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>O questo sapeva che doveva essere il sugello di tutte le mie ladre fatiche.</p>
           </sp>
-          <sp>
+          <sp who="#belisario">
             <speaker><emph rend="sc">belisario</emph>.</speaker>
             <p>Mi duole com'hai rubato mille cose, così tu non abbia mille colli da poter mille volte essere appiccato.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Ha ragione in vero, però, cari signori, ogni uno di voi il suo collo mi presti, per farmi appiccare tante volte quante il signor Belisario desidera; e voi, Belisario, siate il primo.</p>
           </sp>
-          <sp>
+          <sp who="#belisario">
             <speaker><emph rend="sc">belisario</emph>.</speaker>
             <p>O che scellato, ancora ischerza ed è vicino alla forca.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Oh? Se adesso veggo la mia natività adempiuta qual era, ch'io gli ultimi scherzi li doveva fare su la forca, non volete ch'io faccia quello che le stelle mi minacciarono?</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Ah manigoldo, e forse ch'io non credeva di difendere un conte, il quale, per tanta bravura mia, mi dovesse poi ricompensare? Ladronaccio poltrone! Caro Bargello, se non v'è boia, fate che sia io quello, ché allora conoscerò anch'io che virtù di stella mi fu posto nome Rampino, accioché io potessi sostener nell'aria questa carne da corbi.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Fatti appiccar volentieri, quando un conte per trattenimento si fa appicar teco, onorandoti tanto la forca. Oh caro vecchietto, mi volete troppo bene! So che non vi darà mai il cuore di farmi appiccare, siete troppo spauroso, avreste tema ch'io venisse la notte a farvi paura.<pb n="203"/></p>
           </sp>
-          <sp>
+          <sp who="#belisario">
             <speaker><emph rend="sc">belisario</emph>.</speaker>
             <p>Oh bene, fa' come dice il proverbio. Vatti apicca' e poi viemmi a far paura.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Orsù signori, so che questo vecchio burla, come pur per fargli una burletta anch'io gli aveva portato via tutto il suo.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Poca cosa ha fatto, solo un bada tutto! O che briccone.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Udite e poi tutti gridate per l'invenzione spiritosa: viva viva il Trinca! viva il Trinca! ché tale è 'l mio nome, per dilettarmi molto di bere, sin da piccolino avendo perciò fatto fallire un mercante da vino.</p>
           </sp>
-          <sp>
+          <sp who="#belisario">
             <speaker><emph rend="sc">belisario</emph>.</speaker>
             <p>La volete più bella, signori? Da picciolo e da grande alfine di costui doveva e ruvinare e assassinare. Or sù comincia.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Signori, state a sentire e riderete poi. Da piccolino, a questo sfortunato (e non so chi diavolo glelo ponesse in capo) gli venne voglia di pigliarmi a star seco, e perché io faceva di segreto il ruffiano a sua moglie.</p>
           </sp>
-          <sp>
+          <sp who="#belisario">
             <speaker><emph rend="sc">belisario</emph>.</speaker>
             <p>Menti per la gola!</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Di grazia, lasciatemi dire l'istoria come va. Costei mi pose grande affezione, e così fece ancora che questo povero messer Cornelio...</p>
           </sp>
-          <sp>
+          <sp who="#belisario">
             <speaker><emph rend="sc">belisario</emph>.</speaker>
             <p>Che Cornelio? Cornuto se' tu.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Ma fusè senza filo. Lasciatimi finire. In somma dico, tanto fece, che questo vecchio non vedeva per altri occhi che per i miei.</p>
           </sp>
-          <sp>
+          <sp who="#belisario">
             <speaker><emph rend="sc">belisario</emph>.</speaker>
             <p>Te ne menti.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Aspetta, vecchio, che non si finisce la fòla, che ti voglio far porre in prigione per monetario.</p>
           </sp>
-          <sp>
+          <sp who="#belisario">
             <speaker><emph rend="sc">belisario</emph>.</speaker>
             <p>O povero me.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Fammi lasciare, ché sarà meglio, e perdonami, se non che vivo o morto, ti voglio ruvinare: morto con lo spiritarti, vivo col far bruciarti.</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>Non temete, signore.<pb n="204"/></p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>E furfante, le parole de' maligni gli uomini d'onore offendono in quella guisa che offende il fulmine l'alloro, il fuoco la salamandra e il veleno Mitridate.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Sì, Mitridate! Tu sa' bene quello che dir posso di te! Adagio, tu per lo meno vai in berlina.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Fagioli! S'io parlo, vo alla frusta senz'aitro.</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>Finisci pure, acciò che 'l boia possa incominciari.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>E così come vi dico, non potendo aver figli, questa vacca di sua moglie mi fece suo figliolo addotivo. Morì costei, e costui di lì a poco pur s'ammalò, e perché io sentiva che i medici dicevano che sarebbe andata in lungo questa sua malattia, non potendo più questa minchioneria aspetare, per non aver occasione una notte d'accoparlo, per termine di carità vinto, presi tutte le sue gioie, i suoi dinari, gli argenti, e me la battei, desideroso di fermarmi in una città e alla barba sua di sguazzare. Ma il suo malanno ha voluto che questo ladro mi venga per i piedi, prima che io abbia potuto goder l'utile di questo figliolo addotivo. Or che saprai dire vecchio bacucco? non è mia questa roba? non se' tu meritevole d'una forca? Di' sù, da' la sentenza. Via, pigliàtelo e menàtelo prigione.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>E perché piange vostra signorìa?</p>
           </sp>
-          <sp>
+          <sp who="#belisario">
             <speaker><emph rend="sc">belisario</emph>.</speaker>
             <p>Io piango perché vengo a rinovellare gli scherzi suoi puerili, quali tanto già mi piacquero, come ora mi dispiace di dover esser la sua ruina, con così calamitoso e disonorato modo.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>So che tu m'ha' da perdonare, ma io non voglio.</p>
           </sp>
-          <sp>
+          <sp who="#belisario">
             <speaker><emph rend="sc">belisario</emph>.</speaker>
             <p>Sai tu chi prega ora nel mio côre per te? L'amore, che mia moglie Felippa ispida ti portava, e que' baci, che in tenera età da me ricevesti e da te lo colsi; per tanto, mentre ch'io abbia il mio, io ti perdono.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>E poi?<pb n="205"/></p>
           </sp>
-          <sp>
+          <sp who="#belisario">
             <speaker><emph rend="sc">belisario</emph>.</speaker>
             <p>E poi, va' a far bene.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Va' a far bene? Così non canta il mio gallo; dir bisogna: e poi tu ritorni in grazia mia. In somma, io ho preso troppo amore a questa vostra roba.</p>
           </sp>
-          <sp>
+          <sp who="#belisario">
             <speaker><emph rend="sc">belisario</emph>.</speaker>
             <p>Or sù, sia tua. L'amor ch'io porto a te è di gran lunga maggiore di quello ch'io porto a questi beni di fortuna, quali doppo al morir mio alcun obbligo non m'avranno, né di me avranno ricordanza alcuna; sono cose insensate alfine e fecie della terra. Tu, almeno, non credo che così discortese sarai che, in età adulta ritrovandoti un giorno, e per me fatto ricco, tu non abbia il Cielo da pregar per la salute di quest'alma e lodarmi alcuna fiata fra gli uomini. Io ti perdono e ti rintegro nella grazia mia. Caino? Andate voi a dar sodisfazione alla Corte, ché poscia io verrò da voi e si accorderemo.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>E io vi prometto, o vecchio cortese, che tutto quello che scioccamente ha donato in qua e in là costui, tutto vi sarà ritornato.</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>Sciogliete tutti duo. E voi, vecchio, fate che Caino ne tratti bene, perché l'essersi voltato costui alla Corte, è di qualche considerazione, se l'accusassimo.</p>
           </sp>
-          <sp>
+          <sp who="#belisario">
             <speaker><emph rend="sc">belisario</emph>.</speaker>
             <p>Caino, contenta ciascuno e per mio amore si taccia.</p>
           </sp>
-          <sp>
+          <sp who="#caino">
             <speaker><emph rend="sc">caino</emph>.</speaker>
             <p>Venite, e senza fallo state allegri, ch'io lo farò.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Dite pure, o Bargello, al boia, che sempre tutto sono al suo servizio. O caro vecchio, vi bacio e piango, considerando al favore che m'avete fatto e vi giuro che mi sforzerò, se tanto potrò, d'esser galant'uomo.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Tenerezza di povero vecchio, come l'abbraccia, come piange. Lodato il Cielo, che alfine modo n'insegnò di trarre dall'assenzio il mèle. Ogn'uno, in questo giorno, lieto può nominarsi: godrà Prudenza d'esser di Fulgenzio consorte; godrà Orazio d'esser di Florinda marito; giubilerà Lelio d'aver ritrovata la sorella, l'amata amante e il vecchio Belisario il suo Trinca tanto trincato.<pb n="206"/></p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Ne vogliamo noi fare una più bella? Succiola, io pur era già oste in Sinigaglia, ma fallii; pigliami per marito.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Sìe, i' mi contento, ma con il patto.</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>E quale?</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Di fatti fare il gioco de' fanciulli, cioè il Bicicu, quando a cavaluccio montandosi dicono: «Bicicu cù cù, quante corna stan qua sù?».</p>
           </sp>
-          <sp>
+          <sp who="#rondone">
             <speaker><emph rend="sc">rondone</emph>.</speaker>
             <p>Oh? Come tu non vuoi altro, dammi la mano, son dalla tua.</p>
           </sp>
-          <sp>
+          <sp who="#succiola">
             <speaker><emph rend="sc">succiola</emph>.</speaker>
             <p>Al corpo di mene, ch'i' son contenta! Tocchela quie, abbracciamoci, basciamoci, ma averti, che tu m'ha da vestir di camurra, ché zimarrine non vo' per casa.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>E Grillo in qual buco si ficcherà, o signore spose?</p>
           </sp>
-          <sp>
+          <sp who="#cicala">
             <speaker><emph rend="sc">cicala</emph>.</speaker>
             <p>E Cicala su qual ramo canterà, signore belle?</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Cari signori, vi raccomando i miei paggi: han servito conti, considerino che pure sapranno servir gentiluomini privati.</p>
           </sp>
-          <sp>
+          <sp who="#schiavetto">
             <speaker><emph rend="sc">schiavetto</emph>.</speaker>
             <p>Or sù io piglio Grillo.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker><emph rend="sc">grillo</emph>.</speaker>
             <p>O cara signora vi bacio la mano.</p>
           </sp>
-          <sp>
+          <sp who="#prudenza">
             <speaker><emph rend="sc">prudenza</emph>.</speaker>
             <p>E io piglio Cicala.</p>
           </sp>
-          <sp>
+          <sp who="#cicala">
             <speaker><emph rend="sc">cicala</emph>.</speaker>
             <p>O che siate benedetta! Vi bacio anch'io la veste e 'l sotto veste.</p>
           </sp>
-          <sp>
+          <sp who="#rampino">
             <speaker><emph rend="sc">rampino</emph>.</speaker>
             <p>Solo Rampino, tanto fedele al suo signore, rimarrà senza appoggio.</p>
           </sp>
-          <sp>
+          <sp who="#nottola">
             <speaker><emph rend="sc">nottola</emph>.</speaker>
             <p>Or sù, vien qua. In ogni modo Belisario e io vogliamo tenere una cavalcatura, tu sta' meco e a voi altri donerò tanto che potrete andare commodamente alle vostre case, state allegri.</p>
           </sp>
-          <sp>
+          <sp who="#belisario">
             <speaker><emph rend="sc">belisario</emph>.</speaker>
             <p>Mi contento di tutto quello che vuole il mio caro figliolo Trinca.</p>
           </sp>
-          <sp>
+          <sp who="#facceto">
             <speaker><emph rend="sc">facceto</emph>.</speaker>
             <p>E tu, Solfanello, da me non t'allontanerai, poi che intendo Orazio (se così vorrà) venga a far sua vita nella bella Partenope.<pb n="207"/></p>
           </sp>
-          <sp>
+          <sp who="#orazio">
             <speaker><emph rend="sc">orazio</emph>.</speaker>
             <p>Farò, caro cognato e signore, quello che più gli agradirà.</p>
           </sp>
-          <sp>
+          <sp who="#solfanello">
             <speaker><emph rend="sc">solfanello</emph>.</speaker>
             <p>E io pure, signora sposa, che Solfanello sono, servirò per accendere quelle tante fascine che si dovranno consumare per far cucinare le robbe nuziali.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Or poi, che 'l tutto è assettato, rimane solo che voi altri gentilissimi spettatori vi leviate da questo luogo e verso la cena v'indirizziate, perché (a dirvela) se a sorte, tirati dalla gola di queste tre para di nozze, voi qui faceste dimora, sappiate, come finte sono queste case, così sono stati finti gli amori e finti gli sposalizi, onde perciò finti ancora saranno i banchetti, sì che se morir non volete dalla fame ogn'uno vada a vedere come sta la sua pignatta; e chi pignatta al fuoco non ha per sua sventura, pigli in una mano del pane, nell'altra la generosità del conte Nottola e alla meglio giunga al fine della sua grassa cena. Dio vi salvi, a rivedersi.</p>
           </sp>

--- a/tei/anonimo-cleopatra-e-marc-antonio.xml
+++ b/tei/anonimo-cleopatra-e-marc-antonio.xml
@@ -74,6 +74,55 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="antonio">
+            <persName>Antonio</persName>
+          </person>
+          <person xml:id="cleop">
+            <persName>Cleopatra</persName>
+          </person>
+          <person xml:id="diom">
+            <persName>Diomede</persName>
+          </person>
+          <person xml:id="canid">
+            <persName>Canidio</persName>
+          </person>
+          <person xml:id="ecira">
+            <persName>Ecira</persName>
+          </person>
+          <person xml:id="cani">
+            <persName>Canidio</persName>
+          </person>
+          <person xml:id="eci">
+            <persName>Ecira</persName>
+          </person>
+          <person xml:id="dicer">
+            <persName>Dicerteo </persName>
+          </person>
+          <person xml:id="olimp">
+            <persName>Olimpio</persName>
+          </person>
+          <person xml:id="carmia">
+            <persName>Carmia</persName>
+          </person>
+          <person xml:id="olim">
+            <persName>Olimpio</persName>
+          </person>
+          <person xml:id="ario">
+            <persName>Ario</persName>
+          </person>
+          <person xml:id="epaf">
+            <persName>Epafrodito</persName>
+          </person>
+          <person xml:id="ottavio">
+            <persName>Ottavio</persName>
+          </person>
+          <person xml:id="proculeio">
+            <persName>Proculeio</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Pavia</name>Digitalizzazione</change>
@@ -122,8 +171,7 @@
           <role> Olimpio </role>
           <roleDesc>medico e nutritio di Cleopatra</roleDesc>
         </castItem>
-        <castItem>
-          <role>Ecira</role> e <role>Carmia</role>
+        <castItem><role>Ecira</role> e <role>Carmia</role>
           <roleDesc>camariere di Cleopatra</roleDesc>
         </castItem>
         <castItem>
@@ -312,7 +360,7 @@
           <stage>
             <hi rend="sc">ANTONIO. CLEOPATRA. DIOMEDE.</hi>
           </stage>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
@@ -324,7 +372,7 @@
             <p>Fra tanto io voglio, – se però così a voi piace –, che viviamo con tutti que' maggior piaceri, e con tutte quelle più alte magnificenze che a noi saranno possibili. </p>
             <p>Faccino poi gli iddii di noi quello che a lor più piace.</p>
           </sp>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
@@ -333,7 +381,7 @@
             <p>Perché l'haver rotta l'armata di mare, a lui parrà di haver fatto nulla, quando vedrà noi in vita et in esser di potersi diffender e rimettere. </p>
             <p>Pur, per compiacer al voler vostro, mi contento che questo restante di vita, che si concederanno gli iddii dell'Egitto, lo consumiamo ne' conviti e nelli amori soliti, né vi pensate, grandissimo imperadore, che la vostra Cleopatra sia mai per abbandonarvi, perciò che ella è per seguirvi in tutte le fortune. </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
@@ -345,7 +393,7 @@
             <p>Ho tutti gli re dell'Asia amici, e grandissima intelligenza nell'Italia, e molti senatori mi richiamano per reprimer l'insolenza di questo nòvo Cesare, ch'aspira alla monarchia, siché spero di rimetter ancora le forze di prima insieme, e vendicarmi delle ingiurie ricevute. </p>
             <p>Inanzi ch'ei sforzi Pelusio, havrem tempo di provedersi per diffendersi, e per scacciarlo ancora, se il re Ethiopo non mancherà dell'aiuto suo, come mi ha con mille giuramenti promesso. </p>
           </sp>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
@@ -353,7 +401,7 @@
             <p>Io, come ho detto, e armata e disarmata, vi seguirò sempre e quella fede che una volta vi diedi, da me vi sarà ampiamente osservata. </p>
             <p>Habbiamo vittoria, venga pur morte, o prigionia, io starò sempre salda, e costante nell'amor vostro. </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
@@ -362,7 +410,7 @@
             <p>O che vaghezza era il vedervi in quella guisa! </p>
             <p>Mareviglia non fu se al primo tratto restai conquiso da tanta bellezza, e benedico il dì e l'hora che diedi principio a così felice e beato amore, e suplico con le man giunte i celesti dèi che, né in vita, né in morte, si separino mai. </p>
           </sp>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
@@ -372,45 +420,45 @@
             <p>Hor vadi pur la cosa del pari, e attendiamo al primo proponimento di darsi ai piaceri, ai conviti, ai suoni, ai canti, e alli amori primieri. </p>
             <p>Diomede! </p>
           </sp>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
             <p> Serenissima reina, son qua. </p>
             <p>Che mi comanda la maestà vostra? </p>
           </sp>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
             <p> Ritrova i scalchi e i camarieri, e ordina ch'apprecchino i bagni di odorifere acque, con tutti quelli arabi ingredienti che sono necessarii: il balsamo per ungersi, il letto per riposarsi e poi il convito per ricrearsi, con tutti i suoni e musiche ordinarie e di più, se il ce ne può havere; i comici per far i giuochi scenici, e fa' che non manchino in cosa alcuna perché vi si ha da trovar presente questa sera un imperador più degno e più grande che ci fosse mai, et io, sua amante e serva, in compagnia. </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
             <p> Ah, grandissima regina, voi mi offendete sopra modo a nominarvi serva: amante sì bene, e moglie carissima; io più tosto mi dovrei chiamar servo, ritrovandomi nelle vostre forze, ma non voglio farvi questa ingiuria. </p>
           </sp>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
             <p> Quello ch'ho detto, sia detto, e tolghisi da voi in quella parte che più vi piace, che in tutti i modi restarò vostra. </p>
             <p>Hor via tu Diomede, va' ad esequir quanto ti ho detto. </p>
           </sp>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
             <p> Serenissima regina, il convito, le feste, i comici e le musiche sono all'ordine e non attendono altro che la real presenza di voi altri signori. </p>
           </sp>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
             <p> Se così è, entriamo adunque signore, e godianci allegramente, sin tanto che il tempo ne serve. </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
@@ -422,7 +470,7 @@
           <stage>
             <hi rend="sc">CANIDIO. ECIRA. DICERTEO. </hi>
           </stage>
-          <sp>
+          <sp who="#canid">
             <speaker>
               <hi rend="sc">CANID.</hi>
             </speaker>
@@ -443,33 +491,33 @@
             <p>Forse che deve esser a tavola, che questa apunto è la sua hora. </p>
             <p>Voglio battere. </p>
           </sp>
-          <sp>
+          <sp who="#ecira">
             <speaker>
               <hi rend="sc">ECIRA</hi>
             </speaker>
             <p> Chi picchia là? (alla finestra) </p>
           </sp>
-          <sp>
+          <sp who="#cani">
             <speaker>
               <hi rend="sc">CANI.</hi>
             </speaker>
             <p> Amici siamo, son nuntio che vorrei esser introdutto dinanzi all'imperador o alla regina. </p>
           </sp>
-          <sp>
+          <sp who="#eci">
             <speaker>
               <hi rend="sc">ECI.</hi>
             </speaker>
             <p> Fratello, se Giove scendesse dal cielo co' suoi fulmini e minacciasse rovina a questo real pallaggio, egli non potrebbe entrar a quest'hora, nella qual non vi praticano huomini di sorte alcuna, né vi si portano nòve, che possino turbar i loro piaceri, ma si ragiona solamente di amore e di altre cose dilettevoli. </p>
             <p>Vatene pur e ritorna dimane. </p>
           </sp>
-          <sp>
+          <sp who="#canid">
             <speaker>
               <hi rend="sc">CANID.</hi>
             </speaker>
             <p> Apunto addesso, che l'inimico si trova su le porte della città, è tempo di attender a queste pratiche. </p>
             <p>Deh, giovane amorevole, fammi gratia ch'io entri, perciò che io tengo cose di grandissima importanza per salute de' tuoi signori e di tutta la città. </p>
           </sp>
-          <sp>
+          <sp who="#ecira">
             <speaker>
               <hi rend="sc">ECIRA</hi>
             </speaker>
@@ -480,20 +528,20 @@
             <p>Come ti chiami per nome? </p>
             <p>Dilomi, acciò che io possa riferrirlo alle loro maestà. </p>
           </sp>
-          <sp>
+          <sp who="#canid">
             <speaker>
               <hi rend="sc">CANID.</hi>
             </speaker>
             <p> Se pur brami intenderlo, io te lo dirò, acciò che la cosa non vada in longo. </p>
             <p>Dirai dunque all' imperador che Canidio, suo capitano, per gran sorte è capitato qui in Alessandria; e che son quello che vorrei esser introdotto per avisarlo di cose importantissime, alle quali è necessario hor hora provedere. </p>
           </sp>
-          <sp>
+          <sp who="#ecira">
             <speaker>
               <hi rend="sc">ECIRA</hi>
             </speaker>
             <p> Ho inteso; andarò a far l'ambasciata e non starò molto a ritornarti risposta. </p>
           </sp>
-          <sp>
+          <sp who="#canid">
             <speaker>
               <hi rend="sc">CANID.</hi>
             </speaker>
@@ -507,7 +555,7 @@
             <p>Di due cose una, overo che vengono così veloci, spinti dal comandamento dell'imperadore, qual si dêe esser stupito della mia venuta e perciò bramoso di vedermi, o che vengono per ispedir ancor me. </p>
             <p>Ma eccoti la fante alla finestra. </p>
           </sp>
-          <sp>
+          <sp who="#ecira">
             <speaker>
               <hi rend="sc">ECIRA</hi>
             </speaker>
@@ -517,7 +565,7 @@
             <p>Certo che dovete esser qualche gran personaggio. </p>
             <p>Perdonatemi se qui alla finestra vi ho tenuto a disaggio, perché così dalla regina mia signora havevo in commissione. </p>
           </sp>
-          <sp>
+          <sp who="#canid">
             <speaker>
               <hi rend="sc">CANID.</hi>
             </speaker>
@@ -525,34 +573,34 @@
             <p>Hai fatto il debito tuo. </p>
             <p>Sin qui le cose passano bene; ma eccovi – s'io non m'inganno – Dicerteo nostro che esce con le guardie: io me gli vo' far incontra. </p>
           </sp>
-          <sp>
+          <sp who="#dicer">
             <speaker>
               <hi rend="sc">DICER.</hi>
             </speaker>
             <p> Canidio, signor mio, e che buona fortuna vi ha condutto qui in Alessandria a quest'hora? </p>
           </sp>
-          <sp>
+          <sp who="#canid">
             <speaker>
               <hi rend="sc">CANID.</hi>
             </speaker>
             <p> O Dicerteo, mio carissimo amico, sii il ben trovato. </p>
             <p>Il signor nostro, come sta egli? </p>
           </sp>
-          <sp>
+          <sp who="#dicer">
             <speaker>
               <hi rend="sc">DICER.</hi>
             </speaker>
             <p> Benissimo, e più giocondo che mai; e sta con desiderio infinito di vedervi. </p>
             <p>Ma ditemi, di gratia: che nòve portate, che così pensoso vi veggio! </p>
           </sp>
-          <sp>
+          <sp who="#canid">
             <speaker>
               <hi rend="sc">CANID.</hi>
             </speaker>
             <p> Godo infinitamente che sia salvo. </p>
             <p>Entriamo dunque, acciò non si stia ad aspettare, che quivi poi più ad aggio ti contarò la causa della mia venuta. </p>
           </sp>
-          <sp>
+          <sp who="#dicer">
             <speaker>
               <hi rend="sc">DICER.</hi>
             </speaker>
@@ -671,7 +719,7 @@
           <stage>
             <hi rend="sc">CLEOPATRA. OLIMPIO. ECIRA. CARMIA. </hi>
           </stage>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
@@ -685,7 +733,7 @@
             <p>Guardate qual sia di manco dolore e passione, e quello datemi perché io al tutto voglio morir libera, e reina di Egitto. </p>
             <p>Non voglio sopportar che queste mie carni siano tocche da altri che dal mio Antonio, qual intendo seguir in vita e in morte. </p>
           </sp>
-          <sp>
+          <sp who="#olimp">
             <speaker>
               <hi rend="sc">OLIMP.</hi>
             </speaker>
@@ -695,7 +743,7 @@
             <p>I Romani son di natura clementi e godono infinitamente quando è lor data occasione di usar la clemenza. </p>
             <p>E qual più degna e più alta occasione potrebbero ritrovar di questa, poi che salvano il regno e la vita della maggior e della più bella reina del mondo? </p>
           </sp>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
@@ -705,7 +753,7 @@
             <p>La mia ultima resolutione è di seguir la sorte del mio Antonio. </p>
             <p>Via dunque all'esseqution del fatto. </p>
           </sp>
-          <sp>
+          <sp who="#olimp">
             <speaker>
               <hi rend="sc">OLIMP.</hi>
             </speaker>
@@ -715,7 +763,7 @@
             <p>Pensate forse che – restando Ottavio vincitore – habbi da portarsi verso voi manco magnanimo del padre e del cognato? </p>
             <p>Ah, non lo credete, serenissima figliuola, che v'ingannate certo. </p>
           </sp>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
@@ -724,7 +772,7 @@
             <p>Non no, fatte pur quanto vi ho detto, e non mandate più la cosa in longo, altrimenti hor hora, alla presenza vostra, mi trappasserò il petto con questo pugnale che in mano mi vedete. </p>
             <p>Voglio giocar di securo. </p>
           </sp>
-          <sp>
+          <sp who="#olimp">
             <speaker>
               <hi rend="sc">OLIMP.</hi>
             </speaker>
@@ -732,7 +780,7 @@
             <p>Ma come potrò io darlovi, che per cordoglio inanzi di voi non muori? </p>
             <p>Ah, figliuola serenissima, che mi cavate il cuore! </p>
           </sp>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
@@ -740,13 +788,13 @@
             <p>È necessario far quanto ho detto per ogni disordine che potesse nascere. </p>
             <p>Preparatine pur uno che faccia l'effetto presto e che non dia molta passione, e non vi dubitate poi del resto, perché non si mancherà di tentar tutto quello che sarà possibile per salvarsi. </p>
           </sp>
-          <sp>
+          <sp who="#olimp">
             <speaker>
               <hi rend="sc">OLIMP.</hi>
             </speaker>
             <p> L'aconito genera dolori, la cicuta e 'l napello estorsioni, e sudori frigidi, la rubetta gonfia il corpo e manda la morte in longo e, brevemente, tutti i veleni presi per bocca partoriscono accidenti e sincope crudeli. </p>
           </sp>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
@@ -756,21 +804,21 @@
             <p><hi rend="sc"> COSÌ GUIDA </hi> le cose<hi rend="sc"> FORTUNA.</hi> </p>
             <p>Ma che non si dimori più: preparate quello che più sicuro e più spedito vi pare. </p>
           </sp>
-          <sp>
+          <sp who="#olimp">
             <speaker>
               <hi rend="sc">OLIMP.</hi>
             </speaker>
             <p> Horsù, io andarò, e nell'aspido voglio che fermiamo il nostro disegno, come in quello che veramente dà manco pena de tutti gli altri; e so un mio amico che ne ha alquanti per farne teriaca. </p>
             <p>Uno di quelli mi farò consignare e in poter vostro lo darò. </p>
           </sp>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
             <p> Hor andate padre mio e negotiate speditamente, che sto pur a mirar da qual parte io sii cinta da soldati di Ottavio, e presa viva. </p>
             <p>Voi altre, camariere, togliete tutte le mie più preciose gioie, e reponetile nella camera sopra il sepolcro, che sta appresso il tempio de Iside, ove si ritrova ancora il resto del thesoro e seco portate stoppa, pece e solfo: e quivi aspettatime. </p>
           </sp>
-          <sp>
+          <sp who="#carmia">
             <speaker>
               <hi rend="sc">CARMIA</hi>
             </speaker>
@@ -778,7 +826,7 @@
             <p>Ma poscia che i dii sono adirati con noi e che non ci hanno più nulla di compassione, ma è necessario, per liberarsi da tanti travagli e disturbi, col foco ispedir i thesori già tanti anni accumulati, e la vita insieme, andaremo ad esequir prontamente quanto ci havete imposto, assicurando vostra maestà di seguirla viva, e morta. </p>
             <p>Andiamo, Ecira mia. </p>
           </sp>
-          <sp>
+          <sp who="#ecira">
             <speaker>
               <hi rend="sc">ECIRA</hi>
             </speaker>
@@ -787,7 +835,7 @@
             <p>Bisogna poi conformarsi col voler dei celesti dèi quali forse, col mezzo di così gran fatto, vorranno deificarvi, e procurarvi in questo mondo tempi, e honori divini. </p>
             <p>Salda dunque e costante in questo estremo di vita. </p>
           </sp>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
@@ -800,13 +848,13 @@
           <stage>
             <hi rend="italic"> (l'accompagnano sin alla porta et poi si voltano)</hi>
           </stage>
-          <sp>
+          <sp who="#ecira">
             <speaker>
               <hi rend="sc">ECIRA</hi>
             </speaker>
             <p> Tanto faremo, serenissima reina. </p>
           </sp>
-          <sp>
+          <sp who="#carmia">
             <speaker>
               <hi rend="sc">CARMIA</hi>
             </speaker>
@@ -816,14 +864,14 @@
             <p>Non le ho voluto replicar cosa alcuna, né tampoco disuaderla, dubitando di non far peggio, conoscendola precipitosa e furibonda, che havrebbe con quel suo pugnale potuto far qualche male, ma ho pensato esser stato meglio di dar loco al tempo, et aspettar che le passi questa soa prima furia. </p>
             <p>Fra tanto si penserà il modo di poter rimediare: <hi rend="sc">CHI HA TEMPO HA VITA.</hi> </p>
           </sp>
-          <sp>
+          <sp who="#ecira">
             <speaker>
               <hi rend="sc">ECIRA</hi>
             </speaker>
             <p> Certo è stato benissimo inteso asecondarla, per il rispetto ch'hai detto, ma non ti dubitar, che forse le cose passeranno meglio di quello &lt;che&gt; pensamo. </p>
             <p>Facciamo pur quanto ci ha imposto, e del resto lascimone la cura ai dèi della patria, e alla providenza dell'imperadore, qual non mancherà mai all'honor suo, per salute di questa nostra reina, e di tutto il regno. </p>
           </sp>
-          <sp>
+          <sp who="#carmia">
             <speaker>
               <hi rend="sc">CARMIA</hi>
             </speaker>
@@ -831,7 +879,7 @@
             <p>Né i Romani haverebbero mai molestato questo regno, se da essa non fosse sta' racettato; e beata lei se, seguito il conseglio di me sua serva, havesse dato nelle mani di Ottavio, quando per Tireo lo mandò a dimandare, questo nòvo Sardanapalo, qual, quando doveva provedersi di arme e de huomini da guerra, per conservation soa e del regno, pur allhora si dava ai conviti e ai piaceri, e pareva che incominciassero gli amori e che non havesse mai più goduta la reina, e la reina lui, tal e tanti erano gli abbracciamenti e lascivie che passavano tra loro. </p>
             <p><hi rend="sc"> MA COSÌ GUIDA </hi> le cose <hi rend="sc"> AMORE.</hi> </p>
           </sp>
-          <sp>
+          <sp who="#ecira">
             <speaker>
               <hi rend="sc">ECIRA</hi>
             </speaker>
@@ -839,7 +887,7 @@
             <p>Egli è pur quel capitano strenuo e invitto, che fu sempre e, se per l'adietro dimostrò prudenza ed arte, son certa che la farà conoscer al presente più che mai, e tanto più havendo seco Canidio, suo generale, peritissimo nell'arte militare e nelle imprese, per quanto intendo, fortunatissimo. </p>
             <p>Sì che non ti dubitare che gli iddi, fautori della giustitia, prospereranno le cose loro, e noi altre finalmente restaremo consolate. </p>
           </sp>
-          <sp>
+          <sp who="#carmia">
             <speaker>
               <hi rend="sc">CARMIA</hi>
             </speaker>
@@ -850,13 +898,13 @@
             <p>Fra tanto andaremo ad esequir quanto ci ha ordinato. </p>
             <p>Venga poi quel che si vuole, già di noi è prefisso in cielo quel ch'ha da essere. </p>
           </sp>
-          <sp>
+          <sp who="#ecira">
             <speaker>
               <hi rend="sc">ECIRA</hi>
             </speaker>
             <p> Horsù, andiamo dunque speditamente, e lasciamone la cura a chi tocca, e risolvianci noi di esser leali alla reina nostra, e proseguir la soa fortuna sin alla morte. </p>
           </sp>
-          <sp>
+          <sp who="#carmia">
             <speaker>
               <hi rend="sc">CARMIA</hi>
             </speaker>
@@ -869,7 +917,7 @@ Hor va' inanzi, che ti sieguo. </p>
           <stage>
             <hi rend="sc">ANTONIO. CANIDIO. </hi>
           </stage>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
@@ -877,7 +925,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Ma sarà quello che vorranno gli iddii Romani. </p>
             <p>Mentre risguardo te, o capitano fedelissimo, non dubito punto che non si faccia qualche notabil impresa. </p>
           </sp>
-          <sp>
+          <sp who="#canid">
             <speaker>
               <hi rend="sc">CANID.</hi>
             </speaker>
@@ -891,7 +939,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Forse che uditesi le ragioni delle parti, gli iddii prospereranno l'intento nostro. </p>
             <p>Pur mi rimetto a quanto da lei mi sarà comandato.</p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
@@ -900,14 +948,14 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Va' dunque, che miglior né più sicuro di te posso mandar in questo fatto, e con l'occhio del tuo giudicio negotia con Ottavio, che quanto da te sarà concluso, da me sarà ampiamente ratificato, essendo certo che non farai cosa che pregiudichi all'honor mio. </p>
             <p>Fra questo mezzo, così armato, io me ne andrò a visitar la reina e a darle nòva della vittoria seguita. </p>
           </sp>
-          <sp>
+          <sp who="#canid">
             <speaker>
               <hi rend="sc">CANID.</hi>
             </speaker>
             <p> E io ancora andarò con buona licenza di vostra maestà. </p>
             <p>La si arricordi ordinar al gran sacerdote che offerrisca l'oblation pacifica a tutti i dèi del cielo, acciò che prosperino il viaggio mio. </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
@@ -922,7 +970,7 @@ Hor va' inanzi, che ti sieguo. </p>
           <stage>
             <hi rend="sc">CLEOPATRA. DIOMEDE. ANTONIO. </hi>
           </stage>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
@@ -930,13 +978,13 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Qualche buona nuova dêe havere, ma certo egli havrà incontro assai duro e contrario al suo pensiero, perché io, in tutti i modi, voglio liberarlo dal sospetto che di me tiene, cioè che non voglia tradirlo e dar in man di Ottavio. </p>
             <p>E a far ciò non so che altro mezo tenere, se non con questo pugnale darmi in soa presenza la morte, che così resterà libero, e non punto dubbioso di esser tradito; ma voglio prima star ad udir ciò che dice. </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
             <p> Clementissima reina, i dii fautori delle cose giuste, i quali ci hanno dato una vittoria gloriosissima de' nostri nemici, salvino e mantenghino vostra maestà. </p>
           </sp>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
@@ -944,7 +992,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Horsù patientia! </p>
             <p>L'amor mio non meritava mai tal mercede. </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
@@ -953,7 +1001,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Ah, che più tosto vorrei mille volte morire, e grandemente mi offendete a pensar tanto male di me, che amo più voi sola che tutti gli imperii del mondo. </p>
             <p>Levatevi, reina, questi pensieri dal petto, e credete fermamente che vi amo come prima, e che in me non si ritrova una minima dramma di sospetto. </p>
           </sp>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
@@ -968,21 +1016,21 @@ Hor va' inanzi, che ti sieguo. </p>
           <stage>
             <hi rend="italic"> (quivi si vuol  uccidere). </hi>
           </stage>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
             <p> Codesto non farete già voi, reina, sin tanto che terrò questo vostro real braccio nelle mie mani. </p>
             <p>Presto, voi altri, levatele il pugnal di mano e tenetila, che non faccia qualche disordine. </p>
           </sp>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
             <p> Deh, imperadore, non mi siate almeno in questo ultimo crudele. </p>
             <p>Basti bene per il passato: lasciatemi, vi prego, seguir il mio proponimento. </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
@@ -992,7 +1040,7 @@ Hor va' inanzi, che ti sieguo. </p>
           <stage>
             <hi rend="italic"> (sfodra la spada)</hi>
           </stage>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
@@ -1004,7 +1052,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>E voi, imperador, contentatevi ch'io muori e ch'io dia fine al vostro sospetto e alle mie miserie, e non mi tormentate più di quello che sono. </p>
             <p>Basti a voi il chiarirvi, con simil mezzo, della mia fede, che altro non ne saprei mai ritrovare, essendo certa che di tutte le rovine che vi verranno sopra, finalmente ne darete la colpa a me sola. </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
@@ -1015,7 +1063,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Altrimenti hor hora mi vedrete alla presenza vostra morto, e meco morranno tutte le speranze della vostra libertà, e di quella de tutto il regno. </p>
             <p>E non chiamate le guardie, perché al primo accento e al primo suono della vostra real voce, vedrete da questa spada, che in mano tengo, il petto del vostro Antonio traffitto da una parte all'altra. </p>
           </sp>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
@@ -1027,14 +1075,14 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Arricordatevi della grandezza dell'animo vostro e del vostro alto sangue, e non mettete in scompiglio così miseramente il regno, la città, questi vostri piccioli figliuoli e noi altri vostri vassali, e non siate cagione della rovina di così grande imperadore. </p>
             <p>Non vedete voi come egli se ne sta lagrimoso e risoluto, con quella spada ignuda, di uccidersi, se non lo compiacete della vita vostra? </p>
           </sp>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
             <p> Poi che la forza di costoro, che mi tengono, e le lagrime vostre, altissimo imperadore, che sono assai più potenti, mi stringono a vivere, e che le ragioni son molte, che a ciò mi persuadono, non voglio mancar di far quello che a reina si conviene. </p>
             <p>Fattime dunque lasciar, che me vi rendo, e vi do la mia real fede, che non farò cosa che vi sia in dispiacere.Ma arricordatevi che ancora havete da chiamar perfida e disleale Cleopatra; e faccino i dii che questo mio pronostico resti falso. </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
@@ -1046,7 +1094,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Non si manca di tentar tutti que' partiti che all'honor nostro sono possibili: sopra che ho mandato Canidio a Cesare, e spero che negotierà felicemente e che, o per accordo o per battaglia, si levaremo questo peso da dosso. </p>
             <p>Fra tanto, entriamo in pallaggio, che quivi si discorrerà più a longo, e si darà ordine al resto. </p>
           </sp>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
@@ -1133,33 +1181,33 @@ Hor va' inanzi, che ti sieguo. </p>
           <stage>
             <hi rend="sc">ANTONIO. CLEOPATRA. CANIDIO. DICERTEO. </hi>
           </stage>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
             <p> Sì che, serenissima regina, il rispetto che mi ha ritenuto di non voler udir la resolutione, qual ha portata Canidio dal campo, da solo a solo, non è stato altro salvo che per non metter qualche ombra nel vostro real petto, per farvi conoscere con questa attione che con voi camino sinceramente. </p>
             <p>Hora che ci siete ancor voi presente, racconti Canidio l'appuntamento che ha fatto con Ottavio; e poscia tra noi si consulterà il negotio e concluderemo il partito che si ha da pigliare. </p>
           </sp>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
             <p> Voi havete fatto da imperador magnanimo e grande, come siete, et io ne godo infinitamente, non già perché mi diffidi di voi, ma sì bene per interesser anch'io all'una e all'altra fortuna, e prontissima per seguirvi dovunque da quella saremo spinti o guidati. </p>
             <p>Dica dunque Canidio la conclusion del fatto. </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
             <p> Hor via Canidio, esponi la resolution di Ottavio. </p>
           </sp>
-          <sp>
+          <sp who="#canid">
             <speaker>
               <hi rend="sc">CANID.</hi>
             </speaker>
             <p> Sappiate, sacratissimo imperadore e voi, altissima regina, partito ch'io fui di Alessandria per l'ispeditione impostami, subito mandai per il salvo condotto, qual hebbi senza difficoltà veruna, e così m'inviai verso il campo nemico, qual si trovava ancora sottosopra per la stretta ricevuta, e a meza strada fui incontrato da Ario, filosofo e primo consiglier di Ottavio, qual, per non esser ancora ben giorno, né tampoco acquetato l'essercito, per buon rispetto mi condusse al suo alloggiamento e quivi, questa mattina per tempo, col mezzo suo trattai il negotio, e finalmente, dapoi molte proposte e risposte, si contentò Ottavio di venir pur questa mattina, inanzi il desinare, con voi a parlamento, con patti che tutti i capitani principali dell'una e l'altra parte siano presenti all'abboccamento, con pari numero de soldati, et assicura vostra maestà sopra la soa fede da ogni insidia che potesse seguire, et io all'incontro l'ho assicurato del medesimo in nome vostro, sì che questo è l'appuntamento: quando esso Ottavio sarà all'ordine, Ario, al qual ho fatto il salvo condotto, verrà in Alessandria a ritrovarmi per dar eseqution al negotio, se però così a voi altri signori parerà che si faccia. </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
@@ -1167,7 +1215,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>E quel tanto che di nòvo conseglierai che si faccia, da me parimente sarà essequito, in te rimettendomi come in quel solo nel qual tengo fondate tutte le mie speranze. </p>
             <p>E son certo che la reina nostra farà il medesimo. </p>
           </sp>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
@@ -1175,7 +1223,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Hor via, Canidio, di' su liberamente: conosci tu mezzo veruno che si possa metter in speranza di salute? </p>
             <p>Parla pur chiaro, e non discorrer sopra speranze vane, ma consiglia solo quello che veramente senti, che da noi sarà come un oracolo infallibile accettato. </p>
           </sp>
-          <sp>
+          <sp who="#canid">
             <speaker>
               <hi rend="sc">CANID.</hi>
             </speaker>
@@ -1185,20 +1233,20 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Però non si mancherà tentarlo con tutti que' migliori modi che saranno possibili. </p>
             <p>E, quando non siegui l'effetto, si potrà ricorrer al secondo, qual tengo per più sicuro e più espedito, ma temo che non sii per esser di molta satisfattione a tutti e massime a voi, serenissima reina: però è meglio che io me lo taccia per sani rispetti. </p>
           </sp>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
             <p> E che rispetti son questi? </p>
             <p>Di' su liberamente il parer tuo del qual ti ricerchiamo, che, quando sia per arreccar all'imperador, a me e al regno mio, qualche salute, quanto si aspetta alla parte mia, non sono se non per accettarlo con ogni prontezza di animo, e ti assicuro di non restar offesa di te in cosa alcuna. </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANTO.</hi>
             </speaker>
             <p> Et io ti do la mia fede di far il medesimo. </p>
           </sp>
-          <sp>
+          <sp who="#canid">
             <speaker>
               <hi rend="sc">CANID.</hi>
             </speaker>
@@ -1210,7 +1258,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>E con questo mezzo, a imitation di Scipione Africano, e con l'essempio di Anibale, che dell'istesso consigliava Antioco, divertirete la guerra dall'Egitto, e torrete a lui l'Italia e l'Europa insieme, et io fra tanto starò a servir questa serenissima regina, per la diffesa di Alessandria, qual, per conto di batterie e di assalti, è inespugnabile, e si ritrova ancora per molto tempo, munita di vittovaglie. </p>
             <p>Né dubito punto di non conservarla. </p>
           </sp>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
@@ -1221,14 +1269,14 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Una sorte, un'istessa fortuna habbiamo da correr amendua. </p>
             <p>Parla pur d'altro. </p>
           </sp>
-          <sp>
+          <sp who="#canid">
             <speaker>
               <hi rend="sc">CANID.</hi>
             </speaker>
             <p> Serenissima reina, la cagione perché ho persuaso che restiate qui in Alessandria non è stata per altro, salvo che per tener, con la vostra real presenza, questo vostro popolo in fede, qual si potria ribellar e darsi in man del nemico, ogni volta che vedesse voi fuggita in Italia col signor nostro; e così tutti i disegni resteriano rotti, con danno e rovina estrema del regno vostro e dell'imperio del mio signore. </p>
             <p>Pur voi altri, che siete signori, fatte quello che più ispediente vi pare. </p>
           </sp>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
@@ -1238,7 +1286,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Quell'amorevolezza dunque che io allhora usai verso voi, non mancate ancor voi di usarla al presente verso me. </p>
             <p>E non mi abbandonnate, altrimenti io vi giuro per la mia real testa o che subito mi ucciderò overo che sopra un'altra galera vi seguirò a discrettion di Fortuna. </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANTO.</hi>
             </speaker>
@@ -1246,34 +1294,34 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Io al presente vi dò la mia fede che o restarò con voi nell'Egitto, overo che voi venirete meco in Italia. </p>
             <p>Hor via Canidio, vai ad incontrar Ario; e tu, Dicerteo, andarai con essolui per dar poi aviso dell'hora quando io debba comparire, et io fra tanto n'entrarò nel mio pallaggio, per metter a ordine quanto fa bisogno. </p>
           </sp>
-          <sp>
+          <sp who="#canid">
             <speaker>
               <hi rend="sc">CANID.</hi>
             </speaker>
             <p> Tanto sarà essequito, signore, et hor hora vado. </p>
             <p>Andiamo, Dicerteo. </p>
           </sp>
-          <sp>
+          <sp who="#dicer">
             <speaker>
               <hi rend="sc">DICER.</hi>
             </speaker>
             <p> Vengo. </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANTO.</hi>
             </speaker>
             <p> A rivedersi, serenissima reina. </p>
             <p>Di quel tanto che si concluderà, ne sarete subito avisata. </p>
           </sp>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
             <p> Andate, che i dèi vi accompagnino e prosperino le attioni vostre. </p>
             <p>Fra questo mezzo mi riposarò sopra la fede che mi havete data. </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANTO.</hi>
             </speaker>
@@ -1285,7 +1333,7 @@ Hor va' inanzi, che ti sieguo. </p>
           <stage>
             <hi rend="sc">CLEOPATRA. OLIMPIO.</hi>
           </stage>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
@@ -1296,7 +1344,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Purché Olimpio habbi preparato quanto gli ho imposto; ma eccolo in tempo, che spunta dalla piazza con non so che in mano. </p>
             <p>Aspettiamolo</p>
           </sp>
-          <sp>
+          <sp who="#olimp">
             <speaker>
               <hi rend="sc">OLIMP.</hi>
             </speaker>
@@ -1308,44 +1356,44 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>In fine, essendogli arreccata, ringratiò colui che gliela diede e disse che quello era stato il maggior beneficio ch'havesse mai in questo mondo ricevuto. </p>
             <p>Ma ecco la reina su la porta del suo pallaggio, e mi accenna ch'io vada. </p>
           </sp>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
             <p> Olimpio, padre mio, a tempo siete venuto. </p>
           </sp>
-          <sp>
+          <sp who="#olimp">
             <speaker>
               <hi rend="sc">OLIMP.</hi>
             </speaker>
             <p> La mia venuta sarà tanto più grata. </p>
           </sp>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
             <p> Che cosa tenete voi in quella scattola?</p>
             <p>È egli forse il servitio che mi portate? </p>
           </sp>
-          <sp>
+          <sp who="#olimp">
             <speaker>
               <hi rend="sc">OLIMP.</hi>
             </speaker>
             <p> Quello è, serenissima reina. </p>
           </sp>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
             <p> E in quel vaso, che cosa tenete? </p>
           </sp>
-          <sp>
+          <sp who="#olim">
             <speaker>
               <hi rend="sc">OLIM.</hi>
             </speaker>
             <p> In questo vaso vi è non so che altra compositione che, facendo bisogno, si potrà adoperare. </p>
           </sp>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
@@ -1354,7 +1402,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Ho posto parimente Diomede, mio secretario, in pratica. </p>
             <p>Se lo trovate, accordative insieme, e negotiate come sapete fare. </p>
           </sp>
-          <sp>
+          <sp who="#olimp">
             <speaker>
               <hi rend="sc">OLIMP.</hi>
             </speaker>
@@ -1362,7 +1410,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Tenete pur per fermo che sono per seguir la fortuna vostra in vita e in morte. </p>
             <p>Et al presente non mancarò, con ogni mio sapere e potere, di usar ogni sorte di diligenza, acciò restiate a pieno sodisfatta di me. </p>
           </sp>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
@@ -1375,14 +1423,14 @@ Hor va' inanzi, che ti sieguo. </p>
           <stage>
             <hi rend="sc">CANIDIO. ARIO. DICERTEO. EPAFRODITO. </hi>
           </stage>
-          <sp>
+          <sp who="#canid">
             <speaker>
               <hi rend="sc">CANID.</hi>
             </speaker>
             <p> Quel tanto, Ario, che fu concluso questa matina con Ottavio, tuo signore, ho riferrito al nostro imperadore, qual si contenta di venir all'hora concertata seco a parlamento, con pari numero de soldati e capitani, secondo l'ordine dato e quivi, se si potrà concluder la pace, o almeno una longa tregua, a beneficio dell'impero romano, e a conservation di questa tua città di Alessandria, qual sta pur in pericolo di esser mal trattata da ' soldati. </p>
             <p>A noi, dunque, che siamo mediatori di tanto bene, starà il saperlo persuader a questi gran prencipi. </p>
           </sp>
-          <sp>
+          <sp who="#ario">
             <speaker>
               <hi rend="sc">ARIO</hi>
             </speaker>
@@ -1390,25 +1438,25 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>E poi che stanno in pronto per venire, essendo questa l'hora deputata, e non attendon altro che il nostro aviso, manda tu Dicerteo et io mandarò Epafrodito; et avisiamo che il tutto si ritrova in punto e che comparischino a loro piacere. </p>
             <p>Epafrodito, va' e nuntia all'imperador nostro che il tutto si ritrova all'ordine, e sicuro. </p>
           </sp>
-          <sp>
+          <sp who="#epaf">
             <speaker>
               <hi rend="sc">EPAF.</hi>
             </speaker>
             <p> Vado hor hora. </p>
           </sp>
-          <sp>
+          <sp who="#canid">
             <speaker>
               <hi rend="sc">CANID.</hi>
             </speaker>
             <p> E tu, Dicerteo, va' e nuntia il medesimo all'imperador nostro. </p>
           </sp>
-          <sp>
+          <sp who="#dicer">
             <speaker>
               <hi rend="sc">DICER.</hi>
             </speaker>
             <p> Tanto sarà essequito. </p>
           </sp>
-          <sp>
+          <sp who="#ario">
             <speaker>
               <hi rend="sc">ARIO</hi>
             </speaker>
@@ -1416,14 +1464,14 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Perciò che l'accamparsi intorno la città, trattar il negotio e concluder il partito, è stata una cosa istessa; e in simili maneggi e pratiche vi sogliono correr le settimane, i mesi, e ben spesso gli anni interi. </p>
             <p>Penso che il mio signor lo faccia per dar satisfattione e per gratificarsi l'esercito, dubbioso ancora da qual parte pendi la ragione, e che il tuo signor anch'egli, come prudente e savio, cerchi di accommodarsi al tempo e alla fortuna. </p>
           </sp>
-          <sp>
+          <sp who="#canid">
             <speaker>
               <hi rend="sc">CANID.</hi>
             </speaker>
             <p> Non dir così Ario, perciò che il mio signore non procura la pace, perché non gli basti l'animo di resistere alla potentia di Ottavio, e di superarlo ancora, havendo egli e forze e ingegno di poterlo fare, e questa notte ve ne poteste accorgere nella fattion seguita. </p>
             <p>Lo fa dunque per non sparger con questa guerra civile il sangue de cittadini romani e di tanti altri invitti capitani e soldati, quali vorria servare per servirsene contra ' barbari, e massime nell'impresa de' Parthi. </p>
           </sp>
-          <sp>
+          <sp who="#ario">
             <speaker>
               <hi rend="sc">ARIO</hi>
             </speaker>
@@ -1434,13 +1482,13 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Presaggio verissimo della rotta che hebbe. </p>
             <p>Ma di più ti dico che l'interiora delle vittime si mostrano in favor nostro. </p>
           </sp>
-          <sp>
+          <sp who="#canid">
             <speaker>
               <hi rend="sc">CANID.</hi>
             </speaker>
             <p> Se si ha da andar dietro alli auspicii e sogni, penso che il mio signor sarà anch'egli vincitore, perciò che questa matina nell'aurora, ha pur veduto una visione che par a me, secondo il mio poco giudicio, e secondo l'interpretatione del gran sacerdote, che faccia per la parte nostra. </p>
           </sp>
-          <sp>
+          <sp who="#ario">
             <speaker>
               <hi rend="sc">ARIO</hi>
             </speaker>
@@ -1449,7 +1497,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>E questo non fanno ad altro fine, salvo che per conservarsi in gratia del patrone; e da qui nasce <hi rend="sc"> CHE NIUNO, </hi> mentre ha la fortuna in favore, non può mai saper la verità né <hi rend="sc"> DA CHI SIA AMATO </hi> veramente, perché ognuno lo serve e lo corteggia a disegno, e se pur avviene all'opposito, è di rado, e questi tali, che amano e servono i loro signori di cuore – che pochi se ne trovano –, son ben degni della suprema laude. </p>
             <p>Sì che, non ti aggravando, mentre che habbiamo questo poco di tempo, dimmi la visione; che ti prometto la mia fede io, che già molti anni mi sono essercitato in questa professione, che le darò ancora la soa vera interpretatione. </p>
           </sp>
-          <sp>
+          <sp who="#canid">
             <speaker>
               <hi rend="sc">CANID.</hi>
             </speaker>
@@ -1461,7 +1509,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Il sacerdote ha interpretato che l'aquila è Ottavio, il qual vorria privar il mio signor dell'imperio; il corvo che lo diffese è il re di Ethiopia, che con grosso essercito viene ad aiutarlo; e che l'aquila morta significa l'ultima rovina di Ottavio e gli uccelli che la piangono sono i suoi capitani, i quali si lamenteranno della morte soa; e che quel strepito rusticano non significa altro che l'applauso della vittoria. </p>
             <p>Questa è la visione, e l'interpretatione insieme. </p>
           </sp>
-          <sp>
+          <sp who="#ario">
             <speaker>
               <hi rend="sc">ARIO</hi>
             </speaker>
@@ -1474,7 +1522,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Né da qui inanzi si ha più da sentire: questa è la vera e giusta interpretatione e credimi, Canidio, che il sacerdote l'ha ingannato. </p>
             <p>Il meglio dunque suo sarà, come ho detto, di accommodarsi al tempo e alla fortuna. </p>
           </sp>
-          <sp>
+          <sp who="#canid">
             <speaker>
               <hi rend="sc">CANID.</hi>
             </speaker>
@@ -1485,7 +1533,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Ma ecco i littori, con fasci e scurri, che già incominciano a comparire. </p>
             <p>Tirianci da parte. </p>
           </sp>
-          <sp>
+          <sp who="#ario">
             <speaker>
               <hi rend="sc">ARIO</hi>
             </speaker>
@@ -1497,13 +1545,13 @@ Hor va' inanzi, che ti sieguo. </p>
           <stage>
             <hi rend="sc">ANTONIO. OTTAVIO. CANIDIO. DICERTEO. ARIO.</hi>
           </stage>
-          <sp>
+          <sp who="#ottavio">
             <speaker>
               <hi rend="sc">OTTA.</hi>
             </speaker>
             <p> A voi, Antonio, che per età mi siete superiore, e che ancora siete in casa vostra, si aspetta di esser il primo ad esponer qui, alla presenza di questi capitani, le ragioni vostre e le cause ch'havete di far meco guerra; io poi, come più giovine, dirò le mie. </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANTO.</hi>
             </speaker>
@@ -1513,7 +1561,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Et è cosa che gli iddii superni abborriscono, e ben spesso impediscono i disegni humani. </p>
             <p>Nulla dimeno, se havete colore alcuno di ragione, esponetelo qui alla presenza di questi gran capitani, che io vi risponderò poi. </p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>
               <hi rend="sc">OTTA.</hi>
             </speaker>
@@ -1524,7 +1572,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Queste dunque, et altre ragioni, che per brevità trallascio, son state potissima causa di farmi pigliar l'armi, e diffender la patria, l'honor e la vita insieme. </p>
             <p>Se voi all'incontro havete cosa veruna da dire, ditela, che, quando fia ragionevole, vi rendo certo che da me e da' miei capitani sarà prontamente abbracciata. </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANTO.</hi>
             </speaker>
@@ -1537,7 +1585,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Gli havevo acquistati con l'armi in mano, gli potevo anco distribuire come mi pareva, anzi, che da qui si può cavare ch'io non fui mai ambitioso di usurparmi, come fatte voi, la tirannide de' regni altrui, ma sì bene di scacciar essi tiranni e domar i nemici del popolo romano. </p>
             <p>Se queste furono cagioni giustissime a farmi levar in arme, per diffender l'honor mio e per ricuperar quello che di ragione mi perveniva, lasciolo giudicar a questi grandissimi capitani, al parer de' quali mi rimetterò sempre. </p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>
               <hi rend="sc">OTTA.</hi>
             </speaker>
@@ -1549,20 +1597,20 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Se dunque come vinto – che vedete ben non poter fuggir dalle mie mani. –, vi metterete nelle braccia della mia clementia, io non mancarò di usarla con voi, come ho ancora fatto con Lepido. </p>
             <p>Se anco ostinatamente vorrete aspettar il successo della battaglia, mettettevi all'ordine; che farete prova delle vostre e dell'altrui forze: e questa fia l'ultima conditione che vi ho da proporre. </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANTO.</hi>
             </speaker>
             <p> Io ho con mio grandissimo thedio intese le vostre tante ragioni e l'ultima vostre risolutione: ma ch'io mi voglia metter volontariamente, come femina usa al filare, nelle mani di un insolente giovane, di cui potrei esser padre due volte, questo non sarà mai vero, ma più tosto voglio patir mille morti che mai si dica un tal fatto di Antonio; e se bene havete il mondo tutto che siegue la bandiera vostra e me ha tradito e abbandonnato, mi trovo però di tal cuore che spero di farvi sudar la fronte più di due volte, inanzi ch'io mi renda: e penso che questa notte nella stretta qual diedi alla vostra cavalleria, ve ne poteste accorgere. </p>
             <p>Su dunque, Canidio e voi altri capitani, date nel tamburo e apparecchiate le armi e le squadre: che si combatti e che hoggi si finisca la guerra. </p>
           </sp>
-          <sp>
+          <sp who="#canid">
             <speaker>
               <hi rend="sc">CANID.</hi>
             </speaker>
             <p> Ah, grandissimi imperadori, mettete giù gli sdegni e udite le persuasioni ragionevoli de' mediatori, perché in fine tutte le differenze si accommoderanno. </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
@@ -1570,7 +1618,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Son nato nelle armi, e in quelle intendo vivere e morire. </p>
             <p>Io, Ottavio, quantunque mi ritrovi in età senile, disfido voi giovane a corpo a corpo a combatter meco, per decider le nostre litti. </p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>
               <hi rend="sc">OTTA.</hi>
             </speaker>
@@ -1578,20 +1626,20 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Andate pur, e fatte quel che potete, che il medesimo farò ancor io: con l'armi risponderò poi a quel punto dell'insolentia. </p>
             <p>Andiamo. </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
             <p> Ed io risponderò a quell'altro della superbia. </p>
             <p>Dicerteo, va', e avisa la reina di quanto è seguito, e dille che hoggi si ha da combatter, e far l'ultima prova di fortuna. </p>
           </sp>
-          <sp>
+          <sp who="#dicer">
             <speaker>
               <hi rend="sc">DICER.</hi>
             </speaker>
             <p> Vado signore, e tanto per me le sarà esposto. </p>
           </sp>
-          <sp>
+          <sp who="#ario">
             <speaker>
               <hi rend="sc">ARIO</hi>
             </speaker>
@@ -1599,7 +1647,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Mi pesa oltremodo, Canidio, che non habbiamo fatto nulla e che i disegni siano riusciti vani. </p>
             <p>Faccino mo' quello che più lor piace, e vinca chi si voglia: grande alteratione ha da seguire. </p>
           </sp>
-          <sp>
+          <sp who="#canid">
             <speaker>
               <hi rend="sc">CANID.</hi>
             </speaker>
@@ -1607,14 +1655,14 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>In questo non so che altro dirmi, salvo che essequir il comandamento impostomi. </p>
             <p>Hor siegui tu il tuo signor, ch'io seguirò il mio. </p>
           </sp>
-          <sp>
+          <sp who="#ario">
             <speaker>
               <hi rend="sc">ARIO</hi>
             </speaker>
             <p> Così intendo fare. </p>
             <p>Mi raccomando. </p>
           </sp>
-          <sp>
+          <sp who="#canid">
             <speaker>
               <hi rend="sc">CANID.</hi>
             </speaker>
@@ -1685,27 +1733,27 @@ Hor va' inanzi, che ti sieguo. </p>
           <stage>
             <hi rend="sc">DIOMEDE. CLEOPATRA.</hi>
           </stage>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
             <p> Io vado ad avisar la reina che stia avertita, e che si guardi dalla furia del nostro imperadore, perciò che egli si tiene tradito da lei, atteso che l'armata nostra, uscita questa mattina del porto, si è, senza combatter, unita con quella di Cesare e la cavalleria altresì, con la maggior parte dell'esercito, l'ha abbandonnato: onde tutto furibondo se ne ritorna in la città per far qualche sinistro con lei, qual certo tengo senza colpa; ma il <hi rend="sc"> SOSPETTO, </hi> potentissimo per metter in disordine <hi rend="sc"> IL MONDO,</hi> è talmente penetrato nel suo petto, che difficile fia il levarglielo. </p>
             <p>Voglio batter; ma eccola alla finestra, che non me n'ero accorto. </p>
           </sp>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
             <p> Diomede, odi: e che sorte di ragionamento è quello che da te stesso hai fatto, di ribellione di esercito e di armata? </p>
             <p>È stato forse abbandonato l'imperador da' soldati? </p>
           </sp>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
             <p> Serenissima regina, egli si ritrova abbandonnatissimo non che abbandonnato, e tien per fermo che voi ne siate partecipe, e torna in la città malissimo disposto contra di voi; e se farete al modo di questo vostro servidore, vi assicurarete là dentro, che è pur luogo forte, sin tanto che gli passi questa prima furia. </p>
           </sp>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
@@ -1714,7 +1762,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Ma se brami, Diomede, in queste mie ultime calamità servirmi, voglio che tu lo vada ad incontrare e dargli nòva – come tu, pratico, saprai fare – che, havendo io inteso ch'egli era stato abbandonato da soldati e che se n'era fuggito sopra la Falcona verso Italia, subito – spinta da cordoglio e da disperatione –, da me stessa mi son uccisa. </p>
             <p>E sappime dir il motivo che farà; ma servime fedelmente e con secretezza, ch'io prometto di non esserti ingrata; e, se vedi Olimpio nostro, avisalo del fatto. </p>
           </sp>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
@@ -1729,7 +1777,7 @@ Hor va' inanzi, che ti sieguo. </p>
           <stage>
             <hi rend="sc">ANTONIO. CANIDIO. DIOMEDE. </hi>
           </stage>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
@@ -1737,7 +1785,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Parti che questa notte la sapesse ben fingere? </p>
             <p>Infatti NON È malitia sopra quella DELLA DONNA. </p>
           </sp>
-          <sp>
+          <sp who="#canid">
             <speaker>
               <hi rend="sc">CANID.</hi>
             </speaker>
@@ -1745,19 +1793,19 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Veggio venir in qua Diomede molto pensoso e melanconico. </p>
             <p>Da lui intenderemo qualche cosa. </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANTO.</hi>
             </speaker>
             <p> Così credo: stiamo ad aspettare. </p>
           </sp>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
             <p> Altissimo e sacratissimo imperadore, i dii prosperino et accompagnino questo vostro così subito ingresso nella città di Alessandria. </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
@@ -1766,26 +1814,26 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Havete bene in questo ultimo dimostrato che siete istabile e barbara e che quell'amore, qual mi mostravate, non era veramente amore, ma sì bene disegno e fittione e che tanto voi vi havete fatta mia, QUANTO che Fortuna mi ha favorito. </p>
             <p>Ma arricordatevi, perfida, che gli dii vi puniranno ancora di tanta perfidia, sola cagione di questa mia presente rovina. </p>
           </sp>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
             <p> Deh, signor, non procedete più oltre nelle querele di quella reina, perciò che questo è un vanissimo sospetto ed ella vi è stata fedelissima. </p>
             <p>Ahimè, che per pietà mi sento mancar il cuore. </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
             <p> E che cosa sarà mai intravenuta, Diomede? </p>
           </sp>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
             <p> Ah signor, non me lo fatte dire, perché è cosa troppo compassionevole. </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
@@ -1793,7 +1841,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Le saria forse occorso qualche accidente? </p>
             <p>Di' su, che tu mi cavi l'anima. </p>
           </sp>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
@@ -1801,39 +1849,39 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Basta sapere che contra ragione la chiamate perfida e barbara. </p>
             <p>O infelice reina, a che termine miserabile siete ridutta! </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
             <p> E che lamenti, che esclamationi son queste tue?</p>
             <p>Dimmi chiaramente se la reina è viva o morta, e che caso è questo che tu vai deplorando. </p>
           </sp>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
             <p> Poscia, sacratissimo imperadore, che mi sforzate a dirlo, io lo dirò: sappiate dunque come è venuto un nuntio dal campo e poi un altro appresso, quali hanno portato nòva conforme alla reina: qualmente l'armata nostra, uscita dal porto per combattere, si è unita con quella di Ottavio e che tutto il nostro esercito si era ribellato e che voi imperadore, vinto da cordoglio – chiamandovi tradito da lei –, vi eravate messo sopra la Falcona e che vi eravate dato in preda alla fortuna per fuggirvene verso Italia e che di voi non si sapeva altro. </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
             <p> Hor ben, e che motivo fece ella a questa nòva? </p>
           </sp>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
             <p> Udito questo, subito come fuorsennata, corse sopra il molo e, scoperta l'armata nostra con quella di Ottavio e che la galea Falcona non c'era, né altro legno nel porto, sopra il qual montare per seguirvi, voltata verso Italia incominciò a chiamarvi ad alta voce, dicendo: </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
             <p> Ah, che affetto grande! </p>
             <p>Seguita. </p>
           </sp>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
@@ -1845,39 +1893,39 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Ah, che non fia mai vero!» </p>
             <p>Poi, inginnocchiatasi con le mani stese verso il cielo, disse queste ultime parole... </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
             <p> Come ultime?</p>
             <p>Io mi sento morire! </p>
           </sp>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
             <p> ... «Voi, dèi di Egitto, siate testimoni della mia fede e dell'amor, qual sempre gli ho portato» e, così detto, tolta con le sue belle mani una pungente spada, che seco havea portata... </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
             <p> Ah, pietà grande! </p>
           </sp>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
             <p> ... e richiamandovi ad alta voce, se l'appuntò al petto. </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
             <p> Io moro.</p>
             <p>E che seguì? </p>
           </sp>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
@@ -1886,7 +1934,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Questo è il caso miserabile ch'io non volevo dire per non contristar vostra maestà. </p>
             <p>Hor veda se ha ragione di dolersi di lei. </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
@@ -1897,14 +1945,14 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Perché non levarle la spada di mano, come fei io questa notte? </p>
             <p>E, bisognando, tenerla per forza, sin tanto che le fosse passata quella prima furia? </p>
           </sp>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
             <p> Deh signor, ch'io non ci arrivai a tempo, che già il caso era seguito, né viddi altro salvo che il sangue sparso. </p>
             <p>Il restante intesi dalle sue camariere, che quivi forte piangevano. </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
@@ -1919,28 +1967,28 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Ma oimè, e come farò io l'effetto, ritrovandomi, come sono, armato? </p>
             <p>Entriamo dunque in pallaggio, Canidio, e aiutami a cavar la corazza, che quivi darò fine a' miei travagli, perché non bisogna perder tempo e ci sarebbe troppo vergogna l'esser prevenuti da una donna e non pigliar partito! </p>
           </sp>
-          <sp>
+          <sp who="#canid">
             <speaker>
               <hi rend="sc">CANID.</hi>
             </speaker>
             <p> Signor, poi che dalla parte nostra si è fatto tutto quello ch'è stato possibile per salvarsi, e che le cose nostre si trovano disperate e in poter di Cesare, e non c'è più rimedio a resistere, e che così vuole la nostra perversa sorte, e i dèi si compiacciono del nostro sangue, entriamo e plachisi l'ira loro. </p>
             <p>È vero che si potrebbe far un'irrutione tra ' nemici e morir in battaglia con l'armi in mano, ma poi, chi ben la considera, sarà il medesimo, oltre che vi corre il pericolo di esser presi vivi. </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
             <p> È meglio, più sicuro e più spedito a quest'altro modo. </p>
             <p>Entriamo pur a far quanto prima l'effetto. </p>
           </sp>
-          <sp>
+          <sp who="#canid">
             <speaker>
               <hi rend="sc">CANID.</hi>
             </speaker>
             <p> O pallaggio già tanto florido e beato, et hora così infelice et horrido, è possibile che alla vista di tanto compassionevole spettacolo non ti spezzi per pietà e che non rovini da' fondamenti per non vederlo? </p>
             <p>O mio signor Antonio, a che termine siete voi ridutto, poscia che invece de' trionfi che vi aspettavano, siete hora necessitato a levarvi la vita? </p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>
               <hi rend="sc">ANT.</hi>
             </speaker>
@@ -1950,7 +1998,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Se muoro io hora, morrà ancora colui ch'è cagione della mia morte, e così saremo uguali quanto alla necessità del corpo, che, quanto a quella del nome, io penso di viver assai più glorioso e di maggior fama che non farà egli. </p>
             <p>Hor via, capitano valoroso, vieni, e aiutami a far quanto ti ho richiesto e arricordati, se di là si potrà tener memoria di un amico caro e fedele, che Antonio terrà sempre saldo e scolpito nel petto il suo Canidio. </p>
           </sp>
-          <sp>
+          <sp who="#canid">
             <speaker>
               <hi rend="sc">CANID.</hi>
             </speaker>
@@ -1963,7 +2011,7 @@ Hor va' inanzi, che ti sieguo. </p>
           <stage>
             <hi rend="sc"> DIOMEDE. DICERTEO. ECIRA. CLEOPATRA.</hi>
           </stage>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
@@ -1986,7 +2034,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Qualche infelice principio. </p>
             <p>Dicerteo, e che nòve porti, che così smarrito ti veggio? </p>
           </sp>
-          <sp>
+          <sp who="#dicer">
             <speaker>
               <hi rend="sc">DICER.</hi>
             </speaker>
@@ -1995,13 +2043,13 @@ Hor va' inanzi, che ti sieguo. </p>
           <stage>
             <hi rend="italic">(con un pugnal in mano)</hi>
           </stage>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
             <p> Io me le inmagino: pur dille. </p>
           </sp>
-          <sp>
+          <sp who="#dicer">
             <speaker>
               <hi rend="sc">DICER.</hi>
             </speaker>
@@ -2012,7 +2060,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Et io, che non tengo simil capriccio nel capo, ma intendo viver sin che potrò, per guadagnarmi la gratia di Cesare, me ne vado volando ad avisarlo del fatto. </p>
             <p>E se farai il mio conseglio, provederai ancor tu ai casi tuoi. </p>
           </sp>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
@@ -2021,13 +2069,13 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Ma eccoti Ecira alla finestra. </p>
             <p>Ecira, avisa la reina nostra che tutti i presidi della città, tutte le porte e i soldati sono in poter di Cesare, e che provedi alla salute soa, e che l'imprador nostro, udita la finta nòva della sua morte, si ha dato due ferite mortali, chiamandola ad alta voce in segno di amore, e che, se sinhora non è morto, che morirà in breve. </p>
           </sp>
-          <sp>
+          <sp who="#ecira">
             <speaker>
               <hi rend="sc">ECIRA</hi>
             </speaker>
             <p> Udite voi, serenissima regina, ciò che ci arrecca di nòvo il nostro Diomede! </p>
           </sp>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
@@ -2039,13 +2087,13 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Corri volando alla camera dell'imperadore et opera che ad ogni modo io l'habbi nelle mie braccia, o morto o vivo. </p>
             <p>E se per buona sorte t'incontrassi in Olimpio, menalo teco e, trovandolo ancora vivo, fagli fasciar le ferite al meglio che si può, e poi presentatilo qui alla finestra di dietro, che con una funne lo tiraremo nella stanza di questo sepolcro, presaggio veramente delle presenti angoscie. </p>
           </sp>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
             <p> Serenissima reina, non mancarò con ogni mio potere di operar quanto da voi mi è stato imposto e vi servirò con quella prestezza e lealtà, che ho fatto sempre, e vi prometto che fra lo spatio di breve hora, non intravenendo altro impaccio, l'imperador Antonio si troverà o vivo o morto nelle vostre braccia. </p>
           </sp>
-          <sp>
+          <sp who="#cleop">
             <speaker>
               <hi rend="sc">CLEOP.</hi>
             </speaker>
@@ -2058,7 +2106,7 @@ Hor va' inanzi, che ti sieguo. </p>
           <stage>
             <hi rend="sc">DIOMEDE. OLIMPIO. </hi>
           </stage>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
@@ -2072,7 +2120,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Forse che questo sarà il rimedio del negotio. </p>
             <p>Voglio star a udir ciò che dice. </p>
           </sp>
-          <sp>
+          <sp who="#olimp">
             <speaker>
               <hi rend="sc">OLIMP.</hi>
             </speaker>
@@ -2081,25 +2129,25 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Horsù, si può ben dire che le cose della regina nostra siano spedite, poi che spediti sono ancora coloro che le potevano mantenere, essendosi il generale ucciso del tutto e l'imperador ferito a morte. </p>
             <p>O Fortuna crudele, istabile e perversa, è possibile che non ti ritrovi ancora satia di lacerar questa povera regina e questo suo infelice regno? </p>
           </sp>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
             <p> Dimostra haver una gran passione di animo. </p>
           </sp>
-          <sp>
+          <sp who="#olimp">
             <speaker>
               <hi rend="sc">OLIMP.</hi>
             </speaker>
             <p> Io gli ho, al meglio che si è potuto, fasciate le ferite e gli ho affirmato che la regina vive e che non è possibile che sia vero quello che gli ha riferrito Diomede, atteso che io, dopo la partita soa, l'havevo lasciata sana e salva: né so imaginarmi a che fine esso Diomede, ch'è pur prudente e savio, habbi trovata questa fittione; e certo che ha fatto notabil errore. </p>
           </sp>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
             <p> Senza altro havevo pronosticato che tutti i colpi sarebbero finalmente venuti sovra le mie spalle, e che da tutte le parti sarei biasimato. </p>
           </sp>
-          <sp>
+          <sp who="#olimp">
             <speaker>
               <hi rend="sc">OLIMP.</hi>
             </speaker>
@@ -2109,19 +2157,19 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Hor non c'è tempo da perder: voglio andar ad avisar la reina, e dar ordine a quanto si ha da fare. </p>
             <p>Ma ecco qua Diomede, che non me n'ero accorto: Diomede, e che fai così solo e così turbato in viso? </p>
           </sp>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
             <p> Né voi, Olimpio, per quanto io veggio e per quanto ho sentito, siete molto allegro. </p>
           </sp>
-          <sp>
+          <sp who="#olimp">
             <speaker>
               <hi rend="sc">OLIMP.</hi>
             </speaker>
             <p> Hor ben; la cosa della nostra reina, ch'hai dato ad intender al nostro imperadore, come passa? </p>
           </sp>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
@@ -2129,7 +2177,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Basta per hora sapere che il tutto è stato fatto per ordine e per comandamento della nostra reina, qual è informata d'ogni cosa, e non accade che ve n'andiate più oltre ma bisogna che ve ne ritorniate meco, per aiutarmi a condur l'imperador nelle braccia sue, che così mi ha dato commissione; et è necessario ispedirsi quanto prima, avanti che gli ufficiali di Cesare prendino il possesso della piazza e del pallazzo reale, perché ci sarebbe poi che far assai. </p>
             <p>Andiamo dunque, tanto che il tempo ne serve. </p>
           </sp>
-          <sp>
+          <sp who="#olimp">
             <speaker>
               <hi rend="sc">OLIMP.</hi>
             </speaker>
@@ -2234,13 +2282,13 @@ Hor va' inanzi, che ti sieguo. </p>
           <stage>
             <hi rend="sc">ARIO. OTTAVIO. PROCULEIO. EPAFRODITO. </hi>
           </stage>
-          <sp>
+          <sp who="#ario">
             <speaker>
               <hi rend="sc">ARIO</hi>
             </speaker>
             <p> Sacratissimo imperadore, poscia che gli eterni dèi vi hanno fatto conseguir la vittoria senza spargimento di sangue e che hora vi ritrovate signor assoluto del mondo, voglio pregar vostra maestà ad usar la soa solita clemenza verso questa nobilissima città, della qual sono ancor io cittadino; e tanto più lo deve fare quanto che i poveri cittadini non ne hanno colpa, né hanno punto seguito la parte antoniana, ma solamente per obligo hanno ubidito alla loro reina. </p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>
               <hi rend="sc">OTTAV.</hi>
             </speaker>
@@ -2248,21 +2296,21 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Sappi che per amor tuo, che ti amo di cuore, per amor di Alessandro Magno, che l'edifficò, e per mia natural clemenza, io l'assolvo e libero da qualunque sorte di calamità e rovina che le potesse incontrare e de più la faccio esente per dieci anni da ogni tributo e gabella; e prometto ancora di conservar tutti i suoi privilegi e di aggrandirla et honorarla di theatri, de tempi, e di altri edifici assai più di quello che ha fatto Antonio. </p>
             <p>Così ho determinato; e tanto per i miei thesorieri e procuratori sarà essequito. </p>
           </sp>
-          <sp>
+          <sp who="#ario">
             <speaker>
               <hi rend="sc">ARIO</hi>
             </speaker>
             <p> O risposta divina e generosa, degna veramente di un tanto imperadore. </p>
             <p>Io, inginnocchiato, a nome di tutti i miei cittadini, rendo gratie inmortali a vostra maestà e supplico i celesti dèi, poi che in terra non c'è possanza più che lo possi fare, che di tanto beneficio vi rendino il guidardone. </p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>
               <hi rend="sc">OTTAV.</hi>
             </speaker>
             <p> Hor lievati, Ario mio, e sappi che son per far assai più di quello che ho promesso. </p>
             <p>Ma ecco Proculeio nostro che se ne viene molto allegro; Proculeio, e che nòve porti? (scena) </p>
           </sp>
-          <sp>
+          <sp who="#proculeio">
             <speaker>
               <hi rend="sc">PROC.</hi>
             </speaker>
@@ -2279,7 +2327,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Vi prega ancora, altissimo imperadore, che alle ossa del suo Antonio possi, per suo contento e sodisfattione, far il sacrificio e poi il convito funerale secondo il costume di Egitto, libera sin tanto che dureranno le esequie: il che vorria essequir al presente, havendo già in pronto tutti gli aromatici e le espiationi per placar i dèi Manni. </p>
             <p>Desidera ancora, per maggior gratia, che le concediate in compagnia i suoi piccioli figliuoli e finalmente che vi degniate, spedito che sarà il funerale, di prestarle audienza e darle loco di poter venir in habito di serva a riconoscervi per suo signore. </p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>
               <hi rend="sc">OTTAV.</hi>
             </speaker>
@@ -2290,20 +2338,20 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Fra tanto col mio Ario me n'entrarò nel Ginnasio, a passar il tempo con qualche bel discorso di filosofia. </p>
             <p>Andiamo, amico singolarissimo. </p>
           </sp>
-          <sp>
+          <sp who="#ario">
             <speaker>
               <hi rend="sc">ARIO</hi>
             </speaker>
             <p> Come vi piace, altissimo imperadore. </p>
             <p>Son qui ad ogni vostro comando. </p>
           </sp>
-          <sp>
+          <sp who="#proculeio">
             <speaker>
               <hi rend="sc">PROC.</hi>
             </speaker>
             <p> E noi, Epafrodito, andiamo ad essequir quanto ci è stato imposto. </p>
           </sp>
-          <sp>
+          <sp who="#epaf">
             <speaker>
               <hi rend="sc">EPAF.</hi>
             </speaker>
@@ -2315,13 +2363,13 @@ Hor va' inanzi, che ti sieguo. </p>
           <stage>
             <hi rend="sc"> OLIMPIO. DIOMEDE.</hi>
           </stage>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
             <p> A tale, Olimpio, che del negotio non si è fatto nulla. </p>
           </sp>
-          <sp>
+          <sp who="#olimp">
             <speaker>
               <hi rend="sc">OLIMP.</hi>
             </speaker>
@@ -2334,7 +2382,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Mi dispiace infinitamente a non poterle parlare, che vedrei pur di persuaderla a far qualche bene. </p>
             <p>Ma se è, come hai detto, in poter di Cesare, ci sarà che far assai. </p>
           </sp>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
@@ -2345,7 +2393,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Tirianci un poco da parte e stiamo a vedere ciò che disegnano fare. </p>
             <p>All'habito mi paiono romani e ministri di Cesare. </p>
           </sp>
-          <sp>
+          <sp who="#olimp">
             <speaker>
               <hi rend="sc">OLIMP.</hi>
             </speaker>
@@ -2357,26 +2405,26 @@ Hor va' inanzi, che ti sieguo. </p>
           <stage>
             <hi rend="sc"> PROCULEIO. EPAFRODITO.</hi>
           </stage>
-          <sp>
+          <sp who="#proculeio">
             <speaker>
               <hi rend="sc">PROC.</hi>
             </speaker>
             <p> Epafrodito, aspettami qui, fin tanto che io avisi la reina che se ne venga a suo commodo e piacere a far il sacrificio. </p>
             <p>E non starai molto, perciò che inanzi ch'io avisassi l'imperadore, già il tutto era all'ordine. </p>
           </sp>
-          <sp>
+          <sp who="#epaf">
             <speaker>
               <hi rend="sc">EPAF.</hi>
             </speaker>
             <p> Va' a tuo piacere e fa' di me con essolei quella buona relatione che deve far l'amico e ch'io la gratificherò in tutto quello che la saprà desiderare. </p>
           </sp>
-          <sp>
+          <sp who="#proculeio">
             <speaker>
               <hi rend="sc">PRO</hi>
             </speaker>
             <p>. È stato soverchio l'avertirmi, che senza altro havrei sodisfatto, anzi che per questo non ti ho voluto introdurre, per non parer alla tua presenza qualche addulatore. (scena) </p>
           </sp>
-          <sp>
+          <sp who="#epaf">
             <speaker>
               <hi rend="sc">EPAF.</hi>
             </speaker>
@@ -2395,13 +2443,13 @@ Hor va' inanzi, che ti sieguo. </p>
           <stage>
             <hi rend="sc"> DIOMEDE. OLIMPIO. </hi>
           </stage>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
             <p> Buone nòve Olimpio: a quel che veggio e che ho sentito, la reina esce di pallaggio per andar al sacrificio. </p>
           </sp>
-          <sp>
+          <sp who="#olimp">
             <speaker>
               <hi rend="sc">OLIMP.</hi>
             </speaker>
@@ -2409,21 +2457,21 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Questo deve essere il funerale che vuol far per l'imperadore. </p>
             <p>Facciamosi inanzi, che si possa vedere, acciò che, bisognandole la nostra opera, se ne possa servire. </p>
           </sp>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
             <p> Sarà ben fatto; andiamo. </p>
             <p>Ma eccola con la corona in capo, col scettro in mano, vestita regalmente e con quella sua mirabil cassa di cristallo inanzi: e che novità sarà mai questa? </p>
           </sp>
-          <sp>
+          <sp who="#olimp">
             <speaker>
               <hi rend="sc">OLIMP.</hi>
             </speaker>
             <p> Io non so. </p>
             <p>Forse che dentro vi havrà riposto l'imperador morto, che mi par veder non so che disteso, con una corona in capo. </p>
           </sp>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
@@ -2438,33 +2486,33 @@ Hor va' inanzi, che ti sieguo. </p>
               <hi rend="sc">CLEOPATRA. PROCULEIO. EPAFRODITO. DIOMEDE. OLIMPIO SACERDOTE. </hi>
               <hi rend="italic">(con tre altri et portan suso la casa con Ant.o dentro, et pian pian van per far il sacrificio)</hi>
             </stage>
-            <sp>
+            <sp who="#cleop">
               <speaker>
                 <hi rend="sc">CLEOP.</hi>
               </speaker>
               <p> Proculeio, è forse questo il custode della mia persona di cui hora mi hai parlato? </p>
             </sp>
-            <sp>
+            <sp who="#proculeio">
               <speaker>
                 <hi rend="sc">PROC.</hi>
               </speaker>
               <p> Egli è desso, serenissima reina. </p>
             </sp>
-            <sp>
+            <sp who="#cleop">
               <speaker>
                 <hi rend="sc">CLEOP.</hi>
               </speaker>
               <p> Godo infinitamente di haver conseguito un custode così degno e così cortese. </p>
               <p>Hor stanne allegro e non ti dubitar di me in cosa alcuna, perché io ti assicuro che breve e poco fastidio havrai di Cleopatra. </p>
             </sp>
-            <sp>
+            <sp who="#epaf">
               <speaker>
                 <hi rend="sc">EPAF.</hi>
               </speaker>
               <p> Clementissima reina, io son venuto a far quest'uffitio così mandato dall'imperador mio signore, al qual è necessario ubidire. </p>
               <p>Ma si renda pur certa vostra maestà che da me non è per haver se non quell'alta servitù, che si conviene a così gran signora. </p>
             </sp>
-            <sp>
+            <sp who="#cleop">
               <speaker>
                 <hi rend="sc">CLEOP.</hi>
               </speaker>
@@ -2472,38 +2520,38 @@ Hor va' inanzi, che ti sieguo. </p>
               <p>Ma non son questi che qua veggio i miei più cari e più fidati servitori, ch'io mi haggia? </p>
               <p>A tempo siete venuti. </p>
             </sp>
-            <sp>
+            <sp who="#diom">
               <speaker>
                 <hi rend="sc">DIOM.</hi>
               </speaker>
               <p> Quelli siamo, altissima reina, e più pronti a servirvi che mai. </p>
             </sp>
-            <sp>
+            <sp who="#cleop">
               <speaker>
                 <hi rend="sc">CLEOP.</hi>
               </speaker>
               <p> Rallegratevi meco, che io al presente, per gratia di Cesare, mi trovo libera reina dell'Egitto e, con questa libertà, vado a celebrar il funeral del mio caro Antonio. </p>
               <p>Voi Olimpio, padre mio, statemi sempre appresso e non mi abbandonate sin tanto che intieramente non sarà spedito il sacrificio. </p>
             </sp>
-            <sp>
+            <sp who="#olimp">
               <speaker>
                 <hi rend="sc">OLIMP.</hi>
               </speaker>
               <p> Serenissima figliuola, son qua ad ogni vostro comando. </p>
             </sp>
-            <sp>
+            <sp who="#cleop">
               <speaker>
                 <hi rend="sc">CLEOP.</hi>
               </speaker>
               <p> E tu Diomede non ti partir senza dirmi una parola, perciò che di te mi voglio servire in cosa d'importanza. </p>
             </sp>
-            <sp>
+            <sp who="#diom">
               <speaker>
                 <hi rend="sc">DIOM.</hi>
               </speaker>
               <p> Tanto farò, serenissima reina. </p>
             </sp>
-            <sp>
+            <sp who="#cleop">
               <speaker>
                 <hi rend="sc">CLEOP.</hi>
               </speaker>
@@ -2513,19 +2561,19 @@ Hor va' inanzi, che ti sieguo. </p>
               <p>Olimpio, padre mio, dove siete? </p>
               <p>Non mi abbandonate! </p>
             </sp>
-            <sp>
+            <sp who="#olim">
               <speaker>
                 <hi rend="sc">OLIM.</hi>
               </speaker>
               <p> Son qua, serenissima figliuola; non vi dubitate di me, che con voi starò sin al fine, come vi ho promesso. </p>
             </sp>
-            <sp>
+            <sp who="#cleop">
               <speaker>
                 <hi rend="sc">CLEOP.</hi>
               </speaker>
               <p> Sì, padre mio caro, quando havranno fornita l'oblatione, levarete il mio capo da questa cassa, acciò che ancor io dal mio amato Antonio possa tor licenza. </p>
             </sp>
-            <sp>
+            <sp who="#olimp">
               <speaker>
                 <hi rend="sc">OLIMP.</hi>
               </speaker>
@@ -2571,45 +2619,45 @@ Hor va' inanzi, che ti sieguo. </p>
           </div>
           <div>
             <head>[seconda parte] </head>
-            <sp>
+            <sp who="#olim">
               <speaker>
                 <hi rend="sc">OLIM.</hi>
               </speaker>
               <p> Serenissima reina, levatevi perciò che l'oblatione è fatta e cantate le laudi dell'invittissimo imperador nostro solennemente. </p>
             </sp>
-            <sp>
+            <sp who="#cleop">
               <speaker>
                 <hi rend="sc">CLEOP.</hi>
               </speaker>
               <p> Sta bene, farò ancor io la parte mia.</p>
               <p>Diomede, piglia questa lettera e portala a Cesare quanto prima, e tu Proculeio, se mai bramasti di farmi cosa grata, sarai contento di accompagnarlo e farai uffitio caldo per me di quanto gli ricerco. </p>
             </sp>
-            <sp>
+            <sp who="#proculeio">
               <speaker>
                 <hi rend="sc">PROC.</hi>
               </speaker>
               <p> Io andarò, serenissima reina, molto volentieri e procurarò con tutte le mie forze che vostra maestà resti consolata. </p>
               <p>Andiamo, Diomede, penso che non potremo errare a inviarsi verso il Ginnasio, che quivi al sicuro lo trovaremo a passar il tempo con Ario, suo consigliere e filosofo. </p>
             </sp>
-            <sp>
+            <sp who="#diom">
               <speaker>
                 <hi rend="sc">DIOM.</hi>
               </speaker>
               <p> Come ti pare, io ti verrò dietro. </p>
             </sp>
-            <sp>
+            <sp who="#cleop">
               <speaker>
                 <hi rend="sc">CLEOP.</hi>
               </speaker>
               <p> Epafrodito, vatene alla porta del mio real pallaggio e quivi aspettami e ordina alle guardie che non introducano alcun dentro sin tanto che non fia spedito il sacrificio e 'l convito e che con la risposta non sia ritornato Proculeio. </p>
             </sp>
-            <sp>
+            <sp who="#epaf">
               <speaker>
                 <hi rend="sc">EPAF.</hi>
               </speaker>
               <p> Vado, altissima reina, e tanto sarà essequito et osservato. </p>
             </sp>
-            <sp>
+            <sp who="#cleop">
               <speaker>
                 <hi rend="sc">CLEOP.</hi>
               </speaker>
@@ -2628,13 +2676,13 @@ Hor va' inanzi, che ti sieguo. </p>
               <p>Voi altri fra tanto proseguirete con i concerti e con le musiche il restante del sacrificio. </p>
               <p>E voi, Olimpio, nutritio e mio caro padre, venete meco e non mi lasciate in questo estremo. </p>
             </sp>
-            <sp>
+            <sp who="#olimp">
               <speaker>
                 <hi rend="sc">OLIMP.</hi>
               </speaker>
               <p> Son qua, serenissima figliuola: non temete che il vostro Olimpio sia mai per abbandonarvi. </p>
             </sp>
-            <sp>
+            <sp who="#cleop">
               <speaker>
                 <hi rend="sc">CLEOP.</hi>
               </speaker>
@@ -2680,7 +2728,7 @@ Hor va' inanzi, che ti sieguo. </p>
           <stage>
             <hi rend="sc"> PROCULEIO. EPAFRODITO. </hi>
           </stage>
-          <sp>
+          <sp who="#proculeio">
             <speaker>
               <hi rend="sc">PRO.</hi>
             </speaker>
@@ -2691,32 +2739,32 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Parmi ch'egli non sia p&lt;unto&gt; turbato, che quando fosse il vero egli dovrebbe essere tutto ripieno di amaritudine, come quello che l'havea in custodia. </p>
             <p>Epafrodito, che si fa qui con tanti armati? </p>
           </sp>
-          <sp>
+          <sp who="#epaf">
             <speaker>
               <hi rend="sc">EPAF.</hi>
             </speaker>
             <p> Io aspettavo te, che così ho in commissione dalla reina. </p>
           </sp>
-          <sp>
+          <sp who="#proculeio">
             <speaker>
               <hi rend="sc">PRO.</hi>
             </speaker>
             <p> Buon custode certo sei stato di lei. </p>
           </sp>
-          <sp>
+          <sp who="#epaf">
             <speaker>
               <hi rend="sc">EPAF.</hi>
             </speaker>
             <p> Anzi buonissimo. </p>
             <p>Hor non vedi tu con quanti soldati sto qui alla guardia del pallaggio, sin tanto che si espedisca il convito? </p>
           </sp>
-          <sp>
+          <sp who="#proculeio">
             <speaker>
               <hi rend="sc">PROC.</hi>
             </speaker>
             <p> Sì bene, ma non sai ch'ella si è tolta la vita? </p>
           </sp>
-          <sp>
+          <sp who="#epaf">
             <speaker>
               <hi rend="sc">EPAF.</hi>
             </speaker>
@@ -2725,7 +2773,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Ma che stiamo a badare? </p>
             <p>Andianci a chiarire. </p>
           </sp>
-          <sp>
+          <sp who="#proculeio">
             <speaker>
               <hi rend="sc">PROC.</hi>
             </speaker>
@@ -2737,7 +2785,7 @@ Hor va' inanzi, che ti sieguo. </p>
           <stage>
             <hi rend="sc"> DIOMEDE. DICERTEO.</hi>
           </stage>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
@@ -2753,48 +2801,48 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>O Fortuna istabile e perversa! </p>
             <p>Parti ch'ella ci habbi profondati tutti nell'abisso delle miserie. </p>
           </sp>
-          <sp>
+          <sp who="#dicer">
             <speaker>
               <hi rend="sc">DICER.</hi>
             </speaker>
             <p> E chi è costui che parla qui così dolente? Alla voce parmi che sii Diomede. </p>
           </sp>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
             <p> Non ti bastava, ingrata, di haverci tolto il nostro imperadore che, non ancora satia, ci hai privi della nostra natural reina? </p>
             <p>Horsù, così passano le cose di questo fallace mondo! </p>
           </sp>
-          <sp>
+          <sp who="#dicer">
             <speaker>
               <hi rend="sc">DICER.</hi>
             </speaker>
             <p> Diomede, odi Diomede, e che lamenti son questi tuoi? </p>
             <p>È forse morta la reina Cleopatra? </p>
           </sp>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
             <p> O Dicerteo mio, quasi che non ti conoscevo con quest'habito a&lt;lla&gt; romana. </p>
             <p>A tempo sei venuto, che teco potrò pur sfogar il mio dolore e pigliar conseglio da te di ritrovar qualche compenso al fatto mio. </p>
           </sp>
-          <sp>
+          <sp who="#dicer">
             <speaker>
               <hi rend="sc">DICER.</hi>
             </speaker>
             <p> In tutto quello che ti potrò giovare e servire, comandami con o&lt;gni&gt; sicurtà, che non sono se non per gratificarti. </p>
             <p>Ma dimmi che cosa è intravenuta alla reina, che così altamente la piangevi? </p>
           </sp>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
             <p> Sappi, Dicerteo, ch'io tengo per fermo ch'ella a quest'hora s&lt;ia&gt; spedita, per certi inditii quali ti dirò poi più ad aggio, che hora &lt;non&gt; c'è tempo. </p>
             <p>Io godo poi che ti veggio molto all'ordine; qualche b&lt;uona&gt; mancia dovesti guadagnare da Cesare, quando voltasti bandiera e che gli andasti ad annuntiar la morte del nostro imperadore. </p>
           </sp>
-          <sp>
+          <sp who="#dicer">
             <speaker>
               <hi rend="sc">DICER.</hi>
             </speaker>
@@ -2808,7 +2856,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Partianci di qua, che non si veggia per buoni rispetti. </p>
             <p>Con più comodità parlarem poi. </p>
           </sp>
-          <sp>
+          <sp who="#diom">
             <speaker>
               <hi rend="sc">DIOM.</hi>
             </speaker>
@@ -2820,27 +2868,27 @@ Hor va' inanzi, che ti sieguo. </p>
           <stage>
             <hi rend="sc"> OTTAVIO. PROCULEIO. ARIO. OLIMPIO. </hi>
           </stage>
-          <sp>
+          <sp who="#ottavio">
             <speaker>
               <hi rend="sc">OTTA.</hi>
             </speaker>
             <p> Sì che, Ario mio, Cleopatra mi ha scritto in questa lettera, che poco fa mi arreccò il suo secretario, ch'io mi contenti di darle luogo appresso l&lt;e&gt; ossa di Antonio suo marito, ond'io dubito assai che, dopo fatto il sacrificio, inmediata non si sia uccisa: e certo che, quando ciò fosse, io non starei per molti giorni allegro. </p>
             <p>Che dici, Ario mio? </p>
           </sp>
-          <sp>
+          <sp who="#ario">
             <speaker>
               <hi rend="sc">ARIO</hi>
             </speaker>
             <p> Non dico altro, eccelso imperadore, se non che concorro ancor io nel parer vostro, e giudico che questa gran donna, qual conobbi sempre di gran cuore, per morir libera, dubitandosi di non esser fatta spettacolo del mondo nel trionfo ch'havete da far in Roma, con questa sua ingeniosa inventione di voler sacrificar all'usanza di Egitto, si habbi data la morte. Ma eccovi Proculeio che ritorna. </p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>
               <hi rend="sc">OTTA.</hi>
             </speaker>
             <p> Da lui intenderemo il fatto come sia seguito. </p>
             <p>Proculeio, e che nòve porti? </p>
           </sp>
-          <sp>
+          <sp who="#proculeio">
             <speaker>
               <hi rend="sc">PRO.</hi>
             </speaker>
@@ -2852,78 +2900,78 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Ella, sign&lt;or&gt;, se ne sta sopra il suo ricco letto vestita regalmente e par proprio che dorma, e mostra ancora nel suo aspetto quella maestà e quella bellezza, come quando era viva. </p>
             <p>Là dentro non ho ritrovato altri che questi suoi piccioli figliuoli e quest&lt;o&gt;vecchio ministro del fatto. </p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>
               <hi rend="sc">OTTA.</hi>
             </speaker>
             <p> O nòva strana e dispiacevole, me ne attristo tanto, come s'io havessi persa Ottavia mia sorella e 'l più bel regno ch'habbi ne &lt;l'&gt; imperio. </p>
             <p>Hor via, presto, che la si porti così come sta alla mia presenza, acciò che la possi almeno veder morta, poi che non ho havuto tempo di vederla viva. </p>
           </sp>
-          <sp>
+          <sp who="#proculeio">
             <speaker>
               <hi rend="sc">PROC.</hi>
             </speaker>
             <p> Il tutto sarà esequito, sacratissimo imperadore, et hor hora sarà qui presentata. </p>
             <p>Venete meco, voi altri. </p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>
               <hi rend="sc">OTTA.</hi>
             </speaker>
             <p> E tu, insensato vecchio, come hai havuto tanto ardire che t&lt;i&gt; sia bastato l'animo di dar morte a costei, sapendo ch'era mia serva? </p>
           </sp>
-          <sp>
+          <sp who="#olimp">
             <speaker>
               <hi rend="sc">OLIMP.</hi>
             </speaker>
             <p> Quel tanto che ho fatto, o Cesare, è stato in tempo che la reina Cleopatra, mia signora, non era in vostro potere e me lo poteva comandare. </p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>
               <hi rend="sc">OTTA.</hi>
             </speaker>
             <p> Come che non era in mio potere? </p>
             <p>Non l'haveva già Proculeio pre&lt;sa&gt; in mio nome e non havevo io la città e i thesori nelle mani? </p>
           </sp>
-          <sp>
+          <sp who="#olimp">
             <speaker>
               <hi rend="sc">OLIMP.</hi>
             </speaker>
             <p> Quando mi comandò ch'io le dovesse preparar il veleno, la città di Alessandria non era ancora in vostro dominio et ella era libera reina et in esser di potersi diffender, se l'imperador Antonio non l'abbandonava. </p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>
               <hi rend="sc">OTTA.</hi>
             </speaker>
             <p> E quando seguì l'effetto non era ella presa? </p>
           </sp>
-          <sp>
+          <sp who="#olimp">
             <speaker>
               <hi rend="sc">OLIMP.</hi>
             </speaker>
             <p> È vero, ma voi per gratia l'havevate fatta libera, mentre che duravano le essequie. </p>
             <p>Nel qual tempo da me con un aspido e una subita potione le fu tolta la vita. </p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>
               <hi rend="sc">OTTA.</hi>
             </speaker>
             <p> Non potevi pensar che, facendo tu ciò, incorrevi nella mia disgratia e, non lo facendo, mi facevi piacere? </p>
           </sp>
-          <sp>
+          <sp who="#olimp">
             <speaker>
               <hi rend="sc">OLIMP.</hi>
             </speaker>
             <p> Io lo sapevo, ma dell'uno e dell'altro poco mi curava, pur ch'io sodisfacessi a lei che mi poteva comandare. </p>
             <p>Ma se havevate pensiero ch'ella vivesse, e chi lo poteva far meglio di voi? </p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>
               <hi rend="sc">OTTA.</hi>
             </speaker>
             <p> E in che modo? </p>
           </sp>
-          <sp>
+          <sp who="#olimp">
             <speaker>
               <hi rend="sc">OLIMP.</hi>
             </speaker>
@@ -2936,7 +2984,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Vi pensavi forse che Cleopatra, qual era così gran  reina magnanima e tremenda nelle sue imprese, fosse di animo cotanto vile e basso, che la si fosse inchinata di venir con esso voi in Italia per servir a Ottavia, vostra sorella, o ad altre cittadine romane? </p>
             <p>Voi vi siete ingannato; e credetemi che tutte le cose del mondo potevano essere, eccetto questa. </p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>
               <hi rend="sc">OTTA.</hi>
             </speaker>
@@ -2944,25 +2992,25 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Non so dove tieni fondata questa tua audacia. </p>
             <p>Non sai ch'hora parli con Ottavio, imperador del mondo? </p>
           </sp>
-          <sp>
+          <sp who="#olimp">
             <speaker>
               <hi rend="sc">OLIMP.</hi>
             </speaker>
             <p> La grave età e la morte, che di hora in hora aspetto, son quelle che mi fanno audace, poco curandomi di voi, né delle cose nostre. </p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>
               <hi rend="sc">OTTA.</hi>
             </speaker>
             <p> Se la grave età, come hai detto, non mi ritenesse, io ti farei pentire di questo tuo licentioso parlare, ma voglio credere ch'ella in parte ti habbi levato il sentimento della ragione. </p>
           </sp>
-          <sp>
+          <sp who="#ario">
             <speaker>
               <hi rend="sc">ARIO</hi>
             </speaker>
             <p> Sacratissimo imperadore, poi ch'a me, vostro indegno servo, havete fatte tante gratie e che già mi havete donati tutti i miei cittadini, io vi chieggio in dono ancora questo, qual, oltre ch'è mio amico, egli è uno de' grandi huomini nella professione della medicina, ch'habbi il mondo, e rendasi ce&lt;rto&gt; vostra maestà che quanto ha operato è stato per forza. </p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>
               <hi rend="sc">OTTA.</hi>
             </speaker>
@@ -2970,31 +3018,31 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Io dunque dono a te questo vecchio, del qual già mi sono mosso a compassione, e gli perdono quanto ha fatto et esequito nella persona di Cleopatra. </p>
             <p>Che poi, per dir il vero, la colpa è più tosto mia che d'altri, che non dovevo mai levarle le guardie d'intorno. </p>
           </sp>
-          <sp>
+          <sp who="#olimp">
             <speaker>
               <hi rend="sc">OLIMP.</hi>
             </speaker>
             <p> Deh, Ario mio, non ti affaticar più per me, perché è invano, havendo anch'io tolto il veleno a termine, che fra poche ore mi torrà la vita. </p>
           </sp>
-          <sp>
+          <sp who="#ario">
             <speaker>
               <hi rend="sc">ARIO</hi>
             </speaker>
             <p> Come che hai preso il veleno? </p>
           </sp>
-          <sp>
+          <sp who="#olimp">
             <speaker>
               <hi rend="sc">OLIMP.</hi>
             </speaker>
             <p> Io l'ho preso, Ario, e fra due ore andrò a ritrovar la reina morta, che così le ho promesso. </p>
           </sp>
-          <sp>
+          <sp who="#ario">
             <speaker>
               <hi rend="sc">ARIO</hi>
             </speaker>
             <p> Non hai tu, che sei peritissimo nella medicina, qualche potente rimedio che ti possa salvar la vita? </p>
           </sp>
-          <sp>
+          <sp who="#olimp">
             <speaker>
               <hi rend="sc">OLIMP.</hi>
             </speaker>
@@ -3002,14 +3050,14 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Ma a che fine più vivere? </p>
             <p>Ad ogni modo poco più inanzi posso andare, e la mia vita non sarà accompagnata da altro che da affanni e dolori di mente e di corpo. </p>
           </sp>
-          <sp>
+          <sp who="#ario">
             <speaker>
               <hi rend="sc">ARIO</hi>
             </speaker>
             <p> Sia come si voglia. </p>
             <p>Io intendo che per amor mio ti aiuti e che quanto prima tu prenda il rimedio e che tu servi l'imperador, mio signore, con quella fede che tu hai ancora serviti l'imperador Antonio e la reina Cleopatra, e che viviamo insieme sin tanto che le Parche troncheranno il filo della nostra vita. </p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>
               <hi rend="sc">OTTA.</hi>
             </speaker>
@@ -3018,21 +3066,21 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>E ti prometto che sopra il capo di questa bella fanciulla porrò una corona, non men degna di quella di sua madre. </p>
             <p>Sì che va' a curarti e vivi, e da me spera ogni bene. </p>
           </sp>
-          <sp>
+          <sp who="#olimp">
             <speaker>
               <hi rend="sc">OLIMP.</hi>
             </speaker>
             <p> Sacratissimo e altissimo imperadore, per non mostrarmi ingrato di un tanto beneficio e per amor di questi figliuolini, quali la reina lor madre mi haveva imposto che vi raccomandassi, il che mi haveva fatto prender il veleno a termine per poter sodisfare, io mi rendo e son contento di prolongar questa misera vita, la qual voi hora per gratia mi havete data et, acciò che il veleno non prenda più il possesso, hor hora andarò a pigliar il rimedio. </p>
             <p>Voi altri, figliuoli, inginnocchiatevi e basciate le mani di soa maestà, come vostro signore e benefattore. </p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>
               <hi rend="sc">OTTA.</hi>
             </speaker>
             <p> Questo bel vecchio e questi fanciulli mi hanno talmente intenerito, che quasi non mi posso contener dalle lagrime. </p>
             <p>Levatevi, figliuoli, e andate allegri col vostro nutritio e tu, Olimpio, habbine buona cura. </p>
           </sp>
-          <sp>
+          <sp who="#olimp">
             <speaker>
               <hi rend="sc">OLIMP.</hi>
             </speaker>
@@ -3040,7 +3088,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Ario, a rivedersi. </p>
             <p>Hora non c'è tempo da spender in ringratiamenti. </p>
           </sp>
-          <sp>
+          <sp who="#ario">
             <speaker>
               <hi rend="sc">ARIO</hi>
             </speaker>
@@ -3052,26 +3100,26 @@ Hor va' inanzi, che ti sieguo. </p>
           <stage>
             <hi rend="italic">  (quivi portano la regina sopra d'una sedia adobada con l'aspido et con il braccio nudo)</hi>
           </stage>
-          <sp>
+          <sp who="#proculeio">
             <speaker>
               <hi rend="sc">PROC.</hi>
             </speaker>
             <p> Eccovi, invittissimo imperadore, colei che, vivendo l'imperador Antonio, havea concetto nel suo grand'animo di farsi imperatrice di Roma. </p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>
               <hi rend="sc">OTTA.</hi>
             </speaker>
             <p> Dunque questa, questa è quella Cleopatra cotanto famosa, che di sé ha lasciato così gran nome all'Imperio Romano? </p>
           </sp>
-          <sp>
+          <sp who="#proculeio">
             <speaker>
               <hi rend="sc">PROC.</hi>
             </speaker>
             <p> Quella è, sacratissimo imperadore, e questo è l'aspido che nel suo bel braccio ha fatto queste due picciole punture, che le hanno tolta la vita; che altro segno non si è ritrovato nel suo real corpo, la bellezza del quale, o Cesare, è tale che meritamente si potria agguagliar ad uno di quelli delle più sublimi e delle più gloriose dèe del cielo. </p>
             <p>E non fu maraviglia se il gran Cesare vostro padre e 'l magno Antonio al primo tratto se ne invaghirono; e accortezza grande fu la vostra a non volerla così incautamente vedere, perciò che, essendo ancor voi huomo come gli altri, e non havendo il cuor di tigre né di orso, facilmente allettato e forse ammagliato dalle sue lusinghe, sareste corso la medesima sorte che gli antecessori, e non sarebbe stata mareviglia, poscia che così morta par ch'habbi ancora potere di tramutar il cuore delli huomini: il che si può chiaramente vedere nell'aspetto di vostra maestà, qual veggio, fuori del solito, tutto alterato e mesto. </p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>
               <hi rend="sc">OTTA.</hi>
             </speaker>
@@ -3082,7 +3130,7 @@ Hor va' inanzi, che ti sieguo. </p>
             <p>Ma poi che la grandezza dell'animo tuo ha prevenuto il mio disegno, non voglio almeno mancarti in morte. </p>
             <p>Su dunque, voi altri cittadini, ordinate le essequie con pompa regale, apparecchiate lumi eterni e honori divini a questa vostra natural reina, indrizzandole tempi, altari e statue di argento e d'oro, acciò che come dea sia adorata da tutte le nationi dell'universo; e non mancate di collocarla, poi che così ha richiesto, appresso le ossa di Antonio, suo marito. E voi altri capitani date nel tamburo e nelle trombe e ordinate le squadre, che si marchi per Italia. </p>
           </sp>
-          <sp>
+          <sp who="#proculeio">
             <speaker>
               <hi rend="sc">PROC.</hi>
             </speaker>

--- a/tei/anonimo-fabula-de-cefalo-e-procris.xml
+++ b/tei/anonimo-fabula-de-cefalo-e-procris.xml
@@ -82,6 +82,19 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="aurora">
+            <persName>Aurora</persName>
+          </person>
+          <person xml:id="procris">
+            <persName>Procris</persName>
+          </person>
+          <person xml:id="cefalo">
+            <persName>Cefalo</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -171,7 +184,7 @@
         <stage>
           <p>Recitato dicto argumento, CEFAL vestito da caciatore <add resp="#ed">con</add> cani, corni, comp<add resp="#ed">agni</add>, archi, faretre e dardi andò al bosco a la cacia. Andato CEFALO a la cacia, l'AURORA inamorata de CEFALO, vestita da vechia, andò a PROCRIS e disse queste parole, <foreign xml:lang="lat">videlicet:<emph> verba linguae</emph> susurae</foreign>.</p>
         </stage>
-        <sp>
+        <sp who="#aurora">
           <speaker>AURORA</speaker>
           <lg>
             <l>Cum gran dolor, Procris, figliola mia,</l>
@@ -205,7 +218,7 @@
           </lg>
         </sp>
         <stage>Parole de PROCRIS.</stage>
-        <sp>
+        <sp who="#procris">
           <speaker>PROCRIS</speaker>
           <lg>
             <l>Misera me, che cosa è quel che sento!</l>
@@ -219,7 +232,7 @@
           </lg>
         </sp>
         <stage>Dapoi PROCRIS  andò cum la vechia al bosco per vedere CEFALO; la qual sentita da llui li passò el core col dardo, et inde conoscendo che era PROCRIS soa disse queste parole, <foreign xml:lang="lat">videlicet</foreign>:</stage>
-        <sp>
+        <sp who="#cefalo">
           <speaker>CEFALO</speaker>
           <lg>
             <l>O Cefal traditor, o dispietato</l>
@@ -233,7 +246,7 @@
           </lg>
         </sp>
         <stage>E presa PROCRIS  in brazo e sedendo lui in terra, lei morendo li disse queste parole:</stage>
-        <sp>
+        <sp who="#procris">
           <speaker>PROCRIS</speaker>
           <lg>
             <l>Io te prego, per li imortali dei,</l>

--- a/tei/anonimo-la-canterina.xml
+++ b/tei/anonimo-la-canterina.xml
@@ -74,6 +74,22 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="apollonia">
+            <persName>Apollonia</persName>
+          </person>
+          <person xml:id="gasparina">
+            <persName>Gasparina</persName>
+          </person>
+          <person xml:id="don_ettore">
+            <persName>Don Ettore</persName>
+          </person>
+          <person xml:id="don_pelagio">
+            <persName>Don Pelagio</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -103,7 +119,7 @@
           <head>Scena 1</head>
           <stage>Camera con un tavolino e sedie da una parte, dall'altra un clavicembalo.<lb/>
 Gasparina e Apollonia</stage>
-          <sp>
+          <sp who="#apollonia">
             <speaker>APOLLONIA</speaker>
             <l>Che visino delicato</l>
             <l>Che ti fa questo belletto;</l>
@@ -129,29 +145,29 @@ Gasparina e Apollonia</stage>
             <l>quint'elemento di noialtre donne!</l>
           </sp>
           <stage>(si batte alla porta di fuori)</stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Bussano, chi sarà?</l>
           </sp>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>Sarà il Maestro, adesso...</l>
             <l>Oh, oh, Don Ettore!</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Che vuol questo sguaiato?</l>
             <l>Diglielo tu, che il padre ha minacciato</l>
             <l>Farrni sfregiar, se lo ricevo in casa.</l>
             <l>Ei non ha più che darmi, questo è il male.</l>
           </sp>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>Ma, figlia benedetta,</l>
             <l>Vuoi farti rovinare da tuo padre?</l>
           </sp>
           <stage>(si batte un'altra volta)</stage>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>E' torna! siam' serrate,</l>
             <l>Non si può aprire.</l>
@@ -160,99 +176,99 @@ Gasparina e Apollonia</stage>
         <div>
           <head>Scena 2</head>
           <stage>Don Ettore e dette</stage>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>Ah, gnora!</l>
             <l>Voi così mi trattate?</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Caccialo, questo pazzo, con un legno!</l>
           </sp>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>Signora, tanto sdegno</l>
             <l>Perché?</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Rompiti il collo!</l>
           </sp>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>Or ben, questo cerchietto</l>
             <l>Di diamanti, che ho preso da mia madre,</l>
             <l>Lo porterò a donar all'Angelina.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Diamanti? Oh ben, chi è lì fuori?</l>
           </sp>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>Figlia,</l>
             <l>È Don Ettore.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Don Ettore?</l>
           </sp>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>Signora, servo suo.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Cor mio, sono due mesi</l>
             <l>Che veduto non t'ho!</l>
           </sp>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>Figlia, che fai,</l>
             <l>Se il padre lo sa?</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Che me ne preme,</l>
             <l>Io per dispetto suo lo voglio amare.</l>
           </sp>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>Benedetta, tu sài quel che ti fare.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Vostra madre sta bene?</l>
           </sp>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>Sì, e vedete, questo è suo;</l>
             <l>Io l'ho preso e 'l dono a voi</l>
             <l>Assieme con quest'olanda.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Ma se mai</l>
             <l>Se n'accorge?</l>
           </sp>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>Ella m'ama, io gliel dico,</l>
             <l>E si sta zitta.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Madre, vedi, che bella</l>
             <l>Cosa ricca,</l>
             <l>Che tela di signore,</l>
             <l>Che m'ha dato Don Ettore!</l>
           </sp>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>Oh, bella cosa!</l>
           </sp>
           <stage>(con disprezzo)</stage>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>(Valerà tre doppie</l>
             <l>Tutto il regalo.)</l>
@@ -263,70 +279,70 @@ Gasparina e Apollonia</stage>
             <l>Voi vedete la vita che facciamo</l>
             <l>Sempre chiuse.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Credea, or ch'han bussato,</l>
             <l>Che fusse un mercante,</l>
             <l>Che vuol donarmi un abito di stoffa</l>
             <l>Per sentirmi cantare.</l>
           </sp>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>E per che cosa non lo vuo' accettare?</l>
           </sp>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>Chi? Che dite?</l>
             <l>Alla casa di Gasparina Zuffoli?</l>
             <l>Qui nessun ci mette piedi;</l>
             <l>La mia figliola, lei, chi mai la crede?</l>
           </sp>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>Piano, signora, io non ho detto niente.</l>
             <l>Or senti, Gasparina,</l>
             <l>Starò a pranzo con te questa mattina.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Padrone! Ma bisogna trattenersi un pochetto,</l>
             <l>Finché prenda lezione e il Mastro vada via</l>
           </sp>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>Ti servo, anima mia,</l>
             <l>Ma il Mastro ch'è?</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Oh, egli è un uom fantastico,</l>
             <l>Mi sgriderebbe subito.</l>
           </sp>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>La conosce ragazza.</l>
           </sp>
           <stage>(si sente battere)</stage>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>Uh, la porta, diavolo!</l>
           </sp>
           <stage>(confusa)</stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Come farem? Chi è?</l>
           </sp>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>Il Mastro!</l>
           </sp>
           <stage>(sorpresa)</stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Il Mastro? Nascondi questa spada!</l>
             <l>Che penseremo?</l>
           </sp>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>Uh, canchero!</l>
           </sp>
@@ -334,91 +350,91 @@ Gasparina e Apollonia</stage>
         <div>
           <head>Scena 3</head>
           <stage>Don Pelagio e detti</stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Signor Mastro, vi fò riverenza.</l>
           </sp>
           <stage>(a Don Ettore)</stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Dunque, due lire il palmo?</l>
           </sp>
           <stage>(a Don Pelagio)</stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Questo qua è un venditor di tela olanda,</l>
             <l>E ci ha portato certa bella roba</l>
             <l>Che mi bisogna, ed ei la dà per niente.</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Quant'importa?</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Tre canne, son quarant'otto lire.</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Niente di meno?</l>
           </sp>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>Che so io!</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Sicuro, se egli s'è posto</l>
             <l>A un prezzo ragionevole,</l>
             <l>Più non sa dir.</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Facciamo trenta lire!</l>
           </sp>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>Mia madre l'ha comprata per sessanta.</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Come? Oh bella! Che dice?</l>
           </sp>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>La madre fa il negozio, egli va in giro</l>
             <l>Vendendo.</l>
           </sp>
           <stage>(Ma che sciocco!)</stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Via, sbrigatelo presto, poveraccio!</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Ecco!</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Prendi!</l>
           </sp>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>Bel trucco!</l>
           </sp>
           <stage>(a parte a Don Ettore)</stage>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>(Va, va abbasso al caffè!</l>
             <l>Quand'è partito il Maestro,</l>
             <l>Io ti chiamo dal balcone.)</l>
           </sp>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>Vi riverisco tutti.</l>
           </sp>
           <stage>(via)</stage>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Mio padrone!</l>
           </sp>
@@ -426,7 +442,7 @@ Gasparina e Apollonia</stage>
         <div>
           <head>Scena 4</head>
           <stage>Don Pelagio, Gasparina e Apollonia</stage>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Accostati ed ascolta un po'</l>
             <l>Quest'aria ch'ho scritta questa notte;</l>
@@ -447,259 +463,259 @@ Gasparina e Apollonia</stage>
             <l>Che farai, misero cor?”</l>
             <l>Che dici?</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Viva!</l>
           </sp>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>Bravo, signor Maestro!</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Via, canta appresso a me!</l>
           </sp>
-          <sp>
+          <sp who="#gasparina #don_pelagio">
             <speaker rend="sc">GASPARINA e DON PELAGIO</speaker>
             <l>“Che mai far deggio?”</l>
             <l>“Sposo!”</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Dolce, dolce!</l>
           </sp>
-          <sp>
+          <sp who="#gasparina #don_pelagio">
             <speaker rend="sc">GASPARINA e DON PELAGIO</speaker>
             <l>“Ti vedrò esangue?”</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Tieni ...</l>
           </sp>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>“Esangue” fa così.</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Gnora, fa calze, non t'impacciar!</l>
           </sp>
-          <sp>
+          <sp who="#gasparina #don_pelagio">
             <speaker rend="sc">GASPARINA e DON PELAGIO</speaker>
             <l>“E spirerai quell'alma?”</l>
           </sp>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>Spirare, apri la bocca!</l>
             <l>“E spirerai quell'alma?”</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Vedi, che vituperio!</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Soffritela, Maestro, la sapete.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina #don_pelagio">
             <speaker rend="sc">GASPARINA e DON PELAGIO</speaker>
             <l>“E chiuderai quei lumi,</l>
             <l>Quei dolci lumi?”</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Ah, quei dolci lumi!</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>“Quei dolci lumi!”</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Dolci lumi tuoi!</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>“Tuoi” non vi sta.</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Parlo di te.</l>
           </sp>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>Ci vuole “lumi tuoi”,</l>
             <l>Fa più grazia, tu non capisci.</l>
             <l>Ecco: “E chiuderai...”</l>
           </sp>
           <stage>(con rabbia)</stage>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Quella fetente bocca!</l>
           </sp>
           <stage>(Fa partire la gnora!)</stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Signora madre, un po' di cioccolatte!</l>
           </sp>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>Dammi la chiave!</l>
             <l>“E chiuderai quell'alma!</l>
             <l>E spirerai quei lumi!”</l>
             <l>Viva il signor Maestro!</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>(Oh, che si rompa il collo!)</l>
             <l>Come sta, signorina?</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Per servirvi.</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Tutta stanotte io non ho preso sonno.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Per l'aria?</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Per pensare a te, furbetta!</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Oh, sì, vi credo già.</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Cari quegl'occhi!</l>
           </sp>
           <stage>(vedendo Apollonia)</stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Uh, la signora madre!</l>
           </sp>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>Signor Mastro, che la vuole accecar?</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>“Chiuder i lumi”</l>
             <l>Ha da far l'azion di serrar l'occhi.</l>
           </sp>
           <stage>(qui parte Apollonia)</stage>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Che gran suggezion questa tua madre!</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Oh, quest'è il male; appena che s'accorge</l>
             <l>Ch'io scherzo,</l>
             <l>Fa tremarmi.</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Ogni cantante</l>
             <l>Ha questa suggezione.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>(Così a credere diamo</l>
             <l>A chi è babbione.)</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Or io ti vo' sposar, che dici? Parla!</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Parlatene alla gnora!</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Il fistol se la mangi!</l>
             <l>Sempre con questa gnora!</l>
             <l>Io vo' sapere, se tu tieni altri in core.</l>
             <l>Dimmi la verità!</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Ah, traditore!</l>
             <l>Così, così mi tratti?</l>
             <l>Uh, ti darei...</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Ah, vipera!</l>
           </sp>
           <stage>(Apollonia ritorna)</stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>La gnora</l>
             <l>Entra di nuovo qui.</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Uh, m'entrasse... !</l>
           </sp>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>Cos'è?</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Tu bada ben, un'altra volta!</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Che colp'ho io?</l>
             <l>Quell'entrate all'improvviso</l>
             <l>Son difficili.</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>È vero</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Questa suggezion di quest'entrate</l>
             <l>Bisogna che la levi;</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Furbetta, quanto sai!</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Vostra scolara!</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Hai vinto già il maestro, figlia cara.</l>
             <l>Via, partiamo, ch'è tardi.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Ve n'andate?</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Sì, figlia cara mia. (Vedi, ch'occhiate!)</l>
           </sp>
           <stage>(via)</stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Che povero merlotto!</l>
             <l>Ma tu il farai stancare</l>
             <l>Con tante stitichezze.</l>
           </sp>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>Tu che fai del mestier, lasciane il peso</l>
             <l>A chi lo sa da mastra, m'hai tu inteso?</l>
@@ -708,33 +724,33 @@ Gasparina e Apollonia</stage>
         <div>
           <head>Scena 5</head>
           <stage>Gasparina, poi Don Pelagio</stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Dice il vero. Ma ancor non vien Don Ettore?</l>
           </sp>
           <stage>(verso la finestra con isdegno)</stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Salite!... ma che allocco!</l>
           </sp>
           <stage>(piano e non visto da Gasparina)</stage>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Qui certo l'ho lasciata.</l>
           </sp>
           <stage>(come sopra)</stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Il Maestro è partito.</l>
             <l>Venga! Che scimunito!</l>
             <l>S'ha rotto il collo, sì. Non l'hai veduto?</l>
             <l>Sei orbo. Presto, è ora già di pranzo.</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Diavolo, che ascolto!</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Via, verrotti a incontrare per le scale.</l>
             <l>Andiam, andiamo, povero animale!</l>
@@ -744,7 +760,7 @@ Gasparina e Apollonia</stage>
         <div>
           <head>Scena 6</head>
           <stage>Don Pelagio solo</stage>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Oh, rabbia! Oh gelosia!</l>
             <l>Va, va senza rossore;</l>
@@ -753,7 +769,7 @@ Gasparina e Apollonia</stage>
             <l>Se di te non mi vendico.</l>
           </sp>
           <stage>(additando il clavicembalo)</stage>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Nascondiamoci qui, vediam la fine</l>
             <l>Di sue furfanterie;</l>
@@ -767,40 +783,40 @@ Gasparina e Apollonia</stage>
         <div>
           <head>Scena 7</head>
           <stage>Don Pelagio nascosto, Gasparina e Don Ettore.</stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Vedi, fatti capace!</l>
           </sp>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>Io sempre sono stato a far la spia,</l>
             <l>né l'ho veduto.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Eh via!</l>
           </sp>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>Mi è toccato a dar luogo al signor Mastro</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>(Or io do luogo a voi;</l>
             <l>Ah, così sono le vicende umane.)</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Che luogo? Tu sei matto!</l>
           </sp>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>Ma ella perché ha fatto</l>
             <l>Fingermi venditor di queste tele,</l>
             <l>Facendone pagar dal Mastro il prezzo?</l>
             <l>Segno che vi ama, e voi ...</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Ah, sciocco!</l>
             <l>Egli mi deve</l>
@@ -808,38 +824,38 @@ Gasparina e Apollonia</stage>
             <l>Non avea come vestirsi, ond'io procuro</l>
             <l>Di ricuoterli alla meglio.</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>(Ah falsa, ah finta,</l>
             <l>Falsa più del falsetto istesso!)</l>
           </sp>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>E quanto deve ancora?</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Quattro zecchini.</l>
           </sp>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>Lascialo in mal'ora.</l>
           </sp>
           <stage>(facendosi innanzi)</stage>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>No, voglio pagare.</l>
             <l>Dica, signora, l'ho a dare?</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Uh, rovina!</l>
           </sp>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>Lei che va facendo?</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Zitto, viso di capra! Prendi,</l>
             <l>Ecco il denaro!</l>
@@ -848,40 +864,40 @@ Gasparina e Apollonia</stage>
         <div>
           <head>Scena 8</head>
           <stage>Apollonia e detti</stage>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>Presto in tavola,</l>
             <l>Che siete arrivati.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Ah, ch'è venuto il precipizio mio!</l>
           </sp>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>Signor Maestro!</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Signor corno, addio!</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Scellerata, mancatrice, traditrice.</l>
           </sp>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>Non gridate!</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Per pietate!</l>
           </sp>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>Signor mio, lei l'uccida che poch'è.</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Vo' gridar dalli balconi:</l>
             <l>Queste donne, miei padroni,</l>
@@ -889,37 +905,37 @@ Gasparina e Apollonia</stage>
             <l>Basta dir, son canterine,</l>
             <l>Imparatelo da me!</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Ch'accidente!</l>
           </sp>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>Che sventura!</l>
           </sp>
-          <sp>
+          <sp who="#gasparina #apollonia">
             <speaker rend="sc">GASPARINA e APOLLONIA</speaker>
             <l>Per l'affanno e la paura</l>
             <l>Io mi reggo appena in piè.</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Scellerata!</l>
           </sp>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>Signor mio!</l>
           </sp>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>Ci buttiamo a' piedi vostri.</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Lungi, lungi, gente ingrata,</l>
             <l>Castigata hai da restar.</l>
           </sp>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>La mia tela, i miei diamanti,</l>
             <l>Zi! Non servon questi pianti,</l>
@@ -932,36 +948,36 @@ Gasparina e Apollonia</stage>
         <div>
           <head>Scena 1</head>
           <stage>Gasparina ed Apollonia.</stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Uh, rovinate noi!</l>
           </sp>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>Che si farà?</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Per fare a modo tuo,</l>
             <l>lo mi trovo ridotta in questo stato.</l>
           </sp>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>Se mi avessi ascoltato,</l>
             <l>Non corressi rischio.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Ti fossi rotto il collo,</l>
             <l>Quando venisti in casa,</l>
             <l>Ruffianaccia cenciosa!</l>
           </sp>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>Sì signora cosa,</l>
             <l>non farmi parlare.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Parla, parla, che possa tu scoppiare!</l>
             <l>Don Pelagio, bargello, facchini e dette.</l>
@@ -969,7 +985,7 @@ Gasparina e Apollonia</stage>
         </div>
         <div>
           <head>Scena 2</head>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Signor mio, l'ufficio suo</l>
             <l>Lei lo faccia con rigor!</l>
@@ -977,11 +993,11 @@ Gasparina e Apollonia</stage>
             <l>Queste donne vadan via;</l>
             <l>Lei si sbrighi, mio signor!</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Che mai vuol dir tal cosa?</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Signora virtuosa,</l>
             <l>Vuol dir, che lei si sfratti</l>
@@ -990,68 +1006,68 @@ Gasparina e Apollonia</stage>
             <l>E poi sen' vada in pace,</l>
             <l>Lungi da me, dove le pare e piace.</l>
           </sp>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>S'è imbrogliato il negozio,</l>
             <l>Bisogna alzar i ponti;</l>
             <l>Or via, prendiamo</l>
             <l>La cosa nostra e andiamo!</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Carcerate costei, ch'è la sua madre.</l>
           </sp>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>A me? Non la conosco.</l>
             <l>Parlatene con lei,</l>
             <l>Uccidetela pur, signori miei!</l>
           </sp>
           <stage>(parte via correndo)</stage>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Sfratta, sfratta, via presto!</l>
           </sp>
           <stage>(qui mette mani il bargello)</stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Piano, che modo è questo?</l>
             <l>Lasciate pria, ch'affitti un'altra casa.</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Che casa? Sior bargello,</l>
             <l>Se non va via col buon,</l>
             <l>Sa già che fare.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Piano, sbirraglia indegna;</l>
             <l>Non mettete le mani</l>
             <l>Sopra una virtuosa!</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Virtuosa, di che?</l>
             <l>Strascinatela via!</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Ah Don Pelagio caro!</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Vada, vada!</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Pietà!</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Son sordo.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Oh Dio!</l>
             <l>Deh, ti muova pietade il pianto mio!</l>
@@ -1065,7 +1081,7 @@ Gasparina e Apollonia</stage>
         <div>
           <head>Scena 3</head>
           <stage>Don Pelagio solo.</stage>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Misera! Dove andrà?</l>
             <l>Se si fermava un altro pochettino,</l>
@@ -1079,49 +1095,49 @@ Gasparina e Apollonia</stage>
         <div>
           <head>Scena 4</head>
           <stage>Gasparina e detto.</stage>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Via, facchini,</l>
             <l>Portate in casa mia codeste robe!</l>
           </sp>
           <stage>(i facchini mettono mani)</stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Piano,</l>
             <l>Chè v'è della mia roba ch'ho restata.</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>E cosa?</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Un bussolotto</l>
             <l>Ripieno di belletto,</l>
             <l>Un pettine e uno specchio al naturale.</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Lasciato avevi tutto il capitale.</l>
             <l>L'hai trovato?</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Ecco qui.</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Dove ne vai?</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Disperata a buttarmi in qualche pozzo</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>(Misera! Più non posso.)</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Conosco che da voi</l>
             <l>Non merito ne' pure esser guardata,</l>
@@ -1129,7 +1145,7 @@ Gasparina e Apollonia</stage>
             <l>Però vi chieggo prima</l>
             <l>Umilmente perdon, poi parto, addio!</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>(Or crepo.) Senti, figlia,io ti perdono;</l>
             <l>Le mesate ti dono,</l>
@@ -1137,7 +1153,7 @@ Gasparina e Apollonia</stage>
             <l>Ch'io sia tanto crudel, restati in casa,</l>
             <l>Finché trovi altro comodo.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Oh ciel!</l>
             <l>Quest'è un favore da me non meritato;</l>
@@ -1145,7 +1161,7 @@ Gasparina e Apollonia</stage>
             <l>Lasciate ch'io vi baci</l>
             <l>Almen la mano.</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>No, no! (Via, ch'ho da far?)</l>
             <l>Ferma, facchino,</l>
@@ -1153,12 +1169,12 @@ Gasparina e Apollonia</stage>
             <l>Campita sia</l>
             <l>Oggi la grazia mia!</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Che ascolto! Ah, un altro bacio</l>
             <l>Vo' impremere su quella mano.</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Elà, facchini,</l>
             <l>Lascio il cembalo ancor;</l>
@@ -1167,45 +1183,45 @@ Gasparina e Apollonia</stage>
             <l>Che mi scordo de' tanti falli tuoi:</l>
             <l>Ma la pietade è propria degli eroi.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Lo veggo, e son confusa;</l>
             <l>Ah, un'altra volta lasciatemi</l>
             <l>Baciar la mano!</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Facchini, piano, piano;</l>
             <l>Lasciatele ogni cosa!</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Che alma generosa!</l>
             <l>Ah, mi voglio buttar a' piedi vostri</l>
             <l>E non partirne più.</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Piano, che fai?</l>
             <l>Facchini, in casa andate</l>
             <l>E tutte le mie robe qua portate!</l>
           </sp>
           <stage>(i facchini via)</stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Ma oimé, sento mancarmi.</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Cos'è?</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>La gran paura, la collera,</l>
             <l>Il digiuno...</l>
           </sp>
           <stage>(finge di svenire)</stage>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Oh stelle, aiuto!</l>
             <l>Gnora! Don Ettore! Ah, poverina,</l>
@@ -1219,191 +1235,191 @@ Gasparina e Apollonia</stage>
           <head>Scena 5</head>
           <stage>Don Ettore, Apollonia e detti.</stage>
           <stage>(con ammirazione)</stage>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>lo sono chiamato qui.</l>
           </sp>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>Chiamata son pur io.</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Oibò, non me la trovo.</l>
           </sp>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>Ma cosa vedo?</l>
           </sp>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>Ah, mia figlia svenuta!</l>
           </sp>
           <stage>(con agitazione)</stage>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>O povera me, o povera me!</l>
           </sp>
           <stage>(tiene una borsa in mano)</stage>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Prendi qua!</l>
           </sp>
           <stage>(gli reca una scatula de' diamanti)</stage>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>Prendi là!</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Piano!</l>
           </sp>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>Adagio!</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Oibò, questa è la borsa.</l>
           </sp>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>Che bon odor è quello</l>
             <l>De' diamanti!</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Oh buona, ella l'odora poveretta,</l>
             <l>Sta fuor di sé. Apollonia!</l>
           </sp>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>(Fingi bene, mia figlia benedetta,</l>
             <l>L'è del mestier.) Ah, poverina figlia!</l>
           </sp>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>Ha un poco di furbetta.</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Via, spirito, mia diletta!</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Apri pur, mia dea terrestre,</l>
             <l>L'amorose tue finestre,</l>
             <l>Ch'all'oscuro mi fai star.</l>
           </sp>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>Ah, rischiara quelle ciglia,</l>
             <l>Guarda intorno, cara figlia,</l>
           </sp>
           <stage>(addita le gioie e i danari)</stage>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>(Non lasciarti mai scappar!)</l>
           </sp>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>Non l'intendo, sia rossore</l>
             <l>O piuttosto un finto amore;</l>
             <l>Basta, non mi vo' fidar.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Ah, mi sento ristorata,</l>
             <l>Già mi trovo risanata,</l>
             <l>Pian. Oimè, torn'a mancar.</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Questa è borsa.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Mi ristora.</l>
           </sp>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>Quest'è gioia.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Com'odora,</l>
             <l>mi consola in verità.</l>
           </sp>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>Quest'anello allegra il core</l>
             <l>Per il prezzo, non l'odore;</l>
             <l>Troppo scaltra è questa qua.</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>La mia borsa allegra il core</l>
             <l>Per, il suon, non per l'odore;</l>
             <l>Troppo scaltra è questa qua.</l>
           </sp>
           <stage>(a Don Pelagio)</stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Mio diletto!</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Mia diletta!</l>
           </sp>
           <stage>(a Don Ettore)</stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Caro, caro!</l>
           </sp>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>Cara, cara!</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Sei bonino, sei bellino</l>
             <l>Mio diletto, caro, caro!</l>
           </sp>
-          <sp>
+          <sp who="#don_ettore #don_pelagio">
             <speaker rend="sc">DON ETTORE e DON PELAGIO</speaker>
             <l>Questo anello sta in camino,</l>
             <l>La mia borsa</l>
             <l>Via lo voglio regalar.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina #apollonia">
             <speaker rend="sc">GASPARINA e APOLLONIA</speaker>
             <l>Vo' provar il mio destino.</l>
             <l>Tenta pur il tuo destino,</l>
             <l>Mi preparo a trionfar</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Mel' donaste?</l>
           </sp>
-          <sp>
+          <sp who="#don_pelagio">
             <speaker rend="sc">DON PELAGIO</speaker>
             <l>Non mi pento.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker rend="sc">GASPARINA</speaker>
             <l>Questo in dono?</l>
           </sp>
-          <sp>
+          <sp who="#don_ettore">
             <speaker rend="sc">DON ETTORE</speaker>
             <l>Tel' presento.</l>
           </sp>
-          <sp>
+          <sp who="#apollonia">
             <speaker rend="sc">APOLLONIA</speaker>
             <l>Viviam noi, evviva il Maestro!</l>
             <l>Non risplende più disastro</l>
             <l>Che ci possa sconsolar.</l>
           </sp>
-          <sp>
+          <sp who="#appolonia #gasparina #don_ettore #don_pelagio">
             <speaker rend="sc">TUTTI</speaker>
             <l>Sì viviamo tutti quanti,</l>
             <l>E finiam in lieti canti</l>

--- a/tei/anonimo-la-festa-di-susanna.xml
+++ b/tei/anonimo-la-festa-di-susanna.xml
@@ -80,6 +80,55 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="beco">
+            <persName>Beco</persName>
+          </person>
+          <person xml:id="tangoccio">
+            <persName>Tangoccio</persName>
+          </person>
+          <person xml:id="notaio">
+            <persName>Il Notaio</persName>
+          </person>
+          <person xml:id="primo_giudice">
+            <persName>Il Primo Giudice</persName>
+          </person>
+          <person xml:id="messetto">
+            <persName>Messetto</persName>
+          </person>
+          <person xml:id="secondo_giudice">
+            <persName>Il Secondo Giudice</persName>
+          </person>
+          <person xml:id="susanna">
+            <persName>Susanna</persName>
+          </person>
+          <person xml:id="giovacchino">
+            <persName>Giovacchino</persName>
+          </person>
+          <person xml:id="madre">
+            <persName>La Madre di Susanna</persName>
+          </person>
+          <person xml:id="padre">
+            <persName>Il Padre di Susanna</persName>
+          </person>
+          <person xml:id="siniscalco">
+            <persName>Il Siniscalco</persName>
+          </person>
+          <person xml:id="cavaliere">
+            <persName>Il Cavaliere</persName>
+          </person>
+          <person xml:id="daniello">
+            <persName>Daniello</persName>
+          </person>
+          <person xml:id="rufaldone">
+            <persName>Rufaldone</persName>
+          </person>
+          <person xml:id="angelo">
+            <persName>L'Angelo</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -146,7 +195,7 @@
         </argument>
         <stage>In prima comincia una questione che fanno due contadini e sì vanno a difinirla alla Ragione (cioè a que' due vecchioni che condannarono Susanna a morte e poi eglino furono lapidati), e sì giudicano che quello avea avere abbi a dare a quello a chi egli addomandava.
 <lb/>Dice quello che addomanda:</stage>
-        <sp>
+        <sp who="#beco">
           <speaker>BECO</speaker>
           <lg>
             <l>Ha' tu diliberato, o buon garzone,</l>
@@ -154,13 +203,13 @@
           </lg>
         </sp>
         <stage>Risponde Tangoccio:</stage>
-        <sp>
+        <sp who="#tangoccio">
           <speaker>TANGOCCIO</speaker>
           <l>Che va' tu anfanando, o bighellone,</l>
           <l>che trarti si vorrebbe la pazzia?</l>
         </sp>
         <stage>Risponde Beco:</stage>
-        <sp>
+        <sp who="#beco">
           <speaker>BECO</speaker>
           <l>Dunque me la vuo' mettere in quistione</l>
           <l>di tormi el mio, e farmi villania?</l>
@@ -168,7 +217,7 @@
           <l>Fellon cattivo, tu sarai impiccato!</l>
         </sp>
         <stage>Dice Tangoccio:</stage>
-        <sp>
+        <sp who="#tangoccio">
           <speaker>TANGOCCIO</speaker>
           <lg>
             <l>Oh, i' ti darò la bella batacchiata,</l>
@@ -176,29 +225,29 @@
           </lg>
         </sp>
         <stage>Risponde Beco:</stage>
-        <sp>
+        <sp who="#beco">
           <speaker>BECO</speaker>
           <l>Non ti de' ricordar della picchiata</l>
           <l>che pur l'altrier ti die' Beco del Mora?</l>
         </sp>
         <stage>Risponde Tangoccio:</stage>
-        <sp>
+        <sp who="#tangoccio">
           <speaker>TANGOCCIO</speaker>
           <l>Tu ha' ragio&lt;n&gt; che da lunge un'occhiata</l>
           <l>si senta il tuo guair giù per la gora.</l>
         </sp>
         <stage>Risponde Beco:</stage>
-        <sp>
+        <sp who="#beco">
           <speaker>BECO</speaker>
           <l>Ammicca un poco, o ladroncel da forche!</l>
         </sp>
         <stage>Dice Tangoccio:</stage>
-        <sp>
+        <sp who="#tangoccio">
           <speaker>TANGOCCIO</speaker>
           <l>Ladro se' tu, e le tuo donne porche!</l>
         </sp>
         <stage>Dice Beco:</stage>
-        <sp>
+        <sp who="#beco">
           <speaker>BECO</speaker>
           <lg>
             <l>Poiché i' veggo che tuo villania</l>
@@ -208,19 +257,19 @@
           </lg>
         </sp>
         <stage>Dice Tangoccio:</stage>
-        <sp>
+        <sp who="#tangoccio">
           <speaker>TANGOCCIO</speaker>
           <l>Deh, va' pur là, che per la tuo follia</l>
           <l>i' ti gastigherò, bel fanciulletto.</l>
         </sp>
         <stage>Risponde Beco:</stage>
-        <sp>
+        <sp who="#beco">
           <speaker>BECO</speaker>
           <l>Ben lo vedrò se mi manicherai:</l>
           <l>se tu scoppiassi,tu mi pagherai.</l>
         </sp>
         <stage>Beco va alla Ragione e dice così:</stage>
-        <sp>
+        <sp who="#beco">
           <speaker>BECO</speaker>
           <lg>
             <l>Voi siate e ben trovati tutti quanti.</l>
@@ -228,13 +277,13 @@
           </lg>
         </sp>
         <stage>Risponde el Notaio:</stage>
-        <sp>
+        <sp who="#notaio">
           <speaker>NOTAIO</speaker>
           <l>Eccogli qua, e fatti più avanti.</l>
           <l>Parla sicura a lor, se ti bisogna.</l>
         </sp>
         <stage>Beco dice così a' Giudici:</stage>
-        <sp>
+        <sp who="#beco">
           <speaker>BECO</speaker>
           <lg>
             <l>Messere, io sono un povero uom di Chianti</l>
@@ -244,7 +293,7 @@
           </lg>
         </sp>
         <stage>Risponde il Primo Giudice:</stage>
-        <sp>
+        <sp who="#primo_giudice">
           <speaker>PRIMO GIUDICE</speaker>
           <lg>
             <l>Vien qua, Notaio, fa una richiesta:</l>
@@ -252,7 +301,7 @@
           </lg>
         </sp>
         <stage>Parla il Notaio:</stage>
-        <sp>
+        <sp who="#notaio">
           <speaker>NOTAIO</speaker>
           <lg>
             <l>Vien qua, Messetto, e per Tangoccio andrai,</l>
@@ -260,7 +309,7 @@
           </lg>
         </sp>
         <stage>Risponde il Messo:</stage>
-        <sp>
+        <sp who="#messetto">
           <speaker>MESSETTO</speaker>
           <lg>
             <l>I' debbo andar tra via e chiassolini:</l>
@@ -268,7 +317,7 @@
           </lg>
         </sp>
         <stage>Giugne il Messo a casa Tangoccio:</stage>
-        <sp>
+        <sp who="#messetto">
           <speaker>MESSETTO</speaker>
           <lg>
             <l>Vienne, Tangoccio, che tu se' richiesto</l>
@@ -278,7 +327,7 @@
           </lg>
         </sp>
         <stage>Risponde Tangoccio:</stage>
-        <sp>
+        <sp who="#tangoccio">
           <speaker>TANGOCCIO</speaker>
           <lg>
             <l>Forza del mondo, oh che vorrà dir questo</l>
@@ -290,7 +339,7 @@
           </lg>
         </sp>
         <stage>Giugne Tangoccio all'Ufficio e dice così:</stage>
-        <sp>
+        <sp who="#tangoccio">
           <speaker>TANGOCCIO</speaker>
           <lg>
             <l>Dio vi salvi, Signor della Giustizia.</l>
@@ -304,7 +353,7 @@
           </lg>
         </sp>
         <stage>Dice Beco a' Giudici:</stage>
-        <sp>
+        <sp who="#beco">
           <speaker>BECO</speaker>
           <lg>
             <l>Iddio vi guardi, omin della Ragione,</l>
@@ -314,14 +363,14 @@
           </lg>
         </sp>
         <stage>Risponde Tangoccio:</stage>
-        <sp>
+        <sp who="#tangoccio">
           <speaker>TANGOCCIO</speaker>
           <l>Deh sì, ma non pigliate turbazione.</l>
           <l>Se grida un po' non vi maravigliate,</l>
           <l>ch'egli ha del pazzo, ed è quel che dich'io.</l>
         </sp>
         <stage>Risponde Beco:</stage>
-        <sp>
+        <sp who="#beco">
           <speaker>BECO</speaker>
           <l>Tu di' il vero, i' fu' pazzo a darti il mio.</l>
           <lg>
@@ -344,13 +393,13 @@
           </lg>
         </sp>
         <stage>Parla un Giudice:</stage>
-        <sp>
+        <sp who="#primo_giudice">
           <speaker>PRIMO GIUDICE</speaker>
           <l>Dite le cagion vostre, e ritenete</l>
           <l>le mani a voi, o in prigion balzerete.</l>
         </sp>
         <stage>Risponde Beco:.</stage>
-        <sp>
+        <sp who="#beco">
           <speaker>BECO</speaker>
           <lg>
             <l>Non mi posso tener che quanto chente</l>
@@ -374,7 +423,7 @@
           </lg>
         </sp>
         <stage>Parla el Primo Giudice:</stage>
-        <sp>
+        <sp who="#primo_giudice">
           <speaker>PRIMO GIUDICE</speaker>
           <lg>
             <l>A chiunque è posto per seguir ragione,</l>
@@ -388,7 +437,7 @@
           </lg>
         </sp>
         <stage>Il Primo Giudice si volge all'altro contadino e dice:</stage>
-        <sp>
+        <sp who="#primo_giudice">
           <speaker>PRIMO GIUDICE</speaker>
           <lg>
             <l>Rispondi adunque tu. Com'uomo intero,</l>
@@ -396,7 +445,7 @@
           </lg>
         </sp>
         <stage>Risponde Tangoccio:</stage>
-        <sp>
+        <sp who="#tangoccio">
           <speaker>TANGOCCIO</speaker>
           <l>Messere, io gliele niego e niego il vero,</l>
           <l>e tengo in tutto non gli avere a dare,</l>
@@ -404,13 +453,13 @@
           <l>e siate certi che nol può provare.</l>
         </sp>
         <stage>Dice uno Giudice:</stage>
-        <sp>
+        <sp who="#primo_giudice">
           <speaker>PRIMO GIUDICE</speaker>
           <l>Vedi che costui niega. Adunque pruova</l>
           <l>che tu abbi a avere: altro non giova.</l>
         </sp>
         <stage>Dice Beco al Giudice:</stage>
-        <sp>
+        <sp who="#beco">
           <speaker>BECO</speaker>
           <lg>
             <l>Io non ho pruova che 'l vedesse scorto,</l>
@@ -418,13 +467,13 @@
           </lg>
         </sp>
         <stage>Risponde uno Giudice:</stage>
-        <sp>
+        <sp who="#primo_giudice">
           <speaker>PRIMO GIUDICE</speaker>
           <l>Se tu non mostri altro, tu hai il torto:</l>
           <l>non so se pare a te, compagno mio.</l>
         </sp>
         <stage>Dice l'altro Giudice:</stage>
-        <sp>
+        <sp who="#secondo_giudice">
           <speaker>SECONDO GIUDICE</speaker>
           <l>Certo sì, tu di' il ver come uomo accorto,</l>
           <l>né altrimenti so giudicare io;</l>
@@ -432,7 +481,7 @@
           <l>che costui ch'addomanda abbi a pagare.</l>
         </sp>
         <stage>Dice il Primo Giudice al Notaio:</stage>
-        <sp>
+        <sp who="#primo_giudice">
           <speaker>PRIMO GIUDICE</speaker>
           <lg>
             <l>O prudente Notaio, el mio sermone</l>
@@ -446,7 +495,7 @@
           </lg>
         </sp>
         <stage>Dice il primo Contadino ch'addomanda, mostrandosi adirato, questa stanza:</stage>
-        <sp>
+        <sp who="#beco">
           <speaker>BECO</speaker>
           <lg>
             <l>Io ne fo boto a Dio e alle Guagnele </l>
@@ -463,7 +512,7 @@
 <lb/><foreign xml:lang="lat">Deo gratias</foreign>.
 <lb/>Or comincia la festa di Susanna.
 <lb/>I Giudici sì si parlano insieme e dice così l'uno all'altro:</stage>
-        <sp>
+        <sp who="#primo_giudice">
           <speaker>PRIMO GIUDICE</speaker>
           <lg>
             <l>E' non è, fratel mio, sotto le stelle</l>
@@ -477,7 +526,7 @@
           </lg>
         </sp>
         <stage>Risponde l'altro Giudice:</stage>
-        <sp>
+        <sp who="#secondo_giudice">
           <speaker>SECONDO GIUDICE</speaker>
           <lg>
             <l>Se gli dei vinti son per tale effetto,</l>
@@ -501,7 +550,7 @@
           </lg>
         </sp>
         <stage>Parla il Primo Giudice:</stage>
-        <sp>
+        <sp who="#primo_giudice">
           <speaker>PRIMO GIUDICE</speaker>
           <lg>
             <l>Un modo c'è: costei va nel giardino</l>
@@ -515,7 +564,7 @@
           </lg>
         </sp>
         <stage>Risponde il Secondo Giudice:</stage>
-        <sp>
+        <sp who="#secondo_giudice">
           <speaker>SECONDO GIUDICE</speaker>
           <lg>
             <l>Tu n'hai cavato el cor con tale avviso:</l>
@@ -527,13 +576,13 @@
           </lg>
         </sp>
         <stage>Risponde il Primo Giudice:</stage>
-        <sp>
+        <sp who="#primo_giudice">
           <speaker>PRIMO GIUDICE</speaker>
           <l>Deh, come hai detto ben, più non ne stiamo,</l>
           <l>ché, se si può, che presto noi v'entriamo.</l>
         </sp>
         <stage>Vanno i Giudici e nascondonsi nel giardino. Viene Susanna colle cameriere e dice:</stage>
-        <sp>
+        <sp who="#susanna">
           <speaker>SUSANNA</speaker>
           <lg>
             <l>Andate e m'arrecate l'unzïone,</l>
@@ -547,7 +596,7 @@
           </lg>
         </sp>
         <stage>Le cameriere vanno via, cioè ritornano a casa dond'ell'escono. E poi e Giudici vanno a Susanna che era alla fonte e il Primo dice così:</stage>
-        <sp>
+        <sp who="#primo_giudice">
           <speaker>PRIMO GIUDICE</speaker>
           <lg>
             <l>Amor che scalderebbe un cuor di sasso,</l>
@@ -561,7 +610,7 @@
           </lg>
         </sp>
         <stage>Dice il Secondo Giudice:</stage>
-        <sp>
+        <sp who="#secondo_giudice">
           <speaker>SECONDO GIUDICE</speaker>
           <lg>
             <l>Noi ti preghiam, Susanna, ch'acconsenti</l>
@@ -575,7 +624,7 @@
           </lg>
         </sp>
         <stage>Parla Susanna molto adirata e dice così:</stage>
-        <sp>
+        <sp who="#susanna">
           <speaker>SUSANNA</speaker>
           <lg>
             <l>Qual cechità di mente o quale errore</l>
@@ -589,7 +638,7 @@
           </lg>
         </sp>
         <stage>Parla il Primo Giudice:</stage>
-        <sp>
+        <sp who="#primo_giudice">
           <speaker>PRIMO GIUDICE</speaker>
           <lg>
             <l>Che bisogna, Susanna, far romore?</l>
@@ -599,7 +648,7 @@
           </lg>
         </sp>
         <stage>Parla Susanna:</stage>
-        <sp>
+        <sp who="#susanna">
           <speaker>SUSANNA</speaker>
           <l>Guardimi Iddio da così fatto errore,</l>
           <l>ch'io bisogno non ho di domandare,</l>
@@ -607,7 +656,7 @@
           <l>e bisogno non ho di vostre cose.</l>
         </sp>
         <stage>Parla il Secondo Giudice:</stage>
-        <sp>
+        <sp who="#secondo_giudice">
           <speaker>SECONDO GIUDICE</speaker>
           <lg>
             <l>Omè Susanna, io tel chieggo di grazia,</l>
@@ -617,7 +666,7 @@
           </lg>
         </sp>
         <stage>Parla Susanna:</stage>
-        <sp>
+        <sp who="#susanna">
           <speaker>SUSANNA</speaker>
           <l>Ed io me l'abbi innanzi a tal disgrazia!</l>
           <l>La verità d'Iddio, lucida e pura,</l>
@@ -625,7 +674,7 @@
           <l>ch'è usa a dirizzar tutti i gran torti.</l>
         </sp>
         <stage>Comincia Susanna a gridare forte e dice così:</stage>
-        <sp>
+        <sp who="#susanna">
           <speaker>SUSANNA</speaker>
           <lg>
             <l>Omè, omè, Iddio che tutto vedi,</l>
@@ -635,7 +684,7 @@
           </lg>
         </sp>
         <stage>Parla il Primo Giudice:</stage>
-        <sp>
+        <sp who="#primo_giudice">
           <speaker>PRIMO GIUDICE</speaker>
           <l>Meritrice, no' ti trovamo a' piedi</l>
           <l>quel giovinetto, e or fai ta' romori?</l>
@@ -643,7 +692,7 @@
           <l>ed or non mi vuoi dir chi e' si sia.</l>
         </sp>
         <stage>Parla il Secondo Giudice e grida fortemente e dice così:</stage>
-        <sp>
+        <sp who="#secondo_giudice">
           <speaker>SECONDO GIUDICE</speaker>
           <lg>
             <l>Oltre qua, tosto, corra&lt;n&gt; prestamente,</l>
@@ -657,7 +706,7 @@
           </lg>
         </sp>
         <stage>Qui corre tutto il popolo al romore, e così e sua di casa, e 'l Marito le parla e dice così:</stage>
-        <sp>
+        <sp who="#giovacchino">
           <speaker>GIOVACCHINO</speaker>
           <lg>
             <l>Omè, Susanna mia, io non pensai</l>
@@ -667,7 +716,7 @@
           </lg>
         </sp>
         <stage>Risponde Susanna:</stage>
-        <sp>
+        <sp who="#susanna">
           <speaker>SUSANNA</speaker>
           <l>Iddio lo sa, e tu da me il saprai:</l>
           <l>odi le mie parole tapinelle.</l>
@@ -675,7 +724,7 @@
           <l>perch'io non volli, lor m'hanno accusato.</l>
         </sp>
         <stage>Parla la Madre di Susanna a Susanna:</stage>
-        <sp>
+        <sp who="#madre">
           <speaker>MADRE</speaker>
           <lg>
             <l>Omè, figliuola mia, onesta e pura</l>
@@ -689,7 +738,7 @@
           </lg>
         </sp>
         <stage>Parla il Padre di Susanna a Susanna:</stage>
-        <sp>
+        <sp who="#padre">
           <speaker>PADRE</speaker>
           <lg>
             <l>Se tu non hai, figliuola mia, errato,</l>
@@ -699,7 +748,7 @@
           </lg>
         </sp>
         <stage>Parla Susanna:</stage>
-        <sp>
+        <sp who="#susanna">
           <speaker>SUSANNA</speaker>
           <l>E Lui ne sia lodato e ringraziato,</l>
           <l>pur male è lo innocente giudicare.</l>
@@ -707,7 +756,7 @@
           <l>che ciò ch'i' fo co' sua santi occhi vede.</l>
         </sp>
         <stage>Parlano e' Giudici, e mandano el Siniscalco per Susanna, e il Primo dice così:</stage>
-        <sp>
+        <sp who="#primo_giudice">
           <speaker>PRIMO GIUDICE</speaker>
           <lg>
             <l>Andate presto a casa Giovacchino</l>
@@ -717,7 +766,7 @@
           </lg>
         </sp>
         <stage>El Siniscalco va per Susanna e parla così a Susanna:</stage>
-        <sp>
+        <sp who="#siniscalco">
           <speaker>SINISCALCO</speaker>
           <l>Vienne, Susanna, entra con noi in cammino,</l>
           <l>che l'error tuo è chiaro e publicato;</l>
@@ -725,7 +774,7 @@
           <l>a ogni modo e' ti convien venire.</l>
         </sp>
         <stage>Parla la Madre di Susanna piangendo forte:</stage>
-        <sp>
+        <sp who="#madre">
           <speaker>MADRE</speaker>
           <lg>
             <l>O sventurata a me, per qual cagione</l>
@@ -735,7 +784,7 @@
           </lg>
         </sp>
         <stage>Parla il Padre di Susanna:</stage>
-        <sp>
+        <sp who="#padre">
           <speaker>PADRE</speaker>
           <l>Orsù, Susanna, andiàno alla Ragione.</l>
           <l>I' vo' saper per qual cosa molesta</l>
@@ -743,7 +792,7 @@
           <l>E' non ti faranno altro che il dovere.</l>
         </sp>
         <stage>Vanno alla Ragione, e Giovacchino va innanzi e dice così a' Giudici:</stage>
-        <sp>
+        <sp who="#giovacchino">
           <speaker>GIOVACCHINO</speaker>
           <lg>
             <l>Se per dritto giudicio Iddio v'ha posti</l>
@@ -757,7 +806,7 @@
           </lg>
         </sp>
         <stage>Parla il Primo Giudice:</stage>
-        <sp>
+        <sp who="#primo_giudice">
           <speaker>PRIMO GIUDICE</speaker>
           <lg>
             <l>Non è sanza cagion quel che si vede,</l>
@@ -767,7 +816,7 @@
           </lg>
         </sp>
         <stage>Parla el Padre di Susanna:</stage>
-        <sp>
+        <sp who="#padre">
           <speaker>PADRE</speaker>
           <l>Ch'ell'abbi errato, è cieco chi lo crede.</l>
           <l>I' spero in Dio che questi lacci sciolti</l>
@@ -775,7 +824,7 @@
           <l>perch'ell'è onesta, casta, pura e netta.</l>
         </sp>
         <stage>Volgonsi i Giudici a Susanna molto turbati, e il Secondo dice così:</stage>
-        <sp>
+        <sp who="#secondo_giudice">
           <speaker>SECONDO GIUDICE</speaker>
           <lg>
             <l>Perché la tua follia è manifesta,</l>
@@ -799,7 +848,7 @@
           </lg>
         </sp>
         <stage>Chiamano el Cavaliere, e il Primo Giudice dice così:</stage>
-        <sp>
+        <sp who="#primo_giudice">
           <speaker>PRIMO GIUDICE</speaker>
           <lg>
             <l>Vien qua, o Cavalier, piglia costei.</l>
@@ -813,7 +862,7 @@
           </lg>
         </sp>
         <stage>Parla il Cavalieri e chiama i famigli, o vuoi dire e birri sua:</stage>
-        <sp>
+        <sp who="#cavaliere">
           <speaker>CAVALIERE</speaker>
           <lg>
             <l>Oltre sù, franca mia compagnia,</l>
@@ -827,7 +876,7 @@
           </lg>
         </sp>
         <stage>Legano Susanna colle mani drieto. Quand'ella è legata, la Madre le dice così:</stage>
-        <sp>
+        <sp who="#madre">
           <speaker>MADRE</speaker>
           <lg>
             <l>Omè, figliuola mia, or ti conforta.</l>
@@ -841,7 +890,7 @@
           </lg>
         </sp>
         <stage>Parla Susanna a tutti i sua:</stage>
-        <sp>
+        <sp who="#susanna">
           <speaker>SUSANNA</speaker>
           <lg>
             <l>Omè, dolce Marito e car Signore,</l>
@@ -855,7 +904,7 @@
           </lg>
         </sp>
         <stage>Va Susanna alla giustizia e, quando è a mezza via, s'inginocchia e dice:</stage>
-        <sp>
+        <sp who="#susanna">
           <speaker>SUSANNA</speaker>
           <lg>
             <l>O dolcissimo Iddio, Re eternale,</l>
@@ -869,7 +918,7 @@
           </lg>
         </sp>
         <stage>Apparisce Daniello e grida forte e dice così a tutto il popolo:</stage>
-        <sp>
+        <sp who="#daniello">
           <speaker>DANIELLO</speaker>
           <lg>
             <l>O popol matto, cieco ed iscoretto,</l>
@@ -883,7 +932,7 @@
           </lg>
         </sp>
         <stage>El Cavaliere si maraviglia fortemente e dice così:</stage>
-        <sp>
+        <sp who="#cavaliere">
           <speaker>CAVALIERE</speaker>
           <lg>
             <l>Quest'è ben cosa fuor d'ogni suggello,</l>
@@ -892,14 +941,14 @@
           </lg>
         </sp>
         <stage>Risponde Daniello:</stage>
-        <sp>
+        <sp who="#daniello">
           <speaker>DANIELLO</speaker>
           <lg>
             <l>Ho nome Danïello.</l>
           </lg>
         </sp>
         <stage>&lt;El Cavaliere risponde:&gt;</stage>
-        <sp>
+        <sp who="#cavaliere">
           <speaker>CAVALIERE</speaker>
           <l>Or taci, taci, ched io nol vo' fare,</l>
           <l>ch'io ho a fare esecuzion di quello</l>
@@ -908,7 +957,7 @@
           <l>per suo peccato ha esser lapidata.</l>
         </sp>
         <stage>Parla Daniello al Cavaliere:</stage>
-        <sp>
+        <sp who="#daniello">
           <speaker>DANIELLO</speaker>
           <lg>
             <l>Ragguarda, Cavalier, l'età mia pura,</l>
@@ -922,7 +971,7 @@
           </lg>
         </sp>
         <stage>Parla il Cavaliere:</stage>
-        <sp>
+        <sp who="#cavaliere">
           <speaker>CAVALIERE</speaker>
           <lg>
             <l>I' vorrei volentieri essere stato</l>
@@ -936,7 +985,7 @@
           </lg>
         </sp>
         <stage>La Giustizia torna indietro. Parlano e Giudici al Cavaliere e il Primo dice così:</stage>
-        <sp>
+        <sp who="#primo_giudice">
           <speaker>PRIMO GIUDICE</speaker>
           <lg>
             <l>Che vuol dir questo, pazzo svemorato?</l>
@@ -946,7 +995,7 @@
           </lg>
         </sp>
         <stage>Parla el Cavaliere:</stage>
-        <sp>
+        <sp who="#cavaliere">
           <speaker>CAVALIERE</speaker>
           <l>O Signor mio, io ho tra via trovato</l>
           <l>Questo fanciul che m'ha forte invilito,</l>
@@ -954,7 +1003,7 @@
           <l>ed hammi fatto indrieto ritornare.</l>
         </sp>
         <stage>Parla il Secondo Giudice a Daniello:</stage>
-        <sp>
+        <sp who="#secondo_giudice">
           <speaker>SECONDO GIUDICE</speaker>
           <lg>
             <l>Chiarisci a noi come mal giudicato</l>
@@ -964,7 +1013,7 @@
           </lg>
         </sp>
         <stage>Parla Daniello:</stage>
-        <sp>
+        <sp who="#daniello">
           <speaker>DANIELLO</speaker>
           <l>O popol crudo, stolto e dissensato,</l>
           <l>dispartite costor, però ch'i spero</l>
@@ -972,7 +1021,7 @@
           <l>con lor gran pregiudicio e ria tristizia.</l>
         </sp>
         <stage>E levato via il Secondo Giudice, parla Daniello al Primo Giudice che è rimasto a seder e dice così:</stage>
-        <sp>
+        <sp who="#daniello">
           <speaker>DANIELLO</speaker>
           <lg>
             <l>O invecchiato di mala vecchiezza,</l>
@@ -985,12 +1034,12 @@
           </lg>
         </sp>
         <stage>Parla il Giudice:</stage>
-        <sp>
+        <sp who="#primo_giudice">
           <speaker>PRIMO GIUDICE</speaker>
           <l>Non gli vid'io? E' fu sotto el susino.</l>
         </sp>
         <stage>Parla Daniello:</stage>
-        <sp>
+        <sp who="#daniello">
           <speaker>DANIELLO</speaker>
           <lg>
             <l>Ahi fellone, la cosa è manifesta,</l>
@@ -1004,7 +1053,7 @@
           </lg>
         </sp>
         <stage>Levano via il Primo Giudice e mena&lt;no&gt; l'altro e Daniello dice così:</stage>
-        <sp>
+        <sp who="#daniello">
           <speaker>DANIELLO</speaker>
           <lg>
             <l>O simigliante al dimon dello Inferno,</l>
@@ -1017,12 +1066,12 @@
           </lg>
         </sp>
         <stage>Parla il Giudice:</stage>
-        <sp>
+        <sp who="#secondo_giudice">
           <speaker>SECONDO GIUDICE</speaker>
           <l>Nel giardin proprio a punto sotto il pino.</l>
         </sp>
         <stage>Parla Daniello:</stage>
-        <sp>
+        <sp who="#daniello">
           <speaker>DANIELLO</speaker>
           <lg>
             <l>Cattivo, doloroso, sciagurato,</l>
@@ -1036,7 +1085,7 @@
           </lg>
         </sp>
         <stage>Parla Daniello a Susanna:</stage>
-        <sp>
+        <sp who="#daniello">
           <speaker>DANIELLO</speaker>
           <lg>
             <l>Or di', Susanna, come andò la cosa,</l>
@@ -1046,7 +1095,7 @@
           </lg>
         </sp>
         <stage>Parla Susanna:</stage>
-        <sp>
+        <sp who="#susanna">
           <speaker>SUSANNA</speaker>
           <l>Presso alla fonte ch'io mi stavo in posa</l>
           <l>vennon costoro e volonmi sforzare.</l>
@@ -1054,7 +1103,7 @@
           <l>e' m'hanno a torto a morte giudicata.</l>
         </sp>
         <stage>Parla Daniello:</stage>
-        <sp>
+        <sp who="#daniello">
           <speaker>DANIELLO</speaker>
           <lg>
             <l>O popol mal usato a buon giudicio,</l>
@@ -1068,7 +1117,7 @@
           </lg>
         </sp>
         <stage>Parla Daniello e chiama il Cavaliere:</stage>
-        <sp>
+        <sp who="#daniello">
           <speaker>DANIELLO</speaker>
           <lg>
             <l>Vien qua, o Cavalier, piglia costoro.</l>
@@ -1082,7 +1131,7 @@
           </lg>
         </sp>
         <stage>Vanno e Giudici alla giustizia, e quando sono in sul monte, ai pie' della colonna, el Cavaliere dice loro così:</stage>
-        <sp>
+        <sp who="#cavaliere">
           <speaker>CAVALIERE</speaker>
           <lg>
             <l>Io non arei già mai immaginato,</l>
@@ -1091,24 +1140,24 @@
           </lg>
         </sp>
         <stage>Parla il Primo Giudice:</stage>
-        <sp>
+        <sp who="#primo_giudice">
           <speaker>PRIMO GIUDICE</speaker>
           <l>Vedi, molti altri sentimenti ha rotti.</l>
         </sp>
         <stage>Parla il Cavaliere:</stage>
-        <sp>
+        <sp who="#cavaliere">
           <speaker>CAVALIERE</speaker>
           <l>Ciascun di voi stia bene apparecchiato.</l>
           <l>Perdon vi chieggio a voi che siete dotti.</l>
         </sp>
         <stage>Parla il Secondo Giudice:</stage>
-        <sp>
+        <sp who="#secondo_giudice">
           <speaker>SECONDO GIUDICE</speaker>
           <l>Fa quel che hai a fare, o Cavalier prudente,</l>
           <l>per esempio siam qui di tutta gente.</l>
         </sp>
         <stage>Ora pigliano e manigoldi e sassi e gittangli a' Giudici e quando sono morti, el Cavaliere dice così a Rufaldone:</stage>
-        <sp>
+        <sp who="#cavaliere">
           <speaker>CAVALIERE</speaker>
           <lg>
             <l>Muoviti, Rufaldone, immantenente,</l>
@@ -1119,22 +1168,22 @@
           </lg>
         </sp>
         <stage>Parla Rufaldone:</stage>
-        <sp>
+        <sp who="#rufaldone">
           <speaker>RUFALDONE</speaker>
           <l>Io vo' far cosa che in piacer vi sia.</l>
         </sp>
         <stage>Parla il Cavaliere:</stage>
-        <sp>
+        <sp who="#cavaliere">
           <speaker>CAVALIERE</speaker>
           <l>Fa far presto a' tuo' franchi birrieri.</l>
         </sp>
         <stage>Parla Rufaldone:</stage>
-        <sp>
+        <sp who="#rufaldone">
           <speaker>RUFALDONE</speaker>
           <l>Sia fatto, Cavaliere, e volentieri.</l>
         </sp>
         <stage>Parla il Cavaliere a Daniello quando è fatta la giustizia:</stage>
-        <sp>
+        <sp who="#cavaliere">
           <speaker>CAVALIERE</speaker>
           <lg>
             <l>O mandato da Dio, ecco ch'ho fatto</l>
@@ -1148,7 +1197,7 @@
           </lg>
         </sp>
         <stage>Parla uno Angelo e licenzia il popolo:</stage>
-        <sp>
+        <sp who="#angelo">
           <speaker>ANGELO</speaker>
           <lg>
             <l>O voi egregi e franchi cittadini,</l>

--- a/tei/anonimo-la-rappresentazione-della-nativita-di-nostro-signore-gesu-cristo.xml
+++ b/tei/anonimo-la-rappresentazione-della-nativita-di-nostro-signore-gesu-cristo.xml
@@ -79,6 +79,58 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="angelo_annunciatore">
+            <persName>L'Angelo che annuncia la festa</persName>
+          </person>
+          <person xml:id="imperatore">
+            <persName>L'Imperatore Ottaviano Augusto Cesare</persName>
+          </person>
+          <person xml:id="maestro">
+            <persName>Un Maestro de murare</persName>
+          </person>
+          <person xml:id="sacerdote">
+            <persName>Un Sacerdote</persName>
+          </person>
+          <person xml:id="popolano">
+            <persName>Un Popolano</persName>
+          </person>
+          <personGrp xml:id="sacerdoti">
+            <name>Sacerdoti</name>
+          </personGrp>
+          <person xml:id="porfirio">
+            <persName>Porfirio</persName>
+          </person>
+          <person xml:id="sibilla">
+            <persName>La Sibilla</persName>
+          </person>
+          <personGrp xml:id="banditori">
+            <name>I Banditori</name>
+          </personGrp>
+          <personGrp xml:id="savi">
+            <name>Savi</name>
+          </personGrp>
+          <person xml:id="primo_pastore">
+            <persName>Primo Pastore</persName>
+          </person>
+          <person xml:id="secondo_pastore">
+            <persName>Secondo Pastore</persName>
+          </person>
+          <person xml:id="giuseppe">
+            <persName>Giuseppe</persName>
+          </person>
+          <person xml:id="maria">
+            <persName>La Vergine Maria</persName>
+          </person>
+          <personGrp xml:id="araldi">
+            <name>Gli Araldi</name>
+          </personGrp>
+          <person xml:id="angelo_che_licenzia">
+            <persName>Un Angelo che licenzia il popolo</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -115,9 +167,7 @@
         <castItem>
           <role>Un Popolano</role>
         </castItem>
-        <castItem>
-          <role>Porfirio</role>, <roleDesc><hi rend="italic">un barone</hi></roleDesc>
-        </castItem>
+        <castItem><role>Porfirio</role>, <roleDesc><hi rend="italic">un barone</hi></roleDesc></castItem>
         <castItem>
           <role>La Sibilla</role>
         </castItem>
@@ -149,7 +199,7 @@
         <stage>QUESTA È LA RAPPRESENTAZIONE DELLA NATIVITÀ DEL NOSTRO SIGNORE
 GESÙ CRISTO, E IN PRIMA VIENE UNO ANGELO ED ANNUNZIA LA FESTA AL POPOLO
 E DICE COSÌ:</stage>
-        <sp>
+        <sp who="#angelo_annunciatore">
           <speaker>ANGELO ANNUNCIATORE</speaker>
           <lg>
             <l>Al nome sia del sommo Redentore,</l>
@@ -193,7 +243,7 @@ E DICE COSÌ:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Parla lo 'Mperadore a' Maestri</hi>:</stage>
-        <sp>
+        <sp who="#imperatore">
           <speaker>IMPERATORE</speaker>
           <lg>
             <l>Quanto potrà questo tempio durare</l>
@@ -203,7 +253,7 @@ E DICE COSÌ:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde un Maestro de murare allo 'Mperadore</hi>:</stage>
-        <sp>
+        <sp who="#maestro">
           <speaker>MAESTRO</speaker>
           <lg>
             <l>Di questo non bisogna ragionare,</l>
@@ -213,7 +263,7 @@ E DICE COSÌ:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde lo 'Mperadore a' Maestri</hi>:</stage>
-        <sp>
+        <sp who="#imperatore">
           <speaker>IMPERATORE</speaker>
           <lg>
             <l>Maestri miei, dunque non cadrà mai</l>
@@ -227,7 +277,7 @@ E DICE COSÌ:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Parla un Sacerdote al popolo, fatto il sacrificio</hi>:</stage>
-        <sp>
+        <sp who="#sacerdote">
           <speaker>SACERDOTE</speaker>
           <lg>
             <l>Che altra deità si può stimare</l>
@@ -272,7 +322,7 @@ E DICE COSÌ:</stage>
         </sp>
         <stage><hi rend="italic">Parla uno Popolano al Sacerdote, confermando il suo
 detto</hi>:</stage>
-        <sp>
+        <sp who="#popolano">
           <speaker>POPOLANO</speaker>
           <lg>
             <l>Qualunque uomo saggio e d'intelletto</l>
@@ -286,7 +336,7 @@ detto</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Parla uno Sacerdote allo 'Mperadore</hi>:</stage>
-        <sp>
+        <sp who="#sacerdote">
           <speaker>SACERDOTE</speaker>
           <lg>
             <l>O santo Imperador, nobilitato</l>
@@ -300,7 +350,7 @@ detto</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde lo 'Mperadore al Sacerdote ed al popolo</hi>:</stage>
-        <sp>
+        <sp who="#imperatore">
           <speaker>IMPERATORE</speaker>
           <lg>
             <l>I' non so che partito in ciò pigliarmi,</l>
@@ -314,7 +364,7 @@ detto</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Rispondono i Sacerdoti allo Imperadore</hi>:</stage>
-        <sp>
+        <sp who="#sacerdoti">
           <speaker>SACERDOTI</speaker>
           <lg>
             <l>Noi siàn contenti, e tre giorni stareno,</l>
@@ -329,7 +379,7 @@ detto</hi>:</stage>
         </sp>
         <stage><hi rend="italic">Partiti i Sacerdoti e Dottori, lo 'Mperadore dice infra sé medesimo
 così</hi>:</stage>
-        <sp>
+        <sp who="#imperatore">
           <speaker>IMPERATORE</speaker>
           <lg>
             <l>Come esser può ch'io sia adorato,</l>
@@ -350,7 +400,7 @@ così</hi>:</stage>
         </sp>
         <stage><hi rend="italic">Lo 'Mperadore chiama un Barone e manda per la Sibilla e
 dice</hi>:</stage>
-        <sp>
+        <sp who="#imperatore">
           <speaker>IMPERATORE</speaker>
           <lg>
             <l>Muovi Porfirio e fa che prestamente</l>
@@ -358,7 +408,7 @@ dice</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde Porfirio</hi>:</stage>
-        <sp>
+        <sp who="#porfirio">
           <speaker>PORFIRIO</speaker>
           <lg>
             <l>Fatt'è, Signor, ecco ch'i' entro in via,</l>
@@ -366,7 +416,7 @@ dice</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Parla Porfirio alla Sibilla</hi>:</stage>
-        <sp>
+        <sp who="#porfirio">
           <speaker>PORFIRIO</speaker>
           <lg>
             <l>Vergine pura, onesta e benedetta,</l>
@@ -376,7 +426,7 @@ dice</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde la Sibilla a Porfirio</hi>:</stage>
-        <sp>
+        <sp who="#sibilla">
           <speaker>SIBILLA</speaker>
           <lg>
             <l>Ciò ch'io far possa forte mi diletta,</l>
@@ -386,7 +436,7 @@ dice</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Parla la Sibilla allo Imperadore</hi>:</stage>
-        <sp>
+        <sp who="#sibilla">
           <speaker>SIBILLA</speaker>
           <lg>
             <l>O degno e magno Imperador sereno,</l>
@@ -396,7 +446,7 @@ dice</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde lo 'Mperadore alla Sibilla</hi>:</stage>
-        <sp>
+        <sp who="#imperatore">
           <speaker>IMPERATORE</speaker>
           <lg>
             <l>Tu sia la ben venuta, ed or sareno</l>
@@ -406,7 +456,7 @@ dice</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde la Sibilla allo Imperadore</hi>:</stage>
-        <sp>
+        <sp who="#sibilla">
           <speaker>SIBILLA</speaker>
           <lg>
             <l>Se tu vuogli in segreto consigliarti</l>
@@ -416,7 +466,7 @@ dice</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde lo 'Mperadore alla Sibilla</hi>:</stage>
-        <sp>
+        <sp who="#imperatore">
           <speaker>IMPERATORE</speaker>
           <lg>
             <l>Io son contento e sol per contentarti</l>
@@ -426,7 +476,7 @@ dice</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Sono in segreto luogo e lo 'Mperadore parla alla Sibilla</hi>:</stage>
-        <sp>
+        <sp who="#imperatore">
           <speaker>IMPERATORE</speaker>
           <lg>
             <l>El mondo tutto cerca d'adorarmi,</l>
@@ -440,7 +490,7 @@ dice</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde la Sibilla allo 'Mperadore</hi>:</stage>
-        <sp>
+        <sp who="#sibilla">
           <speaker>SIBILLA</speaker>
           <lg>
             <l>Quest'è gran cosa solo a 'mmaginarla,</l>
@@ -454,7 +504,7 @@ dice</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Chiama lo 'Mperadore e Banditori</hi>:</stage>
-        <sp>
+        <sp who="#imperatore">
           <speaker>IMPERATORE</speaker>
           <lg>
             <l>Passin qua con prestezza i banditori.</l>
@@ -464,7 +514,7 @@ dice</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Rispondono i Banditori allo 'Mperadore</hi>:</stage>
-        <sp>
+        <sp who="#banditori">
           <speaker>BANDITORI</speaker>
           <lg>
             <l>Per tutta Roma farem pubblicare</l>
@@ -473,7 +523,7 @@ dice</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">I Banditori bandiscono al popolo</hi>:</stage>
-        <sp>
+        <sp who="#banditori">
           <speaker>BANDITORI</speaker>
           <lg>
             <l>Fa metter bando 'spresso e comandare</l>
@@ -487,7 +537,7 @@ dice</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Parlano i Banditori allo 'Mperadore</hi>:</stage>
-        <sp>
+        <sp who="#banditori">
           <speaker>BANDITORI</speaker>
           <lg>
             <l>Per tutta Roma siàno iti sonando,</l>
@@ -497,7 +547,7 @@ dice</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Dice lo 'Mperadore a' Savi suo'</hi>:</stage>
-        <sp>
+        <sp who="#imperatore">
           <speaker>IMPERATORE</speaker>
           <lg>
             <l>Or oltre sù, seguite il mio comando,</l>
@@ -507,7 +557,7 @@ dice</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Rispondono i Savi allo 'Mperadore</hi>:</stage>
-        <sp>
+        <sp who="#savi">
           <speaker>SAVI</speaker>
           <lg>
             <l>Fatt'è, Signore , e prestamente andreno</l>
@@ -517,7 +567,7 @@ dice</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Parlano i Savi alla Sibilla</hi>:</stage>
-        <sp>
+        <sp who="#savi">
           <speaker>SAVI</speaker>
           <lg>
             <l>L'eccelso illustre Imperador sereno</l>
@@ -527,7 +577,7 @@ dice</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde la Sibilla a' Savi</hi>:</stage>
-        <sp>
+        <sp who="#sibilla">
           <speaker>SIBILLA</speaker>
           <lg>
             <l>Andiàn ch'i' son contenta di venire,</l>
@@ -537,7 +587,7 @@ dice</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Giugne la Sibilla allo 'Mperadore</hi>:</stage>
-        <sp>
+        <sp who="#sibilla">
           <speaker>SIBILLA</speaker>
           <lg>
             <l>O magnanimo Imperio e giusto Sire,</l>
@@ -547,7 +597,7 @@ dice</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde lo 'Mperadore alla Sibilla</hi>:</stage>
-        <sp>
+        <sp who="#imperatore">
           <speaker>IMPERATORE</speaker>
           <lg>
             <l>Tanto m'è grato il tuo ritornamento</l>
@@ -557,7 +607,7 @@ dice</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde la Sibilla allo Imperadore</hi>:</stage>
-        <sp>
+        <sp who="#sibilla">
           <speaker>SIBILLA</speaker>
           <lg>
             <l>Lodiamo Iddio e poi di buon talento</l>
@@ -573,7 +623,7 @@ dice</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde lo 'Mperadore alla Sibilla</hi>:</stage>
-        <sp>
+        <sp who="#imperatore">
           <speaker>IMPERATORE</speaker>
           <lg>
             <l>Andiàn che tal disio in me raccogli</l>
@@ -582,7 +632,7 @@ dice</hi>:</stage>
         </sp>
         <stage><hi rend="italic">Parla lo 'Mperadore alla Sibilla quando sono giunti in luogo arioso e
 aperto</hi>:</stage>
-        <sp>
+        <sp who="#imperatore">
           <speaker>IMPERATORE</speaker>
           <lg>
             <l>Vedi quant'aria c'è, pura e serena?</l>
@@ -590,7 +640,7 @@ aperto</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Parla la Sibilla allo Imperadore</hi>:</stage>
-        <sp>
+        <sp who="#sibilla">
           <speaker>SIBILLA</speaker>
           <lg>
             <l>Or fa com'io, ve' ch'i' sono scalzata</l>
@@ -600,7 +650,7 @@ aperto</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde lo 'Mperadore alla Sibilla</hi>:</stage>
-        <sp>
+        <sp who="#imperatore">
           <speaker>IMPERATORE</speaker>
           <lg>
             <l>I' veggo l'aria bella, pura e grata,</l>
@@ -608,7 +658,7 @@ aperto</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde la Sibilla allo 'Mperadore</hi>:</stage>
-        <sp>
+        <sp who="#sibilla">
           <speaker>SIBILLA</speaker>
           <lg>
             <l>Di poi che l'aria è cosi graziosa,</l>
@@ -616,7 +666,7 @@ aperto</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde lo 'Mperadore</hi>:</stage>
-        <sp>
+        <sp who="#imperatore">
           <speaker>IMPERATORE</speaker>
           <lg>
             <l>Io veggo l'aria bella e dilicata,</l>
@@ -626,7 +676,7 @@ aperto</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde la Sibilla allo Imperadore</hi>:</stage>
-        <sp>
+        <sp who="#sibilla">
           <speaker>SIBILLA</speaker>
           <lg>
             <l>Or pon la pianta ritta tua scalzata</l>
@@ -636,7 +686,7 @@ aperto</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde lo 'Mperadore alla Sibilla</hi>:</stage>
-        <sp>
+        <sp who="#imperatore">
           <speaker>IMPERATORE</speaker>
           <lg>
             <l>I' veggo un cerchio sì maraviglioso</l>
@@ -646,7 +696,7 @@ aperto</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde la Sibilla allo 'Mperadore</hi>:</stage>
-        <sp>
+        <sp who="#sibilla">
           <speaker>SIBILLA</speaker>
           <lg>
             <l>Guardal pur bene e infin ch'i' non ti poso.</l>
@@ -654,7 +704,7 @@ aperto</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde lo 'Mperadore alla Sibilla</hi>:</stage>
-        <sp>
+        <sp who="#imperatore">
           <speaker>IMPERATORE</speaker>
           <lg>
             <l>Nel cerchio d'or prima non era nulla,</l>
@@ -662,7 +712,7 @@ aperto</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde la Sibilla allo 'Mperadore</hi>:</stage>
-        <sp>
+        <sp who="#sibilla">
           <speaker>SIBILLA</speaker>
           <lg>
             <l>Che fanciulla è, per Dio, polla ben mente</l>
@@ -670,7 +720,7 @@ aperto</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde lo 'Mperadore alla Sibilla</hi>:</stage>
-        <sp>
+        <sp who="#imperatore">
           <speaker>IMPERATORE</speaker>
           <lg>
             <l>In abito ed in vista ell'è lucente,</l>
@@ -682,7 +732,7 @@ aperto</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde la Sibilla allo Imperadore</hi>:</stage>
-        <sp>
+        <sp who="#sibilla">
           <speaker>SIBILLA</speaker>
           <lg>
             <l>Che bambino è? Come ti par formato?</l>
@@ -690,7 +740,7 @@ aperto</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde lo 'Mperadore alla Sibilla</hi>:</stage>
-        <sp>
+        <sp who="#imperatore">
           <speaker>IMPERATORE</speaker>
           <lg>
             <l>D'una corona d'oro il veggio ornato</l>
@@ -698,7 +748,7 @@ aperto</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde la Sibilla allo Imperadore</hi>:</stage>
-        <sp>
+        <sp who="#sibilla">
           <speaker>SIBILLA</speaker>
           <lg>
             <l>Or guardal ben, ched io te l'ho mostrato:</l>
@@ -708,7 +758,7 @@ aperto</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Parla pure la Sibilla allo 'Mperadore</hi>:</stage>
-        <sp>
+        <sp who="#sibilla">
           <speaker>SIBILLA</speaker>
           <lg>
             <l>Però, o Imperadore, è tempo omai</l>
@@ -722,7 +772,7 @@ aperto</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde lo 'Mperadore alla Sibilla</hi>:</stage>
-        <sp>
+        <sp who="#imperatore">
           <speaker>IMPERATORE</speaker>
           <lg>
             <l><add resp="#ed">O</add> vergine prudente e benedetta,</l>
@@ -737,7 +787,7 @@ aperto</hi>:</stage>
         </sp>
         <stage><hi rend="italic">Partita la Sibilla, ritornano i Sacerdoti ed il popolo allo Imperadore ed a
 lui parlano così dicendo</hi>:</stage>
-        <sp>
+        <sp who="#sacerdoti">
           <speaker>SACERDOTI</speaker>
           <lg>
             <l>Temp'è, sereno grande Imperadore,</l>
@@ -751,7 +801,7 @@ lui parlano così dicendo</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde lo 'Mperadore a' Sacerdoti ed al popolo</hi>:</stage>
-        <sp>
+        <sp who="#imperatore">
           <speaker>IMPERATORE</speaker>
           <lg>
             <l>Quel vivo e vero Iddio immaculato</l>
@@ -771,7 +821,7 @@ lui parlano così dicendo</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Rispondono i Savi allo Imperadore</hi>:</stage>
-        <sp>
+        <sp who="#savi">
           <speaker>SAVI</speaker>
           <lg>
             <l>No' siàn contenti poi ch'a te non pare,</l>
@@ -782,7 +832,7 @@ lui parlano così dicendo</hi>:</stage>
         </sp>
         <stage><hi rend="italic">E parlato i Savi allo Imperadore, di subito roina il tempio e la Natività del
 Nostro Signore apparisce, e di poi va l'Angelo a' Pastori e parla loro così</hi>:</stage>
-        <sp>
+        <sp who="#angelo_annunciatore">
           <speaker>ANGELO</speaker>
           <lg>
             <l>Gloria sia in cielo al sempiterno Iddio,</l>
@@ -806,7 +856,7 @@ Nostro Signore apparisce, e di poi va l'Angelo a' Pastori e parla loro così</hi
           </lg>
         </sp>
         <stage><hi rend="italic">Parlano i Pastori tra loro e 'l primo dice</hi>:</stage>
-        <sp>
+        <sp who="#primo_pastore">
           <speaker>PRIMO PASTORE</speaker>
           <lg>
             <l>Chi è costui che ci manda a cittade?</l>
@@ -814,7 +864,7 @@ Nostro Signore apparisce, e di poi va l'Angelo a' Pastori e parla loro così</hi
           </lg>
         </sp>
         <stage><hi rend="italic">Parla l'altro Pastore</hi>:</stage>
-        <sp>
+        <sp who="#secondo_pastore">
           <speaker>SECONDO PASTORE</speaker>
           <lg>
             <l>S'egli è nata la santa Maestade,</l>
@@ -822,7 +872,7 @@ Nostro Signore apparisce, e di poi va l'Angelo a' Pastori e parla loro così</hi
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde l'altro</hi>:</stage>
-        <sp>
+        <sp who="#primo_pastore">
           <speaker>PRIMO PASTORE</speaker>
           <lg>
             <l>Chi fia di noi che sappi queste strade</l>
@@ -830,21 +880,21 @@ Nostro Signore apparisce, e di poi va l'Angelo a' Pastori e parla loro così</hi
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde l'altro</hi>:</stage>
-        <sp>
+        <sp who="#secondo_pastore">
           <speaker>SECONDO PASTORE</speaker>
           <lg>
             <l>Meo del Giambarda la saprà di fatto.</l>
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde l'altro</hi>:</stage>
-        <sp>
+        <sp who="#primo_pastore">
           <speaker>PRIMO PASTORE</speaker>
           <lg>
             <l>To' due caciuoli, ognun ne venga ratto.</l>
           </lg>
         </sp>
         <stage><hi rend="italic">Parla uno Pastore a Gesù</hi>:</stage>
-        <sp>
+        <sp who="#primo_pastore">
           <speaker>PRIMO PASTORE</speaker>
           <lg>
             <l>Salviti Iddio, che se' nostro Signore,</l>
@@ -854,7 +904,7 @@ Nostro Signore apparisce, e di poi va l'Angelo a' Pastori e parla loro così</hi
           </lg>
         </sp>
         <stage><hi rend="italic">Parla uno Pastore alla Vergine Maria</hi>:</stage>
-        <sp>
+        <sp who="#primo_pastore">
           <speaker>PRIMO PASTORE</speaker>
           <lg>
             <l>O santa Madre, panni di colore</l>
@@ -864,7 +914,7 @@ Nostro Signore apparisce, e di poi va l'Angelo a' Pastori e parla loro così</hi
           </lg>
         </sp>
         <stage><hi rend="italic">Parla l'altro Pastore a Gesù</hi>:</stage>
-        <sp>
+        <sp who="#secondo_pastore">
           <speaker>SECONDO PASTORE</speaker>
           <lg>
             <l>Die ti salvi, Signor di tutto il mondo,</l>
@@ -878,7 +928,7 @@ Nostro Signore apparisce, e di poi va l'Angelo a' Pastori e parla loro così</hi
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde Giuseppe a' Pastori</hi>:</stage>
-        <sp>
+        <sp who="#giuseppe">
           <speaker>GIUSEPPE</speaker>
           <lg>
             <l>Vo' siate, pastor giusti, e ben venuti</l>
@@ -892,7 +942,7 @@ Nostro Signore apparisce, e di poi va l'Angelo a' Pastori e parla loro così</hi
           </lg>
         </sp>
         <stage><hi rend="italic">Parla la Vergine Maria a' Pastori</hi>:</stage>
-        <sp>
+        <sp who="#maria">
           <speaker>MARIA</speaker>
           <lg>
             <l>Buoni pastor, venuti dalle gregge</l>
@@ -907,7 +957,7 @@ Nostro Signore apparisce, e di poi va l'Angelo a' Pastori e parla loro così</hi
         </sp>
         <stage><hi rend="italic">Parla lo 'Mperadore fra sé medesimo quando vede caduto il tempio e dice,
 quando vede esser fornito il misterio della Natività interamente</hi>:</stage>
-        <sp>
+        <sp who="#imperatore">
           <speaker>IMPERATORE</speaker>
           <lg>
             <l>Per certo, poi che 'l tempio è ruinato,</l>
@@ -917,7 +967,7 @@ quando vede esser fornito il misterio della Natività interamente</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Manda lo 'Mperadore pe' Savi e dice così</hi>:</stage>
-        <sp>
+        <sp who="#imperatore">
           <speaker>IMPERATORE</speaker>
           <lg>
             <l>O voi ch'avete sempre mai studiato</l>
@@ -927,7 +977,7 @@ quando vede esser fornito il misterio della Natività interamente</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Rispondono i Savi allo Imperadore</hi>:</stage>
-        <sp>
+        <sp who="#savi">
           <speaker>SAVI</speaker>
           <lg>
             <l>O santo Imperador, chi 'l 'dificoe</l>
@@ -941,7 +991,7 @@ quando vede esser fornito il misterio della Natività interamente</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde lo 'Mperadore a' Savi</hi>:</stage>
-        <sp>
+        <sp who="#imperatore">
           <speaker>IMPERATORE</speaker>
           <lg>
             <l>Or son io chiaro che lo Spirito Santo</l>
@@ -955,7 +1005,7 @@ quando vede esser fornito il misterio della Natività interamente</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Parla lo 'Mperadore agli Araldi</hi>:</stage>
-        <sp>
+        <sp who="#imperatore">
           <speaker>IMPERATORE</speaker>
           <lg>
             <l>E però festa grande oggi facciamo</l>
@@ -968,14 +1018,14 @@ quando vede esser fornito il misterio della Natività interamente</hi>:</stage>
           </lg>
         </sp>
         <stage><hi rend="italic">Rispondono gli Araldi allo Imperadore</hi>:</stage>
-        <sp>
+        <sp who="#araldi">
           <speaker>ARALDI</speaker>
           <lg>
             <l>Egli è fatto, sereno Imperadore.</l>
           </lg>
         </sp>
         <stage><hi rend="italic">Parla un Angelo licenziando il popolo</hi>:</stage>
-        <sp>
+        <sp who="#angelo_che_licenzia">
           <speaker>ANGELO CHE LICENZIA</speaker>
           <lg>
             <l>O voi, egregi e saggi cittadini,</l>

--- a/tei/anonimo-la-rappresentazione-di-josef-di-jacob-e-de-fratelli.xml
+++ b/tei/anonimo-la-rappresentazione-di-josef-di-jacob-e-de-fratelli.xml
@@ -79,6 +79,70 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="angelo_annunciatore">
+            <persName>L'Angelo che annuncia</persName>
+          </person>
+          <person xml:id="josef">
+            <persName>Josef</persName>
+          </person>
+          <personGrp xml:id="fratelli">
+            <name>Gli Undici Fratelli di Josef</name>
+          </personGrp>
+          <person xml:id="jacob">
+            <persName>Jacob</persName>
+          </person>
+          <person xml:id="uomo">
+            <persName>Un Uomo arante</persName>
+          </person>
+          <person xml:id="ruben">
+            <persName>Ruben</persName>
+          </person>
+          <person xml:id="juda">
+            <persName>Juda</persName>
+          </person>
+          <person xml:id="mercatante">
+            <persName>Mercatante</persName>
+          </person>
+          <person xml:id="altro_mercatante">
+            <persName>Altro Mercatante</persName>
+          </person>
+          <person xml:id="putifar">
+            <persName>Putifar</persName>
+          </person>
+          <person xml:id="reina">
+            <persName>La Reina del Re Faraone</persName>
+          </person>
+          <person xml:id="re_faraone">
+            <persName>Il Re Faraone</persName>
+          </person>
+          <person xml:id="carceriere">
+            <persName>Il Carceriere</persName>
+          </person>
+          <person xml:id="servidore_di_coppa">
+            <persName>Il Servidore di Coppa</persName>
+          </person>
+          <person xml:id="servidore_del_re">
+            <persName>Il Servidore del Re</persName>
+          </person>
+          <person xml:id="panattiere">
+            <persName>Il Panattiere</persName>
+          </person>
+          <person xml:id="savio">
+            <persName>Savio</persName>
+          </person>
+          <person xml:id="interprete">
+            <persName>L'interprete del Re</persName>
+          </person>
+          <person xml:id="dispensatore">
+            <persName>Il Dispensiere di Josef</persName>
+          </person>
+          <person xml:id="altro_angelo">
+            <persName>L'Angelo che licenzia il popolo</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -154,7 +218,7 @@
     <body>
       <div n="La rappresentazione di Josef, di Jacob e de' fratelli">
         <stage rend="italic">In prima viene uno Angelo e annunzia dicendo:</stage>
-        <sp>
+        <sp who="#angelo_annunciatore">
           <speaker rend="sc">ANGELO ANNUNCIATORE</speaker>
           <lg>
             <l>A laude de l'immenso eterno Dio,</l>
@@ -178,7 +242,7 @@
           </lg>
         </sp>
         <stage rend="italic">Josef d'età d'anni xvi rivela a' suoi Fratelli uno suo sogno dicendo:</stage>
-        <sp>
+        <sp who="#josef">
           <speaker rend="sc">JOSEF</speaker>
           <lg>
             <l>Deh, udite, fratelli, 'l sogno mio</l>
@@ -192,7 +256,7 @@
           </lg>
         </sp>
         <stage rend="italic">Uno de' Fratelli d'Josef per tutti al sogno risponde:</stage>
-        <sp>
+        <sp who="#fratelli">
           <speaker rend="sc">FRATELLI</speaker>
           <lg>
             <l>Adunque sara' tu el nostro sire</l>
@@ -206,7 +270,7 @@
           </lg>
         </sp>
         <stage rend="italic">Josef dice un altro suo sogno altra volta al Padre e a&lt;lla&gt; Madre e a' suo' Fratelli insieme:</stage>
-        <sp>
+        <sp who="#josef">
           <speaker rend="sc">JOSEF</speaker>
           <lg>
             <l>I' vidi quasi il sole e la luna</l>
@@ -216,7 +280,7 @@
           </lg>
         </sp>
         <stage rend="italic">Jacob dice a Josef:</stage>
-        <sp>
+        <sp who="#jacob">
           <speaker rend="sc">JACOB</speaker>
           <lg>
             <l>Che sogno vedi tu per una cruna?</l>
@@ -226,7 +290,7 @@
           </lg>
         </sp>
         <stage rend="italic">Jacob in altro tempo dice a Josef:</stage>
-        <sp>
+        <sp who="#jacob">
           <speaker rend="sc">JACOB</speaker>
           <lg>
             <l>E tuo' fratelli insin che e' fur mandati</l>
@@ -236,7 +300,7 @@
           </lg>
         </sp>
         <stage rend="italic">Josef risponde a Jacob così:</stage>
-        <sp>
+        <sp who="#josef">
           <speaker rend="sc">JOSEF</speaker>
           <lg>
             <l>Eccomi con arnesi apparecchiati</l>
@@ -244,7 +308,7 @@
           </lg>
         </sp>
         <stage rend="italic">Jacob a Josef:</stage>
-        <sp>
+        <sp who="#jacob">
           <speaker rend="sc">JACOB</speaker>
           <lg>
             <l>Rapporta a me come prospero sia</l>
@@ -252,7 +316,7 @@
           </lg>
         </sp>
         <stage rend="italic">Andando Josef a' Fratelli truova uno Uomo arante che dice a Josef:</stage>
-        <sp>
+        <sp who="#uomo">
           <speaker rend="sc">UOMO</speaker>
           <lg>
             <l>O dove vai, garzon? che vai cercando?</l>
@@ -260,7 +324,7 @@
           </lg>
         </sp>
         <stage rend="italic">Josef risponde allo Arante:</stage>
-        <sp>
+        <sp who="#josef">
           <speaker rend="sc">JOSEF</speaker>
           <lg>
             <l>De' mie' fratelli io addomando:</l>
@@ -268,7 +332,7 @@
           </lg>
         </sp>
         <stage rend="italic">L'Arante dice a Josef:</stage>
-        <sp>
+        <sp who="#uomo">
           <speaker rend="sc">UOMO</speaker>
           <lg>
             <l>Di questo loco si partiron quando</l>
@@ -278,7 +342,7 @@
           </lg>
         </sp>
         <stage rend="italic">Uno de' Fratelli di Josef, vedendolo da lungi venire verso loro, pensando d'ucciderlo innanzi che giunga a loro, agli altri Fratelli dice accennandolo:</stage>
-        <sp>
+        <sp who="#fratelli">
           <speaker rend="sc"> FRATELLI</speaker>
           <lg>
             <l>Ecco che viene a noi el sognatore.</l>
@@ -292,7 +356,7 @@
           </lg>
         </sp>
         <stage rend="italic">Rubem, uno de' Fratelli, per liberarlo da morte, dice agli altri Fratelli:</stage>
-        <sp>
+        <sp who="#ruben">
           <speaker rend="sc">RUBEN</speaker>
           <lg>
             <l>Non l'uccidiàn ché l'anima è eterna,</l>
@@ -306,7 +370,7 @@
           </lg>
         </sp>
         <stage rend="italic">Giunto Josef a' Fratelli, lo spogliano, non vi sendo Rubem, della sua gonnella freg&lt;i&gt;ata e mettonlo nella cisterna; poi mangiando viddono passare Mercatanti smaelliti per andare in Egitto, e Juda dice a' Fratelli così:</stage>
-        <sp>
+        <sp who="#juda">
           <speaker rend="sc">JUDA</speaker>
           <lg>
             <l>Che pro farà a noi se uccidiamo</l>
@@ -318,7 +382,7 @@
           </lg>
         </sp>
         <stage rend="italic">Uno degli altri Fratelli risponde a Juda così per tutti:</stage>
-        <sp>
+        <sp who="#fratelli">
           <speaker rend="sc">FRATELLI</speaker>
           <lg>
             <l>Ciascun di noi al tuo dire consente:</l>
@@ -326,7 +390,7 @@
           </lg>
         </sp>
         <stage rend="italic">Tratto Josef della Citerna, Juda dice a' Mercatanti così:</stage>
-        <sp>
+        <sp who="#juda">
           <speaker rend="sc">JUDA</speaker>
           <lg>
             <l>Che ci volete dar se quel garzone</l>
@@ -336,7 +400,7 @@
           </lg>
         </sp>
         <stage rend="italic">Uno de' Mercatanti per tutti risponde a Juda:</stage>
-        <sp>
+        <sp who="#mercatante">
           <speaker rend="sc">MERCATANTE</speaker>
           <lg>
             <l>Trenta danar d'argento si dispone</l>
@@ -344,7 +408,7 @@
           </lg>
         </sp>
         <stage rend="italic">Juda a' Mercatanti risponde:</stage>
-        <sp>
+        <sp who="#juda">
           <speaker rend="sc">JUDA</speaker>
           <lg>
             <l>Noi siàn contenti per quel prezzo dare</l>
@@ -352,7 +416,7 @@
           </lg>
         </sp>
         <stage rend="italic">Josef, vedendosi venduto, dice a' Fratelli:</stage>
-        <sp>
+        <sp who="#josef">
           <speaker rend="sc">JOSEF</speaker>
           <lg>
             <l>Iddio m'aiuti, io non so dov'io vada!</l>
@@ -366,7 +430,7 @@
           </lg>
         </sp>
         <stage rend="italic">Tornando Rubem alla cisterna, che non trovò alla vendita d' Josef, e non trovandolo, stracciasi le vestimenta ed a' Fratelli dice:</stage>
-        <sp>
+        <sp who="#ruben">
           <speaker rend="sc">RUBEN</speaker>
           <lg>
             <l>Quel fanciullo, fratelli miei cari,</l>
@@ -376,7 +440,7 @@
           </lg>
         </sp>
         <stage rend="italic">Uno di loro risponde a Rubem ed agli altri insieme:</stage>
-        <sp>
+        <sp who="#fratelli">
           <speaker rend="sc">FRATELLI</speaker>
           <lg>
             <l>Deh, non vogliàn nostro parlar divari.</l>
@@ -386,7 +450,7 @@
           </lg>
         </sp>
         <stage rend="italic">Insanguinata la vesta d'Josef con sangue di capretto, la portano al Padre e uno di loro dice al Padre:</stage>
-        <sp>
+        <sp who="#fratelli">
           <speaker rend="sc">FRATELLI</speaker>
           <lg>
             <l>Con gran dolor no' ti rechiàn la vesta</l>
@@ -396,7 +460,7 @@
           </lg>
         </sp>
         <stage rend="italic">El Padre, squarciandosi e suo' panni, dice:</stage>
-        <sp>
+        <sp who="#jacob">
           <speaker rend="sc">JACOB</speaker>
           <lg>
             <l>Oimè lasso, che novella è questa?</l>
@@ -406,7 +470,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde uno per tutti e conforta el Padre:</stage>
-        <sp>
+        <sp who="#fratelli">
           <speaker rend="sc">FRATELLI</speaker>
           <lg>
             <l>Perché la morte è comune a ciascuno,</l>
@@ -420,7 +484,7 @@
           </lg>
         </sp>
         <stage rend="italic">Jacob risponde a' Figliuoli:</stage>
-        <sp>
+        <sp who="#jacob">
           <speaker rend="sc">JACOB</speaker>
           <lg>
             <l>Se Giuseppe con meco fussi morto,</l>
@@ -434,7 +498,7 @@
           </lg>
         </sp>
         <stage rend="italic">Tornonsi e Mercanti smaellitici che, volendo vendere Josef  a Putifar unìco di Faraone Re d'Egitto e maestro de' suoi militi, uno de' Mercatanti dice a Putifar:</stage>
-        <sp>
+        <sp who="#altro_mercatante">
           <speaker rend="sc">ALTRO MERCATANTE</speaker>
           <lg>
             <l>O Putifar, duca della milizia,</l>
@@ -448,7 +512,7 @@
           </lg>
         </sp>
         <stage rend="italic">Putifar, veduto el garzon, risponde a' Mercatanti:</stage>
-        <sp>
+        <sp who="#putifar">
           <speaker rend="sc">PUTIFAR</speaker>
           <lg>
             <l>Del garzon sì mi piace 'l suo aspetto</l>
@@ -460,7 +524,7 @@
           </lg>
         </sp>
         <stage rend="italic">E Mercatanti per uno di loro dicono al Cavaliere:</stage>
-        <sp>
+        <sp who="#altro_mercatante">
           <speaker rend="sc">ALTRO MERCATANTE</speaker>
           <lg>
             <l>Il prezzo suo in te rimettïamo:</l>
@@ -468,7 +532,7 @@
           </lg>
         </sp>
         <stage rend="italic">La Reina del Re Faraone, innamorata d'Josef, gli dice:</stage>
-        <sp>
+        <sp who="#reina">
           <speaker rend="sc">REINA</speaker>
           <lg>
             <l>O giulivo scudiere, odi 'l parlare</l>
@@ -482,7 +546,7 @@
           </lg>
         </sp>
         <stage rend="italic">Josef crucciato risponde alla Reina:</stage>
-        <sp>
+        <sp who="#josef">
           <speaker rend="sc">JOSEF</speaker>
           <lg>
             <l>El mio Signore ogni sua cosa ha data</l>
@@ -496,7 +560,7 @@
           </lg>
         </sp>
         <stage rend="italic">Infestando più volte la Reina Josef, e mai lui consentendole, essendo un dì il Re a cacciare, e in quel dì entrando Josef  nella stanza della Reina per ubbidire el suo Signore, la Reina il prese per uno gherone della sua vesta dicendo:</stage>
-        <sp>
+        <sp who="#reina">
           <speaker rend="sc">REINA</speaker>
           <lg>
             <l>O Josef, e' convien che mi consenti,</l>
@@ -504,7 +568,7 @@
           </lg>
         </sp>
         <stage rend="italic">Josef risponde alla Reina:</stage>
-        <sp>
+        <sp who="#josef">
           <speaker rend="sc">JOSEF</speaker>
           <lg>
             <l>Prima che a tal cosa io consenti,</l>
@@ -512,7 +576,7 @@
           </lg>
         </sp>
         <stage rend="italic">Fugge Josef dalla donna, essendole rimase uno pezzo della vesta d'Josef stracciata in mano nel trarre, e la Reina dice a' ministri del Re gridando:</stage>
-        <sp>
+        <sp who="#reina">
           <speaker rend="sc">REINA</speaker>
           <lg>
             <l>O tutti nella casa mia essenti,</l>
@@ -522,7 +586,7 @@
           </lg>
         </sp>
         <stage rend="italic">In quel punto torna il Re e la Reina gli dice:</stage>
-        <sp>
+        <sp who="#reina">
           <speaker rend="sc">REINA</speaker>
           <lg>
             <l>Egli è stato mandato a me l'Ebreo,</l>
@@ -536,7 +600,7 @@
           </lg>
         </sp>
         <stage rend="italic">El Re fa Josef incarcerare e ben guardarlo dal Principe de'carcerieri sanza dirgli perché, dicendo così:</stage>
-        <sp>
+        <sp who="#re_faraone">
           <speaker rend="sc">RE FARAONE</speaker>
           <lg>
             <l>Incarcera tu quel t&lt;r&gt;isto poltrone.</l>
@@ -550,7 +614,7 @@
           </lg>
         </sp>
         <stage rend="italic">El Carceriere, ignorando e fatti della Reina, a Josef dice nella prigione:</stage>
-        <sp>
+        <sp who="#carceriere">
           <speaker rend="sc">CARCERIERE</speaker>
           <lg>
             <l>Josef, siàno a tua guardia e prigioni:</l>
@@ -564,7 +628,7 @@
           </lg>
         </sp>
         <stage rend="italic">Curando Josef e prigioni, essendovi carcerati uno Servidore di Coppa ed uno Panattiere del Re per loro mancamenti, una mattina vedendo Josef que' dua maninconosi e tristi, dice loro:</stage>
-        <sp>
+        <sp who="#josef">
           <speaker rend="sc">JOSEF</speaker>
           <lg>
             <l>Perché più triste oggi le facce vostre</l>
@@ -584,7 +648,7 @@
           </lg>
         </sp>
         <stage rend="italic">Josef a' detti dua prigioni dice:</stage>
-        <sp>
+        <sp who="#josef">
           <speaker rend="sc">JOSEF</speaker>
           <lg>
             <l>Non è Iddio vero interpetratore?</l>
@@ -614,7 +678,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde Josef al Servidore del Signore, esponendogli el suo sogno:</stage>
-        <sp>
+        <sp who="#josef">
           <speaker rend="sc">JOSEF</speaker>
           <lg>
             <l>Quest'è del sogno tuo declarazione:</l>
@@ -638,7 +702,7 @@
           </lg>
         </sp>
         <stage rend="italic">Veggendo el Panattiere del Re che Josef aveva sì bene esposto el sogno del Servidore del Re, dice a Josef:</stage>
-        <sp>
+        <sp who="#panattiere">
           <speaker rend="sc">PANATTIERE</speaker>
           <lg>
             <l>El sogno che vide mia fantasia:</l>
@@ -652,7 +716,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde Josef al Panattiere del Re:</stage>
-        <sp>
+        <sp who="#josef">
           <speaker rend="sc">JOSEF</speaker>
           <lg>
             <l>Se 'l sogno tuo ho ben interpetrato,</l>
@@ -666,7 +730,7 @@
           </lg>
         </sp>
         <stage rend="italic">Dopo tre dì, essendo il dì della natività di Faraone e facendo quel dì secondo suo consueto uno convito agli uomini suoi, si ricordò il Re del suo Servidore e del Panattiere incarcerati e disse a' suo' Ministri:</stage>
-        <sp>
+        <sp who="#re_faraone">
           <speaker rend="sc">RE FARAONE</speaker>
           <lg>
             <l>Andate e di prigione scarcerate</l>
@@ -680,7 +744,7 @@
           </lg>
         </sp>
         <stage rend="italic">Dipoi a due anni, vide Faraone in sogno certe cose per le quali manda Corrieri per tutti e sua Savi ed Indovini dicendo:</stage>
-        <sp>
+        <sp who="#re_faraone">
           <speaker rend="sc">RE FARAONE</speaker>
           <lg>
             <l>O corrier miei, andate prestamente</l>
@@ -694,7 +758,7 @@
           </lg>
         </sp>
         <stage rend="italic">Giunti e Savi del Re, Faraone rivela loro il suo sogno dicendo:</stage>
-        <sp>
+        <sp who="#re_faraone">
           <speaker rend="sc">RE FARAONE</speaker>
           <lg>
             <l>Filosofi, Astrolagi e Dottori</l>
@@ -728,7 +792,7 @@
           </lg>
         </sp>
         <stage rend="italic">Uno per tutti e Savi risponde al Re dopo molto loro studio così:</stage>
-        <sp>
+        <sp who="#savio">
           <speaker rend="sc">SAVIO</speaker>
           <lg>
             <l>O sacra Maestà, noi congregati</l>
@@ -756,7 +820,7 @@
           </lg>
         </sp>
         <stage rend="italic">Mandò il Re per Josef e prima tonduto e bene rivestito di volontà del Re, el Re gli dice:</stage>
-        <sp>
+        <sp who="#re_faraone">
           <speaker rend="sc">RE FARAONE</speaker>
           <lg>
             <l>Io vidi certi sogni, e nessuno</l>
@@ -768,7 +832,7 @@
           </lg>
         </sp>
         <stage rend="italic">Josef risponde con riverenza al Re:</stage>
-        <sp>
+        <sp who="#josef">
           <speaker rend="sc">JOSEF</speaker>
           <lg>
             <l>Senza me Iddio tuo &lt;sogno&gt; solverae,</l>
@@ -776,7 +840,7 @@
           </lg>
         </sp>
         <stage rend="italic">Manifestando il Re il sogno a Josef, gli dice così:</stage>
-        <sp>
+        <sp who="#re_faraone">
           <speaker rend="sc">RE FARAONE</speaker>
           <lg>
             <l>Parevami che sopra un'acqua stessi</l>
@@ -800,7 +864,7 @@
           </lg>
         </sp>
         <stage rend="italic">Josef risponde al Re, solvendo el sogno suo:</stage>
-        <sp>
+        <sp who="#josef">
           <speaker rend="sc">JOSEF</speaker>
           <lg>
             <l>E due sogni son uno in verità,</l>
@@ -824,7 +888,7 @@
           </lg>
         </sp>
         <stage rend="italic">Faraone a' sua uomini e ministri dice così:</stage>
-        <sp>
+        <sp who="#re_faraone">
           <speaker rend="sc">RE FARAONE</speaker>
           <lg>
             <l>Noi non potrem trovare un uom nel mondo</l>
@@ -832,7 +896,7 @@
           </lg>
         </sp>
         <stage rend="italic">E rivolto il Re a Josef, gli dice:</stage>
-        <sp>
+        <sp who="#re_faraone">
           <speaker rend="sc">RE FARAONE</speaker>
           <lg>
             <l>Perché Iddio t'ha fatto sì giocondo,</l>
@@ -864,7 +928,7 @@
           </lg>
         </sp>
         <stage rend="italic">Passati sette anni della abbundanza, provveduto alla vettuvaglia, venne el tempo della carestia e, oltre all'Egitto, quasi per tutto el mondo, e vedendo Jacob che gli alimenti si vendeano in Egitto, disse a' dieci suoi Figliuoli, Fratelli d'Josef, in questo modo:</stage>
-        <sp>
+        <sp who="#jacob">
           <speaker rend="sc">JACOB</speaker>
           <lg>
             <l>Perché oziosi qui cattiveggiate,</l>
@@ -888,35 +952,35 @@
           </lg>
         </sp>
         <stage rend="italic">Giunti e dieci Fratelli in Egitto a Josef principe, no&lt;n&gt; lo conoscendo l'adorano, e Josef dice loro per uno Interpetro com'al viso:</stage>
-        <sp>
+        <sp who="#interprete">
           <speaker rend="sc">INTERPRETE</speaker>
           <lg>
             <l>Onde voi siete e perché qui venuti?</l>
           </lg>
         </sp>
         <stage rend="italic">Uno de' Fratelli per tutti risponde a Josef:</stage>
-        <sp>
+        <sp who="#fratelli">
           <speaker rend="sc">FRATELLI</speaker>
           <lg>
             <l>Di terra di Canaan venuti siàno.</l>
           </lg>
         </sp>
         <stage rend="italic">Lo'nterpetro risponde:</stage>
-        <sp>
+        <sp who="#interprete">
           <speaker rend="sc">INTERPRETE</speaker>
           <lg>
             <l>Per noi spie siete conosciuti.</l>
           </lg>
         </sp>
         <stage rend="italic">Uno de' Fratelli risponde:</stage>
-        <sp>
+        <sp who="#fratelli">
           <speaker rend="sc">FRATELLI</speaker>
           <lg>
             <l>Ispie no, ma per comperar grano.</l>
           </lg>
         </sp>
         <stage rend="italic">Lo 'nterpetro per Josef dice:</stage>
-        <sp>
+        <sp who="#interprete">
           <speaker rend="sc">INTERPRETE</speaker>
           <lg>
             <l>Per la città siete stati veduti</l>
@@ -926,7 +990,7 @@
           </lg>
         </sp>
         <stage rend="italic">Uno de' Fratelli di Josef dice per tutti:</stage>
-        <sp>
+        <sp who="#fratelli">
           <speaker rend="sc">FRATELLI</speaker>
           <lg>
             <l>Noi tuo' servi, tutti d'un uom nati,</l>
@@ -940,7 +1004,7 @@
           </lg>
         </sp>
         <stage rend="italic">Un altro Fratello per tutti gli altri segue:</stage>
-        <sp>
+        <sp who="#fratelli">
           <speaker rend="sc">FRATELLI</speaker>
           <lg>
             <l>D'un padre siamo, dodici fratelli</l>
@@ -954,7 +1018,7 @@
           </lg>
         </sp>
         <stage rend="italic">Parla lo 'nterpetro in nome d'Josef:</stage>
-        <sp>
+        <sp who="#interprete">
           <speaker rend="sc">INTERPRETE</speaker>
           <lg>
             <l>Or veggo di voi lo sperimento,</l>
@@ -968,7 +1032,7 @@
           </lg>
         </sp>
         <stage rend="italic">Josef gli fa incarcerare, e dopo il terzo dì trâgli fuori, e fa dir loro allo Interpetro:</stage>
-        <sp>
+        <sp who="#interprete">
           <speaker rend="sc">INTERPRETE</speaker>
           <lg>
             <l>Se pacifici voi siete, farete</l>
@@ -982,7 +1046,7 @@
           </lg>
         </sp>
         <stage rend="italic">Josef in presenza de' Fratelli fa legare Simeon e metterlo in carcere, e parlando fra loro gli altri Fratelli, non credendo Josef gli intendesse, dice uno di loro agli altri Fratelli così:</stage>
-        <sp>
+        <sp who="#fratelli">
           <speaker rend="sc">FRATELLI</speaker>
           <lg>
             <l>Noi patiam questo merita&lt;ta&gt;mente,</l>
@@ -994,7 +1058,7 @@
           </lg>
         </sp>
         <stage rend="italic">Ruben dice agli altri Fratelli:</stage>
-        <sp>
+        <sp who="#ruben">
           <speaker rend="sc">RUBEN</speaker>
           <lg>
             <l>Ben vi diss'io, non vogliate peccare</l>
@@ -1002,7 +1066,7 @@
           </lg>
         </sp>
         <stage rend="italic">Josef &lt;in&gt; assenza de' suo' Fratelli dice a' Ministri suoi:</stage>
-        <sp>
+        <sp who="#josef">
           <speaker rend="sc">JOSEF</speaker>
           <lg>
             <l>Di grano èmpesi tutt'i sacchi loro,</l>
@@ -1016,7 +1080,7 @@
           </lg>
         </sp>
         <stage rend="italic">Caricate le sacca e per via uno di loro apre uno sacco per pascer loro animali, e trovate le loro pecunie nel sacco, maravigliandosi, dice a' Fratelli:</stage>
-        <sp>
+        <sp who="#fratelli">
           <speaker rend="sc">FRATELLI</speaker>
           <lg>
             <l>Nella bocca del mio sacco ho trovato</l>
@@ -1024,7 +1088,7 @@
           </lg>
         </sp>
         <stage rend="italic">Uno degli altri segue:</stage>
-        <sp>
+        <sp who="#fratelli">
           <speaker rend="sc">FRATELLI</speaker>
           <lg>
             <l>Cotesto a me ancora è incontrato.</l>
@@ -1036,7 +1100,7 @@
           </lg>
         </sp>
         <stage rend="italic">Uno de' Fratelli tornati dice a Jacob:</stage>
-        <sp>
+        <sp who="#fratelli">
           <speaker rend="sc">FRATELLI</speaker>
           <lg>
             <l>Per l'esc'andamo con altri in Egitto,</l>
@@ -1070,7 +1134,7 @@
           </lg>
         </sp>
         <stage rend="italic">Jacob risponde al Figliuolo:</stage>
-        <sp>
+        <sp who="#jacob">
           <speaker rend="sc">JACOB</speaker>
           <lg>
             <l>Senza figliuolo me esser faresti,</l>
@@ -1084,14 +1148,14 @@
           </lg>
         </sp>
         <stage rend="italic">Consumato el grano che arrecorono, dice Jacob a' nove suoi Figliuoli:</stage>
-        <sp>
+        <sp who="#jacob">
           <speaker rend="sc">JACOB</speaker>
           <lg>
             <l>Tornate a comperare della biada.</l>
           </lg>
         </sp>
         <stage rend="italic">Juda dice a Jacob:</stage>
-        <sp>
+        <sp who="#juda">
           <speaker rend="sc">JUDA</speaker>
           <lg>
             <l>Quell'uomo disse a noi con giuramento</l>
@@ -1104,7 +1168,7 @@
           </lg>
         </sp>
         <stage rend="italic">Jacob risponde a' Figliuoli:</stage>
-        <sp>
+        <sp who="#jacob">
           <speaker rend="sc">JACOB</speaker>
           <lg>
             <l>Se così è bisogno, così fate.</l>
@@ -1118,7 +1182,7 @@
           </lg>
         </sp>
         <stage rend="italic">Giunti a Josef, comanda Josef al suo Dispensatore dicendo:</stage>
-        <sp>
+        <sp who="#josef">
           <speaker rend="sc">JOSEF</speaker>
           <lg>
             <l>Mena costoro nella casa mia.</l>
@@ -1132,7 +1196,7 @@
           </lg>
         </sp>
         <stage rend="italic">Menati in casa d'Josef, uno de' Fratelli dice agli altri:</stage>
-        <sp>
+        <sp who="#fratelli">
           <speaker rend="sc">FRATELLI</speaker>
           <lg>
             <l>Oggi si scuopre la nostra vergogna.</l>
@@ -1146,7 +1210,7 @@
           </lg>
         </sp>
         <stage rend="italic">Uno di loro dice al Dispensatore:</stage>
-        <sp>
+        <sp who="#fratelli">
           <speaker rend="sc">FRATELLI</speaker>
           <lg>
             <l>Deh, piacciati, o Signor, a sentire</l>
@@ -1164,7 +1228,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde il Dispensatore a' Fratelli di Josef:</stage>
-        <sp>
+        <sp who="#dispensatore">
           <speaker rend="sc">DISPENSATORE</speaker>
           <lg>
             <l>Deh, non abbiate alcuna temenza,</l>
@@ -1176,7 +1240,7 @@
           </lg>
         </sp>
         <stage rend="italic">Josef tornando a desinare, e Fratelli inchinati l'adorano, e Josef con benignità gli saluta e dice loro, tenendogli per mano:</stage>
-        <sp>
+        <sp who="#josef">
           <speaker rend="sc">JOSEF</speaker>
           <lg>
             <l>Ègli salvo el vostro padre antico?</l>
@@ -1184,7 +1248,7 @@
           </lg>
         </sp>
         <stage rend="italic">Uno risponde per tutti, adorandolo di nuovo:</stage>
-        <sp>
+        <sp who="#fratelli">
           <speaker rend="sc">FRATELLI</speaker>
           <lg>
             <l>Lo nostro padre, tuo servo ti dico,</l>
@@ -1192,7 +1256,7 @@
           </lg>
         </sp>
         <stage rend="italic">Josef, volto a Beniamin, dice così:</stage>
-        <sp>
+        <sp who="#josef">
           <speaker rend="sc">JOSEF</speaker>
           <lg>
             <l>E questo è 'l minore, 'l più pudico</l>
@@ -1202,7 +1266,7 @@
           </lg>
         </sp>
         <stage rend="italic">Partesi in fretta Josef per tenerezza e, andando in camera, piange di segreto, poi lavatosi la faccia, torna e pone e Fratelli da una parte e dice:</stage>
-        <sp>
+        <sp who="#josef">
           <speaker rend="sc">JOSEF</speaker>
           <lg>
             <l>Secondo gl'anni vostri v'acconciate,</l>
@@ -1216,7 +1280,7 @@
           </lg>
         </sp>
         <stage rend="italic">Manda Josef di secreto al Dispensatore che empia loro le sacca di biada e nelle sommità metta le loro pecunie, e 'l suo nappo dello argento nella bocca del sacco del più giovane, e così si fa, e lasciagli andare la mattina, e poco dilungati, Josef al Dispensatore dice:</stage>
-        <sp>
+        <sp who="#josef">
           <speaker rend="sc">JOSEF</speaker>
           <lg>
             <l>Leva sù e gli Ebrei seguiterai,</l>
@@ -1230,7 +1294,7 @@
           </lg>
         </sp>
         <stage rend="italic">El Dispensatore prese gli Ebrei e dice loro:</stage>
-        <sp>
+        <sp who="#dispensatore">
           <speaker rend="sc">DISPENSATORE</speaker>
           <lg>
             <l>Perché rendete voi male per bene?</l>
@@ -1241,7 +1305,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde uno di loro al Dispensatore:</stage>
-        <sp>
+        <sp who="#fratelli">
           <speaker rend="sc">FRATELLI</speaker>
           <lg>
             <l>A chi di noi e' sarà &lt;ri&gt;trovato,</l>
@@ -1249,14 +1313,14 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde il Dispensatore:</stage>
-        <sp>
+        <sp who="#dispensatore">
           <speaker rend="sc">DISPENSATORE</speaker>
           <lg>
             <l>Sia secondo el vostro tenore.</l>
           </lg>
         </sp>
         <stage rend="italic">Aperto le sacca e trovato el nappo nel sacco del minore, stupefatti ne sono menati presi a Josef che ancora era in casa, e a lui s'inginocchiano, e Josef dice loro:</stage>
-        <sp>
+        <sp who="#josef">
           <speaker rend="sc">JOSEF</speaker>
           <lg>
             <l>Perché volesti voi tal cosa fare?</l>
@@ -1266,7 +1330,7 @@
           </lg>
         </sp>
         <stage rend="italic">Juda a' Frategli dice:</stage>
-        <sp>
+        <sp who="#juda">
           <speaker rend="sc">JUDA</speaker>
           <lg>
             <l>Ognun di noi è in sul traspirare.</l>
@@ -1276,7 +1340,7 @@
           </lg>
         </sp>
         <stage rend="italic">Josef risponde a' Fratelli dicendo:</stage>
-        <sp>
+        <sp who="#josef">
           <speaker rend="sc">JOSEF</speaker>
           <lg>
             <l>Da voi si parta ch'io così faccia.</l>
@@ -1286,7 +1350,7 @@
           </lg>
         </sp>
         <stage rend="italic">Juda dice a Josef:</stage>
-        <sp>
+        <sp who="#juda">
           <speaker rend="sc">JUDA</speaker>
           <lg>
             <l>Signor, alquanto ascoltar ti piaccia.</l>
@@ -1326,7 +1390,7 @@
           </lg>
         </sp>
         <stage rend="italic">Non si potendo più Josef  tenere, costretto da grande tenerezza paternale e fraternale, fatto mandare fuori di casa sua ogni egiziano, levò con grandissima voce uno pianto che fu udito da tutti quelli di casa di Faraone, dicendo a' sua Fratelli così:</stage>
-        <sp>
+        <sp who="#josef">
           <speaker rend="sc">JOSEF</speaker>
           <lg>
             <l>I' son Josef, il quale voi vendesti.</l>
@@ -1350,7 +1414,7 @@
           </lg>
         </sp>
         <stage rend="italic">Poi che riconosciutosi ed abbracciatosi furono Josef e' Fratelli, Josef con parte de' suo' Fratelli va a Faraone dicendogli:</stage>
-        <sp>
+        <sp who="#josef">
           <speaker rend="sc">JOSEF</speaker>
           <lg>
             <l>Serenissimo Re magno e prudente,</l>
@@ -1364,7 +1428,7 @@
           </lg>
         </sp>
         <stage rend="italic">Il Re dice a Josef per sua consolazione:</stage>
-        <sp>
+        <sp who="#re_faraone">
           <speaker rend="sc">RE FARAONE</speaker>
           <lg>
             <l>Comanda a' tuo' fratel che mie giumente</l>
@@ -1378,7 +1442,7 @@
           </lg>
         </sp>
         <stage rend="italic">Dopo 'l comandamento del Re, Josef dice a' Fratelli:</stage>
-        <sp>
+        <sp who="#josef">
           <speaker rend="sc">JOSEF</speaker>
           <lg>
             <l>Secondo l'imperio di Faraone,</l>
@@ -1392,7 +1456,7 @@
           </lg>
         </sp>
         <stage rend="italic">Tornati e Fratelli di Josef in Canaam, uno di loro dice a Jacob:</stage>
-        <sp>
+        <sp who="#fratelli">
           <speaker rend="sc">FRATELLI</speaker>
           <lg>
             <l>O padre nostro, tuo Josef è vivo</l>
@@ -1400,7 +1464,7 @@
           </lg>
         </sp>
         <stage rend="italic">Jacob, come da sonno svegliato, risponde:</stage>
-        <sp>
+        <sp who="#jacob">
           <speaker rend="sc">JACOB</speaker>
           <lg>
             <l>Più tosto credo sia di vita privo</l>
@@ -1408,7 +1472,7 @@
           </lg>
         </sp>
         <stage rend="italic">E Figliuoli di Jacob dicono:</stage>
-        <sp>
+        <sp who="#fratelli">
           <speaker rend="sc">FRATELLI</speaker>
           <lg>
             <l>Leva sù 'l capo, vedi qui l'ulivo:</l>
@@ -1416,7 +1480,7 @@
           </lg>
         </sp>
         <stage rend="italic">Jacob a' Figliuoli dice:</stage>
-        <sp>
+        <sp who="#jacob">
           <speaker rend="sc">JACOB</speaker>
           <lg>
             <l>Se ancor vive 'l dolce figliuol mio,</l>
@@ -1424,21 +1488,21 @@
           </lg>
         </sp>
         <stage rend="italic">Partesi Jacob con ogni sua cosa e va al Pozzo del Guernimento, e fatto sacrificio a Dio, udì in visione chiamarsi per uno Angelo in voce di Dio, dicente:</stage>
-        <sp>
+        <sp who="#angelo_annunciatore">
           <speaker rend="sc">ANGELO</speaker>
           <lg>
             <l>Jacob, Jacob, odi 'l parlar mio!</l>
           </lg>
         </sp>
         <stage rend="italic">Jacob risponde:</stage>
-        <sp>
+        <sp who="#jacob">
           <speaker rend="sc">JACOB</speaker>
           <lg>
             <l>Eccomi qui, che sono ubbidïente.</l>
           </lg>
         </sp>
         <stage rend="italic">L'Angelo in nome di Dio segue:</stage>
-        <sp>
+        <sp who="#angelo_annunciatore">
           <speaker rend="sc">ANGELO</speaker>
           <lg>
             <l>Io son del padre tuo forte Dio.</l>
@@ -1450,7 +1514,7 @@
           </lg>
         </sp>
         <stage rend="italic">Va Jacob con settanta suo' discendenti maschi e femmine, e manda innanzi Juda a significare a Josef sua venuta, e Josef  in sul carro suo viene incontro al Padre, ed il Padre e la Madre adorandolo, Josef si gitta in terra ed abbraccia il Padre in sul collo e &lt;il Padre&gt; dice:</stage>
-        <sp>
+        <sp who="#jacob">
           <speaker rend="sc">JACOB</speaker>
           <lg>
             <l>Oramai morrò lieto e contento</l>
@@ -1458,7 +1522,7 @@
           </lg>
         </sp>
         <stage rend="italic">Josef al Padre e a' Fratelli dice:</stage>
-        <sp>
+        <sp who="#josef">
           <speaker rend="sc">JOSEF</speaker>
           <lg>
             <l>Padre e fratelli, udite 'l mio talento:</l>
@@ -1470,7 +1534,7 @@
           </lg>
         </sp>
         <stage rend="italic">Annunzia Josef a Faraone la venuta de' sua parenti:</stage>
-        <sp>
+        <sp who="#josef">
           <speaker rend="sc">JOSEF</speaker>
           <lg>
             <l>Sacratissimo Sire, e' son venuti</l>
@@ -1480,14 +1544,14 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde il Re a Josef:</stage>
-        <sp>
+        <sp who="#re_faraone">
           <speaker rend="sc">RE FARAONE</speaker>
           <lg>
             <l>Fagli venire, che sian benvenuti.</l>
           </lg>
         </sp>
         <stage rend="italic">Josef al Re:</stage>
-        <sp>
+        <sp who="#josef">
           <speaker rend="sc">JOSEF</speaker>
           <lg>
             <l>Eccone qui a te ubbidïenti</l>
@@ -1496,7 +1560,7 @@
           </lg>
         </sp>
         <stage rend="italic">Uno de' Fratelli d'Josef dice al Re per tutti:</stage>
-        <sp>
+        <sp who="#fratelli">
           <speaker rend="sc">FRATELLI</speaker>
           <lg>
             <l>Uomini siàn, pastor, tuo' servidori</l>
@@ -1510,7 +1574,7 @@
           </lg>
         </sp>
         <stage rend="italic">Il Re a Josef risponde per loro dicendo:</stage>
-        <sp>
+        <sp who="#re_faraone">
           <speaker rend="sc">RE FARAONE</speaker>
           <lg>
             <l>El tuo padre e madre e' figliuol loro</l>
@@ -1522,21 +1586,21 @@
           </lg>
         </sp>
         <stage rend="italic">Poi il Re, benedetto Jacob, dice:</stage>
-        <sp>
+        <sp who="#re_faraone">
           <speaker rend="sc">RE FARAONE</speaker>
           <lg>
             <l>Quanti son gli anni della vita vostra?</l>
           </lg>
         </sp>
         <stage rend="italic">Jacob con riverenza risponde al Re:</stage>
-        <sp>
+        <sp who="#jacob">
           <speaker rend="sc">JACOB</speaker>
           <lg>
             <l>Centotrent'anni è ch'al mondo fu mostra.</l>
           </lg>
         </sp>
         <stage rend="italic">Il Re dice a Josef:</stage>
-        <sp>
+        <sp who="#re_faraone">
           <speaker rend="sc">RE FARAONE</speaker>
           <lg>
             <l>Se tu conosci loro ammaestrati,</l>
@@ -1550,7 +1614,7 @@
           </lg>
         </sp>
         <stage rend="italic">Uno Angelo fa fine della festa e dice:</stage>
-        <sp>
+        <sp who="#altro_angelo">
           <speaker rend="sc">ALTRO ANGELO</speaker>
           <lg>
             <l>Fedel cristiani, voi avete udita</l>

--- a/tei/anonimo-la-rappresentazione-di-moise-e-faraone-re-d-egitto.xml
+++ b/tei/anonimo-la-rappresentazione-di-moise-e-faraone-re-d-egitto.xml
@@ -79,6 +79,52 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="angelo">
+            <persName>L'Angelo</persName>
+          </person>
+          <person xml:id="altro_angelo">
+            <persName>Un altro Angelo</persName>
+          </person>
+          <person xml:id="reina">
+            <persName>La Reina</persName>
+          </person>
+          <person xml:id="prima_balia">
+            <persName>Prima Balia</persName>
+          </person>
+          <person xml:id="seconda_balia">
+            <persName>Seconda Balia</persName>
+          </person>
+          <person xml:id="terza_balia">
+            <persName>Terza Balia</persName>
+          </person>
+          <person xml:id="donzella">
+            <persName>Una Donzella della Reina</persName>
+          </person>
+          <person xml:id="damigella">
+            <persName>Damigella</persName>
+          </person>
+          <person xml:id="fanciulla">
+            <persName>Una Fanciulla ebrea</persName>
+          </person>
+          <person xml:id="balia_ebrea">
+            <persName>Una Balia ebrea madre della Fanciulla</persName>
+          </person>
+          <person xml:id="faraone">
+            <persName>Faraone</persName>
+          </person>
+          <person xml:id="speranza">
+            <persName>Speranza</persName>
+          </person>
+          <person xml:id="savio">
+            <persName>Savio</persName>
+          </person>
+          <personGrp xml:id="savi">
+            <name>I Savi della corte</name>
+          </personGrp>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -100,9 +146,7 @@
         <castItem>
           <role>Un altro Angelo</role>
         </castItem>
-        <castItem>
-          <role>La Reina</role>, <roleDesc>figlia di Faraone</roleDesc>
-        </castItem>
+        <castItem><role>La Reina</role>, <roleDesc>figlia di Faraone</roleDesc></castItem>
         <castItem>
           <role>Moisè bambino</role>
         </castItem>
@@ -124,12 +168,8 @@
         <castItem>
           <role>Una Balia ebrea madre della Fanciulla</role>
         </castItem>
-        <castItem>
-          <role>Faraone</role>, <roleDesc>re d'Egitto</roleDesc>
-        </castItem>
-        <castItem>
-          <role>Speranza</role>, <roleDesc>servo di Faraone</roleDesc>
-        </castItem>
+        <castItem><role>Faraone</role>, <roleDesc>re d'Egitto</roleDesc></castItem>
+        <castItem><role>Speranza</role>, <roleDesc>servo di Faraone</roleDesc></castItem>
         <castItem>
           <role>Baroni della corte</role>
         </castItem>
@@ -142,7 +182,7 @@
       <div>
         <head>La rappresentazione di Moisè e Faraone re d’Egitto</head>
         <stage>Parla l'Angelo e chiama Iddio nel principio della festa:</stage>
-        <sp>
+        <sp who="#angelo">
           <speaker>ANGELO</speaker>
           <lg>
             <l>Altissimo Signor, mente increata,</l>
@@ -156,7 +196,7 @@
           </lg>
         </sp>
         <stage>Risponde il Secondo Angelo:</stage>
-        <sp>
+        <sp who="#altro_angelo">
           <speaker>ALTRO ANGELO</speaker>
           <lg>
             <l>Al qual per ogni tempo sempre sia</l>
@@ -170,7 +210,7 @@
           </lg>
         </sp>
         <stage>Questa è la nunziazione della festa:</stage>
-        <sp>
+        <sp who="#angelo #altro_angelo">
           <speaker>ANGELI</speaker>
           <lg>
             <l>Noi vogliàn far la rappresentazione</l>
@@ -194,7 +234,7 @@
           </lg>
         </sp>
         <stage>Comincia la storia e parla la Figlia di Faraone a' servi e valletti:</stage>
-        <sp>
+        <sp who="#reina">
           <speaker>REINA</speaker>
           <lg>
             <l>Oltre sù, cari miei servi e valletti,</l>
@@ -208,7 +248,7 @@
           </lg>
         </sp>
         <stage>Tornono e servi e valletti e recano il Fanciullo Moisè e presentonlo alla Reina e la Reina l'accetta e parla alle sue damigelle e dice così:</stage>
-        <sp>
+        <sp who="#reina">
           <speaker>REINA</speaker>
           <lg>
             <l>Questa a me par non piccola ventura</l>
@@ -232,7 +272,7 @@
           </lg>
         </sp>
         <stage>Vengon le Balie e la Reina dice:</stage>
-        <sp>
+        <sp who="#reina">
           <speaker>REINA</speaker>
           <lg>
             <l>Vo' siete, balie mie, le ben venute.</l>
@@ -246,7 +286,7 @@
           </lg>
         </sp>
         <stage>Parla una Balia per tutte e dice così:</stage>
-        <sp>
+        <sp who="#prima_balia">
           <speaker>PRIMA BALIA</speaker>
           <lg>
             <l>Eccelsa degna famosa Reina,</l>
@@ -260,7 +300,7 @@
           </lg>
         </sp>
         <stage>E poi piglia il Fanciullo e 'l Fanciullo non vuole poppare:</stage>
-        <sp>
+        <sp who="#prima_balia">
           <speaker>PRIMA BALIA</speaker>
           <lg>
             <l>Che fortuna o disgrazia oggi mi sia?</l>
@@ -268,7 +308,7 @@
           </lg>
         </sp>
         <stage>Dice l'altra:</stage>
-        <sp>
+        <sp who="#seconda_balia">
           <speaker>SECONDA BALIA</speaker>
           <lg>
             <l>Dallo un po' qua e darogli la mia,</l>
@@ -276,7 +316,7 @@
           </lg>
         </sp>
         <stage>E anche non la vuole, onde essa dice:</stage>
-        <sp>
+        <sp who="#seconda_balia">
           <speaker>SECONDA BALIA</speaker>
           <lg>
             <l>Quest'è per certo una gran ricadia:</l>
@@ -284,7 +324,7 @@
           </lg>
         </sp>
         <stage>E l'altra Balia dice:</stage>
-        <sp>
+        <sp who="#terza_balia">
           <speaker>TERZA BALIA</speaker>
           <lg>
             <l>Poi ch'e' non poppa, e' non ci viverane</l>
@@ -292,7 +332,7 @@
           </lg>
         </sp>
         <stage>E veduto la Reina che 'l Fanciullo non poppa, ella dice così:</stage>
-        <sp>
+        <sp who="#reina">
           <speaker>REINA</speaker>
           <lg>
             <l>Poi che la poppa el fanciul non l'attira,</l>
@@ -306,7 +346,7 @@
           </lg>
         </sp>
         <stage>Parla una Donzella e dice alla Reina:</stage>
-        <sp>
+        <sp who="#donzella">
           <speaker>DONZELLA</speaker>
           <lg>
             <l>Madonna gentilissima Reina,</l>
@@ -320,7 +360,7 @@
           </lg>
         </sp>
         <stage>Risponde la Reina:</stage>
-        <sp>
+        <sp who="#reina">
           <speaker>REINA</speaker>
           <lg>
             <l>Questa mi pare un'ottima ragione,</l>
@@ -334,7 +374,7 @@
           </lg>
         </sp>
         <stage>Parla una Donzella:</stage>
-        <sp>
+        <sp who="#donzella">
           <speaker>DONZELLA</speaker>
           <lg>
             <l>Magnifica Reina mia prudente,</l>
@@ -348,7 +388,7 @@
           </lg>
         </sp>
         <stage>Parla la Reina e dice:</stage>
-        <sp>
+        <sp who="#reina">
           <speaker>REINA</speaker>
           <lg>
             <l>Fammela qui venir, che 'l tempo fugge,</l>
@@ -362,7 +402,7 @@
           </lg>
         </sp>
         <stage>Parla la Damigella alla Fanciulla e dice:</stage>
-        <sp>
+        <sp who="#damigella">
           <speaker>DAMIGELLA</speaker>
           <lg>
             <l>O povera fanciulla, avventurata</l>
@@ -376,7 +416,7 @@
           </lg>
         </sp>
         <stage>Parla la Fanciulla alla Reina:</stage>
-        <sp>
+        <sp who="#fanciulla">
           <speaker>FANCIULLA</speaker>
           <lg>
             <l>Altissima e infinita provedenza</l>
@@ -390,7 +430,7 @@
           </lg>
         </sp>
         <stage>Risponde la Reina alla Fanciulla:</stage>
-        <sp>
+        <sp who="#reina">
           <speaker>REINA</speaker>
           <lg>
             <l>Cara mia serva, io ho &lt;pur&gt; sentito</l>
@@ -404,7 +444,7 @@
           </lg>
         </sp>
         <stage>Va la Fanciulla e mena la Madre e la Madre dice così:</stage>
-        <sp>
+        <sp who="#balia_ebrea">
           <speaker>BALIA EBREA</speaker>
           <lg>
             <l>Famosissima, degna, alta e felice</l>
@@ -418,7 +458,7 @@
           </lg>
         </sp>
         <stage>Risponde la Reina alla Balia:</stage>
-        <sp>
+        <sp who="#reina">
           <speaker>REINA</speaker>
           <lg>
             <l>Cara mia serva, un attivo mie figlio,</l>
@@ -432,7 +472,7 @@
           </lg>
         </sp>
         <stage>Risponde la Balia e dice:</stage>
-        <sp>
+        <sp who="#balia_ebrea">
           <speaker>BALIA EBREA</speaker>
           <lg>
             <l>Fatel venir, che Dio sia benedetto,</l>
@@ -446,7 +486,7 @@
           </lg>
         </sp>
         <stage>E la Reina fa dare il Fanciullo alla Balia ond'egli poppa e la Reina disse così:</stage>
-        <sp>
+        <sp who="#reina">
           <speaker>REINA</speaker>
           <lg>
             <l>Da poi che poppa il latte, tal ventura</l>
@@ -460,7 +500,7 @@
           </lg>
         </sp>
         <stage>Risponde la Balia:</stage>
-        <sp>
+        <sp who="#balia_ebrea">
           <speaker>BALIA EBREA</speaker>
           <lg>
             <l>Gentil Reina, fate conto ch'io</l>
@@ -474,7 +514,7 @@
           </lg>
         </sp>
         <stage>Vassene la Balia e portasene il Fanciullo. Ora comincia il Re e dice a' suoi servi così:</stage>
-        <sp>
+        <sp who="#faraone">
           <speaker>FARAONE</speaker>
           <lg>
             <l>Vien qua, Speranza, e va alla mia figlia,</l>
@@ -488,7 +528,7 @@
           </lg>
         </sp>
         <stage>Va il servo per la Reina e dice così:</stage>
-        <sp>
+        <sp who="#speranza">
           <speaker>SERVO</speaker>
           <lg>
             <l>Gentilissima dama la Reina,</l>
@@ -502,7 +542,7 @@
           </lg>
         </sp>
         <stage>Va la Reina dinanzi al Re e il Re parla così:</stage>
-        <sp>
+        <sp who="#faraone">
           <speaker>FARAONE</speaker>
           <lg>
             <l>E' non bisogna a me da te saluto</l>
@@ -526,7 +566,7 @@
           </lg>
         </sp>
         <stage>Risponde la Reina al Re:</stage>
-        <sp>
+        <sp who="#reina">
           <speaker>REINA</speaker>
           <lg>
             <l>Chi può, santa Corona, immaginare</l>
@@ -540,7 +580,7 @@
           </lg>
         </sp>
         <stage>Parla pure la Reina:</stage>
-        <sp>
+        <sp who="#reina">
           <speaker>REINA</speaker>
           <lg>
             <l>Però, santa Corona, inginocchione</l>
@@ -554,7 +594,7 @@
           </lg>
         </sp>
         <stage>Risponde il Re alla Figliuola:</stage>
-        <sp>
+        <sp who="#faraone">
           <speaker>FARAONE</speaker>
           <lg>
             <l>Tu vai pigliando pur con man gli stecchi</l>
@@ -568,7 +608,7 @@
           </lg>
         </sp>
         <stage>Parla la Reina :</stage>
-        <sp>
+        <sp who="#reina">
           <speaker>REINA</speaker>
           <lg>
             <l>Padre mio, giusto Re, caro Signore,</l>
@@ -582,7 +622,7 @@
           </lg>
         </sp>
         <stage>Risponde il Re:</stage>
-        <sp>
+        <sp who="#faraone">
           <speaker>FARAONE</speaker>
           <lg>
             <l>Dolce figliuola mia, vie maggior fatti</l>
@@ -596,7 +636,7 @@
           </lg>
         </sp>
         <stage>Parla la Reina:</stage>
-        <sp>
+        <sp who="#reina">
           <speaker>REINA</speaker>
           <lg>
             <l>Tante grazie ti renda il Creatore,</l>
@@ -610,7 +650,7 @@
           </lg>
         </sp>
         <stage>Vanne &lt;la&gt; Reina e manda pel Fanciullo e giunge la Balia col Fanciullo e parla:</stage>
-        <sp>
+        <sp who="#balia_ebrea">
           <speaker>BALIA EBREA</speaker>
           <lg>
             <l>Ecco, santa Corona, il bambolino.</l>
@@ -624,7 +664,7 @@
           </lg>
         </sp>
         <stage>Risponde la Reina alla Balia:</stage>
-        <sp>
+        <sp who="#reina">
           <speaker>REINA</speaker>
           <lg>
             <l>Io mel veggio negli occhi, né parlare</l>
@@ -638,7 +678,7 @@
           </lg>
         </sp>
         <stage>&lt;Parla il Re:&gt;</stage>
-        <sp>
+        <sp who="#faraone">
           <speaker>FARAONE</speaker>
           <lg>
             <l>Egregi miei Baroni alti e potenti,</l>
@@ -652,7 +692,7 @@
           </lg>
         </sp>
         <stage>E qui si comincia a sonare e a ballare e quando hanno ballato un poco la Reina venga col Fanciullo e comincia parlare:</stage>
-        <sp>
+        <sp who="#reina">
           <speaker>REINA</speaker>
           <lg>
             <l>Santissima Corona alta e potente,</l>
@@ -666,7 +706,7 @@
           </lg>
         </sp>
         <stage>Risponde il Re:</stage>
-        <sp>
+        <sp who="#faraone">
           <speaker>FARAONE</speaker>
           <lg>
             <l>Carissima figli&lt;uol&gt;a, ogni impromessa</l>
@@ -680,7 +720,7 @@
           </lg>
         </sp>
         <stage>Pigliò il Re il Fanciullo in collo e 'l Fanciullo prese la corona e gitolla in terra e 'l Re disse così:</stage>
-        <sp>
+        <sp who="#faraone">
           <speaker>FARAONE</speaker>
           <lg>
             <l>Tanto sie tu, traditore isconfitto</l>
@@ -694,7 +734,7 @@
           </lg>
         </sp>
         <stage>La Reina abbracciò il Fanciullo e disse:</stage>
-        <sp>
+        <sp who="#reina">
           <speaker>REINA</speaker>
           <lg>
             <l>Santissima Corona, il sentimento</l>
@@ -708,7 +748,7 @@
           </lg>
         </sp>
         <stage>Risponde il Re e dice:</stage>
-        <sp>
+        <sp who="#faraone">
           <speaker>FARAONE</speaker>
           <lg>
             <l>O figlia maladetta e disleale,</l>
@@ -722,7 +762,7 @@
           </lg>
         </sp>
         <stage>Risponde la Reina:</stage>
-        <sp>
+        <sp who="#reina">
           <speaker>REINA</speaker>
           <lg>
             <l>Caro mio padre, ogni piccola cosa</l>
@@ -736,7 +776,7 @@
           </lg>
         </sp>
         <stage>Risponde il Re alla Reina:</stage>
-        <sp>
+        <sp who="#faraone">
           <speaker>FARAONE</speaker>
           <lg>
             <l>Io non posso dal core isviluppare</l>
@@ -750,7 +790,7 @@
           </lg>
         </sp>
         <stage>Risponde la Reina e dice:</stage>
-        <sp>
+        <sp who="#reina">
           <speaker>REINA</speaker>
           <lg>
             <l>Se io nol pruovo, i' voglio esser contenta</l>
@@ -764,7 +804,7 @@
           </lg>
         </sp>
         <stage>Dice il Re a' Savi sua:</stage>
-        <sp>
+        <sp who="#faraone">
           <speaker>FARAONE</speaker>
           <lg>
             <l>Orsù, fate venir tutti i mie' Savi</l>
@@ -778,7 +818,7 @@
           </lg>
         </sp>
         <stage>Giungono i Savi e 'l Re parla e dice:</stage>
-        <sp>
+        <sp who="#faraone">
           <speaker>FARAONE</speaker>
           <lg>
             <l>Con ogni ingegno e regola e dottrina</l>
@@ -792,7 +832,7 @@
           </lg>
         </sp>
         <stage>Risponde un Savio:</stage>
-        <sp>
+        <sp who="#savio">
           <speaker>SAVIO</speaker>
           <lg>
             <l>Venga chi vuol, che noi abbiàn tant'arte</l>
@@ -806,7 +846,7 @@
           </lg>
         </sp>
         <stage>Allora la Figlia si rizza e 'l Re dice così:</stage>
-        <sp>
+        <sp who="#faraone">
           <speaker>FARAONE</speaker>
           <lg>
             <l> Difendi oggimai, figliuola mia,</l>
@@ -820,7 +860,7 @@
           </lg>
         </sp>
         <stage>Parla la Reina e dice due stanze:</stage>
-        <sp>
+        <sp who="#reina">
           <speaker>REINA</speaker>
           <lg>
             <l>Nessuno ingegno mai sotto le stelle</l>
@@ -844,7 +884,7 @@
           </lg>
         </sp>
         <stage>Rispondono i Savi:</stage>
-        <sp>
+        <sp who="#savi">
           <speaker>SAVI</speaker>
           <lg>
             <l>Quest'è, madonna, sì vera ragione</l>
@@ -856,7 +896,7 @@
           </lg>
         </sp>
         <stage>Viene un bacino di fiorini e una tegghia di fuoco e pongonle innanzi al Fanciullo &lt;e il Fanciullo&gt; prese il fuoco. &lt;Parlano i Savi&gt;:</stage>
-        <sp>
+        <sp who="#savi">
           <speaker>SAVI</speaker>
           <lg>
             <l>né niun di noi ci può fare parola,</l>
@@ -864,7 +904,7 @@
           </lg>
         </sp>
         <stage>Parla la Reina:</stage>
-        <sp>
+        <sp who="#reina">
           <speaker>REINA</speaker>
           <lg>
             <l>Diletto padre mio giusto e da bene,</l>
@@ -878,7 +918,7 @@
           </lg>
         </sp>
         <stage>Parla uno Savio:</stage>
-        <sp>
+        <sp who="#savio">
           <speaker>SAVIO</speaker>
           <lg>
             <l>Questa giovana donna, alta Reina</l>
@@ -892,7 +932,7 @@
           </lg>
         </sp>
         <stage>Risponde il Re:</stage>
-        <sp>
+        <sp who="#faraone">
           <speaker>FARAONE</speaker>
           <lg>
             <l>Io son contento e vo' che così sia</l>
@@ -906,7 +946,7 @@
           </lg>
         </sp>
         <stage>Finita la storia parla l'Angelo:</stage>
-        <sp>
+        <sp who="#angelo">
           <speaker>ANGELO</speaker>
           <lg>
             <l>Carissimi gentili sapïenti</l>

--- a/tei/anonimo-la-rappresentazione-di-salamone.xml
+++ b/tei/anonimo-la-rappresentazione-di-salamone.xml
@@ -79,6 +79,31 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="angelo">
+            <persName>L'Angelo che annuncia</persName>
+          </person>
+          <person xml:id="dio">
+            <persName>Dio che gli appare in sogno</persName>
+          </person>
+          <person xml:id="salamone">
+            <persName>Salamone</persName>
+          </person>
+          <person xml:id="cognata_buona">
+            <persName>La Donna buona</persName>
+          </person>
+          <person xml:id="cognata_trista">
+            <persName>La Donna trista</persName>
+          </person>
+          <person xml:id="messo">
+            <persName>Il Messo del Re</persName>
+          </person>
+          <person xml:id="angelo_che_licenzia">
+            <persName>L'Angelo che licenzia il popolo</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -123,7 +148,7 @@
     <body>
       <div n="La rappresentazione di Salamone">
         <stage rend="italic">Uno Angelo annunzia la festa:</stage>
-        <sp>
+        <sp who="#angelo">
           <speaker rend="sc">ANGELO</speaker>
           <lg>
             <l>Al nome sia del vero ed uno Dio,</l>
@@ -167,7 +192,7 @@
           </lg>
         </sp>
         <stage rend="italic">Nel principio, tutti e vestiti di Salamone, giunti al palco, si fermino giù al basso e faccino coro, e faccino reverenza a Salamone passando pel mezzo di loro per andare a fare il sacrificio; e fatto Salamone il sacrificio e tornato in sedia, tutti gli altri vadino a sedere. Salamone va in sul monte e fa sacrificio a Dio con mille agnelli e incenso sopra l'altare; e dipoi s'addormenta e Dio gli parla in sogno e dice così:</stage>
-        <sp>
+        <sp who="#dio">
           <speaker rend="sc">DIO</speaker>
           <lg>
             <l>O Salamon, questa tua grande offerta</l>
@@ -181,7 +206,7 @@
           </lg>
         </sp>
         <stage rend="italic">Salamone ginocchioni dice:</stage>
-        <sp>
+        <sp who="#salamone">
           <speaker rend="sc">SALAMONE</speaker>
           <lg>
             <l>O sommo eterno bene, o solo Dio,</l>
@@ -195,7 +220,7 @@
           </lg>
         </sp>
         <stage rend="italic">Detto questo si raddormenta, e Dio in sogno gli risponde:</stage>
-        <sp>
+        <sp who="#dio">
           <speaker rend="sc">DIO</speaker>
           <lg>
             <l>El tuo parlare è di tanta eccellenza</l>
@@ -209,7 +234,7 @@
           </lg>
         </sp>
         <stage rend="italic">Salamone si desta, e di nuovo ginocchioni ringrazia Dio:</stage>
-        <sp>
+        <sp who="#salamone">
           <speaker rend="sc">SALAMONE</speaker>
           <lg>
             <l>Nessuna lingua mai potrebbe esprimere</l>
@@ -223,7 +248,7 @@
           </lg>
         </sp>
         <stage rend="italic">La Cognata Buona vedendo el fanciullo morto, non essendo il suo figliuolo dice:</stage>
-        <sp>
+        <sp who="#cognata_buona">
           <speaker rend="sc">COGNATA BUONA</speaker>
           <lg>
             <l>O femmina malvagia e maladetta,</l>
@@ -237,7 +262,7 @@
           </lg>
         </sp>
         <stage rend="italic">La Cognata Trista risponde:</stage>
-        <sp>
+        <sp who="#cognata_trista">
           <speaker rend="sc">COGNATA TRISTA</speaker>
           <lg>
             <l>Deh, vanne via con la mala ventura</l>
@@ -251,7 +276,7 @@
           </lg>
         </sp>
         <stage rend="italic">La Buona dice:</stage>
-        <sp>
+        <sp who="#cognata_buona">
           <speaker rend="sc">COGNATA BUONA</speaker>
           <lg>
             <l>O falsa, e' non bisogna argumentare</l>
@@ -265,7 +290,7 @@
           </lg>
         </sp>
         <stage rend="italic">La Trista risponde:</stage>
-        <sp>
+        <sp who="#cognata_trista">
           <speaker rend="sc">COGNATA TRISTA</speaker>
           <lg>
             <l>Tu menti come falsa e ria bugiarda</l>
@@ -279,7 +304,7 @@
           </lg>
         </sp>
         <stage rend="italic">La Buona dice alla Trista:</stage>
-        <sp>
+        <sp who="#cognata_buona">
           <speaker rend="sc">COGNATA BUONA</speaker>
           <lg>
             <l>S'io credessi per darti riavere</l>
@@ -293,7 +318,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde la Trista:</stage>
-        <sp>
+        <sp who="#cognata_trista">
           <speaker rend="sc">COGNATA TRISTA</speaker>
           <lg>
             <l>Piccola stima fa de' gracchiar tuoi</l>
@@ -307,7 +332,7 @@
           </lg>
         </sp>
         <stage rend="italic">La Buona dice:</stage>
-        <sp>
+        <sp who="#cognata_buona">
           <speaker rend="sc">COGNATA BUONA</speaker>
           <lg>
             <l>Malizia mai con tanta falsitade</l>
@@ -321,7 +346,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde la Trista:</stage>
-        <sp>
+        <sp who="#cognata_trista">
           <speaker rend="sc">COGNATA TRISTA</speaker>
           <lg>
             <l>La vita n'andrà a te, che falsamente</l>
@@ -335,7 +360,7 @@
           </lg>
         </sp>
         <stage rend="italic">La Buona dice:</stage>
-        <sp>
+        <sp who="#cognata_buona">
           <speaker rend="sc">COGNATA BUONA</speaker>
           <lg>
             <l>Poi che minacce, lusinghe e consiglio</l>
@@ -349,7 +374,7 @@
           </lg>
         </sp>
         <stage rend="italic">La Trista risponde:</stage>
-        <sp>
+        <sp who="#cognata_trista">
           <speaker rend="sc">COGNATA TRISTA</speaker>
           <lg>
             <l>Deh, va pur tosto, che tu sarai morta,</l>
@@ -357,7 +382,7 @@
           </lg>
         </sp>
         <stage rend="italic">La Buona dice:</stage>
-        <sp>
+        <sp who="#cognata_buona">
           <speaker rend="sc">COGNATA BUONA</speaker>
           <lg>
             <l>Io vo in luogo dove sarà scorta</l>
@@ -365,7 +390,7 @@
           </lg>
         </sp>
         <stage rend="italic">La Trista risponde:</stage>
-        <sp>
+        <sp who="#cognata_trista">
           <speaker rend="sc">COGNATA TRISTA</speaker>
           <lg>
             <l>La tua malizia molto mi conforta,</l>
@@ -373,21 +398,21 @@
           </lg>
         </sp>
         <stage rend="italic">La Buona dice:</stage>
-        <sp>
+        <sp who="#cognata_buona">
           <speaker rend="sc">COGNATA BUONA</speaker>
           <lg>
             <l>Sì tu, ribalda, sarai tormentata!</l>
           </lg>
         </sp>
         <stage rend="italic">La Trista risponde alla Buona:</stage>
-        <sp>
+        <sp who="#cognata_trista">
           <speaker rend="sc">COGNATA TRISTA</speaker>
           <lg>
             <l>Ribalda sei, come io, ma più sfacciata.</l>
           </lg>
         </sp>
         <stage rend="italic">La Buona va a Salamone, e inginocchioni gli dice piangendo:</stage>
-        <sp>
+        <sp who="#cognata_buona">
           <speaker rend="sc">COGNATA BUONA</speaker>
           <lg>
             <l>O sacra Maestà, santa Corona,</l>
@@ -401,7 +426,7 @@
           </lg>
         </sp>
         <stage rend="italic">Salamone risponde alla Donna Buona:</stage>
-        <sp>
+        <sp who="#salamone">
           <speaker rend="sc">SALAMONE</speaker>
           <lg>
             <l>Donna, sta suso, e così ritta in piede</l>
@@ -415,7 +440,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde la Donna Buona a Salamone:</stage>
-        <sp>
+        <sp who="#cognata_buona">
           <speaker rend="sc">COGNATA BUONA</speaker>
           <lg>
             <l>Giusto Signor, non si dubita o teme</l>
@@ -479,7 +504,7 @@
           </lg>
         </sp>
         <stage rend="italic">Salamone risponde alla Donna Buona e dice:</stage>
-        <sp>
+        <sp who="#salamone">
           <speaker rend="sc">SALAMONE</speaker>
           <lg>
             <l>Donna, tu puoi star certa e ben sicura</l>
@@ -493,7 +518,7 @@
           </lg>
         </sp>
         <stage rend="italic">El Messo va con due famigli alla Donna Trista e dice:</stage>
-        <sp>
+        <sp who="#messo">
           <speaker rend="sc">MESSO</speaker>
           <lg>
             <l>Donna, el nostro Re a te mi manda</l>
@@ -507,7 +532,7 @@
           </lg>
         </sp>
         <stage rend="italic">La Donna Trista risponde al Messo:</stage>
-        <sp>
+        <sp who="#cognata_trista">
           <speaker rend="sc">COGNATA TRISTA</speaker>
           <lg>
             <l>Io sono all'ubbidire apparecchiata,</l>
@@ -521,7 +546,7 @@
           </lg>
         </sp>
         <stage rend="italic">La Donna Trista col Messo giunge a Salamone e ginocchioni gli dice:</stage>
-        <sp>
+        <sp who="#cognata_trista">
           <speaker rend="sc">COGNATA TRISTA</speaker>
           <lg>
             <l>Potente e sommo Re, io son venuta</l>
@@ -535,7 +560,7 @@
           </lg>
         </sp>
         <stage rend="italic">Salamone gli risponde:</stage>
-        <sp>
+        <sp who="#salamone">
           <speaker rend="sc">SALAMONE</speaker>
           <lg>
             <l>Donna sta sù, che insin qui l'ubbidire</l>
@@ -549,7 +574,7 @@
           </lg>
         </sp>
         <stage rend="italic">La Donna Buona dice a Salamone:</stage>
-        <sp>
+        <sp who="#cognata_buona">
           <speaker rend="sc">COGNATA BUONA</speaker>
           <lg>
             <l>Maestà sacra, sì come io t'ho detto,</l>
@@ -573,7 +598,7 @@
           </lg>
         </sp>
         <stage rend="italic">Salamone dice alla Donna Trista:</stage>
-        <sp>
+        <sp who="#salamone">
           <speaker rend="sc">SALAMONE</speaker>
           <lg>
             <l>Tu intendi, donna, quel che costei dice,</l>
@@ -587,7 +612,7 @@
           </lg>
         </sp>
         <stage rend="italic">La Donna Trista risponde:</stage>
-        <sp>
+        <sp who="#cognata_trista">
           <speaker rend="sc">COGNATA TRISTA</speaker>
           <lg>
             <l>Se quel che è morto fussi el mio figliuolo,</l>
@@ -601,7 +626,7 @@
           </lg>
         </sp>
         <stage rend="italic">La Donna Buona dice alla Trista:</stage>
-        <sp>
+        <sp who="#cognata_buona">
           <speaker rend="sc">COGNATA BUONA</speaker>
           <lg>
             <l>Per cotesta medesima ragione,</l>
@@ -615,7 +640,7 @@
           </lg>
         </sp>
         <stage rend="italic">La Trista risponde alla Buona:</stage>
-        <sp>
+        <sp who="#cognata_trista">
           <speaker rend="sc">COGNATA TRISTA</speaker>
           <lg>
             <l>Io non arei già mai questo creduto</l>
@@ -629,7 +654,7 @@
           </lg>
         </sp>
         <stage rend="italic">La Buona dice:</stage>
-        <sp>
+        <sp who="#cognata_buona">
           <speaker rend="sc">COGNATA BUONA</speaker>
           <lg>
             <l>Tu sai che 'l mio figliuolo era maggiore</l>
@@ -643,7 +668,7 @@
           </lg>
         </sp>
         <stage rend="italic">La Trista risponde:</stage>
-        <sp>
+        <sp who="#cognata_trista">
           <speaker rend="sc">COGNATA TRISTA</speaker>
           <lg>
             <l>Io posso far verace sacramento</l>
@@ -657,7 +682,7 @@
           </lg>
         </sp>
         <stage rend="italic">Dice la Buona:</stage>
-        <sp>
+        <sp who="#cognata_buona">
           <speaker rend="sc">COGNATA BUONA</speaker>
           <lg>
             <l>Tacer non posso, né tacerò mai</l>
@@ -671,7 +696,7 @@
           </lg>
         </sp>
         <stage rend="italic">Salamone dice a tutta due:</stage>
-        <sp>
+        <sp who="#salamone">
           <speaker rend="sc">SALAMONE</speaker>
           <lg>
             <l>Qualunque sia di voi non vuole il morto</l>
@@ -715,7 +740,7 @@
           </lg>
         </sp>
         <stage rend="italic">La Donna Trista risponde a Salamone:</stage>
-        <sp>
+        <sp who="#cognata_trista">
           <speaker rend="sc">COGNATA TRISTA</speaker>
           <lg>
             <l>Quanto la morte del figliuol mi duole</l>
@@ -729,7 +754,7 @@
           </lg>
         </sp>
         <stage rend="italic">La Buona risponde alla Trista:</stage>
-        <sp>
+        <sp who="#cognata_buona">
           <speaker rend="sc">COGNATA BUONA</speaker>
           <lg>
             <l>O maladetta femmina crudele,</l>
@@ -737,7 +762,7 @@
           </lg>
         </sp>
         <stage rend="italic">La Trista risponde:</stage>
-        <sp>
+        <sp who="#cognata_trista">
           <speaker rend="sc">COGNATA TRISTA</speaker>
           <lg>
             <l>E' non è tuo, ma tu piena di fiele</l>
@@ -745,7 +770,7 @@
           </lg>
         </sp>
         <stage rend="italic">La Buona s'inginocchia e con le mani in alto a Dio dice così:</stage>
-        <sp>
+        <sp who="#cognata_buona">
           <speaker rend="sc">COGNATA BUONA</speaker>
           <lg>
             <l>O Dio, soccorso di ciascun fedele,</l>
@@ -753,21 +778,21 @@
           </lg>
         </sp>
         <stage rend="italic">La Trista dice alla Buona:</stage>
-        <sp>
+        <sp who="#cognata_trista">
           <speaker rend="sc">COGNATA TRISTA</speaker>
           <lg>
             <l>La ipocrisia non ti varrà nïente!</l>
           </lg>
         </sp>
         <stage rend="italic">La Buona risponde:</stage>
-        <sp>
+        <sp who="#cognata_buona">
           <speaker rend="sc">COGNATA BUONA</speaker>
           <lg>
             <l>Ben sei ribalda, e trista, e fraudolente.</l>
           </lg>
         </sp>
         <stage rend="italic">Salamone dice al Giustiziere:</stage>
-        <sp>
+        <sp who="#salamone">
           <speaker rend="sc">SALAMONE</speaker>
           <lg>
             <l>Va, maestro Giustizier, piglia lo infante</l>
@@ -781,7 +806,7 @@
           </lg>
         </sp>
         <stage rend="italic">La Buona si gitta inginocchione e dice a Salamone quando il Giustiziere vuol fare l'offizio suo:</stage>
-        <sp>
+        <sp who="#cognata_buona">
           <speaker rend="sc">COGNATA BUONA</speaker>
           <lg>
             <l>O sacro Re, o giusto, o buon Signore,</l>
@@ -805,7 +830,7 @@
           </lg>
         </sp>
         <stage rend="italic">La Trista dice alla Buona:</stage>
-        <sp>
+        <sp who="#cognata_trista">
           <speaker rend="sc">COGNATA TRISTA</speaker>
           <lg>
             <l>La sentenza del Re è sì perfetta</l>
@@ -819,7 +844,7 @@
           </lg>
         </sp>
         <stage rend="italic">La Buona risponde:</stage>
-        <sp>
+        <sp who="#cognata_buona">
           <speaker rend="sc">COGNATA BUONA</speaker>
           <lg>
             <l>Io dico ch'egli è tuo, e ch'io ti dono</l>
@@ -833,7 +858,7 @@
           </lg>
         </sp>
         <stage rend="italic">Salamone dice al Giustiziere:</stage>
-        <sp>
+        <sp who="#salamone">
           <speaker rend="sc">SALAMONE</speaker>
           <lg>
             <l>Rifascia presto el figliuol, Giustiziere.</l>
@@ -847,7 +872,7 @@
           </lg>
         </sp>
         <stage rend="italic">Salamone dice alla Donna Trista:</stage>
-        <sp>
+        <sp who="#cognata_trista">
           <speaker rend="sc">COGNATA TRISTA</speaker>
           <lg>
             <l>E tu, malvagia e ria, che fusti ardita</l>
@@ -861,7 +886,7 @@
           </lg>
         </sp>
         <stage rend="italic">La Donna Trista s'inginocchia dinanzi a Salamone e dice:</stage>
-        <sp>
+        <sp who="#cognata_trista">
           <speaker rend="sc">COGNATA TRISTA</speaker>
           <lg>
             <l>O misera dolente sventurata,</l>
@@ -875,7 +900,7 @@
           </lg>
         </sp>
         <stage rend="italic">Salamone dice a' suoi comandatori:</stage>
-        <sp>
+        <sp who="#salamone">
           <speaker rend="sc">SALAMONE</speaker>
           <lg>
             <l>Fatemi presto questa incarcerare</l>
@@ -889,7 +914,7 @@
           </lg>
         </sp>
         <stage rend="italic">La Donna Buona s'inginocchia, e ringrazia Salamone e partesi. L'Angelo licenzia:</stage>
-        <sp>
+        <sp who="#angelo_che_licenzia">
           <speaker rend="sc">ANGELO CHE LICENZIA</speaker>
           <lg>
             <l>Signor, che state ad udire e vedere</l>

--- a/tei/anonimo-la-rappresentazione-di-san-bernardo.xml
+++ b/tei/anonimo-la-rappresentazione-di-san-bernardo.xml
@@ -80,6 +80,55 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="angelo">
+            <persName>L'Angelo</persName>
+          </person>
+          <person xml:id="signore">
+            <persName>Il Signore</persName>
+          </person>
+          <person xml:id="arrigaccio">
+            <persName>Arrigaccio</persName>
+          </person>
+          <person xml:id="fantaccio">
+            <persName>Fantaccio</persName>
+          </person>
+          <person xml:id="mulattiere">
+            <persName>Il Mulattiere</persName>
+          </person>
+          <person xml:id="famiglio">
+            <persName>Famiglio</persName>
+          </person>
+          <person xml:id="cuciniere">
+            <persName>Il Cuciniere</persName>
+          </person>
+          <person xml:id="falserone">
+            <persName>Falserone, il Demonio</persName>
+          </person>
+          <person xml:id="vergine_maria">
+            <persName>La Vergine Maria</persName>
+          </person>
+          <person xml:id="san_bernardo">
+            <persName>San Bernardo</persName>
+          </person>
+          <person xml:id="placito">
+            <persName>Placito</persName>
+          </person>
+          <person xml:id="contadino">
+            <persName>Contadino</persName>
+          </person>
+          <person xml:id="altro_contadino">
+            <persName>Altro Contadino</persName>
+          </person>
+          <person xml:id="servo">
+            <persName>Un Servo</persName>
+          </person>
+          <person xml:id="maurizio">
+            <persName>Maurizio</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -160,7 +209,7 @@
     <body>
       <div n="La rappresentazione di San Bernardo">
         <stage rend="italic">Prima viene un Angelo e dice così:</stage>
-        <sp>
+        <sp who="#angelo">
           <speaker rend="sc">ANGELO</speaker>
           <lg>
             <l>Laude del Redentor della natura</l>
@@ -204,7 +253,7 @@
           </lg>
         </sp>
         <stage rend="italic">Viene il Signore in sedia e dice così:</stage>
-        <sp>
+        <sp who="#signore">
           <speaker rend="sc">SIGNORE</speaker>
           <lg>
             <l>O car fratelli, amici e compagni,</l>
@@ -218,7 +267,7 @@
           </lg>
         </sp>
         <stage rend="italic">El Signore fa un Cavaliere, e dice così:</stage>
-        <sp>
+        <sp who="#signore">
           <speaker rend="sc">SIGNORE</speaker>
           <lg>
             <l>Vedete esser forte el mio paese</l>
@@ -232,7 +281,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde Arrigaccio e dice:</stage>
-        <sp>
+        <sp who="#arrigaccio">
           <speaker rend="sc">ARRIGACCIO</speaker>
           <lg>
             <l>Io ti ringrazio, caro mio Signore,</l>
@@ -246,7 +295,7 @@
           </lg>
         </sp>
         <stage rend="italic">Viene Fantaccio con un prigione e dice al Signore:</stage>
-        <sp>
+        <sp who="#fantaccio">
           <speaker rend="sc">FANTACCIO</speaker>
           <lg>
             <l>Buona vita, Signore, i' son Fantaccio</l>
@@ -260,7 +309,7 @@
           </lg>
         </sp>
         <stage rend="italic">Dice el Prigione, ch'è mulattiere, così:</stage>
-        <sp>
+        <sp who="#mulattiere">
           <speaker rend="sc">MULATTIERE</speaker>
           <lg>
             <l>Car Signor mio, i' mi t'arraccomando</l>
@@ -284,7 +333,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde el Signore e dice così:</stage>
-        <sp>
+        <sp who="#signore">
           <speaker rend="sc">SIGNORE</speaker>
           <lg>
             <l>Or non temer, prigion, che s'tu farai</l>
@@ -298,7 +347,7 @@
           </lg>
         </sp>
         <stage rend="italic">Viene un altro con dua Romei e dice:</stage>
-        <sp>
+        <sp who="#famiglio">
           <speaker rend="sc">FAMIGLIO</speaker>
           <lg>
             <l>Signor, costoro alla strada ho trovati.</l>
@@ -312,7 +361,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde el Signore a uno Servo e dice così:</stage>
-        <sp>
+        <sp who="#signore">
           <speaker rend="sc">SIGNORE</speaker>
           <lg>
             <l>Cercate pur s'egli hanno altro nascosto,</l>
@@ -326,7 +375,7 @@
           </lg>
         </sp>
         <stage rend="italic">Viene Arrigaccio e mena due mercatanti e dice:</stage>
-        <sp>
+        <sp who="#arrigaccio">
           <speaker rend="sc">ARRIGACCIO</speaker>
           <lg>
             <l>Caro Signore, el nostro mulattiero</l>
@@ -340,7 +389,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde el Signore e dice così:</stage>
-        <sp>
+        <sp who="#signore">
           <speaker rend="sc">SIGNORE</speaker>
           <lg>
             <l>Rendetegli e suo' muli imprimamente,</l>
@@ -354,7 +403,7 @@
           </lg>
         </sp>
         <stage rend="italic">Fantaccio viene con quattro Sonatori:</stage>
-        <sp>
+        <sp who="#fantaccio">
           <speaker rend="sc">FANTACCIO</speaker>
           <lg>
             <l>Send'io, Signore, alla strada fuori</l>
@@ -378,7 +427,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde el Signore e dice così:</stage>
-        <sp>
+        <sp who="#signore">
           <speaker rend="sc">SIGNORE</speaker>
           <lg>
             <l>Deh compagnoni a me cotanto cari,</l>
@@ -392,7 +441,7 @@
           </lg>
         </sp>
         <stage rend="italic">Viene el Cuciniere col Guattero e dice:</stage>
-        <sp>
+        <sp who="#cuciniere">
           <speaker rend="sc">CUCINIERE</speaker>
           <lg>
             <l>Signor, quest'è un pover compagnone</l>
@@ -406,7 +455,7 @@
           </lg>
         </sp>
         <stage rend="italic">Dice il Guattero al Signore:</stage>
-        <sp>
+        <sp who="#falserone">
           <speaker rend="sc">FALSERONE</speaker>
           <lg>
             <l>Signor, i' son un uom malcapitato,</l>
@@ -420,7 +469,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde el Signore:</stage>
-        <sp>
+        <sp who="#signore">
           <speaker rend="sc">SIGNORE</speaker>
           <lg>
             <l>Maestro mio cucinier, costui mi piace.</l>
@@ -434,7 +483,7 @@
           </lg>
         </sp>
         <stage rend="italic">Essendo quivi appresso uno monasterio dove abitava San Bernardo, la Nostra Donna gli apparve e dice:</stage>
-        <sp>
+        <sp who="#vergine_maria">
           <speaker rend="sc">VERGINE MARIA</speaker>
           <lg>
             <l>Bernardo mio, dal mio Figliuolo amato</l>
@@ -498,7 +547,7 @@
           </lg>
         </sp>
         <stage rend="italic">Dice San Bernardo a Nostra Donna:</stage>
-        <sp>
+        <sp who="#san_bernardo">
           <speaker rend="sc">SAN BERNARDO</speaker>
           <lg>
             <l>Serenissima stella, alma Maria,</l>
@@ -512,7 +561,7 @@
           </lg>
         </sp>
         <stage rend="italic">Dice San Bernardo a uno monaco:</stage>
-        <sp>
+        <sp who="#san_bernardo">
           <speaker rend="sc">SAN BERNARDO</speaker>
           <lg>
             <l>Abbi, Placito, cura a' monacelli</l>
@@ -526,7 +575,7 @@
           </lg>
         </sp>
         <stage rend="italic">Placito monaco dice a San Bernardo:</stage>
-        <sp>
+        <sp who="#placito">
           <speaker rend="sc">PLACITO</speaker>
           <lg>
             <l>Benigno padre &lt;mio&gt; e eccellente,</l>
@@ -536,7 +585,7 @@
           </lg>
         </sp>
         <stage rend="italic">San Bernardo parla:</stage>
-        <sp>
+        <sp who="#san_bernardo">
           <speaker rend="sc">SAN BERNARDO</speaker>
           <lg>
             <l>Maurizio, Agabito, nïente</l>
@@ -546,7 +595,7 @@
           </lg>
         </sp>
         <stage rend="italic">Viene Arrigaccio e ha preso due Contadini e dice:</stage>
-        <sp>
+        <sp who="#arrigaccio">
           <speaker rend="sc">ARRIGACCIO</speaker>
           <lg>
             <l>Signore, egli è passato quattro mesi</l>
@@ -560,7 +609,7 @@
           </lg>
         </sp>
         <stage rend="italic">Dicon e Contadini al Signore:</stage>
-        <sp>
+        <sp who="#contradino #altro_contadino">
           <speaker rend="sc">CONTADINI</speaker>
           <lg>
             <l>Signor, no' sian lavorator di terra</l>
@@ -574,7 +623,7 @@
           </lg>
         </sp>
         <stage rend="italic">Dice uno de' Contadini al Signore:</stage>
-        <sp>
+        <sp who="#contadino">
           <speaker rend="sc">CONTADINO</speaker>
           <lg>
             <l>I' ho nascosi cento fiorin d'oro</l>
@@ -584,7 +633,7 @@
           </lg>
         </sp>
         <stage rend="italic">Dice l'altro Contadino:</stage>
-        <sp>
+        <sp who="#altro_contadino">
           <speaker rend="sc">ALTRO CONTADINO</speaker>
           <lg>
             <l>E io sessanta n'ho presso all'alloro</l>
@@ -594,7 +643,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde el Signore:</stage>
-        <sp>
+        <sp who="#signore">
           <speaker rend="sc">SIGNORE</speaker>
           <lg>
             <l>Tommi dinanzi costor, Arrigaccio,</l>
@@ -608,7 +657,7 @@
           </lg>
         </sp>
         <stage rend="italic">Viene Fantaccio e dice al Signore:</stage>
-        <sp>
+        <sp who="#fantaccio">
           <speaker rend="sc">FANTACCIO</speaker>
           <lg>
             <l>O car nostro Signor, buone novelle!</l>
@@ -622,7 +671,7 @@
           </lg>
         </sp>
         <stage rend="italic">Viene Arrigaccio con San Bernardo:</stage>
-        <sp>
+        <sp who="#arrigaccio">
           <speaker rend="sc">ARRIGACCIO</speaker>
           <lg>
             <l>Signore, el venerabil sacerdote</l>
@@ -636,7 +685,7 @@
           </lg>
         </sp>
         <stage rend="italic">Dice San Bernardo al Signore:</stage>
-        <sp>
+        <sp who="#san_bernardo">
           <speaker rend="sc">SAN BERNARDO</speaker>
           <lg>
             <l>Come disse Arrigaccio, i' son venuto,</l>
@@ -650,7 +699,7 @@
           </lg>
         </sp>
         <stage rend="italic">Dice el Signore a' compagni:</stage>
-        <sp>
+        <sp who="#signore">
           <speaker rend="sc">SIGNORE</speaker>
           <lg>
             <l>Compagni miei fedel, venite avanti</l>
@@ -664,7 +713,7 @@
           </lg>
         </sp>
         <stage rend="italic">Dice San Bernardo al Signore:</stage>
-        <sp>
+        <sp who="#san_bernardo">
           <speaker rend="sc">SAN BERNARDO</speaker>
           <lg>
             <l>Acciò che 'l mio parlar sanza bugie</l>
@@ -688,7 +737,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde el Signore a San Bernardo:</stage>
-        <sp>
+        <sp who="#signore">
           <speaker rend="sc">SIGNORE</speaker>
           <lg>
             <l>O riverendo Padre, i' ti confesso</l>
@@ -712,7 +761,7 @@
           </lg>
         </sp>
         <stage rend="italic">Dice San Bernardo:</stage>
-        <sp>
+        <sp who="#signore">
           <speaker rend="sc">SIGNORE</speaker>
           <lg>
             <l>Signore, questo maledetto astuto</l>
@@ -726,7 +775,7 @@
           </lg>
         </sp>
         <stage rend="italic">Dice Fantaccio al Signore:</stage>
-        <sp>
+        <sp who="#fantaccio">
           <speaker rend="sc">FANTACCIO</speaker>
           <lg>
             <l>Noi abbiàn tutto cercô e ricercato,</l>
@@ -740,7 +789,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde el Signore:</stage>
-        <sp>
+        <sp who="#signore">
           <speaker rend="sc">SIGNORE</speaker>
           <lg>
             <l>Orsù orsù, ed anche costui venga,</l>
@@ -754,7 +803,7 @@
           </lg>
         </sp>
         <stage rend="italic">Uno Servo dice al Signore:</stage>
-        <sp>
+        <sp who="#servo">
           <speaker rend="sc">SERVO</speaker>
           <lg>
             <l>Signore, egli è sì vinto e mal vestito</l>
@@ -768,7 +817,7 @@
           </lg>
         </sp>
         <stage rend="italic">Dice el Signore a' Famigli:</stage>
-        <sp>
+        <sp who="#signore">
           <speaker rend="sc">SIGNORE</speaker>
           <lg>
             <l>Menatemelo qui, non più parole,</l>
@@ -782,7 +831,7 @@
           </lg>
         </sp>
         <stage rend="italic">Viene el Guattero menato quasi per forza e dice al Signore così:</stage>
-        <sp>
+        <sp who="#falserone">
           <speaker rend="sc">FALSERONE</speaker>
           <lg>
             <l>Signor, questa brigata m'ha diserto,</l>
@@ -796,7 +845,7 @@
           </lg>
         </sp>
         <stage rend="italic">Dice San Bernardo così:</stage>
-        <sp>
+        <sp who="#san_bernardo">
           <speaker rend="sc">SAN BERNARDO</speaker>
           <lg>
             <l>Or dimmi, vecchio, che va' tu facendo?</l>
@@ -810,7 +859,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde el Guattero a San Bernardo:</stage>
-        <sp>
+        <sp who="#falserone">
           <speaker rend="sc">FALSERONE</speaker>
           <lg>
             <l>I' non so qual&lt;e&gt; sia sì poco accorto</l>
@@ -844,7 +893,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde San Bernardo:</stage>
-        <sp>
+        <sp who="#san_bernardo">
           <speaker rend="sc">SAN BERNARDO</speaker>
           <lg>
             <l>O Falseron, quel che tu di' è certo,</l>
@@ -868,7 +917,7 @@
           </lg>
         </sp>
         <stage rend="italic">El Guattero dice così:</stage>
-        <sp>
+        <sp who="#falserone">
           <speaker rend="sc">FALSERONE</speaker>
           <lg>
             <l>Oimè, cimè, &lt;oimè&gt;, di Paradiso</l>
@@ -902,7 +951,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde el Signore a San Bernardo:</stage>
-        <sp>
+        <sp who="#signore">
           <speaker rend="sc">SIGNORE</speaker>
           <lg>
             <l>O Padre santo, <foreign xml:lang="lat">miserere mei</foreign>,</l>
@@ -926,7 +975,7 @@
           </lg>
         </sp>
         <stage rend="italic">Dice San Bernardo a tutti:</stage>
-        <sp>
+        <sp who="#san_bernardo">
           <speaker rend="sc">SAN BERNARDO</speaker>
           <lg>
             <l>Acciò che Dio in sua grazia v'accetti,</l>
@@ -940,7 +989,7 @@
           </lg>
         </sp>
         <stage rend="italic">&lt;Ar&gt;rigaccio dice a San Bernardo:</stage>
-        <sp>
+        <sp who="#arrigaccio">
           <speaker rend="sc">ARRIGACCIO</speaker>
           <lg>
             <l>O santo Abate, in questo tristo impaccio</l>
@@ -960,7 +1009,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde San Bernardo:</stage>
-        <sp>
+        <sp who="#san_bernardo">
           <speaker rend="sc">SAN BERNARDO</speaker>
           <lg>
             <l>Ognun di voi il benvenuto sia,</l>
@@ -970,7 +1019,7 @@
           </lg>
         </sp>
         <stage rend="italic">Dice Maurizio a tutti e Compagni e al Signore:</stage>
-        <sp>
+        <sp who="#maurizio">
           <speaker rend="sc">MAURIZIO</speaker>
           <lg>
             <l>Signori stati a pericol sì gravi,</l>

--- a/tei/anonimo-la-rappresentazione-di-san-giovanni-battista.xml
+++ b/tei/anonimo-la-rappresentazione-di-san-giovanni-battista.xml
@@ -80,6 +80,61 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="angelo">
+            <persName>Un Angelo che annuncia</persName>
+          </person>
+          <person xml:id="san_giovanni">
+            <persName>San Giovanni Battista</persName>
+          </person>
+          <personGrp xml:id="scribi">
+            <name>Gli Scribi del Re Erode</name>
+          </personGrp>
+          <person xml:id="gesù">
+            <persName>Gesù Cristo</persName>
+          </person>
+          <person xml:id="spirito_santo">
+            <persName>Lo Spirito Santo</persName>
+          </person>
+          <person xml:id="re_erode">
+            <persName>Il Re Erode</persName>
+          </person>
+          <person xml:id="reina">
+            <persName>La Reina</persName>
+          </person>
+          <person xml:id="vassallo">
+            <persName>Il Vassallo del Re</persName>
+          </person>
+          <person xml:id="araldo">
+            <persName>L'Araldo del Re</persName>
+          </person>
+          <person xml:id="signore">
+            <persName>Signore</persName>
+          </person>
+          <person xml:id="altro_signore">
+            <persName>Altro Signore</persName>
+          </person>
+          <person xml:id="fanciulla">
+            <persName>La Fanciulla</persName>
+          </person>
+          <person xml:id="barone">
+            <persName>Barone</persName>
+          </person>
+          <person xml:id="altro_barone">
+            <persName>Altro Barone</persName>
+          </person>
+          <person xml:id="siniscalco">
+            <persName>Il Siniscalco</persName>
+          </person>
+          <person xml:id="manigoldo">
+            <persName>Il Manigoldo</persName>
+          </person>
+          <person xml:id="adamo">
+            <persName>Adamo</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -138,8 +193,7 @@
         <castItem>
           <role>Il Manigoldo</role>
         </castItem>
-        <castItem>
-          <role>Adamo</role> e i <role>Santi Padri del Limbo</role>
+        <castItem><role>Adamo</role> e i <role>Santi Padri del Limbo</role>
         </castItem>
       </castList>
     </front>
@@ -149,7 +203,7 @@
       </div>
       <div n="La rappresentazione di San Giovanni Battista quando fu decollato">
         <stage rend="italic">In prima viene uno Angelo e annuncia dicendo le infrascritte stanze:</stage>
-        <sp>
+        <sp who="#angelo">
           <speaker rend="sc">ANGELO</speaker>
           <lg>
             <l>A voi, sapïenti cittadini,</l>
@@ -223,7 +277,7 @@
           </lg>
         </sp>
         <stage rend="italic">Viene San Giovanni e dice così:</stage>
-        <sp>
+        <sp who="#san_giovanni">
           <speaker rend="sc">SAN GIOVANNI</speaker>
           <lg>
             <l>O gente umana, fonte d'eccellenza,</l>
@@ -257,7 +311,7 @@
           </lg>
         </sp>
         <stage rend="italic">Ora battezza tutti i discepoli ed ha a dire questa stanza. E quando sono battezzati, verranno gli Scribi del Re a San Giovanni e dimandano chi egli è:</stage>
-        <sp>
+        <sp who="#san_giovanni">
           <speaker rend="sc">SAN GIOVANNI</speaker>
           <lg>
             <l>Battezzo in acqua a questa nuova legge</l>
@@ -271,7 +325,7 @@
           </lg>
         </sp>
         <stage rend="italic">Vengono gli Scribi a San Giovanni, cioè due bellissimi barbassori e dicono così a San Giovanni:</stage>
-        <sp>
+        <sp who="#scribi">
           <speaker rend="sc">SCRIBI</speaker>
           <lg>
             <l>Qual si sia la cagion del tuo venire,</l>
@@ -285,7 +339,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde San Giovanni agli Scribi e dice così:</stage>
-        <sp>
+        <sp who="#san_giovanni">
           <speaker rend="sc">SAN GIOVANNI</speaker>
           <lg>
             <l>Cristo non son, che innanzi a me è nato</l>
@@ -296,14 +350,14 @@
           </lg>
         </sp>
         <stage rend="italic">Rispondo&lt;no&gt; gli Scribi e dicono con furia a San Giovanni:</stage>
-        <sp>
+        <sp who="#scribi">
           <speaker rend="sc">SCRIBI</speaker>
           <lg>
             <l>Perché dunque battezzi, o per qual via?</l>
           </lg>
         </sp>
         <stage rend="italic">Risponde San Giovanni:</stage>
-        <sp>
+        <sp who="#san_giovanni">
           <speaker rend="sc">SAN GIOVANNI</speaker>
           <lg>
             <l>Battezzo in acqua ed in Cristo mi fido</l>
@@ -311,7 +365,7 @@
           </lg>
         </sp>
         <stage rend="italic">Hae a parire Gesù e Dio Padre in sul monte e hae a venire Gesù con quattro angeli, due innanzi e due a drieto, e hae a venire tanto adagio tanto che San Giovanni dica questa istanza innanzi che giunga a Lui:</stage>
-        <sp>
+        <sp who="#san_giovanni">
           <speaker rend="sc">SAN GIOVANNI</speaker>
           <lg>
             <l>Volgete, gente umana, lo 'ntelletto</l>
@@ -325,7 +379,7 @@
           </lg>
         </sp>
         <stage rend="italic">Parla ancora San Giovanni e volgesi agli Scribi e mostra loro Gesù e dice:</stage>
-        <sp>
+        <sp who="#san_giovanni">
           <speaker rend="sc">SAN GIOVANNI</speaker>
           <lg>
             <l>Ecco l'Agnel di Dio immaculato,</l>
@@ -349,7 +403,7 @@
           </lg>
         </sp>
         <stage rend="italic">Giugne Gesù tra loro e tutti si gettono bocconi. Gesù sì dice:</stage>
-        <sp>
+        <sp who="#gesù">
           <speaker rend="sc">GESÙ</speaker>
           <lg>
             <l>La pace mia, che in eterno meno</l>
@@ -373,7 +427,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde San Giovanni a Gesù:</stage>
-        <sp>
+        <sp who="#san_giovanni">
           <speaker rend="sc">SAN GIOVANNI</speaker>
           <lg>
             <l>Omè, omè, benigno Signor mio,</l>
@@ -383,7 +437,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde Gesù a San Giovanni:</stage>
-        <sp>
+        <sp who="#gesù">
           <speaker rend="sc">GESÙ</speaker>
           <lg>
             <l>Taci, che questo piace al Padre mio,</l>
@@ -391,7 +445,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde San Giovanni a Gesù:</stage>
-        <sp>
+        <sp who="#san_giovanni">
           <speaker rend="sc">SAN GIOVANNI</speaker>
           <lg>
             <l>Oltre, poiché a lui piace, andianne all'acque.</l>
@@ -399,7 +453,7 @@
           </lg>
         </sp>
         <stage rend="italic">Hae a venire una colomba cioè lo Spirito Santo ed hae a essere una boce nascosa che dica per quella colomba e hae a dire questa istanza che dice così:</stage>
-        <sp>
+        <sp who="#spirito_santo">
           <speaker rend="sc">SPIRITO SANTO</speaker>
           <lg>
             <l>Ecco che quest'è el mio Figliuol diletto</l>
@@ -413,7 +467,7 @@
           </lg>
         </sp>
         <stage rend="italic">Vassene Gesù in sul monte e San Giovanni ripiglia la sua predica e dice sette stanze che dicono così:</stage>
-        <sp>
+        <sp who="#san_giovanni">
           <speaker rend="sc">SAN GIOVANNI</speaker>
           <lg>
             <l>— Apparecchiate la via al Signore,</l>
@@ -487,7 +541,7 @@
           </lg>
         </sp>
         <stage rend="italic">Ora &lt;il Re&gt; ha venire nel diserto ed ha a giungere innanzi che questa stanza qui di sopra sia fornita, e San Giovanni gli ha a dire queste tre stanze che sono qui da piè:</stage>
-        <sp>
+        <sp who="#san_giovanni">
           <speaker rend="sc">SAN GIOVANNI</speaker>
           <lg>
             <l>O sempiterno ed infinito e pio,</l>
@@ -521,7 +575,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde il Re a San Giovanni:</stage>
-        <sp>
+        <sp who="#re_erode">
           <speaker rend="sc">RE ERODE</speaker>
           <lg>
             <l>O profeta di Dio alluminato,</l>
@@ -531,7 +585,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde San Giovanni così:</stage>
-        <sp>
+        <sp who="#san_giovanni">
           <speaker rend="sc">SAN GIOVANNI</speaker>
           <lg>
             <l>Ah folle Re, non mel tener celato!</l>
@@ -541,7 +595,7 @@
           </lg>
         </sp>
         <stage rend="italic">Ritorna il Re a casa e vassene di tratto alla Femmina e sì le dice così:</stage>
-        <sp>
+        <sp who="#re_erode">
           <speaker rend="sc">RE ERODE</speaker>
           <lg>
             <l>Omè dolente a me, isventurato!</l>
@@ -555,7 +609,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde la Femmina tutta turbata, quasi in atto di piangere, e dice così:</stage>
-        <sp>
+        <sp who="#reina">
           <speaker rend="sc">REINA</speaker>
           <lg>
             <l>Omè, misera a me, o tapinella,</l>
@@ -569,7 +623,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde il Re e dice così:</stage>
-        <sp>
+        <sp who="#re_erode">
           <speaker rend="sc">RE ERODE</speaker>
           <lg>
             <l>Taci, donna, non dir cota' parole,</l>
@@ -579,7 +633,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde la Femmina e dice così:</stage>
-        <sp>
+        <sp who="#reina">
           <speaker rend="sc">REINA</speaker>
           <lg>
             <l>Ahi franco Re, sa' tu che far si vuole?</l>
@@ -599,7 +653,7 @@
           </lg>
         </sp>
         <stage rend="italic">Parla il Re e dice così:</stage>
-        <sp>
+        <sp who="#re_erode">
           <speaker rend="sc">RE ERODE</speaker>
           <lg>
             <l>Taci, donna, non dir, raffrena omai</l>
@@ -613,7 +667,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde la Femmina e dice così:</stage>
-        <sp>
+        <sp who="#reina">
           <speaker rend="sc">REINA</speaker>
           <lg>
             <l>La cagion c'è se te la metti in testa,</l>
@@ -635,7 +689,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde il Re subitamente e dice così:</stage>
-        <sp>
+        <sp who="#re_erode">
           <speaker rend="sc">RE ERODE</speaker>
           <lg>
             <l>Fia fatto, donna, eccoti, 'l &lt;tu&gt;o talento.</l>
@@ -643,7 +697,7 @@
           </lg>
         </sp>
         <stage rend="italic">E dette queste parole, il Re ne va in sedia e chiama il Vassallo e 'l Vassallo va e inginocchiasi e 'l Re dice così:</stage>
-        <sp>
+        <sp who="#re_erode">
           <speaker rend="sc">RE ERODE</speaker>
           <lg>
             <l>Muovi, Vassallo, e vattene al diserto,</l>
@@ -657,7 +711,7 @@
           </lg>
         </sp>
         <stage rend="italic">Muovesi el Vassallo e va e a San Giovanni e dice così a San Giovanni:</stage>
-        <sp>
+        <sp who="#vassallo">
           <speaker rend="sc">VASSALLO</speaker>
           <lg>
             <l>O buon Giovanni, a Dio servo fedele,</l>
@@ -671,7 +725,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde San Giovanni al Vassallo e dice quattro versi e poi il Re si leva di sedia e vassene dov'è la Femmina e ivi aspetta San Giovanni. Dice San Giovanni:</stage>
-        <sp>
+        <sp who="#san_giovanni">
           <speaker rend="sc">SAN GIOVANNI</speaker>
           <lg>
             <l>Laudato sia l'eterno e sommo Iddio,</l>
@@ -681,7 +735,7 @@
           </lg>
         </sp>
         <stage rend="italic">Giugne San Giovanni al Re e dice così:</stage>
-        <sp>
+        <sp who="#san_giovanni">
           <speaker rend="sc">SAN GIOVANNI</speaker>
           <lg>
             <l>Eccomi, Re, a tutto il tuo disio.</l>
@@ -689,7 +743,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde il Re presto e dice così:</stage>
-        <sp>
+        <sp who="#re_erode">
           <speaker rend="sc">RE ERODE</speaker>
           <lg>
             <l>Ah Giovanni, Giovanni, il tuo rigoglio</l>
@@ -703,7 +757,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde San Giovanni al Re:</stage>
-        <sp>
+        <sp who="#san_giovanni">
           <speaker rend="sc">SAN GIOVANNI</speaker>
           <lg>
             <l>Io dico, Re, se vuoi fuggire il lutto</l>
@@ -713,7 +767,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde la Femmina che è quivi presente e dice così:</stage>
-        <sp>
+        <sp who="#reina">
           <speaker rend="sc">REINA</speaker>
           <lg>
             <l>O sapïente Re e magno Signore,</l>
@@ -727,7 +781,7 @@
           </lg>
         </sp>
         <stage rend="italic">Parla il Re con gran superbia e dice così:</stage>
-        <sp>
+        <sp who="#re_erode">
           <speaker rend="sc">RE ERODE</speaker>
           <lg>
             <l>Oltre, franchi scudier, pigliate questo</l>
@@ -741,7 +795,7 @@
           </lg>
         </sp>
         <stage rend="italic">Fu preso e messo in prigione e il Re se ne va in sedia allegro e dice a' Baron così. Ora ha dire il Re all'Araldo che vada a invitare la baronia:</stage>
-        <sp>
+        <sp who="#re_erode">
           <speaker rend="sc">RE ERODE</speaker>
           <lg>
             <l>Fatti qua presto, o cavaliere Araldo,</l>
@@ -755,7 +809,7 @@
           </lg>
         </sp>
         <stage rend="italic">Partesi l'Araldo e va annunziare e dice:</stage>
-        <sp>
+        <sp who="#araldo">
           <speaker rend="sc">ARALDO</speaker>
           <lg>
             <l>Magnifico Signore, in veritate</l>
@@ -769,7 +823,7 @@
           </lg>
         </sp>
         <stage rend="italic">Partesi l'Araldo, e vassene il Signore colla sua gente e dice così:</stage>
-        <sp>
+        <sp who="#signore">
           <speaker rend="sc">SIGNORE</speaker>
           <lg>
             <l>Po' ch'a lui piace, i' son molto contento</l>
@@ -779,7 +833,7 @@
           </lg>
         </sp>
         <stage rend="italic">Giungono al Re e dicon così:</stage>
-        <sp>
+        <sp who="#signore">
           <speaker rend="sc">SIGNORE</speaker>
           <lg>
             <l>Eccoti, Re, che t'è in piacimento</l>
@@ -789,7 +843,7 @@
           </lg>
         </sp>
         <stage rend="italic">Giungono tutti e Signori e Baroni e 'l Re dice loro così:</stage>
-        <sp>
+        <sp who="#re_erode">
           <speaker rend="sc">RE ERODE</speaker>
           <lg>
             <l>Venerabili miei Regi e Signori</l>
@@ -823,7 +877,7 @@
           </lg>
         </sp>
         <stage rend="italic">Vannone tutti a tavola e mangiano e quando hanno mezzo mangiato e la Reina manda la Fanciulla a ballare ed ella va e balla una danza poi fa lo inchino al Re suo padre e quivi si rizza uno di quegli Signori e dice così al Re:</stage>
-        <sp>
+        <sp who="#altro_signore">
           <speaker rend="sc">ALTRO SIGNORE</speaker>
           <lg>
             <l>O glorïosa Maestà regale,</l>
@@ -837,7 +891,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde il Re e dice così:</stage>
-        <sp>
+        <sp who="#re_erode">
           <speaker rend="sc">RE ERODE</speaker>
           <lg>
             <l>Cara la vita mia, Signor, mi tegno</l>
@@ -851,7 +905,7 @@
           </lg>
         </sp>
         <stage rend="italic">Partesi la Fanciulla dalla tavola e vassene alla Madre e dice così:</stage>
-        <sp>
+        <sp who="#fanciulla">
           <speaker rend="sc">FANCIULLA</speaker>
           <lg>
             <l>Diletta madre mia, i' sono stata</l>
@@ -865,7 +919,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde la Madre alla Figlia e dice così:</stage>
-        <sp>
+        <sp who="#reina">
           <speaker rend="sc">REINA</speaker>
           <lg>
             <l>Va, dolce figlia mia, al Re tuo padre.</l>
@@ -879,7 +933,7 @@
           </lg>
         </sp>
         <stage rend="italic">Or si parte la Fanciulla dalla Madre e va al Re e dice così:</stage>
-        <sp>
+        <sp who="#fanciulla">
           <speaker rend="sc">FANCIULLA</speaker>
           <lg>
             <l>O degnitosi, egregi Signor cari,</l>
@@ -893,7 +947,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponda il Re e dice così:</stage>
-        <sp>
+        <sp who="#re_erode">
           <speaker rend="sc">RE ERODE</speaker>
           <lg>
             <l>Omè, omè, figliuola, maledetta</l>
@@ -917,7 +971,7 @@
           </lg>
         </sp>
         <stage rend="italic">A queste parole la Fanciulla fa vista di piangere, ed un Barone si rizza su e dice così:</stage>
-        <sp>
+        <sp who="#barone">
           <speaker rend="sc">BARONE</speaker>
           <lg>
             <l>O sapïente e vera Monarchia,</l>
@@ -931,7 +985,7 @@
           </lg>
         </sp>
         <stage rend="italic">Ancora sta pertinace il Re e un altro Barone si rizza sù e dice così:</stage>
-        <sp>
+        <sp who="#altro_barone">
           <speaker rend="sc">ALTRO BARONE</speaker>
           <lg>
             <l>Oltre sù, Signore, deh, questo giorno</l>
@@ -945,7 +999,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde il Re e dice così:</stage>
-        <sp>
+        <sp who="#re_erode">
           <speaker rend="sc">RE ERODE</speaker>
           <lg>
             <l>Io vorre' nanzi che 'l mio regno fosse</l>
@@ -969,7 +1023,7 @@
           </lg>
         </sp>
         <stage rend="italic">Fassi innanzi il Siniscalco e chiama tutta la sua gente e dice così:</stage>
-        <sp>
+        <sp who="#siniscalco">
           <speaker rend="sc">SINISCALCO</speaker>
           <lg>
             <l>Oltre sù, con prestezza, nonne state,</l>
@@ -983,7 +1037,7 @@
           </lg>
         </sp>
         <stage rend="italic">Hanno a 'ndare alla prigione ma hanno a 'spettare che Gesù si parta da San Giovanni e poi hanno a correre là. Dice Gesù a San Giovanni:</stage>
-        <sp>
+        <sp who="#gesù">
           <speaker rend="sc">GESÙ</speaker>
           <lg>
             <l>O buon Giovanni, il fin di questa vita</l>
@@ -1027,7 +1081,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde San Giovanni:</stage>
-        <sp>
+        <sp who="#san_giovanni">
           <speaker rend="sc">SAN GIOVANNI</speaker>
           <lg>
             <l>O Verbo eterno, o Gesù benedetto,</l>
@@ -1041,7 +1095,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde Gesù a San Giovanni:</stage>
-        <sp>
+        <sp who="#gesù">
           <speaker rend="sc">GESÙ</speaker>
           <lg>
             <l>Istà forte, Giovanni, che gran frutto</l>
@@ -1051,7 +1105,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde San Giovanni:</stage>
-        <sp>
+        <sp who="#san_giovanni">
           <speaker rend="sc">SAN GIOVANNI</speaker>
           <lg>
             <l>Pon mente al viso mio lieto e asciutto:</l>
@@ -1061,7 +1115,7 @@
           </lg>
         </sp>
         <stage rend="italic">Viene il Manigoldo alla prigione e dice così a San Giovanni:</stage>
-        <sp>
+        <sp who="#manigoldo">
           <speaker rend="sc">MANIGOLDO</speaker>
           <lg>
             <l>Vien qua Giovanni, e tien la mente desta.</l>
@@ -1071,7 +1125,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde San Giovanni:</stage>
-        <sp>
+        <sp who="#san_giovanni">
           <speaker rend="sc">SAN GIOVANNI</speaker>
           <lg>
             <l>Laudato Iddio ad ogni sua richiesta.</l>
@@ -1081,7 +1135,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde il Manigoldo e dice:</stage>
-        <sp>
+        <sp who="#manigoldo">
           <speaker rend="sc">MANIGOLDO</speaker>
           <lg>
             <l>Perdonami per Dio, Giovanni buono,</l>
@@ -1091,7 +1145,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde San Giovanni:</stage>
-        <sp>
+        <sp who="#san_giovanni">
           <speaker rend="sc">SAN GIOVANNI</speaker>
           <lg>
             <l>Fa francamente, che baleno o tuono</l>
@@ -1101,7 +1155,7 @@
           </lg>
         </sp>
         <stage rend="italic">San Giovanni chinò el capo e fugli tagliato e il Siniscalco aspetta col bacino e drento vi messe la testa, e dipartissi l'Anima dal corpo e andonne al Limbo e disse così a' Santi Padri che sono nel Limbo:</stage>
-        <sp>
+        <sp who="#san_giovanni">
           <speaker rend="sc">SAN GIOVANNI</speaker>
           <lg>
             <l>Celeste gaudio e letizia infinita</l>
@@ -1115,7 +1169,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde Adamo e dice così:</stage>
-        <sp>
+        <sp who="#adamo">
           <speaker rend="sc">ADAMO</speaker>
           <lg>
             <l>Quel vero Iddio Figliuol di Dio, che nato</l>
@@ -1129,7 +1183,7 @@
           </lg>
         </sp>
         <stage rend="italic">Il Siniscalco porta la testa in mensa e dice così:</stage>
-        <sp>
+        <sp who="#siniscalco">
           <speaker rend="sc">SINISCALCO</speaker>
           <lg>
             <l>Ecco, magno Signor, la chiesta testa</l>
@@ -1138,7 +1192,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde subito il Re e dice così:</stage>
-        <sp>
+        <sp who="#re_erode">
           <speaker rend="sc">RE ERODE</speaker>
           <lg>
             <l>Cattiva, dolorosa figlia ria,</l>
@@ -1149,7 +1203,7 @@
           </lg>
         </sp>
         <stage rend="italic">La Fanciulla prese la testa e portolla alla Madre e dice così alla Madre:</stage>
-        <sp>
+        <sp who="#fanciulla">
           <speaker rend="sc">FANCIULLA</speaker>
           <lg>
             <l>Ecco, diletta madre, del Battista</l>
@@ -1159,7 +1213,7 @@
           </lg>
         </sp>
         <stage rend="italic">Risponde la Madre e dice così:</stage>
-        <sp>
+        <sp who="#reina">
           <speaker rend="sc">REINA</speaker>
           <lg>
             <l>Mostra qua, dolce figlïuola. Vista!...</l>
@@ -1169,7 +1223,7 @@
           </lg>
         </sp>
         <stage rend="italic">Dette queste parole, hassi a fare ruinare la Reina e fare uno scoppio che s'accordi l'uno coll'altro e la terra s'apre ed inghiottisce la Reina. Dipoi dice l'Angelo questa stanza e licenzia ognuno:</stage>
-        <sp>
+        <sp who="#angelo">
           <speaker rend="sc">ANGELO</speaker>
           <lg>
             <l>O voi ch'avete la festa veduta</l>

--- a/tei/anonimo-la-veniexiana.xml
+++ b/tei/anonimo-la-veniexiana.xml
@@ -74,6 +74,28 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="iulius">
+            <persName>Iulius</persName>
+          </person>
+          <person xml:id="oria">
+            <persName>Oria</persName>
+          </person>
+          <person xml:id="valeria">
+            <persName>Valeria</persName>
+          </person>
+          <person xml:id="angela">
+            <persName>Angela</persName>
+          </person>
+          <person xml:id="nena">
+            <persName>Nena</persName>
+          </person>
+          <person xml:id="bernardo">
+            <persName>Bernardo</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -101,7 +123,7 @@
         <stage>
           <foreign xml:lang="lat" rend="italic">Iulius iuvenis foresterius.</foreign>
         </stage>
-        <sp>
+        <sp who="#iulius">
           <speaker>
             <add>&lt;IULIUS&gt;</add>
           </speaker>
@@ -111,37 +133,37 @@
         <stage>
           <foreign xml:lang="lat" rend="italic">Iulius foresterius, Oria serva.</foreign>
         </stage>
-        <sp>
+        <sp who="#iulius">
           <speaker>
             <add>&lt;IULIUS&gt;</add>
           </speaker>
           <p> Dio benedica questa gentil giovene, che va costumata como una sapia sposa.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Gran merçé a la Magnificenzia Vostra.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> De grazia, vi supplico, firmative, che io vi dica doe parolle, e perdonatime se io son prosumptuoso: ché la umanità vostra mi presta confidenzia da parlarvi.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Al comando vostro, Missier.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> I' sun un zentilomo forrestieri, venuto per veder la noboltà de questa inclita terra e per cognoscer qua<add>&lt;l&gt;</add> sii una Venezia. Ma, oltre che somamente me ha piaciuto la terra, senza comparazion più queste belissime gentildonne, e, fra tutte, vostra Madona, la giovene: tanto che me ha cavato il core e facto schiavo perpetuo de soa beltà e gentileza. Io vi chiedo, di grazia: diceteli per parte mia che son suo, e a lei degnateve ricomandarmi.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Perdonème, Missier, che no voio far tal imbasata (avé pazienzia) del vostro amor.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> De grazia, vi supplico.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Mo via, e ne l'avé troppo bon tempo!</p>
         </sp>
@@ -198,129 +220,129 @@ quanto più bella d'ogni bella sète. </l>
         <stage>
           <foreign xml:lang="lat" rend="italic">Oria serva, Valeria domina.</foreign>
         </stage>
-        <sp>
+        <sp who="#oria">
           <speaker>
             <add>&lt;ORIA&gt;</add>
           </speaker>
           <p> Madona Valiera, che voleu pagar? ché ve dirò de gnovo.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Che? bestia! de la çizeta, che xè vegnua?</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Digo altro che çizeta! che xè meio.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Che cosa?</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Nol voio dir, perché m'avé ditto 'bestia'.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Non ti scorozar, cara fia. Dilo voluntiera.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Non sciò chi 'l gera, che in la calle m'ha parlao, non so che, de vu.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Che distu? de mi? che zànzestu?</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Vàrdame Dio! no l'ho volesto scoltar una parolla.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Chi xèlo costù? Chi te ha parlao?</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Un forrestier vestio da sbisao, cun la spa', col penachio in la bereta, col vestio a la corta, de veluo.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Xèlo un zovene forrestier co i cavei negri?</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Madona sì: negri, trezolai.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Che dìselo?</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> No l'ho volesto scoltar, mi.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> O che maladeta zente che xè sorda a i besogni!</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Sì, ché me dissé vilanie, o ché me fessé dar de le bastonae a Missier.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Ti ha ben paura! No sastu tàser queste cose?</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Non le ho voleste scoltar, per no tàserle.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Estu tanto smemoria, che ti non t'arecordi una parolla?</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Se no una, per questa Crose! la dreana.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Dila, cun ti la scià.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Disse: «Recomandeme a Madona».</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Ti me sogie.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Se no volé creder, vostro danno!</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Che gh'hastu resposto?</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Gnente, gnente.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Non esser cusì discortese. Se til scontre, faghe reverenzia e di': «La Madonna ve rengrazia», sastu?</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> No voio che Missier me çiga, po'.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> No çercar de Missier. Ti fa' çiò che te digo mi; e tasi. Hastu inteso?</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Madona sì.</p>
         </sp>
@@ -353,225 +375,225 @@ foco del vostro amore. </l>
         <stage>
           <foreign xml:lang="lat" rend="italic">Angela vidua, Nena in lecto.</foreign>
         </stage>
-        <sp>
+        <sp who="#angela">
           <speaker>
             <add>&lt;ANGELA&gt;</add>
           </speaker>
           <p> Nena, dolçe, cara Nena, dòrmestu, fia?</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Volea far un soneto: ché sun straca de voltarmi in questo benedeto letto.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Ti xè in letto, e mi nel fuogo che me consuma.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Che diseu, de fuogo?</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Le mie carne brùsciano. Moro de doia.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Aveu frebe? Lasseme un puoco tocar.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> La frebe xè qua entro, nel cuor.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> De la bon'ora, chiamaremo misser Antonio, el nostro medico.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> No xè, in tuta Veniesa, si no un medico che savesse medigar Anzola.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> No: si no quei che no xè castroni.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Ti no intende. Digo un sol omo.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Cussì voliu dir: un omo grande, bello, possente?</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Digo un sol: che xè un viso de anzolo, un musin d'oro, vegnuo qual dal Paradiso.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Madona, tuti xè uomini.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Sì, ma questo xè el megio de quanti xè in Veniesa, in Levante, in Terraferma, in tuto 'l mondo.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Ve par cussì, perché vu ghe volé ben.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Che, ben?! El xè el mio tesoro, le mie zoie, el mio dio!</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Felo vegnir, se 'nd'avé tanta voia.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Non vul vardarme sotto el panesello: el me crede vechia. E po', el xè inamorao in Valiera, qua presso casa.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Iiih! El xè quel bel fio? Che voleu far d'un puto?</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Che, an? Varda sta bestia! Ti no scià, no?</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Disé un puoco zò che volé far.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Butarghe cusì le braze al collo, zicar quelle lavrine, e tegnirlo streto streto.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> E po', no altro?</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> La lenguina in boca.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Meio lo saverae far mi, ca esso.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Quella bochina dolçe tegnerla per mi, cussì, sempre sempre!</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Sté indrio, ché me sofoghé!</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Caro, dolçe pì che no xè el zùcaro!</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Vu no v'arecordé che sun donna.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Sun morta, mi. Sudo in aqua, tuta.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Gran merçé! perché vu fe matiere.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Passarà pur la note, e vegnerà doman.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Che, doman? Disé: che fareu doman?</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Voio aver quel fio, mi.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> A che modo voleu far?</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Cun danari e cun presenti.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Sì, cun zente che 'l sappa menar.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Cun tuto ziò che ti dirà.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Orsù, torné al vostro luogo, e dormé.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Voio star qua. E, se ti vul che dorma, gèttame cussì le to braze; e mi sererò gi ochii, e te crederò el fio.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Voleu cusì?</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Sì, cara fia.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Me credeu, mo?</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> No ancora: de qua un pezeto.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Vogio dormir, mi. Guardé: non me strenzé.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Vostu farme un piaser?</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Che?</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Cara, dolçe, sta' cusì un puoco; e po' comenza a biastemar, azò che ti creda omo.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> No sciò zò che dir, mi.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Biastema el corpo de Cristo, menzona le parolle sporche: co' fa i omeni.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Disé: che parolle?</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Quelle sporcarie che se dise in bordello, no sastu?</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Se no dormo, le dirò; ma, se dormo, non dirò gnente, mi.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Cara Nena, fa' un puoco el sbisao, per mio amor.</p>
         </sp>
@@ -583,7 +605,7 @@ foco del vostro amore. </l>
         <stage>
           <foreign xml:lang="lat" rend="italic">Nena sola.</foreign>
         </stage>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Tutto zò che Madonna pensa de notte, besogna che mi lo catta de zorno per contentarla. Adesso vuol un fio che se noma Iulio forestier - co' la dise, moroso de Madona Valiera - che xè alozao a l'Ostaria del Pavon. Ma no sciò che deba far; la cossa xè difiçile: condur el fio, farlo secreto. E po', una donna no puol.</p>
           <p>
@@ -592,487 +614,487 @@ Voio pa<add>&lt;r&gt;</add>lar col Bernardo fachin, che xè pratico, secreto e f
         <stage>
           <foreign xml:lang="lat" rend="italic">Nena, Bernardus.</foreign>
         </stage>
-        <sp>
+        <sp who="#nena">
           <speaker>
             <add>&lt;NENA&gt;</add>
           </speaker>
           <p> Bernardo, frar, o' vastu cussì in pressa?</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A' vaghi al magazì de Garipol, a cargà robi.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Fèrmate un puoco; vien qua apresso, ché te voio pa<add>&lt;r&gt;</add>lar.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A' no pos scoltà baianì. A' t'parlarò, po', una festa.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Te voio adesso, mi. Aldi, ché ti vadagnaré forsi pì in questo, che a stentarte.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> L'è lu ol vira, ch'a' l'è mei guadagnà e sgrignà, ca guadagnà e stantà.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Ti volio dir un secreto; ma tasi, azò che, caro frar, che la terra nol sapi. E po', voio che te fasi un servisio grande.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> No set chi so'? A' 'l non gh'è om del nos paìs, azò che t'sapi, ch'a' no sia gi simel al confessador, maidé, maidé!</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Madona xè inamoraa de un zovene forestier, che se noma Missier Iulio, che xè alozao al Pavon, sastu?</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Sta benissem: a' l'è rasò çircà qualche consolaziò.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Caro Bernardo, l'ha d'essere cotta che mai: no la puol dormir, né manzar gnente, si no sorber qualche vovo o tuor un puoco de pignocà.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Poh! ixì fa la milizia d'Amor: ch'a' fa causà in prinçipi trebulaziò e doventa plasì po'.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Sastu zò che la vorave?</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Nol so fis: ma ol pense be.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Se ti bastasse l'animo de trovar costù e parlarghe...</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A' m' bastaràf l'anim de parlà a ol Dus!</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Cusì digo mi. Mi vorae che til menasse in casa, che 'l no savesse come el fusse vegnuo: no sciò a che partio, mi.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> S'a' 'l vorà lasàs governà, ol condurem com s' fa la robi sanza pagà ol dazi.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> No so mo se esso serà contento.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A' 'l nol gh'è om ch'a' nol gh' plasi 'vita dulcedo'.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Eh, eh! Che ghe dirastu, caro frar?</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Oh, oh, cancar! A' gh' dirò che una madona voràf ch'a' 'l vegnès a scrivìgh una lettra.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> No dir cusì; ma che la vul che 'l vegna a dormir co essa.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A' 'l se scrif <hi rend="italic">i</hi> cun una otra pena, che col penarol da l'ingioster.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Iih! che distu? E po', crederalo, se ti ghe di' cusì?</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> S'a' 'l nol s' vorà fidà, a' gh' darò un pegn in le man, mi.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Sastu, bel Misier, zò che ti vadagnaré, e quanti danari ti vul dar Madona? diès ducati, lombrai, in un sacheto.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> An? chi vegna manc a fà u tal lavor e menàgh u tal plasì a casa? Chigasang! A' l'è be oter ca pever o canella! gna' zucar de Candia. A' t' sto dì mi, ch'a' l'è de quel de la «Salve Rezina»</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Ti me fè rider. No te voio dir pì altro, mi.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A' no l'è fag nient alò, s'a' no m' dè inanz trag qualche monida che m'recorde dol servisi.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Mi non ho danari. Se ti vul quest'anello, tienlo fin che Madona te darà i danari. Tuò. Ma tasi, ve'!</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Va', diavol! se taserò, an? A' l'è faga.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Vostu altro? ché voio tornar a Madona, mi.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Dim un po': com è 'l fag costù?</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Un zovene senza barba, rosseto in viso, co i cavei negri, vestio de seda, tuto galante.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Oh, cancar! l'è bella: ol cognòs mi costù.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Caro Bernardo, pàrlaghe ancuo: ché ti prego, caro frar.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Sta sira faghi l'offizi e t' rendi la resposta. Làghet vidì.</p>
         </sp>
         <stage>
           <foreign xml:lang="lat" rend="italic">Oria serva, Iulius foresterius.</foreign>
         </stage>
-        <sp>
+        <sp who="#oria">
           <speaker>
             <add>&lt;ORIA&gt;</add>
           </speaker>
           <p> Madona xè zà morosa de quel zentilomo e me manda per çercar Missier, azò che parla co esso. Sum contenta: se essa cusì vul, e mi voio. Eccolo qua.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Ben vegni la mia sorella.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> E la Vostra Magnificenzia.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Avete salutato Madonna per nome mio?</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Missier sì.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> De grazia, degnàtive referir sua resposta.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Regrazia la Vostra Magnificenzia e se recomanda a vu.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> O gran contento! Iulio, sei felice, poi che una tal donna se degna ricomandarse a te, che sei suo servitore e schiavo.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> La Vostra Magnificenzia xè un zentilomo da ben, no schiavo!</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> I' sun per morir per lei e adoprar questa persona e spada in suo servizio.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Mille grazie a la Vostra Magnificenzia.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Sorella cara, dicèteme: non potrei io aver tanta grazia da Sua Signoria che li potesse parlar diece parolle? ché poi me chiamarei contentissimo.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Co', Missier? Voleu che 'l mario la mazi? ché la xè noviza.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Più presto amazar me, che lei! Non volio che, per un quarto d'ora, farli saper che gli sun servo, e non altro.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Puoh! per sì puoco mi credo che Madona serà contenta, perché la xè cortese.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> A voi, sorella, de ogni mio ben voglio esser obligato, e remunerarvi non de un picol dono ma de un grande: de maritarvi in loco, ove sempre starete rica.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Gran merçé a la Vostra Magnificenzia.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Non ve degnarete, per amor mio, sopra questo dir doe parolle a Madona?</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Missier sì.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Ma come lo saperomi?</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Questa sera la Vostra Magnificenzia passerà per qua, a tre ore. Se Madona serà contenta de parlarve, la porta serà un puoco averta; se no, andaré al vostro viazo, senza far çegno.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Io non so come mai meritar tanta cortesia vostra. Lo farò, e venerò a l'ora.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Orsù, non voio star pì qua. Resté in pase.</p>
         </sp>
         <stage>
           <foreign xml:lang="lat" rend="italic">Nena, Angela.</foreign>
         </stage>
-        <sp>
+        <sp who="#nena">
           <speaker>
             <add>&lt;NENA&gt;</add>
           </speaker>
           <p> Ho trovato Bernardo, vostro sàntolo, e l'ho tanto pregato, che l'ha tolesto la impresa de parlar a l'amigo.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Per l'amor de Dio, che 'l sappa tàser?</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Se 'l pagaré ben, el saverà tàser.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Che gh'hastu impromesso?</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Diès ducati.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Ende voio dar quindese.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Eh, che fadiga! ne merita tre. Pì ho fatto mi, ca esso.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> A ti vogio dar çento, quando ti farò noviza.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Questa sera vu saveré ogna cosa.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> No spetar pì. Apparechia el mezao, cun le so spaliere; meti el sopraçelo a la letiera; trova li acanini da brusar, sastu? fia dolçe.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Sun contenta. Vado in freza.</p>
         </sp>
         <stage>
           <foreign xml:lang="lat" rend="italic">Bernardis, Iulius.</foreign>
         </stage>
-        <sp>
+        <sp who="#bernardo">
           <speaker>
             <add>&lt;BERNARDO&gt;</add>
           </speaker>
           <p> A' so' sta al Paòn. Nol cati m', a çircà Rialt e Sam Marc. A' crez che li grolli l'abi mangiat, costù. S'a' gh' dovès dà una zucada, l'arèf trovà a la prima. Ma vòi spetàl quilò: a' l'è propi ol camin d'andà a casa.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> O felice casa, che mia Signora tene chiusa! Ben potrò laudarti: cun questa inclita terra, quando da alguna zentildonna serò cognosciuto per vero amante.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> E 'l quest? alò, ve': i cavei atrezolì, e quel ari da fomnella. Chigasang! a' l'è quel.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Già è tempo de visitar la Piaza. Non sciò che ora mo sü. Dime, compagno, che ora è mo?</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Patrò', dissìf che ora è? A' 'l pò esser vintadò, o li après.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Gran mercé a te.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> No la cad ch'a' m' regrazié, perché a' so' quilò per faf a de mei, ca insegnàf li ori.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Che hai detto tu?</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A' dig ch'a' so' quilò per fàf un aplasì.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Volesse Dio che fosse bono per me.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> No guardé seben porti ol zac: ch'a' so' perzò om da podìf dà un benefiçii, sì.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Non volio esser de chiesa, ma soldato io.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A' dig un benefiçii da zentilom e compagnò da bo tep.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Lo melior beneficio serebbe che me insegnassi qualche bon loco ove potessi adoperar mia gioventù e pigliar piacere: ché a questo sum venuto.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A' parli de quel, propi, che çirca fin ac i osei.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Vienne un poco da parte: che cosa vòi dir tu?</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Vedì, se m' voli dà la fed da om da be e fà com dirò mi, a' f' menarò sta not in 'gloria in exselcis'.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Ah, ah, che voce de angelo! Se non vòi altro, èccome a tuo comando, e quanta tengo roba, e famiglii, questa persona; e, più, esserti schiavo.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A' no dig tanti cossi: a' nof domandi ca vo, mi.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Èccome solo, se solo me vòi.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Dig: in sta not.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Da tre ore mi è necessario andar in un servizio: trovar mie compagni. Avanti, verò ove tu vòi.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Maidé, maidé! s'a' volì dol be, frel, da fag, no çirché compagni adès, né ol diavol.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Come vòi che io facia?</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Ch'a' f' lassé governà a quest'om.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Dimi, de grazia: ove vòi che venga?</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Int'ol Paravìs, a revesità Domnidè ch'è inamorat int'ol fag vos.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Io ho mal pratica de strate. E poi, armato, non sciò quanto serei securo.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A' f' menarò in la gondola, sanza perìgol, e sì f' portarò fin a la camara. Volìf plù, mo?</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Làssame vedere se hai ciera da omo da bene e che no dichi baie, o se vadi ordinando qualche intrespo.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Guardòn un po' fis quilò: e vedi la fed gubelina. E la to, duchesche.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Vedi come costui scià che i' sun duchesco!</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Poh! a' cognòs un om da be in la vista, a la prima, mi.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Me dai la toa fede da vero ghebelino?</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Sì, al Guagneli dol Salvador.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> A che ora vòi che te expecti?</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A quater ori, o çirca.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Vòi che me fida de te?</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Nof dubité: da valentom.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> A l'Ostaria dil Paòn è lo mio allogiamento.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A' so mei o' sè logiat, ca vo medisem.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Basta; non più. Te expecto.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A' vaghi mo a drizà l'ordègn, mi.</p>
         </sp>
         <stage>
           <foreign xml:lang="lat" rend="italic">Iulius solus.</foreign>
         </stage>
-        <sp>
+        <sp who="#iulius">
           <speaker>
             <add>&lt;IULIUS&gt;</add>
           </speaker>
@@ -1087,121 +1109,121 @@ Già è sera. A l'Ostaria me riduco. Poco cibo è bono per cena, per non aggrava
         <stage>
           <foreign xml:lang="lat" rend="italic">Bernardus, Angela.</foreign>
         </stage>
-        <sp>
+        <sp who="#bernardo">
           <speaker>
             <add>&lt;BERNARDO&gt;</add>
           </speaker>
           <p> Bon<add>&lt;a&gt;</add> sira a la Magnificenzia Vostra.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Sia el benvegnuo el mio Bernardo caro.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A' no vegn ma' quilò sanza boni novelli.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Cusì fanno li boni amiçi de casa.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Che m' voli dà dol mesagg, s'a' f' dig cossi ch'a' f' piasarà?</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Zò che ti vul: tuta la roba, e danari.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Via dol pagament, un par de colzi rossi.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Questo xè un ducato. Tuò, che til dono. Ma di' zò che ti sa.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A' l'è su a l'orden, la platica.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Deh, sì, caro frar? Gh'hastu parlao?</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> S'a' gh'ho parlat, an? A' l'ho çircà per tut, s'a' 'l fos una bella puta.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Che gh'hastu ditto?</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A' no gh'ho dit vergòt, s'a' no che a' 'l vòi menà int'un lug, in sta not, a dormì.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Esso ch'halo ditto?</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A' 'l no s' fidava, né voliva vegnì.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> E po', com hastu fatto?</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> E po' gh'ho fag savì chi so'.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Volel vegnir?</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Çertissem! A quater ori smenarò ol preson, mi. Voràf ch'a' gh' feséf boni spesi.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Ohimè! no parla<add>&lt;r&gt;</add> pì.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A' l'è lu tal com u angiol.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> El xè tropo bello per mi.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Mo via, dèm da bif. E spetèm a li quater ori. E parechié un po' de colaziò.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Zò che ti vul.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Volìf oter, alò?</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Bernardo, che ti abba secreto, frar. Pensa che non m'aria fidao del primo parente ch'abba in Veniesa.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A' nol f' bisogna avì fantasia de quest, perché a' 'l desmentegarò subit com sii pagat.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Mozenighi gniovi te voio dar, de zeca.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Oh, cancar! a' volì, ve', ch'a' voghi la gondoleta, in sta sira! Orsù, sté con Dè. </p>
         </sp>
@@ -1215,81 +1237,81 @@ Già è sera. A l'Ostaria me riduco. Poco cibo è bono per cena, per non aggrava
         <stage>
           <foreign xml:lang="lat" rend="italic">Valeria domina, Oria serva.</foreign>
         </stage>
-        <sp>
+        <sp who="#valeria">
           <speaker>
             <add>&lt;VALERIA&gt;</add>
           </speaker>
           <p> El xè sonao tre ore e costù no vien. Ti non gh'ha parlao chiar<add>&lt;o&gt;</add>, Oria.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Mi gh'ho parlao chiarissimo. Forsi che 'l ghe xè intravegnuo qualche disconzo, che non ha podesto vegnir.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Sastu che?</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Che? Disé.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Qualche morosa che vul dormir co esso.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Sì, oxelle!</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> L'è mana che no se cata cusì per tuto, questi fii che par anzoli. E po' el xè forestier, che se ne puol piàr piasér, e po' va fuora, che no ti sta sempre in gli ochii.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Nol vegnerà pì. Presto xè quatro <add>&lt;ore&gt;</add>.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Ti ghe doveve dir che mi ghe volea ben!</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Se m'avesse ditto, cussì ghe averave ditto, mi.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> No sastu che a un tal fio no se ghe pul dir de no?</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Mi non s<add>&lt;c&gt;</add>iò cognoscer, a tàser.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Ti pul ben pensar che a ognun piase quello che xè bello e che ognun manza volentier de bon, sastu?</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Ma mi non savea tanto avanti.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Vèdestu? un'altra farà meio che mi, in questa notte!</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Se nol xè vegnuo adesso, vegnerà doman. Seramo la porta; nol spetamo pì.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Ancora un gozìn, e no pì.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Digo che non vegnerà pì. Aldé quante ore!</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> O grama mi! el xè tardi. Orsù, andemo. </p>
         </sp>
@@ -1316,214 +1338,214 @@ cangierebbe col mio corona e pelle. </l>
         <stage>
           <foreign xml:lang="lat" rend="italic">Bernardus, Iulius, Nena, Angela.</foreign>
         </stage>
-        <sp>
+        <sp who="#bernardo">
           <speaker>
             <add>&lt;BERNARDO&gt;</add>
           </speaker>
           <p> A' sem arivà. Salté illò, ché vegne m'da mi.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Questo è un belissimo palazo. De chi è?</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> No çirché se la gonella a' l'è de chi 'l té.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> I' sun deliberato non saper più di quello che vòi tu. Se la vita t'ho confidato, melio ti posso confidar lo saper e il resto.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Lassém un po' li parolli. Vegnìm dré.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Bona sera a questo zentilomo e al nostro Bernardo zentile e da ben.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Bona not. Com s' va mo: per qui fo'?</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Entra in quel mezao là.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> L'abitazion de Dio è questa! Oh, che casa rica e ornata! che belissimo loco!</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Nof disìf mi che l'ira ol Paravìs?</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Le zentil persone meritano tal cose, e meglio.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Mangié un po' de confet e bevì de st'aquaruol de Candia.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Per m<add>&lt;i&gt;</add>a fe', non tengo né fame né sete; ma, per compagnia tua, sun contento.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Madona, el xè vegnuo el zentilomo, el pì galante del mondo, armao como San Zorzi.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Tasi, ché l'ho veduo. Che ti par? voio andar cusì in scufioto negro, azò che non me cognosca.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Vu ste ben cusì. Andé, presto, ché 'l no staghi solo.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Bernardo xè ancora co esso.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A' f' lassi quilò presò per u pez. Mi ricomandi.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Ove vai?</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A' vaghi zà su, a revesità un po' la cosena.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Va' in bon viaggio.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Aldé Bernardo che xè partio. Aveu sentio quella vosina dolçe?</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Sì. Orsù, vogio andar. Tien Bernardo e sera ben l'uscio de sora, sastu?</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Non avé pensier de gnente. </p>
         </sp>
         <stage>
           <foreign xml:lang="lat" rend="italic">Angela, Iulius amantes.</foreign>
         </stage>
-        <sp>
+        <sp who="#angela">
           <speaker>
             <add>&lt;ANGELA&gt;</add>
           </speaker>
           <p> Bona sera a questo zentilomo mio caro.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> E a Vostra Signoria gentile e cortese.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Fio dolce, quanto t'ho desiderao! No sciò qual cosa pì cara potesse aver abuo, che tegnerte qua, mio preson.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Maggior grazia è la mia verso Vostra Signoria, che se abi degnato acceptarmi in servitore; e tanto più grande, quanto non per mei meriti, per propria zentileza lo ha fatto.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Cor mio, ti prego che te me n' voie aver excusaa, se cusì grossamente e licenziosamente te ho fatto vegnir qua e se prosumptuosamente parlasse, o fesse qualche cosa che non ti paresse conveniente: perché el fogo del to amor, che me bruscia, me ha infiamaa como dopier.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Signora mia, la beltà e nobeltà vostra è tanta, che ogni vostra cosa a me parerà cortese. Né non è necessario excusarvi, però che vi dono questa persona, questa anima; e, da qua avanti, sii vostro il tuto e non più mio.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Lo acceto, anima mia. E cusì tu pia la mia, che xè tuta toa.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> E io la piglio, insieme cun questa persona, per mia signora e dio.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Cusì consumeria. Spoia queste arme. Bevi un giozo, e riposamo.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Qui sun de Vostra Signoria tuto. Di bever, ho beuto un poco: più non mi comporta.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Questo puoco, per amor mio.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Per amor de voi, se fussi risagallo o arsenico, lo beveria.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Che lizadra persona! Beato el pare e la madre che tal fio ha fatto nascer!</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Beati sono veramente, poi che hanno fatto cosa che agrada a Vostra Signoria, che è dignissima.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Ancora te vogio basar per questa parolina.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Più dolce è la boca vostra, che le mie labre.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Vien qua, ché te voio aiutar.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Questo non pàtio. Vostra Signoria se svesta, che io la adiuterò lei.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Aveu besogno de gnente? Non guardé a mi: disèlo.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Madonna no. Né Vostra Signoria abi respeto alcuno de uno suo cordial servo.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Respecto? No sastu che ti xè mio, fio caro, dolçe? Pur che ti me voie la mità del ben che te voio, sum contenta.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Lo amor mio verso Vostra Signoria mo è incomenciato, e serà tanto, che ancor Venezia me vederà vechio.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Acònzati qua: ancora un poco avanti.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Vostra Signoria me fa torto. Pur, poi che i' sum suo, non voglio in cosa alguna contradire.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Ecco, Anzola, el to contento! Ecco che ti ha presso el to amor e tuta la toa speranza.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Madona, sete voi mia: mia speranza, mia signora.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Lo mio lo volio guardar, ché nol sia robao; ma tegnerlo cusì in le braze, streto. </p>
         </sp>
@@ -1548,430 +1570,430 @@ che me occidete, voi potete aiarme. </l>
         <stage>
           <foreign xml:lang="lat" rend="italic">Alquantulum postea.</foreign>
         </stage>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Anima mia dolçe, credea che ti avessi portao aqua per amorzar el fogo del mio peto, ma ti ha portao legna e carbon per farlo pì arder.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Io veni libero a Vostra Signoria; ora sun legato più che malfatore: vostro pregion, preggion de queste mameline dolce.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Ah, giotonzello, ti le base, sì? Guarda no le strucar, ché le çigarà.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Questa pomellina voglio per me; l'altra sii la vostra.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Sun contenta, perché la xè quella dal coresin.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Volete che gli dica quatro parolle?</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Sì, di' zò che ti vul. Ah, ah! te me squassi el cor. Lassa, ché ti vogio morder in questa volta.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Sapete ciò che risponde? Che è contenta.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Di': che gh'hastu ditto?</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Se quella cosa è stata dolce; se ne vole ancora.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Ben sa che sì, postema mio dolçe.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Madonna, me avete abrazato: lassate che ve abraza ancora voi; e faremo le braze.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Sì, ma dame la lenguina.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Voglio la tetina che me avete donato.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> No voio, se no ti mi dà la le<add>&lt;n&gt;</add>guina. Te strucarò con i dente, sì, a la fe'.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Volete cusì?</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Tuta, tuta, sì. </p>
         </sp>
         <stage>
           <foreign xml:lang="lat" rend="italic">Bernardus, Nena.</foreign>
         </stage>
-        <sp>
+        <sp who="#bernardo">
           <speaker>
             <add>&lt;BERNARDO&gt;</add>
           </speaker>
           <p> A' 'l sona! sona oto ori. Color non gh'a' sent: a' t' sto dì mi, ch'a' i sera su li pìgor in la stalla.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Che distu, matto? Tasi.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> N'het sentut? Ol farèf da mi, ixsì, vecg com a' so', a' gh'avès orden da podì drizzà la novella.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Non hastu vergonza, senza çervello?</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> M'het entis quei basòt? A cagar, la fuma!</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Lassa far a la zoventù; e ti, tendi a guadagnar.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> No vit s'a' 'l faghi?</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Credo che Miser Domenedio te m'ha mandado in li piedi, ché ognun xè contento: la Madona contenta, lo zovene contento, ti contento, mi contenta.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A' vaghi ogna dì a messa a pregà ol Salvador, che s' recordi dol pover om.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> No parlar pì. Aldi zò ch'i parla da baso. </p>
         </sp>
         <stage>
           <foreign xml:lang="lat" rend="italic">Angela, Iulius.</foreign>
         </stage>
-        <sp>
+        <sp who="#angela">
           <speaker>
             <add>&lt;ANGELA&gt;</add>
           </speaker>
           <p> Non me vostu ancora giozo de ben? Di', su, caro fio dolçe.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Madonna, i' non sciò quanto più demonstrarlo, se non volete apra questo petto cun un pugnale.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Doman ti serà smentegao ogn'amor mio.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Doman? Non cento anni dopoi mia morte.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Voio che ti zure a le Vagnele, qua, de dir la verità de zò che ti domandarò.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Così facio sacramento a Vostra Signoria.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Hastu morosa qua in Veniesa?</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Vi dirò: una zentildonna me ha festegiato algune volte da la fenestra; ma mai gli ho parlato.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> O' stala costie?</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Credo a San Bàrnaba. Non sciò però de certo.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Aldi zò che ti digo: se me credesse che ti tocasse altra donna, moreria qua d'angonissa in le to braze.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Poi che Vostra Signoria se è degnata amarmi, voglio voi sola, e tuto mio amor e contento meter in voi.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Cusì voio che ti zura ancora.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Cussì giuro, e facio voto.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Tuta questa persona voio per mi: la boca, gi ochii, el naso, le gambe, le braze e ogni cosa. E me doio che ti no sia co' xè un bùsolo da zibeto, ché ti portaria cusì sempre in sen, sempre sempre.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Vostra Signoria ha dubio l'amor mio? I' no<add>&lt;n&gt;</add> sciò qual serebbe possibile trovar che fosse, tale como voi, disposta a l'amor, cortese, gentile. Questi occhi chiama<add>&lt;n&gt;</add> amor, questo viso grazia, la bocca dolceza. De la mia tetina poi non parlo, ché è più preziosa che oro e argento.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Di' el vero: vostu ben a la to tetina?</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Più che a la mia vita.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Sastu zò che la farà, quando ti no vegnarè visitarla? La se amalerà de stiza e de cordoio.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Spesso la visitarò: no<add>&lt;n&gt;</add> voglio che se amali, no.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Vostu che te basa ancora un puoco? Xèstu straco?</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Non domandi Vostra Signoria quello che è suo; ché mai me trovarà istraco in farvi cosa grata.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Dormi, sera li ochii: ché volio far a mio modo.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Pur che io non mora, sun qua per voi.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Mette cusì le braze.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Vostra Signoria starà disconza.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Tasi e dormi, ché voio far a mio modo. </p>
         </sp>
         <stage>
           <foreign xml:lang="lat" rend="italic">Bernardus, Nena, Angela, Iulius.</foreign>
         </stage>
-        <sp>
+        <sp who="#bernardo">
           <speaker>
             <add>&lt;BERNARDO&gt;</add>
           </speaker>
           <p> Orbè! A' n'ho plu tep da poltronezà. Costor no fornaràf ma' de menà la polenta. A' i vòi chiamà, mi.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Làssai ancora un giozeto.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Ah, diavol! n'het sentut? Des ori. A' 'l scomenza a fà di. Avri un po' la fenestra.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Iih! el xè pì tardi che no credea.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Poh sì, a' camini a chiamà, s' ti vurì. Maidé, ol diavol! a' i no pensa sti novelli, lor.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Batti pian pian a l'usso.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Lassa un po' fà quest'om. <hi rend="italic">Ta! Ta!</hi>
 </p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> O che fadiga dolçe! Dòrmestu, fio?</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Ho dormido, cussì, un puoco.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> E mi ho caminao tanto, che sun straca.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p><hi rend="italic">Ta! Ta!</hi> Olà! A' crez ch'a' no gh'a' sié, mi.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Chi batte, la Nena?</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Madona, a' l'è quilò, di fag. A' l'è ora d'andà.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Ohimè! xè zorno? Costù xè matto. No è un'ora che semo qua.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> No ste mo a bisgà, ché 'l tep camina. Lassèn, ah, per çeno!</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Voio vèder. Iesus! xè tardi.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Non piglii fastidio Vostra Signoria, ché presto saremo in ordine.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Non te muover: aspeta, ché ti voio dir quatro parolle, in leto.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Venete da questo canto, qui.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Fio caro, dolçe, bello, d'oro, daspò' che t'ho donao la persona e la vita, voio che per amor mio ti accete anco questo puoco presente: questa caenella d'oro, che sempre xè sta compagna de la to tetina, e questo smeraldin: uno, perché ti t'arecordi che ti xè ligao a mi per sempre; l'altro, perché ti sappa che l'amor mio xè che no ti tochi altra donna che viva. E, ti prego, accetali cun quel cuor che ti le dono. E, in remunerazion de ogni cosa, non voio che un sol baseto da ti.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Se io refudasse cosa che Vostra Signoria me donasse, pareria esser vilano, perché non avere' animo de remunerarli. Ma io lo accepto, poi che cossì volete. Lo amor mio in voi non accade più arecordarlo, però che, e morto e vivo, Iulio è vostro. E poi, volite un baso? Sun contento; ma degnative de darmi lo contracambio. </p>
         </sp>
         <stage>
           <foreign xml:lang="lat" rend="italic">Nena, Bernardus, Angela, Iulius.</foreign>
         </stage>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Hastu sentuo?</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Maidé! pur adès ha i scomenzà a basàs.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Abi un puoco de pazienzia.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A' gh' lassi mo l'impaz a lor, mi. A' sentarò quilò.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> La gondola xèla in ordene?</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Fos ixì a l'orden mi, che t'arèf stramesiat in sta not com s' fa li sémoli.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Se no se dise altro, se no di le to valentisie?</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Rengraziat Domnidè, a' trove pur!</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Bernardo, ti rendo el to prison, san e salvo. Eccolo che til consegno.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A' 'l dì pisà da puc in zà: m'acorzi ch'a' 'l poràf sgollà, s'a' 'l avès alli.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Madonna, lui sta turbato, perché è stato viduo in questa notte.</p>
         </sp>
-        <sp>
+        <sp who="#nena">
           <speaker>NENA</speaker>
           <p> Sì, in verità, ché li aghi nol movarae.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Set perché? Perché me l'ha tant strucat in zoventut, ch'adès a' 'l vol dormì d'ostinaziò.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> E pur ti vul partir, Iulio?</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Come pare a Vostra Signoria.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Ve', ol diavol! nol volìf alò lassà? A' crez ch'a' pensé ch'a' 'l voia menà in Çiper.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Bernardo, varda ben el mio cuor.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A' guardarò la gondola ch'a' no s' travolzi; e lu s' guardarà da per lu. Orsù, andèm fo'.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Signora e Madona mia, lasso qui l'anima, e il corpo porto. Vol altro Vostra Signoria comandarmi?</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Una sol cosa: recomandarti Anzola e recordarti zò che ti ha promesso.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Questo porto meco per sempiterno recordo.</p>
         </sp>
-        <sp>
+        <sp who="#angela">
           <speaker>ANGELA</speaker>
           <p> Me recomando ancora.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Resti contenta e felice Vostra Signoria e mi abi per suo servo fidelissimo.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A' l'è pur compit ol zanzùm. Salté qui diter, ch'a' vòi che m' cunté da nu la barùffola.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Tu me hai menato a consumarmi el core e l'anima. Ma dimi: come se dice costei?</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Quest è ol bel de la segùr: ol manegh. Domà vel dirò, ch'adès non recordi vergòt.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Se tu non vòi, non voglio anco io. </p>
         </sp>
@@ -1983,7 +2005,7 @@ che me occidete, voi potete aiarme. </l>
         <stage>
           <foreign xml:lang="lat" rend="italic">Oria serva, sola.</foreign>
         </stage>
-        <sp>
+        <sp who="#oria">
           <speaker>
             <add>&lt;ORIA&gt;</add>
           </speaker>
@@ -2021,7 +2043,7 @@ lieto morto serò non men che or viva. </l>
         <stage>
           <foreign xml:lang="lat" rend="italic">Iulius.</foreign>
         </stage>
-        <sp>
+        <sp who="#iulius">
           <speaker>
             <add>&lt;IULIUS&gt;</add>
           </speaker>
@@ -2031,64 +2053,64 @@ lieto morto serò non men che or viva. </l>
         <stage>
           <foreign xml:lang="lat" rend="italic">Valeria domina, Oria serva.</foreign>
         </stage>
-        <sp>
+        <sp who="#valeria">
           <speaker>
             <add>&lt;VALERIA&gt;</add>
           </speaker>
           <p> Vegnerà Iulio, como ti ha ditto? Dilo un'altra volta, cara dolçe Oria.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> No aveu inteso, che sì? A tre ore.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Ti divevi confortarlo che nol dubitasse de gnente.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> El disse che vegnirae senza fallo; e n'ho sapuo che responder, mi.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Sta ben. Che ora xè adesso?</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Do, sonae.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Voio che a<add>&lt;n&gt;</add>damo da basso.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Cusì presto?</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> No sastu zò che se dise? «Chi ha tempo, no speta tempo».</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Mi no ghe voio star sempre. Quando vu ghe seré sta un pezeto, tornarò indrio.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Che crèdestu, che 'l voia tegnir a zanzar? Mi no voio altro da esso, ca saver se 'l me vul ben; e po' ghe ordenarò zò che l'averà a far.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Voleu che porta candela?</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Pòrtala, ché ti la tegnerà de drio la porta, ascosa. Andamo tosto. </p>
         </sp>
         <stage>
           <foreign xml:lang="lat" rend="italic">Iulius solus, in itinere.</foreign>
         </stage>
-        <sp>
+        <sp who="#iulius">
           <speaker>
             <add>&lt;IULIUS&gt;</add>
           </speaker>
@@ -2097,244 +2119,244 @@ lieto morto serò non men che or viva. </l>
         <stage>
           <foreign xml:lang="lat" rend="italic">Valeria, Iulius, Oria.</foreign>
         </stage>
-        <sp>
+        <sp who="#valeria">
           <speaker>
             <add>&lt;VALERIA&gt;</add>
           </speaker>
           <p>Ben par in chi xè puoco amor e fede: quando abe sognao a fidarlo, e po' 'ncora no s'ha fidao, ch'ha volesto venir armao.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Signora, le arme son necessarie a un giovene, maxime forrestier, per diversi rispecti.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Chi non ama, in un luogo non ha anche besogno vardarse de inimisi.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Se Vostra Signoria non m'è amica, e inimica Quella cognosco, più non...</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Disé: perché non <add>&lt;ve&gt;</add> siu degnao vegnir ier sera?</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Fo per esser un puoco fastidiato, che non mi parse escir di casa.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> O che amor! quando un puoco de fastidio lo tien in casa.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Perciò non resta che non sii servo di Vostra Signoria e che Quella non ami più che me istesso.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Disé, se Dio ve guarda: perché comenzassi cussì a guardarme?</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> La beleza e zentileza vostra, la prima fiata che io ve vidi, me ligorno per vostro perpetuo pregione.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> In che luogo me vedessi?</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> In chiesa a quelle moniche, ove era festa.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Non savevu che gera noviza?</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> I' non pensai se non a la grazia e beltà de Vostra Signoria.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Che cosa xè questa che avé cusì al collo, sotto el bàvaro? Lasela vèder, de grazia.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> È 'na catena d'oro.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Lassela un poco vèder.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Lèvela Vostra Signoria, e sii la soa, se gli piace.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Questa catena xè cosa de Veniesa.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Signora, qui l'ho comprata.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Magnifica Madona, savé a che la someia? A quella che portava Madona Anzola, avanti che moresse so mario.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Sì, per la fede mia digo che la xè quella, mi.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Pode esser, Signora, che l'ha fatta vender.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Questa xè la magagna! Basta, intendo ben.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Se Vostra Signoria se degna, io ne facio un presente a Quella.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Dio me ne guardi! La catena no xè compraa, ma donaa.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Vostra Signoria ben me crede puoco, quando non mi prestate fede in questa picol cosa.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Missier Iulio, se vu fosse sta cusì fidele como mi, no avesse questa catena. M'aveu inteso?</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Già Vostra Signoria ha preso triste opinion de quello che io non sciò.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Lo fastidio de ier sera xè una bella soia.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Perdoname Vostra Signoria, ché non è soia alguna.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Anzola farave meio a viver ben, e non çercar quello che la non dié.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Già sete turbata; e non sapete la causa.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Basta! Non se dié inganar alcun, savé, Miser Iulio? No, no se dié cussì sbefizar una povera zovene zentildonna. Mi non sun da manco de Anzola.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Io non intendo.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Missier Iulio, questo non meritava. Pazienzia! Anzola xè sta <add>&lt;pì&gt;</add> venturaa che mi.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Me dolio esser venuto qui per fastidio de Vostra Signoria.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> E mi digo che avé fatto ben a vègner; ché Dio cusì ha volesto, per farme saver che non me volé giozo de ben, azò che no ve varda pì drio.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Di questo non sciò che responder a Vostra Signoria.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Disé co' volé; che vu avé gran torto contra de mi.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Se cusì volete, lo confesso.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Se Anzola xè vostra, tegnela. Né voio dir altro, ca tàser, da qua indrio.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Non cognosco Anzola, per la fede de zentilomo.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Orsù, no pì! Mo credé çerto che mai me fo fatto iniuria che la volesse padir: né anche voio tolerar questa per nisun modo.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Vostra Signoria non se moverà senza raggion.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Sora tuto, voio rason. Credèlo çerto, se volé, che, se 'l me fosse onor, Valiera faria andar la cosa fin a la Avogarìa, per la Crose Sancta!</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Non sete offesa né in l'onore né in la roba da me, che io sappi.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Missier, vu staré a rason: se averé falao, seré punio.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> A Vostra Signoria sta darmi quella punizion che gli pare.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Savé quel che merta un che inganna un altro? Essere bandizao.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> I' sun forrestieri.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Basta! Anzola e vu m'avé assassinaa.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Non, che io sappi.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> La caena, che xè al collo, lo prova.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> I' non sciò che più replicare.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Missier, andé. E vardé da qua indrio no tratar cusì zentildonne; e disé a Anzola che Valiera ghe renderà el cambio, col tempo.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Me ricomando a Vostra Signoria.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Recomandeve a Anzola, e no a mi. </p>
         </sp>
         <stage>
           <foreign xml:lang="lat" rend="italic">Iulius solus.</foreign>
         </stage>
-        <sp>
+        <sp who="#iulius">
           <speaker>
             <add>&lt;IULIUS&gt;</add>
           </speaker>
@@ -2397,7 +2419,7 @@ Solo la donna mia pace non have. </l>
         <stage>
           <foreign xml:lang="lat" rend="italic">Oria serva, sola, in itinere.</foreign>
         </stage>
-        <sp>
+        <sp who="#oria">
           <speaker>
             <add>&lt;ORIA&gt;</add>
           </speaker>
@@ -2412,153 +2434,153 @@ Solo la donna mia pace non have. </l>
         <stage>
           <foreign xml:lang="lat" rend="italic">Bernardus, Iulius, Oria serva.</foreign>
         </stage>
-        <sp>
+        <sp who="#bernardo">
           <speaker>
             <add>&lt;BERNARDO&gt;</add>
           </speaker>
           <p> Bona vita a ol mi patronçì onorìgol.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Ben venga lo fratel mio. Che bone nove?</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A' l'è be da pensà! la canzon da l'oltr'er.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Veni mo da quella zentildonna, patrona tua e signora mia?</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A' no so do' vegni, mi; basta mo, ch'a' so' tornat alò per quel cant.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Lo ben venuto e lo meglio trovato.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> M'avì entis, n'è vira?</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Entendo; non più, mo taci: so.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A' dig ch'a' vòi ch'a' sié de personi ch'a' f' sa<add>&lt;v&gt;</add>rà fà plu carezzi che ol Bernard.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Ah, ah! de tuti doi!</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Iih! el ghe xè un omo co esso. Grama mi, non so che far. Ho vergonza.
 Mo lassa, che 'l se parte.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Che andìf fazand, olà? Çirchèf da vo la manestra?</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Andé al vostro viazo, ché non voglio niente da fachini.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Orsù, non çirchì olter. Andé inanz, ch'a' trovarì el desmesteg.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Miser Iulio, alda do parolle la Vostra Magnificenzia.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Madama...? Madonna Oria? Perdonatime, sorella mia, che non sapevo qual fosti. Che bisogna da me?</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Caro Miser Iulio, daspo' che iar sera vu partissi da Madona Valiera cusì da mala voglia, scorezà, mai essa ha podesto regar. Sempre la xè sta in pianto. Digo che la xè meza morta. El xè forza che vu vegné questa sera a consolarla, si no che la morerà de doia. Caro Miser Iulio bello, vegné là, ché vu saré causa de vostro gran ben e so.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Me spiace asai che Madonna Valiera abi auto alcun scontento, e tanto, che Dio scià; perché io gli so' bon servitore, e me rencrescie che in me non sii modo da potergli levar tal male, ché lo farei volunteri.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Che? che? non avé modo? A punto, tuto el modo de varirla sta in vu. Se vegné subito, essa guarirà.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Non vorei poi, venendo, esser causa de magior male suo. Lei è colerica, e non mi crede: come me veggia, se adirarà tanto, ché gli nocerà poi.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> No disé questo, ché la xè grama de quello che la xè sta scorazà cu<add>&lt;n&gt;</add> vu, e sempre s'ha doiesto de questo. Adesso no la vul pì çigar de gnente, si no tanto quanto volé vu, e ve vul per tuto el so onor e anima.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Rengrazia Sua Signoria; ma io non sciò che me fare, perché vorei andar a Padoa in questa note, per attrovar mei parenti che mo vengono al Studio.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Miser, nol bisogna scusa qua. Vedé, el xè forza che vegné; e po', quando seré sta co epsa, andaré po' dove ve piaserà.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> E como è tanta forza?</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Che bisogna parlar? ché la muor, se non la fa pase cun vu.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Porzeteme la man, ché mi faccio bona pace cun voi, per nome suo.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Digo che nol val gnente: ché la vul epsa tocarve la man. E po', se volé che vel diga, per ogni triste parola che v'è ditto, la vul tante volte basarve.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Or volete che venga?</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Sì, dolçe, caro, d'oro, Misier Iulio.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> A qual ora?</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Como l'altro zorno maladetto.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Dio voglii che non sii cusì questo.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Tegné çerto che 'l serà benedeto.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Or so' contento. Expetatime, e salutate Madona per nome mio, e a lei, sino che vengo, raccomandatime.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Romagné in pase. </p>
         </sp>
         <stage>
           <foreign xml:lang="lat" rend="italic">Iulius solus.</foreign>
         </stage>
-        <sp>
+        <sp who="#iulius">
           <speaker>
             <add>&lt;IULIUS&gt;</add>
           </speaker>
@@ -2611,80 +2633,80 @@ che già dal corso suo volse Atalanta. </l>
         <stage>
           <foreign xml:lang="lat" rend="italic">Bernardus, Iulius.</foreign>
         </stage>
-        <sp>
+        <sp who="#bernardo">
           <speaker>
             <add>&lt;BERNARDO&gt;</add>
           </speaker>
           <p> Olà, a bas, che diavol spetè? No m'avìf sentut zuffolà plù de ses fiadi?</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Bernardo, sei già venuto?</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> No m' vedìf? Mo via, andòm, ché l'è ora.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> So' contento; ma, avanti che entri, voglio che me dichi como ha nome l'amico e de che casa è: perché non voglio viver più frenetico in racordarmi cantoni.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Che gril ve becca adès li orechi? Nol so; e, sel savès, nol dirèf.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Se non vòi dirlo, né io voglio venire.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A' crez ch'a' sié fo' dol çervel, mi. No savìf o' vòi menàf?</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Lo sciò; ma io voglio saperlo meglio.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Maidé, a' 'l dì esser strac ol caval, che 'l ropeta ixì col cul!</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> O straco o gagliardo, m'hai enteso.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A' la va mal, quat ol puza li rusi.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Non più. Questo è deliberato.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> A' l'ho mi entisa, che a' volì slongarla a doma.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Va' di' a Madona che più non voglio vegnir, se non sciò lo nome suo.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Sii, col nom de Dé! A' ghel vòi dì a le. Per mi no savrì vergòt, se la no s' contenta.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Parli bene. Va' parlagli.</p>
         </sp>
-        <sp>
+        <sp who="#bernardo">
           <speaker>BERNARDO</speaker>
           <p> Non pensé mo gna' ch'a' spetti domà: ch'a' gh' vaghi adès, in pressa. </p>
         </sp>
         <stage>
           <foreign xml:lang="lat" rend="italic">Iulius solus.</foreign>
         </stage>
-        <sp>
+        <sp who="#iulius">
           <speaker>
             <add>&lt;IULIUS&gt;</add>
           </speaker>
@@ -2693,105 +2715,105 @@ che già dal corso suo volse Atalanta. </l>
         <stage>
           <foreign xml:lang="lat" rend="italic">Oria, Valeria, Iulius.</foreign>
         </stage>
-        <sp>
+        <sp who="#oria">
           <speaker>
             <add>&lt;ORIA&gt;</add>
           </speaker>
           <p> Madona Valeria, che pagasse mo, ché questo che vien cusì pestezando fosse Misier Iulio?</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Sastu zò che pagarave? tanto co' val questo anello che porto in questo deo.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Pian! ché çerto el xè quello.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Se ti fossi indovina, ti vorave pì ben che no voio a la Laurina, mia suor.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Che sì! Tasé mo, e scolté un puoco. Xèlo mo quello? Bona note, Misier.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Chi è qui? Bona notte.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Misier Iulio, vu m'avé fatto vadagnar tutto l'amor de Madona, a vegnir cusì adesso.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Mi piace; e io ce ho guadagnato.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Vu avé guadagnà un corpo e un'anima che gera persa, se no vegneve a vederla.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Signora, non volio aver guadagnato più che la grazia de Vostra Signoria, ché Quella se degni avermi in servitore suo.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Digo in mio mazor. Vu savé ben che pena m'avé dà, perché ho volesto esserve mazora; ma da qua avanti voio esserve menora in ogni canto.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Non dica questo Vostra Signoria, ché io non merito tanto.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Magnifica Madona, ormai xè tempo che Miser Iulio faza quella pase che volea far co mi, quando non volsi.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Miser Iulio, cor mio, perché seu tanto crudel verso de mi?</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Crudel verso Vostra Signoria? Dio, non lo consentir! anzi, umanissimo verso la mia diva: è ben tuto che io spero.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Se xè cusì, voio che sié mio; e che vu me perdoné, se l'altro zorno ve ho fatto scorozar.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Vostra Signoria perdòname a me, se per mia causa ha pigliato fastidio alguno; ché mo qui so' tuto suo, per cangiar ogni affanno in piacere.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Che paroline d'oro!</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Misier Iulio caro, el se suol dir che el xè matiera parlar cusì a la scoverta, perché i venti ha orechie e occhi. Vegné dentro e me alegraré un puoco a vèderve a la luse.</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> Non è necessario che Vostra Signoria me dichi ragion alcuna. Comandatime e dicete: «Voglio cusì», ché vostro so' io.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Cusì voio far, Misser Iulio, fio bello, dolçe.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Madona, voleu far la pase cusì presto!</p>
         </sp>
-        <sp>
+        <sp who="#iulius">
           <speaker>IULIUS</speaker>
           <p> La pace, Madonna, sta nel viso vostro, che la prima fiata che lo vidi me ligò.</p>
         </sp>
-        <sp>
+        <sp who="#valeria">
           <speaker>VALERIA</speaker>
           <p> Oria, fia, sera la camera e va' su a Miser grando, che no çiga. E se 'l dise gnente de mi, di' che ho mal e che per questa sera non voio che nisun me rompa la testa.</p>
         </sp>
-        <sp>
+        <sp who="#oria">
           <speaker>ORIA</speaker>
           <p> Lassé far a Oria, che in fatto provederà a ben e presto. </p>
         </sp>

--- a/tei/anonimo-orphei-tragoedia.xml
+++ b/tei/anonimo-orphei-tragoedia.xml
@@ -82,6 +82,46 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="mopsus">
+            <persName>Mopsus</persName>
+          </person>
+          <person xml:id="aristeus">
+            <persName>Aristeus</persName>
+          </person>
+          <person xml:id="thyrsis">
+            <persName>Thyrsis</persName>
+          </person>
+          <person xml:id="dryas">
+            <persName>Dryas</persName>
+          </person>
+          <person xml:id="orpheus">
+            <persName>Orpheus</persName>
+          </person>
+          <person xml:id="mnasyllus">
+            <persName>Mnasyllus</persName>
+          </person>
+          <person xml:id="pluto">
+            <persName>Pluto</persName>
+          </person>
+          <person xml:id="proserpina">
+            <persName>Proserpina</persName>
+          </person>
+          <person xml:id="euridice">
+            <persName>Euridice</persName>
+          </person>
+          <person xml:id="tisiphone">
+            <persName>Tisiphone</persName>
+          </person>
+          <personGrp xml:id="menades">
+            <name>Menades</name>
+          </personGrp>
+          <person xml:id="menas">
+            <persName>Menas</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -124,7 +164,7 @@
         <stage>
           <foreign xml:lang="lat">Interloquuntur modulanturque MOPSUS, ARISTEUS et THYRSIS.</foreign>
         </stage>
-        <sp>
+        <sp who="#mopsus">
           <speaker>MOPSUS.</speaker>
           <lg>
             <l>Avresti visto un mio vitulin bianco,</l>
@@ -132,7 +172,7 @@
             <l>e un pecio rosso dal ginochio al fianco?</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#aristeus">
           <speaker>ARISTEUS.</speaker>
           <lg>
             <l>Caro mio Mopso, apresso a questa fonte</l>
@@ -160,7 +200,7 @@
             <l>e sancia mai dormir iacio nel letto.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mopsus">
           <speaker>MOPSUS.</speaker>
           <lg>
             <l>Aristeo mio, questa amorosa face,</l>
@@ -178,7 +218,7 @@
             <l>e vite e biade e paschi e mandre e grege.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#aristeus">
           <speaker>ARISTEUS.</speaker>
           <lg>
             <l>Mopso, tu parli queste cose a' morti,</l>
@@ -200,7 +240,7 @@
         <stage>
           <foreign xml:lang="lat">Cantus Aristei.</foreign>
         </stage>
-        <sp>
+        <sp who="#aristeus">
           <speaker>ARISTEUS.</speaker>
           <lg>
             <l>Odette, selve, mie dolce parole,</l>
@@ -246,7 +286,7 @@
             <l>poiché la bella ninfa odir non vole.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mopsus">
           <speaker>MOPSUS.</speaker>
           <lg>
             <l>El non è tanto el mormorio piacevole</l>
@@ -259,13 +299,13 @@
             <l>Ma ecco Tirse, che dal monte sdruciula.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#aristeus">
           <speaker>ARISTEUS.</speaker>
           <lg>
             <l>Che è del vitello? Hallo tu ritrovato?</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#thyrsis">
           <speaker>THYRSIS.</speaker>
           <lg>
             <l>Sì ho, così avessi egli il capo mocio,</l>
@@ -275,14 +315,14 @@
             <l>ma ben scio dirti che egli ha pien el gozio.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#aristeus">
           <speaker>ARISTEUS.</speaker>
           <lg>
             <l>Ora io vorebe la cagione odire</l>
             <l>perché sei stato tanto a rivenire.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#thyrsis">
           <speaker>THYRSIS.</speaker>
           <lg>
             <l>Steti a mirar una gentil donzella</l>
@@ -295,21 +335,21 @@
             <l>e gli ochi bruni, e candida la vesta.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#aristeus">
           <speaker>ARISTEUS.</speaker>
           <lg>
             <l>Rimanti, Mopso, ché io la vo' seguire,</l>
             <l>perché essa è quella di cui te ho parlato.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mopsus">
           <speaker>MOPSUS.</speaker>
           <lg>
             <l>Guarda Aristeo che troppo grande ardire</l>
             <l>non te conduca in qualche tristo lato.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#aristeus">
           <speaker>ARISTEUS.</speaker>
           <lg>
             <l>O mi convien questo giorno morire,</l>
@@ -318,7 +358,7 @@
             <l>che io voglio ire a cercarla oltro a quel monte.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mopsus">
           <speaker>MOPSUS.</speaker>
           <lg>
             <l>O Tirsi, o che ti pare or del tuo sire?</l>
@@ -327,7 +367,7 @@
             <l>quanto gli fa vergogna questo amore.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#thyrsis">
           <speaker>THYRSIS.</speaker>
           <lg>
             <l>O Mopso, al servo sta bene obedire,</l>
@@ -344,7 +384,7 @@
         <stage>
           <foreign xml:lang="lat">Loquitur ARISTEUS, interloquuntur item planguntque flebili cantu DRYADES.</foreign>
         </stage>
-        <sp>
+        <sp who="#aristeus">
           <speaker>ARISTEUS.</speaker>
           <lg>
             <l>Non me fugir, dongella,</l>
@@ -368,7 +408,7 @@
             <l>porgime, Amore, e presta le toe ale</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#dryas">
           <speaker>DRYAS.</speaker>
           <lg>
             <l>Anonzio di lamento e di dolore,</l>
@@ -395,7 +435,7 @@
         <stage>
           <foreign xml:lang="lat">Chorus Dryadum.</foreign>
         </stage>
-        <sp>
+        <sp who="#dryas">
           <speaker>DRYAS.</speaker>
           <lg>
             <l>L'aria de pianti se oda risonare</l>
@@ -449,7 +489,7 @@
             <l>crescano e' fiumi al colmo de la riva.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#dryas">
           <speaker>DRYAS.</speaker>
           <lg>
             <l>Orfeo certo è colui che al monte ariva</l>
@@ -481,7 +521,7 @@
         <stage>
           <foreign xml:lang="lat">Modulatur lamentaturque cithara ORPHEUS, obloquitur DRYAS et MNASYLLUS Satyrus.</foreign>
         </stage>
-        <sp>
+        <sp who="#orpheus">
           <speaker>ORPHEUS.</speaker>
           <lg>
             <l>
@@ -498,7 +538,7 @@
             <l><foreign xml:lang="lat">intrepidusque fero riserit ore puer</foreign>.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#dryas">
           <speaker>DRYAS.</speaker>
           <lg>
             <l>Crudiel novella ti riporto, Orfeo:</l>
@@ -511,7 +551,7 @@
             <l>che ad un tempo finì la vita e 'l corso.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mnasyllus">
           <speaker>MNASYLLUS.</speaker>
           <lg>
             <l>Vedi come dolente</l>
@@ -524,7 +564,7 @@
             <l>se al suo lamento el monte se commova.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#orpheus">
           <speaker>ORPHEUS.</speaker>
           <lg>
             <l>Ora piagnamo, o sconsolata lira,</l>
@@ -547,7 +587,7 @@
             <l>e le selve tirate, e ' fiumi svolti.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mnasyllus">
           <speaker>&lt;MNASYLLUS&gt; satyrus.</speaker>
           <lg>
             <l>Non se volge sì leve</l>
@@ -568,7 +608,7 @@
         <stage>
           <foreign xml:lang="lat">Verbis flebilibus modulatur ORPHEUS, interloquuntur PLUTO et PROSERPINA, EURIDICE item et TISIPHONE; etenim duplici actu haec scena utitur.</foreign>
         </stage>
-        <sp>
+        <sp who="#orpheus">
           <speaker>ORPHEUS.</speaker>
           <lg>
             <l>Pietà, pietà del misero amatore,</l>
@@ -591,7 +631,7 @@
             <l>donque me apriti le ferrate porte.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#pluto">
           <speaker>PLUTO.</speaker>
           <lg>
             <l>Chi è costui che con la aurata cetra</l>
@@ -608,7 +648,7 @@
             <l>ma tutti stano al dolce canto intenti.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#proserpina">
           <speaker>PROSERPINA.</speaker>
           <lg>
             <l>Caro consorte, poi che per tuo amore</l>
@@ -625,7 +665,7 @@
             <l>posati alquanto e il dolce canto ascolta.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#orpheus">
           <speaker>ORPHEUS.</speaker>
           <lg>
             <l>O regnatori a tutte quelle genti</l>
@@ -678,7 +718,7 @@
             <l>non vo' più su tornar, ma chiedo morte.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#proserpina">
           <speaker>PROSERPINA.</speaker>
           <lg>
             <l>Non credevo, io, consorte,</l>
@@ -691,7 +731,7 @@
             <l>pel canto, pe' lo amor, pe' iusti priegi.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#pluto">
           <speaker>PLUTO.</speaker>
           <lg>
             <l>Resa sii con tal lege</l>
@@ -704,7 +744,7 @@
             <l>se inclini la potenzia del mio sceptro.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#orpheus">
           <speaker>ORPHEUS.</speaker>
           <lg>
             <l><foreign xml:lang="lat">Ite triumphales circum mea tempora lauri</foreign>!</l>
@@ -719,7 +759,7 @@
             </l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#euridice">
           <speaker>EURIDICE.</speaker>
           <lg>
             <l>Ahimè che troppo amore</l>
@@ -730,7 +770,7 @@
             <l>ché indietro son tirata. Orpheu mi, vale!</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#orpheus">
           <speaker>ORPHEUS.</speaker>
           <lg>
             <l>Chi pon legge a li amanti?</l>
@@ -741,7 +781,7 @@
             <l>convien ch'io torni a morte un'altra volta.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#tisiphone">
           <speaker>TISIPHONE.</speaker>
           <lg>
             <l>Più non venire avanti:</l>
@@ -761,7 +801,7 @@
         <stage>
           <foreign xml:lang="lat">Lamentatur ORPHEUS, interloquuntur, agunt et cantant MENADES.</foreign>
         </stage>
-        <sp>
+        <sp who="#orpheus">
           <speaker>ORPHEUS.</speaker>
           <lg>
             <l>Qual sarà mai sì miserabil canto</l>
@@ -797,7 +837,7 @@
         <stage>
           <foreign xml:lang="lat">Viso Orpheo.</foreign>
         </stage>
-        <sp>
+        <sp who="#menades">
           <speaker>MENADES.</speaker>
           <lg>
             <l>Oh oh oh, ohè, sorelle,</l>
@@ -817,7 +857,7 @@
         <stage>
           <foreign xml:lang="lat">Interfecto Orpheo.</foreign>
         </stage>
-        <sp>
+        <sp who="#menas">
           <speaker>MENAS.</speaker>
           <lg>
             <l>Euoè, o Bacco, io ti ringrazio.</l>
@@ -833,7 +873,7 @@
         <stage>
           <foreign xml:lang="lat">Chorus Menadum.</foreign>
         </stage>
-        <sp>
+        <sp who="#menades">
           <speaker>MENADES.</speaker>
           <lg>
             <l>Ciascun segue, o Bacco, te,</l>

--- a/tei/anonimo-quando-iddio-fece-il-mondo-e-l-uomo-e-ogni-cosa-creata.xml
+++ b/tei/anonimo-quando-iddio-fece-il-mondo-e-l-uomo-e-ogni-cosa-creata.xml
@@ -80,6 +80,79 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="angelo_annunciatore">
+            <persName>L'Angelo che annuncia</persName>
+          </person>
+          <person xml:id="iddio">
+            <persName>Iddio Padre</persName>
+          </person>
+          <personGrp xml:id="angeli">
+            <name>Angeli</name>
+          </personGrp>
+          <personGrp xml:id="arcangeli">
+            <name>Arcangeli</name>
+          </personGrp>
+          <personGrp xml:id="principati">
+            <name>Principati</name>
+          </personGrp>
+          <personGrp xml:id="potestati">
+            <name>Potestati</name>
+          </personGrp>
+          <person xml:id="virtu">
+            <persName>Virtù</persName>
+          </person>
+          <personGrp xml:id="dominazioni">
+            <name>Dominazioni</name>
+          </personGrp>
+          <personGrp xml:id="troni">
+            <name>Troni</name>
+          </personGrp>
+          <personGrp xml:id="cherubini">
+            <name>Cherubini</name>
+          </personGrp>
+          <personGrp xml:id="serafini">
+            <name>Serafini</name>
+          </personGrp>
+          <person xml:id="lucifero">
+            <persName>Lucifero</persName>
+          </person>
+          <person xml:id="michael">
+            <persName>Michäel</persName>
+          </person>
+          <person xml:id="adamo">
+            <persName>Adamo</persName>
+          </person>
+          <person xml:id="serpente">
+            <persName>Il Serpente</persName>
+          </person>
+          <person xml:id="eva">
+            <persName>Eva</persName>
+          </person>
+          <person xml:id="abello">
+            <persName>Abello</persName>
+          </person>
+          <person xml:id="caino">
+            <persName>Caino</persName>
+          </person>
+          <person xml:id="angelo_che_piglia">
+            <persName>Angelo che piglia l'Anima</persName>
+          </person>
+          <person xml:id="lamech">
+            <persName>Lamech</persName>
+          </person>
+          <person xml:id="fanciullo">
+            <persName>Il Fanciullo</persName>
+          </person>
+          <person xml:id="dimonio">
+            <persName>Il Dimonio</persName>
+          </person>
+          <person xml:id="angelo_che_gliela">
+            <persName>L'Angelo che gliela contraddice</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -159,7 +232,7 @@ Serafini</role>
       <div>
         <head>UNA RAPPRESENTAZIONE QUANDO IDDIO FECE IL MONDO E L'UOMO E OGNI COSA CREATA</head>
         <stage rend="sc">Viene uno Angelo ch'annu&lt;n&gt;zia la rappresentazione e dice così:</stage>
-        <sp>
+        <sp who="#angelo_annunciatore">
           <speaker rend="sc">ANGELO ANNUNCIATORE</speaker>
           <lg>
             <l>Padre, Figliuolo e Spirito Santo,</l>
@@ -203,7 +276,7 @@ Serafini</role>
           </lg>
         </sp>
         <stage rend="sc">Cominciasi la rappresentazione come Iddio fe' li angeli e 'l dì e la notte cioè la domenica e come Iddio parla il primo dì:</stage>
-        <sp>
+        <sp who="#iddio">
           <speaker rend="sc">IDDIO</speaker>
           <l>Acciò che si dimostri il nostro amore</l>
           <l>e che da noi ogni ben si produce</l>
@@ -212,18 +285,18 @@ Serafini</role>
           <l>el previsto <foreign xml:lang="lat">ab eterno</foreign> or venga fore.</l>
         </sp>
         <stage rend="sc">Detto questo verso, si scuoprono i cori degli Angeli tutti e nove:</stage>
-        <sp>
+        <sp who="#iddio">
           <speaker rend="sc">IDDIO</speaker>
           <l>Dico e comando che sie fatta luce.</l>
         </sp>
         <stage rend="sc">Ora si scuopre motti luminari:</stage>
-        <sp>
+        <sp who="#iddio">
           <speaker rend="sc">IDDIO</speaker>
           <l>Domenica sia il nome in far così</l>
           <l>che tenebre sie notte e luce il dì.</l>
         </sp>
         <stage rend="sc">Ora si volge Iddio Padre agli Angeli e dice:</stage>
-        <sp>
+        <sp who="#iddio">
           <speaker rend="sc">IDDIO</speaker>
           <l>Angeli miei colla mente sincera,</l>
           <l>per grande amor da me suti creati,</l>
@@ -235,7 +308,7 @@ Serafini</role>
           <l>il ben ch'avete, ed in me permanendo.</l>
         </sp>
         <stage rend="sc">Primo coro, cioè Angeli, parlano a Dio:</stage>
-        <sp>
+        <sp who="#angeli">
           <speaker rend="sc">ANGELI</speaker>
           <l>O sommo Re del ciel, fattor del tutto,</l>
           <l>dator de' benefici tanto grandi</l>
@@ -247,7 +320,7 @@ Serafini</role>
           <l>ma sempre intorno canterènti osanna.</l>
         </sp>
         <stage rend="sc">Secondo coro, Arcangioli, parlano a Dio:</stage>
-        <sp>
+        <sp who="#arcangeli">
           <speaker rend="sc">ARCANGELI</speaker>
           <l>O glorïoso Imperador superno,</l>
           <l>lo qual no'tuoi Arcangioli fatt'hai</l>
@@ -259,7 +332,7 @@ Serafini</role>
           <l>e de l'ineffabil tua beatitudine.</l>
         </sp>
         <stage rend="sc">Terzo coro, Principati, parlano a Dio:</stage>
-        <sp>
+        <sp who="#principati">
           <speaker rend="sc">PRINCIPATI</speaker>
           <l>O vero padre lo qual ci hai creati,</l>
           <l>per grazia e per amor sì com'ha' detto,</l>
@@ -271,7 +344,7 @@ Serafini</role>
           <l>ma ringraziànti quanto ci è possibile.</l>
         </sp>
         <stage rend="sc">Quarto coro, Potestadi, parlano a Dio:</stage>
-        <sp>
+        <sp who="#potestati">
           <speaker rend="sc">POTESTATI</speaker>
           <l>O santa, o degna, o somma Maestate,</l>
           <l>che se' sanza prencipio e sanza fine,</l>
@@ -283,7 +356,7 @@ Serafini</role>
           <l>che del don che ci fai possiàn laudarti.</l>
         </sp>
         <stage rend="sc">Quinto coro, le Virtù, parlano a Dio:</stage>
-        <sp>
+        <sp who="#virtu">
           <speaker rend="sc">VIRTÙ</speaker>
           <l>O Signore de' Signor, Re d'' Re, degno</l>
           <l>sopra tutt'altri di laude compiute,</l>
@@ -295,7 +368,7 @@ Serafini</role>
           <l>per providenza de' tuo' buon governi.</l>
         </sp>
         <stage rend="sc">Sesto coro, Dominazioni, parlano a Dio:</stage>
-        <sp>
+        <sp who="#dominazioni">
           <speaker rend="sc">DOMINAZIONI</speaker>
           <l>Somma cagion di tutte le cagioni,</l>
           <l>che non compreso ogni cosa comprendi,</l>
@@ -307,7 +380,7 @@ Serafini</role>
           <l>dell'impotenza, ma pel vero affetto.</l>
         </sp>
         <stage rend="sc">Settimo coro, cioè Troni, parlano a Dio:</stage>
-        <sp>
+        <sp who="#troni">
           <speaker rend="sc">TRONI</speaker>
           <l>O primo ben, cagion di tutt'i beni,</l>
           <l>mirabil largitor d'ogni contento,</l>
@@ -319,7 +392,7 @@ Serafini</role>
           <l>del ben il qual per noi di te si gaude.</l>
         </sp>
         <stage rend="sc">Ottavo coro, cioè Cherubini, parlano a Dio:</stage>
-        <sp>
+        <sp who="#cherubini">
           <speaker rend="sc">CHERUBINI</speaker>
           <l>O Trina Maestade in una essenza,</l>
           <l>il qual non circuscritto circuscrivi</l>
@@ -331,7 +404,7 @@ Serafini</role>
           <l>le somme laude tue cantando sempre.</l>
         </sp>
         <stage rend="sc">Nono coro, cioè Serafini, parlano a Dio:</stage>
-        <sp>
+        <sp who="#serafini">
           <speaker rend="sc">SERAFINI</speaker>
           <l>O Amor, che per amor ci ardi d'amore</l>
           <l>con fiamma tanto dolce e sì gioconda,</l>
@@ -343,7 +416,7 @@ Serafini</role>
           <l>con eterna canzon ti ringraziamo.</l>
         </sp>
         <stage rend="sc">Lucifero dica:</stage>
-        <sp>
+        <sp who="#lucifero">
           <speaker rend="sc">LUCIFERO</speaker>
           <lg>
             <l>I' son saggio, io son bello, i' sono ornato,</l>
@@ -367,7 +440,7 @@ Serafini</role>
           </lg>
         </sp>
         <stage rend="sc">E detto questo, d'isso fatto cade Lucifero e i suoi. Iddio parla a Lucifero:</stage>
-        <sp>
+        <sp who="#iddio">
           <speaker rend="sc">IDDIO</speaker>
           <l>Donde avvien che sì bello e tanto degno</l>
           <l>in tanta gloria e gran gaudio prudotto</l>
@@ -379,7 +452,7 @@ Serafini</role>
           <l>t'ha privo di sì gran beatitudine.</l>
         </sp>
         <stage rend="sc">Iddio comanda a Michäel:</stage>
-        <sp>
+        <sp who="#iddio">
           <speaker rend="sc">IDDIO</speaker>
           <l>Or tu, Michäel, mio fedel perfetto,</l>
           <l>in grazia confermato co' veraci,</l>
@@ -391,7 +464,7 @@ Serafini</role>
           <l>in fuoco ardente e in tenebre eterne.</l>
         </sp>
         <stage rend="sc">Michäel a Lucifero e a' suoi:</stage>
-        <sp>
+        <sp who="#michael">
           <speaker rend="sc">MICHÄEL</speaker>
           <l>Via fellon maladetto, ingrato e rio,</l>
           <l>superbo, iniquo, invidïoso e fiero,</l>
@@ -403,7 +476,7 @@ Serafini</role>
           <l>co' lui n'andate in eternal supplizio.</l>
         </sp>
         <stage rend="sc">Iddio parla il secondo dì:</stage>
-        <sp>
+        <sp who="#iddio">
           <speaker rend="sc">IDDIO</speaker>
           <l>Dico ancor che sie fatto il fermamento</l>
           <l>in nel mezzo dell'acque, dividendo</l>
@@ -415,7 +488,7 @@ Serafini</role>
           <l>come nel primo fe' la mia dottrina.</l>
         </sp>
         <stage rend="sc">Pure Iddio il terzo dì dice:</stage>
-        <sp>
+        <sp who="#iddio">
           <speaker rend="sc">IDDIO</speaker>
           <l>Ancor comando l'acque raunarsi,</l>
           <l>le qual son sotto 'l cielo, in un sol loco;</l>
@@ -427,7 +500,7 @@ Serafini</role>
           <l>Questo fo martedì nel terzo giorno.</l>
         </sp>
         <stage rend="sc">Pure Iddio il quarto dì parla:</stage>
-        <sp>
+        <sp who="#iddio">
           <speaker rend="sc">IDDIO</speaker>
           <l>Del fermamento ancor lumi e pianeti</l>
           <l>sien fatti, i dì dalla notte divisi;</l>
@@ -439,7 +512,7 @@ Serafini</role>
           <l>e l'altre cose in ciel fatte sì belle.</l>
         </sp>
         <stage rend="sc">Nel quinto dì pure Iddio parla:</stage>
-        <sp>
+        <sp who="#iddio">
           <speaker rend="sc">IDDIO</speaker>
           <l>Giovial giorno ancora, tutte piene</l>
           <l>fo che sien l'acque d'animal viventi:</l>
@@ -451,7 +524,7 @@ Serafini</role>
           <l>crescete, dico, e sì multiplicate.</l>
         </sp>
         <stage rend="sc">Venerdì il sesto dì pure Iddio dice:</stage>
-        <sp>
+        <sp who="#iddio">
           <speaker rend="sc">IDDIO</speaker>
           <l>In questo giorno sesto dico ancora</l>
           <l>produr la terra, ogni generazione</l>
@@ -463,7 +536,7 @@ Serafini</role>
           <l>nostra sie fatto, sanza aver mancanza.</l>
         </sp>
         <stage rend="sc">Pure Iddio dice:</stage>
-        <sp>
+        <sp who="#iddio">
           <speaker rend="sc">IDDIO</speaker>
           <l>Tutti pesci, uccelli, e animali</l>
           <l>terresti e belve, legni, arbori, e frutti,</l>
@@ -475,7 +548,7 @@ Serafini</role>
           <l>e così vi confermo e benedico.</l>
         </sp>
         <stage rend="sc">Iddio parla pel settimo dì:</stage>
-        <sp>
+        <sp who="#iddio">
           <speaker rend="sc">IDDIO</speaker>
           <l>E ora adunque nel settimo giorno</l>
           <l>che 'l magno lavorio nostro e copioso</l>
@@ -487,7 +560,7 @@ Serafini</role>
           <l>presi riposo, di tutto Fattore.</l>
         </sp>
         <stage rend="sc">Iddio ad Adam:</stage>
-        <sp>
+        <sp who="#iddio">
           <speaker rend="sc">IDDIO</speaker>
           <l>Adam, che così voglio che abbi nome,</l>
           <l>io ti do a mangiar di ciascun legno</l>
@@ -499,7 +572,7 @@ Serafini</role>
           <l>annu&lt;n&gt;zio a te che di morte morrai.</l>
         </sp>
         <stage rend="sc">Segue Iddio ad Adam:</stage>
-        <sp>
+        <sp who="#iddio">
           <speaker rend="sc">IDDIO</speaker>
           <l>E tutti li animali e l'altre cose</l>
           <l>ti pongo innanzi, sì come tu vedi</l>
@@ -511,7 +584,7 @@ Serafini</role>
           <l>e così a loro ubbidirti comando.</l>
         </sp>
         <stage rend="sc">Parla Adam e pone i nomi a'pesci:</stage>
-        <sp>
+        <sp who="#adamo">
           <speaker rend="sc">ADAMO</speaker>
           <l>Balene, tonni, alfin, morene, orate,</l>
           <l>muggini, storioni, tinche e reine,</l>
@@ -523,7 +596,7 @@ Serafini</role>
           <l>e sì d'ogni altr'i nomi che ho lor posti.</l>
         </sp>
         <stage rend="sc">Parla Adam e pone i nomi agli uccelli:</stage>
-        <sp>
+        <sp who="#adamo">
           <speaker rend="sc">ADAMO</speaker>
           <l>Aquile, astor, giralchi e milïoni,</l>
           <l>sparvier, moscardi, gheppi, corvi e gazze,</l>
@@ -535,7 +608,7 @@ Serafini</role>
           <l>il nome ch'io do lor sempre ritenghino.</l>
         </sp>
         <stage rend="sc">Parla Adam e pone i nomi alle bestie:</stage>
-        <sp>
+        <sp who="#adamo">
           <speaker rend="sc">ADAMO</speaker>
           <l>Leofanti, leon, camelli e buoi,</l>
           <l>orsi, asini, caval, porci, e pantere,</l>
@@ -547,7 +620,7 @@ Serafini</role>
           <l>per che dunque il suo nome ognun ritenga.</l>
         </sp>
         <stage rend="sc">Iddio parla:</stage>
-        <sp>
+        <sp who="#iddio">
           <speaker rend="sc">IDDIO</speaker>
           <l>Fatto abbiam l'uom però che degno sia</l>
           <l>del bene il qual da me gli è conceduto;</l>
@@ -559,7 +632,7 @@ Serafini</role>
           <l>cagion che 'l faccia al presente dormire.</l>
         </sp>
         <stage rend="sc">Adam dorme e Iddio gli trae una costola e sègnale e ne fa una donna. Iddio dice ad Adam:</stage>
-        <sp>
+        <sp who="#iddio">
           <speaker rend="sc">IDDIO</speaker>
           <l>Adam, per cosa grata, bella, e magna,</l>
           <l>molto a te necessaria nel tuo stato,</l>
@@ -571,7 +644,7 @@ Serafini</role>
           <l>s'io non ti davo lei per tuo aiuto.</l>
         </sp>
         <stage rend="sc">Adam parla a Dio:</stage>
-        <sp>
+        <sp who="#adamo">
           <speaker rend="sc">ADAMO</speaker>
           <l>Costei, Signore, è del mio osso l'ossa,</l>
           <l>detta Virago, ché de l'uomo è tratta.</l>
@@ -583,7 +656,7 @@ Serafini</role>
           <l>e così sempre in mio genere sia.</l>
         </sp>
         <stage rend="sc">Parla il Serpente alla donna:</stage>
-        <sp>
+        <sp who="#serpente">
           <speaker rend="sc">SERPENTE</speaker>
           <l>Per qual ragion ha comandato Iddio</l>
           <l>che voi del legno de la sapïenza</l>
@@ -595,7 +668,7 @@ Serafini</role>
           <l>che di questo mangiar non vi conceda?</l>
         </sp>
         <stage rend="sc">Eva al Serpente risponde:</stage>
-        <sp>
+        <sp who="#eva">
           <speaker rend="sc">EVA</speaker>
           <l>Conceduto ci ha Dio che di que' frutti,</l>
           <l>o d'ogni legno qua del Paradiso,</l>
@@ -607,7 +680,7 @@ Serafini</role>
           <l>e questa è la ragion che nol mangiamo.</l>
         </sp>
         <stage rend="sc">Il Serpente dice:</stage>
-        <sp>
+        <sp who="#serpente">
           <speaker rend="sc">SERPENTE</speaker>
           <l>Certo di morte mai vo' non morrete,</l>
           <l>ma se del legno, che de' beni e mali</l>
@@ -619,7 +692,7 @@ Serafini</role>
           <l>se esser volete in tanta dignitate.</l>
         </sp>
         <stage rend="sc">Mangia Eva del pome e poi dice ad Adam:</stage>
-        <sp>
+        <sp who="#eva">
           <speaker rend="sc">EVA</speaker>
           <l>Buono e dolce a mangiare, gaio e bello,</l>
           <l>e grato, e dilettevole all'aspetto,</l>
@@ -631,7 +704,7 @@ Serafini</role>
           <l>l'esser noi come Lui in grado verace.</l>
         </sp>
         <stage rend="sc">Mangiato, Adam dice ad Eva:</stage>
-        <sp>
+        <sp who="#adamo">
           <speaker rend="sc">ADAMO</speaker>
           <l>Oimé ch'i' veggio noi essere ignudi,</l>
           <l>della vergogna conoscenti e sperti.</l>
@@ -643,7 +716,7 @@ Serafini</role>
           <l>e del nostro fallir non ci ripruovi.</l>
         </sp>
         <stage rend="sc">Il Signore ad Adam:</stage>
-        <sp>
+        <sp who="#iddio">
           <speaker rend="sc">IDDIO</speaker>
           <l>Adam, Adam, dove ne se' tu gito?</l>
           <l>Che vuoi dir che tu se' così nascosto,</l>
@@ -655,7 +728,7 @@ Serafini</role>
           <l>che dalla faccia mia nascosto stai.</l>
         </sp>
         <stage rend="sc">Adam a Dio:</stage>
-        <sp>
+        <sp who="#adamo">
           <speaker rend="sc">ADAMO</speaker>
           <l>Udii la voce tua nel Paradiso</l>
           <l>la quale, o Signor mio, temetti molto;</l>
@@ -667,7 +740,7 @@ Serafini</role>
           <l>e queste son cagion ch'io mi nascosi.</l>
         </sp>
         <stage rend="sc">Iddio ad Adam:</stage>
-        <sp>
+        <sp who="#adamo">
           <speaker rend="sc">ADAMO</speaker>
           <l>Adam, chi ti mostrò l'esser tu nudo,</l>
           <l>che sai che'n prima non te n'eri addato</l>
@@ -679,7 +752,7 @@ Serafini</role>
           <l>Qual è stata cagion di tua mancanza?</l>
         </sp>
         <stage rend="sc">Adam a Dio:</stage>
-        <sp>
+        <sp who="#adamo">
           <speaker rend="sc">ADAMO</speaker>
           <l>La femmina, Signor, che tu mi desti,</l>
           <l>la qual mi fusse aiuto e compagnia,</l>
@@ -691,7 +764,7 @@ Serafini</role>
           <l>ed or di mio fallir t'ho detto tutto.</l>
         </sp>
         <stage rend="sc">Iddio ad Eva:</stage>
-        <sp>
+        <sp who="#iddio">
           <speaker rend="sc">IDDIO</speaker>
           <l>Tu femmina, da me fatta formosa,</l>
           <l>nel mondo bella, tanto grata e degna,</l>
@@ -703,7 +776,7 @@ Serafini</role>
           <l>ché l'uomo incolpa te con rimprovèro.</l>
         </sp>
         <stage rend="sc">Eva a Dio:</stage>
-        <sp>
+        <sp who="#eva">
           <speaker rend="sc">EVA</speaker>
           <l>Signore, i' ti dirò interamente</l>
           <l>sanza voler di nulla a te mentire.</l>
@@ -715,7 +788,7 @@ Serafini</role>
           <l>ché poi sapremo quanto tu, Iddio.</l>
         </sp>
         <stage rend="sc">Iddio al Serpente:</stage>
-        <sp>
+        <sp who="#iddio">
           <speaker rend="sc">IDDIO</speaker>
           <l>Perché tu hai commessa questa guerra,</l>
           <l>animal reo, e tu sia maladetto</l>
@@ -727,7 +800,7 @@ Serafini</role>
           <l>attriterà il tuo capo al suo calcagno.</l>
         </sp>
         <stage rend="sc">Pure Iddio ad Eva:</stage>
-        <sp>
+        <sp who="#iddio">
           <speaker rend="sc">IDDIO</speaker>
           <l>Femmina, or sappi ch'è le tue sciagure:</l>
           <l>moltiplicare e tuoi concepimenti</l>
@@ -739,7 +812,7 @@ Serafini</role>
           <l>voglio e dispongo che ti signoreggi.</l>
         </sp>
         <stage rend="sc">Iddio parla ad Adam:</stage>
-        <sp>
+        <sp who="#iddio">
           <speaker rend="sc">IDDIO</speaker>
           <l>Però che della moglie tua udisti</l>
           <l>la voce, e sì mangiasti di quel legno</l>
@@ -751,7 +824,7 @@ Serafini</role>
           <l>e viverai del sudor del tuo volto.</l>
         </sp>
         <stage rend="sc">Pure Iddio ad Adam:</stage>
-        <sp>
+        <sp who="#iddio">
           <speaker rend="sc">IDDIO</speaker>
           <lg>
             <l>Ancora vi concedo queste veste</l>
@@ -772,14 +845,14 @@ Serafini</role>
           </lg>
         </sp>
         <stage rend="sc">Dice Iddio al Angiol Serafino:</stage>
-        <sp>
+        <sp who="#iddio">
           <speaker rend="sc">IDDIO</speaker>
           <l>E tu, fedel mio Angiol Serafino,</l>
           <l>rimarrai qui a guardia d'esto loco,</l>
           <l>col terribil coltello tuo di foco.</l>
         </sp>
         <stage rend="sc">Adamo ad Eva:</stage>
-        <sp>
+        <sp who="#adamo">
           <speaker rend="sc">ADAMO</speaker>
           <l>Dappoi che per lo nostro fallimento,</l>
           <l>donna mia, nato dal disubbidire,</l>
@@ -791,7 +864,7 @@ Serafini</role>
           <l>e a te fuso e conocchia e la rocca.</l>
         </sp>
         <stage rend="sc">Avendo Eva partoriti dui figliuoli, e già cresciiuti, dice Adam:</stage>
-        <sp>
+        <sp who="#adamo">
           <speaker rend="sc">ADAMO</speaker>
           <l>A te, Cain, primogenito mio,</l>
           <l>comando sempre lavorar la terra,</l>
@@ -803,7 +876,7 @@ Serafini</role>
           <l>e questo vo' che sia  il tuo esercizio.</l>
         </sp>
         <stage rend="sc">Adam dice ad Abello:</stage>
-        <sp>
+        <sp who="#adamo">
           <speaker rend="sc">ADAMO</speaker>
           <l>E tu, Abel, di gregge sia pastore,</l>
           <l>mandre guidando, ordinando e pascendo,</l>
@@ -815,7 +888,7 @@ Serafini</role>
           <l>E di ciò v'amunisco e vi comando.</l>
         </sp>
         <stage rend="sc">Abello a Dio:</stage>
-        <sp>
+        <sp who="#abello">
           <speaker rend="sc">ABELLO</speaker>
           <l>Signor, per cui di tanti beni abondo</l>
           <l>li quai tu solamente mi concedi,</l>
@@ -827,7 +900,7 @@ Serafini</role>
           <l>fa 'l sagrificio mio perfetto e degno.</l>
         </sp>
         <stage rend="sc">Cain a sé medesimo:</stage>
-        <sp>
+        <sp who="#caino">
           <speaker rend="sc">CAINO</speaker>
           <l>Questo m'è di grand'onta e gran dolore,</l>
           <l>tal che nol posso al tutto sopportare,</l>
@@ -839,7 +912,7 @@ Serafini</role>
           <l>che mi sento agghiadar per tal tormento.</l>
         </sp>
         <stage rend="sc">Il Signore a Cain:</stage>
-        <sp>
+        <sp who="#iddio">
           <speaker rend="sc">IDDIO</speaker>
           <l>Cain, Cain, perché se' tu turbato?</l>
           <l>Donde nasce 'l tuo duol? Donde vien l'ira?</l>
@@ -851,7 +924,7 @@ Serafini</role>
           <l>sicché 'l mal far non sie ma' consentito.</l>
         </sp>
         <stage rend="sc">Cain ad Abello:</stage>
-        <sp>
+        <sp who="#caino">
           <speaker rend="sc">CAINO</speaker>
           <l>Andiamo insieme qua di fuori, Abello,</l>
           <l>a ragguardare a' nostri lavorìi,</l>
@@ -863,7 +936,7 @@ Serafini</role>
           <l>veggendoli al Signore essere accetti.</l>
         </sp>
         <stage rend="sc">Abel a Dio sagrificando:</stage>
-        <sp>
+        <sp who="#abello">
           <speaker rend="sc">ABELE</speaker>
           <l>Signor, dal qual viene ogni benefizio,</l>
           <l>e lo qual ci concedi tutti e beni,</l>
@@ -875,7 +948,7 @@ Serafini</role>
           <l>de' miglior ben che i' ho, ti fo Signore.</l>
         </sp>
         <stage rend="sc">Cain parla seco:</stage>
-        <sp>
+        <sp who="#caino">
           <speaker rend="sc">CAINO</speaker>
           <l>Ben conosco ch'a Dio sono in dispetto,</l>
           <l>e ciò comprendo nel sacrificare,</l>
@@ -887,7 +960,7 @@ Serafini</role>
           <l>spegner di terra il mio fratello Abello.</l>
         </sp>
         <stage rend="sc">L'Angelo piglia l'anima d'Abello e dice:</stage>
-        <sp>
+        <sp who="#angelo_che_piglia">
           <speaker rend="sc">ANGELO che piglia l'anima</speaker>
           <l>Anima benedetta, il cui ben fare</l>
           <l>mosse ad invidia il tuo crudel fratello,</l>
@@ -899,7 +972,7 @@ Serafini</role>
           <l>sperando in quel Messia lo qual ti dico.</l>
         </sp>
         <stage rend="sc">Iddio a Caino:</stage>
-        <sp>
+        <sp who="#iddio">
           <speaker rend="sc">IDDIO</speaker>
           <l>Cain, dov'è Abel? Che n'ha' tu fatto,</l>
           <l>ch'i' nol veggio con teco essere insieme?</l>
@@ -911,7 +984,7 @@ Serafini</role>
           <l>e però or mi di' quel ch'è di lui.</l>
         </sp>
         <stage rend="sc">Caino al Signore:</stage>
-        <sp>
+        <sp who="#caino">
           <speaker rend="sc">CAINO</speaker>
           <l>Non ti so dir quel che di lui si sia,</l>
           <l>per che di ciò il domandarmi è vano,</l>
@@ -923,7 +996,7 @@ Serafini</role>
           <l>sicché dov'è non ti sapre' 'nsegnare.</l>
         </sp>
         <stage rend="sc">Iddio a Caino:</stage>
-        <sp>
+        <sp who="#iddio">
           <speaker rend="sc">IDDIO</speaker>
           <l>Il sangue, oimé, del tuo fratel mi chiama</l>
           <l>di terra, il quale, o miser, tu hai morto,</l>
@@ -935,7 +1008,7 @@ Serafini</role>
           <l>starai in terra insin che sarai vivo.</l>
         </sp>
         <stage rend="sc">Caino al Signore:</stage>
-        <sp>
+        <sp who="#caino">
           <speaker rend="sc">CAINO</speaker>
           <l>Maggior cognosco la mie iniquitate</l>
           <l>che la cremenza tua e perdonanza,</l>
@@ -947,7 +1020,7 @@ Serafini</role>
           <l>richiede ch'io, se uccisi, ancor sie morto.</l>
         </sp>
         <stage rend="sc">Il Signore a Caino:</stage>
-        <sp>
+        <sp who="#iddio">
           <speaker rend="sc">IDDIO</speaker>
           <l>Certo non fallerà questa sentenza,</l>
           <l>ma ben ch'avvenga quel che tu ha' detto,</l>
@@ -959,7 +1032,7 @@ Serafini</role>
           <l>e solo in me rimanga il far vendetta.</l>
         </sp>
         <stage rend="sc">Parla Lamech a uno Fanciullo:</stage>
-        <sp>
+        <sp who="#lamech">
           <speaker rend="sc">LAMECH</speaker>
           <lg>
             <l>Io son Lamech, o puro Fanciulletto,</l>
@@ -983,7 +1056,7 @@ Serafini</role>
           </lg>
         </sp>
         <stage rend="sc">Dice il Fanciullo dopo la presa di parecchi fiere:</stage>
-        <sp>
+        <sp who="#fanciullo">
           <speaker rend="sc">FANCIULLO</speaker>
           <l>Lamech, i' sento le frasche fremire</l>
           <l>con romor grande dentro a un macchione,</l>
@@ -995,7 +1068,7 @@ Serafini</role>
           <l>ch'i' t'ho adirizzato ben la mira.</l>
         </sp>
         <stage rend="sc">Dice Cain gridando:</stage>
-        <sp>
+        <sp who="#caino">
           <speaker rend="sc">CAINO</speaker>
           <l>Omé, omé, o misero, i' son morto</l>
           <l>per questa ricevuta gran ferita.</l>
@@ -1007,7 +1080,7 @@ Serafini</role>
           <l>sarò dannato eternalmente in pene.</l>
         </sp>
         <stage rend="sc">Viene il Dimonio per l'anima di Caino e dice a l'Angiolo:</stage>
-        <sp>
+        <sp who="#dimonio">
           <speaker rend="sc">DIMONIO</speaker>
           <l>Angiol di Dio, non mi voler far torto,</l>
           <l>perché costui è nostro giustamente,</l>
@@ -1019,7 +1092,7 @@ Serafini</role>
           <l>farò di lui il debito governo.</l>
         </sp>
         <stage rend="sc">Lamech al Fanciullo:</stage>
-        <sp>
+        <sp who="#lamech">
           <speaker rend="sc">LAMECH</speaker>
           <l>O Fanciul maladetto, stolto e matto,</l>
           <l>non vedi tu quel che m'hai fatto fare?</l>
@@ -1031,7 +1104,7 @@ Serafini</role>
           <l>ma così giudicato è dal Signore.</l>
         </sp>
         <stage rend="sc">L'Angiolo viene per l'anima del Fanciullo e il Dimonio gliele contraddice:</stage>
-        <sp>
+        <sp who="#dimonio">
           <speaker rend="sc">DIMONIO</speaker>
           <l>L'anima del Fanciul debbe esser mia,</l>
           <l>o Angiol, che per lei così tu vieni,</l>
@@ -1055,7 +1128,7 @@ Serafini</role>
           <l>la sua innocenza la concedo a Dio.</l>
         </sp>
         <stage rend="sc">Finita la rappresentazione, viene l'Angiolo ch'annu&lt;n&gt;zia la rappresentazione e dice queste due stanze:</stage>
-        <sp>
+        <sp who="#angelo_annunciatore">
           <speaker rend="sc">ANGELO ANNUNCIATORE</speaker>
           <lg>
             <l>Signori stati a udire e vedere</l>

--- a/tei/anonimo-representazione-di-febo-e-feton.xml
+++ b/tei/anonimo-representazione-di-febo-e-feton.xml
@@ -81,6 +81,49 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="mercurio">
+            <persName>Mercurio</persName>
+          </person>
+          <person xml:id="ninfa">
+            <persName>Ninfa</persName>
+          </person>
+          <person xml:id="febo">
+            <persName>Febo</persName>
+          </person>
+          <person xml:id="altra_ninfa">
+            <persName>Altra Ninfa</persName>
+          </person>
+          <person xml:id="pastore">
+            <persName>Pastore</persName>
+          </person>
+          <person xml:id="venere">
+            <persName>Venere</persName>
+          </person>
+          <person xml:id="cupido">
+            <persName>Cupido</persName>
+          </person>
+          <person xml:id="dafne">
+            <persName>Dafne</persName>
+          </person>
+          <person xml:id="penneo">
+            <persName>Penneo</persName>
+          </person>
+          <person xml:id="giove">
+            <persName>Giove</persName>
+          </person>
+          <person xml:id="marte">
+            <persName>Marte</persName>
+          </person>
+          <person xml:id="iunone">
+            <persName>Iunone</persName>
+          </person>
+          <person xml:id="neptuno">
+            <persName>Neptuno</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -94,7 +137,7 @@
       <div>
         <head>REPRESENTAZIONE DI FEBO E FETON</head>
         <stage><hi rend="sc">MERCURIO</hi> anunzio de la festa.</stage>
-        <sp>
+        <sp who="#mercurio">
           <speaker rend="sc">MERCURIO</speaker>
           <lg>
             <l>Signori attenti: el fu già un serpente</l>
@@ -148,7 +191,7 @@
           </lg>
         </sp>
         <stage>Una <hi rend="sc">NINFA</hi> corre a <hi rend="sc">FEBO</hi> a dire del serpente e dice cossì:</stage>
-        <sp>
+        <sp who="#ninfa">
           <speaker rend="sc">NINFA</speaker>
           <lg>
             <l>Fa triegua ormai co' cervi, o biondo Apollo,</l>
@@ -162,7 +205,7 @@
           </lg>
         </sp>
         <stage>Risposta di <hi rend="sc">FEBO</hi> alla <hi rend="sc">NINFA</hi>:</stage>
-        <sp>
+        <sp who="#febo">
           <speaker rend="sc">FEBO</speaker>
           <lg>
             <l>Mostrami, ninfa, pur la obscura grotta</l>
@@ -176,7 +219,7 @@
           </lg>
         </sp>
         <stage>Un'altra <hi rend="sc">NINFA</hi> a certi <hi rend="sc">PASTORI</hi>:</stage>
-        <sp>
+        <sp who="#altra_ninfa">
           <speaker rend="sc">ALTRA NINFA</speaker>
           <lg>
             <l>Pastor, correte a veder che spavento</l>
@@ -190,7 +233,7 @@
           </lg>
         </sp>
         <stage>Risposta d'uno <hi rend="sc">PASTORE</hi> per tutti alla <hi rend="sc">NINFA</hi>:</stage>
-        <sp>
+        <sp who="#pastore">
           <speaker rend="sc">PASTORE</speaker>
           <lg>
             <l>Andiàn per l'arco e per gli strali e l'armi</l>
@@ -204,7 +247,7 @@
           </lg>
         </sp>
         <stage>El <hi rend="sc">PASTORE</hi> riman morto dal serpente. <hi rend="sc">FEBO</hi> va lui con lo strale e prima dimanda grazia a <hi rend="sc">GIOVE</hi> gli dia vittoria:</stage>
-        <sp>
+        <sp who="#febo">
           <speaker rend="sc">FEBO</speaker>
           <lg>
             <l>O crudel fera, o troppo orrendo mostro,</l>
@@ -218,7 +261,7 @@
           </lg>
         </sp>
         <stage><hi rend="sc">FEBO</hi> chiede grazia a <hi rend="sc">GIOVE</hi>, e dice cossì:</stage>
-        <sp>
+        <sp who="#febo">
           <speaker rend="sc">FEBO</speaker>
           <lg>
             <l>Tu, sommo Giove, padre onnipotente,</l>
@@ -232,7 +275,7 @@
           </lg>
         </sp>
         <stage>Scusa di <hi rend="sc">FEBO</hi> a la <hi rend="sc">TERRA</hi>:</stage>
-        <sp>
+        <sp who="#febo">
           <speaker rend="sc">FEBO</speaker>
           <lg>
             <l>O Terra, o madre di ciascun che ha vita,</l>
@@ -246,7 +289,7 @@
           </lg>
         </sp>
         <stage>Grazie che rende <hi rend="sc">FEBO</hi> al padre, e dice cossì:</stage>
-        <sp>
+        <sp who="#febo">
           <speaker rend="sc">FEBO</speaker>
           <lg>
             <l>Immenso padre, onnipotente idio,</l>
@@ -260,7 +303,7 @@
           </lg>
         </sp>
         <stage>Una <hi rend="sc">NINFA</hi> corre a <hi rend="sc">VENERE</hi>, a <hi rend="sc">NEPTUNNO</hi> e a <hi rend="sc">MARTE</hi> de la morte del serpente, e dice cossì:</stage>
-        <sp>
+        <sp who="#ninfa">
           <speaker rend="sc">NINFA</speaker>
           <lg>
             <l>Ciprigna bionda, e tu Neptunno e Marte,</l>
@@ -274,7 +317,7 @@
           </lg>
         </sp>
         <stage><hi rend="sc">VENERE</hi> comanda a <hi rend="sc">CUPIDO</hi> che vada a vedere Fetonte morto:</stage>
-        <sp>
+        <sp who="#venere">
           <speaker rend="sc">VENERE</speaker>
           <lg>
             <l>Va', vedi tu, figliuol, Feton ch'è morto,</l>
@@ -288,7 +331,7 @@
           </lg>
         </sp>
         <stage><hi rend="sc">FEBO</hi> vittorioso del serpente torna e scontra <hi rend="sc">CUPIDO</hi> e dice cossì:</stage>
-        <sp>
+        <sp who="#febo">
           <speaker rend="sc">FEBO</speaker>
           <lg>
             <l>Che farestu, fanciul, con le forte armi?</l>
@@ -312,7 +355,7 @@
           </lg>
         </sp>
         <stage><hi rend="sc">CUPIDO</hi> risponde a <hi rend="sc">FEBO</hi> cossì:</stage>
-        <sp>
+        <sp who="#cupido">
           <speaker rend="sc">CUPIDO</speaker>
           <lg>
             <l>Febo, se col tuo arco ogni gran cosa</l>
@@ -326,7 +369,7 @@
           </lg>
         </sp>
         <stage><hi rend="sc">FEBO</hi> passa via, e scontra <hi rend="sc">DAFNE</hi>; <hi rend="sc">CUPIDO</hi> va a <hi rend="sc">VENERE</hi> e duolsi di <hi rend="sc">FEBO</hi> che gli ha detto ingiuria, e <hi rend="sc">VENERE</hi> gli dà due strali, uno d'oro e l'altro di piombo. Poi <hi rend="sc">CUPIDO</hi> ne va su al monte di Parnaso:</stage>
-        <sp>
+        <sp who="#cupido">
           <speaker rend="sc">CUPIDO</speaker>
           <lg>
             <l>O sacra, o santa, o veneranda madre,</l>
@@ -350,7 +393,7 @@
           </lg>
         </sp>
         <stage><hi rend="sc">VENERE</hi> risponde al figliuolo cossì:</stage>
-        <sp>
+        <sp who="#venere">
           <speaker rend="sc">VENERE</speaker>
           <lg>
             <l>Siché Febo non teme i nostri colpi</l>
@@ -384,7 +427,7 @@
           </lg>
         </sp>
         <stage><hi rend="sc">CUPIDO</hi> va in sul monte Parnaso. <hi rend="sc">FEBO</hi> si scontra cum <hi rend="sc">DAFNE</hi>. <hi rend="sc">CUPIDO</hi> gli vede dal monte e saetta l'uno dell'oro e l'altro del piombo e dice cossì <hi rend="sc">FEBO</hi> alla ninfa:</stage>
-        <sp>
+        <sp who="#febo">
           <speaker rend="sc">FEBO</speaker>
           <lg>
             <l>Ninfa, che per veder Feton te 'n vai,</l>
@@ -398,7 +441,7 @@
           </lg>
         </sp>
         <stage><hi rend="sc">DAFNE</hi> risponde a <hi rend="sc">FEBO</hi>:</stage>
-        <sp>
+        <sp who="#dafne">
           <speaker rend="sc">DAFNE</speaker>
           <lg>
             <l>Onor, fama immortal de l'uman regno</l>
@@ -412,7 +455,7 @@
           </lg>
         </sp>
         <stage><hi rend="sc">CUPIDO</hi> dal monte Parnaso dice a <hi rend="sc">FEBO</hi> queste parole e diserra l'arco con lo stral d'oro.</stage>
-        <sp>
+        <sp who="#cupido">
           <speaker rend="sc">CUPIDO</speaker>
           <lg>
             <l>Febo, che te ne vai superbo e altiero,</l>
@@ -436,7 +479,7 @@
           </lg>
         </sp>
         <stage>Poi si volge <hi rend="sc">CUPIDO</hi> a <hi rend="sc">DAFNE</hi> e dice cossì:</stage>
-        <sp>
+        <sp who="#cupido">
           <speaker rend="sc">CUPIDO</speaker>
           <lg>
             <l>E tu, ninfa, che vai libera e sciolta</l>
@@ -450,7 +493,7 @@
           </lg>
         </sp>
         <stage><hi rend="sc">DAFNE</hi> torna al padre. <hi rend="sc">FEBO</hi> si sente ferito e dice cossì:</stage>
-        <sp>
+        <sp who="#febo">
           <speaker rend="sc">FEBO</speaker>
           <lg>
             <l>Che forza è questa, che ardente face</l>
@@ -474,7 +517,7 @@
           </lg>
         </sp>
         <stage><hi rend="sc">PENNEO</hi> dice a <hi rend="sc">DAFNE</hi> di darli marito in questa forma:</stage>
-        <sp>
+        <sp who="#penneo">
           <speaker rend="sc">PENNEO</speaker>
           <lg>
             <l>Dafne figliuola, il tempo chiede ormai</l>
@@ -488,7 +531,7 @@
           </lg>
         </sp>
         <stage><hi rend="sc">DAFNE</hi> risponde al padre che la lassi star vergine.</stage>
-        <sp>
+        <sp who="#dafne">
           <speaker rend="sc">DAFNAE</speaker>
           <lg>
             <l>Padre, se giusto amor di me ti preme,</l>
@@ -502,7 +545,7 @@
           </lg>
         </sp>
         <stage><hi rend="sc">PENNEO</hi> risponde a <hi rend="sc">DAFNE</hi>.</stage>
-        <sp>
+        <sp who="#penneo">
           <speaker rend="sc">PENNEO</speaker>
           <lg>
             <l>Cossì ti sia concesso e cossì voglio:</l>
@@ -516,7 +559,7 @@
           </lg>
         </sp>
         <stage><hi rend="sc">DAFNE</hi> va per boschi fuggendo <hi rend="sc">FEBO</hi> e <hi rend="sc">FEBO</hi> la segue e dice cossì:</stage>
-        <sp>
+        <sp who="#febo">
           <speaker rend="sc">FEBO</speaker>
           <lg>
             <l>Ninfa non ti fuggir, ma el passo allenta,</l>
@@ -591,7 +634,7 @@
           </lg>
         </sp>
         <stage><hi rend="sc">DAFNE</hi> essendo per esser gionta da <hi rend="sc">FEBO</hi> dicendo questa stanza si transformò in lauro.</stage>
-        <sp>
+        <sp who="#dafne">
           <speaker rend="sc">DAFNAE</speaker>
           <lg>
             <l>Padre, se tu se' dio di fiumi o di acqui,</l>
@@ -605,7 +648,7 @@
           </lg>
         </sp>
         <stage><hi rend="sc">DAFNE</hi> si muta in lauro e <hi rend="sc">FEBO</hi> ammirato guarda l'albero e dice cossì:</stage>
-        <sp>
+        <sp who="#febo">
           <speaker rend="sc">FEBO</speaker>
           <lg>
             <l>Poi ch'esser non mi puoi più cara moglie,</l>
@@ -629,7 +672,7 @@
           </lg>
         </sp>
         <stage><hi rend="sc">FEBO</hi> prega <hi rend="sc">GIOVE</hi> che guardi la sua amata fronde.</stage>
-        <sp>
+        <sp who="#febo">
           <speaker rend="sc">FEBO</speaker>
           <lg>
             <l>Padre, che 'l cielo e l'universo imperi,</l>
@@ -663,7 +706,7 @@
           </lg>
         </sp>
         <stage><hi rend="sc">GIOVE</hi> risponde a <hi rend="sc">FEBO</hi>.</stage>
-        <sp>
+        <sp who="#giove">
           <speaker rend="sc">GIOVE</speaker>
           <lg>
             <l>Prima ch'al tuo voler, Febo, risponda,</l>
@@ -687,7 +730,7 @@
           </lg>
         </sp>
         <stage><hi rend="sc">MARTE</hi> risponde a <hi rend="sc">GIOVE</hi> per <hi rend="sc">FEBO</hi> cossì:</stage>
-        <sp>
+        <sp who="#marte">
           <speaker rend="sc">MARTE</speaker>
           <lg>
             <l>Signore e padre mio, tonante Giove,</l>
@@ -701,7 +744,7 @@
           </lg>
         </sp>
         <stage><hi rend="sc">IUNONE</hi> contro a <hi rend="sc">MARTE</hi> risponde cossì:</stage>
-        <sp>
+        <sp who="#iunone">
           <speaker rend="sc">IUNONE</speaker>
           <lg>
             <l>Marte, non ti impacciar, che non bisogna</l>
@@ -715,7 +758,7 @@
           </lg>
         </sp>
         <stage>IOVE risponde contro a <hi rend="sc">IUNONE</hi> e <hi rend="sc">MARTE</hi> in questa forma:</stage>
-        <sp>
+        <sp who="#giove">
           <speaker rend="sc">GIOVE</speaker>
           <lg>
             <l>Fa' silenzio Junon! Taci tu Marte,</l>
@@ -729,7 +772,7 @@
           </lg>
         </sp>
         <stage><hi rend="sc">GIOVE</hi> comincia a fulminare e dice cossi:</stage>
-        <sp>
+        <sp who="#giove">
           <speaker rend="sc">GIOVE</speaker>
           <lg>
             <l>Non mi fati venir, figliuoli, a peggio,</l>
@@ -743,7 +786,7 @@
           </lg>
         </sp>
         <stage><hi rend="sc">GIOVE</hi> comanda a <hi rend="sc">MERCURIO</hi> che vada per <hi rend="sc">VENUS</hi> e <hi rend="sc">NEPTUNNO</hi> e <hi rend="sc">CUPIDO</hi> e dice cossì:</stage>
-        <sp>
+        <sp who="#giove">
           <speaker rend="sc">GIOVE</speaker>
           <lg>
             <l>Mercurio leva su, va' presto, e trova</l>
@@ -757,7 +800,7 @@
           </lg>
         </sp>
         <stage><hi rend="sc">MERCURIO</hi> va e dice a <hi rend="sc">VENUS</hi>, a <hi rend="sc">NEPTUNNO</hi> e a <hi rend="sc">CUPIDO</hi> e dice cossì:</stage>
-        <sp>
+        <sp who="#mercurio">
           <speaker rend="sc">MERCURIO</speaker>
           <lg>
             <l>Padre Neptuno e madre Citarea,</l>
@@ -771,7 +814,7 @@
           </lg>
         </sp>
         <stage><hi rend="sc">NEPTUNNO</hi> risponde così a <hi rend="sc">MERCURIO</hi>:</stage>
-        <sp>
+        <sp who="#neptuno">
           <speaker rend="sc">NEPTUNO</speaker>
           <lg>
             <l>Egli è ben giusto d'inclinarsi a Giove</l>
@@ -785,7 +828,7 @@
           </lg>
         </sp>
         <stage>Giunti inanti a <hi rend="sc">GIOVE</hi> lui li accetta graziosamente e cossì dice:</stage>
-        <sp>
+        <sp who="#giove">
           <speaker rend="sc">GIOVE</speaker>
           <lg>
             <l>Voi siate i ben venuti, o car figliuoli;</l>
@@ -809,7 +852,7 @@
           </lg>
         </sp>
         <stage>NEPTUNO risponde a <hi rend="sc">GIOVE</hi> e dice che vole <hi rend="sc">FEBO</hi> per figliolo</stage>
-        <sp>
+        <sp who="#neptuno">
           <speaker rend="sc">NEPTUNO</speaker>
           <lg>
             <l>Quanto ti piace, Giove, anche a me piace,</l>
@@ -823,7 +866,7 @@
           </lg>
         </sp>
         <stage><hi rend="sc">FEBO</hi> risponde a <hi rend="sc">NEPTUNNO</hi>.</stage>
-        <sp>
+        <sp who="#febo">
           <speaker rend="sc">FEBO</speaker>
           <lg>
             <l>Neptuno, el tuo voler col cor accetto,</l>
@@ -837,7 +880,7 @@
           </lg>
         </sp>
         <stage>E qui se abracciano insieme <hi rend="sc">FEBO</hi>, <hi rend="sc">NEPTUNNO</hi>, <hi rend="sc">VENERE</hi> e <hi rend="sc">CUPIDO</hi>. E <hi rend="sc">CUPIDO</hi> dice in questa forma:</stage>
-        <sp>
+        <sp who="#cupido">
           <speaker rend="sc">CUPIDO</speaker>
           <lg>
             <l>O Febo, il tuo parlar d'umiltà pieno</l>
@@ -851,7 +894,7 @@
           </lg>
         </sp>
         <stage><hi rend="sc">GIUNONE</hi> parla cossì a tutti:</stage>
-        <sp>
+        <sp who="#iunone">
           <speaker rend="sc">IUNONE</speaker>
           <lg>
             <l>Di tanta guerra, di tanti odi e sdegni</l>

--- a/tei/ariosto-cassaria.xml
+++ b/tei/ariosto-cassaria.xml
@@ -81,6 +81,70 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="erof">
+            <persName>Erofilo</persName>
+          </person>
+          <person xml:id="nebb">
+            <persName>Nebbia</persName>
+          </person>
+          <person xml:id="giand">
+            <persName>Gianda</persName>
+          </person>
+          <person xml:id="eulal">
+            <persName>Eulalia</persName>
+          </person>
+          <person xml:id="coris">
+            <persName>Corisca</persName>
+          </person>
+          <person xml:id="carid">
+            <persName>Caridoro</persName>
+          </person>
+          <person xml:id="lucr">
+            <persName>Lucrano, </persName>
+          </person>
+          <person xml:id="furba">
+            <persName>Furba</persName>
+          </person>
+          <person xml:id="volp">
+            <persName>Volpino</persName>
+          </person>
+          <person xml:id="fulc">
+            <persName>Fulcio</persName>
+          </person>
+          <person xml:id="trap">
+            <persName>Trappola</persName>
+          </person>
+          <person xml:id="brusc">
+            <persName>Brusco</persName>
+          </person>
+          <person xml:id="corb">
+            <persName>Corbacchio</persName>
+          </person>
+          <person xml:id="negro">
+            <persName>Negro</persName>
+          </person>
+          <person xml:id="mor">
+            <persName>Morione</persName>
+          </person>
+          <person xml:id="crisob">
+            <persName>Crisobolo</persName>
+          </person>
+          <person xml:id="gallo">
+            <persName>Gallo</persName>
+          </person>
+          <person xml:id="crit">
+            <persName>Critone</persName>
+          </person>
+          <person xml:id="arist">
+            <persName>Aristippo</persName>
+          </person>
+          <person xml:id="marso">
+            <persName>Marso</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione - OCR</change>
@@ -191,15 +255,15 @@
             <hi rend="bold">SCENA PRIMA</hi>
           </head>
           <stage>EROFILO <hi rend="italic">giovane</hi>, NEBBIA <hi rend="italic">servo</hi>.</stage>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Così ve n'andrete, come io vho detto, a trovare Filostrato, e farete tutto quello che vi commanderà, e per modo che non mi venga di voi richiamo altrimenti. Ma dove è rimasto il mio pedagogo, il mio maestro, il mio custode saggio? Che vol che v'indugiate a sua posta sino a sera? Ancor non viene? Per Dio, che s'io ritorno indietro!... Andate tutti e strascinatemelo fòra per li capelli. Non vaglion parole con questo asino, né vol, se non per forza di bastone, obedir mai. Vedi che io t'ho fatto uscire.</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p>Sia in malora: non si poteva senza me finir la festa. Io so bene che 'mporta l'andata, ma non posso più.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Andatevene, né sia alcun di voi sì ardito, che prima che esso vi dia licenzia, mi venga inanzi. M'avete inteso?</p>
           </sp>
@@ -209,119 +273,119 @@
             <hi rend="bold">SCENA SECONDA</hi>
           </head>
           <stage>GIANDA, NEBBIA <hi rend="italic">servi</hi>.</stage>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>È pur grande, o Nebbia, cotesta pazzia, che tu solo di tutti noi conservi vogli contrastare sempre con Erofilo. E pur ti doveresti accorgere come fin qui t'abbia giovato! Ubidisci, col malanno, o mal o ben che ti commandi: è figliuol del patrone un tratto; et ha, secondo la età, più lungamente a commandarci che il vecchio. Perché vòi tu restare in casa, quando lui vol che tu n'eschi?</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p>Se tu in mio loco fussi, così faresti, e forse peggio.</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Potrebbe essere; ma non lo credo già, che non so vedere che ti giovi troppo.</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p>Io non debbo fare altrimente.</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>E perché?</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p>Se me ascolti, io tel dirò.</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>T'ascolto, di'.</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p>Connosci tu questo ruffiano, che da un mese in qua è venuto in questa vicinanza?</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Connoscolo.</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p>Credo che tu gli abbia veduto un paio di bellissime giovane in casa.</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>L'ho vedute.</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p>De l'una d'esse Erofilo nostro è sì invaghito, che per avere da comperarla venderia se stesso; e 'l ruffiano, che averne tanto desiderio lo connosce, e che sa che del più ricco uomo di Metellino è figliuolo, li dimanda cento di quel che forse a un altro lasseria per dieci.</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Quanto ne domanda?</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p>Non so: so ben che ne domanda gran prezzo; et è tanto che, frustando Erofilo tutti li amici che ha, non ne potrebbe trovare la metade.</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Che potrà fare dunque?</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p>Che potrà fare? Danno grandissimo a suo padre e similmente a se medesimo. Credo che abbia adocchiato di saccheggiare il grano, che di dui anni e tre s'ha riserbato insino a questo giorno il vecchio; o sete o lane o altre cose, di che la casa è piena, come tu sai. Suo consiglieri e guida è quel ladro di Volpino. Han longamente questa occasione attesa, che 'l vecchio sia partito, come ha fatto oggi, per andare a Negroponte. E perché non si veggin le lor trame, non mi vogliono in casa: mi mandano ora a trovare Filostrato, acciò che mi tenga in opera, né ritornarci lassi fin che non abbino essi el lor disegno fornito.</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Che diavol n'hai tu a pigliarti sì gran cura, se ben votassi la casa? Egli del rimanente serà erede, e non tu, bestia.</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p>Una bestia sei tu, Gianda, che non hai più discorso che d'un bue. Se Crisobolo ritorna, che fia di me? Non sai tu che partendo questa matina, mi consegnò tutte le chiavi di casa, e commandommi, quanto avevo la vita cara, non le dessi a persona, e men di tutti li altri a suo figliuolo; né, per faccenda che potesse accadere, mettessi mai fuor di quella porta piedi? Or vedi come gli ho bene obedito! Non credo che fussi ancor fòr de la porta, che volse le chiavi Erofilo, dicendomi voler cercare d'un suo corno da caccia che aveva smarrito; e così mal mio grado l'ebbe, e forse tu vi ti trovasti.</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Non mi vi trovai già, ma ben sentii sin colà, dove ero, el suono di gran bastonate, che da dieci in su toccasti, prima che dargliene volessi.</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p>S'io non gliele dava, credo che m'arebbe morto. Che volevi tu che io facessi?</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Che facessi? Che alla prima richiesta tu gliel'avessi date, e così che al primo cenno fussi con noi altri uscito di casa. Non ti puoi tu sempre scusare col patrone, e narrare per il vero come è andato il fatto? Non connoscerà egli che la etade e condizion tua non è per poter contrastare a un giovane appetitoso de la sorte di Erofilo?</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p>Non saprà forse egli tutta la colpa riversarmi adosso? E forse li mancheranno testimoni a suo proposito, sì perché egli è patrone, sì perché tutti in casa mi volete male, per mio demerito non già, ma per tenere la ragione del vecchio, e non comportare che sia rubato?</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Pur per tua mala ventura, che non ti sai fare uno amico.</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p>Ma qual altro connosci tu in qual tu voglia casa, che abbi l'offizio che i' ho, che non sia odiato similmente?</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Perché siete tristi e di pessima condizione tutti; che li patroni in fare elezione di chi abbia a provedere alla famiglia, cercano sempre el peggiore omo che abbino in casa, acciò che de ogni disagio che si patisca, più agevolmente possino sopra voi scaricarsi de la colpa. Ma lassiamo andare. Dimmi un poco: chi è quel giovane che pur dianzi è intrato in casa nostra, che Erofilo onora come sia maggior suo?</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p>El figliuol del Bassà di questa terra.</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Come ha nome?</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p>Caridoro. Egli ama in casa questo ruffiano l'altra bella giovane; né credo che abbia meglio el modo di Erofilo a comperarla, se non provede di rubar suo padre similmente. Ma guarda, guarda: quella che è su la porta del ruffiano, è la giovine che Erofilo ama; l'altra, che è più fòra ne la strada, è l'amica di Caridoro. Che te ne pare?</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Se così ne paressi alli amanti loro, farebbe el ruffiano ricchissimo guadagno. Ma andiamo; che se sboccasse Erofilo, mal per noi.</p>
           </sp>
@@ -331,35 +395,35 @@
             <hi rend="bold">SCENA TERZA</hi>
           </head>
           <stage>EULALIA, CORSICA fanciulle.</stage>
-          <sp>
+          <sp who="#eulal">
             <speaker>EULAL.</speaker>
             <p>Corisca, non te slungare da questa porta, che se Lucrano ne cogliesse, s'adirerebbe con noi.</p>
           </sp>
-          <sp>
+          <sp who="#coris">
             <speaker>CORIS.</speaker>
             <p>Non temere, Eulalia, che miglior vista avemo che lui, e seremo prime a vederlo. Deh prendiamo, ora che non è in casa, questo poco di spasso.</p>
           </sp>
-          <sp>
+          <sp who="#eulal">
             <speaker>EULAL.</speaker>
             <p>Che spasso, misere noi, che ricompense la millesima parte de la disgrazia nostra? Noi siamo schiave, la qual condizione pur tolerare si potrebbe, quando fussimo de alcuno che avesse umanitade e ragione in sé. Ma fra tutti li ruffiani del mondo, non si potrebbe scegliere el più avaro, el più crudele, el più furioso, el più bestiale di questo, a cui la pessima sorte ce ha dato in subiezione.</p>
           </sp>
-          <sp>
+          <sp who="#coris">
             <speaker>CORIS.</speaker>
             <p>Speriamo, Eulalia. Avemo, tu Erofilo et io Caridoro, che tante volte ci hanno promesso e con mille giuramenti affermato di farci presto libere.</p>
           </sp>
-          <sp>
+          <sp who="#eulal">
             <speaker>EULAL.</speaker>
             <p>Quante più volte ci hanno promesso e non atteso mai, è tanto più evidente segno che non hanno voglia di farlo. Se mille volte ci avessino negato e una sola promesso poi, io mi starei con molta speranza; ma così ne ho pochissima. Se l'hanno a fare, che tardano più? Vogliono la baia, e ci tengono in ciancie, e ci fanno gran danno, che forse altri sarebbon comparsi per liberarci, e manco parole averiano usate e più fatti, e per rispetto di costoro si sono restati. Hanno poi fatto sdegnare Lucrano, che se ha veduto menare a lungo con vane promesse; e ieri mi disse, e forse ben vi ti trovasti, che non poteva più stare in su la spesa, e che fra dieci dì, non comparendo chi ci liberasse, voleva che ognuna di noi, o bona o ria, si guadagnassi il pane; e non potendo venderne in grosso, ne venderia a minuto per quattro o sei quattrini, e per quel che si potrà avere. O misere noi!</p>
           </sp>
-          <sp>
+          <sp who="#coris">
             <speaker>CORIS.</speaker>
             <p>E faccialo: che domin serà? Pur vuo' credere e tener certo, che li nostri amanti non ci abbino a lassare giugnere a tanta miseria.</p>
           </sp>
-          <sp>
+          <sp who="#eulal">
             <speaker>EULAL.</speaker>
             <p>Meglio è che andiamo dentro, che per nostra sciagura Lucrano non ci sopragiugnesse.</p>
           </sp>
-          <sp>
+          <sp who="#coris">
             <speaker>CORIS.</speaker>
             <p>Ah! vedi i nostri cori, che ne vengono a noi. Non ci partiamo così presto: vediamo ciò che oggi ci apportano.</p>
           </sp>
@@ -369,75 +433,75 @@
             <hi rend="bold">SCENA QUARTA</hi>
           </head>
           <stage>EROFILO, CARIDORO <hi rend="italic">giovani</hi>, EULALIA, CORSICA <hi rend="italic">fanciulle</hi>.</stage>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>O che felice incontro è questo, Caridoro! Questo è il maggior ben che per noi si possa desiderare al mondo.</p>
           </sp>
-          <sp>
+          <sp who="#carid">
             <speaker>CARID.</speaker>
             <p>Queste son le serene e luminose stelle, che al lor bello apparire achetar ponno le tempeste de' nostri travagliati pensieri.</p>
           </sp>
-          <sp>
+          <sp who="#eulal">
             <speaker>EULAL.</speaker>
             <p>Con più verità potresti dir di noi, che 'l bene e la salute nostra saresti, quando ci amassi così in effetto, come cercate in parole di dimostrare. Voi sète gran promettitori alla presenzia nostra. – Dammi la mano, Eulalia; dammi la mano, Corisca: oggi o doman senza fallo serete per noi franche: se non, che siamo... – Odili pure: vòlte che ci avete le spalle, vi ridete de' casi nostri.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Hai torto, Eulalia, a dir così.</p>
           </sp>
-          <sp>
+          <sp who="#eulal">
             <speaker>EULAL.</speaker>
             <p>Se ben voi sète gentiluomini e ricchi e ne le patrie vostre, non doveresti però schernire e pigliare di noi gioco: noi semo di buon sangue, ancora che ci abbia la disgrazia nostra così condutte.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Deh! non fare, Eulalia, con queste lacrime e querele più di quel che sia la mia passione acerba. Io serò il più ingrato, il più discortese villan del mondo, se per tutto doman...</p>
           </sp>
-          <sp>
+          <sp who="#eulal">
             <speaker>EULAL.</speaker>
             <p>Deh! mal abbia el mio crederti tanto.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Lassami finire: io non te posso dire ogni cosa, ma sta sicura che per tutto domane, alla più lunga, serai libera da questo impurissimo ruffiano. La cosa è gita più a longa che non era el tuo bisogno e il creder mio; ma non ho possuto più. Non ti credere, benché io vada onoratamente vestito, e sia di Crisobolo unico figliolo, estimato el più ricco mercatante di Metellino, che de le sue facultade io possa a mio appetito disponere. E quel che io dico di me, dico di questo altro ancora, che li nostri vecchi non sono meno ricchi che avari; né più è il desiderio nostro di spendere, che la lor cura di vietarci el modo. Ma or che partito è mio padre per navigare a Negroponte, e non mi terrà li occhi alle mani sempre, vederai de l'amor che io ti porto chiarissimi effetti, e presto.</p>
           </sp>
-          <sp>
+          <sp who="#eulal">
             <speaker>EULAL.</speaker>
             <p>Dio ti metta in core di farlo. Se mi ami e la salute mia desìderi, fai lo dover tuo, che più che li occhi miei e più che 'l cor mio t'ho sempre, da poi che prima ti connobbi, auto caro.</p>
           </sp>
-          <sp>
+          <sp who="#carid">
             <speaker>CARID.</speaker>
             <p>E tu, Corisca, abbi la medesima fede e senno: poco poco ci manca per venire a bona conclusione.</p>
           </sp>
-          <sp>
+          <sp who="#eulal">
             <speaker>EULAL.</speaker>
             <p>Or non più, che non ci sopragiugnesse Lucrano.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Non passerà dui dì che mi potrai star sicura in braccio.</p>
           </sp>
-          <sp>
+          <sp who="#eulal">
             <speaker>EULAL.</speaker>
             <p>Et io viverò in questa speranza.</p>
           </sp>
-          <sp>
+          <sp who="#coris">
             <speaker>CORIS.</speaker>
             <p>Et io ancora, neh?</p>
           </sp>
-          <sp>
+          <sp who="#carid">
             <speaker>CARID.</speaker>
             <p>Non si studia al ben de l'una senza quel de l'altra. Restate di buona voglia. A Dio.</p>
           </sp>
-          <sp>
+          <sp who="#coris">
             <speaker>CORIS.</speaker>
             <p>A Dio.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>A Dio, radice del mio core.</p>
           </sp>
-          <sp>
+          <sp who="#eulal">
             <speaker>EULAL.</speaker>
             <p>A Dio, vita mia.</p>
           </sp>
@@ -447,19 +511,19 @@
             <hi rend="italic">SCENA QUINTA</hi>
           </head>
           <stage>EROFILO, CARIDORO <hi rend="italic">giovani</hi>.</stage>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Ch'io non li dimostri l'amore ch'io li porto? Ch'io patisca che stia più in servitù? Non bisogna che vadi più in longo questa trama. Se non viene oggi Volpino a qualche effetto bono, non starò più a tante soie, con che da matina a sera, d'oggi in domane, già più d'un mese m'ha girato el capo, or promettendomi di trar di mano a mio padre il denaio da comperarla, or di gittare adosso a questo Albanese ladro una rete da non potersene, se non mi lassa la giovene, sviluppar già mai. Ch'io stia più alle sue ciancie? Non starò, per Dio. Quando non possa venire secretamente al mio disegno, ci verrò alla scoperta; né chiavi né chiovi mi potrà serrare cosa ch'io sappia che sia per il mio bisogno. Sarei bene a peggior termini che Tantalo, se in mezo l'acqua mi lassassi strugger di sete. Ho in casa panni, sete, lane, drappi d'oro e d'argento, vini e grani da fare in una ora quanti danari io voglio; e serò sì pusillanime e vile, che non vorrò satisfare per un tratto al desiderio mio?</p>
           </sp>
-          <sp>
+          <sp who="#carid">
             <speaker>CARID.</speaker>
             <p>Deh fussi pur io nel tuo grado, che avessi mio padre absente, che non anderei, per Dio, cercando altro mezo che me stesso per satisfarmi! Dui giorni soli che se levassi da Metellino, mi basterieno per cento: netterei sì bene il granaro, e sì sgomberrei di ogni masserizia camere e sale, che parrebbe che uno anno vi avesseno avuto li Spagnuoli alloggiamento. Ma eccolo che viene.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Chi? Sì, sì, Lucrano; così ci fusse egli portato. Andiamo pur noi dentro ad essequire ciò che ne fu da Volpino ordinato, che non si possa in su la nostra negligenzia escusare come ritorni.</p>
           </sp>
-          <sp>
+          <sp who="#carid">
             <speaker>CARID.</speaker>
             <p>Andiamo.</p>
           </sp>
@@ -478,15 +542,15 @@
             <hi rend="bold">SCENA SETTIMA</hi>
           </head>
           <stage>LUCRANO <hi rend="italic">ruffiano</hi>, FURBA <hi rend="italic">servo</hi>.</stage>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Tu sei pur tornato quando non hai possuto indugiar più: non ti bisogna mai dar meno d'un giorno di tempo a fare uno servizio, asino da bastone. Corri al porto in tuo mal punto; corri te dico, e fa che tu sia tornato subito. Oh dove vai tu che non aspetti a 'ntendere quel ch'io voglia? Trova il patrone da Barutti, con chi parlammo questa matina, e sappi da lui el certo se questa notte ha da partirsi o fino a quanto indugiasse; e quando ti raffermasse quel che ti disse oggi, di pur volersi questa notte partire, ritorna subito, e mena dua carri teco e tre facchini o quattro, che prima che ci manchi il giorno, fo pensiero avere tutta sgomberata la casa et imbarcata ogni mia cosa, che nulla c'impedisca da potere con lui partire; che più util viaggio far possiamo che quando venimmo ad abitare qui, dove sono più li forestieri in odio, che la verità nelle corti. Che guardi, che non voli via tosto? Spuleggia de non calarte in solfa per questa marca, che al cordoan si mochi la schioffia.</p>
           </sp>
-          <sp>
+          <sp who="#furba">
             <speaker>FURBA</speaker>
             <p>Ciffo ribaco il contrapunto.</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>(Averò cantato in guisa che, se Erofilo è in casa, mi potrà aver sentito.)</p>
           </sp>
@@ -501,383 +565,383 @@
             <hi rend="bold">SCENA PRIMA</hi>
           </head>
           <stage>EROFILO, CARIDORO <hi rend="italic">giovani</hi>, VOLPINO, FULCIO <hi rend="italic">servi</hi>.</stage>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Non so che imaginarmi, che così tardi Volpino ha ritornare.</p>
           </sp>
-          <sp>
+          <sp who="#carid">
             <speaker>CARID.</speaker>
             <p>Se Fulcio non lo ritrova, almen ritornasse lui.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Credo che tutti l'infortuni abbino congiurato a' nostri danni.</p>
           </sp>
-          <sp>
+          <sp who="#carid">
             <speaker>CARID.</speaker>
             <p>Eccoli, per Dio, che vengono.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>(Se potrebbe, Fulcio, per salvare dua amanti e distruggere uno avarissimo ruffiano, ordinare astuzia che fusse più di questa memorabile?</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Volpino, per quella fede ho ne le mie spalle, mi pare questa invenzione simile ad uno fertile e mal cultivato campo, che non manco de triste, che de bone erbe, si vede pieno.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Quando non succeda, aremo uno conforto almeno, che non seremo per minima causa puniti. A che peggio si pò giungere, che alle bastonate?</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Non ti bisognarà, so ben, desiderare più sufficienti spalle che coteste: a stancare ogni bon braccio pur troppo idonie sono.)</p>
           </sp>
-          <sp>
+          <sp who="#carid">
             <speaker>CARID.</speaker>
             <p>Vengon, mi par, ridendo.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>(E se più sufficienti pur cercare mi bisognasse, piglierei le tue.)</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Che credi tu? Che sì, qualche buon vino trovato hanno, che come forse de la tanta dimora, così deve di questo opportuno loro riso esser cagione.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>(Studiamo il passo: non vedi tu che da' nostri patroni attesi siamo?)</p>
           </sp>
-          <sp>
+          <sp who="#carid">
             <speaker>CARID.</speaker>
             <p>Andiamogli incontra, che pur in questa allegrezza che dimostrano sperar mi giova.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Nulla debbono de la partita di Lucrano sapere, che non verriano sì lieti.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Dio vi conservi longamente.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Sì, ma di miglior voglia che or non siamo.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Spera fin che vivi, e lassa disperare a' morti.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Tu non sai, Volpino, che domane, o questa notte forse, Lucrano si parte?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Partasi con tempesta; ma non gli credo: sono arti che egli usa per ispaventarvi.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Taci. Se udito avessi quel che al Furba suo adesso dicea, non si credendo da noi essere udito, ti parrebbe che non fussino arti: domandane costui.</p>
           </sp>
-          <sp>
+          <sp who="#carid">
             <speaker>CARID.</speaker>
             <p>È così certo.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Ahi lasso! Come potrò poi vivere, se lui ne mena ogni mio bene? Dovunque ne vada Eulalia, ne andrà con essa el cor mio.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Se 'l cor tuo s'ha da partir questa notte, fa che io lo sappia così a tempo, che tòr possa la sua bulletta, prima che si serri l'uffizio.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>E che se gli faccia una veste o altra cosa da coprirlo.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Perché veste?</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Che li uccelli di rapina, che usano dietro al mare, non lo becchino, ritrovandolo così nudo.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Ve', Caridoro, come ci beffano li manigoldi! Ah misero chi è servo d'amore!</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>È più misero chi è servo de' servi d'amore. Non ti giudicavo, Erofilo, di sì poco animo che, sentendoti Volpino appresso, in sì piccola cosa te avessi a sbigottire.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Piccola cosa è questa? Nessun'altra maggiore mi potrebbe essere.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Guardami in viso: partese el ruffiano, come hai detto? Ancora se per viltà non mi mancate, non serà una ora di notte (benché avemo più del giorno poco), che averete tutti dui parimente le vostre donne in braccio; e questo Lucrano, uomo sì arrogante, toserò come una pecora.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>O uomo di gran pregio!</p>
           </sp>
-          <sp>
+          <sp who="#carid">
             <speaker>CARID.</speaker>
             <p>O Volpino mio da bene!</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Ma dimmi: hai tu apparecchiato, come ti dissi, le forbici da tosarlo?</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Di che forbici m'hai tu parlato?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Non t'ho detto che di man del Nebbia facessi opera di avere le chiavi de la camera di tuo padre?</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>L'ho fatto.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>E che togliessi quella cassa che ti mostrai?</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>T'ho obedito.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>E che mandassi for di casa tutti li famigli?</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Così ho fatto.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>E più di tutti li altri el Nebbia?</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Non ho lassata cosa che mi abbi detta.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Ben sta: queste le forbici sono che ti domandavo. Or attendi a quanto vo' che si facci. Ho ritrovato un mio grande amico, servo de' mammalucchi del Soldano, venuto per faccende del suo padrone a Metellino, dove non fu mai più, né credo che ci sia un altro che lo connosca. Io gran pratica al Cairo ebbi con lui, già fa l'anno che ve andai con tuo padre, dove stemmo più di duo mesi; e domane ha da partirsi all'alba.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Che avemo noi a intendere di questa amicizia?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Io dirò: ascolta. Voglio costui vestire da mercatante: torrò de' panni di tuo padre; oltre che ha bella presenza, lo acconcerò in modo che non serà chi non creda, vedendolo, che lui non sia mercatante di gran traffico.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Séguita.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Costui, così vestito, anderà a ritrovare el ruffiano, e si farà portare la cassa dietro c'hai tolta, e lasseràgliela pegno.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Pegno?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>E farassi dar la femina.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>A chi vuoi che la lassi pegno?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Al ruffiano.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Al ruffiano?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Fin tanto che 'l prezzo de la tua Eulalia li porti.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Come diavol! che la lassi al ruffiano?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Dico la cassa; e che si facci dare la femina e te la conduca.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Pur troppo intendo, ma non mi piace.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Voglio ben poi, che subito andiamo...</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Parla d'altro. Ch'io ponga roba di tanto valore in mano d'uno ruffiano fuggitivo?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Lassane a me la cura: odi.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Non è cosa da udire: è troppo periculosa.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Non è: se ascolti, si potrà facilmente...</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Che facilmente?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Se taci, tel dirò. È bisogno a chiunque vole...</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Che ciancie son queste che cominci?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Tuo danno se udir non vuoi: ben sono io pazzo.</p>
           </sp>
-          <sp>
+          <sp who="#carid">
             <speaker>CARID.</speaker>
             <p>Lassalo dire.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Dica.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Poss'io morir se più...</p>
           </sp>
-          <sp>
+          <sp who="#carid">
             <speaker>CARID.</speaker>
             <p>Non te partir, Volpino: ben te ascolterà. Odilo: lassalo dire.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>E che inferire vuo' tu, insomma?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Che? chi voglio inferire? Tutto 'l dì mi prieghi, stimoli e tormenti ch'io trovi modi di far che tu abbi questa tua femina: n'ho trovati cento, né te ne piace alcuno. L'uno ti par difficile, periculoso l'altro; questo longo, quel scoperto: chi te pote intendere? Vuoi e non vuoi, desìderi e non sai che! O Erofilo, non si può fare, credilo a me, cosa memorabile senza periculo e fatica. Te pensi per prieghi e lamentazioni si pieghi el ruffiano, e te la doni?</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Mi parrebbe pur gran sciocchezza poner cosa di tanta valuta a così manifesto periculo. Non sai tu, come io so, che quella cassa tutta d'ori filati è piena, che dua milia ducati comprerieno a pena? e più, che quella è d'Aristandro, che mio padre la tiene in deposito? Queste mi paion forbici da tosar noi, più presto che la pecora che m'hai detta.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Me estimi tu di sì poco ingegno, che io cerchi perdere una cosa di tanto prezzo, e che pensato prima non abbia come riaverla subito? Lassane, Erofilo, la cura a me: io sto a periculo più di te, quando non riuscisse el disegno, de la qual cosa non dubito. Tu ne sentirai le grida solo; io el bastone o ceppi o carcere o remo.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Che via serà del racquistarla, se non se gli portan li denari, de' quali avemo nessuna cosa meno? E se ritornasse mio padre intanto, o che nascosamente Lucrano si fuggisse, a che termine ci troveremo noi?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Se hai tanta pazienzia che m'ascolti, vederai che el mio disegno è bono, e che non v'è periculo che, subito e sanza alcun danno, non se riabbia la cosa nostra.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Io t'ascolto: or di'.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Tosto che in man di Lucrano sia rimasa la cassa, e che 'l mercante nostro t'abbia la femina condutta, noi ce n'andremo al Bassà, padre di Caridoro, al quale tu farai querela che questa cassa ti sia stata di casa tolta, e che suspetti ch'un ruffiano vicin tuo te l'abbia tolta.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Intendo; e serà cosa credibile.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>E che tu lo prieghi che te dia el braccio, sì che tu possa andare a cercarli la casa. Caridoro ti serà favorevole apresso il padre, che teco mandi el bargello a tale effetto.</p>
           </sp>
-          <sp>
+          <sp who="#carid">
             <speaker>CARID.</speaker>
             <p>Serà facile, et io, bisognando, ci verrò in persona.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Seremo sì presti, che la cassa li troveremo sùbito in casa, che non gli daremo tempo di poterla trafugare altrove. Egli dirà ch'un mercatante per il prezzo d'una sua femina gliel'ha lassata pegno. Chi vorrà credere che per cosa, che val cinquanta a pena, si lassi la valuta di più di mille assai? Trovatogli apresso il furto, serà strascinato in prigione, e impiccato forse: sia squartato ancora, che pensiero n'averemo noi?</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Ben, per Dio: il disegno è da succedere.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Tu, Caridoro, come il ruffian sia preso, potrai fornire il desiderio tuo per te medesimo; che mentre li toi servi meneranno Lucrano prigione, tu farai de la tua Corisca el piacer tuo. Sempre averà di grazia el ruffiano lassartela in dono, pur che te gli offerischi apresso tuo padre favorevole, sì che almeno non ci lassi la vita.</p>
           </sp>
-          <sp>
+          <sp who="#carid">
             <speaker>CARID.</speaker>
             <p>O Volpino, una corona meriti.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Anzi una mitra e lo stendardo inanzi.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Non pò, Fulcio, giugnere a queste tue degnitati ognuno.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>E dove è costui che in forma di mercatante vuoi vestire?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Mi maraviglio che oramai non sia qui; ma verrà sùbito.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Vuoi che lui stesso si porti la cassa in collo?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>No, ha un conservo con lui, che farà el bisogno. Ma va in casa, et apparecchia una de le veste di tuo padre, quella che ti par meglio, che non si perdi tempo.</p>
           </sp>
-          <sp>
+          <sp who="#carid">
             <speaker>CARID.</speaker>
             <p>Ho io qui a far altro?</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Ti puoi tornare a casa, che tutto il successo ti farò intendere. A Dio.</p>
           </sp>
-          <sp>
+          <sp who="#carid">
             <speaker>CARID.</speaker>
             <p>A Dio.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Se non avete altro bisogno di me, anderò con mio patrone.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>A tuo piacere.</p>
           </sp>
@@ -887,59 +951,59 @@
             <hi rend="bold">SCENA SECONDA</hi>
           </head>
           <stage>VOLPINO, TRAPPOLA, BRUSCO <hi rend="italic">servi</hi>.</stage>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>(Io dovevo pure avere in memoria che rare volte il Trappola era usato a dire il vero: io son ben stato sciocco a lassarmelo tòr da canto fin che non l'abbia qui condotto. Se lui m'averà, come dubito, ingannato, nulla potrò far di quello che disegnato avevo. Ma eccolo, per Dio: la mia è stata più ventura che avertenza.)</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>È gran cosa, Brusco, che tu non sappia fare un servizio mai, di che l'uomo te n'abbia avere obligo.</p>
           </sp>
-          <sp>
+          <sp who="#brusc">
             <speaker>BRUSC.</speaker>
             <p>È maggior cosa, Trappola, che mai le tue faccende e del patrone non ti dieno da far tanto, che non te voglia impacciare sempre in quelle de li strani, e che niente t'appertengono.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Io non reputo strano Volpino, e che non mi appertenga di cercar sempre nòve amicizie, massimamente de' giovini, quali intendo questo Erofilo essere, suo patrone.</p>
           </sp>
-          <sp>
+          <sp who="#brusc">
             <speaker>BRUSC.</speaker>
             <p>Se pur sei volenteroso de novi amici, te doveria parere assai d'acquistarli in tua fatica sola, senza travagliare e me e li altri che non hanno simile desiderio.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>E che avevamo per oggi a fare altro?</p>
           </sp>
-          <sp>
+          <sp who="#brusc">
             <speaker>BRUSC.</speaker>
             <p>Provederci di pane e vino e altre cose necessarie per uso nostro in nave; che avendo noi a partire all'alba, non ci averemo più tempo.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>(Se vengono più lieti, che ben paron de' principi.) Io mi credevo, Trappola, che mi avessi ingannato.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>M'incresce ch'abbi creduto il falso.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Tu vieni molto sul riposato.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Non è iusto che, dovendo di servo diventare uomo grave, impari un poco andar con gravità?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Chi lo doveria saper meglio di te, che la più parte de la tua vita hai fatta con ferri a' piedi?</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Non è bestia di sì duro trotto, che non pigliasse l'ambio, se 'l suo cavallaro sì benignamente li facesse portare le bolze, come a te tuo patrone i ceppi.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Andiamo, che non è più da tardare.</p>
           </sp>
@@ -954,67 +1018,67 @@
             <hi rend="bold">SCENA PRIMA</hi>
           </head>
           <stage>VOLPINO, TRAPPOLA <hi rend="italic">servi</hi>, EROFILO</stage>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Prima che tu mi lassi, impara bene, sì che venir sappi con la femina qua, dove t'ho detto. Ricordati che, passato el portico che tu trovi su per questa contrada, è la terza casa a man ritta.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Me lo ricordo.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Non serà meglio, perché non falli, che la meni qui sùbito e noi la conduciamo poi là?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Per nessun modo, che la potrebbe vedere alcuno vicino, e verrieno scoperte le insidie che al ruffiano si tendono.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Tu di' il vero.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>È una porta piccola fatta di nuovo.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Tu me l'hai detto.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Lena si chiama la patrona de la casa.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>L'ho a mente.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>All'incontro v'è uno sporto di legname.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Va, non dubitare, ch'io vi saprò quasi venire sì ritto, come alla taverna.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Noi anderemo quivi ad aspettarti e faremo apparecchiare la cena intanto.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Fa che vi sia da bere in copia, che queste veste longhe m'han già messo sete.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Non te ne mancherà. Abbi el cervel teco, che questo ruffiano, che ha il diavolo in corpo, non s'avedesse.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Ah, ah, ah! chi vol insegnarmi a dir bugie, che prima in bocca l'ebbi, che tu le poppe!</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Ora va, che prosperi succedino i disegni.</p>
           </sp>
@@ -1024,19 +1088,19 @@
             <hi rend="bold">SCENA SECONDA</hi>
           </head>
           <stage>BRUSCO, TRAPPOLA <hi rend="italic">servi</hi>.</stage>
-          <sp>
+          <sp who="#brusc">
             <speaker>BRUSC.</speaker>
             <p>Spàcciati presto. Che avemo da fare altro anco questa sera?</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Avemo da cenare e stare in gioia.</p>
           </sp>
-          <sp>
+          <sp who="#brusc">
             <speaker>BRUSC.</speaker>
             <p>Mi fiacchi el collo se, come ho posata giù questa cassa, t'aspetto un atimo.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Va poi a piacer tuo; ma taci, ch'io sento aprir quello uscio, che debbe essere questo el ruffiano, se io non fallo.</p>
           </sp>
@@ -1046,159 +1110,159 @@
             <hi rend="bold">SCENA TERZA</hi>
           </head>
           <stage>LUCRANO <hi rend="italic">ruffiano</hi>, TRAPPOLA</stage>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Meglio m'è uscire di casa, che queste cicale m'assordano, mi rompono el capo, m'occidono con ciancie. Voi farete a mio modo sin che vi serò patrone, al vostro marzo dispetto.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>(Li altri hanno i segni di loro arti sul petto, e l'ha costui sul viso!)</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Quanta superbia, quanta insolenzia han tutte queste gaglioffe puttane! Sempre cercano, sempre studiano di porsi al contrario de' desiderii tuoi: mai non hanno el cor se non di rubarti, se non di usarti fraude, se non di mandarti in precipizio.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>(Mai non udii alcuno altro lodar meglio una merce che voglia vendere!)</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Io credo bene, se uno omo avessi tutti li peccati solo, che sono sparsi per tutto el mondo, e che tenessi come me femine a guadagno in vendita, e che tolerar possi la lor pratica senza gridare e bestemiare ogni dì mille volte cielo e terra, più meriterebbe di questa pazienzia sola, che di tutte le astinenzie, di tutte le vigilie, cilici e discipline che sieno al mondo.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>(Credo ben che del tenerle in casa a te sia un purgatorio, a lor misere in starvi sia uno oscurissimo inferno. Ma andiamo inanzi.)</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Costui che vien qua, deve essere pur ora smontato di nave, che si mena drieto el facchino carico.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>– Non può star molto discosto: questa è pur la casa grande, all'incontro de la quale mi è detto che li abita. –</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Non deve trovar albergo, per quel ch'io sento.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>– Oh veggio a tempo costui, che mi saprà forse chiarire, perché non son qui molto pratico. – Dimmi, omo da bene.</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Tu dimostri per certo di non esser molto pratico, che m'hai chiamato per un nome, che né a me né a mio padre né ad alcun del sangue mio fu mai più detto.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Perdonami, che non t'avevo ben mirato: io mi emenderò. Dimmi, tristo omo, d'origine pessima... ; ma, per Dio, tu sei quel forse proprio ch'io cerco, o fratello o cugin suo, o del suo parentado almeno.</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Potrebbe essere; e chi cerchi tu?</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Un baro, un pergiuro, uno omicidiale.</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Va piano, che sei per la via di trovarlo. Come è il proprio nome?</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>El nome..., ha nome..., or or l'avevo in bocca: non so che me n'abbi fatto.</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>O ingiottito o sputato l'hai.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Sputato l'ho forse, ingiottito no, che cibo di tanto fetore non potrei mandare ne lo stomaco senza vomitarlo poi sùbito.</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Coglilo adunque de la polvere.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Ben tel saprò con tanti contrasegni dimostrare, che non serà bisogno che del proprio nome si cerchi: è bestemmiatore e bugiardo.</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Queste son de le appartenenzie al mio essercizio.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Ladro, falsamonete, tagliaborse.</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>È forse tristo guadagno saper giocare de terza?</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>È ruffiano.</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>La principal de l'arte mia.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Reportatore, maldicente, seminatore di scandali e di zizanie.</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Se noi fussimo in corte di Roma, si potria dubitare di chi tu cercassi; ma in Metellino non puoi cercare se non di me, sì che 'l mio proprio nome ti vo' ricordare anco: mi chiamo Lucrano.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Lucrano, sì, sì, Lucrano, col malanno.</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Che Dio te dia. Son quel proprio che tu cerchi. Che vuoi da me?</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Tu sei quel proprio?</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Quel proprio. Di', che vuoi?</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Voglio che prima facci che costui si scarichi in casa tua, e poi dirò perché ti cerco.</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Va dentro, e ponla colà dove ti pare. Olà, aiutalo a scaricarsi.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Essendo in Alessandria a questi giorni, lo Amiraglio, che m'è grande amico e può come patrone commandarmi, mi pregò che, venendo in questa città, come lui sapea che ero per venire di corto, da te comperassi a suo nome una tua giovane che ha nome Eulalia, la bellezza de la quale gli è stata molto da più persone laudata, che te l'hanno veduta in casa; e comperata ch'io l'avessi, per questo suo servitore, che ha mandato meco a posta, gliel'avessi a mandare incontinente. E perché parte questa notte un crippo che fa quella volta, desideroso di servirlo bene e presto, ti son venuto a ritrovare per far teco a una parola il mercato, sì che tu me la dia e che lui la possa inviare subito. Or fammi intendere ciò che ne domandi.</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>È ver che avevo saldato il pregio con un gran ricco di questa terra, che a me doveva tornare domane con denari, e menarsi la femina; tuttavolta, quando...</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Tuttavolta, s'io ti do più, vuoi dire?</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Tu intendi: questo è il mio offizio, di attendere a chi più mi dà sempre.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Ma andiamo in casa, perché non mancherò di accordarmi teco per il dovere.</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Parli benissimo: andiamo dentro.</p>
           </sp>
@@ -1208,103 +1272,103 @@
             <hi rend="bold">SCENA QUARTA</hi>
           </head>
           <stage>CORBACCHIO, NEGRO, GIANDA, NEBBIA, MORIONE</stage>
-          <sp>
+          <sp who="#corb">
             <speaker>CORB.</speaker>
             <p>Gentile e liberal giovane è Filostrato veramente.</p>
           </sp>
-          <sp>
+          <sp who="#negro">
             <speaker>NEGRO</speaker>
             <p>Questi sono uomini da servire, che dànno da lavorar poco e da ber molto.</p>
           </sp>
-          <sp>
+          <sp who="#corb">
             <speaker>CORB.</speaker>
             <p>E che merenda ci ha apparecchiata!</p>
           </sp>
-          <sp>
+          <sp who="#mor">
             <speaker>MOR.</speaker>
             <p>Parliamo del vino, che m'ha per certo tocco il core.</p>
           </sp>
-          <sp>
+          <sp who="#corb">
             <speaker>CORB.</speaker>
             <p>Non credo che ne sia un migliore in questa terra.</p>
           </sp>
-          <sp>
+          <sp who="#mor">
             <speaker>MOR.</speaker>
             <p>Vedesti mai el più chiaro, el più bello?</p>
           </sp>
-          <sp>
+          <sp who="#corb">
             <speaker>CORB.</speaker>
             <p>Gustasti mai tu el più odorifero, el più suave?</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>E di che possanza! Vale ogni denaio.</p>
           </sp>
-          <sp>
+          <sp who="#corb">
             <speaker>CORB.</speaker>
             <p>N'avess'io questa notte uno orciuolo al piumaccio.</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>N'avess'io inanzi in mio potere la botte.</p>
           </sp>
-          <sp>
+          <sp who="#mor">
             <speaker>MOR.</speaker>
             <p>Deh venisse ogni dì volontà al patrone di prestare la nostra opera a Filostrato, come ha fatto oggi.</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Sì, se ci avessi ogni dì a far godere così bene.</p>
           </sp>
-          <sp>
+          <sp who="#corb">
             <speaker>CORB.</speaker>
             <p>Io non so come per la parte vostra vi state voi: io per la mia così mi sento allegro, che mi par ch'io non possa capere ne la pelle.</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Credo che siamo a un segno tutti.</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p>Così ci fussimo quando tornerà il vecchio! Tutti al bere e al trangugiare siamo stati compagni: a me solo toccherà, come lui ritorni, a pagare il vino, e a patire.</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Non ti porre affanno, bestia, del male che ancor non hai: non trar di culo prima che tu non sia punto. Che sai tu quel che abbia a venire?</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p>Non son già profeta né astrologo; ma tu vedrai, come in casa siamo, che serà tutto successo come oggi ti predissi.</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Io te l'ho detto oggi, e ora te lo ridico di nuovo, che ti cerchi di fare amico Erofilo, e vederai succeder bene i fatti tuoi. Se per obedire al vecchio tu perseveri di tenertelo odioso, tu l'averai sempre, o con pugni o con bastoni, sul viso e sul capo, e ti storpierà o ti occiderà un giorno, e tu n'averai el danno. Ma se, per compiacere al giovane, tu non serai così ogni volta al vecchio obediente, el vecchio, che è più moderato e più saggio, ti serà di lui più placabile sempre; e ben connoscerà quanto vaglia un par tuo per contrastare a un sì gagliardo cervello, come è quel del suo figliuolo. Io te parlo da amico.</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p>Io connosco per certo che tu mi dici el vero, e son disposto ogni modo di mutar proposito; ma attendi.</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Che?</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p>Chi è costui che esce di casa del ruffiano e mena seco una de le fanciulle d'esso? Debbe averla comperata.</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Mi par l'amica del patron nostro.</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p>È quella senza fallo.</p>
           </sp>
-          <sp>
+          <sp who="#corb">
             <speaker>CORB.</speaker>
             <p>È quella veramente.</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Estobla, fermiamoci: ritraetevi qui tutti, che guardiamo dove la mena, acciò che ad Erofilo lo sappiamo ridir poi: zit.</p>
           </sp>
@@ -1314,203 +1378,203 @@
             <hi rend="bold">SCENA QUINTA</hi>
           </head>
           <stage>TRAPPOLA, GIANDA, CORBACCHIO, MORIONE, NEBBIA, NEGRO <hi rend="italic">servi</hi>.</stage>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>– El Brusco s'è partito. Oh che asino indiscreto a lassarmi di notte qui solo con questo carriaggio a mano! –</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Costui, per quel ch'io vedo, se ne mena Eulalia.</p>
           </sp>
-          <sp>
+          <sp who="#corb">
             <speaker>CORB.</speaker>
             <p>O sventurato Erofilo!</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Oh che affanno, oh che maninconia se ne porrà, come l'intende!</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>– Non pianger, bella giovane. –</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Vogliàn ben fare?</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p>Che?</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Levarla a costui e menarla ad Erofilo.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>– T'incresce così forte lasciar Metellino? –</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Come se scosti un poco, leviamogliela.</p>
           </sp>
-          <sp>
+          <sp who="#mor">
             <speaker>MOR.</speaker>
             <p>In che modo faremo?</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Come si fa? con pugni e calci. Noi siamo cinque, e lui è solo.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>– Non pianger per questo... –</p>
           </sp>
-          <sp>
+          <sp who="#negro">
             <speaker>NEGRO</speaker>
             <p>Canchero a chi si pente.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>– Che ti fo certa, che non ti menerò molto lontana. -</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p>E se grida, non gli accorrerà tutta la vicinanza?</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Sì, per Dio, che verrà a tempo!</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>– Tu non rispondi? –</p>
           </sp>
-          <sp>
+          <sp who="#corb">
             <speaker>CORB.</speaker>
             <p>E chi è quello che senta gridar la notte, e vogliasi subito saltar su la via?</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>– Deh! non macchiare con queste tue lacrime sì polite guance. –</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Adesso è, Nebbia, il tempo di farsi con sì gran benefizio (quanto serà, se ce aiuti) Erofilo amicissimo sempre.</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p>Facciànlo; ma non si meni già in casa, che seremo connosciuti e aremo mal fatto.</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>E dove la merremo dunque?</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p>Che so io?</p>
           </sp>
-          <sp>
+          <sp who="#negro">
             <speaker>NEGRO</speaker>
             <p>Non si stia per questo: la potremo condurre a casa Chiroro de' Nobili, che è tanto amico di Erofilo, et è il miglior compagno di questa terra.</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Non si potea meglio pensare.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>– Io sto tutto sospeso di andare a questa ora così solo: io non pensavo già che questo asino mi dovesse però lassare. –</p>
           </sp>
-          <sp>
+          <sp who="#mor">
             <speaker>MOR.</speaker>
             <p>Voi lo terrete a bada con bone pugna e calci, et io e Corbacchio ce ne porteremo la giovane.</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Or inanzi, e non più parole.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>– Ohimè! che turba è questa che mi vien dreto? –</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Férmati, mercatante.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Che volete voi?</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Che roba è cotesta?</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Tu te pigli strana cura: te n'ho io a pagare el dazio?</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Tu non la déi avere denunziata alla dogana. Dove n'hai tu la bulletta?</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Che bulletta? Questa non è merce da tòrne bulletta.</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>D'ogni merce s'ha a pagare dazio.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Di quelle da guadagno si paga, non di queste che son da perdita.</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Da perdita ben dicesti, che tu l'hai persa. T'abbiàn pur colto in contrabando: lassa costei.</p>
           </sp>
-          <sp>
+          <sp who="#corb">
             <speaker>CORB.</speaker>
             <p>Eulalia, andiamo a trovare Erofilo tuo.</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Lassa, se non ch'io...</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Così se assassinano i forestieri?</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Se tu non taci, ti caccio li occhi.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Voi credete a questo modo, ribaldi?... Aiuto, aiuto!</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Spezzali el capo, càvali la lingua.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>A questo modo, traditori, m'avete tolto la mia femina?</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Andiamoci con Dio, e lassamolo gracchiare.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Che farò, misero? Se dovessi ben morire, vo' seguitarli per vedere ove la menano.</p>
           </sp>
-          <sp>
+          <sp who="#giand">
             <speaker>GIAND.</speaker>
             <p>Se tu non ritorni, ti farò più pezzi di cotesta tua testaccia, che non si fe' mai di vetro. Se tu ci pretendi aver ragione, làssati veder domani all'offizio de' doganieri.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>– Son mal condotto: m'han tolta la femina, m'hanno gettato nel fango, stracciato la veste e tutto pesto il viso. –</p>
           </sp>
@@ -1520,147 +1584,147 @@
             <hi rend="bold">SCENA SESTA</hi>
           </head>
           <stage>EROFILO, VOLPINO, TRAPPOLA</stage>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Costui per certo indugia molto a condurne costei.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Non venir più inanzi, che tu guasti ogni disegno nostro.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>(Con che fronte poss'io comparir dove sia Erofilo?)</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Parmi vederlo là.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>(Come potrò mai giustificarmi seco, che non creda...)</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Esso è, per Dio.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>(Che da mia voluntade, e non per forza, m'abbia lasciata Eulalia tòrre?)</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Ma non ha la giovane seco.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Né la cassa, che è molto peggio.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>(Ah misero! non so che mi faccia.)</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Trappola, come? non hai avuto la mia Eulalia ancora?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Dove hai tu messa la cassa?</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Avevo avuta Eulalia.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Eulalia?</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>E 'nsin qui l'avevo condotta.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Ahimè!</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>E qui son stato da più di venti persone assalito, in modo che me l'hanno tolta.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Te l'hanno tolta?</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>M'hanno tutto pesto e lassato qui in terra per morto.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>T'hanno tolto la mia Eulalia?</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Pur la sua m'aranno tolta! e non son molto di lungi.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>E per qual via se la portano?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Dove hai tu messa la cassa?</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Lassa che risponda a me, che questo importa più.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Importa pur assai più la cassa.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Quelli che m'hanno battuto, se ne vanno là.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Dove è la cassa?</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Che cess'io d'andarli drieto?</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>È in casa del ruffiano.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Dove vuoi tu gire? Che pensi tu di fare?</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>O di morire o di aver la donna mia.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Ricordati, aspetta, che la cassa è in pericolo: attendasi qui prima, e poi...</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>A che poss'io prima attendere, ch'al mio core, che all'anima mia?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Non andar, per Dio! Con chi sai tu che abbi a fare?</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Se hai paura, ti resta: io nulla stimo, perduta la mia Eulalia; la mia vita è quella.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>El se n'è ito, et io vo' seguitarlo in ogni modo, perché non lassi perdere la cassa. Aspettami qui tu in casa del patrone, che apresso alli altri danni tu non perdessi questa veste ancora. Bussa presto, ch'io veggio escire el ruffiano: presto, che non ti veggia meco. Non ti partire di qui sin che non torni.</p>
           </sp>
@@ -1670,15 +1734,15 @@
             <hi rend="bold">SCENA SETTIMA</hi>
           </head>
           <stage>LUCRANO <hi rend="italic">ruffiano</hi>, FURBA <hi rend="italic">servo</hi>.</stage>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Non fu mai uccellatore più di me fortunato, che avendo oggi tese le panie a dui magri uccelletti, che tutto el dì mi cantavano intorno, a caso una buona e grassa perdice ci è venuta ad invescarsi. Perdice chiamo un certo mercatante, perché mi par che sia più di perdita che di guadagno amico. È costui venuto a comperare una mia femina, e ha fatto meco in dua parole il mercato: cento saraffi li ho domandati, e cento saraffi ha detto darmi; e perché non s'ha ritrovato avere alla mano il denaio, m'ha lassata una sua cassa pegno, che tutta d'ori filati è piena, che più di quindici volte tanto ben credo che vaglia: me l'ha aperta, e poi chiusa e sigillata, e portatosene la chiave, e dettomi, ch'io la serbi fin che mi porti el pregio convenuto. Questa e una occasione che sòl venire di rado, e s'io serò sì pazzo che fuggir la lassi, non la incontro mai più. S'io porto questa cassa altrove, io non serò mai più alla mia vita povero; e così ho deliberato fare; e così la simulazion, che facevo oggi di volermi di questa città partire, serà stata de la verità pronostico, perché mi vo' con effetto partire all'alba. Né se potrà perciò questo mercatante da me chiamare ingannato, che prima che lo ricevessi in casa mia, non gli abbia fatto intendere che ero baro, giuntatore, ladro e pien d'ogni vizio; se pur s'è voluto poi di me fidare, se n'abbia il danno. Ma ecco il Furba a tempo. Si parte il legno questa notte, o quando?</p>
           </sp>
-          <sp>
+          <sp who="#furba">
             <speaker>FURBA</speaker>
             <p>Non gli selasti col furbido in berta?</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Trucca de bella al mazo de la lissa, e cantagli se vol calarsi de Brunoro, c'ho il fiore in pugno, e comperar vo' il mazo.</p>
           </sp>
@@ -1693,7 +1757,7 @@
             <hi rend="bold">SCENA PRIMA</hi>
           </head>
           <stage>VOLPINO <hi rend="italic">servo</hi>, solo.</stage>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Tante aversità, tante sciagure t'assagliono, misero Volpino, da tutti i canti, che se te ne sai difendere, te puoi dar vanto del migliore schermidore che oggi sia al mondo. O ria fortuna, come stai per opporti alli disegni nostri apparecchiata sempre! Chi averia possuto imaginarsi che, tolta che fussi di casa del ruffiano Eulalia, si avessi sì subito e sì scioccamente a perdere? La qual cosa non alli amori di Erofilo è contraria, come pericula che mai più non si possa avere la cassa. Io mi credevo che, tosto che fusse in poter nostro Eulalia, dovesse Erofilo ire a querelarsi al Bassà de la terra, e seguir tutto che oggi ordinammo; e son rimaso del mio credere ingannato, però che lui, solo intento a spiare de la femina tolta, va di là di qua tutta la città scorrendo; né le mie suasioni o prieghi, né il proprio periculo di perdere la cassa, che val tanto, lo ponno indurre a quel che non facendo, oltra la disfazione e ruina de suo patre e sua, si suscita una continua guerra in casa, e a me tormenti e perpetua carcere apparecchia, e forse morte ancora. Da questo infortunio, benché sia gravissimo, mi saprei forse difendere, s'io avessi tanto spazio che vi pensassi un poco: n'avessi tanto ch'io potessi respirare almeno! Ma si da un canto mi occupa il dubbio che con la cassa il ruffiano non si fugga questa notte, da l'altro uno improviso timore ch'el vecchio patrone non ci sopragiunga, e mi cogli e mi opprima in guisa che io non abbia tempo da comperarmi uno capestro con che mi impicchi per la gola, ch'io non so dove mi corra a rompere questo infortunato capo. Un servo da Calibassa or ora m'ha trovato, e dettomi che el vecchio mio non è uscito del porto, però che in quel punto che era per sciorsi, arrivò da Negroponte un legno con lettere, che l'hanno così raguagliato d'ogni faccenda per che lui andava, che non gli è stato bisogno di gire più inanzi; e si maraviglia che già non fussi a casa, e che veduto io non l'avessi. Se non ch'io non gli do pur piena fede, or ora, senza uno atimo indugiare, andarei con quella maggior fretta che portar mi potessino le gambe, ad affogarmi in mare. Ma che lume è questo che di là viene? Ohimè, che non sia el vecchio? Ahi lasso! è il patron certo. Tu sei morto, Volpino! Che farai, misero? Dove ti puoi tu nascondere? Donde precipitarti sùbito, per levarti da tanti supplizii che ti si apparecchiano?</p>
           </sp>
@@ -1703,431 +1767,431 @@
             <hi rend="bold">SCENA SECONDA</hi>
           </head>
           <stage>CRISOBOLO <hi rend="italic">vecchio patrone</hi>, VOLPINO, GALLO <hi rend="italic">servi</hi>.</stage>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Tanto mi sono, senza avedermi, indugiato in casa del Plutero, che è fatto notte; però non ho perduto el tempo, ch'i' ho risaldato alcuni miei conti con esso lui, e ho fatto una opera che lungamente ho desiderato di finire.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>(Ah vile e pusillanimo Volpino! Dove è ita l'audacia, dove è l'usato tuo ingegno? Tu siedi al governo di questa barca, e serai el primo che sbigottir ti lassi da sì piccola tempesta? Caccia ogni timor da parte, e móstrati qual ne' periculosi casi sei solito d'essere: ritruova l'antique astuzie, e qui le poni in opera, che ci hanno più bisogno che in altra tua impresa avessino mai.)</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>È per certo più tardi assai ch'io non pensai.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>(Anzi molto più per tempo che non era il mio bisogno. Ma venga pur, venga a sua posta, che apparecchiata ho già la tasca da farli il più netto e il più bel giuoco di bagattelle ch'altro maestro giocasse mai.)</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>O come è stata buona sorte la mia, che non abbia bisognato partir di Metellino al presente!</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>(Trista altrettanta è stata la nostra.)</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Che lassare i miei traffichi e la roba mia a discrezione d'un prodigo giovane, qual è el mio Erofilo, e di schiavi senza fede, non ero sicuro molto.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>(Ben t'apponesti.)</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Ma serò tornato così presto, che non arà auto pur tempo di pensar, non che di farmi danno.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>(Te n'avedrai: se fussi corso più che pardo, non potevi giugnere a tempo. Ma che cesso io di cominciare il giuoco?) Che faremo, sciagurati noi? Distrutti e ruinati semo.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Non è Volpino che grida costà?</p>
           </sp>
-          <sp>
+          <sp who="#gallo">
             <speaker>GALLO</speaker>
             <p>Così parmi.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>O città scelerata e piena di ribaldi!</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Debbe alcun male essere accaduto, ch'io non so.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>O Crisobolo, di che animo serai tu, come lo sappi?</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>O Volpino.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Ma merita questo e peggio chi più si fida d'un schiavo imbriaco, che del suo figliuol proprio.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Io tremo e sudo di paura che qualche grave infortunio non mi sia incontrato.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Lassa cura de la tua camera, di tanta roba piena, a una bestia senza ragione, che sempre la lassa aperta, e mai non si ferma in casa.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Cesso io di chiamarlo? O Volpino.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Se questa notte non si ritrova, è totalmente perduta.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Volpino, non odi tu? Volpino, a chi dico io?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Chi mi chiama? Oh è il patrone, è il patron, per Dio!</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Vieni in qua.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>O patron mio, che Dio t'abbia...</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Che ci è di male?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Menato or qui?</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Che hai tu?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Ero disperato, né sapevo a chi ridurmi.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Che è incontrato?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Ma poi ch'io ti veggio, o signor mio...</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Di', che ci è?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Comincio a respirare.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Di' su presto.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Ero morto, ahimè! ma ora...</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Che è stato fatto?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Ritorno vivo.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Dimmi in somma, che ci è?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>El tuo Nebbia...</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Che ha fatto?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Quel ladro, quell'imbriaco...</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Che cosa ha fatto?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Apena posso trarre il fiato, tanto son tutto oggi corso di giù e di su.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Di' a una parola: che ha fatto?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>T'ha ruinato per sua sciocchezza.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Finiscimi d'occidere; non mi tener più in agonia.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Ha lassato rubare...</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Che?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>De la tua camera propria, di quella ove tu dormi...</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Che cosa?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Di che a lui solo hai date le chiavi, e tanto gliele raccomandasti...</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Che ha lassato rubare?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Quella cassa che tu...</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Qual cassa ch'io...?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Che per la lite che è tra Aristandro e... come ha nome?</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>La cassa che io ho in deposito?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Non l'hai, dico, che è stata rubata.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Ah misero e infelice Crisobolo! Lassa or cura de la tua casa a questi gaglioffi, a questi poltroni, a questi impiccati! Potevo non meno lassarvi tanti asini.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Patron, se trovi la cucina mai in punto, di che hai lassata a me la cura, castigame, e famme portar supplizio; ma de la tua camera, che ho da far io?</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Questa è la discrezion di Erofilo? questo è l'offizio di un buon figliuolo? ha così pensiero e sollecitudine de le mie cose e sue?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>A parlar per diritto, a torto te corucci con lui. E che diavol di colpa n'ha lui? Se gli lassassi el maneggio e governo de la tua casa, come fanno li altri padri a' lor figlioli, e' faria el debito, se ne piglierebbe lui cura, e forse n'anderebbon le tue cose meglio. Ma se più te fidi d'un imbriaco, d'un fuggitivo servo, che del tuo proprio sangue, e che te n'avenga male, non hai di che dolerti più iustamente che di te medesimo.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Io non so che mi faccia: io sono il più ruinato e disfatto uomo che sia al mondo.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Patron, poi che ti ritrovi qui, ho speranza che non serà la cassa perduta, e Dio t'ha ben fatto tornare a tempo.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>E come? Hai tu nessuna traccia per la quale la possiamo trovare?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Tanto mi sono oggi travagliato, e tanto sono ito come un cane a naso, or di qua or di là, che credo saperti mostrare ove è la roba tua.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Se lo sai, perché non me l'hai già detto?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Non dico che lo sappia, ma credo di saperlo.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Dove hai tu sospetto?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Tìrati un poco più in qua; ancor più, che tel dirò. Vieni anco più in qua.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Che temi tu che n'oda?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Colui che credo che l'abbia rubata.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Abita qui presso dunque?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>In questa casa abita.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Che? credi tu questo ruffiano che abita qui, l'abbia rubata?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Lo credo, e ne son certo.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Che indizio n'hai?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Ti dico che n'ho certezza; ma, per Dio, non perder tempo in voler ch'io ti narri per che via, con qual fatica, con quanta arte io sia venuto a certificarmi di ciò, perché ogni indugio è periculoso troppo, che te so dire che s' apparecchia di fuggirsene all'alba el ladroncello.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Che ti par ch'io faccia? che sì oppresso mi veggio all'improviso, ch'io non so dove mi volga.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Mi par che andiamo subito al Bassà, e che a lui facci intendere che uno ruffiano tuo vicino t'ha rubato una tua cassa, con la quale s'apparecchia di fuggire; e che lo prieghi che non te manchi di iustizia, e che mandi teco alcuno de li suoi a cercare la tua roba, perché te credi ancor l'abbia il ruffiano in casa.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Che indizio, che prova gli saprò dar io per farli constare che sia così?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Non è buono indizio che, essendo ruffiano, non sia ladro ancora? E dicendolo, non ti serà creduto più che a dieci altri testimoni?</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Se non aven meglio di cotesto, siàn forniti. A chi dànno più credito i gran maestri in questo tempo, e più favore, che alli ruffiani? e chi più beffano, che gli uomini costumati e da bene? a chi tendono più insidie, che alli miei pari, che hanno fama d'esser ricchi e denarosi?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Se ve vengo io, darò bene al Bassà tali indizi e conietture e prove, che non potrà, se ben volesse, negare di crederti; che a te le lasso di narrare per non indugiar più. Andian più presto e studiamo el passo, che, mentre tardiamo a dir parole, non ci facesse il ruffian la beffa.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Andiamo, che... Deh férmati, che m'è venuto in animo di far meglio.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Che meglio puoi tu far di questo?</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Rosso, corri qui in casa di Critone, e pregalo da mia parte che venga a me sùbito, e meni seco o suo fratello o qual vogli altro de' suoi domestici. Corri, dico: te aspetto qui, vola.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Che ne vuoi fare?</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Vo' intrare improvviso in casa del ruffiano. Non poss'io, avendo uno o dua testimoni degni di fede apresso, tòr la roba mia dovunque io la ritrovi? Se per parlare al Bassà andassimo ora, seria l'andata vana: o che trovassimo che cenar vorrebbe, o che giocarebbe o a carte o a dadi, o che stanco da le faccende del giorno si vorria stare in ozio. Non so io l'usanza di questi che ci reggono, che quando più soli sono e stannosi a grattar la pancia, vogliono demostrare aver più occupazione: fanno stare un servo alla porta, e che li giuocatori, li ruffiani, li cinedi introduca, e dia agli onesti cittadini e virtuosi uomini repulsa?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Se gli facessi intendere de l'importanza che fusse il tuo bisogno, non ti negarebbe audienzia.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>E come se li farebbe intendere? Non sai tu come li uscieri e portinari usano a rispondere? – Non se gli pò parlare. – Digli che sono io. – Ha commesso che non se gli faccia imbasciata. – Come t'hanno così risposto, non pò' replicarli altro. Ma farò pur così, che serà meglio e molto più sicuro, pur che la cassa vi sia.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Ve è senza fallo; sì che éntravi sicuramente, e hai pensato benissimo.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Intanto che aspettiamo Critone, dimmi un poco: quando e come ti accorgesti che fusse rubata la cassa, e con che indizi se' venuto a cognizion che l'abbi avuta questo ruffiano?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Seria lunga diceria, né averemo tempo. Andiamo a trovare la cassa prima, che ben ti conterò ogni cosa poi.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>N'averemo d'avanzo; e se non mi pòi fornire el tutto, fa che ne sappi parte.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Comincerò, ma so che non te ne dirò la metade, che non ci serà tempo.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Me n'averesti già detto un pezzo: or di' su.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Poi che vuoi ch'io tel dica, tel dirò: or odi. Oggi, dapoi che avemo desinato d'un pezzo, e già tuo figliuolo era tornato a casa (che mangiò fuora), venne il Nebbia a trovare Erofilo, e gli portò la chiave de la tua camera, senza che gli fussi chiesta da alcuno.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Buon principio questo fu de obedirmi! Quello appunto che gli avevo commesso!</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Egli disse: – Io voglio andar sino alla piazza per una mia faccenda: fa serbar, fin ch'io torni, questa chiave. – Erofilo, senza altrimenti pensarvi, la piglia: el Nebbia va fuor di casa, né mai più è ritornato.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Ancor m'ha in questo assai bene obedito; e perché io non gli avevo espressamente commesso che non si partisse di casa mai!</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Tu vedi! Stiamo così un pezzo ragionando d'una cosa e d'un'altra: venimo a dire, come parlando accade, di andare uno giorno a caccia. In questo venne Erofilo a ricordar d'un corno che soleva avere e che già molti giorni non l'aveva veduto; e gli venne voluntà di cercare se fusse ne la tua camera. Tolle la chiave, apre l'uscio, io gli vo drieto: ne l'entrare fu primo tuo figliuolo, che s'avide non v'era la cassa; a me si volta, e dice: – Volpino, ha mio patre, che tu sappi, restituita la cassa di Aristandro, che tanti giorni ha tenuto in deposito? – Io guardo, e tutto resto attonito, e gli respondo che no; e certo mi ricordo che, quando ti partisti, la vidi a capo al letto, ov'era solita di stare. In un tratto m'aveggio de la sciocca astuzia del tuo Nebbia, che tosto che s'ha veduto mancar la cassa, ha portato la chiave de la camera ad Erofilo per farlo participe de la colpa, che è tutta sua. Pigli tu, come io voglio inferire?</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Intendo. Ah ribaldo! s'io vivo...</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Fa il sciocco; ma è malizioso più che 'l diavolo. Tu non lo connosci bene.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Séguita.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Or, come io te dico, patron mio caro, Erofilo et io, veduto questo, essaminamo e tra noi discorremo chi la possa aver tolta. Io dimando el suo parere ad Erofilo, Erofilo a me domanda il mio; che dovemo fare, che via tenere per venire a qualche notizia: consigliamo e masticamo un pezzo: non sapemo ove ricorrere, dove battere il capo. O patron mio dolce, dapoi ch'io nacqui non fui mai nel maggiore affanno, nel maggior travaglio mai. Io m'ho trovato oggi a tal ora così di mala voglia, così desperato, che desideravo e che averei avuto di somma grazia d'esser morto, anzi di non esser mai nato. Ma ecco Critone col fratello Aristippo: io ti narrerò questa cosa più ad agio.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Non m'hai con tutte queste ciancie produtto alcuno che 'l ruffiano, più che altri, abbi avuta la mia cassa; né so con che speranza di ritrovarla io debbi intrarli in casa.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Entrali sicuramente, e se non ve la trovi, impiccami, ch'io tel consento. S'io non avessi più che certezza, non ti direi che tu v'entrassi.</p>
           </sp>
@@ -2137,39 +2201,39 @@
             <hi rend="bold">SCENA TERZA</hi>
           </head>
           <stage>CRITONE, CRISOBOLO <hi rend="italic">mercanti</hi>, VOLPINO <hi rend="italic">servo</hi>.</stage>
-          <sp>
+          <sp who="#crit">
             <speaker>CRIT.</speaker>
             <p>Per tutto son ladri, ma più in questa terra che in altro loco del mondo. Come possemo noi mercatanti avere animo di andare a torno, se ne le nostre proprie case non siamo sicuri? O Crisobolo, Dio ti guardi: siamo qui per farti, ove possiamo, benefizio.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Ben m'incresce di sconciarvi a quest'ora: a voi toccherà un'altra volta el commandarmi.</p>
           </sp>
-          <sp>
+          <sp who="#crit">
             <speaker>CRIT.</speaker>
             <p>Non accadeno fra noi queste parole, che vorremmo far per te ogni gran cosa.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Voi serete contenti di venir meco in questa casa, et essermi testimoni di quel che fare vi voglio.</p>
           </sp>
-          <sp>
+          <sp who="#crit">
             <speaker>CRIT.</speaker>
             <p>In questo e in maggior servizio puoi commandarmi.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Non più parole: andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#crit">
             <speaker>CRIT.</speaker>
             <p>Andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Stendetevi lungo el muro, e nascondasi el lume, e lassate bussare a me; e come aprano, intrate tutti. Io tenerò la porta, a ciò, mentre voi cercaste in un cantone, non levasse da un altro il ruffiano la cassa e la mandasse altrove.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Bussa, e fa come ti pare.</p>
           </sp>
@@ -2179,39 +2243,39 @@
             <hi rend="bold">SCENA QUARTA</hi>
           </head>
           <stage>FULCIO, VOLPINO <hi rend="italic">servi</hi>.</stage>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Sono alcuni avantatori che frappano e bravano di far cose che, quando poi si viene alla prova, non ardiscono tentarle; fra li quali è questo briaco Volpino, che disse oggi di far per mezo d'un suo amico al ruffiano un giunto d'una sua femina il più bello e meglio disegnato del mondo, e che poi verrebbe avisarne d'ogni successo, a ciò che noi fornissimo quel resto, a chi non poteva lui inanzi. Siamo Caridoro et io stati tutta sera alla posta, né ancor n'aviamo udita novella. Io vo per saper se ha mutato proposito, o pur se qualche impedimento gli è venuto in mezo.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>(Io sento venire uno in qua: par che lui vadi per battere alla porta nostra.) Olà, che cerchi? Chi domandi tu?</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>O Volpino, io non cerco, io non domando altri che tu.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Io non te avevo, Fulcio, connosciuto. Che vuoi?</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Che si fa? Avete mutato consiglio? O pur non vi ricordate di quel che dicemo oggi?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>O Fulcio, il diavol ci ha messo il capo con tutte le corna, e non pur, come si dice, la coda, per guastare i nostri ordini in tutto.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Che ci è di male?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Tel dirò, ma... taci, taci.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Che turba è questa che con tanto romore e strepito esce di casa el ruffiano?</p>
           </sp>
@@ -2221,79 +2285,79 @@
             <hi rend="bold">SCENA QUINTA</hi>
           </head>
           <stage>LUCRANO <hi rend="italic">ruffiano</hi>, CRISOBOLO, VOLPINO, CRITONE</stage>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Si fa così a' forestieri, omo da bene, eh?</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Si fa così a' cittadini, ladro, eh?</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Non passerà come tu pensi: me ne dorrò sino al cielo.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Io non anderò già tanto alto a dolermi, ma bene in loco ove la tua scelerità serà punita.</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Non ti persuadere, perch'io sia ruffiano, ch'io non debba essere udito...</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Ancora ardisci a parlare?</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>E che non abbia lingua a dire le ragion mie.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Cotesta ti farà il capestro uscire un palmo de la bocca. Che audacia arebbe se in casa nostra avesse ritrovato il suo?</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Porrommi, e farò porre quanti n'ho in casa al tormento, e farò constare a qual voglia giudice, che la cassa m'ha data pegno un mercatante per lo prezzo d'una mia femina, come v'ho già detto.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Ancor apri la bocca, ladron manifesto?</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>E chi più di te manifesto, che mi vieni a rubare, e ne meni li testimoni teco?</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Se non parli cortesemente, ti farò, giotton...</p>
           </sp>
-          <sp>
+          <sp who="#crit">
             <speaker>CRIT.</speaker>
             <p>Non gridar con questa cicala, che non è convenevole a un par tuo: andiamo. Se tu pretendi che ti si faccia torto, làssati veder in palazzo domane. Andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Mi vedrete, siatene sicuri: non anderà, non, per Dio, come vi credete forse. (Ma or son troppi, et io son solo: ben ci rivedremo in loco dove non averanno sì gran vantaggio.)</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Vedesti voi mai el più audace e presuntuoso ladro di costui?</p>
           </sp>
-          <sp>
+          <sp who="#crit">
             <speaker>CRIT.</speaker>
             <p>Non veramente. Gran ventura hai avuta, Crisobolo, che mi piace.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>La maggior del mondo.</p>
           </sp>
-          <sp>
+          <sp who="#crit">
             <speaker>CRIT.</speaker>
             <p>Vòi altro da noi?</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Che di me, dove io possa, vi degnate servirvi. To', Volpino, quel lume, e ritórnagli a casa.</p>
           </sp>
@@ -2303,79 +2367,79 @@
             <hi rend="bold">SCENA SESTA</hi>
           </head>
           <stage>FULCIO, VOLPINO, CRITONE, ARISTIPPO</stage>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Vòi ch'io t'aspetti, Volpino?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Voglio, che ho da ragionare un pezzo teco.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Ritorna presto.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Serò qui sùbito; ma meglio è che venga tu ancora.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Vai lontano?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Vo allato questo canto, alla prima casa.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Verrò anch'io.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Vien, che torneremo insieme ragionando. Oh diavolo!</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Che ti rompa 'l collo. Che hai tu?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Io son ruinato, io son disfatto.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Che hai de novo?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>To' questo lume, et accompagna questi gentiluomini a casa. Maladetta la mia sì poca memoria!</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Tenetelo voi, e fatevi lume voi stessi, che voglio ciò che di novo a questo pazzo accade intendere.</p>
           </sp>
-          <sp>
+          <sp who="#crit">
             <speaker>CRIT.</speaker>
             <p>Bon servitori tutti dua sète, e cortesi giovini per certo!</p>
           </sp>
-          <sp>
+          <sp who="#arist">
             <speaker>ARIST.</speaker>
             <p>Converrà che facciamo come i cavalieri da Napoli, che se dice s'accompagnan l'un l'altro.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Che hai tu, bestia? Che t'è accaduto di fresco?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Ahi lasso! ch'io ho lassato il Trappola in casa con li panni del mio vecchio indosso, e non mi son ricordato, prima che arrivi el patron, di correre a dispogliarlo, e rendergli il suo gabbano, che serrai ne la mia stanza.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Ah trascurataccio! va subito e fallo nascondere, che non lo veda Crisobolo almeno.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Io farò tardi; e tardi ben son stato, che sento il rumore e 'l strepito grande.</p>
           </sp>
@@ -2385,239 +2449,239 @@
             <hi rend="bold">SCENA SETTIMA</hi>
           </head>
           <stage>CRISOBOLO, VOLPINO, TRAPPOLA</stage>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Dove ti credi fuggire? Sta saldo, viso di ladro. Onde hai tu rubata questa mia veste?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>(Che farai più, sciagurato Volpino?)</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Tu déi esser quell'uom da bene che m'avea rubata la cassa ancora.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>(Oh, me gli potessi accostare all'orecchio un poco!)</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Tu non rispondi, truffatore? A chi dico io? Aiutatemi, che non mi fugga. Tu non vuoi parlare, eh? Costui è mutolo, o che lo finge.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>(Non potea all'improviso infortunio trovar miglior riparo: ora è da soccorrergli.) Patron, che hai a far col mutolo?</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Ho trovato costui ne la cucina vestito alla guisa che tu vedi.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Chi diavolo ha condotto questo mutolo in cucina?</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>E non gli posso far rispondere una parola.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>E come vuoi, se è mutolo, che risponda?</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>È mutolo costui?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Che? non lo connosci?</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Non lo vidi mai più.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Tu non lo connosci? il mutolo che sta ne la taverna de la Simia?</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Che mutolo? che simia vuoi tu ch'io connosca? A tuo dire, parrebbe ch'io andassi, manigoldo, alla taverna.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Mi par che abbia indosso la tua veste; sì, ben la riconnosco.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>E di che mi coruccio io?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>È lo tuo capello in capo?</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Mi par che abbia del mio sino alle scarpe.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>È così, per Dio: questa è la più strana pratica del mondo. Non gli hai tu domandato chi l'ha del tuo sì messo in punto?</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Che vuoi tu ch'io gli domandi, se non mi sa rispondere, e s'egli è mutolo?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Fa che tu l'accenni. Ma lassa domandarlo a me, che lo soglio intendere non meno ch'io faccia te.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Domandalo.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Chi t'ha dato la veste del patrone? Cotesta, cotesta donde l'hai avuta?</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>(Questo pazzo ragiona con le mani, come fanno li altri con la lingua.) Sai tu che dica?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Chiaro accenna che uno qui di casa gli ha tolti i suoi panni, e che gli ha lassati questi fin che torni, e per ciò l'attendeva egli.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Un qui di casa? Deh fa, se sai, che te accenni qual di casa è stato.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Farollo. Eh!</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>(Io gli guaterei cento anni alle mani e non saperei un minimo construtto cavarne.) Che vol dire quando leva la mano, e che si tocca or il capo or il volto?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Mostra che è stato un grande, asciutto, che ha grosso il naso, et è canuto, e che parla in fretta.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Io credo che voglia dire il Nebbia, ch'altro non è in casa così fatto. Ma come sa che parla in fretta? Adunque ode costui?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Non ho detto che parla in fretta, ma che partì in fretta. Vol dire ch'è 'l Nebbia senza fallo: tu l'hai più presto inteso, che non ho io.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Che ha voluto fare quel pazzo a tòrre i panni di questo mutolo?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Or m'appongo perché: poi che s'ha veduto mancare la cassa, si debbe esser fuggito, e per non esser connosciuto, si serà d'abito mutato.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Perché non ha più presto lassato a costui li suoi panni, che li miei?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Che diavol so io? Non connosci tu come è pazzo?</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Menalo tu in casa, e dàgli qualche tabarro vecchio, che non macchiasse la mia veste.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Lassane la cura a me.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>(Potrebbe essere anco altrimenti. Sì, potrebbe in verità: non è da credere a questo Volpino ogni cosa, che non è però evangelista.) Non andare: aspetta, Volpino. Non ci disse il ruffiano che gli aveva data la cassa un mercatante? e non ce lo dipinse, se ben mi ricordo, vestito in questo modo proprio?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Te vuoi fondare in le ciancie di quel ribaldo?</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Né miglior terreno sei ancor tu, dove io mi fondi. Io farò altrimenti. Rosso, Gallo, Marochio, tenete costui, e legatemelo.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Perché così?</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Al Subassi vo' mandarlo, che con la corda provi se può guarirlo, sì che parli.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Non so io s'egli è mutolo? Pur, se ti pare che finga, el menerò al ruffiano; e se serà il mercatante di che dubiti, lo connoscerà di botto.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Io non vo' altro mezo in questo. Spacciatevi, e se non avete altro, spiccate la fune del pozzo. Legali le mani dietro; ma levali, col malanno, prima la mia veste.</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Escusami, Volpino, fin che altro non ho sentito che parole, t'ho voluto servire...</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>(Ahimè!)</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Ma per te non voglio esser né storpiato né morto.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>O beata fune, anzi miracolosa, che sì ben risani i mutoli! Chi te la ponesse alla gola, Volpino, credi tu che ti sanasse del giotto? Or rispondimi tu: chi t'ha dato li miei panni?</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Tuo figliuolo e costui mi vestirno oggi così.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>A che effetto?</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Per mandarmi a pigliare una femina di casa un ruffiano.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Fusti tu quel che vi recasti la mia cassa?</p>
           </sp>
-          <sp>
+          <sp who="#trap">
             <speaker>TRAP.</speaker>
             <p>Con una cassa mi vi mandorno, che avessi a lassarvi pegno, e così feci.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>A questo modo, Volpino, tu hai auto audacia di porre in mano d'un fuggitivo ruffiano a tanto pericolo la roba mia; e dare a mio figliuolo, che sì t'avea raccomandato, così buon consiglio; e farti beffe di me, et aggirarmi il capo come io fussi il maggior sciocco del mondo? Non te ne vanterai, per Dio. Lassate cotesto, e legatemi quel traditore.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>O patrone, tuo figliuolo m'ha sforzato a fare così: tu me gli lassasti per servo, non per curatore o maestro.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>S'io non morrò in questa notte, io darò per te uno essempio a quest'altri, che non ardiranno usarmi fraude mai più.</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>O signor mio!...</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Io t'insegnerò, scelerato. Vieni tu ancor dentro, che tutta questa pratica vo' sapere a pieno.</p>
           </sp>
@@ -2636,159 +2700,159 @@
             <hi rend="bold">SCENA NONA</hi>
           </head>
           <stage>LUCRANO <hi rend="italic">ruffiano</hi>, FULCIO</stage>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>(Quanto più differisco a lamentarme, fo le mie ragion deboli. Io stavo aspettando el Furba, perché venisse meco; ma poi che non appare, me n'anderò pur solo.)</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>O Dio, ch'io ritrovi Lucrano in casa...</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>(Costui mi nomina.)</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>A ciò che io gli avisi de la ruina che gli viene adosso...</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>(Che dice costui?)</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Sì che se salvi la vita almeno...</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>(Ahimè!)</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Benché, se gran ventura non l'aiuta, spacciato lo veggio.</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Non bussar, Fulcio, ch'io son qui, se tu mi cerchi.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>O infelice, o sciagurato Lucrano, che fai tu qui? Perché non fuggi?</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Ch'io fugga?</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Ché non te nascondi? ché non te levi del mondo? Poveretto, fuggi.</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Perché vòi ch'io fugga?</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Tu serai impiccato sùbito sùbito sùbito, se te ritrovano.</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Chi me farà impiccare?</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>El Bassà mio signore. Fuggi, te dico: ancor ti stai? fuggi, misero.</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>E che ho fatto io, che meriti la forca?</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Hai rubato Crisobolo el tuo vicino.</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Non è così.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>E egli t'ha ritrovato in casa con testimoni il furto. Et ancora t'indugi? Fuggi presto, fuggi: che fai?</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Se vorrà intendere il Bassà le ragion mie...</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Non perder tempo in ciancie, pover omo; fuggi col diavol, fuggi; che non è venti braccia lungi el bargello, che ha commissione di subito impiccarte, e mena il boia seco. Fuggi, diléguati presto.</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Ah Fulcio, mi ti raccomando: io t'ho amato sempre, poi ch'io ho avuta tua connoscenzia, e studiato di farti, ove ho possuto, piacere.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>E per questo son venuto ad avisarte.</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Io te ringrazio.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Che se 'l mio patron lo sapesse, mi farebbe impiccar teco; ma fuggi e non gracchiar più.</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Ahimè, la casa e la roba mia!</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Che casa? che roba? fuggi col malanno.</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>E dove debb'io fuggire?</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Che so io? Ho fatto il mio debito un tratto: se sei impiccato, tuo danno; già non voglio esserti impiccato appresso.</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Ah Fulcio! ah Fulcio!</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Non mi nomare, che sia squartato! che non te oda alcuno, che non rapporti al mio signore ch'io t'abbi avisato.</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Non mi lassar, di grazia; mi ti raccomando.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Alle forche ti raccomando. Non vorrei, per quanto vale el mondo, che al Bassà fusse detto che io t'avessi parlato.</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Ah, per Dio! odi una parola.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Non è tempo ch'io aspetti, che mi pare non so che sentire, e son certo ch'è il bargello.</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Io verrò teco.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Non venir; fuggi altrove.</p>
           </sp>
-          <sp>
+          <sp who="#lucr">
             <speaker>LUCR.</speaker>
             <p>Sì, verrò pure.</p>
           </sp>
@@ -2803,207 +2867,207 @@
             <hi rend="bold">SCENA PRIMA</hi>
           </head>
           <stage>FULCIO, EROFILO, FURBA</stage>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>E con queste, e con altre parole e gesti, che mi sono benissimo successi, posi tanta paura a quel sciocco, che per tutta la città me l'ho fatto correr dietro: d'ogni poco suono ch'udiva, più che foglia tremava, che sempre el bargello e la sbirraria li pareva avere alle spalle.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Maravìgliomi come, sapendosi di tale imputazione, come pur la verità, innocente, non ha avuto animo da presentarse.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Come animo da presentarse? S'io gli ho persuaso che 'l bargello aveva strettissima commissione, senza essamina, senza inquisizione, d'impiccarlo sùbito che lo trovasse?</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Io non so come t'abbia creduto sì facilmente.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Non te ne paia strano, che ad altri suoi pari altre volte ha fatto di simili scherzi il mio patrone; così gli è stato sempre el nome di ruffiano odioso! E questo, e quanto egli sia di còlera sùbito, sa Lucrano pur troppo, che ben l'ha connosciuto altrove ancora.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Pur, sentendosi innocente...</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Che più? Ancor di questo sia innocente, di quanti altri malefizi te credi che 'l sia consapevole, el minor de' quali merita mille forche? È il diavolo andare in prigione, e farsi porre alla tortura, connoscendosi ribaldo. E se ben d'una falsa calunnia si purgasse, anderia a periculo di scoprire altri veri delitti, che condennar lo farieno a morte agevolmente.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Come s'assicurò di condursi alla camera di Caridoro?</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Io gli diedi intendere che 'l Bassà, disposto d'impiccarlo in ogni modo, avea commesso che, quando non si potesse la notte avere, non se lassassi partir legno de la isola, prima che con diligentissima inquisizione e bando non se cercassi per ogni casa fin che ritrovato fusse; e con queste e con altre infinite mie ciancie a tal disperazion lo trassi, che non so tórre tanto alta, donde non si fusse precipitato, per potersene de qui fuggire; poi, fingendomi pur desideroso di salvarlo, lo confortai che si riducesse al Caridoro, che sapea io che gli era amico, e che se da lui non avea aiuto o consiglio, non si sperasse averlo da altri.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>E così ve lo conducesti?</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Io seppi tanto cicalare che ve lo trassi finalmente. Or vorrei qui che veduto l'avessi, pallido, lacrimoso e tremebundo, dimandare, pregare, suplicare Caridoro, che avesse di sé pietate, abracciarli le ginocchia, baciarli i piedi, proferirli, non che la giovane, ma quanto avea al mondo.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Ah, ah, ah, ah, ah!</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Vorrei che Caridoro da l'altra parte veduto avessi simulare di lui pietoso, ma timido di incorrere in la inimicizia di suo patre, e pregarlo che se gli levassi di casa, e non volesse essere cagione di volerlo mettere in disgrazia di quell'omo, che più di tutti li altri riverire et observar dovea.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Ah, ah, ah, ah!</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Vorria che me veduto avessi in mezo, raccomandare quel misero, e proporre a Caridoro che modi avea a tenere per aiutarlo.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Ah, ah, ah! saria stato impossibile che io avessi possuto ritenere le risa.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Alfin io diedi per consiglio a Lucrano, che facessi Corisca venire, che con la presenzia d'essa so che moveria el giovane meglio ad aiutarlo. Accettò il partito, e scrisse questa polizza e dièmi per segno questo annello; e così vo a tòrre la femina, alla cui giunta son certo che s'ha da concordare il tutto.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>T'aspetta, dunque, il ruffiano alla stanza di Caridoro?</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Va', ch'io ti tacevo il meglio. Noi l'avemo, perché non sia da quelli di casa e quelli che vanno e vengono veduto, fatto appiattare sotto il letto, dove si sta con la maggior paura del mondo, e non osa, per non esser sentito, respirare.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Che Caridoro abbi del suo amore così piacevole successo, radoppia l'allegrezza ch'io sento d'aver la mia Eulalia ritrovata; la qual mi è stata più ioconda a ritrovare, dopo tanti disturbi e timori avuti che per me non fussi totalmente perduta, che se, quando prima io l'attendeva, me l'avessi condotta il mercatante nostro; però che in quella aspettazione avevo una parte già finita e quasi consunta del mio gaudio.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Così accade, che una bona cosa più deletta, quando viene insperata.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>E così uno improviso male vie più che l'aspettato molesta. El che provo al presente de la pessima novella che m'hai detta, che mio patre sia tornato, e che abbi tutta la nostra pratica intesa, e sia Volpino, il nostro consiglieri, in prigione.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Tu potrai medicare facilmente tutto questo male. Con quattro o sei bone parole che tu dici a tuo patre, farai che averà di grazia a perdonarti, e farà ciò che tu vuoi, pur che gli mostri d'averlo in timore e in reverenzia; e di questa pace nascerà che libererai Volpino dal pericolo in che si trova; et a te tocca, Erofilo, di salvarlo.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Io ne farò ogni bona opera.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Un'altra cosa, che non meno importa, avemo a fare ancora.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Che avemo a fare?</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Che domatina all'alba questo ruffiano se ne fugga.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Faccisi: chi l'impedisce che non possa fuggire?</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Il non avere uno aspro da potersene (io tel so dire) levare con sua famiglia e robe, e da vivere per il camino.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Di questo con ogni altro che con meco te consiglia, che per me non ho che darli.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Tu seresti ben povero: fatti prestar denari.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Da chi?</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Da l'Ebreo, s'altri non hai che ti soccorra.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>E che pegno ho io da darli?</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Venticinque o trenta saraffi che mi dessi, saria a bastanza.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Tu parli meco indarno: io non gli ho, né so da chi averli.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Il resto fino a cinquanta troverà Caridoro.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>S'io vi sapessi modo, non mi faria pregare.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Come faremo adunque?</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Pénsavi tu.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Vi penso: non me ne potresti dare una parte?</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Non te ne potrei dare uno: tu getti via parole. Tu saprai bene investigare, se vi pensi, che si farà senza.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Non si può far senza a patto nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Dunque, trovagli tu.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Penso ove trovarli.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Pénsavi.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Vi penso tuttavia, e forse forse te gli troverò.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Io mi confido sì nel tuo ingegno, che gli sapresti far nascere di nuovo, se ben non se ne trovassi al mondo.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Orsù, lassane la cura a me, ch'io spero di trovargli questa notte. Ancora io mi espedirò di condurre prima costei a Caridoro, e applicherò poi tutto l'animo a trovar questi danari. O tu, qualunque ti sia, che là entri, férmati, ch'io ti parli un poco.</p>
           </sp>
-          <sp>
+          <sp who="#furba">
             <speaker>FURBA</speaker>
             <p> Se tu m'avessi comperato, non mi doveresti commandare con più arroganzia. S'io te son bisogno, viemmi dreto.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Costui dimostra esser famiglio di chi egli è, sì ben imita li superbi costumi di suo patrone.</p>
           </sp>
@@ -3013,91 +3077,91 @@
             <hi rend="bold">SCENA SECONDA</hi>
           </head>
           <stage>EROFILO, CRISOBOLO</stage>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>(Io anderò in casa, e vederò di mitigare mio patre, che se non fusse per aiutar Volpino, non ardirei per dieci giorni andarli inanzi. Ma chi apre la porta? Ahimè, che è esso! Io mi sento struggere il core.)</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Come tardano a ritornare quest'altri! Ancor non gli sento apparire da nessun canto; e dove possono essere li gaglioffi a questa ora? Vedi che saria s'io ci stessi da casa tre mesi o quattro absente, ch'un mezo dì ch'io ne son stato, me trovo sì bene! Ma se mi giunta el scelerato più, gli perdono. Come ero io sciocco ad ascoltarne le sue ciancie!</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>(Io sono in dubbio s'io me gli appresento o s'io mi resto.)</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>S'egli sa con sue astuzie uscir di ceppi, ove io l'ho fatto porre, gli do licenzia che mi vi metta in suo cambio.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>(Bisogna, infine, far bono animo, altrimenti Volpino starà fresco.)</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Tu sei qui, valent'omo?</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>O patre, tu non sei ito? E quando ritornasti?</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Con che audacia, ribaldo e sfacciato, tu mi vieni inanzi?</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>M'incresce, patre, fino al core averti dato causa di turbarte.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Se dicessi el vero, viveresti meglio che tu non fai. Va pur, ch'io ti castigherò da tempo, che tu crederai ch'io me l'abbia scordato.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Io serò un'altra volta meglio avertito, né mai più darò causa di dolerti di me.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Io non voglio che con parole dimostri di donar quello che tu studi con fatti levarmi sempre. Io non pensavo già, Erofilo, che di bon fanciullo, che con sì gran studio te allevai, tu dovessi riuscire uno de li più tristi e dissoluti giovani di questa città; e quando io m'aspettavo che mi fussi bastone per substentare la mia vecchiezza, mi dovessi essere bastone per battermi, per rompermi e farmi inanzi l'ora morire.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>O patre!</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Tu m'appelli patre con ciancie, ma con l'opre tu dimostri poi essermi el più capital nemico ch'io abbia al mondo.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Perdonami, patre.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Se non fussi per l'onor di tua matre, io direi che non mi fussi figliuolo. Io non veggio in te costumi che mi rassomigli, e molto arei più caro che mi rassomigliassi ne le bone opere, che in viso.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Incusa la giovinezza mia.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Non credi tu che anch'io sia stato giovane? Io in la tua etate ero sempre a lato del tuo avo, e con sudore e fatica lo aiutavo ad ampliare el patrimonio e le facultà nostre, che tu, prodigo e bestiale, con tua lascivia cerchi consumare e struggere. Sempre ne la gioventù mia era il maggior mio desiderio d'esser presso alli omini boni stimato bono, e con quelli conversavo, e questi con tutto el studio mio cercavo imitare; e tu, pel contrario, hai sol pratica di ruffiani e bari e bevitori e simile canaglia; che se mio figliuolo vero fussi, aresti rossore d'esser veduto loro in compagnia.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Ho fallato, patre, perdonami, e sta sicuro che questo serà l'ultimo fallo che t'abbia a far mai più disdegnar meco.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Erofilo, per Dio ti giuro che, se non t'emendi, ti farò con tuo grande spiacere connoscere ch'io mi risento. Se ben talor fingo di non vederti, non ti creder ch'io sia però cieco. Se non farai il tuo debito, io farò il mio; e minor danno è stare senza figliuolo, che averlo scelerato.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Patre, mi sforzerò per l'avenire esserti più obediente.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Se attendi al ben vivere, oltre che mi farai cosa gratissima e quel che ti si conviene, tu farai l'utilità tua; e siene certo.</p>
           </sp>
@@ -3107,23 +3171,23 @@
             <hi rend="bold">SCENA TERZA</hi>
           </head>
           <stage>FULCIO, MARSO <hi rend="italic">servi.</hi></stage>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Debb'io qui tutta notte aspettare, come io non abbia se non questa faccenda? Sollecitala tu fin ch'io ritorni, che vo qui appresso. – Spendono queste femine pur assai tempo in adornarse; mai non ne vengono al fine: mutano ogni capello in dieci guise, inanzi che si contentino che così resti. E che fan? Prima col liscio (oh che longa pazienzia!), or col bianco, or col rosso, metteno, levano, acconciano, guastano, cominciano di nuovo, tornano mille volte a vederse, a contemplarse nel specchio: in pelarse poi le ciglia, in rassettarse le poppe, in rilevarse ne' fianchi, in lavarse, in ungerse le mani, in tagliarse l'ugne, in fregarse, strusciarse li denti, oh quanto studio, quanto tempo si consuma! quanti bossoli, ampolle, vasetti, oh quante zacchere si mettono in opera! in minor tempo si dovea di tutto punto armare una galea. Io potrò ben con grande agio fornire intanto la battaglia che ho giurato a Crisobolo, poi che ho la maggior fortezza espugnata, prima che li nemici avessino dirizzata l'artigliaria, per battere l'ultima rocca che mi fa guerra, che è la borsa di questo tenacissimo vecchio; che, se mi succede come io spero, rapporterò di aver rotti, vinti et esterminati gli inimici: averò la gloria solo. Or, bussando a questa porta, assalterò le sprovedute guardie.</p>
           </sp>
-          <sp>
+          <sp who="#marso">
             <speaker>MARSO</speaker>
             <p> Chi è?</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Fa assapere a Crisobolo, che un messo del signor Bassà gli ha da fare una imbasciata.</p>
           </sp>
-          <sp>
+          <sp who="#marso">
             <speaker>MARSO</speaker>
             <p> Ché non entri tu in casa?</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Digli che si degni venir fòra per bon rispetto, e che per sua gran faccenda io son venuto.</p>
           </sp>
@@ -3133,227 +3197,227 @@
             <hi rend="bold">SCENA QUARTA</hi>
           </head>
           <stage>CRISOBOLO, FULCIO</stage>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Chi a quest'ora importuna mi domanda?</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Non ti maravigliare, e perdonami s'io t'ho chiamato qui fòra, che avendoti a dire cose secretissime, non me fido costà drento di non essere udito da gente che poi lo rapporti. Io mi potrò meglio qui vedere a torno, né averò dubbio che me ascolti omo che io non veggia. Ma ritiriance più ne la strada, e fa che questi tuoi si stieno drento.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Aspettatemi in casa voi. Tu di' ciò che ti pare.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Io t'ho da salutare prima in nome di Caridoro, figliuolo del Bassà di Metellino, il quale, per la amicizia che è fra tuo figliuolo e lui, t'ha in observanzia e t'ama come patre; e per questo, dove lui veggia di posserti fare utile et onore e schivarti biasimo e danno, non è mai per mancarti.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Io lo ringrazio, e gli sono obligatissimo sempre.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Or odi. Uscendo egli testé di casa per andare, come usano li giovani, a spasso (et io ero con lui), ce scontramo inanzi al palazzo, come la tua buona sorte vuole, in uno certo ruffiano, che dice essere tuo vicino...</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Oh bene!</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Che veniva irato gridando; e con dui, che non so chi si sieno, molto di te e di tuo figliuolo si dolea.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>E che dicea?</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>E' se n'andava al Bassà diritto a querelarse, se non l'avesse Caridoro ritenuto, di un giunto che gli ha fatto il figliuol tuo; che in verità, se dice il vero, è di pessima natura e sorte.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>(Or pon mente che travaglio mi si apparecchia per la pazzia di costui!)</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Dicea che un certo baro, che è vestito a guisa di mercatante...</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>(Ahi vedi che pur!...)</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Gli avea mandato con certo pegno a tòrre una sua femina. Io non l'ho inteso a punto, perché m'ha Caridoro con troppa fretta mandato ad avisarti correndo.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Ha fatto l'offizio di buono amico.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>E quelli dui che ha seco il ruffiano, come t'ho detto, mi par che voglino testificar per lui a carico.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>E di che?</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Dicono che 'l baro, che ha fatto il giunto, è in casa tua, e che di tuo consentimento è condutta questa cosa.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Di mio consentimento?</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Così dice; e mi par d'aver anco inteso, che tu in persona sei andato a tòrre o cassa o forzieri di casa del ruffiano.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Ah de quanto male serà causa la leggerezza d'uno fanciullo, sollicitata dal stimulo d'un ribaldo!</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Io non ti so ben dire il tutto, che per la fretta d'avisarti ho auto, non gli potetti se non in confuso intendere. Caridoro ti manda a dire che ritenerà quanto gli serà possibile il ruffiano che non parli al signore; ma che intanto tu ti veggia di provedere, acciò che oltra il danno, che saria molto, non ricevessi col tuo figliuolo alcuna pùblica vergogna.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Che provisione vi posso far io? Vedi se tutte le sciagure mi perseguono sempre!</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Fagli restituire la femina, o dagli qualche aspro, che si taccia.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Gli farei la femina restituire di grazia; ma mi pare che se l'hanno, per loro sciocchezza, lassata tra via tòrre, non sanno da chi.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Non ha Erofilo, dunque, la femina in mano?</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Non, ti dico, e non sa che ne sia.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Cotesto è il peggio. Come si potrà fare, adunque?</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Che so io? Ben so il più sfortunato e miser uomo che sia al mondo.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>La più corta e miglior via è che tu gli paghi la femina quello che ad altri l'ha possuta vendere, e che si faccia tacere.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Mi par strano dovere spendere il mio denaio in cosa che non abbia avere utile.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Non si può sempre guadagnare, Crisobolo; benché non poco guadagno a vietare con pochi danari un grandissimo danno, una publica vergogna non ti venga adosso. Se all'orecchie del signore verrà simil querela, a che termine ti troverai? Patirai tu sentire inquirerti contra? chiamare tuo figliuolo in ringhiera? gridare in bando? Oltra questo, pensa che hai nome del più ricco uomo di questa terra: a quel che molti altri repareriano con cento, tu non potrai ben riparare con mille: tu intendi.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Che ti par ch'io faccia?</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Questo ruffiano è povero e timido, come sono li pari suoi; gli serà la femina pagata, lo faren tacere; perché già Caridoro gli ha fatto intendere, che se vorrà litigar teco, non la farà bene, perché hai denari da tenerlo tutta la vita sua in piato, e de' parenti et amici da farlo un dì pentire de averti dato noia.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Sai quanto se ne tenessi cara la femina? o quel che n'abbia possuto avere?</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Mi fu già detto che un soldato valacco gli ne offerse cento saraffi, e dare non gli la volse; che per meno di centoventi dicea che non la lasseria mai.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Con minor prezzo s'arìa uno armento di vacche. Cotesto saria ben troppo: io non ne vo' far nulla: lamentisi, e faccia il peggio che puote.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Mi par strano che più estimi questi pochi denari...</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Pochi, eh?</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Che 'l tuo figliuolo, te medesimo, l'onor tuo. Io referirò dunque a Caridoro che non ne vuoi far nulla.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Non se potria con meno far tacere questo ruffiano?</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Se poteria con uno coltello, che costeria meno, e scannarlo.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Io non dico così. Centoventi saraffi è pur troppo prezzo.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Forse lo farai star queto per cento: per quel medesimo che da gli altri n'ha possuto avere.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>E non per meno?</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Che so io? vorrei in tuo servizio che lo potessi achetare con nulla. S'io fussi Crisobolo, manderei subito Erofilo con denari a trovare Caridoro: seremo tutti insieme adosso al ruffiano, et acconceremola con minor tua spesa che sia possibile.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Meglio è ch'io medesimo vi venga.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Non far, diavolo! Se 'l ruffiano ti vede caldo in questa pratica, crederà che di tuo consentimento l'abbia il tuo figliuolo gabbato, e con speranza di farti trarre più in grosso, ristarassi e farà l'asino il possibile: anzi mi pare che Erofilo venga solo, e che finga di cercare sanza tua saputa questo accordo, e che abbia trovati questi danari o da gli amici o all'interesso.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Erofilo vi venga solo? Sì, per Dio, perché gli è molto cauto! Se lassaria in un tratto aviluppare e tirarsi come 'l bufalo per el naso.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Non è de li tuoi servo alcuno, che sia accorto e pratico, da mandare con lui? Che è di quel tuo Volpino? Suol avere pure il diavolo in testa. Egli serà buono quanto possi desiderare.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Quel ladroncello è stato causa, guida e capo di tutta questa ribalderia: io l'ho in ceppi, e trattarollo come proprio lui merita.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Non lassar, Crisobolo, che la còlera ti regga: mandalo con Erofilo, che non puoi far meglio.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>È il maggior tristo, ogni modo, che sia al mondo: tuttavolta io non ho alcuno in casa che sapessi poner due parole insieme, et è forza, non possendo far altrimenti, che pur a lui ricorra. Ben mi rincresce.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Lassa andare: tu arai tempo di castigarlo de l'altre volte.</p>
           </sp>
-          <sp>
+          <sp who="#crisob">
             <speaker>CRISOB.</speaker>
             <p>Dio sa ben quanto mi par duro a roder questo osso. Ma sia con Dio: non te partire: manderògli ora ambidui con teco.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Io gli aspetto. – Or mi perviene il trionfo meritamente, poi che rotti io ho gli nimici e disfatti totalmente; senza sangue, senza danno de le mie squadre, ho lor ripari e lor fortezze tutte spianate a terra, e tutti al mio fisco fatti di più somma tributari, che non fu al mio principio mia speranza. Altro non mi resta ora che sciorre il voto che ti feci, Fortuna, di stare imbriaco tre giorni interi: io ti satisfarò volentieri, e vi darò principio tosto ch'io n'abbia agio. Ma ecco che li miei soldati escono, carichi di spoglie e preda ostile, di casa di Crisobolo; e sol ponno questa lor ventura al mio ingegno, alla mia virtù attribuire.</p>
           </sp>
@@ -3363,43 +3427,43 @@
             <hi rend="bold">SCENA QUINTA</hi>
           </head>
           <stage>VOLPINO, EROFILO, FULCIO</stage>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Io vederò di farlo rimanere tacito per quel che poterò meno, e farò più che se tu ce fussi in persona, e so che ti loderai di me.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>O Fulcio, quando ti poterò mai referire degne grazie del gran benefizio che tu m'hai fatto? S'io mettessi per te ciò ch'io ho al mondo, non mi par che mai satisfar potessi all'obligo ch'io ho teco.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Mi basta assai che mi facci buon viso.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Ma dove è la mia unica speranza, il mio refugio, la vera mia salute?</p>
           </sp>
-          <sp>
+          <sp who="#volp">
             <speaker>VOLP.</speaker>
             <p>Fulcio, di gran travagli, di gran paura, di crudelissimi tormenti hai liberata questa vita, sì che ad ogni tuo cenno io son per spenderla dove ti parrà.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Volpino, queste son opere che si prestano. Ti pare, Erofilo, ch'io t'abbia saputo ritrovar denari in abondanzia?</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Molto più che quelli che avemo detti.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Ho voluto che, oltra a quelli che daremo al ruffiano, tu n'abbi per mantenere la fanciulla, e per le spese, e per li altri suoi bisogni.</p>
           </sp>
-          <sp>
+          <sp who="#erof">
             <speaker>EROF.</speaker>
             <p>Eccoteli tutti: fanne quel che ti pare.</p>
           </sp>
-          <sp>
+          <sp who="#fulc">
             <speaker>FULC.</speaker>
             <p>Tiengli e portagli teco, che sùbito che io abbia condutta Corisca a Caridoro, te verrò a casa del Moro a ritrovare. – Brigata, tornàtevene a casa, che questa fanciulla ch'io vo a tòrre, non vuole esser veduta uscire; e dovendo anco el ruffiano fuggirsene, non è a proposito che ci sieno tanti testimoni. E fate segno d'allegrezza.</p>
           </sp>

--- a/tei/ariosto-i-studenti.xml
+++ b/tei/ariosto-i-studenti.xml
@@ -76,6 +76,46 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="bonifazio">
+            <persName>Bonifazio</persName>
+          </person>
+          <person xml:id="claudio">
+            <persName>Claudio</persName>
+          </person>
+          <person xml:id="eurialo">
+            <persName>Eurialo</persName>
+          </person>
+          <person xml:id="accursio">
+            <persName>Accursio</persName>
+          </person>
+          <person xml:id="pistone">
+            <persName>Pistone</persName>
+          </person>
+          <person xml:id="veronese">
+            <persName>Veronese</persName>
+          </person>
+          <person xml:id="ippolita">
+            <persName>Ippolita</persName>
+          </person>
+          <person xml:id="stanna">
+            <persName>Stanna</persName>
+          </person>
+          <person xml:id="riccio">
+            <persName>Riccio</persName>
+          </person>
+          <person xml:id="frate">
+            <persName>Frate Predicatore</persName>
+          </person>
+          <person xml:id="bartolo">
+            <persName>Bartolo</persName>
+          </person>
+          <person xml:id="messer_lazzaro">
+            <persName>Messer Lazzaro</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>2007-06-08T00:00:00.000+02:00</date><name>Novadata systems</name>Digitalizzazione - OCR</change>
@@ -382,7 +422,7 @@ Flamminia</roleDesc>
         <div type="scene" n="Scena I">
           <head>SCENA I</head>
           <stage>Bonifazio vecchio, Claudio scolare</stage>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>M'incresce che vogliate, messer Claudio,</l>
             <l>Così partirvi: non perché mi manchino</l>
@@ -392,7 +432,7 @@ Flamminia</roleDesc>
             <l>Avevo amor, ché mi parea che proprio</l>
             <l part="I">Voi mi foste figliuolo.</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l part="F">Io vi ringrazio</l>
             <l>Di cotesto buon animo, e in perpetuo</l>
@@ -404,12 +444,12 @@ Flamminia</roleDesc>
             <l>Con voi sì forte di benevolenzia</l>
             <l>Che, fin ch'io viva, nol credo disciogliere.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>Onde nasce cotesta così sùbita</l>
             <l part="I">Volontà di partirvi?</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l part="F">Da la solita</l>
             <l>Disgrazia mia ch'ovunque vo mi séguita;</l>
@@ -421,11 +461,11 @@ Flamminia</roleDesc>
             <l>A voi ch'in luogo di padre vi reputo.</l>
             <l part="I">Or ascoltate.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="M">Io v'ascolto.</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l part="F">A principio</l>
             <l>Che da mio padre fui mandato in Studio</l>
@@ -440,12 +480,12 @@ Flamminia</roleDesc>
             <l>Quella fraternità fra noi che dettavi</l>
             <l part="I">Ho più volte.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Che forse fu potissima</l>
             <l part="I">Cagion di farvi venir qui.</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l part="F">Consentovi</l>
             <l>Che ne fu in parte, ma non già potissima.</l>
@@ -504,13 +544,13 @@ Flamminia</roleDesc>
             <l>Potuto avessi far al desiderio</l>
             <l>Che nott'e dì mi rode, afflige e macera.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>Se l'amavate tanto, domandarglila</l>
             <l>Per moglie dovevate. Forse datavi</l>
             <l>L'avrebbe; e che nol fêste maravigliomi.</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l>Né di domandarglila né di prenderla</l>
             <l>Avrei avuto ardir, senza licenzia</l>
@@ -521,13 +561,13 @@ Flamminia</roleDesc>
             <l>E ch'io mi addottorassi, indi in la patria</l>
             <l>Darmi, a suo modo, una moglie ricchissima.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>Ora che senza patre sète libero,</l>
             <l>Perché coi vostri amici non fate opera</l>
             <l part="I">Ch'egli pur ve la dia?</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l part="F">Scrissi ad Eurialo,</l>
             <l>A' di passati, che ne fêsse pratica;</l>
@@ -548,19 +588,19 @@ Flamminia</roleDesc>
             <l>Per questa causa ero venuto, e postomi</l>
             <l part="I">In casa vostra per potere...</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Intendovi.</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l>...Meglio fruir la vista di Flamminia</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>Né potevate aver luogo più commodo.</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l>Poi ch'io son qui, mi par che più non séguiti</l>
             <l>Che s'abbia a far in questa terra Studio.</l>
@@ -570,14 +610,14 @@ Flamminia</roleDesc>
             <l>E che la via del Po che va a Vinegia</l>
             <l>Farà, senz'altrimenti qui venirsene.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>Oh, quest'è dunque la cagion che Bartolo,</l>
             <l>Che molti giorni era stato aspettandolo,</l>
             <l>Questa matina si è partito, e dicono</l>
             <l>Li suoi di casa che va sino a Napoli.</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l>Potete or, senza ch'io 'l dica, comprendere</l>
             <l>Che m'induca, mi sforzi e mi necessiti</l>
@@ -588,7 +628,7 @@ Flamminia</roleDesc>
             <l>Che parta oggi o domane; ch'io voglio essere,</l>
             <l>S'io potrò, prima là di messer Lazzaro.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>Gli è buon ch'io torni in casa e faccia cuocere</l>
             <l>Il desinar, sì che possa ir a tavola</l>
@@ -600,25 +640,25 @@ Flamminia</roleDesc>
         <div type="scene" n="Scena II">
           <head>SCENA II</head>
           <stage>Eurialo, Bonifazio</stage>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>Dio ve ne renda mille, Bonifazio.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="I">Èssi partito?</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Or ora. Non debb'essere</l>
             <l part="I">Ancor al Ponte</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Com'ha egli indugiatosi</l>
             <l>Tanto, ch'omai credea fosse a San Prospero?</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>Gli avea promesso di prestar, quell'asino</l>
             <l>Di Giannuol, un caval ch'iersera, udendolo,</l>
@@ -626,11 +666,11 @@ Flamminia</roleDesc>
             <l>Sotto una mula che sta come un trespolo</l>
             <l>In tre piedi, viziosa più che il diavolo.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="I">Com'ha egli fatto?</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Siamo iti a un stallatico:</l>
             <l>Ch'è andando verso il Ponte: è, credo, l'ultimo;</l>
@@ -641,11 +681,11 @@ Flamminia</roleDesc>
             <l>Al fin pur l'ho messo a cavallo e vassene,</l>
             <l part="I">Che Dio 'l conduca</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="M">E andarà solo</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Aspettalo</l>
             <l>A Bologna un famiglio ch'al servizio</l>
@@ -656,42 +696,42 @@ Flamminia</roleDesc>
             <l>Tre giorni o quattro, tanto che vi capiti</l>
             <l>Alcuna compagnia che vada a Napoli.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>E che buone facende così il menano?</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>Già molti anni v'ha voto. Messer Claudio</l>
             <l part="I">È in casa?</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="M">Non.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Com'egli torna, ditegli</l>
             <l>Ch'io vuo' che mangi meco alla domestica</l>
             <l part="I">Questa matina.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Gliel dirò. Voletemi</l>
             <l part="I">Commandar altro?</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="M">Non altro.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">(Dovendogli</l>
             <l>Dar costui disinar, meglio è non cuocere</l>
             <l>Quelle starne. Io vo a dir che non si mettano</l>
             <l part="I">Più al fuoco.)</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Colui là mi par Accursio.</l>
             <l>È egli o no? Senza dubbio egli è Accursio,</l>
@@ -707,33 +747,33 @@ Flamminia</roleDesc>
         <div type="scene" n="Scena III">
           <head>SCENA III</head>
           <stage>Eurialo, Accursio</stage>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="I">Quando giungesti?</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="M">Io giung'ora.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Hai tu lettere?</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l>N'ho così poche che so a pena leggere,</l>
             <l>Avenga che con voi sia stato in Studio.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>Non motteggiar. M'hai tu portate lettere</l>
             <l part="I">De la mia vita?</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="M">Messerno.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Farestime</l>
             <l>Ben maledir e rinegar e rompere</l>
@@ -744,173 +784,173 @@ Flamminia</roleDesc>
             <l>Fossi, né t'avrebb'ella, senza scrivermi,</l>
             <l part="I">Lasciato mai così venire.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Fecile</l>
             <l>Motto purtroppo, e pur senza sue lettere</l>
             <l part="I">Io son venuto</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Ohimè! com'è possibile?</l>
             <l part="I">Io vo' ben dir... Ma tu pur ridi...</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Or ridere</l>
             <l>Non posso e non aver però sue lettere?</l>
             <l>Ma s'io avessi di lei meglio che lettere?</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="I">E che?</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Ve lo dirò. Ma prima ditemi</l>
             <l>Voi quando il vecchio sia per gire a Napoli.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>Si part'or ora per andarvi, et essere</l>
             <l part="I">Non può lontan ancor un miglio.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Ditemi</l>
             <l part="I">II vero.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="M">Io 'l dico: si è partito.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Diagli</l>
             <l>Dio buon viaggio. Ora, messer Eurialo,</l>
             <l>Potete dir che siate felicissimo</l>
             <l part="I">Per la sua andata.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="M">E come?</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Era pericolo</l>
             <l>Se non si partiv'oggi ch'ove gaudio</l>
             <l>Vi avrò portato, portato molestia</l>
             <l part="I">V'avessi e briga:</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="M">C'hai portato?</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Vòlsivi</l>
             <l>Dir ch'avevo condotto, ché gravatomi</l>
             <l part="I">Troppo avrebbon le spalle.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Or su, espediscimi</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l>S'io vi dicessi che venuta Ippolita</l>
             <l>Fosse a Ferrara, vi parria miracolo?</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="I">Come venuta?</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="M">In nave.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">La mia Ippolita</l>
             <l part="I">È in Ferrara?</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="M">È in Ferrara.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="M">Ove?</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Lasciatala</l>
             <l>Ho in San Polo e m'aspetta fin che a rendere</l>
             <l part="I">Le vo risposta.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Non ti posso credere,</l>
             <l part="I">S'io non la veggo.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Venite, e vedretela.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="I">Com'è così venuta?</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">In nave, dicovi.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>Non ti domando cotesto, domandoti</l>
             <l>Per qual via e come di casa partitasi</l>
             <l part="I">Sia de la sua patrona.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO</speaker>
             <l part="F">Per la solita</l>
             <l>Via ch'usan gli altri è venuta; e debb'essere</l>
             <l part="I">Uscita per la porta.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Tu mi strazii</l>
             <l part="I">E mi dileggi, gaglioffo!</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Anzi dicovi</l>
             <l>La verità, né mi volete credere</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="I">Ell'è venuta certo?</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="M">Certo.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">O anima</l>
             <l>Mia cara, o vita mia! Mi sento struggere,</l>
             <l>Mi sento il cor liquefar di letizia.</l>
             <l>Ma dimmi un poco la cosa per ordine.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="I">Ve la dirò, se m'ascoltate.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Ascoltoti.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l>Io ritrovai la Veronese, e dissile</l>
             <l>Ch'io m'ero per partir il marte prossimo</l>
@@ -941,32 +981,32 @@ Flamminia</roleDesc>
             <l>Stavo in timor ch'incontrar lor potevano</l>
             <l part="I">Nel camin.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Gli è per certo stato l'animo</l>
             <l part="I">Lor gagliardo.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Anzi audace e temerario.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>Anzi pur grato, benigno, amorevole.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l>Io feci por le robe in nave, e messimi</l>
             <l>Alla via, e quando ci fermamo al dazio</l>
             <l>Di Piacenza, trovai che m'aspettavono.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>Non è già 'l primo né 'l secondo indizio,</l>
             <l>Ma si bene il maggior questo che datomi</l>
             <l>Ha de l'amor che mi porta. Ma séguita.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l>Quindi la feci tôrre in nave, et hovela</l>
             <l>Condotta. Ma al cor sempre ho avuto un stimolo:</l>
@@ -977,31 +1017,31 @@ Flamminia</roleDesc>
             <l>Non poteste, e ch'in luogo di letizia,</l>
             <l>La sua venuta affanno avesse ad esservi.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>La sua venuta in ogni tempo, o fosseci</l>
             <l>Mio patre o non ci fosse, non puote essermi</l>
             <l>Se non gioconda; e senza fin ringraziola.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l>Meglio m'è tornar dunque, e far che vengano.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="I">Dove?</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="M">Qui in casa.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Qui in casa? Non, domine</l>
             <l>Non sai come Pistone è rincrescevole?</l>
             <l part="I">Diria ch'io comminciassi presto.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Oh diavolo!</l>
             <l>Mi maraviglio ben di voi! Voletevi</l>
@@ -1010,7 +1050,7 @@ Flamminia</roleDesc>
             <l>Che voi volete esser padrone e fatelo,</l>
             <l>Se vi vuol soprafar, parere un asino.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>Se 'l vecchio fosse sì lontan, che dubbio</l>
             <l>Del suo tornar non avessi pel scrivere</l>
@@ -1022,27 +1062,27 @@ Flamminia</roleDesc>
             <l>Meglio è che troviàn lor oggi una camera</l>
             <l>In compagnia di qualche buona femina.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="I">Bona? e dov'è?</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Che ne so io? Vòlsiti</l>
             <l>Dir de le manco rie che si ritrovano.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l>In questo mezzo vi par ch'elle debbiano</l>
             <l>Star in chiesa digiune, o si riducano</l>
             <l>Coi frati alla piatanza in reffettorio?</l>
             <l part="I">Ma facciàn altrimente</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="M">Come?</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Dicasi</l>
             <l>In casa ch'elle son di messer Lazzaro</l>
@@ -1052,14 +1092,14 @@ Flamminia</roleDesc>
             <l>Sono, e che pur Ferrara veder vogliono,</l>
             <l>Prima che passin per andar a Padova.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>Tu parli ben; ma come verisimile</l>
             <l>Potrà parer che senza messer Lazzaro</l>
             <l>Siano venute; e che seco non abbino</l>
             <l part="I">Almeno una fantesca?</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Messer Lazzaro</l>
             <l>Con la famiglia e robe diremo essere</l>
@@ -1068,12 +1108,12 @@ Flamminia</roleDesc>
             <l>Non ci vuol dar molta spesa. Lasciatemi</l>
             <l part="I">Pur governar questa cosa.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Governala</l>
             <l part="I">Come ti par.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Datele voi principio.</l>
             <l>Andate a ritrovar Pistone, e ditegli</l>
@@ -1089,30 +1129,30 @@ Flamminia</roleDesc>
             <l>Persone a casa di rispetto, e siavi</l>
             <l>Più ch'altro a core ch'abbian buona tavola.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="I">Tu che farai?</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">C'ho a far, se non tornarmene</l>
             <l>Là dove l'ho lasciate, e dir che vengano?</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>Or va', ma prima avertisci et informale.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l>Le avertirò, ma d'informarle ufficio</l>
             <l part="I">Vostro sarà.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Non cianciare. Instruiscele</l>
             <l>Di ciò ch'elle hanno a dire et a rispondere.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l>Le farò dotte in modo che ben credere</l>
             <l>Si potrà ch'allevate sian in Studio.</l>
@@ -1123,11 +1163,11 @@ Flamminia</roleDesc>
             <l>Domandi che facciate che non sappia</l>
             <l>Che siano in questa terra ella né Ippolita.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="I">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Mi penso che sia perché, avendola</l>
             <l>Posta con la Contessa messer Claudio,</l>
@@ -1141,14 +1181,14 @@ Flamminia</roleDesc>
             <l>A lui, sì com'ad uomo ch'amicissimo</l>
             <l>Sia de la sua padrona e molto intrinseco.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>Non sa la Veronese, non sa Ippolita</l>
             <l>Che, se de la Contessa è messer Claudio,</l>
             <l>Ch'egli è più mio, né mai saria per movere</l>
             <l>Lingua di cosa ove credesse offendermi?</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l>Ma non sapete voi che messer Claudio</l>
             <l>Meglio dirà che non ci son, credendosi</l>
@@ -1157,7 +1197,7 @@ Flamminia</roleDesc>
             <l>Che si parton dal cor, che quelle ch'escono</l>
             <l>Sol da la bocca, alla intenzion contrarie.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>Tu pensi bene. Or dille che non dubiti,</l>
             <l>Ché, poi che non le par, non son per dirglilo.</l>
@@ -1169,7 +1209,7 @@ Flamminia</roleDesc>
         <div type="scene" n="Scena I">
           <head>SCENA I</head>
           <stage>Bonifazio, Pistone famiglio</stage>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>Meglio è ch'io vada in Piazza, e ch'io faccia opera</l>
             <l>Col bidel che mi trovi alcuno giovene</l>
@@ -1177,19 +1217,19 @@ Flamminia</roleDesc>
             <l>Mie lochi; che, volendo messer Claudio,</l>
             <l>Come dice, partir, vòte non restino.</l>
           </sp>
-          <sp>
+          <sp who="#pistone">
             <speaker>PISTONE:</speaker>
             <l>Vo' uscir di casa, né prima lasciarmici</l>
             <l>Oggi trovar, che sian sonati i vesperi.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>Ecco la feccia di quanti si trovano</l>
             <l>Famigli negligenti, temerarii,</l>
             <l>Cianciatori! Non so come potutolo</l>
             <l>Abbia patir sì longamente Bartolo.</l>
           </sp>
-          <sp>
+          <sp who="#pistone">
             <speaker>PISTONE:</speaker>
             <l>Dovean mandar un messo inanzi, o scrivere,</l>
             <l>E darne almen d'un mezzo giorno spazio.</l>
@@ -1203,59 +1243,59 @@ Flamminia</roleDesc>
             <l>Pià le facende che 'l patron impostemi</l>
             <l>Ha che l'apparecchiar credenze e tavole.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="I">Che vuol dir quest'apparecchio</l>
           </sp>
-          <sp>
+          <sp who="#pistone">
             <speaker>PISTONE:</speaker>
             <l part="F">Ci vengono</l>
             <l part="I">Forestier.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="M">E chi son?</l>
           </sp>
-          <sp>
+          <sp who="#pistone">
             <speaker>PISTONE:</speaker>
             <l part="F">Non posso dirlovi.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="I">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#pistone">
             <speaker>PISTONE:</speaker>
             <l part="F">Perc'ha commesso in casa Eurialo</l>
             <l part="I">Che non si dica fuor.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Fati in qua, dimmelo</l>
             <l>Dentro l'orecchia; ma non vòlse intendere</l>
             <l part="I">Di me.</l>
           </sp>
-          <sp>
+          <sp who="#pistone">
             <speaker>PISTONE:</speaker>
             <l part="F">Nol so. Ha ben commesso in specie</l>
             <l>Che non si dica a questo vostro giovine</l>
             <l part="I">Che vi sta in casa.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="M">E perché?</l>
           </sp>
-          <sp>
+          <sp who="#pistone">
             <speaker>PISTONE:</speaker>
             <l part="F">Voglio dirlovi</l>
             <l>Pur com'egli è: di voi disse il medesimo,</l>
             <l part="I">Che non vi si dicesse.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">È egli possibile?</l>
           </sp>
-          <sp>
+          <sp who="#pistone">
             <speaker>PISTONE:</speaker>
             <l>Gli è com'io dico. Ma a sua posta vogliolo</l>
             <l>A voi dir ogni modo, che vi reputo</l>
@@ -1267,12 +1307,12 @@ Flamminia</roleDesc>
             <l>Adosso alla sprovista, quando Bartolo</l>
             <l part="I">È partito.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">E chi son? Pur messer Lazzaro,</l>
             <l part="I">Quel dottor da Pavia?</l>
           </sp>
-          <sp>
+          <sp who="#pistone">
             <speaker>PISTONE:</speaker>
             <l part="F">Non messer Lazzaro,</l>
             <l>Ma la moglier e la figliuola. Vogliono</l>
@@ -1281,55 +1321,55 @@ Flamminia</roleDesc>
             <l>Elle due, e con lor solo è il nostro Accursio,</l>
             <l part="I">Senza più.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">E dove resta messer Lazzaro?</l>
           </sp>
-          <sp>
+          <sp who="#pistone">
             <speaker>PISTONE:</speaker>
             <l>Va giù per l'altro Po. Non ci vuol, dicono,</l>
             <l part="I">Dar tanta spesa.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Debbe esser che misero,</l>
             <l>Se si va assottigliando in cose minime!</l>
           </sp>
-          <sp>
+          <sp who="#pistone">
             <speaker>PISTONE:</speaker>
             <l>Anzi pur grandi, sì che già m'increscono.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="I">Staranci assai?</l>
           </sp>
-          <sp>
+          <sp who="#pistone">
             <speaker>PISTONE:</speaker>
             <l part="F">Cinque o sei giorni. Aspettano</l>
             <l>Un vecchio lor di casa, che debb'essere</l>
             <l>Qui presto, il qual poi le conduca a Padova.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="I">Perché non vuol che si sappia?</l>
           </sp>
-          <sp>
+          <sp who="#pistone">
             <speaker>PISTONE:</speaker>
             <l part="F">Al giudicio</l>
             <l>Mio, queste donne, perché qui si veggono</l>
             <l>Senza serve e famigli, si vergognano</l>
             <l part="I">Ma voglio andar.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">La via è spedita e libera.</l>
           </sp>
-          <sp>
+          <sp who="#pistone">
             <speaker>PISTONE:</speaker>
             <l>Ma, per Dio, questa cosa, Bonifazio,</l>
             <l part="I">Stia in voi.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Non dubitar, che secretario</l>
             <l>Non potreste trovar di me più tacito.</l>
@@ -1353,7 +1393,7 @@ Flamminia</roleDesc>
         <div type="scene" n="Scena II">
           <head>SCENA II</head>
           <stage>Veronese vecchia, Ippolita, Accursio, Bonifazio</stage>
-          <sp>
+          <sp who="#veronese">
             <speaker>VERONESE:</speaker>
             <l>I gesti e i detti nostri si conformino</l>
             <l>Con quel ch'abbiamo disegnato, Ippolita,</l>
@@ -1362,21 +1402,21 @@ Flamminia</roleDesc>
             <l>Che noi non siamo quelle che 'l nostr'utile</l>
             <l>Commun richiede che debbiamo fingersi</l>
           </sp>
-          <sp>
+          <sp who="#ippolita">
             <speaker>IPPOLITA:</speaker>
             <l part="I">Saprò ben fare io per me .</l>
           </sp>
-          <sp>
+          <sp who="#veronese">
             <speaker>VERONESE:</speaker>
             <l part="F">Sì, se Eurialo</l>
             <l part="I">Non ci fosse.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Anzi 'l farà meglio, essendoci</l>
             <l part="I">Egli.</l>
           </sp>
-          <sp>
+          <sp who="#veronese">
             <speaker>VERONESE:</speaker>
             <l part="F">Di quel far non dico, ma dicole</l>
             <l>Ch'avrà dificoltà a tenersi, essendoci</l>
@@ -1385,50 +1425,50 @@ Flamminia</roleDesc>
             <l>In viso, o motteggiandolo, che liquido</l>
             <l>E chiaro faccia altrui che fra lor s'amino.</l>
           </sp>
-          <sp>
+          <sp who="#ippolita">
             <speaker>IPPOLITA:</speaker>
             <l>Se ci sarà persona a cui sia debito</l>
             <l>D'aver rispetto, io starò cheta et umile,</l>
             <l>Con gli occhi bassi, che parrò una monaca:</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l>Ecco la casa là del nostro Eurialo.</l>
           </sp>
-          <sp>
+          <sp who="#ippolita">
             <speaker>IPPOLITA:</speaker>
             <l>O cor mio caro, o vita mia! Difficile</l>
             <l>Sarà potermi tener di non correre</l>
             <l part="I">Ad abbracciarlo.</l>
           </sp>
-          <sp>
+          <sp who="#veronese">
             <speaker>VERONESE:</speaker>
             <l part="F">Vedi come, Accursio,</l>
             <l part="I">Mi è costei bene ubidïente!</l>
           </sp>
-          <sp>
+          <sp who="#ippolita">
             <speaker>IPPOLITA:</speaker>
             <l part="F">Affrettati,</l>
             <l>Vecchia! Cotesto passo di testuggine</l>
             <l>Allunga un poco. Vuoi che stiàn a giungere</l>
             <l part="I">A quella casa cento anni?</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">È impossibile</l>
             <l>Insomma ch'agli amanti legge mettere</l>
             <l>Si possa. Ecco, siàn pur a casa. Entrateci.</l>
           </sp>
-          <sp>
+          <sp who="#ippolita">
             <speaker>IPPOLITA:</speaker>
             <l part="I">Entrate, madre.</l>
           </sp>
-          <sp>
+          <sp who="#veronese">
             <speaker>VERONESE:</speaker>
             <l part="F">Va' là, ch'io ti séguito,</l>
             <l part="I">Figliuola.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Non mi dispiace il principio.</l>
           </sp>
@@ -1436,7 +1476,7 @@ Flamminia</roleDesc>
         <div type="scene" n="Scena III">
           <head>SCENA III</head>
           <stage>Bonifazio</stage>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>È assai bella e, per Dio, c'ha gentil aria.</l>
             <l>Ma che tardo io di cercar messer Claudio,</l>
@@ -1456,7 +1496,7 @@ Flamminia</roleDesc>
         <div type="scene" n="Scena IV">
           <head>SCENA IV</head>
           <stage>Claudio, Bonifazio</stage>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l>Non so se dica il ver, ma mal credibile</l>
             <l>Mi par però che senza messer Lazzaro</l>
@@ -1468,66 +1508,66 @@ Flamminia</roleDesc>
             <l>Posso), non dovria almeno a me nasconderlo.</l>
             <l>Ma sono appresso ove posso chiarirmene.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>Che mi volete pagar, messer Claudio,</l>
             <l>S'una novella vi do che gratissima</l>
             <l part="I">Vi fia?</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l part="F">La so, ché 'l servitor di Bartolo</l>
             <l>Che m'ha trovato su quel canto, dettala</l>
             <l part="I">M'ha.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="M">Ve l'ha detta Piston?</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l part="F">Piston dettami</l>
             <l part="I">L'ha.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Guata bestia! Mi prega di grazia</l>
             <l>Ch'io non vel dica, e poi vien egli a dirvela!</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l>Così ha pregato me ancora che tacito</l>
             <l>Io me ne stia, né con altri 'l comunichi.</l>
             <l part="I">Ma non gli credo!</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Sopra me credetegli,</l>
             <l>Perch'egli è vero; né sì poco giungere</l>
             <l>Potevate più presto, che vedutele</l>
             <l part="I">Avreste entrar là dentro.</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l part="F">Voi vedutele</l>
             <l part="I">Avete?</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="M">Con questi occhi.</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l part="F">Raffermandomi</l>
             <l>Voi d'averle vedute, posso crederlo.</l>
             <l part="I">Chi è con lor?</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Nessun altr'ho vedutoci</l>
             <l part="I">Che figlia e madre.</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l part="F">Com'è egli possibile</l>
             <l>Che con loro una serva almen non abbino?</l>
@@ -1550,7 +1590,7 @@ Flamminia</roleDesc>
             <l>Da non poter Lucrezia né Virginia,</l>
             <l>Se ci venisson, servar pudicizia.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>Ah, non dite cotesto, che grandissimo</l>
             <l>Torto avete; Se bene hanno licenzia</l>
@@ -1564,13 +1604,13 @@ Flamminia</roleDesc>
             <l>L'ho di mestizia, e che vi spiace intendere</l>
             <l part="I">Ch'elle sian qui.</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l part="F">Vi dirò, Bonifazio</l>
             <l>La verità. Questo volerlo ascondere</l>
             <l>A me ch'Eurial fa, mi guasta il stomaco.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>Non date fede a quel poltron. Credibile</l>
             <l>Non è ch'Eurialo avesse fatta simile</l>
@@ -1580,35 +1620,35 @@ Flamminia</roleDesc>
             <l>Che ve ne dia la novella, o vuol farlavi</l>
             <l part="I">D'improviso veder.</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l part="F">Il “forse” è debole</l>
             <l>Fondamento. Le cose che si veggono</l>
             <l>Si puon dir certe, le future in dubbio</l>
             <l>Son sempre, che ponn'essere e non essere.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>Volete voi ch'io lievi questo dubbio,</l>
             <l>Se per ben o per mal costui nascondere</l>
             <l part="I">Cerca questa venuta?</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l part="F">Lo desidero.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>Gli vuo' porre una spia, che qual sia minima</l>
             <l>Cosa non potrà far né dir, che sùbito</l>
             <l part="I">Non la intendiàn.</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l part="F">Fatel, di grazia, e costimi</l>
             <l part="I">Quel che vuol.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Molto non vi vuo' far spendere;</l>
             <l>Ma trovarete al fin ch'ell'è una favola.</l>
@@ -1627,7 +1667,7 @@ Flamminia</roleDesc>
         <div type="scene" n="Scena V">
           <head>SCENA V</head>
           <stage>Stanna fantesca, Bonifazio, Claudio</stage>
-          <sp>
+          <sp who="#stanna">
             <speaker>STANNA:</speaker>
             <l>Io cercarò, ma sempre suole in li ultimi</l>
             <l>Giorni del Carnevale esser difficile</l>
@@ -1635,33 +1675,33 @@ Flamminia</roleDesc>
             <l>Che tutti feste e conviti apparecchiano,</l>
             <l>Dieci e dodici di prima gli inarrano.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>Se la Stanna vorrà far quest'ufficio</l>
             <l part="I">D'esserci spia, sarà buona.</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l part="F">Bonissima;</l>
             <l part="I">Pur ch'ella voglia.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Ella vorrà, vedretelo.</l>
           </sp>
-          <sp>
+          <sp who="#stanna">
             <speaker>STANNA:</speaker>
             <l>S'io non ne posso aver, torrò in quel cambio</l>
             <l>Un pezzo di vitella, o anatre, o simile</l>
             <l>Cosa; ma dirà prima a messer Claudio</l>
             <l part="I">Questo ch'io gli ho da dir.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Ecco, vi nomina.</l>
             <l>Vedrete al fin ch'egli è com'io m'imagino.</l>
           </sp>
-          <sp>
+          <sp who="#stanna">
             <speaker>STANNA:</speaker>
             <l>Ma qui lo veggo a tempo. — Messer Claudio,</l>
             <l>Mio patron, che v'avea per Bonifazio</l>
@@ -1671,37 +1711,37 @@ Flamminia</roleDesc>
             <l>Andar in villa. Un'altra volta al debito</l>
             <l part="I">Sodisferà.</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l part="M">Come gli piace.</l>
           </sp>
-          <sp>
+          <sp who="#stanna">
             <speaker>STANNA:</speaker>
             <l part="F">Pregavi</l>
             <l part="I">Che voi gli perdoniate.</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l part="F">Non accadono</l>
             <l part="I">Qui perdonanze. Egli dov'è?</l>
           </sp>
-          <sp>
+          <sp who="#stanna">
             <speaker>STANNA:</speaker>
             <l part="F">Partitosi</l>
             <l part="I">È già un pezzo e va in villa.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Debb'io credere</l>
             <l>Che sia così indiscreto, che venuteli</l>
             <l>Essendo gentildonne a casa, vogliale</l>
             <l part="I">Lasciar sole?</l>
           </sp>
-          <sp>
+          <sp who="#stanna">
             <speaker>STANNA:</speaker>
             <l part="M">Che gentildonne?</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Avemole</l>
             <l>(Nol negar) ben vedute, e siàn certissimi</l>
@@ -1713,12 +1753,12 @@ Flamminia</roleDesc>
             <l>È, per Dio, molto bella, e mostra all'aria</l>
             <l part="I">Esser non men gentil.</l>
           </sp>
-          <sp>
+          <sp who="#stanna">
             <speaker>STANNA:</speaker>
             <l part="F">A fede, avetele</l>
             <l part="I">Vedute?</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Ambe le vidi, quando vennero,</l>
             <l>La madre e la figliuola. Accarezzatele</l>
@@ -1726,22 +1766,22 @@ Flamminia</roleDesc>
             <l>E per rispetto poi di messer Lazzaro,</l>
             <l>Al qual odo ch'Eurial ha immortal obligo.</l>
           </sp>
-          <sp>
+          <sp who="#stanna">
             <speaker>STANNA:</speaker>
             <l>Non mancamo far lor ciò ch'è possibile.</l>
             <l>Gli è ver che son venute quando Bartolo</l>
             <l>Non c'è, che tutti ne trova in disordine.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>Non dir tutti, ch'io so, quando in disordine</l>
             <l>Ben fossin gli altri, tu sei sempre in ordine.</l>
           </sp>
-          <sp>
+          <sp who="#stanna">
             <speaker>STANNA:</speaker>
             <l part="I">Voi volete la baia.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Questo è 'l solito</l>
             <l>De' vecchi: tôr, quando dar non la possono.</l>
@@ -1751,12 +1791,12 @@ Flamminia</roleDesc>
             <l>Una saia con noi, ch'abbia le maniche</l>
             <l>Di seta, che non fasti mai sì orrevole.</l>
           </sp>
-          <sp>
+          <sp who="#stanna">
             <speaker>STANNA:</speaker>
             <l>Ben bisogno n'avrei: pur senza premio</l>
             <l>Son per farvi, ov'io possa, ogni servizio.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>Voglio che, per mio amor e per tuo utile,</l>
             <l>Usi, Stanna mia cara, diligenzia</l>
@@ -1764,11 +1804,11 @@ Flamminia</roleDesc>
             <l>È inamorato. Facilmente accorgere</l>
             <l part="I">Te ne potrai.</l>
           </sp>
-          <sp>
+          <sp who="#stanna">
             <speaker>STANNA:</speaker>
             <l part="F">Ch'accade a voi d'intenderlo?</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>Te lo dirò. Sappiàn che 'l patre darglila</l>
             <l>Vorrebbe, et anco v'è inclinato Bartolo.</l>
@@ -1777,19 +1817,19 @@ Flamminia</roleDesc>
             <l>Verità, mal gli crediamo. Tu studia</l>
             <l part="I">D'informarti del ver.</l>
           </sp>
-          <sp>
+          <sp who="#stanna">
             <speaker>STANNA:</speaker>
             <l part="F">Senz'altro studio</l>
             <l>So che non dice 'l vero, e son chiarissima</l>
             <l>Ch'egli è come pensate. Insieme s'amano,</l>
             <l part="I">Et è fra lor altro che ciance.</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l part="F">Ah misero!</l>
             <l part="I">Post'avrò il dito nel vespaio.</l>
           </sp>
-          <sp>
+          <sp who="#stanna">
             <speaker>STANNA:</speaker>
             <l part="F">E dicovi</l>
             <l>Più: che la matre istessa è consapevole</l>
@@ -1800,19 +1840,19 @@ Flamminia</roleDesc>
             <l>E faccia in guisa che né questo giovane</l>
             <l>Né voi possiate saper che ci sieno.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>Non er'io qui ne la via quando vennero?</l>
             <l>Non temer ch'egli 'l sappia. Ma ch'indizio</l>
             <l part="I">Hai tu che sia come ci affermi?</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l part="F">Ah misero!</l>
             <l>Avrò cercato quel che rincrescevole</l>
             <l part="I">E noioso mi fia trovar.</l>
           </sp>
-          <sp>
+          <sp who="#stanna">
             <speaker>STANNA:</speaker>
             <l part="F">Diròlovi.</l>
             <l>Quando testé le donne in casa vennero,</l>
@@ -1835,63 +1875,63 @@ Flamminia</roleDesc>
             <l>Le bocche, che parean quando la rondine</l>
             <l part="I">Imbecca i figli.</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l part="F">E la madre vedevagli?</l>
           </sp>
-          <sp>
+          <sp who="#stanna">
             <speaker>STANNA:</speaker>
             <l part="I">Come voi me. Ma questo è nulla.</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l part="F">Abbiamone</l>
             <l>Purtroppo, e non ne vogliàn or più intendere.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>Sta' pur intenta, Stanna, e referiscine</l>
             <l part="I">Ciò che tu vedi.</l>
           </sp>
-          <sp>
+          <sp who="#stanna">
             <speaker>STANNA:</speaker>
             <l part="M">Volete altro?</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l part="F">Eurialo</l>
             <l part="I">È in casa?</l>
           </sp>
-          <sp>
+          <sp who="#stanna">
             <speaker>STANNA:</speaker>
             <l part="M">E dove può star meglio?</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Dettoci</l>
             <l part="I">Avevi ch'era ito in villa.</l>
           </sp>
-          <sp>
+          <sp who="#stanna">
             <speaker>STANNA:</speaker>
             <l part="F">Pote essere</l>
             <l>Ch'a Figarolo o di là da Garofalo</l>
             <l part="I">Or sia alla Pelosella.</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l part="F">Per Dio, mandala</l>
             <l part="I">Via, ch'ella mi distrugge!</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Or su, non perdere</l>
             <l>Tempo, va'. Ben noi ti farèn il debito.</l>
           </sp>
-          <sp>
+          <sp who="#stanna">
             <speaker>STANNA:</speaker>
             <l part="I">Sempre il debito è fatto.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Messer Claudio,</l>
             <l>Poi che lo invito e 'l desinar d'Eurialo</l>
@@ -1902,13 +1942,13 @@ Flamminia</roleDesc>
             <l>Si che vo' ritornar, e far rimettere</l>
             <l part="I">Le starne nel schidone.</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l part="F">Andate, e fatene</l>
             <l>Quel che vi par, ch'io per me ho guasto il stomaco,</l>
             <l>Né spero mai mai più di racconciarlomi.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>Oh, che volete voi per questo affligervi?</l>
             <l>Morir per questo? Quasi che le femine</l>
@@ -1916,25 +1956,25 @@ Flamminia</roleDesc>
             <l>Ricco e bello; n'avrete in abondanzia</l>
             <l>Ancora tal che vi verrà a fastidio.</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l part="I">Ah lasso, io vo' morir!</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Fate buon animo.</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l>Volete voi farmi un piacer? Lasciatemi</l>
             <l part="I">Qui sol.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Cotesto non ricerca il debito</l>
             <l part="I">De l'amor che vi porto.</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l part="F">Non amandomi</l>
             <l>Colei che sola al mondo amo, e mancandomi</l>
@@ -1946,12 +1986,12 @@ Flamminia</roleDesc>
             <l>Ad alcuno fedele, e donne et uomini,</l>
             <l>Sia chi si vuol, menar tutti a una regola.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>Questo non è parlar d'uom ch'abbia animo</l>
             <l part="I">Maschio.</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l part="F">Non so s'io l'abbia maschio o femina;</l>
             <l>So ben ch'io l'ho mal contento, e che d'essere</l>
@@ -1960,19 +2000,19 @@ Flamminia</roleDesc>
             <l>Avendo quella ch'a suo modo volgere</l>
             <l part="I">Lo potea.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Tal parole non convengono</l>
             <l>A voi, ch'altrui mostrar la sapïenzia</l>
             <l>Dovreste, essendo sempre ne le lettere</l>
             <l>Versato e in tanti essempi de filosofi.</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l>Ne' libri, ohimè!, si leggono e si scrivono</l>
             <l>Molte cose, ch'in fatti poi non reggono.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>Venite almeno in casa, e disfogatevi</l>
             <l>Come vi par, e non state qui in publico,</l>
@@ -1981,7 +2021,7 @@ Flamminia</roleDesc>
             <l>Da me conforto né consiglio, vogliovi</l>
             <l>Esser compagno a lagrimar e piangere.</l>
           </sp>
-          <sp>
+          <sp who="#claudio">
             <speaker>CLAUDIO:</speaker>
             <l>Né in casa né in Ferrara, Bonifazio,</l>
             <l>Mi vo' fermar, se non quanto si carichi</l>
@@ -1997,7 +2037,7 @@ Flamminia</roleDesc>
             <l>Ch'io venni al mondo, e la puttana balia</l>
             <l>Che nel bagnuol non mi fece sommergere!</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>(Oh, egli è ben disperato! Pover giovane,</l>
             <l>E pover tutti gli altri che si lasciano</l>
@@ -2006,46 +2046,46 @@ Flamminia</roleDesc>
             <l>Ma ecco torna la Stanna.) Trovastene</l>
             <l part="I">Pur?</l>
           </sp>
-          <sp>
+          <sp who="#stanna">
             <speaker>STANNA:</speaker>
             <l part="F">N'ho trovati senza molto avolgermi;</l>
             <l>E sono buoni, in fé di Dio. Toccategli.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="I">Oh, come son ben sodi!</l>
           </sp>
-          <sp>
+          <sp who="#stanna">
             <speaker>STANNA:</speaker>
             <l part="F">Non dicevo di</l>
             <l>Questi, che non sono però da cuocere.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>Da cuocer no, ma sì ben da goderceli</l>
             <l part="I">Vivi e sani.</l>
           </sp>
-          <sp>
+          <sp who="#stanna">
             <speaker>STANNA:</speaker>
             <l part="F">Saria pasto da giovane,</l>
             <l>E non da voi, ché vi potrebbon nuocere</l>
             <l part="I">Più che giovar.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="M">Odi, Stanna.</l>
           </sp>
-          <sp>
+          <sp who="#stanna">
             <speaker>STANNA:</speaker>
             <l part="F">Lasciateme</l>
             <l>Ir, c'ho troppo da far senz'anco spendere</l>
             <l part="I">Il tempo in ciance.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">E se fatti ci fossero?</l>
           </sp>
-          <sp>
+          <sp who="#stanna">
             <speaker>STANNA:</speaker>
             <l>Mi levarei di notte per attenderci.</l>
           </sp>
@@ -2056,7 +2096,7 @@ Flamminia</roleDesc>
         <div type="scene" n="Scena I">
           <head>SCENA I</head>
           <stage>Eurialo, Accursio</stage>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>Chi si governa per cervel di femina</l>
             <l>O di genti ch'a' lor pareri attendono,</l>
@@ -2080,7 +2120,7 @@ Flamminia</roleDesc>
             <l>Io l'avessi avertito come passano</l>
             <l part="I">Le cose.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Or, quel ch'è già fatto è impossibile</l>
             <l>Che non sia fatto. Veggiàn pur di mettere</l>
@@ -2088,7 +2128,7 @@ Flamminia</roleDesc>
             <l>Abbia più inanzi. È buon chiamarlo, e dirgli la</l>
             <l part="I">Cosa tutta.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">E menarlo in casa, e farglila</l>
             <l>Vedere, e trarlo di questa ignoranzia.</l>
@@ -2102,7 +2142,7 @@ Flamminia</roleDesc>
         <div type="scene" n="Scena II">
           <head>SCENA II</head>
           <stage>Pistone, Eurialo</stage>
-          <sp>
+          <sp who="#pistone">
             <speaker>PISTONE:</speaker>
             <l>S'io avessi tolto il punto de l'astrologo,</l>
             <l>Io non avrei potuto il piede mettere</l>
@@ -2112,41 +2152,41 @@ Flamminia</roleDesc>
             <l>Mio, quella strada, che sei mesi passano</l>
             <l part="I">Ch'io non vi son più stato.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F"> (Quanto intendere</l>
             <l>Posso, ha novelle costui che gli piacciono.)</l>
           </sp>
-          <sp>
+          <sp who="#pistone">
             <speaker>PISTONE:</speaker>
             <l>La mia è ben stata ventura grandissima,</l>
             <l>Che nel maggior bisogno, e quando avevone</l>
             <l>Minor speme, così veduto io l'abbia.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>(Costui danari o annello o cosa simile</l>
             <l>Ha ritrovato. La vuo' bene intendere.)</l>
             <l>C'hai tu, Piston, trovato? Ci voglio essere</l>
             <l part="I">A parte.</l>
           </sp>
-          <sp>
+          <sp who="#pistone">
             <speaker>PISTONE:</speaker>
             <l part="M">Vostro padre, il qual...</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Dio, aiutami!</l>
           </sp>
-          <sp>
+          <sp who="#pistone">
             <speaker>PISTONE:</speaker>
             <l part="I">È ritornato in dietro.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="M">Come?</l>
           </sp>
-          <sp>
+          <sp who="#pistone">
             <speaker>PISTONE:</speaker>
             <l part="F">Dicemi</l>
             <l>Che non era anco al Ponte, che sferratosi</l>
@@ -2154,67 +2194,67 @@ Flamminia</roleDesc>
             <l>Al maliscalco, sapete, ch'è l'ultimo</l>
             <l>Poi ce d'un pezzo si è passato l'Agnolo.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="I">Pur andarà?</l>
           </sp>
-          <sp>
+          <sp who="#pistone">
             <speaker>PISTONE:</speaker>
             <l part="F">Non. Gli ho detto io che giunteci</l>
             <l part="I">Son queste donne a casa.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Ah temerario,</l>
             <l>Indiscreto, gaglioffo! Or non avevoti</l>
             <l>Commesso espressamente e minacciatoti</l>
             <l part="I">Che non ne fêssi parola?</l>
           </sp>
-          <sp>
+          <sp who="#pistone">
             <speaker>PISTONE:</speaker>
             <l part="F">Vietastemi</l>
             <l>Ch'io nol dicessi a strani, ma in quel novero</l>
             <l part="I">Non è da por vostro padre.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Vietavoti,</l>
             <l>Dunque, ch'al Brusco o ch'a Biagiuol da l'Abaco</l>
             <l>Tu nol dicessi? Ma dove, brutto asino,</l>
             <l>T'ho parlato io de strani o di domestici?</l>
           </sp>
-          <sp>
+          <sp who="#pistone">
             <speaker>PISTONE:</speaker>
             <l>Mi credea di far bene, e che molt'obligo</l>
             <l>Voi me n'avessi aver, perc'ho fatt'opera</l>
             <l part="I">Che restarà.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Ribaldo! Che ti vengano</l>
             <l>Cento cancari! Dunque ha diferita la</l>
             <l part="I">Sua andata?</l>
           </sp>
-          <sp>
+          <sp who="#pistone">
             <speaker>PISTONE:</speaker>
             <l part="M">Sì.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="M">Non si part'oggi?</l>
           </sp>
-          <sp>
+          <sp who="#pistone">
             <speaker>PISTONE:</speaker>
             <l part="F">Al credere</l>
             <l>Mio, né doman ancor, né fin ch'a Padova</l>
             <l>Non vadan elle; far lor si delibera</l>
             <l>Carezze e onor, né perdonar al spendere.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="I">Ma egli ora dove è?</l>
           </sp>
-          <sp>
+          <sp who="#pistone">
             <speaker>PISTONE:</speaker>
             <l part="F">Tornammo a rendere</l>
             <l>La bestia. Io gli trassi i stivali e messigli</l>
@@ -2224,28 +2264,28 @@ Flamminia</roleDesc>
             <l>Il canestro e la sporta grande, e vientene</l>
             <l>Al Castel, ch'io sarò fra i pizzicagnoli. —</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>Dunque, fa' come t'ha detto, che rompere</l>
             <l part="I">Ti possi 'l collo!</l>
           </sp>
-          <sp>
+          <sp who="#pistone">
             <speaker>PISTONE:</speaker>
             <l part="F">Io mel ruppi il medesimo</l>
             <l part="I">Giorno ch'io venni a star con voi.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Se prendere</l>
             <l part="I">Mi fai due braccia d'un querciuol...</l>
           </sp>
-          <sp>
+          <sp who="#pistone">
             <speaker>PISTONE:</speaker>
             <l part="F">Che diavolo!</l>
             <l>Non ne saprò uscir io senza cacciarmine</l>
             <l>Voi col baston, come i cani si cacciano?</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>(Non è questo poltron se non superbia.</l>
             <l>Per Dio, per Dio! Deh, che farò? Deh, misero</l>
@@ -2268,90 +2308,90 @@ Flamminia</roleDesc>
         <div type="scene" n="Scena III">
           <head>SCENA III</head>
           <stage>Eurialo, Accursio, Pistone</stage>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="I">Hai tu udito Pistone?</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Così mutolo</l>
             <l>Oggi foss'egli stato, che parlatone</l>
             <l part="I">A voi né ad altri avesse!</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Ve' a che termine</l>
             <l part="I">Noi siàn condotti per tua colpa!</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Fatemi</l>
             <l>Indovin, ch'io farò voi ricco. Avrestelo</l>
             <l part="I">Pensato voi?</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="M">Gli è qui il vecchio.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Sia <foreign xml:lang="lat">in nomine</foreign>
                   </l>
             <l><foreign xml:lang="lat">Domini</foreign>. Che sarà però? Voletevi</l>
             <l part="I">Porre affanno per questo?</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">E di che porlomi</l>
             <l part="I">Debb'io, che monti più?</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Monta più ch'abita</l>
             <l>A piè de l'alpi, il falcon monta e l'aquila;</l>
             <l>Monta altrimente 'l gallo e i frati 'n pergamo,</l>
             <l>E molte volte altrove, pur che possano.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>Che monta e monta! Già tanto non montano</l>
             <l>Le ciance tue, che montino un pel d'asino.</l>
             <l part="I">Mio patre è in questa terra.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">(In terra foss'egli</l>
             <l>Pur da dover, com'è suo patre e l'avolo!)</l>
             <l part="I">Che volete voi dir per questo?</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Voglioti</l>
             <l>Dir che tu non ti pensi fargli credere,</l>
             <l part="I">Com'hai fatto a Piston.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Se sarà incredulo,</l>
             <l>Vorrò che se n'andiàn a San Domenico.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="I">Che vi faremo?</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Gli faren procedere</l>
             <l>Contra, come a infedele e come a eretico,</l>
             <l part="I">Dal patre inquisitor.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Va', tu m'infracidi</l>
             <l>Con queste tue sciocchezze. Per Dio, lasciale</l>
             <l part="I">Da parte e attendi a questo.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Per Dio, datevi</l>
             <l>Buon tempo, e la fatica e tutto 'l carico</l>
@@ -2365,12 +2405,12 @@ Flamminia</roleDesc>
             <l>Lui quel fattor che dee condurle a Padova;</l>
             <l>Che già abbiàn detto in casa ch'elle aspettano.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>E chi avren noi che faccia quest'ufficio</l>
             <l part="I">E non sia connosciuto?</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Per Dio, mancano</l>
             <l>la questa terra i barattieri, voglili</l>
@@ -2383,11 +2423,11 @@ Flamminia</roleDesc>
             <l>Per quattro o cinque giorni, dove ascondere,</l>
             <l>Fin che sia il vecchio partito, si possano.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="I">Ma ecco che Piston vien fuor.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Portatoci</l>
             <l>Foss'egli co' piè inanzi! Deh, mandatemi</l>
@@ -2400,7 +2440,7 @@ Flamminia</roleDesc>
             <l>In che elle sono, se non si governano</l>
             <l part="I">Bene.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Io 'l farò — Piston voglio ch'Accursio</l>
             <l>Venghi teco. Ma tu non odi? Guardati</l>
@@ -2409,24 +2449,24 @@ Flamminia</roleDesc>
             <l>Piacer e gaudio; se non ti certifico</l>
             <l>Ch'io ti farò del tuo error riconnoscere.</l>
           </sp>
-          <sp>
+          <sp who="#pistone">
             <speaker>PISTONE:</speaker>
             <l>Non son stato a quest'ora a riconnoscermi</l>
             <l>Et a saper che quest'e peggio merita</l>
             <l>Chi cerca altrui servir, e può star libero.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l>Deh, lascial dir come vuol; non ti mettere</l>
             <l>A garrir seco: gli è padron, gli è giovane,</l>
             <l part="I">Gli ha buon tempo.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">(Io vuo' prima a messer Claudio</l>
             <l part="I">Parlar, ch'io torni in casa.)</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">È intrato in còlera</l>
             <l>Col padre alquanto, e pur dianzi dicevami,</l>
@@ -2437,20 +2477,20 @@ Flamminia</roleDesc>
             <l>Ch'egli torni per questo, che mi reputa</l>
             <l>Un uom ben grosso e ben privo d'industria...</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>(Meglio è chiamarlo, e far che con noi disini...)</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l>...Poi che non si è fidato di commettere</l>
             <l>Alla mia discrezion cosa sì picciola. —</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>(...E ch'egli sganni se stesso, veggendole.)</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l>Egli avrebbe voluto questa gloria.</l>
             <l>Tutta per sé: che referito avessero</l>
@@ -2459,33 +2499,33 @@ Flamminia</roleDesc>
             <l>Suo patre... Tu m'intendi. Venir sogliono</l>
             <l>Simil pensieri in li animi dei giovani.</l>
           </sp>
-          <sp>
+          <sp who="#pistone">
             <speaker>PISTONE:</speaker>
             <l>E che colpa n'ho io, che s'abbia a movere</l>
             <l part="I">Incontra me tant'aspramente?</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Lasciala.</l>
             <l>(Ma chi è colui che vien in qua? Dio, aiutaci!</l>
             <l part="I">Mi par un servitor.)</l>
           </sp>
-          <sp>
+          <sp who="#pistone">
             <speaker>PISTONE:</speaker>
             <l part="F">C'hai tu, che tutto ti</l>
             <l part="I">Sei cambiato nel viso?</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">(È 'l Riccio.) Vatene,</l>
             <l>Piston, pur senza me. Mi bisogna essere</l>
             <l part="I">Un poco a casa.</l>
           </sp>
-          <sp>
+          <sp who="#pistone">
             <speaker>PISTONE:</speaker>
             <l part="M">A Dio.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Gli è desso. Debbelo</l>
             <l>Aver mandato dietro a queste femine</l>
@@ -2493,7 +2533,7 @@ Flamminia</roleDesc>
             <l>A me. Vedete colui? Connoscetelo</l>
             <l part="I">Voi?</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Sì, per Dio! Gli è 'l Riccio! Ohimè, ohimè misero!</l>
             <l>Gli è desso. Ora le cose in più pericolo</l>
@@ -2503,57 +2543,57 @@ Flamminia</roleDesc>
         <div type="scene" n="Scena IV">
           <head>SCENA IV</head>
           <stage>Riccio staffiere, Accursio, Eurialo</stage>
-          <sp>
+          <sp who="#riccio">
             <speaker>RICCIO:</speaker>
             <l>(So ch'io non erro; questa è senza dubbio</l>
             <l>La strada. Ma la casa dov'egli abita</l>
             <l part="I">Io non so già qual sia...)</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Noi cerca, uditelo.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="I">L'odo, e m'incresce udir.</l>
           </sp>
-          <sp>
+          <sp who="#riccio">
             <speaker>RICCIO:</speaker>
             <l part="F">(...se questi giovani</l>
             <l>Non me la mostran. Ma quelli mi paiono</l>
             <l>Ch'io cerco; a punto son dessi.) A Dio, giovani</l>
             <l part="I">Da bene; Dio vi guardi.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Da ben guardi te</l>
             <l part="I">Dio pure e noi da male.</l>
           </sp>
-          <sp>
+          <sp who="#riccio">
             <speaker>RICCIO:</speaker>
             <l part="F">Tu, al contrario</l>
             <l>De l'intenzion, il mio parlar interpreti.</l>
             <l>Ma dimmi un poco, Accursio, ch'a te volgere</l>
             <l part="I">Mi voglio prima...</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">A me già non ti volgere;</l>
             <l>Volgeti a questi umanisti che cercano</l>
             <l>Medaglie, e di rovesci si dilettano.</l>
           </sp>
-          <sp>
+          <sp who="#riccio">
             <speaker>RICCIO:</speaker>
             <l>Pon da parte le ciance. Ti par ch'opera</l>
             <l>Lodevole sia stata il far ingiuria</l>
             <l part="I">Alla padrona mia?</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Dove le ho ingiuria</l>
             <l part="I">Fatto io?</l>
           </sp>
-          <sp>
+          <sp who="#riccio">
             <speaker>RICCIO:</speaker>
             <l part="F">Non lo sai tu? Torle una giovane</l>
             <l>Di casa a questo modo, che da picciola</l>
@@ -2561,11 +2601,11 @@ Flamminia</roleDesc>
             <l>Tu l'hai fatta fuggire; tu menatala</l>
             <l part="I">Hai qui teco.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="M">Io?</l>
           </sp>
-          <sp>
+          <sp who="#riccio">
             <speaker>RICCIO:</speaker>
             <l part="F">Tu sì. Deh, non ti fingere</l>
             <l>Così maraviglioso, c'ho chiarissima</l>
@@ -2573,24 +2613,24 @@ Flamminia</roleDesc>
             <l>So come tuo padron, messer Eurialo,</l>
             <l part="I">Che vuo' che m'oda...</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Riccio, non mi mettere</l>
             <l part="I">In questa trama.</l>
           </sp>
-          <sp>
+          <sp who="#riccio">
             <speaker>RICCIO:</speaker>
             <l part="F">...ti lasciò, partendosi</l>
             <l part="I">Lui, per questo in Pavia.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Quando colpevole</l>
             <l>Ben ogni altro ne fosse, innocentissimo</l>
             <l>Ne son io, e credo ch'innocente Accursio</l>
             <l part="I">Ne sia non meno.</l>
           </sp>
-          <sp>
+          <sp who="#riccio">
             <speaker>RICCIO:</speaker>
             <l part="F">A voi vorrò rispondere</l>
             <l>Più ad agio. Or parlo con costui. So, dicoti,</l>
@@ -2602,23 +2642,23 @@ Flamminia</roleDesc>
             <l>Tu quindi, et in Ferrara tu conduttele</l>
             <l part="I">Hai.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Se tu così ben come epiloghi</l>
             <l>Facessi il resto, orator saresti ottimo.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="I">Non si trovarà mai...</l>
           </sp>
-          <sp>
+          <sp who="#riccio">
             <speaker>RICCIO:</speaker>
             <l part="F">Non puoi negarlomi;</l>
             <l>Ch'io son stato alla nave che condottivi,</l>
             <l>Ha in questa terra, et il nocchier narratomi</l>
             <l part="I">Ha 'l tutto.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">È ver ch'a Piacenza ci entrarono</l>
             <l>Due donne in nave, una vecchia e una giovane,</l>
@@ -2628,17 +2668,17 @@ Flamminia</roleDesc>
             <l>Di farsi poi condurre a Roma. Rendite</l>
             <l>Certo che non son quelle che tu imagini.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>Per Dio, 'l nocchier dicea di queste! Toltele</l>
             <l part="I">Tu in cambio hai di quest'altre.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Non pote essere</l>
             <l part="I">Altrimente.</l>
           </sp>
-          <sp>
+          <sp who="#riccio">
             <speaker>RICCIO:</speaker>
             <l part="F">Fingetela e acconciatela</l>
             <l>Come meglio vi pare: a me sta credere</l>
@@ -2648,7 +2688,7 @@ Flamminia</roleDesc>
             <l>Che s'in Ferrara saran queste femine,</l>
             <l>Non avrete possanza di nasconderle.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l>Non sono quelle che ti pensi. Vengono</l>
             <l>Queste due da Turin: se 'l ver mi dicono,</l>
@@ -2658,7 +2698,7 @@ Flamminia</roleDesc>
             <l>Che 'l sangue de li Apostoli e de' Martiri</l>
             <l>È molto dolce, e a lor spese è un bel vivere.</l>
           </sp>
-          <sp>
+          <sp who="#riccio">
             <speaker>RICCIO:</speaker>
             <l>Non mi tôr con tue ciance di proposito</l>
             <l>Queste ch'io cerco son qui, e troverannosi,</l>
@@ -2667,50 +2707,50 @@ Flamminia</roleDesc>
             <l>Mi ha pregato ch'io non dia queste lettere</l>
             <l part="I">Fin ch'egli non sia qui...</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Vien messer Lazzaro</l>
             <l part="I">In questa terra?</l>
           </sp>
-          <sp>
+          <sp who="#riccio">
             <speaker>RICCIO:</speaker>
             <l part="F">...a quest' ora a pentirvene</l>
             <l part="I">Stati, per Dio, non sareste!</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Rispondimi:</l>
             <l part="I">Vien messer Lazzar?</l>
           </sp>
-          <sp>
+          <sp who="#riccio">
             <speaker>RICCIO:</speaker>
             <l part="F">Non può star a giungere</l>
             <l part="I">Molto.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="M">(Stiàn freschi!) Ove l'hai visto?</l>
           </sp>
-          <sp>
+          <sp who="#riccio">
             <speaker>RICCIO:</speaker>
             <l part="F">A Sermide.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l>Io 'l lasciai pur, ch'in un giorno medesimo</l>
             <l>Da Pavia ci partimmo, ch'aveva animo</l>
             <l part="I">Di non venir a Ferrara.</l>
           </sp>
-          <sp>
+          <sp who="#riccio">
             <speaker>RICCIO:</speaker>
             <l part="F">Si mutano</l>
             <l>Facilmente le volontà degli uomini.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>(Mira se la Fortuna mi perseguita!)</l>
           </sp>
-          <sp>
+          <sp who="#riccio">
             <speaker>RICCIO:</speaker>
             <l>Ben ir volea per l'altro Po, ma, avendoli</l>
             <l>Detta la causa del venir mio, fecilo</l>
@@ -2718,22 +2758,22 @@ Flamminia</roleDesc>
             <l>In un burchiello, egli e la moglie, insieme la</l>
             <l part="I">Figliuola e, credo, una fantesca...</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">(Ah misero</l>
             <l part="I">Me, destinato alle disgrazie!)</l>
           </sp>
-          <sp>
+          <sp who="#riccio">
             <speaker>RICCIO:</speaker>
             <l part="F">...e manda li</l>
             <l>Altri, col burchio di sue robe carico,</l>
             <l>A Francolin, dove vuol che l'aspettino.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="I">Messer Lazzar vien qui?</l>
           </sp>
-          <sp>
+          <sp who="#riccio">
             <speaker>RICCIO:</speaker>
             <l part="F">Vuoi ch'io tel replichi</l>
             <l>Più? Dicovi che viene, e dovrebb'essere</l>
@@ -2742,12 +2782,12 @@ Flamminia</roleDesc>
             <l>Voler venir, per far che senza strepito</l>
             <l>Tra voi e me le cose s'adattassino.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l>S'adattaran facilmente, chiarendoti</l>
             <l>Che di cotesto noi non siàn colpevoli.</l>
           </sp>
-          <sp>
+          <sp who="#riccio">
             <speaker>RICCIO:</speaker>
             <l>Pensa pur altro, e credi che pochissimo</l>
             <l>Meco il dissimular vi giovi e 'l fingere.</l>
@@ -2761,7 +2801,7 @@ Flamminia</roleDesc>
             <l>Con essovoi. Vi do da pensar termine</l>
             <l part="I">Tutt'oggi. A Dio.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Va', alla buon'ora. Pongati</l>
             <l>Dio 'l vero in mente e ti faccia connoscere</l>
@@ -2771,15 +2811,15 @@ Flamminia</roleDesc>
         <div type="scene" n="Scena V">
           <head>SCENA V</head>
           <stage>Eurialo, Accursio</stage>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>Or siàn usciti pur fuor di pericolo</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="I">Usciti? E come?</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Non c'è più pericolo.</l>
             <l>Pericolo si chiama ove sta l'animo,</l>
@@ -2788,20 +2828,20 @@ Flamminia</roleDesc>
             <l>Danno; quest'è rovina inevitabile.</l>
             <l part="I">Ohimè, io son morto.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">I morti non favellano...</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="I">Aiutami, per Dio.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">...né dar rimedio</l>
             <l part="I">Né aiuto si può a' morti.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Or apparecchiami</l>
             <l>Dunque il sepolcro, e prima in terra ascondimi</l>
@@ -2811,7 +2851,7 @@ Flamminia</roleDesc>
             <l>Che cacciato mi sia di casa Ippolita,</l>
             <l>A guisa d'una fante infame e publica.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l>Se vorrete lasciar voi stesso perdere</l>
             <l>Vilmente, siate certo ch'anco lppolita</l>
@@ -2819,13 +2859,13 @@ Flamminia</roleDesc>
             <l>Porrete e piedi e mano e senno in opera,</l>
             <l part="I">Salvarete amendue.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">C'ho a far? Insegnami,</l>
             <l>Ch'io per me mi ritrovo in modo attonito,</l>
             <l part="I">Che non so dove io sia.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Mi par che sùbito</l>
             <l>Si dica a messer Claudio e a Bonifazio</l>
@@ -2844,24 +2884,24 @@ Flamminia</roleDesc>
             <l>Così gli avamo, acciò fosse solecito</l>
             <l>E diligente più che non è solito.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>Mi piace 'l tuo parer. Or presto facciasi</l>
             <l>L'effetto. Torna tu in casa et avisale.</l>
             <l part="I">Io parlarò a questi altri.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Ma vedetelo!</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>Mio padre? Ohimè, gli è desso! Avremo in aria</l>
             <l>Fatto il castel! Non possiàn più difenderci,</l>
             <l>Ch'al suo apparir tutt'i ripari cascano.</l>
             <l part="I">Accursio, io son ben morto.</l>
           </sp>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l part="F">Gli è meglio essere</l>
             <l>Ben morto che mal vivo. Or raccoglietevi</l>
@@ -2882,7 +2922,7 @@ Flamminia</roleDesc>
         <div type="scene" n="Scena VI">
           <head>SCENA VI</head>
           <stage>Frate predicatore, Bartolo</stage>
-          <sp>
+          <sp who="#frate">
             <speaker>FRATE:</speaker>
             <l>Voi potete veder la bolla e leggere</l>
             <l>Le facultadi mie che sono amplissime,</l>
@@ -2898,7 +2938,7 @@ Flamminia</roleDesc>
             <l>Oltra diversi infiniti pericoli</l>
             <l>Che ponno a chi va per camino occorrere.</l>
           </sp>
-          <sp>
+          <sp who="#bartolo">
             <speaker>BARTOLO:</speaker>
             <l>Se ben agli altri, padre venerabile,</l>
             <l>Dico ch'io vo per voto, <foreign xml:lang="lat">nihilominus</foreign>
@@ -2914,11 +2954,11 @@ Flamminia</roleDesc>
             <l>Modo ci fia. Ma quel ch'io dico, dicolo</l>
             <l part="I">In confessione.</l>
           </sp>
-          <sp>
+          <sp who="#frate">
             <speaker>FRATE:</speaker>
             <l part="F">E in confessione tolgolo.</l>
           </sp>
-          <sp>
+          <sp who="#bartolo">
             <speaker>BARTOLO:</speaker>
             <l>Altro non è ch'el sappia, eccettuandone</l>
             <l>Solo il nostro piovan, che la quaresima</l>
@@ -2926,14 +2966,14 @@ Flamminia</roleDesc>
             <l>Questo caso, che, come voi, teologo</l>
             <l>Non è: sa un poco di ragion canonica.</l>
           </sp>
-          <sp>
+          <sp who="#frate">
             <speaker>FRATE:</speaker>
             <l>Io v'offerisco, quanto si può estendere</l>
             <l>Il saper mio, di darvi quel medesimo</l>
             <l>Consiglio che per me mi torrei. Ditemi</l>
             <l part="I">Il caso vostro.</l>
           </sp>
-          <sp>
+          <sp who="#bartolo">
             <speaker>BARTOLO:</speaker>
             <l part="F">Io vel dirò. Già passano</l>
             <l>Venti anni che in Milan stavo al stipendio</l>
@@ -2966,13 +3006,13 @@ Flamminia</roleDesc>
             <l>Scrittura alcuna farne, ma rimettersi</l>
             <l part="I">A me del tutto.</l>
           </sp>
-          <sp>
+          <sp who="#frate">
             <speaker>FRATE:</speaker>
             <l part="F">La promessa semplice</l>
             <l>D'un amico fedel purtroppo è valida</l>
             <l>Senza giurar o testimonii o rogiti.</l>
           </sp>
-          <sp>
+          <sp who="#bartolo">
             <speaker>BARTOLO:</speaker>
             <l>Tornò il Duca in Milan, come debb'esservi</l>
             <l>Noto, e poco vi ste', che li medesimi</l>
@@ -2984,7 +3024,7 @@ Flamminia</roleDesc>
             <l>Era piaciuta a un signor che dicevano</l>
             <l part="I">Esser napolitano.</l>
           </sp>
-          <sp>
+          <sp who="#frate">
             <speaker>FRATE:</speaker>
             <l part="F">È verisimile</l>
             <l>Che signor fosse, poi ch'era da Napoli,</l>
@@ -2992,7 +3032,7 @@ Flamminia</roleDesc>
             <l>Che a Ferrara de conti; e credo ch'abbiano</l>
             <l>Come questi contato, quei dominio.</l>
           </sp>
-          <sp>
+          <sp who="#bartolo">
             <speaker>BARTOLO:</speaker>
             <l>Questo napolitan, signor o suddito</l>
             <l>Che fosse, se l'avea tolta, e condottala</l>
@@ -3019,22 +3059,22 @@ Flamminia</roleDesc>
             <l>O seco o pur con altri; e, ritrovandole,</l>
             <l>Far quel che già molti anni era mio debito.</l>
           </sp>
-          <sp>
+          <sp who="#frate">
             <speaker>FRATE:</speaker>
             <l>Questa fatica volontier, potendola</l>
             <l part="I">Schifar, voi schifareste?</l>
           </sp>
-          <sp>
+          <sp who="#bartolo">
             <speaker>BARTOLO:</speaker>
             <l part="F">Chi ne dubita?</l>
           </sp>
-          <sp>
+          <sp who="#frate">
             <speaker>FRATE:</speaker>
             <l>Ben si potrà commutar in qualch'opera</l>
             <l>Pia. Non si trova al mondo sì fort'obligo</l>
             <l>Che non si possa sciôr con l'elemosina.</l>
           </sp>
-          <sp>
+          <sp who="#bartolo">
             <speaker>BARTOLO:</speaker>
             <l>Andiamo in casa e più ad agio parliamone.</l>
           </sp>
@@ -3045,7 +3085,7 @@ Flamminia</roleDesc>
         <div type="scene" n="Scena I">
           <head>SCENA I</head>
           <stage>Bonifazio, Eurialo</stage>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>Va' ratto, che sii là prima che giungano,</l>
             <l>E ch'altra guida piglino; e ricordati</l>
@@ -3069,31 +3109,31 @@ Flamminia</roleDesc>
             <l>Per l'ottav'opra di misericordia.</l>
             <l part="I">Ma ecco Eurialo a tempo.)</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Bonifazio,</l>
             <l part="I">Havvi parlato Accursio?</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="M">Sì.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">E narratovi</l>
             <l>Ov'io mi trovo per voler attendere</l>
             <l part="I">Al suo consiglio?</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Ogni cosa per ordine</l>
             <l part="I">M'ha detto.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="M">Che vi par?</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Fu temerario</l>
             <l>Consiglio il suo, ogni modo; pur rimedio</l>
@@ -3101,7 +3141,7 @@ Flamminia</roleDesc>
             <l>Si può in tal caso, e spero che succedere</l>
             <l part="I">Debbia.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">V'avrei speranza anch'io, se spingere</l>
             <l>Io potessi di casa, pur il spazio</l>
@@ -3114,12 +3154,12 @@ Flamminia</roleDesc>
             <l>In che serrate queste donne fingono</l>
             <l part="I">Di dormir.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Non v'accade di nasconderle.</l>
             <l part="I">Lasciate pur</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Non so dove mi volgere,</l>
             <l>Se non a voi. Così a voi, da principio</l>
@@ -3129,46 +3169,46 @@ Flamminia</roleDesc>
             <l>La moglie e la figliuola vegga giungere.</l>
             <l part="I">Io me vi raccomando.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Avete dubbio</l>
             <l>Che noi vi abbandoniàn, messer Eurialo?</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>Per bontà e cortesia vostra, aiutatemi,</l>
             <l>Ch'in più travaglio, in più affanno, in più angustia</l>
             <l>Mi trovo in che mai si trovasse misero.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>Io non vi mancherò, fate buon animo.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>Levatelo di casa un poco, e ditegli</l>
             <l>Che vi bisogna in Piazza la sua opera.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="I">E di ch'opra ho bisogno io?</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Fingetela:</l>
             <l>Che qualche vostra causa ai segretarii</l>
             <l part="I">O al Podestà raccomandi.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Io non litigo.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>Di qualch'amico vostro imaginatevi</l>
             <l part="I">Qualche facenda.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Quest'è troppo incommoda</l>
             <l>Ora di tuor di casa un suo par: debbono</l>
@@ -3179,13 +3219,13 @@ Flamminia</roleDesc>
             <l>Ben sarà luogo ove quest'altre alloggino</l>
             <l>Con lor commoditade, senza strepito.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>Come? Volete voi che messer Lazzaro</l>
             <l>Con le sue venga, e che queste altre femine</l>
             <l part="I">Ci trovi in casa?</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Non cotesto. Statime</l>
             <l>Un poco a udir. Mandat'ho inanzi Accursio</l>
@@ -3194,11 +3234,11 @@ Flamminia</roleDesc>
             <l>Qui in casa mia. Io sarò qui a ricevergli,</l>
             <l>E voi meco, e diremo ch'io sia Bartolo.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="I">Che voi siate mio padre?</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Sì; e confannosi</l>
             <l>L'etadi, che sarà ben verisimile.</l>
@@ -3209,12 +3249,12 @@ Flamminia</roleDesc>
             <l>Che con Bartolo alloggi sarà facile.</l>
             <l part="I">Che ve ne par?</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F"><foreign xml:lang="lat">Est generis promiscui</foreign>:</l>
             <l part="I">Esser può ben e mal.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Non c'è pericolo.</l>
             <l>Voi verso me farete i convenevoli</l>
@@ -3223,12 +3263,12 @@ Flamminia</roleDesc>
             <l>Non meno in questa casa che se fossino</l>
             <l part="I">In casa vostra.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Il veder messer Claudio</l>
             <l part="I">Non piacerà al dottor.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Stia messer Claudio</l>
             <l>Occulto intanto; poi, come succedere</l>
@@ -3245,24 +3285,24 @@ Flamminia</roleDesc>
             <l>In modo ancora, che prima che partano</l>
             <l>Di casa mia farò un suocero e un genero.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>Io non so che mi dica: ponno occorrere</l>
             <l>Molti disturbi che il disegno guastino.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>E che volete ch'occorra? Proveggasi</l>
             <l>Che non vi venga la ruina a opprimere.</l>
             <l>Non vedete voi come vi si approssima?</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>Io la veggo purtroppo e, non essendoci</l>
             <l>Miglior riparo, è forza a quest'apprendermi;</l>
             <l>E sia come si voglia, o forte o debole.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>Gli è forte più che marmo: riposatevi</l>
             <l>Pur sopra lui. Ma mi parria a proposito</l>
@@ -3270,25 +3310,25 @@ Flamminia</roleDesc>
             <l>Lor, voi gli raccogliessi e accompagnassili</l>
             <l part="I">Qui dentro.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Sto in gran dubbio che, se restano</l>
             <l>Senza me in casa quest'altre, non facciano</l>
             <l>O dican qualche cosa onde si scoprano.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>E che ponno elle o dir o fare, avendole</l>
             <l>Voi già avisate? Ma vedete Accursio</l>
             <l part="I">Ch'a noi torna.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Ohimè, quest'è messer Lazzaro,</l>
             <l>La moglie e tutta la brigata! Domine,</l>
             <l part="I">Aiutami, ch'io tremo!</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Ah pusilanime!</l>
             <l>Voi siete divenuto così pallido?</l>
@@ -3296,18 +3336,18 @@ Flamminia</roleDesc>
             <l>Con altro volto; cotesto più idoneo</l>
             <l>Saria dar lor combiato che riceverli.</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l>Oh, se mio patre, ohimè, venisse a mettere</l>
             <l part="I">In questo tempo il capo fuor!</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Che diavolo</l>
             <l>Potria saper che fossin, non avendoli</l>
             <l part="I">Mai più veduti?</l>
           </sp>
-          <sp>
+          <sp who="#eurialo">
             <speaker>EURIALO:</speaker>
             <l part="F">Facciàn noi pur ch'entrino.</l>
           </sp>
@@ -3315,27 +3355,27 @@ Flamminia</roleDesc>
         <div type="scene" n="Scena II">
           <head>SCENA II</head>
           <stage>Messer Lazzaro, Bonifazio</stage>
-          <sp>
+          <sp who="#messer_lazzaro">
             <speaker>MESSER LAZZARO:</speaker>
             <l>(Io veggo a noi venir messer Eurialo.</l>
             <l>Quel che gli è inanzi suo patre dev'essere.)</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>Ben venga messer Lazzaro, e ben vengano</l>
             <l part="I">Queste madonne.</l>
           </sp>
-          <sp>
+          <sp who="#messer_lazzaro">
             <speaker>MESSER LAZZARO:</speaker>
             <l part="F">E voi, che messer Bartolo</l>
             <l part="I">Credo siate...</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Son Bartolo, a servizio</l>
             <l part="I">Vostro.</l>
           </sp>
-          <sp>
+          <sp who="#messer_lazzaro">
             <speaker>MESSER LAZZARO:</speaker>
             <l part="F">...siate per cento e cento milia</l>
             <l>Volte il ben ritrovato. Oh mio discepolo!</l>
@@ -3343,7 +3383,7 @@ Flamminia</roleDesc>
             <l>Come vostro figliuol. Si potria credere</l>
             <l part="I">Che vi fosse fratello.</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l part="F">Il non mi mettere</l>
             <l>Molti affanni e fuggir tutti li incommodi</l>
@@ -3357,11 +3397,11 @@ Flamminia</roleDesc>
             <l>Vostri fan vostra con l'aver, con gli uomini,</l>
             <l>Con ciò che siamo o che siàn mai per essere.</l>
           </sp>
-          <sp>
+          <sp who="#messer_lazzaro">
             <speaker>MESSER LAZZARO:</speaker>
             <l>La vostra umanitade, messer Bartolo...</l>
           </sp>
-          <sp>
+          <sp who="#bonifazio">
             <speaker>BONIFAZIO:</speaker>
             <l>Deh, non moltiplichiamo in cerimonie:</l>
             <l>O poniànle da parte o diferiamole</l>
@@ -3371,7 +3411,7 @@ Flamminia</roleDesc>
         <div type="scene" n="Scena III">
           <head>SCENA III</head>
           <stage>Accursio</stage>
-          <sp>
+          <sp who="#accursio">
             <speaker>ACCURSIO:</speaker>
             <l>A punto siàn come gli augei che cascano</l>
             <l>Ne la rete, che quanto si dibattono</l>
@@ -3420,7 +3460,7 @@ Flamminia</roleDesc>
         <div type="scene" n="Scena IV">
           <head>SCENA IV</head>
           <stage>Frate, Bartolo, Accursio</stage>
-          <sp>
+          <sp who="#frate">
             <speaker>FRATE:</speaker>
             <l part="F">Portaròlavi,</l>
             <l>E ve la lasciarò veder e leggere.</l>
@@ -3429,14 +3469,14 @@ Flamminia</roleDesc>
             <l>Meco, vi posso interamente assolvere,</l>
             <l>Non meno che potria 'l papa medesimo.</l>
           </sp>
-          <sp>
+          <sp who="#bartolo">
             <speaker>BARTOLO:</speaker>
             <l>Vi credo; nondimeno, per discarico</l>
             <l>De la mia conscïenza, la desidero</l>
             <l>Vedere, e far anco vedere e leggere</l>
             <l part="I">Al mio parrochiano.</l>
           </sp>
-          <sp>
+          <sp who="#frate">
             <speaker>FRATE:</speaker>
             <l part="F">
               <foreign xml:lang="lat">Sit in nomine</foreign>
@@ -3445,7 +3485,7 @@ Flamminia</roleDesc>
             <l>A chi vi pare. Intanto, messer, Domene–</l>
             <l part="I">dio sia con voi.</l>
           </sp>
-          <sp>
+          <sp who="#bartolo">
             <speaker>BARTOLO:</speaker>
             <l part="F">E con voi, padre, simile–</l>
             <l>mente. Ma ecco Accursio.</l>

--- a/tei/ariosto-i-suppositi-red-in-versi.xml
+++ b/tei/ariosto-i-suppositi-red-in-versi.xml
@@ -75,6 +75,61 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="balia">
+            <persName>Balia</persName>
+          </person>
+          <person xml:id="polinesta">
+            <persName>Polinesta</persName>
+          </person>
+          <person xml:id="cleandro">
+            <persName>Cleandro</persName>
+          </person>
+          <person xml:id="pasifilo">
+            <persName>Pasifilo</persName>
+          </person>
+          <person xml:id="dulippo">
+            <persName>Dulippo</persName>
+          </person>
+          <person xml:id="caprino">
+            <persName>Caprino</persName>
+          </person>
+          <person xml:id="erostrato">
+            <persName>Erostrato</persName>
+          </person>
+          <person xml:id="senese">
+            <persName>Senese</persName>
+          </person>
+          <person xml:id="servo">
+            <persName>Servo del Senese</persName>
+          </person>
+          <person xml:id="carione">
+            <persName>Carione</persName>
+          </person>
+          <person xml:id="dalio">
+            <persName>Dalio</persName>
+          </person>
+          <person xml:id="damonio">
+            <persName>Damonio</persName>
+          </person>
+          <person xml:id="nevola">
+            <persName>Nevola</persName>
+          </person>
+          <person xml:id="psiteria">
+            <persName>Psiteria</persName>
+          </person>
+          <person xml:id="filogono">
+            <persName>Filogono</persName>
+          </person>
+          <person xml:id="ferrarese">
+            <persName>ferrarese</persName>
+          </person>
+          <person xml:id="lizio">
+            <persName>Lizio</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>2007-06-08T00:00:00.000+02:00</date><name>Novadata systems</name>Digitalizzazione - OCR</change>
@@ -211,7 +266,7 @@
         <div type="scene" n="Scena I">
           <head>SCENA I</head>
           <stage>Balia, Polinesta</stage>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l>Non ci veggo persona, sì che vientene</l>
             <l>Pur qui fuor, Polinesta, e riguardiamoci</l>
@@ -220,35 +275,35 @@
             <l>Qui dentro orecchie le panche, le tavole,</l>
             <l part="I">Le casse e i letti.</l>
           </sp>
-          <sp>
+          <sp who="#polinesta">
             <speaker>POLINESTA:</speaker>
             <l part="F">Vi dovreste aggiungere</l>
             <l>L'urne, i tegami, i boccali e le pentole,</l>
             <l>Che l'hanno similmente, e più lor paiono.</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l>Tu pur motteggi? In fé di Dio, sarebbeti</l>
             <l>Meglio non esser così pazza; e credemi,</l>
             <l>Io te l'ho detto mille volte, guardati</l>
             <l>Di parlar con Dulippo che ti vegghino.</l>
           </sp>
-          <sp>
+          <sp who="#polinesta">
             <speaker>POLINESTA:</speaker>
             <l>E perché non volete che mi vegghino,</l>
             <l part="I">Se mi veggon parlar con gli altri?</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l part="F">Or séguita</l>
             <l>Pur a tuo modo, e per tua trascuraggine</l>
             <l>E me e Dulippo e te stessa precipita.</l>
           </sp>
-          <sp>
+          <sp who="#polinesta">
             <speaker>POLINESTA:</speaker>
             <l>Ma sì, per Dio, ci è bene un gran pericolo!</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l>Tu te ne avederai. Ti dovrebbe essere</l>
             <l>Pur a bastanza ch'ogni notte, e tacita–</l>
@@ -262,7 +317,7 @@
             <l>Famiglio di tuo padre da chi attendere</l>
             <l>Non ne puoi altro che vergogna e biasimo.</l>
           </sp>
-          <sp>
+          <sp who="#polinesta">
             <speaker>POLINESTA:</speaker>
             <l>E chi n'è, se non voi, stata principio?</l>
             <l>Che continuamente voi lodandomi,</l>
@@ -273,22 +328,22 @@
             <l>Né mai cessaste, finché nel medesimo</l>
             <l>Desiderio con lui mi vedeste ardere.</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l>Non ti voglio negar che da principio</l>
             <l>Io non te ne parlassi, per grandissima</l>
             <l>Compassion ch'io gli avevo, e per continue</l>
             <l part="I">Preci che mi faceva.</l>
           </sp>
-          <sp>
+          <sp who="#polinesta">
             <speaker>POLINESTA:</speaker>
             <l part="F">Anzi pur, balia,</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l>Perché n'avate pensïone e prezio.</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l>Creder tu puoi ciò che ti par; ma rendeti</l>
             <l>Certa, che s'io pensavo che procedere</l>
@@ -297,19 +352,19 @@
             <l>Sufficïenti per fartene muovere</l>
             <l part="I">Da me parola.</l>
           </sp>
-          <sp>
+          <sp who="#polinesta">
             <speaker>POLINESTA:</speaker>
             <l part="F">Chi 'l menò alla camera,</l>
             <l>E poi nel letto mio, se non la balia?</l>
             <l>Per vostra fé, non mi fate trascorrere</l>
             <l part="I">A dir qualche pazzia.</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l part="F">Sarò principio</l>
             <l part="I">Stata io di tutto il male!</l>
           </sp>
-          <sp>
+          <sp who="#polinesta">
             <speaker>POLINESTA:</speaker>
             <l part="F">Anzi principio</l>
             <l>Di tutto il bene; e vi vo' fare intendere</l>
@@ -317,36 +372,36 @@
             <l>In luogo assai più degno e più onorevole</l>
             <l part="I">Che non pensate.</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l part="F">Se gli è vero, allegromi</l>
             <l>Di vederti mutata di proposito</l>
           </sp>
-          <sp>
+          <sp who="#polinesta">
             <speaker>POLINESTA:</speaker>
             <l>Né mutata ne son, né mutar vogliomi.</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l part="I">Che di' tu dunque?</l>
           </sp>
-          <sp>
+          <sp who="#polinesta">
             <speaker>POLINESTA:</speaker>
             <l part="F">Dico che né un povero</l>
             <l>Famiglio, né Dulippo come credere</l>
             <l>Vi veggo, am'io né rintat'ho proposito.</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l>O questo non può stare insieme, o intendere</l>
             <l>Io non ti debbo, sì che meglio esprimelo.</l>
           </sp>
-          <sp>
+          <sp who="#polinesta">
             <speaker>POLINESTA:</speaker>
             <l>Io non vi vo' dir altro, che per obligo</l>
             <l>Di fede son costretta di tacermene.</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l>Resti tu di narrarmelo per dubbio</l>
             <l>Ch'io nol ridica? Tu m'hai consapevole</l>
@@ -357,7 +412,7 @@
             <l>Sia verso l'altren di che secretaria</l>
             <l part="I">Ti son?</l>
           </sp>
-          <sp>
+          <sp who="#polinesta">
             <speaker>POLINESTA:</speaker>
             <l part="F">Più assai che non credete, balia,</l>
             <l>Importa; pur dirolla, promettendomi</l>
@@ -365,12 +420,12 @@
             <l>Darne mai, sì che alcun possa comprendere</l>
             <l part="I">Che lo sappiate.</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l part="F">La mia fede ti obligo</l>
             <l part="I">Di far così.</l>
           </sp>
-          <sp>
+          <sp who="#polinesta">
             <speaker>POLINESTA:</speaker>
             <l part="F">Or udite: questo giovene,</l>
             <l>Il qual Dulippo voi riputate essere,</l>
@@ -379,12 +434,12 @@
             <l>Filogono è suo padre, de' ricchi uomini</l>
             <l>Che sieno in tutto il regno di Sicilia.</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l>Non è Erostrato il figliuol di Filogono,</l>
             <l part="I">Questo nostro vicino, il quale?...</l>
           </sp>
-          <sp>
+          <sp who="#polinesta">
             <speaker>POLINESTA:</speaker>
             <l part="F">Uditemi</l>
             <l>Per vostra fé, e tacete fin ch'io v'esplichi</l>
@@ -405,11 +460,11 @@
             <l>Un pover fante, si cercò di mettere</l>
             <l>Per servitor di mio patre, e successegli.</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l part="I">Questa cosa hai per certa?</l>
           </sp>
-          <sp>
+          <sp who="#polinesta">
             <speaker>POLINESTA:</speaker>
             <l part="F">Per certissima.</l>
             <l>Da l'altra parte Dulippo, facendosi</l>
@@ -420,25 +475,25 @@
             <l>Alle lettere ha dato sì buon'opera,</l>
             <l>Che in esse ha fatto un profitto mirabile.</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l>Non è alcun altro siciliano ch'abiti</l>
             <l>Qui? O non ce ne capita, che gli abbino</l>
             <l part="I">Scoperti?</l>
           </sp>
-          <sp>
+          <sp who="#polinesta">
             <speaker>POLINESTA:</speaker>
             <l part="F">Nessun altro odo che ci abiti,</l>
             <l>E pochi ce ne capitan per transito.</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l>Gran sorte è stata! Ma come si accozzano</l>
             <l>Tal cose insieme? che costui che studia,</l>
             <l>Che vuoi che sia Dúlippo e non Erostrato,</l>
             <l>Ti fa per moglie a tuo padre richiedere?</l>
           </sp>
-          <sp>
+          <sp who="#polinesta">
             <speaker>POLINESTA:</speaker>
             <l>Gli è finzïone che fanno, acciò spingano</l>
             <l>II dottoraccio , il qual con tanta instanzia</l>
@@ -447,7 +502,7 @@
             <l>Io mi farei ben mille volte monaca,</l>
             <l part="I">Più tosto che pigliarlo.</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l part="F">Tu hai grandissima</l>
             <l>Ragion, figliuola mia. Ma ritraiamoci</l>
@@ -457,111 +512,111 @@
         <div type="scene" n="Scena II">
           <head>SCENA II</head>
           <stage>Cleandro dottor vecchio, Pasifilo parasito, Dulippo finto</stage>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Non erano, o mi parve pur che fusseno</l>
             <l part="I">Donne dinanzi a quella porta?</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Aveteci</l>
             <l>Veduto Polinesta e la sua balia.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="I">Polinesta mia v'era?</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Messersì, eravi.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="I">Per Dio, non l'ho conosciuta!</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Miracolo</l>
             <l>Non è, ch'oggi è una grossa e nebbios'aria.</l>
             <l>Né la potevo al viso anch'io comprendere;</l>
             <l>Ma le vesti me l'han fatta conoscere.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Io de la etade mia ho assai, Dio grazia,</l>
             <l>Buona vista, ne molto differenzia</l>
             <l>In me sento da quel che solevo essere</l>
             <l part="I">Di venti anni o di trenta.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Perché credere</l>
             <l>Debb'io altrimenti? Non sète. voi giovene?</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="I">Son ne' cinquanta anni.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">(Più di dodici</l>
             <l part="I">Dice di manco!)</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Che di manco dodici</l>
             <l part="I">Di' tu?</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Che vi estimavo più di dodici</l>
             <l>Anni di manco. Non mostrate all'aria</l>
             <l part="I">Passar trentasette anni.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Sono al termine</l>
             <l part="I">Pur ch'io ti dico.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">La vostra abitudine</l>
             <l>È tal, che vo passerete il centesimo</l>
             <l part="I">Mostratemi la man.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Sei tu, Pasifilo,</l>
             <l part="I">Buon chiromante?</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Io ci ho pur qualche pratica.</l>
             <l part="I">Deh, lasciatemi un po' vedervela.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Eccola.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l>O che bella, che lunga e netta linea!</l>
             <l>Non vidi mai la miglior. Oltra il termine</l>
             <l>Vi veggo di Melchisedech aggiungere</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="I">Matusalem vuoi dir?</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Non è un medesimo?</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>O come sei mal dotto ne la Bibia!</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l>Anzi dotto ci son, ma ne la bibia</l>
             <l>Ch'esce fuor de la botte Ve' béllissimi</l>
@@ -571,7 +626,7 @@
             <l>Ad agio, e farvi alcune cose intendere</l>
             <l part="I">Che non vi spiaceran.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">L'avrò gratissimo:</l>
             <l>Ma dimmi, per tua fé, dimmi, Pasifilo:</l>
@@ -579,7 +634,7 @@
             <l>Si contentasse per marito, avendone</l>
             <l>A pigliar un di noi: di me, o di Erostrato?</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l>Di voi senza alcun dubbio. Ella è magnanima:</l>
             <l>Io so che assai fa più conto del credito</l>
@@ -589,17 +644,17 @@
             <l>Si dica; ma Dio sa chi è ne la patria</l>
             <l part="I">Sua!</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">In questa terra fa molto il magnifico.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l>Sì, dove alcun non gli dice il contrario.</l>
             <l>Ma facci quanto vuol: val la scïenzia</l>
             <l>Vostra più che non val tutta Sicilia.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>L'uom che se stesso loda, si vitupera.</l>
             <l>Pur dir posso con ver che la scïenzia</l>
@@ -613,141 +668,141 @@
             <l>Di venti anni acquistai di più di sedici</l>
             <l>Mila ducati la valuta, e séguito.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l>Queste son vere virtù Che filosofi!</l>
             <l>Che poesie! tutte l'altre scïenzie,</l>
             <l>A paragon de le leggi, mi paiono</l>
             <l part="I">Ciance.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Ben ciance. Onde abbiàn quel notabile</l>
             <l>Verso e così morale: <foreign xml:lang="lat">Opes dat sanctio</foreign>
                   </l>
             <l part="I"><foreign xml:lang="lat">Iustiniana</foreign>.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="M">O come è buono!</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">
               <foreign xml:lang="lat">Ex aliis</foreign>
             </l>
             <l part="I"><foreign xml:lang="lat">Paleas</foreign>...</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="M">Eccellente!</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">...<foreign xml:lang="lat">ex istis collige</foreign>
                   </l>
             <l part="I"><foreign xml:lang="lat">Grana</foreign>.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="M">Chi 'l fe'? Virgilio?</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Che Virgilio!</l>
             <l>Gli è d'una nostra glosa elegantissima.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l>Non udii il miglior mai; si dovria scrivere</l>
             <l>In lettre d'or. Ma torniamo a proposito.</l>
             <l>Dovete ormai aver fatto un peculio</l>
             <l>Maggior di quel che già lasciaste ad Otranto.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Lo credo aver multiplicato in quadruplo;</l>
             <l>Ma un figliolin vi perdei, che m'era unico:</l>
             <l part="I">Avea cinque anni a punto...</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Ah, fu gran perdita!</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>...Che valea più che quanti danar siano</l>
             <l part="I">Al mondo</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="M">Me ne duol.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Non so se 'l misero</l>
             <l>Morisse, o pur li Turchi ancor lo tengano</l>
             <l part="I">In servitù.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Voi mi farete piangere</l>
             <l>De la compassïon. Ma pazïenzia:</l>
             <l>Ne acquistarete ben con questa giovane</l>
             <l part="I">De gli altri.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="M">Sì, s'io l'avrò.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Non c'è dubbio.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>E non ci debbe esser gran dubbio, dandomi</l>
             <l part="I">Il padre queste lunghe?</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Egli desidera</l>
             <l>Di ben locarla, e prima che deliberi,</l>
             <l>Ci vuol pensar; e nel pensar, credetemi</l>
             <l>Che a favor vostro al fin sia per risolversi.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Non gli hai tu detto ch'io vo' di dua milia</l>
             <l part="I">Ducati farli sopradote?</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Dettogli</l>
             <l part="I">L'ho molte volte.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">E che ti sa rispondere?</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l>Non risponde altro, se non che 'l medesimo</l>
             <l part="I">Gli offerisce anco Erostrato.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Può Erostrato</l>
             <l>Far dunque tale offerta? E entrare in obligo</l>
             <l>Alcuno, <foreign xml:lang="lat">cum sit filius familias</foreign>?</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l>Messer Cleandro, io ve l'ho detto, veggolo</l>
             <l>Per noi disposto, e non per l'avversario.</l>
             <l>Or andate, e lasciatene a me il carico.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Or va'. S'io aspetto mai da te, Pasifilo</l>
             <l>Piacere alcuno, va', truova mio suocero,</l>
@@ -759,77 +814,77 @@
             <l>Ch'io so che saprai far. Or va', non perdere</l>
             <l part="I">Tempo.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="M">Ove poi vi troverò?</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Vien sùbito</l>
             <l>A casa mia, ch'avrai disnato. Scusami</l>
             <l>S'io non ti invito, ch'oggi è la vigilia</l>
             <l>D'un santo ch'ebbi sempre in riverenzia.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="I">(Digiuna sì che muoi di fame.)</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Ascoltami.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l>(Parla coi morti, ch'altresì digiunano.)</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="I">Tu non odi?</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="M">(Né tu intendi.)</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Se' in còlera</l>
             <l>Perché non t'ho invitato? Pur, parendoti,</l>
             <l>Ci puoi venire: io ti farò participe</l>
             <l part="I">Di quel, poco ch'avrò.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Credete, domine,</l>
             <l part="I">Che mi manchi ove mangiar?</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Non, Pasifilo,</l>
             <l part="I">Non credo già che ti manchi.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Credetelo,</l>
             <l>E siatene pur certo; me ne pregano</l>
             <l>Matina e sera quanti gentiluomini</l>
             <l part="I">M'incontrano per via.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Ne son certissimo:</l>
             <l>Ma so ben che in nessun luogo puoi essere</l>
             <l>Più volentier veduto, che alla tavola</l>
             <l part="I">Mia.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="M">A Dio, Messer.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="M">A Dio.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">(Guarda avarizia</l>
             <l>D'uomo! Ritrova scusa di vigilia,</l>
@@ -876,77 +931,77 @@
             <l>Se 'l padron c'è.) — Dove va questo giovene</l>
             <l part="I">Galante?</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">A cercar vengo un che desini</l>
             <l>Col mio padrone, il quale è solo a tavola.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l>Non ir più inanzi; ove avrai tu il più idonio?</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l>Non ho commissïone di menargline</l>
             <l part="I">Tanti.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Che tanti? verrò solo: menami</l>
             <l part="I">Solo.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Che sol, che sempre ne lo stomaco</l>
             <l part="I">Hai dieci lupi affamati?</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Ecco il solito</l>
             <l>De' servitori, d'aver sempre in odio</l>
             <l part="I">Gli amici del patron!</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="M">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Perché eglino</l>
             <l part="I">Hanno la bocca e i denti.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Anzi, Pasifilo,</l>
             <l part="I">Perc'hanno lingua.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Ove mai t'ebbe a nuocere</l>
             <l part="I">La lingua mia?</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Scherzo teco, Pasifilo.</l>
             <l>Entra in casa, che bene i denti nuocere</l>
             <l>Molto più che la lingua ti potrebbono.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l>Così per tempo qua dentro si desina?</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l>Chi si lieva per tempo, ancora desina</l>
             <l part="I">Per tempo.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Or volentieri io vorrei vivere</l>
             <l>Con essovoi: al tuo consiglio apprendere</l>
             <l part="I">Mi vo', Dulippo.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Il trovarai, credo, utile.</l>
           </sp>
@@ -954,7 +1009,7 @@
         <div type="scene" n="Scena III">
           <head>SCENA III</head>
           <stage>Dulippo solo</stage>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l>Il mio discorso fu infelice e misero,</l>
             <l>Che alli tormenti miei pensai che attissima</l>
@@ -1016,60 +1071,60 @@
         <div type="scene" n="Scena IV">
           <head>SCENA IV</head>
           <stage>Caprino ragazzo, Dulippo finto</stage>
-          <sp>
+          <sp who="#caprino">
             <speaker>CAPRINO:</speaker>
             <l>Di Erostrato? Dirotelo: di Erostrato</l>
             <l>Son molti libri e molte masserizie,</l>
             <l>E vesti e pannilini e cose simili.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l>Io ti domando che m'insegni Erostrato.</l>
           </sp>
-          <sp>
+          <sp who="#caprino">
             <speaker>CAPRINO:</speaker>
             <l part="I">A compito o a distesa?</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Che se a mettere</l>
             <l>Le man ti vengo ne le orecchie, credi tu</l>
             <l>Ch'io ti farò rispondere a proposito?</l>
           </sp>
-          <sp>
+          <sp who="#caprino">
             <speaker>CAPRINO:</speaker>
             <l part="I">Taruò!</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="M">Aspettami un poco.</l>
           </sp>
-          <sp>
+          <sp who="#caprino">
             <speaker>CAPRINO:</speaker>
             <l part="F">Per Dio, scusami,</l>
             <l part="I">Ch'or non ci ho l'agio.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Giocaremo a correre.</l>
           </sp>
-          <sp>
+          <sp who="#caprino">
             <speaker>CAPRINO:</speaker>
             <l>Tu c'hai più lunghe le gambe, dovevimi</l>
             <l part="I">Dar vantaggio.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Or su, dimmi: che è di Erostrato?</l>
           </sp>
-          <sp>
+          <sp who="#caprino">
             <speaker>CAPRINO:</speaker>
             <l>Io l'ho lasciato in Piazza, ove ricorrere</l>
             <l>M'ha fatto a tôr questo capestro — volsiti</l>
             <l>Dir canestro —; et ha seco Dalio, e dissemi</l>
             <l>Che alla Porta del Duca m'aspettavano.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l>Se tu lo truovi, digli che grandissimo</l>
             <l>Bisogno avrei di parlarli. Deh, aspettami:</l>
@@ -1084,7 +1139,7 @@
         <div type="scene" n="Scena I">
           <head>SCENA I</head>
           <stage>Dulippo finto, Erostrato finto</stage>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l>Io non credo che gli occhi, che si dicono</l>
             <l>D'Argo, a bastanza oggi stati mi fusseno,</l>
@@ -1094,49 +1149,49 @@
             <l>Venuti inanzi, fuor che lui: ma eccolo</l>
             <l part="I">Pur finalmente.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">A tempo, padron, veggovi:</l>
             <l part="I">A punto io vi volea.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Che patron? Chiamami</l>
             <l>Dulippo, se tu m'ami; e serva il credito</l>
             <l part="I">Ch'io t'ho dato col nome.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Ora lasciatemi</l>
             <l>Onorarvi e far parte del mio debito,</l>
             <l part="I">Che non c'è alcun che n'oda.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Il non guardartene</l>
             <l>Sempre ti potria fare errar di facile,</l>
             <l>In luogo ove notati potremo essere.</l>
             <l part="I">Che nuove apporti?</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="M">Buone.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="M">Buone?</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Anzi ottime.</l>
             <l part="I">Abbiàn vinto il partito,</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Felicissimo</l>
             <l part="I">Me, se cotesto fusse vero!</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Uditemi:</l>
             <l>Iersera al tardi io ritrovo Pasifilo,</l>
@@ -1149,84 +1204,84 @@
             <l>E m'ha per lo avvenir promesso d'essere</l>
             <l>Tutto in nostro favore in questa pratica.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l>Non so se sai che non è da fidarsene,</l>
             <l>E che è bugiardo, adulatore e perfido.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l>Ben lo conosco anch'io: ma so che nuocere</l>
             <l>Non mi può questo suo parlar, trovandolo</l>
             <l>E toccandol con man tutto verissimo.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="I">E che t'ha detto insomma?</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Che Damonio</l>
             <l>Avea di dar la figliuola pur animo</l>
             <l>Al dottor, poi ch'offega di duo milia</l>
             <l part="I">Ducati sopradote.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Dunque paiono</l>
             <l>A te queste novelle buone, anzi ottime?</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l>E che credete voi sì tosto intendere,</l>
             <l part="I">S'io non v'ho detto il tutto ancora?</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Séguita.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l>A questo gli risposi, che era simile–</l>
             <l>mente acconcio da farle la medesima</l>
             <l part="I">Sopradote.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="M">Ben rispondesti.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Uditemi,</l>
             <l>Che non son anco ove è il punto difficile.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="I">Difficile? Ci è peggio dunque?</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Che obligo,</l>
             <l>Fingendomi figliuolo di Filogono,</l>
             <l>Posso far io, senza mandato in spezie</l>
             <l part="I">Del padre in questo?</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Sei stato allo Studio</l>
             <l part="I">Più di me.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Né voi sète stato a perdere</l>
             <l>Tempo; ma queste cose su quel codice</l>
             <l>Che vi ponete inanzi non si trattano.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="I">Lascia le ciance e vieni al fatto.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Dissigli</l>
             <l>Che da mio padre avevo avute lettere</l>
@@ -1241,7 +1296,7 @@
             <l>Avrebbe quante promesse, quanti oblighi</l>
             <l>Io avessi fatti in questo sponsalizio.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l>Util sarà questo indugio, ottenendolo,</l>
             <l>Che ancor quindici di mi farà vivere.</l>
@@ -1250,19 +1305,19 @@
             <l>Mi sarebbe di lui? Ah tristo e misero</l>
             <l part="I">Me! che sia maladetto...</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Confidatevi</l>
             <l>In me: credete che non sia rimedio</l>
             <l part="I">A questo ancora?</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Deh, fratel, ritornami</l>
             <l>Vivo, che, poi che entramo in questa pratica,</l>
             <l part="I">Son stato sempre più che morto.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Or statemi</l>
             <l>Un poco a udir: questa matina, avendomi</l>
@@ -1290,20 +1345,20 @@
             <l>Si ferma alora, e mi prega di grazia</l>
             <l>Che questa cosa tutta a pieno gli esplichi.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="I">Io non intendo questa trama.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Credovi:</l>
             <l part="I">Udite pur.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="M">Séguita pur.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Soggiungoli:</l>
             <l>— Perché, gentiluom mio, già ne la patria</l>
@@ -1317,22 +1372,22 @@
             <l>A certi ambasciadori del duca Ercole</l>
             <l>Che da Napoli in qua se ne tornavano.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l>Che favole son queste? che appertengono</l>
             <l part="I">Al caso mio?</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Se m'ascoltate, favole</l>
             <l>Non vi parranno; ma che vi appertenghino</l>
             <l part="I">Molto più ch'ora non credete.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Séguita.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l>Io gli soggiunsi: — Questi gentiluomini,</l>
             <l>O, come ho detto ambasciatori aveano</l>
@@ -1353,22 +1408,22 @@
             <l>Come se del più vile e del più ignobile</l>
             <l>Mercatante del mondo state fosseno.—</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l>Esser può che appertenga questa istoria</l>
             <l>A me; ma capo non ci so discernere,</l>
             <l>Né coda, né mi posso indurre a crederlo.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l>O come sète impazïente! Statemi</l>
             <l>Un poco a udir: lasciatemi concludere.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="I">Di' pur quant'io t'ascoltarò.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Gli séguito:</l>
             <l>— Di ciò si è il Duca dogliuto con lettere,</l>
@@ -1383,43 +1438,43 @@
             <l>Fin alle brache, e che cacciati vadino</l>
             <l>Di qui con vituperio: et ignominia. —</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l>E donde così grande e così sùbita</l>
             <l>Bugia ti imaginasti, e a che proposito?</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l>Saper vi farò il tutto; né possibile</l>
             <l>Era per noi trovar cosa più utile.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l>Sto pur attento a quel che vòi concludere.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l>Vorrei ch'udite le parole e visti li</l>
             <l>Gesti vo' aveste, con che affaticavomi</l>
             <l part="I">Di persuadergli questa baia.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Credoti,</l>
             <l>Che so purtroppo come sai ben fingere.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l>Io gli soggiunsi che pene gravissime</l>
             <l>Aveva il Duca imposte a quei che albergano,</l>
             <l>Ch'alloggiasson senesi, e non ne dessino</l>
             <l>Ai soprastanti immantinente indizio.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="I">Ci mancava cotesto!</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Costui, che essere</l>
             <l>Fra gli uomini del mondo de' più pratichi</l>
@@ -1427,13 +1482,13 @@
             <l>Girava già la briglia per tornarsene</l>
             <l part="I">Indietro.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Eh, come mostra esser mal pratico,</l>
             <l>Se non sa quel ch'esser dovria notissimo,</l>
             <l>Se fusse vero, in Siena a tutto il populo!</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l>E perché non potrebbe esser, se passano</l>
             <l>Dui mesi o tre ch'egli non fu alla patria,</l>
@@ -1441,22 +1496,22 @@
             <l>Fusseno occorse, e tuttavolta occorrano,</l>
             <l>Di che egli non potesse aver notizia?</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l>Pur non debbe aver.troppa esperïenzia.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l>Credo che n'ha pochissima; e ben reputo</l>
             <l>Buona sorte la nostra, che mandatomi</l>
             <l>Abbia uomo inanzi sì al nostro proposito.</l>
             <l part="I">State a udir pur.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="M">Finisce pur.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Sentendosi</l>
             <l>Dir questo, già si volgea per tornarsene</l>
@@ -1480,31 +1535,31 @@
             <l>Et io, che nominato sono Erostrato,</l>
             <l>Vi farò, come a padre, i convenevoli. —</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l>Deh, come son ben sciocco e poco pratico!</l>
             <l>Pur or comincio il tuo disegno a intendere!</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="I">Che ve ne par?</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Assai ben: ma uno scropulo,</l>
             <l part="I">Che non mi piace, ci resta.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Che scropulo?</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l>Che stando un giorno o dui qui, e accadendogli</l>
             <l>Di ragionar con altri, potrà facile–</l>
             <l>mente che tu l'abbi uccellato accorgersi.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l>Non vi pensate voi ch'io n'abbi a aggiungere</l>
             <l>Altro? Io l'ho già sì accarezzato, e vogliolo</l>
@@ -1517,11 +1572,11 @@
             <l>Di compiacermi in cosa, dove a mettere</l>
             <l>Egli non ha se non parole semplici.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="I">Che vuoi che faccia?</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Che faccia il medesimo</l>
             <l>Che farebbe Filogono, trovandosi</l>
@@ -1535,49 +1590,49 @@
             <l>A lui questo contratto, non essendoci</l>
             <l>Scritto il suo nome, ma quel d'uno estraneo.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="I">Pur che succeda.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Facciamo il possibile.</l>
             <l>E de la sorte più tosto dogliamoci,</l>
             <l>Che di noi stessi, che per negligenzia</l>
             <l part="I">Siamo restati.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Or su, dove lasciatolo</l>
             <l>Hai?</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l>Ad un'osteria, perché tre bestie</l>
             <l>Ch'egli ha non bene in casa capirebbono.</l>
             <l>Vo' che i cavalli all'osteria si lascino,</l>
             <l>E le persone in casa nostra alloggino.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="I">Perché non l'hai menato teco?</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Parvemi</l>
             <l part="I">Meglio avisarvi prima.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Or torna e menalo;</l>
             <l>E fagli onore, e non guardare a spendere.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l>Ubidiròvi. Eccol, per Dio! vedetelo</l>
             <l part="I">Che viene in qua.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Gli è questo? Or va' et incontralo.</l>
             <l>Anch'io lo voglio un po' squadrar, s'ha l'aria</l>
@@ -1587,42 +1642,42 @@
         <div type="scene" n="Scena II">
           <head>SCENA II</head>
           <stage>Senese, il suo Famiglio, Erostrato</stage>
-          <sp>
+          <sp who="#senese">
             <speaker>SENESE:</speaker>
             <l>Chi va pel mondo incorre in gran pericoli.</l>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>FAMIGLIO:</speaker>
             <l>Gli è ver: se questa matina a Garofalo,</l>
             <l>Passando il fiume, si fusse pel carico</l>
             <l>La nave aperta, tutti affogavamoci,</l>
             <l>Che non abbiàn di notar molta pratica.</l>
           </sp>
-          <sp>
+          <sp who="#senese">
             <speaker>SENESE:</speaker>
             <l part="I">Di cotesto non dico.</l>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>FAMIGLIO:</speaker>
             <l part="F">Del terribile</l>
             <l>Fango voi dite, che di qua da Padoa</l>
             <l>Trovamo, ove più volte ebbi gran dubbio</l>
             <l>Che i poveri cavalli rimanessino?</l>
           </sp>
-          <sp>
+          <sp who="#senese">
             <speaker>SENESE:</speaker>
             <l>Va', tu sei grosso. Io dico del pericolo</l>
             <l>Nel quale siamo stati per incorrere</l>
             <l part="I">In questa terra.</l>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>FAMIGLIO:</speaker>
             <l part="F">Gnaffe, un gran pericolo</l>
             <l>Ritrovar chi vi lasci a pena giungere,</l>
             <l>E che da l'osteria vi levi sùbito</l>
             <l part="I">E alloggi in casa sua!</l>
           </sp>
-          <sp>
+          <sp who="#senese">
             <speaker>SENESE:</speaker>
             <l part="F">Mercé del giovene</l>
             <l>Gentile e grazïoso ch'oggi Domene–</l>
@@ -1633,74 +1688,74 @@
             <l>Siate di nominarmi per Filogono</l>
             <l part="I">Di Catanea.</l>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>FAMIGLIO:</speaker>
             <l part="F">Cotesto sì eteroclito</l>
             <l>Nome per certo avrò male in memoria;</l>
             <l>Ma non già quella castagna sì facile–</l>
             <l part="I">mente mi scordarò.</l>
           </sp>
-          <sp>
+          <sp who="#senese">
             <speaker>SENESE:</speaker>
             <l part="F">Dico Catanea,</l>
             <l part="I">E non castagna, in tuo mal punto.</l>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>FAMIGLIO:</speaker>
             <l part="F">Dicalo</l>
             <l>Un altro pur, che a me non basta l'animo</l>
             <l part="I">Ricordarmene mai.</l>
           </sp>
-          <sp>
+          <sp who="#senese">
             <speaker>SENESE:</speaker>
             <l part="F">Sta' dunque tacito,</l>
             <l>E guardati che Siena mai non nomini.</l>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>FAMIGLIO:</speaker>
             <l>Che vi parria, s'io mi fingesse mutolo,</l>
             <l>Come feci anco in casa di Crisobolo?</l>
           </sp>
-          <sp>
+          <sp who="#senese">
             <speaker>SENESE:</speaker>
             <l>Fa' come ti par meglio. Ma ecco il giovene</l>
             <l part="I">Tanto cortese.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Ben venga Filogono,</l>
             <l part="I">Mio padre.</l>
           </sp>
-          <sp>
+          <sp who="#senese">
             <speaker>SENESE:</speaker>
             <l part="F">E ben sia il mio figliuolo Erostrato</l>
             <l part="I">Trovato.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Abbiate in mente a saper fingere,</l>
             <l>Che questi ferraresi, c'hanno il diavolo</l>
             <l>In corpo tutti, non possino accorgersi</l>
             <l part="I">Che voi siate senesi.</l>
           </sp>
-          <sp>
+          <sp who="#senese">
             <speaker>SENESE:</speaker>
             <l part="F">No, no, statene</l>
             <l>Pur sicuro, che ben faremo il debito.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l>Sareste svaligiati, et altre ingiurie</l>
             <l>E scorni avreste, che a <foreign xml:lang="lat">furore populi</foreign>
                   </l>
             <l>Vi cacciarian come ribaldi sùbito.</l>
           </sp>
-          <sp>
+          <sp who="#senese">
             <speaker>SENESE:</speaker>
             <l>Io li venivo ammonendo, e non dubito</l>
             <l>Che punto punto in questa cosa fallino.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l>E con li miei di casa avete il simile</l>
             <l>Modo a tener; che questi che mi servono</l>
@@ -1712,7 +1767,7 @@
         <div type="scene" n="Scena III">
           <head>SCENA III</head>
           <stage>Dulippo solo</stage>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l>Questa cosa non ha tristo principio,</l>
             <l>Pur che peggior il mezzo o il fin non séguiti.</l>
@@ -1737,7 +1792,7 @@
         <div type="scene" n="Scena IV">
           <head>SCENA IV</head>
           <stage>Carione famiglio, Cleandro, Dulippo finto</stage>
-          <sp>
+          <sp who="#carione">
             <speaker>CARIONE:</speaker>
             <l>O padron, ch'ora è questa fuora d'ordine</l>
             <l>D'andare a cerco? Credo che si stuzzichi</l>
@@ -1745,12 +1800,12 @@
             <l>Ogni banchier, ogni ufficial di Camera,</l>
             <l>Che sono a uscir di Piazza sempre gli ultimi.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Io son venuto per trovar Pasifilo,</l>
             <l part="I">Acciò desini meco.</l>
           </sp>
-          <sp>
+          <sp who="#carione">
             <speaker>CARIONE:</speaker>
             <l part="F">Come fussemo</l>
             <l>Pochi sei bocche che siamo, e, aggiungendovi</l>
@@ -1761,30 +1816,30 @@
             <l>Che senza più in cucina s'apparecchiano,</l>
             <l>Per voi e tutta la famiglia pascere.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="I">Temi, lupaccio, che ti manchi?</l>
           </sp>
-          <sp>
+          <sp who="#carione">
             <speaker>CARIONE:</speaker>
             <l part="F">Temone</l>
             <l part="I">Purtroppo.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">(Non debbo uccellare, e prendermi</l>
             <l part="I">Piacer di questo vecchio?)</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Dee dunque essere</l>
             <l part="I">La prima volta.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="M">(Che dirò?)</l>
           </sp>
-          <sp>
+          <sp who="#carione">
             <speaker>CARIONE:</speaker>
             <l part="F">Rincrescemi</l>
             <l>De la famiglia, e non già del mio incommodo;</l>
@@ -1796,40 +1851,40 @@
             <l>E con l'ossa la mula vostra, et anco la</l>
             <l>Carne, s'avesse pur carne la misera.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="I">Tua colpa, che sì ben n'hai cura.</l>
           </sp>
-          <sp>
+          <sp who="#carione">
             <speaker>CARIONE:</speaker>
             <l part="F">Datene</l>
             <l>Pur colpa al fieno, e alla biada, che costano.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="I">(Lascia pur fare a me!)</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Taci, brutto asino,</l>
             <l>E guarda se apparir vedi Pasifilo.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l>( Quando io non possa far altro, vo' spargere</l>
             <l>Tra Pasifilo e lui tanta zizzania,</l>
             <l>Che non credo che mai più amici tornino.)</l>
           </sp>
-          <sp>
+          <sp who="#carione">
             <speaker>CARIONE:</speaker>
             <l>Non bastava, patrone, che venutoci</l>
             <l>Fusse un di noi, senza venir voi proprio?</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Sì, perché sète assai diligenti uomini!</l>
           </sp>
-          <sp>
+          <sp who="#carione">
             <speaker>CARIONE:</speaker>
             <l>Per Dio, voi cercate altri che Pasifilo;</l>
             <l>Che dovete pensar che, se Pasifilo</l>
@@ -1837,150 +1892,150 @@
             <l>De la vostra, già un pezzo ne la camera</l>
             <l part="I">Vi aspettarebbe al fuoco.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Or non mi rompere</l>
             <l>Il capo. Ma ecco da chi potrò intendere</l>
             <l>Se forse con Damonio costui desina.</l>
             <l>Non sei tu servitore di Damonio?</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="I">Sì, sono, al vostro piacer.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Ti ringrazio.</l>
             <l>Tu mi saprai dunque dir se Pasifilo</l>
             <l part="I">Gli è stato oggi a parlar</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Ci è stato, e credo ci</l>
             <l part="I">Sia forse ancora. Ah, ah!</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Ma di che ridi tu?</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l>D'uno ragionamento, da non ridere</l>
             <l>Per ognuno però, ch'ebbe Pasifilo</l>
             <l part="I">Pur dianzi con mio patrone.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Potrebbesi</l>
             <l part="I">Risaper...</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Ah, non saria onesto dirvelo!</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="I">Se si appertiene a me?</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="M">Basti.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Rispondemi.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l>Non vi posso dir altro: perdonatemi.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Questo solo, e non altro, vorria intendere,</l>
             <l>Se si appertiene a me: dillo, di grazia.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l>Quando io fussi sicuro che star tacito</l>
             <l>Voi ne doveste, vi scoprirei libera–</l>
             <l part="I">mente ogni cosa.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Io sarò secretissimo,</l>
             <l>Non dubitar. — Tu, Carïone, aspettami</l>
             <l part="I">Costà. — Or di' su.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Se mio patrone a intendere</l>
             <l>Venisse mai che per me auto indizio</l>
             <l>Voi n'avesse, mi farebbe il più misero</l>
             <l part="I">Uomo che viva.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Non è per intenderlo</l>
             <l part="I">Mai. Or di' pur.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="M">Chi m'assicura?</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">T'obligo.</l>
             <l part="I">E ti do in pegno la mia fede.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">È debole</l>
             <l>Pegno, che sopra li Ebrei non vi prestano.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Più che l'oro e le gemme val tra gli uomini</l>
             <l part="I">Da bene.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">E dove al dì d'oggi si trovano?</l>
             <l part="I">Volete pur ch'io vel dica?</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Anzi pregoti</l>
             <l>E te ne fo le croci, appertenendosi</l>
             <l part="I">A me però.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Vi s'appertiene, e vogliovi–</l>
             <l>lo dir, perché mi duol che un uomo simile</l>
             <l>Sia così dileggiato da una bestia.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="I">Dimmel, di grazia.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Io vel dirò, giurandomi</l>
             <l>Però voi prima, che mai né a Pasifilo,</l>
             <l>E meno a mio patron, siate per muoverne</l>
             <l part="I">Parola.</l>
           </sp>
-          <sp>
+          <sp who="#carione">
             <speaker>CARIONE:</speaker>
             <l part="F">(Qualche ciancetta debbe essere,</l>
             <l>Che da parte gli dà di questa giovane,</l>
             <l>Forse con speme di trarne alcun utile.)</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Io credo a punto d'aver qui una lettera.</l>
           </sp>
-          <sp>
+          <sp who="#carione">
             <speaker>CARIONE:</speaker>
             <l>(Mal lo conosce: ci bisognerebbono</l>
             <l>Tanaglie e non parole; che più facile–</l>
@@ -1988,13 +2043,13 @@
             <l>De la mascella che scemare un picciolo</l>
             <l part="I">De la scarsella.)</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Ecco una carta: pigliala</l>
             <l>Et aprila tu stesso; così giuroti</l>
             <l>Di non parlarne con persona. Or dimmelo.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l>Io vel dirò. M'incresce che Pasifilo</l>
             <l>Vi uccelli; che il ghiotton vi dia ad intendere</l>
@@ -2005,142 +2060,142 @@
             <l>Arosto, o Rospo, o Grosco. Io nol so esprimere:</l>
             <l part="I">Ha un nome indiavolato.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Chi è? Erostrato?</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l>Sì sì, così si chiama: e dice il perfido</l>
             <l>Di voi tutti li mali che si possono</l>
             <l part="I">Dir d'alcun uomo infame.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="M">A chi?</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">A Damonio,</l>
             <l part="I">Et anco a Polinesta.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">È egli possibile?</l>
             <l part="I">Ah ribaldo! E che dice?</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Imaginatevi</l>
             <l>Quel che si può dir peggio: che il più misero,</l>
             <l part="I">E il più strett'uom non è di voi...</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Pasifilo</l>
             <l part="I">Dice cotesto. di me?</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">...e che venendovi</l>
             <l>A casa, ha da morir, per avarizia</l>
             <l part="I">Vostra, di fame...</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Oh, che sel porti il diavolo!</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l>...E che il più fastidioso e il più colerico</l>
             <l>Uomo del mondo voi sète, e distruggere</l>
             <l part="I">La farete d'affanno...</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Oh lingua pessima!</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l>...E che tossite, e sputate continua–</l>
             <l>mente dì e notte con tanta spurcizia,</l>
             <l>Che i porci aver di voi schifo dovrebbono.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="I">Non tosso pur, né mai sputo.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">È chiarissimo,</l>
             <l part="I">Or me n'aveggo.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">È ver ch'or son gravissima–</l>
             <l>mente infreddato; ma chi n'è ben libero</l>
             <l part="I">Di questo tempo?</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">E dice che vi puzzano</l>
             <l>Li piedi e le ditella, sì che amorbano;</l>
             <l>E più, ch'avete un fiato incomportabile...</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Non possi aver mai cosa ch'io desideri,</l>
             <l part="I">S'io non lo pago.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">...e che vi pende l'ernia...</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Oh, che gli venga il mal di santo Antonio!</l>
             <l>Tutto cotesto che dice è falsissimo.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l>...E che cercate pigliar questa giovane</l>
             <l>Più perché di mariti desiderio</l>
             <l part="I">Avete, che di moglie.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Che significa</l>
             <l part="I">Questo suo dire?</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Che adescar li gioveni</l>
             <l>Così volete, che a casa vi venghino,</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="I">Li gioveni? A che effetto?</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Imaginatelo</l>
             <l part="I">Voi pur.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Può esser che dica Pasifilo</l>
             <l part="I">Coteste ciance?</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">E molte altre bruttissime</l>
             <l part="I">E disoneste.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">E gli crede Damonio?</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l>Sì, più che al <emph>Credo</emph>; e già vi avrebbe dato la</l>
             <l>Repulsa, se non fosse che Pasifilo</l>
@@ -2148,86 +2203,86 @@
             <l>Che spera, s'egli tien la cosa in pratica,</l>
             <l>Aver da voi danari e mille commodi.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Aver da me? Voglio che, come merita,</l>
             <l>Abbi un capestro. E perché non ebbi animo</l>
             <l>Di dargli queste calze, come fossino</l>
             <l>Un poco più di quel che sono, logore!</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l>Per Dio, per Dio, avrà fatto gran perdita!</l>
             <l part="I">Volete altro da me?</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Non altro, avutone</l>
             <l part="I">Ho purtroppo.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Io ritornarò, piacendovi,</l>
             <l part="I">In casa.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Va': dimmi anco, se mi è lecito</l>
             <l part="I">Saperlo, come è il nome tuo?</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Mi dicono</l>
             <l part="I">Maltivenga.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Noioso e dispiacevole</l>
             <l>Nome hai certo. Sei tu di questa patria?</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l>Messerno, sono d'un castel che chiamano</l>
             <l>Fossucciso, colà nel territorio</l>
             <l part="I">Di Tagliacozzi. A Dio.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">A Dio. (Deh misero!</l>
             <l>Di chi mi fidavo io! Come provistomi</l>
             <l>Ero d'un messaggero e d'uno interprete!)</l>
           </sp>
-          <sp>
+          <sp who="#carione">
             <speaker>CARIONE:</speaker>
             <l>Vogliàn, patrone, a posta di Pasifilo</l>
             <l part="I">Oggi morir di fame?</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Non mi rompere</l>
             <l>Il capo, che impiccati insieme fossivo</l>
             <l part="I">Amendui.</l>
           </sp>
-          <sp>
+          <sp who="#carione">
             <speaker>CARIONE:</speaker>
             <l part="F">(Non ha nuove che gli piaccino.)</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Hai sì gran fretta di mangiar? Che sazio</l>
             <l part="I">Non possi esser tu mai!</l>
           </sp>
-          <sp>
+          <sp who="#carione">
             <speaker>CARIONE:</speaker>
             <l part="F">(Sono certissimo</l>
             <l>Di non mi saziar mai, fin che al servizio</l>
             <l part="I">Suo stia.)</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="M">Ma andiamo, in malora!</l>
           </sp>
-          <sp>
+          <sp who="#carione">
             <speaker>CARIONE:</speaker>
             <l part="F">(Ma in pessima</l>
             <l>Per te, e per quanti avari si ritruovano!)</l>
@@ -2239,7 +2294,7 @@
         <div type="scene" n="Scena I">
           <head>SCENA I</head>
           <stage>Dalio cuoco, Caprino ragazzo, Erostrato finto</stage>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO:</speaker>
             <l>Giunti che siamo a casa, se di sedici</l>
             <l>Ova c'hai nel canestro, una o due coppie</l>
@@ -2255,16 +2310,16 @@
             <l>S'io trovo rotto un ovo solo, voglioti</l>
             <l part="I">Rompere il capo.</l>
           </sp>
-          <sp>
+          <sp who="#caprino">
             <speaker>CAPRINO:</speaker>
             <l part="F">Sì ben forse rompere,</l>
             <l>Ch'io non possa di poi seder, brutto asino.</l>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO:</speaker>
             <l part="I">Ah frasca!</l>
           </sp>
-          <sp>
+          <sp who="#caprino">
             <speaker>CAPRINO:</speaker>
             <l part="F">S'io son frasca, non posso essere</l>
             <l part="I">Con un becco sicuro.</l>
@@ -2273,48 +2328,48 @@
             <l>Non fuss'io, ti farei veder se un asino</l>
             <l part="I">E un becco fussi.</l>
           </sp>
-          <sp>
+          <sp who="#caprino">
             <speaker>CAPRINO:</speaker>
             <l part="F">Rade volte veggoti,</l>
             <l>Poltron, che tu non sia molto ben carico</l>
             <l>Di vino o di mazzate in abondanzia.</l>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO:</speaker>
             <l>Al dispetto..., ch'io son per attaccargliela!</l>
           </sp>
-          <sp>
+          <sp who="#caprino">
             <speaker>CAPRINO:</speaker>
             <l>Ah rubaldon! Tu biastemi con l'animo,</l>
             <l part="I">E con la lingua non ardisci.</l>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO:</speaker>
             <l part="F">Vogliolo</l>
             <l>Dire al patrone: o mi darà licenzia,</l>
             <l>O tu non mi dirai tuttavia ingiuria.</l>
           </sp>
-          <sp>
+          <sp who="#caprino">
             <speaker>CAPRINO:</speaker>
             <l part="I">Fammi il peggio che sai far.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Che discordia,</l>
             <l part="I">Che disputa è cotesta?</l>
           </sp>
-          <sp>
+          <sp who="#caprino">
             <speaker>CAPRINO:</speaker>
             <l part="F">Mi vuol battere,</l>
             <l>Padron, perch'io 'l riprendo che biastemia.</l>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO:</speaker>
             <l>El se ne mente per la gola: dicemi</l>
             <l>Ingiuria il ladroncel, perch'io, 'l sollicito</l>
             <l part="I">Che venga tosto.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Non più. Va' tu, Dalio,</l>
             <l>E pela i tordi et i piccioni, e acconciami</l>
@@ -2332,22 +2387,22 @@
         <div type="scene" n="Scena II">
           <head>SCENA II</head>
           <stage>Dulippo finto, Erostrato finto</stage>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l>C'hai tu fatto di tuo padre Filogono?</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l>Io l'ho lasciato in casa. Di Pasifilo</l>
             <l>Ho bisogno: sapreste vo' insegnarmelo?</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l>Questa matina desinò alla tavola</l>
             <l>Di mio patron: non so poi dove andatone</l>
             <l part="I">Sia. Che ne vuoi tu far?</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Ch'egli notifichi</l>
             <l>La venuta di mio padre a Damonio,</l>
@@ -2358,27 +2413,27 @@
             <l>Di diventare un becco, che in malizia</l>
             <l>Et in cautele io non gli son per cedere.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l>Va', fratel caro, va', cerca Pasifilo,</l>
             <l>Tanto che 'l truovi, e vede di concludere</l>
             <l>Oggi ogni modo a nostro benefizio.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="I">Dove ho a cercarne?</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Dove s'apparecchino</l>
             <l>Conviti: il puoi trovar fra i pizzicagnoli;</l>
             <l>Con pescatori e beccai spesso bazzica.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="I">Che fa con loro?</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Guata quei che comprano</l>
             <l>Qualche gallina grassa, qualche morbida</l>
@@ -2389,30 +2444,30 @@
             <l>Con un “bel pro vi faccia” salutando li</l>
             <l>Convitati, si assetti alla domestica.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="I">Cotesti luoghi cercherò.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">È impossibile</l>
             <l>Che tu nol truovi. lo t'ho poi da far ridere.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="I">Di che?</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">D'un parlamento, che con l'emulo</l>
             <l part="I">Nostro ebbi pur testé.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Perché non dirmelo</l>
             <l part="I">Ora?</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Non voglio: va' pure, e sollicita</l>
             <l>Quel c'hai da fare, e ritruova Pasifilo.</l>
@@ -2421,7 +2476,7 @@
         <div type="scene" n="Scena III">
           <head>SCENA III</head>
           <stage>Dulippo solo</stage>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l>Questa causa amorosa, che si litiga</l>
             <l>Tra me e Cleandro a un giuoco mi par simile</l>
@@ -2463,15 +2518,15 @@
         <div type="scene" n="Scena IV">
           <head>SCENA IV</head>
           <stage>Damonio, Dulippo, Nevola</stage>
-          <sp>
+          <sp who="#damonio">
             <speaker>DAMONIO:</speaker>
             <l part="I">Dulippo.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="M">Eccomi.</l>
           </sp>
-          <sp>
+          <sp who="#damonio">
             <speaker>DAMONIO:</speaker>
             <l part="F">Va' in casa, e di' al Nevola,</l>
             <l>Al Rosso, al Mantovan, che a me qui venghino,</l>
@@ -2485,11 +2540,11 @@
             <l>Fusse un ser Lippo da Piazza), et arrecalo</l>
             <l part="I">Qui a me.</l>
           </sp>
-          <sp>
+          <sp who="#dulippo">
             <speaker>DULIPPO:</speaker>
             <l part="F">Così farò con diligenzia.</l>
           </sp>
-          <sp>
+          <sp who="#damonio">
             <speaker>DAMONIO:</speaker>
             <l>Va' pur, ch'uno instrumento più increscevole</l>
             <l>Vi troverai, che non ti pensi. (Ah misero</l>
@@ -2515,11 +2570,11 @@
             <l>Più chetamente che vi sia possibile;</l>
             <l>Poi torna immantinente a me tu. Nevola.</l>
           </sp>
-          <sp>
+          <sp who="#nevola">
             <speaker>NEVOLA:</speaker>
             <l part="I">Sarà fatto.</l>
           </sp>
-          <sp>
+          <sp who="#damonio">
             <speaker>DAMONIO:</speaker>
             <l part="F">Ma fatel senza strepito.</l>
             <l>(Come debb'io di così grave ingiuria,</l>
@@ -2569,48 +2624,48 @@
         <div type="scene" n="Scena V">
           <head>SCENA V</head>
           <stage>Nevola, Damonio, Pasifilo</stage>
-          <sp>
+          <sp who="#nevola">
             <speaker>NEVOLA:</speaker>
             <l>Patrone, abbiàn fatto il bisogno, et eccovi</l>
             <l part="I">La chiave.</l>
           </sp>
-          <sp>
+          <sp who="#damonio">
             <speaker>DAMONIO:</speaker>
             <l part="F">Bene sta. Vanne or tu, Nevola,</l>
             <l>A ritrovar messer Paulin da Bibula:</l>
             <l part="I">Sta presso a San Francesco.</l>
           </sp>
-          <sp>
+          <sp who="#nevola">
             <speaker>NEVOLA:</speaker>
             <l part="M">Io 'l so.</l>
           </sp>
-          <sp>
+          <sp who="#damonio">
             <speaker>DAMONIO:</speaker>
             <l part="F">Domandagli</l>
             <l>Da parte mia quei suoi ferri da mettere</l>
             <l>A' prigionieri ai piedi, e torna sùbito.</l>
           </sp>
-          <sp>
+          <sp who="#nevola">
             <speaker>NEVOLA:</speaker>
             <l part="I">Io vo.</l>
           </sp>
-          <sp>
+          <sp who="#damonio">
             <speaker>DAMONIO:</speaker>
             <l part="F">Ma ascolta: se volesse intendere</l>
             <l>A chi li voglio adoperar, rispondegli</l>
             <l part="I">Che tu nol sai.</l>
           </sp>
-          <sp>
+          <sp who="#nevola">
             <speaker>NEVOLA:</speaker>
             <l part="M">Così dirò.</l>
           </sp>
-          <sp>
+          <sp who="#damonio">
             <speaker>DAMONIO:</speaker>
             <l part="F">Odi: guardati</l>
             <l>Che né a lui dica, né ad altri una minima</l>
             <l>Parola, che Dulippo abbiamo in carcere.</l>
           </sp>
-          <sp>
+          <sp who="#nevola">
             <speaker>NEVOLA:</speaker>
             <l>Gli è difficile insomma, anzi impossibile,</l>
             <l>Che li danari altrui in man ti venghino,</l>
@@ -2630,27 +2685,27 @@
             <l>Gli sarebbe, .per Dio, stato più utile</l>
             <l part="I">A non far tanto.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Tu di' il vero, Nevola,</l>
             <l part="I">Ch'egli l'ha fatto, troppo:</l>
           </sp>
-          <sp>
+          <sp who="#nevola">
             <speaker>NEVOLA:</speaker>
             <l part="F">Donde diavolo</l>
             <l part="I">Esci tu?</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Esco de la casa propria</l>
             <l>Che tu, ma non per quel uscio medesimo.</l>
           </sp>
-          <sp>
+          <sp who="#nevola">
             <speaker>NEVOLA:</speaker>
             <l>Dove eri tu? Già un pezzo credavamoci</l>
             <l part="I">Che ti fussi partito.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Essendo a tavola,</l>
             <l>Mi sentii in corpo non so che, che correre</l>
@@ -2660,20 +2715,20 @@
             <l>Sopra la paglia, dove ho poi continua–</l>
             <l part="I">mente dormito. E tu dove vai?</l>
           </sp>
-          <sp>
+          <sp who="#nevola">
             <speaker>NEVOLA:</speaker>
             <l part="F">Mandami</l>
             <l>In gran fretta l padrone in un servizio.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="I">&gt;Si può egli dir?</l>
           </sp>
-          <sp>
+          <sp who="#nevola">
             <speaker>NEVOLA:</speaker>
             <l part="M">No.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Quasi più informatone</l>
             <l>Di me fuss'egli! O Dio, che cosa, standomi</l>
@@ -2707,29 +2762,29 @@
         <div type="scene" n="Scena VI">
           <head>SCENA VI</head>
           <stage>Psiteria vecchia, Pasifilo</stage>
-          <sp>
+          <sp who="#psiteria">
             <speaker>PSITERIA:</speaker>
             <l>Qua presso, a casa di mona Beritola.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l>Che? vai tu a cicalarvi e fargli intendere</l>
             <l>De le belle opre de la vostra giovane?</l>
           </sp>
-          <sp>
+          <sp who="#psiteria">
             <speaker>PSITERIA:</speaker>
             <l>In fé de Dio, non già; ma donde, domene,</l>
             <l part="I">Lo sai?</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Tu dianzi mel facesti intendere.</l>
           </sp>
-          <sp>
+          <sp who="#psiteria">
             <speaker>PSITERIA:</speaker>
             <l part="I">E quando tel diss'io?</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Quando a Damonio</l>
             <l>Lo dicevi anco, che in tal luogo stavomi,</l>
@@ -2741,17 +2796,17 @@
             <l>Di lasciarvi la vita, et altri scandoli</l>
             <l part="I">Che seguiranno!</l>
           </sp>
-          <sp>
+          <sp who="#psiteria">
             <speaker>PSITERIA:</speaker>
             <l>Certo fu inconsidera–</l>
             <l>tamente; né la colpa è di Psiteria</l>
             <l part="I">In tutto.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="M">E di chi è colpa?</l>
           </sp>
-          <sp>
+          <sp who="#psiteria">
             <speaker>PSITERIA:</speaker>
             <l part="F">Abbi pazienzia,</l>
             <l>Ch'io ti dirò come le cose passano.</l>
@@ -2772,11 +2827,11 @@
             <l>Mi chiamò ne la stalla e volse intendere</l>
             <l part="I">Il tutto.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="M">E come gli hai detto?</l>
           </sp>
-          <sp>
+          <sp who="#psiteria">
             <speaker>PSITERIA:</speaker>
             <l part="F">Ah misera!</l>
             <l>S'io avessi pensato che Damonio,</l>
@@ -2784,12 +2839,12 @@
             <l>A mal, prima m'avrei lasciata uccidere,</l>
             <l part="I">Che dirglielo.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Gran fatto, se de' averselo</l>
             <l part="I">A mal!</l>
           </sp>
-          <sp>
+          <sp who="#psiteria">
             <speaker>PSITERIA:</speaker>
             <l part="F">M'incresce più di quella povera</l>
             <l>Fanciulla, che s'afflige, piange e stracciasi</l>
@@ -2799,7 +2854,7 @@
             <l>Ch'ambi vede in grandissimo pericolo.</l>
             <l part="I">Ma voglio andar, c'ho fretta.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Va', ma in polvere;</l>
             <l>Che ben lor hai concia in capo la cuffia!</l>
@@ -2811,7 +2866,7 @@
         <div type="scene" n="Scena I">
           <head>SCENA I</head>
           <stage>Erostrato finto</stage>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l>Che debb'io fare, ahi lasso! che rimedio,</l>
             <l>Che partito, che scusa poss'io prendere,</l>
@@ -2852,87 +2907,87 @@
         <div type="scene" n="Scena II">
           <head>SCENA II</head>
           <stage>Caprino, Psiteria, Erostrato finto</stage>
-          <sp>
+          <sp who="#caprino">
             <speaker>CAPRINO:</speaker>
             <l>O buona donna... o vecchia... o brutta femina...</l>
             <l>Vecchiaccia sorda... non odi, fantasima?</l>
           </sp>
-          <sp>
+          <sp who="#psiteria">
             <speaker>PSITERIA:</speaker>
             <l>Dio facci che tu vecchio non possi essere</l>
             <l>Mai, sì che alcun non t'abbia a dire il simile.</l>
           </sp>
-          <sp>
+          <sp who="#caprino">
             <speaker>CAPRINO:</speaker>
             <l>Vedi s'in casa è Dulippo, di grazia.</l>
           </sp>
-          <sp>
+          <sp who="#psiteria">
             <speaker>PSITERIA:</speaker>
             <l part="I">Così non ci fusse egli!</l>
           </sp>
-          <sp>
+          <sp who="#caprino">
             <speaker>CAPRINO:</speaker>
             <l part="M">Deh, domandalo</l>
             <l>Un poco da mia parte, c'ho grandissimo</l>
             <l part="I">Bisogno di parlargli.</l>
           </sp>
-          <sp>
+          <sp who="#psiteria">
             <speaker>PSITERIA:</speaker>
             <l part="F">Abbi pazienzia,</l>
             <l part="I">Ch'egli è impacciato.</l>
           </sp>
-          <sp>
+          <sp who="#caprino">
             <speaker>CAPRINO:</speaker>
             <l part="F">Volto mio bello, anima</l>
             <l part="I">Mia cara, fagli l'imbasciata.</l>
           </sp>
-          <sp>
+          <sp who="#psiteria">
             <speaker>PSITERIA:</speaker>
             <l part="F">Dicoti</l>
             <l part="I">Ch'egli è impacciato.</l>
           </sp>
-          <sp>
+          <sp who="#caprino">
             <speaker>CAPRINO:</speaker>
             <l part="F">E tu impazzata, femina</l>
             <l part="I">Poltrona!</l>
           </sp>
-          <sp>
+          <sp who="#psiteria">
             <speaker>PSITERIA:</speaker>
             <l part="M">Deh capestro!</l>
           </sp>
-          <sp>
+          <sp who="#caprino">
             <speaker>CAPRINO:</speaker>
             <l part="F">O indiscreta asina!</l>
           </sp>
-          <sp>
+          <sp who="#psiteria">
             <speaker>PSITERIA:</speaker>
             <l>O ribaldel, che ti nasca la fistola;</l>
             <l part="I">Che tu sarai impiccato!</l>
           </sp>
-          <sp>
+          <sp who="#caprino">
             <speaker>CAPRINO:</speaker>
             <l part="F">E tu, malefica</l>
             <l>Strega, sarai bruciata, se già il cancaro</l>
             <l>Pria non ti mangia: gran fatto sarebbeti</l>
             <l part="I">A dirgli una parola?</l>
           </sp>
-          <sp>
+          <sp who="#psiteria">
             <speaker>PSITERIA:</speaker>
             <l part="F">Se t'approssimi,</l>
             <l part="I">Io ti darò una bastonata.</l>
           </sp>
-          <sp>
+          <sp who="#caprino">
             <speaker>CAPRINO:</speaker>
             <l part="F">Guardati,</l>
             <l>Vecchia imbriaca, che s'io piglio un ciottolo,</l>
             <l>Non ti spezzi questo capo di scimia.</l>
           </sp>
-          <sp>
+          <sp who="#psiteria">
             <speaker>PSITERIA:</speaker>
             <l>Or sia in malora: credo tu sia il diavolo</l>
             <l part="I">Che mi viene a tentar.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Caprin, non odi tu?</l>
             <l>Ritorna a me; che stai così a contendere?</l>
@@ -2945,7 +3000,7 @@
         <div type="scene" n="Scena III">
           <head>SCENA III</head>
           <stage>Filogono, il Ferrarese, Lizio servo</stage>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l>Valent'uom, siate certo che gli è proprio</l>
             <l>Come voi dite, che non è amor simile</l>
@@ -2959,13 +3014,13 @@
             <l>Sol per veder mio figliuolo, e menarmelo</l>
             <l part="I">Meco.</l>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERRARESE:</speaker>
             <l part="F">Mi credo ch'abbiate gravissima–</l>
             <l>mente patito, e più che bisognevole</l>
             <l part="I">All'età vostra non era.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">Credetelo:</l>
             <l>Venuto son con certi gentiluomini</l>
@@ -2976,11 +3031,11 @@
             <l>Poi da Ravenna in qua sempre a contrario</l>
             <l>D'acqua venuto son con grande incommodo.</l>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERRARESE:</speaker>
             <l>E mali alloggiamenti vi si truovano.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l>Pessimi certo; ma questo una favola</l>
             <l>Reputo verso il dispetto e il fastidio</l>
@@ -2994,18 +3049,18 @@
             <l>Per veder se tra carne e pelle fossino</l>
             <l>Mercanzie o robe che pagasson dazio.</l>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERRARESE:</speaker>
             <l>Ho inteso che cotesti fanno pessime</l>
             <l>Cose, e che i mercandanti vi assassinano.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l>Siatene certo; né se ne può credere</l>
             <l>Altro; che chi aver cerca .tali ufficii</l>
             <l>È ribaldo, e ghiotton per consequenzia.</l>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERRARESE:</speaker>
             <l>Vi sarà questa passata molestia</l>
             <l>Oggi uno accrescimento di letizia,</l>
@@ -3020,20 +3075,20 @@
             <l>Lui, che a tôr voi questa fatica, e mettere</l>
             <l>La vita vostra a non poco pericolo?</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l>Cotesta non è stata la potissima</l>
             <l>Cagione; anzi il maggior mio desiderio</l>
             <l>È che finisca e lasci questo Studio,</l>
             <l part="I">E che ritorni a casa.</l>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERRARESE:</speaker>
             <l part="F">Non essendovi</l>
             <l>A cuor che si facesse uomo di lettere,</l>
             <l part="I">Perché il mandaste allo Studio?</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">Diròvelo.</l>
             <l>Quando egli stava a casa, tenea pratiche</l>
@@ -3057,13 +3112,13 @@
             <l>Lo studio, dove in breve ha indubitabile.</l>
             <l>Speranza riuscire eccellentissimo.</l>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERRARESE:</speaker>
             <l>In verità molti scolari, et uomini</l>
             <l>Degni di fede, sento ch'el commendano,</l>
             <l>Né studente è di lui di maggior credito.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l>Che bene speso abbia il tempo, n'ho gaudio;</l>
             <l>Pur non mi curo di tanta scïenza,</l>
@@ -3073,13 +3128,13 @@
             <l>Disperato; e per questo mi delibero</l>
             <l part="I">Menarlo meco.</l>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERRARESE:</speaker>
             <l part="F">L'essere amorevole</l>
             <l>Ai figli è cosa umana, ma biasmevole</l>
             <l>E feminile è l'esserne sì tenero.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l>Or io son così fatto. Ancora vogliovi</l>
             <l>Dire un'altra cagion di più importanzia</l>
@@ -3101,30 +3156,30 @@
             <l>O morir o impazzare o d'altra simile</l>
             <l part="I">Disgrazia darsi cagion.</l>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERRARESE:</speaker>
             <l part="F">Riprensibile</l>
             <l>È ogni cosa troppo. Ecco dove abita</l>
             <l>Vostro figliuolo: io busserò, piacendovi.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l>Bussate. Io sento il sangue per letizia</l>
             <l part="I">Che tutto mi si muove.</l>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERRARESE:</speaker>
             <l part="F">Non rispondono.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="I">Bussate un'altra volta.</l>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERRARESE:</speaker>
             <l part="F">Credo dormino.</l>
           </sp>
-          <sp>
+          <sp who="#lizio">
             <speaker>LIZIO:</speaker>
             <l>Se questo uscio v'avesse dato l'essere,</l>
             <l>Con più respetto non devreste batterlo.</l>
@@ -3135,142 +3190,142 @@
         <div type="scene" n="Scena IV">
           <head>SCENA IV</head>
           <stage>Dalio cuoco, Ferrarese, Filogono, Lizio</stage>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO:</speaker>
             <l>Che furia è questa? Ci volete rompere</l>
             <l part="I">Le nostre porte?</l>
           </sp>
-          <sp>
+          <sp who="#lizio">
             <speaker>LIZIO:</speaker>
             <l part="F">Per Dio, credevamoci</l>
             <l>Che voi dormissi, e destar volevamovi.</l>
             <l part="I">Erostrato che fa?</l>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO:</speaker>
             <l part="M">Non è in casa.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">Aprici.</l>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO:</speaker>
             <l>Se pensier fate d'alloggiar, mutatilo;</l>
             <l>Ch'abbiamo un altro forestiero ch'occupa</l>
             <l>Tutte le stanze, e non ci capirebbono</l>
             <l part="I">Tanti.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">Sufficïente e onorevole</l>
             <l part="I">Servitor certo! E chi ci è?</l>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO:</speaker>
             <l part="F">Ci è Filogono.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="I">Filogono?</l>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO:</speaker>
             <l part="F">Filogono, di Erostrato</l>
             <l>Padre, giunto pur dianzi di Sicilia.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l>Ce serà poi che aperto avrai l'uscio: aprici,</l>
             <l part="I">Se ti piace.</l>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO:</speaker>
             <l part="F">L'aprirvi mi fia facile,</l>
             <l>Ma non ci serà luogo per voi, dicovi,</l>
             <l part="I">Che le stanze son piene.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="M">Chi ci è?</l>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO:</speaker>
             <l part="F">Avetemi</l>
             <l>Inteso? Ci è, dico, il padre di Erostrato,</l>
             <l>Filogono, venuto di Catanea.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="I">Quando ci venne se non ora?</l>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO:</speaker>
             <l part="F">Debbono</l>
             <l>Esser due ore o più che smontò all'Angelo,</l>
             <l>Dove sono anco i cavalli; et Erostrato</l>
             <l part="I">V'andò, e lo menò qui.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">Vedi che bestia!</l>
             <l part="I">Vuol dileggiarmi.</l>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO:</speaker>
             <l part="F">Anzi voi me, pigliandovi</l>
             <l>Piacer di farmi star quivi a rispondervi,</l>
             <l>Né possi far le cose che mi importano.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="I">Costui per certo è imbriaco.</l>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERRARESE:</speaker>
             <l part="F">N'ha l'aria:</l>
             <l part="I">Vedete come è rosso?</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">Che Filogono</l>
             <l part="I">È cotesto, di chi tu parli?</l>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO:</speaker>
             <l part="F">Un nobile</l>
             <l>Gentiluomo e da ben, padre di Erostrato.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="I">E dove è?</l>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO:</speaker>
             <l part="M">Gli e qui in casa.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">Non potrebbesi</l>
             <l part="I">Veder?</l>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO:</speaker>
             <l part="M">Sì, mi credo io.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">Deh, va', domandane.</l>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO:</speaker>
             <l part="I">Così farò.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">Non so quel ch'io m'imagini.</l>
           </sp>
-          <sp>
+          <sp who="#lizio">
             <speaker>LIZIO:</speaker>
             <l>Patrone, il mondo è grande: debbono essere</l>
             <l>Altri Erostrati ancora, altri Filogoni,</l>
@@ -3280,17 +3335,17 @@
             <l>Figliuol d'un altro Filogon debbe essere:</l>
             <l part="I">Credete a me.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">Non so ch'io m'abbia a credere,</l>
             <l>Se non che tu sia pazzo e quell'altro ebrio.</l>
           </sp>
-          <sp>
+          <sp who="#lizio">
             <speaker>LIZIO:</speaker>
             <l>Guardate, uomo da ben, un luoco in cambio</l>
             <l part="I">Voi non togliate d'alcun altro.</l>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERRARESE:</speaker>
             <l part="F">Aiutimi</l>
             <l>Domenedio! Non credete che Erostrato</l>
@@ -3303,125 +3358,125 @@
         <div type="scene" n="Scena V">
           <head>SCENA V</head>
           <stage>Senese, Filogono, Dalio</stage>
-          <sp>
+          <sp who="#senese">
             <speaker>SENESE:</speaker>
             <l part="I">Mi domandate, gentiluomo?</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">Intendere</l>
             <l part="I">Vorrei donde voi siate.</l>
           </sp>
-          <sp>
+          <sp who="#senese">
             <speaker>SENESE:</speaker>
             <l part="F">Di Sicilia</l>
             <l part="I">Sono.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="M">E di che cittade?</l>
           </sp>
-          <sp>
+          <sp who="#senese">
             <speaker>SENESE:</speaker>
             <l part="F">Di Catanea.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="I">Il nome vostro?</l>
           </sp>
-          <sp>
+          <sp who="#senese">
             <speaker>SENESE:</speaker>
             <l part="F">Mi chiamo Filogono.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="I">E che essercizio fate?</l>
           </sp>
-          <sp>
+          <sp who="#senese">
             <speaker>SENESE:</speaker>
             <l part="F">Il mio essercizio</l>
             <l part="I">È mercatante.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">E che mercanzia aveteci</l>
             <l part="I">Voi arrecata?</l>
           </sp>
-          <sp>
+          <sp who="#senese">
             <speaker>SENESE:</speaker>
             <l part="F">Nessuna. Venutoci</l>
             <l>Son per vedere un mio figliuol che studia</l>
             <l>In questa terra; che dua anni passano</l>
             <l part="I">Che più nol vidi.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="M">Come è il nome?</l>
           </sp>
-          <sp>
+          <sp who="#senese">
             <speaker>SENESE:</speaker>
             <l part="F">Erostrato.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="I">Erostrato è vostro figliuolo?</l>
           </sp>
-          <sp>
+          <sp who="#senese">
             <speaker>SENESE:</speaker>
             <l part="F">Erostrato</l>
             <l part="I">È mio figliuolo.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">E voi sète Filogono?</l>
           </sp>
-          <sp>
+          <sp who="#senese">
             <speaker>SENESE:</speaker>
             <l part="I">Sì, sono.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">E mercatante di Catanea?</l>
           </sp>
-          <sp>
+          <sp who="#senese">
             <speaker>SENESE:</speaker>
             <l>E che bisogna tanto replicarvelo?</l>
             <l part="I">Non vi direi bugia.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">Anzi espressissima–</l>
             <l>mente la dici; e sei un barro e un pessimo</l>
             <l part="I">Uomo.</l>
           </sp>
-          <sp>
+          <sp who="#senese">
             <speaker>SENESE:</speaker>
             <l part="F">Avete gran torto a dirmi ingiuria.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l>Oltra il dirla, saria più dritto a fartela,</l>
             <l>Uomo sfacciato, che vuoi farmi credere</l>
             <l part="I">Che tu sia quel che non sei.</l>
           </sp>
-          <sp>
+          <sp who="#senese">
             <speaker>SENESE:</speaker>
             <l part="F">Son Filogono,</l>
             <l>Come ho detto; s'io non fossi, credetemi</l>
             <l part="I">Che non ve lo direi.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">O Dio, che audacia!</l>
             <l>Che viso invetriato! Tu Filogono</l>
             <l part="I">Sei di Catanea?</l>
           </sp>
-          <sp>
+          <sp who="#senese">
             <speaker>SENESE:</speaker>
             <l part="F">Ormai dovreste intendermi.</l>
             <l part="I">Che vi maravigliate?</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">Maravigliomi</l>
             <l>Come in un uomo tanta improntitudine</l>
@@ -3431,7 +3486,7 @@
             <l>Quel che son io, ribaldo, temerario,</l>
             <l part="I">Aggiuntator che sei.</l>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO:</speaker>
             <l part="F">Non fia ch'io toleri</l>
             <l>Che al padre del padron tu dica ingiuria;</l>
@@ -3446,36 +3501,36 @@
         <div type="scene" n="Scena VI">
           <head>SCENA VI</head>
           <stage>Filogono, Lizio, Ferrarese</stage>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="I">Lizio, che te ne par?</l>
           </sp>
-          <sp>
+          <sp who="#lizio">
             <speaker>LIZIO:</speaker>
             <l part="F">Che può parermene</l>
             <l>Se non mal? Mai non m'è piaciuto, a dirvi la</l>
             <l>Verità, questo nome Ferrara: eccovi</l>
             <l>Che ben gli effetti secondo il nome escono.</l>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERRARESE:</speaker>
             <l>Hai torto a dir mal de la nostra patria.</l>
             <l>Che colpa n'ha questa città? Non senti tu</l>
             <l>All'idioma, al parlar, che non debbe essere</l>
             <l>Ferrarese costui che vi fa ingiuria?</l>
           </sp>
-          <sp>
+          <sp who="#lizio">
             <speaker>LIZIO:</speaker>
             <l>Tutti n'avete colpa. Ma più debbesi</l>
             <l>Dare alli vostri rettori, che simili</l>
             <l>Barerie ne la terra lor comportano.</l>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERRARESE:</speaker>
             <l>Che san di questo li rettori? Credi tu</l>
             <l part="I">Che intendino ogni cosa?</l>
           </sp>
-          <sp>
+          <sp who="#lizio">
             <speaker>LIZIO:</speaker>
             <l part="F">Anzi, che intendino</l>
             <l>Poco e malvolentier, credo, e non voglino</l>
@@ -3483,42 +3538,42 @@
             <l>E le orecchie più aperte aver dovrebbeno</l>
             <l>Che le taverne gli usci la domenica.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="I">Parla dei pari tuoi, bestia.</l>
           </sp>
-          <sp>
+          <sp who="#lizio">
             <speaker>LIZIO:</speaker>
             <l part="F">Una coppia</l>
             <l>Saren, se Dio non ci aiuta, di bestie.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="I">Che faren?</l>
           </sp>
-          <sp>
+          <sp who="#lizio">
             <speaker>LIZIO:</speaker>
             <l part="F">Lodarei che noi cercassimo</l>
             <l>Di ritrovare in altra parte Erostrato.</l>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERRARESE:</speaker>
             <l>Io vi farò compagnia di bonissime</l>
             <l>Voglia: o alle Scuole il trovaremo, o al circulo</l>
             <l part="I">In Vescovato.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l>Io sono stanco; vogliolo</l>
             <l>Più tosto aspettar qui: forza è che capiti</l>
             <l part="I">Qui finalmente.</l>
           </sp>
-          <sp>
+          <sp who="#lizio">
             <speaker>LIZIO:</speaker>
             <l part="F">Patrone, io mi dubito</l>
             <l>Che troverà egli ancora un altro Erostrato.</l>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERRARESE:</speaker>
             <l>Eccovel là. Ma dove va? Aspettatemi,</l>
             <l>Ch'io gli vo' dir che voi siate qui. Erostrato,</l>
@@ -3528,108 +3583,108 @@
         <div type="scene" n="Scena VII">
           <head>SCENA VII</head>
           <stage>Erostrato, Ferrarese, Filogono, Lizio, Dalio</stage>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l>(Io non mi posso, insomma, più nascondere.</l>
             <l>Bisogna far un buon viso, un bon animo;</l>
             <l part="I">Altramente...)</l>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERRARESE:</speaker>
             <l part="F">O Erostrato, Filogono</l>
             <l>Vostro padre è venuto di Sicilia.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l>Cotesto non m'è nuovo: ben vedutolo</l>
             <l part="I">Ho, e son con lui stato un pezzo.</l>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERRARESE:</speaker>
             <l part="F">È possibile?</l>
             <l>Per quel che dice, non par che vedutovi</l>
             <l part="I">Abbia già ancora.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">E voi dove parlatogli</l>
             <l part="I">Avete e quando?</l>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERRARESE:</speaker>
             <l part="F">Eccovelo, vedetelo:</l>
             <l>Par che nol conosciate. Ecco, Filogono,</l>
             <l>Eccovi il caro figliuol vostro Erostrato.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l>Erostrato cotesto? Non è Erostrato</l>
             <l>Mio figliuol così fatto. Mi par essere</l>
             <l part="I">Dulippo: egli è Dulippo!</l>
           </sp>
-          <sp>
+          <sp who="#lizio">
             <speaker>LIZIO:</speaker>
             <l part="F">Chi ne dubita?</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="I">Chi è quest'uomo?</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">Oh, tu sei sì onorevole</l>
             <l>Di vesti! Tu pari un dottor! Che pratica</l>
             <l part="I">È questa?</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="M">A chi parla quest'uom?</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">Dio aiutami!</l>
             <l part="I">Non mi conosci tu?</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Non ho in memoria</l>
             <l part="I">D'avervi mai più veduto.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">Odi, Lizio!</l>
             <l>Vedi a che noi siàn giunti! Questo perfido,</l>
             <l>Questo ribaldo finge non conoscermi!</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l>Gentiluom, voi m'avete preso in cambio.</l>
           </sp>
-          <sp>
+          <sp who="#lizio">
             <speaker>LIZIO:</speaker>
             <l>Non vi diss'io ch'eramo in Ferrara? Eccovi</l>
             <l>La fé del vostro Dulippo, che simula</l>
             <l>Di non vi aver mai veduto. Attaccatogli</l>
             <l part="I">Ha il suo mal questa città.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">Taci, bestia.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l>Non ho nome Dulippo: domandatene</l>
             <l>Chi voi volete, che dal grande al piccolo</l>
             <l>Mi conoscono tutti: domandatene</l>
             <l>Costui, che è qui con voi. Come mi nomino?</l>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERRARESE:</speaker>
             <l>V'ho sempre conosciuto per Erostrato</l>
             <l>Di Catanea, et Erostrato vi nomina</l>
             <l part="I">Chi vi conosce.</l>
           </sp>
-          <sp>
+          <sp who="#lizio">
             <speaker>LIZIO:</speaker>
             <l part="F">Ormai dovreste accorgervi,</l>
             <l>Patron, che siàn tra bari. Questo giovene,</l>
@@ -3637,14 +3692,14 @@
             <l>S'accorda con Dulippo, e vuol che Erostrato</l>
             <l>Egli sia: e crede farlo anche a noi credere.</l>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERRARESE:</speaker>
             <l>A torto ti lamenti di me, Lizio.</l>
             <l>Costui non seppi mai ch'altro che Erostrato</l>
             <l>Fusse, e dal di che giunse di Sicilia</l>
             <l>Ho sentito che tutti così il chiamano.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l>E che potresti altrimente conoscermi</l>
             <l>Che per quello ch'io sono? E che mi debbono</l>
@@ -3652,29 +3707,29 @@
             <l>Ma ben son stolto che sto a udir le favole</l>
             <l part="I">Di questo vecchio.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">Ah, fuggitivo, ah pessimo</l>
             <l>Ribaldo! A questo, a questo modo, perfido,</l>
             <l>Si raccoglie il padron? C'hai tu di Erostrato</l>
             <l>Fatto, assassino, poiché 'l suo nome occupi?</l>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO:</speaker>
             <l>Anche qui abbaia questo cane? E io tolero</l>
             <l>Che così dica al mio patrone ingiuria?</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l>Ritorna in casa: a chi dico io? Che diavolo</l>
             <l part="I">Vuoi far di quel pestel di salsa?</l>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO:</speaker>
             <l part="F">Rompere</l>
             <l>Voglio il capo a questo vecchio farnetico.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l>E tu pon giù quel sasso: ritornatevi</l>
             <l>In casa tutti. Abbiasi reverenzia</l>
@@ -3684,7 +3739,7 @@
         <div type="scene" n="Scena VIII">
           <head>SCENA VIII</head>
           <stage>Filogono, Ferrarese, Lizio</stage>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l>Chi mi dee dare aiuto? A chi ricorrere</l>
             <l>Debbo, poi che costui, ch'io m'ho da tenero</l>
@@ -3704,13 +3759,13 @@
             <l>De la Natura, in centanai di secoli,</l>
             <l>Ch'altri mai che Dulippo potesse essere.</l>
           </sp>
-          <sp>
+          <sp who="#lizio">
             <speaker>LIZIO:</speaker>
             <l>Se in questa terra gli altri testimonii</l>
             <l>Son così fatti, facilmente debbono</l>
             <l>Li litiganti provar ciò che vogliono.</l>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERRARESE:</speaker>
             <l>O gentiluomo, poi che questo giovene</l>
             <l>Arrivò in questa terra, o di Sicilia</l>
@@ -3725,7 +3780,7 @@
             <l>Si puote. Ho detto quel ch'odo dir publica–</l>
             <l>mente e credevo che fusse verissimo.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l>Dunque costui ch'io diedi al mio carissimo</l>
             <l>Figliuol per mastro, per guida, per sozio,</l>
@@ -3742,14 +3797,14 @@
             <l>Capitan, Podestade o Commissario</l>
             <l>In questa terra, a ch'io possa ricorrere?</l>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERRARESE:</speaker>
             <l>Ci abbiamo Podestà, ci abbiamo Iudici,</l>
             <l>E sopra tutti un Principe iustissimo.</l>
             <l>Voi non avete da temer, Filogono,</l>
             <l>Che vi si manchi di ragione, avendola.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l>Per vostra fé, venite, andiamo al Principe,</l>
             <l>Al Podestade, o sia a qual altro Iudice,</l>
@@ -3757,20 +3812,20 @@
             <l>E lo più abominevol maleficio</l>
             <l>Che potesse uom pensar, non che commettere.</l>
           </sp>
-          <sp>
+          <sp who="#lizio">
             <speaker>LIZIO:</speaker>
             <l>Padrone, a chi vuol litigar bisognano</l>
             <l>Quattro cose: ragion, prima, bonissima;</l>
             <l>E poi chi ben la sappia dire; e terzio</l>
             <l part="I">Chi la faccia; e favor poi.</l>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERRARESE:</speaker>
             <l part="F">Di quest'ultima</l>
             <l>Parte non odo che le leggi facciano</l>
             <l>Menzïon. Che cosa è favor? Chiariscelo.</l>
           </sp>
-          <sp>
+          <sp who="#lizio">
             <speaker>LIZIO:</speaker>
             <l>Aver amici potenti, ch'al iudice</l>
             <l>Raccomandin la causa tua, che, vincere</l>
@@ -3780,7 +3835,7 @@
             <l>Che stanco al fin di spese, affanni, e strazi,</l>
             <l>Brami accordarsi teco il tuo avversario.</l>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERRARESE:</speaker>
             <l>Di questa parte, quantunque, Filogono,</l>
             <l>Non s'usi in questa terra, pur, avendone</l>
@@ -3789,7 +3844,7 @@
             <l>Avocato, che buono a sufficienzia</l>
             <l>Per tutte queste cose vi puote essere.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l>Dunque a questi che avocano e procurano</l>
             <l>Mi darò in preda? Alla cui insaziabile</l>
@@ -3809,25 +3864,25 @@
             <l>Non che i danar de la borsa, ma l'anima</l>
             <l part="I">Del corpo.</l>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERRARESE:</speaker>
             <l part="F">Questo avocato, Filogono,</l>
             <l>Ch'io vi propongo, non è agli altri simile:</l>
             <l part="I">È mezzo santo.</l>
           </sp>
-          <sp>
+          <sp who="#lizio">
             <speaker>LIZIO:</speaker>
             <l part="F">L'altro mezzo è diavolo,</l>
             <l>Forse.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">Ben dice Lizio. Anch'io pochissima</l>
             <l>Fede ho in questi che torto il capo portano,</l>
             <l>E con parole mansüete et umili</l>
             <l>Si van coprendo, fin che te l'attaccano.</l>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERRARESE:</speaker>
             <l>Costui ch'io vi propongo non vo' credere</l>
             <l>Che sia di questa sorte; ma mettiamo che</l>
@@ -3836,43 +3891,43 @@
             <l>Farà che, senza guardare al proprio utile,</l>
             <l>Vi darà aiuto e ogni favor possibile.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="I">Che nimicizia è la loro?</l>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERRARESE:</speaker>
             <l part="F">Diròvelo.</l>
             <l>Ambi per moglie una figlia domandano</l>
             <l>D'un nostro gentiluomo, e concorrenzia</l>
             <l part="I">Hanno d'amore.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">È dunque di tal credito,</l>
             <l>A mio costo, in Ferrara questo perfido,</l>
             <l>Ch'ardisce domandare a gentiluomini</l>
             <l part="I">Le figliuole?</l>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERRARESE:</speaker>
             <l part="M">Tant'è.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">Come si nomina</l>
             <l part="I">Questo dottor?</l>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERRARESE:</speaker>
             <l part="F">Messer Cleandro il dicono,</l>
             <l>De li primi che legghin ne lo Studio.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="I">Andiamo dunque a ritrovarlo.</l>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERRARESE:</speaker>
             <l part="F">Andiamovi.</l>
           </sp>
@@ -3883,7 +3938,7 @@
         <div type="scene" n="Scena I">
           <head>SCENA I</head>
           <stage>Erostrato finto</stage>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l>Questa, in fatti, è pur stata una disgrazia</l>
             <l>Grande, che prima che trovare Erostrato</l>
@@ -3912,7 +3967,7 @@
         <div type="scene" n="Scena II">
           <head>SCENA II</head>
           <stage>Pasifilo; Erostrato finto</stage>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l>(Due novelle ho sentite a me gratissime:</l>
             <l>L'una, che in casa di messere Erostrato</l>
@@ -3924,84 +3979,84 @@
             <l>D'intervenir di me, vengo in grandissima</l>
             <l>Fretta per ritrovarlo a casa, et eccolo.)</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l>Fammi un piacer, se tu m'ami, Pasifilo.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l>Chi v'ama più di me? Chi ha desiderio</l>
             <l>Più di me di servirvi? Commandatemi.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l>Va' costà un poco in casa di Damonio,</l>
             <l part="I">E domanda Dulippo, e digli...</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Avisovi</l>
             <l>Che non potrò parlargli, che l'è in carcere.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="I">Come in carcere? E dove?</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">In luogo pessimo.</l>
             <l part="I">Non più.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="M">Saine la causa?</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Non più: bastivi</l>
             <l>Aver da me saputo ch'egli è in carcere.</l>
             <l part="I">Io ve n'ho purtroppo detto</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Pasifilo,</l>
             <l>Vuo' che mi dichi il tutto, se mai grazia</l>
             <l part="I">Pensi di farmi.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Non vogliate astringermi.</l>
             <l part="I">Che tocca a voi saperlo?</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Assai, Pasifilo,</l>
             <l part="I">Più che non credi.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Et anco più che credere</l>
             <l>Voi non potreste, tocca ad altri il starmene</l>
             <l part="I">Cheto.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Cotesta è la fede, Pasifilo,</l>
             <l>C'ho in te? L'offerte tue così riescono?</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l>Digiunato avess'io più tosto e statomi</l>
             <l>Senza mangiar tutt'oggi intiero, ch'esservi</l>
             <l part="I">Venuto inanzi!</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">O mel dirai, Pasifilo,</l>
             <l>O che farai pensier mai più non mettere</l>
             <l part="I">Piè dentro a questa porta.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Voglio, Erostrato,</l>
             <l>Più tosto che la vostra nimicizia,</l>
@@ -4009,23 +4064,23 @@
             <l>Ma se udite novelle che vi increschino,</l>
             <l part="I">Vostra colpa.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Niente può rincrescermi</l>
             <l>Più che il mal di Dulippo: né il mio proprio.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l>Poi che così vi par, dunque diróvelo:</l>
             <l>È stato ritrovato questo povero</l>
             <l>Garzon che con la figlia di Damonio</l>
             <l part="I">Si giacia.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Ahimè! E l'ha saputo Damonio?</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l>L'ha una fante accusato, e il patron sùbito</l>
             <l>Prender l'ha fatto, e così ancora la balia</l>
@@ -4034,12 +4089,12 @@
             <l>In casa sua però, dove, al mio credere,</l>
             <l>Faran de' lor peccati penitenzia.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l>Va' in cucina, Pasifilo, e fa' cuocere</l>
             <l>E dispor quelle vivande a tuo arbitrio.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l>Se voi certo m'aveste fatto Iudice</l>
             <l>De' Savii, non mi avreste dato ufficio</l>
@@ -4049,7 +4104,7 @@
         <div type="scene" n="Scena III">
           <head>SCENA III</head>
           <stage>Erostrato finto solo</stage>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l>Più tosto che mi sia stato possibile</l>
             <l>Ho spinto via costui, perché le lacrime</l>
@@ -4107,29 +4162,29 @@
         <div type="scene" n="Scena IV">
           <head>SCENA IV</head>
           <stage>Pasifilo, Erostrato finto</stage>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l>Conciali pur, ma a fuoco non si mettino,</l>
             <l>Fin che non siamo per entrare a tavola.</l>
             <l>Io spero che il convito andrà per ordine;</l>
             <l>Ma s'io non ci ero, accadea qualche scandolo.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="I">Che scandalo accadea?</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Volea por Dalio</l>
             <l>La lonza a un tempo e i tordi in un medesimo</l>
             <l>Schidone al fuoco. Sciocco, non considera</l>
             <l>Che questa tarda, e quei tosto si cuocono!</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l>Fusse pur il maggior cotesto scandolo!</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l>E de' dua mali, un ne seguia certissimo:</l>
             <l>Se a par di quella i tordi si lasciavano,</l>
@@ -4137,17 +4192,17 @@
             <l>Avesse prima, freddi e dispiacevoli</l>
             <l part="I">Sariano stati.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="F">Auto hai bon iudicio.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l>Anderò in Piazza a comperar, parendovi</l>
             <l>Melarance et ulive, che, mancãndoci</l>
             <l>Tai cose, nulla varrebbe il convivio.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l>Nïente mancherà, non ne aver dubbio.</l>
           </sp>
@@ -4155,7 +4210,7 @@
         <div type="scene" n="Scena V">
           <head>SCENA V</head>
           <stage>Pasifilo</stage>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l>Poi ch'io gli ho detto che Dulippo è in carcere,</l>
             <l>Tutto è tornato bizzarro e fantastico.</l>
@@ -4174,7 +4229,7 @@
         <div type="scene" n="Scena VI">
           <head>SCENA VI</head>
           <stage>Cleandro, Filogono, Pasifilo, Lizio</stage>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Come potrete voi provar che Erostrato</l>
             <l>Non sia costui, essendoci contraria</l>
@@ -4184,7 +4239,7 @@
             <l>Il medesimo, e adduce in testimonio</l>
             <l>Quest'altro ch'ognun crede che sia Erostrato?</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l>Io voglio qui costituirmi in carcere,</l>
             <l>E che si mandi sùbito a Catanea,</l>
@@ -4195,156 +4250,156 @@
             <l>Son io, o colui; e così ancor se Erostrato</l>
             <l>O pur Dulippo è questo servo perfido.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="I">(Io lo vo' salutar.)</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Serà lunghissima</l>
             <l part="I">Via, e di gran spesa...</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="M">E sia.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">...ma necessaria:</l>
             <l>Ch'io non ci so veder altra a proposito.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l>Dio vi conservi, padron mio dolcissimo.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="I">A te dia quel che meriti.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">La grazia</l>
             <l>Vostra darammi, e godere in perpetuo.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Ti darà un laccio che t'impicchi, perfido,</l>
             <l part="I">Ghiotto, ribaldo, che tu sei!</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Confessovi</l>
             <l>Ch'io son ghiotto: ribaldo no, né perfido.</l>
             <l>Ma non so già perché mi dite ingiuria,</l>
             <l>S'io vi son servitore et amico ottimo.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="I">Che servitor? Che amico?</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Per Dio, ditemi:</l>
             <l part="I">In che v'ho offeso?</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Va' alle forche, lievati</l>
             <l part="I">Di qui</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Sempre ve ho auto in reverenzia.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Traditor, io te ne pagarò, renditi</l>
             <l part="I">Certo.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">E che tradimento può imputarmisi?</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Te lo farò ben con tuo danno intendere,</l>
             <l>Ladro, imbriaco, furfante, brutto asino.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l>Non son però vostro schiavo, ch'io toleri</l>
             <l>Che tuttavia mi diciate ignominia.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Porco, ancor hai d'aprir la bocca audacia?</l>
             <l>Io ti farò, se Dio mi lascia vivere...</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l>Quando ho sofferto e sofferto, che diavolo</l>
             <l>Mi farete? Non ho roba, né litigo,</l>
             <l>Ch'io tema che me la facciate perdere.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="I">Gaglioffo, manigoldo!</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Io mi credo essere</l>
             <l part="I">Tant'uomo da ben, quanto voi siate!</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Boia, tu</l>
             <l part="I">Ne menti per la gola.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">Ah no, la còlera</l>
             <l part="I">Non vi trasporti.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Ve' chi mi vuol battere!</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Io ti giungerò a tempo, lascia... E speroti</l>
             <l part="I">Far impiccare.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Or su, non vo' contendere</l>
             <l part="I">Con essolui.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">Voi siete entrato in còlera.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Questo tristo... Ma torniamo al proposito</l>
             <l>Nostro: non cessarò che, come merita,</l>
             <l>Lo tratterò. Seguite pur narrandomi</l>
             <l part="I">Il caso vostro.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">Quietate un po' l'animo,</l>
             <l>Che così mi darete mal udienzia.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>No, dite pur, v'ascolterò benissimo.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l>Io dico che si mandi uno a Catanea,</l>
             <l part="I">E che si faccia...</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Questo ho inteso: e al credere</l>
             <l>Mio, non si può miglior partito prendere.</l>
@@ -4352,36 +4407,36 @@
             <l>Fate ch'io sappia in che modo, informatemi</l>
             <l part="I">A pieno d'ogni cosa.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">Informaròvene.</l>
             <l>Al tempo che li Turchi Otranto presero...</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Voi mi tornate i miei danni a memoria.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="I">Come?</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Che allora io fui cacciato, misero!</l>
             <l>Di quella terra che era la mia patria;</l>
             <l>E tanto vi perdei, che sempre povero</l>
             <l part="I">Ne sarò et infelice.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">D'ogni incommodo</l>
             <l part="I">Vostro mi duol.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="M">Seguite.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">In quel medesimo</l>
             <l>Tempo fur alcun nostri di Sicilia,</l>
@@ -4389,11 +4444,11 @@
             <l>Ch'ebbero spia che di preda ricchissima</l>
             <l>Un legno d'infedel tornava carico...</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>E v'era su del mio, forse, in gran copia!</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l>E alla volta di quel se ne andarono,</l>
             <l>E fur seco alle mani. Al fin lo presero,</l>
@@ -4402,76 +4457,76 @@
             <l>Ci avean questo ribaldo, che al mio credere</l>
             <l>Non dovea ancora alli cinque anni giungere.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Uno, ah misero me!, de la medesima</l>
             <l part="I">Etade vi perdei.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">E ritrovandomi</l>
             <l>Io quivi, e assai l'aspetto suo piacendomi,</l>
             <l>Profersi lor venti ducati, et ebbilo.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Era il fanciullo turco, o pur l'avevano</l>
             <l part="I">In Otranto rapito quei Turchi?</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">Eglino,</l>
             <l>Ch'era il fanciullo d'Otranto, dicevano.</l>
             <l>Ma che ha a far questo? Io lo comprai, e spesivi</l>
             <l part="I">Il mio danaio.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Nol dico, Filogono,</l>
             <l>Per disputar se valse o no la vendita.</l>
             <l part="I">Deh, fosse egli quello!</l>
           </sp>
-          <sp>
+          <sp who="#lizio">
             <speaker>LIZIO:</speaker>
             <l part="M">Stiàn freschi!</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Ditemi:</l>
             <l part="I">Avea egli nome allor Dulippo?</l>
           </sp>
-          <sp>
+          <sp who="#lizio">
             <speaker>LIZIO:</speaker>
             <l part="F">Abbiatevi</l>
             <l part="I">Cura, patron.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">Che ti vuoi tu intromettere?</l>
             <l>Dulippo no, ma Carino era il proprio</l>
             <l part="I">Nome.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="M">Carino? O Dio!</l>
           </sp>
-          <sp>
+          <sp who="#lizio">
             <speaker>LIZIO:</speaker>
             <l part="F">Sì, sì lasciatevi</l>
             <l part="I">Pur trar di bocca ogni cosa.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">O Dio ottimo,</l>
             <l>S'oggi volesse farmi felicissimo!</l>
             <l>E perché il nome gli mutaste proprio?</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l>Dulippo detto fu, perché nel piangere</l>
             <l>Sempre chiamar questo nome era solito.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Io son ben certo che questo è il mio unico</l>
             <l>Figliuol, che insieme perdei con la patria:</l>
@@ -4480,64 +4535,64 @@
             <l>Quando piangeva, era un de' miei dimestici</l>
             <l>Che lo nutriva, e che n'avea custodia.</l>
           </sp>
-          <sp>
+          <sp who="#lizio">
             <speaker>LIZIO:</speaker>
             <l>Altrove ancor che nel Regno di Napoli</l>
             <l>Si truova Bari: in Ferrara trovatolo</l>
             <l>Avrai. Costui ti vorrà dare a intendere</l>
             <l>Che del tuo servo è padre, per levartelo.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="I">Non dissi mai bugia.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">Non ci interrompere,</l>
             <l part="I">Temerario.</l>
           </sp>
-          <sp>
+          <sp who="#lizio">
             <speaker>LIZIO:</speaker>
             <l part="F">Ogni cosa vuol principio.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Deh, non abbiate, Filogono, un minimo</l>
             <l part="I">Sospetto ch'io vi inganni.</l>
           </sp>
-          <sp>
+          <sp who="#lizio">
             <speaker>LIZIO:</speaker>
             <l part="F">Non un minimo</l>
             <l>Sospetto n'ha d'aver, ma si un grandissimo.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Taci tu un poco. Il fanciullo, o Filogono,</l>
             <l>Tenea del nome del padre memoria,</l>
             <l>O de la madre, o de la sua progenie?</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l>Si ricordava de la madre, et hallami</l>
             <l>Già nominata; ma non l'ho in memoria.</l>
           </sp>
-          <sp>
+          <sp who="#lizio">
             <speaker>LIZIO:</speaker>
             <l part="I">Ce l'ho ben io.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Dillo tu, dunque, Lizio.</l>
           </sp>
-          <sp>
+          <sp who="#lizio">
             <speaker>LIZIO:</speaker>
             <l part="I">Non dirò già.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="M">Dillo, se 'l sai.</l>
           </sp>
-          <sp>
+          <sp who="#lizio">
             <speaker>LIZIO:</speaker>
             <l part="F">Saputone</l>
             <l>Ha purtroppo da voi: prima che dirglielo</l>
@@ -4545,19 +4600,19 @@
             <l>Pur ch'egli va a tenton: se lo sa, dicalo</l>
             <l part="I">Prima di noi.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Cotesto mi fia facile:</l>
             <l>La mia moglie, e sua madre, era Sofronia</l>
             <l part="I">Nominata.</l>
           </sp>
-          <sp>
+          <sp who="#lizio">
             <speaker>LIZIO:</speaker>
             <l part="F">Per Dio, gran fatto, essendovi</l>
             <l>Insieme già accordati, che egli dettovi</l>
             <l>Abbia, che nominata era Sofronia!</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Non mi bisogna più evidenti indicii,</l>
             <l>Che questo è il mio figliuol senza alcun dubbio,</l>
@@ -4566,12 +4621,12 @@
             <l>Sinistro aver un segno rosso, simile</l>
             <l part="I">Ad una mora.</l>
           </sp>
-          <sp>
+          <sp who="#lizio">
             <speaker>LIZIO:</speaker>
             <l part="F">Il segno v'ha: v'avess'egli</l>
             <l>Così...</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Buone parole! Ah Lizio, andiamolo</l>
             <l>A ritrovare. Oh Fortuna, ben libera–</l>
@@ -4579,35 +4634,35 @@
             <l>Poi che mi fai ritrovare il carissimo</l>
             <l part="I">Mio figliuolo.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">Io gli ho tanto men obligo,</l>
             <l>Che 'l mio ho perduto: e voi che favorevole</l>
             <l>Speravo avere, or veggo che contrario</l>
             <l part="I">Mi sarete e nimico.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Andiàn, Filogono,</l>
             <l>A trovar mio figliuol, che par che l'animo</l>
             <l>Mi dica, che trovarete medesima–</l>
             <l part="I">mente il vostro.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="M">Andiamo.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Poi che truovo le</l>
             <l>Porte aperte, entraremo alla dimestica.</l>
           </sp>
-          <sp>
+          <sp who="#lizio">
             <speaker>LIZIO:</speaker>
             <l>Deh guardati, padron, che in qualche trappola</l>
             <l part="I">Non vi meni costui.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l part="F">Quasi, se Erostrato</l>
             <l>Perduto avessi, io mi curassi vivere!</l>
@@ -4616,55 +4671,55 @@
         <div type="scene" n="Scena VII">
           <head>SCENA VII</head>
           <stage>Damonio, Psiteria</stage>
-          <sp>
+          <sp who="#damonio">
             <speaker>DAMONIO:</speaker>
             <l>Vien qua, cianciera e temeraria femina!</l>
             <l>Come sapria questa cosa Pasifilo,</l>
             <l>Se tu non gli l'avessi fatto intendere?</l>
           </sp>
-          <sp>
+          <sp who="#psiteria">
             <speaker>PSITERIA:</speaker>
             <l>Messer, non l'ha già da me intesa, e dicovi</l>
             <l>Che egli è stato il primo a domandarmene.</l>
           </sp>
-          <sp>
+          <sp who="#damonio">
             <speaker>DAMONIO:</speaker>
             <l>Tu ne menti, ribalda; ma delibera</l>
             <l>Di dire il vero, o che cotesto fradico</l>
             <l>Carcame d'osso in osso io t'abbia a rompere.</l>
           </sp>
-          <sp>
+          <sp who="#psiteria">
             <speaker>PSITERIA:</speaker>
             <l>Se ritrovate altrimenti, amazzatemi</l>
             <l part="I">Ancora.</l>
           </sp>
-          <sp>
+          <sp who="#damonio">
             <speaker>DAMONIO:</speaker>
             <l part="M">E dove ti parlò?</l>
           </sp>
-          <sp>
+          <sp who="#psiteria">
             <speaker>PSITERIA:</speaker>
             <l part="F">Qui proprio</l>
             <l part="I">Ne la via, non è un'ora.</l>
           </sp>
-          <sp>
+          <sp who="#damonio">
             <speaker>DAMONIO:</speaker>
             <l part="F">E che facevi tu</l>
             <l part="I">Qui?</l>
           </sp>
-          <sp>
+          <sp who="#psiteria">
             <speaker>PSITERIA:</speaker>
             <l part="F">Andavo a casa di mona Beritola,</l>
             <l>Per veder una mia tela che a tessere</l>
             <l part="I">Le ho data.</l>
           </sp>
-          <sp>
+          <sp who="#damonio">
             <speaker>DAMONIO:</speaker>
             <l>E che accadea così a Pasifilo</l>
             <l>Di parlar teco, se tu già, ria femina,</l>
             <l>Non eri prima a cominciar la favola?</l>
           </sp>
-          <sp>
+          <sp who="#psiteria">
             <speaker>PSITERIA:</speaker>
             <l>Anzi, egli fu che cominciò a riprendermi</l>
             <l>E dirmi ingiuria, che a voi questa pratica</l>
@@ -4675,7 +4730,7 @@
             <l>E credo veramente che appiattatosi</l>
             <l part="I">Era fra il fieno ne la stalla.</l>
           </sp>
-          <sp>
+          <sp who="#damonio">
             <speaker>DAMONIO:</speaker>
             <l part="F">Ah misero,</l>
             <l>Me! Che farò? Che farò? Ahi lasso! Lievate</l>
@@ -4715,42 +4770,42 @@
         <div type="scene" n="Scena VIII">
           <head>SCENA VIII</head>
           <stage>Pasifilo, Damonio</stage>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l>O Dio, ch'io trovi in casa ora Damonio!</l>
           </sp>
-          <sp>
+          <sp who="#damonio">
             <speaker>DAMONIO:</speaker>
             <l part="I">(Che vuol da me?)</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Ch'io giunga primo a dirglilo!</l>
           </sp>
-          <sp>
+          <sp who="#damonio">
             <speaker>DAMONIO:</speaker>
             <l>(Che mi vuol dire? Onde vien tanto gaudio,</l>
             <l part="I">Che così salta?)</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">O me felice! Veggolo</l>
             <l part="I">Là ne la via.</l>
           </sp>
-          <sp>
+          <sp who="#damonio">
             <speaker>DAMONIO:</speaker>
             <l part="F">Che novella, Pasifilo,</l>
             <l>Mi arrechi? Donde vien tanta letizia?</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="I">Quïete, pace, contento vi annunzio.</l>
           </sp>
-          <sp>
+          <sp who="#damonio">
             <speaker>DAMONIO:</speaker>
             <l part="I">Ne avrei bisogno.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Io so che di malissima</l>
             <l>Voglia sète d'un caso intervenutovi,</l>
@@ -4761,11 +4816,11 @@
             <l>Può; né voi, ben che siate ricco e nobile,</l>
             <l>Vi avete da sdegnar che vi sia genero.</l>
           </sp>
-          <sp>
+          <sp who="#damonio">
             <speaker>DAMONIO:</speaker>
             <l part="I">Che ne sai tu?</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Or suo padre Filogono</l>
             <l>Di Catanea, che dovete conoscere</l>
@@ -4773,11 +4828,11 @@
             <l>Ricchezza, è qui arrivato di Sicilia</l>
             <l part="I">In casa di questo vicin.</l>
           </sp>
-          <sp>
+          <sp who="#damonio">
             <speaker>DAMONIO:</speaker>
             <l part="F">Di Erostrato?</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l>Anzi pur di Dulippo. Ben credevasi</l>
             <l>Che questo vicin vostro fusse Erostrato,</l>
@@ -4791,20 +4846,20 @@
             <l>Vostri; e con questo mezzo, con più commodo,</l>
             <l>Venisse a fine del suo desiderio.</l>
           </sp>
-          <sp>
+          <sp who="#damonio">
             <speaker>DAMONIO:</speaker>
             <l>Dunque falso non è quel che narratomi</l>
             <l part="I">Ha Polinesta?</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Dice ella il medesimo?</l>
           </sp>
-          <sp>
+          <sp who="#damonio">
             <speaker>DAMONIO:</speaker>
             <l>Sì, ma che fosse una ciancia credevomi.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l>State sicur, che è verità verissima.</l>
             <l>Voi vederete ora venir Filogono</l>
@@ -4821,13 +4876,13 @@
             <l>Da lor potrete chiarirvi benissimo,</l>
             <l>Che veràn qui; né credo molto indugino.</l>
           </sp>
-          <sp>
+          <sp who="#damonio">
             <speaker>DAMONIO:</speaker>
             <l>Io voglio da Dulippo, o sia da Erostrato</l>
             <l>Udir a punto tutta questa istoria,</l>
             <l>Prima ch'io venga a parlar con Filogono.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l>Sarà ben fatto: io dirò lor che tardino</l>
             <l>Ancora un poco; ma veggo che vengono.</l>
@@ -4836,7 +4891,7 @@
         <div type="scene" n="Scena IX">
           <head>SCENA IX</head>
           <stage>Senese, Cleandro, Filogono</stage>
-          <sp>
+          <sp who="#senese">
             <speaker>SENESE:</speaker>
             <l>Non accade né all'un né all'altro stendervi</l>
             <l>Per far le scuse in cosi lungo prologo;</l>
@@ -4854,7 +4909,7 @@
             <l>Debb'io e senza disdegno, essendo pratica</l>
             <l part="I">D'amore.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l part="F">Così è il vero; è ormai superfluo</l>
             <l>A dirne più. Vi può, gentiluomo, essere</l>
@@ -4868,7 +4923,7 @@
             <l>Per altra via non era che a notizia</l>
             <l>Venissi mai del mio figliuol carissimo.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l>Credo che sia così, né che una minima</l>
             <l>Foglia qua giù si muova senza l'ordine</l>
@@ -4876,7 +4931,7 @@
             <l>Ch'ogni momento mi par un lunghissimo</l>
             <l>Anno, che a ritrovar tardo il mio Erostrato.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Andiàn noi. Gentiluom, meglio è tornarvene;</l>
             <l>E tu, Carino, in casa; che non debbono</l>
@@ -4887,12 +4942,12 @@
         <div type="scene" n="Scena X">
           <head>SCENA X</head>
           <stage>Pasifilo, Cleandro</stage>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l>Messer Cleandro, non debbo aver grazia</l>
             <l>Che mi diciate ove v'ho fatto ingiuria?</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Pasifilo mio caro, io son chiarissimo</l>
             <l>Che quello che t'ho detto, te l'ho indebita–</l>
@@ -4901,14 +4956,14 @@
             <l>Che di ragion non ci dovea aver credito,</l>
             <l>M'ha fatto in questo fallo teco incorrere.</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l>Mi piace che non sia da la malizia</l>
             <l>La ragion tutta oppressa. Pur si facile,</l>
             <l>Per Dio, non dovevate essere a credere,</l>
             <l>E dirmi tanto obrobrio e tanto incarico.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Non più, tu hai ragione, il mio Pasifilo.</l>
             <l>Son tuo, come.fui sempre; et accennandomi,</l>
@@ -4920,7 +4975,7 @@
         <div type="scene" n="Scena XI">
           <head>SCENA XI</head>
           <stage>Cleandro, Filogono, Damonio, Erostrato, Pasifilo</stage>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Veniamo a voi per rivoltarvi in gaudio,</l>
             <l>Damonio, la mestizia, la qual debita–</l>
@@ -4937,7 +4992,7 @@
             <l>Molto superïor, come per publica</l>
             <l>Fama devete aver chiara notizia.</l>
           </sp>
-          <sp>
+          <sp who="#filogono">
             <speaker>FILOGONO:</speaker>
             <l>Et io, presente questi gentiluomini,</l>
             <l>Vi proferisco mio figliuol per genero:</l>
@@ -4945,7 +5000,7 @@
             <l>Altra cosa far posso, comandatemi,</l>
             <l>Che mi ci trovarete paratissimo.</l>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLEANDRO:</speaker>
             <l>Et io, che vostra figlia in matrimonio</l>
             <l>Vi domandavo, di voi contentissimo</l>
@@ -4960,7 +5015,7 @@
             <l>Avea perduto, ho trovato, Dio grazia,</l>
             <l>Come più ad agio poi vi farò intendere.</l>
           </sp>
-          <sp>
+          <sp who="#damonio">
             <speaker>DAMONIO:</speaker>
             <l>Il parentado vostro e la amicizia,</l>
             <l>Per molte condizion che in voi si truovano,</l>
@@ -4979,11 +5034,11 @@
             <l>Eccovi il vostro figliuolo e mio genero.</l>
             <l part="I">E questa è vostra nuora.</l>
           </sp>
-          <sp>
+          <sp who="#erostrato">
             <speaker>EROSTRATO:</speaker>
             <l part="M">O mio padre!</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Eccovi</l>
             <l>Quanto sono ai figliuoli i padri teneri!</l>
@@ -4993,7 +5048,7 @@
             <l>Ma che volete voi qui far in publico?</l>
             <l part="I">Andiamo in casa.</l>
           </sp>
-          <sp>
+          <sp who="#damonio">
             <speaker>DAMONIO:</speaker>
             <l part="F">Ben dice Pasifilo:</l>
             <l>Andiamo in casa e staren con più commodo.</l>
@@ -5002,20 +5057,20 @@
         <div type="scene" n="Scena XII">
           <head>SCENA XII</head>
           <stage>Nevola, Damonio, Pasifilo</stage>
-          <sp>
+          <sp who="#nevola">
             <speaker>NEVOLA:</speaker>
             <l part="I">Ho portato, padrone, i ferri.</l>
           </sp>
-          <sp>
+          <sp who="#damonio">
             <speaker>DAMONIO:</speaker>
             <l part="F">Portali</l>
             <l part="I">Via.</l>
           </sp>
-          <sp>
+          <sp who="#nevola">
             <speaker>NEVOLA:</speaker>
             <l part="M">Che n'ho a far?</l>
           </sp>
-          <sp>
+          <sp who="#pasifilo">
             <speaker>PASIFILO:</speaker>
             <l part="F">Che quanto è lungo il manico</l>
             <l>Tu te li chiavi... ben m'intendi, Nevola?</l>

--- a/tei/ariosto-i-suppositi.xml
+++ b/tei/ariosto-i-suppositi.xml
@@ -81,6 +81,61 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="nutr">
+            <persName>Nutrice</persName>
+          </person>
+          <person xml:id="polin">
+            <persName>Polinesta</persName>
+          </person>
+          <person xml:id="clean">
+            <persName>Cleandro</persName>
+          </person>
+          <person xml:id="pasif">
+            <persName>Pasifilo</persName>
+          </person>
+          <person xml:id="dulip">
+            <persName>Dulippo</persName>
+          </person>
+          <person xml:id="capr">
+            <persName>Caprino</persName>
+          </person>
+          <person xml:id="erost">
+            <persName>Erostrato</persName>
+          </person>
+          <person xml:id="san">
+            <persName>Sanese</persName>
+          </person>
+          <person xml:id="servo">
+            <persName>Servo</persName>
+          </person>
+          <person xml:id="car">
+            <persName>Carione</persName>
+          </person>
+          <person xml:id="dalio">
+            <persName>Dalio</persName>
+          </person>
+          <person xml:id="dam">
+            <persName>Damone</persName>
+          </person>
+          <person xml:id="nebb">
+            <persName>Nebbia</persName>
+          </person>
+          <person xml:id="psit">
+            <persName>Psiteria</persName>
+          </person>
+          <person xml:id="filog">
+            <persName>Filogono</persName>
+          </person>
+          <person xml:id="ferrarese">
+            <persName>Un Ferrarese</persName>
+          </person>
+          <person xml:id="lico">
+            <persName>Lico</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione - OCR</change>
@@ -206,135 +261,135 @@
         <div type="scene">
           <head>SCENA PRIMA</head>
           <stage>NUTRICE e POLINESTA</stage>
-          <sp>
+          <sp who="#nutr">
             <speaker>NUTR.</speaker>
             <p>Nessuno appare; sì che esci, Polinesta, ne la via, dove ci potremo vedere intorno, e seremo certe almeno non essere da alcun altro udite. Credo che in casa nostra sino le lettiere e le casse e li usci abbino li orecchi.</p>
           </sp>
-          <sp>
+          <sp who="#polin">
             <speaker>POLIN.</speaker>
             <p>E bigonciuoli e pentole l'hanno similmente.</p>
           </sp>
-          <sp>
+          <sp who="#nutr">
             <speaker>NUTR.</speaker>
             <p>Tu motteggi pure, ma ti serebbe meglio, in fé di Dio, che tu fussi più cauta che non sei. Io t'ho detto mille volte che tu ti guardi di parlare, che tu sia veduta, con Dulippo.</p>
           </sp>
-          <sp>
+          <sp who="#polin">
             <speaker>POLIN.</speaker>
             <p>Perché non vuoi tu ch'io gli parli così come io faccio agli altri?</p>
           </sp>
-          <sp>
+          <sp who="#nutr">
             <speaker>NUTR.</speaker>
             <p>A questo «perché» t'ho risposto più volte; ma tu vuoi fare a tuo senno, e te e Dulippo e me precipiterai a un tratto.</p>
           </sp>
-          <sp>
+          <sp who="#polin">
             <speaker>POLIN.</speaker>
             <p>Maisì, gli è bene un gran pericolo!</p>
           </sp>
-          <sp>
+          <sp who="#nutr">
             <speaker>NUTR.</speaker>
             <p>Tu te ne avedrai. Ti dovrebbe pure essere a bastanza che per il mezo mio vi trovate tutta la notte insieme, benché io il facci mal volentieri, e vorrei che l'animo tuo in più onorevole amore di questo si fussi occupato. Duolmi che, lasciando tanti nobilissimi giovani, che ti averieno amata e per moglie congiuntisi, tu ti abbi per amatore eletto uno famiglio di tuo padre, dal quale non ne puoi se non vergogna attendere.</p>
           </sp>
-          <sp>
+          <sp who="#polin">
             <speaker>POLIN.</speaker>
             <p>Chi n'è stato principio se non la nutrice mia? che tu continuamente lodandomi, or la bellezza sua, or li gentili costumi, or persuadendomi che egli oltramodo mi amava, non cessasti pormelo in grazia, e farmi di lui pietosa, e successivamente accendermi del suo amore, come io ne sono.</p>
           </sp>
-          <sp>
+          <sp who="#nutr">
             <speaker>NUTR.</speaker>
             <p>È vero che da principio te lo raccomandai per la compassione che io ne avevo, per le continue preci con che mi sollecitava.</p>
           </sp>
-          <sp>
+          <sp who="#polin">
             <speaker>POLIN.</speaker>
             <p>Anzi per la pensione e prezzo che tu ne traevi.</p>
           </sp>
-          <sp>
+          <sp who="#nutr">
             <speaker>NUTR.</speaker>
             <p>Tu puoi credere quel che ti pare: tuttavia renditi certa che se io avessi pensato che poscia voi dovessi procedere così inanzi, né per compassione o pensione o prece o prezzo te ne arei parlato.</p>
           </sp>
-          <sp>
+          <sp who="#polin">
             <speaker>POLIN.</speaker>
             <p>Chi la prima notte lo condusse al mio letto se non tu? Chi altri che tu? Deh taci, per tua fé, che mi faresti dire qualche pazzia.</p>
           </sp>
-          <sp>
+          <sp who="#nutr">
             <speaker>NUTR.</speaker>
             <p>Or serò stata io cagione di tutto il male!</p>
           </sp>
-          <sp>
+          <sp who="#polin">
             <speaker>POLIN.</speaker>
             <p>Anzi di tutto il bene. Sappi, nutrice mia, che io non amo Dulippo né un famiglio, e ho posto più degnamente il cor mio che non ti pensi; ma non ti vo' dire più inanzi.</p>
           </sp>
-          <sp>
+          <sp who="#nutr">
             <speaker>NUTR.</speaker>
             <p>Ho piacere che tu abbi mutato proposito.</p>
           </sp>
-          <sp>
+          <sp who="#polin">
             <speaker>POLIN.</speaker>
             <p>Anzi non l'ho mutato né voglio mutarlo.</p>
           </sp>
-          <sp>
+          <sp who="#nutr">
             <speaker>NUTR.</speaker>
             <p>Che di' tu adunque?</p>
           </sp>
-          <sp>
+          <sp who="#polin">
             <speaker>POLIN.</speaker>
             <p>Che io non amo Dulippo né un famiglio, e non ho mutato né mutar voglio proposito.</p>
           </sp>
-          <sp>
+          <sp who="#nutr">
             <speaker>NUTR.</speaker>
             <p>O questo non può stare insieme, o io non t'intendo; sì che parlami chiaro.</p>
           </sp>
-          <sp>
+          <sp who="#polin">
             <speaker>POLIN.</speaker>
             <p>Non ti voglio dire altro, perché ho dato la fede di tacerlo.</p>
           </sp>
-          <sp>
+          <sp who="#nutr">
             <speaker>NUTR.</speaker>
             <p>Stai di narrarlo per dubbio ch'io lo riveli? Tu ti fidi di me in quello che importa l'onore e la vita; e temi ora narrarmi questo, che certissima sono essere di poco momento verso li altri segreti di che io sono di te consapevole?</p>
           </sp>
-          <sp>
+          <sp who="#polin">
             <speaker>POLIN.</speaker>
             <p>La cosa è di più importanza che non ti pensi; e volentieri te la dirò quando tu mi prometta, non solo di tacerla, ma di non fare alcun segno onde suspicare si possa che tu lo sappi.</p>
           </sp>
-          <sp>
+          <sp who="#nutr">
             <speaker>NUTR.</speaker>
             <p>Così ti do la fede mia; sì che parla sicuramente.</p>
           </sp>
-          <sp>
+          <sp who="#polin">
             <speaker>POLIN.</speaker>
             <p>Sappi che costui, che tu reputi che sia Dulippo, è nobililsimo siciliano, e il suo vero nome è Erostrato, figliuolo di Filogono, uno dei più ricchi uomini di quel paese.</p>
           </sp>
-          <sp>
+          <sp who="#nutr">
             <speaker>NUTR.</speaker>
             <p>Come? Erostrato? Non è Erostrato, figliuolo di Filogono, questo vicin nostro, il quale...</p>
           </sp>
-          <sp>
+          <sp who="#polin">
             <speaker>POLIN.</speaker>
             <p>Taci, se tu vuoi, e ascoltami, che io ti chiarirò del tutto. Quello che insino a qui Dulippo hai reputato, è, come io ti dico, Erostrato, el quale venne per dare opera agli studi in questa città; et essendo a pena uscito di nave, mi scontrò ne la Via Grande, e subito s'innamorò di me; e di tale veemenza fu questo amore suo, che in un tratto mutò consiglio, e gittò da parte i libri e i panni lunghi, e deliberossi che io sola el suo studio fussi; e per avere più commodità di vedermi e di ragionare meco, cambiò li panni, el nome e la condizione con Dulippo suo servo, che solo aveva di Sicilia menato con lui: sì che egli, quel dì medesimo, di Erostrato e patrone e studente, si fe' Dulippo famiglio, e ne l'abito che tu vedi, studente d'amore; e tanto per diversi mezi tramò, che dopo alcun dì gli venne fatto d'acconciarsi per famiglio di mio padre.</p>
           </sp>
-          <sp>
+          <sp who="#nutr">
             <speaker>NUTR.</speaker>
             <p>E questa cosa tu l'hai per certa?</p>
           </sp>
-          <sp>
+          <sp who="#polin">
             <speaker>POLIN.</speaker>
             <p>Per certissima. Da l'altra parte Dulippo facendosi nominare Erostrato, con le veste del padrone suo, e libri et altre cose convenienti a chi studia, e con la reputazione di essere figliuolo di Filogono, cominciò a dare opera alle lettere, ne le quali ha fatto profitto et è venuto in buon credito.</p>
           </sp>
-          <sp>
+          <sp who="#nutr">
             <speaker>NUTR.</speaker>
             <p>Non abitano altri Siciliani qui, o non ce ne sono intanto mai venuti, che gli abbino scoperti?</p>
           </sp>
-          <sp>
+          <sp who="#polin">
             <speaker>POLIN.</speaker>
             <p>Non ce n'è capitato alcuno per stanziarsici, e pochi per transito ancora.</p>
           </sp>
-          <sp>
+          <sp who="#nutr">
             <speaker>NUTR.</speaker>
             <p>È stata gran ventura. Ma come insieme convengono queste cose, che lo studente, el quale tu vuoi che sia Dulippo, e non Erostrato, ti ha fatto domandare per moglie a tuo padre?</p>
           </sp>
-          <sp>
+          <sp who="#polin">
             <speaker>POLIN.</speaker>
             <p>È una fizione che si fa per disturbare il dottoraccio de la berretta lunga, el quale con ogni instanzia procura avermi per moglie. Ahimè! non è egli quello che viene in qua? Che bel marito! Mi farei bene inanzi monaca.</p>
           </sp>
-          <sp>
+          <sp who="#nutr">
             <speaker>NUTR.</speaker>
             <p>Tu hai ragione certo. Come ne viene per farsi vedere! O Dio, che pazza cosa è un vecchio innamorato!</p>
           </sp>
@@ -342,243 +397,243 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>CLEANDRO <emph>dottore</emph>, PASIFILO <emph>parassito</emph> </stage>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p>Non erano ora, Pasifilo, gente inanzi a quella porta?</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>Sì, erano, sapientissimo Cleandro: non ci hai tu veduto Polinesta tua?</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p>Eravi Polinesta mia? Per Dio, non l'ho conosciuta.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>Non me ne maraviglio: oggi è uno aer grosso e mezo nebbioso, et io l'ho più compresa ai panni, che io l'abbia raffigurata al viso.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p>Io, Dio grazia, di mia etade ho assai buona vista e sento in me poca differenza da quel ch'io ero di venticinque o trenta anni.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>E perché non? sei tu forse vecchio?</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p>Io sono ne li cinquantasei anni.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>(Ne dice dieci manco!)</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p>Che di' tu: dieci manco?</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>Dico che io ti stimavo di dieci manco: non mostri passare trentasei o trentotto anni al più.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p>Io sono pure al termine che io ti narro.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>In buona etade sei tu, e l'abitudine tua promette che arriverai alli cento anni. Lasciami vedere la mano.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p>Sei tu chiromante?</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>Chi ne fa maggior professione di me? Mostramela, di grazia. O bella e netta linea, non ne vidi un'altra mai così lunga: tu camperai più che Melchisedech.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p>Tu vuoi dir Matusalem.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>Io credevo che fussi tutto uno.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p>Tu sei poco dotto ne la Bibia.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>Anzi dottissimo, ma in quella che sta ne la botte. Oh come buono è questo monte di Venere! ma non siamo in loco commodo: vogliotela vedere un'altra matina ad agio, e ti farò intendere cose che ti piaceranno.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p>Tu mi farai cosa gratissima. Ma dimmi: di chi ti credi che Polinesta più si contentasse, avendol per marito, o di Erostrato o di me?</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>Di te sanza dubbio: ella è una giovane magnanima; fa più conto de la reputazione che acquisterà per esser tua moglie, che di ciò che all'incontro sperar possa da quel scolare, che Dio sa quel ch'egli è a casa sua!</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p>El fa molto el magnifico in questa terra.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>Sì, dove non è chi gli dica il contrario. Ma facci a sua posta: la tua virtù val più che tutta Sicilia.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p>A me non convien lodare me stesso; tuttavia dirò pure, per la veritade, che la mia scienza al bisogno mi è più valsa che tutta la roba che io avessi potuto avere. Io uscii di Otranto, che è la patria mia, quando fu preso da' Turchi, in giubbone, e venni a Padova prima, e di lì in questa città; dove leggendo, avocando e consigliando, in spazio di venti anni ho acquistato il valere di quindici mila ducati o più.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>Queste sono vere virtù. Che filosofia? che poesia? Tutto il resto de le scienzie, verso quelle de le leggi, mi paiono ciancie.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p>Ciancie ben dicesti; unde versus: Opes dat sanctio Iustiniana; Ex aliis paleas, ex istis collige grana.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>O buono! Di chi è? di Virgilio?</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p>Che Virgilio? è d'una nostra glosa escellentissima.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>Bello e moral certo, e degno di porsi in lettere d'oro. Tu déi avere acquistato oggimai più di quello che a Otranto lasciasti.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p>Triplicato ho le mie facultà: è vero che io vi persi uno figliolino di cinque anni, che avevo più caro che quanta roba sia al mondo.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>Ah! troppo gran perdita veramente.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p>Non so se morisse o pure ancora viva in captivitade.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>Io piango per compassione che n'ho; ma sta di buona voglia, che con Polinesta ne acquisterai de gli altri.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p>Che pensi tu di queste lunghe che Damone mi dà?</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>È il padre desideroso di ben locare la figliuola: prima che determini, vuol pensarci e ripensarci un pezzo; ma non dubito punto che al tuo favore non si risolva in fine.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p>Gli hai tu fatto intendere che io le voglio fare sopradote di duo mila ducati?</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>Io non son stato a quest'ora.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p>Che ti risponde?</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>Non altro, se non che Erostrato gli offerisce il medesimo.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p>Come può obligarsi Erostrato a questo, essendo figliuolo di famiglia?</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>Credi tu che io sie stato negligente a ricordarglielo? Non dubitare che l'aversario tuo non è per averla se non forse in sogno.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p>Va, Pasifilo mio, se mai aspetto da te piacere, e truova Damone, e digli che io non gli domando altro che sua figliuola, e non voglio da lui dote: io la doterò del mio, e se duo mila ducati non sono a bastanza, io ve ne aggiugnerò cinquecento, e mille, e quel più che vuole egli medesimo. Va, e fa quella opera che io so che tu saprai fare. Non intendo in modo alcuno di perdere questa causa. Non tardare più, va adesso.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>Dove ti ritroverò poi?</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p>A casa mia.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> A che ora?</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Quando vorrai tu. Ben t'inviterei a desinare meco, ma digiuno oggi che è vigilia di san Nicolò, il quale ho in divozione. </p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> (Digiuna tanto che ti muoi di fame.) </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Ascolta. </p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> (Parla co' morti, che digiunano altresì.) </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p>Tu non odi? </p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>(Né tu intendi?) </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p>Ti sei sdegnato perché non ti ho invitato a desinare meco? Tuttavia tu ci puoi venire: ti darò di quello che averò io ancora.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>Credi tu che mi manchi dove mangiare? </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p>Non credo già che ti manchi, Pasifilo mio caro.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>Siene pur certo: ho chi me ne prega.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p>Anzi ne sono certissimo; ma so bene che in loco alcuno non sei meglio veduto che in casa mia. Io t'aspetterò.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>Orsù, verrò, poi che me lo commandi.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p>Fa che mi porti buona novella.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>E tu provedi che io truovi buona scodella.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p>Ti loderai di me.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>E tu vedrai l'opera mia. — Che avarizia! Che miseria d'uomo! Truova scusa di digiunare, perché non desini con lui, quasi che io abbia a mangiare con la sua bocca; e perch'egli è usato apparecchiare splendidi conviti, onde io gli debba restare molto obligato se mi vi chiama. Oltre che parcissimamente sia parata la mensa, vi è differenzia sempre grandissima tra el suo cibo e il mio: io non gusto mai del vino ch'egli beve, né del pane ch'egli mangia; sanza altri vantaggiuzzi che in un medesimo desco ha sempre da me: e gli pare che se talvolta mi tiene seco a desinare o a cena, aver satisfatto a ogni fatica che continuamente per esso mi piglio. Crederia forse alcuno che in altra maggior cosa mi sia liberale: io posso dire in veritade che mai, da sei o sette anni in qua ch'io tengo sua pratica, non mi donò tanto che vaglia una stringa. E' si crede ch'io mi pasca del suo favore, perché talvolta dice, e con fatica ancora, una parola per me. Oh se io non mi procacciassi altronde il vivere, come ben la farei! Ma sono come el bìvaro o la lontra, che sto in acqua e in terra, dove io ritruovo miglior pastura. Io non sono men dimestico di Erostrato, ch'io sia di costui; or de l'uno or de l'altro più amico, quando or l'uno or l'altro mi apparecchia miglior mensa. Così bene mi so reggere fra loro, che quantunque l'uno mi veggia o intenda ch'io sia con l'altro, non però di me si fida manco; perché gli faccio poi credere ch'io séguito l'aversario per spiare segreti: e così, ciò che da tutti duo trar posso, riporto all'uno e all'altro. Sortisca questa pratica l'effetto che vuole: a me ne arà grazia qualunque d'essi ne rimarrà vincitore. Ma ecco Dulippo, el famiglio di Damone: da lui intenderò se il suo patrone è in casa.</p>
           </sp>
@@ -586,67 +641,67 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>PASIFILO, DULIPPO <emph>servo</emph> </stage>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>Dove si va, Dulippo galante?</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>A cercare se truovo chi desinar voglia col patrone mio, el quale è solo.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>Non ti affaticar più, che non ne puoi trovare uno più atto di me.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Non ho commissione di menarne tanti.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>Perché tanti? Io solo verrò.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>E come solo, che dieci lupi hai ne lo stomaco?</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>Questa è usanza de' famigli: avere in odio tutti gli amici del suo patrone.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Sai tu per che causa?</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>Perché hanno denti.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Anzi perché hanno lingua.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>Lingua! E che dispiacere t'ha fatto la mia lingua?</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Io scherzo, Pasifilo, teco. Entra in casa, che tu non tardassi troppo, che 'l patrone mio è per intrare a tavola.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>Desina egli così per tempo?</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Chi se lieva per tempo, mangia per tempo.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p>Con costui viverei io volentieri. Io mi atterrò al tuo consiglio.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Ti serà utile. — Tristo et infelice discorso fu el mio, che a' desideri miei attissima salute reputai mutar col mio servo l'abito e 'l nome, e farmi di questa casa famiglio. Speravomi, come la fame per il cibo, per l'acqua la sete, il freddo pel fuoco, e mille altre simili passioni per apropriati remedi si estinguono, così l'amorosa mia brama, per il continuo vedere Polinesta, e spesso ragionare con essa, et a furtivi abracciamenti quasi ogni notte ritrovarmela apresso, dovesse aver fine. Ahimè! che di tutti li umani effetti solo è amore insaziabile. Sono oggi mai dua anni che sotto spezie di famiglio di Damone ad Amore servo, dal quale, la sua merzé, quanto di ben possa un innamorato core desiderare, io, sopra tutti li amanti aventuroso, ho conseguito; ma quando fra tale abundanzia dovrei ricco e sazio ritrovarmi, io sono el più povero e 'l più desideroso che mai. Ahi lasso! che fia di me, se adesso per Cleandro mi serà tolta? il quale per mezo di questo importuno parassito procaccia averla per moglie. Non solo de li notturni amorosi sollazzi rimarrò privo, ma de parlarli ancora. Egli tosto ne serà geloso, né pur lascerà che li uccelli la possino vedere. Avevo speranza interrompere al vecchio ogni disegno dopo che 'l mio servo, il quale col nome e panni e credito mio si finge esser me, gli avevo opposto rivale e concorrente; ma il cavilloso dottore ogni dì ritruova nuovi partiti da inclinare Damone alle sue voglie. Hammi dato el servo mio intenzione tendergli una trappola all'incontro, dove la maliziosa volpe impacciata resti. Quel che egli ordisca non so, né l'ho veduto questa matina. Ora andando io ad essequire ciò che il padrone mio mi ha commandato, in un medesimo viaggio vedrò di trovarlo, o in casa o dove e' sia, acciò che nello amoroso mio travaglio da lui riporti, se non aiuto, almeno qualche speranza. Ma ecco a tempo il suo ragazzo che esce ne la via.</p>
           </sp>
@@ -654,55 +709,55 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>DULIPPO <emph>e</emph> CAPRINO <emph>ragazzo</emph>.</stage>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>O Caprino, che è di Erostrato?</p>
           </sp>
-          <sp>
+          <sp who="#capr">
             <speaker>CAPR.</speaker>
             <p>Di Erostrato? Di Erostrato sono libri, veste e danari e molte altre cose che egli ha in casa.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Ah ghiotto! io ti domando che tu m'insegni Erostrato.</p>
           </sp>
-          <sp>
+          <sp who="#capr">
             <speaker>CAPR.</speaker>
             <p>A compito o a distesa?</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>S'io ti prendo ne li capelli, io ti farò rispondermi a proposito.</p>
           </sp>
-          <sp>
+          <sp who="#capr">
             <speaker>CAPR.</speaker>
             <p>Taruò!</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Aspettami un poco.</p>
           </sp>
-          <sp>
+          <sp who="#capr">
             <speaker>CAPR.</speaker>
             <p>Io non ne ho tempo.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Per Dio! proveremo chi di noi corre più forte.</p>
           </sp>
-          <sp>
+          <sp who="#capr">
             <speaker>CAPR.</speaker>
             <p>Tu mi dovevi dar vantaggio, che hai più lunghe le gambe.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Dimmi, Caprino, che è di Erostrato?</p>
           </sp>
-          <sp>
+          <sp who="#capr">
             <speaker>CAPR.</speaker>
             <p>Uscì questa mattina di casa a buona ora, e non è mai ritornato. Io lo vidi poi in piazza, che mi disse ch'io venissi a tòrre questo cesto, e ritornassi lì, dove Dalio me aspettaria; e così ritorno.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Va dunque, e se tu 'l vedi, digli che io ho grandissimo bisogno di parlargli. Egli è meglio che anch'io vada alla piazza, che forse ve lo troverò.</p>
           </sp>
@@ -713,319 +768,319 @@
         <div type="scene">
           <head>SCENA PRIMA</head>
           <stage>DULIPPO <emph>finto et</emph> EROSTRATO <emph>finto</emph>.</stage>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Se io avessi auti cento occhi, non mi bastavano a riguardare, or ne la piazza, or nel cortile, s'io vedevo costui. Non è scolare, non è dottore in Ferrara, che non mi sia, escetto lui, venuto ne' piedi: forse serà ritornato a casa. Ma eccolo finalmente.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>A tempo, patron mio, ti vedo.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Deh chiamami Dulippo, per tua fé, e mantieni la reputazione che una volta, volendo io così, hai col mio nome incominciata.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Questo c'importa poco, poi che niuno è qui presso che ci possa intendere.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Per la consuetudine potresti errare facilmente dove potremo esser notati: abbici avertenza. Or che novelle mi apporti?</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Buone.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Buone?</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Ottime: abbiàn vinto el partito.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Beato me, se fussi vero.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Tu lo intenderai.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>E come?</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Trovai iersera il parassito, il quale non dopo molti inviti menai a cena meco, dove con buone accoglienze e con migliori effetti me lo feci amicissimo; et in tal modo che tutti li disegni di Cleandro e la voluntade di Damone mi rivelò, e mi promesse in questa pratica operare per l'avenire in mio favore.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Non ti fidare di lui, ch'egli è fallace e più bugiardo che se in Creta o in Affrica nato fusse.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Lo connosco ben io: tuttavia ciò che mi ha detto, tocco con mano essere verissimo.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Che t'ha detto, infine?</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Che Damone era in animo di dare la figlia al dottore, dopo che quello offerto gli avea dumila ducati di sopradote.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>E queste sono le buone, anzi ottime novelle et il partito vinto che apportarmi dicevi?</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Non volere intendere tu prima che io abbia dato fine al ragionamento.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Or séguita.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>A questo gli risposi che io ero apparecchiato, non meno che fusse Cleandro, a fargli altrettanto di sopradote.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Fu buona risposta.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Aspetta, ché tu non sai ancora dove sta la difficultà.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Difficultà? Dunque vi è peggio ancora?</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>E come posso io, fingendomi figliuolo di Filogono, senza autoritade e consenso di quello, obligarmi a tal cosa?</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Tu hai più di me studiato.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Né tu ancora hai perso el tempo; ma il quaderno che tu ti poni inanzi non tratta di queste cose.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Lascia le ciancie e vieni al fatto.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Io gli dissi che da mio padre avevo aute lettere, per le quali di giorno in giorno lo aspettavo in questa terra, e che da mia parte egli pregasse Damone che per quindici giorni ancora volesse differire a concludere questo maritaggio; perché io speravo, anzi tenevo certissimo, che Filogono averia fermo e rato ciò che circa questo io avessi disposto.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Utile è stato almeno in questo: che per quindici giorni ancora prolungherà la vita mia; ma che serà poi? Mio padre non verrà; e quando venisse ancora, non sarebbe forse al proposito nostro. Ah misero me! sie maledetto...</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Taci, non ti disperare: credi tu che io dorma quando io ho a fare cosa che sia a benefizio tuo?</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Ah! caro fratel mio, tornami vivo; che io sono stato, poi che queste pratiche si cominciarono, sempre peggio che morto.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Or ascolta.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Di'.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Questa matina montai a cavallo et uscii de la porta del Leone, con animo di andare verso il Polesine per fare la faccenda che tu sai; ma un partito, che mi si offerse assai migliore, me lo ha fatto lasciare. Passato che io ebbi il Po, e cavalcato in là forse duo miglia, me incontrai in uno gentiluomo attempato e di buono aspetto, che ne veniva con tre cavalli in sua compagnia. Io lo saluto, egli mi risponde graziosamente: gli domando donde viene e dove va: mi dice venire da Vinegia, per ritornarsi ne la sua patria, che gli è sanese. Io subito con viso ammirativo gli replico: — Sanese! e come vieni tu a Ferrara, dunque? — Et egli mi risponde: — O perché non ci debbo venire? — Et io: — Come! non sai tu a che pericolo ti poni se ci vieni, quando per sanese tu ci sia connosciuto! — Et egli allora, tutto stupefatto e timido si ferma, e mi priega in cortesia che io gli voglia esplicare il tutto a pieno.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Io non intendo questa trama.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Credolo: ascolta pure.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Segui.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Ora io gli soggiungo: — Gentiluomo mio caro, perché ne la terra vostra un tempo che io vi studiai sono stato accarezzato e ben visto, io debitamente a tutti li Sanesi sono affezionatissimo; e però, dove el danno e la vergogna tua vietar posso, non la comporterò per modo alcuno. Mi maraviglio che tu non sappi l'ingiuria che li tuoi Sanesi feciono a' dì passati agl'imbasciadori del duca di Ferrara, li quali dal re di Napoli in qua se ne ritornavano.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Che favola è questa che tu hai cominciata? Che appertengono a me queste ciancie?</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Non è favola, ti dico: è cosa che ti appertiene assai. Odi pure.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Segui.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Io gli dico: — Questi imbasciadori avevano con loro parecchi poledri e alcuni carriaggi di selle e fornimenti da cavalli bellissimi, e sommachi e profumi et altre cose belle e signorili, che tutte in dono il re Ferrante a questo principe mandava. E come giunsono a Siena, le furono alle gabelle ritenute: onde né per patenti che gli avessino, né per testimoni che producessino che le robe erano del duca, le poteron mai spedire; fino che d'ogni minima cosa pagorono il dazio sanza avervi remissione d'un soldo, come se del più vile mercatante che sia al mondo fussino state.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Può essere che questa cosa appertenga a me; ma non vi truovo né capo né via, perché io lo debba credere.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>O come sei impaziente! ma lasciami dire.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Di' pur: tanto quanto io ti ascolterò.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Io li seguo: — Poi avendo il duca inteso questo, ne ha dopo fatto querela a quel Senato, e per lettere e per un suo cancelliero, che vi ha mandato a questo effetto; et ha avuta la più insolente e bestial risposta che si udissi mai. Per questo di tanto sdegno et odio si è contro a tutti li Sanesi infiammato, che ha disposto spogliare sino alla camicia quanti nel dominio suo capiteranno, e di qui con grandissima ignominia cacciarli.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Onde sì gran bugia e sì sùbita ti imaginasti, e a che effetto?</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Tu lo intenderai; né a proposito nostro più di questa si poteva ritrovare.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Orsù, io sto attento alla conclusione.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Vorrei che le parole avessi udite, e veduto la faccia e li gesti ch'io fingevo a persuaderli.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Credoti più che non mi narri, che non è pure adesso che io ti connosco.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Io gli soggiunsi che notificato con pena capitale era agli albergatori che, se alloggiassino Sanesi, ne dessino agli ufiziali indizio.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Questo vi mancava!</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Costui di chi ti parlo, ch'al primo tratto iscorsi non essere de li più pratichi uomini del mondo, come intese questo, voltava la briglia per ritornarsene indrieto.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>E ben dimostra che sia mal pratico, credendoti questa baia. Come potrebbe essere che non sapesse quello che fussi ne la sua patria occorso?</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Facilmente: se è già più d'un mese se n'è partito, bene essere può che non sappi quello che da sei giorni in qua sia intervenuto.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Pur non debbe avere molta esperienzia.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Credo che ne abbia pochissima, e ben reputo la nostra gran ventura, che mandato ci abbi tale uomo inanzi. Or odi pure.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Finisci pure.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Egli, come io ti narro, poi che intese questo, volgeva la briglia per tornarsi indrieto. Io, fingendomi stare sopra di me alquanto pensoso, a benefizio di esso, dopo poco intervallo gli dissi: — Non dubitare, gentiluomo, che ho ritrovato sicurissima via a salvarti, e sono deliberato, per amore de la tua patria, fare ogni opera che tu non sia per sanese in Ferrara connosciuto. Voglio che tu simuli essere il padre mio, e così tu te ne verrai alloggiar meco. Io sono siciliano d'una terra là detta Catania, figliuolo d'uno mercatante chiamato Filogono. Così tu dirai a chiunque te ne dimandassi: che sei Filogono catanese, e io, che Erostrato mi chiamo, tuo figliuolo sono; et io per padre ti onorerò.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>O come sciocco sino adesso sono istato! Pure ora comprendo il tuo disegno.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>E che te ne pare?</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Assai bene; pure mi resta uno scrupolo che non mi piace.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Che scrupolo?</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Che mi pare impossibile che, stando qui e parlando con altri, presto non se ne aveda che tu l'abbi soiato.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Come?</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Che facile gli sia, dissimulando ancora che sia sanese, chiarirsi che questo è tutto falso che tu gli hai detto.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Son certo che el potrebbe accadere, se io mi fermassi qui, né ci facessi altra provisione; ma ben l'ho così accarezzato già, e così lo carezzerò in casa, e farolli tanto onore, che sicuramente allargare mi potrò con lui, e narrargli come sta la cosa a punto. Serà bene ingrato poi, se negassi di aiutarmi in questo, dove egli non ci ha se non a metter parole.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Che vuoi tu che costui poi faccia?</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Quello che farebbe Filogono se qui si trovasse, e fusse di questo parentado contento. Credo che mi serà facil cosa disporlo che in nome di Filogono faccia instrumenti e contratti e tutte le obligazioni che io gli saprò domandare. Che nocerà a lui obligare il nome di altri, non essendo egli per patire di questo uno minimo detrimento?</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Pur che succeda il disegno.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Non ci potremo di noi dolere almeno, che non abbiamo fatto quel tutto che sia stato possibile per aiutarsi.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Or su, ma dove l'hai tu lasciato?</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Io l'ho fatto ismontare fuori del borgo, all'osteria de la Corona, perché in casa, come sai, non ho fieno, né paglia, né stanza d'alloggiare cavalli.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Perché non l'hai ora menato in tua compagnia?</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Prima ho voluto parlar teco, et avisarti del tutto.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Non hai mal fatto; ma non tardare; va, e menalo a casa, e non guardare a spesa per farli onore.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Adesso vado; ma per mia fé, ch'egli è questo che viene in qua.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>È questo? Io lo voglio aspettare qui, per vedere se ha viso di quel ch'egli è.</p>
           </sp>
@@ -1033,87 +1088,87 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage><emph>El</emph> SANESE, <emph>el</emph> SERVO <emph>suo</emph>, EROSTRATO <emph>e</emph> DULIPPO</stage>
-          <sp>
+          <sp who="#san">
             <speaker>SAN.</speaker>
             <p>In grandi et inopinati pericoli spesso incorre chi va pel mondo.</p>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>SERVO</speaker>
             <p>È vero. Se questa matina, passando noi al ponte del Lagoscuro, si fossi la nave aperta, tutti affogavamo; che non è alcuno di noi che sappia notare.</p>
           </sp>
-          <sp>
+          <sp who="#san">
             <speaker>SAN.</speaker>
             <p>Io non dico di questo.</p>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>SERVO</speaker>
             <p>Tu vuoi dir forse del fango che noi trovamo ieri venendo da Padova, che per dua volte fu la mula tua per traboccare?</p>
           </sp>
-          <sp>
+          <sp who="#san">
             <speaker>SAN.</speaker>
             <p>Va, tu sei una bestia: dico del pericolo nel quale in questa terra siamo quasi incorsi.</p>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>SERVO</speaker>
             <p>Gran pericolo certo, ritrovare chi ti lievi da la osteria e ti alloggi in casa sua!</p>
           </sp>
-          <sp>
+          <sp who="#san">
             <speaker>SAN. </speaker>
             <p>Mercé del gentiluomo che vedi là. Ma lascia le buffonerie: guàrdati, e così dico a voi altri, guardatevi tutti di dire che siamo sanesi, o di chiamarmi altrimenti che Filogono di Catania. </p>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>SERVO</speaker>
             <p>Di questo nome strano mi ricorderò male; ma quella Castagnia non mi dimenticherò già.</p>
           </sp>
-          <sp>
+          <sp who="#san">
             <speaker>SAN. </speaker>
             <p>Che Castagnia? io dico Catania, in tuo mal punto.</p>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>SERVO</speaker>
             <p>Non saprò dir mai.</p>
           </sp>
-          <sp>
+          <sp who="#san">
             <speaker>SAN. </speaker>
             <p>Taci dunque; non nominare Siena, né altro.</p>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>SERVO</speaker>
             <p>Vòi tu ch'io mi finga mutolo, come io feci un'altra volta?</p>
           </sp>
-          <sp>
+          <sp who="#san">
             <speaker>SAN. </speaker>
             <p>Sarebbe una sciocchezza oramai. Or non più, tu hai piacere di cianciare. Ben venga el mio figliuolo.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Abbi a mente che questi Ferraresi sono astuti, che né in parole né in gesti si possino accorgere che tu sia altro che Filogono catanese, e mio padre.</p>
           </sp>
-          <sp>
+          <sp who="#san">
             <speaker>SAN.</speaker>
             <p>Non dubitare.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>El dubbio a te più tocca e a questi tuoi, che sereste incontinente isvaligiati, e forse ancora ve ne seguiria peggio.</p>
           </sp>
-          <sp>
+          <sp who="#san">
             <speaker>SAN.</speaker>
             <p>Io gli venivo ammonendo: sapranno simulare ottimamente.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>Con li miei di casa ancora simulate non meno che con gli altri, perché li famigli che io ho sono tutti di questa terra, né mio padre né Sicilia videro mai. Questa è la stanza nostra: entriamo drento.</p>
           </sp>
-          <sp>
+          <sp who="#san">
             <speaker>SAN.</speaker>
             <p>Io vado inanzi.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p>E così conviene per ogni rispetto.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Il principio è assai buono, purché vi corrisponda il mezo e il fine. Ma non è questo el rivale e competitore mio Cleandro? O avarizia, o cecità de gli uomini! che Damone, per non dotare una così gentile e costumata figliuola, pensi costui farsi genero, che gli serebbe per etade conveniente suocero! et ama assai più la sua borsa che quella de la figliuola, che per non scemare l'una di qualche fiorino, non si curerebbe che l'altra in perpetuo vòta rimanessi, salvo se non fa conto che questo vecchio gli ponga drento de li suoi doppioni. Deh misero me, che io motteggio e ne ho poca voglia!</p>
           </sp>
@@ -1121,363 +1176,363 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>CARIONE <emph>servo</emph>, CLEANDRO <emph>e</emph> DULIPPO</stage>
-          <sp>
+          <sp who="#car">
             <speaker>CAR.</speaker>
             <p>Che ora importuna è questa, patron mio, di venire per questa contrada? Non è banchiero in Ferrara che non sia ito a bere ormai.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN. </speaker>
             <p>Venivo per vedere se io trovavo Pasifilo, che io lo menassi a desinar meco.</p>
           </sp>
-          <sp>
+          <sp who="#car">
             <speaker>CAR. </speaker>
             <p>Quasi che sei bocche che in casa tua si ritruovano, e sette con la gatta, non sieno a mangiare sufficienti uno luccetto d'una libra e mezo, e una pentola di ceci, e venti sparagi, che senza più sono per pascere te e la tua famiglia apparecchiati.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN. </speaker>
             <p>Temi tu che ti debba mancare, lupaccio?</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP. </speaker>
             <p>(Non debbo io soiare un poco questo uccellaccio?)</p>
           </sp>
-          <sp>
+          <sp who="#car">
             <speaker>CAR. </speaker>
             <p>Non sarebbe la prima fiata.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP. </speaker>
             <p>(Che gli dirò?)</p>
           </sp>
-          <sp>
+          <sp who="#car">
             <speaker>CAR. </speaker>
             <p>Pure io non dico per questo, ma perché la famiglia starà a disagio, né Pasifilo rimarrà satollo, che mangerebbe te, con la pelle et ossa de la tua mula: direi ancora la carne insieme, se la ne avessi.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN. </speaker>
             <p>Tua colpa, che così bene ne hai cura.</p>
           </sp>
-          <sp>
+          <sp who="#car">
             <speaker>CAR. </speaker>
             <p>Colpa pure del fieno e de la biada, che son cari.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP. </speaker>
             <p>(Lascia, lascia fare a me.)</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN. </speaker>
             <p>Taci, imbriaco, e guarda per la contrada se tu vedi costui.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP. </speaker>
             <p>(Quando io non faccia altro, porrò tra Pasifilo e lui tanta discordia, che Mercurio non li potrebbe ritornare amici.)</p>
           </sp>
-          <sp>
+          <sp who="#car">
             <speaker>CAR. </speaker>
             <p>Non potevi tu mandarlo a cercare sanza che tu ci venissi in persona?</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN. </speaker>
             <p>Sì, perché voi siete diligenti!</p>
           </sp>
-          <sp>
+          <sp who="#car">
             <speaker>CAR.</speaker>
             <p> O patrone, di' pure che tu passi di qui per vedere altro che Pasifilo; che se Pasifilo ha voglia di mangiare teco, è un'ora che ti deve aspettare a casa.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Taci, che io intenderò da costui s'egli è in casa del patron suo. Non sei tu de la famiglia di Damone? </p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> Sì, sono al piacere e al servizio tuo. </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p>Ti ringrazio. Mi sai dire se Pasifilo questa matina è stato a parlargli? </p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>Vi è stato e credo che vi sia ancora: ah, ah, ah! </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Di che ridi tu? </p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> D'un ragionamento che egli ha auto col patron mio, che non è però da ridere per ognuno. </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN. </speaker>
             <p>Che ragionamento ha auto con lui? </p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> Ah, non è da dire. </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> È cosa che a me s'appertenga? </p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> Eh! </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Tu non rispondi? </p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> Ti direi il tutto, s'io credessi che tu me lo tenessi secreto. </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Io tacerò, non dubitare. Aspetta tu là. </p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> Se 'l mio patrone lo risapesse poi, guai a me. </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Non lo risaperà mai; di' pure. </p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> Chi me ne assicura? </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Ti darò la fede mia in pegno. </p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> È tristo pegno: l'Ebreo non vi dà sopra dinari. </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Tra gli uomini da bene val più che oro o gemme. </p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> Vòi pur che io tel dica? </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Sì, se appertiene a me. </p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> A te appertiene più che a uomo del mondo, e mi duole che una bestia, quale è Pasifilo, dileggi un par tuo. </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Dimmi, dimmi, che cosa è? </p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> Voglio che tu mi giuri per sacramento che mai tu non parlerai, né con Pasifilo, né con Damone, né con persona alcuna. </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Io son contento: aspetta ch'io toglia una carta. </p>
           </sp>
-          <sp>
+          <sp who="#car">
             <speaker>CAR.</speaker>
             <p> (Questa debbe essere qualche ciancetta, che colui gli dà da parte di questa giovane che l'ha fatto impazzare, con speranza di trarne qualche guadagnetto.) </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Ecco pure che io ho ritrovato una lettera. </p>
           </sp>
-          <sp>
+          <sp who="#car">
             <speaker>CAR.</speaker>
             <p> (Connosce male l'avarizia sua: ci bisognano tanaglie e non parole, che più presto si lascerebbe trarre un dente de la mascella che un grosso de la scarsella.) </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Pigliala tu in mano, e così ti giuro che di quanto tu mi dirai, non ne parlerò a persona del mondo, se non quanto piacerà a te. </p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> Sta bene. E' m'incresce che Pasifilo ti dia la soia, e che tu creda che parli e procuri per te; et insta continuamente e stimula el patron mio che dia sua figliuola a un certo scolare forestieri che ha nome Rosorostro o Arosto. Non lo so dire: ha un nome indiavolato. </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Chi è? Erostrato? </p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> Sì, sì, non mi sarebbe mai venuto in bocca. E dice tutti li mali che si è possibile imaginarsi di te. </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> A chi? </p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p>A Damone et a Polinesta ancora. </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Ah ribaldo! E che dice egli? </p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> Quanto si può dir peggio. </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> O Dio! </p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> Che tu sei il più avaro e misero uomo che nascesse mai, e che tu la farai morire di fame. </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Pasifilo dice questo di me? </p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> Di questo el padre si cura poco, che ben sapeva che, sendo tu de la professione che tu sei, non potevi essere altrimenti che avarissimo. </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Io non so che avaro: so bene che chi non ha roba a questo tempo è reputato una bestia. </p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> Egli ha detto che tu sei fastidioso et ostinato sopra tutti gli altri, e che tu la farai consumare d'affanno. </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> O uomo maligno! </p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> E che dì e notte non fai altro che tossire e sputare, e che li porci averieno schifo di te. </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Io non tosso, né sputo pur mai. Uòh, uòh, uòh... È vero che io sono adesso un poco infreddato; ma chi non è di questo tempo? </p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> E dice molto peggio: che ti puzzano li piedi e le ascelle e, più che 'l resto, il fiato. </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> O traditore! al corpo ch'io... </p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> E che tu sei aperto di sotto, e che ti pende fino alle ginocchia una borsa più grossa che tu non hai la testa. </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Non abbia mai cosa ch'io voglia, s'io non ne lo pago. Ei mente per la gola di ciò che e' dice: s'io non fussi qui ne la via, ti farei vedere il tutto. </p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> E che tu la domandi più per voglia che hai di marito, che di moglie. </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Che vuol per questo inferire? </p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> Che con tale ésca vorresti tirarti li giovani a casa. </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Li giovani a casa io? A che effetto? </p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> Che tu patisci una certa infermità, a cui giova et è apropriato rimedio lo stare con li giovani di prima barba. </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Può fare Iddio, ch'egli abbia dette queste cose? </p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> Altre infinite; e non pur questa, ma molte e molte altre fiate ancora. </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Damone gli crede? </p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> Più che al <emph>Credo</emph>, e sono molti dì che te avria dato repulsa, se non che Pasifilo l'ha pregato che ti tenga in parole, perché pur spera con queste pratiche cavarti di man qualche cosetta. </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> O scelerato! O uom senza fede! Perché io non mi avevo pensato donargli queste calze che io ho in piedi, come io l'avessi un poco più fruste! Mi caverà da le mani... eh! voglio che mi cavi un capestro che l'impicchi. </p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> Vuoi cosa che io possa, che io ho fretta di tornare a casa? </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Non altro. </p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> Per tua fé, non ne parlare con persona del mondo, che saresti causa de la mia ruina. </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Io t'ho una volta dato la fede mia. Ma dimmi, come è il tuo nome? </p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> Mi dicono Maltivenga. </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Sei tu di questa terra? </p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> No, sono d'un castello là in Pistorese, nomato Fustiucciso. A Dio, non ho più tempo da star qui. </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> O misero me, di chi mi sono fidato! Che messaggio, che interpetre me avevo io trovato! </p>
           </sp>
-          <sp>
+          <sp who="#car">
             <speaker>CAR.</speaker>
             <p> Patrone, andiamo a desinare. Vuoi tu stare fino a sera a posta di Pasifilo? </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Non mi rompere il capo: che fossi amendua impiccati! </p>
           </sp>
-          <sp>
+          <sp who="#car">
             <speaker>CAR.</speaker>
             <p> (Non ha avute novelle che gli sieno piaciute.) </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Hai tu così gran fretta di mangiare? Che non possi tu mai saziarti! </p>
           </sp>
-          <sp>
+          <sp who="#car">
             <speaker>CAR.</speaker>
             <p> Son certo che io non mi sazierò mai fin che io sto teco. </p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Andiamo, col malanno che Dio ti dia. </p>
           </sp>
-          <sp>
+          <sp who="#car">
             <speaker>CAR.</speaker>
             <p> El mal sempre a te e a tutto il resto de gli avari. </p>
           </sp>
@@ -1488,127 +1543,127 @@
         <div type="scene">
           <head>SCENA PRIMA</head>
           <stage>DALIO <emph>cuoco</emph>, CAPRINO <emph>ragazzo</emph>, EROSTRATO, DULIPPO</stage>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO</speaker>
             <p> Come siamo a casa, credo ch'io non ritrovarò de l'uova che porti in quel cesto uno solo intero. Ma con chi parlo io? Dove diavolo è rimasto ancora questo ghiotto? Sarà restato a dar la caccia a qualche cane o a scherzare con l'orso. A ogni cosa che truova per via, si ferma: se vede facchino o villano o giudeo, non lo terrieno le catene che non gli andasse a fare qualche dispiacere. Tu verrai pure una volta, capestro: bisogna che di passo in passo ti vadi aspettando. Per Dio, s'io truovo pure un solo di quelle uova rotte, ti romperò la testa. </p>
           </sp>
-          <sp>
+          <sp who="#capr">
             <speaker>CAPR.</speaker>
             <p> Sì ch'io non potrò sedere. </p>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO</speaker>
             <p> Ah! frasca, frasca.</p>
           </sp>
-          <sp>
+          <sp who="#capr">
             <speaker>CAPR.</speaker>
             <p> S'io son frasca, son dunque mal sicuro a venir con un becco.</p>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO</speaker>
             <p> S'io non fussi carico, ti mostrerei s'io sono un becco.</p>
           </sp>
-          <sp>
+          <sp who="#capr">
             <speaker>CAPR.</speaker>
             <p> Rade volte t'ho veduto che tu non sia carico, o di vino o di bastonate.</p>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO</speaker>
             <p> Al dispetto ch'io non dico!...</p>
           </sp>
-          <sp>
+          <sp who="#capr">
             <speaker>CAPR.</speaker>
             <p> Ah poltrone! tu biastemi col cuore e non osi con la lingua.</p>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO</speaker>
             <p> Io lo dirò al patrone: o ch'io mi partirò da lui, o che tu non mi dirai villania.</p>
           </sp>
-          <sp>
+          <sp who="#capr">
             <speaker>CAPR.</speaker>
             <p> Fammi il peggio che tu sai.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> Che romore è questo?</p>
           </sp>
-          <sp>
+          <sp who="#capr">
             <speaker>CAPR.</speaker>
             <p> Costui mi vuol battere, perché io lo riprendo che biastema.</p>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO</speaker>
             <p> E' mente per la gola: mi dice villania perch'io lo sollicito che venga presto.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> Non più parole. Tu apparecchia ciò che fa di bisogno; come io ritorno, ti dirò quello ch'io voglio che sia lesso, e quello arrosto; e tu, Caprino, pon giù quel cesto e torna che mi facci compagnia. O come ritroverei volentieri Pasifilo! e non so dove. Ecco il patron mio, forse me ne saprà dare egli notizia.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> Che hai tu fatto del tuo Filogono?</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> L'ho lasciato in casa.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> E dove vai tu ora?</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> Vorrei trovare Pasifilo. Me lo sapresti insegnare tu?</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> No; è ben vero che questa matina desinò qui con Damone, ma non so poi dove sia ito. E che ne vuoi tu fare?</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> Che egli notifichi a Damone la venuta di questo mio padre, el quale è apparecchiato a fare la sopradote et ogni altra cosa che possa egli per noi. Voglio che tu veda se io saprò quanto quel pecorone, che fa ciò che può per diventare un becco.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> Va, caro fratello; cerca Pasifilo tanto che tu lo truovi, che oggi si concluda quel che è possibile a benefizio nostro.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> Ma dove debbo io cercare?</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> Dove si apparecchiano conviti: alle pescherie et alle beccherie si ritroverà ancora spesso.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> Che fa egli quivi?</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> Per vedere chi fa comperare qualche bel petto o lonza di vitella, o qualche gran pesce, acciò che improviso poi gli sopraggiunga, e con un bel — pro vi faccia — con loro si ponga a mensa.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> Io cercherò tutti questi lochi: serà gran fatto che io non ve lo truovi.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> Fa poi che io ti riveda, che io t'ho da far ridere.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> Di che?</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> D'uno ragionamento che io ho avuto con Cleandro.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> Dimmelo ora.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> Non ti voglio impedire. Va pure, ritruova costui.</p>
           </sp>
@@ -1616,63 +1671,63 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>DULIPPO <emph>solo</emph>, DAMONE, NEBBIA <emph>servo</emph>.</stage>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> L'amorosa contenzione, la quale è tra Cleandro e costui che procura in mio nome, al gioco di zara mi pare simile: dove tu vedi l'uno far del resto, che in più volte ha perduto tanto, che tu aspetti che a quel punto esca di giuoco. La fortuna gli arride, e vince quel tratto, e dua, e quattro apresso, tanto che si rifà: tu vedi all'altro, che dal canto suo quasi tutti li dinari aveva ridotti, scemarsi il monte tanto, che resta nel grado in che pur dianzi era il suo aversario; poi di nuovo risurge, e di nuovo cade: e così a vicenda or l'uno or l'altro guadagna e perde, fin che viene in un punto chi da un lato raccoglie il tutto, e lascia netto l'altro più che una bambola di specchio. Quante volte mi ho estimato avere contro a questo maladetto vecchio vinto el partito! Quante volte ancora me gli sono veduto inferiore! E quinci e quindi in pochi giorni sì m'ha travagliato Fortuna, che né sperare molto né in tutto disperar mi posso. Questa via, che l'astuzia del mio servo ha investigata, assai al presente mi par sicura; tuttavia non meno mi si agita il core che soglia nel petto, che qualche impremeditato disturbo non si interponga. Ma ecco el mio signore Damone, che esce fuora.</p>
           </sp>
-          <sp>
+          <sp who="#dam">
             <speaker>DAM.</speaker>
             <p> Dulippo.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> Patrone</p>
           </sp>
-          <sp>
+          <sp who="#dam">
             <speaker>DAM.</speaker>
             <p> Ritorna in casa, e di' al Nebbia, al Moro et al Rosso che venghino fuora, che io gli voglio mandare in diversi luochi. E tu va ne la cameretta terrena, e guarda ne l'armario de le scritture, e cerca tanto che tu ritruovi uno instrumento, rogato per Lippo Malpensa, de la vendita che fece Ugo da le Siepi al mio bisavolo, d'un campo di terra che si chiama il Serraglio, et arrecalo qui a me.</p>
           </sp>
-          <sp>
+          <sp who="#dulip">
             <speaker>DULIP.</speaker>
             <p> Io vado.</p>
           </sp>
-          <sp>
+          <sp who="#dam">
             <speaker>DAM.</speaker>
             <p> (Va pure, che bene altro instrumento, che non pensi, vi troverai. O misero chi in altro che in sé stesso si confida! O ingiuriosa Fortuna, che da casa del diavolo questo ladroncello qui mandato mi hai per ruina de l'onor mio e di tutta la mia casa!) Venite qua voi, e fate quello che io vi commanderò; ma con diligenzia. Andate ne la camera terrena, dove troverete Dulippo, e simulando di volere altro, accostàtevegli, e prendetelo, e con la fune che io vi ho lasciata a questo effetto, che vedrete in sul desco, legategli le mane e li piedi, e portatelo ne la stanza piccola e buia, la quale è sotto la scala, e lasciatelo quivi, e con destrezza e con minore strepito che si può. Tu, Nebbia, ritorna, fatto questo, a me sùbito: eccoti la chiave; riportamela poi.</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p> Serà fatto.</p>
           </sp>
-          <sp>
+          <sp who="#dam">
             <speaker>DAM.</speaker>
             <p> Come debbo io, ahi lasso! di così grave ingiuria vendicarme? Se questo scelerato secondo li pessimi suoi portamenti e la mia iustissima ira punir voglio, da le leggi e dal principe serò punito io, perché non lice a cittadino privato di sua propria autorità farsi ragione; e se al duca e alli ufiziali suoi me ne lamento, publico la mia vergogna. Deh! che penso io di fare? Quando di questo tristo avessi fatto tutti li strazi che sieno possibili, non potrò far però che mia figliuola violata et io disonorato in perpetuo non sia. Ma di chi voglio io fare strazio? Io, io solo son quello che merito d'essere punito, che me ho fidato lasciarla in guardia di questa puttana vecchia. Se io volevo che fussi bene custodita, la dovevo custodire io, farla dormire ne la camera mia, non tenere famigli giovani, non le fare un buon viso mai. O cara moglie mia, adesso connosco la iattura che io feci, quando di te rimasi privo! Deh! perché, già tre anni, quando io potetti, non la maritai? Se ben non così riccamente, almeno con più onore l'arei fatto. Io ho indugiato di anno in anno, di mese in mese, per porla altamente: ecco che me ne accade! A chi volevo io darla? a un principe. O misero, o infelice, o sciaurato me! Questo è ben quel dolore che vince tutti gli altri. Che perder roba! che morte di figliuoli e di moglie! Questo è l'affanno solo che può uccidere, e mi ucciderà veramente. O Polinesta, la mia bontade verso te, la mia clemenzia non meritava un così duro premio.</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p> Padrone, il tuo commandamento essequito abbiamo: eccoti la chiave.</p>
           </sp>
-          <sp>
+          <sp who="#dam">
             <speaker>DAM.</speaker>
             <p> Bene sta: vanne ora a ritrovare Nomico da Perugia, e da mia parte lo priega che mi presti quelli ferri da prigioniero, che egli ha; e torna sùbito.</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p> Io vado.</p>
           </sp>
-          <sp>
+          <sp who="#dam">
             <speaker>DAM.</speaker>
             <p> Odi: se ti domanda quel che ne voglio fare, di' che tu nol sai.</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p> Così dirò.</p>
           </sp>
-          <sp>
+          <sp who="#dam">
             <speaker>DAM.</speaker>
             <p> Ascolta: guarda che non dicessi a alcuno che Dulippo sia preso.</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p> Non ne parlerò con uomo vivo.</p>
           </sp>
@@ -1680,99 +1735,99 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>NEBBIA <emph>servo</emph>, PASIFILO <emph>parassito</emph>, PSTERIA <emph>ancilla</emph>.</stage>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p> È impossibile maneggiare li danari d'altri che qualcuno non te ne rimanga fra l'unghie. Mi maravigliavo bene che Dulippo vestir si potesse così bene, di quel poco salario ch'egli aveva dal patrone. Ora comprendo quale ne era la causa: egli era il spenditore; egli aveva la cura di vendere li formenti e li vini; egli pigliava e teneva conto de l'entrate e de le spese, et era fa il tutto. Dulippo di qua. Dulippo di là: egli favorito del patrone, egli favorito de' figliuoli: noi tutti altri di casa apresso lui eramo da niente. Vedi in un tratto quello che ora gli è intervenuto! Gli sarebbe stato più utile non fare tante cose.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Tu di' ben vero, che egli l'ha fatto troppo.</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p> Donde diavolo esci tu?</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Di casa vostra, per l'uscio di drieto.</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p> Credevo che già due ore ti fussi partito.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Ti dirò. Come ebbi desinato, andai ne la stalla per fare... tu ben m'intendi, e mi prese il maggior sonno ch'io avessi mai, e mi coricai di sopra alla paglia, et ho dormito in fino adesso. Ma dove vai tu?</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p> A fare una faccenda, che m'ha il patrone imposto.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Non si può ella dire?</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p> No.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Tu sei molto secreto. — Quasi ch'io non lo sappia meglio di lui. O Dio, che ho io sentito! O Dio, che ho io visto! O Cleandro, o Erostrato, che moglie desiderate, e vergine, come vi potria succedere facilmente che aresti l'uno e l'altro insieme: che Polinesta, benché essa non sia, forse ha la vergine nel corpo, che voi cercate! Chi averia di lei così creduto? Dimanda alla vicinanza di sua condizione: la migliore, la più devota giovane del mondo; non pratica mai se non con suore; la più parte del dì sta in orazione; rarissime volte si vede o a uscio o a finestra; non si ode che d'alcuno innamorata sia: è una santarella. Buon pro le faccia! Colui che l'averà per moglie, guadagnerà più dote che non si pensa: un paio almeno, se non più, di lunghissime corna mancar non gli possono. Per la mia lingua non si sturberanno già queste nozze, anzi le procurerò più che mai. Ma non è questa la malefica vecchia che dianzi udii che tutta la trama a Damone ha discoperta? Dove si va, Psiteria?</p>
           </sp>
-          <sp>
+          <sp who="#psit">
             <speaker>PSIT.</speaker>
             <p> Qui presso a una mia comare.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Che vi vai tu a fare? A cicalare con essa un poco de le belle opere de la tua giovane patrona?</p>
           </sp>
-          <sp>
+          <sp who="#psit">
             <speaker>PSIT.</speaker>
             <p> Non già, in buona fé; ma che sai tu di queste cose?</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Tu me l'hai fatte intendere.</p>
           </sp>
-          <sp>
+          <sp who="#psit">
             <speaker>PSIT.</speaker>
             <p> E quando te lo dissi io?</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Quando a Damone anco tu lo dicevi; che io ero in luogo ch'io ti vedevo e udivo. O bella pruova! accusare quella misera fanciulla, e dar cagione a quel povero vecchio che si muoia d'affanno! oltre alla ruina di quello infelice giovane e de la nutrice, et altri scandali che ne seguiranno.</p>
           </sp>
-          <sp>
+          <sp who="#psit">
             <speaker>PSIT.</speaker>
             <p> È stato inconsideratamente, e non ho tanta colpa come tu pensi.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> E chi ne ha colpa?</p>
           </sp>
-          <sp>
+          <sp who="#psit">
             <speaker>PSIT.</speaker>
             <p> Ti dirò come è stata la cosa. Sono molti dì che io mi ero aveduta che Dulippo si giaceva quasi ogni notte con Polinesta per mezo de la nutrice, e mi tacevo; ma questa mattina la nutrice cominciò a garrir meco, e ben tre volte mi disse imbriaca; e le risposi alfine: — Taci, taci, ruffiana, tu non sai forse che sappi quello che per Dulippo fai quasi ogni notte? — ma bene in verità non credendo essere udita. Ma la disgrazia volse che il patrone me intese, e mi chiamò là, dove è stata forza che io li narri il tutto.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> E come bene gliel'hai narrato!</p>
           </sp>
-          <sp>
+          <sp who="#psit">
             <speaker>PSIT.</speaker>
             <p> Ah misera me! Se io pensavo che il patrone se lo dovessi così avere a male, mi averia prima lasciata uccidere, che io gliel'avessi rivelato.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Gran fatto, se dovea averselo per male.</p>
           </sp>
-          <sp>
+          <sp who="#psit">
             <speaker>PSIT.</speaker>
             <p> Mi duole di quella misera fanciulla che piange e si straccia i capelli, e si dibatte, che gli è gran compassione a vederla; non perché il patre l'abbia battuta né minacciata, anzi il doloroso vecchio ha pianto con lei: ma per pietà che ella ha de la sua nutrice, e più, sanza paragone, di Dulippo, che amendua sono per fare male li fatti loro. Ma voglio andare, che io ho fretta.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Va pure, che tu gli hai ben concio la cuffia in capo.</p>
           </sp>
@@ -1790,71 +1845,71 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>CAPRINO, PSTERIA, EROSTRATO</stage>
-          <sp>
+          <sp who="#capr">
             <speaker>CAPR.</speaker>
             <p> O vecchia..., o vecchiaccia sorda..., non odi tu, fantasima?</p>
           </sp>
-          <sp>
+          <sp who="#psit">
             <speaker>PSIT.</speaker>
             <p> Dio faccia che tu non sia mai vecchio, perché a te non sia detto similmente.</p>
           </sp>
-          <sp>
+          <sp who="#capr">
             <speaker>CAPR.</speaker>
             <p> Vedi un poco se Dulippo è in casa.</p>
           </sp>
-          <sp>
+          <sp who="#psit">
             <speaker>PSIT.</speaker>
             <p> Vi è pur troppo; così non vi fussi egli mai stato!</p>
           </sp>
-          <sp>
+          <sp who="#capr">
             <speaker>CAPR.</speaker>
             <p> Digli in servizio mio che venghi fin qui, che io voglio parlarli.</p>
           </sp>
-          <sp>
+          <sp who="#psit">
             <speaker>PSIT.</speaker>
             <p> Non può, ch'egli è impacciato.</p>
           </sp>
-          <sp>
+          <sp who="#capr">
             <speaker>CAPR.</speaker>
             <p> Fagli l'imbasciata, volto mio bello.</p>
           </sp>
-          <sp>
+          <sp who="#psit">
             <speaker>PSIT.</speaker>
             <p> Deh, capestro, io ti dico ch'egli è impacciato.</p>
           </sp>
-          <sp>
+          <sp who="#capr">
             <speaker>CAPR.</speaker>
             <p> E tu se' impazzata: è un gran fatto dirgli una parola?</p>
           </sp>
-          <sp>
+          <sp who="#psit">
             <speaker>PSIT.</speaker>
             <p> Ben sai che gli è gran fatto, ghiotto fastidioso.</p>
           </sp>
-          <sp>
+          <sp who="#capr">
             <speaker>CAPR.</speaker>
             <p> O asina indiscreta!</p>
           </sp>
-          <sp>
+          <sp who="#psit">
             <speaker>PSIT.</speaker>
             <p> O ti nasca la fistola, ribaldello, che tu serai impiccato ancora.</p>
           </sp>
-          <sp>
+          <sp who="#capr">
             <speaker>CAPR.</speaker>
             <p> E tu serai bruciata, brutta strega, se 'l cancaro non ti mangia prima.</p>
           </sp>
-          <sp>
+          <sp who="#psit">
             <speaker>PSIT.</speaker>
             <p> Se mi ti accosti, ti darò una bastonata.</p>
           </sp>
-          <sp>
+          <sp who="#capr">
             <speaker>CAPR.</speaker>
             <p> S'io piglio un sasso, ti spezzerò quella testaccia balorda.</p>
           </sp>
-          <sp>
+          <sp who="#psit">
             <speaker>PSIT.</speaker>
             <p> Or sia in malora. Credo che tu sia il diavolo che mi viene a tentare.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> Caprino, ritorna a me: che stai tu a contendere? Ahimè! ecco Filogono, il vero patron mio, che viene in qua. Non so che mi debba fare: non voglio che mi veda in questo abito, né prima che io abbia il vero Erostrato ritrovato.</p>
           </sp>
@@ -1862,87 +1917,87 @@
         <div>
           <head>SCENA TERZA</head>
           <stage>FILOGONO <emph>vecchio, un</emph> FERRARESE <emph>e</emph> LICO <emph>servo</emph>.</stage>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Sii certo, valentuomo, che, come tu dici, è così veramente: che nessuno amore a quel del patre si può aguagliare. A chi me l'avessi, già tre anni, detto, non arei creduto che di questa etade io mi partissi di Sicilia, ancora che faccenda di grandissima importanzia di fuora accaduta mi fussi; et ora, solo per vedere il mio figliuolo e rimenarlo meco, mi sono posto in così lungo e travaglioso viaggio.</p>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERR.</speaker>
             <p> Tu vi debbi aver patito assai fatica e mal conveniente alla tua oramai grave etade.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Sono venuto con certi gentiluomini miei compatrioti, che voto avevano a Loreto, fino ad Ancona; et indi a Ravenna in una barca, che pur conduceva peregrini, ma con poco disconcio da Ravenna poi fin qui venire a contrario di acqua più m'è incresciuto che tutto il resto del camino.</p>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERR.</speaker>
             <p> E mali alloggiamenti vi si truovano.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Pessimi; ma stimo questo una ciancia verso il fastidio de gli importuni gabellieri che vi usano. Quante volte mi hanno aperto uno forziero che ho meco in nave e quella valigia, e rovistato e voltomi sozopra ciò che io vi ho dentro, e ne la tasca m'hanno voluto vedere e cercare nel seno! Io dubitai qualche volta che non mi scorticassino, per vedere se tra carne e pelle avevo roba da dazio.</p>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERR.</speaker>
             <p> Ho udito che vi si fanno grandi assassinamenti.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Tu ne puoi esser certissimo, né maraviglia ne ho, perché chi cerca tali offizi, è necessario che ribaldo e di pessima natura sia.</p>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERR.</speaker>
             <p> Questa passata molestia ti serà oggi accrescimento di letizia, quando in riposo ti vedrai il carissimo tuo figliuolo appresso. Ma non so perché più presto non hai fatto a te lui giovane ritornare, che tu pigliarti di venire qui tanta fatica, non avendoci, come tu dici, altra faccenda. Hai forse più rispetto auto di non sviarlo dal studio, che te medesimo porre al pericolo de la vita?</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Non è stata questa la cagione; anzi arei piacere che non procedessi il suo studio più inanzi, purché ritornassi a casa.</p>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERR.</speaker>
             <p> Se tu non avevi voglia che vi facessi profitto, perché ve lo hai mandato?</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Quando gli era a casa, gli bolliva il sangue, come alli giovani è usanza, e teneva pratiche che non mi parevano buone, e faceva ogni dì qualche cosa, onde io non poco dispiacere ne avevo; e non mi credendo io che increscere tanto me ne dovessi poi, lo confortai a venire a studio in quella terra che a lui più satisfacesse: e così se ne venne egli qui. Non credo che ci fussi ancora giunto, che me ne cominciò a dolere tanto, che da quell'ora sino a questa non sono mai stato di buona voglia, e da indi in qua con cento lettere l'ho pregato che se ne ritorni; né ho possuto impetrarlo mai. Egli sempre ne le sue risposte me ha supplicato, che dal studio, dove mi promette escellentissimo riuscire, non lo vogli rimuovere.</p>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERR.</speaker>
             <p> In verità, che da uomini degni di fede ho udito commendarlo, et è fra li scolari di ottimo credito.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Mi piace che non abbia invano consumato il suo tempo; tuttavia non mi curo che sia di tanta dottrina, dovendo stare per questo molti anni da lui disgiunto; che se io venissi a morte et egli non vi si trovassi, me ne morrei disperato. Non mi partirò di questa terra, che io lo ritornerò meco.</p>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERR.</speaker>
             <p> Amar li figliuoli è cosa umana, ma averne tanta tenerezza è feminile.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Io sono così fatto. Dirotti ancora che alla venuta mia ha dato maggior causa dua o tre nostri Siciliani, che diversamente sono a caso passati per questa terra, et io gli ho domandati del mio figliuolo: mi hanno risposto essere stati a Ferrara, et avere inteso di lui tutti li beni del mondo, ma che non l'hanno mai potuto vedere; e sono stati chi dua chi tre volte per visitarlo a casa. Dubito che sia tanto in queste sue lettere occupato, che non vogli mai fare altro, e schivi di parlare con gli amici e compatrioti suoi, per non defraudare il suo studio di quel pochissimo tempo; e per questo non deve sofferir pure de mangiare, e dubito che tutta la notte vegghi. Egli è giovane, con delicatezze allevato: se ne potrebbe morire, o impazzare facilmente, o di qualche altra simile disgrazia darsi cagione.</p>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERR.</speaker>
             <p> Tutte le cose troppe, sino alle virtù, sono da condennare. Ma questa è la casa dove abita Erostrato tuo: io batterò.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Batti.</p>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERR. </speaker>
             <p>Nessuno risponde.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Batti un'altra volta.</p>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERR.</speaker>
             <p> Credo che costoro si dormino.</p>
           </sp>
-          <sp>
+          <sp who="#lico">
             <speaker>LICO</speaker>
             <p> Se questa porta fusse tua madre, maggior rispetto non averesti di batterla. Lascia fare a me. Oh, olà, non è in questa casa alcuno?</p>
           </sp>
@@ -1950,123 +2005,123 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>DALIO, FILOGONO, LICO, FERRARESE</stage>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO</speaker>
             <p> Che furia è questa? Ci volete voi spezzar l'uscio?</p>
           </sp>
-          <sp>
+          <sp who="#lico">
             <speaker>LICO</speaker>
             <p> Io credo che voi dormivate.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Erostrato che fa?</p>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO</speaker>
             <p> Non è in casa.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Apri, che noi intriamo.</p>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO</speaker>
             <p> Se avete fatto pensiero di alloggiare, mutatelo, che altri forestieri ci sono prima di voi, e non ci capiresti tutti.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Sufficiente famiglio, e da far onore a ogni patrone! E chi c'è?</p>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO</speaker>
             <p> Filogono di Catania, il padre di Erostrato, è arrivato questa matina di Sicilia.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Vi serà, poi che tu arai aperto. Apri, se ti piace.</p>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO</speaker>
             <p> L'aprirvi mi serà poca fatica; ma siate certi che non vi potrete alloggiare, che le stanze sono piene.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> E chi v'è?</p>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO</speaker>
             <p> Non mi avete inteso? Io dico che v'è il padre di Erostrato, Filogono di Catania.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Quando ci venne prima che adesso?</p>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO</speaker>
             <p> Sono più di quattro ore ch'egli smontò all'osteria de la Corona, dove ancora sono li cavalli suoi, et Erostrato vi andò poi e l'ha menato qui.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Io credo che tu mi dileggi.</p>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO</speaker>
             <p> E voi avete piacere di farmi star qui, perché io non faccia quello che ho da fare.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Costui debbe essere imbriaco.</p>
           </sp>
-          <sp>
+          <sp who="#lico">
             <speaker>LICO</speaker>
             <p> Ne ha l'aria: non vedi come è rosso in viso?</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Che Filogono è questo di chi tu parli?</p>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO</speaker>
             <p> È un gentiluomo da bene, padre del mio patrone.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> E dov'è egli?</p>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO</speaker>
             <p> È qui in casa.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Potrei io vederlo?</p>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO</speaker>
             <p> Credo che sì, se cieco non sei.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Dimandalo in servizio, che venga di fuori, tanto che io gli parli.</p>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO</speaker>
             <p> Io vo.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Non so quello mi debba imaginare di questo.</p>
           </sp>
-          <sp>
+          <sp who="#lico">
             <speaker>LICO</speaker>
             <p> Patrone, il mondo è grande. Non credi tu che vi sia più d'una Catania e più d'una Sicilia, e più d'uno Filogono e d'uno Erostrato, e più d'una Ferrara ancora? Questa non è forse la Ferrara dove sta il tuo figliuolo, che noi cerchiamo.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Io non so ch'io mi creda, se non che tu sia pazzo e colui imbriaco, né sappia che si dica. Guarda tu, valentuomo, che non abbi errato la stanza.</p>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERR.</speaker>
             <p> Non credi tu ch'io connosca Erostrato di Catania, e non sappia che stia qui? Pur ieri ce lo vidi; ma ecco chi ti potrà chiarire, che non ha viso d'imbriaco come quel famiglio.</p>
           </sp>
@@ -2074,111 +2129,111 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>SANESE, FILOGONO, LICO, FERRARESE, DALIO</stage>
-          <sp>
+          <sp who="#san">
             <speaker>SAN.</speaker>
             <p> Mi domandi tu, gentiluomo?</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Vorrei intendere donde tu sia.</p>
           </sp>
-          <sp>
+          <sp who="#san">
             <speaker>SAN.</speaker>
             <p> Siciliano sono, al piacer tuo.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Di che terra?</p>
           </sp>
-          <sp>
+          <sp who="#san">
             <speaker>SAN.</speaker>
             <p> Di Catania.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Come hai nome?</p>
           </sp>
-          <sp>
+          <sp who="#san">
             <speaker>SAN.</speaker>
             <p> Filogono.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Che esercizio è il tuo?</p>
           </sp>
-          <sp>
+          <sp who="#san">
             <speaker>SAN.</speaker>
             <p> Mercatante.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Che mercanzia hai tu menato qui?</p>
           </sp>
-          <sp>
+          <sp who="#san">
             <speaker>SAN.</speaker>
             <p> Niuna: ci sono venuto per vedere un mio figliuolo che studia in questa terra, e sono più di dua anni che io non lo vidi.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Chi è tuo figliuolo?</p>
           </sp>
-          <sp>
+          <sp who="#san">
             <speaker>SAN.</speaker>
             <p> Erostrato.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Erostrato è tuo figliuolo?</p>
           </sp>
-          <sp>
+          <sp who="#san">
             <speaker>SAN.</speaker>
             <p> Sì, è.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> E tu sei Filogono?</p>
           </sp>
-          <sp>
+          <sp who="#san">
             <speaker>SAN.</speaker>
             <p> Sì, sono.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> E mercatante in Catania?</p>
           </sp>
-          <sp>
+          <sp who="#san">
             <speaker>SAN.</speaker>
             <p> Che bisogna domandare? Non ti direi bugia.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Anzi tu dici la bugia, e sei un baro et uno cattivissimo uomo.</p>
           </sp>
-          <sp>
+          <sp who="#san">
             <speaker>SAN.</speaker>
             <p> Hai torto a dirmi villania, che non ti offesi, ch'io sappi, mai.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> E tu fai da tristo e barattieri a dire che tu sia quello che tu non sei.</p>
           </sp>
-          <sp>
+          <sp who="#san">
             <speaker>SAN.</speaker>
             <p> Io son quello che io ti dico; e se io non fussi, perché lo direi?</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> O Dio, che audacia, che viso invetriato! Filogono di Catania sei tu?</p>
           </sp>
-          <sp>
+          <sp who="#san">
             <speaker>SAN.</speaker>
             <p> Quanto più vuoi ch'io te lo ridica? Io sono quel Filogono che io t'ho detto. E di che ti maravigli?</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Che un uomo di tanta presunzione si ritruovi! Né tu, né maggior di te far potrebbe che tu fussi quello che sono io; ribaldo, aggiuntatore che tu sei.</p>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO</speaker>
             <p> Patirò io che tu dica oltraggio al patre del patron mio? Se non ti lievi di questo uscio, ti caccierò questo schidione ne la pancia. Guai a te, se Erostrato qui si ritruovava! Torna in casa, signore, e lascia gracchiare questo uccellaccio ne la strada, tanto che si crepi.</p>
           </sp>
@@ -2186,59 +2241,59 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>FILOGONO, LICO, FERRARESE</stage>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Che ti pare, Lico mio, di queste cose?</p>
           </sp>
-          <sp>
+          <sp who="#lico">
             <speaker>LICO</speaker>
             <p> Che vuoi che me ne paia se non male? Non mi piacque mai questo nome Ferrara; ma veggio ora che sono assai peggiori gli effetti, che non è la nominanza.</p>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERR.</speaker>
             <p> Hai torto a dir male de la terra nostra: questi, che vi fanno ingiuria, non sono Ferraresi, per quanto vedo al loro idioma.</p>
           </sp>
-          <sp>
+          <sp who="#lico">
             <speaker>LICO</speaker>
             <p> Tutti ne avete colpa, e più gli ufiziali vostri, che comportano queste barerie ne la sua terra.</p>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERR.</speaker>
             <p> Che sanno gli ufiziali di queste trame? Credi tu che intendino ogni cosa?</p>
           </sp>
-          <sp>
+          <sp who="#lico">
             <speaker>LICO</speaker>
             <p> Anzi credo che intendino pochissimo, e mal volentieri, dove guadagno non vedono. Doverebbeno aprir li occhi, et aver le orecchie più patenti che non hanno le porte l'osterie.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Taci, bestia; parla de' fatti tuoi.</p>
           </sp>
-          <sp>
+          <sp who="#lico">
             <speaker>LICO</speaker>
             <p> Ho paura, se Iddio non ci aiuta, che amendua pareremo come hai detto.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Che faremo?</p>
           </sp>
-          <sp>
+          <sp who="#lico">
             <speaker>LICO</speaker>
             <p> Loderei che cercassimo tanto, che ritrovassimo Erostrato.</p>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERR.</speaker>
             <p> Io vi farò compagnia per tutto: andremo alle Scuole prima; se non quivi, lo troveremo alla piazza.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Io sono stanco, et ho più bisogno di riposo che di gire atorno: l'aspetteremo qui. È gran fatto che non ritorni a casa.</p>
           </sp>
-          <sp>
+          <sp who="#lico">
             <speaker>LICO</speaker>
             <p> Io dubito che ritroverà un nuovo Erostrato egli ancora.</p>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERR.</speaker>
             <p> Ecco, ecco che io lo vedo là... Ma dove è ritornato? Aspettami qui, che io lo chiamerò. O Erostrato, o Erostrato; tu non odi? O Erostrato, torna in qua.</p>
           </sp>
@@ -2246,123 +2301,123 @@
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>EROSTRATO, FERRARESE, FILOGONO, DALIO, LICO</stage>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> (Io non mi posso insomma nascondere: bisogna fare un buon animo; altrimenti...)</p>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERR.</speaker>
             <p> O Erostrato, Filogono il patre tuo è venuto fino di Sicilia per vederti.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> Tu non mi narri cosa di nuovo: io l'ho veduto e sono stato un gran pezzo con lui. E' venne fino questa matina per tempo.</p>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERR.</speaker>
             <p> A quello che egli m'ha detto, non mi par già che più veduto t'abbia.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> E dove gli hai tu parlato?</p>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERR.</speaker>
             <p> Par che tu non lo connosca: vedilo che vien qui. Filogono, eccoti il tuo figliuolo Erostrato.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Erostrato questo? Mio figliuolo non è così fatto.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> Chi è questo uom da bene?</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Oh questo mi pare Dulippo mio servo.</p>
           </sp>
-          <sp>
+          <sp who="#lico">
             <speaker>LICO</speaker>
             <p> Chi non lo connoscerebbe?</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Tu sei così vestito di lungo! Hai tu, Dulippo, ancora studiato forse?</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> A chi parla costui?</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Par che tu non mi connosca! Parlo io teco, o no?</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> Di' tu a me, gentiluomo?</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> O Dio, dove sono io arrivato? Questo ribaldo finge di non connoscermi. Sei tu Dulippo, o t'ho preso in scambio?</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> In cambio me avete voi tolto veramente, che io non ho cotesto nome.</p>
           </sp>
-          <sp>
+          <sp who="#lico">
             <speaker>LICO</speaker>
             <p> Patrone, non ti dissi io che eramo in Ferrara? Ecco la fé del tuo servo Dulippo, che niega di connoscerti! Ha preso de' costumi di qua.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Taci tu, in malora.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> Dimanda chi ti pare in questa terra, che non ci è uomo da bene che il mio nome non sappia. Tu che qui hai condotto questo forestiero, di': chi sono io?</p>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERR.</speaker>
             <p> Per Erostrato di Catania t'ho sempre connosciuto, e così ho udito nominarti, da poi che di Sicilia venisti in questa terra.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> O Dio, che oggi diventerò pazzo!</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> Dubito che tu non sia già.</p>
           </sp>
-          <sp>
+          <sp who="#lico">
             <speaker>LICO</speaker>
             <p> Non ti avedi, patrone, che siamo fra bari? Costui che credevano che mostra guida fussi, si è d'accordo con questo altro, e dice ch'egli è Erostrato questo, il quale è Dulippo mio conservo.</p>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERR.</speaker>
             <p> A torto ti lamenti di me, perché costui non udii mai altrimenti nominare che Erostrato di Catania.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> Che vuoi tu avere udito altrimenti nominarmi, che per il mio proprio nome? Ma sono bene io pazzo a dare audienza a parole di questo vecchio, che mi pare uscito del senno.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Ah fuggitivo! ah ribaldo! ah traditore! A questo modo si accetta il patron suo? Che hai tu fatto del mio figliuolo?</p>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO</speaker>
             <p> Ancora qui abbaia questo cane? E tu comporti, Erostrato, che ti dica villania?</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> Torna indrieto, bestia, che vuo' tu fare di quel pestello?</p>
           </sp>
-          <sp>
+          <sp who="#dalio">
             <speaker>DALIO</speaker>
             <p> Voglio spezzare la testa a questo vecchio rabbioso.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> E tu pon giù quel sasso. Tornatevi tutti in casa: non guardiamo al suo mal dire; abbisi rispetto all'età.</p>
           </sp>
@@ -2370,103 +2425,103 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>FILOGONO, FERRARESE, LICO</stage>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> A chi mi debbo io ricorrere e dimandargli aiuto, poiché costui, che io mi ho allevato et in luogo di figliuolo auto sempre, mi tradisce, e finge di non connoscermi? E tu, che per guida avevo tolto, et amico mi tenevo, ti sei con questo sceleratissimo mio servo già messo in lega? e sanza aver rispetto che io sono qui forestiero, e ne la miseria in che al presente mi ritruovo, o riguardare a Dio, che è giustissimo iudice e ogni cosa intende, al primo tratto hai falsamente testificato ch'egli è Erostrato costui, il quale tutto il mondo e la natura insieme non potrien fare che Dulippo non fussi.</p>
           </sp>
-          <sp>
+          <sp who="#lico">
             <speaker>LICO</speaker>
             <p> Se tutti gli altri testimoni in questa terra sono così fatti, si debbe provare ciò che si vuole.</p>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERR.</speaker>
             <p> Gentiluomo, dopo che in questa terra venne, né so donde, l'ho udito nominare Erostrato, e per figliuolo d'un Filogono catanese reputare. Che egli sia quello o no, lascierò a voi giudicare, e a chi, prima che venissi in questa città, ha di lui cognizione avuta. Chi depone quello che crede che così sia, né apresso Dio né apresso gli uomini si può per falsario condennare. Io non ho detto se non quello che avevo da gli altri udito, e che per me stimavo che così fussi.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Ah lasso! costui dunque, che al mio carissimo Erostrato diedi per famiglio e scorta, averà o venduto o assassinato il mio figliuolo, o di lui fatto qualche pessimo contratto; et averassi, non solo e panni e libri e ciò che per il viver suo di Sicilia conduceva, ma il nome ancora di Erostrato usurpato, per potere le lettere di cambio e il credito che io davo al mio figliuolo, senza altro impedimento usare a benefizio suo. Ah misero et infelice Filogono! Ah infortunatissimo vecchio! Non ci è iudice o capitano o potestà o altro rettore in questa terra, a cui mi possa ricorrere?</p>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERR.</speaker>
             <p>Ci abbiamo e iudici e potestà e sopra tutti uno principe iustissimo. Non dubitare che ti sia mancato di ragione, quando tu l'abbia.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Menami per tua fé, menami adesso o a principe o a potestà o a chi pare a te, ch'io gli voglio fare vedere la maggiore bareria, la maggiore iniquità, il più scelerato malefizio, che si commettessi mai.</p>
           </sp>
-          <sp>
+          <sp who="#lico">
             <speaker>LICO</speaker>
             <p> Patrone, a chi litigar vuole, bisogna quattro cose, e tu il sai: ragion prima, chi la sappia dire, favore, e chi te la faccia.</p>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERR.</speaker>
             <p> Favore? Di questa parte non odo che le leggi ne facciano menzione.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Non gli dare audienza, ch'egli è pazzo.</p>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERR.</speaker>
             <p> Di', per tua fé, Lico; che cosa è favore?</p>
           </sp>
-          <sp>
+          <sp who="#lico">
             <speaker>LICO</speaker>
             <p> Avere chi raccomandi la tua causa, perché, dovendo tu vincere, presto abbia fine; e così, se la conclusione non fa per te, che si differisca e meni in lungo, tanto che per il molto distrazio l'aversario stanco ti ceda, o teco pigli accordo.</p>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERR.</speaker>
             <p> Di questa parte, Filogono, benché qui non si usi, ti fornirò io ancora, non dubitare: ti menerò a uno avocato che ti basterà per tutte queste cose.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Convien ch'io mi dia dunque agli avocati e procuratori in preda, alla cui insaziabile avarizia supplire non mi terrei sufficiente con ciò che fare posso, ancora che ne la patria mi trovassi? Connosco io purtroppo li costumi loro. La prima volta che io gli parlerò, la causa vinta sanza alcuno dubbio mi prometteranno: escetto quella, ogni dì sempre vi ritroveranno, anzi vi faranno maggior dubbio, e mi vorranno dar colpa che da principio non gli abbia bene informati: e questo per trarmi non solo de la borsa li dinari, ma de l'osso le midolle.</p>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERR.</speaker>
             <p> Questo che io vi propongo è mezo santo.</p>
           </sp>
-          <sp>
+          <sp who="#lico">
             <speaker>LICO</speaker>
             <p> E che è l'altro mezo, diavolo?</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Ben dice Lico: anch'io mi fido poco di questi che portano il collo torto.</p>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERR.</speaker>
             <p> Voglio che sia come tu dici, e peggio ancora: l'odio e la malivolenza che egli porta a questo Erostrato, o Dulippo che sia, farà che, sanza avere rispetto al guadagnare teco, abbraccerà questa causa, e perseguiralla gagliardamente.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Che inimicizia è tra loro?</p>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERR.</speaker>
             <p> Di amore: amendua competitori sono d'una moglie, figliuola d'un cittadino nostro.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Adunque, questo truffatore è di tal credito a mie spese in questa terra, che ardisce dimandare per moglie una figliuola d'un cittadino?</p>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERR.</speaker>
             <p> Così è.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Come si nomina questo suo aversario?</p>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERR.</speaker>
             <p> Cleandro, de li primi dottori di questo Studio.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Andiamo a ritrovarlo.</p>
           </sp>
-          <sp>
+          <sp who="#ferrarese">
             <speaker>FERR.</speaker>
             <p> Andiamo.</p>
           </sp>
@@ -2484,119 +2539,119 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>PASIFILO, EROSTRATO <emph>finto</emph>.</stage>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> (Due buone et a me gratissime novelle mi sono state referite: l'una che Erostrato apparecchia per questa sera un bellissimo convito; l'altra, che egli mi cerca per tutto. Per torgli fatica che più vada per ritrovarmi atorno, e perché dove copiosamente e di buono si mangia, non è in questa terra alcuno che più di me vi debba intervenire, io vado per vedere se egli è in casa. Ma eccolo, per Dio.)</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> Pasifilo, fammi un piacere, se non ti grava.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Chi mi può commandare più di te, che per amor tuo intrerei nel fuoco? Che ho a fare?</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> Va lì, alla casa di Damone, e batti, e domanda Dulippo, e dilli...</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> A Dulippo non potrò parlare, io te n'aviso.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> E perché?</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> È in prigione.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> Come in prigione! e dove?</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> In un pessimo luogo, qui, ne la casa del patron suo.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> Che ne sai tu?</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Mi vi sono ritrovato.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> E questo è vero?</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Così non fussi!</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> Sai tu la causa?</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Non ti curare più oltre: bastiti esser certo che egli è preso.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> Pasifilo, io voglio che tu me lo dica, se mai tu speri aver da me piacere.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Deh, non mi astringere che io te lo dica; e che tocca te di saperlo?</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> Assai, e più che tu non pensi.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> E assai, e più che tu non pensi, tocca ad altri ancora che io lo taccia.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> Ah Pasifilo, è questa la fede che io ho in te? Sono queste le offerte che tu mi hai fatte?</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Avessi io più presto digiunato oggi, che esserti venuto inanzi!</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> O che tu me lo dica, o che tu faccia conto che questa porta stia sempre per te chiusa.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Voglio, prima che la inimicizia tua, quella di tutti gli uomini del mondo. Ma se odi cosa che ti dispiaccia, non ne incolpare altri che te.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> Non è che mi possa aggravare più che il male di Dulippo; non el mio proprio ancora: sì che non ti pensare peggior novella dirmi di quella che già detta mi hai, che egli sia preso.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Poi che tu pur me lo commandi, ti dirò il vero. È stato ritrovato che si giacea con Polinesta tua.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> Ahimè! Damone l'ha saputo?</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Una vecchia l'ha accusato; il quale sùbito l'ha fatto prendere, e così la nutrice ancora, che ne era consapevole et adiutrice; et amendua ha fatto porre in loco, dove faranno de' peccati loro durissima penitenzia.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> Pasifilo, entra in casa, e va ne la cucina, e fa cuocere e disporre quelle vivande secondo il parer tuo.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Se mi avessi fatto iudice de' Savi, non mi davi uffizio che più secondo il mio appetito fussi. Io vi vo di botto.</p>
           </sp>
@@ -2611,39 +2666,39 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>PASIFILO, EROSTRATO <emph>finto</emph>.</stage>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Facciasi pure, ma non si ponga al fuoco finché non siamo per intrare a tavola. — Ogni cosa va per ordine, ma se io non mi ci trovavo, sarebbe un grande scandalo accaduto.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> Che cosa accadea?</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Dalio volea porre in un medesimo schidione ad un tempo al fuoco li tordi con la lonza, avendo poca considerazione che questa tarda un pezzo, e quelli subito si cuocono.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> Deh, fussi questo il maggior scandalo che ci accade.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> E di dua mali non si potea fuggir l'uno. Se li avessi lasciati al par di quella, si sarebbono abbruciati e strutti: se li traessi prima, li aremo mangiati o freddi o male in punto.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> Tu hai auto buon consiglio.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Io andrò, se vuoi, a comperare de li aranci e de le ulive, che nulla varrebbe questo convito senza.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> Niente vi mancherà: non ti dubitare.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Costui, dopo che la cosa di Dulippo ha intesa, è tutto fantastico e bizarro: ha tanto martello che si crepa; ma abbilo, e crepi quanto vuole, purché io ceni questa sera in casa sua. D'altro non mi curo. Ma non è quello Cleandro, che viene in qua? Or bene, in capo gli porremo il cimiero de le corna. Senza dubbio Polinesta serà sua, che Erostrato, per quel che di Dulippo ha da me saputo, non la domanderà, né vorrà più.</p>
           </sp>
@@ -2651,327 +2706,327 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>CLEANDRO, FILOGONO, PASIFILO <emph>e</emph> LICO</stage>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Ma come mostrerai tu che costui non sia Erostrato, essendoci la publica presunzione in contrario? e come, che tu sia Filogono di Catania, quando quest'altro col testimonio del simulato Erostrato lo nieghi e che sia quello esso pertinacissimamente contenda?</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Qui voglio in prigione constituirmi, e sùbito si mandi a Catania (e sono contento che a mie spese ancora), e faccisi venire dua o tre di fé degni, li quali di Filogono e di Erostrato vera cognizione abbino; e stiamo al giudizio loro, se io sono o se pure quell'altro è Filogono; e così, s'egli è Erostrato, o pur s'egli Dulippo mio servo, quest'altro audacissimo ribaldo.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> (Io voglio salutarlo.)</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Questa serà via lunga e di gran spesa, ma necessaria, non ce ne vedendo io alcuna altra migliore.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Dio ti dia contento, patron mio singulare.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> A te dia quello che meriti.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Mi darà la grazia tua e da godere in perpetuo.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Ti darà un laccio che t'impicchi, ghiotto, ribaldo che tu sei.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Che io sia ghiotto, tel confesso, ma ribaldo no: hai torto dirmi così, che servitor ti sono.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Né servitore né amico ti voglio.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Che t'ho fatto io?</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Va alle forche, perfido traditore.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Ah Cleandro! pianamente.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Io te ne pagherò: renditi certo, imbriaco, gaglioffo.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Io non so di averti offeso.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Te lo farò bene io sapere a tempo. Lévamiti dinanzi, manigoldo.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Cleandro, io non sono però tuo schiavo.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Tu ardisci di aprir la bocca, assassino? Io ti farò...</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Che diavolo! Quando io ho ben sofferto e sofferto, che mi farai tu?</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Quel ch'io ti farò? S'io non guardassi, poltrone...</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Io sono uom da bene quanto tu.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Tu ne menti per la gola, impiccato.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Ah! non correre a furia.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Chi mi vuol battere?</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p>Io ti giugnerò a tempo; lascia, lascia...</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Orsù, sia con Dio: io non voglio stare a contendere.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Va pure; se io non te ne pago, mutami nome.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Che diavol mi puoi tu fare? Io non ho roba un tratto, che io tema che tu mi muova lite.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Tu sei intrato in còlera.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Questo tristo... Ma lasciamo andare: ritorniamo al fatto nostro. Non cesserò che io lo farò impiccare, come merita.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Tu sei turbato, a mi darai mala audienzia.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> No, no: dimmi pure il fatto tuo.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Io dico che si mandi a Catania, e che si faccia...</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Sì, sì, ho inteso questo: è necessario far così. Ma come è tuo servo colui, e donde l'avesti? Informami del tutto pienamente.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Io ti dirò. Al tempo che da gli infedeli Otranto fu preso...</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Ahimè! tu mi ricordi i dolor miei.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Come?</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Che allora io uscii di quella terra che è la patria mia, e vi persi tanto, che io non spero mai più racquistarlo.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Me ne duole.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Séguita.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> In quel tempo alcuni Siciliani nostri, che con tre buone armate galee scorrevano il mare, ebbono spia d'un legno di Turchi, che da la presa città con ricchissima preda verso la Velona si ritornava.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> E forse ve n'era buona parte del mio.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Et alla volta di quella se n'andarono, e furono alle mani seco, e lo presero finalmente, et a Palermo, donde erano essi, se ne ritornarono; e fra l'altre cose che posero in vendita, vi avevano costui, allora fanciullo di cinque in sei anni.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Uno de la medesima etade, ah lasso! ne lasciai in Otranto.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> E ritrovandomi io quivi, e piacendomi lo aspetto suo, ventiquattro ducati lo comperai.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Era il fanciullo turco, o i Turchi pure di Otranto lo avevano rapito?</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Eglino pure di quella terra l'avevano tolto; ma che monta questo? una volta io lo comperai de li danari miei.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Non te lo domando a questo effetto. Deh, fussi egli quello che io vorrei!</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Chi vorresti che e' fussi?</p>
           </sp>
-          <sp>
+          <sp who="#lico">
             <speaker>LICO</speaker>
             <p> Noi stiàn freschi. Aspetta pure.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Aveva egli nome Dulippo allora?</p>
           </sp>
-          <sp>
+          <sp who="#lico">
             <speaker>LICO</speaker>
             <p> Patrone, abbi cura al fatto tuo.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Che vuoi tu cianciare, presuntuoso? Non Dulippo, ma Carino era il suo nome.</p>
           </sp>
-          <sp>
+          <sp who="#lico">
             <speaker>LICO</speaker>
             <p> Làsciati pur trarre ogni cosa di bocca.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Carino era il suo nome? O Dio, se oggi beato far mi volessi! Perché gli mutasti nome?</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Gli dicemo Dulippo, perché usato era piangendo chiamare tal nome spesso.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Vedo oramai certo che questo è il mio figliuolo, che nominato fu Carino; e quel Dulippo, che chiamar solea piangendo, fu uno allevato mio, che lo nutriva, et a cui lo avevo dato in custodia.</p>
           </sp>
-          <sp>
+          <sp who="#lico">
             <speaker>LICO</speaker>
             <p> Non ti dissi io, patrone, che siamo in terra di Bari, e credevamo essere in Ferrara? Costui, per privarti del servo tuo, se lo vorrà con ciance adottare per figliuolo.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Io non sono usato dir bugie.</p>
           </sp>
-          <sp>
+          <sp who="#lico">
             <speaker>LICO</speaker>
             <p> Ogni cosa vuol principio.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Non avere, Filogono, un minimo sospetto che io t'inganni.</p>
           </sp>
-          <sp>
+          <sp who="#lico">
             <speaker>LICO</speaker>
             <p> Non un minimo, ma un grandissimo sì.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Taci un poco. Dimmi: aveva alcuna memoria el fanciullo de la stirpe sua, o del nome del padre o de la madre?</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Aveva, sì; e me l'ha già detto, ma non l'ho in memoria veramente.</p>
           </sp>
-          <sp>
+          <sp who="#lico">
             <speaker>LICO</speaker>
             <p> Ce l'ho ben io.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Dillo tu, adunque.</p>
           </sp>
-          <sp>
+          <sp who="#lico">
             <speaker>LICO</speaker>
             <p> Non dirò io già: ne ha saputo pur troppo da te.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Dillo, se tu lo sai.</p>
           </sp>
-          <sp>
+          <sp who="#lico">
             <speaker>LICO</speaker>
             <p> Io lo so, e mi lascierei prima tagliare la gola, che io lo dicessi. Ché non lo dice egli inanzi? E chi non si avedrebbe ch'egli va a tentone?</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> El mio nome sapete voi già: la mia donna e matre di lui aveva nome Sofronia; la casa mia si chiama da la Spiaggia.</p>
           </sp>
-          <sp>
+          <sp who="#lico">
             <speaker>LICO</speaker>
             <p> Io non so tante cose; so bene che e' diceva sua madre aver nome Sofronia; ma è un gran fatto, s'egli è teco d'accordo, che e' t'abbia del tutto informato?</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Non ho bisogno di più manifesti segni oramai: questo senza alcun dubbio è el mio figliuolo, che già diciotto anni fa ho perso e mille volte pianto, et aver debbe un neo di buona grandezza ne l'omero sinistro.</p>
           </sp>
-          <sp>
+          <sp who="#lico">
             <speaker>LICO</speaker>
             <p> Che maraviglia, se te l'ha detto, che tu lo sappia? El neo vi ha pur troppo: così vi avesse egli...</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Ah, Lico, buone parole. Presto, andiamo a ritrovarlo. O Fortuna, liberamente ti perdono, poi ch'el mio figliuolo oggi ritrovar mi fai!</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Et io le sono tanto meno obligato, che non so che del mio figliuolo si sia. E tu, che per avocato apparecchiato me avea, ora a favor di Dulippo et a mio danno ti serai tutto converso.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Filogono, andiamo a parlare col mio figliuolo, che io spero che tu insieme el tuo ritroverai.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Poi ch'io vedo l'uscio aperto, sanza chiamare o battere me ne entrerò alla domestica.</p>
           </sp>
-          <sp>
+          <sp who="#lico">
             <speaker>LICO</speaker>
             <p> Padrone, guarda come tu vai qua dentro, ch'io son certo che costui ha fatto questa fizione per condurti in qualche precipizio.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Quasi che se 'l mio figliuolo perduto fussi, io mi curassi restar vivo!</p>
           </sp>
-          <sp>
+          <sp who="#lico">
             <speaker>LICO</speaker>
             <p> Io te l'ho detto: or fa tu quel che ti piace.</p>
           </sp>
@@ -2979,47 +3034,47 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>DAMONE, PSITERIA</stage>
-          <sp>
+          <sp who="#dam">
             <speaker>DAM.</speaker>
             <p> Vien qua, cianciera e temeraria femina; onde ha potuto, se non da te, Pasifilo intendere questa cosa?</p>
           </sp>
-          <sp>
+          <sp who="#psit">
             <speaker>PSIT.</speaker>
             <p> Da me non l'ha già intesa: è stato il primo egli a dirlo a me.</p>
           </sp>
-          <sp>
+          <sp who="#dam">
             <speaker>DAM.</speaker>
             <p> Tu ne menti, gaglioffa; tu mi dirai il vero o ch'io ti romperò quante ossa tu hai ne la persona.</p>
           </sp>
-          <sp>
+          <sp who="#psit">
             <speaker>PSIT.</speaker>
             <p> Se tu ritruovi che sia altrimenti, amazzami ancora.</p>
           </sp>
-          <sp>
+          <sp who="#dam">
             <speaker>DAM.</speaker>
             <p> Dove ti ha egli parlato?</p>
           </sp>
-          <sp>
+          <sp who="#psit">
             <speaker>PSIT.</speaker>
             <p> Qui ne la strada.</p>
           </sp>
-          <sp>
+          <sp who="#dam">
             <speaker>DAM.</speaker>
             <p> Che facevi tu qui?</p>
           </sp>
-          <sp>
+          <sp who="#psit">
             <speaker>PSIT.</speaker>
             <p> Andavo a casa di mona Bionda, per vedere una tela che ella ti tesse.</p>
           </sp>
-          <sp>
+          <sp who="#dam">
             <speaker>DAM.</speaker>
             <p> Che accadeva a lui parlare di questo teco, se tu non avessi cominciato la favola?</p>
           </sp>
-          <sp>
+          <sp who="#psit">
             <speaker>PSIT.</speaker>
             <p> Anzi egli mi cominciò a riprendere e dirmi villania, perché ero stata quella che ti avevo il tutto riferito. Io lo domandai che ne sapeva: egli mi disse che mi aveva udito, perché era ne la stalla nascosto quando tu oggi mi vi chiamasti.</p>
           </sp>
-          <sp>
+          <sp who="#dam">
             <speaker>DAM.</speaker>
             <p> Ah misero me! che farò adunque? Torna tu in casa. Non morrò, che io trarrò la lingua a un paio di queste cicale. Mi duole ancora più che Pasifilo lo sappia, che non ha fatto che ne sia l'effetto accaduto; che accaduto ne è per pochissima mia avertenza. Chi vuole bene confidare un suo secreto, lo dica a Pasifilo: solo il popolo e chi ha orecchie, e non altri, lo intenderà mai. Ora se ne parla in cento luoghi. Cleandro serà stato il primo che l'arà inteso, Erostrato il secondo, e poi di mano in mano tutta la città. O che dote se gli è apparecchiata! Quando la mariterò io mai più? Ahi misero me, misero più che la miseria istessa veramente! O Dio, fussi almeno vero quello che la mia figliuola m'ha narrato: che costui che l'ha violata, non è de la vile condizione, come ha simulato fino a questo giorno ne la casa mia, anzi è di buon sangue e di facultà amplissime ne la sua patria. Quando anche non fussi se non la metà di quello che ella mi ha detto, arei di somma grazia fargliela sposare; ma dubito che con queste ciance il scelerato Dulippo ingannata l'abbia. Io voglio essaminare lui ancora: connoscerò bene io al parlare se questa è una favola, che e' s'abbi, per venire al suo disegno, finta, o pure stia così il vero. Ma non è quel Pasifilo, che esce di casa del vicino nostro? Onde viene tanta letizia, che e' salta come pazzo ne la via?</p>
           </sp>
@@ -3027,79 +3082,79 @@
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>PASIFILO, DAMONE</stage>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> O Dio, ch'io truovi Damone in casa, né mi convenga cercarlo per tutta la terra! et altri precorri intanto e la nunziatura mi lievi di mezzo. O me felice, che io lo vedo in su la porta!</p>
           </sp>
-          <sp>
+          <sp who="#dam">
             <speaker>DAM.</speaker>
             <p> (Che nunziatura vuol da me costui?) Che t'è di bene accaduto, Pasifilo, che così lieto sei?</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> El tuo bene è causa de l'allegrezza mia.</p>
           </sp>
-          <sp>
+          <sp who="#dam">
             <speaker>DAM.</speaker>
             <p> Che cosa è?</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Io so che sei per il caso de la tua figliuola addoloratissimo.</p>
           </sp>
-          <sp>
+          <sp who="#dam">
             <speaker>DAM.</speaker>
             <p> E quanto!</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Sappi che colui, che t'ha fatto disonore, è figliuolo di tale uomo, che sdegnar non ti déi che ti sia genero.</p>
           </sp>
-          <sp>
+          <sp who="#dam">
             <speaker>DAM.</speaker>
             <p> Che ne sai tu?</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Il patre suo, quale è Filogono di Catania, che io so che per fama de la sua ricchezza connosci, è arrivato adesso di Sicilia, et è in casa del vicin nostro.</p>
           </sp>
-          <sp>
+          <sp who="#dam">
             <speaker>DAM.</speaker>
             <p> Di Erostrato, vuoi dire?</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Anzi di Dulippo. Bene abbiamo fino a questa ora creduto che questo vicin tuo Erostrato sia, e non è; ma quello che tu hai in casa prigione, che si faceva Dulippo nominare, ha nome Erostrato, et era patrone di quest'altro, il quale è Dulippo e sempre in questa terra se ha fatto nominare Erostrato. E fra loro si avevano ordinato questa cosa perché Erostrato, col nome di Dulippo, in abito servile commodamente facessi quello che egli ha fatto in casa tua.</p>
           </sp>
-          <sp>
+          <sp who="#dam">
             <speaker>DAM.</speaker>
             <p> Dunque non è falso quello che Polinesta mi narrava dianzi?</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Ti ha detto ella così ancora?</p>
           </sp>
-          <sp>
+          <sp who="#dam">
             <speaker>DAM.</speaker>
             <p> Sì, ma dubitavo che non fussi una ciancia.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Anzi è una verità verissima. Filogono a te verrà qui adesso, e Cleandro è con lui.</p>
           </sp>
-          <sp>
+          <sp who="#dam">
             <speaker>DAM.</speaker>
             <p> Come Cleandro?</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Odi un'altra bella istoria. Cleandro ha ritrovato che quel Dulippo che si faceva nominare Erostrato, è suo figliuolo, che ne la perdita di Otranto gli fu da' Turchi rapito, e pervenne poi alle mani di Filogono; il quale da piccolino lo ha allevato, et in compagnia del suo figliuolo l'aveva mandato in questa terra. Il più bel caso di questo non accadde mai: se ne potria fare una comedia. Seranno tutti qui adesso, e da loro pienamente ti chiarirai d'ogni cosa.</p>
           </sp>
-          <sp>
+          <sp who="#dam">
             <speaker>DAM.</speaker>
             <p> Io voglio da Dulippo, o Erostrato che sia, tutta questa pratica intendere, prima che io venga con Filogono a parlamento.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Serà ben fatto, et io andrò a fare costoro indugiare un poco. Ma mi pare che venghino già.</p>
           </sp>
@@ -3107,27 +3162,27 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>SANESE, FILOGONO <emph>e</emph> CLEANDRO</stage>
-          <sp>
+          <sp who="#san">
             <speaker>SAN.</speaker>
             <p> Non accade che meco più ti scusi; che quando bene tu mi abbi soiato, non me ne essendo venuto peggio che parole, io ne fo pochissimo conto; anzi mi giova avere imparato, sanza alcuno mio danno, di essere un'altra volta più cauto et ogni cosa non credere così al primo tratto. E tanto più, sendo stata una trama amorosa, leggermente e sanza un minimo sdegno me ne passo. E così tu, Filogono, s'io ho fatto cosa che ti sia spiaciuta, pigliala per quella via onde è venuta.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Io non mi doglio d'altro, se non de le parole ingiuriose che io t'ho detto.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Di questo è detto a bastanza: è superfluo oramai ogni ragionare che se ne faccia più ancora. Avverrà che tu per gran cosa non vorresti che fussi restato di accaderti questo inganno, o come tu il vuoi nominare: che ti serà una fabula piacevole da ricontare in cento luoghi. E tu credi, Filogono, che così dal cielo ordinato era; che per altra che per questa via non era possibile che del mio Carino avessi mai ricognizione, né egli di me, essendo l'odio e la inimicizia tra noi, che da l'uno e da l'altro hai tu medesmo inteso.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> Io connosco che gli è come tu narri, perché una minima foglia non credo che quaggiù senza la superna voluntà si muova. Ma ritroviamo questo Damone, che ogni momento che io indugio di rivedere il mio figliuolo, uno anno mi pare.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Andiamo. Tu puoi, gentiluomo, rimanere col mio figliuolo in casa, che queste cose da principio non sono da trattare con tanti testimoni.</p>
           </sp>
-          <sp>
+          <sp who="#san">
             <speaker>SAN.</speaker>
             <p> Io farò come voi volete.</p>
           </sp>
@@ -3135,55 +3190,55 @@
         <div type="scene">
           <head>SCENA NONA</head>
           <stage>PASIFILO, CLEANDRO, FILOGONO, DAMONE, EROSTRATO</stage>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Non posso io, Cleandro, impetrare da te che dir mi vogli in che t'ho offeso?</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Sono ormai, Pasifilo, chiaro che io t'ho con parole ingiuriato a torto; ma el testimonio a cui ho dato in causa propria, contro al debito, fede, mi ha tratto in questo errore.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Mi piace che la ragione stata non sia da la malizia oppressa; ma non dovevi credere così facilmente e dirmi tanta villania.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Ho questa mia còlera così sùbita, che non ci posso riparare.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Che còlera? Ingiuriare un uom da bene publicamente e darli carico, e poi dar colpa alla còlera, è una bella scusa!</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Non più, Pasifilo; io ti sono, come fui sempre, amico, et accadendone l'esperienza, sono per dimostrartene chiarissimi effetti. Domatina t'aspetto a desinar meco. Questo è Damone, che esce di casa: lascia parlare a me prima. Vegnamo a te, Damone, per farti tornare in gaudio la mestizia, che ci persuadiamo che debitamente per il caso occorso ti molesti, certificandoti che colui che fino a questa ora per Dulippo e tuo famiglio hai reputato, è figliuolo di questo gentiluomo Filogono di Catania, a te non inferiore di sangue, ma di ricchezza, come tu stesso aver puoi per fama inteso, superiore assai.</p>
           </sp>
-          <sp>
+          <sp who="#filog">
             <speaker>FILOG.</speaker>
             <p> E così sono apparecchiato emendare, in quello ch'io posso, il fallo del mio figliuolo, facendolo a te genero legittimo, quando ti contenti; e se altra cosa è che per te io possa fare più, ad ogni voler tuo mi offero paratissimo.</p>
           </sp>
-          <sp>
+          <sp who="#clean">
             <speaker>CLEAN.</speaker>
             <p> Et io, che pur dianzi Polinesta ti domandavo per sposa, da te rimango satisfattissimo quando, a mia instanzia, al figliuolo di costui tu la concedi, a cui più debitamente che a me, e per l'età e per l'amore che egli li ha portato e mille altri rispetti, se li conviene; però che io, che moglie cercavo per desiderio di lasciare erede, ora non ne ho più bisogno né voglia, perché il mio figliuolo, che ne la presa de la mia patria persi, oggi ho ritrovato, come più ad agio ti narrerò.</p>
           </sp>
-          <sp>
+          <sp who="#dam">
             <speaker>DAM.</speaker>
             <p> El parentado e l'amicizia tua, Filogono, io la debbo per molte condizioni non meno desiderare che tu la mia; e così la accetto, e sopra tutte le altre che mi siano state offerte, o che io sperate abbi, mi è gratissima. El tuo figliuolo per genero e per figliuolo raccoglio, e te per onoratissimo parente; e tanto più me ne gode l'animo quanto te, Cleandro, veggio rimanere satisfatto; e teco senza fine mi allegro che ritrovato abbi el tuo figliuolo, di che Pasifilo me ne ha pienamente informato. Ma eccoti, Filogono, il tuo desiderato Erostrato; e questa è la nuora tua.</p>
           </sp>
-          <sp>
+          <sp who="#erost">
             <speaker>EROST.</speaker>
             <p> O padre mio!</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Quanta è la tenerezza de' padri verso de' figliuoli! Per il gaudio non ha facultà Filogono di potere esprimere una sola parola, et usa le lacrime in questa vice.</p>
           </sp>
-          <sp>
+          <sp who="#dam">
             <speaker>DAM.</speaker>
             <p> Andiamo in casa.</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> È ben detto: in casa, in casa.</p>
           </sp>
@@ -3191,19 +3246,19 @@
         <div type="scene">
           <head>SCENA DECIMA</head>
           <stage>NEBBIA, DAMONE <emph>e</emph> PASIFILO</stage>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p> Patrone, ho portato li ferri.</p>
           </sp>
-          <sp>
+          <sp who="#dam">
             <speaker>DAM.</speaker>
             <p> Portali via.</p>
           </sp>
-          <sp>
+          <sp who="#nebb">
             <speaker>NEBB.</speaker>
             <p> Che vuoi ch'io ne faccia?</p>
           </sp>
-          <sp>
+          <sp who="#pasif">
             <speaker>PASIF.</speaker>
             <p> Chiàvateli in culo. Chi non ci ha a fare, si parta, perché a queste nozze non vogliamo essere tanti.</p>
           </sp>

--- a/tei/ariosto-il-negromante.xml
+++ b/tei/ariosto-il-negromante.xml
@@ -77,6 +77,52 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="margarita">
+            <persName>Margarita</persName>
+          </person>
+          <person xml:id="balia">
+            <persName>Balia</persName>
+          </person>
+          <person xml:id="lippo">
+            <persName>Lippo</persName>
+          </person>
+          <person xml:id="fazio">
+            <persName>Fazio</persName>
+          </person>
+          <person xml:id="cintio">
+            <persName>Cintio</persName>
+          </person>
+          <person xml:id="temolo">
+            <persName>Temolo</persName>
+          </person>
+          <person xml:id="massimo">
+            <persName>Massimo</persName>
+          </person>
+          <person xml:id="nibbio">
+            <persName>Nibbio</persName>
+          </person>
+          <person xml:id="astrologo">
+            <persName>Astrologo</persName>
+          </person>
+          <person xml:id="camillo">
+            <persName>Camillo</persName>
+          </person>
+          <person xml:id="madonna">
+            <persName>Madonna</persName>
+          </person>
+          <person xml:id="fantesca">
+            <persName>Fantesca</persName>
+          </person>
+          <person xml:id="facchino">
+            <persName>Facchino</persName>
+          </person>
+          <person xml:id="abondio">
+            <persName>Abondio</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>2007-06-08T00:00:00.000+02:00</date><name>Novadata systems</name>Digitalizzazione - OCR</change>
@@ -218,7 +264,7 @@
         <div type="scene" n="Scena I">
           <head>SCENA I</head>
           <stage>Margarita fantesca, Balia</stage>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA:</speaker>
             <l>Io non ho mai, da quel di ch'andò Emilia</l>
             <l>A marito (che un mese e più debbe essere)</l>
@@ -238,135 +284,135 @@
             <l>E star un pezzo con lei. Ma la balia</l>
             <l>Esce di casa. Dove si va, balia?</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l>In nessun luogo. Io venia, ché parevami</l>
             <l>D'aver sentito un di questi che girano</l>
             <l part="I">Vendendo l'erbe.</l>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA:</speaker>
             <l part="F">Mia madonna acconciasi</l>
             <l part="I">Per partir anco?</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l part="F">Oh! sei stata sollecita</l>
             <l part="I">Molto a venir per lei.</l>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA:</speaker>
             <l part="F">La nostra Emilia</l>
             <l part="I">Che fa?</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l part="F">Pur dianzi si serraro in camera</l>
             <l>Ella e la madre, et è con esse un medico</l>
             <l>Che ci venne oggi, forestiero, e parlano</l>
             <l part="I">Di segreto.</l>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA:</speaker>
             <l part="F">Io venia con desiderio</l>
             <l part="I">Di stare un pezzo pur con lei.</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l part="F">Mal copia</l>
             <l>Oggi ne avrai, che tutta è maninconica.</l>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA:</speaker>
             <l part="I">Che l'è accaduto?</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l part="F">Quel ch'avea la misera</l>
             <l>Da aspettar meno: che nasca una fistola,</l>
             <l>A chi mai fece questo sponsalizio!</l>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA:</speaker>
             <l>Ognun sì lo lodava da principio</l>
             <l>Per un partito de' miglior che fossino</l>
             <l part="I">In questa terra.</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l part="F">Dar non la potevano,</l>
             <l part="I">Margarita mia, peggio.</l>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA:</speaker>
             <l part="F">È pur bel giovene.</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l part="I">Altro bisogna.</l>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA:</speaker>
             <l part="F">Intendo che è ricchissimo:</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l part="I">Bisogna anch'altro.</l>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA:</speaker>
             <l part="F">Debbe esser spiacevole?</l>
             <l>Ma non stia in punta e giostri di superbia</l>
             <l part="I">Con essolui.</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l part="F">Deh, non temer che giostrino,</l>
             <l>Che la lancia è spuntata e trista e debole.</l>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA:</speaker>
             <l part="I">Dunque non le fa il debito egli?</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l part="F">Il debito, eh?</l>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA:</speaker>
             <l part="I">Che! non può?</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l part="F">La infelice è così vergine,</l>
             <l>Come era inanzi questo sponsalizio.</l>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA:</speaker>
             <l part="I">Uh che disgrazia!</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l part="F">È bene una disgrazia</l>
             <l>De le maggiori ch'aver possa femina.</l>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA:</speaker>
             <l>Lasci andar, né però si dia molestia;</l>
             <l part="I">Potrà ben...</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l part="F">Quando potrà ben, se in quindici</l>
             <l part="I">O trenta di non può?</l>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA:</speaker>
             <l part="F">Se ne ritruovano,</l>
             <l>Intendo, alcuni, che stan così deboli</l>
             <l>Gli anni, e ritornan poi come prima erano.</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l>Gli anni? Signor! Dunque debbe ella attendere,</l>
             <l>A bocca aperta, che le biade naschino</l>
@@ -378,14 +424,14 @@
             <l>Cose, ch'aver poteva in abondanzia</l>
             <l part="I">Col padre ancora?</l>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA:</speaker>
             <l part="F">Qualche trista femina,</l>
             <l>Con cui lo sposo avrà già avuto pratica,</l>
             <l>L'averà così guasto per invidia.</l>
             <l>Ma pur sono a tal cose dei rimedii.</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l>Provati se ne sono, e se ne provano</l>
             <l>Tuttavia molti, e par che nulla vaglino:</l>
@@ -395,14 +441,14 @@
             <l>Sì che di peggio che malia mi dubito.</l>
             <l>E che gli manchi... ben puommi tu intendere.</l>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA:</speaker>
             <l>Ben saria meglio che data l'avessino</l>
             <l>A Camillo, che tante volte chiedere</l>
             <l>La fece lor. Perché gliela negarono?</l>
             <l part="I">Perché Cintio è più ricco?</l>
           </sp>
-          <sp>
+          <sp who="#balia">
             <speaker>BALIA:</speaker>
             <l part="F">Differenzia</l>
             <l>Di roba è poca tra loro; anzi il fecero</l>
@@ -422,7 +468,7 @@
         <div type="scene" n="Scena II">
           <head>SCENA II</head>
           <stage>Lippo, Fazio</stage>
-          <sp>
+          <sp who="#lippo">
             <speaker>LIPPO:</speaker>
             <l>Questa è la prima strada che, volgendosi</l>
             <l>A man manca, passato Santo Stefano</l>
@@ -433,96 +479,96 @@
             <l>Veggol, per Dio! Gli è quel ch'io cerco proprio.</l>
             <l part="I">Gli è desso.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="M">Non è questo. Lippo?</l>
           </sp>
-          <sp>
+          <sp who="#lippo">
             <speaker>LIPPO:</speaker>
             <l part="F">O Fazio!</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="I">Quando a Cremona?</l>
           </sp>
-          <sp>
+          <sp who="#lippo">
             <speaker>LIPPO:</speaker>
             <l part="F">O caro Fazio, veggoti</l>
             <l part="I">Volentieri.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Io tel credo; et io te simile</l>
             <l>mente. E che buone faccende ti menano?</l>
           </sp>
-          <sp>
+          <sp who="#lippo">
             <speaker>LIPPO:</speaker>
             <l>Mi manda Copo nostro per riscuotere</l>
             <l>Alcuni suoi danari, che gli debbono</l>
             <l>Li eredi di Mengoccio de da Semola.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="I">Quando giungesti?</l>
           </sp>
-          <sp>
+          <sp who="#lippo">
             <speaker>LIPPO:</speaker>
             <l part="F">Giunsi ieri sul vespero.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="I">Or che si fa a Fiorenza?</l>
           </sp>
-          <sp>
+          <sp who="#lippo">
             <speaker>LIPPO:</speaker>
             <l part="F">Si fa il solito.</l>
             <l>Odo che ti sei fatto in corpo e in anima</l>
             <l>Cremonese, né più curi la patria.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l>Che vuoi ch'io faccia? A Firenze sì premeno</l>
             <l>Le publiche gravezze, che resistere</l>
             <l>Non vi si può: qui mi ridussi, e vivomi</l>
             <l>Con la mia brigatella assai più commodo.</l>
           </sp>
-          <sp>
+          <sp who="#lippo">
             <speaker>LIPPO:</speaker>
             <l part="I">Tua moglie come sta?</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Sana, Dio grazia.</l>
           </sp>
-          <sp>
+          <sp who="#lippo">
             <speaker>LIPPO:</speaker>
             <l>Non avevate una figliuola? Parmene</l>
             <l part="I">Pur ricordar.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Ben ricordar potrebbeti</l>
             <l>D'una fanciulla, che ci abbiàn da piccola</l>
             <l>Allevata e tenuta cara, e amiamola</l>
             <l part="I">Più che figliuola.</l>
           </sp>
-          <sp>
+          <sp who="#lippo">
             <speaker>LIPPO:</speaker>
             <l part="F">Vostra reputavola.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l>Nostra figliuola ella non è: lasciataci</l>
             <l>Fu da sua madre, la qual, capitataci</l>
             <l>In casa inferma, dopo dieci o dodici</l>
             <l part="I">Giorni che v'alloggiò, si morì.</l>
           </sp>
-          <sp>
+          <sp who="#lippo">
             <speaker>LIPPO:</speaker>
             <l part="F">Avetela</l>
             <l part="I">Ancora maritata?</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Maritatala</l>
             <l>Avevamo, e sì bene, che pochissimi</l>
@@ -531,30 +577,30 @@
             <l>Dentro, sì che talor vorrei non essere</l>
             <l part="I">Nato.</l>
           </sp>
-          <sp>
+          <sp who="#lippo">
             <speaker>LIPPO:</speaker>
             <l part="F">Me incresce d'ogni tua molestia.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="I">Ben ne son certo.</l>
           </sp>
-          <sp>
+          <sp who="#lippo">
             <speaker>LIPPO:</speaker>
             <l part="F">E se in ciò far servizio</l>
             <l part="I">Ti posso, mi commanda.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Ti ringrazio.</l>
           </sp>
-          <sp>
+          <sp who="#lippo">
             <speaker>LIPPO:</speaker>
             <l>E s'io sapessi il caso, e potessi  utile</l>
             <l>Farti o di fatti o di parole, avrestimi,</l>
             <l>Quanto altro amico abbi al mondo, prontissimo.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l>Se quando ero a Firenze, Lippo, amavoti</l>
             <l>Quanto me stesso, e s'ancor mai nasconderti</l>
@@ -565,7 +611,7 @@
             <l>Mia verso te; e ch'in te la mia fiducia</l>
             <l>Non sia in Cremona, quale era in la patria.</l>
           </sp>
-          <sp>
+          <sp who="#lippo">
             <speaker>LIPPO:</speaker>
             <l>Io ti ringrazio di queste amorevoli</l>
             <l>Parole e buona voluntà; e certissimo</l>
@@ -575,7 +621,7 @@
             <l>Sicuramente, che depositario</l>
             <l>Ti sarò in ogni parte fedelissimo.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l>Or odi. Ne la casa qui di Massimo</l>
             <l>Un costumato e gentil giovene Abita,</l>
@@ -596,13 +642,13 @@
             <l>Si chiama, all'uscio o alle finestre, accesesi</l>
             <l part="I">Oltra modo di lei.</l>
           </sp>
-          <sp>
+          <sp who="#lippo">
             <speaker>LIPPO:</speaker>
             <l part="F">Fatta debbe essere</l>
             <l>Bella, per quanto di lei far giudicio</l>
             <l part="I">Si potea da fanciulla.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Ha assai buon'aria.</l>
             <l>Odi pur. Cintio cominciò a principio</l>
@@ -639,20 +685,20 @@
             <l>Et in secreto ancor sin qui godutisi</l>
             <l>Sono, e successo il tutto era benissimo.</l>
           </sp>
-          <sp>
+          <sp who="#lippo">
             <speaker>LIPPO:</speaker>
             <l>Cotesto “era” mi spiace: or questo Cintio</l>
             <l>Si debbe esser mutato di proposito?</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l>Cotesto no: Lavinia ama egli al solito.</l>
           </sp>
-          <sp>
+          <sp who="#lippo">
             <speaker>LIPPO:</speaker>
             <l part="I">Che ci è dunque?</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Diròtelo. Non passano</l>
             <l>Tre mesi, che, nulla sappiendo Massimo</l>
@@ -668,33 +714,33 @@
             <l>Menar a casa, sì che dire il misero</l>
             <l>Non seppe una parola in contrario.</l>
           </sp>
-          <sp>
+          <sp who="#lippo">
             <speaker>LIPPO:</speaker>
             <l>Così Lavinia fia lasciata, e vedova</l>
             <l part="I">Sarà, vivendo il marito?</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Ne dubito:</l>
             <l>Pur tentiamo una. via, che succedendoci</l>
             <l>Si potria far che 'l nuovo sponsalizio</l>
             <l part="I">Non seguiria.</l>
           </sp>
-          <sp>
+          <sp who="#lippo">
             <speaker>LIPPO:</speaker>
             <l part="M">Che via?</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Non ha ancor Cintio</l>
             <l>Fatto alcun saggio di quest'altra femina.</l>
           </sp>
-          <sp>
+          <sp who="#lippo">
             <speaker>LIPPO:</speaker>
             <l>Cotesto non credo io, che gli è impossibile</l>
             <l>Ma che vi dia la ciancia ben vuo' credere.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l>Non mi dà ciancia, no: siane certissimo.</l>
             <l>Non ti sarebbe a crederlo difficile,</l>
@@ -712,12 +758,12 @@
             <l>Donar venti fiorini, se lo libera.</l>
             <l part="I">Vedi se ci dileggia o no</l>
           </sp>
-          <sp>
+          <sp who="#lippo">
             <speaker>LIPPO:</speaker>
             <l part="F">Che speri tu</l>
             <l>Che per tal fizïone abbia a succedere?</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l>Che poi che stato sia sei mesi, or mettila</l>
             <l>A un anno, Cintio in tanta continenzia,</l>
@@ -731,16 +777,16 @@
             <l>Parlasse, poi che d'impotente e debole</l>
             <l>Ha nome.</l>
           </sp>
-          <sp>
+          <sp who="#lippo">
             <speaker>LIPPO:</speaker>
             <l>                   È bel disegno, e può succedere,</l>
             <l>Pur che Cintio stia saldo in un proposito.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="I">Non temo che si muti.</l>
           </sp>
-          <sp>
+          <sp who="#lippo">
             <speaker>LIPPO:</speaker>
             <l part="F">S'egli séguita,</l>
             <l>Pel più fedel lo lodo e da ben giovine,</l>
@@ -749,12 +795,12 @@
             <l>A tutti i vostri desiderii! Possoti</l>
             <l part="I">Far cosa che ti piaccia?</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Che domestica–</l>
             <l part="I">mente alloggi qui meco.</l>
           </sp>
-          <sp>
+          <sp who="#lippo">
             <speaker>LIPPO:</speaker>
             <l part="F">Io ti ringrazio.</l>
             <l>Son con questi alloggiato da la Semola:</l>
@@ -762,17 +808,17 @@
             <l>Posso male; et a pena ho avuto spazio</l>
             <l>Di venirti a vedere; et or m'aspettano.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="I">Verrò a trovarti questa sera.</l>
           </sp>
-          <sp>
+          <sp who="#lippo">
             <speaker>LIPPO:</speaker>
             <l part="F">Lasciati</l>
             <l>Per tua fé spesso veder; e godiamoci</l>
             <l>Fin ch'io sto qui, più che ci sia possibile.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l>Così faremo. — Ecco Cintio con Temolo.</l>
             <l>Se tutti i servitori così fossero</l>
@@ -784,171 +830,171 @@
         <div type="scene" n="Scena III">
           <head>SCENA III</head>
           <stage>Cintio, Temolo, Fazio</stage>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l>Temolo, che ti par di questo astrologo</l>
             <l part="I">O negromante vogli dir?</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Lo giudico</l>
             <l part="I">Una volpaccia vecchia.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">Or ecco fazio.</l>
             <l>Io domandavo costui de l'Astrologo</l>
             <l part="I">Nostro quel che gli par.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Dico ch'io il giudico</l>
             <l part="I">Una volpaccia vecchia.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">Et a voi, Fazio,</l>
             <l part="I">Che ne par?</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Lo stimo uom di grande astuzia</l>
             <l part="I">E di molta dottrina.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">In che scïenzia</l>
             <l part="I">È egli dotto?</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">In l'arti che si chiamano</l>
             <l part="I">Liberali.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">Ma pur ne l'arte magica</l>
             <l>Credo che intenda ciò che si può intendere,</l>
             <l>E non ne sia per tutto il mondo un simile.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="I">Che ne sapete voi?</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">Cose mirabili</l>
             <l part="I">Di lui mi narra il suo garzone.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Fateci,</l>
             <l>Se Dio v'aiuti, udir questi miracoli.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l>Mi dice ch'a sua posta fa risplendere</l>
             <l part="I">La notte, e il dì oscurarsi.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Anch'io so simile–</l>
             <l part="I">mente cotesto far.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="M">Come?</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Se accendere</l>
             <l>Di notte anderò un lume, e di dì a chiudere</l>
             <l part="I">Le finestre.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">Deh, pecorone! dicoti</l>
             <l>Che estingue il sol per tutto il mondo, e splendida</l>
             <l part="I">Fa la notte per tutto.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Gli dovrebbeno</l>
             <l>Dar gli speciali dunque un buon salario.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="I">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Perché calare il prezzo e crescere,</l>
             <l>Quando gli paia, può alla cera e all'olio.</l>
             <l part="I">Or sa far altro?</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">Fa la terra muovere,</l>
             <l part="I">Sempre che 'l vuol.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Anch'io talvolta muovola:</l>
             <l>S'io metto al fuoco o ne levo la pentola;</l>
             <l>O quando cerco al buio se più gocciola</l>
             <l>Di vino è nel boccale, alor dimenola.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l>Te ne fai beffe, e ti par d'udir favole?</l>
             <l>Or che dirai di questo: che invisibile</l>
             <l part="I">Va a suo piacer?</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Invisibile? Avetelo</l>
             <l part="I">Voi mai, padron, veduto andarvi?</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">Oh, bestia!</l>
             <l>Come si può veder, se va invisibile?</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="I">Ch'altro sa far?</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">De le donne e de gli uomini</l>
             <l>Sa trasformar, sempre che vuole, in varii</l>
             <l>Animali e volatili e quadrupedi.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l>Si vede far tutto il dì, né miracolo</l>
             <l part="I">È cotesto.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="M">U' si vede far?</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Nel populo</l>
             <l part="I">Nostro.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">Non date udienza alle sue chiacchiere,</l>
             <l part="I">Che ci dileggia.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Io vo' saperlo: narraci</l>
             <l part="I">Pur come.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Non vedete voi, che sùbito</l>
             <l>Un divien podestade, commissario,</l>
@@ -957,43 +1003,43 @@
             <l>Che li costumi umani lascia, e prendeli</l>
             <l>O di lupo o di volpe o di alcun nibio?</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="I">Cotesto è vero.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">E tosto ch'un d'ignobile</l>
             <l>Grado vien consigliere o segretario,</l>
             <l>E che di commandar agli altri ha ufficio,</l>
             <l>Non è vero anco che diventa un asino?</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="I">Verissimo.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Di molti, che si mutano</l>
             <l part="I">In becco vuo' tacer.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">Cotesta, Temolo,</l>
             <l part="I">È una cattiva lingua.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Lingua pessima</l>
             <l>La vostra è pur, che favole mi recita</l>
             <l part="I">Per cose vere.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">Dunque, non vuoi credere</l>
             <l>Che costui faccia tali esperïenzie?</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l>Anzi, che di maggior ne faccia, credere</l>
             <l>Vi voglio, quando con parole semplici,</l>
@@ -1002,29 +1048,29 @@
             <l>Quando danari e quando roba. Or essere</l>
             <l>Potria prova di questa più mirabile?</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l>Tu cianci pur, né rispondi a proposito.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l>Parlate cose vere, o che si possino</l>
             <l>Credere almeno; e come è convenevole</l>
             <l part="I">Risponderòvi.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">Dimmi questo: credi tu</l>
             <l>Che costui gran maestro sia di magica?</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l>Ch'egli sia mago, et eccellente, possovi</l>
             <l>Credere; ma che farsi li miracoli,</l>
             <l>Che dite voi, si possino per magica,</l>
             <l part="I">Non crederò.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">La poca esperïenzia</l>
             <l>C'hai del mondo, n'è causa. Dimmi: credi tu</l>
@@ -1032,7 +1078,7 @@
             <l>Come scongiurar spirti, che rispondino</l>
             <l>Di molte cose che tu vogli intendere?</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l>Di questi spirti, a dirvi il ver, pochissimo</l>
             <l>Per me ne crederei; ma li grandi uomini,</l>
@@ -1040,18 +1086,18 @@
             <l>Fanno col loro esempio ch'io, vilissimo</l>
             <l part="I">Fante, vi credo ancora.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">Concedendomi</l>
             <l>Questo, mi puoi similmente concedere</l>
             <l>Ch'io sono il più infelice omo e il più misero</l>
             <l part="I">Ch'oggi si trovi al mondo.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Come? Séguita.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l>S'egli venisse a scongiurar li spiriti,</l>
             <l>Non saprebbe egli ch'io non sono debole,</l>
@@ -1062,57 +1108,57 @@
             <l>Et al mio vecchio insieme riferendolo,</l>
             <l part="I">A che termin sono io?</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">E' non è dubbio</l>
             <l part="I">Che saresti a mal termine.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">Anzi a pessimo.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l>Volete, Cintio, ch'io vi metta un ottimo</l>
             <l>Partito inanzi, sopra il qual fantastico</l>
             <l>Già molti giorni, e concludo ch'altro essere</l>
             <l>Non ci può, se non questo, salutifero?</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="I">Dite.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Mi par che costui sia molto avido</l>
             <l part="I">Di guadagnare assai.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">Son del medesimo</l>
             <l part="I">Parere anch'io. Che più?</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Dunque rendetevi</l>
             <l>Certo ch'egli più;tosto vorrà apprendersi</l>
             <l part="I">A quaranta, che a venti.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">L'ho certissimo.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l>Il vecchio gli ha promesso, se vi libera,</l>
             <l>Di donar venti scudi; e, credo, trattone</l>
             <l part="I">Le spese.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="M">Seguitate.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Or ritrovatelo,</l>
             <l>E tutto il desiderio vostro apriteli;</l>
@@ -1120,12 +1166,12 @@
             <l>Di quaranta ducati, e che facci opera</l>
             <l>Che si dissolva questo sponsalizio.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l>Ma da chi trovarò quaranta piccioli,</l>
             <l part="I">Non che fiorini, in tal tempo?</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Lasciatene</l>
             <l>A me la cura: s'io dovessi vendere</l>
@@ -1134,55 +1180,55 @@
             <l>La casa stessa, provederò sùbito</l>
             <l part="I">A tal bisogno.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">In questa cosa, Fazio,</l>
             <l>Et in ogni altra, sempremai rimettere</l>
             <l part="I">A voi mi voglio.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Che ne di' tu, Temolo?</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="I">Il medesmo che voi dite.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">Parendovi</l>
             <l part="I">Dunque così, gli parlarò.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Parlategli,</l>
             <l part="I">E tosto.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">Or ora, poiché senza avolgermi</l>
             <l>Per la terra a cercarlo, io l'ho qui commodo</l>
             <l part="I">In casa.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="M">Egli è qui in casa?</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="M">Sì.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Chiamatelo</l>
             <l>Da parte, o vi serrate ne la camera</l>
             <l part="I">Con lui.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="M">Così farò.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Ma ecco Massimo,</l>
             <l>Ch'a tempo vi dà luoco. Resti Temolo</l>
@@ -1193,15 +1239,15 @@
         <div type="scene" n="Scena IV">
           <head>SCENA IV</head>
           <stage>Massimo, Cintio</stage>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="I">Cintio.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="M">Messere.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="F">Odimi un poco: voglioti</l>
             <l>Pur dir quel che più volte ho auto in animo,</l>
@@ -1212,23 +1258,23 @@
             <l>Non mi par molto buona né lodevole:</l>
             <l>Mal si confanno insieme i vecchi e i gioveni.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l>Messer, cotesto parlare è contrario</l>
             <l>A quel che dir solete: che li gioveni,</l>
             <l>Praticando coi vecchi, sempre imparano.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l>Male imparar si può, dove il discepolo</l>
             <l part="I">Sa più del suo maestro.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">Gli è da credere;</l>
             <l part="I">Ma non v'intendo.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="F">Te l'ho dunque a lettere</l>
             <l>Di speciali a chiarir? Mal convenevole</l>
@@ -1250,7 +1296,7 @@
             <l>Lo scilinguagnolo, e dir che malissima,</l>
             <l>mente fai, più tenendo cotal pratica.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l>Non è per mal effetto s'io gli pratico</l>
             <l>In casa; e non è tra me e quella giovane</l>
@@ -1258,12 +1304,12 @@
             <l>Me ne sia Dio. Ma chi può le malediche</l>
             <l>Lingue frenar, che a lor modo non parlino?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l>Pur ciance! Che vi fai tu? Che commercio</l>
             <l part="I">Hai tu con lor?</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">Non altro che amicizia</l>
             <l>Onesta e buona. Ma in quali case essere</l>
@@ -1272,27 +1318,27 @@
             <l>Essendo o non essendovi i lor uomini)</l>
             <l part="I">A corteggiar?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="F">Né l'usanza è lodevole;</l>
             <l>Cotesto al tempo mio non era solito.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l>Doveano al vostro tempo avere i gioveni,</l>
             <l>Più che non hanno a questa età, malizia.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l>Non già; ma ben gli vecchi più accorti erano.</l>
             <l>Mi maraviglio che al presente gli uomini</l>
             <l>Non sieno a fatto grassi come tortore.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="I">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="F">Perc'hanno tutti sì buon stomaco.</l>
             <l>Torna in casa, e tien compagnia all'Astrologo;</l>
@@ -1313,7 +1359,7 @@
         <div type="scene" n="Scena I">
           <head>SCENA I</head>
           <stage>Nibbio</stage>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>Per certo, questa è pur gran confidenzia,</l>
             <l>Che mastro Iachelino ha in se medesimo,</l>
@@ -1357,40 +1403,40 @@
         <div type="scene" n="Scena II">
           <head>SCENA II</head>
           <stage>Astrologo, Nibbio</stage>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Provederò ben al tutto io: lasciatene</l>
             <l part="I">A me pur il pensier</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="F">Sì, sì, lasciatene</l>
             <l>La cura a lui: non vi potete abbattare</l>
             <l part="I">Meglio.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Oh, tu se', Nibbio, costì? Volevoti</l>
             <l part="I">A punto.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="F">Anzi vorreste in altro simile</l>
             <l>A quel che resta costà dentro, ch'utile</l>
             <l part="I">Poco avrete di me.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Vorrei de' simili</l>
             <l>Più tosto a questi, che meco fuor escono.</l>
             <l part="I">Ve' che non t'apponesti ?</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="F">Come diavolo</l>
             <l part="I">Faceste?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Dianzi me li diede Massimo,</l>
             <l>Che in certe medicine, che bisognano,</l>
@@ -1398,11 +1444,11 @@
             <l>Due buone paia di capponi, e siano...</l>
             <l>Tu intendi: fa' che di grassezza colino.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>Vi chiamarete servito benissimo.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Dua baccini d'argento, che non vagliono</l>
             <l>Men di cento cinquanta scudi, voglioti</l>
@@ -1410,12 +1456,12 @@
             <l>Vorrà uno scritto di mano, e in presenzia .</l>
             <l>Di qualche testimonio consegnarmeli</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>Fate a mio senno, padron: come avutili</l>
             <l>Avete, andiamo a Ferrara o a Vinegia.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Con sì poco bottin tu vuoi ch'io sgomberi?</l>
             <l>Credi tu ch'io non abbi più d'un traffico</l>
@@ -1425,12 +1471,12 @@
             <l>Così mille ducati, come a studiosi</l>
             <l>Andassi, ov'ha più fondo il mare, a spargerli.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>Ch'altro traffico, senza quel di Massimo,</l>
             <l part="I">Avete voi?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">N'ho con questo suo Cintio</l>
             <l>Un altro non minor; ma da cavarsene</l>
@@ -1443,13 +1489,13 @@
             <l>Camillo Pocosale, un certo giovene</l>
             <l part="I">Bianco, tutto galante.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="F">Pur conoscere</l>
             <l>Lo devrei;così spesso venir veggolo</l>
             <l part="I">Con voi.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Ma tu non sai c'ha una bellissima</l>
             <l>Quantitade d'argenti, che lasciatili</l>
@@ -1458,12 +1504,12 @@
             <l>Con lui, veder me li fe' tutti. Vagliono</l>
             <l>Settecento ducati, e credo passino.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>Non è già posta da lasciar: farebbono</l>
             <l part="I">Per noi.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Per noi faran, se mi riescono</l>
             <l>Alcuni bei disegni ch'io fantastico.</l>
@@ -1489,14 +1535,14 @@
             <l>E cinquanta fiorin donar promessemi,</l>
             <l>Se il parentado facevo disciogliere.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>Verso l'argenti cotesto è una favola:</l>
             <l>Ma né i cinquanta fiorini anco putono;</l>
             <l>E mi par che 'l beccarli vi fia facile;</l>
             <l>Che tosto che dichiate al padre o al suocero...</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Deh! insegnami pur altro che di mugnere</l>
             <l>Le borse, che gli è mio primo esercizio.</l>
@@ -1553,38 +1599,38 @@
             <l>Che del suo amore ella si strugge, e lettere</l>
             <l>Et ambasciate ho da sua parte fintomi .</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>Non m'avete più detto questa pratica.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>...E da sua parte ancora certi piccioli</l>
             <l>Doni arrecati gli ho, ch'egli ha gratissimi.</l>
             <l>Questa matina egli mi die' un bellissimo</l>
             <l part="I">Annelletto, ch'io dessi a lei</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="F">Terretelo</l>
             <l part="I">Per voi, o pur le lo darete?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Voglione</l>
             <l part="I">Il tuo consiglio.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="M">Per Dio, no.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Ma eccolo.</l>
             <l>Sta' pure all'erta, e fa' il grossieri, e mostrati</l>
             <l part="I">Di non aver le capre.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="F">Starò tacito.</l>
           </sp>
@@ -1592,12 +1638,12 @@
         <div type="scene" n="Scena III">
           <head>SCENA III</head>
           <stage>Astrologo, Camillo, Nibbio</stage>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Dove va questo inamorato giovene,</l>
             <l>Sopra tutti gli amanti felicissimo?</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l>Io vengo a ritrovare il potentissimo</l>
             <l>Di tutti i maghi, ad inchinarmi all'idolo</l>
@@ -1606,56 +1652,56 @@
             <l>Fortuna sète. Ah! ch'io non posso esprimere,</l>
             <l>Maestro, quant'ho verso voi buon animo.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>(Credo che tosto muterai proposito.)</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Queste parole meco non accadono</l>
             <l>In tutto quel ch'io son buono, servitevi</l>
             <l>Di me, che sempre m'avrete prontissimo.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l>Ben ne son certo; e ve n'ho eterna grazia</l>
             <l>Ma ditemi, che fa la mia carissima</l>
             <l part="I">E dolcissima mia?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Va' via tu, scostati</l>
             <l part="I">Da noi.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="F">(Ben vince costui tutti gli uomini</l>
             <l part="I">D'esser secreto. O buono aviso!)</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Simili</l>
             <l>Cose non sono mai da dir, che v'odano</l>
             <l>Li famigli, che tuttavia riportano</l>
             <l>Ciò che sanno. Io non ci avevo avvertenzia.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l>Ma che fa la mia bella e dolce Emilia?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Arde per vostro amor, tanto ch'io dubito</l>
             <l>Che s'io produco troppo in lungo a porvela</l>
             <l>In braccio, come nieve al sol vedremola,</l>
             <l>o come fa la cera al fuoco, struggere.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>(Ciò ch'egli dice è bugia; ma sapràgliela</l>
             <l>Sì bene ornar, che gliela farà credere.)</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l>Per non lasciarla dunque voi distruggere,</l>
             <l>E me morir poi di dolor, forniscasi</l>
@@ -1664,7 +1710,7 @@
             <l>Mai consumi con essa il matrimonio,</l>
             <l>Che 'l padre suo non negherà di darmela.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Mi fa ella ancor questi preghi medesimi.</l>
             <l>A voi che amate, e che lasciate reggervi</l>
@@ -1676,29 +1722,29 @@
             <l>Non gli abbia fatto ancor; non darò indizio,</l>
             <l>Anzi segno di fraude evidentissimo?</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l>Sempre al vostro parer mi vuo' rimettere.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>Come è soro e innocente questo giovene</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Almen voi sète più di lei placabile.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="I">Ella non fa così?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Così, eh? S'incollera,</l>
             <l>Non mi vuole ascoltar, e piange, e dicemi</l>
             <l>Ch'io meno in lungo questa trama a studio.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l>Io non dirò mai più che a voi possibile</l>
             <l>Non sia ogni cosa, poi che così accendere</l>
@@ -1707,65 +1753,65 @@
             <l>mente ho amato e servito, un segno minimo</l>
             <l>Non potetti aver mai d'esserli in grazia.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>(Quando lo battezzâr non doveva essere</l>
             <l>Sale al mondo, che non trovâr da porgliene</l>
             <l part="I">Un grano in bocca.)</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Ho ben meco una lettera</l>
             <l part="I">Ch'ella vi scrive.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">Che cessate darmela?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="I">La volete vedere?</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">Io ve ne supplico.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>(Questa esser de' la lettera, che scrivere</l>
             <l>Gli viddi dianzi; or gli darà ad intendere</l>
             <l>Che scritta di man sua gliel'abbia Emilia.)</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l>Di quelle man, più che di latte candide,</l>
             <l>Più che di nieve, è uscita questa lettera?</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>(Uscita è pur di man rognose e sucide</l>
             <l>Del mio padron: tentela cara, e baciala.)</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Prima da lo alabastro, o sia ligustico</l>
             <l>Marmo, del petto viene, ove fra picciole</l>
             <l>Et odorate due pome giacevasi.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l>Dal bel seno de la mia dolce Emilia</l>
             <l>Dunque vien questa carta felicissima?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Sua bella man quindi la trasse, e diemela.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>(Così t'avesse dato il latte mammata!)</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l>O bene aventurosa carta, o lettera</l>
             <l>Beata, quanto è la tua sorte prospera!</l>
@@ -1782,35 +1828,35 @@
             <l>Poi che degnata s'è la mia bellissima</l>
             <l>Padrona i suoi segreti in te descrivere!</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>(Sarà più lunga del salmo l'antifona.)</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l>Ma che tardo io d'aprirti, et in te leggere</l>
             <l>Quanto m'arrechi di gaudio e di iubilo,</l>
             <l part="I">Di ben, di gioia, di vita?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Fermatevi:</l>
             <l part="I">Fate a mio senno.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="M">Di che?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Andate a leggerla</l>
             <l part="I">A casa vostra.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="M">Perché non qui?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Dubito</l>
             <l>Che, avendo fatto a questa chiusa lettera</l>
@@ -1824,46 +1870,46 @@
             <l>Leviate un grido, che intorno accorrano</l>
             <l part="I">Tutti i vicini.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">Non farò: lasciatemi</l>
             <l part="I">Legger, maestro.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="M">Leggetela.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">Leggola</l>
             <l><hi rend="italic">Signor mio car</hi>...Non dovea questo titolo</l>
             <l part="I">Darmi, ch'io le son servo.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="M">Seguite.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">
               <hi rend="italic">Unica</hi>
             </l>
             <l><hi rend="italic">Speranza mia</hi>. O parola meliflua</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Anzi pur zucariflua, che ignobile</l>
             <l part="I">È il mel.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="M">Voi dite il ver.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="M">Seguite.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">
               <hi rend="italic">O anima</hi>
@@ -1873,12 +1919,12 @@
             <l><hi rend="italic">Per quanto ben mi volete</hi>... Fortissimo</l>
             <l part="I">Scongiur!</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="F">(Debbe esser materia difficile,</l>
             <l>Che vien di parte in parte comentandola.)</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l>
               <hi rend="italic">...E per l'amor, che grande e inestimabile</hi>
@@ -1905,15 +1951,15 @@
               <hi rend="italic">Può questa pruova. State sano e amatemi.</hi>
             </l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>(<foreign xml:lang="lat">Cuius figurae</foreign>? ben si può dir: <foreign xml:lang="lat">simplicis</foreign>.)</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="I">Sète vo' al fine?</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">Sì, ma che accadevano</l>
             <l>Preghi? Non è ella certa che, accennandomi,</l>
@@ -1921,18 +1967,18 @@
             <l>Il cuor, son per spararmi il petto, e darglielo</l>
             <l part="I">Che ho a far?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">È come vedete, lettera</l>
             <l>Credenzïale: oggi vi farò intendere</l>
             <l>Quel che da parte sua v'ho a dir. Lasciatevi</l>
             <l part="I">Riveder.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">Non è meglio ora spedirmene?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>La cosa importa, e non è da passarsene</l>
             <l>In tre parole o in quattro: differiamola</l>
@@ -1948,7 +1994,7 @@
         <div type="scene" n="scena IV">
           <head>SCENA IV</head>
           <stage>Madonna, Fantesca</stage>
-          <sp>
+          <sp who="#madonna">
             <speaker>MADONNA:</speaker>
             <l>Confortati, figliuola, che rimedio,</l>
             <l>Fuor ch'al morire, ad ogni cosa truovano</l>
@@ -1956,16 +2002,16 @@
             <l>Umana vita! a quanti strani e insoliti</l>
             <l>Casi è suggetto questo nostro vivere!</l>
           </sp>
-          <sp>
+          <sp who="#fantesca">
             <speaker>FANTESCA:</speaker>
             <l>In fé di Dio, che tôr non si dovrebbono</l>
             <l part="I">Se non a pruova li mariti.</l>
           </sp>
-          <sp>
+          <sp who="#madonna">
             <speaker>MADONNA:</speaker>
             <l part="F">Ah bestia!</l>
           </sp>
-          <sp>
+          <sp who="#fantesca">
             <speaker>FANTESCA:</speaker>
             <l>Che bestia? Io dico il ver. Mai non si compera</l>
             <l>Cosa, che prima ben non si consideri</l>
@@ -1975,11 +2021,11 @@
             <l>Per man tornate: et a barlume gli uomini</l>
             <l>Si torran poi, che tanto ci bisognano?</l>
           </sp>
-          <sp>
+          <sp who="#madonna">
             <speaker>MADONNA:</speaker>
             <l part="I">Credo che sii ubriaca.</l>
           </sp>
-          <sp>
+          <sp who="#fantesca">
             <speaker>FANTESCA:</speaker>
             <l part="F">Anzi, più sobria</l>
             <l>Unqua non fui. Io conobbi una savia,</l>
@@ -1990,11 +2036,11 @@
             <l>De la figliuola sua, ch'ella aveva unica,</l>
             <l part="I">Lo fe' marito.</l>
           </sp>
-          <sp>
+          <sp who="#madonna">
             <speaker>MADONNA:</speaker>
             <l part="F">Va', scrofa, e vergognati.</l>
           </sp>
-          <sp>
+          <sp who="#fantesca">
             <speaker>FANTESCA:</speaker>
             <l>Dunque mi debbio vergognare a dirve la</l>
             <l>Verità? S'anco voi la esperienzia</l>
@@ -2006,19 +2052,19 @@
             <l>Provedetevi. Ma prima provatelo:</l>
             <l part="I">Fate a mio senno</l>
           </sp>
-          <sp>
+          <sp who="#madonna">
             <speaker>MADONNA:</speaker>
             <l part="F">Uh, che consiglio, domine,</l>
             <l part="I">Mi dà costei!</l>
           </sp>
-          <sp>
+          <sp who="#fantesca">
             <speaker>FANTESCA:</speaker>
             <l part="F">Se non volete prendere</l>
             <l>Questo, ve ne do un altro: a me lasciatelo</l>
             <l>Provar; s'io il provo, saprò far giudicio</l>
             <l>Se se n'avrà da contentare Emilia.</l>
           </sp>
-          <sp>
+          <sp who="#madonna">
             <speaker>MADONNA:</speaker>
             <l>O brutta, disonesta e trista femina,</l>
             <l>Serra la bocca in tua malora, e seguimi.</l>
@@ -2030,7 +2076,7 @@
         <div type="scene" n="Scena I">
           <head>SCENA I</head>
           <stage>Astrologo, Cintio, Nibbio</stage>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Cintio, siate pur certo che narratomi</l>
             <l>Voi non avete cosa, che benissimo</l>
@@ -2044,7 +2090,7 @@
             <l>Vostri mi avete sempre favorevole</l>
             <l>Ritrovato, più tosto che contrario.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l>S'io da voi per adietro, non sapendolo</l>
             <l>Né ve ne richiedendo, ebbi alcuno utile,</l>
@@ -2060,7 +2106,7 @@
             <l>mente al mio vecchio et agli altri rispondere</l>
             <l>Che l'impotenzia mia non è curabile.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>S'al vecchio e agli altri io volessi rispondere</l>
             <l>Che l'impotenzia non fosse curabile,</l>
@@ -2077,46 +2123,46 @@
             <l>Levar costei di casa vostra, e andarsene</l>
             <l part="I">Là donde venne.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">Se 'l vi piace, ditela.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Non vuo' che costui m'oda. — Va' tu, scostati,</l>
             <l>Dacci un po' luoco: non volere intendere</l>
             <l part="I">Sempre ciò che si dice.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="F">(Come dettomi</l>
             <l>Non abbia il suo disegno, e ciò c'ha in animo</l>
             <l part="I">Di far!)</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Non son da dir cose che importano</l>
             <l part="I">Alla presenzia de' famigli.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="F">(Un simile</l>
             <l>Secretario non ha il mondo. Se i principi</l>
             <l>Lo conoscesson com'io, lo vorrebbeno:</l>
             <l part="I">Per impiccarlo dico.)</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Ora a proposito</l>
             <l>Nostro, io vuo' far che costei vi sia sùbito</l>
             <l part="I">Tolta di casa.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">Se 'l vi piace, ditemi</l>
             <l part="I">Il modo.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Prima ch'io vel dica, voglio mi</l>
             <l>Promettiate di non parlarne ad anima</l>
@@ -2128,12 +2174,12 @@
             <l>E se, senza saperlo voi, far l'opera</l>
             <l>Potessi, io la farei di miglior animo.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l>S'io v'obligo la fede di star tacito,</l>
             <l part="I">Temete ch'io non ve la servi?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Credovi</l>
             <l>Ch'abbiate or questa intenzïon; ma sùbito</l>
@@ -2142,52 +2188,52 @@
             <l>Direte; e tutto un dì non è possibile</l>
             <l>Che cosa occulta stia, che sappia femina.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l>Né con lei, né con altri son per muovere</l>
             <l part="I">Parola.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="M">E così promettete?</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">V'obligo</l>
             <l part="I">La fede mia.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Vel dirò dunque: uditemi.</l>
             <l>Io voglio far che ritroviate un giovene</l>
             <l>Questa notte nel letto con Emilia.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="I">Che avete detto?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Che troviate un giovene</l>
             <l>Questa notte nel letto con Emilia.</l>
             <l part="I">Non m'intendete?</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">Forse me medesimo</l>
             <l part="I">Ci trovarò.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Dicovi un altro giovene,</l>
             <l>Che le darà di quello in abondanzia</l>
             <l part="I">Che le negate voi.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">Dunque ella è adultera?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Cotesto no, ma casta e pudicissima;</l>
             <l>Ma sarà tosto giudicata adultera</l>
@@ -2197,12 +2243,12 @@
             <l>So non la terrà in casa, e vorrà sùbito</l>
             <l part="I">Che torni a casa il padre.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">Ah, sarà scandolo</l>
             <l>Et infamia perpetua de la giovane!</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>E che noia vi dà, pur che la lievino</l>
             <l>Di casa vostra, e che mai più non abbino</l>
@@ -2214,7 +2260,7 @@
             <l>Né si può dir che colui falli, ch'imita</l>
             <l part="I">La maggior parte.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">Fate voi: guidatemi</l>
             <l>Come vi par. Gli è ver, se gli è possibile</l>
@@ -2222,25 +2268,25 @@
             <l>E tanto disonor di questa giovane,</l>
             <l>Io ci verrò di molto miglior animo;</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Verrete solo a trovarmi alla Camera...</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="I">(Se vi vai, te la attacca.)</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">...che per ordine</l>
             <l>Vi mostrarò che non ci fia lo scandolo,</l>
             <l>Né il disonor, che vi date ad intendere.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>(Il mio patron ara col bue e con l'asino.)</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Sollecitate voi pur questo suocero</l>
             <l>Vostro, che questa sera i danar siano</l>
@@ -2250,17 +2296,17 @@
             <l>Di questa notte, a far che tutto séguiti</l>
             <l part="I">Ciò ch'io prometto.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="M">lo vo a trovarlo.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Siavi</l>
             <l>A mente, che fra noi le cose stiano</l>
             <l part="I">Secrete.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">Saran più che secretissime.</l>
           </sp>
@@ -2268,7 +2314,7 @@
         <div type="scene" n="Scena II">
           <head>SCENA II</head>
           <stage>Astrologo, Nibbio</stage>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Poich'io truovo Fortuna tanto prospera</l>
             <l>A tutti i miei disegni, egli è impossibile</l>
@@ -2291,31 +2337,31 @@
             <l>In una cosa: or bisogna servirmene</l>
             <l>In un'altra più degna e più proficua.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>De le tre starne che in piè avete, ditemi,</l>
             <l part="I">Qual mangiarete?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Vedra'mi ir beccandole</l>
             <l>Ad una ad una, et attaccarmi in ultimo</l>
             <l>Alla più grassa, e tutta divorarmela.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>Eccoven'una, e la miglior: mettetevi,</l>
             <l>Se avete fame, a piacer vostro a tavola.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="I">Chi è, Camillo?</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="M">Sì.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Sì ben mangiarmelo</l>
             <l>Voglio, che l'ossa non credo ci restino.</l>
@@ -2324,18 +2370,18 @@
         <div type="scene" n="Scena III">
           <head>SCENA III</head>
           <stage>Camillo, Astrologo, Nibbio</stage>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="I">lo son tornato.</l>
             <l>ASTROLOGO:</l>
             <l part="M">Io il veggo.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">Ora chiaritemi</l>
             <l part="I">Che vuol da me la mia padrona.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Vuolevi</l>
             <l>Seco nel letto questa notte, e stringervi</l>
@@ -2343,25 +2389,25 @@
             <l>Volte baciarvi, e del resto rimettersi</l>
             <l part="I">Alla discrezïon vostra.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">Deh, ditemi</l>
             <l>Quel ch'ella vuol, ch'io non ho sì propizie</l>
             <l>Le stelle, che sì tosto debba giungere</l>
             <l part="I">A tanto bene.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">lo dico il vero, e credere</l>
             <l>Non mi volete? Vuol che ne la camera</l>
             <l part="I">Con lei vi ponga questa notte.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">E Cintio</l>
             <l part="I">Dove sarà?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Vuo' ch'al mio albergo Cintio</l>
             <l>Alloggi questa notte, sotto specie</l>
@@ -2369,21 +2415,21 @@
             <l>Debbian essere a questa sua impotenzia.</l>
             <l part="I">Or che pensate?</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">Penso che difficile</l>
             <l>Cosa mi pare e di molto pericolo.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="I">Pericolo eh?</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">Sì come avessi a scendere</l>
             <l>Nel lago de' leon di Babilonia.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>E mi soggiunse poi, che ritraendovi</l>
             <l>Voi d'ire a lei, vuole ella a voi venirsene</l>
@@ -2394,26 +2440,26 @@
             <l>Vuol dal marito stanotte, e venirsene</l>
             <l part="I">A ritrovarvi a casa.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">Ah no, levatela</l>
             <l>Di tal pensier, che fôra il maggior scandolo,</l>
             <l>maggior scorno, il maggior vituperio,</l>
             <l>Ch'al mondo accader mai potesse a femina.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Pensate pur c'ho usato la retorica,</l>
             <l>Né ci seppi trovar altro rimedio,</l>
             <l>Che di darle la fede mia di mettervi</l>
             <l part="I">Questa notte con lei.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">Voi consigliatemi</l>
             <l part="I">D'andarvi?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Senza dubbio; perché andandovi,</l>
             <l>La potrete dispor che dieci o dodici</l>
@@ -2422,27 +2468,27 @@
             <l>E de' parenti e d'amici, legitima</l>
             <l>mente e con onor possa a voi venirsene.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>(Vi par che 'l ciurmator saprà attaccargliela?)</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l>E come potrebbe essere, che andandovi</l>
             <l part="I">lo non pericolassi?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Non ne dubito,</l>
             <l>Qual volta voi n'andaste non sappiendolo</l>
             <l>Io; ma con mia saputa, sicurissimo</l>
             <l>Come vo' andaste in casa vostra propria.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="I">Come v'andro?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Son cento modi facili</l>
             <l>Da mandarvi sicur. Vi farò prendere</l>
@@ -2450,17 +2496,17 @@
             <l>O di gatto. Or che direste, vedendovi</l>
             <l>Trasformare in un topo, che è si piccolo?</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l>Forse anco in pulce o in ragno cangiarestemi?</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>(Io mi vuo' discostar, per non intendere</l>
             <l>Questi ragionamenti, che impossibile</l>
             <l>Mi saria udirli, e non scoppiar di ridere.)</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Cangiar vi posso in quante varie spezie</l>
             <l>Son d'animali, e farvi indi rassumere</l>
@@ -2470,11 +2516,11 @@
             <l>Qualche mazzata, e nel tempo più commodo</l>
             <l>Voi sareste cacciato de la camera.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l>Dunque, fia meglio mandarme invisibile?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Invisibil per certo, ma dissimile–</l>
             <l>mente da quel che pensate. Volendovi</l>
@@ -2492,12 +2538,12 @@
             <l>Che sa il tutto. Ella poi ne verrà tacita–</l>
             <l part="I">mente, e trarràvi de la cassa.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">Intendovi;</l>
             <l>Ma mi par che ci sia molto pericolo.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Volevate testé, solo accennandovi</l>
             <l>Lei, cacciarvi nel fuoco, e il petto fendervi:</l>
@@ -2505,31 +2551,31 @@
             <l>Cosa, e con piacer vostro, e state attonito?</l>
             <l>E vi par che ci sia tanto pericolo?</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="I">Di lei, non di me temo.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Ah diffidenzia!</l>
             <l>Dove son io, potete voi, sentendomi</l>
             <l>Ch'io vi sia presso, temer di pericolo?</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l>Non potreste altramente che chiudendomi</l>
             <l part="I">In una cassa, con lei por?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Facillima–</l>
             <l>mente; ma non già s'io non ho più spazio.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l>Dunque tre giorni o quattro differiscasi.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Io per me diferir son contentissimo</l>
             <l>Sei giorni, o dieci, o un anno, pur che Emilia</l>
@@ -2540,32 +2586,32 @@
             <l>In che si truova. Ogni modo, aspettatela</l>
             <l part="I">Stanotte.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">Prima che patirlo, vogliomi</l>
             <l>Non solo in una cassa, ma rinchiudermi</l>
             <l>Ne la fornace ove il vetro si liquida.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Non dubitate. Ditemi, la camera</l>
             <l part="I">Vostra guarda a levante?</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="M">Sì fa.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">È ottima</l>
             <l>Pel mio bisogno. Stanotte serrarmivi</l>
             <l part="I">Dentro voglio...</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="M">A che effetto?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">...né mai chiudere</l>
             <l>Gli occhi, ma dir orazïoni, e leggere</l>
@@ -2573,18 +2619,18 @@
             <l>Da far che tutti qui in casa di Massimo,</l>
             <l>Insino ai topi, eccetto Emilia, dormano.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l>Come potete star ne la mia camera</l>
             <l>Questa notte, volendo tener Cintio</l>
             <l part="I">Alla vostra con voi?</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="F">(Abbia memoria</l>
             <l part="I">Chi bugiardo esser vuol.)</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Così non dormeno</l>
             <l>I ghiri, come vuo' che dorma Cintio</l>
@@ -2594,32 +2640,32 @@
             <l>Come voi proprio, che voglio che veglino</l>
             <l>Meco e, secondo dirò lor, m'aiutino.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="I">Così farò.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Ma non abbiàn da perdere</l>
             <l>Tempo. Trovate una cassa, che commoda–</l>
             <l>mente capir voi possa, e aspettatemi</l>
             <l part="I">In casa.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="M">Volete altro?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="M">Non altro.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="F">Eccovi</l>
             <l>Che, levata una vivanda di tavola,</l>
             <l part="I">L'altra ne vien.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Venga pur, c'ho buon stomaco</l>
             <l>Da mangiarmela. Or pon da bere e ascoltami.</l>
@@ -2628,23 +2674,23 @@
         <div type="scene" n="Scena IV">
           <head>SCENA IV</head>
           <stage>Massimo, Astrologo, Nibbio</stage>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l>O mastro, a tempo vi veggo: venivovi</l>
             <l part="I">A punto a ritrovar.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Et io voi simile–</l>
             <l part="I">mente volevo.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="F">Io venia a farvi intendere</l>
             <l>C'ho ritrovato un baccino assai simile</l>
             <l>Al mio, e son quasi d'un peso medesimo.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Mi piace: or che son due, potrò far l'opera</l>
             <l>Utile e fruttuosa. Ma ascoltatemi:</l>
@@ -2652,11 +2698,11 @@
             <l>Vuo' cosa, che pochi altri maghi o astrologhi</l>
             <l>Vorrebbon fare o, volendo, saprebbeno.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="I">Che cosa?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Vuo' veder, prima che a crescere</l>
             <l>Più cominci la spesa, se sanabile</l>
@@ -2665,7 +2711,7 @@
             <l><foreign xml:lang="lat">Nolo</foreign>), più onor a me, e a voi più utile</l>
             <l>Saria, se chiaro vel facessi intendere.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l>So che non fia incurabile: mettetevi</l>
             <l>Pur alla cura sua con sicuro animo.</l>
@@ -2673,36 +2719,36 @@
             <l>Gli ha fatto per invidia, che disciogliere</l>
             <l part="I">Facil vi fia.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Così credo debb'essere;</l>
             <l>Ma potria questa ancora esser stata opera</l>
             <l>D'alcuno incantator sì dotto e pratico,</l>
             <l>Che la cura saria lunga o impossibile.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l>Non vuo' creder che sia di questa pessima</l>
             <l part="I">Sorte.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="M">E se fusse?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="F">Se fusse, pazienzia!</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Se fusse, non saria meglio a conoscerlo,</l>
             <l>Prima che più le spese augumentassino?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="I">Si</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">    Vo' per questo porre in un cadavere</l>
             <l>Uno spirto, che con intelligibile</l>
@@ -2712,20 +2758,20 @@
             <l>Or dove potren noi trovare un camice</l>
             <l>Nuovo, che mai non sia più stato in opera?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="I">Non so.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Con ventidua braccia farebbesi</l>
             <l>Di tela, ma sottile e candidissima.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>(Di camicie ha bisogno, e non di camice.)</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Bisogna far la stola e dua manipuli</l>
             <l>Di drappo nero, e porne a piè del camice</l>
@@ -2734,43 +2780,43 @@
             <l>Quando alle feste solenne s'apparano</l>
             <l>Con quattro braccia il tutto fornirebbesi.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>(Sì, d'un capestro: il suo farsetto è logro; ne</l>
             <l part="I">Vorrebbe un nuovo.)</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Ah! quasi che 'l pentacolo</l>
             <l part="I">M'ero scordato.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="F">Ho in casa de le pentole</l>
             <l part="I">Assai.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Pentole non, dico pentacoli.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>Per far nascer le calze il terren semina.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="I">Vedren di torne in presto.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Non si prestano</l>
             <l part="I">Tal cose.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="M">E come faren dunque?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Pensoci:</l>
             <l>Me sovien che a questi giorni un monaco</l>
@@ -2780,24 +2826,24 @@
             <l>Per men di sei fiorini, ma per dodici</l>
             <l>Lire di queste vostre avria lasciatolo.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>(Di qui farà non sol le calze nascere,</l>
             <l>Ma la berretta, e sin alle pantofole.)</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l>Tanto cotesti pennacchi si vendono?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Io non dico pennacchi, ma pentacoli.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l>C'ho a far del nome? lo miro a quel che costano.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>S'io posso far che ve lo dia per undici</l>
             <l>Lire e mezza, a chiusi occhi comperatelo,</l>
@@ -2808,19 +2854,19 @@
             <l>Per consacrarli a tempo, sì che possino</l>
             <l part="I">Fare il bisogno.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="M">I baccin sono in ordine.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>(Altro che calze e giubbon n'ha a riescere!)</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="I">Ho da proveder altro?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Ci bisognano</l>
             <l>Dua torchi, assai candele, et erbe varie,</l>
@@ -2829,39 +2875,39 @@
             <l>Carlini. O Fate voi ch'oggi si comprino,</l>
             <l>O a me ne date li danari e il carico.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>(La mignatta è alla pelle, né levarsene</l>
             <l>Vorrà, fin che di sangue vi sia gocciola.)</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l>Andate intanto a veder voi se il monaco</l>
             <l part="I">Ha più quel suo spantacchio.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">No, pentacolo.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l>Tant'è: saldate il prezzo, che poi Cintio</l>
             <l>Mandarò a voi con li danari, sùbito</l>
             <l>Che torni a casa, perché tutte comperi</l>
             <l>Con essovoi le cose che bisognano.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Fate che venga tosto, che far vogliovi</l>
             <l>Udir con le vostre orecchie uno spirito</l>
             <l>Con favella chiarissima rispondere,</l>
             <l>Che cosa vi parrà bella e mirabile.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="I">lo n'avrò gran piacer.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Voglio il cadavere</l>
             <l>Mandarvi in una cassa; ma non sappino</l>
@@ -2873,11 +2919,11 @@
             <l>Domatina, fornito che sia il camice,</l>
             <l>Verrò ne l'alba a scongiurar li spiriti.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="I">Come vi pare.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Ma abbiate avvertenzia,</l>
             <l>E li vostri di casa si avvertischino</l>
@@ -2888,65 +2934,65 @@
             <l>Ardì toccare una mia cassa simile:</l>
             <l part="I">Costui vi dica che gli avenne.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="F">Dicalo.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>Immantinente si vide tutto ardere.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Et arse in guisa, che non pur la cenere</l>
             <l part="I">Ne restò.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="F">Ma quegli altri che vi vòlsero,</l>
             <l>Per trovar s'avevàn roba da dazio,</l>
             <l part="I">Guardar ne le valigie?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Deh! raccontali</l>
             <l part="I">Che avenne lor.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="F">In rane trasformaronsi,</l>
             <l>E tuttavia alla porta dietro gracchiano</l>
             <l>Ai forastier, che inanzi e indietro passano.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="I">E dove fu cotesto?</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="F">In Andrinopoli</l>
             <l>Voi trovareste in Vinegia un par d'uomini</l>
             <l>Che san la cosa a punto, e così in Genova.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l>Come vorrei volentier che vi desseno</l>
             <l>Questi nostri un dì noia, per vederveli</l>
             <l>Castigare. Io non credo che ne siano</l>
             <l part="I">De' più molesti al mondo.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="F">Conciariali</l>
             <l>Così ben per un tratto, che in perpetuo</l>
             <l>Per lor Cremona avria di lui memoria.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l>Oh, come fate bene ad avvertirmene!</l>
             <l>Chi toccasse la cassa non sappiendolo?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Il toccarla, o sapendo o non sapendolo,</l>
             <l>Nïente può giovare, e molto nuocere:</l>
@@ -2954,14 +3000,14 @@
             <l>Non solo sé, ma voi, con quanti fossino</l>
             <l>In casa vostra, porria in gran pericolo.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l>Oh, saria molto audace e temerario</l>
             <l>Chi ardisse aprirla, o la toccasse a studio!</l>
             <l>Ma ben noto farò questo pericolo</l>
             <l part="I">A tutti i miei di casa.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Mandaròvela</l>
             <l>Per questo mio. Voi, come ho detto, fatela</l>
@@ -2969,26 +3015,26 @@
             <l>A canto il letto, e fate poi la camera</l>
             <l part="I">Serrar.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="F">Non mancherò di diligenzia.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="I">Io vo a farla arrecar.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="F">Io a farlo intendere</l>
             <l>Or ora a tutti i miei, che non facessino,</l>
             <l>Per non saperlo a tempo, qualche scandolo.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>Cotesta è una gran tresca; che n'ha a essere</l>
             <l part="I">Al fin?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Tosar vuo' ad una ad una e mungere</l>
             <l>Quelle pecore c'hanno, chi il vello aureo,</l>
@@ -3017,12 +3063,12 @@
             <l>De la nostra levata a prima accorgersi,</l>
             <l part="I">Che a Francolin saremo.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="F">C'ha a succedere</l>
             <l part="I">Poi di Camillo?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Io lo dono al gran diavolo:</l>
             <l>Egli sarà ritrovato certissima,</l>
@@ -3036,7 +3082,7 @@
             <l>Ma andiamo a ritrovarlo et a richiuderlo</l>
             <l part="I">Ne la cassa.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="F">Andate oltre, ch'io vi séguito.</l>
             <l>(Mio padrone è ben giotto, e pien d'astuzia;</l>
@@ -3054,7 +3100,7 @@
         <div type="scene" n="Scena V">
           <head>SCENA V</head>
           <stage>Fazio</stage>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l>Temo ch'avrò mal consigliato Cintio,</l>
             <l>A farli i suoi pensier dire allo Astrologo.</l>
@@ -3086,7 +3132,7 @@
         <div type="scene" n="Scena I">
           <head>SCENA I</head>
           <stage>Fazio, Temolo</stage>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l>(Sta' pur sicura, ch'io non son per dargliene</l>
             <l>Un soldo, prima ch'io non vegga l'opera</l>
@@ -3095,21 +3141,21 @@
             <l>Sia una volpaccia d'inganni e d'astuzia</l>
             <l part="I">Piena.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Non volevate dianzi credermi.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l>E temo ch'avren dato a Cintio un pessimo</l>
             <l>Consiglio, a farli dir quel ch'al martorio,</l>
             <l>S'avevamo cervel, dir non dovevasi.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="I">Che c'è di nuovo?</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Ci è, che assai mi dubito</l>
             <l>Che, poi che sa come le cose passano,</l>
@@ -3134,7 +3180,7 @@
             <l>Ce la attacchi, e che già qualche principio</l>
             <l>Dato abbia, e mezzo guasto sì buon animo.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l>Ho io ancor questo timor medesimo</l>
             <l>Per altri segni; e tra gli altri, che il perfido</l>
@@ -3145,57 +3191,57 @@
             <l>Ch'avrà forza di far che insieme s'amino,</l>
             <l>Se ben fusse tra lor capital odio.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="I">Quando disse mandarla?</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Maravigliomi?</l>
             <l>Che non sia qui. Disse mandarla sùbito</l>
             <l part="I">Che fusse a casa.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Egli n'ha senza dubbio</l>
             <l part="I">Ingannati. Ah ribaldo!</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Ribaldissimo!</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l>Ma altrotanto noi sciocchi, ch'aperto la</l>
             <l>Strada gli abbiamo, ove or ne viene a nuocere;</l>
             <l>La qual non era per trovar, s'avessimo</l>
             <l part="I">Me' saputo tacer.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Or, non avendola</l>
             <l part="I">Taciuta, che faremo?</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Trovar Cintio</l>
             <l>Bisogna, et avvertirlone; che diavolo</l>
             <l part="I">So io? Ma dimmi: è in casa?</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="M">No.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Saprestimi</l>
             <l part="I">Insegnar ove sia?</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="M">No.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Pur trovarnelo</l>
             <l>Bisogna, e far ch'egli venga Lavinia</l>
@@ -3206,27 +3252,27 @@
             <l>Non facesse, per arte dïabolica,</l>
             <l>Raffreddar verso lei l'amor di Cintio.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l>Ah tu facesti mal! Ritorna, e lievale</l>
             <l>Questo timor, che non ci è quel pericolo</l>
             <l part="I">Che le hai dipinto.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Ci bisogna altr'opera</l>
             <l>Che la mia! Fin ch'ella non vegga Cintio,</l>
             <l part="I">Non è per confortarsi.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Dunque truovalo.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="I">Anderò in piazza.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Va', sarebbe facile</l>
             <l>Che tu 'l trovassi... Tu non odi? Ascoltami.</l>
@@ -3235,66 +3281,66 @@
             <l>Che forse gli è con lui. Ma dove torni tu</l>
             <l part="I">Con tanta fretta?</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Ah! che la cassa arrecano</l>
             <l part="I">C'hai detto.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="M">Ov'è?</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Vien ov'io sono, e vedila.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="I">Chi la porta?</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="M">Un facchin.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="M">Solo?</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Accompagnala</l>
             <l part="I">Pur quel suo servitore.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Ecci lo Astrologo?</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="I">L'Astrologo non ci è.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="M">Non ci è?</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Non, dicoti.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="I">Lascia far dunque a me.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="M">Che vuoi far?</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Eccola:</l>
             <l>Avvertisci a rispondermi a proposito.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l>Che di' tu? Ma con chi parl'io? Ove diavolo</l>
             <l>Corre costui? Perché da me sì sùbito</l>
@@ -3304,61 +3350,61 @@
         <div type="scene" n="Scena II">
           <head>SCENA II</head>
           <stage>Temolo, Fazio, Nibbio, Facchino</stage>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="I">O terra scelerata!</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Di che diavolo</l>
             <l part="I">Grida costui?</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Non ci si può più vivere:</l>
             <l part="I">Tutt'è piena di traditor...</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Che gridi tu?</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="I">...E d'assassini.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="M">Chi t'ha offeso?</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">O povero</l>
             <l part="I">Gentiluomo!</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="M">Mi par che tu sia...</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">O Fazio,</l>
             <l part="I">Gran pietà!</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="M">Che pietade?</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Oh caso orribile!</l>
             <l>Non m'ho potuto ritener di piangere</l>
             <l part="I">Di compassione.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="M">Di che?</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Ahimè! d'un povero</l>
             <l>Forestier, c'ho veduto or ora uccidere</l>
@@ -3366,30 +3412,30 @@
             <l>Ha un traditor sul capo, che nel volgere</l>
             <l part="I">Del canto lo attendea.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">C'hai tu a curartene?</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l>Io gli avea posto amor, perché dimestico</l>
             <l>Era di casa nostra. Conoscevilo</l>
             <l part="I">Tu?</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Che so io, se prima non lo nomini?</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l>E io non so se sia spagnuolo o astrologo</l>
             <l>O negromante: lo chiaman lo Astrologo.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>Misero me! Che di' tu de l'Astrologo?</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l>Oh, non t'aveva visto ancor: non eri tu</l>
             <l>Suo servitor? Il tuo patrone pessima–</l>
@@ -3397,21 +3443,21 @@
             <l>Abbia un ribaldo, il qual l'attendea al svolgere</l>
             <l part="I">Del canto.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="M">Ahimè!</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Dietro il capo gravissimo</l>
             <l part="I">È il colpo: ognun v'accorre.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="F">Ah! per Dio, insegnami</l>
             <l part="I">Dov'egli è.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Va' diritto fino al svolgere</l>
             <l>Di questo canto; indi a man manca piegati</l>
@@ -3422,56 +3468,56 @@
             <l>Errar. Va' dietro agli altri: grand e piccoli</l>
             <l part="I">V'accorron tutti.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="M">O Dio!</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Non posso credere</l>
             <l part="I">Che 'l truovi vivo.</l>
           </sp>
-          <sp>
+          <sp who="#facchino">
             <speaker>FACCHINO:</speaker>
             <l part="F">E dove ho io a mettere</l>
             <l part="I">La cassa?</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="F">O mastro Iachelino misero,</l>
             <l part="I">Ben te lo predicevo io!</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Che farnetichi?</l>
             <l>Dove, in sì poco tempo che levato mi</l>
             <l>Sei da lato, hai sognato queste favole?</l>
           </sp>
-          <sp>
+          <sp who="#facchino">
             <speaker>FACCHINO:</speaker>
             <l>Vada a sua posta: non gli vuo' già correre</l>
             <l>Dietro. Almeno sapess'io dov'ho a mettere...</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l>Tu l'hai da por qua dentro: va', ti scarica</l>
             <l>Dove costui ti dirà. Voi mostrateli</l>
             <l>Dove il padron ci disse, ne la camera</l>
             <l>Di sopra, a canto il letto di Lavinia.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="I">Di Lavinia?</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Dovreste pur intendere.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="I">T'ho inteso.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Poi pagatelo, e mandatelo</l>
             <l>Via, ch'io non vuo' cessar ch'io truovi Cintio.</l>
@@ -3480,44 +3526,44 @@
         <div type="scene" n="Scena III">
           <head>SCENA III</head>
           <stage>Cintio, Temolo, Fazio, Facchino</stage>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l>Io truovo finalmente che rimedio</l>
             <l>Altro non ci è, che far che paia adultera</l>
             <l part="I">Costei.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="M">(Eccol, per Dio!)</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">Darmi ad intendere</l>
             <l>Vuol pur, che potrà quindi acquetar facile–</l>
             <l>mente la cosa, e non ci sarà infamia</l>
             <l part="I">Alcuna.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Credo v'andate a nascondere,</l>
             <l>Quando a maggior bisogni vi vorressimo.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="I">Che bisogni son questi?</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Se Lavinia</l>
             <l>Non ite tosto a consolare, ho dubbio</l>
             <l part="I">Che morta poi la ritroviate.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">Ah! Temolo,</l>
             <l part="I">Che li è accaduto?</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">È in tal timor la misera,</l>
             <l>Che questo negromante con malefica</l>
@@ -3525,80 +3571,80 @@
             <l>Che si strugge, e uno svenimento d'animo</l>
             <l part="I">Gli è venuto...</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="M">Non tema.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">...e sta malissimo.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="I">Io vo a lei.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="M">Per vostra fé.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">V'ha, Cintio,</l>
             <l part="I">Detto costui come Lavinia...?</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">Or eccomi,</l>
             <l part="I">Ch'io vengo per cotesto.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Confortatela.</l>
             <l>Non avresti potuto pensar, Temolo,</l>
             <l part="I">Meglio.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Pagate il facchino, e mandatelo</l>
             <l>Pur via, e mandatel ben lontano, e sùbito.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l>Ve', questo è un grosso: fammi anco un servizio.</l>
           </sp>
-          <sp>
+          <sp who="#facchino">
             <speaker>FACCHINO:</speaker>
             <l part="I">Lo farò.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Va' alle Grazie, e di' al Vicario</l>
             <l>Ch'io mando a tôr da lui quelli raponzoli,</l>
             <l part="I">Di che ier gli parlai.</l>
           </sp>
-          <sp>
+          <sp who="#facchino">
             <speaker>FACCHINO:</speaker>
             <l part="F">Credo ci sieno</l>
             <l part="I">Più di dua miglia.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">E sian: vuoi, se non, essere</l>
             <l part="I">Pagato?</l>
           </sp>
-          <sp>
+          <sp who="#facchino">
             <speaker>FACCHINO:</speaker>
             <l part="F">Da cui parte li ho io a chiedere?</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l>Da parte di Bertel che fa le maschere.</l>
           </sp>
-          <sp>
+          <sp who="#facchino">
             <speaker>FACCHINO:</speaker>
             <l part="I">Io vo.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Va' sì lontan, che non ci capiti</l>
             <l>Mai più inanzi. Or vedrai che, se far utile</l>
@@ -3607,16 +3653,16 @@
             <l>Noi faren farlo alla nostra Lavinia,</l>
             <l>Non come avea disegnato lo Astrologo.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l>Voi dite il ver; ma meglio ancora vogliovi</l>
             <l part="I">Insegnar.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="M">Di'.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Venite su, e rompiamola</l>
             <l>In pezzi, o in fondo a un cesso sotterriamola,</l>
@@ -3628,13 +3674,13 @@
             <l>Aprir lor li usci, e lasciar che la cerchino</l>
             <l part="I">Per tutto.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Noi ci porremo a pericolo</l>
             <l>Di ruinar la casa, che certissimo</l>
             <l>Sono che tutta sia piena di spiriti.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l>Voi date fede a tali sciocchezze? O semplice</l>
             <l>Uomo! Sopra me sia tutto il pericolo.</l>
@@ -3650,7 +3696,7 @@
         <div type="scene" n="Scena IV">
           <head>SCENA IV</head>
           <stage>Nibbio, Fazio</stage>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>(Che uomin oggi al mondo si ritruovano,</l>
             <l>Che si dilettan, senza alcun lor utile,</l>
@@ -3681,7 +3727,7 @@
             <l>Saprà quest'uom da bene.) Che è del giovene</l>
             <l part="I">Che m'ha dato la corsa?</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Non deve esserti</l>
             <l>Maraviglia, perché tener è solito</l>
@@ -3689,26 +3735,26 @@
             <l>E veramente t'avrà colto in cambio</l>
             <l part="I">D'un cavallo.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="F">In bon'ora, avrò da rendergli</l>
             <l>Forse una volta anch'io questo servizio.</l>
             <l>Ma del facchin, che costì lasciai carico,</l>
             <l part="I">Sapete voi novella?</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Un pezzo in dubbio</l>
             <l>Stette dove la cassa avesse a mettere,</l>
             <l>Poi si risolse al, fin d'andarla a mettere</l>
             <l part="I">In gabella, et andòvi.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="F">Ah, facchin asino,</l>
             <l part="I">Indiscreto, poltron!</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Ben potrai giungerlo,</l>
             <l>Se corri un poco. (Corri pur, che il palio</l>
@@ -3720,7 +3766,7 @@
         <div type="scene" n="Scena V">
           <head>SCENA V</head>
           <stage>Abondio, Fazio, Camillo</stage>
-          <sp>
+          <sp who="#abondio">
             <speaker>ABONDIO:</speaker>
             <l>M'incresce più ch'io vegga in bocca al populo?</l>
             <l>Questa cosa, che d'alcun altro incommodo</l>
@@ -3731,34 +3777,34 @@
             <l>E incantatori, e fatto ha solennissime</l>
             <l>Pazzie, che a pena i fanciulli farebbono.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l>(T'avessi pur in prigion, che sei milia</l>
             <l>Fiorini avrei da te, prima che fossino...</l>
             <l>Chi è questo fante, che in farsetto sgombera</l>
             <l part="I">Di casa mia con tal fretta?)</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">O pericolo</l>
             <l part="I">Grande!</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">(È Camil Pocosal. Chi condotto lo</l>
             <l part="I">Averà qui? Dio m'aiuti!)</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">O perfidia</l>
             <l part="I">D'uomini scelerati!</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">(Quando diavolo</l>
             <l part="I">Entrò qua dentro?)</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">O caso spaventevole!</l>
             <l>O pericolo grande! O gran pericolo,</l>
@@ -3767,11 +3813,11 @@
             <l>Hanno da me ricevuto e ricevono</l>
             <l part="I">Tuttavia...</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="M">(Che grida egli?)</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">...mi tradiscono?</l>
             <l>Bontà divina, che tanta ignominia,</l>
@@ -3781,60 +3827,60 @@
             <l>Per saperle, ch'io sia stato a pericolo</l>
             <l part="I">Di lasciarci oggi la vita!</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">(M'imagino</l>
             <l>Che qualche gran ruina n'ha da opprimere.)</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l>Ma da chi aver in presto ora potrebbesi,</l>
             <l>Da pormi sul farsetto, almeno un picciolo</l>
             <l>Mantellino, per ire a trovar sùbito</l>
             <l part="I">Abondio...</l>
           </sp>
-          <sp>
+          <sp who="#abondio">
             <speaker>ABONDIO:</speaker>
             <l part="F">(Chi è quel che là mi nomina?)</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l>...E fargli intender quanto, a suo perpetuo</l>
             <l>Scorno e de la figliuola, e ad ignominia</l>
             <l part="I">Di casa sua...</l>
           </sp>
-          <sp>
+          <sp who="#abondio">
             <speaker>ABONDIO:</speaker>
             <l part="M">(Dio m'aiuti!)</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">...cercavano</l>
             <l part="I">Di far questi ribaldi?</l>
           </sp>
-          <sp>
+          <sp who="#abondio">
             <speaker>ABONDIO:</speaker>
             <l part="F">(Mi pare essere</l>
             <l part="I">Camillo Pocosale: è desso.)</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">Abondio,</l>
             <l part="I">Non volevo altro che voi.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">(Non può nascere</l>
             <l>Altro di qui che danno et infortunio.)</l>
           </sp>
-          <sp>
+          <sp who="#abondio">
             <speaker>ABONDIO:</speaker>
             <l>Io ti veggo così in farsetto e in ordine</l>
             <l>Per giocar forse alla palla? Provedeti</l>
             <l>Pur d'un altro, che sia a questo esercizio</l>
             <l>Miglior di me, ch'io non ci son molto agile.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l>Né per giocar con voi a palle, Abondio,</l>
             <l>Vengo a trovarvi; ma per farvi intendere</l>
@@ -3846,16 +3892,16 @@
             <l>Ch'io mi vergogno d'apparir in publico</l>
             <l part="I">Così spogliato.</l>
           </sp>
-          <sp>
+          <sp who="#abondio">
             <speaker>ABONDIO:</speaker>
             <l part="F">Andiàn qui in casa Massimo.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l>Pio tosto vuo' ch'andiamo in casa Massimo,</l>
             <l part="I">Che d'alcun altro; e ch'egli m'oda.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Temolo,</l>
             <l>Temolo, or presto va' lor dietro, e sforzati</l>
@@ -3866,24 +3912,24 @@
         <div type="scene" n="Scena VI">
           <head>SCENA VI</head>
           <stage>Fazio, Cintio, Temolo</stage>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l>Cintio, che cosa è questa? Come diavolo</l>
             <l part="I">Era costui qua dentro?</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">A punto il diavolo</l>
             <l>Ce l'ha portato! Ma chi ha fatto mettere;</l>
             <l>Una cassa qua su, ch'era dato ordine</l>
             <l part="I">Che fusse messa in casa nostra?</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Temolo</l>
             <l>Et io ce l'abbiàn fatta or ora mettere.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l>E voi or ora, e Temol, ruinato mi</l>
             <l>Avete; e le mie spemi e di Lavinia,</l>
@@ -3891,14 +3937,14 @@
             <l>mente, avete sospinte in precipizio</l>
             <l part="I">Perché l'avete voi fatto?</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Per rompere</l>
             <l>Il disegno allo Astrologo, certissimi</l>
             <l>Che col mezzo di quella cassa studia</l>
             <l part="I">Di tradirvi.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">E perché almeno non dirmene</l>
             <l>Una parola, e non lasciarmi incorrere</l>
@@ -3918,7 +3964,7 @@
             <l>Sarà placarlo, che d'avermi in odio</l>
             <l part="I">Ha cagion troppo giusta.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Potete essere</l>
             <l>Certo di venir tardi, perché Abondio</l>
@@ -3928,7 +3974,7 @@
             <l>Parola a dritto la stizza e la còlera)</l>
             <l part="I">Ha contato ogni cosa.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">Non è misero</l>
             <l>Uomo al mondo, col qual non cangiasse essere,</l>
@@ -3936,34 +3982,34 @@
             <l>Che lo sappia di tratto). O Dio! a che termine</l>
             <l part="I">Son io?</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Fate pur conto che lo sappia,</l>
             <l>Che, a lui Camillo drittamente e Abondio</l>
             <l>Son iti, e senza dubbio già narratoli</l>
             <l part="I">Hanno il tutto:</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">Son iti insieme a Massimo?</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="I">Sì, sono.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">lo son spacciato, io son morto! Apriti,</l>
             <l>Apriti, per Dio, terra, e seppelliscemi.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l>Non è così da disperarsi, Cintio,</l>
             <l>Ma da pensare, e molto ben rivolgere,</l>
             <l>Se c'è provisïone, se rimedio</l>
             <l part="I">Si può far qui.</l>
           </sp>
-          <sp>
+          <sp who="#cintio">
             <speaker>CINTIO:</speaker>
             <l part="F">Né proveder, né prendere</l>
             <l>Altro rimedio so, che di fuggirmene</l>
@@ -3972,14 +4018,14 @@
             <l>Non voglio. A Dio. Vi raccomando, Fazio,</l>
             <l part="I">La mia Lavinia.</l>
           </sp>
-          <sp>
+          <sp who="#fazio">
             <speaker>FAZIO:</speaker>
             <l part="F">Ah, dove, pusillanime,</l>
             <l>Fuggite voi? — Se n'è andato. Va', Temolo,</l>
             <l>In casa, e diligentemente informati</l>
             <l>Di tutto quel che accade, e riferiscemi.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l>Così farò. Tu costà dentro aspettami.</l>
           </sp>
@@ -3990,20 +4036,20 @@
         <div type="scene" n="Scena I">
           <head>SCENA I</head>
           <stage>Massimo, Camillo, Abondio, Temolo</stage>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l>S'io truovo che sia ver, ne farò (statene</l>
             <l>Sicuri) tal dimostrazion, che accorgervi</l>
             <l>Potrete che m'incresca, e ch'io non reputi</l>
             <l>Meno esser fatta a me, che a voi, l'ingiuria.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l>Se trovate altramente, publicatemi</l>
             <l>Pel più tristo, pel più maligno et invido</l>
             <l part="I">Uom che sia al mondo.</l>
           </sp>
-          <sp>
+          <sp who="#abondio">
             <speaker>ABONDIO:</speaker>
             <l part="F">Se non fusse, Massimo,</l>
             <l>Più che vero, io conosco costui giovene</l>
@@ -4012,13 +4058,13 @@
             <l>Che non resti impunita; né passarlami</l>
             <l part="I">Vuo' così leggiermente.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="F">Udite, Abondio,</l>
             <l>Per vostra fede, e non correte a furia:</l>
             <l part="I">Informiamoci meglio.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">Chi informarvene</l>
             <l>Meglio vi può di me, che con le proprie</l>
@@ -4026,12 +4072,12 @@
             <l>Veduto, che qui dentro il vostro Cintio</l>
             <l part="I">Ha un'altra moglie?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="F">Piano: io vuo' informarmene</l>
             <l part="I">Un poco meglio.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">Entriàn dentro: menatemi</l>
             <l>Al paragone; e se trovate ch'io abbia</l>
@@ -4039,16 +4085,16 @@
             <l>Parola, vi consento e do licenzia</l>
             <l>Che mi caviate il cuor, la lingua e l'anima.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="I">Andiamo, andiamo.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">Andiàn tutti; chiariamoci</l>
             <l part="I">A fatto.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="F">Deh, restate voi: lasciatemi</l>
             <l>Andarvi solo, e non si facci strepito,</l>
@@ -4056,16 +4102,16 @@
             <l>Non procacciàn noi stessi la ignominia</l>
             <l part="I">Nostra.</l>
           </sp>
-          <sp>
+          <sp who="#abondio">
             <speaker>ABONDIO:</speaker>
             <l part="F">Voi dunque andate, e poi chiamateci</l>
             <l part="I">Quando vi par.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="F">Così farò: aspettatemi.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l>(Io gli vuo' pur ir dietro, e veder l'ultima</l>
             <l>Calamità che ci ha tutti a distruggere.)</l>
@@ -4074,36 +4120,36 @@
         <div type="scene" n="Scena II">
           <head>SCENA II</head>
           <stage>Nibbio, Abondio, Camillo</stage>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>(Credo che tolto per una pallottola.</l>
             <l>Da maglio questi ghiottoni oggi m'abbino:</l>
             <l>Che l'un, con una ciancia percotendomi,</l>
             <l>Mi caccia un colpo insino a San Domenico...)</l>
           </sp>
-          <sp>
+          <sp who="#abondio">
             <speaker>ABONDIO:</speaker>
             <l>Fu gran pazzia la tua, lasciarti chiudere</l>
             <l>In una cassa, e posto a gran pericolo</l>
             <l part="I">Ti sei per certo.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="F">(Io torno, e trovo in ordine</l>
             <l part="I">L'altro con l'altra ciancia...)</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">Resto attonito</l>
             <l>Di me medesmo, tuttavia pensandoci.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>(...Che sta alla posta, e mena, e fa ch'io sdrucciolo</l>
             <l>Fin in Gabella. A quest'altra mi spingono</l>
             <l part="I">Fuor de la porta.)</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">Veramente, Abondio,</l>
             <l>Non voglio attribuirlo sì al mio essere</l>
@@ -4113,31 +4159,31 @@
             <l>Ecco un di quei che ne la cassa chiusermi,</l>
             <l>E vostra figlia e voi e me tradivono.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>(Non so a chi mi ritorni.) Ma ecco il giovene</l>
             <l>Che v'era dentro serrato: io mi dubito,</l>
             <l>Per Dio, che avremo fatto qualche scandolo.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l>Ah ghiotton, ladro, traditore e perfido,</l>
             <l>E tu e tuo padron! Così si trattano</l>
             <l>Quei ch'alla fede vostra si commettono?</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>Né io, né mio padron, mai se non utile</l>
             <l part="I">Vi facemmo, e piacer.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">Piacere et utile</l>
             <l>Grande mi saria stato, succedendovi,</l>
             <l>D'avermi fatto, com'un ladro, prendere</l>
             <l part="I">Di notte in casa altrui!</l>
           </sp>
-          <sp>
+          <sp who="#abondio">
             <speaker>ABONDIO:</speaker>
             <l part="F">L'oneste giovini</l>
             <l>Non avete rossor, né conscïenzia,</l>
@@ -4145,17 +4191,17 @@
             <l>E alle famiglie dar de' gentiluomini,</l>
             <l>Con vostre fraudi, nota et ignominia?</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>Parlate a lui, che vi saprà rispondere.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l>Gli parlarò chiarissimo, e ben siatene</l>
             <l>Certi, ma altrove; e vi farà rispondere</l>
             <l>La fune; e questa, e vostre altre mal'opere...</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>Potete dir quel che vi par, ma ufficio</l>
             <l>Non è già vostro, né di gentiluomini,</l>
@@ -4163,21 +4209,21 @@
             <l>Il mio padron ben sarà buon per rendervi</l>
             <l part="I">Conto di sé.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="M">Sì, sarà ben.</l>
           </sp>
-          <sp>
+          <sp who="#abondio">
             <speaker>ABONDIO:</speaker>
             <l part="F">Lasciatelo</l>
             <l part="I">senza risponderli altro.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">Ora col diavolo</l>
             <l>Va', ladroncello; va' alle forche, e impiccati.</l>
           </sp>
-          <sp>
+          <sp who="#abondio">
             <speaker>ABONDIO:</speaker>
             <l>Lascialo andare, e non entrar più in còlera.</l>
             <l>Ormai dovria chiamarne dentro Massimo;</l>
@@ -4188,101 +4234,101 @@
         <div type="scene" n="Scena III">
           <head>SCENA III</head>
           <stage>Temolo, Abondio, Camillo, Massimo</stage>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l>(O aventura grande, o Fortuna ottima!</l>
             <l>Come tanta paura e tanta orribile</l>
             <l>Tempesta in sì sicura et in sì placida</l>
             <l>Quïete hai rivoltato così sùbito!)</l>
           </sp>
-          <sp>
+          <sp who="#abondio">
             <speaker>ABONDIO:</speaker>
             <l part="I">Perché è costui sì allegro?</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">(Dove correre,</l>
             <l>Dove volar debbo io per trovar Cintio?)</l>
           </sp>
-          <sp>
+          <sp who="#abondio">
             <speaker>ABONDIO:</speaker>
             <l part="I">Ch'esser può questo?</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="M">                               lo non so.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">(Ch'io gli annunzii</l>
             <l>ll maggior gaudio, la maggior letizia</l>
             <l part="I">Ch'avesse mai.)</l>
           </sp>
-          <sp>
+          <sp who="#abondio">
             <speaker>ABONDIO:</speaker>
             <l part="M">Che fia?</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">(La sua Lavinia</l>
             <l>Ritruovano esser figliuola di Massimo.)</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="I">L'avete inteso?</l>
           </sp>
-          <sp>
+          <sp who="#abondio">
             <speaker>ABONDIO:</speaker>
             <l part="M">Sì.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">Come può essere?</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l>(Ma che cess'io d'andare a trovar Cintio?)</l>
           </sp>
-          <sp>
+          <sp who="#abondio">
             <speaker>ABONDIO:</speaker>
             <l>Moglie non ebbe egli già mai, ch'io sappia.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l>S'hanno figliuoli anco de l'altre femine,</l>
             <l part="I">Che non son mogli.</l>
           </sp>
-          <sp>
+          <sp who="#abondio">
             <speaker>ABONDIO:</speaker>
             <l part="F">Eccoci lui, che intendere</l>
             <l part="I">Ci farà il tutto.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">Trovate voi, Massimo,</l>
             <l part="I">Ch'io sia bugiardo?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="M">Non, per Dio.</l>
           </sp>
-          <sp>
+          <sp who="#abondio">
             <speaker>ABONDIO:</speaker>
             <l part="F">Chiariteci:</l>
             <l>Che figlia è questa vostra, che ci ha Temolo</l>
             <l part="I">Detto ch'avete trovato?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="F">Diròvelo,</l>
             <l part="I">Se ascoltar mi vorrete.</l>
           </sp>
-          <sp>
+          <sp who="#abondio">
             <speaker>ABONDIO:</speaker>
             <l part="F">Ambe vi accommodo</l>
             <l>L'orecchie volentieri a questo ufficio.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l>Ricordar vi dovreste a quei principii</l>
             <l>Che i Veneziani Cremona teneano,</l>
@@ -4290,11 +4336,11 @@
             <l>Io n'ebbi bando, e taglia di tremilia</l>
             <l part="I">Ducati dietro.</l>
           </sp>
-          <sp>
+          <sp who="#abondio">
             <speaker>ABONDIO:</speaker>
             <l part="M">Mi ricordo.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="F">Anda'mene,</l>
             <l>Che mai non mi fermai, fin in Calabria;</l>
@@ -4352,16 +4398,16 @@
             <l>Che v'ha fatto gravissima; et escusilo</l>
             <l part="I">L'etade.</l>
           </sp>
-          <sp>
+          <sp who="#abondio">
             <speaker>ABONDIO:</speaker>
             <l part="F">Insomma trovate che Cintio</l>
             <l part="I">L'ha tolta per mogliere?</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">Chi ne dubita?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l>Alla temerità non più del giovene</l>
             <l>Si debbe attribuir, che all'infallibile</l>
@@ -4392,7 +4438,7 @@
             <l>Come sia il nostro, e ricco; io mi vi profero</l>
             <l>Con ciò ch'al mondo ho, sempre paratissimo.</l>
           </sp>
-          <sp>
+          <sp who="#abondio">
             <speaker>ABONDIO:</speaker>
             <l>Se fin da püerizia sempre, Massimo,</l>
             <l>Io v'ho portato amore e reverenzia,</l>
@@ -4409,7 +4455,7 @@
             <l>Il che a rimaritarla sarà ostacolo</l>
             <l part="I">Maggior che non vi par.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="F">Eccovi il genero</l>
             <l>Apparecchiato qui: Camillo, nobile</l>
@@ -4417,56 +4463,56 @@
             <l>Che l'ama più che se stesso, e desidera</l>
             <l>D'averla. Or dove me' potete metterla?</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l>Cotesta bocca sia da Dio in perpetuo.</l>
             <l part="I">Benedetta!</l>
           </sp>
-          <sp>
+          <sp who="#abondio">
             <speaker>ABONDIO:</speaker>
             <l part="F">Dica egli, et io rispondere</l>
             <l part="I">Saprò al suo detto.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">Io l'averò di grazia;</l>
             <l>Così con tutto il cor vi prego e supplico</l>
             <l>Che me la concediate di buon animo.</l>
           </sp>
-          <sp>
+          <sp who="#abondio">
             <speaker>ABONDIO:</speaker>
             <l part="I">Et io te la prometto.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">Io per legitima</l>
             <l part="I">Sposa l'accetto...</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="F">Dio conduca e prosperi,</l>
             <l>Senza averci mai lite; il matrimonio.</l>
           </sp>
-          <sp>
+          <sp who="#abondio">
             <speaker>ABONDIO:</speaker>
             <l part="I">Siàn d'accordo?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="M">D'accordo.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">D'accordissimo.</l>
           </sp>
-          <sp>
+          <sp who="#abondio">
             <speaker>ABONDIO:</speaker>
             <l>Deh, se 'l vi piace, fateci un po' intendere</l>
             <l>Dove è stata costei nascosa sedici</l>
             <l>Anni o diciotto, e come oggi venutone</l>
             <l>Sète, più ch'altro dì, così a notizia?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l>Ero entrato qua dentro per intendere</l>
             <l>Più chiaramente quello che narratoci</l>
@@ -4488,7 +4534,7 @@
             <l>Avea abitato alcun tempo in Calabria,</l>
             <l part="I">E quivi tolto moglier.</l>
           </sp>
-          <sp>
+          <sp who="#abondio">
             <speaker>ABONDIO:</speaker>
             <l part="F">Sète, Massimo,</l>
             <l>Prudente; pur vi vo' ricordar ch'essere</l>
@@ -4496,7 +4542,7 @@
             <l>Avendo intesa questa istoria, fingersi</l>
             <l part="I">Volesse vostra figliuola.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="F">Onde Cintio</l>
             <l>Lo può saper, che por mai non ho minima</l>
@@ -4515,12 +4561,12 @@
             <l>Quando non ci fusse altro; ma la effigie</l>
             <l>C'ha de la matre, ancor mi certifica.</l>
           </sp>
-          <sp>
+          <sp who="#abondio">
             <speaker>ABONDIO:</speaker>
             <l>Ch'è de la matre? Ve ne sa ella rendere</l>
             <l part="I">Conto?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="F">Si ben; ma più quegli altri dicono</l>
             <l>Che, tornando la matre vêr Calabria,</l>
@@ -4533,42 +4579,42 @@
             <l>E la chiamaron Lavinia, in memoria</l>
             <l>D'una lor, credo m'abbiano detto, avola.</l>
           </sp>
-          <sp>
+          <sp who="#abondio">
             <speaker>ABONDIO:</speaker>
             <l>Son de' vostri contenti contentissimo.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="I">Et io similemente.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="F">Vi ringrazio.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="I">Noi che faremo?</l>
           </sp>
-          <sp>
+          <sp who="#abondio">
             <speaker>ABONDIO:</speaker>
             <l part="F">A tuo piacere Emilia</l>
             <l part="I">Potrai sposare.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="F">E perché non concludere</l>
             <l part="I">Ora quel che s'ha a far?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASSIMO:</speaker>
             <l part="F">Ben dice, sposila</l>
             <l part="I">Ora.</l>
           </sp>
-          <sp>
+          <sp who="#abondio">
             <speaker>ABONDIO:</speaker>
             <l part="M">Sposila: andiamo.</l>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO:</speaker>
             <l part="I">Andiàn, di grazia.</l>
           </sp>
@@ -4576,7 +4622,7 @@
         <div type="scene" n="Scena IV">
           <head>SCENA IV</head>
           <stage>Temolo, Astrologo</stage>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l>Era ito per trovar Cintio, con animo</l>
             <l>D'aver il beveraggio de lo annunzio</l>
@@ -4600,7 +4646,7 @@
             <l>Ben lodevole e santa a fargli mettere</l>
             <l part="I">La mano adosso.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">lo non so quel che Nibbio</l>
             <l>Fatto abbia de la cassa, di che carico</l>
@@ -4619,29 +4665,29 @@
             <l>Ritrovato la cassa, e consegnatola</l>
             <l part="I">A chi io gli dissi.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">(Io vo' porre ogni industria</l>
             <l>Per fargli qualche beffa memorabile.)</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Ma veggo chi mel saprà dire. — O giovene,</l>
             <l>Il mio garzon, che tu déi ben conoscere,</l>
             <l part="I">Ha portato una cassa qui?</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Portato l'ha</l>
             <l>Pur un facchino, et è stato a pericolo,</l>
             <l>Se non era io, di far non poco scandolo.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Mi disse ben ch'un de li vostri data gli</l>
             <l part="I">Avea la baia.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Un de li nostri? Dettovi</l>
             <l>Non ha la verità; fu un certo giovene</l>
@@ -4654,7 +4700,7 @@
             <l>patron venne poi sùbito, e chiusela,</l>
             <l>E seco ne portò la chiave a cintola.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Come facesti bene! Te n'ha Massimo,</l>
             <l>E tutti i suoi di casa, da aver obligo:</l>
@@ -4662,35 +4708,35 @@
             <l>Li spirti usciti e entrati in casa a furia</l>
             <l>Questa notte, e trattati mal vi avrebbeno.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l>O maestro, pur che questi vostri spiriti</l>
             <l>Si stian ne la lor cassa, e che non corrano</l>
             <l>Per casa, e qualche danno non ci faccino.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Non dubitate, che non ci è pericolo.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l>Voi direte la vostra, voi: mi triemano</l>
             <l part="I">Di paura le viscere.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Fidatevi</l>
             <l>Pur di me, ch'io non vi lascerò nuocere.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="I">Cel promettete voi?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Sì, non aprendola.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l>Oh, ben pazzo saria chi avesse audacia</l>
             <l>D'aprirla, o pur sol di toccarla: guardimi</l>
@@ -4709,12 +4755,12 @@
             <l>Intanto voi dite al patron che avuto li</l>
             <l part="I">Avete.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Non saria meglio, che dirgli la</l>
             <l part="I">Bugia, che vada e li arrechi?</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Dovendoli</l>
             <l>Portar scoperti, non voglio ir, che Massimo</l>
@@ -4725,18 +4771,18 @@
             <l>Ma sì sciocco non son, ch'io non consideri</l>
             <l>Che non saria domanda convenevole.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Se pur ti par che la sia buona, pigliala.</l>
             <l>Ma perché non debbe esser buona? Pigliala</l>
             <l part="I">Ogni modo, e va' ratto.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Sarebbe ottima,</l>
             <l>Ma mi parria gran villania spogliarvene.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Peggio saria s'io lasciassi trascorrere</l>
             <l>Una coniunzïon, che per me idonea</l>
@@ -4744,37 +4790,37 @@
             <l>Piglia pur tu la vesta, e torna sùbito,</l>
             <l>Che qui t'aspettarò, in casa Massimo.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l>Mi par strano lasciarvi in questo piccolo</l>
             <l>Gonnellin; nondimeno, commandolo</l>
             <l part="I">Voi, pigliarolla.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="M">Pigliala.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">Or lo Astrologo</l>
             <l part="I">Son io, e non voi.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Tu mi pari in questo abito</l>
             <l part="I">Un uom da bene.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">E voi parete... vogliolo</l>
             <l part="I">Poi dir com'io ritorni a voi.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Va', e studia</l>
             <l part="I">passo, e torna tosto.</l>
           </sp>
-          <sp>
+          <sp who="#temolo">
             <speaker>TEMOLO:</speaker>
             <l part="F">(Quasi dettogli</l>
             <l>Ho che pare un ghiottone e un ladro. Aspettimi</l>
@@ -4788,7 +4834,7 @@
         <div type="scene" n="Scena V">
           <head>SCENA V</head>
           <stage>Astrologo, Nibbio</stage>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Era ben certo che esser miei dovessino</l>
             <l>Gli argenti di Camillo; perché, avendolo</l>
@@ -4808,19 +4854,19 @@
             <l>Non di lei, ma di sé poi si ramarichi.</l>
             <l>La prenderò ben io. Ma ecco Nibbio.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>Voi sète così in gonnellino: avetevi</l>
             <l part="I">Forse giocata la vesta?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Prestatala</l>
             <l>Ho pur a un de' famigli qui di Massimo,</l>
             <l>Che è ito a tôr quei dua baccini, e aspettolo</l>
             <l part="I">Che me gli arrechi.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="F">Baccini? Eh levatevi,</l>
             <l>Padron, di qui! Quel ribaldo attaccatavi</l>
@@ -4828,12 +4874,12 @@
             <l>Dunque che siàn scoperti, e che quel giovine</l>
             <l part="I">È de la cassa uscito?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Uscito? diavolo!</l>
             <l part="I">Egli ne è uscito?</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="F">N'è uscito, e da Cintio</l>
             <l>Tutto lo inganno ha sentito per ordine,</l>
@@ -4841,42 +4887,42 @@
             <l>Levatevi, per Dio! Non è da perdere</l>
             <l part="I">Tempo.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="M">Io vorrei pur la mia vesta.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="F">Toltola,</l>
             <l>Padron, non credo abbia colui per renderla;</l>
             <l part="I">A chi l'avete voi data?</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">A quel giovene</l>
             <l>Che con Cintio suol ir: come si nomina?</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="I">L'avrete data a Temolo.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Si, a Temolo;</l>
             <l part="I">A punto a lui l'ho data.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="F">Oh, gli è il medesimo</l>
             <l>Ch'oggi mi de' la caccia, e mi fe' correre.</l>
             <l>Al libro de l'uscita avete a metterla.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Duolmene, e tanto più, quanto mio solito</l>
             <l>Era di guadagnare, e non di perdete.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>Guardatevi, patron, da maggior perdita</l>
             <l>Che d'una vesta. Andiàn tosto: levatevi</l>
@@ -4885,12 +4931,12 @@
             <l>Che ci porterà in giù. Mi par che giunghino</l>
             <l>Tuttavia i birri, et in prigion ci caccino.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l>Non vogliamo ir prima allo albergo, e prendere</l>
             <l part="I">Le cose nostre?</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="F">Andate voi pur sùbito</l>
             <l>Al porto, e ritrovate, o grande o piccola</l>
@@ -4898,23 +4944,23 @@
             <l>Ch'io vo correndo allo albergo, et arrecovi</l>
             <l part="I">Tutte le cose nostre.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="M">Or va'.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="F">Volgetevi</l>
             <l part="I">Pur giù per questa strada.</l>
           </sp>
-          <sp>
+          <sp who="#astrologo">
             <speaker>ASTROLOGO:</speaker>
             <l part="F">Io vo; ma ascoltami:</l>
             <l>Non lasciar cosa nostra ne la camera</l>
             <l>De l'oste; anzi se puoi far netto, pigliane</l>
             <l part="I">De le sue.</l>
           </sp>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l part="F">L'avvertimento è superfluo.</l>
           </sp>
@@ -4922,7 +4968,7 @@
         <div type="scene" n="Scena VI">
           <head>SCENA VI</head>
           <stage>Nibbio</stage>
-          <sp>
+          <sp who="#nibbio">
             <speaker>NIBBIO:</speaker>
             <l>S'io vo dietro a costui, sto in gran pericolo</l>
             <l>Che un giorno io mi creda essere in Italia,</l>

--- a/tei/ariosto-la-cassaria-red-in-versi.xml
+++ b/tei/ariosto-la-cassaria-red-in-versi.xml
@@ -76,6 +76,67 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="nebbia">
+            <persName>Nebbia</persName>
+          </person>
+          <person xml:id="corbo">
+            <persName>Corbo</persName>
+          </person>
+          <person xml:id="corisca">
+            <persName>Corisca</persName>
+          </person>
+          <person xml:id="eulalia">
+            <persName>Eulalia</persName>
+          </person>
+          <person xml:id="erofilo">
+            <persName>Erofilo</persName>
+          </person>
+          <person xml:id="caridoro">
+            <persName>Caridoro</persName>
+          </person>
+          <person xml:id="lucramo">
+            <persName>Lucramo</persName>
+          </person>
+          <person xml:id="furbo">
+            <persName>Furbo</persName>
+          </person>
+          <person xml:id="vulpino">
+            <persName>Vulpino</persName>
+          </person>
+          <person xml:id="fulcio">
+            <persName>Fulcio</persName>
+          </person>
+          <person xml:id="trappola">
+            <persName>Trappola</persName>
+          </person>
+          <person xml:id="brusco">
+            <persName>Brusco</persName>
+          </person>
+          <person xml:id="stamma">
+            <persName>Stamma</persName>
+          </person>
+          <person xml:id="bruno">
+            <persName>Bruno</persName>
+          </person>
+          <person xml:id="rosso">
+            <persName>Rosso</persName>
+          </person>
+          <person xml:id="riccio">
+            <persName>Riccio</persName>
+          </person>
+          <person xml:id="crisobolo">
+            <persName>Crisobolo</persName>
+          </person>
+          <person xml:id="critone">
+            <persName>Critone</persName>
+          </person>
+          <person xml:id="servitor">
+            <persName>Servitor</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>2007-06-08T00:00:00.000+02:00</date><name>Novadata systems</name>Digitalizzazione - OCR</change>
@@ -319,7 +380,7 @@
         <div>
           <head>Scena I</head>
           <stage>Nebbia, Corbo servi</stage>
-          <sp>
+          <sp who="#nebbia">
             <speaker>NEBBIA:</speaker>
             <l>Io anderò: non vi bisogna prendere</l>
             <l>Né spada né bastone per cacciarmene.</l>
@@ -328,7 +389,7 @@
             <l>Solo, che possa levar malmettere</l>
             <l>Ciò che gli pare e senza testimonii.</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l>La tua per certo, Nebbia, è una mirabile</l>
             <l>Pazzia; che fra noi tutti che a un medesimo</l>
@@ -346,45 +407,45 @@
             <l>Egli mandar con noi fuor? Perché studi tu</l>
             <l>Fartilo di nimico inimicissimo?</l>
           </sp>
-          <sp>
+          <sp who="#nebbia">
             <speaker>NEBBIA:</speaker>
             <l>Se dal patron le commission strettissime</l>
             <l>Avessi avute, c’ho avute io, non dubito</l>
             <l part="I">Che faresti il medesimo.</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="F">Puote essere.</l>
           </sp>
-          <sp>
+          <sp who="#nebbia">
             <speaker>NEBBIA:</speaker>
             <l>E se mirassi ove io miro, parrebbeti</l>
             <l part="I">Ch’io non facessi a bastanza.</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="F">Ove miri tu?</l>
           </sp>
-          <sp>
+          <sp who="#nebbia">
             <speaker>NEBBIA:</speaker>
             <l>Io tel dirò. Tu dovresti conoscere</l>
             <l>Questo ruffian che non è molto ch’abita</l>
             <l part="I">In questa nostra contrada.</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="F">Conoscolo.</l>
           </sp>
-          <sp>
+          <sp who="#nebbia">
             <speaker>NEBBIA:</speaker>
             <l>Se ’l conosci, credo anco che vedutogli</l>
             <l>Abbi in casa due giovani bellissime.</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="I">L’ho vedute.</l>
           </sp>
-          <sp>
+          <sp who="#nebbia">
             <speaker>NEBBIA:</speaker>
             <l part="F">De l’una il nostro Erofilo</l>
             <l>È sì invaghito che tôrria, potendola</l>
@@ -395,11 +456,11 @@
             <l>Gli ne chiede più il doppio e passa i termini</l>
             <l>Di quel che, pel dove, gli dovria chiedere.</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="I">E che gli ne chiede egli?</l>
           </sp>
-          <sp>
+          <sp who="#nebbia">
             <speaker>NEBBIA:</speaker>
             <l part="F">Non so dirtelo</l>
             <l>A punto; so che più de l’ordinario</l>
@@ -408,11 +469,11 @@
             <l>Il padre solamente, potria ascendere</l>
             <l part="I">A sì gran somma.</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="M">Che farà?</l>
           </sp>
-          <sp>
+          <sp who="#nebbia">
             <speaker>NEBBIA:</speaker>
             <l part="F">Grandissimo</l>
             <l>Danno a suo padre e insieme a se medesimo.</l>
@@ -431,7 +492,7 @@
             <l>Con iscusa che quei si vuol de l’opera</l>
             <l part="I">Nostra servire in sue facende.</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="F">Faccialo,</l>
             <l>A che effetto si vuol: c’hai tu a pigliartene</l>
@@ -439,7 +500,7 @@
             <l>E vòtassin la casa, del residuo</l>
             <l>Sarà Erofilo erede e non tu, bestia.</l>
           </sp>
-          <sp>
+          <sp who="#nebbia">
             <speaker>NEBBIA:</speaker>
             <l>Bestia pur tu: che non hai più d’un asino</l>
             <l>Discorso. Dimmi, Corbo, se Crisobolo</l>
@@ -459,37 +520,37 @@
             <l>Di certo corno suo da caccia: et ebbele:</l>
             <l part="I">E forse tu ti ci trovasti.</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="F">Odivone</l>
             <l>Ben il rumor, che da dieci o da dodici</l>
             <l part="I">Bastonate senti’.</l>
           </sp>
-          <sp>
+          <sp who="#nebbia">
             <speaker>NEBBIA:</speaker>
             <l part="F">Fur più di quindici</l>
             <l part="I">E più di venti!</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="F">Che ti rassettavano</l>
             <l>Il basto, prima che volessi darglile;</l>
             <l>Ma non mi ci trovai già alla presenzia.</l>
           </sp>
-          <sp>
+          <sp who="#nebbia">
             <speaker>NEBBIA:</speaker>
             <l>Non mi ci fussi anch’io trovato! Avrebbemi</l>
             <l part="I">Morto, s’io non gli le lasciavo.</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="F">Credolo.</l>
           </sp>
-          <sp>
+          <sp who="#nebbia">
             <speaker>NEBBIA:</speaker>
             <l part="I">E che dovevo io far?</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="F">Darglile, subito</l>
             <l>Che te le domandò; così uscir subito</l>
@@ -502,7 +563,7 @@
             <l>Giovane, altiero, appetitoso, et unico</l>
             <l part="I">Suo figliuol?</l>
           </sp>
-          <sp>
+          <sp who="#nebbia">
             <speaker>NEBBIA:</speaker>
             <l part="F">Sì, per Dio, gli fia difficile</l>
             <l>Di pormi tutta la colpa su gli omeri!</l>
@@ -512,19 +573,19 @@
             <l>Ma sì per mia bontà perché io non tolero</l>
             <l part="I">Che ’l patron sia rubato.</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="F">Per tua pessima</l>
             <l>Natura pur: ch’alcun farti benivolo</l>
             <l part="I">Non sai.</l>
           </sp>
-          <sp>
+          <sp who="#nebbia">
             <speaker>NEBBIA:</speaker>
             <l part="F">Qual vedi tu, ch’abbia l’ufficio</l>
             <l>Mio in qual si voglia casa, e non sia simile-</l>
             <l>mente da tutti gli altri avuto in odio?</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l>Perché voi sète tristi affatto, et uomini</l>
             <l>Ribaldi tutti: che i patroni sogliono</l>
@@ -538,16 +599,16 @@
             <l>Ch’entrò pur dianzi in casa a cui fa Erofilo</l>
             <l part="I">Così onor?</l>
           </sp>
-          <sp>
+          <sp who="#nebbia">
             <speaker>NEBBIA</speaker>
             <l part="F">Del Capitan di giustizia</l>
             <l part="I">È figliuol.</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="M">Come ha nome?</l>
           </sp>
-          <sp>
+          <sp who="#nebbia">
             <speaker>NEBBIA:</speaker>
             <l part="F">Egli si nomina</l>
             <l>Caridoro. Vorria quell’altra giovane,</l>
@@ -562,17 +623,17 @@
             <l>Ma vedi, Corbo, le fanciulle ch’escono</l>
             <l part="I">Di casa del ruffian.</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="F">Di quale è Erofilo</l>
             <l part="I">Innamorato?</l>
           </sp>
-          <sp>
+          <sp who="#nebbia">
             <speaker>NEBBIA:</speaker>
             <l part="F">Di quella più prossima</l>
             <l>All’uscio; di quell’altra, l’altro giovane.</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l>Studiamo il passo; che se uscisse Erofilo,</l>
             <l>E ci trovasse qui, di negligenzia</l>
@@ -582,13 +643,13 @@
         <div>
           <head>Scena II</head>
           <stage>Corisca, Eulalia fanciulle</stage>
-          <sp>
+          <sp who="#corisca">
             <speaker>CORISCA:</speaker>
             <l>Deh vieni Eulalia poi che non c’è Lucramo</l>
             <l>In casa; vieni un poco fuor; pigliamoci</l>
             <l part="I">Questo spasso.</l>
           </sp>
-          <sp>
+          <sp who="#eulalia">
             <speaker>EULALIA:</speaker>
             <l part="F">Che spasso possiàn misere</l>
             <l>Pigliar, che ricompensi la millesima</l>
@@ -603,27 +664,27 @@
             <l>Come costui del qual la nostra pessima</l>
             <l part="I">Sorte ci ha fatto schiave.</l>
           </sp>
-          <sp>
+          <sp who="#corisca">
             <speaker>CORISCA:</speaker>
             <l part="F">Pazïenzia</l>
             <l>Sorella: non abbiàn così in perpetuo</l>
             <l>A star però. Spero pur che ci levino</l>
             <l>Li amici, un giorno, di questa miseria.</l>
           </sp>
-          <sp>
+          <sp who="#eulalia">
             <speaker>EULALIA:</speaker>
             <l>E quando hanno a far questo, non avendolo</l>
             <l>Sin qui mai fatto? E come vòi, partendoci</l>
             <l>All’alba noi domani, che lo facciano?</l>
           </sp>
-          <sp>
+          <sp who="#corisca">
             <speaker>CORISCA:</speaker>
             <l>Io so ben quel che Caridor promessomi</l>
             <l>Ha tante volte; e tu sai quel che Erofilo</l>
             <l>Ha promesso a te ancora; e quanto ci amino</l>
             <l part="I">Sapemo parimente.</l>
           </sp>
-          <sp>
+          <sp who="#eulalia">
             <speaker>EULALIA:</speaker>
             <l part="F">Che promessoci</l>
             <l>Hanno so ben; ma che attener ci vogliono</l>
@@ -631,7 +692,7 @@
             <l>Né tu lo sai, che lor non vedi l’animo.</l>
             <l>Ben sappiàn questo, che amar ci dovrebbono</l>
           </sp>
-          <sp>
+          <sp who="#corisca">
             <speaker>CORISCA:</speaker>
             <l>Se dovrebbeno amarci? Essendo gioveni</l>
             <l>Da bene come sono, tu déi credere</l>
@@ -639,7 +700,7 @@
             <l>Quello che già mille volte promessoci</l>
             <l part="I">Hanno.</l>
           </sp>
-          <sp>
+          <sp who="#eulalia">
             <speaker>EULALIA:</speaker>
             <l part="F">Io vorrei più tosto che negatoci</l>
             <l>Avessin mille e duomilia e promessoci</l>
@@ -661,13 +722,13 @@
             <l>Nostra cagion che la stizza e la còlera</l>
             <l part="I">Sfoghi sopra di noi.</l>
           </sp>
-          <sp>
+          <sp who="#corisca">
             <speaker>CORISCA:</speaker>
             <l part="F">Sorella, avendoci</l>
             <l>Noi a partir da Sibari, vogliamoci,</l>
             <l>Senza far motto agli amici, partircene?</l>
           </sp>
-          <sp>
+          <sp who="#eulalia">
             <speaker>EULALIA:</speaker>
             <l>Deh, se, come tu di’, costor ci fossino</l>
             <l>Stati amici, io non credo che ci avessino,</l>
@@ -677,29 +738,29 @@
             <l>Di servitude avrebbono e tenuteci</l>
             <l part="I">Con essolor in questa terra.</l>
           </sp>
-          <sp>
+          <sp who="#corisca">
             <speaker>CORISCA:</speaker>
             <l part="F">Perdere</l>
             <l>Non vo’ la speme, ch’ancor non lo facciano.</l>
           </sp>
-          <sp>
+          <sp who="#eulalia">
             <speaker>EULALIA:</speaker>
             <l>Torniamo in casa, poi ch’essi non vogliono</l>
             <l>Mostrarsi fuor; non è già convenevole</l>
             <l part="I">Che andiàn noi loro a picchiar l’uscio.</l>
           </sp>
-          <sp>
+          <sp who="#corisca">
             <speaker>CORISCA:</speaker>
             <l part="F">Stiamoci,</l>
             <l>Eulalia, un poco ancora. Non dovrebbono</l>
             <l>Tardar già però molto: io sento muovere</l>
             <l part="I">Quella porta; saran dessi.</l>
           </sp>
-          <sp>
+          <sp who="#eulalia">
             <speaker>EULALIA:</speaker>
             <l part="M">Sono.</l>
           </sp>
-          <sp>
+          <sp who="#corisca">
             <speaker>CORISCA:</speaker>
             <l part="F">Eccoli.</l>
           </sp>
@@ -707,21 +768,21 @@
         <div>
           <head>Scena III</head>
           <stage>Erofilo, Caridoro, Eulalia, Corisca</stage>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l>O Caridoro, tutti avranno prospero</l>
             <l>Successo li disegni nostri essendoci</l>
             <l>Sì buon incontro, sì felice augurio</l>
             <l part="I">Venuto inanzi.</l>
           </sp>
-          <sp>
+          <sp who="#caridoro">
             <speaker>CARIDORO:</speaker>
             <l part="F">Queste sono, Erofilo,</l>
             <l>Queste son le serene e salutifere</l>
             <l>Stelle che ’l tempestoso e oscuro pelago</l>
             <l>De’ pensier nostri all’apparire achetano!</l>
           </sp>
-          <sp>
+          <sp who="#eulalia">
             <speaker>EULALIA:</speaker>
             <l>Noi dir cotesto a voi più veritevole-</l>
             <l>mente potremo, che ben potreste essere</l>
@@ -739,11 +800,11 @@
             <l>Voi, se quei mali a che non osservando le</l>
             <l>Promesse vi condennate, venissero.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="I">Hai torto a dir così.</l>
           </sp>
-          <sp>
+          <sp who="#eulalia">
             <speaker>EULALIA:</speaker>
             <l part="F">Se gentiluomini</l>
             <l>Voi sète e ricchi, non però noi povere</l>
@@ -752,7 +813,7 @@
             <l>Nostra ci guidi, non però d’ignobile</l>
             <l>Casato eramo ne la nostra patria.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l>Non far, Eulalia, con questi ramarichi</l>
             <l>Il mio affanno più acerbo. Deh, non credere</l>
@@ -785,14 +846,14 @@
             <l>Pel più scortese, pel più ingrato e perfido</l>
             <l part="I">Uom che sia al mondo, se domani...</l>
           </sp>
-          <sp>
+          <sp who="#eulalia">
             <speaker>EULALIA:</speaker>
             <l part="F">Ah Erofilo,</l>
             <l>Mal abbia il mio crederti tanto! Passano</l>
             <l>E gli oggi e gli ieri tutti e pur non giungono</l>
             <l part="I">Mai questi vostri domani.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Deh, lasciami</l>
             <l>Finir: ascolta quel ch’io vo’ concludere.</l>
@@ -800,7 +861,7 @@
             <l>Certa e vivi sicura che più termine</l>
             <l>Non voglio che domani a farti libera.</l>
           </sp>
-          <sp>
+          <sp who="#eulalia">
             <speaker>EULALIA:</speaker>
             <l>Ancor che tu dicessi il ver, che credere</l>
             <l>Non posso che lo diche, pur concedere</l>
@@ -812,32 +873,32 @@
             <l>Nel corpo? Tu non sai, forse, che Lucramo</l>
             <l>Vuol che domani si partiàn da Sibari?</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="I">Non credo che sia vero.</l>
           </sp>
-          <sp>
+          <sp who="#eulalia">
             <speaker>EULALIA.</speaker>
             <l part="F">Perché dirti la</l>
             <l part="I">Bugia vorrei?</l>
           </sp>
-          <sp>
+          <sp who="#corisca">
             <speaker>CORISCA:</speaker>
             <l part="F">Noi ci partiàn, credeteci.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l>Ben credo che ve l’abbia detto Lucramo,</l>
             <l>Ma che ’l ver detto v’abbia, non vo’ credere.</l>
           </sp>
-          <sp>
+          <sp who="#caridoro">
             <speaker>CARIDORO:</speaker>
             <l>Erofilo, che può nuocere a credere</l>
             <l>Che dica il ver? Veggiàn se gli è possibile</l>
             <l>Quel che s’avea domani a far, concludere</l>
             <l part="I">Oggi.</l>
           </sp>
-          <sp>
+          <sp who="#eulalia">
             <speaker>EULALIA:</speaker>
             <l part="F">Oh fate veder in guisa a Lucramo</l>
             <l>Questo che voi disegnate, che credere</l>
@@ -845,7 +906,7 @@
             <l>Voi che domani il danaio abbia a correre,</l>
             <l part="I">Si fermerà.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Poi che ’l vecchio levatomi</l>
             <l>È d’appresso e tener gli occhi continua-</l>
@@ -855,12 +916,12 @@
             <l>E che d’altro uomo tu non sei per essere</l>
             <l part="I">Mai, se non mia.</l>
           </sp>
-          <sp>
+          <sp who="#caridoro">
             <speaker>CARIDORO:</speaker>
             <l part="F">Et io dico il medesimo</l>
             <l part="I">A te, Corisca mia.</l>
           </sp>
-          <sp>
+          <sp who="#eulalia">
             <speaker>EULALIA:</speaker>
             <l part="F">Dio v’oda e facciavi</l>
             <l>Perseverare in questa voglia, e mettere</l>
@@ -873,38 +934,38 @@
             <l>Ma or non più, che non tornasse Lucramo</l>
             <l part="I">E ci cogliesse qui.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Non credo passino</l>
             <l>Molte ore che potrai star meco libera-</l>
             <l part="I">mente:</l>
           </sp>
-          <sp>
+          <sp who="#eulalia">
             <speaker>EULALIA</speaker>
             <l part="M">Dio il voglia!</l>
           </sp>
-          <sp>
+          <sp who="#corisca">
             <speaker>CORISCA:</speaker>
             <l part="M">Et io?</l>
           </sp>
-          <sp>
+          <sp who="#caridoro">
             <speaker>CARIDORO:</speaker>
             <l part="F">Non men si pratica</l>
             <l>Il tuo ben, vita mia, che quel di Eulalia.</l>
           </sp>
-          <sp>
+          <sp who="#corisca">
             <speaker>CORISCA:</speaker>
             <l part="I">Con questa speme andrò.</l>
           </sp>
-          <sp>
+          <sp who="#caridoro">
             <speaker>CARIDORO:</speaker>
             <l part="F">Va’ di buon animo.</l>
           </sp>
-          <sp>
+          <sp who="#eulalia">
             <speaker>EULALIA:</speaker>
             <l part="I">A Dio, Erofilo.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">A Dio, cara mia Eulalia.</l>
           </sp>
@@ -912,7 +973,7 @@
         <div>
           <head>Scena IV</head>
           <stage>Erofilo, Caridoro</stage>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l>Ch’io non la faccia chiara del grandissimo</l>
             <l>Ben ch’io le voglio, e ch’io non la certifichi</l>
@@ -954,7 +1015,7 @@
             <l>Serò ne l’acqua sin al mento e struggere</l>
             <l part="I">Mi lascerò di sete?</l>
           </sp>
-          <sp>
+          <sp who="#caridoro">
             <speaker>CARIDORO:</speaker>
             <l part="F">Foss’io, Erofilo,</l>
             <l>Pur nel tuo grado, che tolto da Sibari</l>
@@ -966,15 +1027,15 @@
             <l>Stati alloggiati alcun tempo. Ma eccolo</l>
             <l part="I">Che vien.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="M">Chi viene?</l>
           </sp>
-          <sp>
+          <sp who="#caridoro">
             <speaker>CARIDORO:</speaker>
             <l part="M">Il ruffian.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Così fossilo</l>
             <l>Portato, ma nel modo ch’egli merita.</l>
@@ -983,7 +1044,7 @@
         <div>
           <head>Scena V</head>
           <stage>Lucramo ruffiano</stage>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l>Quando si sente lodar troppo e mettere,</l>
             <l>Come si dice, in ciel beltà di femina</l>
@@ -1175,7 +1236,7 @@
         <div>
           <head>Scena I</head>
           <stage>Lucramo ruffiano, Furbo servo</stage>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l>Il Furbo ancor non ritorna. Lasciatolo</l>
             <l>Ho in piazza dianzi, ch’un danar mi comperi</l>
@@ -1195,12 +1256,12 @@
             <l>Non te lo vegghi e le cervella spargere</l>
             <l>Inanzi a’ piedi, apri l’orecchie, e ascoltami.</l>
           </sp>
-          <sp>
+          <sp who="#furbo">
             <speaker>FURBO:</speaker>
             <l>Aprirò la bocca anco, acciò che m’entrino</l>
             <l part="I">Meglio le tue parole.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="F">Anzi pur chiudila.</l>
             <l>Nel resto poi, di sopra e di sotto, apriti</l>
@@ -1208,11 +1269,11 @@
             <l>La lingua, se di questo ch’io communico</l>
             <l part="I">Teco, tu parli.</l>
           </sp>
-          <sp>
+          <sp who="#furbo">
             <speaker>FURBO:</speaker>
             <l part="M">Io tacerò.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="F">Ora ascoltami.</l>
             <l>Tu sai che da sei giorni in qua continua-</l>
@@ -1238,31 +1299,31 @@
             <l>Ti mostri e diligente, ma sia il fingere</l>
             <l part="I">Senza mio danno: intendemi tu?</l>
           </sp>
-          <sp>
+          <sp who="#furbo">
             <speaker>FURBO:</speaker>
             <l part="F">Intendoti.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l>Or ritorniamo verso casa. Accostati</l>
             <l>All’uscio un poco; un poco ancora; or fermati.</l>
             <l>Tu di’ che ’l nochier vuol ch’oggi si carchino</l>
             <l part="I">Tutte le cose nostre?</l>
           </sp>
-          <sp>
+          <sp who="#furbo">
             <speaker>FURBO:</speaker>
             <l part="F">Così dicovi.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l>E vuol domani uscir del porto, e mettersi</l>
             <l part="I">A camino?</l>
           </sp>
-          <sp>
+          <sp who="#furbo">
             <speaker>FURBO:</speaker>
             <l part="M">Così m’ha detto.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="F">Affrettesi</l>
             <l>Dunque quel che s’ha a far. Udite, femine</l>
@@ -1311,11 +1372,11 @@
             <l>Odi: costà m’aspetta; odi la musica:</l>
             <l part="I">È tutta per amor.</l>
           </sp>
-          <sp>
+          <sp who="#furbo">
             <speaker>FURBO:</speaker>
             <l part="F">Contro ribeccola.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l>Tarda a tornar tanto che verisimile</l>
             <l>Paia che sia stato al porto, e rapportami</l>
@@ -1335,7 +1396,7 @@
         <div>
           <head>Scena II</head>
           <stage>Caridoro, Erofilo</stage>
-          <sp>
+          <sp who="#caridoro">
             <speaker>CARIDORO:</speaker>
             <l>Che faremo ora che siàn chiari; Erofilo,</l>
             <l>De la partita di costui? Parrebbeti</l>
@@ -1347,7 +1408,7 @@
             <l>Vedessimo di far che almen sì sùbito</l>
             <l part="I">Non si partisse?</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">O Caridor, parrebbemi</l>
             <l>Che si provasse ogni cosa possibile</l>
@@ -1357,19 +1418,19 @@
             <l>Del qual non so ch’io creda o ch’io m’imagini</l>
             <l part="I">Che tanto indugi a ritornar.</l>
           </sp>
-          <sp>
+          <sp who="#caridoro">
             <speaker>CARIDORO:</speaker>
             <l part="F">Se Fulcio</l>
             <l>Non lo ritrova, almen non stesse a perdere</l>
             <l part="I">Tempo: ritornasse egli!</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Non parlandogli</l>
             <l>Prima e de la partenza raguagliandolo</l>
             <l part="I">Di costui, non saprei che far.</l>
           </sp>
-          <sp>
+          <sp who="#caridoro">
             <speaker>CARIDORO:</speaker>
             <l part="F">Or eccoli,</l>
             <l>Per Dio: vengon insieme amendua, vedili.</l>
@@ -1378,14 +1439,14 @@
         <div>
           <head>Scena III</head>
           <stage>Vulpino, Fulcio servi, Caridoro, Erofilo</stage>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>Si potria, Fulcio, per salvar duo gioveni</l>
             <l>Amanti e castigar un avarissimo</l>
             <l>E ribaldo ruffiano, ordire astuzia</l>
             <l>Che fosse più di questa memorabile?</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l>Vulpin, per quella fede che grandissima</l>
             <l>Ho ne le spalle, mi par che sia simile</l>
@@ -1393,7 +1454,7 @@
             <l>In cui durezza, spine e amaritudine</l>
             <l part="I">Molta più trovi che bontade.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Abbiamoci</l>
             <l>Da confortar in questo: che venendoci</l>
@@ -1401,73 +1462,73 @@
             <l>Fallo. A che peggio possiamo noi giungere</l>
             <l part="I">Che alle mazzate?</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">E chi può me’ riceverle</l>
             <l>Di te, che ti ritruovi le più idonee</l>
             <l part="I">Spalle del mondo?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Sol le tue le vincono,</l>
             <l>Che stancherian le braccia di dieci uomini</l>
             <l>E cento mazze il giorno lograrebbono.</l>
           </sp>
-          <sp>
+          <sp who="#caridoro">
             <speaker>CARIDORO:</speaker>
             <l part="I">Par che vengan ridendo.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">I pazzi ridono</l>
             <l part="I">Di poca cosa.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Eccoli che ci aspettano.</l>
           </sp>
-          <sp>
+          <sp who="#caridoro">
             <speaker>CARIDORO:</speaker>
             <l>Pur mi giova sperar ne la letizia</l>
             <l part="I">Che mostrano.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Gli è vana: che di Lucramo</l>
             <l>Non sanno che si parta così sùbito.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="I">Dio vi salvi, patroni.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Ben abbiamone</l>
             <l>Bisogno, e ch’Egli e li Santi ci salvino.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>Anzi non vo’ che Dio o che Santi piglino</l>
             <l>Fatica di salvarvi ora, possendovi</l>
             <l>Salvar io sol: non più Vulpin mi nomino,</l>
             <l part="I">Ma la Salute.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Ohimè, non sai che Lucramo</l>
             <l part="I">È per partirsi domatina?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Partasi</l>
             <l part="I">Con tempesta.</l>
           </sp>
-          <sp>
+          <sp who="#caridoro">
             <speaker>CARIDORO:</speaker>
             <l part="F">Deh non! Che porterebbono,</l>
             <l>Con essolui, le fanciulle pericolo.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>Io vo’ che le fanciulle in terra restino</l>
             <l>E ch’egli in mar si affoghi; io, come prospera</l>
@@ -1476,17 +1537,17 @@
             <l>Ogni modo e salvar voi mi delibero;</l>
             <l part="I">Ma non crediate che si parta.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Partesi,</l>
             <l part="I">Credi a chi ’l sa.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Per spaventarvi simula</l>
             <l part="I">Di partire il ribaldo.</l>
           </sp>
-          <sp>
+          <sp who="#caridoro">
             <speaker>CARIDORO:</speaker>
             <l part="F">Non vedendoci</l>
             <l>E non sappiendoci essere ove udivasi</l>
@@ -1500,18 +1561,18 @@
             <l>Questa sera alla nave. Vulpin, renditi</l>
             <l part="I">Certo ch’egli si parte.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Ohimè, partendosi,</l>
             <l>Che fia di me? Dovunque vada Eulalia</l>
             <l part="I">Anderà il mio cor anco.</l>
           </sp>
-          <sp>
+          <sp who="#caridoro">
             <speaker>CARIDORO:</speaker>
             <l part="F">Anderà simile-</l>
             <l part="I">mente il mio con Corisca.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Se deliberi</l>
             <l>Che ’l tuo cor vada domatina, avisami.</l>
@@ -1519,23 +1580,23 @@
             <l>La sua bolletta, che non lo ritenghino</l>
             <l part="I">Ai passi.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Né sarà fuor di proposito</l>
             <l>Che facci al tuo una veste, acciò nol becchino,</l>
             <l>Trovandol nudo, li corbacci e l’aquile.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l>Ve’, Caridoro, come ci dileggiano</l>
             <l part="I">Questi furfanti gaglioffi!</l>
           </sp>
-          <sp>
+          <sp who="#caridoro">
             <speaker>CARIDORO:</speaker>
             <l part="F">Deh, misero,</l>
             <l part="I">Chi serve Amor!</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Noi che serviamo a miseri</l>
             <l>Servi, siàn, Fulcio, doppiamente miseri.</l>
@@ -1544,12 +1605,12 @@
             <l>Vulpino appresso ti dovessi mettere</l>
             <l>Tanta paura in cosa così picciola...</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l>Picciola questa? E qual altra puote essere</l>
             <l part="I">Grande se questa è picciola?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Guardatemi</l>
             <l>In viso: parte il ruffian? Vo’ concedere</l>
@@ -1559,45 +1620,45 @@
             <l>In braccio, a te Corisca; e questo Lucramo</l>
             <l>Sì arrogante tosar come una pecora.</l>
           </sp>
-          <sp>
+          <sp who="#caridoro">
             <speaker>CARIDORO:</speaker>
             <l part="I">O Vulpino da bene!</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Da benissimo!</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>Ma dimmi, hai tu apparecchiate le forbici,</l>
             <l part="I">Ch’io dissi da tosar?</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Che forbici hami tu</l>
             <l part="I">Detto?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Non ti dissi io che facessi opera</l>
             <l>D’aver in man le chiavi de la camera</l>
             <l part="I">Di tuo padre?</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="M">L’ho avute.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">E si mandassino</l>
             <l>Fuor tutti i servi di casa, e più il Nebbia</l>
             <l part="I">De gli altri?</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="M">Tutto è fatto.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Ecco le forbici</l>
             <l>Ch’io domandavo; Or attendi et ascoltami:</l>
@@ -1611,12 +1672,12 @@
             <l>Deve domani: pur ier giunse e statoci</l>
             <l part="I">Mai più non è.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Che m’appertiene intendere</l>
             <l part="I">Cotesto?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Tel dirò, ascoltami: vogliolo</l>
             <l>Vestir co’ panni di tuo padre. Metterli</l>
@@ -1631,29 +1692,29 @@
             <l>A tuo padre, stivata di finissimi</l>
             <l part="I">Filati d’oro.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="M">E che n’ha a far?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Che a Lucramo</l>
             <l>La porti, gli la lasci pegno e facciasi</l>
             <l part="I">Dar Eulalia.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">La lasci in mano a Lucramo?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="I">A Lucramo.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="M">Al ruffian?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Al ruffian; odimi</l>
             <l>Un poco: vo’ che dia la cassa a Lucramo,</l>
@@ -1663,82 +1724,82 @@
             <l>Il prezzo il qual mostrerà di concludere</l>
             <l part="I">Con lui.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">T’ho ben inteso: come diavolo</l>
             <l part="I">Che la lasci a un ruffiano?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">E che la femina</l>
             <l>Si faccia dar. Voglio che andiàn poi subito...</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l>Parla pur d’altro: in mano a un barro, a un perfido,</l>
             <l>Al maggior ladroncel del mondo, mettere</l>
             <l part="I">Roba di tanta valuta?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">A me lasciane</l>
             <l part="I">La cura: ascolta.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">È di troppo pericolo.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>Non è, s’ascolti. Si potrà poi facile-</l>
             <l part="I">mente...</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="M">Che facilemente?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Se stai tacito,</l>
             <l>Te lo dirò: gli è di bisogno, Erofilo,</l>
             <l part="I">Qualunque vuol...</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Deh che ciance, che favole</l>
             <l part="I">Son queste che aviluppi?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Non volendomi</l>
             <l part="I">Udir, tuo danno: ben io pazzo...</l>
           </sp>
-          <sp>
+          <sp who="#caridoro">
             <speaker>CARIDORO:</speaker>
             <l part="F">Lascialo</l>
             <l part="I">Dir.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="M">Dica.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">... a travagliarmi in voler utile</l>
             <l>Far a chi non lo vuol. Mi mangi il cancaro</l>
             <l part="I">Se più.</l>
           </sp>
-          <sp>
+          <sp who="#caridoro">
             <speaker>CARIDORO:</speaker>
             <l part="F">Non ti partir: t’udirà. – Odilo.</l>
             <l>– Non ti partir, Vulpin, ritorna. – Ascoltalo</l>
             <l part="I">Un poco tu.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Che vòi tu dir? Ascoltoti.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>Quel ch’io vo’ dir? Tu mi preghi e mi stimuli,</l>
             <l>E tutto il dì consumi, ch’io m’industrii</l>
@@ -1754,7 +1815,7 @@
             <l>Che pensi tu con tuoi sospiri e lagrime</l>
             <l>Poter piegar questo ruffian a dartila?</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l>Pur mi parrebbe gran sciocchezza a mettere</l>
             <l>Cosa di tanta valuta a pericolo</l>
@@ -1767,7 +1828,7 @@
             <l>Da tosar noi coteste, e non la pecora,</l>
             <l part="I">Che detto m’hai.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Mi stimi tu sì, Erofilo,</l>
             <l>Di poco ingegno, ch’io volessi perdere</l>
@@ -1781,7 +1842,7 @@
             <l>Ne la persona, o mi farebbe in carcere,</l>
             <l part="I">Morir di fame.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">E che via c’è, ponendola</l>
             <l>In mano di costui, poi di levarglila,</l>
@@ -1793,18 +1854,18 @@
             <l>Se gli porta con lui, dimmi: a che termine</l>
             <l part="I">Ci ritroviamo?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">S’averai pazienzia</l>
             <l>D’udirmi, troverai che buono et ottimo</l>
             <l>Disegno è il mio; e che c’è modo facile</l>
             <l>Che questa notte ancora si riabbiano.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="I">Or su t’ascolto: di’.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Tosto che data la</l>
             <l>Cassa abbia il nostro mercadante a Lucramo,</l>
@@ -1816,11 +1877,11 @@
             <l>Che sia stato un ruffiano il quale t’abita</l>
             <l part="I">Vicino.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="M">Intendo.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">E gli è cosa credibile,</l>
             <l>Poi ch’è ruffiano, che ladro possa esseri.</l>
@@ -1830,13 +1891,13 @@
             <l>Ti sarà appresso il padre, e farà muovere</l>
             <l part="I">Immantinente il bargello.</l>
           </sp>
-          <sp>
+          <sp who="#caridoro">
             <speaker>CARIDORO:</speaker>
             <l part="F">Gli è facile</l>
             <l>Cosa cotesta. Io verrò, bisognandoci,</l>
             <l part="I">Anco in persona.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Gli saren sì subito</l>
             <l>Adosso, che la cassa trovaremovi,</l>
@@ -1853,11 +1914,11 @@
             <l>Che n’abbiàn noi a far? Per le tristizie</l>
             <l>Sue, in ogni modo, e questo e peggio merita</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l>Ben, per Dio, è bel disegno e può succedere.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>Tu, Caridoro, preso che sia Lucramo,</l>
             <l>Essendo l’uom che sei, per te medesimo</l>
@@ -1871,35 +1932,35 @@
             <l>In dono, se te gli mostrerai d’essere</l>
             <l>Con tuo padre e con gli altri favorevole.</l>
           </sp>
-          <sp>
+          <sp who="#caridoro">
             <speaker>CARIDORO:</speaker>
             <l>Per Dio, Vulpino, una corona meriti.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="I">Anzi una bella mitra.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Non può, Fulcio,</l>
             <l>Alle tue dignitadi ognuno ascendere.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l>Or dove è questo tuo, che porre in abito</l>
             <l part="I">Vogliàn di mercadante?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Maravigliomi</l>
             <l>Che non sia qui; ma non può stare a giungere.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l>Vòi ch’egli stesso la cassa si carichi</l>
             <l part="I">In collo?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">A questo è preso anco un buon ordine:</l>
             <l>Egli ha seco un villano del medesimo</l>
@@ -1910,28 +1971,28 @@
             <l>Veste e quell’altre cose che bisognano,</l>
             <l part="I">Che giunto qui non stia a bada.</l>
           </sp>
-          <sp>
+          <sp who="#caridoro">
             <speaker>CARIDORO:</speaker>
             <l part="F">Voletevi</l>
             <l part="I">Servire in altro di me?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Ritornartene</l>
             <l>Puoi, Caridoro, a casa: ben faremoti</l>
             <l part="I">Tutto il successo intendere.</l>
           </sp>
-          <sp>
+          <sp who="#caridoro">
             <speaker>CARIDORO:</speaker>
             <l part="F">Andaròmene,</l>
             <l part="I">A Dio.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Se non vi accade altro servizio</l>
             <l part="I">Da me, anderò con mio patrone.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Vattene.</l>
           </sp>
@@ -1939,7 +2000,7 @@
         <div>
           <head>Scena IV</head>
           <stage>Vulpino, Trappola barro, Brusco villano</stage>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>(Io dovea pur ricordarmi che ’l Trappola</l>
             <l>Solea dir ver rade volte. Ben semplice</l>
@@ -1952,75 +2013,75 @@
             <l>Per Dio! Poi che gli è qui, spero che prospera-</l>
             <l>mente ogni cosa mi debbia succedere.)</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l>Gli è pur gran fatto, Brusco, ch’un servizio</l>
             <l>Tu non sappia mai far, ch’uom te n’abbia obligo.</l>
           </sp>
-          <sp>
+          <sp who="#brusco">
             <speaker>BRUSCO:</speaker>
             <l>Gli è maggior fatto che non abbi, Trappola,</l>
             <l>Maisì da far per te, che non ti dieno</l>
             <l>Le cose d’altri che non t’appertengono</l>
             <l part="I">Da far ancora.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Mie le cose reputo</l>
             <l>Di Vulpino né men che le mie proprie;</l>
             <l>E questa è la mia usanza et appertiemmesi</l>
             <l>Procacciar sempremai nuove amicizie.</l>
           </sp>
-          <sp>
+          <sp who="#brusco">
             <speaker>BRUSCO:</speaker>
             <l>Se tua usanza è acquistar nove amicizie</l>
             <l>E ti appertien, con tua fatica acquistale;</l>
             <l>Né voler dar a me né agli altri incommodo,</l>
             <l>Che non abbiamo simil desiderio.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="I">E che avevamo a far?</l>
           </sp>
-          <sp>
+          <sp who="#brusco">
             <speaker>BRUSCO:</speaker>
             <l part="F">Per li buoi mettere</l>
             <l>Del fieno in nave, e per il nostro vivere</l>
             <l>Fornirci de le cose che bisognano.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="I">Ci sarà tempo.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Mi credevo, Trappola,</l>
             <l part="I">Che tu m’avessi ingannato.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Rincrescemi</l>
             <l>Per Dio, Vulpin, ch’io t’abbia fatto credere</l>
             <l>Il falso: ma non ci ebbi più avertenzia.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="I">Tu vien su molta gravità.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Dovendomi</l>
             <l>Oggi far uomo grave, è convenevole</l>
             <l part="I">Che ’l passo impari a far grave.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Dovrestilo</l>
             <l>Tu saper me’ d’ogn’altro, che sei solito</l>
             <l>Spesso andar co’ ferri a’ piè per meriti</l>
             <l part="I">Tuoi.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Chi vi suol ir più di te? Che bestia</l>
             <l>Non è di trotto sì duro che apprendere</l>
@@ -2029,7 +2090,7 @@
             <l>Portar le balze avesse come fattole</l>
             <l part="I">Ha portar a te il tuo.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Vien dentro; lascia le</l>
             <l>Ciance, che non abbiàn tempo da perdere.</l>
@@ -2038,7 +2099,7 @@
         <div>
           <head>Scena V</head>
           <stage>Brusco solo</stage>
-          <sp>
+          <sp who="#brusco">
             <speaker>BRUSCO:</speaker>
             <l>Per Dio, son quasi in pensier di tornarmene</l>
             <l>All’albergo e lasciar qui questa bestia</l>
@@ -2098,7 +2159,7 @@
         <div>
           <head>Scena I</head>
           <stage>Vulpino, Trappola, Erofilo</stage>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>Prima che tu ti parta da noi, metteti</l>
             <l>Molto ben quel ch’io t’ho detto a memoria,</l>
@@ -2109,7 +2170,7 @@
             <l>Al primo canto a man manca; indi numera</l>
             <l part="I">Fin al quinto uscio.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Che accade che replichi</l>
             <l>Tanto? Oggimai t’avrebbe inteso un asino.</l>
@@ -2117,7 +2178,7 @@
             <l>Qui e daròvela in mano, e voi menatela</l>
             <l part="I">Dove volete.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Ci potrebbe Lucramo</l>
             <l>Vedere insieme, o altri, e riferirglilo.</l>
@@ -2125,63 +2186,63 @@
             <l>Nostre trame scoperte, e guasterebbesi</l>
             <l part="I">Il tutto.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="M">Dunque non dir più.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">È una picciola</l>
             <l part="I">Porta fatta di novo.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Io l’ho in memoria.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="I">La donna de la casa...</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="M">Io ’l so.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">... si nomina</l>
             <l part="I">Lena; all’incontro è uno sporto.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">M’infracidi.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l>Or non gli dar più tante ciance; andiamolo</l>
             <l>Pur noi ad aspettar. Non è possibile</l>
             <l part="I">Ch’egli erri.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Come tu sia giunto al svolgere</l>
             <l>Del canto, fa’ che ti sentiamo; ziffola,</l>
             <l part="I">Che ti verremo incontro.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Ho la bocca arida</l>
             <l>Così di sete, che mi fia difficile</l>
             <l part="I">A ziffolar.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Avrai da ber in copia.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="I">Vorrei già aver bevuto.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Meglio, sobrio,</l>
             <l>Avrai teco il cervello: or va’, ricordati</l>
@@ -2193,14 +2254,14 @@
             <l>L’avrà posta: ch’a un tratto io possa mettervi</l>
             <l part="I">Su le mani.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Io t’ho inteso; non mi rompere</l>
             <l>Il capo più. Se a cena così prodigo</l>
             <l>Sarai nel darmi ber come ora chiacchiare,</l>
             <l part="I">La cosa anderà gaia.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Or su lasciamolo;</l>
             <l>E se per noi c’è da far altro, facciasi.</l>
@@ -2209,22 +2270,22 @@
         <div>
           <head>Scena II</head>
           <stage>Brusco, Trappola</stage>
-          <sp>
+          <sp who="#brusco">
             <speaker>BRUSCO:</speaker>
             <l>Spacciati tosto; non mi far più perdere</l>
             <l part="I">Tempo.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Che fretta hai tu? Chi ti solicita?</l>
           </sp>
-          <sp>
+          <sp who="#brusco">
             <speaker>BRUSCO:</speaker>
             <l>Ti par che senza me tutt’oggi debbano</l>
             <l>Restar i buoi, che festuca non abbiano</l>
             <l part="I">Di fieno inanzi?</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Avranno agio di pascersi</l>
             <l>Quanto la notte è lunga, a suo gran comodo.</l>
@@ -2233,14 +2294,14 @@
             <l>Questa cena ove abbiamo a star in gaudio</l>
             <l part="I">Con damigelle e in chiaranzana.</l>
           </sp>
-          <sp>
+          <sp who="#brusco">
             <speaker>BRUSCO:</speaker>
             <l part="F">Restavi</l>
             <l>Pur tu, se vòi; ch’io, tosto che levatomi</l>
             <l>Ho la cassa di collo, il collo rompere</l>
             <l>Mi possi s’io t’aspetto pur un atimo.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l>Taci, ch’io sento aprir l’uscio. Debbe essere</l>
             <l>Questo il ruffian che di ribaldo ha l’aria.</l>
@@ -2249,30 +2310,30 @@
         <div>
           <head>Scena III</head>
           <stage>Lucramo, Trappola</stage>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l>Meglio m’è uscir di casa che mi assordino</l>
             <l>Queste cicale, che ’l capo mi rompano,</l>
             <l>Che mi struggano, infracidino, uccidano.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l>(Portano gli altri del loro essercizio</l>
             <l>Sul petto il segno, e costui l’ha notabile</l>
             <l part="I">Sopra la faccia.)</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="F">Voi farete, femine,</l>
             <l>A modo mio; se vi crepasse l’anima,</l>
             <l part="I">Fin che starete meco.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F"> (Me lo mostrano</l>
             <l part="I">Le parole anco più.)</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="F">Quanta superbia,</l>
             <l>Quanta insolenzia han queste porche! Cercano</l>
@@ -2282,13 +2343,13 @@
             <l>D’usarti fraude e tradimento; l’animo</l>
             <l>Lor tutto è di cacciarte in precipizio.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l>(Costui, per quel ch’io sento, si de’ accorgere</l>
             <l>Che comprar voglio, che cerca, lodandomi</l>
             <l>Tanto le merci sue, pormele in grazia.)</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l>S’avesse un uom tutte le scelleraggini</l>
             <l>Commesse che si possano commettere,</l>
@@ -2302,43 +2363,43 @@
             <l>Mai con orazïon santi ne l’eremo,</l>
             <l>Con discipline, digiuni e vigilie.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l>(E s’elle duran teco e non s’impiccano,</l>
             <l>Più che di Iob è la lor pazïenzia.)</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l>(Costui che viene in qua, pur or debbe essere</l>
             <l>Di nave uscito, che ’l fachino carico</l>
             <l part="I">Si mena dietro.)</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Secondo l’indizio</l>
             <l>Ch’io n’ho, in questo contorno questo uomo abita:</l>
             <l>Ecco la casa grande, ecco la picciola</l>
             <l>Strada; i duo sporti qui dietro rimangono.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l>(Costui debbe cercar dove si mettere</l>
             <l>Senza ire all’oste; volentier starebbesi</l>
             <l part="I">A Francolino.)</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Ecco chi può informarmene.</l>
             <l>Dimmi, uom da ben, perché io son qui mal pratico…</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO</speaker>
             <l>E quanto tu ci debbi esser mal pratico!</l>
             <l>Io non ho il nome c’hai detto, e non ebbelo</l>
             <l>Mio patre mai, né mai l’ebbe mio avolo,</l>
             <l part="I">Né mai alcun del sangue mio.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Perdonami</l>
             <l>Se, per non saper più, t’ho fatto ingiuria</l>
@@ -2346,131 +2407,131 @@
             <l>Pessima: ma, per Dio tu potresti essere</l>
             <l>Colui ch’io cerco, o de la sua progenie.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="I">Chi cerchi tu?</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Cerco un ghiottone, un perfido,</l>
             <l part="I">Un barro, un giuntator, un ladro.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="F">Fermati,</l>
             <l>Che tu sei su la traccia: il nome proprio?</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l>Il nome proprio? Ha nome… Or ora avevolo</l>
             <l>In bocca e non so quel che divenutone</l>
             <l part="I">Sia.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="F">L’averai sputato o ingiottitolo.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l>Sputato l’ho più tosto: che sì fetido</l>
             <l>Cibo mandar non potrei ne lo stomaco,</l>
             <l>O saria forza vomitarlo sùbito.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO</speaker>
             <l part="I">Coglilo dunque de la polve.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Possoti</l>
             <l>Con tante qualità costui dipingere,</l>
             <l>Che far potremo senza il nome proprio</l>
             <l>Tuttavia grida, riniega, biastemia.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l>Chi si terrebbe, avendo in casa femine</l>
             <l part="I">Come io?</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="M">Bugiardo, pergiuro.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="F">Appertengono</l>
             <l>Queste condizïoni al mio essercizio.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l>E falsa le monete e tosa e sfogliale.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l>Pur che ci fusse il modo, il maggior utile</l>
             <l part="I">Non è di questo.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">È marïolo e taglia le</l>
             <l part="I">Borse.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="F">Il saper giocar di mano reputi</l>
             <l part="I">Poca virtude?</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="M">È ruffiano.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="F">L’industria</l>
             <l part="I">Mia principal.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Riportator maledico,</l>
             <l>Seminator di discordie e di scandali.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l>Non ti affaticar più, senza alcun dubbio</l>
             <l>Tu di me cerchi. Ricordare il proprio</l>
             <l>Mio nome ti voglio anco: ho nome Lucramo.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="I">Lucramo col malanno!</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="M">A te sol.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Lucramo</l>
             <l part="I">Cerco a punto.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="F">Io son quel che cerchi. Or narrami:</l>
             <l part="I">Che vòi da me?</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Fa’ prima che si scarichi</l>
             <l>Costui là in casa, e poi ti farò intendere</l>
             <l part="I">Quel ch’io voglio da te.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="F">Va’ dentro; mettila</l>
             <l>Dove ti pare. O femine, aiutatelo</l>
             <l part="I">A scaricar.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">L’altr’ieri essendo a Napoli,</l>
             <l>Un signor de li grandi che vi sieno,</l>
@@ -2492,25 +2553,25 @@
             <l>Se Elene fosson tutte o fosson Veneri:</l>
             <l part="I">Saldiàn pur il mercato?</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="F">Ho già vendutole,</l>
             <l>E n’ho l’arra, e domani tornar debbono</l>
             <l part="I">Col prezzo i compratori, pur...</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Intendoti:</l>
             <l>Tu vuoi dir che i partiti entrar fan gli uomini</l>
             <l part="I">In galea.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="F">Tu la intendi: gli è mio officio,</l>
             <l>Senza rispetto, a chi mi dà più attendere;</l>
             <l part="I">Andiamo in casa.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Non mi gravò spendere</l>
             <l>Già mai, pur che le merci il pregio vagliano.</l>
@@ -2519,7 +2580,7 @@
         <div>
           <head>Scena IV</head>
           <stage>Stamma fantesca, Lucramo</stage>
-          <sp>
+          <sp who="#stamma">
             <speaker>STAMMA:</speaker>
             <l>Che li calciari miei non rimanessmo,</l>
             <l>Padrone, in mano al zabattaio, avendoci</l>
@@ -2529,12 +2590,12 @@
             <l>Cinque quattrini, che tanto d’avermili</l>
             <l part="I">Racconci domanda egli.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="F">Non mi rompere</l>
             <l part="I">Il capo, bestia.</l>
           </sp>
-          <sp>
+          <sp who="#stamma">
             <speaker>STAMMA:</speaker>
             <l part="F">Io son sempre una bestia,</l>
             <l>Ch’io gli domando. Non è verso i poveri</l>
@@ -2571,7 +2632,7 @@
         <div>
           <head>Scena V</head>
           <stage>Brusco</stage>
-          <sp>
+          <sp who="#brusco">
             <speaker>BRUSCO:</speaker>
             <l>Egli è entrato qua dentro in una chiacchiera,</l>
             <l>Che non sarà sì tosto per concludere.</l>
@@ -2604,80 +2665,80 @@
         <div>
           <head>Scena VI</head>
           <stage>Riccio, Bruno, Corbo, Nebbia, Rosso servi</stage>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l>Gli è certo un gentil giovene Filostrato,</l>
             <l part="I">Umano e liberal.</l>
           </sp>
-          <sp>
+          <sp who="#bruno">
             <speaker>BRUNO:</speaker>
             <l part="F">Questi son uomini</l>
             <l>Da servir, li quali poco ti affaticano</l>
             <l part="I">E ti dan da ber molto.</l>
           </sp>
-          <sp>
+          <sp who="#nebbia">
             <speaker>NEBBIA:</speaker>
             <l part="F">E che abondanzia</l>
             <l>Era di carne sopra quella tavola!</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l>Parliàn del vino, che m’ha tocco l’anima.</l>
           </sp>
-          <sp>
+          <sp who="#rosso">
             <speaker>ROSSO:</speaker>
             <l>Mai non vidi il più chiaro né il più simile</l>
             <l part="I">A topazio.</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="F">Gustaste il più odorifero</l>
             <l part="I">O il più suave già mai?</l>
           </sp>
-          <sp>
+          <sp who="#riccio">
             <speaker>RICCIO:</speaker>
             <l part="F">Non sentivi tu</l>
             <l>Come piccava e la lingua mordevati?</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l>Dolci quei morsi! Più che i baci vagliono</l>
             <l>Di queste bocche vermiglie di mascare.</l>
           </sp>
-          <sp>
+          <sp who="#rosso">
             <speaker>ROSSO:</speaker>
             <l>N’avessi io questa notte ne la camera</l>
             <l part="I">Una guastada!</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="F">Io a capo il letto un’anfora!</l>
           </sp>
-          <sp>
+          <sp who="#riccio">
             <speaker>RICCIO:</speaker>
             <l>Avessi pur la botte al mio dominio!</l>
           </sp>
-          <sp>
+          <sp who="#bruno">
             <speaker>BRUNO:</speaker>
             <l>Venisse ogni dì pur voglia ad Erofilo</l>
             <l part="I">Di mandarci a servirlo.</l>
           </sp>
-          <sp>
+          <sp who="#riccio">
             <speaker>RICCIO:</speaker>
             <l part="F">Sì, dovendoci</l>
             <l part="I">Sì ben trattar.</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="F">Non so come si trovino</l>
             <l>Gli altri; io per me mi trovo in tanto gaudio</l>
             <l>Che mi par non capir in me medesimo.</l>
           </sp>
-          <sp>
+          <sp who="#rosso">
             <speaker>ROSSO:</speaker>
             <l>Credo che si troviamo tutti a un termine.</l>
           </sp>
-          <sp>
+          <sp who="#nebbia">
             <speaker>NEBBIA:</speaker>
             <l>Così a un termine tutti ci trovassimo,</l>
             <l>Quando tornerà il vecchio; concordatici</l>
@@ -2685,19 +2746,19 @@
             <l>Ma, come il patron torna, restar dubito</l>
             <l>Io sol che paghi lo scotto e smaltiscalo.</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l>Del mal ch’ancor non hai, perché vòi metterti</l>
             <l>Affanno, bestia? Se non senti pungerti,</l>
             <l>Non trar del cul. Che sai che possa nascere?</l>
           </sp>
-          <sp>
+          <sp who="#nebbia">
             <speaker>NEBBIA:</speaker>
             <l>Io non son già né profeta né astrologo,</l>
             <l>Ma, come torni a casa, vedrai essere</l>
             <l>Tutto successo quel ch’oggi dicevoti.</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l>Non son anche io né profeta né astrologo,</l>
             <l>E pur ti voglio predir che mal essito</l>
@@ -2720,14 +2781,14 @@
             <l>Brilla il cervel saresti pazzo: parloti</l>
             <l part="I">D’amico.</l>
           </sp>
-          <sp>
+          <sp who="#nebbia">
             <speaker>NEBBIA:</speaker>
             <l part="F">Poi che mi dicesti il simile,</l>
             <l>Oggi ci ho molto ben pensato; e all’ultimo</l>
             <l>Concludo che tu mi dì il vero, e voglioti</l>
             <l part="I">Ogni modo ubidir.</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="F">Ti sarà utile.</l>
           </sp>
@@ -2735,73 +2796,73 @@
         <div>
           <head>Scena VII</head>
           <stage>Trappola, Corbo, Nebbia, Rosso, Bruno, Riccio</stage>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l>(Questo villano si è partito? Oh che asino,</l>
             <l part="I">Che gaglioffo indiscreto!)</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="F">Vedi, Nebbia,</l>
             <l part="I">Vedi?</l>
           </sp>
-          <sp>
+          <sp who="#nebbia">
             <speaker>NEBBIA:</speaker>
             <l part="F">Veggo: non è quella la giovane</l>
             <l part="I">Che Erofilo ama?</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="M">Mi par dessa.</l>
           </sp>
-          <sp>
+          <sp who="#nebbia">
             <speaker>NEBBIA:</speaker>
             <l part="F">Paiati</l>
             <l part="I">Dessa, perché gli è dessa certo.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">(Andarsene</l>
             <l part="I">Senza far motto il gaglioffone.)</l>
           </sp>
-          <sp>
+          <sp who="#nebbia">
             <speaker>NEBBIA:</speaker>
             <l part="F">Debbela</l>
             <l part="I">Aver colui comperata.</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="F">O prestatali</l>
             <l part="I">L’ha il ruffian forse.</l>
           </sp>
-          <sp>
+          <sp who="#nebbia">
             <speaker>NEBBIA:</speaker>
             <l part="F">Se comincia a mettere</l>
             <l>La botte a mano, senza molto spendere</l>
             <l>Nostro patrone avrà da bere, e trarsene</l>
             <l part="I">Potrà la sete.</l>
           </sp>
-          <sp>
+          <sp who="#rosso">
             <speaker>ROSSO:</speaker>
             <l part="F">Molto meglio trarlami</l>
             <l part="I">Potria il vin d’oggi.</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="M">Et a me ancor.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">(Si è sùbito</l>
             <l>Fatto notte, e ch’io meni questa giovane</l>
             <l part="I">Solo non è molto sicur.)</l>
           </sp>
-          <sp>
+          <sp who="#bruno">
             <speaker>BRUNO:</speaker>
             <l part="F">Fermiamoci:</l>
             <l part="I">Vediamo ove la meni.</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="F">Nascondetevi</l>
             <l>Dietro a quel canto voi; noi ritraemoci</l>
@@ -2809,90 +2870,90 @@
             <l>Da quella porta, pian pian seguitiamoli,</l>
             <l>Per saper riguagliar del tutto Erofilo.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l>(Poi ch’io mi trovo sol, mi pento d’essere</l>
             <l part="I">Entrato in ballo.</l>
           </sp>
-          <sp>
+          <sp who="#riccio">
             <speaker>RICCIO:</speaker>
             <l part="F">O sventurato Erofilo!</l>
             <l>Oh come noi gli daren mal annunzio!</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="I">Vogliàn far un bel tratto?</l>
           </sp>
-          <sp>
+          <sp who="#nebbia">
             <speaker>NEBBIA:</speaker>
             <l part="M">Che?</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="F">Levarglila.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l>(Pur bisogna ire inanzi e far buono animo.)</l>
           </sp>
-          <sp>
+          <sp who="#bruno">
             <speaker>BRUNO:</speaker>
             <l part="I">Cancaro a chi si pente.</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="F">A me, pentendomi,</l>
             <l part="I">Venga.</l>
           </sp>
-          <sp>
+          <sp who="#riccio">
             <speaker>RICCIO:</speaker>
             <l part="M">Venga a me ancora.</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="F">Verrà al Nebbia,</l>
             <l part="I">Che non risponde.</l>
           </sp>
-          <sp>
+          <sp who="#nebbia">
             <speaker>NEBBIA:</speaker>
             <l part="F">Quando gli altri vogliano</l>
             <l part="I">Farlo, lo farò anche io.</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="F">Miglior principio</l>
             <l>Di questo aver non pòi per farti Erofilo</l>
             <l part="I">Amico.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <l part="F">– Non ti affligger, bella giovane</l>
             <l part="I">Che tu non vai con nimici. –</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="F">Lasciamolo</l>
             <l>Scostar un po’ da la casa di Lucramo,</l>
             <l part="I">Poi siamo a’ fatti.</l>
           </sp>
-          <sp>
+          <sp who="#nebbia">
             <speaker>NEBBIA:</speaker>
             <l part="F">E se grida e ci accorrano</l>
             <l part="I">De le persone?</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="F">Non potranno giungere</l>
             <l>A tempo; e trovi pochi che si vogliano</l>
             <l>Mover la notte quando rumor sentano</l>
             <l part="I">Di fuori.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">– Non guastar con queste lagrime</l>
             <l part="I">Così polite guance. –</l>
           </sp>
-          <sp>
+          <sp who="#nebbia">
             <speaker>NEBBIA:</speaker>
             <l part="F">Dove, tolta che</l>
             <l>La sia, l’abbiàn noi a condur? Che metterla</l>
@@ -2901,34 +2962,34 @@
             <l>mente vederla entrar e a farci mettere</l>
             <l>Le mani adosso saria troppo indizio.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l>– Ti par sì duro il partirti da Sibari? –</l>
           </sp>
-          <sp>
+          <sp who="#rosso">
             <speaker>ROSSO:</speaker>
             <l part="I">Dove si menerà dunque?</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="F">Che diavolo</l>
             <l part="I">So io?</l>
           </sp>
-          <sp>
+          <sp who="#nebbia">
             <speaker>NEBBIA:</speaker>
             <l part="F">Fia dunque da non travagliarcene.</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l>Voi non farete ch’io non voglia pentirmene,</l>
             <l>E che per questo a venir m’abbia il cancaro.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l>– Non pianger, non versar per questo lagrime,</l>
             <l part="I">Che non andrai lontana molto –</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="F">Menisi</l>
             <l>A casa di Galante, che di Erofilo</l>
@@ -2936,136 +2997,136 @@
             <l>Come sapete, in luogo solitario</l>
             <l part="I">Lungo le mura.</l>
           </sp>
-          <sp>
+          <sp who="#riccio">
             <speaker>RICCIO:</speaker>
             <l part="F">Dice bene: è commodo</l>
             <l part="I">Il luogo e più la persona.</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="F">Moviamoci:</l>
             <l>Voi lo terrete a bada e sonaretelo</l>
             <l>Con pugni e calci se fa resistenzia,</l>
             <l>Il Nebbia et io menaremo la giovane.</l>
           </sp>
-          <sp>
+          <sp who="#bruno">
             <speaker>BRUNO:</speaker>
             <l>Non più parole: inanzi valent’uomini.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l>(Ohimè, chi son costoro che ci vengono</l>
             <l part="I">Dietro in tal fretta?)</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="F">Mercadante, fermati:</l>
             <l part="I">Che roba è questa?</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Non accade intenderlo</l>
             <l>A te, ch’io non te n’ho da pagar dazio.</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l>Tu non ne déi né bolletta né pollizza</l>
             <l>Aver pigliata, e pensavi menartila</l>
             <l>Di contrabando. S’hai bolletta, mostrala.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l>Guardami a basso, e l’annello ritrovaci</l>
             <l part="I">Da bollar. Che bolletta?</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="F">Non trovandoti</l>
             <l part="I">Bolletta, cadi in frodo.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Non si pigliano</l>
             <l>Di simil cose bollette, né pagasi</l>
             <l>Dazio ove più del guadagno è la perdita.</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l>Perdita ben dicesti, che perdutala</l>
             <l>Hai per voler fraudar il dazio: lasciala.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l>A questo modo credete levarmila?</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="I">Lasciala, ti dico io.</l>
           </sp>
-          <sp>
+          <sp who="#bruno">
             <speaker>BRUNO:</speaker>
             <l part="M">Lasciala.</l>
           </sp>
-          <sp>
+          <sp who="#riccio">
             <speaker>RICCIO:</speaker>
             <l part="F">Tagliali,</l>
             <l part="I">Se non la lascia, il braccio.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Si assassinano</l>
             <l>Dunque così li forestieri in Sibari?</l>
           </sp>
-          <sp>
+          <sp who="#nebbia">
             <speaker>NEBBIA:</speaker>
             <l>Eulalia, andiamo a trovar il tuo Erofilo...</l>
           </sp>
-          <sp>
+          <sp who="#corbo">
             <speaker>CORBO:</speaker>
             <l part="I">Cacciali un occhio, se non tace.</l>
           </sp>
-          <sp>
+          <sp who="#bruno">
             <speaker>BRUNO:</speaker>
             <l part="F">Spezzali</l>
             <l part="I">Il capo.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Aiuto! Aiuto! Soccorretemi,</l>
             <l part="I">Cittadini!</l>
           </sp>
-          <sp>
+          <sp who="#rosso">
             <speaker>ROSSO:</speaker>
             <l part="F">Che fate, che tagliatali</l>
             <l part="I">Già non avete la lingua?</l>
           </sp>
-          <sp>
+          <sp who="#bruno">
             <speaker>BRUNO:</speaker>
             <l part="F">Difendesi</l>
             <l part="I">Coi denti.</l>
           </sp>
-          <sp>
+          <sp who="#rosso">
             <speaker>ROSSO:</speaker>
             <l part="F">Tien, fin ch’io piglio quel ciottolo,</l>
             <l>E tutti ad un ad un quanti n’ha svellogli.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l>A questa guisa, ribaldi, levatami</l>
             <l part="I">Avete la mia femina?</l>
           </sp>
-          <sp>
+          <sp who="#bruno">
             <speaker>BRUNO:</speaker>
             <l part="F">Lasciamolo</l>
             <l part="I">Gracchiare, andiamo.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">(Che debb’io far misero?</l>
             <l>Io li vo’ seguitar; se mi dovessino</l>
             <l>Uccider, per veder dove la menano.)</l>
           </sp>
-          <sp>
+          <sp who="#bruno">
             <speaker>BRUNO:</speaker>
             <l>Dove vai tu? Se non ti lievi sùbito,</l>
             <l>E pigli un’altra strada, più minuccioti</l>
@@ -3074,7 +3135,7 @@
             <l>Se ti pretendi ragion ne la femina,</l>
             <l>Trovati inanzi al Consultor del dazio.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l>(Son mal condotto: m’han tolto la femina,</l>
             <l>Gittato in terra e pel fango rivoltomi,</l>
@@ -3085,166 +3146,166 @@
         <div>
           <head>Scena VIII</head>
           <stage>Erofilo, Vulpino, Trappola</stage>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l>Così, venendo pian piano, condottici</l>
             <l>Siàn fin a casa, né incontrato il Trappola</l>
             <l>Abbiamo ancor, che ci meni la giovane.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>Non passiamo più inanzi, che lasciandoci</l>
             <l>Veder, potremmo far qualche disordine.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l>(Con che fronte posso io dove sia Erofilo</l>
             <l part="I">Comparir?)</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Parmi ’l veder. Ma la giovane</l>
             <l part="I">Non c’è.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">(Che gli dirò che mi giustifichi?)</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="I">Non ci veggo la cassa.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">(Che preambulo</l>
             <l>Serà il mio a dirli che tolta me l’abbiano?)</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="I">Andiamo a ritrovarlo.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">(Come credere</l>
             <l>Mi potrà che per forza e non di propria</l>
             <l>Volontade abbia lasciato levarmila?)</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l>E che? Non hai possuto aver la giovane?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="I">Ove hai posta la cassa?</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Avea la giovane</l>
             <l>Avuta e tolta di casa, e menavola...</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="I">Ohimè.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">...e, come fui qui, da più di quindici</l>
             <l>Persone, che tutte a ferro lucevano...</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l>Vedi, se ci serà inframesso il diavolo.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l>...Fui circondato, che a doppio sonandomi</l>
             <l>M’han tutto pesto, e levato la femina.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="I">Te l’hanno tolta?</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">A tre colpi mi steseno</l>
             <l>In terra tramortito, e me ne diedero</l>
             <l>Cento e cent’altri appresso. Al fin, credendosi</l>
             <l part="I">D’avermi morto, mi lasciâr.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Et hannosi</l>
             <l part="I">Menata Eulalia?</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <l part="F">Nol so dir, ma credololo</l>
             <l part="I">Ch’al levar ch’io mi feci...</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Consegnasti la</l>
             <l part="I">Cassa al ruffian?</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Lascialo a me rispondere,</l>
             <l part="I">Ch’importa più.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Pur importa più intendere</l>
             <l>De la cassa, che sei chiaro che toltagli</l>
             <l part="I">La giovane hanno.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Che cesso io lor correre</l>
             <l part="I">Dietro?</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">La cassa ho consegnata a Lucramo.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="I">Ove ir vòi tu? Che pensi tu far?</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Vogliola</l>
             <l part="I">O riavere o morire.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Non correre</l>
             <l>In tanta fretta, Erofilo, ricordati</l>
             <l>Che noi siamo in pericolo di perdere</l>
             <l part="I">La cassa: attendi a quella, e poi…</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Che attendere?</l>
             <l>Che cassa? Più m’importa la mia Eulalia</l>
             <l>Che quanta roba è al mondo. Ove ti pensi tu</l>
             <l part="I">Ch’abbian presa la via?</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Di qua mi parveno</l>
             <l part="I">Andar.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Non ir, patron, che non ti facciano</l>
             <l part="I">Qualche male.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">E che peggio mi potriano</l>
             <l>Far, se già m’han levato il cor e l’anima?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>Gli voglio ir dietro, e veder di rivolgerlo</l>
             <l>A far quel che, se non fa, s’ha da perdere</l>
@@ -3259,7 +3320,7 @@
         <div>
           <head>Scena IX</head>
           <stage>Lucramo, Furbo</stage>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l>Non è fra quanti uccellatori uccellano</l>
             <l>Di me il più aventuroso, che a duo piccioli</l>
@@ -3303,12 +3364,12 @@
             <l>La fune? U’ sono i fachini, che amaglino</l>
             <l part="I">Le robe ch’io ti dissi?</l>
           </sp>
-          <sp>
+          <sp who="#furbo">
             <speaker>FURBO:</speaker>
             <l part="F">Ghisilastimi</l>
             <l part="I">Di berta ciffo?</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="F">Trucca ch’al coriandolo</l>
             <l>Moccato ho il vino, ho il fior in pugno, e calomi,</l>
@@ -3326,7 +3387,7 @@
         <div>
           <head>Scena I</head>
           <stage>Vulpino</stage>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>Tante contrarietà, tanti infortunii,</l>
             <l>Miser Vulpin; da ogni lato ti assagliono,</l>
@@ -3407,38 +3468,38 @@
         <div>
           <head>Scena II</head>
           <stage>Crisobolo patrone, Vulpino servo</stage>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Non mi debbe già increscer che vietatomi</l>
             <l>Abbia questo mal tempo d’ire a Procida…</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>(A tuo figliuolo e a me ben n’ha da increscere.)</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Che del restar, ancor che volontario</l>
             <l>Non fu, ho più guadagnato che partendomi</l>
             <l part="I">Non avrei fatto…</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">(Se guadagno o perdita</l>
             <l part="I">Ci sia, te ne avedrai.)</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">...perché al discendere</l>
             <l>In terra ho trovato uno, che già dodici</l>
             <l part="I">Anni non vidi…</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">(Deh perché il medesimo</l>
             <l part="I">Non abbiàn noi fatto di te?)</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">…e credevolo</l>
             <l>Morto. Cento saraffi in Alessandria</l>
@@ -3446,23 +3507,23 @@
             <l>Dugento, dielli per un anno a credito;</l>
             <l>Poi, poco appresso, egli fallì e credevomi…</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="I">(Fallito ho io.)</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">…di mai non ne riscuotere</l>
             <l>Un grosso. Egli m’ha detto che in Arabia</l>
             <l part="I">È stato e in India...</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">(Farian per noi simili</l>
             <l>Patroni che così lontan andassino,</l>
             <l>Ch’a ritornar tardassin gli anni e i secoli.)</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>...E ch’egli è fatto ricco; e dipartitici</l>
             <l>D’insieme noi non siàn, che numeratomi</l>
@@ -3474,7 +3535,7 @@
             <l>A noi di qua, si è fatto notte, e l’aria</l>
             <l part="I">Oscura e buia.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">(Ah vile e pusillanimo</l>
             <l>Vulpino, ov’è l’audacia, ov’è l’industria,</l>
@@ -3488,12 +3549,12 @@
             <l>Qui, dove ha di bisogno più che avessino</l>
             <l part="I">In altra impresa mai.)</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Gli è senza dubbio</l>
             <l part="I">L’ora tarda.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">(Anzi l’ora è senza dubbio</l>
             <l>Più presta che ’l bisogno e il desiderio</l>
@@ -3503,7 +3564,7 @@
             <l>Di bagatelle, il più bello e mirabile</l>
             <l part="I">Che si vedesse mai.)</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Poi che vietatomi</l>
             <l>Ha il tempo ch’oggi non sono ito a Procida,</l>
@@ -3511,20 +3572,20 @@
             <l>Il medesmo, e sarammi a maggior utile</l>
             <l part="I">Il rimanere.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">(A noi sarà il contrario.)</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Perché lasciar la mia roba in custodia</l>
             <l>De’ fattori e famigli è con pericolo.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>(Gli è stato un poco tardo ad avedersene.)</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Massimamente ove si truovi un prodigo</l>
             <l>Figliuolo, quale è il mio, che non si sazia</l>
@@ -3533,19 +3594,19 @@
             <l>Di ciò ch’è in piazza di buono da vendere,</l>
             <l>Costi quel che si vuol, vuol che si comperi.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>(Se questa volta fatto non avessimo</l>
             <l>Altro che pasti avresti a contentartene.)</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Ma così è stato il mio ritorno sùbito</l>
             <l>A questa volta che, s’avrà avuto animo</l>
             <l>Di far alcun disordine, mancatogli</l>
             <l part="I">Sarà il tempo.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">(Te ne potrai accorgere</l>
             <l>Tosto: se fossi corso più che cervio,</l>
@@ -3554,49 +3615,49 @@
             <l>E non comincio a far il gioco?) Ah miseri,</l>
             <l part="I">Ah sciagurati noi!</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Quel mi par essere</l>
             <l part="I">Vulpin mio.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">O città piena d’insidie,</l>
             <l part="I">Piena de ladri e di tristi!</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Dio, aiutami!</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>O pazzia d’imbriaco, o negligenzia</l>
             <l part="I">Di manigoldo!</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="M">Che cosa è?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Di che animo</l>
             <l>Sarà il patron come n’abbia notizia?</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="I">Vulpin?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Ma ben gli sta: vada or, confidisi</l>
             <l>Più in un gaglioffo che nel figliuol proprio.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Io tremo e sudo che qualche infortunio</l>
             <l part="I">Non mi sia occorso.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Lascia le sue camere</l>
             <l>Piene di tanta e tanta roba in guardia</l>
@@ -3604,167 +3665,167 @@
             <l>Ha aperte tutto oggi e mai fermatosi</l>
             <l part="I">Non è in casa.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="M">Vulpin!</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Se non la trovano</l>
             <l part="I">Questa notte è spacciata.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Vulpin, fermati.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="I">Ruinato è il patron.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Più tosto secchiti</l>
             <l part="I">La lingua che sia ver. Vulpino!</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Sentomi</l>
             <l part="I">Chiamar.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="M">Vulpino!</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="M">Oh, gli è il patron.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Che gridi tu?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="I">O patron mio!</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="M">Che cosa c’è?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Vuo’ credere…</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="I">Che c’è di mal?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">…che Dio t’ha per miracolo…</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="I">Che cosa c’è?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="M">…fatto tornar.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Su, narrami:</l>
             <l part="I">Che male è intervenuto?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">A pena cogliere</l>
             <l part="I">Posso il fiato.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="M">C’hai tu?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Ma or, veggendoti,</l>
             <l>Comincio a respirar. Non sapea, misero,</l>
             <l part="I">A chi voltarmi.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Di chi ti ramarichi?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="I">Morto ero.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="M">Di che mal?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Ma or resuscito,</l>
             <l part="I">Ch’io ti veggo, patron.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="M">Che c’è?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Né perdere</l>
             <l part="I">Posso più la speranza...</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Or di’ su, spacciala:</l>
             <l part="I">Che cosa c’è?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">…che tu non la recuperi.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Che vòi tu ch’io recuperi? Che diavolo</l>
             <l part="I">C’è? Nol posso oggi...</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="M">O patron!</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">…da te intendere?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="I">Il tuo servo…</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO.</speaker>
             <l part="M">Che servo mio?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Il tuo Nebbia...</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="I">C’ha egli fatto?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">T’ha fatto grandissimo</l>
             <l part="I">Danno.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="M">C’ha fatto?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Tel dirò, ma lasciami</l>
             <l>Un poco riposar, ch’altro che correre</l>
@@ -3772,71 +3833,71 @@
             <l>Mi posso, et ho difficultade a esprimere</l>
             <l part="I">Le parole.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Dinne una sola e bastami.</l>
             <l part="I">C’ha egli fatto?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Per sua trascuragine</l>
             <l part="I">T’ha ruinato.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Finisci d’uccidermi,</l>
             <l>Non mi tener, manigoldo, più in transito.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>Egli ha lasciato rubar de la camera...</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Che ha lasciato rubar de la camera?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>...Patron, di quella ove tu dormi proprio,</l>
             <l>De la quale a lui solo hai consegnate le</l>
             <l>Chiavi, la qual così raccomandatagli</l>
             <l part="I">Avevi...</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Che cosa è de la mia camera</l>
             <l>Stato rubato? Dillo a un tratto, spacciati.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="I">La cassa.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="M">Cassa?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Quella che quei giovini,</l>
             <l>Credo che sian fiorentini, vi posero.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="I">Quella?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="M">Quella.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Ohimè, quella c’ho in deposito?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="I">Di’ che già avevi: ch’or non l’hai più.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Ah misero,</l>
             <l>Ah più d’ogn’altro infelice Crisobolo!</l>
@@ -3845,21 +3906,21 @@
             <l>A gaglioffacci impiccati! Potevola</l>
             <l>Così lasciare in guardia a cotanti asini.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>Se la cantina ritrovi in disordine,</l>
             <l>Di che la cura hai data a me, castigami,</l>
             <l>Patron, e fammi patir quel supplicio</l>
             <l>Che vòi. Ma c’ho a far io de la tua camera?</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Ecco discrezïone del mio Erofilo:</l>
             <l>Così ha pensier, così solicitudine</l>
             <l>De le mie cose e sue? Questo è l’ufficio</l>
             <l part="I">Di buon figliuol?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Né lui anco riprendere</l>
             <l>In questo déi: che può far meglio un giovane</l>
@@ -3872,12 +3933,12 @@
             <l>Abbi le spalle, partirsi, e la camera</l>
             <l part="I">Lasciar aperta?</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Son disfatto: o povero,</l>
             <l part="I">O ruinato me!</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Patrone, pigliaci,</l>
             <l>Tanto ch’è fresco il mal, qualche rimedio</l>
@@ -3886,74 +3947,74 @@
             <l>La cassa tua, e ben credo che t’ha Domene-</l>
             <l part="I">dio fatto a tempo tornar.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Hai vestigio,</l>
             <l>Hai traccia su la qual mi possi mettere</l>
             <l part="I">Per ritrovarla?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Tanto travagliatomi</l>
             <l>Son oggi e tanto son ito avolgendomi</l>
             <l>Di qua e di là, come un bracco, che credo</l>
             <l>Saper mostrar dove sia questa lepore.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Perché non me l’hai già detto, sappiendolo?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>Non dico ch’io lo sappia certo, dicoti</l>
             <l part="I">Ch’io credo di saperlo.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">A chi hai tu l’animo</l>
             <l part="I">Che l’abbia tolta?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Tel dirò, ma tirati</l>
             <l>Un poco in qua; più ancora un poco. Scostati</l>
             <l part="I">Da quella porta in tutto.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Di chi temi tu</l>
             <l part="I">Che possa udirci?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Di colui ch’io dubito</l>
             <l part="I">Che l’abbia avuta.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">È sì appresso che intendere</l>
             <l part="I">Ci possa?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">È in questa casa, la qual prossima</l>
             <l part="I">Hai da man destra.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Tu credi che toltala</l>
             <l>Abbia questo ruffian che qui dentro abita?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="I">Lo credo e ne son certo.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Ma che indicio</l>
             <l part="I">N’hai tu?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Non pur io n’ho indicio, ma dicoti</l>
             <l>Ch’io n’ho certezza. Ma per Dio, non perdere</l>
@@ -3964,13 +4025,13 @@
             <l>Che ’l tristo s’apparecchia di fuggirsene</l>
             <l>All’alba, tosto che le porte s’aprano.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>E che ti par ch’io faccia? Tu consigliami,</l>
             <l>Che m’ha questo improviso caso e sùbito</l>
             <l>Sì oppresso, che non so dove mi volgere.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>Io ti consiglio che tu faccia intendere</l>
             <l>Or ora al Capitano di iustizia</l>
@@ -3981,19 +4042,19 @@
             <l>Che fuggir possa o la cassa malmettere,</l>
             <l part="I">Sei certo di trovarla.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Ma che indicio</l>
             <l>Di ciò gli posso dar, che pruova fargline?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>Essendo egli ruffiano, non dà indicio</l>
             <l>Chiaro che sia anco ladro? E poi, dicendolo</l>
             <l>Tu, non t’ha il Capitano più da credere,</l>
             <l>Che non avria a dieci altri testimonii?</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>S’altro indicio non c’è, siamo a mal termine</l>
             <l>A chi più dànno i gran maestri credito</l>
@@ -4003,7 +4064,7 @@
             <l>Che a’ mercadanti e a’ pari miei l’insidie,</l>
             <l part="I">Ch’avemo nome d’esser ricchi?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Lasciami</l>
             <l>Pur venir teco, che ben tali indicii</l>
@@ -4015,18 +4076,18 @@
             <l>Al ruffian di fuggire o di nascondere</l>
             <l part="I">Le robe altrove.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Andiamo ora. Deh fermati,</l>
             <l>Ch’un’altra via mi s’appresenta, e vogliola</l>
             <l part="I">Pigliar.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Qual altra miglior potrebbe essere</l>
             <l part="I">Di questa e più sicura?</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Vien qui Nespolo:</l>
             <l>Va’ sino a casa di Critone, e pregalo</l>
@@ -4036,11 +4097,11 @@
             <l>Che vengan ratti. Io qui li aspetto: spacciati,</l>
             <l part="I">Vola.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="M">Che ne vòi far?</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Che testimonii</l>
             <l>Mi sian qua dentro ove entrar mi delibero,</l>
@@ -4064,13 +4125,13 @@
             <l>Gli onesti cittadini indietro e gli uomini</l>
             <l part="I">Virtuosi.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Se gli facessi intendere</l>
             <l>Che tu gli avessi a dir cose che importano,</l>
             <l>Non crederei che ti negasse audienzia.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>E come si potria farglila intendere?</l>
             <l>Non sai come gli uscieri ti rispondono:</l>
@@ -4082,51 +4143,51 @@
             <l>Senza altri mezzi, entri qua dentro e piglimi</l>
             <l>Le cose mie: ma pur ch’elle vi sieno.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>Vi sono senza dubbio alcun. Sì che entravi</l>
             <l>Sicuramente, e pensato hai benissimo.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Intanto che aspettiàn Critone, narrami,</l>
             <l>Fammi saper come sai che involatami</l>
             <l>Abbia la cassa il ruffiano, e che indicio</l>
             <l part="I">N’hai tu.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Saria a contarlo lunga istoria,</l>
             <l>Né ci sarebbe tempo: facciamo opera</l>
             <l>Pur di ricuperarla, che più commoda-</l>
             <l>mente ti farò il tutto ad agio intendere.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Avren tempo a bastanza; o non potendomi</l>
             <l part="I">Pur dir il tutto, dinne parte.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Possovi</l>
             <l part="I">Cominciar, ma non già finir.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Avrestene</l>
             <l part="I">Già detto un pezzo.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Poi che pur sei d’animo</l>
             <l>Ch’io te lo dica, tel dirò. (Che diavolo</l>
             <l part="I">Gli dirò?)</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="M">Non rispondi?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Sto in gran dubbio</l>
             <l>Che non tardi Criton troppo, e dia commodo</l>
@@ -4136,13 +4197,13 @@
             <l>Tenerlo a bada fin che comparissero</l>
             <l part="I">Costor.)</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Non andar, no: non credo indugino</l>
             <l>Più troppo. Dimmi: steste ad avedervene</l>
             <l part="I">Molto di poi che fu rubata?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Uditemi,</l>
             <l>Che vel dirò, se pur volete intenderlo.</l>
@@ -4156,24 +4217,24 @@
             <l>Vi possi entrar. – E gli la die’ senza esserli</l>
             <l part="I">Domandata.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Questo assai buon principio</l>
             <l part="I">Fu d’ubidirmi.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Erofil, che malizia</l>
             <l>Non vi pensava, la pigliò; andò il Nebbia</l>
             <l part="I">Fuor.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">E perché? Non gli avevo espressissima-</l>
             <l>mente interdetto di mai non si muovere</l>
             <l>Di casa e da la guardia de le camere?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>Tu intendi: stamo così un pezzo in varii</l>
             <l>Ragionamenti, entramo d’un proposito</l>
@@ -4202,30 +4263,30 @@
             <l>Dare a lui solo tutta quanta. Pigli tu</l>
             <l part="I">Quel ch’io voglio inferir?</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">T’intendo; séguita</l>
             <l>Pur: io lo tratterò ben come merita.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>Fa il sciocco, ma gli è pieno più che ’l diavolo</l>
             <l part="I">Di malizia. Tu nol conosci.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Séguita.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>(Tardan costor sì a comparir, ch’io dubito</l>
             <l>Di non aver tante ciance che bastino.)</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="I">Tu hai la mente altrove?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">La pigrizia</l>
             <l>Ch’io veggo di costor, che ancor non vengono,</l>
@@ -4247,14 +4308,14 @@
             <l>Ha pur voluto, et ha seco suo genero</l>
             <l part="I">Et il fratel.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Con tutte queste chiacchiere,</l>
             <l>Ancora non m’hai dato alcun indizio,</l>
             <l>Onde io possa arguir che ’l ruffian abbia la</l>
             <l part="I">Mia cassa avuta più che alcun altro.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Entravi</l>
             <l>Sicuro, e se non la ritrovi, impiccami.</l>
@@ -4265,7 +4326,7 @@
         <div>
           <head>Scena III</head>
           <stage>Critone, Crisobolo, Vulpino</stage>
-          <sp>
+          <sp who="#critone">
             <speaker>CRITONE:</speaker>
             <l>(Per tutto son dei ladri, ma più copia</l>
             <l>N’è qui ch’in altro luogo. Ove esser debbono</l>
@@ -4274,39 +4335,39 @@
             <l>Ci duol del caso: usa e valti de l’opera</l>
             <l part="I">Nostra dove ti par.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Io vi ringrazio.</l>
             <l>Ben m’incresce a quest’ora darvi incommodo:</l>
             <l>Un’altra volta tocchi, a beneficio</l>
             <l part="I">Vostro, a voi incommodarmi.</l>
           </sp>
-          <sp>
+          <sp who="#critone">
             <speaker>CRITONE:</speaker>
             <l part="F">Non accadono</l>
             <l part="I">Tal parole con noi.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Vorrei, piacendovi,</l>
             <l>Che voi venisse meco, e testimonii</l>
             <l>Voi mi fosse qua dentro, ove ho notizia</l>
             <l part="I">Che troverò la roba mia.</l>
           </sp>
-          <sp>
+          <sp who="#critone">
             <speaker>CRITONE:</speaker>
             <l part="F">Verremovi,</l>
             <l part="I">E volentier.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Non più parole: entriamoci</l>
           </sp>
-          <sp>
+          <sp who="#critone">
             <speaker>CRITONE:</speaker>
             <l part="I">Entriamoci.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Voi altri ritiratevi</l>
             <l>Qui lungo il muro e i lumi si nascondano,</l>
@@ -4317,7 +4378,7 @@
             <l>Da un altro fuor la facesse, e nasconderla</l>
             <l part="I">In altra parte.</l>
           </sp>
-          <sp>
+          <sp who="#critone">
             <speaker>CRITONE:</speaker>
             <l part="F">Or su, picchia, e governaci</l>
             <l>Come ti par che sia meglio a proposito.</l>
@@ -4326,7 +4387,7 @@
         <div>
           <head>Scena IV</head>
           <stage>Fulcio, Vulpino</stage>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l>Son molti cianciatori che si vantano</l>
             <l>Di far molte facende, e molto frappano,</l>
@@ -4347,45 +4408,45 @@
             <l>O pur se qualche impedimento, postoci</l>
             <l>In mezzo, sia venuto ad interromperci.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>(Sento un che vien di là: par che s’approssimi</l>
             <l>All’uscio nostro e che vada per battere.)</l>
             <l>Chi sei tu? Olà? Che cerchi? Chi domandi tu?</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="I">O Vulpino, altri non vo’ che te.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">O Fulcio,</l>
             <l part="I">Io non t’avevo conosciuto.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Abbiamoti</l>
             <l>D’aspettar più che venghi con Erofilo</l>
             <l>A far quel che fu detto, o di proposito</l>
             <l part="I">Sète mutati pur?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">O Fulcio, postoci</l>
             <l>Ha il capo con tutte le corna il diavolo,</l>
             <l>Non pur solo la coda, come dicono,</l>
             <l>E tutti ha scompigliati li nostri ordini.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="I">Che v’è accaduto?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Ascoltami e diròtilo.</l>
             <l part="I">Deh, taci, taci.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Ma che moltitudine</l>
             <l>È questa, che con tal rumore e strepito</l>
@@ -4395,45 +4456,45 @@
         <div>
           <head>Scena V</head>
           <stage>Lucramo, Crisobolo, Critone, Vulpino</stage>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l>A questo modo, uomo da ben, si trattano</l>
             <l part="I">Li forestieri?</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">I cittadin si trattano</l>
             <l part="I">A questo modo, ladron?</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="F">Non ti credere</l>
             <l>Che passar me ne debbia così tacito:</l>
             <l part="I">Me ne dorrò sin al cielo.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Dolermene</l>
             <l>Tanto alto già non voglio io, ma dorròmene</l>
             <l>Ben in loco, ove la tua sceleraggine</l>
             <l part="I">Sarà punita.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="F">Non ti dar a intendere,</l>
             <l>Se ben io son ruffian, ch’io non abbia essere</l>
             <l part="I">Udito...</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Ancora hai di parlar audacia?</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l>...E ch’io non abbia lingua per esprimere</l>
             <l part="I">La ragion mia.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Cotesta un palmo mettere</l>
             <l>Ti farà il boia fuor di bocca; e ch’essere</l>
@@ -4441,7 +4502,7 @@
             <l>Sua roba in casa mia, come io trovata la</l>
             <l part="I">Mia ho qua dentro in casa sua?</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="F">Vogliomi</l>
             <l>Porre, e vo’ che li miei tutti si pongano</l>
@@ -4451,22 +4512,22 @@
             <l>Che ci siàn convenuti d’una femina</l>
             <l>Che da me dianzi comperò, mi numeri.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Ancora ardisci aprir la bocca, publico</l>
             <l part="I">E manifesto ladro?</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="F">Chi è più publico</l>
             <l>E manifesto di te, che venendomi</l>
             <l>A rubar, meni teco i testimonii?</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Ghiotton, se tu non parli con modestia...</l>
           </sp>
-          <sp>
+          <sp who="#critone">
             <speaker>CRITONE:</speaker>
             <l>Non far parole seco, non rispondere</l>
             <l>Alle sue ciance; andiàn, che convenevole</l>
@@ -4477,7 +4538,7 @@
             <l>Dinanzi al Capitano di iustizia</l>
             <l part="I">Vedere.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="F">Ben mi vederete, siatene</l>
             <l>Sicuri: non passerà così facile-</l>
@@ -4485,26 +4546,26 @@
             <l>Ma sète troppi contra un sol; vedremoci</l>
             <l>In loco ove di par potrò rispondere.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Vedeste voi già mai tanta insolenzia?</l>
             <l>Vedeste ladro di tanta arroganzia</l>
             <l part="I">Come costui?</l>
           </sp>
-          <sp>
+          <sp who="#critone">
             <speaker>CRITONE:</speaker>
             <l part="F">Non mai. La tua, Crisobolo,</l>
             <l part="I">È stata grande aventura.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Grandissima.</l>
           </sp>
-          <sp>
+          <sp who="#critone">
             <speaker>CRITONE:</speaker>
             <l part="I">Ci commandi tu altro?</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Che, accadendovi,</l>
             <l>Vi vagliate di me, come valutomi</l>
@@ -4515,69 +4576,69 @@
         <div>
           <head>Scena VI</head>
           <stage>Fulcio, Vulpino, Critone</stage>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="I">Vòi ch’io t’aspetti, Vulpino?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Sì, aspettami,</l>
             <l part="I">Perché ho da ragionar teco.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Solicita</l>
             <l part="I">Di tosto ritornar.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Sarò qui sùbito.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="I">Vai tu lontan?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="M">Anzi qui presso.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Voglioti</l>
             <l part="I">Far compagnia.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Gli è meglio; ch’avrò spazio</l>
             <l>Di conferir le cose nostre. Oh diavolo!</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="I">Ti rompa il collo! C’hai tu?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Ohimè, ohimè misero!</l>
             <l part="I">Son disfatto, son morto.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">C’hai tu, bestia?</l>
             <l part="I">Che t’accade?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Deh, piglia il lume, Fulcio,</l>
             <l>Et accompagna questi gentiluomini;</l>
             <l>Che maledetta sia la mia memoria.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l>Deh, tenetevel pur voi stessi, e fatevi</l>
             <l>Lume fra voi: perché quanto accadutogli,</l>
             <l>O bene o mal di nuovo sia, vo’ intendere.</l>
           </sp>
-          <sp>
+          <sp who="#critone">
             <speaker>CRITONE:</speaker>
             <l>Galanti servitor; cortesi gioveni</l>
             <l>Amendue sète: certo, se pericolo</l>
@@ -4592,11 +4653,11 @@
             <l>Lume noi stessi e facciàn come i poveri</l>
             <l>Cavallier che l’un l’altro s’accompagnano.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="I">Che t’è di novo accaduto?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Ohimè, il Trappola</l>
             <l>È rimaso coi panni di Crisobolo</l>
@@ -4605,13 +4666,13 @@
             <l>E farlo a un tratto dispogliar e renderli</l>
             <l>Il suo gaban, ch’è dentro alla mia camera.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l>O trascurato e da poco uom! Va’ sùbito,</l>
             <l>E fallo in qualche lato almen nascondere,</l>
             <l part="I">Che non lo vegga tuo patron.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Mi dubito</l>
             <l>Ch’è tardi; e ben ch’io sarò stato a giungere</l>
@@ -4622,29 +4683,29 @@
         <div>
           <head>Scena VII</head>
           <stage>Crisobolo, Volpino, Trappola</stage>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Dove credi fuggir? Sta’ saldo, fermati,</l>
             <l>Viso di ladroncello. Donde toltami</l>
             <l part="I">Hai questa veste?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">(Che farai più, misero?</l>
             <l part="I">Che, sciagurato Vulpin?)</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Tu debbi essere</l>
             <l>Quel uom da bene che ancora involatami</l>
             <l part="I">La cassa avevi.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">(Oh, potess’io accostarmigli</l>
             <l part="I">All’orecchio).</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Non ti farò rispondere,</l>
             <l>Ribaldo truffatore? Olà, aiutatemi,</l>
@@ -4652,149 +4713,149 @@
             <l>Questo ghiotton, né vuol parlare; o mutolo</l>
             <l>È costui certo, o che si finge d’essere.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>(Non si potea a sì improviso infortunio</l>
             <l>Trovar miglior riparo; or di soccorrerlo</l>
             <l>È tempo.) C’hai tu a far, patron, col mutolo?</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Ho ritrovato costui, che vestitosi</l>
             <l part="I">Ha, come vedi, i miei panni.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Chi diavolo</l>
             <l>Gli ha dato la tua veste, e chi condottolo</l>
             <l part="I">Ha in casa?</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Né gli posso far rispondere</l>
             <l part="I">Una parola.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">E come, se gli è mutolo,</l>
             <l part="I">Vòi tu che ti risponda?</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">È costui mutolo?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="I">E che, non lo conosci tu?</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Vedutolo</l>
             <l part="I">Non ho mai più.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Tu non conosci il mutolo</l>
             <l>Il qual sta alla taverna de la Simia?</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Che taverna, che mutolo, che simia</l>
             <l>Vòi ch’io conosca, manigoldo? Paioti</l>
             <l part="I">Uomo che vada alle taverne?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Veggolo</l>
             <l part="I">Vestito de’ tuoi panni.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">E di che diavolo</l>
             <l part="I">Altro mi coruccio io?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Veggo che postosi</l>
             <l part="I">Ha il tuo capello ancora.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Anzi, che postosi</l>
             <l>Da la camicia ha sino alle pantofole.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>Per Dio sì, questa è la più strana pratica</l>
             <l>Del mondo. Gli hai domandato chi datoli</l>
             <l part="I">Abbia così i tuoi panni?</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Domandatoli</l>
             <l>Ho purtroppo: ma che vòi, se gli è mutolo,</l>
             <l part="I">Che mi risponda?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Vedi che accennandoti</l>
             <l part="I">Te lo faccia saper.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Io non so intendere</l>
             <l part="I">Chi non parla.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="M">Io sì ben.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Dunque l’interroga</l>
             <l part="I">Tu che lo intendi.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Io l’intendo benissimo,</l>
             <l part="I">Né men ch’io faccia ogn’altro.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Tu domandagli</l>
             <l part="I">Dunque.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Chi t’ha dato cotesti? Dicoti</l>
             <l>Cotesti panni, cotesti onde avutili</l>
             <l part="I">Hai?</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">(Vedi come ben fra lor ragionano</l>
             <l>Con le mano, e non meno che farebbono</l>
             <l>Con lingua tutti gli altri.) Dimmi: intendi tu</l>
             <l part="I">Ciò che vuol dir?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">M’accenna che pigliati li</l>
             <l>Suoi stracci ha un qui di casa e dato in cambio</l>
             <l>Gli ha la tua veste e gli altri panni, e dettogli</l>
             <l part="I">Che qui l’aspetti fin che torni.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Accennali</l>
             <l>Che ti faccia saper, se gli è possibile,</l>
             <l part="I">Chi sia questo di casa.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Sarà facile.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>(Lo guaterei mill’anni, né comprendere</l>
             <l>Cosa potrei che voglia dir, né un minimo</l>
@@ -4803,32 +4864,32 @@
             <l>Il capo e il volto e spesso il naso, e gonfia</l>
             <l part="I">La bocca?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Mostra che sia stato un picciolo,</l>
             <l>Ch’abbia gran naso, il capo riccio, pallido</l>
             <l part="I">In viso e parli alquanto in fretta.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Pensomi</l>
             <l>Che ’l Nebbia voglia dir. Ma che notizia</l>
             <l>Può egli aver che parli in fretta? Un mutolo</l>
             <l part="I">Può dunque udir?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Non parla in fretta: dicoti</l>
             <l>Che partì in fretta; senza fallo il Nebbia .</l>
             <l>Vuol dir: tu prima e meglio di me intesolo</l>
             <l part="I">Hai.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">C’ha voluto far quel sciocco a mettersi</l>
             <l part="I">Indosso i panni di costui?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">M’imagino</l>
             <l>Che, veduto mancar la cassa et essere</l>
@@ -4836,28 +4897,28 @@
             <l>E perché lo potrian, conoscendolo,</l>
             <l>Tenere ai passi, ch’abbia mutato abito.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>E perché non più tosto dovea dargli li</l>
             <l part="I">Suoi panni il Nebbia, che li miei?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Che diavolo</l>
             <l>So io? Gli è qualche volta temerario.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Or va’, menalo in casa, e fagli mettere</l>
             <l>Indosso qualche veste convenevole</l>
             <l part="I">A lui, che non macchiasse la mia.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Lasciane</l>
             <l part="I">A me la cura.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">(Per Dio, potrebbe essere</l>
             <l>Anco altrimente. Non è da passarsene</l>
@@ -4870,29 +4931,29 @@
             <l>Dipinse, s’io non son senza memoria,</l>
             <l>Ch’era vestito a questo modo proprio?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>Che? Tu ti vòi fondar in quel che dettoti</l>
             <l part="I">Abbia il ruffian?</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Né te, Vulpino, iudico</l>
             <l>Miglior terreno in ch’io mi fondi. Vogliola</l>
             <l>Far altrimente. Gallo, Negro, Nespolo,</l>
             <l>Teneteme costui saldo e legatelo.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="I">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Vo’ al Capitano di iustizia</l>
             <l>Mandarlo, per provar se buon rimedio</l>
             <l>Fosse la fune a sanarlo del mutolo.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>Non so certo io, patrone, se gli è mutolo?</l>
             <l>Se pur vòi meglio anco chiarirti, dammilo,</l>
@@ -4900,7 +4961,7 @@
             <l>Dica se gli è il mercadante che datagli</l>
             <l>Abbia la cassa: chi ’l può mei conoscere?</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Io voglio che la fune abbia a chiarirmene</l>
             <l>Del Capitano, e non altri. Spacciatevi.</l>
@@ -4909,24 +4970,24 @@
             <l>Le mani dietro. Or, col malanno, lievagli</l>
             <l part="I">Prima di dosso la mia veste.</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Scusami,</l>
             <l>Vulpino: fin che le parole andavano</l>
             <l>E le minacce a torno, né venivasi</l>
             <l part="I">A’ fatti, t’ho servito.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">(Ohimè, ohimè, misero</l>
             <l part="I">Vulpino.)</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Ma per te già non voglio essere</l>
             <l part="I">Né storpiato né morto.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Per Dio, merita</l>
             <l>Questa fune esser posta nel catalogo</l>
@@ -4936,42 +4997,42 @@
             <l>Di guarirti del giotto? Ora rispondimi</l>
             <l part="I">Tu: chi t’ha dato li miei panni?</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Dièmili</l>
             <l part="I">Tuo figliuolo.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="M">E Vulpino no?</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Amendua erano</l>
             <l part="I">Insieme.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="M">Ma a che effetto?</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Mi mandarono</l>
             <l>Così vestito a pigliar una femina</l>
             <l part="I">Di casa d’un ruffiano.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Tu arrecastivi</l>
             <l part="I">La mia cassa?</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Una cassa essi mi dierono,</l>
             <l>La qual vi feci portare, e lasciavila</l>
             <l>Pegno, come essi a punto mi commissero.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>A questo modo hai dunque avuto audacia,</l>
             <l>Vulpin, di porre con tanto pericolo</l>
@@ -4989,14 +5050,14 @@
             <l>Fune pur da colui tosto, e legatemi</l>
             <l part="I">Questo ribaldo.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">O patron commandòmilo,</l>
             <l>E mi sforzò tuo figliuolo: lasciastime</l>
             <l>Perché gli avessi a stare a ubidienzia,</l>
             <l part="I">E non perché gli commandassi.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Legalo</l>
             <l>Ben forte; se mi lascia anco Dio vivere</l>
@@ -5004,12 +5065,12 @@
             <l>Essempio agli altri, che non avran animo</l>
             <l part="I">D’ingannarmi mai più.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">Misericordia,</l>
             <l part="I">Patron.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Ribaldo! Vien anco tu, e pigliati</l>
             <l>Li panni tuoi; viene anco, perché intendere</l>
@@ -5019,7 +5080,7 @@
         <div>
           <head>Scena VIII</head>
           <stage>Fulcio</stage>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l>La cosa va mal per tutti, ma pessima-</l>
             <l>mente va per Vulpin: che la mutabile</l>
@@ -5085,7 +5146,7 @@
         <div>
           <head>Scena IX</head>
           <stage>Lucramo, Fulcio</stage>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l>(Quanto più differisco a lamentarmene,</l>
             <l>Tanto più fo le mie ragioni deboli.</l>
@@ -5093,91 +5154,91 @@
             <l>Tanto a tornar, che serà forza andarmene</l>
             <l part="I">Solo.)</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">O Dio, ch’io ritrovi in casa Lucramo</l>
             <l part="I">Per avisarlo...</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO</speaker>
             <l part="F">(Chi è che là mi nomina?)</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l>...De la ruina che lo viene a opprimere.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="I">(Che dice?)</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Sì che almen non v’abbia a mettere</l>
             <l part="I">La vita.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO.</speaker>
             <l part="M">(Ohimè.)</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Benché v’è più pericolo</l>
             <l>Che sicurezza di salvarla, vogliolo</l>
             <l part="I">Ogni modo avisar.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="F">Non bussar, Fulcio,</l>
             <l part="I">Ch’io son qui, se di me tu cerchi.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">O misero,</l>
             <l>O infelice, o sciagurato Lucramo,</l>
             <l part="I">Che fai tu? Che non fuggi?</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="F">Perché diavolo</l>
             <l part="I">Ho da fuggir?</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">O poverello, lievati,</l>
             <l>Lievati di qui tosto, fuggi, ascondeti.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="I">Perché vòi tu ch’io fugga?</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Sarai sùbito</l>
             <l>Sùbito appeso, mischin, se ti trovano;</l>
             <l part="I">Fuggi. Che tardi?</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="F">Chi mi farà appendere?</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l>Mio patron, il Capitan di iustizia.</l>
             <l>Fuggi, ti dico: ancor stai? Fuggi, misero!</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l>E che ho io fatto che le forche meriti?</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l>Tu hai rubato il tuo vicin Crisobolo.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="I">Cotesto è falso.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Et esso ritrovatoti</l>
             <l>Con testimonii, e con che testimonii,</l>
@@ -5185,12 +5246,12 @@
             <l>Lievati, e fuggi ratto, e fuggi sùbito.</l>
             <l part="I">Tu non ti muovi ancor?</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="F">Se vorrà intendere</l>
             <l part="I">Il tuo patron la ragion mia...</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Non perdere</l>
             <l>Tempo, non star a dir parole, povero</l>
@@ -5200,104 +5261,104 @@
             <l>Impiccarti et ha seco il boia. Or vedi se</l>
             <l>Hai tempo di cianciar: fuggi, dileguati.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l>Ah Fulcio, io mi ti raccomando, aiutami,</l>
             <l>Consigliami: sai ben s’io t’amo e amatoti</l>
             <l>Abbia sempre di poi che l’amicizia</l>
             <l part="I">Nostra si cominciò.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Per questo vengoti</l>
             <l>Ad avisar e mi metto a pericolo</l>
             <l part="I">D’esserne castigato.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="F">Ti ringrazio.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO.</speaker>
             <l>Che se ’l patron mio lo sapesse, dubito</l>
             <l>Che mi faria teco impiccar; ma lievati</l>
             <l part="I">Di qui, e non gracchiar più.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="F">Ma la mia povera</l>
             <l>Famiglia e le mie robe ove rimangono?</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l>Che famiglia, che robe! Meglio perdere</l>
             <l>È ogn’altra cosa tua che te medesimo.</l>
             <l part="I">Fuggi; che tardi ancor?</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="F">Ma dove, misero,</l>
             <l>Posso io fuggir? Dove mi debbio ascondere?</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l>E che diavol so io? Ho fatto il debito</l>
             <l>Mio un tratto: tuo sia il danno se t’impiccano.</l>
             <l>Io non vo’ già che teco mi ritrovino,</l>
             <l part="I">E m’impicchino appresso.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="F">Ah Fulcio, ah Fulcio!</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l>Taci, non nominarmi, che possi essere</l>
             <l>Squartato! Che non t’oda alcuno, e accusimi</l>
             <l>Al patron ch’io sia corso ad avisartene.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l>Io mi ti raccomando. Deh, di grazia,</l>
             <l part="I">Non mi lasciar.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Al boia raccomandati,</l>
             <l>Non a me: non vorrei per cento milia</l>
             <l>Ducati che ’l patron venisse a intendere</l>
             <l part="I">Ch’io t’avessi parlato.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="F">Ah, per Dio, ascoltami</l>
             <l part="I">Una parola.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Io non ti posso attendere</l>
             <l>Che mi par di sentir di qua, e mi dubito</l>
             <l part="I">Che sia il bargello.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="M">Io verrò teco.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Voltati</l>
             <l>Altrove pur, che non vo’ che ti trovino</l>
             <l part="I">Meco.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="M">Voglio venir.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="M">Non far, non.</l>
           </sp>
-          <sp>
+          <sp who="#lucramo">
             <speaker>LUCRAMO:</speaker>
             <l part="F">Piglia la</l>
             <l>Via che vòi, che seguirti mi delibero.</l>
@@ -5309,7 +5370,7 @@
         <div>
           <head>Scena I</head>
           <stage>Fulcio, Erofilo, Furbo</stage>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l>Con queste et altre parole che varii</l>
             <l>E appropriati gesti accompagnavano,</l>
@@ -5322,14 +5383,14 @@
             <l>Le foglie al vento, che ’l bargel parevali</l>
             <l>Sempre aver dietro e i birri che ’l seguisseno.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l>Mi maraviglio pur che, conoscendosi</l>
             <l>Di ciò innocente, come è senza dubbio,</l>
             <l>Sia tanto vil che non abbia avuto animo</l>
             <l part="I">Di comparir.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">E che, ti par miracolo?</l>
             <l>Se già gli avevo detto e persuasogli</l>
@@ -5337,12 +5398,12 @@
             <l>Senza inquisizïon, senz’altra essamina,</l>
             <l>Preso che fosse, d’impiccarlo subito!</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l>Io non so come sia stato sì facile</l>
             <l part="I">A crederti.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">E perché non dovea credermi?</l>
             <l>Conosce ben mio patron, che vedutolo</l>
@@ -5352,12 +5413,12 @@
             <l>E quanto il nome di ruffiano in odio</l>
             <l part="I">Sempremai gli sia stato.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Pur sentendosi</l>
             <l part="I">Innocente?</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Che più? Voglio concederti</l>
             <l>Che sia, come è, di questo innocentissimo.</l>
@@ -5372,13 +5433,13 @@
             <l>Di scoprire altri delitti, che facile-</l>
             <l>mente dannare a morte lo farebbono.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l>Tu di’ ch’andò a ritrovar alla camera</l>
             <l>Caridoro? Come ebbe così animo</l>
             <l part="I">Di condurvisi?</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Io gli diedi a intendere</l>
             <l>Che ’l signor mio patron volea che subito</l>
@@ -5403,11 +5464,11 @@
             <l>Non negaria, fin che un poco la còlera</l>
             <l>Si acchetasse del padre, di nasconderlo.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="I">E così ve lo conducesti?</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Seppigli</l>
             <l>Cicalar tanto, che vel trassi all’ultimo.</l>
@@ -5422,11 +5483,11 @@
             <l>Ma tutto ciò ch’aveva al mondo, et esserli</l>
             <l part="I">Schiavo in eterno.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Ah, ah, tu mi fai ridere.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l>Vorrei che Caridor veduto simile-</l>
             <l>mente tu avessi, che molto difficile</l>
@@ -5437,23 +5498,23 @@
             <l>Il qual dovea più che quant’altri fussino</l>
             <l>Al mondo amare e avere in riverenzia.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="I">Ah, ah.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Vorrei che me raccomandarglilo</l>
             <l>Veduto avessi, e a Caridoro mettere</l>
             <l>Partiti e modi inanzi che, tenendoli,</l>
             <l>Senza suo biasmo lo potria soccorrere.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l>Ah, ah, per Dio, saria stato impossibile</l>
             <l>Che ritenuto mi fossi da ridere.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l>Al fine io diedi per consiglio a Lucramo</l>
             <l>Che facessi venir quivi la giovane,</l>
@@ -5466,12 +5527,12 @@
             <l>La giunta de la qual farà bonissimo</l>
             <l part="I">Effetto.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Io ne son certo. Dunque in camera</l>
             <l part="I">Di Caridor t’aspetta il ruffian?</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Va’, ch’io ti</l>
             <l>Lasciavo il meglio! Perché non lo veggano</l>
@@ -5481,7 +5542,7 @@
             <l>A bastanza: non osa, per non essere</l>
             <l part="I">Sentito, pur di respirar.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Ho gaudio</l>
             <l>Ch’abbia de l’amor suo così piacevole</l>
@@ -5500,14 +5561,14 @@
             <l>In quella certa aspettazion, mettendola</l>
             <l>Come già avuta, fruito del gaudio.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l>E così avien che i beni più dilettano</l>
             <l>Quando con più fatica e più pericolo</l>
             <l>Avuti s’hanno, e quando più mancatane</l>
             <l part="I">Era la speme.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Anco così in contrario</l>
             <l>Il mal, che vien quando men tu ne dubiti,</l>
@@ -5519,7 +5580,7 @@
             <l>Nostra trama scoperta e fatto mettere</l>
             <l>Vulpino, il nostro consigliere, in carcere.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l>Tu potrai medicar questo mal facile-</l>
             <l>mente: che quattro o sei parole ch’umili</l>
@@ -5534,21 +5595,21 @@
             <l>Da satisfar ancora, e dimportanzia</l>
             <l part="I">Non minore.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="M">Che debito?</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Che Lucramo</l>
             <l part="I">Fuggir si facci domatina.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Facciasi</l>
             <l part="I">Fuggir questa notte anco.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Ci bisognano</l>
             <l>Danari a farlo, ch’almen le due giovani</l>
@@ -5561,38 +5622,38 @@
             <l>Altretanti. Con cento scudi mandisi</l>
             <l>Via immantinente, e non s’oda altro strepito.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l>Con ogn’altro che meco pur consigliati</l>
             <l>Di questo, che da me un carlino, un picciolo</l>
             <l part="I">Non potrai aver.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Tu saresti ben povero;</l>
             <l part="I">Trova chi te li presti.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Io non ho credito</l>
             <l part="I">Di sì gran somma.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Gli ebrei te li prestino,</l>
             <l>S’altro amico non hai dove ricorrere.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="I">Che pegni ho io dar loro?</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Almen trovane,</l>
             <l>Se non puoi più, fin a trenta; non perdere</l>
             <l part="I">Tempo.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Io non gli ho, né so donde trovartili.</l>
             <l>Poi che ’l vecchio è tornato, e che la pratica</l>
@@ -5600,16 +5661,16 @@
             <l>Speranza in me ch’io lo possa soccorrere</l>
             <l part="I">D’un soldo.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="M">Che faremo dunque?</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Pensaci</l>
             <l part="I">Tu.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Ci penso purtroppo. Non potrestime</l>
             <l>Darne, quando non più, almen fin a quindici?</l>
@@ -5618,32 +5679,32 @@
             <l>Levar con la famiglia, et anco vivere</l>
             <l>Per via, vedi se far può senza spendere!</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l>Non gli ne posso dar uno; tu trovagli.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="I">Io penso pur donde trovarli.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Pensaci</l>
             <l part="I">Bene.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO</speaker>
             <l part="F">Io ci penso tuttavolta e credoli</l>
             <l part="I">Di ritrovar in fin.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Tanta fiducia</l>
             <l>Ho ne l’ingegno tuo, che voglio credere</l>
             <l>Che li sapresti far di novo nascere,</l>
             <l part="I">Se non ne fosse al mondo.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Or su, su, lasciane</l>
             <l>A me la cura, che credo trovartili</l>
@@ -5654,14 +5715,14 @@
             <l>– Qualunque sei, ch’entri là dentro, fermati,</l>
             <l part="I">Che ti voglio parlar.</l>
           </sp>
-          <sp>
+          <sp who="#furbo">
             <speaker>FURBO:</speaker>
             <l part="F">Se comperatomi</l>
             <l>Avessi, commandar con più arroganzia</l>
             <l>Non mi dovresti; quando ti sia l’opera</l>
             <l part="I">Mia di bisogno, viemmi dietro.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">O ch’asino!</l>
             <l>Ben di costumi al suo patrone è simile.</l>
@@ -5670,7 +5731,7 @@
         <div>
           <head>Scena II</head>
           <stage>Erofilo, Crisobolo</stage>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l>(Voglio ir in casa, e far tanto ch’io mitighi</l>
             <l>Mio padre; e se non fosse per soccorrere</l>
@@ -5679,7 +5740,7 @@
             <l>Nostra porta che s’apre. È desso: sentomi</l>
             <l>Muovere il Sangue e il cor nel petto battere.)</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Come quest’altri gaglioffi s’indugiano</l>
             <l>A ritornar! In nessun lato appaiono</l>
@@ -5693,44 +5754,44 @@
             <l>mente. Deh, come ero io ben sciocco a credere</l>
             <l part="I">Alle sue ciance!</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">(Io son pur anco in dubbio</l>
             <l>S’io debbio o s’io non debbio appresentarmeli.)</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Se tanto saprà far con le sue astuzie</l>
             <l>Ch’esca di ceppi, ove io l’ho fatto mettere,</l>
             <l>Son contento e gli do piena licenzia</l>
             <l>Che me vi faccia mettere in suo cambio.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l>(Bisogna insomma ch’io faccia un buon animo:</l>
             <l>Altrimente Vulpin farà malissimo.)</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="I">O valent’uomo!</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Tu non sei ito a Procida</l>
             <l part="I">Padre?</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Vedi, ribaldo, con che audacia</l>
             <l part="I">Mi vieni inanzi!</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">O mio padre, rincrescemi</l>
             <l>E duolmi grandemente che materia</l>
             <l part="I">Io t’abbia data di turbarti.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Erofilo,</l>
             <l>Se fosse ver, cercheresti di vivere</l>
@@ -5738,14 +5799,14 @@
             <l>E quando tu penserai che scordatomi</l>
             <l part="I">L’abbia, ricordarottilo.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Perdonami,</l>
             <l>Padre, ch’un’altra volta più avertenzia</l>
             <l>Avrò di non darti cagion legitima</l>
             <l part="I">Di dolere.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Eh, non mi voler, Erofilo,</l>
             <l>Con parole donar quel che ti studii</l>
@@ -5762,22 +5823,22 @@
             <l>E romper tutto d’osso in osso, e mettermi</l>
             <l>E cacciarmi sotterra inanzi il termine.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="I">O padre!</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Con le ciance tu mi nomini</l>
             <l>Padre, ma poi con gli effetti in contrario</l>
             <l part="I">Mi ti dimostri nimico.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Perdonami,</l>
             <l part="I">Padre.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Se non che pur non voglio offendere</l>
             <l>Qui l’onor di tua madre, io diria, Erofilo,</l>
@@ -5786,12 +5847,12 @@
             <l>Molto e molto più caro avrei vedermiti</l>
             <l>Simil ne le virtù che ne la effigie.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l>Padre, l’etade e la poca avertenzia</l>
             <l>M’ha fatto teco in questo errore incorrere.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Non credi tu che anche io sia stato giovene?</l>
             <l>Io ne l’etade tua quasi continua-</l>
@@ -5814,14 +5875,14 @@
             <l>Non che in viso arrosir, che teco fossino</l>
             <l>Veduti da li augei, non che da gli uomini.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l>Padre, ho fallito: il confesso. Perdonami,</l>
             <l>E sta’ sicur che questa serà l’ultima</l>
             <l>Volta ch’avrai cagion d’intrare in còlera</l>
             <l part="I">Meco.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Per Dio, per Dio, ti giuro Erofilo,</l>
             <l>Se non ti emendi e non torni al ben vivere,</l>
@@ -5834,12 +5895,12 @@
             <l>Senza figliuol, ch’averne un che mi stimuli</l>
             <l>Sempre e flagelli e non mi lasci vivere.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l>Per l’avenir mi sforzerò più d’esserti</l>
             <l part="I">Ubidiente.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">S’attendi alle buone opere,</l>
             <l>Oltre che mi farai cosa gratissima,</l>
@@ -5850,7 +5911,7 @@
         <div>
           <head>Scena III</head>
           <stage>Fulcio solo</stage>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l>Non farò in tutta notte altro servizio</l>
             <l>Né altra cosa, s’io qui la voglio attendere,</l>
@@ -5934,32 +5995,32 @@
         <div>
           <head>Scena IV</head>
           <stage>Servitor, Fulcio, Crisobolo</stage>
-          <sp>
+          <sp who="#servitor">
             <speaker>SERVITOR:</speaker>
             <l part="I">Chi picchia qui?</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Fa’ saper a Crisobolo</l>
             <l>Ch’io sono un servitor d’un suo amicissimo,</l>
             <l>Che vo’ parlargli per cose ch’importano.</l>
           </sp>
-          <sp>
+          <sp who="#servitor">
             <speaker>SERVITOR:</speaker>
             <l>Se tu gli vòi parlar, perché non entri tu</l>
             <l part="I">In casa?</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Per qualche rispetto vogliolo</l>
             <l>Aspettar qui di fuor: né gli ha da increscere,</l>
             <l>Se m’ode, d’aver preso questo incommodo.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="I">Chi è, ch’a questa ora mi vuol?</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Perdonami,</l>
             <l>Se disagio ti do, che chi mandatomi</l>
@@ -5968,12 +6029,12 @@
             <l>Chi a te mi manda. Fa’ pur che ritornino</l>
             <l part="I">Dentro.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Tornate in casa, et aspettatemi</l>
             <l part="I">Costì: tu dì quel c’hai da dirmi.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Mandami</l>
             <l>A ritrovarte il mio patrone giovene,</l>
@@ -5984,12 +6045,12 @@
             <l>Egli possa et onor e schivar biasimo,</l>
             <l part="I">Non è mai per mancar.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Io lo ringrazio,</l>
             <l>E sempre gli ne sono obligatissimo.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l>Or odi: uscia di casa ora per irsene</l>
             <l>Un poco a spasso, come usano i giovini,</l>
@@ -5998,22 +6059,22 @@
             <l>In un certo ruffiano, il qual dice essere</l>
             <l part="I">Tuo vicino.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="M">Che poi?</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Veniva in còlera</l>
             <l>Gridando, e di te molto lamentandosi</l>
             <l>E di Erofilo tuo con certi ch’erano</l>
             <l part="I">Seco.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="M">E che sapea egli dir?</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Volea venirsene</l>
             <l>Diritto al Capitano di iustizia,</l>
@@ -6024,57 +6085,57 @@
             <l>Ha, fosse vera, sarebbe di pessima</l>
             <l part="I">Sorte.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Or pon mente se, per imprudenzia</l>
             <l>Di questo pazzarello, apparecchiatomi</l>
             <l part="I">Serà non poco travaglio!</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Dicevaci</l>
             <l>Ch’oggi vestito avea a similitudine</l>
             <l>Di mercadante un barro, e che mandatoli</l>
             <l part="I">L’avea con certo pegno.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Ve’, se ’l diavolo</l>
             <l part="I">Ci sarà ancora!</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Il qual pegno lasciandogli,</l>
             <l>Il barro gli avea tolta una sua femina;</l>
             <l>Io non l’ho inteso a punto, che mandatomi</l>
             <l>Ha Caridoro in fretta ad avisartene.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Noi gli siamo obligati: ha fatto ufficio</l>
             <l part="I">Di gentiluomo e d’amico.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">I dui ch’erano</l>
             <l>Col ruffian, come ho detto, par che vogliano</l>
             <l>Per lui testificar e darti carico.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="I">E che carico dar mi ponno?</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Dicono</l>
             <l>Che ’l barro è in casa tua, e di tua scienzia</l>
             <l part="I">Questo giunto ordinò.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Di mia scienzia?</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l>Così dicono: e parmi che dicessino</l>
             <l>Anco, se ben mi ricordo, che entratogli</l>
@@ -6091,53 +6152,53 @@
             <l>Non potrà tuo figliuol se non ricevere,</l>
             <l>Oltra il tuo danno, una vergogna publica.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Che provisïon farci, che rimedio</l>
             <l part="I">Posso io?</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Fagli restituir la femina.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Non si può, che non l’ha, né sa chi toltagli</l>
             <l part="I">L’abbia.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="M">Questo è gran mal.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Non potrebbe essere</l>
             <l part="I">Peggio.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="M">E come faren dunque?</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Che domine</l>
             <l>So io? Non è il più sfortunato e misero</l>
             <l part="I">Uomo al mondo di me.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Il miglior rimedio</l>
             <l>E più breve sarà che la sua femina</l>
             <l>Paghi al ruffiano quello almen che venderla</l>
             <l>Poté altre volte, e lo facci star tacito.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Strano mi par ch’io debbia così spendere</l>
             <l>Il mio danaio, ch’io non l’uso a spendere</l>
             <l>Se non in cose che mi sieno d’utile.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l>Non si può sempre guadagnar, Crisobolo,</l>
             <l>Benché però non si può dir poco utile</l>
@@ -6156,11 +6217,11 @@
             <l>Tu non riparerai senza gran numero</l>
             <l>Di scudi. Sei prudente e pommi intendere.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="I">Che mi consigli tu?</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Il ruffiano è povero</l>
             <l>E, come li suoi pari, vile e timido;</l>
@@ -6170,81 +6231,81 @@
             <l>Teco farà più il danno suo che l’utile,</l>
             <l>Che tu ti truovi danar senza numero...</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Per Dio, son meno assai di quel che credono!</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l>...Da poterlo tener tutta in litigio</l>
             <l>La vita sua, né parenti ti mancano</l>
             <l>Né buoni amici, da fargli rincrescere</l>
             <l>D’aver cercato di darti molestia.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Sai quanto si tenessi questa femina</l>
             <l>Cara, o quanto possuto l’abbia vendere?</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l>Odo ch’un mercadante di Tessalia</l>
             <l>Cento quaranta ducati profertigli</l>
             <l>Avea, né dar gli la volse e chiedeane</l>
             <l part="I">Dugento.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">È troppo: comprar si potriano</l>
             <l>Cinquanta vacche con manco pecunia.</l>
             <l>Io non ne son per far altro: lamentisi,</l>
             <l part="I">E faccia al peggio che può.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Maravigliomi</l>
             <l part="I">Che questi pochi danari...</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">A te paiono</l>
             <l part="I">Pochi?</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">…Tu estimi più che ’l figliuol proprio</l>
             <l>E che te stesso e l’onor tuo. Tornarmene</l>
             <l>Posso al mio patron dunque, riferendoli</l>
             <l part="I">Che non ne vòi far altro.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Non potrebbesi</l>
             <l part="I">Con minor spesa acchetarlo?</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Potrebbesi</l>
             <l>Con un coltel, che s’avria per pochissimo</l>
             <l>Prezzo, scannarlo, e così far che tacito</l>
             <l part="I">Stessi.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Io non dico così: pur gran numero</l>
             <l>Dugento scudi o ducati mi paiono.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l>Io tel confesso: forse accheterebbesi</l>
             <l>Per meno; io credo che s’avrà il medesimo</l>
             <l>Che già ne poté aver, che starà tacito.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="I">E non per meno?</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Io voria in tuo servizio</l>
             <l>Che s’acchetasse con nulla. Perdonami,</l>
@@ -6257,12 +6318,12 @@
             <l>Non si potrà schermir: così saremoli</l>
             <l>Adosso tutti, che ’l faremo arrendere.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Or non è molto meglio ch’io medesimo</l>
             <l part="I">Vi venga?</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Non, secondo il mio giudicio:</l>
             <l>Che se ’l ruffian ti vede in questa pratica</l>
@@ -6276,14 +6337,14 @@
             <l>Danar prestar dagli amici, anzi toltoli</l>
             <l>All’interesse con suo grande incommodo.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Che venga sol? Sì, per Dio, che gli è giovene</l>
             <l>Molto cauto! In un tratto lascerebbesi</l>
             <l>Aviluppare e tirar come un bufalo</l>
             <l part="I">Pel naso.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Ma di questi che al servizio</l>
             <l>Tuo stanno, non ce n’è alcuno sì pratico</l>
@@ -6292,7 +6353,7 @@
             <l>In corpo. Egli saria purtroppo idoneo</l>
             <l>A questo, né il miglior potresti eleggere.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Quel ladroncel? Esso è stato potissima</l>
             <l>Cagione, è stato la guida, il principio</l>
@@ -6300,17 +6361,17 @@
             <l>Io l’ho cacciato in ceppi, e mi delibero</l>
             <l>Per Dio, di castigarlo come merita.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l>Deh non lasciar, Crisobol, che la còlera</l>
             <l>Ti vinca e offuschi ragione. Mandalo</l>
             <l>Con tuo figliuol: non puoi far meglio, e credimi.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="I">È il maggior tristo.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Tanto è più a proposito</l>
             <l>Tuo in questo, quanto gli è più tristo; mandalo</l>
@@ -6318,7 +6379,7 @@
             <l>Fra mille il più sufficiente; mandalo.</l>
             <l>Con tuo figliuolo e fa’ che vengan sùbito.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l>Ancor che sia quel che gli è e ch’io desideri</l>
             <l>Di castigar, pur mi è forza ricorrere</l>
@@ -6327,19 +6388,19 @@
             <l>Insieme due parole che ben stessino.</l>
             <l>Dio sa che mi rincresce fin all’anima!</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l>Lascia andar: ben potrai con più tuo commodo</l>
             <l part="I">De l’altre volte castigarlo.</l>
           </sp>
-          <sp>
+          <sp who="#crisobolo">
             <speaker>CRISOBOLO:</speaker>
             <l part="F">Duolmene</l>
             <l>Insomma, e molto mi par duro a rodere</l>
             <l>Quest’osso, ma non ti partir, aspettali</l>
             <l>Un poco qui. Vo’ ch’ambi teco vengano.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l>Va’, ch’io gli aspetto. (Or mi convien ben debita-</l>
             <l>mente il trionfo, or convien ben che cintomi</l>
@@ -6369,7 +6430,7 @@
         <div>
           <head>Scena V</head>
           <stage>Trappola, Fulcio</stage>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l>Non sarà mai più ver che con pericolo</l>
             <l>D’averne io danno io faccia altrui servizio.</l>
@@ -6384,11 +6445,11 @@
             <l>N’avrebbe tante e tante, e pur facendomi</l>
             <l>Cantare in aria a guisa de le lodole.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="I">(Costui si appone.)</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">Ch’andavo a pericolo</l>
             <l>Di non poter mai più riveder Napoli;</l>
@@ -6396,12 +6457,12 @@
             <l>Tanto da terra che già non dovriano</l>
             <l>Il guardar da lontano impedir gli arbori.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l>(Fu buona sorte che così passarsene,</l>
             <l>Senza fargli altro, volesse Crisobolo.)</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l>Ma poi che questa volta, buona femina,</l>
             <l>Ne sono uscito, più non mi ci coglieno.</l>
@@ -6409,25 +6470,25 @@
             <l>Per me le vorrò far, e non per utile</l>
             <l part="I">D’alcun.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">(Non è però pentito d’essere</l>
             <l>Tristo, ma solo di far le tristizie</l>
             <l part="I">Senza profitto.)</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <l part="F">Non pur guadagnarmene</l>
             <l>Posso una cena: e perché disegnatomi</l>
             <l>Non avea di godere e stare in gaudio</l>
             <l part="I">Sin all’alba del giorno...</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">(Non riescono</l>
             <l part="I">Sempre i disegni.)</l>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA:</speaker>
             <l part="F">...e perché non ho in ordine</l>
             <l>L’appetito, stasera più rincrescemi;</l>
@@ -6442,7 +6503,7 @@
             <l>Che mi dileggi, che la fame a rodermi</l>
             <l>Tutta notte abbia e a consumar lo stomaco.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l>(Credo sia il meglio, che la fame supera</l>
             <l>Ogni altro mal: non è tanto pericolo</l>
@@ -6455,7 +6516,7 @@
         <div>
           <head>Scena VI</head>
           <stage>Vulpino; Erofilo, Fulcio</stage>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>Io vederò di farlo restar tacito,</l>
             <l>Non dubitar, per quel men che possibile</l>
@@ -6464,15 +6525,15 @@
             <l>A me la cura pur. So che de l’opera</l>
             <l>Mia ti contenterai. Ma veggo Fulcio.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="I">Dove è?</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="M">Vedilo là.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Lo veggo. O Fulcio,</l>
             <l>Quando mai ti potren riferir grazie</l>
@@ -6482,12 +6543,12 @@
             <l>Poco, e ch’io non satisfacessi all’obbligo,</l>
             <l part="I">Ch’io t’ho infinito.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Assai mi basta, Erofilo,</l>
             <l part="I">Che mi faccia buon viso.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l part="F">O mia infallibile</l>
             <l>Speranza, o mio rifugio, o mia vera unica</l>
@@ -6497,7 +6558,7 @@
             <l>Vita, la qual io son per sempre mettere</l>
             <l part="I">A tutti i cenni tuoi.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Queste son opere,</l>
             <l>Questi servizii che si prestano.</l>
@@ -6505,51 +6566,51 @@
             <l>Ch’abbia saputo trovare e far nascere</l>
             <l>Danar, come io promisi, in abondanzia?</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l>E più di quelli ancor che bisognavano.</l>
           </sp>
-          <sp>
+          <sp who="#vulpino">
             <speaker>VULPINO:</speaker>
             <l>Or se tu n’hai più del bisogno, rendili</l>
             <l part="I">Al tuo padre.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="M">Non farò già.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Né Fulcio</l>
             <l part="I">Ti dà questo consiglio.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">E meno io prendere</l>
             <l part="I">Lo vorrei.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Saran buoni quei ch’avanzano</l>
             <l>Da farti qualche giorno con Eulalia</l>
             <l part="I">Tua goder.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Quanti a Lucramo vogliamone</l>
             <l part="I">Dar?</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Quei che potren manco. Ci ha a concorrere</l>
             <l part="I">Per la metade Caridoro.</l>
           </sp>
-          <sp>
+          <sp who="#erofilo">
             <speaker>EROFILO:</speaker>
             <l part="F">Pigliali,</l>
             <l part="I">E fanne quel che ti par.</l>
           </sp>
-          <sp>
+          <sp who="#fulcio">
             <speaker>FULCIO:</speaker>
             <l part="F">Anzi portali</l>
             <l>Teco, che tosto ch’abbi questa giovene</l>

--- a/tei/ariosto-la-lena.xml
+++ b/tei/ariosto-la-lena.xml
@@ -76,6 +76,64 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="corbolo">
+            <persName>Corbolo</persName>
+          </person>
+          <person xml:id="flavio">
+            <persName>Flavio</persName>
+          </person>
+          <person xml:id="lena">
+            <persName>Lena</persName>
+          </person>
+          <person xml:id="fazio">
+            <persName>Fazio</persName>
+          </person>
+          <person xml:id="ilario">
+            <persName>Ilario</persName>
+          </person>
+          <person xml:id="egano">
+            <persName>Egano</persName>
+          </person>
+          <person xml:id="pacifico">
+            <persName>Pacifico</persName>
+          </person>
+          <person xml:id="cremonino">
+            <persName>Cremonino</persName>
+          </person>
+          <person xml:id="torbido">
+            <persName>Torbido</persName>
+          </person>
+          <person xml:id="gemignano">
+            <persName>Gemignano</persName>
+          </person>
+          <person xml:id="giuliano">
+            <persName>Giuliano</persName>
+          </person>
+          <person xml:id="bartolo">
+            <persName>Bartolo</persName>
+          </person>
+          <person xml:id="magagnino">
+            <persName>Magagnino</persName>
+          </person>
+          <person xml:id="spagnolo">
+            <persName>Spagnolo</persName>
+          </person>
+          <personGrp xml:id="sbirri">
+            <name>Sbirri</name>
+          </personGrp>
+          <person xml:id="menica">
+            <persName>Menica</persName>
+          </person>
+          <personGrp xml:id="staffieri">
+            <name>Staffieri</name>
+          </personGrp>
+          <person xml:id="menghino">
+            <persName>Menghino</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>2007-06-08T00:00:00.000+02:00</date><name>Novadata systems</name>Digitalizzazione - OCR</change>
@@ -253,7 +311,7 @@
           <div type="scene" n="Scena I">
             <head>SCENA I</head>
             <stage>Corbolo, Flavio</stage>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Flavio, se la dimanda è però lecita,</l>
               <l>Dimmi: ove vai sì per tempo? che suonano</l>
@@ -262,13 +320,13 @@
               <l>Vestito e ben ornato, e come bossolo</l>
               <l>Di spezie tutto ti sento odorifero.</l>
             </sp>
-            <sp>
+            <sp who="#flavio">
               <speaker>FLAVIO:</speaker>
               <l>Io vo qui dove il mio Signor gratissimo,</l>
               <l>Amor, mi mena a pascere i famelici</l>
               <l>Occhi d'una bellezza incomparabile.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>E che bellezza vuoi tu in queste tenebre</l>
               <l>Veder? Se forse veder non desideri</l>
@@ -276,40 +334,40 @@
               <l>Ma né quell'anco di levarsi è solita</l>
               <l part="I">Così per tempo.</l>
             </sp>
-            <sp>
+            <sp who="#flavio">
               <speaker>FLAVIO:</speaker>
               <l part="F">Né cotesta, Corbolo,</l>
               <l>Né stella altra del ciel, né il sole proprio</l>
               <l>Luce quanto i begli occhi di Licinia.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Né gli occhi de la gatta; questo aggiungere</l>
               <l>Dovevi ancora, che saria più simile</l>
               <l>Comparazion, perché son occhi e lucono.</l>
             </sp>
-            <sp>
+            <sp who="#flavio">
               <speaker>FLAVIO:</speaker>
               <l>Il malanno che Dio te dia, che compari</l>
               <l>Gli occhi d'animal bruto ai lumi angelici!</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Gli occhi di Cochiolin più confarebbonsi,</l>
               <l>Di Sabbadino, Mariano e simili,</l>
               <l>Quando di Gorgadello ubriachi escono.</l>
             </sp>
-            <sp>
+            <sp who="#flavio">
               <speaker>FLAVIO:</speaker>
               <l part="I">Deh, va' in malora!</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Anzi in buon'ora a stendermi</l>
               <l>Nel letto, et a fornirvi un suavissimo</l>
               <l part="I">Sonno che tu m'hai rotto.</l>
             </sp>
-            <sp>
+            <sp who="#flavio">
               <speaker>FLAVIO:</speaker>
               <l part="F">Or vien qui et odimi,</l>
               <l>E pon da lato queste sciocche arguzie.</l>
@@ -326,13 +384,13 @@
               <l>Ch'a patto ignun non te ne vo' richiedere,</l>
               <l>Se prima di tacerlo non mi t'oblighi.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Non accade usar meco questo prologo,</l>
               <l>Che tu sai ben per qualche esperïenzia</l>
               <l>Ch'ove sia di bisogno so star tacito.</l>
             </sp>
-            <sp>
+            <sp who="#flavio">
               <speaker>FLAVIO:</speaker>
               <l>Or odi: io so che sai, senza ch'io 'l replichi,</l>
               <l>Ch'amo Licinia, figliuola di Fazio</l>
@@ -359,11 +417,11 @@
               <l>Entrar, potriano alcun sospetto prendere,</l>
               <l part="I">Vuol ch'io v'entri di notte.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">È convenevole.</l>
             </sp>
-            <sp>
+            <sp who="#flavio">
               <speaker>FLAVIO:</speaker>
               <l>Verrà a suo acconcio e tornerà la giovane,</l>
               <l>Come andarvi e tornarne ogni di è solita.</l>
@@ -371,13 +429,13 @@
               <l>Insino a notte. Questa notte tacita–</l>
               <l part="I">mente uscironne.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Con che modo volgere</l>
               <l>Hai potuto la moglie di Pacifico</l>
               <l>Che ruffiana ti sia de la discepola?</l>
             </sp>
-            <sp>
+            <sp who="#flavio">
               <speaker>FLAVIO:</speaker>
               <l>Disposta l'ho con quel mezzo medesimo</l>
               <l>Con che più salde menti si dispongono</l>
@@ -402,26 +460,26 @@
               <l>Come ita sia la cosa, che stia tacita</l>
               <l part="I">Fin a diman.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Se ti crede, fia un'opera</l>
               <l>Santa che tu l'inganni. Porca! ch'ardere</l>
               <l>La possa il fuoco! Non ha conscïenzia,</l>
               <l>Di chi si fida in lei la figlia vendere!</l>
             </sp>
-            <sp>
+            <sp who="#flavio">
               <speaker>FLAVIO:</speaker>
               <l>E che sai tu che gran ragion non abbia?</l>
               <l>Acciò tu intenda, questo vecchio misero</l>
               <l>Le ha voluto già bene, e 'l desiderio</l>
               <l part="I">Suo molte volte n'ha avuto.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Miracolo!</l>
               <l part="I">Gli è forse il primo?</l>
             </sp>
-            <sp>
+            <sp who="#flavio">
               <speaker>FLAVIO:</speaker>
               <l part="F">Ben credo, patendolo</l>
               <l>Il marito, o fingendo non accorgersi.</l>
@@ -436,7 +494,7 @@
               <l>Pigion alcuna —; come nulla meriti</l>
               <l>Ella de l'insegnar che fa a Licinia!</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Veramente, se fin qui nulla merita,</l>
               <l>Meritarä ne l'avenir, volendole</l>
@@ -444,7 +502,7 @@
               <l>Che far si possa, di menar le calcole</l>
               <l>E batter fisso. Ella ha ragion da vendere.</l>
             </sp>
-            <sp>
+            <sp who="#flavio">
               <speaker>FLAVIO:</speaker>
               <l>Abbia torto o ragion, c'ho da curarmene?</l>
               <l>Poi che mi fa piacer, le ho d'aver obligo.</l>
@@ -459,58 +517,58 @@
               <l>Quest'è un fiorino, te': non me ne rendere</l>
               <l part="I">Danaro in drieto.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Il ricordo è superfluo.</l>
             </sp>
-            <sp>
+            <sp who="#flavio">
               <speaker>FLAVIO:</speaker>
               <l part="I">lo vo' far segno alla Lena.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Sì, faglilo,</l>
               <l>Ma su la faccia, che, per Dio, lo merita.</l>
             </sp>
-            <sp>
+            <sp who="#flavio">
               <speaker>FLAVIO:</speaker>
               <l>Perché, se mi fa bene, ho io da offenderla?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Il farti ella suonar, come un bel cembalo,</l>
               <l>Di venticinque fiorini, tu nomini</l>
               <l>Bene? Ma dimmi: ove sarà, pigliandoli</l>
               <l>Tu in presto, poi provisïon di renderli?</l>
             </sp>
-            <sp>
+            <sp who="#flavio">
               <speaker>FLAVIO:</speaker>
               <l>No quattro mesi da pensarci termine;</l>
               <l>Che sai che possa in questo mezzo nascere?</l>
               <l>Non potrebbe morir, prima che fossino</l>
               <l part="I">Li tre, mio padre?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Sì; ma potria vivere</l>
               <l>Ancor: se vive, come è più credibile,</l>
               <l>Che modo avrai di pagar questo debito?</l>
             </sp>
-            <sp>
+            <sp who="#flavio">
               <speaker>FLAVIO:</speaker>
               <l>Non verrai tu sempre a prestarmi un'opera,</l>
               <l part="I">Che gli vorrò far un fiocco?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Te n'offero</l>
               <l part="I">Più di diece.</l>
             </sp>
-            <sp>
+            <sp who="#flavio">
               <speaker>FLAVIO:</speaker>
               <l part="F">Ma sento che l'uscio apreno.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>E tu aprir loro il borsello apparecchiati.</l>
             </sp>
@@ -518,65 +576,65 @@
           <div type="scene" n="Scena II">
             <head>SCENA II</head>
             <stage>Flavio, Lena, Corbolo</stage>
-            <sp>
+            <sp who="#flavio">
               <speaker>FLAVIO:</speaker>
               <l part="I">Buon dì, Lena, buon dì.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Saria più proprio</l>
               <l>Dir buona notte. Oh, molto sei sollecito!</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="I">Più cortese.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Con buoni effetti vogliolo</l>
               <l>Risalutar ben lo dovevi, et essere</l>
               <l>Risalutar, non con parole inutili.</l>
             </sp>
-            <sp>
+            <sp who="#flavio">
               <speaker>FLAVIO:</speaker>
               <l>So ben che 'l mio buon dì sta nel tuo arbitrio:</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="I">E 'l mio nel tuo.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Anch'io il mio nel tuo mettere</l>
               <l part="I">Vorrei.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">O che guadagno! Dimmi, Flavio:</l>
               <l part="I">Hai tu quella faccenda</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Ben puoi credere</l>
               <l>Che non saria venuto, non avendola.</l>
               <l>Ti so dir che l'ha bella e ben in ordine?</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l>Non li dico di quella; ma dimandogli</l>
               <l part="I">S'egli arreca denar.</l>
             </sp>
-            <sp>
+            <sp who="#flavio">
               <speaker>FLAVIO:</speaker>
               <l part="F">Credea arrecarteli</l>
               <l part="I">Per certo...</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Tu credevi? Mal principio</l>
               <l part="I">Cotesto!</l>
             </sp>
-            <sp>
+            <sp who="#flavio">
               <speaker>FLAVIO:</speaker>
               <l part="F">...ch'un amico mio servirmene</l>
               <l>Dovea fin ieri, e poi mi fece intendere</l>
@@ -585,108 +643,108 @@
               <l>Ma sta' sopra di me: doman non fieno</l>
               <l part="I">Vint'ore, che gli arai.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Diman, avendoli,</l>
               <l>Farò che l'altro dì, a questa medesima</l>
               <l>Ora, intrarai qua dentro. Intanto renditi</l>
               <l part="I">Certo di star di fuori.</l>
             </sp>
-            <sp>
+            <sp who="#flavio">
               <speaker>FLAVIO:</speaker>
               <l part="F">Lena, reputa</l>
               <l part="I">D'averli.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Pur parole, Flavio: reputa</l>
               <l>Ch'io non son, senza denari, per crederti.</l>
             </sp>
-            <sp>
+            <sp who="#flavio">
               <speaker>FLAVIO:</speaker>
               <l part="I">Ti do la fede mia.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Saria mal cambio</l>
               <l>Tôr per denari la fede, che spendere</l>
               <l>Non si può; e questi che i dazi riscuoteno,</l>
               <l>Fra le triste monete la bandiscono.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="I">Tu cianci, Lena, sì?</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Non ciancio: dicoli</l>
               <l part="I">Del meglior senno ch'io m'abbia.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Può essere</l>
               <l>Che, essendo bella, tu non sia piacevole</l>
               <l part="I">Ancora?</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">O bella o brutta, il danno e l'utile</l>
               <l>È mio: non sarò almen sciocca, che volgere</l>
               <l part="I">Mi lassi a ciance.</l>
             </sp>
-            <sp>
+            <sp who="#flavio">
               <speaker>FLAVIO:</speaker>
               <l part="F">Mi sia testimonio</l>
               <l part="I">Dio.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Testimonio non vo' ch'allo esamine</l>
               <l part="I">Io non possa condur.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Sì poco credito</l>
               <l part="I">Abbiamo teco noi?</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Non stia qui a perdere</l>
               <l>Tempo, ch'io gli conchiudo ch'egli a mettere</l>
               <l>Non ha qua dentro il piede se non vengono</l>
               <l>Prima questi denari e l'uscio gli aprino.</l>
             </sp>
-            <sp>
+            <sp who="#flavio">
               <speaker>FLAVIO:</speaker>
               <l part="I">Tu temi ch'io te la freghi?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Sì, fregala,</l>
               <l>Padron, che poi ti sarà più piacevole.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="I">lo non ho scesa.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">(Un randello di frassino</l>
               <l>Di due braccia ti freghi le spalle, asina!)</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l>Io voglio, dico, denari, e non frottole.</l>
               <l>Sa.ben che 'l patto è così; né dolersene</l>
               <l part="I">Può.</l>
             </sp>
-            <sp>
+            <sp who="#flavio">
               <speaker>FLAVIO:</speaker>
               <l part="F">Tu di' il vero, Lena: ma può essere</l>
               <l>Che sii sì cruda, che mi vogli escludere</l>
               <l part="I">Di casa tua?</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Può esser che sì semplice</l>
               <l>Mi estimi, Flavio, ch'io ti debba credere</l>
@@ -700,7 +758,7 @@
               <l>Lievati la berretta, e all'Ebreo mandali,</l>
               <l>Che ben de l'altre robe hai da rimetterti.</l>
             </sp>
-            <sp>
+            <sp who="#flavio">
               <speaker>FLAVIO:</speaker>
               <l>Facciàn, Lena, così: piglia in deposito</l>
               <l>Fin a diman questa roba, et impegnala</l>
@@ -708,12 +766,12 @@
               <l>Non ti do li denari, o fo arrecarteli</l>
               <l part="I">Per costui.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Tu pur te ne spoglia, e mandala</l>
               <l part="I">Ad impegnar tu stesso.</l>
             </sp>
-            <sp>
+            <sp who="#flavio">
               <speaker>FLAVIO:</speaker>
               <l part="F">Mi delibero</l>
               <l>Di compiacerti, e di forti conoscere</l>
@@ -721,21 +779,21 @@
               <l>Questa berretta e questa roba: aiutami,</l>
               <l part="I">Ch'ella non vada in terra.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Che, vuoi trartela?</l>
             </sp>
-            <sp>
+            <sp who="#flavio">
               <speaker>FLAVIO:</speaker>
               <l>La vo' a ogni modo satisfar; che diavolo</l>
               <l part="I">Fia?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Or vadan tutti li beccai e impicchinsi,</l>
               <l>Che nessuno ben come la Lena scortica.</l>
             </sp>
-            <sp>
+            <sp who="#flavio">
               <speaker>FLAVIO:</speaker>
               <l>Voglio che fra le quindici e le sedici</l>
               <l>Ore, da parte mia, tu vada a Giulio,</l>
@@ -747,27 +805,27 @@
               <l>Venticinque fiorini; e, come avutoli</l>
               <l>Abbi, o da un luogo o da un altro, qui arrecali.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="I">E tu starai spogliato?</l>
             </sp>
-            <sp>
+            <sp who="#flavio">
               <speaker>FLAVIO:</speaker>
               <l part="F">Che più? Portami</l>
               <l part="I">Un cappin e un saion di panno.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Spacciala;</l>
               <l>Ch'ancor ch'egli entri qui, non ha da credere</l>
               <l>Ch'io voglia che di qua passi la giovane</l>
               <l>Prima che li contanti non mi annoveri.</l>
             </sp>
-            <sp>
+            <sp who="#flavio">
               <speaker>FLAVIO:</speaker>
               <l part="I">Intrarò dunque in casa.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Sì ben, entraci;</l>
               <l>Ma con la condizion ch'io ti specifico.</l>
@@ -776,7 +834,7 @@
           <div type="scene" n="Scena III">
             <head>SCENA III</head>
             <stage>Corbolo solo</stage>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Potta! che quasi son per attaccargliela.</l>
               <l>Ho ben avute a' miei di mille pratiche</l>
@@ -804,7 +862,7 @@
           <div type="scene" n="Scena I">
             <head>SCENA I</head>
             <stage>Fazio, Lena</stage>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l>Chi non si lieva per tempo, e non opera</l>
               <l>La matina le cose che gl'importano,</l>
@@ -825,25 +883,25 @@
               <l>Un agnel buono... Eh non, fia meglio venderlo.</l>
               <l part="I">Va', va'... Purtroppo...</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Sì, era un miracolo</l>
               <l>Che diventato voi foste a prodigo!</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="I">Buon dì, Lena.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Buon dì e buon anno, Fazio</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l>Ti lievi sì per tempo?Che disordine</l>
               <l part="I">È questo tuo?</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Saria ben convenevole</l>
               <l>Che, poi che voi mi vestite sì nobile–</l>
@@ -851,111 +909,111 @@
               <l>Che fin a nona io dormissi a mio commodo,</l>
               <l>E 'l di senza far nulla io stessi in ozio!</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l>Fo quel ch'io posso, Lena: maggior rendite</l>
               <l>De le mie a farti cotesto sarebbono</l>
               <l>Bisogno; pur, secondo che si stendono</l>
               <l>Le mie forze, mi studio di farti utile.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="I">Che util mi fate voi?</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="F">Quest'è il tuo solito</l>
               <l>Di sempremai scordarti i benefizii.</l>
               <l>Sol mentre ch'io ti do, me ne ringrazii</l>
               <l>Tosto c'ho dato, il contrario fai sùbito.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l>Che mi deste voi mai? Forse repetere</l>
               <l>Volete ch'io sto qui senza pagarvene</l>
               <l part="I">Pigione?</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="F">Ti par poco? Son pur dodici</l>
               <l>Lire ogn'anno coteste, senz'il commodo</l>
               <l>C'hai d'essermi vicina;, ma tacermene</l>
               <l>Voglio, per non parer di rinfacciartelo</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l>Che rinfacciar? Che se talor v'avanzano</l>
               <l>Minestre o broda, solete mandarmene?</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="I">Anch'altro, Lena.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Forse una o due coppie</l>
               <l>Di pane il mese; o un poco di vin putrido?</l>
               <l>O di lasciarmi tôrre un legno picciolo,</l>
               <l>Quando costì le carra se ne scarcano?</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="I">Hai ben anch'altro.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Ch'altro ho io? deh, ditelo;</l>
               <l part="I">Cotte di raso o di velluto?</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="F">Lecito</l>
               <l>Non saria a te portarle, né possibile</l>
               <l part="I">A me di darle.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Una saia mostratemi</l>
               <l>Che voi mi deste mai.</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l>Non vo'rispondérti</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l>Qualche par di scarpacce o di pantofole,</l>
               <l>Poi che l'avete ben spellate e logore,</l>
               <l>Mi date alcuna volta per Pacifico.</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="I">E nuove anco per te.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Non credo siano</l>
               <l>In quattr'anni tre paia. Or nulla vagliono</l>
               <l>Le virtuti che insegno e che continua,</l>
               <l part="I">mente ho insegnate a vostra figlia?</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="F">Vagliono</l>
               <l part="I">Assai, non voglio negar.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Ch'a principio</l>
               <l>Ch'io venni a abitar qui, non sapea leggere</l>
               <l>Ne la tavola il <foreign xml:lang="lat">pater</foreign> pur a compito,</l>
               <l part="I">Né tener l'ago.</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="M">È vero.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Né pur volgere</l>
               <l>Un fuso: et or sì ben dice l'offizio,</l>
@@ -963,7 +1021,7 @@
               <l>Che sia in Ferrara: non è sì difficile</l>
               <l>Punto ch'ella nol tolga da l'essempio.</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l>Ti confesso ch'è 'l vero; non voglio essere</l>
               <l>Simile a te, ch'io nieghi d'averti obligo:</l>
@@ -973,7 +1031,7 @@
               <l>Di dieci giulii l'anno: differenzia</l>
               <l>Mi par pur grande da tre lire a dodici!</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l>Non ho mai fatto altro per voi, ch'io meriti</l>
               <l>Nove lire di più? In nome del diavolo,</l>
@@ -987,11 +1045,11 @@
               <l>Ma non vi voglio più star dentro: datela</l>
               <l part="I">Ad altri.</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="M">Guarda,quel che tu di'.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Datela.</l>
               <l>Non vo' che sempremai mi si rimproveri</l>
@@ -1000,27 +1058,27 @@
               <l>Di drieto al Paradiso una, o nel Gambaro,</l>
               <l part="I">Non vo' star qui.</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="F">Pensaci ben, e parlami.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l>Io ci ho pensato quel ch'io voglio: datela</l>
               <l part="I">A chi vi pare.</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="F">Io la trovo da vendere,</l>
               <l part="I">E venderolla.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Quel che vi par fatene:</l>
               <l>Vendetela, donatela, et ardetela,</l>
               <l>Anch'io procaccerò trovar recapito.</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l>(Quanto più fo carezze e più mi umilio)</l>
               <l>A costei, tanto più superba e rigida</l>
@@ -1028,33 +1086,33 @@
               <l>Ciò ch'io le dono; così poca grazia</l>
               <l>Me n'ha: vorria potermi succhiar l'anima.)</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l>(Quasi che senza lui non potrò vivere!)</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l>(E veramente, oltre che non mi pagano</l>
               <l>La pigion de la casa, più di dodeci</l>
               <l>Altre lire ella e 'l marito mi costano</l>
               <l part="I">L'anno.)</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">(Dio grazia, io sono anco sì giovane,</l>
               <l part="I">Ch'io mi posso aiutar.)</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="F">(Spero d'abbattere</l>
               <l>Tanta superbia: io non voglio già vendere</l>
               <l>La casa, ma si ben farglielo credere.)</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="I">(Non son né guercia, né sciancata.)</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="F">(Voglioci</l>
               <l>Condurre o Biagïolo o quel da l'Abbaco</l>
@@ -1070,7 +1128,7 @@
           <div type="scene" n="Scena II">
             <head>SCENA II</head>
             <stage>Lena sola</stage>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l>Vorrebbe il dolce senza amaritudine;</l>
               <l>Ammorbarmi col fiato suo spiacevole</l>
@@ -1106,18 +1164,18 @@
           <div type="scene" n="Scena III">
             <head>SCENA III</head>
             <stage>Corbolo, Lena</stage>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>(Un uom val cento, e cento un uom non vagliono.</l>
               <l>Questo è un proverbio che in esperïenzia</l>
               <l part="I">Questa matina ho avuto.)</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Parmi Corbolo</l>
               <l part="I">Che di là viene: è desso.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">(Che partendomi</l>
               <l>Di qui per far quanto m'impose, Flavio,</l>
@@ -1126,32 +1184,32 @@
               <l>Indi inanzi al Castello, e i pizzicagnoli</l>
               <l>Vo dimandando s'hanno quaglie o tortore.)</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l>Vien molto adagio: par che i passi annoveri.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>(Nulla ne truovo: alcuni piccion veggovi</l>
               <l>Sì magri, sì leggieri che parevano</l>
               <l>Che la quartana un anno avuto avessino.)</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="I">Pur ch'egli abbia i denar!</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Un altro toltoli</l>
               <l>Averia, e detto fra sé: non ce n'erano</l>
               <l>De' megliori; c'ho a far che, magri sieno</l>
               <l>O grassi, poiché non s'han per me a cuocere?)</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l>Vien col braccio sinistro molto carico.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>(Ma non ho fatto io così; che gli ufficii,</l>
               <l>Non le discrezïoni, dar si dicono.</l>
@@ -1172,12 +1230,12 @@
               <l>E perché non son care! Si concordano</l>
               <l part="I">Tutti al mio detto.)</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Io vo' aspettarlo, e intendere</l>
               <l part="I">Quel ch'egli ha fatto.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">(Io mi parto: mi séguita</l>
               <l>Un d'essi, e al canto ove comincian gli Orafi</l>
@@ -1197,11 +1255,11 @@
               <l>Quattro, sei, sette, diece paia, accennami</l>
               <l>Pur che tra noi stia la cosa. — Ringraziolo...)</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l>Par che molto fra sé parli fantastichi.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>(...E gli prometto la mia fede d'essere</l>
               <l>Secreto: ma mi vien voglia di ridere;</l>
@@ -1210,11 +1268,11 @@
               <l>Guardar la sua campagna; e li medesimi</l>
               <l>Che n'hanno cura, son quei che la rubano.)</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l>Spiccati, che spiccata ti sia l'anima!</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>(Non ponno a nozze et a conviti publici</l>
               <l>Li fagiani apparir sopra le tavole,</l>
@@ -1224,29 +1282,29 @@
               <l>Lesso; e qui nel canestro caldi arrecoli.</l>
               <l part="I">Ecco la Lena.)</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Hai tu i denari, Corbolo?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="I">Io li avrò.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Non mi piace udir risponde</l>
               <l part="I">In futuro.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Contraria all'altre femine</l>
               <l>Sei tu, che tutte l'altre il futuro amano.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="I">Piaceno a me i presenti.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Ecco, presentoti</l>
               <l>Cappon, fagiani, pan, vin, cacio: portali</l>
@@ -1254,20 +1312,20 @@
               <l>Aver portati piccioni, vedendoti</l>
               <l>Averne in seno dui grossi bellissimi.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="I">Deh, ti venga il malanno.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Lascia pormivi</l>
               <l>La man, ch'io tocchi come sono morbidi.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l>lo ti darò d'un pugno. I denar, dicoti.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Finalmente ogni salmo torna in gloria.</l>
               <l>Tu non tel scordi: fra mezz'ora arrecoli.</l>
@@ -1280,87 +1338,87 @@
               <l>Hanno d'aver? ch'io son cagion potissima</l>
               <l>Che i venticinque fiorin ti si diano.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="I">Che vòi tu?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Ch'io tel dica? Quel che dandomi,</l>
               <l>E se ne dessi a cento, non pòi perdere.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="I">lo non intendo.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="M">Io 'l dirò chiaro.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Portami</l>
               <l>I denar, ch'io non so senz'essi intendere.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Son dunque i denar buoni a far intendere?</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l>Me sì, e credo anco non men tutti gli uomini.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Saria, Lena, cotesto buon rimedio</l>
               <l part="I">A far ch'udisse un sordo?</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Differenzia</l>
               <l>Molta è, babbion, tra l'udire e l'intendere.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Fa' che anch'io sappia questa differenzia.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l>Gli asini ragghiar s'odono alla macina,</l>
               <l part="I">Né s'intendon però.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">A me par facile,</l>
               <l>Sempre ch'io gli odo, intenderli; vorrebbono</l>
               <l>A punto quel ch'anch'io da te desidero.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l>Tu sei malizïoso più che 'l fistolo</l>
               <l>Or che l'arrosto è in stagion, vieni, andiamone</l>
               <l part="I">A mangiar.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Vengo. Dimmi: ov'è la giovane?</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="I">Dove sono i denari?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Credo farteli</l>
               <l part="I">Aver fra un'ora.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Et io credo la giovane</l>
               <l>Far venir qui come i denar ci siano.</l>
               <l>Andiàn, che le vivande si raffreddano.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Va' là, ch'io vengo. Possino esser l'ultime</l>
               <l>Che tu mangi mai più; ch'elle t'affoghino!</l>
@@ -1377,7 +1435,7 @@
           <div type="scene" n="Scena I">
             <head>SCENA I</head>
             <stage>Corbolo solo</stage>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Or ho di due faccende fatto prospera–</l>
               <l>mente una, e con satisfazione d'animo,</l>
@@ -1424,304 +1482,304 @@
           <div type="scene" n="Scena II">
             <head>SCENA II</head>
             <stage>Ilario, Egano, Corbolo</stage>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>Non si dovrebbe alcuna cosa in grazia</l>
               <l>Aver mai sì che potendo ben venderla,</l>
               <l>Non si vendesse, solo eccettuandone</l>
               <l part="I">Le mogli.</l>
             </sp>
-            <sp>
+            <sp who="#egano">
               <speaker>EGANO:</speaker>
               <l part="F">E quelle ancor, se fosse lecito</l>
               <l part="I">Per legge o per usanza.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Non che in vendita,</l>
               <l>Ma a baratto, ma in don dar si dovrebbeno.</l>
             </sp>
-            <sp>
+            <sp who="#egano">
               <speaker>EGANO:</speaker>
               <l>Di quelle che non far per te, <foreign xml:lang="lat">intelligitur</foreign>.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>Ita: non è già usanza che si vendano,</l>
               <l>Ma darle ad uso par che pur si toleri.</l>
               <l>D'un par di buoi, per tornar a proposito,</l>
               <l>Parlo, che trenta ducati, e tutti ungari.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>(Questi al bisogno nostro supplirebbono.)</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>...Ieri io vendei a un contadin da Sandalo.</l>
             </sp>
-            <sp>
+            <sp who="#egano">
               <speaker>EGANO:</speaker>
               <l part="I">Esser belli dovean.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Potete credere...</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="I">(Io li voglio, io li avrò.)</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">…che son bellissimi.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="I">(Son nostri.)</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Belli a posta lor: mi piaceno</l>
               <l part="I">Molto più questi denar.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">È impossibile</l>
               <l part="I">Che non stia forte.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Almen non avrò dubbio</l>
               <l>che 'l giudice alle fosse me li scortichi</l>
             </sp>
-            <sp>
+            <sp who="#egano">
               <speaker>EGANO:</speaker>
               <l>Feste bene. Quest'è la via. Potendovi</l>
               <l part="I">Far piacer, commandatemi.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">A Dio, Egano.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>(La quaglia è sotto la rete; io vo' correre</l>
               <l>Inanzi, e for ch'ella s'appanni, e prendasi.)</l>
               <l>Io non so che mi far, dove mi volgere,</l>
               <l part="I">Poi che 'l padron non è in la terra.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">(O che essere</l>
               <l part="I">può questo?)</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">E che accadea partirsi a Flavio?</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>(Questa fia qualche cosa dispiacevole.)</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Molto era meglio aver scritto una lettera</l>
               <l>Al padre, e aver mandato un messo sùbito...</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>(Ohimè, occorsa sarà qualche disgrazia!)</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="I">...Ch'andarvi egli in persona.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">(Che può essere?)</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Meglio era ch'egli istesso il fêsse intendere</l>
               <l part="I">Al Duca.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="M">(Dio m'aiuti!)</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Come Ilario</l>
               <l part="I">Lo sa, verrà volando a casa.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Corbolo!</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Non lo vorrà patir e farà il diavolo.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="I">Corbolo!</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="M">Ma che farà anch'egli?</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Corbolo!</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="I">Chi mi chiama? O padron!</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="M">Che c'è?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">V'ha Flavio</l>
               <l part="I">Scontrato?</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="M">Ch'è di lui?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Non eran dodici</l>
               <l>Ore, ch'uscì de la cittade, e dissemi</l>
               <l part="I">Che veniva a trovarvi.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Che importanzia</l>
               <l part="I">C'era?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Voi non sapete a che pericolo</l>
               <l part="I">Egli sia stato!</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Pericolo? Narrami</l>
               <l part="I">Che gli è accaduto.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Può dir, padron, d'essere</l>
               <l>Un'altra volta nato: quasi mortio lo</l>
               <l>Hanno alcuni giottoni; pur, Dio grazia,</l>
               <l part="I">Il male...</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="M">Ha dunque mal?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Non di pericolo.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>Che pazzia è stata la sua di venirsene</l>
               <l>In villa s'egli ha male, o grande o piccolo?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>L'andar a questo mal suo non può nuocere.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="I">Come non?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Non, vi dico; anzi più agile</l>
               <l part="I">Ne fia.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="M">Dimmi: è ferito?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Sì, e difficile–</l>
               <l>mente potrà guarir; non già che sanguini</l>
               <l part="I">La piaga.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="M">Ohimè, io son morto!</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Ma intendetemi</l>
               <l part="I">Dove.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="M">Di'.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Non nel capo, non negli omeri,</l>
               <l part="I">Non nel petto o ne' fianchi.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Dove? spacciala.</l>
               <l part="I">Pur ha mal?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">N'ha purtroppo, e rincrescevole.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>Esser non può ch'egli non stia gravissimo.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="I">Anzi troppo leggiero.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Oh, tu mi strazii!</l>
               <l>Ha male o non ha mal? Chi ti può intendere?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="I">Vel dirò.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="M">Di' in mal punto.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="M">Udite.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Séguita.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="I">Non è ferito nel corpo.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Ne l'anima</l>
               <l part="I">Dunque?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">È ferito in una cosa simile.</l>
               <l>Flavio con una brigata di giovini</l>
@@ -1735,139 +1793,139 @@
               <l>Fu circondato da quattro, et aveano</l>
               <l>Arme d'asta, ch'assai colpi gli trassero.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>E non l'hanno ferito? Oh che pericolo!</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Com'è piaciuto a Dio, mai non lo colsero</l>
               <l part="I">Ne la persona.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">O Dio, te ne ringrazio.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Egli voltò loro le spalle, e messesi</l>
               <l>Quanto più andar poteano i piedi, a correre.</l>
               <l part="I">Un gli trasse alla testa.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="M">Ohimè!</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Ma colselo</l>
               <l>Ne la medaglia d'or ch'aveva, e caddegli</l>
               <l part="I">La berretta.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="M">E perdella?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Non: la tolsero</l>
               <l part="I">Quelli rubaldi.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">E non glila renderono?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="I">Renderon, eh?</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Mi costò più di dodici:</l>
               <l>Ducati coi pontal d'oro che v'erano.</l>
               <l>Lodato Dio, che peggio non gli fecero.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>La roba fra le gambe aviluppandosi,</l>
               <l>Che gli cadea da un lato, fu per metterlo</l>
               <l>Tre volte o quattro in terra; al fin, gittandola</l>
               <l>Con ambedue le mani, sviluppossene.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="I">Insomma l'ha perduta?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Pur la tolsero</l>
               <l part="I">Quei ladroncelli ancora.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">E se la tolsero</l>
               <l>Quei ladroncelli, non ti par che Flavio</l>
               <l part="I">L'abbia perduta?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Non credea che perdere</l>
               <l>Si dicesse alle cose ch'altri trovano.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>Oh, tu sei grosso! Mi vien, con la federa</l>
               <l>Ottanta scudi. Insomma; non è Flavio</l>
               <l part="I">Ferito?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="M">Non, ne la persona.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">U' diavolo</l>
               <l>In altra parte ferir lo poteano?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Ne la mente; che si pon gran fastidio</l>
               <l>Pensando, oltr'al suo danno alla molestia</l>
               <l>Che voi ne sentirete risapendolo.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>Vide chi fusser quei che l'assalissero?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Non che la gran paura, e l'oscurissima</l>
               <l>Notte, non gli ne lasciò alcun conoscere.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="I">Por si può al libro de l'uscita.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Temone.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>Frasca! perché non t'aspettar, dovendolo</l>
               <l part="I">Tu gir a tôr?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="M">Vedete pur...</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Ma un asino</l>
               <l>Sei tu però, che non fosti sollecito</l>
               <l>Ad ir per lui.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Cotesto è il vostro solito:</l>
               <l>Me degli errori suoi sempre riprendere.</l>
@@ -1877,24 +1935,24 @@
               <l>Ma non si perda tempo: ora. prendeteci,</l>
               <l>Padron, che 'l mal è fresco, alcun rimedio.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>Rimedio? E che rimedio poss'io prenderci?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Parlate al podestade, ai segretarii,</l>
               <l>E se sarà bisogno, al Duca proprio.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>E che diavolo vuoi che me ne faccino?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="I">Faccian far gride.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Acciò ch'oltre alla perdita,</l>
               <l>Sia il biasmo ancora Non direbbe il populo</l>
@@ -1914,19 +1972,19 @@
               <l>Col cavallier dei quali o contestabile</l>
               <l>Il podestà fa a parte; e tutti rubano.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="I">Che s'ha dunque da far?</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">D'aver pazienzia.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="I">Flavio non l'avrà mai.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Converrà aversela,</l>
               <l>O voglia o non: poi ch'è campato, reputi</l>
@@ -1941,7 +1999,7 @@
               <l>Mi venga ne la borsa la pecunia</l>
               <l>Ch'avrò spesa perch'egli non stia in perdita.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Non saria buon che i rigattieri fussero</l>
               <l>Avisati, e gli Ebrei, che se venisseno</l>
@@ -1950,7 +2008,7 @@
               <l>Che voi fosse avisato, sì che, andandovi,</l>
               <l>Le riavessi, e lor facessi prendere?</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>Cotesto più giovar potria che nuocere;</l>
               <l>Pur nondi spero: che questi che prestano</l>
@@ -1962,12 +2020,12 @@
               <l>Costan lor poco; e se denar vi prestano</l>
               <l>Sopra, sanno che mai non si riscuoteno.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Avisiamoli pur: facciamo il debito</l>
               <l>Nostro noi.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Se 'l ti par, va' dunque, avisali.</l>
             </sp>
@@ -1975,7 +2033,7 @@
           <div type="scene" n="Scena III">
             <head>SCENA III</head>
             <stage>Corbolo Pacifico</stage>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>La cosa ben procede, e posso metterla</l>
               <l>Per fatta: non mi resta altro a conchiuderla,</l>
@@ -1988,26 +2046,26 @@
               <l>Si sappia e i nostri detti si conformino.</l>
               <l part="I">Ecco Pacifico esce.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="F">Ti vuol Flavio.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>A lui ne vengo, e buone nuove apportogli.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l>Le sa, che ciò c'hai detto, dal principio</l>
               <l>Al fine abbiamo inteso; ch'ambi stati te</l>
               <l>Siamo a udir dietro all'uscio, né perdutane</l>
               <l part="I">Abbiàn parola.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="M">Che ve ne par?</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="F">Demmoti</l>
               <l>La gloria e 'l vanto di saper me' fingere</l>
@@ -2019,38 +2077,38 @@
           <div type="scene" n="Scena IV">
             <head>SCENA IV</head>
             <stage>Fazio, Pacifico</stage>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l>Perché non vi vorrei giunger, Pacifico,</l>
               <l>Improviso, fra un mese provedetevi</l>
               <l>Di casa, che cotesta son per vendere.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l>Gli è vostra: a vostro arbitrio disponetene.</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l>Il comprator et io ci siàn nel Torbido</l>
               <l>Compromessi, che è andato a tôr la pertica</l>
               <l>Per misurarla tutta: non mi dubito</l>
               <l>Che si spicchi da me senza conchiudere.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l>L'avessi ieri saputo, che assettatala</l>
               <l>Un po' l'avrei; mi cogliete in disordine.</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l>Or va', e al me' che puoi, tosto rassettala,</l>
               <l>Che non può far indugio che non venghino.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l>Non oggi, ma diman fate che tornino.</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l>Non ci potrebbe costui che la compera</l>
               <l>Esser domane, che vuol ire a Modena.</l>
@@ -2059,7 +2117,7 @@
           <div type="scene" n="Scena V">
             <head>SCENA V</head>
             <stage>Pacifico, Corbolo</stage>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l>Come faremo, Corbolo, di ascondere</l>
               <l>Il tuo padron che costor non lo veggano?</l>
@@ -2067,43 +2125,43 @@
               <l>S'avisarà la cosa, e sarà il scandolo</l>
               <l part="I">Troppo grande.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Ecci luogo ove nasconderlo?</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l>Che luogo in simil casa (misurandola</l>
               <l>Tutta) esser può sicur che non lo trovino?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Or non c'è alcuna cassa, alcun armario?</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l>Non ci son altre che due casse picciole</l>
               <l>Che Santino in giubbon non capirebbono.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Dunque facciànlo uscir prima che venghino.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="I">Così spogliato?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Io vo a casa, et arrecogli</l>
               <l part="I">Un'altra veste.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="F">Or va' e ritorna sùbito,</l>
               <l part="I">Che qui t'aspetto.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Io veggo uscir Ilario.</l>
             </sp>
@@ -2111,7 +2169,7 @@
           <div type="scene" n="Scena VI">
             <head>SCENA VI</head>
             <stage>Ilario, Corbolo, Cremonino</stage>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>Non sarà se non buono, oltre che Corbolo</l>
               <l>V'abbia mandato, s'anch'io vo; che credere</l>
@@ -2119,256 +2177,256 @@
               <l>Usi ne le mie cose, di me proprio.</l>
               <l part="I">Ma eccol qui. C'hai fatto?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Isac e Beniami</l>
               <l>Dai Sabbioni ho avisato: ora vo' volgermi</l>
               <l>Ai Carri, quei da Riva saran gli ultimi.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>Che dimanda colui che va per battere</l>
               <l part="I">La nostra porta?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">È il Cremonino. (Oh diavolo,</l>
               <l part="I">Siamo scoperti!)</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Che dimandi, giovine?</l>
             </sp>
-            <sp>
+            <sp who="#cremonino">
               <speaker>CREMONINO:</speaker>
               <l part="I">Dimando Flavio.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Oh, quella mi par essere</l>
               <l>La sua veste.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>A me ancor: vedete simile–</l>
               <l>mente la sua berretta. (Or aiutatemi,</l>
               <l part="I">Bugie; se non, siamo spacciati.)</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Corbolo,</l>
               <l part="I">Come va questa cosa?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Li suoi proprii</l>
               <l>Compagni avran fatto la beffa, e toltosi,</l>
               <l>Credo, piacer d'averlo fatto correre.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="I">Bel scherzo in verità!</l>
             </sp>
-            <sp>
+            <sp who="#cremonino">
               <speaker>CREMONINO:</speaker>
               <l part="F">Mio padron Giulio</l>
               <l>Gli rimanda i suoi pegni, e gli fa intendere</l>
               <l part="I">Che quel suo amico...</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Che amico? Odi favola!</l>
             </sp>
-            <sp>
+            <sp who="#cremonino">
               <speaker>CREMONINO:</speaker>
               <l part="I">...Quel che prestar su questi pegni.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Chiacchiare!</l>
             </sp>
-            <sp>
+            <sp who="#cremonino">
               <speaker>CREMONINO:</speaker>
               <l>...Gli dovea li danari, che tu Corbolo...</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="I">O che finzion!</l>
             </sp>
-            <sp>
+            <sp who="#cremonino">
               <speaker>CREMONINO:</speaker>
               <l part="F">...venisti oggi a richiedergli.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="I">Io?</l>
             </sp>
-            <sp>
+            <sp who="#cremonino">
               <speaker>CREMONINO:</speaker>
               <l part="M">   Tu, sì.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Guata viso! come fingere</l>
               <l part="I">Sa bene una bugia!</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Corbolo, pigliali</l>
               <l>E riponli; va', va' tu, va', di' a Giulio</l>
               <l>Che questi scherzi usar. non si dovrebbono</l>
               <l part="I">Con gli amici...</l>
             </sp>
-            <sp>
+            <sp who="#cremonino">
               <speaker>CREMONINO:</speaker>
               <l part="M">Che scherzi?</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">…e convenevoli</l>
               <l part="I">Non sono alli par suoi.</l>
             </sp>
-            <sp>
+            <sp who="#cremonino">
               <speaker>CREMONINO:</speaker>
               <l part="F">Non credo ch'abbia</l>
               <l>Mio padron fatto... Che m'accenni, bestia?</l>
               <l part="I">Vo' dir la verità...</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="M">Accenno io?</l>
             </sp>
-            <sp>
+            <sp who="#cremonino">
               <speaker>CREMONINO:</speaker>
               <l part="F">...e difendere</l>
               <l>El mio padron, ch'a torto tu calunnii.</l>
               <l>S'avesse avuto egli i denar, prestatogli</l>
               <l part="I">Li avrebbe, e volentier.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Danari? Pigliati</l>
               <l>Piacer! Ti sogno forse? O noi pur scorgere</l>
               <l>Credi per ubriachi o per farnetichi?</l>
             </sp>
-            <sp>
+            <sp who="#cremonino">
               <speaker>CREMONINO:</speaker>
               <l>Or non portasti questa veste a Giulio,</l>
               <l part="I">Tu, questa mane?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">A piè o a cavallo? Abbiamoti</l>
               <l part="I">Inteso.</l>
             </sp>
-            <sp>
+            <sp who="#cremonino">
               <speaker>CREMONINO:</speaker>
               <l part="M">Pur anco m'accenni?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Accennoti?</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>Oh, che ti venga il mal di Santo Antonio!</l>
               <l part="I">Non t'ho veduto io che gli accenni?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Accennoli</l>
               <l>Per certo, a dimostrar che le malizie</l>
               <l>Sue conosciamo, e che a noi non può venderle.</l>
             </sp>
-            <sp>
+            <sp who="#cremonino">
               <speaker>CREMONINO:</speaker>
               <l part="I">Malizie son le tue.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">La voglio intendere.</l>
               <l part="I">Onde hai tu avute queste robe?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Giulio</l>
               <l part="I">Ieri stette alla posta.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Da lui vogliolo,</l>
               <l part="I">E non da te, saper.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Ti darà a intendere</l>
               <l>Qualche baia, che sa troppo ben fingere.</l>
             </sp>
-            <sp>
+            <sp who="#cremonino">
               <speaker>CREMONINO:</speaker>
               <l part="I">Fingi pur tu.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Or guatami, e non ridere.</l>
             </sp>
-            <sp>
+            <sp who="#cremonino">
               <speaker>CREMONINO:</speaker>
               <l part="I">Che rider, che guatar?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Va', va', di' a Giulio</l>
               <l>Che Flavio sarà un dì buono per renderli</l>
               <l part="I">Merto di questo.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Non andar, non: lievati</l>
               <l>Pur tu di qui, ch'io vo' da lui informarmene,</l>
               <l part="I">E non da te.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Non fia vero ch'io toleri</l>
               <l part="I">Mai che costui vi dileggi.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Che temi tu,</l>
               <l>Che le parole sue però m'incantino?</l>
               <l>Ma dimmi: queste robe...Va' Via, lievati</l>
               <l part="I">Tu di qui.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Pur volete dargli udienzia?</l>
               <l>Quanti torcoli son per la vendemia</l>
               <l>Non gli potrebbon fare un vero esprimere.</l>
             </sp>
-            <sp>
+            <sp who="#cremonino">
               <speaker>CREMONINO:</speaker>
               <l part="I">Dirò la verità.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Così è possibile</l>
               <l>Come che dica il <title>Paternostro</title> un asino.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="I">Lascialo dir.</l>
             </sp>
-            <sp>
+            <sp who="#cremonino">
               <speaker>CREMONINO:</speaker>
               <l part="F">Io vi dirò il Vangelio.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Scopriànci il capo, perché non è lécito</l>
               <l>Udir a capo coperto il Vangelio.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>Per ogni via tu cerchi d'interrompere;</l>
               <l>Ma se tu parli più... Deh vien, lasciamolo</l>
@@ -2380,7 +2438,7 @@
           <div type="scene" n="Scena VII">
             <head>SCENA VII</head>
             <stage>Corbolo, Pacifico</stage>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Noi siàn forniti: a quattro a quattro correno</l>
               <l>Li venticinque fiorini, ma e' correno</l>
@@ -2392,7 +2450,7 @@
               <l>Mandato questo pecorone a rompere</l>
               <l>Le fila ordite, e ch'io stavo per tessere.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l>Che sei stato costi tanto a contendere?</l>
               <l>Dov'è la vesti che tu arrechi a Flavio?</l>
@@ -2400,40 +2458,40 @@
               <l>Fuor di casa! Che aspetti, ch'entri Fazio,</l>
               <l part="I">E che lo vegga?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">S'io non posso in camera</l>
               <l>Entrar! se m'ha di fuor serrato Ilario!</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="I">Come faremo?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Vedi di nasconderlo</l>
               <l part="I">In casa.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="M">Non c'è luogo.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Dunque mettilo</l>
               <l>Fuor in giubbon. Di due partiti prendene</l>
               <l>L'uno: o l'ascondi in casa o in giubbon mandalo</l>
               <l part="I">Di fuor.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="F">Né l'un né l'altro vogl'io prendere.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="I">Che farai dunque?</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="F">Or mi torna a memoria</l>
               <l>C'ho in casa una gran botte, che prestatami</l>
@@ -2445,38 +2503,38 @@
               <l>Tanto che questi, che verran con Fazio,</l>
               <l>Cercato a suo ben'agio ogni cosa abbiano.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="I">Vi capirà egli dentro?</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="F">Sì, a suo commodo;</l>
               <l>E già più giorni o la nettai benissimo,</l>
               <l>E posso a mio piacer levarne e mettere</l>
               <l part="I">Un fondo.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Andiamo dunque e consigliamoci</l>
               <l part="I">Con essolui.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="F">Credo che questi siano</l>
               <l>A punto quei ch'entrar qua dentro vogliono:</l>
               <l>Son dessi certo, ch'io conosco il Torbido.</l>
               <l part="I">Forniàn noi quel ch'abbiamo a far.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Forniamolo.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="I">Dunque vien,dentro.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Va' là, ch'io ti séguito.</l>
             </sp>
@@ -2484,55 +2542,55 @@
           <div type="scene" n="Scena VIII">
             <head>SCENA VIII</head>
             <stage>Torbido, Gemignano, Fazio</stage>
-            <sp>
+            <sp who="#torbido">
               <speaker>TORBIDO:</speaker>
               <l>Poi ch'io l'avro misurata, la pertica</l>
               <l>Mi dirà quanto ella val, fino a un picciolo.</l>
             </sp>
-            <sp>
+            <sp who="#gemignano">
               <speaker>GEMIGNANO:</speaker>
               <l>Dunque talvolta le pertiche parlano?</l>
             </sp>
-            <sp>
+            <sp who="#torbido">
               <speaker>TORBIDO:</speaker>
               <l>Si ben, e spesso fan parlar, stendendole</l>
               <l>In su le spalle altrui. Ma ecco Fazio.</l>
               <l part="I">Ch'abbiamo a far?</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="F">Quel ch'è detto: mettetevi</l>
               <l>A misurar quando vi par: cominciano</l>
               <l>Qui le confine, e quel segno non passano.</l>
             </sp>
-            <sp>
+            <sp who="#torbido">
               <speaker>TORBIDO:</speaker>
               <l part="I">Cominciarem qui dunque.</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="F">Cominciateci.</l>
             </sp>
-            <sp>
+            <sp who="#torbido">
               <speaker>TORBIDO:</speaker>
               <l part="I">Una; méttevi in capo il coltello.</l>
             </sp>
-            <sp>
+            <sp who="#gemignano">
               <speaker>GEMIGNANO:</speaker>
               <l part="F">Eccolo.</l>
             </sp>
-            <sp>
+            <sp who="#torbido">
               <speaker>TORBIDO:</speaker>
               <l>E dua, e questo appresso, a punto mancano</l>
               <l>Dui sesti, che tre piedi non ponno essere.</l>
               <l part="I">Andiamo or dentro.</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="F">La matita prendere</l>
               <l part="I">Potete, e notar questo.</l>
             </sp>
-            <sp>
+            <sp who="#torbido">
               <speaker>TORBIDO:</speaker>
               <l part="F">Io lo noto, eccolo.</l>
             </sp>
@@ -2540,7 +2598,7 @@
           <div type="scene" n="Scena IX">
             <head>SCENA IX</head>
             <stage>Giuliano solo</stage>
-            <sp>
+            <sp who="#giuliano">
               <speaker>GIULIANO:</speaker>
               <l>Or ora su in palazzo ritrovandomi,</l>
               <l>Ho veduto segnar una licenzia</l>
@@ -2565,7 +2623,7 @@
           <div type="scene" n="Scena I">
             <head>SCENA I</head>
             <stage>Cremonino solo</stage>
-            <sp>
+            <sp who="#cremonino">
               <speaker>CREMONINO:</speaker>
               <l>Or vedo ben ch'io son stato mal pratico;</l>
               <l>E me n'ha gravemente da riprendere</l>
@@ -2588,7 +2646,7 @@
           <div type="scene" n="Scena II">
             <head>SCENA II</head>
             <stage>Bartolo solo</stage>
-            <sp>
+            <sp who="#bartolo">
               <speaker>BARTOLO:</speaker>
               <l>Io gli ho mandato dieci volte o dodici</l>
               <l>Li messi, acciò che li pegni gli tolgano;</l>
@@ -2626,39 +2684,39 @@
           <div type="scene" n="Scena III">
             <head>SCENA III</head>
             <stage>Bartolo, Magagnino</stage>
-            <sp>
+            <sp who="#bartolo">
               <speaker>BARTOLO:</speaker>
               <l>Magagnin, vien inanzi e fa' il tuo officio:</l>
               <l part="I">Batti quell'uscio.</l>
             </sp>
-            <sp>
+            <sp who="#magagnino">
               <speaker>MAGAGNINO:</speaker>
               <l part="F">Perché debbo batterlo,</l>
               <l part="I">Se non m'ha offeso?</l>
             </sp>
-            <sp>
+            <sp who="#bartolo">
               <speaker>BARTOLO:</speaker>
               <l part="F">Offende me, vietandomi</l>
               <l>Per li statuti che costui che ci abita</l>
               <l part="I">Non posso far pigliar.</l>
             </sp>
-            <sp>
+            <sp who="#magagnino">
               <speaker>MAGAGNINO:</speaker>
               <l part="F">Tu te ne vendica;</l>
               <l>E poi ch'averne altro non puoi, disfogati</l>
               <l>Sopra di lui: con mani e, con piè battilo.</l>
             </sp>
-            <sp>
+            <sp who="#bartolo">
               <speaker>BARTOLO:</speaker>
               <l>Spero pur averne altro ancora: entramoci.</l>
               <l part="I">Ma sento ch'egli s'apre.</l>
             </sp>
-            <sp>
+            <sp who="#magagnino">
               <speaker>MAGAGNINO:</speaker>
               <l part="F">Ha fatto savia,</l>
               <l>mente a ubidirti, e non lasciarsi battere.</l>
             </sp>
-            <sp>
+            <sp who="#bartolo">
               <speaker>BARTOLO:</speaker>
               <l>Molta gente mi par: qua su tiramoci</l>
               <l>Da parte un poco; credo che fuor portino</l>
@@ -2668,48 +2726,48 @@
           <div type="scene" n="Scena IV">
             <head>SCENA IV</head>
             <stage>Giuliano, Pacifico, Bartolo</stage>
-            <sp>
+            <sp who="#giuliano">
               <speaker>GIULIANO:</speaker>
               <l>E se la botte è mia, perché vietarmela</l>
               <l part="I">Voi tu ch'io non la pigli?</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="F">Perché, avendola</l>
               <l>Lasciata qui sei mesi, ora di tormela</l>
               <l>Ti nasce questa voglia così sùbita?</l>
             </sp>
-            <sp>
+            <sp who="#giuliano">
               <speaker>GIULIANO:</speaker>
               <l>Perché, lasciandola oggi, sto a pericolo,</l>
               <l>Per la cagion ch'io t'ho detto, di perderla.</l>
             </sp>
-            <sp>
+            <sp who="#bartolo">
               <speaker>BARTOLO:</speaker>
               <l>(Esser dovean avisati, né giungere</l>
               <l part="I">Ci potevàn più a tempo.)</l>
             </sp>
-            <sp>
+            <sp who="#giuliano">
               <speaker>GIULIANO:</speaker>
               <l part="F">Né comprendere</l>
               <l>Posso, se non mel narri, il danno o l'utile</l>
               <l>Che far ti possa il tortela o il lasciartela.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l>Tollendola ora, tu mi fai grandissimo</l>
               <l part="I">Danno.</l>
             </sp>
-            <sp>
+            <sp who="#giuliano">
               <speaker>GIULIANO:</speaker>
               <l part="M">Tu pure a me.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="F">Mezz'ora piacciati</l>
               <l part="I">Di lasciarmela ancora.</l>
             </sp>
-            <sp>
+            <sp who="#giuliano">
               <speaker>GIULIANO:</speaker>
               <l part="F">E s'ora vengono</l>
               <l>Per vuotarti la casa i birri? Et eccoli,</l>
@@ -2720,68 +2778,68 @@
           <div type="scene" n="Scena V">
             <head>SCENA V</head>
             <stage>Bartolo, Magagnino, Spagnolo, Giuliano</stage>
-            <sp>
+            <sp who="#bartolo">
               <speaker>BARTOLO:</speaker>
               <l>Cotesta vo' per parte del mio credito.</l>
               <l>Falcione, e tu Magagnino, pigliatela</l>
               <l part="I">In spalla, e tu Spagnuolo.</l>
             </sp>
-            <sp>
+            <sp who="#magagnino">
               <speaker>MAGAGNINO:</speaker>
               <l part="F">Io non soglio essere</l>
               <l part="I">Facchino.</l>
             </sp>
-            <sp>
+            <sp who="#spagnolo">
               <speaker>SPAGNOLO:</speaker>
               <l part="M">Et io tampoco</l>
             </sp>
-            <sp>
+            <sp who="#bartolo">
               <speaker>BARTOLO:</speaker>
               <l part="F">Un bel servizio</l>
               <l part="I">C'ho da voi!</l>
             </sp>
-            <sp>
+            <sp who="#giuliano">
               <speaker>GIULIANO:</speaker>
               <l part="F">Non sia alcun che di toccarmela</l>
               <l part="I">Ardisca, se non vuol...</l>
             </sp>
-            <sp>
+            <sp who="#bartolo">
               <speaker>BARTOLO:</speaker>
               <l part="F">Dunque vietarmi tu</l>
               <l>Vuoi, che non si esequisca la licenzia</l>
               <l part="I">C'ho di levargli i pegni?</l>
             </sp>
-            <sp>
+            <sp who="#giuliano">
               <speaker>GIULIANO:</speaker>
               <l part="F">Li suoi toglierli</l>
               <l>Non vi divieto, ma 'sta botte dicovi</l>
               <l part="I">Che gli è mia.</l>
             </sp>
-            <sp>
+            <sp who="#bartolo">
               <speaker>BARTOLO:</speaker>
               <l part="M">Come tua?</l>
             </sp>
-            <sp>
+            <sp who="#giuliano">
               <speaker>GIULIANO:</speaker>
               <l part="F">Gli è mia verissima–</l>
               <l>mente, che uguanno fu da me prestatali.</l>
             </sp>
-            <sp>
+            <sp who="#bartolo">
               <speaker>BARTOLO:</speaker>
               <l>Deh, che ciance son queste? Ritrovandola</l>
               <l>Uscir di casa sua, come sua tolgola.</l>
             </sp>
-            <sp>
+            <sp who="#giuliano">
               <speaker>GIULIANO:</speaker>
               <l>La tolli? Sì, s'io tel comporto: lasciala,</l>
               <l part="I">Se non ch'io te...</l>
             </sp>
-            <sp>
+            <sp who="#bartolo">
               <speaker>BARTOLO:</speaker>
               <l part="F">Siatemi testimonii</l>
               <l part="I">Che costui vieta...</l>
             </sp>
-            <sp>
+            <sp who="#giuliano">
               <speaker>GIULIANO:</speaker>
               <l part="F">Che vieta? Lasciatela.</l>
             </sp>
@@ -2789,78 +2847,78 @@
           <div type="scene" n="Scena VI">
             <head>SCENA VI</head>
             <stage>Fazio, Giuliano, Pacifico, Bartolo, Corbolo</stage>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l>Oh, che rumor fate voi qui? Che strepito</l>
               <l part="I">È questo?</l>
             </sp>
-            <sp>
+            <sp who="#giuliano">
               <speaker>GIULIANO:</speaker>
               <l part="F">È mia la botte, e riportarmela</l>
               <l>Voglio a casa; e costui crede vietarmelo.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="I">Dice il ver: sua è per certo.</l>
             </sp>
-            <sp>
+            <sp who="#bartolo">
               <speaker>BARTOLO:</speaker>
               <l part="F">Anzi non dicono</l>
               <l part="I">Il vero.</l>
             </sp>
-            <sp>
+            <sp who="#giuliano">
               <speaker>GIULIANO:</speaker>
               <l part="M">Tu pur menti.</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="F">Senza ingiuria</l>
               <l part="I">Dirvi, parlate.</l>
             </sp>
-            <sp>
+            <sp who="#bartolo">
               <speaker>BARTOLO:</speaker>
               <l part="M">Tu mi menti.</l>
             </sp>
-            <sp>
+            <sp who="#giuliano">
               <speaker>GIULIANO:</speaker>
               <l part="F">Menti tu,</l>
               <l part="I">Che tu di' ch'io non dico il vero.</l>
             </sp>
-            <sp>
+            <sp who="#bartolo">
               <speaker>BARTOLO:</speaker>
               <l part="F">Fazio,</l>
               <l>Vi par, se di casa esce di Pacifico;</l>
               <l>Ch'io mi debbia lasciar dar ad intendere</l>
               <l part="I">Che la sia se non sua?</l>
             </sp>
-            <sp>
+            <sp who="#giuliano">
               <speaker>GIULIANO:</speaker>
               <l part="F">Se di Pacifico</l>
               <l>Fusse, fuor ne la strada non trarrebbesi.</l>
             </sp>
-            <sp>
+            <sp who="#bartolo">
               <speaker>BARTOLO:</speaker>
               <l>Anzi la traevate per nasconderla.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l>Non già, per Dio! La traevo per rendere</l>
               <l>A lui, che uguanno me ne fe' servizio.</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="I">Ch'io dica il mio parer?</l>
             </sp>
-            <sp>
+            <sp who="#bartolo">
               <speaker>BARTOLO:</speaker>
               <l part="F">Sì ben, rimettere</l>
               <l part="I">Mi voglio in voi.</l>
             </sp>
-            <sp>
+            <sp who="#giuliano">
               <speaker>GIULIANO:</speaker>
               <l part="M">Io ancora.</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="F">Lascia, Bartolo,</l>
               <l>Che questa botte io mi chiami in deposito,</l>
@@ -2868,102 +2926,102 @@
               <l>Che sia sua, l'averà; ma non facendomi</l>
               <l>Buona prova, vorrò ch'abbia pazienzia.</l>
             </sp>
-            <sp>
+            <sp who="#giuliano">
               <speaker>GIULIANO:</speaker>
               <l part="I">Son ben contento.</l>
             </sp>
-            <sp>
+            <sp who="#bartolo">
               <speaker>BARTOLO:</speaker>
               <l part="M">Et io contento.</l>
             </sp>
-            <sp>
+            <sp who="#giuliano">
               <speaker>GIULIANO:</speaker>
               <l part="F">Possovi</l>
               <l>Che gli è mia facilmente far conoscere.</l>
             </sp>
-            <sp>
+            <sp who="#bartolo">
               <speaker>BARTOLO:</speaker>
               <l>Se prova gliene fai vera e legitima,</l>
               <l>Sia tua: tu, dove e quando vuoi, via portala.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l>Tu mi par poco savio a compromettere,</l>
               <l>E lasciar turbidar la chiara e liquida</l>
               <l part="I">Ragion che v'hai.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Dice il vero: lasciatela</l>
               <l>Più tosto ov'era, in casa di Pacifico.</l>
             </sp>
-            <sp>
+            <sp who="#bartolo">
               <speaker>BARTOLO:</speaker>
               <l>Questo consiglio non mi sarebbe utile.</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l>Che tocca a te? Che ci hai tu da intrometterti,</l>
               <l part="I">O tu, se non è tua?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Per me rispondere</l>
               <l part="I">Voglio, che forse ci ho parte.</l>
             </sp>
-            <sp>
+            <sp who="#giuliano">
               <speaker>GIULIANO:</speaker>
               <l part="F">Concederti </l>
               <l part="I">Non voglio già cotesto.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Et appertiemmisi</l>
               <l part="I">Vie più che non ti pare.</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="F">Et appertengasi.</l>
             </sp>
-            <sp>
+            <sp who="#giuliano">
               <speaker>GIULIANO:</speaker>
               <l part="I">Come appertien? non è vero.</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="F">Appertengagli.</l>
               <l>E non ti par ch'in casa mia debbia essere</l>
               <l>Sicura dunque? come sol con Bartolo,</l>
               <l>E non con Giuliano anco, abbia amicizia!</l>
             </sp>
-            <sp>
+            <sp who="#giuliano">
               <speaker>GIULIANO:</speaker>
               <l>Ci siamo un tratto compromessi in Fazio:</l>
               <l>Sia il depositario egli, egli sia il giudice.</l>
             </sp>
-            <sp>
+            <sp who="#bartolo">
               <speaker>BARTOLO:</speaker>
               <l part="I">E così dico anch'io.</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="F">Dunque spingetela</l>
               <l>Qua dentro in casa; e non abbiate dubbio</l>
               <l>Che, in fin ch'io non son ben chiaro e certissimo</l>
               <l>Di chi sia la ragion, la lasci muovere.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l>(Flavio c'è dentro: or ve' s'ogni disgrazia,</l>
               <l>Or ve' s'ogni sciagura mi perseguita!)</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l>Pacifico, faresti meglio attendere</l>
               <l>A casa, che gli sbirri non ti tolgano</l>
               <l part="I">Altro, e ti faccian peggio.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="F">E che mi possono</l>
               <l>Tôrre? Il poco che ci è, sanno tutto essere</l>
@@ -2974,54 +3032,54 @@
           <div type="scene" n="Scena VII">
             <head>SCENA VII</head>
             <stage>Sbirri, Torbido, Gemignano, Giuliano, Fazio</stage>
-            <sp>
+            <sp who="#sbirri">
               <speaker>SBIRRI:</speaker>
               <l>Altro insomma non ci è, che quel che soliti</l>
               <l>Siamo trovar e ch'è su l'inventario.</l>
             </sp>
-            <sp>
+            <sp who="#torbido">
               <speaker>TORBIDO:</speaker>
               <l>Ah ladri, ribaldoni, che involatomi</l>
               <l part="I">Avete il mio mantello!</l>
             </sp>
-            <sp>
+            <sp who="#sbirri">
               <speaker>SBIRRI:</speaker>
               <l part="F">Fai grandissimo</l>
               <l>Male accusarci a torto e dirci ingiuria.</l>
             </sp>
-            <sp>
+            <sp who="#torbido">
               <speaker>TORBIDO:</speaker>
               <l>Brutto impiccato, che ti venghi il cancaro!</l>
               <l part="I">Che è questo che tu hai sotto?</l>
             </sp>
-            <sp>
+            <sp who="#sbirri">
               <speaker>SBIRRI:</speaker>
               <l part="F">Tolto avevolo</l>
               <l>Per le mie spese, e non per involartelo.</l>
             </sp>
-            <sp>
+            <sp who="#torbido">
               <speaker>TORBIDO:</speaker>
               <l>Io ti darò ben spese, se la pertica</l>
               <l part="I">Non mi vien meno.</l>
             </sp>
-            <sp>
+            <sp who="#gemignano">
               <speaker>GEMIGNANO:</speaker>
               <l part="F">Io vo' prestarti un'opera.</l>
             </sp>
-            <sp>
+            <sp who="#giuliano">
               <speaker>GIULIANO:</speaker>
               <l>Non mi vo' anch'io tener le mani a cintola.</l>
             </sp>
-            <sp>
+            <sp who="#torbido">
               <speaker>TORBIDO:</speaker>
               <l>Ve'lì quel sasso, Gemignano? piglialo,</l>
               <l>Spezzali il capo: tu sei pur da Modena.</l>
             </sp>
-            <sp>
+            <sp who="#sbirri">
               <speaker>SBIRRI:</speaker>
               <l>Gli ufficial del Signor così si trattano?</l>
             </sp>
-            <sp>
+            <sp who="#torbido">
               <speaker>TORBIDO:</speaker>
               <l>Il Signor non tien ladri al suo servizio.</l>
               <l>Via, ladri; via, poltroni; via col diavolo!</l>
@@ -3032,11 +3090,11 @@
               <l>Che in spalla, ad uso d'una picca, avendola,</l>
               <l>Sarei paruto un Lanzchenech o Svizzaro.</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="I">Resta a misurar altro?</l>
             </sp>
-            <sp>
+            <sp who="#torbido">
               <speaker>TORBIDO:</speaker>
               <l part="F">Fin all'ultimo</l>
               <l>Mattone ho misurato, e fin all'ultimo</l>
@@ -3044,23 +3102,23 @@
               <l>Poi ne leverò il conto, e farò intendere</l>
               <l>Ad ambi a quanto prezzo possa ascendere.</l>
             </sp>
-            <sp>
+            <sp who="#gemignano">
               <speaker>GEMIGNANO:</speaker>
               <l part="I">Quando?</l>
             </sp>
-            <sp>
+            <sp who="#torbido">
               <speaker>TORBIDO:</speaker>
               <l part="F">Oggi ancora. Commandi altro, Fazio?</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="I">Non, ora.</l>
             </sp>
-            <sp>
+            <sp who="#torbido">
               <speaker>TORBIDO:</speaker>
               <l part="M">A Dio.</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="F">Son vostro. — Olà, Licinia,</l>
               <l>S'alcun mi viene a dimandar, rimettilo</l>
@@ -3071,7 +3129,7 @@
           <div type="scene" n="Scena VIII">
             <head>SCENA VIII</head>
             <stage>Lena sola</stage>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l>Nel male è grande aventura che Fazio</l>
               <l>Uscito sia di casa, che difficile–</l>
@@ -3099,47 +3157,47 @@
           <div type="scene" n="Scena IX">
             <head>SCENA IX</head>
             <stage>Menica, Lena, Corbolo, Pacifico</stage>
-            <sp>
+            <sp who="#menica">
               <speaker>MENICA:</speaker>
               <l part="I">Lena, che vuoi?</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Piacciati, cara Menica,</l>
               <l>Di farmi un gran servigio, da dovertene</l>
               <l part="I">Esser sempre tenuta.</l>
             </sp>
-            <sp>
+            <sp who="#menica">
               <speaker>MENICA:</speaker>
               <l part="M">Che vuoi?</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Vuo' mi tu</l>
               <l part="I">Farlo?</l>
             </sp>
-            <sp>
+            <sp who="#menica">
               <speaker>MENICA:</speaker>
               <l part="F">Io 'l farò, pur che far sia possibile.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l>Va', madre mia, se m'ami, fin agli Angeli.</l>
             </sp>
-            <sp>
+            <sp who="#menica">
               <speaker>MENICA:</speaker>
               <l part="I">Ora?</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="M">Ora sì.</l>
             </sp>
-            <sp>
+            <sp who="#menica">
               <speaker>MENICA:</speaker>
               <l part="F">Lasciami prima mettere</l>
               <l part="I">La cena al fuoco.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Non, sa' pur, che mettere</l>
               <l>Io saprò senza te al fuoco una pentola.</l>
@@ -3149,12 +3207,12 @@
               <l>A man sinistra, alla contrada dicono</l>
               <l part="I">Mirasol, credo. Or va'.</l>
             </sp>
-            <sp>
+            <sp who="#menica">
               <speaker>MENICA:</speaker>
               <l part="F">Che vi vuoi, domine,</l>
               <l part="I">Ch'io vada a far?</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Vedi cervello! Informati</l>
               <l>Quivi (credo sia il terzo uscio) dove abita</l>
@@ -3167,12 +3225,12 @@
               <l>Or va', Menica cara: donar voglioti</l>
               <l>Poi tanta tela, che facci una cuffia.</l>
             </sp>
-            <sp>
+            <sp who="#menica">
               <speaker>MENICA:</speaker>
               <l>La carne è nel catin lavata e in ordine,</l>
               <l>Non resta se non porla ne la pentola.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l>Troppo cred'io che la sia ben in ordine;</l>
               <l>Dico quella di Flavio, ma in la pentola</l>
@@ -3193,20 +3251,20 @@
               <l>Alcuna veste, che lo possiàn mettere</l>
               <l part="I">Fuor, mentre l'agio ci abbiamo.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Anzi, pregoti,</l>
               <l>Mentre abbiamo agio, fa' che possa mettere</l>
               <l>Dentro, e dategli luogo tu e Pacifico.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l>In fé di Dio, non farà: né ti credere</l>
               <l>Ch'io gli lassi aver cosa che desideri,</l>
               <l>Se prima li denari non mi annovera;</l>
               <l>Et esser guardiana io stessa voglione.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Guardala sì che gli occhi vi rimanghino.</l>
               <l>(Debbio patir che Flavio da Licinia</l>
@@ -3245,53 +3303,53 @@
               <l>Mi potrà? Crederammi. Ma Pacifico</l>
               <l part="I">Vien fuora.)</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="M">Ov'è la veste?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Che veste? hammi tu</l>
               <l>Scorto per Sarto? Oh, par che 'l mio essercizio</l>
               <l>Non sappi: io tengo la zecca, e vo' battere</l>
               <l>Venticinque fiorini ora per darteli.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="I">Foss'egli il vero!</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="M">A mio senno governati.</l>
               <l>Hai tu alcun'arma in casa?</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="F">Su in la camera</l>
               <l>Dipinta è nel camin l'arma di Fazio.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="I">Dico da offesa.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="F">Assai n'ho che m'offendono:</l>
               <l>La povertà, li pensieri, la rabbia</l>
               <l>Di mia moglie, e 'l suo sempre dirmi ingiuria.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Dico s'hai spiedo o ronca o spada o simile</l>
               <l part="I">Cosa.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="F">Ci è un spiedo antico e tutto ruggine.</l>
               <l>Ve' se gli è tristo, se gli è male in ordine,</l>
               <l>Che i birri mai non curan di levarmelo.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Basta, viemmelo mostra. Or bella archimia</l>
               <l>Non ti parrà s'io fo di questa ruggine</l>
@@ -3304,20 +3362,20 @@
           <div type="scene" n="Scena I">
             <head>SCENA I</head>
             <stage>Corbolo, Pacifico, Staffieri</stage>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Vien fuora, vien più in quà, più ancora: partiti</l>
               <l>Di casa un poco. Tu mi par più timido</l>
               <l>Con l'arme in mano, che non dovresti essere</l>
               <l>Se l'avessi nel petto: di chi dubiti?</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l>Del capitan de la Piazza, che cogliere</l>
               <l>Mi potria qui con questo spiedo, e mettermi</l>
               <l part="I">la prigion.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">No, ch'io gli daria ad intendere</l>
               <l>Che fussi un sbirro o il boia; e crederebbelo,</l>
@@ -3326,11 +3384,11 @@
               <l>Sta' ritto, sta' gagliarlo, fa' il terribile,</l>
               <l part="I">Fa' il bravo.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="M">E come fassi il bravo?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Attaccala</l>
               <l>Spesso a Dio e santi: tienlo così: volgeti</l>
@@ -3341,34 +3399,34 @@
               <l>Che, dove costui manca, puon soccorrermi;</l>
               <l part="I">Voglio ire a lor. Buon dì, fratelli.</l>
             </sp>
-            <sp>
+            <sp who="#staffieri">
               <speaker>STAFFIERI:</speaker>
               <l part="F">O Corbolo,</l>
               <l>Buon dì e buon anno. Come la fai?Vuonne tu</l>
               <l part="I">Dar bere?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Sì, volentieri, ma pensovi</l>
               <l part="I">Di dar meglio che bere.</l>
             </sp>
-            <sp>
+            <sp who="#staffieri">
               <speaker>STAFFIERI:</speaker>
               <l part="M">Che?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Fermandovi</l>
               <l>Qui meco una mezz'ora, voglio mettervi</l>
               <l>Un contrabando in man, da guadagnarvene</l>
               <l part="I">Almeno un paio di scudi per uno.</l>
             </sp>
-            <sp>
+            <sp who="#staffieri">
               <speaker>STAFFIERI:</speaker>
               <l part="F">Eccoci,</l>
               <l>Del ben che ne farai per averti obligo.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>lo vi dirò. Questi Giudei che prestano</l>
               <l>A Riva, ier compraro una grandissima</l>
@@ -3390,13 +3448,13 @@
               <l>Per suo mezzo. Or s'a parte volete essere</l>
               <l part="I">Voi, volentier v'accetto.</l>
             </sp>
-            <sp>
+            <sp who="#staffieri">
               <speaker>STAFFIERI:</speaker>
               <l part="F">Anzi pregartene</l>
               <l>Vogliamo, et il guadagno promettemoti</l>
               <l part="I">Partir da buon compagni.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Ora fermatevi.</l>
               <l>Tu qui, e tien l'occhio, che se là passassino</l>
@@ -3414,7 +3472,7 @@
           <div type="scene" n="Scena II">
             <head>SCENA II</head>
             <stage>Ilario solo</stage>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>Oh, come netta me la facea nascere</l>
               <l>Quel ladroncel, se non m'avesse Domene–</l>
@@ -3443,48 +3501,48 @@
           <div type="scene" n="Scena III">
             <head>SCENA III</head>
             <stage>Ilario, Corbolo</stage>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>Ancora hai, brutto manigoldo, audacia</l>
               <l part="I">Di venire ov'io sia?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Deh! questa còlera</l>
               <l>Ponete giù; e per Dio, non vi contamini</l>
               <l part="I">La pietade.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="M">Oh, tu piangi?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">E voi pur piangere</l>
               <l part="I">Dovreste, che vostro figliuol...</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Dio, aiutami!</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="I">...È in pericol.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="M">Pericolo?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Sì, d'essere</l>
               <l>Morto, se non ci si ripara sùbito.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="I">Come, come? di', di', dove è?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Pacifico</l>
               <l>L'ha colto con la moglie in adulterio.</l>
@@ -3493,48 +3551,48 @@
               <l>Suoi parenti, et aspetta anco che venghino</l>
               <l part="I">Tre suoi cognati.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="M">Egli dove è?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Chi? Flavio?</l>
               <l>Là dentro questi ribaldi lo assediano.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="I">Dove là dentro?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">In casa là di Fazio.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="I">Evvi Fazio?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Se vi fusse,. il pericolo</l>
               <l>Non mi parrebbe tanto. Ecci una giovane</l>
               <l>Sua figlia, senza più: consideratela</l>
               <l>Or voi, ch'aiuto può aver da una femina!</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>Se con la moglie in casa sua Pacifico</l>
               <l>L'ha colto, come è in casa ora di Fazio?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Io vi dirò la cosa da principio.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>Dilla, ma non ci scemar, né ci aggiungere.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>La dirò a punto come sta; ma vogliovi</l>
               <l>Prima certificar che quella favola,</l>
@@ -3548,12 +3606,12 @@
               <l>Quella via essendo, è in molto peggior termine</l>
               <l part="I">La vita sua, che non fu dianzi.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Narrami</l>
               <l part="I">Come sta il fatto.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Flavio oggi, credendosi</l>
               <l>Che fusse fuor Pacifico, e credendolo</l>
@@ -3563,31 +3621,31 @@
               <l>Non so dov'era, saltò per ucciderlo</l>
               <l part="I">Fuor con quel spiedo.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="M">Il cuor mi trema.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Flavio</l>
               <l>Pregando fe' pur tanto e supplicandolo,</l>
               <l>E di donar denari promettendoli,</l>
               <l part="I">Che gli lasciò la vita.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Or me resusciti,</l>
               <l>Se con denar la cosa si pacifica.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="I">Non, udite anco il tutto.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Che ci è? Séguita.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>In venticinque fiorin si convennono</l>
               <l>Che, prima che d'insieme si partissero,</l>
@@ -3601,54 +3659,54 @@
               <l>Per lui, se non ci riparate, è a termine.</l>
               <l part="I">Che Dio l'aiuti!</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Perché debbe nuocerli,</l>
               <l part="I">Se son d'accordo?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Udite pur. Pacifico,</l>
               <l>Tenendosi uccellato, con più furia</l>
               <l>Che prima corse al spiedo, e senza intendere</l>
               <l>Alcuna scusa, volea pur ucciderlo.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>Facesti error; che non venisti sùbito</l>
               <l>Ad avisarmi. Al fin ch'avenne? séguita.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Non so perché non l'uccise; e credetemi</l>
               <l>Che ben Dio e santi Flavio ebbe propizii.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>Un manigoldo poltrone ha avuto animo</l>
               <l>Di minacciar un mio figliuol d'ucciderlo?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Se non che vostro figliuol, riparandosi</l>
               <l>Con un scanno che prese, e ritraendosi</l>
               <l>Pur sempre all'uscio, saltò fuor, avrebbelo</l>
               <l part="I">Morto.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="M">Si salvò insomma?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Nol vo' mettere</l>
               <l part="I">Per salvo ancor.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="M">Tu m'occidi.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Incalzandolo</l>
               <l>Tuttavia quel ribaldo, e non lasciandolo</l>
@@ -3656,24 +3714,24 @@
               <l>Che si fuggisse in casa là di Fazio;</l>
               <l part="I">E così v'è assediato.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Vedi audacia</l>
               <l>D'un mendico, furfante, temerario!</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>E più, c'ha fatto e cerca far d'altri uomini</l>
               <l>Ragunanza, e d'intrar là dentro ha in animo.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>Entrar là dentro? Io non son così povero</l>
               <l>Di facultà e d'amici, che difendere</l>
               <l>Io non lo possa, e far parer Pacifico</l>
               <l part="I">Un sciagurato.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Non vogliate mettervi</l>
               <l>A cotal pruova, avendo altro rimedio:</l>
@@ -3703,12 +3761,12 @@
               <l>Senza guerra e d'accordo, che in pericolo</l>
               <l>Porvi di cinquecento o mille perderne.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>Meglio è ch'io stesso parli con Pacifico</l>
               <l part="I">E vegga un poco il suo pensier.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Non, diavolo!</l>
               <l>Non andate, che tratto da la còlera</l>
@@ -3719,15 +3777,15 @@
               <l>E fia pur vostro onor se qui condurvelo</l>
               <l part="I">Potrò.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="M">Va' dunque.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="M">Aspettatemi qui.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Odimi.</l>
               <l>Fagli profferte, ma non ti risolvere</l>
@@ -3735,13 +3793,13 @@
               <l>Del pregio voglio che stia a me: prometteli</l>
               <l part="I">Generalmente: tu m'intendi.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Intendendovi</l>
               <l>Tuttavia non guardate di più spendere</l>
               <l part="I">Un paio o due di fiorini.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">A me lasciane</l>
               <l>Cura, ch' in questo son di te più pratico.</l>
@@ -3750,7 +3808,7 @@
           <div type="scene" n="Scena IV">
             <head>SCENA IV</head>
             <stage>Ilario solo</stage>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>Penso che sarà cosa salutifera</l>
               <l>Che prima ch'io m'abbocchi con Pacifico</l>
@@ -3766,7 +3824,7 @@
           <div type="scene" n="Scena V">
             <head>SCENA V</head>
             <stage>Corbolo Staffieri, Pacifico</stage>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Fratelli, andate pur; non state a perdere</l>
               <l>Tempo, che 'l padron mio, dal quale comprano</l>
@@ -3774,33 +3832,33 @@
               <l>Han mutato proposito, e che tolgono</l>
               <l>Pur la bolletta, et han pagato il dazio.</l>
             </sp>
-            <sp>
+            <sp who="#staffieri">
               <speaker>STAFFIERI:</speaker>
               <l>Era però un miracolo che fossimo</l>
               <l part="I">Si aventurosi.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Accettate il buon animo:</l>
               <l>Non è per me restato di farvi utile.</l>
             </sp>
-            <sp>
+            <sp who="#staffieri">
               <speaker>STAFFIERI:</speaker>
               <l>Lo conosciamo, e te ne avren sempre obligo.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="I">Son vostro sempre, fratelli.</l>
             </sp>
-            <sp>
+            <sp who="#staffieri">
               <speaker>STAFFIERI:</speaker>
               <l part="F">A Dio, Corbolo.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="I">Come hai fatto?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Benissimo: ti fièno</l>
               <l>Venticinque fiorin dati da Ilario,</l>
@@ -3812,11 +3870,11 @@
               <l>Tempo, riponilo, et a me torna sùbito.</l>
               <l part="I">Odi.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="M">Che vuoi?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Poi che non hai più dubbio</l>
               <l>Che li denar promessi non ne vengano,</l>
@@ -3824,7 +3882,7 @@
               <l>Che questi amanti insieme si solazzino</l>
               <l>Prima che torni la fante o che Fazio.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l>Ci sarà tempo: ancora che la Menica</l>
               <l>Tornasse, avrò ben luogo dove spingerla</l>
@@ -3832,7 +3890,7 @@
               <l>Che mai tornare a casa non è solito</l>
               <l>Fin che le ventiquattro ore non suonino.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Or su, ripon quel spiedo, e vien, che Ilario</l>
               <l>Li venticinque fiorini ti annoveri.</l>
@@ -3841,7 +3899,7 @@
           <div type="scene" n="Scena VI">
             <head>SCENA VI</head>
             <stage>Corbolo solo</stage>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Ben succede l'impresa: avrà l'essercito</l>
               <l>De le bugie, dopo tanti pericoli,</l>
@@ -3855,30 +3913,30 @@
           <div type="scene" n="Scena VII">
             <head>SCENA VII</head>
             <stage>Pacifico, Corbolo</stage>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="I">Eccomi, eccomi qui.</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Corri, Pacifico</l>
               <l>Provedi che colui non vegga Flavio.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="I">Chi colui?</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l part="F">Come ha nome questo giovene</l>
               <l>Vostro? Che tardi? Va' dentro, e conoscilo:</l>
               <l part="I">Menghino, il dirò pur.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="F">Menghino? diavolo</l>
             </sp>
-            <sp>
+            <sp who="#corbolo">
               <speaker>CORBOLO:</speaker>
               <l>Menghino sì, Menghin. Ve' diligenzia</l>
               <l>Di bestia! ma più bestia io, che rimettermi</l>
@@ -3892,7 +3950,7 @@
           <div type="scene" n="Scena VIII">
             <head>SCENA VIII</head>
             <stage>Menica sola</stage>
-            <sp>
+            <sp who="#menica">
               <speaker>MENICA:</speaker>
               <l>Alla croce di Dio! mai più servizio</l>
               <l>Non fo alla Lena. M'ha di là dagli Angeli</l>
@@ -3924,7 +3982,7 @@
           <div type="scene" n="Scena IX">
             <head>SCENA IX</head>
             <stage>Ilario, Fazio</stage>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>(Io son ito a trovar Fazio, pensandomi</l>
               <l>Fusse buon mezzo a por d'accordo Flavio</l>
@@ -3940,7 +3998,7 @@
               <l>Possiamo prima che segua altro scandolo.</l>
               <l>Fatel, se mai da voi spero aver grazia.</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l>Non posso, né possendo mai vo', Ilario</l>
               <l>Patir che dopo tanti benefizii</l>
@@ -3948,33 +4006,33 @@
               <l>Da me questa gaglioffa, così m'abbia</l>
               <l>Tradito. Son disposto vendicarmene.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>S'ella v'ha fatto ingiuria, vendicatevi:</l>
               <l>Non vi prego per lei, ma sol che Flavio</l>
               <l>Mio non lasciate offender da Pacifico</l>
               <l part="I">In casa vostra.</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="F">D'un fanciul volubile</l>
               <l>Ha fatto elezïon, che potrebbe essere</l>
               <l>Suo figliuolo, e sperar non ne può merito,</l>
               <l>Se non che se ne vanti e le dia infamia.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>Non credea mio figliuolo già d'offendervi;</l>
               <l>Che se creduto egli avesse esser pratica</l>
               <l>Vostra costei, so che v'avria grandissimo</l>
               <l>Rispetto avuto, come ha riverenzia.</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l>Questa è la causa che m'era da quindici</l>
               <l>Giorni in qua ritornata si salvatica.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>Rispondetemi un poco senza còlera.</l>
             </sp>
@@ -3982,91 +4040,91 @@
           <div type="scene" n="Scena X">
             <head>SCENA X</head>
             <stage>Menghino, Ilario, Pacgico, Fazio, Lena</stage>
-            <sp>
+            <sp who="#menghino">
               <speaker>MENGHINO:</speaker>
               <l>Io l'ho veduto, non varrà nasconderlo.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>Ah, che noi siàn troppo tardati! gridano</l>
               <l>Là in casa vostra. Deh, Fazio, aiutatemi.</l>
             </sp>
-            <sp>
+            <sp who="#menghino">
               <speaker>MENGHINO:</speaker>
               <l>Lo voglio ire a trovare, e fargli intendere</l>
               <l part="I">Le belle opere vostre.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="F">Menghino, odimi.</l>
             </sp>
-            <sp>
+            <sp who="#menghino">
               <speaker>MENGHINO:</speaker>
               <l part="I">Pur troppo ho udito e veduto.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="F">Non essere...</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="I">Che cosa è questa?</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="F">...tu cagion d'accendere</l>
               <l part="I">Tanto fuoco.</l>
             </sp>
-            <sp>
+            <sp who="#menghino">
               <speaker>MENGHINO:</speaker>
               <l part="F">Vo' dirlo, se ben perdere</l>
               <l part="I">Ne dovessi la testa.</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="F">Deh, fermatevi:</l>
               <l>Stiamo un poco qui a udir di che contendono.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l>Fermati qui, Menghin: fermati, ascoltami.</l>
             </sp>
-            <sp>
+            <sp who="#menghino">
               <speaker>MENGHINO:</speaker>
               <l>Lasciami andar, Pacifico, non credere</l>
               <l part="I">Che per te resti di nol dire.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Che diavolo</l>
               <l>Puoi tu dir in cent'anni? Che la fistola</l>
               <l>Ti venga! e c'hai veduto tu, brutto asino?</l>
             </sp>
-            <sp>
+            <sp who="#menghino">
               <speaker>MENGHINO:</speaker>
               <l>Ho veduto Licinia e questo giovine</l>
               <l part="I">Figliuol d'Ilario...</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Lena, e non Licinia,</l>
               <l part="I">Vòls'egli dire.</l>
             </sp>
-            <sp>
+            <sp who="#menghino">
               <speaker>MENGHINO:</speaker>
               <l part="F">...che abbracciati stavano.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="I">Tu menti per la gola.</l>
             </sp>
-            <sp>
+            <sp who="#menghino">
               <speaker>MENGHINO:</speaker>
               <l part="F">Or ecco Fazio.</l>
               <l>Padron, vi dirò il ver; non vi voglio essere</l>
               <l part="I">Traditor: vostra figliuola...</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="F">Oh, la bestia!</l>
               <l>T'ho ben udito. Che, vòi farlo intendere</l>
@@ -4077,20 +4135,20 @@
               <l>Che favole, che ciance fatte credere</l>
               <l>M'avete de la Lena e di Pacifico?</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>Così l'avevo udito anch'io da Corbolo.</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l>Ma questa non è ingiuria da passarsene</l>
               <l>Sì leggiermente: è di troppa importanzia.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="I">Per vostra fede, Fazio...</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="F">Deh, Ilario,</l>
               <l>Mi maraviglio ben di voi: l'ingiuria</l>
@@ -4101,23 +4159,23 @@
               <l>M'esca di casa, per lui darò essempio</l>
               <l>Che non si denno li miei pari offendere.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>Pel filïale amor, del qual notizia</l>
               <l>Avete voi com'io, vi prego e supplico</l>
               <l>Che di me abbiate pietade e di Flavio.</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l>E l'amor filiale a punto m'eccita</l>
               <l part="I">A vendicar.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Per l'antiqua amicizia</l>
               <l part="I">Nostra!</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="F">Sarebbe ancora a voi difficile</l>
               <l>Il perdonar, essendo ne' miei termini.</l>
@@ -4126,18 +4184,18 @@
               <l>E quanto ho al mondo vo' più tosto perdere</l>
               <l>Che quello, e senza quello non vo' vivere.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l>Se modo ci sarà di non lo perdere?</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l>Con voi a un tratto mi voglio risolvere.</l>
               <l>Quando vostro figliuol sposi Licinia</l>
               <l>Mia, e che l'onor perduto le recuperi,</l>
               <l part="I">Saremo amici; altrimenti...</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Fermatevi.</l>
               <l>Credo che cinquant'anni oggimai passino</l>
@@ -4155,11 +4213,11 @@
               <l>Ch'io farò tutto quel che convenevole</l>
               <l>Mi sia per emendarvi questa ingiuria.</l>
             </sp>
-            <sp>
+            <sp who="#fazio">
               <speaker>FAZIO:</speaker>
               <l part="I">Entriamo in casa.</l>
             </sp>
-            <sp>
+            <sp who="#ilario">
               <speaker>ILARIO:</speaker>
               <l part="F">Entrate, ch'io vi séguito.</l>
             </sp>
@@ -4167,23 +4225,23 @@
           <div type="scene" n="Scena XI">
             <head>SCENA XI</head>
             <stage>Pacifico, Lena</stage>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l>Or vedi, Lena, a quel che le tristizie</l>
               <l>E le puttanerie tue ti conducono!</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="I">Chi m'ha fatto puttana?</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="F">Così chiedere</l>
               <l>Potresti a quei che tuttodì s'impiccano</l>
               <l>Chi li fa ladri. Imputane la propria</l>
               <l part="I">Tua volontà.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Anzi la tua insaziabile</l>
               <l>Golaccia, che ridotti ci ha in miseria;</l>
@@ -4193,12 +4251,12 @@
               <l>Del bene ch'io t'ho fatto, mi rimproveri,</l>
               <l part="I">Poltron, ch'io sia puttana?</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="F">Ti, rimprovero,</l>
               <l>Che lo dovresti far con più modestia.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l>Ah, beccaccio, tu parli di modestia?</l>
               <l>S'io avessi a tutti quelli che propostomi</l>
@@ -4209,18 +4267,18 @@
               <l>Tutti bastar pareati, e consigliavimi</l>
               <l>Che quel di dietro anco ponessi in opera.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l>Per viver teco in pace proponevoti</l>
               <l>Quel ch'io sapevo che t'era grandissima–</l>
               <l>mente in piacere, e che vietar volendoti,</l>
               <l>Saria stato il durar teco impossibile.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="I">Doh, che ti venga il morbo!</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="F">Io l'ho continua–</l>
               <l>mente teco. Bastar, Lena, dovrebbeti</l>
@@ -4230,7 +4288,7 @@
               <l>Di ruffianar le figliuole degli uomini</l>
               <l part="I">Da ben.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">S'io avessi a star tuttavia giovane,</l>
               <l>Il mantener amendue col medesimo</l>
@@ -4246,13 +4304,13 @@
               <l>Ad imparar? Che vuoi ch'io indugi all'ultimo,</l>
               <l>Quand'io sarò nel bisogno, ad apprenderla?</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l>Se contra ogni altro avessi questi termini</l>
               <l>Usati, mi saria più tolerabile</l>
               <l>Che contra Fazio, al quale abbiàn troppo obligo.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l>Deh manigoldo, ti venga la fistola!</l>
               <l>Come tu non sia stato consapevole</l>
@@ -4262,7 +4320,7 @@
               <l>La parte, e più che la parte, volutane</l>
               <l part="I">Avresti ben.</l>
             </sp>
-            <sp>
+            <sp who="#pacifico">
               <speaker>PACIFICO:</speaker>
               <l part="F">Non più, ch'esce la Menica.</l>
             </sp>
@@ -4270,28 +4328,28 @@
           <div type="scene" n="Scena XII">
             <head>SCENA XII</head>
             <stage>Menica, Lena</stage>
-            <sp>
+            <sp who="#menica">
               <speaker>MENICA:</speaker>
               <l>Lena, si fa così? Ti par che meriti</l>
               <l>Fazio da te che gli facci una ingiuria</l>
               <l part="I">Di questa sorte?</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">E che ingiuria? Che diavolo</l>
               <l part="I">Gli ho fatt'io?</l>
             </sp>
-            <sp>
+            <sp who="#menica">
               <speaker>MENICA:</speaker>
               <l part="M">Nulla!</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Nulla a punto. Ai strazii</l>
               <l>Che fa di me, non è così notabile</l>
               <l>Ingiuria al mondo che da me non meriti.</l>
             </sp>
-            <sp>
+            <sp who="#menica">
               <speaker>MENICA:</speaker>
               <l>Tu gli hai scoperto, Lena, il tuo mal animo,</l>
               <l>Né però fatto nocumento, anzi utile,</l>
@@ -4299,23 +4357,23 @@
               <l>Figliuola ha in così ricco e nobil giovine,</l>
               <l>Quanto egli stesso avria saputo eleggersi.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="I">Glila darà pur per moglier?</l>
             </sp>
-            <sp>
+            <sp who="#menica">
               <speaker>MENICA:</speaker>
               <l part="F">Già datagli</l>
               <l>L'ha: si sono accordati egli et Ilario</l>
               <l part="I">In due parole.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Anco che questo misero</l>
               <l>Vecchio mi sia più che le serpi in odio,</l>
               <l>Pur ho piacer d'ogni ben di Licinia.</l>
             </sp>
-            <sp>
+            <sp who="#menica">
               <speaker>MENICA:</speaker>
               <l>Se tu perseverassi in questa còlera,</l>
               <l>Saresti, Lena, la più ingrata femina</l>
@@ -4338,14 +4396,14 @@
               <l>Massimamente che gli torna in utile</l>
               <l part="I">Questo error tuo.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l part="F">Faccia egli pur, e piglila</l>
               <l>Come gli pare. Se sarà il medesimo</l>
               <l>Verso me, ch'egli suol, me la medesima</l>
               <l part="I">Verso sé trovarà, che suole.</l>
             </sp>
-            <sp>
+            <sp who="#menica">
               <speaker>MENICA:</speaker>
               <l part="F">Or voglioti</l>
               <l>Dir, Lena, il vero. A te mi manda Fazio,</l>
@@ -4355,7 +4413,7 @@
               <l>A nozze; e intende che non sol Licinia</l>
               <l>E Flavio questa notte i sposi siano.</l>
             </sp>
-            <sp>
+            <sp who="#lena">
               <speaker>LENA:</speaker>
               <l>lo son per far quanto gli piace. — Or diteci,</l>
               <l>Voi spettatori, se grata e piacevole</l>

--- a/tei/barbieri-l-inavertito.xml
+++ b/tei/barbieri-l-inavertito.xml
@@ -81,6 +81,46 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="cinzio">
+            <persName>Cinzio</persName>
+          </person>
+          <person xml:id="fulvio">
+            <persName>Fulvio</persName>
+          </person>
+          <person xml:id="scappino">
+            <persName>Scappino</persName>
+          </person>
+          <person xml:id="celia">
+            <persName>Celia</persName>
+          </person>
+          <person xml:id="mezzettino">
+            <persName>Mezzettino</persName>
+          </person>
+          <person xml:id="beltrame">
+            <persName>Beltrame</persName>
+          </person>
+          <person xml:id="lavinia">
+            <persName>Lavinia</persName>
+          </person>
+          <person xml:id="pantalone">
+            <persName>Pantalone</persName>
+          </person>
+          <person xml:id="birro">
+            <persName>Birro</persName>
+          </person>
+          <person xml:id="spacca">
+            <persName>Spacca</persName>
+          </person>
+          <person xml:id="capitano">
+            <persName>Capitano Bellorofonte Martellione</persName>
+          </person>
+          <person xml:id="laudomia">
+            <persName>Laudomia</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Siena</name>Digitalizzazione</change>
@@ -149,115 +189,115 @@
         <div type="scene">
           <head rend="italic">SCENA PRIMA</head>
           <stage><hi rend="sc">cinzio</hi>, <hi rend="italic">e</hi><hi rend="sc">fulvio</hi></stage>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>V'intendo, signor Fulvio, voi m'andate motteggiando per solleticarmi il silenzio, acciò che nello scomporsi vi dia materia di ridere con suoi spropositi. Ma non potrebbono forse esser tanto sproporzionati, che avessi materia di sodisfare al vostro gusto, o all'assetata vostra curiosità; poiché ad esausto palato poco liquore non rimedia, e la poc'acqua del fabro non spegne, ma raviva la fiamma. Voi stimate forse violenza, quello ch'io prendo per elezione. Altr'oggetto non mi muove di casa per tempo, che il desìo di conservarmi la sanità, e avantaggiarmi nello studio, poiché l'aurora è delle Muse amica.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Signor Cinzio, né per violentare con l'amicizia il vostro silenzio, né per spegnere alcuna sete di curiosità ch'io abbia de' vostri affari, io ho detto felice quel oggetto, che fa così vigilante il signor Cinzio, ma è stato un scherzo,qual è sdrucciolato per la via dell'amicizia fino al ritegno della confidenza, mosso da un presupposto: che l'amore della<pb n="387"/> signora Lavinia sia quello, che v'invita a passeggiar per tempo queste contrade. Però, quando questo presupposto non abbia angolo di verità che lo ritenga, lasciatelo cader nell'elemento della nostr'amicizia, ché non sarà molesto, essendo in sua propria sfera.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Nel crogiuolo della fede, l'oro della nostra amicizia a fiamme d'amore è stato molte volte copellato, e i sofistici moltiplicamenti di sdegni, o disgusti, si consumeranno mai sempre a sì pure fiamme. Ma perché in così affinat'oro d'amicizia non si deve legare mentita gioia, ma candida margarita di verità, io v'assicuro che non è la bellezza di Lavinia il primo mobile, che conduca la sfera de' miei pensieri a mover i passi per questi contorni. E se ben amore semina nel mio core abbondantissime granella de' suoi meriti, e che i raggi de' suoi begl'occhi, quasi vivi soli, faccino il loro officio di generare, non avend'io già mai con l'acqua del mio consenso inaffiato questo cuore, il seme non ha potuto concepire vegitativo germoglio. E quando anche la natura facesse sforzo, almeno in superficie, sapend'ora che la signora Lavinia deve esser vostra consorte, non inafiarei di speranza i verdeggianti prati, ma l'innonderei d'acqua letale per disperder tutto quello che potesse contaminare l'amicizia nostra.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Per esser le grazie, ch'io li devo render di tanta cortesia, senza fine, io non gli do principio, e per non diminuire con parole il debito riserbato a gl'effetti taccio. Ma ben gli dico che la signora Lavinia non sarà mia moglie, ancor che mio padre tratti questo parentado, atteso ch'io ho collocato i miei pensieri in altr'oggetto.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>A benché i frutti primitivi non siano di sostanza per essere intempestivi, tuttavia, il gusto della novità gli fa<pb n="388"/> bramare. Io, veramente, dovrei aspettare il maturo tempo di sapere chi è la dama da vostra signoria amata, ma la curiosità delle cose nove me ne fa voglioso. Però, sia sempre anteposto il suo al mio gusto.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Il non compartire i gusti co' suoi amici è un portar ricchissime gioie per pompa e tenerle coperte, che ponno pericolare e non far onore. L'allegrezza non compartita è un gusto di sogno, un schermir con molta leggiadrìa al buio, un umore melanconico; e il gusto compartito all'amico è doppio contento. Per raddoppiare, adunque, il mio contento con farne parte all'amico, gli dico com'io amo una giovane nomata Celia, schiava di Mezzettino, quest'è la signora de' miei pensieri. E però mio padre non potrà violentar il mio arbitrio, ove gli converrà condescender alle mie giuste pretensioni.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Siamo due falconi ad una starna. Manco male, ch'io sono venuto in chiarezza del dubbio, ch'io teneva.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Par che vostra signorìa facci molta riflessione sopra questo mio amore. Non vi par forse giovane meritevole quella?</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Per certo sì, ma faceva riflesso non sapend'il fine di quest'amore.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Il fine è di prenderla per consorte.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Per consorte?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Signorsì, e così vostra signorìa potrà prender la signora Lavinia, ché non solo non me ne farà dispiacere, ma mi darà gusto; sì perché tanta bellezza restarà ben collocata, quanto che mi sarà levata la molestia, che, per tal cagione, mi potrebbe dar mio padre.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Come, signore, sposare una schiava? E chi sapete voi ch'ella si sia? Il Cielo sa chi è costei, potrebbe esser anche di così vil lignaggio, che ve ne avesti a pentire col tempo. Io non nego ch'ella non abbia un non so che di nobile nell'aspetto, e che non sia vestita in modo da potersi argomentare ch'ella sia di mediocre fortuna; ma non tutti i bei fiori hanno gentil odore, e di non molta virtù. E poi molte volte i<pb n="389"/> mercanti stessi addobbano le loro schiave, e insegnano loro il susiego per tenerle in prezzo. Vedete quello che fate, ché non ve ne abbiate a pentire, quando poi il pentire nulla giova.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Io vi ringrazio dell'avviso, ma sappiate che la schiava è figliuola d'un buon cittadino, chiamato il signor Gusberto Quercimoro Palermitano, qual fu da' Turchi, con questa e un'altra sua figliuola e altri amici, che insieme barcheggiavano, fatti schiavi. I loro parenti hanno riscattato il padre e trattano di riscuoter le figliuole, e fin ad ora hanno notizia di questa; ove non può passar molto tempo a giungere il suo riscatto. Io so questo caso da un mio fidato amico. Ma il mio dubbio è che l'avarizia di Mezzettino, suo padrone, non la facci vendere prima che il padre la possi liberare, e che non vada lontana da Napoli, e ch'io ne rimanga privo. Io volentieri la riscuoterei, ma non ho comodità, e non oso di chieder danari a mio padre, e massime per tal compra. Vero e ch'io ho per aiuto il mio fidatissimo Scappino, qual tenta ogni strada per aver soldi da consolarmi; ma la mia frettolosa passione mi ha fatto molte volte inavertito, onde ho sconciato scioccamente l'orditure, ch'egli avea fatte, ma da qui avanti l'interesse mio, mi farà esser più accurato. Vostra signorìa séguiti pur dunque la sua impresa, e procuri d'aver la signora Lavinia, ch'io gli la rinunzio in tutto e per tutto.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Io seguiterò dunque l'impresa incominciata, e s'io vi leverò la pretesa moglie, di grazia non vi dolete poi di me, ma doletevi di voi, ché sarete stato artefice del vostro disgusto.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Anzi, ch'io ne averò gusto, e vorrei che vostra signorìa sollecitasse il parentado.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Lo solleciterò. E se mi vengono oggi i denari, ch'io aspetto per lo mio dottorato, cercherò d'aver, con il mezzo di quelli, prima la moglie che la toga.<pb n="390"/></p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Vostra signorìa farà bene. E s'io potrò aver denari riscuoterò anch'io la mia.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Basta, chi prima avrà denari di noi sarà il primo ad esser felice.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>E forse tutti dua ad un tempo.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>O questo non può essere.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>E perché?</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Non dice vostra signorìa ch'io sollecita le nozze?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Signorsì.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>E io dico che le solleciterò, ma che vostra signorìa non si lamenta poi di me.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Ma io non v'intendo.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Mi avrebbe ben inteso Scappino. Ma signore io mi sono dichiarato quasi troppo. Basta, io servirò vostra signorìa nel sollecitare il matrimonio, che sarà appunto un accelerare le mie contentezze. Servitore, signor Fulvio.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Bacio la mano.</p>
           </sp>
@@ -268,7 +308,7 @@
             <hi rend="sc">fulvio</hi>
             <hi rend="italic">solo</hi>
           </stage>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Il parlare di costui mi ha posto in confusione. Io non so s'egli, metaforicamente, parla di mio padre, che s'opporrà a' miei gusti, o s'egli, cronicamente, mi accarezza per qualche suo interesse, o che mi voglia, per spasso, amareggiar anche i dubbiosi contenti. Ma quel dire d'essersi dichiarato troppo mi travaglia molto, e più, mi confonde l'aver detto che Scappino l'avrebbe inteso; adunque io non l'ho inteso. Mi dà anche da pensare quel dire che vorrà prima la moglie che la toga. Io non vorrei già cader in sospetto che costui amasse anch'egli questa schiava; tuttavia, s'io raduno insieme i suoi interrotti detti, mi figuro qualche rovina intorno. In somma, ad interpretare l'enigma di quest'Edipo non vi vuol altre che la sfinge di Scappino! Ed eccolo appunto.</p>
           </sp>
@@ -277,75 +317,75 @@
         <div type="scene">
           <head rend="italic">SCENA TERZA</head>
           <stage><hi rend="sc">fulvio</hi>, <hi rend="italic">e</hi><hi rend="sc">scappino</hi></stage>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>O benvenuto tramontana, che mi ha da condurre la travagliata navicella de' molesti pensieri nel porto della felicità.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>O ben trovato scirocco, che mi fa andare sempre alla orza, e che ben spesso mi vien per prua, mettendomi in necessità di calar le vele del mio buon animo di servire, con pericolo anche di farmi urtar nel scoglio della disgrazia di Pantalone.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Tu hai il torto a rimproverarmi per mancamento quel buon affetto, ch'io ho sempre di sott'entrare alle tue fatiche per agevolarti la strada del mio servigio. E se la forma non ha secondato i miei destri, non resta, però, che l'animo non sia stato bono verso di te.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>È vero, ma chi non ha sorte, non vadi a pescare! Io vorrei più tosto, a' miei mali, un medico ignorante e fortunato, che un sapiente sventurato. I vostri aiuti, perdonatemi, sono come le carezze che fanno gl'asini ai loro padroni, che sono sempre di nocumento. Ogn'uno ha la sua fortuna, la vostra è nelle scienze, e la mia nelle furbarie. Per cortesia, se volete ch'io vi mandi a fine questo negozio, lasciate la cura tutta a me, e non ve ne impicciate.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Così farò.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Che fate voi qua ora? Avete parlato alla vostra innamorata?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Non io, ma se tu vuoi fare il solito cenno le parlarei volentieri, e con tal occasione mi leverò forse un dubbio, che m'ha posto in capo il signor Cinzio, favellando meco.<pb n="392"/></p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>E che dubbio?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Dubito ch'egli non mi sia rivale, e che prima di me non riscuota questa giovine, perché m'ha detto ch'egli aspetta dugento ducati da suo padre, e che in cambio d'addottorarsi si vuol maritare; dunque egli vuol il matrimonio senza saputa del padre. E poi io l'ho veduto molte volte passeggiare per questi contorni, e potrebbe esser per Celia, e non per Lavinia come io credeva.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Non è il vostro dubbio senza fondamento. La giovane è bella, e, s'egli avrà i denari pronti, le mie astuzie serviranno per steccadenti dopo pasto! O qui bisogna pensar bene, star avertito, e non perder tempo.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Guarda pur tu quello, che debbo fare per aiutarti, e non dubitar, ch'io porrò ogni mio ingegno in opera.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Se voi ponete il vostro ingegno in opera la schiava è perduta.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Oh, che dici?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Dico, che il bisogno, ch'io ho di voi, è che facciate nulla, e se manco di nulla si può fare, che lo facciate, ché sarete più presto servito, e sarà bene per voi, e non rovinarete me.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>O poter dal Cielo, è possibile ch'io sia tale, che le disaventure mie levino la fortuna a gl'altri?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Signore, non è tempo di ragionar di fortune, né far prova se l'una mitiga il vigor dell'altra. So ben che fin ad ora la vostra ha distrutto le mie astuzie, però scommodatevi un poco in far nulla, ed esercitatevi un poco in tacere, ch'io m'accingerò a servirvi, se bene che il mercantare senza soldi, e senza credito, è un comprar sogno; tuttavia l'astuzie ponno assai, aiutatemi ancor voi col star lontano e tacere.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Io sequestro le mie invenzioni nella mia mente, e sigillo col silenzio le mie parole, e lascio l'opera tutta sopra le tue spalle. Ma dimmi, non vuoi ch'io saluti Celia?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Questo non è se non bene per rallegrarla un poco, e per intendere, con tal occasione, se ci fosse novità alcuna, da<pb n="393"/> che non li parlasti. L'intenderete, e vi chiarirete del signor Cinzio, e consolarete voi. Ecco, io faccio il cenno e mi ritiro a far la guardia.</p>
           </sp>
@@ -358,27 +398,27 @@
             <hi rend="sc">scappino</hi>
             <hi rend="italic">in disparte</hi>
           </stage>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Servitor, signora Celia, cielo, ove le mie speranze s'inviano; primo mobile, ove le mie voglie si reggono; e sfera, ove i miei pensieri soggiornano. Eccomi con il solito tributo de i saluti, co i dovuti ossequii di riverenza, e con l'augurio dell'usato buon giorno.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Signor Fulvio, io godo d'esser cielo, primo mobile e sfera delle vostre speranze e vostri contenti, e benedico amore, cagione efficiente di tanti miei contenti, i quali sono inenarrabili, sì come sono infinite quelle grazie, ch'io li rendo per tal cagione. O mio Fulvio, per vostra benignità, donatemi il credito di quei tant'oblighi ch'io vi devo, ch'io vi giuro, per quell'amore ch'io vi porto, ch'io non so come satisfarvi. O qual ventura sarebbe mai di colui, che solcando tal or il mare, quando più è procelloso, e che in vece d'esser dall'onde trovasse benigna deità, che non solo lo liberasse, ma l'arricchisse di preziosissima gemma. Ben potrebbe dir colui: o avventurata disaventura. E che cosa debbo dir io, caduta nel mare de i travagli per la mia captività, e quando penso d'aver perduta la libertà ritrovo voi, mio terreno nume, che non solo cercate di liberarmi, ma mi donate anche l'amor vostro? Ohimè che felice disaventura, o che disgrazia avventurata! Io per me mi struggierei di gioia, se il dubbio che non mi fugga il tempo a proseguir tanto bene non mi rallentasse il contento.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>O mia signora, voi non solo m'avete levato l'arbitrio con le vostre bellezze, imprigionato il cuore con la vostra<pb n="394"/> grazia, ché anche m'annodate la lingua con l'amorose vostre ragioni: io per me mi rendo vinto alla vostra facondia.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Le mie bellezze e grazie v'hanno imprigionato? O signore, o voi scherzate meco, o che v'infingete le cause, che mi vi fanno parer bella! Vostra signorìa scorge e vede in me quello, che a me nasconde lo specchio. Ad ogni modo sia come si sia, io la ringrazio, e godo che, lodando me, ella faccia pompa della sua facondia. Le sue lodi servono, appunto, come l'opere de gl'eccelsi pittori, che, nel servire altri, illustrano sé stessi. Queste lodi che mi date non sono generate dal mio merito, ma dalla vostra gentilezza, la quale, facendomi molte volte arrossire, nel udir a lodarmi, contra ogni mio merito, quel rossore partorisse poi quelle grazie, che a voi tanto piacciano. Ma vedete, signore, la generazione è fatta da voi, onde, ogni cosa che scorgete bella in me, è vostra figliuola, e non è meraviglia, perciò, se tanto l'amate.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Il rossore suole anche apparire nelle guancie de gl'umili, per esser lodati di verità; dunque la verità fa così bella generazione, e se vostra signorìa mi chiama padre di tali figliole sono, dunque, padre putativo, e però ringrazio la mia verità, che genera nella vostr'umiltà, e che mi fa padre di sì leggiadra prole.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Il rossore suol anche venire tal ora nelle guancie per dubbio di qualche mancamento. Voglia il Cielo, ch'il mio rossore sia come vostra signorìa interpreta, e che non nasca dal mancamento di quei meriti, che vostra signorìa dice di scorger in me.</p>
           </sp>
@@ -388,63 +428,63 @@
           <stage>
             <hi rend="sc">mezzettino, celia, scappino</hi>
           </stage>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Schiavetta, o schiavetta.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Signore.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Retiratevi, e lasciate parlar a me.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Mi ritiro.<pb n="395"/></p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Dove sète? Ah, alla fenestra! Vi sentiva e non vi vedeva.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Era qua.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Ah, ho inteso, adesso è arrivato qua il procaccio, col dispaccio dell'onore. Che fate qua galant'uomo, che faccende avete voi con la mia schiava?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Io era venuto un poco a domandargli se nella sua schiaveria avrebbe mai conosciuto un mio fratello, quale fu fatto schiavo, andando all'isole Filippine già molti giorni sono.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>E voi, madonna schiava, ch'andavate filippinando con questo segretario de i piaceri di Venere? E che avete da far de' suoi fratelli?</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Egli mi ha veduto qui a caso alla fenestra, e mi ha dimandato di questo caro suo fratellino, e io, per carità compassionando lo stato suo, diceva di non averlo mai veduto, e l'andava confortando con le mie miserie.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Oh voi sète troppo caritatevole de' fratellini! Ho caro che non l'abbiate veduto, perché non potevate veder cosa buona. E per levar l'occasione a costui, che non torni più qua con tal scusa, retiratevi.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Volentieri, amico, se mi sovverrà di questo vostro fratello ve ne darò nuova.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Io vi dirò le sue fattezze, e certe sue imperfezioni, per le quali lo potreste conoscere.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Non mi state a dipingere, né a descrivere i fratelli alle mie schiave, m'avete inteso? E voi, sfacciatella, volete ritirarvi, o volete ch'io venghi a privarvi anche del comodo della finestra?</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Signorsì, signorsì.</p>
           </sp>
@@ -453,59 +493,59 @@
         <div type="scene">
           <head rend="italic">SCENA SESTA</head>
           <stage><hi rend="sc">mezzettino, scappino</hi>, <hi rend="italic">e</hi><hi rend="sc">fulvio</hi><hi rend="italic">lontano e quasi dentro, che alcuna volta pone fuori il capo per vedere l'esito</hi></stage>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Messer Scappino, parlate con me di questo vostro fratello, ché per tutto marzo io ho da tornar in Algieri, per comprar schiavi. Che persona è, che offizio era il suo, perché i virtuosi non si pongano al remo.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Mio fratello è di statura mediocre.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Deve somigliare a voi senz'altro. Che professione?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Era tiratore.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Da che, d'archibugio o da borse?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>No, tirava l'artegliaria.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Bombardiere, volete dire.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>No, tirava l'artegliaria con le corde, dove non potevano andar bovi o cavalli.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Era guastatore, adunque.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Sì sì.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Anch'io son guastatore, e credo d'aver guastato adesso il ragionamento, che voi facevate con la mia schiava, e questo era qualche raccomandazione del vostro padrone. Orsù, voglio consolarvi, sentite all'orecchio: vogliono esser dugento ducati e non chiacchiere, però starò avvertito per qualche stratagemma.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Avete torto, messer Mezzettino. Né io, né il mio padrone, abbiamo pensiero della vostra schiava. Il signor Fulvio è maritato, e io voleva intender del fratello, e non altro; ma poiché vedo che voi v'insospettite, men'andarò, a Dio.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>A rivedersi senza il fratello, se volete ch'io vi cre<pb n="397"/>da.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Saprò dunque senza di voi trovarne il conto, poiché siete tale, che vi pigliate ombra d'ogni cosa.</p>
           </sp>
@@ -513,19 +553,19 @@
         <div type="scene">
           <head rend="italic">SCENA SETTIMA</head>
           <stage><hi rend="sc">fulvio</hi>, <hi rend="italic">e</hi><hi rend="sc">mezzettino</hi></stage>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>O il gran mariuolo, ch'è costui.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>O Scappino! È partito disgustato, costui non ha voluto fargli servizio. Vedete, messer Mezzettino, voi la venderete poi a qualche persona, che non vi farà mai un servizio al mondo, e io vi posso apportare qualche piacere, e se non abbiamo danari ora, sapete bene di chi son figliuolo, e se posso da un'ora all'altra far soldi; ma indugio per non disgustar mio padre. Almeno non la vendete ad altri, ve ne prego, per otto giorni, ch'io vi pagherò la spesa del suo vitto.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Signor, ho inteso il tuono della canzone, ma la musica non fa melodia rispetto a voi, che sète fuori di concerto. Dovevate prima prender la voce dal vostro servitore, che ha intonato in un altro modo. Ma spero che la sua musica comincerà con la chiave della giustizia, seguiterà con alti sospiri e darà fine con molte battute un giorno di mercato. Signor, vi vuol concerto, o che bisogna esser solo a far star le persone, che non sono merlote. Io credo che voi siate quello dal fratello tiratore e guastatore, poiché avete guastato forse l'orditura di Scappino. All'erta, Mezzettino.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>O misero me, che cosa ho fatt'io.</p>
           </sp>
@@ -534,35 +574,35 @@
         <div type="scene">
           <head rend="italic">SCENA OTTAVA</head>
           <stage><hi rend="sc">scappino</hi>, <hi rend="italic">e</hi><hi rend="sc">fulvio</hi></stage>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>E dove sarà andato costui?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Ho parlato con Mezzettino, e l'ho pregato a darti la schiava in credenza, ch'io gli sarei stato sicurtà. O che almeno non la venda ad altrui, per otto giorni avvenire, ché noi gli sborsaremo il riscatto, e egli si burla di me. Non è stato tale il tuo ragionamento?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Giusto appunto, o meschino me, costui m'ha rovinato a fatto. O poveretto voi, e che cosa avete detto! Io, per non dargli sospetto, ho mostrato d'aver un fratello schiavo, e di cercarne indizio dalla sua schiava, e l'ho cercato d'assicurare; e voi, per far al solito vostro, siete andato al mercato senza soldi e l'avete posto in sospetto, acciò ch'io non possa pratticare a casa sua. E voi sète poi quello, che vuol esser servito? Son ben io pazzo a pigliarmi una briga, che puzza di galera, o per lo meno un esilio dalla casa di Pantalone per sempre, e per chi, poi? Per uno che mi ha da far perder o il cervello o il credito.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Piano, fratello, piano, ch'io non ho pensato di far male! Si dice che chi dice la verità non falla, io non credeva di fallare dicendo la verità. Tu m'hai detto di voler levar questa schiava, o con danari o con qualche stratagemma; tu non m'hai detto con bugìe, ma ora ch'io intendo che bisogna dir delle bugìe, lascia pur far a me, ché non m'uscirà più verità di bocca.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>O bello! E per cominciare dite che voi sète un giovane trincato e accorto, e che sopra il tutto sapete tacere ove bisogna. Ditemi, di grazia, come sono i nostri patti.<pb n="399"/></p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Che s'io voglio aver la schiava, ch'io non m'intrighi più in cosa alcuna, e che lassi tutto il carico a te, non è così?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>E perché ve ne intrigate?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Fratello, questo è stato un accidente per aver trovato Mezzettino in strada, ché del rimanente io non avrei parlato già mai; e da qua avanti, o a Mezzettino o a chi si sia, non parlerò senz'ordine tuo, e che ciò sia vero ecco ch'io taccio, e parto.</p>
           </sp>
@@ -573,7 +613,7 @@
             <hi rend="sc">scappino</hi>
             <hi rend="italic">solo</hi>
           </stage>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Questo povero giovine non ha mai pratticato il mondo, ed è stato sempre sotto i precetti del padre e la cura de' maestri, onde non ha potuto imparare per esperienza, o per necessità, l'astuzie del mondo, però io lo compatisco, e lo voglio aiutare ad ogni modo, s'io potrò. Questo Cinzio, col suo danaro pronto, me la potrebbe far della mano, ma s'io farò a tempo, vorrò ch'il mio ingegno furbesco avanzi la sua commodità. Questa notte ho pensato un modo d'aver danari, che mi par riuscibile. Messer Beltrame mi ha credito, e se bene li faccio una truffa, come ho tempo vorrò anche aver ragione. O di casa!</p>
           </sp>
@@ -581,111 +621,111 @@
         <div type="scene">
           <head rend="italic">SCENA DECIMA</head>
           <stage><hi rend="sc">beltrame</hi>, <hi rend="italic">e</hi><hi rend="sc">scappino</hi></stage>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Chi è là?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Amici.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>O se' tu, Scappino.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Signorsì.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Che chiedi?<pb n="400"/></p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Son venuto a darvi il bon giorno.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Bon giorno e bon anno, ti ringrazio, a Dio.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>O che uomo di poche cerimonie! Messer Beltrame!</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Chi è là</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Son io.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Che vòi?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Son venuto a salutarvi da parte del padrone ancora.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Sii ben venuto, ti ringrazio, raccomandami a lui.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Fermatevi, di grazia, ch'io non ho finito il ragionamento. Il mio padrone vorrebbe un servizio da voi.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Egli vuol un servizio da me?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Signorsì.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Orsù, come verrà, lo servirò volentieri.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Fermatevi, in bon'ora, se volete intender il rimanente.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Fratello, fa' presto, ch'io non ho tempo da perdere.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Farò presto. Come sta vostra figliuola?</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>O quest'è un'altra, a Dio.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Fermatevi, se non, vi straccierò il ferraiuolo.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>E che hai da far tu di mia figliuola?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Non è ella moglie del figliuolo del mio padrone?</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Ha da essere.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>O bene, io l'ho da salutare da parte del signor Fulvio, e poi ho da parlar con vostra signorìa.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>È ben tempo che lui manda un saluto! Io non ho mai veduto matrimonio più freddo di questo. Lavinia.</p>
           </sp>
@@ -693,75 +733,75 @@
         <div type="scene">
           <head rend="italic">SCENA UNDICESIMA</head>
           <stage><hi rend="sc">lavinia, beltrame</hi>, <hi rend="italic">e</hi><hi rend="sc">scappino</hi></stage>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Signor padre, che volete?</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Eccoti qua il magnifico messer Scappino, che t'ha da parlare.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>A me?</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>A te, sì.<pb n="401"/></p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Il signor Fulvio, mio padrone, manda mille saluti a vostra signorìa e vi priega a tenerlo nella vostra buona grazia, e manda me a far scusa, con vostra signorìa, per non aver mandato prima d'ora a salutarla, poiché egli non sapeva che fusse costume di mandar saluti alle spose avanti lo sposalizio; però chiede perdono dell'inavertito mancamento, e le fa intendere per me che non commetterà più tal errore.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>O come il signor Fulvio dice così! Può ben pensare il signor Fulvio ch'io penso quello che si può pensare intorno a questo, e, in risposta, so che direi cose che non si potrebbono esprimere sapendole, ma a tutti non è dato d'andar a Corinto. Ma dirò tra me appunto come disse quel savio, ch'intendeva il parlare de gl'uccelli, che forse fu simile al signor Fulvio, poiché egli ha sempre professato belle lettere, e in vero ch'egli merita, a mio parere, ma che parere? che voglio giudicar'io, inesperta e ignorante? Io son appunto come quello, che tal or o sa o non sa, poiché tutti non hanno uno stesso ingegno. Pur si prende la rosa, e si lascia la spina, ché far d'ogni erba fascio non è da una giovane che vive con l'obedienza paterna, e poi so ch'il signor Fulvio non avrebbe caro ch'io facessi come dice colui, ma il dovere è dire se non quello, che s'ha nel cuore. So che son benissimo intesa, e tanto più dal mio signor padre.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>A fé, che t'inganni, più tosto avrei inteso il parlar arabico o caldeo che il tuo! Io non credo che t'intendesse, parlando così, manco il primo interprete della torre di Babele. Queste tue non son massime sciolte, né parlar conciso,<pb n="402"/> ma più tosto mi paiano lettere sciolte, ché tra tante si potrebbe far un anagramma, che dicesse qualche cosa, ma così, s'io intendo nulla, non dicono nulla.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Che vostra signorìa non m'intende, adunque?</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Madonna no, ch'io non t'intendo, né credo che niun altro t'intendesse, se non t'intendesse a caso messer Scappino, che è prattico fino del parlar in zifera.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Io capisco molte zifere, intendo gli oltramontani per prattica, i muti per cenni, e gl'animali irrazionali per discrezione; ma il linguaggio vostro, di senso incognito, io non lo so interpretare così all'improviso. O mutate modo, o scoprite il senso, o datemi il vostro Calepino, se non, l'oratore non saprà riportar la risposta al suo padrone.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Mi dispiace d'esser tanto ignorante, ch'io parli in modo che niuno m'intenda, vedrò di farmi intendere.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Questo modo è buono, e s'intende benissimo, seguitate questa frase che saremo d'accordo.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Dite al signor Fulvio che gl'ardenti miei sospiri, ancorché indistinti tra l'aria e 'l fuoco, che vanno alla determinata loro sfera, e che gl'occhi miei, bramosi di contemplar l'oggetto della loro felicità, che sono quasi snervati, usciti dal lor concavo, e che quasi dinotano un'oblivione di spiriti visivi. E che non tanta ambrosia, e nettare consumano gli dèi alle loro mense, quanto sono le dolcezze, che in amando si provano, e che se 'l cuore è centro d'un amoroso petto, che l'amore è centro d'ogni cuore amante, e che sì come è impossibile ch'il sole si parta dall'ecclitica, così è impossibile di<pb n="403"/> far retrogrado d'un ben radicato amore nel cielo dell'altrui voglie. Però egli, che spira tutta grazia e gentilezza, che può co' suoi vaghi portamenti bear un mondo intero, e che a sua signorìa sta il dar salute a chi tanto la brama.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>O se vostra signorìa m'avesse parlato così alla prima forse l'avrei intesa manco di quello che ho fatto adesso. Però io ho parlato con voi come ho saputo, vostra signorìa meco come ha voluto, il signor Beltrame ha inteso come il Cielo ha conceduto, e io referirò come mal instrutto.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Va' in casa.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>E perché?</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Va' via, ti dico.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Servitrice di vostra signorìa.</p>
           </sp>
@@ -772,59 +812,59 @@
             <hi rend="sc">beltrame, scappino, lavinia</hi>
             <hi rend="italic">sta ritirata mettendo fuori il capo alcuna volta dalla porta per udire</hi>
           </stage>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Che ne dici, Scappino?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Di che?</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Del ragionamento di mia figliuola.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Dico che se vostra figliuola studierà niente niente più in complimenti, che riuscirà la più pazza dottoressa ch'abbia il donnesco stuolo.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Io ho inteso il concetto.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>O voi sareste da più della Sfinge.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Il concetto è questo: sdegno e timore. Queste cagioni l'hanno fatta parlare con quel sì imbrogliato stile, il timore della presenza mia, e lo sdegno, che le ha cagionato il signor Fulvio. Come domine, che in tanto tempo, che Pantalone ha dato parola, mai suo figliuolo si sia degnato farsi vedere dalla sposa? E gli paiono, a loro, cose queste da captar benevolenza? Ove sono i fiori e le galanterie, che si sogliono donar alle spose, quando sono promesse? In somma, ha ragione d'aver parlato in modo di non perdere il rispetto a me, e di non si gettar dietro a chi forse poco la cura.<pb n="404"/></p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Signor Beltrame, voi dite troppo la verità, e il signor Pantalone ne ha una mortificazione grandissima, e appunto io sono venuto da parte sua, a far la scusa, e a pregarvi d'un aiuto appartenente a questo negozio. Il signor Fulvio si trova inamorato d'una schiava di messer Mezzettino, e per questo ritarda il parentado. Però il signor Pantalone ha trovato, per espediente, che vostra signorìa compri questa schiava e che la ponga in luogo nascosto, e che faccia che Mezzettino dica d'averla venduta ad un forastiero, che non sa chi si sia; ché in tanto farà che suo figliuolo sposi la signora Lavinia vostra figlia. E poi esso ripiglierà la schiava e sborserà il costo e pagherà la spesa del vitto a vostra signorìa ed egli, poi, ne farà escito subito, ma non in questa città, per levar l'occasione a suo figliuolo di rivederla.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>E perché non far far questo servizio da un altro, non far palesar i defetti di suo figliuolo a me, nell'ora del parentado?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Perché ogni altro che la comprasse potrìa, per farsi ben volere dal signor Fulvio, palesare il negozio; ma vostra signorìa non lo scoprirà, per essere interessato. E perché le cose non possono star sempre celate, vi fa saper di bon'ora come passa il negozio, quale non trascende lo stile della giovanezza e vostra signorìa ben lo sa.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Ha pensato bene e concluso meglio. Io andrò or ora da Mezzettino, qual appunto mi deve aspettare in casa, poiché io gl'ho promesso di riveder certe sue scritture, e fargli certi conti. Mi sbrigherò di questo, di poi gli trattarò della schiava, e me la farò condur da lui fino a casa mia, e poi la nasconderò per quattro, o sei giorni; ma con patto però che, subito fatto il parentado, il tuo padrone mi rimborsi il mio danaro, e poi che faccia esito della schiava, perché non sia cagione di far aver mala vita a mia figliuola.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Vostra signorìa non si dubiti, ch'il mio padrone non promette se non attende.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>La casa è aperta, e io vo a far il servizio.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Andate.</p>
           </sp>
@@ -833,67 +873,67 @@
         <div type="scene">
           <head rend="italic">SCENA TREDICESIMA</head>
           <stage><hi rend="sc">lavinia</hi>, <hi rend="italic">e</hi><hi rend="sc">scappino</hi></stage>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Messer signor Scappino, a questo modo, eh? Queste sono le promesse, che mi faceste a giorni adietro, quando vi palesai l'amore ch'io porto al signor Cinzio, con tanti giuramenti, e sopra l'onor vostro, e sopra la grazia de gl'amati cibi vostri, ch'avreste sturbato il trattato di mio padre, e agevolato il matrimonio del signor Cinzio? E ora concertar con mio padre il modo di farmi rimaner di Fulvio? Ma non vi verrà effettuato il vostro concerto, e voi avete da far meco, che vuol dire con una sdegnata, e tanto basta.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Piano, piano, e non con tanta collera! Cape, so che vi fuma io! È vero ch'io v'ho promesso di aiutarvi in farvi avere il signor Cinzio, e ch'io avrei disturbato il trattato del signor Fulvio, e lo giurai sopra l'onor mio, giuramento in vero interdetto al mio parentado. Però io sono qua per osservar quanto io v'ho promesso, e quello, che vostra signorìa da me ha udito, quando ho parlato con il signor Beltrame, è il principio.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Se dal bel mattino si può argomentar buon giorno, poco posso sperar dal vostro principio.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Signora, voi non sète ancora capace delle cose del mondo per più strade si va a Roma. Anche il gettar via il grano per i campi pare che sia pazzia e pur è 'l principio d'aver del grano. Lo uccider i vitelli, e i capponi, pare crudeltà, e pure s'ammazzano per pietà, perché la lor morte è nutrimento a tanti galant'uomini. Vostra signorìa non sa per che verso io mi navighi per far ch'il batello del signor Cinzio entri nel porto de' vostri gusti, quando egli ha il timone rivolto altrove. Io non ho danari, questa è cosa che ha del credibile. Il signor Fulvio passa sotto l'istesso influsso, e non è solo sotto a tale influenza, e per aver questa schiava<pb n="406"/> ci vogliono dugento ducati. Ora io ho pensato di servirmi di quelli di vostro padre, e l'ho mandato, con quella invenzione che avete udita e intesa, a comprarla, acciocché Mezzettino non la venda al signor Cinzio. E ch'il signor Fulvio sia poi contento a far a modo del padre, faremo porre la schiava in casa vostra, e poi faremo che Fulvio venghi a visitare vostra signorìa come sposa, e voi gli darete commodità che s'abbocchi seco, e che la conduca dove gli sarà commodo, e così, privandone Cinzio, egli poi si risolverà di far quello che non può far adesso per occasione di questa schiava.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Io ho inteso, ma quel dar commodità ad un giovine che meni via una sua morosa, che ufficio si chiama?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Ad un par mio si direbbe di ruffiano, ma se ciò facesse un gentil'uomo si direbbe un servizio, e ad una par vostra si dice aiuto. Il ruffianesimo è come il furto: in un grande è aggrandimento di stato, ad un mercante è ingegno, e in un disgraziato è latrocinio.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Che dirà poi mio padre, come si accorga della fuga della schiava? Darà la colpa a me della mala custodia.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>E voi vi dorrete di lui, che abbia posto donna tale in vostra compagnia, da dar cattivo esempio. E vi dorrete dell'affronto fattovi dal signor Fulvio per colpa sua, e così il povero vecchio avrà il male e le beffe.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Messer Scappino, voi sète un gran mariuolo.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Signora, sono ancora novizio, ma spero col tempo di perfezionarmi.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Se più vi perfezionate, potrete por scola d'insegnare quello, che non sa il demonio.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>O signora, m'onorate troppo.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Non dico fuor de i vostri meriti. Orsù, aspetterò il vostro aiuto, attenderò i vostri avisi, e starò lesta a' vostri cenni.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>O così va bene: aiutarsi l'uno con l'altro, perché il negozio butti meglio.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Io sarò sempre pronta.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Ed io vedrò di ritrovarmi lesto.</p>
           </sp>
@@ -905,55 +945,55 @@
         <div type="scene">
           <head rend="italic">SCENA PRIMA</head>
           <stage><hi rend="sc">beltrame, mezzettino</hi>, <hi rend="italic">e</hi><hi rend="sc">celia</hi></stage>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>O via, cessino ormai i pianti e i lamenti, e venitevene meco a contar i vostri soldi, ora che abbiamo revisto le scritture.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Signore, non posso far di meno di non gettar quattro lagrimuccie, se si perde solo un cagnolino, che pure è una bestia, come vostra signorìa sa meglio di me.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Che asinaccio!</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Pur dà dolore. O vedete che farà il perdere una giovane bella come è questa! Io sono una persona, che mi affeziono tanto alle creature, che io non me gli vorrei mai levar d'attorno. E se io fossi ricco non la vorrei mai vendere, ma tenerla per farmi far delle sberettate dalla gioventù, per far frequentar queste strade della brigata, e per farmi dar del molto magnifico da gl'amanti. Questa mi servirebbe per compagnia in casa, per conversazione alla tavola, e per materia a' miei sogni, che mi farebbono star allegro.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Veramente la giovane è bella ed è meritevole d'esser accarezzata; ma non è cosa da voi! Voi, a tenerla in casa, portate pericolo d'esser tenuto in mal concetto, ed ella in poca riputazione. E poi non mi negarete che non viviate<pb n="409"/> sempre con qualche sospetto, o che vi sia menata via di furto, o che non s'inferma e defrauda il riscatto, o che non mora, e che perdiate il vostro capitale. Consolatevi, dunque, e venite a prender i danari.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Il vero, e più per questo la vendo, che per il guadagno. La sua spesa non mi dà fastidio, perché ella è di buona bocca, ella s'accomoda a quello che gli vien posto avanti, e non rifiuta mai cosa alcuna. Questa non è come certe svogliate, che se il cibo non è conforme alle loro voglie, torceno il muso fiutando sopra ad ogni cosa, del poco si sdegnano, e 'l molto lo strapazzano, questa no. Ella è di bona natura, digerisce tutto, e sempre si conserva un poco d'appetito per quello che gli pò occorrere.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>O così vogliono essere le donne a mantenersi sane! Orsù, andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>O signor padrone, e pur mi volete mandar via da casa vostra! Pazienza, al meno m'aveste tenuta tanto, che n'aveste trovat'un'altra; ma rimaner voi solo soletto, e come farete? e chi vi farà da mangiare? e chi saperà fare quelle torte tanto a vostro gusto come sapevo far io?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>O misero me, è vero! Ohimè, se la torta non mi fa mancar di parola, niuna cosa mi fa mancare. Signor Beltrame, per grazia, lasciatemela ancor un poco, due o tre giorni, sin tanto che io ne compri un'altra, e che questa gli dia la dose di quella buona torta, e l'intavolatura di certi macaroni, che mi rimettono il fiato in corpo, quando sono svogliato.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Mi meraviglio di voi. E vi lasciate dunque prender per la gola da un piatto di macaroni o da una torta? O sarebbe bella, che stando voi soletto in casa, che questa<pb n="410"/> schiava vi avvelenasse la torta, o i macaroni, e vi facesse morire per aver libertà! Fareste meglio a non mangiar nulla delle loro mani.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Voi dite il vero, ancorché la mia morte potrebbe esser peggiore, poiché sono stato pronosticato ch'io ho da morire per giustizia, ove che sarebbe pur meglio morire con la bocca unta di buona torta, che con la gola stretta da tristo laccio.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Non vi fate questo augurio in vano, di grazia.</p>
           </sp>
@@ -961,127 +1001,127 @@
         <div type="scene">
           <head rend="italic">SCENA SECONDA</head>
           <stage><hi rend="sc">fulvio, mezzettino</hi>, <hi rend="italic">e</hi><hi rend="sc">celia</hi><add resp="#ed"><hi rend="sc">beltrame</hi></add></stage>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Non oso di passare per questa strada, per non disturbare le invenzioni di Scappino. Ma che veggìo, messer Beltrame e la mia Celia?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Io spero che l'astrologia sia fallace, e poi mi sarebbe più caro morire di qua cent'anni impiccato, che morir dimani annegato nel mèle, morte la più dolce che si possa fare.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Mi piace il vostro umore! Orsù, andiamo pure.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Andiamo. Ma, caro signore, fatemi grazia di darmi moneta buona, perché la voglio rimetter in un'altra schiava o in un paio, se saranno a buon mercato; io sono principiante in quest'arte e non ho altro che trecento scudi da trafficare, co' quali io vado campando la vita.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Ohimè, mi trema il cuore, che cosa è questa?</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Non dubitate, che avrete sodisfazione da me. E voi, bella giovane, non v'attristate per lasciar la casa di messer Mezzettino, ché andarete in luogo dove non sarete manco ben veduta ch'in casa sua. E che mirate? Statemi allegra, per cortesia.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Ohimè, che odo? Beltrame la compra. Questo è qualche inganno, che hanno ordito i vecchi contra di me, ma non verrà lor fatta. Servitor, signor Beltrame.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Ben venuto, signor genero.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Non mi chiamate genero per genero, in cortesia, fin<pb n="411"/> tanto che non siano effettuate le nozze. Ma che mercanzia è questa, che vostra signorìa fa con messer Mezzettino?</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Ho comprato questa schiava.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Per voi?</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Signornò, per un mio amico.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Questo è rispondente del padre di Cinzio, è certo ch'egli la compra per lui. Ohimè son rovinato! Caro signor Beltrame, vostra signorìa mi faccia grazia per ritrattar questo mercato, ch'io lo riceverò per un favor segnalatissimo.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>E perché, signore?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Perché sono stato pregato da un mio amico a far uffizio che Mezzettino tenga ancor un poco questa giovane, tanto ch'i suoi parenti la riscuotano. E presto gli sarà sborzato il riscatto e la povera giovane andrà in poter de' suoi, senza andare or in mano di questo, or di quel altro.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Vostra signorìa mi mostri, o mi faccia mostrar lettere de' suoi parenti, che volentieri vi compiacerò.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Le lettere sono nelle mani di questo amico mio.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Orsù, porrò la schiava in casa mia, e poi verrò con esso voi a veder le lettere. Ma chi è questo vostro amico?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Vostra signorìa non lo conosce?</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Forse che sì.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>E chi è egli?</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Orsù, basta. Questo è mio amico, ancora tanto quanto mi siete voi, e per suo bene io l'ho comprata.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Signor, non mi avete ad impacciar se quello che la vuole fa bene, o male.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Non vi avete voi ad impacciar nelle mie mercanzìe.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Io v'ho più interesse che voi.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Ed io ho più possesso di voi, e la voglio.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Ed io non voglio che l'abbiate.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Che?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>O là, signore, non mi rovinate i miei mercati! Io l'ho venduta, la schiava. È mia e ben venduta.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Ve ne pentirete ambidue.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>O là, che parlar è il vostro? che arroganza è questa?</p>
           </sp>
@@ -1090,127 +1130,127 @@
         <div type="scene">
           <head rend="italic">SCENA TERZA</head>
           <stage><hi rend="sc">pantalone, beltrame, fulvio</hi>, <hi rend="italic">e</hi><hi rend="sc">mezzettino</hi></stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>O là, o là, che strepito è questo? Signor Beltrame, con chi l'avete? con mio figliuolo forse? che fai tu qua? Tu non parli. Che cosa è questa, signor Beltrame? che cosa v'ha fatto questo forfante?</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>E son pazzo io a voler le brighe de gl'altri! Pigliate, signor Pantalone, ecco, ve la do in mano, e bella e finita.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Che cosa è questa?</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Il negozio.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Qual negozio?</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Il negozio vostro.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>V'ingannate, ch'io non negozio più tale mercanzia, ma solo attendo a' cambi.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Ma è ben cosa di vostro ordine, e per vostro conto; anzi, cosa che m'ha fatto perder il rispetto, che mi si deve per l'età, da vostro figliuolo.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Mio figliuolo ha avuto così poco rispetto a voi, sì poco timore di me, e così poco giudizio di dir parole in disgusto vostro?</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Ha detto tanto, che se non fosse stato per amor vostro io mi sarei risentito con parole, se io non avessi potuto far de' fatti.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Ah manigoldo, tu me la pagherai!</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Signore.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Taci, furfante, sai bene ch'io ti conosco. E che cosa volete ch'io faccia di questa schiava?</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Quello che a voi piace.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Io non ho che far altro, che tornarla a voi.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>A me? Io non voglio più questa briga, trovate pur un'altra invenzione, e accommodatevi.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Mi posso accomodar come voglio, ch'io non farò nulla, non sapendo a che fine mi ponete in questo imbroglio. Di grazia, parlatemi chiaro.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>E volete ch'io parli, se ci è vostro figliuolo?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>E che ho che far io di mio figliuolo?<pb n="413"/></p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Non mi son io apposto che questo è qualch'inganno, ordito contro di me.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Ma poi che così volete la dirò chiara io.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Ditela, in buon'ora.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Scappino è venuto da parte vostra, e mi ha detto ch'il parentado nostro non si conclude, rispetto che vostro figliuolo è inamorato di questa schiava. Però che io la comperassi, e ponessi in luogo segreto, fin tanto ch'il matrimonio sia effettuato, che poi vostra signorìa mi rimborserà il mio danaro, e che doppo manderà la schiava tanto lontano, che il signor Fulvio non saprà dov'ella sia, per torgli l'occasione del disgustar me, e la sposa, e così ho fatto.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Vi ringrazio. Scappino è un menzognero, e io non gl'ho dato questo ordine. E quando lo mando per danari, o per altro, sapete bene ch'io scrivo sempre una poliza di mia mano, però io non voglio i suoi imbrogli. Di chi è questa schiava?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Mia, signore.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Toglietela, e custoditela bene, perché se mio figliuolo la comprerà ve la farò tornar in dietro. E vi protesto che non mi farete piacere a vendergliela, mi avete inteso.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Io vi ho inteso, e io vi protesto che se vostro figliuolo, o il vostro servitore, manderanno sotto mano a comprarla, ch'io non voglio che sia ben venduta a loro, e se mi averanno dato caparra, vorrò che sia perduta, e meterò la schiava per uso ordinario di casa.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Per me mi contento, e mi farete piacere.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Signor Beltrame, io piglio questa chiaritura per amor vostro.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Fratello, io non la compravo per me, avete inteso come è passato il negozio. Abbiate pazienza ancor voi, scuserà che vi dia l'intavolatura de i macaroni e la dose delle buone torte.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Avete ragione, appunto questa sera io la voglio adoprare un tantino per mio conto, e voglio ch'ella meni un poco più del solito le mani per amor mio, e che mi faccia qualche cosetta di gustoso, poi ch'ella è in transito di perder casa mia. Orsù, vien qua figliuola, andiamo, ché sei stata cavalla di ritorno.</p>
           </sp>
@@ -1219,71 +1259,71 @@
         <div type="scene">
           <head rend="italic">SCENA QUARTA</head>
           <stage><hi rend="sc">pantalone, fulvio</hi>, <hi rend="italic">e</hi><hi rend="sc">beltrame</hi></stage>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>O Scappino traditore! s'io ti posso trovare!</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>E tu sai quello che ti voglio dire: trovati questa sera di bon'ora a casa, ché voglio che si tocca la mano alla sposa. E non far ch'io abbia da dare ne i rotti, ché sarà male per te.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>O signore.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Che signore, citto.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Almeno, datemi un poco più tempo.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Non vi è altro tempo, m'hai tu inteso. Andiamo, signor Beltrame, alla volta di piazza, ché trattaremo del vestir la sposa.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Non la voglio, signor Beltrame, m'intendete.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Ed io non ve la darò, ché non la meritate, m'intendete ancor voi.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Che borbottate? che cosa dice colui?</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Niente niente.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Non guardate, signore, al suo poco ingegno.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Anzi, vi devo ben guardare.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Per amor mio, supite le sue leggierezze.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Io ho bello supito.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Non sapete, no.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>No no, in lettere maiuscole.</p>
           </sp>
@@ -1292,163 +1332,163 @@
         <div type="scene">
           <head rend="italic">SCENA QUINTA</head>
           <stage><hi rend="sc">fulvio</hi>, <hi rend="italic">e</hi><hi rend="sc">scappino</hi></stage>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Ah Scappino, a me, ch'io lo sopporterò? Ah, non sia vero!</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>E dove troverò io costui ora? O eccolo!</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Ah, traditore!</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Ohimè, son morto! O, signor Fulvio, con la spada ignuda contro di me, a un vostro fidato servitore?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Contra ad un nemico.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Ohimè, che dite? Frenate l'ira, per grazia, e ditemi in che v'ho offeso.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>O assassino, domanda alla tua coscienza!</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>E dove volete ch'io trovi la mia coscienza ora? Il Cielo sa dove si ritrova! Eh, ditemelo voi, per grazia.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Ah, cane, ancora tu ti burli di me?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Ah signore, ah signore, giustizia per voi, compassione per me! Ohimè, è possibile ch'io non vi possa far sospendere quest'ira?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>A questo modo assassinarmi? in questa maniera? Tu non la scaperai certo!</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Ohimè, ditemi per grazia in che vi ho offeso, e poi fate di me non quello, che l'intelletto vostro vi somministrarà, ma quello, che la giustizia comporta.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>In che m'hai offeso? e ancor t'infingi? Far comprar la schiava da Beltrame, e ordinargli che la nasconda, acciò che perduta la speranza d'aver Celia, io sia necessitato a prender Lavinia, e ti par nulla questo? per sodisfar al vecchio, assassinarmi in questo modo? O traditore!</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Adagio, adagio! E per questo siete adirato contro di me? O respiro! Rimettete pur la collera, e lasciatemi dir la mia ragione senza farmi paura.<pb n="416"/></p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Che ragione? Di' pur che vòi scusarti del mancamento, e che mi vòi far vedere d'aver fatto bene con la tua logica salavatica. Ma non mi ci farai star questa volta a fé! Di' pur quello che sai.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>È vero.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Ed ecco.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Piano, è vero parte di quello, che avete detto, ma non tutto.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>È vero tutto, e io ho udita tutta la trama, non vi occorrono scuse.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Ho caro che avete udito. E bene, come sta il negozio? Ditelo, per cortesia.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Io mi son trovato presente, quando che Beltrame voleva menar via la schiava, e mi son adirato seco, e in questo è sopra gionto mio padre, e Beltrame gl'ha detto d'ordine tuo; ove mio padre ha fatto che Mezzettino pigli la sua schiava, e che non contratti più né meco, né teco. E così sono levate le mie speranze. Che dici, ora, non è così?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>È vero, ma chi vi ha fatto parlare con Beltrame?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>La mia buona fortuna, acciò che Celia non parta da Napoli, e ch'io conosca chi mi tradisce.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>La vostra disgrazia, acciò che perdiate, quanto prima, voi la schiava e io il cervello. Avete denari voi?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Che dimande sono queste?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Dimande giuste, acciò che da voi vi accorgiate del vostro bell'ingegno.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Tu vai provocando l'ira mia, e poco starà a precipitare.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>E voi m'andate assofocando la pazienza per ridurmi alla disperazione. Udite, di grazia, il mio fallo e 'l vostro antivedere. Io ho fatto comprar la schiava con astuzia dal signor Beltrame, e gl'ho ordinato che la tenga nascosta, e poi ho passato, d'accordo con la signora Lavinia, che per dar colore alla cosa, che voi andarete a visitare come sposa, e ch'ella poi vi dia commodità di condur via la schiava. Beltrame l'ha comprata e mentre la conducevamo via, è sopra<pb n="417"/> gionto il vostro bell'ingegno e ha rovinato tutto il trattato, e ha posto me in contumacia di Pantalone, in poco credito a Beltrame, e in conto di furbo con Mezzettino, dove non potrò mai più far colpo che vaglia. Questo è l'assassinamento, ch'io vho fatto. Castigatemi, ch'io lo merito.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>O Scappino mio.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>No no, castigatemi dico, ch'io lo merito, non perché io abbia fatto errore a far comprar la schiava; ma perché voglio servire uno che mi rovina l'invenzioni, ch'io con tanto pericolo vado ritrovando per servirlo. No no, merito ogni male, fate quello che volete.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Io merito castigo, fratello, e non tu. Scappino, confesso l'error mio, io ho fatto male, ma da qua avanti...</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Farete poi male, e peggio. Orsù, operarete un poco voi, per l'avvenire, e farete conto ch'io non sia in questo mondo per voi.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>O come, tu non sei in questo mondo per me? Bisogna ch'io esca dal mondo per te, perché senza il tuo aiuto io son morto.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Ed avete ancor animo di dire ch'io v'aiuti, e ora mi volevate uccidere?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Perdonami, Scappino, la diffidenza; sol è stato un errore. Ma del resto io non ho errato. O fratello, io vedevo condur via la donna, e vuoi ch'io pensi bene? Ah, Scappino, trasformati in me, ti priego!</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Per far gilè de' merlotti, non è vero? Signor Fulvio, io non vorrei tener in mal concetto niuno, ma se vostro padre fosse stato al mio paese, come mio padre è stato al vostro, io dubitarei di mia madre. Stante il gran bene, ch'io vi voglio, andate, ché vi perdono, e vedrò quello, ch'io potrò fare, ma avvertite.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Io t'ho inteso, aprirò ben gl'occhi.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Sì, per vedere più presto dove mi potrete guastare.<pb n="418"/></p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>No, da qua avanti ha d'andar in altro modo. A rivederci.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Sarebbe meglio e' non si rivedere fino che il negozio non fosse finito.</p>
           </sp>
@@ -1456,7 +1496,7 @@
         <div type="scene">
           <head rend="italic">SCENA SESTA</head>
           <stage><hi rend="sc">cinzio</hi>, <hi rend="italic">e</hi><hi rend="sc">scappino</hi><add resp="#ed"><hi rend="italic">in disparte</hi></add></stage>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Io non vorrei, ch'in tanto che s'affortiscono le lettere, e che se ne fa la lista, ch'il signor Fulvio trattasse di quanto gli ha detto al suo servitore, perché senz'altro s'accorgierebbe de' miei andamenti, e potrebbe imparare la schiava avanti di me. Io l'ho quasi posto in sospetto, e quello Scappino è tanto trincato, che mi fa dubitare. O s'io avessi un servitore, come è quello! Beato me, le mie cose andarebbero assai meglio. Però faccia quello che vuole Scappino, e Fulvio. Io la procurarò col danaro, ch'io aspetto, e prima del denaro con un poco di caparra.</p>
           </sp>
@@ -1464,108 +1504,108 @@
         <div type="scene">
           <head rend="italic">SCENA SETTIMA</head>
           <stage><hi rend="sc">mezzettino, cinzio</hi>, <hi rend="italic">e</hi><hi rend="sc">scappino</hi><hi rend="italic">in disparte</hi></stage>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Chi è là.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Amici.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>O servitore, padron mio.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Ben trovato, messer Mezzettino. Ditemi, per grazia, non avete voi una schiava da vendere?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Signore sì.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>La volete vendere a me?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>La venderò ad ogn'uno, fuori ch'al signor Fulvio, e a quel mariolo di Scappino suo servitore.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>O bella cosa esser in credito, come son io.<pb n="419"/></p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Ho caro che la vendiate a me, e non a quelli, che cercercano d'ingannarvi. Quanto volete?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Io la comprai così vestita, e così vestita ve la venderò, e per non far longhe parole, mi darete quello, che mi dava il signor Beltrame, se il signor Pantalone non guastava il mercato.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Mercè del bell'ingegno del signor Fulvio.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Beltrame accomprava la schiava? Che domine ne volev'egli fare? Manco male, ch'io sono a tempo.</p>
             <p>Quanto vi dava il signor Beltrame?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Dugento ducati.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>E dugento ducati vi darò io.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Fulvio, buon pro vi faccia, è fatto il becco all'oca.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Io aspetto oggi dugento ducati.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Ed io è un pezzo, che gl'aspetto, se ben non vengano.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>In tanto, eccovi dieci ducati di caparra, oggi vi darò il resto, e poi mi darete la schiava.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Son contento.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Ma avvertite, non la date ad alcuno se non vedete la mia persona, o vero quest'anello.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Lasciatemelo veder bene, che cosa è questa?</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>È il mio sigillo legato in oro, vedete la mia arma.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Qui non v'è più rimedio.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Io la terrò a memoria bene.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Mi raccomando, messer Mezzettino.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>A rivederci.</p>
           </sp>
@@ -1573,135 +1613,135 @@
         <div type="scene">
           <head rend="italic">SCENA OTTAVA</head>
           <stage><hi rend="sc">scappino</hi>, <hi rend="italic">e</hi><hi rend="sc">mezzettino</hi></stage>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Quel sigillo m'ha sigillato tutte le mie invenzioni, or sì ch'io son finito.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>A Dio, messer Scappino, che fate così pensoso? Pensate forse ancora a quel vostro fratello tiratore?<pb n="420"/></p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Messer no, io penso ora ad una sorella, che sta in transito di perdersi.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Ché ha forse da venir nelle vostre mani?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Se venisse nelle mie mani non sarebbe perduta.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Almanco sarìa in transito dell'onore.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Non siamo tutt'uno voi ed io, e perciò nelle mie mani sarebbe sicura. O là, guardate come parlate con gl'uomini onorati.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Chi è onorato?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Io, al dispetto di chi non lo crede!</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Io credo che siate onoratissimo, anzi un uomo carico d'onore, ma non è patrimonio, né lecito acquisto: è tutto furto.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>È vero, e m'incresce che voi non abbiate mai avuto capitale di questo, perché mi sarei insegnato di far qualche avanzo ancora sopra vostro, ma zero via zero fan nulla.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Io ne ho a bastanza.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Però non si vede.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Il cieco non giudica de' colori.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Né il fallito può far sicurtà.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>È che voi non conoscete il mio onore.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Deve dunque esser forestiero.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>L'onor mio è paesano.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Ma bandito, ché non si vede.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Voi volete la burla.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Sì per certo adesso, ma non burlerò sempre, s'io potrò.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Ingegnatevi se potete.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>S'io vedrò il tempo, e voi vedrete l'ingegno, se non, pazienza.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Orsù, adunque, io goderò il tempo e voi, col vostro ingegno, e' goderete la pazienza.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Io godrò la mia per fin a tanto, ch'io vi faccia rinegar la vostra.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Voi parlate in modo, ch'io non v'intendo.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Ho caro, e così possino esser l'operazioni mie.<pb n="421"/></p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Orsù voi siete pazzo.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Un pazzo mi fa dir pazzo da un pazzo.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Mi fate ridere voi.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Farò al contrario un'altra volta. A rivederci.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Ma con più cervello.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Con più sorte sarà meglio.</p>
           </sp>
@@ -1714,51 +1754,51 @@
             <hi rend="sc">scappino</hi>
             <hi rend="italic">alla lontana</hi>
           </stage>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>«Fategli rendere le sue scritture, e fatelo tornar in possesso, ch'io son sodisfatto da lui. Vi ringrazio del favore, e aspetterò d'esser commandato da vostra signorìa per aver sicurtà di domandargli altre volte de' favori. Gli bacio le mani. Di Nochiera il dì...».</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Questa non fa per me.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Questa è quella ch'io aspettavo: «Molto magnifico signor mio osservandissimo, piacerà a vostra signorìa di sborzare dugento ducati a mio figliuolo, quali hanno da servire per vestirsi, e per addottorarsi, e mettetegli alla mia partita...».</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Sin adesso mi par d'aver un candelino da un tornese alumato, comincio a vedere un poco.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>«Priego vostra signorìa ad esser assistente, quando si addottorerà. Io ho caro che si faccia onore col solito limito de' galant'uomini; ma che non faccia da cavalierazzo per non dar danno alla sua modestia, e alla mia borza. Intesi poi, dal signor Domizio, come vostra signorìa trattava di maritar sua figliuola: se fosse maritata averei caro del suo contento, ma se non fosse il trattato concluso, e che vostra signorìa credesse che mio figliuolo fosse meritevole di questo<pb n="422"/> parentado, io per me non vorrei cercar miglior partito di questo. Scrivo anche a mio figliuolo, in conformità di questa, e priego il Cielo che s'è per lo meglio d'una parte e l'altra, che le cose abbiano esito secondo il mio buon pensiero, e averei gusto ch'all'arrivo di mio figliuolo, io lo vedessi addottorato e maritato. Aspetto subito risposta e gli bacio la mano. Di Benevento... », eccetera. O questo sarebbe a mio gusto!</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Ed a mio proposito.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Mia figliuola vede volentieri questo giovine, e io averei caro di compiacerla. Averci gusto di non la dare a quel puzza zibetto del signor Fulvio, che pare che mia figliuola sia così mostruosa, che sia d'esser aborrita e non amata. Io non posso digerire ch'uno mi dica in faccia non la voglio. Questo è troppo poco conto ch'egli fa della casata Ben Forniti, ma s'io potrò egli non l'averà.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Quest'è un principio di mar placato, che m'invita a far il mio viaggio.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Io non voglio dir nulla a mia figliuola, ma lasciarò la lettera sopra la tavola. So che la sua curiosità glie la farà leggere e forse il negozio si disponerà senza mio fastidio.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Sarò anch'io buon sollecitatore.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Voglio andar in casa e mostrar d'esser turbato, per darle occasione ch'ella, per saperne la cagione, legga la lettera subito.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Andate in buon'ora. Il sentir i fatti de gl'altri alle volte è un grand'avantaggio. Se bene delle volte si sente quello, che non si avrebbe voluto sentire. Ma questa volta a me mi è un lume, che mi mostra una strada molto agevole.</p>
           </sp>
@@ -1767,176 +1807,176 @@
         <div type="scene">
           <head rend="italic">SCENA DECIMA</head>
           <stage><hi rend="sc">cinzio</hi>, <hi rend="italic">e</hi><hi rend="sc">scappino</hi><hi rend="italic">in disparte</hi></stage>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>In somma, la felicità di questo mondo è sempre accompagnata con qualche disgusto. Ora dimmi, fortuna, come vuoi tu ch'io faccia a levar questi dugento scudi da Beltrame, se sopra la stessa lettera mio padre scrive ch'io procuri d'aver la signora Lavinia per consorte? E quello ch'è peggio, mi dice d'aver scritto ancora al signor Beltrame di questo negozio. Onde, s'egli avrà caro il mio parentado, come credo, non avendo gusto, per quello ch'intendo, che le nozze di Fulvio seguino, mi sarà alla vita in modo, che non avrò tempo di scusarmi. E il dir di no non è conveniente, per rispetto dell'amicizia nostra e per il merito della giovane, oltra l'esservi il comandamento del padre. E il dir di sì è contro ogni mio gusto, a tale che io son confuso, e non so a che risolvermi. O misero me.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>O fortuna, scrolla il capo, ti priego, ché s'io non m'attacco a' primi capelli, che io vedo sciolti, voltame le spalle per sempre, ch'io ti perdono.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>S'io avessi un amico fidato, io vorrei mandar la lettera di cambio, e far riscuoter i danari per terza persona, mostrando necessità de' soldi, e un impedimento grande in quest'ora; e per dargli speranza del matrimonio fargli dire ch'io ho bisogno di parlargli di cosa che molto importa, ma in tempo commodo a tutti due. Ma chi mi potrà far questo servizio fedelmente?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Ora mi par tempo di far frutto. O meschino me, pazienza, scrivete quest'azione nel libro de li vostri fatti eroici.</p>
             <p>Servitore, signor Cinzio.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>A Dio, Scappino, dove vai così turbato?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Fuggendo disgrazie, e cercando ventura.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Che disgrazie? che cosa vi è di nuovo? e dove è il signor Fulvio?<pb n="424"/></p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Il signor Fulvio sta troppo bene, e meglio starà da qua avanti, ché non avrà più Scappino che s'opponga a' suoi gusti.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Oh oh, sdegno e martello?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Io non so di martello né di tenaglie, per me so ben ch'io non lo servirò mai più, se bene credessi di morire di fame.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>O, la cosa è rotta fuor di modo, mi dispiace, perch'egli ti voleva bene, e tu lo servivi con grand'affetto. Qualche grand' accidente è stato questo, che ha rotto quest'amicizia.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Eh, le straccie vanno all'aria, come dice Lombardo. Pazienza.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Si potrebbe sapere la cagione di questa separazione?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Signorsì, questa aviene dall'aver due padroni contrarii di pareri, che l'uno dica: va' là se non che io ti spezzo le braccie; e l'altro che dice: sta' qua se non ch'io ti rompo il capo.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>O questa è una mala cosa.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Il signor Pantalone ha inteso come suo figliuolo non vuol pigliar per moglie la figliuola del signor Beltrame, perché è inamorato d'una schiava, e ha imposto a me ch'io trovi remedio a questo negozio. Io per sodisfar al vecchio, e a quello che mi è parso giusto, aveva preso per ispediente di far comprar quella schiava dal signor Beltrame, e farla allontanare fin tanto ch'il signor Fulvio si trovasse privo di speranza di quella, e prendesse la signora Lavinia. In questo è arrivato il signor Fulvio ed ha sconcertato il tutto, e ha<pb n="425"/> posto mano alla spada contro di me, e mi ha seguitato per tutta rua Catalana.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Non t'ha già arrivato.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Signornò lui, ma la spada m'ha giunto qualche volta di piatto. Che dite, signore, vi pare ch'io abbi ragione?</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Per certo sì, ma il signor Pantalone non consentirà che tu parta dalla sua servitù, e vi troverà rimedio.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Il rimedio è unguento d'allabastro, o biacca, per ungermi le ammaccature.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>È, dico, rimedio <add resp="#ed">che il</add> figliuolo stia ne' suoi termini.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Stiassi pur come vuole, io non ho possessioni confinante alla sua, e però non voglio manco i suoi termini.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>O tu muterai pensiero, come t'è passata la collera.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>O s'io mi muto, che possa io perder gl'occhi che vedo!</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>O tolga il Cielo, la cosa è fondata sopra la verità, di già so ch'il signor Beltrame voleva comprar questa schiava, tal che io mi potrei quasi servire di costui nel mio negozio. Dimmi un poco, Scappino, faresti volentieri una burla al signor Fulvio?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Ohimè, signore, dir ad un goloso se gli piace la vitella a rosto, chi non lo sa? Dire ad un offeso a torto, se farebbe volentieri vendetta, questo è un invitarlo a nozze!</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Ti si presenta un'occasione di disgustar Fulvio, e di far servizio a Pantalone.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Ohimè, o che non sarà vero, o che mi sogno.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>È vero e non è sogno, or a punto la fortuna ti fa cader la palla in mano, se la saprai giuocare.<pb n="426"/></p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>S'io non la saprò giuocare, che la fortuna mi facci restar senza palle, acciò che io non giuochi più, ch'io gli perdono. In che posso servir vostra signorìa e consolar me?</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>To' questa lettera, e va' dal signor Beltrame, e fatti dare dugento scudi da parte mia, e digli che stai meco, e perché ti possa credere, to', mostragli questo anello, qual'è il mio sigillo, benissimo da lui conosciuto, e digli ch'io non son andato in persona rispetto al grande affare ch'io ho perché mi sono stati dati or or i punti.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>I punti? e dove? alle calzette o alle scarpe?</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Eh balordo! I punti che danno gl'elettori dello studio per addottorar le persone.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Io non sapeva che vi bisognassero punti. Che domine devono esser, ciabattini o rappezzini da scienze, questi officiali?</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Messer sì, cucitori da lettere. E digli che domani, o l'altro, ho poi da trovarmi seco per cosa che molto importa a tutti due, e che sua signorìa deputi l'ora, e dove abbiamo a trovarsi insieme.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Tanto farò. Ma dove è questa vendetta ch'io ho da fare contro il signor Fulvio?</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Io voglio poi che con questi dugento ducati vadi da Mezzettino, e che tu riscuoti la sua schiava, e che tu la conduca a casa mia, che ne dici? Non è questo un trafiger il cuore al signor Fulvio? e un contento che darai a Pantalone?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Ohimè, ohimè, ch'io temo ch'il tempo non mi fuga, e che Mezzettino non faccia esito mentre ch'io riscuoterò i danari! Oh signore, ohimè, mi manca il fiato dall'allegrezza, io voglio star con vostra signorìa e vi voglio servir tre anni senza salario, per questa grazia che mi fate!</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Starai meco per modo di provisione, e per l'avvenire parlaremo poi. Ma in tanto fa' questo servigio come si deve.<pb n="427"/></p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Io non so mai come rendervi di questo beneficio le dovute grazie, però accettate il buon animo. O questo sì che è uno stratagemma da far dar del capo nelle mura a chi non se lo pensa. Signore, vostra signorìa restarà maravigliato di me, che non passarà troppo. Questo servizio è più mio che di vostra signorìa. Di grazia, lasciate tutta la cura a me, e poi chi si lamenta suo danno.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Va' pure, riscuoti i danari, e poi ci parlaremo.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Vado subito. Mi è nata l'invenzione: costui non vuol esser veduto da Beltrame, né vuol parlar con Lavinia. Buono, mi farò dare campo franco da negoziare.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Veramente un animo sdegnato fa gran cose, e le battiture dispiacciono in sino a' cani! Ma il signor Fulvio è quasi stato autore de' suoi proprii disgusti, e non s'averà da dolersi né di Scapino né di me, quando si vedrà privo di quella schiava.</p>
           </sp>
@@ -1944,43 +1984,43 @@
         <div type="scene">
           <head rend="italic">SCENA UNDECIMA</head>
           <stage><hi rend="sc">lavinia</hi>, <hi rend="italic">e</hi><hi rend="sc">cinzio</hi></stage>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Scappino m'ha detto, in isfugendo sotto voce, che Cinzio è in strada. Oh eccolo. Servitrice, signor Cinzio.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Ohimè m'ha veduto. Servitore, signora Lavinia.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Ho veduto vostra signorìa dalla finestra, e perché l'affezione, ch'io li porto, trapassa il decoro di giovane da marito, mi sono lasciata spingere dall'affetto fino a gl'estremi confini della modestia, e sono venuta qua alla porta per fargli riverenza. La priego, adunque, a prender in grado questo mio ardente affetto, e non me lo ascrivere a sfacciatagine.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>O questo è troppo a' miei meriti, signora.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Forse troppo al vostro gusto, e pazienza. Se vostra signorìa vol venire in casa, mio padre ne avrà consolazione,<pb n="428"/> e credo che egli abbia da ragionare con vostra signorìa per certe lettere, venute ora dal vostro signor padre.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Io lo so, ma ora non ho tempo di trattenermi molto, e perciò ho mandato Scappino per un mio bisogno dal signor Beltrame, perché la penuria del tempo non mi facesse commetter qualche mala creanza di lasciar il negozio, ch'io ho da trattar seco, imperfetto. E poi è cosa da non trattarsi così in isfugendo.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>E forse non avete voluto venir in casa nostra, perché non vi è soggetto riguardevole, ma se fosse in altro luogo forse tutti gl'affari si diferirebbono. Pazienza! Ma sentite signore, tal ora si suol mirare anche ne gl'oggetti di poca stima, per conoscer da i contrarii i più meritevoli. Mirate dunque me, brutta e sgraziata, ch'io servirò per discerner meglio la bellezza e la grazia della vostra inamorata.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Ringrazio vostra signorìa dell'onesto modo che ella tiene in darmi del balordo. O che io ho conoscenza del bello, o no; s'io conosco il bello, conoscerò anche vostra signorìa per bellissima, e s'io non lo conosco, non occorre ch'io faci parallelo di bellezza. Vostra signorìa mi dipinge amante, e io non so d'esser tale, né oserei di presumer tanto. Io, povero scolare, privo di quei talenti che si ricercano per captar benevolenza dalle fanciulle, chi volete che sia quella che ponga cura a me? Io vado per le strade come vanno certi cagnacci che non sono da caccia, che corrono per li prati, e, per le campagne, in cambio di far preda, spaventano gl'uccelli e le salvaticine; tale a punto son io. S'io vado per le strade, in cambio di farmi amante, faccio fugir le fanciulle dalle porte e dalle finestre, e se vostra signorìa non si parte ora da me, n'è cagione l'amicizia de' nostri genitori, del resto passerei seco la medesima sorte.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Signore, il mio modo non è di far parer vostra signorìa di poco ingegno, ch'io non ho arte tale da sostentar il falso per vero; ma le maniere di vostra signorìa son bene per farmi parer pazza, poiché tanto stimo meritevole vostra<pb n="429"/> signorìa. O forse è un modo, il vostro, di star su le difese, per levar l'occasione di corrispondere a chi v'adora e ama! Eh, signore, non bisogna dar nome di brilli ai diamanti ove sono gioiellieri, perché si offendono troppo. Io, per aver letto molto, so per scienza che cosa sono proporzioni di membri, uniti con vaghezza de' colori, e che cosa siano nobili portamenti intrecciati con le grazie. Ma sì come voi non mi conoscete atta alla distinzione del bello al brutto, così mi dovete conoscere immeritevole dell'amor vostro, e così si fa a chiarire le pazze, che troppo presumono, come son io. Anche quelli, che non vogliono prestar danari, dicono di non ne avere, o d'aver fatto un sborzo poco fa, però pazienza.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Vostra signorìa vuole ch'io commetta mancamento in ogni modo, o vuol ch'io tenghi lei per adulatrice, o ch'io mi confessi superbo di quelle perfezioni, ch'ella dice che sono in me, o vuol ch'io confermi d'esser ignorante a non le conoscere, o pur avaro in nasconderle, e non parteciparne a chi le merita. Signora mia, mi ponete in confusione con i vostri concetti.</p>
           </sp>
@@ -1988,84 +2028,84 @@
         <div type="scene">
           <head rend="italic">SCENA DODICESIMA</head>
           <stage><hi rend="sc">fulvio, lavinia, cinzio</hi>, <hi rend="italic">e</hi><hi rend="sc">scappino</hi><hi rend="italic">dietro</hi></stage>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Non mi par esser vivo, lontano da Scappino. Ma ecco il signor Cinzio con la signora Lavinia. Servitore, signor Cinzio, bon pro vi faccia.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>O sia maledetto chi ha mandato costui qua.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Signor Fulvio, vostra signorìa non mi tenghi né per isfacciato, né per mal creato, s'io parlo qua con la signora Lavinia, perché ho negozio col suo signor padre, e ho commissione dal mio genitore di salutarla a suo nome, ed ora cominciava a far il debito mio. Ben è vero che se vostra signorìa non sopragiongeva così presto, ch'io mi voleva rallegrar seco del matrimonio, che si tratta tra vostra signorìa e lei.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Bene, bene, non parliamo di matrimonio, che sono cose che maneggiano i nostri padri, e 'l Ciel sa quello che sarà, e<pb n="430"/> forse la signora Lavinia gradirebbe più vostra signorìa che la mia persona.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Signore, perdonatemi, io avrò caro quello che 'l Cielo mi destinerà, e che concluderà il mio signor padre. Vostra signorìa mi farà grazia, signor Cinzio, di ringraziare il suo signor padre com'io ringrazio lei dello scommodo, che per me s'ha tolto.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>La fortuna ha mandato qui costui per far che quest'altro non parta mai ed io non potrò fare il fatto mio. Hem, hem.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>L'obligo mio è di servirla, e rescrivendo farò quant'ella mi commanda.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Scappino mi fa cenno e credo che dica ch'io rompa con quest'occasione il parentado.</p>
             <p>Che dite, signor Cinzio, delle cortese maniere di questa giovane, non farebbono inamorar un insensato marmo?</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Per certo si.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Hem.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>E pur m'acenna.</p>
             <p>Signore, s'io vi do noia io men'anderò.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>I pari di vostra signorìa non aportano mai noia.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Par che dica ch'io dii delle ferite a costui.</p>
             <p>Se non a vostra signorìa, forse alla signora Lavinia.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Il decoro mio non mi concede di trattenermi più su la porta, servitrice signori.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Hem.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>No no, partirò io, ch'è di dovere.</p>
             <p>Scappino mi pone in confusione.</p>
             <p>Vostra signorìa resti pure.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>O vengh'il càncaro alla bestia!</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Signora, il signor Fulvio parte e io non gli voglio dar gelosia. Vostra signorìa ha veduto come era confuso, che pareva fuori di sé. Servitore.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Il Ciel perdoni a chi l'ha mandato qua, non poteva venir a peggior punto per me.</p>
           </sp>
@@ -2074,31 +2114,31 @@
         <div type="scene">
           <head rend="italic">SCENA TREDICESIMA</head>
           <stage><hi rend="sc">scappino</hi>, <hi rend="italic">e</hi><hi rend="sc">lavinia</hi></stage>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>E ben, non vi ho dato io campo da parlare? Io ho fatto contar tre volte i soldi a vostro padre, per trattenerlo.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Io vi ringrazio Scappino, ma ho goduto poco il mio bel sole, perché è sopragiunta quella nuvolaccia del signor Fulvio, che m'ha privata di consolazione, onde posso dire: a pena vidi il sol, che ne fui priva.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Chi non può quel che vuol, quel che può voglia.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Come sarebbe a dire?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Che Roma non si fabricò tutta in un giorno, e, chi non vuol aver pazienza, ha poi spesse volte disgusto. Lasciatemi levar la causa, ch'io levarò poi l'effetto. Io non vi prometto nulla fin tanto ch'io non ho riscosso questa schiava. Andate in casa, e trattenete un poco vostro padre per mezz'ora che non esca di casa, acciò che non vi dia impaccio, ch'io vedrò di servirvi in piedi in piedi.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Volentieri. Mi raccomando, Scappino, e mi pongo nelle vostre braccia.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>E le mie braccia vi serviranno a tutto suo potere, e così ogn'altra mia cosa che vi possa dar gusto. Orsù, non vi è tempo da perdere.</p>
           </sp>
@@ -2106,103 +2146,103 @@
         <div type="scene">
           <head rend="italic">SCENA QUATTORDICESIMA</head>
           <stage><hi rend="sc">scappino</hi>, <hi rend="italic">e</hi><hi rend="sc">mezzettino</hi></stage>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>O là.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Chi è là? O, siete qua, sollecitatore della concupiscienza!</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Messer Mezzettino son ben disgraziato con esso voi. Che cosa v'ho mai fatto che mi fa tener da voi in così mal concetto?<pb n="432"/></p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Non m'avete fatto nulla, perché non v'è venuto taglio, ma se la sentinella dormiva il posto era preso.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Qual posto?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>E ch'innocentino! Qual posto? La schiava. Quella, ch'il vostro padrone fa seco l'amore, e che voi voresti comprar senza soldi.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Avete torto. Il signor Fulvio l'averebbe tolta a credenza e io gli sarei stato sicurtà. Ma non senza soldi.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>O bella sicurtà! Voi l'averesti assicurato sopra i vostri feudi?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Piano, ch'al mio paese ho de' beni stabili, e anche qua. Quelli del paese sono sassi tanto grossi, che non si possono movere, e i stabili di qua sono ch'io ho stabilito di far una burla ad uno, e son risoluto di fargliela, e gli la farò, se non cade il Cielo.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>A me non la farete certo, e stabilite quanto volete. Ma io non ho voglia di burlare, che volete da me?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>La schiava.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>O bello, voi siete venuto qua per farmi ridere, ma guadagnerete poco col fatto mio, ch'io non sono prencipe da donare abiti. Eh messer Scappino vogliono esser soldi! E poi non basta, perché non la voglio dar al vostro padrone.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>E perché, non ne avete ricevuto la caparra?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Orsù, vaneggiate? La caparra io l'ho avuta dal signor Cinzio, e non dal vostro padrone.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>O vedete s'io vaneggio, o s'io parlo a proposito! Io sto con il signor Cinzio ed egli è che mi manda da voi a sborzarvi i soldi e a prender la schiava. Il signor Fulvio m'ha strapazzato, e io ho mutato padrone, e che sì che direte ch'anche questa è una furberia?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>E se, non è, non sarebbe manco giudizio temerario a dubitarne, che quando un medico va ogni giorno a casa, s'una persona stimasse che colà vi fossero infermi, non farebbe grand'errore, perché farebbe presupposto commune.<pb n="433"/> Voi siete tant'uso a questi negozii aromatici, che si può dubitar, o del vostro abito, o della vostra natura.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Veramente l'abito mio non è molto buono, e val pochi soldi, la natura poi m'inclina, come fa ad ogn'uno. Ma che dite, mi volete dar la schiava?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Dove sono i soldi?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Eccovi qua cento novanta ducati, diece n'avete di caparra, che fanno dugento, e questo è l'anello col sigillo del mio padrone. Che dite ora? che son io?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>O sarebbe da rider, che voi foste uomo da bene!</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Sono, e sarò sempre, e voi m'offendete a torto, ma l'esperienza vi chiarirà.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Fratello, perdonatemi, faceva errore.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Sì come fate adesso, dovevate far prima, chiarirvi, e poi dir la verità, e non parlar con presupposto di bugiarda fama.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Paesano mio, ogni uomo è atto a fallare; ma da qua avanti vi terrò in buon concetto.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Farete anch'errore del sicuro, se non lo fate.</p>
           </sp>
@@ -2210,43 +2250,43 @@
         <div type="scene">
           <head rend="italic">SCENA QUINDICESIMA</head>
           <stage><hi rend="sc">scappino, mezzettino</hi>, <hi rend="italic">e</hi><hi rend="sc">celia</hi></stage>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Celia?</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Signore.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Figliuola, dopo il tuono spesso viene la pioggia. Tuono di venderti fu quello con il signor Beltrame; ma venne la tramontana del signor Pantalone, e discacciò e la fe' sparirire; ora non vi e più scampo, ecco il vento di Levante di messer Scappino, che vi ha comprata e vi vuol menar via, lasciando me nella pioggia delle lagrime per la vostra partenza.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Mi piace che parlate con concetti marinareschi.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Eh, prattico spesso il mare, e non n'è meraviglia, ch'io m'intenda di qualche vento.<pb n="434"/></p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Messer padrone, ben era presaga di questa vendita, ché sono due giorni, ch'io non ho il cuore contento. Orsù pazienza, quest'è cosa, che ha da succedere, o una volta, o un'altra: voi avete bisogno di trafficare i vostri soldi, e avete ragione. Messer Mezzettino, a Dio.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Ohidè, ohidè, hù hù hù.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Orsù basta, andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>A Dio, cara figliuola, hù hù hù.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Messer Mezzettino, s'io v'ho dato fastidio, perdonatemi.</p>
           </sp>
@@ -2254,87 +2294,87 @@
         <div type="scene">
           <head rend="italic">SCENA SEDICESIMA</head>
           <stage><hi rend="sc">birro, mezzettino, celia</hi>, <hi rend="italic">e</hi><hi rend="sc">scappino</hi></stage>
-          <sp>
+          <sp who="#birro">
             <speaker><emph rend="sc">birro</emph>.</speaker>
             <p>O là, alto alla Corte! Chi è messer Mezzettino di voi?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Io, perché?</p>
           </sp>
-          <sp>
+          <sp who="#birro">
             <speaker><emph rend="sc">birro</emph>.</speaker>
             <p>Togliete questa carta, io vi sequestro in mano tutto quello, che avete del signor Cinzio: danari, gioie, anelli, e in particolare una schiava nomata Celia, sotto pena di cinque cento ducati.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Questo non è tuono, né pioggia, è tempesta, che coglie sopra la mia possessione avanti che si suonano le campane.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>O poveretto me.</p>
           </sp>
-          <sp>
+          <sp who="#birro">
             <speaker><emph rend="sc">birro</emph>.</speaker>
             <p>Qual è la schiava? questa?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Birrissimo messer sì.</p>
           </sp>
-          <sp>
+          <sp who="#birro">
             <speaker><emph rend="sc">birro</emph>.</speaker>
             <p>Mandatela in casa or ora.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Va' in casa figliuola disgraziata, e obedisci la signora giustizia.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Disgraziato son io, o ch'io partecipo della disgrazia di Fulvio.</p>
           </sp>
-          <sp>
+          <sp who="#birro">
             <speaker><emph rend="sc">birro</emph>.</speaker>
             <p>Andatevi ancor voi a farle compagnia per buon rispetto.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Volentieri, o meschino io vado, a Dio Scappino.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Adagio, e i miei soldi?<pb n="435"/></p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Ma credo ch'i denari siano sequestrati con la schiava e con la mia persona. Non è così, messer giustiziatore?</p>
           </sp>
-          <sp>
+          <sp who="#birro">
             <speaker><emph rend="sc">birro</emph>.</speaker>
             <p>Così è, e avertite bene al fatto vostro.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>No, non m'usciranno di mano al certo! Cappe, ho troppo paura della giustizia.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Ma a che proposito la giustizia vuol sequestrare il mio, s'io non ho a far seco, né i danari sono di messer Mezzettino?</p>
           </sp>
-          <sp>
+          <sp who="#birro">
             <speaker><emph rend="sc">birro</emph>.</speaker>
             <p>Io non so tante cose per me, ho fatto l'ordine, che mi è stato imposto. Se voi vi pretendete offeso ricorrete alla giustizia, e voi avvertite bene, se non la giustizia procederà contro di voi.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>No, no, che la giustizia proceda pure con pari suoi, e non mi dii fastidio a me, se bene che senza fastidio non si tratta con la giustizia, Scappino mi raccommando, manco male, che voi non perdete altro ch'i denari, ma io, meschino, che perdo la libertà, e forse anche la vita? Hù hù hù.</p>
           </sp>
-          <sp>
+          <sp who="#birro">
             <speaker><emph rend="sc">birro</emph>.</speaker>
             <p>Ed io perdo tempo, e non vado a far la relazione.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Ed io perdo il denaro, il credito e il cervello! O meschino, se qualche amico non mi consola, quest'è la volta ch'io fo qualche pazzia!</p>
           </sp>
@@ -2348,7 +2388,7 @@
           <stage>
             <hi rend="sc">scappino</hi>
           </stage>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Io non oso d'andare alla Vicarìa per intendere chi ha fatto far quel sequestro, per aver la coscienza maculata. Io sono mentito servitore del signor Cinzio, e poco reale del signor Pantalone, e non vorrei esser trovato colà, né dall'uno, né dall'altro, per non aver da inventar menzogne, e per non potergli dire la verità. Se il signor Cinzio intende il successo, vorrà rimediarvi, e non può rimediare al sequestro se non mi leva la schiava, ed eccomi più imbrogliato che mai! O, povero Fulvio, io per me credo che questo giovane sii figliuolo bastardo di Pantalone, e figliuolo legitimo della disgrazia! Quest'è stato troppo il grand'accidente! Aver la schiava pagata, esser di già fuori di casa di Mezzettino, averla io nelle mani, e perderla, quest'è cosa da far impazzare ogni galant'uomo! Il Cielo sa dove si trova adesso Fulvio. Eccolo a punto tutto allegro. O meschino, la sua letizia procede dalla fede, ch'egli ha delle mie operazioni, ma non so che far io, la mia fortuna è troppo picciola da contrastare con la sua gran disgrazia.</p>
           </sp>
@@ -2357,239 +2397,239 @@
         <div type="scene">
           <head rend="italic">SCENA SECONDA</head>
           <stage><hi rend="sc">scappino</hi>, <hi rend="italic">e</hi><hi rend="sc">fulvio</hi></stage>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Signor Fulvio, e dove andate così allegro?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Non in altro luogo che cercando il mio caro Scappino, per fargli parte di quell'allegrezza, che quasi mi trabocca del cuore.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>E ch'allegrezza è questa, avete forse trovato il lapis philosophorum?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Che lapis? Tu vai dietro alle burle! Odimi, e poi stupisci, io ho fatto quello che mai ti sapresti immaginare.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Bisogna che abbiate fatto qualche cosa che stia bene.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Lo credo, ma dimmi tu prima, che facevi in casa del signor Beltrame dietro a quella giovane, quando m'accennavi?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Un servizio per vostro conto, e perché questo?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Per bene, perché da quei cenni m'è sovvenuto l'invenzione d'aver il gusto, ch'io ti vo' poi narrare. Ma che dici tu, non t'intesi alla prima, quando mi facevi cenno?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>A me par di no, tuttavia ditemi, che intendeste voi?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>O tu m'accennavi ch'io facessi questione col signor Cinzio.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Ohimè meschino, e che avete forse fatto questione con quel giovine?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Non ancora, ma l'avrò posto in obligo di farla. Ma non mi facevate cenno ch'io menassi le mani con la spada?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Non, in tanta buona ora! Accennava che dicessi ch'io non dimorava vosco più, e che m'avevate mandato via a furia di piattonate.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Ed io intendeva che volessi ch'io facessi rumore, e poi ch'io me ne andassi.<pb n="438"/></p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Signor no, che lo faceste patir lui, per poter far il fatto mio. Ma ditemi, per grazia, che cosa avete fatto voi, ch'io moro di voglia saperlo?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Bene, bene.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>E meraviglia.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Non ti dubitare, ch'io t'avrò aiutato, se bene non t'intesi.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Non mi potevate aiutar in altro se non col tacere e far il fatto vostro.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Orsù, si dà l'offizio, ma non la discrezione.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Io non ho mai avuto intenzione di darvi altro che l'offizio, per non seminare nell'arena.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Dove non v'è tempo di consiglio, ogni aiuto è bono. Io ho trovato la più bell'invenzione, che si possa trovare, acciò che Cinzio non abbia la schiava.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>E che bella cosa avete voi inventato, dite caro padrone?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Io mi trovava creditore di quindeci ducati guadagnati sopra il giuoco a questo giovane.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Avevate un capitale di soldi, ch'io non lo sapeva.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Ma è ben vero, ch'io ne restava poi da dar dieceotto al signor Domizio della Fravola.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Mi meravigliava, che vi fusse avanzo.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>E il signor Domizio doveva dare alquanti carlini al signor Cinzio, e aveva detto: io menerò buon i vostri a lui e faremo poi conto; e così restò il conto senza aggiustamento. Ora che pensi tu che cosa abbia fatto?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Una delle vostre.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Certo, ch'io l'ho fatta, ma bella.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Ohimè, me la fate digerire con la volontà, avanti ch'io l'abbia gustata! Ditela presto, in cortesia.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Io aveva inteso ch'il signor Cinzio aveva dato caparra a Mezzettino per la schiava, ma, dich'io, qua non v'è tempo<pb n="439"/> da perdere! E subito sono andato alla giustizia, e in virtù di quei soldi, io ho fatto sequestrar la schiava e i denari in mano a Mezzettino, e così, tanto che si litigherà, avaremo tempo d'aver denari, e la schiava sarà mia.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Che, siete voi, che avete mandato quel sequestro?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Messer sì, che dici ora? chi son io?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Chi siete? Or ora lo direte voi, udite. Io aveva trovato invenzione col signor Cinzio d'esser partito da voi con delle busse, sono stato a riscuoter per lui dugento ducati, e aveva i denari e segnale del suo sigillo; sono stato a riscuoter la schiava, e mentre ch'io l'aveva fuori di casa per condurla nel fondico per voi, è arrivato il sequestro, e io ho perduto la schiava, i denari, il credito, e quasi il cervello. Che dite ora chi siete? Voi non favelate, ditelo, ditelo!</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Ohimè, una bestia.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>E così restate, a rivederci.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>E che, tu te ne vuoi andare?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>E che volete dal fatto mio? Voi sapete trovar dell'invenzioni da voi, e non avete più bisogno di me.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Scappino, non mi schernire per grazia, ché pur troppo mi procuro il male e le beffe da me.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Ma caro padrone, io non so più quello che vogliate dal fatto mio! Per amor vostro, io vado invitando la berlina, lusingando la frusta, e trescando con la galera, e non vi basta, e che volete ch'io faccia salto maggiore? O certo no per adesso, son pover uomo, e se non mi volete in casa vostra non mi mancheranno padroni, io non voglio saper più di schiave, né di schiavine.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>E ti soffrirà il cuore d'abbandonarmi nel maggior bisogno? Ho fatto errore, è vero; ma non sono entrato nella tua invenzione, è stato uno spirito, che mi è nato, di far una<pb n="440"/> cosa bella da me, per aver qualche lode dal fatto tuo; ma non è riuscita, pazienza.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Non solo non v'è riuscita, ma la vostra invenzione incerta, ha rovinato la mia certa.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>È vero, però il danno è più mio, che tuo; poiché tu operi per mio servizio.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>È vero, ch'io opero per voi, ma il rischio è mio, e scoprendosi, come so che succederà, non potendo star celato il mal fare longo tempo, la pena tutta caderà sopra di me.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Orsù, qua non v'è tanto gran male, il caso non è ancora disperato, e adesso è 'l tempo d'aiutarmi. Fratello, ora si vedrà chi ha ingegno e si conoscerà chi è Scappino!</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>E non ho bisogno di questi ingrandimenti io! Lasciatemi star, per cortesia.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Ohimè, vòi tu condannarmi a morte per così lieve errore?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>E chi vi vuol condannar a morte?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Se tu desisti dall'impresa io morirò, o di dolore o di disperazione. Si perdonano gl'errori di malizia a chi si pente, o vedi tu se deono perdonarsi quelli dell'inavertenza! Eh, Scappino, mi son pentito, orsù vedo che tu mi perdoni, io ti ringrazio.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Voi ve la fate, e voi ve la dite! O siete il gran lusinghiero, andate a far il fatto vostro, di grazia, e non v'intrigate più.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Io vado, Scappino mio, hà hà hà!</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Voi ridete e che, mi burlate?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>No, fratello, io rido di quella bell'invenzione, che tu hai di già trovata per consolarmi.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Qual invenzione?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Quella c'hai nel pensiero.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>E ch'invenzione è questa, che voi sapete avanti di me?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Non la so; ma stimo così tra me, che deve esser bellissima, perché conosco il tuo bell'ingegno.<pb n="441"/></p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>O che vi vegna... che quasi l'ho detto! Voi v'allegrate del figliuolo maschio inanzi che sia generato. Di grazia, partitevi, se non, mi farete scordar quello che ho da fare. Gran cosa è voler bene! Io non gli so dir di no senza rossore di viso, anzi, quello che la bocca niega, il cuor promette. Di già ho pensato il modo d'aiutarlo.</p>
           </sp>
@@ -2601,271 +2641,271 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">lavinia</hi>
           </stage>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>O di casa!</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Lavinia, guarda un poco, questa mi pare voce di Scappino.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Io vado. O Scappino! E bene, siete tornato con qualche buona risposta, o pure con qualche invenzione, per trattenermi nella solita speranza?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Non vi dubitate, signora, ch'io non prometto se non quello che voglio fare; ma alle volte il volere è oppresso del non potere.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Il mio amore è una pianta, quale non è abbarbicata nel terreno della certezza, ma si mantiene, perché voi l'inaffiate di promesse, e non può dimorar gran tempo in tale stato; si consumerà anche quel poco verde della speranza e perirà, se non fate presto. Deh, per grazia, non mi fate tanto languire.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Signora, non tutte le fortezze si prendono con assalto, alcune se ne prendono con inganni, altre con assedio e altre per danari. Io sono qua per far uno stratagemma con il vostro aiuto e ridurre le promesse in effetti. Quel poco ingegno ch'io ho lo porrò tutto in opera, ponete ancor voi il vostro aiuto, e così il negozio anderà avanti, e tra tutti due faremo qualche frutto.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Vedete dove vi posso aiutare.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Il signor Cinzio è in procinto di comprar, con quei denari ch'io ho riscosso, la schiava di Mezzettino, e la potrebbe prender per consorte, io vorrei che vostro padre facesse levar un tal sequestro che ha.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Che cosa v'è di nuovo, messer Scappino?<pb n="442"/></p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>A punto ragionava con vostra figliuola di quel signor Cinzio, che fece riscuotere i denari, i quali intendo che gli vuol sprecare in una schiava, che ha Mezzettino in mano. E di già l'averebbe riscossa, se non fosse che gl'è stata sequestrata la schiava e i soldi in mano a Mezzettino, il quale, pover'uomo, è disperato per il timor grande che egli ha della giustizia, e chiede, per pietà, d'esser liberato.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Eh, questo giovine ha poca voglia di far bene! Ché comprar schiave? E che ne vuol egli fare? Farebbe meglio a studiare e addottorarsi, e dar gusto a suo padre. Eh, giovine senza ingegno, comprar schiave? È forse egli qualche principe? Eh mio padre farà bene che Mezzettino non contratterà con questo povero pollastraccio, che non sa che cosa sia il vivere del mondo! Vedete questa compra è una vanità, o ch'egli la compra per far boria, o per qualche inonesto amore, in qual si voglia modo è mal fatto, e mio padre non lo comporterà.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Ah, madonna figliuola, e che menar la lingua è questo? e che pensi ch'io non sappia parlare, ch'abbi tu da rispondere a me? che creanza è questa?</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Signore, perdonatemi, l'onor vostro mi fa parlare. Vostra signorìa è suo tutore, è raccomandato a voi, e se il giovine commette qualche mancamento, suo padre lo attribuirà tutto alla poca custodia vostra e al poco amore che gli portate, e dirà che non averebbe fatto egli così con voi.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>O mi pare che tu te la pigli molto calda!</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Io? Perdonatemi, parlo per l'obligo che vostra signorìa tiene in virtù dell'amicizia con suo padre, ché del resto a me non importa nulla.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Non t'importa niente, eh?</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Niente, ma la riputazione vostra vuole che non gli lasciate comprar quella schiava.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Questo è il punto.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Eh, ella dice quello che la natura gli porge, e poi chi vol pensar ad altro vi pensi.<pb n="443"/></p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>A punto, so che vostra signorìa ha giudizio, e che non comporterà che si effettui questa compra.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Qui cantò Meliseo.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Mi sapresti tu dire da che procede che mia figliuola s'ingerisca tanto in questo negozio, parlandone con tanto affettato affetto?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Io no. Il mio talento naturale non arriva sino dove gli rode, né dove forse gli coce questo negozio.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Io lo so.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>E da che viene?</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Dall'esser lei inamorata di questo signor Cinzio.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>O mi diresti ben di novo.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>È così al sicuro. E che ciò sia vero, sta' ad udire, ch'io la voglio far uscir fuori da sua posta.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Starò ad udire.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Veramente tu dici bene, figliuola, se questo giovine facesse qualche sproposito, suo padre potrebbe dar la colpa alla mia mala custodia.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>E del certo.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Ma è ch'io temo di peggio, con questo giovine. Mi vien detto che ogni notte egli va vagabondo, ove potrebbe, una volta o un'altra, tornar a casa non molto sano, poiché l'andar di notte in comitiva fa che l'uno facci insolente l'altro; ma voglio rimediarvi.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Farete molto bene.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Io non voglio che egli stia più in quell'alloggiamento con quegl'altri scolari, perché vedo che porta pericolo, e com'uno è buono vien burlato da gl'altri; e, tal volta, si fa quello di che non s'ha voglia, per aderire a gl'altri. Però io lo voglio tirar in casa nostra ad alloggiare.<pb n="444"/></p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>O questo sì, che sarebbe bene.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Hà hà, che dici.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Io dico che sarà anche bene, perché vostra figliuola saprà poi quando sarà dentro, e quando sarà fuori di casa, se qualche persona ne addimanda.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Ma che camera gli daremo noi? quella che è vicina alla tua sarebbe commoda?</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Commodissima.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Al manco questa non è noce da far cadere con le pertiche, ché se ne viene da sua posta.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>E non, ché v'è quel pergolato, che lieva il lume. E poi è tanto vicino alla tua, che ti darebbe fastidio il sentirlo studiare, perché gli scolari si levano a buon'ora.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Io credo che non gli darebbe fastidio manco se si levasse a mezza notte, non è vero?</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>A me no, ch'io ho il sonno tanto profondo, che non mi destarebbe manco il tuono. Mi copro, e poi, buona notte pagliariccio!</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Quest'è il bello: star coperta e lasciar fare a chi ha da fare.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Sarebbe più commoda la tua; ma mettere due letti in quella camera l'ingombrarebbe troppo, che dici?</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>O gli rinunziarò la mia camera, che s'accomoda.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Io non ti voglio levar dal tuo luogo.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>In camera meco, signor padre.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Eh, perché è tanto modesto.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Per certo sì, ma non è già nostro parente da tirarlo nella propria camera. Se bene che vostra signorìa l'ama da figliuolo, io non credo, però, che fusse lecito; ma tuttavia fate voi.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Eh, presupporre che vi sia fratello, e accettarlo per quel fratello, caro e amato.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Che dici?</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Io non porrei mai la lingua in tal negozio.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Ned'io tan poco.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Hà, sfacciata senza ingegno, e dove ti lasci tu portar dal senso?</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>E perché mi sgridate?<pb n="445"/></p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Ti pare bella cosa acconsentire ch'un giovine forestiero venga in casa d'una giovane da marito? e che vorresti tu che dicesse il vicinato, di'?</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Ma vostra signorìa me lo proponeva, e io mi fidava del giudizio vostro, e condiscendeva, perché sono obediente.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Diceva così per provarti.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>O questo, è provare un gatto affamato, se sa far la guardia al lardo.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Ma, e perché provarmi? Ben può, vostra signorìa, anche farmelo condurre nella camera, ché a voi sta il fare che sia lecito. So che vostra signorìa m'intende.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>O notta dotto.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Va' in casa.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Anderò, signore, ma...</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Zitto, abbassa quegl'occhi, e va' in casa. Che ne dici Scappino?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Dico, che mi par ch'ella porta affezione a quel giovine, e che non è gran cosa che abbia condesceso a tirarlo in casa, poiché nelle città come è questa, vi sono delle case, che vi stanno due e tre famiglie, ove spesso vi sono gioveni e giovinette. Ella è sdrucciolata un poco nella camera vicina, ma se l'ha passata bene, con dire potete far che sia lecito, volendo dire: fate che mi sia marito. Orsù, signore, fate di lei quello che vi par meglio. Ma in tanto vostra signorìa vada un poco a far levar quello sequestro. Servitore di vostra signorìa.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Così farò.</p>
           </sp>
@@ -2877,363 +2917,363 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">mezzettino</hi>
           </stage>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>O di casa!</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Chi è là?</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Amici.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Che amici?<pb n="446"/></p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Sono Beltram, o là, che voce languida è questa? Messer Mezzettino, una parola.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Perdonatemi, messer Beltrame, non posso uscire.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>E che, avete le mani in pasta?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Sto in modo che non mi posso muovere.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>E che cosa avete?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Cosa tale, che non posso venire.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>E che, siete storpiato?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Peggio, signore.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Ma in buon'ora, fate ch'io sappia, almeno, quello ch'avete.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Sono sequestrato.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Come sequestrato? Siete sequestrato in casa?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Non so. So bene ch'io son sequestrato tutto.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Aprite la porta e non uscite voi, se siete sequestrato in casa.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Ma credo che sia sequestrato anche la porta.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>O mi fate ridere, voi siete ben balordo, e come si sequestrano le porte?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Eccomi. Ma avertite, che s'io cado in pena alcuna, che ne siete cagione voi.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Ove è il sequestro?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>È qui, in scarzella.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Mostratemelo un poco.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Come mostrarlo, s'egli è sequestrato?</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>O questa sì che è da scemo: il sequestro è sequestrato anch'egli. Siete così ignorante, o pur fate il balordo per qualche vostro interesse?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Io non sono mai stato in questo intrico, mio padre morì disgraziatamente per giustizia, e io con l'esempio suo mi sono avilito in modo che, vedendo i Birri, mi pare esser legato.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>E come morì vostro padre?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Lo strozzorono per aver fatto la sentinella.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Doveva aver fatto qualche segnale al nemico, o passato qualche accordo seco.<pb n="447"/></p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Anzi, ché fu impiccato per esser troppo fedele.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Io ciò non intendo, se non parlate più chiaro.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Faceva la sentinella mentre che certi suoi compagni rompevano una bottega, accioché la Corte non sopragiongesse. E uno, invidioso del ben altrui, gli diede la querela; e per far servizio al suo prossimo, fu col prossimo mandato in Picardia.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Veramente queste sono certe carità, che non chiedono altra ricompensa. E voi, che cosa avete fatto?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Niente di male, ch'io sappia, e per niente son ridotto a questo passo. Hù hù hù.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Non piangete, siete voi così pusilanimo! È vergogna, un uomo come voi siete, pratico del mondo, dare in queste bassezze!</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Do nelle bassezze per tema di dare nell'altezze e rimaner in aria. È una mala cosa l'esser stato pronosticato a far il fine del padre e cominciare la giustizia a venirmi in casa. Il mal comincia spesso dal poco, e quel poco s'avanza tanto, che tira le persone alla morte. La giustizia ha cominciato, non so dir altro.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Mostratemi, di grazia, questo sequestro.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Toglietelo voi fuori di scarzella, ché io non voglio preterire l'ordine della signora giustizia. Ma avertite a quello che voi fate.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Lasciate la cura a me. «<foreign xml:lang="lat">De mandato Magnae Curiae Vicariae</foreign>» ...</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Chi ha mandato alcuna vigliacaria?</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>A proposito! Non dice vigliacheria, dice: d'ordine della gran Corte della Vicarìa. Non sapete che cosa è Vicarìa, in Napoli?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Signor sì, dove sono gl'incarcerati. Ed ecco che questo è un principio di disgrazia, o Cielo, aiutatemi!<pb n="448"/></p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Fermatevi. «<foreign xml:lang="lat">Ad instantiam domini Fulvi de Bisognosis</foreign>»...</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Signor no, signor no, io non ho fatto instanza al signor Fulvio, è lui, che voleva la mia schiava. Il signor Pantalone ha torto a mandarmi la giustizia a casa.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Piano, piano, ch'il signor Pantalone non vi fa torto, né dice che abbiate fatto instanza al signor Fulvio. «<foreign xml:lang="lat">Sequestretur omne per illud, quod reperitur penes domino Mezzettino</foreign>»...</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Io non ho raparito, né rapito, né penne né pennacchi a nissuno; la giustizia è mal informata.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Tacete, in buon'ora, ché non parla né di rapire, né di rubbare! «<foreign xml:lang="lat">Uti bona pertinenza al dominum Cinthium Fidentium</foreign>»...</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Non è vero, io non ho fatte impertinenze al signor Cinzio, io gl'ho parlato sempre con ogni riverenza.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Se voi non avete pazienza, non la finiremo mai! Non intendete e però tacete! «<foreign xml:lang="lat">Scolarem Beneventanum videlicet aurum, et argentum</foreign>»...</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Sono dugento ducati d'oro, e io non ho argento suo. E non l'ho rubati, ché sono per il ricatto della schiava.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>In buon'ora! «<foreign xml:lang="lat">Et in specie</foreign>»...</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Io non ho spezie.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Non parla di vostre spezie. Achetatevi, dico! «<foreign xml:lang="lat">Mancipiam unam captivam</foreign>»...</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Io non ho manco sepie cattive, né pesce buono.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>O siete impaziente! «<foreign xml:lang="lat">Cum declaratione, quod ipse non possit amplius eam retinere, neque possidere</foreign>»...</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Ch'io non possa più sedere? Ohimè son rovinato, o meschino, è impossibile ch'io possi star sempre in piedi!</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>O pazzo, non dice che non possiate sedere, dice che non possi possedere, «<foreign xml:lang="lat">neque in pedibus</foreign>»...</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Né anco in piedi? O povereto me, son morto!</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Voi mi volete far perdere la pazienza! Fermatevi, in buon'ora, ché starete sentato, in piedi, come vorrete voi. «<foreign xml:lang="lat">Ut<pb n="449"/> dicitur alienum constituere, et quod fieret in contrarium fiat frustra</foreign>».</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>O questa sì, ch'io l'ho intesa, e non me la imbrogliarete. <foreign xml:lang="lat" rend="italic">Contrarium frustra</foreign> vuol dire che mi frusteranno per le contrade.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Voi mi volete far morir di ridere! O che voi dubitate de' vostri meriti, o ch'interpretate a forza di paura.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>E signore, voi non volete esser quello che mi dia la cattiva nova! Ma io intendo per discrezione.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>O se v'intendeste tanto di mangiare, non occorrebbono maestre da torte, o musiche da macaroni! Datevi pace, e abbiate pazienza ch'io legga il tutto. «<foreign xml:lang="lat">Et haec sub pena ontiarium auri centum</foreign>»...</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Che mi vogliono ongere in cento?</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>A proposito, le onze d'oro sono un valor di moneta, e credo che sia cinque ducati d'oro un'onzia. «<foreign xml:lang="lat">Regio Fisco applicandarum</foreign>»...</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Che mi vogliono appiccare al fresco? O poveretto me! O mia madre, che trista novella intenderete dell'unico vostro figliuolo! Almanco si potesse saper perché.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Eh quietatevi, che non vuol dir così, no?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Eh, apicandarmi, ho inteso benissimo.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p><foreign xml:lang="lat" rend="italic">Applicandarum</foreign>, dice, e non <foreign xml:lang="lat" rend="italic">apicandarum</foreign>: da applicarsi al fisco, da dare alla Corte, intendete? «<foreign xml:lang="lat">Registrum per publicum Notariorum Mosettinus Calera</foreign>».</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>O questa non si può già dir più chiara: Mezzettino in galera.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Maidesì, voi diventarete pazzo tra la vostra interpretazione e la vostra paura. <foreign xml:lang="lat" rend="italic">Mozzettinus</foreign> vuol dir Moisè in diminutive, come Battista Battestino, Carlo Carlino, e Calera è una casata spagnuola.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Io non voglio mai andar in Spagna, per l'augurio di tal casata! Ma in che linguaggio è scritta quella carta?</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>In latino.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Deve dunque venir questo sequestro dal paese de' Latini, e io non so dove sia.<pb n="450"/></p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Il paese de' Latini è l'Italia e il sequestro è fatto qua, nella Vicarìa di Napoli.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Ma a che proposito colui va scrivere in latino, se gli è italiano e lo manda ad un italiano? Questo è uno sproposito o un inganno.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>E no, fratello, è un costume così fatto, per rispetto de gl'altri paesi.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Orsù, non so come si sia, basta. Ma ditemi, se vi piace, che contiene questo sequestro?</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Che voi non diate né denari, né robba, né schiava, al signor Cinzio, fino che egli non abbi sodisfatto il signor Fulvio d'un non so che danari che deve avere.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>E non altro? E non v'è pericolo né di frusta né di galera?</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>No poveretto.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Or sia lodato il Cielo, mi sento ora così leggiero, che mi pare di caminar per l'aria; io voglio far un salto d'allegrezza!</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Venite meco, ché io voglio far levar il sequestro.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Che siate voi benedetto! Ma non v'è già pericolo ch'io già contrafacci a gl'ordini della signora giustizia, no?</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>No fratello, venite alla Vicarìa, ch'io vi voglio anche far fare un precetto in faccia.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>A che proposito mi volete far guastare la faccia? Io non vo' nulla in faccia, voglio il mio viso intato, o bello o brutto che sia.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Io non vi voglio guastare la faccia. Voglio farvi far un commandamento, che non debbiate contrattare più col signor Cinzio, e che ogni contratto resta invalido. E dico in faccia, cioè senza mandar scritture a casa.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>A mano a mano non potrò trattar con niuno! Il signor Pantalone non vuole ch'io contratti con suo figliuolo né con Scappino, vostra signorìa con il signor Cinzio; che sì che mi converrà presto presto partir da Napoli.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Il contrattar con figliuoli di famiglia è pericoloso ed incerto. Venite meco, andiamo.<pb n="451"/></p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Vengo, ma andate adaggio, ché m'è rimaso un poco di reliquia di sequestro in questa gamba, che mi tiene l'andar veloce. Orsù, passa, passa.</p>
           </sp>
@@ -3241,115 +3281,115 @@
         <div type="scene">
           <head rend="italic">SCENA QUINTA</head>
           <stage><hi rend="sc">fulvio, cinzio, spacca, pantalone</hi>, <hi rend="italic">e</hi><hi rend="sc">scappino</hi><hi rend="italic">facendo questione</hi></stage>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Fermatevi, fermatevi.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>A me quest'affronto?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Fermatevi, signor Cinzio.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Fermatevi, signor Fulvio.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Fermatevi, dico, abbassate l'armi e ditemi la cagione della vostra rissa.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Io mi fermo, ma vostro figliuolo s'è portato male con me.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Che cosa v'ha egli fatto?</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Io aveva sborsato dugento ducati per comprare una schiava ed egli me gli ha fatti sequestrare per quindeci ducati, ch'egli pretende da me, ma non è vero.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Che danari hai tu d'avere da questo gentil uomo?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Quindeci ducati, ch'io gli vinsi al gioco l'altro giorno, e non me gli vuol dare.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Il signor Domizio ve gl'ha fatti buoni sopra dieci otto, che voi gli dovete dare a lui.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Io son uomo da pagar i miei debiti, senza che niuno li paghi per me.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Pagateli, dunque, e levatemi di parola col signor Domizio, ch'io pagherò poi voi.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Fermatevi, caro signore, per grazia! E tu vai al giuoco? e ti ha dato l'animo di giocare quindeci ducati? O forfante! E poi vai a far fare un sequestro ad un tuo amico, che non ti deve dar nulla? e di più, por man all'armi contro di lui? O scelerato!</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Signore, io l'ho fatto per ben suo. Ho fatto far quel sequestro non tanto per il danaro, quanto perch'egli non<pb n="452"/> getti i soldi del suo dottorato in una schiava, e acciò ch'egli non dii disgusto a suo padre con queste sue leggierezze.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>O che possi tu crepare, tu vòi regolare le case altrui? Tu vòi dar precetti di economica? Vati regola tu, bestia senza ingegno, che non sai dove abbi il capo. O guarda chi compassiona il disgusto del padre de gl'altri! Uno che continuamente trasgredisce gl'ordini paterni! Signore, io vedo, per il mio conoscere, che ella è più prudente assai, che l'età non ricerca, e perciò oserò di pregarla di condonnare il mancamento, fatto da mio figliuolo, alla passione che forsi egli ha di quella schiava.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Io sono qua per registrare il mio potere al libro del vostro volere, io gli rimetto ogni offesa come non ricevuta, e iscuso nel signor Fulvio quello che averei caro che fusse iscusato in me.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Vostra signorìa mi favorisca di dargli la mano in segno di pace, e poi si compiaccia di venir meco alla Vicarìa, ch'io gli farò levar il sequestro.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Signor Fulvio, io non vorrei che l'amor di quella schiava vi facesse dimenticare l'amicizia nostra.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>O questo no mai! Ma il presupposto, ch'io ho fatto del vostro utile, m'ha fatto transcorrere tanto oltre. Però vostra signorìa mi iscusi.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Signore, vi sono servidore, e so che quello ch'avete fatto lo conoscete, e ciò mi basta.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Signore, avete inteso come è stato il negozio; se non era il signor Fulvio io menava la schiava a casa.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>A casa di chi? del signor Fulvio?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Di vostra signorìa.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Orsù, torna pure col tuo padrone, ch'io t'ho posto in opera a bastanza.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Come commanda vostra signorìa.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Che cosa vi dice colui sotto voce? Vostra signorìa non se ne fidi molto, poiché egl'è il turcimano di mio figliuolo.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Me ne vado assicurando.</p>
           </sp>
@@ -3358,123 +3398,123 @@
         <div type="scene">
           <head rend="italic">SCENA SESTA</head>
           <stage><hi rend="sc">spacca, scappino, cinzio, celia</hi>, <hi rend="italic">alla finestra, e</hi><hi rend="sc">beltrame <add resp="#ed">pantalone</add></hi></stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Amico, vi ringrazio del cortese officio che avete fatto, col porvi di mezo a questi giovani.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Vi sono servidore, patron mio.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>E tu, va' a ritrovar or ora un fabro, e fa' porre una toppa o serratura a questa porta davanti il fondaco, ch'io non voglio che tu dorma più in quelle camere per guardia di quelle robbe vecchie, ch'io voglio levar la commodità di far contrabandi la notte a mio figliuolo.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>O vostra signorìa mi comincia a circoncidere il credito.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>No no fratello, il fidarsi è da galant'uomo, e il non fidarsi è da uomo prudente. Tu hai troppa simpatia con mio figliuolo, e non vorrei che si facesse lecito, con la scusa della gioventù o dell'amore, qualche cosa che urtasse nel supposito e che ne cagionasse poi un maggiore in me. Fa' far quello ch'io ho detto quanto prima.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Or vado.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>E tu vien meco a far levar il sequestro. Signor Cinzio, vi piace di venir ancor voi.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Io vado a dir una parola ad un mio amico, e poi mi troverò anch'io verso la Vicarìa, servidore. Mi è parso di vedere la schiava alla finestra, io voglio star in agguato per questi contorni, e vedere s'io potessi scoprire qualche adito a' miei contenti.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>O galant'uomo! Qua, qua, guardate ad alto.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Questa non parla meco, e se parla meco non mi conosce.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Messere, qui, qui.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Ah signora, che mi commandate?</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Conoscete messer Scappino, servitore del signor Fulvio Bisognosi?</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Signora sì.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Fatemi un piacere, per grazia, ditegli che quando egli<pb n="454"/> avrà trovato un magnano, che venga qua d'intorno, perch'io voglio che mi faccia aprire questa camera, accioché io possa andare seco dove egli sa; ma che stii alerta che Mezzettino non sia in casa, intendete?</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Io vi servirò volentieri.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Non farete piacere ad un'ingrata; mi raccomando.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>O quest'è un altro imbroglio, costei vol fugirsene con Scappino. O se la giustizia se n'avvede, overo che Mezetino ne dia querela, eccoti Scappino in transito di galera.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Io leverò il pericolo a Scappino, io sono innamorato di questa giovane e io mi travestirò da fabro e la levarò di quella casa, poiché la giustizia non potrà procedere contro di me, come farebbe contro di Scappino.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>E perché con vostra signorìa no, e con Scappino sì? Siete forsi famigliare della giustizia?</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Io non sono né famigliare né domestico, ma è che la schiava è mia, avendo di già sborsato il riccatto a Mezzettino.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>E perché non ve la fate dare da Mezzettino senza prenderla di furto?</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Perché un amico di mio padre non vorrebbe ch'io la comprassi, e credo che Mezzettino sia stato pregato a non venderla a me dall'istesso amico.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Orsù, vostra signorìa dunque vadi a travestirsi, e la leva, ch'io non cercherò altro.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Questo a me non basta, io vorrei che mi facesti piacere di non palesare questo fatto né a Scappino né al signor Fulvio, poiché essi trattano pur questo negozio, e accorgendosi di me s'attraversarebbero al mio gusto.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Io non dirò nulla.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Caro voi, fatemi questo piacere, ad ogni modo il signor Fulvio non la può avere, perché suo padre l'impedisce, e io ve n'averò obligo.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Non mi uscirà di bocca, per vita della mia Aniella.<pb n="455"/></p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Eccovi meza patacca, andate a bere il greco per amor mio.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Io vi son schiavo, patrone mio, e se bene il vino fa parlare, io ne berrò tanto, ch'io m'adormenterò, e così tacerò anche per forza.</p>
           </sp>
@@ -3486,47 +3526,47 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">scappino</hi>
           </stage>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Io voglio bilanciare qual pesa di più o la mezza patacca o l'amor di Scappino, e appigliarmi al meglio.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Spacca, che fai?</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Bilancio.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Che cosa? il cervello con la borza? o l'onor con l'utile? Dimmi la verità, tu hai fatto qualche mariolarìa.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>O tu m'hai in cattivo conto! Se tu fussi giudice, mi condennaresti senza esaminare testimonii.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Io non potrei condennarti, perché non si può esser giudice e parte.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Tu dici la verità. Scappino, io t'averei da palesare una cosa, ma non posso, ch'io mi sono legato in giuramento, per vita della mia morosa, in presenza d'un testimonio da venticinque grana.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Mi dispiace ch'una concubina mi levi questo gusto.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Che domine dirai, questa è donna onorata al dispetto dell'onore. Orsù, poiché Celia mi ha detto che qui venirà Scappino per far por la serratura sopra la porta del fondaco, che gli dica che vada da lei, ché, se il suo patrone non sarà in casa, vuol far aprire la porta della sua camera e andarsene con Scappino. E che il signor Cinzio, sentendo quest'ordine,<pb n="456"/> ha detto che vuol far egli questo furto, e che non debba dir nulla a Scappino né a Fulvio. Io gli voglio osservar la parola, non tanto per la mezza patacca che mi ha dato, quanto ch'io devo servire chi merita. Retìrati tu, ché non voglio che senti i fatti miei.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Volentieri. Io voglio andar or ora a rimediare ad un inconveniente, per far servizio al mio padrone. Di grazia, Spacca, perdonami s'io non posso trattenermi teco.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Va' pur a far i fatti tuoi e non stare a tentare i segretari. Io potrò giurare di non aver detto nulla di questo fatto a Scappino.</p>
           </sp>
@@ -3538,19 +3578,19 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">spacca</hi>
           </stage>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Spacca, che fai?</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Caro signore, sono qua imbrogliato, perché una schiava vuol fuggire dal suo patrone e uno vuol fingere un magnano e menarla via, e io son pregato a tacere e non dir nulla a Scappino, e Scappino, senza che io gl'abbia detto nulla, dice che vi rimediarà.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Che schiava? che magnano?</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Signore, io son obligato d'osservare il silenzio, e non voglio dire che la schiava stia in questa casa, né che quello che si vuol travestire sia uno che ha sborsato dugento ducati per averla e che gli siano stati sequestrati i danari e la schiava, perché mancherei di parola, perdonatemi in cortesia, ch'io voglio serbar la fede a chi l'ho data. Io mi parto.</p>
           </sp>
@@ -3561,7 +3601,7 @@
             <hi rend="sc">fulvio</hi>
             <hi rend="italic">solo</hi>
           </stage>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>La schiava che sta qua? Senz'altro ella è Celia, il magnano delli dugento ducati e del sequestro è Cinzio, s'io non fallo. Ma costui dice di non aver detto cosa alcuna a Scappino, e come Scappino ha detto di rimediarvi? Ohimè, le cose<pb n="457"/> sono così confuse, ch'io non so come guidarmi, io non mi posso ingegnare per amor di Scappino, e pur vedo la cosa rovinata.</p>
           </sp>
@@ -3573,72 +3613,72 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">fulvio</hi>
           </stage>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Io sono liberato dal sequestro, ma non sono affatto liberato dalla giustizia, ché l'avversario ha pur voluto farmi intricare con li precetti.</p>
             <p>O siete qua, signore?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Al vostro servizio.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Io ho ordine dalla signora giustizia di non contrattare con voi, né col signor Cinzio; per tanto vi prego a lasciarmi viver in pace e non impedirvi della mia schiava.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Almeno, fatemi piacere di non la vendere ad alcuno per otto giorni, ch'io spero, in virtù de' miei prieghi, far condescender mio padre alle mie voglie, caro il mio Mezzettino.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Signore, mi fate pietà. Ma non vi posso sodisfare, perché la mercanzìa delle schiave è mercanzìa viva e può morire, e non è come il vino, l'olio, il formaggio, che quanto più invecchiano, più sono migliori; ché le donne quanto più invecchiano, più calano di prezzo. E poi è una mercanzìa che alle volte magna non solo il guadagno, ma anche il capitale. Perdonatemi, signore, io la voglio dar via quanto prima e traficar i miei soldi.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Se morirà, morirà per me; e s'invecchierà, mio danno. Io vi farò buono quello che spenderete nel suo vitto.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Signor Fulvio, voi non la volete intendere. Non voglio inimicarmi vostro padre, né voglio aspettar altro che i miei soldi.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Non la volete dar a me per darla al signor Cinzio.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Vi dico che ho precetto di non contrattar con esso lui ancora, e ch'io non gli la darò.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>E gliela darete bene.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Non gliela darò già.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Egli se la prenderà.<pb n="458"/></p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Che se la prenderà, e dove siamo, nel bosco di Baccano?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Non ve la torrà per forza, ma la prenderà con inganno.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>E io starò avvertito.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Avvertite quanto volete, ch'egli sarà vestito da magnano, che non lo conoscerete, e come voi andarete fuori di casa ed esso verrà a levar la serratura e la condurrà via al vostro dispetto. E non si potrà dir furto, perché ve l'avrà pagata. Ma questo è forsi vostro concerto, per non parer di far contro gl'ordini che ve ha fatto far il signor Beltrame. Ma s'io me n'accorgerò averete poi a far meco.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Io non ho concerto con niuno e ringrazio vostra signorìa dell'avviso; ma se me la farà, sarà un grand'uomo.</p>
           </sp>
@@ -3646,107 +3686,107 @@
         <div type="scene">
           <head rend="italic">SCENA UNDECIMA</head>
           <stage><hi rend="sc">scappino</hi><hi rend="italic">da magnano</hi>, <hi rend="sc">mezzettino</hi>, <hi rend="italic">e</hi><hi rend="sc">fulvio</hi></stage>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>O chi conza chiave, chiave?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>O galant'uomo.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>O fortuna, costui è qua, passerò di longo.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>O maestro, volete mutar un puoco una serratura qua?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Non ho tempo adesso.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>E perché andate gridando, se non volete lavorare?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Vado cercando da lavorar per domani, oggi ho da fare.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Accostatevi e levategli la barba rimessa.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>A galant'uomo!</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Ah signor Cinzio! Ohimè, che vedo?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>A non vi è già riuscita! O mi guarderò da qua avanti. Signor Fulvio, io vi ringrazio dell'aviso.<pb n="459"/></p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Ah, che siete voi quell'uomo di coscienza, che ha fatto la carità d'avisare Mezzettino? O siate benedetto!</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Io sono stato assassinato da Spacca, o Scappino. Sono stato tradito, fratello! Spacca m'ha detto che il signor Cinzio era vestito da magnano e che voleva menar via la schiava, e io per far bene ho avisato Mezzettino.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Spacca ve l'ha detto?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Messer sì.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>E come ve l'ha detto, se lui avea giuramento di non scoprir questo fatto a niuno?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Non me l'ha detto chiaro, ma io l'ho compreso per circonscrizione.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Nel suo parlare avea nominato Scappino?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Sì, ma ha detto Scappino non lo sa, ma dice che vi rimedierà.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>O questo bastava, quest'era segno che egli aveva parlato in zifera meco, o in metafora, come avea fatto con voi.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Ma Scappino, non si può già indovinare tutte le cose!</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Che indovinare occorre, se voi non avete da far cosa in questo negozio? Ma io credo che voi farete pur male quand'anche non farete nulla. O meschino me, io vo gridando conza serrature, e voi andate girando a romper invenzioni.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>O poter del mondo, ogn'uomo vi sarìa caduto a quell'inganno. Ma tu mi poni in tanto spavento, ch'io temo d'ogni cosa, e dubito che dormendo infin a i sogni non mi travaglino, credendo di non romper qualche invenzione.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Se gli lenzuola fossero di strattagemme, per certo che dormiresti da gallo! Andatemi via da gl'occhi, per grazia.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Bisognerà ch'io mi bandisca da Napoli senz'altro.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>È l'importanza ch'io non so se la disgrazia sii la sua o la mia, quella che distrugge le mie maniche. Ma facci il mondo quello che vuole, ch'io ne voglio veder il fine.</p>
           </sp>
@@ -3758,55 +3798,55 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">scappino</hi>
           </stage>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>E bene, come t'è riuscito il negozio?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Quale?<pb n="460"/></p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Quello ch'io non t'ho potuto dire.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Ah, quello che non ho potuto effettuare.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>E perché?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Perché il mio padrone ha fatto la carità d'avisar Mezzettino, pensando che il signor Cinzio v'andasse lui travestito.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Orsù, questa se gli può perdonare.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Eh sì, se non avesse avuto ordine da me di non parlare con Mezzettino, né con altri per conto della schiava.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>O che vuoi tu fare, scusalo di grazia, e aiutalo. Egli è tanto buon giovine, che mi fa pietà vederlo travagliato.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Vuoi tu aiutarmi in un'altra invenzione?</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Io sì volentieri.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Vieni meco nel fondaco, ch'io ti travestirò e farò finger un messo del padre della schiava per aver tempo di negoziare.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Andiamo pure.</p>
           </sp>
@@ -3814,89 +3854,89 @@
         <div type="scene">
           <head rend="italic">SCENA DECIMATERZA</head>
           <stage><hi rend="sc">cinzio</hi><hi rend="italic">da magnano</hi>, <hi rend="sc">mezzettino</hi>, <hi rend="italic">e</hi><hi rend="sc">pantalone</hi></stage>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>O chi vuol far conzar chiave, chiave!</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>O mastro, mastro, una parola.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Che volete, signore?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Ponete un poco qua una serratura forte e levate questa vecchia, ch'io vi pagherò.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Io non ho cosa a proposito, venirò domani a vederla.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Voi dite di non aver cosa a proposito, e non guardate manco la porta e chinate il capo. E che, temete di non esser sodisfatto?</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>E' credo ogni cosa; ma non ho lavori adesso per vostra signorìa. O chiave!</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>O magnano, magnano.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>O poter del mondo, costui è in casa e questo altro m'impedisce, voglio partire.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Fermatevi maestro, ch'io vi voglio mostrare certi lavori.<pb n="461"/></p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Venirò poi domani.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Vedetegli solo, sono in casa mia, non avete da far viaggio, né da perder tempo.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Vediamoli.</p>
             <p>Scuserà pigliar la pratica della casa.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Costui è un furbo.</p>
             <p>Signor Pantalone, guardate un poco! Ah, signor Cinzio, a me questo, eh? Togliete la vostra barba. Signor Pantalone, fermatevi per cortesia qui.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Volontieri.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Signor Pantalone, m'avete rovinato! Se vostra signorìa non mi tratteneva, io passavo di longo e non era scoperto da costui.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Caro signore, io avevo bisogno d'un fabro, e non m'avrei mai pensato una leggierezza tale in un vostro pari, però dell'error vostro vi sia questo rossor il pagamento.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Amore ha fatto far di peggio a persone più gravi di me.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Togliete questi, sono li dugento ducati, io ve gli restituisco in presenza del signor Pantalone; il sequestro è levato e io ho ordine dalla signora giustizia di non contrattar più con voi, sotto pena di perder la mercanzìa, però fate il fatto vostro, e lasciatemi in pace, per cortesia.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Signore, non fate più questi mancamenti all'esser vostro, attendete allo studio, ché non vi mancheranno donne belle e degne della vostra condizione.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Ringrazio vostra signorìa. Orsù, le cose mi si vanno attraversando, sarà meglio ch'io mi disponga al voler del padre; ma non so come far questo passaggio così di repente. Se o lo sdegno o l'impazienza non mi serve per mezzo, io dubito di questo tragitto, ma faccia il Cielo.</p>
           </sp>
@@ -3908,91 +3948,91 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">fulvio</hi>
           </stage>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Tu sei informato del tutto, dagli la lettera, ch'io t'aspetto nel fondaco.<pb n="462"/></p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Lascia fare a me. O là.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Chi è là?</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Sono io. Siete voi misser Mezzettino?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Son io. Che volete, paesano?</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Io son un servitore del signor Gusberto Quercimoro, padre di quella giovane che avete voi, il qual vi saluta e vi manda questa lettera.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Io ringrazio sua signorìa e voi ancora; ma mi sapreste dire il contenuto della lettera? Perché la lettera viene da Sicilia e io non intendo lo scrivere siciliano.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Chi è colui che parla con Mezzettino?</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Signor sì, il signor Gusberto vi prega a non far esito di sua figliuola per otto giorni, poich'egli vuol venire in persona, e a quest'ora sarà partito da Palermo.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Chi t'ha dato questo palandrano e questo capello?</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Io l'ho portato di Sicilia.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Che Sicilia? Questa è robba mia.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Hem hem.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Ho inteso, ho inteso.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Ho inteso ancor io, Scappino è costì. Dove v'è vino dolce ivi sono mosciolini; dove è Scappino vi sono stratagemme. Ecco, e tre n'ho pelati oggi! Togliete la vostra barba e la vostra lettera, e non tornate più qua, se non vi farò castigare dalla signora giustizia. Intendete, misser Scappino, voi mi volete far scaltro al mio dispetto, ma lo dirò al signor Pantalone.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Che domine ha mandato colui qua?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>La sua mala fortuna, per la mia disperazione, non sì tosto l'ho veduto, c'ho detto tra me: l'invenzione è al bordello.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>È possibile che costui sii così disgraziato che non sappia manco far bene a sé stesso?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Il proverbio dice: chi non fa non falla e fallando s'impara. Ma costui falla sempre e non impara mai, anzi peggio, ché non facendo pur falla e rovina le fatiche de gl'altri. O pensa tu come mi ritrovo, sono tanto in contumacia con Mezzettino, che tratta dell'impossibile far più cosa che riesca.<pb n="463"/></p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Io te lo credo; ma che ti gioverà l'aver affaticato tanto, se non ne mostri qualche opera? Qui di nuovo bisogna assotigliar l'ingegno.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Questa è la cagione che mi travaglia, io ho posto l'assedio a questa fortezza e mi par vergogna il levarlo senza frutto. Orsù, vieni a spogliarti, che si consigliaremo.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Andiamo nel fondaco.</p>
           </sp>
@@ -4006,7 +4046,7 @@
           <stage>
             <hi rend="sc">capitano bellorofonte martellione</hi>
           </stage>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Manco male ch'io sono uscito di barca ad ora che non vi erano persone di rispetto al molo e che niuno ha sentito quando ho detto all'uffìciale della sanità ch'io mi chiamo Capitan Bellorofonte Martellione, che potrò star sconosciuto a far il fatto mio. Ben ch'io dubito che l'aspetto mio formidabile non mi palesa più presto di quello ch'io ho proposto, perché non posso far forza a questa mia terribile fierezza. Mi escono d'ogn'intorno spiriti così furiosi, che non v'è occhio umano che possi far schermo, quando gl'incontrano, e men'accorgo dal veder che quelli che mi mirano si raccapricciano o s'interizano. E pur mi sforzo di lampeggiar sguardi con benigno ciglio, o pensa tu sorte s'io gli lasciassi scorrere a briglia sciolta! Guai al mondo! Però, se gl'occhi miei fanno alcuna volta danno alle persone, gli fanno ancor beneficio. E come sarebbero usciti dal pericolo del procelloso mare quei poveri passaggieri, che meco erano nel naviglio, s'io non inarcava le ciglia e non vibrava sguardi d'inferno contro quel vasto monstro? Di già aveva scomposto il liquido suolo, e, per far mostra di quei tesori ch'egli nasconde nel seno, solevava l'onde sino alla sfera del fuoco, levando per terror il fiato a quei meschini, che non potevano manco gridare aiuto, né implorare dal Cielo soccorso. E s'io non gli<pb n="465"/> rincorava con dirgli: non dubitate, fratelli, che se Cesare disse in simile pericolo a' suoi marinari: non vi togliete pensiere che avete Cesare con voi; e io a voi dico: state allegri, che avete vosco quello che ha maggior fortuna di Cesare. E al mio bretto sguardo le spaventose voragini hanno ingoiato gl'ondosi monti e, fattosi il mare quasi un suolo di congelato mercurio, ha levato la tema a' passaggieri e a me l'empito dell'ira. Conosco però tutto questo da quelle mie benigne stelle che mai da' miei voleri si scompagnorono, sì come quei meschini, che sotto a' miei benigni influssi si sono salvati, mi rimarranno in obligo della vita e daranno alla fama quest'aviso, accioch'ella intuona con ori calchi di letizia le mie glorie. Voglio col tempo far stancar la fama, di modo, nel dire delle mie azioni, ch'io la voglio far diventar rauca e fiocca.</p>
             <p>Le opere del cavalier Marino hanno quasi tratto a terra tutte l'antiche poesie liriche, così i miei gesti hanno col tempo a far dimenticare al mondo de gl'Ercoli e de' Briarei, non che de gl'Alessandri ed i Cesari. O come io abbia questa giovane per moglie, io voglio rinovar la memoria di Cadmo, voglio seminargli nel ventre tanti guerrieri, che vo' riempir il mondo di persone di commando e far dar al diavolo questi soldatucci del tempo d'oggi, che non avranno mai più un buon carico militare. O mi vengono i bei pensieri in capo, alle volte! Ma io sto qua nudrendomi d'imaginazioni e non vado ad effettuar il negozio per lo quale sono<pb n="466"/> venuto. S'io non erro, per i contrasegni che mi sono stati dati, questa debb'esser la casa di Pantalone. O sia o non sia, voglio picchiare.</p>
@@ -4019,84 +4059,84 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">pantalone</hi>
           </stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Chi è là? chi batte?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>È il terremotto.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>O Cielo aiuto, o povera la casa mia, vicini aiuto, ohimè il terremotto!</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Per che cosa grida costui?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>O signore, è vostra signorìa quello che m'ha avisato che si sente il terremoto nella città?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Sì, ch'io son io.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>E vostra signorìa l'ha udito?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Hà hà hà, io sono il terremoto e peggio del terremoto, quando io voglio! Ohimè, mi farò conoscere a sua posta! E voi chi siete?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Una pecora, un balordo, una bestia, che vuol credere ogni cosa. Vostra signorìa adunque è il terremoto?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Io, io, sì, perché?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Perché non pensava mai di veder tal animale a' miei giorni, che dà spavento ad ogn'uno solo col nome, e attera le città col fiato, e pur lo vedo bello d'aspetto e leggiadro nel moto.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Io non son il terremoto ordinario sotteraneo, ma un estraordinario, lieto e sociabile, non son uno scatenato, senza ritegno, non uno imprigionato fuori della sua sfera, ma uno ch'affrena le voglie all'ira ultrice, per raddoppiarla poi, quando è di mestiere. Son uomo nell'aspetto, ma nella forza un terremoto, un fulmine, un satanasso, che spezzo e bruggio, e in diavolo chi tenta d'essere mio nemico.<pb n="467"/></p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Signore, io non solo vi sono amico, ma vi sono servitore e schiavo, ma ditemi per grazia, caro padrone, perché andate così raccontando queste iperboliche cose? È forsi un vostro capriccio d'andar a casa per casa a dir queste meraviglie, o pur è grazia particolare che fate a me? S'ella va per tutto, bisognerà che produca i testimonii d'esser tale, se non, ogn'uno lo crederà un pazzo, ma se grazia fatta a me solo, io la ringrazio e in ricompensa li prometto sforzarmi di credergli qualche cosa più del dovere, ancora che mi fosse dato del merlotto.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Non v'è persona al mondo, per credente ch'ella sia, che possa prestar piena fede alle mie prove, perché traboccano dalle straordinarie, però il non esser io creduto è tutta mia gloria. Non può un picciolo vaso capire in sé l'immenso oceano, né picciol intelletto capire i miei impossibili.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>A tale, che s'io dicessi che vostra signorìa è leggiero di cervello a dir queste cose, li farei onore, e direi quello che molti suoi conoscenti devono dire.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Sì, sì per certo. Ancora mio padre mi tiene per pazzo, perché nascondo l'azioni eroiche, accioché non mi facciano nominar tanto, che i popoli, desiderosi di vedermi, ne vengono in tanto numero al mio paese, che faccino un mondo nella mia città e lascino spopolate l'altre patrie.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Signore, io vi tengo al doppio di quello ch'io vi teneva per lo passato ed ho caro a conoscerla. Ma a che effetto è venuto vostra signorìa in Napoli, se la dimanda è lecita?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>A trovare il signor Pantalone de' Bisognosi.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Ohimè son rovinato, chi diavolo ha mandato questa bestia alla mia porta? Senz'altro è qualche bell'umore per farmi una burla!</p>
             <p>O patron mio osservandissimo, Pantalone non ha alloggiamento proporzionato per un par vostro. Hanno errato quelli che l'hanno inviato qua; loco per vostra signorìa sarebbe il castello dell'Ovo, o la gran casa de gl'Incurabili.<pb n="468"/></p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Io non voglio alloggiar da Pantalone, ch'io ho da ritornar in Sicilia, forsi ben senza alloggiar per una notte in Napoli. Io ho da parlare seco solo per conto d'una poliza di cambio. Ma dove sta Pantalone? non è questa la sua casa? siete forsi voi Pantalone per sorte?</p>
           </sp>
@@ -4104,119 +4144,119 @@
         <div type="scene">
           <head rend="italic">SCENA TERZA</head>
           <stage><hi rend="sc">scappino, spacca, pantalone</hi>, <hi rend="italic">e</hi><hi rend="sc">capitano</hi></stage>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Chi è quel penacchione che parla col mio padrone?</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Io non lo conosco, accostiamosi, ché l'intendaremo.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Signor sì, per servirla, e che commanda la terribilità sua?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Teribiltà? E chi è costui?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Mio padre vi saluta e vi manda questa lettera.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Chi è il padre di vostra signorìa?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Il signor Salzimuzio Variabelli.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>O patron mio osservandissimo, me gl'inchino, m'allegro di veder il frutto d'un mio caro amico, e un frutto che trapassa l'eccellenza della pianta. Cappe, il signor Salsimuzio ha un bel figliuolo, e valoroso, per quello che posso notare.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Non parliamo del valore, ché per quello io non sono figliuolo di mio padre, ma della mia propria volontà. La bellezza, poi, è quella ch'io mi sono compiacciuto farmi da me medesmo, con le dita nel ventre della madre. Mio padre non avea tanta scultura, né architetura, da far fabrica sì stupenda, se bene che d'una fetid'erba nasce il gilio. Però qual sono, sono per favorir il signor Pantalone, in virtù dell'amicizia ch'egli tiene con quello c'ha gloria d'essermi padre.<pb n="469"/></p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Io tanto la ringrazio, quant'egli merita, non osando di dire quanto so e posso, per esser puoco ad un tant'uomo.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Chi diavolo è questo parabolano?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>M'incresse che vostra signorìa voglia tornar subito in Sicilia, ch'io non ho tempo di far il debito mio, però m'esibisco a tutt'i suoi commandamenti. Io non vedo troppo bene e mi bisognerà tornar in casa a prender gl'occhiali per leggere la lettera, ma vostra signorìa si compiacerebbe di palesarmi il contenuto?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Signor sì, nella lettera vi è una polizza di cambio di trecento ducati, co' quali io ho da riscuotere una schiava, e subito riscossa, io me vo' tornar ad imbarcare, e però non accetto l'invito.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Questi sarebbono buoni per noi.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Andiamo dunque in casa a leggere la lettera, e in tanto potrebbe arrivar un mio servitore che ha buona vista, ch'io gli farò contar i danari, e manderemo dove vostra signorìa vorrà.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Io ho deto ad uno dei miei creati che venisse in terra e che addimandasse della casa del signor Pantalone, ch'io sarei colà. Se viene, non occorrerà altro servitore, andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Tu hai inteso, questo aspetta un servitore, io entrerò in casa, tu verrai meco prontamente, e quando Pantalone mi darà i sacchetti, io conterò i danari a te, tu tirali e reponili ne i sacchetti, e vediamo che Pantalone ti stimi un creato del forastiero, e ch'il forastiero ti stimi di casa di Pantalone, e così buscheremo questi soldi da far il nostro negozio. Tu poi starai nascosto un poco, e, se ben la cosa si scoprisse, remediaremo al tutto.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>E s'a caso mi fusse dimandato, o dall'uno o dall'altro, chi sono, che cosa vuoi ch'io dica?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Che sei meco per alcuni servigi e piglia pur i danari,<pb n="470"/> che per viaggio faremo qualche imbroglio, o che cambiaremo il sacchetto, o che faremo nascer qualche briga.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Io tirerò i danari e tu rimarrai con Pantalone per dar credito alla cosa, ch'io gli darò poi un cantone per pagamento.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Del cantone va bene, ma ch'io resti con Pantalone non è a proposito.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Perché?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Perché la burla la voglio far io al forastiero, e non voglio che tu la facci al forastiero e a me. Col forastiero poi la ridurremo a sodisfazione col tempo, e placaremo Pantalone; ma tu, se 'l diavolo ti tentasse a far un viaggio incognito, come s'accommodarebbe il negozio? No no, fratello, io non voglio far la zuppa per il gatto.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Perché? tu non ti fidi di me?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Sì bene, ma però tanto quanto ti vedo e ch'io ti possa giongere. Fratello, la somma è un poco grossa, e non ho ancora tant'esperienza di te di fidarmi tanto.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>O sei il gran furbo.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Sì, s'io mi potrò salvar da te.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>E perchè mi poni in opera, se m'hai per uomo tale?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Ti adopro come fanno i speziali il veleno, limitatamente, e per necessità. Ma entriamo.</p>
           </sp>
@@ -4228,47 +4268,47 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">cinzio</hi>
           </stage>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Un par vostro travestito da magnano, a pericolo d'esser scoperto dalla giustizia ed averne danno e disturbo, e dar travaglio a vostro padre e a' vostri amici! Eh, signore, di grazia andate un poco più considerato per l'avenire.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Signore. Questa è stata più perfidia che amore, poiché io sono stato posto al punto da un mio rivale. Però non v'era pericolo di giustizia, rispetto ch'io m'era travestito qui vicino e aveva concertato con amici di dire che questa era una scommessa fatta fra di noi scolari.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Ogni cosa alla fine si sa, e non è cosa manco tanto riuscibile, a tale, ch'è sempre bene a fuggir gl'inconvenienti.<pb n="471"/> E poi, queste machine di barbe posticcie sono cose che hanno del inverissimile.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Era, com'ho detto, poco viaggio, sotto pretesto di scommessa; era momentaneo, non v'intravenivano persone di stima, era ben travestito, e poi era un negozio desiderato d'una schiava, che non m'avea da vedere nel viso e che attendeva solo il nome di Scappino; e poi mi era di già stata venduta. In conclusione, la machina non ha avuto effetto ed ecco levato l'impossibile.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Basta, la cosa non poteva apportare né lode né utile scoprendosi né manco poteva dare odore di prudenza.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Ogn'uomo è atto a fallare.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>È vero, però è prudenza lo star avertito. Il vostro signor padre m'ha scritto una tale particolarità e dice d'averla scritta anche a vostra signorìa. Io non so che dirgli intorno a questo; s'io sarò richiesto, risponderò a tenore.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>È vero, m'ha scritto di vostra figliuola, ed è questo ch'io ho fatto dire da Scappino a vostra signorìa, ch'io gl'avea da parlare di cosa d'importanza. Ma mio padre non deve sapere che la signora Lavinia sii promessa al signor Fulvio.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Io aveva dato il mio assenso a quel giovine, a contemplazione del signor Pantalone; ma gl'amori del signor Fulvio con quella schiava cagionano ch'il detto fa poca stima del mio parentado e io manco del suo, tanto più che mia figliuola non inclina molto alle sue nozze, a tal ch'io credo che questo parentado s'annichilerà.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Io non vorrei che per amor mio s'intorbidassero le cose, e che gl'effetti non avessero il fine che brama il signor Pantalone. Tutta via dall'esito ch'io vedrò,io mi governerò, e si riparleremo, servitore di vostra signorìa.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>A Dio figliuolo. Quest'è tocco ancor lui dell'amor di quella schiava e non sa risolversi. Io voglio vedere di far vendere questa schiava quanto prima, s'io dovessi far il sensale, e anche rimettervi qualche cosa del mio, acciò che possi far effettuar il parentado con questo giovine. Io non voglio però correre con furia, per star su 'l mio decoro, ma né anche voglio rallentare il negozio molto, acciò che non vadi in nulla.</p>
           </sp>
@@ -4277,128 +4317,128 @@
         <div type="scene">
           <head rend="italic">SCENA QUINTA</head>
           <stage><hi rend="sc">fulvio, pantalone, capitano, spacca</hi>, <hi rend="italic">e</hi><hi rend="sc">scappino</hi></stage>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Se Scappino non mi facea cenno, io gli rovinava qualch'invenzione senza altro; ma chi averebbe potuto tacere vedendo la mia robba intorno ad un furbo? Tuttavia è meglio fare come dice Scappino: vedere, tacere ed aspettare il fine. Ma che persona è quella ch'esce di casa mia con mio padre?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Mi rincresce, signore, che vostra signorìa non abbia accettato l'invito almeno d'un bicchiero di vino.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Signore, io bevo alle volte per la sete naturale, alle volte bevo per gusto, e alle volte per sete di rabbia e colera. Per la sete naturale io bevo vino generoso, per gusto bevo sangue d'animali rapaci per mantenermi la ferocia, e alla rabbia e colera bevo nettare e ambrosia per farmi correggere l'ira. Ma ora non ho niuna di queste seti e però ringrazio vostra signorìa.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>O ecco mio figliuolo. Fulvio, fa' riverenza a questo nostro padrone, questo è figliuolo del signor Salsimuzio Variabelli, tanto nostro amico e padrone.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Io me l'inchino e dedico umilissimo servidore. Levati di mezo tu, forfante.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Férmati, ché egli è creato del signor Capitano.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Mio non è, ch'io non ho famiglia così infama dietro. Io lo stimava un vostro servidore da strapazzo.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Signor no. Lascia qua questi danari, chi t'ha mandato qua tu?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>A valent'uomo, il diavolo non vi vuol mai far tacere, che siate amaladetto!</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Io era venuto qua perché Scappino mi fa far qualche servigio, e mi fa guadagnare qualche cinquina, ed ora pensava di guadagnar un carlino con questo signore.<pb n="473"/></p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Va' via di qua, ch'io voglio persone conosciute a far questi servigi.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>È bene galant'uomo, sì, ve ne potete fidare.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>E come è galant'uomo, s'or ora lo discacciai?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Fate peggio, in buon'ora! Non dite parola, che non fate errore.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Non l'aveva figurato bene prima, ma adesso l'ho conosciuto.</p>
             <p>Or su, signore, con sua buona grazia andrò per un mio servigio verso il mercato, servidore.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Va' pur al mercato, ché nel mezo v'è quella che tu meriti.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Le bacio la mano. È andato via quel furbo?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Signor sì.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>È partito il furbo e 'l pazzo.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Ha fatto bene, io gl'ho quasi dato d'una mano su 'l viso! Ma perché gl'averei gettato i denti di bocca, e, non essendo conosciuto in Napoli, vedendolo le persone con i denti tutti fuori di bocca m'averebbono tolto per un ciarlatano o cavadenti, e perciò mi son pentito.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Se non ceretano, parabolano al certo.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>È stato bene, e per quello, e per vostra signorìa: quello, che potrà masticare per l'avenire, e per vostra signorìa, che starà sicura del suo danaro. Ma questo farà il servizio, che è mio servitore fidato; fidato però in quello ch'io gli consegno, ché del rimanente non mi porrei in rischio di farli sicurtà, per non star in sospetto di fallire.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Pazienza signore, io spero ancora ch'un giorno mi conoscerete.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Starà male per me, perché le cose stanno sempre su 'l peggiorare.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Io gli porterò, ché non fanno ingombro. Del peso poi me ne rido, ch'io son uso a portare le palle d'artiglierìa nelle saccochie.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Gli debbano dunque dire il Capitano Palotta.<pb n="474"/></p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Taci bestia, se vuoi mangiar biscotto! Non hai inteso, dunque, quello ch'egli fa con i schiaffì? Signore, gli do l'arbitrio e del servitore e di me ancora, e s'altro non mi commanda gli farò riverenza e gl'auguro il buon viaggio.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Le bacio la mano. O tu, dove sta Mezzettino?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Qua signore, a questa porta.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Batti un puoco, pichia, o chiama.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Volentieri. Tic, toc.</p>
           </sp>
@@ -4406,83 +4446,83 @@
         <div type="scene">
           <head rend="italic">SCENA SESTA</head>
           <stage><hi rend="sc">mezzettino, capitano</hi>, <hi rend="italic">e</hi><hi rend="sc">scappino</hi></stage>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Chi è là? O siete voi, mi raccomando, o non me la farete fratello.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Perché s'è partito costui? ha forse avuto paura di me?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Di vostra signorìa o di me.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>O là, e che siamo tutt'uni? O mascalzone, guarda chi vuol domesticarsi in far paura a gl'uomini! L'aspetto mio formidabile l'ha spaventato.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>L'astuzie mie singolari l'hanno fatto fuggire.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Passa via di qua.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Ah signore! Ah signore! Parto, parto!</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Guarda chi vuol giostrar meco in bravura! Mi sa male ch'io non ho mirato ben in viso questo briccone per conoscerlo un'altra volta. O là.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Chi è là?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Amici.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Ho inteso, questo è un altro furbo maiuscolo e bizarro, che ha mandato Scappino. Or me ne chiarisco.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Férmati, férmati! A traditore, tirar la barba al fiore de i capitani! Sei morto, fa' testamento, che cosa hai al mondo? A chi la lasci, presto?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Non ha altro che il cànchero e ve ne fa erede voi! O se mi sentisse ora.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>O signore, un salvo condotto, per grazia, per fin tanto ch'io abbia detto la mia ragione.<pb n="475"/></p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Di' sù presto, che non mi passa la colera, ché senza colera non posso far male a niuno.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>E poi la colera anche l'offesa, che non vede a far male a niuno.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Son stato ingannato da certi marioli e oggi n'ho scoperti tre con levar le barbe posticcie, e dubitando che vostra signorìa ne fusse un altro, e per questo gli ho tirato la barba, stimandola anche ella posticcia; ma per quello ch'io vedo, vostra signorìa deve esser galant'uomo.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Sono l'idea de' galant'uomini, il fiore de gl'onorati e la schiuma de i bravi. Questo aspetto dunque ha un minimo neo di furbo? Sciagurato, non so chi mi tenga, ch'io non te ne dii una memoria per sempre!</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Compassione signore, ch'io trovo che gl'uomini sono come li meloni, che molti ingannano non solo alla vista, ma al pelo e all'odorato. Ma chi è vostra signorìa, se si può sapere?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <lg type="nondefinito">
               <l>Son il Capitano Bellorofonte Martellione</l>
@@ -4505,142 +4545,142 @@
               <l>al pesar dell'Oblivione.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <lg type="nondefinito">
               <l>Ma vigliacco e arcipoltrone</l>
               <l>e calamita da bastone.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>O signore, il vostro nome non è per persone di poca memoria, né per quelli c'hanno fretta! Ma che commanda, vostra signorìa, a questo pover'uomo, e che ricerca, un tanto soggetto, da questo vile albergo?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Nell'ostrica v'è la perla preziosa, nelle vene dell'inculta terra vi sta l'argento e l'oro e le gioie, e nel vostro albergo vi è la perla margarita e la preggiata gioia.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>O me felice, sono ricco e non lo sapeva, e dove è questa gioia, caro signore?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Questo pover'uomo s'allegra in credenza.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Quel cielo ch'avete in casa è la gioia.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Qual cielo? Se non è il cielo della mia camera, ch'io l'addimando soffitta, io non ho altro cielo, ch'io sappia.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Che camera! Dico quella deità che fa cielo tutta la<pb n="477"/> casa vostra, quel rassunto di bellezza, quella quarta grazia, quell'epilogo di perfezione, la bella Celia, dico.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>La mia schiava?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Quella.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>E quella è la gioia?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Quello è un tesoro a chi la conosce.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Orsù, confesso d'esser ignorante, non è dunque meraviglia se tanti cercano di levarmela. Cappe, mi volevano levar la gioia, questi manigoldi.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Orsù, questo pover'uomo diventerà pazzo, se pratica niente niente con costui.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Ma come le dite gioia, non è questa donna come l'altre? In casa questa magna bene, beve meglio, e fa altre cose come fanno l'altre. Caro signore, mi imbrogliate col dirmi queste cose, che cosa bramate, in somma, da me?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Che mi date questa schiava, ch'io la voglio menar in Sicilia.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Come, che ve la dia?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Che me la date a me, sì. Eccovi lettere di suo padre ed eccovi qua i danari per lo suo riscatto.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Ohimè, se costui non è pazzo, son io rovinato.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Buono, ma vostra signorìa è informata del suo riscatto?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>So che sono dugento ducati e poi la vostra manza, non è così?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Così è, ma avvertite, signore, che se per sorte foste mandato dal signor Cinzio Fidenzio, o dal signor Fulvio Bisognosi, la compra non vale, ch'io non posso contrattar con essi loro.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Perché, m'avete per sensale, forsi? O corpo de i coturni di Berencie , io comprar per altri, e che direte?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>La tema di non errare m'ha fatto dir questo sproposito, perdonatemi signore.<pb n="478"/></p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Chiamatela, ch'io la consoli con la mia presenza.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Vostra signorìa la conosce, forsi?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>O corpo del trentesimo occhio d'Argo, s'io la conosco! Io son amante d'una sua sorella, qual fu presa seco, col padre e altri, da' Corsari; io son quello che per ricuperarla ha fatto tanta strage de' Turchi. E non volete ch'io la conoschi?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>E perché non la liberaste?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Perché la colera non volse.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Come la colera?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Ve lo dirò, io armai subito un bergantino e li seguitai, ma la rabbia dell'affronto che mi avevano fatto, mi faceva gettar tanti sospiri, ch'il fiato mio gli serviva per vento in popa e così si salvorono.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Buon per loro. Dunque, Celia vi conoscerà?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>O come, se mi conoscerà? Tutti gli uomini del mondo mi conoscono per la fama, tutti i potentati dell'universo per tema, tutt'i soldati per riverenza, e tutte le belle e curiose per i ritratti che sono sparsi di questo gran colosso. O pensa se mi conoscerà, la signora Celia, che m'ha più volte pratticato.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>La fama non ha saputo trovar casa mia, o che s'è scordata, o ch'io son fuor del mondo, poi ch'io non lo conosco; la fama mi ha fatto torto, pazienza. Celia, Celia?</p>
           </sp>
@@ -4648,103 +4688,103 @@
         <div type="scene">
           <head rend="italic">SCENA SETTIMA</head>
           <stage><hi rend="sc">celia, mezzettino, capitano</hi>, <hi rend="italic">e</hi><hi rend="sc">scappino</hi></stage>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Signore.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Guarda un poco se conosci questo gran cavalierazzo.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>O signor Capitano.<pb n="479"/></p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Ben trovata, signora Celia, calamita che ha tirata questa massa ferigna da Sicilia a Napoli.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Per far ch'io vada da Napoli alle forche per disperazione.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>E che nuova ha, vostra signorìa, di mio padre e di mia sorella?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Di vostra sorella non se ne sa nuova, vostro padre è riscosso e non potendomi dar la signora Lavinia per moglie, sì come l'avea promesso, mi ha concesso vostra signorìa in quella vece, e io son venuto a riscuoterla e a ricondurla in Sicilia come mia moglie.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Bona notte e buon anno, io son finito.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>M'allegro di mio padre riscattato, mi dolgo che mia sorella non si trovi, e ho gusto della presenza di vostra signorìa, ma io non sarò il vero oggetto da voi amato, anzi sarò una memoria di quel bello ch'avete impresso nel cuore. E non essendo l'originale, ma copia con mille mancamenti, sarò più materia di sospiri che di respiri, a tale ch'io mi terrò vostra sempre per necessità e non per elezione, e non rimarrò mai consolata per tal rimembranza.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Signora Celia, vostra sorella a quest'ora è forsi collocata nel stellato manto a far quaranta nove imagini celesti, dove come privo di speranza di vederla mai più se non nel Cielo. Ritirerò tutto l'affetto mio in me, e porrollo nel crociuolo del mio cuore, e postolo sopra le scintillanti fiammelle de' vostri bei lumi, e fattone purificata massa, v'impronterò la vostra bella imagine, circondata con caratteri de' vostri meriti, e così, cuniato con la fede, non vi sarà altro che il vostro nobilissimo simulacro, e solo con quello m'adornerò il petto, e viverete sicura.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Ringrazio vostra signorìa. E perché mio padre non è venuto esso a riscuotermi?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Per non s'esporre più a pericolo de i Corsari, né alla balìa de' venti.<pb n="480"/></p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>E s'io di nuovo fossi presa, e ch'io fossi cagione che vostra signorìa perdesse la libertà?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Guardane il Cielo, sarebbe la ruina dell'Europa e la ventura dell'Affrica! Come io fossi cattivo, non darei tre soldi dell'Italia, perché il Maumetano, assicurato di non aver resistenza a' suoi empiti, s'avanzarebbe tanto, che non si vedrebbe altro, ch'il vesilo della luna in questo paese. E, per contrario, vostra signorìa porterebbe gusto a tutte le donne d'Europa e noia a tutte quelle d'Affrica, queste per non aver emule di bellezza, e quelle per sopragiongerle chi l'offuscarebbe la loro bellezza.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Mi piace che vostra signorìa dice le cose da giorno di festa, in lettere maiuscole.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Io non dico delle cento parti una la verità.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Io te lo credo.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Orsù, signore, vostra signorìa si degni di venir ad onorar casa mia. Conteremo i denari e poi vostra signorìa si condurrà la schiava a sua commodità.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Son contento d'onorar casa vostra, e poiché vi ricordate di me, voglio privileggiarvi, voglio che poniate sopra la casa vostra l'arma mia, e che le scriviate sopra: albergo del Capitan Bellorofonte Martellione, accioché ogn'uno ve la rispetti.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>E chi ha d'aver la possa sequestrare.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Vostra signorìa entri.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Tocca a mia moglie.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Vostra signorìa mi perdoni.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Prendetevi per mano ed entrate insieme.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Entrate pur allegramente, ch'io son uno di quelli che stanno di fuori. Orsù, la speranza fin ad ora è stata inferma, ora è moribonda.</p>
           </sp>
@@ -4757,51 +4797,51 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">scappino</hi>
           </stage>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>La mia invenzione mi riuscì tanto male, ch'io ho quasi vergogna a farmi vedere da Mezzettino, e ho rossore del signor Fulvio e di Scappino, che si rideranno di me.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Servitore signor Cinzio, io ho poi fatto pace col signor Fulvio.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Eh, quando ti tolse meco, ti pigliai per modo di provisione e per impiegarti in quel servigio solo, ché del rimanente non t'averei chiesto, sapendo che tu non potevi star senza il signor Fulvio, né d'egli senza di te. L'interesse mio mi fece credere quello che disapassionato non averei creduto; ma tu sai colorir bene le tue cose. Ma che farai con questa schiava? a che serviranno le tue scaltritezze ed i tuoi rigiri?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>A farmi tenere in conto di furbo da Mezzettino, e da un balordo da tutti gl'altri.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>E perché? Sei forsi fuori di speranza d'averla?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Anzi sono sicuro di perderla affatto.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>O questa debb'esser qualch'orditura, overo che con tal modo vuoi assicurare il negozio, però io credo quello che si può credere da te e anche con difficoltà.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Vostra signorìa mi può prestar intiera fede, perché le dirò cosa tale che mi farò creder per forza.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Che cosa v'è di nuovo?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>La schiava non sarà più né vostra né del signor Fulvio, atteso ch'è venuto un Capitan da Sicilia da parte del padre della fanciulla a riscuoterla e menarla al paese come sua moglie.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Ohimè, che cosa sent'io?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>È così, ed ecco che vengono di casa, ritiriamoci, e vostra signorìa s'assicurerà del tutto.</p>
           </sp>
@@ -4810,71 +4850,71 @@
         <div type="scene">
           <head rend="italic">SCENA NONA</head>
           <stage><hi rend="sc">mezzettino, celia, capitano, cinzio</hi>, <hi rend="italic">e</hi><hi rend="sc">scappino</hi></stage>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Figliuola mi raccomando, salutate il signor padre in mio nome, e pregatelo a commandarmi dove potrò servirlo.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Messer Mezzettino, s'io v'ho dato travaglio, perdonatemi, e condannate il tutto alla gioventù. A Dio messer Mezzettino.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>A Dio. Signore, ve la raccomando.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Mi raccommandate le mie cose! È superfluo, fratello, lei è sicura, sì perché ella è con suo marito, quanto che ella si trova con quello che pone in fuga i nemici col nome solo, gl'inferma con la vista bieca, e gl'uccide con la voce colerica. Mi raccomando.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Hù hù hù hù hù.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Che ne dite ora?</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>O caso strano.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>E degno di compassione.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Moglie mia carissima, andiamo al mio navilio, colà sarete regalata da prencipessa, là vi sono i miei creati che v'attendono, e ve ne sono di quelli che voi conoscerete.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Averò gusto di vedere i conoscenti, sì come avrò gusto che vostra signorìa non mi sposi, infino che non siamo dove è mio padre; le starò a canto con nome di moglie e con effetti di sorella.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Andiamo pure, ch'io non vi scompiacerò, perché piangete.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>O Fulvio mio, a Dio, mi scoppia l'anima a non vederti. Signore, mi trema il cuore d'andar per mare.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>E come, signora, tremate? Adunque il mio valore non pone in fuga la vostra tema? Forsi non osa di violentar niuna cosa, che si trova in voi. O gli darò ben io il tema di quello ch'egli dovrà fare. Il mar è in calma, e se sarà turbato<pb n="483"/> non v'imbarcherò, e ritornerò in casa del vostro padrone sin ch'io lo facci quietare, e forsi s'acquietarà al mio comparire. E non crediate ch'io vi dica iperbole, ch'il mare teme la mia fortuna favorevole ne' viaggi; ove penso che non s'adirerà per non rimaner in vergogna, dovendosi poi acquietar per forza. Ah, reserenate il viso, andiamo. S'io troverò una segetta, io vi porrò dentro, ancora che sia puoco il camino.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Ecco, ne mira, saluta e piange.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Ohimè, che m'ha commosso tutto, il Cielo ti dia buon viaggio.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Io la voglio seguitare alla lontana, e vederla ad imbarcar, e poi ve ne darò conto.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Va', ch'io l'avrò caro.</p>
           </sp>
@@ -4884,7 +4924,7 @@
           <stage>
             <hi rend="sc">cinzio</hi>
           </stage>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Come il signor Fulvio sappia che la schiava sia partita, facilmente, per sodisfar il padre, solliciterà le nozze della signora Lavinia ed io rimarrò senza l'una e senza l'altra. E se il signor Beltrame scrive a mio padre la freddezza ch'io ho mostrato nella sua oblazione, mio padre avrà occasione di dolersi di me, onde mi vado consigliando che sarà meglio a non disgustar il padre, l'amico e la giovane, che contro ogni mio merito tanto m'ama, e prima del signor Fulvio prenderla per moglie. E tanto più ch'io potrò dire d'esserne stato pregato dal signor Fulvio istesso. Io voglio vedere se il signor Beltrame è in casa. Tic, toc.</p>
           </sp>
@@ -4897,47 +4937,47 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">cinzio</hi>
           </stage>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Chi è là?</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Amici, il signor Beltram è in casa?</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Signor no, vostra signorìa vuole ch'io gli dica qualche cosa, com'egli torna a casa?</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Mi farà favore a dirgli ch'io lo cercava per quel negozio che gl'ha scritto mio padre.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>La servirò volentieri. Ma vostra signorìa non ha ricevuto i danari?</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Signora sì, ma v'è un'altra particolarità in quella lettera, la quale, se fusse così cara a vostra signorìa come sarebbe a me, rimarrei molto consolato.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Eh, signor Cinzio, il chieder ad un fanciullo se gli piacciano i frutti, o ad una fanciulla se gli sono cari i fiori e i vaghi adornamenti, è quesito superfluo, ma prosupposto sicuro. Dir a me se mi fussero cari i vostri gusti,ohimè, voi mi tentate di pazienza: o che voi defidate del amor mio, o che non sapette che cosa sia amare. Io sono in virtù d'amore così trasformata in voi, ch'io non vorrei poter pensare se non co' vostri pensieri, né respirare se non co' vostri respiri, e stimare somma felicità il potere esser presaga de' vostri gusti, per incontrar e mendicar con ogni possibile occasione per agevolar la strada a' vostri contenti, tanto sono bramosa de' vostri gusti. O vedete se vi è da por dubbio che le vostre gioie non siano i miei contenti.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>O mia signora, e chi non rimarrebbe schiavo a tanta cortesia? e chi non s'accenderebbe a quest'affettuose parole? Veramente, chi può far preda con tutti i sentimenti, non deve temer dello scherno d'un cuor protervo. Feriscono i vostri occhi, innamorano le vostre grazie, rapiscono le vostre leggiadre maniere, incatenano le vostre virtù e assassinano le vostre parole. E chi può resister a tanti e sì potenti campioni? Signora, io mi vi rendo per vinto, e perché non voglio che il tempo mi fuga, e col tempo la gioia, io vado or ora a trovar il vostro signor padre, perché egli mi leghi con indissolubil nodo al carro de' vostri trionfi.<pb n="485"/></p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Voi al carro de' miei trionfi? Eh, vostra signorìa vuol scherzar meco, come tall'ora fanno i cavalieri co' suoi servidori, che gli pongono in cocchio, ed in vece di quelli prendono il carico del cocchiere. Io sarò quella che, mostrando al mondo la grazia che mi viene segnata dalla vostra cortesia, riempirò d'allegrezza tutti i miei amici. Andate pure, ch'io attendendovi spenderò il tempo in contemplare i vostri meriti, accioché questo gusto non mi faccia sentire la noia dell'aspettare, che suol far parer l'ore più longhe del solito.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Io vado, e non rispondo più a' vostri amorosi detti, per non involare a me stesso quel tempo con parole ch'io devo distribuire per vostra consolazione. A Dio, mio bene.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>A Dio, mia unica speme.</p>
           </sp>
@@ -4948,7 +4988,7 @@
             <hi rend="sc">mezzettino</hi>
             <hi rend="italic">con i danari</hi>
           </stage>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Io ho gettato quattro lagrimuccie di tenerezza, ho contato tre volte i soldi, e sono giusti, ho mangiato due bocconi saporiti, e ho bevuto una volta al fiasco, e così ho passato l'ozio. Veramente mi par d'esser perduto a star così solo, non posso stare senza compagnia, io ho gusto di chiachierare, il parlar solo è da pazzo. Io voglio andar da un certo sensale, che mi disse ieri che gl'erano arrivate certe schiave da vendere. Voglio veder se posso impiegare i miei danari in qualche cosa di bello, veramente le più belle sono più vendibili.</p>
           </sp>
@@ -4958,7 +4998,7 @@
           <stage>
             <hi rend="sc">scappino</hi>
           </stage>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Il tempo è cattivo, Celia non si vuol imbarcare, io credo che quando gl'ho mostrato il bolletino della camera<pb n="486"/> locante, che m'abbi inteso; gl'ho detto in isfugendo al fondaco, io penso che l'amor di Fulvio la farà scaltra. Orsù, mi rabufferò i capelli, mi slargherò la barba, mutarò linguagio, mi travestirò, e s'a caso gli nascerà dubio, dirò d'esser fratello di Scappino, e non se n'avederà, ché non m'ha praticato molto. Orsù, il bolettino sta bene.</p>
           </sp>
@@ -4970,31 +5010,31 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">capitano</hi>
           </stage>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Signore, m'avereste fatto morire il cuore ad imbarcarmi con quel mare così procelloso! Ohimè, come freme e strepita.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Hà hà hà, mi fate ridere! Sapete che vuol dir quel rumore?</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Io no.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Quella è l'allegrezza che mostra il mare della vostra presenza, quella è una salva ch'egli faceva al vostro imbarco, ma voi non l'avete gradita.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Io non so di salva per me, io credo che sia una salva che dica salvate, e felice chi può salvarsi dal empito suo. Io pormi in quel mare così tempestoso? fra quei monti di quel'onde? Il Cielo me ne liberi!</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Quei monti erano machine da tornei fatti per voi, e non avete posto cura come per riverenza si umiliavano a' vostri piedi, e quasi riverenti volevano bacciarvi il lembo delle veste?</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>No no, manco ossequii che mi farà, e manco salve! Io l'averò più caro.</p>
           </sp>
@@ -5007,109 +5047,109 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">celia</hi>
           </stage>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Hem.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Andiamo dunque dal vostro mercante a riposarsi un poco.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Ho inteso, Scappino. Signor Capitano, io averei caro d'andar in ogn'altro luogo a riposarmi, ch'in quello di messer Mezzettino.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>E perché?</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Perché, vedendomi in quella casa, mi parrebbe d'esser tornata schiava e non mi potrei mai rallegrare.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Io non vi vorrei condur troppo discosto dal molo, per non vi condur così per istrada senza servitù. Se vi fosse qualche alloggiamento buono per questi contorni, io vi compiacerei volontieri.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Eccone costì uno, là vi soleva già star un forastiero molto onorato, per quello ch'io intendeva, non so se vi dimora più. Eh, ogni alloggiamento è buono per puoco tempo, né più né meno vostra signorìa non è conosciuto.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Io non vorrei degradare della mia condizione, né vorrei darmi a conoscere di vista a niun prencipe, per non aver da dimorar qua un mese in accettare e rendere le visite. Se si sapesse ch'io son in Napoli, io avrei più popolo intorno alla casa, che non ha il Vici Re, quando fa l'entrata.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>E bene, in luogo picciolo, vostra signorìa sarà manco conosciuto.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Io pichierò dunque a questo. O là.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Chi è?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Son io, averesti alloggiamento per questa giovine e per me?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Allogiamento vi è, ma non per un par di vostra signorìa; ad un par suo vi vorebbe il Castello dell'Ovo o la<pb n="488"/> Vicarìa, e a pena sarebbono stanze proporzionate, tuttavia se si compiace d'onorar questo vil tugurio, io gli lo offerisco.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Buono buono, questa tua umiltà mi farà accettar ogni picciol albergo. Pur che vi sia un camerino per questa giovine, io mi contento.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>O povera signora, il Ciel vi dia pazienza.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Perché dite così?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Eh signore, io stimo che questa debb'esser qualche principessa che vostra signorìa ha fatta schiava.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Al corpo di quel occhio sgangarato di Polifemo, che costui mi conosce! O buon compagno, per chi m'hai tu pigliato? ove mi conosci tu?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Io non conosco vostra signorìa, ma l'aspetto suo mi dà da credere che sia persona di commando e al moto de gl'occhi, che quasi mi spaventano, lo stimo per l'estratto di formidabili.</p>
             <p>Bisogna gonfiarla per prenderlo, costui! Manco male che non mi conosce.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Tu sei un grand'uomo, bisogna che tu abbi buona astrologia.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>O spionerìa.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Che dici?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Un puoco di fisonomia, ma per prattica, non di scienza.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Molte volte la prattica val più della scienza. Orsù signora, entriamo qua.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Entriamo.</p>
             <p>Manco male che non ti conosce.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Ma mi vado coprendo con la mano più che sia possibile, or tirando il mostaccio, e or fregandomi gli occhi.</p>
           </sp>
@@ -5122,103 +5162,103 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">capitano</hi>
           </stage>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Scappino non comparisce e io senza di lui son morto, non oso di parlar con alcuno, poich'il demonio per farmi disperare non vuole ch'io possa ragionare con alcuno, che non mi faccia danno. O là, ond'esse costui?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Il sito è commodo, ma è mal addobato. Mi dice che ha altre camere e che mi farà aver la chiave fra due ore. In nome del Cielo!</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Servidor, signor Capitano.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>O schiavo, padron mio, non è vostra signorìa il figliuolo del signor Pantalone?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Signor sì, per servirla.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Mi perdoni, non l'ho veduto se non quel puoco, e l'ho conosciuto all'abito.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>E non è meraviglia in un forestiere. Ho caro che vostra signorìa si sia degnata di rimaner con noi, questa sera.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>L'inquietezza del mare m'ha fatto rimanere e ritirar qua, a questo povero albergo, per questa notte. Di grazia, vostra signorìa faci scusa con il suo signor padre, se non ho accetat'il suo albergo.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Il nostro ancor questo, ma è un fondaco dove teniamo delle robbe che ingombrano la casa. Ma che vedo io, un bolletino di camera locante.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Non è camera locante questa?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Or quest'è l'imbroglio, debbo dire di sì o di no? Ohimè mi trema il cuore per tema di non guastar qualche cosa.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Vostra signorìa si consiglia a rispondermi, voi mi ponete in sospetto, perché in Napoli si fanno delle pazze burle, per quello ch'io ho inteso da molti.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Vostra signorìa non si turbi, perché sto in dubio che questo bollettino no'l abbi posto un mio servitore per qualche invenzione.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Che invenzione?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Eh, dirò a vostra signorìa: io son inamorato d'una schiava nomata Celia e non ho danari per riscuoterla, ed ho<pb n="490"/> proibizione dal padre di non la guardare manco, e un mio fidelissimo servidore cerca ogni modo di farmela capitar nelle mani, e forse questa dev'essere qualch'invenzione per farmela avere. Caro patron mio, vostra signorìa mi favorisca di secondar la cosa, occorrendo, ch'io ve ne resterò con obligo.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Volontieri, anzi ch'io v'aiuterò occorrendo.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Buon buono, o siate benedetto.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Tic toc.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Chi è là?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Amici, io voglio entrar in casa.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Ohimè, Fulvio è qua, l'invenzione è rovinata, hà.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>No no, Scappino, scuopreti pure, ché siamo d'accordo io e questo signore.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Siate benedetto, orsù vado.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Siate dunque accordati, o sia lodato il Cielo, sono pur fuori di fastidio!</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Sì sì, il mio caro Scappino, questo Capitano mi vuole aiutare.</p>
           </sp>
@@ -5230,123 +5270,123 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">scappino</hi>
           </stage>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Signor Fulvio, vi ringrazio dell'aviso, mi raccomando.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Signor Fulvio, a Dio. A Dio, mio Fulvio.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Scappino?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Signor Fulvio?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Che cosa è questa?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Che cosa è questa? Non lo sapete voi, non dite che siete accordato con quel signore?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>E come, Celia era colà dentro?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>O quest'è un'altra, e ch'accordo è stato il vostro?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>O misero me.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Che cosa avete? di che vi dolete?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Ahimè, che non sapendo che costui avesse Celia, io gl'ho raccontato l'amor ch'io porto a Celia, e gl'ho detto le tue trame e gl'ho chiesto aiuto ed egli me l'ha promesso.<pb n="491"/></p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Sì? O posso dunque levar il bolletino dalla porta e porlo sopra la fronte vostra, poiché il vostro capo potrà servire per camera locante, ch'il cervello ha sgombrato la stanza! E forsi ch'io non l'avevo condotto fino a casa? E quando più la credevo perduta, e forsi ch'io non avea pensato di trabalzarla subito, che quel Capitano voltava le spalle in luogo lontano, con pericolo della giustizia e dell'ira di quell'uomo furibondo? Orsù, voi non siete degno di questa giovane, la fortuna non ve la vuol concedere e io non mi voglio più romper il cervello, né tener voi in isperanza dell'aiuto mio. E per levar le cause, io mi voglio partir anche da voi.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Ah Scappino mio.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Che mio? A rivederci.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>O questo no, io non mi spicherò mai da te.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Lasciatemi.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Questo no, mai.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Lasciatemi, dico, non avete vergogna?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Non ho né vergogna, né sorte, né cervello.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Dico che mi lasciate, ch'io voglio andar da certi miei amici.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Io voglio venir teco, e va' ove ti piace.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Io voglio andar a giuocare per farmi passar la colera.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Venirò anch'io, ch'io non ho men colera di te.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Voglio fugir via da questa città.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Ed io voglio far lo stesso.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Voglio andarmi a precipitare di disperazione.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Venirò ancor io a pianger l'amaro tuo caso.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>E non a precipitarvi ancor voi?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Eh fratello, basta d'uno.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>O come basta de uno, andatevi dunque voi solo!</p>
           </sp>
@@ -5361,7 +5401,7 @@
             <hi rend="sc">fulvio</hi>
             <hi rend="italic">solo</hi>
           </stage>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>O Fortuna, frena quell'ira ormai, che senza ritegno fai scorrere sopra di me, o mitiga il rigore de' suoi maligni influssi, che tanto mi tormentano, o cessa di scherzar meco, se pure sono scherzi, quelli che tanto m'affliggono! Qual mio demerto t'abbia irritata io non lo so, qual rigore mi sovrasta tu ben lo sai ed io lo provo; ma, se pure questi sono tuoi scherzi, ahi che toccano troppo al vivo! Ferma, ferma, ti prego, e mira a che termine son ridotto. Io sono in disgrazia del padre, di puoca stima al suocero, in derisione col Capitano, in conto di pazzo a Mezzettino, in punto di perder Celia, ed in somma sono la favola della città, e quello ch'è peggio, io sono in odio a Scappino, qual mi fugge ed ha raggione. Cessa, cessa, scapigliata dea, di tormentarmi, te ne priego! Ma chi priegh'io? Una sorda, una cieca, una più inesorabile della morte! Ma ecco Scappino. O se la mia ventura volesse ch'egli avesse digerito quella colera concetta contro di me, quanto mi stimarei felice, io sperarei ancor qualche soccorso.</p>
           </sp>
@@ -5374,47 +5414,47 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">fulvio</hi>
           </stage>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Quel Capitanio va girando dal molo picciolo al grande e non sa ove dar di capo per alloggiar questa notte, e non vuol lasciar d'occhio quella schiava, io credo che l'ambizione d'aver questa bella schiava seco lo facci passeggiar volentieri per mendicar sberetate.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>A Dio, il mio dolcissimo Scappino.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>A Dio, il mio amarissimo signor Fulvio.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Tanto amaro, in vero, e tanto scuro, ch'io non ho più gusto di cosa alcuna al mondo e non posso veder più raggio di contentezza.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Ed io pure tant'amaro c'ho perduto il gusto di servirvi, e tanto scuro c'ho l'ingegno adombrato in modo, che non so più che mi fare per far bene.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Tu hai ragione, ma so ben anche che tu conosci che queste inavertenze mie non sono artificiose; ma che sono effetti di quelle seconde cause inclinatrici di così esorbitanti effetti, influssi prodotti da quelle motrici cagioni a noi nascoste perch'io viva sempre con qualche mortificazione. Ma delle mie disgrazie tu ne hai solo il disgusto e io infelice che ne ho il disgusto e 'l danno congionti d'un rossore di vergogna, con un battimento di cuore più di disgustar te, che di qual si voglia altra persona concernente a questo negozio. O Scappino, pietà, pietà ti prego, quel Capitano ancor non è partito, ancor vi è tempo di far qualche profitto! O se tu vinci questa mia costellazione, sarai chiamato un superatore de' maligni influssi, un dominatore de gl'effetti delle stelle, il schernitore del mio maligno ascendente, in somma il mio desiderato triangolo.<pb n="494"/></p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Piano con questi triangoli e questi ascendenti, ché se un ascendente mi fa discendere da un triangolo, io sono rovinato.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Eh tu non m'intendi.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Io v'intendo per discrezione, so che mi sollevate tanto al cielo, che mi fate venir le vertigini. Mi avete posto in capo tant'albagìa, a dirmi che s'io supero queste vostre disgrazie ch'io sarò chiamato la sponga che fuga i cattivi umori alle stelle, e l'acqua forte che rode i maligni influssi alle persone, che mi fate tornar la voglia di seguitar l'impresa per farmi cronicare per uno che contrasta con le stelle o che abbaia alla luna! Andate un poco in buon'ora, e lasciatemi far i miei castelli in aria a mio modo.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Io vado, o me felice.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Si tien di già felice ed io non ho ancora trovato il modo d'aiutarlo. Al corpo di me, che mi nasce un'invenzione, e questa potrìa riuscire; caso che no, galera aspettami. Ed ecco costui che pare ch'abbia poca voglia di far bene, lo voglio far scorrere la mia sorte.</p>
           </sp>
@@ -5426,79 +5466,79 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">scappino</hi>
           </stage>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Che diavolo di disgraziato è quel tuo padrone? Come puoi mai alzar fabrica alcuna, se quanto tu sai fare egli disfa? In vero che mi vien colera da tua parte, tu sei più disgraziato che i ragni delle case polite, ch'a pena tirano le fila delle loro reti, che la fantesca gli dà della scopa dentro. Io, ti dico la verità, non avrei tanta pazienza per certo.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Veramente è un gran sopportare! Ma alle volte si vede due che giuocano e uno s'affezionerà ad una parte, in modo che sente disgusto quando l'altro vince. O pensa, poi, quan<pb n="495"/>do v'è interesse! Questo giovine è allevato, si può dire, da me e mio padrone, mi vuol bene. E poi io nelle mie cose sono un poco perfidioso, e non vorrei lasciar quest'opera imperfetta, a tal ch'io ho gusto ne l'opera, e colera a non poterla mandar a fine, e se bene ora è quasi cura disperata, tuttavia io mi picco di furbo straordinario, e vorrei riuscirne con onore.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>O bello, riuscir con onore! Come se le mariolarie fussero cose onorate.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>E perché? Anche le stratagemme militari sono mariolarie, e pur sono onorate e beato colui che sa trapolare l'aversario. E chi può acquistar con stratagemma ha più lode che a sparger sangue.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Aiutiamolo dunque, e forniamola senza tante retoriche.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Orsù aiutiamolo. Vien qua tu, ti basterebbe l'animo? Dubito di no.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>A far che? Cosa è, tant'importante che tu ti difide di me?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Cosa a te grandissima e dubito assai.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Che cosa sarà mai? Ho forsi d'andar a levar il tulpante al gran Turco?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>E non è questo. È ch'io ho dubbio, perché vorrei che tu facessi una cosa contra al uso tuo.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>O t'intendo, tu vorresti ch'io facessi qualch'opera buona.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Anzi no.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>E tu ti difidi dunque, o balordo, o che non mi conosci bene, o che la cosa deve eccedere il mio potere.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Io te la dirò per levarti di sospetto. Vi è un mercante amico mio che ha certe medaglie d'oro e d'argento, io me le vorrei far prestare e porle in una borsa con un poco di moneta e poi vorrei che tu la ponessi nascostamente adosso di quel Capitanio che ha menato via la schiava. Quest'è la diffidenza mia, che tu sei uso a levar le borse e non a porle adosso alle persone. Ch'io poi, con qualche scusa mi trovarei subito con la Corte in quel luoco e vorrei che tu gridassi, fingendo d'esser stato assassinato da colui e dandogli i<pb n="496"/> contrasegni delle medaglie, facessimo andar carcerato quel Capitanio tanto ch'io gli trafugassi la schiava. Che dici? ti basta l'animo?</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Veramente, mi pare difficile il por borse adosso de gl'altri. Se fusse vuota, pur pur io son uso a gettarle o porle adosso a chi trovo commodo, ma con danari non ho mai provato. Ma se al menare prigione colui, mi conducessero me ancora, per sapere chi mi ha dato quelle medaglie?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Di' che sono mie e ch'io te le mandava ad impegnare, ma non ti meneranno carcerato tu, perché si prende il reo e non l'accusatore.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Hai bel dire tu, io ti dico che tresco mal volontieri con la giustizia, io vorrei più tosto sette misericordie ch'una mezza giustizia.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>E da quant'in qua hai tema della giustizia? Se hai questo timore ti converrà mutar vita e sarebbe ben tempo. Orsù, questa non è cosa che possa portar molto pericolo, vien meco.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Non v'è niuno che m'abbia da far romper il collo, se non se' tu.</p>
           </sp>
@@ -5510,136 +5550,136 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">lavinia</hi>
           </stage>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Ho caro che vostra signorìa abbia fatto questa resoluzione, perché fa cosa grata al suo signor padre e di gusto a me. Quanto poi alla parola data al signor Fulvio, la posso ritrattar quando voglio con mio onore.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Ho caro di compiacer mio padre e vostra signorìa e di non pregiudicar niuno, e se a vostra signorìa paresse bene ch'io toccassi la mano alla sposa adesso, io l'avrei a caro.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>E io ho gusto della vostra sodisfazione. Vostra signorìa mi farà grazia di non lasciarsi vedere così subito da mia figliuola, perché la voglio esaminar un poco, e intender come ella condescende a questo parentado.<pb n="497"/></p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Volontieri, so ben io che non le può dar più grata nuova di questa.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>O là, Lavinia.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Questa è la voce del signor padre.</p>
             <p>Che mi commandate signor padre?</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Figliuola, il signor Fulvio non può concluder le nozze così presto e io non vorrei star con questa aspettativa.Io sono quasi di parere, quando a te non fusse discaro, di trovar qualche altro partito, che te ne pare?</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>A me par bene, e, per dirvi la verità, io non ho molto gusto di questo matrimonio; tutta via voi siete padrone.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Se non fusse per alienarti da Napoli, quasi quasi che ti darei ad un forastiero, ma dubito che non lasciareste volontieri questa bella città e che non avreste gusto d'allontanarti da me.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Veramente mi sarebbe strano e l'uno e l'altro; se bene ch'il mutar paese è un goder di quelle delizie che ne concede il Cielo, c'ha fatto così bel mondo, e mi stupisco di tanti che potendo far di meno, come si ristringono in un picciol angolo, come se fussero sequestrati in quelle parti. Il lasciar il padre, poi, quest'è costume delle figliuole, che prendono marito, che o poco o assai si dilungano dalle case paterne, anzi che molti padri vorrebbono le figliuole lontane dalle case loro, per levarsi di sospetto ch'elle furtivamente non soccorressero i mali mariti.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Tu dici bene, a tal ch'io posso trovar altro marito, e occorrendo, anche un forestiero, non è vero?</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Signor sì.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>E se ti levassi da Napoli?</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Che importa, tutt'il mondo è paese.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>A dirti il vero, mi è venuto un partito d'un studente, che mi par assai buono.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Buono, ho caro d'esser in mano d'un letterato.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Quest'è un giovine acquilano.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Acquilano? E che, mi volete mandar a cogliere zafarano? <pb n="498"/></p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Ti voglio mandar ad udir testi, paragrafi, e digesti, e non coglier zafarano.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>O mandarmi in quei paesi cotanto freddi, patirò troppo! E perché non mi date un beneventano, ché ve ne sono qua che mi pigliarebbono per moglie, ed è patria vicina a Napoli, aria buona; e forsi vostra signorìa potrebbe venir anche ella colà ad abitare, per star appresso al suo sangue.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Il Cielo me ne liberi d'andar a Benevento.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>E perché?</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Perché, com'uno vuole augurar male ad un mercante, gli dice: va', che possi andar a Benevento.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>E a che proposito? Non è quella una patria nobile, abondante di viveri e amica de' forastieri? Io ne ho sempre udito dir bene e non so perché si proverbia a questo modo.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Ti dirò che non vi è città, di potentato diverso da questo di Napoli, più vicino a Benevento, e com'uno falisse, o è in contumacia della Corte, va collà e perciò si dice così.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Il Cielo vi liberi da tali accidenti, ma diceva io...</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Taci taci, ch'io t'ho inteso senza che parli, tu vuoi dire che ti piace il signor Cinzio.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>He.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Che dici? Tu non parli, tu ridi, ah fraschetta! Signor Cinzio?</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Signore.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Ho parlato con mia figliuola, la quale mostra di gradir più il vostro parentado che quello del signor Fulvio.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Io gliene resto obligatissimo, e le farò quella buona compagnia che i suoi meriti richiedono.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Denudate dunque la mano, ch'io vi congiongo.</p>
           </sp>
@@ -5652,71 +5692,71 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">lavinia</hi>
           </stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Olà, che cosa è questa?</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Un matrimonio, il Cielo vi feliciti.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Rompo, spezzo e annichilo questo parentado.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>E io cuso, ripezzo, e taccono il matrimonio.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>O là, signor Beltrame, a che giuoco giuochiamo?</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>A Pichetto, che la bocca giuoca.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Se la bocca giuoca, questa giovane è di mio figliuolo, ché così voi gline avete dato parola.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>È vero, ma quand'uno ha scartato, non può più ripigliar le carte e far giuoco con quelle. Vostro figliuolo m'ha detto che non la vuole, e con qualche mio rossore, ed io non sto seco, e se si fosse mutato d'umore, io non voglio far un matrimonio con un capriccioso e sprezzatore del mio parentado.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Signor Pantalone, io v'assicuro che vostro figliuolo non vuol quella giovane e di già ha cedute le sue pretensioni a me.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Vostra signorìa è parte, e non sono tenuto a crederli. Che mi facciano piacere, che andiamo di compagnia a trovar mio figliuolo, accioch'egli non trovi scuse, che l'avrebbe presa, se bene in quel ponto mostrò renitenza, e che se ne dolesse poi di me e del signor Beltrame doppo il fatto, ma così si chiariremo, e io avrò sodisfazione di rimproverar io lui e non egli me.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Per vostra sodisfazione, io son contento.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>E io contentissimo.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>E io disgustatissima.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Vostra signorìa non si pigli pensiero, ché so quello ch'io dico, il signor Fulvio mira altrove.<pb n="500"/></p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Che miri pur dov'egli vuole, pur che non mira me, e quando poi anche suo padre tanto lo persuadesse a condescender a questo parentado, saprò persuader anch'io il mio a non lo consentire.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Ritornaremo presto.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Non può esser sì presto, ch'a me non paia molto tardo.</p>
           </sp>
@@ -5728,127 +5768,127 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">corte</hi>
           </stage>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Signora, quelli allogiamenti non sono da farne capitale, vi è troppo la gran confusione di gente e donnaccie di poca onestà. Io vi lodarei a dimorar, per una notte, in casa di quel vostro mercadante. Già esso non ha altra persona in casa, per quant'ho veduto, e voi mi dite che v'onorava e vi serviva con amore, dove volete star meglio? Ora non starete come schiava, ma come padrona, io comprerò da cena per tutti e manderò per uno de' miei creati alla barca, che venga a servirvi, e staremo allegri, ed in questo mentre venirà buon tempo, ch'io so ch'il tempo non se la vorrà poi tôr meco alla disperata.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Signore, starò dove gli è in piacere, e anche che mi paresse d'essere ritornata schiava, vedendo vostra signorìa mi parerà d'esser riscossa, e anderò col pensiero felicitandomi da me, con pormi a memoria il signor padre, i parenti, la patria.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Buono, buono, per certo.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Vedo Scappino con la Corte, ora è tempo. Ohimè meschino, o sconsolato me!</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Eccolo, è quel meschino che piange collà, io non voglio lasciarmi vedere per non parere ch'io abbi fatto la spia.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Aiuto, aiuto, ohimè.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Che sì, che l'ombra mia avrà fatto dispiacere a costui, per non star in darno? Che hai, pover'uomo?<pb n="501"/></p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>Che cosa è buon compagno, perché piangi e ti lamenti?</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>A signori, giustizia, giustizia.</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>Che cosa è?</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Mi è stata rubbata una borsa rossa con tre medagliette antiche, effigiate d'imperadori dentro, una d'oro e due d'argento, una mezza patacca, un carlino da vint'uno e quattro tornesi.</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>Chi ti è stato appresso, lo sapresti, per sorte?</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Signor sì, non m'è stato vicino niun'altro se non questo signore, qual mi ha dato due volte delli urtoni, e io, per tema e riverenza dell'aspetto suo, gli guardava la faccia e l'abito, e non gli ho guardato alle mani.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Che dici, manigoldo?</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Dico che giurarei che vostra signorìa mi ha tolto la borsa.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>O vigliacco! Signora, scostatevi un poco da costoro. E tu, furfante!</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>Piano signore, ché la giustizia vuol il suo loco.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Tenetelo, signore, ché non mi dia.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>O Cielo, per non pagare quelli che l'hanno da sepelire, mi vuol spuorcare a dargli un pugno sopra il capo che l'uccida e sepelisca a un tratto! Ma non ti voglio far quest'onore, non voglio che si scriva ne' miei annali queste bagatele. Ma non ho io veduto costui un'altra volta?</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>So anch'io che mi avete veduto, quando voleva far pesar le medaglie da quel orefice.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Ah sciagurato!</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>Fermatevi, da parte del signor Regente della Vicarìa.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Mi fermo.</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>Cercalì adosso tu. Con licenza, signore, la giustizia commanda così. Se non sarà vero ch'abbiate questo furto, prenderemo carcerato costui.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Son contento, se ben ch'io non son uso ad obedire se non a generalissimi di terra e di mare, ma per non aver briga di mostrarvi tutti i miei privilegii e patenti, mi fermo e vi lascio far l'officio vostro, cercate pure.</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>Guarda nell'altra sacoccia.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Manco male che qua non vi si trovano prìncipi, né gran personaggi che mi vedono o conoscono, ché del resto io<pb n="502"/> sarei svergognato.</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>Questa è una borsa rossa?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Che cosa ved'io, ohimè?</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>Queste sono le tre medaglie e quest'è la moneta, che costui ha detto.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>O fortuna, quest'è un affronto, che mi fa fare il conte Palatino, perché gli ho fatto perder lo Stato! Ma me la pagherà.</p>
           </sp>
@@ -5858,128 +5898,128 @@
           <stage>
             <hi rend="sc">fulvio, corte, capitano, spacca, scappino, celia</hi>
           </stage>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Che cosa è questa? I birri prendono il Capitano? O là, che fate voi?</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>L'officio nostro. Signore, bisogna venir carcerato.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Menàtelo prigione, ch'io v'aspetto alle carceri.</p>
             <p>Ho veduto Fulvio, non voglio esser veduto da lui, accioché, parlando con la Corte, non s'accorga dell'inganno e lo guasta.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Io prigione? io carcerato? Levatemi d'intorno, vil canaglia, se non ch'io vi fracasso tutti.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Fermatevi, vi prego. Che cosa è, signor Capitano?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Signore, costoro m'hanno trovato una borsa adosso, qual non è mia, e dicono ch'io l'ho rubbata. Per cortesia, vostra signorìa non mi lasci far affronto da costoro, ch'io sarei poi in obligo di truccidargli, e far porre Napoli sosopra.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Dove è la borsa?</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>Eccola.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>A chi è stata rubbata?<pb n="503"/></p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>Ad uno ch'è ito or ora alla Vicarìa.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Conoscete voi me?</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>Vostra signorìa è figliuolo di quel mercante veneziano che sta qua.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>È vero, e io faccio sicurtà per questo signore, per quanto vagliono sette borse. Questo c'ha dato questa denonzia è qualche mariuolo che vuol travagliar questo cavagliere. Questo signor è un amico di mio padre venuto oggi di Sicilia, e ha portato una poliza di trecento ducati, e mio padre a lui gli ha sborsati. O vedete se questo ha bisogno di questa borsa!</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Io non rubbarei, s'io non rubbassi qualche Stato, o, per capriccio, qualche naviglio, che sono furti illustri. Informatevi fuori di questa città chi son io, ché qua non sono conosciuto se non per fama, e poi parlatemi.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Io venirò domani alla Vicarìa all'ora di Corte, se bisogna. Togliete qua questi tre carlini e andate a bere per amor mio.</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>Ma se colui si duole della borsa?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Io gliela restituirò. Chi è costui, lo conoscete?</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>Mi pare un certo Spacca Strombolo.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>È un mariolo al sicuro.</p>
           </sp>
-          <sp>
+          <sp who="#corte">
             <speaker><emph rend="sc">corte</emph>.</speaker>
             <p>Orsù, vostra signorìa comparisca dunque domani alla Vicarìa.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Sì sì, figliuolo, a Dio.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Quest'altra ancora, ah traditore?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Ohimè, che cosa ho fatto io?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Non vedete ch'il Capitano ha la schiava seco? Io ho fatto che Spacca gli ponga la borsa adosso per farlo andar carcerato, accioch'io potessi menar via la schiava. Assassino di voi stesso, a questo modo, ah!</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>O Scappino, va' pur, che hai mille raggioni, io non son degno di questa giovane, né del tuo aiuto. Ferma, ché hai fatto troppo. A Dio, signor Capitano. A Dio, Scappino. Il mondo è finito per me.<pb n="504"/></p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Che cosa ha il signor Fulvio, che si duole? È forsi per l'affronto che m'hanno fatto quei forfanti cercandomi adosso? Non occorre, poi ch'io l'ho passato sotto silenzio, per non far una delle mie, e por sotto sopra questa città, e dar occasione d'esser conosciuto, atteso ch'io voglio star incognito.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Vostra signorìa fa bene a tener le azioni sue incognite, ma il signor Fulvio è arabbiato d'altro negozio. Il poverino, per far bene ad altri, ha fatto male a sé stesso.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>E che male ha il signor Fulvio? Ohimè, signore, egli è il più garbato giovine del mondo!</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Che non vi scappasse di dire il più sapiente o il più trincato, ché cadereste in stima di poch'ingegno ancor voi.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Perché?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Perché lo trovo tanto simpliciaccio ne gl'affari del mondo, che mi darebbe prima l'animo d'imparare di chitarra ad una scimia, che di far capire una lezione di mariolaria a lui.</p>
           </sp>
@@ -5991,120 +6031,120 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">scappino</hi>
           </stage>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Io son uso a tener schiave, non vi dubitate, e non guardate a questo abito fatto all'antica, ch'io lo porto per modo di provisione, e poi io ho ordine dalla mia borsa d'andarvi sino a suo aviso, ma ne ho tre o quattro nella mia mente, che non sono ingrati.</p>
           </sp>
-          <sp>
+          <sp who="#laudomia">
             <speaker><emph rend="sc">laudomia</emph>.</speaker>
             <p>E, signore, non mirava l'abito, guardava al viso, per veder se mi può far scemar la reputazione e darmi tarra.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>E che sì, che mi bisognerà prender un bel mostaccio a nolo, o mostrarle i testimonii, ch'io son galant'uomo!</p>
             <p>O eccovi qua un'altra schiava, che è stata mia più di due mesi, ella v'informerà s'io son uomo da bene o no.</p>
           </sp>
-          <sp>
+          <sp who="#laudomia">
             <speaker><emph rend="sc">laudomia</emph>.</speaker>
             <p>Ohimè che ved'io, mia sorella?</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Laudomia?<pb n="505"/></p>
           </sp>
-          <sp>
+          <sp who="#laudomia">
             <speaker><emph rend="sc">laudomia</emph>.</speaker>
             <p>Celia?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Signora Laudomia?</p>
           </sp>
-          <sp>
+          <sp who="#laudomia">
             <speaker><emph rend="sc">laudomia</emph>.</speaker>
             <p>Consorte caro?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>O anima mia, o mio recuperato tesoro.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>O mia recuperata speranza, e che sento?</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>O signore, non mi stazonate la mia mercanzìa, e che cerimonie sono queste?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>0 galant'uomo?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Per modo di dire.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Quest'è mia moglie in parola, e non sapendosi nuova, stimassimo ch'ella fosse stata eletta regina di Persia, o prima sultana. E come, privo di speranza di rivederla più, avendo suo padre nuova della signora Celia, me la diede in vece di quella per moglie, e così sono venuto a Napoli a riscuoterla, ma in vero quest'è la mia legitima moglie. Signora Celia, perdonatemi, io non posso mancar alla prima.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Signore, io ho triplicato gusto: d'aver trovato la sorella, quando manco sperava; di consolar vostra signorìa, e di non esser vostra consorte, avendo i miei pensieri rivolti in altr'oggetto. E s'io condescendeva al partirmi di qua, era solo per esser libera, e veder mio padre, e chiederli grazia d'aver un giovine di Napoli, e però pregai vostra signorìa a non mi sposare sino ch'io non fossi dal padre.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Ho caro che restiate consolata, e s'io posso adoperarmi in vostro servizio avanti di partire, vi supplico ad impiegarmi, ch'io vi servirò di cuore.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Signore, tra le magnanime imprese ch'avete fatto, se ne vorrete por una segnalata ne i vostri annali, che trapasserà le altre, ora si vi appresenta l'occasione.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>E qual è quest'impresa che mi germoglia innavedutamente nelle mani?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Il signor Fulvio ama senza termine la signora Celia, e vostra signorìa non può prender due mogli. Io vorrei chieder grazia a vostra signorìa, per quanto amore portate a quest'altra giovane, e per quelle inaudite prove che si debbano raccontar di vostra signorìa per tutt'il mondo, ch'io non le dico perché non le so, fate ch'il signor Fulvio abbi questa giovane, ché vi sarà pagato il riscatto e lo tornerete da morte a vita.<pb n="506"/></p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>O se vostra signorìa fa questa grazia a questo giovane, io mi voglio constituire tant'obligata alla sua generosità, ch'io non vorrò mai più obligarmi a niun'altra cosa, per non scemar questo, ch'ora le prometto di conservar con tutta la pienezza del mio potere.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>In giorno di tante allegrezze mi vengono chieste grazie di sì poco momento? Ma che dico, questa non è grazia, è obligo mio, ch'io son tenuto a servire le belle dame, e tanto più questa, che è mia illustrissima parente.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>E viva il signor Capitano!</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>E viva il signor Capitano, anche per mio conto, doppo però ch'io avrò avuto il mio danaro del riscatto e qualche manza.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Ringrazio vostra signorìa e messer Mezzettino, cagione ch'io veda mia sorella e ch'io abbia tanto contento.</p>
           </sp>
-          <sp>
+          <sp who="#laudomia">
             <speaker><emph rend="sc">laudomia</emph>.</speaker>
             <p>Sia benedetto messer Mezzettino.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Però queste carezze non vanno già a conto della manza, no?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Messer no.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>No no, il mio Mezzettino.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Ho quasi invidia di quelle carezze! O vedi fortuna, colui è applaudito, che ha operato a caso, e di me non si parla. Orsù, mi lauderò da mia posta. Viva Scappino! Sia benedetto Scappino!</p>
           </sp>
@@ -6116,67 +6156,67 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">mezzettino</hi>
           </stage>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Io voglio chiedere la benedizione di mio padre e poi andarmene tanto lontano, che niuno de' miei parenti sappia dove mi sia.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Signor Fulvio.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Signor Fulvio.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Ohimè, senz'altro ho fatto errore a comparir qua, avrò rovinato qualche cosa, anche non parlando. O stelle avverse, voglio partire.<pb n="507"/></p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Signor Fulvio, venite qua.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Ah no signora, ché pur troppo ho fatto errore sin adesso, me ne vado.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>E perché fugge egli?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Per non mancare alle solite balordarie! Questo non sa far bene, manco quando il bene gli salta adosso per forza.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Che cosa ha quel giovine, che quasi profugo s'invola da gl'amici, e chiude l'orecchie alla sonora voce di questa bellissima dama?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>L'esser avezzo a far male fa ch'il bene li disordina ed ha l'ingegno avviluppato ne i dubbii, in modo ch'ormai non sa discerner il bene dal male, e non sa ove girarsi per far cosa buona. Per questo giovine io ho posto l'onore, la libertà, il cervello, alla sbaraglia, io fui quello della camera locante, io vi fece pore quelle medaglie adosso, per levarvi questa schiava.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>O gran rischio, ed io non t'ho conosciuto, ma è ch'io non pongo cura a cose basse.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>In somma, ho fatto l'impossibile e l'incredibile per aiutarlo, ed ora, che la vostra incomparabile magnanimità gli fa così preggiato dono, fugge.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Buono, buono.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Per non mancare del suo solito mal fare, fugge accioché il signor Cinzio suo rivale s'intermetta in questo negozio,e facci sì che Pantalone non consenta a questa compra e intorbida le sue contentezze. Che se il signor Fulvio avesse la giovane in potere, il padre non gli lasciarebbe commetter mancamento, ove gli sarebbe moglie per forza, e il signor Beltrame rimarrebbe appagato da Pantalone, non essendo egli quello che manca di parola. E questo pazzo (mi sia perdonato il dirglielo) ora fugge e il Cielo sa che accidenti ponno succedere in questo mezzo! O fortuna, dammi pazienza e conserva il cervello a me, poiché l'hai levato a quell'altro.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Mi dispiace del poch'ingegno di questo giovine, ma se mi diviene cognato, io vorrò conversar sovente seco, per farlo valoroso e più avveduto.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Eh signore, se la sua disgrazia non è stanca, o che la natura non gli dia un altro cervello, né vostra signorìa, né<pb n="508"/> tutt'il mondo, lo farà astuto. Quest'è come li scogli del mare, che stanno sempre nell'acqua e mai imparano a nuotare. Quello che non ha fatto meco, che sono (e sia detto senz'ambizione) la schiuma della mariolarìa, non lo farà manco con niun'altra persona.</p>
           </sp>
@@ -6184,67 +6224,67 @@
         <div type="scene">
           <head rend="italic">SCENA DECIMA</head>
           <stage><hi rend="sc">beltrame, pantalone, cinzio, scappino, capitano, celia, laudomia</hi>, <hi rend="italic">e</hi><hi rend="sc">mezzettino</hi></stage>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Voi avete veduto come s'è turbato nel vedervi.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Io ho veduto che va come un pazzo, isfuggendo chi lo conosce e m'ha posto in sospetto ch'ei non abbi fatto qualche rumore. O quante persone! Servitore, signor Capitano.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Bacio la mano, signor Pantalone. Sapete dove si trova il signor Fulvio vostro figliuolo?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>L'abbiamo incontrato or ora, io non so se mi debba dire colerico o intimorito.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Signor Pantalone, se voi non rimediate al male di vostro figliuolo, voi lo perderete, o per fuga o per scemamento di cervello o per disperazione.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Che cosa ha egli, ch'apponto va come pazzo per la città?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Io ve lo dirò. Egli si ritrova innamorato di questa signora, già schiava e ora cognata del signor Capitano, e abbiamo trovato mille invenzioni per aver danari da riscuotterla o modo di levarla a Mezzettino senza soldi.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Io vi ringrazio.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Intendendo però che vostra signorìa l'avesse poi pagata, e niuna cosa è riuscita. Ora il sionor Capitano ha riscossa la giovane con pensiero di pigliarla per moglie, poi ch'è arrivata un'altra sorella, già moglie in promissione dal sudetto signor Capitano; ond'egli, perciò, cede la prima a vostro figliuolo e si piglia quest'altra, di novo ritrovata e prima a lui destinata. Ora altro non resta se non che vostra signorìa dia il <foreign xml:lang="lat" rend="italic">placet</foreign> di questo parentado, se non, voi perderete Ful<pb n="509"/>vio; o se l'avrete, l'avrete pazzo. Che il parentado sia lecito, ve ne farà fede il signor Capitano. E poi il signor Fulvio non ha gusto di pigliar la signora Lavinia, a tal che darete gusto a questa giovane, stabilirete il cervello a vostro figliuolo e farete ch'io m'acquieterò e potrei forsi doventar galant'uomo.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Non sarebbe poco.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Caro signore, non mi sdegnate per nuora, ch'io vi prometto d'esservi e serva e schiava, non che nuora.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Io vi ringrazio bella figliuola.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Il padre ha solo due figliuole, la dotte è competente, e sono due figliuole d'eredità. Vostra signorìa lo può fare, e tanto più per aver me per parente, ché l'ombra mia solo vale per mille dotte.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Come, signore, mi fate troppo onore! La giovane è di garbo, mi piace, e gli do l'assenso mio. In questo mentre il signor Beltrame potrà fare il suo parentado, ché poi faremo le nozze di compagnia e vostra signorìa starà ad onorar le nozze.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Volonteri. E io scriverò al signor Gusberto come è successo il caso e darò nova a tutti i potentati del mondo delle mie nozze.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Lavinia.</p>
           </sp>
@@ -6256,19 +6296,19 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">pantalone</hi>
           </stage>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Signore.</p>
           </sp>
-          <sp>
+          <sp who="#beltrame">
             <speaker><emph rend="sc">beltrame</emph>.</speaker>
             <p>Eccoti venuta quell'ora tanto da te desiderata, eccoti il tuo signore Cinzio. Levati il guanto, il Cielo vi prosperi e vi dia figliuoli maschi.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>E a vostra signorìa longa e tranquilla vita.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker><emph rend="sc">lavinia</emph>.</speaker>
             <p>Sia lodato il Cielo.</p>
           </sp>
@@ -6277,248 +6317,248 @@
         <div type="scene">
           <head rend="italic">SCENA DUODECIMA</head>
           <stage><hi rend="sc">fulvio, spacca</hi>, <hi rend="italic">e tutti gl'altri</hi></stage>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Eh fratello, il mio caso è troppo disperato, e se pur v'è raggio di speranza con la nube della mia inavvertenza lo coprirò. In somma, io son troppo sfortunato.</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Lasciatevi regere per grazia, e non parlate senz'ordine di Scappino, e così non fallirete.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Ohimè, che sono qua tutti! Or mi convien o tacere o partire.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Passa qua tu.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Signor padre, con licenza di vostra signorìa, son aspettato da un mio amico.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Fermatevi, signor Fulvio.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>S'io mi fermo, rovino qualche cosa a Scappino.</p>
             <p>Servidor, padrona.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Fermatevi, in buon'ora.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Scappino, guarda ben quel che mi fai fare.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>O così va detto, bisognava guardarvi prima e non ora.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Perché non è più a tempo? Ohimè, la cosa è disperata, io me lo merito!</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Vuoi fermarti, bestia, sì o no?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Scappino?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Egli parla con voi! Guardate vostro padre, che avete? siete pazzo?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Ohimè Scappino, son confuso.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>State in cervello.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Passa qua. È vero che tu sei innamorato di questa giovine?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Signor no.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Che?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Signor no, dico.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Ma a che proposito mi nieghi quello che tutti mi affermano?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Per mostrare il suo bell'ingegno! Perché dite di no?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Non m'hai tu detto ch'io stia in cervello?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>E bene?<pb n="511"/></p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Sta' in cervello vuol dire guardate che non confessi.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>O bell'intelletto, vuol dire che respondiate a proposito, ch'adesso è il tempo.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Che consegli sono questi? Vuoi tu ch'io ti dii questa giovane per moglie?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Scappino?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>E che vi vuol il consenso di Scappino?</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Il meschino teme di non errare. Di grazia, iscusatelo.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Dite di sì, in buon'ora!</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Guarda bene che non mi facci fare qualche balordaria.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Sì, sì dico.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Signor sì.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Toccali la mano.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Ah ah?</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Sì.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Ecco, io gliela tocco.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>E non fate...</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Ohimè, c'ho fatto errore! O meschino!</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Che cosa hai, balordo?</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Sì? Scappino mi dice non fate.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Se mi rompete...</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>L'invenzione è...</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>No, in buon'ora! Dico che mi rompete la parola a mezzo! Dissi non fate, e voleva seguir: tante bagatelle! Finitela, ma l'impazienza vostra e la tema vuole tribular anche nelle allegrezze.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Gli toccherò dunque la mano, n'è, signor padre?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Sì sì, se la vòi, però.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Signora, siete mia moglie.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>E vostra signorìa mio marito, grazia del Cielo e l'aiuto del signor Capitano.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Ah ah! Abbiamo pur fatto tanto, che in ultimo l'abbiamo vinta.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Di grazia, ponetevi in donzina. Se macarone non vi cadeva in bocca, per voi vi sareste morto di fame! Signor Pantalone, se il padre è obligato per il figliuolo, vostra si<pb n="512"/>gnorìa è obligato a farmi raccommandare il cervello, ché vostro figliuolo l'ha tolto da segno.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>M'allegro, signor Fulvio, delle vostre contentezze. Son maritato anch'io: ecco la mia moglie.</p>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker><emph rend="sc">fulvio</emph>.</speaker>
             <p>Ringrazio vostra signorìa e ho gusto anch'io del loro contento, e vi giuro che sono quasi ebro di contentezza, e mi pare un sogno.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>O sogno o favola, la cosa è conclusa. Si sodisfarà messer Mezzettino, e si daranno le nuove a parenti e a gli amici.</p>
           </sp>
-          <sp>
+          <sp who="#mezzettino">
             <speaker><emph rend="sc">mezzettino</emph>.</speaker>
             <p>Vostra signorìa parla bene.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Presto, figliuoli, chi mi vuol far un servigio?</p>
           </sp>
-          <sp>
+          <sp who="#spacca">
             <speaker><emph rend="sc">spacca</emph>.</speaker>
             <p>Io, signore, per scontar il disgusto che v'ho dato col volervi far ir carcerato.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Ah furfante, mi pareva bene di conoscerti per quello che voleva portar via ancora gli trecento ducati, ma non mi assicurava. Orsù, ti perdono.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Io lo faceva mutar spesso e di feraiolo e di capello, e però era difficile il conoscerlo, ma che tutte le cose giravano per far aver questa giovane al signor Fulvio, cose in vero degne di scusa e di compassione. Ma che commanda vostra signorìa?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Andate a comprarmi una risma di carta ch'io possa scrivere a tutt'il mondo, e dite a tutti i corrieri che niuno parta senza ch'io gli dia il mio dispaccio.</p>
           </sp>
-          <sp>
+          <sp who="#scappino">
             <speaker><emph rend="sc">scappino</emph>.</speaker>
             <p>Avvisaremo i corrieri e avvisaremo ancora questi signori che non v'è altro che fare, se non andar a cena.</p>
           </sp>

--- a/tei/beccari-il-sacrificio-1555.xml
+++ b/tei/beccari-il-sacrificio-1555.xml
@@ -75,6 +75,46 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="erasto">
+            <persName>Erasto</persName>
+          </person>
+          <person xml:id="orenio">
+            <persName>Orenio</persName>
+          </person>
+          <person xml:id="carpalio">
+            <persName>Carpalio</persName>
+          </person>
+          <person xml:id="turico">
+            <persName>Turico</persName>
+          </person>
+          <person xml:id="ophelio">
+            <persName>Ophelio</persName>
+          </person>
+          <person xml:id="satiro">
+            <persName>Satiro</persName>
+          </person>
+          <person xml:id="callinome">
+            <persName>Callinome</persName>
+          </person>
+          <person xml:id="melidia">
+            <persName>Melidia</persName>
+          </person>
+          <person xml:id="stellinia">
+            <persName>Stellinia</persName>
+          </person>
+          <person xml:id="sacerdote">
+            <persName>Sacerdote</persName>
+          </person>
+          <personGrp xml:id="choro">
+            <name>Choro</name>
+          </personGrp>
+          <person xml:id="meledia">
+            <persName>Meledia</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>2003-05-15T00:00:00.000+02:00</date><name>Camilla Ghedini</name><name>CIBIT-Ferrara</name>Digitalizzazione - Trascrizione a cura di Elisa Borsari</change>
@@ -327,7 +367,7 @@ Madama Leonora da Este.</salute>
             <hi rend="sc">SCENA I</hi>
           </head>
           <stage>Erasto giovine. Orenio vecchio</stage>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Horrida selva, in cui piangendo spargo</l>
             <l>gli ardenti miei sospir, gli accesi lai,</l>
@@ -352,14 +392,14 @@ Madama Leonora da Este.</salute>
             <l>produr si scorga frutti sì mortali,</l>
             <l>come sei tu, tu che gli amanti attoschi.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Se 'l chiaro giorno a me non è nimico</l>
             <l>contro lo stile suo, questi ch'io veggo</l>
             <l>è l'infelice <name>Erasto</name>, che sua vita</l>
             <l>mena con tristi et angosciosi pianti.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Ben so, <name>Vener</name> gentil, se 'l ciel t'havesse</l>
             <l>dato tanto poter quanto al tuo figlio,</l>
@@ -374,14 +414,14 @@ Madama Leonora da Este.</salute>
             <pb n="A7v"/>
             <l>poich'amo e seguo chi mi fugge et odia?</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Misera gioventù, poi che 'l disio</l>
             <l>di goder con amaro un poco dolce</l>
             <l>qua e là girando ti trasporta et move,</l>
             <l>qual posta al vento una minuta canna.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Ben ti fu contra il ciel, misero <name>Erasto</name>,</l>
             <l>a porti in servitù d'una crudele,</l>
@@ -408,11 +448,11 @@ Madama Leonora da Este.</salute>
             <l>e la gran piaga che mi fece <name>Amore</name>.</l>
             <l>Però chi fu di me mai pi<add>ù</add> infelice?</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Tanto è misero l'huom quant'ei si tiene.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Ai <name>Callinome</name> ingrata, ai quanti scorni</l>
             <l>per te patisco, poi che la gran fama</l>
@@ -422,12 +462,12 @@ Madama Leonora da Este.</salute>
             <l>e va mancando, qual accesa lampa,</l>
             <l>cui sia negato il nutritivo humore.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Costui non può addolcire un cor di donna</l>
             <l>e faria per pietà movere i sassi.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Chi havea più grassa et più lanosa greggia?</l>
             <l>Chi armento più felice et prosperoso?</l>
@@ -443,7 +483,7 @@ Madama Leonora da Este.</salute>
             <l>che più non entra ne l'usata mandra,</l>
             <l>il mio veng<add>a a</add> veder, né vadi altrove.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Che meraviglia, s' un che di sé cura</l>
             <l>o nulla o poca tien lascia l'agnelle</l>
@@ -456,18 +496,18 @@ Madama Leonora da Este.</salute>
             <l>Et sol questa cagion da <name>Amor</name> deriva.</l>
             <l part="I"><name>Erasto</name>, <name>Erasto</name>.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l part="F">O 'l mio gentil <name>Orenio</name></l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l><name>Erasto</name>, ov'è la tua prudenza e 'l senno?</l>
             <l>Ov'è 'l tuo bel governo et la gran cura</l>
             <l>c'haver solevi a la tua greggia intorno?</l>
           </sp>
           <pb n="B1r"/>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l><name>Orenio</name> mio gentil, se 'l grand' amore</l>
             <l>che tu portasti in vita a la tua <name>Crinia</name></l>
@@ -476,7 +516,7 @@ Madama Leonora da Este.</salute>
             <l>Sovengati de l'hore che tu in vano</l>
             <l>spendesti, <name>Orenio</name>, et del perduto tempo.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Ti prego, <name>Erasto</name>, per quel dolce nome</l>
             <l>della nimica tua che t' sì ingrata,</l>
@@ -492,7 +532,7 @@ Madama Leonora da Este.</salute>
             <l>in sua memoria (o degno sacrificio)</l>
             <l>si pon veder tutti sanguigni et grassi.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Quant'<name>Orenio</name> son' io di scusa degno,</l>
             <l>seguendo alma immortal degna d'impero,</l>
@@ -502,7 +542,7 @@ Madama Leonora da Este.</salute>
             <l>volte si son raccolte 'n campo spiche)</l>
             <l>nella memoria ancor porti e nel petto?</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Tal fu il mio amor verso colei che tanto</l>
             <l>ardendo amai, che tempo, hora o stagione</l>
@@ -518,7 +558,7 @@ Madama Leonora da Este.</salute>
             <l>d'odiar la <name>Crinia</name> mia, c'havea nel core</l>
             <l>sola fede scolpita e amor perfetto.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Se ben dura è la mia, convien, <name>Orenio</name>,</l>
             <l>volendo o no, che questa ingrata segua,</l>
@@ -532,7 +572,7 @@ Madama Leonora da Este.</salute>
             <l>matura, et nobil più de' pomi, e 'l cigno</l>
             <l>di dolce canto al par di lei non vale.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Lasciamo, <name>Erasto</name>, il dolce ragionare</l>
             <l>onde più tosto la nostr'alma langue</l>
@@ -552,7 +592,7 @@ Madama Leonora da Este.</salute>
             <l>Sai ben che non bisogna ove va il culto</l>
             <l>Divin, por cosa maculata e 'mmonda.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l><name>Amor</name>, <name>Amor</name> non vuol ch'io lasci tempo,</l>
             <l>né che 'ntrametta alcun momento d'hora</l>
@@ -564,7 +604,7 @@ Madama Leonora da Este.</salute>
             <l>che mal fa chi <num value="2">duo</num> lepri a un tempo caccia;</l>
             <l>però che mi consigli in simil caso?</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Questo intraviene una sol volta a l'anno</l>
             <l>di far tai giochi et celebrar tai voti,</l>
@@ -576,7 +616,7 @@ Madama Leonora da Este.</salute>
             <l>sotto la noce o sotto il fral cupresso,</l>
             <l>che simil ombre tua sciagura merta.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Andiamo, <name>Orenio</name>, et la tua chioma bianca</l>
             <l>sia fida scorta a la mia verde etate.</l>
@@ -588,7 +628,7 @@ Madama Leonora da Este.</salute>
             <hi rend="sc">SCENA II</hi>
           </head>
           <stage>Carpalio giovine</stage>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Quando vedrai, <name>Carpalio</name>, pascer l'api</l>
             <l>in queste parti de l'<name>Arcadia</name> il thimo,</l>
@@ -630,13 +670,13 @@ Madama Leonora da Este.</salute>
             <hi rend="sc">SCENA III</hi>
           </head>
           <stage>Turico giovine. Carpalio</stage>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Parmi la voce d'un pastor tra queste</l>
             <l>selve sentir, che 'n lamentevol note</l>
             <l>qualche gran caso sospirando esponga.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Questi è <name>Turico</name>, a l'habito, a la voce.</l>
             <l>Ben venga quel <name>Turico</name> et quel pastore,</l>
@@ -644,7 +684,7 @@ Madama Leonora da Este.</salute>
             <pb n="B4r"/>
             <l>il più felice e aventuroso tempo.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Era ben già che la <name>Stellinia</name> mia,</l>
             <l>ove havea posta mia tranquilla pace,</l>
@@ -670,14 +710,14 @@ Madama Leonora da Este.</salute>
             <l>Dove dunque dee l'huom por la sua fede,</l>
             <l>se così poco appresso donna dura?</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Come può star che così bella nimpha,</l>
             <l>come si sa, che t'havea dato il core,</l>
             <l>ad altro amor, ad altro van disio</l>
             <l>habbia rimesse nove penne et ali?</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Per questa sacra e 'mmaculata selva,</l>
             <l>ove non pose mai l'empia bipenne</l>
@@ -693,7 +733,7 @@ Madama Leonora da Este.</salute>
             <l>tant'oltraggio m'ha fatto et tanto scorno</l>
             <l>quanto questo pastor' hoggi ti dice.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>S'io credessi, <name>Turico</name>, che la mia</l>
             <l>fosse a la tua di fede tal conforme,</l>
@@ -709,7 +749,7 @@ Madama Leonora da Este.</salute>
             <l>a i segni e al ragionar, mostra d'amarmi</l>
             <l>quanto stender si pon forze di donna.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Deh, se grave non t'è, pastor felice,</l>
             <l>se la dimanda è lecita, et se mai</l>
@@ -720,7 +760,7 @@ Madama Leonora da Este.</salute>
             <l>et che ti sprona in sì sonore note</l>
             <l>in queste selve a ricordar d'<name>Amore</name>?</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l><name>Turico</name>, vero honor di queste selve</l>
             <l>et di pastori alta corona et pregio,</l>
@@ -738,12 +778,12 @@ Madama Leonora da Este.</salute>
             <l>mi preme 'l piede, e a la sublime 'l braccio</l>
             <l>quasi vittorioso in parte stendo.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Come star pon questi contrari insieme,</l>
             <l>ch'a un tempo sii infelice e aventuroso?</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Io ti dirò; felice son, che i cieli</l>
             <l>la più leggiadra che di selva in selva,</l>
@@ -756,11 +796,11 @@ Madama Leonora da Este.</salute>
             <l>amar più l'altro. Ond'invido <name>Amor</name> fatto,</l>
             <l>post'ha la spina a questa rosa in mezo.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Onde vien et di qual dea è la tua nimpha?</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Questa mia nimpha, anzi del ciel pur dea,</l>
             <l>nacque nel mondo ben di qualche dio,</l>
@@ -771,7 +811,7 @@ Madama Leonora da Este.</salute>
             <l>affetto che con altri occhi non vede,</l>
             <l>né conosce altro ben, ch'ambeduo noi.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Ben, ben conosco e l'uno e l'altro. O bella,</l>
             <l>o bella, so che 'l fiore hai conosciuto.</l>
@@ -779,7 +819,7 @@ Madama Leonora da Este.</salute>
             <l>poich'ella t'ama et parimente <name>Ophelio</name>,</l>
             <l>et essendo, com'è, libera et sciolta?</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Hor odi: il suo fratel tanto si mostra</l>
             <l>a me nimico fuor d'ogni ragione</l>
@@ -794,14 +834,14 @@ Madama Leonora da Este.</salute>
             <l>a questo nostro sì felice amore</l>
             <l>et me rifiuta com'un vil capraro.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Forse 'l fratell', onde ambeduoi sian nati,</l>
             <l>da qualche dio esser discesi al mondo,</l>
             <l>però si sdegna ch'un pastoral seme</l>
             <l>si sparga in questo sì celeste campo.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Ma ecco <name>Ophelio</name> mio, ecco il buon vecchio</l>
             <l>d'ambo e gemelli, che non men si duole</l>
@@ -813,15 +853,15 @@ Madama Leonora da Este.</salute>
             <hi rend="sc">SCENA IV</hi>
           </head>
           <stage>Ophelio vecchio. Carpalio. Turico</stage>
-          <sp>
+          <sp who="#ophelio">
             <speaker>Ophelio</speaker>
             <l>O buon principio: ecco <name>Carpalio</name> mio.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Che vuoi, gentil' <name>Ophelio</name>, che mi nomi?</l>
           </sp>
-          <sp>
+          <sp who="#ophelio">
             <speaker>Ophelio</speaker>
             <l>S'<name>Amor</name> hoggi non dà quel lieto fine,</l>
             <l><name>Carpalio</name> figliuol mio, che tu et <name>Melidia</name></l>
@@ -838,21 +878,21 @@ Madama Leonora da Este.</salute>
             <l>starà, tu con <name>Melidia</name> tua potrai</l>
             <l>dar fine al tanto desiato amore.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Ma se fortuna, come suol, nimica</l>
             <l>noi si facesse, discoprendo quello</l>
             <l>che tra noi potria star sempre celato,</l>
             <l>che faremo? Qual fia po 'l pensier nostro?</l>
           </sp>
-          <sp>
+          <sp who="#ophelio">
             <speaker>Ophelio</speaker>
             <l>Diremo, ch'alcun satiro o alcun fauno,</l>
             <l>o ver, che meglio fia, alcun dio del cielo</l>
             <l>sotto mentita forma l'habbia presa,</l>
             <l>levandole quel fior ch'altri havrà colto.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Merita peggio, poich'è sì malvagio,</l>
             <l>né di rispetto se gli dee haver punto.</l>
@@ -860,19 +900,19 @@ Madama Leonora da Este.</salute>
             <l>Così potessi io fin porr'al mio male</l>
             <l>come al ben tuo principio dar potrai.</l>
           </sp>
-          <sp>
+          <sp who="#ophelio">
             <speaker>Ophelio</speaker>
             <l>Andiamo, andiamo, che ciascun si pone</l>
             <l>in ordine per ire al sacrificio.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l><name>Turico</name>, se ti par ch'io possa aiuto</l>
             <l>porgerti nel tuo amor, comanda pure,</l>
             <l>ch'io son pastor ch'agevolmente servo</l>
             <l>chiunque l'opra mia chiede 'n soccorso.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Di questa offerta i' ti ringratio e anch'io</l>
             <l>mi t'offero per quanto pon patire</l>
@@ -895,75 +935,75 @@ Madama Leonora da Este.</salute>
             <hi rend="sc">SCENA V</hi>
           </head>
           <stage>Satiro. Turico</stage>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>O, o, qualche pastor che si querela</l>
             <l>di sua sorte infelice. Altro tra queste</l>
             <l>selve hor non s'ode che d'amor lamenti.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Possibil fia ch'un'altra volta <name>Amore</name></l>
             <l>non potrà intenerir quel duro petto,</l>
             <l>ch'entro il velen d'ogn'aspra serpe inchiude?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Salvo sii, bel pastor.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">Satiro a <name>dio</name></l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">così forte d'<name>Amor</name>?</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">Non tel vuò dire.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Come, che nol vuoi dir?</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">No, che tu forse</l>
           </sp>
           <sp>
             <l part="I">me 'l vorresti vietare.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Anzi, vuò darti</l>
             <l part="I">(se n'hai bisogno) qualche aiuto.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">Il tuo</l>
             <l>aiuto poco curo, ch'al mio male</l>
             <l part="I">rimedio non havresti.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Dimmel dunque</l>
             <l>per cortesia.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">Ti dico che non voglio.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Tel farò dir mal grado tuo.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">Tu buono</l>
             <l>sarai per farmel dir non volend'io?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>O, in quanta poca riverenza siamo</l>
             <l>noi satir, hor che più non siam tenuti</l>
@@ -971,12 +1011,12 @@ Madama Leonora da Este.</salute>
             <l>né dei né semidei. Dunque ch'io possa</l>
             <l part="I">farloti dir non credi?</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">Tu, né quanti</l>
             <l>vorran saperlo a forza, il saperanno.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>O incredulo, o malvagio, a questo modo?</l>
             <l>Lascia, che mi dirai più che non voglio.</l>
@@ -1003,52 +1043,52 @@ Madama Leonora da Este.</salute>
             <l>Comincia. Dimmi il nome di colei</l>
             <l part="I">che lamentar ti fa.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F"><name>Stellinia</name> ha nome.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Di qual color si veste?</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">Di vermiglio.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Ove suol praticare?</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">Qui d'intorno.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Horsù, sta ben, tu non l'hai detto a un sordo.</l>
             <l part="I">Di qual arbor' ha l'arco?</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">Egli è di tasso.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Non so che chiederl'altro. Dimmi, è bella?</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="I">Bellissima.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="M">É cortese?</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">A me no<expan>n</expan> troppo.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Sarà al proposto. Hoggi vuò in ordin porre</l>
             <l>la mia trappola e qui stenderla, e quante</l>
@@ -1067,11 +1107,11 @@ Madama Leonora da Este.</salute>
             <l>che sonnacchioso non la vederebbe.</l>
             <l>Tanto fa, se gli do ben ne la testa.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Oimè. Che vuol dir questo? Ove son' io?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Guardati i piedi, guardati le gambe.</l>
           </sp>
@@ -1081,7 +1121,7 @@ Madama Leonora da Este.</salute>
             <hi rend="sc">SCENA VI</hi>
           </head>
           <stage>Turico solo</stage>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Oimè son morto, oimè che cosa è questa?</l>
             <l>O come son fuori di me, mi sento</l>
@@ -1123,7 +1163,7 @@ Madama Leonora da Este.</salute>
             <hi rend="sc">SCENA I</hi>
           </head>
           <stage>Erasto. Callinome nimpha di Diana</stage>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Havea deliberato hoggi di starmi</l>
             <l>al sacrificio in compagnia d'<name>Orenio</name>,</l>
@@ -1148,7 +1188,7 @@ Madama Leonora da Este.</salute>
             <l>ciò che seco ragiona, e a l'improviso</l>
             <l>discoprirmele poi. Ecco ch'è giunta.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Sciolta da ogni pensier, da ogn'alta cura</l>
             <l>solinga me ne vo di selva in selva,</l>
@@ -1165,13 +1205,13 @@ Madama Leonora da Este.</salute>
             <l>et breve via di salir sopra il cielo,</l>
             <l>ove l'alme beate han posto il seggio?</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Se per esser crudel s'acquista il cielo,</l>
             <l>tu più d'ogn'altra ti puoi dir beata,</l>
             <l part="I">poi che sì cruda sei.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l part="F">Lodato Dio,</l>
             <pb n="C3v"/>
@@ -1179,11 +1219,11 @@ Madama Leonora da Este.</salute>
             <l>d'<name>Erasto</name> mi dia noia, poi che tutti</l>
             <l>i pastor' hoggi vanno a i sacrifici.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Misero <name>Erasto</name>, a che congiunto sei?</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Però qui posso riposarmi senza</l>
             <l>haver tema di lui. Ma chi veggo io</l>
@@ -1196,7 +1236,7 @@ Madama Leonora da Este.</salute>
             <l>mi si accosti. Egli vien. Ma vuò mostrare</l>
             <l part="I">di non temere.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l part="F">Io vuò venirti in contra</l>
             <l>perché bramo morir con le tue mani,</l>
@@ -1204,11 +1244,11 @@ Madama Leonora da Este.</salute>
             <l>aventami, che morte mi fia grata</l>
             <l part="I">quando venga da te.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l part="F">Sta' pur lontano.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Perché cerchi fuggir? Perché paventi?</l>
             <l>Di che vuoi tu temer? Deh, ferma il piede.</l>
@@ -1218,12 +1258,12 @@ Madama Leonora da Este.</salute>
             <l>riverisce et honora, et che ti tiene</l>
             <l>più che la vita sua cara et accetta.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Che mi potrai tu far quando non voglia?</l>
             <l>Horsù di ciò che vuoi, di', che t'ascolto.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Quando fia mai, o dolce mia nimica,</l>
             <l>ch'io venga al fin de le mie pene amare,</l>
@@ -1255,12 +1295,12 @@ Madama Leonora da Este.</salute>
             <l>vienlo a toccar con mano et a chiarirti,</l>
             <l>che troverai via più di quel c'ho detto.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Sei molto ricco, <name>Erasto</name>. Hai tu fors'altro</l>
             <l>da dir? Perché vuò andar' al mio viaggio.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Non t'ho ancor detto com'un capriolo</l>
             <l>ti serbo e <num value="2">duoi</num> capretti di sì fatta</l>
@@ -1275,21 +1315,21 @@ Madama Leonora da Este.</salute>
             <l>in contracambio un ricco vel donarmi,</l>
             <l>ma senz'altro tuoi fiano e li ti dono.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Non me ne curo, <name>Erasto</name>, se ben fila</l>
             <l>d'argento i velli havessero, e le corna</l>
             <l>d'oro. Tienlili pur, o dalli altrui,</l>
             <l>fanne pur ciò che vuoi, poiché son tuoi.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Ai, <name>Callinome</name> dura più che un sasso,</l>
             <l>so ben ch'i doni miei sprezzi e non curi.</l>
             <l>Ma dove vai? Dove ne volgi il passo?</l>
             <l>Non ti partir, volgi la fronte alquanto.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>La riverenza ch'a la mia reina</l>
             <l>debitamente porto vuol ch'io serbi</l>
@@ -1298,7 +1338,7 @@ Madama Leonora da Este.</salute>
             <l>Però cerca altra via, cerca altro amore,</l>
             <l>se vuoi disacerbar questi tuo' affanni.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Te, <name>Callinome</name> ingrata, il ciel mi diede</l>
             <l>ch'amassi e non altrui. Né pensar ch'io</l>
@@ -1312,23 +1352,23 @@ Madama Leonora da Este.</salute>
             <l>spargon talhor, perché lor porti amore,</l>
             <l>e lor per te, crudel, fuggo et disprezzo.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Fai male, <name>Erasto</name>, a non seguir chi t'ama.</l>
             <l>Io son brutta appo lor, segui pur quelle.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Anzi più bella, e tra lor sembri quale</l>
             <l>tra le stelle minori il chiaro sole.</l>
             <l>Et ben si vede, poi che come neve</l>
             <l>mi struggo appresso te, né te ne cale.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Perché più non ti sfacci, io me ne vado.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Deh, fammi don nel tuo partir di questa</l>
             <l>sol gratia per li tanti miei dolori</l>
@@ -1361,7 +1401,7 @@ Madama Leonora da Este.</salute>
             <hi rend="sc">SCENA II</hi>
           </head>
           <stage>Satiro solo</stage>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Poich'è sì lieto e sì tranquillo il giorno,</l>
             <l>non può far che le nimphe per li boschi</l>
@@ -1407,7 +1447,7 @@ Madama Leonora da Este.</salute>
             <hi rend="sc">SCENA III</hi>
           </head>
           <stage>Melidia nimpha. Satiro</stage>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Quando, <name>Melidia</name>, havran le tue querele</l>
             <l>qualche tregua o conforto? E quando lieta</l>
@@ -1426,12 +1466,12 @@ Madama Leonora da Este.</salute>
             <l>perché non lievi il fratel mio del mondo</l>
             <l>per salvar <num value="2">duoi</num> così fideli amanti?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Nota, nota che vuol, che 'l fratel muoia</l>
             <l>per darsi in preda a qualche vil pastore.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Deh, perché <name>Amor</name> mi fusti sì benigno?</l>
             <l>Perché mi fusti sì contrario e averso?</l>
@@ -1440,11 +1480,11 @@ Madama Leonora da Este.</salute>
             <l>Ove imparasti sì maligne leggi</l>
             <l>di dar sì lunghi affanni a' tuoi seguaci?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Ti seguirò ben' io. Vien pur innanzi.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Non negherai già, <name>Amor</name>, che tu non sappi,</l>
             <l>che sanlo i boschi, le campagne e i fiori,</l>
@@ -1458,17 +1498,17 @@ Madama Leonora da Este.</salute>
             <l>io vuò veder di riposarmi alquanto</l>
             <l>sotto questa robusta et alta quercia.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Vieni un poco più innanzi. Ancora un poco.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Attendendo se 'l mio dolce <name>Carpalio</name>,</l>
             <l>rinovellando le sue antiche piaghe,</l>
             <l>quinci prendesse quest'usato calle.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Senza troppo macchiar questa ho nel pugno.</l>
             <l>Siedi pur, c'hora vengo. Ma vuò prima</l>
@@ -1481,7 +1521,7 @@ Madama Leonora da Este.</salute>
             <hi rend="sc">SCENA IV</hi>
           </head>
           <stage>Ophelio. Melidia. Satiro</stage>
-          <sp>
+          <sp who="#ophelio">
             <speaker>Ophelio</speaker>
             <l>Quando il lasso bifolco il campo pieno</l>
             <l>intorno intorno di verdette biade</l>
@@ -1502,12 +1542,12 @@ Madama Leonora da Este.</salute>
             <l>d'haver' accoppiar questi <num value="2">duo</num>' amanti</l>
             <l>vai prolungando per più nostra pena.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Sei pur venuto, <name>Amore</name>, a buon mercato,</l>
             <l>ch'ognun vuol giocar teco a la civetta.</l>
           </sp>
-          <sp>
+          <sp who="#ophelio">
             <speaker>Ophelio</speaker>
             <l>Le selve, i boschi e le palustri valli,</l>
             <l>quasi mosse a pietà, rispondon meste</l>
@@ -1515,14 +1555,14 @@ Madama Leonora da Este.</salute>
             <l>ripetendo la voce mi risponde</l>
             <l>quante fiate 'n van chiamo <name>Melidia</name>.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Qualche gran caso a questo miser vecchio</l>
             <l>è intravenuto, che sì forte cerca</l>
             <l>chiamando il nome mio, me 'n queste selve.</l>
           </sp>
           <pb n="D1r"/>
-          <sp>
+          <sp who="#ophelio">
             <speaker>Ophelio</speaker>
             <l>Se ti rimembra punto, o sacro <name>Apollo</name>,</l>
             <l>l'acuto dardo che ti punse 'l core</l>
@@ -1531,33 +1571,33 @@ Madama Leonora da Este.</salute>
             <l>dammi soccorso in ritrovar <name>Melidia</name>,</l>
             <l>c'homai le membra mie son lasse et stanche.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Povero <name>Apollo</name>, ognun ti dà in su 'l viso,</l>
             <l>col rimembrarti la selvaggia <name>Daphne</name>.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Mi vuò scoprir, né più tenerlo in tempo.</l>
             <l><name>Ophelio</name>, in queste selve (si com'hora</l>
             <l>mi par d'haver' udito) grandemente</l>
             <l>mi vai cercando et di chiamar non cessi.</l>
           </sp>
-          <sp>
+          <sp who="#ophelio">
             <speaker>Ophelio</speaker>
             <l>T'ho ricercata sì; quanto facesse</l>
             <l>pastor giamai smarrita pecorella.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Alza i piè, vecchio, che tai barbagianni</l>
             <l>prender non vuò con la mia stesa rete.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l part="I">Eccomi.</l>
           </sp>
-          <sp>
+          <sp who="#ophelio">
             <speaker>Ophelio</speaker>
             <l part="F">Io ne ringratio il nostro <name>Giove</name>,</l>
             <l>qual salva ci mantien l'amata greggia.</l>
@@ -1566,7 +1606,7 @@ Madama Leonora da Este.</salute>
             <l>poic'hor m'ha scorto ove tu fermi il piede.</l>
           </sp>
           <pb n="D1v"/>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Dimmi, <name>Ophelio</name> gentil, padre honorando,</l>
             <l>dico padre d'amor' a me e a <name>Pimonio</name>,</l>
@@ -1574,7 +1614,7 @@ Madama Leonora da Este.</salute>
             <l>che bisogno hai di me, che di trovarmi</l>
             <l>tanto bramoso mi ti sei scoperto?</l>
           </sp>
-          <sp>
+          <sp who="#ophelio">
             <speaker>Ophelio</speaker>
             <l>Tu sai con quanto amor, con quanto zelo,</l>
             <l>con quanta carità, con quanta fede,</l>
@@ -1596,11 +1636,11 @@ Madama Leonora da Este.</salute>
             <l>pur' il disio c'havea di ritrovarti,</l>
             <l>mi fea parer la via molto più breve</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>per correr più leggier, vecchio ubbriacco.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Certa sempre ne fui, benigno <name>Ophelio</name>,</l>
             <l>che 'l tuo disio di compiacermi tanto</l>
@@ -1614,7 +1654,7 @@ Madama Leonora da Este.</salute>
             <l>felici sì, che non invidi alcuno</l>
             <l>che pasca in questa sì felice <name>Arcadia</name>.</l>
           </sp>
-          <sp>
+          <sp who="#ophelio">
             <speaker>Ophelio</speaker>
             <l>Lasciam, <name>Melidia</name>, questi preghi a tempo</l>
             <l>più commodo di questo, et attendiamo</l>
@@ -1642,59 +1682,59 @@ Madama Leonora da Este.</salute>
             <l>ove tu possi il tuo <name>Carpalio</name>, quanto</l>
             <l>per te si può, far più contento et lieto.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Lieto io sarei se ti vedessi morto,</l>
             <l>et lei ne' lacci miei vedessi presa.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l part="I">Egli dov'è?</l>
           </sp>
           <pb n="D3r"/>
-          <sp>
+          <sp who="#ophelio">
             <speaker>Ophelio</speaker>
             <l part="F">Non è troppo lontano,</l>
             <l>che di nascosto il tuo fratello attende</l>
             <l>fin che si parta per andar' a i giochi.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Costei vuol far morir certo il fratello.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Tu vecchio sei, tu ben conosci et sai</l>
             <l>come tu guidi questi <num value="2">duoi</num> amanti.</l>
             <l>A te lascio il pensier, a te l'affanno</l>
             <l>ch'indi potrebbe a qualche tempo uscire.</l>
           </sp>
-          <sp>
+          <sp who="#ophelio">
             <speaker>Ophelio</speaker>
             <l>No, no, <name>Melidia</name>, mentre 'l cacciatore</l>
             <l>si vede haver la fera circondata,</l>
             <l>cessar non suol fin che 'n sue man non l'habbia.</l>
             <l>Che chi tempo ha e l'aspetta, al fin lo perde.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Se tu non mi impedivi, anch'io voleva</l>
             <l>quest'ordine tener' a' miei disegni.</l>
           </sp>
-          <sp>
+          <sp who="#ophelio">
             <speaker>Ophelio</speaker>
             <l><name>Melidia</name>, andrò correndo a dar la nov<add>a</add></l>
             <l>al tuo <name>Carpalio</name>, com'io t'ho trovata.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Va' pur oltre, ch'anch'io mi pongo in via.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Ei parte, ella rimane. O buona nova.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Se con accenti folli,</l>
             <l>ho fatte un tempo risonar le valli</l>
@@ -1709,11 +1749,11 @@ Madama Leonora da Este.</salute>
             <l>che i colli homai potrai, le valli e i fiori</l>
             <l>ritornar lieti ne' lor primi honori.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Finisci tosto, e movi i lenti passi.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>S'io porsi un tempo in vano</l>
             <l>a te, dolce signor, le mie fiscelle</l>
@@ -1728,11 +1768,11 @@ Madama Leonora da Este.</salute>
             <l>sper'h<add>or</add> ch'entrambi ne corremo il frutto.</l>
           </sp>
           <pb n="D4r"/>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>che potria sovraggiungere alcun'altro.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Se la tua sovra human</l>
             <l>sampogna cacciò un tempo oscure note,</l>
@@ -1746,29 +1786,29 @@ Madama Leonora da Este.</salute>
             <l>potrai, dolce <name>Carpalio</name>, con <name>Melidia</name></l>
             <l>star sì ch'ogni pastor ne senta invidia.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Vien pur' innanzi. Il tordo è ne la ragna.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Sian maledetti i cespi. Oimè, ch'a un laccio</l>
             <l part="I">son presa, oimè.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Non dubitar, sta' salda.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Deh, lasciami. Ritorna, <name>Ophelio</name>, <name>Ophelio</name>.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Pensa pur che partir quindi non puoi,</l>
             <l>se non mi dai un bascio a bocca a bocca.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Deh, satiro mio bel, non far, ti prego,</l>
             <l>che se 'l sapesse il fratel mio <name>Pimonio</name></l>
@@ -1778,23 +1818,23 @@ Madama Leonora da Este.</salute>
             <l>dirti in secreto, e ti fia tanto a grado</l>
             <l part="I">quanto altra cosa mai.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Di' prima, et poi</l>
             <l>ti lascio, se fia cosa ch'a me tochi.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l><name>Satiro</name> mio cortese, io vuò che sappi</l>
             <l>ch'un certo mio fratello, anzi un serpente,</l>
             <l>sempre 'n guerra mi tiene. Ma di' prima,</l>
             <l>si pon gli huomini ancor pigliar con questa?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Huomini e donne e tutti gli animali.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Sarà al proposto. Io vuò, se tu vorrai,</l>
             <l>pigliar con questa questo mio fratello,</l>
@@ -1815,7 +1855,7 @@ Madama Leonora da Este.</salute>
             <l>ch'io vil son femminella, non ti spiaccia,</l>
             <l>né ti curi accettar questa mia offerta.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Anzi, m'aggrada quanto dir si possa.</l>
             <l>Ma avertisce ch'io vuò, prima che parti</l>
@@ -1823,7 +1863,7 @@ Madama Leonora da Este.</salute>
             <l>che tu mi fai un bascio di quel modo</l>
             <l part="I">che so che saprai darmi.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l part="F">Egli è 'l dovere.</l>
             <l>Ma perché non vidi io mai simil cosa,</l>
@@ -1833,18 +1873,18 @@ Madama Leonora da Este.</salute>
             <l>per ir' al santo sacrificio e a i giochi,</l>
             <l part="I">però fa tosto et slegami.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Ma sappi</l>
             <l>c'huomo alcun non è buon mai di snodare</l>
             <l>questi lacciuo', quando si tiran troppo.</l>
             <l>Ma uopo è alhor che si ricida il nodo.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Fai bene ad avertirmi d'ogni cosa.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Hor vedi et nota ben, guardami bene.</l>
             <pb n="D5v"/>
@@ -1858,18 +1898,18 @@ Madama Leonora da Este.</salute>
             <l>ch'altramente, slegato ch'egli fosse,</l>
             <l part="I">ti potria dar la morte.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l part="F">Tu ben dici.</l>
             <l>Io non havea avertito a questo punto.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Ma se fossi quell'io che lo prendessi?</l>
             <l>Perché par non convenga che tu dii</l>
             <l>morte ad un che ti sia (com' ei) fratello?</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Deh, se tu fossi, com'io sempre sono,</l>
             <l>mal trattata da lui, tu parimente</l>
@@ -1878,26 +1918,26 @@ Madama Leonora da Este.</salute>
             <l>di questo mondo, poi che <num value="1000">mille</num> volte</l>
             <l>per lui convien ch'io morte chiami l'hora.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Fa' dunque tu, pur che tu sappi fare.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Aspetta, io starò ascosa, tu va' innanzi,</l>
             <pb n="D6r"/>
             <l>passa, ch'io tirerò tanto che impari.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Non è fuor di proposto, tira pure.</l>
             <l>Non tirar tanto, non tirar: che fai?</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Così chi inganna altrui vien' ingannato.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Ai malvagia, ai rubalda, a questo modo?</l>
             <l>Rispetto non s'ha a' satiri? Tu fuggi?</l>
@@ -1930,7 +1970,7 @@ Madama Leonora da Este.</salute>
             </hi>
           </head>
           <stage>Turico solo</stage>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l><name>Turico</name>, che ti val l'esser sì destro,</l>
             <l>far prove ognhor con la tua stanca vita</l>
@@ -1979,7 +2019,7 @@ Madama Leonora da Este.</salute>
             </hi>
           </head>
           <stage>Callinome. Stellinia nimphe</stage>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Io mi credea c'hoggi le selve e i boschi</l>
             <l>devessi ritrovar senza lamenti</l>
@@ -2004,13 +2044,13 @@ Madama Leonora da Este.</salute>
             <l>che segua un pastorel che lei non curi,</l>
             <l>et ch'ella lui più che se stessa brami.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Che fa qui sì soletta questa nimpha</l>
             <l>cui porta tanto amor' il crudo <name>Erasto</name>,</l>
             <l>Ben che lo fugge più ch'agnella lupo?</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>L'altrhier, porgendo a le mie stanche membra</l>
             <l>dolce riposo sotto ombroso faggio</l>
@@ -2023,11 +2063,11 @@ Madama Leonora da Este.</salute>
             <l>simil' a queste o tai parole usando,</l>
             <l>fea d'ogn'intorno risonar' i boschi.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>A tempo qualche cosa a udir son giunta.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>"Perché vuoi tu lasciar, benigno <name>Erasto</name>,</l>
             <l>d'amar nimpha sì bella com'io sono,</l>
@@ -2040,11 +2080,11 @@ Madama Leonora da Este.</salute>
             <l>et la ruina tua? Tienti pur morto,</l>
             <l>s'avien che la sua dea mai se n'avegga."</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Costei dice di me certo et d'<name>Erasto</name>.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>"Per te, crudel più che selvaggio toro,</l>
             <l>lasciato ho il mio <name>Turico</name>, pastor tale</l>
@@ -2061,13 +2101,13 @@ Madama Leonora da Este.</salute>
             <l>Perché dunque mi fuggi, <name>Erasto</name> altero?</l>
             <l>Perché non degni così bella nimpha?"</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>So che di passo in passo, ad una ad una</l>
             <l>notò le mie parole, hor segui pure.</l>
           </sp>
           <pb n="Elr"/>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>"Perché, lassa,"dicea, "perché rifiuti</l>
             <l>ciò che ti dona chi per te si strugge?</l>
@@ -2099,7 +2139,7 @@ Madama Leonora da Este.</salute>
             <l>E simil' altre parolette usando</l>
             <l>c'havrian mosse a pietà l'onde et i venti.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>S'io non credessi ancor che 'l vago arciero</l>
             <l>t'havesse a trappassar quel duro petto</l>
@@ -2108,13 +2148,13 @@ Madama Leonora da Este.</salute>
             <l>troncherei sì che la natura insieme,</l>
             <l>volendo, non potria porle 'n <num value="1000">mill</num>'anni.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Ma non è questa quella bella nimpha</l>
             <l>che pur hor nominava? Ella è per certo.</l>
             <l>Ecco che verso me vien passo passo.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>S'io potessi levarle quella cinta</l>
             <l>che porta intorno, <name>Amor</name> potria ferirla.</l>
@@ -2125,7 +2165,7 @@ Madama Leonora da Este.</salute>
             <l>Ch'esser non può, ch'essendo bella, <name>Amore</name></l>
             <l>in te non habbia la sua gratia infusa.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Senza ch'altri te 'l dica tu ben sai</l>
             <l>nimpha gentil, che 'n me non ha possanza</l>
@@ -2136,20 +2176,20 @@ Madama Leonora da Este.</salute>
             <l>a cui la di noi cura ingombra il petto</l>
             <l>via più che de l'istessa sua persona.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Ho più volte disio non poco havuto</l>
             <l>d'entrar nel vostro choro, ma una nimpha</l>
             <l>con false paroline il cor mi trasse</l>
             <l>da quella così degna e honesta impresa.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Che cosa potea mai dir la malvagia</l>
             <l>(sia qual si fosse) che potesse un core</l>
             <l>dal suo primo voler trar con parole?</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Potria porr'amistà tra il nibbio e 'l corvo,</l>
             <l>tanto sa ben parlar. Deh, nota il modo</l>
@@ -2180,7 +2220,7 @@ Madama Leonora da Este.</salute>
             <pb n="E3r"/>
             <l>onde 'l mel mi si fa fele et veleno.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Quando un si sente 'n qualche error' avinto</l>
             <l>vorria che 'n quel cadesse il mondo tutto.</l>
@@ -2189,18 +2229,18 @@ Madama Leonora da Este.</salute>
             <l>per volger fosse mai da quel che prima</l>
             <l>mi mostrò il cielo in sin da' tener anni.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Deh, se sei nimpha, come mostri, adorna</l>
             <l>di cortesia, deh, non negarmi il primo</l>
             <l>piacer che 'l troppo ardir mio ti chied'hora.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Chiedi ciò che tu vuoi, che se fia cosa</l>
             <l>che si possa per me, non te la nego.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Mostra, ti prego, quella benda ch'opra</l>
             <l>sì forte contra <name>Amor</name> lascivo, s'io</l>
@@ -2214,7 +2254,7 @@ Madama Leonora da Este.</salute>
             <pb n="E3v"/>
             <l>Seguendo vai hor questa fera hor quella.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Quantunque espressamente ci habbia imposto</l>
             <l>l'alta reina nostra che da torno</l>
@@ -2224,35 +2264,35 @@ Madama Leonora da Este.</salute>
             <l>de la mia dea che 'n tuo favor si volga.</l>
             <l>Poi vuò che tu mi renda il mio legame.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Ah, nimpha più cortese che natura,</l>
             <l>non dubitar, farò quanto a te piace.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l part="I">Slegal tu stessa.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">O membra delicate.</l>
             <l>Eccolo, sii contenta, poic'hai fatto</l>
             <l>il più, di far' il men. Legalo, nimpha,</l>
             <l>che da me non potrei. Tu stringi forte.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Sorella mia lo stringer forte importa,</l>
             <l>che se non fosse stretto, il suo vigor,</l>
             <l>se non del tutto, in parte perderebbe.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Stringe quanto tu vuoi, quanto ti pare,</l>
             <l>che tu ben dei saper come si faccia.</l>
             <l>Hor porge a la tua dea qualche preghiera.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>O alta dea, che i bianchi cervi desti</l>
             <pb n="E4r"/>
@@ -2276,40 +2316,40 @@ Madama Leonora da Este.</salute>
             <l>qui sotto questo faggio,</l>
             <l>ond' ella vuol lasciar <name>Venere</name> e <name>Amore</name>.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Sento pastori assai tra queste frondi</l>
             <l>venir con passo frettoloso et presto,</l>
             <pb n="E4v"/>
             <l>leva, su, non istar più così, nimpha.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l part="I">Chi son costor?</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">É parte di pastori,</l>
             <l>c'hoggi van celebrando intorno intorno</l>
             <l>i giochi che si fanno a <name>Pan Liceo</name>.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Rendemi, nimpha, la mia benda prima</l>
             <l part="I">ch'aggiungano, fa' tosto.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Aspetta, aspetta,</l>
             <l>vuoi che veggan che m'alzi e panni al vento?</l>
             <l>Tantosto passeranno, ecco son giunti.</l>
             <l>Tanto più tempo <name>Amor</name> 'havrà di trarle.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Oimè.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Non dubitar, che non dan noia.</l>
           </sp>
@@ -2319,7 +2359,7 @@ Madama Leonora da Este.</salute>
             <hi rend="sc">SCENA III</hi>
           </head>
           <stage>Sacerdote. Choro</stage>
-          <sp>
+          <sp who="#sacerdote">
             <speaker>Sacerdote</speaker>
             <l>Tu, c'hai le corna risguardanti al cielo,</l>
             <l>fisse ne l'ampia fronte et spaciosa,</l>
@@ -2333,11 +2373,11 @@ Madama Leonora da Este.</salute>
           </sp>
           <pb n="E5r"/>
           <stage>Il Choro risponde in musica.</stage>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l>O <name>Pan Liceo</name>, o <name>Pan Liceo</name>.</l>
           </sp>
-          <sp>
+          <sp who="#sacerdote">
             <speaker>Sacerdote</speaker>
             <l>Tu, che come ver re lo scettro tieni</l>
             <l>ne l'una man come celeste dono,</l>
@@ -2349,11 +2389,11 @@ Madama Leonora da Este.</salute>
             <l>mostrane e 'l tuo favore</l>
             <l>tanto grato a ciascuno, o <name>Pan liceo</name>.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l>O <name>Pan Liceo</name>, o <name>Pan Liceo</name>.</l>
           </sp>
-          <sp>
+          <sp who="#sacerdote">
             <speaker>Sacerdote</speaker>
             <l>Habbi del gregge et de l'armento cura,</l>
             <l>che va pascendo in queste folte selve,</l>
@@ -2366,7 +2406,7 @@ Madama Leonora da Este.</salute>
             <l>se 'l pregar nostro sale</l>
             <l>in sino a le tue orecchie, o <name>Pan Liceo</name>.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l>O <name>Pan Liceo</name>, o <name>Pan Liceo</name>.</l>
           </sp>
@@ -2376,14 +2416,14 @@ Madama Leonora da Este.</salute>
             <hi rend="sc">SCENA IV</hi>
           </head>
           <stage>Callinome. Stellinia</stage>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Deh, dimmi, nimpha mia, perché cagione</l>
             <l>Portano que' pastori quel flagello?</l>
             <l>Se sai tanto mistero et s'io son degna</l>
             <l part="I">di saperlo.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Lo tengono per questo,</l>
             <l>che le donne che son gravide vanno</l>
@@ -2393,45 +2433,45 @@ Madama Leonora da Este.</salute>
             <l>con l'huomo divenire non possa madre,</l>
             <l>subito par che 'l far figliuoli impetri.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Rider tu mi farai. O volentieri</l>
             <l>(se però non ti scommodo) verrei</l>
             <l>a veder tutto il resto di que' giochi,</l>
             <l>che 'ntendo che si veggon belle cose.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Bellissime nel ver. Ma chi ti tiene?</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Dubito che <name>Diana</name> nol risappia.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Deh, che vuoi star d'haver un giorno lieto,</l>
             <l>il qual sì tosto più non vederai,</l>
             <l>per dir che temi che <name>Diana</name> il sappia?</l>
             <l>Andiamo, andiamo, chi vuoi che le 'l dica?</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Gl'invidi del mio ben. Se mi prometti</l>
             <l part="I">di tacer, ne verrò.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Per questo giorno</l>
             <l>tanto solenne ti prometto ch'io</l>
             <l part="I">son per tacer. Andiamo.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l part="F">Dammi prima</l>
             <l part="I">la cinta mia.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Andiam pur, c'hor te la re<expan>n</expan>do.</l>
             <l>Fatt'ho pur tanto che cagione ancora</l>
@@ -2450,7 +2490,7 @@ Madama Leonora da Este.</salute>
             <hi rend="sc">SCENA I</hi>
           </head>
           <stage>Erasto solo</stage>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Ch'oltraggio, <name>Amor</name>, mi puoi tu far maggiore</l>
             <l>che pormi inna<expan>n</expan>zi a gli occhi il fo<expan>n</expan>te chiaro,</l>
@@ -2485,7 +2525,7 @@ Madama Leonora da Este.</salute>
             <hi rend="sc">SCENA II</hi>
           </head>
           <stage>Orenio. Erasto</stage>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Deh, perché non mi diede 'l ciel cent'occhi</l>
             <l>alhor ch'io nacqui, come diede ad <name>Argo</name>?</l>
@@ -2495,12 +2535,12 @@ Madama Leonora da Este.</salute>
             <l>il giovinetto <name>Erasto</name>. Ai sorte iniquia,</l>
             <l>ai maledetto fato, o giorno oscuro.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Misero me, che lamentevol voce</l>
             <l>è quella ch'odo del pastor <name>Orenio</name>?</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Deh, <name>Amor</name>, non ti rincresca, se i miei preghi</l>
             <pb n="E7v"/>
@@ -2514,36 +2554,36 @@ Madama Leonora da Este.</salute>
             <l>in pericol di morte ritrovarsi,</l>
             <l>deh, che farai, meschin, di', che farai?</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Udito non m'ha ancor, né ancor m'ha visto.</l>
             <l part="I"><name>Orenio</name>, <name>Orenio</name>.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l part="F">O caso horre<expan>n</expan>do et strano.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l part="I"><name>Orenio</name>?</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l part="M">O, tu se' qui.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l part="F">Più volte, <name>Orenio</name>,</l>
             <l>io t'ho chiamato, ma di quei più sordo</l>
             <l>sei che sogliono star d'intorno al <name>Nilo</name>.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Perdonami il mio <name>Erasto</name>, che 'l gran caso</l>
             <l>ove havea posto ogni mio senso e vista</l>
             <l>è cagion ch'io non veggo et ch'io non sento.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Non altramente che da vento scossa</l>
             <l>foglia leggiera, il cor nel petto trema,</l>
@@ -2553,7 +2593,7 @@ Madama Leonora da Este.</salute>
             <l>può mai fortuna dar' in un sol punto,</l>
             <l>pur che sia salva la nimica mia.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>A punto, <name>Erasto</name>, quella nimpha bella</l>
             <l>che tu speravi pur volger col tempo,</l>
@@ -2562,14 +2602,14 @@ Madama Leonora da Este.</salute>
             <l>tanto propitia non le fosse, ch'oltre</l>
             <l>il giuditio ch'io fo non me 'ngannassi.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Oimè, che cosa, <name>Orenio</name>, da te intendo.</l>
             <l>Dimmi, ti prego, questa gran cagione,</l>
             <l>che più non son per contemplar quel viso,</l>
             <l>viso ch'a un tempo mi da vita et morte.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Benché, <name>Erasto</name>, mi paia duro et aspro</l>
             <l>il raccontarti cosa onde 'l dolore,</l>
@@ -2578,7 +2618,7 @@ Madama Leonora da Este.</salute>
             <l>qualche rimendio, benché spero invano,</l>
             <l>ti farò aperto quel che t'era occulto.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Se gli è mal, o gran <name>Giove</name>, che sia senza</l>
             <l>qualche rimedio, dammi morte prima</l>
@@ -2591,23 +2631,23 @@ Madama Leonora da Este.</salute>
             <hi rend="sc">SCENA III</hi>
           </head>
           <stage>Stellinia. Orenio. Erasto</stage>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Ecco il mio <name>Erasto</name>, ecco il mio dolce amante.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l><name>Erasto</name> mio, gentil come figliuolo,</l>
             <l>tu sai c'hoggi <name>Callinome</name> tua nimpha,</l>
             <l>condotta da maligna et fera stella,</l>
             <l>venne a veder' i sacrifici nostri.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Di <name>Callinome</name> è 'l lor ragionamento,</l>
             <l>non può far ch'io non oda qualche cosa.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Io la vidi per certo con <name>Stellinia</name>,</l>
             <l>et mi parea veder' a punto un tauro</l>
@@ -2615,7 +2655,7 @@ Madama Leonora da Este.</salute>
             <l>si senta l'un de' corni, sì smarrita</l>
             <l part="I">si mostrava nel viso.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l part="F">Dubitava</l>
             <l>di quel che gli è avenuto, che <name>Diana</name></l>
@@ -2629,12 +2669,12 @@ Madama Leonora da Este.</salute>
             <l>sparge tal fiamma, che 'l suo proprio cerchio,</l>
             <l>quantunque freddo, accenderia volendo.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Oimè, ch'io temo che quest'ira et sdegno</l>
             <l>non sia cagion di più che d'una morte.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Questo non so, so ben ch'a questa nimpha,</l>
             <l>per quanto si comprende, incresce assai</l>
@@ -2642,22 +2682,22 @@ Madama Leonora da Este.</salute>
             <l>poiché sovente con parlar sommesso</l>
             <l>par che 'l tuo nome sospirando chiami.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l><name>Amor</name> forse l'ha punta. Ah dunque, <name>Orenio</name>,</l>
             <l>s'usa così verso il tuo <name>Erasto</name>, a darli</l>
             <l>con tanto amar questa sì dolce nova?</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Dolce nova ti par ciò ch'io vuò dirti?</l>
             <l>Non dei dunque saper perché ti chiami.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l part="I">Aspetto che me 'l dichi.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l part="F">Oimè, <name>Diana</name>,</l>
             <l>non sapendo in qual guisa darle morte</l>
@@ -2675,17 +2715,17 @@ Madama Leonora da Este.</salute>
             <l>A te procuri, e a te la vita serbi</l>
             <l>s'a la vita di lei soccorso porgi.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l part="I">Oimè, che è quel ch'io odo?</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l part="F">Homai pon fine</l>
             <l>a i sospiri, et con fatti et con parole</l>
             <l>cerca lo scampo suo, purché l'aiuti.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Che vi posso far' io senza tuo aiuto</l>
             <l>et senza tuo consiglio? Che ben sai</l>
@@ -2694,7 +2734,7 @@ Madama Leonora da Este.</salute>
             <l>se cosa sai che 'n tal bisogno possa</l>
             <l part="I">esser di giovamento alcuno.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l part="F">É vero</l>
             <l>ch'appo me già tener solea un secreto</l>
@@ -2705,17 +2745,17 @@ Madama Leonora da Este.</salute>
             <pb n="F2r"/>
             <l>che soverrammi dov'i' l'habbia posto.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Fa' pur quanto tu vuoi, che poco aiuto</l>
             <l>dar si può a quel che 'n simil caso è posto.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Non ti rimembra al men ciò che bisogna</l>
             <l part="I">a porlo insieme?</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l part="F">Sì, ma non è cosa</l>
             <l>che si faccia sì tosto come pensi.</l>
@@ -2728,22 +2768,22 @@ Madama Leonora da Este.</salute>
             <l>Ma hora mi sovien dove l'ho posto,</l>
             <l>andia<expan>m</expan>, ch'io l'ho a man salva.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>A<expan>n</expan>diamo, <name>Orenio</name>,</l>
             <l>che del più ardito paio di mie' agnelli</l>
             <l>ti faccio don, se questo ha buon effetto.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Fatt'io la prova ho più di <num value="10">diece</num> volte.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>O, fosti per lo collo a un tronco appeso,</l>
             <l>Isposto a' corvi in solitario bosco.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Andiamo adunque, et non tardiam di gratia,</l>
             <l>che s'io soccorro lei con questo aiuto,</l>
@@ -2751,11 +2791,11 @@ Madama Leonora da Este.</salute>
             <l>ben sarà tigre, od orsa se poi nega</l>
             <l>di volermi accettar per suo compagno.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Con questo patto pria l'astrengeremo.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Fuor di proposto non mi par che sia.</l>
             <l>il ciel ne sia propitio, <name>Amor</name>', e <name>Pane</name>.</l>
@@ -2766,7 +2806,7 @@ Madama Leonora da Este.</salute>
             <hi rend="sc">SCENA IV</hi>
           </head>
           <stage>Stellinia sola</stage>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Misera me, ch'io credea haver la lepre</l>
             <l>al veltro posta in bocca, et ne fia lungi</l>
@@ -2833,31 +2873,31 @@ Madama Leonora da Este.</salute>
             <hi rend="sc">SCENA V</hi>
           </head>
           <stage>Carpalio. Turico</stage>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Considerando il mio gran mal, <name>Turico</name>,</l>
             <l>c'ho sofferto sin qui, render s<add>icuro</add></l>
             <l>ti puoi che 'n questo son per porr'ogn'opra</l>
             <l part="I">(che ch'ella sia) per amor tuo.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">Farai,</l>
             <l>gentil <name>Carpalio</name>, ad huom piacer cui tempo</l>
             <l>punto non leverà di rimembranza.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Se lei, <name>Turico</name>, aggiungo, et che sia sola,</l>
             <l>pensa pur ch'io farò ciò che tra noi</l>
             <l part="I">habbiam deliberato.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">Va' pur via,</l>
             <l>ch'io farò al detto fonte ch'è qui appresso.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Non in tempo più commodo di questo</l>
             <l>poteva intravenir, c'hor non si vede</l>
@@ -2866,7 +2906,7 @@ Madama Leonora da Este.</salute>
             <l>di quella nimpha di <name>Diana</name>, astretta</l>
             <l>a porsi al gran contrasto del cinghiale.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>S'ella ne scampa, fia voler del cielo,</l>
             <l>ma non già per sua forza. Ma lasciamo</l>
@@ -2875,16 +2915,16 @@ Madama Leonora da Este.</salute>
             <l>che non troppo lontan quindi esser deve,</l>
             <l part="I">s'a quel pastor creder si dee.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l part="F">Gli è huomo</l>
             <l>da me fidel provato in ogni conto.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="I">Hor va', che là t'aspetto.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l part="F">Io vado, io vado.</l>
           </sp>
@@ -2894,7 +2934,7 @@ Madama Leonora da Este.</salute>
             <hi rend="sc">SCENA VI</hi>
           </head>
           <stage>Carpalio solo</stage>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>O <name>Amor</name>, di quante cose sei cagione.</l>
             <l>Vedi come tu privi l'huom d'ingegno,</l>
@@ -2976,7 +3016,7 @@ Madama Leonora da Este.</salute>
             <hi rend="sc">SCENA VII</hi>
           </head>
           <stage>Stellinia. Satiro</stage>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Oimè, ch'è questo? Oimè, chi qui m'ha avinta?</l>
             <l>Chi è stato questo tristo? A questo modo?</l>
@@ -2988,85 +3028,85 @@ Madama Leonora da Este.</salute>
             <l>Deh, perché 'l ciel non manda qui un pastore</l>
             <l>che mi venga aiutar' a l'improviso?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Io sento lamentarsi fortemente,</l>
             <l>et mi par voce feminil. Se cieco</l>
             <l>non son, questa è una nimpha ch'è qui presa.</l>
             <l part="I">O caso strano.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">O satiro malvagio,</l>
             <l>O satiro crudele. Certo è stato</l>
             <l part="I">egli che m'ha qui avinta.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">O bella nimpha,</l>
             <l>chi è stato quel sì tristo et sì perverso</l>
             <l part="I">che qui t'avinse?</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Se tu non sei stato,</l>
             <l>imaginar nol mi saprei giamai.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Non dir già questo, nimpha, ch'io non fui,</l>
             <l>et mi vergognerei far tale scherzo.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Se non sei stato tu, slegami adunque.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Slegarti? O, o, non sai ch'io son nimico</l>
             <l>di voi nimphe, che noi satiri tanto</l>
             <l part="I">havete 'n odio.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Slegami, di gratia.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Dammi il tuo nome.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Il mio nome è <name>Stellinia</name>.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I"><name>Stellinia</name>?</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="M">Sì, <name>Stellinia</name>.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">A punto è dessa.</l>
             <l part="I">Dove è il tuo arco?</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="M">Eccolo là.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Di tasso.</l>
             <l part="I">É questa.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Che vuoi far, di', del mio arco?</l>
           </sp>
           <pb n="F7r"/>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>O, o, che ne vuò far hora il saprai.</l>
             <l>Hoggi da me non sei per dipartirti,</l>
@@ -3074,31 +3114,31 @@ Madama Leonora da Este.</salute>
             <l>vuò giocar teco a singolar battaglia</l>
             <l>del modo che natura e <name>Amor</name> comanda.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Deh, slegami, et dopo ciò che tu vuoi</l>
             <l part="I">chiedemi, che l'havrai.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Ciò, che t'ho detto</l>
             <l part="I">voglio, et non altro.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Io ti farò contento,</l>
             <l>ma slegami, di gratia, che le mani</l>
             <l>tutte son dormentate, né le sento.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Mi prometti di dar ciò che ti chieggio?</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="I">Lo ti prometto, dico.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Ecco, ti slego,</l>
             <l>ma guarda non fuggir, che ben tu sai</l>
@@ -3107,15 +3147,15 @@ Madama Leonora da Este.</salute>
             <l>donna ch'al mondo o in queste selve sia.</l>
             <l part="I">Sei slegata?</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Sì sono, et ti ringratio.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Ogni promessa è debita.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Gli è 'l vero.</l>
             <l>Ma, satiro mio bel, satiro ornato,</l>
@@ -3127,71 +3167,71 @@ Madama Leonora da Este.</salute>
             <l>ardirei discoprirti quel che volle</l>
             <l>che 'n donna fosse la natura ascoso.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Io son contento far ciò che tu vuoi,</l>
             <l>pur che sicuro sia che tu non fugga.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Tien saldo questo lembo de la vesta,</l>
             <l>e tienlo stretto, se tu temi ch'io</l>
             <l>voglia ingannarti. Sei sicuro ancora?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>La vuò tener con ambedue le mani.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="I">Tu mostri di fidarti mal.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Parole.</l>
             <l>Horsù, veniamo al fin, vuoi tu abbendarmi?</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="I">Sì voglio.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Horsù, di' pur, che vuoi ch'io faccia?</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Corcati in terra ch'appo te mi corco</l>
             <l part="I">hor' hor' anch'io.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="M">Su corcati.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Horsù aspetta,</l>
             <l>oimè mi vuoi fiaccare? Aspetta alqua<expan>n</expan>to.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Non posso più aspettar.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Sei frettoloso,</l>
             <l>aspetta, dico, ch'io vuò prima dire</l>
             <l>certi miei preghi a <name>Venere</name> e a <name>Cupido</name></l>
             <l>perché buon fin nostro desio consegua.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Di' pur ciò che tu vuoi, purché sia breve.</l>
           </sp>
           <pb n="F8r"/>
           <stage>Mentre la nimpha dice le infrascritte parole, lega la sua sopravesta aperta dinanzi a un albero vicino.
 Et poi si parte pian piano.</stage>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l><name>Venere</name> bella, e tu, suo figlio <name>Amore</name>,</l>
             <l>concedete a' <num value="2">duo</num> amanti</l>
@@ -3200,7 +3240,7 @@ Et poi si parte pian piano.</stage>
             <l>(mentre scalda del sol l'ardente raggio)</l>
             <l>godino fresco e sempiterno maggio.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Hai tu finito? Di'? Tu non rispondi.</l>
             <l>O là, sei sorda? Dimmi, hai tu finito?</l>
@@ -3230,7 +3270,7 @@ Et poi si parte pian piano.</stage>
             <hi rend="sc">SCENA I</hi>
           </head>
           <stage>Satiro solo</stage>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Io credo che costei si sia disfatta</l>
             <l>o che si sia conversa in fior o in fonte.</l>
@@ -3291,7 +3331,7 @@ Et poi si parte pian piano.</stage>
             <hi rend="sc">SCENA II</hi>
           </head>
           <stage>Stellinia. Satiro</stage>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Io non lo veggo, certo è andato altrove.</l>
             <l>Ah ah, rider conviemmi, questa bestia</l>
@@ -3299,12 +3339,12 @@ Et poi si parte pian piano.</stage>
             <l>che si credea ingannarmi. O gran peccato</l>
             <l part="I">ch'io non lo contentassi.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Vieni, vieni.</l>
             <l>Piglia la vesta, se tu vuoi ch'io rida.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Ma dov'è la mia vesta? Forse questo</l>
             <l>buffal per mio dispregio l'havrà tolta.</l>
@@ -3314,33 +3354,33 @@ Et poi si parte pian piano.</stage>
             <l>Ch'aggiunger non vi possa. O bella prova,</l>
             <l part="I">O bello scherno.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Senti, senti come</l>
             <l part="I">mi vitupera et morde.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">O, che vuol dire</l>
             <l part="I">che quest'albero è aperto?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Oimè, l'aguatto</l>
             <l part="I">discoprirà.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Costui nel salir forse</l>
             <l>qui sopra per lo peso l'ha schiantato</l>
             <l part="I">in <num value="2">due</num> parti.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Ha proposo ella et risciolto,</l>
             <l>più non temo. Su, spacciati e fa' tosto.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Ma non vuò star più qui, che la disgratia</l>
             <l>non rimenasse qui quell'animale,</l>
@@ -3349,11 +3389,11 @@ Et poi si parte pian piano.</stage>
             <l>Oimè son morta, oimè, oimè meschina.</l>
           </sp>
           <pb n="G2v"/>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Ecco che 'l tordo è dato ne la pania.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>O satiro malvagio, oimè, di novo</l>
             <l>mi ci ha pur colta. Oimè, questo è un inganno</l>
@@ -3361,46 +3401,46 @@ Et poi si parte pian piano.</stage>
             <l>Oimè, da me non posso, oimè, il mio braccio.</l>
             <l part="I">O me infelice.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Sì tu vi sei giunta?</l>
             <l>A questo modo tu ti pigli gioco</l>
             <l>del fatto mio? Così i satiri inganni?</l>
             <l part="I">Perfida et disleale.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Oim?eschina</l>
             <l>Mi chiamo in colpa, oimè, di ciò c'ho fatto.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Colpa a tua posta.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Eh aiutami, ti prego.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Aiuto non havrai da me, ch'usarmi</l>
             <l part="I">non devevi tal' atto.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Oimè, l'amore</l>
             <l>de la mia castità questo volea.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>L'amor ne i dei maggior dev'esser sempre.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>La fede che già diedi al mio compagno</l>
             <l part="I">questo non richiedea.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">La fede c'hebbi</l>
             <l>inverso te quando ti diedi aiuto</l>
@@ -3413,19 +3453,19 @@ Et poi si parte pian piano.</stage>
             <l>"Metteti un velo a gli occhi." Tristarella,</l>
             <l part="I">sfacciata che tu se'.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Non son per trarre</l>
             <l>più da costui pietà, poic'ha sì in odio</l>
             <l part="I">il sesso feminil.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">L'ho in odio a punto</l>
             <l>che voi donne cagion sete, che l'huomo</l>
             <l>non habbia in questo mondo alcun riposo.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Perché, satiro mio, hai qualche sdegno</l>
             <l>d'altra cagion, sol per sfocarti contra</l>
@@ -3435,35 +3475,35 @@ Et poi si parte pian piano.</stage>
             <l>forse ti roderai, et d'haver detto</l>
             <l>contra noi cosa che sia men che degna.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Favole.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Eh dammi, satiro gentile,</l>
             <l>aiuto, che vedrai ch'a servir donna</l>
             <l>non si può perder mai, anzi s'acquista.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Di' pur ciò che tu vuoi.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="M">Deh, dammi aiuto.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Deh sì, per Dio.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>E se poi non ti faccio</l>
             <l>contento, d'ogni morte fammi rea.</l>
           </sp>
           <pb n="G3v"/>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Ma che? Havendo costei ne le mie forze,</l>
             <l>per suo maggior dispregio, per l'inganno</l>
@@ -3471,7 +3511,7 @@ Et poi si parte pian piano.</stage>
             <l>senza riguardo haver' a l'honor suo,</l>
             <l part="I">adempir le mie voglie?</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Oimè meschina.</l>
           </sp>
@@ -3481,12 +3521,12 @@ Et poi si parte pian piano.</stage>
             <hi rend="sc">SCENA III</hi>
           </head>
           <stage>Turico. Satiro. Stellinia</stage>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Oimè, che fa quel satiro malvagio</l>
             <l part="I">qui d'intorno a <name>Stellinia</name>?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Pensa pure</l>
             <l>che mi vuò contentar senza aiutarti,</l>
@@ -3496,66 +3536,66 @@ Et poi si parte pian piano.</stage>
             <l>con qualche inganno qui mi troverei</l>
             <l>deluso. Non mai più mi fido in donna.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="I">Oimè meschino.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="M">Ai povera <name>Stellinia</name>.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Sì tu piangi?</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Ai rubaldo, comportarti</l>
             <l part="I">debbo io questo giamai?</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Aiuto, aiuto.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Gli è tempo homai. O là, <name>Silvan</name>, <name>Dametha</name>,</l>
             <l><name>Carpalio</name>, su, pastori, su, correte.</l>
             <l>Oimè, la mia <name>Stellinia</name>, adosso, adosso.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Oimè rotto è 'l disegno.</l>
           </sp>
           <pb n="G4r"/>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">Dalli, dalli.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Tempo non è di star più qui.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">Tu fuggi.</l>
             <l>Non dubitar, <name>Stellinia</name>, io son <name>Turico</name>,</l>
             <l>Ch'a tempo e ad hora ti può dar le mani.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>O <name>Turico</name> gentil, gentil <name>Turico</name>,</l>
             <l>deh, se calti di me, dammi soccorso</l>
             <l>ch'ad altro effetto il ciel qui non ti spinse.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Ecco ch'io vuò aiutarti, tu fa poi</l>
             <l>ciò che ti piace: assai mi basta ch'io</l>
             <l>ti mostri l'amor mio tanto più verde</l>
             <l>quanto fu il tuo ver me sempre più secco.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Quando potrò giamai, anima mia,</l>
             <l>conforto mio, di questo sì bel merto</l>
@@ -3563,18 +3603,18 @@ Et poi si parte pian piano.</stage>
             <l>mi concedesser di <num value="1000">mill</num>'anni vita,</l>
             <l>renderti il guiderdon mai non potrei.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>O giorno aventuroso, o giorno lieto,</l>
             <l>tanto più accetto quanto men pensato.</l>
             <l>Ecco la vesta tua, ecco ogni cosa.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Aiutami, <name>Turico</name>, a rivestire,</l>
             <l part="I">ch'io non ho forza.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">Che? Ti duole? Lascia</l>
             <pb n="G4v"/>
@@ -3586,7 +3626,7 @@ Et poi si parte pian piano.</stage>
             <l>nol mi negar, poich'ogni tuo scontento</l>
             <l>m'annoia e ogni piacer tuo mi diletta.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l><num value="2">Due</num> volte, anima mia, qui in picciol tempo</l>
             <l>son con <num value="2">due</num> scorni stata avinta et presa.</l>
@@ -3597,7 +3637,7 @@ Et poi si parte pian piano.</stage>
             <l>sol perch'a lui di me copia non feci</l>
             <l>alhor che m'aiutò, legata essendo.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>O bella cosa s'io vi fossi stato.</l>
             <l>Ma il tristo ha havuto ardir di farti oltraggi</l>
@@ -3607,11 +3647,11 @@ Et poi si parte pian piano.</stage>
             <l>nel camin ritenuto, i' giungea a tempo.</l>
           </sp>
           <pb n="G5r"/>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Ma chi è questo pastor che 'n qua ne viene?</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Quest'è <name>Carpalio</name> mio, pastor cortese,</l>
             <l>qual satio di lodar non sarò mai.</l>
@@ -3622,7 +3662,7 @@ Et poi si parte pian piano.</stage>
             <hi rend="sc">SCENA IV</hi>
           </head>
           <stage>Carpalio. Turico</stage>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Ho sentito gridar' ad alta voce</l>
             <l>e mi parea <name>Turico</name>. Ma lo veggio</l>
@@ -3634,24 +3674,24 @@ Et poi si parte pian piano.</stage>
             <l>Prospera il ciel conservi questa copia</l>
             <l>et le lor greggie ognhor felici accresca.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Di simil gratia ancor te parimente</l>
             <l>faccia il ciel degno, poiché tu lo merti.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Tra me godo, <name>Turico</name>, sommamente</l>
             <l>sol per tuo amor, poiché sì ben condussi</l>
             <l>la lepre al varco ch'è rimasa presa.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Sopra questo con teco un'altra volta</l>
             <pb n="G5v"/>
             <l>vuò ragionar, un caso, o se sapesti.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Basta, quanto tu vuoi. Ecco <name>Melidia</name>,</l>
             <l>et par sì mesta et sconsolata in viso.</l>
@@ -3664,7 +3704,7 @@ Et poi si parte pian piano.</stage>
             <hi rend="sc">SCENA V</hi>
           </head>
           <stage>Melidia. Carpalio. Turico. Stellinia</stage>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>O cieco mondo, o pien d'inganni <name>Amore</name>,</l>
             <l>tu m'hai pur presa come pesce a l'hamo.</l>
@@ -3674,11 +3714,11 @@ Et poi si parte pian piano.</stage>
             <l>che mio fratel dar mi potria quand'egli</l>
             <l>sappia la cosa come stia tra noi.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Come senza ragion sospira et geme.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Se ben dirò ch'un satiro selvaggio</l>
             <l>(com'anco quasi inver m'è 'ntravenuto)</l>
@@ -3686,48 +3726,48 @@ Et poi si parte pian piano.</stage>
             <l>come spogliate siamo, altro di buono</l>
             <l>in noi non resta, creder non vorrallo.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l part="I">O, come teme.</l>
           </sp>
           <pb n="G6r"/>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l part="F">A posta mi son tolta</l>
             <l>di casa, ch'io non vuò la sua fierezza</l>
             <l>aspettar sola, io vuò cercar <name>Carpalio</name>,</l>
             <l>con cui sicura son per star mai sempre.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l part="I"><name>Melidia</name>, o là, <name>Melidia</name>.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l part="F">Chi mi chiama?</l>
             <l>O il mio <name>Carpalio</name>, di mia vita vero</l>
             <l>sostegno, ne le braccia tue mi pongo.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Che vuol dir questo? Di che cosa hai tema?</l>
             <l>Onde procedon queste tue querele?</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>O quanto poco è per durar' il nostro</l>
             <l>dolce piacer' e 'l nostro bel diletto.</l>
             <l>Oimè, ch'io temo del fratel mio crudo</l>
             <l>l'aspre minaccie et la vendetta horrenda.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Non dubitar, conforto mio, non darmi</l>
             <l>questo sì mal contento, te ne prego,</l>
             <l>che sì afflitta vedendoti non lasci</l>
             <l>ch'io prenda alcun piacer del mio conforto.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Quando l'huom pensa haver la rota in mano,</l>
             <l>e a suo bel grado di girarla crede,</l>
@@ -3737,13 +3777,13 @@ Et poi si parte pian piano.</stage>
             <l>Io mi credea <name>Carpalio</name> il più felice</l>
             <l>pastor del mondo, ed hor non mi par desso.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Deh, che farem <name>Carpalio</name>? Oimè, <name>Carpalio</name></l>
             <l>dammi conforto, ch'io mi sento l'alma</l>
             <l>venir' a meno et liquefarsi il core.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Non dubitar, non dubitar, <name>Melidia</name>,</l>
             <l>che se per te bisognerà ch'esponga</l>
@@ -3751,21 +3791,21 @@ Et poi si parte pian piano.</stage>
             <l>pronta sarà. Deh, lascia il porti affanno.</l>
             <l>Lascia questi sospir, questi singulti.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Tutta mi sento alleggerita et scarca</l>
             <l>poi che son ritornata al mio <name>Turico</name>,</l>
             <l>che pria parea che su le spalle havessi</l>
             <l>il mondo, et mi piegasse insino in terra.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Ti veggio, il mio <name>Carpalio</name>, in gran fastidio.</l>
             <l>La cagione non so, la cerco meno,</l>
             <l>ma se per te convien mia vita isporre,</l>
             <l>comandami, che pronto sarò sempre.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Non accade, <name>Turico</name>, io ti ringratio.</l>
             <l>Questa piaga non è cui uopo sia</l>
@@ -3774,7 +3814,7 @@ Et poi si parte pian piano.</stage>
             <l>il tuo fratel, con questo legno il tolgo</l>
             <l>(purché tu vogli) hor hor di questa vita.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Oimè, debbo io del sangue mio medesimo</l>
             <l>(ch'a un tempo nati siamo) divenire</l>
@@ -3784,13 +3824,13 @@ Et poi si parte pian piano.</stage>
             <l>la madre, i suoi fratelli et le sorelle.</l>
             <l>Muoia pur egli, et viviam lieti noi.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Ben fe natura a non dar forze a donna</l>
             <l>che invitta e' inespugnabil saria sempre.</l>
             <l>Ma chi è costui che vien sì lieto in viso?</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Gli è <name>Ophelio</name> nostro, che credea di porne</l>
             <l>in bel giardino e 'n selva oscura siamo.</l>
@@ -3801,7 +3841,7 @@ Et poi si parte pian piano.</stage>
             <hi rend="sc">SCENA VI</hi>
           </head>
           <stage>Ophelio. Carpalio. Melidia. Turico. Stellinia</stage>
-          <sp>
+          <sp who="#ophelio">
             <speaker>Ophelio</speaker>
             <l>Dove potrò trovar <name>Carpalio</name> mio?</l>
             <l>Dove <name>Melidia</name> da me tanto amata?</l>
@@ -3809,67 +3849,67 @@ Et poi si parte pian piano.</stage>
             <l>questa (come mi credo) grata nova.</l>
           </sp>
           <pb n="G7v"/>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Senti, <name>Melidia</name>, il nostro vecchio <name>Ophelio</name>,</l>
             <l>che noi cercando va con buona nova.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l part="I">Chiamiamilo.</l>
           </sp>
-          <sp>
+          <sp who="#ophelio">
             <speaker>Ophelio</speaker>
             <l part="F">Non credo che più a tempo</l>
             <l>cosa sì grata ad huom avenir possa.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l part="I"><name>Ophelio</name>.</l>
           </sp>
-          <sp>
+          <sp who="#ophelio">
             <speaker>Ophelio</speaker>
             <l part="F">Io ne ringratio il sommo <name>Giove</name></l>
             <l>c'ha morto un sol per conservarne <num value="2">duoi</num>.</l>
             <l>Benché morto non è, pur come morto</l>
             <l>starà da noi lontan qualch'anno intiero.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l part="I"><name>Ophelio</name>.</l>
           </sp>
-          <sp>
+          <sp who="#ophelio">
             <speaker>Ophelio</speaker>
             <l part="M">Chi mi chiama?</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l part="F">Il tuo <name>Carpalio</name></l>
             <l>et la <name>Melidia</name> tua, che te più a petto</l>
             <l part="I">han che la vita lor.</l>
           </sp>
-          <sp>
+          <sp who="#ophelio">
             <speaker>Ophelio</speaker>
             <l part="F"><name>Carpalio</name> mio,</l>
             <l><name>Melidia</name> mia, che nova, o Dio, che nova</l>
             <l part="I">v'apporto a l'improviso.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">Su, <name>Stellinia</name>,</l>
             <l>andiamo ancora noi a udir tal nova,</l>
             <l>che rallegrar mi possa con <name>Carpalio</name>.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Non ascoltiam, <name>Turico</name>, e fatti loro.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>E perché no, s'amici siam? Venite.</l>
             <l part="I">Che nova è questa?</l>
           </sp>
-          <sp>
+          <sp who="#ophelio">
             <speaker>Ophelio</speaker>
             <l part="F">Il tuo fratel, <name>Melidia</name>,</l>
             <l>mentre stava a mirar intento il porco</l>
@@ -3894,43 +3934,43 @@ Et poi si parte pian piano.</stage>
             <l>in questo mezo vi potrete dire</l>
             <l>i più felici giovani del mondo.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Ben v'ha provisto il cielo, c'havevamo</l>
             <l>dat'ordine levarli hoggi la vita.</l>
           </sp>
-          <sp>
+          <sp who="#meledia">
             <speaker>Meledia</speaker>
             <l>Dunque ha da ritornar dopo <num value="9">nov</num>'anni</l>
             <l part="I">huomo com'era prima?</l>
           </sp>
-          <sp>
+          <sp who="#ophelio">
             <speaker>Ophelio</speaker>
             <l part="F">Sì, purch'egli</l>
             <pb n="G8v"/>
             <l>non gusti, com'ho detto, carne humana,</l>
             <l>mentre lupo starà tra gli altri in schiera.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Oimè, saran pur pochi sol <num value="9">nov</num>'anni.</l>
           </sp>
-          <sp>
+          <sp who="#ophelio">
             <speaker>Ophelio</speaker>
             <l>Non dubitar, ch'egli potria fra tanto</l>
             <l>giunger' al fin de la sua trista vita.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l part="I">Io stupisco del caso.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l part="F">Et io, <name>Melidia</name>,</l>
             <l>non so se questo sogno o desto senta</l>
             <l part="I">narrarmi.</l>
           </sp>
-          <sp>
+          <sp who="#ophelio">
             <speaker>Ophelio</speaker>
             <l part="F">O voi felici, o gratia rara.</l>
             <l>Non so per amor vostro ch'io mi voglia,</l>
@@ -3939,22 +3979,22 @@ Et poi si parte pian piano.</stage>
             <l>sentia che 'n <num value="1000">mille</num> pezzi era diviso,</l>
             <l>sì come tra più veltri è un picciol lepre.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l><name>Carpalio</name>, mi rallegro del tuo bene,</l>
             <l>che sì insperatamente ti è avenuto.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Ben possiam dir, <name>Turico</name>, hoggi che 'l cielo</l>
             <l>ci ha rimenati a nova vita al mondo.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Senti, senti, <name>Carpalio</name>, ecco qui <name>Erasto</name></l>
             <l part="I">che sospirando viene.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Ecco 'l crudele</l>
             <l>ch'al fin non vien d'alcun contento suo.</l>
@@ -3966,32 +4006,32 @@ Et poi si parte pian piano.</stage>
             <hi rend="sc">SCENA VII</hi>
           </head>
           <stage>Erasto. Ophelio. Carpalio. Turico</stage>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Che vuoi tu far più in questo mondo, <name>Erasto</name>,</l>
             <l>poich'ogni stella a' tui disegni è contra?</l>
             <l>Che mi puoi far più, <name>Amor</name>? C'hai che tu serbi,</l>
             <l>che sia per darmi maggior duol di questo?</l>
           </sp>
-          <sp>
+          <sp who="#ophelio">
             <speaker>Ophelio</speaker>
             <l>Ecco, chi lieto in su la rota siede</l>
             <l>in questo mondo et chi nel basso cade.</l>
             <l>Questo pastor' al mio giuditio ha cosa</l>
             <l>che lo tormenta quanto dir si possa.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Ai fortuna malvagia, ai fero <name>Amore</name>,</l>
             <l>o <name>Amor</name> malvagio, o instabil dea, o dea</l>
             <l>ch'a un colpo hai tronco ogni disegno mio.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Tu che 'l più vecchio sei, chiamalo, <name>Ophelio</name>,</l>
             <l>e offerisce di noi l'opra, s'è buona.</l>
           </sp>
-          <sp>
+          <sp who="#ophelio">
             <speaker>Ophelio</speaker>
             <l>Gentil pastor, che 'n questi boschi hai preso</l>
             <l>così solingo aspro sentier da <num value="1000">mille</num></l>
@@ -4002,7 +4042,7 @@ Et poi si parte pian piano.</stage>
             <l>dimmi, se dir si può, questa sì horrenda</l>
             <l>cagion che di tal duol ti fa sì pieno.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Saggio pastor, più non convien ch'io dica</l>
             <l>l'alte querele e i gran sospiri e pianti</l>
@@ -4016,12 +4056,12 @@ Et poi si parte pian piano.</stage>
             <l>contra un crudel cinghial postole 'n contro</l>
             <l part="I">da la dea <name>Diana</name>.</l>
           </sp>
-          <sp>
+          <sp who="#ophelio">
             <speaker>Ophelio</speaker>
             <l part="F">Anzi sì. sciolla,</l>
             <l>e so ch'ella è rimasa vincitrice.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Però questo è cagion ch'io vuò con questo</l>
             <l>dardo darmi nel cor con le mie mani;</l>
@@ -4038,14 +4078,14 @@ Et poi si parte pian piano.</stage>
             <l>l'he prima havea contro costei</l>
             <l>tutto ha converso in più fervente amore.</l>
           </sp>
-          <sp>
+          <sp who="#ophelio">
             <speaker>Ophelio</speaker>
             <l>Non suol <name>Diana</name> già rimetter l'</l>
             <l>a chi l'e una sol volta; sai</l>
             <l>tu di certo che gratia habbia et pietà</l>
             <l>costei trovata appresso la reina?</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Non lo vuò già affermar, ma ben vuò dirti</l>
             <l>ch'i me n'to alcun inditio,</l>
@@ -4057,26 +4097,26 @@ Et poi si parte pian piano.</stage>
             <l>mi son partito, e ciò ch''a,</l>
             <l>ancor non so, ma temo sia in mio danno.</l>
           </sp>
-          <sp>
+          <sp who="#ophelio">
             <speaker>Ophelio</speaker>
             <l>Ancor non sai, come la cosa passi</l>
             <pb n="H2v"/>
             <l>et già ti tieni più che disperato.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Ai, s'essi, s'essi contra</l>
             <l>pormi a <name>Diana</name>, o che farei. O mondo,</l>
             <l>mi sei pur stato sepoltura eterna.</l>
           </sp>
-          <sp>
+          <sp who="#ophelio">
             <speaker>Ophelio</speaker>
             <l>Che vuoi tu far, poi che così a la dea</l>
             <l>piace: ben sai che contra i dei non ponno</l>
             <l>le forze humane, però ti consiglio</l>
             <l>A lasciar questa impresa.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Ai che co<expan>n</expan>siglio?</l>
             <l>Ai maledetto <name>Amor</name> cieco et nefando,</l>
@@ -4084,34 +4124,34 @@ Et poi si parte pian piano.</stage>
             <l>m'stri i lieti fiori et gli arbuscelli,</l>
             <l>ch'e et spine ha poi nel fin'e.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Non por la cosa tanto disperata,</l>
             <l>che forse ancor potresti haver un giorno</l>
             <l>da lei qualche conforto: il ciel sa fare,</l>
             <l>fratello, quando vuol, mirabil cose.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Chi è questo vecchio sì felice al mondo,</l>
             <l>al par di cui vien così bella nimpha?</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Questa è la nimpha mia, questa è colei</l>
             <l>che lo stame a mia vita accorcia et slunga.</l>
           </sp>
-          <sp>
+          <sp who="#ophelio">
             <speaker>Ophelio</speaker>
             <l>Se ti bisogna aiuto o di parole</l>
             <pb n="H3r"/>
             <l>o d' qui per te son preparato.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l> part="I"&gt;E noi tutti altri.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l part="F">Stiamo qui in disparte</l>
             <l>et ascoltiamo et, come 'o è buono</l>
@@ -4124,20 +4164,20 @@ Et poi si parte pian piano.</stage>
           <head><hi rend="sc">SCENA VIII</hi> et ultima.</head>
           <stage>Callinome. Orenio. Erasto. Turico. Ophelio.
 Stellinia. Carpalio. Melidia</stage>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Non si può inver dir'mente ch'</l>
             <l>fosti accorti et prudenti in darmi quello</l>
             <l>sì degno et salutifero secreto,</l>
             <l part="I">ch'alcun non se n'avide</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l part="F">Ben più saggia</l>
             <l>fosti tu, nimpha, in dar quel velo in pegno</l>
             <l part="I">al giovinetto <name>Erasto</name>.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l part="F">Io credea bene,</l>
             <l>che <name>Diana</name> dopo sì gran vittoria</l>
@@ -4147,12 +4187,12 @@ Stellinia. Carpalio. Melidia</stage>
             <pb n="H3v"/>
             <l>pur un sol punto, che mai non perdona.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Che volontà ti venne di venire</l>
             <l part="I">hoggi a que'i sacrifici?</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l part="F">Causa</l>
             <l>ne fu quella <name>Stellinia</name>, che 'me</l>
@@ -4163,35 +4203,35 @@ Stellinia. Carpalio. Melidia</stage>
             <l>odor de l' e alhor disio mi venne</l>
             <l part="I">stato è cagion.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l part="F">Deh dimmi, che pensiero</l>
             <l>è ' poi che <name>Diana</name> ti rifiuta?</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Andiamo tutti insieme e siate meco</l>
             <l>in volgerla, accadendo, che mi tolga</l>
             <l part="I">per suo co<expan>m</expan>pagno.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l part="F">Oimè, che turba è questa?</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="I">Non dubitar.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l part="M">Oimè.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">No<expan>n</expan> hai temuto</l>
             <l>un sì forte cinghiale, e temi hor noi?</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l><name>Erasto</name>, vieni innanzi et hor contempla</l>
             <l>quanto tu vuoi la tua leggiadra nimpha.</l>
@@ -4229,7 +4269,7 @@ Stellinia. Carpalio. Melidia</stage>
             <l>simil' parole, ma ben veggio</l>
             <l>che la tua buona volontà nol chiede.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>O, quant' tengo con costui.</l>
             <l>Non le hai pur detto, <name>Orenio</name>, come ricco</l>
@@ -4237,12 +4277,12 @@ Stellinia. Carpalio. Melidia</stage>
             <l>et di greggie et d'i et d'beni,</l>
             <l part="I">ch'reder nol vuol.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l part="F">Si fa tuo conto</l>
             <l>ch'ol dee saper sì ben com'</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Quanto forza d'<name>Amor</name> sia grande et forte</l>
             <l>ne la persona mia fatt'prova,</l>
@@ -4255,13 +4295,13 @@ Stellinia. Carpalio. Melidia</stage>
             <l>Ma tu, <name>Stellinia</name>, principal cagione</l>
             <l part="I">d'osa sei stata.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">É stato pure</l>
             <l>lo tuo sprezzar <name>Amor</name> che t'uto</l>
             <l>hoggi mostrar quanto sua forza vaglia.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Horsù lasciam da parte tai parole.</l>
             <l><name>Erasto</name>, poiché tu fosti cagione</l>
@@ -4269,15 +4309,15 @@ Stellinia. Carpalio. Melidia</stage>
             <l>ti diedi in pegno, ti vuò far contento,</l>
             <l>et in segno di ciò questo è l'o.</l>
           </sp>
-          <sp>
+          <sp who="#ophelio">
             <speaker>Ophelio</speaker>
             <l>Ha perduta la voce d'ezza.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Tutta mi sento lieta per suo amore.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>O dilettevol giorno, o giorno ameno.</l>
             <l>Ridono i prati, le campagne e i fiori,</l>
@@ -4292,37 +4332,37 @@ Stellinia. Carpalio. Melidia</stage>
             <pb n="H5v"/>
             <l>ove festa farem con canti e suoni.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Venite pur voi tutti al mio, che sorte</l>
             <l>a me non men ch6apos,a te stata è propitia</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Anzi, con me venir non vi sdegnate,</l>
             <l>che di sorte miglior' non ciedo.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Horsù, così si faccia. Hoggi noi tutti</l>
             <l>andiamo con <name>Erasto</name>, et con <name>Carpalio</name></l>
             <l>domani, et dopo andremo con <name>Turico</name>.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l part="I">Così è conchiuso?</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="M">E così sia.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l part="F">E sia.</l>
             <l>O il mio gentil'<name>Orenio</name>, la mia vita</l>
             <l>e ciò ch'e; mio, vuò che sia tuo per sempre.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Deh, poiché qui è <name>Carpalio</name> e 'hio <name>Orenio</name>,</l>
             <l>la mia <name>Stellinia</name> e 'uoso <name>Erasto</name>,</l>
@@ -4330,22 +4370,22 @@ Stellinia. Carpalio. Melidia</stage>
             <l>il primo loco, una canzone in lode</l>
             <l>di sì felice giorno andiam cantando.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l part="I">Egli è 'r, cantiamo pur.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l part="F">Cantiamo.</l>
             <l>Ma tu, <name>Turico</name>, c'oposo, dinne</l>
             <l>pria la canzon che vuoi che noi cantiamo.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Io son contento, horsù, poiché a voi piace.</l>
           </sp>
           <pb n="H6r"/>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>O dei silvestri, s'ui d'o</l>
             <l>è stato a udir le nostre fiamme vive</l>
@@ -4355,7 +4395,7 @@ Stellinia. Carpalio. Melidia</stage>
             <l>danzando in lieto corno,</l>
             <l>si sdegni d'r così bel giorno.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Andiam, non più, che l'de la notte</l>
             <l>qui non ci sovraggiunga. E voi, madonne,</l>

--- a/tei/beccari-il-sacrificio-1587.xml
+++ b/tei/beccari-il-sacrificio-1587.xml
@@ -82,6 +82,46 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="erasto">
+            <persName>Erasto</persName>
+          </person>
+          <person xml:id="orenio">
+            <persName>Orenio</persName>
+          </person>
+          <person xml:id="carpalio">
+            <persName>Carpalio</persName>
+          </person>
+          <person xml:id="turico">
+            <persName>Turico</persName>
+          </person>
+          <person xml:id="ofelio">
+            <persName>Ofelio</persName>
+          </person>
+          <person xml:id="satiro">
+            <persName>Satiro</persName>
+          </person>
+          <person xml:id="callinome">
+            <persName>Callinome</persName>
+          </person>
+          <person xml:id="melidia">
+            <persName>Melidia</persName>
+          </person>
+          <person xml:id="stellinia">
+            <persName>Stellinia</persName>
+          </person>
+          <person xml:id="sacerdote">
+            <persName>Sacerdote</persName>
+          </person>
+          <personGrp xml:id="coro">
+            <name>Coro</name>
+          </personGrp>
+          <person xml:id="brusco">
+            <persName>Brusco</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>2001-05-15T00:00:00.000+02:00</date><name>Roberta Fossali</name><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -506,7 +546,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
           </head>
           <pb n="14"/>
           <stage><name>Erasto</name> giovine, <name>Orenio</name> vecchio</stage>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Orrida selva, in cui piangendo spargo</l>
             <l>Gli ardenti miei sospir, gli accesi lai,</l>
@@ -530,14 +570,14 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Produr sì scorga fruttì sì mortalì</l>
             <l>Come fai tu, che gli amanti attoschi.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Se 'l chiaro giorno a me non è nimico</l>
             <l>Contro lo stile suo, questi ch'io veggo</l>
             <l>E' l'infelice <name>Erasto</name>, che sua vita</l>
             <l>Mena con tristi et angosciosi pianti.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Ben so, <name>Vener</name> gentil, se 'l ciel t'avesse</l>
             <l>Dato tanto poter quanto al tuo figlio,</l>
@@ -553,14 +593,14 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Estinguer, sì ch'oblia quanto dentro arse,</l>
             <l>Poich'amo e seguo chi mi fugge et odia?</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Misera gioventù, poi che 'l disio</l>
             <l>Di goder con amaro un poco dolce</l>
             <l>Qua e là girando ti trasporta e move,</l>
             <l>Qual posta al vento una minuta canna!</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Ben ti fu contra il ciel, misero <name>Erasto,</name></l>
             <l>A porti in servitù d'una crudele,</l>
@@ -587,11 +627,11 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>E la gran piaga che mi fece Amore.</l>
             <l>Però, chi più di me vive infelice?</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Tanto è misero l'uom quant'ei si tiene.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Ahi, <name>Callinome</name> ingrata, ahi quanti scorni</l>
             <l>Per te patisco, poi che la gran fama</l>
@@ -601,12 +641,12 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>E va mancando, qual accesa lampa</l>
             <l>Cui sia negato il nutritivo umore.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Costui non può adolcire un cor di donna,</l>
             <l>E faria per pietà movere i sassi.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Chi avea più grassa e più lanosa greggia?</l>
             <l>Chi armento più fecondo e prosperoso?</l>
@@ -621,7 +661,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Che più non entra ne l'usata mandra,</l>
             <l>Il mio venga a veder, né vadi altrove.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Che meraviglia, s'un che di sè cura</l>
             <l>O nulla o poca tien lascia l'agnelle</l>
@@ -635,18 +675,18 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>E sol questa cagion d'Amor deriva.
 <name>Erasto</name>, <name>Erasto</name>!</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Oh, 'l mio gentil <name>Orenio</name>!</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l><name>Erasto</name>, ov'è la tua prudenza e 'l senno?</l>
             <l>Ov'è 'l tuo bel governo, e la gran cura</l>
             <l>Ch'aver solevi di tua greggia, ch'ora</l>
             <l>Sparsa senza pastor se ne va intorno?</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l><name>Orenio</name> mio gentil, se 'l grand'amore</l>
             <l>Che tu portasti in vita a la tua <name>Crinia</name></l>
@@ -655,7 +695,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Sovengati de l'ore che tu invano</l>
             <l>Spendesti, <name>Orenio</name>, e del perduto tempo.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Ti prego, <name>Erasto</name>, per quel dolce nome</l>
             <l>De la nimica tua che t'è sì ingrata,</l>
@@ -672,7 +712,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Si pon veder tutti sanguigni e grassi.</l>
           </sp>
           <pb n="18"/>
-          <sp>
+          <sp who="#erasto">
             <speaker>
               <name>Erasto</name>
             </speaker>
@@ -683,7 +723,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Volte si son raccolte in campo spiche)</l>
             <l>Ne la memoria ancor porti e nel petto?</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Tal fu il mio amor verso colei che tanto</l>
             <l>Ardendo amai, che tempo, ora o stagione</l>
@@ -699,7 +739,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>D'odiar la <name>Crinia</name> mia, ch'avea nel core</l>
             <l>Sola fede scolpita e amor perfetto.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Se ben dura è la mia, convien, <name>Orenio</name>,</l>
             <l>Volendo o no, che questa ingrata segua,</l>
@@ -712,7 +752,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Matura, e nobil più de' pomi, e 'l cigno</l>
             <l>Di dolce canto al par di lei non vale.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Lasciamo, <name>Erasto</name>, il dolce ragionare</l>
             <l>Onde più tosto la nostr'alma langue,</l>
@@ -732,7 +772,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Sai ben che non bisogna, ove va il culto</l>
             <l>Divin, por cosa maculata e immonda.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>
               <name>Erasto</name>
             </speaker>
@@ -746,7 +786,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Che mal fa chi <num value="2">due</num> lepri a un tempo caccia.</l>
             <l>Però, che mi consigli in simil caso?</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>
               <name>Orenio</name>
             </speaker>
@@ -760,7 +800,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Sotto la noce o sotto il fral cipresso,</l>
             <l>Che simil ombre tua sciagura merta.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>
               <name>Erasto</name>
             </speaker>
@@ -774,7 +814,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
           </head>
           <pb n="20"/>
           <stage><name>Carpalio</name> giovine</stage>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Quando vedrai, <name>Carpalio</name>, che di timo</l>
             <l>L'api si pasceranno ne l'<name>Arcadia</name>,</l>
@@ -817,20 +857,20 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
           </head>
           <pb n="21"/>
           <stage><name>Turico</name> giovine, <name>Carpalio</name></stage>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Parmi la voce d'un pastor tra queste</l>
             <l>Selve sentir, che in lamentevol note</l>
             <l>Qualche gran caso sospirando esponga.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Questi è <name>Turico</name>, a l'abito, a la voce.</l>
             <l>Ben venga quel <name>Turico</name> e quel pastore,</l>
             <l>Di cui non ha tra tutti gli altri alcuno</l>
             <l>Il più felice e aventuroso tempo.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Era ben già che la <name>Stellinia</name> mia,</l>
             <l>In cui riposto avea tutto il mio bene,</l>
@@ -856,14 +896,14 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <pb n="22"/>
             <l>Se così poco appresso donna dura?</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Come può star che così bella ninfa,</l>
             <l>Come si sa, che t'avea dato il core,</l>
             <l>Ad altro amor, ad altro van desio</l>
             <l>Abbia senza vergogna il cor rivolto?</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Per questa sacra e immaculata selva,</l>
             <l>Ove non pose mai l'empia secure</l>
@@ -879,7 +919,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Tant'oltraggio m'ha fatto e tanto scorno</l>
             <l>Quanto questo pastor oggi ti dice.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>S'io credessi, <name>Turico</name>, che la mia</l>
             <l>Fosse a la tua di fede tal conforme,</l>
@@ -894,7 +934,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Ai segni e al ragionar, mostra d'amarmi</l>
             <l>Quanto stender si pon forze di donna.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Deh, se grave non t'è, pastor felice,</l>
             <pb n="23"/>
@@ -906,7 +946,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>E che ti sprona in sì sonore note</l>
             <l>In queste selve a ricordar d'Amore.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l><name>Turico</name>, vero onor di queste selve</l>
             <l>E de' pastori alta corona e pregio,</l>
@@ -923,12 +963,12 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Mi preme 'l piede, e a la sublime 'l braccio</l>
             <l>Quasi vittorioso in parte stendo.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Come star pon questi contrari insieme,</l>
             <l>Ch'a un tempo sii infelice e aventuroso?</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Io ti dirò. Felice son, ché i cieli</l>
             <l>Mi diero in sorte la più bella ninfa,</l>
@@ -942,11 +982,11 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Post'ha la spina a questa rosa in mezzo.</l>
           </sp>
           <pb n="24"/>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Onde vien, e di qual dea è la tua ninfa?</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Questa mia ninfa, anzi del ciel pur dea,</l>
             <l>Nacque nel mondo ben di qualche dio</l>
@@ -957,7 +997,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Affetto che con altri occhi non vede,</l>
             <l>Né conosce altro ben ch'ambedue noi.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Ben, ben conosco e l'uno e l'altra. O bella,</l>
             <l>O bella! So che 'l fiore hai conosciuto.</l>
@@ -966,7 +1006,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Il cui poter in lei dev'esser grande,</l>
             <l>Et essendo, com'è, libera e sciolta?</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Or vedi: il suo fratel tanto si mostra</l>
             <l>A me nimico fuor d'ogni ragione</l>
@@ -980,7 +1020,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>A questo nostro sì felice amore,</l>
             <l>E me rifiuta com'un vil capraro.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Forse il fratello, onde ambedue sian nati,</l>
             <l>Tra sé ritien ch'agevolmente ponno</l>
@@ -989,7 +1029,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <pb n="25"/>
             <l>Si sparga in questo sì celeste campo.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Ma ecco <name>Ofelio</name> mio, ecco il buon vecchio</l>
             <l>Dei <num value="2">due</num> gemelli, che non men si duole</l>
@@ -1001,15 +1041,15 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <hi rend="sc">SCENA IV</hi>
           </head>
           <stage><name>Ofelio</name> vecchio, <name>Carpalio</name>, <name>Turico</name></stage>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l>O buon principio! Ecco <name>Carpalio</name> mio.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Che vuoi, gentil <name>Ofelio</name>, che mi nomi?</l>
           </sp>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l>S'Amor oggi non dà quel lieto fine,</l>
             <l><name>Carpalio</name> figliuol mio, che tu e <name>Melidia</name></l>
@@ -1025,7 +1065,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Starà, tu con <name>Melidia</name> tua potrai</l>
             <l>Dar fine al tanto desiato amore.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Ma se fortuna, come suol, nimica</l>
             <l>A noi si facesse, discoprendo quello</l>
@@ -1033,33 +1073,33 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Che faremo? Qual fia po' il pensier nostro?</l>
           </sp>
           <pb n="26"/>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l>Diremo ch'alcun satiro o alcun fauno,</l>
             <l>O ver, che meglio fia, alcun dio del cielo</l>
             <l>Sotto mentita forma l'abbia presa,</l>
             <l>Levandole quel fior ch'altri avrà colto.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Merita peggio, poich'è sì malvagio,</l>
             <l>Né di rispetto se gli dee aver punto.</l>
             <l>Così potess'io fin porr'al mio male</l>
             <l>Come al ben tuo principio dar potrai!</l>
           </sp>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l>Andiamo, andiamo, che ciascun si pone</l>
             <l>In ordine per ire al sacrificio.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l><name>Turico</name>, se ti par ch'io possa aiuto</l>
             <l>Porgerti nel tuo amor, comanda pure,</l>
             <l>Ch'io son pastor ch'agevolmente servo</l>
             <l>Chiunque l'opra mia chiede in soccorso.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Di questa offerta e ti ringrazio e anch'io</l>
             <l>Mi t'offero per quanto pon patire</l>
@@ -1082,87 +1122,87 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
           </head>
           <pb n="27"/>
           <stage>Satiro, <name>Turico</name></stage>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Oh, oh, qualche pastor che si querela</l>
             <l>Di sua sorte infelice. Altro tra queste</l>
             <l>Selve or non s'ode che d'amor lamenti.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Possibil fia che un'altra volta Amore</l>
             <l>Non potrà intenerir quel duro petto,</l>
             <l>Ch'entro il velen d'ogn'aspra serpe inchiude?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Salvo sii, bel pastor.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F"><name>Satiro</name>, a <name>Dio</name>.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Ché ti vai querelando da te stesso</l>
             <l part="I">Così forte d'Amor?</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">Non tel vuo' dire.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Come, ché non vuoi dir?</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">No. Ché tu forse</l>
             <l part="I">Mel vorresti vietare?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Anzi, vuo' darti</l>
             <l part="I">(Se n'hai bisogno) qualche aiuto.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">Il tuo</l>
             <l>Aiuto poco curo, ch'al mio male</l>
             <pb n="28"/>
             <l part="I">Rimedio non avresti.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Dimmel dunque</l>
             <l part="I">Per cortesia.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">Ti dico che non voglio.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Tel farò dir mal grado tuo.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">Tu buono</l>
             <l>Sei per farmelo dir non volend'io?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Oh, in quanta poca riverenza siamo</l>
             <l>Noi satir, or che più non siam tenuti</l>
             <l>Né dei né semidei! Dunque ch'io possa</l>
             <l part="I">Farloti dir non credi?</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">Tu, né quanti</l>
             <l>Vorran saperlo a forza, il saperanno.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>O incredulo, o malvagio, a questo modo?</l>
             <l>Lascia, che mi dirai più che non voglio.</l>
@@ -1191,61 +1231,61 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Comincia: dimmi il nome di colei</l>
             <l part="I">Che lamentar ti fa.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F"><name>Stellinia</name> ha nome.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Di qual color si veste?</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">Di vermiglio.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Ove suol praticar?</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">Spesso qui intorno.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Orsù, sta ben: tu non l'hai detto a un sordo.</l>
             <l part="I">Di qual arbor ha l'arco?</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">Egli è di tasso.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Non so che chieder altro. Dimmi, è bella?</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="I">Bellissima.</l>
           </sp>
           <pb n="30"/>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="M">È cortese?</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">A me non troppo.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Di chi fu figlia?</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">De la bella <name>Clinia</name>.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Sarà al proposto. Oggi vuo' in ordin porre</l>
             <l>La mia trappola e qui stenderla, e quante</l>
@@ -1263,11 +1303,11 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Che sonnacchioso non la vederebbe.</l>
             <l>Tanto fa, se gli do ben ne la testa.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Ohimè, che vuol dir questo? Ove son io?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Guardati i piedi, guardati le gambe.</l>
           </sp>
@@ -1278,7 +1318,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
           </head>
           <pb n="31"/>
           <stage><name>Turico</name> solo</stage>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Ohimè, son morto; ohimè, che cosa è questa?</l>
             <l>Oh come son fuori di me! Mi sento</l>
@@ -1319,7 +1359,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
           </head>
           <pb n="32"/>
           <stage><name>Erasto</name>, <name>Callinome</name> ninfa di <name>Diana</name></stage>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Avea deliberato oggi di starmi</l>
             <l>Al sacrificio in compagnia d'<name>Orenio</name>,</l>
@@ -1343,7 +1383,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Ciò che seco ragiona, e a l'improviso</l>
             <l>Discoprirmele poi. Ecco ch'è giunta.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Sciolta da ogni pensier, da ogn'altra cura,</l>
             <l>Solinga me ne vo di selva in selva,</l>
@@ -1361,24 +1401,24 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>E breve via di gir ai Campi Elisi,</l>
             <l>Ove l'alme beate han il vero seggio?</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Se per esser crudel s'acquista il bene,</l>
             <l>Tu più d'ogn'altra ti poi dir contenta,</l>
             <l part="I">Poiché sì cruda sei.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l part="F">Lodato <name>Giove</name>,</l>
             <l>Ch'oggi non temerò che quel capraro</l>
             <l>D'<name>Erasto</name> mi dia noia, poiché tutti</l>
             <l>I pastor oggi vanno ai sacrifici.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Misero <name>Erasto</name>, a che congiunto sei!</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Però qui posso riposarmi senza</l>
             <l>Aver tema di lui. Ma chi veggo io</l>
@@ -1391,7 +1431,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Mi si accosti. Egli vien, ma vuo' mostrare</l>
             <l part="I">Di non temere.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l part="F">Io vuo' venirti incontra</l>
             <l>Perché bramo morir con le tue mani.</l>
@@ -1400,11 +1440,11 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l part="I">Quando venga da te.</l>
           </sp>
           <pb n="34"/>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l part="F">Sta' pur lontano.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Perché cerchi fuggir? Perché paventi?</l>
             <l>Di che vuoi tu temer? Deh, ferma il piede!</l>
@@ -1413,12 +1453,12 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Riverisce et onora, e che ti tiene</l>
             <l>Più che la vita sua cara et accetta.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Che mi potrai tu far, quando non voglia?</l>
             <l>Orsù, di' ciò che vuoi, di', che t'ascolto.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Quando fia mai, o dolce mia nimica,</l>
             <l>Ch'io venga al fin de le mie pene amare,</l>
@@ -1450,12 +1490,12 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Vienlo a toccar con mano et a chiarirti,</l>
             <l>Che troverai via più di quel c'ho detto.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Sei molto ricco, <name>Erasto</name>. Hai tu fors'altro</l>
             <l>Da dir? Perché vuo' andar al mio viaggio.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Non t'ho ancor detto com'un capriolo</l>
             <l>Ti serbo, e <num value="2">due</num> capretti di sì fatta</l>
@@ -1469,21 +1509,21 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>In contracambio un ricco vel donarmi.</l>
             <l>Ma senz'altro tuoi siano, e li ti dono.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Non me ne curo, <name>Erasto</name>, se ben fila</l>
             <l>D'argento i velli avessero, e le corna</l>
             <l>D'oro. Tienliti pur, o dalli altrui:</l>
             <l>Fanne pur ciò che vuoi, poiché son tuoi.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Ahi, <name>Callinome</name> dura più che un sasso,</l>
             <l>So ben ch'i doni miei sprezzi e non curi!</l>
             <l>Ma dove vai? Dove ne volgi il passo?</l>
             <l>Non ti partir, volgi la fronte alquanto.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>La riverenza ch'a la mia reina</l>
             <l>Debitamente porto vuol ch'io serbi</l>
@@ -1493,7 +1533,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Però cerca altra via, cerca altro amore,</l>
             <l>Se vuoi disacerbar questi tuo' affanni.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Te, <name>Callinome</name> ingrata, il ciel mi diede</l>
             <l>Ch'amassi e non altrui, né pensar ch'io</l>
@@ -1506,23 +1546,23 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Spargon talor perché lor porti amore,</l>
             <l>E lor per te, crudel, fuggo e disprezzo.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Fai male, <name>Erasto</name>, a non seguir chi t'ama.</l>
             <l>Io son brutta appo lor, segui pur quelle.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Anzi più bella, e tra lor sembri quale</l>
             <l>Tra le stelle minori il chiaro sole,</l>
             <l>E ben si vede, poi che come neve</l>
             <l>Mi struggo appresso te, né te ne cale.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Perché più non ti sfacci, io me ne vado.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Deh, fammi don nel tuo partir di questa</l>
             <l>Sol grazia per li tanti miei dolori</l>
@@ -1555,7 +1595,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <hi rend="sc">SCENA II</hi>
           </head>
           <stage>Satiro solo</stage>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Poich'è sì lieto e sì tranquillo il giorno,</l>
             <l>Non può far che le ninfe per li boschi</l>
@@ -1604,7 +1644,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <hi rend="sc">SCENA III</hi>
           </head>
           <stage><name>Melidia</name> ninfa, satiro</stage>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Quando, <name>Melidia</name>, avran le tue querele</l>
             <l>Qualche tregua o conforto? E quando lieta</l>
@@ -1623,12 +1663,12 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Perché non lievi il fratel mio del mondo</l>
             <l>Per salvar due così fideli amanti?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Nota, nota, che vuol che 'l fratel muoia</l>
             <l>Per darsi in preda a qualche vil pastore.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Deh, perché, Amor, mi fosti sì benigno?</l>
             <l>Perchè mi fosti sì contrario e averso?</l>
@@ -1637,11 +1677,11 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Ove apparasti sì maligne leggi</l>
             <l>Di dar sì lunghi affanni a' tuoi seguaci?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Ti seguirò ben io. Vien pur innanzi.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Non negherai già, Amor, che tu non sappi,</l>
             <l>Ché sanlo i boschi e le campagne e i fiori,</l>
@@ -1654,18 +1694,18 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Io vuo' veder di riposarmi alquanto</l>
             <l>Sotto questa ramosa et alta quercia</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Vieni un poco più inanzi, ancora un poco.</l>
           </sp>
           <pb n="40"/>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Attendendo se 'l mio dolce <name>Carpalio</name>,</l>
             <l>Rinovellando le sue antiche piaghe,</l>
             <l>Quinci prendesse quest'usato calle.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Senza troppo macchiar questa ho nel pugno.</l>
             <l>Siedi pur, ch'ora vengo. Ma vuo' prima</l>
@@ -1678,7 +1718,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <hi rend="sc">SCENA IV</hi>
           </head>
           <stage><name>Ofelio</name>, <name>Melidia</name>, satiro</stage>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l>Quando il lasso bifolco il campo pieno</l>
             <l>Intorno intorno di verdette biade</l>
@@ -1698,13 +1738,13 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>D'aver accoppiar questi due amanti</l>
             <l>Vai prolungando per più nostra pena.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Sei pur venuto, Amore, a buon mercato,</l>
             <l>Ch'ognun vuol giocar teco a la civetta.</l>
           </sp>
           <pb n="41"/>
-          <sp>
+          <sp who="#ofelio">
             <speaker>
               <name>Ofelio</name>
             </speaker>
@@ -1714,13 +1754,13 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Ripetendo la voce mi risponde</l>
             <l>Quante fiate invan chiamo <name>Melidia</name>.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Qualche gran caso a questo miser vecchio</l>
             <l>E' intravenuto, che sì ratto scorre</l>
             <l>Chiamando il nome mio per queste selve.</l>
           </sp>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l>Se ti rimembra punto, o sacro <name>Apollo</name>,</l>
             <l>L'acuto dardo che ti punse 'l core</l>
@@ -1730,34 +1770,34 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Dammi soccorso in ritrovar <name>Melidia</name>,</l>
             <l>Ch'omai le membra mie son lasse e stanche.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Povero <name>Apollo</name>, ognun ti dà in sul viso</l>
             <l>Col rimembrarti la selvaggia <name>Dafne</name>.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Mi vuo' scoprir, né più tenerlo in tempo.</l>
             <l><name>Ofelio</name>, in queste selve (sì com'ora</l>
             <l>Mi par d'aver udito) con gran fretta</l>
             <l>Mi vai cercando, e di chiamar non cessi.</l>
           </sp>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l>T'ho ricercata sì, più che facesse</l>
             <l>Pastor giamai smarrita pecorella.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Alza i piè, vecchio, che tai barbagianni</l>
             <l>Prender non vuo' con la mia stessa rete.</l>
           </sp>
           <pb n="42"/>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l part="I">Eccomi.</l>
           </sp>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l part="F">Io ne ringrazio il nostro <name>Giove</name>,</l>
             <l>Che salva ci mantien l'amata greggia,</l>
@@ -1765,7 +1805,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Gli vuo' offerir un don degno di lui,</l>
             <l>Poich'or m'ha scorto ove tu fermi il piede.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Dimmi, <name>Ofelio</name> gentil, padre onorando,</l>
             <l>Dico padre d'amor a me e a <name>Pimonio</name>,</l>
@@ -1773,7 +1813,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Che bisogno hai di me, che di trovarmi</l>
             <l>Tanto bramoso mi ti sei scoperto?</l>
           </sp>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l>Tu sai con quanto amor, con quanto zelo,</l>
             <l>Con quanta carità, con quanto affetto,</l>
@@ -1796,12 +1836,12 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Che se per altrui corso avessi meno.</l>
           </sp>
           <pb n="43"/>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Lasciato avesti il capo a mezza via</l>
             <l>Per correr più leggier, vecchio ubbriaco.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Certa sempre ne fui, benigno <name>Ofelio</name>,</l>
             <l>Che 'l tuo disio di compiacermi tanto</l>
@@ -1815,7 +1855,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Fecondi sì, che non invidi alcuno</l>
             <l>Che pasca in questa sì felice <name>Arcadia</name>.</l>
           </sp>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l>Lasciam, <name>Melidia</name>, questi preghi a tempo</l>
             <l>Più commodo di questo, et attendiamo</l>
@@ -1843,60 +1883,60 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Ove tu possi il tuo <name>Carpalio</name>, quanto</l>
             <l>Per te si può, far più contento e lieto.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Lieto io sarei se ti vedessi morto,</l>
             <l>E lei ne' lacci miei vedessi presa.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l part="I">Egli dov'è?</l>
           </sp>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l part="F">Non è troppo lontano,</l>
             <l>Che di nascosto il tuo fratello attende</l>
             <l>Finché si parta per andare ai giochi.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Costei vuol far morir certo il fratello.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Tu vecchio sei, tu ben conosci e sai</l>
             <l>Come questi <num value="2">due</num> amanti oggi tu guidi:</l>
             <l>A te lascio il pensier, a te l'affanno</l>
             <l>Ch'indi potrebbe a qualche tempo uscire.</l>
           </sp>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l>No, no, <name>Melidia</name>: mentre 'l cacciatore</l>
             <l>Si vede aver la fera circondata,</l>
             <l>Cessar non suol finché in sue man non l'abbia,</l>
             <l>Che chi tempo ha e l'aspetta, al fin lo perde.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Se tu non m'impedivi, anch'io voleva</l>
             <l>Quest'ordine tener a' miei disegni.</l>
           </sp>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l><name>Melidia</name>, andrò correndo a dar la nova</l>
             <l>Al tuo <name>Carpalio</name> com'io t'ho trovata,</l>
             <l>Poi ridurrommi verso casa seco.</l>
           </sp>
           <pb n="45"/>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Va' pur oltre, ch'anch'io mi pongo in via.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Ei parte, ella rimane. O buona nova!</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Se con accenti folli</l>
             <l>Ho fatte un tempo risonar le valli</l>
@@ -1910,11 +1950,11 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Che i colli omai potran, le valli e i fiori</l>
             <l>Ritornar lieti ne' lor primi onori.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Finisci tosto, e movi i lenti passi.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>S'io porsi un tempo invano</l>
             <l>A te, dolce signor, le mie fiscelle</l>
@@ -1928,13 +1968,13 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Facendone a me don senza costrutto,</l>
             <l>Sper'or ch'entrambi ne corremo il frutto.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Il tanto tuo cianciar troppo m'annoia,</l>
             <l>Che potria sovraggiungere alcun altro.</l>
           </sp>
           <pb n="46"/>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Se parve un tempo vana</l>
             <l>La tua sampogna e cacciò oscure note,</l>
@@ -1948,29 +1988,29 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Potrai, dolce <name>Carpalio</name>, con <name>Melidia</name></l>
             <l>Star sì ch'ogni pastor ne senta invidia.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Vien pur innanzi. Il tordo è ne la ragna.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Sian maledetti i cespi. Ohimè, ch'a un laccio</l>
             <l part="I">Son presa, ohimè!</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Non dubitar, sta' salda.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Deh, lasciami. Ritorna, <name>Ofelio!</name> <name>Ofelio!</name></l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Pensa pur che partir quindi non puoi,</l>
             <l>Se non mi dai ciò che a me più diletta.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Deh, satiro mio bel, non far, ti prego,</l>
             <l>Né mi astringer a far simil errore,</l>
@@ -1984,23 +2024,23 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Sviluppami, di grazia, che non paia</l>
             <l part="I">Che mi vogli sforzar.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Dì' prima, e poi</l>
             <l>Ti lascio, se fia cosa ch'a me tocchi.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Satiro mio cortese, io vuo' che sappi</l>
             <l>Ch'un certo mio fratello, anzi un serpente,</l>
             <l>Sempre in guerra mi tiene. Ma di' prima,</l>
             <l>Si pon gli uomini ancor pigliar con questa?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Uomini e donne, e ogni animal terrestre.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Sarà al proposto. Io vuo', se tu vorrai,</l>
             <l>Pigliar con questa questo mio fratello,</l>
@@ -2020,7 +2060,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Ch'io vil son feminella, non ti spiaccia,</l>
             <l>Né ti curi accettar questa mia offerta.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Anzi, m'aggrada quanto dir si possa.</l>
             <l>Ma avertisci ch'io vuo', prima che parti</l>
@@ -2029,15 +2069,15 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Che tu mi fai qualche amoroso segno,</l>
             <l part="I">Come più ti contenti.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l part="F">Egli è il dovere</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Se mi dà un bacio, a meglio anco l'aspetto.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Ma perché non vidi io mai simil cosa,</l>
             <l>Però contento sii ch'io provi prima</l>
@@ -2046,18 +2086,18 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Per ir al santo sacrificio e ai giochi,</l>
             <l part="I">Però fa' tosto e slegami.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Ma sappi</l>
             <l>Ch'uom alcun non è buon mai di snodare</l>
             <l>Questi lacciuol quando si tiran troppo,</l>
             <l>Ma uopo è alor che si ricida il nodo.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Tu fai bene avertirmi d'ogni cosa.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Or vedi e nota ben, guatami bene.</l>
             <l>Prima farai così, così da poi;</l>
@@ -2073,18 +2113,18 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l part="I">Ti potria dar la morte.</l>
           </sp>
           <pb n="49"/>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l part="F">Tu ben dici:</l>
             <l>Io non avea avertito questo punto.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Ma se fossi quell'io che lo prendessi?</l>
             <l>Perché par non convenga che tu dii</l>
             <l>Morte ad un che ti sia (com'ei) fratello.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Deh, se tu fossi, com'io sempre sono,</l>
             <l>Mal trattata da lui, tu parimente</l>
@@ -2093,39 +2133,39 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Di questo mondo, poiché <num value="1000">mille</num> volte</l>
             <l>Per lui convien ch'io morte chiami l'ora.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Di tutte l'altre cose abbiam parlato,</l>
             <l>Sol che di quel ch'importa più. Certezza</l>
             <l>Non veggo ancor di riaver la rete</l>
             <l>E che mantenghi ogni promessa fatta.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Mi seguirai discosto alquanto, e in parte</l>
             <l>Che 'l mio fratel non se n'aveda punto,</l>
             <l>Così sarai sicuro d'ogni cosa.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Fa' dunque tu, pur che tu sappi fare.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Aspetta, io starò ascosa, tu va' innanzi;</l>
             <l>Passa, ch'io tirerò tanto che impari.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Non è fuor di proposto: tira pure.</l>
             <l>Non tirar tanto, non tirar, che fai?</l>
           </sp>
           <pb n="50"/>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Così ch'inganna altrui vien ingannato.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Ahi, malvagia, ahi, rubalda, a questo modo?</l>
             <l>Rispetto non s'ha a' satiri? Tu fuggi!</l>
@@ -2154,7 +2194,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
           </head>
           <pb n="51"/>
           <stage><name>Turico</name> solo</stage>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l><name>Turico</name>, che ti val l'esser sì destro,</l>
             <l>Far prove ognor con la tua stanca vita</l>
@@ -2201,7 +2241,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <hi rend="sc">SCENA II</hi>
           </head>
           <stage><name>Callinome</name>, <name>Stellinia</name>, ninfe</stage>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Io mi credea ch'oggi le selve e i boschi</l>
             <l>Dovessi ritrovar senza lamenti</l>
@@ -2225,14 +2265,14 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Che segua un pastorel che lei non curi,</l>
             <l>E ch'ella ami costui più che se stessa.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Che fa qui sì soletta questa ninfa</l>
             <pb n="54"/>
             <l>Cui porta tanto amor il crudo <name>Erasto</name>,</l>
             <l>Benché l'odia ella più ch'agnella lupo?</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>L'altrier, porgendo a le mie stanche membra</l>
             <l>Dolce riposo sotto ombroso faggio</l>
@@ -2245,11 +2285,11 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Simil a queste o tai parole usando,</l>
             <l>Fea d'ogn'intorno risonar i boschi.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>A tempo qualche cosa a udir son giunta.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Perché, dicea, vuoi tu lasciar, <name>Erasto</name>,</l>
             <l>D'amar ninfa sì bella com'io sono,</l>
@@ -2261,11 +2301,11 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>E la ruina tua? Tienti pur morto,</l>
             <l>S'avien che la sua dea mai se n'avegga.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Costei dice di me certo, e d'<name>Erasto</name>.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Per te, crudel più che selvaggio toro,</l>
             <l>Lasciato ho il mio <name>Turico</name>, pastor tale</l>
@@ -2283,12 +2323,12 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Perché dunque mi fuggi, <name>Erasto</name> altero?</l>
             <l>Perché non degni così bella ninfa?</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>So che di passo in passo, ad <num value="1">una</num> ad <num value="1">una</num></l>
             <l>Notò le mie parole. Or segui pure.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Perché, lassa, dicea, perché rifiuti</l>
             <l>Ciò che ti dona chi per te si strugge?</l>
@@ -2320,7 +2360,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>E simil altre parolette usando,</l>
             <l>Ch'avrian mosse a pietà l'onde et i venti.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>S'io non credessi ancor che 'l vago arciero</l>
             <l>T'avesse a trapassar quel duro petto</l>
@@ -2329,13 +2369,13 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Troncherei sì che la natura insieme,</l>
             <l>Volendo, non potria porle in <num value="1.000">mill</num>'anni.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Ma non è questa quella bella ninfa</l>
             <l>Che pur or nominava? Ella è per certo.</l>
             <l>Ecco che verso me vien passo passo.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>S'io potessi levarle quella cinta</l>
             <l>Che porta intorno, Amor potria ferirla.</l>
@@ -2345,7 +2385,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Ch'esser non può, ch'essendo bella, Amore</l>
             <l>in te non abbia la sua grazia infusa.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Senza ch'altri tel dica tu ben sai,</l>
             <l>Ninfa gentil, che in me non ha possanza</l>
@@ -2357,20 +2397,20 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Via più che de l'istessa sua persona.</l>
           </sp>
           <pb n="57"/>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Ho più volte disio non poco avuto</l>
             <l>D'entrar nel vostro coro, ma una ninfa</l>
             <l>Con false paroline il cor mi trasse</l>
             <l>Da quella così degna e onesta impresa.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Che cosa potea mai dir la malvagia</l>
             <l>(Sia qual si fosse) che potesse un core</l>
             <l>Da così buon voler trar con parole?</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Potria porr'amistà tra il nibbio e 'l corvo,</l>
             <l>Tanto sa ben parlar. Deh, nota il modo</l>
@@ -2400,7 +2440,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>onde 'l mel mi si fa fele e veleno.</l>
           </sp>
           <pb n="58"/>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Quando un si sente in qualche error avinto</l>
             <l>Vorria che in quel cadesse il mondo tutto.</l>
@@ -2409,18 +2449,18 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Per volger fosse mai da quel che prima</l>
             <l>Mi mostrò il cielo insin da' tener anni.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Deh, se sei ninfa, come mostri, adorna</l>
             <l>Di cortesia, deh, non negarmi il <num value="1">primo</num></l>
             <l>Piacer che 'l troppo ardir mio ti chied'ora.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Chiedi ciò che tu vuoi, che se fia cosa</l>
             <l>Che si possa per me, non te la nego.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Mostra, ti prego, quella benda ch'opra</l>
             <l>Sì forte contra Amor lascivo, s'io</l>
@@ -2433,7 +2473,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Mentre solinga, senz'Amor intorno,</l>
             <l>Seguendo vai or questa fera or quella.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Quantunque espressamente ci abbia imposto</l>
             <l>L'alta reina nostra che da torno</l>
@@ -2444,35 +2484,35 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Poi vuo' che tu mi renda il mio legame.</l>
           </sp>
           <pb n="59"/>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Ah, ninfa più cortese che natura,</l>
             <l>Non dubitar, farò quanto a te piace.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l part="I">Slegal tu stessa.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">O membra delicate!</l>
             <l>Eccolo: sii contenta, poic'hai fatto</l>
             <l>Il più, di far il men. Legalo, ninfa,</l>
             <l>Che da me non potrei. Tu stringi forte!</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Sorella mia, lo stringer forte importa,</l>
             <l>Che se non fosse stretto, il suo vigore,</l>
             <l>Se non del tutto, in parte perderebbe.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Stringe quanto tu vuoi, quanto ti pare,</l>
             <l>Che tu ben dèi saper come si faccia.</l>
             <l>Or porge a la tua dea qualche preghiera.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>O alta dea, che i bianchi cervi desti</l>
             <l>A un tempo e affreni e arresti</l>
@@ -2495,39 +2535,39 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Con apparente raggio,</l>
             <l>Ond'ella vuol lasciar <name>Venere</name> e Amore.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Parmi veder pastori assai tra queste</l>
             <l>Frondi venir con passi frettolosi.</l>
             <l>Leva, su, non istar più così, ninfa.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l part="I">Chi son costor?</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">E' parte de' pastori</l>
             <l>Ch'oggi van celebrando intorno intorno</l>
             <l>I giochi che si fanno a <name>Pan Liceo</name>.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Rendimi, ninfa, la mia benda prima</l>
             <l part="I">Ch'aggiungano, fa' tosto.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Aspetta, aspetta:</l>
             <l>Vuoi che veggan che m'alzi i panni al vento?</l>
             <l>Tantosto passeranno. Ecco, son giunti.</l>
             <l>Tanto più tempo Amor avrà di trarle.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l part="I">Ohimè.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Non dubitar, che non daran noia.</l>
           </sp>
@@ -2538,7 +2578,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
           </head>
           <pb n="61"/>
           <stage>Sacerdote, coro</stage>
-          <sp>
+          <sp who="#sacerdote">
             <speaker>Sacerdote</speaker>
             <l>Tu, c'hai le corna risguardanti al cielo,</l>
             <l>Fisse ne l'ampia fronte e spaziosa,</l>
@@ -2554,7 +2594,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
           <sp>
             <l>O <name>Pan Liceo</name>, o <name>Pan Liceo</name>.</l>
           </sp>
-          <sp>
+          <sp who="#sacerdote">
             <speaker>Sacerdote</speaker>
             <l>Tu, che come ver re lo scettro tieni</l>
             <l>Ne l'una man come celeste dono,</l>
@@ -2566,11 +2606,11 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Mostrane e 'l tuo favore</l>
             <l>Tanto grato a ciascuno, o <name>Pan Liceo</name>.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>Coro</speaker>
             <l>O <name>Pan Liceo</name>, o <name>Pan Liceo</name>.</l>
           </sp>
-          <sp>
+          <sp who="#sacerdote">
             <speaker>Sacerdote</speaker>
             <l>De la greggia abbi e de l'armento cura</l>
             <l>Che va pascendo in queste folte selve,</l>
@@ -2583,7 +2623,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Se 'l pregar nostro sale</l>
             <l>Insino a le tue orecchie, o <name>Pan Liceo</name>.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>Coro</speaker>
             <l>O <name>Pan Liceo</name>, o <name>Pan Liceo.</name></l>
           </sp>
@@ -2593,14 +2633,14 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <hi rend="sc">SCENA IV</hi>
           </head>
           <stage><name>Callinome</name>, <name>Stellinia</name>, ninfe</stage>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Deh dimmi, ninfa mia, per che cagione</l>
             <l>Portano que' pastori quel flagello,</l>
             <l>Se sai tanto mistero, e s'io son degna</l>
             <l part="I">Di saperlo.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Lo tengono per questo,</l>
             <l>Che le donne che son gravide vanno</l>
@@ -2610,53 +2650,53 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Con l'uomo divenir non possa madre,</l>
             <l>Subito par che 'l figliuol far ottenga.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Rider tu mi farai. Oh, volentieri</l>
             <l>(Se però non ti scommodo) verrei</l>
             <l>A veder tutto il resto di que' giochi,</l>
             <l>Che intendo che si veggon belle cose.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Bellissime, nel ver. Ma chi ti tiene?</l>
           </sp>
           <pb n="63"/>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Dubito che <name>Diana</name> nol risappia.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Deh, ché vuoi star d'aver un giorno lieto,</l>
             <l>Il qual sì tosto più non vederai,</l>
             <l>Per dir che temi che <name>Diana</name> il sappia? </l>
             <l>Andiamo, andiamo: chi vuoi che gliel dica?</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Gl'invidi del mio ben. Se mi prometti</l>
             <l part="I">Di tacer, ne verrò.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Per questo giorno</l>
             <l>Tanto solenne ti prometto ch'io</l>
             <l part="I">Son per tacer. Andiamo.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l part="F">Dammi prima</l>
             <l part="I">La cinta mia.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Andiam pur, ch'or te la rendo.</l>
             <l>Fatto ho pur tanto che cagione ancora</l>
             <l>Sarò di far precipitarla e porla</l>
             <l>In disgrazia a <name>Diana</name> e a le compagne.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Vedi, <name>Stellinia</name>, un satiro malvagio</l>
             <l>Che a tutto suo poter correndo cerca</l>
@@ -2664,13 +2704,13 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Per salvarsi ne vien. Dobbiam fuggire,</l>
             <l>O pur qui per salvarla star alquanto?</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Guardiamo che volendo salvar lei</l>
             <l>Non ci troviamo tutte e <num value="3">tre</num> in periglio.</l>
           </sp>
           <pb n="64"/>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Non dubitar, che veggo di lontano</l>
             <l>Un pastor ch'ambedue velocemente</l>
@@ -2689,7 +2729,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Credo che <name>Dio</name> per nostro purgo gli abbia</l>
             <l part="I">Prodotti al mondo.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Son di male bestie.</l>
             <l>Io per me non vorrei trovarmi mai</l>
@@ -2698,11 +2738,11 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>D'andar al sacrificio, et attendiamo</l>
             <l>Ai fatti nostri, se così vi pare.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l part="I">Così facciamo. Per qual via?</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Per questa.</l>
           </sp>
@@ -2713,7 +2753,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
           </head>
           <pb n="66"/>
           <stage><name>Ofelio</name>, <name>Carpalio</name></stage>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l>Certo che 'l buon compagno, quando vide</l>
             <l>Che non mancava aiuto da due bande</l>
@@ -2723,11 +2763,11 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Tanto timor la debbe aver salita</l>
             <l>Che starà un pezzo a ripigliar lo spirto.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l part="I">Che farem dunque?</l>
           </sp>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l part="F">Stiamo qui d'intorno</l>
             <l>Alquanto per veder s'esca pur fuori</l>
@@ -2762,7 +2802,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Ci fuggirà, né forse di trovarla</l>
             <l>Ci fia dal ciel concesso. Che ne dici?</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l><name>Ofelio</name> mio gentil, tutto mi pongo</l>
             <l>Al tuo parer: fa' pur quanto ti piace,</l>
@@ -2773,7 +2813,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Non m'indurresti a far cosa ch'al fine</l>
             <l>Ad alcuno di noi nocer potesse.</l>
           </sp>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l>Stanne sicur, <name>Carpalio</name>, che tant'amo</l>
             <l>L'uno e l'altro di voi (o sia che 'l cielo</l>
@@ -2781,7 +2821,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Che <num value="1">un'</num>ora mi par <num value="1000">mille</num> perché siate</l>
             <l>Contenti e vi sposiate ambedue insieme.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Io ti ringrazio, <name>Ofelio</name>; e tu fa' conto</l>
             <l>Che de la vita mia, de la mia robba</l>
@@ -2792,7 +2832,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Se così pare a te, se così credi</l>
             <l part="I">Che bene stia.</l>
           </sp>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l part="F">Così ben penso anch'io.</l>
             <pb n="67"/>
@@ -2862,7 +2902,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <hi rend="sc">SCENA VII</hi>
           </head>
           <stage>Satiro solo</stage>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Non credo che di me satiro alcuno</l>
             <l>Viva infelice più, né più in disdetta</l>
@@ -2932,7 +2972,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
           </head>
           <pb n="70"/>
           <stage><name>Erasto</name> solo</stage>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Ch'oltraggio, Amor, mi puoi tu far maggiore</l>
             <l>Che pormi innanzi agli occhi il fonte chiaro,</l>
@@ -2970,7 +3010,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
           </head>
           <pb n="71"/>
           <stage><name>Orenio</name>, <name>Erasto</name></stage>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Deh, perché non mi diede il ciel <num value="100">cent</num>'occhi</l>
             <l>Alor ch'io nacqui, come diede ad <name>Argo</name>?</l>
@@ -2980,12 +3020,12 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Il giovinetto <name>Erasto</name>. Ahi, sorte iniqua,</l>
             <l>Ahi, maledetto fato! O giorno oscuro!</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Misero me, che lamentevol voce</l>
             <l>È quella ch'odo del pastor <name>Orenio</name>?</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Deh, Amor, non ti rincresca, se i miei preghi</l>
             <l>Vagliono appresso te punto, di pormi</l>
@@ -2998,37 +3038,37 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>In pericol di morte ritrovarsi,</l>
             <l>Deh, che farai, meschin, di', che farai?</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Udito non m'ha ancor, né ancor m'ha visto.</l>
             <l part="I"><name>Orenio</name>, <name>Orenio</name>!</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l part="F">O caso orrendo e strano!</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l part="I"><name>Orenio</name>!</l>
           </sp>
           <pb n="72"/>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l part="M">Oh, tu se' qui?</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l part="F">Più volte, <name>Orenio</name>,</l>
             <l>Io t'ho chiamato, ma di quei più sordo</l>
             <l>Sei che sogliono star d'intorno al <name>Nilo</name>.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Perdonami, il mio <name>Erasto</name>, che 'l gran caso</l>
             <l>Ove avea posto ogni mio senso e vista</l>
             <l>E' cagion ch'io non veggo e ch'io non sento.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Non altrimente che da vento scossa</l>
             <l>Foglia leggiera, il cor nel petto trema,</l>
@@ -3037,7 +3077,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Può mai fortuna dar in un sol punto,</l>
             <l>Purché sia salva la nimica mia.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>A punto, <name>Erasto</name>, quella ninfa bella</l>
             <l>Che tu speravi pur volger col tempo,</l>
@@ -3046,14 +3086,14 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Tanto propizia non le fosse, ch'oltre</l>
             <l>Il giudicio ch'io fo non m'ingannassi.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Ohimè, che cosa, <name>Orenio</name>, da te intendo!</l>
             <l>Dimmi, ti prego, questa gran cagione</l>
             <l>Che più non son per contemplar quel viso,</l>
             <l>Viso ch'a un tempo mi dà vita e morte.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Benché, <name>Erasto</name>, mi paia duro et aspro</l>
             <l>Il raccontarti cosa onde 'l dolore</l>
@@ -3063,7 +3103,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Qualche rimedio, benché spero invano,</l>
             <l>Ti farò aperto quel che t'era occulto.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Se gli è mal, o gran <name>Giove</name>, che sia senza</l>
             <l>Qualche rimedio, dammi morte, prima</l>
@@ -3075,23 +3115,23 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <hi rend="sc">SCENA III</hi>
           </head>
           <stage><name>Stellinia</name>, <name>Orenio</name>, <name>Erasto</name></stage>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Ecco il mio <name>Erasto</name>, ecco il mio dolce amante.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l><name>Erasto</name> mio, gentil come figliuolo,</l>
             <l>Tu sai ch'oggi <name>Callinome</name> tua ninfa,</l>
             <l>Condotta da maligna e fera stella,</l>
             <l>Venne a veder i sacrifici nostri.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Di <name>Callinome</name> è 'l lor ragionamento:</l>
             <l>Non può far ch'io non oda qualche cosa.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Io la vidi per certo con <name>Stellinia</name>,</l>
             <l>E mi parea veder a punto un toro</l>
@@ -3099,7 +3139,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Si senta l'un de' corni, sì smarrita</l>
             <l part="I">Si mostrava nel viso.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l part="F">Dubitava</l>
             <l>Di quel che gli è avenuto, che <name>Diana</name></l>
@@ -3113,12 +3153,12 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Sparge tal fiamma che 'l suo proprio cerchio,</l>
             <l>Quantunque freddo, accenderia volendo.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Ohimè, ch'io temo che quest'ira e sdegno</l>
             <l>Non sia cagion di più che d'una morte.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Questo non so. So ben ch'a questa ninfa,</l>
             <l>Per quanto si comprende, incresce assai</l>
@@ -3126,22 +3166,22 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Poiché sovente con parlar sommesso</l>
             <l>Par che 'l tuo nome sospirando chiami.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Amor forse l'ha punta! Ah, dunque, <name>Orenio</name>,</l>
             <l>S'usa così verso il tuo <name>Erasto</name>, a dargli</l>
             <l>Con tanto amar questa sì dolce nova?</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Dolce nova ti par ciò ch'io vuo' dirti?</l>
             <l>Non dèi dunque saper perché ti chiami?</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l part="I">Aspetto che me 'l dichi.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l part="F">Ohimè, <name>Diana</name>,</l>
             <l>Non sapendo in qual guisa darle morte</l>
@@ -3159,17 +3199,17 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>A te procuri, e a te la vita serbi</l>
             <l>S'a la vita di lei soccorso porgi.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l part="I">Ohimè, che è quel ch'io odo?</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l part="F">Omai pon fine</l>
             <l>Ai sospiri, e con fatti e con parole</l>
             <l>Cerca lo scampo suo, purché l'aiuti.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Che vi posso far io senza il tuo aiuto</l>
             <l>E senza il tuo consiglio? Che ben sai</l>
@@ -3178,7 +3218,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Se cosa sai che in tal bisogno possa</l>
             <l part="I">Esser di giovamento alcuno.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l part="F">E' vero</l>
             <l>Ch'appo me già tener solea un secreto</l>
@@ -3188,18 +3228,18 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Prova di simil sorte, a pena credo</l>
             <l>Che soverrammi dov'i' l'abbia posto.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Fa' pur quanto tu vuoi, che poco aiuto</l>
             <l>Dar si può a quei che in simil caso stanno.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Non ti rimembra almen ciò che bisogna</l>
             <l part="I">A porlo insieme?</l>
           </sp>
           <pb n="76"/>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l part="F">Sì, ma non è cosa</l>
             <l>Che si faccia sì tosto come pensi.</l>
@@ -3212,33 +3252,33 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Sta', ch'ora mi sovien dove l'ho posto.</l>
             <l part="I">Andiam, ch'io l'ho a man salva.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l part="F">Andiamo, <name>Orenio</name>,</l>
             <l>Che del più grasso paio di miei agnelli</l>
             <l>Ti faccio don, se questo ha buon effetto.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Fatt'io la prova ho più di <num value="10">diece</num> volte.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Oh, fosti per lo collo a un tronco appeso,</l>
             <l>Isposto a' corvi in solitario bosco</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Andiamo adunque, e non tardiam, di grazia,</l>
             <l>Che s'io soccorro lei con questo aiuto,</l>
             <l>Ben sarà tigre od orsa se poi nega</l>
             <l>Di volermi accettar per suo compagno.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Con questo patto pria l'astrengeremo.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Fuor di proposto non mi par che sia.</l>
             <l>Il ciel ne sia propizio, Amor e Pane.</l>
@@ -3250,7 +3290,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
           </head>
           <pb n="77"/>
           <stage><name>Stellinia</name> sola</stage>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Misera me, ch'io credea aver la lepre</l>
             <l>Al veltro posta in bocca, e ne fia lungi</l>
@@ -3315,32 +3355,32 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <hi rend="sc">SCENA V</hi>
           </head>
           <stage><name>Carpalio</name>, <name>Turico</name></stage>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Considerando il mio gran mal, <name>Turico</name>,</l>
             <l>C'ho sofferto sin qui, render sicuro</l>
             <l>Ti puoi che in questo son per porr'ogn'opra</l>
             <l part="I">(Che ch'ella sia) per amor tuo.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">Farai,</l>
             <l>Gentil <name>Carpalio</name>, ad uom piacer cui tempo</l>
             <l>Punto non leverà di rimembranza.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Se lei, <name>Turico</name>, aggiungo, e che sia sola,</l>
             <pb n="79"/>
             <l>Pensa pur ch'io farò ciò che tra noi</l>
             <l part="I">Abbiam deliberato.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">Va' pur via,</l>
             <l>Ch'io sarò al detto fonte ch'è qui appresso.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Non in tempo più commodo di questo</l>
             <l>Poteva intravenir, ch'or non, si vede</l>
@@ -3349,7 +3389,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Di quella ninfa di <name>Diana</name>, astretta</l>
             <l>A porsi al gran contrasto del cinghiale.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>S'ella ne scampa, fia voler del cielo,</l>
             <l>Non già per la sua forza. Ma lasciamo</l>
@@ -3357,16 +3397,16 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Che non troppo lontan quindi esser deve,</l>
             <l part="I">S'a quel pastor creder si dee.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l part="F">Gli è uomo</l>
             <l>Da me fidel provato in ogni conto.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="I">Or va', che là t'aspetto.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l part="F">Io vado, io vado.</l>
           </sp>
@@ -3377,7 +3417,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
           </head>
           <pb n="80"/>
           <stage><name>Carpalio</name> solo</stage>
-          <sp>
+          <sp who="#carpalio">
             <speaker>
               <name>Carpalio</name>
             </speaker>
@@ -3464,7 +3504,7 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <hi rend="sc">SCENA VII</hi>
           </head>
           <stage><name>Stellinia</name>, Satiro</stage>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Ohimè, ch'è questo? Chi m'ha qui legata?</l>
             <l>Chi è stato questo tristo? A questo modo?</l>
@@ -3475,67 +3515,67 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Deh, perché 'l ciel non manda qui un pastore</l>
             <l>Che mi venga aiutar a l'improviso?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Io sento lamentarsi fortemente,</l>
             <l>E mi par voce feminil. Se cieco</l>
             <l>Non son, questa è una ninfa ch'è qui presa.</l>
             <l part="I">O caso strano!</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">O satiro malvagio,</l>
             <l>O satiro crudele ! Certo è stato</l>
             <l part="I">Egli che m'ha qui avinta.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">O bella ninfa,</l>
             <l>Chi è stato quel sì tristo e sì perverso</l>
             <l part="I">Che qui t'avinse?</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Se tu non sei stato,</l>
             <l>Imaginar nol mi saprei giamai.</l>
           </sp>
           <pb n="83"/>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Non dir già questo, ninfa, ch'io non fui,</l>
             <l>E mi vergognerei far tale scherzo.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Se non sei stato tu, slegami adunque.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Slegarti? Oh, oh, non sai ch'io son nimico</l>
             <l>Di voi ninfe, che noi satiri tanto</l>
             <l part="I">Avete in odio?</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Slegami, di grazia.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Dimmi il tuo nome.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Il mio nome è <name>Stellinia</name>.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I"><name>Stellinia</name>?</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="M">Sì, <name>Stellinia</name>.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">A punto questo</l>
             <l>(Se mi ricordo ben) mi par il nome</l>
@@ -3543,21 +3583,21 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Mi palesò stamane. Dimmi un poco,</l>
             <l part="I">Dove è il tuo arco?</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="M">Eccolo là.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Di tasso:</l>
             <l part="I">E' dessa.</l>
           </sp>
           <pb n="84"/>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Che vuoi far, di', del mio arco?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Oh, oh, che ne vuo' far ora il saprai.</l>
             <l>Oggi da me non sei per dipartirti,</l>
@@ -3565,31 +3605,31 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Vuo' giocar teco a singolar battaglia</l>
             <l>Del modo che natura e Amor commanda.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Deh, slegami, e dopo ciò che tu vuoi</l>
             <l part="I">Chiedimi, che l'avrai.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Ciò che t'ho detto</l>
             <l part="I">Voglio, e non altro.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Io ti farò contento,</l>
             <l>Ma slegami, di grazia, che le mani</l>
             <l>Tutte son dormentate, né le sento.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Mi prometti di dar ciò che ti chieggio?</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="I">Lo ti prometto, dico.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Ecco, ti slego,</l>
             <l>Ma guarda non fuggir, che ben tu sai</l>
@@ -3598,16 +3638,16 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Donna ch'al mondo o in queste selve sia.</l>
             <l part="I">Sei slegata?</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Sì, sono, e ti ringrazio.</l>
           </sp>
           <pb n="85"/>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Ogni promessa è debita.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Gli è 'l vero;</l>
             <l>Ma, satiro mio bel, satir cortese,</l>
@@ -3621,66 +3661,66 @@ Savoia</name>, Signore di <name>Sassuolo</name>.</p>
             <l>Ardirei discoprirti quel che volle</l>
             <l>Che in donna fosse la natura ascoso.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Ancor ch'io non dovrei farti tal grazia,</l>
             <l>Pur son contento far ciò che tu vuoi,</l>
             <l>Ma voglio esser sicur che tu non fugga.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Hai ben ragione. Orsù, vuo' assicurarti.</l>
             <l>Tien saldo questo lembo de la vesta,</l>
             <l>E tienlo stretto, se tu temi ch'io</l>
             <l>Voglia ingannarti. Sei sicuro ancora?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Lo vuo' tener con ambedue le mani.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="I">Tu mostri di fidarti mal.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Parole.</l>
             <l>Orsù, veniamo al fin: vuoi tu abbendarmi?</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="I">Sì, voglio.</l>
           </sp>
           <pb n="86"/>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Orsù, di' pur, che vuoi ch'io faccia?</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Siedi qui in terra, che sedervi anch'io</l>
             <l>Intendo appresso te, dove d'amore</l>
             <l>Insieme trattarem come ti piace.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Così sta ben. Su, siedi dunque tosto,</l>
             <l>Che 'l tempo passa né si vien al fine.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Aspetta alquanto, ch'io vuo' prima dire</l>
             <l>Certi miei preghi a <name>Venere </name>e a <name>Cupido</name>,</l>
             <l>Perché buon fin nostro disio consegua.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Di' pur ciò che tu vuoi, purché sia breve.</l>
           </sp>
           <stage>Mentre la ninfa dice le infrascritte parole, lega
 la sua sopravesta aperta dinanzi a un albero vicino,
 e poi si parte pian piano.</stage>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l><name>Venere</name> bella, e tu, suo figlio Amore,</l>
             <l>Concedete a due amanti</l>
@@ -3689,7 +3729,7 @@ e poi si parte pian piano.</stage>
             <l>(Mentre scalda del sol l'ardente raggio)</l>
             <l>Godino fresco e sempiterno maggio.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Hai tu finito? Di', tu non rispondi?</l>
             <l>O là, sei sorda? Dimmi, hai tu finito?</l>
@@ -3715,7 +3755,7 @@ e poi si parte pian piano.</stage>
             <hi rend="sc">SCENA VIII</hi>
           </head>
           <stage><name>Brusco</name>, capraro di <name>Carpalio</name></stage>
-          <sp>
+          <sp who="#brusco">
             <speaker>Brusco</speaker>
             <l>Mi pesa questo pan, mi pesa il fiasco,</l>
             <l>Ma più m'ingombra la faretra e 'l dardo</l>
@@ -3834,7 +3874,7 @@ e poi si parte pian piano.</stage>
           </head>
           <pb n="91"/>
           <stage>Satiro solo</stage>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Io credo che costei si sia disfatta</l>
             <l>O che si sia conversa in fior o in fonte.</l>
@@ -3896,19 +3936,19 @@ e poi si parte pian piano.</stage>
             <hi rend="sc">SCENA II</hi>
           </head>
           <stage><name>Stellinia,</name> satiro</stage>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Io non lo veggo: certo è andato altrove.</l>
             <l>Ah, ah, rider conviemmi: questa bestia</l>
             <l>Che si credea ingannarmi! O gran peccato</l>
             <l part="I">Ch'io non lo contentassi!</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Vieni, vieni:</l>
             <l>Piglia la vesta, se tu vuoi ch'io rida.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Ma dov'è la mia vesta? Forse questo</l>
             <pb n="94"/>
@@ -3919,33 +3959,33 @@ e poi si parte pian piano.</stage>
             <l>Ch'aggiunger non vi possa. O bella prova,</l>
             <l part="I">O bello scherno!</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Senti, senti come</l>
             <l part="I">Mi vitupera e morde.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Oh, che vuol dire</l>
             <l part="I">Che quest'albero è aperto?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Ohimè, l'aguatto</l>
             <l part="I">Discoprirà.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Costui nel salir forse</l>
             <l>Qui sopra per lo peso l'ha schiantato</l>
             <l part="I">In <num value="2">due</num> parti.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Ha proposo ella e risciolto:</l>
             <l>Più non temo. Su, spacciati, e fa' tosto.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Ma non vuo' star più qui, che la disgrazia</l>
             <l>Non rimenasse qui quell'animale,</l>
@@ -3953,11 +3993,11 @@ e poi si parte pian piano.</stage>
             <l>Bisogna che mi slunghi e che m'ingegni.</l>
             <l>Ohimè, son morta! Ohimè, ohimè meschina !</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Ecco data è la passera nel vischio.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>O satiro malvagio, ohimè, di novo</l>
             <pb n="95"/>
@@ -3966,46 +4006,46 @@ e poi si parte pian piano.</stage>
             <l>Ohimè, da me non posso, ohimè, il mio braccio!</l>
             <l part="I">O me infelice !</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Sì, tu vi sei giunta.</l>
             <l>A questo modo tu ti pigli gioco</l>
             <l>Del fatto mio? Così i satiri inganni,</l>
             <l part="I">Perfida e disleale?</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Ohimè meschina,</l>
             <l>Mi chiamo in colpa, ohimè, di ciò c'ho fatto.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Colpa a tua posta.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Eh, aiutami, ti prego.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Aiuto non avrai da me, ch'usarmi</l>
             <l part="I">Non devevi tal atto.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Ohimè, l'amore</l>
             <l>De la mia castità questo volea.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>L'amor nei dei maggior dev'esser sempre.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>La fede che già diedi al mio compagno</l>
             <l part="I">Questo non richiedea.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">La fede ch'ebbi</l>
             <l>Inverso te quando ti diedi aiuto</l>
@@ -4018,19 +4058,19 @@ e poi si parte pian piano.</stage>
             <l>Mettiti un velo agli occhi! Tristarella,</l>
             <l part="I">Sfacciata che tu se'.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Non son per trarre</l>
             <l>Più da costui pietà, poic'ha sì in odio</l>
             <l part="I">Il sesso feminil.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">L'ho in odio a punto</l>
             <l>Poiché sempre cercate ingannar l'uomo,</l>
             <l>Anzi, coi propri dei gli inganni usate.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Perché, satiro mio, hai qualche sdegno</l>
             <l>D'altra cagion, per isfocarti contra</l>
@@ -4040,35 +4080,35 @@ e poi si parte pian piano.</stage>
             <l>Forse ti roderai, e d'aver detto</l>
             <l>Contra noi cosa che sia men che degna.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Favole.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Eh, dammi, satiro gentile,</l>
             <l>Aiuto, che vedrai ch'a servir donna</l>
             <l>Non si può perder mai, anzi s'acquista.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Di' pur ciò che tu vuoi.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Deh, dammi aiuto.</l>
           </sp>
           <pb n="97"/>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Deh, sì, per <name>Dio</name>.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">E se poi non ti faccio</l>
             <l>Contento, d'ogni morte fammi rea.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Ma che? Avendo costei ne le mie forze,</l>
             <l>Per suo maggior dispregio, per l'inganno</l>
@@ -4076,11 +4116,11 @@ e poi si parte pian piano.</stage>
             <l>Senza riguardo aver a l'onor suo,</l>
             <l part="I">Farne strazio crudel?</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Ohimè meschina!</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Nuda ti vuo' spogliar, poi tutta nuda</l>
             <l>Ti vuo' piagar e farti tutta sangue.</l>
@@ -4091,12 +4131,12 @@ e poi si parte pian piano.</stage>
             <hi rend="sc">SCENA III</hi>
           </head>
           <stage><name>Turico</name>, satiro, <name>Stellinia</name></stage>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Ohimè, che fa quel satiro malvagio</l>
             <l part="I">Qui d'intorno a <name>Stellinia</name>?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Pensa pure</l>
             <l>Che ti vuo' maltrattar, perfida e ingrata,</l>
@@ -4108,54 +4148,54 @@ e poi si parte pian piano.</stage>
             <pb n="98"/>
             <l part="I">Ohimè meschino.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Ahi, povera <name>Stellinia</name> !</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Sì tu piangi?</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">Ahi, rubaldo, comportarti</l>
             <l part="I">Debbo io questo giamai?</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Aiuto, aiuto !</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Gli è tempo, omai. O là, <name>Silvan</name>, <name>Dameta</name>,</l>
             <l><name>Carpalio</name>, su, pastori, su, correte!</l>
             <l>Ohimè, la mia <name>Stellinia</name>. Adosso, adosso!</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Ohimè, rotto è 'l disegno.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">Dalli, dalli !</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Tempo non è di star più qui.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">Tu fuggi!</l>
             <l>Non dubitar, <name>Stellinia</name>, io son <name>Turico</name>,</l>
             <l>Ch'a tempo e ad ora ti può dar aiuto.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>O <name>Turico</name> gentil, gentil <name>Turico</name>,</l>
             <l>Deh, se calti di me, dammi soccorso,</l>
             <l>Ch'ad altro effetto il ciel qui non ti spinse.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Ecco ch'io vuo' aiutarti. Tu fai poi</l>
             <pb n="99"/>
@@ -4163,7 +4203,7 @@ e poi si parte pian piano.</stage>
             <l>Ti mostri l'amor mio tanto più verde</l>
             <l>Quanto fu il tuo ver me sempre più secco.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Quando potrò giamai, anima mia,</l>
             <l>Conforto mio, di questo sì bel merto</l>
@@ -4171,18 +4211,18 @@ e poi si parte pian piano.</stage>
             <l>Mi concedesser di <num value="1.000">mill'</num>anni vita,</l>
             <l>Renderti il guiderdon mai non potrei.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>O giorno aventuroso, o giorno lieto,</l>
             <l>Tanto più accetto quanto men pensato!</l>
             <l>Ecco la vesta tua, ecco ogni cosa.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Aiutami, <name>Turico</name>, a rivestire,</l>
             <l part="I">Ch'io non ho forza.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">Che ti duole? Lascia</l>
             <l>Veder: non dubitar. Eh, non vi hai male.</l>
@@ -4193,7 +4233,7 @@ e poi si parte pian piano.</stage>
             <l>Nol mi negar, poich'ogni tuo scontento</l>
             <l>M'annoia, e ogni piacer tuo mi diletta.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l><num value="2">Due</num> volte, anima mia, qui in picciol tempo</l>
             <l>Son con <num value="2">due</num> scorni stata avinta e presa.</l>
@@ -4205,7 +4245,7 @@ e poi si parte pian piano.</stage>
             <l>Alor che m'aiutò, legata essendo.</l>
           </sp>
           <pb n="100"/>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>O bella cosa s'io vi fossi stato !</l>
             <l>Ma il tristo ha avuto ardir di farti oltraggi</l>
@@ -4214,11 +4254,11 @@ e poi si parte pian piano.</stage>
             <l>Ma s'io non era da un compagno mio</l>
             <l>Nel camin ritenuto, i' giungea a tempo.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Ma chi è questo pastor che 'n qua ne viene?</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Quest'è <name>Carpalio</name> mio, pastor cortese,</l>
             <l>Qual sazio di lodar non sarò mai.</l>
@@ -4229,7 +4269,7 @@ e poi si parte pian piano.</stage>
             <hi rend="sc">SCENA IV</hi>
           </head>
           <stage><name>Carpalio</name>, <name>Turico</name></stage>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Ho sentito gridar ad alta voce</l>
             <l>E mi parea <name>Turico</name>; ma lo veggio</l>
@@ -4241,24 +4281,24 @@ e poi si parte pian piano.</stage>
             <l>Prospera il ciel conservi questa copia</l>
             <l>E la sua greggia ognor felice accresca.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Di simil grazia ancor te parimente</l>
             <l>Faccia il ciel degno, poiché tu lo merti.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Tra me godo, <name>Turico</name>, sommamente</l>
             <l>Sol per tuo amor, poiché sì ben condussi</l>
             <pb n="101"/>
             <l>La lepre al varco ch'è rimasa presa.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Sopra questo con teco un'altra volta</l>
             <l>Vuo' ragionar. Un caso, oh, se sapesti!</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Basta, quando tu vuoi. Ecco <name>Melidia</name>,</l>
             <l>E par sì mesta e sconsolata in viso.</l>
@@ -4271,7 +4311,7 @@ e poi si parte pian piano.</stage>
             <hi rend="sc">SCENA V</hi>
           </head>
           <stage><name>Melidia</name>, <name>Carpalio</name>, <name>Turico</name>, <name>Stellinia</name></stage>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>O cieco mondo, o pien d'inganni Amore,</l>
             <l>Tu m'hai pur presa come il pesce a l'amo.</l>
@@ -4281,11 +4321,11 @@ e poi si parte pian piano.</stage>
             <l>L'ira e il furor del mio fratel, quand'egli</l>
             <l>Sappia la cosa come stia tra noi.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Come senza ragion sospira e geme!</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Se ben dirò ch'un satiro selvaggio</l>
             <l>(Com'anco quasi inver m'è intravenuto)</l>
@@ -4293,48 +4333,48 @@ e poi si parte pian piano.</stage>
             <l>Come spogliate siamo, altro di buono</l>
             <l>In noi non resta, creder non vorrallo.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l part="I">Oh, come teme !</l>
           </sp>
           <pb n="102"/>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l part="F">A posta mi son tolta</l>
             <l>Di casa, ch'io non vuo' la sua fierezza</l>
             <l>Aspettar sola. Io vuo' cercar <name>Carpalio</name>,</l>
             <l>Con cui son per istar sempre sicura.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l part="I"><name>Melidia</name>, o là, <name>Melidia</name>!</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l part="F">Chi mi chiama?</l>
             <l>O il mio <name>Carpalio</name>, di mia vita vero</l>
             <l>Sostegno, ne le braccia tue mi pongo.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Che vuol dir questo? Di che cosa hai tema?</l>
             <l>Onde procedon queste tue querele?</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Oh, quanto poco è per durar il nostro</l>
             <l>Dolce piacer e 'l nostro bel diletto!</l>
             <l>Ohimè, ch'io temo del fratel mio crudo</l>
             <l>L'aspre minaccie e la vendetta orrenda.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Non dubitar, conforto mio, non darmi</l>
             <l>Questo sì mal contento, te ne prego,</l>
             <l>Che sì afflitta vedendoti non lasci</l>
             <l>Ch'io prenda alcun piacer del mio conforto.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Quando l'uom pensa aver la rota in mano,</l>
             <l>E a suo bel grado di girarla crede,</l>
@@ -4343,14 +4383,14 @@ e poi si parte pian piano.</stage>
             <l>Io mi credea <name>Carpalio</name> il più felice</l>
             <l>Pastor del mondo, et or non mi par desso.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Deh, che farem, <name>Carpalio</name>? Ohimè, <name>Carpalio</name>,</l>
             <pb n="103"/>
             <l>Dammi conforto, ch'io mi sento l'alma</l>
             <l>Venir a meno e liquefarsi il core.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Non dubitar, non dubitar, <name>Melidia</name>,</l>
             <l>Che se per te bisognerà ch'esponga</l>
@@ -4358,21 +4398,21 @@ e poi si parte pian piano.</stage>
             <l>Pronta sarà. Deh, lascia il porti affanno,</l>
             <l>Lascia questi sospir, questi singulti.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Tutta mi sento alleggerita e scarca</l>
             <l>Poi che son ritornata al mio <name>Turico</name>,</l>
             <l>Che pria parea che su le spalle avessi</l>
             <l>Il mondo, e mi piegasse insino in terra.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Ti veggio, il mio <name>Carpalio</name>, in gran fastidio.</l>
             <l>La cagione non so, la cerco meno,</l>
             <l>Ma se per te convien mia vita isporre,</l>
             <l>Comandami, che pronto sarò sempre.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Non accade, <name>Turico</name>, io ti ringrazio:</l>
             <l>Questa piaga non è cui uopo sia</l>
@@ -4380,7 +4420,7 @@ e poi si parte pian piano.</stage>
             <l>il tuo fratel, con questo legno il tolgo</l>
             <l>(Purché tu vogli) or or di questa vita.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Ohimè, debbo io del sangue mio medesmo</l>
             <l>(Ch'a un tempo nati siamo) divenire</l>
@@ -4393,13 +4433,13 @@ e poi si parte pian piano.</stage>
             <l>Ci leverem di qui, vivremo altrove.</l>
           </sp>
           <pb n="104"/>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Prontissime nel ver le donne sono</l>
             <l>Ai consigli improvisi: ben dice ella.</l>
             <l>Ma chi è costui che vien sì lieto in viso?</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Gli è <name>Ofelio</name> nostro, che credea di porne</l>
             <l>In bel giardino, e in selva oscura siamo.</l>
@@ -4410,74 +4450,74 @@ e poi si parte pian piano.</stage>
             <hi rend="sc">SCENA VI</hi>
           </head>
           <stage><name>Ofelio</name>, <name>Carpalio</name>, <name>Melidia</name>, <name>Turico</name>, <name>Stellinia</name></stage>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l>Dove potrò trovar <name>Carpalio</name> mio?</l>
             <l>Dove <name>Melidia</name> da me tanto amata?</l>
             <l>Vuo' pur esser quell'io ch'ad ambedue</l>
             <l>Apporti questa così grata nova.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Senti, <name>Melidia</name>, il nostro vecchio <name>Ofelio</name>,</l>
             <l>Che noi cercando va con buona nova?</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l part="I">Chiamiamolo.</l>
           </sp>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l part="F">Non credo che più a tempo</l>
             <l>Cosa sì grata ad uomo avenir possa.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l part="I"><name>Ofelio</name>!</l>
           </sp>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l part="F">Io ne ringrazio il sommo <name>Giove</name>,</l>
             <l>Poich'egli è stato sol quel c'ha trovato</l>
             <l>A tanto mal rimedio sì opportuno.</l>
           </sp>
           <pb n="105"/>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l part="I"><name>Ofelio</name>!</l>
           </sp>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l part="M">Chi mi chiama?</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l part="F">Il tuo <name>Carpalio</name></l>
             <l>E la <name>Melidia</name> tua, che te più a petto</l>
             <l part="I">Han che la vita lor.</l>
           </sp>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l part="F"><name>Carpalio</name> mio,</l>
             <l><name>Melidia</name> mia, che nova, o <name>Dio</name>, che nova</l>
             <l part="I">V'apporto a l'improviso!</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">Su, <name>Stellinia</name>,</l>
             <l>Andiamo ancora noi a udir tal nova,</l>
             <l>Che possiam rallegrarci con <name>Carpalio</name>.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l>Non ascoltiam, <name>Turico</name>, i fatti loro.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>E perché no, s'amici siam? Venite.</l>
             <l part="I">Che nova è questa?</l>
           </sp>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l part="F">Il tuo fratel, <name>Melidia</name>,</l>
             <l>Mentre stava a mirar intento il porco</l>
@@ -4502,43 +4542,43 @@ e poi si parte pian piano.</stage>
             <l>In questo mezzo vi potrete dire</l>
             <l>I più felici giovani del mondo.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Ben v'ha provisto il cielo, ch'avevamo</l>
             <l>Dat'ordine levarli oggi la vita.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Dunque ha da ritornar dopo <num value="9">nov'</num>anni</l>
             <l part="I">Uomo com'era prima?</l>
           </sp>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l part="F">Sì, purch'egli</l>
             <l>Non gusti, com'ho detto, carne umana</l>
             <l>Mentre lupo starà tra gli altri lupi.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l>Ohimè, saran pur pochi sol <num value="9">nov'</num>anni.</l>
           </sp>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l>Non dubitar, ch'egli potria fra tanto</l>
             <l>Giunger al fin de la sua trista vita.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>Melidia</speaker>
             <l part="I">Io stupisco del caso.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l part="F">Et io, <name>Melidia</name>,</l>
             <l>Non so se questo sogno o desto senta</l>
             <l part="I">Narrarmi.</l>
           </sp>
           <pb n="107"/>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l part="F">O voi felici, o grazia rara</l>
             <l>Non so per amor vostro ch'io mi voglia,</l>
@@ -4547,22 +4587,22 @@ e poi si parte pian piano.</stage>
             <l>Sentia che in <num value="1000">mille</num> pezzi era diviso,</l>
             <l>Sì come tra più veltri è un picciol lepre.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l><name>Carpalio</name>, mi rallegro del tuo bene,</l>
             <l>Che sì insperatamente t'è avenuto.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Ben possiam dir, <name>Turico</name>, oggi che 'l cielo</l>
             <l>Ci ha rimenati a nuova vita al mondo.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Odi, <name>Carpalio</name>. Ecco qui il nostro <name>Erasto</name></l>
             <l part="I">Che sospirando viene.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>Stellinia</speaker>
             <l part="F">Ecco 'l crudele</l>
             <l>Ch'al fin non vien d'alcun contento suo.</l>
@@ -4573,14 +4613,14 @@ e poi si parte pian piano.</stage>
             <hi rend="sc">SCENA VII</hi>
           </head>
           <stage><name>Erasto</name>, <name>Ofelio</name>, <name>Carpalio</name>, <name>Turico</name></stage>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Che vuoi tu far più in questo mondo, <name>Erasto</name>,</l>
             <l>Poich'ogni stella a' tuoi disegni è contra?</l>
             <l>Che mi puoi far più, Amor? C'hai che tu serbi,</l>
             <l>Che sia per darmi maggior duol di questo?</l>
           </sp>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l>Ecco: chi lieto in su la rota siede</l>
             <l>in questo mondo, e chi nel basso cade.</l>
@@ -4588,18 +4628,18 @@ e poi si parte pian piano.</stage>
             <pb n="108"/>
             <l>Che lo tormenta quanto dir si possa.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Ahi, fortuna malvagia, ahi, fero Amore!</l>
             <l>O Amor ingrato, o instabil dea, o dea</l>
             <l>Ch'a un colpo hai tronco ogni disegno mio!</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Tu che 'l più vecchio sei, chiamalo, <name>Ofelio</name>,</l>
             <l>E offerisci di noi l'opra, s'è buona.</l>
           </sp>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l>Gentil pastor, che in questi boschi hai preso</l>
             <l>Così solingo aspro sentier da <num value="1000">mille</num></l>
@@ -4609,7 +4649,7 @@ e poi si parte pian piano.</stage>
             <l>Dimmi, se dir si può, questa sì orrenda</l>
             <l>Cagion che di tal duol ti fa si pieno.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Saggio pastor, più non convien ch'io dica</l>
             <l>L'alte querele e i gran sospiri e pianti</l>
@@ -4627,7 +4667,7 @@ e poi si parte pian piano.</stage>
             <l>Ne restasse da quel, per certo sdegno</l>
             <l part="I">Ch'avea contra la ninfa.</l>
           </sp>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l part="F">Anzi sì, sciolla,</l>
             <pb n="109"/>
@@ -4635,7 +4675,7 @@ e poi si parte pian piano.</stage>
             <l>Fuor del creder d'ognun, ché troppo fiero</l>
             <l>Era infatti il cinghial, troppo ella molle.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Però questo è cagion ch'io vuo' con questo</l>
             <l>Dardo darmi nel cor con le mie mani,</l>
@@ -4650,14 +4690,14 @@ e poi si parte pian piano.</stage>
             <l>L'odio che prima avea contro costei</l>
             <l>Tutto ha converso in più fervente amore.</l>
           </sp>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l>Non suol <name>Diana</name> già rimetter l'onte</l>
             <l>A chi l'offende <num value="1">una</num> sol volta. Sai</l>
             <l>Tu di certo che grazia abbia e pietà</l>
             <l>Costei trovata appresso la reina?</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Non lo vuo' già affermar, ma ben vuo' dirti</l>
             <l>Ch'i segni me n'han dato alcun indizio,</l>
@@ -4669,26 +4709,26 @@ e poi si parte pian piano.</stage>
             <l>Mi son partito, e ciò ch'a venir abbia</l>
             <l>Ancor non so, ma temo sia in mio danno.</l>
           </sp>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l>Ancor non sai come la cosa passi,</l>
             <l>E già ti tieni più che disperato?</l>
           </sp>
           <pb n="110"/>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Ah, s'io potessi, s'io potessi contra</l>
             <l>Pormi a <name>Diana</name>, oh che farei! O mondo,</l>
             <l>Stato mi sei pur sepoltura eterna.</l>
           </sp>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l>Che vuoi tu far, poi che così a la dea</l>
             <l>Piace? Ben sai che contra i dei non ponno</l>
             <l>Le forze umane, però ti consiglio</l>
             <l part="I">A lasciar questa impresa.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l part="F">Ahi, che consiglio!</l>
             <l>Ahi, maledetto Amor cieco e nefando,</l>
@@ -4696,34 +4736,34 @@ e poi si parte pian piano.</stage>
             <l>M'hai mostri i lieti fiori e gli arbuscelli,</l>
             <l>Ch'urtiche e spine ha poi nel fin avute!</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Non por la cosa tanto disperata,</l>
             <l>Che forse ancor potresti aver un giorno</l>
             <l>Da lei qualche conforto. Il ciel sa fare,</l>
             <l>Fratello, quando vuol, mirabil cose.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l>Chi è questo vecchio sì felice al mondo,</l>
             <l>Al par di cui vien così bella ninfa?</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Questa è la ninfa mia, questa è colei</l>
             <l>Che lo stame a mia vita accorcia e slunga.</l>
           </sp>
-          <sp>
+          <sp who="#ofelio">
             <speaker>Ofelio</speaker>
             <l>Se ti bisogna aiuto o di parole</l>
             <l>O d'altro, qui per te son preparato.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l part="I">E noi tutti altri.</l>
           </sp>
           <pb n="111"/>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l part="F">Stiamo qui in disparte</l>
             <l>Et ascoltiamo e, come 'l tempo è buono</l>
@@ -4738,20 +4778,20 @@ e poi si parte pian piano.</stage>
           </head>
           <stage><name>Callinome</name>, <name>Orenio</name>, <name>Erasto</name>, <name>Turico</name>,
 <name>Ofelio</name>, <name>Stellinia</name>, <name>Carpalio</name>, <name>Melidia</name></stage>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Non si può inver dir altrimente ch'ambo</l>
             <l>Fosti accorti e prudenti in darmi quello</l>
             <l>Sì degno e salutifero secreto,</l>
             <l part="I">Ch'alcun non se n'avide.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l part="F">Ben più saggia</l>
             <l>Fosti tu, ninfa, in dar quel velo in pegno</l>
             <l part="I">Al giovinetto <name>Erasto</name>.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l part="F">Io credea bene</l>
             <l>Che <name>Diana</name> dopo sì gran vittoria</l>
@@ -4760,13 +4800,13 @@ e poi si parte pian piano.</stage>
             <l>Non convien deviar da la sua legge</l>
             <l>Per un sol punto, che mai non perdona.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Che volontà ti venne di venire</l>
             <l part="I">Oggi a que' nostri sacrifici?</l>
           </sp>
           <pb n="112"/>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l part="F">Causa</l>
             <l>Ne fu quella <name>Stellinia</name>, che 'l legame</l>
@@ -4778,35 +4818,35 @@ e poi si parte pian piano.</stage>
             <l>Di veder quel che di travaglio tanto</l>
             <l part="I">Stato è cagion.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l part="F">Deh, dimmi, che pensiero</l>
             <l>E'l tuo, poi che <name>Diana</name> ti rifiuta?</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Andiamo tutti insieme, e siate meco</l>
             <l>In volgerla, accadendo, che mi tolga</l>
             <l part="I">Per suo compagno.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l part="F">Ohimè, che turba è questa?</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="I">Non dubitar.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l part="M">Ohimè.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="F">Non hai temuto</l>
             <l>Un sì forte cinghiale, e temi un uomo?</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>
               <name>Orenio</name>
             </speaker>
@@ -4847,7 +4887,7 @@ e poi si parte pian piano.</stage>
             <l>Simil altre parole, ma ben veggio</l>
             <l>Che la tua buona volontà noi chiede.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>
               <name>Erasto</name>
             </speaker>
@@ -4857,7 +4897,7 @@ e poi si parte pian piano.</stage>
             <l>E di greggie e d'armenti e d'altri beni,</l>
             <l part="I">Ch'a me creder nol vuol.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>
               <name>Orenio</name>
             </speaker>
@@ -4865,7 +4905,7 @@ e poi si parte pian piano.</stage>
             <l>Ch'ella nol dee saper sì ben com'altri.</l>
           </sp>
           <pb n="114"/>
-          <sp>
+          <sp who="#callinome">
             <speaker>Callinome</speaker>
             <l>Quanto il valor, quanta la forza sia</l>
             <l>Degli amorosi strali oggi ho provato,</l>
@@ -4877,7 +4917,7 @@ e poi si parte pian piano.</stage>
             <l>Ma tu, <name>Stellinia</name>, principal cagione</l>
             <l part="I">D'ogni cosa sei stata.</l>
           </sp>
-          <sp>
+          <sp who="#stellinia">
             <speaker>
               <name>Stellinia</name>
             </speaker>
@@ -4885,7 +4925,7 @@ e poi si parte pian piano.</stage>
             <l>Il tuo sprezzar Amor, che t'ha voluto</l>
             <l>Oggi mostrar quant'egli possa e vaglia.</l>
           </sp>
-          <sp>
+          <sp who="#callinome">
             <speaker>
               <name>Callinome</name>
             </speaker>
@@ -4895,19 +4935,19 @@ e poi si parte pian piano.</stage>
             <l>Ti diedi in pegno, ti vuo' far contento,</l>
             <l>Et in segno di ciò questo è l'indizio.</l>
           </sp>
-          <sp>
+          <sp who="#ofelio">
             <speaker>
               <name>Ofelio</name>
             </speaker>
             <l>Ha perduta la voce d'allegrezza.</l>
           </sp>
-          <sp>
+          <sp who="#melidia">
             <speaker>
               <name>Melidia</name>
             </speaker>
             <l>Tutta mi sento lieta per suo amore.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>
               <name>Erasto</name>
             </speaker>
@@ -4924,59 +4964,59 @@ e poi si parte pian piano.</stage>
             <l>Stasera al mio tugurio, dove festa</l>
             <l>Or col canto faremo, ora col suono,</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>
               <name>Carpalio</name>
             </speaker>
             <l>Venite pur voi tutti al mio, che sorte</l>
             <l>A me non men ch'a te stata è propizia.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>
               <name>Turico</name>
             </speaker>
             <l>Anzi, con me venir non vi sdegnate,</l>
             <l>Che di sorte miglior a voi non cedo.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Orsù, così si faccia. Oggi noi tutti</l>
             <l>Andiamo con <name>Erasto</name>, e con <name>Carpalio</name></l>
             <l>Domani, e dopo andremo con <name>Turico</name>.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l part="I">Così è conchiuso.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l part="M">E così sia.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l part="F">E sia.</l>
             <l>O il mio gentil <name>Orenio</name>, la mia vita</l>
             <l>E ciò ch'è mio, vuo' che sia tuo per sempre.</l>
           </sp>
-          <sp>
+          <sp who="#turico">
             <speaker>Turico</speaker>
             <l>Deh, poiché qui è <name>Carpalio</name> e 'l vecchio <name>Orenio</name>,</l>
             <l>Che tra gli altri pastori tien nel canto</l>
             <l>Il <num value="1">primo</num> loco, una canzone in lode</l>
             <l>Di sì felice giorno andiam cantando.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l part="I">Egli è 'l dover. Cantiamo pur.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l part="F">Cantiamo.</l>
             <l>Ma tu, <name>Turico</name>, c'hai proposto, dinne</l>
             <l>Pria la canzon che vuoi che noi cantiamo.</l>
           </sp>
           <pb n="116"/>
-          <sp>
+          <sp who="#turico">
             <speaker>
               <name>Turico</name>
             </speaker>
@@ -4985,11 +5025,11 @@ e poi si parte pian piano.</stage>
             <l>Parmi conveniente a questo giorno</l>
             <l>Tutto pieno di gioia e di contento.</l>
           </sp>
-          <sp>
+          <sp who="#carpalio">
             <speaker>Carpalio</speaker>
             <l part="I">Cantiamola.</l>
           </sp>
-          <sp>
+          <sp who="#erasto">
             <speaker>Erasto</speaker>
             <l>Ben dici. Orsù, si canti.</l>
             <l>O dei silvestri, s'alcun qui d'intorno</l>
@@ -5000,7 +5040,7 @@ e poi si parte pian piano.</stage>
             <l>Cantando in lieto corno,</l>
             <l>Lodar con noi così felice giorno.</l>
           </sp>
-          <sp>
+          <sp who="#orenio">
             <speaker>Orenio</speaker>
             <l>Andiam, non più, che l'ombra de la notte</l>
             <l>Qui non ci sovraggiunga, E voi, madonne,</l>

--- a/tei/bellincioni-egloga-ovvero-pasturale.xml
+++ b/tei/bellincioni-egloga-ovvero-pasturale.xml
@@ -82,6 +82,31 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="silvano">
+            <persName>Silvano</persName>
+          </person>
+          <person xml:id="piride">
+            <persName>Piride</persName>
+          </person>
+          <person xml:id="alfeo">
+            <persName>Alfeo</persName>
+          </person>
+          <person xml:id="putto">
+            <persName>Putto</persName>
+          </person>
+          <person xml:id="omo">
+            <persName>Omo</persName>
+          </person>
+          <person xml:id="donna">
+            <persName>Donna</persName>
+          </person>
+          <personGrp xml:id="pastori">
+            <name>Pastori</name>
+          </personGrp>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -97,7 +122,7 @@
         <argument>
           <p>Questa seguente operetta fece fare il signor conte di Caiaza a uno certo suo proposto. Se chiama EGLOGA, o vero PASTURALE, però che in questa se introducono certi pastori, che parlano e disputano d'amore, delli quali prima ne parla uno chiamato SILVANO, che seco così parlando si lamenta d'amore.</p>
         </argument>
-        <sp>
+        <sp who="#silvano">
           <speaker>SILVANO</speaker>
           <lg>
             <l>Sia maladetto el giorno,</l>
@@ -143,7 +168,7 @@
           </lg>
         </sp>
         <stage>Seguita SILVANO ancor dolendosi.</stage>
-        <sp>
+        <sp who="#silvano">
           <speaker>SILVANO</speaker>
           <lg>
             <l>Quanto chiamar mi posso sventurato</l>
@@ -167,7 +192,7 @@
           </lg>
         </sp>
         <stage>PIRIDE , el secundo pastore viene e SILVANO lo dimanda:</stage>
-        <sp>
+        <sp who="#silvano">
           <speaker>SILVANO</speaker>
           <lg>
             <l>Piride mio, onde vien tu o vai,</l>
@@ -175,7 +200,7 @@
           </lg>
         </sp>
         <stage>PIRIDE risponde:</stage>
-        <sp>
+        <sp who="#piride">
           <speaker>PIRIDE</speaker>
           <lg>
             <l>Io non tel posso dir, ma tu el vedrai</l>
@@ -184,7 +209,7 @@
             <l>che ti monstri così pien di dolore?</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#silvano">
           <speaker>SILVANO</speaker>
           <lg>
             <l>Non d'altro che d'Amor è il pianto mio:</l>
@@ -192,7 +217,7 @@
           </lg>
         </sp>
         <stage>Ancor parla SILVANO.</stage>
-        <sp>
+        <sp who="#silvano">
           <speaker>SILVANO</speaker>
           <lg>
             <l>Mentre che libertà seco ti tenne,</l>
@@ -206,7 +231,7 @@
           </lg>
         </sp>
         <stage>PIRIDE a SILVANO:</stage>
-        <sp>
+        <sp who="#piride">
           <speaker>PIRIDE</speaker>
           <lg>
             <l>Silvano, e' mi dispiace el tuo dolore;</l>
@@ -220,7 +245,7 @@
           </lg>
         </sp>
         <stage>SILVANO dice como s'inamorò:</stage>
-        <sp>
+        <sp who="#silvano">
           <speaker>SILVANO</speaker>
           <lg>
             <l>Quella ch'io cerco, un dì discinta e scalza</l>
@@ -264,7 +289,7 @@
           </lg>
         </sp>
         <stage>Un altro pastore detto ALFEO stato ascosto ha inteso tutto quel ha detto SILVANO a PIRIDE:</stage>
-        <sp>
+        <sp who="#alfeo">
           <speaker>ALFEO</speaker>
           <lg>
             <l>O Piride, o Silvano, i' sono stato</l>
@@ -277,7 +302,7 @@
             <l>e Piride beato è per amore.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#alfeo">
           <speaker>ALFEO</speaker>
           <lg>
             <l>Lassa, Piride mio, pur dir Silvano,</l>
@@ -341,7 +366,7 @@
           </lg>
         </sp>
         <stage>Dopo questo, ALFEO disse, monstrando un puto per figliolo:</stage>
-        <sp>
+        <sp who="#alfeo">
           <speaker>ALFEO</speaker>
           <lg>
             <l>Vedi, Piride mio, se in grande errore</l>
@@ -350,7 +375,7 @@
           </lg>
         </sp>
         <stage>El putto disse ad ALFEO suo patre:</stage>
-        <sp>
+        <sp who="#putto">
           <speaker>PUTTO</speaker>
           <lg>
             <l>O patre mio, da poi che Amor m'ha fatto,</l>
@@ -359,7 +384,7 @@
           </lg>
         </sp>
         <stage>Rispose il patre:</stage>
-        <sp>
+        <sp who="#alfeo">
           <speaker>ALFEO</speaker>
           <lg>
             <l>Figliol, el tempo te l'ara a 'nsegnare,</l>
@@ -370,7 +395,7 @@
           </lg>
         </sp>
         <stage>Finito che ha ALFEO , PIRIDE pastore più giovane si volta a SILVANO e così dice:</stage>
-        <sp>
+        <sp who="#piride">
           <speaker>PIRIDE</speaker>
           <lg>
             <l>Silvan, prender non vo' però spavento</l>
@@ -394,7 +419,7 @@
           </lg>
         </sp>
         <stage>In questo tempo subito un GENOVESI ed una GENOVESE aparveno e l'omo alla donna in questo modo parla:</stage>
-        <sp>
+        <sp who="#omo">
           <speaker>OMO</speaker>
           <lg>
             <l>Madonna, i'veggio là certi pastori</l>
@@ -408,7 +433,7 @@
           </lg>
         </sp>
         <stage>Lei risponde:</stage>
-        <sp>
+        <sp who="#donna">
           <speaker>DONNA</speaker>
           <lg>
             <l>Andian, caro parente, andian da loro,</l>
@@ -418,7 +443,7 @@
           </lg>
         </sp>
         <stage>Mentre che vengono, PIRIDE dice a SILVANO:</stage>
-        <sp>
+        <sp who="#piride">
           <speaker>PIRIDE</speaker>
           <lg>
             <l>Silvan, per cortesia</l>
@@ -431,7 +456,7 @@
           </lg>
         </sp>
         <stage>Dice SILVANO quando ha visto la GENOVESE:</stage>
-        <sp>
+        <sp who="#silvano">
           <speaker>SILVANO</speaker>
           <lg>
             <l>Certo costei all'abito mi pare</l>
@@ -445,7 +470,7 @@
           </lg>
         </sp>
         <stage>Giunta che fu la donna a' pastori dice:</stage>
-        <sp>
+        <sp who="#donna">
           <speaker>DONNA</speaker>
           <lg>
             <l>Perché spesso nel volto apare el core,</l>
@@ -459,7 +484,7 @@
           </lg>
         </sp>
         <stage>SILVANO a PIRIDE:</stage>
-        <sp>
+        <sp who="#silvano">
           <speaker>SILVANO</speaker>
           <lg>
             <l>Piride mio, da te piglio or licenzia</l>
@@ -473,7 +498,7 @@
           </lg>
         </sp>
         <stage>Parlato che ha SILVANO, come sapeva bene che lei arebbe data la sentenzia per PIRIDE che si namorassi, PIRIDE alegro si volta a certi pastori e cantarono così:</stage>
-        <sp>
+        <sp who="#piride #pastori">
           <speaker>PIRIDE E PASTORI</speaker>
           <lg>
             <l>Non voglio esser più pastore,</l>

--- a/tei/bellincioni-ripresentazione-di-pavia.xml
+++ b/tei/bellincioni-ripresentazione-di-pavia.xml
@@ -82,6 +82,43 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="mercurio">
+            <persName>Mercurio</persName>
+          </person>
+          <person xml:id="iunone">
+            <persName>Iunone</persName>
+          </person>
+          <person xml:id="grammatica">
+            <persName>Grammatica</persName>
+          </person>
+          <person xml:id="logica">
+            <persName>Logica</persName>
+          </person>
+          <person xml:id="retorica">
+            <persName>Retorica</persName>
+          </person>
+          <person xml:id="aritmetica">
+            <persName>Aritmetica</persName>
+          </person>
+          <person xml:id="geometria">
+            <persName>Geometria</persName>
+          </person>
+          <person xml:id="astrologia">
+            <persName>Astrologia</persName>
+          </person>
+          <person xml:id="musica">
+            <persName>Musica</persName>
+          </person>
+          <person xml:id="saturno">
+            <persName>Saturno</persName>
+          </person>
+          <person xml:id="li_quatri_elementi">
+            <persName>Li Quatri Elementi</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -102,7 +139,7 @@
       <div>
         <head>Ripresentazione di Pavia</head>
         <stage>MERCURIO parla in laude del Duca Ercole.</stage>
-        <sp>
+        <sp who="#mercurio">
           <speaker>MERCURIO</speaker>
           <lg>
             <l>Quivi è colui, che mai si vide sazio</l>
@@ -126,7 +163,7 @@
           </lg>
         </sp>
         <stage>IUNONE, vedendo MERCURIO, in questo modo parla:</stage>
-        <sp>
+        <sp who="#iunone">
           <speaker>IUNONE</speaker>
           <lg>
             <l>Mercurio, unde vai o donde vieni?</l>
@@ -140,7 +177,7 @@
           </lg>
         </sp>
         <stage>Parlato IUNONE, MERCURIO a lei così risponde:</stage>
-        <sp>
+        <sp who="#mercurio">
           <speaker>MERCURIO</speaker>
           <lg>
             <l>O glorïosa Iddea, alta Iunone,</l>
@@ -174,7 +211,7 @@
           </lg>
         </sp>
         <stage>GIUNONE a MERCURIO ancora risponde:</stage>
-        <sp>
+        <sp who="#iunone">
           <speaker>GIUNONE</speaker>
           <lg>
             <l>Mercurio, io vo' venir con teco insieme,</l>
@@ -188,7 +225,7 @@
           </lg>
         </sp>
         <stage>Venuta IUNONE insieme con MERCURIO davante alla Duchessa in questo modo gli parla:</stage>
-        <sp>
+        <sp who="#iunone">
           <speaker>GIUNONE</speaker>
           <lg>
             <l>O sacre Iddee, o voi superne stelle,</l>
@@ -242,7 +279,7 @@
           </lg>
         </sp>
         <stage>Dicte che ebbe le precedente parole IUNONE se partite e subito venerno le sette arte liberale e prima GRAMMATICA.</stage>
-        <sp>
+        <sp who="#grammatica">
           <speaker>GRAMMATICA</speaker>
           <lg>
             <l>Io son colei che ne l'Egipto naqui,</l>
@@ -266,7 +303,7 @@
           </lg>
         </sp>
         <stage>Dicto GRAMMATICA, venne la LOGICA.</stage>
-        <sp>
+        <sp who="#logica">
           <speaker>LOGICA</speaker>
           <lg>
             <l>Logica son io, e son colei</l>
@@ -290,7 +327,7 @@
           </lg>
         </sp>
         <stage>Seguita la RETORICA:</stage>
-        <sp>
+        <sp who="#retorica">
           <speaker>RETORICA</speaker>
           <lg>
             <l>Retorica son io, che col parlare</l>
@@ -314,7 +351,7 @@
           </lg>
         </sp>
         <stage>Seguita l'ARITMETICA:</stage>
-        <sp>
+        <sp who="#aritmetica">
           <speaker>ARITMETICA</speaker>
           <lg>
             <l>Aritmetica sono, e son colei</l>
@@ -338,7 +375,7 @@
           </lg>
         </sp>
         <stage>Seguita la GEOMETRIA:</stage>
-        <sp>
+        <sp who="#geometria">
           <speaker>GEOMETRIA</speaker>
           <lg>
             <l>I' son quella sotil Geometria,</l>
@@ -362,7 +399,7 @@
           </lg>
         </sp>
         <stage>ASTROLOGIA poi sequita:</stage>
-        <sp>
+        <sp who="#astrologia">
           <speaker>ASTROLOGIA</speaker>
           <lg>
             <l>I' son colei, che per le sette spere</l>
@@ -386,7 +423,7 @@
           </lg>
         </sp>
         <stage>MUSICA la septima e ultima:</stage>
-        <sp>
+        <sp who="#musica">
           <speaker>MUSICA</speaker>
           <lg>
             <l>Musica son, che tutto il regno santo</l>
@@ -410,7 +447,7 @@
           </lg>
         </sp>
         <stage>Finito ch'ebbono di parlar le sette Arte incominciorno a cantare la seguente canzonetta:</stage>
-        <sp>
+        <sp who="#grammatica #logica #retorica #aritmetica #geometria #astrologia #musica">
           <speaker>Sette Arte</speaker>
           <lg>
             <l>Le sette Arte siàn chiamate,</l>
@@ -454,7 +491,7 @@
           </lg>
         </sp>
         <stage>Dapoi la sera venne SATURNO con li quatto elementi e disse le sequente parole:</stage>
-        <sp>
+        <sp who="#saturno">
           <speaker>SATURNO</speaker>
           <lg>
             <l>I' son Saturno, el più alto pianeta:</l>
@@ -533,7 +570,7 @@
           </lg>
         </sp>
         <stage>LI QUATRI ELEMENTI poi così cantorno:</stage>
-        <sp>
+        <sp who="#li_quatri_elementi">
           <speaker>LI QUATRI ELEMENTI</speaker>
           <lg>
             <l>Cantiàn tutti viva 'l Moro,</l>

--- a/tei/boiardo-timone.xml
+++ b/tei/boiardo-timone.xml
@@ -82,6 +82,52 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="luciano">
+            <persName>Luciano</persName>
+          </person>
+          <person xml:id="timone">
+            <persName>Timone</persName>
+          </person>
+          <person xml:id="iove">
+            <persName>Iove</persName>
+          </person>
+          <person xml:id="mercurio">
+            <persName>Mercurio</persName>
+          </person>
+          <person xml:id="richeza">
+            <persName>Richeza</persName>
+          </person>
+          <person xml:id="povertate">
+            <persName>Povertate</persName>
+          </person>
+          <person xml:id="fama">
+            <persName>Fama</persName>
+          </person>
+          <person xml:id="gnatonide">
+            <persName>Gnatonide</persName>
+          </person>
+          <person xml:id="fliade">
+            <persName>Fliade</persName>
+          </person>
+          <person xml:id="demea">
+            <persName>Demea</persName>
+          </person>
+          <person xml:id="trasicle">
+            <persName>Trasicle</persName>
+          </person>
+          <person xml:id="auxilio">
+            <persName>Auxilio</persName>
+          </person>
+          <person xml:id="siro">
+            <persName>Siro</persName>
+          </person>
+          <person xml:id="parmeno">
+            <persName>Parmeno</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -97,7 +143,7 @@
           <hi rend="sc">Prologo</hi>
         </head>
         <stage>Entra Timone nel proscenio. <hi rend="sc">luciano</hi> è volto a li Spectatori; dice li sequenti versi:</stage>
-        <sp>
+        <sp who="#luciano">
           <speaker>
             <hi rend="sc">luciano.</hi>
           </speaker>
@@ -262,7 +308,7 @@
           <hi rend="sc">Atto primo</hi>
         </head>
         <stage>Entra <hi rend="sc">timone</hi> da lo altro capo del proscenio, e prima comincia a zapare, poi, intrametendo la opera, volta la facia al cielo, e dice così:</stage>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -468,7 +514,7 @@
           </lg>
         </sp>
         <stage>Le cortine del cielo se aprino, <hi rend="sc">iove</hi> appare cum <hi rend="sc">mercurio</hi> ne li abiti già descripti, et insieme parlano, come apare di sotto.</stage>
-        <sp>
+        <sp who="#iove">
           <speaker>
             <hi rend="sc">iove.</hi>
           </speaker>
@@ -490,7 +536,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">mercurio.</hi>
           </speaker>
@@ -507,7 +553,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#iove">
           <speaker>
             <hi rend="sc">iove.</hi>
           </speaker>
@@ -519,7 +565,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">mercurio.</hi>
           </speaker>
@@ -551,7 +597,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#iove">
           <speaker>
             <hi rend="sc">iove.</hi>
           </speaker>
@@ -647,7 +693,7 @@
           </lg>
         </sp>
         <stage><hi rend="sc">mercurio</hi> lascia <hi rend="sc">iove</hi> in sedia e, caminando per el proscenio superiore , dice le parole che segueno, volgendo el viso a li spectatori:</stage>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">mercurio.</hi>
           </speaker>
@@ -688,7 +734,7 @@
           </lg>
         </sp>
         <stage><hi rend="sc">timone</hi> passa oltro al monte, e prima che vi arivi va dicendo queste parole:</stage>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -735,7 +781,7 @@
           <hi rend="sc">Atto secondo</hi>
         </head>
         <stage>Questo secondo acto è tuto ne la scena superiore. <hi rend="sc">mercurio</hi> conduce la <hi rend="sc">richeza</hi> a <hi rend="sc">iove</hi>, e tra loro parlano come aparerà di sotto.</stage>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">mercurio.</hi>
           </speaker>
@@ -752,7 +798,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#iove">
           <speaker>
             <hi rend="sc">iove.</hi>
           </speaker>
@@ -764,7 +810,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#richeza">
           <speaker>
             <hi rend="sc">richeza.</hi>
           </speaker>
@@ -781,7 +827,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#iove">
           <speaker>
             <hi rend="sc">iove.</hi>
           </speaker>
@@ -798,7 +844,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#richeza">
           <speaker>
             <hi rend="sc">richeza.</hi>
           </speaker>
@@ -855,7 +901,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#iove">
           <speaker>
             <hi rend="sc">iove.</hi>
           </speaker>
@@ -965,7 +1011,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#richeza">
           <speaker>
             <hi rend="sc">richeza.</hi>
           </speaker>
@@ -1072,7 +1118,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#iove">
           <speaker>
             <hi rend="sc">iove.</hi>
           </speaker>
@@ -1119,7 +1165,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#richeza">
           <speaker>
             <hi rend="sc">richeza.</hi>
           </speaker>
@@ -1141,7 +1187,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#iove">
           <speaker>
             <hi rend="sc">iove.</hi>
           </speaker>
@@ -1187,7 +1233,7 @@
           </lg>
         </sp>
         <stage><hi rend="sc">iove</hi>, levatosi di sedia, camina tanto che passa le cortine; <hi rend="sc">mercurio</hi> prende la <hi rend="sc">richeza</hi> a mano e caminando per el proscenio e spesso firmandosi, ragiona cum lei, come aparerà di sotto.</stage>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">mercurio.</hi>
           </speaker>
@@ -1199,7 +1245,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#richeza">
           <speaker>
             <hi rend="sc">richeza.</hi>
           </speaker>
@@ -1221,7 +1267,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">mercurio. </hi>
           </speaker>
@@ -1248,7 +1294,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#richeza">
           <speaker>
             <hi rend="sc">richeza.</hi>
           </speaker>
@@ -1340,7 +1386,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">mercurio.</hi>
           </speaker>
@@ -1357,7 +1403,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#richeza">
           <speaker>
             <hi rend="sc">richeza.</hi>
           </speaker>
@@ -1379,7 +1425,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">mercurio.</hi>
           </speaker>
@@ -1391,7 +1437,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#richeza">
           <speaker>
             <hi rend="sc">richeza.</hi>
           </speaker>
@@ -1423,7 +1469,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">mercurio.</hi>
           </speaker>
@@ -1440,7 +1486,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#richeza">
           <speaker>
             <hi rend="sc">richeza.</hi>
           </speaker>
@@ -1452,7 +1498,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">mercurio. </hi>
           </speaker>
@@ -1474,7 +1520,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#richeza">
           <speaker>
             <hi rend="sc">richeza.</hi>
           </speaker>
@@ -1486,7 +1532,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">mercurio.</hi>
           </speaker>
@@ -1498,7 +1544,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#richeza">
           <speaker>
             <hi rend="sc">richeza.</hi>
           </speaker>
@@ -1525,7 +1571,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">mercurio.</hi>
           </speaker>
@@ -1537,7 +1583,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#richeza">
           <speaker>
             <hi rend="sc">richeza.</hi>
           </speaker>
@@ -1564,7 +1610,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">mercurio.</hi>
           </speaker>
@@ -1591,7 +1637,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#richeza">
           <speaker>
             <hi rend="sc">richeza.</hi>
           </speaker>
@@ -1603,7 +1649,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">mercurio.</hi>
           </speaker>
@@ -1620,7 +1666,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#richeza">
           <speaker>
             <hi rend="sc">richeza.</hi>
           </speaker>
@@ -1647,7 +1693,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">mercurio.</hi>
           </speaker>
@@ -1664,7 +1710,7 @@
           <hi rend="sc">Atto terzo</hi>
         </head>
         <stage> Entra <hi rend="sc">timone</hi>  in siena dicendo le prime parole che segueno; cum lui sono la <hi rend="sc">povertade</hi> e l'altre tre compagne. Sopraviene poi <hi rend="sc">mercurio</hi> e la <hi rend="sc">richeza</hi>, e parlano tra sé ne' modi scripti di sotto.</stage>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -1691,7 +1737,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">mercurio.</hi>
           </speaker>
@@ -1703,7 +1749,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#richeza">
           <speaker>
             <hi rend="sc">richeza.</hi>
           </speaker>
@@ -1725,7 +1771,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">mercurio.</hi>
           </speaker>
@@ -1742,7 +1788,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#richeza">
           <speaker>
             <hi rend="sc">richeza.</hi>
           </speaker>
@@ -1754,7 +1800,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">mercurio.</hi>
           </speaker>
@@ -1766,7 +1812,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#richeza">
           <speaker>
             <hi rend="sc">richeza.</hi>
           </speaker>
@@ -1778,7 +1824,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">mercurio.</hi>
           </speaker>
@@ -1794,7 +1840,7 @@
           </lg>
         </sp>
         <stage>La <hi rend="sc">povertate</hi> se move del loco suo e vien contro a <hi rend="sc">mercurio</hi>, e parlano così tra loro.</stage>
-        <sp>
+        <sp who="#povertate">
           <speaker>
             <hi rend="sc">povertate.</hi>
           </speaker>
@@ -1806,7 +1852,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">mercurio.</hi>
           </speaker>
@@ -1818,7 +1864,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#povertate">
           <speaker>
             <hi rend="sc">povertate.</hi>
           </speaker>
@@ -1850,7 +1896,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">mercurio.</hi>
           </speaker>
@@ -1862,7 +1908,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#povertate">
           <speaker>
             <hi rend="sc">povertate.</hi>
           </speaker>
@@ -1889,7 +1935,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">mercurio.</hi>
           </speaker>
@@ -1905,7 +1951,7 @@
           </lg>
         </sp>
         <stage>Come la <hi rend="sc">povertate</hi> cum le compagne hano passate le cortine, <hi rend="sc">timone</hi> leva el capo, ché avea zappato sempre, mentre che le soprascrite persone hano parlato insieme. Ora volto a <hi rend="sc">mercurio</hi> e la <hi rend="sc">richeza</hi>, cum voce orgogliosa, dice così:</stage>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -1937,7 +1983,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">mercurio.</hi>
           </speaker>
@@ -1949,7 +1995,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -1971,7 +2017,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#richeza">
           <speaker>
             <hi rend="sc">richeza.</hi>
           </speaker>
@@ -1988,7 +2034,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">mercurio.</hi>
           </speaker>
@@ -2005,7 +2051,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -2022,7 +2068,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">mercurio.</hi>
           </speaker>
@@ -2039,7 +2085,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -2106,7 +2152,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#richeza">
           <speaker>
             <hi rend="sc">richeza.</hi>
           </speaker>
@@ -2118,7 +2164,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -2130,7 +2176,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#richeza">
           <speaker>
             <hi rend="sc">richeza.</hi>
           </speaker>
@@ -2172,7 +2218,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -2184,7 +2230,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">mercurio.</hi>
           </speaker>
@@ -2196,7 +2242,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -2208,7 +2254,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">mercurio.</hi>
           </speaker>
@@ -2229,7 +2275,7 @@
           </lg>
         </sp>
         <stage><hi rend="sc">mercurio</hi> entra  per machina, ascende in cielo o furtivamente se nasconde di subito. La <hi rend="sc">richeza</hi> come cieca sta sospesa e parla come se vede di sotto; poi fuggie velocemente. <hi rend="sc">timone</hi> zapando trova el tesoro, e parla come aparerà al suo loco.</stage>
-        <sp>
+        <sp who="#richeza">
           <speaker>
             <hi rend="sc">richeza.</hi>
           </speaker>
@@ -2251,7 +2297,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -2398,7 +2444,7 @@
           <hi rend="sc">Atto quarto</hi>
         </head>
         <stage>Cominzia lo atto quarto nel quale la <hi rend="sc">fama</hi> ne lo abito suo entra in scena, e dice le seguente parole:</stage>
-        <sp>
+        <sp who="#fama">
           <speaker>
             <hi rend="sc">fama.</hi>
           </speaker>
@@ -2484,7 +2530,7 @@
           </lg>
         </sp>
         <stage>Come <hi rend="sc">timone</hi> appare, la <hi rend="sc">fama</hi> se parte, et esso dice così:</stage>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -2610,7 +2656,7 @@
           </lg>
         </sp>
         <stage><hi rend="sc">gnatonide</hi> cum altri apariscono, ma lui solo se presenta a <hi rend="sc">timone</hi> e parla, così:</stage>
-        <sp>
+        <sp who="#gnatonide">
           <speaker>
             <hi rend="sc">gnatonide.</hi>
           </speaker>
@@ -2632,7 +2678,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -2649,7 +2695,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#gnatonide">
           <speaker>
             <hi rend="sc">gnatonide.</hi>
           </speaker>
@@ -2666,7 +2712,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -2678,7 +2724,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#gnatonide">
           <speaker>
             <hi rend="sc">gnatonide.</hi>
           </speaker>
@@ -2690,7 +2736,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -2702,7 +2748,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#gnatonide">
           <speaker>
             <hi rend="sc">gnatonide.</hi>
           </speaker>
@@ -2714,7 +2760,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -2726,7 +2772,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#gnatonide">
           <speaker>
             <hi rend="sc">gnatonide.</hi>
           </speaker>
@@ -2738,7 +2784,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -2774,7 +2820,7 @@
           </lg>
         </sp>
         <stage>Fugie <hi rend="sc">gnatonide</hi> e <hi rend="sc">fliade</hi> fuor de li altri se tra' avanti e dice queste parole:</stage>
-        <sp>
+        <sp who="#fliade">
           <speaker>
             <hi rend="sc">fliade.</hi>
           </speaker>
@@ -2811,7 +2857,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -2823,7 +2869,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#fliade">
           <speaker>
             <hi rend="sc">fliade.</hi>
           </speaker>
@@ -2835,7 +2881,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -2876,7 +2922,7 @@
           </lg>
         </sp>
         <stage>Partendosi <hi rend="sc">fliade</hi> cum la testa rotta, viene oltre <hi rend="sc">demea</hi> cum uno decreto o privilegio in mano, e come gionge presso a <hi rend="sc">timone</hi>, lo inchina, e dice così:</stage>
-        <sp>
+        <sp who="#demea">
           <speaker>
             <hi rend="sc">demea.</hi>
           </speaker>
@@ -2908,7 +2954,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -2920,7 +2966,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#demea">
           <speaker>
             <hi rend="sc">demea.</hi>
           </speaker>
@@ -2942,7 +2988,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -2954,7 +3000,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#demea">
           <speaker>
             <hi rend="sc">demea.</hi>
           </speaker>
@@ -2996,7 +3042,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -3008,7 +3054,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#demea">
           <speaker>
             <hi rend="sc">demea.</hi>
           </speaker>
@@ -3040,7 +3086,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -3052,7 +3098,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#demea">
           <speaker>
             <hi rend="sc">demea.</hi>
           </speaker>
@@ -3064,7 +3110,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -3076,7 +3122,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#demea">
           <speaker>
             <hi rend="sc">demea.</hi>
           </speaker>
@@ -3093,7 +3139,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -3239,7 +3285,7 @@
           </lg>
         </sp>
         <stage>Avendo <hi rend="sc">timone</hi> parlato come apare di sopra, ne viene contra a <hi rend="sc">trasicle</hi>, che alquanto scostato da lui sta tacito; ma <hi rend="sc">timone</hi> verso esso dice così:</stage>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -3251,7 +3297,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#trasicle">
           <speaker>
             <hi rend="sc">trasicle.</hi>
           </speaker>
@@ -3343,7 +3389,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -3355,7 +3401,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#trasicle">
           <speaker>
             <hi rend="sc">trasicle.</hi>
           </speaker>
@@ -3367,7 +3413,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -3389,7 +3435,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#trasicle">
           <speaker>
             <hi rend="sc">trasicle.</hi>
           </speaker>
@@ -3399,7 +3445,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -3425,7 +3471,7 @@
           <hi rend="sc">Atto quinto</hi>
         </head>
         <stage>Comincia el quinto acto nel quale entra lo <hi rend="sc">auxilio</hi> ne lo abito suo, e dice le parole che segueno, cioè:</stage>
-        <sp>
+        <sp who="#auxilio">
           <speaker>
             <hi rend="sc">auxilio.</hi>
           </speaker>
@@ -3566,7 +3612,7 @@
           </lg>
         </sp>
         <stage>Come <hi rend="sc">timone</hi> apare, lo <hi rend="sc">auxilio</hi> se parte, et esso <hi rend="sc">timone</hi> viene cum sé dicendo le sotto scritte parole.</stage>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -3632,7 +3678,7 @@
           </lg>
         </sp>
         <stage>Fermasi <hi rend="sc">timone</hi>;  <hi rend="sc">parmeno</hi> e <hi rend="sc">siro</hi> lentamente procedendo tra loro così ragionano.</stage>
-        <sp>
+        <sp who="#siro">
           <speaker>
             <hi rend="sc">siro.</hi>
           </speaker>
@@ -3644,7 +3690,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#parmeno">
           <speaker>
             <hi rend="sc">parmen.</hi>
           </speaker>
@@ -3671,7 +3717,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#siro">
           <speaker>
             <hi rend="sc">siro.</hi>
           </speaker>
@@ -3683,7 +3729,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#parmeno">
           <speaker>
             <hi rend="sc">parmeno.</hi>
           </speaker>
@@ -3700,7 +3746,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#siro">
           <speaker>
             <hi rend="sc">siro.</hi>
           </speaker>
@@ -3712,7 +3758,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#parmeno">
           <speaker>
             <hi rend="sc">parmeno.</hi>
           </speaker>
@@ -3729,7 +3775,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#siro">
           <speaker>
             <hi rend="sc">siro.</hi>
           </speaker>
@@ -3741,7 +3787,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#parmeno">
           <speaker>
             <hi rend="sc">parmeno.</hi>
           </speaker>
@@ -3753,7 +3799,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#siro">
           <speaker>
             <hi rend="sc">siro.</hi>
           </speaker>
@@ -3770,7 +3816,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#parmeno">
           <speaker>
             <hi rend="sc">parmeno.</hi>
           </speaker>
@@ -3782,7 +3828,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#siro">
           <speaker>
             <hi rend="sc">siro.</hi>
           </speaker>
@@ -3794,7 +3840,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#parmeno">
           <speaker>
             <hi rend="sc">parmeno.</hi>
           </speaker>
@@ -3811,7 +3857,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#siro">
           <speaker>
             <hi rend="sc">siro.</hi>
           </speaker>
@@ -3863,7 +3909,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#parmeno">
           <speaker>
             <hi rend="sc">parmeno.</hi>
           </speaker>
@@ -3875,7 +3921,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#siro">
           <speaker>
             <hi rend="sc">siro.</hi>
           </speaker>
@@ -3887,7 +3933,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#parmeno">
           <speaker>
             <hi rend="sc">parmeno.</hi>
           </speaker>
@@ -3903,7 +3949,7 @@
           </lg>
         </sp>
         <stage>Li doi servi vengono verso il sopolcro: <hi rend="sc">timone</hi> li scrida cum le seguente parole, et cossì rispondono come aparirà di sotto.</stage>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -3920,7 +3966,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#parmeno">
           <speaker>
             <hi rend="sc">parmeno.</hi>
           </speaker>
@@ -3937,7 +3983,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -3949,7 +3995,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#siro">
           <speaker>
             <hi rend="sc">siro.</hi>
           </speaker>
@@ -3966,7 +4012,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -3978,7 +4024,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#parmeno">
           <speaker>
             <hi rend="sc">parmeno.</hi>
           </speaker>
@@ -3990,7 +4036,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -4012,7 +4058,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#parmeno">
           <speaker>
             <hi rend="sc">parmeno.</hi>
           </speaker>
@@ -4024,7 +4070,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#siro">
           <speaker>
             <hi rend="sc">siro.</hi>
           </speaker>
@@ -4036,7 +4082,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -4048,7 +4094,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#siro">
           <speaker>
             <hi rend="sc">siro.</hi>
           </speaker>
@@ -4085,7 +4131,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -4097,7 +4143,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#siro">
           <speaker>
             <hi rend="sc">siro.</hi>
           </speaker>
@@ -4119,7 +4165,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -4201,7 +4247,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#siro">
           <speaker>
             <hi rend="sc">siro.</hi>
           </speaker>
@@ -4213,7 +4259,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#parmeno">
           <speaker>
             <hi rend="sc">parmeno.</hi>
           </speaker>
@@ -4225,7 +4271,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#siro">
           <speaker>
             <hi rend="sc">siro.</hi>
           </speaker>
@@ -4242,7 +4288,7 @@
             </lg>
           </lg>
         </sp>
-        <sp>
+        <sp who="#parmeno">
           <speaker>
             <hi rend="sc">parmeno.</hi>
           </speaker>
@@ -4253,7 +4299,7 @@
           </lg>
         </sp>
         <stage>Li doi servi se partono e poco da  poi <hi rend="sc">timone</hi>, dicendo le parole che seguano apresso:</stage>
-        <sp>
+        <sp who="#timone">
           <speaker>
             <hi rend="sc">timone.</hi>
           </speaker>
@@ -4286,7 +4332,7 @@
           </lg>
         </sp>
         <stage>Partito <hi rend="sc">timone</hi> entra lo <hi rend="sc">auxilio</hi>, quale volto a li spectatori dice così :</stage>
-        <sp>
+        <sp who="#auxilio">
           <speaker>
             <hi rend="sc">auxilio.</hi>
           </speaker>

--- a/tei/cammelli-panfila.xml
+++ b/tei/cammelli-panfila.xml
@@ -82,6 +82,52 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="demetrio">
+            <persName>Demetrio</persName>
+          </person>
+          <person xml:id="panfila">
+            <persName>Panfila</persName>
+          </person>
+          <person xml:id="filostrato">
+            <persName>Filostrato</persName>
+          </person>
+          <personGrp xml:id="coro">
+            <name>Coro</name>
+          </personGrp>
+          <person xml:id="amore">
+            <persName>Amore</persName>
+          </person>
+          <person xml:id="tindaro">
+            <persName>Tindaro</persName>
+          </person>
+          <person xml:id="pandero">
+            <persName>Pandero</persName>
+          </person>
+          <person xml:id="parche">
+            <persName>Parche</persName>
+          </person>
+          <person xml:id="atropos">
+            <persName>Atropos</persName>
+          </person>
+          <person xml:id="tinolo">
+            <persName>Tinolo</persName>
+          </person>
+          <person xml:id="pinzia">
+            <persName>Pinzia</persName>
+          </person>
+          <person xml:id="donzella">
+            <persName>Donzella</persName>
+          </person>
+          <person xml:id="filada">
+            <persName>Filada</persName>
+          </person>
+          <person xml:id="litigia">
+            <persName>Litigia</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>2003-05-30T00:00:00.000+02:00</date><name>Caterina Grata</name><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -166,7 +212,7 @@
           <head>Scena I</head>
           <stage><hi rend="sc"><name>DEMETRIO</name></hi> re, <hi rend="sc"><name>PANFILA</name> figliola.
 </hi></stage>
-          <sp>
+          <sp who="#demetrio">
             <speaker>DEMETRIO</speaker>
             <l>Questi alti gradi de la signoria</l>
             <l>fan molte fiate ai prìncipi parere</l>
@@ -230,7 +276,7 @@
             <l>or ti dono licenzia, essendo meco,</l>
             <l>che alla proposta mia rispondi un poco.</l>
           </sp>
-          <sp>
+          <sp who="#panfila">
             <speaker>PANFILA.</speaker>
             <l>La poca experienzia e 'l manco indizio </l>
             <l>e la mia verde età non voglion che io</l>
@@ -267,7 +313,7 @@
             <l>non sol gli aiuta, aiutali e consiglia,</l>
             <l>perché questa serà tua eterna fama.</l>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker>DEMETRIO re.</speaker>
             <l>Ottimo è el tuo parlar, cara mia figlia,</l>
             <l>in questa verde etade, e quel che hai detto</l>
@@ -284,7 +330,7 @@
         <div type="scene">
           <head>Scena II</head>
           <stage>Lauda <hi rend="sc"><name>FILOSTRATO</name> servo:</hi></stage>
-          <sp>
+          <sp who="#filostrato">
             <speaker>FILOSTRATO</speaker>
             <l>Se i servi fussen, figlia, qual costui, </l>
             <l>non serebbe bisogno aver paura</l>
@@ -361,7 +407,7 @@
         </div>
         <div type="scene">
           <head>Scena III</head>
-          <sp>
+          <sp who="#panfila">
             <speaker>PANFILA.</speaker>
             <l>Ogni cosa rinova, io me disfaccio</l>
             <l>in ardenti suspir, qual cera al foco,</l>
@@ -415,52 +461,52 @@
           <head>Scena IV</head>
           <stage><hi rend="sc">El CORO</hi> e <hi rend="sc">AMORE.
 </hi></stage>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO.</speaker>
             <l>Ogni cosa vinci, <name>Amore</name>;</l>
             <l>del tutto hai la signoria.</l>
           </sp>
-          <sp>
+          <sp who="#amore">
             <speaker>AMORE.</speaker>
             <l>Quel che vuol la grazia mia</l>
             <l>non ne spende altro che 'l core.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO.</speaker>
             <l>Nullo uom po' contra tue prove,</l>
             <l>perde ognun che ha teco guerra.</l>
           </sp>
-          <sp>
+          <sp who="#amore">
             <speaker>AMORE. </speaker>
             <l>Io cavai fuor del ciel <name>Giove</name>,</l>
             <l>fecil poi venire in terra.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO.</speaker>
             <l>Non sì tosto se disserra</l>
             <l>quel che lega el tuo furore.</l>
           </sp>
-          <sp>
+          <sp who="#amore">
             <speaker>AMORE.</speaker>
             <l>El mio foco non se amorza</l>
             <l>né per acqua erbe o parole.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO.</speaker>
             <l>Nulla val contra tua forza.</l>
             <l>Chi sen lauda e chi sen dole.</l>
           </sp>
-          <sp>
+          <sp who="#amore">
             <speaker>AMORE.</speaker>
             <l>Per me venne in terra il Sole</l>
             <l>e per me si fé pastore.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO. </speaker>
             <l>Tu vincesti <name>Ercule</name> greco</l>
             <l>che domava ogni gran mostro.</l>
           </sp>
-          <sp>
+          <sp who="#amore">
             <speaker>AMORE.</speaker>
             <l>Lassò <name>Pluto</name> il regno cieco,</l>
             <l>lassù <name>Pluto</name> el tartar chiostro:</l>
@@ -469,22 +515,22 @@
             <l>Perdonar non volsi a patre,</l>
             <l>Come quel che non ha parte. </l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO.</speaker>
             <l>Irretir festi tua matre;</l>
             <l>e compagno a lei fu <name>Marte</name>.</l>
           </sp>
-          <sp>
+          <sp who="#amore">
             <speaker>AMORE.</speaker>
             <l>Le mie forze sono sparte,</l>
             <l>qual del sole il suo splendore.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO.</speaker>
             <l> Quel che crede esser sicuro,</l>
             <l>da te prima è saettato.</l>
           </sp>
-          <sp>
+          <sp who="#amore">
             <speaker>AMORE.</speaker>
             <l>Non pensava nel futuro</l>
             <l>benché giunto ho <name>Filostrato</name>,</l>
@@ -506,7 +552,7 @@
         <div type="scene">
           <head>Scena I</head>
           <stage><name>FILOSTRATO</name> giovene innamorato.</stage>
-          <sp>
+          <sp who="#filostrato">
             <speaker>FILOSTRATO</speaker>
             <l>Non guardai tanto mai <name>Panfila</name> in viso</l>
             <l>quanto questa mattina, e per ventura</l>
@@ -575,7 +621,7 @@
         </div>
         <div type="scene">
           <head>Scena II</head>
-          <sp>
+          <sp who="#panfila">
             <speaker>PANFILA.</speaker>
             <l><name>Filostrato</name> che fai ? dégnate un poco.</l>
             <l>Mio padre il re tanto ti fa superbo</l>
@@ -590,7 +636,7 @@
             <l>se tu le sciogli, relegale poi,</l>
             <l>e portane due altre incolorite.</l>
           </sp>
-          <sp>
+          <sp who="#filostrato">
             <speaker>FILOSTRATO. </speaker>
             <l>O <name>Amore</name>, duri sono i colpi toi!</l>
             <l>Ma come serà mai ch'io me ritegna</l>
@@ -613,7 +659,7 @@
             <hi rend="sc"><name>TINDARO</name> vecchio,<name>FILOSTRATO.
 </name></hi>
           </stage>
-          <sp>
+          <sp who="#tindaro">
             <speaker>TINDARO.</speaker>
             <l>Ben ti so dir che m'ha servito il re</l>
             <l>di quanto adimandava, qual se mai</l>
@@ -661,7 +707,7 @@
             <l>a tormi il tempo. O re aspro e crudele,</l>
             <l>postù patir quel che ho teco patito.</l>
           </sp>
-          <sp>
+          <sp who="#filostrato">
             <speaker>FILOSTRATO.</speaker>
             <l>O ninfa, a me bisogna esser fidele</l>
             <l>secondo che ho qui letto per l'adviso,</l>
@@ -691,7 +737,7 @@
             <l>la rondinella ai figli, quanto io vado</l>
             <l>da lei. Adunque aiutami, <name>Cupido</name>.</l>
           </sp>
-          <sp>
+          <sp who="#tindaro">
             <speaker>TINDARO.</speaker>
             <l>Chi me biasimarebbe in questo grado</l>
             <l>s'io lo tradise? Veramente alcuno</l>
@@ -712,7 +758,7 @@
             <l>andar pensoso che da lui favella;</l>
             <l>per ascoltarlo il parlar non procedo.</l>
           </sp>
-          <sp>
+          <sp who="#filostrato">
             <speaker>FILOSTRATO.</speaker>
             <l>Come faremo, o mia <name>Panfila</name> bella,</l>
             <l>ch'io venga a te? chi me darà lo specchio</l>
@@ -724,7 +770,7 @@
             <l>secondo che ho qui letto. Or ecco il duolo,</l>
             <l>per non poterli dir quel ch'io vorrei.</l>
           </sp>
-          <sp>
+          <sp who="#tindaro">
             <speaker>TINDARO.</speaker>
             <l>Questo è pur <name>Filostrato</name> che vien solo.</l>
             <l>Egli è? Non è? Sì, è. Lassami gire:</l>
@@ -736,7 +782,7 @@
             <l>fatto qualche atto che non fusse iusto,</l>
             <l>come tal volta fa a un bon servitore ?</l>
           </sp>
-          <sp>
+          <sp who="#filostrato">
             <speaker>FILOSTRATO.</speaker>
             <l><name>Tindaro</name>, el mal mio regna nel gusto;</l>
             <l>né a te lo posso dir, né a uom che viva.</l>
@@ -745,31 +791,31 @@
             <l>tanto lamento che far t'ho sentito?</l>
             <l>La causa non so dir, se ben te odiva.</l>
           </sp>
-          <sp>
+          <sp who="#tindaro">
             <speaker>TINDARO.</speaker>
             <l>Questo serà un ottimo partito</l>
             <l>a dir affanni insieme tra noi du'</l>
             <l>secreti nostri; comencia, io te invito. </l>
           </sp>
-          <sp>
+          <sp who="#filostrato">
             <speaker>FILOSTRATO.</speaker>
             <l>Per fare al tempo onor comencia tu,</l>
             <l>et io te giuro per el dio <name>Poluce</name>,</l>
             <l>che alcun nol saperà. Di' adunque, or su!</l>
           </sp>
-          <sp>
+          <sp who="#tindaro">
             <speaker>TINDARO.</speaker>
             <l>Or guarda a quel che un giovene me adduce</l>
             <l>con giuramento a questo punto extremo!</l>
             <l>pur lo dirò se del tuo averò luce.</l>
           </sp>
-          <sp>
+          <sp who="#filostrato">
             <speaker>FILOSTRATO.</speaker>
             <l>Tu temi a dirlo et io, <name>Tindaro</name>, tremo</l>
             <l>a discoprirti i mei secreti occulti:</l>
             <l>ma giura ora non dir quanto diremo.</l>
           </sp>
-          <sp>
+          <sp who="#tindaro">
             <speaker>TINDARO.</speaker>
             <l>Per lo dio <name>Ercul</name>, de tenirli sculti</l>
             <l>secreti i toi pensier, quanto più grandi;</l>
@@ -787,13 +833,13 @@
             <l>ma danno gli farei male e vergogna,</l>
             <l>né lassarei per vendicarmi ogn'arte.</l>
           </sp>
-          <sp>
+          <sp who="#filostrato">
             <speaker>FILOSTRATO.</speaker>
             <l> Or questo è quel che a me proprio bisogna.</l>
             <l>Tindaro, troppo sei vecchio e maturo;</l>
             <l>gli anni ti fan parlar come chi sogna.</l>
           </sp>
-          <sp>
+          <sp who="#tindaro">
             <speaker>TINDARO.</speaker>
             <l>Filostrato, per <name>Jupiter</name> ti giuro</l>
             <l>che s'io mai vedo el bel, tu el vederai;</l>
@@ -802,7 +848,7 @@
             <l>qual causa sì te tien mesto et afflitto:</l>
             <l>forsi da me qualche rimedio arai.</l>
           </sp>
-          <sp>
+          <sp who="#filostrato">
             <speaker>FILOSTRATO. </speaker>
             <l>Non dunque replichiam quel che abbian ditto</l>
             <l>d'esser secreto. Togli, legi il frutto</l>
@@ -815,7 +861,7 @@
           <argument>
             <p>Epistola de PANFILA a FILOSTRATO.</p>
           </argument>
-          <sp>
+          <sp who="#tindaro">
             <speaker>Tindaro</speaker>
             <l>Tu forsi , <name>Filostrato</name>, admirerai</l>
             <l>di quel che soneranno le parole</l>
@@ -871,7 +917,7 @@
         <div type="scene">
           <head>Scena IV</head>
           <stage>Letta la epistola <name><hi rend="sc">TINDARO</hi></name> dice:</stage>
-          <sp>
+          <sp who="#tindaro">
             <speaker>TINDARO.</speaker>
             <l>Questa è bona novella, o <name>Filostrato</name>;</l>
             <l><name>Amor</name> te aiuta ben, <name>Amor</name> ti chiama;</l>
@@ -956,7 +1002,7 @@
         <div type="scene">
           <head>Scena I</head>
           <stage><name>TINDARO</name> vecchio.</stage>
-          <sp>
+          <sp who="#tindaro">
             <speaker>TINDARO.</speaker>
             <l>Vedi che <name>Amor </name>m'ha mostro il tempo e 'l loco</l>
             <l>e 'l modo a fare ogni vendetta mia;</l>
@@ -999,7 +1045,7 @@
           <stage>
             <hi rend="sc">FILOSTRATO, TINDARO</hi>
           </stage>
-          <sp>
+          <sp who="#filostrato">
             <speaker>FILOSTRATO.</speaker>
             <l>Facil mi fu l'andar, ma il tornar duro;</l>
             <l>la via più aspra, el pericul più grande,</l>
@@ -1032,7 +1078,7 @@
             <l>Egli è pur desso. - <name>Tindaro</name>, salute:</l>
             <l>el ci è novelle infinite da dire.</l>
           </sp>
-          <sp>
+          <sp who="#tindaro">
             <speaker>TINDARO.</speaker>
             <l>Io non vi sono stato, e gli ho vedute</l>
             <l>careze: ché con bocca e mani e tatto</l>
@@ -1044,7 +1090,7 @@
             <l>come debbon gli amici con gli amici</l>
             <l>che han ben del bene, e del mal despiacere.</l>
           </sp>
-          <sp>
+          <sp who="#filostrato">
             <speaker>FILOSTRATO.</speaker>
             <l>Questi tempi son, Tindaro, felici:</l>
             <l>diletti senza guai, una suave</l>
@@ -1069,7 +1115,7 @@
             <l>in questa età so che parte del foco</l>
             <l>se attaccherebbe alla tua vecchia spoglia.</l>
           </sp>
-          <sp>
+          <sp who="#tindaro">
             <speaker>TINDARO.</speaker>
             <l><name>Filostrato</name>, prudente in parlar poco:</l>
             <l>io so apunto quel che esser pò stato,</l>
@@ -1081,7 +1127,7 @@
             <l>Sii pur constante e fa' i consigli mei:</l>
             <l>va' cautamente, e la preda raffronta.</l>
           </sp>
-          <sp>
+          <sp who="#filostrato">
             <speaker>FILOSTRATO.</speaker>
             <l><name>Tindaro</name>, io tornarò dunque da lei.</l>
             <l>Come notte serà, dentro mi trovo;</l>
@@ -1092,7 +1138,7 @@
         <div type="scene">
           <head>Scena III</head>
           <stage><hi rend="sc">TINDARO</hi> solo.</stage>
-          <sp>
+          <sp who="#tindaro">
             <speaker>TINDARO.</speaker>
             <l>Inamorato giovene gagliardo</l>
             <l>costui si vede, e temo ch'el non faccia</l>
@@ -1124,7 +1170,7 @@
         <div type="scene">
           <head>Scena IV</head>
           <stage><name><hi rend="sc">DEMETRIO</hi></name> re, <name><hi rend="sc">PANDERO</hi></name> secretario.</stage>
-          <sp>
+          <sp who="#demetrio">
             <speaker>DEMETRIO.</speaker>
             <l>Quanto più crede l'om esser contento,</l>
             <l>usanza è de <name>Fortuna</name> che gli invola</l>
@@ -1178,7 +1224,7 @@
             <l>sia morto: e viva, qui viverà morta.</l>
             <l>Una vendetta ne punirà dui.</l>
           </sp>
-          <sp>
+          <sp who="#pandero">
             <speaker>PANDERO.</speaker>
             <l>O quante volte a l'occhio il sonno porta</l>
             <l>sogni, che ben che quei siano bugie,</l>
@@ -1190,13 +1236,13 @@
             <l>per questo son venuto e ancor mi pare,</l>
             <l>s'io lo dicesse al re, mi terrìa pazzo.</l>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker>DEMETRIO. </speaker>
             <l>El non è tempo da tempo aspettare.</l>
             <l>Taglian la causa, ché lo effetto cesse;</l>
             <l>ché tosto un mal se vorìa medicare.</l>
           </sp>
-          <sp>
+          <sp who="#pandero">
             <speaker>PANDERO. </speaker>
             <l>Io credo ben che se 'l re lo sapesse</l>
             <l>di questo sogno, ch'el n'averìa spavento;</l>
@@ -1220,7 +1266,7 @@
             <l>Lassami andarli incontro. - Iddio te observi</l>
             <l>a noi, sacro re invitto e glorïoso.</l>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker>DEMETRIO. </speaker>
             <l>Ben vada un servo tra gli altri mei servi</l>
             <l>più iusto, più fidel, più obediente.</l>
@@ -1229,14 +1275,14 @@
             <l>una mala novella serà questa.</l>
             <p>Vien dentro, ch'io la dica ascosamente.</p>
           </sp>
-          <sp>
+          <sp who="#pandero">
             <speaker>PANDARO.</speaker>
             <l>Vedi che 'l sogno mio gli cade in testa.</l>
           </sp>
         </div>
         <div type="scene">
           <head>Scena V</head>
-          <sp>
+          <sp who="#tindaro">
             <speaker>TINDARO.</speaker>
             <l>Valete, amici, e tu, corte, rimanti;</l>
             <l>io fuggo la mia morte e la tua insidia;</l>
@@ -1268,7 +1314,7 @@
         <div type="scene">
           <head>Scena VI</head>
           <stage>Le tre <hi rend="sc">PARCHE</hi>.</stage>
-          <sp>
+          <sp who="#parche">
             <speaker>PARCHE.</speaker>
             <l>Ciascun nasce per morire;</l>
             <l>nasca pur chi nascer vole:</l>
@@ -1326,7 +1372,7 @@
         <div type="scene">
           <head>Scena I</head>
           <stage><name><hi rend="sc">PANDERO,</hi></name><name><hi rend="sc">TINOEO</hi></name> servo.</stage>
-          <sp>
+          <sp who="#pandero">
             <speaker>PANDERO.</speaker>
             <l>El re m'ha detto, tutto d'ira acceso,</l>
             <l>ch'io informi dui più fidi, e che da loro</l>
@@ -1365,31 +1411,31 @@
           <head>Scena II</head>
           <stage><name><hi rend="sc">DEMETRIO</hi></name> re, <name><hi rend="sc">PANDERO</hi>.
 </name></stage>
-          <sp>
+          <sp who="#demetrio">
             <speaker>DEMETRIO.</speaker>
             <l>Pandero, che di' tu del caso rio?</l>
             <l>Va' te poi fida e di servo e di figlia!</l>
             <l>A molti exempio fia l'exempio mio.</l>
           </sp>
-          <sp>
+          <sp who="#pandero">
             <speaker>PANDERO.</speaker>
             <l>El male è grande e mi fo maraviglia</l>
             <l>de lo error che ha <name>Filostrato </name>comesso,</l>
             <l>che parea el più fidel de tua famiglia.</l>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker>DEMETRIO.</speaker>
             <l>Et io non mai pensato arìa lo excesso,</l>
             <l>né de la mia figliola el grave errore,</l>
             <l>se non che con questi occhi el vidi expresso.</l>
           </sp>
-          <sp>
+          <sp who="#pandero">
             <speaker>PANDERO.</speaker>
             <l>Pensa che per costor mi creppa il core,</l>
             <l>sendo gioveni e belli, e tanto oltraggio</l>
             <l>farti, condutti dal foco d'amore.</l>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker>DEMETRIO.</speaker>
             <l>'Nanzi che 'l sole asconda il chiaro raggio</l>
             <l>ne farò tal vendetta che 'l mal loro</l>
@@ -1398,7 +1444,7 @@
             <l>perché gli amava, e sì per mia vergogna</l>
             <l>qual mi toglie l'onor, sì gran tesoro.</l>
           </sp>
-          <sp>
+          <sp who="#pandero">
             <speaker>PANDERO. </speaker>
             <l>Molte fiate, <name>Demetrio</name>, in più menzogna</l>
             <l>casca chi fa di tal cose vendetta:</l>
@@ -1425,7 +1471,7 @@
             <l>fanne quel che ti par, po' che in man l'hai.</l>
             <l>Oh che peccato d'un sì bel garzone!</l>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker>DEMETRIO re.</speaker>
             <l> O <name>Filostrato</name>, io non credetti mai</l>
             <l>che la benignità mia meritato</l>
@@ -1440,13 +1486,13 @@
         </div>
         <div type="scene">
           <head>Scena III</head>
-          <sp>
+          <sp who="#filostrato">
             <speaker>FILOSTRATO. </speaker>
             <l>La mia fral voluntà, l'altrui desio</l>
             <l>son state le cagion, né me ne pento,</l>
             <l>ché <name>Amor</name> pò molto più che tu o io.</l>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker>DEMETRIO re.</speaker>
             <l>Secondo il fallo serà el tuo tormento.</l>
             <l>Pandero, fal menare in parte obscura</l>
@@ -1457,7 +1503,7 @@
         <div type="scene">
           <head>Scena IV</head>
           <stage>Sopragiongendo <name><hi rend="sc">PANFILA</hi></name>, <name><hi rend="sc">DEMETRIO</hi></name> dice:</stage>
-          <sp>
+          <sp who="#demetrio">
             <speaker>DEMETRIO.</speaker>
             <l><name>Panfila,</name> a me cognoscer parse già</l>
             <l>esser in te non pur sola virtù,</l>
@@ -1506,7 +1552,7 @@
             <l>la qual per excusarti mi farai;</l>
             <l>se bona sia, mi farò maraviglia.</l>
           </sp>
-          <sp>
+          <sp who="#panfila">
             <speaker>PANFILA.</speaker>
             <l>A volerti negar, padre, non sono</l>
             <l>disposta mai, essendo a te presente,</l>
@@ -1598,7 +1644,7 @@
             <l>spargile loro e piangi il caso seco;</l>
             <l>ché a noi 'l morir sarà la vita nova</l>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker>DEMETRIO re.</speaker>
             <l>Al re bisogna vecchio esser pietoso</l>
             <l>se non de tutti dai almanco d'uno. </l>
@@ -1620,7 +1666,7 @@
         </div>
         <div type="scene">
           <head>Scena V</head>
-          <sp>
+          <sp who="#atropos #coro">
             <speaker>ATROPOS e 'l CORO.</speaker>
             <l>Ciascun mal sempre è punito,</l>
             <l>e ogni ben remunerato;</l>
@@ -1678,7 +1724,7 @@
         <div type="scene">
           <head>Scena I</head>
           <stage><name><hi rend="sc">PANDERO</hi></name>, <name><hi rend="sc">TINOLO</hi></name> servo.</stage>
-          <sp>
+          <sp who="#pandero">
             <speaker>PANDERO.</speaker>
             <l>O crudele spectaculo empio e duro,</l>
             <l>crudel comandamento, accerba pena,</l>
@@ -1726,7 +1772,7 @@
             <l>Fate pur diligente el vostro offizio</l>
             <l>ché 'l core al re tosto de lui sia porto. </l>
           </sp>
-          <sp>
+          <sp who="#tinolo">
             <speaker>TINOLO. </speaker>
             <l>Non già se aspetta a noi tal maleffizio.</l>
             <l>Ma poi ch'el piace alla testa regale,</l>
@@ -1737,7 +1783,7 @@
         <div type="scene">
           <head>Scena II</head>
           <stage><name><hi rend="sc">PANFILA</hi></name> sola.</stage>
-          <sp>
+          <sp who="#panfila">
             <speaker>PANFILA.</speaker>
             <l>Quel che felice il mondo molto scrive</l>
             <l>no' intende ben quel che la vita importa,</l>
@@ -1778,7 +1824,7 @@
         <div type="scene">
           <head>Scena III</head>
           <stage><name><hi rend="sc">TINOLO</hi></name>, <name><hi rend="sc">DEMETRIO</hi></name>.</stage>
-          <sp>
+          <sp who="#tinolo">
             <speaker>TINOLO.</speaker>
             <l>Ecco, o re, il cor del tuo servo caldissimo,</l>
             <l>qual da per lui con le sue mani avolsessi</l>
@@ -1808,7 +1854,7 @@
             <l>Fagli a tuo modo vaso o tabernacolo,</l>
             <l>poi che sei vendicato d'un tuo emolo.</l>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker>DEMETRIO re. </speaker>
             <l>Andate alla mia figlia senza obstaculo,</l>
             <l>e in questa coppa d'or gli sia portato</l>
@@ -1822,7 +1868,7 @@
         <div type="scene">
           <head>Scena IV</head>
           <stage><name><hi rend="sc">PANFILA</hi></name>, <name><hi rend="sc">TINOLO</hi></name>.</stage>
-          <sp>
+          <sp who="#panfila">
             <speaker>PANFILA.</speaker>
             <l>E pur non fa <name>Filostrato</name> ritorno!</l>
             <l>Quanto anxia è la mia vita, sol pensando</l>
@@ -1858,7 +1904,7 @@
             <l>voglio aspettarli qui, pur che gli servi</l>
             <l>mi portin cosa che mi torni in gioco.</l>
           </sp>
-          <sp>
+          <sp who="#tinolo">
             <speaker>TINOLO.</speaker>
             <l>O Panfila, <name>Diana </name>ti conservi,</l>
             <l>come richiedon gli desider tui.</l>
@@ -1867,7 +1913,7 @@
             <l>figliola sei, ti manda il caro dono</l>
             <l>per consolarti come hai fatto lui.</l>
           </sp>
-          <sp>
+          <sp who="#panfila">
             <speaker>PANFILA.</speaker>
             <l>Non men sepulcro, men ricco e men bono</l>
             <l>si conveniva al cor de <name>Filostrato</name>,</l>
@@ -1887,7 +1933,7 @@
         <div type="scene">
           <head>Scena V</head>
           <stage><name><hi rend="sc">PINZIA</hi></name>, <name><hi rend="sc">TINOLO</hi></name>.</stage>
-          <sp>
+          <sp who="#pinzia">
             <speaker>PINZIA.</speaker>
             <l>Andiam pur via, ch'a me si scoppia il core</l>
             <l>per aver visto del rege la figlia</l>
@@ -1899,7 +1945,7 @@
             <l>fra el riso e il pianto alcun caldo suspire,</l>
             <l>come per gran pietà ciascun far suole.</l>
           </sp>
-          <sp>
+          <sp who="#tinolo">
             <speaker>TINOLO. </speaker>
             <l>O mondo traditor, bello è il venire</l>
             <l>a visitarti, e quando un molto è stato</l>
@@ -1919,7 +1965,7 @@
         </div>
         <div type="scene">
           <head>Scena VI</head>
-          <sp>
+          <sp who="#panfila">
             <speaker>PANFILA.</speaker>
             <l>Ahi dolce albergo d'ogni mio piacere,</l>
             <l>la crudeltate maledetta sia</l>
@@ -1962,7 +2008,7 @@
           <stage>
             <hi rend="sc">UNA DONZELLA.</hi>
           </stage>
-          <sp>
+          <sp who="#donzella">
             <speaker>DONZELLA.</speaker>
             <l>Già son tre sere che l'uccel ferrale</l>
             <l>canta di notte sopra queste mura</l>
@@ -1984,7 +2030,7 @@
         </div>
         <div type="scene">
           <head>Scena VIII</head>
-          <sp>
+          <sp who="#filada">
             <speaker>FILADA.</speaker>
             <l>Se tarda sono stata a te redire,</l>
             <l>dona, <name>Panfila</name>, colpa a un novo caso</l>
@@ -2008,7 +2054,7 @@
             <l>ché le disgrazie non le compra alcuno;</l>
             <l>duolmi s'io non t'ho fatta cosa grata</l>
           </sp>
-          <sp>
+          <sp who="#panfila">
             <speaker>PANFILA.</speaker>
             <l> Filada cara, non in più opportuno</l>
             <l>tempo portar potevi, o meglior sorte,</l>
@@ -2021,13 +2067,13 @@
           <stage>
             <hi rend="sc"><name><hi rend="sc">DEMETRIO</hi></name> re, <name><hi rend="sc">LITIGIA</hi></name>, <name><hi rend="sc">PANFILA</hi></name>.</hi>
           </stage>
-          <sp>
+          <sp who="#demetrio">
             <speaker>DEMETRIO.</speaker>
             <l>Io non ho bene inteso ogni parola.</l>
             <l>Reddi' de nuovo, che non corra fallo:</l>
             <l>e che partito fe' la mia figliola.</l>
           </sp>
-          <sp>
+          <sp who="#litigia">
             <speaker>LITIGIA.</speaker>
             <l>Ella fe' darsi un vaso de cristallo,</l>
             <l>penso che vi era dentro solimato,</l>
@@ -2036,7 +2082,7 @@
             <l>poi missesselo a bocca e in abandono</l>
             <l>la beve, qual fa l'acqua un amalato.</l>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker>DEMETRIO. </speaker>
             <l>Tardo, ahimè! avveduto mi sono</l>
             <l>de la mia crudeltà; fuss'io degiuno</l>
@@ -2066,7 +2112,7 @@
             <l>qual pena, dime, così te importuna?</l>
             <l>Fa' pur bon core e meco ti consiglia.</l>
           </sp>
-          <sp>
+          <sp who="#panfila">
             <speaker>PANFILA. </speaker>
             <l>O padre, a più desiata fortuna</l>
             <l>le tue lacrime serba e 'l tuo lamento,</l>
@@ -2089,7 +2135,7 @@
         <div type="scene">
           <head>Scena X</head>
           <stage>Morta <name><hi rend="sc">PANFILA</hi></name>, et dolendossene il padre, <name><hi rend="sc">PANDERO </hi></name>confortandolo dice:</stage>
-          <sp>
+          <sp who="#pandero">
             <speaker>PANDERO.</speaker>
             <l>Non esser causa, o re, che i giorni toi</l>
             <l>si scemin per dolore, acciò che in breve</l>
@@ -2117,7 +2163,7 @@
             <l>Raffrena el pianto, abbi di te mercede</l>
             <l>e fa' la tua figliola sepelire.</l>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker>DEMETRIO.</speaker>
             <l>Questo caso non è da scordar mai</l>
             <l>per esserne io im prima causa stato</l>
@@ -2139,7 +2185,7 @@
             <l>coi membri tristi lacerati e guasti,</l>
             <l>e con la mia figliola sia sepulto.</l>
           </sp>
-          <sp>
+          <sp who="#pandero">
             <speaker>PANDERO. </speaker>
             <l>Al servo buono el qual ama el signore</l>
             <l>d'ogni ben suo s'alegra, e così suole</l>

--- a/tei/carmignani-polissena.xml
+++ b/tei/carmignani-polissena.xml
@@ -76,6 +76,28 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="pirro">
+            <persName>Pirro</persName>
+          </person>
+          <person xml:id="arsindo">
+            <persName>Arsindo</persName>
+          </person>
+          <person xml:id="calcante">
+            <persName>Calcante</persName>
+          </person>
+          <person xml:id="polidoro">
+            <persName>Polidoro</persName>
+          </person>
+          <person xml:id="polissena">
+            <persName>Polissena</persName>
+          </person>
+          <person xml:id="erope">
+            <persName>Erope</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>2000-02-28T00:00:00.000+02:00</date><name>Patricia Frosini</name><name>CIBIT - Pisa</name>Digitalizzazione</change>
@@ -476,14 +498,14 @@ in un gran dolore, ed in una specie
 d'oppressione. Arsindo è sul proscenio. Pirro
 dopo alquanto di silenzio s'alza confusamente,
 e d'un aria smarrita viene ad Arsindo.</emph></stage>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l> Arsindo, ah! per pietà toglimi a questi </l>
             <l>Luoghi sacri alla morte ove non spira </l>
             <l>Che lutto, che terror, che pianto intorno. </l>
             <pb n="1"/>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l> Come, Signor! già trasgredir vorrai </l>
             <l>Al comando celeste? Egli t'astringe </l>
@@ -515,7 +537,7 @@ e d'un aria smarrita viene ad Arsindo.</emph></stage>
             <l>Mostrar debbesi Achille onde svelarti </l>
             <l>Dello sdegno de' Numi il fran segreto. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l>  Troppo tu speri; a rosseggiar comincia </l>
             <l>Sul Balzo Oriental la bella Aurora. </l>
@@ -528,14 +550,14 @@ estinte le faci in lontano</stage>
             <l>Non brillan più. Spettro infernal non puote </l>
             <l>Del già vicino Sol soffrir la luce. </l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l> Ebben? forse non può del tuo gran Padre </l>
             <l>Fatta già Semi-Dio l'anima augusta </l>
             <l>Cinta di gloria a te mostrarsi in mezzo </l>
             <l>Allor splendor del più brillante giorno? </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l> Tutto è ver: Ma chi sa, che il sacro cenno, </l>
             <l>Che quì m'astringe ad ingannar non tenda </l>
@@ -546,13 +568,13 @@ estinte le faci in lontano</stage>
             <l>Calcante lo protegge … Ei seco forse </l>
             <l>Sì reo pretesto onde ingannarmi a preso.</l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l> Come! … Calcante! … un Sacerdote? Ah, taci: </l>
             <l>Un Ministro de' Numi in lui rispetta: </l>
             <l>Non offender così chi lor somiglia. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l> Infallibile dunque esser tu credi <note><foreign xml:lang="lat"><emph>Cet organe des Dieux est il donc infallible? Un ministére saint les attache aux autels: Ils approchement des Dieux, mais ils sont des mortels</emph>. <abbr>Oedip.</abbr> Tra<abbr>g.</abbr> </foreign></note></l>
             <l>Quest'organo del Cielo? Un sacro rito </l>
@@ -566,45 +588,45 @@ estinte le faci in lontano</stage>
             <l>Amico, io non ho pace … al Campo andiamo: </l>
             <l part="I">Tutto mi fa tremar. </l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l part="F"> Ma qual ti punge </l>
             <l part="I">Cura sì grave? … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="M"> Ah! Polissena … </l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l part="F"> E tanto </l>
             <l>La schiava tua fra' tuoi pensieri a loco? </l>
             <l part="I">Tanto degna ti sembra … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F"> Olà: che parli? </l>
             <l>Questa schiava rispetta. A lei si debbe </l>
             <l>Qualunque omaggio, e benché vinta il collo </l>
             <l>Pieghi al giogo d'un Greco, ella è Regina.</l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l> Signore perdona al zelo mio … tant'ira, </l>
             <l>Un sì acerbo parlar … di Polissena </l>
             <l>Al nome sol tu di color cangiasti </l>
             <l part="I">Forse … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="M"> Che dir vorrai? </l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l part="F"> Forse il tuo cuore </l>
             <l part="I">Vinto da lei … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F"> Sì: mio fedele, io l'amo. </l>
             <l>Tacer nol posso … Il primo sei, che aperto </l>
@@ -614,15 +636,15 @@ estinte le faci in lontano</stage>
             <l>Io tutto avvampo, e i lunghieri incanti </l>
             <l>Di Polissena idolatrar m'è duopo. </l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l part="I"> Oh, Ciel! </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="M"> Stupisci?  </l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l part="F"> E chi stupir non debbe! </l>
             <l>Tu di Priamo uccisor, tu il più crudele </l>
@@ -631,7 +653,7 @@ estinte le faci in lontano</stage>
             <pb n="4"/>
             <l>Scusami, non credei d'Achille un figlio </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l> Ah! sol fugge l'amor chi non ha cuore! </l>
             <l>Amico, fu nella terribil notte, </l>
@@ -694,7 +716,7 @@ estinte le faci in lontano</stage>
             <l>Contro ogni voglia mia varcar fu forza </l>
             <l>Dallo sdegno all'amor il breve passo. </l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l> Deh! reprimi, Signor, se pur ti cale </l>
             <l>Dell'onor tuo, della tua gloria, in seno </l>
@@ -706,7 +728,7 @@ estinte le faci in lontano</stage>
             <l>Ond'è sospinto il giovanil tuo cuore </l>
             <l>Frena ora che il puoi; vince l'amor chi 'l fugge.</l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l> Non sperar, ch'io t'ascolti; Il Ciel in pria </l>
             <l>L'invido Ciel sulla mia testa irato </l>
@@ -721,11 +743,11 @@ estinte le faci in lontano</stage>
             <l>Ma … mostrar gli potrei come far suole </l>
             <l>La sue vendette un disperato amante. </l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l part="I"> Dunque, Signor … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F"> Cedi al mio cenno, e parti.</l>
           </sp>
@@ -733,7 +755,7 @@ estinte le faci in lontano</stage>
         </div>
         <div type="scene">
           <head>SCENA II </head>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l> Posso solo una volta appien disciorre </l>
             <l part="I">Libero il freno alle mie pene, o Dei! </l>
@@ -806,19 +828,19 @@ Della gloria le vie calcasti, ardito? </l>
           <stage rend="italic">Cessa il fragore, e vedesi il gran Sacerdote Calcante
 venire a passo lento; Pirro l'osserva;
 S'alza, e dice:</stage>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="I"> Calcante </l>
             <stage rend="italic">(andandoli incontro)</stage>
             <l part="M">quai prodigj!</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="F"> Il Ciel t'elegge </l>
             <l>Per suo vendicator; seconda, o figlio, </l>
             <l>Col voler tuo la volontà de' Numi. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l> Ma qual'è mai la minacciata testa, </l>
             <l>Che vuol recisa al suo furor l'Olimpo? </l>
@@ -828,7 +850,7 @@ S'alza, e dice:</stage>
             <l>Molcer debbe lo sdegno, onde propizia </l>
             <l>Spinga l'aura bramata i Greci legni. </l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l> Frena il malcauto ardor. Spesso si rende </l>
             <l>Del favore de' Numi un cuore indegno </l>
@@ -838,7 +860,7 @@ S'alza, e dice:</stage>
             <l>Alla grand'opra … Ella costar ti debbe. </l>
             <pb n="9"/>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l> Ah! ciò, Signor, ch'ho di più sacro al Mondo </l>
             <l>Ceder pronto agli Dei dolce mi fia, </l>
@@ -854,16 +876,16 @@ S'alza, e dice:</stage>
             <l>Mesto un grido feral da quella tomba. </l>
             <l part="I">Che mai sarà! …</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="F"> Del Padre tuo la voce, </l>
             <l>Figlio, sortir da questi marmi udisti.</l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="I"> E che brama da me?</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="F"> Chiede vendetta.</l>
             <l>Sai, che per man del rapitore infame, </l>
@@ -872,11 +894,11 @@ S'alza, e dice:</stage>
             <l>A sì valido Eroe tolse la vita.</l>
             <l part="I">Ei tradito spirò. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F"> Ciel! che mi narri! </l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l> Quest'orribil segreto, è ver, coperse </l>
             <l>Con le tenebre sue finor l'oblìo; </l>
@@ -891,29 +913,29 @@ S'alza, e dice:</stage>
 L'indegno acciar, che penetrò le vie </l>
             <l>Del cuore augusto al Padre tuo tradito. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l> Stelle! … che sento … in rimirar quel ferro </l>
             <l>Tutte m'arde le fibre un fuoco ignoto. </l>
             <l part="I">Porgi … </l>
             <stage rend="italic">volendo impaziente il pugnale</stage>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="F"> Ascoltami in pria. Giurar tu devi </l>
             <l>Su quest'acciaro a tutti i Numi in faccia </l>
             <l>Di vendicar del Padre tuo la morte.</l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l> Che? … dubitar della mia fe potresti? </l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l> No; ma voglion gli Dei, che all'opra astringa </l>
             <l>La tua virtude indissolubil nodo.</l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="I"> Ebben … </l>
             <stage rend="italic">(risoluto)</stage>
@@ -929,7 +951,7 @@ L'indegno acciar, che penetrò le vie </l>
             <stage rend="italic">(alto)</stage>
             <l part="F">pur sento …</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l> Eh! l'Uomo estingui, e in te l'Eroe ravviva. </l>
             <l>Forse di contentar l'ombra sdegnata </l>
@@ -937,7 +959,7 @@ L'indegno acciar, che penetrò le vie </l>
             <stage rend="italic">(vanno alla tomba)</stage>
             <l part="I">Vieni. Eseguisci il giuramento. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F"> Quale, </l>
             <l>Qual mai terrore ad esitar m'induce! </l>
@@ -945,19 +967,19 @@ L'indegno acciar, che penetrò le vie </l>
             <l part="I">Si giuri. </l>
             <stage rend="italic">alto</stage>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="M"> Ecco l'acciar.  </l>
           </sp>
           <stage rend="italic">Pirro prende il ferro</stage>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F"> Macchiar prometto </l>
             <l>Questo perfido ferro entro le vene </l>
             <l>A quei, che il Ciel per olocausto elegge … </l>
             <l>E su quest'urna a tutti i Numi giuro. </l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l> Degno figlio d'Achille! Il tuo deponi </l>
             <l>Innocente pugnale, e quello stringi. </l>
@@ -977,21 +999,21 @@ L'indegno acciar, che penetrò le vie </l>
             <l>E folle è ben quei, che di troppo altero </l>
             <l>Arbitro de' suoi voti il Ciel non brama.</l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l> Tutto farò … la vittima infelice, </l>
             <l>Che il Cielo elegge a massacrar m'accingo, </l>
             <l>È già pronto il mio cuor - pur sulla scelta </l>
             <l>Tremo, Signor … </l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l> Trema, ma sul delitto. </l>
             <l>Non paventar. Lascia, che il Ciel tu guidi </l>
             <l>Al sacrifizio, e ch'ei ti regga il braccio. </l>
             <l part="I">S'appressa alcuno … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F"> Arsindo! che mai reca! </l>
           </sp>
@@ -999,7 +1021,7 @@ L'indegno acciar, che penetrò le vie </l>
         <div type="scene">
           <head>SCENA IV </head>
           <stage>Calcante, Pirro, Arsindo frettoloso. </stage>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l part="I"> Corri, Signor. </l>
             <stage rend="italic">(a Pirro)</stage>
@@ -1019,7 +1041,7 @@ Si minaccia Calcante, e te con lui. </l>
             <l>Vola la Plebe alle tue tende, e i gridi </l>
             <l>Del Popol folle han preceduto il giorno. </l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l>  Al riparo si corra - Empj! a quel segno </l>
             <l>Giunger non puote un temerario ardire? </l>
@@ -1030,7 +1052,7 @@ Si minaccia Calcante, e te con lui. </l>
             <l>Già gl'Atridi conosco, e i lor disegni … </l>
             <l part="I">Ma … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F">  Ti calma, ch'io pronto a tanto sdegno </l>
             <l>Volo ad impor qualche riparo almeno. </l>
@@ -1044,19 +1066,19 @@ Si minaccia Calcante, e te con lui. </l>
         <div type="scene">
           <head>SCENA V </head>
           <stage rend="italic">Calcante, Arsindo.</stage>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l part="I">  Da quell'ira che speri? </l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="F">  Ogni soccorso.</l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l part="I">  Ma il suo fatal amor … </l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="F">  Soffri, che tutta </l>
             <l><pb n="13"/>
@@ -1066,11 +1088,11 @@ Spero sanar di quel gran cuor la piaga. </l>
             <l>Polissena è la vittima …  il suo sangue </l>
             <l>L'Oracolo richiede; Ei sarà sparso. </l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l part="I">  Ah! di Pirro pavento.  </l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="F">  Anch'io conosco, </l>
             <l>E con dolor, se confessar il deggio, </l>
@@ -1091,14 +1113,14 @@ Spero sanar di quel gran cuor la piaga. </l>
             <l>Vola al suo fianco, e di sedar procura </l>
             <l>Insiem con lui la sollevata Plebe. </l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l>  M'è legge il cenno. Ad ubbidirti io corro. </l>
           </sp>
         </div>
         <div type="scene">
           <head>SCENA VI </head>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l> Voi, che il cuor mi vedete, amici Numi, </l>
             <l>Deh! secondate il mio desir. Ritorni </l>
@@ -1121,7 +1143,7 @@ Alle vie di virtù quel cuor sedotto, </l>
           <head>SCENA I </head>
           <pb n="15"/>
           <stage>Polidoro entra smarrito. </stage>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l> Stelle! ove son! … dove le piante aggiro </l>
             <l>Vil rifiuto dell'onde in questi lidi! </l>
@@ -1173,18 +1195,18 @@ D'ossa insepolte, e di recisi teschj </l>
 Polissena mostra essere in grande agitazione; dopo
 aver fatti alcuni passi le mancan le forze;
 s'appogga ad Erope dicendo:</stage>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="I">  Sostienmi, amica … </l>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <l part="F"> I spirti tuoi ravviva; </l>
             <l>Sorgi: Non vacillar; Del Ciel irato </l>
             <l>Con me t'attingi a sopportar lo sdegno.</l>
           </sp>
           <stage rend="italic">la conduce sul Proscenio</stage>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l>  Ove mai mi conduci? - Ah! m'abbandona </l>
             <l>Erope, al duol, che mi soverchia il seno </l>
@@ -1199,7 +1221,7 @@ Che ogni pace ritolse ai sensi miei … </l>
             <l>Ditemi almen se questi orrendi spettri </l>
             <l>Son del vostro furor gl'infausti annunzj! </l>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <l> Fremer mi fai. -Da quai tartaree larce </l>
             <l>Spaventata tuttor veder ti deggio! </l>
@@ -1211,7 +1233,7 @@ Che ogni pace ritolse ai sensi miei … </l>
             <l>Perché, da un tetro orror colpita ognora, </l>
             <l>Offusca i lumi tuoi nube di pianto? </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l>  E tu … Amica tu stessa in questo stato </l>
             <l>Del pianto mio chieder mi puoi ragione! </l>
@@ -1229,7 +1251,7 @@ Che ogni pace ritolse ai sensi miei … </l>
             <l part="I">O Numi! … </l>
             <stage>piange</stage>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <l> A che tuttor de' nostri mali </l>
             <l>Rinnovellar la rimembranza amara? </l>
@@ -1245,7 +1267,7 @@ Ma perché mai rimproverarne i Numi! </l>
             <l>Questa loro bontà mal corrisposta </l>
             <l>De' pianti tuoi non si ritrovi offesa. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l>  Ah! chi pianger dovrà, se creder puoi </l>
             <l>Tu stessa, Amica, in me delitto il pianto! </l>
@@ -1274,25 +1296,25 @@ Ma perché mai rimproverarne i Numi! </l>
             <stage>alto con vivacità s'alza</stage>
             <l part="F">Tutto ho perduto. </l>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <l> Che? tu non conti più sul tuo Germano, </l>
             <l>Su Polidoro? ed obliar potesti </l>
             <l>Questo raggio di speme ancor non spento? </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l>  Vana speranza! - la sua morte è certa; </l>
             <l>E un sogno ancora agli occhi miei presente … </l>
             <pb n="19"/>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <l> Sulla mal certa fe perché turbarti </l>
             <l>D'una larva notturna? Una Germana? </l>
             <l>Del grande Ettore dovrà temer d'un sogno? </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l> Volesse il Ciel, che invan tremassi! Ha sempre </l>
             <l>Tutto a temer degl'infelici il cuore. </l>
@@ -1308,14 +1330,14 @@ Ma perché mai rimproverarne i Numi! </l>
             <l>Che il Figlio suo della sua Patria un giorno </l>
             <l>Lo sventurato distruttor sarebbe. </l>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <l> Qual fantasma in quest'oggi, o qual sinistro </l>
             <l>Crudel presagio inorridir ti fece? </l>
             <l>Di narrarmelo ardisci; Il cuor solleva, </l>
             <l>Il racconto d'un mal ben spesso il tempra. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l> Qual orror! - qual spavento! - Io sola errava </l>
             <l>In questi a morte sacri orrendi asili, </l>
@@ -1362,7 +1384,7 @@ Mille fra lor distinte ombre di morte, </l>
             <l>Fremé coi lampi, e mormorò l'Averno. </l>
             <pb n="21"/>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <l> Principessa, dal sen discaccia omai </l>
             <l>Questi torbidi oggetti, e alfin riprendi </l>
@@ -1382,7 +1404,7 @@ Mille fra lor distinte ombre di morte, </l>
         <div type="scene">
           <head>SCENA III </head>
           <stage>Polissena, indi Polidoro.</stage>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l> Nemico Ciel! che più sperar degg'io? </l>
             <l>L'unico mio conforto, il solo appoggio </l>
@@ -1393,7 +1415,7 @@ Mille fra lor distinte ombre di morte, </l>
             <l>Uno Stranier! - Numi … in mirarlo solo </l>
             <l>Straziar mi sento in mille parti il cuore. </l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l part="I"> Fingiam. </l>
             <stage>(a parte, indi alto)</stage>
@@ -1407,31 +1429,31 @@ Mille fra lor distinte ombre di morte, </l>
             <l><pb n="22"/>
 Di', qual lido è mai questo, e quì chi regna? </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="I">Qual dolce suon … </l>
             <stage>(tutto a parte)</stage>
             <l part="F">qual voce … Il sangue mio </l>
             <l>Agitato entro il sen posa non trova. </l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l part="I"> Come! …  e vorrai … </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F"> Nel rimirarti io sento, </l>
             <l>Giovine sventurato, il cuor commosso. </l>
             <l part="I">Sappi … </l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l part="F"> Ti calma; Un grato cuor compiange </l>
             <l>A fronte dell'altrui le sue sventure: </l>
             <l>Moti son di pietà quei, che provasti. </l>
             <l part="I">Ma dimmi: ove siam noi? </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F"> Quelle, che vedi </l>
             <l>Giacer colà rovine ancor fumanti </l>
@@ -1440,24 +1462,24 @@ Di', qual lido è mai questo, e quì chi regna? </l>
             <l>Queste a sinistra man le Tende sono </l>
             <l>De' Distruttori suoi … dell'Armi Greche. </l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l> Donna, che ascolto! … o dolorosa vista! </l>
             <l>Quell'è l'alta Ilion - quelle mura </l>
             <l>De' Pergami superbi? - Ah! tutto in duolo </l>
             <l>A sì truce veduta il cuor si strugge. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l> Stranier, tu il primo sei, cui sparger vedo </l>
             <l>Lacrime di dolor sulla mia Patria. </l>
             <l part="I">Forse … </l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l part="M"> E Priamo che fa? </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F"> Stranier, che dici? </l>
             <l>Ah! … Priamo! … oh! rimembranza! e tu che sai </l>
@@ -1465,7 +1487,7 @@ Di', qual lido è mai questo, e quì chi regna? </l>
             <l part="I">Ch'ei spirò … ch'ei lasciommi … </l>
           </sp>
           <stage>piange</stage>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <stage rend="italic">a parte</stage>
             <l part="F">Oh! colpo atroce! </l>
@@ -1478,7 +1500,7 @@ Di', qual lido è mai questo, e quì chi regna? </l>
             <l part="F">Io manco. </l>
             <stage>s'appoggia ad un alb.</stage>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="I"> Stranier! </l>
             <stage>(sorpresa)</stage>
@@ -1487,45 +1509,45 @@ Di', qual lido è mai questo, e quì chi regna? </l>
             <l part="I">Il mio German … respira ancor? </l>
             <stage>con impazien.</stage>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l> Sì, vive. </l>
             <l part="I">Ma, oh Dei! … </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F"> Che? - tu il conosci? - ei vive ancora! </l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l> Sì - Ma sol per finir le sue sventure. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l>  Parla … Dov'è? - le pene mie compisci … </l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l part="I"> Come! - ignorar tu puoi … </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F"> Pianger ti vedo … </l>
             <l>Ah! chiunque tu sei parla, o m'uccidi. </l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l> I miei singulti …  il pianto mio … non fanno </l>
             <l part="I">Che scuoprirmi pur troppo.</l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F"> Qual sospetto </l>
             <l>Nell'afflitto mio sen nasce improvviso! </l>
             <l>Il suo volto … i suoi tratti … un grido interno … </l>
             <l part="I">Possibil sia! - Stranier ti svela … </l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <stage>
               <add>si getta fra le di lei braccia</add>
@@ -1533,26 +1555,26 @@ Di', qual lido è mai questo, e quì chi regna? </l>
             <l part="F">Ebbene, </l>
             <l>A questo pianto il tuo German conosci. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="I"> Mio German … </l>
             <stage>l'abbraccia con trasporto piangendo</stage>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l part="M"> Polissena … </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F"> Oh! lieto giorno … </l>
             <l>Oh! contentezza! - In abbracciarti … io sento </l>
             <l>L'anima errar su' labbri miei tremanti. </l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l part="I"> Stelle! qul ti ritrovo! … </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F"> Il Ciel mi rende </l>
             <l>Tutto ciò che perdei, caro, in te solo. </l>
@@ -1561,11 +1583,11 @@ Di', qual lido è mai questo, e quì chi regna? </l>
             <l>Libero alfin mi t'hanno reso in braccio. </l>
             <pb n="24"/>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l part="I"> Ma fra tanti Nemici … </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F"> Il ciglio astergi. </l>
             <l>Ti consola; tu sei per anco ignoto. </l>
@@ -1573,7 +1595,7 @@ Di', qual lido è mai questo, e quì chi regna? </l>
             <l>Fai però ch'io sappi qual sorte amica </l>
             <l>Te dalla Tracia in questi Lidi ha spinto. </l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l> Sai, che me pargoletto ancor mal fermo </l>
             <l>E insiem con me tesori immensi un giorno </l>
@@ -1612,7 +1634,7 @@ Che a morte m'involò non saprei dirti, </l>
             <l>E stanche alfin di tormentarmi l'onde </l>
             <l>Mi gettai semivivo in questi scogli. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l> Lode agli Dei! - Da quel fatal periglio </l>
             <l>Scampato omai stringer ti posso al seno! </l>
@@ -1630,18 +1652,18 @@ Che a morte m'involò non saprei dirti, </l>
             <l part="F">se mai Pirro fosse … </l>
             <l part="I">Se i suoi  cupi sospetti … ah! va … </l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l part="F"> Non deggio </l>
             <l>Te abbandonar … fra le tue braccia almeno </l>
             <l part="I">Bramo … </l>
             <stage>vuol por mano al pugnale</stage>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="M"> Crudel, vuoi la mia morte? </l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <stage>partendo alla parte opposta alle Tende Greche</stage>
             <l part="F">Io cedo.</l>
@@ -1655,12 +1677,12 @@ Egli è già entrato qualche momento avanti, ed
 ha fissato gl'occhi attentamente sopra Polidoro.
 S'è alquanto turbato, ma rassicurandosi si
 calma, ed inoltrato dice alle Guardie.</stage>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l> Voi quì pronti attendete ogni mio cenno.</l>
             <stage>le Guardie si dispongono nel fondo del Teatro</stage>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="I"> Che mai vorrà? </l>
             <stage>a parte mentre Pirro
@@ -1668,16 +1690,16 @@ s'avanza lentamente sul Proscenio sempre
 guardando dov'è partito Polidoro</stage>
             <l part="F">forse ha scoperto … io tremo.</l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="I"> Polissena.</l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="M"> Signor … </l>
             <stage>con timore</stage>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F"> Conosco omai </l>
             <l>Quanto mal si conviene alla sua destra </l>
@@ -1685,7 +1707,7 @@ guardando dov'è partito Polidoro</stage>
             <l>E mi rendono i Numi assai felice </l>
             <l>Onde pronto involarti a tal rossore.</l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="I"> Respiro … </l>
             <stage>(a parte, indi alto)</stage>
@@ -1693,7 +1715,7 @@ guardando dov'è partito Polidoro</stage>
             <l part="M">Signor … lascia, ch'a' piedi … </l>
             <stage>vuol <abbr>inginocch.</abbr></stage>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="I"> Sorgi. Che fai? … </l>
             <stage>sollevandola</stage>
@@ -1703,12 +1725,12 @@ guardando dov'è partito Polidoro</stage>
             <l part="I">Che ciascun si ritiri. </l>
             <stage>le Guardie partono</stage>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <stage>a parte</stage>
             <l part="F">O amabil cuore!</l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l> Principessa, se il ciel maggior m'aprisse </l>
             <l>Strada ond'esserti grato, in favor tuo </l>
@@ -1735,7 +1757,7 @@ Godrei di tributar la vita istessa, </l>
             <l>Di me stesso più ancor libera assai. </l>
             <stage>con passione</stage>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l> Modera del tuo cuor tanta bontade, </l>
             <l>Di cui m'opprime il generoso eccesso. </l>
@@ -1744,7 +1766,7 @@ Godrei di tributar la vita istessa, </l>
             <l>Quest'alma assoggettar più che non pensi </l>
             <l>A quel giogo fatal, da cui mi sciogli. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l> </l>
             <stage>con amarezza</stage>
@@ -1752,11 +1774,11 @@ Godrei di tributar la vita istessa, </l>
             <l>Grato a te dimostrarsi, e se nol sai, </l>
             <l>Le tue bellezze il maggior Duce adora. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="I"> Chi? … me, Signor … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F"> Tutto scopersi. Invano </l>
             <l><pb n="28"/>
@@ -1787,7 +1809,7 @@ Agamennone tenta agl'occhi miei, </l>
             <l>Al par del cuor schiava non sia ridotta </l>
             <l>D'un amante non già, ma d'un Tiranno. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l> Soprafatta, Signor, da ciò che ascolto </l>
             <l>Temo a ragion, che non m'inganni un sogno. </l>
@@ -1802,7 +1824,7 @@ Tu in mio favor voler piegar te stesso? </l>
             <l>Non bastava per me l'esser tu privo </l>
             <l part="I">Di quel rancor … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F"> Io, Principessa, odiarti? </l>
             <l>Con qualunque color la mia fierezza </l>
@@ -1815,11 +1837,11 @@ Tu in mio favor voler piegar te stesso? </l>
             <l>Resister solo al seduttor incanto … </l>
             <stage>con traspor.</stage>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="I"> Come! … Signor … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F"> Dissimular non giova; </l>
             <l>Già troppo avanti l'amor mio mi spinse: </l>
@@ -1870,7 +1892,7 @@ La mia fierezza un sol momento a vinta, </l>
             <l>Per te già concepito, e che nascoso </l>
             <l>Senza di te forse tuttor saria. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l> Ah! di troppo, Signore, il mio destino </l>
             <l>Questo tuo fioco onora, e troppo indegna </l>
@@ -1895,11 +1917,11 @@ Mi vogliono gli Dei de' tuoi pensieri. </l>
             <l>Tutto distrusse, e suo malgrado il suolo </l>
             <l>De' Nepoti di Teucro il sangue bevve. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="I"> Ah! furor ch'io detesto! </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F"> E poi qual speme, </l>
             <l>Signor, fomenti? Il Greco Campo intiero </l>
@@ -1921,7 +1943,7 @@ Che sol si pasce d'amarezza, e pianto</l>
             <l>Che piangere il mio Fato, e sulla Tomba </l>
             <l>Sparger mesta de' miei lacrime amare.</l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l> Tutto creder mi giova, ed il tuo pianto </l>
             <l>Delle sventure tue figlio esser debbe. </l>
@@ -1929,7 +1951,7 @@ Che sol si pasce d'amarezza, e pianto</l>
             <l>Un sospetto, che assai forse t'offende … </l>
             <l part="I">Se mai per Agamennone. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F"> Che dici? </l>
             <l>Agamennone! - o Dei! - Prence, che ascolto! </l>
@@ -1945,7 +1967,7 @@ Che sol si pasce d'amarezza, e pianto</l>
             <l>Avrei potuto, e con lui tale offesa … </l>
             <l>Ma tu, Signor … ma tu così mi tratti? </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l> Principessa, perdona ad un amante, </l>
             <l>Che nell'amor si perde, e che egli stesso </l>
@@ -1954,7 +1976,7 @@ Che sol si pasce d'amarezza, e pianto</l>
             <l>Eppur non osa vendicarsi - Il cuore </l>
             <l part="I">Sospettoso però … </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F"> Signor, tu cerchi </l>
             <l>A tormentarti - Ah! deploriam piuttosto </l>
@@ -1962,12 +1984,12 @@ Che sol si pasce d'amarezza, e pianto</l>
 Amendue, caro Prence, i nostri affanni … </l>
             <stage>con trasporto</stage>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l> Che? … Principessa … ed io sperar potrei! … </l>
             <l part="I">Deh! parla almen … </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F"> Troppo ti dissi - Il labbro </l>
             <l part="I">Ad onta mia … </l>
@@ -1981,13 +2003,13 @@ Amendue, caro Prence, i nostri affanni … </l>
             <l part="I">Fuggimi … </l>
             <stage>con forza</stage>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F"> O Ciel! - Dunque così m'aborri, </l>
             <l>Che odiosa t'è la mia presenza istessa? </l>
             <l part="I">Crudele! … </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="M"> E creder puoi! … </l>
             <stage>(con vivacità)</stage>
@@ -1996,28 +2018,28 @@ Amendue, caro Prence, i nostri affanni … </l>
             <stage>(con trasporto)</stage>
             <l part="M">Ah! Prence … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F"> Ingrata </l>
             <l>Almen compisci, o mi dividi il cuore. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="I"> A che giova, Signor … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="M"> Parla … </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="M"> Non deggio. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F"> Barbara! … </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="I"> Taci …  se il mio cuor vedessi! … </l>
             <stage>con tenerezza</stage>
@@ -2025,7 +2047,7 @@ Amendue, caro Prence, i nostri affanni … </l>
             <stage>(riprendendosi)</stage>
             <l part="I">lasciami in pace … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l>  </l>
             <stage>risoluto</stage>
@@ -2033,7 +2055,7 @@ Amendue, caro Prence, i nostri affanni … </l>
             <l>Finché non sia il mio destin deciso </l>
             <l part="I">Ad onta tua … </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F"> Ma qual piacer spietato </l>
             <l><pb n="34"/>
@@ -2048,7 +2070,7 @@ Amendue, caro Prence, i nostri affanni … </l>
             <l part="I">Che dissi! … </l>
             <stage>a parte</stage>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F">  Ah! Polissena! - Ah! qual contento</l>
             <l>Tutto il seno m'inonda, e il cuor m'opprime!</l>
@@ -2057,7 +2079,7 @@ Amendue, caro Prence, i nostri affanni … </l>
             <l>E un torrente di fuoco in faccia tua </l>
             <l>Lungi da me la mia anima trasporta.</l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="I">  Fuggi … Signor … </l>
             <stage>(con tristezza).</stage>
@@ -2065,7 +2087,7 @@ Amendue, caro Prence, i nostri affanni … </l>
             <l>Dolor funesto, e non voler, ten prego, </l>
             <l part="I">Prence, esultar del tuo trionfo. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F"> Io parto, </l>
             <l>Io m'involo, Idol mio, ma per dar calma </l>
@@ -2073,11 +2095,11 @@ Amendue, caro Prence, i nostri affanni … </l>
             <l>Dolcemente turbaro i detti tuoi. </l>
             <l>Addio … ma di', sarà poi ver … </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l> Che temi? </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l> Se ingannato da te … ma no - perdona: </l>
             <l>È d'inganno incapace un sì bel labbro.</l>
@@ -2086,7 +2108,7 @@ Amendue, caro Prence, i nostri affanni … </l>
         </div>
         <div type="scene">
           <head> SCENA V </head>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l> Vincesti, empio, vincesti - Ah! se celata </l>
             <l>Avessi almen la debolezza mia </l>
@@ -2109,7 +2131,7 @@ Un conforto di più trovar potrei </l>
           <head> SCENA I </head>
           <pb n="36"/>
           <stage>Calcante, Arsindo.</stage>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l>  Tutto è in calma, Signor; l'intiero Campo </l>
             <l>Pirro sedò: Tace l'orribil grido </l>
@@ -2120,11 +2142,11 @@ Un conforto di più trovar potrei </l>
             <l>Frenar non può quella continua guerra, </l>
             <l>Che la mente gli turba, e il cuor gl'opprime.</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="I"> Che mi racconti! </l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l part="F"> Il ver ti narro; È giunto </l>
             <l>A tal segno l'ardor nel sen di Pirro, </l>
@@ -2135,7 +2157,7 @@ Un conforto di più trovar potrei </l>
             <l>Ei troppo avvampa, e la ragione in lui </l>
             <l>Da una forza maggior vinta già langue. </l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l> Gioventù sconsigliata! a quai tempeste </l>
             <l>Sempre in braccio non è dell'uom la vita! </l>
@@ -2146,12 +2168,12 @@ Un conforto di più trovar potrei </l>
             <l>Ad altre vie: D'arte v'ha d'uopo e spero </l>
             <l>Con l'istesse armi sue vincer quel petto. </l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l part="I"> E per qual via? </l>
             <pb n="37"/>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="F"> Molto non ha che in questi </l>
             <l>Del nemico Sigèo barbari scogli </l>
@@ -2164,11 +2186,11 @@ Un conforto di più trovar potrei </l>
             <l>Che con Ecuba, e Lei sparger si vede </l>
             <l>Trojano il fanno, e tale io stesso il credo. </l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l part="I"> Ebben? </l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="F"> Costui con Polissena è spesso: </l>
             <l>Ella il compiange, e amendue dan sfogo </l>
@@ -2182,14 +2204,14 @@ Un conforto di più trovar potrei </l>
             <l>E alle sue smanie in preda a un punto solo </l>
             <l>Sullo Stranier truciderà la Schiava. </l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l> Qual Nume t'inspirò - miglior non vedo </l>
             <l>Artificio onde trar da ceppi suoi </l>
             <l>D'Achille il Figlio. Io stesso a portar vado </l>
             <l>Tutte in quel cuor di gelosia le fiamme. </l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l> Arte adopra, e coraggio. O te felice! </l>
             <l>Se alle vie dell'Olimpo, ed alla Gloria </l>
@@ -2204,23 +2226,23 @@ Un conforto di più trovar potrei </l>
           <head>SCENA II </head>
           <pb n="38"/>
           <stage>Pirro, Arsindo.</stage>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l part="I">  Ei di me viene in traccia. </l>
           </sp>
           <stage>a parte</stage>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F"> Amico, il Fato </l>
             <l>Alle ricerche mie pronto ti rende; </l>
             <l part="I">Uopo mi fa dell'opra tua. </l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l part="F"> M'è legge </l>
             <l part="I">Ogni tuo cenno. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l> In queste Rive è giunto </l>
             <l>Un naufrago Stranier; Molto ei mi sembra </l>
@@ -2234,14 +2256,14 @@ Un conforto di più trovar potrei </l>
             <l>Qual'è la Patria sua, qual cura alfine </l>
             <l>Tanto diletto a Polissena il renda. </l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l> Ma, Signor, la tua gloria, ed il tuo grado </l>
             <l>Far ti denno obliar quel cieco affetto, </l>
             <l>Che ad una Schiava tua servo può farti. </l>
             <l part="I">Se costei … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F"> Per pietà risparmia, amico, </l>
             <l>Una smania novella a questo cuore. </l>
@@ -2250,19 +2272,19 @@ Un conforto di più trovar potrei </l>
             <l>Pensar soltanto a rilasciar colei, </l>
             <l>Che ad onta di me stesso amar m'è forza. </l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l part="I"> Ma una nemica … </l>
           </sp>
           <pb n="39"/>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <stage>sdegnato</stage>
             <l part="F">Or se tu vuoi, ch'io porga </l>
             <l>Orecchi a detti tuoi con me rispetta </l>
             <l part="I">Polissena. </l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l part="F">  Signor, ceder m'è duopo </l>
             <l>Quando tu il vuoi; Solo a donar m'avanzo </l>
@@ -2302,7 +2324,7 @@ Chi t'invola a un velen? Chi t'assicura </l>
             <l>Per te favellerà? - Tanto disprezzo </l>
             <l>Tanto orror, che costei … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l>  Dell'odio suo </l>
             <l>Lasciami dubitare un sol momento, </l>
@@ -2313,14 +2335,14 @@ Chi t'invola a un velen? Chi t'assicura </l>
             <l>Che l'odio tuo per Polissena è quello. </l>
             <l part="I">Che in questa guisa a favellar t'induce. </l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l part="F">  Sì - </l>
             <stage>(amaramente)</stage>
             <l>Se, Prence, però noto ti fosse </l>
             <l part="I">A qual punto … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F">  T'accheta - altro non bramo </l>
             <l>Udir da te; Minacci pur, se il vuole, </l>
@@ -2328,7 +2350,7 @@ Chi t'invola a un velen? Chi t'assicura </l>
             <l>Ch'ella ne tronchi a suo piacere, almeno </l>
             <l>Da una destra sì cara avrò la morte.</l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l>  Fatale errore! - Troppo, Signor, ti lasci </l>
             <l>Al periglio condur dall'amor tuo. </l>
@@ -2345,7 +2367,7 @@ Poco è l'empio desìo, ch'ha di vendetta </l>
             <l>Polissena per te, poco è l'odiarti … </l>
             <l>Prence, temi un rivale - Un altro ell'ama. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="I">  Un altro ell'ama! - </l>
             <stage>(con furore)</stage>
@@ -2364,12 +2386,12 @@ Poco è l'empio desìo, ch'ha di vendetta </l>
             <l part="F">saper non voglio </l>
             <l part="I">Altro da labbri tuoi … </l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <stage>con con ironia in atto di partire</stage>
             <l part="F">Resta; io ti lascio. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <stage>dopo un poco di pausa ritenendolo</stage>
             <l part="I">Sentimi non partir …  </l>
@@ -2381,11 +2403,11 @@ Poco è l'empio desìo, ch'ha di vendetta </l>
             <l part="I">Di straziarmi compisci … </l>
             <stage>impaziente</stage>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l part="F">  Ebben; se il vuoi … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="I">  Sì; feriscimi il cuor … </l>
             <stage>(smaniando)</stage>
@@ -2393,24 +2415,24 @@ Poco è l'empio desìo, ch'ha di vendetta </l>
             <l part="I">Chi mi tradì … </l>
             <stage>con impazienza furiosa</stage>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l part="F">  Quello Stranier, che giunse </l>
             <l part="I">In queste Rive, e che conoscer brami. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F">  Stelle! … </l>
             <stage>come escendo da un inganno</stage>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l>  Molto non ha, che assiso al fianco </l>
             <l>Della tua Schiava a ragionar d'amore </l>
             <l part="I"><pb n="42"/>
 Da me fu visto. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F">  Giusto Ciel! … che intesi! </l>
             <l part="I">Perfido … </l>
@@ -2423,7 +2445,7 @@ Da me fu visto. </l>
             <stage>prende per mano Arsindo</stage>
             <l part="F">Andiamo. </l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l>  Frena la smania tua. Conosci in prima </l>
             <l>Con gl'occhi tuoi, che sei tradito, e quindi </l>
@@ -2431,7 +2453,7 @@ Da me fu visto. </l>
             <stage>si vedon comparir nel fondo Polissena, e Polidoro,
 che parlano assieme con qualche interesse</stage>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F">  O Dei! </l>
             <l>Che dubitar! - Gl'empj non vedo io stesso </l>
@@ -2439,14 +2461,14 @@ che parlano assieme con qualche interesse</stage>
             <l part="I">Lascia, ch'io vibri … </l>
             <stage>mette mano alla spada</stage>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <stage>ritenendolo</stage>
             <l part="F">A preparar mi siegui </l>
             <l part="I">La morte lor - non ti scuoprir … </l>
             <stage>lo conduce seco</stage>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <stage>ripone mano alla spada: si ritiene, indi sortendo</stage>
             <l part="F">Comanda, </l>
@@ -2457,13 +2479,13 @@ che parlano assieme con qualche interesse</stage>
         <div type="scene">
           <head>SCENA III</head>
           <stage>Polidoro, e Polissena.</stage>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l>  Ciel! quegli è Pirro! - Ah! lascia pur ch'io </l>
             <l part="I">A sfidarlo, e morir … </l>
             <stage>vuol partire</stage>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <stage>lo ritiene</stage>
             <l part="F">Ferma: che tenti? </l>
@@ -2472,7 +2494,7 @@ che parlano assieme con qualche interesse</stage>
             <l part="I">Ferma … </l>
             <stage>sempre ritenendolo</stage>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l part="F">  Almen se spirar deggio su queste</l>
             <l><pb n="43"/>
@@ -2482,7 +2504,7 @@ Miserabili arene, allor ch'io muojo </l>
             <l>Ei vuol, ch'io porga al Padre mio vendetta. </l>
             <l part="I">Pirro l'uccise - ei morir debbe. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <stage>a parte</stage>
             <l part="F">Oh! Numi! </l>
@@ -2492,7 +2514,7 @@ Miserabili arene, allor ch'io muojo </l>
             <l>Se tu scoperto sei, e il Padre estinto </l>
             <l>Senza placar, me con te stesso uccidi. </l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l>  Ebben; si ceda … Io però in cuor non spengo </l>
             <l>Quella furia crudel che mi divora, </l>
@@ -2512,17 +2534,17 @@ Miserabili arene, allor ch'io muojo </l>
             <l part="I">Oh! vendetta! …  </l>
             <stage>fremendo</stage>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="M">  Ah! crudel! </l>
             <stage>con grido di dolore</stage>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l part="F">  Stelle! tu gemi! </l>
             <l part="I">Che vedo! … </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F">  E come inorridir non debbe </l>
             <l>Quest'alma allor, che trasportar ti vedo, </l>
@@ -2530,11 +2552,11 @@ Miserabili arene, allor ch'io muojo </l>
             <l><pb n="44"/>
 Con tanto sdegno delirando insulti? </l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l part="I">  Che? - D'un nemico … </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F">  Io di scusar non cerco </l>
             <l>Il furor suo; Ma s'ei la Patria nostra </l>
@@ -2544,7 +2566,7 @@ Con tanto sdegno delirando insulti? </l>
             <l>Involar volle - e l'ira sua fu giusta. </l>
             <l part="I">Ma tu … </l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l part="F">  Che parli? - A Polidoro in faccia </l>
             <l>Sugl'occhi al tuo German difender tenti </l>
@@ -2552,33 +2574,33 @@ Con tanto sdegno delirando insulti? </l>
             <l>In me il desìo disapprovare ardisci? </l>
             <l part="I">Forse Pirro … </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="M">  Io mi perdo … </l>
             <stage>a parte</stage>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <stage>minacciando</stage>
             <l part="F">Ah! se giammai </l>
             <l part="I">Potessi immaginar … </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F">  Di che sospetti? … </l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l part="I">  Io pavento per te … </l>
             <stage>come sopra</stage>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F">  Comanda, imponi </l>
             <l>Ciò, che far debbo, onde affogarti in seno </l>
             <l>Quel timor, che ti turba, e che m'oltraggia. </l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l>  Voglia il Ciel, ch'io m'inganni - Ah! fa' ch'io perda </l>
             <l>Ogni timor; Degna ti rendi alfine </l>
@@ -2596,20 +2618,20 @@ Solingo spesso al fianco tuo lo tragge. </l>
             <l>Al suo stolido amor pascolo cerca </l>
             <l>Fiso ne' lumi tuoi, passagli il cuore. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="I">  Empio! … </l>
             <stage>(inorridita)</stage>
             <l part="M">Che mi comandi! </l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <stage>con furia</stage>
             <l part="F">Ho tutto inteso.</l>
             <l part="I">Temi, spergiura … </l>
             <stage>minacciandola</stage>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <stage>a parte</stage>
             <l part="M">Ah! mi tradii … </l>
@@ -2617,23 +2639,23 @@ Solingo spesso al fianco tuo lo tragge. </l>
             <l part="F">Perdona, </l>
             <l part="I">Germano al mio timor …</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l part="I">  Taci: Tu stessa </l>
             <l>Svelasti ciò, che ad accusarti basta. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l>  Numi! e come sperar, che un debil braccio, </l>
             <l part="I">Che una femmina imbelle … </l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l part="F">  Invan ti sforzi </l>
             <l>Pretesti a mendicar, Pirro ferisci, </l>
             <l>E allor ti crederò - Parla: Il prometti? </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <stage>a parte</stage>
             <l part="I">Oh contrasto fatal! … </l>
@@ -2643,11 +2665,11 @@ Solingo spesso al fianco tuo lo tragge. </l>
             <l part="F">Non posso. </l>
             <stage>con trasporto</stage>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l part="I">  Perfida! - Dunque vuoi … </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <stage>con trasporto di dolore</stage>
             <l part="F">Perchè straziarmi, </l>
@@ -2668,43 +2690,43 @@ A quei, che mi salvò, che per giovarmi </l>
             <l part="I">Traditrice di quei … </l>
             <stage>ritenendosi</stage>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l part="F">  Che non compisci? </l>
             <l part="I">Colma le smanie mie - Di quei? </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F">  Prevedo </l>
             <l>Tutto il tuo duol - Sento quai fieri colpi </l>
             <l>A portarti io m'accingo … Eppure non posso </l>
             <l part="I">Dissimular … Pirro … </l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <stage>fremendo a parte</stage>
             <l part="M">Ah! l'ingrata! </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l>  </l>
             <stage>piangendo</stage>
             <l part="F">0d onta </l>
             <l>E di Te, e di Me stessa io l'idolatro. </l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l part="I">  Oh esecrabili accenti! … </l>
             <stage>(con furore eccessivo)</stage>
             <l part="M">Empia! … </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F">  Ferisci </l>
             <l>Questo cuore infelice - e alfine estingui </l>
             <l>Ne' flutti del suo sangue il fuoco mio. </l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l>  Obbrobrio di tua stirpe! Alma imbecille! </l>
             <l>Disonor de' tuoi Padri! A me tu chiedi </l>
@@ -2720,7 +2742,7 @@ A quei, che mi salvò, che per giovarmi </l>
             <l>Del pianto mio, del tuo dover soltanto. </l>
             <l part="I">Me lo giuri? </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F">  Ah! German, perché non posso </l>
             <l>Con lacrime più degne in questo punto </l>
@@ -2735,7 +2757,7 @@ Tutte lavar dell'onor mio le macchie! </l>
             <l>Del mio delitto, onde sanar quest'alma, </l>
             <l>Con l'arrossirne l'error suo s'emenda. </l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l>  Or ti conosco: Or mia Germana sei. </l>
             <l>Quanto m'è dolce il rimirar risorti </l>
@@ -2750,14 +2772,14 @@ Tutte lavar dell'onor mio le macchie! </l>
           <head>SCENA IV </head>
           <stage>Escono inosservarti verso il fondo Pirro,
 ed Arsindo.</stage>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <stage>seguitando</stage>
             <l>Io stesso frangerò l'orribil giorno </l>
             <l>Che t'opprime - Ti calma; A questo ferro </l>
             <l part="I">L'onor m'è dato … </l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <stage>adagio a Pirro</stage>
             <l part="M">Odi? </l>
@@ -2770,29 +2792,29 @@ una breve scena muta con Polissena è in atto
 di partire.</stage>
             <pb n="48"/>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="I">  Ove corri? …</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l part="F">  A svenar di propria mano </l>
             <l part="I">Il tuo più reo nemico. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F">  Ah! no … m'ascolta.</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l part="I">  Come! e sì presto … </l>
             <stage>minacciando</stage>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="M">  Io per te tremo … </l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l part="F">  Ascondi </l>
             <l>Quei sospiri, e quel pianto. Or or vedrai, </l>
@@ -2806,14 +2828,14 @@ al Proscenio dalla parte ove è sortito Pirro.</stage>
         <div type="scene">
           <head>SCENA V </head>
           <stage>Polissena, Arsindo.</stage>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l>  Ei mi lascia - Egli freme. O Dei, spengete </l>
             <l>Entro quel petto un sì fatal sdegno; </l>
             <l>Essere ei puote ad amendue funesto. </l>
             <l part="I">Ciel! … qual strepito ascolto? </l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <stage>fingendo di venir frettoloso dalla Scena</stage>
             <l part="F">Altrove io deggio </l>
@@ -2823,17 +2845,17 @@ al Proscenio dalla parte ove è sortito Pirro.</stage>
             <l>De' miei più fidi un preparato stuolo: </l>
             <l part="I">Ei sarà la tua scorta. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="M">  Ah! di' … </l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l part="F">  Perdona </l>
             <l>All'impazienza mia. Fuggi; È tra l'armi </l>
             <l part="I">La tua vita in periglio. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F">  O infausto giorno!</l>
           </sp>
@@ -2844,7 +2866,7 @@ Pirro, e Polidoro.</stage>
           <head>SCENA VI </head>
           <pb n="49"/>
           <stage>Arsindo.</stage>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l> Di sì provida impresa il fin proteggi </l>
             <l part="I">Amico Ciel … </l>
@@ -2856,12 +2878,12 @@ si volta verso la Scena</stage>
         <div type="scene">
           <head>ATTO TERZO, SCENA VII </head>
           <stage>Pirro, Polidoro, Arsindo, Guardie.</stage>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <stage>fra le Scene</stage>
             <l part="I">Barbaro! Son tradito … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <stage>combattendo fra le Scene</stage>
             <l part="F">Invan resisti. </l>
@@ -2869,7 +2891,7 @@ si volta verso la Scena</stage>
 <abbr>Polid.</abbr> che è già senz'elmo, e senza manto</stage>
             <l>Cedi quel  brando, o ti trafiggo il cuore.</l>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <l part="I">  L'avrai … </l>
             <stage>retrocedendo</stage>
@@ -2879,7 +2901,7 @@ si volta verso la Scena</stage>
             <stage>egli cade, e dice</stage>
             <l part="F">Io spiro. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l>  Cadde l'audace, e seco lui sen muore </l>
             <l part="I">La frode, e il tradimento … </l>
@@ -2927,11 +2949,11 @@ in atto di partire, ma Pirro soggiunge</stage>
             <l>Quest'oggetto fatal de' miei furori.</l>
           </sp>
           <stage>due Guardie portano fuori della Scena il cadavere.</stage>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l part="I">  Signor, che pronto colpo … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F">  Invan paventi, </l>
             <l>Ch'io l'inumana a risparmiar mi pieghi. </l>
@@ -2943,13 +2965,13 @@ Io l'aborrito, e l'ingannato sono? </l>
             <l part="I">La spergiura! … </l>
             <stage>s'appog. oppresso alla smania</stage>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l part="F">  Signor, dal sen discaccia </l>
             <l>Idee sì meste, e l'infedele oblìa. </l>
             <l part="I">Calmati. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <stage>alzandosi con furore</stage>
             <l part="F">Nò, veder la voglio, </l>
@@ -2957,11 +2979,11 @@ Io l'aborrito, e l'ingannato sono? </l>
             <l>L'apparecchio in mirar della sua morte, </l>
             <l>E che grazia mi chieda, e non l'ottenga. </l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l>  Come! tu brami agl'occhi suoi mostrarti? </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l>  Non temer: la sua morte è già prefissa; </l>
             <l>Nell'amor mio spera l'ingrata invano, </l>
@@ -2977,7 +2999,7 @@ Io l'aborrito, e l'ingannato sono? </l>
         <div type="scene">
           <head>SCENA VIII </head>
           <stage>Pirro.</stage>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l> Stelle! che sarà mai quella, ch'io provo </l>
             <l>Brama fatal di rimirar l'ingrata! </l>
@@ -3000,14 +3022,14 @@ Eccola … </l>
         <div type="scene">
           <head>ATTO TERZO, SCENA IX </head>
           <stage>Pirro, Polissena, Guardie.</stage>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F">  Ove son tratta! o Cieli ! </l>
             <l>Qual volto … Quali sguardi … Il mio Germano </l>
             <l part="I">Forse è scoperto … </l>
             <stage>tutto a parte</stage>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <stage>da sé</stage>
             <l part="F">Avidi miei furori </l>
@@ -3016,7 +3038,7 @@ Eccola … </l>
             <l part="I">T'avvicina. </l>
             <stage>con tuono feroce</stage>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <stage>tremante</stage>
             <l part="M">Ah! Signor … </l>
@@ -3024,62 +3046,62 @@ Eccola … </l>
             <l part="F">Qual tuon! qual voce! </l>
             <l part="I">Soccorso, o Dei! … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <stage>freddamente</stage>
             <l part="F">Tu fosti un dì mia schiava. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l>  Fortunato il momento, in cui potesti </l>
             <l>Prodigare in favor d'una tua serva </l>
             <l>Di libertade il generoso dono. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <stage>come sopra</stage>
             <l>Dimmi: sai tu qual la cagione ne fosse? </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l>  Ah! Signor, qual mio fallo un tanto sdegno </l>
             <l part="I">Poté sì presto meritar! … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <stage>bruscamente</stage>
             <l part="F">Rispondi. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l>  O tormento! … a spezzare i lacci miei </l>
             <l>Quella dolce pietà, che un dì ti spinse </l>
             <l>Fu di tua compassion forse l'effetto. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <stage>con furia eccessiva</stage>
             <l part="I">Tu mentisci, spergiura; </l>
             <l part="F">Egli fu amore. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="I">  Dei! qual furor! … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <stage>con furore</stage>
             <l part="F">Perfida, trema; È tutto </l>
             <l>Il tuo delitto ad onta tua palese. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="I">  Che! qual delitto!</l>
             <stage>(a parte)</stage>
             <l part="F">il mio German conobbe. </l>
             <pb n="53"/>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="I">  Me ne domandi? …  </l>
             <stage>con ironìa amara</stage>
@@ -3087,12 +3109,12 @@ Eccola … </l>
             <l>In quel perfido seno io non t'immerga? </l>
             <l part="I">Che nel tuo sangue … </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <stage>in atto supplichevole</stage>
             <l part="M">0h! Principe … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F">  T'acquieta; </l>
             <l>Più pietade non v'è, non v'è clemenza. </l>
@@ -3100,14 +3122,14 @@ Eccola … </l>
             <l>Saran puniti, e la tua morte è certa. </l>
             <l part="I">Sì traditrice … </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <stage>con trasporto</stage>
             <l part="F">Ah! se il Ciel lo sdegno </l>
             <l>Io potei meritar, se in me v'è colpa </l>
             <l>Ella v'è sol, perch'io t'amai di troppo. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <stage>a parte</stage>
             <l>Che? di sì puro amor può assicurarmi </l>
@@ -3116,11 +3138,11 @@ Eccola … </l>
             <stage>(alto)</stage>
             <l part="F">È poi ben veder  che m'ami? </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="I">  Che dubitarne? il Ciel n'attesto. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <stage>a parte</stage>
             <l part="F">Indegna! </l>
@@ -3129,19 +3151,19 @@ Eccola … </l>
             <l part="F">fra i beni, che promette Amore </l>
             <l>Dimmi qual ben di preferir ti piace? </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="I">  La fedeltà. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="M">  Senza di lei? </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F">  La morte. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="I">  Soddisfatta sarai … </l>
             <stage>(con furore)</stage>
@@ -3149,13 +3171,13 @@ Eccola … </l>
             <l part="I">Lungi costei … </l>
           </sp>
           <stage>Polis. è circondata dalle Guardie.</stage>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <stage>partendo dà un'occhiata penetrante a Pirro</stage>
             <l part="M">Barbaro! … </l>
             <stage>via</stage>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F">  Ah! con quel guardo </l>
             <l>Quasi mi disarmò - Ma non s'attenda, </l>
@@ -3185,7 +3207,7 @@ nuda. Da parte sinistra giace disteso sul palco
 il cadavere di Polidoro ucciso.
 <emph>Polissena condotta da una Guardia esce
 verso il fondo.</emph> </stage>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l> Dimmi almeno a qual fato i giorni miei </l>
             <l part="I">Serbati son …  </l>
@@ -3264,34 +3286,34 @@ Barbaro! - e quel tuo cuor, quell'empio cuore </l>
         <div type="scene">
           <head>SCENA II </head>
           <stage>Polissena, Pirro entra inosservato nel fondo.</stage>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <stage>senza essere udito</stage>
             <l part="F">Ecco l'indegna. </l>
             <l>Chiama il suo bene … Il seguirà frappoco. </l>
             <stage>si ferma ad udirla</stage>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l>  Con quest'acciar del sangue tuo vermiglio </l>
             <l part="I">A te m'accoppierò … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="M">  Fremo. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F">  Ah! Germano! … </l>
             <l part="I">Mio sangue … mia speranza … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <stage>con agitazione estrema</stage>
             <l part="F">Ciel! che sento! </l>
             <l>Suo German … sommi Dei! - possibil fia? </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l>  Ah! di Priamo infelice unico germe </l>
             <l><pb n="57"/>
@@ -3305,12 +3327,12 @@ Scopo innocente di miei brame … arresta </l>
             <l>Il cuor m'incatenò … dovessi estinto, </l>
             <l>Sventurato Germano, al suol cadere? </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l>  Cieli!… Ella m'ama! … e sarà ver? - che intesi! </l>
             <l>Suo German Polidoro! - Io sono amato! </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l>  Almen la morte mia, terribil'ombra, </l>
             <l part="I">Ti plachi - Alfin … </l>
@@ -3332,13 +3354,13 @@ Scopo innocente di miei brame … arresta </l>
             <l>Del barbaro Idol mio mescervi a sorte </l>
             <l part="I">Qualche stilla di pianto … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F">  Io reggo appena. </l>
             <l part="I">Crudel! che feci! </l>
             <stage>smaniando avvicina</stage>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F">  Ah! questa dolce idea </l>
             <l>Entro il mio sen tutta la forza avviva; </l>
@@ -3346,19 +3368,19 @@ Scopo innocente di miei brame … arresta </l>
             <stage>prende la tazza</stage>
             <pb n="58"/>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="I">  Fermati … oh! Dio! … </l>
             <stage>lanciandosi l'arresta, e getta la tazza</stage>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <stage>spaventata</stage>
             <l part="F">Da me che vuoi crudele? </l>
             <l part="I">Lasciami in pace … </l>
             <stage>cade sul sedile</stage>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F">  Anima mia, perdono, </l>
             <l part="I">Io t'offesi … </l>
@@ -3375,7 +3397,7 @@ Scopo innocente di miei brame … arresta </l>
             <l part="F">No … perdono - </l>
             <l part="I">e più non chiedo. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="I">  Involati, crudel; Vedi: tu sei </l>
             <l>Di quel sangue innocente ancor bagnato, </l>
@@ -3385,12 +3407,12 @@ Scopo innocente di miei brame … arresta </l>
             <l>Se ogni speranza mi togliesti, lascia </l>
             <l>A questo sen la libertà del pianto. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="I">  Polissena … </l>
             <stage>con tenerezza</stage>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F">  Spietato! - aggiunger brami </l>
             <l>L'oltraggio a tuoi delitti? Il sen mi vuoi </l>
@@ -3400,7 +3422,7 @@ Scopo innocente di miei brame … arresta </l>
             <l>A Polidoro, e per le vie lo spingi </l>
             <l>Di questo cuore … Esse a te note sono. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l>  Ove ti porta il tuo dolor! - Deh! cessa  </l>
             <l>D'insultare a miei mali, e men severi </l>
@@ -3409,7 +3431,7 @@ Volgi que' lumi tuoi verso un meschino, </l>
             <l>Che se t'offese, il cuor straziar si sente </l>
             <l>Dalla voce feral de' suoi rimorsi. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="I">  Ah! barbaro! </l>
             <stage>(s'alza)</stage>
@@ -3417,7 +3439,7 @@ Volgi que' lumi tuoi verso un meschino, </l>
             <l>Di pentimento - Ed io contar potrei </l>
             <l part="I">Sulla tua fede? </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F">  Ah! tutto puoi, mel credi, </l>
             <l>Sopra di me, se quel tuo sdegno ammorzi; </l>
@@ -3428,24 +3450,24 @@ Volgi que' lumi tuoi verso un meschino, </l>
             <l>Nelle lacrime mie restin sepolti. </l>
             <l part="I">Io ti giuro … </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F">  T'accheta; Il Ciel rispetta; </l>
             <l>Forse pretendi agl'occhi miei far pompa </l>
             <l part="I">D'una menzogna … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F">  Tu m'oltraggi a torto. </l>
             <l>Assai t'è noto questo cuor; risparmia </l>
             <l>La pena mia - L'affetto tuo mi rendi.  </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="I">  Stelle! che chiedi! … ahimè! </l>
             <stage>voltan altrove</stage>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F">  Soffrir non puote </l>
             <l>Lo sguardo tuo la mia fatal presenza, </l>
@@ -3453,13 +3475,13 @@ Volgi que' lumi tuoi verso un meschino, </l>
             <l>Ma ti volgi - l'avrai … Prendi quel ferro, </l>
             <l>E sazia nel mio sangue il tuo spavento. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l>  Taci. Io bramo la morte. Io, che da' Numi </l>
             <l>Dagl'uomini, da te, dal mio destino </l>
             <l part="I">Aborrita mi vedo. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F">  Io sono il solo </l>
             <l>Colpevole, il geloso, il disumano; </l>
@@ -3471,7 +3493,7 @@ Se la tema di perderti ha potuto </l>
             <l part="I">Tu viver dei - Pirro lo vuole </l>
             <stage>con trasporto</stage>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F">  Ah! questi </l>
             <l>Giorni infelici, il di cui fragil corso </l>
@@ -3498,7 +3520,7 @@ indietro spaventata, e si getta sul sedile</stage>
             <l part="F">tu ardisci </l>
             <l>Portar quel cuor su' labbri miei sanguigni? </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="I">  Misera! tu deliri. Amici, </l>
             <stage>escon  quattro Guardie</stage>
@@ -3506,7 +3528,7 @@ indietro spaventata, e si getta sul sedile</stage>
             <l>Quel cadavere si tragga, ed a quei lumi </l>
             <l>Un spettacolo sì fier pronti togliete. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="I">  T'arresta … </l>
             <stage>s'alza, e corre alle Guardie,
@@ -3522,13 +3544,13 @@ che prendono il cadavere</stage>
             <l part="I">A quella cara alma … </l>
             <stage>è ritenuta da <abbr>Pir.</abbr></stage>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F">  E dove corri? </l>
             <l part="I">Lascia … </l>
             <stage>due Guardie portan fuori il cadavere</stage>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="M">  No … </l>
             <stage>si stacca dalle mani di <abbr>Pir.</abbr></stage>
@@ -3537,7 +3559,7 @@ che prendono il cadavere</stage>
             <l part="F">Io più non reggo. </l>
             <stage>ella è sostenuta dall'altre due Guardie</stage>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="I">  Ella manca … </l>
             <stage>(con dolore)</stage>
@@ -3549,7 +3571,7 @@ che prendono il cadavere</stage>
         <div type="scene">
           <head>SCENA III </head>
           <stage>Pirro.</stage>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="I"> Torbida gelosìa! … </l>
             <stage>si getta a sedere</stage>
@@ -3582,18 +3604,18 @@ S'aspetta il sollevarla, e vo' che unisca </l>
         <div type="scene">
           <head>SCENA IV</head>
           <stage>Pirro, Arsindo agitato.</stage>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l part="I">  Ferma, Signor … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <stage>volgendosi</stage>
             <l part="F">Che vuoi? … perché quel volto </l>
             <l>Sì pien d'orrore … onde quei Cupi sguardi </l>
             <l part="I">Quell'irto crin … </l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <stage>riprendendo il respiro</stage>
             <l part="F">Tacer vorrei, se il Cielo </l>
@@ -3601,11 +3623,11 @@ S'aspetta il sollevarla, e vo' che unisca </l>
             <l>Non volesse un secreto, al mio sol nome </l>
             <l>Atterito ti mostri, e il cuor ti trema. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="I">  Parla. </l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l part="F">  Io palpito ancora; Ancor le membra </l>
             <l>Un orribil timor m'agita, e scuote. </l>
@@ -3651,18 +3673,18 @@ E Polissena 'l mio furore uccida." </l>
             <l>Disse: E fra i lampi all'urna sua tornando </l>
             <l>Senza moto lasciommi, e senza voce. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="I">  Cielo! … </l>
             <stage>si getta sul sedile</stage>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l part="F">  Udisti, Signor? Se al tuo gran Padre </l>
             <l>Negar non vuoi la contentezza estrema </l>
             <l part="I">Svenar t'è duopo Polissena. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <stage>minacciando</stage>
             <l part="F">Ardisci </l>
@@ -3672,36 +3694,36 @@ E Polissena 'l mio furore uccida." </l>
             <l>Tutto alle smanie mie gettarmi in preda. </l>
           </sp>
           <stage>s'appoggia disperato alla tavola</stage>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l part="I">  E a Calcante dirò … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="M">  Lasciami. </l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l part="F">  Almeno </l>
             <l part="I">Di' se del sacrifizio … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <stage>alzandosi confusamente</stage>
             <l part="F">A lui dir devi …  </l>
             <stage>irresoluto </stage>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l part="I">  Che debbo dir? </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <stage>impaziente</stage>
             <l part="M">Ciò che ti piace. </l>
             <stage>s'appoggia di nuovo</stage>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l part="F">  Oh! amore!</l>
           </sp>
@@ -3710,7 +3732,7 @@ E Polissena 'l mio furore uccida." </l>
         <div type="scene">
           <head>SCENA V </head>
           <stage>Pirro.</stage>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l>  Compiste alfin di tormentarmi appieno </l>
             <l>Barbarie mie sventure - Il duol, che eccede, </l>
@@ -3756,7 +3778,7 @@ Pompa fatal per l'innocenza eretta </l>
           <head>SCENA VI </head>
           <pb n="66"/>
           <stage>Pirro, Polissena.</stage>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F">  Che vuoi </l>
             <l>Da un infelice oppressa? a mali miei </l>
@@ -3767,7 +3789,7 @@ Pompa fatal per l'innocenza eretta </l>
             <l>Per opra tua scampata, il fatal colpo </l>
             <l>Debbo incontrar dalla tua destra istessa. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l>  Qual sospetto t'ingombra! - Ah! se di questo </l>
             <l>Sventurato mio cuor tutte le pene </l>
@@ -3776,7 +3798,7 @@ Pompa fatal per l'innocenza eretta </l>
             <l>Tutto all'orecchie tue non giunse ancora </l>
             <l>Il mio spavento … </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l>  Spaventar sol puommi </l>
             <l>Della morte il rifiuto. Entro il tuo seno </l>
@@ -3797,7 +3819,7 @@ Di rimorso col nome agl'occhi miei </l>
             <l>Celarsi tenta - m'aborrisci, ingrato, </l>
             <l part="I">Né mai m'amasti. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <stage>con amarezza</stage>
             <l part="F">Io non t'amai? - crudele! </l>
@@ -3823,21 +3845,21 @@ Di rimorso col nome agl'occhi miei </l>
             <l>Più mi festi provar, che i miei delitti, </l>
             <l>Che il mio destin, che dell'Olimpo i cenni. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="I">  Di quai cenni favelli! … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F">  Il Ciel volesse, </l>
             <l>Ch'essi fossero a te per anco ignoti. </l>
             <l part="I">Non sai … </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="M">  Parla. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F">  Se ancor tutta non giunse </l>
             <l>Delle nostre sventure a te la fama, </l>
@@ -3845,21 +3867,21 @@ Di rimorso col nome agl'occhi miei </l>
 Non curar di saperle - A te pur troppo </l>
             <l>Per comune dolor note saranno. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l>  Non dubitar di spaventarmi; a tutto </l>
             <l part="I">Disposta son - parla. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F">  Non trar, ti prego, </l>
             <l>Da questi labbri un sì fatal annunzio. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="I">  Tu m'insulti … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F">  Se il vuoi, tutto ti svelo. </l>
             <l>L'Oracol degli Dei morta ti vuole, </l>
@@ -3867,25 +3889,25 @@ Non curar di saperle - A te pur troppo </l>
             <l>Comanda, ch'io ti sveni, e col tuo sangue </l>
             <l>Onde placarla, il suo sepolcro asperga. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="I">  Numi! … </l>
             <stage>si getta sul sedile</stage>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F">  Afflitto mio Bene, o vera imago </l>
             <l>Dell'oppressa virtude …  ecco a quel punto </l>
             <l>In questo dì l'empio destin c'ha tratti. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <stage>s'appoggia</stage>
             <l>Questo sfogo perdona la mio dolore … </l>
             <l>Io respirare appena posso - e cinta </l>
             <l>Da' legami di morte è l'alma mia. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l>  Sorgi! … non paventar. Della tua vita </l>
             <l>In me, tel giuro, il difensore avrai. </l>
@@ -3894,13 +3916,13 @@ Non curar di saperle - A te pur troppo </l>
             <l>Sempre t'adorerò, questo mio brando </l>
             <l>Sempre terrò per tua difesa in pugno. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l>  Ove trascorri? - Il dover tuo rammenta, </l>
             <l>Servi alla Patria, e la tua Schiava oblìa; </l>
             <l part="I">Signor … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F">  Vedrai, se in questo petto è chiuso </l>
             <l>Tanto valor da liberarti - Io vado </l>
@@ -3910,51 +3932,51 @@ Per guidarti con me libera al Mare. </l>
             <l>Quivi su' legni miei potrò sicura </l>
             <l part="I">Lungi di quà condurti. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F">  E non paventi </l>
             <l>L'ira del Ciel? Spengi una folle speme </l>
             <l part="I">Stolido Dio de' ciechi amanti …  </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F">  Indarno </l>
             <l>Tenti arrestarmi - a liberarti io volo. </l>
             <l part="I">Tu m'attendi, e vedrai … </l>
             <stage>in atto di partire</stage>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <stage>alzandosi spaventata</stage>
             <l part="F">Ferma, ove corri? </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="I">  A difenderti. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F">  Oh! Dio! - Prence, rifletti … </l>
             <l part="I">Pensa, che sei … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F">  No, non so più chi sono.</l>
             <stage>in atto di partire</stage>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="I">  Odimi … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="M">  Addio. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="M">  Che cerchi tu? </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <stage>parte furibondo</stage>
             <l part="F">La morte.</l>
@@ -3970,25 +3992,25 @@ Fine dell'Atto <num>IV</num>.</stage>
           <pb n="70"/>
           <stage>Il Teatro di nuovo rappresenta il Bosco, e la Tomba.
 Erope, Arsindo.</stage>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <l> E dell'infausto sacrifizio ancora </l>
             <l part="I">L'esito non si sa? </l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l part="F">  Come! ed ignori, </l>
             <l>Che dalle mani dei Sacerdoti a forza </l>
             <l>Pirro involò l'Ostia de' Fati attesa? </l>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <l> Nulla intender poss'io; svelta poc'anzi </l>
             <l>Dall'infelice Principessa, e lungi </l>
             <l>Dal fianco suo più non la vidi, e sono, </l>
             <l>Misera! ancor del suo destino incerta. </l>
           </sp>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l>  Odimi; A cenni di Calcante appena </l>
             <l>La sventurata Vittima in potere </l>
@@ -4014,7 +4036,7 @@ Sparge il vento i duoi detti: Il Garzon truce </l>
             <l>L'involato olocausto, e col suo sangue </l>
             <l>Omai l'ira placar del Cielo offeso. </l>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <l> Principessa infelice! - È questo dunque </l>
             <l>Sacro solo alle stragi infausto giorno? </l>
@@ -4030,7 +4052,7 @@ Sparge il vento i duoi detti: Il Garzon truce </l>
         <div type="scene">
           <head>SCENA II </head>
           <stage>Arsindo.</stage>
-          <sp>
+          <sp who="#arsindo">
             <speaker>ARSINDO</speaker>
             <l> Quanto il destino lor (misere!) è degno </l>
             <l>D'esser compianto. Io son de' Greci, è vero, </l>
@@ -4051,17 +4073,17 @@ Sparge il vento i duoi detti: Il Garzon truce </l>
           <stage>Pirro conduce a forza Polissena in bianca veste,
 cinta di fiori come preparata per il Sacrifizio.
 Seguito di Guerrieri.</stage>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="I">  Seguimi: Non temer … </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F">  Dove mi guidi? </l>
             <l>Lasciami per pietà … Prence, non vedi, </l>
             <l>Che con la mia tu la tua morte affretti? </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l>  Vieni, non dubitar; D'un volgo insano </l>
             <l>Spregia i tumulti, e non temer quell'ira. </l>
@@ -4079,19 +4101,19 @@ Seguito di Guerrieri.</stage>
             <l>Onde quel duol? … Perché alle mie premure </l>
             <l part="I">Rispondi sol con dei sospiri? … </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F">  Ah! lascia </l>
             <l>Di liberarmi; Ogni mia speme è posta </l>
             <l>Nel fatal colpo, che a subir m'accingo.  </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l>  Che? - tu morir? … di tormentar deh! cessa </l>
             <l>Questo misero cuor - Non sai, che pende </l>
             <l>La mia felicità da' giorni tuoi? </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l>  Principe, il Ciel non ha giammai congiunto </l>
             <l><pb n="73"/>
@@ -4107,17 +4129,17 @@ Il tuo destin con i miei giorni; Invano </l>
             <l>In questo sen da rimirar costante </l>
             <l part="I">Il mio supplizio. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F">  Ah! tu mi strappi il cuore. </l>
             <l part="I">Seguimi … </l>
             <stage>vuol condurla</stage>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="M">  Invan lo speri … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F">  Ah! cessa - Oh! Numi! </l>
             <l>Che veggio mai! - giunge Calcante, e seco </l>
@@ -4131,7 +4153,7 @@ Il tuo destin con i miei giorni; Invano </l>
             <l part="F">Saprò ben'io come involarti </l>
             <l>Al barbaro furor de' tuoi tiranni. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="I">  Lasciami … </l>
             <stage>(volendo liberarsi)</stage>
@@ -4145,13 +4167,13 @@ Il tuo destin con i miei giorni; Invano </l>
           <pb n="74"/>
           <stage>Pirro, Polissena, Calcante, Arsindo, Sacerdoti,
 Guerrieri, Guardie, Popolo.</stage>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l>  O sacrilegio! o Numi offesi! - E dove, </l>
             <l>Temerario, ti spinse un cieco affetto? </l>
             <l>Lascia quell'ostia … Ella è in poter del Cielo. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l>  Carnefice crudel! - Non vuol l'Olimpo </l>
             <l>Questi di crudeltà barbari esempj. </l>
@@ -4159,7 +4181,7 @@ Guerrieri, Guardie, Popolo.</stage>
             <l>Barbari, audaci a tuo capriccio i Numi. </l>
             <l part="I">Scostati. </l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="F">  Scellerato! - ah! questo è troppo. </l>
             <l>Deh! non v'offenda un tale eccesso, o Dei! </l>
@@ -4169,7 +4191,7 @@ Guerrieri, Guardie, Popolo.</stage>
             <l>Vendicatrice folgore non scenda? </l>
             <l part="I">Empio! in tal guisa … </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F">  A questo cuore indarno </l>
             <l>Con sognate minacce, e folli sdegni </l>
@@ -4215,7 +4237,7 @@ D'un innocente vittima, cui nulla </l>
             <l>E l'innocente vittima sottragga </l>
             <l part="I">Al furor di colui … </l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="F">  Guerrieri, udite. </l>
             <l>Gl'offesi Dei fremono di sdegno: Achille </l>
@@ -4238,7 +4260,7 @@ Brama far sazio il furor suo nel sangue. </l>
             <l>Giove istesso è, che parla; E non potremo </l>
             <l>La Patria riveder, che a questo prezzo. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="I">  Ah! t'arrendi, Signor. </l>
             <stage>(a Pirro)</stage>
@@ -4249,22 +4271,22 @@ Brama far sazio il furor suo nel sangue. </l>
             <l part="I">Lascia … </l>
             <stage>vuol liberarsi</stage>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l>  Che temi? - a questo brando è dato </l>
             <l>Il vendicarti, e finché quì tu sei </l>
             <l>Non potria spaventarmi il Mondo intero. </l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="I">  Dunque ceder non vuoi? </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <stage>ferocemente</stage>
             <l part="F">Lo speri indarno. </l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l>  Ebben: se tanto alla passione in preda </l>
             <l>L'offuscato tuo cuor mirar degg'io </l>
@@ -4276,13 +4298,13 @@ Brama far sazio il furor suo nel sangue. </l>
             <l>L'ombra del grande Achille, e il Cielo irato </l>
             <l>La bramata vendetta al vostro braccio. </l>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="I"> Cedi… oh! Dio!
 	…</l>
             <stage>a Pirro. Le Guardie fanno un movimento</stage>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="F">  Temerarj! - a questo ferro </l>
             <l>Veder saprem chi presentarsi ardisce. </l>
@@ -4290,7 +4312,7 @@ Brama far sazio il furor suo nel sangue. </l>
             <stage>(a suoi)</stage>
             <l part="M">All'armi. </l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <stage> alle Guardie, e al
 	seguito</stage>
@@ -4301,19 +4323,19 @@ Brama far sazio il furor suo nel sangue. </l>
 Polissena già libera dalle mani di Pirro,
 che corre alla pugna, si scaglia in mezzo
 alle due Truppe, ed esclama</stage>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F"> Olà: fermate. </l>
             <l>Non sia mai ver, che per me sol si sparga </l>
             <l>Tanto sangue innocente; avranno i Numi </l>
             <l part="I">La vendetta richiesta. </l>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <l part="M">  O Dei!</l>
             <stage>vuol lanciarsi verso Polissena</stage>
           </sp>
-          <sp>
+          <sp who="#polissena">
             <speaker>POLISSENA</speaker>
             <l part="F"> Ti scosta. </l>
             <l>Conoscete chi son: Quel regio sangue </l>
@@ -4324,13 +4346,13 @@ alle due Truppe, ed esclama</stage>
             <l part="F">Io muojo.</l>
             <stage>cade</stage>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="I"> Ciel! …</l>
           </sp>
           <stage>tutti danno segno della loro estrema
 sorpresa</stage>
-          <sp>
+          <sp who="#pirro">
             <speaker>PIRRO</speaker>
             <stage>immobile</stage>
             <l part="M">Polissena! …</l>
@@ -4353,7 +4375,7 @@ sorpresa</stage>
 sul cadavere dicendo</stage>
             <l>Se perder ti dovei … seguir ti voglio. </l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l> Principe sventurato! - Arsindo, appresta </l>
             <l>A quell'alma abbattuta ogni soccorso. </l>

--- a/tei/cascina-alfea-reverente.xml
+++ b/tei/cascina-alfea-reverente.xml
@@ -74,6 +74,22 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="Alfea">
+            <persName>Alfea</persName>
+          </person>
+          <personGrp xml:id="coro">
+            <name>Coro delle ninfe dell'arno</name>
+          </personGrp>
+          <personGrp xml:id="due_ninfe">
+            <name>Due delle ninfe</name>
+          </personGrp>
+          <person xml:id="la_fama">
+            <persName>La Fama</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT-Pisa</name>Digitalizzazione</change>
@@ -108,7 +124,7 @@ GRANDUCHESSA DI TOSCANA</hi></p>
           <p>Era la notte; onde giunto il Carro al cominciare della destra sponda del Nobil Arno; Gareggiando in rompere, e fugar l'ombre, con'una quantità grandissima di torce, che portate da numeroso stuolo di Staffieri anch'essi bizzarramente vestiti, lo accompagnavano, si veddero in un subito ciascheduna delle Rive del Fiume interamente illuminate; allo splendor' delle quali, per maggior ricchezza del Teatro veniva non solo aggiunto il reflesso dell'onde, ma nell'istesso tempo si accrebbe il sereno lampeggiar de gl'occhi d'infinite Dame, che s'affacciarno. Quindi per la medesima riva, con l'ordine suddetto caminando, arrivato alla Piazza della Regia abitazione di S.A.S. Venendo quella onorata dalla presenza delle Serenissime Altezze, e questa illustrata anch'ella da infiniti lumi, e dalla bellezza indicibile d'altre Principali Dame Forestiere, e della Città si fermò il Carro, e con profondo, e maestoso inchino, havendo Alfea reverite le Serenissime Altezze, rivolta quindi alle Ninfe dell'Arno, et a' Cavalieri che le facevano Corona, e doppo alle rive dell'istesso Fiume, precedente una Musicale sinfonia di varij instrumenti toccati dalle Ninfe, al suono ben regolato de' medesimi, sciolse la lingua in questi accenti. </p>
         </div>
         <div type="scene" n="Scena">
-          <sp>
+          <sp who="#Alfea">
             <speaker>
               <hi rend="sc"> ALFEA SOLA</hi>
             </speaker>
@@ -178,7 +194,7 @@ GRANDUCHESSA DI TOSCANA</hi></p>
               <l>Del Gran <hi rend="sc"> FERNANDO</hi> al nome, e di <hi rend="sc"> VITTORIA. </hi> </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>
               <hi rend="sc"> CORO DELLE NINFE DELL'ARNO</hi>
             </speaker>
@@ -189,7 +205,7 @@ GRANDUCHESSA DI TOSCANA</hi></p>
               <l>Chi già mai ridir potrà? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#alfea">
             <speaker>
               <hi rend="sc"> ALFEA</hi>
             </speaker>
@@ -206,7 +222,7 @@ GRANDUCHESSA DI TOSCANA</hi></p>
               <l>Fan Corona ampi Tesori. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#due_ninfe">
             <speaker>
               <hi rend="sc"> DUE DELLE NINFE DEL CORO</hi>
             </speaker>
@@ -219,7 +235,7 @@ GRANDUCHESSA DI TOSCANA</hi></p>
               <l>Regio Core, Alma Divina. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>
               <hi rend="sc"> IL CORO TUTTO</hi>
             </speaker>
@@ -232,7 +248,7 @@ GRANDUCHESSA DI TOSCANA</hi></p>
               <l>Chi già mai ridir potrà? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#alfea">
             <speaker>
               <hi rend="sc"> ALFEA</hi>
             </speaker>
@@ -249,7 +265,7 @@ GRANDUCHESSA DI TOSCANA</hi></p>
               <l>Di virtù, di senno, è piena. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#due_ninfe">
             <speaker>
               <hi rend="sc"> LE DUE NINFE</hi>
             </speaker>
@@ -262,7 +278,7 @@ GRANDUCHESSA DI TOSCANA</hi></p>
               <l>Regio Core, Alma Divina. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>
               <hi rend="sc"> TUTTO IL CORO</hi>
             </speaker>
@@ -275,7 +291,7 @@ GRANDUCHESSA DI TOSCANA</hi></p>
               <l>Chi già mai ridir potrà? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#alfea">
             <speaker>
               <hi rend="sc"> ALFEA</hi>
             </speaker>
@@ -292,7 +308,7 @@ GRANDUCHESSA DI TOSCANA</hi></p>
               <l>Cadan vinti a i Toschi Legni. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#due_ninfe">
             <speaker>
               <hi rend="sc"> LE DUE NINFE</hi>
             </speaker>
@@ -303,7 +319,7 @@ GRANDUCHESSA DI TOSCANA</hi></p>
               <l>Regio Core, Alma Divina. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>
               <hi rend="sc"> IL CORO TUTTO </hi>
             </speaker>
@@ -316,7 +332,7 @@ GRANDUCHESSA DI TOSCANA</hi></p>
               <l>Chi già mai ridir potrà? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#alfea">
             <speaker>
               <hi rend="sc"> ALFEA</hi>
             </speaker>
@@ -341,7 +357,7 @@ GRANDUCHESSA DI TOSCANA</hi></p>
           </sp>
           <stage>Qui le Trombe e i Tamburi fanno piena Sinfonia.</stage>
           <stage>In quello una delle Ninfe levatasi in piedi, et all'Ali apparitele a gl'Omeri et all'aurea Tromba vedutasele nelle mani, scopertasi d'esser la <hi rend="sc"> FAMA, </hi> accennando alle Trombe, et a i Tamburi che si quietino scioglie la voce in questo suono.</stage>
-          <sp>
+          <sp who="#la_fama">
             <speaker>
               <hi rend="sc"> LA FAMA</hi>
             </speaker>
@@ -404,7 +420,7 @@ GRANDUCHESSA DI TOSCANA</hi></p>
               <l> (Se 'l tuo Cenno le scorga) il Mondo intero. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>
               <hi rend="sc"> TUTTO IL CORO </hi>
             </speaker>

--- a/tei/cecchini-l-amico-tradito.xml
+++ b/tei/cecchini-l-amico-tradito.xml
@@ -81,6 +81,49 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="pantalone">
+            <persName>Pantalone</persName>
+          </person>
+          <person xml:id="dottor">
+            <persName>Dottor Graziano</persName>
+          </person>
+          <person xml:id="virginio">
+            <persName>Virginio</persName>
+          </person>
+          <person xml:id="celia">
+            <persName>Celia</persName>
+          </person>
+          <person xml:id="cinzio">
+            <persName>Cinzio</persName>
+          </person>
+          <person xml:id="bagattino">
+            <persName>Bagattino</persName>
+          </person>
+          <person xml:id="capitano">
+            <persName>Capitan Rinoceronte</persName>
+          </person>
+          <person xml:id="fritellino">
+            <persName>Fritellino</persName>
+          </person>
+          <person xml:id="flaminia">
+            <persName>Flaminia</persName>
+          </person>
+          <person xml:id="franceschina">
+            <persName>Franceschina</persName>
+          </person>
+          <person xml:id="pantalon">
+            <persName>Pantalone</persName>
+          </person>
+          <person xml:id="carluccio">
+            <persName>Carluccio</persName>
+          </person>
+          <person xml:id="togato">
+            <persName>Uno togato</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Siena</name>Digitalizzazione</change>
@@ -136,51 +179,51 @@ umilissimo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">dottore</hi>
           </stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>È possibile che sto mondo no possa star senza despareri?</p>
           </sp>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>Da i dsparer nass l' discordi, da l' discordi l' lit, e da le lit la vita d'i duttur.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>I mii despareri ne incaga a i dottori, puo' che no i puol zenerar lite, né altre discordie, che la separazion della nostr'amicizia.</p>
           </sp>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p><foreign xml:lang="lat">Amicitiam frangere potest dici frangere amicitiam et</foreign> amicus non est amicus, si amicitia non durat.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>I sensi de sti vostri latini tanto volgari xe così balordi, quanto che Verzinio vostro xe un dissoluto, per la qual cossa no vogio che Cinzio mio fio pratica più con esso, sotto pena della privazion de tutte le mie facultae, perché ho molto ben compreso che tutto quello che lui opera de mal xe tutto in vertù del mal esempio e del mal consegio de vostro fio.<pb n="691"/></p>
           </sp>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>Putana d' mi, an sidi in la gran colra, e sì ha parladi tant'alterad, ch'al s' comprend ch'avidi pers 'l giudizi, e sì an savidi quel ch'an dsì.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Come, se so quel che digo, se mio dir xe fondao su 'l far de mio fio?</p>
           </sp>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>Vostr fiol ha del far? Mo a lu ndrà ben, perché l'è car quest'ann. E chi gh' l'ha dà Virgini? Ah furb, al m' l'ha rubà a mi! Dadm un poch al mia far, via prest, al mia far.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>No se intendemo, sior capochia.</p>
           </sp>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>Com ch'an v'intend? Al se delina hoc far farriis al furment triticum tritidici. La fava, faba fabae, la fava picciola, haec fabula, fava porcina, Scribonius Cargus. An intend molt ben mi!</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Nol xe el far nome, el xe el far verbo, che significa far poltronarie come fa vostro fio, e che sia la veritae, eccolo ch'el vien in qua con una putana. <stage>(<emph>E si ritira</emph>)</stage></p>
           </sp>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>O pota d' Zuda, questa è Celia mia nazza, che vien da Bologna per mudar aria.</p>
           </sp>
@@ -197,32 +240,32 @@ umilissimo servitore
               <hi rend="sc">pantalone</hi>
             </add>
           </stage>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Signora cugina, non mi poteva il Cielo favorir d'avantaggio, che nel farmi giunger a tempo di poterla servire. Ma perché non mandar avviso della sua venuta?</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Lo incomodo non premeditato dà meno incomodo.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>E qual noia puol porgere chi con la sua presenza non solo scaccia la noia, ma tiene suprema virtù di poter introdurre una consolatissima gioia?</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Signor cugino, le cirimonie ch'oltra passano i termini credibili o sono favolose o puoco lontane dal scandaloso. Non vorrei che fosti udito, per quanto io amo il nostro decoro.</p>
           </sp>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p><stage>(<emph>Si fa innanzi, l'abbraccia, e dice</emph>)</stage>Oh sgnora Celia, sgnora nvodina mia dolza, mo ch' gust, oh ch' consulaziun, sana, bella, grassa, tonda, mobida e tutta gudibil. Vgnì in ca', vgnidù a rpusar su 'l let. Andem.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Entriamo tutti, entriamo.</p>
           </sp>
           <stage>(<emph>Tutti entrano. Pantalone riman solo, senza aver mai udito nulla, ma però, vedute le cerimonie, dice</emph>)</stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Non ho mai visto el più grazioso ruffian de quel dottor, né 'l più libero putanier de so fio, né 'l più bel postribulo de quella casa.</p>
           </sp>
@@ -234,51 +277,51 @@ umilissimo servitore
           </stage>
           <stage>(<emph>Cinzio nell'arrivar guarda le finestre di Flaminia. Pantalone l'osserva, Cinzio dice</emph>)</stage>
           <pb n="693"/>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>O albergo, vera cagione che Cinzio viva senz'anima. O anima, che colà dentro vivi in Flaminia e che Flaminia sia quasi moribonda, quantunque abbia due anime.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Ecco quel furbo, che guarda, parla e sospira. Ghe voio mortificar le rene con sto baston che vedo qua in terra. Tiò, tiò, tiò, pezzo de can, nemigo mio, scandolo della zitae e traditor di sé medemo!</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>A me signor padre? a Cinzio? a vostro figlio?</p>
           </sp>
           <stage>(<emph>Pantalone li dà una mano su 'l volto e li rompe il naso</emph>)</stage>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Ohimè, cavarmi ancor sangue? Questo è pur vostro sangue; e, quello che più vi deve premere, sangue innocente.</p>
           </sp>
           <stage>(<emph>Pantalone piange sotto voce</emph>)</stage>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Quel sangue che sparso per altro accidente vi averebbe tutto contaminato, ora viene violentato da voi e forse con qualche diletto?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Ohimè, ohimè, i me.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Quel sangue (dico) pura residenza di quell'anima che il Cielo vi fe' mediatore per farla scender in questo corpo?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Non più, ché ste viscere (pur massa tormentae da altri accidenti) no puol più far, incontro al martirio de ste parole, convertie in tante stilettae per destruzer sto corpo, forsi nassuo perché ti nasci, e che senz'altro morirave si ti morissi. Lievate in piè, abbrazzame e basame.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Io non mi levarò mai, s'io non son fatto sicuro che il vostro sdegno abbia finito di contaminar il vostro amore.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Ecco, che mi te lievo, e per segurezza della purità del mio affetto, te do sto baso, e per certezza del pronto mio effetto, te dono sta borsa con zinquanta zecchini trabuccanti. Paga (se ti ha qualche debito) e vien a casa a portarme e a consolarme con quella parte che me manca, quando ti è fuora. A Dio Cinzio.</p>
           </sp>
           <stage>(<emph>Cinzio riman solo</emph>)</stage>
           <pb n="694"/>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Segno evidente di ribellata natura al corso di una longa avarizia. O Cielo, e che favori son questi? Anzi, che grazie, in tempo di tanta necessità di Flaminia mia.</p>
           </sp>
@@ -290,71 +333,71 @@ umilissimo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">cinzio</hi>
           </stage>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>O povertà, muda luogh! Se non am senti, che 'l bisognarà che mi muda mond, puo' ch'in quest am senti morir de fam.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Ecco quell'infelice di Bagattin, il quale ha unite all'infelicità della sua nascita, l'estremità di quelle de gl'accidenti di Flaminia.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>O signor Cinzio. Perdoném, che non g'ho fiat de respondia plu fort, perché l'è doi dì, che tra la signora Flaminia non avem mangiat otter che una zambela da un baioch e un tochet de formai, scampat de bocca a un sorgh, che fuziva de cumbat.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Miseria che solo a udirla contamina e confonde tutt'i nostri sensi.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>E a provarla contamin e ammazza i desgraziat.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Che dice la signora Flaminia?</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>La no parla, per non mandà fuora quel poch de fiat che gh' serv a pena per respirà.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>E ho inteso, tu vòi ch'io mora, poiché la mia vita tanto vive, quanto sa che Flaminia vive.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Ul voster viver e morir, sta su le relativ, ma al noster sta su la sustantaria. Mo quel voster bambì, quella cara lengueta, che sa nominà tutt le cose mangiative se ben nol ghe ne ha mai niguna?</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Non più afflizioni, non più digiuni o patimenti, poiché le cose passate son tutte finite.<pb n="695"/></p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>E so anca mi che tutt le cos passat son finide, ma l'è le present, e quelle ch'an da vegnì, che me dan travai.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Ecco il rimedio delle presenti e delle future, eccoti una borsa con cinquanta zecchini. Spendi, mangia, mangiate, state allegri, che forse non mancarà mai più nulla.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Il nulla non n'amanca mai lui, perché l'avem sempre, l'è un qualche cose che n'aviva abbandonat.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Orsù, guarda che la borsa non ti sia rubata. Di' alla signora Flaminia che questo è il tempo di adoperar la prudenza e di vincer soffrendo quello che perderebbe disperando. Bacia il mio Caruluccio, il mio caro figliuolo, compragli ciambelle, frutti e tutte quelle galanterie, le quali son proprie della sua età.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Non è tempo de galanterie, né de zambele, ma de pan, vin, manestra, formai, macarù, carne de bò, con al rest de quelle cose, che la natura me andarà de man in man a dandom la lista.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>A Dio Bagattino, mille saluti a quella a cui è appoggiata la mia salute. <stage>(<emph>E via</emph>)</stage></p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>A Dio signor Cinzi. Zinquanta zecchini? Am dubiti che la quantità non me intorbide la liberalità e che n'm' passi via al temp del spender e del mangià.</p>
           </sp>
@@ -366,80 +409,80 @@ umilissimo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">bagattino</hi>
           </stage>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Io ho perduta la traccia di Celia. Mi dubito che Marte, per farmi una burla, non voglia fingere di averla tolta in fallo per Venere e averla condotta in qualche luoco alle strette. E se ciò credessi su il saldo, le belle piattonate ch'io<pb n="696"/> li vorrei dare! Ma ecco chi me ne saprà forsi dar qualche indizio.</p>
             <p>O buon compagno. A Dio, a Dio.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Questa è un'invenziù per invidarm a spender i zinquanta zecchì. Am vuoi logà la borsa. Bondì fradel, bondì.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Fratello a chi?</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>A vu, sol ve par d'essern degn.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Degno di che?</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>D'avì un fradel che sia galant'om.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>E che ti pensi ch'io sia? Furfante, ignorante, briccone, mascalzone, impiccato, malcreato.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>A nol so, nol vuoi savì, no mel desì, lassém sta e andé in colà, che ho olter in cò, che sta chilò, a menà boi, con un sonai da sparavier, a Dio messer.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Férmati, in virtù di quell'ordine che puol far che si fermino tutti gli eserciti, ancorché marcianti, spironanti e fuganti.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Am fermi, che i furfant, a tutt i or, ha da obedì a i so mazor.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Levati il capello.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Eccol levat.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Rispondi con riverenza. Hai tu veduto passar di qui la Bellezza in abito di campagna?</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Signor no.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Hai tu veduto rapir da Marte una che pareva ma non era Venere?</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Signor no. Ho ben vedut rapir da Sabàt un che pariva ma non era po' vu.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Tu non m'intendi, bisogna ch'io parli più aperto, più chiaro, più intelligibile, più proprio e accomodato al tuo sape<pb n="697"/>re, al tuo ingegno e alla tua intelligenza. Hai tu veduto passare una gentildonna accompagnata da una serva, che veniva da questa parte?</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Signor no; ma signor no sul sald, signor no maiuscolament, e signor no, per quant am pudì creder che v'abbia per un chiacchiarù.<stage>(<emph>E va correndo</emph>)</stage></p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Io non mi poteva imbatter in peggior di costui. Voglio cercar tutta la città, e quando mi avegga esser disperato il negozio di ritrovarla, voglio ritirarmi in un luoco il più eminente della città, e con un soffio gettar a terra tutte le cose. No, ché se Celia fusse in qualcheduna di esse potrebbe perire. Non caderebbe quelle ove fusse Celia, se non per quanto fusse per lasciar Celia visibile a gl'occhi del Capitano; che non può il mio fiato, ben che convertito in Borea, o d'Aquilone, far altro uffizio che di rifrigerante con la mia bellissima Celia. Io non voglio perder più tempo, poiché anche Celia patisce in estremo, non mi vedendo.</p>
           </sp>
@@ -451,51 +494,51 @@ umilissimo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">fritellino</hi>
           </stage>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Ed è pur vero, o Fritellino, che l'amicizia ch'io tengo con Cinzio, e l'amor grande ch'io le porto, fanno ch'io sia nemico a me istesso, e che per lui ancora abbia in abborimento me medemo.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Se così è, farete rider gl'amici, e in breve tempo doventarete pazzo. Ma come sta questo?</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Io amo Flaminia, amata con tutte le viscere da Cinzio. Io non oso scoprirmi, per non offender Cinzio, e tacendo occido me stesso.<pb n="698"/></p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>O che abuso, o che pazzia. Ascoltatemi bene: se uno (fuori di voi) amasse Flaminia, concorrendo Cinzio in amore, che faresti?</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>L'ucciderei.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Perché?</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Perché io amo Cinzio sopra tutti gl'altri amici ch'io m'abbia.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>O questo ha più del credibile, poiché amando voi Cinzio più del suo concorrente, vi porresti a i danni di quello. Ma naturalmente dovendo amar voi stesso più di Cinzio, non è bene il credere che vi poniate a i vostri danni più tosto che a quelli di Cinzio. Onde bisogna concludere che tra Cinzio e un altro, viva Cinzio, ma tra Cinzio e Virginio, viva Virginio.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Buono, per mia fé, dottrina più salda della mia. Procurisi adunque Flaminia, e potendola ottenere abbiasi pazienza l'amico, poiché il proprio interesse malamente conosce l'altrui bisogno.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Udite un'altra ragione più costante della prima. Se si dovesse dar una sentenza che dovesse esser cacciato il cuore o a Virginio o a Cinzio, che caldezza d'uffizio vogliam credere che fareste, tutti due, accioché fosse cacciato al compagno?</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Grande.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Non dite di essere senza cuore, non avendo Flaminia? non lo dice l'istesso Cinzio? Orsù non più, lasciate fare a me, retiratevi, ché or ora vi mostrarò come si confermino i cuori.</p>
           </sp>
@@ -508,54 +551,54 @@ umilissimo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">virginio</hi>
           </stage>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Non ci sarà nissuno che vadi a veder chi batte, eh? Orsù, ci andarò io. Chi batte?</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Un vostro servitore, signora Flaminia. Il signor Cinzio è in casa?<pb n="699"/></p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Non ci è e di rado ci viene.</p>
           </sp>
           <stage>(<emph>Fritellino rivolto a Virginio dice</emph>)</stage>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Non vel diss'io che sarebbe dall'amica?</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Io non lo potevo mai credere, andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Vengo or ora. </p>
             <p>Ah povera signora Flaminia mal trattata, puoco conosciuta e, forse... chi sa! È meglio tacere.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Tu hai detto tanto che il non dir il rimanente non è quasi tacere. Di', che è di Cinzio?</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Bene di corpo, ma molto infermo d'operazioni.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>E come? Ohimè, tu mi uccidi.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Io non posso dir altro. Andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>È meglio. Non affligger più quella povera signora. Andiamo, ché lo trovaremo colà.</p>
           </sp>
           <stage>(<emph>Partono</emph>)</stage>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Lo trovaremo colà? ma dove? Adunque Cinzio ha luoco di più gusto della casa mia, nella quale ha pur la fede impegnata, il sangue in deposito e l'onore obligato? Sì che può stare, poiché le sue dimore adombrate di scuse sono validissime querele approvate e convinte, e quello che non sai tu, o Flaminia, lo debbe sapere tutta la città. Ma eccolo, non voglio mostrarmi adirata.</p>
           </sp>
@@ -567,16 +610,16 @@ umilissimo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">flaminia</hi>
           </stage>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Ogn'ora, ch'io sto senza veder la mia Flaminia, è un secolo di tormento a quest'anima mia. Ma eccola. </p>
             <p>E come in strada? Guardatevi, guardiamoci, che mio padre non n'abbia qualche relazione, che malbeato me e puoco contenta voi.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Adunque vostro padre procura tanto di saper dove andate?</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Ohimè, non si può credere.</p>
           </sp>
@@ -588,23 +631,23 @@ umilissimo servitore
           <stage>
             <hi rend="sc">fritellino, cinzio, flaminia</hi>
           </stage>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Signor Cinzio, venite via correndo, ché il signor Virginio vi aspetta dove voi sapete.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Sì, sì, vengo. Signora abbiate pazienza. <stage>(<emph>E via</emph>)</stage></p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>E dove va così in fretta?</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Da una tal signora, dove credevamo di ritrovarlo.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p><stage>(<emph>sola</emph>)</stage>E forsi ch'io gli ho potuto addimandar dove va, forsi ch'egli mi ha detto ora ritorno? L'uno non me l'averebbe detto, e l'altro l'ha taciuto per non mentire. O Cinzio tanto diverso da te, che non sei più Cinzio; ché se fosti Cinzio (com'eri) saresti anco Flaminia, e se fosti Flaminia saresti fedele: onde non sei più né Cinzio né Flaminia né fedele. Chi sei adunque? un'anima diformata, la quale, intorbidate le potenze, informa un corpo senza fede, immemore de gl'oblighi, con l'intelletto così contaminato, che ti sei dimenticato l'obligo e di padre e di marito.</p>
           </sp>
@@ -616,24 +659,24 @@ umilissimo servitore
             <hi rend="italic">con robbe da mangiare, e</hi>
             <hi rend="sc">flaminia</hi>
           </stage>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Questa è carne e questi son polaster, che tant temp han abbut ul band da casa nostra, signora. Ecco vivand da pudì stà allegrament, questa è tutta spisa fatta del denar del signor Cinz con ul rest de zinquanta zecchì, che ho chilò int'al taschì.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Robbe di Cinzio? danari di Cinzio?</p>
           </sp>
           <stage>(<emph>Getta via tutto</emph>)</stage>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Fermef signora, ohimè, tanti ingredienti, da metì infossù ne i budei per salut dell'affliziù del corpo, han d'andà adonca a mal tutti? Signora Flaminia, avvertì, che morirem de fam prestissim.<pb n="701"/></p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Io non mi curo, son di già avvelenata. <stage>(<emph>Entra</emph>)</stage></p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Orvietà, orvietà, prest, orvietà.</p>
           </sp>
@@ -645,47 +688,47 @@ umilissimo servitore
             <hi rend="italic">al romore, e</hi>
             <hi rend="sc">bagattin</hi>
           </stage>
-          <sp>
+          <sp who="#franceschina">
             <speaker><emph rend="sc">franceschina</emph>.</speaker>
             <p>Che strepiti? che romori? O quanta robba mangiativa, chi l'ha versata?</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Effetti del velen.</p>
           </sp>
-          <sp>
+          <sp who="#franceschina">
             <speaker><emph rend="sc">franceschina</emph>.</speaker>
             <p>E che? è forse robba avvelenata? Levala via.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>E no, l'è una signora, che ha ul velen int'al venter, che non ghe ha volut mettì dentr sti altri laùr.</p>
           </sp>
-          <sp>
+          <sp who="#franceschina">
             <speaker><emph rend="sc">franceschina</emph>.</speaker>
             <p>Ah an, ha fatto bene, mangiamolo noi.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Andemoi a mangià.</p>
           </sp>
-          <sp>
+          <sp who="#franceschina">
             <speaker><emph rend="sc">franceschina</emph>.</speaker>
             <p>Bisogna prima cucinare e poi mangiare.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Ul se cusina a chi ha temp d'aspettà.</p>
           </sp>
-          <sp>
+          <sp who="#franceschina">
             <speaker><emph rend="sc">franceschina</emph>.</speaker>
             <p>Vuoi tu dunque mangiar questa carne cruda?</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>La mangiaravi anc viva.</p>
           </sp>
-          <sp>
+          <sp who="#franceschina">
             <speaker><emph rend="sc">franceschina</emph>.</speaker>
             <p>O lupo, entriamo, e lascia far a me.</p>
           </sp>
@@ -697,7 +740,7 @@ umilissimo servitore
             <hi rend="sc">fritellino</hi>
             <hi rend="italic">solo</hi>
           </stage>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Io non voglio lasciar strada intentata, invenzion oziosa, né qualsivoglia modo difficile, per aiutar Virginio. Ne ho pensat'uno che, forse forse, sarà il migliore di quanti me ne sian passati per la mente. Voglio servirmi della signora Celia. O bella se mi riesce, come l'animo mi predice.</p>
           </sp>
@@ -706,139 +749,139 @@ umilissimo servitore
         <div type="scene">
           <head rend="italic">SCENA XIII</head>
           <stage><hi rend="sc">celia</hi><hi rend="italic">alla finestra</hi>, <hi rend="sc">fritellino</hi></stage>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Sarò io forse venuta in questa casa per non veder mai più il mio Capitano? Egli ha pur sempre seguitato la carrozza da Bologna sin qua a Ferrara.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>E chi ha seguitato la carrozza?</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Ohimè, che costui mi avrà udita. Un canino, ch'io ho poi smarrito nell'entrar dentro.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Mi dispiace che l'abbiate smarrito prima ch'egli sia entrato.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Entrarà, se non è entrato, e forsi lo trovarò.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Io non ho veduto cani, ho ben visto un Capitano, il quale va sperso per la città.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Ohimè, non più, vengo a basso.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>O quanto è stato bene per i miei disegni, ch'io abbia udito quel nome di Capitano! Questo senz'altro è un suo amante. Eccola.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Che dici tu di Capitano?</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Che dite voi di cagnolino?</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Parliamo di quello che più importa.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Vi debbe importar più (mi cred'io) quel canino, del qual dovet'esser innamorata, che quel Capitano, che al certo non conoscete.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Orsù via, furbo, tu mi hai sentita.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>E intesa, ch'è peggio.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>E bene, che di' tu? dove è questo Capitano?</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Lo cercarò, lo trovarò, ve lo condurò, e che volete di più?</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Nulla, e io che posso far per te?</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Gran cose con puoca fatica.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Eccomi pronta.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Il signor Virginio vostro cugino, per una scommessa fatta con un gentiluomo, il quale fa il bel parlatore, vorrebbe udirlo parlare amorosamente, e che voi lo ascoltaste, per veder se la presenza di una dama lo sgomenta. E, occor<pb n="703"/>rendo, desidera anche che gli rispondiate, per meglio chiarirsi della sua sufficienza.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>O questo non farò mai.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Fate punto su il «non lo farò» e levate via quel «mai».</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Io dico che non lo farò mai, mai, mai.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Questa moltitudine di mai è la ruvina de i vostri negozii.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>E come?</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Né io mai, anzi mai, mai, vi condurrò il Capitano, e, di più, procurarò ch'egli se ne vadi via della città. A Dio signora.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Férmati, ch'io levo il mai! Ma mi riserbo però il quando.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Il quando lo so io.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>E come lo sai tu, s'io non l'ho ancora determinato?</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Sarà quando vorrete il Capitano.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Se così fusse sarebbe or ora.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Facciamo adunque così. Io tornerò, farete, e io farò, e così contenti tutti due, l'uno non si potrà doler dell'altro.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Io me n'entro, ti attendo, non mancare, ch'io al certo non mancarò.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Il negozio piglia una tal forma, che mi promette ogni bene, e di raro chi ben principia finisce male i negozii. </p>
             <p>Ma ecco, per mia fé, Cinzio, ed è accompagnato con Virginio.</p>
@@ -851,61 +894,61 @@ umilissimo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">fritellino</hi>
           </stage>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Signor Virginio, vostra signoria mi ha da far grazie di venir meco a cena, ché doppo discorreremo di quello ch'oggi non abbiamo potuto concludere per l'interrompimento di quelli che, con tanta mala creanza, si hanno volsuto accompagnar con noi, senza esser richiesti, e quasi mezo rifiutati.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Di questi ce ne son tanti, che il Cielo ne guardi ogn'uomo ch'abbia faccende.</p>
           </sp>
           <stage>(<emph>Fritellino accenna Virginio. Virginio guarda Fritellino e non l'intende</emph>)</stage>
           <pb n="704"/>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Costui mi accenna, né so che voglia dire.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Signor Virginio, questo è il tempo che voi rimediate a quello di cui forse non sarete per più poterci rimediare se il signor Cinzio vi lascia.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Che domine vuol dir costui? Sì, è vero.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Lasciate dir a me, ch'io mi accorgo che non vorresti incomodar il signor Cinzio.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Férmati, ch'io mi dichiaro che il maggior incommodo che potessi aver quest'animo mio sarebbe il credere che il signor Virginio avesse pensiero d'incomodarmi, anche con il tenermi sempre impiegato ne' suoi affari. Di', che cosa poss'io fare per suo servizio?</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Sappia, vostra signoria, come il signor Virginio è amante riamato...</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Che cosa sarà questa?</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Di una signora. E perché il padre di lei ambisce di darla ad uno di casa Bisognosi, vorrebbe, per levar il vecchio di sospetto, che i favori di vostra signoria s'impiegassero (almeno per una volta) in parlare a detta signora, accioché una tal serva, posta da lui alla guardia, non avesse cagione di scoprirgli i suoi amori, ma che potesse assicurar il padre che lei parla ad un di casa Bisognosi, sì che con quattro parole amorose ella può assicurar i guste del signor Virginio e della sua dama.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>O che invenzione storpiata, e dall'ingegno e dalle parole!</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Il signor Virginio non vuol altro? Dopo cena faremo il servizio. Entriamo, ché ne discorreremo meglio.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Tu glie l'hai pur volsuto dire, an?</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Ha fatto bene. O di casa.</p>
           </sp>
@@ -919,15 +962,15 @@ umilissimo servitore
               <hi rend="sc">fritellino</hi>
             </add>
           </stage>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>O che bella compagnia. Vogliono cenar qui tutti?</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Signora sì.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Starete molto bene. Ma perché vien notte, non laudo lo star qui fuori al sereno. Entriamo. O che allegrezza!</p>
           </sp>
@@ -937,7 +980,7 @@ umilissimo servitore
           <stage>
             <hi rend="sc">capitano</hi>
           </stage>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Io son sicuro che Celia mia è in questa casa, essendomi stato detto che un suo zio abbita qui dentro. Il quale, quando avesse voglia di pazzamente morire, si opporrebbe scioccamente a i miei gusti. O porte, o finestre, se avesti punto di senso, come vi spalancaresti all'avviso de i miei desiderii. A luna, luna cornuta! Io vedo che tu vuoi spontar fuori: non lo fare, sta' nascosta, ché tu porti pericolo ch'io non ispicchi un salto e ch'io non venghi con un guanto di maglia a sfigurarti quel volto, altre volte da me minacciato in simili occasioni. Queste stelle scintillano che par che si rallegrino nel vedermi passeggiar senza quell'alterazione ch'altra volta le pose spavento ch'io li privassi del loro albergo.</p>
           </sp>
@@ -950,67 +993,67 @@ umilissimo servitore
             <hi rend="sc">capitano</hi>
           </stage>
           <stage>(<emph>Notte</emph>)</stage>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Ora al no gh'è negot da mangià e ora al gh'è tropp mangiador.<pb n="706"/></p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Chi parla?</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Ecco un olter mangiador.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Chi va là?</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Mi no vagh in là, ma a sto ferm chilò.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Tu parli e non m'addimandi licenza.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Se domanda anc licenza de tasì?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Anco di questo.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>E com se puol ela domandà, se no se parla?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Si addimanda e poi subito si tace.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Mi voraf licenza de parlà e de tasì quando me torna comod.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Queste licenze generali non si danno se non in iscritto; onde bisogna che tu vadi alla mia segretaria.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Com l'hoi da domandà?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Dimanda la segretaria del Capitano e tanto basta.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>An, se' vu Capitano de le secret civil e criminal, n'è?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>A furfante, passa qui, va' di là, salta, balla, fa' corbette! Io non so che mi tenga ch'io non ti pigli per un braccio o per un piede e gettarti cento miglia oltre i Monti Caspi.</p>
           </sp>
@@ -1021,39 +1064,39 @@ umilissimo servitore
           <stage>
             <hi rend="sc">cinzio, virginio, fritellino, capitano</hi>
           </stage>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Iscusate l'indugio, caro signore, la serva è pazza, il servo mal pratico.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Non importa, signore.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Che ho io da fare in suo servizio?<pb n="707"/></p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Se si raccorda, gli dissi che il padre della dama riamante del signor Virginio aveva (e ha) gran pensiero di maritarla in uno di casa Bisognosi, onde ogn'altro partito gli par manchevole di merito, e dubitand'egli che la giovane non inclini al signor Virginio, desideriamo che lei parli quattro parole amorose con detta signora, acciò che la sua serva riferisca che non parla con Virginio.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Non era buono ogn'uno di far quest'uffizio e massime dovendosi far di notte?</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Si poteva farlo far ad ogn'altro, ma la confidenza del signor Virginio non è generale con tutti gl'amici.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Dice bene Fritellino. Io non ho amico più confidente del mio signor Cinzio.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Io non fui mai tanto intricato com'ora: bisogna ch'io diversi le parole dal cuore, e che pazienza.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Quattro parole bastano.<stage>(<emph>Fa cenni a Celia</emph>)</stage></p>
           </sp>
@@ -1069,20 +1112,20 @@ umilissimo servitore
               <hi rend="sc">cinzio</hi>
             </add>
           </stage>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Questa debb'esser l'ora di parlare o di ascoltare quello della scommessa.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Signora Celia, fatemi la grazia compiuta, ch'io vo per il signor Capitano. </p>
             <p>Signor Cinzio, all'ordine.<stage>(<emph>Ed entra da Flaminia</emph>)</stage></p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Se ci fussero altri Capitani che me, in questo mondo, direi che colui andasse per un altro Capitano.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Io non so dove mi principiare. </p>
             <p>Signora, signora mia.</p>
@@ -1101,58 +1144,58 @@ umilissimo servitore
               <hi rend="sc">virginio</hi>
             </add>
           </stage>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Signora mia, l'amor grande ch'io vi porto m'intorbida i discorsi e mi confonde i concetti.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>O traditore!</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Onde non posso a pieno iscoprire quello che tanto tempo io ho in animo di dirgli.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Non posso più.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Tacete, o dite piano.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Ah cuor mio tribulato! Anzi, tribulato cuor mio.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>È troppo aspettare. Ah traditore!<stage>(<emph>E lo ferisce</emph>)</stage></p>
           </sp>
           <stage>(<emph>Cinzio cade e dice</emph>)</stage>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Son morto.</p>
           </sp>
           <stage>(<emph>Virginio fugge</emph>)</stage>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Se non sei morto morirai, ingannatore, perfido, spergiuro!</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Non più, ché queste parole sono peggiori delle ferite.</p>
           </sp>
           <stage>(<emph>Fritellino spinge in casa Flaminia per forza, la serra, poi dice</emph>)</stage>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Ohimè, che romor è questo?<stage>(<emph>E va via</emph>)</stage></p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Medici, amici, non ci è nissuno? Me n'anderò solo, almeno sapess'io dove.<stage>(<emph>E via</emph>)</stage></p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Al corpo di me, che la mia spada ha ferito un non so chi, ch'io non me ne sono avveduto, né so chi si sia. Voglio che me lo dica.<stage>(<emph>E via</emph>)</stage></p>
           </sp>
@@ -1166,7 +1209,7 @@ umilissimo servitore
           <stage>
             <hi rend="sc">flaminia</hi>
           </stage>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Almeno sapess'io se Cinzio sia morto, o s'io mi debbo assicurare ch'egli sia per morire, poi che in ogni modo la sua vita potrebbe cagionar mill'altre ruvine a mill'altre povere innocenti. </p>
             <p>Io avevo quel servo sospetto di mala lingua, e se le prove non mi accertavano il mancamento di Cinzio, forse ch'io averei sempre sospettato della bontà di quell'uomo da bene; poiché per altro tempo non averei mai creduto (a chi si fusse) mancamento nella fede di Cinzio. Ma che dich'io? alla fede di uno che mai non n'ebbe? all'amor mio, dirò, il quale sì come non ebbe mai pari, così Cinzio nel tradimento non ebbe mai uguale. Tant'anni di patimento, carcerazione quasi perpetua, una vita sempre inquieta, e finalmente una morte risuscitante per più volte farmi morire. E come potrò vivamente amare quel parto nato delle nostre congiunzioni, pensando che quello puol più tosto esser venuto alla luce per testimonio del mio mancamento, che per indizio di conformità di sangue tra noi. Io amerò però, e sarà per quella parte di pura concorrenza che solo fu mia, la quale, assicurata dalla mia fede, renderà il figlio legitimo parto di celeste disposizione.</p>
@@ -1180,31 +1223,31 @@ umilissimo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">flaminia</hi>
           </stage>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Il male non è quanto mi dubitava. Ma ecco questa furia infernale.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Ma eccolo, che non è morto.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>A me questi tradimenti eh?</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Non si puol tradire un traditore.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Che t'ho fatt'io, inumanissima femina?</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Ancor me ingiuri?<stage>(<emph>E li dà un schiaffo</emph>)</stage></p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>A me un schiaffo?<stage>(<emph>Li tira e la tocca con il pugnale</emph>)</stage></p>
           </sp>
@@ -1212,27 +1255,27 @@ umilissimo servitore
         <div type="scene">
           <head rend="italic">SCENA III</head>
           <stage><hi rend="sc">dottor</hi><hi rend="italic">si mette di mezzo</hi>, <hi rend="sc">flaminia</hi><hi rend="italic">e</hi><hi rend="sc">cinzio</hi></stage>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>N' v' dadi, n' v' dadi, perché i pugnai cavan sangu e 'l sangu v'imbrattarà i pugn'.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Io non posso dimorarmi senza pericolo di far male, le mie ragioni son troppo potenti. In grazia, conducetela in casa vostra, e s'è ferita, fatela medicare.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Si parte il ribaldo, sapendo che, nel dirvi i suoi mancamenti, non vi potreste tenere d'ingiuriarlo. Io son ferita.</p>
           </sp>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>Am la mustrarì in casa comdament sul lett dispuià, e sì a vdrò che tasta i vuol. Andém, la mia tosa.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Andiamo, e intenderete gran cose.</p>
           </sp>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>E sì an vedrò fuors de mazzor.</p>
           </sp>
@@ -1246,51 +1289,51 @@ umilissimo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">fritellino</hi>
           </stage>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Quella fa una gran ruvina, Fritellino.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Avete un gran passo, signor Virginio! Ve la cogliesti come se le botte venissero a voi.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Io lo feci per non esser addimandato per testimonio.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>E acciò ch'io fussi testimonio della vostra buona disposizione di gambe.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Lasciamo le burle. E che crediamo che succedesse di Flaminia e Cinzio?</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Non si può creder nulla di buono, egli fu ferito, ch'io lo so di sicuro.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Malamente?</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Buonamente non può essere.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Vogliamo veder s'egli è in casa?</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Non ci sarà (mi cred'io).</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Dove lo trovaremo?</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Ecco vostro padre ch'esce di casa.</p>
           </sp>
@@ -1302,31 +1345,31 @@ umilissimo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">fritellino</hi>
           </stage>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>Capucci! Che quas a i ho det com dis una volta un altr. La cos è intrigada, insanguinada, invlupada e quas desprada.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Di dove venite, signor padre?</p>
           </sp>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>De casa dov al gh'è... O gran cossa! Ascolta, stupiss, e puo' di' com puol esser. L'è un poch longa, tutt'via rassumém, restringém e cavàm sola la sostanzia, la qual è questa. I aspetti del Ciel non cognosudi da tutti mnazzava sangu, per via di fer adoperad per man d'una donna.<pb n="713"/></p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Ohimè, il caso di Flaminia!</p>
           </sp>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>Donc, sent la miseria de l'accident, mentr ch'in strada iera. Tas mo, una, dò, tre, quattr, vint dò or, a i ho da far. Bon dì.<stage>(<emph>E va via</emph>)</stage></p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Se n'è andato e lasciatoci in una confusione così gagliarda, che meglio era il non vederlo.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Abbiamo però rassunto la ferita e non so che altro, che quasi pare che il tutto sia noto alla casa vostra. Questi principii mi bastano per fondamento di una gran fabrica.</p>
           </sp>
@@ -1338,48 +1381,48 @@ umilissimo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">fritellino</hi>
           </stage>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>La mia spada mi giura esser più di trent'anni che non ha offeso niuno. Ma il romore fu però grande, e quello che mi fece incolpar la spada fu ch'io udii uno che disse: «Ohimè son morto!», e mi parve anco di udir la voce di Celia mia.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Questo è il signor Capitan Rinoceronte, amico e signor mio di tant'anni.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>O questo è maggior ciarlone di vostro padre!</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Io fo riverenza al signor Capitano, raccordandogli la mia divozione di tanto tempo.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>E io l'auguro quelli anni di salute ch'io ho levati di vita a 7834 Maumetani.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Grand'affetto, in gran parte ristretto alla mia credenza.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Io debbo dire al signor Virginio, in conformità della mia svisceratezza, che il Cielo mi ha infuso di volergli esser cognato, o vogliamo dir cugino, essend'ella fratel cugino della signora Celia, desiderando io che mi divenghi moglie per moltiplicar quella specie, mortificazione de gl'infedeli.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Il partito di queste nozze è molto avantaggiato alla nostra condizione, ma l'autorità di far ciò non è propria<pb n="714"/> mia, ma sì ben di mio padre, come quello che di Bologna ne tiene assoluto mandato. Ne parlerò con lui e sarò sollecito negoziatore de' suoi desiderii. In tanto vado, per non mi poter più trattenere. Servitor suo.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>A Dio, signor Virginio.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Rimanete in tanta buon'ora.</p>
           </sp>
           <stage>(<emph>Partono. Capitano rimane</emph>)</stage>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>S'io non sapessi che la signora Celia tien meco commune il desiderio, dubitarei di qualche intoppo, che mi astringesse ad una delle mie stravagantissime stravaganze.</p>
           </sp>
@@ -1391,35 +1434,35 @@ umilissimo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">capitano</hi>
           </stage>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Io son pur stata tanto sollecita, ch'io ho quasi importunatamente impetrato dal Cielo di poterla vedere.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>E io stava sospetto che la notte passata non si fusse lasciata vedere alle finestre, anzi che non avesse amorosamente parlato con un cavaliere.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Io mi feci alla finestra, e gli volevo parlare, ma però fintamente; e questo per servir ad uno il quale mi aveva promesso in premio di farmi parlare con vostra signoria.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Anco quest'ombra di sospetto mi potrebbe porger alterazione, s'io non fussi certo che la memoria ch'io l'amo non l'avrebbe lasciato commetter minima scintilla d'errore.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Vi si può anco aggiungere che la rimembranza della mia qualità non mi averebbe permesso ombra di mancamento.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Io l'ho chiesta in moglie al signor suo cugino, il quale mi ha promesso di unire l'autorità di suo padre alla prontezza della sua volontà, e quanto prima darmi libero il possesso dell'impero (anzi della monarchia) de i meriti e della bellezza di vostra signoria.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Io vorrei ch'ella lasciasse gl'iperboli per deridere, e non l'esercitasse nel laudare, poiché mi porrà in dubbio se mi burla o se mi lauda.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Burlar quando laudo la signora Celia? Io burlerei più tosto quand'io giuro a fé da generale.<pb n="715"/></p>
             <p>Vado per il signor Virginio, rimanghi lieta, ché oggi spero la vanità delle parole s'abbia a ridurre in generosità de' fatti.</p>
@@ -1432,25 +1475,25 @@ umilissimo servitore
             <hi rend="italic">con una lettera, e</hi>
             <hi rend="sc">celia</hi>
           </stage>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>È possibil che noss possa viver senza travai? e che 'l bisogna anc piass i fastidii d'olter? </p>
             <p>Bondì, signora Celia.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Bon dì. Ho visto costui, sì, sì. </p>
             <p>Che lettera è quella?</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Una lettera del signor Cinzi, che va alla signora Flaminia.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>La signora Flaminia è in casa nostra travagliata, disperata e anco leggiermente ferita. Io li dirò che tu gli vuoi parlare, aspetta non ti partire.<stage>(<emph>Ed entra</emph>)</stage></p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Ul signor Cinzi me ha datt caregh che la faci tornà a casa soa, e far che la lezi sto scartabel. Ma se no la 'l voless lezil, che farò io?</p>
           </sp>
@@ -1462,136 +1505,136 @@ umilissimo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">bagattino</hi>
           </stage>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Chi mi vuole?</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Mancaraff che ve piarav.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Orsù, manco ciancie, sei tu che mi domanda?</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Signora sì, ma no tant furiosa.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>La mia furia a te poco debb'importare. Che vuoi?</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Parlarve.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Parla, di' presto, né mi tener su le burle.<pb n="716"/></p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Se parli prest, a no m' poss fà ben intender, né dis delle zanze chi parla a proposit.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>O tu sei pontuale nelle risposte.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Sie' mo anca vu pontual ne l'ascoltarm?</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Orsù di'.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Ul signor Cinzi...</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Ohimè, che odioso principio!</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Ul fi' sarà fors amoros. Ul signor Cinzi, tutt afflitt, sconsolat e mez mort, m'ha chiamat.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Questi sono principii per rendermi curiosa di saper perché tante disgrazie. Io non le voglio sapere, poiché non possono andar disunite da quelle materie che mi rendono più di lui sconsolata e afflitta. E s'egli è mezzo morto, è un grand'avantaggio che hanno i suoi meriti, che lo ricercarebbero morto di molto tempo.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Augurémegli dal ben, per non av da pianzer ul so mal.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Hai tu altro che dirmi?</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Non ho ancora cominzat.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Comincia, e quanto prima finisci.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Me chiamò, com av diss, Cinzi e me diss: Bagattin, quel che mi no poss fà per impedimento de forze e per mancament de fiat, fal ti per quell'amor e per quell'affett, che ti ha semper mostrat alla signora Flaminia e a mi. Digli che la torni alla casa nostra, per non far savì a tutta la città i fatt noster, e dagli in man sta lettera che a volivi scriver con al mé sangu, se i amis non m'impediva.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Sue lettere? o questo no!</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Lézila e po' stràzzela.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Legger caratteri impressi da quella mano che mi voleva uccidere? chi mi consigliarebbe?</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Ah signora, che l'intenziù del signor Cinzi no ha mai peccat, se bè la colera l'ha fat parì peccador. Lézine dò righe sole.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Da' qui, vediamo quello ch'egli sa dire. </p>
             <p>«Amatissimo mio bene... », menti per la gola! Dir mio bene, quando egli sa che io mi sono avveduta ch'egli mi vuol male, sì per le parole udite, come per essermi poi<pb n="717"/> certificata dalla crudeltà de' suoi fatti, che s'egli non mi ha uccisa è stato per la cura che ha tenuto il Cielo di me.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Lézin un olter verset.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>«L'afflitt'anima mia, ohimè, avolta tra queste apparenze di colpe, che la possono rendere odiosa alla mia Flaminia (parendoli forsi somministratrice di costumi infedeli) non potrà mai respirare sino all'avviso della sua salute», avviso di salute di chi procurasti darli la morte? Piglia, ch'io non ne voglio altro.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Ohimè. Dò altre paroline.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>«Che quando tosto non l'abbia, niuno speri di più vivo rivedermi», vuol morir? Ah!</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Pur che 'l nun sia mort.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>«Io non niego, mia vita, che quell'amorose parole, che tu forsi potesti avermi udito dire a Celia, non possino esser state accenditrice di sdegno; ma non erano mie (testimonio il mio core, che mai vi concorse), ma sì ben dette ad istanza d'amico, il qual fece parer affetto di Cinzio quello che fu stimolo delle sue parole. S'io potessi più regger la penna, direi d'avantaggio, ma il dolor mi contamina lo spirito e indebolisce la mano.» E chi potrebbe legger con gli occhi asciutti parole così lacrimevoli? Ohimè, Bagattino.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Lezì ul rest, cara signora.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>«Dirò solo che il ritorno alla casa è tanto dovuto, quanto che non è ragionevole che il picciolo nostro bambino rimanghi senza la cara mamma», né meno debbe stare senza il caro babbo. Sustentami, Bagattino, e accompagnami in casa, ché quasi non mi posso più reggere. O affetto di madre, o credenza d'amante!</p>
           </sp>
@@ -1602,31 +1645,31 @@ umilissimo servitore
           <stage>
             <hi rend="sc">virginio, fritellino</hi>
           </stage>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Io non ho più dubbio che Flaminia non debb'esser mia.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Se l'avete in casa, non è vostra?<pb n="718"/></p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Riman solo ch'ella si contenta per non mi dar occasione di sforzarla.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Ne vengon sforzate puoche.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>E pur qualched'una...</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Qualcheduna lo dice, ma niuna vien creduta.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Battiamo e informiamoci da Celia del modo che dobbiamo tenir per scoprirci. Tic, toc.</p>
           </sp>
@@ -1636,79 +1679,79 @@ umilissimo servitore
           <stage>
             <hi rend="sc">celia, virginio, fritellino</hi>
           </stage>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Siete voi, signor cugino? e perché non venir in casa?</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Sarebbe stato forse meglio per più comodamente poterli dimandare della signora Flaminia. O bene, come sta, che dice?</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Per ora io non so quello ch'ella dica, poiché per quello ch'io mi sono avveduta è andata a casa sua, e, mi perdoni sua signoria, con qualche mancamento di buona creanza, non mi avendo pur detto a Dio.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>A casa è ita? e come si mostra alterata?</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Tanto che niuno lo saprebbe dir se non lei.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Si è riposata? ha male?</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Il suo maggior mal è nell'animo, luoco che non ha ricorso alle medicine ordinarie. L'infelice isvenì. Io la slacciai e con mille parole e baci la ridussi capace di consiglio, ché prima non era possibile il potergliene dare.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Si spogliò tutta?</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Si lasciò spogliar quelle parti che gli potevano render meno noiosa l'agitazione del male.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Male assai, eh?</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Una ferita, ma di puoco momento, che anco si sanarebbe con lo scordarsi di averla. Ma cercando per tutto il corpo per vedere se ve n'era più d'una, non ne trovai d'altre.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Non dovesti cercar bene.<pb n="719"/></p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Cercai, e ne l'usar diligenza più che ordinaria, viddi (ohimè viddi) un neo, ch'ella tiene sotto la zinna manca, che fieramente mi violentò l'animo e ordinò alle labra che per tributo li dessero mille baci. Egli non si spiccava punto dall'avvorio delle sue carni, ma v'era impresso qual stella fissa nel cristallino di quel corpo, ch'io non so dir se sia cielo o pur s'io la debba chiamar materia terrestre come son l'altre, che so io? Orsù, non più di questo.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Sotto la zinna manca?</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Sì, sotto la zinna manca.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Seguitate il vostro discorso.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Io la rivestei, la ribaciai, e tanto mi sono rimaste impresse le sue bellezze, ch'io mi sono mortificata l'opinione ch'io aveva di esser bella anch'io. Me n'entro, per andare a baciar anche quel luoco tocco dalla divinità di quelle membra, che sono pure insidiatrici dell'idolatria del suo bello.<stage>(<emph>Lei entra</emph>)</stage></p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Scopritevi alla signora Flaminia, senza pur perdere un momento di tempo, ch'io vado per por all'ordine una tal invenzione, la più criminale che mai sia stata posta in opera ne gl'atti civili de gl'amanti.<stage>(<emph>via</emph>)</stage></p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Guarda di far bene, accioché il civile non divenga poi criminale, per te, poiché ne gl'atti civili de gl'amanti, non comprendo che v'abbia luoco la criminalità delle tue invenzioni. Ma come dirò, e come? e come mi scoprirò con Flaminia? adulterò dell'amicizia ch'io tengo con Cinzio? La dottrina di Fritellino, dettami nel principio, è quella che può esser legge a gl'amanti. Tic, toc.</p>
           </sp>
@@ -1721,36 +1764,36 @@ umilissimo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">virginio</hi>
           </stage>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Non è in casa il signor Cinzio.Volet'altro?</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Voglio lei, e non compiacendosi di udirmi, gli dirò cosa che forse non gli dispiacerà.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Ancorch'ella fusse per dispiacermi, temperarei il dispiacere con l'intendere che a lei piace di parlarmi.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Dovendo imprimere le mie parole nel più vivo del cuore della signora Flaminia, bisognarebbe ch'io avessi una suavità di concetti, che dolcemente la rendessero capace ch'io non posso di meno di non amarla, sì per l'obligo commune che ogn'un tiene di amarla, sì per quello che è poi mio solo, per non poter vivere senza servirla. È gran tempo che lo stimolo della mia salute mi sprona di venirla a ritrovare, ma dubitando che Cinzio non rimanesse offeso per l'amore ch'io mi credeva che vi portasse, ho taciuto sin qui, e forse non averei mai detto nulla, s'io non mi fussi accertato de i suoi mancamenti. </p>
             <p>Vengo adunque a supplicarla di voler dar luoco nella sua memoria a chi non è mai per scordarsi la grandezza de' suoi meriti.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Io ho rassunto dall'infedeltà del vostro discorso come vorresti ch'io tenessi Cinzio per infedele, la qual cosa potendo anche essere, ed essendo di ragione che l'una e l'altra si palesi in fronte del mondo, sarà necessario il dar principio dalla vostra temerità di soverchio biasimevole per non dir infame, e perché Cinzio sappia ch'io so i suoi mancamenti, li dirò che me gli avete scoperti.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Ohimè, ch'io perdo in uno l'amico e l'amata, meglio è ch'io occida costei.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Io gli dirò insieme...</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p><stage>(<emph>mette mano al pugnale</emph>)</stage> Che gli dirai, scelerata?</p>
           </sp>
@@ -1766,15 +1809,15 @@ umilissimo servitore
             <hi rend="sc">flaminia</hi>
           </stage>
           <stage>(<emph>Virginio sotto occhio vede Cinzio e dice</emph>)</stage>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Questo pugnale sia la mia morte, se il signor Cinzio non vi ama di tutto cuore.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>O amico caro, o uffizio degno di un animo nobile com'è il vostro!<stage>(<emph>E l'abbraccia, poi rivolto a Flaminia, entrano</emph>)</stage></p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Né anche Fritellino avrebbe saputo trovar così subbito un partito così bello. Pur ch'ella non gli dica ora il tutto. Forse che no. Ecco Fritellino.</p>
           </sp>
@@ -1786,15 +1829,15 @@ umilissimo servitore
             <hi rend="italic">con una lettera, e</hi>
             <hi rend="sc">virginio</hi>
           </stage>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>O io l'ho trovata bella!</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>O se tu sapessi, fratello, mi è pur intervenuto la bella cosa! Orsù, te la dirò poi. Che lettera è quella?</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Questa è una materia che ti renderà gustatissimo, sappi. O ecco gente.</p>
           </sp>
@@ -1804,53 +1847,53 @@ umilissimo servitore
           <stage>
             <hi rend="sc">capitano, virginio, fritellino</hi>
           </stage>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Bondì. Io son venuto per la risposta.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Che termini son questi? </p>
             <p>Attaccàtela, dite che non sapete ciò che si dica.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Ma s'io lo so.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Attaccàtela, ché so io perché.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Non so che vi dichiate di risposta.<pb n="722"/></p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Non mi avete promesso la signora Celia per moglie?</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Dite: «Menti per la gola! ».</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>È troppo, lascia dir a me. </p>
             <p>Io non me lo ricordo.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Signor Virginio, non dite ch'io metta mano, ché me la vorresti aver data prima che promessa.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Ho la spada anch'io.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Metti mano!</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Eccomi.</p>
           </sp>
@@ -1865,52 +1908,52 @@ umilissimo servitore
             </add>
           </stage>
           <stage>(<emph>Cinzio difende Virginio.Fritellino si lascia cader la lettera</emph>)</stage>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Io non voglio ammazzar tanti in una volta.<stage>(<emph>E via</emph>)</stage></p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>I pari miei non fanno il ruffiano.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Che differenze sono le vostre?</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Lasciatele dire a me, signor Virginio.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Di', ché se bene le so, tu lo sai meglio di me.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Quel Capitano Cucuzza mi aveva data quella lettera, ch'io ho poi gettata in terra, acciò che io la portassi alla signora Flaminia.</p>
           </sp>
           <stage>(<emph>Cinzio piglia la lettera</emph>)</stage>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Questa lettera?</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Signor sì, e mi soggiunse: "Né ti creder di far offesa alla signora Flaminia, poiché ella non ha altro gusto che il legger le mie, anzi ch'io ti assicuro che ne trarrai non solo mille benedizioni, ma buona mancia ancora, poi che la nostra prattica è di molti mesi".</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Non più, io ho inteso abbastanza. Il prenderne vendetta sarà pensier mio.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Mi dispiace de i vostri disgusti.<stage>(<emph>E via</emph>)</stage><pb n="723"/></p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Anc a mi.<stage>(<emph>E via</emph>)</stage></p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Voglio veder un poco la leggiadria de i concetti. «Non v'ha titolo che arrivi a i gran meriti di vostra signoria, onde dirò solo: anima di questo corpo, poiché lontano da lei vivo quasi disanimato, e di già sarei morto, se quel fiato, ch'io ricevei dalla sua bocca in virtù di quel bacio che mi diede, non mi avesse alimentato sin ora. Non gli sarà adunque discaro di trovar modo, ond'io possa la notte a ventura venire a ricevere nuovo alimento e a ribaciar quel neo dilizia di queste labra... », ohimè, ch'io non posso più, «le quali non osano di accostarsi più ad altr'oggetto, per non offender la grandezza del suo gran merito. Non sarebbe gran cosa che quel Cinzio... », quel Cinzio? «non venisse a casa questa notte, avendo inteso ch'egli ha fatto la pace con suo padre? » Io so che va ispiando tutti i fatti miei. Io... non occorre l'andar moltiplicando i disgusti con la lunghezza del leggere. A i rimedii! Ma che rimedio si può pigliare ad un caso seguìto? Altro non saprei che mi fare, salvo che con la lor morte dar la gloria in mano della vendetta. Morirai, indegna, e s'io morrò, sarà solo per non lasciarti senza le mie persecuzioni anco nell'altra vita.</p>
           </sp>
@@ -1921,29 +1964,29 @@ umilissimo servitore
             <hi rend="sc">pantalone, cinzio</hi>
             <hi rend="italic">tutto suspeso</hi>
           </stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Non ho mai più visto Cinzio da i zinquanta zecchini in qua. Mi vago dubitando de no ghe aver pagao el viazo d'andarse con Dio, con qualche morosetta. Ma eccolo, tutto sospeso estatico. </p>
             <p>Cinzio? o Cinzio? Cinzio? Ti no rispondi.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>O quanto faresti meglio a levarvi di qui, prima ch'io vi rompi il naso con un pugno.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Costui parla, ma nol me vede, né sa chi el diga ste parole. Cinzio, fio mio, sappi che t'ho maridao in un partio tanto bon, che ti medemo non saveresti desiderar meio.<pb n="724"/></p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Fio mio te ho maridao? Andeve a far dar un boio al cervello!</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Un boio al cervello? Vago in casa a tior un baston per darte un boio alle spalle, forfante insolente!</p>
           </sp>
           <stage>(<emph>Cinzio non lo guarda mai, e doppo partito dice</emph>)</stage>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Chi era costui che mi rompeva il capo? Orsù, Cinzio, non è più tempo di star su le considerazioni, ma determinatamente lasciar i dubbii e porsi con ogni fretta alle vendette di quel Capitano. O eccolo là.</p>
           </sp>
@@ -1954,7 +1997,7 @@ umilissimo servitore
           <stage>
             <hi rend="sc">dottor</hi>
           </stage>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>Am vuoi andar a vder quel che fa la signora Flaminia. Che pagn son questi? O che bel fraiol, al i è anc al capel, e si al n's' ved al patron, am vuoi vestir un poch suldadescament.</p>
           </sp>
@@ -1968,15 +2011,15 @@ umilissimo servitore
             <hi rend="sc">dottor</hi>
           </stage>
           <stage>(<emph>Pantalon, credendolo Cinzio, lo bastona, e dice</emph>)</stage>
-          <sp>
+          <sp who="#pantalon">
             <speaker><emph rend="sc">pantalon</emph>.</speaker>
             <p>Tiò forfante, impara de responder a to pare!</p>
           </sp>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>Non più, caro signor padr.<stage>(<emph>E via</emph>)</stage></p>
           </sp>
-          <sp>
+          <sp who="#pantalon">
             <speaker><emph rend="sc">pantalon</emph>.</speaker>
             <p>L'ho io castigao sto furbo.<stage>(<emph>E via</emph>)</stage><pb n="725"/></p>
           </sp>
@@ -1989,7 +2032,7 @@ umilissimo servitore
           <stage>
             <hi rend="sc">dottor</hi>
           </stage>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>Ch' vuoia è vgnù a mio padr d' vegnirm a bastonar, ch'è trent'an che l'è mort e fuor che 'l n'mnava l' man? Se gh' diff vgnir in ment ch'una volta am diss a un mia fradel fiol d'un bech?</p>
           </sp>
@@ -2002,12 +2045,12 @@ umilissimo servitore
             <hi rend="sc">dottor</hi>
           </stage>
           <stage>(<emph>Cinzio senza parlarli leva le sue robbe d'intorno. Dottor non parla e si lascia levar il tutto, poi con una bella riverenza si parte</emph>).</stage>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>E come sono capitate queste robbe in man di costui? Ah, sì, io mi ricordo che quasi pazzo lo gettai a punto in questo luoco. Oh lettera, lettera impressa de quei caratteri che furono originati dal tuo cuore a pregiudizio della mia vita e a distruzione de l'onor mio! Ma sì come io non ho più nulla di tuo, avendo tu donato ciò c'hai di buono a quel Capitano (sì come ho letto meglio su la tua), né tu ragione<pb n="727"/>volmente devi aver nulla del mio. E prima che tu dia principio a mal trattar Carluccio mio, voglio che tu me lo renda. Dico mio, poiché in quel tempo so che tu non avevi mezzo adulterati i pensieri, né sapevi che al mondo ci foss'altri per te che Cinzio solo. Ora lo voglio, né voglio tardar un momento a levartene il possesso. </p>
             <p>Tic, toc, o di casa!</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Sarà forse uno di quelli amici fedeli.</p>
           </sp>
@@ -2019,19 +2062,19 @@ umilissimo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">cinzio</hi>
           </stage>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>O siate il benvenuto, io ho pur da dirvi le gran cose. Par che siate alterato, che avete?</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Chiama Carluccio.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>E perché?</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Bagattino, Bagattino.</p>
           </sp>
@@ -2043,23 +2086,23 @@ umilissimo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">flaminia</hi>
           </stage>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Che me comandef, signur?</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Presto, va e conducimi qui Carluccio.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Vaghi e vegni adess adess.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Non offendete la ragione con lo soverchio esser alterato. Che novità è questa?</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Non hai ancora provato la mia alterazione.</p>
           </sp>
@@ -2071,19 +2114,19 @@ umilissimo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">carluccio</hi>
           </stage>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Eccol, che 'l voliva far la cacca.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Vien meco, ché il luoco de gl'angeli non è tutt'uno con quello delle furie. <stage>(<emph>Lo porta via</emph>)</stage><pb n="728"/></p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Cinzio, Carluccio? cor mio? ohimè, che sorte di furto è questo? rubbarmi l'anima? dove s'intese mai la ferità di quest'uso sacrilego? Cinzio avverti, ch'è tuo, non lo niego, ma che però è anco mio; onde del pari lo dobbiamo godere senza pregiudizio delle comuni ragioni. Ah, che non è tempo di dimorarsi, ma di seguirlo, e farmi restituire quello che non mi poteva levare.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Questa è una lit, che ha molt del stravagant. Cinzi ha purtat via ul putel per no tornà più, Flaminia ul seguita e starà via un gran pez, la casa è vuoda de zent e piena de robba. Chì ghe va fà 'l consei e intender quel che dis Franceschina. </p>
             <p>Tic, toc. Franceschina? o Franceschina.</p>
@@ -2096,51 +2139,51 @@ umilissimo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">bagattino</hi>
           </stage>
-          <sp>
+          <sp who="#franceschina">
             <speaker><emph rend="sc">franceschina</emph>.</speaker>
             <p>Che furie son queste?</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>La fortuna, che ha pressia de sbrigàn de povertà.</p>
           </sp>
-          <sp>
+          <sp who="#franceschina">
             <speaker><emph rend="sc">franceschina</emph>.</speaker>
             <p>E come? Di', presto.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>A sem patroni della casa, dal momebel, se però stem stabil int'al portal via.</p>
           </sp>
-          <sp>
+          <sp who="#franceschina">
             <speaker><emph rend="sc">franceschina</emph>.</speaker>
             <p>Ce l'hanno donato?</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>No, i ne l'ha lassat.</p>
           </sp>
-          <sp>
+          <sp who="#franceschina">
             <speaker><emph rend="sc">franceschina</emph>.</speaker>
             <p>E che son morti?</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>I è vini tutti dal cervel in fuora, che 'l se gh'è svanit e lor gh'è cors dré.</p>
           </sp>
-          <sp>
+          <sp who="#franceschina">
             <speaker><emph rend="sc">franceschina</emph>.</speaker>
             <p>O tu m'intrichi.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>A te digh che Cinzi ha portà via Carluzz. Flaminia è tegnù dré a tutti dò, al negozzi è desperad, la robba è in<pb n="729"/> le nostre man, che se anca nu no perdem al zervel, me par che la n'posse servì inte i noster bisogn, che puol vegnì a remedià anc ai present.</p>
           </sp>
-          <sp>
+          <sp who="#franceschina">
             <speaker><emph rend="sc">franceschina</emph>.</speaker>
             <p>O bene, come faremo?</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Vender tutt. Che se a sort i se tornass accordà, che i se accordi anc a comprà de l'altra robba.</p>
           </sp>
@@ -2148,170 +2191,170 @@ umilissimo servitore
         <div type="scene">
           <head rend="italic">SCENA VII</head>
           <stage><hi rend="sc">pantalone</hi>, <hi rend="italic">non conosciuto da loro,</hi><hi rend="sc">bagattino</hi><hi rend="italic">e</hi><hi rend="sc">franceschina</hi></stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Come quel furfant de Cinzio se lassò bastonar senza quasi muoverse mai? Forsi che fu per obedienzia. O e son pur bestial in le mie ressoluzion (podeva anco far de manco de darghe).</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Quest'om ne savrà fors insegnà chi comprarà le robb.</p>
           </sp>
-          <sp>
+          <sp who="#franceschina">
             <speaker><emph rend="sc">franceschina</emph>.</speaker>
             <p>Ci vuole una qualche invenzione, per non parer che le robbiamo.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>L'ho bella e trovada.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Costù ha ciera del solenissimo furbo.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Signor, un mé parent, che è mort, m'ha lassat certi mobili, che voraf mo venderli. Com'hoi da fà, perché mi no son pratich della terra?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Bisogna mostrar el testamento del parent, per veder s'el xe la veritae, ch'el vi abbia lassai.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Al dir ul vira, i è mobei d'un mé patrù, che è andat fuora della città e me ha dat ordine che i vendi.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Bisogna che ti mostri l'ordine in scritto. E però, a dirte al vero, compro anca mi robbe, ma no compro se non robbe rubbae.</p>
           </sp>
-          <sp>
+          <sp who="#franceschina">
             <speaker><emph rend="sc">franceschina</emph>.</speaker>
             <p>Di questo abbiamo bisogno noi.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Signor, per non avì testament, né mandat, fé conto che l'abbia rubbat e comparé vu.<pb n="730"/></p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Dove xele?</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>In quella ca', che a dirv al vira ghe stava un gentilom chiamat ul signor Cinzi, fiol d'un tal vecchiazz, beccù cornut, avar, spilorz, miser, al qual, avend una murusa, bisognava per mantegnirla rubbar in casa, stocchizà con i amisi e far quel fa un pover zoven fiul d'un pader sassin.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>No lo inzuriar tanto! Come hallo nome?</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Polenton, Pelizon, Poltrunzon... no, no, Pantalon! un nom infin da scopazzon.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Orsù tornemo alle robbe, dove xele? Vedemole.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Aspetta, Franceschina, che a vegni adess adess.<stage>(<emph>Entrano</emph>)</stage></p>
           </sp>
-          <sp>
+          <sp who="#franceschina">
             <speaker><emph rend="sc">franceschina</emph>.</speaker>
             <p>Il Cielo ce la mandi buona. Se i patroni tornassero mentre che siamo su la vendita, bella frustatura per me e solenne galera per Bagattino. Ma io direi di non ne saper nulla, in ogni modo io non ho parlato e non ho contrattato con questo vecchio né con altri.</p>
           </sp>
           <stage>(<emph>Pantalon parla in casa</emph>)</stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Sto pavaion, che credeva che fosse in le altre mie robbe da inverno, xe vegnuo a sborarse in sta casa che no cognosco. E ste spagliere, che ho dao la colpa a più de diese, che me le abbia robbae?</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Messer, o messer, vegnì de qua, che el gh'è dell'altro, robba bona.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Me basta d'aver visto sin qua. Andemo fuora a far el mercao.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Andém.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Quanto vustu de tutto?</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Cent trenta sett scud e un terz.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Robba che me costa a mi più di zinquezento. Te ne voio dar ottanta.<pb n="731"/></p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Cossa è più, ottanta o zent?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Zento xe vinti più de ottanta.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Ghe ne voio donca ottanta e po' vinti.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Orsù, tiò questi a bon conto. Dame la chiave della casa, che vago per il restante.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Mo perché volif la chiav?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Per esser seguro che ti no vendi le robbe a qualchedun altro.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Non so fà poltronerie. Eccov la chiav.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Mostra quei soldi, che te i voio dar tutti in tanti zecchini traboccanti.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Tolì, demen assé.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Quel Pelizon, Poltronzon (ma però Pantalon) son mi; quel vecchio spilorzo, becco, cornuo, non son mi, el xe to pare! Furbo, laro, nassuo per le forche e la frusta.</p>
           </sp>
-          <sp>
+          <sp who="#franceschina">
             <speaker><emph rend="sc">franceschina</emph>.</speaker>
             <p>Questa vien a me.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Xe poco a i to meriti, ma adesso vago a formar una querela dalla qual ensirà una sentenzia che forsi gramo quando ti sii nassuo! E ti, porca, putana, poltrona, ruffiana, strega, te vogio far metter su l'aseno con la coda in man, e darte una frustadura, che te serva per memoria, e al popol per esempio.</p>
           </sp>
-          <sp>
+          <sp who="#franceschina">
             <speaker><emph rend="sc">franceschina</emph>.</speaker>
             <p>Signor, io non ce ne ho colpa, ma sì ben quel ribaldo, il quale, ripreso da me, voleva ammazzarmi. E quante volte ho conteso con te dicendo: il signor Cinzio è figlio di un uomo da bene, ché così dice tutta la città? Non ti voglio più vedere, ché le tue furbarie mi avvelenano. </p>
             <p>A Dio signore, il Cielo v'ispiri a conoscermi. <stage>(<emph>E via</emph>)</stage></p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Isquisitissima mariuola, astutissima poltrona, che xe questa. </p>
             <p>E ti, furbo, lievate de qua, puo' che me resolvo de lassar ch'el Cielo te gastiga.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>A credi, signor, che ve sie' accort che non so fà ul lader, se ben ul bisogn me voliva insegnà. <stage>(<emph>E via</emph>)</stage></p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>O mondo, o Cinzio, o robbe, o furbi, o accidente, che in vero me ha disciplinà 'l giudizio a non incolpar né a<pb n="732"/> far reo de cause criminal mai più nissun, se prima con el levar la fede alle relaziò, no lasso luogo che giusto abbia spazio de comparir. No truovo però scusa per Cinzio, qua dentro ghe xe la domestichezza de i furti, qua ghe giera la signora e qua xe il tempio de tutt i so mancamenti e qua xe la dogana, dove se desgabellava tutte le poltronerie che se faseva in casa mia.</p>
           </sp>
@@ -2319,51 +2362,51 @@ umilissimo servitore
         <div type="scene">
           <head rend="italic">SCENA VIII</head>
           <stage><hi rend="sc">flaminia</hi><hi rend="italic">in abito di serva</hi>, <hi rend="sc">pantalone</hi></stage>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Io non saperei trovar abito proporzionato alle mie miserie, anco ch'io vestissi quello della necessità. O Flaminia, se la divisione dell'anima da questo corpo è di tanto dolore, e qual dolore debb'esser il tuo, che con uno non più inteso modo hai un'anima tripartita? e ogni parte così alienata, che non puoi trovar modo di unirle? Cinzio in virtù d'amore ne tien una, l'altra in virtù dell'odio te l'involò con il figlio, e tu sei rimasta con quella sola porzione che non ti basterebbe per vivere, se chi te la diede non la facesse servire per un'anima intiera.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>L'uso della curiositae me ha fatto fermar per saver le cause delle lamentazion de quella povera zovene. Bonzorno fia.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Buon anno, mio signore.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Che aspetto, che maestae, che portamento? ma non halla un'illustrissima depenta nella fronte? Me sento una violenza d'offerirghe 'l mio servizio, che me sforza a lassar 'l pensier de i mii affari e tutto dedicarme a i so comandi.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Vostra signoria non se maravigli se così immota me ne sto, quasi ch'io non avessi a far nulla, poiché il molto che fare mi confonde il modo di ritrovar la via per dar principio.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Le vostre passion me ha de muodo intorbidao l'arbitrio, che ad altro nol me lassa pensar che nell'impiegarme ne i vostri commandi.<pb n="733"/></p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>La pregarei a farmi grazia di ritrovarmi una casa onorata per potervi fedelissimamente impiegare il mio servizio.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>El Ciel ve ha de zà provisto d'un liogo dove poderé comandando farve obbedir.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Il mio merito non arriva tant'oltre.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Gl'ordini del Ciel conferisce i meriti e dona le comoditae. Fé conto che mi sia istromento della divina disposizion e che quello sia el liuogo determinao all'esercizio de i vostri meriti.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Io non posso altro che credere che voler divino vi abbia eletto istromento per solevar le mie passioni, le quali, con aggio maggiore, vi narrerò entrati che saremo in casa.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Entremo, ché reposada me diré puo' quello che v'importa e che più ve preme.</p>
           </sp>
@@ -2376,31 +2419,31 @@ umilissimo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">carluccio</hi>
           </stage>
-          <sp>
+          <sp who="#carluccio">
             <speaker><emph rend="sc">carluccio</emph>.</speaker>
             <p>Pappa, io ho fame. Vorrei veder la mamma.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Mangiarai, figliuol mio, ma della mamma non ne parlar, m'intendi?</p>
           </sp>
-          <sp>
+          <sp who="#carluccio">
             <speaker><emph rend="sc">carluccio</emph>.</speaker>
             <p>Perché, che gl'ho fatto? Son pur anco stato buono.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Foss'ella così buona, come se' tu.</p>
           </sp>
-          <sp>
+          <sp who="#carluccio">
             <speaker><emph rend="sc">carluccio</emph>.</speaker>
             <p>Mo ella non grida mai, se non quando non ci è pane e ch'io ho fame.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Orsù taci, ch'io ti portarò in luoco dove starai meglio che con la mamma.</p>
           </sp>
-          <sp>
+          <sp who="#carluccio">
             <speaker><emph rend="sc">carluccio</emph>.</speaker>
             <p>Voglio la mamma io, mamma, mamma.</p>
           </sp>
@@ -2412,15 +2455,15 @@ umilissimo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">cinzio</hi>
           </stage>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Eccomi, figlio. <stage>(<emph>Lo piglia per un braccio</emph>)</stage></p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Lassalo, traditrice!</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Menti per la gola, scellerato!</p>
           </sp>
@@ -2435,38 +2478,38 @@ umilissimo servitore
             </add>
           </stage>
           <stage>(<emph>Pantalone in casa dice</emph>)</stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Che romori sent'io in strada?</p>
           </sp>
           <stage>(<emph>Cinzio, udendo il padre, fugge</emph>)</stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p><stage>(<emph>in strada</emph>)</stage> Che romori? che fio xe questi?</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Ecco cessato una gran parte del mio dolore ed ecco in questo solo oggetto la tregua de gl'infiniti miei dispiaceri. Signore, questo è mio figlio, involatomi da un barbaro che quasi mi aveva ridotta fuor di me stessa, e con molta ragione, poiché se fuori della mia vita v'era il figliuolo ed entro alle viscere la barbarità del furto, e come potea io non esser tutta contaminata? Ora mi sono in gran parte riauta. Baciami, caro il mio bene, bacia la tua mamma, figlio.</p>
           </sp>
-          <sp>
+          <sp who="#carluccio">
             <speaker><emph rend="sc">carluccio</emph>.</speaker>
             <p>Mi aveva pensato di andar sempre gridando mamma così forte, ché, se fosti anco stata su 'l tetto, m'avresti sentito.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Cara lenguetta, caro bambino, mo chi no xe innamorarave in quelle care parolette de zuccaro? Portelo in casa, ché vegno anca mi.</p>
           </sp>
           <stage>(<emph>Flaminia e Carluccio entrano in casa</emph>)</stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Voio tior sta fia per moier, per governo e per caritae, e lassar che Cinzio fazza anch'esso a so modo. Mo come me chiamerà sto fantolin? Babo, pare, missier? El par che quel missier se asseta meio a sta etae, de tutti i altri nomi.</p>
           </sp>
           <stage>(<emph>Carluccio in casa dice</emph>)</stage>
-          <sp>
+          <sp who="#carluccio">
             <speaker><emph rend="sc">carluccio</emph>.</speaker>
             <p>Missere, missere, ove siete?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Vegno fio, vegno. Orsù, sou 'l missier.</p>
           </sp>
@@ -2479,75 +2522,75 @@ umilissimo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">capitano</hi>
           </stage>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Voi Dottore? esercitate l'avvocato? o siete giudice? o pur un uomo vestito così per far ridere?</p>
           </sp>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>A son Dottor, a so far l'avocat, e sì a spier d' far al zuds per mandarv in galea a farv pianzer.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Io non intendo la scabrosità di questa vostra lingua. Ditemi, conosceresti voi il Dottor Graziano?</p>
           </sp>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>A n' al cgnoss.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Bisogna conoscerlo, trovarlo, parlarli e dirli che non vadi questa notte a casa, per quanto egli ha accaro di levarsi domattina; se però egli ha negozii in Europa, poi che voglio portar la sua casa in Affrica con Celia mia moglie, di dove l'ho fatta regina di tutto quel paese.</p>
           </sp>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>Celia sa 'la sta vostra deliberazion?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Chesto signor no, io voglio fare il tutto all'improviso.</p>
           </sp>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>I aviv mai parlà?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Io gl'ho data la fede sino in Bologna, ho poi ratificata in questa città.</p>
           </sp>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>I aviv dit di condurla in Affrica?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Signor no. Io glie lo voglio dir poi, per il cammino.</p>
           </sp>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>Mo com purtariv la casa?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Con un soffio la anderò spingendo per l'aria sino che arriviamo alla nostra reggia.</p>
           </sp>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>A dir al vera a son so barba e son 'l Dottor Grazian. Av la concied con pat ch'av voi andar in casa, andar a let e dormir sin a tant ch'am dsì: a sem in Affrica.<pb n="736"/></p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Vostra signoria, padre, volsi dir zio, della regina Celia? Io mi risolvo di far le nozze in questa città, a fine che voi possiate regalar tutt i Dottori, per poterli poi far un privilegio, che hanno mangiato alla mia tavola. Io vorrei parlarli.</p>
           </sp>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>Chi v' tien? n'i aviv tuccà la man senza mi?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Signor sì.</p>
           </sp>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>Mo tucai anc 'l rest. O d' casa?</p>
           </sp>
@@ -2559,52 +2602,52 @@ umilissimo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">capitano</hi>
           </stage>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Che addimandate signor zio?</p>
           </sp>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>An dimand nient mi, l'è chì al re d'Affrica ch' dmanda la regina.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>O signor Capitano.</p>
           </sp>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>L'è calà d' condizion.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Iscusatemi, ch'io non vi aveva veduto.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Il signor Dottor sa ben quello ch'io aveva pensato di fare, ma mi son mutato di pensiero.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Vi par che ci ritocchiam la mano in presenza del signor zio?</p>
           </sp>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>Bisogna toccar quel che n'v' sid tucà, perché la man av la tuccassi sina in Bologna.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>È vero, che ci rimane dunque che fare?</p>
           </sp>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>Quel che n'è fat. Andanv in casa, ch' la natura v'insegnerà 'l rest.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Andiamo monarchessa delle donne e moglie del monarca delle milizie.</p>
           </sp>
           <stage>(<emph>Entrano</emph>)</stage>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>Da chì a poch, la monarchia sarà stracca.</p>
           </sp>
@@ -2617,99 +2660,99 @@ umilissimo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">fritellino</hi>
           </stage>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Io voglio Flaminia in tutti i modi. Vada la robba, non si estimi la vita, e se l'onor patisce, abbia pazienza anco lui ché Amor non guarda ad altro che al proprio interesse.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Se la robba se ne va, la vita riman tribulando; e un corpo tribulato dalla povertà non serve all'onore per altro che per una carcere secreta che non lo lascia venir mai alla luce.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Come faremo per aver Flaminia?</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Non la volete per goderla, o per amor o per forza?</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Sì.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Godendola non la disonorate?</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>La vorrei per moglie io.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Ed ella non vuol voi, adunque non puol essere.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Pigliamola adunque a disonorare.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Dovendola disonorare, disonoratevi per meglio disonorarla.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Forfante, disonorarmi?</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>E che? crederesti forsi d'onorarvi con il furto d'una donna che non vi vuole? E questo non è meno lo intiero disonore ch'io son per dirvi.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Che ci è di peggio, o di più grave, che non possi esser stato commesso da chi professa e spende il nome di uomo onorato?</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Si spendono anco tante doppie per buone e pur son false. Orsù a i fatti nostri. Sapete quello che bisogna che di necessità voi facciate? Ve lo dirò: bisogna che amazziate Cinzio.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Ohimè, questo non mai.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Lasciatelo dunque far a lui?</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>E come?<pb n="738"/></p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>E che, voi dubitate forsi che Cinzio non vi amazzi, accorgendosi che l'insidiate la donna? o pur almeno non v'impedisca che non l'abbiate, la qual cosa (secondo voi) sarebbe pur anche una ferita mortale?</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Lo farei poi anche, quando il mondo potess'aver qualche sodisfazione intorno al perché, onde non si dicesse che io l'avessi fatto solo per levargli la donna.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Io ho per la mente un perché tanto onorato, che al dispetto dell'essere, parerete uomo da bene.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Nel parere consist'oggi l'importanza. Se così è, facciamolo.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Voglio che sparghiam voce che Cinzio si vanta di goder Celia, vostra cugina, e io trovarò doi uomini da bene che giureranno di averlo udito.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>O bello, o buono, o ingegno nato solo per dar consiglio! Io al primo incontro senza parlare li darò una pugnalata.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Eccolo che viene. Animo, ardire, coraggio!</p>
           </sp>
@@ -2732,93 +2775,93 @@ umilissimo servitore
             </add>
           </stage>
           <stage>(<emph>Flaminia per di dietro li leva il pugnale, che non lo vede e dice</emph>)</stage>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>O traditore!</p>
           </sp>
           <stage>(<emph>Cinzio si volta</emph>)</stage>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p><stage>(<emph>subito dice</emph>)</stage> Traditrice sei tu, che vuoi occidere uno amante di cui certo sei indegna!</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Ah scelerata!</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>La cosa s'intriga.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>E perché a me questo?<pb n="739"/></p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Uditemi due parole.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Non debbe parlare chi è indegna di aver tanto parlato.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Concedetemi in grazia ch'io parli, per non vi aver a pentire di non mi aver lasciato parlare.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Di', ma di' presto.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Ditemi, la casa non è l'albergo di chi ci sta?</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Che proposito? Sì, che vòi tu dire?</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Quel fodro, che tiene a canto quel traditore, è l'albergo di questo pugnale, con cui vi voleva tradire. Io glie lo levai, acciò non vi togliesse la vita. Se questo è l'errore, condannatemi, ma leggete prima nel suo volto il processo del suo mancamento.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Non più, il caso è tanto apparente, che ogni negativa sarebbe una irriverente bugia in offesa della purissima innocenza di Flaminia, tradita da me in tante guise, che il solo accennarle sarebbe il martiro di ogni anima ben composta. Io ho amato con ogni sfrenatagine la bella Flaminia e dalla perfida natura di un mio servo ebbi per consiglio...</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Non è tempo di star più qui.<stage>(<emph>E fugge</emph>)</stage></p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Ebbi, dico, per consiglio di romper il rispetto all'amicizia e d'esser sollecito persecutore del signor Cinzio, da me per altro tempo osservato e riverito quanto le mie forze mi permettevano (se non quanto il suo gran merito richiedeva). Fui invitato da quel perfido a persuader vostra signoria di amorosamente parlare in tempo di notte a quella dama, per far che la signora Flaminia, ingelosita, si fuggisse di casa. Successero qui intorno diversi accidenti, che ridussero il caso in una disperata risoluzione di ferir Flaminia, la quale salvata (a persuasione del signor Cinzio) dal Dottor mio zio, fu poscia ridotta in casa e in letto, dove poi Celia mia cugina la spugliò e li fece quella poca servitù che la picciol offesa del ferro per allora ricercava. Viddi Celia (e semplicemente mi riferì) un tal neo sotto la zinna manca alla signora Flaminia, e con parole (puramente adescatrici) me lo rappresentò in guisa ch'io immediate mi sentii rapire di grembo alla ragione e precipitare nelle braccia della lascivia. Sopra di questo<pb n="740"/> neo fu, dalla diabolica natura di quel mio servo, fabricata una perfidissima invenzione (che senz'altro il demonio non era capace di una così perfida dottrina) e fu che in nome di un tal Capitano si dovesse formar una lettera amorosa nella quale descrivesse la bellezza del neo, la grazia più volte ricevuta di ribaciarlo e molt'altre bugie, che unite, la morte a pena bastarebbe per indice di quel male che merita quel ribaldo. Mi fece poi fare quella spropositata quistione sotto spezie di difensore della sua dabenaggine, che non arebbe permesso ch'egli portasse lettere amorose. Mi consigliò il medesimo traditore ch'io vi occidesi sotto certi pretesti che vi avantavate di goder Celia, che so io? Orsù, non più, poiché non è di dovere che più viva un aperto occisore della fama di Flaminia, un pubblico distruggitore della vostra quiete, e un deliberato occisore della vostra vita, la quale tanto è viva, quanto che il Cielo l'ha conservata come innocente.</p>
           </sp>
           <stage>(<emph>Cinzio abbraccia Flaminia</emph>)</stage>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Non si tratti più di colpe, essendo rassunte tutte in</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Non si tratti meno di castigo, essendo offizio del Cielo. Trattisi adunque solo di perdoni, essendo uffizio di quell'uomo onorato, non conosciuto da chi usa di far vendetta.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Io non poteva essere ben conosciuta da voi, se non con il mezzo di questo che ha posto il suo onor a sbaraglio per conservazione del mio.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>Sapendo di non meritar perdono, io sto anco in dubbio di averlo ottenuto.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Il Cielo faccia l'istesso e sarete sicuro del castigo.</p>
           </sp>
-          <sp>
+          <sp who="#virginio">
             <speaker><emph rend="sc">virginio</emph>.</speaker>
             <p>A Dio, signori.<stage>(<emph>E via</emph>)</stage></p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Ohimè, la porta de mio padre si apre. O il mio padrone esce di casa.</p>
           </sp>
@@ -2830,31 +2873,31 @@ umilissimo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">flaminia</hi>
           </stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Dove seu, fia mia?</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Son qui, signore.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Che feu qua in strada?<pb n="741"/></p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Mi pareva che fusse stato battuto alla porta, ma non fu poi vero.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Orsù fia, sta' a sentir quello che me ha ispirao el Ciel per vostro ben e per mio gusto. Cioè, che senza cercar altra fede della vostra nascita, che quella sola che me fa i vostri costumi, de volerve tior per mogier. Mo disème, quel fantolin di chi èllo o di chi fu ello fio?</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Con più comodo glie lo dirò, né mi par che sia bene lo strigner tanto negozio così importante fino all'intiero conoscimento, se si dee fare. Vadi e torni, ché forsi da un mio discorso comprenderà ch'io merito l'amor suo per la realtà di questo animo mio svilupato da tutti gl'interessi. <stage>(<emph>Ed entra</emph>)</stage></p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Questo xe un accrescimento di desiderio che me farave levar gl'intoppi a tutte le difficultae. Mi no credo che l'abbia mario, se ben quel fantolin è una certa raise, è qualche sospetto. El puol anch'esser fio d'un amante che se interponesse a i mii disegni, questo vuol dir niente, quando mi ho el consenso della zovene. El xe stao un gran colpo quello aver detto che comprenderò che la merita l'amor mio.</p>
           </sp>
@@ -2866,56 +2909,56 @@ umilissimo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">pantalone</hi>
           </stage>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Io non so se Flaminia sarà tornata a casa sua o se pur smarrita (non volendo star sola) sarà ritornata in casa dalla signora Celia. O ecco mio padre. </p>
             <p>Buon giorno, signor padre. In grazia mi scusi di tanti mancamenti di creanza, poiché preda di mille agitazioni e d'animo e di corpo, non so ormai più quello ch'io mi faccia o in virtù di chi operi.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Orsù, te voio agiustar la mente e accomodart 'l corpo. Ti xe innamorao, ch'el so, e sin adesso ti ti è vardao da mi, che forsi ti averessi sposà quella che zà molto tempo ti<pb n="742"/> galdi. Te do rason, no vogio più che i legami del timor te fazza adulterar i oblighi delle promesse. Tiola, se ti la vuol, né ti averà però causa de inzelosirte per tema d'accrescimento d'eredi, essendo int'una tal etae, che più tosto me abreviano i zorni che prestarli alla discendenza. Però marìdate ché me marido, né se parli tra nu de cose che abbia da introdur disputa intorno a quello che xe che no xe 'l dover.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>La legge del dovere è quella che si spicca dal vostro volere. Ma chi è la sposa?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Te vogio far rider e stupir. Truovo qua in strada una zovene preda della necessitae, che lacrimevolmente va cercando patron. Me ritiro in mi, la guardo, vedo una tal serenitae in la so fronte, che immediate me dispose a tiorla più per servirla che perché essa me servisse. E qua deti subito le chiave del mio arbitrio in mano della compassion, la qual subito l'ha inserao nella stanzia della caritae, con un ordine espresso ch'el debba sposar per quanto el tien cara la grazia del Ciel.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>E chi vorebbe contradire alla giustizia di questa causa? Ma ditemi, e dove è questa giovine?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>La xe in casa e sì a te zuro da pare che no ghe ho manco toccao una man. Ma te ho da dir de più bello: questa ha un fantolin el più caro, el più bello e 'l più dolze mataziuol de tutto el mondo, no te digo altro, el meterave l'allegrezza nel tempio della malenconia! El noma Carluzzo, Carleto, Carlin.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Carluccio?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Sì, ma ascolta el più bello. Un fio d'un becco cornuo ghe l'aveva tiolto, no so se per burlo o per farla desperar; basta, ché al despetto de quella bestia se ha trovao. Se ti avessi visto quanto la povera zovane s'è muà de ciera! Fa' conto ch'el si sia visto el caligo convertirse in sol: la se ha abbelio tutto l'asetto, de muodo che mi giudico ch'el mondo non abbia niente de più bello de sta zovene.<pb n="743"/></p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Com'ha ella nome?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Flaminia.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p><foreign xml:lang="lat">Et est</foreign>. Si può vedere?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Se puol, ma no vogio. Andemo, prima che ti la vedi, a tior delle veste che possa servir per indizio del so merito e per la medema strada ne compraremo anca per vestir la toa. Andemo.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Andiamo. </p>
             <p>Non ho più dubio che non sia Flaminia mia.</p>
@@ -2926,7 +2969,7 @@ umilissimo servitore
           <stage>
             <hi rend="sc">dottor</hi>
           </stage>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>An so s'al re d'Affrica abbia ancora consgnà l' scetr alla razina. Al diss d' portar la casa in Affrica, è possibil ch'in quel paes al re n'abbia dov aluzar?</p>
           </sp>
@@ -2934,40 +2977,40 @@ umilissimo servitore
         <div type="scene">
           <head rend="italic">SCENA XX</head>
           <stage><hi rend="sc">franceschina</hi><hi rend="italic">filando</hi>, <hi rend="sc">bagattino</hi><hi rend="italic">aguchiando, e</hi><hi rend="sc">dottor</hi></stage>
-          <sp>
+          <sp who="#franceschina">
             <speaker><emph rend="sc">franceschina</emph>.</speaker>
             <p>Tu sei cagione ch'io fila, né trovarò mai più una patrona come la signora Flaminia.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>E mi vagh agucchiand, né poss guadagnà tant ch'accompri l'acqui vita. O ecc un om. </p>
             <p>Bondì messir.</p>
           </sp>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>Bondì e bon ann.</p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Me savrisev insegnà un patrù?</p>
           </sp>
-          <sp>
+          <sp who="#franceschina">
             <speaker><emph rend="sc">franceschina</emph>.</speaker>
             <p>E a me una patrona?</p>
           </sp>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>Fad cont d'aver truvà tutt du la vostra vintura. Ti at vuoi metter con al re d'Affrica e tu con la razina.<pb n="744"/></p>
           </sp>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>Dai al mat! Dai al mat! <stage>(<emph>E via</emph>)</stage></p>
           </sp>
-          <sp>
+          <sp who="#franceschina">
             <speaker><emph rend="sc">franceschina</emph>.</speaker>
             <p>Dagli, che è matto, dagli, dagli!<stage>(<emph>E via</emph>)</stage></p>
           </sp>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>O ch' besti, com l' zent s' zuoga la sort.<stage>(<emph>Piglia le chiave, apre ed entra in casa</emph>)</stage></p>
           </sp>
@@ -2978,15 +3021,15 @@ umilissimo servitore
             <hi rend="sc">pantalone, cinzio, mercante</hi>
             <hi rend="italic">con veste</hi>
           </stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Se ben le xe veste fatte, le xe però niuove.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Diamo le sue alla vostra sposa e l'altre le portaremo poi alla mia.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Bon, ti parli ben. O de casa!</p>
           </sp>
@@ -2996,49 +3039,49 @@ umilissimo servitore
           <stage>
             <hi rend="sc">flaminia, cinzio, pantalone</hi>
           </stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Nel costituirve mia maggior, ve costituisso anco patrona del mio aver e comenzo de ste vesture.</p>
           </sp>
           <stage>(<emph>Flaminia guarda sott'occhio Cinzio. Cinzio accenna che pigli le veste. Pantalone gli guarda tutti doi e dice</emph>)</stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Par che ve cognosse.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>La riconosco e so ch'ella è gentildonna meritevole di maggior presente di questo.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Fo quanto mi comandate.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Pigliate ancor queste dua per mia moglie.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>La cognosèla?</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Meglio di nissun altro.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>E l'ho accaro, a fé de omo da ben.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>O eccola.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Dove xela?</p>
           </sp>
           <stage>(<emph>Cinzio tocca la mano a Flaminia e dice</emph>)</stage>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>O signora consorte.</p>
           </sp>
@@ -3050,19 +3093,19 @@ umilissimo servitore
             <hi rend="sc">carluccio</hi>
             <hi rend="italic">e stessi</hi>
           </stage>
-          <sp>
+          <sp who="#carluccio">
             <speaker><emph rend="sc">carluccio</emph>.</speaker>
             <p>Signor padre bello caro. Ecco il mio missere.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Ecco i miei furbi.</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Signor padre, questa è mia moglie, il cui merito è sottoscritto dal vostro giudizio.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Non ho liogo da dolerme, né da reprenderve. Tiolève, ch'el Cielo ve benedighi.</p>
           </sp>
@@ -3072,39 +3115,39 @@ umilissimo servitore
           <stage>
             <hi rend="sc">capitano, celia, dottor, cinzio, flaminia, pantalone</hi>
           </stage>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>Larg al re e alla regina d'Affrica!</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Dove setli?</p>
           </sp>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>Eccoli.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>O che bestia!</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker><emph rend="sc">capitano</emph>.</speaker>
             <p>Io invito tutti alle nozze, alle feste, al torneo e alla giostra, la qual si farà all'arrivo di due mila cavaglieri ch'io aspetto d'Affrica e di Portugallo.</p>
           </sp>
-          <sp>
+          <sp who="#dottor">
             <speaker><emph rend="sc">dottor</emph>.</speaker>
             <p>E si n' saran tant, quattr Ebrei, che faran una moresca.</p>
           </sp>
-          <sp>
+          <sp who="#celia">
             <speaker><emph rend="sc">celia</emph>.</speaker>
             <p>Signora Flaminia mi rallegro somamente di vederla e forsi risanata del corpo e dell'animo.</p>
           </sp>
-          <sp>
+          <sp who="#flaminia">
             <speaker><emph rend="sc">flaminia</emph>.</speaker>
             <p>Le cicatrici rimaranno però sempre.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Chi è costù, scapao dalle forche?</p>
           </sp>
@@ -3119,15 +3162,15 @@ umilissimo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">flaminia</hi>
           </stage>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Eccovi, o signori, il ritratto di tutte le scelleragini, il compendio di tutte le furbarie, e, per dirvi tutto in una parola, eccovi Fritellino!</p>
           </sp>
-          <sp>
+          <sp who="#cinzio">
             <speaker><emph rend="sc">cinzio</emph>.</speaker>
             <p>Taci, ché sappiamo tanto che tu senz'altro non confessaresti tanto. Divieni quello che non sei mai stato e sarai uomo da bene.</p>
           </sp>
-          <sp>
+          <sp who="#fritellino">
             <speaker><emph rend="sc">fritellino</emph>.</speaker>
             <p>Io ho una cosa molto difficile, il far un esercizio che non si abbia mai imparato.</p>
           </sp>
@@ -3143,15 +3186,15 @@ umilissimo servitore
             </add>
           </stage>
           <stage>(<emph>Bagattino e Franceschina sono stati in disparte a veder il tutto</emph>)</stage>
-          <sp>
+          <sp who="#bagattino">
             <speaker><emph rend="sc">bagattino</emph>.</speaker>
             <p>A sem chilò per domandat perdon d'un mal ch'a non avem finit de fà. Però se avì perdonat a chi ne ha fatt tanti, perdonén anca nu, che non avem fatt se non mez.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker><emph rend="sc">pantalone</emph>.</speaker>
             <p>Non doventar laro, ché ti non sa far el mestier. Lassalo far a chi el fa senza paura della nostra giustizia. Te sia perdonao.</p>
           </sp>
-          <sp>
+          <sp who="#franceschina">
             <speaker><emph rend="sc">franceschina</emph>.</speaker>
             <p>E io domando perdono di non aver fatto nulla.</p>
           </sp>
@@ -3159,7 +3202,7 @@ umilissimo servitore
         <div type="scene">
           <head rend="italic">SCENA XXVII</head>
           <stage>(<emph>Uno togato parla con l'Auditorio</emph>)</stage>
-          <sp>
+          <sp who="#togato">
             <speaker><emph rend="sc">TOGATO</emph>.</speaker>
             <p>Cortesissimi signori, che con qualche incommodo averete favorito l'autore e con esso i rappresentanti, servite ancora all'occorenza de i vostri interessi con il negar il consen<pb n="747"/>so a chi vi persuade al male; accioché non crediate ne gl'errori che quasi hanno consumato a Virginio, con la riputazione, la vita ancora. </p>
             <p>E voi, signori carichi d'anni, non allegerite il cervello con lo alterarvi se in casa avete giovani innamorati, poiché vi mettete a pericolo di servir per esempio di leggerezza nel tempo assegnato apunto alla vostr'età per correggere chi è leggier di mente. Lo so che averete raccolte materie di maggior profitto, le quali, per non più stancarvi, lasciarò il carico alla rettitudine del vostro giudizio.</p>

--- a/tei/cosci-paola-da-buti.xml
+++ b/tei/cosci-paola-da-buti.xml
@@ -80,6 +80,49 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="ugo">
+            <persName>Ugo</persName>
+          </person>
+          <person xml:id="guglielmo">
+            <persName>Guglielmo</persName>
+          </person>
+          <person xml:id="giovanni">
+            <persName>Giovanni</persName>
+          </person>
+          <person xml:id="paola">
+            <persName>Paola</persName>
+          </person>
+          <person xml:id="armida">
+            <persName>Armida</persName>
+          </person>
+          <person xml:id="matanno">
+            <persName>Matanno</persName>
+          </person>
+          <person xml:id="anselmo">
+            <persName>Padre Anselmo</persName>
+          </person>
+          <person xml:id="antonio">
+            <persName>Padre Antonio</persName>
+          </person>
+          <person xml:id="maria">
+            <persName>Maria</persName>
+          </person>
+          <person xml:id="contadina">
+            <persName>Contadina</persName>
+          </person>
+          <person xml:id="melosso">
+            <persName>Melosso</persName>
+          </person>
+          <person xml:id="vitelli">
+            <persName>Paolo Vitelli</persName>
+          </person>
+          <person xml:id="malvezzi">
+            <persName>Lucio Malvezzi</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>2000-02-28T00:00:00.000+02:00</date><name>Brunamonti Samuela</name><name>CIBIT-Pisa</name>Digitalizzazione</change>
@@ -104,9 +147,13 @@
         <castItem type="role"><role>UGO</role> (<roleDesc>fidanzato di Paola</roleDesc>)</castItem>
         <castItem type="role"><role>MARIA</role> (<roleDesc>la piccola montanara</roleDesc>)</castItem>
         <castItem type="role">
-          <role><add>CONTADINA</add></role>
+          <role>
+            <add>CONTADINA</add>
+          </role>
         </castItem>
-        <castItem type="role"><role>PADRE ANSELMO</role></castItem>
+        <castItem type="role">
+          <role>PADRE ANSELMO</role>
+        </castItem>
         <castItem type="role"><role>PADRE ANTONIO</role> (<roleDesc>frati vestiti di bianco dell'ordine camaldolese</roleDesc>)</castItem>
         <castItem type="role"><role>PAOLO VITELLI</role> (<roleDesc>di parte nemica, comandante</roleDesc>)</castItem>
         <castItem type="list"><role>MATANNO</role> E <role>MELOSSO</role> ed <roleDesc>altri soldati che non parlano</roleDesc></castItem>
@@ -200,28 +247,28 @@ stava leggendo al suo piccolo uditorio composto dei suoi familiari. Come segue</
           <head>SCENA PRIMA </head>
           <stage>Guglielmo, Paola, Armida e Ugo amico di casa e fidanzato di Paola che entra vestito a guerriero
 foriero di cattive novità; tanto mai addolorato.</stage>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <stage>(entrando)</stage>
             <l>Giungo forse inaspettato? </l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l> Perché, Ugo! E in qual maniera </l>
             <l>In ritardo sei stasera? </l>
           </sp>
-          <sp>
+          <sp who="#giovanni">
             <speaker>GIOVANNI</speaker>
             <l> E in divisa tutto armato! </l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l> Ugo, dimmi per favore </l>
             <l>Quale male ci minaccia, </l>
             <l>Che guardando la tua faccia </l>
             <l>Vi si legge un gran dolore. </l>
           </sp>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <l> Eh! Purtroppo, caro amico, </l>
             <l>Un tal disse in gran segreto </l>
@@ -237,15 +284,15 @@ Venni a casa e, come vedi, </l>
             <l>Corsi a te così, Guglielmo, </l>
             <l>Perché meglio tu mi credi. </l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l> Giusto cielo, tutto intesi! </l>
           </sp>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <l> Son lucchesi o fiorentini? </l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l> Sia chi sia, son malandrini </l>
             <l>Che l'àn presa coi Butesi. </l>
@@ -253,11 +300,11 @@ Venni a casa e, come vedi, </l>
             <l>Ugo, aspetta il mio intervento! </l>
             <l>Cingerò pur io quel brando </l>
           </sp>
-          <sp>
+          <sp who="#giovanni">
             <speaker>GIOVANNI</speaker>
             <l> E così ci vai lasciando? </l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l> Ma ritorno nel momento. </l>
             <stage>(partendo colla moglie mentre il padre gli va dietro da destra)</stage>
@@ -266,14 +313,14 @@ Venni a casa e, come vedi, </l>
         <div type="scene">
           <head>SCENA SECONDA </head>
           <stage>Paola e Ugo</stage>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> E tu Ugo che ne dici? </l>
             <l>Quando soli qui saremo </l>
             <l>Certo è che temeremo </l>
             <l>Un affronto dai nemici. </l>
           </sp>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <l> Stai tranquilla Paola cara, </l>
             <l>Abbi a me fiducia e amore, </l>
@@ -284,7 +331,7 @@ Venni a casa e, come vedi, </l>
             <l>Per quel detto sol che bramo; </l>
             <l>Paola dillo!… </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Non pensiamo </l>
             <l>A tai cose che rigetto. </l>
@@ -293,12 +340,12 @@ Venni a casa e, come vedi, </l>
             <l>Meritato guiderdone </l>
             <l>E sposarmi allor potrai. </l>
           </sp>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <l> E se poi fosse altra cosa! </l>
             <l>Se restassi in guerra ucciso? </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Non lo dir, ché in Paradiso </l>
             <l>Sarò sempre la tua sposa. </l>
@@ -310,7 +357,7 @@ Venni a casa e, come vedi, </l>
           <stage>Rientrano sulla scena Guglielmo, il padre Giovanni e Armida, piangendo col
 fazzoletto, che si asciuga gli occhi perché suo marito vuol partire e andare
 a combattere.</stage>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <stage>(vestito del tutto a guerriero rivolto ai suoi)</stage>
             <l>Or conviene far </l>
@@ -319,7 +366,7 @@ a combattere.</stage>
             <l>Ugo andiam, sento rumore, </l>
             <l>Urge la nostra presenza. </l>
           </sp>
-          <sp>
+          <sp who="#armida">
             <speaker>ARMIDA</speaker>
             <stage>(andando alla porta chiude il passo a Guglielmo)</stage>
             <l>No, Guglielmo, non partire </l>
@@ -330,7 +377,7 @@ a combattere.</stage>
               <pb n="136"/>
             </l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l> Sgombra il passo, cosa fai? </l>
             <l>Cosa dici? O mio furore! </l>
@@ -338,12 +385,12 @@ a combattere.</stage>
             <l>Prima vittima cadrai. </l>
             <stage>(Paola con Giovanni e Ugo in disparte pensosi)</stage>
           </sp>
-          <sp>
+          <sp who="#armida">
             <speaker>ARMIDA</speaker>
             <l> Non m'importa, di tua mano </l>
             <l>Preferisco di morire! </l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l> Cielo! Armida, inorridire </l>
             <l>Tu mi fai coll'atto insano </l>
@@ -351,19 +398,19 @@ a combattere.</stage>
             <l>Via, desisti </l>
             <stage> (Guglielmo getta Armida da una parte della porta)</stage>
           </sp>
-          <sp>
+          <sp who="#armida">
             <speaker>ARMIDA</speaker>
             <l> Prima morta! </l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l> Bada Armida, mi arrovello. </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Non trascendere, fratello! </l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l> Va, ti scosta dalla porta! </l>
             <stage> (e finisce di gettarla in disparte)</stage>
@@ -371,11 +418,11 @@ a combattere.</stage>
             <stage>(soffermandosi)</stage>
             <l> Ugo andiam… </l>
           </sp>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <l> Son teco anch'io, </l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l> Fate còr, miei cari, addio; </l>
             <l>Vo cantando una canzone: </l>
@@ -397,7 +444,7 @@ CON MOTIVO DIVERSO DAL MAGGIO </head>
           <head>SCENA QUARTA </head>
           <pb n="137"/>
           <stage>Giovanni, Paola e Armida</stage>
-          <sp>
+          <sp who="#giovanni">
             <speaker>GIOVANNI</speaker>
             <l> Donne mie, se preparate </l>
             <l>Già vi siete, andremo fòra </l>
@@ -408,11 +455,11 @@ CON MOTIVO DIVERSO DAL MAGGIO </head>
             <l>Triste a noi! Partiamo, avanti, </l>
             <l>Ché si fugge un tal malanno. </l>
           </sp>
-          <sp>
+          <sp who="#armida">
             <speaker>ARMIDA</speaker>
             <l> Dove andremo in tal momento? </l>
           </sp>
-          <sp>
+          <sp who="#giovanni">
             <speaker>GIOVANNI</speaker>
             <l> Salirem sul Monte Serra </l>
             <l>Come profughi di guerra, </l>
@@ -420,11 +467,11 @@ CON MOTIVO DIVERSO DAL MAGGIO </head>
             <l>E se della selve nostra </l>
             <l>Abitassimo il metato? </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Grazie o padre, ài ben pensato! </l>
           </sp>
-          <sp>
+          <sp who="#armida">
             <speaker>ARMIDA</speaker>
             <l> Qual dimor,a a noi ci mostra… </l>
             <l>Ma se poi dobbiam fuggire </l>
@@ -432,7 +479,7 @@ CON MOTIVO DIVERSO DAL MAGGIO </head>
             <l>Ché se ancor qui staremo </l>
             <l>Ci potrebbero aggredire. </l>
           </sp>
-          <sp>
+          <sp who="#giovanni">
             <speaker>GIOVANNI</speaker>
             <stage>(guardando dalla porta di fuori a sinistra)</stage>
             <l>Donne andiamo, è scuro il cielo, </l>
@@ -446,7 +493,7 @@ CON MOTIVO DIVERSO DAL MAGGIO </head>
           <pb n="138"/>
           <stage>Matanno aiutante a Paolo Vitelli entra furtivo nella casa di Giovanni
 appena che le <num>3</num> persone sono partite. (Giovanni Paola e Armida partono da destra)</stage>
-          <sp>
+          <sp who="#matanno">
             <speaker>MATANNO</speaker>
             <l> Son passato dal verone, </l>
             <l>Rampicando qual capretto </l>
@@ -467,7 +514,7 @@ appena che le <num>3</num> persone sono partite. (Giovanni Paola e Armida parton
           <head>SCENA SESTA </head>
           <stage>Meravigliata Paola ritornando indietro sola a casa perché si era dimenticata
 una cosa sacra; trovando la porta aperta</stage>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <stage>(meravigliata)</stage>
             <l>Ciel che vedo, l'uscio è aperto! </l>
@@ -514,26 +561,26 @@ nascosto, e di ciò Paola si spaventa.</stage>
             <l>In mia casa così sola? </l>
             <l>Ciel, fuggiamo!… </l>
           </sp>
-          <sp>
+          <sp who="#matanno">
             <speaker>MATANNO</speaker>
             <stage>(trattenendola)</stage>
             <l>Una parola! </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Non v'è alcun che mi difende? </l>
           </sp>
-          <sp>
+          <sp who="#matanno">
             <speaker>MATANNO</speaker>
             <l> Leggiadrissima donzella, </l>
             <l>Io, dovendoti parlare, </l>
             <l>Qui furtivo volli entrare. </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Sei straniero alla favella. </l>
           </sp>
-          <sp>
+          <sp who="#matanno">
             <speaker>MATANNO</speaker>
             <l> La tua casa a quanto pare </l>
             <l>Ci resulta assai sospetta, </l>
@@ -549,7 +596,7 @@ nascosto, e di ciò Paola si spaventa.</stage>
 Se non mostri i connotati </l>
             <l>Di quei grandi documenti. </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Prima i tuoi voglio vedere </l>
             <l>Col medesimo diritto… </l>
@@ -557,7 +604,7 @@ Se non mostri i connotati </l>
             <l>Pure il tuo di possedere. </l>
             <stage>Matanno dà un foglio a Paola che lo legge subito</stage>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Riconosco nei suggelli </l>
             <l>Che tal piano è preparato </l>
@@ -569,7 +616,7 @@ Se non mostri i connotati </l>
           <head>SCENA OTTAVA </head>
           <stage>Ugo che spiava le mosse del nemico Matanno irrompeva da sinistra con due
 soldati arrestandolo.</stage>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <stage>(a spada tratta)</stage>
             <l>Cedi a me l'incartamento, </l>
@@ -585,14 +632,14 @@ soldati arrestandolo.</stage>
             <l>Era tanto che in paese </l>
             <l>Di nascosto ti spiavo. </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Ugo, grazie! t'invocavo </l>
             <l>Ed il Cielo alfin m'intese. </l>
             <pb n="142"/>
             <stage>tela</stage>
           </sp>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <l>Stavo dietro ad ascoltare </l>
             <l>E già tutto quanto intesi; </l>
@@ -603,16 +650,16 @@ soldati arrestandolo.</stage>
             <l>Costui prendere non solo </l>
             <l>Ma con lui di guerra il piano. </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Grazie ancora, e dal mio cuore </l>
             <l>Avrai un tempo ricompenza. </l>
           </sp>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <l> Paola addio! Faccio partenza. </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Io ritorno al genitore. </l>
           </sp>
@@ -629,13 +676,13 @@ Serra in Buti.</stage>
         <div type="scene">
           <head>SCENA PRIMA </head>
           <stage>Da destra giunge Padre Anselmo e Padre Antonio.</stage>
-          <sp>
+          <sp who="#anselmo">
             <speaker>P. ANSELMO</speaker>
             <l> O fratel, chi venne mai </l>
             <l>Al convento di sul Serra </l>
             <l>Per sottrarsi dalla guerra? </l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>P. ANTONIO</speaker>
             <l> Tre persone viste mai: </l>
             <l>Era un padre colla figlia </l>
@@ -643,22 +690,22 @@ Serra in Buti.</stage>
             <l>Che lì presso hanno dimora, </l>
             <l>Colle lacrime alle ciglia. </l>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>P. ANSELMO</speaker>
             <l> Cosa disse il Superiore? </l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>P. ANTONIO</speaker>
             <l> Mi commise di scrutare </l>
             <l>Sui soldati e domandare </l>
             <l>Se di guerra c'è sentore. </l>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>P. ANSELMO</speaker>
             <l> Che notizie torni a dare </l>
             <l>A quei miseri al convento? </l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>P. ANTONIO</speaker>
             <l> Non lo dir, che non m'attento </l>
             <l>Di qui oltre seguitare. </l>
@@ -666,7 +713,7 @@ Serra in Buti.</stage>
  Poi che dir, guarda, fratello, </l>
             <l>Su Roncali e Sant'Antone… </l>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>P. ANSELMO</speaker>
             <l> Gesù mio, che confusione! </l>
             <l>Fa che cessi tal flagello! </l>
@@ -679,17 +726,17 @@ Serra in Buti.</stage>
             <l>Meco ond'erami avviato, </l>
             <l>Sulle grotte ritte a cresta. </l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>P. ANTONIO</speaker>
             <l> Io non so che cosa fare, </l>
             <l>Mi divora l'incertezza. </l>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>P. ANSELMO</speaker>
             <l> Pria Maria, nostra salvezza, </l>
             <l>Vieni meco a scongiurare. </l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>P. ANTONIO</speaker>
             <l> Sl verrò, ché la preghiera </l>
             <l>Maggiormente è necessaria </l>
@@ -700,7 +747,7 @@ Serra in Buti.</stage>
             <l>Come dissemi una donna, </l>
             <l>Fu nascosta dalla gente? </l>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>P. ANSELMO</speaker>
             <l> Vero è proprio e la proposta </l>
             <l>Fu del nostro superiore, </l>
@@ -712,31 +759,31 @@ Serra in Buti.</stage>
             <l>Si mantiene fresco e bello </l>
             <l>Di soavissime viole. </l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>P. ANTONIO</speaker>
             <l> E sai tu per qual ragione </l>
             <l>Si serbò quel simulacro? </l>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>P. ANSELMO</speaker>
             <l> Perché poi divenga sacro </l>
             <l>Di una immenza devozione. </l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>P. ANTONIO</speaker>
             <l> E sai tu chi fu l'autore? </l>
             <l>Certo alcuno sarà stato, </l>
             <l>Che scolpiva appassionato </l>
             <l>Tal Madonna con fervore! </l>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>P. ANSELMO</speaker>
             <l> Tal Madonna fu in Roncali </l>
             <l>Sculta in albero di pero </l>
             <l>Con artistico amor vero </l>
             <l>Dai fratelli Panicali. </l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>P. ANTONIO</speaker>
             <l> Buon per loro, che . lasciata </l>
             <l>Consacrata a somma gloria </l>
@@ -753,35 +800,35 @@ Serra in Buti.</stage>
           <head>SCENA SECONDA </head>
           <pb n="146"/>
           <stage>Entrano nella scena da destra padre Giovanni, Paola e Armida.</stage>
-          <sp>
+          <sp who="#giovanni">
             <speaker>GIOVANNI</speaker>
             <l> Dal convento ai Caparroni </l>
             <l>Di lì siamo alla Fucella, </l>
             <l>Senza aver qualche novella </l>
             <l>Circa il modo di fazioni. </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Buona sorte che il guardiano, </l>
             <l>Uom di Dio, di Provvidenza, </l>
             <l>Mai ci ha fatto restar senza </l>
             <l>Del suo pane quotidiano! </l>
           </sp>
-          <sp>
+          <sp who="#giovanni">
             <speaker>GIOVANNI</speaker>
             <l> Sl tal pane abbiam trovato </l>
             <l>Dal Guardiano tutto cuore, </l>
             <l>Servo degno del Signore: </l>
             <l>Ma sarà ricompensato. </l>
           </sp>
-          <sp>
+          <sp who="#armida">
             <speaker>ARMIDA</speaker>
             <l> Dite ben, ma non sappiamo </l>
             <l>A Guglielmo come è andata, </l>
             <l>Se la guerra è incominciata </l>
             <l>E che far noi qui dobbiamo! </l>
           </sp>
-          <sp>
+          <sp who="#giovanni">
             <speaker>GIOVANNI</speaker>
             <stage>(mentre va intorno ad osservare)</stage>
             <l>Non si fu d'accordo ognuno </l>
@@ -791,11 +838,11 @@ Serra in Buti.</stage>
             <l>Ma che dico? In lontananza </l>
             <l>Gente armata eppur si sferra. </l>
           </sp>
-          <sp>
+          <sp who="#armida">
             <speaker>ARMIDA</speaker>
             <l> Vero è pur! </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <stage>(osservando da ogni parte)</stage>
             <l>Dovunque è guerra </l>
@@ -803,7 +850,7 @@ Serra in Buti.</stage>
             <l><pb n="147"/>
 Fratel caro!… </l>
           </sp>
-          <sp>
+          <sp who="#armida">
             <speaker>ARMIDA</speaker>
             <l> Sposo mio, </l>
             <l>Quale orrore ci ripugna! </l>
@@ -813,19 +860,19 @@ Fratel caro!… </l>
             <l>Di Guglielmo la partenza? </l>
             <l>Bella e fiera la presenza! </l>
           </sp>
-          <sp>
+          <sp who="#armida">
             <speaker>ARMIDA</speaker>
             <l> Ma lasciommi appassionata: </l>
             <l>Lo ricordo, il viso amato, </l>
             <l>Le fattezze sue leggiadre… </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <stage>(interrompendo)</stage>
             <l>Cosa vedi, caro padre, </l>
             <l>Che da me ti siei scostato? </l>
           </sp>
-          <sp>
+          <sp who="#giovanni">
             <speaker>GIOVANNI</speaker>
             <stage>(chiamando le donne colla mano)</stage>
             <l>Donne, l lungo la valle </l>
@@ -833,31 +880,31 @@ Fratel caro!… </l>
             <l>Di vedere che un guerriero </l>
             <l>Porti un altro sulle spalle? </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Sl purtroppo, avanza lento </l>
             <l>E noi qui cosa facciamo? </l>
           </sp>
-          <sp>
+          <sp who="#giovanni">
             <speaker>GIOVANNI</speaker>
             <l> Par dei nostri; non temiamo… </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Odo ancor qualche lamento. </l>
           </sp>
-          <sp>
+          <sp who="#armida">
             <speaker>ARMIDA</speaker>
             <l> Non ti sembra che il ferito </l>
             <l>Sia scortato da due frati? </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Forse in via si son trovati </l>
             <l>E così l'avran seguito. </l>
             <pb n="148"/>
           </sp>
-          <sp>
+          <sp who="#armida">
             <speaker>ARMIDA</speaker>
             <stage>(parlando piano)</stage>
             <l>Che mai intesi! Zitti stiamo! </l>
@@ -870,45 +917,45 @@ Fratel caro!… </l>
           <head>SCENA TERZA </head>
           <stage>Guglielmo sulle spalle di Ugo seguiti dai frati Padre Anselmo e Padre Antonio
 entrano sulla scena dalla parte destra.</stage>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Son vicini, o quali angoscie! </l>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>P. ANSELMO</speaker>
             <stage>(di dentro)</stage>
             <l>Buona gente!… </l>
           </sp>
-          <sp>
+          <sp who="#armida">
             <speaker>ARMIDA</speaker>
             <l> Ci ´n chiamate!… </l>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>P. ANSELMO</speaker>
             <stage>(di dentro)</stage>
             <l>Presto qua vi avvicinate, </l>
             <l>Il ferito vi conosce </l>
             <stage>(tutti si avvicinano a Guglielmo)</stage>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l> Cari miei, correte, io mòro, </l>
             <l>Fortemente son piagato! </l>
             <stage>(Paola cade svenuta)</stage>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> È Guglielmo che  parlato. </l>
           </sp>
-          <sp>
+          <sp who="#giovanni">
             <speaker>GIOVANNI</speaker>
             <l> Figlio! </l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l> Padre! </l>
           </sp>
-          <sp>
+          <sp who="#armida">
             <speaker>ARMIDA</speaker>
             <stage>(abbracciandolo)</stage>
             <l>O mio tesoro!… </l>
@@ -920,7 +967,7 @@ entrano sulla scena dalla parte destra.</stage>
           <stage>Padre Antonio allontana Armida e vedendo Guglielmo morente eseguisce
 prontamente il suo santo ministero.</stage>
           <pb n="149"/>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <l> A che punto è tal famiglia! </l>
             <l>Il marito in questo stato </l>
@@ -936,49 +983,49 @@ prontamente il suo santo ministero.</stage>
             <l>Questo anello col mio stemma </l>
             <l>Cambierò colla tua gemma. </l>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>P. ANSELMO</speaker>
             <l> Paola è morta? </l>
           </sp>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <stage>(piangendo)</stage>
             <l>Almeno pare. </l>
             <l>Sommo Cielo, aver perduta </l>
             <l>Donna tale così bella… </l>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>P. ANSELMO</speaker>
             <stage>(sentendo il cuore coll'orecchio)</stage>
             <l>È sol priva di favella, </l>
             <l>Il cuor batte, sta svenuta. </l>
           </sp>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <l> Molto preme, o Padre Anselmo, </l>
             <l>Che la giovane rinvenga. </l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l> Paola!… Ahimè!… Fate che venga! </l>
             <l>Padre, e tu? </l>
           </sp>
-          <sp>
+          <sp who="#giovanni">
             <speaker>GIOVANNI</speaker>
             <l> Son qui, Guglielmo. </l>
             <stage>Paola rinvenuta sorretta da Ugo e dagli altri viene condotta dal fratello
 morente.</stage>
           </sp>
           <pb n="150"/>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Cosa fu, perché son desta? </l>
           </sp>
-          <sp>
+          <sp who="#armida">
             <speaker>ARMIDA</speaker>
             <l> Venir devi dal fratello. </l>
           </sp>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <l> Io raggiungere il drappello </l>
             <l>Devo subito alla lesta. </l>
@@ -988,24 +1035,24 @@ morente.</stage>
             <l>Mi si bagnano le ciglia: </l>
             <l>Addio tutti, io debbo andare. </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Fratel mio, Guglielmo amato, </l>
             <l>Qui ti assiste un confessore. </l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>P. ANTONIO</speaker>
             <l> Già l'assolsi nel Signore. </l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l> Paola! </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> O Cielo, mi ha chiamato! </l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l> Io con te voglio sfogarmi, </l>
             <l>Proprio all'ultimo momento: </l>
@@ -1016,18 +1063,18 @@ morente.</stage>
             <l>Il nemico ci ha distrutto? </l>
             <l>Ah! Vendetta! Sl vendetta! </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> O fratel, qual gioia feroce </l>
             <l>Balenar ti vedo in viso! </l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l> Paola, in me già ti ravviso, </l>
             <l>grave;i pur anco la mia voce! </l>
           </sp>
           <pb n="151"/>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> No, Guglielmo, in te perdona </l>
             <l>Il nemico in questo stato: </l>
@@ -1038,32 +1085,32 @@ morente.</stage>
             <l>Perché Lui di sulla croce </l>
             <l>Volle a tutti perdonare. </l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l> Dici bene, e ancor Guglielmo </l>
             <l>Li perdona nel Signore; </l>
             <l>Ma chi prende il mio vigore, </l>
             <l>La mia spada unita all'elmo? </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Io li prendo! A giuramento </l>
             <l>Vestirò la tua divisa </l>
             <l>Difendendo sempre Pisa </l>
             <l>In tuo nome… </l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l> O qual contento! </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Se non altro per sedare </l>
             <l>L'ingiustizia e la rapina </l>
             <l>E l'emblema fiorentina </l>
             <l>Giunger poscia a calpestare. </l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <stage>(con un filo di voce udibile, morente)</stage>
             <l>Del tuo slancio franco, audace </l>
@@ -1072,20 +1119,20 @@ morente.</stage>
             <l>Ti ringrazio e spiro in pace. </l>
             <pb n="152"/>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Ciel, Guglielmo se ne mòre, </l>
             <l>Si abbandona sul mio seno! </l>
           </sp>
-          <sp>
+          <sp who="#giovanni">
             <speaker>GIOVANNI</speaker>
             <l> Figlio! … </l>
           </sp>
-          <sp>
+          <sp who="#armida">
             <speaker>ARMIDA</speaker>
             <l> Sposo! Un detto almeno… </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Più non parla, è fermo il cuore. </l>
           </sp>
@@ -1103,7 +1150,7 @@ simulacro della Madonna del Rosario di Buti.</stage>
           <head>SCENA PRIMA </head>
           <stage>Maria la piccola montanara <add>con una contadina</add> viene alle grotte a pronunciare
 la sua consueta preghiera. E poi inoltra Paola vestita a guerriera.</stage>
-          <sp>
+          <sp who="#maria">
             <speaker>MARIA</speaker>
             <stage>(rivolta alle grotte)</stage>
             <l>Madonnina mia adorata, </l>
@@ -1111,7 +1158,7 @@ la sua consueta preghiera. E poi inoltra Paola vestita a guerriera.</stage>
             <l>Che periglio triste e rio </l>
             <l>Corre forse in tal giornata. </l>
           </sp>
-          <sp>
+          <sp who="#contadina">
             <speaker>CONTADINA</speaker>
             <l> Colla guerra che sconvolge </l>
             <l>Tutto Buti crudelmente </l>
@@ -1119,13 +1166,13 @@ la sua consueta preghiera. E poi inoltra Paola vestita a guerriera.</stage>
             <l>Che al cuore tuo si rivolge. </l>
             <stage>(colla mano le manda un bacio)</stage>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>MARIA</speaker>
             <l> Ciel, chi giunge alla mia volta, </l>
             <l>Chi s'inoltra in questa via? </l>
             <l>Gran guerriero par che sia. </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Tal son io, ma ti conforta. </l>
             <stage>(e rimane sorpresa di Paola, che giunge da sinistra)</stage>
@@ -1143,59 +1190,59 @@ A invocare con dolore </l>
             <l>D'ottener la protezione </l>
             <l>Di Maria del Ciel Regina? </l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>MARIA</speaker>
             <l> Sl gran fede, o mio guerriero, </l>
             <l>Pongo in Lei d'amor che brucia, </l>
             <l>Sempr'è in me di gran fiducia </l>
             <l>Che mi calma un gran pensiero. </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Che pensiero ti divora </l>
             <l>Nell'etade tua fiorente? </l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>MARIA</speaker>
             <l> Per la guerra il babbo è assente </l>
             <l>E la mamma si addolora. </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Pria d'andarmene vorreste </l>
             <l>Meco fare un'orazione? </l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>MARIA</speaker>
             <l> Si, ma è poco, e l'intenzione </l>
             <l>Appagata non vedreste. </l>
             <l>Di che nome vi chiamate? </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Paola son… </l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>MARIA</speaker>
             <l> Santa Madonna! </l>
             <l>Cosa dite? Voi, una donna, </l>
             <l>In tal veste? E dove andate? </l>
             <pb n="155"/>
           </sp>
-          <sp>
+          <sp who="#contadina">
             <speaker>CONTADINA</speaker>
             <l> Paola, dunque non temete </l>
             <l>A inoltrarvi in tal mistero? </l>
             <l>Per mia parte un gran guerriero </l>
             <l>Mi parevi, e donna siete. </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Temer no, ma sento pena </l>
             <l>Per l'avversa situazione… </l>
             <l>Via, facci. quest'orazione. </l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>MARIA</speaker>
             <l> Far dovreste una novena: </l>
             <l>Stando qui con meco unita </l>
@@ -1203,7 +1250,7 @@ A invocare con dolore </l>
             <l>Non mancate, e del favore </l>
             <l>Voi sarete esaudita. </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Ciel, non posso acconsentire </l>
             <l>chè dimani, a giuramento, </l>
@@ -1214,13 +1261,13 @@ A invocare con dolore </l>
             <l>Tu che sei di grazia piena </l>
             <l>E che sei di qui vicina ? </l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>MARIA</speaker>
             <l> Lo prometto, e state certa </l>
             <l>Che per nove dì precisi </l>
             <l>Pregherò come promisi. </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Bene, allor prendi un'offerta. </l>
             <stage>(gli da una borsa di denaro)</stage>
@@ -1230,18 +1277,18 @@ Se andò in guerra ancor tuo padre </l>
             <l>Questa borsa almen per ora </l>
             <l>Può servire alla tua madre. </l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>MARIA</speaker>
             <l> Dolce è qui con voi lo stare! </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Cara, quanto ti vo' bene: </l>
             <l>In gran parte le mie pene </l>
             <l>Fatto mi ài dimenticare. </l>
             <stage>(l'abbraccia e la bacia)</stage>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> La preghiera tua innocente </l>
             <l>Giunger possa al Ciel diretta </l>
@@ -1256,7 +1303,7 @@ Se andò in guerra ancor tuo padre </l>
 grotta adornandola poi con due rami e tralci di rose.
 Paola poco dopo ritorna pian piano non vista dalla bambina, che forse in
 quel momento crede di già Paola lontana. Da destra.</stage>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <stage>(rivolta al pubblico)</stage>
             <l>Della gente misteriosa </l>
@@ -1280,7 +1327,7 @@ Nel lavoro tuo giocondo </l>
           <stage>Matanno e Melosso.
 Questi due nemici contrarii alla parte che difende Paola entrano da destra
 andando con cattive idee verso la bambina vegliata già da Paola nascosta.</stage>
-          <sp>
+          <sp who="#matanno">
             <speaker>MATANNO</speaker>
             <stage>(al suo amico)</stage>
             <l>Una bimba in questo loco </l>
@@ -1289,26 +1336,26 @@ andando con cattive idee verso la bambina vegliata già da Paola nascosta.</stag
             <l>Darla qua, parliamo un poco! </l>
             <stage>(gli strappano di mano la borsetta)</stage>
           </sp>
-          <sp>
+          <sp who="#melosso">
             <speaker>MELOSSO</speaker>
             <l> Chi ti diede tal monete? </l>
             <l>Parla, su, non far la muta! </l>
             <stage>(viene malmenata)</stage>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>MARIA</speaker>
             <l> Madonnina, son perduta: </l>
             <l>Deh, pietà, mi soccorrete! </l>
             <stage>(Paola fa un atto di impazienza)</stage>
           </sp>
-          <sp>
+          <sp who="#matanno">
             <speaker>MATANNO</speaker>
             <l> Ti ridno volentieri </l>
             <l>Il denaro, se ci dici </l>
             <l>Se di qui di noi nemici </l>
             <l>Mai passarono guerrieri. </l>
           </sp>
-          <sp>
+          <sp who="#maria">
             <speaker>MARIA</speaker>
             <l> Per non dirvi una bugia </l>
             <l>È passato qui soltanto </l>
@@ -1323,14 +1370,14 @@ andando con cattive idee verso la bambina vegliata già da Paola nascosta.</stag
 luce solo fa per un attimo vedere nella nicchia della grotta l'immagine della
 nostra Madonna, segnale quello perché Paola insorgesse a spada tratta a
 difendere la piccola Maria, la montanara.</stage>
-          <sp>
+          <sp who="#melosso">
             <speaker>MELOSSO</speaker>
             <stage>(minaccioso estraendo la spada)</stage>
             <l>A noi niente dir non vòi? </l>
             <l>E di noi non dirai niente!… </l>
             <l>Tieni, prendi tal fendente! </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <stage>(scattando colla spada ferisce Melosso)</stage>
             <l>Scellerato, ferma e muoi! </l>
@@ -1354,44 +1401,44 @@ sconosciuta Paola stesa al suolo. Finché Ugo disperdendo tutto e tutti, solo
 rimane, ritto, padrone di quella situazione orrenda.
 Nello svolgersi di questa scena di battaglia, fra lo strepito, i due capi
 drappello Ugo e Matanno inveiscono con le seguenti parole.</stage>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <l> Scellerati Fiorentini! </l>
           </sp>
-          <sp>
+          <sp who="#matanno">
             <speaker>MATANNO</speaker>
             <l> E voi barbari Pisani! </l>
           </sp>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <l> Vi uccidiamo come cani! </l>
           </sp>
-          <sp>
+          <sp who="#matanno">
             <speaker>MATANNO</speaker>
             <l> Traditori ed assassini! </l>
             <l>State attenti alla bandiera, </l>
             <l>Che al nemico par che ondeggi. </l>
           </sp>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <stage>(a Paola che non conosce)</stage>
             <l>Strappa, strappa… </l>
           </sp>
-          <sp>
+          <sp who="#matanno">
             <speaker>MATANNO</speaker>
             <l> Reggi, reggi, </l>
             <l>Che deciman la mia schiera! </l>
           </sp>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <l> Il vessillo è già ghermito, </l>
             <l>Quel guerrier lo tenga stretto! </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Mi . piagato in mezzo al petto… </l>
           </sp>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <l> Farò scudo a quel ferito. </l>
             <l>Arrendetevi o vi uccido, </l>
@@ -1404,13 +1451,13 @@ di impossessarsi dei prigionieri.</stage>
             <l>Giù le spade, e farem pace!… </l>
             <l>Resistete… </l>
           </sp>
-          <sp>
+          <sp who="#matanno">
             <speaker>MATANNO</speaker>
             <l> Ci arrendiamo, </l>
             <l>A te l'arme consegnamo, </l>
             <l>Fai di noi cosa ti piace. </l>
           </sp>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <l> Fidi miei, vi impadronite </l>
             <l>Dei supestiti nemici </l>
@@ -1453,29 +1500,29 @@ Con tal segno s`distinto </l>
             <l>Angiol caro, stai contenta </l>
             <l>Che ti vengo a confortare. </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Ugo aimè! Vieni a salvare </l>
             <l>Un dei tuoi… </l>
           </sp>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <l> Chi si lamenta? </l>
             <l>Ei vivea, per quanto sento. </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Ugo, presto, dammi aita!… </l>
           </sp>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <l> Sto cercando la ferita. </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Perdo sangue… </l>
           </sp>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <l> Un sol momento. </l>
             <l>Non mi sembri in brutto stato </l>
@@ -1487,12 +1534,12 @@ Certo è che dalla morte </l>
             <l>T'ho salvato non volendo, </l>
             <l>T'alza pur, la mano ti prendo. </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <stage>(alzandosi la visiera calata)</stage>
             <l>Grazie, o Ciel, mi sento forte. </l>
           </sp>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <l> Ma chi siei che la visiera </l>
             <l>Tieni ancor così calata? </l>
@@ -1503,13 +1550,13 @@ Certo è che dalla morte </l>
             <l>Paola, o Ciel! Fammi vedere </l>
             <l>Il tuo dolce portamento! </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <stage>(si china e prende la bandiera)</stage>
             <l>Il vessillo fiorentino </l>
             <l>Lo strappai colla mia mano. </l>
           </sp>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <l> Tu, gran donna, caso strano! </l>
             <l>Al valore tuo m'inchino. </l>
@@ -1517,7 +1564,7 @@ Certo è che dalla morte </l>
             <l>Come andò che ti sei messa </l>
             <l>Tal divisa? </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Una promessa </l>
             <l>A Guglielmo aveo giurata. </l>
@@ -1535,37 +1582,37 @@ Gli promisi che lottavo </l>
             <l>In tantissimi brandelli </l>
             <l>La vo' far, per suo dispetto. </l>
           </sp>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <l> Quale fu la tua opinione </l>
             <l>Quando in lotta mi vedesti? </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Io non so come facesti, </l>
             <l>A spacciar tante persone. </l>
           </sp>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <l> Eri tu che mi spronavi </l>
             <l>A lottar così furente, </l>
             <l>Perché t'amo immensamente. </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> E lontana mi pensavi. </l>
           </sp>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <l> Sl lontana, che giammai </l>
             <l>Qui con me non ti credevo, </l>
             <l>Paola! O Ciel! Se lo sapevo!… </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Cosa avresti fatto mai? </l>
           </sp>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <l> A tornare al genitore </l>
             <l>T'avrei certo persuasa: </l>
@@ -1573,13 +1620,13 @@ Gli promisi che lottavo </l>
             <l>Coll'insegna del valore. </l>
             <pb n="164"/>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Dividiamoci e partiamo: </l>
             <l>Fa che stringa con affetto </l>
             <l>La tua mano, o mio diletto. </l>
           </sp>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <l> Cara, addio, ci rivediamo. </l>
           </sp>
@@ -1592,7 +1639,7 @@ Gli promisi che lottavo </l>
         <div type="scene">
           <head>SCENA PRIMA </head>
           <stage>Vitelli e Paola</stage>
-          <sp>
+          <sp who="#vitelli">
             <speaker>VITELLI</speaker>
             <stage>(entrando da sinistra)</stage>
             <l>Mi fu detto che a Verruca </l>
@@ -1630,7 +1677,7 @@ Gli promisi che lottavo </l>
             <l>E perché non ti àn fermata </l>
             <l>Nel valcare la frontiera? </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Mio carissimo signore, </l>
             <l>A te innanzi ambasciatrice </l>
@@ -1641,7 +1688,7 @@ Gli promisi che lottavo </l>
             <l>Di levare un tale assedio, </l>
             <l>La tua vita non permane. </l>
           </sp>
-          <sp>
+          <sp who="#vitelli">
             <speaker>VITELLI</speaker>
             <l> Questo assedio io pur potrei </l>
             <l>Di levare nel momento </l>
@@ -1649,55 +1696,55 @@ Gli promisi che lottavo </l>
             <l>Sol per te che bella sei. </l>
             <pb n="165"/>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Siàn nemici, e tal disgrazia </l>
             <l>Si frappone a ciò che brami. </l>
           </sp>
-          <sp>
+          <sp who="#vitelli">
             <speaker>VITELLI</speaker>
             <l> Ma se dici che tu m'ami, </l>
             <l>Chieder pòi qualunque grazia. </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Già saprai che ti richiedo </l>
             <l>Cosa grande a te gelosa. </l>
           </sp>
-          <sp>
+          <sp who="#vitelli">
             <speaker>VITELLI</speaker>
             <l> Chiedi a me qualunque cosa, </l>
             <l>Che potendo ti concedo. </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Bene, allor da Panicale </l>
             <l>E sull'alto di Solaio </l>
             <l>Dei soldati il paretaio </l>
             <l>Togli fino allo Spedale. </l>
           </sp>
-          <sp>
+          <sp who="#vitelli">
             <speaker>VITELLI</speaker>
             <l> Ciel, che cosa vieni a dire, </l>
             <l>Questa è grande veramente! </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> T'amo allora e tanta gente </l>
             <l>Ti potrebbe benedire. </l>
           </sp>
-          <sp>
+          <sp who="#vitelli">
             <speaker>VITELLI</speaker>
             <l> Poca cosa, ricompenza </l>
             <l>Del grandioso mio favore, </l>
             <l>Tu disponi nel tuo cuore… </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Allor parto… </l>
             <stage>(Vitelli un po'sopra pensiero e poi risolutissimo)</stage>
           </sp>
-          <sp>
+          <sp who="#vitelli">
             <speaker>VITELLI</speaker>
             <l> Attendi udienza. </l>
             <l>Teco stare io troppo bramo </l>
@@ -1709,7 +1756,7 @@ Gli promisi che lottavo </l>
             <l>E mai più ci sia concesso </l>
             <l>Riveder questi castelli. </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> E che cosa dici mai! </l>
             <l>I miei luoghi non mi sento </l>
@@ -1723,39 +1770,39 @@ Gli promisi che lottavo </l>
             <l>Non sia mai, se quel che ho detto </l>
             <l>Non adempi… </l>
           </sp>
-          <sp>
+          <sp who="#vitelli">
             <speaker>VITELLI</speaker>
             <l> Io tel prometto, </l>
             <l>Anzi andiamo ad eseguire. </l>
             <stage>(Avviandosi tutti e due verso destra, soffermandosi ancora con Paola)</stage>
             <l>Se seguirmi a te non cale… </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Bene, andiàn, ti faccio scorta. </l>
           </sp>
-          <sp>
+          <sp who="#vitelli">
             <speaker>VITELLI</speaker>
             <l> Non tradir, perché sei morta </l>
             <l>Se qualcun dei tuoi mi assale. </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Basta un cenno alle tue genti </l>
             <l>Per levare un tale assedio. </l>
           </sp>
-          <sp>
+          <sp who="#vitelli">
             <speaker>VITELLI</speaker>
             <stage>(a scatti indietreggiando)</stage>
             <l>Donna… ài vinto… Aimè rimedio </l>
             <l>Più non v'è… </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Di che paventi ? </l>
             <pb n="168"/>
           </sp>
-          <sp>
+          <sp who="#vitelli">
             <speaker>VITELLI</speaker>
             <l> Che mai vedo, e come e quando </l>
             <l>Una turba di assediati </l>
@@ -1771,12 +1818,12 @@ Gli promisi che lottavo </l>
             <l>Di fuggire preferisco </l>
             <l>Ma con te, che tanto agogno. </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Aspettiam che sia calmata </l>
             <l>La terribile bufera. </l>
           </sp>
-          <sp>
+          <sp who="#vitelli">
             <speaker>VITELLI</speaker>
             <l> Sono i miei senza bandiera: </l>
             <l>Chi la perse, e come è andata? </l>
@@ -1787,13 +1834,13 @@ Gli promisi che lottavo </l>
             <l>Io non c'ero e non mi accorsi; </l>
             <l>Parla su, non esitare. </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <stage>(ridendo)</stage>
             <l>Io fui quella, che ti pare?, </l>
             <l>Senza avere dei rimorsi. </l>
           </sp>
-          <sp>
+          <sp who="#vitelli">
             <speaker>VITELLI</speaker>
             <l> Cielo, tu? Che vieni a dire! </l>
             <l>Troppo, infami, è ciò che ascolto! </l>
@@ -1808,12 +1855,12 @@ Gli promisi che lottavo </l>
             <l>Di una volta, che non sento? </l>
             <l>Quel livore?… </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Io te l'ho spento </l>
             <l>Col mio fiato incantatore! </l>
           </sp>
-          <sp>
+          <sp who="#vitelli">
             <speaker>VITELLI</speaker>
             <l> Donna, o Cielo, m'ài annientato, </l>
             <l>L'ira più nel cuor mi sento; </l>
@@ -1823,18 +1870,18 @@ Gli promisi che lottavo </l>
             <l>È che non mi corrispondi, </l>
             <l>Qui mi tieni e mi confondi… </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Gastigarti solo intendo. </l>
           </sp>
-          <sp>
+          <sp who="#vitelli">
             <speaker>VITELLI</speaker>
             <stage>(inginocchiato davanti a Paola)</stage>
             <l>Dunque, o donna, a me non vale </l>
             <l>La preghiera, inginocchiarmi? </l>
             <l>Perché tanto affascinarmi? </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <stage>(levandoli la spada)</stage>
             <l>Io punisco uno sleale; </l>
@@ -1842,11 +1889,11 @@ Gli promisi che lottavo </l>
 E la spada ancor ti toglio </l>
             <l>Che del mal potreste farmi. </l>
           </sp>
-          <sp>
+          <sp who="#vitelli">
             <speaker>VITELLI</speaker>
             <l> Donna, e ancora mi disarmi? </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Ti vo' mite e senza orgoglio. </l>
             <stage>(Vitelli si rialsa macchinalmente)</stage>
@@ -1867,7 +1914,7 @@ E la spada ancor ti toglio </l>
             <l>Tu peccasti, il Ciel non resse </l>
             <l>E qual donna t'annientai. </l>
           </sp>
-          <sp>
+          <sp who="#vitelli">
             <speaker>VITELLI</speaker>
             <l> Ó perduto la ragione, </l>
             <l>Più non so che cosa fare: </l>
@@ -1875,7 +1922,7 @@ E la spada ancor ti toglio </l>
             <l>Mi condanni a dannazione. </l>
             <pb n="172"/>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Ver non sia che disperare </l>
             <l>Tu ti devi al Sommo Bene </l>
@@ -1884,7 +1931,7 @@ E la spada ancor ti toglio </l>
             <stage>Vitelli mortificato e contrito se ne va in fondo allla scena col volto fra le
 mani mentre che Paola s'inginocchia e prega.</stage>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <stage> (rivolta coll'occhi al Cielo)</stage>
             <l>Riconosco in tal momento, </l>
@@ -1900,18 +1947,18 @@ mani mentre che Paola s'inginocchia e prega.</stage>
         </div>
         <div type="scene">
           <head>SCENA SECONDA </head>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <stage>(entrando da sinistra)</stage>
             <l>Alto là! Che scena è questa, </l>
             <l>Cielo! Paola inginocchiata! </l>
             <l>Piangi forse, o mia adorata? </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> No, pregava!… </l>
           </sp>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <l> E sei s`mesta? </l>
             <l>T'alza, amore, che qui appunto </l>
@@ -1923,21 +1970,21 @@ mani mentre che Paola s'inginocchia e prega.</stage>
             <l>Scaltra, audace, la più fina, </l>
             <l>Sarai meglio decorata. </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Ugo grazie, so che brami </l>
             <l>Il mio bene, e salvatore </l>
             <l>Già mi sei, che questo cuore </l>
             <l>Non pòi creder quanto t'ami. </l>
           </sp>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <l> Paola, narra! Che sgomento </l>
             <l>Nel saperti solitaria </l>
             <l>Messaggera volontaria </l>
             <l>Ad un uom così cruento! </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Venne a me dunque l'idea, </l>
             <l>Nel trovarmi in triste assedio, </l>
@@ -1960,12 +2007,12 @@ E perciò, da donna astuta, </l>
             <l>Farén s`che l'esponiamo </l>
             <l>Che da tempo noi ci amiamo. </l>
           </sp>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <l> Forse giunge in questo istante. </l>
             <stage>(si odono dei rumori al di fuori a destra e squillo di tromba)</stage>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <stage>(guarda fra le quinte)</stage>
             <l>Cielo, o Dio, che vedo mai, </l>
@@ -1985,7 +2032,7 @@ la motivazione circa l'eroismo compiuto da Paola da Buti, che per il suo
 bel modo di fare fece scomparire l'assedio in cui erano stretti i Pisani e
 dopo di ciò riportarono grande vittoria qui sulla nostra patria
       valle.</stage>
-          <sp>
+          <sp who="#malvezzi">
             <speaker>LUCIO MALVEZZI</speaker>
             <stage>(leggendo un foglio)</stage>
             <l>Della Patria la colonna, </l>
@@ -2015,19 +2062,19 @@ Essa è Paola, e conoscente </l>
             <l>Ricompenso i miei guerreri, </l>
             <l>Premio grande da me avrai. </l>
           </sp>
-          <sp>
+          <sp who="#paola">
             <speaker>PAOLA</speaker>
             <l> Io vorrei, sor comandante, </l>
             <l>Che presente a questo rito </l>
             <l>Il futuro mio marito </l>
             <l>Fosse meco nell'istante. </l>
           </sp>
-          <sp>
+          <sp who="#malvezzi">
             <speaker>MALVEZZI</speaker>
             <l> E chi è il tuo fido amante? </l>
             <l>Spiega tosto questo arcano. </l>
           </sp>
-          <sp>
+          <sp who="#ugo">
             <speaker>UGO</speaker>
             <l> Ugo io son, sor capitano, </l>
             <l>Che per lei sono smaniante. </l>
@@ -2040,7 +2087,7 @@ Essa è Paola, e conoscente </l>
             <l>E per essa abbi. lottato, </l>
             <l>Sono al colmo del contento. </l>
           </sp>
-          <sp>
+          <sp who="#malvezzi">
             <speaker>MALVEZZI</speaker>
             <l> Nella posa tua marziale, </l>
             <l>Nobil donna di valore, </l>

--- a/tei/da-correggio-fabula-de-cefalo.xml
+++ b/tei/da-correggio-fabula-de-cefalo.xml
@@ -82,6 +82,61 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="aurora">
+            <persName>Aurora</persName>
+          </person>
+          <person xml:id="cefalo">
+            <persName>Cefalo</persName>
+          </person>
+          <person xml:id="fante">
+            <persName>Fante</persName>
+          </person>
+          <person xml:id="procri">
+            <persName>Procri</persName>
+          </person>
+          <person xml:id="diana">
+            <persName>Diana</persName>
+          </person>
+          <person xml:id="fauno">
+            <persName>Fauno</persName>
+          </person>
+          <person xml:id="coridone">
+            <persName>Coridone</persName>
+          </person>
+          <person xml:id="tirsi">
+            <persName>Tirsi</persName>
+          </person>
+          <person xml:id="damone">
+            <persName>Damone</persName>
+          </person>
+          <person xml:id="alfesibeo">
+            <persName>Alfesibeo</persName>
+          </person>
+          <person xml:id="fantesca">
+            <persName>Fantesca</persName>
+          </person>
+          <person xml:id="calliope">
+            <persName>Calliope</persName>
+          </person>
+          <person xml:id="filis">
+            <persName>Filis</persName>
+          </person>
+          <person xml:id="galatea">
+            <persName>Galatea</persName>
+          </person>
+          <person xml:id="deiopea">
+            <persName>Deiopea</persName>
+          </person>
+          <person xml:id="colomba">
+            <persName>Colomba</persName>
+          </person>
+          <personGrp xml:id="coro">
+            <name>Coro</name>
+          </personGrp>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>2003-05-21T00:00:00.000+02:00</date><name>Serena Ballin</name><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -175,7 +230,7 @@
           <hi rend="sc">ATTO PRIMO</hi>
         </head>
         <stage>Qui comenza l'<name><hi rend="sc">AURORA</hi></name> parlando a <name><hi rend="sc">CEFALO</hi></name>, exortandolo e pregandolo ch'el voglia condescendere a le sue voglie e desideri, e che facendolo lo colocarà nel numero di' dei:</stage>
-        <sp>
+        <sp who="#aurora">
           <speaker>AURORA.</speaker>
           <l><name>Cefalo</name>, io sum quella celeste <name>Aurora</name></l>
           <l>che dal vechio <name>Titon</name> tanto è bramata,</l>
@@ -195,7 +250,7 @@
           <l>dandoti me che tengo a schifo il <name>Sole</name>!</l>
         </sp>
         <stage><name><hi rend="sc">CEFALO</hi></name> risponde:</stage>
-        <sp>
+        <sp who="#cefalo">
           <speaker>
             <hi rend="sc">CEFALO.</hi>
           </speaker>
@@ -216,7 +271,7 @@
           <l>quella è la mia speranza e ogni mio bene</l>
           <l>e quella sola in vita or mi mantiene.</l>
         </sp>
-        <sp>
+        <sp who="#aurora">
           <speaker>
             <hi rend="sc">AURORA.</hi>
           </speaker>
@@ -238,7 +293,7 @@
           <l>così fa Amor dove ha posto l'assedio.</l>
         </sp>
         <stage><name><hi rend="sc">CEFALO</hi></name> a l'<name><hi rend="sc">AURORA</hi></name>:</stage>
-        <sp>
+        <sp who="#cefalo">
           <speaker>
             <name>
               <hi rend="sc">CEFALO.</hi>
@@ -254,7 +309,7 @@
           <l>se fidele al suo sposo se ritrova.</l>
         </sp>
         <stage>Partito <name><hi rend="sc">CEFALO</hi></name>, <hi rend="sc">AURORA</hi> parla a sé stessa:</stage>
-        <sp>
+        <sp who="#aurora">
           <speaker>
             <hi rend="sc">AURORA.</hi>
           </speaker>
@@ -284,7 +339,7 @@
           <l>quietar mi voglio in qualche umbroso lato.</l>
         </sp>
         <stage><name><hi rend="sc">CEFALO</hi></name> gionto a <name><hi rend="sc">PROCRI</hi></name> stravestito:</stage>
-        <sp>
+        <sp who="#cefalo">
           <speaker>
             <hi rend="sc">CEFALO.</hi>
           </speaker>
@@ -292,7 +347,7 @@
           <l>ch'io ho bixogno di parlarli alquanto.</l>
         </sp>
         <stage>La <name><hi rend="sc">FANTE</hi></name> de <name><hi rend="sc">PROCRI</hi></name> risponde:</stage>
-        <sp>
+        <sp who="#fante">
           <speaker>
             <hi rend="SC">FANTE.</hi>
           </speaker>
@@ -300,7 +355,7 @@
           <l>per gran facenda: io non potrei star tanto!</l>
         </sp>
         <stage><name><hi rend="sc">CEFALO</hi></name> risponde a la <name><hi rend="sc">FANTE</hi></name>:</stage>
-        <sp>
+        <sp who="#cefalo">
           <speaker>
             <hi rend="sc">CEFALO.</hi>
           </speaker>
@@ -310,7 +365,7 @@
           <l>falo, ch'io scio non servirai l'ingrato.</l>
         </sp>
         <stage><name><hi rend="sc">PROCRI</hi></name> essendo a la finestra sente parlar la <name><hi rend="sc">FANTE</hi></name>, dice in tal modo a lei:</stage>
-        <sp>
+        <sp who="#procri">
           <speaker>
             <hi rend="sc">PROCRI.</hi>
           </speaker>
@@ -318,7 +373,7 @@
           <l>teco ragiona e fa parole tante?</l>
         </sp>
         <stage>La <name><hi rend="sc">FANTE</hi></name> risponde a la <name><hi rend="sc">MADONNA</hi></name>:</stage>
-        <sp>
+        <sp who="#fante">
           <speaker>
             <hi rend="SC">FANTE.</hi>
           </speaker>
@@ -326,7 +381,7 @@
           <l>e mostra esser famoso mercadante.</l>
         </sp>
         <stage><name><hi rend="sc">PROCRI</hi></name> replicando a la <name><hi rend="sc">SERVA</hi></name> dice:</stage>
-        <sp>
+        <sp who="#procri">
           <speaker>
             <hi rend="sc">PROCRI.</hi>
           </speaker>
@@ -336,7 +391,7 @@
           <l>Ma via, che già t'hai smenticato il cesto!</l>
         </sp>
         <stage><name><hi rend="sc">CEFALO</hi></name> vedendo <name><hi rend="sc">PROCRI</hi></name> a lui venire essendo in abito mercadentesco li comenza a dire:</stage>
-        <sp>
+        <sp who="#cefalo">
           <speaker>
             <hi rend="sc">CEFALO.</hi>
           </speaker>
@@ -374,7 +429,7 @@
           <l>non curi d'altro e porti questo in dito.</l>
         </sp>
         <stage>Qui <name><hi rend="sc">CEFALO</hi></name> manda via el famiglio, e lui segue parlando:</stage>
-        <sp>
+        <sp who="#cefalo">
           <speaker>
             <hi rend="sc">CEFALO.</hi>
           </speaker>
@@ -388,7 +443,7 @@
           <l>tuo' fieno i doni, e me tuo servitore.</l>
         </sp>
         <stage>Qui <name><hi rend="sc">PROCRIS</hi></name> vòl fuzire. <name><hi rend="sc">CEFALO</hi></name> cusì segue parlando:</stage>
-        <sp>
+        <sp who="#procri">
           <speaker>
             <hi rend="sc">PROCRIS.</hi>
           </speaker>
@@ -418,7 +473,7 @@
           <l>Deh, non mi tenir più! Vedi ch'io moro!</l>
         </sp>
         <stage>Qui ritorna il famiglio; <name><hi rend="sc">CEFALO</hi></name> vedendolo va a lui. <name><hi rend="sc">PROCRIS</hi></name> da sì medema dice li sequenti versi:</stage>
-        <sp>
+        <sp who="#procri">
           <speaker>
             <hi rend="sc">PROCRIS.</hi>
           </speaker>
@@ -432,7 +487,7 @@
           <l>poi Amor me dice: Ogni secreta è casta.</l>
         </sp>
         <stage><name><hi rend="sc">CEFALO</hi></name> tornato a <name><hi rend="sc">PROCRIS</hi></name>, ela comenza, seguendo:</stage>
-        <sp>
+        <sp who="#cefalo">
           <speaker>
             <hi rend="sc">CEFALO.</hi>
           </speaker>
@@ -446,7 +501,7 @@
           <l>ma far contra el mio <name>Cefal</name> pur mi pesa.</l>
         </sp>
         <stage>Qui <name><hi rend="sc">CEFALO</hi></name> se scopre e volela tocare e PROCRI como sdegnata fugge e va dicendo li sequenti versi:</stage>
-        <sp>
+        <sp who="#procri">
           <speaker>
             <hi rend="sc">PROCRIS.</hi>
           </speaker>
@@ -460,7 +515,7 @@
           <l>né creder che impunito il ciel ti lassi!</l>
         </sp>
         <stage><name><hi rend="sc">CEFALO</hi></name> mal contento di averla inzuriata li dice:</stage>
-        <sp>
+        <sp who="#cefalo">
           <speaker>
             <hi rend="sc">CEFALO.</hi>
           </speaker>
@@ -474,7 +529,7 @@
           <l>che tu me cognoscesti ancor coperto.</l>
         </sp>
         <stage><name><hi rend="sc">PROCRIS</hi></name> entra fugiendo nel bosco e <name><hi rend="sc">CEFALO</hi></name> adolorato va fuore dicendo da sì instesso:</stage>
-        <sp>
+        <sp who="#cefalo">
           <speaker>
             <hi rend="sc">CEFALO.</hi>
           </speaker>
@@ -488,7 +543,7 @@
           <l>si faria Iuno dal suo ciel cadere!</l>
         </sp>
         <stage>Finito lo primo acto, la <name><hi rend="sc">AURORA</hi></name> acompagnata da un coro di <name><hi rend="sc">Muse</hi></name> che cantando l'acompagnoreno a l'asciender in ciel:</stage>
-        <sp>
+        <sp who="#aurora">
           <speaker>
             <hi rend="sc">AURORA.</hi>
           </speaker>
@@ -523,7 +578,7 @@
           <hi rend="sc">ATTO II</hi>
         </head>
         <stage>Incomenza il secundo acto: qui <name><hi rend="sc">PROCRIS</hi></name> esce del bosco ove era intrata e va al fonte de <name><hi rend="sc">DIANA</hi></name> che stava cum uno coro de ninfe e lamentandosi a lei dice li infrascriti versi:</stage>
-        <sp>
+        <sp who="#procri">
           <speaker>
             <hi rend="sc">PROCRIS.</hi>
           </speaker>
@@ -545,7 +600,7 @@
           <l>ché tal vita al mio gusto sempre piaque!</l>
         </sp>
         <stage><name><hi rend="sc">DIANA</hi></name> rispondendo a <name><hi rend="sc">PROCRIS</hi></name> dice:</stage>
-        <sp>
+        <sp who="#diana">
           <speaker>
             <hi rend="sc">DIANA.</hi>
           </speaker>
@@ -567,7 +622,7 @@
           <l>avanza, e le altre fiere a lui fien pigre.</l>
         </sp>
         <stage>Fato questo, entrano nel bosco per vestir <name><hi rend="sc">PROCRIS</hi></name> da ninfa e <name><hi rend="sc">CEFALO</hi></name> vien fuora del bosco e dice come segue:</stage>
-        <sp>
+        <sp who="#cefalo">
           <speaker>
             <hi rend="sc">CEFALO.</hi>
           </speaker>
@@ -589,7 +644,7 @@
           <l>e aiuta el pianger mio l'aura e le fronde.</l>
         </sp>
         <stage>Qui <name><hi rend="sc">PROCRIS</hi></name> vien fuora col dardo e col cane vestita da ninfa e <name><hi rend="sc">CEFALO</hi></name> la vede e segue cusì parlando:</stage>
-        <sp>
+        <sp who="#cefalo">
           <speaker>
             <hi rend="sc">CEFALO.</hi>
           </speaker>
@@ -611,7 +666,7 @@
           <l>fa' di me stracio, e lassa andar i cervi.</l>
         </sp>
         <stage><name><hi rend="sc">PROCRIS</hi></name> vedendo che <name><hi rend="sc">CEFALO</hi></name> la segue se gli volta e dice:</stage>
-        <sp>
+        <sp who="#procri">
           <speaker>
             <hi rend="sc">PROCRIS.</hi>
           </speaker>
@@ -625,7 +680,7 @@
           <l>e de più onesta dona te inamora.</l>
         </sp>
         <stage><name><hi rend="sc">CEFALO</hi></name> replicando segue cusì:</stage>
-        <sp>
+        <sp who="#cefalo">
           <speaker>
             <hi rend="sc">CEFALO.</hi>
           </speaker>
@@ -655,7 +710,7 @@
           <l>se Amor ve adempia i desiati ardori!</l>
         </sp>
         <stage>Qui si leva un <name><hi rend="sc">PASTOR</hi></name> veglio e ritinendo <name><hi rend="sc">PROCRIS</hi></name> sì gli dice:</stage>
-        <sp>
+        <sp who="#fauno">
           <speaker>
             <hi rend="sc">FAUNO.</hi>
           </speaker>
@@ -674,7 +729,7 @@
           <l>ferma qui el passo e fa' che non ti movi!</l>
         </sp>
         <stage><name><hi rend="sc">CEFALO</hi></name> visto da longi el pastore che ritenea <name><hi rend="sc">PROCRIS</hi></name> e domandavagli la cagione della sua fuga, cominzia a cridare e pregar quelo la vogli placare e dice:</stage>
-        <sp>
+        <sp who="#cefalo">
           <speaker>
             <hi rend="sc">CEFALO.</hi>
           </speaker>
@@ -696,7 +751,7 @@
           <l>Scio non serai contra di me crudiele!</l>
         </sp>
         <stage><name><hi rend="sc">PROCRIS</hi></name> sdegnata per la iniuria ricevuta, dice sicome in l'infrascriti versi se contene:</stage>
-        <sp>
+        <sp who="#procri">
           <speaker>
             <hi rend="sc">PROCRIS.</hi>
           </speaker>
@@ -705,7 +760,7 @@
           <l>mai questa offesa darò in arbandono</l>
           <l>fin che ‘l mio onor non è al suo ver riduto!</l>
         </sp>
-        <sp>
+        <sp who="#cefalo">
           <speaker>
             <hi rend="sc">CEFALO.</hi>
           </speaker>
@@ -719,7 +774,7 @@
           <l>di te, che dea del ciel tanto non vale!</l>
         </sp>
         <stage><name><hi rend="sc">PROCRIS</hi></name> placata per il sconzuro fato da <name><hi rend="sc">CEFALO</hi></name> dice come segue:</stage>
-        <sp>
+        <sp who="#procri">
           <speaker>
             <hi rend="sc">PROCRIS.</hi>
           </speaker>
@@ -729,7 +784,7 @@
           <l>di quel che è dicto in fin questa ora basta.</l>
         </sp>
         <stage>Finito che ebe <name><hi rend="sc">PROCRIS</hi></name>, quel pastore che ritiene <name><hi rend="sc">PROCRIS</hi></name>, alegro che i diti amanti siano pacificati, chiama con questa stanza alcuni pastori e invitali a festigiare:</stage>
-        <sp>
+        <sp who="#procri">
           <speaker>
             <hi rend="sc">PROCRIS.</hi>
           </speaker>
@@ -743,7 +798,7 @@
           <l>laudiamo Amor che sì gli amanti lacera.</l>
         </sp>
         <stage>Qui <name><hi rend="sc">CEFALO</hi></name> e <name><hi rend="sc">PROCRIS</hi></name> intrati nel bosco sonando e cantando insieme, e'; vien alcuni pastori fuora del bosco sonando e cantando la infrascrita egloga:</stage>
-        <sp>
+        <sp who="#coridone">
           <speaker>
             <hi rend="sc">CORIDONE.</hi>
           </speaker>
@@ -757,7 +812,7 @@
           <l>quando nel fiume a l'ombra de quei fagi</l>
           <l><name>Galatea</name> vene a fugir <name>Polifemo</name>.</l>
         </sp>
-        <sp>
+        <sp who="#tirsi">
           <speaker>
             <hi rend="sc">TIRSI.</hi>
           </speaker>
@@ -765,7 +820,7 @@
           <l>più di me cura, e vàsine sì altera</l>
           <l>che ‘l sol, vedendo lei, declina i ragi.</l>
         </sp>
-        <sp>
+        <sp who="#coridone">
           <speaker>
             <hi rend="sc">CORIDONE.</hi>
           </speaker>
@@ -773,7 +828,7 @@
           <l>vnuda giungesti quella mia nimica</l>
           <l>vinsuperbirsi a vagheggiar sua spera!</l>
         </sp>
-        <sp>
+        <sp who="#damone">
           <speaker>
             <hi rend="sc">DAMONE.</hi>
           </speaker>
@@ -784,7 +839,7 @@
           <l>chi gode, tace, e in fin dal cel s'asconde;</l>
           <l>sola cantando piange <name>Filomena</name>.</l>
         </sp>
-        <sp>
+        <sp who="#alfesibeo">
           <speaker>
             <hi rend="sc">ALFESIBEO.</hi>
           </speaker>
@@ -792,7 +847,7 @@
           <l>una umile caseta, e ognun si prenda</l>
           <l>una ninfa per forza in mezzo l'onde.</l>
         </sp>
-        <sp>
+        <sp who="#damone">
           <speaker>
             <hi rend="sc">DAMONE.</hi>
           </speaker>
@@ -803,7 +858,7 @@
           <l>e sia laudato il signor nostro Amore</l>
           <l>cum dolci soni e cum gli usati canti.</l>
         </sp>
-        <sp>
+        <sp who="#tirsi">
           <speaker>
             <hi rend="sc">TIRSI.</hi>
           </speaker>
@@ -811,7 +866,7 @@
           <l>l'altrui felicità, se ‘l mio tormento</l>
           <l>a pianger mi conduce a tute l'ore?</l>
         </sp>
-        <sp>
+        <sp who="#damone">
           <speaker>
             <hi rend="sc">DAMONE.</hi>
           </speaker>
@@ -819,7 +874,7 @@
           <l>non ti ricordar più, <name>Tirsi</name>, di quella:</l>
           <l>chi troppo abraza spesso strenze il vento.</l>
         </sp>
-        <sp>
+        <sp who="#alfesibeo">
           <speaker>
             <hi rend="sc">ALFESIBEO.</hi>
           </speaker>
@@ -827,7 +882,7 @@
           <l>mi ricordo aver già in brazo <name>Elisea</name>,</l>
           <l>gli ati ricordo, il volto e la favella.</l>
         </sp>
-        <sp>
+        <sp who="#coridone">
           <speaker>
             <hi rend="sc">CORIDONE.</hi>
           </speaker>
@@ -835,7 +890,7 @@
           <l>fugirmi inanti a questo sito florido</l>
           <l>e rider quanto più mi distrugea.</l>
         </sp>
-        <sp>
+        <sp who="#tirsi">
           <speaker>
             <hi rend="sc">TIRSI.</hi>
           </speaker>
@@ -843,7 +898,7 @@
           <l>seguir colei che ardea per un garzone</l>
           <l>sul primo pello, e tu già pastor orrido!</l>
         </sp>
-        <sp>
+        <sp who="#coridone">
           <speaker>
             <hi rend="sc">CORIDONE.</hi>
           </speaker>
@@ -858,7 +913,7 @@
           <hi rend="sc">ATTO III</hi>
         </head>
         <stage>Qui segue il terzio acto nel quale PROCRI e <name><hi rend="sc">CEFALO</hi></name> pacificati insieme escono del bosco avendo <name>Lepala</name> cane cum seco, e <name><hi rend="sc">PROCRI</hi></name> gli dona queste cose, dicendo così a <name><hi rend="sc">CEFALO</hi></name>.</stage>
-        <sp>
+        <sp who="#procri">
           <speaker>
             <hi rend="sc">PROCRI.</hi>
           </speaker>
@@ -904,7 +959,7 @@
           <l><name>Diana</name> invoca, e me ricorderai.</l>
         </sp>
         <stage><name><hi rend="sc">CEFALO</hi></name> aceptando li doni gli referise grazie e dice:</stage>
-        <sp>
+        <sp who="#cefalo">
           <speaker>
             <hi rend="sc">CEFALO.</hi>
           </speaker>
@@ -926,14 +981,14 @@
           <l>vien, <name>Procri</name>, cara a me più ca la vita!</l>
         </sp>
         <stage><name><hi rend="sc">PROCRI</hi></name> caminando per il bosco vide un cingiale e dice a <name><hi rend="sc">CEFALO</hi></name> che lasi il cane:</stage>
-        <sp>
+        <sp who="#procri">
           <speaker>
             <hi rend="sc">PROCRI.</hi>
           </speaker>
           <l>Eccoti il tempo ormai che pòi far prova</l>
           <l>lassa, <name>Cefal</name>, il can, ritieni il dardo!</l>
         </sp>
-        <sp>
+        <sp who="#cefalo">
           <speaker>
             <hi rend="sc">CEFALO.:</hi>
           </speaker>
@@ -941,7 +996,7 @@
           <l>Piglialo, traditor! Va là, gagliardo!</l>
         </sp>
         <stage><name><hi rend="sc">PROCRIS</hi></name> vedendo il cane entrar nel bosco dice a <name><hi rend="sc">CEFALO</hi></name> che ‘l seguise che altramente il perderia:</stage>
-        <sp>
+        <sp who="#procri">
           <speaker>
             <hi rend="sc">PROCRIS.</hi>
           </speaker>
@@ -951,7 +1006,7 @@
           <l>non t'intravenga! El par che l'abia l'ale!</l>
         </sp>
         <stage><name><hi rend="sc">PROCRIS</hi></name> parlando da sì medema dice:</stage>
-        <sp>
+        <sp who="#procri">
           <speaker>
             <hi rend="sc">PROCRIS.</hi>
           </speaker>
@@ -981,7 +1036,7 @@
           <l>Che torni salvo <name>Iove</name> gli conceda!</l>
         </sp>
         <stage>Entrata <name><hi rend="sc">PROCRIS</hi></name> in casa viene <name><hi rend="sc">CEFALO</hi></name> for del bosco stanco per seguitare il cane e dise fra lui:</stage>
-        <sp>
+        <sp who="#cefalo">
           <speaker>
             <hi rend="sc">CEFALO.</hi>
           </speaker>
@@ -1003,7 +1058,7 @@
           <l>medico a le fadiche, aura mia, viene!</l>
         </sp>
         <stage>Qui <name><hi rend="sc">CEFALO</hi></name> tace e uno <name><hi rend="sc">FAUNO</hi></name> che abitava quilli boschi 1'odì che parlava e cognosilo; va a <name><hi rend="sc">PROCRIS</hi></name> che aspetava <name><hi rend="sc">CEFALO</hi></name> e sì li dise:</stage>
-        <sp>
+        <sp who="#fauno">
           <speaker>
             <hi rend="sc">FAUNO.</hi>
           </speaker>
@@ -1025,7 +1080,7 @@
           <l>d'un novo amante ti provederai.</l>
         </sp>
         <stage>Risponde <name><hi rend="sc">PROCRIS</hi></name> al <name><hi rend="sc">FAUNO</hi></name>:</stage>
-        <sp>
+        <sp who="#procri">
           <speaker>
             <hi rend="sc">PROCRIS.</hi>
           </speaker>
@@ -1037,7 +1092,7 @@
           <l>io mi raconcigliai col traditore!</l>
         </sp>
         <stage>Il <name><hi rend="sc">FAUNO</hi></name> replica e dice:</stage>
-        <sp>
+        <sp who="#fauno">
           <speaker>
             <hi rend="sc">FAUNO.</hi>
           </speaker>
@@ -1053,7 +1108,7 @@
           <l>se vòi altro da me, io sto là su.</l>
         </sp>
         <stage><name><hi rend="sc">PROCRIS</hi></name> pàrtisse per andar verso il bosco e dice da sua porta:</stage>
-        <sp>
+        <sp who="#procri">
           <speaker>
             <hi rend="sc">PROCRIS.</hi>
           </speaker>
@@ -1075,7 +1130,7 @@
           <l>esser sepulta viva in una fossa!</l>
         </sp>
         <stage>In questo mezo che lei dicea cusì da per lei, guardando per il bosco vide <name><hi rend="sc">CEFALO</hi></name> che era stato a cercare il cane. <name><hi rend="sc">CEFALO</hi></name> parla a <name><hi rend="sc">PROCRIS</hi></name> e dice:</stage>
-        <sp>
+        <sp who="#cefalo">
           <speaker>
             <hi rend="sc">CEFALO.</hi>
           </speaker>
@@ -1099,7 +1154,7 @@
           <l>ché stato è forsi de li dei sum'opra.</l>
         </sp>
         <stage><name><hi rend="sc">CEFALO</hi></name> entra in casa e <name><hi rend="sc">PROCRI</hi></name> che era a la finestra gli risponde e dice:</stage>
-        <sp>
+        <sp who="#procri">
           <speaker>
             <hi rend="sc">PROCRIS.</hi>
           </speaker>
@@ -1111,7 +1166,7 @@
           <l>che io li interomperò el suo desiderio!</l>
         </sp>
         <stage>Qui finise el terzo acto. El <name><hi rend="sc">FAUNO</hi></name> che vedendo da longi averse messo fra <name><hi rend="sc">CEFALO</hi></name> e <name><hi rend="sc">PROCRI</hi></name>, chiama alcun che a consolazion di questo vogliano sonare e saltare e cusì uscisseno del bosco cum varii acti e salti dicendo li infrascripti versi:</stage>
-        <sp>
+        <sp who="#fauno">
           <speaker>
             <hi rend="sc">FAUNO.</hi>
           </speaker>
@@ -1162,7 +1217,7 @@
           <hi rend="sc">ATTO IV</hi>
         </head>
         <stage>Qui comenza el quarto acto come la <name><hi rend="sc">FANTESCA</hi></name> de <name><hi rend="sc">PROCRI</hi></name> esce de casa e va per cercar el <name><hi rend="sc">FAUNO</hi></name> che acusò <name><hi rend="sc">CEFALO</hi></name>, e da sì instessa parlando in questa forma dice:</stage>
-        <sp>
+        <sp who="#fantesca">
           <speaker>
             <hi rend="sc">FANTESCA.</hi>
           </speaker>
@@ -1192,7 +1247,7 @@
           <l>e per fugirla è fato cazatore.</l>
         </sp>
         <stage>Continua il parlare:</stage>
-        <sp>
+        <sp who="#fantesca">
           <speaker>
             <hi rend="sc">FANTESCA.</hi>
           </speaker>
@@ -1214,7 +1269,7 @@
           <l>chi crede a l'ochio e non quel che se dice!</l>
         </sp>
         <stage>La  <name>Fante</name> torna a casa e <name><hi rend="sc">CEFALO</hi></name> torna fuora del bosco. Quando <name><hi rend="sc">PROCRI</hi></name> il seguiva, stando <name><hi rend="sc">PROCRI</hi></name> da la lunga sente <name><hi rend="sc">CEFALO</hi></name> che dicea li ultimi versi:</stage>
-        <sp>
+        <sp who="#cefalo">
           <speaker>
             <hi rend="sc">CEFALO.</hi>
           </speaker>
@@ -1228,7 +1283,7 @@
           <l>cum piacer brevi dà longi dolori.</l>
         </sp>
         <stage>Intrando <name><hi rend="sc">CEFALO</hi></name> in uno altro boscheto, <name><hi rend="sc">PROCRI</hi></name> sì se asconde fra certe frasche ad audir quelo che <name><hi rend="sc">CEFALO</hi></name> dicea e così dice:</stage>
-        <sp>
+        <sp who="#cefalo">
           <speaker>
             <hi rend="sc">CEFALO.</hi>
           </speaker>
@@ -1242,7 +1297,7 @@
           <l>de gli affanni ristoro, <name>Aura</name> mia vene!</l>
         </sp>
         <stage><name><hi rend="sc">PROCRI</hi></name> che udiva <name><hi rend="sc">CEFALO</hi></name>, credendo che lui chiamase la <name><hi rend="sc">AURORA</hi></name> se leva per vederla e <name><hi rend="sc">CEFALO</hi></name> la crede che sia una fiera; levato in pié cusì dice:</stage>
-        <sp>
+        <sp who="#cefalo">
           <speaker>
             <hi rend="sc">CEFALO.</hi>
           </speaker>
@@ -1256,7 +1311,7 @@
           <l>di chiamar te e lei nel cor tenire.</l>
         </sp>
         <stage><name><hi rend="sc">CEFALO</hi></name> trato il dardo vagli drieto nel bosco credendo aver ferito una fiera: trovata <name><hi rend="sc"><name><hi rend="sc">PROCRI</hi></name></hi></name> ferita, lei vistolo cade e crida dicendo:</stage>
-        <sp>
+        <sp who="#procri">
           <speaker>
             <hi rend="sc">PROCRIS.</hi>
           </speaker>
@@ -1270,7 +1325,7 @@
           <l>perché vòi farme de li amanti exempio?</l>
         </sp>
         <stage><name><hi rend="sc">CEFALO</hi></name> visto <name><hi rend="sc">PROCRI</hi></name> ferita e caduta a terra, core là e pigliala in bracio e dice:</stage>
-        <sp>
+        <sp who="#cefalo">
           <speaker>
             <hi rend="sc">CEFALO.</hi>
           </speaker>
@@ -1292,7 +1347,7 @@
           <l>venir vo' teco a quella infernal corte.</l>
         </sp>
         <stage>Como <name><hi rend="sc">CEFALO</hi></name> volendo sferare, <name><hi rend="sc">PROCRI</hi></name> gli dice:</stage>
-        <sp>
+        <sp who="#cefalo">
           <speaker>
             <hi rend="sc">CEFALO.</hi>
           </speaker>
@@ -1314,7 +1369,7 @@
           <l>tira può ‘l fero del mio pecto fuora.</l>
         </sp>
         <stage><name><hi rend="sc">CEFALO</hi></name> vedendo <name><hi rend="sc">PROCRI</hi></name> render l'alma cusì dice:</stage>
-        <sp>
+        <sp who="#cefalo">
           <speaker>
             <hi rend="sc">CEFALO.</hi>
           </speaker>
@@ -1328,7 +1383,7 @@
           <l>e la mia di tardar tropo se teme.</l>
         </sp>
         <stage><name><hi rend="sc">CEFALO</hi></name> vedendo morta <name><hi rend="sc">PROCRI</hi></name> alzati li ochi vide <name>CALIOPE</name> cum tute le muse e incomenzò a dire così sopra el morto corpo:</stage>
-        <sp>
+        <sp who="#cefalo">
           <speaker>
             <hi rend="sc">CEFALO.</hi>
           </speaker>
@@ -1346,7 +1401,7 @@
           <l>spiegati un mesto canto,</l>
           <l>che a pietà di costei mova le stelle.</l>
         </sp>
-        <sp>
+        <sp who="#calliope">
           <speaker>
             <hi rend="sc">CALLIOPE.</hi>
           </speaker>
@@ -1368,7 +1423,7 @@
           <l>che si spenda in tal acto ne concede.</l>
         </sp>
         <stage><name><hi rend="sc">CEFALO.</hi></name><name><hi rend="sc">CEFALO</hi></name> voltato a le ninfe in tal modo gli dice:</stage>
-        <sp>
+        <sp who="#cefalo">
           <speaker>
             <hi rend="sc">CEFALO.</hi>
           </speaker>
@@ -1382,7 +1437,7 @@
           <l>ché cagion le mie man de ciò sun state.</l>
         </sp>
         <stage><name><hi rend="sc">FILIS</hi></name> ninfa se gli acosta vedendola morta e voltasi ale altre ninfe e dice:</stage>
-        <sp>
+        <sp who="#filis">
           <speaker>
             <hi rend="sc">FILIS.</hi>
           </speaker>
@@ -1396,7 +1451,7 @@
           <l>l'ellera pigliarò, tu el mirto prendi.</l>
         </sp>
         <stage><name><hi rend="sc">GALATEA</hi></name> parla a <name><hi rend="sc">CEFALO</hi></name>:</stage>
-        <sp>
+        <sp who="#galatea">
           <speaker>
             <hi rend="sc">GALATEA.</hi>
           </speaker>
@@ -1437,7 +1492,7 @@
           <l>morte non manchi al misero amatore.</l>
         </sp>
         <stage>Qui <name><hi rend="sc">GALATEA</hi></name> e <name><hi rend="sc">FILIS</hi></name> leva <name><hi rend="sc">CEFALO</hi></name> e copreno <name><hi rend="sc">PROCRI</hi></name> morta e lui andando a casa, voltandosi a guardar <name><hi rend="sc">PROCRI</hi></name>, dice:</stage>
-        <sp>
+        <sp who="#cefalo">
           <speaker>
             <hi rend="sc">CEFALO.</hi>
           </speaker>
@@ -1451,7 +1506,7 @@
           <l>come de pietà siti or tanto ignude?</l>
         </sp>
         <stage><name><hi rend="sc">DEIOPEA</hi></name> dice sopra <name><hi rend="sc">PROCRI</hi></name> questi versi:</stage>
-        <sp>
+        <sp who="#deiopea">
           <speaker>
             <hi rend="sc">DEIOPEA.</hi>
           </speaker>
@@ -1465,7 +1520,7 @@
           <l>riposa, ninfa, eternalmente in pace!</l>
         </sp>
         <stage>CALIOPE ninfa:</stage>
-        <sp>
+        <sp who="#calliope">
           <speaker>
             <hi rend="sc">CALIOPE.</hi>
           </speaker>
@@ -1479,7 +1534,7 @@
           <l>che riposo non sta cum gelosia.</l>
         </sp>
         <stage>Questa stanza se cantò in l'aere, da la columba, sopra el morto corpo:</stage>
-        <sp>
+        <sp who="#colomba">
           <speaker>
             <hi rend="sc">COLOMBA.</hi>
           </speaker>
@@ -1493,7 +1548,7 @@
           <l>che ‘l passo in Stigie non gi sia vetato.</l>
         </sp>
         <stage>Capitolo che dise <name><hi rend="sc">GALATEA</hi></name> cum la face in mano per acender la pira dove morta <name><hi rend="sc">PROCRI</hi></name> iacea:</stage>
-        <sp>
+        <sp who="#galatea">
           <speaker>
             <hi rend="sc">GALATEA.</hi>
           </speaker>
@@ -1529,7 +1584,7 @@
           <hi rend="sc">ATTO V</hi>
         </head>
         <stage>Qui comenza el quinto acto, como <name><hi rend="sc">DIANA</hi></name> vien cum le sue ninfe e dice l'infrascripti versi:</stage>
-        <sp>
+        <sp who="#diana">
           <speaker>
             <hi rend="sc">DIANA.</hi>
           </speaker>
@@ -1551,7 +1606,7 @@
           <l>ché in ciel comando, e in terra, a li elimenti.</l>
         </sp>
         <stage>Qui <name><hi rend="sc">DIANA</hi></name> toca <name><hi rend="sc">PROCRI</hi></name> col dardo e dice:</stage>
-        <sp>
+        <sp who="#diana">
           <speaker>
             <hi rend="sc">DIANA.</hi>
           </speaker>
@@ -1565,7 +1620,7 @@
           <l>cantise in festa qui, siate tranquille.</l>
         </sp>
         <stage><name><hi rend="sc">GALATEA</hi></name> va per <name><hi rend="sc">CEFALO</hi></name> con <name><hi rend="sc">FILLE</hi></name>; e <name><hi rend="sc">PROCRI</hi></name>, a <name><hi rend="sc">DIANA</hi></name> ingionochiata, parlando dice:</stage>
-        <sp>
+        <sp who="#procri">
           <speaker>
             <hi rend="sc">PROCRI.</hi>
           </speaker>
@@ -1587,7 +1642,7 @@
           <l>sciolselo a un tracto col mio viver morte.</l>
         </sp>
         <stage><name><hi rend="sc">DIANA</hi></name> a <name><hi rend="sc">PROCRI</hi></name>.</stage>
-        <sp>
+        <sp who="#diana">
           <speaker>
             <hi rend="sc">DIANA.</hi>
           </speaker>
@@ -1601,7 +1656,7 @@
           <l>e siati insieme lungamente in pace.</l>
         </sp>
         <stage>Come <name><hi rend="sc">GALATEA</hi></name> vien parlando a <name><hi rend="sc">CEFALO</hi></name> e levili uno manto bruno e cusì dice:</stage>
-        <sp>
+        <sp who="#galatea">
           <speaker>
             <hi rend="sc">GALATEA.</hi>
           </speaker>
@@ -1611,7 +1666,7 @@
           <l>l'ochio tuo fa che al mio parlar dai fede!</l>
         </sp>
         <stage><name><hi rend="sc">CEFALO</hi></name> risponde:</stage>
-        <sp>
+        <sp who="#cefalo">
           <speaker>
             <hi rend="sc">CEFALO.</hi>
           </speaker>
@@ -1619,7 +1674,7 @@
           <l>ch'io la tochi, che l'ochio ancor no ‘l crede.</l>
         </sp>
         <stage><name><hi rend="sc">GALATEA</hi></name> dice:</stage>
-        <sp>
+        <sp who="#galatea">
           <speaker>
             <hi rend="sc">GALATEA.</hi>
           </speaker>
@@ -1627,7 +1682,7 @@
           <l>che di ben farti mai se vide sazia!</l>
         </sp>
         <stage><name><hi rend="sc">CEFALO</hi></name> in zenochion a <name><hi rend="sc">DIANA</hi></name> dice :</stage>
-        <sp>
+        <sp who="#cefalo">
           <speaker>
             <hi rend="sc">CEFALO.</hi>
           </speaker>
@@ -1641,7 +1696,7 @@
           <l>e magior don di me dar non ti posso.</l>
         </sp>
         <stage><name><hi rend="sc">DIANA</hi></name> fa levar <name><hi rend="sc">CEFALO</hi></name> e presentagli <name><hi rend="sc">PROCRI</hi></name>:</stage>
-        <sp>
+        <sp who="#diana">
           <speaker>
             <hi rend="sc">DIANA.</hi>
           </speaker>
@@ -1663,7 +1718,7 @@
           <l>Vui, ninfe, adunque festigiar si vòle.</l>
         </sp>
         <stage>Qui vano insieme a casa acompagnati da le ninfe e muse intorno cantando la ultima cantilena che cusì comenza:</stage>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <hi rend="sc">CORO.</hi>
           </speaker>
@@ -1696,7 +1751,7 @@
           <l>Cantate, o ninfe belle.</l>
         </sp>
         <stage>Dicta questa cantilena vene fuora <name><hi rend="sc">CALLIOPE</hi></name> e dice la sequente stanza:</stage>
-        <sp>
+        <sp who="#calliope">
           <speaker>
             <hi rend="sc">CALLIOPE.</hi>
           </speaker>

--- a/tei/da-ponte-cosi-fan-tutte.xml
+++ b/tei/da-ponte-cosi-fan-tutte.xml
@@ -85,6 +85,28 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="ferrando">
+            <persName>Ferrando</persName>
+          </person>
+          <person xml:id="guglielmo">
+            <persName>Guglielmo</persName>
+          </person>
+          <person xml:id="alfonso">
+            <persName>Don Alfonso</persName>
+          </person>
+          <person xml:id="fiordiligi">
+            <persName>Fiordiligi</persName>
+          </person>
+          <person xml:id="dorabella">
+            <persName>Dorabella</persName>
+          </person>
+          <person xml:id="despina">
+            <persName>Despina</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -140,46 +162,46 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>Ferando, Guglielmo e Don Alfonso.</stage>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>La mia Dorabella</l>
             <l>Capace non è:</l>
             <l>Fedel quanto bella</l>
             <l>Il cielo la fe’.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>La mia Fiordiligi</l>
             <l>Tradirmi non sa:</l>
             <l>Uguale in lei credo</l>
             <l>Costanza a beltà</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Ho i crini già grigi,</l>
             <l><emph>Ex cathedra</emph> parlo;</l>
             <l>Ma tali litigi</l>
             <l>Finiscano qua.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <l>No, detto ci avete</l>
             <l>Che infide esser ponno:</l>
             <l>Provar ce ’l dovete,</l>
             <l>Se avete onestà.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Tai prove lasciamo…</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <stage>metton mano alla spada</stage>
             <l>No no, le vogliamo:</l>
             <l>O fuori la spada,</l>
             <l>Rompiam l’amistà.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <stage>
               <stage>da sé</stage>
@@ -189,7 +211,7 @@
             <l>Quel mal che trovato</l>
             <l>Meschini ci fa.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <stage>da sé</stage>
             <l>Sul vivo mi tocca</l>
@@ -197,32 +219,32 @@
             <l>Sortire un accento</l>
             <l>Che torto le fa.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Fuor la spada! Scegliete</l>
             <l>Qual di noi più vi piace.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <stage>placido</stage>
             <l>Io son uomo di pace,</l>
             <l>E duelli non fo, se non a mensa.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>O battervi, o dir subito</l>
             <l>Perché d’infedeltà le nostre amanti</l>
             <l>Sospettate capaci!</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Cara semplicità, quanto mi piaci!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Cessate di scherzar, o giuro al cielo…</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Ed io, giuro alla terra,</l>
             <l>Non scherzo, amici miei.</l>
@@ -233,12 +255,12 @@
             <l>Se mangian come noi, se veston gonne,</l>
             <l>Alfin se dèe, se donne son…</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <l>Son donne,</l>
             <l>Ma… son tali… son tali…</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>E in donne pretendete</l>
             <l>Di trovar fedeltà?</l>
@@ -249,29 +271,29 @@
             <l>Che vi sia ciascun lo dice;</l>
             <l>Dove sia nessun lo sa.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <stage>con fuoco</stage>
             <l>La fenice è Dorabella!</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>La fenice è Fiordiligi!</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Non è questa, non è quella:</l>
             <l>Non fu mai, non vi sarà.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Scioccherie di poeti!</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Scempiaggini di vecchi!</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Orbene, udite,</l>
             <l>Ma senza andar in collera:</l>
@@ -280,159 +302,159 @@
             <l>Chi vi fe’ sicurtà che invariabili</l>
             <l>Sono i lor cori?</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>  Lunga esperienza…</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Nobil educazion…</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Pensar sublime…</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Analogia d’umor…</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Disinteresse…</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Immutabil carattere…</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Promesse…</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Proteste…</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Giuramenti…</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Pianti, sospir, carezze, svenimenti.</l>
             <l>Lasciatemi un po’ ridere…</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>  Cospetto!</l>
             <l>Finite di deriderci?</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l> Pian piano:</l>
             <l>E se toccar con mano</l>
             <l>Oggi vi fo che come l’altre sono?</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Non si può dar!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Non è!</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Giochiam!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Giochiamo!</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Cento zecchini.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>E mille, se volete.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Parola…</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l> Parolissima.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>E un cenno, un motto, un gesto</l>
             <l>Giurate di non far di tutto questo</l>
             <l>Alle vostre Penelopi.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>  Giuriamo.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Da soldati d’onore.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Da soldati d’onore.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>E tutto quel farete</l>
             <l>Ch’io vi dirò di far.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l> Tutto!</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Tuttissimo!</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Bravissimi!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <l>  Bravissimo,</l>
             <l>Signor Don Alfonsetto!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>  A spese vostre</l>
             <l>Or ci divertiremo.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <stage>a Ferrando</stage>
             <l>E de’ cento zecchini, che faremo?</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Una bella serenata</l>
             <l>Far io voglio alla mia dea.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>In onor di Citerea</l>
             <l>Un convito io voglio far.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Sarò anch’io de’ convitati?</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <l>Ci sarete, sì signor.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo #alfonso">
             <speaker>FERRANDO, GUGLIELMO, ALFONSO</speaker>
             <l>E che brindisi replicati</l>
             <l>Far vogliamo al Dio d’amor!</l>
@@ -443,46 +465,46 @@
           <head>SCENA II</head>
           <stage>Giardino sulla spiaggia del mare.</stage>
           <stage>Fiordiligi e Dorabella guardano un ritratto che lor pende al fianco.</stage>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Ah guarda, sorella,</l>
             <l>Se bocca più bella,</l>
             <l>Se aspetto più nobile</l>
             <l>Si può ritrovar.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Osserva tu un poco</l>
             <l>Che fuoco ha ne’ sguardi!</l>
             <l>Se fiamma, se dardi</l>
             <l>Non sembran scoccar.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Si vede un sembiante</l>
             <l>Guerriero ed amante.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Si vede una faccia</l>
             <l>Che alletta e minaccia.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Io sono felice.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Felice son io.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Se questo mio core</l>
             <l>Mai cangia desio,</l>
             <l>Amore mi faccia</l>
             <l>Vivendo penar!</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Mi par che stamattina volentieri</l>
             <l>Farei la pazzarella: ho un certo fuoco,</l>
@@ -490,33 +512,33 @@
             <l>Quando Guglielmo viene, se sapessi</l>
             <l>Che burla gli vo’ far.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Per dirti il vero.</l>
             <l>Qualche cosa di nuovo</l>
             <l>Anch’io nell’alma provo: io giurerei</l>
             <l>Che lontane non siam dagli imenei.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Dammi la mano, io voglio astrolicarti.</l>
             <l>Uh che bell’Emme! E questo</l>
             <l>È un Pi! Va bene: matrimonio presto.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Affé, che ci avrei gusto!</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Ed io non ci avrei rabbia.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Ma che diavol vuol dir che i nostri sposi</l>
             <l>Ritardano a venir? Son già le sei…</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Eccoli.</l>
           </sp>
@@ -524,31 +546,31 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>Fiordiligi, Dorabella e Don Alfonso.</stage>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Non son essi: è Don Alfonso,</l>
             <l>L’amico lor.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Ben venga</l>
             <l>Il signor Don Alfonso!</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>  Riverisco.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Cos’è? perché qui solo? Voi piangete?</l>
             <l>Parlate, per pietà: che cosa è nato?</l>
             <l>L’amante…</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l> L’idol mio…</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l> Barbaro fato!</l>
             <l>Vorrei dir e cor non ho,</l>
@@ -560,92 +582,92 @@
             <l>Dar di peggio non si può:</l>
             <l>Ho di voi, di lor pietà!</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Stelle! per carità, signor Alfonso.</l>
             <l>Non ci fate morir.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l> Convien armarvi,</l>
             <l>Figlie mie, di costanza.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>  O Dei! qual male</l>
             <l>È addivenuto mai, qual caso rio?</l>
             <l>Forse è morto il mio bene?</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>È morto il mio?</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Morti… non son; ma poco men che morti.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Feriti?</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>No.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Ammalati?</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Neppur.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l> Che cosa, dunque?</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l> Al marzial campo</l>
             <l>Ordin regio li chiama.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l> Oimè, che sento!</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>E partiran?</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l> Sul fatto.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>E non v’è modo</l>
             <l>D’impedirlo?</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Non v’è.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Né un solo addio?…</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Gli infelici non hanno</l>
             <l>Coraggio di vedervi.</l>
             <l>Ma se voi lo bramate,</l>
             <l>Son pronti…</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Dove son?</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Amici, entrate.</l>
           </sp>
@@ -653,105 +675,105 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>Fiordiligi, Dorabella, Don Alfonso, Ferrando e Guglielmo in abito da viaggio.</stage>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Sento, oh Dio, che questo piede</l>
             <l>È restio nel girle avante.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Il mio labbro palpitante</l>
             <l>Non può detto pronunziar.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Nei momenti i più terribili</l>
             <l>Sua virtù l’eroe palesa.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Or che abbiam la nuova intesa,</l>
             <l>A voi resta a fare il meno.</l>
             <l>Fate core: a entrambe in seno</l>
             <l>Immergeteci l’acciar.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <l>Idol mio, la sorte incolpa,</l>
             <l>Se ti deggio abbandonar.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Ah no no, non partirai!</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>No, crudel, non te ne andrai!</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Voglio pria cavarmi il core!</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Pria ti vo’ morire ai piedi!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <stage>sottovoce a Don Alfonso</stage>
             <l>Cosa dici?</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <stage>sottovoce a Don Alfonso</stage>
             <l>Te n’avvedi?</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <stage>sottovoce ai due amanti</stage>
             <l>Saldo, amico: <foreign xml:lang="lat">finem lauda.</foreign></l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella #ferrando #guglielmo #alfonso">
             <speaker>FIORDILIGI, DORABELLA, FERRANDO, GUGLIELMO, ALFONSO</speaker>
             <l>Il destin così defrauda</l>
             <l>Le speranze de’ mortali.</l>
             <l>Ah chi mai fra tanti mali,</l>
             <l>Chi mai può la vita amar?</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Non piangere, idol mio!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Non disperarti,</l>
             <l>Adorata mia sposa!</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Lasciate lor tal sfogo: è troppo giusta</l>
             <l>La cagion di quel pianto.</l>
             <stage>Si abbracciano teneramente.</stage>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Chi sa s’io più ti veggio!</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Chi sa se più ritorni!</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Lasciami questo ferro: ei mi dia morte,</l>
             <l>Se mai barbara sorte</l>
             <l>In quel seno a me caro…</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Morrei di duol; d’uopo non ho d’acciaro.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <l>Non farmi, anima mia,</l>
             <l>Questi infausti presagi.</l>
@@ -768,28 +790,28 @@
             <l>Felice al tuo seno</l>
             <l>Io spero tornar.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <stage>da sé</stage>
             <l>La commedia è graziosa, e tutti e due</l>
             <l>Fan ben la loro parte. </l>
             <stage>Si sente un tamburo a distanza.</stage>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>O cielo! questo</l>
             <l>È il tamburo funesto</l>
             <l>Che a divider mi vien dal mio tesoro.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Ecco, amici, la barca.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Io manco.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l> Io moro.</l>
           </sp>
@@ -798,7 +820,7 @@
           <head>SCENA V</head>
           <stage>Fiordiligi, Dorabella, Don Alfonso, Ferrando, Guglielmo, soldati e popolani.</stage>
           <stage>Marcia militare in qualche distanza. Arriva una barca alla sponda; poi entra nella scena una truppa di soldati, accompagnata da uomini e donne.</stage>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Bella vita militar!</l>
             <l>Ogni dì si cangia loco,</l>
@@ -809,32 +831,32 @@
             <l>Forza accresce al braccio e all’anima,</l>
             <l>Vaga sol di trionfar.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Non v’è più tempo, amici: andar conviene</l>
             <l>Ove il destino, anzi il dover v’invita.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Mio cor…</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Idolo mio…</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>  Mio ben…</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>  Mia vita…</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Ah per un sol momento…</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Del vostro reggimento</l>
             <l>Già è partita la barca.</l>
@@ -842,60 +864,60 @@
             <l>Che su legno più lieve</l>
             <l>Attendendo vi stanno.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <l>Abbracciami, idol mio!</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Muoio d’affanno.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <stage>piangendo</stage>
             <l>Di… scrivermi… ogni… giorno</l>
             <l>Giurami… vita… mia.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <stage>piangendo</stage>
             <l>Due volte… ancora…</l>
             <l>Tu… scrivimi… se… puoi…</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Sii certa, o cara.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Non… dubitar mio bene…</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <stage>da sé</stage>
             <l>Io crepo, se non rido!</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Sii costante a me sol…</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>  Sèrbati fido.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Addio!</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Addio!</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Addio!</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella #ferrando #guglielmo">
             <speaker>FIORDILIGI, DORABELLA, FERRANDO, GUGLIELMO </speaker>
             <l>Mi si divide il cor, bell’idol mio!</l>
           </sp>
@@ -904,21 +926,21 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>Fiordiligi, Dorabella e Don Alfonso.</stage>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <stage>in atto di chi rinviene da un letargo</stage>
             <l>Dove son?</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Son partiti.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>  Oh dipartenza</l>
             <l>Crudelissima, amara!</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Fate core,</l>
             <l>Carissime figliuole.</l>
@@ -926,31 +948,31 @@
             <l>Guardate, da lontano</l>
             <l>Vi fan cenno con mano i cari sposi.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Buon viaggio, mia vita!</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Buon viaggio!</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>O dèi, come veloce</l>
             <l>Se ne va quella barca! Già sparisce,</l>
             <l>Già, non si vede più. Deh faccia il cielo</l>
             <l>Ch’abbia prospero corso.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Faccia che al campo giunga</l>
             <l>Con fortunati auspici.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>E a voi salvi gli amanti, a me gli amici.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella #alfonso">
             <speaker>FIORDILIGI, DORABELLA, ALFONSO</speaker>
             <l>Soave sia il vento,</l>
             <l>Tranquilla sia l’onda,</l>
@@ -963,7 +985,7 @@
         <div type="scene">
           <head>SCENA VII</head>
           <stage>Don Alfonso da solo.</stage>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Non son cattivo comico! Va bene…</l>
             <l>Al concertato loco i due campioni</l>
@@ -985,7 +1007,7 @@
           <head>SCENA VIII</head>
           <stage>Camera gentile con diverse sedie, un tavolino ecc.; tre porte: due laterali, una di mezzo.</stage>
           <stage>Despina che sta facendo il cioccolatte.</stage>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Che vita maledetta</l>
             <l>È il far la cameriera!</l>
@@ -1009,33 +1031,33 @@
         <div type="scene">
           <head>SCENA IX</head>
           <stage>Despina, Dorabella, Fiordiligi ch’entrano disperatamente. Despina presenta il cioccolatte sopra una guantiera. Dorabella gitta tutto a terra.</stage>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Diamine! Cosa fate?</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Ah!</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Ah! </l>
             <stage>Si cavano entrambe tutti gli ornamenti donneschi.</stage>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Che cosa è nato?</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Ov’è un acciaro?</l>
             <l>Un veleno dov’è?</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l> Padrone, dico!…</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Ah scòstati! Paventa il triste effetto</l>
             <l>D’un disperato affetto!</l>
@@ -1057,92 +1079,92 @@
             <l>De’ miei sospir!</l>
             <stage>Si mettono a sedere in disparte, ad forsennate.</stage>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Signora Dorabella,</l>
             <l>Signora Fiordiligi,</l>
             <l>Ditemi: che cosa è stato?</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Oh terribil disgrazia!</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Sbrigatevi, in buonora!</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Da Napoli partiti</l>
             <l>Sono gli amanti nostri.</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <stage>ridendo</stage>
             <l>Non c’è altro?</l>
             <l>Ritorneran.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l> Chi sa!</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>  Come, chi sa?</l>
             <l>Dove son iti?</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Al campo di battaglia.</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Tanto meglio per loro:</l>
             <l>Li vedrete tornar carchi d’alloro.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Ma ponno anche perir.</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l> Allora, poi,</l>
             <l>Tanto meglio per voi.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <stage>sorge arrabbiata</stage>
             <l>Sciocca! che dici?</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>La pura verità: due ne perdete,</l>
             <l>Vi restan tutti gli altri.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Ah perdendo Guglielmo</l>
             <l>Mi pare ch’io morrei!</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Ah Ferrando perdendo</l>
             <l>Mi par che viva a seppellirmi andrei!</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Brave, «vi par», ma non è ver: sinora</l>
             <l>Non vi fu donna che d’amor sia morta.</l>
             <l>Per un uomo morir!… Altri ve n’hanno</l>
             <l>Che compensano il danno.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>E credi che potria</l>
             <l>Altro uomo amar chi s’ebbe per amante</l>
             <l>Un Guglielmo, un Ferrando?</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Hanno gli altri ancora</l>
             <l>Tutto quello ch’han essi.</l>
@@ -1155,23 +1177,23 @@
             <l>Pianti perdere il tempo,</l>
             <l>Pensate a divertirvi.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <stage>con trasporto di collera</stage>
             <l>Divertirci?</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Sicuro! E, quel ch’è meglio,</l>
             <l>Far all’amor come assassine e come</l>
             <l>Faranno al campo i vostri cari amanti.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Non offender così quelle alme belle,</l>
             <l>Di fedeltà, d’intatto amore esempi!</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Via, via! Passaro i tempi</l>
             <l>Da spacciar queste favole ai bambini!</l>
@@ -1211,7 +1233,7 @@
         <div type="scene">
           <head>SCENA X</head>
           <stage>Don Alfonso solo; poi Despina.</stage>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Che silenzio! che aspetto di tristezza</l>
             <l>Spirano queste stanze! Poverette!</l>
@@ -1233,83 +1255,83 @@
             <stage>batte</stage>
             <l>Despinetta!</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l> Chi batte?</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Oh!</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Ih!</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>  Despina mia,</l>
             <l>Di te bisogno avrei.</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Ed io niente di lei.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Ti vo’ fare del ben.</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>A una fanciulla</l>
             <l>Un vecchio come lei non può far nulla.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Parla piano, ed osserva.</l>
             <stage>le mostra una moneta d’oro</stage>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Me la dona?</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Sì, se meco sei buona.</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>E che vorrebbe?</l>
             <l>È l’oro il mio giulebbe.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Ed oro avrai</l>
             <l>Ma ci vuol fedeltà.</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Non c’è altro? Son qua.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>  Prendi, ed ascolta:</l>
             <l>Sai che le tue padrone</l>
             <l>Han perduto gli amanti.</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Lo so.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Tutti i lor pianti</l>
             <l>Tutti i deliri loro anco tu sai.</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>So tutto.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Orben, se mai,</l>
             <l>Per consolarle un poco</l>
@@ -1321,7 +1343,7 @@
             <l>C’è una mancia per te di venti scudi,</l>
             <l>Se li fai riuscir.</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>  Non mi dispiace</l>
             <l>Questa proposizione.</l>
@@ -1332,22 +1354,22 @@
             <stage>da sé</stage>
             <l>(Per me questa mi preme.)</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>  Han tutto quello</l>
             <l>Che piacer può alle donne di giudizio.</l>
             <l>Li vuoi veder?</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>E dove son?</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Son lì.</l>
             <l>Li posso far entrar?</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l> Direi di sì.</l>
           </sp>
@@ -1356,14 +1378,14 @@
         <div type="scene">
           <head>SCENA XI</head>
           <stage>Don Alfonso, Despina, Ferrando, Guglielmo; poi Fiordiligi e Dorabella.</stage>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Alla bella Despinetta</l>
             <l>Vi presento, amici miei;</l>
             <l>Non dipende che da lei</l>
             <l>Consolar il vostro cor.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <stage>con tenerezza affettata</stage>
             <l>Per la man che lieto io bacio,</l>
@@ -1371,7 +1393,7 @@
             <l>Fa’ che volga a me sereni</l>
             <l>I begli occhi il mio tesor.</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <stage>da sé, ridendo</stage>
             <l>Che sembianze! che vestiti!</l>
@@ -1379,64 +1401,64 @@
             <l>Io non so se son Vallacchi,</l>
             <l>O se turchi son costor.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <stage>sottovoce a Despina</stage>
             <l>Che ti par di quell’aspetto?</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Per parlarvi schietto schietto,</l>
             <l>Hanno un muso fuor dell’uso,</l>
             <l>Vero antidoto d’amor.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso #ferrando #guglielmo">
             <speaker>ALFONSO, FERRANDO, GUGLIELMO </speaker>
             <l>Or la cosa è appien decisa:</l>
             <l>Se costei non li <add resp="#ed">ci</add> ravvisa</l>
             <l>Non c’è più nessun timor.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <stage>di dentro</stage>
             <l>Ehi, Despina! Olà, Despina!</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Le padrone!</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <stage>a Despina</stage>
             <l>Ecco l’istante!</l>
             <l>Fa’ con arte: io qui m’ascondo.</l>
             <stage>si ritira</stage>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Ragazzaccia tracotante,</l>
             <l>Che fai, lì, con simil gente?</l>
             <l>Falli uscire immantinente,</l>
             <l>O ti fo pentir con lor.</l>
           </sp>
-          <sp>
+          <sp who="#despina #ferrando #guglielmo">
             <speaker>DESPINA, FERRANDO, GUGLIELMO </speaker>
             <l>Ah madame, perdonate!</l>
             <l>Al bel piè languir mirate</l>
             <l>Due meschin, di vostro merto</l>
             <l>Spasimanti adorator.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Giusti Numi! cosa sento?</l>
             <l>Dell’enorme tradimento</l>
             <l>Chi fu mai l’indegno autor?</l>
           </sp>
-          <sp>
+          <sp who="#despina #ferrando #guglielmo">
             <speaker>DESPINA, FERRANDO, GUGLIELMO </speaker>
             <l>Deh calmate quello sdegno…</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Ah che più non ho ritegno!</l>
             <l>Tutta piena ho l’alma in petto</l>
@@ -1444,18 +1466,18 @@
             <l>Ah perdon, mio bel diletto!</l>
             <l>Innocente è questo cor.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <l>Qual diletto è a questo petto</l>
             <l>Quella rabbia e quel furor!</l>
           </sp>
-          <sp>
+          <sp who="#despina #alfonso">
             <speaker>DESPINA, ALFONSO</speaker>
             <stage>don Alfonso dalla porta</stage>
             <l>Mi dà un poco di sospetto</l>
             <l>Quella rabbia e quel furor.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Che susurro! che strepito!</l>
             <l>Che scompiglio è mai questo! Siete pazze,</l>
@@ -1463,24 +1485,24 @@
             <l>Volete sollevar il vicinato?</l>
             <l>Cosa avete? che è nato?</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <stage>con furore</stage>
             <l>Oh ciel! Mirate:</l>
             <l>Uomini in casa nostra!</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <stage>senza guardarli</stage>
             <l>Che male c’è?</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <stage>con fuoco</stage>
             <l>Che male? in questo giorno!…</l>
             <l>Dopo il caso funesto!…</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Stelle! sogno o son desto? Amici miei,</l>
             <l>Miei dolcissimi amici?</l>
@@ -1489,85 +1511,85 @@
             <stage>sottovoce</stage>
             <l>Secondatemi.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Amico Don Alfonso!</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Amico caro!</l>
             <stage>si abbracciano con trasporto</stage>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Oh bella improvvisata!</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Li conoscete, voi?</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Se li conosco! Questi</l>
             <l>Sono i più dolci amici</l>
             <l>Ch’io m’abbia in questo mondo,</l>
             <l>E i vostri ancor saranno.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>E in casa mia che fanno?</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Al vostri piedi</l>
             <l>Due rei, due delinquenti, ecco, madame!</l>
             <l>Amor…</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l> Numi! che sento!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Amor, il Nume</l>
             <l>Sì possente, per voi qui ci conduce.</l>
           </sp>
           <stage>Le donne si ritirano; essi le inseguono.</stage>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>… Vista appena la luce</l>
             <l>Di vostre fulgidissime pupille…</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>… Che alle vive faville…</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>… Farfallette amorose e agonizzanti…</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>… Vi voliamo davanti…</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>… Ed ai lati, ed a retro…</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <l>Per implorar pietade in flebil metro!</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Stelle! che ardir!</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Sorella, che facciamo?</l>
             <stage>Despina esce impaurita.</stage>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Temerari! sortite</l>
             <l>Fuori di questo loco! E non profani</l>
@@ -1592,40 +1614,40 @@
             <l>Non vi renda audaci ancor.</l>
           </sp>
           <stage>Van per aprire. Ferrando la richiama; Guglielmo richiama l’altra.</stage>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Ah non partite!</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <stage>a Dorabella</stage>
             <l>Ah barbara, restate!</l>
             <stage>a Don Alfonso</stage>
             <l>Che vi pare?</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Aspettate,</l>
             <l>Per carità, ragazze,</l>
             <l>Non mi fate più far trista figura!</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <stage>con fuoco</stage>
             <l>E che pretendereste?</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Eh nulla… Ma mi pare…</l>
             <l>Che un pochin di dolcezza…</l>
             <l>Alfin, son galantuomini</l>
             <l>E sono amici miei.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Come! e udire dovrei…</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Le nostre pene,</l>
             <l>E sentirne pietà!</l>
@@ -1671,39 +1693,39 @@
           <head>SCENA XII</head>
           <stage>Ferrando, Guglielmo e Don Alfonso</stage>
           <stage>I due amanti ridono smoderatamente e burlano Don Alfonso.</stage>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>E voi ridete?</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <stage>ridono fortissimo</stage>
             <l>Certo, ridiamo.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Ma cosa avete?</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <l>Già lo sappiamo.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Ridete piano!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <l>Parlate invano!</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Se vi sentissero,</l>
             <l>Se vi scoprissero,</l>
             <l>Si guasterebbe</l>
             <l>Tutto l’affar.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <stage>ridono sottovoce, sforzandosi di non ridere</stage>
             <l>Ah che dal ridere</l>
@@ -1711,7 +1733,7 @@
             <l>Ah che le viscere</l>
             <l>Sento scoppiar!</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Mi fa da ridere</l>
             <l>Questo lor ridere,</l>
@@ -1720,69 +1742,69 @@
             <l>Si può sapere un poco</l>
             <l>La cagion di quel riso?</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Oh cospettaccio!</l>
             <l>Non vi pare che abbiam giusta ragione,</l>
             <l>Il mio caro padrone?</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <stage>scherzando</stage>
             <l>Quanto pagar volete,</l>
             <l>E a monte è la scommessa?</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <stage>scherzando</stage>
             <l>Pagate la metà!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l> Pagate solo</l>
             <l>Ventiquattro zecchini!</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Poveri innocentini!</l>
             <l>Venite qua: vi voglio</l>
             <l>Porre il ditino in bocca!</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>E avete ancora</l>
             <l>Coraggio di fiatar?</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l> Avanti sera</l>
             <l>Ci parlerem.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Quando volete!</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>  Intanto,</l>
             <l>Silenzio e ubbidienza</l>
             <l>Fino a doman mattina.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Siamo soldati, e amiam la disciplina.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Orbene, andate un poco</l>
             <l>Ad attendermi entrambi in giardinetto:</l>
             <l>Colà vi manderò gli ordini miei.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Ed oggi non si mangia?</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Cosa serve?</l>
             <l>A battaglia finita</l>
@@ -1801,7 +1823,7 @@
         <div type="scene">
           <head>SCENA XIII</head>
           <stage>Don Alfonso solo; poi Despina.</stage>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Oh la saria da ridere: sì poche</l>
             <l>Son le donne costanti, in questo mondo,</l>
@@ -1809,20 +1831,20 @@
             <l>Vieni, vieni, fanciulla, e dimmi un poco</l>
             <l>Dove sono e che fan le tue padrone.</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Le povere buffone</l>
             <l>Stanno nel giardinetto</l>
             <l>A lagnarsi coll’aria e colle mosche</l>
             <l>D’aver perso gli amanti.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>E come credi</l>
             <l>Che l’affar finirà? vogliam sperare</l>
             <l>Che faranno giudizio?</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l> Io lo farei;</l>
             <l>E dove piangon esse io riderei.</l>
@@ -1831,13 +1853,13 @@
             <l>Guardate che pazzia!</l>
             <l>Se ne pigliano due, s’uno va via.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Brava, questa è prudenza!</l>
             <stage>da sé</stage>
             <l>Bisogna impuntigliarla.</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>È legge di natura,</l>
             <l>E non prudenza sola. Amor cos’è?</l>
@@ -1847,27 +1869,27 @@
             <l>Se incomodo diventa,</l>
             <l>Se invece di piacer nuoce e tormenta.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Ma intanto queste pazze…</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>  Quelle pazze</l>
             <l>Faranno a modo nostro. È buon che sappiano</l>
             <l>D’esser amate da color.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Lo sanno.</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Dunque riameranno.</l>
             <l>«Diglielo», si suol dire,</l>
             <l>«E lascia fare al diavolo».</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>  Ma come</l>
             <l>Far vuoi perché ritornino,</l>
@@ -1875,7 +1897,7 @@
             <l>E tentare si lascino,</l>
             <l>Queste tue bestioline?</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>A me lasciate</l>
             <l>La briga di condur tutta la macchina.</l>
@@ -1885,20 +1907,20 @@
             <l>Saprò menar due femmine. Son ricchi</l>
             <l>I due monsù mustacchi?</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Son ricchissimi.</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Dove son?</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Sulla strada</l>
             <l>Attendendo mi stanno.</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>  Ite e sul fatto</l>
             <l>Per la picciola porta</l>
@@ -1915,7 +1937,7 @@
           <head>SCENA XIV</head>
           <stage>Giardinetto gentile; due sofà d’erba ai lati.</stage>
           <stage>Fiordiligi e Dorabella.</stage>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Ah che tutta in un momento</l>
             <l>Si cangiò la sorte mia…</l>
@@ -1930,58 +1952,58 @@
         <div type="scene">
           <head>SCENA XV</head>
           <stage>Fiordiligi, Dorabella; Ferrando, Guglielmo e Don Alfonso dentro le quinte; poi Despina.</stage>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <l>Si mora, sì, si mora</l>
             <l>Onde appagar le ingrate!</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>C’è una speranza ancora:</l>
             <l>Non fate, o dei, non fate!</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Stelle, che grida orribili!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <l>Lasciatemi!</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>  Aspettate!</l>
             <stage>Ferrando e Guglielmo, portando ciascuno una boccetta, entrano seguiti da Don Alfonso.</stage>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <l>L’arsenico mi liberi</l>
             <l>Di tanta crudeltà!</l>
             <stage>bevono e gittan via il nappo; nel voltarsi vedono le due donne</stage>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Stelle! Un velen fu quello?</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Veleno buono e bello</l>
             <l>Che ad essi in pochi istanti</l>
             <l>La vita toglierà.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Il tragico spettacolo</l>
             <l>Gelare il cor mi fa.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <l>Barbare, avvicinatevi:</l>
             <l>D’un disperato affetto</l>
             <l>Mirate il tristo effetto</l>
             <l>E abbiate almen pietà.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella #ferrando #guglielmo #alfonso">
             <speaker>FIORDILIGI, DORABELLA, FERRANDO, GUGLIELMO, ALFONSO</speaker>
             <l>Ah che del sole il raggio</l>
             <l>Fosco per me diventa.</l>
@@ -1991,53 +2013,53 @@
             <l>Accenti articolar!</l>
             <stage>Ferrando e Guglielmo cadono sopra i banchi d’erba.</stage>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Giacché a morir vicini</l>
             <l>Sono quei meschinelli,</l>
             <l>Pietade almeno a quelli</l>
             <l>Cercate di mostrar.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Gente, accorrete, gente!</l>
             <l>Nessuno, oh Dio, ci sente!</l>
             <l>Despina!</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <stage>di dentro</stage>
             <l>Chi mi chiama?</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Despina!</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <stage>in scena</stage>
             <l>Cosa vedo!</l>
             <l>Morti i meschini io credo,</l>
             <l>O prossimi a spirar.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Ah che purtroppo è vero!</l>
             <l>Furenti, disperati,</l>
             <l>Si sono avvelenati.</l>
             <l>Oh amore singolar!</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Abbandonar i miseri</l>
             <l>Saria per voi vergogna:</l>
             <l>Soccorrerli bisogna.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella #alfonso">
             <speaker>FIORDILIGI, DORABELLA, ALFONSO</speaker>
             <l>Cosa possiam mai far?</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Di vita ancor dàn segno:</l>
             <l>Colle pietose mani</l>
@@ -2048,75 +2070,75 @@
             <l>Voliamo a ricercar.</l>
             <stage>Despina e Don Alfonso partono.</stage>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Dèi, che cimento è questo!</l>
             <l>Evento più funesto</l>
             <l>Non si potea trovar!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <stage>da sé</stage>
             <l>Più bella commediola</l>
             <l>Non si potea trovar!</l>
             <l>Ah!</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <stage>stando lontano dagli amanti</stage>
             <l>Sospiran gli infelici!</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Che facciamo?</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l> Tu che dici?</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>In momenti sì dolenti,</l>
             <l>Chi potriali abbandonar?</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <stage>si accosta un poco</stage>
             <l>Che figure interessanti!</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <stage>si accosta un poco</stage>
             <l>Possiam farci un poco avanti.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Ha freddissima la testa.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Fredda fredda è ancora questa.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Ed il polso?</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>  Io non gliel sento.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Questo batte lento lento.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Ah se tarda ancor l’aita,</l>
             <l>Speme più non v’è di vita.</l>
             <l>Poverini! la lor morte</l>
             <l>Mi farebbe lagrimar.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <l>Più domestiche e trattabili</l>
             <l>Sono entrambe diventate.</l>
@@ -2127,28 +2149,28 @@
         <div type="scene">
           <head>SCENA XVI</head>
           <stage>Fiordiligi, Dorabella, Ferrando, Guglielmo; Despina travestita da medico e Don Alfonso.</stage>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Eccovi il medico,</l>
             <l>Signore belle.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <stage>da sé</stage>
             <l>Despina in maschera!</l>
             <l>Che trista pelle!</l>
           </sp>
-          <sp xml:lang="lat">
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>(Salvete, amabiles</l>
             <l>Bonae puellae!)</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Parla un linguaggio</l>
             <l>Che non sappiamo.</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Come comandano,</l>
             <l>Dunque, parliamo:</l>
@@ -2157,7 +2179,7 @@
             <l>Lo svevo e il tartaro</l>
             <l>So ancor parlar.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Tanti linguaggi</l>
             <l>Per sé conservi.</l>
@@ -2166,12 +2188,12 @@
             <l>Preso hanno il tossico,</l>
             <l>Che si può far?</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Signor dottore,</l>
             <l>Che si può far?</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <stage>tocca il polso e la fronte all’uno e all’altro</stage>
             <l>Saper bisognami</l>
@@ -2183,7 +2205,7 @@
             <l>Se in una volta</l>
             <l>Bebberla, o in più.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella #alfonso">
             <speaker>FIORDILIGI, DORABELLA, ALFONSO</speaker>
             <l>Preso han l’arsenico,</l>
             <l>Signor dottore:</l>
@@ -2192,19 +2214,19 @@
             <l>Ed in un sorso</l>
             <l>Se ’l mandar giù.</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Non vi affannate,</l>
             <l>Non vi turbate:</l>
             <l>Ecco una prova</l>
             <l>Di mia virtù.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella #alfonso">
             <speaker>FIORDILIGI, DORABELLA, ALFONSO</speaker>
             <l>Egli ha di un ferro</l>
             <l>La man fornita.</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <stage>tocca con un pezzo di calamita la testa ai finti infermi e striscia dolcemente i loro corpi per lungo</stage>
             <l>Questo è quel pezzo</l>
@@ -2215,37 +2237,37 @@
             <l>Che poi sì celebre</l>
             <l>Là in Francia fu.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella #alfonso">
             <speaker>FIORDILIGI, DORABELLA, ALFONSO</speaker>
             <l>Come si muovono,</l>
             <l>Torcono, scuotono!</l>
             <l>In terra il cranio</l>
             <l>Presto percuotono.</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Ah lor la fronte</l>
             <l>Tenete su.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Eccoci pronte.</l>
             <stage>metton la mano alla fronte dei due amanti</stage>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Tenete forte.</l>
             <l>Coraggio! Or liberi</l>
             <l>Siete da morte.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella #alfonso">
             <speaker>FIORDILIGI, DORABELLA, ALFONSO</speaker>
             <l>Attorno guardano,</l>
             <l>Forze riprendono</l>
             <l>Ah questo medico</l>
             <l>Vale un Perù!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <stage>sorgono in piedi</stage>
             <l>Dove son? che loco è questo?</l>
@@ -2259,17 +2281,17 @@
             <l>E che sola è il mio tesor.</l>
             <stage>abbraccian le amanti teneramente e bacian loro la mano</stage>
           </sp>
-          <sp>
+          <sp who="#despina #alfonso">
             <speaker>DESPINA, ALFONSO</speaker>
             <l>Son effetti ancor del tossico:</l>
             <l>Non abbiate alcun timor.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Sarà ver, ma tante smorfie</l>
             <l>Fanno torto al nostro onor.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <stage>da sé</stage>
             <l>Dalla voglia ch’ho di ridere</l>
@@ -2278,32 +2300,32 @@
             <l>Per pietà, bell’idol mio</l>
             <l>Volgi a me le luci liete!</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Più resister non poss’io.</l>
           </sp>
-          <sp>
+          <sp who="#despina #alfonso">
             <speaker>DESPINA, ALFONSO</speaker>
             <l>In poch’ore, lo vedrete,</l>
             <l>Per virtù del magnetismo</l>
             <l>Finirà quel parossismo,</l>
             <l>Torneranno al primo umor.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <l>Dammi un bacio, o mio tesoro;</l>
             <l>Un sol bacio, o qui mi moro.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Stelle! Un bacio?</l>
           </sp>
-          <sp>
+          <sp who="#despina #alfonso">
             <speaker>DESPINA, ALFONSO</speaker>
             <l>Secondate</l>
             <l>Per effetto di bontate.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Ah che troppo si richiede</l>
             <l>Da una fida, onesta amante.</l>
@@ -2314,7 +2336,7 @@
             <l>Tardi inver vi pentirete,</l>
             <l>Se più cresce il mio furor!</l>
           </sp>
-          <sp>
+          <sp who="#despina #alfonso">
             <speaker>DESPINA, ALFONSO</speaker>
             <l>Un quadretto più giocondo</l>
             <l>Non si vide in tutto il mondo.</l>
@@ -2323,7 +2345,7 @@
             <l>Ch’io ben so che tanto fuoco</l>
             <l>Cangerassi in quel d’amor.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <l>Un quadretto più giocondo</l>
             <l>Non s’è visto, in questo mondo.</l>
@@ -2340,51 +2362,51 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>Fiordiligi, Dorabella e Despina.</stage>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Andate là, che siete</l>
             <l>Due bizzarre ragazze!</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Oh cospettaccio!</l>
             <l>Cosa pretenderesti?</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l> Per me nulla.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Per chi, dunque?</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Per voi.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l> Per noi?</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>  Per voi:</l>
             <l>Siete voi donne, o no?</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>E per questo?</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>E per questo</l>
             <l>Dovete far da donne.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Cioè?</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Trattar l’amore <foreign xml:lang="fre">en bagattelle</foreign>:</l>
             <l>Le occasioni belle</l>
@@ -2395,13 +2417,13 @@
             <l>A chi si fida in uomo;</l>
             <l>Mangiar il fico e non gittare il pomo.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <stage>da sé</stage>
             <l>Che diavolo! Tai cose</l>
             <l>Fàlle tu, se n’hai voglia.</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Io già le faccio.</l>
             <l>Ma vorrei che anche voi,</l>
@@ -2411,11 +2433,11 @@
             <l>Son andati alla guerra? Infin che tornano,</l>
             <l>Fate alla militare: reclutate.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Il cielo ce ne guardi!</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Eh che noi siamo in terra, e non in cielo!</l>
             <l>Fidatevi al mio zelo: giacché questi</l>
@@ -2430,7 +2452,7 @@
             <stage> da sé</stage>
             <l>Par che ci trovin gusto.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Perbacco, ci faresti</l>
             <l>Far delle belle cose!</l>
@@ -2439,43 +2461,43 @@
             <l>Ai nostri cari sposi</l>
             <l>Credi tu che vogliam dar tal tormento?</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>E chi dice che abbiate</l>
             <l>A far loro alcun torto?</l>
             <l>(Amiche siamo in porto.)</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Non ti pare che sia torto bastante,</l>
             <l>Se noto si facesse</l>
             <l>Che trattiamo costor?</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Anche per questo</l>
             <l>C’è un mezzo sicurissimo:</l>
             <l>Io voglio sparger fama</l>
             <l>Che vengono da me.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Chi vuoi che il creda?</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Oh bella! Non ha forse</l>
             <l>Merto una cameriera</l>
             <l>D’aver due cicisbei? Di me fidatevi.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>No, no: son troppo audaci,</l>
             <l>Questi tuoi forastieri.</l>
             <l>Non ebber la baldanza</l>
             <l>Fin di chieder dei baci?</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <stage>da sé</stage>
             <l>Che disgrazia!</l>
@@ -2488,22 +2510,22 @@
             <l>Manierosi, modesti e mansueti.</l>
             <l>Lasciateli venir.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>E poi?</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>E poi…</l>
             <l>Caspita! Fate voi!</l>
             <stage>da sé</stage>
             <l>L’ho detto che cadrebbero.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Cosa dobbiamo far?</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>  Quel che volete:</l>
             <l>Siete d’ossa e di carne, o cosa siete?</l>
@@ -2540,27 +2562,27 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>Fiordiligi e Dorabella.</stage>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Sorella, cosa dici?</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Io son stordita</l>
             <l>Dallo spirto infernal di tal ragazza.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Ma credimi: è una pazza.</l>
             <l>Ti par che siamo in caso</l>
             <l>Di seguir suoi consigli?</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Oh certo, se tu pigli</l>
             <l>Pel rovescio il negozio.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Anzi io lo piglio</l>
             <l>Per il suo vero dritto:</l>
@@ -2568,28 +2590,28 @@
             <l>Per due giovani omai promesse spose,</l>
             <l>Il far di queste cose?</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Ella non dice</l>
             <l>Che facciamo alcun mal.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>È mal che basta,</l>
             <l>Il far parlar di noi.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>  Quando si dice</l>
             <l>Che vengon per Despina!…</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Oh tu sei troppo</l>
             <l>Larga di coscienza! E che diranno,</l>
             <l>Gli sposi nostri?</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Nulla:</l>
             <l>O non sapran l’affare,</l>
@@ -2597,72 +2619,72 @@
             <l>O sapran qualche cosa, e allor diremo</l>
             <l>Che vennero per lei.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Ma i nostri cori?</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Restano quel che sono:</l>
             <l>Per divertirsi un poco e non morire</l>
             <l>Dalla malinconia,</l>
             <l>Non si manca di fé, sorella mia.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Questo è ver.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Dunque?</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Dunque,</l>
             <l>Fa’ un po’ tu; ma non voglio</l>
             <l>Aver colpa, se poi nasce un imbroglio.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Che imbroglio nascer deve,</l>
             <l>Con tanta precauzion? Per altro, ascolta:</l>
             <l>Per intendersi bene,</l>
             <l>Qual vuoi sceglier per te de’ due narcisi?</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Decidi tu, sorella.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l> Io già decisi:</l>
             <l>Prenderò quel brunettino,</l>
             <l>Che più lepido mi par.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Ed intanto io col biondino</l>
             <l>Vo’ un po’ ridere e burlar.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Scherzosetta, ai dolci detti</l>
             <l>Io di quel risponderò.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Sospirando, i sospiretti</l>
             <l>Io dell’altro imiterò.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Mi dirà: «Ben mio, mi moro!».</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Mi dirà: «Mio bel tesoro!».</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Ed intanto, che diletto,</l>
             <l>Che spassetto io proverò!</l>
@@ -2672,7 +2694,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>Fiordiligi, Dorabella e Don Alfonso.</stage>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Ah correte al giardino,</l>
             <l>Le mie care ragazze! che allegria!</l>
@@ -2680,11 +2702,11 @@
             <l>Che brillante spettacolo! che incanto!</l>
             <l>Fate presto, correte!</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Che diamine esser può?</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>  Tosto vedrete.</l>
           </sp>
@@ -2693,7 +2715,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>Ferrando e Guglielmo, Despina, Fiordiligi, Dorabella,Don Alfonso, marinai, servi riccamente vestiti, coro di musici.</stage>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <l>Secondate, aurette amiche,</l>
             <l>Secondate i miei desiri,</l>
@@ -2704,70 +2726,70 @@
             <l>Ripetete al caro bene</l>
             <l>Tutto quel che udiste allor.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Secondate, aurette amiche.</l>
             <l>Il desir di sì bei cor.</l>
             <stage>Nel tempo del ritornello di questo coro, Ferrando e Guglielmo scendono con catene di fiori. Don Alfonso e Despina li conducono davanti le due amanti, che resteranno ammutite ed attonite.</stage>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <stage>ai servi che portano un bacile con fiori</stage>
             <l>Il tutto deponete</l>
             <l>Sopra quei tavolini, e nella barca</l>
             <l>Ritiratevi, amici.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Cos’è tal mascherata?</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Animo, via, coraggio! Avete perso</l>
             <l>L’uso della favella? </l>
           </sp>
           <stage>La barca s’allontana dalla sponda.</stage>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Io tremo e palpito</l>
             <l>Dalla testa alle piante.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Amor lega le membra a vero amante.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <stage>alle donne</stage>
             <l>Da brave, incoraggiateli!</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <stage>agli amanti</stage>
             <l>Parlate.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <stage>agli amanti</stage>
             <l>Liberi dite pur quel che bramate.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Madama…</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Anzi, madame…</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Parla pur tu.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>  No, no, parla pur tu.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Oh cospetto del diavolo!</l>
             <l>Lasciate tali smorfie</l>
@@ -2793,7 +2815,7 @@
             <l>Su, via, rispondete!</l>
             <l>Guardate… e ridete?</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <stage>si mette davanti le due donne</stage>
             <l>Per voi la risposta</l>
@@ -2806,7 +2828,7 @@
             <l>A me porgete il braccio,</l>
             <l>Né sospirate più.</l>
           </sp>
-          <sp>
+          <sp who="#despina #alfonso">
             <speaker>DESPINA, ALFONSO</speaker>
             <stage>a parte, sottovoce</stage>
             <l>Per carità, partiamo</l>
@@ -2819,75 +2841,75 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>Fiordiligi, Dorabella, Ferrando e Guglielmo.</stage>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Oh che bella giornata!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Caldetta anziché no.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Che vezzosi arboscelli!</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Certo, certo, son belli:</l>
             <l>Han più foglie che frutti.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Quei viali</l>
             <l>Come sono leggiadri!</l>
             <l>Volete passeggiar?</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l> Son pronto, o cara,</l>
             <l>Ad ogni vostro cenno.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l> Troppa grazia!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <stage>nel passare, a Guglielmo</stage>
             <l>Eccoci alla gran crisi.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Cosa gli avete detto?</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Eh gli raccomandai</l>
             <l>Di divertirla bene.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <stage>a Guglielmo</stage>
             <l>Passeggiamo anche noi.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Come vi piace.</l>
             <stage>passeggiano</stage>
             <l>Aimè!</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Che cosa avete?</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Io mi sento sì male,</l>
             <l>Sì male, anima mia,</l>
             <l>Che mi par di morire.</l>
             <stage>Gli altri due fanno scena muta in lontananza.</stage>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <stage>da sé</stage>
             <l>Non otterrà nientissimo.</l>
@@ -2897,7 +2919,7 @@
             <l>Saranno rimasugli</l>
             <l>Del velen che beveste.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <stage>con fuoco</stage>
             <l>Ah che un veleno assai più forte io bevo</l>
@@ -2905,12 +2927,12 @@
             <l>Mongibelli amorosi!</l>
             <stage>Gli altri due partono, in atto di passeggiare.</stage>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Sarà veleno càlido:</l>
             <l>Fatevi un poco fresco.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Ingrata, voi burlate,</l>
             <l>Ed intanto io mi moro!</l>
@@ -2918,30 +2940,30 @@
             <l>Son spariti:</l>
             <l>Dove diamin son iti?</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Eh via, non fate…</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Io mi moro, crudele, e voi burlate?</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Io burlo? io burlo?</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>  Dunque,</l>
             <l>Datemi qualche segno, anima bella,</l>
             <l>Della vostra pietà.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>  Due, se volete:</l>
             <l>Dite quel che far deggio, e lo vedrete.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <stage>da sé</stage>
             <l>Scherza, o dice davvero?</l>
@@ -2949,30 +2971,30 @@
             <l>Questa picciola offerta</l>
             <l>D’accettare degnatevi.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Un core?</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Un core: è simbolo di quello</l>
             <l>Ch’arde, languisce e spasima per voi.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <stage>da sé</stage>
             <l>Che dono prezioso.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>L’accettate?</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>  Crudele!</l>
             <l>Di sedur non tentate un cor fedele.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <stage>da sé</stage>
             <l>La montagna vacilla.</l>
@@ -2980,38 +3002,38 @@
             <l>È l’onor di soldato.</l>
             <l>V’adoro!</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l> Per pietà…</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>  Son tutto vostro!</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Oh dei!</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Cedete, o cara!</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Mi farete morir…</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l> Morremo insieme</l>
             <l>Amorosa mia speme.</l>
             <l>L’accettate?</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <stage>dopo breve intervallo, con un sospiro</stage>
             <l>L’accetto.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <stage>da sé</stage>
             <l>Infelice Ferrando. Oh che diletto!</l>
@@ -3020,75 +3042,75 @@
             <l>Ma il vostro vo’ anch’io:</l>
             <l>Via, datelo a me.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Me ’l date, lo prendo;</l>
             <l>Ma il mio non vi rendo.</l>
             <l>Invan me ’l chiedete:</l>
             <l>Più meco ei non è.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Se teco non l’hai,</l>
             <l>Perché batte qui?</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Se a me tu lo dài,</l>
             <l>Che mai balza lì?</l>
           </sp>
-          <sp>
+          <sp who="#dorabella #guglielmo">
             <speaker>DORABELLA, GUGLIELMO</speaker>
             <l>È il mio coricino</l>
             <l>Che più non è meco:</l>
             <l>Ei venne a star teco,</l>
             <l>Ei batte così.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <stage>vuol metterle il core dov’ha il ritratto dell’amante</stage>
             <l>Qui lascia che il metta.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Ei qui non può star.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>T’intendo, furbetta.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Che fai?</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>  Non guardar.</l>
             <stage>le torce dolcemente la faccia dall’altra parte, le cava il ritratto e vi mette il core</stage>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <stage>da sé</stage>
             <l>Nel petto un Vesuvio</l>
             <l>D’avere mi par.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <stage>da sé</stage>
             <l>Ferrando Ferrando</l>
             <l>Possibil non par.</l>
             <l>L’occhietto a me gira.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Che brami?</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l> Rimira</l>
             <l>Se meglio può andar.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella #ferrando">
             <speaker>DORABELLA, FERRANDO</speaker>
             <l>Oh cambio felice</l>
             <l>Di cori e d’affetti!</l>
@@ -3101,44 +3123,44 @@
           <head>SCENA VI</head>
           <stage>Fiordiligi e Ferrando.</stage>
           <stage>Entra Fiordiligi agitata e seguita da Ferrando.</stage>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Barbara, perché fuggi?</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l> Ho visto un aspide,</l>
             <l>Un’idra, un basilisco!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Ah crudel, ti capisco!</l>
             <l>L’aspide, l’idra, il basilisco, e quanto</l>
             <l>I libici deserti han di più fiero,</l>
             <l>In me solo tu vedi.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l> È vero, è vero.</l>
             <l>Tu vuoi tormi la pace.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Ma per farti felice.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Cessa di molestarmi!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Non ti chiedo che un guardo.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Pàrtiti!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l> Non sperarlo,</l>
             <l>Se pria gli occhi men fieri a me non giri.</l>
@@ -3162,7 +3184,7 @@
         <div type="scene">
           <head>SCENA VII</head>
           <stage>Fiordiligi da sola.</stage>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Ei parte… Senti!… Ah no: partir si lasci,</l>
             <l>Si tolga ai sguardi miei l’infausto oggetto</l>
@@ -3201,34 +3223,34 @@
         <div type="scene">
           <head>SCENA VIII</head>
           <stage>Ferrando e Guglielmo.</stage>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <stage>lietissimo</stage>
             <l>Amico, abbiamo vinto!</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>  Un ambo, o un terno?</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Una cinquina, amico: Fiordiligi</l>
             <l>È la modestia in carne.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l> Niente meno?</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Nientissimo. Sta’ attento</l>
             <l>E ascolta come fu.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>T’ascolto: di’ pur su.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Pel giardinetto,</l>
             <l>Come eravam d’accordo,</l>
@@ -3237,40 +3259,40 @@
             <l>Di mille cose indifferenti; alfine</l>
             <l>Viensi all’amor.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Avanti.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Fingo labbra tremanti,</l>
             <l>Fingo di pianger, fingo</l>
             <l>Di morir al suo piè.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Bravo assai, per mia fé.</l>
             <l>Ed ella?</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>  Ella da prima</l>
             <l>Ride, scherza, mi burla.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>E poi?</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l> E poi</l>
             <l>Finge d’impietosirsi.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Oh cospettaccio!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Alfin scoppia la bomba.</l>
             <l>Pura come colomba</l>
@@ -3280,7 +3302,7 @@
             <l>Testimonio rendendomi e messaggio</l>
             <l>Che una femmina ell’è senza paraggio.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Bravo tu, bravo io,</l>
             <l>Brava la mia Penelope!</l>
@@ -3289,7 +3311,7 @@
             <l>O mio fido Mercurio!</l>
             <stage>si abbracciano</stage>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>E la mia Dorabella?</l>
             <l>Come s’è diportata?</l>
@@ -3297,73 +3319,73 @@
             <l>Oh non ci ho neppur dubbio! assai conosco</l>
             <l>Quella sensibil alma.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Eppur, un dubbio,</l>
             <l>Parlandoti a quattr’occhi,</l>
             <l>Non saria mal, se tu l’avessi!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l> Come?</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Dico così per dir.</l>
             <stage>da sé</stage>
             <l>Avrei piacere</l>
             <l>D’indorargli la pillola.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Stelle! Cesse ella forse</l>
             <l>Alle lusinghe tue? Ah s’io potessi</l>
             <l>Sospettarlo soltanto!</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>È sempre bene</l>
             <l>Il sospettare un poco, in questo mondo.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Eterni dei, favella! A fuoco lento</l>
             <l>Non mi far qui morir… Ma no, tu vuoi</l>
             <l>Prenderti meco spasso: ella non ama,</l>
             <l>Non adora che me.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Certo! Anzi, in prova</l>
             <l>Di suo amor, di sua fede,</l>
             <l>Questo bel ritrattino ella mi diede.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <stage>furente</stage>
             <l>Il mio ritratto! Ah perfida!</l>
           </sp>
           <stage>vuol partire</stage>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Ove vai?</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>A trarle il cor dal scellerato petto</l>
             <stage>furente</stage>
             <l>E a vendicar il mio tradito affetto.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Férmati!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <stage>risoluto</stage>
             <l>  No, mi lascia!</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Sei tu pazzo?</l>
             <l>Vuoi tu precipitarti</l>
@@ -3372,34 +3394,34 @@
             <l>Non vorrei che facesse</l>
             <l>Qualche corbelleria.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Numi! Tante promesse,</l>
             <l>E lagrime, e sospiri, e giuramenti,</l>
             <l>In sì pochi momenti</l>
             <l>Come l’empia obliò?</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Perbacco, io non lo so.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Che fare or deggio?</l>
             <l>A qual partito, a qual idea m’appiglio?</l>
             <l>Abbi di me pietà: dammi consiglio.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Amico, non saprei</l>
             <l>Qual consiglio a te dar.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>  Barbara! ingrata!</l>
             <l>In un giorno!… in poche ore!…</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Certo, un caso quest’è da far stupore.</l>
             <l>Donne mie, la fate a tanti,</l>
@@ -3433,7 +3455,7 @@
         <div type="scene">
           <head>SCENA IX</head>
           <stage>Ferrando solo; poi Guglielmo e Don Alfonso che parlano in fondo.</stage>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>In qual fiero contrasto, in qual disordine</l>
             <l>Di pensieri e di affetti io mi ritrovo?</l>
@@ -3453,16 +3475,16 @@
             <l>Io sento per essa</l>
             <l>Le voci d’amor.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Bravo! Questa è costanza!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Andate, o barbaro!</l>
             <l>Per voi misero sono.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Via, se sarete buono</l>
             <l>Vi tornerò l’antica calma. Udite:</l>
@@ -3471,11 +3493,11 @@
             <l>Si conserva fedel, e Dorabella</l>
             <l>Infedel a voi fu.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Per mia vergogna.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Caro amico, bisogna</l>
             <l>Far delle differenze in ogni cosa:</l>
@@ -3485,26 +3507,26 @@
             <l>Se facciamo tra noi… Tu vedi, amico,</l>
             <l>Che un poco di più merto…</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Eh anch’io lo dico.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Intanto mi darete</l>
             <l>Cinquanta zecchinetti.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l> Volontieri.</l>
             <l>Pria però di pagar, vo’ che facciamo</l>
             <l>Qualche altra esperienza.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Come?</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Abbiate pazienza; infin domani</l>
             <l>Siete entrambi miei schiavi: a me voi deste</l>
@@ -3519,19 +3541,19 @@
           <head>SCENA X</head>
           <stage>Camera con diverse porte, specchio e tavolini.</stage>
           <stage>Dorabella e Despina; poi Fiordiligi.</stage>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Ora vedo che siete</l>
             <l>Una donna di garbo.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>  Invan, Despina,</l>
             <l>Di resister tentai: quel demonietto</l>
             <l>Ha un artifizio, un’eloquenza, un tratto</l>
             <l>Che ti fa cader giù se sei di sasso.</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Corpo di satanasso,</l>
             <l>Questo vuol dir saper! Tanto di raro</l>
@@ -3541,63 +3563,63 @@
             <l>Ma ecco la sorella.</l>
             <l>Che ceffo!</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l> Sciagurate!</l>
             <l>Ecco per colpa vostra</l>
             <l>In che stato mi trovo!</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Cosa è nato,</l>
             <l>Cara madamigella?</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l> Hai qualche mal, sorella?</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Ho il diavolo che porti</l>
             <l>Me, te, lei, Don Alfonso, i forastieri</l>
             <l>E quanti pazzi ha il mondo!</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Hai perduto il giudizio?</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Peggio, peggio.</l>
             <l>Inorridisci: io amo! e l’amor mio</l>
             <l>Non è sol per Guglielmo.</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l> Meglio, meglio!</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>E che sì, che anche tu se’ innamorata</l>
             <l>Del galante biondino?</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <stage>sospirando</stage>
             <l>Ah purtroppo per noi!</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Ma brava!</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Tieni</l>
             <l>Settanta mille baci.</l>
             <l>Tu il biondino, io ’l brunetto:</l>
             <l>Eccoci entrambe spose!</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>  Cosa dici?</l>
             <l>Non pensi agli infelici</l>
@@ -3607,7 +3629,7 @@
             <l>Dove, dove apprendesti?</l>
             <l>Sì diversa da te come ti festi?</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Odimi: sei tu certa</l>
             <l>Che non muoiano in guerra,</l>
@@ -3616,39 +3638,39 @@
             <l>Tra un ben certo e un incerto</l>
             <l>C’è sempre un gran divario!</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>E se poi torneranno?</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Se torneran, lor danno!</l>
             <l>Noi saremo allor mogli, noi saremo</l>
             <l>Lontane mille miglia.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Ma non so come mai</l>
             <l>Si può cangiar in un sol giorno un core.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Che domanda ridicola! Siam donne!</l>
             <l>E poi, tu com’hai fatto?</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>  Io saprò vincermi.</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Voi non saprete nulla.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Farò che tu lo veda.</l>
           </sp>
-          <sp>
+          <sp who="#dorabella">
             <speaker>DORABELLA</speaker>
             <l>Credi, sorella, è meglio che tu ceda.</l>
             <l>È amore un ladroncello,</l>
@@ -3673,7 +3695,7 @@
         <div type="scene">
           <head>SCENA XI</head>
           <stage>Fiordiligi sola; poi Guglielmo e Ferrando, e Don Alfonso che passano senza esser veduti, indi Despina.</stage>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Come tutto congiura</l>
             <l>A sedurre il mio cor! Ma no! Si mora</l>
@@ -3687,12 +3709,12 @@
             <l>Se lo lascian passar: veder nol voglio,</l>
             <l>Quel seduttor.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Bravissima,</l>
             <l>La mia casta Artemisia! La sentite?</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Ma potria Dorabella,</l>
             <l>Senza saputa mia… Piano! un pensiero</l>
@@ -3701,11 +3723,11 @@
             <l>Di Guglielmo e Ferrando… Ardir! Despina!</l>
             <l>Despina!</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>  Cosa c’è?</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Tieni un po’ questa chiave, e senza replica,</l>
             <l>Senza replica alcuna,</l>
@@ -3713,21 +3735,21 @@
             <l>Due spade, due cappelli e due vestiti</l>
             <l>De’ nostri sposi.</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>E che volete fare?</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Vanne; non replicare!</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <stage>da sé</stage>
             <l>Comanda in <foreign xml:lang="fre">abrégé</foreign>, Donna Arroganza!</l>
             <stage>parte</stage>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Non c’è altro: ho speranza</l>
             <l>Che Dorabella stessa</l>
@@ -3735,25 +3757,25 @@
             <l>Altra strada non resta,</l>
             <l>Per serbarci innocenti.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <stage>dalla porta</stage>
             <l>Ho capito abbastanza.</l>
             <stage>a Despina, che ritorna</stage>
             <l>Vanne pur, non temer.</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l> Eccomi.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Vanne.</l>
             <l>Sei cavalli di posta</l>
             <l>Voli un servo a ordinar. Di’ a Dorabella</l>
             <l>Che parlar le vorrei.</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>  Sarà servita.</l>
             <stage>da sé</stage>
@@ -3764,7 +3786,7 @@
         <div type="scene">
           <head>SCENA XII</head>
           <stage>Fiordiligi, poi Ferrando. Guglielmo e Don Alfonso nell’altra camera.</stage>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>L’abito di Ferrando</l>
             <l>Sarà buono per me; può Dorabella</l>
@@ -3776,11 +3798,11 @@
             <l>Ite in malora,</l>
             <l>Ornamenti fatali! Io vi detesto.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Si può dar un amor simile a questo?</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Di tornar non sperate alla mia fronte</l>
             <l>Pria ch’io qui torni col mio ben; in vostro</l>
@@ -3794,17 +3816,17 @@
             <l>Oh che gioia il suo bel core</l>
             <l>Proverà nel ravvisarmi!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Ed intanto di dolore,</l>
             <l>Meschinello, io mi morrò.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Cosa veggio! Son tradita.</l>
             <l>Deh partite!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Ah no, mia vita!</l>
             <stage>prende la spada dal tavolino, la sfodera</stage>
@@ -3813,47 +3835,47 @@
             <l>E se forza, oh Dio, non hai,</l>
             <l>Io la man ti reggerò.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Taci, aimè! Son abbastanza</l>
             <l>Tormentata ed infelice!</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #ferrando">
             <speaker>FIORDILIGI, FERRANDO </speaker>
             <l>Ah che omai la mia <add resp="#ed">sua</add> costanza,</l>
             <l>A quei sguardi, a quel che dice,</l>
             <l>Incomincia a vacillar.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Sorgi, sorgi!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Invan lo credi.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Per pietà, da me che chiedi?</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Il tuo cor, o la mia morte.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>Ah non son, non son più forte…</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Cedi, cara!</l>
             <stage>le prende la mano e gliela bacia</stage>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <l>  Dei, consiglio!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Volgi a me pietoso il ciglio:</l>
             <l>In me sol trovar tu puoi</l>
@@ -3861,14 +3883,14 @@
             <stage>tenerissimamente</stage>
             <l>Idol mio, più non tardar.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi">
             <speaker>FIORDILIGI</speaker>
             <stage>tremando</stage>
             <l>Giusto ciel! Crudel, hai vinto:</l>
             <l>Fa’ di me quel che ti par.</l>
             <stage>Don Alfonso trattiene Guglielmo che vorrebbe entrare.</stage>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #ferrando">
             <speaker>FIORDILIGI, FERRANDO </speaker>
             <l>Abbracciamci, o caro bene,</l>
             <l>E un conforto a tante pene</l>
@@ -3880,16 +3902,16 @@
         <div type="scene">
           <head>SCENA XIII</head>
           <stage>Guglielmo e Don Alfonso; poi Ferrando.</stage>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Oh poveretto me! Cosa ho veduto,</l>
             <l>Cosa ho sentito mai!</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Per carità, silenzio!</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Mi pelerei la barba,</l>
             <l>Mi graffierei la pelle,</l>
@@ -3898,37 +3920,37 @@
             <l>L’Artemisia del secolo! Briccona,</l>
             <l>Assassina, furfante, ladra, cagna!</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <stage>lieto</stage>
             <l>Lasciamolo sfogar.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <stage>entrando</stage>
             <l>Ebben!</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Dov’è?</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Chi? La tua Fiordiligi?</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>La mia Fior… fior di diavolo, che strozzi</l>
             <l>Lei prima e dopo me!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <stage>ironicamente</stage>
             <l>Tu vedi bene:</l>
             <l>V’han delle differenze in ogni cosa.</l>
             <l>Un poco di più merto…</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Ah cessa, amico,</l>
             <l>Cessa di tormentarmi;</l>
@@ -3936,48 +3958,48 @@
             <l>Studiam di castigarle</l>
             <l>Sonoramente.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Io so qual è: sposarle.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Vorrei sposar piuttosto</l>
             <l>La barca di Caronte.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>La grotta di Vulcano.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>La porta dell’inferno.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Dunque, restate celibi in eterno.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Mancheran forse donne</l>
             <l>Ad uomin come noi?</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Non c’è abbondanza d’altro.</l>
             <l>Ma l’altre che faran, se ciò fer queste?</l>
             <l>In fondo, voi le amate</l>
             <l>Queste vostre cornacchie spennacchiate.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Ah purtroppo!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Purtroppo!</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>  Ebben, pigliatele</l>
             <l>Com’elle son. Natura non potea</l>
@@ -4004,7 +4026,7 @@
         <div type="scene">
           <head>SCENA XIV</head>
           <stage>Ferrando, Guglielmo, Don Alfonso e Despina.</stage>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Vittoria, padroncini!</l>
             <l>A sposarvi disposte</l>
@@ -4016,11 +4038,11 @@
             <l>Attendendo vi stanno.</l>
             <l>Siete così contenti?</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo #alfonso">
             <speaker>FERRANDO, GUGLIELMO, ALFONSO </speaker>
             <l> Contentissimi.</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Non è mai senza effetto,</l>
             <l>Quand’entra la Despina in un progetto.</l>
@@ -4031,7 +4053,7 @@
           <head>SCENA XV</head>
           <stage>Sala ricchissima illuminata. Orchestra di fondo. Tavola per quattro persone, con doppieri d’argento.</stage>
           <stage>Quattro servi riccamente vestiti. Despina poi Don Alfonso.</stage>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Fate presto, o cari amici,</l>
             <l>Alle faci il fuoco date</l>
@@ -4043,7 +4065,7 @@
             <l>E voi gite ai vostri posti,</l>
             <l>Finché i sposi vengon qua.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Facciam presto, o cari amici,</l>
             <l>Alle faci il fuoco diamo</l>
@@ -4054,7 +4076,7 @@
             <l>Andiam tutti ai nostri posti</l>
             <l>Finché i sposi vengon qua.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Bravi, bravi! Ottimamente!</l>
             <l>Che abbondanza! che eleganza!</l>
@@ -4066,7 +4088,7 @@
             <l>Lieto canto suon giulivo</l>
             <l>Empia il ciel d’ilarità.</l>
           </sp>
-          <sp>
+          <sp who="#despina #alfonso">
             <speaker>DESPINA, ALFONSO</speaker>
             <stage>sottovoce, partendo per diverse porte</stage>
             <l>La più bella commediola</l>
@@ -4076,7 +4098,7 @@
         <div type="scene">
           <head>SCENA XVI</head>
           <stage>Fiordiligi, Dorabella, Ferrando, Guglielmo, servi e suonatori.</stage>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Benedetti i doppi coniugi</l>
             <l>E le amabili sposine!</l>
@@ -4085,7 +4107,7 @@
             <l>Sien di figli ognor prolifiche,</l>
             <l>Che le agguaglino in beltà.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella #ferrando #guglielmo">
             <speaker>FIORDILIGI, DORABELLA, FERRANDO, GUGLIELMO </speaker>
             <l>Come par che qui prometta</l>
             <l>Tutto gioia e tutto amore!</l>
@@ -4096,7 +4118,7 @@
             <l>E noi qui seggiamo intanto</l>
             <l>In maggior giovialità.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Benedetti i doppi coniugi</l>
             <l>E le amabili sposine!</l>
@@ -4106,38 +4128,38 @@
             <l>Che le agguaglino in beltà.</l>
           </sp>
           <stage>Il coro parte: restano quattro servitori per servir gli sposi, che si mettono alla tavola.</stage>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <l>Tutto, tutto, o vita mia,</l>
             <l>Al mio fuoco or ben risponde.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Pel mio sangue l’allegria</l>
             <l>Cresce, cresce e si diffonde.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <l>Sei pur bella!</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Sei pur vago!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <l>Che bei rai!</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>  Che bella bocca!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo #fiordiligi #dorabella">
             <speaker>FERRANDO, GUGLIELMO, FIORDILIGI, DORABELLA </speaker>
             <stage>toccando i bicchieri</stage>
             <l>Tocca e bevi! Bevi e tocca!</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella #ferrando">
             <speaker>FIORDILIGI, DORABELLA, FERRANDO </speaker>
             <l>E nel tuo, nel mio bicchiero</l>
             <l>Si sommerga ogni pensiero.</l>
@@ -4145,7 +4167,7 @@
             <l>E non resti più memoria</l>
             <l>Del passato, ai nostri cor.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <stage>da sé</stage>
             <l>Ah bevessero del tossico,</l>
@@ -4155,22 +4177,22 @@
         <div type="scene">
           <head>SCENA XVII</head>
           <stage>Fiordiligi, Dorabella, Ferrando, Guglielmo e Don Alfonso; poi Despina travestita da notaio.</stage>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Miei signori, tutto è fatto:</l>
             <l>Col contratto nuziale</l>
             <l>Il notaio è sulle scale,</l>
             <l>E, <foreign xml:lang="lat">isso facto</foreign>, qui verrà.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella #ferrando #guglielmo">
             <speaker>FIORDILIGI, DORABELLA, FERRANDO, GUGLIELMO </speaker>
             <l>Bravo, bravo! Passi subito!</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Vo a chiamarlo. Eccolo qua.</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <stage>
               <add resp="#ed">con voce nasale</add>
@@ -4185,11 +4207,11 @@
             <l>Pria tossendo, poi sedendo,</l>
             <l><foreign xml:lang="lat">Clara voce</foreign> leggerà.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella #ferrando #guglielmo #alfonso">
             <speaker>FIORDILIGI, DORABELLA, FERRANDO, GUGLIELMO, ALFONSO</speaker>
             <l>Bravo, bravo, in verità!</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Per contratto da me fatto,</l>
             <l>Si congiunge in matrimonio</l>
@@ -4200,19 +4222,19 @@
             <l>Questi, nobili albanesi.</l>
             <l>E per dote e controdote…</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella #ferrando #guglielmo">
             <speaker>FIORDILIGI, DORABELLA, FERRANDO, GUGLIELMO </speaker>
             <l>Cose note, cose note!</l>
             <l>Vi crediamo, ci fidiamo,</l>
             <l>Soscriviam: date pur qua.</l>
           </sp>
           <stage>solamente le due donne sottoscrivono</stage>
-          <sp>
+          <sp who="#despina #alfonso">
             <speaker>DESPINA, ALFONSO </speaker>
             <l>Bravi, bravi, in verità!</l>
           </sp>
           <stage>La carta resta in mano di Don Alfonso. Si sente un gran suono di tamburo e canto lontano.</stage>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <stage>interno</stage>
             <l>Bella vita militar!</l>
@@ -4220,11 +4242,11 @@
             <l>Oggi molto e doman poco,</l>
             <l>Ora in terra ed or sul mar.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella #despina #ferrando #guglielmo">
             <speaker>FIORDILIGI, DORABELLA, DESPINA, FERRANDO, GUGLIELMO</speaker>
             <l>Che rumor, che canto è questo?</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>State cheti; io vo a guardar.</l>
             <stage>va alla finestra</stage>
@@ -4234,18 +4256,18 @@
             <l>Io tremo! io gelo!</l>
             <l>Gli sposi vostri…</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Lo sposo mio…</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>In questo istante</l>
             <l>Tornaro, oh Dio;</l>
             <l>Ed alla riva</l>
             <l>Sbarcano già!</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella #ferrando #guglielmo">
             <speaker>FIORDILIGI, DORABELLA, FERRANDO, GUGLIELMO</speaker>
             <l>Cosa mai sento!</l>
             <l>Barbare stelle!</l>
@@ -4253,53 +4275,53 @@
             <l>Che si farà?</l>
           </sp>
           <stage>I servi portano via la tavola, e i suonatori partono in furia.</stage>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Presto, partite!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo #despina #alfonso">
             <speaker>FERRANDO, GUGLIELMO, DESPINA, ALFONSO</speaker>
             <l>Ma se ci <add resp="#ed">li</add> veggono?</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Presto, fuggite!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo #despina #alfonso">
             <speaker>FERRANDO, GUGLIELMO, DESPINA, ALFONSO</speaker>
             <l>Ma se ci <add resp="#ed">li</add> incontrano?</l>
           </sp>
           <stage>Fiordiligi e Dorabella conducono li due amanti in una camera. Don Alfonso conduce Despina in un’altra. Gli amanti escono non veduti e partono.</stage>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Là, là; celatevi,</l>
             <l>Per carità.</l>
             <l>Numi, soccorso!</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Rasserenatevi…</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Numi, consiglio!</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Ritranquillatevi…</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <stage>quasi frenetiche</stage>
             <l>Chi dal periglio</l>
             <l>Ci salverà?</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>In me fidatevi:</l>
             <l>Ben tutto andrà.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Mille barbari pensieri</l>
             <l>Tormentando il cor mi vanno:</l>
@@ -4310,55 +4332,55 @@
         <div type="scene">
           <head>SCENA XVIII</head>
           <stage>Fiordiligi e Dorabella; Ferrando e Guglielmo con mantelli e cappelli militari; Despina in camera; Don Alfonso.</stage>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <l>Sani e salvi, agli amplessi amorosi</l>
             <l>Delle nostre fidissime amanti</l>
             <l>Ritorniamo, di gioia esultanti,</l>
             <l>Per dar premio alla lor fedeltà.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Giusti Numi! Guglielmo, Ferrando!</l>
             <l>Oh che giubilo! qui? come, e quando?</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <l>Richiamati da regio contrordine,</l>
             <l>Pieno il cor di contento e di giòlito,</l>
             <l>Ritorniamo alle spose adorabili,</l>
             <l>Ritorniamo alla vostra amistà.</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <stage>a Fiordiligi</stage>
             <l>Ma cos’è quel pallor, quel silenzio?</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <stage>a Dorabella</stage>
             <l>L’idol mio perché mesto si sta?</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Dal diletto confuse ed attonite,</l>
             <l>Mute mute si restano là.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <stage>da sé</stage>
             <l>Ah che al labbro le voci mi mancano:</l>
             <l>Se non moro, un prodigio sarà.</l>
           </sp>
           <stage>I servi portano un baule.</stage>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Permettete che sia posto</l>
             <l>Quel baul in quella stanza</l>
             <l>Dei, che veggio! Un uom nascosto?</l>
             <l>Un notaio! Qui che fa?</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <stage>entrando, senza cappello</stage>
             <l>Nossignor, non è un notaio:</l>
@@ -4366,37 +4388,37 @@
             <l>Che dal ballo or è tornata,</l>
             <l>E a spogliarsi venne qua.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo #alfonso">
             <speaker>FERRANDO, GUGLIELMO, ALFONSO</speaker>
             <l>Una furba uguale a questa</l>
             <l>Dove mai si troverà?</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Una furba che m’agguagli</l>
             <l>Dove mai si troverà?</l>
           </sp>
           <stage>Don Alfonso lascia cadere accortamente il contratto sottoscritto dalle donne.</stage>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>La Despina! La Despina!</l>
             <l>Non capisco come va.</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <stage>sottovoce, piano agli amanti</stage>
             <l>Già cader lasciai le carte:</l>
             <l>Raccoglietele con arte.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <l>Ma che carte sono queste?</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <l>Un contratto nuziale?</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <l>Giusto ciel! Voi qui scriveste;</l>
             <l>Contraddirci omai non vale!</l>
@@ -4406,7 +4428,7 @@
             <l>Indi il sangue scorrerà!</l>
           </sp>
           <stage>Vanno per entrare nell’altra camera; le donne li arrestano.</stage>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Ah signor, son rea di morte,</l>
             <l>E la morte io sol vi chiedo.</l>
@@ -4414,30 +4436,30 @@
             <l>Con quel ferro un sen ferite</l>
             <l>Che non merita pietà.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <l>Cosa fu?</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>  Per noi favelli</l>
             <stage>additando Don Alfonso e Despina</stage>
             <l>Il crudel, la seduttrice…</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>Troppo vero è quel che dice,</l>
             <l>E la prova è chiusa lì.</l>
           </sp>
           <stage>accenna alla camera dov’erano entrati prima gli amanti</stage>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <stage>da sé</stage>
             <l>Dal timor io gelo, io palpito:</l>
             <l>Perché mai li discoprì!</l>
             <stage>Ferrando e Guglielmo entrano un momento in camera, poi sortono senza cappello, senza mantello e senza mustacchi, ma coll’abito in modo finto; e burlano in modo ridicolo le amanti e Despina.</stage>
           </sp>
-          <sp>
+          <sp who="#ferrando">
             <speaker>FERRANDO</speaker>
             <stage>facendo dei complimenti affettati a Fiordiligi</stage>
             <l>A voi s’inchina,</l>
@@ -4445,7 +4467,7 @@
             <l>Il cavaliere</l>
             <l>Dell’Albania!</l>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <stage>a Dorabella</stage>
             <l>Il ritrattino</l>
@@ -4453,7 +4475,7 @@
             <l>Ecco, io le rendo,</l>
             <l>Signora mia.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <stage>a Despina</stage>
             <l>Ed al magnetico</l>
@@ -4461,29 +4483,29 @@
             <l>Rendo l’onore</l>
             <l>Che meritò.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella #despina">
             <speaker>FIORDILIGI, DORABELLA, DESPINA</speaker>
             <l>Stelle! Che veggo!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo #alfonso">
             <speaker>FERRANDO, GUGLIELMO, ALFONSO</speaker>
             <l>Son stupefatte!</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella #despina">
             <speaker>FIORDILIGI, DORABELLA, DESPINA</speaker>
             <l>Al duol non reggo!</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo #alfonso">
             <speaker>FERRANDO, GUGLIELMO, ALFONSO</speaker>
             <l>Son mezze matte!</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <stage>accennando a Don Alfonso</stage>
             <l>Ecco là il barbaro</l>
             <l>Che c’ingannò!</l>
           </sp>
-          <sp>
+          <sp who="#alfonso">
             <speaker>ALFONSO</speaker>
             <l>V’ingannai, ma fu l’inganno</l>
             <l>Disinganno ai vostri amanti,</l>
@@ -4495,26 +4517,26 @@
             <l>Tutti quattro ora ridete,</l>
             <l>Ch’io già risi e riderò.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella">
             <speaker>FIORDILIGI, DORABELLA</speaker>
             <l>Idol mio, se questo è vero,</l>
             <l>Colla fede e coll’amore</l>
             <l>Compensar saprò il tuo core,</l>
             <l>Adorarti ognor saprò.</l>
           </sp>
-          <sp>
+          <sp who="#ferrando #guglielmo">
             <speaker>FERRANDO, GUGLIELMO</speaker>
             <l>Te lo credo, gioia bella,</l>
             <l>Ma la prova io far non vo’.</l>
           </sp>
-          <sp>
+          <sp who="#despina">
             <speaker>DESPINA</speaker>
             <l>Io non so se questo è sogno:</l>
             <l>Mi confondo, mi vergogno.</l>
             <l>Manco mal, se a me l’han fatta,</l>
             <l>Che a molt’altri anch’io la fo.</l>
           </sp>
-          <sp>
+          <sp who="#fiordiligi #dorabella #despina #ferrando #guglielmo #alfonso">
             <speaker>FIORDILIGI, DORABELLA, DESPINA, FERRANDO, GUGLIELMO, ALFONSO</speaker>
             <l>Fortunato l’uom che prende</l>
             <l>Ogni cosa pel buon verso,</l>

--- a/tei/da-ponte-don-giovanni.xml
+++ b/tei/da-ponte-don-giovanni.xml
@@ -83,6 +83,46 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="leporello">
+            <persName>Leporello</persName>
+          </person>
+          <person xml:id="anna">
+            <persName>Donn'Anna</persName>
+          </person>
+          <person xml:id="don_giovanni">
+            <persName>Don Giovanni</persName>
+          </person>
+          <person xml:id="commendatore">
+            <persName>Il Commendatore</persName>
+          </person>
+          <person xml:id="ottavio">
+            <persName>Don Ottavio</persName>
+          </person>
+          <person xml:id="elvira">
+            <persName>Donn'Elvira</persName>
+          </person>
+          <person xml:id="zerlina">
+            <persName>Zerlina</persName>
+          </person>
+          <personGrp xml:id="contadine">
+            <name>Contadine</name>
+          </personGrp>
+          <person xml:id="masetto">
+            <persName>Masetto</persName>
+          </person>
+          <personGrp xml:id="contadini">
+            <name>Contadini</name>
+          </personGrp>
+          <personGrp xml:id="servi">
+            <name>Servi</name>
+          </personGrp>
+          <personGrp xml:id="coro">
+            <name>Coro</name>
+          </personGrp>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -155,7 +195,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>Leporello con ferraiuolo, che passeggia davanti la casa di Donn'Anna; poi Don Giovanni, Donn'Anna; indi il Commendadore.</stage>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Notte e giorno faticar</l>
             <l>Per chi nulla sa gradir;</l>
@@ -170,78 +210,78 @@
             <l>Non mi voglio far sentir.</l>
             <stage>s'asconde</stage>
           </sp>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <stage>tenendo forte pel braccio Don Giovanni ed egli cercando sempre di celarsi</stage>
             <l>Non sperar' se non m'uccidi</l>
             <l>Ch'io ti lasci fuggir mai</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Donna folle! indarno gridi!</l>
             <l>Chi son io tu non saprai.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Che tumulto! oh ciel, che gridi!</l>
             <l>Il padron in nuovi guai.</l>
           </sp>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <l>Gente! servi! al traditore!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Taci, e trema al mio furore.</l>
           </sp>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <l>Scellerato!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Sconsigliata!</l>
             <l>Questa furia disperata</l>
             <l>Mi vuol far precipitar.</l>
           </sp>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <l>Come furia disperata</l>
             <l>Ti saprò perseguitar.</l>
             <stage>sentendo il Commendadore, lascia Don Giovanni ed entra in casa</stage>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Sta a veder che il libertino</l>
             <l>Mi farà precipitar.</l>
           </sp>
-          <sp>
+          <sp who="#commendatore">
             <speaker>COMMENDATORE</speaker>
             <l>Lasciala, indegno!</l>
             <l>Battiti meco!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Va': non mi degno</l>
             <l>Di pugnar teco.</l>
           </sp>
-          <sp>
+          <sp who="#commendatore">
             <speaker>COMMENDATORE</speaker>
             <l>Così pretendi</l>
             <l>Da me fuggir?</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>(Potessi almeno</l>
             <l>di qua partir!)</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Misero, attendi,</l>
             <l>Se vuoi morir.</l>
             <stage>combattono</stage>
           </sp>
-          <sp>
+          <sp who="#commendatore">
             <speaker>COMMENDATORE</speaker>
             <stage>mortalmente ferito</stage>
             <l>Ah soccorso!... Son tradito!...</l>
@@ -250,7 +290,7 @@
             <l>Sento l'anima partir.</l>
             <stage>muore</stage>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>a parte</stage>
             <l>Ah... già cadde il sciagurato...</l>
@@ -258,7 +298,7 @@
             <l>Già dal seno palpitante</l>
             <l>Veggo l'anima partir.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <stage>a parte</stage>
             <l>Qual misfatto! qual eccesso!</l>
@@ -270,51 +310,51 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>Don Giovanni, Leporello</stage>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>sottovoce sempre</stage>
             <l>Leporello, ove sei?</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <stage>sottovoce sempre</stage>
             <l>Son qui per disgrazia; e voi?</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Son qui.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Chi è morto, voi o il vecchio?</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Che domanda da bestia! Il vecchio.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Bravo:</l>
             <l>Due imprese leggiadre:</l>
             <l>Sforzar la figlia, ed ammazzar il padre.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>L'ha voluto, suo danno.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Ma Donn'Anna</l>
             <l>Cosa ha voluto?</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Taci,</l>
             <l>Non mi seccar, vien meco, se non vuoi</l>
             <stage>in atto di batterlo</stage>
             <l>Qualche cosa ancor tu.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Non vo' nulla, signor, non parlo più.</l>
             <stage>partono</stage>
@@ -323,20 +363,20 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage> Don Ottavio, Donn'Anna con servi che portono diversi lumi.</stage>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <stage>con risolutezza</stage>
             <l>Ah! Del padre in periglio</l>
             <l>In soccorso voliam.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <stage>con ferro ignudo in mano</stage>
             <l>Tutto il mio sangue</l>
             <l>Verserò, se bisogna:</l>
             <l>Ma dov'è il scellerato?</l>
           </sp>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <l>  In questo loco...</l>
             <stage>vede il cadavere</stage>
@@ -344,11 +384,11 @@
             <l>Spettacolo funesto agli occhi miei!</l>
             <l>Il padre... padre mio... mio caro padre...</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <l>Signore!...</l>
           </sp>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <l>Ah l'assassino</l>
             <l>Mel trucidò. Quel sangue...</l>
@@ -358,7 +398,7 @@
             <l>Padre mio... caro padre... padre amato...</l>
             <l>Io manco... io moro.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <l>Ah soccorrete, amici, il mio tesoro!</l>
             <l>Cercatemi... recatemi...</l>
@@ -366,64 +406,64 @@
             <l>Donn'Anna... sposa... amica... Il duolo estremo</l>
             <l>La meschinella uccide...</l>
           </sp>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <stage>rinviene</stage>
             <l>Ahi...</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <l>  Già rinviene.</l>
             <l>Datele nuovi aiuti.</l>
           </sp>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <l>  Padre mio...</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <l>Celate, allontanate agli occhi suoi</l>
             <l>Quell'oggetto d'orrore.</l>
             <stage>Il Commendadore viene trasportato.</stage>
             <l>Anima mia... consòlati... fa' core...</l>
           </sp>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <l>Fuggi, crudele, fuggi!</l>
             <l>Lascia che mora anch'io</l>
             <l>Ora ch'è morto, oh Dio!</l>
             <l>Chi a me la vita diè.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <l>Senti, cor mio, deh senti,</l>
             <l>Guardami un solo istante,</l>
             <l>Ti parla il caro amante</l>
             <l>Che vive sol per te.</l>
           </sp>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <l>Tu sei... perdon, mio bene...</l>
             <l>L'affanno mio... le pene...</l>
             <l>Ah il padre mio dov'è?</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <l>Il padre... lascia, o cara,</l>
             <l>La rimembranza amara...</l>
             <l>Hai sposo e padre in me.</l>
           </sp>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <l>Ah vendicar, se il puoi,</l>
             <l>Giura quel sangue ognor.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <l>Lo giuro agli occhi tuoi,</l>
             <l>Lo giuro al nostro amor.</l>
           </sp>
-          <sp>
+          <sp who="#anna #ottavio">
             <speaker>ANNA, OTTAVIO</speaker>
             <l>Che giuramento, oh Dei!</l>
             <l>Che barbaro momento!</l>
@@ -436,63 +476,63 @@
           <head>SCENA IV</head>
           <stage>Alba chiara. Strada</stage>
           <stage>Don Giovanni, Leporello.</stage>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Orsù, spìcciati presto... cosa vuoi?</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>L'affar di cui si tratta</l>
             <l>È importante.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Lo credo.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l> È importantissimo.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Meglio ancora: finiscila.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l> Giurate</l>
             <l>Di non andar in collera.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Lo giuro sul mio onore,</l>
             <l>Purché non parli del Commendatore.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Siamo soli?</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>  Lo vedo.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Nessun ci sente.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Via!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Vi posso dire tutto</l>
             <l>Liberamente?</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Sì!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Dunque quand'è così:</l>
             <l>Caro signor padrone,</l>
@@ -500,35 +540,35 @@
             <stage>all'orecchio, ma forte</stage>
             <l>è da briccone!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Temerario!  In tal guisa </l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>E il giuramento!...</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Non so di giuramenti... taci... o ch'io...</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Non parlo più, non fiato, o padron mio.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Così saremo amici; or odi un poco,</l>
             <l>Sai tu perché son qui?</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>  Non ne so nulla:</l>
             <l>Ma, essendo l'alba chiara, non sarebbe</l>
             <l>Qualche nuova conquista?</l>
             <l>Io lo devo saper per porla in lista.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Va' là, che sei il grand'uom: sappi ch'io sono</l>
             <l>Innamorato d'una bella dama;</l>
@@ -537,25 +577,25 @@
             <l>Questa notte verrà... Zitto: mi pare</l>
             <l>Sentir odor di femmina...</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l> (Cospetto!</l>
             <l>Che odorato perfetto!)</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>All'aria mi par bella.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>(E che occhio, dico!)</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Ritiriamoci un poco,</l>
             <l>E scopriamo terren.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>  Già prese fuoco.</l>
           </sp>
@@ -563,7 +603,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>I suddetti in disparte; Donn'Elvira in abito da viaggio.</stage>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>Ah chi mi dice mai</l>
             <l>Quel barbaro dov'è,</l>
@@ -574,50 +614,50 @@
             <l>Vo' farne orrendo scempio,</l>
             <l>Gli vo' cavar il cor.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Udisti? qualche bella</l>
             <l>Dal vago abbandonata. Poverina!</l>
             <l>Cerchiam di consolare il suo tormento.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Così ne consolò mille e ottocento.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Signorina!</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l> Chi è là?</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>  Stelle! che vedo!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>O bella! Donna Elvira!</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>   Don Giovanni!</l>
             <l>Sei qui, mostro, fellon, nido d'inganni!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <stage>da sé</stage>
             <l>(Che titoli cruscanti! Manco male</l>
             <l>Che lo conosce bene.)</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Via, cara Donn'Elvira,</l>
             <l>Calmate quella collera... sentite...</l>
             <l>Lasciatemi parlar...</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l> Cosa puoi dire,</l>
             <l>Dopo azion sì nera? In casa mia</l>
@@ -633,25 +673,25 @@
             <l>Al rimorso ed al pianto,</l>
             <l>Per pena forse che t'amai cotanto! </l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <stage>da sé</stage>
             <l>(Pare un libro stampato.)</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>  Oh in quanto a questo</l>
             <l>Ebbi le mie ragioni:</l>
             <stage>a Leporello</stage>
             <l> È vero?</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>È vero.</l>
             <stage>ironicamente</stage>
             <l>E che ragioni forti!</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l> E quali sono,</l>
             <l>Se non la tua perfidia,</l>
@@ -659,7 +699,7 @@
             <l>Volle ch'io ti trovassi</l>
             <l>Per far le sue, le mie vendette.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>   Eh via,</l>
             <l>Siate più ragionevole...</l>
@@ -669,38 +709,38 @@
             <l>Al labbro mio, credete</l>
             <l>A questo galantuomo.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <stage>da sé</stage>
             <l>(Salvo il vero.)</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>a Leporello</stage>
             <l>Via, dille un poco...</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <stage>sottovoce</stage>
             <l>E cosa devo dirle?</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Sì, sì, dille pur tutto.</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <stage>a Leporello</stage>
             <l>Ebben, fa' presto...</l>
             <stage>In questo fra tempo Don Giovanni fugge.</stage>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Madama... veramente... in questo mondo</l>
             <l>Conciossia cosa quando fosse che</l>
             <l>Il quadro non è tondo...</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <stage>a Leporello</stage>
             <l>Sciagurato!</l>
@@ -711,17 +751,17 @@
             <l>Stelle! l'iniquo</l>
             <l>Fuggì! misera me! dove? In qual parte...</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Eh lasciate che vada. Egli non merta</l>
             <l>Che di lui ci pensiate...</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>   Il scellerato</l>
             <l>M'ingannò, mi tradì!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>   Eh consolatevi:</l>
             <l>Non siete voi, non foste e non sarete</l>
@@ -766,7 +806,7 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>Donn'Elvira sola.</stage>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>In questa forma, dunque,</l>
             <l>Mi tradì il scellerato? È questo il premio</l>
@@ -781,7 +821,7 @@
         <div type="scene">
           <head>SCENA VII</head>
           <stage>Masetto, Zerlina, e coro di contadini e contadine che suonano, ballano e cantano.</stage>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>Giovinette che fate all'amore,</l>
             <l>Non lasciate che passi l'età:</l>
@@ -790,12 +830,12 @@
             <l>La la la, la la la, la la lera</l>
             <l>Che piacer, che piacer che sarà!</l>
           </sp>
-          <sp>
+          <sp who="#contadine">
             <speaker>CONTADINE</speaker>
             <l>La la la, la la la, la la lera</l>
             <l>Che piacer, che piacer che sarà!</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>Giovinotti leggeri di testa,</l>
             <l>Non andate girando qua e là.</l>
@@ -804,12 +844,12 @@
             <l>La la la, la la la, la la lera</l>
             <l>Che piacer, che piacer che sarà!</l>
           </sp>
-          <sp>
+          <sp who="#contadini">
             <speaker>CONTADINI</speaker>
             <l>La la la, la la la, la la lera</l>
             <l>Che piacer, che piacer che sarà!</l>
           </sp>
-          <sp>
+          <sp who="#zerlina #masetto">
             <speaker>ZERLINA, MASETTO</speaker>
             <l>Vieni, vieni, carino <add resp="#ed">carina</add> e godiamo,</l>
             <l>E cantiamo e balliamo e saltiamo;</l>
@@ -825,7 +865,7 @@
         <div type="scene">
           <head>SCENA VIII</head>
           <stage>Zerlina, Masetto, contadini, contadine, Don Giovanni e Leporello.</stage>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>entrando da sé</stage>
             <l>Manco male è partita. </l>
@@ -833,64 +873,64 @@
             <l>Oh guarda, guarda</l>
             <l>Che bella gioventù! che belle donne!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Tra tante per mia fé</l>
             <l>Vi sarà qualche cosa anche per me.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Cari amici, buon giorno. Seguitate</l>
             <l>A stare allegramente,</l>
             <l>Seguitate a suonar, o buona gente.</l>
             <l>C'è qualche sposalizio? </l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>Sì, signore,</l>
             <l>E la sposa son io.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>  Me ne consolo.</l>
             <l>Lo sposo?</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>Io, per servirla.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Oh bravo! per servirmi: questo è vero</l>
             <l>Parlar da galantuomo!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Basta che sia marito.</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>   Oh il mio Masetto</l>
             <l>È un uom d'ottimo core.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>  Oh anch'io, vedete!</l>
             <l>Voglio che siamo amici. Il vostro nome?</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>Zerlina.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>   E il tuo?</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>   Masetto.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Oh caro il mio Masetto!</l>
             <l>Cara la mia Zerlina! v'esibisco</l>
@@ -899,12 +939,12 @@
             <l>Leporello...</l>
             <l>Cosa fai lì, birbone? </l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Anch'io, caro padrone,</l>
             <l>Esibisco la mia protezione.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Presto, va' con costor: nel mio palazzo</l>
             <l>Conducili sul fatto; ordina ch'abbiano</l>
@@ -915,64 +955,64 @@
             <l>Fa' che resti contento il mio Masetto.</l>
             <l>Hai capito? </l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Ho capito.</l>
             <stage>ai contadini</stage>
             <l>   Andiam!</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <stage>a Don Giovanni</stage>
             <l>Signore...</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Cosa c'è?</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>   La Zerlina</l>
             <l>Senza me non può star.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>In vostro loco</l>
             <l>Ci sarà sua Eccellenza, e saprà bene</l>
             <l>Fare le vostre parti.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>  Oh la Zerlina</l>
             <l>È in man d'un Cavalier: va' pur, fra poco</l>
             <l>Ella meco verrà.</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>Va', non temere!</l>
             <l>Nelle mani son io d'un cavaliere.</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>E per questo?</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>E per questo</l>
             <l>Non c'è da dubitar...</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>   Ed io, cospetto...</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Olà, finiam le dispute: se subito</l>
             <l>Senz'altro replicar, non te ne vai,</l>
             <stage>mostrandogli la spada</stage>
             <l>Masetto, guarda ben, ti pentirai.</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>Ho capito, signorsì,</l>
             <l>Chino il capo e me ne vo:</l>
@@ -998,17 +1038,17 @@
         <div type="scene">
           <head>SCENA IX</head>
           <stage>Don Giovanni e Zerlina.</stage>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Alfin siamo liberati,</l>
             <l>Zerlinetta gentil, da quel scioccone.</l>
             <l>Che ne dite, mio ben, so far pulito?</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>Signore, è mio marito...</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>   Chi? colui?</l>
             <l>Vi par che un'onest'uomo,</l>
@@ -1017,12 +1057,12 @@
             <l>Quel viso inzuccherato,</l>
             <l>Da un bifolcaccio vil sia strapazzato?</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>Ma, signor, io gli diedi</l>
             <l>Parola di sposarlo.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Tal parola</l>
             <l>Non vale un zero; voi non siete fatta</l>
@@ -1032,22 +1072,22 @@
             <l>Quelle ditucce candide e odorose:</l>
             <l>Parmi toccar giuncata, e fiutar rose.</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>Ah non vorrei...</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Che non vorreste?</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>  Alfine</l>
             <l>Ingannata restar; io so che rado</l>
             <l>Colle donne voi altri cavalieri</l>
             <l>Siete onesti e sinceri.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>   È un'impostura</l>
             <l>Della gente plebea! La nobiltà</l>
@@ -1055,11 +1095,11 @@
             <l>Orsù, non perdiam tempo: in questo istante</l>
             <l>Io vi voglio sposar.</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>Voi?</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>   Certo, io.</l>
             <l>Quel casinetto è mio: soli saremo,</l>
@@ -1069,38 +1109,38 @@
             <l>Vedi non è lontano:</l>
             <l>Partiam, ben mio, di qui.</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>Vorrei, e non vorrei,</l>
             <l>Mi trema un poco il cor;</l>
             <l>Felice, è ver, sarei;</l>
             <l>Ma può burlarmi ancor.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Vieni, mio bel diletto.</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>Mi fa pietà Masetto.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Io cangerò tua sorte.</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>Presto non son più forte.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Andiam, andiam!</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>  Andiam!</l>
           </sp>
-          <sp>
+          <sp who="#zerlina #don_giovanni">
             <speaker>ZERLINA, DON GIOVANNI</speaker>
             <l>Andiam, andiam, mio bene,</l>
             <l>A ristorar le pene</l>
@@ -1110,37 +1150,37 @@
         <div type="scene">
           <head>SCENA X</head>
           <stage>I suddetti e Donn'Elvira che ferma con atti disperatissimi Don Giovanni.</stage>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>Férmati, scellerato: il ciel mi fece</l>
             <l>Udir le tue perfidie; io sono a tempo</l>
             <l>Di salvar questa misera innocente</l>
             <l>Dal tuo barbaro artiglio.</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>Meschina, cosa sento!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>Amor, consiglio!</stage>
             <stage>a Donn'Elvira piano</stage>
             <l>Idol mio, non vedete</l>
             <l>Ch'io voglio divertirmi...</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <stage>ad alta voce</stage>
             <l>Divertirti?</l>
             <l>È vero! divertirti! Io so, crudele,</l>
             <l>Come tu ti diverti...</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>Ma, signor cavaliere...</l>
             <l>È ver quel ch'ella dice?</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>piano a Zerlina</stage>
             <l>La povera infelice</l>
@@ -1148,7 +1188,7 @@
             <l>E per pietà deggio fingere amore;</l>
             <l>Ch'io son, per mia disgrazia, uom di buon core.</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>Ah fuggi il traditor,</l>
             <l>Non lo lasciar più dir:</l>
@@ -1164,41 +1204,41 @@
         <div type="scene">
           <head>SCENA XI</head>
           <stage>Don Giovanni solo; poi Don Ottavio e Donn'Anna.</stage>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Mi par ch'oggi il demonio si diverta</l>
             <l>D'opporsi a' miei piacevoli progressi;</l>
             <l>Vanno mal tutti quanti.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <stage>a Donn'Anna, insieme con la quale entra</stage>
             <l>Ah ch'ora, idolo mio, son vani i pianti!</l>
             <l>Di vendetta si parli... Ah Don Giovanni!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>Mancava questo, inver!</stage>
           </sp>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <stage>a Don Giovanni</stage>
             <l>Signore, a tempo</l>
             <l>Vi ritroviam: avete core, avete</l>
             <l>Anima generosa?</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>(Sta' a vedere</l>
             <l>Che il diavolo le ha detto qualche cosa.)</l>
             <l>Che domanda! perché?</l>
           </sp>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <l>  Bisogno abbiamo</l>
             <l>Della vostra amicizia.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>(Mi torna il fiato in corpo.)</l>
             <l>Comandate:</l>
@@ -1215,7 +1255,7 @@
         <div type="scene">
           <head>SCENA XII</head>
           <stage>I suddetti; Donn'Elvira.</stage>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>Ah ti ritrovo ancor, perfido mostro!</l>
             <l>Non ti fidar, o misera,</l>
@@ -1223,14 +1263,14 @@
             <l>Me già tradì, quel barbaro:</l>
             <l>Te vuol tradir ancor.</l>
           </sp>
-          <sp>
+          <sp who="#anna #ottavio">
             <speaker>ANNA, OTTAVIO</speaker>
             <l>Cieli! che aspetto nobile!</l>
             <l>Che dolce maestà!</l>
             <l>Il suo pallor, le lagrime,</l>
             <l>M'empiono di pietà.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>a parte, Donn'Elvira ascolta</stage>
             <l>La povera ragazza</l>
@@ -1238,90 +1278,90 @@
             <l>Lasciatemi con lei,</l>
             <l>Forse si calmerà.</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>Ah non credete al perfido!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>È pazza, non badate.</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>Restate ancor, restate!</l>
           </sp>
-          <sp>
+          <sp who="#anna #ottavio">
             <speaker>ANNA, OTTAVIO</speaker>
             <l>A chi si crederà!</l>
           </sp>
-          <sp>
+          <sp who="#anna #ottavio #don_giovanni">
             <speaker>ANNA, OTTAVIO, DON GIOVANNI</speaker>
             <l>Certo moto d'ignoto tormento</l>
             <l>Dentro l'alma girare mi sento,</l>
             <l>Che mi dice per quell'infelice</l>
             <l>Cento cose che intender non sa.</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>Sdegno, rabbia, dispetto, tormento</l>
             <l>Dentro l'alma girare mi sento,</l>
             <l>Che mi dice di quel traditore</l>
             <l>Cento cose che intender non sa.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <stage>a parte</stage>
             <l>Io di qua non vado via,</l>
             <l>Se non so com'è l'affar.</l>
           </sp>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <stage>a parte</stage>
             <l>Non ha l'aria di pazzia</l>
             <l>Il suo volto, il suo parlar.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>a parte</stage>
             <l>Se men vado, si potria</l>
             <l>Qualche cosa sospettar.</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>Da quel ceffo si dovria</l>
             <l>La ner'alma giudicar.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <stage>a Don Giovanni</stage>
             <l>Dunque, quella?</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l> È pazzerella.</l>
           </sp>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <stage>a Donn'Elvira</stage>
             <l>Dunque, quegli?</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>  È un traditore.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Infelice!</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l> Mentitore!</l>
           </sp>
-          <sp>
+          <sp who="#anna #ottavio">
             <speaker>ANNA, OTTAVIO</speaker>
             <l>Incomincio a dubitar.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>piano a Donn'Elvira</stage>
             <l>Zitto, zitto, ché la gente</l>
@@ -1329,7 +1369,7 @@
             <l>Siate un poco più prudente,</l>
             <l>Vi farete criticar.</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <stage>forte a Don Giovanni</stage>
             <l>Non sperarlo, o scellerato:</l>
@@ -1338,7 +1378,7 @@
             <l>Voglio a tutti palesar.</l>
             <stage>parte</stage>
           </sp>
-          <sp>
+          <sp who="#anna #ottavio">
             <speaker>ANNA, OTTAVIO</speaker>
             <stage>a parte, guardando Don Giovanni</stage>
             <l>Quegli accenti sì sommessi,</l>
@@ -1346,7 +1386,7 @@
             <l>Son indizi troppo espressi,</l>
             <l>Che mi fan determinar.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Povera sventurata! i passi suoi</l>
             <l>Voglio seguir: non voglio</l>
@@ -1360,47 +1400,47 @@
         <div type="scene">
           <head>SCENA XIII</head>
           <stage>Donn'Anna e Don Ottavio.</stage>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <l>Don Ottavio, son morta!</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <l>  Cosa è stato?</l>
           </sp>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <l>Per pietà, soccorretemi!</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <l>Mio bene...</l>
             <l>Fate coraggio!</l>
           </sp>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <l>   Oh Dei! Quegli è il carnefice</l>
             <l>Del padre mio.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <l>  Che dite...</l>
           </sp>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <l>Non dubitate più: gli ultimi accenti</l>
             <l>Che l'empio proferì tutta la voce</l>
             <l>Richiamar nel cor mio di quell'indegno</l>
             <l>Che nel mio appartamento...</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <l>  Oh ciel! possibile</l>
             <l>Che sotto il sacro manto d'amicizia...</l>
             <l>Ma come fu, narratemi,</l>
             <l>Lo strano avvenimento.</l>
           </sp>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <l>Era già alquanto</l>
             <l>Avanzata la notte,</l>
@@ -1412,12 +1452,12 @@
             <l>Ma riconobbi poi</l>
             <l>Che un inganno era il mio.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <stage>con affanno</stage>
             <l>Stelle! seguite.</l>
           </sp>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <l>Tacito a me s'appressa,</l>
             <l>E mi vuol abbracciar: sciogliermi cerco,</l>
@@ -1427,11 +1467,11 @@
             <l>E coll'altra m'afferra</l>
             <l>Stretta così, che già mi credo vinta.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <l>Perfido! e alfin?</l>
           </sp>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <l> Alfin il duol, l'orrore</l>
             <l>Dell'infame attentato</l>
@@ -1439,11 +1479,11 @@
             <l>Di svincolarmi, torcermi e piegarmi,</l>
             <l>Da lui mi sciolsi.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <l>Oimè! respiro.</l>
           </sp>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <l>   Allora</l>
             <l>Rinforzo i stridi miei, chiamo soccorso,</l>
@@ -1470,7 +1510,7 @@
         <div type="scene">
           <head>SCENA XIV</head>
           <stage>Don Ottavio solo.</stage>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <l>Come mai creder deggio</l>
             <l>Di sì nero delitto</l>
@@ -1499,57 +1539,57 @@
         <div type="scene">
           <head>SCENA XV</head>
           <stage>Leporello solo; poi Don Giovanni.</stage>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Io deggio ad ogni patto</l>
             <l>Per sempre abbandonar questo bel matto!</l>
             <l>Eccolo qui: guardate</l>
             <l>Con qual indifferenza se ne viene! </l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Oh Leporello mio, va tutto bene!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Don Giovannino mio, va tutto male!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Come va tutto male?</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>  Vado a casa,</l>
             <l>Come voi m'ordinaste,</l>
             <l>Con tutta quella gente...</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>   Bravo!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l> A forza</l>
             <l>Di chiacchiere, di vezzi e di bugie,</l>
             <l>Ch'ho imparato sì bene a star con voi,</l>
             <l>Cerco d'intrattenerli...</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Bravo!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>  Dico</l>
             <l>Mille cose a Masetto per placarlo,</l>
             <l>Per trargli dal pensier la gelosia...</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Bravo, in coscienza mia!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l> Faccio che bevano</l>
             <l>E gli uomini e le donne:</l>
@@ -1558,51 +1598,51 @@
             <l>Altri séguita a ber; in sul più bello,</l>
             <l>Chi credete che càpiti? </l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Zerlina!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Bravo! E con lei chi viene?</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l> Donna Elvira!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Bravo! e disse di voi </l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Tutto quel mal che in bocca le venia.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Bravo, in coscienza mia!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>E tu cosa facesti?</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Tacqui.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>  Ed ella?</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Seguì a gridar.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>   E tu?</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l> Quando mi parve</l>
             <l>Che già fosse sfogata, dolcemente</l>
@@ -1610,7 +1650,7 @@
             <l>Chiusa la porta a chiave, io mi cavai,</l>
             <l>E sulla via soletta la lasciai.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Bravo, bravo, arcibravo!</l>
             <l>L'affar non può andar meglio: incominciasti,</l>
@@ -1646,30 +1686,30 @@
           <head>SCENA XVI</head>
           <stage>Giardino di Don Giovanni con due porte chiuse a chiave per di fuori; nel fondo il palazzo illuminato; due nicchie ai lati. </stage>
           <stage>Masetto e Zerlina; Coro di contadini e di contadine sparse qua e là che dormono e sedono sopra sofà d'erbe. </stage>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>Masetto: senti un po'! Masetto, dico!</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>Non mi toccar.</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>  Perché?</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l> Perché mi chiedi?</l>
             <l>Perfida! il tatto sopportar dovrei</l>
             <l>D'una man infedele?</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>Ah no: taci crudele!</l>
             <l>Io non merto da te tal trattamento!</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>Come! ed hai l'ardimento di scusarti?</l>
             <l>Star sola con un uom; abbandonarmi</l>
@@ -1678,7 +1718,7 @@
             <l>Questa marca d'infamia! Ah se non fosse,</l>
             <l>Se non fosse lo scandalo vorrei...</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>Ma se colpa io non ho! ma se da lui</l>
             <l>Ingannata rimasi... E poi, che temi?</l>
@@ -1701,40 +1741,40 @@
             <l>In contenti ed allegria</l>
             <l>Notte e dì vogliam passar.</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>Guarda un po' come seppe</l>
             <l>Questa strega sedurmi! siamo pure</l>
             <l>I deboli di testa!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>di dentro</stage>
             <l>Sia preparato tutto a una gran festa!</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>Ah Masetto, Masetto! odi la voce</l>
             <l>Del monsù cavaliero!</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>Ebben, che c'è?</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>Verrà!</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l> Lascia che venga.</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>   Ah se vi fosse</l>
             <l>Un buco da fuggir!</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>Di cosa temi? </l>
             <l>Perché diventi pallida? Ah capisco.</l>
@@ -1746,32 +1786,32 @@
             <l>C'è una nicchia... qui celato</l>
             <l>Cheto, cheto mi vo' star.</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>Senti senti... dove vai!</l>
             <l>Non t'asconder, o Masetto!</l>
             <l>Se ti trova, poveretto,</l>
             <l>Tu non sai quel che può far.</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>Faccia, dica quel che vuole!</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>Ah non giovan le parole!</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>Parla forte, e qui t'arresta!</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>Che capriccio ha nella testa!</l>
             <l>Quell'ingrato, quel crudele</l>
             <l>Oggi vuol precipitar.</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>Capirò se m'è fedele,</l>
             <l>E in qual modo andò l'affar.</l>
@@ -1781,7 +1821,7 @@
         <div type="scene">
           <head>SCENA XVII</head>
           <stage>Zerlina; Don Giovanni con quattro servi nobilmente vestiti.</stage>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Sù, svegliatevi, da bravi,</l>
             <l>Sù, coraggio, o buona gente!</l>
@@ -1793,7 +1833,7 @@
             <l>Ed a tutti in abbondanza</l>
             <l>Gran rinfreschi fate dar.</l>
           </sp>
-          <sp>
+          <sp who="#servi">
             <speaker>SERVI</speaker>
             <l>Sù, svegliatevi, da bravi,</l>
             <l>Sù, coraggio, o buona gente!</l>
@@ -1805,51 +1845,51 @@
         <div type="scene">
           <head>SCENA XVIII</head>
           <stage>Don Giovanni, Zerlina; Masetto nella nicchia.</stage>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>Tra quest'arbori celata</l>
             <l>Si può dar che non mi veda.</l>
             <stage>vuol nascondersi</stage>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Zerlinetta mia garbata,</l>
             <l>T'ho già visto, non scappar.</l>
             <stage>la prende</stage>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>Ah lasciatemi andar via...</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>No, no, resta, gioia mia!</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>Se pietade avete in core...</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Sì, ben mio, son tutto amore.</l>
             <l>Vieni un poco in questo loco,</l>
             <l>Fortunata io ti vo' far.</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>Ah s'ei vede il sposo mio,</l>
             <l>So ben io quel che può far!</l>
             <stage>Don Giovanni, nell'aprire la nicchia, e vedendo Masetto, fa un moto di stupore.</stage>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Masetto!</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l> Sì Masetto!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>un po' confuso</stage>
             <l>E chiuso là, perché?</l>
@@ -1858,12 +1898,12 @@
             <l>Non può, la poverina,</l>
             <l>Più star senza di te.</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <stage>un poco ironico</stage>
             <l>Capisco, sì, signore.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>a Zerlina</stage>
             <l>Adesso fate core.</l>
@@ -1871,7 +1911,7 @@
             <l>I suonatori udite;</l>
             <l>Venite omai con me.</l>
           </sp>
-          <sp>
+          <sp who="#masetto #zerlina">
             <speaker>MASETTO, ZERLINA</speaker>
             <l>Sì, sì, facciamo core,</l>
             <l>Ed a ballar con gli altri</l>
@@ -1882,85 +1922,85 @@
         <div type="scene">
           <head>SCENA XIX</head>
           <stage>Don Ottavio, Donn'Anna e Donn'Elvira in maschera; poi Leporello e Don giovanni alla finestra.</stage>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>Bisogna aver coraggio,</l>
             <l>O cari amici miei,</l>
             <l>E i suoi misfatti rei</l>
             <l>Scoprir potremo allor.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <l>L'amica dice bene:</l>
             <l>Coraggio aver conviene.</l>
             <l>Discaccia, o vita mia,</l>
             <l>L'affanno ed il timor.</l>
           </sp>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <l>Il passo è periglioso</l>
             <l>Può nascer qualche imbroglio:</l>
             <l>Temo pel caro sposo</l>
             <l>E per noi temo ancor.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <stage>apre la finestra e s'affaccia</stage>
             <l>Signor, guardate un poco</l>
             <l>Che maschere galanti!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Fàlle passar avanti,</l>
             <l>Di' che ci fanno onor.</l>
             <stage>rientra</stage>
           </sp>
-          <sp>
+          <sp who="#anna #elvira #ottavio">
             <speaker>ANNA, ELVIRA, OTTAVIO</speaker>
             <l>(Al volto e alla voce</l>
             <l>Si scopre il traditor.)</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Zì, zì, signore maschere!</l>
             <l>Zì, zì...</l>
           </sp>
-          <sp>
+          <sp who="#anna #elvira">
             <speaker>ANNA, ELVIRA</speaker>
             <stage>piano a Don Ottavio</stage>
             <l>  Via, rispondete.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Zì, zì...</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <stage>a Leporello</stage>
             <l>  Cosa chiedete?</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Al ballo, se vi piace,</l>
             <l>V'invita il mio signor.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <l>Grazie di tanto onore;</l>
             <l>Andiam, compagne belle!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>L'amico anche su quelle</l>
             <l>Prova farà d'amor.</l>
             <stage>entra e chiude</stage>
           </sp>
-          <sp>
+          <sp who="#anna #ottavio">
             <speaker>ANNA, OTTAVIO</speaker>
             <l>Protegga il giusto cielo</l>
             <l>Il zelo del mio cor.</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>Vendichi il giusto cielo</l>
             <l>Il mio tradito amor.</l>
@@ -1972,285 +2012,285 @@
           <stage>Sala illuminata e preparata per una gran festa di ballo.</stage>
           <stage>Don Giovanni, Masetto, Zerlina, Leporello; contadini e contadine; poi Donn'Anna, Donn'Elvira e Don Ottavio in maschera; suonatori, servitori con rinfreschi. </stage>
           <stage>Don Giovanni fa seder le ragazze, e Leporello i ragazzi, che saranno in atto di aver finito un ballo. </stage>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Riposate, vezzose ragazze.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Rinfrescatevi, bei giovanotti.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni #leporello">
             <speaker>DON GIOVANNI, LEPORELLO </speaker>
             <l>Tornerete a far presto le pazze,</l>
             <l>Tornerete a scherzar e ballar.</l>
             <stage>si portano i rinfreschi</stage>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Ehi caffè!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>  Cioccolata!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>  Sorbetti!</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>Ah Zerlina, giudizio!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>  Confetti!</l>
           </sp>
-          <sp>
+          <sp who="#zerlina #masetto">
             <speaker>ZERLINA, MASETTO</speaker>
             <stage>a parte</stage>
             <l>Troppo dolce comincia la scena,</l>
             <l>In amaro potria terminar.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>fa carezze a Zerlina</stage>
             <l>Sei pur vaga, brillante Zerlina!</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>Sua bontà!</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <stage>fremendo</stage>
             <l>La briccona fa festa.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <stage>imita il padrone colle altre ragazze</stage>
             <l>Sei pur cara, Giannotta, Sandrina!</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>Tocca pur, che ti cada la testa!</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <stage>a parte</stage>
             <l>Quel Masetto mi par stralunato,</l>
             <l>Brutto brutto si fa quest'affar.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni #leporello">
             <speaker>DON GIOVANNI, LEPORELLO</speaker>
             <stage>a parte</stage>
             <l>Quel Masetto mi par stralunato,</l>
             <l>Qui bisogna cervello adoprar.</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>Ah briccona, mi vuoi disperar!</l>
             <stage>Entrano Don Ottavio, Donn'Anna e Donn'Elvira mascherati.</stage>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Venite pur avanti,</l>
             <l>Vezzose mascherette!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>È aperto a tutti quanti,</l>
             <l>Viva la libertà!</l>
           </sp>
-          <sp>
+          <sp who="#anna #elvira #ottavio">
             <speaker>ANNA, ELVIRA, OTTAVIO</speaker>
             <l>Siam grati e tanti segni</l>
             <l>Di generosità.</l>
           </sp>
-          <sp>
+          <sp who="#anna #elvira #ottavio #don_giovanni #leporello">
             <speaker>ANNA, ELVIRA, OTTAVIO, DON GIOVANNI, LEPORELLO</speaker>
             <l>Viva la libertà!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>ai suonatori</stage>
             <l>Ricominciate il suono.</l>
             <stage>a Leporello</stage>
             <l>Tu accoppia i ballerini.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Da bravi, via, ballate.</l>
             <stage>Don Ottavio balla Menuetto con Donn'Anna.</stage>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <stage>a Donn'Anna</stage>
             <l>Quella è la contadina.</l>
           </sp>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <l>Io moro!</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <stage>a Donn'Anna</stage>
             <l>Simulate.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni #leporello">
             <speaker>DON GIOVANNI, LEPORELLO</speaker>
             <l>Va bene, in verità!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>piano a Leporello</stage>
             <l>A bada tien Masetto.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <stage>a Masetto</stage>
             <l>Non balli, poveretto!</l>
             <l>Vien qua, Masetto caro:</l>
             <l>Facciam quel ch'altri fa.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>a Zerlina</stage>
             <l>Il tuo compagno io sono,</l>
             <l>Zerlina, vien pur qua.</l>
             <stage>si mette a ballare con Zerlina una contradanza</stage>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Eh balla, amico mio!</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>No, no, ballar non voglio.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Caro Masetto, balla!</l>
           </sp>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <stage>a Donn'Elvira</stage>
             <l>Resister non poss'io!</l>
           </sp>
-          <sp>
+          <sp who="#elvira #ottavio">
             <speaker>ELVIRA, OTTAVIO</speaker>
             <stage>a Donn'Anna</stage>
             <l>Fingete, per pietà!</l>
             <stage>Leporello balla la Teitsch con Masetto.</stage>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>a Zerlina</stage>
             <l>Vieni con me, mia vita...</l>
             <stage>ballando conduce Zerlina presso una porta, e la fa entrare quasi per forza</stage>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <stage>a Leporello</stage>
             <l>Lasciami... ah... no... Zerlina!...</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>Oh numi! son tradita!...</l>
             <stage>Masetto si cava dalle mani di Leporello e segue Zerlina.</stage>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Qui nasce una ruina.</l>
             <stage>segue in fretta Don Giovanni</stage>
           </sp>
-          <sp>
+          <sp who="#anna #elvira #ottavio">
             <speaker>ANNA, ELVIRA, OTTAVIO</speaker>
             <l>L'iniquo da se stesso</l>
             <l>Nel laccio se ne va.</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <stage>di dentro, ad alta voce; strepito di piedi a destra</stage>
             <l>Gente aiuto, aiuto gente!</l>
           </sp>
-          <sp>
+          <sp who="#anna #elvira #ottavio">
             <speaker>ANNA, ELVIRA, OTTAVIO</speaker>
             <l>Soccorriamo l'innocente!</l>
             <stage>I suonatori e gli altri partono confusi.</stage>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>Ah Zerlina!</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <stage>di dentro</stage>
             <l>Scellerato!</l>
           </sp>
-          <sp>
+          <sp who="#anna #elvira #ottavio">
             <speaker>ANNA, ELVIRA, OTTAVIO</speaker>
             <l>Ora grida da quel lato...</l>
             <l>Ah gittiamo giù la porta!</l>
             <stage>gettano giù la porta</stage>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <stage>esce da un'altra porta</stage>
             <l>Soccorretemi, son morta!</l>
           </sp>
-          <sp>
+          <sp who="#anna #elvira #ottavio #masetto">
             <speaker>ANNA, ELVIRA, OTTAVIO, MASETTO</speaker>
             <l>Siam qui noi per tua difesa.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>esce con spada in mano; conduce seco per un braccio Leporello, e finge di voler ferirlo; ma la spada non esce dal fodero</stage>
             <l>Ecco il birbo che t'ha offesa:</l>
             <l>Ma da me la pena avrà.</l>
             <l>Mori, iniquo!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Ah cosa fate!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Mori, dico!</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <stage>cava una pistola contro Don Giovanni</stage>
             <l>   Nol sperate!</l>
           </sp>
-          <sp>
+          <sp who="#anna #elvira #ottavio">
             <speaker>ANNA, ELVIRA, OTTAVIO</speaker>
             <stage>si cava la maschera</stage>
             <l>L'empio crede con tal frode</l>
             <l>Di nasconder l'empietà.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Donn'Elvira!</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>Sì malvagio!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Don Ottavio!</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <l>Sì signore!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>a Donn'Anna</stage>
             <l>Ah credete!...</l>
           </sp>
-          <sp>
+          <sp who="#anna #elvira #zerlina #ottavio #masetto">
             <speaker>ANNA, ELVIRA, ZERLINA, OTTAVIO, MASETTO</speaker>
             <l> Traditore!</l>
             <l>Tutto, tutto già si sa!</l>
@@ -2263,7 +2303,7 @@
             <l>Sul tuo capo, in questo giorno,</l>
             <l>Il suo fulmine cadrà.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni #leporello">
             <speaker>DON GIOVANNI, LEPORELLO</speaker>
             <l>È confusa la mia <add resp="#ed">sua</add> testa,</l>
             <l>Non so <add resp="#ed">sa</add> più quel ch'io mi <add resp="#ed">ei si</add> faccia,</l>
@@ -2282,61 +2322,61 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>Don Giovanni e Leporello.</stage>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Ehi, via, buffone, non mi seccar.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>No, no, padrone, non vo' restar.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Sentimi, amico:</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>   Vo' andar vi dico.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Ma che ti ho fatto che vuoi lasciarmi?</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Oh niente affatto: quasi ammazzarmi!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Va', che sei matto! fu per burlar.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Ed io non burlo, ma voglio andar.</l>
             <stage>va per partire</stage>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Leporello.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>  Signore.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Vien qui, facciamo pace: prendi...</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Cosa?</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>gli dà del denaro</stage>
             <l>Quattro doppie.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>   Oh sentite,</l>
             <l>Per questa volta ancora</l>
@@ -2345,28 +2385,28 @@
             <l>Di sedurre i miei pari,</l>
             <l>Come le donne, a forza di danari.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Non parliam più di ciò! Ti basta l'animo</l>
             <l>Di far quel ch'io ti dico?</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Purché lasciam le donne.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Lasciar le donne! pazzo!</l>
             <l>Lasciar le donne? Sai ch'elle per me</l>
             <l>Son necessarie più del pan che mangio,</l>
             <l>Più dell'aria che spiro!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>  E avete core</l>
             <l>D'ingannarle poi tutte?</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>   È tutto amore.</l>
             <l>Chi a una sola è fedele</l>
@@ -2377,22 +2417,22 @@
             <l>Le donne, poi che calcolar non sanno</l>
             <l>Il mio buon natural chiamano inganno.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Non ho veduto mai</l>
             <l>Naturale più vasto, e più benigno.</l>
             <l>Orsù, cosa vorreste?</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Odi: vedesti tu la cameriera</l>
             <l>Di Donn'Elvira?</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Io no.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l> Non hai veduto</l>
             <l>Qualche cosa di bello,</l>
@@ -2402,12 +2442,12 @@
             <l>Per aguzzarle meglio l'appetito,</l>
             <l>Di presentarmi a lei col tuo vestito.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>E perché non potreste</l>
             <l>Presentarvi col vostro?</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>  Han poco credito</l>
             <l>Con gente di tal rango</l>
@@ -2415,11 +2455,11 @@
             <stage>si cava il proprio abito e si mette quello di Leporello</stage>
             <l>Sbrìgati... via...</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Signor... per più ragioni...</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>con collera</stage>
             <l>Finiscila, non soffro opposizioni.</l>
@@ -2430,70 +2470,70 @@
           <head>SCENA II</head>
           <stage>Don Giovanni, Leporello, Donn'Elvira.</stage>
           <stage>Si fa notte a poco a poco.</stage>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>Ah taci, ingiusto core,</l>
             <l>Non palpitarmi in seno:</l>
             <l>È un empio, è un traditore,</l>
             <l>È colpa aver pietà.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Zitto! di Donn'Elvira</l>
             <l>Signor, la voce io sento!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Cogliere io vo' il momento.</l>
             <l>Tu férmati un po' là!</l>
             <stage>si mette dietro Leporello e parle a Donn'Elvira</stage>
             <l>Elvira, idolo mio!...</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>Non è costui l'ingrato?</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Sì, vita mia, son io,</l>
             <l>E chiedo carità.</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>Numi, che strano affetto</l>
             <l>Mi si risveglia in petto!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>State a vedere la pazza,</l>
             <l>Che ancor gli crederà.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Discendi, o gioia bella:</l>
             <l>Vedrai che tu sei quella</l>
             <l>Che adora l'alma mia;</l>
             <l>Pentito io sono già.</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>No, non ti credo, o barbaro!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>con trasporto e quasi piangendo</stage>
             <l>Ah credimi, o m'uccido!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <stage>piano a Don Giovanni</stage>
             <l>Se seguitate, io rido.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Idolo mio, vien qua.</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <stage>a parte</stage>
             <l>Dei, che cimento è questo!</l>
@@ -2502,7 +2542,7 @@
             <l>La mia credulità.</l>
             <stage>parte dalla finestra</stage>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>a parte</stage>
             <l>Spero che cada presto.</l>
@@ -2510,7 +2550,7 @@
             <l>Più fertile talento</l>
             <l>Del mio, no, non si dà.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <stage>a parte</stage>
             <l>Già quel mendace labbro</l>
@@ -2518,17 +2558,17 @@
             <l>Deh proteggete, o Dei,</l>
             <l>La sua credulità.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>allegrissimo</stage>
             <l>Amico, che ti par?</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>   Mi par che abbiate</l>
             <l>Un'anima di bronzo.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Va' là, che se' il gran gonzo! Ascolta bene:</l>
             <l>Quando costei qui viene,</l>
@@ -2537,20 +2577,20 @@
             <l>Fingi la voce mia, poi con bell'arte</l>
             <l>Cerca teco condurla in altra parte.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Ma signor...</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>mette presso il naso una pistola a Leporello</stage>
             <l>Non più repliche!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>E se poi mi conosce?</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Non ti conoscerà, se tu non vuoi...</l>
             <l>Zitto, ell'apre. Ehi giudizio.</l>
@@ -2560,19 +2600,19 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>I suddetti; Donn'Elvira.</stage>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>Eccomi a voi!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>(Veggiamo che farà).</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>(Che bell'imbroglio!)</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <stage>a Leporello, scambiandolo per Don Giovanni</stage>
             <l>Dunque creder potrò che i pianti miei</l>
@@ -2580,102 +2620,102 @@
             <l>L'amato Don Giovanni al suo dovere</l>
             <l>E all'amor mio ritorna?...</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <stage>alterando la voce</stage>
             <l>Sì, carina!</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>Crudele! se sapeste</l>
             <l>Quante lagrime e quanti</l>
             <l>Sospir voi mi costate!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l> Io, vita mia?</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>Voi.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>  Poverina! quanto mi dispiace!</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>Mi fuggirete più?</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l> No, muso bello.</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>Sarete sempre mio?</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>  Sempre.</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>  Carissimo!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Carissima!</l>
             <l>(La burla mi dà gusto.)</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>Mio tesoro!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>  Mia Venere!</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>Son per voi tutta foco!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>  Io tutto cenere.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>(Il birbo si riscalda.)</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>E non m'ingannerete?</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l> No, sicuro.</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>Giuratemi.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Lo giuro a questa mano,</l>
             <l>Che bacio con trasporto... e a quei bei lumi...</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>finge di uccider qualcheduno con la spada alla mano</stage>
             <l>Ih Eh Ih Eh Ih Ah  sei morto!</l>
           </sp>
-          <sp>
+          <sp who="#elvira #leporello">
             <speaker>ELVIRA, LEPORELLO</speaker>
             <l>Oh Numi!</l>
           </sp>
           <stage>fuggono</stage>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>ride</stage>
             <l>Ih Eh Ih Eh Ih Ah! Par che la sorte</l>
@@ -2696,25 +2736,25 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>Masetto armato d'archibugio e pistola; contadini e suddetto.</stage>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>Non ci stanchiamo: il cor mio dice</l>
             <l>Che trovarlo dobbiam.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>Qualcuno parla.</stage>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>Fermatevi: mi pare</l>
             <l>Che alcuno qui si muova!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>(Se non fallo è Masetto.)</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <stage>forte</stage>
             <l>Chi va là?</l>
@@ -2724,7 +2764,7 @@
             <stage>più forte</stage>
             <l>Chi va là?</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>(Non è solo:</l>
             <l>Ci vuol giudizio.</l>
@@ -2734,32 +2774,32 @@
             <stage>come sopra</stage>
             <l> Sei tu, Masetto?</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <stage>in collera</stage>
             <l>Appunto quello! E tu?</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Non mi conosci? Il servo</l>
             <l>Son io di Don Giovanni.</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l> Leporello!</l>
             <l>Servo di quell'indegno cavaliere!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Certo: di quel briccone...</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>Di quell'uom senza onor...! Ah dimmi un poco</l>
             <l>Dove possiam trovarlo:</l>
             <l>Lo cerco con costor per trucidarlo.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>(Bagatelle!) Bravissimo, Masetto!</l>
             <l>Anch'io con voi m'unisco,</l>
@@ -2793,57 +2833,57 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>Don Giovanni e Masetto.</stage>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>ritorna in scena, conducendo seco per la mano Masetto</stage>
             <l>Zitto! Lascia ch'io senta: ottimamente</l>
             <l>Dunque dobbiam ucciderlo.</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>  Sicuro.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>E non ti basterìa rompergli l'ossa...</l>
             <l>Fracassargli le spalle...</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>No, no, voglio ammazzarlo,</l>
             <l>Vo' farlo in cento brani...</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Hai buon'armi?</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>   Cospetto!</l>
             <l>Ho pria questo moschetto;</l>
             <l>E poi questa pistola...</l>
             <stage>dà il moschetto e la pistola a Don Giovanni</stage>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l> E poi?</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>  Non basta? </l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Oh basta certo! Or prendi:</l>
             <stage>batte col rovescio della spada Masetto</stage>
             <l>Questa per la pistola...</l>
             <l>Questa per il moschetto...</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>Ahi! ahi soccorso! ahi! ahi!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>minacciandolo con le armi alla mano</stage>
             <l>   Taci, o sei morto!</l>
@@ -2856,69 +2896,69 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>Masetto; poi Zerlina con lanterna.</stage>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <stage>gridando forte</stage>
             <l>Ahi ahi! la testa mia!</l>
             <l>Ahi ahi! le spalle e il petto!</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>Di sentire mi parve</l>
             <l>La voce di Masetto.</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l> Oh Dio! Zerlina</l>
             <l>Zerlina mia! soccorso!</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>  Cosa è stato?</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>L'iniquo! il scellerato</l>
             <l>Mi ruppe l'ossa e i nervi!</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>Oh poveretta me! chi?</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l> Leporello!</l>
             <l>O qualche diavol che somiglia a lui.</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>Crudel! non tel diss'io,</l>
             <l>Che con questa tua pazza gelosia</l>
             <l>Ti ridurresti a qualche brutto passo?</l>
             <l>Dove ti duole?</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>  Qui.</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>   E poi?</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>Qui... e ancora qui...</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>E poi non ti duol altro?</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>   Duolmi un poco</l>
             <l>Questo piè, questo braccio, e questa mano.</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>Via, via: non è gran mal, se il resto è sano.</l>
             <l>Vientene meco a casa;</l>
@@ -2948,18 +2988,18 @@
         <div type="scene">
           <head>SCENA VII</head>
           <stage>Leporello, Donn'Elvira; poi Donn'Anna, Don Ottavio con servi e lumi; poi Zerlina e Masetto.</stage>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Di molte faci il lume</l>
             <l>S'avvicina, o mio ben: stiamci qui ascosi</l>
             <l>Fin che da noi si scosta.</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l> Ma che temi,</l>
             <l>Adorato mio sposo?</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>   Nulla, nulla...</l>
             <l>Certi riguardi... io vo' veder se il lume</l>
@@ -2970,7 +3010,7 @@
             <l>Rimanti, anima bella...</l>
             <stage>s'allontana</stage>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>Ah non lasciarmi!</l>
             <l>Sola sola, in buio loco,</l>
@@ -2978,7 +3018,7 @@
             <l>E m'assale un tal spavento,</l>
             <l>Che mi sembra di morir.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <stage>andando a tentone</stage>
             <l>Più che cerco, men ritrovo</l>
@@ -2988,7 +3028,7 @@
           </sp>
           <stage>sbaglia la porta</stage>
           <stage>Donn'Anna e Don Ottavio entrano vestiti a lutto.</stage>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <stage>a Donn'Anna</stage>
             <l>Tergi il ciglio, o vita mia,</l>
@@ -2996,24 +3036,24 @@
             <l>L'ombra ormai del genitore</l>
             <l>Pena avrà de' tuoi martir.</l>
           </sp>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <l>Lascia almen alla mia pena</l>
             <l>Questo picciolo ristoro,</l>
             <l>Sol la morte, o mio tesoro,</l>
             <l>Il mio pianto può finir.</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <stage>senza esser vista</stage>
             <l>Ah dov'è lo sposo mio? </l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <stage>dalla porta, senza esser visto</stage>
             <l>Se mi trovan, son perduto!</l>
           </sp>
-          <sp>
+          <sp who="#elvira #leporello">
             <speaker>ELVIRA, LEPORELLO</speaker>
             <l>Una porta là vegg'io.</l>
             <l>Cheta <add resp="#ed">Cheto</add> cheta <add resp="#ed">cheto</add> io vo' partir.</l>
@@ -3023,31 +3063,31 @@
         <div type="scene">
           <head>SCENA VIII</head>
           <stage>I suddetti; Zerlina e Masetto.</stage>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <stage>s'asconde la faccia</stage>
           </sp>
-          <sp>
+          <sp who="#zerlina #masetto">
             <speaker>ZERLINA, MASETTO</speaker>
             <l>Ferma, briccone,</l>
             <l>Dove ten vai?</l>
           </sp>
-          <sp>
+          <sp who="#anna #ottavio">
             <speaker>ANNA, OTTAVIO</speaker>
             <l>Ecco il fellone!...</l>
             <l>Com'era qua?</l>
           </sp>
-          <sp>
+          <sp who="#anna #zerlina #ottavio #masetto">
             <speaker>ANNA, ZERLINA, OTTAVIO, MASETTO</speaker>
             <l>Ah mora il perfido</l>
             <l>Che m'ha tradito!</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>È mio marito!</l>
             <l>Pietà, pietà!</l>
           </sp>
-          <sp>
+          <sp who="#anna #zerlina #ottavio #masetto">
             <speaker>ANNA, ZERLINA, OTTAVIO, MASETTO</speaker>
             <l>È Donna Elvira,</l>
             <l>Quella ch'io vedo?</l>
@@ -3055,7 +3095,7 @@
             <l>No, no! Morrà!</l>
             <stage>Don Ottavio fa l'atto di ucciderlo. Leporello si scopre e si mette in ginocchio davanti agli altri.</stage>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <stage>quasi piangendo</stage>
             <l>Perdon, perdono,</l>
@@ -3065,21 +3105,21 @@
             <l>Viver lasciatemi,</l>
             <l>Per carità!</l>
           </sp>
-          <sp>
+          <sp who="#anna #zerlina #elvira #ottavio #masetto">
             <speaker>ANNA, ZERLINA, ELVIRA, OTTAVIO, MASETTO</speaker>
             <l>Dei! Leporello!</l>
             <l>Che inganno è questo!</l>
             <l>Stupida <add resp="#ed">Stupido</add> resto:</l>
             <l>Che mai sarà!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Mille torbidi pensieri</l>
             <l>Mi s'aggiran per la testa:</l>
             <l>Se mi salvo in tal tempesta,</l>
             <l>È un prodigio in verità!</l>
           </sp>
-          <sp>
+          <sp who="#anna #zerlina #elvira #ottavio #masetto">
             <speaker>ANNA, ZERLINA, ELVIRA, OTTAVIO, MASETTO</speaker>
             <l>Mille torbidi pensieri</l>
             <l>Mi s'aggiran per la testa...</l>
@@ -3091,41 +3131,41 @@
         <div type="scene">
           <head>SCENA IX</head>
           <stage>Donn'Elvira, DonOttavio, Leporello, Zerlina e Masetto.</stage>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <stage>a Leporello</stage>
             <l>Dunque, quello sei tu che il mio Masetto</l>
             <l>Poco fa crudelmente maltrattasti?</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <stage>a Leporello</stage>
             <l>Dunque, tu m'ingannasti, o scellerato,</l>
             <l>Spacciandoti con me da Don Giovanni?</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <stage>a Leporello</stage>
             <l>Dunque, tu in questi panni</l>
             <l>Venisti qui per qualche tradimento!</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>A me tocca punirlo.</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l>Anzi, a me!</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <l>  No, no: a me!</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>Accoppatelo meco tutti e tre!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <stage>a Don Ottavio e Donn'Elvira</stage>
             <l>Ah pietà, signori miei,</l>
@@ -3164,20 +3204,20 @@
         <div type="scene">
           <head>SCENA X</head>
           <stage>Donn'Elvira, Don Ottavio, Zerlina e Masetto.</stage>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>Ferma, perfido, ferma!...</l>
           </sp>
-          <sp>
+          <sp who="#masetto">
             <speaker>MASETTO</speaker>
             <l>Il birbo ha l'ali ai piedi...</l>
           </sp>
-          <sp>
+          <sp who="#zerlina">
             <speaker>ZERLINA</speaker>
             <l> Con qual arte</l>
             <l>Si sottrasse l'iniquo!...</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <l>   Amici miei,</l>
             <l>Dopo eccessi sì enormi,</l>
@@ -3203,7 +3243,7 @@
           <head>SCENA XI</head>
           <stage>Loco chiuso in forma di sepolcreto.  Diverse statue equestri; statua del Commendadore.</stage>
           <stage>Don Giovanni entra per muretto ridendo; indi Leporello.</stage>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>ridendo forte</stage>
             <l>Ah ah ah questa è buona:</l>
@@ -3218,63 +3258,63 @@
             <l>L'affar tra Leporello e Donn'Elvira.</l>
             <l>S'egli ha avuto giudizio...</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <stage>in istrada</stage>
             <l>Alfin vuole ch'io faccia un precipizio!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>È desso; oh Leporello!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <stage>dal muretto</stage>
             <l>Chi mi chiama?</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Non conosci il padron?</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Così nol conoscessi!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>  Come? Birbo!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Ah siete voi? scusate!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Cosa è stato?</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Per cagion vostra io fui quasi accoppato.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Ebben, non era questo</l>
             <l>Un onore per te?</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l> Signor, vel dono!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Via, via, vien qua: che belle</l>
             <l>Cose ti deggio dir!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Ma cosa fate qui?</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Vien dentro, e lo saprai.</l>
             <stage>Leporello entra; si cangiano d'abito.</stage>
@@ -3283,11 +3323,11 @@
             <l>Ti dirò un'altra volta: or la più bella</l>
             <l>Ti vo' solo narrar.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>  Donnesca al certo?</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>C'è dubbio! Una fanciulla,</l>
             <l>Bella, giovin, galante,</l>
@@ -3296,103 +3336,103 @@
             <l>Dico poche parole, ella mi piglia...</l>
             <l>Sai per chi?</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>   Non lo so.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>  Per Leporello!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Per me?</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Per te.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Va bene.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l> Per la mano</l>
             <l>Ella allora mi prende...</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>   Ancora meglio.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>M'accarezza, mi abbraccia...</l>
             <l>«Caro il mio Leporello...</l>
             <l>Leporello mio caro...» Allor m'accorsi</l>
             <l>Ch'era qualche tua bella.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>(Oh maledetto!)</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Dell'inganno approfitto; non so come</l>
             <l>Mi riconosce: grida; sento gente;</l>
             <l>A fuggir mi metto; e pronto pronto,</l>
             <l>Per quel muretto in questo loco io monto.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>E mi dite la cosa</l>
             <l>Con tale indifferenza!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Perché no?</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l> Ma se fosse</l>
             <l>Costei stata mia moglie?</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l> Meglio ancora!</l>
             <stage>ride molto forte</stage>
           </sp>
-          <sp>
+          <sp who="#commendatore">
             <speaker>COMMENDATORE</speaker>
             <l>Di rider finirai pria dell'aurora.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Chi ha parlato?</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <stage>con atti di paura</stage>
             <l>Ah! qualche anima</l>
             <l>Sarà dell'altro mondo!</l>
             <l>Che vi conosce a fondo.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Taci, sciocco!</l>
             <stage>mette mano alla spada, cerca qua e là pel sepolcreto, dando diverse percosse alle statue</stage>
             <l>Chi va là? chi va là?</l>
           </sp>
-          <sp>
+          <sp who="#commendatore">
             <speaker>COMMENDATORE</speaker>
             <l>   Ribaldo, audace,</l>
             <l>Lascia a' morti la pace.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Ve l'ho detto!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>con indifferenza e sprezzo</stage>
             <l>   Sarà qualcun di fuori</l>
@@ -3401,41 +3441,41 @@
             <l>Non è questa la statua? Leggi un poco</l>
             <l>Quella iscrizion.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Scusate...</l>
             <l>Non ho imparato a leggere</l>
             <l>A' raggi della luna...</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>   Leggi dico!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <stage>legge</stage>
             <l>«Dell'empio che mi trasse al passo estremo</l>
             <l>Qui attendo la vendetta». Udiste?... Io tremo!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>O vecchio buffonissimo!</l>
             <l>Digli che questa sera</l>
             <l>L'attendo a cena meco.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Che pazzia! Ma vi par... Oh Dei, mirate</l>
             <l>Che terribili occhiate egli ci dà!</l>
             <l>Par vivo! par che senta,</l>
             <l>E che voglia parlar...</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>   Orsù va' là,</l>
             <l>O qui t'ammazzo e poi ti seppellisco!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <stage>tremando</stage>
             <l>Piano piano, signore, ora obbedisco.</l>
@@ -3445,22 +3485,22 @@
             <l>Padron... mi trema il core;</l>
             <l>Non posso terminar.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Finiscila, o nel petto</l>
             <l>Ti metto quest'acciar.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Che impiccio, che capriccio!</l>
             <l>Io sentomi gelar.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Che gusto, che spassetto!</l>
             <l>Lo voglio far tremar.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>O statua gentilissima</l>
             <l>Benché di marmo siate...</l>
@@ -3468,11 +3508,11 @@
             <l>Ah padron mio, mirate</l>
             <l>Che seguita a guardar.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Mori!...</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>No no, attendete...</l>
             <stage>alla statua</stage>
@@ -3483,44 +3523,44 @@
             <l>Ah, ah, che scena è questa!</l>
             <l>Oh ciel, chinò la testa!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Va' là, che se' un buffone...</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Guardate ancor, padrone!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>E che degg'io guardar?</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Colla marmorea testa</l>
             <stage>imita la statua</stage>
             <l>Ei fa così, così.</l>
             <stage>La statua china qui testa.</stage>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>vedendo il chino</stage>
             <l>Con la marmorea testa Ei fa così, così.</l>
             <stage>alla statua</stage>
             <l>Parlate se potete: Verrete a cena? </l>
           </sp>
-          <sp>
+          <sp who="#commendatore">
             <speaker>COMMENDATORE</speaker>
             <l>   Sì.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Mover mi possa appena...</l>
             <l>Mi manca, oh Dei, la lena!</l>
             <l>Per carità... partiamo,</l>
             <l>Andiamo via di qui.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Bizzarra è inver la scena...</l>
             <l>Verrà il buon vecchio a cena...</l>
@@ -3533,17 +3573,17 @@
           <head>SCENA XII</head>
           <stage>Camera tetra.</stage>
           <stage>Donn'Anna eDon Ottavio.</stage>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <l>Calmatevi, idol mio; di quel ribaldo</l>
             <l>Vedrem puniti in breve i gravi eccessi;</l>
             <l>Vendicati sarem.</l>
           </sp>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <l>Ma il padre, oddio!</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <l>Convien chinare il ciglio</l>
             <l>Ai voleri del ciel; respira, o cara,</l>
@@ -3552,19 +3592,19 @@
             <l>Questo cor, questa mano...</l>
             <l>Che il mio tenero amor...</l>
           </sp>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <l>  Oh Dei, che dite</l>
             <l>In sì tristi momenti...</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <l>E che! vorresti,</l>
             <l>Con indugi novelli,</l>
             <l>Accrescer le mie pene?</l>
             <l>Crudele!</l>
           </sp>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <l>  Ah no, mio ben! Troppo mi spiace</l>
             <l>Allontanarti un ben che lungamente</l>
@@ -3582,7 +3622,7 @@
             <l>Sentirà pietà di me.</l>
             <stage>parte</stage>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <l>Ah, si segua il suo passo: io vo' con lei</l>
             <l>Dividere i martìri;</l>
@@ -3594,7 +3634,7 @@
           <head>SCENA XIII</head>
           <stage>Sala; una mensa preparata per mangiare.</stage>
           <stage>Don Giovanni, Leporello; alcuni suonatori.</stage>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Già la mensa è preparata.</l>
             <l>Voi suonate, amici cari:</l>
@@ -3602,105 +3642,105 @@
             <l>Io mi voglio divertir.</l>
             <l>Leporello, presto in tavola!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Son prontissimo a servir.</l>
             <stage>I servi portano in tavola, mentre Leporello vuol uscire.  I suonatori cominciano a suonare, e Don Giovanni mangia.</stage>
             <l>Bravi! «Cosa rara»! </l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Che ti par del bel concerto?</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>È conforme al vostro merto.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Ah che piatto saporito!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <stage>a parte</stage>
             <l>Ah che barbaro appetito!</l>
             <l>Che bocconi da gigante!</l>
             <l>Mi par proprio di svenir.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>a parte</stage>
             <l>Nel vedere i miei bocconi</l>
             <l>Gli par proprio di svenir.</l>
             <l>Piatto!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l> Servo.</l>
             <l>Evvivano i «Litiganti»!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>   Versa il vino.</l>
             <stage>Leporello versa il vino nel bicchiere</stage>
             <l>Eccellente marzimino!</l>
             <stage>Leporello cangia il piatto a Don Giovanni e mangia in fretta.</stage>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <stage>a parte</stage>
             <l>Questo pezzo di fagiano</l>
             <l>Piano piano vo' inghiottir.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>a parte</stage>
             <l>Sta mangiando, quel marrano;</l>
             <l>Fingerò di non capir.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Questa poi la conosco pur troppo...</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>lo chiama senza guardarlo</stage>
             <l>Leporello!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <stage>risponde con la bocca piena</stage>
             <l>Padron mio...</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Parla schietto, mascalzone!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Non mi lascia una flussione</l>
             <l>Le parole proferir.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Mentre io mangio, fischia un poco.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Non so far!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>s'accorge che sta mangiando</stage>
             <l>   Cos'è? </l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>  Scusate;</l>
             <l>Sì eccellente è il vostro cuoco,</l>
             <l>Che lo volli anch'io provar.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Sì eccellente è il cuoco mio,</l>
             <l>Che lo volle anch'ei provar.</l>
@@ -3709,7 +3749,7 @@
         <div type="scene">
           <head>SCENA XIV</head>
           <stage>I suddetti; Donn'Elvira.</stage>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <stage>entra disperata</stage>
             <l>L'ultima prova</l>
@@ -3720,12 +3760,12 @@
             <l>Gl'inganni tuoi,</l>
             <l>Pietade io sento...</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni #leporello">
             <speaker>DON GIOVANNI, LEPORELLO</speaker>
             <stage>sorgendo</stage>
             <l>Cos'è? cos'è?</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <stage>s'inginocchia</stage>
             <l>Da te non chiede</l>
@@ -3733,7 +3773,7 @@
             <l>Della sua fede</l>
             <l>Qualche mercé.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Mi maraviglio!</l>
             <l>Cosa volete?</l>
@@ -3741,17 +3781,17 @@
             <l>Non resta in piè!</l>
             <stage>s'inginocchia</stage>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>Ah non deridere</l>
             <l>Gli affanni miei!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Quasi da piangere</l>
             <l>Mi fa costei.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>sorgendo fa sorgere Donn'Elvira</stage>
             <l>Io te deridere?</l>
@@ -3759,40 +3799,40 @@
             <l>Cieli! perché?</l>
             <l>Che vuoi, mio bene?</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>Che vita cangi.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Brava!</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>  Cor perfido!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Lascia ch'io mangi;</l>
             <stage>torna a sedere a mangiare</stage>
             <l>E se ti piace,</l>
             <l>Mangia con me.</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>Réstati, barbaro,</l>
             <l>Nel lezzo immondo,</l>
             <l>Esempio orribile</l>
             <l>D'iniquità!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Se non si muove</l>
             <l>Del suo dolore</l>
             <l>Di sasso ha il core,</l>
             <l>O cor non ha!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>bevendo</stage>
             <l>Vivan le femmine,</l>
@@ -3800,31 +3840,31 @@
             <l>Sostegno e gloria</l>
             <l>D'umanità!</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <stage>sorte</stage>
             <l>Ah!</l>
             <stage>rientra e fugge dall'altra parte</stage>
           </sp>
-          <sp>
+          <sp who="#don_giovanni #leporello">
             <speaker>DON GIOVANNI, LEPORELLO</speaker>
             <l>Che grido è questo mai!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Va' a veder che cosa è stato.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <stage>sorte, e prima di tornare, mette un grido</stage>
             <l>Ah!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l> Che grido indiavolato!</l>
             <l>Leporello, che cos'è?</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <stage>entra spaventato e chiude l'uscio</stage>
             <l>Ah signor... per carità!...</l>
@@ -3836,41 +3876,41 @@
             <stage>imitando i passi della statua</stage>
             <l>Ta ta ta ta ta ta ta!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Non capisco niente affatto.</l>
             <l>Tu sei matto in verità.</l>
             <stage>Si sente battere alla porta.</stage>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Ah sentite!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l> Qualcun batte:</l>
             <l>Apri...</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <stage>tremando</stage>
             <l>  Io tremo...</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Apri, ti dico!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Ah...</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>   Per togliermi d'intrico,</l>
             <l>Ad aprir io stesso andrò!</l>
             <stage>piglia lume e va per aprire</stage>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Non vo' più veder l'amico;</l>
             <l>Pian pianin m'asconderò.</l>
@@ -3880,29 +3920,29 @@
         <div type="scene">
           <head>SCENA XV</head>
           <stage>I suddetti; il Commendatore.</stage>
-          <sp>
+          <sp who="#commendatore">
             <speaker>COMMENDATORE</speaker>
             <l>Don Giovanni, a cenar teco</l>
             <l>M'invitasti, e son venuto.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Non l'avrei giammai creduto,</l>
             <l>Ma farò quel che potrò!</l>
             <l>Leporello, un'altra cena</l>
             <l>Fa che subito si porti!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <stage>mezzo fuori col capo dalla mensa</stage>
             <l>Ah padron, siam tutti morti!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Vanne, dico... </l>
             <stage>Leporello, con molti atti di paura, esce e va per partire.</stage>
           </sp>
-          <sp>
+          <sp who="#commendatore">
             <speaker>COMMENDATORE</speaker>
             <l>Ferma un po'.</l>
             <l>Non si pasce di cibo mortale</l>
@@ -3910,143 +3950,143 @@
             <l>Altre cure più gravi di queste,</l>
             <l>Altra brama quaggiù mi guidò!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>La terzana d'avere mi sembra,</l>
             <l>E le membra fermar più non so.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Parla dunque: che chiedi? che vuoi?</l>
           </sp>
-          <sp>
+          <sp who="#commendatore">
             <speaker>COMMENDATORE</speaker>
             <l>Parlo, ascolta, più tempo non ho.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Parla, parla, ascoltando ti sto.</l>
           </sp>
-          <sp>
+          <sp who="#commendatore">
             <speaker>COMMENDATORE</speaker>
             <l>Tu n'invitasti a cena,</l>
             <l>Il tuo dover or sai;</l>
             <l>Rispondimi: verrai</l>
             <l>Tu a cenar meco?</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <stage>da lontano, tremando</stage>
             <l>  Oibò!</l>
             <l>Tempo non ha... scusate.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>A torto di viltate</l>
             <l>Tacciato mai sarò!</l>
           </sp>
-          <sp>
+          <sp who="#commendatore">
             <speaker>COMMENDATORE</speaker>
             <l>Risolvi!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Ho già risolto.</l>
           </sp>
-          <sp>
+          <sp who="#commendatore">
             <speaker>COMMENDATORE</speaker>
             <l>Verrai?</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <stage>a Don Giovanni</stage>
             <l>   Dite di no!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Ho fermo il core in petto:</l>
             <l>Non ho timor, verrò!</l>
           </sp>
-          <sp>
+          <sp who="#commendatore">
             <speaker>COMMENDATORE</speaker>
             <l>Dammi la mano in pegno!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Eccola!</l>
             <stage>grida forte</stage>
             <l>  Oimè!</l>
           </sp>
-          <sp>
+          <sp who="#commendatore">
             <speaker>COMMENDATORE</speaker>
             <l>  Cos'hai?</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Che gelo è questo mai?</l>
           </sp>
-          <sp>
+          <sp who="#commendatore">
             <speaker>COMMENDATORE</speaker>
             <l>Pèntiti, cangia vita:</l>
             <l>È l'ultimo momento!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <stage>vuol sciogliersi, ma invano</stage>
             <l>No no, ch'io non mi pento,</l>
             <l>Vanne lontan da me!</l>
           </sp>
-          <sp>
+          <sp who="#commendatore">
             <speaker>COMMENDATORE</speaker>
             <l>Pèntiti scellerato!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>No, vecchio infatuato!</l>
           </sp>
-          <sp>
+          <sp who="#commendatore">
             <speaker>COMMENDATORE</speaker>
             <l>Pèntiti.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>   No.</l>
           </sp>
-          <sp>
+          <sp who="#commendatore #leporello">
             <speaker>COMMENDATORE, LEPORELLO</speaker>
             <l>Sì.</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>   No.</l>
           </sp>
-          <sp>
+          <sp who="#commendatore">
             <speaker>COMMENDATORE</speaker>
             <l>Ah tempo più non v'è.</l>
             <stage>parte</stage>
             <stage>Foco da diverse parti.</stage>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Da qual tremore insolito...</l>
             <l>Sento assalir gli spiriti...</l>
             <l>Donde escono quei vortici</l>
             <l>Di fuoco pien d'orror!</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <stage>di sotterra, con voci cupe</stage>
             <l>Tutto a tue colpe è poco.</l>
             <l>Vieni: c'è un mal peggior!</l>
           </sp>
-          <sp>
+          <sp who="#don_giovanni">
             <speaker>DON GIOVANNI</speaker>
             <l>Chi l'anima mi lacera!</l>
             <l>Chi m'agita le viscere!</l>
             <l>Che strazio, oimè, che smania!</l>
             <l>Che inferno! che terror!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Che ceffo disperato!</l>
             <l>Che gesti da dannato!</l>
@@ -4054,7 +4094,7 @@
             <l>Come mi fa terror! </l>
             <stage>Il fuoco cresce; Don Giovanni si sprofonda.</stage>
           </sp>
-          <sp>
+          <sp who="#don_giovanni #leporello">
             <speaker>DON GIOVANNI, LEPORELLO</speaker>
             <l>Ah!</l>
           </sp>
@@ -4063,48 +4103,48 @@
         <div type="scene">
           <head>SCENA XVI</head>
           <stage>Leporello, Donn'Anna, Donn'Elvira, Don Ottavio, Zerlina, Masetto con ministri di giustizia.</stage>
-          <sp>
+          <sp who="#anna #elvira #zerlina #ottavio #masetto">
             <speaker>ANNA, ELVIRA, ZERLINA, OTTAVIO, MASETTO</speaker>
             <l>Ah dove è il perfido,</l>
             <l>Dove è l'indegno?</l>
             <l>Tutto il mio sdegno</l>
             <l>Sfogar io vo'.</l>
           </sp>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <l>Solo mirandolo</l>
             <l>Stretto in catene,</l>
             <l>Alle mie pene</l>
             <l>Calma darò.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Più non sperate...</l>
             <l>Di ritrovarlo...</l>
             <l>Più non cercate:</l>
             <l>Lontano andò.</l>
           </sp>
-          <sp>
+          <sp who="#anna #elvira #zerlina #ottavio #masetto">
             <speaker>ANNA, ELVIRA, ZERLINA, OTTAVIO, MASETTO</speaker>
             <l>Cos'è? favella!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Venne un colosso...</l>
           </sp>
-          <sp>
+          <sp who="#anna #elvira #zerlina #ottavio #masetto">
             <speaker>ANNA, ELVIRA, ZERLINA, OTTAVIO, MASETTO</speaker>
             <l>Via, presto, sbrìgati!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Ma, se non posso...</l>
           </sp>
-          <sp>
+          <sp who="#anna #elvira #zerlina #ottavio #masetto">
             <speaker>ANNA, ELVIRA, ZERLINA, OTTAVIO, MASETTO</speaker>
             <l>Presto! favella!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Tra fumo e foco...</l>
             <l>Badate un poco...</l>
@@ -4115,25 +4155,25 @@
             <l>Giusto là il diavolo</l>
             <l>Se 'l trangugiò.</l>
           </sp>
-          <sp>
+          <sp who="#anna #elvira #zerlina #ottavio #masetto">
             <speaker>ANNA, ELVIRA, ZERLINA, OTTAVIO, MASETTO</speaker>
             <l>Stelle! che sento!</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Vero è l'evento!</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>Ah certo è l'ombra</l>
             <l>Che m'incontrò!</l>
           </sp>
-          <sp>
+          <sp who="#anna #elvira #zerlina #ottavio #masetto">
             <speaker>ANNA, ELVIRA, ZERLINA, OTTAVIO, MASETTO</speaker>
             <l>Ah certo, è l'ombra</l>
             <l>Che l'incontrò!</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <stage>a Donn'Anna</stage>
             <l>Or che tutti, o mio tesoro,</l>
@@ -4141,34 +4181,34 @@
             <l>Porgi, porgi a me un ristoro:</l>
             <l>Non mi far languire ancor.</l>
           </sp>
-          <sp>
+          <sp who="#anna">
             <speaker>ANNA</speaker>
             <l>Lascia, o caro, un anno ancora</l>
             <l>Allora sfogo del mio cor.</l>
             <l>Al desio di chi t'adora</l>
             <l>Ceder deve un fido amor.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <l>Al desio di chi m'adora</l>
             <l>Ceder deve un fido amor.</l>
           </sp>
-          <sp>
+          <sp who="#elvira">
             <speaker>ELVIRA</speaker>
             <l>Io men vado in un ritiro</l>
             <l>A finir la vita mia.</l>
           </sp>
-          <sp>
+          <sp who="#zerlina #masetto">
             <speaker>ZERLINA, MASETTO</speaker>
             <l>Noi, Masetto <add resp="#ed">Zerlina</add>, a casa andiamo,</l>
             <l>A cenar in compagnia.</l>
           </sp>
-          <sp>
+          <sp who="#leporello">
             <speaker>LEPORELLO</speaker>
             <l>Ed io vado all'osteria</l>
             <l>A trovar padron miglior.</l>
           </sp>
-          <sp>
+          <sp who="#zerlina #masetto #leporello">
             <speaker>ZERLINA, MASETTO, LEPORELLO</speaker>
             <l>Resti dunque quel birbon</l>
             <l>Con Proserpina e Pluton.</l>

--- a/tei/da-ponte-le-nozze-di-figaro.xml
+++ b/tei/da-ponte-le-nozze-di-figaro.xml
@@ -84,6 +84,49 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="figaro">
+            <persName>Figaro</persName>
+          </person>
+          <person xml:id="susanna">
+            <persName>Susanna</persName>
+          </person>
+          <person xml:id="bartolo">
+            <persName>Bartolo</persName>
+          </person>
+          <person xml:id="marcellina">
+            <persName>Marcellina</persName>
+          </person>
+          <person xml:id="cherubino">
+            <persName>Cherubino</persName>
+          </person>
+          <person xml:id="conte">
+            <persName>Il Conte d'Almaviva</persName>
+          </person>
+          <person xml:id="basilio">
+            <persName>Basilio</persName>
+          </person>
+          <personGrp xml:id="coro">
+            <name>Coro</name>
+          </personGrp>
+          <person xml:id="contessa">
+            <persName>La Contessa D'Almaviva</persName>
+          </person>
+          <person xml:id="antonio">
+            <persName>Antonio</persName>
+          </person>
+          <person xml:id="curzio">
+            <persName>Don Curzio</persName>
+          </person>
+          <person xml:id="barbarina">
+            <persName>Barbarina</persName>
+          </person>
+          <personGrp xml:id="due_donne">
+            <name>Due Donne</name>
+          </personGrp>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -166,13 +209,13 @@
           <head>SCENA I</head>
           <stage>Camera non affatto ammobiliata, un seggiolone in mezzo.</stage>
           <stage>Figaro con una misura in mano e Susanna allo specchio che si sta mettendo un cappellino ornato di fiori. </stage>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>misurando</stage>
             <l>Cinque… dieci… venti… trenta…</l>
             <l>Trentasei… quarantatré…</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>fra se stessa, guardandosi nello specchio</stage>
             <l>Ora sì ch’io son contenta;</l>
@@ -181,73 +224,73 @@
             <l>Guarda un po’, mio caro Figaro,</l>
             <l>Guarda adesso il mio cappello.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Sì mio core, or è più bello,</l>
             <l>Sembra fatto inver per te.</l>
           </sp>
-          <sp>
+          <sp who="#susanna #figaro">
             <speaker>SUSANNA, FIGARO</speaker>
             <l>Ah il mattino alle nozze vicino</l>
             <l>Quanto è dolce al mio <add resp="#ed">tuo</add> tenero sposo</l>
             <l>Questo bel cappellino vezzoso</l>
             <l>Che Susanna ella stessa si fe’.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Cosa stai misurando,</l>
             <l>Caro il mio Figaretto? </l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Io guardo se quel letto</l>
             <l>Che ci destina il Conte</l>
             <l>Farà buona figura in questo loco.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>In questa stanza?…</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Certo: a noi la cede</l>
             <l>Generoso il padrone.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Io per me te la dono.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>E la ragione?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>toccandosi la fronte</stage>
             <l>La ragione l’ho qui.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>facendo lo stesso</stage>
             <l>Perché non puoi</l>
             <l>Far che passi un po’ qui?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Perché non voglio.</l>
             <l>Sei tu mio servo o no?</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l> Ma non capisco</l>
             <l>Perché tanto ti spiace</l>
             <l>La più comoda stanza del palazzo.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Perch’io son la Susanna, e tu sei pazzo.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Grazie; non tanti elogi! guarda un poco</l>
             <l>Se potriasi star meglio in altro loco.</l>
@@ -260,7 +303,7 @@
             <l>Don don; in tre salti</l>
             <l>Lo vado a servir.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Così se il mattino</l>
             <l>Il caro Contino,</l>
@@ -270,40 +313,40 @@
             <l>Il diavol lo porta,</l>
             <l>Ed ecco in tre salti…</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Susanna, pian pian</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Ascolta…</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Fa’ presto…</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Se udir brami il resto,</l>
             <l>Discaccia i sospetti</l>
             <l>Che torto mi fan.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Udir bramo il resto,</l>
             <l>I dubbi, i sospetti</l>
             <l>Gelare mi fan.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Orbene; ascolta e taci!</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>inquieto</stage>
             <l>Parla, che c’è di nuovo?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>  Il signor Conte,</l>
             <l>Stanco di andar cacciando le straniere</l>
@@ -313,76 +356,76 @@
             <l>Né già di sua consorte, bada bene,</l>
             <l>Appetito gli viene…</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>E di chi, dunque?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Della sua Susannetta.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>con sorpresa</stage>
             <l>Dite?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l> Di me medesma; ed ha speranza</l>
             <l>Che al nobil suo progetto</l>
             <l>Utilissima sia tal vicinanza.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Bravo! tiriamo avanti.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Queste le grazie son, questa la cura</l>
             <l>Ch’egli prende di te, della tua sposa.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Oh guarda un po’ che carità pelosa!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Chétati: or viene il meglio: Don Basilio,</l>
             <l>Mio maestro di canto, e suo mezzano,</l>
             <l>Nel darmi la lezione</l>
             <l>Mi ripete ogni dì questa canzone.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Chi Basilio? oh, birbante!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>E tu credevi</l>
             <l>Che fosse la mia dote</l>
             <l>Merto del tuo bel muso!</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Me n'era lusingato.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l> Ei la destina</l>
             <l>Per ottener da me certe mezz’ore…</l>
             <l>Che il diritto feudale…</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Come? ne’ feudi suoi</l>
             <l>Non l’ha il Conte abolito?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Ebben, ora è pentito, e par che tenti</l>
             <l>Riscattarlo da me.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Bravo! mi piace:</l>
             <l>Che caro signor Conte!</l>
@@ -390,15 +433,15 @@
             <stage>si sente suonare un campanello</stage>
             <l>Chi suona? la Contessa.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Addio, addio, addio, Figaro bello.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Coraggio, mio tesoro.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l> E tu, cervello.</l>
           </sp>
@@ -407,7 +450,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>Figaro solo.</stage>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>passeggiando con foco per la camera e fregandosi le mani</stage>
             <l>Bravo, signor padrone!… Ora incomincio</l>
@@ -440,13 +483,13 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>Bartolo e Marcellina con un contratto in mano.</stage>
-          <sp>
+          <sp who="#bartolo">
             <speaker>BARTOLO</speaker>
             <l>Ed aspettaste il giorno</l>
             <l>Fissato a le sue nozze</l>
             <l>Per parlarmi di questo?</l>
           </sp>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <l>  Io non mi perdo</l>
             <l>Dottor mio di coraggio:</l>
@@ -461,7 +504,7 @@
             <l>Prenderà il mio partito,</l>
             <l>E Figaro così fia mio marito.</l>
           </sp>
-          <sp>
+          <sp who="#bartolo">
             <speaker>BARTOLO</speaker>
             <stage>prende il contratto dalle mani di Marcellina</stage>
             <l>Bene, io tutto farò: senza riserve</l>
@@ -495,7 +538,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>Marcellina, poi Susanna con una cuffia da donna, un nastro e un abito da donna.</stage>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <l>Tutto ancor non ho perso:</l>
             <l>Mi resta la speranza:</l>
@@ -506,110 +549,110 @@
             <l>E quella buona perla</l>
             <l>La vorrebbe sposar!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>da sé, resta indietro</stage>
             <stage>Di me favella.</stage>
           </sp>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <l>Ma da Figaro alfine</l>
             <l>Non può meglio sperarsi: <foreign xml:lang="fre">argent fait tout</foreign>.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>da sé</stage>
             <l>(Che lingua! Manco male</l>
             <l>Ch’ognun sa quanto vale.)</l>
           </sp>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <l>Brava! questo è giudizio!</l>
             <l>Con quegli occhi modesti,</l>
             <l>Con quell’aria pietosa,</l>
             <l>E poi…</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>da sé</stage>
             <l>(Meglio è partir.)</l>
           </sp>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <l> (Che cara sposa!)</l>
             <stage>vanno tutte due per partire, e s’incontrano alla porta</stage>
           </sp>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <stage>facendo una riverenza</stage>
             <l>Via resti servita,</l>
             <l>Madama brillante.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>facendo una riverenza</stage>
             <l>Non sono sì ardita,</l>
             <l>Madama piccante.</l>
           </sp>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <stage>riverenza</stage>
             <l>No, prima a lei tocca.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>riverenza</stage>
             <l>No, no, tocca a lei.</l>
           </sp>
-          <sp>
+          <sp who="#susanna #marcellina">
             <speaker>SUSANNA, MARCELLINA </speaker>
             <stage>riverenza</stage>
             <l>Io so i dover miei,</l>
             <l>Non fo inciviltà.</l>
           </sp>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <stage>riverenza</stage>
             <l>La sposa novella!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>riverenza</stage>
             <l>La dama d’onore!</l>
           </sp>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <stage>riverenza</stage>
             <l>Del Conte la bella!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>riverenza</stage>
             <l>Di Spagna l’amore!</l>
           </sp>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <l>I meriti!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>L’abito!</l>
           </sp>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <l>Il posto!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>  L’età!</l>
           </sp>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <stage>infuriata</stage>
             <l>Per Bacco precipito,</l>
             <l>Se ancor resta qua!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>minchiandola</stage>
             <l>Sibilla decrepita,</l>
@@ -620,7 +663,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>Susanna e poi Cherubino.</stage>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Va’ là, vecchia pedante,</l>
             <l>Dottoressa arrogante,</l>
@@ -628,24 +671,24 @@
             <l>E seccata Madama in gioventù…</l>
             <stage>mette il vestito sopra il seggiolone</stage>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <stage>esce in fretta</stage>
             <l>Susannetta sei tu?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Son io; cosa volete?</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l>Ah cor mio, che accidente!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Cor vostro! Cosa avvenne?</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l>Il Conte ieri</l>
             <l>Perché trovommi sol con Barbarina,</l>
@@ -656,13 +699,13 @@
             <stage>con ansietà</stage>
             <l>Io non ti vedo più, Susanna mia!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Non vedete più me! Bravo! Ma dunque</l>
             <l>Non più per la Contessa</l>
             <l>Secretamente il vostro cor sospira?</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l>Ah che troppo rispetto ella m’ispira!</l>
             <l>Felice te, che puoi</l>
@@ -674,45 +717,45 @@
             <l> Ah, se in tuo loco…</l>
             <l>Cos’hai lì? — dimmi un poco…</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Ah il vago nastro, e la notturna cuffia</l>
             <l>Di comare sì bella.</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l>Deh dammelo sorella,</l>
             <l>Dammelo, per pietà!</l>
             <stage>toglie il nastro di mano a Susanna</stage>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Presto quel nastro!</l>
             <stage>vuol riprenderlo</stage>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <stage>egli si mette a girare intorno al seggiolone</stage>
             <l>Oh caro, oh bello, o fortunato nastro!</l>
             <stage>bacia e ribacia il nastro</stage>
             <l>Io non te ’l renderò che con la vita!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>séguita a corrergli dietro, ma poi si arresta come se fosse stanca</stage>
             <l>Cos’è quest’insolenza?</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l> Eh via, sta cheta!</l>
             <l>In ricompensa poi</l>
             <l>Questa mia canzonetta io ti vo’ dare.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>E che ne debbo fare?</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l>Leggila alla padrona:</l>
             <l>Leggila tu medesma;</l>
@@ -720,11 +763,11 @@
             <stage>con trasporti di gioia</stage>
             <l>Leggila ad ogni donna del palazzo!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Povero Cherubin, siete voi pazzo?</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l>Non so più cosa son, cosa faccio,</l>
             <l>Or di fuoco, ora sono di ghiaccio,</l>
@@ -749,51 +792,51 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>Cherubino, Susanna e poi il Conte.</stage>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l>(Ah, son perduto!)</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>cerca mascherar Cherubino</stage>
             <l>Che timor! — Il Conte!</l>
             <l>Misera me!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Susanna, tu mi sembri</l>
             <l>Agitata e confusa.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Signor… io chiedo scusa…</l>
             <l>Ma… se mai… qui sorpresa…</l>
             <l>Per carità! partite.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Un momento, e ti lascio,</l>
             <stage>si mette a sedere sul seggiolone, prende Susanna per la mano</stage>
             <l>Odi.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>si distacca con forza</stage>
             <l>  Non odo nulla.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Due parole. Tu sai</l>
             <l>Che ambasciatore a Londra</l>
             <l>Il re mi dichiarò; di condur meco</l>
             <l>Figaro destinai.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>timida</stage>
             <l>Signor, se osassi…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>sorge</stage>
             <l>Parla, parla mia cara,</l>
@@ -802,13 +845,13 @@
             <l>Ch’oggi prendi su me finché tu vivi</l>
             <l>Chiedi, imponi, prescrivi.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>con smania</stage>
             <l>Lasciatemi signor; dritti non prendo,</l>
             <l>Non ne vo’, non ne intendo… oh, me infelice!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Ah no Susanna, io ti vo’ far felice!</l>
             <stage>come sopra</stage>
@@ -818,47 +861,47 @@
             <l>Meco in giardin, sull’imbrunir del giorno…</l>
             <l>Ah per questo favore io pagherei…</l>
           </sp>
-          <sp>
+          <sp who="#basilio">
             <speaker>BASILIO</speaker>
             <stage>dentro la scena</stage>
             <l>È uscito poco fa.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l> Chi parla?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Oh Dei!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Esci, e alcun non entri.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>inquietissima</stage>
             <l>Ch’io vi lasci qui solo?</l>
           </sp>
-          <sp>
+          <sp who="#basilio">
             <speaker>BASILIO</speaker>
             <stage>dentro</stage>
             <l>Da Madama ei sarà, vado a cercarlo.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>addita il seggiolone</stage>
             <l>Qui dietro mi porrò.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Non vi celate.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Taci, e cerca ch’ei parta.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Oimè! che fate?</l>
           </sp>
@@ -867,22 +910,22 @@
         <div type="scene">
           <head>SCENA VII</head>
           <stage>Detti e Basilio.</stage>
-          <sp>
+          <sp who="#basilio">
             <speaker>BASILIO</speaker>
             <l>Susanna, il ciel vi salvi: avreste a caso</l>
             <l>Veduto il Conte?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l> E cosa</l>
             <l>Deve far meco il Conte? — animo uscite.</l>
           </sp>
-          <sp>
+          <sp who="#basilio">
             <speaker>BASILIO</speaker>
             <l>Aspettate, sentite,</l>
             <l>Figaro di lui cerca.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>da sé</stage>
             <l>Oh cieli!</l>
@@ -890,18 +933,18 @@
             <l>Ei cerca</l>
             <l>Chi dopo voi più l’odia.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>da sé</stage>
             <l>(Veggiam come mi serve.)</l>
           </sp>
-          <sp>
+          <sp who="#basilio">
             <speaker>BASILIO</speaker>
             <l>Io non ho mai nella moral sentito</l>
             <l>Ch’uno ch’ama la moglie odi il marito.</l>
             <l>Per dir che il Conte v’ama…</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Sortite, vil ministro</l>
             <l>Dell’altrui sfrenatezza:</l>
@@ -910,7 +953,7 @@
             <l>Della vostra morale,</l>
             <l>Del Conte, del suo amor…</l>
           </sp>
-          <sp>
+          <sp who="#basilio">
             <speaker>BASILIO</speaker>
             <l>Non c’è alcun male.</l>
             <l>Ha ciascun i suoi gusti: io mi credea</l>
@@ -919,25 +962,25 @@
             <l>Un signor liberal, prudente, e saggio,</l>
             <l>A un giovinastro, a un paggio…</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>con ansietà</stage>
             <l>A Cherubino!</l>
           </sp>
-          <sp>
+          <sp who="#basilio">
             <speaker>BASILIO</speaker>
             <l>A Cherubino! a Cherubin d’amore,</l>
             <l>Ch’oggi sul far del giorno,</l>
             <l>Passeggiava qui intorno</l>
             <l>Per entrar…</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>con forza</stage>
             <l>Uom maligno,</l>
             <l>Un’impostura è questa.</l>
           </sp>
-          <sp>
+          <sp who="#basilio">
             <speaker>BASILIO</speaker>
             <l>È un maligno con voi chi ha gli occhi in testa.</l>
             <l>E quella canzonetta?</l>
@@ -945,12 +988,12 @@
             <l>E ad altrui nulla dico:</l>
             <l>È per voi, per Madama?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>mostra dello smarrimento</stage>
             <l>Chi diavol gliel’ha detto?</l>
           </sp>
-          <sp>
+          <sp who="#basilio">
             <speaker>BASILIO</speaker>
             <l>A proposito, figlia,</l>
             <l>Istruitelo meglio: egli la guarda</l>
@@ -959,60 +1002,60 @@
             <l>Che se il Conte s’accorge… ehi, sul tal punto,</l>
             <l>Sapete, egli è una bestia.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>  Scellerato!</l>
             <l>E perché andate voi</l>
             <l>Tai menzogne spargendo?</l>
           </sp>
-          <sp>
+          <sp who="#basilio">
             <speaker>BASILIO</speaker>
             <l>Io! che ingiustizia! Quel che compro io vendo.</l>
             <l>A quel che tutti dicono</l>
             <l>Io non aggiungo un pelo.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>sortendo</stage>
             <l>Come! Che dicon tutti?</l>
           </sp>
-          <sp>
+          <sp who="#basilio">
             <speaker>BASILIO</speaker>
             <l>  Oh bella!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Oh cielo!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>a Basilio</stage>
             <l>Cosa sento! tosto andate,</l>
             <l>E scacciate il seduttor.</l>
           </sp>
-          <sp>
+          <sp who="#basilio">
             <speaker>BASILIO</speaker>
             <l>In mal punto son qui giunto,</l>
             <l>Perdonate, oh mio signor.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Che ruina, me meschina,</l>
             <stage>quasi svenuta</stage>
             <l>Son oppressa dal dolor.</l>
           </sp>
-          <sp>
+          <sp who="#conte #basilio">
             <speaker>CONTE, BASILIO </speaker>
             <stage>sostenendola</stage>
             <l>Ah, già svien la poverina!</l>
             <l>Come oddio! le batte il cor!</l>
           </sp>
-          <sp>
+          <sp who="#basilio">
             <speaker>BASILIO</speaker>
             <stage>approssimandosi al sedile in atto di farla sedere</stage>
             <l>Pian pianin su questo seggio.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Dove sono?</l>
             <stage>rinviene</stage>
@@ -1020,12 +1063,12 @@
             <stage>staccandosi da tutti due</stage>
             <l>Che insolenza, andate fuor.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Siamo qui per aiutarti,</l>
             <l>Non turbarti, oh mio tesor.</l>
           </sp>
-          <sp>
+          <sp who="#basilio">
             <speaker>BASILIO</speaker>
             <stage>con malignità</stage>
             <l>Siamo qui per aiutarvi:</l>
@@ -1034,34 +1077,34 @@
             <l>Ah del paggio quel ch’ho detto</l>
             <l>Era solo un mio sospetto!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>È un’insidia, una perfidia,</l>
             <l>Non credete all’impostor.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Parta parta il damerino!</l>
           </sp>
-          <sp>
+          <sp who="#basilio #susanna">
             <speaker>BASILIO, SUSANNA</speaker>
             <l>Poverino!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>ironicamente</stage>
             <l>Poverino!</l>
             <l>Ma da me sorpreso ancor.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Come!</l>
           </sp>
-          <sp>
+          <sp who="#basilio">
             <speaker>BASILIO</speaker>
             <l>Che!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Da tua cugina</l>
             <l>L’uscio ier trovai rinchiuso;</l>
@@ -1076,44 +1119,44 @@
             <stage>con sorpresa</stage>
             <l>Ah! cosa veggio!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>con timore</stage>
             <l>Ah! crude stelle!</l>
           </sp>
-          <sp>
+          <sp who="#basilio">
             <speaker>BASILIO</speaker>
             <stage>con riso</stage>
             <l>Ah! meglio ancora!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Onestissima signora!</l>
             <l>Or capisco come va!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Accader non può di peggio:</l>
             <l>Giusti Dei! che mai sarà!</l>
           </sp>
-          <sp>
+          <sp who="#basilio">
             <speaker>BASILIO</speaker>
             <l>Così fan tutte le belle;</l>
             <l>Non c’è alcuna novità!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Basilio, in traccia tosto</l>
             <l>Di Figaro, volate:</l>
             <l>Io vo’ ch’ei veda…</l>
             <stage>addita Cherubino che non si muove di loco</stage>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>con vivezza</stage>
             <l>Ed io che senta: andate.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>a Basilio</stage>
             <l>Restate:</l>
@@ -1121,15 +1164,15 @@
             <l>Che baldanza! e quale scusa,</l>
             <l>Se la colpa è evidente?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Non ha d’uopo di scusa un’innocente.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Ma costui quando venne?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Egli era meco</l>
             <l>Quando voi qui giungeste, e mi chiedea</l>
@@ -1138,42 +1181,42 @@
             <l>In scompiglio lo pose,</l>
             <l>Ed allor in quel loco si nascose.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Ma s’io stesso m’assisi</l>
             <l>Quando in camera entrai!</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <stage>timidamente</stage>
             <l>Ed allora di dietro io mi celai.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>E quando io là mi posi?</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l>Allor io pian mi volsi, e qui m’ascosi.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Oh ciel! dunque ha sentito</l>
             <l>Quello ch’io ti dicea?</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l>Feci per non sentir quanto potea.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Oh perfidia!</l>
           </sp>
-          <sp>
+          <sp who="#basilio">
             <speaker>BASILIO</speaker>
             <l> Frenatevi: vien gente.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>a Cherubino</stage>
             <l>E voi restate qui, picciol serpente!</l>
@@ -1199,34 +1242,34 @@
             <l>D’un più bel fiore</l>
             <l>L’almo candor.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>a Figaro con sorpresa</stage>
             <l>Cos’è questa commedia?</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>piano a Susanna</stage>
             <l>(Eccoci in danza:</l>
             <l>Secondami cor mio.)</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>da sé</stage>
             <l>(Non ci ho speranza.)</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Signor non isdegnate</l>
             <l>Questo del nostro affetto</l>
             <l>Meritato tributo: or che aboliste</l>
             <l>Un dritto sì ingrato a chi ben ama…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Quel dritto or non v’è più; cosa si brama?</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Dalla vostra saggezza il primo frutto</l>
             <l>Oggi noi coglierem: le nostre nozze</l>
@@ -1235,7 +1278,7 @@
             <l>Illibata serbò, coprir di questa,</l>
             <l>Simbolo d’onestà, candida vesta.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>da sé</stage>
             <l>(Diabolica astuzia!</l>
@@ -1252,16 +1295,16 @@
             <speaker>TUTTI</speaker>
             <l>Evviva, evviva, evviva!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>malignamente</stage>
             <l>Che virtù!</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>  Che giustizia!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>a Figaro e Susanna</stage>
             <l>A voi prometto</l>
@@ -1275,62 +1318,62 @@
             <l>Andate, amici.</l>
             <stage>I contadini ripetono il Coro, spargendo il resto dei fiori, e partono.</stage>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Evviva!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Evviva!</l>
           </sp>
-          <sp>
+          <sp who="#basilio">
             <speaker>BASILIO</speaker>
             <l> Evviva!</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>a Cherubino</stage>
             <l>E voi non applaudite?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>È afflitto poveretto!</l>
             <l>Perché il padron lo scaccia dal castello!</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Ah in un giorno sì bello!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>In un giorno di nozze!</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Quando ognuno v’ammira!</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <stage>s’inginocchia</stage>
             <l>Perdono mio signor…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l> Nol meritate.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Egli è ancora fanciullo!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Men di quel che tu credi.</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l>È ver, mancai; ma dal mio labbro alfine…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>lo alza</stage>
             <l>Ben ben; io vi perdono.</l>
@@ -1339,20 +1382,20 @@
             <l>Io scelgo voi; partite tosto: addio.</l>
             <stage>Il Conte vuol partire, Susanna e Figaro l’arrestano.</stage>
           </sp>
-          <sp>
+          <sp who="#susanna #figaro">
             <speaker>SUSANNA, FIGARO </speaker>
             <l>Ah fin domani sol…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>  No, parta tosto.</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <stage>con passione e sospirando</stage>
             <l>A ubbidirvi signor son già disposto.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Via, per l’ultima volta</l>
             <l>La Susanna abbracciate.</l>
@@ -1360,7 +1403,7 @@
             <l>(Inaspettato è il colpo.)</l>
             <stage>Cherubino abbraccia la Susanna, che rimane confusa.</stage>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l> Ehi capitano</l>
             <l>A me pure la mano.</l>
@@ -1405,7 +1448,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>La Contessa sola; poi Susanna, e poi Figaro.</stage>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Porgi amor qualche ristoro</l>
             <l>Al mio duolo, a’ miei sospir.</l>
@@ -1414,32 +1457,32 @@
             <l>Vieni, cara Susanna:</l>
             <l>Finiscimi l’istoria.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>entra</stage>
             <l>È già finita.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Dunque volle sedurti?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>  Oh il signor Conte</l>
             <l>Non fa tai complimenti</l>
             <l>Colle donne mie pari;</l>
             <l>Egli venne a contratto di danari.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Ah il crudel più non m’ama!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>  E come poi</l>
             <l>È geloso di voi?</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Come lo sono</l>
             <l>I moderni mariti: per sistema</l>
@@ -1447,18 +1490,18 @@
             <l>E per orgoglio poi tutti gelosi.</l>
             <l>Ma se Figaro t’ama… ei sol potria…</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>cantando entro la scena</stage>
             <l>La, la la la, la la la, la la la,</l>
             <l>La, la la la, la la la, la, la, la.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Eccolo: vieni, amico.</l>
             <l>Madama impaziente…</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>con ilare disinvoltura</stage>
             <l>A voi non tocca</l>
@@ -1470,24 +1513,24 @@
             <l>Il diritto feudale.</l>
             <l>Possibile è la cosa, e naturale.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Possibil!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l> Natural!</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>  Naturalissima.</l>
             <l>E se Susanna vuol possibilissima.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Finiscila una volta.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>  Ho già finito.</l>
             <l>Quindi prese il partito</l>
@@ -1498,12 +1541,12 @@
             <l>Minaccia di protegger Marcellina.</l>
             <l>Questo è tutto l’affare.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Ed hai coraggio di trattar scherzando</l>
             <l>Un negozio sì serio?</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Non vi basta</l>
             <l>Che scherzando io ci pensi? Ecco il progetto:</l>
@@ -1514,12 +1557,12 @@
             <l>Che per l’ora del ballo</l>
             <l>A un amante voi deste…</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>  O ciel! che sento!</l>
             <l>Ad un uom sì geloso!…</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Ancora meglio:</l>
             <l>Così potrem più presto imbarazzarlo,</l>
@@ -1536,12 +1579,12 @@
             <l>E in faccia a lei</l>
             <l>Non fia, ch’osi d’opporsi ai voti miei.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>È ver, ma in di lui vece</l>
             <l>S’opporrà Marcellina.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>a Susanna</stage>
             <l>Aspetta: al Conte</l>
@@ -1555,24 +1598,24 @@
             <l>Onde Monsù, sorpreso da Madama,</l>
             <l>Sia costretto a far poi quel che si brama.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>a Susanna</stage>
             <l>Che ti par?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Non c’è mal.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>  Nel nostro caso…</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Quand’egli è persuaso… e dove è il tempo?</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Ito è il conte alla caccia; e per qualch’ora</l>
             <l>Non sarà di ritorno.</l>
@@ -1581,11 +1624,11 @@
             <l>Cherubino vi mando; lascio a voi</l>
             <l>La cura di vestirlo.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>E poi?</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l> E poi…</l>
             <l>Se vuol ballare,</l>
@@ -1598,7 +1641,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>La Contessa, Susanna, poi Cherubino.</stage>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Quanto duolmi, Susanna,</l>
             <l>Che questo giovinotto abbia del Conte</l>
@@ -1607,30 +1650,30 @@
             <l>Da me stessa ei non venne?…</l>
             <l>Dov’è la canzonetta?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Eccola: appunto</l>
             <l>Facciam che ce la canti.</l>
             <l>Zitto, vien gente: è desso. Avanti avanti:</l>
             <l>Signor uffiziale.</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l> Ah, non chiamarmi</l>
             <l>Con nome sì fatale! ei mi rammenta</l>
             <l>Che abbandonar degg’io</l>
             <l>Comare tanto buona…</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>  E tanto bella!</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <stage>sospirando</stage>
             <l>Ah sì… certo…</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>imitandolo</stage>
             <l>Ah sì… certo… Ipocritone!</l>
@@ -1638,32 +1681,32 @@
             <l>Che stamane a me deste</l>
             <l>A Madama cantante.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>aprendola</stage>
             <l>Chi n’è l’autor?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>additando Cherubino</stage>
             <l> Guardate: ha due braccia</l>
             <l>Di rossor sulla faccia.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Prendi la mia chitarra, e l’accompagna.</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l>Io sono sì tremante…</l>
             <l>Ma se Madama vuole…</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Lo vuole, sì lo vuol. Manco parole.</l>
             <stage>La Susanna fa il ritornello sul chitarrino.</stage>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l>Voi che sapete</l>
             <l>Che cosa è amor</l>
@@ -1698,23 +1741,23 @@
             <l>Donne vedete</l>
             <l>S’io l’ho nel cor.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Bravo! che bella voce! Io non sapea</l>
             <l>Che cantaste sì bene.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Oh in verità</l>
             <l>Egli fa tutto ben quello ch’ei fa.</l>
             <l>Presto a noi bel soldato:</l>
             <l>Figaro v’informò…</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l>Tutto mi disse.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Lasciatemi veder.</l>
             <stage>si misura con Cherubino</stage>
@@ -1722,20 +1765,20 @@
             <l>Siam d’uguale statura… giù quel manto,</l>
             <stage>gli cava il manto</stage>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>a Susanna</stage>
             <l>Che fai?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l> Niente paura.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>E se qualcuno entrasse?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Entri: che mal facciamo?</l>
             <l>La porta chiuderò.</l>
@@ -1743,7 +1786,7 @@
             <l>Ma come poi</l>
             <l>Acconciargli i capelli?</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Una mia cuffia</l>
             <l>Prendi nel gabinetto</l>
@@ -1751,44 +1794,44 @@
             <stage>Susanna va nel gabinetto a pigliar una cuffia;Cherubino si accosta alla Contessa, e gli lascia veder la patente che terrà in petto; la Contessa la prende, la apre, e vede che manca il sigillo.</stage>
             <l>Che carta è quella?</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l>  La patente.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Che sollecita gente!</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l>L’ebbi or da Basilio.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>gliela rende</stage>
             <l>Dalla fretta obliato hanno il sigillo.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>sorte</stage>
             <l>Il sigillo di che?</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Della patente.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Cospetto! che premura!</l>
             <l>Ecco la cuffia.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>a Susanna</stage>
             <l>Spìcciati: va bene.</l>
             <l>Miserabili noi, se il Conte viene.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Venite inginocchiatevi:</l>
             <stage>prende Cherubino e lo fa inginocchiare davanti, poco discosto dalla Contessa che siede</stage>
@@ -1815,11 +1858,11 @@
             <l>Se l’amano le femmine,</l>
             <l>Han certo il lor perché.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Quante buffonerie!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>  Ma se ne sono</l>
             <l>Io medesma gelosa!</l>
@@ -1827,35 +1870,35 @@
             <l>  Ehi serpentello,</l>
             <l>Volete tralasciar d’esser sì bello?</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Finiam le ragazzate: or quelle maniche</l>
             <l>Oltre il gomito gli alza,</l>
             <l>Onde più agiatamente</l>
             <l>L’abito gli si adatti.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>eseguisce</stage>
             <l>Ecco.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l> Più indietro.</l>
             <l>Così:</l>
             <stage>scoprendo un nastro, onde ha fasciato il braccio</stage>
             <l>  Che nastro è quello?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>È quel ch’esso involommi.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>stacca il nastro</stage>
             <l>E questo sangue?</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <stage>turbato</stage>
             <l>Quel sangue… io non so come…</l>
@@ -1863,12 +1906,12 @@
             <l>In un sasso… la pelle io mi graffiai…</l>
             <l>E la piaga col nastro io mi fasciai.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Mostrate: non c’è mal. Cospetto! ha il braccio</l>
             <l>Più candido del mio! qualche ragazza…</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>E segui a far la pazza?</l>
             <l>Va’ nel mio gabinetto, e prendi un poco</l>
@@ -1880,106 +1923,106 @@
             <l>Inver… per il colore</l>
             <l>Mi spiacea di privarmene…</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>entra e le da il taffetà e le forbici</stage>
             <l> Tenete:</l>
             <l>E da legargli il braccio?</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l> Un altro nastro</l>
             <l>Prendi insiem col mio vestito.</l>
             <stage>Susanna parte per la porta ch’è in fondo e porta seco il mantello di Cherubino.</stage>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l>Ah più presto m’avria quello guarito!</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Perché? — questo è migliore!</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l>Allor che un nastro…</l>
             <l>Legò la chioma… ovver toccò la pelle…</l>
             <l>D’oggetto…</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>interrompendolo</stage>
             <l>Forastiero,</l>
             <l>È buon per le ferite! non è vero?</l>
             <l>Guardate qualità ch’io non sapea!</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l>Madama scherza; ed io frattanto parto.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Poverin! che sventura!</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l>Oh me infelice!</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>con affanno e commozione</stage>
             <l>Or piange…</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l>  O ciel! perché morir non lice!</l>
             <l>Forse vicino all’ultimo momento…</l>
             <l>Questa bocca oseria!</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>gli asciuga gli occhi col fazzoletto</stage>
             <l>Siate saggio: cos’è questa follia?</l>
             <stage>Si sente picchiare alla porta.</stage>
             <l>Chi picchia alla mia porta?</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>fuori dalla porta</stage>
             <l>Perché chiusa?</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Il mio sposo, o Dei! son morta!</l>
             <l>Voi qui senza mantello!</l>
             <l>In quello stato! un ricevuto foglio…</l>
             <l>La sua gran gelosia!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>con più forza</stage>
             <l>Cosa indugiate?</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>confusa</stage>
             <l>Son sola… anzi… son sola…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>  E a chi parlate?</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>A voi… certo… a voi stesso…</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l>Dopo quel ch’è successo, il suo furore…</l>
             <l>Non trovo altro consiglio!</l>
             <stage>entra nel gabinetto, e chiude</stage>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Ah mi difenda il cielo in tal periglio!</l>
           </sp>
@@ -1988,199 +2031,199 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>La Contessa e il Conte vestito da cacciatore.</stage>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>entrando</stage>
             <l>Che novità! non fu mai vostra usanza</l>
             <l>Di rinchiudervi in stanza!</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>È ver; ma io…</l>
             <l>Io stava qui mettendo…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l> Via, mettendo…</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Certe robe… era meco la Susanna…</l>
             <l>Che in sua camera è andata.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Ad ogni modo</l>
             <l>Voi non siete tranquilla.</l>
             <l>Guardate questo foglio.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>da sé</stage>
             <l> Numi! è il foglio</l>
             <l>Che Figaro gli scrisse…</l>
             <stage>Cherubino fa cadere un tavolino, ed una sedia in gabinetto, con molto strepito.</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Cos’è codesto strepito?</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>Strepito?…</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>In gabinetto</l>
             <l>Qualcosa è caduta</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Io non intesi niente.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Convien che abbiate gran pensieri in mente.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Di che?</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Là v’è qualcuno.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Chi volete che sia?</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>  Lo chiedo a voi.</l>
             <l>Io vengo in questo punto.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Ah sì, Susanna… appunto…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Che passò mi diceste alla sua stanza!</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Alla sua stanza, o qui — non vidi bene…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Susanna! — e donde viene</l>
             <l>Che siete sì turbata?</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>con un risolino forzato</stage>
             <l>Per la mia cameriera?</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l> Io non so nulla:</l>
             <l>Ma turbata senz’altro.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>  Ah questa serva</l>
             <l>Più che non turba me, turba voi stesso.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>È vero, è vero: e lo vedrete adesso.</l>
             <stage>La Susanna entra per la porta ond’è uscita, e si ferma vedendo il Conte, che dalla porta del gabinetto sta favellando.</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Susanna or via sortite,</l>
             <l>Sortite io così vo’.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>al Conte affannata</stage>
             <l>Fermatevi… sentite…</l>
             <l>Sortire ella non può.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Cos’è codesta lite!</l>
             <l>Il paggio dove andò!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>E chi vietarlo or osa?</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Lo vieta l’onestà.</l>
             <l>Un abito da sposa</l>
             <l>Provando ella si sta.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Chiarissima è la cosa:</l>
             <l>L’amante qui sarà!</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Bruttissima è la cosa:</l>
             <l>Chi sa cosa sarà.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Capisco qualche cosa:</l>
             <l>Veggiamo come va.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Dunque parlate almeno,</l>
             <l>Susanna se qui siete…</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Nemmen nemmen nemmeno,</l>
             <l>Io v’ordino tacete.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>si nasconde entro l’alcova</stage>
             <l>Oh cielo un precipizio,</l>
             <l>Un scandalo, un disordine</l>
             <l>Qui certo nascerà.</l>
           </sp>
-          <sp>
+          <sp who="#conte #contessa">
             <speaker>CONTE, CONTESSA </speaker>
             <l>Consorte mia <add resp="#ed">mio</add> giudizio,</l>
             <l>Uno scandalo, un disordine</l>
             <l>Schiviam, per carità.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Dunque, voi non aprite?</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l> E perché deggio</l>
             <l>Le mie camere aprir?</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Ebben, lasciate,</l>
             <l>L’aprirem senza chiavi: ehi gente…</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>  Come?</l>
             <l>Porreste a repentaglio</l>
             <l>D’una dama l’onore?</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>È vero, io sbaglio:</l>
             <l>Posso senza rumore,</l>
@@ -2191,24 +2234,24 @@
             <l>Io prima chiuderò.</l>
             <stage>chiude a chiave la porta che conduce alle stanze delle cameriere</stage>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>a parte</stage>
             <stage>Che imprudenza!</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Voi la condiscendenza</l>
             <l>Di venir meco avrete.</l>
             <stage>con affettata ilarità</stage>
             <l>Madama, eccovi il braccio, andiamo.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>con ribrezzo</stage>
             <l>Andiamo.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>accenna il gabinetto</stage>
             <l>Susanna starà qui finché torniamo.</l>
@@ -2218,7 +2261,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>Susanna e Cherubino.</stage>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>uscendo dall’alcova in fretta</stage>
             <l>Aprite, presto, aprite;</l>
@@ -2227,32 +2270,32 @@
             <l>Sortite, via, sortite,</l>
             <l>Andate via di qua.</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <stage>confuso e senza fiato</stage>
             <l>Oimè che scena orribile!</l>
             <l>Che gran fatalità!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Partite, non tardate</l>
             <l>Di qua, di qua, di là.</l>
           </sp>
-          <sp>
+          <sp who="#susanna #cherubino">
             <speaker>SUSANNA, CHERUBINO </speaker>
             <stage>accostandosi ad una, or ad un’altra porta</stage>
             <l>Le porte son serrate.</l>
             <l>Che mai, che mai sarà!</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l>Qui perdersi non giova.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>V’uccide, se vi trova.</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l>M’uccide, se mi trova.</l>
             <stage>affacciandosi alla finestra</stage>
@@ -2260,25 +2303,25 @@
             <stage>facendo moto di saltar giù</stage>
             <l>Da proprio nel giardino.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>trattenendolo</stage>
             <l>Fermate, Cherubino!</l>
             <l>Fermate, per pietà!</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <stage>tornando a guardare</stage>
             <l>Un vaso o due di fiori,</l>
             <l>Più mal non avverrà.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>trattenendolo sempre</stage>
             <l>Tropp’alto per un salto.</l>
             <l>Fermate per pietà!</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <stage>si scioglie</stage>
             <l>Lasciami: pria di nuocerle,</l>
@@ -2288,7 +2331,7 @@
             <stage>salta fuori</stage>
             <l>così si fa.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Ei va a perire oh Dei!</l>
             <l>Fermate, per pietà!</l>
@@ -2304,13 +2347,13 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>La Contessa, il Conte con martello e tenaglia in mano; al suo arrivo esamina tutte le porte.</stage>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Tutto è come il lasciai: volete dunque</l>
             <l>Aprir voi stessa, o deggio…</l>
             <stage>in atto di aprir a forza la porta</stage>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Aimè fermate;</l>
             <l>E ascoltatemi un poco.</l>
@@ -2318,24 +2361,24 @@
             <l>Mi credete capace</l>
             <l>Di mancar al dover?</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l> Come vi piace.</l>
             <l>Entro quel gabinetto</l>
             <l>Chi v’è chiuso vedrò.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>timida e tremante</stage>
             <l>Si lo vedrete…</l>
             <l>Ma uditemi tranquillo.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>alterato</stage>
             <l>Non è dunque Susanna!</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>come sopra</stage>
             <l>No ma invece è un oggetto</l>
@@ -2345,35 +2388,35 @@
             <l>Di far si disponeva… ed io vi giuro…</l>
             <l>Che l’onor… l’onestà…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l> Chi è dunque! Dite…</l>
             <stage>più alterato</stage>
             <l>L’ucciderò.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>come sopra</stage>
             <l>Sentite.</l>
             <l>Ah, non ho cor.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Parlate.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>È un fanciullo…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l> Un fanciul!…</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Sì… Cherubino…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>da sé</stage>
             <l>(E mi farà il destino</l>
@@ -2387,92 +2430,92 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>La Contessa, il Conte.</stage>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>alla porta del gabinetto con impeto</stage>
             <l>Esci ormai garzon malnato,</l>
             <l>Sciagurato, non tardar.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>ritirandolo a forza dal gabinetto</stage>
             <l>Ah signore, quel furore</l>
             <l>Per lui fammi il cor tremar.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>E d’opporvi ancor osate?</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>No, sentite:</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l> Via parlate.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Giuro al ciel ch’ogni sospetto…</l>
             <stage>tremante e sbigottita</stage>
             <l>E lo stato in che il trovate…</l>
             <l>Sciolto il collo… nudo il petto…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Nudo il petto! Seguitate.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Per vestir femminee spoglie…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Ah comprendo indegna moglie,</l>
             <l>Mi vo’ tosto vendicar.</l>
             <stage>s’appressa al gabinetto e poi torna indietro</stage>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>con forza</stage>
             <l>Mi fa torto quel trasporto,</l>
             <l>M’oltraggiate a dubitar.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Qua la chiave.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>  Egli è innocente,</l>
             <l>Voi, sapete…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l> Non so niente.</l>
             <l>Va lontan dagli occhi miei.</l>
             <l>Un’infida, un’empia sei</l>
             <l>E mi cerchi d’infamar.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Vado… sì… ma…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Non ascolto.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Non son rea.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Vel leggo in volto!</l>
             <l>Mora, mora, e più non sia</l>
             <l>Ria cagion del mio penar.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Ah la cieca gelosia</l>
             <l>Qualche eccesso gli fa far…</l>
@@ -2482,12 +2525,12 @@
         <div type="scene">
           <head>SCENA VII</head>
           <stage>I suddetti e la Susanna ch’esce dal gabinetto.</stage>
-          <sp>
+          <sp who="#conte #contessa">
             <speaker>CONTE, CONTESSA </speaker>
             <stage>con maraviglia</stage>
             <l>Susanna!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l> Signore,</l>
             <l>Cos’è quel stupore?</l>
@@ -2497,34 +2540,34 @@
             <l>Quel paggio malnato</l>
             <l>Vedetelo qua.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>da sé</stage>
             <l>Che scola! la testa</l>
             <l>Girando mi va.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>da sé</stage>
             <l>Che storia è mai questa;</l>
             <l>Susanna v’è là.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>da sé</stage>
             <l>Confusa han la testa,</l>
             <l>Non san come va.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Sei sola?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>  Guardate:</l>
             <l>Qui ascoso sarà.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Guardiamo, guardiamo,</l>
             <l>Qui ascoso sarà.</l>
@@ -2536,18 +2579,18 @@
           <stage>
             <add resp="#ed">Susanna, la Contessa e poi il Conte.</add>
           </stage>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Susanna, son morta:</l>
             <l>Il fiato mi manca.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>allegrissima, addita alla Contessa la finestra onde è saltato Cherubino</stage>
             <l>Più lieta, più franca,</l>
             <l>In salvo è di già.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>esce confuso dal gabinetto</stage>
             <l>Che sbaglio mai presi!</l>
@@ -2557,44 +2600,44 @@
             <l>Ma far burla simile</l>
             <l>È poi crudeltà.</l>
           </sp>
-          <sp>
+          <sp who="#contessa #susanna">
             <speaker>CONTESSA, SUSANNA </speaker>
             <stage>la Contessa col fazzoletto alla bocca per celar
 il disordine di spirito</stage>
             <l>Le vostre follie</l>
             <l>Non mertan pietà.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Io v’amo.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>rinvenendo dalla confusione a poco a poco</stage>
             <l>  Nol dite.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Vel giuro!</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Mentite!</l>
             <stage>con forza e collera</stage>
             <l>Son l’empia, l’infida</l>
             <l>Che ognora v’inganna.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Quell’ira, Susanna,</l>
             <l>M’aita a calmar.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Così si condanna</l>
             <l>Chi può sospettar.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>con risentimento</stage>
             <l>Adunque la fede</l>
@@ -2602,12 +2645,12 @@ il disordine di spirito</stage>
             <l>Sì fiera mercede</l>
             <l>Doveva sperar?</l>
           </sp>
-          <sp>
+          <sp who="#susanna #conte">
             <speaker>SUSANNA, CONTE </speaker>
             <stage>in atto di preghiera</stage>
             <l>Signora! Rosina!</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>al Conte</stage>
             <l>Crudele!</l>
@@ -2617,52 +2660,52 @@ il disordine di spirito</stage>
             <l>Che avete diletto</l>
             <l>Di far disperar.</l>
           </sp>
-          <sp>
+          <sp who="#conte #susanna">
             <speaker>CONTE, SUSANNA </speaker>
             <l>Confuso, pentito,</l>
             <l>Son <add resp="#ed">È</add> troppo punito:</l>
             <l>Abbiate pietà.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Soffrir sì gran torto.</l>
             <l>Quest’alma non sa.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Ma il paggio rinchiuso?</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Fu sol per provarvi.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Ma i tremiti, i palpiti?…</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Fu sol per burlarvi.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>E un foglio sì barbaro?</l>
           </sp>
-          <sp>
+          <sp who="#contessa #susanna">
             <speaker>CONTESSA, SUSANNA</speaker>
             <l>Di Figaro è il foglio,</l>
             <l>E a voi per Basilio…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Ah perfidi, io voglio!…</l>
           </sp>
-          <sp>
+          <sp who="#contessa #susanna">
             <speaker>CONTESSA, SUSANNA</speaker>
             <l>Perdono non merta</l>
             <l>Chi agli altri nol dà.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>con tenerezza</stage>
             <l>Ebben, se vi piace,</l>
@@ -2670,35 +2713,35 @@ il disordine di spirito</stage>
             <l>Rosina inflessibile</l>
             <l>Con me non sarà.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Ah quanto, Susanna,</l>
             <l>Son dolce di core!</l>
             <l>Di donne al furore</l>
             <l>Chi più crederà!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Cogli uomin, signora,</l>
             <l>Girate, volgete,</l>
             <l>Vedrete che ognora</l>
             <l>Si cade poi là.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>con tenerezza</stage>
             <l>Guardatemi.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>  Ingrato.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Ho torto: e mi pento.</l>
             <stage>bacia e ribacia la mano della Contessa</stage>
           </sp>
-          <sp>
+          <sp who="#conte #contessa #susanna">
             <speaker>CONTE, CONTESSA, SUSANNA</speaker>
             <l>Da questo momento</l>
             <l>Quest’alma a conoscervi <add resp="#ed">conoscermi, conoscerla</add></l>
@@ -2708,7 +2751,7 @@ il disordine di spirito</stage>
         <div type="scene">
           <head>SCENA IX</head>
           <stage>I suddetti e Figaro.</stage>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Signori, di fuori</l>
             <l>Son già i suonatori:</l>
@@ -2720,21 +2763,21 @@ il disordine di spirito</stage>
             <l>Le nozze a compir!</l>
             <stage>prende Susanna sotto braccio</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>trattenendolo</stage>
             <l>Pian piano, men fretta.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>La turba m’aspetta.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Un dubbio toglietemi</l>
             <l>In pria di partir.</l>
           </sp>
-          <sp>
+          <sp who="#conte #contessa #figaro #susanna">
             <speaker>CONTE, CONTESSA, FIGARO, SUSANNA</speaker>
             <stage>sottovoce</stage>
             <l>La cosa è scabrosa;</l>
@@ -2742,108 +2785,108 @@ il disordine di spirito</stage>
             <l>Con arte le carte</l>
             <l>Convien qui scoprir.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>a Figaro</stage>
             <l>Conoscete, signor Figaro,</l>
             <stage>mostrandogli il foglio</stage>
             <l>Questo foglio chi vergò?</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>fingendo d’esaminarlo</stage>
             <l>Nol conosco… nol conosco..</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Nol conosci?</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Nol conosci?</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Nol conosci?</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>a tutti tre, l’un dopo l’altro, con risolutezza</stage>
             <l>No, no, no!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>E nol desti a Don Basilio…</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Per recarlo…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Tu c’intendi…</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l> Oibò, oibò.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>E non sai del damerino…</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Che stasera nel giardino…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Già capisci…</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Io non lo so.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Cerchi invan difesa e scusa,</l>
             <l>Il tuo ceffo già t’accusa:</l>
             <l>Vedo ben che vuoi mentir.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>al Conte</stage>
             <l>Mente il ceffo, io già non mento.</l>
           </sp>
-          <sp>
+          <sp who="#contessa #susanna">
             <speaker>CONTESSA, SUSANNA</speaker>
             <stage>a Figaro</stage>
             <l>Il talento aguzzi invano.</l>
             <l>Palesato abbiam l’arcano:</l>
             <l>Non v’è nulla da ridir.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Che rispondi?</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>  Niente, niente.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Dunque, accordi?</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>  Non accordo.</l>
           </sp>
-          <sp>
+          <sp who="#contessa #susanna">
             <speaker>CONTESSA, SUSANNA</speaker>
             <stage>a Figaro</stage>
             <l>Eh via, chétati, balordo:</l>
             <l>La burletta ha da finir.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Per finirla lietamente</l>
             <l>E all’usanza teatrale</l>
@@ -2851,13 +2894,13 @@ il disordine di spirito</stage>
             <l>Un’azion matrimoniale</l>
             <l>Le faremo ora seguir.</l>
           </sp>
-          <sp>
+          <sp who="#contessa #figaro #susanna">
             <speaker>CONTESSA, FIGARO, SUSANNA</speaker>
             <stage>al Conte</stage>
             <l>Deh signor nol contrastate:</l>
             <l>Consolate i miei <add resp="#ed">lor</add> desir.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>da sé</stage>
             <l>Marcellina, Marcellina!</l>
@@ -2868,147 +2911,147 @@ il disordine di spirito</stage>
           <head>SCENA X</head>
           <stage>La Contessa, il Conte, Susanna, Figaro e Antonio,</stage>
           <stage>Entra Antonio, il giardiniere, mezzo ubriaco, portando un vaso di  garofani schiacciato.</stage>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO</speaker>
             <stage>infuriato</stage>
             <l>Ah signore… signor…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>con ansietà</stage>
             <l>Cosa è stato?…</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO</speaker>
             <l>Che insolenza! chi ’l fece! chi fu!</l>
           </sp>
-          <sp>
+          <sp who="#conte #contessa #figaro #susanna">
             <speaker>CONTE, CONTESSA, FIGARO, SUSANNA</speaker>
             <stage>con ansietà</stage>
             <l>Cosa dici, cos’hai, cosa è nato?</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO</speaker>
             <stage>come sopra</stage>
             <l>Ascoltate.</l>
           </sp>
-          <sp>
+          <sp who="#conte #contessa #figaro #susanna">
             <speaker>CONTE, CONTESSA, FIGARO, SUSANNA</speaker>
             <l>Via, parla, di’ su.</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO</speaker>
             <l>Dal balcone che guarda in giardino</l>
             <l>Mille cose ogni dì gettar veggio,</l>
             <l>E poc’anzi, può darsi di peggio?</l>
             <l>Vidi un uom, signor mio, gittar giù.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>con vivacità</stage>
             <l>Dal balcone?</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO</speaker>
             <stage>additandogli il vaso di fiori schiacciato</stage>
             <l> Vedete i garofani?</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>In giardino?</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO</speaker>
             <l>  Sì.</l>
           </sp>
-          <sp>
+          <sp who="#contessa #susanna">
             <speaker>CONTESSA, SUSANNA</speaker>
             <stage>piano a Figaro</stage>
             <l>Figaro all’erta!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Cosa sento!</l>
           </sp>
-          <sp>
+          <sp who="#contessa #figaro #susanna">
             <speaker>CONTESSA, FIGARO, SUSANNA</speaker>
             <stage>da sé</stage>
             <l>Costui ci sconcerta:</l>
             <stage>ad alta voce</stage>
             <l>Quel briaco che viene a far qui?</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>ad Antonio con fuoco</stage>
             <l>Dunque un uom… Ma dov’è, dov’è gito?</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO</speaker>
             <l>Ratto ratto il birbone è fuggito</l>
             <l>E ad un tratto di vista m’uscì.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>sottovoce a Figaro</stage>
             <l>Sai che il paggio…</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>sottovoce a Susanna</stage>
             <l>  So tutto, lo vidi.</l>
             <stage>ride forte</stage>
             <l>Ah, ah, ah!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Taci là.</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO</speaker>
             <stage>a Figaro</stage>
             <l>Cosa ridi?</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>ad Antonio</stage>
             <l>Tu sei cotto dal sorger del dì.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>ad Antonio</stage>
             <l>Or ripetimi: un uom dal balcone…</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO</speaker>
             <l>Dal balcone…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l> In giardino…</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO</speaker>
             <l>In giardino…</l>
           </sp>
-          <sp>
+          <sp who="#contessa #figaro #susanna">
             <speaker>CONTESSA, FIGARO, SUSANNA</speaker>
             <l>Ma signore, se in lui parla il vino!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>ad Antonio</stage>
             <l>Segui pure: né in volto il vedesti?</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO</speaker>
             <l>No, nol vidi.</l>
           </sp>
-          <sp>
+          <sp who="#contessa #susanna">
             <speaker>CONTESSA, SUSANNA</speaker>
             <stage>sottovoce a Figaro</stage>
             <l>Olà, Figaro, ascolta!</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>ad Antonio</stage>
             <l>Via piangione sta’ zitto una volta:</l>
@@ -3017,106 +3060,106 @@ il disordine di spirito</stage>
             <l>Giacché il fatto non può stare occulto,</l>
             <l>Sono io stesso saltato di lì.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Chi? voi stesso?</l>
           </sp>
-          <sp>
+          <sp who="#contessa #susanna">
             <speaker>CONTESSA, SUSANNA</speaker>
             <stage>da sé</stage>
             <l>Che testa! che ingegno!</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>al Conte</stage>
             <l>Che stupori!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Già creder nol posso.</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO</speaker>
             <stage>a Figaro</stage>
             <l>Come mai diventaste sì grosso?</l>
             <l>Dopo il salto non foste così.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>A chi salta succede così.</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO</speaker>
             <l>Chi ’l direbbe?</l>
           </sp>
-          <sp>
+          <sp who="#contessa #susanna">
             <speaker>CONTESSA, SUSANNA</speaker>
             <stage>da sé</stage>
             <l>Ed insiste, quel pazzo!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>ad Antonio</stage>
             <l>Tu che dici?</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO</speaker>
             <l>E a me parve il ragazzo.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>con fuoco</stage>
             <l>Cherubin!</l>
           </sp>
-          <sp>
+          <sp who="#contessa #susanna">
             <speaker>CONTESSA, SUSANNA</speaker>
             <stage>da sé</stage>
             <l>Maledetto!</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Esso appunto.</l>
             <stage>ironicamente</stage>
             <l>Da Siviglia a cavallo qui giunto,</l>
             <l>Da Siviglia ov’ei forse sarà.</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO</speaker>
             <stage>con rozza semplicità</stage>
             <l>Questo no, questo no, ché il cavallo</l>
             <l>Io non vidi saltare di là.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Che pazienza! Finiam questo ballo!</l>
           </sp>
-          <sp>
+          <sp who="#contessa #susanna">
             <speaker>CONTESSA, SUSANNA</speaker>
             <stage>da sé</stage>
             <l>Come mai, giusto ciel! finirà?</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>a Figaro</stage>
             <l>Dunque tu…</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>  Saltai giù.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Ma perché?</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Il timor…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>  Che timor?</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>additando le camere delle serve</stage>
             <l> Là rinchiuso,</l>
@@ -3127,145 +3170,145 @@ il disordine di spirito</stage>
             <stage>fingendo d’aversi stroppiato il piede</stage>
             <l>E stravolto m’ho un nervo del piè!</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO</speaker>
             <l>Vostre dunque saran queste carte</l>
             <stage>porgendo a Figaro alcune carte chiuse</stage>
             <l>Che perdeste…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>togliendogliele</stage>
             <l>Olà, porgile a me.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>piano alla Contessa e a Susanna</stage>
             <l>Sono in trappola.</l>
           </sp>
-          <sp>
+          <sp who="#contessa #susanna">
             <speaker>CONTESSA, SUSANNA</speaker>
             <stage>piano a Figaro</stage>
             <l>Figaro all’erta!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>apre il foglio e lo chiude tosto</stage>
             <l>Dite un po’, questo foglio cos’è?</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Tosto tosto… n’ho tanti, aspettate.</l>
             <stage>cavando di tasca alcune carte per guardare</stage>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO</speaker>
             <l>Sarà forse il sommario de’ debiti.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>No, la lista degli osti.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>a Figaro</stage>
             <l>Parlate.</l>
             <stage>ad Antonio</stage>
             <l>E tu lascialo!</l>
           </sp>
-          <sp>
+          <sp who="#contessa #figaro #susanna">
             <speaker>CONTESSA, FIGARO, SUSANNA</speaker>
             <l>Lascialo <add resp="#ed">Lasciami</add> e parti…</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO</speaker>
             <l>Parto sì, ma se torno a trovarti.</l>
             <stage>parte</stage>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Vanne, vanne, non temo di te.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>riapre la carta e poi tosto la chiude</stage>
             <stage>a Figaro</stage>
             <l>Dunque?…</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>piano a Susanna</stage>
             <l>  O ciel! la patente del paggio!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>piano a Figaro</stage>
             <l>Giusti Dei! la patente!…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>a Figaro ironicamente</stage>
             <l>Coraggio!</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>fingendo di risovvenirsi</stage>
             <l>Uh, che testa! — Quest’è la patente</l>
             <l>Che poc’anzi il fanciullo mi diè.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Per che fare?</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>imbrogliato</stage>
             <l>Vi manca…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>  Vi manca?</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>piano a Susanna</stage>
             <l>Il suggello.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>piano a Figaro</stage>
             <l> Il suggello!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>  Rispondi?</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>finge di pensare</stage>
             <l>È l’usanza…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Su via ti confondi?</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>È l’usanza di porvi il suggello.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>guarda e vede che manca il sigillo; guasta il foglio e con somma collera lo getta</stage>
             <l>(Questo birbo mi toglie il cervello;</l>
             <l>Tutto, tutto è un mistero per me.)</l>
           </sp>
-          <sp>
+          <sp who="#contessa #susanna">
             <speaker>CONTESSA, SUSANNA</speaker>
             <stage>da sé</stage>
             <l>(Se mi salvo da questa tempesta,</l>
             <l>Più non avvi naufragio per me.)</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>da sé</stage>
             <l>(Sbuffa invano, e la terra calpesta;</l>
@@ -3275,92 +3318,92 @@ il disordine di spirito</stage>
         <div type="scene">
           <head>SCENA XI</head>
           <stage>I suddetti, Marcellina, Bartolo e Basilio.</stage>
-          <sp>
+          <sp who="#marcellina #bartolo #basilio">
             <speaker>MARCELLINA, BARTOLO, BASILIO</speaker>
             <stage>al Conte</stage>
             <l>Voi signor, che giusto siete,</l>
             <l>Ci dovete or ascoltar.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>da sé</stage>
             <l>Son venuti a vendicarmi.</l>
             <l>Io mi sento a consolar.</l>
           </sp>
-          <sp>
+          <sp who="#contessa #figaro #susanna">
             <speaker>CONTESSA, FIGARO, SUSANNA</speaker>
             <stage>da sé</stage>
             <l>Son venuti a sconcertarmi,</l>
             <l>Qual rimedio ritrovar?</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>al Conte</stage>
             <l>Son tre stolidi, tre pazzi.</l>
             <l>Cosa mai vengono a far?</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Pian pianin, senza schiamazzi</l>
             <l>Dica ognun quel che gli par.</l>
           </sp>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <l>Un impegno nuziale</l>
             <l>Ha costui con me contratto:</l>
             <l>E pretendo che il contratto</l>
             <l>Deva meco effettuar.</l>
           </sp>
-          <sp>
+          <sp who="#contessa #figaro #susanna">
             <speaker>CONTESSA, FIGARO, SUSANNA</speaker>
             <l>Come! Come!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>  Olà, silenzio:</l>
             <l>Io son qui per giudicar.</l>
           </sp>
-          <sp>
+          <sp who="#bartolo">
             <speaker>BARTOLO</speaker>
             <l>Io da lei scelto avvocato</l>
             <l>Vengo a far le sue difese,</l>
             <l>Le legittime pretese</l>
             <l>Io qui vengo a palesar.</l>
           </sp>
-          <sp>
+          <sp who="#contessa #figaro #susanna">
             <speaker>CONTESSA, FIGARO, SUSANNA</speaker>
             <l>È un birbante!…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l> Olà, silenzio:</l>
             <l>Io son qui per giudicar.</l>
           </sp>
-          <sp>
+          <sp who="#basilio">
             <speaker>BASILIO</speaker>
             <l>Io, com’uom al mondo cognito,</l>
             <l>Vengo qui per testimonio</l>
             <l>Del promesso matrimonio</l>
             <l>Con prestanza di danar.</l>
           </sp>
-          <sp>
+          <sp who="#contessa #figaro #susanna">
             <speaker>CONTESSA, FIGARO, SUSANNA</speaker>
             <l>Son tre matti!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Lo vedremo,</l>
             <l>Il contratto leggeremo</l>
             <l>Tutto in ordin deve andar.</l>
           </sp>
-          <sp>
+          <sp who="#conte #marcellina #bartolo #basilio">
             <speaker>CONTE, MARCELLINA, BARTOLO, BASILIO</speaker>
             <l>Che bel colpo, che bel caso!</l>
             <l>È cresciuto a tutti il naso,</l>
             <l>Qualche Nume a noi propizio</l>
             <l>Qui li <add resp="#ed">ci</add> ha fatti capitar.</l>
           </sp>
-          <sp>
+          <sp who="#contessa #figaro #susanna">
             <speaker>CONTESSA, FIGARO, SUSANNA</speaker>
             <l>Son confusa <add resp="#ed">confuso</add> son stordita <add resp="#ed">stordito</add>,</l>
             <l>Disperata <add resp="#ed">Disperato</add>, sbalordita <add resp="#ed">sbalordito</add>.</l>
@@ -3375,7 +3418,7 @@ il disordine di spirito</stage>
         <div type="scene">
           <head>SCENA I </head>
           <stage>Il Conte solo che passeggia.</stage>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Che imbarazzo è mai questo! un foglio anonimo…</l>
             <l>La cameriera in gabinetto chiusa…</l>
@@ -3393,201 +3436,201 @@ il disordine di spirito</stage>
         <div type="scene">
           <head>SCENA II</head>
           <stage>Il suddetto, la Contessa e Susanna; s’arrestano in fondo alla scena, non vedute dal Conte.</stage>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Via, fàtti core: digli</l>
             <l>Che ti attenda in giardino.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Saprò se Cherubino</l>
             <l>Era giunto a Siviglia: a tale oggetto</l>
             <l>Ho mandato Basilio…</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>  Oh cielo! e Figaro?</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>A lui non dèi dir nulla: in vece tua</l>
             <l>Voglio andarci io medesma.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l> Avanti sera</l>
             <l>Dovrebbe ritornar…</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>  Oh Dio… non oso!</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Pensa ch’è in tua mano il mio riposo.</l>
             <stage>si nasconde</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>E Susanna? chi sa ch’ella tradito</l>
             <l>Abbia il secreto rito… Oh, se ha parlato,</l>
             <l>Gli fo sposar la vecchia.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>s’avanza</stage>
             <l>(Marcellina!)</l>
             <l>Signor…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>serio</stage>
             <l>Cosa bramate?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Mi par che siete in collera!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Volete qualche cosa?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Signor… la vostra sposa</l>
             <l>Ha i soliti vapori,</l>
             <l>E vi chiede il fiaschetto degli odori.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Prendete.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l> Or vel riporto.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Eh no: potete</l>
             <l>Ritenerlo per voi.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Per me?</l>
             <l>(Scusate)</l>
             <l>Questi non son mali</l>
             <l>Da donne triviali.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Un’amante, che perde il caro sposo</l>
             <l>Sul punto d’ottenerlo…</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Pagando Marcellina</l>
             <l>Con la dote che voi mi prometteste…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Ch’io vi promisi? quando?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Credea d’averlo inteso.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Sì, se voluto aveste</l>
             <l>Intendermi voi stessa.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>  È mio dovere:</l>
             <l>E quel di sua Eccellenza è il mio volere.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Crudel! Perché finora</l>
             <l>Farmi languir così?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Signor, la donna ognora</l>
             <l>Tempo ha di dir di sì.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Dunque in giardin verrai?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Se piace a voi, verrò.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>E non mi mancherai?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>No, non vi mancherò.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>(Mi sento dal contento</l>
             <l>Pieno di gioia il cor.)</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>(Scusatemi se mento,</l>
             <l>Voi che intendete amor.)</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>E perché fosti meco</l>
             <l>Stamattina sì austera?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Col paggio ch’ivi c’era…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l> Ed a Basilio,</l>
             <l>Che per me ti parlò?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Ma qual bisogno</l>
             <l>Abbiam noi che un Basilio…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l> È vero, è vero,</l>
             <l>E mi prometti poi…</l>
             <l>Se tu manchi, oh cor mio.. Ma la Contessa</l>
             <l>Attenderà il fiaschetto.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Eh fu un pretesto:</l>
             <l>Parlato io non avrei senza di questo.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>le prende la mano</stage>
             <l>Carissima!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>si ritira</stage>
             <l>Vien gente.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>  È mia senz’altro.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Forbitevi la bocca, oh signor scaltro.</l>
           </sp>
@@ -3595,17 +3638,17 @@ il disordine di spirito</stage>
         <div type="scene">
           <head>SCENA III</head>
           <stage>Figaro, Susanna e subito il Conte.</stage>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Ehi, Susanna, ove vai?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Taci: senza avvocato</l>
             <l>Hai già vinta la causa.</l>
             <stage>parte</stage>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Cosa è nato?</l>
           </sp>
@@ -3614,7 +3657,7 @@ il disordine di spirito</stage>
         <div type="scene">
           <head>SCENA IV</head>
           <stage>Il Conte solo.</stage>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Hai già vinta la causa! cosa sento!</l>
             <l>In qual laccio cadea! Perfidi! io voglio</l>
@@ -3651,102 +3694,102 @@ il disordine di spirito</stage>
         <div type="scene">
           <head>SCENA V</head>
           <stage>Il Conte, Marcellina, Don Curzio, Figaro e Bartolo; poi Susanna.</stage>
-          <sp>
+          <sp who="#curzio">
             <speaker>CURZIO</speaker>
             <stage>tartagliando</stage>
             <l>È decisa la lite.</l>
             <l>O pagarla, o sposarla. Ora ammutite.</l>
           </sp>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <l>Io respiro.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Ed io moro.</l>
           </sp>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <stage>da sé</stage>
             <l>Alfin sposa io sarò d’un uom che adoro.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Eccellenza, m’appello…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>È giusta la sentenza:</l>
             <l>O pagar, o sposar, bravo Don Curzio.</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CURZIO</speaker>
             <l>Bontà dì sua Eccellenza.</l>
           </sp>
-          <sp>
+          <sp who="#bartolo">
             <speaker>BARTOLO</speaker>
             <l>Che superba sentenza!</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>In che superba?</l>
           </sp>
-          <sp>
+          <sp who="#bartolo">
             <speaker>BARTOLO</speaker>
             <l>Siam tutti vendicati…</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Io non la sposerò.</l>
           </sp>
-          <sp>
+          <sp who="#bartolo">
             <speaker>BARTOLO</speaker>
             <l>La sposerai.</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CURZIO</speaker>
             <l>O pagarla, o sposarla. Lei t’ha prestato</l>
             <l>Duemila pezzi duri.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Son gentiluomo, e senza</l>
             <l>L’assenso de’ miei nobili parenti..</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Dove sono? chi sono?</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Lasciate ancor cercarli:</l>
             <l>Dopo dieci anni io spero di trovarli.</l>
           </sp>
-          <sp>
+          <sp who="#bartolo">
             <speaker>BARTOLO</speaker>
             <l>Qualche bambin trovato?</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>No perduto, dottor, anzi rubato.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Come?</l>
           </sp>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <l>Cosa?</l>
           </sp>
-          <sp>
+          <sp who="#bartolo">
             <speaker>BARTOLO</speaker>
             <l>La prova?</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CURZIO</speaker>
             <l> Il testimonio?</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>L’oro, le gemme, e i ricamati panni,</l>
             <l>Che ne’ più teneri anni</l>
@@ -3755,111 +3798,111 @@ il disordine di spirito</stage>
             <l>Di mia nascita illustre: e sopra tutto</l>
             <l>Questo al mio braccio impresso geroglifico…</l>
           </sp>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <l>Una spatola impressa al braccio destro…</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>E a voi chi ’l disse?</l>
           </sp>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <l>Oh Dio,</l>
             <l>È egli…</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l> È ver, son io.</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CURZIO</speaker>
             <l>Chi?</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Chi?</l>
           </sp>
-          <sp>
+          <sp who="#bartolo">
             <speaker>BARTOLO</speaker>
             <l>Chi?</l>
           </sp>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <l>  Raffaello.</l>
           </sp>
-          <sp>
+          <sp who="#bartolo">
             <speaker>BARTOLO</speaker>
             <l>E i ladri ti rapir…</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Presso un castello.</l>
           </sp>
-          <sp>
+          <sp who="#bartolo">
             <speaker>BARTOLO</speaker>
             <l>Ecco tua madre.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l> Balia…</l>
           </sp>
-          <sp>
+          <sp who="#bartolo">
             <speaker>BARTOLO</speaker>
             <l>No, tua madre.</l>
           </sp>
-          <sp>
+          <sp who="#conte #curzio">
             <speaker>CONTE, CURZIO </speaker>
             <l>Sua madre!</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>  Cosa sento!</l>
           </sp>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <l>Ecco tuo padre.</l>
             <stage>abbracciando Figaro</stage>
             <l>Riconosci in questo amplesso</l>
             <l>Una madre, amato figlio!</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>a Bartolo</stage>
             <l>Padre mio, fate lo stesso,</l>
             <l>Non mi fate più arrossir.</l>
           </sp>
-          <sp>
+          <sp who="#bartolo">
             <speaker>BARTOLO</speaker>
             <stage>abbracciando Figaro</stage>
             <l>Resistenza la coscienza</l>
             <l>Far non lascia al tuo desir.</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CURZIO</speaker>
             <l>Ei suo padre, ella sua madre,</l>
             <l>L’imeneo non può seguir.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Son smarrito, son stordito:</l>
             <l>Meglio è assai di qua partir.</l>
             <stage>vuol partire</stage>
           </sp>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <l>Figlio amato!</l>
           </sp>
-          <sp>
+          <sp who="#bartolo">
             <speaker>BARTOLO</speaker>
             <l> Figlio amato!</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Parenti amati!</l>
           </sp>
           <stage>Susanna entra con una borsa in mano.</stage>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>arrestando il Conte</stage>
             <l>Alto, alto, signor Conte,</l>
@@ -3867,12 +3910,12 @@ il disordine di spirito</stage>
             <l>A pagar vengo per Figaro,</l>
             <l>Ed a porlo in libertà.</l>
           </sp>
-          <sp>
+          <sp who="#conte #curzio">
             <speaker>CONTE, CURZIO </speaker>
             <l>Non sappiam com’è la cosa,</l>
             <l>Osservate un poco là!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>si volge vedendo Figaro che abbraccia Marcellina</stage>
             <l>Già d’accordo colla sposa;</l>
@@ -3880,33 +3923,33 @@ il disordine di spirito</stage>
             <stage>vuol partire</stage>
             <l>Lascia, iniquo!</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>trattenendo Susanna</stage>
             <l>No, t’arresta!</l>
             <l>Senti, oh cara!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>dà uno schiaffo a Figaro</stage>
             <l>Senti questa!</l>
           </sp>
-          <sp>
+          <sp who="#figaro #bartolo #marcellina">
             <speaker>FIGARO, BARTOLO, MARCELLINA</speaker>
             <l>È un effetto di buon core,</l>
             <l>Tutto amore è quel che fa.</l>
           </sp>
-          <sp>
+          <sp who="#conte #curzio">
             <speaker>CONTE, CURZIO</speaker>
             <l>Fremo <add resp="#ed">Freme</add>, smanio <add resp="#ed">smania</add> dal furore:</l>
             <l>Il destino me la <add resp="#ed">gliela</add> fa.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Fremo, smanio dal furore,</l>
             <l>Una vecchia me la fa.</l>
           </sp>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <stage>corre ad abbracciar Susanna</stage>
             <l>Lo sdegno calmate,</l>
@@ -3914,7 +3957,7 @@ il disordine di spirito</stage>
             <l>Sua madre abbracciate,</l>
             <l>Che or vostra sarà.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Sua madre?</l>
           </sp>
@@ -3922,12 +3965,12 @@ il disordine di spirito</stage>
             <speaker>TUTTI</speaker>
             <l> Sua madre!</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>E quello è mio padre,</l>
             <l>Che a te lo dirà.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Suo padre?</l>
           </sp>
@@ -3935,20 +3978,20 @@ il disordine di spirito</stage>
             <speaker>TUTTI</speaker>
             <l> Suo padre!</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>E quella è mia madre.</l>
             <l>Che a te lo dirà.</l>
             <stage>corrono tutti quattro ad abbracciarsi</stage>
           </sp>
-          <sp>
+          <sp who="#susanna #figaro #marcellina #bartolo">
             <speaker>SUSANNA, FIGARO, MARCELLINA, BARTOLO</speaker>
             <l>Al dolce contento</l>
             <l>Di questo momento,</l>
             <l>Quest’anima appena</l>
             <l>Resister or sa.</l>
           </sp>
-          <sp>
+          <sp who="#conte #curzio">
             <speaker>CONTE, CURZIO</speaker>
             <l>Al fiero tormento</l>
             <l>Di questo momento,</l>
@@ -3960,58 +4003,58 @@ il disordine di spirito</stage>
         <div type="scene">
           <head>SCENA VI</head>
           <stage>Susanna, Marcellina, Figaro, Bartolo.</stage>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <l>Eccovi, oh caro amico, il dolce frutto</l>
             <l>Dell’antico amor nostro…</l>
           </sp>
-          <sp>
+          <sp who="#bartolo">
             <speaker>BARTOLO</speaker>
             <l>  Or non parliamo</l>
             <l>Di fatti sì remoti; egli è mio figlio,</l>
             <l>Mia consorte voi siete;</l>
             <l>E le nozze farem quando volete.</l>
           </sp>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <l>Oggi, e doppie saranno:</l>
             <stage>dà un biglietto a Figaro</stage>
             <l>Prendi, questo è il biglietto</l>
             <l>Del danar che a me devi, ed è tua dote.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>getta per terra una borsa di denari</stage>
             <l>Prendi ancor questa borsa.</l>
           </sp>
-          <sp>
+          <sp who="#bartolo">
             <speaker>BARTOLO</speaker>
             <stage>fa lo stesso</stage>
             <l>E questa ancora.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Bravi, gettate pur ch’io piglio ognora.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Voliamo ad informar d’ogni avventura</l>
             <l>Madama e nostro zio.</l>
             <l>Chi al par di me contento?</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l> Io.</l>
           </sp>
-          <sp>
+          <sp who="#bartolo">
             <speaker>BARTOLO</speaker>
             <l>Io.</l>
           </sp>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <l>Io.</l>
           </sp>
-          <sp>
+          <sp who="#susanna #figaro #marcellina #bartolo">
             <speaker>SUSANNA, FIGARO, MARCELLINA, BARTOLO</speaker>
             <stage>partendo abbracciati</stage>
             <l>E schiatti il signor Conte al gusto mio!</l>
@@ -4020,20 +4063,20 @@ il disordine di spirito</stage>
         <div type="scene">
           <head>SCENA VII</head>
           <stage>Barbarina, Cherubino.</stage>
-          <sp>
+          <sp who="#barbarina">
             <speaker>BARBARINA</speaker>
             <l>Andiamo, andiam, bel paggio, in casa mia</l>
             <l>Tutte ritroverai</l>
             <l>Le più belle ragazze del castello</l>
             <l>Di tutte sarai tu certo il più bello.</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l>Ah! se il Conte mi trova,</l>
             <l>Misero me, tu sai</l>
             <l>Che partito ei mi crede per Siviglia.</l>
           </sp>
-          <sp>
+          <sp who="#barbarina">
             <speaker>BARBARINA</speaker>
             <l>Oh, ve’ che maraviglia, e se ti trova,</l>
             <l>Non sarà cosa nuova…</l>
@@ -4047,7 +4090,7 @@ il disordine di spirito</stage>
         <div type="scene">
           <head>SCENA VIII</head>
           <stage>La Contessa sola.</stage>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>E Susanna non vien! sono ansiosa</l>
             <l>Di saper come il Conte</l>
@@ -4081,28 +4124,28 @@ il disordine di spirito</stage>
         <div type="scene">
           <head>SCENA IX</head>
           <stage>Il Conte ed Antonio con un cappello in mano.</stage>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO</speaker>
             <l>Io vi dico, signor, che Cherubino</l>
             <l>È ancora nel castello,</l>
             <l>E vedete per prova il suo cappello.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Ma come, se a quest’ora</l>
             <l>Esser giunto a Siviglia egli dovria?</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO</speaker>
             <l>Scusate, oggi Siviglia è a casa mia.</l>
             <l>Là vestissi da donna, e là lasciati</l>
             <l>Ha gl’altri abiti suoi.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Perfidi!</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO</speaker>
             <l>Andiam, e li vedrete voi.</l>
           </sp>
@@ -4111,34 +4154,34 @@ il disordine di spirito</stage>
         <div type="scene">
           <head>SCENA X</head>
           <stage>La Contessa e Susanna.</stage>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Cosa mi narri, e che ne disse il Conte?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Gli si leggeva in fronte</l>
             <l>Il dispetto e la rabbia.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Piano: ché meglio or lo porremo in gabbia.</l>
             <l>Dov’è l’appuntamento</l>
             <l>Che tu gli proponesti?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>In giardino.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l> Fissiamgli un loco. Scrivi.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Ch’io scriva… ma signora…</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Eh scrivi dico; e tutto</l>
             <l>Io prendo su me stessa.</l>
@@ -4146,55 +4189,55 @@ il disordine di spirito</stage>
             <stage>dettando</stage>
             <l>Canzonetta sull’aria…</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>scrivendo</stage>
             <l>Sull’aria…</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>dettando</stage>
             <l>Che soave zeffiretto…</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>ripete le parole della Contessa</stage>
             <l>Zeffiretto…</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Questa sera spirerà,</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Questa sera spirerà…</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Sotto i pini del boschetto.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>domandando</stage>
             <l>Sotto i pini?</l>
             <stage>scrivendo</stage>
             <l>Sotto i pini… del boschetto</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Ei già il resto capirà.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Certo certo il capirà.</l>
             <stage>leggono insieme lo scritto</stage>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>piega la lettera</stage>
             <l>Piegato è il foglio… Or come si sigilla?</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>si cava una spilla e gliela dà</stage>
             <l>Ecco… prendi una spilla:</l>
@@ -4202,12 +4245,12 @@ il disordine di spirito</stage>
             <l>Sul riverso del foglio:</l>
             <l>«Rimandate il sigillo».</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>  È più bizzarro</l>
             <l>Di quel della patente.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Presto nascondi: io sento venir gente.</l>
           </sp>
@@ -4220,7 +4263,7 @@ il disordine di spirito</stage>
             contadinelle vestite nel medesimo modo con mazzetti  di fiori e
             detti.
           </stage>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Ricevete, oh padroncina,</l>
             <l>Queste rose e questi fior,</l>
@@ -4231,33 +4274,33 @@ il disordine di spirito</stage>
             <l>Ma quel poco che rechiamo</l>
             <l>Ve lo diamo di buon cor.</l>
           </sp>
-          <sp>
+          <sp who="#barbarina">
             <speaker>BARBARINA</speaker>
             <l>Queste sono, Madama,</l>
             <l>Le ragazze del loco,</l>
             <l>Che il poco ch’han vi vengono ad offrire,</l>
             <l>E vi chiedon perdon del loro ardire.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Oh brave, vi ringrazio.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Come sono vezzose.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>E chi è, narratemi,</l>
             <l>Quell’amabil fanciulla</l>
             <l>Ch’ha l’aria sì modesta?</l>
           </sp>
-          <sp>
+          <sp who="#barbarina">
             <speaker>BARBARINA</speaker>
             <l>Ell’è una mia cugina, e per le nozze</l>
             <l>È venuta ier sera.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Onoriamo la bella forastiera.</l>
             <l>Venite qui… datemi i vostri fiori.</l>
@@ -4265,7 +4308,7 @@ il disordine di spirito</stage>
             <l>Come arrossì… Susanna, e non ti pare…</l>
             <l>Che somigli ad alcuno?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l> Al naturale.</l>
           </sp>
@@ -4274,54 +4317,54 @@ il disordine di spirito</stage>
           <head>SCENA XII</head>
           <stage>I detti, il Conte ed Antonio.</stage>
           <stage>Antonio ha il cappello di Cherubino: entra in scena pian piano, gli cava la cuffia di donna gli mette in testa il cappello stesso.</stage>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO</speaker>
             <l>Ehi! cospettaccio! È questi l’uffiziale.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Oh stelle!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>(Malandrino!)</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l> Ebben, Madama…</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Io sono, oh signor mio,</l>
             <l>Irritata e sorpresa al par di voi.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Ma stamane…</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>  Stamane…</l>
             <l>Per l’odierna festa</l>
             <l>Voleam travestirlo al modo stesso,</l>
             <l>Che l’han vestito adesso.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>a Cherubino</stage>
             <l>E perché non partiste?</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <stage>cavandosi il cappello bruscamente</stage>
             <l>Signor!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Saprò punire</l>
             <l>La sua disobbedienza</l>
           </sp>
-          <sp>
+          <sp who="#barbarina">
             <speaker>BARBARINA</speaker>
             <l>Eccellenza, Eccellenza,</l>
             <l>Voi mi dite sì spesso,</l>
@@ -4329,28 +4372,28 @@ il disordine di spirito</stage>
             <l>Barbarina, se m’ami,</l>
             <l>Ti darò quel che brami…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Io dissi questo?</l>
           </sp>
-          <sp>
+          <sp who="#barbarina">
             <speaker>BARBARINA</speaker>
             <l>Voi.</l>
             <l>Or datemi, padrone,</l>
             <l>In sposo Cherubino,</l>
             <l>E v’amerò com’amo il mio gattino.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>al Conte</stage>
             <l>Ebbene: or tocca a voi.</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO</speaker>
             <l>Brava figliuola!</l>
             <l>Hai buon maestro, che ti fa la scuola.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>da sé</stage>
             <l>Non so qual uom, qual demone, qual Dio</l>
@@ -4360,18 +4403,18 @@ il disordine di spirito</stage>
         <div type="scene">
           <head>SCENA XIII</head>
           <stage>I detti, Figaro.</stage>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Signor… se trattenete</l>
             <l>Tutte queste ragazze,</l>
             <l>Addio feste… addio danza…</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>E che, vorresti</l>
             <l>Ballar col piè stravolto?</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>finge di drizzarsi la gamba e poi si prova a ballare</stage>
             <l>Eh non mi duol più molto.</l>
@@ -4379,51 +4422,51 @@ il disordine di spirito</stage>
             <l>Andiam belle fanciulle.</l>
             <stage>Il Conte lo richiama.</stage>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>a Susanna</stage>
             <l>Come si caverà dall’imbarazzo?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>alla Contessa</stage>
             <l>Lasciate fare a lui.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Per buona sorte</l>
             <l>I vasi eran di creta.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l> Senza fallo.</l>
             <stage>come sopra</stage>
             <l>Andiamo, dunque, andiamo.</l>
             <stage>Antonio lo richiama.</stage>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO</speaker>
             <l>E intanto a cavallo</l>
             <l>Di galoppo a Siviglia andava il paggio.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Di galoppo, o di passo… buon viaggio.</l>
             <stage>come sopra</stage>
             <l>Venite, oh belle giovani.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>torna a ricondurlo in mezzo</stage>
             <l>E a te la sua patente</l>
             <l>Era in tasca rimasta…</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l> Certamente,</l>
             <l>Che razza di domande!</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO</speaker>
             <stage>a Susanna</stage>
             <l>Via non gli far più motti, ei non t’intende.</l>
@@ -4431,35 +4474,35 @@ il disordine di spirito</stage>
             <l>Ed ecco chi pretende</l>
             <l>Che sia un bugiardo il mio signor nipote.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Cherubino?</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO</speaker>
             <l> Or ci sei.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>al Conte</stage>
             <l>Che diamin canta?</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Non canta, no, ma dice</l>
             <l>Ch’egli saltò stamane in sui garofani…</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Ei lo dice! Sarà… se ho saltato io,</l>
             <l>Si può dare che anch’esso</l>
             <l>Abbia fatto lo stesso.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Anch’esso?</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Perché no?</l>
             <l>Io non impugno mai quel che non so.</l>
@@ -4469,26 +4512,26 @@ il disordine di spirito</stage>
             <l>Susanna, dammi il braccio.</l>
             <stage>prende per un braccio Susanna</stage>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Eccolo.</l>
             <stage>Partono tutti, eccettuati il Conte e la Contessa.</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>fra sé</stage>
             <l>Temerari!</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>fra sé</stage>
             <l>Io son di ghiaccio.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Contessa…</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l> Or non parliamo.</l>
             <l>Ecco qui le due nozze,</l>
@@ -4496,7 +4539,7 @@ il disordine di spirito</stage>
             <l>D’una vostra protetta.</l>
             <l>Seggiam.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Seggiamo.</l>
             <stage>fra sé</stage>
@@ -4519,7 +4562,7 @@ il disordine di spirito</stage>
             per ricevere lui il cappello ecc.; Figaro conduce Marcellina alla
             Contessa e fa la stessa funzione.
           </stage>
-          <sp>
+          <sp who="#due_donne">
             <speaker>DUE DONNE</speaker>
             <l>Amanti costanti,</l>
             <l>Seguaci d’onor,</l>
@@ -4530,7 +4573,7 @@ il disordine di spirito</stage>
             <l>Ei caste vi rende</l>
             <l>Ai vostri amator.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Cantiamo, lodiamo</l>
             <l>Sì saggio signor.</l>
@@ -4538,13 +4581,13 @@ il disordine di spirito</stage>
           <stage>I figuranti ballano.</stage>
           <stage>Susanna, essendo in ginocchio durante il duo, tira il Conte per l’abito, e gli mostra il bigliettino, dopo passa la mano dal lato degli spettatori alla testa, dove pare che il Conte le aggiusti il cappello, e gli dà il biglietto. Il Conte se lo mette furtivamente in seno. Susanna s’alza, e gli fa una riverenza. Figaro viene a riceverla, e si balla il fandango. Marcellina s’alza un po’ più tardi. Bartolo viene a riceverla dalle mani della Contessa.</stage>
           <stage>Il Conte va da un lato, cava il biglietto, e fa l’atto d’un uom che rimase punto al dito: lo scuote, lo preme, lo succhia; e, vedendo il biglietto sigillato colla spilla, dice, gittando la spilla a terra, e intanto che l’orchestra suona pianissimo..</stage>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Eh già solita usanza,</l>
             <l>Le donne ficcan gli aghi in ogni loco:</l>
             <l>Ah! ah! capisco il gioco.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>vede tutto, e dice a Susanna</stage>
             <l>Un biglietto amoroso</l>
@@ -4554,7 +4597,7 @@ il disordine di spirito</stage>
             <stage>Il Conte legge, bacia il biglietto, cerca la spilla, la trova e se la mette alla manica del saio.</stage>
             <l>Il narciso or la cerca; oh, che stordito!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Andate amici! e sia per questa sera</l>
             <l>Disposto l’apparato nuziale</l>
@@ -4572,7 +4615,7 @@ il disordine di spirito</stage>
         <div type="scene">
           <head>SCENA I</head>
           <stage>Barbarina sola.</stage>
-          <sp>
+          <sp who="#barbarina">
             <speaker>BARBARINA</speaker>
             <stage>cercando qualche cosa per terra</stage>
             <l>L’ho perduta… me meschina…</l>
@@ -4584,29 +4627,29 @@ il disordine di spirito</stage>
         <div type="scene">
           <head>SCENA II</head>
           <stage>Barbarina, Figaro e Marcellina.</stage>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Barbarina, cos’hai?</l>
           </sp>
-          <sp>
+          <sp who="#barbarina">
             <speaker>BARBARINA</speaker>
             <l>L’ho perduta, cugino.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Cosa?</l>
           </sp>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <l>Cosa?</l>
           </sp>
-          <sp>
+          <sp who="#barbarina">
             <speaker>BARBARINA</speaker>
             <l>La spilla,</l>
             <l>Che a me diede il padrone</l>
             <l>Per recar a Susanna.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>A Susanna… la spilla?</l>
             <stage>in collera</stage>
@@ -4615,11 +4658,11 @@ il disordine di spirito</stage>
             <stage>si calma</stage>
             <l>Di far tutto sì ben quel che tu fai?</l>
           </sp>
-          <sp>
+          <sp who="#barbarina">
             <speaker>BARBARINA</speaker>
             <l>Cos’è? vai meco in collera?</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>E non vedi ch’io scherzo? osserva… </l>
             <stage>cerca un momento per terra, dopo aver destramente cavato una spilla dall’abito o dalla cuffia di Marcellina, e la dà a Barbarina</stage>
@@ -4629,45 +4672,45 @@ il disordine di spirito</stage>
             <l>E servia di sigillo a un bigliettino;</l>
             <l>Vedi s’io sono istrutto.</l>
           </sp>
-          <sp>
+          <sp who="#barbarina">
             <speaker>BARBARINA</speaker>
             <l>E perché il chiedi a me, quando sai tutto?</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Aveva gusto d’udir come il padrone</l>
             <l>Ti diè la commissione.</l>
           </sp>
-          <sp>
+          <sp who="#barbarina">
             <speaker>BARBARINA</speaker>
             <l>Che miracoli!</l>
             <l>«Tieni, fanciulla, reca questa spilla</l>
             <l>Alla bella Susanna, e dille: Questo</l>
             <l>È il sigillo de’ pini».</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Ah, ah! de’ pini!</l>
           </sp>
-          <sp>
+          <sp who="#barbarina">
             <speaker>BARBARINA</speaker>
             <l>È ver ch’ei mi soggiunse:</l>
             <l>«Guarda che alcun non veda»;</l>
             <l>Ma tu già tacerai.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>  Sicuramente.</l>
           </sp>
-          <sp>
+          <sp who="#barbarina">
             <speaker>BARBARINA</speaker>
             <l>A te già niente preme.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>  Oh niente, niente.</l>
           </sp>
-          <sp>
+          <sp who="#barbarina">
             <speaker>BARBARINA</speaker>
             <l>Addio, mio bel cugino;</l>
             <l>Vo da Susanna, e poi da Cherubino.</l>
@@ -4677,55 +4720,55 @@ il disordine di spirito</stage>
         <div type="scene">
           <head>SCENA III</head>
           <stage>Figaro e Marcellina.</stage>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>quasi istupidito</stage>
             <l>Madre!</l>
           </sp>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <l>Figlio!</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Son morto.</l>
           </sp>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <l>Càlmati, figlio mio.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>  Son morto, dico.</l>
           </sp>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <l>Flemma, flemma, e poi flemma: il fatto è serio;</l>
             <l>E pensarci convien: ma pensa un poco</l>
             <l>Che ancor non sai di chi si prenda gioco.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Ah quella spilla, oh madre, è quella stessa</l>
             <l>Che poc’anzi ei raccolse.</l>
           </sp>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <l>  È ver. Ma questo</l>
             <l>Al più ti porge un dritto</l>
             <l>Di stare in guardia, e vivere in sospetto:</l>
             <l>Ma non sai, se in effetto…</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>All’erta dunque: il loco del congresso</l>
             <l>So dov’è stabilito…</l>
           </sp>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <l>Dove vai figlio mio?</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>A vendicar tutti i mariti: addio.</l>
           </sp>
@@ -4734,7 +4777,7 @@ il disordine di spirito</stage>
         <div type="scene">
           <head>SCENA IV</head>
           <stage>Marcellina sola.</stage>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <l>Presto, avvertiam Susanna:</l>
             <l>Io la credo innocente: quella faccia,</l>
@@ -4763,7 +4806,7 @@ il disordine di spirito</stage>
           <head>SCENA V</head>
           <stage>Folto giardino con due nicchie parallele preticabili.</stage>
           <stage>Barbarina sola con alcune frutta e ciambelle.</stage>
-          <sp>
+          <sp who="#barbarina">
             <speaker>BARBARINA</speaker>
             <stage>con in mano alcune frutta e ciambelle</stage>
             <l>Nel padiglione a manca: ei così disse.</l>
@@ -4784,24 +4827,24 @@ il disordine di spirito</stage>
         <div type="scene">
           <head>SCENA VI</head>
           <stage>Figaro solo; poi Basilio, Bartolo e truppa di lavoratori. Figaro con mantello e lanternino notturno.</stage>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>È Barbarina…</l>
             <stage>ode venir gente</stage>
             <l>Chi va là?</l>
           </sp>
-          <sp>
+          <sp who="#basilio">
             <speaker>BASILIO</speaker>
             <l>Son quelli</l>
             <l>Che invitasti a venir.</l>
           </sp>
-          <sp>
+          <sp who="#bartolo">
             <speaker>BARTOLO</speaker>
             <l>Che brutto ceffo!</l>
             <l>Sembri un cospirator: che diamin sono</l>
             <l>Quegli infausti apparati?</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Lo vedrete tra poco.</l>
             <l>In questo stesso loco</l>
@@ -4809,14 +4852,14 @@ il disordine di spirito</stage>
             <l>Della mia sposa onesta</l>
             <l>E del feudal signor…</l>
           </sp>
-          <sp>
+          <sp who="#basilio">
             <speaker>BASILIO</speaker>
             <l>Ah buono buono,</l>
             <l>Capisco come egli è.</l>
             <stage>da sé</stage>
             <l>(Accordati si son senza di me.)</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Voi da questi contorni</l>
             <l>Non vi scostate; intanto</l>
@@ -4829,26 +4872,26 @@ il disordine di spirito</stage>
         <div type="scene">
           <head>SCENA VII</head>
           <stage>Basilio e Bartolo.</stage>
-          <sp>
+          <sp who="#basilio">
             <speaker>BASILIO</speaker>
             <l>Ha i diavoli nel corpo.</l>
           </sp>
-          <sp>
+          <sp who="#bartolo">
             <speaker>BARTOLO</speaker>
             <l>Ma cosa nacque?</l>
           </sp>
-          <sp>
+          <sp who="#basilio">
             <speaker>BASILIO</speaker>
             <l> Nulla.</l>
             <l>Susanna piace al Conte: ella, d’accordo,</l>
             <l>Gli diè un appuntamento</l>
             <l>Ch’a Figaro non piace.</l>
           </sp>
-          <sp>
+          <sp who="#bartolo">
             <speaker>BARTOLO</speaker>
             <l>E che dunque dovria soffrirlo in pace?</l>
           </sp>
-          <sp>
+          <sp who="#basilio">
             <speaker>BASILIO</speaker>
             <l>Quello che soffron tanti</l>
             <l>Ei soffrir non potrebbe? e poi, sentite,</l>
@@ -4907,7 +4950,7 @@ il disordine di spirito</stage>
         <div type="scene">
           <head>SCENA VIII</head>
           <stage>Figaro solo.</stage>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Tutto è disposto: l’ora</l>
             <l>Dovrebbe esser vicina; io sento gente.</l>
@@ -4957,23 +5000,23 @@ il disordine di spirito</stage>
         <div type="scene">
           <head>SCENA IX</head>
           <stage>Susanna e Contessa travestite; Marcellina.</stage>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Signora, ella mi disse</l>
             <l>Che Figaro verravvi.</l>
           </sp>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <l>  Anzi, è venuto:</l>
             <l>Abbassa un po’ la voce.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Dunque, un ci ascolta, e l’altro</l>
             <l>Dèe venir a cercarmi.</l>
             <l>Incominciam.</l>
           </sp>
-          <sp>
+          <sp who="#marcellina">
             <speaker>MARCELLINA</speaker>
             <l> Io voglio qui celarmi</l>
           </sp>
@@ -4982,35 +5025,35 @@ il disordine di spirito</stage>
         <div type="scene">
           <head>SCENA X</head>
           <stage>I suddetti, Figaro in disparte.</stage>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Madama, voi tremate: avreste freddo?</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Parmi umida la notte; io mi ritiro.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>da sé</stage>
             <l>(Eccoci della crisi al grande istante.)</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Io sotto queste piante,</l>
             <l>Se Madama il permette,</l>
             <l>Resto a prendere il fresco una mezz’ora.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>(Il fresco, il fresco!)</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>  Restaci in buon’ora.</l>
             <stage>si nasconde</stage>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>sottovoce</stage>
             <l>Il birbo è in sentinella:</l>
@@ -5041,12 +5084,12 @@ il disordine di spirito</stage>
         <div type="scene">
           <head>SCENA XI</head>
           <stage>I suddetti e poi Cherubino.</stage>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Perfida, e in quella forma</l>
             <l>Meco mentia? Non so s’io veglio o dormo.</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <stage>cantando</stage>
             <l>La la la la la la la la lera.</l>
@@ -5055,40 +5098,40 @@ il disordine di spirito</stage>
             <l>Donne vedete</l>
             <l>S’io l’ho nel cor.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Il picciol paggio!</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l> Io sento gente, entriamo</l>
             <l>Ove entrò Barbarina.</l>
             <l>Oh vedo qui una donna.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l> Ahi me meschina!</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l>M’inganno! a quel cappello</l>
             <l>Che nell’ombra vegg’io, parmi Susanna.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>E se il Conte ora vien, sorte tiranna!</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l>Pian pianin le andrò più presso,</l>
             <l>Tempo perso non sarà.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>(Ah, se il Conte arriva adesso,</l>
             <l>Qualche imbroglio accaderà!)</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <stage>alla Contessa</stage>
             <l>Susannetta… Non risponde…</l>
@@ -5096,13 +5139,13 @@ il disordine di spirito</stage>
             <l>Or la burlo, in verità.</l>
             <stage>la prende per la mano e l’accarezza</stage>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>cerca liberarsi alterando la voce a tempo</stage>
             <l>Arditello, sfacciatello,</l>
             <l>Ite presto via di qua!</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l>Smorfiosa, maliziosa,</l>
             <l>Io già so perché sei qua.</l>
@@ -5111,146 +5154,146 @@ il disordine di spirito</stage>
         <div type="scene">
           <head>SCENA XII</head>
           <stage>I suddetti, il Conte.</stage>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>da lontano</stage>
             <l>Ecco qui la mia Susanna!</l>
           </sp>
-          <sp>
+          <sp who="#figaro #susanna">
             <speaker>FIGARO, SUSANNA</speaker>
             <stage>lontani l’uno dall’altro</stage>
             <l>Ecco qui l’uccellatore.</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l>Non far meco la tiranna!</l>
           </sp>
-          <sp>
+          <sp who="#susanna #conte #figaro">
             <speaker>SUSANNA, CONTE, FIGARO</speaker>
             <stage>da sé</stage>
             <l>Ah nel sen mi batte il core!</l>
             <l>Un altr’uom con lei si sta.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Via, partite, o chiamo gente.</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <stage>sempre tenendola per la mano</stage>
             <l>Dammi un bacio, o non fai niente.</l>
           </sp>
-          <sp>
+          <sp who="#susanna #conte #figaro">
             <speaker>SUSANNA, CONTE, FIGARO</speaker>
             <stage>da sé</stage>
             <l>Alla voce è quegli il paggio.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Anche un bacio, che coraggio!</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l>E perché far io non posso</l>
             <l>Quel che il Conte or or farà!</l>
           </sp>
-          <sp>
+          <sp who="#contessa #susanna #conte #figaro">
             <speaker> CONTESSA, SUSANNA, CONTE, FIGARO</speaker>
             <stage>tutti da sé</stage>
             <l>(Temerario!)</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l>Oh, ve’ che smorfie,</l>
             <l>Sai ch’io fui dietro il sofà.</l>
           </sp>
-          <sp>
+          <sp who="#contessa #susanna #conte #figaro">
             <speaker> CONTESSA, SUSANNA, CONTE, FIGARO</speaker>
             <stage>come sopra</stage>
             <l>(Se il ribaldo ancor sta saldo,</l>
             <l>La faccenda guasterà.)</l>
           </sp>
-          <sp>
+          <sp who="#cherubino">
             <speaker>CHERUBINO</speaker>
             <l>Prendi intanto…</l>
           </sp>
           <stage>volendo dare un bacio alla Contessa</stage>
           <stage>Il Conte si mette in mezzo e riceve il bacio egli stesso.</stage>
-          <sp>
+          <sp who="#contessa #cherubino">
             <speaker>CONTESSA, CHERUBINO</speaker>
             <l>Oh cielo, il Conte!</l>
           </sp>
           <stage>Il paggio entra da Barbarina.</stage>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>appressandosi al Conte</stage>
             <l>Vo’ veder cosa fan là.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Perché voi nol ripetete,</l>
             <l>Ricevete questo qua!</l>
           </sp>
           <stage>crede di dare uno schiaffo al Paggio e lo dà a Figaro</stage>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Ah ci ho fatto un bel guadagno</l>
             <l>Colla mia curiosità!</l>
           </sp>
           <stage>si ritira</stage>
-          <sp>
+          <sp who="#contessa #conte">
             <speaker>CONTESSA, CONTE</speaker>
             <l>Ah ci ha fatto un bel guadagno</l>
             <l>Colla sua temerità!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>ride</stage>
             <l>Ah! ci ha fatto un bel guadagno,</l>
             <l>Colla sua curiosità!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>alla Contessa</stage>
             <l>Partito è alfin l’audace,</l>
             <l>Accostati ben mio!</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Giacché così vi piace,</l>
             <l>Eccomi qui, Signor.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Che compiacente femmina!</l>
             <l>Che sposa di buon cor!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Porgimi la manina!</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Io ve la do.</l>
           </sp>
-          <sp>
+          <sp who="#conte #figaro">
             <speaker>CONTE, FIGARO</speaker>
             <l>  Carina!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Che dita tenerelle!</l>
             <l>Che delicata pelle!</l>
             <l>Mi pizzica, mi stuzzica,</l>
             <l>M’empie di un nuovo ardor.</l>
           </sp>
-          <sp>
+          <sp who="#susanna #contessa #figaro">
             <speaker>SUSANNA, CONTESSA, FIGARO</speaker>
             <l>La cieca prevenzione</l>
             <l>Delude la ragione,</l>
             <l>Inganna i sensi ognor.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Oltre la dote, oh cara,</l>
             <l>Ricevi anco un brillante</l>
@@ -5258,70 +5301,70 @@ il disordine di spirito</stage>
             <l>In pegno del suo amor.</l>
             <stage>le dà un anello</stage>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Tutto Susanna piglia</l>
             <l>Dal suo benefattor.</l>
           </sp>
-          <sp>
+          <sp who="#susanna #conte #figaro">
             <speaker>SUSANNA, CONTE, FIGARO</speaker>
             <l>Va tutto a maraviglia!</l>
             <l>Ma il meglio manca ancor.</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>al Conte</stage>
             <l>Signor, d’accese fiaccole</l>
             <l>Io veggio il balenar.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Entriam, mia bella Venere</l>
             <l>Andiamoci a celar!</l>
           </sp>
-          <sp>
+          <sp who="#susanna #figaro">
             <speaker>SUSANNA, FIGARO</speaker>
             <l>Mariti scimuniti,</l>
             <l>Venite ad imparar!</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Al buio, signor mio?</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>È quello che vogl’io:</l>
             <l>Tu sai che là per leggere</l>
             <l>Io non desio d’entrar.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>La perfida lo séguita,</l>
             <l>È vano il dubitar.</l>
             <stage>passa</stage>
           </sp>
-          <sp>
+          <sp who="#contessa #susanna">
             <speaker>CONTESSA, SUSANNA</speaker>
             <l>I furbi sono in trappola,</l>
             <l>Cammina ben l’affar.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>con voce alterata</stage>
             <l>Chi passa?</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>con rabbia</stage>
             <l>Passa gente!</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>sottovoce al Conte</stage>
             <l>È Figaro: men vo.</l>
             <stage>entra a man destra</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Andate; io poi verrò.</l>
           </sp>
@@ -5330,7 +5373,7 @@ il disordine di spirito</stage>
         <div type="scene">
           <head>SCENA XIII</head>
           <stage>Figaro e Susanna.</stage>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Tutto è tranquillo e placido;</l>
             <l>Entrò la bella Venere;</l>
@@ -5338,12 +5381,12 @@ il disordine di spirito</stage>
             <l>Nuovo Vulcano del secolo</l>
             <l>In rete la potrò.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>cangiando la voce</stage>
             <l>Ehi Figaro: tacete</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Oh questa è la Contessa…</l>
             <stage>a Susanna</stage>
@@ -5353,47 +5396,47 @@ il disordine di spirito</stage>
             <l>Di propria man la cosa</l>
             <l>Toccar io vi farò.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>si dimentica di alterar la voce</stage>
             <l>Parlate un po’ più basso.</l>
             <l>Di qua non muovo passo,</l>
             <l>Ma vendicar mi vo’.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>da sé</stage>
             <l>(Susanna!)</l>
             <stage>a Susanna</stage>
             <l>Vendicarsi?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Sì.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Come potria farsi?</l>
             <stage>da sé</stage>
             <l>La volpe vuol sorprendermi,</l>
             <l>E secondar la vo’.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>da sé</stage>
             <l>L’iniquo io vo’ sorprendere;</l>
             <l>Poi so quel che farò.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>con comica affettazione</stage>
             <l>Ah se Madama il vuole!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Su via, manco parole.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>come sopra</stage>
             <l>Eccomi ai vostri piedi…</l>
@@ -5401,61 +5444,61 @@ il disordine di spirito</stage>
             <l>Esaminate il loco…</l>
             <l>Pensate al traditor.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>da sé</stage>
             <l>Come la man mi pizzica,</l>
             <l>Che smania, che furor!</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>da sé</stage>
             <l>Come il polmon mi si altera,</l>
             <l>Che smania, che furor!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>alterando la voce un poco</stage>
             <l>E senza alcun affetto?</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Suppliscavi il dispetto.</l>
             <l>Non perdiam tempo invano,</l>
             <stage>si frega le mani</stage>
             <l>Datemi un po’ la mano…</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>in voce naturale gli dà uno schiaffo</stage>
             <l>Servitevi, signor!</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Che schiaffo!</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>lo schiaffeggia a tempo</stage>
             <l> E ancora questo,</l>
             <l>E questo, e poi quest’altro.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Non batter così presto.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>sempre schiaffeggiandolo</stage>
             <l>E questo, signor scaltro,</l>
             <l>E qui quest’altro ancor!</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Oh schiaffi graziosissimi,</l>
             <l>Oh mio felice amor.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Impara, impara, o perfido,</l>
             <l>A fare il seduttor.</l>
@@ -5464,91 +5507,91 @@ il disordine di spirito</stage>
         <div type="scene">
           <head>SCENA XIV</head>
           <stage>I suddetti, poi il Conte.</stage>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>si mette in ginocchio</stage>
             <l>Pace, pace, mio dolce tesoro,</l>
             <l>Io conobbi la voce che adoro,</l>
             <l>E che impressa ognor serbo nel cor.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>ridendo e con sorpresa</stage>
             <l>La mia voce?</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>La voce che adoro.</l>
           </sp>
-          <sp>
+          <sp who="#susanna #figaro">
             <speaker>SUSANNA, FIGARO</speaker>
             <l>Pace, pace, mio dolce tesoro,</l>
             <l>Pace, pace, mio tenero amor.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Non la trovo, e girai tutto il bosco.</l>
           </sp>
-          <sp>
+          <sp who="#susanna #figaro">
             <speaker>SUSANNA, FIGARO</speaker>
             <l>Questi è il Conte, alla voce il conosco.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>parlando verso la nicchia, dove entrò Madama, cui apre egli stesso</stage>
             <l>Ehi, Susanna… sei sorda… sei muta?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>Bella, bella! non l’hai conosciuta!</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>sottovoce a Susanna</stage>
             <l>Chi?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>  Madama.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Madama?</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <l>  Madama.</l>
           </sp>
-          <sp>
+          <sp who="#susanna #figaro">
             <speaker>SUSANNA, FIGARO</speaker>
             <stage>sottovoce</stage>
             <l>La commedia, idol mio, terminiamo,</l>
             <l>Consoliamo il bizzarro amator.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>mettendosi ai piedi di Susanna</stage>
             <l>Sì, Madama, voi siete il ben mio.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>La mia sposa… Ah, senz’arme son io.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>sempre inginocchiato</stage>
             <l>Un ristoro al mio cor concedete.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>alterando la voce</stage>
             <l>Io sono qui, faccio quel che volete.</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Ah, ribaldi!</l>
           </sp>
-          <sp>
+          <sp who="#susanna #figaro">
             <speaker>SUSANNA, FIGARO</speaker>
             <l> Ah, corriamo, mio bene,</l>
             <l>E le pene compensi il piacer.</l>
@@ -5558,42 +5601,42 @@ il disordine di spirito</stage>
         <div type="scene">
           <head>SCENA XV</head>
           <stage>I suddetti, Antonio, Basilio, servitori con fiaccole accese; indi la Contessa.</stage>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>arresta Figaro</stage>
             <l>Gente, gente, all’armi all’armi!</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>finge eccessiva paura</stage>
             <l>Il padrone! Son perduto!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Gente, gente, aiuto, aiuto!</l>
           </sp>
-          <sp>
+          <sp who="#basilio #antonio">
             <speaker>BASILIO, ANTONIO</speaker>
             <l>Cosa avvenne?</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Il scellerato!</l>
             <l>M’ha tradito, m’ha infamato,</l>
             <l>E con chi, state a veder.</l>
           </sp>
-          <sp>
+          <sp who="#basilio #antonio">
             <speaker>BASILIO, ANTONIO</speaker>
             <stage>sottovoce</stage>
             <l>Son stordito, sbalordito.</l>
             <l>Non mi par che ciò sia ver!</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Sono storditi, sbalorditi:</l>
             <l>Oh, che scena, che piacer!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Invan resistete,</l>
             <l>Uscite, Madama,</l>
@@ -5602,71 +5645,71 @@ il disordine di spirito</stage>
             <stage>Il Conte tira pel braccio Cherubino, che fa forza per non uscire, né si vede che per metà; dopo il paggio, escono Barbarina, Marcellina e Susanna, vestita cogli abiti della Contessa: si tiene il fazzoletto sulla faccia, e s’inginocchia ai piedi del Conte.</stage>
             <l>Il paggio!</l>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO</speaker>
             <l>  Mia figlia!</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <l>Mia madre!</l>
           </sp>
-          <sp>
+          <sp who="#basilio #antonio #bartolo #figaro">
             <speaker>BASILIO, ANTONIO, BARTOLO, FIGARO</speaker>
             <l> Madama!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>Scoperta è la trama,</l>
             <l>La perfida è qua.</l>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <stage>s’inginocchia ai piedi del Conte</stage>
             <l>Perdono! perdono!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>No, no, non sperarlo.</l>
           </sp>
-          <sp>
+          <sp who="#figaro">
             <speaker>FIGARO</speaker>
             <stage>s’inginocchia</stage>
             <l>Perdono! perdono!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <l>No, no, non vo’ darlo!</l>
           </sp>
-          <sp>
+          <sp who="#susanna #cherubino #marcellina #basilio #antonio #figaro">
             <speaker>SUSANNA, CHERUBINO, MARCELLINA, BASILIO, ANTONIO, FIGARO</speaker>
             <stage>s’inginocchiano</stage>
             <l>Perdono, perdono!</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>con più forza</stage>
             <l>No no, no, no, no!</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <stage>esce dall’altra nicchia</stage>
             <l>Almeno io per loro</l>
             <l>Perdono otterrò.</l>
           </sp>
           <stage>vuole inginocchiarsi; il Conte non lo permette</stage>
-          <sp>
+          <sp who="#conte #basilio #antonio #bartolo">
             <speaker>CONTE, BASILIO, ANTONIO, BARTOLO</speaker>
             <stage>da sé</stage>
             <l>Oh cielo, che veggio!</l>
             <l>Deliro! vaneggio!</l>
             <l>Che creder non so?</l>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage>in tono supplichevole</stage>
             <l>Contessa, perdono!</l>
           </sp>
-          <sp>
+          <sp who="#contessa">
             <speaker>CONTESSA</speaker>
             <l>Più docile io sono,</l>
             <l>E dico di sì.</l>

--- a/tei/dal-carretto-comedia-de-timon-greco.xml
+++ b/tei/dal-carretto-comedia-de-timon-greco.xml
@@ -83,6 +83,46 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="el_poeta">
+            <persName>El Poeta</persName>
+          </person>
+          <person xml:id="timon">
+            <persName>Timon</persName>
+          </person>
+          <person xml:id="iove">
+            <persName>Iove</persName>
+          </person>
+          <person xml:id="mercurio">
+            <persName>Mercurio</persName>
+          </person>
+          <person xml:id="giove">
+            <persName>Giove</persName>
+          </person>
+          <person xml:id="richeza">
+            <persName>Richeza</persName>
+          </person>
+          <person xml:id="poverta">
+            <persName>Povertà</persName>
+          </person>
+          <person xml:id="gnato">
+            <persName>Gnato</persName>
+          </person>
+          <person xml:id="filiade">
+            <persName>Filiade</persName>
+          </person>
+          <person xml:id="demea">
+            <persName>Demea</persName>
+          </person>
+          <person xml:id="trasicle">
+            <persName>Trasicle</persName>
+          </person>
+          <person xml:id="brepsias">
+            <persName>Brepsias</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>2003-05-30T00:00:00.000+02:00</date><name>Alice Faccani</name><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -102,7 +142,7 @@ COMEDIA DE <name>TIMON</name> GRECO</hi>
           <hi rend="sc">PROLOGO</hi>
         </head>
         <stage>El POETA parla:</stage>
-        <sp>
+        <sp who="#el_poeta">
           <speaker>El POETA</speaker>
           <l>Letizia, contenteza, gaudio e pace</l>
           <l>Idio vi doni, o voi qui circunstanti</l>
@@ -145,7 +185,7 @@ COMEDIA DE <name>TIMON</name> GRECO</hi>
         </head>
         <div type="scene" n="Scena prima">
           <stage><hi rend="sc">TIMON</hi> essendo in povertà lamentassi di <hi rend="sc">GIOVE</hi> e dice solo questo capitolo avendo la zappa in mano.</stage>
-          <sp>
+          <sp who="#timon">
             <speaker>TIMON</speaker>
             <l>O re del ciel, che a noi già fusti pio,</l>
             <l>che usurpi il falso nome tuo di Giove,</l>
@@ -222,7 +262,7 @@ COMEDIA DE <name>TIMON</name> GRECO</hi>
         <div type="scene" n="Scena seconda">
           <stage>Sentendo <hi rend="sc">GIOVE</hi> le gran querele de <hi rend="sc">TIMON</hi>, guardandolo e non lo conoscendo dice a <hi rend="sc">MERCURIO</hi> le subsequente parole cum ciera maravigliosa.
 <hi rend="sc">IOVE</hi> a <hi rend="sc">MERCURIO</hi>.</stage>
-          <sp>
+          <sp who="#iove">
             <speaker>
               <hi rend="sc">IOVE</hi>
             </speaker>
@@ -236,7 +276,7 @@ COMEDIA DE <name>TIMON</name> GRECO</hi>
             <l>fode la terra e laborando frappa.</l>
           </sp>
           <stage><hi rend="sc">MERCURIO</hi> a <hi rend="sc">GIOVE</hi>.</stage>
-          <sp>
+          <sp who="#mercurio">
             <speaker>
               <hi rend="sc">MERCURIO</hi>
             </speaker>
@@ -250,7 +290,7 @@ COMEDIA DE <name>TIMON</name> GRECO</hi>
             <l>e getta contra te queste parole.</l>
           </sp>
           <stage><hi rend="sc">GIOVE</hi> a <hi rend="sc">MERCURIO</hi>.</stage>
-          <sp>
+          <sp who="#giove">
             <speaker>
               <hi rend="sc">GIOVE</hi>
             </speaker>
@@ -264,7 +304,7 @@ COMEDIA DE <name>TIMON</name> GRECO</hi>
             <l>guarda se 'l celo è stato a lui contrario!</l>
           </sp>
           <stage><hi rend="sc">MERCURIO</hi> a <hi rend="sc">GIOVE</hi>.</stage>
-          <sp>
+          <sp who="#mercurio">
             <speaker>
               <hi rend="sc">MERCURIO</hi>
             </speaker>
@@ -286,7 +326,7 @@ COMEDIA DE <name>TIMON</name> GRECO</hi>
             <l>vive a l'altrui mercé como un vilano.</l>
           </sp>
           <stage><hi rend="sc">IOVE</hi> a <hi rend="sc">MERCURIO</hi>.</stage>
-          <sp>
+          <sp who="#iove">
             <speaker>
               <hi rend="sc">IOVE</hi>
             </speaker>
@@ -316,7 +356,7 @@ COMEDIA DE <name>TIMON</name> GRECO</hi>
             <l>che 'l facia rico e levi lui di pena.</l>
           </sp>
           <stage><hi rend="sc">MERCURIO</hi> partendosi dice lui solo queste parole:</stage>
-          <sp>
+          <sp who="#mercurio">
             <speaker>
               <hi rend="sc">MERCURIO</hi>
             </speaker>
@@ -332,17 +372,17 @@ COMEDIA DE <name>TIMON</name> GRECO</hi>
         </div>
         <div type="scene" n="Scena terza">
           <stage><hi rend="sc">MERCURIO</hi> va da la <hi rend="sc">RICHEZA</hi> e gli dice:</stage>
-          <sp>
+          <sp who="#mercurio">
             <speaker>
               <hi rend="sc">MERCURIO</hi>
             </speaker>
             <l>Da te, Richeza, Giove qui mi manda.</l>
           </sp>
-          <sp>
+          <sp who="#richeza">
             <speaker><hi rend="sc">RICHEZA</hi>.</speaker>
             <l part="I">Per qual cagion?</l>
           </sp>
-          <sp>
+          <sp who="#mercurio">
             <speaker>
               <hi rend="sc">MERCURIO.</hi>
             </speaker>
@@ -352,7 +392,7 @@ COMEDIA DE <name>TIMON</name> GRECO</hi>
             <l>il qual gli ha facto una querela granda</l>
             <l>di sua miseria in solitarie parti.</l>
           </sp>
-          <sp>
+          <sp who="#richeza">
             <speaker>
               <hi rend="sc">RICHEZA.</hi>
             </speaker>
@@ -362,7 +402,7 @@ ch'io vada a quel che me fe' tanta offensa.</l>
         </div>
         <div type="scene" n="Scena quarta">
           <stage>La <hi rend="sc">RICHEZA</hi> compare e dice a GIOVE:</stage>
-          <sp>
+          <sp who="#richeza">
             <speaker>
               <hi rend="sc">RICHEZA</hi>
             </speaker>
@@ -376,7 +416,7 @@ ch'io vada a quel che me fe' tanta offensa.</l>
             <l>par che dal parco patre suo degenere.</l>
           </sp>
           <stage><hi rend="sc">IOVE</hi> a la <hi rend="sc">RICHEZA</hi>.</stage>
-          <sp>
+          <sp who="#iove">
             <speaker>
               <hi rend="sc">IOVE</hi>
             </speaker>
@@ -384,7 +424,7 @@ ch'io vada a quel che me fe' tanta offensa.</l>
 dal mio Timon,</l>
             <l>poi ch'io il comando e dico?</l>
           </sp>
-          <sp>
+          <sp who="#richeza">
             <speaker><hi rend="sc">RICHEZA</hi>.</speaker>
             <l>Sempre fui presta a li precetti toi,</l>
             <l>ma questo mai non fu mio vero amico</l>
@@ -403,7 +443,7 @@ dal mio Timon,</l>
           </sp>
           <stage><hi rend="sc">IOVE</hi> a la <hi rend="sc">RICHEZA.</hi>
 </stage>
-          <sp>
+          <sp who="#iove">
             <speaker>
               <hi rend="sc">IOVE</hi>
             </speaker>
@@ -441,7 +481,7 @@ dal mio Timon,</l>
             <l>ch'a' liberali el celo è tesauriero.</l>
           </sp>
           <stage>La <hi rend="sc">RICHEZA</hi> a <hi rend="sc">GIOVE</hi>.</stage>
-          <sp>
+          <sp who="#richeza">
             <speaker>
               <hi rend="sc">RICHEZA</hi>
             </speaker>
@@ -488,7 +528,7 @@ dal mio Timon,</l>
           </sp>
           <stage><hi rend="sc">IOVE</hi> a la <hi rend="sc">RICHEZA.</hi>
 </stage>
-          <sp>
+          <sp who="#iove">
             <speaker>
               <hi rend="sc">IOVE</hi>
             </speaker>
@@ -510,7 +550,7 @@ dal mio Timon,</l>
             <l>sobrio e parco più ch'el fuosse mai.</l>
           </sp>
           <stage>La <hi rend="sc">RICHEZA</hi> a <hi rend="sc">GIOVE</hi>.</stage>
-          <sp>
+          <sp who="#richeza">
             <speaker>
               <hi rend="sc">RICHEZA</hi>
             </speaker>
@@ -524,7 +564,7 @@ dal mio Timon,</l>
             <l>a quelle c'hanno i perforati vasi.</l>
           </sp>
           <stage><hi rend="sc">GIOVE</hi> a la <hi rend="sc">RICHEZA</hi>.</stage>
-          <sp>
+          <sp who="#giove">
             <speaker>
               <hi rend="sc">GIOVE</hi>
             </speaker>
@@ -547,14 +587,14 @@ dal mio Timon,</l>
         </head>
         <div type="scene" n="Scena prima">
           <stage><hi rend="sc">MERCURIO</hi> a la <hi rend="sc">RICHEZA</hi> che nel partire va zoppa e cieca.</stage>
-          <sp>
+          <sp who="#mercurio">
             <speaker>
               <hi rend="sc">MERCURIO</hi>
             </speaker>
             <l>Andiam, Riccheza. Ohimè, tu non te move!</l>
             <l>Tu ceca sei e vai cum un pé zoppo.</l>
           </sp>
-          <sp>
+          <sp who="#richeza">
             <speaker><hi rend="sc">RICHEZA</hi>.</speaker>
             <l>Non son sempre cossì,</l>
             <l>ma quando Giove d'alcun mi manda,</l>
@@ -572,7 +612,7 @@ dal mio Timon,</l>
             <l>cossì passo io e vo cum leggier pede</l>
             <l>che de' spectanti alcun mai non mi vede.</l>
           </sp>
-          <sp>
+          <sp who="#mercurio">
             <speaker><hi rend="sc">MERCURIO</hi>.</speaker>
             <l> Ohimé, te inganni:</l>
             <l>perché sono molti,</l>
@@ -584,7 +624,7 @@ dal mio Timon,</l>
             <l>e da costor, sì come dir ti sento</l>
             <l>tu non andasti già col piede lento.</l>
           </sp>
-          <sp>
+          <sp who="#richeza">
             <speaker><hi rend="sc">RICHEZA</hi>.</speaker>
             <l> Da Giove già mandata non son io
 a questa giente,</l>
@@ -620,7 +660,7 @@ de le richezze, come ognuno vede;</l>
             <l>donando in un sol dì quel che in molt'anni</l>
             <l>fu guadagnato cum spergiuri e inganni.</l>
           </sp>
-          <sp>
+          <sp who="#mercurio">
             <speaker>
               <hi rend="sc">MERCURIO.</hi>
             </speaker>
@@ -631,19 +671,19 @@ de le richezze, come ognuno vede;</l>
             <l>Quelli, dico io, quai come vòl Giove</l>
             <l>son di te sola degni e iusti eredi.</l>
           </sp>
-          <sp>
+          <sp who="#richeza">
             <speaker>
               <hi rend="sc">RICHEZA.</hi>
             </speaker>
             <l>Perché or son molti de diverse tempre,</l>
             <l>però costoro non gli trovo sempre.</l>
           </sp>
-          <sp>
+          <sp who="#mercurio">
             <speaker><hi rend="sc">MERCURIO</hi>.</speaker>
             <l> Quando tu pur sei destinata ' andare,</l>
             <l>dimi, Richeza, per tua fé, che fai?</l>
           </sp>
-          <sp>
+          <sp who="#richeza">
             <speaker><hi rend="sc">RICHEZA</hi>.</speaker>
             <l>Or suso or giuso incomincio a errare</l>
             <l>andando in luoco dove non fu' mai,</l>
@@ -652,7 +692,7 @@ de le richezze, come ognuno vede;</l>
             <l>che mai si crese de vedermi seco,</l>
             <l>et in bon stato, de miseria, el reco.</l>
           </sp>
-          <sp>
+          <sp who="#mercurio">
             <speaker>
               <hi rend="sc">MERCURIO.</hi>
             </speaker>
@@ -661,7 +701,7 @@ de le richezze, come ognuno vede;</l>
             <l>e faci richi, non cum arte e inganni,</l>
             <l>sol quei che sono de richeza degni!</l>
           </sp>
-          <sp>
+          <sp who="#richeza">
             <speaker>
               <hi rend="sc">RICHEZA.</hi>
             </speaker>
@@ -678,14 +718,14 @@ de le richezze, come ognuno vede;</l>
             <l>e lieta vivo un tempo cum costoro.</l>
             <l>poi, quando parmi, partomi da loro.</l>
           </sp>
-          <sp>
+          <sp who="#mercurio">
             <speaker>
               <hi rend="sc">MERCURIO.</hi>
             </speaker>
             <l>Partendoti da lor, poi, come fai</l>
             <l>se nel fugir tu non sai la via?</l>
           </sp>
-          <sp>
+          <sp who="#richeza">
             <speaker>
               <hi rend="sc">RICHEZA.</hi>
             </speaker>
@@ -696,7 +736,7 @@ de le richezze, come ognuno vede;</l>
             <l>quando qualcun da lui partir mi vede,</l>
             <l>alor, Mercurio, non ho zoppo il pede.</l>
           </sp>
-          <sp>
+          <sp who="#mercurio">
             <speaker><hi rend="sc">MERCURIO</hi>.</speaker>
             <l>De molti ancor me maraviglia alquanto</l>
             <l>i quai san che sei smorta, cieca e zoppa,</l>
@@ -707,21 +747,21 @@ de le richezze, come ognuno vede;</l>
             <l>e se si vedon da te abandonati</l>
             <l>viveno al mondo como desperati.</l>
           </sp>
-          <sp>
+          <sp who="#richeza">
             <speaker>
               <hi rend="sc">RICHEZA.</hi>
             </speaker>
             <l>Non credi tu ch'a loro sian palesi</l>
             <l>i miei diffecti et ogni occulto inganno?</l>
           </sp>
-          <sp>
+          <sp who="#mercurio">
             <speaker>
               <hi rend="sc">MERCURIO.</hi>
             </speaker>
             <l>Perché son ceci e del tuo amor accesi</l>
             <l>e di te sempre tanta stima fanno?</l>
           </sp>
-          <sp>
+          <sp who="#richeza">
             <speaker>
               <hi rend="sc">RICHEZA.</hi>
             </speaker>
@@ -738,7 +778,7 @@ de le richezze, come ognuno vede;</l>
             <l>sempre in pensieri et in tristizia stanno</l>
             <l>per fin ch'in le sue forze lor non m'hanno.</l>
           </sp>
-          <sp>
+          <sp who="#mercurio">
             <speaker>
               <hi rend="sc">MERCURIO. </hi>
             </speaker>
@@ -751,20 +791,20 @@ de le richezze, come ognuno vede;</l>
             <l>e pur ritorna in quel come fusse orbo:</l>
             <l>qual se ha poi mal per suo diffetto e il morbo.</l>
           </sp>
-          <sp>
+          <sp who="#richeza">
             <speaker>
               <hi rend="sc">RICHEZA.</hi>
             </speaker>
             <l>Alcune cosse son, Mercurio mio,</l>
             <l>qual tengo in mio soccorso a tal preposto.</l>
           </sp>
-          <sp>
+          <sp who="#mercurio">
             <speaker>
               <hi rend="sc">MERCURIO.</hi>
             </speaker>
             <l>Qual sono queste de saper desio.</l>
           </sp>
-          <sp>
+          <sp who="#richeza">
             <speaker>
               <hi rend="sc">RICHEZA.</hi>
             </speaker>
@@ -782,7 +822,7 @@ de le richezze, come ognuno vede;</l>
             <l>ancor che veda il mal suo manifesto:</l>
             <l>lui di lassarmi moriria più presto.</l>
           </sp>
-          <sp>
+          <sp who="#mercurio">
             <speaker>
               <hi rend="sc">MERCURIO.</hi>
             </speaker>
@@ -795,7 +835,7 @@ de le richezze, come ognuno vede;</l>
             <l>Ma fin faciamo. E poi, como faremo</l>
             <l>che lo tesoro nosco non avemo?</l>
           </sp>
-          <sp>
+          <sp who="#richeza">
             <speaker><hi rend="sc">RICHEZA</hi>.</speaker>
             <l> Non dubitar, però che ascoso in terra</l>
             <l>sempre né tengo ad ogni piacer mio,</l>
@@ -811,13 +851,13 @@ de le richezze, come ognuno vede;</l>
           </foreign>
         </head>
         <div type="scene" n="Scena prima">
-          <sp>
+          <sp who="#mercurio">
             <speaker><hi rend="sc">MERCURIO</hi>.</speaker>
             <l>Non siamo al luoco, se 'l veder non erra,</l>
             <l>dove è Timon, il qual servir desio:</l>
             <l>vien mecco donche e tienti forte al braccio.</l>
           </sp>
-          <sp>
+          <sp who="#richeza">
             <speaker>
               <hi rend="sc">RICHEZA.</hi>
             </speaker>
@@ -827,7 +867,7 @@ de le richezze, come ognuno vede;</l>
             <l>Ma che vòl dir tal strepito sonante,</l>
             <l>che par ch'un ferro su 'na petra dia?</l>
           </sp>
-          <sp>
+          <sp who="#mercurio">
             <speaker><hi rend="sc">MERCURIO</hi>.</speaker>
             <l>Timon è quel ch'in questo luoco astante</l>
             <l>avendo molta giente in compagnia,</l>
@@ -842,24 +882,24 @@ de le richezze, come ognuno vede;</l>
             <l>e certo, a dir il vero qua tra noi,</l>
             <l>sono meglior compagni assai ch'i toi.</l>
           </sp>
-          <sp>
+          <sp who="#richeza">
             <speaker><hi rend="sc">RICHEZA</hi>.</speaker>
             <l> Ohimè, Mercurio, come no partemo</l>
             <l>da lui c'ha tanti e tai compagni a lato?</l>
             <l>Perche laudabil cossa non faremo</l>
             <l>cum lui ch'è cossi ben accompagnato.</l>
           </sp>
-          <sp>
+          <sp who="#mercurio">
             <speaker><hi rend="sc">MERCURIO</hi>.</speaker>
             <l>Richeza, aver timor noi non dovemo,</l>
             <l>però che cossi Giove ha già ordinato.</l>
           </sp>
-          <sp>
+          <sp who="#poverta">
             <speaker><hi>POVERTà</hi>.</speaker>
             <l>O d'Argo già pastor falso omicida,</l>
             <l>di questa ceca chi t'ha facto guida?</l>
           </sp>
-          <sp>
+          <sp who="#mercurio">
             <speaker>
               <hi rend="sc">MERCURIO.</hi>
             </speaker>
@@ -872,7 +912,7 @@ de le richezze, come ognuno vede;</l>
             <l>e lui per non lassarlo in tal tristeza</l>
             <l>da quel mandato m'ha cum la Richeza.</l>
           </sp>
-          <sp>
+          <sp who="#poverta">
             <speaker>
               <hi rend="sc">POVERTà.</hi>
             </speaker>
@@ -889,7 +929,7 @@ de le richezze, come ognuno vede;</l>
             <l>ma la sua veste lacera gli serbo</l>
             <l>che anchor lui tornerà nel nostro grege.</l>
           </sp>
-          <sp>
+          <sp who="#mercurio">
             <speaker>
               <hi rend="sc">MERCURIO.</hi>
             </speaker>
@@ -898,7 +938,7 @@ de le richezze, come ognuno vede;</l>
             <l>noi siam venuti qua como tu vedi,</l>
             <l>non già per farte ingiuria come credi.</l>
           </sp>
-          <sp>
+          <sp who="#poverta">
             <speaker>
               <hi rend="sc">POVERTà</hi>
             </speaker>
@@ -914,14 +954,14 @@ de le richezze, come ognuno vede;</l>
         </div>
         <div type="scene" n="Scena seconda">
           <stage><hi rend="sc">MERCURIO</hi> vedendo partir la <hi rend="sc">POVERTà</hi> dice:</stage>
-          <sp>
+          <sp who="#mercurio">
             <speaker>
               <hi rend="sc">MERCURIO</hi>
             </speaker>
             <l>Poiché la Povertà con socii sol</l>
             <l>se pàrtino da lui, andiamo inanti.</l>
           </sp>
-          <sp>
+          <sp who="#timon">
             <speaker>
               <hi rend="sc">TIMON.</hi>
             </speaker>
@@ -932,7 +972,7 @@ de le richezze, come ognuno vede;</l>
             <l>Partiteve in malora, orsù partete,</l>
             <l>se da me sassi in dono non volete.</l>
           </sp>
-          <sp>
+          <sp who="#mercurio">
             <speaker>
               <hi rend="sc">MERCURIO.</hi>
             </speaker>
@@ -945,7 +985,7 @@ de le richezze, come ognuno vede;</l>
             <l>Et io Mercurio son e da te Giove </l>
             <l>ne manda e sopra te sua grazia piove.</l>
           </sp>
-          <sp>
+          <sp who="#timon">
             <speaker>
               <hi rend="sc">TIMON.</hi>
             </speaker>
@@ -958,7 +998,7 @@ de le richezze, come ognuno vede;</l>
             <l>la voglio martelar cum la mia zappa</l>
             <l>e puoco non farà se la mi scappa.</l>
           </sp>
-          <sp>
+          <sp who="#richeza">
             <speaker>
               <hi rend="sc">RICHEZA.</hi>
             </speaker>
@@ -967,7 +1007,7 @@ de le richezze, come ognuno vede;</l>
             <l>ché chi d'un stolto scappa da la mano</l>
             <l>elegie certo un optimo conseglio.</l>
           </sp>
-          <sp>
+          <sp who="#mercurio">
             <speaker>
               <hi rend="sc">MERCURIO.</hi>
             </speaker>
@@ -976,7 +1016,7 @@ de le richezze, come ognuno vede;</l>
             <l>piglia Richeza, fin che averla pòi,</l>
             <l>qual Giove manda a li bisogni toi.</l>
           </sp>
-          <sp>
+          <sp who="#timon">
             <speaker>
               <hi rend="sc">TIMON.</hi>
             </speaker>
@@ -989,7 +1029,7 @@ de le richezze, come ognuno vede;</l>
             <l>ché sol beato è quel che si contenta</l>
             <l>di quel c'ha per sua sorte, ancor ch' el stenta.</l>
           </sp>
-          <sp>
+          <sp who="#mercurio">
             <speaker>
               <hi rend="sc">MERCURIO.</hi>
             </speaker>
@@ -1002,7 +1042,7 @@ de le richezze, come ognuno vede;</l>
             <l>a tua salute fussero contrari</l>
             <l>e gli rifiuti come suchi amari.</l>
           </sp>
-          <sp>
+          <sp who="#timon">
             <speaker>
               <hi rend="sc">TIMON.</hi>
             </speaker>
@@ -1013,14 +1053,14 @@ de le richezze, come ognuno vede;</l>
             <l>e poi che mi son sciolto del suo laccio,</l>
             <l>mai più tornargli son deliberato.</l>
           </sp>
-          <sp>
+          <sp who="#mercurio">
             <speaker>
               <hi rend="sc">MERCURIO.</hi>
             </speaker>
             <l> Deh, dimi, per tua fé, caro Timone</l>
             <l>se non ti spiace, qual è la cagione.</l>
           </sp>
-          <sp>
+          <sp who="#timon">
             <speaker>
               <hi rend="sc">TIMON.</hi>
             </speaker>
@@ -1057,7 +1097,7 @@ de le richezze, come ognuno vede;</l>
             <l>ché l'acqua e 'l pane son più dolci assai</l>
             <l>che giotti cibi misti cum gran guai.</l>
           </sp>
-          <sp>
+          <sp who="#mercurio">
             <speaker>
               <hi rend="sc">MERCURIO.</hi>
             </speaker>
@@ -1068,19 +1108,19 @@ de le richezze, come ognuno vede;</l>
             <l>da poi che cum Richeza a te me invia</l>
             <l>e che soa grazia sopra di te piove.</l>
           </sp>
-          <sp>
+          <sp who="#richeza">
             <speaker>
               <hi rend="sc">RICHEZA.</hi>
             </speaker>
             <l>Timon, te parlarò se non t'è greve.</l>
           </sp>
-          <sp>
+          <sp who="#timon">
             <speaker>
               <hi rend="sc">TIMON.</hi>
             </speaker>
             <l>Parla, o Richeza, e cerca d'esser breve.</l>
           </sp>
-          <sp>
+          <sp who="#richeza">
             <speaker>
               <hi rend="sc">RICHEZA.</hi>
             </speaker>
@@ -1110,7 +1150,7 @@ de le richezze, come ognuno vede;</l>
 di Giove:</l>
             <l>e come a te venir non volsi.</l>
           </sp>
-          <sp>
+          <sp who="#mercurio">
             <speaker>
               <hi rend="sc">MERCURIO.</hi>
             </speaker>
@@ -1123,7 +1163,7 @@ di Giove:</l>
             <l>fa che 'l tesoro in questa parte trove,</l>
             <l>sì come già tu prometesti a Giove.</l>
           </sp>
-          <sp>
+          <sp who="#timon">
             <speaker>
               <hi rend="sc">TIMON.</hi>
             </speaker>
@@ -1136,7 +1176,7 @@ di Giove:</l>
             <l>che se me desti più, non mi bisogna:</l>
             <l>a me faresti danno, a te vergogna.</l>
           </sp>
-          <sp>
+          <sp who="#mercurio">
             <speaker>
               <hi rend="sc">MERCURIO.</hi>
             </speaker>
@@ -1159,7 +1199,7 @@ di Giove:</l>
         </head>
         <div type="scene" n="Scena prima">
           <stage><hi rend="sc">RICHEZA</hi> a <hi rend="sc">TIMON.</hi></stage>
-          <sp>
+          <sp who="#richeza">
             <speaker>
               <hi rend="sc">RICHEZA</hi>
             </speaker>
@@ -1173,7 +1213,7 @@ di Giove:</l>
             <l>Adio Timon, ormai rimane in pace.</l>
           </sp>
           <stage><hi rend="sc">TIMON</hi> cavando cum la zappa trova un tesoro.</stage>
-          <sp>
+          <sp who="#timon">
             <speaker>
               <hi rend="sc">TIMON </hi>
             </speaker>
@@ -1253,7 +1293,7 @@ di Giove:</l>
         </div>
         <div type="scene" n="Scena seconda">
           <stage>In questo instante <hi rend="sc">TIMON</hi> vede venire alcuni uomini dissoluti e dice:</stage>
-          <sp>
+          <sp who="#timon">
             <speaker>
               <hi rend="sc">TIMON</hi>
             </speaker>
@@ -1278,7 +1318,7 @@ saranno a me vicini o drieto o inanti,</l>
         </div>
         <div type="scene" n="Scena terza">
           <stage><hi rend="sc">GNATO</hi> arrivando dove è <hi rend="sc">TIMON</hi> gli dice:</stage>
-          <sp>
+          <sp who="#gnato">
             <speaker>
               <hi rend="sc">GNATO</hi>
             </speaker>
@@ -1289,12 +1329,12 @@ saranno a me vicini o drieto o inanti,</l>
             <l>Idio te salvi, e 'l tuo desir te dia,</l>
             <l>o placido Timon liberalissimo!</l>
           </sp>
-          <sp>
+          <sp who="#timon">
             <speaker><hi rend="sc">TIMON</hi>.</speaker>
             <l>Se' tu quel grande vorator Gnatone</l>
             <l>che manzi roba per dece persone?</l>
           </sp>
-          <sp>
+          <sp who="#gnato">
             <speaker>
               <hi rend="sc">GNATO.</hi>
             </speaker>
@@ -1308,53 +1348,53 @@ saranno a me vicini o drieto o inanti,</l>
             <l>perché tu sai che sempre fui tuo amico.</l>
           </sp>
           <stage><hi rend="sc">TIMON</hi> piglia la zappa e battendolo dice:</stage>
-          <sp>
+          <sp who="#timon">
             <speaker>
               <hi rend="sc">TIMON</hi>
             </speaker>
             <l>Quando t'arò percuosso cum la zappa,</l>
             <l>alor mi canterai la tua canzone!</l>
           </sp>
-          <sp>
+          <sp who="#gnato">
             <speaker>
               <hi rend="sc">GNATO.</hi>
             </speaker>
             <l> Timon tu pur mi dai?</l>
           </sp>
-          <sp>
+          <sp who="#timon">
             <speaker>
               <hi rend="sc">TIMON.</hi>
             </speaker>
             <l>Do su la cappa.</l>
           </sp>
-          <sp>
+          <sp who="#gnato">
             <speaker>
               <hi rend="sc">GNATO.</hi>
             </speaker>
             <l>Anzi mi batti contra ogni ragione.</l>
           </sp>
-          <sp>
+          <sp who="#timon">
             <speaker>
               <hi rend="sc">TIMON.</hi>
             </speaker>
             <l>Se tua persona in le mie mane incappa</l>
             <l>io ti torrò la vita, o vil poltrone!</l>
           </sp>
-          <sp>
+          <sp who="#gnato">
             <speaker>
               <hi rend="sc">GNATO.</hi>
             </speaker>
             <l>Non piacia a Dio! ma sanami 'sta piaga</l>
             <l>perché l'or stringe senza l'arte maga.</l>
           </sp>
-          <sp>
+          <sp who="#timon">
             <speaker>
               <hi rend="sc">TIMON.</hi>
             </speaker>
             <l> Ancor qui meco, o vil gaglioffo, resti?</l>
             <l>E non fai stima de' miei colpi amari?</l>
           </sp>
-          <sp>
+          <sp who="#gnato">
             <speaker>
               <hi rend="sc">GNATO.</hi>
             </speaker>
@@ -1368,7 +1408,7 @@ saranno a me vicini o drieto o inanti,</l>
         </div>
         <div type="scene" n="Scena quarta">
           <stage><hi rend="sc">FILIADE</hi> compare inanti a <hi rend="sc">TIMON</hi>.</stage>
-          <sp>
+          <sp who="#timon">
             <speaker>
               <hi rend="sc">TIMON.</hi>
             </speaker>
@@ -1382,7 +1422,7 @@ saranno a me vicini o drieto o inanti,</l>
             <l>e lui mi dè di pugni, il che non cresi.</l>
           </sp>
           <stage><hi rend="sc">FILIADE</hi> essendo cum <hi rend="sc">TIMON</hi> gli dice:</stage>
-          <sp>
+          <sp who="#filiade">
             <speaker>
               <hi rend="sc">FILIADE</hi>
             </speaker>
@@ -1412,7 +1452,7 @@ saranno a me vicini o drieto o inanti,</l>
             <l>a ciò che 'l tuo non doni al tuo nemico.</l>
           </sp>
           <stage><hi rend="sc">TIMON</hi> battendo <hi rend="sc">FILIADE</hi> cum la zappa gli dice:</stage>
-          <sp>
+          <sp who="#timon">
             <speaker>
               <hi rend="sc">TIMON</hi>
             </speaker>
@@ -1420,7 +1460,7 @@ saranno a me vicini o drieto o inanti,</l>
             <l>che cum la zappa ti vo' far gran festa.</l>
           </sp>
           <stage><hi rend="sc">FILIADE</hi> essendo battuto grida ad alta voce:</stage>
-          <sp>
+          <sp who="#filiade">
             <speaker>
               <hi rend="sc">FILIADE</hi>
             </speaker>
@@ -1441,7 +1481,7 @@ saranno a me vicini o drieto o inanti,</l>
         </head>
         <div type="scene" n="Scena prima">
           <stage><hi rend="sc">TIMON</hi> vedendo <hi rend="sc">DEMEA</hi> venir da longe dice:</stage>
-          <sp>
+          <sp who="#timon">
             <speaker>
               <hi rend="sc">TIMON</hi>
             </speaker>
@@ -1465,7 +1505,7 @@ regnasse in questo tanta sconoscenzia!</l>
         </div>
         <div type="scene" n="Scena seconda">
           <stage><hi rend="sc">DEMEA</hi> giungendo da <hi rend="sc">TiMON</hi> dice:</stage>
-          <sp>
+          <sp who="#demea">
             <speaker>
               <hi rend="sc">DEMEA</hi>
             </speaker>
@@ -1476,7 +1516,7 @@ regnasse in questo tanta sconoscenzia!</l>
             <l>Ascolta quel c'ho scritto in tuo favore.</l>
           </sp>
           <stage><hi rend="sc">DEMEA </hi>legendo una sua scritta che ha in mano dice:</stage>
-          <sp>
+          <sp who="#demea">
             <speaker>
               <hi rend="sc">DEMEA</hi>
             </speaker>
@@ -1484,7 +1524,7 @@ regnasse in questo tanta sconoscenzia!</l>
             <l>Timon ben canta balla salta e corre</l>
             <l>et a luctar è forte come torre.</l>
           </sp>
-          <sp>
+          <sp who="#timon">
             <speaker>
               <hi rend="sc">TIMON.</hi>
             </speaker>
@@ -1497,7 +1537,7 @@ regnasse in questo tanta sconoscenzia!</l>
             <l>ma nel laudarmi t'affatichi in vano</l>
             <l>ch'ogni tuo inganno m'è palese e piano.</l>
           </sp>
-          <sp>
+          <sp who="#demea">
             <speaker>
               <hi rend="sc">DEMEA. </hi>
             </speaker>
@@ -1510,7 +1550,7 @@ regnasse in questo tanta sconoscenzia!</l>
             <l>e ne portasti summo onor e gloria</l>
             <l>per l'ottenuta grande tua victoria.</l>
           </sp>
-          <sp>
+          <sp who="#timon">
             <speaker>
               <hi rend="sc">TIMON. </hi>
             </speaker>
@@ -1519,7 +1559,7 @@ regnasse in questo tanta sconoscenzia!</l>
             <l>ché mai da tempo alcun non portai armi,</l>
             <l>né di portarne ancor già mai intendo!</l>
           </sp>
-          <sp>
+          <sp who="#demea">
             <speaker>
               <hi rend="sc">DEMEA.</hi>
             </speaker>
@@ -1544,13 +1584,13 @@ regnasse in questo tanta sconoscenzia!</l>
             <l>ché certo mi parrebe mancamento</l>
             <l>a far ch'un tanto nome fusse spento.</l>
           </sp>
-          <sp>
+          <sp who="#timon">
             <speaker>
               <hi rend="sc">TIMON. </hi>
             </speaker>
             <l>Come esser può, che mai togliesti moglie?</l>
           </sp>
-          <sp>
+          <sp who="#demea">
             <speaker>
               <hi rend="sc">DEMEA.</hi>
             </speaker>
@@ -1559,7 +1599,7 @@ regnasse in questo tanta sconoscenzia!</l>
             <l>e nome arà Timone senza inganno.</l>
           </sp>
           <stage><hi rend="sc">TIMON</hi> battendo <hi rend="sc">DEMEA</hi> cum la zappa dice:</stage>
-          <sp>
+          <sp who="#timon">
             <speaker>
               <hi rend="sc">TIMON</hi>
             </speaker>
@@ -1569,7 +1609,7 @@ regnasse in questo tanta sconoscenzia!</l>
             <l>cum tua falsa arte; e che non son già bestia.</l>
           </sp>
           <stage><hi rend="sc">DEMEA</hi> essendo battuto dice:</stage>
-          <sp>
+          <sp who="#demea">
             <speaker>
               <hi rend="sc">DEMEA</hi>
             </speaker>
@@ -1581,28 +1621,28 @@ regnasse in questo tanta sconoscenzia!</l>
             <l>perché 'l sacrario già brusasti et anco
 per altri falli.</l>
           </sp>
-          <sp>
+          <sp who="#timon">
             <speaker>
               <hi rend="sc">TIMON.</hi>
             </speaker>
             <l>Non è ver, poltrone!</l>
             <l>Per questo, se ti batto i' n'ho ragione.</l>
           </sp>
-          <sp>
+          <sp who="#demea">
             <speaker>
               <hi rend="sc">DEMEA.</hi>
             </speaker>
             <l> Se ricco fatto sei, fu che robasti</l>
             <l>el luoco sacro dove fu el tesoro!</l>
           </sp>
-          <sp>
+          <sp who="#timon">
             <speaker>
               <hi rend="sc">TIMON.</hi>
             </speaker>
             <l> Integro è quel sacrario, e mal parlasti:</l>
             <l>en tela ragna tesci el tuo lavoro!</l>
           </sp>
-          <sp>
+          <sp who="#demea">
             <speaker>
               <hi rend="sc">DEMEA.</hi>
             </speaker>
@@ -1610,20 +1650,20 @@ per altri falli.</l>
             <l>in quello la tua roba e mal dato oro!</l>
           </sp>
           <stage><hi rend="sc">TIMON</hi> di novo battendolo dice:</stage>
-          <sp>
+          <sp who="#timon">
             <speaker>
               <hi rend="sc">TIMON</hi>
             </speaker>
             <l part="I">To' su quest'altra gnoca.</l>
           </sp>
-          <sp>
+          <sp who="#demea">
             <speaker>
               <hi rend="sc">DEMEA. </hi>
             </speaker>
             <l part="F">Ohimè, le rene!</l>
             <l>Ohi uomo iniquo, a che mi dai tal pene?</l>
           </sp>
-          <sp>
+          <sp who="#timon">
             <speaker>
               <hi rend="sc">TIMON.</hi>
             </speaker>
@@ -1639,7 +1679,7 @@ per altri falli.</l>
         </div>
         <div type="scene" n="Scena terza">
           <stage><hi rend="sc">TIMON</hi> vedendo venir <hi rend="sc">TRASICLE</hi> da longe dice:</stage>
-          <sp>
+          <sp who="#timon">
             <speaker>
               <hi rend="sc">TIMON</hi>
             </speaker>
@@ -1685,7 +1725,7 @@ per altri falli.</l>
             <l>e come uom stupefacto ora ti guardo.</l>
           </sp>
           <stage><hi rend="sc">TRASICLE</hi> giunto da <hi rend="sc">TIMON</hi> gli dice:</stage>
-          <sp>
+          <sp who="#trasicle">
             <speaker>
               <hi rend="sc">TRASICLE</hi>
             </speaker>
@@ -1723,7 +1763,7 @@ per altri falli.</l>
             <l>e che a miseria a gran pena contrasta.</l>
           </sp>
           <stage><hi rend="sc">TIMON</hi> battendo cum pugni e cum la zappa <hi rend="sc">TRASICLE</hi> dice:</stage>
-          <sp>
+          <sp who="#timon">
             <speaker>
               <hi rend="sc">TIMON</hi>
             </speaker>
@@ -1737,7 +1777,7 @@ per altri falli.</l>
             <l>che te piaga de pugni el dover vòle.</l>
           </sp>
           <stage><hi rend="sc">TRASICLE</hi> essendo battuto gridando dice:</stage>
-          <sp>
+          <sp who="#trasicle">
             <speaker>
               <hi rend="sc">TRASICLE</hi>
             </speaker>
@@ -1746,21 +1786,21 @@ per altri falli.</l>
             <l>Venite, prego, a questi gran rumori,</l>
             <l>né consentite che sia distraciato!</l>
           </sp>
-          <sp>
+          <sp who="#timon">
             <speaker>
               <hi rend="sc">TIMON.</hi>
             </speaker>
             <l> Perché ti sdegni, o re d'inganatori?</l>
             <l>Sì come degno sei, t'ho bastonato!</l>
           </sp>
-          <sp>
+          <sp who="#trasicle">
             <speaker>
               <hi rend="sc">TRASICLE.</hi>
             </speaker>
             <l>Se tu mi batterai, Timon insano,</l>
             <l>io ti trarò di quel che averò in mano!</l>
           </sp>
-          <sp>
+          <sp who="#timon">
             <speaker>
               <hi rend="sc">TIMON.</hi>
             </speaker>
@@ -1768,7 +1808,7 @@ per altri falli.</l>
             <l>dartene quatro sopra l'altre avute!</l>
           </sp>
           <stage><hi rend="sc">TIMON</hi> vedendo in questo istante venire alcuni altri dice:</stage>
-          <sp>
+          <sp who="#timon">
             <speaker>
               <hi rend="sc">TIMON</hi>
             </speaker>
@@ -1785,13 +1825,13 @@ per altri falli.</l>
             <l>ch'a mia salute io non voglio altre armi</l>
             <l>finché saciato contra lor mi sia.</l>
           </sp>
-          <sp>
+          <sp who="#brepsias">
             <speaker>
               <hi rend="sc">BREPSIAS.</hi>
             </speaker>
             <l>Non trar Timon, che tutti se n'andiamo!</l>
           </sp>
-          <sp>
+          <sp who="#timon">
             <speaker>
               <hi rend="sc">TIMON.</hi>
             </speaker>
@@ -1808,7 +1848,7 @@ per altri falli.</l>
       </div>
       <div type="epilogue" n="Epilogo">
         <stage><hi rend="sc">EL POETA</hi> parla a li circunstanti.</stage>
-        <sp>
+        <sp who="#el_poeta">
           <speaker>
             <hi rend="sc">EL POETA</hi>
           </speaker>

--- a/tei/dal-carretto-noze-de-psiche-e-cupidine.xml
+++ b/tei/dal-carretto-noze-de-psiche-e-cupidine.xml
@@ -83,6 +83,121 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="cosmo">
+            <persName>Cosmo</persName>
+          </person>
+          <person xml:id="endilizia">
+            <persName>Endilizia</persName>
+          </person>
+          <person xml:id="apollo">
+            <persName>Apollo</persName>
+          </person>
+          <person xml:id="venere">
+            <persName>Venere</persName>
+          </person>
+          <person xml:id="cupido">
+            <persName>Cupido</persName>
+          </person>
+          <person xml:id="un_citadino">
+            <persName>Un Citadino</persName>
+          </person>
+          <person xml:id="psiche">
+            <persName>Psiche</persName>
+          </person>
+          <person xml:id="zefiro">
+            <persName>Zefiro</persName>
+          </person>
+          <personGrp xml:id="coro">
+            <name>Coro</name>
+          </personGrp>
+          <person xml:id="donna">
+            <persName>Donna</persName>
+          </person>
+          <person xml:id="prima_sorella">
+            <persName>La Prima Sorella de Psiche</persName>
+          </person>
+          <person xml:id="seconda_sorella">
+            <persName>La Seconda Sorella de Psiche</persName>
+          </person>
+          <person xml:id="ancille">
+            <persName>Ancille</persName>
+          </person>
+          <person xml:id="pan">
+            <persName>Pan</persName>
+          </person>
+          <person xml:id="el_marito">
+            <persName>El Marito</persName>
+          </person>
+          <person xml:id="ceres">
+            <persName>Ceres</persName>
+          </person>
+          <person xml:id="iunone">
+            <persName>Iunone</persName>
+          </person>
+          <person xml:id="mercurio">
+            <persName>Mercurio</persName>
+          </person>
+          <person xml:id="una_donna">
+            <persName>Una Donna</persName>
+          </person>
+          <person xml:id="consuetudine">
+            <persName>Consuetudine</persName>
+          </person>
+          <person xml:id="tristizia">
+            <persName>Tristizia</persName>
+          </person>
+          <person xml:id="una_formica">
+            <persName>Una Formica</persName>
+          </person>
+          <person xml:id="voce">
+            <persName>Voce</persName>
+          </person>
+          <person xml:id="aquila">
+            <persName>Aquila</persName>
+          </person>
+          <person xml:id="la_torre">
+            <persName>La Torre</persName>
+          </person>
+          <person xml:id="primo_marito">
+            <persName>Marito De La Prima Sorella</persName>
+          </person>
+          <person xml:id="secundo_marito">
+            <persName>Marito De La Secunda Sorella</persName>
+          </person>
+          <person xml:id="giove">
+            <persName>Giove</persName>
+          </person>
+          <person xml:id="vulcano">
+            <persName>Vulcano</persName>
+          </person>
+          <person xml:id="minerva">
+            <persName>Minerva</persName>
+          </person>
+          <person xml:id="baco">
+            <persName>Baco</persName>
+          </person>
+          <person xml:id="marte">
+            <persName>Marte</persName>
+          </person>
+          <person xml:id="febo">
+            <persName>Febo</persName>
+          </person>
+          <person xml:id="el_primo_genero">
+            <persName>El Primo Genero</persName>
+          </person>
+          <person xml:id="la_magior_sorella">
+            <persName>La Magior Sorella</persName>
+          </person>
+          <person xml:id="la_matre">
+            <persName>La Matre</persName>
+          </person>
+          <person xml:id="le_tre_grazie">
+            <persName>Le Tre Grazie</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -234,7 +349,7 @@
       <div>
         <head>ATTO PRIMO</head>
         <stage><hi rend="sc">COSMO</hi> et <hi rend="sc">ENDILIZIA</hi> sua moglie vano a l'oraculo d'<hi rend="sc">APPOLINE</hi> per intender qual fia quello che deve esser marito de <hi rend="sc">PSICHE</hi> sua figlia.</stage>
-        <sp>
+        <sp who="#cosmo">
           <speaker>
             <hi rend="sc">COSMO.</hi>
           </speaker>
@@ -266,7 +381,7 @@
           <l>ne dia consiglio quel che a far abiamo</l>
           <l>di questa figlia che se struge in pianto.</l>
         </sp>
-        <sp>
+        <sp who="#endilizia">
           <speaker>
             <hi rend="sc">ENDILIZIA.</hi>
           </speaker>
@@ -283,7 +398,7 @@
           <l>entriamo donche ne la sacra chiesa</l>
           <l>dove è adorato Apollo e reverito.</l>
         </sp>
-        <sp>
+        <sp who="#cosmo">
           <speaker>
             <hi rend="sc">COSMO.</hi>
           </speaker>
@@ -305,7 +420,7 @@
           <l>e quel che noi debiamo far di lei.—</l>
         </sp>
         <stage>APOLLO non veduto responde a COSMO.</stage>
-        <sp>
+        <sp who="#apollo">
           <speaker>
             <hi rend="sc">APOLLO</hi>
           </speaker>
@@ -319,7 +434,7 @@
           <l>e fuor de' petti uman i spirti invola.</l>
         </sp>
         <stage><hi rend="sc">COSMO</hi>, avendo sentito da l'oracolo d'<hi rend="sc">APOLLINE</hi> la soprascritta risposta, partendosi dice per camino cum <hi rend="sc">ENDELIZIA</hi> sua moglie le infrascritte parolle:</stage>
-        <sp>
+        <sp who="#cosmo">
           <speaker>
             <hi rend="sc">COSMO.</hi>
           </speaker>
@@ -335,7 +450,7 @@
           <l>ma poi che piace al ciel, non li renunzio.</l>
         </sp>
         <stage>Essendo <hi rend="sc">COSMO</hi> partito da l'oracolo cum sua moglie e per camino fatto avendo i soprascripti lamenti, ritorna mesto in cassa et in quello instante compare <hi rend="sc">VENERE</hi> che parla cum <hi rend="sc">CUPIDINE SUO</hi> figlio:</stage>
-        <sp>
+        <sp who="#venere">
           <speaker>
             <hi rend="sc">VENERE.</hi>
           </speaker>
@@ -370,7 +485,7 @@
           <l>fa che costei d'amor fervente acendi</l>
           <l>d'un uom d'extrema sorte al suo paragio.</l>
         </sp>
-        <sp>
+        <sp who="#cupido">
           <speaker>
             <hi rend="sc">CUPIDO.</hi>
           </speaker>
@@ -383,7 +498,7 @@
           <l>ne vederai l'effetto in ben puoche ore.</l>
         </sp>
         <stage>COSMO con sua moglie menano PSICHE sua figliola al destinato scoglio cum li incesi lumi e lacrimosa tromba e sono acompagnati da molti parenti et amici vestiti a bruno, e COSMO dice:</stage>
-        <sp>
+        <sp who="#cosmo">
           <speaker>
             <hi rend="sc">COSMO.</hi>
           </speaker>
@@ -400,7 +515,7 @@
           <l>mi disse che costei fia maritata</l>
           <l>ad un celeste e serpentin consorte.</l>
         </sp>
-        <sp>
+        <sp who="#endilizia">
           <speaker>
             <hi rend="sc">ENDILIZIA.</hi>
           </speaker>
@@ -411,7 +526,7 @@
           <l>vegendo, ohimè, che per divin decreto</l>
           <l>abandonar ne debbi in tempo corto?</l>
         </sp>
-        <sp>
+        <sp who="#un_citadino">
           <speaker>
             <hi rend="sc">UN CITADINO.</hi>
           </speaker>
@@ -419,7 +534,7 @@
           <l>poi che la patria nostra è priva in tuto</l>
           <l>del tuo bel viso d'ogni ben repleto.</l>
         </sp>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
@@ -448,7 +563,7 @@
           <l>d'andar col sposo mio, che per exizio</l>
           <l>de tuto el mondo naque, e per mal mio?</l>
         </sp>
-        <sp>
+        <sp who="#cosmo">
           <speaker>
             <hi rend="sc">COSMO.</hi>
           </speaker>
@@ -456,14 +571,14 @@
           <l>e prego Giove che bon fin te dia,</l>
           <l>e che 'l benigno ciel te sia propizio.</l>
         </sp>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
           <l>Vale, mio patre, e tu, pia matre mia.</l>
         </sp>
         <stage>PSICHE essendo partiti el patre e matre e parenti et amici soi riman sola, e CUPIDO non veduto da lei, mirandola dice egli solo cossi:</stage>
-        <sp>
+        <sp who="#cupido">
           <speaker>
             <hi rend="sc">CUPIDO.</hi>
           </speaker>
@@ -495,7 +610,7 @@
           <l>a pie' del bosco, in quella amena valle</l>
           <l>ove è l'albergo mio, d'angustie casso.</l>
         </sp>
-        <sp>
+        <sp who="#zefiro">
           <speaker>
             <hi rend="sc">ZEFIRO.</hi>
           </speaker>
@@ -503,7 +618,7 @@
           <l>portar la voglio cum tranquillo vento</l>
           <l>al tuo pallazzo bel per dritto calle.</l>
         </sp>
-        <sp>
+        <sp who="#cupido">
           <speaker>
             <hi rend="sc">CUPIDO.</hi>
           </speaker>
@@ -525,7 +640,7 @@
           <l>ma forza fia che 'l sdegno suo padisca.</l>
         </sp>
         <stage>Partito che è <hi rend="sc">CUPIDO</hi>, <hi rend="sc">PSICHE</hi> vien portata da <hi rend="sc">ZEFIRO</hi> nel bel palazzo d'Amore; e nel intrare un <hi rend="sc">CORO</hi> non veduto canta questa canzone. <hi rend="sc">El CORO</hi> canta.</stage>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <hi rend="sc">CORO</hi>
           </speaker>
@@ -564,7 +679,7 @@
           <l>Veni, sposa.</l>
         </sp>
         <stage>Mentre che questo <hi rend="sc">CORO</hi> de donne non vedute canta la soprascripta canzonetta, <hi rend="sc">PSICHE</hi> portata da <hi rend="sc">ZEFIRO</hi> nel pallazo dice tuta admirativa:</stage>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE</hi>
           </speaker>
@@ -579,7 +694,7 @@
           <l>e pur alcuna avanti a me non vene.</l>
         </sp>
         <stage>Una <hi rend="sc">DONNA</hi> non veduta.</stage>
-        <sp>
+        <sp who="#donna">
           <speaker>
             <hi rend="sc">DONNA</hi>
           </speaker>
@@ -599,7 +714,7 @@
           <l>ivi col sposo noi te lassaremo.</l>
         </sp>
         <stage>Finite queste parolle l'uscio par che si serra per sé e <hi rend="sc">PSICHE</hi> rimane sarata in camera, dove si lava, cena e va a dormire e da uno altro canto le due magior sorelle ritrovandosi in casa del mesto patre fano gli soi lamenti cantando la subseguente ode.</stage>
-        <sp>
+        <sp who="#prima_sorella #seconda_sorella">
           <speaker>Le due <hi rend="sc">SORELLE</hi> de <hi rend="sc">PSICHE</hi>.</speaker>
           <l>Patre almo, caro<space dim="horizontal" quantity="20" unit="mm"/> e tu, pia genetrice</l>
           <l>ch'in pianto amaro<space dim="horizontal" quantity="20" unit="mm"/> per la morta Psiche</l>
@@ -627,7 +742,7 @@
           <l>cavette el freno.</l>
         </sp>
         <stage>Finita questa oda la camera del patre ove sone queste due SORELLE si serra et CUPIDO in quello instante essendo in letto cum la sua PSICHE parla cum lei stando però sempre la camera serrata e dicegli cossì:</stage>
-        <sp>
+        <sp who="#cupido">
           <speaker>
             <hi rend="sc">CUPIDO.</hi>
           </speaker>
@@ -644,7 +759,7 @@
           <l>non gli responder, perché mi daresti</l>
           <l>non puoca doglia, e tu n'aresti danno.</l>
         </sp>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
@@ -653,7 +768,7 @@
           <l>per questo non convien ch'in doglia resti.</l>
         </sp>
         <stage>Partito che è <hi rend="sc">CUPIDO</hi>, <hi rend="sc">PSICHE</hi> apre l'uscio e dice lei sola queste parolle:</stage>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
@@ -669,7 +784,7 @@
           <l>che par ch'io perdi la vital virtute.</l>
         </sp>
         <stage><hi rend="sc">PSICHE</hi> torna in la sua camera et serrasi l'uscio et essendo in letto cum <hi rend="sc">CUPIDINE</hi> gli dice così a lei:</stage>
-        <sp>
+        <sp who="#cupido">
           <speaker>
             <hi rend="sc">CUPIDO.</hi>
           </speaker>
@@ -686,7 +801,7 @@
           <l>il qual ti dedi già per tua salute,</l>
           <l>te ne ricordirai cum pentimento.</l>
         </sp>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
@@ -694,7 +809,7 @@
           <l>te prego che 'sta grazia non mi nieghi</l>
           <l>che mie sorelle sian da me vedute.</l>
         </sp>
-        <sp>
+        <sp who="#cupido">
           <speaker>
             <hi rend="sc">CUPIDO.</hi>
           </speaker>
@@ -708,7 +823,7 @@
           <l>seducer non ti lassi in ricercare</l>
           <l>quel ch'io mi sia, che ciò sol cercan loro.</l>
         </sp>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
@@ -722,7 +837,7 @@
           <l>te prego che al tuo Zefiro comande</l>
           <l>che porti mie sorelle in questo nido.</l>
         </sp>
-        <sp>
+        <sp who="#cupido">
           <speaker>
             <hi rend="sc">CUPIDO.</hi>
           </speaker>
@@ -732,7 +847,7 @@
           <l>e fa' che al suo voler non contradice.</l>
         </sp>
         <stage>In questo tempo comparano per strada le due SORELLE de PSICHE quale andando al scoglio dove lei fu destinata dicano questa oda in canto.</stage>
-        <sp>
+        <sp who="#prima_sorella #seconda_sorella">
           <speaker>
             <hi rend="sc">Le SORELLE.</hi>
           </speaker>
@@ -762,7 +877,7 @@
           <l>stan sconsolate!</l>
         </sp>
         <stage><hi rend="sc">PSICHE</hi> esce del pallazo et udendo i queruli ululati e dolente voci de le sorelle sue dice:</stage>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
@@ -776,7 +891,7 @@
           <l>sì come spero ben che tu serai,</l>
           <l>porta le mie sorelle ai lati mei.</l>
         </sp>
-        <sp>
+        <sp who="#zefiro">
           <speaker>
             <hi rend="sc">ZEFIRO.</hi>
           </speaker>
@@ -784,7 +899,7 @@
           <l>come tosto portarò le tue sorelle</l>
           <l>al bel pallazo, dove sola stai.</l>
         </sp>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
@@ -792,7 +907,7 @@
           <l>qui d'abraciarvi e de basarvi ancora,</l>
           <l>contra el voler de le contrarie stelle.</l>
         </sp>
-        <sp>
+        <sp who="#prima_sorella">
           <speaker>
             <hi rend="sc">LA PRIMA SORELLA.</hi>
           </speaker>
@@ -806,7 +921,7 @@
           <l>credendo noi che tu già morta fusti:</l>
           <l>or siamo liete, et altro non respondo.</l>
         </sp>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
@@ -820,7 +935,7 @@
           <l>a questa mia custodia e servitute</l>
           <l>dal mio marito, a cui son data in dono.</l>
         </sp>
-        <sp>
+        <sp who="#seconda_sorella">
           <speaker>
             <hi rend="sc">L'ALTRA SORELLA.</hi>
           </speaker>
@@ -828,7 +943,7 @@
           <l>al tuo servizio, fanno el suo dovere</l>
           <l>ancora che da noi non sian vedute.</l>
         </sp>
-        <sp>
+        <sp who="#prima_sorella">
           <speaker>
             <hi rend="sc">LA PRIMA SORELLA.</hi>
           </speaker>
@@ -836,7 +951,7 @@
           <l>de che condicïone è questo sposo,</l>
           <l>ch'ha questo bel pallazo in suo puotere.</l>
         </sp>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
@@ -850,7 +965,7 @@
           <l>e tu, Zefiro mio, fa che le porti</l>
           <l>a le lor stanze col tuo vol celeste.</l>
         </sp>
-        <sp>
+        <sp who="#seconda_sorella">
           <speaker>
             <hi rend="sc">L'ALTRA SORELLA.</hi>
           </speaker>
@@ -897,7 +1012,7 @@
       <div>
         <head>ATTO SECONDO</head>
         <stage><hi rend="sc">LE DUE SORELLE</hi> portate da <hi rend="sc">ZEFIRO</hi> sul scoglio andando verso la casa del patre dicano per camino tra lor cossì:</stage>
-        <sp>
+        <sp who="#prima_sorella">
           <speaker>
             <hi rend="sc">LA PRIMA SORELLA.</hi>
           </speaker>
@@ -923,7 +1038,7 @@
           <l>questa è felice sopra le felici,</l>
           <l>tal che nel fin di' dei fia eletta al coro.</l>
         </sp>
-        <sp>
+        <sp who="#seconda_sorella">
           <speaker>
             <hi rend="sc">L'ALTRA SORELLA.</hi>
           </speaker>
@@ -937,7 +1052,7 @@
           <l>ch'io lo vorei, e certa son che ognuno</l>
           <l>d'esto vechion più masculo se appella.</l>
         </sp>
-        <sp>
+        <sp who="#prima_sorella">
           <speaker>
             <hi rend="sc">LA PRIMA SORELLA.</hi>
           </speaker>
@@ -957,7 +1072,7 @@
           <l>e tenemi per medica e servente</l>
           <l>e non per moglie sua, già fa tant'anni.</l>
         </sp>
-        <sp>
+        <sp who="#seconda_sorella">
           <speaker>
             <hi rend="sc">L'ALTRA SORELLA.</hi>
           </speaker>
@@ -986,7 +1101,7 @@
           <l>ché quei felici, a li iudìci nostri,</l>
           <l>el cui ben late ad altri, non stimiamo.</l>
         </sp>
-        <sp>
+        <sp who="#prima_sorella">
           <speaker>
             <hi rend="sc">LA PRIMA SORELLA.</hi>
           </speaker>
@@ -994,14 +1109,14 @@
           <l>ma voglio ch'ascondian questi monili</l>
           <l>quando del patre giongeremo ai chiostri.</l>
         </sp>
-        <sp>
+        <sp who="#seconda_sorella">
           <speaker>
             <hi rend="sc">L'ALTRA SORELLA.</hi>
           </speaker>
           <l>Eccoti el patre in quei luochi gentili.</l>
         </sp>
         <stage><hi rend="sc">LE DUE SORELLE</hi> giunte al patre dicono cum queruli canti questa canzoneta.</stage>
-        <sp>
+        <sp who="#prima_sorella #seconda_sorella">
           <speaker>
             <hi rend="sc">LE DUE SORELLE</hi>
           </speaker>
@@ -1019,7 +1134,7 @@
           <l>e lei in alcun canto<space dim="horizontal" quantity="20" unit="mm"/> non troviano.</l>
         </sp>
         <stage><hi rend="sc">PSICHE</hi> essendo in letto col marito ode la sua voce che gli dice queste parolle:</stage>
-        <sp>
+        <sp who="#cupido">
           <speaker>
             <hi rend="sc">CUPIDO.</hi>
           </speaker>
@@ -1051,7 +1166,7 @@
           <l>che tacer debbi, el figlio fia mortale,</l>
           <l>e tu ne resterai col cuor doglioso.</l>
         </sp>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
@@ -1070,7 +1185,7 @@
           <l>ch'ho nel mio corpo tumido e fecundo.</l>
         </sp>
         <stage><hi rend="sc">LE DUE SORELLE</hi> andando al scoglio ove fu lassata <hi rend="sc">PSICHE</hi> dicono per strada fra loro:</stage>
-        <sp>
+        <sp who="#prima_sorella">
           <speaker>
             <hi rend="sc">LA PRIMA SORELLA.</hi>
           </speaker>
@@ -1079,7 +1194,7 @@
           <l>portate ove vogliano</l>
           <l>da Zefir ch'ha 'l suo spirto così leve.</l>
         </sp>
-        <sp>
+        <sp who="#seconda_sorella">
           <speaker>
             <hi rend="sc">L'ALTRA SORELLA.</hi>
           </speaker>
@@ -1088,7 +1203,7 @@
           <l>portarne in tempo breve</l>
           <l>al bel pallazo ove è nostra sorella.</l>
         </sp>
-        <sp>
+        <sp who="#prima_sorella">
           <speaker>
             <hi rend="sc">LA PRIMA.</hi>
           </speaker>
@@ -1097,7 +1212,7 @@
           <l>faremo tanto ch'ella</l>
           <l>ne scoprirà ch'è questo suo marito.</l>
         </sp>
-        <sp>
+        <sp who="#seconda_sorella">
           <speaker>
             <hi rend="sc">L'ALTRA.</hi>
           </speaker>
@@ -1107,7 +1222,7 @@
           <l>cara sorella, mi conforta asai.</l>
         </sp>
         <stage>CUPIDO essendo in letto cum la sua PSICHE gli dice queste parolle e pur non è veduto da lei.</stage>
-        <sp>
+        <sp who="#cupido">
           <speaker>
             <hi rend="sc">CUPIDO.</hi>
           </speaker>
@@ -1127,7 +1242,7 @@
           <l>qual per germane iniustamente apelle,</l>
           <l>lassar non vogli a te venir davante.</l>
         </sp>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
@@ -1147,7 +1262,7 @@
           <l>in questo infante che nel ventre porto:</l>
           <l>poi me contento che lo tuo mi cele.</l>
         </sp>
-        <sp>
+        <sp who="#cupido">
           <speaker>
             <hi rend="sc">CUPIDO.</hi>
           </speaker>
@@ -1157,7 +1272,7 @@
           <l>al bel pallazo per l'usato calle.</l>
         </sp>
         <stage>Partito <hi rend="sc">CUPIDO</hi>, <hi rend="sc">PSICHE</hi> escie de camera e le dite magior <hi rend="sc">SORELLE</hi> portate da <hi rend="sc">ZEFIRO</hi> avanti a lei gli dicano:</stage>
-        <sp>
+        <sp who="#prima_sorella #seconda_sorella">
           <speaker>
             <hi rend="sc">LE DUE SORELLE</hi>
           </speaker>
@@ -1174,7 +1289,7 @@
           <l>el bel figliol che di te nascer deve,</l>
           <l>nel tuo bel ventre el dio d'amor s'asconde.</l>
         </sp>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
@@ -1190,7 +1305,7 @@
           <l>tanto fian dolce le sue melodie;</l>
         </sp>
         <stage>Queste <hi rend="sc">ANCILLE</hi> non vedute cantano la subsequente canzonetta.</stage>
-        <sp>
+        <sp who="#ancille">
           <speaker>
             <hi rend="sc">ANCILLE</hi>
           </speaker>
@@ -1224,7 +1339,7 @@
           <l>fra le belle ha sol l'onore.</l>
         </sp>
         <stage>Finita questa canzoneta le <hi rend="sc">SORELLE</hi> che erano serrate in camera cum <hi rend="sc">PSICHE</hi>, tute de compagnia escono fora et una de loro cioè la magiore dice a <hi rend="sc">PSICHE</hi> così:</stage>
-        <sp>
+        <sp who="#prima_sorella">
           <speaker>
             <hi rend="sc">LA PRIMA SORELLA</hi>
           </speaker>
@@ -1232,7 +1347,7 @@
           <l>piaciati dirne qual è 'l tuo marito</l>
           <l>che vene a dormir teco qui ogni notte.</l>
         </sp>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
@@ -1251,7 +1366,7 @@
           <l>ché 'l tuo presidio al modo usato invoco.</l>
         </sp>
         <stage><hi rend="sc">LE DUE SORELLE</hi> essendo portate in un momento da <hi rend="sc">ZEFIRO</hi> sul scoglio usato dicano tra loro per camino:</stage>
-        <sp>
+        <sp who="#prima_sorella">
           <speaker>
             <hi rend="sc">LA PRIMA.</hi>
           </speaker>
@@ -1262,7 +1377,7 @@
           <l>che 'l sposo suo, qual dianzi giovene era,</l>
           <l>già sia canuto in cossì puoco spazio?</l>
         </sp>
-        <sp>
+        <sp who="#seconda_sorella">
           <speaker>
             <hi rend="sc">L'ALTRA.</hi>
           </speaker>
@@ -1282,14 +1397,14 @@
           <l>che noi torniano da' parenti nostri</l>
           <l>e che gl'impiamo de cordoglio rio.</l>
         </sp>
-        <sp>
+        <sp who="#prima_sorella">
           <speaker>
             <hi rend="sc">LA PRIMA.</hi>
           </speaker>
           <l>Entriamo donche nei paterni chiostri.</l>
         </sp>
         <stage>Essendo giunte queste due <hi rend="sc">SORELLE</hi> dal patre e da la matre, una di loro dice al patre:</stage>
-        <sp>
+        <sp who="#prima_sorella">
           <speaker>
             <hi rend="sc">LA PRIMA.</hi>
           </speaker>
@@ -1302,7 +1417,7 @@
           <l>aciò che piangi nosco l'aspra sorte</l>
           <l>de tua figliuola, ch'è in puoter di morte.</l>
         </sp>
-        <sp>
+        <sp who="#cosmo">
           <speaker>
             <hi rend="sc">COSMO.</hi>
           </speaker>
@@ -1323,7 +1438,7 @@
           <l>a le frequente lacrime demostri:</l>
           <l>da te, scontente, se dipartiremo.</l>
         </sp>
-        <sp>
+        <sp who="#endilizia">
           <speaker>
             <hi rend="sc">ENDILIZIA.</hi>
           </speaker>
@@ -1331,7 +1446,7 @@
           <l>doglie me trista e sconsolata matre.</l>
         </sp>
         <stage><hi rend="sc">LE DUE SORELLE</hi> se parteno e la seconda dice:</stage>
-        <sp>
+        <sp who="#seconda_sorella">
           <speaker>
             <hi rend="sc">LA SECONDA.</hi>
           </speaker>
@@ -1344,7 +1459,7 @@
           <l>ché 'l suo dolor procede da pietate,</l>
           <l>e noi da invidia siamo tormentate.</l>
         </sp>
-        <sp>
+        <sp who="#prima_sorella">
           <speaker>
             <hi rend="sc">LA PRIMA.</hi>
           </speaker>
@@ -1356,14 +1471,14 @@
           <l>facendo fidelmente in noi suo officio.</l>
           <l>Prendine, o Zefir, sopra le tue spalle!</l>
         </sp>
-        <sp>
+        <sp who="#zefiro">
           <speaker>
             <hi rend="sc">ZEFIRO.</hi>
           </speaker>
           <l>Et io vi prendo e portovi in la valle.</l>
         </sp>
         <stage>Essendo queste due sorelle portate da <hi rend="sc">ZEFIRO</hi> ne la vale, apre la porta del pallazo la secunda <hi rend="sc">SORELLA</hi>; nel intrar de la porta dice a l'altra così:</stage>
-        <sp>
+        <sp who="#seconda_sorella">
           <speaker>
             <hi rend="sc">LA SECUNDA.</hi>
           </speaker>
@@ -1401,7 +1516,7 @@
           <l>i tristi amplexi del protervo monstro,</l>
           <l>al modo usato fa che tu el receva.</l>
         </sp>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
@@ -1418,7 +1533,7 @@
           <l>che a me col figliol mio salubre sia</l>
           <l>volgete el mio timor in secur riso.</l>
         </sp>
-        <sp>
+        <sp who="#prima_sorella">
           <speaker>
             <hi rend="sc">LA PRIMA.</hi>
           </speaker>
@@ -1447,7 +1562,7 @@
           <l>noi tornaremo al destinato scoglio</l>
           <l>col tuo suave Zefiro volante.</l>
         </sp>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
@@ -1483,7 +1598,7 @@
           <l>e a occultarla: e qua dentro mi serro.</l>
         </sp>
         <stage><hi rend="sc">PSICHE</hi> serrassi ne la camera, fa quello che ha deliberato de fare et in questo le due magior SORELLE comparano e parlano tra loro.</stage>
-        <sp>
+        <sp who="#prima_sorella">
           <speaker>
             <hi rend="sc">LA PRIMA SORELLA.</hi>
           </speaker>
@@ -1505,7 +1620,7 @@
           <l>che lei sprezzata se consumi in pianto.</l>
         </sp>
         <stage>Finito el secundo atto el <hi rend="sc">CORO</hi> canta questa canzoneta.</stage>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <hi rend="sc">CORO</hi>
           </speaker>
@@ -1543,7 +1658,7 @@
           <foreign xml:lang="lat">TERTIUS ACTUS</foreign>
         </head>
         <stage>Costoro se ascondano e <hi rend="sc">PSICHE</hi> essendo col marito suo in letto, nel dormir che lui fa ella si leva pian piano et apre l'uscio et dice:</stage>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
@@ -1569,7 +1684,7 @@
           <l>così stupisco per sua gran beltade!</l>
         </sp>
         <stage><hi rend="sc">PSICHE</hi> basiando <hi rend="sc">CUPIDO</hi> che dormiva e piegando nel basar la lucerna ch'era accesa e piena d'olio bollente, una gocia calda gli cade su la spalla di esso <hi rend="sc">CUPIDO</hi>, quale scotando lo sveglia e dice cum gran crido:</stage>
-        <sp>
+        <sp who="#cupido">
           <speaker>
             <hi rend="sc">CUPIDO.</hi>
           </speaker>
@@ -1597,7 +1712,7 @@
           <l>conven per doglia se consuma e struga.</l>
         </sp>
         <stage><hi rend="sc">CUPIDO</hi> avendo dito a <hi rend="sc">PSICHE</hi> queste parolle si parte dal arboro e dispare e <hi rend="sc">PSICHE</hi> inamorata lo segue e per camino se imbatte a pié d'un fiume nel qual gitandosi è portato da quello sopra l'acque in l'altra rippa dove è <hi rend="sc">PAN</hi> cum una fistula in mano. Il qual sonando questa infrascripta canzonetta canta a la sua Siringa, mentre che le sue pecori pascano per quel lito.</stage>
-        <sp>
+        <sp who="#pan">
           <speaker>
             <hi rend="sc">PAN</hi>
           </speaker>
@@ -1657,7 +1772,7 @@
           <l>Crudel, fuge, se sai.</l>
         </sp>
         <stage>Finita la canzonetta <hi rend="sc">PAN</hi> vedendo <hi rend="sc">PSICHE</hi> andar errando gli dice (e lei non gli responde):</stage>
-        <sp>
+        <sp who="#pan">
           <speaker>
             <hi rend="sc">PAN.</hi>
           </speaker>
@@ -1671,7 +1786,7 @@
           <l>ma come blando e pieno de libidine.</l>
         </sp>
         <stage><hi rend="sc">PSICHE</hi> non respondendo al dio <hi rend="sc">PAN</hi> gli fa riverenza e vassene per suo camino e dice sola:</stage>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE</hi>
           </speaker>
@@ -1698,7 +1813,7 @@
           <l>ch'Amor la vòl per sua fida amica.</l>
         </sp>
         <stage><hi rend="sc">PSICHE</hi> giunta da la <hi rend="sc">SORELLA</hi> magiore gli dice:</stage>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
@@ -1709,7 +1824,7 @@
           <l>e per nararti le mie angustie e guai</l>
           <l>che per mia sorte porto in cuor coperti.</l>
         </sp>
-        <sp>
+        <sp who="#prima_sorella">
           <speaker>
             <hi rend="sc">LA SORELLA.</hi>
           </speaker>
@@ -1717,7 +1832,7 @@
           <l>e qual è la cagion che qui soletta</l>
           <l>venuta sei, e che facendo vai.</l>
         </sp>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
@@ -1749,7 +1864,7 @@
           <l>a Zefir comandò che mi portasse</l>
           <l>fuor da' confini del suo santo tetto.</l>
         </sp>
-        <sp>
+        <sp who="#prima_sorella">
           <speaker>
             <hi rend="sc">LA SORELLA.</hi>
           </speaker>
@@ -1757,7 +1872,7 @@
           <l>come pòi meglio: e se egli non te vole</l>
           <l>la ragion vòl che in pace stare el lasse.</l>
         </sp>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
@@ -1767,7 +1882,7 @@
           <l>portando in pace questo caso adverso.</l>
         </sp>
         <stage>Partita che è <hi rend="sc">PSICHE</hi> la <hi rend="sc">SORELLA</hi> va tosto dal <hi rend="sc">MARITO</hi> e gli dice:</stage>
-        <sp>
+        <sp who="#prima_sorella">
           <speaker>
             <hi rend="sc">LA SORELLA</hi>
           </speaker>
@@ -1780,7 +1895,7 @@
           <l>che 'l debito ben parmi<space dim="horizontal" quantity="20" unit="mm"/> a far tai pianti,</l>
           <l>quando sarò da mia matre avanti.</l>
         </sp>
-        <sp>
+        <sp who="#el_marito">
           <speaker>
             <hi rend="sc">EL MARITO.</hi>
           </speaker>
@@ -1794,7 +1909,7 @@
           <l>e cum tua matre troppo non sogiorni.</l>
         </sp>
         <stage>La magior <hi rend="sc">SORELLA</hi> dice per camino così:</stage>
-        <sp>
+        <sp who="#prima_sorella">
           <speaker>
             <hi rend="sc">LA SORELLA</hi>
           </speaker>
@@ -1816,7 +1931,7 @@
           <l>al rico, adorno, degno et aureo albergo.</l>
         </sp>
         <stage>Costei precipitandosi giù dal scoglio cum opinione che <hi rend="sc">ZEFIRO</hi> al modo usato la racogli e porti al albergo d'<hi rend="sc">AMORE</hi>, non lo trovando ruina giù al basso e si rompe el collo.</stage>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
@@ -1853,7 +1968,7 @@
           <l>e che volea contratto<space dim="horizontal" quantity="20" unit="mm"/> poi far teco,</l>
           <l>e che giacesti come sposa seco.</l>
         </sp>
-        <sp>
+        <sp who="#seconda_sorella">
           <speaker>
             <hi rend="sc">LA SECONDA SORELLA.</hi>
           </speaker>
@@ -1866,7 +1981,7 @@
           <l>non star qui mesta fuore,<space dim="horizontal" quantity="20" unit="mm"/> orsù vien meco,</l>
           <l>che star dispongo insino a morte teco.</l>
         </sp>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
@@ -1880,7 +1995,7 @@
           <l>di quel che via vola cum sue forte ale.</l>
         </sp>
         <stage>Essendo partita <hi rend="sc">PSICHE</hi>, la seconda <hi rend="sc">SORELLA</hi>, andando al scoglio, dice sola:</stage>
-        <sp>
+        <sp who="#seconda_sorella">
           <speaker>
             <hi rend="sc">LA SECONDA SORELLA</hi>
           </speaker>
@@ -1894,7 +2009,7 @@
           <l>che questa notte fia mio sposo fido.</l>
         </sp>
         <stage>Giongendo costei al scoglio e credendosi esser raccolta da <hi rend="sc">ZEFIRO</hi> se getta giù dal scoglio e cadendo se occide. <hi rend="sc">VENERE</hi> compare e parla lei sola.</stage>
-        <sp>
+        <sp who="#venere">
           <speaker>
             <hi rend="sc">VENERE.</hi>
           </speaker>
@@ -1928,7 +2043,7 @@
           <l>e da indi avanti starà meco sodo.</l>
         </sp>
         <stage><hi rend="sc">VENERE</hi> intra ne la camera d'oro dove era el figliolo infermo e gli dice:</stage>
-        <sp>
+        <sp who="#venere">
           <speaker>
             <hi rend="sc">VENERE.</hi>
           </speaker>
@@ -1986,7 +2101,7 @@
           <l>che già d'unguento pien d'odor fei pingui.</l>
         </sp>
         <stage><hi rend="sc">CERES</hi> compare e diceli et ha cum lei <hi rend="sc">IUNONE.</hi></stage>
-        <sp>
+        <sp who="#ceres">
           <speaker>
             <hi rend="sc">CERES</hi>
           </speaker>
@@ -1994,7 +2109,7 @@
           <l>a far lamenti inusitati e novi</l>
           <l>per questi luochi al regno tuo vicini.</l>
         </sp>
-        <sp>
+        <sp who="#venere">
           <speaker>
             <hi rend="sc">VENERE.</hi>
           </speaker>
@@ -2005,7 +2120,7 @@
           <l>la fabula famosa de mia casa</l>
           <l>né del mio figlio ancor conven ch'io diche.</l>
         </sp>
-        <sp>
+        <sp who="#iunone">
           <speaker>
             <hi rend="sc">IUNONE.</hi>
           </speaker>
@@ -2025,14 +2140,14 @@
           <l>che più te adori e miri tua beltate,</l>
           <l>se stimi che ad amar sia stil vizioso?</l>
         </sp>
-        <sp>
+        <sp who="#venere">
           <speaker>
             <hi rend="sc">VENERE.</hi>
           </speaker>
           <l>Io non vi voglio già per advocate.</l>
         </sp>
         <stage><hi rend="sc">VENERE</hi> irata partesi da costoro le quale ancora loro se ne vanno per un'altra strada et PSICHE in quello instante compare per camino e dice:</stage>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
@@ -2059,7 +2174,7 @@
           <l>le cose sacre, ma cum reverenzia</l>
           <l>esser curate e in luoco degno chiuse.</l>
         </sp>
-        <sp>
+        <sp who="#ceres">
           <speaker>
             <hi rend="sc">CERES.</hi>
           </speaker>
@@ -2070,7 +2185,7 @@
           <l>ti va cercando e ti desidra avere</l>
           <l>per far contra di te vendetta dura.</l>
         </sp>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
@@ -2093,7 +2208,7 @@
           <l>in queste spiche, aciò che fugir possa</l>
           <l>el gran furor di questa dea proterva.</l>
         </sp>
-        <sp>
+        <sp who="#ceres">
           <speaker>
             <hi rend="sc">CERES.</hi>
           </speaker>
@@ -2108,7 +2223,7 @@
           <l>né creder che ciò fazia per nequizia.</l>
         </sp>
         <stage>PSICHE partendo per strada dice così:</stage>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE</hi>
           </speaker>
@@ -2130,7 +2245,7 @@
           <l>abbi pietate a gl'infortuni mei!</l>
         </sp>
         <stage><hi rend="sc">IUNONE</hi> non vista gli risponde:</stage>
-        <sp>
+        <sp who="#iunone">
           <speaker>
             <hi rend="sc">IUNONE</hi>
           </speaker>
@@ -2142,7 +2257,7 @@
           <l>vatene donca, e non voler qui stare.</l>
         </sp>
         <stage><hi rend="sc">PSICHE</hi> partendo dice:</stage>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE</hi>
           </speaker>
@@ -2158,7 +2273,7 @@
           <l>forse ivi fia cullui che 'l ciel mi dede.</l>
         </sp>
         <stage><hi rend="sc">PSICHE</hi> se ne va dentro ad una spelunca dove sta una povera donna da cui è racolta. <hi rend="sc">VENERE</hi> compare insieme cum <hi rend="sc">MERCURIO</hi> al quale dice così:</stage>
-        <sp>
+        <sp who="#venere">
           <speaker>
             <hi rend="sc">VENERE.</hi>
           </speaker>
@@ -2178,14 +2293,14 @@
           <l>Psiche per nome questa ria se chiama:</l>
           <l>ecco el libello ove el suo nome è scrito.</l>
         </sp>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">MERCURIO.</hi>
           </speaker>
           <l>Sorella, exequirò quel che m'hai ditto.</l>
         </sp>
         <stage>Finito el terzo atto el <hi rend="sc">CORO</hi> canta questa canzonetta.</stage>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <hi rend="sc">CORO</hi>
           </speaker>
@@ -2220,7 +2335,7 @@
           <add resp="#ed">ATTO QUARTO</add>
         </head>
         <stage><hi rend="sc">MERCURIO</hi> scorrendo tuto el mondo cum alta voce {dice} per camino:</stage>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">MERCURIO</hi>
           </speaker>
@@ -2234,7 +2349,7 @@
           <l>castigarà collui sì come merta.</l>
         </sp>
         <stage><hi rend="sc">UNA DONNA</hi> dove <hi rend="sc">PSICHE</hi> stava ascosa, sentendo la grida de <hi rend="sc">MERCURIO</hi>, dice a <hi rend="sc">PSICHE</hi>:</stage>
-        <sp>
+        <sp who="#una_donna">
           <speaker>
             <hi rend="sc">UNA DONNA</hi>
           </speaker>
@@ -2248,7 +2363,7 @@
           <l>che più non vo' che tu qui alberghi meco.</l>
         </sp>
         <stage><hi rend="sc">PSICHE</hi> uscendo del speco se incontra in la <hi rend="sc">CONSUETUDINE</hi> qual gli dice:</stage>
-        <sp>
+        <sp who="#consuetudine">
           <speaker>
             <hi rend="sc">CONSUETUDINE.</hi>
           </speaker>
@@ -2262,7 +2377,7 @@
           <l>de la tua audacia qui serai punita.</l>
         </sp>
         <stage>La <hi rend="sc">CONSUETUDINE</hi> piglia <hi rend="sc">PSICHE</hi> per capelli e percottendola la men avanti a <hi rend="sc">VENERE</hi>, la qual facendo un riso sforzato, crollando la testa gli dice:</stage>
-        <sp>
+        <sp who="#venere">
           <speaker>
             <hi rend="sc">VENERE.</hi>
           </speaker>
@@ -2276,7 +2391,7 @@
           <l>punitime costei de sua mallizia.</l>
         </sp>
         <stage>La <hi rend="sc">SOLLICITUDINE</hi> e la <hi rend="sc">TRISTIZIA</hi> menano in casa <hi rend="sc">PSICHE</hi> e la flagelano e <hi rend="sc">VENERE</hi> stando fuora dice sola così:</stage>
-        <sp>
+        <sp who="#venere">
           <speaker>
             <hi rend="sc">VENERE.</hi>
           </speaker>
@@ -2287,7 +2402,7 @@
           <l>e che ha la gloria e la vittoria avuta</l>
           <l>del mio figliol, ch'ha vinto omini e dei.</l>
         </sp>
-        <sp>
+        <sp who="#tristizia">
           <speaker>
             <hi rend="sc">TRISTIZIA.</hi>
           </speaker>
@@ -2295,7 +2410,7 @@
           <l>e avanti al tuo conspetto la meniamo.</l>
         </sp>
         <stage>Avendo la <hi rend="sc">SOLLICITUDINE</hi> e la <hi rend="sc">TRISTIZIA</hi> presentata <hi rend="sc">PSICHE</hi> a <hi rend="sc">VENERE</hi>, dicegli ridendo cum ironia:</stage>
-        <sp>
+        <sp who="#venere">
           <speaker>
             <hi rend="sc">VENERE.</hi>
           </speaker>
@@ -2317,7 +2432,7 @@
           <l>se patirò nel parto esserti pia.</l>
         </sp>
         <stage><hi rend="sc">VENERE</hi> ditte le parole la piglia per capelli e crolandola forte la percuote e pigliando molti grani de furmento et orzo, de miglio, de papavero, de ciceri, de lente e de fabe, quali tuti inseme erano misti, gli dice così:</stage>
-        <sp>
+        <sp who="#venere">
           <speaker>
             <hi rend="sc">VENERE</hi>
           </speaker>
@@ -2331,7 +2446,7 @@
           <l>tute stasera me consignerai.</l>
         </sp>
         <stage><hi rend="sc">VENERE</hi> se parte e <hi rend="sc">PSICHE</hi> tuta stordita se muta e non sa che se fare e una formica a lei presente avendoli pietà, convocate molte formiche gli dice:</stage>
-        <sp>
+        <sp who="#una_formica">
           <speaker>
             <hi rend="sc">UNA FORMICA.</hi>
           </speaker>
@@ -2345,7 +2460,7 @@
           <l>verso costei ch'è unica sua nura.</l>
         </sp>
         <stage>Alora subito comparano molte formiche e discernano tuti quelli grani e <hi rend="sc">VENERE</hi> carica de rose tornando et essendole consignate tute per ordine da <hi rend="sc">PSICHE</hi> gli dice:</stage>
-        <sp>
+        <sp who="#venere">
           <speaker>
             <hi rend="sc">VENERE.</hi>
           </speaker>
@@ -2359,7 +2474,7 @@
           <l>in fin che torni, o giovene scorretta.</l>
         </sp>
         <stage><hi rend="sc">VENERE</hi> se parte e <hi rend="sc">PSICHE</hi> resta et in questo instante <hi rend="sc">CUPIDO</hi> infermo essendo custodito nel cubiculo suo dice solo così:</stage>
-        <sp>
+        <sp who="#cupido">
           <speaker>
             <hi rend="sc">CUPIDO.</hi>
           </speaker>
@@ -2373,7 +2488,7 @@
           <l>qual ha in sue forze tutti i spirti mei.</l>
         </sp>
         <stage><hi rend="sc">VENERE</hi> ritorna dove è <hi rend="sc">PSICHE</hi> e gli dice:</stage>
-        <sp>
+        <sp who="#venere">
           <speaker>
             <hi rend="sc">VENERE.</hi>
           </speaker>
@@ -2388,7 +2503,7 @@
           <l>coi passi toi al ritornar non tardi.</l>
         </sp>
         <stage><hi rend="sc">PSICHE</hi> essendo partita da <hi rend="sc">VENERE</hi> è per precipitare nel fiume e dice:</stage>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE</hi>
           </speaker>
@@ -2397,7 +2512,7 @@
           <l>che a darme morte ria quasi trabocco.</l>
         </sp>
         <stage>Una <hi rend="sc">VOCE</hi> usendo fuora de le canne che sonno atorno a quel fiume gli dice:</stage>
-        <sp>
+        <sp who="#voce">
           <speaker>
             <hi rend="sc">VOCE</hi>
           </speaker>
@@ -2420,7 +2535,7 @@
           <l>le fronde di quel bosco quasserai,</l>
           <l>e cum la lana tornarai contenta.</l>
         </sp>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
@@ -2446,7 +2561,7 @@
           <l>cum l'aureo vello come comandasti,</l>
           <l>qual prego che tu accetti cum cuor bono.</l>
         </sp>
-        <sp>
+        <sp who="#venere">
           <speaker>
             <hi rend="sc">VENERE.</hi>
           </speaker>
@@ -2466,7 +2581,7 @@
           <l>Vatene donche e portami in questa olla</l>
           <l>di quelle aspre acque sopra le tue spalle.</l>
         </sp>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
@@ -2482,7 +2597,7 @@
           <l>ma far dispongo la via cominciata.</l>
         </sp>
         <stage>Una VOCE ch'è ne l'acqua di quel luoco dice:</stage>
-        <sp>
+        <sp who="#voce">
           <speaker>
             <hi rend="sc">VOCE</hi>
           </speaker>
@@ -2492,7 +2607,7 @@
           <l>andando avanti te ne pentirai.</l>
         </sp>
         <stage>Una <hi rend="sc">AQUILA</hi> ariva avanti a <hi rend="sc">PSICHE</hi> per camino e gli dice così:</stage>
-        <sp>
+        <sp who="#aquila">
           <speaker>
             <hi rend="sc">AQUILA</hi>
           </speaker>
@@ -2506,7 +2621,7 @@
           <l>dammi questa olla, e statene secura.</l>
         </sp>
         <stage><hi rend="sc">PSICHE</hi> poi che l'<hi rend="sc">AQUILA</hi> è partita cum l'olla dice:</stage>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE</hi>
           </speaker>
@@ -2520,7 +2635,7 @@
           <l>ecco che ariva l'aquila cum l'olla.</l>
         </sp>
         <stage>L'<hi rend="sc">AQUILA</hi> tornando dice a <hi rend="sc">PSICHE</hi>:</stage>
-        <sp>
+        <sp who="#aquila">
           <speaker>
             <hi rend="sc">AQUILA</hi>
           </speaker>
@@ -2529,7 +2644,7 @@
           <l>portala donche tosto a Cetarea,</l>
           <l>la quel torna da te cum passi presti.</l>
         </sp>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
@@ -2537,20 +2652,20 @@
           <l>meglior soccorso agli mei casi mesti</l>
           <l>quanto fu el tuo, dil che te son tenuta.</l>
         </sp>
-        <sp>
+        <sp who="#aquila">
           <speaker>
             <hi rend="sc">L'AQUILA.</hi>
           </speaker>
           <l>Eccoti Vener: vanne e la saluta.</l>
         </sp>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
           <l>Salve, sublima e veneranda diva,</l>
           <l>i' t'ho portato l'acqua che m'hai chiesta.</l>
         </sp>
-        <sp>
+        <sp who="#venere">
           <speaker>
             <hi rend="sc">VENERE.</hi>
           </speaker>
@@ -2570,7 +2685,7 @@
           <l>Poi, nel ritorno tuo, fa' che non dorme.</l>
         </sp>
         <stage><hi rend="sc">PSICHE</hi> andando per camino col busciolo dice:</stage>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE</hi>
           </speaker>
@@ -2584,7 +2699,7 @@
           <l>la sua indignazion vedi finita.</l>
         </sp>
         <stage><hi rend="sc">PSICHE</hi> giongendo apreso ad una <hi rend="sc">TORRE</hi> sente una voce in quella che gli dice così:</stage>
-        <sp>
+        <sp who="#la_torre">
           <speaker>
             <hi rend="sc">LA TORRE.</hi>
           </speaker>
@@ -2664,7 +2779,7 @@
           <l>d'ogni pericol, non aprir di Venere</l>
           <l>el busciol, ché in gran mal potresti càdere.</l>
         </sp>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
@@ -2677,7 +2792,7 @@
           <l>e vomene al gran regno de Lucifero.</l>
         </sp>
         <stage><hi rend="sc">PSICHE</hi> se ne va verso l'Inferno et in questo tempo compare sopra la sua porta el <hi rend="sc">MARITO</hi> de la prima sorella e ponendosi in camino dice solo:</stage>
-        <sp>
+        <sp who="#primo_marito">
           <speaker>
             <hi rend="sc">MARITO de la prima sorella</hi>
           </speaker>
@@ -2703,7 +2818,7 @@
           <l>che cosa hai tu che tanto el cuor te atrista?</l>
         </sp>
         <stage>El MARITO de la secunda sorella.</stage>
-        <sp>
+        <sp who="#secundo_marito">
           <speaker>
             <hi rend="sc">MARITO de la secunda sorella.</hi>
           </speaker>
@@ -2721,7 +2836,7 @@
           <l>son per morir per troppe angustie e pene.</l>
         </sp>
         <stage/>
-        <sp>
+        <sp who="primo_marito">
           <speaker>
             <hi rend="sc">El MARITO de la prima sorella.</hi>
           </speaker>
@@ -2742,7 +2857,7 @@
           <l>e tosto intender se ella è viva o morta,</l>
           <l>però che lo tardar troppo me importa.</l>
         </sp>
-        <sp>
+        <sp who="primo_marito">
           <speaker>
             <hi rend="sc">EL PRIMO MARITO.</hi>
           </speaker>
@@ -2755,7 +2870,7 @@
           <l>et in un punto spero trovaremo</l>
           <l>le due sorelle, se le cercaremo.</l>
         </sp>
-        <sp>
+        <sp who="secundo_marito">
           <speaker>
             <hi rend="sc">EL SECUNDO MARITO.</hi>
           </speaker>
@@ -2769,7 +2884,7 @@
           <l>vatene avanti, che sarai mia scorta.</l>
         </sp>
         <stage>Intrati questi mariti nel pallazo de <hi rend="sc">COSMO</hi> suo socero, <hi rend="sc">PSICHE</hi> tornando da l'inferno col busciolo chiuso dice sola per camino così.</stage>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
@@ -2804,7 +2919,7 @@
           <l>aciò che ad Amor piacia il bel mio aspetto?</l>
         </sp>
         <stage><hi rend="sc">PSICHE</hi> aprendo el busciolo cade in terra come morta e <hi rend="sc">CUPIDO</hi> essendo guarito et uscendo per una fenestra sopragionge ove è costei, e reponendo nel busciolo el sonno infernale e poi serrandolo, cum la punta d'una sua saetta la percuote e sveglia e dicegli:</stage>
-        <sp>
+        <sp who="#cupido">
           <speaker>
             <hi rend="sc">CUPIDO.</hi>
           </speaker>
@@ -2818,7 +2933,7 @@
           <l>che tosto son per provederti al resto.</l>
         </sp>
         <stage><hi rend="sc">CUPIDO</hi> avendo dato el busciolo a <hi rend="sc">PSICHE</hi> subito se parte senza aspetar risposta e lei rimasa sola dice così:</stage>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE</hi>
           </speaker>
@@ -2839,14 +2954,14 @@
           <l>Ecco che Vener venne: i' vo da quella</l>
           <l>per dargli el dono come mi chiese ella.</l>
         </sp>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
           <l>O dea celeste, i' t'ho portato el dono</l>
           <l>nel busciol, come già tu me chiedesti.</l>
         </sp>
-        <sp>
+        <sp who="#venere">
           <speaker>
             <hi rend="sc">VENERE.</hi>
           </speaker>
@@ -2858,7 +2973,7 @@
           <l>che la mia mente è verso te quïeta.</l>
         </sp>
         <stage>Finito el quarto atto el <hi rend="sc">CORO</hi> canta questa oda.</stage>
-        <sp>
+        <sp who="#coro">
           <speaker>
             <hi rend="sc">CORO</hi>
           </speaker>
@@ -2891,7 +3006,7 @@
       <div>
         <head xml:lang="lat">QUINTUS ACTUS</head>
         <stage><hi rend="sc">CUPIDO</hi> essendo andato in ciel da <hi rend="sc">GIOVE</hi> gli dice così:</stage>
-        <sp>
+        <sp who="#cupido">
           <speaker>
             <hi rend="sc">CUPIDO.</hi>
           </speaker>
@@ -2908,7 +3023,7 @@
           <l>e Vener cassi el conceputo sdegno,</l>
           <l>e 'n matrimonio resti meco unita.</l>
         </sp>
-        <sp>
+        <sp who="#giove">
           <speaker>
             <hi rend="sc">GIOVE.</hi>
           </speaker>
@@ -2934,7 +3049,7 @@
           <l>a tutti i dei, che vengano al concilio</l>
           <l>prima che passi questa alma giornata.</l>
         </sp>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">MERCURIO.</hi>
           </speaker>
@@ -2950,56 +3065,56 @@
           <l>Orsù, venite et affrettate i passi.</l>
         </sp>
         <stage>I dei venendo al concistoro dicano fra loro per camino:</stage>
-        <sp>
+        <sp who="#vulcano">
           <speaker>
             <hi rend="sc">VULCANO.</hi>
           </speaker>
           <l>Che può voler costui</l>
           <l>no 'l so pensar per certo.</l>
         </sp>
-        <sp>
+        <sp who="#venere">
           <speaker>
             <hi rend="sc">VENERE.</hi>
           </speaker>
           <l>Forse che alcun de nui</l>
           <l>fatto ha qualche demerto?</l>
         </sp>
-        <sp>
+        <sp who="#iunone">
           <speaker>
             <hi rend="sc">IUNONE.</hi>
           </speaker>
           <l>Sempre fidel gli fui,</l>
           <l>e mal alcun non merto.</l>
         </sp>
-        <sp>
+        <sp who="#minerva">
           <speaker>
             <hi rend="sc">MINERVA.</hi>
           </speaker>
           <l>Quando saren da lui</l>
           <l>el caso ne fia aperto.</l>
         </sp>
-        <sp>
+        <sp who="#baco">
           <speaker>
             <hi rend="sc">BACO.</hi>
           </speaker>
           <l> Forse che dar ne vòle</l>
           <l>qualche buona novella.</l>
         </sp>
-        <sp>
+        <sp who="#marte">
           <speaker>
             <hi rend="sc">{MARTE}.</hi>
           </speaker>
           <l>Forse che alcun se dole</l>
           <l>de qualche ingiuria fella.</l>
         </sp>
-        <sp>
+        <sp who="#febo">
           <speaker>
             <hi rend="sc">FEBO.</hi>
           </speaker>
           <l>Forse, come far sòle,</l>
           <l>per consultar ne appella.</l>
         </sp>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">MERCURIO.</hi>
           </speaker>
@@ -3007,7 +3122,7 @@
           <l>che Giove è assiso in sella.</l>
         </sp>
         <stage><hi rend="sc">GIOVE</hi> essendo in concistoro cum li dei gli dice avendo <hi rend="sc">CUPIDO</hi> avanti:</stage>
-        <sp>
+        <sp who="#giove">
           <speaker>
             <hi rend="sc">GIOVE</hi>
           </speaker>
@@ -3038,7 +3153,7 @@
           <l>e fa immortal chi beve i liquor soi.</l>
         </sp>
         <stage><hi rend="sc">VENERE</hi> responde a GIOVE:</stage>
-        <sp>
+        <sp who="#venere">
           <speaker>
             <hi rend="sc">VENERE.</hi>
           </speaker>
@@ -3052,7 +3167,7 @@
           <l>e che Mercurio a questo far descendi.</l>
         </sp>
         <stage><hi rend="sc">GIOVE</hi> a <hi rend="sc">MERCURIO</hi>.</stage>
-        <sp>
+        <sp who="#giove">
           <speaker>
             <hi rend="sc">GIOVE</hi>
           </speaker>
@@ -3063,7 +3178,7 @@
           <l>Poi Psiche menerai al bel iocundo</l>
           <l>concistor de la mia celeste corte.</l>
         </sp>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">MERCURIO.</hi>
           </speaker>
@@ -3100,7 +3215,7 @@
           <l>— <foreign xml:lang="lat">Surgite, mortui</foreign>, e drieto a me venite —.</l>
         </sp>
         <stage>Le due <hi rend="sc">SORELLE</hi> saltano in pede e dicano questa oda:</stage>
-        <sp>
+        <sp who="#prima_sorella #seconda_sorella">
           <speaker>
             <hi rend="sc">LE DUE SORELLE</hi>
           </speaker>
@@ -3122,7 +3237,7 @@
           <l>laudiamo asai.</l>
         </sp>
         <stage>Queste due <hi rend="sc">SORELLE</hi> ponendosi in camino cum <hi rend="sc">MERCURIO</hi> se ascondano e in questo tempo <hi rend="sc">COSMO</hi> patre loro esce di casa sua e cum li doi so generi e dice:</stage>
-        <sp>
+        <sp who="#cosmo">
           <speaker>
             <hi rend="sc">COSMO.</hi>
           </speaker>
@@ -3135,7 +3250,7 @@
           <l>ch'in qualche caso extremo<space dim="horizontal" quantity="20" unit="mm"/> non sian giunte,</l>
           <l>o forse ch'ambedue non sian defunte.</l>
         </sp>
-        <sp>
+        <sp who="#el_primo_genero">
           <speaker>
             <hi rend="sc">EL PRIMO GENERO.</hi>
           </speaker>
@@ -3148,7 +3263,7 @@
           <l>a che infelice stato<space dim="horizontal" quantity="20" unit="mm"/> siàn condotti,</l>
           <l>tal che mai non aremo gli ochi asciuti.</l>
         </sp>
-        <sp>
+        <sp who="#cosmo">
           <speaker>
             <hi rend="sc">COSMO.</hi>
           </speaker>
@@ -3170,7 +3285,7 @@
           <l>in gaudi e piacer molti,<space dim="horizontal" quantity="20" unit="mm"/> poi ti vegio.</l>
           <l>Ma dimi i casi toi, che in grazia chiegio.</l>
         </sp>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
@@ -3255,7 +3370,7 @@
           <l>verso la tua cara figliola Psiche.</l>
         </sp>
         <stage>El primo <hi rend="sc">MARITO</hi> avendo inteso queste parolle se volta al cugnato e dicegli:</stage>
-        <sp>
+        <sp who="primo_marito">
           <speaker>
             <hi rend="sc">PRIMO MARITO</hi>
           </speaker>
@@ -3268,7 +3383,7 @@
           <l>Ma lor cum sua malizia<space dim="horizontal" quantity="20" unit="mm"/> e gran peccato</l>
           <l>questo infortunio se hanno comprato.</l>
         </sp>
-        <sp>
+        <sp who="secundo_marito">
           <speaker>
             <hi rend="sc">L'ALTRO MARITO.</hi>
           </speaker>
@@ -3282,7 +3397,7 @@
           <l>patito non arebber tai martiri.</l>
         </sp>
         <stage>In questo tempo ariva <hi rend="sc">MERCURIO</hi> cum le due magior <hi rend="sc">SORELLE</hi> suscitate, e <hi rend="sc">COSMO</hi> vedendole dice:</stage>
-        <sp>
+        <sp who="#cosmo">
           <speaker>
             <hi rend="sc">COSMO.</hi>
           </speaker>
@@ -3296,7 +3411,7 @@
           <l>e par che de venir da noi accenne.</l>
         </sp>
         <stage><hi rend="sc">MERCURIO</hi> giunto cum le due <hi rend="sc">SORELLE</hi> dice a <hi rend="sc">PSICHE</hi>:</stage>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">MERCURIO</hi>
           </speaker>
@@ -3325,7 +3440,7 @@
           <l>tu gli perdoni el già comesso errore</l>
           <l>poi che ti fan de penitenzia segno.</l>
         </sp>
-        <sp>
+        <sp who="#la_magior_sorella">
           <speaker>
             <hi rend="sc">LA MAGIOR SORELLA.</hi>
           </speaker>
@@ -3336,7 +3451,7 @@
           <l>nostra non guardi, ma ne dii perdono,</l>
           <l>e da indi avanti tu ne sii propizia.</l>
         </sp>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
@@ -3359,7 +3474,7 @@
           <l>che me ne vado al trïunfante coro</l>
           <l>de la corte superna e glorïosa.</l>
         </sp>
-        <sp>
+        <sp who="#cosmo">
           <speaker>
             <hi rend="sc">COSMO.</hi>
           </speaker>
@@ -3370,14 +3485,14 @@
           <l>vedendoti salir a l'alta gloria,</l>
           <l>e che ogni tuo travaglio sia perfetto.</l>
         </sp>
-        <sp>
+        <sp who="#la_matre">
           <speaker>
             <hi rend="sc">LA MATRE.</hi>
           </speaker>
           <l>Vatene in pace, et abbine in memoria.</l>
         </sp>
         <stage>Partendo <hi rend="sc">PSICHE</hi> cum <hi rend="sc">MERCURIO</hi>, <hi rend="sc">COSMO</hi> dice:</stage>
-        <sp>
+        <sp who="#cosmo">
           <speaker>
             <hi rend="sc">COSMO</hi>
           </speaker>
@@ -3390,7 +3505,7 @@
           <l>Voi, mie figliole, andate<space dim="horizontal" quantity="20" unit="mm"/> ai cari chiostri</l>
           <l>de vostre patrie coi mariti vostri.</l>
         </sp>
-        <sp>
+        <sp who="#prima_sorella">
           <speaker>
             <hi rend="sc">LA PRIMA SORELLA.</hi>
           </speaker>
@@ -3404,7 +3519,7 @@
           <l>che ai nostri alberghi noi torniamo liete.</l>
         </sp>
         <stage><hi rend="sc">MERCURIO</hi> essendo giunto da <hi rend="sc">GIOVE</hi> cum <hi rend="sc">PSICHE</hi> dice così:</stage>
-        <sp>
+        <sp who="#mercurio">
           <speaker>
             <hi rend="sc">MERCURIO</hi>
           </speaker>
@@ -3418,7 +3533,7 @@
           <l>che queste cose asai vi son palese.</l>
         </sp>
         <stage><hi rend="sc">GIOVE</hi> pigliando <hi rend="sc">PSICHE</hi> per mano e facendoli porgere la bevanda celeste gli dice:</stage>
-        <sp>
+        <sp who="#giove">
           <speaker>
             <hi rend="sc">GIOVE.</hi>
           </speaker>
@@ -3439,7 +3554,7 @@
           <l>E tu, mio Apollo, che mi stai qui avanti,</l>
           <l>fa' che in la lira tu qui sòni e canti.</l>
         </sp>
-        <sp>
+        <sp who="#cupido">
           <speaker>
             <hi rend="sc">CUPIDO.</hi>
           </speaker>
@@ -3450,7 +3565,7 @@
           <l>però che in grandi affanni già vivea</l>
           <l>per star da sua beltà longi e distante.</l>
         </sp>
-        <sp>
+        <sp who="#psiche">
           <speaker>
             <hi rend="sc">PSICHE.</hi>
           </speaker>
@@ -3458,7 +3573,7 @@
           <l>e di tal grazia gran merzé vi dico.</l>
         </sp>
         <stage><hi rend="sc">APOLLO</hi> cum la lira canta avanti a <hi rend="sc">GIOVE</hi> e agli altri dei questo capitulo.</stage>
-        <sp>
+        <sp who="#apollo">
           <speaker>
             <hi rend="sc">APOLLO.</hi>
           </speaker>
@@ -3510,7 +3625,7 @@
           <l>che nascerà de voi la Voluptate.</l>
         </sp>
         <stage>Le tre <hi rend="sc">GRAZIE</hi> cantano questa canzonetta in laude del sancto matrimonio.</stage>
-        <sp>
+        <sp who="#le_tre_grazie">
           <speaker>
             <hi rend="sc">LE TRE GRAZIE</hi>
           </speaker>

--- a/tei/de-dottori-aristodemo.xml
+++ b/tei/de-dottori-aristodemo.xml
@@ -74,6 +74,46 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="aristodemo">
+            <persName>Aristodemo</persName>
+          </person>
+          <person xml:id="amfia">
+            <persName>Amfia</persName>
+          </person>
+          <person xml:id="policare">
+            <persName>Policare</persName>
+          </person>
+          <person xml:id="merope">
+            <persName>Merope</persName>
+          </person>
+          <person xml:id="tisi">
+            <persName>Tisi</persName>
+          </person>
+          <person xml:id="messo">
+            <persName>Messo</persName>
+          </person>
+          <person xml:id="nutrice">
+            <persName>Nutrice</persName>
+          </person>
+          <person xml:id="soldato">
+            <persName>Soldato</persName>
+          </person>
+          <personGrp xml:id="coro">
+            <name>Coro</name>
+          </personGrp>
+          <person xml:id="ofioneo">
+            <persName>Ofioneo</persName>
+          </person>
+          <person xml:id="licisco">
+            <persName>Licisco</persName>
+          </person>
+          <person xml:id="erasitea">
+            <persName>Erasitea</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -101,15 +141,11 @@
         <castItem type="role">
           <role>NUTRICE</role>
         </castItem>
-        <castItem type="role">
-          <role>OFIONEO</role>, <roleDesc>sacerdote</roleDesc>
-        </castItem>
+        <castItem type="role"><role>OFIONEO</role>, <roleDesc>sacerdote</roleDesc></castItem>
         <castItem type="role">
           <role>LICISCO</role>
         </castItem>
-        <castItem type="role">
-          <role>ERASITEA</role>, <roleDesc>sacerdotessa</roleDesc>
-        </castItem>
+        <castItem type="role"><role>ERASITEA</role>, <roleDesc>sacerdotessa</roleDesc></castItem>
         <castItem type="role">
           <role>TISI</role>
         </castItem>
@@ -136,7 +172,7 @@
         <div type="scene">
           <head>SCENA I </head>
           <stage>ARISTODEMO, AMFIA.</stage>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>Tanto piangesti tu, tanto io pregai,</l>
@@ -148,7 +184,7 @@
               <l>e, s'a noi tocca, di Messenia al regno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>Lagrime avventurose,</l>
@@ -163,7 +199,7 @@
               <l>Merope mia vi tesserà corone?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>Ma sia privato il sacrifizio, Amfia;</l>
@@ -177,14 +213,14 @@
               <l>dell'oppresso mestissimo Licisco,</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>Così farò né perché meco esulti,</l>
               <l>resto di pianger con Licisco il caso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>È generosa questa,</l>
@@ -194,14 +230,14 @@
               <l>il sangue degli Epitidi all'altare.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>Ma che fia, s'egli niega</l>
               <l>d'esser padre d'Arena?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>                                      Uopo è di prova</l>
@@ -215,27 +251,27 @@
               <l>men fede che pietà trova in Itome.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>Pur se frode non fosse?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>                                      Aristodemo</l>
               <l>daria la propria.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>                         Oimé, signor, d'Arena,</l>
               <l>non di Merope nostra, uscito è 'l nome.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>Dunque è vittima Arena; e invan Licisco</l>
@@ -243,7 +279,7 @@
               <l>ed inganna la terra.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>Per lo tuo genio grande, e per le sacre</l>
@@ -254,28 +290,28 @@
               <l>Merope al sacerdote.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>E tu non creder più ch'altri ch'Arena</l>
               <l>sia la vittima eletta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>                                È degno certo</l>
               <l>il timor di perdono in donna e madre.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>Ma non soverchio in donna illustre, e moglie</l>
               <l>d'Aristodemo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>                        È così fiero il moto</l>
@@ -290,7 +326,7 @@
               <l>di rimettersi in calma.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>                                     A te sen viene</l>
@@ -304,7 +340,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>POLICARE, AMFIA.</stage>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>O giorno per me candido e sereno,</l>
@@ -330,7 +366,7 @@
               <l>rispetto di fortuna?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>Policare, diverso</l>
@@ -341,7 +377,7 @@
               <l>della noia il contento.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>Non mi cape nel seno</l>
@@ -367,7 +403,7 @@
               <l>spuma sul margo e quasi il margo affonda.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>Necessaria altrettanto</l>
@@ -380,7 +416,7 @@
               <l>ne bea mal nota o peregrina fede.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>Qual reliquia di tema</l>
@@ -388,7 +424,7 @@
               <l>Arena al sacrificio?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>                                  O che sien queste</l>
@@ -410,7 +446,7 @@
               <l>io parlo di Licisco.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>O generosa Amfia, non osa ancora</l>
@@ -431,7 +467,7 @@
               <l>che ministra di lui ne trasse il nome?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>Oh quanto di conforto,</l>
@@ -448,32 +484,32 @@
               <l>fatto dal suo pericolo e più caro.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>Candida Giuno, vieni!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>Vieni e tu, Citerea!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>                                Merope torni</l>
               <l>dal rogo mesto alle felici tede.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>Merope torni dal sepolcro al letto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>E se Arena in sua vece</l>
@@ -483,7 +519,7 @@
               <l>la stirpe degli Epitidi in Itome.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>Io stessa della patria, e di noi degne</l>
@@ -513,7 +549,7 @@
               <l>sì che le purghi in un sol punto Arena.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>Pace resti alla Grecia, a voi lo scettro</l>
@@ -529,7 +565,7 @@
               <l>Merope fortunata ogni fortuna.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>Quella, di cui si parla, ecco sen viene.</l>
@@ -542,7 +578,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>POLICARE, MEROPE.</stage>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>E doveasi con tanto</l>
@@ -556,7 +592,7 @@
               <l>dall'arbitrio superbo di Fortuna?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Policare, s'io vivo,</l>
@@ -568,7 +604,7 @@
               <l>la vita, quanto è tua.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>                                 Se non fu sordo</l>
@@ -592,7 +628,7 @@
               <l>d'una fiamma dolcissima m'ingombra.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Forse che sembra lume</l>
@@ -607,7 +643,7 @@
               <l>il suo lume col dì.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>                             Fu sempre lume</l>
@@ -615,7 +651,7 @@
               <l>i' n'arsi, e n'arderò.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>                                  Ma non potrebbe</l>
@@ -623,19 +659,19 @@
               <l>foco nel sen. Dunque la fiamma è pari.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>Dunque la nutra un sempre fido amore.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>E con quella del rogo alfin s'unisca.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>E 'l cener nostro una sol'urna accolga.</l>
@@ -643,13 +679,13 @@
               <l>e taciturno il venerabil Tisi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Resta, io ti lascio a lui.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>                                     Parti, io l'incontro.</l>
@@ -663,7 +699,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>POLICARE, TISI.</stage>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>Saggio Tisi, che porti, e donde vieni?</l>
@@ -672,7 +708,7 @@
               <l>tacitamente ne discorri.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tisi">
             <speaker>TISI</speaker>
             <lg>
               <l>                                      È certo</l>
@@ -696,7 +732,7 @@
               <l>ha, prima di morir, lasciato erede.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>Ma se il fato d'Arena è il fin de' mali,</l>
@@ -705,7 +741,7 @@
               <l>di lagrime dovute; e poi si speri.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tisi">
             <speaker>TISI</speaker>
             <lg>
               <l>Certo non ha mai più veduto Itome</l>
@@ -716,14 +752,14 @@
               <l>ma in sé non ha prodigio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>                                          Ultimo forse</l>
               <l>ei sarà de' flagelli.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tisi">
             <speaker>TISI</speaker>
             <lg>
               <l>                                Ultima pena</l>
@@ -736,7 +772,7 @@
               <l>e compri dalle Furie ignobil pace.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>I suo' segreti il Fato</l>
@@ -748,7 +784,7 @@
               <l>che i propri tempii folgorando abbatte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tisi">
             <speaker>TISI</speaker>
             <lg>
               <l>Può ben esser occulta</l>
@@ -921,7 +957,7 @@
               <l>lassù di Giove ad aspetarne il fine.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>Gran cose ascolto. Io, quando ardì Panormo</l>
@@ -934,7 +970,7 @@
               <l>del nostro mal fu de' garzoni il fallo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tisi">
             <speaker>TISI</speaker>
             <lg>
               <l>Spesso un misfatto prospero e felice</l>
@@ -946,27 +982,27 @@
               <l>delitto, del commesso assai maggiore.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>Ma di Licisco?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tisi">
             <speaker>TISI</speaker>
             <lg>
               <l>                          O trovar deve il padre</l>
               <l>d'Arena, o consegnarla.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>                                         E se trovasse</l>
               <l>il genitor?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tisi">
             <speaker>TISI</speaker>
             <lg>
               <l>                 Ritorna</l>
@@ -978,14 +1014,14 @@
               <l>se vanno esenti le bambine.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>                                              O santi</l>
               <l>numi del ciel, no 'l consentite!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tisi">
             <speaker>TISI</speaker>
             <lg>
               <l>                                                  Alfine</l>
@@ -996,7 +1032,7 @@
               <l>ed attonito vien?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>                            Messo è di corte.</l>
@@ -1006,7 +1042,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>MESSO, POLICARE, TISI.</stage>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <lg>
               <l>I tutelari patrii numi e Giove</l>
@@ -1019,7 +1055,7 @@
               <l>di titoli e di regno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tisi">
             <speaker>TISI</speaker>
             <lg>
               <l>                                O tu, che mostri</l>
@@ -1028,31 +1064,31 @@
               <l>Nunzio di che?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <lg>
               <l>                         D'insoliti accidenti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>Eletto è 'l re?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <lg>
               <l>                      Non anco.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tisi">
             <speaker>TISI</speaker>
             <lg>
               <l>                                          E chi succede?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <lg>
               <l>Aristodemo ha tutto</l>
@@ -1062,44 +1098,44 @@
               <l>ch'alla Messenia il re.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>                                      Fu scelta Arena.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <lg>
               <l>Scelta, ma non presente.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>                                        Oh Dio! Licisco?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <lg>
               <l>Fuggito è seco.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tisi">
             <speaker>TISI</speaker>
             <lg>
               <l>                          Oh stravaganza!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>                                                      I' temo</l>
               <l>qualche sciagura orribile.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <lg>
               <l>                                          Licisco,</l>
@@ -1114,13 +1150,13 @@
               <l>nell'esequie del re.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>                                Tradita è Itome.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <lg>
               <l>Pur fu chi sospettò, chi lo riferse;</l>
@@ -1130,7 +1166,7 @@
               <l>il suo delitto e 'l comun danno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>                                                   O crudo</l>
@@ -1144,7 +1180,7 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>NUTRICE, MEROPE.</stage>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>Figlia e signora, è vero:</l>
@@ -1172,7 +1208,7 @@
               <l>di lieto cor l'alta ventura incontri?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Nulla osservi, o Nutrice,</l>
@@ -1193,7 +1229,7 @@
               <l>moderarmi d'Arena.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>Ma non merta una vita</l>
@@ -1202,7 +1238,7 @@
               <l>e più severo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>                      Il dono</l>
@@ -1216,7 +1252,7 @@
               <l>maggior dell'altre alle tenarie vie.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>Figlia, termina il fasto</l>
@@ -1224,7 +1260,7 @@
               <l>a insuperbir fra i morti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>                                        Il merto ha premi</l>
@@ -1234,7 +1270,7 @@
               <l>grande anco un'ombra.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>                                      Ombra quantunque grande</l>
@@ -1250,7 +1286,7 @@
               <l>di seno alcun de' tuo' riguardi alteri.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Generoso è Policare, e non chiede</l>
@@ -1258,7 +1294,7 @@
               <l>prove dell'amor mio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>                                    Par che tu abusi</l>
@@ -1269,7 +1305,7 @@
               <l>e 'l piacer della vita?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>                                    Io non ricuso</l>
@@ -1280,7 +1316,7 @@
               <l>e men lieta, e men avida, l'incontro.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>Il passato timor non t'assicura.</l>
@@ -1291,7 +1327,7 @@
               <l>a te lo sposo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>                       A me lo sposo. Or questa</l>
@@ -1308,21 +1344,21 @@
               <l>in cui tutta apparia, quant'è, la morte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>E in questo solo acquisto</l>
               <l>bella t'apparirà, com'è, la vita.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Di Policare sono,</l>
               <l>a lui vivrò.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>                    Vivrai, nobile dono</l>
@@ -1334,7 +1370,7 @@
         <div type="scene">
           <head>SCENA VII</head>
           <stage>ARISTODEMO, SOLDATO.</stage>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>O troppo nel donar facili dèi,</l>
@@ -1363,7 +1399,7 @@
               <l>e natura comanda?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#soldato">
             <speaker>SOLDATO</speaker>
             <lg>
               <l>                                 È già in procinto</l>
@@ -1374,7 +1410,7 @@
               <l>qualor tu 'l chieda.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>                                Ite, allentate i freni,</l>
@@ -1392,7 +1428,7 @@
               <l>spargete incensi e cominciate il canto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Mentre salgono al ciel fumi odorati,</l>
@@ -1479,7 +1515,7 @@
         <div type="scene">
           <head>SCENA I </head>
           <stage>AMFIA, NUTRICE.</stage>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>Nulla più di speranza</l>
@@ -1490,21 +1526,21 @@
               <l>cura d'alcun di lor.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>                                Febo non mente:</l>
               <l>indarno ella fuggì.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>                               Pur fugge, e resta</l>
               <l>Merope mia di nuovo esposta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>                                                  Il Cielo</l>
@@ -1512,76 +1548,76 @@
               <l>è la vittima eletta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>                             E chi del Cielo</l>
               <l>gli arcani intende e può saper le vie?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>Parlò in Delfo abbastanza.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>                                           Io non l'intendo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>Febo s'espresse ben.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>                                    Non disse Arena.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>Disse un'eletta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>                          Epitida v'aggiunse.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>Di che temi o gran donna?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>                                              Dell'incerte</l>
               <l>vie di fortuna e dell'ingegno umano.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>La tema è figlia del tu' amor.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>                                                 La tema</l>
               <l>nel dubbio è un infelice augure muto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>Ma spesso vano. Or quai prodigi osservi?</l>
@@ -1595,7 +1631,7 @@
               <l>e la sposa a Policare; e tu temi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>Voce notturna, vocal marmo o tronco</l>
@@ -1639,7 +1675,7 @@
               <l>cagione ho di temer.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>                                  Non te lo niego;</l>
@@ -1647,14 +1683,14 @@
               <l>da geloso timor troppo osservate.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>Pur attonito stava il sacerdote,</l>
               <l>e le temeva.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>                      Spesse volte al caso</l>
@@ -1670,7 +1706,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>AMFIA, SOLDATO, NUTRICE, TISI in disparte.</stage>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>Ferma i passi, o guerrier, narrami quanto</l>
@@ -1678,7 +1714,7 @@
               <l>nel seguitar Licisco.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#soldato">
             <speaker>SOLDATO</speaker>
             <lg>
               <l>                                   O donna eccelsa,</l>
@@ -1732,14 +1768,14 @@
               <l>torniam dolenti ad avvisarne Itome.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>Ecco certi i prodigi,</l>
               <l>ecco i segni veraci.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>                                Ah dèi, che sento?</l>
@@ -1749,7 +1785,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>TISI</stage>
-          <sp>
+          <sp who="#tisi">
             <speaker>TISI</speaker>
             <lg>
               <l>Non sol fuggita, ma perduta è dunque</l>
@@ -1801,7 +1837,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>ARISTODEMO, AMFIA <emph>in disparte</emph>.</stage>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>Hai vinto, Sparta, hai vinto:</l>
@@ -1852,7 +1888,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>AMFIA, ARISTODEMO, TISI <emph>in fine</emph>. </stage>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>Fra i Messenii io pur sono</l>
@@ -1881,7 +1917,7 @@
               <l>gli dèi saranno e soddisfatto Averno?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>Donna, né a te s'aspetta</l>
@@ -1900,7 +1936,7 @@
               <l>volar eterno alle venture etadi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>E pur è ver! Determinato è questo</l>
@@ -1923,7 +1959,7 @@
               <l>moglie e madre dolente?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>                                         Ad altro tempo</l>
@@ -1935,7 +1971,7 @@
               <l>di duello scettro a che m'acclama Itome.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>Vorran questa i Messenii</l>
@@ -1957,7 +1993,7 @@
               <l>al padre ambizioso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>                                  Io non pretendo</l>
@@ -1967,55 +2003,55 @@
               <l>più che la figlia mia la patria e 'l nome.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>Gran parte sono della patria i figli.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>E dansi per la patria.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>Dansi lecitamente.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>Non è lecito sol, ma degno il caso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>Il caso ha scelto Arena.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>Ed il caso l'ha tolta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>Chi chiede il sacrifizio, il caso o Febo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>Certo, il delfico nume.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>Or a lui s'obbedisca e torni il nome</l>
@@ -2024,7 +2060,7 @@
               <l>di ritentarla.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>                      Invidiata è questa</l>
@@ -2038,7 +2074,7 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>TISI, ARISTODEMO, AMFIA.</stage>
-          <sp>
+          <sp who="#tisi">
             <speaker>TISI</speaker>
             <lg>
               <l>Non basta all'avid'Orco</l>
@@ -2050,13 +2086,13 @@
               <l>poco goder la crudeltà d'Averno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>E chi l'afferma?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tisi">
             <speaker>TISI</speaker>
             <lg>
               <l>                             Ofioneo. Di Febo</l>
@@ -2064,7 +2100,7 @@
               <l>la delfica risposta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>                              Egli ci forma</l>
@@ -2072,14 +2108,14 @@
               <l>perché non si ritorna?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tisi">
             <speaker>TISI</speaker>
             <lg>
               <l>Tanto commercio non abbiam col cielo,</l>
               <l>ch'a voglia nostra ei parli.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>O Tisi, o sempre</l>
@@ -2088,7 +2124,7 @@
               <l>misere mie speranze.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tisi">
             <speaker>TISI</speaker>
             <lg>
               <l>                                   Amfia, mi duole</l>
@@ -2097,7 +2133,7 @@
               <l>richiesto parlo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>                          O misera! E mi serba</l>
@@ -2118,7 +2154,7 @@
               <l>dal padre suo, preparerò la via.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>Necessità di Fato,</l>
@@ -2147,7 +2183,7 @@
         <div type="scene">
           <head>SCENA VII</head>
           <stage>AMFIA, TISI.</stage>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>Udite strana legge,</l>
@@ -2166,21 +2202,21 @@
               <l>ma non la morte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tisi">
             <speaker>TISI</speaker>
             <lg>
               <l>Non è virtù temer la vita, Amfia,</l>
               <l>ma l'ostare ai gran mali.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>                                         È lieve il duolo</l>
               <l>capace di consiglio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tisi">
             <speaker>TISI</speaker>
             <lg>
               <l>                                  I proprii casi,</l>
@@ -2192,7 +2228,7 @@
               <l>dall'atteso prepara.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>                                 Ov'è Fortuna?</l>
@@ -2200,7 +2236,7 @@
               <l>ei condanna la figlia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tisi">
             <speaker>TISI</speaker>
             <lg>
               <l>                                    E la Fortuna,</l>
@@ -2209,7 +2245,7 @@
               <l>sulla vittima il colpo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>                                    Ah, moribonde</l>
@@ -2219,7 +2255,7 @@
               <l>della madre ho disposto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tisi">
             <speaker>TISI</speaker>
             <lg>
               <l>Furiosa ella parte. Oh qual feroce</l>
@@ -2230,7 +2266,7 @@
               <l>cura o pietà della Messenia almeno!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>O sapienza eterna di natura,</l>
@@ -2319,7 +2355,7 @@
         <div type="scene">
           <head>SCENA I </head>
           <stage>ARISTODEMO, CORO <emph>de' Messenii</emph>.</stage>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>Poiché del sangue nostro Averno ha sete,</l>
@@ -2350,7 +2386,7 @@
               <l>la cupidigia dell'ingordo Abisso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>O d'Alcide e d'Epito inclita prole,</l>
@@ -2363,7 +2399,7 @@
               <l>sempre del merto tuo minor mercede.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>S'avvisi Ofioneo, s'erga l'altare,</l>
@@ -2373,7 +2409,7 @@
               <l>imputato a fiacchezza.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>È sublime vittoria e gloriosa</l>
@@ -2387,7 +2423,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>POLICARE, CORO <emph>de' Messenii</emph>.</stage>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>Poiché fuggì l'usurpator Licisco</l>
@@ -2413,32 +2449,32 @@
               <l>si ricovrò tra le spartane genti?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Un padre generoso offre la figlia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>Cleone o Dami?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>                           Aristodemo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>                                                 Oh Dio!</l>
               <l>Chi divolga l'offerta?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>                                      Il padre appunto,</l>
@@ -2447,7 +2483,7 @@
               <l>di sacrifizio tal degno apparato.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>Scota Nettun la terra,</l>
@@ -2460,7 +2496,7 @@
               <l>sacrificar si deve ostia sì grande.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Ei da sé stesso</l>
@@ -2469,7 +2505,7 @@
               <l>Segni d'affanno immenso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>Merope è sola forse</l>
@@ -2478,7 +2514,7 @@
               <l>condannata è dal padre?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Ella è sol atta al sacrifizio, a cui</l>
@@ -2490,70 +2526,70 @@
               <l>né contamina il don con bassi affetti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>E lo permette Amfia?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>                                     Perch'è costretta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>E l'approva Messenia?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>                                      Altra non resta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>E non si cerca Arena?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>                                     Ella è fuggita.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>Non si toglie al nemico?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>                                         Ah, di salute</l>
               <l>trattasi qui, non di ruina.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>                                         In lei</l>
               <l>la salute consiste.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>                               E per lei forse</l>
               <l>perirebbesi indarno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>                                 Or vanne, e trova</l>
@@ -2562,14 +2598,14 @@
               <l>Non perirà.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>                      Giovane audace, frena</l>
               <l>l'impeto del dolor.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>                                 Prima quel colpo</l>
@@ -2607,7 +2643,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>MEROPE, POLICARE.</stage>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Policare, vicino</l>
@@ -2640,7 +2676,7 @@
               <l>deh, per pietà la madre mia consola.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>Ch'io viva? Io ti dia tomba? Io così vile,</l>
@@ -2699,7 +2735,7 @@
               <l>certa solo del danno?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>S'io non ti salvo, perdo</l>
@@ -2735,7 +2771,7 @@
               <l>a ragion non ti piace.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>Vuoi ch'io viva, e m'uccidi</l>
@@ -2759,7 +2795,7 @@
               <l>misere mie speranze.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Questa perdita è indegna</l>
@@ -2769,7 +2805,7 @@
               <l>A che dunque seguir quel che men prezzi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>Io volentier confesso</l>
@@ -2788,7 +2824,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>SOLDATO, MEROPE, POLICARE, NUTRICE <emph>in fine</emph>.</stage>
-          <sp>
+          <sp who="#soldato">
             <speaker>SOLDATO</speaker>
             <lg>
               <l>Merope, Aristodemo a sé ti chiama</l>
@@ -2796,7 +2832,7 @@
               <l>da conferir alti pensieri.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>                                        Il padre</l>
@@ -2824,7 +2860,7 @@
               <l>io parto, addio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>                          Dove n'andrai, crudele,</l>
@@ -2838,7 +2874,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>NUTRICE, POLICARE.</stage>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>Pigri, e imbelli siam noi, se posta in uso</l>
@@ -2880,7 +2916,7 @@
               <l>degna di lei, degna di te prepara.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>Se non ricusa d'incontrar la morte,</l>
@@ -2890,7 +2926,7 @@
               <l>quanto sarìa Policare infelice!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>Della sua lingua è men feroce il core.</l>
@@ -2905,35 +2941,35 @@
               <l>se cessi, è morte certa.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>                                      Ecco, o nutrice,</l>
               <l>un rischio non minor: l'offender lei.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>Vie più l'offendi</l>
               <l>a lasciarla perir.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>                           Che più si tarda?</l>
               <l>Chi nulla può sperar, nulla disperi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>Nulla più, no: ma se ben dritto io miro,</l>
               <l>forza giovar non può. S'usi l'inganno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>S'usi purché si salvi, e poi mi tocchi</l>
@@ -2942,7 +2978,7 @@
               <l>d'Etna giacer perché Tifeo respiri.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>Non sarà sì colpevol la frode.</l>
@@ -2954,7 +2990,7 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>OFIONEO.</stage>
-          <sp>
+          <sp who="#ofioneo">
             <speaker>OFIONEO</speaker>
             <lg>
               <l>Oh come sferza i rapidi destrieri</l>
@@ -3006,7 +3042,7 @@
               <l>onorandone il corso illustra il fine.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Sotto al selvoso Tenaro una rupe</l>
@@ -3083,7 +3119,7 @@
         <div type="scene">
           <head>SCENA I </head>
           <stage>POLICARE, ARISTODEMO.</stage>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>Mio re, ché re fra poco</l>
@@ -3092,7 +3128,7 @@
               <l>che 'l re comanda agli altri, al re la legge.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>Custode è della legge</l>
@@ -3100,7 +3136,7 @@
               <l>da lei partirsi mai.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>                               Tal è di grande</l>
@@ -3110,13 +3146,13 @@
               <l>e quale un re nell'altrui mogli?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>                                                  Segui.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>Poco ho da dir. Né Aristodemo padre,</l>
@@ -3126,7 +3162,7 @@
               <l>non me la tolga il re.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>                                   Che fia mai questo?</l>
@@ -3143,7 +3179,7 @@
               <l>a mostrarsi virtù.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>                             Signor, tu dammi</l>
@@ -3162,7 +3198,7 @@
               <l>della Messenia: Aristodemo è salvo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>Salvisi pur la patria. E tu, garzone,</l>
@@ -3186,7 +3222,7 @@
               <l>onorati vestigi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>                           Il sangue diedi</l>
@@ -3196,73 +3232,73 @@
               <l>se manca il padre. A' dèi, se 'l re non m'ode.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>Han già risposto i dèi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>                                      Non sono intesi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>Ciò niega Ofioneo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>                                 Tutto non vede.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>Sol può Dio preveder.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>                                    L'uomo provegga.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>Ben dicesti. Io proveggo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>                                           Inutilmente.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>Salvandosi la patria?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>                                    Tu la perdi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>Augure infausto, taci.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>                                    Aristodemo,</l>
@@ -3275,7 +3311,7 @@
               <l>e 'l fin dell'opra.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>                             Assai</l>
@@ -3285,7 +3321,7 @@
               <l>per irritar gli dèi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>                             Più chiaro dunque</l>
@@ -3298,7 +3334,7 @@
               <l>è la Messenia, io la rinunzio e taccio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>Che senti, Aristodemo? A questi colpi</l>
@@ -3311,7 +3347,7 @@
               <l>fingerà vanamente?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>Attonito ei riman, qual chi di serpe</l>
@@ -3319,7 +3355,7 @@
               <l>pallido incontra inaspettato assalto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>Ma deluder mi giova arte con arte.</l>
@@ -3328,7 +3364,7 @@
               <l>trova indegni pretesti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>                                    Io non t'ascondo</l>
@@ -3338,7 +3374,7 @@
               <l>un delitto del padre.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>Con un altro delitto</l>
@@ -3351,7 +3387,7 @@
               <l>di donatore, offeso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>Signor, se grave è l'amorosa colpa,</l>
@@ -3364,7 +3400,7 @@
               <l>non anco a' numi inferni.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>A preghiere d'Amfia</l>
@@ -3398,7 +3434,7 @@
               <l>Policare e Licisco.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>Tolga il ciel, che 'l mio amor nobile e giusto,</l>
@@ -3428,7 +3464,7 @@
               <l>sforza le stelle.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>                           O te la serbi il fato,</l>
@@ -3444,7 +3480,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>POLICARE.</stage>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>Bella dea, che mi reggi,</l>
@@ -3488,7 +3524,7 @@
           <head>SCENA III</head>
           <stage>OFIONEO, MEROPE.</stage>
           <stage>CORO <emph>de' sacerdoti che non parla</emph>.</stage>
-          <sp>
+          <sp who="#ofioneo">
             <speaker>OFIONEO</speaker>
             <lg>
               <l>Ministri, il bruno manto</l>
@@ -3520,7 +3556,7 @@
               <l>lascialo in pace.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Padre, due giorni sono</l>
@@ -3547,7 +3583,7 @@
               <l>ogni pensier depongo, e muoro in pace.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ofioneo">
             <speaker>OFIONEO</speaker>
             <lg>
               <l>Figlia, questo è un affetto</l>
@@ -3564,7 +3600,7 @@
               <l>dell'amor tuo, che perderia morendo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Se Policare vive, omai consacra</l>
@@ -3582,7 +3618,7 @@
               <l>in sì nobil acquisto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ofioneo">
             <speaker>OFIONEO</speaker>
             <lg>
               <l>Parlando in questa guisa,</l>
@@ -3622,7 +3658,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>OFIONEO, CORO.</stage>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>O tu nella cui mente il sacro ardore</l>
@@ -3633,7 +3669,7 @@
               <l>sotto l'ire del Ciel? Merope è tolta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ofioneo">
             <speaker>OFIONEO</speaker>
             <lg>
               <l>Cessi la tema infausta. Ostia sincera</l>
@@ -3645,7 +3681,7 @@
               <l>Merope or com'è tolta?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Tolta già molto tempo ed incapace</l>
@@ -3655,7 +3691,7 @@
               <l>vicina ad esser madre.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ofioneo">
             <speaker>OFIONEO</speaker>
             <lg>
               <l>Gran cose, o dèi! Chi violò la figlia</l>
@@ -3668,7 +3704,7 @@
               <l>che violenza è questa?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Policare la sposa a lui promessa</l>
@@ -3677,13 +3713,13 @@
               <l>la nutrice ed Amfia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ofioneo">
             <speaker>OFIONEO</speaker>
             <lg>
               <l>Aristodemo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>                      Egli stimò la figlia</l>
@@ -3694,14 +3730,14 @@
               <l>la figlia indietro inutilmente offerta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ofioneo">
             <speaker>OFIONEO</speaker>
             <lg>
               <l>Ed al giovane amante</l>
               <l>deve il padre prestar subita fede?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Amfia tutto conferma; e corre fama,</l>
@@ -3720,7 +3756,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>POLICARE, AMFIA.</stage>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>Sin qua molto s'è fatto. Erra la fama</l>
@@ -3735,7 +3771,7 @@
               <l>corrisponde il successo!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>                                        Or tu mi narra</l>
@@ -3743,7 +3779,7 @@
               <l>ch'ogni momento è prezioso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>                                                 Il tutto</l>
@@ -3757,7 +3793,7 @@
               <l>a cangiar volto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amfia">
             <speaker>AMFIA</speaker>
             <lg>
               <l>                           A noi</l>
@@ -3798,7 +3834,7 @@
               <l>l'ingannerò. Torni pur mia: non temo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policare">
             <speaker>POLICARE</speaker>
             <lg>
               <l>Cresce la notte, e con la notte il grande</l>
@@ -3813,7 +3849,7 @@
         <div type="scene">
           <head>SCENA VI</head>
           <l>ARISTODEMO.</l>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>Così comincia il regno. Ecco la prima</l>
@@ -3880,7 +3916,7 @@
               <l>Che approvino, che fuggano: sia fatto!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Pera chi prima</l>
@@ -3939,7 +3975,7 @@
               <l>tolto è l'uffizio all'ozioso aratro!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#saffici">
             <speaker>SAFFICI</speaker>
             <lg>
               <l>E se non placa — i dèi d'abisso Itome,</l>
@@ -3979,7 +4015,7 @@
         <div type="scene">
           <head>SCENA I </head>
           <stage>NUTRICE, TISI.</stage>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>Qual procelloso turbine mi porta</l>
@@ -3997,7 +4033,7 @@
               <l>efferato ed inospito paese?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tisi">
             <speaker>TISI</speaker>
             <lg>
               <l>A ragion ti lamenti,</l>
@@ -4008,7 +4044,7 @@
               <l>narra come seguì l'eccesso grande.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>Se raccolgo gli spiriti, se 'l corpo</l>
@@ -4054,7 +4090,7 @@
               <l>per non vederlo; e giacque.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tisi">
             <speaker>TISI</speaker>
             <lg>
               <l>A che non guida un cieco</l>
@@ -4062,7 +4098,7 @@
               <l>d'onor tiranno!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>Ciò non bastò al crudele.</l>
@@ -4091,7 +4127,7 @@
               <l>l'infelice cagion della sua colpa.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tisi">
             <speaker>TISI</speaker>
             <lg>
               <l>Ma chi dannò Policare alla morte</l>
@@ -4107,7 +4143,7 @@
               <l>l'abborriscan li dèi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>                                 Prima abborrito</l>
@@ -4133,7 +4169,7 @@
               <l>ad impedir che non s'uccida Amfia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tisi">
             <speaker>TISI</speaker>
             <lg>
               <l>Aristodemo concitò la plebe</l>
@@ -4161,7 +4197,7 @@
               <l>che tanto amò, lasciar le membra in terra.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>Egli morir volea,</l>
@@ -4181,7 +4217,7 @@
               <l>rapito a noi cade sommerso il giorno?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tisi">
             <speaker>TISI</speaker>
             <lg>
               <l>Teme a ragion. Ché sfortunata fede</l>
@@ -4201,7 +4237,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>TISI, CORO</stage>
-          <sp>
+          <sp who="#tisi">
             <speaker>TISI</speaker>
             <lg>
               <l>O di che strani, o di che fieri eventi</l>
@@ -4211,7 +4247,7 @@
               <l>Che di Messenia?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>                              Aristodemo adduce</l>
@@ -4224,13 +4260,13 @@
               <l>così la patria.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tisi">
             <speaker>TISI</speaker>
             <lg>
               <l>                        A ciò consente Itome?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Approva, e spera. Ofioneo sol resta,</l>
@@ -4242,7 +4278,7 @@
               <l>il nuovo re ricuperar poi deve.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tisi">
             <speaker>TISI</speaker>
             <lg>
               <l>Tuoni il ciel da sinistra, e pe' sereni</l>
@@ -4252,14 +4288,14 @@
               <l>che non sia lieto e non consenta il cielo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Così voglian li dèi: ma viene appunto</l>
               <l>Aristodemo. — Io qui l'attendo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tisi">
             <speaker>TISI</speaker>
             <lg>
               <l>                                                      Io parto.</l>
@@ -4271,7 +4307,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>ARISTODEMO, CORO.</stage>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>Chi mi vuol, terra o inferno?</l>
@@ -4318,7 +4354,7 @@
               <l>Messenii, l'indovin?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>                                    Sul giogo ei siede,</l>
@@ -4335,7 +4371,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>LICISCO, ARISTODEMO, CORO, ERASITEA <emph>in fine</emph></stage>
-          <sp>
+          <sp who="#licisco">
             <speaker>LICISCO</speaker>
             <lg>
               <l>Licisco io son, quell'empio</l>
@@ -4347,7 +4383,7 @@
               <l>né son padre ad Arena.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>Qual nostro Dio, qual tuo furor ti guida</l>
@@ -4366,7 +4402,7 @@
               <l>giustamente morrai.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#licisco">
             <speaker>LICISCO</speaker>
             <lg>
               <l>In cupo centro in tenebrosa stanza,</l>
@@ -4375,7 +4411,7 @@
               <l>Tu ne fosti l'autor.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>                               L'autor più tosto</l>
@@ -4383,7 +4419,7 @@
               <l>e quasi tu della ruina.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#licisco">
             <speaker>LICISCO</speaker>
             <lg>
               <l>col favor degli dèi vittima impropria,</l>
@@ -4392,7 +4428,7 @@
               <l>un delitto alla patria.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>In fallo? Or chi commise</l>
@@ -4402,14 +4438,14 @@
               <l>E come ascosa fu?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#licisco">
             <speaker>LICISCO</speaker>
             <lg>
               <l>                                Di me non nacque:</l>
               <l>ier fu tolta da' tuoi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>                                  Favole inette,</l>
@@ -4419,7 +4455,7 @@
               <l>del violento esacerbato volgo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Trovi la figlia prima</l>
@@ -4428,7 +4464,7 @@
               <l>oggi Messenia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#licisco">
             <speaker>LICISCO</speaker>
             <lg>
               <l>                          È ben ragion che torni</l>
@@ -4459,7 +4495,7 @@
               <l>gli sconsolati miei sterili giorni.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Io t'ho pietà, bella innocente, e molto</l>
@@ -4467,7 +4503,7 @@
               <l>dove si frangerà?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>                             Rendasi il corpo</l>
@@ -4476,7 +4512,7 @@
               <l>dunque non è paterno?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#licisco">
             <speaker>LICISCO</speaker>
             <lg>
               <l>                                       Io rivelarti</l>
@@ -4487,13 +4523,13 @@
               <l>sacerdotessa illustre.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Chiamisi. O Dio! che scoprirà Licisco?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#licisco">
             <speaker>LICISCO</speaker>
             <lg>
               <l>Messenii, chi di voi non si rammenta</l>
@@ -4609,7 +4645,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>ERASITEA, ARISTODEMO, CORO, OFIONEO <emph>in fine</emph>.</stage>
-          <sp>
+          <sp who="#erasitea">
             <speaker>ERASITEA</speaker>
             <lg>
               <l>Vengo, Licisco, vengo</l>
@@ -4643,13 +4679,13 @@
               <l>ambe per la tua mano, ambe tue figlie.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>Che sento, oimé! Già temo. Ah rimembranza</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erasitea">
             <speaker>ERASITEA</speaker>
             <lg>
               <l>Se ti rammenta più, signor, de' nostri</l>
@@ -4709,14 +4745,14 @@
               <l>io prima il capo mio stendo alla scure.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>O che gravi accidenti! O di natura</l>
               <l>col rigor del destin pugna infelice!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>Donna, parti, e mi lascia</l>
@@ -4725,7 +4761,7 @@
               <l>Almen giungesse Ofioneo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>                                             Non lunge</l>
@@ -4736,7 +4772,7 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>OFIONEO, ARISTODEMO, CORO.</stage>
-          <sp>
+          <sp who="#ofioneo">
             <speaker>OFIONEO</speaker>
             <lg>
               <l>Io tutto intesi. Aristodemo, il cielo</l>
@@ -4778,7 +4814,7 @@
               <l>dallo spietato sovversor fatale.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Or sì, lecito è il pianto, or sì, è dovuto.</l>
@@ -4793,7 +4829,7 @@
         <div type="scene">
           <head>SCENA VII</head>
           <stage>ARISTODEMO.</stage>
-          <sp>
+          <sp who="#aristodemo">
             <speaker>ARISTODEMO</speaker>
             <lg>
               <l>Rapitemi all'orrenda</l>
@@ -4827,7 +4863,7 @@
               <l>contagiosa fortuna io vi disgravo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Tolga il Ciel, che quest'altro</l>
@@ -4841,7 +4877,7 @@
         <div type="scene">
           <head>SCENA VIII</head>
           <stage>TISI, CORO, SOLDATO</stage>
-          <sp>
+          <sp who="#tisi">
             <speaker>TISI</speaker>
             <lg>
               <l>O con qual di natura</l>
@@ -4870,7 +4906,7 @@
               <l>o dalla sorte o dalla voglia altrui.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Dolce cosa agli afflitti</l>
@@ -4883,7 +4919,7 @@
               <l>invita a lamentarsi oggi Fortuna.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#soldato">
             <speaker>SOLDATO</speaker>
             <lg>
               <l>Morte a morte s'aggiunge, e lutto a lutto.</l>
@@ -4900,14 +4936,14 @@
               <l>fu Aristodemo!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Narra ciò che vedesti. Io già m'appongo</l>
               <l>al ver. S'uccise Aristodemo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#soldato">
             <speaker>SOLDATO</speaker>
             <lg>
               <l>                                              O dèi!</l>
@@ -4934,7 +4970,7 @@
               <l>quello spazio funesto ingombri tutto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tisi">
             <speaker>TISI</speaker>
             <lg>
               <l>Ah, spettacolo indegno! In questa guisa</l>

--- a/tei/de-medici-rappresentazione-di-san-giovanni-e-paolo.xml
+++ b/tei/de-medici-rappresentazione-di-san-giovanni-e-paolo.xml
@@ -82,6 +82,118 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="angelo_annunziatore">
+            <persName>Angelo Annunziatore</persName>
+          </person>
+          <person xml:id="primo_parente">
+            <persName>Primo Parente di Sant'Agnesa</persName>
+          </person>
+          <person xml:id="secondo_parente">
+            <persName>Secondo Parente di Sant'Agnesa</persName>
+          </person>
+          <person xml:id="terzo_parente">
+            <persName>Terzo Parente di Sant'Agnesa</persName>
+          </person>
+          <person xml:id="constanza">
+            <persName>Constanza</persName>
+          </person>
+          <person xml:id="servo_1">
+            <persName>Un Servo di Constanza</persName>
+          </person>
+          <person xml:id="constantino">
+            <persName>Constantino</persName>
+          </person>
+          <person xml:id="gallicano">
+            <persName>Gallicano</persName>
+          </person>
+          <person xml:id="una_delle_figliuole_di_gallicano">
+            <persName>Una delle figliuole di Gallicano</persName>
+          </person>
+          <person xml:id="altra_figliuola">
+            <persName>Altra Figliuola</persName>
+          </person>
+          <person xml:id="artemia">
+            <persName>Artemia</persName>
+          </person>
+          <person xml:id="attica">
+            <persName>Attica</persName>
+          </person>
+          <person xml:id="giovanni">
+            <persName>Giovanni</persName>
+          </person>
+          <person xml:id="paulo">
+            <persName>Paulo</persName>
+          </person>
+          <person xml:id="un_angelo">
+            <persName>Un angelo</persName>
+          </person>
+          <person xml:id="trombetto">
+            <persName>Trombetto</persName>
+          </person>
+          <person xml:id="principe">
+            <persName>Principe</persName>
+          </person>
+          <person xml:id="messo">
+            <persName>Messo</persName>
+          </person>
+          <person xml:id="re">
+            <persName>Re</persName>
+          </person>
+          <person xml:id="constantino_figliuolo">
+            <persName>Constantino, figliuolo di Constantino imperadore</persName>
+          </person>
+          <person xml:id="constante">
+            <persName>Constante</persName>
+          </person>
+          <person xml:id="constanzio">
+            <persName>Constanzio</persName>
+          </person>
+          <person xml:id="imperadore">
+            <persName>Imperadore</persName>
+          </person>
+          <person xml:id="servo_2">
+            <persName>Un Servo</persName>
+          </person>
+          <person xml:id="un_fante">
+            <persName>Un Fante</persName>
+          </person>
+          <person xml:id="uno_1">
+            <persName>Uno 1</persName>
+          </person>
+          <person xml:id="uno_2">
+            <persName>Uno 2</persName>
+          </person>
+          <person xml:id="uno_3">
+            <persName>Uno 3</persName>
+          </person>
+          <person xml:id="un_altro">
+            <persName>Un altro</persName>
+          </person>
+          <person xml:id="un_terzo">
+            <persName>Un terzo</persName>
+          </person>
+          <person xml:id="un_quarto">
+            <persName>Un quatro</persName>
+          </person>
+          <person xml:id="terenziano">
+            <persName>Terenziano</persName>
+          </person>
+          <person xml:id="san_basilio">
+            <persName>San Basilio</persName>
+          </person>
+          <person xml:id="maria">
+            <persName>Maria Vergine</persName>
+          </person>
+          <person xml:id="tesoriere">
+            <persName>Tesoriere</persName>
+          </person>
+          <person xml:id="astrologi">
+            <persName>Astrologi</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -197,7 +309,7 @@
     </front>
     <body>
       <div type="part" n="Rappresentazione">
-        <sp>
+        <sp who="#angelo_annunziatore">
           <speaker>
             <hi rend="sc">L'ANGELO</hi>
           </speaker>
@@ -235,7 +347,7 @@
             <l>sopportate l'età di qualche errore.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#primo_parente">
           <speaker>
             <hi rend="sc">PRIMO PARENTE</hi>
             <emph>di Santa Agnesa</emph>
@@ -271,7 +383,7 @@
             <l>se ancor me amate, al dolore e lamenti”.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#secondo_parente">
           <speaker>
             <hi rend="sc">SECONDO PARENTE</hi>
           </speaker>
@@ -286,7 +398,7 @@
             <l>Così la vidi come fussi viva.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#terzo_parente">
           <speaker>
             <hi rend="sc">TERZO PARENTE</hi>
           </speaker>
@@ -301,7 +413,7 @@
             <l>io restai solo e lieto in dolce pianto.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#primo_parente">
           <speaker>
             <hi rend="sc">PRIMO PARENTE</hi>
           </speaker>
@@ -319,7 +431,7 @@
             <l>ché abbiamo in paradiso un'avvocata.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#constanza">
           <speaker>
             <hi rend="sc">CONSTANZA</hi>
           </speaker>
@@ -344,7 +456,7 @@
             <l>che, vivendo così, dargliene cento.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#servo_1">
           <speaker>
             <hi rend="sc">UN SERVO</hi>
             <emph>di Constanza</emph>
@@ -370,7 +482,7 @@
             <l>e' non è mal tentar quel che non nuoce.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#constanza">
           <speaker>
             <hi rend="sc">CONSTANZA</hi>
           </speaker>
@@ -485,7 +597,7 @@
             <l>me dalla lebbra a te da tanta doglia.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#constantino">
           <speaker>
             <hi rend="sc">CONSTANTINO,</hi>
           </speaker>
@@ -526,7 +638,7 @@
             <l>che 'l mio sposo e 'l tuo genero sia Dio.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#constantino">
           <speaker>
             <hi rend="sc">CONSTANTINO</hi>
           </speaker>
@@ -650,7 +762,7 @@
             <l>con gli occhi, come ti veggo col cuore.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#constanza">
           <speaker>
             <hi rend="sc">CONSTANZA</hi>
           </speaker>
@@ -669,7 +781,7 @@
             <l>pur ch'io ti possa dar qualche allegrezza.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#constantino">
           <speaker>
             <hi rend="sc">CONSTANTINO</hi>
           </speaker>
@@ -680,7 +792,7 @@
             <l>è fatto acciò che il chiegga Gallicano.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#constanza">
           <speaker>
             <hi rend="sc">CONSTANZA</hi>
           </speaker>
@@ -723,7 +835,7 @@
             <l>e 'l tempo molte cose acconciar suole.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#constantino">
           <speaker>
             <hi rend="sc">CONSTANTINO</hi>
           </speaker>
@@ -792,7 +904,7 @@
             <l>Constanza è tua: allor faren la festa.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#gallicano">
           <speaker>
             <hi rend="sc">GALLICANO</hi>
           </speaker>
@@ -857,7 +969,7 @@
             <l>Constanza mia da voi sia riverita.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#una_delle_figliuole_di_gallicano">
           <speaker>
             <hi rend="sc">UNA DELLE FIGLIUOLE</hi>
             <emph>di Gallicano</emph>
@@ -873,7 +985,7 @@
             <l>pur noi vorremmo el dolce padre nostro.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#altra_figliuola">
           <speaker>
             <hi rend="sc">L'ALTRA FIGLIUOLA,</hi>
           </speaker>
@@ -889,14 +1001,14 @@
             <l>contentaci, ché puoi, facci tranquille.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#constantino">
           <speaker>CONSTANTINO</speaker>
           <lg>
             <l> Su, non piangete: el vostro Gallicano</l>
             <l>tornerà presto con vittoria e sano.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#gallicano">
           <speaker>
             <hi rend="sc">GALLICANO</hi>
           </speaker>
@@ -932,7 +1044,7 @@
         <stage>
           <emph>Detto questo, fa sacrificio in qualche luogo dove non sia veduto altrimenti; dipoi si parte con lo esercito, e ne va alla impresa di Dacia.</emph>
         </stage>
-        <sp>
+        <sp who="#constanza">
           <speaker>
             <hi rend="sc">CONSTANZA</hi>
           </speaker>
@@ -970,7 +1082,7 @@
             <l>e poi nell'altra vita eterna gloria.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#artemia">
           <speaker>
             <hi rend="sc">ARTEMIA</hi>
           </speaker>
@@ -985,7 +1097,7 @@
             <l>seguir la santa via che m'hai proposta.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#attica">
           <speaker>
             <hi rend="sc">ATTICA</hi>
           </speaker>
@@ -996,7 +1108,7 @@
             <l>con la bocca e col cuor questo ti dico.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#constanza">
           <speaker>
             <hi rend="sc">CONSTANZA</hi>
           </speaker>
@@ -1007,8 +1119,8 @@
             <l>orsù, laudiamo il nostro padre Dio.</l>
           </lg>
         </sp>
-        <sp>
-          <speaker><hi rend="sc">CONSTANZA</hi>, <hi rend="sc">ARTEMIA</hi> <emph>ed</emph> <hi rend="sc">ATTICA</hi></speaker>
+        <sp who="#constanza #artemia #attica">
+          <speaker><hi rend="sc">CONSTANZA</hi>, <hi rend="sc">ARTEMIA</hi><emph>ed</emph><hi rend="sc">ATTICA</hi></speaker>
           <stage>
             <emph>cantano tutte e tre insieme</emph>
           </stage>
@@ -1055,7 +1167,7 @@
             <l>ché non so come a Constantin ritorno.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#giovanni">
           <speaker>
             <hi rend="sc">GIOVANNI</hi>
           </speaker>
@@ -1080,7 +1192,7 @@
             <l>in Dio, dal qual ciaschedun ben procede.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#paulo">
           <speaker>
             <hi rend="sc">PAULO</hi>
           </speaker>
@@ -1105,7 +1217,7 @@
             <l>ché lui sé umiliò fino alla morte.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#gallicano">
           <speaker>GALLICANO</speaker>
           <lg>
             <l> Io non so come a Gesù fia accetto</l>
@@ -1118,7 +1230,7 @@
             <l>la mia miseria in me mostra il contrario.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#giovanni">
           <speaker>
             <hi rend="sc">GIOVANNI</hi>
           </speaker>
@@ -1133,7 +1245,7 @@
             <l>e lui ti renderà gente ed onore.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#gallicano">
           <speaker>
             <hi rend="sc">GALLICANO</hi>
           </speaker>
@@ -1151,7 +1263,7 @@
             <l>altro che te, dolce signor Gesùe.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#giovanni">
           <speaker>
             <hi rend="sc">GIOVANNI</hi>
           </speaker>
@@ -1169,7 +1281,7 @@
             <l>Del tuo umiliato Gallicano.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#un_angelo">
           <speaker>
             <hi rend="sc">UN ANGELO</hi>
           </speaker>
@@ -1187,7 +1299,7 @@
             <l>la croce fia per sempre il tuo stendardo.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#gallicano">
           <speaker>
             <hi rend="sc">GALLICANO</hi>
           </speaker>
@@ -1250,7 +1362,7 @@
             <l>e la condotta a tutti si raddoppia.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#trombetto">
           <speaker>TROMBETTO</speaker>
           <lg>
             <l> Da parte dello invitto capitano</l>
@@ -1305,7 +1417,7 @@
             <l>la qual a me per brieve tempo presti.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#principe">
           <speaker>
             <hi rend="sc">IL PRINCIPE</hi>
           </speaker>
@@ -1323,7 +1435,7 @@
             <l>fa' grazia almeno a noi di morir prima.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#gallicano">
           <speaker>
             <hi rend="sc">GALLICANO</hi>
           </speaker>
@@ -1338,7 +1450,7 @@
             <l>insin che a Constantin condotto sono.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#messo">
           <speaker>
             <hi rend="sc">IL MESSO</hi>
           </speaker>
@@ -1356,7 +1468,7 @@
             <l>Dammi un buon beveraggio, ch'io lo merto.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#constantino">
           <speaker>
             <hi rend="sc">CONSTANTINO</hi>
           </speaker>
@@ -1384,7 +1496,7 @@
             <l>abbiam la terra e 'l regno sottomesso.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#re">
           <speaker>
             <hi rend="sc">IL RE</hi>
           </speaker>
@@ -1402,7 +1514,7 @@
             <l>ma più nella vittoria esser clemente.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#constantino">
           <speaker>
             <hi rend="sc">CONSTANTINO</hi>
           </speaker>
@@ -1435,7 +1547,7 @@
             <l>che porti teco? hai tu mutato fede?</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#gallicano">
           <speaker>
             <hi rend="sc">GALLICANO</hi>
           </speaker>
@@ -1473,7 +1585,7 @@
             <l>t'assolvo, imperador, della promessa.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#constantino">
           <speaker>
             <hi rend="sc">CONSTANTINO</hi>
           </speaker>
@@ -1498,7 +1610,7 @@
             <l>Dio, che per grazia e non per merto premia.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#gallicano">
           <speaker>GALLICANO</speaker>
           <lg>
             <l> Miglior novelle, alto signore e degno,</l>
@@ -1531,7 +1643,7 @@
             <l>lascia me in pace servire ora a Dio.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#constantino">
           <speaker>
             <hi rend="sc">CONSTANTINO</hi>
           </speaker>
@@ -1559,7 +1671,7 @@
         <stage>
           <emph>Gallicano si parte, e di lui non si fa più menzione.</emph>
         </stage>
-        <sp>
+        <sp who="#constantino">
           <speaker>
             <hi rend="sc">CONSTANTINO</hi>
           </speaker>
@@ -1620,7 +1732,7 @@
         <stage>
           <emph>Constantin padre, detto che ha queste parole, si parte e se ne va copertamente, e di lui non si ragiona più</emph>
         </stage>
-        <sp>
+        <sp who="#constantino_figliuolo">
           <speaker>
             <hi rend="sc">CONSTANTINO FIGLIUOLO</hi>
           </speaker>
@@ -1638,7 +1750,7 @@
             <l>e la ragion ch'io prenda questa cura.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#constante">
           <speaker>
             <hi rend="sc">CONSTANTE</hi>
           </speaker>
@@ -1652,7 +1764,7 @@
             <l>questo ha voluto Dio e 'l nostro fato.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#constanzio">
           <speaker>
             <hi rend="sc">CONSTANZO</hi>
           </speaker>
@@ -1666,7 +1778,7 @@
             <l>Or siede ormai nella paterna sede.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#imperadore">
           <speaker>
             <emph>Il nuovo</emph>
             <hi rend="sc">IMPERADORE</hi>
@@ -1682,7 +1794,7 @@
             <l>siam pur d'un padre e d'una madre nati.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#servo_2">
           <speaker>
             <hi rend="sc">UN SERVO</hi>
           </speaker>
@@ -1697,7 +1809,7 @@
             <l>convien che grande esercito vi mandi.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#imperadore">
           <speaker>
             <hi rend="sc">IMPERADORE</hi>
           </speaker>
@@ -1718,7 +1830,7 @@
             <l>potete dir veramente: “Egli è nostro”.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#constante #constanzio">
           <speaker>
             <hi rend="sc">CONSTANTE</hi>
             <emph>e</emph>
@@ -1734,7 +1846,7 @@
             <l>noi ci avviamo, e 'l campo drieto venga.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#imperadore">
           <speaker>
             <hi rend="sc">IMPERADORE</hi>
           </speaker>
@@ -1749,7 +1861,7 @@
             <l>quanto in questo principio ci minaccia.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#un_fante">
           <speaker>
             <hi rend="sc">UN FANTE</hi>
           </speaker>
@@ -1767,7 +1879,7 @@
             <l>morti reston con gli altri su la terra.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#imperadore">
           <speaker>
             <hi rend="sc">IMPERADORE</hi>
           </speaker>
@@ -1806,7 +1918,7 @@
             <l>e Dio ringrazia che se' sol rimaso.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#imperadore">
           <speaker>
             <hi rend="sc">LO IMPERADORE</hi>
           </speaker>
@@ -1881,7 +1993,7 @@
           </speaker>
           <l> Orsù! presto, per lui un di noi vada.</l>
         </sp>
-        <sp>
+        <sp who="#imperadore">
           <speaker>
             <hi rend="sc">GIULIANO</hi>
             <emph>nuovo imperadore</emph>
@@ -1939,7 +2051,7 @@
             <l>né il tuo editto obbedito hanno mai.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#imperadore">
           <speaker>
             <hi rend="sc">GIULIANO</hi>
             <emph>imperadore</emph>
@@ -1978,7 +2090,7 @@
             <l>la roba tutta, ovver Giove adorate.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#giovanni #paulo">
           <speaker>
             <hi rend="sc">GIOVANNI</hi>
             <emph>e</emph>
@@ -1995,7 +2107,7 @@
             <l>fa' quel che vuoi, questa è la voglia nostra.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#imperadore">
           <speaker>
             <hi rend="sc">GIULIANO</hi>
           </speaker>
@@ -2023,7 +2135,7 @@
             <l>che non ci si ritorna un'altra volta.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#giovanni #paulo">
           <speaker>
             <hi rend="sc">GIOVANNI</hi>
             <emph>e</emph>
@@ -2050,7 +2162,7 @@
             <l>il corpo è tuo, lo spirito a Dio è dato.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#imperadore">
           <speaker>
             <hi rend="sc">GIULIANO</hi>
             <emph>imperadore</emph>
@@ -2066,7 +2178,7 @@
             <l>va', fa l'officio tuo, Terenziano.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#terenziano">
           <speaker>
             <hi rend="sc">TERENZIANO</hi>
           </speaker>
@@ -2080,7 +2192,7 @@
             <l>prima che al collo sentiate il coltello.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#giovanni">
           <speaker>
             <hi rend="sc">GIOVANNI</hi>
           </speaker>
@@ -2091,7 +2203,7 @@
             <l>la morte è uno uscir di molti affanni.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#terenziano">
           <speaker>
             <hi rend="sc">TERENZIANO</hi>
           </speaker>
@@ -2102,7 +2214,7 @@
             <l>poiché lo imperador se ne contenta?</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#paulo">
           <speaker>
             <hi rend="sc">PAULO</hi>
           </speaker>
@@ -2113,7 +2225,7 @@
             <l>ma più alta potenzia muove Giove.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#giovanni">
           <speaker>
             <hi rend="sc">GIOVANNI</hi>
           </speaker>
@@ -2122,7 +2234,7 @@
             <l>se adorassi il dolce Dio Gesùe.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#terenziano">
           <speaker>
             <hi rend="sc">TERENZIANO</hi>
           </speaker>
@@ -2148,7 +2260,7 @@
           <l>Sangue spargesti e sangue ti rendiamo:</l>
           <l>ricevilo, ché lieti te lo diamo.</l>
         </sp>
-        <sp>
+        <sp who="#imperadore">
           <speaker>
             <hi rend="sc">GIULIANO</hi>
             <emph>imperadore</emph>
@@ -2224,7 +2336,7 @@
             <l>Ditemi poi quando ogni cosa è in punto.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#san_basilio">
           <speaker>
             <emph>Il vescovo</emph>
             <hi rend="sc">SANTO BASILIO</hi>
@@ -2243,7 +2355,7 @@
             <l>fa' ch'io ne vegga almen qualche vendetta.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#maria">
           <speaker>
             <hi rend="sc">LA VERGINE MARIA</hi>
           </speaker>
@@ -2271,7 +2383,7 @@
             <l>el qual si pasce sol del cristian sangue.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#tesoriere">
           <speaker>
             <hi rend="sc">IL TESORIERE</hi>
           </speaker>
@@ -2289,7 +2401,7 @@
             <l>armata bene, obbediente, ardita.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#astrologi">
           <speaker>
             <hi rend="sc">GLI ASTROLOGHI</hi>
           </speaker>
@@ -2301,7 +2413,7 @@
           <l>il qual procede da un uom ch'è morto.</l>
           <l>Forse ti riderai di tal consiglio.</l>
         </sp>
-        <sp>
+        <sp who="#imperadore">
           <speaker>
             <hi rend="sc">LO IMPERADORE</hi>
           </speaker>
@@ -2325,7 +2437,7 @@
             <l>con voi starò, alla vita, alla morte.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#imperadore">
           <speaker>
             <hi rend="sc">GIULIANO</hi>
           </speaker>

--- a/tei/della-valle-la-reina-di-scozia.xml
+++ b/tei/della-valle-la-reina-di-scozia.xml
@@ -74,6 +74,46 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="ombra">
+            <persName>Ombra del re di Francia</persName>
+          </person>
+          <person xml:id="reina">
+            <persName>Reina di Scozia</persName>
+          </person>
+          <person xml:id="cameriera">
+            <persName>Cameriera</persName>
+          </person>
+          <personGrp xml:id="coro">
+            <name>Coro di damigelle</name>
+          </personGrp>
+          <person xml:id="servo">
+            <persName>Servo</persName>
+          </person>
+          <person xml:id="consigliero">
+            <persName>Consigliero della Reina d'Inghilterra</persName>
+          </person>
+          <person xml:id="conte_di_pembrocia">
+            <persName>Conte di Pembrocia</persName>
+          </person>
+          <person xml:id="conte_di_comberlandia">
+            <persName>Conte di Comberlandia</persName>
+          </person>
+          <person xml:id="maggiorduomo">
+            <persName>Maggiorduomo della Reina di Scozia</persName>
+          </person>
+          <person xml:id="mazziero">
+            <persName>Mazziero</persName>
+          </person>
+          <person xml:id="carnefice">
+            <persName>Carnefice</persName>
+          </person>
+          <person xml:id="messo">
+            <persName>Messo</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -123,7 +163,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
       </castList>
       <prologue>
         <head>PROLOGO</head>
-        <sp>
+        <sp who="#ombra">
           <speaker>OMBRA</speaker>
           <l>Monte è ne l'aria, e il sostengon nembi,</l>
           <l>al cui penoso piè s'aggiran spirti;</l>
@@ -212,7 +252,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
         <div type="scene">
           <head>SCENA PRIMA</head>
           <stage>REINA, CAMERIERA</stage>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Se pur è alcun, che nel volubil giro</l>
             <l>de le cose mortali</l>
@@ -290,7 +330,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>ahi affanno, ahi dolore,</l>
             <l>come non spezzi il core?</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>Deh, quai memorie dure</l>
             <l>a la memoria torni,</l>
@@ -395,7 +435,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>quella che sorge e nasce</l>
             <l>dai campi degli affanni.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Mia vittoria sarà la sepoltura!</l>
             <l>Ivi alzerò il trofeo</l>
@@ -426,7 +466,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>ed è mortale affanno,</l>
             <l>anzi occide ogni speme il rimembrarlo.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>Infausto, acerbo dì fu veramente;</l>
             <l>e m'adiro, e mi doglio, e temo, e tremo,</l>
@@ -453,12 +493,12 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>cadendo e scemando,</l>
             <l>giunge a la fine al nulla.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l rend="align:right">Io così stimo</l>
             <l part="I">che fia di me!</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l part="F">Anzi de la sventura,</l>
             <l>che presente ti preme. Volga il Cielo</l>
@@ -468,19 +508,19 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>a cor, di ben digiuno</l>
             <l>e già sazio di male.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Son nemiche fra loro</l>
             <l>la miseria e la speme,</l>
             <l>ch'essendo lieta, mal germoglia o nasce</l>
             <l>nel terren del dolore.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>Ma se virtù l'irriga,</l>
             <l>e nasce e cresce e pasce.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Arida vien virtù, se non ha umore</l>
             <l>da celeste rugiada, e per me il Cielo</l>
@@ -488,7 +528,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>forse a mirar quel che farà alfin donna</l>
             <l part="I">misera abbandonata.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l part="F">Ohimé, che sento!</l>
             <l>e tu che dici, o mia reina! Torni,</l>
@@ -499,7 +539,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>or, perché scende o cade</l>
             <l>in disperati abissi?</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Riconosco l'errore,</l>
             <l>e già ne piange il coro;</l>
@@ -519,7 +559,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>s'alzi per tua pietà l'anima almeno</l>
             <l>nel tuo dolce sereno!</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>Ascolti Dio le voci, e loro impetri</l>
             <l>grazia e mercé la sua bontade immensa;</l>
@@ -533,7 +573,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>quel che qui ti condusse</l>
             <l part="I">da le stanze riposte.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l part="F">Men soviene</l>
             <l>e miro se pur veggio</l>
@@ -548,7 +588,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>Deh, che qualche accidente non recida</l>
             <l part="I">la sua pietosa cura!</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l part="F">Se commandi,</l>
             <l>poiché per tôr sospetto a te non lece,</l>
@@ -560,7 +600,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>può poi ne l'avenir chiuder la via</l>
             <l part="I">a mille aiuti e mille.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l part="F">È ragion vera;</l>
             <l>ma questo luogo pur mi si concede</l>
@@ -572,19 +612,19 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>Tu qui aspetta: e se viene,</l>
             <l>già sai quel ch'io vorrei saper da lui.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>Sòllo, e ho anco cura</l>
             <l>d'adempier quel che vuoi, come conviensi</l>
             <l part="I">a fedel serva umìle.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l part="F">Anzi, pur come</l>
             <l>a misera compagna</l>
             <l>di sventure e d'affanni.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>Misera, sì, ma misera contenta,</l>
             <l>poiché sorte m'elesse,</l>
@@ -614,13 +654,13 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>CORO, CAMERIERA.</stage>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>Ma voi, figlie, che fate,</l>
             <l>che tutte uscite Resta dunque sola</l>
             <l part="I">la reina là entro?</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="F">Ella c'impose</l>
             <l>il venircen qui fuori, a l'aria, al cielo,</l>
@@ -628,7 +668,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>sola là, ne la stanza più riposta,</l>
             <l part="I">dove orar suole.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l part="F">Impetrino i suoi prieghi</l>
             <l>pace a l'alma affannata. Or qui vi lascio,</l>
@@ -642,7 +682,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>e devoto conviensi a gran sciagura,</l>
             <l>ch'alfin si piega il Cielo.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Non fu stanca giamai</l>
             <l>né la lingua né 'l cuore</l>
@@ -697,46 +737,46 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
         <div type="scene">
           <head>SCENA UNICA</head>
           <stage>SERVO, CAMERIERA <emph>e</emph> CORO.</stage>
-          <sp>
+          <sp who="#servo">
             <speaker>SERVO</speaker>
             <l>Donne chi mi conduce ov'io ragioni</l>
             <l>a la vostra reina? Ove si trova?</l>
             <l>O forse è qui tra voi?</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Qui non è, ma lontana</l>
             <l>esser molto non può. La sua fortuna</l>
             <l>picciol cerchio le ascrive. Tu che chiedi?</l>
             <l part="I">Che porti frettoloso?</l>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>SERVO</speaker>
             <l part="F">A lei mi manda</l>
             <l>il mio signor, ch'è capitan custode</l>
             <l>di questa prigion vostra e de le genti,</l>
             <l part="I">che vi fan siepe intorno.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="F">Ufficio acerbo!</l>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>SERVO</speaker>
             <l>Ma dolce è 'l commandar. Su tosto, i' debbo</l>
             <l>parlar a la reina.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Qui vien la cameriera: a lei ragiona.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>Amico, a me puoi dire</l>
             <l>quel che dir devi a lei, e io ben tosto</l>
             <l part="I">gliel'andrò a riferir.</l>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>SERVO</speaker>
             <l part="F">Nulla m'importa</l>
             <l>parlar teco o seco: sappia solo</l>
@@ -744,23 +784,23 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>son ministri reali, uomini eccelsi,</l>
             <l part="I">dei maggiori del regno.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l part="F">E ciò, ch'importa</l>
             <l>a la reina mia? Se son venuti,</l>
             <l part="I">tornino o stien, come a lor pare.</l>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>SERVO</speaker>
             <l part="F">Io credo</l>
             <l part="I">che così possan far.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l part="F">Così potesse</l>
             <l part="I">con altri chi t'ascolta!</l>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>SERVO</speaker>
             <l part="F">A varie sorti</l>
             <l>vario è 'l poter: ma tu par che sdegnosa</l>
@@ -768,7 +808,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>e pur apporto cose</l>
             <l>dolci e care ad udirsi.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>L'anima inacerbita dal dolore</l>
             <l>forma imagini acerbe o ne la voce,</l>
@@ -781,45 +821,45 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>fronte ritrosa fanno.</l>
             <l part="I">Ma che apporti, ti prego?</l>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>SERVO</speaker>
             <l part="F">A la reina</l>
             <l part="I">mi manda il capitan.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l part="F">Già ciò detto hai.</l>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>SERVO</speaker>
             <l>E son venuti i conti, i' non so quali,</l>
             <l part="I">ma quattro o cinque sono...</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l part="F">Segui il resto:</l>
             <l part="I">che però dice il capitan?</l>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>SERVO</speaker>
             <l part="F">Ch'ei stima</l>
             <l>e ha sentito cose, onde si puote</l>
             <l>congetturar che rechin ordin seco</l>
             <l part="I">di liberar la tua reina.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l part="F">O voce</l>
             <l>soavissima, amata</l>
             <l part="I">quanto poco sperata!</l>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>SERVO</speaker>
             <l part="F">E perché speri,</l>
             <l>mi manda il capitan a la reina</l>
             <l>con la cara novella.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>Deh, s'ella fie mai vera,</l>
             <l>alta mercé n'aspetti il capitano,</l>
@@ -841,7 +881,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>come sia grave il peso</l>
             <l>di sorte sventurata.</l>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>SERVO</speaker>
             <l>Io da buon zelo spinto</l>
             <l>ho affrettato a mio poter il passo,</l>
@@ -851,25 +891,25 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>sentisse tal novella; la qual stimo</l>
             <l part="I">che cara le sarà.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l part="F">E quanto cara!</l>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>SERVO</speaker>
             <l>Però venir vorrei</l>
             <l>io stesso a riferirla, oltra che anco</l>
             <l>altro ho da dir, che altrettanto fie</l>
             <l part="I">caro ad udirsi.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="F">E perché 'l taci, lassa!</l>
             <l>Perché dividi 'l bene,</l>
             <l>di cui quel che ritieni a te non giova</l>
             <l>e 'n me scema le pene?</l>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>SERVO</speaker>
             <l>M'affretta a la reina</l>
             <l>l'obligo mio e la voglia;</l>
@@ -887,13 +927,13 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>tacer non l'ho voluto: il compiacervi</l>
             <l part="I">so ch'utile mi fie.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="F">Così potessi</l>
             <l>quel che poter devrei, come sarebbe</l>
             <l part="I">certa la tua credenza!...</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l part="F">Or io me n'entro</l>
             <l>con due care novelle,</l>
@@ -906,7 +946,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>fôra il mio riferir, per conseguirti</l>
             <l part="I">la mercé, che n'aspetti.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="F">Ei ben la merta!</l>
             <l>Or tosto vanne, amico,</l>
@@ -948,7 +988,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
         <div type="scene">
           <head>SCENA PRIMA</head>
           <stage>SERVO, CORO.</stage>
-          <sp>
+          <sp who="#servo">
             <speaker>SERVO</speaker>
             <l>Felice me, se giunge ad esser vera</l>
             <l>la portata novella! I' men ritorno</l>
@@ -963,7 +1003,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>e ch'a l'alme migliori</l>
             <l>giran sorti peggiori!</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Mesce le cose il fato</l>
             <l>in invisibil urna,</l>
@@ -997,7 +1037,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>È consolata, è lieta</l>
             <l>con la novella lieta?</l>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>SERVO</speaker>
             <l>Entrai, come vedeste, e fosca scala</l>
             <l>solitaria, ahimé quanto, e quanto indegna</l>
@@ -1016,14 +1056,14 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>senza coscin, senza tapeto, e gli occhi</l>
             <l>fissi alti in una croce al muro appesa.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Gli occhi tien a l'insegna</l>
             <l>e 'l core al capitano,</l>
             <l>e a pugnar per lui l'anima è accinta,</l>
             <l>benché debil la mano.</l>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>SERVO</speaker>
             <l>La vecchia entrata dentro,</l>
             <l>sento un alto sospiro, e quinci a poco</l>
@@ -1069,7 +1109,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>poco sapea che dir, poco ho risposto,</l>
             <l>e nulla forse ho detto.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Stupor e riverenza</l>
             <l>desta nei petti altrui real presenza:</l>
@@ -1084,7 +1124,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>intorbidò, ma non oscura in lei</l>
             <l>le sembianze reali.</l>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>SERVO</speaker>
             <l>Del matutin colore</l>
             <l>ne la languida sera</l>
@@ -1095,7 +1135,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>prontezza: al suo signor chi tardi arriva,</l>
             <l>con suo periglio arriva.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Ma l'amistà non parta,</l>
             <l>se ben si parte il piede.</l>
@@ -1104,7 +1144,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>sol possiamo obliar le cure acerbe</l>
             <l>col sentir nuove cose.</l>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>SERVO</speaker>
             <l>Quel che senza mio rischio in util vostro</l>
             <l>potrò adoprar, tutto farò. Ma ecco</l>
@@ -1114,7 +1154,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>REINA, CAMERIERA <emph>e</emph> CORO.</stage>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Spero, lassa, o non spero?</l>
             <l>O che creder debb'io de la novella</l>
@@ -1131,7 +1171,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>toglie la fede al bene,</l>
             <l>che frettoloso viene!</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>Quasi lieve rugiada matutina,</l>
             <l>ch'invisibil ci bagna,</l>
@@ -1143,7 +1183,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>quanto è più certo il tuono,</l>
             <l>poi che s'è visto il lampo.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Ma sovente balena,</l>
             <l>e taciturno poi</l>
@@ -1152,7 +1192,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>apparirci l'aurora,</l>
             <l>e poi non segue il sole.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>È cosa sì comune la speranza,</l>
             <l>che non v'è stato umano,</l>
@@ -1175,7 +1215,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>d'un ben, che mai non nuoce</l>
             <l>e può sempre giovarci.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Volar può la speranza,</l>
             <l>come tu dici, ed offerirsi altrui;</l>
@@ -1187,7 +1227,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>e 'nvolve in cieco velo</l>
             <l>a l'infelice il cielo.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>A me par, se la speme</l>
             <l>è aspettazion di bene,</l>
@@ -1200,11 +1240,11 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>che la speme del misero esser debbe</l>
             <l>del felice la tema.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Vuoi tu dunque ch'io speri?</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>Anzi 'l vuol la ragione!</l>
             <l>Né tu potrai negar, o mia rena,</l>
@@ -1227,7 +1267,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>noi solamente siamo</l>
             <l>disperazione e ombra.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Speri l'alma al voler de l'altrui voglia,</l>
             <l>s'al mio voler non puote! Io spero, o donne;</l>
@@ -1242,13 +1282,13 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>l'aria, ond'han nodrimento e spirto e vita,</l>
             <l>sotto libero cielo.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Ciò ti conceda il Cielo;</l>
             <l>ch'a conseguir il resto</l>
             <l>fia duce ed arme il dritto.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Oh, se fia mai ch'io giunga</l>
             <l>a riveder i campi</l>
@@ -1276,7 +1316,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>or fra dolci ed acerbe</l>
             <l>a l'alma mi tornate!</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Di colà viene uomo straniero in vista</l>
             <l>e 'n autorevol passo.</l>
@@ -1286,14 +1326,14 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>messaggiera de l'alba, anzi del sole</l>
             <l part="I">de la libertà nostra!</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l part="F">Il riconosco,</l>
             <l>e fu già un tempo conoscenza acerba;</l>
             <l>non so quel ch'or sarà: quel volto ancora</l>
             <l>m'affligge in rivederlo!</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Egli è Beel, il consigliero, amico</l>
             <l>de la nostra nemica.</l>
@@ -1301,7 +1341,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>di disprezzo e d'orgoglio, ha preso il carco</l>
             <l>d'esser ministro a cortese opra e cara.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Anima bassa e vile</l>
             <l>mal può farsi gentile.</l>
@@ -1313,7 +1353,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>CONSIGLIERO, REINA, CAMERIERA <emph>e</emph> CORO.</stage>
-          <sp>
+          <sp who="#consigliero">
             <speaker>CONSIGLIERO</speaker>
             <l>Già quattro lune da l'acute corna</l>
             <l>per l'intorto sentier son giunte al cerchio</l>
@@ -1376,7 +1416,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>con regia autoritade e regio scettro</l>
             <l>ad essequir quel che fie poscia giusto.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>E chi manda e chi viene e quel che dice,</l>
             <l>egualmente è crudel: così fie ingiusto</l>
@@ -1442,13 +1482,13 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>in questo indegno albergo e uscir poi</l>
             <l>a trar l'aria a misura.</l>
           </sp>
-          <sp>
+          <sp who="#consigliero">
             <speaker>CONSIGLIERO</speaker>
             <l>Vanne, ché qui verrà fra spazio poco</l>
             <l>chi la superbia domi e 'l regio fasto</l>
             <l>di bassissima donna!</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>A dimanda crudel, risposta acerba</l>
             <l>non si dica superba.</l>
@@ -1456,13 +1496,13 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>quel che cercar non dee,</l>
             <l part="I">trovi quel che non vuole.</l>
           </sp>
-          <sp>
+          <sp who="#consigliero">
             <speaker>CONSIGLIERO</speaker>
             <l part="F">A la fortuna</l>
             <l>sian pari le parole:</l>
             <l>altro ha da dir chi serve, altro chi impera!</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Serva solo è del giusto anima grande,</l>
             <l>e servitute tale</l>
@@ -1492,7 +1532,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>formar si ponno le medesme cose,</l>
             <l>come son riferite.</l>
           </sp>
-          <sp>
+          <sp who="#consigliero">
             <speaker>CONSIGLIERO</speaker>
             <l>Non nuoce o giova ch'io più dica o meno;</l>
             <l>né venn'io qui, perché da le parole</l>
@@ -1511,19 +1551,19 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>riso era l'umiltade e s'aggiungeva</l>
             <l part="I">a la pena lo scherno.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="F">Ahi, pensier crudo</l>
             <l part="I">e d'anima maligna!</l>
           </sp>
-          <sp>
+          <sp who="#consigliero">
             <speaker>CONSIGLIERO</speaker>
             <l part="F">A te si lasci</l>
             <l>giudicar con parole il crudo o 'l pio</l>
             <l>dei pensier nostri: noi de l'altrui vita</l>
             <l>giudicherem coi fatti.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Sopra me si disfoghi</l>
             <l>l'odio ingiusto e crudele, e il mio sangue</l>
@@ -1544,7 +1584,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
         <div type="scene">
           <head>SCENA PRIMA</head>
           <stage>REINA, CAMERIERA <emph>e</emph> CORO</stage>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Udite avete le dimande ingiuste,</l>
             <l>amiche, e la maniera di spiegarle,</l>
@@ -1576,7 +1616,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>nel danno mio fie celebrata alfine</l>
             <l>con orror e pietade.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>Da l'incostanza del tuo vario stato</l>
             <l>argomentar si deve in chi t'aggira</l>
@@ -1587,13 +1627,13 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>ne l'aspra infermità de la tua sorte,</l>
             <l part="I">sperar salute.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l part="I">Io la salute spero,</l>
             <l>non già qual tu la speri! Ma che dici</l>
             <l>de l'udite dimande? E che ne stimi?</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>Crude son le dimande e sono ingiuste:</l>
             <l>e qual occhio nol vede?</l>
@@ -1607,13 +1647,13 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>quel che può trar da te, pria che sforzata</l>
             <l>ti disciolga e sprigioni.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Sprigionerammi, credo,</l>
             <l>ma a l'alma prima fia</l>
             <l>tolta la prigionia.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>Misera me, con quai duri presagi</l>
             <l>mi tormenti la mente! Il tuo temere</l>
@@ -1682,7 +1722,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>ché soave fie 'l sonno e caro letto</l>
             <l>il feretro e 'l sepolcro.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Dolci campi di Scozia e piagge care</l>
             <l>de la mia patria amata,</l>
@@ -1732,7 +1772,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>dolce, grave e ridente,</l>
             <l>da mano riverente.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Deh, quai cose ti fingi, e quali agogni!</l>
             <l>Tal nel sonno vaneggia</l>
@@ -1750,7 +1790,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>solo la gloria sia</l>
             <l>del mio Signor, non mia.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Il disusato riso, che s'è aperto</l>
             <l>ne la tua cara bocca</l>
@@ -1770,11 +1810,11 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>cara imagine e grata</l>
             <l>di libertade amata.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Pasciamci pur d'imaginate larve!</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>Mira, di là sen torna a lunghi passi</l>
             <l>il servo ch'a noi venne ha poco d'ora:</l>
@@ -1788,7 +1828,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>SERVO, REINA, CAMERIERA <emph>e</emph> CORO.</stage>
-          <sp>
+          <sp who="#servo">
             <speaker>SERVO</speaker>
             <l>Reina, a te mi manda il capitano,</l>
             <l>per dirti com'or qui saranno i conti</l>
@@ -1796,19 +1836,19 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>usciti de l'albergo, e tardar poco</l>
             <l part="I">potranno a giunger qui.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l part="F">Vengan felici;</l>
             <l part="I">me n'entro ad aspettarli.</l>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>SERVO</speaker>
             <l part="F">Anzi per altro</l>
             <l>mi manda il capitan, a cui par bene</l>
             <l>che tu scendessi ad incontrargli, s'eri</l>
             <l part="I">ne le stanze sovrane.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l part="F">Si conceda</l>
             <l>questo anco a la mia sorte, e grazie a Dio,</l>
@@ -1820,7 +1860,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>Che portan seco? Hai nulla udito poscia,</l>
             <l>più di quel che dicesti?</l>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>SERVO</speaker>
             <l>Nulla invero; ma gravi cose certo</l>
             <l>rivolgon ne la mente. Il tornar spesso</l>
@@ -1830,11 +1870,11 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>son di pensier ch'aggiri dubbie cose</l>
             <l>e difficili e grandi.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l part="I">Oh, sian pur anco giuste!</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l part="F">Duramente</l>
             <l>si congiunge con l'utile l'onesto:</l>
@@ -1844,13 +1884,13 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>al consiglio di donna ambiziosa,</l>
             <l part="I">avida del tuo regno.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l part="F">E, quai proposte</l>
             <l>mi propongh'io d'udir, a la risposta</l>
             <l part="I">aiutimi il mio Dio.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="F">Il liberarti</l>
             <l>sia tuo fine, o reina, e la tua lingua,</l>
@@ -1858,7 +1898,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>de le parole tue solo nel segno</l>
             <l>di ritornar al regno.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Di ritornarvi bramo, perché è giusto;</l>
             <l>così quel che potrò dir senza offesa</l>
@@ -1867,7 +1907,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>tutto dirò, per sodisfar a voi,</l>
             <l>e al giusto, e a me medesma.</l>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>SERVO</speaker>
             <l>Sento ch'è saggia cosa</l>
             <l>farsi conformi agli accidenti e ai tempi.</l>
@@ -1880,7 +1920,7 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>han su le spalle son ministri loro</l>
             <l>e segno dan d'autorità reale.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Tali d'alta fenestra</l>
             <l>di dorato palagio</l>
@@ -1888,31 +1928,31 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
             <l>più diletti ministri e più fedeli</l>
             <l part="I">a la reina mia.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l part="F">Con regio fasto</l>
             <l>vengon a donna misera e mendica!</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>In ciò dimostran segno</l>
             <l>d'onor e riverenza: a regia donna</l>
             <l>regio culto conviensi, e di reina</l>
             <l part="I">già ti portan l'insegne.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l part="F">Io qui mi fermo</l>
             <l part="I">ad aspettarli.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l part="F">A mio parer, ben fôra</l>
             <l>moversi lentamente</l>
             <l>inverso lor. Può maestà serbarsi</l>
             <l part="I">ed onorare altrui.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l part="F">Moviamci dunque.</l>
           </sp>
@@ -1921,14 +1961,14 @@ CONTE <emph>di</emph> COMBERLANDIA</role>
           <head>SCENA TERZA</head>
           <stage>C. <emph>di</emph> PEMBROCIA, REINA, CAMERIERA,
 C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
-          <sp>
+          <sp who="#conte_di_pembrocia">
             <speaker>C. <emph>di</emph> PEMBROCIA</speaker>
             <l>Come ci aggiri, o Ciel, come travolvi</l>
             <l>queste cose mortali! In quale stato</l>
             <l>ti riveggio or, o donna! In qual ti vidi</l>
             <l part="I">ha già molt'anni!</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l part="F">E questo esempio sia</l>
             <l>a chi vive, a chi regna; e miri quanto</l>
@@ -1937,23 +1977,23 @@ C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
             <l>la vita che corriamo, ove ci aggira</l>
             <l>mano or placida or dura, or alto or basso.</l>
           </sp>
-          <sp>
+          <sp who="#conte_di_pembrocia">
             <speaker>C. <emph>di</emph> PEMBROCIA</speaker>
             <l>Di quel che dici, tal imagin veggio,</l>
             <l>che non più vivo può mostrarsi il vivo.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Grazie a chi 'l fa; perdono a chi n'ha colpa</l>
             <l part="I">e a chi 'l mal supporta.</l>
           </sp>
-          <sp>
+          <sp who="#conte_di_pembrocia">
             <speaker>C. <emph>di</emph> PEMBROCIA</speaker>
             <l part="F">Per te sola</l>
             <l>parli, poiché tu sola il mal supporti</l>
             <l part="I">e sola n'hai la colpa.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l part="F">Oh, così sia;</l>
             <l>non sia di duo l'error, e sia la pena</l>
@@ -1963,41 +2003,41 @@ C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
             <l>aggravan l'alma, ma chi me condanna,</l>
             <l part="I">non è innocente forse.</l>
           </sp>
-          <sp>
+          <sp who="#conte_di_pembrocia">
             <speaker>C. <emph>di</emph> PEMBROCIA</speaker>
             <l part="F">È giusta e pia!</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>In me si vede: io testimonio sono</l>
             <l part="I">e son giudice e reo!</l>
           </sp>
-          <sp>
+          <sp who="#conte_di_pembrocia">
             <speaker>C. <emph>di</emph> PEMBROCIA</speaker>
             <l part="F">Così mi pesa</l>
             <l>dirti ch'anco sei tu la condennata.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Già di molt'anni 'l son: purtroppo il sento.</l>
           </sp>
-          <sp>
+          <sp who="#conte_di_pembrocia">
             <speaker>C. <emph>di</emph> PEMBROCIA</speaker>
             <l>Dove cresce l'error, cresca la pena.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>È giusta la sentenza, io la confermo.</l>
           </sp>
-          <sp>
+          <sp who="#conte_di_pembrocia">
             <speaker>C. <emph>di</emph> PEMBROCIA</speaker>
             <l>Fallo ostinato è doppio, e doppio aggrava.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>E cresce quanto ostinazion s'invecchia.</l>
           </sp>
-          <sp>
+          <sp who="#conte_di_pembrocia">
             <speaker>C. <emph>di</emph> PEMBROCIA</speaker>
             <l>Così in te crebbe, o donna, a cui molt'anni</l>
             <l>durissimi a portarsi e prigion lunga</l>
@@ -2005,32 +2045,32 @@ C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
             <l>o smover o piegar; anzi ostinata</l>
             <l>più neghi, allorché più conceder déi.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Nulla nego io, che consentir si possa</l>
             <l part="I">da mente giusta e pia.</l>
           </sp>
-          <sp>
+          <sp who="#conte_di_pembrocia">
             <speaker>C. <emph>di</emph> PEMBROCIA</speaker>
             <l part="F">Ma contradici</l>
             <l>a dimanda real d'alta reina,</l>
             <l>cui sconviensi negar, non quel che chiede,</l>
             <l>ma quel che accenna o pensa.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Ove la real voce ha giusto impero</l>
             <l>questa legge s'osservi e s'ubidisca.</l>
             <l>Chi nacque re commandi e sol soggiaccia</l>
             <l part="I">a le leggi e al dritto.</l>
           </sp>
-          <sp>
+          <sp who="#conte_di_pembrocia">
             <speaker>C. <emph>di</emph> PEMBROCIA</speaker>
             <l part="F">Io servo chiamo</l>
             <l>chi è in altrui poter e di se stesso</l>
             <l part="I">sol può quel ch'altri vuole.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l part="F">Anzi, chi vuole</l>
             <l>quel che non deve è servo: anima torta</l>
@@ -2038,50 +2078,50 @@ C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
             <l>porta re ingiusto in capo; al collo, ai piedi</l>
             <l part="I">ha catena, ha capestro.</l>
           </sp>
-          <sp>
+          <sp who="#conte_di_pembrocia">
             <speaker>C. <emph>di</emph> PEMBROCIA</speaker>
             <l part="F">E pur ha forza</l>
             <l>d'assolvere e punir com'a lui pare.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Tal ha forza anco masnadiero in selva,</l>
             <l>che puote armato tôrre e manto e vita</l>
             <l>al maggior re, se disarmato e solo</l>
             <l>ne le sue insidie cade.</l>
           </sp>
-          <sp>
+          <sp who="#conte_di_pembrocia">
             <speaker>C. <emph>di</emph> PEMBROCIA</speaker>
             <l>Ma non si chiami ingiusto chi 'l consiglio</l>
             <l>d'uomini giusti adopra, anzi che scioglia</l>
             <l part="I">al giudizio la voce.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l part="I">Io tal nol chiamo.</l>
           </sp>
-          <sp>
+          <sp who="#conte_di_pembrocia">
             <speaker>C. <emph>di</emph> PEMBROCIA</speaker>
             <l>Non chiamerai dunque la mia reina</l>
             <l part="I">ingiusta.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l part="F">Io nulla dico, ma risponda</l>
             <l>per me questa prigione ove son chiusa.</l>
           </sp>
-          <sp>
+          <sp who="#conte_di_pembrocia">
             <speaker>C. <emph>di</emph> PEMBROCIA</speaker>
             <l>E perché non risponda lungamente</l>
             <l part="I">noi ten veniamo a sciôr.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l part="F">N'è tempo omai,</l>
             <l>e grazie a voi, che qui giusti venite</l>
             <l part="I">ministri a sì giust'opra!</l>
           </sp>
-          <sp>
+          <sp who="#conte_di_pembrocia">
             <speaker>C. <emph>di</emph> PEMBROCIA</speaker>
             <l part="I">di quella autorità ch'a noi è data</l>
             <l>di poter essequir quanto ti dico.</l>
@@ -2089,22 +2129,22 @@ C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
             <l>le riconosci, son de la reina,</l>
             <l part="I">formate di sua mano.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l part="F">E l'uno e l'altro</l>
             <l>riconosco: già molte n'ho veduto.</l>
           </sp>
-          <sp>
+          <sp who="#conte_di_pembrocia">
             <speaker>C. <emph>di</emph> PEMBROCIA</speaker>
             <l part="I">Or spiega tutto e leggi.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="F">O cara carta</l>
             <l>che libertà ci apporti!... Ma si turba</l>
             <l>la reina leggendo e impallidisce...</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Disusata allegrezza</l>
             <l>turba come dolore. Ma tacete,</l>
@@ -2112,12 +2152,12 @@ C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
             <l>il principio, e se tal è 'l mezzo e 'l fine,</l>
             <l part="I">libere sarem tosto.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l part="F">O Cielo, o Dio,</l>
             <l>grazie di grazia tanta!</l>
           </sp>
-          <sp>
+          <sp who="#conte_di_comberlandia">
             <speaker>C. <emph>di</emph> COMBERLANDA</speaker>
             <l>Anzi, perché si tolga a te la noia,</l>
             <l>che leggendo aver puoi, senti e ascolta</l>
@@ -2128,18 +2168,18 @@ C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
             <l>poi dove deve, e 'n libertà sen vada,</l>
             <l part="I">ché ciò le si concede. —</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l part="F">Da tal mano</l>
             <l>tal colpo s'aspettava.</l>
             <l>Togli le carte tue: mente infedele</l>
             <l>le scrisse; non più stian in man fedele!</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Ohimé, ohimé, che veggio!</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Ben par che vaga e ingorda</l>
             <l>è de l'umano sangue</l>
@@ -2151,36 +2191,36 @@ C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
             <l>a me, che sangue sono</l>
             <l part="I">del sangue ond'ella nacque!</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="F">Ahi, dura voce!</l>
             <l>Di che sangue si parla?</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Che fec'io, che diss'io,</l>
             <l>perché s'aprisse il varco</l>
             <l part="I">a tanta crudeltade?</l>
           </sp>
-          <sp>
+          <sp who="#conte_di_comberlandia">
             <speaker>C. <emph>d</emph>i COMBERLANDA</speaker>
             <l part="F">Altro conviensi</l>
             <l>or, ch'incolpar altrui o che dolersi.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Morir conviene, il veggio!</l>
             <l>Ma non si torrà almeno</l>
             <l>il dir che chi m'occide</l>
             <l>empiamente m'occide.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Misera, quai parole</l>
             <l>sento! O reina mia,</l>
             <l>chi morirà, chi occide?</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Io, io sarò l'occisa,</l>
             <l>o figlie! E micidiale</l>
@@ -2188,13 +2228,13 @@ C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
             <l>è la donna crudele,</l>
             <l>di cui son giusta erede!</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>Occisa te, mia donna,</l>
             <l>te, mia reina e vita?</l>
             <l>occisa te? Misera me, che dici?</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Questa testa si chiede,</l>
             <l>e dove già mi cinse aureo monile</l>
@@ -2202,18 +2242,18 @@ C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
             <l>Tale strada s'insegna</l>
             <l>a la mia libertade!</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Passi per questo cor, per questa gola,</l>
             <l>e dal collo disciolta</l>
             <l>sia la mia testa, dono</l>
             <l>di chi testa dimanda!</l>
           </sp>
-          <sp>
+          <sp who="#conte_di_comberlandia">
             <speaker>C. <emph>di</emph> COMBERLANDA</speaker>
             <l>Vada la pena onde la colpa venne.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Da me la colpa venne;</l>
             <l>colpa di creder troppo</l>
@@ -2222,7 +2262,7 @@ C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
             <l>e reina a reina,</l>
             <l>a la zia la nipote.</l>
           </sp>
-          <sp>
+          <sp who="#conte_di_comberlandia">
             <speaker>C. <emph>di</emph> COMBERLANDA</speaker>
             <l>Vane son le parole,</l>
             <l>ove necessità costringe a l'opra:</l>
@@ -2233,7 +2273,7 @@ C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
             <l>per l'altra vita; ché di questa breve</l>
             <l>poco spazio t'avanza.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>O consiglio pietoso</l>
             <l>di consiglier crudele!</l>
@@ -2242,14 +2282,14 @@ C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
             <l>ch'anco non abbia tempo a voglia mia</l>
             <l>di pianger la mia morte?</l>
           </sp>
-          <sp>
+          <sp who="#conte_di_comberlandia">
             <speaker>C. <emph>di</emph> COMBERLANDA</speaker>
             <l>Questo sol, che tu miri</l>
             <l>precipitando già cader nel mare,</l>
             <l>sarà l'ultimo sole</l>
             <l>che veggian gli occhi tuoi.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>O fiera crudeltade,</l>
             <l>o crudeltà di tigre,</l>
@@ -2258,7 +2298,7 @@ C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
             <l>e 'n un punto confonde</l>
             <l>con la vita la morte!</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Già lungo spazio, veggio</l>
             <l>pender sul capo mio l'acuta punta</l>
@@ -2293,7 +2333,7 @@ C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
             <l>e la testa infelice, che mi chiami,</l>
             <l>sia poi mercé de la mercé ch'io chiamo.</l>
           </sp>
-          <sp>
+          <sp who="#conte_di_comberlandia">
             <speaker>C. <emph>di</emph> COMBERLANDA</speaker>
             <l>Lungo spazio s'è dato e lungo rischio</l>
             <l>ha corso testa de la tua più degna:</l>
@@ -2304,7 +2344,7 @@ C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
             <l>ardisca contra lei di tesser frodi</l>
             <l part="I">e perigli di vita.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l part="F">Ahi, com'è vero</l>
             <l>che cor ingiusto, in oltraggiando altrui,</l>
@@ -2312,21 +2352,21 @@ C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
             <l>credimi, fa temer la tua reina,</l>
             <l part="I">non arte o insidia mia.</l>
           </sp>
-          <sp>
+          <sp who="#conte_di_comberlandia">
             <speaker>C. <emph>di</emph> COMBERLANDA</speaker>
             <l part="F">Ancor ardisci</l>
             <l>di gettar biasmi, ove tu devi onori?</l>
             <l>Vanne tosto là entro, e vedrai tosto</l>
             <l part="I">se 'l fallo è altrui o tuo!</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="F">Ahi, empia mano,</l>
             <l>così sospingi e premi</l>
             <l>real persona, e vivi? Soccorriamla,</l>
             <l>vendichiamla, sorelle, o moriam seco!</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Amiche mie, il soccorso</l>
             <l>e la vendetta sia pregar perdono</l>
@@ -2348,7 +2388,7 @@ C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
             <l>di ciò umilmente e caldamente il prego,</l>
             <l>fra le preghiere estreme.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>Ove ne vai, reina?</l>
             <l>Ove ne vai, mia vita? Ove mi lasci?</l>
@@ -2365,7 +2405,7 @@ C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
             <l>in mille squarci e mille,</l>
             <l>pria che da te mi svella!</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Madre, assai lungamente m'hai mostrato</l>
             <l>che tu m'ami, e tal fede io n'ebbi sempre;</l>
@@ -2397,7 +2437,7 @@ C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
             <l>a te d'una tua amica,</l>
             <l>a me d'una sorella.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>Ciò ti darò ben tosto,</l>
             <l>ma morrò poscia teco, o mia reina:</l>
@@ -2407,7 +2447,7 @@ C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
             <l>quanto fedel t'ornai,</l>
             <l>quanto mesta or ti bacio! Ahi, ahi, ahimé!</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Or mi lascia e mi segui, se seguirmi</l>
             <l>ti concede chi forza ha sovra noi.</l>
@@ -2418,7 +2458,7 @@ C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
             <l>non vi vedrò più mai</l>
             <l>da prigion infelice!</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>Seguirò, mia reina;</l>
             <l>e che poss'io più far, che più mi piaccia?</l>
@@ -2427,7 +2467,7 @@ C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
             <l>seguirà l'alma tua l'anima mia,</l>
             <l>sciolta da queste carni.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>E noi non seguiremo?</l>
             <l>Rimarrem vive noi,</l>
@@ -2435,19 +2475,19 @@ C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
             <l>se muor la mia reina?</l>
             <l>Andiam, moriam con lei!</l>
           </sp>
-          <sp>
+          <sp who="#conte_di_comberlandia">
             <speaker>C. <emph>di</emph> COMBERLANDA</speaker>
             <l>Ferminsi queste donne! E tu, soldato,</l>
             <l part="I">vieta loro l'entrata.</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l part="F">O figlie, a Dio,</l>
             <l>a rivederci altrove,</l>
             <l>in più libera stanza e più serena,</l>
             <l>a rivederci in Cielo!</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Crudel, perché ci togli</l>
             <l>poter veder morire,</l>
@@ -2461,7 +2501,7 @@ C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
         <div type="scene">
           <head>SCENA PRIMA</head>
           <stage>MAGGIORDDUOMO <emph>e</emph> CORO.</stage>
-          <sp>
+          <sp who="#maggiorduomo">
             <speaker>MAGGIORDUOMO</speaker>
             <l>Signor, io so che là su regni e vivi,</l>
             <l>e sei dovunque è vita.</l>
@@ -2490,13 +2530,13 @@ C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
             <l>Muore Maria di Scozia e Isabella</l>
             <l part="I">d'Inghilterra l'occide!</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="F">Ohimé, che sento!</l>
             <l>È morta la mia donna,</l>
             <l>è morta la mia vita!</l>
           </sp>
-          <sp>
+          <sp who="#maggiorduomo">
             <speaker>MAGGIORDUOMO</speaker>
             <l>Vive ancor, o sorelle,</l>
             <l>la misera reina</l>
@@ -2506,25 +2546,25 @@ C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
             <l>Anzi le restan solo i danni e i mali,</l>
             <l>di che piena è la vita.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Già molt'anni corr'ella</l>
             <l>in sì duro viaggio,</l>
             <l>sotto sì duro incarco!</l>
             <l>Ma che dicon? Che fanno colà entro?</l>
           </sp>
-          <sp>
+          <sp who="#maggiorduomo">
             <speaker>MAGGIORDUOMO</speaker>
             <l>Che so io? Tutto è male,</l>
             <l>tutto è lagrime e doglia,</l>
             <l>tutto è disprezzo e scherno.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Ahi, empie e crude genti!</l>
             <l>ahi, scelerate menti!</l>
           </sp>
-          <sp>
+          <sp who="#maggiorduomo">
             <speaker>MAGGIORDUOMO</speaker>
             <l>Dato le han poco spazio ancor di vita:</l>
             <l>ed ella, poiché dentro</l>
@@ -2561,13 +2601,13 @@ C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
             <l>Piangi tu la mia vita</l>
             <l>o la mia libertade? —</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Ohimé, ché vita tale</l>
             <l>e cotal libertade</l>
             <l part="I">è mia prigione e morte!</l>
           </sp>
-          <sp>
+          <sp who="#maggiorduomo">
             <speaker>MAGGIORDUOMO</speaker>
             <l part="F">— I' piango — ho detto,</l>
             <l>e altro volea dir; ma 'l duol m'ha tronca</l>
@@ -2593,13 +2633,13 @@ C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
             <l>s'è percosso più volte e ripercosso,</l>
             <l>sospirando e gemendo.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Plachino l'ira tua questi sospiri,</l>
             <l>Signor, e li ricevi</l>
             <l part="I">per prezzo di pietade!</l>
           </sp>
-          <sp>
+          <sp who="#maggiorduomo">
             <speaker>MAGGIORDUOMO</speaker>
             <l part="F">Alfin, volendo</l>
             <l>levarsi, grave dal dolor e forse</l>
@@ -2644,12 +2684,12 @@ C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
             <l>La lascio a forza; poich'a forza m'hanno</l>
             <l part="I">cacciato di là entro.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="F">E dove resta</l>
             <l part="I">la fida cameriera?</l>
           </sp>
-          <sp>
+          <sp who="#maggiorduomo">
             <speaker>MAGGIORDUOMO</speaker>
             <l part="F">La meschina</l>
             <l>caduta è di dolore in grave ambascia.</l>
@@ -2659,7 +2699,7 @@ C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
             <l>dei conti, e dietro lor mira i ministri</l>
             <l>con l'argentate mazze.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Ahi vista acerba e dura!</l>
             <l>Tremo, tremo, mirando,</l>
@@ -2688,20 +2728,20 @@ C. <emph>di</emph> COMBERLANDA <emph>e</emph> CORO.</stage>
           <head>SCENA SECONDA</head>
           <stage>MAZZIERO, REINA, C. <emph>di</emph> COMBERLANDA,
 MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
-          <sp>
+          <sp who="#mazziero">
             <speaker>MAZZIERO</speaker>
             <l>Traetevi in disparte:</l>
             <l>lascisi aperto il varco</l>
             <l>a chi viene, a chi segue.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Lascia ch'io m'avvicini</l>
             <l>ad aiutar la mia reina, o almeno</l>
             <l>a toccarla, a vederla, ohimiei, ohimiei!</l>
             <l>Reina, ove ne vai?</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Io me ne vo a la vita,</l>
             <l>figlie, e anzi ch'io vada,</l>
@@ -2735,13 +2775,13 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>Altra era la mia voglia e la speranza:</l>
             <l>a Dio piace altrimente.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>O Dio, pietoso Dio,</l>
             <l>lasciala solo in vita</l>
             <l>e raddoppia in me i mali!</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Volgete pure i preghi</l>
             <l>a chiedermi la pace,</l>
@@ -2775,29 +2815,29 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>e per sorte compagna</l>
             <l part="I">di sventure e d'affanni.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="F">Ahimiei, ahimiei!</l>
             <l>Per me risponda il pianto,</l>
             <l>se non può la parola.</l>
             <l>Ohimé, ohimé, ohimé!</l>
           </sp>
-          <sp>
+          <sp who="#conte_di_comberlandia">
             <speaker>C. <emph>di</emph> COMBERLANDA</speaker>
             <l>Assai s'è detto; vanne!</l>
             <l part="I">Che più qui si ritarda?</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l part="F">Amico, io vado;</l>
             <l>ma chi le membra aita,</l>
             <l>sì che il piè infermo vada? I' più non posso.</l>
           </sp>
-          <sp>
+          <sp who="#maggiorduomo">
             <speaker>MAGGIORDUOMO</speaker>
             <l>Ahi, reina, ahi padrona!</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Dopo sì lungo strazio ancor ti duoli?</l>
             <l>Che hai, fedel? Che senti?</l>
@@ -2806,12 +2846,12 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>de la tua servitù cara e amata,</l>
             <l>ma mal guiderdonata.</l>
           </sp>
-          <sp>
+          <sp who="#conte_di_pembrocia">
             <speaker>C. <emph>di</emph> PEMBROCIA</speaker>
             <l>Porgile il braccio, aiuta</l>
             <l>la debil tua padrona.</l>
           </sp>
-          <sp>
+          <sp who="#maggiorduomo">
             <speaker>MAGGIORDUOMO</speaker>
             <l>Ahi, ufficio crudele</l>
             <l>di sventurato servo,</l>
@@ -2819,7 +2859,7 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>Io, dunque, ti conduco, o mia reina,</l>
             <l>ti conduco a la morte!</l>
           </sp>
-          <sp>
+          <sp who="#reina">
             <speaker>REINA</speaker>
             <l>Vieni, caro, vien meco.</l>
             <l>Nulla più potrai far, che caro sia,</l>
@@ -2832,14 +2872,14 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>e pregarmi virtute e sofferenza,</l>
             <l>in così orribil varco.</l>
           </sp>
-          <sp>
+          <sp who="#maggiorduomo">
             <speaker>MAGGIORDUOMO</speaker>
             <l>Ahi, che 'l petto si serra,</l>
             <l>ned altro posso, ohimé, se non dolermi!</l>
             <l>Lagrime e pianto, ohimé,</l>
             <l>sono, ahi, sono miei prieghi!</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Ella sen va, sorelle,</l>
             <l>e seco van questi occhi e questo core,</l>
@@ -2854,7 +2894,7 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>CAMERIERA, CARNEFICE <emph>e</emph> CORO.</stage>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>Dove, dove sen va la mia reina?</l>
             <l>Dove l'anima mia?</l>
@@ -2866,21 +2906,21 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>Ahi, mio forte dolore,</l>
             <l>come ratta mi spingi!</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>O madre, o cara madre,</l>
             <l>fedel è l'opra, ma soverchia certo:</l>
             <l>di quanto avemmo un tempo</l>
             <l>sol ci resta il dolore.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>E ci resta il morire,</l>
             <l>ch'esser prima devea;</l>
             <l>ma non fie tardo or anco,</l>
             <l>morremo con lei.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Moriam, ma chi ci occide,</l>
             <l>se 'l dolor non ci occide?</l>
@@ -2895,7 +2935,7 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>veggio a quella fenestra,</l>
             <l>che m'accenna ch'io miri?</l>
           </sp>
-          <sp>
+          <sp who="#carnefice">
             <speaker>CARNEFICE</speaker>
             <l>Viva Isabella, altissima reina,</l>
             <l>e lungo corso regni! E caggia e pera</l>
@@ -2903,7 +2943,7 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>contra lei, contra i suoi giusti decreti</l>
             <l>e le sue giuste leggi!</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Ahi, che veggion questi occhi,</l>
             <l>ahi, che mi mostra il crudo!</l>
@@ -2930,7 +2970,7 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>MAGGIORDUOMO, CAMERIERA <emph>e</emph> CORO.</stage>
-          <sp>
+          <sp who="#maggiorduomo">
             <speaker>MAGGIORDUOMO</speaker>
             <l>Io vivo, lasso, io vivo;</l>
             <l>vive la vita mia,</l>
@@ -2943,7 +2983,7 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>crudo il Ciel, che tant'anni m'ha serbato</l>
             <l>a sì grave dolore!</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Ohimiei, ohimiei, ohimiei!</l>
             <l>Meschina me! Se miri</l>
@@ -2951,14 +2991,14 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>testimonio vedrai che ben sentiamo</l>
             <l>il dolor che tu senti.</l>
           </sp>
-          <sp>
+          <sp who="#maggiorduomo">
             <speaker>MAGGIORDUOMO</speaker>
             <l>Ma tanto meno senti,</l>
             <l>quanto hai veduto meno.</l>
             <l>Ahi, che non visto male</l>
             <l>è sol metà di male!</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Dolor sent'io, quanto sentir può un core;</l>
             <l>ma se stimi che cresca</l>
@@ -2968,20 +3008,20 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>e ne l'imagin forse</l>
             <l>sentirò quel che tu nel ver sentisti.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>Ohimé, misera e trista!</l>
             <l>I' ti riveggio, o cielo,</l>
             <l>ti riveggio nemico</l>
             <l part="I">d'ogni mia voglia.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="F">Madre!</l>
             <l>Torna, madre, in te stessa;</l>
             <l part="I">prendi cor, prendi spirto.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l part="F">E l'uno e l'altro</l>
             <l>m'ha tolto l'altrui morte.</l>
@@ -2989,31 +3029,31 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>A chi porgi tu aita?</l>
             <l>A chi non è più nulla.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Anzi, sei nostra guida,</l>
             <l>sei nostra madre e donna,</l>
             <l>e sei nostra reina.</l>
           </sp>
-          <sp>
+          <sp who="#maggiorduomo">
             <speaker>MAGGIORDUOMO</speaker>
             <l>Solleva, o donna antica,</l>
             <l>le membra abbandonate!</l>
             <l>Sollevati e ascolta.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>Deh, che mi puoi tu dire,</l>
             <l>se non ch'ho ragion, lassa,</l>
             <l>ho ragion di morire?</l>
           </sp>
-          <sp>
+          <sp who="#maggiorduomo">
             <speaker>MAGGIORDUOMO</speaker>
             <l>Altre cose t'apporto</l>
             <l>da chi solea già commandarti viva:</l>
             <l>or morendo ha pregato.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>Ahi, cara pregatrice,</l>
             <l>dove sei, dove andasti?</l>
@@ -3023,7 +3063,7 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>Verrò, verrò, reina,</l>
             <l>verrò, anima cara!</l>
           </sp>
-          <sp>
+          <sp who="#maggiorduomo">
             <speaker>MAGGIORDUOMO</speaker>
             <l>Appoggiata al mio braccio,</l>
             <l>come partir di qui vista l'avete,</l>
@@ -3099,7 +3139,7 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>sodisfatte di me, con l'opra ch'io</l>
             <l>potuto ho far per loro. —</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>Veggiamla, ahimé, veggiamla!</l>
             <l>Sentiamo ragionar dopo la morte</l>
@@ -3112,7 +3152,7 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>Leggi tu, ch'io non posso,</l>
             <l>sì debil è la vista.</l>
           </sp>
-          <sp>
+          <sp who="#maggiorduomo">
             <speaker>MAGGIORDUOMO</speaker>
             <l>Ned a me resta lume,</l>
             <l>tanto s'empion di lagrime questi occhi,</l>
@@ -3161,7 +3201,7 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>di lor, qual di sorelle e come uscite</l>
             <l part="I">da me, che son tua madre. —</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="F">Ahi, dolce cura</l>
             <l>di reina dolcissima e amata,</l>
@@ -3169,7 +3209,7 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>con mostrarmi materno e caro affetto</l>
             <l>di padrona perduta!</l>
           </sp>
-          <sp>
+          <sp who="#maggiorduomo">
             <speaker>MAGGIORDUOMO</speaker>
             <l>— La cameriera mia, cui sol rimane</l>
             <l>imagine di vita,</l>
@@ -3199,7 +3239,7 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>col bacio estremo a quella fronte cara</l>
             <l>ov'io amava me stessa. —</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>Ahi lettera, ahi parole,</l>
             <l>ahi dolore, ahi dolore!</l>
@@ -3217,7 +3257,7 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>dei movimenti estremi</l>
             <l>di quella vita cara.</l>
           </sp>
-          <sp>
+          <sp who="#maggiorduomo">
             <speaker>MAGGIORDUOMO</speaker>
             <l>Dirò quanto potrò, per compiacerti</l>
             <l>in voglia così amara.</l>
@@ -3246,7 +3286,7 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>incomincia quel ch'io ridir non posso,</l>
             <l>né 'l cor basta a dar moto a questa lingua.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Deh, ragiona, ti prego:</l>
             <l>fatta è l'alma di gielo</l>
@@ -3254,7 +3294,7 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>forse diverrà marmo</l>
             <l>per quelle che dirai.</l>
           </sp>
-          <sp>
+          <sp who="#maggiorduomo">
             <speaker>MAGGIORDUOMO</speaker>
             <l>Ahi, ch'io non ho più vita,</l>
             <l>se non quanto mi basta</l>
@@ -3264,7 +3304,7 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>che purtroppo mi stan fisse ne l'alma,</l>
             <l>per trafiggerla ognora!</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Parla, e passami il core</l>
             <l>col ferro, che te fère.</l>
@@ -3272,7 +3312,7 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>questa conserva tua, questa compagna</l>
             <l>di lagrime e di danno.</l>
           </sp>
-          <sp>
+          <sp who="#maggiorduomo">
             <speaker>MAGGIORDUOMO</speaker>
             <l>— Credo, — ha detto la cara mia reina, —</l>
             <l>— credo — ha detto — che qui fra tanti e tanti,</l>
@@ -3344,7 +3384,7 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>Roma sacrata e il Signor suo santo.</l>
             <l>Ed eccomi a morire. —</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Accetti Dio 'l tuo sangue,</l>
             <l>o martire reina,</l>
@@ -3355,7 +3395,7 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>di restar io qui senza te, mia duce,</l>
             <l>mio sostegno e conforto!</l>
           </sp>
-          <sp>
+          <sp who="#maggiorduomo">
             <speaker>MAGGIORDUOMO</speaker>
             <l>Prende vigor quest'alma</l>
             <l>in pensar ch'ella siede ora beata</l>
@@ -3380,13 +3420,13 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>— Amico, ha detto, questo a te non tocca.</l>
             <l part="I">Mano men lorda il faccia. —</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="F">O regio sangue,</l>
             <l>come ritieni in sul morir gli spirti</l>
             <l part="I">nobili, eccelsi!</l>
           </sp>
-          <sp>
+          <sp who="#maggiorduomo">
             <speaker>MAGGIORDUOMO</speaker>
             <l part="F">Era sul fero palco,</l>
             <l>in disparte, una donna,</l>
@@ -3400,7 +3440,7 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>s'è la femina mossa e riverente</l>
             <l part="I">ha nudato il bel collo...</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l part="F">Ahi collo, ahi gola,</l>
             <l>quante volte t'ornâr queste mie mani</l>
@@ -3409,7 +3449,7 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>Or t'ha tronco aspro ferro e tetro sangue</l>
             <l>t'è orrido monile!</l>
           </sp>
-          <sp>
+          <sp who="#maggiorduomo">
             <speaker>MAGGIORDUOMO</speaker>
             <l>Indi con sol duo passi s'è accostata</l>
             <l>a la terribil falce, che 'n mirarla</l>
@@ -3433,12 +3473,12 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>abbracciata la croce, il collo ha steso</l>
             <l part="I">sotto l'orrida falce.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="F">Ahi, che si parte</l>
             <l part="I">il cor imaginando!</l>
           </sp>
-          <sp>
+          <sp who="#maggiorduomo">
             <speaker>MAGGIORDUOMO</speaker>
             <l part="F">Il fier ministro,</l>
             <l>in rimirarla tale, ha tronco tosto</l>
@@ -3454,12 +3494,12 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>riaprirsi e serrarsi, graziosa</l>
             <l>anco nei moti de la morte orrenda.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>Ahi cielo! A qual dolor, lassa, mi serbi,</l>
             <l>se questo non m'occide?</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Moristi, ahimé, moristi,</l>
             <l>o bellissima donna,</l>
@@ -3496,7 +3536,7 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>MESSO, CAMERIERA <emph>e</emph> CORO.</stage>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <l>Qui torna a voi, o donne, quel che puote</l>
             <l>a voi tornar de la padrona vostra:</l>
@@ -3506,7 +3546,7 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>le date, e componete il corpo esangue,</l>
             <l>perch'abbia sepoltura.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>È l'ufficio aspro, amaro,</l>
             <l>ma pur devuto e caro:</l>
@@ -3516,7 +3556,7 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>de l'altrui crudeltade</l>
             <l>e del nostro dolore!</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>Non più, non più sia peso</l>
             <l>di spalle così indegne e sì crudeli</l>
@@ -3524,27 +3564,27 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>ferma, lascia qui a noi quel che ci lascia</l>
             <l>d'ogni ben nostro il Cielo!</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <l>Deponete, ministri, il freddo corpo,</l>
             <l>e lasciaten la cura</l>
             <l>a chi ha d'averne cura.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>A me la cura tocca</l>
             <l>di queste membra care:</l>
             <l>io vive le trattai, vive le ornai;</l>
             <l>or piangerolle, or serberolle morte!</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Tolgasi il panno oscuro,</l>
             <l>e sorga agli occhi lagrimosi e tristi</l>
             <l>vista molto più oscura,</l>
             <l>ohimiei, ohimiei, ohimiei!</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>Così dunque ti veggio e così torni</l>
             <l>a me, o mia reina?</l>
@@ -3565,12 +3605,12 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>o già gloria di Francia,</l>
             <l>o speranza di Scozia!</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>O mio sostegno, o vita</l>
             <l>di mille genti e mille, ohimiei, ohimiei!</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <l>Avrai tu sepoltura</l>
             <l>da questa man, ch'esser devea sepolta,</l>
@@ -3593,7 +3633,7 @@ MAGGIORDUOMO, C. <emph>di</emph> PEMBROCIA <emph>e</emph> CORO.</stage>
             <l>se non reliquia lagrimosa, amara,</l>
             <l>da farmi morir sempre!</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Ahi, miserabil tronco,</l>
             <l>miserabil avanzo</l>

--- a/tei/dolce-marianna.xml
+++ b/tei/dolce-marianna.xml
@@ -81,6 +81,61 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="plutone">
+            <persName>Plutone</persName>
+          </person>
+          <person xml:id="gelosia">
+            <persName>Gelosia</persName>
+          </person>
+          <person xml:id="marianna">
+            <persName>Marianna</persName>
+          </person>
+          <person xml:id="berenice">
+            <persName>Berenice</persName>
+          </person>
+          <person xml:id="soemo">
+            <persName>Soemo</persName>
+          </person>
+          <person xml:id="erode">
+            <persName>Erode</persName>
+          </person>
+          <person xml:id="solome">
+            <persName>Solome</persName>
+          </person>
+          <person xml:id="coppiere">
+            <persName>Coppiere</persName>
+          </person>
+          <person xml:id="beniamino">
+            <persName>Beniamino</persName>
+          </person>
+          <person xml:id="alessandro">
+            <persName>Alessandro</persName>
+          </person>
+          <person xml:id="alessandra">
+            <persName>Alessandra</persName>
+          </person>
+          <person xml:id="cor">
+            <persName>Coro</persName>
+          </person>
+          <person xml:id="consigliere">
+            <persName>Consigliere</persName>
+          </person>
+          <person xml:id="nunzio">
+            <persName>Nunzio</persName>
+          </person>
+          <person xml:id="aristobolo">
+            <persName>Aristobolo</persName>
+          </person>
+          <person xml:id="soldati">
+            <persName>Soldati di Erode</persName>
+          </person>
+          <person xml:id="messo">
+            <persName>Messo</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -214,7 +269,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
       <prologue>
         <head>PROLOGO SECONDO</head>
         <stage>PLUTONE e la GELOSIA</stage>
-        <sp>
+        <sp who="#plutone">
           <speaker>
             <add resp="#ed">PLUT.</add>
           </speaker>
@@ -285,7 +340,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
             <l>Di sempre verde e sempiterno alloro.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#gelosia">
           <speaker>GEL.</speaker>
           <lg type="nondefinito">
             <l>Re de' dannati e Dio bel basso regno,</l>
@@ -304,7 +359,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
             <l>Sia di bagnarmi ogn'or ne l'altrui sangue.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#plutone">
           <speaker>PLUT.</speaker>
           <lg type="nondefinito">
             <l>Quanta la forza è di tal mostro rio,</l>
@@ -426,7 +481,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
         <head>ATTO PRIMO</head>
         <div type="scene">
           <stage>MARIANNA <emph>Reina</emph>, BERENICE <emph>Nudrice</emph></stage>
-          <sp>
+          <sp who="#marianna">
             <speaker>
               <add resp="#ed">MAR.</add>
             </speaker>
@@ -456,7 +511,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Segua, ch'io nel desio, la morte mia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#berenice">
             <speaker>BER.</speaker>
             <lg type="nondefinito">
               <l>Cara figlia e Reina,</l>
@@ -464,7 +519,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>A formar tali accenti?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marianna">
             <speaker>MAR.</speaker>
             <lg type="nondefinito">
               <l>Deh, come sarà mai, Nudrice amica,</l>
@@ -510,7 +565,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>In qual ti conterò, s'udir ti cale.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#berenice">
             <speaker>BER.</speaker>
             <lg type="nondefinito">
               <l>Reina, ben sapete</l>
@@ -545,7 +600,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>De' pensier vostri secretaria antica.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marianna">
             <speaker>MAR.</speaker>
             <lg type="nondefinito">
               <l>Se dir mi dèi crudel, saprai dapoi</l>
@@ -595,7 +650,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>A mia madre, al mio Eunuco è manifesta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#berenice">
             <speaker>BER.</speaker>
             <lg type="nondefinito">
               <l>Non sono da sprezzar, Reina, i sogni:</l>
@@ -606,7 +661,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Né dubitar che sian l'imagin false.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marianna">
             <speaker>MAR.</speaker>
             <lg type="nondefinito">
               <l>Tu dèi saper ch'Erode (il qual giamai</l>
@@ -657,7 +712,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Ma non è la mia mano avezza al ferro.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#berenice">
             <speaker>BER.</speaker>
             <lg type="nondefinito">
               <l>Fiera imposizion fu veramente</l>
@@ -680,7 +735,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Sovra molte ragion ferma s'appoggia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marianna">
             <speaker>MAR.</speaker>
             <lg type="nondefinito">
               <l>Crudeltà con amor non pò aver loco:</l>
@@ -694,7 +749,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>A ritrovar il tuo fratello e l'avo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#berenice">
             <speaker>BER.</speaker>
             <lg type="nondefinito">
               <l>Amor a punto fa di questi effetti,</l>
@@ -702,7 +757,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Indi cresce il suo ardor e più s'affina.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marianna">
             <speaker>MAR.</speaker>
             <lg type="nondefinito">
               <l>Adunque io, che son nata (ahi, che ne piango)</l>
@@ -732,7 +787,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>(Ben lo conosco) de la propria morte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#berenice">
             <speaker>BER.</speaker>
             <lg type="nondefinito">
               <l>Ragion non veggio, onde per voi si tema</l>
@@ -773,7 +828,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
         </div>
         <div type="scene">
           <stage>SOEMO, MARIANNA</stage>
-          <sp>
+          <sp who="#soemo">
             <speaker>
               <add resp="#ed">SOE.</add>
             </speaker>
@@ -805,7 +860,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>E per giovar a voi non tema morte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marianna">
             <speaker>MAR.</speaker>
             <lg type="nondefinito">
               <l>Soemo, ei non accade con parole</l>
@@ -820,7 +875,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>In te sempre conobbi amor e fede.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#soemo">
             <speaker>SOE.</speaker>
             <lg type="nondefinito">
               <l>Voi devete saper, Reina, adunque,</l>
@@ -942,7 +997,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Che per le sante leggi e per l'onesto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marianna">
             <speaker>MAR.</speaker>
             <lg type="nondefinito">
               <l>Leale e vero amico, il ciel m'ha dato</l>
@@ -974,13 +1029,13 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Ei non fia per udir parola alcuna.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#soemo">
             <speaker>SOE.</speaker>
             <lg type="nondefinito">
               <l>È prudenza, Reina, il fuggir morte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marianna">
             <speaker>MAR.</speaker>
             <lg type="nondefinito">
               <l>Non per restar in vergognosa vita.</l>
@@ -1004,7 +1059,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Farà de' vostri affanni alta vendetta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marianna">
             <speaker>MAR.</speaker>
             <lg type="nondefinito">
               <l>Molte cose nel dir facili sono</l>
@@ -1014,7 +1069,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>E di ciò ne vedrai cortese effetto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#soemo">
             <speaker>SOE.</speaker>
             <lg type="nondefinito">
               <l>Vaglivi in questo la prudenza vostra.</l>
@@ -1024,13 +1079,13 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Presto ad ogni successo, o buono o reo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marianna">
             <speaker>MAR.</speaker>
             <lg type="nondefinito">
               <l>Et io vo dentro a disfogar il core.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#soemo">
             <speaker>SOE.</speaker>
             <lg type="nondefinito">
               <l>Come dietro al balen seguita il tuono,</l>
@@ -1124,7 +1179,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
         <head>ATTO SECONDO</head>
         <div type="scene">
           <stage>ERODE, SOLOME</stage>
-          <sp>
+          <sp who="#erode">
             <speaker>
               <add resp="#ed">ER.</add>
             </speaker>
@@ -1227,7 +1282,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
         </div>
         <div type="scene">
           <stage>COPPIERE, ERODE</stage>
-          <sp>
+          <sp who="#coppiere">
             <speaker>
               <add resp="#ed">COP.</add>
             </speaker>
@@ -1243,7 +1298,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Io v'appresento di mia mano il vino.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Tu porgi orecchie a le parole mie,</l>
@@ -1253,7 +1308,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Vorrò saper quel che saper desio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coppiere">
             <speaker>COP.</speaker>
             <lg type="nondefinito">
               <l>Signor, da questa lingua intenderete</l>
@@ -1261,28 +1316,28 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Come sempre dee far servo fedele.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Dunque mi di': quand'è c'hai favellato</l>
               <l part="I">Con Marianna mia?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coppiere">
             <speaker>COP.</speaker>
             <lg type="nondefinito">
               <l part="F">Signor, io credo</l>
               <l>Che fornite non sian quattro o cinqu'ore.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Le parlasti da lei sendo chiamato,</l>
               <l>O pur da te movesti a questo effetto?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coppiere">
             <speaker>COP.</speaker>
             <lg type="nondefinito">
               <l>Ella con molta instanza mi ridusse</l>
@@ -1291,75 +1346,75 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Ch'al pensar mi si arricciano le chiome.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Questo adunque convien che mi palesi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coppiere">
             <speaker>COP.</speaker>
             <lg type="nondefinito">
               <l>Deh lasciate, Signor, ch'io lo vi taccia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Tacer vorrai quel che scoprir mi dèi,</l>
               <l>Posto ch'ancora ei non m'appartenesse?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coppiere">
             <speaker>COP.</speaker>
             <lg type="nondefinito">
               <l>Anzi appartiene a la persona vostra.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>E tu fin qui tenerlo chiuso ardisci?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coppiere">
             <speaker>COP.</speaker>
             <lg type="nondefinito">
               <l>Non vorrei, Signor mio, che 'l divolgarlo</l>
               <l>Apportasse alcun danno a la Reina.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Hai più cura di lei che di me stesso?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coppiere">
             <speaker>COP.</speaker>
             <lg type="nondefinito">
               <l>Basta, Signor, che non sarete offeso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Dunque pensasti tu di farmi offesa?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coppiere">
             <speaker>COP.</speaker>
             <lg type="nondefinito">
               <l>Io no, Signor, ma la consorte vostra.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Et osi ancor d'invilupparmi il vero?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coppiere">
             <speaker>COP.</speaker>
             <lg type="nondefinito">
               <l>Non vogliate, vi prego, intender cosa</l>
@@ -1377,7 +1432,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Apporti a gli occhi miei l'ultima luce.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Non voler più, con differirmi il vero,</l>
@@ -1387,7 +1442,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Ti farò dir ciò che tu vai tacendo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coppiere">
             <speaker>COP.</speaker>
             <lg type="nondefinito">
               <l>Poi che così volete, io v'obedisco,</l>
@@ -1413,7 +1468,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Quand'io l'avessi rapportato a voi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Questo delitto è così strano e grave,</l>
@@ -1425,7 +1480,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Over con qualche testimon, lo provi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coppiere">
             <speaker>COP.</speaker>
             <lg type="nondefinito">
               <l>Re, chi si move a far alcun delitto,</l>
@@ -1435,7 +1490,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>De l'altra non ne possa aver contezza.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Per questo Marianna non devea</l>
@@ -1446,7 +1501,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Di venir al suo fin per altra via.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coppiere">
             <speaker>COP.</speaker>
             <lg type="nondefinito">
               <l>Ella a cotal effetto non poteva</l>
@@ -1469,51 +1524,51 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Per la lingua medesma del suo Eunuco.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Partecipe è costui di tal segreto?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coppiere">
             <speaker>COP.</speaker>
             <lg type="nondefinito">
               <l>È partecipe, e dir posso compagno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Come compagno? Io non intendo questo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coppiere">
             <speaker>COP.</speaker>
             <lg type="nondefinito">
               <l>Egli trovò il veneno, egli lo serba.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>E chi sa che non siate ambi d'accordo,</l>
               <l>A morte e a disonor di Marianna?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coppiere">
             <speaker>COP.</speaker>
             <lg type="nondefinito">
               <l>Qual dee cagion indurci a tanto male?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Lo stimolo d'alcun ch'odia costei,</l>
               <l>O porta invidia al mio tranquillo stato.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coppiere">
             <speaker>COP.</speaker>
             <lg type="nondefinito">
               <l>Io dirò, Signor mio, con veritate</l>
@@ -1526,7 +1581,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Creduto officio di cotanto peso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Ciascuno è buon, pria che commetta il male.</l>
@@ -1539,7 +1594,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Gli augelli pascerai de le tue carni.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coppiere">
             <speaker>COP.</speaker>
             <lg type="nondefinito">
               <l>Signor, ho detto espressamente il vero,</l>
@@ -1553,14 +1608,14 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Poiché l'Eunuco il custodisce e serba.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Basta. Daratti il cuor di sostenere</l>
               <l>Quanto m'affermi a la Reina avanti?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coppiere">
             <speaker>COP.</speaker>
             <lg type="nondefinito">
               <l>Questo io farò, benché mal volentieri,</l>
@@ -1568,7 +1623,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Che, dopo voi, a sua persona io porto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>La riverenza che portassi a lei,</l>
@@ -1579,7 +1634,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Poi mi riserbo interrogar l'Eunuco.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coppiere">
             <speaker>COP.</speaker>
             <lg type="nondefinito">
               <l>Non bisogna, Signor, che voi mandiate,</l>
@@ -1589,7 +1644,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
         </div>
         <div type="scene">
           <stage>MARIANNA, ERODE, COPPIERE</stage>
-          <sp>
+          <sp who="#marianna">
             <speaker>
               <add resp="#ed">MAR.</add>
             </speaker>
@@ -1602,7 +1657,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>A ragionar di me come di rea.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Marianna, io torrei perder il regno,</l>
@@ -1611,7 +1666,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>D'imputarti, o crudel, delitto alcuno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marianna">
             <speaker>MAR.</speaker>
             <lg type="nondefinito">
               <l>Se delitto è l'avervi amato sempre</l>
@@ -1620,7 +1675,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Avete alta cagion d'odiarmi ogniora.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Non m'accade mostrar quel che t'è chiaro,</l>
@@ -1632,7 +1687,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Procuri crudelmente or la mia morte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marianna">
             <speaker>MAR.</speaker>
             <lg type="nondefinito">
               <l>Questa scelerità, ch'e vana e falsa,</l>
@@ -1648,7 +1703,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Che far non mi si può cosa più cara.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Chi disprezza la vita non conosce</l>
@@ -1660,7 +1715,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Di far cosa, onde sii degna di morte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marianna">
             <speaker>MAR.</speaker>
             <lg type="nondefinito">
               <l>Io fin qui non commisi alcun peccato</l>
@@ -1672,7 +1727,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Di molte avute offese al Re del cielo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Cosa non è che maggiormente offenda</l>
@@ -1719,7 +1774,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Ma parmi aver la man sopra il veneno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marianna">
             <speaker>MAR.</speaker>
             <lg type="nondefinito">
               <l>Erode, da quel dì che mi prendeste</l>
@@ -1779,7 +1834,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>A che parlato di veneno avete.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Io non so, Marianna, onde tu prenda</l>
@@ -1812,28 +1867,28 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Darmi il venen, quand'ei mi porge il vino?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marianna">
             <speaker>MAR.</speaker>
             <lg type="nondefinito">
               <l>Se questo ha detto, egli ne mente; e voi</l>
               <l>Credete la bugia, se ciò credete.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Or di' tu, mio fedel, la veritate;</l>
               <l>E non aver rispetto a questa ingrata.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coppiere">
             <speaker>COP.</speaker>
             <lg type="nondefinito">
               <l>A che più replicar quel ch'io v'ho detto?</l>
               <l>Ella se 'l sa non men che lo sapp'io.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marianna">
             <speaker>MAR.</speaker>
             <lg type="nondefinito">
               <l>Et io replicherò che tu ne menti,</l>
@@ -1841,144 +1896,144 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Per far di me qual del fratello e l'avo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Or senza più tardar discopri il vero</l>
               <l>De la malvagità di questa rea.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coppiere">
             <speaker>COP.</speaker>
             <lg type="nondefinito">
               <l>Alto Re, la conscienza ha troppa forza.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Che parli di conscienza? Io ti ridico</l>
               <l>Che senza più tardar racconti il vero.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coppiere">
             <speaker>COP.</speaker>
             <lg type="nondefinito">
               <l>Dico che la conscienza ha troppa forza.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Io non so quel che di conscienza parli.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coppiere">
             <speaker>COP.</speaker>
             <lg type="nondefinito">
               <l>Se voi mi promettete di donarmi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Cortese Re senza richiesta dona.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coppiere">
             <speaker>COP.</speaker>
             <lg type="nondefinito">
               <l>Tropp'alto è 'l don che chieder vi vorrei.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Dunque vuoi patteggiar di doni meco?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coppiere">
             <speaker>COP.</speaker>
             <lg type="nondefinito">
               <l>Signor mio sì, ch'a me la vita importa.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Forse chiedermi vuoi la vita in dono?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coppiere">
             <speaker>COP.</speaker>
             <lg type="nondefinito">
               <l>Ciò bramo e chieggio, e così piaccia a voi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Cotesto è un confessar d'aver peccato.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coppiere">
             <speaker>COP.</speaker>
             <lg type="nondefinito">
               <l>Peccato ho, mio Signor, a dirvi il falso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Adunque non è ver quel che m'hai detto?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coppiere">
             <speaker>COP.</speaker>
             <lg type="nondefinito">
               <l>Anzi pura calunnia e falsa accusa.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>E chi t'ha spinto a così grave fallo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coppiere">
             <speaker>COP.</speaker>
             <lg type="nondefinito">
               <l>Hammi sospinto la sorella vostra.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Dunque tu, per gradir a mia sorella,</l>
               <l>Hai, mentitor, colpata una innocente?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coppiere">
             <speaker>COP.</speaker>
             <lg type="nondefinito">
               <l>Hollo fatto, Signor, per fuggir morte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Anzi l'hai fatto per lasciar la vita,</l>
               <l>Poi che dovevi altrui causar la morte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marianna">
             <speaker>MAR.</speaker>
             <lg type="nondefinito">
               <l>Ecco sì come Dio clemente e giusto</l>
               <l>Non comporta che 'l ver si stia nascosto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Qui certo è ascosa qualche occolta frode.</l>
@@ -1986,7 +2041,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>E questo Eunuco tuo rimanga meco.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marianna">
             <speaker>MAR.</speaker>
             <lg type="nondefinito">
               <l>Godo che quanto più voi cercarete,</l>
@@ -1995,7 +2050,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>La vita, avendo a dimorar con voi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Or tu, ministro mio, sostien costui,</l>
@@ -2007,7 +2062,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
         </div>
         <div type="scene">
           <stage>ERODE, BENIAMINO Eunuco</stage>
-          <sp>
+          <sp who="#erode">
             <speaker>
               <add resp="#ed">ER.</add>
             </speaker>
@@ -2063,7 +2118,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>L'arbitrio è in te di prender questo o quello.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#beniamino">
             <speaker>BEN.</speaker>
             <lg type="nondefinito">
               <l>Re, mio Signor, d'aver io non conosco</l>
@@ -2099,7 +2154,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Chiudete gli occhi e non ve n'avedete.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Si suol dir per proverbio antico e vero</l>
@@ -2109,7 +2164,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Perché fin qui me gli hai tenuto ascosi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#beniamino">
             <speaker>BEN.</speaker>
             <lg type="nondefinito">
               <l>Sapete ben che ne gli abbietti e vili</l>
@@ -2118,7 +2173,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Con gran difficultà s'ascolta il vero.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Anzi coloro i quali han maggior forza</l>
@@ -2129,7 +2184,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Qual sono i traditor de' quai favelli?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#beniamino">
             <speaker>BEN.</speaker>
             <lg type="nondefinito">
               <l>Signor, io so come la bontà vostra</l>
@@ -2138,7 +2193,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Ch'ad alcun altro non avria commesso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>O giustizia di Dio, che non consenti</l>
@@ -2147,20 +2202,20 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Stimo che fedelmente abbia esequito.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#beniamino">
             <speaker>BEN.</speaker>
             <lg type="nondefinito">
               <l>Io credo ch'esequita abbia ciascuna,</l>
               <l>Ma non quella che più d'altre devea.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>E quale è quella c'ha lasciato a dietro?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#beniamino">
             <speaker>BEN.</speaker>
             <lg type="nondefinito">
               <l>Dirò liberamente, poi che voi</l>
@@ -2181,7 +2236,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Da servo disleal, perfido e ingrato.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Questa è la verità, né vo' negarla:</l>
@@ -2201,7 +2256,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Ma tu, com'hai saputo un tal secreto?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#beniamino">
             <speaker>BEN.</speaker>
             <lg type="nondefinito">
               <l>Soemo lo scoperse a la Reina.</l>
@@ -2212,7 +2267,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Acciò ch'al fin lo rivelassi a voi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Or ben conoscer mi si fa quel ch'io</l>
@@ -2351,7 +2406,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Del Re del ciel, che sol puote aiutarci.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marianna">
             <speaker>MAR.</speaker>
             <lg type="nondefinito">
               <l>Tutto quel, madre pia, che prevedete</l>
@@ -2414,7 +2469,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Onorata sarà di miglior vita.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cor">
             <speaker>COR.</speaker>
             <lg type="nondefinito">
               <l>Reina, voi potete leggermente</l>
@@ -2433,7 +2488,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
         </div>
         <div type="scene">
           <stage>ERODE, MARIANNA, CONSIGLIERE</stage>
-          <sp>
+          <sp who="#erode">
             <speaker>
               <add resp="#ed">ER.</add>
             </speaker>
@@ -2452,7 +2507,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Ma 'l premio ti darò conforme al merto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marianna">
             <speaker>MAR.</speaker>
             <lg type="nondefinito">
               <l>Erode, l'esser voi geloso a torto</l>
@@ -2470,7 +2525,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>E casta, più che voi Re giusto e buono.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Io non contenderò teco in parole,</l>
@@ -2482,7 +2537,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Lei parimente e la sua ingiusta madre.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#consigliere">
             <speaker>CONS.</speaker>
             <lg type="nondefinito">
               <l>Re, per quel che tra me vo discorrendo</l>
@@ -2513,7 +2568,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Ne la sua propria causa un altro cerca.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Quando un delitto è manifesto e chiaro,</l>
@@ -2546,7 +2601,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Di che tal fallo e l'adulterio è degno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#consigliere">
             <speaker>CONS.</speaker>
             <lg type="nondefinito">
               <l>Veggio, Signor, che la credenza vostra</l>
@@ -2637,7 +2692,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Ch'ogni adulazion da me disgombra.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Sì come chi non ha figli non puote</l>
@@ -2669,7 +2724,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Voglio che l'adulterio ei mi confessi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#consigliere">
             <speaker>CONS.</speaker>
             <lg type="nondefinito">
               <l>Signor, io stimerò che tutto quello</l>
@@ -2682,7 +2737,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Ch'apporta duol senza rimedio al fine.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Io lo veggo venir, e per le vene</l>
@@ -2693,7 +2748,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
         </div>
         <div type="scene">
           <stage>SOEMO, ERODE, CONSIGLIERE</stage>
-          <sp>
+          <sp who="#soemo">
             <speaker>
               <add resp="#ed">SOE.</add>
             </speaker>
@@ -2702,13 +2757,13 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Ogni felicità, vi dia salute.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>E porga a te la gioia che tu merti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#soemo">
             <speaker>SOE.</speaker>
             <lg type="nondefinito">
               <l>In che vi fa mistieri or di servirvi</l>
@@ -2716,7 +2771,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Ha mandato per me con tanta fretta?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Sendo verso di me tanto fedele,</l>
@@ -2724,7 +2779,7 @@ In Venezia ai xxv di Maggio M D LXV.</p>
               <l>Da te medesmo imaginar tel puoi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#soemo">
             <speaker>
 SOE.</speaker>
             <lg type="nondefinito">
@@ -2745,21 +2800,21 @@ SOE.</speaker>
               <l>Non una sol, ma molte esperienze.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Massime nel segreto ch'io commisi</l>
               <l>Ultimamente a la tua tanta fede.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#soemo">
             <speaker>SOE.</speaker>
             <lg type="nondefinito">
               <l>In questo e in ciascun altro parimente</l>
               <l>Che vi degnaste in alcun tempo impormi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Se così fedelmente t'hai portato</l>
@@ -2768,20 +2823,20 @@ SOE.</speaker>
               <l>Né maggior traditor, di quel che sei.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#consigliere">
             <speaker>CONS.</speaker>
             <lg type="nondefinito">
               <l>Deh temprate, Signor, temprate l'ira.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>La tua perfidia t'è di mente uscita?</l>
               <l>O stimi ch'ella a me non sia palese?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#soemo">
             <speaker>SOE.</speaker>
             <lg type="nondefinito">
               <l>Se perfido è il fedel, che fia l'infido?</l>
@@ -2790,7 +2845,7 @@ SOE.</speaker>
               <l>Cosa che non è in me, né fia giamai.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Quello ch'io ti commisi nel partire,</l>
@@ -2810,7 +2865,7 @@ SOE.</speaker>
               <l>Come l'avesse morso un freddo serpe.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#soemo">
             <speaker>SOE.</speaker>
             <lg type="nondefinito">
               <l>Signor, qual volta io penso a la gran forza</l>
@@ -2818,7 +2873,7 @@ SOE.</speaker>
               <l>ER.Tu pigli da lontan la tua risposta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#consigliere">
             <speaker>CONS.</speaker>
             <lg type="nondefinito">
               <l>Concedete, Signor, ch'egli risponda</l>
@@ -2826,7 +2881,7 @@ SOE.</speaker>
               <l>Che ciò non può adombrar la veritate.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#soemo">
             <speaker>SOE.</speaker>
             <lg type="nondefinito">
               <l>Io mi sento tremar dal capo al piede:</l>
@@ -2884,7 +2939,7 @@ SOE.</speaker>
               <l>Se l'uomo non peccasse alcuna volta?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>L'infirmità ch'offende il corpo umano,</l>
@@ -2928,7 +2983,7 @@ SOE.</speaker>
               <l>Al to grave delitto in parte eguale.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#soemo">
             <speaker>SOE.</speaker>
             <lg type="nondefinito">
               <l>Signor, il fallo mio scusar non voglio,</l>
@@ -2975,7 +3030,7 @@ SOE.</speaker>
               <l>E se dir più potessi, i' più direi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Se l'esser tu, sì come sei nel vero</l>
@@ -3009,7 +3064,7 @@ SOE.</speaker>
               <l>Che 'l giusto voler mio resti adempito.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#soemo">
             <speaker>SOE.</speaker>
             <lg type="nondefinito">
               <l>Erode, come io ne morrò innocente,</l>
@@ -3020,7 +3075,7 @@ SOE.</speaker>
         </div>
         <div type="scene">
           <stage>ERODE, CONSIGLIERE</stage>
-          <sp>
+          <sp who="#erode">
             <speaker>
               <add resp="#ed">ER.</add>
             </speaker>
@@ -3048,7 +3103,7 @@ SOE.</speaker>
               <l>Portar debba vittoria del mio core.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#consigliere">
             <speaker>CONS.</speaker>
             <lg type="nondefinito">
               <l>Signor, parmi soverchio il confortarvi</l>
@@ -3118,7 +3173,7 @@ SOE.</speaker>
               <l>Attribuite questo a la mia fede.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Io conosco in gran parte che son vere</l>
@@ -3210,7 +3265,7 @@ SOE.</speaker>
         <head>ATTO QUARTO</head>
         <div type="scene">
           <stage>NUNZIO, CORO</stage>
-          <sp>
+          <sp who="#nunzio">
             <speaker>
               <add resp="#ed">NUN.</add>
             </speaker>
@@ -3250,7 +3305,7 @@ SOE.</speaker>
               <l>I giorni suoi con non devuta morte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cor">
             <speaker>COR.</speaker>
             <lg type="nondefinito">
               <l>Pur dunque è stato ucciso</l>
@@ -3288,7 +3343,7 @@ SOE.</speaker>
               <l>D'oscuro e negro vel chiuso e coperto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nunzio">
             <speaker>NUN.</speaker>
             <lg type="nondefinito">
               <l>Come è avenuto il fin di quel meschino,</l>
@@ -3298,13 +3353,13 @@ SOE.</speaker>
               <l>Quel che 'l bacin d'argento in sé nasconde.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cor">
             <speaker>COR.</speaker>
             <lg type="nondefinito">
               <l>O rettor delle stelle, e che fia questo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nunzio">
             <speaker>NUN.</speaker>
             <lg type="nondefinito">
               <l>Voi tosto lo vedrete. Ecco il Re nostro.</l>
@@ -3313,7 +3368,7 @@ SOE.</speaker>
         </div>
         <div type="scene">
           <stage>ERODE, NUNZIO, CORO</stage>
-          <sp>
+          <sp who="#erode">
             <speaker>
               <add resp="#ed">ER.</add>
             </speaker>
@@ -3323,7 +3378,7 @@ SOE.</speaker>
               <l>Del traditor e iniquo di Soemo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nunzio">
             <speaker>NUN.</speaker>
             <lg type="nondefinito">
               <l>Signor, subitamente ei fu dal boia</l>
@@ -3332,7 +3387,7 @@ SOE.</speaker>
               <l>Che vi fossero innanzi appresentate.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>O reliquie d'un empio e traditore,</l>
@@ -3342,14 +3397,14 @@ SOE.</speaker>
               <l>Né spettacol giarnai mi fu sì grato.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cor">
             <speaker>COR.</speaker>
             <lg type="nondefinito">
               <l>O cosa empia e inumana!</l>
               <l>O spettacolo orrendo e dispietato!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Voi non ardite di formar parole</l>
@@ -3359,7 +3414,7 @@ SOE.</speaker>
               <l>Come avenuto è il fin di parte in parte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nunzio">
             <speaker>NUN.</speaker>
             <lg type="nondefinito">
               <l>Signor, saper devrete che Soemo</l>
@@ -3420,13 +3475,13 @@ SOE.</speaker>
               <l>A l'empio suo furor, degno gastigo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>O tristo e mentitor fino a la morte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nunzio">
             <speaker>NUN.</speaker>
             <lg type="nondefinito">
               <l>Poi che questo ebbe detto, incontanente</l>
@@ -3438,7 +3493,7 @@ SOE.</speaker>
               <l>ER. Egli se n'avedrà giù ne l'Inferno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nunzio">
             <speaker>NUN.</speaker>
             <lg type="nondefinito">
               <l>Cadde il tronco versando un rio di sangue.</l>
@@ -3459,7 +3514,7 @@ SOE.</speaker>
               <l>Ch'ordinaste ch'a voi fosser portate.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>La pena fu minor del suo demerto,</l>
@@ -3474,7 +3529,7 @@ SOE.</speaker>
               <l>E la mia fida guardia l'accompagni.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cor">
             <speaker>COR</speaker>
             <lg type="nondefinito">
               <l>. Eccomi obediente</l>
@@ -3484,14 +3539,14 @@ SOE.</speaker>
               <l>Che sempre esempio fu di castitate.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Rimase di tal morte sodisfatto</l>
               <l>Il popolo, o mostrò che gli dolesse?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nunzio">
             <speaker>NUN.</speaker>
             <lg type="nondefinito">
               <l>Questo affermar non so: che la paura</l>
@@ -3500,7 +3555,7 @@ SOE.</speaker>
               <l>Parve ch'a tutti ciò premesse molto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>L'ignoranza è cagion ne la vil turba</l>
@@ -3512,7 +3567,7 @@ SOE.</speaker>
               <l>Onde di lui far non si deve stima.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nunzio">
             <speaker>NUN.</speaker>
             <lg type="nondefinito">
               <l>Ma ecco, Signor mio, la guardia et ecco</l>
@@ -3522,7 +3577,7 @@ SOE.</speaker>
         </div>
         <div type="scene">
           <stage>ERODE, MARIANNA, NUNZIO</stage>
-          <sp>
+          <sp who="#erode">
             <speaker>
               <add resp="#ed">ER.</add>
             </speaker>
@@ -3550,7 +3605,7 @@ SOE.</speaker>
               <l>Quel che sempre con l'animo ha veduto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marianna">
             <speaker>MAR.</speaker>
             <lg type="nondefinito">
               <l>Crudel Erode: io non dirò mai Rege,</l>
@@ -3561,7 +3616,7 @@ SOE.</speaker>
               <l>Le sue reliquie, come gemme, avanti?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Tu, Nunzio, or ben solleva alta la testa:</l>
@@ -3580,7 +3635,7 @@ SOE.</speaker>
               <l>A' merti tuoi più convenevol dono.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marianna">
             <speaker>MAR.</speaker>
             <lg type="nondefinito">
               <l>Di Dio nimico e de la gente umana,</l>
@@ -3672,7 +3727,7 @@ SOE.</speaker>
               <l>E quella di Soemo ti perdoni.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Due cose m'hanno, scelerata donna,</l>
@@ -3717,7 +3772,7 @@ SOE.</speaker>
               <l>Di morte a te parrà che sia men grave.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marianna">
             <speaker>MAR.</speaker>
             <lg type="nondefinito">
               <l>Io torno a dir ch'ogni più cruda morte</l>
@@ -3728,7 +3783,7 @@ SOE.</speaker>
               <l>Donna non morì mai di me più lieta,</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Or vanne dentro, e voi la seguitate;</l>
@@ -3736,7 +3791,7 @@ SOE.</speaker>
               <l>Quanto da me di lei ti fia commesso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nunzio">
             <speaker>NUN.</speaker>
             <lg type="nondefinito">
               <l>Signor, aspetto che mi comandiate</l>
@@ -3744,7 +3799,7 @@ SOE.</speaker>
               <l>De le reliquie ch'ancor tengo in mano.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Dalle a mangiar subitamente a' cani;</l>
@@ -3752,7 +3807,7 @@ SOE.</speaker>
               <l>Perché degni non son di sepoltura.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nunzio">
             <speaker>NUN.</speaker>
             <lg type="nondefinito">
               <l>Io farò tutto quel che m'imponete.</l>
@@ -3761,7 +3816,7 @@ SOE.</speaker>
         </div>
         <div type="scene">
           <stage>BERENICE, ERODE, ALESSANDRO, ARISTOBOLO <emph>figliuoli d'Erode</emph>, CORO, <add resp="#ed">SOLDATI <emph>di Erode</emph></add></stage>
-          <sp>
+          <sp who="#berenice">
             <speaker>
               <add resp="#ed">BER.</add>
             </speaker>
@@ -3789,7 +3844,7 @@ SOE.</speaker>
               <l>Che moia, com'è questa, un'innocente.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Semplice vecchia, il numero de gli anni</l>
@@ -3801,7 +3856,7 @@ SOE.</speaker>
               <l>Ma t'affatichi indarno: or ti diparti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#berenice">
             <speaker>BER.</speaker>
             <lg type="nondefinito">
               <l>Poi ch'io non posso ritrovar pietade,</l>
@@ -3824,7 +3879,7 @@ SOE.</speaker>
               <l>Usar effetto alcun contra le leggi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Voi non parlate come si conviene.</l>
@@ -3839,7 +3894,7 @@ SOE.</speaker>
               <l>Che si conviene a l'obligo de' figli.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Io non vi riconosco per figliuoli.</l>
@@ -3882,7 +3937,7 @@ SOE.</speaker>
               <l>Imparando da voi l'esser crudele.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristobolo">
             <speaker>ARIS.</speaker>
             <lg type="nondefinito">
               <l>Io non so se chiamar padre vi debba,</l>
@@ -3903,7 +3958,7 @@ SOE.</speaker>
               <l>La farà certo un dì la man divina.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cor">
             <speaker>COR.</speaker>
             <lg type="nondefinito">
               <l>Ah tolga il Re del cielo</l>
@@ -3911,7 +3966,7 @@ SOE.</speaker>
               <l>Che sia d'infamia a la presente etade.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Le parole da voi, malvagi, dette</l>
@@ -3953,13 +4008,13 @@ SOE.</speaker>
               <l>E li chiedi perdon di quel c'hai detto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristobolo">
             <speaker>ARIS.</speaker>
             <lg type="nondefinito">
               <l>Padre. . .</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Parlar più non bisogna: io non t'ascolto.</l>
@@ -3975,7 +4030,7 @@ SOE.</speaker>
               <l>Ma prendeteli al tutto, o vivi, o morti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cor">
             <speaker>COR.</speaker>
             <lg type="nondefinito">
               <l>O crudeltate immensa!</l>
@@ -3990,7 +4045,7 @@ SOE.</speaker>
               <l>O lagrimoso giorno!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#soldati">
             <speaker>SOLD.</speaker>
             <lg type="nondefinito">
               <l>Ecco la volontà vostra eseguita.</l>
@@ -4009,7 +4064,7 @@ SOE.</speaker>
               <l>E succedan nel regno i vostri eguali.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aristobolo">
             <speaker>ARIS.</speaker>
             <lg type="nondefinito">
               <l>Condannateci tosto, acciò che tosto</l>
@@ -4018,7 +4073,7 @@ SOE.</speaker>
               <l>Aspettando da Dio giusta vendetta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>S'ambi costoro in sì immatura etade</l>
@@ -4048,7 +4103,7 @@ SOE.</speaker>
               <l>Mi porti il Nunzio la bramata nova.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cor">
             <speaker>COR.</speaker>
             <lg type="nondefinito">
               <l>O madri ambe infelici,</l>
@@ -4064,7 +4119,7 @@ SOE.</speaker>
         </div>
         <div type="scene">
           <stage>CONSIGLIERE, ERODE</stage>
-          <sp>
+          <sp who="#consigliere">
             <speaker>
               <add resp="#ed">CONS.</add>
             </speaker>
@@ -4089,7 +4144,7 @@ SOE.</speaker>
               <l>A le ragion che per addurvi io sono.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>L'addurmi più ragioni è un perder tempo,</l>
@@ -4097,7 +4152,7 @@ SOE.</speaker>
               <l>Ch'irrevocabil sia la mia sentenza.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#consigliere">
             <speaker>CONS.</speaker>
             <lg type="nondefinito">
               <l>Per Dio, rompete l'indorata mente,</l>
@@ -4105,7 +4160,7 @@ SOE.</speaker>
               <l>Vi tien per vostro mal serrati e chiusi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Quando arà avuto la sentenza effetto,</l>
@@ -4120,7 +4175,7 @@ SOE.</speaker>
               <l>Che procurò di ber tutto 'l mio sangue.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#consigliere">
             <speaker>CONS.</speaker>
             <lg type="nondefinito">
               <l>Più volte, Signor mio, torno a pregarvi,</l>
@@ -4144,62 +4199,62 @@ SOE.</speaker>
               <l>Verso di voi, Signor, sempre fedeli.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Or si ponga silenzio a questi detti:</l>
               <l>Giusta è la mia sentenza, e la confermo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#consigliere">
             <speaker>CONS.</speaker>
             <lg type="nondefinito">
               <l>Di ciò, Signor, vi pentirete al fine.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Pentito ancor non m'ho d'alcun mio fatto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#consigliere">
             <speaker>CONS.</speaker>
             <lg type="nondefinito">
               <l>Questo vi basterà per mille e mille.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Anzi questo mi fia di somma lode.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#consigliere">
             <speaker>CONS.</speaker>
             <lg type="nondefinito">
               <l>Anzi di biasmo e di perpetuo duolo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>La giustizia non fa di tali effetti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#consigliere">
             <speaker>CONS.</speaker>
             <lg type="nondefinito">
               <l>Signor mio non, ma l'ingiustizia e l'ira.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Tu meno sai, di quel che ti presumi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#consigliere">
             <speaker>CONS.</speaker>
             <lg type="nondefinito">
               <l>Se quei che 'l ver vi dicono non sanno,</l>
@@ -4298,7 +4353,7 @@ SOE.</speaker>
         <head>ATTO QUINTO</head>
         <div type="scene">
           <stage>BERENICE, CORO</stage>
-          <sp>
+          <sp who="#berenice">
             <speaker>
               <add resp="#ed">BER.</add>
             </speaker>
@@ -4323,7 +4378,7 @@ SOE.</speaker>
               <l>Accompagnate il mio sì giusto pianto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cor">
             <speaker>COR.</speaker>
             <lg type="nondefinito">
               <l>Vecchia, infelice vecchia,</l>
@@ -4337,7 +4392,7 @@ SOE.</speaker>
               <l>Quanti dentro del cor abbiam tormenti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#berenice">
             <speaker>BER.</speaker>
             <lg type="nondefinito">
               <l>O vituperio de l'umane genti,</l>
@@ -4361,7 +4416,7 @@ SOE.</speaker>
               <l>Accompagnate il mio sì giusto pianto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cor">
             <speaker>COR.</speaker>
             <lg type="nondefinito">
               <l>Or ben caduta è al fondo</l>
@@ -4375,7 +4430,7 @@ SOE.</speaker>
               <l>Che van tosto in ruina!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#berenice">
             <speaker>
               <add resp="#ed">BER.</add>
             </speaker>
@@ -4403,7 +4458,7 @@ SOE.</speaker>
               <l>Chi sa che 'l fiero Re non sia pentito.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cor">
             <speaker>
               <add resp="#ed">COR</add>
             </speaker>
@@ -4417,7 +4472,7 @@ SOE.</speaker>
         </div>
         <div type="scene">
           <stage>ERODE, MESSO,<add resp="#ed">BERENICE</add>, CORO</stage>
-          <sp>
+          <sp who="#erode">
             <speaker>
               <add resp="#ed">ER.</add>
             </speaker>
@@ -4466,7 +4521,7 @@ SOE.</speaker>
               <l>Senza rispetto: o sia malvagia, o buona,</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MES.</speaker>
             <lg type="nondefinito">
               <l>Signor, non posso dirla senza pianto:</l>
@@ -4474,7 +4529,7 @@ SOE.</speaker>
               <l>ER. O me più ch'altro misero e infelice!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MES.</speaker>
             <lg type="nondefinito">
               <l>Marianna, i tuoi figli et Alessandra</l>
@@ -4486,7 +4541,7 @@ SOE.</speaker>
               <l>Te ne darà particolar aviso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#berenice">
             <speaker>BER.</speaker>
             <lg type="nondefinito">
               <l>Ah, ch'io non voglio più restar in vita,</l>
@@ -4499,14 +4554,14 @@ SOE.</speaker>
               <l>Ucciderò me stessa.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Ben sei crudele, Erode,</l>
               <l>Se non volgi la spada or nel tuo petto!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cor">
             <speaker>COR.</speaker>
             <lg type="nondefinito">
               <l>Oimè, che tale è il frutto</l>
@@ -4521,7 +4576,7 @@ SOE.</speaker>
               <l>A la guerra, a i tormenti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Erode empio e crudele,</l>
@@ -4531,7 +4586,7 @@ SOE.</speaker>
               <l>Senti l'assenzo e 'l fele!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MES.</speaker>
             <lg type="nondefinito">
               <l>Ma ecco che ne vien, Signor, colui</l>
@@ -4541,7 +4596,7 @@ SOE.</speaker>
         </div>
         <div type="scene">
           <stage>NUNZIO, ERODE, CORO</stage>
-          <sp>
+          <sp who="#nunzio">
             <speaker>
               <add resp="#ed">NUN.</add>
             </speaker>
@@ -4554,7 +4609,7 @@ SOE.</speaker>
               <l>La vostra volontà stata è obedita.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Narrami pur, tu c'hai veduto il tutto,</l>
@@ -4564,7 +4619,7 @@ SOE.</speaker>
               <l>Quant'io presi diletto in comandarle.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nunzio">
             <speaker>NUN.</speaker>
             <lg type="nondefinito">
               <l>Fu la Reina a quell'istesso loco</l>
@@ -4610,7 +4665,7 @@ SOE.</speaker>
               <l>Il popol tutto al suon di tai parole.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cor">
             <speaker>COR.</speaker>
             <lg type="nondefinito">
               <l>Pianto avrebbe una tigre, un serpe, un'orsa.</l>
@@ -4627,7 +4682,7 @@ SOE.</speaker>
               <l>Ond'ella ebbe la vita.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nunzio">
             <speaker>NUN.</speaker>
             <lg type="nondefinito">
               <l>Pose l'afflitta le ginocchia in terra,</l>
@@ -4636,7 +4691,7 @@ SOE.</speaker>
               <l>Che le spiccò la testa.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cor">
             <speaker>COR.</speaker>
             <lg type="nondefinito">
               <l>Mi maraviglio che l'istesso colpo</l>
@@ -4644,7 +4699,7 @@ SOE.</speaker>
               <l>La vita a la Reina.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nunzio">
             <speaker>NUN.</speaker>
             <lg type="nondefinito">
               <l>Non morì certo e non rimase viva;</l>
@@ -4652,7 +4707,7 @@ SOE.</speaker>
               <l>Marianna non fu, ma d'essa l'ombra.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>O come ora è diverso questo core</l>
@@ -4660,7 +4715,7 @@ SOE.</speaker>
               <l>Senza lasciar veruna cosa a dietro.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nunzio">
             <speaker>NUN.</speaker>
             <lg type="nondefinito">
               <l>Dopo questa, il maggior figlio Alessandro</l>
@@ -4715,14 +4770,14 @@ SOE.</speaker>
               <l>Or voi ne lascio e la mondana luce.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cor">
             <speaker>COR.</speaker>
             <lg type="nondefinito">
               <l>O misero garzone!</l>
               <l>O crudeltade immensa!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nunzio">
             <speaker>
               <add resp="#ed">NUN.</add>
             </speaker>
@@ -4735,7 +4790,7 @@ SOE.</speaker>
               <l>A mandar, lasso, fuor lo spirto e l'alma.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>O scelerato Erode, o crudel padre!</l>
@@ -4744,7 +4799,7 @@ SOE.</speaker>
               <l>Ma solamente per natura padre.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cor">
             <speaker>COR.</speaker>
             <lg type="nondefinito">
               <l>O Re certo infelice,</l>
@@ -4753,7 +4808,7 @@ SOE.</speaker>
               <l>Il vostro grave errore.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nunzio">
             <speaker>NUN.</speaker>
             <lg type="nondefinito">
               <l>A pena il primo ebbe serrati gli occhi,</l>
@@ -4775,7 +4830,7 @@ SOE.</speaker>
               <l>E posti i corpi un presso l'altro furo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cor">
             <speaker>COR.</speaker>
             <lg type="nondefinito">
               <l>A che misero fine,</l>
@@ -4784,7 +4839,7 @@ SOE.</speaker>
               <l>Del gran Re di Giudea!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Figli infelici, figli:</l>
@@ -4794,7 +4849,7 @@ SOE.</speaker>
               <l>Più ritornarvi in vita!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nunzio">
             <speaker>NUN.</speaker>
             <lg type="nondefinito">
               <l>Poi che sì tristo officio ebbe 'l suo fine,</l>
@@ -4850,7 +4905,7 @@ SOE.</speaker>
               <l>Quel che volete voi che se ne faccia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cor">
             <speaker>COR.</speaker>
             <lg type="nondefinito">
               <l>Il Re per la gran doglia</l>
@@ -4864,7 +4919,7 @@ SOE.</speaker>
               <l>Corte oscura e funesta!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erode">
             <speaker>ER.</speaker>
             <lg type="nondefinito">
               <l>Ora io conosco, mio mal grado, a prova</l>

--- a/tei/epicuro-la-cecaria.xml
+++ b/tei/epicuro-la-cecaria.xml
@@ -81,6 +81,25 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="guida">
+            <persName>La Guida</persName>
+          </person>
+          <person xml:id="vecchio">
+            <persName>Il Vecchio</persName>
+          </person>
+          <person xml:id="geloso">
+            <persName>Il Geloso</persName>
+          </person>
+          <person xml:id="terzo">
+            <persName>Il Terzo</persName>
+          </person>
+          <person xml:id="sacerdote">
+            <persName>Il Sacerdote</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT-Roma</name>Digitalizzazione</change>
@@ -149,7 +168,7 @@
               <l>da mille ardor, da mille aspri martiri. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guida">
             <speaker>Guida</speaker>
             <lg type="terzina">
               <l>Miser, che parli? pensa essermi appresso, </l>
@@ -157,7 +176,7 @@
               <l>ti converria fuggir sempre te stesso. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>Vecchio</speaker>
             <lg type="terzina">
               <l>Or, s'è la pena mia pen'infinita, </l>
@@ -185,7 +204,7 @@
               <l>la lingua che peccò per troppo ardire. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guida">
             <speaker>Guida</speaker>
             <lg type="terzina">
               <l> A che pur sconsolato rinnovelli</l>
@@ -193,7 +212,7 @@
               <l>Se 'l duol t'ancide ognor, ché ne favelli? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>Vecchio</speaker>
             <lg type="terzina">
               <l>Facciol, ch'ognun che qui d'intorno sente, </l>
@@ -206,7 +225,7 @@
               <l>terra crudel, questa malnata spoglia? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guida">
             <speaker>Guida</speaker>
             <lg type="terzina">
               <l>Deh, piú non ti lagnar, deh, miser, vieni; </l>
@@ -375,7 +394,7 @@
               <l> che nel piú bel veder rimasi cieco. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>Geloso</speaker>
             <lg type="terzina">
               <l> S'io non perdei con gli occhi ogn'altro senso, </l>
@@ -393,7 +412,7 @@
               <l> crudel, che m'hai con urto in terra messo! </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>Terzo</speaker>
             <lg type="terzina">
               <l> Ti giuro che non voglia, ira o dispetto</l>
@@ -406,27 +425,27 @@
               <l> drizzava altrove il suo torto vïaggio. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>Geloso</speaker>
             <lg>
               <l part="I">Dunque cieco sei tu? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>Terzo</speaker>
             <lg>
               <l part="F"> Cieco son io. </l>
               <l part="I"> E tu chi sei? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>Geloso</speaker>
             <lg>
               <l part="F"> Ed io son cieco ancora, </l>
               <l> ch'assai piú che il veder morte desio. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guida">
             <speaker>Guida</speaker>
             <lg type="terzina">
               <l>  Quest'è pur meraviglia che in quest'ora</l>
@@ -442,7 +461,7 @@
               <l>Tu ti risvegli? di', forse dormivi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>Vecchio</speaker>
             <lg type="terzina">
               <l>Insieme il sonno e miei lumi fûr spenti,</l>
@@ -450,19 +469,19 @@
               <l>in braccio a li pensier di miei tormenti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>Geloso</speaker>
             <lg>
               <l part="I">Compagno del mio duol! </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>Vecchio</speaker>
             <lg>
               <l part="F">	Che voce intendo? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guida">
             <speaker>Guida</speaker>
             <lg>
               <l>  Dico dui altri son pur senza luce, </l>
@@ -470,19 +489,19 @@
 ch'insieme del suo mal stan qui piangendo. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>Vecchio</speaker>
             <lg>
               <l part="I">Van soli forse? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guida">
             <speaker>Guida</speaker>
             <lg>
               <l part="F">	Soli e senza duce. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>Vecchio</speaker>
             <lg>
               <l>Deh, per mercede, andiam dunque a trovarli</l>
@@ -490,7 +509,7 @@ ch'insieme del suo mal stan qui piangendo. </l>
 per saper qual cagion cosí l'induce. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guida">
             <speaker>Guida</speaker>
             <lg type="terzina">
               <l>Cammina pur,... comincia a salutarli,... </l>
@@ -500,7 +519,7 @@ attienti pur a me,... giá sei vicino, </l>
 ch'intender ben potran ciò che lor parli. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>Vecchio</speaker>
             <lg type="terzina">
               <l> Cari consorti, or qual crudel destino</l>
@@ -510,7 +529,7 @@ ciechi vi scorge, e qual cagion v'invoglia</l>
 soli piangendo andar per tal cammino? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>Geloso</speaker>
             <lg type="terzina">
               <l>Sì grande è il nostro mal, tant'è la doglia, </l>
@@ -520,7 +539,7 @@ che sol per non vederci ognor languire, </l>
 non troviam guida, né altri che n'accoglia. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>Vecchio</speaker>
             <lg type="terzina">
               <l>Non ho men duol nel petto per sentire</l>
@@ -530,7 +549,7 @@ il mal che così par che vi consume, </l>
 che piacer non vedervi in tal martíre. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>Geloso</speaker>
             <lg type="terzina">
               <l>Non ti doler che sian nostri occhi un fiume, </l>
@@ -540,7 +559,7 @@ né che sian ciechi in questo viver frale; </l>
 sol dolgati che mai vedremo lume. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>Terzo</speaker>
             <lg type="terzina">
               <l>Tu che pietoso sei del nostro male, </l>
@@ -553,7 +572,7 @@ né d'amor senta mai face né strale,</l>
               <l part="I">Dinne, chi sei? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>Vecchio</speaker>
             <lg>
               <l part="F">Tal è il mio mal profondo, </l>
@@ -563,7 +582,7 @@ ch'io non so piú chi sia; sol mi conosco</l>
 un vecchio cieco e peregrino al mondo. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>Geloso</speaker>
             <lg type="terzina">
               <l>  O dolce compagnia, deh, vien pur nosco, </l>
@@ -573,7 +592,7 @@ perché potrem sfogar parlando insieme, </l>
 quant'è del nostro petto amaro il tosco. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>Vecchio</speaker>
             <lg type="terzina">
               <l>Ahimè, che il duol che l'alma ognor mi preme</l>
@@ -583,7 +602,7 @@ non si può disfogar, ché gli è sí greve, </l>
 ch'è fuor d'ogni conforto e d'ogni speme. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>Terzo</speaker>
             <lg type="terzina">
               <l>Non creder già lo mio del tuo piú lieve, </l>
@@ -593,7 +612,7 @@ ché d'ora in or mi sfaccio in viv'ardore, </l>
 com'ai raggi del sol falda di neve. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>Geloso</speaker>
             <lg type="terzina">
               <l>Dove si può trovar pena maggiore</l>
@@ -603,7 +622,7 @@ qualor s'accampi al petto gelosia</l>
 con suoi guerrieri a dar battaglia a un core? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>Vecchio</speaker>
             <lg type="terzina">
               <l>Se quanto è piú quel ben che il cuor desia, </l>
@@ -613,7 +632,7 @@ tanto per lunga età piú ne son privo, </l>
 dunque vince ogni duol la pena mia. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>Terzo</speaker>
             <lg type="terzina">
               <l>Cosí tornasse il mio lume visivo </l>
@@ -630,7 +649,7 @@ chi vide mai (né so come esser puote) </l>
 duo fiumi uscir d'un fuoco in corpo umano? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>Vecchio </speaker>
             <lg type="terzina">
               <l>Voi con sospiri e con pietose note </l>
@@ -647,7 +666,7 @@ l'usat'umor dagli occhi piú non sgombra, </l>
 sendo impetrato infin da la radice. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>Geloso </speaker>
             <lg type="terzina">
               <l>A voi forse talor nel petto ingombra, </l>
@@ -664,7 +683,7 @@ ogni pensier, che nel mio pett'ha loco, </l>
 mi fa dí e notte tormentando guerra. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>Terzo </speaker>
             <lg type="terzina">
               <l>Se quant'è il mio maggior d'ogn'altro fuoco </l>
@@ -674,7 +693,7 @@ tant'è men la pietá di chi l'accende, </l>
 dunque ogn'altro dolor con quest'è poco. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>Vecchio </speaker>
             <lg type="terzina">
               <l>Poco il mio pare a chi ben non comprende,</l>
@@ -684,7 +703,7 @@ perché de l'alma l'immortal ferita </l>
 fa ch'io non curi il mal che il corpo offende. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>Geloso </speaker>
             <lg type="terzina">
               <l>Deh, pensi ognun se mia pena è infinita,</l>
@@ -694,7 +713,7 @@ che morte non mi vuol, né io vita bramo, </l>
 e senza morte aver perdei la vita! </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>Terzo </speaker>
             <lg type="terzina">
               <l>Io sempre morte, che m'ancida, chiamo, </l>
@@ -704,7 +723,7 @@ o ancida il morir mio, ch'io moro a torto; </l>
 e tant'è sorda più, quanto piú chiamo. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>Vecchio </speaker>
             <lg type="terzina">
               <l> Non è dolor uguale al duol ch'io porto, </l>
@@ -714,7 +733,7 @@ pensando al stato mio mesto e dolente, </l>
 viver per la cagion per cui son morto. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>Geloso </speaker>
             <lg type="terzina">
               <l>Questo piú ch'altro par che mi tormente: </l>
@@ -724,7 +743,7 @@ perdere cosa viva, amata e cara. </l>
 Chi di ciò non si duol, dolor non sente. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>Vecchio </speaker>
             <lg type="terzina">
               <l>Non è, né fu, né fia mai pen'amara, </l>
@@ -734,7 +753,7 @@ se da speranza vien temprat'alquanto, </l>
 ch'amor soffrirla dolcemente impara. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>Terzo </speaker>
             <lg type="terzina">
               <l>Se il maggior ben ch'in me conosca è il pianto, </l>
@@ -744,7 +763,7 @@ e questo solo par che mi conforte, </l>
 quant'è dunque il mio mal se il bene è tanto? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>Geloso </speaker>
             <lg type="terzina">
               <l>Deh, non piangete il mal ch'avete in sorte, </l>
@@ -754,7 +773,7 @@ ch'ha nome «mal»; ma il mal che il cuor m'attrista </l>
 che nome avrá, s'è mal maggior di morte? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>Vecchio </speaker>
             <lg type="terzina">
               <l>Che 'l ciel ti renda la perduta vista; </l>
@@ -764,7 +783,7 @@ Ma dinne il tuo gran mal, s'ogn'altro avanza, </l>
 e qual cagion ti fa l'alma sí trista. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>Geloso </speaker>
             <lg type="terzina">
               <l>Ahi dolorosa, acerba rimembranza! </l>
@@ -843,7 +862,7 @@ ché non mi fusser duci né piú scorte </l>
 a veder la cagion d'ogni mia morte! </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>Vecchio </speaker>
             <lg>
               <l>Ben hai giusta cagion di pianger sempre </l>
@@ -853,7 +872,7 @@ e lamentarti d'ella, </l>
 se quant'è il tuo dolor, tant'era bella. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>Geloso </speaker>
             <lg type="canzone">
               <lg type="strofa">
@@ -1332,7 +1351,7 @@ Ché giova assai nel mal trovar compagni. </l>
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>Vecchio</speaker>
             <lg type="versi">
               <lg type="strofa">
@@ -1433,7 +1452,7 @@ ch'ogni martìr non mi tormenta assai. </l>
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>Geloso</speaker>
             <lg type="versi">
               <l>E qual fu la beltade</l>
@@ -1441,7 +1460,7 @@ ch'ogni martìr non mi tormenta assai. </l>
 con sí poca pietade? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>
 Vecchio</speaker>
             <lg type="canzone">
@@ -1820,7 +1839,7 @@ sepolto nell'inferno e vivo e cieco. </l>
             </lg>
           </sp>
           <stage>Il Geloso comincia a pregare il Terzo cieco gli voglia narrar la cagion del suo lamento.</stage>
-          <sp>
+          <sp who="#geloso">
             <speaker>Geloso</speaker>
             <lg type="versi">
               <l>Tu che piangendo pur cieco e dolente</l>
@@ -1831,7 +1850,7 @@ or dinne il tuo, se forse il tieni a mente. </l>
             </lg>
           </sp>
           <stage>Narra il Terzo la causa del suo male.</stage>
-          <sp>
+          <sp who="#terzo">
             <speaker>
 Terzo</speaker>
             <lg type="terzina">
@@ -1918,7 +1937,7 @@ per esser dal desir troppo compunto, </l>
 ecco qui il premio e il guiderdon ch'io sento! </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>
 Vecchio</speaker>
             <lg type="versi">
@@ -1927,7 +1946,7 @@ Vecchio</speaker>
 da sí belli occhi uscir sí oscura morte? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>
 Terzo</speaker>
             <lg type="canzone">
@@ -2213,7 +2232,7 @@ da infiammar Giove in ciel, non ch'un mortale. </l>
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>
 Vecchio</speaker>
             <lg type="terzina">
@@ -2224,7 +2243,7 @@ abbian indarno, pur senz'altro effetto, </l>
 tre ciechi insieme qui giunti e guidati. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>
 Geloso</speaker>
             <lg type="terzina">
@@ -2235,7 +2254,7 @@ o del nostro languir abbia il ciel cura, </l>
 s'al mondo siamo noia, ira e dispetto? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>
 Terzo</speaker>
             <lg type="terzina">
@@ -2246,7 +2265,7 @@ che n'andassimo a por tutti tre insieme, </l>
 così mal vivi e ciechi, in sepoltura! </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>
 Vecchio</speaker>
             <lg type="terzina" part="I">
@@ -2255,14 +2274,14 @@ Vecchio</speaker>
 son ben contento. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>
 Terzo</speaker>
             <lg type="terzina" part="M">
               <l part="M">Ed io. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>
 Geloso</speaker>
             <lg type="terzina" part="F">
@@ -2271,7 +2290,7 @@ Geloso</speaker>
 se non morir all'uom ch'è fuor di speme? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>
 Vecchio</speaker>
             <lg type="terzina">
@@ -2295,7 +2314,7 @@ ardir di lingua, d'occhi e gelosia. </l>
             </lg>
           </sp>
           <stage>Qui cominciano le essequie, deliberando tutti tre di morire.</stage>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg type="canzone" part="I">
               <lg type="strofa">
@@ -2319,7 +2338,7 @@ morend'insieme martiri d'amore. </l>
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>
 Geloso</speaker>
             <lg type="canzone" part="M">
@@ -2344,7 +2363,7 @@ serbar una tal fede: </l>
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>
 Terzo</speaker>
             <lg type="canzone" part="M">
@@ -2369,7 +2388,7 @@ se tant'onor portassi in sepoltura! </l>
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guida">
             <speaker>
 Guida</speaker>
             <lg type="canzone" part="M">
@@ -2386,7 +2405,7 @@ godere un bel sereno. </l>
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>
 Vecchio</speaker>
             <lg type="canzone" part="M">
@@ -2415,7 +2434,7 @@ de le tenebre lor qualche mercede. </l>
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>
 Geloso</speaker>
             <lg type="canzone" part="M">
@@ -2442,7 +2461,7 @@ Che piacer prender puoi d'una tal vita? </l>
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>
 Terzo</speaker>
             <lg type="canzone" part="M">
@@ -2471,7 +2490,7 @@ acciò che viva eterno il mio tormento. </l>
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guida">
             <speaker>
 Guida</speaker>
             <lg type="canzone" part="M">
@@ -2488,7 +2507,7 @@ godere un bel sereno. </l>
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>
 Vecchio</speaker>
             <lg type="canzone" part="M">
@@ -2521,7 +2540,7 @@ ditemi voi, sospir, dov'è la vita? </l>
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>
 Geloso</speaker>
             <lg type="canzone" part="M">
@@ -2554,7 +2573,7 @@ trovo or nel cominciar del mio morire. </l>
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>
 Terzo</speaker>
             <lg type="canzone" part="M">
@@ -2583,7 +2602,7 @@ così da te sia, morte, il mio cor giunto. </l>
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guida">
             <speaker>
 Guida</speaker>
             <lg type="canzone" part="M">
@@ -2600,7 +2619,7 @@ goder il bel sereno. </l>
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>
 Vecchio</speaker>
             <lg type="canzone" part="M">
@@ -2627,7 +2646,7 @@ il qual era immortale. </l>
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>
 Geloso</speaker>
             <lg type="canzone" part="M">
@@ -2654,7 +2673,7 @@ vittima del mio cor, urna del petto. </l>
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>
 Terzo</speaker>
             <lg type="canzone" part="M">
@@ -2691,7 +2710,7 @@ che il pregio d'ogni vita è il morir mio. </l>
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guida">
             <speaker>
 Guida</speaker>
             <lg type="canzone" part="M">
@@ -2708,7 +2727,7 @@ goder il bel sereno. </l>
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>
 Geloso</speaker>
             <lg type="canzone" part="F">
@@ -2804,7 +2823,7 @@ sotto la fede sua mi tolse il core. </l>
             </lg>
           </sp>
           <stage>Il Terzo mostra un velo di sua amica.</stage>
-          <sp>
+          <sp who="#terzo">
             <speaker>
 Terzo</speaker>
             <lg type="canzone" part="I">
@@ -2839,7 +2858,7 @@ coprirmi il volto e gli occhi in sepoltura! </l>
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>
 Vecchio</speaker>
             <lg type="canzone" part="M">
@@ -2870,7 +2889,7 @@ ch'accompagni quest'alma all'uscir fuore. </l>
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guida">
             <speaker>
 Guida</speaker>
             <lg type="canzone" part="M">
@@ -2901,7 +2920,7 @@ che si scordò nel fin darvi pietade. </l>
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>
 Vecchio</speaker>
             <lg type="canzone" part="M">
@@ -2935,7 +2954,7 @@ in cieca vita e in sconsolata morte. </l>
             </lg>
             <stage>Qui si baciano insieme per andare a morte.</stage>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>
 Geloso</speaker>
             <lg type="canzone" part="M">
@@ -2948,7 +2967,7 @@ nel regno de gli eletti. </l>
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>
 Terzo</speaker>
             <lg type="canzone" part="M">
@@ -2961,7 +2980,7 @@ vederne piú contenti in l'altra vita. </l>
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guida">
             <speaker>
 Guida</speaker>
             <lg type="canzone" part="M">
@@ -2980,7 +2999,7 @@ poscia ch'in queste strade</l>
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>
 Vecchio</speaker>
             <lg type="canzone" part="M">
@@ -2993,7 +3012,7 @@ indugiar piú la vita. </l>
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guida">
             <speaker>
 Guida</speaker>
             <lg type="canzone" part="M">
@@ -3008,7 +3027,7 @@ come saprai la via, se resti solo? </l>
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>
 Terzo</speaker>
             <lg type="canzone" part="M">
@@ -3039,7 +3058,7 @@ non che sí poca via. </l>
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>
 Geloso</speaker>
             <lg type="canzone" part="M">
@@ -3060,7 +3079,7 @@ che fu del pianto mio. </l>
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guida">
             <speaker>
 Guida</speaker>
             <lg type="canzone" part="M">
@@ -3102,7 +3121,7 @@ che tal premio si rende a chi ben ama! </l>
           <head>SCENA I</head>
           <stage>Il VECCHIO, la GUIDA, il GELOSO, il TERZO e un SACERDOTE
 D'AMORE</stage>
-          <sp>
+          <sp who="#sacerdote">
             <speaker>Sacerdote</speaker>
             <lg type="terzina">
               <l>Chi siete voi che sí dolenti e lassi</l>
@@ -3120,7 +3139,7 @@ la lingua il duol, il cor gli aspri tormenti, </l>
 ch'invece di parlar risponde il pianto? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>
 Vecchio</speaker>
             <lg type="terzina">
@@ -3131,21 +3150,21 @@ ch'una lagrima sol che l'alma attrista, </l>
 o pur un sol de' nostri empii lamenti! </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sacerdote">
             <speaker>
 Sacerdote</speaker>
             <lg type="terzina" part="I">
               <l>Ahimè, voi siete tutti ciechi in vista. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>
 Terzo</speaker>
             <lg type="terzina" part="M">
               <l part="I">Ciechi, come ne vedi. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sacerdote">
             <speaker>
 Sacerdote</speaker>
             <lg type="terzina" part="F">
@@ -3154,7 +3173,7 @@ Sacerdote</speaker>
 con faccia di pallor sí tinta e mista? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>
 Terzo</speaker>
             <lg type="terzina">
@@ -3165,14 +3184,14 @@ sì com'al volto e a' panni si comprende; </l>
 se non c'é speme, il duol chiude le strade. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sacerdote">
             <speaker>
 Sacerdote</speaker>
             <lg type="terzina" part="I">
               <l>Se te speranza cuopre, or che t'offende? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>
 Terzo</speaker>
             <lg type="terzina" part="F">
@@ -3181,7 +3200,7 @@ Terzo</speaker>
 che non sempre un color suo effetto rende. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sacerdote">
             <speaker>
 Sacerdote</speaker>
             <stage>(al Vecchio)</stage>
@@ -3190,7 +3209,7 @@ Sacerdote</speaker>
               <l part="I">dimmi, che n'è cagion? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>
 Vecchio</speaker>
             <lg type="terzina" part="F">
@@ -3199,7 +3218,7 @@ Vecchio</speaker>
 la morte, vita e mia dolente sorte. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sacerdote">
             <speaker>
 Sacerdote</speaker>
             <stage>(al Geloso)</stage>
@@ -3207,7 +3226,7 @@ Sacerdote</speaker>
               <l> O miser, il tuo mal donde procede? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>
 Geloso</speaker>
             <lg type="terzina" part="F">
@@ -3216,7 +3235,7 @@ Geloso</speaker>
 che tanto cresce piú quanto l'uom vede. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sacerdote">
             <speaker>
 Sacerdote</speaker>
             <lg type="terzina">
@@ -3227,7 +3246,7 @@ che no 'l vostro martìr, che così guida</l>
 giunti tre ciechi in disperata via. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>
 Terzo</speaker>
             <lg type="terzina">
@@ -3238,7 +3257,7 @@ dal proposto cammin; deh, piú non voglia</l>
 per troppa compassion farsi omicida. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sacerdote">
             <speaker>
 Sacerdote</speaker>
             <lg type="terzina">
@@ -3249,14 +3268,14 @@ più chiara la cagion che v'arde il core, </l>
 a tal che qui con voi pianga e mi doglia. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>
 Terzo</speaker>
             <lg type="terzina" part="I">
               <l>Del nostro mal n'è sol cagion amore! </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sacerdote">
             <speaker>
 Sacerdote</speaker>
             <lg type="terzina" part="F">
@@ -3273,7 +3292,7 @@ ed in un punto amor sol fa sentire</l>
 mille dolcezze al cor, mille a la mente. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>
 Terzo</speaker>
             <lg type="terzina">
@@ -3332,7 +3351,7 @@ dirsi altro il tuo soggetto noti si puote, </l>
 ch'un van desir temprato di speranza. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sacerdote">
             <speaker>
 Sacerdote</speaker>
             <lg type="terzina" part="I">
@@ -3342,14 +3361,14 @@ Non t'adirar con sí sdegnose note,</l>
 tempra, tempra il dolor.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>
 Terzo</speaker>
             <lg type="terzina" part="M">
               <l part="F">Dimmi chi sei. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sacerdote">
             <speaker>
 Sacerdote</speaker>
             <lg type="terzina" part="F">
@@ -3372,7 +3391,7 @@ vogliate pur a lui drizzar il corso, </l>
 se pur bramate uscir di tanta noia. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>
 Vecchio</speaker>
             <lg type="terzina" part="I">
@@ -3381,14 +3400,14 @@ Vecchio</speaker>
 ch'in su la riva siam de l'ore estreme! </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sacerdote">
             <speaker>
 Sacerdote</speaker>
             <lg type="terzina" part="F">
               <l>Deh, sperate in Amor trovar soccorso. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>
 Vecchio</speaker>
             <lg type="terzina">
@@ -3399,7 +3418,7 @@ or come dunque vuoi ch'Amor n'aite, </l>
 e riponiamo in lui la nostra speme? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sacerdote">
             <speaker>
 Sacerdote</speaker>
             <lg type="terzina">
@@ -3418,7 +3437,7 @@ or venite appo me, che gli è qui presso</l>
 del mio Signor il venerando tempio. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>
 Geloso</speaker>
             <lg type="terzina">
@@ -3429,14 +3448,14 @@ ch'Amor rendesse a noi la cieca luce</l>
 ed a me gli occhi che mi tolsi io stesso! </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>
 Terzo</speaker>
             <lg type="terzina" part="I">
               <l>Andiam, perché costui ne sarà duce. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sacerdote">
             <speaker>
 Sacerdote</speaker>
             <lg type="terzina" part="F">
@@ -3533,7 +3552,7 @@ ma fa palese a' lor foschi intelletti</l>
 come le sorti sue sian qui prescritte. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>
 Vecchio</speaker>
             <lg type="terzina">
@@ -3580,7 +3599,7 @@ ch'io, qui prostrato, sospirando aspetto, </l>
 fin che il responso di tua bocca senta. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>
 Geloso</speaker>
             <lg type="terzina">
@@ -3667,7 +3686,7 @@ non risguardando al mio peccar maligno, </l>
 s'io mai spero d'aver l'amata vista. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>
 Terzo</speaker>
             <lg type="terzina">
@@ -3748,7 +3767,7 @@ con le ginocchia in terra, e con la mente. </l>
             <l>
 vi renderà la luce. </l>
           </lg>
-          <sp>
+          <sp who="#vecchio">
             <speaker>
 Vecchio</speaker>
             <lg>
@@ -3767,7 +3786,7 @@ dunque fia pur mestier ch'in vita oscura</l>
 mi doglia come pria di mia sventura? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>
 Geloso</speaker>
             <lg>
@@ -3786,7 +3805,7 @@ Occhi miei, per piú duol intender vuolsi</l>
 che mai non tornerete ond'io vi tolsi. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>
 Terzo</speaker>
             <lg>
@@ -3809,7 +3828,7 @@ or resta come prima insieme unita</l>
 de gli occhi con le lagrime la vita. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sacerdote">
             <speaker>
 Sacerdote</speaker>
             <lg>
@@ -3832,7 +3851,7 @@ Ite, dunque, e trovate</l>
 la lor vera pietate. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>
 Terzo</speaker>
             <lg>
@@ -3845,7 +3864,7 @@ sia nostra scorta e duce. </l>
         <div type="scene">
           <head>SCENA III</head>
           <stage>I CIECHI, le loro DONNE, il SACERDOTE e la GUIDA.</stage>
-          <sp>
+          <sp who="#vecchio">
             <speaker>
 Vecchio</speaker>
             <lg>
@@ -3868,7 +3887,7 @@ con sí strana dolcezza, </l>
 non puote uscir se non di sua bellezza. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>
 Geloso</speaker>
             <lg>
@@ -3893,7 +3912,7 @@ tenermi sopra i piè senza fatica. </l>
 Qui certo è la mia morte o mia nimica. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>
 Terzo</speaker>
             <lg>
@@ -3912,7 +3931,7 @@ Certo penso che sia</l>
 l'aura che suol spirar la vita mia. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>
 Vecchio</speaker>
             <lg>
@@ -3933,7 +3952,7 @@ certo son qui presenti, </l>
 e potranno ascoltar nostri lamenti. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>
 Geloso</speaker>
             <lg>
@@ -3996,7 +4015,7 @@ Faccia mia vera fede a sé m'accoglia, </l>
 ch'ogni pena è minor de la mia doglia. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>
 Vecchio</speaker>
             <lg type="terzina">
@@ -4083,7 +4102,7 @@ ch'io faccia poi, riavendo il lume spento, </l>
 di pietà vostra al mondo eterna fede. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>
 Terzo</speaker>
             <lg type="ottava">
@@ -4122,7 +4141,7 @@ che s'Ifi oggi sarò per troppo amarte, </l>
 potrai tu ancor venir come Anassarte. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>
 Geloso</speaker>
             <lg type="ottava">
@@ -4161,7 +4180,7 @@ Bagnala poi nel fonte di mercede, </l>
 ché la legge d'Amor serbe e la fede. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>
 Terzo</speaker>
             <lg type="ottava">
@@ -4182,7 +4201,7 @@ Rendimi 'l lume, e non far te immortale</l>
 con tua crudel beltade e con mio male. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>
 Vecchio</speaker>
             <lg type="quartina">
@@ -4200,7 +4219,7 @@ con umil viso in terra: </l>
               </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>
 Geloso</speaker>
             <lg type="distico">
@@ -4209,7 +4228,7 @@ Geloso</speaker>
 non me inganna il pensiero? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>
 Terzo</speaker>
             <lg type="distico">
@@ -4218,7 +4237,7 @@ Terzo</speaker>
 se 'l desir non vaneggia. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>
 Vecchio</speaker>
             <lg type="distico">
@@ -4227,7 +4246,7 @@ Vecchio</speaker>
 o son da me diviso? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>
 Geloso</speaker>
             <lg>
@@ -4256,7 +4275,7 @@ in scambio sol d'incensi</l>
 l'anima vi consacro, il core e i sensi. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#terzo">
             <speaker>
 Terzo</speaker>
             <lg>
@@ -4283,7 +4302,7 @@ benedetto il penar, la lunga noia, </l>
 poi che ogn'altro martìr rivolt'è in gioia. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>
 Vecchio</speaker>
             <lg>
@@ -4308,7 +4327,7 @@ l'anima a te Signore, </l>
 e a te, Madonna, 'l core. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#geloso">
             <speaker>
 Geloso</speaker>
             <lg>
@@ -4319,7 +4338,7 @@ a dar grazie ed onore</l>
 nanzi a l'altar d'Amore. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>
 Vecchio</speaker>
             <lg>
@@ -4334,7 +4353,7 @@ al vostro lume adorno</l>
 vi daremo ancor poi grazie al ritorno. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sacerdote">
             <speaker>
 Sacerdote</speaker>
             <lg type="terzina">

--- a/tei/epicuro-mirzia.xml
+++ b/tei/epicuro-mirzia.xml
@@ -81,6 +81,31 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="venalia">
+            <persName>Venalia</persName>
+          </person>
+          <person xml:id="filerio">
+            <persName>Filerio</persName>
+          </person>
+          <person xml:id="ottimio">
+            <persName>Ottimio</persName>
+          </person>
+          <person xml:id="antiniana">
+            <persName>Antiniana</persName>
+          </person>
+          <person xml:id="diana">
+            <persName>Diana</persName>
+          </person>
+          <person xml:id="mirzia">
+            <persName>Mirzia</persName>
+          </person>
+          <person xml:id="trebazio">
+            <persName>Trebazio</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT-Roma</name>Digitalizzazione - OCR</change>
@@ -93,27 +118,13 @@
     <front>
       <castList>
         <head> INTERLOCUTORI</head>
-        <castItem type="role">
-          <role>Trebazio</role>, <roleDesc>pastore</roleDesc>
-        </castItem>
-        <castItem type="role">
-          <role>Filerio</role>, <roleDesc>pastore</roleDesc>
-        </castItem>
-        <castItem type="role">
-          <role>Ottimio</role>, <roleDesc>pastore</roleDesc>
-        </castItem>
-        <castItem type="role">
-          <role>Mirzia</role>, <roleDesc>ninfa</roleDesc>
-        </castItem>
-        <castItem type="role">
-          <role>Antiniana</role>, <roleDesc>ninfa</roleDesc>
-        </castItem>
-        <castItem type="role">
-          <role>Venalia</role>, <roleDesc>ninfa</roleDesc>
-        </castItem>
-        <castItem type="role">
-          <role>Diana</role>, <roleDesc>dea</roleDesc>
-        </castItem>
+        <castItem type="role"><role>Trebazio</role>, <roleDesc>pastore</roleDesc></castItem>
+        <castItem type="role"><role>Filerio</role>, <roleDesc>pastore</roleDesc></castItem>
+        <castItem type="role"><role>Ottimio</role>, <roleDesc>pastore</roleDesc></castItem>
+        <castItem type="role"><role>Mirzia</role>, <roleDesc>ninfa</roleDesc></castItem>
+        <castItem type="role"><role>Antiniana</role>, <roleDesc>ninfa</roleDesc></castItem>
+        <castItem type="role"><role>Venalia</role>, <roleDesc>ninfa</roleDesc></castItem>
+        <castItem type="role"><role>Diana</role>, <roleDesc>dea</roleDesc></castItem>
         <castItem type="role">
           <role>Un Satiro</role>
         </castItem>
@@ -224,7 +235,7 @@
         <div>
           <head>SCENA II</head>
           <stage>Venalia, Filerio</stage>
-          <sp>
+          <sp who="#venalia">
             <speaker>Venalia</speaker>
             <lg type="terzina">
               <l>Oh fortunato incontro, oh felice ora, </l>
@@ -232,20 +243,20 @@
               <l part="I"> il mio bel sole. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker>Filerio</speaker>
             <lg>
               <l part="F">Ed io la bella aurora. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#venalia">
             <speaker>Venalia</speaker>
             <lg>
               <l>Tanta gioia ho nel cor, ch'a pena creggio</l>
               <l part="I"> quel che con gli occhi scorgo. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker>Filerio</speaker>
             <lg>
               <l part="F">Ed io, mia diva, </l>
@@ -257,7 +268,7 @@
               <l> posiamci all'ombra in questa verde riva. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#venalia">
             <speaker>Venalia</speaker>
             <lg type="terzina">
               <l> Or ben desti, pastor, non poca traccia</l>
@@ -270,7 +281,7 @@
               <l> tutti ne' tuoi servigi opri e dispensi. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker>Filerio</speaker>
             <lg type="terzina">
               <l>Quanti bei rivi questi poggi adorni</l>
@@ -281,13 +292,13 @@
               <l part="I">Ahi fortuna crudel! </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#venalia">
             <speaker>Venalia</speaker>
             <lg>
               <l part="F">A che sospiri? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker>Filerio</speaker>
             <lg>
               <l>Deh, non cercar, Venalia mia, ti priego, </l>
@@ -298,14 +309,14 @@
               <l part="I"> potrei noiarti. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#venalia">
             <speaker>Venalia</speaker>
             <lg>
               <l part="F">Or che d'altro farei</l>
               <l> se a sí vil grazia il tuo voler non piego? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker>Filerio</speaker>
             <lg type="terzina">
               <l>D'amorosi pensier son, Ninfa, i miei</l>
@@ -313,7 +324,7 @@
               <l> che senza lingua inteso esser vorrei. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#venalia">
             <speaker>Venalia</speaker>
             <lg type="terzina">
               <l>Cosa fuor di ragion par ch'oggi senta, </l>
@@ -326,7 +337,7 @@
               <l> se 'l ciel sempre ti fia benigno e lieto. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker>Filerio</speaker>
             <lg type="terzina">
               <l> Il nome non dirò; ma l'auree chiome</l>
@@ -339,7 +350,7 @@
               <l> vedrai, Ninfa, mirando questo fonte. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#venalia">
             <speaker>Venalia</speaker>
             <lg type="terzina">
               <l> Come possibil fia che sotto l'onde</l>
@@ -351,25 +362,25 @@
               <l part="I">qual già dicesti? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker>Filerio</speaker>
             <lg>
               <l part="F">Chiaro ivi si vede. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#venalia">
             <speaker>Venalia</speaker>
             <lg>
               <l part="I">Quella è l'imagin mia. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker>Filerio</speaker>
             <lg>
               <l part="F">Quell'è mia amante! </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#venalia">
             <speaker>Venalia</speaker>
             <lg type="terzina">
               <l>Questa è dunque, pastor, la casta fede</l>
@@ -409,7 +420,7 @@
           <head>SCENA IV</head>
           <div type="part">
             <stage>OTTIMIO, e FILERIO</stage>
-            <sp>
+            <sp who="#ottimio">
               <speaker>Ottimio</speaker>
               <stage>(<emph>fra se</emph>)</stage>
               <lg type="terzina">
@@ -429,7 +440,7 @@
                 <l> or languido ti veggio e melanconico. </l>
               </lg>
             </sp>
-            <sp>
+            <sp who="#filerio">
               <speaker>Filerio</speaker>
               <lg type="terzina">
                 <l>Ottimio, da qui 'nanzi in queste grottole</l>
@@ -442,7 +453,7 @@
                 <l> tal che a morir, non che a languir m'inaspera. </l>
               </lg>
             </sp>
-            <sp>
+            <sp who="#ottimio">
               <speaker>Ottimio</speaker>
               <lg type="terzina">
                 <l>Di meraviglia e di pietà compungemi</l>
@@ -460,7 +471,7 @@
                 <l> tu far mai non dovresti altro che ridere. </l>
               </lg>
             </sp>
-            <sp>
+            <sp who="#filerio">
               <speaker>Filerio</speaker>
               <lg type="terzina">
                 <l>Che giova a me l'esser d'infinitissimo</l>
@@ -478,7 +489,7 @@
                 <l> il più infelice in tutto il grembo esperio. </l>
               </lg>
             </sp>
-            <sp>
+            <sp who="#ottimio">
               <speaker>Ottimio</speaker>
               <lg type="terzina">
                 <l> Più cresce il duol quanto più occolto covasi; </l>
@@ -543,7 +554,7 @@
             </lg>
           </div>
           <div type="part">
-            <sp>
+            <sp who="#filerio">
               <speaker>Filerio</speaker>
               <lg type="terzina">
                 <l>Ahi lasso! qual piacer potrò, qual gioco</l>
@@ -561,7 +572,7 @@
                 <l> e mille volte al dì rinasce e muore! </l>
               </lg>
             </sp>
-            <sp>
+            <sp who="#ottimio">
               <speaker>Ottimio</speaker>
               <lg type="terzina">
                 <l>Ciascun ne la stagion di primavera</l>
@@ -574,7 +585,7 @@
                 <l> che l'alt'ira del ciel lieto soffrei. </l>
               </lg>
             </sp>
-            <sp>
+            <sp who="#filerio">
               <speaker>Filerio</speaker>
               <lg type="terzina">
                 <l>Capre? Che capre! fosser tutte prede</l>
@@ -582,7 +593,7 @@
                 <l> d'amore è quel ch'ogni altro duol eccede. </l>
               </lg>
             </sp>
-            <sp>
+            <sp who="#ottimio">
               <speaker>Ottimio</speaker>
               <lg type="terzina">
                 <l> In ciò non sei già tu primo, né solo, </l>
@@ -604,19 +615,19 @@
                 <l part="I"> del nido di colombi? </l>
               </lg>
             </sp>
-            <sp>
+            <sp who="#filerio">
               <speaker>Filerio</speaker>
               <lg>
                 <l part="F">Ov'è? nol veggio. </l>
               </lg>
             </sp>
-            <sp>
+            <sp who="#ottimio">
               <speaker>Ottimio</speaker>
               <lg>
                 <l>Tra que' due rami sta; né ancor lo scorgi? </l>
               </lg>
             </sp>
-            <sp>
+            <sp who="#filerio">
               <speaker>Filerio</speaker>
               <lg type="terzina">
                 <l>Più cari assai d'un gran tesor gli appreggio</l>
@@ -624,14 +635,14 @@
                 <l> senza più dimorar salir vi deggio. </l>
               </lg>
             </sp>
-            <sp>
+            <sp who="#ottimio">
               <speaker>Ottimio</speaker>
               <lg>
                 <l>Pan faccia sol che non t'affanni invano. </l>
                 <l> Sagli, ch'io ti terrò sopra le spalle. </l>
               </lg>
             </sp>
-            <sp>
+            <sp who="#filerio">
               <speaker>Filerio</speaker>
               <lg>
                 <l>Sostienmi il piè con l'una e l'altra mano. </l>
@@ -639,7 +650,7 @@
                 <l> e già gli prendo. Ohimè, Ottimio, aita! </l>
               </lg>
             </sp>
-            <sp>
+            <sp who="#ottimio">
               <speaker>Ottimio</speaker>
               <lg>
                 <l>Tu lunge rimbombar fai questa valle</l>
@@ -650,7 +661,7 @@
                 <l> Mira che fronte pallida e smarrita! </l>
               </lg>
             </sp>
-            <sp>
+            <sp who="#filerio">
               <speaker>Filerio</speaker>
               <lg type="terzina">
                 <l> Non vedesti cader quei tre fieri angui</l>
@@ -658,7 +669,7 @@
                 <l> che tutti i membri miei son fatti essangui. </l>
               </lg>
             </sp>
-            <sp>
+            <sp who="#ottimio">
               <speaker>Ottimio</speaker>
               <lg type="terzina">
                 <l> Se pur non t'hanno in qualche parte offeso</l>
@@ -666,7 +677,7 @@
                 <l> soglion portar, com'ho più volte inteso. </l>
               </lg>
             </sp>
-            <sp>
+            <sp who="#filerio">
               <speaker>Filerio</speaker>
               <lg type="terzina">
                 <l> Ma di nuovo a salirvi io mi dispono</l>
@@ -684,7 +695,7 @@
                 <l> stiamci fra queste frondi a ragionare. </l>
               </lg>
             </sp>
-            <sp>
+            <sp who="#ottimio">
               <speaker>Ottimio</speaker>
               <lg type="terzina">
                 <l> Vo' piú tosto salir su l'altro olmetto, </l>
@@ -702,7 +713,7 @@
                 <l> Serena, Pausilippo e Mergellino. </l>
               </lg>
             </sp>
-            <sp>
+            <sp who="#filerio">
               <speaker>Filerio</speaker>
               <lg type="terzina">
                 <l>Ed io Vesuvio scorgo, 'Orio a Cremano, </l>
@@ -710,7 +721,7 @@
                 <l> l'Aretusa gentil del mar Sicano. </l>
               </lg>
             </sp>
-            <sp>
+            <sp who="#ottimio">
               <speaker>Ottimio</speaker>
               <lg type="terzina">
                 <l>Taci, che più parlar non ci è concesso; </l>
@@ -718,14 +729,14 @@
                 <l> e in questo fonte suol posarsi spesso. </l>
               </lg>
             </sp>
-            <sp>
+            <sp who="#filerio">
               <speaker>Filerio</speaker>
               <lg>
                 <l>Non ti mover d'un punto, acciò non faccia</l>
                 <l part="I"> di noi quel che d'Atteon. </l>
               </lg>
             </sp>
-            <sp>
+            <sp who="#ottimio">
               <speaker>Ottimio</speaker>
               <lg>
                 <l part="F">Ecco mi celo</l>
@@ -738,7 +749,7 @@
           <head>SCENA V</head>
           <div type="part">
             <stage>ANTINIANA e DIANA con MIRZIA e con VENALIA, e detti.</stage>
-            <sp>
+            <sp who="#antiniana">
               <speaker>Antiniana</speaker>
               <lg type="terzina">
                 <l>Sacra nostra Dïana, ora che in cielo</l>
@@ -746,7 +757,7 @@
                 <l> fermiamci sotto a quest'ombroso velo. </l>
               </lg>
             </sp>
-            <sp>
+            <sp who="#diana">
               <speaker>Diana</speaker>
               <lg type="terzina">
                 <l>Ben si conosce tua debil natura, </l>
@@ -754,7 +765,7 @@
                 <l> poco ha di freddo e men di caldo cura. </l>
               </lg>
             </sp>
-            <sp>
+            <sp who="#antiniana">
               <speaker>Antiniana</speaker>
               <lg type="terzina">
                 <l>Già questo ancor farei, ch'allor più lice, </l>
@@ -767,7 +778,7 @@
                 <l> soffrir cacciando sí fatiche estreme. </l>
               </lg>
             </sp>
-            <sp>
+            <sp who="#diana">
               <speaker>Diana</speaker>
               <lg type="terzina">
                 <l>Non vo' dunque scortese dimostrarmi</l>
@@ -830,7 +841,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>DIANA, MIRZIA, ANTINIANA e VENALIA.</stage>
-          <sp>
+          <sp who="#diana">
             <speaker>Diana</speaker>
             <lg type="terzina">
               <l>Come vi è parso, o ninfe, il sonno ameno? </l>
@@ -838,7 +849,7 @@
               <l> il caro Febo ha già ristretto il freno. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#mirzia">
             <speaker>Mirzia</speaker>
             <lg type="terzina">
               <l>Fra quanti travagliosi, alti pensieri</l>
@@ -846,7 +857,7 @@
               <l> che membrandoli ancor mi paion veri. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antiniana">
             <speaker>Antiniana</speaker>
             <lg type="terzina">
               <l>Ed io tutta gioisco, che disciolta</l>
@@ -854,7 +865,7 @@
               <l> che in gravi affanni mi tenea sepolta. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#venalia">
             <speaker>Venalia</speaker>
             <lg type="terzina">
               <l>Come oggi il cielo eguali ne dispone! </l>
@@ -862,7 +873,7 @@
               <l> cos'aspre, strane e fuor d'ogni ragione. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#diana">
             <speaker>Diana</speaker>
             <lg type="terzina">
               <l>Avrei molto a piacer tai sogni udire. </l>
@@ -870,7 +881,7 @@
               <l> comincia, Mirzia, il tuo primo a scoprire. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#mirzia">
             <speaker>Mirzia</speaker>
             <lg type="terzina">
               <l>Pareami star fra certi alpestri monti, </l>
@@ -883,7 +894,7 @@
               <l> non fùr mai d'accostarsi a quello audaci. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antiniana">
             <speaker>Antiniana</speaker>
             <lg type="terzina">
               <l>Ed io, smarrita da l'amata schiera, </l>
@@ -891,7 +902,7 @@
               <l> vedea con mesta e lagrimosa ciera. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#venalia">
             <speaker>Venalia</speaker>
             <lg type="terzina">
               <l>Io temo forsi che la mia favella</l>
@@ -899,13 +910,13 @@
               <l> ché tutto il sogno mio sol tratta d'ella. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#diana">
             <speaker>Diana</speaker>
             <lg type="terzina" part="I">
               <l part="I">Di' pur ciò che ti piace. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#venalia">
             <speaker>Venalia</speaker>
             <lg type="terzina" part="F">
               <l part="F">Mi parea, </l>
@@ -913,7 +924,7 @@
               <l> dell'amor vostro follemente ardea. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#diana">
             <speaker>Diana</speaker>
             <lg type="terzina">
               <l>Agli affannati spirti, a lasso core</l>
@@ -931,14 +942,14 @@
               <l> vogliate insieme refrigerio darve. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antiniana">
             <speaker>Antiniana</speaker>
             <lg type="terzina" part="I">
               <l>Giochiamo a trar con l'arco in qualche loco, </l>
               <l> per veder chi di noi meglio s'adopra. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#venalia">
             <speaker>Venalia</speaker>
             <lg type="terzina" part="F">
               <l>Un continuo essercizio aggrada poco. </l>
@@ -949,7 +960,7 @@
               <l> nostro nemico Amor più ingegno adopra? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#diana">
             <speaker>Diana</speaker>
             <lg type="terzina">
               <l>Egli è lodato e ben saggio pensiero; </l>
@@ -960,7 +971,7 @@
               <l>E pria Venalia a ciò la lingua sciolga. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#venalia">
             <speaker>Venalia</speaker>
             <lg type="ottava">
               <l>Crudo, iniquo, malvagio, empio tiranno, </l>
@@ -973,7 +984,7 @@
               <l> quanto sarebbe senza morte il mondo. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antiniana">
             <speaker>Antiniana</speaker>
             <lg type="ottava">
               <l>Venenoso, spietato e rigid'angue, </l>
@@ -986,7 +997,7 @@
               <l> se 'l suo contrario tanto mal n'adduce? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#mirzia">
             <speaker>Mirzia</speaker>
             <lg type="ottava">
               <l>Fetida, ingorda, orrenda e brutta arpia, </l>
@@ -999,7 +1010,7 @@
               <l> sol di vita ne spoglia, e tu d'onore... </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#diana">
             <speaker>Diana</speaker>
             <lg type="terzina">
               <l>Tutte arrivate ad egual segno siete, </l>
@@ -1022,7 +1033,7 @@
               <l> qualch'altro nuovo gioco e dilettoso. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#mirzia">
             <speaker>Mirzia</speaker>
             <lg type="terzina">
               <l>Or un me ne sovvien, ch'imaginarsi</l>
@@ -1044,14 +1055,14 @@
               <l part="I">Vuoi tu legarti pria? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antiniana">
             <speaker>Antiniana</speaker>
             <lg type="terzina" part="M">
               <l part="F">Quando a Diana</l>
               <l part="I"> non dispiaccia, il farò. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#diana">
             <speaker>Diana</speaker>
             <lg type="terzina" part="F">
               <l part="F">Contenta sono</l>
@@ -1060,27 +1071,27 @@
               <l> se non è cosa disonesta e vana. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#mirzia">
             <speaker>Mirzia</speaker>
             <lg type="terzina" part="I">
               <l>No, no; chi ha quivi un velo? Il mio fia buono? </l>
               <l part="I"><stage>(<emph>Mirzia benda Antiniana.</emph>)</stage> Vedici? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antiniana">
             <speaker>Antiniana</speaker>
             <lg type="terzina" part="M">
               <l part="I">Nulla veggio. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#mirzia">
             <speaker>Mirzia</speaker>
             <lg type="terzina" part="M">
               <l part="F">Or n'ascondiamo. </l>
               <l part="I"> Vieni a tua posta. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antiniana">
             <speaker>Antiniana</speaker>
             <lg type="terzina" part="F">
               <l part="F">Quivi ho inteso il suono, </l>
@@ -1098,26 +1109,26 @@
             </lg>
             <stage>(<emph>Qui la ninfa si scopre il velo.</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirzia">
             <speaker>Mirzia</speaker>
             <lg type="terzina" part="I">
               <l part="I">Perché ti scopri? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antiniana">
             <speaker>Antiniana</speaker>
             <lg type="terzina" part="M">
               <l part="F">E voi fuggite intorno? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#mirzia">
             <speaker>Mirzia</speaker>
             <lg type="terzina" part="M">
               <l>Di ciò non ti turbar, ché promettemo</l>
               <l part="I"> fermarci a un luogo. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antiniana">
             <speaker>Antiniana</speaker>
             <lg type="terzina" part="F">
               <l part="F">Ecco a coprirmi torno. </l>
@@ -1129,13 +1140,13 @@ coperta.</emph>)</stage>
         <div type="scene">
           <head>SCENA II</head>
           <stage>FILERIO, OTTIMIO e ANTINIANA.</stage>
-          <sp>
+          <sp who="#ottimio">
             <speaker>Ottimio</speaker>
             <lg type="terzina" part="I">
               <l>Partite sono, o sozio, che faremo? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker>Filerio</speaker>
             <lg type="terzina" part="F">
               <l>Scendiamo giù pian pian, ch'ella è velata</l>
@@ -1143,7 +1154,7 @@ coperta.</emph>)</stage>
             </lg>
             <stage>(<emph>Discendon i pastori da gli arbori.</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#antiniana">
             <speaker>Antiniana</speaker>
             <lg type="terzina">
               <l>Voi pur fuggite, ed io sempre ingannata</l>
@@ -1159,26 +1170,26 @@ coperta.</emph>)</stage>
         <div type="scene">
           <head>SCENA III</head>
           <stage>FILERIO e OTTIMIO.</stage>
-          <sp>
+          <sp who="#filerio">
             <speaker>Filerio</speaker>
             <lg type="terzina" part="M">
               <l part="F">Oh, bel piacere! </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottimio">
             <speaker>Ottimio</speaker>
             <lg type="terzina" part="M">
               <l part="I">Anzi noia. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker>Filerio</speaker>
             <lg type="terzina" part="I">
               <l part="I">Ti duol forse che sia</l>
               <l> ella scampata fuor del tuo potere? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottimio">
             <speaker>Ottimio</speaker>
             <lg type="terzina">
               <l>Poco di ciò mi cale, e ben saria</l>
@@ -1187,13 +1198,13 @@ coperta.</emph>)</stage>
             </lg>
             <stage>(<emph>Trebasio nel tugurio dice.</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker>Trebazio</speaker>
             <lg type="terzina" part="I">
               <l part="I">Sonno fugace! </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottimio">
             <speaker>Ottimio</speaker>
             <lg type="terzina" part="F">
               <l part="F">Or un'afflitta e debile</l>
@@ -1201,7 +1212,7 @@ coperta.</emph>)</stage>
               <l> dimostra fuor nel suon doglioso e flebile. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker>Trebazio</speaker>
             <lg type="terzina">
               <l>Fugace sonno, ch'in sì breve spazio</l>
@@ -1234,7 +1245,7 @@ coperta.</emph>)</stage>
               <l> poi che sol morte il nome tuo predicemi. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker>Filerio</speaker>
             <lg type="terzina">
               <l>Or non tardiamo più girlo a soccorrere, </l>
@@ -1246,7 +1257,7 @@ coperta.</emph>)</stage>
         <div type="scene">
           <head>SCENA IV</head>
           <stage>TREBAZIO e detti</stage>
-          <sp>
+          <sp who="#filerio">
             <speaker>Filerio</speaker>
             <lg type="terzina">
               <l>Credo che, nati in un medesmo sidere, </l>
@@ -1274,32 +1285,32 @@ coperta.</emph>)</stage>
               <l> che vicino al morir talor mi spingono. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker>Trebazio</speaker>
             <lg type="terzina" part="I">
               <l part="I">Dunque Amor segui? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker>Filerio</speaker>
             <lg type="terzina" part="M">
               <l part="M">Amore! </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker>Trebazio</speaker>
             <lg type="terzina" part="M">
               <l part="F">E questo sozio? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker>Filerio</speaker>
             <lg type="terzina" part="F">
               <l>Anch'egli Amor, ma non sì strano ed aspero; </l>
               <l> novellamente è intrato in tal negozio. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker>Trebazio</speaker>
             <lg type="terzina">
               <l>Ancorch'assai mi sia grave ed essaspero</l>
@@ -1312,7 +1323,7 @@ coperta.</emph>)</stage>
               <l> che ritrovar non posso a chi l'assimili... </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker>Filerio</speaker>
             <stage>(<emph>interrompendo</emph>)</stage>
             <lg type="terzina">
@@ -1321,7 +1332,7 @@ coperta.</emph>)</stage>
               <l> ma quel di Efialte, di Flegia e di Tizio. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottimio">
             <speaker>Ottimio</speaker>
             <lg type="terzina">
               <l>E benché Amor novellamente adoperi</l>
@@ -1329,7 +1340,7 @@ coperta.</emph>)</stage>
               <l> che voi d'affanni maggior nembo coperi. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker>Trebazio</speaker>
             <lg type="terzina">
               <l>Che abbiate gran dolor per certo credovi</l>
@@ -1337,7 +1348,7 @@ coperta.</emph>)</stage>
               <l> la ninfa mia, tanto di pena eccedovi. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker>Filerio</speaker>
             <lg type="terzina">
               <l>Di beltà, lasso, non parlar, ché a quella, </l>
@@ -1345,7 +1356,7 @@ coperta.</emph>)</stage>
               <l> non men che a Febo cede ogni altra stella. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottimio">
             <speaker>Ottimio</speaker>
             <lg type="terzina">
               <l>Deh, s'esprimer potessi con parole</l>
@@ -1353,7 +1364,7 @@ coperta.</emph>)</stage>
               <l> so che farei parlando oltraggio al sole. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker>Trebazio</speaker>
             <lg type="terzina">
               <l>Ben giudica ciascun quel che desia, </l>
@@ -1366,7 +1377,7 @@ coperta.</emph>)</stage>
               <l> tra le finte bellezze e tra le vere. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker>Filerio</speaker>
             <lg type="terzina">
               <l>So che la mia non è folle credenza, </l>
@@ -1431,7 +1442,7 @@ coperta.</emph>)</stage>
               <l> per unica beltade è al mondo solo! </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker>Trebazio</speaker>
             <lg type="terzina">
               <l>Deh, per Dio, non vogliate ch'io rinovi</l>
@@ -1531,7 +1542,7 @@ coperta.</emph>)</stage>
               <l> stanco di raccontar, non sazio ancora. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottimio">
             <speaker>Ottimio</speaker>
             <lg>
               <l>Lasso, ché a palesar l'eterno bene</l>
@@ -1556,7 +1567,7 @@ coperta.</emph>)</stage>
               <l> che sol se stessa e null'altra simiglia. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker>Trebazio</speaker>
             <lg type="terzina">
               <l>Ognun la mente e 'l suo desire appaga, </l>
@@ -1574,13 +1585,13 @@ coperta.</emph>)</stage>
               <l> ch'a più dritto giudizio alcun s'inchine. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker>Filerio</speaker>
             <lg type="terzina" part="I">
               <l part="I">Contento son. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottimio">
             <speaker>Ottimio</speaker>
             <lg type="terzina" part="F">
               <l part="F">Ed io; ma acciò sia tolta</l>
@@ -1588,7 +1599,7 @@ coperta.</emph>)</stage>
               <l> che cotal cosa qui resti sepolta. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker>Filerio</speaker>
             <lg type="terzina">
               <l>Questa medesim'ombra assale e preme</l>
@@ -1596,7 +1607,7 @@ coperta.</emph>)</stage>
               <l> ch'ognuno il biasmo di sua ninfa teme. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker>Trebazio</speaker>
             <lg type="terzina">
               <l>Ben sarei sciocco se i secreti tuoi</l>
@@ -1604,7 +1615,7 @@ coperta.</emph>)</stage>
               <l> che tu di colpo egual gravar mi puoi. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker>Filerio</speaker>
             <lg type="terzina">
               <l>Ed io voglio esser primo a farvi aperto</l>
@@ -1627,7 +1638,7 @@ coperta.</emph>)</stage>
               <l> e la più cruda che nel mondo sia. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker>Trebazio</speaker>
             <lg type="terzina">
               <l>Colei per cui tante io lagrime sparsi, </l>
@@ -1640,7 +1651,7 @@ coperta.</emph>)</stage>
               <l> che per dar morte ad un che tanto l'ama. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottimio">
             <speaker> Ottimio</speaker>
             <lg type="terzina">
               <l> Tra basse cose il vostro foco giacque, </l>
@@ -1651,7 +1662,7 @@ coperta.</emph>)</stage>
               <l part="I"> Diana amo io! </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina" part="F">
               <l part="F">Diana?!... Ahi, troppo sciocchi</l>
@@ -1669,7 +1680,7 @@ coperta.</emph>)</stage>
               <l> pastor di te l'Esperia non avea. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottimio">
             <speaker> Ottimio</speaker>
             <lg type="terzina">
               <l> Per Pan oggi vi giuro che al mio petto</l>
@@ -1677,7 +1688,7 @@ coperta.</emph>)</stage>
               <l> questo fu il primo e fra l'ultimo affetto. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker> Filerio</speaker>
             <lg type="terzina">
               <l> Ora conosco ben chiaro e palese</l>
@@ -1700,20 +1711,20 @@ coperta.</emph>)</stage>
               <l> ivi lasciollo presso alla fontana. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina" part="I">
               <l> Mirzia qui dunque fu? Lasso, che intendo! </l>
               <l part="I"> E dove er'io? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker> Filerio</speaker>
             <lg type="terzina" part="M">
               <l part="M">Tu stesso il sai! </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina" part="F">
               <l part="F">Ben veggio</l>
@@ -1725,13 +1736,13 @@ coperta.</emph>)</stage>
               <l> senza potermi aitar cader mi veggio! </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker> Filerio</speaker>
             <lg type="terzina" part="M">
               <l part="I"> Ma ecco il vel. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina" part="F">
               <l part="F">O vel, che la tranquilla</l>
@@ -1754,7 +1765,7 @@ coperta.</emph>)</stage>
               <l> onde adempissi in parte i miei desii! </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker> Filerio</speaker>
             <lg type="terzina">
               <l> Esser potria, dopoi ch'ella avvedrasse</l>
@@ -1762,14 +1773,14 @@ coperta.</emph>)</stage>
               <l> di nuovo qui bramoso il piè spronasse. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina" part="I">
               <l> Ma che vi par, ch'io debba ivi lasciarlo, </l>
               <l part="I"> o pur meco tenerlo? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottimio">
             <speaker> Ottimio</speaker>
             <lg type="terzina" part="F">
               <l part="F">A me parrebbe</l>
@@ -1781,13 +1792,13 @@ coperta.</emph>)</stage>
               <l> prigion nelle tue man si troverebbe. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker> Filerio</speaker>
             <lg type="terzina" part="M">
               <l part="I"> Questo ben lodo. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina" part="F">
               <l part="F">E questo lodo anch'io; </l>
@@ -1800,7 +1811,7 @@ coperta.</emph>)</stage>
               <l><stage>(<emph>ad Ottimio</emph>)</stage> A te mi volgo e teco mi consiglio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottimio">
             <speaker> Ottimio</speaker>
             <lg type="terzina">
               <l> Parmi che qui d'intorno or n'ascondiamo, </l>
@@ -1813,7 +1824,7 @@ coperta.</emph>)</stage>
               <l> quel ch'in palese non farebbon mai. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina">
               <l> Così facciamo, o ben composto inganno, </l>
@@ -1821,7 +1832,7 @@ coperta.</emph>)</stage>
               <l> a buon principio meglior fin daranno. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottimio">
             <speaker> Ottimio</speaker>
             <lg type="terzina">
               <l> Ben dimostran li dèi di te gran cura. </l>
@@ -1829,7 +1840,7 @@ coperta.</emph>)</stage>
               <l> che più oltre passar non s'assecura? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina">
               <l> O lieto, avventuroso mio destino, </l>
@@ -1841,7 +1852,7 @@ coperta.</emph>)</stage>
         <div type="scene">
           <head>SCENA V</head>
           <stage>MIRZIA e detti.</stage>
-          <sp>
+          <sp who="#mirzia">
             <speaker>Mirzia</speaker>
             <lg part="I">
               <l> Andar ormai potrò senza spavento</l>
@@ -1872,7 +1883,7 @@ coperta.</emph>)</stage>
 che pastor è questo! </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg part="F">
               <l part="F">O vaga aurora, </l>
@@ -1889,7 +1900,7 @@ che pastor è questo! </l>
               <l> qual tuo piacer, tuo onor, tua gloria sia. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#mirzia">
             <speaker> Mirzia</speaker>
             <lg type="terzina">
               <l> Pastor la tua favella ogni noiosa</l>
@@ -1902,7 +1913,7 @@ che pastor è questo! </l>
               <l> mentre discendo giù quinci ti leva. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina">
               <l> E perché questo ninfa? per potermi</l>
@@ -1910,7 +1921,7 @@ che pastor è questo! </l>
               <l> contra chi non t'offende usare schermi? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#mirzia">
             <speaker> Mirzia</speaker>
             <lg type="terzina">
               <l> Fuor di ragion, pastor, vêr me ti sdegni, </l>
@@ -1928,7 +1939,7 @@ che pastor è questo! </l>
               <l> e da un amante fra lieve ottenere. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina">
               <l> Or mi discosterò, ninfa, da banda, </l>
@@ -1941,7 +1952,7 @@ che pastor è questo! </l>
               <l> e che sotto umiltà non trovi orgoglio? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#mirzia">
             <speaker> Mirzia</speaker>
             <lg type="terzina">
               <l> Amore e fedeltà sempre amendoi</l>
@@ -1949,7 +1960,7 @@ che pastor è questo! </l>
               <l> se privo sei di fé, come amar puoi? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina">
               <l> La fé non sopra in non aver timore</l>
@@ -1967,27 +1978,27 @@ che pastor è questo! </l>
               <l> che non ha il mondo il più fedele amante. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#mirzia">
             <speaker> Mirzia</speaker>
             <lg type="terzina" part="I">
               <l> Come dunque farò che si rimova</l>
               <l part="I"> il tuo sospetto e 'l mio? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina" part="F">
               <l part="F">Già saper déi</l>
               <l> che ad ogni cosa alfin modo si trova. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#mirzia">
             <speaker> Mirzia</speaker>
             <lg type="terzina" part="I">
               <l part="I"> E qual fia questo? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina" part="F">
               <l part="F">Se contenta sei, </l>
@@ -1995,7 +2006,7 @@ che pastor è questo! </l>
               <l> e così tu secura ed io sarei. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#mirzia">
             <speaker> Mirzia</speaker>
             <lg type="terzina">
               <l> Or tua ragione e te stesso riprendi, </l>
@@ -2013,7 +2024,7 @@ che pastor è questo! </l>
               <l> non men già cortesia che amor dimora. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina">
               <l> Or pongo il tuo voler, ninfa, in effetto, </l>
@@ -2026,21 +2037,21 @@ che pastor è questo! </l>
               <l> quando il ritorno mio grato ti fia. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#mirzia">
             <speaker> Mirzia</speaker>
             <lg type="terzina" part="I">
               <l><stage>(<emph>scende col velo</emph>)</stage> Pastore a tuo piacer ritorna
 omai. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina" part="F">
               <l> Lingua non paventar, mostrati audace, </l>
               <l> in discoprir del cor la fiamma e i guai. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#mirzia">
             <speaker> Mirzia</speaker>
             <lg type="terzina">
               <l> Ma se vuoi meco aver tranquilla pace, </l>
@@ -2048,7 +2059,7 @@ omai. </l>
               <l> cortesemente dir quel che ti piace. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina">
               <l> Per Pan ti giuro e per quel vivo raggio</l>
@@ -2078,7 +2089,7 @@ omai. </l>
               <l> tosto m'assale il cor mortal tormento. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#mirzia">
             <speaker> Mirzia</speaker>
             <lg>
               <l> Per lume naturale è desïata</l>
@@ -2093,7 +2104,7 @@ omai. </l>
               <l> s'odïata da te cerco io fuggirti. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg>
               <l> Ninfa, dai vaghi e chiari raggi tuoi, </l>
@@ -2118,7 +2129,7 @@ omai. </l>
               <l> Anzi più lei che mille vite appregio. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#mirzia">
             <speaker> Mirzia</speaker>
             <lg>
               <l> Ambi saremmo di sciocchezza eguali</l>
@@ -2133,7 +2144,7 @@ omai. </l>
               <l> e chi vive, tra' morti non s'ascrive. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg>
               <l> L'alma meco non è, ché in te soggiorna</l>
@@ -2158,7 +2169,7 @@ omai. </l>
               <l> Tu il mio splendor, tu la mia vita sei. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#mirzia">
             <speaker> Mirzia</speaker>
             <lg>
               <l> Pastor, per farti la mia mente piana, </l>
@@ -2173,7 +2184,7 @@ omai. </l>
               <l> ché amore e castità stan male insieme. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg>
               <l> Dunque fia il mio sperar di frutto indegno? </l>
@@ -2188,7 +2199,7 @@ omai. </l>
               <l> se non in tutto in parte le mie pene. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#mirzia">
             <speaker> Mirzia</speaker>
             <lg type="terzina">
               <l> Contenta son ch'oggi da me riceva</l>
@@ -2196,7 +2207,7 @@ omai. </l>
               <l> per amor mio prima una volta beva. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina">
               <l> Questo non sol, ma per tuo amor a schivo</l>
@@ -2208,7 +2219,7 @@ omai. </l>
               <l part="I"> bevrò per compiacerti... </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#mirzia">
             <speaker> Mirzia</speaker>
             <lg type="terzina" part="F">
               <l part="F">Or vo' che lave</l>
@@ -2218,7 +2229,7 @@ omai. </l>
             <stage>(<emph>Qui la ninfa butta il pastore nel fonte e poi
 fugge.</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg>
               <l> O d'ogni nostro ben tenace freno, </l>
@@ -2243,7 +2254,7 @@ fugge.</emph>)</stage>
               <l> posso dall'amor suo l'alma dividere. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker> Filerio</speaker>
             <lg type="terzina">
               <l> Col dolor non si suol, car mio Trebazio, </l>
@@ -2256,7 +2267,7 @@ fugge.</emph>)</stage>
               <l> con che possa il tuo mal quetare e frangere. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina">
               <l> Or più mi avvolgi in tormentoso tedio, </l>
@@ -2264,7 +2275,7 @@ fugge.</emph>)</stage>
               <l> fuor che a schivare un amoroso assedio. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottimio">
             <speaker> Ottimio</speaker>
             <lg type="terzina">
               <l> Qui presso v'è d'Apollo il sacro oracolo, </l>
@@ -2272,7 +2283,7 @@ fugge.</emph>)</stage>
               <l> potrà mai forza d'amoroso giacolo. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina">
               <l> In van cerco d'altrui mia sorte intendere, </l>
@@ -2280,7 +2291,7 @@ fugge.</emph>)</stage>
               <l> mi fia ben chiaro 'l mio destin comprendere. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker> Filerio</speaker>
             <lg type="terzina">
               <l> Anz'io mi sento da desio sollicito</l>
@@ -2293,7 +2304,7 @@ fugge.</emph>)</stage>
               <l> che le nostre pazzie finisca e termine. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina">
               <l> Per me non resti; ma non ben agevole</l>
@@ -2315,7 +2326,7 @@ fugge.</emph>)</stage>
         <div type="scene">
           <head>SCENA VI</head>
           <stage>UNA SIBILLA e detti.</stage>
-          <sp>
+          <sp who="#filerio">
             <speaker>Filerio</speaker>
             <lg type="terzina">
               <l> Febo, che per le selve errante armento, </l>
@@ -2332,7 +2343,7 @@ fugge.</emph>)</stage>
               <l> or raggio di pietà ti scaldi il core. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottimio">
             <speaker> Ottimio</speaker>
             <lg type="terzina">
               <l> Febo, per tua memoria un verde alloro</l>
@@ -2350,7 +2361,7 @@ fugge.</emph>)</stage>
               <l> menar convienmi in sempiterni affanni. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina">
               <l> Febo, il più bello e 'l più feroce tauro</l>
@@ -2368,7 +2379,7 @@ fugge.</emph>)</stage>
             </lg>
             <stage>(<emph>Qui si fa rumor nel tempio.</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker> Filerio</speaker>
             <lg type="terzina">
               <l> Che terribil rumor, che suono orrendo, </l>
@@ -2376,7 +2387,7 @@ fugge.</emph>)</stage>
               <l> è quel ch'uscir dal sacro tempio intendo! </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina">
               <l> Or qui più dimorar non mi confido, </l>
@@ -2384,7 +2395,7 @@ fugge.</emph>)</stage>
               <l> e manda fuor sì tempestoso grido. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottimio">
             <speaker> Ottimio</speaker>
             <lg type="terzina">
               <l> Questa, cari compagni, è la Sibilla, </l>
@@ -2407,7 +2418,7 @@ fugge.</emph>)</stage>
               <l> quel che seguendo aggiungere non puoi. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottimio">
             <speaker> Ottimio</speaker>
             <lg type="terzina">
               <l> Già di partirsi egli è ben tempo omai, </l>
@@ -2415,7 +2426,7 @@ fugge.</emph>)</stage>
               <l> di ben futuri e di futuri guai. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina">
               <l> Questo a Filerio dir ben si concede; </l>
@@ -2428,7 +2439,7 @@ fugge.</emph>)</stage>
               <l> uom cosa mai ch'egli adempir non voglia? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottimio">
             <speaker> Ottimio</speaker>
             <lg type="terzina">
               <l> Deh, quant'ebbi di te più dura ed empia</l>
@@ -2441,7 +2452,7 @@ fugge.</emph>)</stage>
               <l> per uscir fuor de l'amorose pene. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker> Filerio</speaker>
             <lg type="terzina">
               <l> Forse non drittamente le divine</l>
@@ -2454,7 +2465,7 @@ fugge.</emph>)</stage>
               <l> umano ingegno contra 'l ciel disponere. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottimio">
             <speaker> Ottimio</speaker>
             <lg type="terzina">
               <l> Col tuo parlar via più mia pena inforzasi, </l>
@@ -2482,7 +2493,7 @@ fugge.</emph>)</stage>
               <l> unitamente le potrem conducere. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina">
               <l> Io voglio che le greggi mie qui pascano, </l>
@@ -2490,21 +2501,21 @@ fugge.</emph>)</stage>
               <l> per fin che i raggi matutin rinascano. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottimio">
             <speaker> Ottimio</speaker>
             <lg type="terzina" part="I">
               <l> Quanto più sto più di dolor m'infurio. </l>
               <l part="I"> Compagni, a Pan vi lascio. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker> Filerio</speaker>
             <lg type="terzina" part="M">
               <l part="F"> Ed io pur vogliomi</l>
               <l part="I"> teco partir. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina" part="F">
               <l part="F"> Sia con felice augurio. </l>
@@ -2513,7 +2524,7 @@ fugge.</emph>)</stage>
         </div>
         <div type="scene">
           <head>SCENA VII</head>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina">
               <l>Amor, non ho ragion se di te dogliomi, </l>
@@ -2550,7 +2561,7 @@ fugge.</emph>)</stage>
         <div type="scene">
           <head>SCENA VIII</head>
           <stage>MIRZIA E TREBAZIO.</stage>
-          <sp>
+          <sp who="#mirzia">
             <speaker> Mirzia</speaker>
             <lg type="terzina">
               <l> S'io avessi il cor più duro d'un diamante, </l>
@@ -2569,7 +2580,7 @@ fugge.</emph>)</stage>
               <l> or del commesso error perdon ti chieggio. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina">
               <l> Rigido serpe venenoso e rio, </l>
@@ -2577,7 +2588,7 @@ fugge.</emph>)</stage>
               <l> ch'io non son più d'Amor, son fatto mio! </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#mirzia">
             <speaker> Mirzia</speaker>
             <lg type="terzina">
               <l> Come fu il tuo pensier di fragil vetro! </l>
@@ -2590,7 +2601,7 @@ fugge.</emph>)</stage>
               <l> desio, tu sola hai del mio cor le chiavi? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina">
               <l> Al vento spargi, ninfa, ogni parola. </l>
@@ -2603,7 +2614,7 @@ fugge.</emph>)</stage>
               <l> scoprirti la sua fé pura e sincera! </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio </speaker>
             <lg type="terzina">
               <l>Poi che ti veggio a star pur quivi intenta, </l>
@@ -2615,7 +2626,7 @@ fugge.</emph>)</stage>
         <div type="scene">
           <head>SCENA IX</head>
           <stage>MIRZIA sola.</stage>
-          <sp>
+          <sp who="#mirzia">
             <speaker> Mirzia</speaker>
             <lg type="terzina">
               <l>Amoroso disio, colmo di sciocchi</l>
@@ -2747,7 +2758,7 @@ fugge.</emph>)</stage>
         <div type="scene">
           <head>SCENA II</head>
           <stage>OTTIMIO e detto.</stage>
-          <sp>
+          <sp who="#ottimio">
             <speaker> Ottimio</speaker>
             <stage>(<emph>avanzandosi</emph>)</stage>
             <lg type="terzina">
@@ -2781,7 +2792,7 @@ fugge.</emph>)</stage>
               <l> convien che quest'afflitta spoglia lasce. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker> Satiro</speaker>
             <lg type="terzina">
               <l> Che gran sospir, che suon colmi d'affanni</l>
@@ -2800,7 +2811,7 @@ fugge.</emph>)</stage>
               <l> del petto un Etna fai, degli occhi un Gange? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottimio">
             <speaker> Ottimio</speaker>
             <lg type="terzina">
               <l> Satiro, per dio Pan, lasciami un poco, </l>
@@ -2808,7 +2819,7 @@ fugge.</emph>)</stage>
               <l> con pianti il ghiaccio e con sospiri il foco. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker> Satiro</speaker>
             <lg type="terzina">
               <l> Alza almen gli occhi ed al mio giusto priego</l>
@@ -2821,7 +2832,7 @@ fugge.</emph>)</stage>
               <l> trovarai forsi onde l'acqueti e fuggi. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottimio">
             <speaker> Ottimio</speaker>
             <lg type="terzina">
               <l> Anzi parlando avvien che più l'aggreve, </l>
@@ -2829,7 +2840,7 @@ fugge.</emph>)</stage>
               <l> ogni rimedio per tristezza è lieve. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker> Satiro</speaker>
             <lg type="terzina">
               <l> O donne, o crudel peste, o nostra guerra, </l>
@@ -2837,7 +2848,7 @@ fugge.</emph>)</stage>
               <l> né in ciel pioggia saria, né male in terra. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottimio">
             <speaker> Ottimio</speaker>
             <lg type="terzina">
               <l> Al tuo parlar via più di doglia abbondo, </l>
@@ -2845,7 +2856,7 @@ fugge.</emph>)</stage>
               <l> di leggiadro, di bello e di giocondo. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker> Satiro</speaker>
             <lg type="terzina">
               <l> A ciò risposta nulla chieggio, poi</l>
@@ -2853,7 +2864,7 @@ fugge.</emph>)</stage>
               <l> chiar si conosce nei sembianti tuoi. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottimio">
             <speaker> Ottimio</speaker>
             <lg type="terzina">
               <l> Chi la beltà di colei ch'amo vede</l>
@@ -2871,13 +2882,13 @@ fugge.</emph>)</stage>
               <l> ché non può il mio desir giungere a riva. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker> Satiro</speaker>
             <lg type="terzina" part="I">
               <l> E perché nudre il cor fiamma sì audace? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottimio">
             <speaker> Ottimio</speaker>
             <lg type="terzina" part="F">
               <l> Deh, non far che 'l mio duol più rinovelle: </l>
@@ -2890,7 +2901,7 @@ fugge.</emph>)</stage>
               <l> far tigri intorno vaghe danze e belle. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker> Satiro</speaker>
             <lg type="terzina">
               <l> Ahi infelice, ahi duro caso! come</l>
@@ -2898,7 +2909,7 @@ fugge.</emph>)</stage>
               <l> a nominar della sua amante il nome! </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottimio">
             <speaker> Ottimio</speaker>
             <lg type="terzina">
               <l> Questo ch'è quivi, è lupo o pur pastore? </l>
@@ -2910,13 +2921,13 @@ fugge.</emph>)</stage>
               <l> pecore?... paion ninfe e non son fiere... </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker> Satiro</speaker>
             <lg type="terzina" part="F">
               <l> Sciocco d'amanti universal disio! </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottimio">
             <speaker> Ottimio</speaker>
             <lg type="terzina">
               <l> Vo' in questo freddo e duro sasso bere... </l>
@@ -2928,13 +2939,13 @@ fugge.</emph>)</stage>
               <l> aria, sta ferma... or di volare imparo... </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker> Satiro</speaker>
             <lg type="terzina" part="F">
               <l> O d'amorose insanie duro speglio! </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottimio">
             <speaker> Ottimio</speaker>
             <lg type="terzina">
               <l> Deh, torniamo a lottar, sozio mio caro, </l>
@@ -2942,34 +2953,34 @@ fugge.</emph>)</stage>
               <l> ché a questa scossa mal puoi far riparo. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker> Satiro</speaker>
             <lg type="terzina" part="I">
               <l> Ahi dispietata, ahi miserabil sorte, </l>
               <l part="I"> con l'arbor lotta!... </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottimio">
             <speaker> Ottimio</speaker>
             <lg type="terzina" part="F">
               <l part="F"> Oh, buona presa è questa; </l>
               <l> or sugli omeri pur fia che ti porte. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker> Satiro</speaker>
             <lg type="terzina" part="I">
               <l> Pastor, ormai dal vaneggiar ti resta... </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottimio">
             <speaker> Ottimio</speaker>
             <lg type="terzina" part="F">
               <l> Il sol è in Tauro e co' suoi raggi intensi</l>
               <l> par che di nuove erbette il mar rivesta. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker> Satiro</speaker>
             <lg type="terzina">
               <l> Dico che acqueti i travagliati sensi... </l>
@@ -2988,7 +2999,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> versar da gli occhi amare e fervid'onde. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottimio">
             <speaker> Ottimio</speaker>
             <lg type="terzina" part="F">
               <l> Ahi lasso, ahi miser, ché se ben mi accorgo, </l>
@@ -3008,7 +3019,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> Non miri, ohimè, che d'ogni intorn'ondeggio? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker> Satiro</speaker>
             <lg type="terzina" part="F">
               <l> Strani accidenti di pazzesca vita</l>
@@ -3018,7 +3029,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> che la sua forma un'altra forma invita. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottimio">
             <speaker> Ottimio</speaker>
             <lg type="terzina" part="F">
               <l> Lasso, che sento dirti?... Ora sovvienmi</l>
@@ -3071,7 +3082,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> che fai ne l'acqua conservar l'ardore! </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker> Satiro</speaker>
             <lg>
               <l> O infelice e più d'ogn'altro misero, </l>
@@ -3092,7 +3103,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
         <div type="scene">
           <head>SCENA III</head>
           <stage>TREBAZIO e detti.</stage>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <stage>(<emph>rientrando</emph>)</stage>
             <lg type="terzina">
@@ -3111,7 +3122,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> né i rai m'offenderan se tutto offuscoli. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#mirzia">
             <speaker> Mirzia</speaker>
             <lg type="terzina">
               <l> Ahi crudo, empio pastor, sempre al mio essizio</l>
@@ -3119,7 +3130,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> ma cerchi in morte ancor darmi supplizio! </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina">
               <l> O sacro Pan, che voce ho, lasso, udita, </l>
@@ -3132,7 +3143,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> e da piogge e da grandini ti schivi. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#mirzia">
             <speaker> Mirzia</speaker>
             <lg type="terzina">
               <l> Mirzia son io, che con ardente zelo</l>
@@ -3145,7 +3156,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> ch'or più che mai languendo mi distempre. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina">
               <l> Mirzia dunque sei tu che in questa scorza</l>
@@ -3153,7 +3164,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> qual rio destino a ragionar ti sforza? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#mirzia">
             <speaker> Mirzia</speaker>
             <lg type="terzina">
               <l> Io ti dirò: sì mi compunse il forte</l>
@@ -3166,7 +3177,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> di lei, con l'alma in questo tronco ascosa. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina">
               <l> Dunque cagion io fui di tanta doglia? </l>
@@ -3179,7 +3190,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> viver in me quel primo almo desio. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#mirzia">
             <speaker> Mirzia</speaker>
             <lg type="terzina">
               <l> Ben potresti, pastor, gli aspri miei guai</l>
@@ -3197,7 +3208,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> ne' già mutati miei primi sembianti. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina">
               <l> In ciò non vo' che punto or si soggiorni; </l>
@@ -3226,7 +3237,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> render le membra sue vaghe e leggiadre. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker> Satiro</speaker>
             <lg type="terzina">
               <l> Eccomi al tuo volere apparecchiato: </l>
@@ -3234,7 +3245,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> se per destin qui sempre a star gli è dato. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina">
               <l> Forsi migliore e più gioioso fine</l>
@@ -3245,7 +3256,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> Pregoti dunque ch'or la lingua spieghi. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker> Satiro</speaker>
             <lg type="ottava">
               <l> Venere bella, se il tuo fiero Marte</l>
@@ -3258,7 +3269,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> non men bella pietà ch'alta bellezza. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="ottava">
               <l> Venere bella, onde ogni ben deriva, </l>
@@ -3271,7 +3282,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> Citerea, Citerea sonar d'intorno. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker> Satiro</speaker>
             <lg type="ottava">
               <l> Diva madre d'Amor, d'un bel cipresso</l>
@@ -3284,7 +3295,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> in estremi piacer da estremi pianti. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="ottava">
               <l> Diva del terzo ciel, madre d'Amore, </l>
@@ -3322,7 +3333,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> Vener e del figliuol i numi altissimi. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#mirzia">
             <speaker> Mirzia</speaker>
             <lg type="terzina">
               <l> Vaga ciprigna dea, che a tanta grazia</l>
@@ -3345,7 +3356,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> e le napee con le vezzose driadi. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker> Satiro</speaker>
             <lg type="terzina">
               <l> Ma acciò che i fati al buon principio donino</l>
@@ -3360,20 +3371,20 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
         <div type="scene">
           <head>SCENA IV</head>
           <stage>FILERIO, TREBAZIO, MIRZIA e VENALIA.</stage>
-          <sp>
+          <sp who="#filerio">
             <speaker> Filerio</speaker>
             <lg type="terzina" part="I">
               <l> O come son quest'alme amiche e liete! </l>
               <l> Mirzia, questo è il mio caro e dolce sozio. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#mirzia">
             <speaker> Mirzia</speaker>
             <lg type="terzina" part="F">
               <l> Salutatelo pur come solete. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina">
               <l> Vener ti doni pace, requie ed ozio, </l>
@@ -3381,7 +3392,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> di non sprezzar d'amor l'alto negozio. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker> Filerio</speaker>
             <lg type="terzina">
               <l> E te soccorra Pan con grazie ognora, </l>
@@ -3389,7 +3400,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> Trebazio mio, poi c'hai la bella aurora. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina">
               <l> Quest'è 'l mio sol, questa è mia vita propria, </l>
@@ -3397,7 +3408,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> fuor degli affanni e di sì lunga inopia. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker> Filerio</speaker>
             <lg type="terzina">
               <l> Ahimè, quand'avran fin tanti miei guai? </l>
@@ -3405,7 +3416,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> quest'è quel ben che tanto desïai? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina">
               <l> Lascia operare al cieco e alato duce, </l>
@@ -3413,7 +3424,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> che dopo il triste tempo il buon riluce. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#venalia">
             <speaker> Venalia</speaker>
             <lg type="terzina">
               <l> O quanto fui ne le amorose trame</l>
@@ -3426,7 +3437,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> che dimostrava amor puro e sincero. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina">
               <l> O Filerio, Filerio, il ciel, dopoi</l>
@@ -3439,7 +3450,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> che il cieco Amor ti voglia oggi aiutare. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#venalia">
             <speaker> Venalia</speaker>
             <lg type="terzina">
               <l> Io ardo, agghiaccio, e sol tu, crudo Arciero, </l>
@@ -3462,7 +3473,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> ch'ei mi ama, sentirà cangiato stile. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker> Filerio</speaker>
             <lg type="terzina">
               <l> O ciel, benigno mi ti mostri certo, </l>
@@ -3474,25 +3485,25 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l part="I"> Trebazio, che ti par? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina" part="M">
               <l part="F"> Andiamci tutti. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker> Filerio</speaker>
             <lg type="terzina" part="F">
               <l> Pan ti guardi da stenti, pena e doglia. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#venalia">
             <speaker> Venalia</speaker>
             <lg type="terzina" part="I">
               <l> E te levi di affanni e inesti lutti. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#filerio">
             <speaker> Filerio</speaker>
             <lg type="terzina" part="F">
               <l> Ninfa, cangia pensier, che gli occhi, ahi lasso, </l>
@@ -3504,7 +3515,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> là giù nel regno tenebroso e basso. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#venalia">
             <speaker> Venalia</speaker>
             <lg type="terzina">
               <l> Sappi, pastor, ch'io sol son qui per dirti</l>
@@ -3516,7 +3527,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> caccia il timor, nè aver dubbiosa spene. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#trebazio">
             <speaker> Trebazio</speaker>
             <lg type="terzina" part="F">
               <l> Or toccatevi un poco palma a palma, </l>
@@ -3539,7 +3550,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
         <div type="scene">
           <head>SCENA V</head>
           <stage>ANTINIANA e DIANA.</stage>
-          <sp>
+          <sp who="#antiniana">
             <speaker> Antiniana</speaker>
             <lg>
               <l> Sacra Dïana, pregoti che quivi</l>
@@ -3548,13 +3559,13 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> ristorerem le forze già perdute. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#diana">
             <speaker> Diana</speaker>
             <lg>
               <l> Contenta son, pònti ne i verdi rivi. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antiniana">
             <speaker> Antiniana</speaker>
             <lg type="terzina">
               <l> Venalia e Mirzia prim'anci venute</l>
@@ -3562,7 +3573,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> andran le care lor sozie perdute. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#diana">
             <speaker> Diana</speaker>
             <lg type="terzina">
               <l> Meglio dunque sarà che rinfrescando</l>
@@ -3570,7 +3581,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> veniam pian pian le forze racquistando. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antiniana">
             <speaker> Antiniana</speaker>
             <lg type="terzina">
               <l> Non mi ricordo a piè di questo monte</l>
@@ -3578,7 +3589,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> che a tua divinità tutte sian pronte. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#diana">
             <speaker> Diana</speaker>
             <lg type="terzina">
               <l> Antinïana, mai da noi deserto</l>
@@ -3596,7 +3607,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> se ti ricordi, fonte cristallino. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antiniana">
             <speaker> Antiniana</speaker>
             <lg>
               <l> Acque non mai sì dolci e delicate</l>
@@ -3611,7 +3622,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l> da troppo amor s'abbi passato il petto</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#diana">
             <speaker> Diana</speaker>
             <lg type="terzina">
               <l> Acqua, se la natura o pur creata</l>
@@ -3643,7 +3654,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
               <l part="I"> è nostra compagnia. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antiniana">
             <speaker> Antiniana</speaker>
             <lg type="terzina" part="F">
               <l part="F"> Andiamo, o Diva, </l>
@@ -3654,7 +3665,7 @@ fonte.</emph>)</stage> Donne crudel, quest'è pur colpa vostra!... </l>
         <div type="scene">
           <head>SCENA VI</head>
           <stage>OTTIMIO ritornato nella prima forma.</stage>
-          <sp>
+          <sp who="#ottimio">
             <speaker> Ottimio</speaker>
             <stage>(<emph>ritornato nella prima forma</emph>)</stage>
             <lg type="terzina">

--- a/tei/fiorillo-la-lucilla-costante.xml
+++ b/tei/fiorillo-la-lucilla-costante.xml
@@ -81,6 +81,46 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="squarcialeone">
+            <persName>Capitan Squarcialeone</persName>
+          </person>
+          <person xml:id="scaramuzza">
+            <persName>Scaramuzza</persName>
+          </person>
+          <person xml:id="fioretta">
+            <persName>Fioretta</persName>
+          </person>
+          <person xml:id="clarice">
+            <persName>Clarice</persName>
+          </person>
+          <person xml:id="alberto">
+            <persName>Alberto</persName>
+          </person>
+          <person xml:id="matamoros">
+            <persName>Capitan Matamaros</persName>
+          </person>
+          <person xml:id="lucilla">
+            <persName>Lucilla</persName>
+          </person>
+          <person xml:id="fulgenzio">
+            <persName>Fulgenzio</persName>
+          </person>
+          <person xml:id="volpone">
+            <persName>Volpone</persName>
+          </person>
+          <person xml:id="policinella">
+            <persName>Policinella</persName>
+          </person>
+          <person xml:id="scaltrino">
+            <persName>Scaltrino</persName>
+          </person>
+          <personGrp xml:id="sguattari">
+            <name>Sguattari</name>
+          </personGrp>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Siena</name>Digitalizzazione</change>
@@ -155,43 +195,43 @@ umilissimo e perpetuo servitore
             <hi rend="sc">squarcialeone, scaramuzza</hi>
             <hi rend="italic">servo</hi>
           </stage>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Il volermi tu contradire, o Scaramuzza, alle mie bramose voglie e al mio ardente desiderio, credimi certo che è un volerti procacciar la morte, procurarti l'inferno e l'infelice e tormentoso albergo tra le anime dolenti e disperate. Se io amo la bellissima Clarice più che me stesso, come vuoi che la disami? Poiché il vago e potentissimo Amore, a dispetto dell'armi tutte e della mia insuperabilissima bravissima bravura, e di Marte e di Bellona, gli ha dato in man le chiavi di questo durissimo ed infrangibil petto, e l'ha fatta verace e sicura dominatrice delle viscere di questo animosissimo cuore. E con inviolabil fede ho promesso di amarla, e perciò non posso e non debbo essergli manchevole, già che con ogni sua potenza e suprema autorità egli mi constringe e sprona e sforza che io debba star constantissimo e voglioso in amarla, servirla e adorarla, se adorar si può cosa mortale e non divina in terra.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">SCARAMUZZA</emph>.</speaker>
             <p>Sì, sì, sì, sì, adonca si è così, non me n'empaccio, perchè, disse da sapio chilo gran poeta: piscia, vrachetta, ché chi la vole cotta e chi la vole cruda. Chi vo' vascuotte e chi vo' pane muollo. Amore è amaro, e chiù che toro tira,<pb n="531"/> triche varlache ca la casa chiove! E tanto chiù ca io per zi', me sento spisso spisso pogniere e ardere lo core, ca vao 'n ammore de Scioretta, idest, cioè, della zitella de la signora Chiarice. E l'ammore mio co lo suio non è ammore npececato con la cera, né manco co la sputazza; ma co la pece cosuto e tacconiato a spao duppio, che non se pò chiù ascioglier e chiaito muorto. E pe fare, a bo' sorìa, vedere, canoscere e sapere ca ve songo buono e fedele servetore e schiavo, non solamente a la signorìa vostra, ma per zi' a li cane, a li gate, a li surece e a li pulece de tutta la vostra razza, mo ve voglio precoleare aiuto per miezo de la nammoratella mia, sì che, signore mio bello, veccome prunto e preparato come anase confitto e, aùtto faore, dapo' non voraggio da vo' sorìa sulo che me facite deventare marito de Scioretta, e starimmo pace.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">SQUARCIALEONE</emph>.</speaker>
             <p>Scaramuzza, ti giuro da vero capitano, da invincibile feritore, ammazzatore e vero conquistatore d'imperii, per la spada di Marte, per lo tridente di Nettuno, per lo bidente di Plutone, per la lancia di Pallade e per lo scudo di Medusa, che se tu ciò farai e t'adopererai in mio servigio,<pb n="532"/> ti farò un de' miei primi soldati e camerata. E se ti porterai da valoroso, subito ti farò mio caporale, e doppo sergente, alfiere, capitano, luogotenente di cavalleria, collonello, mastro di campo e generale.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">SCARAMUZZA</emph>.</speaker>
             <p>Delle padulle de Napole!</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">SQUARCIALEONE</emph>.</speaker>
             <p>E al fine, se vorrai, ti farò conduttiero generalissimo di tutti i miei numerosi eserciti.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">SCARAMUZZA</emph>.</speaker>
             <p>De la varva e de la cammisa!</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">SQUARCIALEONE</emph>.</speaker>
             <p>E ti farò da tutti per nome chiamare il gran capitan Crollatorri, il general Saltamonti, il capitan Trangugia palle di bombarde, Sputachiodi, Stracciacatene, Tritaeserciti, Sfondaporte, Rodiferro, Levainsegne, Spiantacolonne e Urtamura.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">SCARAMUZZA</emph>.</speaker>
             <p>Si ca staraggio nbriaco! Chesta è na bella canzona da cantare a canto a lo fuoco la sera de' capo d'anno co lo zuco zuco, co lo colascione e lo cò cò. Ma bastarà d'essere chiamato guataro de cocina, attizza fuoco, vota spito, scumma pegnato, lava scotelle, magna forte, zucca medolla, e d'avere assai fissole da spennere. Orsù, ve voglio servire, ma me sbatte lo core e li permunne me aballano dintro lo cuorpo; state a la larga si a besognasse foìre, ch'aggio paura che non venga lo capitanio spagnuolo e me asocciasse lo <pb n="533"/>iepone co na bona chiatoneiata, e puro che non siano cortellate a spacca stromola!</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">SQUARCIALEONE</emph>.</speaker>
             <p>O che viltà è la tua? Animo e cuore, cospettonacionacissimo delle corna storte di Vulcano, poiché dovunque io sono non si parla di paura, ché fugge il timore, va in fumo lo spavento, invisibile la pusilanimità, me riverisce il fato, mi abbraccia la sorte, mi onora la possanza e mi chiama con strepitante e rimbombante sono di tromba la gloriosa fama alla guerra, all'assalto, alla scaramuzza, all'impresa, alla vittoria dell'imperio dell'universo tutto!</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">SCARAMUZZA</emph>.</speaker>
             <p>Pe digni respete state a la larga, che no ce occoresse de mettere 'n'opra lo spatone a dui piede, perché vo' sorìa lo ioca buono. Mo tozzolo. O là, o de la casa !</p>
           </sp>
@@ -201,95 +241,95 @@ umilissimo e perpetuo servitore
           <stage>
             <hi rend="sc">fioretta, scaramuzza, squarcialeone</hi>
           </stage>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Chi è quel che batte? O là, se' tu il fornaio?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>So' chillo che vorrìa nfornare e sfornare.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Allegramente Scaramuzza, coraggio, fratello!</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Ohimè, segnore, steteve zito, ca m'ha paruto da sentire la voce de chella che io festeggio. Me sparpateia lo<pb n="534"/> fecato 'n cuorpo comme a galina storduta! Ietateme, de grazia, no pegnato de vruodo frido 'n face, ca me adevelisco.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>E, di grazia, sta' pur sora di te e parlali arditamente.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Mo torno a tozzoleiare. O là, o da la casa?</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Chi è là, chi batte l'uscio?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Chillo che venne lo caso muscio.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Che dimanda costui? Il signor capitano non è in casa.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>E chesto volimmo nuie.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Oh misser Scaramuzza, che vi è di novo, cor mio?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>E sulo sto cor mio no sarìa a bastante a refregeriare l'arme desperate? Ohimè, bene mio, ca vedenote e sentenote parlare, tutto me sento decreiare, tutto movere e scomovere, e tutto desfare e liquafare. Ora mo sì, ca me ne vao 'n brodetto e 'n zuoccolo.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Scaramuzza, allegramente! Dimandali di Clarice, tratteli dell'amor mio.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Adaso, segnore. E como stai, Scioretta mia?</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Bene, stando in tua grazia. E qual mia bona sorte or mi ti ha qui guidato?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Ammore, ammore, bene mio, che fa che caudamente io te desidera per mogliere, pe frequentarte spisso a boglia mia. Ma siente sto suonno, che de te me aggio sonnato.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Dimelo, di grazia, che sognio è questo?</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Diglielo, Scaramuzza.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Mo nce lo dico, ca l'aggio puosto 'n vierze.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Dunque tu sei poeta?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Poetissimo, ora siente e stupisce.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>O Scaramuzza, fa' presto, ché Marte mi aspetta a cena!</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Aspettate no poco signore, ca mo ve servo, pertonateme.</p>
             <pb n="535"/>
@@ -332,93 +372,93 @@ umilissimo e perpetuo servitore
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Mi par, Scaramuzza, a dirti il vero, che tu sei quello che a me qui fai tener la mula. Vorrei che desti al<pb n="536"/> tronco del mio negozio, corpo del can trifauce e delle furie d'Averno!</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Mo signor, no me sgarrate, ca mo me spedisco e ve servo, no cospetediate tanto! Che tenne pare de sto parlare mio mescaticio e infrogecato napolitano e toscano? Ca così me suole parlare tu, vita mia bella nfanfararella</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>. Il sognio è sognio ed è falacissimo, perché te amo al pari della mia vita; circa della poesia non me ne intendo, perché non ho mai potuto assagiare l'aqua del Castalio fonte.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Sì, sì, t'aggio intiso, che sta a bascio quanno se scenne lo monte Parnaso , dove stanno le Muse a cogliere rose e sciure de cettangolo. E si non è conforme tu mierete, pigliane lo buon armo, perché quanno fice ste vierze non ce vedeva, ché era de notte, e lo cerviello me se sbottava, penzanno a 'sa bella facce toia, spiritillo mio.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Molto ti ringrazio della tua bona volontà e, in somma, desidero di esser tua moglie.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>E io de te essere marito, ma pe arrivare allo designo nuestro, besognia, anze, che è de necesetate, che aiutammo lo signore capitanio Squarcialeone patrone mio, che
 è nammorato de la patrona toia de tale manera che lo pover'ommo se sente lardiare lo core e sfriere dintro de la fersora d'ammore, penzanno alle bellizze soie.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>É verissimo, per l'anima di Leonbruno, di Anti<pb n="537"/>for di Barosia e di Bovo di Antona! Io mi distrugo, mi affligo, mi martiro e mi muoio per lei. Fioretta, rimedio al mio gran male, soccorso al mio dolore, pietà al mio languire, refrigerio alla mia pena, aqua al mio gran foco, riparo alla mia disperazione.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>E mazata 'n coppa de spalle, pe fare le sergazione.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Ohimè, signor mio, non vi dolete tanto, perché molto vi compatisco, perché amo ancor io.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>E ama a mene, sto schieco bello, che me fa sparafonnare de dolore.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Però, che potrò far io per servirla, mio signore?</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Odi, madonna Fioretta, chiamarla, acciò dir gli possa l'intrinseco del mio core e la mia pena; ch'io ti prometto e giuro, per la castità di Diana e per la beltà infinita di Venere, che il mio fedel Scaramuzza sarà tuo marito, con il carico di poter commandare con suprema potenza come patrone assoluto a mezza l'Italia.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Chienna de pecore e de vuoi.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>E se questo sarà poca per ora, abbiate pazienza e accetatelo di paraguanti, che appresso tutta la Spagna sarà vostra, e gran parte della Francia.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>O mio signor capitano, di grazia la mi perdoni se io gli dirò quella bella sentenza di madonna pocofila: chi molto promette poco attende, poiché le molte promissioni sono sorelle delle finte larvi. La si degni di grazia di promettermi poco per attendermi molto.<pb n="538"/></p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>E lassalo dicere, sore mia, ca chisso è lunateco, basta che nui aggiamo lo atiento nuestro, e de lo riesto comme vene vene, disse chillo. Ha ragione signore, de grazia non facite che lo gran nomme vuestro de gran Squarcialeione se converta in Squarcione, abotta pallone e spaca pantano (perdonateme se lo dico).</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>O puttanacia di me, tu mi faresti con viperina lingua e voce diabolica renegare e biastemiare, e mandare in tanta mala mal'ora, quel giorno, quell'ora, quel punto e quel momento che il gran Gradivo e bellicoso nume discese dal suo quinto giro per cingermi al fianco questa mia arcitaglia, squarcia, passa e trapassa, e torna a ripassare, leonissima massima sbudellatrice spada! Se io vi prometto un mezzo mondo, vi giuro per la incomparabil forza di questo smisurato braccionacio di donarvene cento, ducento, e mille mondi!</p>
             <p>Chiamala, Fioretta mia, non mi far più penare. Pregaglilo tu, Scaramuzza, che se' suo amante.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Scioretta mia, io te lo preo, te lo strapreo, e te lo arcepreo, e te lo sconciuro, comme se fosse spiritato. Chiamala priesto, bene mio.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Non occorono cotanti preghi a chi desidera servire! Ora ne vedrete l'effetto. Statevi da me lontano e fingete di sopragiunger all'improviso.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Ha ragione, facimoce chiù là.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Sì certo, non è mal pensiero il suo.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Signora Clarice, signora, signora, lasciatevi vedere, o che graziosi mascari!</p>
           </sp>
@@ -430,176 +470,176 @@ umilissimo e perpetuo servitore
             <hi rend="sc">clarice</hi>
             <hi rend="italic">con i sudetti</hi>
           </stage>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>O là, che dicesti Fioretta di mascari?</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>O vi siete molto trattenuta, signora! Già se ne sono iti da quella parte e vanno per quel vicolo.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>É verissimo, signora. Per certo che erano sopra modo belli e sontuosamente vestiti.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>E nc'era io presente, o che belle femene vestute da uomene, e che belle uomene vestute da femene, o belle zanne, o che gustuse trastulle! Me pareva de vedere chille mascare de Romma, chelle belle mascarate de Napole.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Che vorreste voi altri dir per questo? Chi vi invita qui a ballar senza suoni?</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Che vogliono, che dimandano costoro? Il signor capitano mio padrone non è in casa.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Io non cerco, nè, bramo di parlare al signor capitano vostro patrone, ma ben cerco la grazia, la sovra umana bellezza della signora Clarice.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Che grazia e che bellezza di me cercate? Che avete a far voi meco, che cotanto ardito qui sète venuto ad adularmi senza rispetto alcuno? Dove mi avete mai conosciuta, che così inconsideratamente mi parlate?</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Ah, signora Clarice, piano, non ve adirate tanto contra di chi vi ama.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Non ho bisogno di esser amata da chi non amo, e perciò dico che chi dice ciò che li piace ode in risposta quel che gli dispiace.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Io ho udito quel che non voleva, da chi dir non lo doveva, però il tutto, signora, prudentemente sopporterò, conoscendo che cotanta alterezza deriva dalla vostra infinita beltà, armata tutta di sdegno e d'ira. Vi esorto a non confidar tanto in essa, signora, ché ancor ella è sottoposta al tempo e alla fortuna, raccordandovi che gli ardenti folgori<pb n="540"/> del cielo sogliono più agevolmente percuotere gli alti e superbi edificii, che gli umili e bassi. Come dunque così crudelmente dispregiate chi vi preggia, odiate chi vi ama, fuggite chi vi segue? ma con che raggione? Io mi meraviglio e dolgo di questo, se è proprio donnesco difetto di non esser dissimile alla morte, che sfugge chi la desìa, e abbraccia chi la aborisce.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Anze, che la femmena è comme a la valanza de lo saucicciaro, che da chella banna chiù penne dove nc'è chiù carne.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>E con tutto ciò ben conosco, signora, che quasi inconsiderata farfalla, con dolce diletto, vengo a procacciarmi la morte al vostro amoroso foco, e pure disposto sono di star sempre costantissimo ad amarvi.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>E io costantissima in odiarvi e in procurar la vostra pena.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Dunque sarò un novo Prometeo preso e legato, non da Giove sopra del gran monte Caucasso con il cuor sviscerato dall'aquila rapace, ma dai begli occhi vostri; anzi che voi la vera aquila siete, poiché non solamente sbranate il misero mio cuore, ma lo rapite e molto me ne consolo e contento, e me ne pregio, per aver collocato in sì alto oggetto il mio amore. E chi sarebbe mai tanto di giudizio privo, che lasciasse di seguire così alta e generosa impresa? Poiché voi sola siete il vero fonte di ogni bellezza, avendovi la gran madre natura adotato di grazie tali che né sono state, né sono al presente, né possono essere in bella donna mai, sì che ciò che è di bello al mondo è in voi signora, e ciò che non vi è di bello non è in voi; e credetemi che né da Zeusi, né da Apelle formata né colorita fu mai così bella figura.<pb n="541"/> Dunque, participate molto delle grazie celesti, e se quelle per naturale estinto sogliono giovare alle cose caduche e mortali, perché con la grazia vostra non giovate alla immortalità del mio amore e della mia bravissima bravura, che tanto in maestà alla vostra beltà si rassembrano?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Non so che far io debba, signor capitano, di cotante lodi, che ella oltre ogni mio merito mi dona. Se io l'accetto sarò tenuta da ambiziosa e superba, se le refiuto verrò a trattarvi di adulatore e da bugiardo.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Perdonatemi, signori, se io vi interrompo le vostre belle parole, perché vorrei con lor bona grazia e licenza dirvi una cosa.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Di' pur, Fioretta, ciò che dir ti piace.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Parla tu puro, gioia mia, rosa moscarella dello naso mio e sceruppo nzucarato e medicina defrescativa da fareme vacuare tutti li male umure, ch'aggio 'n cuorpo.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Dirò , signori, poiché son molte le lodi che il signor capitano ha date, dividetele in due parti: la metà che saranno le veraci, signora, se le serba per lei, e le altre fallaci e iperboliche rinunciatele a lui.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>É lo vero, po' che ogni simele apetisciarìa lo suio simile, disse Tadeo de le melella, parlanno co Marco Ambruoso de lo ioio, che beneva cepolle allo mercato.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Orsù, per finirla, e per non perder più qui in vano il tempo, farò ciò che giudicato sarà dal signor Capitano, e lo starò ad udire con diletto, conoscendo che egli molto si preggia e crede che io dia fede alle sue iperboliche parole.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>La ringrazio signora, e perciò giudicherei che già che la mia signora Clarice non le vole accettare, che con queste e altre maggiori unite ne fusse fatto da noi un ricco presente ad Amore, essendo quello che merita ogni onore per avermi egli fatto affezionato servo di così degna padro<pb n="542"/>na. E così non sarà lei tenuta da superba, né d'ambiziosa, né io d'adulatore e bugiardo.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Date dunque questo così ricco presente a lui, poiché li siete tanto obligato; ché io non ho a far seco, né lo conosco, né bramo altro da voi.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>In modo che sarà meglio (perdonatemi signora) che se ne adorni il signor capitano, perché lui certo è degno di gran merito.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Signora, isso non ha besuogno de chisto presiento, né de essere da nullo laudato, ca se sa muto buono laudare chiù isso co una sola parola, che no sarìano ciento poete con ciento milia livre.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Io non le voglio, signora, ch'è verissimo (per vita della guerra) ciò che dice il mio caporale, poiché di già a tutto il mondo è noto che io sono gran mastro di guerra. E tanto sarebbe il dirmi che io sia bravo, forte, orribile e arcivalentissimo valente, quanto a dire che vi sono innumerabili stelle nel cielo e che riluca il sole, e sia molt'aqua nel mare. E io son così capitalissimo nemico d'uomeni vanagloriosi e buggiardi, che non ve lo potesti imaginare.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>E ' lo vero, perché isso vo' essere sulo a dicere buscìe, e per zò da tutte è chiamato cuorpo de verdate, perché se le tenne allo stomaco e mai dice lo vero.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>E se tanti e tanti famosissimi poeti, con sonoro ed eroico stile, celebrano e cantano le mie generose azioni, la bravura, i risoluti assalti, le tremende scaramuzze, le distruzioni, le morti, le vittorie e i miei fatti egreggi...</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>E le foiute e le ritirate.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Non è colpa mia, signora, poiché di ragion non debbo impedire il velocissimo corso e furore di Apollo, poiché egli di sua propria mano e dottissimo ingegno ha composto e scritto per mia gloria un gran volume delle mie invitte prove, detto <title>Il famoso Squarcialeone</title>. Ma per non uscire dal nostro dritto sentiero, dicovi signora, di novo, che vi dobbiate disporre ad amarmi e non prendete iscusa di non<pb n="543"/> conoscere amore, ché non amando di tanto merito dimostraste di essere la dea della discordia e della crudeltà.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Se io vi fosse crudele, non vi dissuaderei a lasciar l'incominciata impresa, perché non desidero il vostro male, raccordandovi che mi dicesti che come farfalla cercate di distrugervi nel mio ardore e io per voi non ardo, anzi m'aggiaccio, e tanto più che chi segue amore non solamente si arde, ma si incenerisce e more; poiché egli è un ascoso fuoco, gradita piaga, saporito veleno, dolce amaritudine, dilettevole infermità, giocondo supplizio e una piacevol morte. E perciò fuggo di amarvi, né voglio che mi amiate.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Ed è amore ancora no macarone senza caso, caso senza cortiello e cortiello senza ponta.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Na minestra senza sale, fummo senza rosto, che ci sta nel cor nascosto.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>E stamoce zitto nui, ca no sapimmo che nce dicere, né che nce pescare.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>É vero, ma lo dico per tener allegra la padrona.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>E vi assicuro che niuna cosa fa scemar più l'amore, quanto il non esser riamato, e lo fa crescere la vera corrispondenza in esso; sì che, essendo chiaro e manifesto a voi che non vi amo, perché amarmi? Se io vi fuggo, perché seguirmi? Cercate, dunque, donna che vi ami e vi corrisponda; ché amando me amerete una statua di marmo, un cuor di ghiaccio e un petto di diamante. Vi lascio signore. Passa tu dentro, madonna civettina, e tu, bragone selvatico, và a far delle tombole in piazza, né più il passeggio intorno alla mia casa! E questo vi basti.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Entro, signora. O poverina me, come sta adirata! A rivedersi, Scaramuzza mio. Vi son serva, signor capitano.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Schiavo, core mio bello.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Mi raccommando, madonna Fioretta.<pb n="544"/></p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Che ve ne pare, signore mio, de sta femena senza n'onza de cerviello 'n capo? Ha lo bene e no lo sa canoscere. E quale gran cavaliero, quale bravo porà mai trovare, che l'amma e boglia bene chiù de vostra signorìa, e che la porrìa fare diventare regina de denare o de coppe; dico, cioè voglio dicere, farla ricca.</p>
             <p>Crediteme che senza pilo ne lo manto ca deve fuorze avere quarcun autro nammorato; e per zò ve fa la schifosa, la vrocolosa, la contegnosa e la cianciosa. Ma no per chesto ve desperate, ca Scioretta ve aiuterà, e nce avviserà de ogni cosa. E tanto chiù che avite dato prenzipio a lo necozio, ché abasta dicere na parola alla orecchia della femmena, e po', lassa lavorare allo brutto papao, ca isso ne caccia lo fracito.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Io non credo che persona veruna la debba né possa pretendere, sapendo pur quanto da me sia amata costei, né mai altri, essendoli manifesto il mio volere, cercheranno di privarme di ciò che bramo. E giuro, Scaramuzza, per quel supremo onore che ho acquistato in tanti anni, così nella Fiandra, come in Ungheria, che con sguardi di basilisco, con il girar de gli occhi, inarcar di ciglia, con il fulminar del brando e con la mia forza orribile, io gli ridurrò in color di morte, li frangerò le osse, li cavarò le budella, li mangierò i cuori, e farò minutissima notomia delle persone loro. Orsù, andiamo a leggere gli avisi del Perù.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Iamo, che te rumpe pe miezo, ca m'aveva enfetato de chiachiare.<pb n="545"/></p>
           </sp>
@@ -610,7 +650,7 @@ umilissimo e perpetuo servitore
             <hi rend="sc">alberto</hi>
             <hi rend="italic">solo</hi>
           </stage>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Me meraviglio. Certo che non so come possibil sia che in questa canuta età Amor si possa prender di me gioco, poiché essendo innamorato della bellissima Clarice, viver non posso un solo momento senza mirare se non lei, almeno questa sua casa, vero erario dove si rinchiude ogni mia gioia, ogni mio ricco tesoro. Io ero molto desideroso di vivere lungamente non pensando che mi si dovessero così scemar le forze; e che pensavo io, che avessero gli anni a ritornar a dietro a rinovellarmi qual unica fenice? Egli è pur vero ciò che il famoso poeta scrisse: «Stamane era fanciullo e or son vecchio», e giudiziosamente disse quel buon poeta: «Dalla culla alla tomba è un breve passo». E senza dubbio alcuno il mio passato tempo mi ha paruto un sogno, e ancora nella mia mente si rinchiudono quei dolci e dilettevoli pensieri giovanili, e farei più di un disordine se lecito mi fosse, e non mi interessasse la borsa; e quanti perigliosi varchi ho passato per giungere a questo segno, orsù pazienza. Non si deve contendere con la natura! Son vecchio, mi dispiace, ma non me ne pento, che non vorrei esser un'altra volta giovane, per non avere a varcare tanti impetuosi mari, e pazzo è quel viandante che, essendo gionto al desiato fine del suo lungo viaggio, voglia ritornare al principio di esso, per aversi ad affaticar di novo. E ciò dico, più per riprender me stesso, che per altro fine, non già per non essere al servigio e piacimento della mia bella Clarice, né meno per esser questo disdicevole all'esser mio, ché ancora caldo il sangue, e non tepido, per le mie vene bolle, e vorrei che se ella mai sposa mi divenesse, che le forze non mi abbandonassero per poter seco fare amorosa battaglia, benché non lascierei d'adoprar l'ingegno; e dirò che dove manca natura, arte procura. Ma ecco,<pb n="546"/> appunto, che di colà ne viene il fratello, vorrei starmene in questa parte da lui discosto, per osservare e intendere ciò che egli fra di sé stesso ragionando viene.</p>
           </sp>
@@ -622,112 +662,112 @@ umilissimo e perpetuo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">alberto</hi>
           </stage>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Por cierto mucho agradezco mi dichiosa fortuna y muy obligado quedo a la gran maestra natura, pues que me ha criado y formado por servir a quella, que mas que a mi alma quiero, fuerte, gallardo, terible y membrudo y mucho mas que orible, que cosa muy facil me sarìa por ella sufrir qualquier gran golpe de muy contraria fortuna. No espantandome, ni del mucho calor del berano, ni el mucho frio del invierno, ni los trabajos de guerra, pues que poco se me darìa lo estar toda la noche, por ella, desnudo a costado ensima de la dura y humida tierra, de baxo de l'abierto cielo, sin dexar las armas y tener en 'l esquirdo lado mi vitoriosa espada, con la muy reluciente daga en la derecha mano, con el fuerte hielmo en la diamantina cabeça. Y dormiendo despertado estar con este ojo derecho abierto y con el otro serado, dexando de dormir de mi soberbio palacio sobre los colchones y almuadas llenos de limaduras de yerro, limado da las armaduras de los gran capitanes, maestros de campos y generales generalisimos, mis defuntos enemigos. Y por esto, no tengo yo por dificultosa cosa de conquistar la soberana belleza de tan gratiosa dama</foreign>.<pb n="547"/></p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Il Cielo mantenghi la di vostra signorìa inespugnabile fortezza e singolarissima bravura, signor capitano mio signore.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p>
               <foreign xml:lang="spa">O mi señor Alberto, bien venido sea vuestra merced y mantengale el Cielo siempre en mi buena gratia. Que hay de nuebo, señor?</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Nulla signore, se non che son più vostro che mio. Però la prego a darmi qualche buona nova di queste guerre d'Italia , si se faranno le paci o averemmo da star sempre in continua guerra.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Nunca jamas se haràn, se yo no me resuelvo un dia de irme a España a tratallas y a concluillas con la majestad del rey mi señor, y despues luego passarme por la buelta de Francia y desde alli con un salto en Alemana</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>E perché non lo fate, signore? Vi raccomando il mondo!</p>
             <p>Questo è un umor malenconico , che si ha posto nel capo, bisogna assecondarlo per fargli piacere.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Yo señor no me voy a España por no perder mi gravedad, ni en Francia por no tener pesa d'umbre, ni en Alemana por no ceder al emperador</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>E perché caro mio signore? Ditemelo, di grazia, se la dimanda è lecita.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Porque el rey catolico no me quiere dar de la alteza, el de Francia no quiere estarme adelante con el sombrero en<pb n="548"/> la mano, y la majestad cesarea no me quiere ceder el mayor lugar</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Certo che cotesti gran potentati non hanno ragione, essendo ella tanto degna de tanti meriti, però quel di Spagna potrebbe farvi dar dell'altezza un giorno, ché molto lo meritate.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Sì por cierto, porque, a fe de cavallero, de mas alto linaje y nobleza nacidos fueron mis antepasados, que no fue el gran sultan Soliman Otoman, emperador de Bisanzia; mas del gran Tamurlan; mas del Africano; Maluque, Giraffa, Saltem, Alibaluque Marzoque</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Può far il mondo, costui certo sarà di razza di giudei o de Turchi, perché questi ultimi nomi non gli ho mai uditi leggere in processo, però questo poco mi giova, né mi nuoce, a me solo basti che egli conceder mi voglia sorella, e cicali pur quanto gli piace. Signor capitano mio osservandissimo, io son qui per veder trattar seco cosa di non poca importanza.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Y yo tambièn, con vuestra merced, señor</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>E sovra di che, di grazia?</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">De fiestas y de alegrias</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>E io di nozze, se pur ella se ne compiacerà.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">De bodas? Que sì, que quiera darme la señora Lucila en matrimonio</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Che sì che vorrà darmi in moglie la signora Clarice. Dicami di grazia, signore, il suo desiderio.<pb n="549"/></p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Yo cedo a mi señor Alberto la preminenza como si el fuera mi padre</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>E io per la sua grandezza le supplico ad esser il primo.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Para servirle, me contento. Señor Alberto, el amor grande que a la señora Lucila tengo, hija de vuestra merced, me tiene sojulgado de baxo de su imperio, de manera tal, que deseo que vuestra merced se contente de darmela por esposa, haviendome contentado dejar de concluir matrimonio con la hija del persiano, del Trasilvano, y con la sobrina del gran Baldugian emperador dell'Eteopia, porque ella solo desco y ella quiero por mi señora, cuando però el mi señor Alberto quiera contentarse que un tan gran cavallero le sea yerno y marido de dama tan hermosa</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>E io, signore, ho lasciato occasione di amogliarmi con la figliuola del signor Pandolfo de gli Onorati da Siena, della sorella del signor Muzio Fiorillo Capuano, della figliuola del signor Fabio Gaudioso, della nipote di messer Cencio Cencino Cenceto de Cencenati Fiorentino, con desiderio di essere legitimo sposo della signora Clarice mia signora e sorella del valorosissimo signor capitano Matamoros mio singularissimo padrone.</p>
             <p>(Pò far la fortuna, so bene che non vorrò ch'egli mi avanzi un punto a dir delle menzogne!)</p>
             <p>Quando però e l'uno e l'altro si vorranno di ciò compiacere.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Señor, por mi parte recivo su buena voluntad y muy gran merced y dichiosa ventura</foreign>.<pb n="550"/></p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>E io il tutto riceverò a grazia singolarissima, e circa della dotte fra noi, non vi sarà disparere alcuno, però con sua buona grazia ne vorrò dar prima contezza a lei, e contentandosene, verrò subito a darne parte a vostra signorìa.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Y yo de la misma manera haré con mi hermana, y se lo avisarè, ya que con tan justa medida y razonablemente me ha respondido, en la plaza le estaré a guardando. Beso las manos de vuestra merced, señor, a Dios</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>E io baccio quelle di vostra signorìa, che sono state mai sempre valorose, vittoriose, invincibili e supreme.</p>
             <p><stage>(<emph>Alberto solo</emph>)</stage> Deve aver certo un gran buon tempo costui a credersi ch'io li creda le sue fraponerìe, però a simil persone per non recarseli odioso non bisogna contradirgli, anzi gonfiarli, acciò se ne vadano in popa, e tanto più lo devo fare per giungere al mio desiato intento. Veramente si conosce che egli sia matto in questo genio di stimarse tanto, però del rimanente ho inteso che è un zuccaro nel praticarlo, e dirò come disse colui:</p>
@@ -751,91 +791,91 @@ umilissimo e perpetuo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">alberto</hi>
           </stage>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Fermati, ballia, ché mio padre mi chiama. Signor Padre, perché non entrate in casa, vi è forsi qualche novità circa l'infermità della signora zia?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Dicono i medici che sia megliorata. Però, a dirti il vero, per cosa di non poco rilievo ti ho chiamata qui di fuora, poiché in fretta convien che io ti parli, avendo dopo subito a girmene verso l'osteria della Posta, perché vi è gionto il procaccio, che va in Napoli, per sapere alcuni avisi di Roma circa i miei corrispondenti.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>E ben, signore, che cosa avete a dirmi? Abbiamo forse qualche buona nova? avetemi comperato alcuna bella cosa?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Bonissima è la nova, perché ho trovato chi te la comprerà.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>E come, dunque altri che vostra signorìa potrà in ciò sodisfarmi?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Sì, e doppiamente, in somma io vorrò che tu ti contenti di passare alle seconde nozze, perché vorrò prender moglie ancor io, n'ho ritrovato un gran buon partito per te.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Marito più darmi?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Marito di nuovo darti, perché ti meravigli?</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Ah signor padre mio, e come non me n'ho da maravigliare, ché ancora non è finito l'anno che Lucidoro, mio primo marito, rese l'anima sua a chi dovea, e che ancora porto coperto il corpo di dolorosissimi panni, e il core di amarissima pena, e la rimembranza della sua infinita bontà spesso mi trafigge e tormenta l'alma! Non desidero altro sposo, poiché ho quello sempre scolpito nella mente e nell'anima mia. Vi prego dunque, o carissimo signor padre, con gli occhi di mestizia pieni, a non discompiacermi in questo, e vi supplico, se mi amate, che dobbiate lasciarmi nel mio mesto e doloroso stato, né men cercate di tôr voi altra con<pb n="552"/>sorte, ché io mi esibisco di aver buona cura così di voi signore, come di tutto il rimanente del nostro avere, e altro marito non vorrò mai che il mio carissimo genitore, né altri io voglio che abbi di me cura, solo che voi, signor padre mio carissimo.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Io ti ho benissimo inteso, ed è vero che tu puoi tener buona custodia di me e di tutte le nostre robbe, ma il volermi far credere che io sarò il tuo marito e tu la mia consorte, per fino a un certo debito termine si potrebbe passare, ma non posso, e non è ragionevole, che io abbia da te ciò che potrei avere dalla moglie mia.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>É bene il dovere di starvene voi nel vostro termine, e io nel mio, perché vi son figliola.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Io non lo niego, ma lo dico acciò tu sappi la differenza che è tra la moglie e la figliola.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Troppo lo so, signor, così per mia buona fortuna non lo avessi mai saputo.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Quando tu saprai che egli sia, a fé che te ne contenterai! Ma ben presto e per non tenerti a bada e piu sospesa, io te'l dirò.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Io non dimando chi egli sia, perché non ho curiosità di saperlo, non desiderando marito.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Oh sei pur da poco! Ascoltami, questi, che io vorrò darti, è per nome chiamato il signor capitano Matamoros, capitano spagnuolo, quello, che vogliono le persone che per il gran valore del suo forte braccio disceso sia dalla prosapìa di Scanderbech.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>E vostra signorìa, che è di maturo giudizio, si lascia dare ad intendere ciò che egli si sogna la notte? Io l'ho inteso celebrare per un parabolano costui, e non per altro.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O che il vero sia, o pur che non sia, mi sarebbe di sommo contento che egli genero mi divenisse, per più degne cagioni.<pb n="553"/></p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Signor, di grazia, perdonatemi, ché io non voglio più altro marito, benché fosse monarca del mondo. Né di padrona, che io son di me stessa, vorrò divenir schiava di altrui, così goder voglio la mia cara libertà. Perdonatemi, signore, se in ciò vi contradisco.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Orsù, Lucilla, già che il tuo volere sin ad ora è stato assai dal mio differente, e forse il tutto per voler del Cielo, e avendo ben udite le tue raggioni, son prontissimo a volerti in ciò compiacere. Dunque vivi lieta, poiché il mio volere dal tuo non è dissimile, ché io lo preggio più che il mio proprio contento, e perché molto te amo, non mi discostarò dalle tue voglie, e ora gli andarò a dare una sicura e certa esecutiva. Vuoi tu altro da me, cara Lucilla mia?</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Io molto ringrazio la mia bona fortuna, che non mi ha dato severo, ma bene amorevole e giustissimo padre, e il volervene molto ringraziare è superfluo, ma il datore delle grazie sia quello che vi conceda felice e prospera salute e lunga vita. Con sua bona licenza, me ne ritornerò in casa, ché con questa allegrezza viverò contenta.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Vattene pur felice, ché allora tutto giubilo e gioisco quando lieta e ridente ti veggo.</p>
             <p><stage>(<emph>Alberto solo</emph>)</stage> Dunque sarà se non bene ch'io vadi a dare la risposta di questo al capitano, acciò che, non essendo sortito il matrimonio conforme il suo desiderio, non corra la voce per la città con qualche suo dispiacere. Cercarò con bella maniera, se potrò, di condurlo al mio volere, acciò mi dia la sorella.</p>
@@ -847,7 +887,7 @@ umilissimo e perpetuo servitore
             <hi rend="sc">fulgenzio</hi>
             <hi rend="italic">solo</hi>
           </stage>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Oh quanto, e più d'ogn'altra vaga, vaga e bella la mia amata e cara Lucilla, non vi è donna mortal in terra che alla maestà del suo angelico aspetto adeguar si possa. Tutte le più belle fatezze, non solo delle più belle donne, ma ancora delle più famose statue e ben colorite figure, sono<pb n="554"/> andato osservando, contemplando e giudicando; né mai una minima sol parte delle sue grazie in loro ritrovar ho potuto. E se prima di formar lei non avesse la gran madre natura creato l'oro, l'avorio, l'ebano, le stelle, le virmiglie rose, i coralli, le perle, l'alabastro, il latte, gli arabi odori, il netare, l'ambrosia e le nevi, senza dubbio alcuno da tutti giudicato stato sarebbe che dal chiaro splendore de' suoi biondi capelli l'oro avesse tolto il colore, l'avorio la candidezza della sua fronte, l'ebano il nero delle sue ciglia, le stelle la luce de' suoi begl'occhi, le vermiglie rose il colore delle sue colorite guancie, i coralli il rossore delle sue labra, le perle la bianchezza de' suoi denti, l'alabastro il candore della sua gola, le nevi la bianchezza del suo petto, il latte la purità delle sue mamelle, gli arabi odori la suavità del suo fiato, il nettare e l'ambrosia la dolcezza della sua soavissima lingua; e in fine quanto di bello fu ed è e sarà nel mondo, tutto è in lei. Dunque, dir ben posso io che fra tutti gli altri amanti non vi sia il più di me felice, poiché in tanta perfetta bellezza ho (mercé d'Amore) collocati gli amorosi miei pensieri, né bastevole io sono, né sarò mai a poter sublimar con il mio basso ingegno quello che è stato di già sublimato ad infinita perfezione. Meglio dunque sarà che, tacendo la lingua, lasci favellare al mio core. Ma che veggio, oh mia felice sorte? Ecco che dall'oriente della mia verde speranza è sorto quel luminoso sole che schiara l'oscurità che ingombrava la mia luce.</p>
           </sp>
@@ -859,142 +899,142 @@ umilissimo e perpetuo servitore
             <hi rend="italic">alla fenestra, e</hi>
             <hi rend="sc">fulgenzio</hi>
           </stage>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Se non mi sono ingannata mi ha parso di aver udita la voce di mio padre.</p>
             <p>Siete voi, signor padre?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Umilmente a lei m'inchino e baccio quella bellissima mano, c'ha del mio cuor le chiavi.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Non occorre che ella per me si prenda questo incomodo! Mio padre non è in casa, e perciò giudicavo di averlo<pb n="555"/> udito costì, e se bramate di favellar seco lo ritroverete al seggio di Antigniano.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Ohimè, che in un punto mirando tanta bellezza, il cuor mi s'aghiaccia e arde.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Che domandate signor, ditemelo, che glielo dirò tosto al suo ritorno?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Io tremo e son fuora di me stesso, oh meraviglia estrema, oh gran miracolo d'Amore!</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Che cosa insensata è questa! Deh, piacciavi di grazia di non porvi più intermissione di tempo a dir ciò che bramate.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Signora mia, signora mia, signora mia...</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Signor mio, signor mio, signor mio. Che episodii sono questi? Se dimandate lui, non è in casa, ho detto. Dicami di grazia chi ella sia, che glielo farò sapere. Non mi tenete più a bada.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Ahi, che per maggior mia pena finge e dissimula di non conoscermi!</p>
             <p>Sono un distrutto e quasi incenerito carbone, che appresso al chiaro lume della vostra bellezza suavemente mi ravvivo. Non credo, signora mia, che il vento aquilone con tanta possanza discacci e sgombri dal cielo le oscure e tenebrose nubbi, come voi discacciato avete con un sol girar di ciglio al vostro apparire l'oscurità dal perturbato mio core.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Queste vostre parole mi paiono offoscati sogni, overo intricate enigme, e io non sono Edipo per poterle interpretare.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Oh misero Fulgenzio, che per maggior mio danno finge di non intendermi!</p>
             <p>Signora, Atlante è tenuto per gran sostenitore de' cieli, perché molta cognizione aveva delle celesti sfere, e perché la mia signora Lucilla è adotata non solamente delle terrene,<pb n="556"/> ma ancora delle sovra umane virtudi, dunque, senza che io più altro li dichi, dovrebbe ella perciò molto ben comprendere la somma eccellenza dell'amor mio, che dipende da quel gran nume che de gli amanti il grande imperio tiene, che mi ha disposto ad amarvi e servirvi.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Io non bramo che altri mi serva, perché in casa non mi manca convenevoli servitù, e il voler vostra signorìa farmi credere di essere quella che io non sono, è un cercar di trattarmi da sciocca e da ignorante. Non sono di tanto suttil ingegno come voi siete, che discorrete e trattate così facondamente sopra dell'umane e celesti cose, che par sia poco tempo che mancate al cielo.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>La buona e falsa moneta si conosce al suono. Della vostra voce, e soavissime parole, chiaramente dimostrate la vostra eccelsa bontà e perfezione, sì che, senza che io altro dichi, so che compreso avete l'animo mio.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Il giudicarmi ingiustamente per quella che io non sono, venite a partecipar del crudel padrigno che, per molto odio che alla figliastra porta, li par male ogni sua buona operazione.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>E questo è il contrario, signora, perché vi amo e non vi odio.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>E questo è peggio, perché siete come l'amoroso padre che, per l'infinito amore che porta alla sua cattiva e malvagia figliola, malagevolmente discerne i suoi mali andamenti. Io sono ignorante e voi volete farmi tener da savia.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Volendo mantenermi, signora, che il ver non dichi, venite a pregiudicar la mia verità e la vostra molta perfezione. E, per dichiararmevi meglio, ben che lo sapete e ignorate il saperlo, per darmi maggior pena dico che vi amo quanto amar si possa mai donna d'infiniti meriti, quale voi siete; e, per premio del mio fedel amore, altro da voi non bramo, solo che ricambiarmi dobbiate d'un puro e corrispondente amore.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>La dimanda è illecita e importuna.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>E perché signora mia?</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Perché non son obligata ad amarvi.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Ben dovete rimunerar chi vi serve.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Sì, quando però sarà la servitù da me gradita.<pb n="557"/></p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Dunque che io non vi sono grato? o me odiate? Questo mi apporta crudelissimo sdegno nell'animo. E mi discacciate dalla vostra presenza? Ohimè, e perché, senza mia colpa, così ingrata e crudele me vi dimostrate?</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Volete voi, dunque, da me per forza ciò che darvi non bramo, né si conviene?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>In somma, non posso sopportare così dispietata ripulsa.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Come, non potete sopportarla, se vi si conviene di esser discacciato? non sapete che una indegna dimanda merita una degna ripulsa? con che ragione volete avere l'autorità di poter domandare e non volete darla a me di negare?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Al molto mio merito non si conviene tanta crudeltà.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Assai sono che si persuadono di meritar molto e non meritano nulla. E perciò chiaramente vi dico che non vi desidero, né voglio. E questo aviso so che sarà bastevole a farvi scemare l'ardore.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Orsù pazienza. Signora, io spero che la mia speranza, o tardi o per tempo, mi darà vittoria.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Ogni speranza è del tempo futuro e ogni futuro è dubbioso. Attendete a i vostri onorati studii, poiché in vano vi affaticate.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Se io non considerassi che altri amanti assai di me maggiori han posto con meno speranza della mia il piede nella amorosa panìa e crudi lacci, e al fine han pure ottenuto il desiato intento, ora mi darei in preda alla dispietata e cieca disperazione, sì che vorrò io, perché mi private di speranza, disperarmi? Dunque colmo d'infinita speranza vi amarò e seguirò sino all'ultima ora della mia vita. Abbiate pietà della mia pena, radolcite la mia amarezza, consolate questo core, concedetemi la vostra grazia con certa speranza di futuro bene.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>E io vi odierò sino a la morte, senza aver mai scintilla di pietà, giungerò pena alla vostra pena, amarissimo assenzio e pestifero veleno alla vostra amaritudine, affligerò e sconsolerò sempre il vostro cuore, e da vita cercarò di ridurvi in morte, poiché tanto noioso mi siete. E vi lascio privo d'ogni speranza, sepolto nell'ardore, in preda della disperazione e morte, se pure è vero che mi amate.<pb n="558"/></p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p><stage>(<emph>solo</emph>)</stage>. Ahimè, misero me! E che dispietatissime parole ha, contro di me infelice, fulminate costei? e perché quasi novello Ulisse al canto delle Sirene, o qual aspide al dispiacevol incanto, non mi son chiuse l'orecchie, ché udito non avrei cotanta mia disaventura? Ecco, misero Fulgenzio, che pure stato escluso sei d'ogni tua speranza, d'ogni conforto. Potrò dunque, misero me, per tal cagione trarmi da gli occhi il pianto, dal core l'acerbissimo dolore e gli angosciosi sospiri, l'ardentissimo fuoco? No, che oltre ogni dovere, a mio malgrado di amar costei mi conviene. Il fuoco non si estingue, le lacrime non si asciugano, i pensieri multiplicano, i dolori non scemano, i sospiri abondano, e tutte queste cose unite sono viluppi d'amore, e i veri messaggieri e nunzii della mia morte. Che debbo dunque fare? debbo morir di doglia per cotanta rigidezza di costei? Oh Amore, tu che feristi questo mio tormentato seno, abbi di me pieta! Non consentire che questa ingratissima donna sia la verace cagione della mia disperata morte, aiutami tu, protegimi tu, consolami tu, che sai quanto fedele ti sono e costantissimo in amar lei!</p>
             <pb n="559"/>
@@ -1009,7 +1049,7 @@ umilissimo e perpetuo servitore
             <hi rend="sc">volpone</hi>
             <hi rend="italic">solo</hi>
           </stage>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Corteggiana innamorata e ruffiano liberale, vanno presto all'ospedale! Ma a me l'ospedale mi sarebbe zuccaro e la berlina una manna e la galera un volermi con la dieta e con l'esercizio tenermi sano; ma la forca è quella che spesso mi minaccia, mi chiama alla morte e me fa star con grandissimo spavento. Però è vero, non vi è rimedio, io me lo sento e me lo conosco, che spuzzo da appicato più che spalla di porco vecchio attaccata al fumo! E certo, se non fosse così pericolosa l'arte ruffianatoria, sarebbe la meglio del mondo, perché il scaltro ed eccellente ruffiano, come sono io, è sempre chiamato, invitato, amato, e stimato da cortesi innamorati e e da bellissime donne. E che ciò sia vero, molte volte che io vado nell'altrui case con iscusa di cercare delle ova fresche e di comperare galline, di vendere alcuna cosa appartenente all'uso feminile o di andare a domandare uno per un altro, come far sogliono i ladri, mi caccio dentro alla libera e ritrovato il comodo opportuno e il tempo di potere negoziare, con bel modo tratto con ogni spezie di persone e fo il fatto mio e quello di chi mi manda a fare il suo. E così onoratamente mi procaccio il vitto, perché chi mi dona un ducato, chi un paio di colzette, chi di scarpe, chi una<pb n="561"/> camicia vecchia, chi nova, chi del cascio, chi vino, chi sopressate di Nola e copeta, chi provature di qui, chi delle legnate su le spalle, chi calci, chi schiaffi, conforme lor porge l'occasione dell'allegra o melanconica risposta e ambasciata. E il tutto cerco di fare per poter vivere da gentil uomo e non lavorare. E, conforme l'occasione, ne vo tutto gioioso e festevole con un mio amico, nominato Pulicinella, all'osteria e colà, per me e per lui, spendo e spando quel che ho e quel che non ho, perché tutti gli osti e bettolieri e magazenieri mi fanno quanta credenza io voglio. Pullicinella mi fa ridere e io a lui e così stiamo allegramente fra di noi, lui detto il cavalier straccione e io il gran barone di campo di fiore.</p>
           </sp>
@@ -1021,100 +1061,100 @@ umilissimo e perpetuo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">volpone</hi>
           </stage>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Se questa bella e chiara luce della mia cara e amata Lucilla non schiara le oscure tenebre del mio cuore, in breve sarà l'ultimo giorno della mia vita.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Servitor, signor Fulgenzio.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Il Cielo ti sia sempre propizio, caro Volpone.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E a vostra signorìa mantenghi sano e con insolito appetito. Se non mi inganno, parmi di vedervi oltra modo turbato, avete forse giocato e perso? avete perduto l'appetito? o non vi piace il vino?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Non la posso vincere, né con amore né con la fortuna, e son rimasto d'ogni gusto privo, odio me stesso e
 <pb n="562"/> amo chi desidera la mia morte, e per compiacerli, tosto vorrò finir i giorni miei.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Ohimè, signor Fulgenzio, e ché ciò dite? Perché volete cadere in così pazzo errore?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Per l'ingratissima Lucilla, della quale io già ti favellai, che in modo alcuno non vuol esser mia.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E perché non fate una degna risoluzione di chiederla in moglie al padre?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Io glie lo fe' dire, e lui mi fece rispondere di non volerla maritare per ora e che lei non si sarebbe contentata, e poco fa, con mio molto grave dolore, ne ho ritrovato il vero. Ma prima di consentir che altri che me abbia a correr seco sì felice sorte, ti giuro che ne vorrò morir o privar di vita lui.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E come non conoscete il grave errore, che contro di voi stesso commetter volete? e che espressa pazzia è questa, voler morire per donna crudele e che vi odia? Deh, signor Fulgenzio, non vi lasciate così dominare dall'ira e dal furore! E come, in tal modo, inconsideratamente ponete in oblivione voi stesso? Datevi in braccio alla ragione, perchè, ciò far volete?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Perché quando sarò morto più non la bramerò e uscirò dalle crude tirannide di costei, né sarò stimolato dal dolore, dalla passione, dall'amore, che io sento, e dall'odio e dalla crudeltà sua.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Signore, io non mi conosco abile di potervi persuadere a cangiar voglia, ma ben vi dico che così disperato e privo di conforto, mi par cosa indegna volervi precipitosamente privar di vita: ma ben vi dico che dobbiate aver speranza in me, perché pensarò forsi cosa che vi potrebbe cavar fuora d'ogni affanno.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Che vuoi tu che io speri, se l'àncora della mia speranza se n'è già sommersa dentro al mar delle miserie, e questo mio fragil legno in periglioso pelago si trova, combattuto dal dispietato rurore dell'instabile fortuna?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>L'àncora non è sommersa, né profondata; la speranza non sarà fallace, il vostro legno senza intoppo di avversa fortuna giungerà forsi al desiato intento. Che altro bramate da me?<pb n="563"/></p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Volpone mio, con queste tue amorevoli e ben considerate parole, vai quasi riducendo in gaudio il mio tormento, in gioia la mia pena e in viva speranza la mia mortal disperazione. Però dicami, di grazia, in che modo potrai giovarmi?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Con l'acutezza del mio ingegno e con l'aiuto di Pulicinella, vostro servitor novello, per non esser conosciuto, farò il tutto. Non sapete voi che la signora Lucilla tiene una sua zia al giardino indisposta?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>É vero, perché?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Ve'l dirò doppo. Prestatemi il servo e andate ad aspettarmi in piazza. E achetatevi la mente, non vi disperate, perché io vi prometto senza dubbio alcuno sicurissimo aiuto.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Orsù, andarò riposandomi sopra di te. Chiama Pullicinella, già che lo vuoi, ché egli è in casa.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Io, signor Fulgenzio, fora d'ogni interesse vi amo e vi voglio servire, essendovi molto obligato.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>So ben io ciò che deggio fare per giovarti. To' per ora queste due doble di Spagna.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Oh vi ringrazio, signore. Non occoreva incomodarvene. A dispetto del padre, che ve l'ha negata, e ad onta di lei, farò che ella vi venghi sino a casa a ritrovarvi come moglie, e se per tal la desiderate.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Sì fratello, che per altro non la bramo, mi ti raccomando, vado ad aspettarti.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Andate, che io chiamerò il servo. State pur allegramente signore.</p>
             <p><stage>(<emph>Volpone solo</emph>)</stage> Due doble! Osteria aspettami! E chi non facesse sempre il ruffiano? Vorrò sempre farlo e inviluppare e scroccare quanto potrò. Oh doble mie care. Non so come gli altri abbiano tanti dinari, tanti argenti e tanti ori, credo che gli rubbano e veramente hanno ragione, poiché le robbe e i tesori di questo mondo sono stati tante volte rubbati e ritornati ad arrubbare, che non si può più giudicare chi<pb n="564"/> sia stato il primo e vero padrone. Vorrò cominciare a servir il cortese Fulgenzio, perché lo merita. Chiamarò fuora quel buffalaccio di Pullicinella, che siamo ancora oltre di qui amicissimi vecchi e compagni nello studio dell'osteria del Ceriglio di Napoli.</p>
@@ -1128,204 +1168,204 @@ umilissimo e perpetuo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">volpone</hi>
           </stage>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Chi è, chi chiama, chi sfonola, chi tozzola la porta della casa nostra?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Questa è la sua voce. Amici, amici, Policinella. Odimi una parola.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Amici siammo, e le vorze comatanno, a che serve a dicere amice amice, penza ca saranno amice amice, ca io non aggio nemice. Chi è, è, è?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Sono un tuo particolar amico, vien fora perché ti ho da parlare.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Io sto comodo cà e non me voggio scometare. Parla dalloco, che te responnarraggio.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E vien fuora, di grazia, ché ho molto a far di te.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>E io non aggio a fare de te, non ce simmo nesciuno, ca simmo asciute tutte fora della casa a cossì m'è chiù comoto. Crepa e schiata, che buoi da me, che se ben ce so', non ce voglio essere?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Policinella, bona sera, fratello.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>O Vorpone, bona sera e bon anno! Tu non stai en cerviello ! Se io t'aggio ditto ca non ce songo a la casa e che si ben ce songo non ce voglio essere, chi te ha dato lecienzia che me chiamme pe nomme di figlio de potana?<pb n="565"/></p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Perché son tuo amico e molto di te mi fido.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Non troppo te ne fidare, ca so' diventato maleziuso e concubinario.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E così voglio che tu sia, perché per ordine del signor Fulgenzio abbiamo a far una grand'imbroglia e un grande intrico.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>A fé? A donca deventaraggio nmbroglione? O bene mio ca saraggio mrogliatore e borraggio nmrogliare tutte li tavernare de Capua, de Napole e da Verza!</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Caro il mio fratello, ascolta.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Tu me chiamme fratiello e me viene a pregiudicare, chiamannome figlio de potana e de cornuto.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>O questo no, perché?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Perché né mama né patremo no hanno fatto mai autro figliulo de me, sì che besognerìa che io o tu fossemo mulle cancirre, o vastarde, toscanescamente parlanno.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Questo è un modo di parlar amorevolmente fra gli amici, ma non mi sei fratello.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>E chesto è peo, perché viene a dicere la buscìa, no lo bide? no lo dicere chiù vi' sa? ca po' te piglia Parasacco e te porta a lo nfierno.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Se io non fo peggio di questo, non ho paura! Sta' pure allegramente, guarda qui, sempre averò per farmi piacere dieci scudi al mio comando.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Per farete piacere a te e no a me?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E a te ancora.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>O bene mio! O commo so' belle russe! Di' lo vero, so' li tuoi 'si denare?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E di chi vuoi tu che siano? E sono al tuo comando. Andaremo, doppo fatto il servizio del tuo padrone, all'osteria a dar tributo alle budella.<pb n="566"/></p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>O felice tene, che hai sempre denare, e sfelice mene, ca non aggio mai niente, e felice 'si denare che stanno
 'n potere dello chiù liberale ed eccellente ruffiano de sta cettate.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Circa del ruffiano, parla piano, Policinella mio caro.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>E puro quinnece co lo gallo! Ca so' lo mio e no lo tuio, ca si ca me saraggio perduto e si voraggio niente da me, besognerà che me te adomanna a te 'n priesteto.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>O puttana di me, che sì che non si potrà più parlar teco, che ogni cosa pigli in duello.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Che puttana de te, dico puttana de me, ca la voglio pe me! Dov'è 'sa puttana?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>É su le forche! dove vòi tu che sia?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Va te la piglia tu, ca no la voglio io. Ora sù, dimme lo vero, vai a caccia lo iuorno a borze e la notte a feraiuole. Nparame comme fai, damene menzione, ca me voglio fare valent'ommo io perzine.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Vedi Pollicinella, tu in tutti i modi mi pregiudichi, ma io ti perdono. Questi dinari me li ha dati il signor Fulgenzio e te ne farò parte, pure che tu ti porti bene ad aiutarmi; e da sua parte te lo comando.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Vorpone caro, io voglio servire lo patrone e obedire a te, ca te so' schiavo e obrecato de tanta denare, che spenive pe me a Napole, e hai spenuto cà ancora. Ma famme no piacere, doname na dobra de chesse, quanto me n'acatto no paro de scarpe vecchie e na menestra grassa a boglia mia. Bene mio, fame 'so piacere, ca te voglio tanto bene.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Policinella, ti parlo da amico, sarai da me riconosciuto un'altra volta, perché non sta bene a discompagniare queste doble essendono pari.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>E tu me le da' tutte doie e scumpimo lo chiaito, non m'entienne?<pb n="567"/></p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Oh par che si convenghi che io me ne rimanghi privo! tami Aiutami e doppo parleremo di questo.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Mese' Vorpone, tu fai iusto commo fa la vorpa, perché si' de chella razza.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Che fa la volpe?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Che fa? Ha la coda longa, che se contenta chiù priesto strascinareia appriesso pe terra, che darene no poco alla poverella scigna, a tale che non mostra le vergogne soie e se ne copra lo tafanario.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E tu appunto fai commo fa la scimbia, che non essendo buona come l'asino per portar delle legna, come al cavallo a tirar la carozza e portar l'uomo, come il bue a tirare il carro ed arare la terra, fa la buffona, facendosi dare delle busse per far ridere e procacciarsi da mangiare.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Ora cà, sì, ca nce iarìa no bello miente pe la gola e na bella cornuriata! O tu me pregiudeche troppo, ma te la perdono pe sta vota, ora sù, non lo dicere chiù. Dimme, ch'aggio da fare per servire lo patrone mio?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Policinella io burlo teco, e dico che no fai bene a dir male delle persone, e per giungere dove si desidera bisogna aver spesso Lodi e Piacenza in bocca.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Sì, me piace chello caso lodesciano e piacentino, dov'è?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Voglio dire che bisogna lodare e piacere alle persone per farsi amare come fo io.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Amare? E che so', femena de lo brutto peccato, che me voglio fare ammare da la gente? Io so' buono figliulo e no me nce suoglie a fare chello che hai ditto.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Orsù, a noi, non saltiamo più da palo in frasca. Conchiudo che servito che averemo il tuo padrone, di donarti una dobla.<pb n="568"/></p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Te ne ringrazio, ma dimme, lo servizio è onorato?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Onoratissimo. Vattene dunque in piazza, colà dove si vendono i limoni, ché vi ritroverai il tuo padrone che ti attende; che doppo all'uno e all'altro informarò del tutto. Va' tosto.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Vao vao! Dice, che tuesto; e che, me voll formare? e che, so' fatto stivale? o che bello varvaianne e che bozzachio !</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p><stage>(<emph> solo</emph>)</stage>. Ho tanti negozii amorosi per la testa, che non so risolvermi a qual debba prima attendere; ché non solo questo del signor Fulgenzio mi travaglia, ma ancora l'amore che a Clarice porta il signor Alberto, che alli giorni passati gli ne diedi bona speranza, non so se ora sia più di quell'umore. Però, ancor io, sono un poco gallesco, e più d'una cosa farei se avessi la possibilità e la nobiltà. La nobiltà fu da me sbandita per disutile e da i miei progenitori, perché chi è stato facchino, chi spaccia camino, chi spacca legna, chi sbirro e chi giustiziatore umano. Solo io ho dato un poco di luce alla mia casa, con ingegnarmi a far lo ambasciator d'Amore, e per farla più luminosa ne ho smantellato i tetti, per andarli a vendere, quando non ero ancora onorato di sì degno offìcio. E non senza cagione ho detto che vorrei essere in maggior stato, perché amo ancor io la signora Clarice, e, per esser quello che io sono, non oso palesarmeli amante, temendo che non me dia una infinità di bricconate per il capo, di mascalzone, di guidone e di ruffiano.</p>
           </sp>
@@ -1337,106 +1377,106 @@ umilissimo e perpetuo servitore
             <hi rend="italic">dalla finestra e</hi>
             <hi rend="sc">volpone</hi>
           </stage>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Lo starsene sempre solitaria e confinata in casa, gran pena apporta a noi misere fanciulle, che non ci è conceduto il venir spesso su le finestre, per non arrecar scandalo e mal<pb n="569"/> esempio all'altre di noi. Ma con tutto ciò, per isfogar l'ardore che con tanta potenza mi distrugge per l'amato mio Fulgenzio, rompendo ogni legge impostami dal mio fratello, vi sono venuta.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>A fé, che questa è la signora Clarice. O felice Volpone, ecco che dolcemente te viene a caderti la fritella sul mèle e il cascio su i macaroni, e poiché per questa contrada non vi scorgo altra persona che lei, sarà se non bene che io dia principio a ciò che bramo. Ma prima voglio con questo fazzuolo fregarmi le scarpe. Orsù stan bene, farò così del volto. O corpo di me, mi son tutto sporcato il viso, porco che sono a non avermi posto il colar bianco questa mane!</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Chi è quel ucellaccio domestico che con tanta leggiadria si pavoneggia e si fa bello?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Servitore di vostra signorìa, Clarice mia padrona.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Appunto desideravo di favellar teco. Ben venghi il mio caro Volpone, so che molto ti preggi in lasciarti vedere da me.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Signora, so che ben sapete che tutte le cose belle e graziose non possono esser così facilmente vedute da tutti.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Oh mi fa da ridere, che sì che si darà a credere di esser bello, voglio gonfiar il suo bestial umore!</p>
             <p>Anzi, che quanto più bello sei tanto più ti dovreste degnare di lasciarti vedere tra noi altre brutte donne, per poter a noi partecipare della tua bella grazia e rallegrarci il cuore, poiché così sopra modo grazioso ti veggio.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Io l'ho detto in burla ed ella parla da dovero. Che sì che si sarà invaghita di me? Vorrò starmene su la mia, per darli maggior martello. Può far il mondo, se io lo sapevo mi averci lavato il viso con l'acqua calda, poiché ha più di dodeci carnevali che non me lo ho bagnato.</p>
             <p>Signora, quando io fossi sicuro che da lei fossi tenuto uomo di qualche degno merito, li farei sapere chiaramente l'animo mio.</p>
             <p>Che sarà mai, quando anco vi spendessi con costei queste doble.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>E chi sarebbe mai così sciocca e priva di giudizio che dir volesse che tu molto non meriti? Anzi, ché tutta sopra del mio caro Volpone sta fondata la mia speranza.<pb n="570"/></p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Mi amate, forse?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>E come, se ti amo? E per degna ricompensa vorei...</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Che vorreste, signora? Vi è il signor capitano in casa?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>É fuora e perciò ardisco di così liberamente parlar te. Vorrei che mi deste aiuto, e con molta diligenza e prestezza, se non chi io moro.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>La cosa è fatta, sono a cavallo!</p>
             <p>In che cosa potrò giovarvi signora? Ditelo, di grazia. Toglietemi di dubbio, perchè, mi sento tutto comovere e distruggere.</p>
             <p>Ohimè non ardisco di dirgli ch'io l'amo; vorrò che ella sia la prima a dirlo, per potermene doppo gloriare e darmene vanto.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>In far saper al signor Fulgenzio che io l'amo e lo desidero per mio sposo.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Al signor Fulgenzio, volete che io dichi questo? e non a me?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>A lui sì, Volpone mio, poi che io t'ho veduto, da dentro la mia fenestra, quando che tu familiarmente seco ragionavi.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E io, viso di porco, mi credevo che fosse stata invaghita di me e delle mie rare bellezze, per disfogar meco le amorose voglie! Orsù, in somma, la natura mi ha creato più ruffiano che bertone, non voglio dirli altro di me, per non arrecar pregiudizio a un certo mio novo disegno; e sarà ben dirgli che Fulgenzio l'ama.</p>
             <p>Signora Clarice, se bene a lei fosse forse paruto che io parlato li avessi come per me, parlavo per il signor Fulgenzio, che più che sé stesso vi ama, e quando vedeste che meco ragionava, mi diceva che io dir vi dovessi la sua pena, e perciò mi andavo avicinando qui a casa vostra, per parlarvi di lui, che vi desidera per sua consorte. Sì che, essendo questo amore fra di voi di tanta corrispondenza, io sarei di parere, e molto lodarei, che questa notte doveste lasciar la porta di casa vostra socchiusa e quella della camera dove dormite aperta, ché, al tocco delle cinque ore di notte,
 <pb n="571"/> quando che vostro fratello sarà vinto dal sonno, ve lo condurrò in camera, dove potrete affermare e conchiudere a vostro comodo, senza lume, il matrimonio.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Dunque che io non ne debbo crederne il contrario di quanto mi hai detto, Volpone mio?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Signora no, ché so che non mi avete ritrovato mai bugiardo.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>E mi ama di perfetto amore Fulgenzio?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Se vi ama lo so io; non vi fate altro dubbio, ma con questo appuntamento non si resti di esequir l'ordine.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>O che felice novella, o che inaspettato contento! Ah, Volpone mio, che per troppa letizia non capisco in me stessa! Farò quanto che mi hai imposto, lo aspettarò. Raccomandami a lui e digli quanto l'amo. E a te per ora non dirò altro, solo che in tuo potere sta la mia vita e la mia morte, e saprò ben io quanto devrò complir teco, e per ora ti dono questo piciolo diamante, goditelo per amor mio e ricordati di me. E per non dar sospetto a mio fratello, se qui sopragiungesse, con ragionar teco, me ne entro, a dio.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>, Son vostro, mi raccomando signora.</p>
             <p>A fé, che glie la potrò caricare, glie la caricarò! E io asinaccio, mi tenevo per sicuro che ella si fosse invaghita di me! Orsù, ho guadagnato questo anello e saprò come governarmi.</p>
@@ -1449,87 +1489,87 @@ umilissimo e perpetuo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">volpone</hi>
           </stage>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>In avere escluso quel capitano spagnolo del matrimonio con mia figlia, mi ha negato di darmi la sorella e mi ha cominciato con sossegate parole a darmi del grosso. A fé, che quella lingua, che ha di me mal favellato, glie la farò morder, se ne è rimasto colà lacerandomi con alcuni gentil uomeni!</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Baccio la mano signor Alberto. Che dite di mala lingua, signore?<pb n="572"/></p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O se' tu qui, Volpone?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Al comando vostro, signore.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Discorrevo tra me medesmo della mala creanza del Matamoros, che ha meco usata, perché gli ho detto che Lucilla non lo vole per marito in conto alcuno.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Certo che è diabolico e insolente quel spagnuolo. Dicesi che più delle volte offende più una cattiva lingua che una buona spada.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>É più che vero. Poiché un certo re d'Egitto, di cui non mi sovviene il nome, mandò a Solone filosofo un agnello che sacrificar lo dovesse a gli dèi, e che in sacrifizio dato gli avesse la miglior parte, e la peggiore avesse rimandata a lui, e quello li mandò la lingua, e il rimanente sacrificò a chi dovea; volendo significar che quella era la peggior parte del corpo, poiché si suol dire che sia il timone della umana vita, come il timone alla nave, ché ben che sia il picciol legno, a lui sta a condurre in precipizio o in sicuro porto il vascello.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Vostra signorìa, Alberto, non dovrebbe dare a mente alle sue parole, poiché corre la voce per la città che come corbo non sa far altro che gracchiare.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Lo so, e perciò temo più della sua cattiva lingua, che delle armi. Chi sa ciò che egli avrà detto e dirà per l'avvenire in pregiudizio di casa mia!</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Lasciatelo tanto dire, che possi scopiare; perché chi lo udirà straparlare, considererà che l'amoroso fuoco lo tormenti, e si riderà di lui, poiché non vi è più potente fuoco quanto quello di amore, perché arde così da lungi come d'appresso.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Vòi dire, per questo, che gli ama Lucilla; e chi non saprà tanto oltre? In somma, è tenuto per una pestifera lingua.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E questo molto vi giova.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>E perché?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Perché non si crede al bugiardo, benché giuri; ben si crede al verace, ancorché mente.<pb n="573"/></p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Non tutti lo stimano bugiardo e di mordace lingua.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Dunque, se costui morisse, che epitaffio se gli potrebbe scrivere su la sua sepoltura? Ditelo, di grazia.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Férmati, ché mi hai colto all'improviso. Lasciami un poco pensarvi sopra.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Pensateci bene. Aveteci pensato?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Férmati, odi se ti piace, rimettendomi però a più saggio pensiero.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Ditelo, signore.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Tacci, no'l me'l far dimenticare. Odi.</p>
             <lg type="nondefinito">
@@ -1538,15 +1578,15 @@ umilissimo e perpetuo servitore
               <l>ancor che morto sia, morde la terra.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Certo che è molto a proposito per lui, perché non sa far altro che cicalare contro di questo e di quello. Ma che vi credete voi, signore, che io farò scriver su la mia sepoltura?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Di', ché ti ascolto, che farai?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <lg type="nondefinito">
               <l>Il buon maestro di gran petti e rutti,</l>
@@ -1554,51 +1594,51 @@ umilissimo e perpetuo servitore
               <l>Vi prego di pisciargli addosso tutti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Hai altro tu che dirmi di bello? E va' via e non mi dar più noia, ché ho altro nel capo che le tue dapocaggine.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Vostra signorìa non mi trattò che desiderava la sorella di questo capitano?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Messersì; però me deliberai, vedendoti così freddo al servirmi, di trattarne con lui e non abbiamo potuto conchiudere cosa alcuna, come ti ho detto.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Vi contentate che io studia un poco nel libro delle mie forfantarìe sopra di questo negozio, per farvela avere a suo marcio dispetto?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Studia pur quanto che vuoi, ché io dispero il caso.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Se non mi bastasse l'animo, non lo direi, e lo dico perché la signora Clarice mi ha detto di amarvi.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Di' tu da dovero, che mi ama lei? Come lo sai, dimelo, di grazia?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Non direi una cosa per un'altra, né voglio cosa alcuna da vostra signorìa, se prima non parlarò seco e ve ne darò risposta, e vi aiuterò.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>E in che modo, dimelo, non mi tener sospeso.<pb n="574"/></p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Ve'l dirò poi.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Non voglio sapere altro. To' questi quattro ducati per ora. Fa' il negozio pulito, di grazia, perché la desidero più per dispetto del fratello, che per altro.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Vi ringrazio, lasciate pur fare a me.</p>
           </sp>
@@ -1610,39 +1650,39 @@ umilissimo e perpetuo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">volpone</hi>
           </stage>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Por vida del rey mi señor, que Alberto no serà siguro en cima de los altos montes Perineos de mis poderosas manos; ni sobre la cabeza de Marte, ni tan poco en los brazos de Plutòn! O là, mal nazido, viejo raposo, aquì estàs? Sabes que has de morir de mi profunda estocada, antes que el sol, rodeando con su carro de oro, se vaia al frio settentrion</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Fermatevi signore, raccordatevi che questi è vecchio, ed ella è giovine e valorosissimo capitano e cavalliero. Portate rispetto, se non alla vecchiaia, alla vostra grandezza.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>State da me alla larga.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Quieres tu tomartela por el? Echa mano a tu espada, vellaco, que te quiero dar a comer a dos grues</foreign>!</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O di casa, portatimi giù la mia spada! Non odi Lucilla? Scaltrino, fuora.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Cacciarò mano ai piedi, fermatevi, state indietro.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Signore, infoderate la vostra spada, ricordatevi che io son quello dalla ragione. Lucilla non si vol maritare, né vi vole, che colpa è la mia?<pb n="575"/></p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Yo no le doy tanto la culpa de esto, quanto que con tan mal termine vino a escluirme, delante de aquellos cavalleros, que la señora Lucila no podìa padezer de verme. Y que soy algun picaròn o algun vellaco? Y como esto, a un cavallero nazido de tan soberano linaje, pues que milliones de verdaderas historias de mi celebran tantos heroicos echos, que allandome eri Flandes, eri el medio de los enemigos exercitos, cerquado de arquebusarias, rodeado de cavalleros a cavallo, a remetido da esquadrones y de emboscadas; sacudido de piezzas de artellarias y bombardas, fulminado de colombrinas y de agudas puntas de espadas, estoques, piquas y alabardas de vallentes soldados, cavos de esquadras, sarjentos, alferez, capitanes, sarjentos majores y generales y generalissimos, y por esto luego huiendo de mi el ocioso espanto y enbrabaciendos en mi la bravezza y estremada fuerza, el animo y valor, con atrebido corazon, ferozidad de leon, crueldad de tigre, furor de cocodrillo, fuerza de brazos, animosidad de corazon, con estocadas, pugnaladas, jacozes, mozicones y con dientes, los gané, los maté y los yze en pedazos, los aniquilé y los profundé de baxo del infernal fuego</foreign>.<pb n="576"/></p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E chi si può salvar si salva.</p>
           </sp>
@@ -1650,31 +1690,31 @@ umilissimo e perpetuo servitore
         <div type="scene">
           <head rend="italic">SCENA SETTIMA</head>
           <stage><hi rend="sc">scaltrino</hi>, <hi rend="italic">con sudetti</hi></stage>
-          <sp>
+          <sp who="#scaltrino">
             <speaker><emph rend="sc">scaltrino</emph>.</speaker>
             <p>Chi è là, che romore è questo? Signore, mi avete chiamato? Perdonatemi, ché dormivo. Ecco la vostra sferra vecchia, avetela con alcuno? Ditelo a me, che ne farò salciccie.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Damela qui. Signor capitano, per farvi piacere crederò più di quello che cicalato mi avete.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>, E io ancora, benché non vi abbia inteso.</p>
           </sp>
-          <sp>
+          <sp who="#scaltrino">
             <speaker><emph rend="sc">scaltrino</emph>.</speaker>
             <p>E io più di loro, se ben non so di che ciarlate.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Né io ne ho inteso niberta di quanto ha spudato il saraco.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">A vellaco, a mi quieres dar la cobierta, y que soy tu</foreign> truhan?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Fermatevi, ché intendete alla roversa, ché ho detto niberta, che vol dir nulla.</p>
           </sp>
@@ -1682,15 +1722,15 @@ umilissimo e perpetuo servitore
         <div type="scene">
           <head rend="italic">SCENA OTTAVA</head>
           <stage><hi rend="sc">fulgenzio</hi>, <hi rend="italic">con sudetti, e</hi><hi rend="sc">squarcia</hi>, <hi rend="italic">e</hi><hi rend="sc">scaramuzza</hi></stage>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Fermatevi, signor capitano, che vergogna è questa?</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>State alla larga, cospetonaccio di Martone. Animo, signor capitano Mattamoros.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Te' messer Arberto, pigliate sta chiatonata!<pb n="577"/></p>
           </sp>
@@ -1698,11 +1738,11 @@ umilissimo e perpetuo servitore
         <div type="scene">
           <head rend="italic">SCENA NONA</head>
           <stage><hi rend="sc">lucilla</hi>, <hi rend="italic">con sudetti</hi></stage>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Signor padre, ho qui la spada per voi. Alla larga, poltroni!</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Avete a far meco, ci ammazzeremo, capitan Matamoros!</p>
           </sp>
@@ -1713,23 +1753,23 @@ umilissimo e perpetuo servitore
             <hi rend="sc">policinella</hi>
             <hi rend="italic">con sudetti</hi>
           </stage>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>A spagniuolo vaiasso, pigliate sta vessicata 'n capo!</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Bravo Policinella! Entrate in casa, signora, poiché tutti se ne sono fuggiti dall'empito e dal furore della vessicata di Policinella.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Ahimè, dove è mio padre? Non so se sarà rimasto ferito.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Non credo signora, ché se ne è andato per altra via.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Anderò in casa.</p>
           </sp>
@@ -1741,43 +1781,43 @@ umilissimo e perpetuo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">volpone</hi>
           </stage>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Dove se n'andò il signor Alberto? É stato alcuno ferito, che tu sappi?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Signor no, Alberto se n'andò per questa strada.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Almeno per tal onorata azione, che ho fatta in difendere il padre della signora Lucilla, non dovrebbe amarmi? Rispondimi, Volpone.<pb n="578"/></p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>É vero, ma non tutti riconoscono il beneficio. Però, per giongere vostra signorìa dove desidera e io bramo, per attendervi ciò che vi ho promesso, vi bisogna del tempo e della fatica.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>La gloria non si acquista, se non con essa, madre della virtù. Affatìcati in mio beneficio, ché da me ne sarai molto ben ricompensato.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Ve ringrazio, non ne fo dubbio alcuno e perciò porrò sempre questa mia vita in qual si voglia pericolo e fatica per servirvi.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Se ti affaticarai per me, farò che alfine ne abbi lieto riposo, poiché la fatica è madre di esso, e spesso si affatica per non più affaticarsi. Il fondamento della virtù di Ercole fu la fatica; le molte fatiche fecero famosi i Scipioni, i Fabii, i Camilli, capitani de' Romani, e la fatica diede gloriosa fama a Pompeo e Alessandro il Magno. E qui è maggior gloria, ove è maggior fatica.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Signore, io non vorrei che mi affaticasse tanto la mente a narrarme cotante faticose fatiche, acciò io per molta stanchezza non mi potessi più affaticar per voi. Ritiratevi, dunque, in vostra casa, già che vi ho conferito in piazza, così a vostra signorìa come a Policinella, l'astutissimo inganno che venendo egli con i limoni potrò oprar il tutto, acciò questa notte possiate godervi della vostra amata Lucilla. Andate pur in casa vostra.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Andarò, poiché il servo non potrà molto indugiare a venire.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Andate signor.</p>
             <p><stage>(<emph>Volpone solo</emph>)</stage> Può far me, ho tanti fastidii, che non ho potuto andare a visitare un poco l'osteria!<pb n="579"/></p>
@@ -1790,123 +1830,123 @@ umilissimo e perpetuo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">volpone</hi>
           </stage>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Affé, ca n'aggio paura de chiste roseca catenacie, di sti penachielle co li mostacce stuorte a cruoche de carne! Uno me teneva mente alla smargiassa, parenno quase che me avesse voluto gliotere e dellegiare, e io co na sbotata de uocchi, na sbattuta de piede 'n terra, no pideto e no stornuto, l'aggio subeto fatto vacuare lo fegato, con tutto lo core e li permune, e deventare tiseco comme a statua e sico coma mumia de levante.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>O misero Scaramuzza, tu vai fra te stesso chimerizando e facendo lo sgherro, e messer Alberto da' suoi bravi ti potrebbe fare ucidere per la piatonata che da dietro tu gli detti.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>O pò far la vita mia, e che ne dici tu? Si' de parere che me ne porrìa fare accidere de sto mbruoglio?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E che ne sei in dubbio di questo? e che aspetti, che non ne fuggi dalla città? come, che non ne farà gran risentimento? un uomo di tanta riputazione, e tanto amato qui nella città di Capua, che credi che se ne voglia stare con le mani alla cintola? O poveretto te, asconditi!</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>E frate Vorpone, tu me farai venire scorezione de cuorpo, tanta paura me miette! Io sto buono a sta città e no me vorrìa partire da sti case cavalluce e provature fresche. O fortuna mia crudele, e quale chilo, che squaglia m'ha tentato, che io le desse?. Ora va', ca lo creo che lo capitanio spagnuolo va cercando isso per zi' Pullicinella e lo volle accidere pe la vessicata che l'ha schissato 'n capo, perché tutte lo chiamano capitan Vessica.<pb n="580"/></p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Orsù, ti esorto una cosa fratello: vate muta di vestimenti, ché non essendo conosciuto, non ti sarà fatto dispiacere.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Io cierto aggio da esser acciso, perché na zingara me lo disse, allo manco trovasse chi me lo sapesse nevinare.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Férmati Scaramuzza, non ti disperare, scopriti quel fronte.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Te ne intienne a fé? E fa' adaso frate, ca me fai male, pare ca volimmo ioquare a tafaro, a tamurro, pizingogola e cemino.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E férmati, non star su le burle.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Me fermo, sto saudo, commo me radesse.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Mostra la mano dritta.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Te'.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>O come spuzza di lavature di piatti.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Non ha doi ora che l'aggio lecate e lavatel A fe', ca da chesto a comienze a nevinare buono.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Questa è la linea del sole. O come va dritta e giusta! Tu sei molto amato da prèncipi e hai da ereditare una gran forca, o voglio dire richezza.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>E ca tu me cossie, frate, no burlare.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Férmati. Achese e bochese e tempore sosina, l'aseno che sta fermo non camina. A te dico, Scaramuzza, sta' in cervello.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>E chi non lo sa chesto? Tu me dellige.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Sta' pur saldo, or qui è l'importanza, stammi ad udire.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Te sento.<pb n="581"/></p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Vergine e Libra da te fugono; Ariete e Gemmini te dominano nelle mani; Pescie ti molesta davanti; il Tauro con il Cancaro da dietro.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>E ba' la forca, vòi burlare!</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Sagittario ti minaccia il fianco, Scorpio il naso, Aquario la gola.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>A lo manco fosse vinario e no aquario!</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Leone tutto il corpo e Capricorno il capo.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>O maro mene, adonca saraggio cornutto a paletta? Pe lo cunto della chiatonata no se ne parla?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Va alla peggio. Vati salva in qualche modo, via, ché la tua stella ti minaccia morte.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Vao, vao, che bole la stella da me? che l'aggio fatto?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E io men vo per ritrovar il servo del signor Fulgenzio.</p>
           </sp>
@@ -1917,7 +1957,7 @@ umilissimo e perpetuo servitore
             <hi rend="sc">squarcia</hi>
             <hi rend="italic">solo</hi>
           </stage>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>É possibile, o mia crudelissima guerriera, che tu così dispietatamente brami la mia morte? Ah, che se io avessi il petto trasparente, in guisa di chiaro e limpido cristallo, ben vedreste, o bella mia Clarice, arder per te mille fornaci ardenti. Poiché il misero e tormentato mio cuore si dilegua, si distrugge e avampa assai più che la fucina di Vulcano, Strombale, Etna e Mongibello ; arde più che il fuoco elementale e infernale; e per estinguerlo bastevoli non sarebbe né sorgenti fonti, né correnti fiumi, né il vasto oceano, né le gran catarate dell'aqua del Nilo, ma solo quella del dolcissimo fonte della tua amata grazia, quello, dico, che mi sostiene in vita. Che farò dunque, cuor mio, se da te non avrò soccorso? chi darà rimedio al mio dolore, come potrò più, senza il tuo aiuto, mantenermi in vita?<pb n="582"/></p>
           </sp>
@@ -1929,111 +1969,111 @@ umilissimo e perpetuo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">squarcia</hi>
           </stage>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Io non so dove se sia cacciato quel Pollicinella.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>A dio Volpone, che dicono i riporti di Fiandra, di me?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Delle fiandrine e della barbaria vi potrei dar più sicuro aviso.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Sempre stai su le burle. A fé, che se tu patessi la pena che io per Clarice patisco, che senz'altro più dire ti anderesti a sepelir vivo.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E perché non vi andate voi?</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Perché sono impenetrabile e immortale e la speranza mi mantiene.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Di gir su una galera.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Ti ho ben inteso, sì, che anco questo esser potrebbe per generalissimo del mare, ma non voglio per ora.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Voi dite che vivete di speranza. Chi vive di speranza, fa la fresca danza. Ohimè, di grazia, vi prego a non farmi quella guardatura di gatto arrabiato, con quello inarcar di ciglia porcine, perché temo di morir vestito.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>L'aquila non piglia mosche, non imbraterei la mia mangiacuori per così poco cibo. Ti dovresti spaventare, porti in fuga e girtene a concentrar nell'abisso, quando che tu fosti un esercito de paladini armati. Fatti in là, non mi mirar così fisso, perché hanno gli occhi miei l'eccelsa virtù del sole, che fanno abbagliar la vista a chi li mira. Non ti accorgi che mi offendi col fiato?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Se pur è vero, che non mi sappia di buono, come voi dite, lo cagionano i molti secreti de gli amici, che per non palesarli sono putrefatti nello stomaco.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>O ti ho inteso, segui ancora di far le ambasciarìe amorose, come di già facevi?<pb n="583"/></p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Dite pure il ruffiano, signore, ché lo fo per eccelenza.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>O putanaccionacissima della quinta essenza del brachiero di Saturno, io non me lo ricordavo. Deh, caro Volpone mio, fammi posseditore della mia bellissima Clarice, ch'io ti prometto e giuro, per la suprema beltà di lei, di farti padrone assoluto di tutti i tesori del Perù.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Pure che il volermi intricare in questi vostri amori, il capitano suo fratello non mi faccia su l'asino re di Cartagine e ministro di Galilea.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Né della frusta, né della galera, porta pericolo chi si adopera in servigio dell'orribile e spaventevole capitan Squarcialeone e Scornatori, arcivalentissimo valente.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Ma dalla forca non so se me ne potrete salvare. E dirò, come scrisse il saggio, che il serpe giace tra' bei fiori e l'erba.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Io ti intendo, vuoi tu dire che l'erba e i fiori sono le molte bellezze della mia donna, e il serpe il suo fratello, non è vero?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Signor sì, bisogna guardarsi di lui.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Che si guardi pur lui di me, che non lo mandi invisibile per aria, come se avesse li stivali di Leonbruno. E tra le spine vi sono ancora le rose; e tra le api il mèle; se ne ha dunque da rimaner privo per questo? Cospettonaccio del gran cavallo di Troia! To', prendi questi quattro ducatoni, spendi e aiutami, e ricordati che se io voglio ti posso far monarca.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Sì dell'ospitale de gli Incurabili di Napoli! Vi ringrazio con vostra signorìa non fui mai interessato, e sappiate che la signora Clarice ama svisceratamente il signor Fulgenzio, e io li ho promesso di farglielo ritrovar questa notte dentro di questa casa vòta, all'ora quando il fratello di lei sarebbe addormentato, che io li avevo promesso di condurgliela, sì che in vece di Fulgenzio, vorrò (se così vi piacerà) che vi andaste voi signor, anticipando il tempo. E darò a<pb n="584"/> credere a lui che l'apuntamento s'è preso per un'altra volta, e perché sarà oscuro, lei vi crederà Fulgenzio, e così farete ciò che vi parerà e anderete tastegiando le sotteranee parti.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Or sì che ti meriti ch'io ti facci imperator di Tartaria.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Vi vado ogni mattina.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Io vi anderò, e per segno che ti amo, goditi ancora questo pregiato anello, che me donò la regina d'Inghilterra per memoria di un gran fatto d'armi, che io per lei feci in Africa.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Io vi ringrazio, e me lo terrò carissimo e conservarò in una amplissima carta, dove vi sta dipinta una città dell'istessa Africa, detta Bugia. Dunque entrate in quella casa che io ho detto, e vederete che ve la farò venir nelle braccia senz'altro dubbio.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Volpone, fratello, io vado; mi raccomando alla tua diligenza.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Andate, ché ormai si approssima la notte.</p>
             <p><stage>(<emph>Volpone solo</emph>)</stage> Il vario leggere molto diletta e piace, ma il certo assai giova. A fé, che non poco mi ha giovato l'aver udito leggere diversi libri d'intrighi e di novelle. Ecco che ora vo ponendo in vero quello che me ha paruto menzogna! Mi importa assai di costui, che stia tutta la notte al fresco! Li ho dato questo ordine per cavarli qualche buon profitto dalle mani e per tormelo davanti.</p>
@@ -2046,183 +2086,183 @@ umilissimo e perpetuo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">volpone</hi>
           </stage>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Hà, hà, hà, hà! Aggio chiù famme che suonno. O che brava vessicata è stata chella ch'aggio schiaffata 'n capo a chillo spagnuolo.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Ecco qui Licaone converso in lupo.<pb n="585"/></p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>E becco lo lupo deventato no aseno.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>O là , misser Policinella, tu ti rassembri a l'orso goffo e destro.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>O se me vedisse iocare de mano e de diente ntuorno a no piatto de maccarune! Ma sì, sì, tu m'hai visto! No magno buono, pre vita toia? Ma vorrìa che me vedisse n'autra vota a le spese toie.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Di grazia, ma ti vederò presto giocar di piede sotto di tre legni.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>E io a te de vraccia, de capo e de gamme, quanno sarai squartato! Che te ne pare, no responno buono?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E non andar in colera, che io burlo teco, andiamo all'osteria quando tu vòi.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>E io per zi' burlo, iamonce mo. Chi ha tiempo, no aspetta tiempo, disse la canzona de gallo e de capone, gallo non è, ca non sai ched'è?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Vù, goffo, credi che non lo sappia? É la gallina.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Merda 'n mbocca a chi nevina! Ah ah, aggio tenge cogliuto?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>A, dunque viene a me, che l'ho indovinato!</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Hà, hà, te' a ta nevinata!</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Non ti vergogni d'esser così disutile?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Se nce so' io, non ce so' le masche, li diente, né le mole meie.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>É questo è peggio; non ti vergogni di andar mangiando per le piazze?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Sai perché mangio per la chiazza?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Perché?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Perché là aggio famme, chi sa si po' avaraggio appetito pe la casa e non c'è che mangiare.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Orsù, vate a picca.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Vance tu, ca no saccio la via, e si bè la sapesse, non ce iarìa pe sette menestre e meze. Non te verguogne di dicere chesto a lo petore maggiore de la cittate?<pb n="586"/></p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Pittore maggiore? Perdonami, da quando in qua ti sei scoperto così gran virtuoso? e come dipingi, a oglio o a guazzo?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>A guazzo, perché spisse vote me caco li cauzune.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E che tanta forza vi pone al dipingere?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Messere sì, ca spisso me nce spremmo comme a stiteco e, seconno lo viento che piglio, lavoro.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Ti servi di vento, e che, sei marinaro? come fai, di grazia, perché vorrei che mi facesti il mio ritratto con una bella barba più appontita di questa.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Me meco le mane a li schianche, de chesta manera, abascio lo capo e alzo lo reverenzia parlanno all'aria, piglio viento e lavoro allegramente e ne do dudece e quinece a tornesse pe campare.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Fermati, come intendi tu questo pittore maggiore, dichiaramelo un poco meglio, di grazia?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Dico pedetore e non petore, e faccio pedeta e depegno quarche vota a guazzo la cammisa e li cauzune quanno magno cose liquide.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E io ho sempre inteso pittore, e non pettore che tira de' petti o delle coreggie! Orsù a noi, sono questi i limoni, in questo bel canestro?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Messere madamma sì, vide como le porto belle copierte, con chisto tafetà de seta.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Ti ricordi la lezione, che io ti ho dato dell'ingano ch'abbiamo a fare?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Sì sì, me l'alecordo, ma tornamme a defrescare la mamoria.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>L'hai ben tu riscaldata a quel spagnolo con darli una vescica sul capo, che si ricorderà di te!</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Perché ha ditto niente lo spagnuolo?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>S'io dico a costui che quello lo cerca per farli dispiacere, non sarà cosa a proposito.<pb n="587"/></p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Ei là, con chi parle tu? co' lo spagnuolo contra di me?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Dov'è il spagnolo, ché io voglia parlar seco? O sei balordo, sta' allegramente, non dubitare. Dunque, dirai di chiamarti, come ti ho detto, Antuono Cipolla, e che sei un servo novamente...</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Stampato con grazia e provilegio e lecienzia de' supreriure.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E no, novamente venuto a stare con la signora Cassandra, e che manda alla signora Lucilla cotesti limoni, e quel che segue.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Ora buono, vòi che tozzola e la chiama fora?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Sì di grazia, e con diligenza.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>O della casa? Si nce site, responiteme, e se non ce site, no sia nesciuno che parla. Che te ne pare de sta delegenzia?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Tu faresti disperare la pazienza, perché queste son diligenze salvatiche. Batti alla libera.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>E ch'è canto de zorfa , che buoi che batta a lo libro? O de la casa, volite responnere, sì o no?</p>
           </sp>
@@ -2233,55 +2273,55 @@ umilissimo e perpetuo servitore
             <hi rend="sc">scaltrino</hi>
             <hi rend="italic">con sudetti</hi>
           </stage>
-          <sp>
+          <sp who="#scaltrino">
             <speaker><emph rend="sc">scaltrino</emph>.</speaker>
             <p>Chi è stato quel beccaccio, che così dispietatamente ha battuto questa porta?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>So' stato io. No me fare lo bello umore, ca te sesco.</p>
           </sp>
-          <sp>
+          <sp who="#scaltrino">
             <speaker><emph rend="sc">scaltrino</emph>.</speaker>
             <p>Che cosa vuoi? Si è fatta la elemosina.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Non saccio, adomannalo a chisto, che me sta dereto, che boglio.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Ah razza di porco! Bisogna che mi ritiri.<pb n="588"/></p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Ah razza de puorco! Besogna che me retira.</p>
           </sp>
-          <sp>
+          <sp who="#scaltrino">
             <speaker><emph rend="sc">scaltrino</emph>.</speaker>
             <p>Férmati, dove vai? Razza di porco se' tu.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Quanno lo cantarielo e quanno 'n terra. Perché la domanne, si' miedeco tu, che buoi sapere dove vao?</p>
           </sp>
-          <sp>
+          <sp who="#scaltrino">
             <speaker><emph rend="sc">scaltrino</emph>.</speaker>
             <p>Son il càncaro che ti mangia!</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>A lo naso te canosco ca te piaceno li mellune.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Di' che chiami la sua padrona.</p>
           </sp>
-          <sp>
+          <sp who="#scaltrino">
             <speaker><emph rend="sc">scaltrino</emph>.</speaker>
             <p>O il cielo me dia pazienza con costui.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Chiamma la patrona toia, ca le voglio parlare.</p>
           </sp>
@@ -2292,123 +2332,123 @@ umilissimo e perpetuo servitore
             <hi rend="sc">lucilla</hi>
             <hi rend="italic">con sudetti</hi>
           </stage>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>O là Scaltrino?</p>
           </sp>
-          <sp>
+          <sp who="#scaltrino">
             <speaker><emph rend="sc">scaltrino</emph>.</speaker>
             <p>Signora.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Entra in casa, chi ha battuto?</p>
           </sp>
-          <sp>
+          <sp who="#scaltrino">
             <speaker><emph rend="sc">scaltrino</emph>.</speaker>
             <p>Vengo signora. Aspetta galant'uomo.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Tu si' lo primo che me l'hai dito. Aspetto, no me partaraggio.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>O che possi perder l'appetito, non me nominare. Stai fuora di te, che accenavi a colui che io ti stavo da dietro? E se lei viene, parlali dolcemente.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Besognerìa che avesse no poco de zucaro nmocca, haine niente pre vita toia?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Voglio dire con soavi e mellate parole.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>A fé, ca me piacceno le mela, cotte co lo zuccaro.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Chi ha battuto questa porta?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Io, signora, perdonateme, ca no l'aggio battuta, né datole per male, perché le voglio bene, ma solamente pe parlare alla signora Lucilla. Site vui, la signorìa vostra vo' sorìa?</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Che vorreste dir per questo?<pb n="589"/></p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Signora sì ca voglio dicere chiù de ciento millia cicere.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Son io Lucilla. Che dimandi? chi sei?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Sei e sei, ha dudece. Vorpone lo fa meglio de me. Dov'è iuto?</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Chi Volpone?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Di' che hai nome Antuono Cipolla, no me nominare.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Me chiamo Antuono Cepolla, no me nomenare.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Se io non so il tuo nome, come ti voglio nominare?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Di' che ti perdoni, che hai fallato.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Vostra signorìa me perdona, ca so' falluto. La signora Cassandra vostra zia, e patrona mia, che sta malata a l'uorto, ve manna a donare chiste dudece lemmune, che ve le magniate tutte sta mattina pe l'amore suio.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Starei brusca e gelata per molti giorni! O sono pur belli, o che bei fiori, e dove sono stati colti?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>A la chiazza.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Ah mastino, di' che tu li hai colti all'orto di lei.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Come, in piazza?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>O mannaggia lo brutto papao, ca me so' scordato! Io co le mane mei l'aggio cogliute a lo giardino suio. Uh, che mala mamoria che aggio! Che me vengano ciento milia pulece ncoppa a li tallune!</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Ben, sta' sopra di te.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Ed ella come sta? vi continua così spesso il medico?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Pe quanto dice lo miedeco, no saperìa che dicere a vostra signorìa.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Mi par molto scemo costui, non mi risponde al proposito.<pb n="590"/></p>
           </sp>
@@ -2419,158 +2459,158 @@ umilissimo e perpetuo servitore
             <hi rend="sc">alberto</hi>
             <hi rend="italic">con sudetti</hi>
           </stage>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Non occorre che quel spagnuolo voglia più farmi il gherro, né il bislacco adosso, ché dove io mancarò suppliranno gli amici.</p>
             <p>Lucilla, che fai tu qui, fuora di casa?</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Sono venuta in strada, perché costui mi ha recato quello bel canestro de limoni da parte della signora zia.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Come sta mia sorella della sua infermità?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Né male, né bene, sta male e sta bene.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Non occorre perdere il cervello con costui, che di dieci parole ne risponde vinti al contrario. Ragioniamo di ciò che
 è succeduto: sia lodato il Cielo, che non siete stato offeso da coloro.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Il signor Fulgenzio, in vero, che si è portato da gentil'uomo; ma quel napolitanello, quel napolitanello me la pagherà! Darmi egli da dietro una piatonata!</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>E io pe l'amore vuostro aggio schiaffata chella vessicata 'n capo allo spagnuolo; come ha da ire sta cosa? Se saraggio acciso, no me ne mpaccio e non ne saccio niente.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Ohimè, adesso sì che butta a terra ogni cosa. Ah infame!</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Come per l'amor mio? dove me hai tu conosciuto?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>E no volite che me fosse stato ditto da la giente, ca iereve fratiello de la sionora Cassandra, patrona mia?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>A fé, che l'ha comodata bene, il porco!</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Tu sei un gran galant'uomo, e te sono obligato per questo.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Deciteme, signore, è bravo assai chilo spagnolo?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Caro quel'uomo! Come hai tu nome?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Antuono Cepolla, pe servire a vostra signorìa.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Hà, hà, hà, non era più da ridere se ti chiamasti Gabano Scalogna! Caro il mio Antuono, io no credo a colui, se non per bravo di menzogne. É vero che la potenza ha per fondamento la virtù, io non so che virtù egli si abbia; e la<pb n="591"/> virtù sta nell'erbe, nelle pietre e nelle parole, dunque che per esser virtuoso e bravo in credenza, la deve fondare sopra delle sue iperboliche parole, che n'ha pieno il mondo.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Signor padre mio, di grazia, statevene ritirato in casa e non andate così solo in volta, per non dare in qualche cattivo incontro.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Signora, perdonateme, se io no saccio fare bona la masciata, perché non aggio mai liuto nullo livro, autro che chillo che sta frisco Antuono co la massaria, le ciaule no me fanno semenare, li sturne so' li primme a benegnare.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Se io non mi caccio inanzi, costui potrebbe disfare tutto l'ordimento.</p>
             <p>Servitore, signor Alberto. O, messer Antuono Cepolla, che fate qui?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>E tu no lo sai? Bello spreposeto.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Taci, non mi rispondere, becco becaccio.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Son tuo, Volpone. Conosci costui?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Signor sì. E ben, come la passi in casa della signora Cassandra, dove ti accomodò quel barbiere nostro amico?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Hà, hà, hà, ahimè, che gusto me ne piglio, o che bello nbruoglio è chisto, me ne schiato de risa!</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Taci, non ridere, viso di Pasquino.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>E che buoi, che chiagnia? Me piglia gusto de la furbarìa.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Volpone, io voglio che tu venghi a cena meco con costui, perché ti averò da parlare di ciò che tu sai. Entriamo Lucilla.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Andiamo signore.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Entrate fra poco voi altri, ché io vi attenderò in camera.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Veneremo, signore.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>No mancaraggio de venire. Metto sti limone dintro de la casa. Nge l'aggio puoste.<pb n="592"/></p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Non rifiuteremo la sua magnanima gentilezza. Orsù, loro sono in casa, appresso vi andaremo noi.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Ah ah, che te ne pare Vorpone? no so' valent'ommo io?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Valent'uomo per fortuna. Entriamo pur a cena, e parla poco per far molto profitto.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>O bene mio, a cena? Bello smorsire che boglio fare a doi ganghe, lassame allargare la correia, e spontareme nante a la panza.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Orsù, allegramente, poche parole e buon reggimento. Andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Iamo iamo, bene mio. Allegrate, cuorpo mio, allargateve stentine, po' che lo core, lo fecato e li permune tutte faranno banchetto, feste e allegrezze all'onore de Bacco. Becco no m'entienne.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Ah goloso, goloso, entriamo, che possi scoppiare.<pb n="593"/></p>
           </sp>
@@ -2586,20 +2626,20 @@ umilissimo e perpetuo servitore
             <hi rend="sc">volpone</hi>
           </stage>
           <stage>(<emph> Comincia la sera</emph>)</stage>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Ecco che la notte, madre di pensieri. già comincia a discacciare il giorno; e se non fosse che abbiamo a fare ciò che in casa mi hai detto, circa di Clarice, io ti farei rimanere a dormir qui da me con quell'altro Antuono Cepolla.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Non occorre signor, ve ringrazio, tanto più che bisogna batter il ferro quando è caldo, e più spesso ancora quando è ben infocato. Ora stiamo sul meglio, non bisogna abbandonar l'impresa; sì che lodarei che vi doveste tratenere in casa di qualche speciale vostro amico, acciò vi desse qualche confortativo, perché debbiate stare bene all'ordine per l'assalto amoroso, e doppo ritrovarvi pronto all'ora determinata in questo proprio loco. E non andate troppo in volta, così di notte, per più rispetti.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Tu hai ragione, andarò prima a far sapere a Lucilla che se questa notte mancasse di venir a casa, non abbia di me sospetto. Vado perciò fare e non star qui a contendere col buio e l'umido della notte, essendo malagevol cosa per noi vecchi.</p>
           </sp>
           <stage>(<emph>Notte</emph>)</stage>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Andate in buon'ora, poiché n'è sopragiunta.</p>
             <p><stage>(<emph>Volpone solo</emph>)</stage> So che il buon Policinella attende tuttavia ad empirsi il ventre e a menar le mascelle più che un molino a
@@ -2613,31 +2653,31 @@ umilissimo e perpetuo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">volpone</hi>
           </stage>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Chi è là, chi chiama?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Corpo del bordello, ne anco un gatto che sta in sentinella del topo! Bona guardia, signor Fulgenzio, bona guardia.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>E ben, a che termine siamo?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>In bonissimo. Sappiate che Policinella, benché abbia del balordo, col mio aiuto si è portato assai bene, ed è stato accettato per il servo della signora Cassandra, e di già è entrato dalla signora Lucilla giunto con il signor Alberto, e gli ho dato i limoni, sì che lo sto attendendo per esequir il rimanente di ciò che vi dissi. Non altro mi impedisse, solo che il padre di lei, che se ne è andato in casa; ma ho ben io ancora ritrovato l'antidoto per farlo sortir fuora.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Dunque starò con molta speranza attendendo così felice vittoria, mediante l'acuto ingegno del mio caro Volpone.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Sì bene, ma fermatevi, ché sento gente. Ritirianci in questo loco.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Non alterar la voce.</p>
           </sp>
@@ -2648,107 +2688,107 @@ umilissimo e perpetuo servitore
             <hi rend="sc">scaramuzza</hi>
             <hi rend="italic">con sudetti</hi>
           </stage>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Io me era resoluto de me nascondere dintro de no furno pe la paura de Arberto, che no me faccia accidere; ma perché non c'era pane, non l'aggio voluto fare, e so' stato conzigliato a vestirme a cossì da femena come sto, pe non essere conosciuto nen da isso, nen da li brave suoie. Ora che<pb n="596"/> me schiaffa tutte chille nase a pezzulo po' che me ne voglio sbignare a la vota d'Averza e po' a Napole.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Chi è là?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Amice! Ohimè, mo so' acciso e non ce veo!</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Chi sei? O là, rispondi?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Una infelice gentildonna romana, fuggita dal marito per debiti.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Da quando in qua si usa fuggire dal marito per debiti?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>L'abbiamo posta noi cotesta bella usanza.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Certo, che debbe esser qualche gentildonna di gran merito, che, per il molto gridare che averà fatto con il marito, è rimasta con la voce roca.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Vi' per certissimo certo.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Bona notte , signora mia.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Bona nottissima e bonanissimo, signore.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Signore, io vi ho fatto un poco di disegno sora di costei, lasciate che io li dia in vostra casa la bona notte, che domattina poi gli darete il buon giorno.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Fa' pur ciò che tu vuoi, ché io altro non bramo che Lucilla.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Di grazia, signori, non molestate la mia pudicizia.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Signora mia, noi non siamo qui per oltraggiarla, e se si vole ella degnare di entrare qui in questa casa, la farò riposare con mia sorella questa notte.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Ahimè, poverina me, non mi maucciate, non mi toccate, non mi provocate a la libidine.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>O puofar me! Signor Fulgenzio fermatevi, ché vi ho da parlar in secreto.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Sovra di che?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Di questa, che dice d'esser gentil donna ed è uomo.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Mi burli, parla piano.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>É verissimo, tacete.<pb n="597"/></p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Vorrò accertarmene. É più che vero ! Corri in casa e ritorna con due bastoni, che io lo trattenirò di parole.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Vado.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Orsù, perdonatimi signori, perché ho da andare in casa di una mia parente. Bona notte.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Fermatevi, di grazia, un poco, non siate così frettolosa.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Lasciatemi il braccio! Ohimè, che troppo me stringete.</p>
           </sp>
@@ -2759,27 +2799,27 @@ umilissimo e perpetuo servitore
             <hi rend="sc">volpone</hi>
             <hi rend="italic">con sudetti</hi>
           </stage>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Prendete, signor Fulgenzio. Regalate così graziosa dama.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Mostra. To', to', to'. Godetevi questo regalo da mia parte.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E da la mia quest'altro. Ah furbonaccio, to', to', to'.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>O Cielo aiutame! Lassame sarvare a chesta casa vecchia.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Volpone, ti aspetterò in casa. Fa' polito il tutto.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Andate, signore.</p>
           </sp>
@@ -2791,43 +2831,43 @@ umilissimo e perpetuo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">volpone</hi>
           </stage>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Non posso discacciare quel Antuono Cipolla de la cucina. Non si vede mai satollo né di bere, né di mangiare! Non so che avrà fatto Volpone.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Chi è là?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Amici. Se' tu, Volpone? che fai?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Quello son io, che mi affatico per voi, signore.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Fratello, io son degno di biasmo, perché facevo diversi pensieri di te. Che vi è di novo?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Ciò che io vi dirò, ma con fretta. Datimi la vostra sopravesta lunga, la baretta, ed entrate or ora nella cantina del capitan Matamoros, ché la porta starà aperta. Fermatevi,<pb n="598"/> che io la tocchi, è vero, aspettate ne la cantina Clarice, che vi verrà a trovare (sendo il fratello fuora di casa, al gioco). Fate i fatti vostri e doppo ritornatevene a casa, che bon pro vi faccia. A rivedersi damattina.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>E perché vuol ella che io vi vadi così senza baretta e senza vesta?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Acciò non siate conosciuto per Alberto. Prendete il mio mantello e il mio capelletto, amorzate quel lume e andate presto, ché ella verrà a trovarvi tosto.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>L'ho smorzato, mostra qui il tuo mantello. Vado, bona notte.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>In buona ora! E io così travestito, me ne anderò in vece di Fulgenzio a godermi di Clarice, dandoli a credere, senza lume, che io sia quello.</p>
           </sp>
@@ -2839,23 +2879,23 @@ umilissimo e perpetuo servitore
             <hi rend="italic">con dui bravi, e</hi>
             <hi rend="sc">volpone</hi>
           </stage>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Te he dicho que ascondes aquella lumbre, pues, que quiero estar toda la noche y toda la manaña delante de la puerta de Alberto, solo por dalle veinte y cinque espaldarazos. Esten ascondidos ellos de tràs de a quel rincon</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>O può far me, che gente è questa?</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Alumbra a cà, este es por vida mia! Dele don Sancho, sierra don Pedro! Toma Alberto vellaco, hijo de puta! Aprende a saber bien trattar con cavalleros</foreign>!</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Ahimè, che son morto da ladri. Non son Alberto, no.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Vamonos cavalleros, que Alberto se ha ido a buscar Acheronte, para passarse al reyno de Plutòn; ya que es muerto</foreign>.<pb n="599"/></p>
           </sp>
@@ -2868,15 +2908,15 @@ umilissimo e perpetuo servitore
             <hi rend="sc">scaramuzza</hi>
             <hi rend="italic">da la casa vòta</hi>
           </stage>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Ritornami tosto cotesta mia spada! Non mi conosci, putanaccia della guerra, che sono il maggior fratello di Marte? Non sarai sicuro in braccio del famoso Alcide!</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>O mama mia bella! Ohimè, è loco! 'N terra la spata toia, sarva, sarva, a sta casa de lo spagnuolo!</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Non ti potrebbe difender Polifemo con suoi Ciclopi, né tutti i superbi giganti fulminati da Giove, se lor vivessero. Ove ne sei tu gito? Questo mi pare il supremo e chiarissimo splendore della mia famosa, forte, sbudellatrice, squarcia, trincia, scanna e uccide spada. Non mi sono ingannato. Sei venuta da tua posta a ritrovarmi? non ti eri già ribellata dal tuo signore? Rispondi se puoi. Certo che se colui che in cambio di Clarice mia, che io attendevo (non so come nelle braccia mi capitò) da me non fuggiva, già l'avrei converso in minuta sabia, per por su le mie lettere, che scriver soglio, a diversi potentati del mondo.</p>
             <p>E come è possibile, che in vece di quella, che io adoro, quinci sia venuto non so chi sia stato, che io credendola donna la ritrovai un uomo, con mio grandissimo pericolo e dell'onore.</p>
@@ -2885,40 +2925,40 @@ umilissimo e perpetuo servitore
         <div type="scene">
           <head rend="italic">SCENA OTTAVA</head>
           <stage><hi rend="sc">alberto, scaramuzza</hi><hi rend="italic">e</hi><hi rend="sc">squarcia</hi>, <hi rend="italic">di casa del</hi><hi rend="sc">matamoros</hi></stage>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Signora Clarice mia cara, già che vi siete degnata di venirmi a ritrovare, almeno rispondetemi una sola parola, dicendomi che volentieri accettato avete, in segno di matri<pb n="600"/>monio, il mio anello. Non volete concedermi così degna mercede? Orsù pazienza, ragioneremo in casa mia.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Che è quel che io odo? S'io non m'inganno, ho udito non so chi parlare con la mia donna. Che sì che forse
 è stata impedita e da altri goduta.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Io già mai sarò per consentire alle vostre libidinose voglie.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>E io potrò tenermi che vinto e superato dallo sdegno e dal furore, che con questa mia fulminante spada non dispolpi e snervi costui? e ponghi in rivolta e in bisbiglio la monarchia d'amore e del mondo tutto?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Andiamo a casa mia, dove far potremo più agiatamente ciò che li amanti bramano. Signora Clarice mia, anima mia.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>O corpo del regno di Cocito , lasciami, becconaccio, cotesta donna, che è mia!</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Ohimè la lascio, non mi uccidete.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Tallune aiutateme, ca me sarvo cà, dinto sta casa de Fulgenzio.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Ben ti giongerò, ancor che avessi di aquila le ali.</p>
           </sp>
@@ -2929,7 +2969,7 @@ umilissimo e perpetuo servitore
             <hi rend="sc">volpone</hi>
             <hi rend="italic">solo</hi>
           </stage>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Non è stato poco, che l'ho cavata netta a non esser stato sbudellato da coloro che m'han tolto in cambio del signor Alberto, ma la colpa che io avevo del cattivo mio pensiero di andare dalla signora Clarice, ha cagionato ciò che veramente me ho meritato. Orsù, il dolore e la paura me hanno fatto passar l'amore! Però non deggio maravigliarmi di questo, poiché tutti i miei antecessori, chi è stato in berlina, chi in galera, chi frustato, e chi appicacato, e perciò di<pb n="601"/> raggione debbo assomigliarmeli, poiché era il dovere che io fusse stato almeno bastonato, benché questa non sia stata la prima volta.</p>
           </sp>
@@ -2941,71 +2981,71 @@ umilissimo e perpetuo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">volpone</hi>
           </stage>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>M'aggio pigliato sta lanterna ch'aggio buono trincato, e non ce averìa veduto iremenne a la casa. O come è stato buono chillo vino verdisco da Verza, chella lagrema de Somma e chello gricco cagniatillo. Me sento l'uochie npeccecate, npaglioccate, scazzate pe lo suonno.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Questi è Policinella. Voglio stare ad udire ciò che si ciarla da sua posta.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>O quanta stelle, che stanno 'n cielo! E dove è la luna? A, a, l'aggio intesa: se ne sarà iuta a corcare co lo sole e se gaudeno amorosamente. O che me potesse pigliare una de chelle stelle pe me la metere a sto capiello. Quanta pon essere: una, doie, tre, quatro, cinco, sei, sette, otto, nove, ù ù quantane, quantane, non le pozzo contare! Se ne porrìa anchire no saco.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>O che ignorantaccio, conta le stelle! Policinella, ferma là.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Ohimè. Iatevenne signure mariuolo, ca n'aggio né donare né feraiuolo!</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Taci, non gridare, non mi conosci che io son Volpone? Hai ben bevuto, che un uomo ti pare un squadrone.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Aggio vippeto buono e ngorsuto meglio. Bona sera, si' sulo?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Solo son io, non mi vedi, e hai il lume in mano? Sai se 'l signore Alberto è ritornato in casa?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Ascette e mai tornao chiù.<pb n="602"/></p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Orsù, dunque presto a noi, ché non è tempo di perdere. Ti ricordi la lezione?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>No, quale lezione?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Del servizio del tuo padrone con la signora Lucilla.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Ah sì sì sì, me era scordato, me l'allecordo mo.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Diamo principio all'opera, batti la porta in fretta, chiamala e fa' del naturale.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Cioè, ca la zia sta malata de morte, e bò fare testamiento, e ba descorrenno.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Bene, bene, o se si vedesse fuora, hai una gran buona memoria. Batti, che io fingerò di sopragiunger appresso.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Dice buono, retìrate là bascio.</p>
             <p>Eilà, eilà, o de la casa!</p>
@@ -3017,155 +3057,155 @@ umilissimo e perpetuo servitore
             <hi rend="sc">lucilla</hi>
             <hi rend="italic">con sudetti, da dentro e poi fuora</hi>
           </stage>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Io odo battere, forse è mio padre, e voi altri dormite. Che dimandi, che vòi?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>So' io, signora, non me vedite, si stongo cà fora e aggio la lanterna?</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>O se' tu, messer Antuono?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Signora sì.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Che battere in fretta, non hai creanza.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Signora no, pe servire a vostra signorìa vengo a chiamareve correnno da parte de vuestro patre, e de la signora Cassandra vostra zia, ca sta pe morire. E dice isso che se ve nce troverite a tiempo a lo testamiento, ve lasserà tutte le robbe soie, e non ve nce trovanno, le lasserà a chill'autro nepote suio.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Dunque lei morirà.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Signora sì, se n'è morta. Iammo priesto, lassate ogni cosa, ca vuestro patre v'aspetta.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>O povera mia zia, ù ù ù ù poverina!</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Ì ì ì ì ! É è è è ! acute; à à à ! Ú ù ù ù!</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Che ti importa il piangere a te?<pb n="603"/></p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Faccio a cossì pe zerimonie ciciliane.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>E chi mi accompagnerà da lei?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Di' che la compagnerai tu.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>No ce lo boglio dicere chesto, ca no me l'ha imparato a la lezione.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Chi è là, fermati qui, chi sei?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>E tu no lo sai? Bello bestiale.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Messer Antuono, buona notte. O signora Lucilla, servitore a vostra signorìa. Ohimè, a che più tardare? E come non siete andata da vostra zia, che vostro padre vi aspetta? Avertite, che se non affrettate il piede, la potreste trovar morta. Andiamo, andiamo signora, ché vi accompagnaremo noi.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Voglio prima raccomandar la casa al ragazzo o alla balia che sta inferma.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Non occorre, ché io subito ritornarò qui a volo e farò che n'abbino cura.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Lasciatemi almeno che mi toglia il manto.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Non, perché non è tempo di manto, né da perdere.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>E priesto signora, ca ve priesto lo capiello mio, che non ve faccia danno la serena.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Andiamo, tien pur dritto quel lume.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Lo tengo. O pota de lo carnevale, mananagia la carne salata, se n'è caduta la canelella da la lanterna!</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>O che ti possano cader le mani! Fatevi in qua signora, da quest'altra parte.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>E a te l'uocchie! No me l'hai nparato tu?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Taci, in ogni parola sei risposte! Che ti sia tagliata la lingua!</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>E a te lo cuollo, piezzo de cata piezzo.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Voi altri contrastate e mi avete allontanata di casa. Cercate per terra, ché la ritrovarete.<pb n="604"/></p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Venite più in qua, signora, eccola a fé. Io vado girando costei acciò perda il dritto sentiero di sua casa.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Ritorniamo a casa, ché la faremo accendere dal ragazzo. Ne siamo lontani?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Signora sì, siamo più appresso qui dove io abito, ché la faremo accendere da mia sorella.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>É lo vero, dice buono Vorpone, bravo mbroglione che è.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Fate pur tosto, di grazia.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Ora, signora. O là di casa! Madonna Pasquetta! Vostro fratello è qui, accendetemi questa candela. Entrate signora, ché starete fra tanto più comoda qui dentro, che fuora.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>É vero, entro. Affrettate vostra sorella.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>La soreca, encappata a lo mastrillo. Io, a dicere lo vero, me ne vorrìa tornare a la casa de la signora Lucilla a magniarme lo riesto de cierte macarune, che aggio lassato, e me ne vorrìa ire a bevere chello grieco. Ma che remmore è chisto, che sento dintro la casa nostra? che sarà sta cosa?</p>
           </sp>
@@ -3173,39 +3213,39 @@ umilissimo e perpetuo servitore
         <div type="scene">
           <head rend="italic">SCENA DUODECIMA</head>
           <stage><hi rend="sc">fulgenzio, lucilla, volpone</hi>, <hi rend="italic">e</hi><hi rend="sc">policinella</hi></stage>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Fermatevi, signora Lucilla! Anima mia, dove volete andare senza lume, essendo voi molto lontano di casa vostra?</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Lasciatemi! Che vilipendio è questo? che insulto, che agravio volete fare al mio onore? O infelice e sventurata Lucilla, o vergogna e gran disonore di casa mia! O povero, afflitto e sconsolato mio padre, o ingrati e traditori servi! O iniquo discortese e villano Fulgenzio! E che inganevoli e intricati lacci, così crudelmente teso mi avete per ingannare una povera innocente donna? Ahi, che prima che il mio<pb n="605"/> genitor lo sappia, e i miei parenti, vorrò con le mie proprie mani darmi la morte.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Non vi disperate, signora. Policinella, entra e fa' che sia posto un lume fuora di quella fenestra. E tu Volpone, va' in casa.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>De grazia, mo vao.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E io me n'entro. Cercate di ridurla al vostro intento col meglio modo che potrete.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Ah traditori, a me questo!</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Non più, signora Lucilla mia, non vi affligete tanto, ché con poca ragione or contro di me vi dolete.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Perché, non ho ragione? come, a torto di voi mi doglio? e di chi volete che mi debba dolere di così gran tradimento, se voi siete più che tigre ircana crudele; più che feroce leone inumano; e che furia d'Averno rigido e dispietato? Lasciatimi il braccio dico, e perché prima non darmi col vostro acuto ferro la morte, che così sozza macchia al onor mio? Ahimè, datemi le vostre armi, lasciatemi dar la morte.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Vi lascio. Fermatevi, piano, piano signora, ché più disonor vi fate ad alterar tanto la voce su la publica strada. Statemi un poco, per cortesia, ad udire. Non vi lasciate così crudelmente dominare dallo sdegno e dalla poca ragione che contro di me avete. Che indicevol cosa, che oltraggio e che macchia avete da me ricevuta, che così ingiustamente con chi più che sé stesso vi ama, vi adirate e dolete?</p>
           </sp>
@@ -3216,15 +3256,15 @@ umilissimo e perpetuo servitore
             <hi rend="sc">policinella</hi>
             <hi rend="italic">dalla finestra, con sudetti</hi>
           </stage>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Vecco la luce, se non ce vedite parlare. Me ne traso ch'aggio da fare, bona notte pagliariccio.<pb n="606"/></p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>É vero signora Lucilla, non lo niego, che io ho il tutto fatto ordire per trarvi al mio amoroso desiderio, e più per servirvi ed amarvi come mia cara sposa, che per altro, come vera posseditrice del mio core, sì che con molta mia ragione non potete di me dolervi, già che non sono per altro volere, se non quello che voi bramate. Io, signora mia, non vi ho mai oltraggiato, né sono per violare il vostro onore, e ora mi protesto davanti alla ragione e al tribunal di amore, che come de la vostra, de la mia volontà sarete sempre vera posseditrice; né altro farò mai se non ciò che da voi, signora, mi sarà posto, poiché il mio giusto volere solo dall'onorato vostro dipende. E se è in vostro piacimento che, per discolpa del mio soverchio ardire, cagionatore del molto dispiacere che ricevuto ne avete, me dia con le mie proprie mani la morte, senza altro dubio, signora, sarò prontissimo in obedirvi. Però vi ricordi e vi sovvenghi, o mia bella e crudelissima guerriera, che di ciò solo n'è stata la verace cagione la vostra incomparabile bellezza, colma di infinità crudeltà, che mirandola e contemplandola rimasi (senza il vostro soccorso) privo della mia libertà, per non volere ella darmi un minimo conforto, né una sola ombra di speranza. Sì che vedendomi così privo di contento, il potentissimo amore, per non farmi sommergere all'ampio mare della disperazione, fe' per mia salute che il mio caro Volpone si adoperasse in questo amoroso inganno.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Oh Volpone forfante e vero ribaldone, tu me la pagherai!</p>
           </sp>
@@ -3235,16 +3275,16 @@ umilissimo e perpetuo servitore
             <hi rend="sc">volpone</hi>
             <hi rend="italic">da la fenestra, con sudetti</hi>
           </stage>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>A la fé, che io son galant'uomo, né vi pagherei un quattrino.</p>
           </sp>
           <stage>(<emph>Volpone si ritira da la fenestra</emph>)</stage>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>E ancora li ha dato aiuto il mio servo Policinella, che mutandosi il nome si fe' chiamare Antuono Cipolla.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Ah sì? sì? Questo ancora? Questo Antuono Cipolla, questo Policinella infame mi ha ingannata!<pb n="607"/></p>
           </sp>
@@ -3255,80 +3295,80 @@ umilissimo e perpetuo servitore
             <hi rend="sc">policinella</hi>
             <hi rend="italic">da la fenestra, con sudetti</hi>
           </stage>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>De chesto io ve do ragione, ca sempre songo infamme e 'n appetito e mo me ne vao a far collazione.</p>
           </sp>
           <stage>(<emph>Rimangano gli amanti</emph>)</stage>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Ho detto soverchio, non mi date più noia, di grazia, poiché il vostro dir mi offende.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Dove andate signora?</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Dove a me piacerà, non ho da renderne conto a voi.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Uditemi, cara la mia signora Lucilla.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Vi ho soverchio udito, signor Fulgenzio, che volete da me?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Ditemi dove volete andar a quest'ora.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>A casa mia a ritrovar mio padre. O misera me, almen sapessi che strada mi pigliare, e che oscura notte è questa! Prestatemi quel lume.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Farò ciò che vi aggrada, però a casa da vostro padre ve ci condurrò io, come mia cara sposa, e al suo debito tempo. Non mi lasciate, vi prego, così fuori di speranza. Non siate cagione, o bel idolo del mio core, che per voi disperato mora un fidelissimo vostro amante, che più che sé stesso vi ama e onora.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Voi mi amate e onorate? Questo è un grande onore che fatto mi avete! Io vi ho per capitalissimo inimico.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Inimico. Ohimè, che dite signora, se tanto fedel servo vi sono e amo somamente la vostra modestia e singolar bellezza, così del corpo come quella dell'animo, ben che me vi dimostrate crudele e bramosa de la morte mia.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Bellezza in me non è, e se pure per mia disaventura ve ne fusse qualche minima parte, vi esorto a disamarla, ché non amarete cosa durabile, ché con il tempo ella è venuta e così farà partenza.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Ahimè, ché quella sola mi mantiene in vita.<pb n="608"/></p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Voi vi appoggiate in un debile sostegno, poiché in un batter di palpebre ella apparisce e fugge. E se breve pioggia di adversa fortuna la bagna, o un picciol vento la rimove, in un tratto dalla dispietata mano della inesorabil morte è colta e presa. Né tanto allegrezza areca seco la sua venuta, quanto dolore apporta la partenza, sì che io non trovo tanta ragione sopra di ciò in voi che la debbiate cotanto apprezzare, e più, che in goderla non vi è altro che il breve diletto del senso. Dunque, signor Fulgenzio, assai più lodabile è cercare di amare cosa eterna, che manchevole e fuggitiva.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Ritrovàtene pur iscuse, signora, e paradossi quanti volete, ché io son disposto di non amare altra cosa che la vostra somma beltà, vero e risplendente sole delli occhi miei.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Avete un fosco velo che vi ingombra gli occhi, che non vi fa discernere il vero dal falso.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Il vero, io lo discerno, e perciò mai per colpo di sinistra fortuna lascierò di amarvi, e se la vostra bellezza sarà fuggitiva, cercarò di seguirla sin che potrò. Anzi, che affermando le vostre ragioni, dico che non debbiate escludermi dalla vostra grazia. E che valerebbe un pomposo e superbo edificio, se non fosse mai lasciato vedere né toccare? Che gioverebbe un ricco tesoro, ascoso senza speranza di esser mai goduto? E quando, quando spalancar vorrete, signora, le inchiodate porte della vostra grazia? quando forsi l'aria del bel viso sarà cangiata in color di morte? quando l'oro de' vostri biondi capelli sarà convertito in argento? e che le tenere guancie e la serena fronte saranno dalle squalide crespe offese e da noiose nubi gli occhi ingombrati? Ma ché spendo più tempo con le parole in vano, sapendo che ben sapete che tempo verrà che in mirarvi nel lucidissimo specchio a pena riconoscerete voi stessa. Dunque, signora, vi prego a non essermi crudele, ché indubitatamente io prometto di far che il padre vostro non rimanga de aderire alle vostre giuste e onorate voglie, poiché sarete la mia cara sposa, il mio bene, la mia vita e la mia padrona.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Voi, signore, in vece di dispormi alla vostra volontà con raccordarmi gli avenenti miei guai, mi persuadete al mio volere, del che per giusta ragione doverci lasciar di amarvi; ma perché detto mi avete di voler esser mio fido sposo, sono<pb n="609"/> sforzata a cangiar voglia. E perché, ritornando a questa ora da mio padre e non credendomi il succeduto inganno, me ne potrebbe sortire peggio di questo, e ritrovandomi fra l'incudine e 'l martello, fra Scilla e Cariddi, e da diversi pensieri assalita, a mio mal grado bisogna condescender alle vostre voglie.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>O me felice, con queste così cortese parole, ora da morte in vita, signora, ritornato mi avete. Benedico dunque quel felice giorno, quell'ora e quel punto, che tanta soprema beltà mirai.</p>
           </sp>
@@ -3336,148 +3376,148 @@ umilissimo e perpetuo servitore
         <div type="scene">
           <head rend="italic">SCENA DECIMASESTA</head>
           <stage><hi rend="sc">volpone, policinella</hi>, <hi rend="italic">e sudetti</hi></stage>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>La pace dei colombi sia con voi, signori.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>E se no chella de le vespe. Trasite a la casa. Che bolite stare tutta sta notte fora come a sportegliune?</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Ecco qui l'inganno, con il tradimento accompagnato. E ben, vi par cosa convenevole di avermi usato così gran tradimento?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Signora sì, perché Vorpone me l'ha nparato e
 'ha sbiato con ciente milia promessiune e mai m'ha dato niente.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>É verissimo, la colpa non è stata mia, signora perdonatemi, ma solo il vedere che se il signor Fulgenzio non vi avesse ottenuta in moglie, si avrebbe per disperazione dato la morte. E per vietar l'inconveniente mi risolsi di ciò fare, e quando ben considerarete sopra questo, che vi pare ora male, lo giudicarete per cosa ragionevole e buona. E qual gentiluomo si potrà aguagliare alli incomparabili meriti suoi, che tanto vi ama e vi sarà consorte, e qui in nostra presenza ve<pb n="610"/> ne darà la fede? E il signor vostro padre, sapendo de l'inganno, vi averà per iscusata e si contenterà del tutto. Dateli dunque, signora, con allegro core la vostra mano in segno di matrimonio, non lo fate più penare, di grazia, poiché è degno di essere amato.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Sì signora mia, bene mio, se no lo bolite facere pe fare piacere a isso, facitelo pe l'amore mio, ca sempre ve saraggio fedele en votare lo spito e a provare la menestra.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Siete ambo degni di severissimo gastigo.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>É vero, non lo niego, lo confesso, perdonatemi signora.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>E io pure me ne confesseraggio co l'amice.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Signora, non so più che dirvi, solo che in vostro potere sta la mia salute.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Orsù dunque, giovandomi certo di credere ciò, che con tanta passione di animo detto mi avete, e acciò che un perfetto amore debba esser giustamente ricompensato, ecco che son disposta di amarvi e accettarvi per mio carissimo sposo; dichiarandomi, però, che non contentandosi di ciò mio padre, debba esser annullata ogni promessa, e contentandosene mi obligo di dar fine al vostro dolore, né vi debba passare fra tanto tra di noi pregiudizio alcuno circa al mio onore.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>O bona, o bona figliola, bona figliola a fé.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Degna risposta di così prudente signora.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Prontissimo sarò sempre in obedire, signora, i suoi comandi, e son di tal sorte rimasto fuora di me stesso per la infinita allegrezza della vostra innata bontà e cortesia, che non posso quasi formar parola, per poterli rendere quelle infinite grazie, che io deverei. Però andiamo, anima mia, in casa, dove che diviseremo uniti ciò che far dobbiamo con il padre vostro, e concedetemi in grazia che io vi tocchi quella bianca mano da me tanto amata.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Eccola, signore.<pb n="611"/></p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Ohimè felice, o me lieto e contento più d'ogn'altro amante, andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Vengo, signore.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Bon prode ve faccia, sia nomme di figlie mascole.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Andate pure, che amor vi accompagni.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>No aude tu, scanna puorco? Leva la luce da la finestra. O bene mio, e che belle banchetto che se avaranno a fare a la casa nostra!</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Gran fretta hai tu di far tôr via quel lume, sempre parli di mangiare.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Fa' chiano, che non te cada a bascio 'sa canela.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Non vedi che se' fatto idolatro della tua gola?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>La funa che te npenna, latro si' tu! Te pienze ca no t'aggio pescato ca voi dicere ca son mariulo? So' omo da bene, adomanamello a me.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Il Cielo me dia pazienza con costui! Sei omo da bene, Policinella?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Messer sì, vi' commo dico lo vero vi', e saccio responnere all'improviso? Ma mo che me alecordo, dove songo li denare che m'hai prommiso?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>O se' pur odioso! Ragioniamo di cose allegre, che ne trattaremo poi secretamente in cantina fra di noi.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Perché nge lo banno a trattarne pubrecamente?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>É grandissimo da pagare il debito.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Io a te, o tu a me?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Io a te.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>A donca pagalo, se no ca grido forte e te faraggio ire presone.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Lo pagherò all'osteria. Andiamo ora di novo in cantina a bere di quel buon greco del tuo padrone.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Iammo cà a la cantina, nc'è pane e caso cavallo a fiasco.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Andiamo, ben che io abbia sonno.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>E io sempre famme. Trasimo.<pb n="612"/></p>
           </sp>
@@ -3485,40 +3525,40 @@ umilissimo e perpetuo servitore
         <div type="scene">
           <head rend="italic">SCENA DECIMASETTIMA</head>
           <stage><hi rend="sc">squarcia</hi>, <hi rend="italic">e</hi><hi rend="sc">matamoros</hi></stage>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Signor capitano, il vostro conquistato onore fra generosi assalti, fra diabolico ribombo e fumo di artiglierie, in vece di qual felice fama volarsene al cielo, se ne è fuggita ed è andata ad abitare e a inconcentrarsi nell'infernal abisso.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p>
               <foreign xml:lang="spa">Señor, si vuestra merced quiere passar con migo donaires, por su vida me lo diga, porque sin pesadumbre pueda sufrir a questas palabras. Como que se ha ido en el abismo, si mi honra, con gloriosa fama con abiertas alas de prudencia y de valor, ya alcanzò volando al quinto cielo y agora hace camarada con el valeroso Marte mi real corespondiente y segunda persona? Y quien ha sido a quel muy gran vellaco, gallina, cobarde, manjadero, que tan enbidioso de mi soberano estado se dexò salir de su pudrida boca tan mentirosas palabras, que le quiero saccar con esta briaresca mano el coraçon del cuerpo y el alma del proprio corazon y la quinta essençia de el alma y luego profundarlo dentro de las negras aguas de Aqueronte?!</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Sarà ben degno di straggi così crudeli, chi di questo ne dicesse il vero?</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">No por cierto, pero es muy gran mentira</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Signor capitano, io son quello che l'ho detto; e non mento e degno son di lode, dicendo il vero.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p>
               <foreign xml:lang="spa">La verdad, y como?</foreign>
               <pb n="613"/>
             </p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Dicovi, signore, che non ha molto che io mi ritrovai qui in questo proprio luogo, quando che un amante parlava in strada con la vostra signora sorella, dicendoli che gli avea dato un anello in segno di matrimonio e la voleva condurre in sua casa e io, stando in disparte e ciò udendo, per l'affezione che io vi porto e zelante del vostro onore, benché non potei conoscer l'amante per l'oscurità della notte, m'avventai verso di lui più veloce che saetta, cacciando mano a questa mia trinciatrice, fulgurante, balenante, arcitonatonante tritta busti, per anichilarlo e farlo convertir in fumo. Tosto egli si trasformò in fantasma, che con incredibile prestezza dinanzi a gli occhi mi sparve; e solo ella viddi, che con molta fretta se ne entrò a salvarsene in casa di Fulgenzio, sì che potete chiamarla per acertarvi del vero.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">O pena, quien me vestiò? Ahi, desdichado de mi, y es possible esto? Agora quiero, si ansi sarà, hazer una mina por de bajo de la casa y hazer saltar todos hasta al cielo de Saturno! Pero mejor serà que da mi criada sepa mas claramente el trattado como ha passado</foreign>.</p>
             <p><foreign xml:lang="spa">O de casa, o de casa, a quien digo, o là Fioretta passa a cà, vente a bajo con la lumbre</foreign>.</p>
@@ -3527,15 +3567,15 @@ umilissimo e perpetuo servitore
         <div type="scene">
           <head rend="italic">SCENA DECIMOTTAVA</head>
           <stage><hi rend="sc">fioretta, matamoros</hi>, <hi rend="italic">e</hi><hi rend="sc">squarcia</hi></stage>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Ahimè, che gran strepito è questo! Eccomi, eccomi signore con il lume.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Ah vellaca, vieja hechizera, alcaguera, celestina, endemoniada! Que es de mi hermana, confiessa la verdad, si no que te haré comer esta daga</foreign>.<pb n="614"/></p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Ahimè, ahimè, signor infoderate il pugnale. La signora è in casa, perché me dite questo? Oh poveretta me, ché mi si è scomosso il sangue tutte ne le vene.</p>
           </sp>
@@ -3546,161 +3586,161 @@ umilissimo e perpetuo servitore
             <hi rend="sc">clarice</hi>
             <hi rend="italic">con sudetti</hi>
           </stage>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Fermatevi signor, che cosa avete con questa povera donna?</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Mas con tigo, que con ella la tengo, pues que por tu causa la querìa matar</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Volgete in là quella punta e ditemi la cagione del vostro sdegno e furore.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Fermatevi signore, udite prima il suceduto caso.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">A donde fuestes esta noche? con tu enamorado, deçid la verdad, si no quieres que te passa esta daga por los lados! Presto, acava, declaramelo</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Ahimè, che parole son queste? io con l'amante? io fuora di casa senza vostra licenza? Vi siete ingannato, o che state fuora di voi stesso, per la colera forse di aver perduto al gioco. Chi di ciò cerca di infamarmi, si parte dal vero, che non puol esser altro che qualche infame e privo di onore. E molto di voi mi meraviglio, che date così facilmente credenza al falso, ché per pregiudicar il nostro onore mi sarà stata data questa infamia. E se io sapessi chi vi ha questo detto, senza dubio (ancora che donna io sia) con le mie proprie mani gli vorrei cavar gli occhi dalla fronte.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>E io con questi denti gli vorei mangiar il naso e cavarli la lingua dalla bocca e con le unghie sgrafignarloutto.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Io non li ho detto nulla, signora.<pb n="615"/></p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Y como señor, quien me lo ha dicho si no el? Cuerpo de quien me pariò</foreign>!</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Lui ve lo ha detto? Ah perfido mentitore, tu lo dicesti? Va' dentro, Fioretta, a tôrmi una spada, ché ben le farò disdire ciò che bugiardamente ha contro di me favellato.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Ah capitano di straccie, ora ti farò fuggire con la mia rocca e ti caccierò il fuso ne li occhi.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Fermatevi, signora, state indietro, di grazia. E tu, sgualdrina, va', frega la padella per frigervi dentro la tua lingua.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Deteneos vos otras mujeres, dejen que yo baga por todos la venganza. Para que infamarnos desta manera? Echa mano a tu espada, que quiere darte en alma y en cuerpo al profundo rey de las animas dollentes</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Non posso cacciar mano, signore, se non contro di un esercito intiero, lasciatomi per testamento da Massimiliano imperatore. Ma vi prego ben di grazia a dar grato orecchio alle mie parole.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Digalo, que quiere dezir, que todo serà mentira</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Conosco, signor capitano, di aver errato, e per colpevole me vi accuso. É vero che l'ho detto, perché così mi parve di aver veduto e udito; è ben vero che non ho udito di lei la voce, né la sua favella, e perciò (senza dubbio) sarà stata altra Clarice. O che io a quel tempo stavo fuora di me stesso, sì ché, signore, vi prego ad avermi per iscusato e perdonarmi di sì grave errore; e se ne ho fatto consapevole a lei, l'ho fatto perché sempre sono stato geloso del vostro onore, e tanto più che ho desiderato per mia moglie la signora Clarice.<pb n="616"/></p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Aunque jamas a ninguno perdoné en todos los dias de mi vida, por la mucha amistad que ha sido entre los dos y porque muestra de tenerme tan grande aficion, le perdono</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>E io non perdonerò mai.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">A que respondes adonde no eres llamada? Mi her mana haviendo entendido la causa de la falta, echa por la culpa de la noche, yo sé que por mi contento ella tan bien serà de mi voluntad</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Benché se ne avrebbe avuta a far maggior dimostrazione, tutta via, signore, mi rimetto alla vostra volontà. Però, chi potrà più levarmi questa machia in tanto mio pregiudizio, avendolo egli, forsi, questo conferito ad altri?</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Io non l'ho confidato né detto a persona veruna, e per più sicurezza di ciò, prego il mio signor capitano a degnarmi di concedermevi per mia consorte, poiché altra grazia non bramo, che servirla come mia degna padrona.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Sta l'importanza se noi vi vogliamo.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Madonna no, che non lo voglio, signor no che non lo desidero né mi piace.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Estense calladas ellas, y vayanse en casa, que lo de mas serà todo mi quidado</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Vado, signor.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Perdonatemi, signora Clarice, vi son servitore.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>E noi non vi siamo nulla.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Per compiacere al mio signor fratello, pongo in oblio le passate offese. A dio signore. Andiamo, Fioretta, in casa.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Andiamo, signora.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Bamonos señor, que por el camino nos conçertaremos sobre el negotio</foreign>.<pb n="617"/></p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Signor, io la ringrazio; però sarei di parere che sarà bene il rimanervene in casa, per essere l'ora tarda.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">No señor, que quiero acompañarle hasta a la suya</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>E io vi racompagnerò qui alla vostra e così anderemo tutta questa notte in giro.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Bamonos por esta callejuela</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Andiamo, almeno comparisce un poco la luna, perché glie l'ho ordinato.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p>
               <foreign xml:lang="spa">Que hora puede ser señor?</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Appresso alle cinque.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Yo prometo a vuestra merced, que si la luna agora non compareçe, que manaña, antes de las quinze horas, haré que sea salido el sol para su mandado</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Lo credo, che prima delle quindeci ore sarà uscito il sole, e comparirà se non sarà ingombrato dalle oscure nubbi.<pb n="618"/></p>
           </sp>
@@ -3712,39 +3752,39 @@ umilissimo e perpetuo servitore
           <head rend="italic">SCENA PRIMA</head>
           <stage><hi rend="sc">scaramuzza, volpone</hi>, <hi rend="italic">e</hi><hi rend="sc">policinella</hi><hi rend="italic">di casa di</hi><hi rend="sc">fulgenzio</hi></stage>
           <stage>(<emph>Séguita la notte</emph>)</stage>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Ahimè, ahimè, non date chiù ca so' muorto!</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Ah bagascia cornuta, iere venuta a la cantina pe arobare lo vino a lo patrone mio? Te sa buono lo grieco, meglio te saparanno ste mazzate!</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Ah sgualdrina, se' ladra, eh?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Te' chest'autra mazzata.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Ahimè, férmati, ché in vece di dar a lei, mi hai colto in un braccio.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Ahimè, ahimè.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Npara a procedere, guitta cornuta. Trasimmo a la casa.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>O maro mene, e comme me hanno buono ntomaccato! Me voglio sedere cà 'n terra, ca non pozzo chiù, e quanta mazzate ch'aggio avute sta notte, e chesto ancora nce mancava pe la ionta de lo ruotolo. Chesta cierto è quarche chianeta a me contralia, che m'ha fatto sborzare tante mazzate!<pb n="619"/></p>
             <p>Ma sento venire a gente. Sarà meglio che stia zitto, ché non me venesse aduosso quarche autro frusco de mazze, e puro che non sia de spate.</p>
@@ -3753,253 +3793,253 @@ umilissimo e perpetuo servitore
         <div type="scene">
           <head rend="italic">SCENA SECONDA</head>
           <stage><hi rend="sc">squarcia, matamoros</hi>, <hi rend="italic">e</hi><hi rend="sc">scaramuzza</hi></stage>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Non vi dissi, signor capitano, che vi avevo di raccompagnarvi a casa vostra?</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Demasciada merced, da el (señor), yo he recevido</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Oh comme me fa male sta spalla, me prode, no saccio se è stata mazzata, o se è peduchio che me martoreia alla gagliarda.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>A noi, signore, ché qui vi è non so chi, che ha detto di esser morto. Se sei morto come tu parli? chi sei?</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p>
               <foreign xml:lang="spa">Da el nombre, a quien digo yo? quien va allà?</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Io signore. So' no spireto che parla pe arte diabolica.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Spirito se' tu? Se da qui tosto non ti parti, ti scongiurerò a forza di bastonate.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Sì de grazia, ca sarrìa lo saprimiento de le cronache mei!</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Quien eres, decid</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Se io l'aggio ditto, quanta vote lo bolite sapere?</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Se questi è spirito, non ho paura. Innanzi, signor capitano, ché io starò qui in sentinella.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Yo le cedo, señor. Quien està allà? Valgate, barra bas, respondes</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Se io non sto 'n cerviello chiste m'acidono, me sbudellano e me smenozzano.</p>
             <p>Che bolite da me, io so' Scaramuzza Squaquara Me Meo.<pb n="620"/></p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Oh putanaccia, e corpo di quanti postribuli ha il mondo! É il mio servo. Scaramuzza?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Segnora.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Che fai tu qui?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Che faccio, faccio l'uovo! So' stato acciso, che boglio fare?</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Sei tu stato ferito?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Segnor no, ma so' stato parichie vote buono amatontato da mazzate.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p>
               <foreign xml:lang="spa">Y quien te ha dado?</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Signore no, ca non aggio ioquato a dade.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Stai tu in terra? Levati su, drizzati in piede.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Vecco ca me so' levato, che bulite?</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p>
               <foreign xml:lang="spa">Es este el creado de vuestra merced?</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Signor sì, egli è desso.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>E lassateve dicere ca no m'ha criato isso, ma me ha criato chillo che ha criato a l'autre pe grazia soia.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Non vogliamo sapere la tua genologia, ma la cagione e il principio di cotesta tua sciagura. Stai vestito da donna, per quanto mi par di scorgere e toccare.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>É lo vero, segnore, e me despiace ca non pozzo troppo parlare, perché me moro de famme e de suonno ed è quase iuorno.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Parla, ché doppo te ne mandarò a casa a riposarti.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Me ne contento, sentite. La prima, e prencepalemente cosa, agiate a sapere (poco manco, e fuorze chiù) che io, illustrissimo signor spagnuolo, che pe l'amore vuostro diete na brava chiatonata a le spalle de messere, o signor Arberto, tentato però da chillo che non pozza mai parere, ma squagliare, commo a cicola de puorco a la tiella, e da<pb n="621"/> Vorpone fui avisato che me vestesse de sta manera, perché lo signore Arberto me voleva far accidere, se io non me fosse sarvato o stravestuto pe non esser canosciuto. E casoalemente venne sta notte nante a la casa de lo signor Fulgenzio, e trovannome a lo scuro, isso e Vorpone, e adomannanome chi era, e io pe no farme canoscere disse ca era una gentile donna, e loro toccannome la faccia me canoscetero pe ommo e me fecero na bona maziata. E io scappai dintro de chella casa vecchia e nce trovai vostra signorìa, signor Squarcia patrone mio, che me abraciastevo, e canoscenome pe omo me facistevo na faccie de secozune. E io ve levai la spata e fuiete a sarvarme a la cantina vostra, signore spagnuolo, dove steva lo signor Arberto, che me abbraciao penzannose che io fosse no saccio chi Clarice, e me deze n'aniello e me voleva fare ire pe forza a la casa soia. E tutto a no tiempo vidde lucere na spata e sentiete na voce dicere lassa 'sa donna, e corenno secutao lo viecchio, e io me ne trasiete a sarvare a la cantina de lo signore Fulgenzio. E cossì, poco da po', scesero Policinella e Vorpone a metter lo vino, e, credendose che io fosse stata femena e mariola, me ne cacciarono fora a forza de bone mazzate. E tutto chesto è stato 'n presenzia mia.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Bàlgate la mona Antona! Y todas a quesas desgratias has pasado esta noche?</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Signor sì, dateme quarche refregerio, ca sto pe morire e aggio na fame che crepo.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Querìa yo saber porque estava em mi casa Alberto, que si, que era venido con armas de fuego para matarme y dudoso de ser da ti descubierto, porque no me lo hubiesses dicho, fingiò de ser enamorado de mi hermana. Però yo lo be de saber, a pesar de sus barbas</foreign>.<pb n="622"/></p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>É lo fatto. Ca io manco me vuoze scoprire pe Scaramuzza, che no me avesse acciso pe la chiatonata che le diete. Ve preo, signore, a darenge remmedio, de grazia.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">No tengas duda, dejad esse cuidado a mi valerosa persona</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>A dunque, signor capitano, ora è discolpata in tutto la signora Clarice, poiché io credendomi Scaramuzza lei, e il signor Alberto suo amante, presi, per la oscurità della notte, così grave errore. E già che ve l'ho chieduta in moglie, vi prego a non negarmela.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Yo me contento, señor, bien que no he querido darla al hijo del rey de Suezia, ni al principe de España. Y tengo por siguro que ella se contenterà, mandandoselo yo</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Me ne terrò molto aventurato.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>E se la signora sore vostra sarà mogliere a lo patrone mio, ve prego a concedereme Fioretta, ca staraggio sano e forte de schiena.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p>
               <foreign xml:lang="spa">Yo te la daré para quitarme tan gran cuidado de casa y tu queres tomar mujer, pobre de ti, porque la quieres?</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>La piglieraggio pe castico de quanto male aggio fatto a sto munno. Orsù, a poco a poco se ha comenzato a farese iuorno e io sto deiuno.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Bamonos, señor</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Fermateve, segnor Matamoros, ca me so' arecordato de ve dicere na cosa.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p>
               <foreign xml:lang="spa">Que quieres dezirme?</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Sentiteme doi parole tutte dui e stopite.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Di' tosto ciò che vuoi tu dire, prima che più agiorni.<pb n="623"/></p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Signore, aggiate a sapere che quanno Vorpone e Policinella (le schiatature de mazze miei) vennero a la cantina de lo segnor Furgenzio, dicevano fra loro che la signora Lucilla, figliula de lo segnur Arberto, contrastava ad auto a la camara con Furgenzio, e che non lo voleva contentare pe fina a tanto che lo patre non se ne fosse contentato de darencella pe mogliere, e che loro l'hanno arrobata a lo patre suio. Orsù buon giorno, ca me ne voglio ire.</p>
           </sp>
           <stage>(<emph>Giorno</emph>)</stage>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p>
               <foreign xml:lang="spa">Y tu lo has da ellos claramente entendido y lo vistes?</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>A dicere lo vero l'aggio io propio sentute contrastare da la cantina, nante che loro nge fossero venute.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>O può far il mondo, gran cosa è questa.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">No te partes de aqui, Escaramuza</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Che ne volite fare de me, lassateme ire a spogliare sti vestite de femena, ca chiamano le mazzate ciento miglia lontano.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Señor cuñado, armas, armas, siera, siera, contra Fulgentio, porque Lucilla es mia, que yo la pretendo. Toca aquella puerta de Fulgentio. Dejad que la toque yo</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Lo chiamerò io.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>La tozzolaraggio io, tozzolamola tutte. O che avesse a lo manco na sferra! O de la casa.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Vengan fuera los de dentro aqui</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Aprite qui, cospettonaccio di Gatta Melata e di Bartolomeo da Bergamo.<pb n="624"/></p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Spaparanzate sta porta.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">O cuerpo de Olimpo y de Tifeo</foreign>.</p>
           </sp>
@@ -4007,41 +4047,41 @@ umilissimo e perpetuo servitore
         <div type="scene">
           <head rend="italic">SCENA TERZA</head>
           <stage><hi rend="sc">fulgenzio, volpone, policinella</hi>, <hi rend="italic">con sudetti</hi></stage>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Che battere da motti e da imbriachi è questo?</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Tu menti mille volte per la putrida golaccia!</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p>
               <foreign xml:lang="spa">Tòmate esta cuchillada, que Lucilla es mia!</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Prèndeti questo man roverso!</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>E se io avessi spata, te darìa no stramazzone.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Nonnavimo paura, ohimè, me sento le brache nfose.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E io tutto bagnato.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Ah traditori assassini, questo a me!</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Hà hà hà! Cà tutte se ne songo sbignate!</p>
           </sp>
@@ -4054,75 +4094,75 @@ umilissimo e perpetuo servitore
               <hi rend="sc">squarcialeone, matamoros, scaramuzza</hi>
             </add>
           </stage>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Ah guidoni, con soverchiarìa a un gentil'uomo di tanto onore?</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Han fatto bene a fuggir tutti dal furore di questa mia vitrice destra.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Diga, señor, desta desenfrenada y diabolica cuchil ladora, beve sangre. Vèngase acà, señora Lucila</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Andate voi altri in là, discostatevi da questa casa, ché io voglio entrarmene.<pb n="625"/></p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">O reniego del diabolico rey Maumetan de Bisantia y de la Tracia toda, venga aqui señora. Parecele cosa buena esta? huirse de su padre con Fulgentio y haçer la casta Lucrecia con migo? Con justa raçon ahora quiero vengarme de lo que es de raçon</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Obedite, signora, al signor capitano, ché non siamo qui per offendervi, ma servirvi.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Lasciatemi! Obeditelo voi, che volete da me?</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Ah señora Penelope, muy casta Diana, aboreçer un cavallero y valiente, qual yo soy, para huirse con Fulgentio! Gran falta es esta que ha echo a su padre y a sus parientes</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Io sono stata ingannata, che volete da me? Non m'annoiate, di grazia.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">No podrà ella allarse escusa alguna para defenderse, yo la quiero dar en poder de su padre, entretanto se podrà estar en mi casa con mi hermana. Toca, Escaramuza, aquella puerta</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Mo, signor. O della casa, casa, casa.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Vi andarò da mia posta. Ohimè, che sono in poter de' nemici.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Quiero llevarsela yo, pues, que ansì cunple a mi honrada persona</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Questa non è azione di cavalliero, lasciatemi andare, io sono stata, come ho detto, ingannata da Volpone e da un altro. Di grazia non sforzate la mia voluntà, è forsi per vostro meglio.<pb n="626"/></p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Yo no lo creo, pero si fuere la verdad, ellos me la pagaran. Toca tu a quella puerta, digo, balgate Satanas</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>L'aggio tozzolata.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Presto, se non vuoi che con un calcio ti manda a incenerirti su la sfera del sole.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Non sentite, no? Ehilà, venite abascio, aprite chesta porta !</p>
           </sp>
@@ -4133,19 +4173,19 @@ umilissimo e perpetuo servitore
             <hi rend="sc">fioretta</hi>
             <hi rend="italic">con sudetti</hi>
           </stage>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Ti possono seccar le mani, e che dispietate percosse sono date a questa porta? chi mal anno sei?</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Lasciatemi, dico! Che discrezione è la vostra?</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Esto no haré por cierto. Llama acà mi hermana</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Ora, signore. Signora padrona, venite fuora per cosa che importa.</p>
           </sp>
@@ -4156,83 +4196,83 @@ umilissimo e perpetuo servitore
             <hi rend="sc">clarice</hi>
             <hi rend="italic">con sudetti</hi>
           </stage>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Che fracasso è questo? O baccio la mano, signora Lucilla.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Son vostra, signora. Soccoretemi se potete, ch' io son in gran lamberinto.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>E come, signora?</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">No quiera ella saver agora ni como, ni porque. Entrese, señora Lucila, en casa con mi hermana, que a hora iré a buscar el señor Alberto y aplacandole yo del sucedido caso, haré que se quede mi esposa; pues que da Escaramuza mi criado hé savido que no han pasado cosa mala con Fulgentio</foreign>.<pb n="627"/></p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Signor, io sono rimasta fuora di ogni mio sentimento, per le cotante mie disaventure, che fra poco in qua la perversa fortuna mi ha fatto correre, che non so che altro dirvi. Solo che vi ricordo che debbiate procedere da onorato capitano, racomandandovi la vostra e mia riputazione.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Stiase ella di buon animo, signora, ché il signor capitano non farà per lei cosa inconvenevole.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>In ciò che vostra signorìa potrà giovarme, la prego ad essermi favorevole, come io spero che il Cielo sarà propizio per la mia innocenza.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>E così glie lo prego ancor io.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">No faltaré de hacer lo que devo, pues naçi cavallero</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>E io di pregarglielo. E credete certo, signora, che se imposto mi aveste che io saltato fusse nell'Indie per condurvi tutti quei tesori, senza dubio alcuno fatto l'avrei; a fé d'ammazzatore lo giuro e lo farò per l'avenire.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>De pulece e de chiatille.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Ea, entre la criada con la señora Lucilla y quedese aqui Clariç, que le tengo de hablar</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Entrate, signora Lucilla.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Vado. Mi raccomando alla vostra clemenza. O infelice me e in che termine mi ha condotta la mia perversa stella!</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Toma esta llave de mi posenta y ençierala alli den tro, que no se vaya, que luego yo bolveré. Tened cuidado della</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Andate signore, e di grazia siate presto di ritorno, non mi lasciate invilupata in questo intrico.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Ea, bamonos, señor capitan. Vayase ella dentro</foreign>.<pb n="628"/></p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Son più vostro che mio, signora Clarice.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Ve ringrazio, signore. Vado, signor fratello.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>E io ve so' schiavo, schiavotolo, schiavone e schiavina, per fin, che schiove, si ben no chiove.</p>
           </sp>
@@ -4244,27 +4284,27 @@ umilissimo e perpetuo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">volpone</hi>
           </stage>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Ah spagnuolo nemico delli macarune.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Taci, Policinella, ché ho ben udito il tutto.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Che te ne pare, messere Vorpone, de sta nzalata? Hai ntiso, hai visto, come nce hanno arrobata la femena? Ora come farimo se sto spagnuolo nce accide?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Fratello, noi siamo stati in disparte, abbiamo osservato il tutto. Circa dell'esser ucisi, come hai detto, io non temo. Chi ha paura si faccia sbirro.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Ma se me accadesse, io sarìa aroinato, ca no saccio come se fa a stare acciso, perché non ce so' stato mai.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Non mi rompere più il capo, per non darmi occasione di risponderti, poiché sto con la mente tanto ofuscata da diversi pensieri, e del sudetto caso, che non saperei che dirti.</p>
           </sp>
@@ -4275,75 +4315,75 @@ umilissimo e perpetuo servitore
             <hi rend="sc">fulgenzio</hi>
             <hi rend="italic">con sudetti</hi>
           </stage>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Forfanti, infami, indegni di onore, questo insulto ad un par mio!</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Ahimè ca son muorto! Signore Furgenzio, nfoderate la spata, ca non nce aggio corpa niente.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Né io, signore. Ohimè, avetela con noi?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Con voi?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Ahimè ca so' speduto.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Con voi? e che mi avete fatto? L'ho con l'assassinamento del Matamoros e di Squarcialeone.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Ahimè, ca non me era restato na livra de sangue dintro a le scarpe.<pb n="629"/></p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>É informato, vostra signorìa, del rimanente?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Io no. Di che?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Come, di che? Sappiate che il Matamoros si ha tolta a forza di casa vostra la signora Lucilla e se l'ha condotta in casa sua; ed è andato via a ritrovar Alberto, acciò glie la dia per moglie.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Ohimè, questo di più! O può far la mia cattiva sorte! E come, non è in casa?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Signore no.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Signor no, né perciò ve disperate, ché per quello, che ho pensato in vostro favore, lo reputo a maggior beneficio, riuscendomi un mio disegno.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Perché di grazia, caro Volpone, dimelo tosto.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Dimelo a me, bene mio, dimello ca po' te voglio dare no bello vuovo, c'ha fatto lo puorco sta mattina.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>In ogni cosa si vuole intricar costui! Tu ti credi di far bene e fai sempre male. Taci, non mi far disperare, di grazia.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Dimme che hai pensato per la mia salute.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Io vi dirò, signore, statemi ad udire, però bisogna asecondare il mio umore con il padre di lei, quando li parleremo.</p>
           </sp>
@@ -4354,143 +4394,143 @@ umilissimo e perpetuo servitore
             <hi rend="sc">alberto</hi>
             <hi rend="italic">con sudetti</hi>
           </stage>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Dicesi che la comodità fa l'uomo ladro e la necessità virtuoso e valente.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Tacete, ché qui appunto è il padre di lei.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>E perciò la necessità ha cagionato che se siano portati valorosi i miei piedi e gambe questa notte, per salvarmi della furia di quel drudo di Clarice. Ed è bene che non mi ha conosciuto, sia salvo io, e del rimanente vada alla peggio! Ma che averà detto Lucilla, che io non sono andato questa notte a riposarmi a casa, e che dirà, vedendomi in questo modo vestito?<pb n="630"/></p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>O Signor Alberto, bon giorno. Udite, udite, di grazia.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O te ho da dir di bello, dove è la mia veste?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>É in salvo. Non è tempo di cercar veste, ma di trattare cose di maggior importanza.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Ahimè, sopra di che?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Di vostra figliuola. Io son quasi morto di stanchezza per cercar di voi con il signor Fulgenzio.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>E io per zi', per vita mia.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E lui ancora! Sempre costui risponde dove non è chiamato.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Signor sì, è vero.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Non è buscìa pe cierto, ca l'affermo io.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>É vero, ché lo afferma Aristotile.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Dimmi, è cosa appartenente al mio onore? Dimelo pure, affretta la lingua.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Di grazia, la mi perdoni il mio signor Alberto, se, fuora del suo e mio decoro, con lei ragionassi cosa che poco grata vi fusse, senza offesa però del vostro onore.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Di' pur, di grazia, non mi tener più suspeso. Che sarà mai questo?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Già ben saper dovete che tre sorte di persone sono odiose e insoportabili al mondo: il povero superbo, il ricco bugiardo e il vecchio lussurioso.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Che vòi dir per questo? Fenisciela.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Voglio dire che è molta stoltizia la vostra, perdonatemi, poiché andate così in volta tanto di giorno quanto di notte per la città, e forse per amore; lasciando la vostra casa ad arbitrio di fortuna, dando occasione che vi sia rubbata la vostra figlia.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Sì sì, ha ragione Vorpone, vosorìa è no bestiale.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Come, rubbata mia figlia? Ohimè, ohimè, dunque mi è stata involata Lucilla? e da chi? Dimelo pur tosto.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>É verissimo, signore, e con molta potenza.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>E chi me l'ha tolta? O povero Alberto!</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Dirovi signore, e in breve se potrò. Sappiate che il capitan Matamoros se ne è venuto con una squadriglia di soldati e con molto empito e furore è entrato a forza in casa vostra e di peso se la ha portata in braccio nella sua.<pb n="631"/></p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>E pe tale segnale, l'è scapato no pidito, pe la forza che faceva la povera signora.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E ritrovandovisi il signor Fulgenzio, per salvezza del vostro onore volendoli porgere aiuto, il predetto spagnolo con suoi soldati l'assalirno malamente, e se noi non ci salvavamo saressimo stati spediti.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Oh misero Alberto, oh infelice mia figlia, oh onor di casa mia! Ohimè, che moro di doglia! E come potrò più comparere tra li amici, che non sia infinite volte da loro mostrato a dito? ù ù ù, povero vecchio, questo d'udir ti mancava all'ultimo de gli anni tuoi!</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Non vi disperate, signore, udite il pensier mio, che vi sarà molto giovevole in questo proposito, e prendete il mio buon consiglio, ché chi ben si consiglia al ben si appiglia.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Ben dice Volpone. Uditelo, signore.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>É lo vero, signore, ca chisto è no nbroglione.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Per tutto mi cacci la lingua, taci, in tua mal'ora!</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Che profitevol consiglio potrai tu darmi, se già il mio onore si è trasformato in vergogna?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Il consiglio è questo, ma prima che ve lo dia, vi prego a perdonarmi di qual si voglia offesa che io vi avessi fatta in qual si voglia modo.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Non mi son mai tenuto da te offeso, né ora me ne tengo, però mi contento, pur che il consiglio sia buono.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Sarà benissimo, datemi grato orecchio. Concedete la signora Lucilla in moglie al signor Fulgenzio, ché come tale la ricuperaremo, ché lui vi difenderà e vi aiuterà con ragione, e vi serviremo tutti. Ora, che il capitano non è in casa, entraremo (se così vi pare) e a forza romperemo le porte e la conduremo in casa vostra, e doppo anderemo alla giustizia tutti uniti a querelarlo, ché io con Policinella ci esamineremo in favor vostro, e che l'avevate data prima al signor Fulgenzio.<pb n="632"/></p>
           </sp>
@@ -4507,63 +4547,63 @@ umilissimo e perpetuo servitore
               <hi rend="sc">alberto, policinella, volpone, fulgenzio</hi>
             </add>
           </stage>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Ahimè, signor padre mio, datemi aiuto, ché il Matamoros a forza mi ha condotta e fatta serrare in questa camera sua.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>O cara la mia figliola, non temere Lucilla mia, vedi se puoi aprir la camera, ché ora ti daremo aiuto.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Vado signore, ma non la potrò aprire senza il vostro potere.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Non aggiate paura, ca si farrite sto matrimonio, lo cielo vi aiuterà, signor Arberto mio bello.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Datevi la mano come parenti.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Eccomi pronto, se egli se ne contenta.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Signor sì, so che se ne contenterà.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Ne son contentissimo. Vi tocco la mano come genero, signore.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>E io me ne stracontento.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Ve ne do la fede.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Più grato suono di questo non mi poteva venire nell'orecchio.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Dunque Lucilla è vostra, e come tale la difenderete.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Signor sì, entriamo tutti.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Trasimmo.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Piano, animo e coraggio! Dentro, può far il mondo!</p>
           </sp>
@@ -4574,7 +4614,7 @@ umilissimo e perpetuo servitore
             <hi rend="sc">scaramuzza</hi>
             <hi rend="italic">solo</hi>
           </stage>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Ancora me fanno male le spalle de tante mazzate che aggio avuto sta notte passata ! E se non me levava da duosso chillo vestito de femena, ancora sarìa mazziato, perché era calamita de tutte le disgrazie. Ma che me porà fare mai chillo viecchio, se aggio dui brave smargiasune e dui<pb n="633"/> liune da la mia? Che gran remmore è chisto che sento dintro sta casa de sto spagniuolo?</p>
           </sp>
@@ -4586,31 +4626,31 @@ umilissimo e perpetuo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">scaramuzza</hi>
           </stage>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Oh misera Clarice, e che poco rispetto portano costoro a mio fratello e a me?</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Sì sì, di questa maniera scassar la porta? E dove è ora il signor capitano?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Sì eh? questa discortesia? Ah, traditori, in casa di un capitano di tanto merito usar tal violenza!</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Aiuto, qui vicini, aiuto!</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Che remmore è chisto? Ehilà ! Piglia, para, tiene, accide, squarta, npiene chisse! Ca gente so' chisse? Venite fuora cornute, pieze de cata piezze.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Dagli, Scaramuzza mio caro, va' dentro, uccideli.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Quarche aseno ce ierìa, sto a la larga.</p>
             <p>N'aggiate paura, signora.</p>
@@ -4619,51 +4659,51 @@ umilissimo e perpetuo servitore
         <div type="scene">
           <head rend="italic">SCENA DECIMATERZA</head>
           <stage><hi rend="sc">volpone, policinella, alberto, fulgenzio, lucilla</hi>, <hi rend="italic">con sudetti</hi></stage>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Ah, becconaccio, che vuoi tu di qua? To'.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Ahimè, ca so' muorto, m'ha rotta la capo co no pignato.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Sta a la larga, figlio de na scrofa cornuta.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Non temete, signora consorte, andiamo in casa vostra.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Sta' pure allegra figliola, non dubitare, andiancene in casa.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>O signor padre mio da me tanto amato.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Tutti, tutti in casa del signor Alberto, andiamo, andiamo.<pb n="634"/></p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Trasimo, trasimo, a dispietto de chillo spagnuolo.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>In tal modo si procede? Dovete ben saper tutti, canaglia, che il mio fratello non lascierà invendicato così fiero oltraggio.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>No no, che non lo lascierà, forfantoni. Entriamo, signora. Scaramuzza, va' di grazia a ritrovare il signor capitano e narrali così strano successo.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Sì di grazia, va' in fretta, entriamo noi.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Iaraggio, signora, lassate fare a me.</p>
             <p><stage>(<emph>solo</emph>)</stage> Brava pignatata, e non m'ha rotta la capo, perché aggio lo caruso tuosto a botte de mazzate.</p>
@@ -4676,31 +4716,31 @@ umilissimo e perpetuo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">scaramuzza</hi>
           </stage>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Pues, que se pensava Fulgentio de ganarla con migo. Yo soy grande amigo de hombres valerosos, y enemigo de cobardes, pero me la pagarà</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Schiavo, signor capitano, ben state allegramente.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Sì que estoy allegre, pues que he dado la fuga a los enemigos y tenida la vittoria de la hermosissima Lucila</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Orsù, non ve pigliate colora, agiate a sapere che Furgenzio, Vorpone, lo signor Arberto e Policinella so' trasite pe forza a la casa vostra, e ve hanno arrobata la signora Lucilla e l'hanno portata quase de pesolo a la casa de lo patre, e nce l'ha data pe mogliere; e le poverelle femene vostre de paura hanno avuto a morire.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">O maldita sca mi mala desventura, desta manera ha suçedido? Y tengo yo de sufrir de estos vellacones un tal agravio? Juro por la grandezza de mi serinissima persona y muy alto linaje, que ellos me lo ha de pagar. Y que tengo tan malamente de perder la muy hermosa Luzila, aquella,<pb n="635"/> que es la resplandeçiente lumbre de mis ojos, la llama de mi coraçon, el ardor y encendio de mi alma, aquella gran lumbre que çentellando saca ya roja los claros rayos del proprio nombre que da resplandor a las estrellas fixas de mi fee y a las errantes de mis pensamientos. No lo quiero çufrir, pues que a elle mas que a mi vida quiero y el agravio ha sido muy grande. Ea, armas, armas, sierra, sierra, agora seran todos muerto de mis poderosas manos</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Signore, non vi fidate di me, ca me ne sbignio.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">A picarones, a cabrones, a sucios, salgan todos aqui fuera, que os tengo de matar</foreign>.</p>
           </sp>
@@ -4711,23 +4751,23 @@ umilissimo e perpetuo servitore
             <hi rend="sc">volpone</hi>
             <hi rend="italic">alla fenestra con sudetti</hi>
           </stage>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Che cosa vòi, misser Scaramuzza, castrone di Foggia?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Asano de terra de Otranto, voglio lo guaio che te stoca co la forca che te npenna!</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Baxan aqui todos, que os tengo de matar y quiero haçer notomia de vos otros y de las estrañas cuerdas para mi ghitara</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Mi darete de la lingua dove manca la pella.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>A baiasso cane, cheste parole se diceno a l'acedetore, a lo scanatore e a lo npenetore de l'uomene?<pb n="636"/></p>
           </sp>
@@ -4738,23 +4778,23 @@ umilissimo e perpetuo servitore
             <hi rend="sc">fulgenzio</hi>
             <hi rend="italic">da la fenestra con sudetti</hi>
           </stage>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Signor capitano, se non fusse che io non voglio perturbare le mie nozze, né la mia cara sposa Lucilla, io ho ben modo da potervi far cagliare. La signora Lucilla era di già stata a me conceduta prima dal padre e non occorre che più la pretendiate, partitevi di costì, perché doppo fra di noi bilancieremo il tutto.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Venga a baxo, digo, que le haré conoçer mi gran valor</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Lassatelo dicere, signor Furgenzio, non ce venite, si ben io ve desfidasse! Venite cà fora, ca ve voglio accidere.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Non mi voglio rompere il collo con voi altri. Andate pur via, ché sarà meglio per voi.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Venga a baxo, digo, gallina mojada</foreign>.</p>
           </sp>
@@ -4762,11 +4802,11 @@ umilissimo e perpetuo servitore
         <div type="scene">
           <head rend="italic">SCENA DECIMASETTIMA</head>
           <stage><hi rend="sc">fulgenzio</hi><hi rend="italic">si ritira</hi>. <hi rend="sc">alberto</hi><hi rend="italic">a la finestra, con sudetti</hi></stage>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Che rumori, che bravate in credenza, mi assembrate il cane, che abbaia alla luna. Che volete di qua? Abbiate creanza, ché oltre che vi faremo fuggire, ne sarete castigati dalla giustizia, e questo vi basti.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Lo viechio se n'è trasuto, iammoncenne, signor, ca sarà meglio pe nuie.<pb n="637"/></p>
           </sp>
@@ -4782,51 +4822,51 @@ umilissimo e perpetuo servitore
               <hi rend="sc">scaramuzza, matamoros</hi>
             </add>
           </stage>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Chi dice chesso che dicite vui, e de chello che no volimmo dicere nui, pe coprire l'embroglie nostre, lo dice fauzefecatamente, e te ne miente petrosine, maiorana, pepe, e zafarana, mile vote pe la canna de la gola e goletta, tiri tirisetta lo trapana e barletta.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Scinne cà a bascio, musso de puorco sarvateco, naso de papagallo!</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>O capile de furia infernale, fronte de maglio ferrato, ciglio de sanguinaccio arostuto, uocchi de taratufole nfracetate, naso de mutillo de pezzente, aurecchie de scorze de nuce, diente de cane aragiato, lengua de spirito diabolico, voca de infierno, canna e cuollo de cestunia, spalle de mazzate, pietto d'aseno mardato, vraccia de npisso, stomaco de sturzo, panza de lupo menale, culo di scignia, gamme de ancora de nave, piede de arpia, che buoi da me, va lava le scotele, ca lo spagnuolo mangia ravanelle.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Ah figlio de na gran potana bagascia zelosa, e de ciento millia cornutune, etzetera, etzetera, ca no l'azetto 'se ngiurie, ma le metto dintro a no sacco de corne e te le rebatto 'n capo e 'n faccie a dispetto tuio.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>E io te le torno a rebattere e ne faccio no presiento a sto spagnuolo, calamita de pormonate e vesicate.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p>
               <foreign xml:lang="spa">Ahi de puta vellacon, rudo animal costal, lleno de paja podrida! A mi tan malas palabras? a mi esto?</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>A te, chesto. E miente ciente millia milliune de<pb n="638"/> vote de 'se ngiurie che hai dito a tutte nui; e me confido e boglio fare a cortellate con tico, a mazzate, a pretate.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">A guardame, oygame, no te vas de aquessa ventana</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>No sto con tico. Che buoi da me sentire chiù chiaro lo prociesso de li fatte tuoie? Adonca sienteme e spila buone, se ha urecchie, tu che me fai lo valente, lo sapio, e lo poeta, e lo cantatore co la chitariglia.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p>
               <foreign xml:lang="spa">Que quieres dezir por esto, cabron?</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Sienteme e crepa, sto sonetto de lo cavaliero Marini, figlio d'Apollo e nepote de le Muse, perché è fatto pe te.</p>
             <p>
@@ -4865,104 +4905,104 @@ umilissimo e perpetuo servitore
               </quote>
             </p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Mirad, vellacon, porque te has descubierto por tan temerario y atrebido y que has dicho de querer pelear co migo, yo me contento por no pareçer que yo tenga miedo de ti. Te deafio a pelear co migo al estecado, con espada sola o como quieres</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Io non voglio palleare con tico, ca no aggio voglia de ioquare.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>E, figlio mio, tu no lo ntienne! Non dice de palleiare co la palla, peleare se ntenne commattere, a lengua soia.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Sì que quiero auchillarme con tigo</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Ora mo sì ca t'aggio entiso. Non voglio comattere con tico, ca non si' pare mio.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Y por que tu eres de tan baxa condicion y yo de tan alto linaje y por esto te hago noble y caballero, y an sì seras mi igual</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Che, che, che?</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Callate, digo, que eres un nezio</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Non mi chiamo Adezio, me chiamo Policinella.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>E ca dice ca si' ignorante e no vozzachio. No responere chiù, siente chello che te dice.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Pozza dicere tanto, che pozza crepare comma la cecala.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Quiero como te he dicho entrar con tigo a la estecada y por esso te doi la noblezza</foreign>.<pb n="640"/></p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Ora buona, io t'aggio ntiso; però corno volimmo commattere?</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">En camisa</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Como 'n camisa, s'io sacio ca non hai camisa e puorti dui fuoglie de carta straccia, uno allo stomaco, e autro alle spalle, co lo collaro ntonato.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">No quiero responder eri tantas tus desconçertadas palabras, pelearemos armados con dos espadas sencillas, sin dagas, ni broquelles</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>E chi cavaliero m'aggio da chiamar, po' che me avite fatto nobile?</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">El cavallero Biscaino</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Buscaino si' tu, ca busca le borze lo iuorno, e li feraiuole la notte! Azzetto la desfida, e nante che se faccia notte, voglio scrapicciarme con tico armato a gusto mio.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Me contento</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Avertiscie ca hai azetato la disfida.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Messersì, mo pe la posta vao a mangiare, perché se aggio da morire, voglio morire abotato de menestra.</p>
           </sp>
           <stage>(<emph>Policinella si ritira, gli altri rimangono</emph>)</stage>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Signor capitanio mio, perdonateme, io non ce sto troppo buono co sta desfida. Che cosa nce porite avanzare con un sciaurato com'a chillo.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Yo lo hago mas por mi gusto, que por otra cosa. Para poder deçir que con todas suerte de personas me he querido pelear, que no queriendose acuchillar con migo Fulgentio, ni Alberto por ser viejo; y para hazer conoçer a Lucila que yo por su causa pongo mi vida en peligro, quiero hazer esta battalla. Bamonos</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Iammo signore dove ve piace.<pb n="641"/></p>
           </sp>
@@ -4970,39 +5010,39 @@ umilissimo e perpetuo servitore
         <div type="scene">
           <head rend="italic">SCENA DECIMANONA</head>
           <stage><hi rend="sc">policinella</hi><hi rend="italic">da dentro la casa di</hi><hi rend="sc">alberto</hi>, <hi rend="italic">con sudetti</hi></stage>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Scaramuzza, Scaramuzza.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Fermateve, signore, ca non saccio chi me chiamma, me ha parzo voce de femena. Chi è là, chi me chiamma?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Sono quella infelice di Lucilla, che ama al par de gli occhi suoi il signor Matamoros, e voglio fugirmene seco.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">O là Escaramuzza, mirad, que Lucila es venida a bajo, y està (si mal no he oydo) de tras de su puerta. Hablale, que yo estaré aqui de guardia</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Signora Lucilla.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Che vòi? Ascoltami un poco per questo buco una parola, ché non voglio esser veduta fuora di casa a ragionar teco, fatte più in qua.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Vecome cà a sto pertusso. Ve ne volite fuire co lo signor capitanio?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Sì, accòstate.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>M'accosto. Ohimè l'uocchie, ca so' cecato!</p>
           </sp>
@@ -5013,15 +5053,15 @@ umilissimo e perpetuo servitore
             <hi rend="sc">policinella</hi>
             <hi rend="italic">e sudetti</hi>
           </stage>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>E ca so' stato io, ca t'aggio schiafato sto cannuolo de farina a l'uocchie! Ah ah ah!</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">A ladron, bien me la pagueras</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Ahimè, ca non ce veo caminare.<pb n="642"/></p>
           </sp>
@@ -5032,119 +5072,119 @@ umilissimo e perpetuo servitore
         <div type="scene">
           <head rend="italic">SCENA PRIMA</head>
           <stage><hi rend="sc">alberto, fulgenzio, volpone</hi>, <hi rend="italic">e</hi><hi rend="sc">policinella</hi></stage>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Non v'ha dubbio alcuno che più offender suole la puntura de l'amico, che la gran ferita dell'inimico. Il Matamoros era egli prima di tutti noi altri amico, e ora, con la sua importunità e ambizione, ne ha tutti offesi e ne è divenuto nemico, senza averne profitto alcuno.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>É vero, signore, che abbiamo a far noi sopra di ciò, se non in tutto, in parte andar sopportando con prudenza questo suo bestial umore. E credetemi che se in tal maniera io non lo avessi sopportato, che o lui o io saressimo rimasti privi di vita, però ho giudicato di esser bene a lasciarlo così distruggere da sua posta, e rodere come la ruggine il ferro; per la molta invidia che egli tiene del nostro felice acordo.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Attendiamo noi a fare il debito nostro, e del rimanente lasciamo operare a la Fortuna. Già, mercè del Cielo, siamo giunti a sicuro porto, non occorre più di altro dubitare.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>É vero, ma non bisogna por la speranza sovra la instabil ruota della fortuna, che in un punto ti volge il tergo e ti abandona, con una mano ti dona con l'altra ti toglie, con un piede si avanza e con l'altro si allontana, con voce umile ci chiama e con altiera ci discaccia. Dico a proposito che bisogna star ben sora di sé con questo capitano, perché sempre va in compagnia di persone di mal affare, e molti traditori abbondano.<pb n="643"/></p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Signore, il consiglio vostro è buono ed è lodabile a porsi in opra.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Ogn'uno parla, sparla e contra parla, e dapo' torna a parlare, e de me pover'ommo mai se parla. Come aggio da fare pe no commatere co isso, si me ha desfidato, e io aggio azzetata la desfida; e né de commatere, né de scrimiare ne saccio spagliocca.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Mi meraviglio di te, che ti spaventi di colui che non vale un zero tra gli uomini.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E signor Fulgenzio, ha ragione il poveraccio, poiché non è bene informato chi egli si sia.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Commo si sia, io creo ca sa sciare e boccare, ma non vo' commattere co lo rimmo , ma co la spata a lo stecato; ca cossì ha dito da sulo a sulo.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E che io non parlo di remi, né che sia, né che voga; dico che tu non sai che quello è più bravo di parole che di effetti.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>No me ne curo che isso aggia defiete, che ne voglio fare? Ma diceno la gente ca smerza l'uomene commo a le stivale; è lo vero? Ca no smerzasse a mme como a cammisa, ca nce parerìa brutto e la gente me farìano la baia pe la terra.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Ti pare che questo abbia del verisimile? Egli è uno eloquente parabolano, e dicono le persone che questo sia un certo suo umor melanconico, come è quello ancora di Squarcialeone, che vogliono esser stimati per quelli che non sono.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E non, signore, che volete dire Squarciapecore, e non leone.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>O piecore, o puorce, o asene, signure chesto a me no me nporta: ma aggio paura de esser acciso contra voglia mia, e no ce so' ausato.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Orsù, Policinella, non dubitare, combatti pur di buon cuore, perché essendo vincitore, come che<pb n="644"/> indubitatamente sarai, tutti ti chiameranno il vittorioso cavalier Pollicinella, e sarai amato, pregiato, riverito e onorato, non solamente tra gli uomeni volgari, ma tra' più dotti, e tra' prencipi, e da tutto il mondo, e ti faranno pasti con esquisitissimi cibi e preziosi vini, e chi ti chiamerà di qua, chi di colà, e te diranno: «E ben signor Policinella, come passò quel gran fatto di arme tra vostra signorìa e il signor capitan Matamoros».</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Chesto sarìa quanno che io restasse guadagnatore, ma se isso me venciesse, senza ca m'accedesse, chi mi darìa manco lo buon giuorno? Anze che, chi me darìa no punio da cà, chi no secozzone da llà, chi na scopoleata, chi mazzate, chi cauce a lo tafanario, chi promonate 'n faccia, e chi tripate allo musso de sette sapate.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Del rimaner perditore non dubitare, ché lui è timido e si spaventerà di te; oltre ciò, che noi ti staremo tutti da presso armati, che conoscendo che lui ti avantagiasse di valore, saressimo pronti al difenderti al suo dispetto; sì che in tutti i modi ne sarai il vittorioso.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Sì che hai bene inteso, dunque animosamente alla battaglia, se vorrai esser posto nel numero de' valorosi campioni e paladini antichi.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>E io me sento debole e non poraggio commattere.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Nulla temere, perché prima che entrerai nel marziale aringo, sarai ben confortato.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Avertite ca no me piaccino le arenghe.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Allo stecato, ha detto. E sarai prima ringagliardito con la sostanzia di buoni caponi, galline, lasagne, pasticci, pollastri arrostiti e maccaroni caldi caldi.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>A fé per vita toia? Ma che non siano tanto caude, che me cocano la vocca.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Non dubitare, certissimo lo vedrai in effetto.<pb n="645"/></p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Adonca si farà così: io me resorvo e despongo de commattere non sulo co isso, ma con ciente de li pare suoie. Ah mariuolo cornuto, ah spagnuolo figlio de quatuordece putane, iesce cà, ca me te voglio gliotere sano como a macarone sodunto.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Questa è una bravata fuora di proposito, bisogna aver fatti e non parole.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>O sarebbe ridicolosa che costui chiarisse quel capitano, che per altro io non lo fo che per fargli calar l'orgoglio.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>O sarebbe da ridere che l'asino si mangiasse il lupo! Orsù, signori, non perdiamo più tempo, andiamo da un mio amico armaruolo, per farlo armare a suo modo. Viva viva il cavalier Policinella!</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Andiamo. Ma che viene a far colui così in fretta alla volta nostra? Aspettiamo, di grazia, un poco.</p>
           </sp>
@@ -5155,156 +5195,156 @@ umilissimo e perpetuo servitore
             <hi rend="sc">scaramuzza</hi>
             <hi rend="italic">con sudetti</hi>
           </stage>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Fermateve, segnure, ascotateme chello che v'aggio a dicere.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>A te puro voglio sbodellare, smatricolare, scannare, scortecare, desossare, squartare e sbufarare.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Si arcuno de vuie autre signure fosse stato offiso da me, ve preo che me perdonate e tanto chiù lo dovite fare quanto che, commo amasciatore de lo signore capitanio Matamoros, vengo a darve sto cartiello, che desfida lo signore nobele e illustrissimo Policinella alla battaglia.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>É il dovere che non debbiate da noi esser offeso. Mostrate il cartello.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Pigliate, signore, aspetto la risposta.<pb n="646"/></p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Orsù, che si legga. Voletelo leggere, signor Policinella?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Come piace a vui, signore. O pover'ommo me, e a che so' areduto.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Avete imparato di umanità in scuola, o avete letto in casa?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>L'aggio a la casa, ma lo patrone mio me fa sempre dormire in coppa a no saccone de paglia. Perché l'adomannate?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Tu non intendi. Dice se hai letto, se sai leggere, se hai mai leggiuto, come te l'ho a dire.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Se io saccio leiere? Non saccio, ma provarragio.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Ti proverai? Come, ti proverai, hai saputo mai leggere?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Signore non aggio mai leiuto, perché patremo no me manao mai a la scola, e perzò non saccio leiutare, ma chi lo sa se ne sapesse quarche poco? Mostra chisso cartiello.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>To', leggilo, se sai leggere.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Ca ca, co co, bi bi bò, bu bu, trista è mamata, e peo si' tu.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>E leggetelo voi, signor genero mio, non odite che egli non sa ciò che si dica.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Mostra qui, damelo.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Te', pigliatelo.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>State bene attento ad udire, signor Policinella, perché vi importa la riputazione e la vita.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>M'avite frusciato con tanta repotazione, me nporta chiù la vita che autro.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p><stage>(<emph>qui legge</emph>)</stage> «<foreign xml:lang="spa">Yo, el gran capitan Matamoros ganavanderas, horrible, terrible, increible, tremendo, estupendo, horrendo, animoso, valeroso, espanto de Marte y de la Muerte, sobrino de Belona, nieto de la fortuna, naçido y criado dentro del gran baratro enfernal, entres los diabolicos gritos de Pluton, Mijera, Tesifone y Eletto, notrido y sustentado de sangre humano, arcecavalleraço de Espaa, destruydor de campos enemigos, rompedor de exercitos, deribador de<pb n="647"/> castillos, conquistador de reynos, temor de imperios, vencedor de batallas, pariente del Soffi, señor del Eteopia, tributado dal turquo, dal persiano y dal grandissimo Lucifero, sostancia y bravezza dela guerra y plus ultra, mas allà de todo el mundo, sessenta mil millones de leguas; desafio el noble Policinella a pelear con migo, armado de la manera que a el fuera de gusto, antes que el claro sol se vaia dentro del oceano y todo lo hago por mantenerle que lo que de mi ha dicho es muy gran mentira</foreign>».</p>
             <p>E ben, signor Policinella, avete ben udito la disfida?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Parte sì e parte no.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Che ve risolvete di fare?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>No saccio, ca me scomuosso lo cuorpo. Vedite, per vita vostra, se lo potessivo accordare, accomodare sta cosa con dareme isso da cordio cinquanta carcacopole e tricento secozzune.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>O bello onore, che ne sarebbe a tutti noi! Non ti vergogni di lasciarti uscire queste parole di bocca?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Ah, Policinella, e dove è il tuo bel animo generoso, il tuo valore, il tuo ardire, il tuo elevato ingegno?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Animo, Policinella mio, non mostrar viltà, aricordati de gli amici, e di principi, e di quegli che per la tua virtù e vittoria ti chiameranno, ti accarezzaranno, ti inviteranno, e più, che i macaroni con la carne ora per te si apparecchiano in cucina, ti chiamano e te invitano in compagnia del greco e invitano all'armi, all'assalto e alla vittoria, alla gloria e alla fama.<pb n="648"/></p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Avite ragione, pota de mene, dateme sto cartiello. To' to' to'! Ora va' e di' a lo spagnuolo ca men'aggio stoiato lo tummentienne, e ca me l'aggio puosto sotta a li piede, e che mo le voglio mannare no contra cartiello nfamatorio scritta 'n carta straccia, acatata a lo funneco de lo Cetrangolo de Napole.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>O bravo Policinella, o che valent'uomo, o buon soldato.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Sì certo, non si può negare.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Non v'è dubbio, è sicuro.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Va' tu, Scaramuzza Me Meo, muzzo de stalla, striglia cavalle, va' alla cantina, e curre 'n cucina, e dille da parte mia a 'so spagnuolo, nemico de la carne de puerco e delle sauciccie arostute, ca no lo sommo na iota. Iamo a solecetare che se coccano priesto li macarune, ca me voglio armare allegramente da dintro e da fore.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Io vao, ma de 'se chiachiare me ne rido, o pover omo te, e pe la canna te fai pigliare, mo nce lo vao a dicere.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Dille ancora ca è no truffa paga, e ca non è vero spagnuolo, ma di chille matane descacciate da Spagna. E tu va', mieteme li puorce a li cetrule, cornuto sbrufa papa.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>A fé, che tu gli hai risposto meglio che per le proprie rime.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>O bene, o bene, ti se' portato da paladino.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Andiamo qui in casa d'un mio amico per scrivergli il tuo cartello, ma che sia da te dettato e ti faremo armare.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Sopra a tutto che nge sia caso piacentino assai e burro sopra li macarune.<pb n="649"/></p>
           </sp>
@@ -5316,23 +5356,23 @@ umilissimo e perpetuo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">squarcia</hi>
           </stage>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Ya enbié mi carte a Policinela, por el criado de vuestra merced, no sé lo que havrà soçedido</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Certo, signore, che molto dispiacemi che per umore e capriccio ella volle con persona così di bassa condizione combattere, e por la sua vita e il proprio onore in compromesso.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Señor, lo hago por que soy tan deseoso de haçer al mondo conoçer que con qualchiera suerte de hombres he querido venir a battalla, y tanto mas que el fue el primero que me desafiò y serà muy gran verguenza la mia en faltar de açello y estoy mas contento que si hubiera de venir a iornada con el muy valeroso monsiur de Chirichì, verdadero y gran paladino de Françia, pero con todo esto, yo le doy este titolo de cavallero, aun que no lo sea</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Sia pur come ella dice, signore. Bastami che, come vero amico e cognato, senza adulazione gli abbi notificato il mio parere, perché da un soldato de' nostri se avrebbe potuto far dare una gran carica di bastonate e sarebbe stata finita la cosa.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Ya està concluydo y me serìa de mucha verguenza el dejarlo de haçer</foreign>.<pb n="650"/></p>
           </sp>
@@ -5343,29 +5383,29 @@ umilissimo e perpetuo servitore
             <hi rend="sc">scaramuzza</hi>
             <hi rend="italic">con sudetti</hi>
           </stage>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Signore, io aggio fatto lo servizio. Policinella ha fatto leiere lo cartiello e dice ca no ve stimma niente, l'ha stracciato e se n'è iuto ad armare dicenno ca ne voleva mannare n'autro a vosegnorìa.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Y no se ha espantado de mi valorosa persona y de mi gran valor? Juro por la fuerza del grande Alcides, que el primero golpe que le tengo de dar en la cabeça y de hazerle saltar los ojos por de dentro de los agujeros de las nariçes. Vete corriendo a mi armero y dile que me tenga a preçevidas las armaduras, y que el estoque sea mas reluciente de los rayos del sol, porque quando alçaré por darle la cuchillada, quiero que el resplandor le quite la vista y lo dexe confundido y fuera de si</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Presto, corri più che il vento, servi il signor capitano.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Facite cunto che sia iuto e tornato, vecome cà.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p>
               <foreign xml:lang="spa">Ea, corras, vete en hora mala, que aguardes?</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Mo, signore, a la bona ora, vao.</p>
           </sp>
@@ -5373,123 +5413,123 @@ umilissimo e perpetuo servitore
         <div type="scene">
           <head rend="italic">SCENA QUINTA</head>
           <stage><hi rend="sc">volpone, matamoros</hi>, <hi rend="italic">e</hi><hi rend="sc">squarcia</hi></stage>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Tuttavia Policinella si va armando.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">A picaron, a qui estas? Tu cabeça es mia</foreign>.<pb n="651"/></p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>E questa gamba è mia.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Ahimè, che sarà questo? Infoderate, signori, le vostre armi e facciamo tregua per due ore, perché vengo come ambasciatore del signor Policinella, e questa carta viene a vostra signorìa, signor capitano Matamoros mio signore.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p>
               <foreign xml:lang="spa">A mi? es carta del emperador?</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Signor sì viene a vostra signorìa, ma non viene di Alemagna.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Detengase señor, que se envainan las espadas</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Ecco che la ritorno al suo loco, per la salute del genere umano.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p>
               <foreign xml:lang="spa">Es papel de España, de Fiandres o de Constantitinopola?</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E non, signore, è un cartello a vostra signorìa, mandato dal nobilissimo signor Policinella.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Che signor Policinella! Corpo del mondo, vuoi tu dire la feccia de' guidoni, la schiuma de' sguattari e de' poltroni.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Si señor, que yo le he dada la nobleça. Damela cà, che dize, me acontento de escuchiarte, levàntate, no steyas mas arodillado delante de mi</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Con vostra licenza m'ergerò in piede.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">No entiendo esta escritura, que es eri lengua italiana</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>É vero, signore.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Pues leed, que te doy licençia, si sabes leer</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Io leggerò, però se non vi sarà cosa di vostro gusto, non ne date la colpa a me.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Non importa, me contento, leed</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Leggi, e se non potrai supplire, ti aiuterò nel legere.<pb n="652"/></p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>State dunque ad udire per cortesia, e non vi turbate.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Desid, presto</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>«Io lo gran nobele e illustrissimo signore Policinella de Gamaro de Tamaro coccumaro de Napole , nasciuto a Pontaselece, figlio de Marco Sfila e de Madama Sbignapriesto, pe mangiare no cacavo de macarune, mangiatore de galline, picciune, fasane, pernice, pastice, sausiccie, migliacie e capune, squarciatore de cosse de porcelle, accedetore de puorce sarvateche, sgareatore de galle d'Innia, e deluviatore d'ogni genere musicorum de vidanne squisite, smafaratore de vuote de grieco, lagrema, guarnacia, marvasia, leateco, mangiaguerra, scolatore de fiasche, polizatore de scotelle, così de iuorno comme de notte, co lumme e senza lumme, dintro e fora coreggia; azzetto la desfida de lo capitanio Matamora, re e monarca de li poltrune, arcefanfaro delli crastate».</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">O mal naçido, vellaco, y de puta cabron</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>«Me offerisco de pigliarolo a mazzate, a besicate, a tripate, a fecatate, e a pormonate 'n facce, a despieto de chi lo vo' favorire. Azzetto la desfida e benga priesto a commattere co lo gran Policinella, re delli mangiature e monarca de li vevetture. E zetera, e zetera, e zetera, e ciente millia zetera, e n'autra vota zetera».</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">No hay mas que dezir. Sé bien lo que tengo de hazer sobre esto</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Ambasciatore non porta pena.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">No hablo con tigo, pero vaya, y digale que se procure sepultura, y presto, antes que, despues de haverle muerto, lo profunda dentro del eterno fuego. Bamonos, señor, al armero</foreign>.<pb n="653"/></p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Andiamo. E digli da mia parte che con un corno del rinoceronte vorrò sbudellarlo.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Non sarebbe meglio con il vostro?</p>
             <p>O se m'avesse inteso. Certo che l'ho scapata buona dalle mani di costoro.</p>
@@ -5498,85 +5538,85 @@ umilissimo e perpetuo servitore
         <div type="scene">
           <head rend="italic">SCENA SESTA</head>
           <stage><hi rend="sc">clarice, fioretta</hi>, <hi rend="italic">e</hi><hi rend="sc">volpone</hi></stage>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Olà, misser Volpone, come va questa cosa? Dalla fenestra ti ho veduto con mio fratello, così presto si è placato contro di te? Se avesti avuto a far meco, so che non l'averesti passata così franca. Che indegnità fu la tua a fare un'insolenza così grande a casa nostra, senza avere riguardo a le persone che noi siamo?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Signora, con alcune efficaci ragioni ho placato il signor vostro fratello, il quale darà per me sodisfazione a vostra signorìa.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Non mi occorreno tante sodisfazioni, so ben che tu sei un mal guidone.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>O per grazia vostra, signora, son troppo favorito da voi.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Veramente, messer Volpone, voi avete un bel collo da forca! Tanta ne farete, che un giorno v'inciamperete sotto, e bene.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Non v'inciamperò, astuta volpe non inciampa a laccio.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Non in laccio di cacciatori, ma de' ladri e de' furboni.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>E non alterare così la voce, ché ti farai scorgere per matta da i vicini! Va' via da qui tu, baronaccio.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Io vado, con ogni debita riverenza parlando.</p>
             <p>E costei dal civile entra nel criminale.</p>
             <p>E io vi ho d'avisare d'una strana cosa.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Che cosa sarà? Forsi qualche tramma da te ordita?<pb n="654"/></p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Il signor capitano vostro fratello si è disfidato a combattere a lo steccato con Policinella, servo del signor Fulgenzio.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Ohimè, che è quel che odo? con quel sciagurataccio, con quel vil uomo da nulla?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Signora sì, ma lui dice di averlo fatto nobile.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>E non mi sapeva comandare che io l'avessi caricato bene le spalle di legnate? Signora, non state suspesa, né pensosa, perché il signor padrone averà finto di voler combattere da dovero, e doppo lo farò bastonare.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Ne credo più di quanto che ha detto costui, perché mio fratello è peggio che matto, né se gli può far mai capire ragione alcuna.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Da catena , avete ragione, signora.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Ah forfantaccio, mascalzone, questo di più! Sì tu, sei matto da catena, da ospedale, da berlina, da galera e da forca! Sfacciatone, ti tirarò d'una pianella.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Non occorre qui più dir altro. Sia come ella si voglia, il Cielo sia quello che li dia vittoria.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Entriamo, signora. Orsù, il malanno vi venga, messer Volpone beccaccio.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E a voi il malanno con la mala Pasqua, madonna Fioretta poltrona.</p>
             <p><stage>(<emph>Volpone solo</emph>)</stage>Dissemi Policinella che io li facessi apparecchiare una sedia.</p>
@@ -5590,35 +5630,35 @@ umilissimo e perpetuo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">volpone</hi>
           </stage>
-          <sp>
+          <sp who="#scaltrino">
             <speaker><emph rend="sc">scaltrino</emph>.</speaker>
             <p>Perché batti a quella porta, Volpone, che non entri? Sai bene che il padrone non è in casa, e che il pasticciero mette all'ordine gran robbe mangiative per Policinella.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Lo so. Va' dunque e porta qui fuora un paro di sedie per la porta che entrano i carri delle legna; e questo per<pb n="655"/> ordine del signor Alberto. E avisa la signora Lucilla che senza fallo si combatterà tra Policinella e il capitano, conforme egli disse di voler fare.</p>
           </sp>
-          <sp>
+          <sp who="#scaltrino">
             <speaker><emph rend="sc">scaltrino</emph>.</speaker>
             <p>Da dovero, o da burla?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Da dovero, dico.</p>
           </sp>
-          <sp>
+          <sp who="#scaltrino">
             <speaker><emph rend="sc">scaltrino</emph>.</speaker>
             <p>O che bel vedere che sarà!</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Se tu non potrai portarle, fatti aiutare.</p>
           </sp>
-          <sp>
+          <sp who="#scaltrino">
             <speaker><emph rend="sc">scaltrino</emph>.</speaker>
             <p>Farò ciò che potrò. Vado, non ti partire.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Sto pensoso, pensando come riuscirà questo duello. Il signor Fulgenzio e noi abbiamo inanimito Policinella a combattere più per mortificazione di quel capitano che per altro, ché ben si sa che è più matto che valente, già che mostra tanta poca prudenza.</p>
           </sp>
@@ -5630,23 +5670,23 @@ umilissimo e perpetuo servitore
             <hi rend="italic">e</hi>
             <hi rend="sc">volpone</hi>
           </stage>
-          <sp>
+          <sp who="#scaltrino">
             <speaker><emph rend="sc">scaltrino</emph>.</speaker>
             <p>Largo, largo, ecco qui le sedie. Poni tu questa colà e quest'altra in qua.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Tu non volendo hai fatto bene a porle una in quella casa del Matamoros, e l'altra appresso la nostra.</p>
           </sp>
-          <sp>
+          <sp who="#scaltrino">
             <speaker><emph rend="sc">scaltrino</emph>.</speaker>
             <p>Andiamo ad incontrare Policinella, andiamo allegramente, o bel ridere che sarà!</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Piano piano, che tanto saltare e ballare, par che andiamo a nozze! Taci, férmati, ché è vergogna.</p>
           </sp>
-          <sp>
+          <sp who="#scaltrino">
             <speaker><emph rend="sc">scaltrino</emph>.</speaker>
             <p>Che sì, che non potrò tôrmi un poco di allegrezza e di piacere?</p>
           </sp>
@@ -5659,15 +5699,15 @@ umilissimo e perpetuo servitore
             <hi rend="sc">fioretta</hi>
             <hi rend="italic">più in alto</hi>
           </stage>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Io sono venuta qui su la finestra solo per saperne il vero di ciò che mi disse quel forfante di Volpone circa di mio fratello, che non lo credo, essendo tutto pieno sempre d'infinite bugie. E non gli volsi altro dire di Fulgenzio, che egli mi promise d'introdurmelo in camera, e ciò l'ho fatto per<pb n="656"/> parere di non tenerne più conto, e tanto più che come sposa si condusse Lucilla via, non essendo egli di me inamorato, ma di lei.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>E io signora, me ne son salita qui sul granaio. State pur salda costì, ché me ha parso aver udito battere il tamburro a la lontana, che sì che passerà qualche compagnia de spagnoli.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>É vero, però non mi stare a fare più la gaza, tacci un poco.</p>
           </sp>
@@ -5678,7 +5718,7 @@ umilissimo e perpetuo servitore
             <hi rend="sc">lucilla</hi>
             <hi rend="italic">con le sudette</hi>
           </stage>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Son venuta un poco qui su la fenestra per non starmene così rinchiusa, come fin ora ho fatto, pensando ai miei passati guai.</p>
           </sp>
@@ -5693,71 +5733,71 @@ umilissimo e perpetuo servitore
           <stage><hi rend="sc">alberto, fulgenzio, volpone, policinella</hi><hi rend="italic">armato</hi>, <hi rend="sc">sguattari</hi><hi rend="italic">con spiedi e robbe da mangiare, con sudetti</hi></stage>
           <stage>(<emph>Policinella fa l'istesso, e si senta a suono di tamburro con Scaltrino, Volpone gli parla nell'orecchio. Scaltrino afferma tacendo</emph>).</stage>
           <pb n="657"/>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Poiché, mercé del potentissimo Marte, giusto, verace e degno protettore di noi altri famosissimi ammazzatori, quinci comparsi vi siano due famosissimi guerrieri, che venir vogliono fra di loro a singolar duello, giusta e ragionevol cosa mi pare, acciò né l'uno, né l'altro possa rimaner offeso, né ingannato, dico che si debbano misurare le loro armi, acciò non vi sia disuguaglianza alcuna, e che per ciò ragionevolmente si debba compartire il sole, conforme usar si suole fra più degni e valorosi eroi.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Faraggio quanto volite vui, ma non me date troppo sole, perché aggio autro caudo che de sole.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Dammi la tua spada, Policinella.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>E perché, è scomputa la guerra, non se commate chiù?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E tacci, non mostrare pusilanimità, ché oggi è quel giorno che acquisterai molta gloria e onore.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>E che so' sbregognato, che me aggio da quistare onore? Ogni poco de onore me abbasta, ca so' sulo.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Dìame, vostra signorìa, quella del signor Matamoros.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Con licenza, signor capitano. Eccola, signore.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Son giustissime. Ripigliàtela, signore.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Prendete, signor capitano.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Animo, signor Policinella.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Y es posible que esta valerosa y vitoriosa espada, que fue del fuerte Achiles, que por sentencia del rey Agamenon fue dada al griego Ulis con las otras armaduras, que al cabo de muchos años y guerras suçediò en las balerosas manos del gran Iulio Cesare primero emperador de Romanos y despues de su muerte cayò en poder de Octaviano, de Octaviano a Tiberio, de Tiberio a Cayo Cesare, da Cayo a Claudio, da Claudio a Neron, da Neron a Sergio, da Sergio a Silvio Orton, da Silvio a Vitelio, da Vitelio a Vespasian, da Vespasian a Tito, da Tito a Domician, da Domician a Cuceio, da Cuceio a Troian, da Troian ad Antonio Pio, da Antonio Pio ad Aurelian, da Aurelian a Comodo y Comodo, por antigua memoria, la encerrò en el templo de Giano en Roma. Que despues, al cabo de muchos successiones, vino en<pb n="658"/> poder del grande emperador Carlos Quinto, quando fue encoronado emperador de Romanos en la famosa ciudad de Bolonia, gran madre de studiosos. Carlos Quinto la diò en sacrificio a Marte; Marte la diò alla Muerte, la Muerte a Pluton, Pluton la diò a mi valerosa persona, gran monarca de muy estremada valentia; paraque deviese matar con ella gran parte del Asia, Africa y Europa, como que ansi hasta hora he hecho para la aumentacion del Reyno Ynfernal, por el muy gran tributo que el principe del fuego me da; y que a hora se ha de ensuçiar de la pudrida y negra sangre de un rudo animal, como es aquel que en todas maneras yo lo he de matar</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Animo, signor Policinella, perché dice così per isbigotirvi, rispondeteli prontamente che non avete paura delle sue chiachiare.<pb n="659"/></p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>O figlio de bagascia cornuta, e che te pienze de me sbaotire? e con chi te pienze de avere a fare, con quarche catarchio, con quarche bozzachio come si' tu, che meglio non te avesse fatto mamata? Sai che chesta è chella spata che era prima no gran cacavo deventao caudata, da caudata pozzonetto, da pozzonetto fressora, da fressora gratiglia da rostireme vrassole e rossole de puorco, da gratiglia deventao cochiara perciata da menestrarence lasagne, da cochiaro spito, da spito spata; aspetta che sputa. E dappo' fu data en potere de lo gran Colafronio Trenta Ova, da Colafronio a Marco Cinco, da Marco Cinco a Gelormo Percuoco, da Gelormo a Pantalè, da Pantalè a Iacovo de lo Caso, da Iacovo ad Antonio Cumaro, da Antonio a Nardiello, Nardiello a Pascariello, Pascariello a Cola Marchione, Cola a Coviello, Coviello a Giananiello de la Conochia, Giananiello la deze a lo gran Micco Passaro Napolitano, paladino de Forcela, smargiaso de lo mercato, bravo de la chiazza del Urmo e isso la deze a lo capitan Totaro e chillo me la donao, ché avesse da cidere tutte li forfantune, taglia vurze, mariule de sacociola e robba ferraiuole de lo munno, e perzò guardate tu ca sai chillo che si', e sufficite appilo, che escie feccia.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>E perché, signori, questo duello senza dubbio si può chiamare padre della morte, per tanto, vi prego a manifestare ciaschedun di loro, quando per disgrazia rimanesse dall'inimico vinto, e forsi estinto, come vi piacerebbe che per memoria si dovesse far scrivere su la sepoltura.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Ora chisto è n'autro chiaito, lo Cielo me la manna bona.<pb n="660"/></p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Aunque cierto y claro soy de no poder morir para ser imortal, todavia yo este epitafio haria poner en cima de mi sepoltura, oigame</foreign>:</p>
             <lg type="nondefinito" xml:lang="spa">
@@ -5776,19 +5816,19 @@ umilissimo e perpetuo servitore
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>E voi, signor Policinella, come vi piacerebbe che si dovesse scrivere su la vostra sepoltura?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Bell'aùrio, che me facite! Lassate no poco che nce penza, e che responna a chisso iosse e bosse e scaravosse, che sta llà, ca le voglio parlare tosco.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Diga el vellaco</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Mo lo dico, piecoro, ora siente.</p>
             <lg type="nondefinito">
@@ -5797,135 +5837,135 @@ umilissimo e perpetuo servitore
               <l>vattene col malan che il Ciel ti dia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Te pozza venire 'n faccie, aseno nmardato.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Signori, fin qui siamo bene aggiustati, però mancavi una sol cosa e doppo si darà il generoso assalto.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Che cosa, signore, ditelo.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Cercare adosso a l'uno e l'altro, acciò non si tenesse qualche sorte di scrittura per l'offesa, o difese delle armi, benché non vi si debbe dar credenza se non alla ragione, tuttavia per sodisfazione di tutti, non si deve lasciar di farsi.<pb n="661"/></p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Me contento, pues que otra escritura no tengo si no la fuerza del braço y el animo del coraçon</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>E a me nesciuno me passe de contentaresse, cercateme tutto ca me contento, stracontento contentessemamente.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Con un soplo lo tengo de embiar a besar los cuernos de la luna</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>E io co no caucio te boglio fare ire a vacuare le fecate a Levante. Signore, nante che se commatta vorrìa dicere doi parole secretamente a Scaramuzza paisano mio.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Presto, Scaramuzza, ascoltalo come amico.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>De grazia, signore. Che buoi da me, messer Policinella?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Fa' arassare tutte, e sienteme na parole a le orecchia.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>De bona voglia, de razia, arassateve segnure, ca me vole parlare secretto.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>É di ragione, ecco che ci siamo ritirati.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Scaramuzza mio bello, nuoi simmo paisane, e si nce mozecammo non ce gli stimmo e me fido de te.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Di' che buoi dicere, e prieste.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Te lo diraggio, con patto però, che non lo diche a nullo. Sienteme e saperai che boglio. Ahimè, frate mio, chesta è una brutta colata pe me, vide tu se lo poi quietare 'so spagnuolo, ca me contentaraggio da cordio che isso co le mano soie propie me vaga frustanno a cavallo a n'aseno pe tutta la cetate de Capua, e che sautaraggio, abuffaraggio e faraggio capo tomole pe tutta la chiazza, che me dia schiaffune, bufettune e cauce quanto vo' isso, puro che no me faccia commattere, ca m'è benuta la cacarella, frate mio, e lassa far a me po', ma come venesse da te.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Povero Pollicinella, cierto che me dispiace.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Ne lo vero, pro vita toia, di' che buoi dicere che te despiace?<pb n="662"/></p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Ca me despiace ca no si' stato dece anne prima acciso, caperonne d'Innia, va' a la forca! Io no le voglio dicere niente, ca voglio che muore acciso pe le mazzate che me hai dato sta notte passata! Crepa, schiata, sfonola, e crepanta!</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>É è è è !</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Che cosa hai, Policinella? Va' in là, Scaramuzza.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>L'aggio dito che me npara dove se va a fare lo servizio, perché aggio fruscio de cuorpo, e isso dice ca non vole e ca no se n'empaccia.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Lassatelo dicere, ca chessa è scusa pe no commattere.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>O che indegnità d'un cavaliere, di un guerriero tanto famoso! Ah, signor Policinella, state sora di voi, non perdiate la riputazione, né il vostro onore.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Io ve dico lo vero, ca me site venute 'n fastidio con tanta segnorìa e tanta reputazione e tanto onore, e me avite confuso. De razia, lassateme ire a mitte.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Fermatevi, dico, non partite. Orsù, Volpone, cerca tu Policinella.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Di grazia, dove è la tua bisacca?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Che?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>La tua scarsella.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>So' ommo de fare squarciella a ciente de li pare tuoi, con chi te pienze de parlare?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E te dico la sacoccia! Eccola qui. Che cosa è questa? Che carta inviluppata.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>É una polesa de cammio che m'ha fatto no potecaro de caso e d'uoglio.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Tu hai ragione, questa è una buona fetta di cascio, e questo bollettino che cosa dice?</p>
             <lg type="nondefinito">
@@ -5935,78 +5975,78 @@ umilissimo e perpetuo servitore
             </lg>
             <p>Il detto è bello, tosto te lo ripongo in scarsella.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Signor Matamoros, resterà ella servita che io faccia lo istesso.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Haga, señor, lo que le fuera de gusto, busque en mi faldriquera</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Con licenza, che cosa è questa?</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">O mi desdichosa fortuna ! Muestra señor. Son guantes de España, para dallos a la reyna de Sueçia</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Segnor no, le bolimmo vedere.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>To', guardateli voi.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Da' cà, ha ha ha, cheste so' ravanelle spagnole contra a l'arme 'taliane! Co licienza le boglio iettare.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>E no, dammele a me, ca so' radice confettate, che le saranno restate 'n mano a la tavola de Marte, ca co isso ha magniato sta mattina.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Non vi si ponghi più intervallo di tempo ad intrar nella battaglia. Animosamente, signor Policinella! Che si batta il tamburro.</p>
           </sp>
           <stage>(<emph>Qui si batte il tamburro</emph>)</stage>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p>
               <foreign xml:lang="spa">Armas, armas, sierra, sierra!</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Ferma, ferma tammorino, damme l'avanzo de lo carrino, non sonare 'sa sonata, ca me ne voglio sbignare.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>E se non avete ancora combattuto?</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Señor capitan Squarcialeon, digale vuestra merced si se ha dicho esta manaña lo que se diçe por toda España de mi valerosa persona</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Ritiratevi in casa, Fioretta, ché non si conviene, né mi comporta l'animo, di vedere tal disordinata pazzia di mio fratello.<pb n="664"/></p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>É vero, signora, però son di umore di saltar fuora per dare una mano di legnate a quel forfantonaccio che si vuole uguagliare con il mio padrone. Andiamo, signora.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Hai bene inteso ciò che ha detto il signor Matamoros.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Lo malanno che le venga, che saccio che se dice.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Se diçe desta manera</foreign>.</p>
             <lg type="nondefinito" xml:lang="spa">
@@ -6014,488 +6054,488 @@ umilissimo e perpetuo servitore
               <l>guardame Marte y guarde muy de veras.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Sai come se dice de me pe tutta la 'Talia?</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Como? Desid</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <lg type="nondefinito">
               <l>Del capitan che spisso va a magniare</l>
               <l>guardame Giove e tu te fa squartare.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Ogni momento mi par un seculo di veder costoro entrar ne la battaglia! Io non so come potrà costui resistere contra di un valoroso capitano.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Orsù, all'armi.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Aqui estoy. Levantate de aquella silla, vellacon</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Ahimè ca so' muorto, sto buono a così, no me voglio levare, tallune aiutateme.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Férmati, o là Policinella, avèntati contro di lui come saetta, vuoi tu rimaner privo di onore?</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Io voglio essere no cornuto, che bolite da me? Lassateme ire pe li fatte miei.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Che tu debba valorosamente combattere e mostrar la faccia e i denti al inimico.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Te', io ce le mostre con tutte le mole, che bo' chiù? Covernateve.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Non ti far questa vergogna, ascolta.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Né questo vituperio a' tuoi amici, a quelli che ti hanno da pasteggiare, da banchettare! Non vedi questi bei conditi macheroni, che sono qui per te dolcemente apparecchiati, questo bel pezzo di arosto, queste quaglie e questi piccioni? Vedi con quanta solennità ti stanno attendendo che tu li debba godere, finita la battaglia, e che ti conforteranno la<pb n="665"/> lingua, il palato, la bocca, e le budella, te impiranno il ventre e trangugiando goderai, bevendo questo eccellentissimo greco, sgorgato che sarà da cotesti odoriferi vasi. Prenderai più vigore, più forza e maggior ardire. Animo, animo e cuore! Entra valorosamente a la battaglia! Batti, dunque, lo marzial stromento per dar maggior animo al nostro valoroso paladino.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>A fé ca hai ragione, lassame prima paziare la nostra guerra co lo nemico, non sonare. Segnore capitanio, ve contentate che io ve acida senza commatere?</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">A bacillero, ladron, tu matar un tan famoso guerre ro? Yo quiero luego con la punta de mi espada arojarte en Yngalterra. Passate a cà</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Ferma, ferma, facimmo prima li pate nuostre.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p>
               <foreign xml:lang="spa">Que patos?</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Che all'assauto no ce dammo co le spate 'n face, né 'n capo, né a le braccia, né a l'uochie, né a lo pieto, né a la panza, né a le spalle, né a nulla parte de la perzona, e damoce dove volite vui.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Yo no tengo de buscar tantas neçedades, cadauno dea adonde podrà. Sierra, sierra</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Serra, serra, ed apre quanto vòi tu.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>In cervello, Scaltrino, con la corda al piede del capitano.</p>
           </sp>
-          <sp>
+          <sp who="#scaltrino">
             <speaker><emph rend="sc">scaltrino</emph>.</speaker>
             <p>L'ho qui, lasciate pur fare a me.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Ferma, ferma, sta' a la larga, mazza franca da cà e da là, lassame sedere, aiuto, aiuto, refregerio, macarune, macarune! Lassamene pigliare na vrancata.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Mangia, mangia Policinella, allegramente.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>O bene mio, lassame no poco adorare la carne arostuta, damme lo stoiavuco.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>To', confortati con il greco di Somma.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Da' cà.<pb n="666"/></p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Dagli il bichiere.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Non mporta, ca vevo a lo fiasco, hà, ca tutto me sento decreiare.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Trinca buono, cornuto, che te faccia fuoco!</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Viene nante mo, spagnuolo scassa poteche</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Venga, el puerco vestido</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Ferma, ferma! Macarune, macarune, carne arrostuta e vino.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>To', non hai combattuto e ti ritorni a confortare.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Sù, di buon animo, all'ultimo assalto, e fenianla, di grazia.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Mo. Te', pìgliate sta cortelata!</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Y tu esta estocada</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Tira becarello.</p>
           </sp>
-          <sp>
+          <sp who="#scaltrino">
             <speaker><emph rend="sc">scaltrino</emph>.</speaker>
             <p>Gli ho invilupato il piede.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Tira adesso.</p>
           </sp>
-          <sp>
+          <sp who="#scaltrino">
             <speaker><emph rend="sc">scaltrino</emph>.</speaker>
             <p>Eccolo in terra a fé.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Sbigna, trucca di calcagnio! Salvati via.</p>
           </sp>
-          <sp>
+          <sp who="#scaltrino">
             <speaker><emph rend="sc">scaltrino</emph>.</speaker>
             <p>E me conviene.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Hay de mi, y que engaño y traycion es esta? Ay que deribado fue en el suelo da un muchacho</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Ariènete, spagnuolo, se no ca te acio e te smenuzzo.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>O là, che tradimenti sono questi? Ah briconzello, te ho ben io veduto, me la pagherai, da capitan generale.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Crai mattino lo smafato e l'accio.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Segnure, io aggio lo nemico 'n terra, che bulite che ne faccia?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Che sia per tuo conto il tutto rimesso nel maturo giudizio del signor Alberto.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Io me ne contento, ca me pare mill'anne de fuìre.<pb n="667"/></p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>E io, in nome del vinto cavalliero, ne son contentissimo.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Già che questa autorità (per vostra buona grazia) da voi altri signori mi vien conceduta, dico che si debba levar su tosto, con promissione inviolabile di lui, che tosto qui voglia perdonare a tutti, come tutti noi l'uno a l'altro facciamo, di qual si voglia offesa ricevuta, così per lo tempo passato, come per il presente, acciò tutti uniti debiamo rimanere pacificati e contenti.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Yo otra cosa no deseava y ne quedo muy contento</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>E io chiù de nullo autro me ne stracontento.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E io ancora.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Dunque, ergasi vostra signorìa in piede, signor capitanio, e abracianci come cari amici, ponendo in oblivione tutte le passate offese.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">A qui estoy, me le offereçco por muy grande amigo</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Il tutto sta bene, però è di ragione che Policinella debba dimandar perdono al signor Matamoros come a suo maggiore, poiché è rimasto vittorioso per inganno.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>É ben il dovere, obedisci Policinella.</p>
           </sp>
-          <sp>
+          <sp who="#policinella">
             <speaker><emph rend="sc">policinella</emph>.</speaker>
             <p>Signor capitanio mio carissimo, illustrissimo, gentilissimo e magnaninio, ve preo che me perdonate, ca la cannarizia e desiderio de essere banchettato e mangiare assai macarune, me ha fatto fare sto sproposeto, e ve vaso le mano, li piedi e le sole delle scarpe.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Yo te perdono, andat, pues que has mostrado ser hombre tan atrebido</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Gridate tutti (dunque) illustrissimi signori sguattari: viva viva il signor Policinella, e conducetelo di peso in cucina.</p>
           </sp>
-          <sp>
+          <sp who="#sguattari">
             <speaker><emph rend="sc">sguattari</emph>.</speaker>
             <p>Viva viva il signor Poricinella, per mare e per terra!</p>
           </sp>
           <stage>(<emph>Partono i Sguattari con Policinella. Gli altri rimangono</emph>.)</stage>
           <pb n="668"/>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Otra cosa que un tan grande engaño no podia hazerme derribar de tal manera en el suelo, aunque fueran esidas todas las piezas de artillarias del mundo</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Signor capitano, di grazia, la non si perturbi l'animo e prenda a scherzo il tutto, già che l'inganno della sua caduta a tutti è stato manifesto, e sappiamo il vostro indicibile valore.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Ha, ha, ha, ha, que me revientan los lados de risa</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Come? E di che, signor capitano?</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">De la astutia militar, que yo he usada con todos vos otros señores</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Ah, ah, ah, ah.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Di che ridi tu?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Ca veo ridere tanto de core lo signor spagnolo.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>E come, e di che, signor capitano?</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Lo diré señor. Yo, deseoso de querer perdonar a todos, y no sabiendo la manera que havia de tener de haçerlo con mi reputacion, considerando que Policinela, en ganarme en batalla, me hubiera pedida merced de perdonar a todos, he querido pelearme con el por mi gusto y contento, con deseo de ser amigo de todos, como que agora lo soy. Y si el mochacho no me atava el pie, de mi propria voluntad caydo me hubiera en el suelo, por darmele vençido, como fingì de dolermene, de manera que por tal causa, quiero todos por muy grandes amigos y ansi lo afirmo</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E chi vi crede è un asino.</p>
             <p>Signor sì, signore, è vero, poiché tutti ci siamo accorti che vi<pb n="669"/> siete aveduto del inganno e lo avete ignorato per vostro piacimento.</p>
             <p>Il concorrere con il suo bestial umore non ci arreca pregiudizio.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Dunque signore, per maggior sua grandezza e generosità, sarà bene che da oggi avanti siamo buoni amici, abbracciandovi con tutti noi.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">De muy buena gana, pues que mucho lo deseo</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>E io sommamente lo bramo.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Dunque, per qual si voglia passata e ricevuta offesa, mi dichiaro in grazia di tutti è perdonato.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Sì por cierto</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Non v'ha dubbio, già l'abbiamo stabilito.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>E chi ne vorrà dir il contrario si parte dalla ragione.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Orsù, abbracciami Scaramuzza, siamo amici.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>T'abbraccio, ma starìa pe no me contentare pe le mazzate che m'hai dato sta notte.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Già che siamo tutti (mercé del Cielo) con gran contento pacificati, dico, signor capitan Matamoros, che desidero sapere da lei qual cagione vi mosse a venire impetuosamente a tôrmi Lucilla per condurla in vostra casa.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">No la tomé, señor, yo de su casa, mas bien de casa del signor Fulgentio, por darla a vuestra merced. Pero, agora que me acuerdo, deseo saber que es lo que vino hazer la noche passada en mi casa</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Signori, vi prego, già che mi avete perdonato del tutto, ad udirmi e perdonarmi di novo, se vi avesse offesi. É vero che il signor capitan Matamoros non tolse egli fuora di vostra casa la signora Lucilla, ma la levò di casa del signor Fulgenzio, e se la menò nella sua per darla a vostra signorìa, come che io da lui proprio intesi, e vi ha detto, e io di veduta ne posso far ampia fede.<pb n="670"/></p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>E come di casa di Fulgenzio? chi ve la condusse e perché?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Perché fu da me e da Policinella ingannata.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Non è questi che dice di chiamarse Antuono Cipolla quando che ne arrecò i limoni mandati da mia sorella? Come ha tanti nomi?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Signor sì, e io li fe' cambiare il nome e il tutto feci per dar maggior colore a l'inganno, che doppo di notte lo mandai dalla signora Lucilla, dandoli a credere che la signora vostra sorella stava moribonda, e che vostra signorìa la aveva mandata a chiamare in fretta, perché quella voleva far testamento e lasciarli tutti i suoi beni. E così, con molta fretta, la tolsimo fuora di casa vostra e, amorzato il lume, fingendo di condurla a casa mia per farla accendere da una mia sorella, la conducessimo in casa del signor Fulgenzio, e avendolo saputo il signor Matamoros, per via di Scaramuzza, a forza la tolse di casa de Fulgenzio e se la condusse nella sua, e io, acciò fosse moglie di lui, ne dissi il contrario.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>A dirti il vero, Volpone, tu sei un gran ribaldo.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Questo non è dubbio. Ma per servire il signor Fulgenzio, che tanto la amava, mi disposi a ciò fare, essendo stato dispreggiato da lei.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Signor capitano, di grazia la mi perdoni, se io vi ho tenuto in cattiva considerazione.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Antes, que yo he de pedir perdono a vuestra merced del agravio que yo en compania de algunos amigos le hiçe la noche passada</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Fermatevi, signore, ché sono io quello che vi ho da perdonare, poiché io fui il ricevitore delle bastonate e piatonate, ché fui preso in cambio per avermi posta la vesta e baretta del signor Alberto, che lo mandai nella vostra cantina (ridete di grazia, hà, hà, hà, hà) che queste è cose da ridere! Poiché li diedi a credere che la signora Clarice, vostra sorella, lo amava e che lo sarebbe venuto a ritrovare come sposa. E il tutto feci per cavarlo fuora di sua casa, acciò non mi avesse impedito lo aver a menar via la figliuola, e ancora,<pb n="671"/> per girmene a tôr un baccio da una certa persona che non debbo nominarla. Ridete, di grazia. Voi non ridete?</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Pues balgate el demonio, son cosas estas de reir si no de cargarte de palos</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Signor no, ché la pace è fatta e non si converebbe.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Tu hai raggione.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Deh, signor capitano mio, non bisogna più tener conto delle passate offese, perché costui averebbe ancora a far meco, che mi mandò in quella casa vòta ad aspettare una dama, e in vece di quella mi mandò un uomo, che non potei conoscerlo, e non ne fo caso alcuno.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>E ca fui io la signorìa mia, che nce veniete pe desgrazia, comme dissi primma.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Una sola cosa mi manca di sapere, se quando io uscii fuora di casa del signor capitan Matamoros, con quella che io chiamava Clarice per menarla a casa mia, se poteste sapere chi ella stata si fusse, e chi fu che mi seguitò con la spada.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Io fui quello, signore, già che dite di esser stato voi il seguitato. Ma quella, che avevate per la mano, non era la signora Clarice?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>L'ho bene a caro. E chi era di grazia?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>La signorìa mia, che po' fuiete a la cantina de lo segnor Furgenzio, e che fui schiatato de mazze da messer Vorpone e da mastro Policinella.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>E perché eri tu in abito di donna?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Pe no ne essere conosciuto da vostra signorìa, a tale che no me avisseva fatto fare despiacere, pe la chiatonata che ve diete da dereto no volenno.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Orsù, basti saper l'innocenza de le nostre donne, e le furbarìe che tu hai comesso; e perché è tempo di allegrezza, non se ne parli più, di grazia. Anzi, che io bramo che il signor Matamoros debba favorirmi de la sua presenza, unito co il signor capitan Squarcialeone, ad onorar le nozze di mia figliola con il signor Fulgenzio.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Por que la nuestra honrada y larga amistad no sea puesta en olvido, vendremos juntos y despues me haran ellos<pb n="672"/> merced de venir a las nuestras bodas, haviendo concluydo de dar mi hermana al señor capitan Squarcialeon, sustancia de la guerra</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Io molto me ne allegro, e staremo prontissimi ad ubedire i loro degni comandi.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Sì, certo, ne sarà favor singolare, e glie ne rimaremo obligati.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>E io lo riceveraggio a piacer particolare.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>E io n'ho gusto incredibile.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Il contento che io ne ho e ne avrò è indicibile.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Vi prego, signor capitan Matamoros, di concedermi per moglie Fioretta.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">El señor capitan me la pediò para Escaramuzza, su criado, no sé si ella se contenterà</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>É lo vero, signore, ca la pretenno io, e de ragione, perché so' anteriore a la domanna. E nce volimmo bene inzieme, ma non però facimo la volontà soia, e pigliase chi vo' essa.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Ha ragione, è galant'uomo Scaramuzza.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>Dunque, sarà se no bene di chiamar le donne qui da noi.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">O là, que digo, o de casa Floretta, Clariç a fuera</foreign>.</p>
           </sp>
@@ -6503,134 +6543,134 @@ umilissimo e perpetuo servitore
         <div type="scene">
           <head rend="italic">SCENA DECIMAQUARTA</head>
           <stage><hi rend="sc">fioretta, clarice</hi>, <hi rend="italic">con sudetti</hi></stage>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Questa è la voce del signor padrone. Chi batte?</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">El valiente , y vitorioso</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Vol esser valente per forza.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Mi chiama?<pb n="673"/></p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">El bravo, digo</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Nel mangiar delle minestre.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Deh, signor fratello, vi vuol altro che bell'umore, ho ben io veduto in parte le vostre disordinate perfidie. Perdonatemi, il ritrovarvi qui fra tante meritevoli persone, cagiona che io la lingua affreni, né dica ciò che dir vi doverei: bisognava far molto bene bastonar colui.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>É vero, signore.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Scioretta mia, parla adaso, ca si Pulicinella te sente auzare la voce, te desfida a comattere co isso.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">No tantas palabras. Has da saber, hermana, que por el obligo grande que tengo al señor capitan Esquarcia Leon, y tambien por sus grandes mericimientos, yo te he casada con el. No me respondas de no, porque me haras enojar y muy de veras</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Signore, per non contradire alla vostra cortesissima volontà, e per non far torto all'amor che lui ha dimostrato portarmi, son contentissima di ubidirvi.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Mucho me huelgo. Dense las manos aqui, delante de todos estos amigos y caballeros</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>Ecco, signori, glie la tocco, con promissione che in brevissimo spazio di tempo farla madre di un grande esercito d'uomeni di guerra, e tutti armati alla bizarra.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>Ed ecco ancora la mia, per conclusione del tutto.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Datemi Fioretta, signore, ché io vi prometto di farla madre di trecento sguatari di cucina.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Non sarìa meglio di ciento millia pecore?</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Sì, ché io sono un becco.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Chi ne dice lo contrario?</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p>
               <foreign xml:lang="spa">Pues que ya havemos determinado y concluydo esto, desid Floreta, quieres tu casarte?</foreign>
               <pb n="674"/>
             </p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Signor sì, perché è un gran tempo che ho desiderato marito, per non morire con la semenza nel corpo come alle zucche.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Quien quieres de los dos: Volpon o el bravo Esca ramuzza? Te doy lizençia, que te tomes quien quieres</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Signor, vi ringrazio di questa libertà. Volpone per la sua virtù è di gran merito e Scaramuzza per lo suo valore è degno d'esser amato; però, per non far torto a ciascun di loro, sarebbe cosa degna e lodabile che mi divenissero marito l'uno e 1'altro.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Sarà meglio a darti a la communità..</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Poiché ho licenzia di abbracciare il mio marito, vieni qua, Volpone mio caro.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>O maro mene, ca la perdo pe la mano.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Eccomi, sposa mia! O che ridere, che Scaramuzza n'è rimasto beffato.</p>
           </sp>
-          <sp>
+          <sp who="#fioretta">
             <speaker><emph rend="sc">fioretta</emph>.</speaker>
             <p>Va' dunque tu in mall'ora in là, e abbraccio per mio consorte il mio Scaramuzza.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuzza">
             <speaker><emph rend="sc">scaramuzza</emph>.</speaker>
             <p>Hà, hà, hà, hà, ca me schiato de ridere! E come si' restato corivo e co no parmo de naso! Adonca, co licienzia de li patrune nuostre, simo marito e mogliere.</p>
           </sp>
-          <sp>
+          <sp who="#matamoros">
             <speaker><emph rend="sc">matamoros</emph>.</speaker>
             <p><foreign xml:lang="spa">Sì ya està hecho</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#squarcialeone">
             <speaker><emph rend="sc">squarcialeone</emph>.</speaker>
             <p>É vero.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker><emph rend="sc">alberto</emph>.</speaker>
             <p>E perché a Lucilla mia ho fatto già dal signor Fulgenzio toccar la mano in casa, è bene che ella ancora venghi ad allegrarsi con la signora Clarice delle stie nozze. Di grazia chiamala, Volpone.</p>
           </sp>
-          <sp>
+          <sp who="#volpone">
             <speaker><emph rend="sc">volpone</emph>.</speaker>
             <p>Di grazia, signore, ma che occorre chiamarla se ella è qui di fuora? Signora Lucilla, il signore vostro padre dimanda.<pb n="675"/></p>
           </sp>
@@ -6641,23 +6681,23 @@ umilissimo e perpetuo servitore
             <hi rend="sc">lucilla</hi>
             <hi rend="italic">con sudetti</hi>
           </stage>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>Sono stata qui in disparte ad osservare, intenta, i vostri curiosi detti e cerimonie, e certo che non poco contento io ne ricevo, per esser così felicemente e senza scandolo sortito il tutto. E perciò molto con vostra signorìa mi allegro, signora Clarice, che siete divenuta sposa di un così valoroso capitano.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>E io ancora ne prendo sommo diletto di aver inteso che con indisolubile nodo maritale vi siete accopiati con il signor Fulgenzio.</p>
           </sp>
-          <sp>
+          <sp who="#lucilla">
             <speaker><emph rend="sc">lucilla</emph>.</speaker>
             <p>É verissimo e il tutto è stato per voler del Cielo, e per servir la mia signora Clarice.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker><emph rend="sc">clarice</emph>.</speaker>
             <p>E io a vostra signorìa, signora Lucilla.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker><emph rend="sc">fulgenzio</emph>.</speaker>
             <p>Gentilissimi signori, già la Comedia della Lucilla costante, e le ridicolose disfide di Policinella (mercè la vostra benigna grazia e grato silenzio) è fenita, e se volessi perciò entrare nel vasto oceano delle vostre lodi e infiniti meriti, sarebbe di necessità che non solo io fossi un novo Omero, un eloquente Cicerone, ma l'istesso Apollo, datore di tutte le somme grazie poetiche, e per questo dico che, dove manca il mio poco valore, supplirà il nostro molto desiderio, che con l'autore di essa abbiamo di servirla. A Dio.</p>
           </sp>

--- a/tei/foscolo-ajace.xml
+++ b/tei/foscolo-ajace.xml
@@ -82,6 +82,34 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="agamennone">
+            <persName>Agamennone</persName>
+          </person>
+          <person xml:id="ulisse">
+            <persName>Ulisse</persName>
+          </person>
+          <person xml:id="teucro">
+            <persName>Teucro</persName>
+          </person>
+          <person xml:id="calcante">
+            <persName>Calcante</persName>
+          </person>
+          <person xml:id="araldo">
+            <persName>Araldo</persName>
+          </person>
+          <person xml:id="aiace">
+            <persName>Aiace</persName>
+          </person>
+          <person xml:id="euribate">
+            <persName>Euribate</persName>
+          </person>
+          <person xml:id="tecmessa">
+            <persName>Tecmessa</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -142,7 +170,7 @@
         <div type="scene" n="Scena I">
           <head>SCENA I</head>
           <stage>AGAMENNONE, ARALDI.</stage>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l>Ite, a Priamo intimate, che alla tregua</l>
             <l>un dì rimane, e che al cader del sole</l>
@@ -161,7 +189,7 @@
         <div type="scene" n="Scena III">
           <head>SCENA III</head>
           <stage>AGAMENNONE, ULISSE.</stage>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l>Terrore è in campo, o re de' re. La turba</l>
             <l>che all'Ellesponto accompagnò gli avanzi</l>
@@ -178,13 +206,13 @@
             <l>or la pugna a bandir corron gli araldi</l>
             <l part="I">come ier m'imponesti.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="F">Ma la furia</l>
             <l>forse o la trama del terrore illude</l>
             <l part="I">anche i re delle genti?</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">Inerme il volgo</l>
             <l>lungo il lito del mar trascorre a torme</l>
@@ -197,7 +225,7 @@
             <l>varrebbe, or che travolto ha il cor di tutti</l>
             <l part="I">religiosa una demenza.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="F">Il campo</l>
             <l>me per or non vedrà. Que' numi suoi</l>
@@ -207,7 +235,7 @@
             <l>un araldo a Calcante, Augure sommo</l>
             <l>che il re supremo degli Achei lo attende.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l>Ove uno, arcano, irrevocato il cenno</l>
             <l>non sia d'un solo, il ciel spesso gli audaci</l>
@@ -219,7 +247,7 @@
             <l>di tal che forte è al par di lui, feroce</l>
             <l>più di lui forse, e ben più accorto... Aiace.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l>Intrepid'alma, altero ingegno, aperti</l>
             <l>detti, e severo amor di patria ostenta:</l>
@@ -234,12 +262,12 @@
             <l>l'alta virtù che in lui ripose il cielo</l>
             <l part="I">mi sforza quasi e ad ammirarlo.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">Ammiri?</l>
             <l part="I">Nè temi?</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="F">In me sempre starà, che Troia</l>
             <l>per Aiace non cada. E indarno il mio</l>
@@ -256,7 +284,7 @@
             <l>Ma re volgare e guerrier sommo il tengo</l>
             <l part="I">a sè dannoso, utile a noi.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">D'Achille</l>
             <l>contro te ribellante è ver che Aiace</l>
@@ -289,7 +317,7 @@
             <l>de' ribelli e del volgo, a cui sol manca</l>
             <l>un condottier che contro noi lo guidi.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l>Alta prudenza è in te. Forse talvolta,</l>
             <l>inclito Ulisse, a stimar troppo altrui</l>
@@ -304,7 +332,7 @@
             <l>del Pelide l'esempio; esempio ei stesso</l>
             <l>a tutti, ei solo insegnerà che io regno.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l>S'io temo, Atride, in parlamento io temo;</l>
             <l>in campo no, tu il sai: nè a me rileva</l>
@@ -344,13 +372,13 @@
             <l>per usarle al tuo freno, e stender quindi</l>
             <l part="I">lo scettro tuo sovra la Grecia.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="F">E il lungo</l>
             <l>dissimular finor mi spiacque; ed oggi</l>
             <l part="I">che giova?</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">E tempo di svelar tua mente</l>
             <l>e il tuo potere omai saria. Ma Achille</l>
@@ -382,22 +410,22 @@
             <l>e imprudente il nomavi. Oh non t'avvedi</l>
             <l>che arte col volgo è il disprezzar chi 'l regge?</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="I">Disprezzar – me?</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">Di quante armi si cinga</l>
             <l part="I">tu il vedi; e tempo aspetta.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="F">L'ira mia</l>
             <l>armi, consiglio, ardir, tempo e speranza</l>
             <l part="I">gli rapirà.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">Ma non la fama. Il sangue</l>
             <l>temi, se il versi venerato e pianto.</l>
@@ -406,7 +434,7 @@
             <l>rendili, e vili; e avrai dall'altrui ferro,</l>
             <l part="I">senz'odio tuo, vittime inulte.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="F">Indegni</l>
             <l>mezzi, e soverchi or che col brando impero.</l>
@@ -415,11 +443,11 @@
         <div type="scene" n="Scena IV">
           <head>SCENA IV</head>
           <stage>AGAMENNONE, ULISSE, TEUCRO.</stage>
-          <sp>
+          <sp who="#teucro">
             <speaker>TEUCRO</speaker>
             <l part="I">T'onori Giove, o re de' forti.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="F">A Dio</l>
             <l>mal s'obbedisce e al re. Dall'alba indissi</l>
@@ -430,7 +458,7 @@
             <l>credono spento col Pelide in noi</l>
             <l part="I">ogni valor?</l>
           </sp>
-          <sp>
+          <sp who="#teucro">
             <speaker>TEUCRO</speaker>
             <l part="F">Vive in noi sempre. E il campo</l>
             <l>riede a fidanza. Delle Danae genti</l>
@@ -438,11 +466,11 @@
             <l>e le fatali chieggio armi d'Achille</l>
             <l part="I">per Aiace.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="F">S'arroga egli quell'armi?</l>
           </sp>
-          <sp>
+          <sp who="#teucro">
             <speaker>TEUCRO</speaker>
             <l>Non ei; d'Achille ancor siede al sepolcro</l>
             <l>presso l'onda sigea. Quivi gli piacque</l>
@@ -451,13 +479,13 @@
             <l>Or lo chiama e lo placa, e a lui sotterra</l>
             <l>manda gemendo omai l'ultimo addio.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l>Tu, dunque, o Teucro (e generoso amore</l>
             <l>ti sprona) estimi delle sacre spoglie</l>
             <l part="I">degno il fratel.</l>
           </sp>
-          <sp>
+          <sp who="#teucro">
             <speaker>TEUCRO</speaker>
             <l part="F">Degne d'Aiace il grido</l>
             <l>universal de' popoli le stima.</l>
@@ -495,7 +523,7 @@
             <l>Chiamano Aiace a un grido solo, Aiace</l>
             <l>degno dell'armi, e domator di Troia.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l>Giovine, ardita inchiesta movi. In mente</l>
             <l>de' numi è ancor di chi fien l'armi. E tale</l>
@@ -506,14 +534,14 @@
             <l>starà l'arbitrio o in me. – Me primo elesse</l>
             <l>esecutor dei suoi consigli il cielo.</l>
           </sp>
-          <sp>
+          <sp who="#teucro">
             <speaker>TEUCRO</speaker>
             <l>Turbato parli, o re; che Aiace l'armi</l>
             <l>al par di te forse non curi estimo;</l>
             <l>non però so che viva altro mortale</l>
             <l part="I">atto a vestirle.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <stage>(<emph>agli araldi: ricevuto il cenno, uno parte</emph>)</stage>
             <l part="F">Un altro araldo all'augure</l>
@@ -524,22 +552,22 @@
         <div type="scene" n="Scena V">
           <head>SCENA V</head>
           <stage>ULISSE, TEUCRO.</stage>
-          <sp>
+          <sp who="#teucro">
             <speaker>TEUCRO</speaker>
             <l>Ira e minaccie! Tanto dunque il nostro</l>
             <l>obbedir lungo, e i detti tuoi fors'anco</l>
             <l>fan più superbo Atride? Or sia: men tarde</l>
             <l>fien e più giuste le vendette nostre.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l>Atride meco secondava i fati.</l>
           </sp>
-          <sp>
+          <sp who="#teucro">
             <speaker>TEUCRO</speaker>
             <l part="I">Tu il dici.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">Premio eran quell'armi al duce</l>
             <l>che più funesto guerreggiasse i Teucri</l>
@@ -550,7 +578,7 @@
             <l>di forti e vili. E credi tu che l'oste</l>
             <l part="I">oggi a caso imperversi?</l>
           </sp>
-          <sp>
+          <sp who="#teucro">
             <speaker>TEUCRO</speaker>
             <l part="F">Di te solo</l>
             <l>che temi ogni uom, spesso a temer mi sforzi.</l>
@@ -560,7 +588,7 @@
             <l>allor le furie drizzeranno i nostri</l>
             <l>brandi a punir le scellerate teste.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l>E più palesi alla città nemica</l>
             <l>le forsennate risse nostre allora</l>
@@ -579,38 +607,38 @@
             <l>Ma che più sto! Solo al fero cimento</l>
             <l part="I">n'andrò...</l>
           </sp>
-          <sp>
+          <sp who="#teucro">
             <speaker>TEUCRO</speaker>
             <l part="M">Tu solo?... e dove?</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">Or, poi che Aiace</l>
             <l>è lunge, andrò con la mia schiera io solo.</l>
           </sp>
-          <sp>
+          <sp who="#teucro">
             <speaker>TEUCRO</speaker>
             <l>D'Aiace or forse ami la gloria tanto? –</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="I">E lo amerò sei m'odia?</l>
           </sp>
-          <sp>
+          <sp who="#teucro">
             <speaker>TEUCRO</speaker>
             <l part="F">Mai di te</l>
             <l part="I">non parla.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">E forse nè più mai vedermi</l>
             <l>dovrà. Per voi corro a non dubbia morte.</l>
           </sp>
-          <sp>
+          <sp who="#teucro">
             <speaker>TEUCRO</speaker>
             <l part="I">Or che ti fingi?</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">E troppo dissi. Or vivi</l>
             <l>col favor degli Dei, Teucro, che il merti:</l>
@@ -628,13 +656,13 @@
             <l>guerreggieran per quelle spoglie, e in noi</l>
             <l part="I">le volgeranno.</l>
           </sp>
-          <sp>
+          <sp who="#teucro">
             <speaker>TEUCRO</speaker>
             <l part="F">Oggi si pugni: resta</l>
             <l>tempo e petto ad Aiace, ove conteso</l>
             <l part="I">gli fosse il premio.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">Guerre, infami guerre! –</l>
             <l>Quindi più onesto or m'è il periglio. Mie</l>
@@ -643,26 +671,26 @@
             <l>plachisi almen! – con l'ombra mia si plachi...</l>
             <l part="I">ma e che? Placarvi! O voi chi siete?</l>
           </sp>
-          <sp>
+          <sp who="#teucro">
             <speaker>TEUCRO</speaker>
             <l part="F">Irato</l>
             <l part="I">parti?</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="M">Meco m'adiro.</l>
           </sp>
-          <sp>
+          <sp who="#teucro">
             <speaker>TEUCRO</speaker>
             <l part="F">E di che pugna</l>
             <l part="I">parli?... ristatti. –</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">Il dir teco non giova.</l>
             <l part="I">Ch'io non ti mento il mostri l'opra.</l>
           </sp>
-          <sp>
+          <sp who="#teucro">
             <speaker>TEUCRO</speaker>
             <l part="F">Aggiri</l>
             <l>tu i re in congresso, ond'io non t'odo; e sembri</l>
@@ -670,29 +698,29 @@
             <l>tu se' mente divina, e Palla è teco.</l>
             <l part="I">Quivi mi scorgi; io pugnerò.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">Il tuo brando</l>
             <l part="I">che pro se l'ora fugge?</l>
           </sp>
-          <sp>
+          <sp who="#teucro">
             <speaker>TEUCRO</speaker>
             <l part="F">Ah parla! Incerto</l>
             <l>sto s'io ti creda; ma pietà e rossore</l>
             <l>mi vince se a cimento orrido corri</l>
             <l part="I">tu per la patria e non t'aiuto.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">E certo</l>
             <l part="I">chi mi farà del tuo silenzio?</l>
           </sp>
-          <sp>
+          <sp who="#teucro">
             <speaker>TEUCRO</speaker>
             <l part="F">Ai fati</l>
             <l>del popol Greco, e sul mio brando il giuro.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l>Delle rocche l'assalto Agamennone</l>
             <l>ad Aiace commette; ardua e mal certa</l>
@@ -713,7 +741,7 @@
             <l>che a' nemici il palesi... Addio; gran tempo</l>
             <l part="I">vuolsi a raccorre i miei...</l>
           </sp>
-          <sp>
+          <sp who="#teucro">
             <speaker>TEUCRO</speaker>
             <l part="F">Fien pochi a tanta</l>
             <l>opra. Se a te corre il nemico, a stento</l>
@@ -728,7 +756,7 @@
             <l>smentirle or puoi... Ma già ti penti... E t'odo?</l>
             <l part="I">Fosti leal tu mai?</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">D'Agamennone</l>
             <l>tal detto udimmo... nol cred'io... Ma quando</l>
@@ -736,7 +764,7 @@
             <l>fosse pria della pugna; ove tu parta</l>
             <l>fra quanti emuli suoi non lasci Aiace?</l>
           </sp>
-          <sp>
+          <sp who="#teucro">
             <speaker>TEUCRO</speaker>
             <l>Tu pur rimanti emulo suo. Per lui</l>
             <l>pugna il consenso degli Achei; la mente</l>
@@ -749,18 +777,18 @@
             <l>precipita. Tu il dici. A divisarmi</l>
             <l part="I">pregoti il loco, il tempo e il modo.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">Vieni:</l>
             <l>Dio sarà meco: pari al brando hai senno,</l>
             <l>e tua virtù magnanima mi sforza.</l>
             <l part="I">... Pur...</l>
           </sp>
-          <sp>
+          <sp who="#teucro">
             <speaker>TEUCRO</speaker>
             <l part="M">Che più ondeggi?</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">I figli miei rimembro</l>
             <l>se alla comun salute offrir la vita</l>
@@ -768,7 +796,7 @@
             <l>precideresti, o giovinetto, a noi</l>
             <l>e al venerando padre tuo canuto!</l>
           </sp>
-          <sp>
+          <sp who="#teucro">
             <speaker>TEUCRO</speaker>
             <l>Pronto al sepolcro ed alla gloria io vivo!</l>
             <l>O Telamone padre mio! Richiami</l>
@@ -784,12 +812,12 @@
         <div type="scene" n="Scena I">
           <head>SCENA I</head>
           <stage>CALCANTE, AGAMENNONE.</stage>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l>Canuto, inerme, il tuo potere io temo,</l>
             <l part="I">ma più il cielo, e l'infamia.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="F">E non ti armavi</l>
             <l>tu dello scudo, e del furor di Achille?</l>
@@ -804,7 +832,7 @@
             <l>a men astuti oracoli. – Rispondi;</l>
             <l part="I">l'armi d'Achille a chi prepari?</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="F">Il vero</l>
             <l>in me difese Achille; il ver che giova</l>
@@ -812,7 +840,7 @@
             <l>tu, cui temono tutti, il vero temi!</l>
             <l>Dirlo or dovrei difenderlo non posso.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l>Vecchio, presagi a te non chiesi; i lieti</l>
             <l>spregio e gli avversi: al detto mio rispondi:</l>
@@ -821,14 +849,14 @@
             <l>or la discerno. Ahi frodolento! ardire</l>
             <l>non hai tu dunque di nomarmi Aiace?</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l>Al grande Aiace i figli degli Achei</l>
             <l>dier l'ardue spoglie; io no: che a lui funesta</l>
             <l>e a noi di pianto e a te d'infamia forse</l>
             <l>temo la troppa sua virtù sublime.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l>Ah tu l'esalti, oggi che è polve e larva</l>
             <l>la tua vantata deità d'Achille;</l>
@@ -842,7 +870,7 @@
             <l>notte starà sul guardo tuo che al cielo</l>
             <l>furar presume l'avvenire e i fati.</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l>Però men temo chè piena imminente,</l>
             <l>non la tua, la divina ira discerno.</l>
@@ -879,12 +907,12 @@
             <l>per la tua gloria ei pugnerà, se a gloria</l>
             <l>più che a possanza, o Agamennone aspiri.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l>Gloria!... Indistinti tu mi davi, eterni</l>
             <l>di parricida e re de' regi i nomi.</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l>Misero re! Pur mi vedesti assiso</l>
             <l>sull'altar della Dea, l'intera notte,</l>
@@ -910,7 +938,7 @@
             <l>nè avrai nuovo poter senza novella</l>
             <l part="I">vittima.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="F">Al dolor mio vittime voglio.</l>
             <l>Questo infamato scettro, ecco, vel rendo:</l>
@@ -923,7 +951,7 @@
             <l>pur mi traeste, siate avvinti al giogo</l>
             <l part="I">del parricida Agamennone.</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="F">Amaro</l>
             <l>pianto i celesti move. E allor la Grecia</l>
@@ -959,7 +987,7 @@
             <l>spoglie trionfa. – Alle fraterne greche</l>
             <l>terre e a' lor numi abbi rispetto, Atride.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l>Oggi o non mai fia manifesto al mondo</l>
             <l>che fin ch'io spiro e ch'io vedrò la terra</l>
@@ -982,7 +1010,7 @@
         <div type="scene" n="Scena II">
           <head>SCENA II</head>
           <stage>AGAMENNONE, CALCANTE, ARALDO.</stage>
-          <sp>
+          <sp who="#araldo">
             <speaker>ARALDO</speaker>
             <l part="I">Aiace re de' Salamini.</l>
           </sp>
@@ -991,7 +1019,7 @@
         <div type="scene" n="Scena III">
           <head>SCENA III</head>
           <stage>AGAMENNONE, CALCANTE.</stage>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="F">In volto</l>
             <l>mi vedrai l'onta del dolor, tu solo. –</l>
@@ -1011,12 +1039,12 @@
         <div type="scene" n="Scena V">
           <head>SCENA V</head>
           <stage>CALCANTE, AIACE, GUERRIERI.</stage>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l>A che sì cinto di guerrier t'appressi</l>
             <l part="I">al padiglion del sommo duce?</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l part="F">È tenda</l>
             <l>o reggia questa? Ecco novelli armati</l>
@@ -1026,13 +1054,13 @@
             <l>signore i modi assume. Odami dunque</l>
             <l part="I">qui favellar da re.</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="F">E andrai tu, o figlio,</l>
             <l>attraverso il civil sangue a ritorti</l>
             <l>l'armi che forse... nè a te solo ei niega?</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l>Che la vittoria al sovrumano Ettorre</l>
             <l>il mio brando rapisse, e ch'ei mi basti</l>
@@ -1059,7 +1087,7 @@
             <l>abbian tal prova omai, che, se ognun trema</l>
             <l>in me la patria e la sua forza vive.</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l>I fati, la tua gloria e il nostro scampo</l>
             <l>stan nell'eccidio de' Troiani. Impresa</l>
@@ -1089,7 +1117,7 @@
             <l>spesso l'anime eccelse a disperato</l>
             <l part="I">furor strascini!</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l part="F">Fortunato vecchio</l>
             <l>quasi dall'alto dell'Olimpo miri</l>
@@ -1113,7 +1141,7 @@
         <div type="scene" n="Scena VI">
           <head>SCENA VI</head>
           <stage>ULISSE, CALCANTE, AIACE, GUERRIERI.</stage>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <stage>(<emph>proseguendo</emph>)</stage>
             <l>... Ma parmi?... o il sir degli Itacensi scorgo</l>
@@ -1124,7 +1152,7 @@
         <div type="scene" n="Scena VII">
           <head>SCENA VII</head>
           <stage>CALCANTE, AIACE, GUERRIERI.</stage>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l part="F">E a me più a lungo</l>
             <l>sarà preclusa? Egregi modi in vero</l>
@@ -1134,7 +1162,7 @@
             <l>aspettar qui s'è fatto, e che precorri</l>
             <l part="I">l'orme d'Aiace.</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="F">Odimi, deh! per poco</l>
             <l>indugia almeno il tuo proposto: almeno</l>
@@ -1148,26 +1176,26 @@
             <l>prime e innocenti vittime, tu stesso</l>
             <l part="I">li svenerai...</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l part="F">Tu parli d'imminente</l>
             <l>periglio;... siegui. – Mi contempli e gemi?</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l>Ahi sciagurati ahi sciagurati Achei! –</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l>Dal re venivi... di pietà confuso</l>
             <l part="I">eri... – Pur taci?</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="F">Aiace al mio silenzio</l>
             <l part="I">abbi rispetto!</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l part="F">Orribile un arcano</l>
             <l>io leggo già sul tuo volto smarrito. –</l>
@@ -1177,7 +1205,7 @@
             <l>e padre e specchio di virtù fra tanta</l>
             <l>comun viltà, tu i fati miei seconda.</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l>L'ara al trono s'appoggia: empi e innocenti,</l>
             <l>leggi ed altar seppellirà s'ei crolla.</l>
@@ -1194,7 +1222,7 @@
         <div type="scene" n="Scena VIII">
           <head>SCENA VIII</head>
           <stage>AIACE, GUERRIERI.</stage>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l>De' suoi terrori il fatal vecchio, oh come</l>
             <l>m'innonda! – Afflitto in me gli occhi volgea</l>
@@ -1221,12 +1249,12 @@
         <div type="scene" n="Scena X">
           <head>SCENA X</head>
           <stage>AIACE, AGAMENNONE, ULISSE.</stage>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l>Signor, te a lungo attesi; e a te veniva.</l>
             <l>Ragion dell'armi e del divieto io chieggio.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l>Illustre figlio di Laerte, i regi</l>
             <l>sien convocati. Principe Nestorre</l>
@@ -1237,7 +1265,7 @@
         <div type="scene" n="Scena XI">
           <head>SCENA XI</head>
           <stage>AIACE, AGAMENNONE.</stage>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l>Signor, m'ascolta. Noi finor divisi</l>
             <l>fummo: te indusse inopportuno zelo</l>
@@ -1257,7 +1285,7 @@
             <l>Ma vo' aperto il tuo sdegno, onde non forse</l>
             <l>a te, ben più che a me torni funesto.</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l>A te, signor? Se alle paterne leggi</l>
             <l>tu sei custode; se pietà del nostro</l>
@@ -1265,7 +1293,7 @@
             <l>fama ti vince; a me funesto o a Troia</l>
             <l part="I">sarò...</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="F">Ma intanto abbiam trofei le tombe</l>
             <l>che la discordia empia di greche vite:</l>
@@ -1278,12 +1306,12 @@
             <l>a chi fia più ribelle, e a te commessa,</l>
             <l part="I">a te...</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l part="F">Se intendi appormi insidie vili,</l>
             <l>cessiam; nè udirti nè scolparmi io deggio.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l>Cieco nel tuo valor corri sull'orme</l>
             <l>ov'altri te precipita. Nè i soli</l>
@@ -1291,12 +1319,12 @@
             <l>se n'hai... tal larva di virtù mostrarti</l>
             <l>può, che per essa ver me reo ti faccia.</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l>Consigli odo, o minaccie? Io del divieto</l>
             <l part="I">ragion dianzi ti chiesi.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="F">Agamennone</l>
             <l>minaccia oprando. – Or piena odi ragione.</l>
@@ -1305,7 +1333,7 @@
             <l>o lo presume; ivi contendi. Troia</l>
             <l>mai non cadrà, mai per l'acciar d'Achille.</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l>Eternamente odierai dunque Achille?</l>
             <l>Ma tue vendette primo ei non assunse</l>
@@ -1318,11 +1346,11 @@
             <l>unica quasi di cadenti padri.</l>
             <l>E chi tentò scettro serbarti e figlia?...</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l>– Che ogn'uom mi versi quel sangue sul volto!</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l>... Fremi?... Obbliate cose io mi credea</l>
             <l>rammentarti, obbliate; e da gran tempo.</l>
@@ -1342,11 +1370,11 @@
             <l>o fratel mio, forse or mi nomi all'ombre</l>
             <l>di lor che teco divorò la guerra!</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="I">Pur me fuggivi.</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l part="F">E tu il volevi. Cupo</l>
             <l>solitario, assoluto, in te ogni dolce</l>
@@ -1383,16 +1411,16 @@
             <l>qual ch'ei pur sia de' regi: ov'altri il rompa,</l>
             <l>a vendicarlo io nuoterò nel sangue.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="I">Signor, te aspetta l'assemblea.</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l part="F">Potremo</l>
             <l part="I">i nostri fati oggi discerner.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="F">Oggi.</l>
           </sp>
@@ -1404,14 +1432,14 @@
         <div type="scene" n="Scena I">
           <head>SCENA I</head>
           <stage>ULISSE, ARALDO.</stage>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l>Dunque nel tempio ei siede? E vi salìa</l>
             <l>sì conturbato che appressar non l'osi?</l>
             <l>Or va: me solo il tuo signore attende: –</l>
             <l part="I">... pur ti soffermi appiè del colle?</l>
           </sp>
-          <sp>
+          <sp who="#euribate">
             <speaker>EURIBATE</speaker>
             <l part="F">Il sire</l>
             <l>scende.</l>
@@ -1420,7 +1448,7 @@
         <div type="scene" n="Scena II">
           <head>SCENA II</head>
           <stage>AGAMENNONE, ULISSE, ARALDO.</stage>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l>Euribate, il campo mio precluso</l>
             <l>a tutti sia finchè sta meco Ulisse.</l>
@@ -1430,23 +1458,23 @@
         <div type="scene" n="Scena III">
           <head>SCENA III</head>
           <stage>AGAMENNONE, ULISSE.</stage>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="I">Sciolto è il consesso, o re de' re.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="F">L'evento?</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="I">Dubbio.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="M">Dubbio!</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">Sedeano i regi, e surto</l>
             <l>Nestore primo dal suo trono indisse</l>
@@ -1461,12 +1489,12 @@
             <l>nè più fe' motto: con la fronte al petto,</l>
             <l>solo, e raccolto in sè, muto sedeva.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l>Disdirsi a' Numi non s'addice; e sia:</l>
             <l part="I">ma tacciano.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">Nè alcun l'armi chiedea.</l>
             <l>A Idomeneo possente re, la gara</l>
@@ -1480,7 +1508,7 @@
             <l>in assemblea son dubitanti, muti.</l>
             <l part="I">Agevolmente io li ritrassi.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="F">Adunque</l>
             <l>tu in consigli converti ogni mio cenno.</l>
@@ -1493,7 +1521,7 @@
             <l>di molti io volli aprire il campo. Achille</l>
             <l>abbiasi eredi, tranne Aiace, tutti.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l>Che? nè guidar, nè disunire i voti,</l>
             <l>comandarli volevi? A te sommessi</l>
@@ -1509,12 +1537,12 @@
             <l>ombra co' regi e con Aiace stava;</l>
             <l part="I">non m'atterrì, l'armi sue chiesi.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="F">Quindi,</l>
             <l>e mel previdi, rimovevi ogni altro.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l>S'altri l'audacia, l'eloquenza, e l'arti</l>
             <l>frenar potea del tuo nemico, ascolta:</l>
@@ -1531,11 +1559,11 @@
             <l>lo serbò Ulisse» grida Aiace, «meco,</l>
             <l>ed al trionfo di maggior nemico».</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="I">E chi ardiva ascoltarlo!</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">Il nome tuo</l>
             <l>non proferì. – La gloria degli eroi</l>
@@ -1572,13 +1600,13 @@
             <l>nel clamore, ne' fremiti, nei cenni</l>
             <l part="I">quel dì membravan.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="F">Stupefatto il membri,</l>
             <l>parmi... tu. – A farmi più tremendo Aiace</l>
             <l part="I">forse?...</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">Pur oggi a me dicevi, o sire,</l>
             <l>che tu lo ammiri. E lodator suo primo</l>
@@ -1598,23 +1626,23 @@
             <l>assumer io?» – Mostrai il mio petto; e inerme</l>
             <l part="I">qual tu mi vedi io stava.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="F">O mal conosco</l>
             <l>Ulisse; o tu nell'adunanza a un tempo</l>
             <l>eri e tra il volgo; e ordisti quel clamore</l>
             <l part="I">dell'armi.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">... Mio... nè il negherò fu in parte.</l>
             <l>Ma e Teucro ov'era? in assemblea nol vidi.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="I">Teucro! – Non v'era?</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">Ei no. Ben il Locrese</l>
             <l>Aiace armato di tutte armi e ritto</l>
@@ -1630,16 +1658,16 @@
             <l>Calcante: e incerta fu dei re la mente. –</l>
             <l>Allor partito necessario estremo...</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="I">E qual?</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">Preaccennato io te l'avea...</l>
             <l>Sagace a te, ma poco regio parve...</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l>Che agli stranieri prigionier la lite</l>
             <l>si deferisca? – Arti non mie. Me dunque,</l>
@@ -1650,7 +1678,7 @@
             <l>voi che movete il volgo, indi il temete;</l>
             <l part="I">ei se ne avvede.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">Aiace spegni... e Ulisse</l>
             <l>dunque: incitate abbiam le schiere entrambi.</l>
@@ -1664,12 +1692,12 @@
             <l>A' prigionieri occulto un cenno ingiungi:</l>
             <l part="I">miseri sono, e obbediranno.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="F">Abbietto</l>
             <l part="I">partito... – e piacque?</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">A tutti no. Ma quete</l>
             <l>così vedean le risse. Indizio n'ebbe</l>
@@ -1678,11 +1706,11 @@
             <l>commendando propose. Ebbe l'assenso</l>
             <l part="I">dei più.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="M">E d'Aiace?</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">Non l'udiva: a lui</l>
             <l>più tempo innanzi susurrò il Locrese</l>
@@ -1690,17 +1718,17 @@
             <l>precipitò i destrieri alle sue tende. –</l>
             <l part="I">... Tumultuar odi qui presso?...</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <stage>(<emph>di dentro</emph>)</stage>
             <l part="F">Vili,</l>
             <l part="I">prostratevi.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="F">La voce odo d'Aiace?</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="I">I tuoi custodi atterra.</l>
           </sp>
@@ -1708,28 +1736,28 @@
         <div type="scene" n="Scena IV">
           <head>SCENA IV</head>
           <stage>AGAMENNONE, ULISSE, AIACE.</stage>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="F">E chi il ribelle?</l>
             <l>Chi il furibondo che meco imperversa?</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l>Io. – Le schiere mi togli; e il cor pretendi</l>
             <l>togliermi e il ferro?... – Ecco il ripongo. Udirmi</l>
             <l>spero e insieme rispondermi vorrai.</l>
             <l part="I">Teucro dov'è?</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="F">Ciò ch'ei tramasse, io tosto</l>
             <l part="I">saprò.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">Suo duce e suo fratel non sei?</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l>Pur a te venne, o Atride, ei su le prime</l>
             <l>ore del dì, mentr'io stava con pochi</l>
@@ -1739,12 +1767,12 @@
             <l>ivi io credea. Gli mandai tosto un messo</l>
             <l part="I">che nol rinvenne.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">Fra le turbe forse</l>
             <l part="I">non l'indagava.</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l part="F">Fra le turbe stava</l>
             <l>la calunnia e il tumulto. – In parlamento</l>
@@ -1755,11 +1783,11 @@
             <l>si accingesse. Volai. Tutti partiti</l>
             <l>celatamente eran con lui gli arcieri.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="I">... Ulisse... seco rimanevi.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">E a' motti</l>
             <l>che a te presente saettò, rimasi.</l>
@@ -1776,29 +1804,29 @@
             <l>più che fratel sublime amico, forse</l>
             <l part="I">l'avria ignorato anch'egli?</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l part="F">Ove pur sia</l>
             <l>mal si accusa di trame: egli? – e tradirvi</l>
             <l>senza tradir me e la sua patria insieme</l>
             <l part="I">potria?</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">Tradir te, il fratel tuo!... – ma e sempre</l>
             <l part="I">udirmi sdegni? e sì m'abborri?...</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l part="F">Il nome</l>
             <l>tuo sempre sdegno io proferir: – ti spregio.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l>Non vile tuo commiliton m'avesti</l>
             <l part="I">spesso; e pur or tu il confessavi.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="F">E tacqui</l>
             <l>che a te rifugio fu il mio scudo spesso.</l>
@@ -1819,7 +1847,7 @@
             <l>Eaco del mio gran padre avo e d'Achille;</l>
             <l>e più tremenda la pietà mel grida. –</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l>E chi librar, chi giudicar può i merti</l>
             <l>de' vincitor meglio che i vinti? Alcuni</l>
@@ -1840,7 +1868,7 @@
             <l>finchè spiri la tregua occultamente</l>
             <l>Teucro n'andò: seco gli arcieri ha quindi.</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l>Tacito io penso se lasciarti io deggio</l>
             <l>te, di fraudi vestito e d'impudenza</l>
@@ -1849,12 +1877,12 @@
             <l>le calunnie rispingere e i sospetti</l>
             <l part="I">col ferro.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">E brando v'ha che meglio uccida</l>
             <l>un greco re? Non hai d'Ettore il brando?</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l>Ahi fatal dono! E il mio ti diedi, o forte</l>
             <l>Ettore, il mio, sul campo ove leale</l>
@@ -1865,7 +1893,7 @@
             <l>a bagnarlo di sangue, di quel sangue</l>
             <l>che tu abborrivi, e ch'io finor difesi.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l>Ed io finor tacito veggio in uno</l>
             <l>sospetti indegni, empio furor nell'altro.</l>
@@ -1893,7 +1921,7 @@
             <l>stranieri. Io il dissi; odilo ancora: Troia</l>
             <l>mai non cadrà, mai per l'acciar d'Achille.</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l>Pari alle tue, pacate odi parole. –</l>
             <l>Nessun di noi l'armi, per esse, pregia.</l>
@@ -1943,7 +1971,7 @@
             <l>Tu col terrore; io con l'amor; costui</l>
             <l>con fraudi nuove, lo trarremo al sangue.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l>Udir detti ribelli, e a tuoi furori</l>
             <l>libero abbandonarti, a te sia prova</l>
@@ -2020,7 +2048,7 @@
         <div type="scene" n="Scena II">
           <head>SCENA II</head>
           <stage>AGAMENNONE, ULISSE.</stage>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l>Pertinaci più sempre i frigi prenci</l>
             <l>dall'assegnar l'armi contese, tutti</l>
@@ -2031,12 +2059,12 @@
             <l>de' prigionieri. – Tuttavia Tecmessa</l>
             <l>quivi è col figlio, ed all'araldo il niega.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l>Oh mia stolta fidanza! – A me si tragga</l>
             <l part="I">Tecmessa.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">L'altro messaggero a' suoi</l>
             <l>accampamenti il Telamonio, ritto</l>
@@ -2044,14 +2072,14 @@
             <l>a squadronar le schiere, a cui frementi</l>
             <l>tutti d'Achille i Tessali s'uniro.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l>O Menelao, superba alma ondeggiante</l>
             <l>nè a virtù, nè a viltà nata nè al regno!</l>
             <l>Ardi s'io teco sono; ov'io ti manchi</l>
             <l part="I">tepido torni.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">Nè premio nè legge</l>
             <l>valse, nè il nome tuo con que' perversi</l>
@@ -2063,11 +2091,11 @@
             <l>additò quelle schiere; e il fero cenno</l>
             <l>mostrò all'araldo del tornar la via.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="I">Pronti son gli altri alla battaglia?</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l part="F">Tutti. –</l>
             <l>Perfido Teucro stiman molti; e ordita</l>
@@ -2076,7 +2104,7 @@
             <l>bramano a te, che se a civil conflitto</l>
             <l>si mova, ritrarranno essi lor armi.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="I">Odi Euribate.</l>
             <stage>(<emph>Euribate s'accosta; Agamennone gli parla all'orecchio; Euribate parte</emph>)</stage>
@@ -2098,7 +2126,7 @@
         <div type="scene" n="Scena III">
           <head>SCENA III</head>
           <stage>AGAMENNONE, TECMESSA, DONZELLE FRIGIE, ARALDO.</stage>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l>Vien ch'io ti veggia, o sposa del sublime</l>
             <l>propugnator di libertà. Fra queste</l>
@@ -2119,16 +2147,16 @@
             <l>E più nel velo ti ravvolgi? – Schiava</l>
             <l part="I">svelati.</l>
           </sp>
-          <sp>
+          <sp who="#tecmessa">
             <speaker>TECMESSA</speaker>
             <l part="F">O Sante Deità de' nostri</l>
             <l part="I">distrutti altari, ah m'aiutate!</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="F">Parla.</l>
           </sp>
-          <sp>
+          <sp who="#tecmessa">
             <speaker>TECMESSA</speaker>
             <l>... Da che all'urna d'Achille il signor mio</l>
             <l>andò, nol vidi;... ohimè! ben aspre cure</l>
@@ -2155,25 +2183,25 @@
             <l>vedo appena i guerrieri; e il tuo sembiante</l>
             <l>talor da lunge io riguardai tremando.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l>Ma non tremavi trafugando il tuo</l>
             <l part="I">figlio.</l>
           </sp>
-          <sp>
+          <sp who="#tecmessa">
             <speaker>TECMESSA</speaker>
             <l part="M">Già in salvo egli era.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="M">E il loco?</l>
           </sp>
-          <sp>
+          <sp who="#tecmessa">
             <speaker>TECMESSA</speaker>
             <l part="F">Ah forse..,</l>
             <l part="I">signor tu non sei padre.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="F">... Io?... fui padre.</l>
           </sp>
@@ -2181,7 +2209,7 @@
         <div type="scene" n="Scena IV">
           <head>SCENA IV</head>
           <stage>AGAMENNONE, TECMESSA, DONZELLE FRIGIE, ARALDI, CALCANTE.</stage>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l>O re de' re, corri a battaglia, e i numi</l>
             <l>del popol tuo teco non hai? nè l'aure</l>
@@ -2193,7 +2221,7 @@
             <l>tu sei che il nostro re pria della pugna</l>
             <l>offre agli Dei; – ma non morrai tu sola.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l>Tua morte a me, nè tua vita rileva.</l>
             <l>Gl'Iddii presenti il mondo teme. A voi</l>
@@ -2207,12 +2235,12 @@
         <div type="scene" n="Scena V">
           <head>SCENA V</head>
           <stage>AGAMENNONE, CALCANTE, TECMESSA, DONZELLE. ARALDI, AIACE <emph>preceduto da un araldo</emph>.</stage>
-          <sp>
+          <sp who="#tecmessa">
             <speaker>TECMESSA</speaker>
             <l part="F">O padre</l>
             <l part="I">del figlio mio!... pur ti riveggio.</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l part="F">... Oh iniqui! ...</l>
             <l>Tu qui! – Ben posso io trartene... ma... loco</l>
@@ -2232,7 +2260,7 @@
             <l>da' domestici Dei; tu la tua fede,</l>
             <l part="I">appena data, rompi.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="F">A voi le trame</l>
             <l>romper intendo; ma da voi fur pria</l>
@@ -2262,13 +2290,13 @@
             <l>a' magnanimi detti onde tu velo</l>
             <l>festi alle insidie; or te conosco: trema.</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l>Tremi colui, che sogna fraudi; trema</l>
             <l>tu che a' rimorsi e al terror che in te provi,</l>
             <l part="I">indur vorresti ogni alto core.</l>
           </sp>
-          <sp>
+          <sp who="#tecmessa">
             <speaker>TECMESSA</speaker>
             <l part="F">Oh Aiace!... –</l>
             <l>Tu che pur gemi all'altrui pianto, i miei</l>
@@ -2277,7 +2305,7 @@
             <l>con me che forse t'amo unica al mondo</l>
             <l>sarai? – Potessi almen perir io sola!</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l>Dir parole di pace era pensiero</l>
             <l>vostro, e agl'insulti trascorrete? Aperte</l>
@@ -2295,7 +2323,7 @@
             <l>eternamente, appena l'ossa e l'urna,</l>
             <l>nè l'urna forse rivedran di voi!</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l>Ascolta dunque, o Agamennon. Tradito</l>
             <l>o traditore esser dee Teucro; quindi</l>
@@ -2310,7 +2338,7 @@
             <l>le trame scopra, e il campo acheo non veda</l>
             <l>di fraterni cadaveri profano.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l>Non nel mio padiglione, in campo il sole</l>
             <l>mi mostri estinto, o tal, che mai più meco</l>
@@ -2334,14 +2362,14 @@
             <l>a strugger tutti d'Eaco i nepoti,</l>
             <l part="I">lo svenerò.</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l part="F">Perchè io mi prostri, devi</l>
             <l>evocar la tua figlia e ricomporre</l>
             <l>le ossa che a cena orrenda il padre tuo</l>
             <l>teco imbandiva al suo fratel Tieste.</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l>O forsennati, forsennati! io veggio</l>
             <l>l'inespiata ira d'Iddio chiamarvi</l>
@@ -2375,7 +2403,7 @@
             <l>pietà, e le voci ti soffoca il pianto.</l>
             <l>Qui presso è un colle ed un altar... Mi segui.</l>
           </sp>
-          <sp>
+          <sp who="#tecmessa">
             <speaker>TECMESSA</speaker>
             <l>A me ti volgi, o signor mio; deh porgi</l>
             <l>a me la destra, che mi trasse un giorno</l>
@@ -2384,30 +2412,30 @@
             <l>chi mi consola?... Ohimè! corri; in periglio</l>
             <l part="I">forse è il mio figlio...</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l part="F">Serva d'altri io mai</l>
             <l part="I">vederti meco! – ...</l>
           </sp>
-          <sp>
+          <sp who="#tecmessa">
             <speaker>TECMESSA</speaker>
             <l part="M">Il figlio mio...</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l part="F">Di tutti</l>
             <l>noi solo, o donna, il figliuol tuo fia salvo.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="I">Guardie, traete a voi la schiava.</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l part="F">A voi</l>
             <l>dunque traete il signor vostro esangue...</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l>Non profanate gli occhi miei di sangue,</l>
             <l>empi! o ch'io torco in voi l'ire de' Greci. –</l>
@@ -2421,14 +2449,14 @@
         <div type="scene" n="Scena VI">
           <head>SCENA VI</head>
           <stage>AGAMENNONE, AIACE.</stage>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l>Va; la mia fè ti giovi. Il campo io movo</l>
             <l>ver le dardanie rocche; e sarà face</l>
             <l>al sentier mio l'incendio delle tende</l>
             <l part="I">de' prigionieri.</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l part="F">O crudelmente astuto!</l>
             <l>ben fuggi il sol; ben nella notte fidi!</l>
@@ -2449,7 +2477,7 @@
             <l>finchè sicura e libera non sia</l>
             <l part="I">la Grecia meco.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="F">Il loco ove perisse</l>
             <l>Agamennone atterrirà voi tutti</l>
@@ -2478,7 +2506,7 @@
         <div type="scene" n="Scena VIII">
           <head>SCENA VIII</head>
           <stage>AIACE, ULISSE.</stage>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULISSE</speaker>
             <l>Pur ti trovo: t'arresta. Al tuo disprezzo</l>
             <l>è pari alfin la mia vendetta. O Aiace,</l>
@@ -2521,21 +2549,21 @@
         <div type="scene" n="Scena I">
           <head>SCENA I</head>
           <stage>CALCANTE, TECMESSA, DONZELLE FRIGIE.</stage>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="I">Fuggi, misera... Scendi.</l>
           </sp>
-          <sp>
+          <sp who="#tecmessa">
             <speaker>TECMESSA</speaker>
             <l part="M">Ahi!</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="F">Dall'orrendo</l>
             <l>spettacolo, voi donne, a piè dei colle</l>
             <l part="I">sottraetela.</l>
           </sp>
-          <sp>
+          <sp who="#tecmessa">
             <speaker>TECMESSA</speaker>
             <l part="F">Il foco ahi! li divora. –</l>
             <stage>(<emph>scendendo</emph>)</stage>
@@ -2584,7 +2612,7 @@
             <l>cader Aiace?... Ah! gridagli che seco</l>
             <l part="I">corre a perir la moglie sua.</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="F">Rimane</l>
             <l>languida vampa all'arse tende; e il fumo</l>
@@ -2597,7 +2625,7 @@
             <l>Voi difendete l'are vostre, o Numi!...</l>
             <l part="I">Ma e questa donna a un tempo udite.</l>
           </sp>
-          <sp>
+          <sp who="#tecmessa">
             <speaker>TECMESSA</speaker>
             <l part="F">Ah i numi</l>
             <l>da che infelice io fui, più non m'udiro!</l>
@@ -2610,13 +2638,13 @@
             <l>nella mia reggia. Allor m'udiva il cielo;</l>
             <l part="I">allor ch'io non gemeva!</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="F">O desolata</l>
             <l>giovine! oppressa dal cordoglio immenso</l>
             <l part="I">delira.</l>
           </sp>
-          <sp>
+          <sp who="#tecmessa">
             <speaker>TECMESSA</speaker>
             <l part="F">E oh quante vergini guidavano</l>
             <l>meco le danze; e zefiro sciogliea</l>
@@ -2634,16 +2662,16 @@
             <l>la mia chioma recisa; e sotterrarle</l>
             <l>nelle rovine dell'avita reggia.</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="I">O sanguinosa alba tu sorgi!</l>
           </sp>
-          <sp>
+          <sp who="#tecmessa">
             <speaker>TECMESSA</speaker>
             <l part="F">Orrenda</l>
             <l part="I">del sacro vecchio odo la voce!</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="F">L'asta</l>
             <l>del Telamonio, o re de' re, ti giunge;</l>
@@ -2671,7 +2699,7 @@
             <l>e a' Salamini inerme; e l'odon tutti,</l>
             <l>torcendo ad Ilio furibondi il volto. –</l>
           </sp>
-          <sp>
+          <sp who="#tecmessa">
             <speaker>TECMESSA</speaker>
             <l>...Spaventoso silenzio!... E non fremea</l>
             <l>di minacce, di carri e di omicidi</l>
@@ -2679,7 +2707,7 @@
             <l>il burrascoso muggito del mare. –</l>
             <l>O! vi siete tra voi svenati tutti!</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l>Rapido il campo su le vie di Troia</l>
             <l>s'affretta. – Aiace,... Aiace solo a noi</l>
@@ -2690,11 +2718,11 @@
         <div type="scene" n="Scena II">
           <head>SCENA II</head>
           <stage>CALCANTE, TECMESSA, DONZELLE FRIGIE, AIACE.</stage>
-          <sp>
+          <sp who="#tecmessa">
             <speaker>TECMESSA</speaker>
             <l>O signor mio!... tu vivi; unico vivi...</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l>Nella mia nave è il figliuol nostro; al mare</l>
             <l>fuggi; solingo è il campo: avrai fidata</l>
@@ -2708,13 +2736,13 @@
             <l>e in me tien fitta l'arida pupilla.</l>
             <l part="I">... Breve ed incerta ora m'avanza!</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="F">Al fato</l>
             <l>il lutto in parte, e solo in parte, il lutto</l>
             <l part="I">che a noi prepara or pagheremo!</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l part="F">... Sorge</l>
             <l>sorge, o Calcante, a' Greci il dì supremo.</l>
@@ -2746,26 +2774,26 @@
             <l>che fia non so: tutti siam noi traditi.</l>
             <l part="I">E solo tu, forse tu solo...</l>
           </sp>
-          <sp>
+          <sp who="#tecmessa">
             <speaker>TECMESSA</speaker>
             <l part="F">O morte!</l>
             <l part="I">Vieni.</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l part="F">Tu va... deh! spento è il nostro sangue</l>
             <l part="I">se tardi.</l>
           </sp>
-          <sp>
+          <sp who="#tecmessa">
             <speaker>TECMESSA</speaker>
             <l part="M">E tu?...</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l part="F">Io? – vado ove andar deggio:</l>
             <l>tu starai forse senza me gran tempo.</l>
           </sp>
-          <sp>
+          <sp who="#tecmessa">
             <speaker>TECMESSA</speaker>
             <l part="I">Gran tempo!...</l>
             <stage>
@@ -2790,7 +2818,7 @@
             <l>ch'io per te più non ho padre e fratelli;</l>
             <l>te piangerò, te seguirò sotterra.</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l>... Mi rivedrai,... se il rivedersi a' giusti</l>
             <l>non è conteso. Ma il più starti meco</l>
@@ -2807,18 +2835,18 @@
             <l>forse dagli altri or ti sarei, se indugi.</l>
             <l part="I">Addio... t'amai; t'amo, Tecmessa...</l>
           </sp>
-          <sp>
+          <sp who="#tecmessa">
             <speaker>TECMESSA</speaker>
             <l part="F">Or quando</l>
             <l>tremò, come or, la tua man nelle mie!...</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l>Cedi a' miei prieghi... lasciami... – Mi prostri</l>
             <l>il cor. Non far che i miei detti infelici</l>
             <l part="I">sieno comandi.</l>
           </sp>
-          <sp>
+          <sp who="#tecmessa">
             <speaker>TECMESSA</speaker>
             <l part="F">A queste fide ancelle</l>
             <l>e a' Dei del mar commetterò il mio figlio:</l>
@@ -2827,7 +2855,7 @@
             <l>e m'atterrisce, alcun sollievo forse</l>
             <l part="I">fia l'amor mio.</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l part="F">Tal v'ha dolor, cui nulla</l>
             <l part="I">dolcezza val che ad innasprirlo.</l>
@@ -2837,25 +2865,25 @@
         <div type="scene" n="Scena III">
           <head>SCENA III</head>
           <stage>AIACE, CALCANTE.</stage>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="F">Io tremo:</l>
             <l>che degg'io far? tu, che rivolgi in mente?</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l>Non gloria a me, nè libertà, nè speme,</l>
             <l>tranne il mio brando e questo petto ov'io</l>
             <l>piantarlo possa, a me nulla più resta.</l>
             <l>Va, di' ch'io muoio, e fia tronca ogni rissa,</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l>Oh ciel!... Tu dunque rapirai i tuoi giorni</l>
             <l>al voler degli Dei!... Tu d'inaudita</l>
             <l>colpa agli Achei primo darai l'esempio!</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l>Fellone io sembro, e viver deggio? – dove? –</l>
             <l>per chi? Fu vano tanto sangue offerto</l>
@@ -2883,14 +2911,14 @@
             <l>Va, riconcilia e salva i Greci; in tempo</l>
             <l part="I">sei forse.</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="F">... Teco noi trafiggi... e mentre</l>
             <l>l'evento ignori de' consigli eterni</l>
             <l>tu lo precidi. Indugia almen... per poco</l>
             <l part="I">spera...</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l part="F">Se il figlio orfano mio distormi,</l>
             <l>nè quella ch'io morendo amo più sempre,</l>
@@ -2917,12 +2945,12 @@
             <l>giovi il tremendo esempio... – Tu i miei fati</l>
             <l part="I">rispetta.</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="F">...Ohimè – che all'orrido proposto</l>
             <l part="I">ti lasci!... Almen...</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l part="F">E tu abbracciarmi, o giusto,</l>
             <l>potresti? Vedi di che sangue io grondo.</l>
@@ -2933,26 +2961,26 @@
             <l>nessun m'insulti e gridi: Ecco la fossa</l>
             <l part="I">d'un traditor.</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="F">E così dunque inganni</l>
             <l>la moglie tua, che a te, misera! torna?</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l>Poichè tu il brami, l'empio Ilio trionfi;</l>
             <l part="I">tu inorridisci intanto...</l>
           </sp>
           <stage>(<emph>per ferirsi</emph>)</stage>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="F">Arresta –... Addio.</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l>Men infelice di me vivi! – Addio.</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l>Gl'iniqui e i giusti un fulmin solo atterra.</l>
             <stage>(<emph>parte</emph>)</stage>
@@ -3016,37 +3044,37 @@
         <div type="scene" n="Scena VI">
           <head>SCENA VI</head>
           <stage>TECMESSA, CALCANTE, TEUCRO, AIACE, GUERRIERI.</stage>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="F">È perduto! – e ogni soccorso è vano.</l>
           </sp>
-          <sp>
+          <sp who="#tecmessa">
             <speaker>TECMESSA</speaker>
             <l>Dal suol ripiglia il ferro tuo... mi svena,</l>
             <l>o fratricida; e nell'onde il mio figlio</l>
             <l>insegui, e sovra il padre suo lo svena.</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <stage>(<emph>di dentro</emph>)</stage>
             <l part="I">O morte!... amara or sei... Ah!</l>
           </sp>
-          <sp>
+          <sp who="#tecmessa">
             <speaker>TECMESSA</speaker>
             <l part="F">Ahi! chi t'uccide,</l>
             <l part="I">o sposo mio...?</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="M">Deh!... statti...</l>
           </sp>
-          <sp>
+          <sp who="#tecmessa">
             <speaker>TECMESSA</speaker>
             <l part="F">Ohimè! sul brando</l>
             <l>si sorregge e vacilla. – O Aiace mio</l>
             <l>vieni; sul petto mio spira... io ti seguo.</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l>Ah!... – del mio cor la via... non trovò il ferro.</l>
             <l>E a tanto lutto or qui rimani... – L'elmo</l>
@@ -3055,20 +3083,20 @@
             <l>figlio... ma troppo nol rammenti... – E dove</l>
             <l>mi posi tu?... Questo è d'Atride il seggio.</l>
           </sp>
-          <sp>
+          <sp who="#teucro">
             <speaker>TEUCRO</speaker>
             <l>Nè a me un guardo rivolge... O mio fratello,</l>
             <l>non esecrarmi! Laverò col mio</l>
             <l>sangue le tue ferite; io che t'uccisi</l>
             <l part="I">e per salvar gl'ingrati Achei.</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l part="F">Gli hai salvi!</l>
             <l>Tu!... o mi deludi anche sull'urna?... Or dove</l>
             <l part="I">eri?... e quai genti ti seguian?</l>
           </sp>
-          <sp>
+          <sp who="#teucro">
             <speaker>TEUCRO</speaker>
             <l part="F">Gran turba</l>
             <l>di prigioni, e d'Ulisse eran le squadre.</l>
@@ -3077,12 +3105,12 @@
             <l>mentre alle rocche tu co' Greci avresti</l>
             <l part="I">dato l'assalto.</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l part="F">Ah!... Ben nell'empia pugna</l>
             <l part="I">pochi scontrai degli Itacensi.</l>
           </sp>
-          <sp>
+          <sp who="#teucro">
             <speaker>TEUCRO</speaker>
             <l part="F">Attesi</l>
             <l>In van sino alla prima ora notturna</l>
@@ -3108,12 +3136,12 @@
             <l>mel recar l'onde a' piedi; a mezza via</l>
             <l part="I">fu trucidato e in mar sospinto...</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l part="F">O quanti</l>
             <l>fedeli amici... io trassi meco... a morte!</l>
           </sp>
-          <sp>
+          <sp who="#teucro">
             <speaker>TEUCRO</speaker>
             <l>Spesso l'afflitta mia mente presaga</l>
             <l>mi consigliò il ritorno. Ah tardi io mossi</l>
@@ -3138,14 +3166,14 @@
             <l>quel traditor, che anelante ed esangue</l>
             <l>non domo ancor dalle ferite esulta.</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l>L'empio nei nembi ravvolgete, o venti!</l>
             <l>Deserta il pianga la sua casa! All'empio,</l>
             <l>o mari, le carpite armi togliete!</l>
             <l>Recatele alla sacra urna d'Aiace!</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l>Al tuo fratel gl'iniqui dubbi, o mio</l>
             <l>Teucro, perdona... reggimi, Tecmessa,</l>
@@ -3153,7 +3181,7 @@
             <l>esecrandoti... io più vile non moro...</l>
             <l part="I">E tu sei salvo.</l>
           </sp>
-          <sp>
+          <sp who="#teucro">
             <speaker>TEUCRO</speaker>
             <l part="F">Mi togliea dall'empie</l>
             <l>spade il sire de' Locri; ei la tua fama</l>
@@ -3166,14 +3194,14 @@
             <l>Morite almen col nostro re; struggete</l>
             <l part="I">la tenda e il trono del tiranno.</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="F">O figlio!</l>
             <l>Qui i tutelari Dei stanno e le leggi</l>
             <l>del popol nostro; il popolo a più atroci</l>
             <l part="I">colpe strascini...</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l part="F">Ah! il civil sangue... basti,</l>
             <l>o Teucro,... teco ogni sostegno a questa</l>
@@ -3188,11 +3216,11 @@
         <div type="scene" n="Scena VII">
           <head>SCENA ULTIMA</head>
           <stage>AIACE, TECMESSA, TEUCRO, CALCANTE, AGAMENNONE, ARALDO, GUERRIERI.</stage>
-          <sp>
+          <sp who="#araldo">
             <speaker>ARALDO</speaker>
             <l part="I">Il re.</l>
           </sp>
-          <sp>
+          <sp who="#aiace">
             <speaker>AIACE</speaker>
             <l part="F">Deh! vieni, coprimi col tuo</l>
             <l>velo, Calcante, coprimi... che l'occhio</l>
@@ -3201,28 +3229,28 @@
             <l part="I">o re de' re!</l>
           </sp>
           <stage>(<emph>muore</emph>)</stage>
-          <sp>
+          <sp who="#tecmessa">
             <speaker>TECMESSA</speaker>
             <l part="F">Ahi miseri! O mio figlio</l>
             <l part="I">più non hai padre!</l>
           </sp>
-          <sp>
+          <sp who="#calcante">
             <speaker>CALCANTE</speaker>
             <l part="F">Dell'eroe sopiti</l>
             <l>ecco gli errori, e le virtù del giusto.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l>O grande anima! – o a te funesta e a noi!</l>
           </sp>
-          <sp>
+          <sp who="#tecmessa">
             <speaker>TECMESSA</speaker>
             <l>Piangi? Fu poco di tua figlia il sangue</l>
             <l>alla porpora tua. Tingila in questo</l>
             <l>nè ti basti mai lagrima che il lavi,</l>
             <l part="I">ma il sangue tuo sparso da' tuoi.</l>
           </sp>
-          <sp>
+          <sp who="#agamennone">
             <speaker>AGAMENNONE</speaker>
             <l part="F">Più forte,</l>
             <l>e più esecrato, e più infelice io sono. –</l>

--- a/tei/foscolo-edippo.xml
+++ b/tei/foscolo-edippo.xml
@@ -75,6 +75,25 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="antigone">
+            <persName>Antigone</persName>
+          </person>
+          <person xml:id="edippo">
+            <persName>Edippo</persName>
+          </person>
+          <person xml:id="arcade">
+            <persName>Arcade</persName>
+          </person>
+          <person xml:id="teseo">
+            <persName>Tesèo</persName>
+          </person>
+          <person xml:id="talete">
+            <persName>Talete</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>2007-06-08T00:00:00.000+02:00</date><name>Novadata systems</name>Digitalizzazione - OCR</change>
@@ -137,7 +156,7 @@ ove morì –</p>
           <head>SCENA 1<hi rend="sup">a</hi>
                </head>
           <stage>ANTIGONE, EDIPPO.</stage>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l>Eccoci Edippo – Appena or sorge l'alba,</l>
@@ -149,14 +168,14 @@ ove morì –</p>
               <l part="I">Marmi qui stan – Siedi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Deh dove, o figlia,</l>
               <l part="I">Dove siam noi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Che dir poss'io? Per quanto</l>
@@ -171,7 +190,7 @@ ove morì –</p>
               <l part="I">In Tebe nostra...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Atene! Oh di fatale,</l>
@@ -185,7 +204,7 @@ ove morì –</p>
               <l>Meco la impronta del mio crudo fato!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l>Oh padre!... Questa, che ti stringe al seno,</l>
@@ -193,7 +212,7 @@ ove morì –</p>
               <l part="I">Il petto, Antigone non è?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Purtroppo!</l>
@@ -205,14 +224,14 @@ ove morì –</p>
               <l part="I">Gl'invocherei...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Ne i miei non s'ebbe a nullo,</l>
               <l part="I">Teco m'univa, e basta –</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Eccoti il dono</l>
@@ -221,14 +240,14 @@ ove morì –</p>
               <l>Il pianto, la miseria, e '1 tremar sempre!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l>Forse ch'il sa!... Deh nol dicevi?... Atene</l>
               <l part="I">Scopo a' tuoi voti ella non era?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Ell'era,</l>
@@ -236,7 +255,7 @@ ove morì –</p>
               <l part="I">Assente il Cielo al sangue nostro?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Almeno</l>
@@ -244,21 +263,21 @@ ove morì –</p>
               <l part="I">Nostri, trarremo...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Oh sì!... Ma a qual terracci</l>
               <l part="I">Poscia Teseo, chi l'assecura?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Meno</l>
               <l part="I">Crudo dei figli...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Oh pareggiar chi fora</l>
@@ -276,7 +295,7 @@ ove morì –</p>
               <l part="I">In quella orribil notte!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Amari giorni</l>
@@ -288,7 +307,7 @@ ove morì –</p>
               <l part="I">Rattempri...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">È ver, indol men cruda, e sensi</l>
@@ -305,7 +324,7 @@ ove morì –</p>
               <l part="I">Sangue su seggio scellerato –</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Ah tolga</l>
@@ -315,7 +334,7 @@ ove morì –</p>
               <l part="I">Tuoi...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Che puon darmi altro che morte alfine</l>
@@ -327,7 +346,7 @@ ove morì –</p>
               <l>Al tuo stato pensando, io lo versava –</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l>Oh caro padre!... Benché alto il mio duolo</l>
@@ -338,14 +357,14 @@ ove morì –</p>
               <l part="I">Tutta su me l'ira sua eterna...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">E tutta</l>
               <l>Versolla il dì, che me seguivi a Lerna –</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l>Oh che dici?... anzi io mai da te staccarmi,</l>
@@ -365,7 +384,7 @@ ove morì –</p>
               <l part="I">Starommi io sempre...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Sì... sempre... lo spero</l>
@@ -374,7 +393,7 @@ ove morì –</p>
               <l part="I">E cui chieder ricetto...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Saggio parli –</l>
@@ -386,7 +405,7 @@ ove morì –</p>
           <head>SCENA 2<hi rend="sup">a</hi>
                </head>
           <stage>EDIPPO.</stage>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l>Or va, né sai che d'un oracol crudo</l>
@@ -420,7 +439,7 @@ ove morì –</p>
           <head>SCENA 3<hi rend="sup">a</hi>
                </head>
           <stage>ANTIGONE, ARCADE, EDIPPO. 2 GUARDIE.</stage>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Or via</l>
@@ -430,7 +449,7 @@ ove morì –</p>
               <l part="I">Andarne...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARCADE</speaker>
             <lg>
               <l part="F">No, statti, gentil donzella,</l>
@@ -440,7 +459,7 @@ ove morì –</p>
               <l>Ché sacro è il loco alle ospitali tazze.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l>Oh cortese mortal, certo i tuoi detti</l>
@@ -448,14 +467,14 @@ ove morì –</p>
               <l part="I">E che in Attica siam.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARCADE</speaker>
             <lg>
               <l part="F">Non lungi Atene</l>
               <l part="I">Stassi, Colono è questa –</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Oh di qual gioja</l>
@@ -464,7 +483,7 @@ ove morì –</p>
               <l part="I">Non sorge un tempio?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARCADE</speaker>
             <lg>
               <l part="F">Ed a Nettuno – Tratto</l>
@@ -472,7 +491,7 @@ ove morì –</p>
               <l part="I">Tesèo qui mosse...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">E lunga, eterna pace,</l>
@@ -482,7 +501,7 @@ ove morì –</p>
               <l part="I">Ove, e per cui vadasi al re –</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARCADE</speaker>
             <lg>
               <l part="F">Non lieve</l>
@@ -492,19 +511,19 @@ ove morì –</p>
               <l>Oggi in Colono?... Tu d'Atene al certo...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="I">No di...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="M">Larissa abitator...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Né vili</l>
@@ -515,14 +534,14 @@ ove morì –</p>
               <l part="I">L'umil inchiesta...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Ah sì, pel Nume eterno,</l>
               <l part="I">Che qui si cole, ten preghiam...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARCADE</speaker>
             <lg>
               <l part="F">Che dirvi</l>
@@ -535,7 +554,7 @@ ove morì –</p>
               <l part="I">Poscia prometto –</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Oh qual tu sia, che grande</l>
@@ -549,7 +568,7 @@ ove morì –</p>
           <head>SCENA 4<hi rend="sup">a</hi>
                </head>
           <stage>ANTIGONE, EDIPPO.</stage>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Udisti? Oh quanta</l>
@@ -558,7 +577,7 @@ ove morì –</p>
               <l part="I">Pietà sol fora.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Ignoto, e nullo solo</l>
@@ -568,7 +587,7 @@ ove morì –</p>
               <l part="I">Quanto il fur le mie colpe –</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Or tempi andati</l>
@@ -579,7 +598,7 @@ ove morì –</p>
               <l part="I">Non indugiar, vieni.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Si vada, e '1 Cielo</l>
@@ -594,7 +613,7 @@ ove morì –</p>
           <head>SCENA 1<hi rend="sup">a</hi>
                </head>
           <stage>ANTIGONE, EDIPPO.</stage>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l>Ne te '1 rimembri? E' d'aspettarlo impose</l>
@@ -604,14 +623,14 @@ ove morì –</p>
               <l part="I">Al re potremo...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Oh sospirato istante</l>
               <l part="I">Alfin sei giunto!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Ma deh bada intanto,</l>
@@ -621,7 +640,7 @@ ove morì –</p>
               <l part="I">Di celar quai noi siamo...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">T'assecura,</l>
@@ -630,7 +649,7 @@ ove morì –</p>
               <l part="I">Dell'affetto tuo sommo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Oh santi Numi!</l>
@@ -638,7 +657,7 @@ ove morì –</p>
               <l part="I">Questo buon padre!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Oh impareggiabil donna!</l>
@@ -646,7 +665,7 @@ ove morì –</p>
               <l part="I">D'essermi figlia!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Se morirti... al fianco...</l>
@@ -654,7 +673,7 @@ ove morì –</p>
               <l part="I">Forte una voce...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Or deh!.:, con dubbi amari</l>
@@ -664,21 +683,21 @@ ove morì –</p>
               <l>Anco oltre Grecia, a noi ch'il vieterebbe?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l>Taci... sento rumor... s'apron le porte...</l>
               <l part="I">Sorgi, Tesèo s'avanza –</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Or ben me traggi</l>
               <l part="I">A lui dinanzi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="M">Aspetta... Ohimè!...</l>
@@ -689,28 +708,28 @@ ove morì –</p>
           <head>SCENA 2<hi rend="sup">a</hi>
                </head>
           <stage>TESÈO, ARCADE, EDIPPO, ANTIGONE</stage>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARCADE</speaker>
             <lg>
               <l part="F">Stranieri,</l>
               <l part="I">Eccovi il re.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Monarca alto d'Atene</l>
               <l part="I">Prostrato a' piedi tuoi...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="F">Mortal qual sia,</l>
               <l part="I">Sorgi, che vuoi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Stupore non ti prenda</l>
@@ -721,7 +740,7 @@ ove morì –</p>
               <l>Deh non abbi la inchiesta – Asilo darmi...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l>Oh chi se' tu? Donde ne vieni? Oh fera</l>
@@ -733,7 +752,7 @@ ove morì –</p>
               <l part="I">Oh misero!...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">In me d'aspro fato vedi</l>
@@ -742,13 +761,13 @@ ove morì –</p>
               <l part="I">Entro Trezene il tuo gran padre Egèo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l>E a cui venivi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Ai giochi ad Ercol sacri.</l>
@@ -761,7 +780,7 @@ ove morì –</p>
               <l part="I">La vista!...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="F">Oh come alta di te pietade</l>
@@ -771,25 +790,25 @@ ove morì –</p>
               <l part="I">Qual fu la patria tua?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="M">Tebe.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARCADE</speaker>
             <lg>
               <l part="F">Che sento!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="I">Ah noi perduti!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="F">Tebe? Oh maledetta</l>
@@ -809,7 +828,7 @@ ove morì –</p>
               <l part="I">Ai delitti d'Edippo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Anco respira</l>
@@ -824,7 +843,7 @@ ove morì –</p>
               <l>In suo soccorso i fulmini di Giove!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l>Oh ben gli sta! Ma ad un Edippo poca</l>
@@ -832,7 +851,7 @@ ove morì –</p>
               <l part="I">Soffrirne prima di morir.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Tu parli</l>
@@ -846,13 +865,13 @@ ove morì –</p>
               <l>Non volute lo trassero disveli.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="I">Che dir potrai?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Che per antiche offese</l>
@@ -920,7 +939,7 @@ ove morì –</p>
               <l part="I">Il fine impetra...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="F">E l'avrà tal ch'il merto –</l>
@@ -935,7 +954,7 @@ ove morì –</p>
               <l part="I">T'abbian tratto mi sveli.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">O re, che cerchi?</l>
@@ -948,7 +967,7 @@ ove morì –</p>
               <l>Sangue trascorra entro le fredde vene?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l>Alto mistero ne' tuoi detti io leggo...</l>
@@ -956,7 +975,7 @@ ove morì –</p>
               <l>A me cui franco pria chiedesti stanza...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l>Sacro per fama agli ospitali Numi</l>
@@ -970,32 +989,32 @@ ove morì –</p>
               <l>Saputo questa infelice mia scorta...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="I">Qual t'è costei?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="M">Figlia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="F">Né d'altra prole</l>
               <l part="I">Tu padre?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="M">Deh così nol fossi!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="F">Or come</l>
@@ -1004,32 +1023,32 @@ ove morì –</p>
               <l part="I">Fra gli altri figli?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="M">Iniqui figli!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Ahi troppo!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l>Né quanto dessi a nostra infame stirpe</l>
               <l>Anco nol son, ma un dì verranlo, spero.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="I">Gran dio quai voti!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Scellerati voti</l>
@@ -1047,13 +1066,13 @@ ove morì –</p>
               <l>Alimento di lagrime bagnato!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="I">Ma quai tue colpe...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Niun delitto al mondo</l>
@@ -1061,7 +1080,7 @@ ove morì –</p>
               <l part="I">La vita.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="F">Inver gran cose a me tu narri!</l>
@@ -1084,7 +1103,7 @@ ove morì –</p>
           <head>SCENA 3<hi rend="sup">a</hi>
                </head>
           <stage>TESÈO.</stage>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l>Qual fia costui? Tebano, esule, cieco,</l>
@@ -1103,19 +1122,19 @@ ove morì –</p>
           <head>SCENA 4<hi rend="sup">a</hi>
                </head>
           <stage>ARCADE, TESÈO.</stage>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARCADE</speaker>
             <lg>
               <l>A te di Tebe un messo parlar chiede.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="I">Odi novella!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARCADE</speaker>
             <lg>
               <l part="F">Altra ne udrai – Possente</l>
@@ -1124,7 +1143,7 @@ ove morì –</p>
               <l part="I">Verso Colono...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="F">Oh che mi narri? Tosto</l>
@@ -1142,7 +1161,7 @@ ove morì –</p>
           <head>SCENA 1<hi rend="sup">a</hi>
                </head>
           <stage>TALETE.</stage>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l>Figlio di Lajo entro Colono ardivi</l>
@@ -1162,21 +1181,21 @@ ove morì –</p>
           <head>SCENA 2<hi rend="sup">a</hi>
                </head>
           <stage>TESÈO, TALETE, ARCADE.</stage>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l part="F">Creonte</l>
               <l part="I">Signor di Tebe...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="F">Re Creonte? e quanti</l>
               <l part="I">Or regi ha Tebe?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l part="F">Per destin fatale</l>
@@ -1221,13 +1240,13 @@ ove morì –</p>
               <l>Ristretti, e chiusi entro la tomba istessa.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="I">Oh mostro!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l part="F">Alfin niun scampo a sé veggendo</l>
@@ -1240,20 +1259,20 @@ ove morì –</p>
               <l>Dessero certa del lor sangue prova.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="I">Oh degna inver prole di Cadmo!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l part="F">Il trono,</l>
               <l part="I">Vuoto di re, tiensi or Creonte...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="F">Il tenga,</l>
@@ -1264,7 +1283,7 @@ ove morì –</p>
               <l>Con orgogliosa mostra entro a' miei stati?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l>Ei tal non viene – Hanno i Teban le spade</l>
@@ -1277,13 +1296,13 @@ ove morì –</p>
               <l part="I">Smania di plebe...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="F">E a che ne vengon quindi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l>A chiederlo da te – Me primo intanto</l>
@@ -1292,27 +1311,27 @@ ove morì –</p>
               <l part="I">A Edippo, ove tu '1 renda a Tebe.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="F">E dove</l>
               <l part="I">Stassi, ch'io '1 renda?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l part="M">Entro Colono.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="F">Edippo</l>
               <l part="I">Entro Colono? Or come?... quando?...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l part="F">Indizi</l>
@@ -1321,7 +1340,7 @@ ove morì –</p>
               <l part="I">Da Antigone...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="F">Possibil fia?... Tebano</l>
@@ -1329,7 +1348,7 @@ ove morì –</p>
               <l>Olà qui tosto ambo i stranier sien scorti...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l>Giova però che in parlar modi io tenga,</l>
@@ -1338,7 +1357,7 @@ ove morì –</p>
               <l part="I">Poscia scoprirsi da se stesso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="F">Ei viene.</l>
@@ -1349,26 +1368,26 @@ ove morì –</p>
           <head>SCENA 3<hi rend="sup">a</hi>
                </head>
           <stage>EDIPPO, ANTIGONE, TESÈO, TALETE, ARCADE.</stage>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="I">Vecchio t'accosta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="M">Oh a che m'appelli?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="F">Statti,</l>
               <l part="I">Novella poscia udrai – Segui.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l part="F">Frattanto</l>
@@ -1386,13 +1405,13 @@ ove morì –</p>
               <l part="I">L'anno novello.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="M">Oh di che parla?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l part="F">Questa</l>
@@ -1408,32 +1427,32 @@ ove morì –</p>
               <l>L'età più tarde crederanlo appena.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="I">Odi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="M">Taci.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="M">Qual fia costui?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Tebano</l>
               <l part="I">Al vestir parrai.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l part="F">In dubbio Marte a lungo</l>
@@ -1461,27 +1480,27 @@ ove morì –</p>
               <l>De' due fratelli sui nudati acciari!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="I">Oh reo furor!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Padre... deh vieni... altrove</l>
               <l part="I">Andianne...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Statti... assai mi giova [...]</l>
               <l part="I">Udirne il fin.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l part="F">Pur Polinice in mezzo</l>
@@ -1508,7 +1527,7 @@ ove morì –</p>
               <l part="I">Un celato pugnal...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Oh degni figli!...</l>
@@ -1516,39 +1535,39 @@ ove morì –</p>
               <l part="I">Morte emendaste!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="M">Ohimè!... e la madre...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l part="F">Oh donna</l>
               <l part="I">Qual dura inchiesta!...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="M">Ebben?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l part="F">Oh fero giorno!</l>
               <l>Oh sventurata, e non colpevol madre!...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="I">Ahi lassa!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Or che?... che vai dicendo?... come..</l>
@@ -1556,20 +1575,20 @@ ove morì –</p>
               <l part="I">Giocasta...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l part="M">Poche eran due morti, e...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Taci,</l>
               <l part="I">Assai dicesti!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l part="F">Consumato appena</l>
@@ -1582,19 +1601,19 @@ ove morì –</p>
               <l part="I">Nel suo seno lo immerge.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Eterni Numi!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="I">E tu pur vivi Edippo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l part="F">Oh che rimembri?</l>
@@ -1603,7 +1622,7 @@ ove morì –</p>
               <l part="I">Svelar sua stanza, non che il nome...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">E 'l Cielo</l>
@@ -1641,19 +1660,19 @@ ove morì –</p>
               <l>Degli insensati, e creduli mortali!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="I">Onde tai furie?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Egli si perde!... Ahi padre...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l>Oh donna, va, scostati, fuggi, osserva</l>
@@ -1675,7 +1694,7 @@ ove morì –</p>
               <l part="I">Di lor non sia, scostati...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Oh padre, invano</l>
@@ -1683,27 +1702,27 @@ ove morì –</p>
               <l part="I">Andronne io mai...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Ma chi sei tu? Che ascondi</l>
               <l part="I">Sotto quel manto insanguinato?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Ahi lassa!...</l>
               <l part="I">Egli vaneggia!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="M">Misero!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">A che scuoti</l>
@@ -1744,7 +1763,7 @@ ove morì –</p>
               <l>Non giunge i falli ad uguagliar d'Edippo –</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l>A tai feroci, ed esecrati voti</l>
@@ -1752,33 +1771,33 @@ ove morì –</p>
               <l part="I">A che ti celi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Me celar? Che parli?</l>
               <l part="I">E '1 voglio, e '1 cerco, e tu tel pensi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="F">Or dona</l>
               <l part="I">Tregua a' tuoi sensi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Alta la serbo, addio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="I">Ferma ove vai?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Dove mi trae mio fato,</l>
@@ -1790,7 +1809,7 @@ ove morì –</p>
           <head>SCENA 4<hi rend="sup">a</hi>
                </head>
           <stage>TESÈO, TALETE, ARCADE.</stage>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l>Non si lasci, seguitelo, consiglio</l>
@@ -1805,7 +1824,7 @@ ove morì –</p>
           <head>SCENA 1<hi rend="sup">a</hi>
                </head>
           <stage>TESÈO,TALETE.</stage>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l>Dunque sperar dal gran Tesèo può Tebe</l>
@@ -1818,7 +1837,7 @@ ove morì –</p>
               <l part="I">Ne' cuor Tebani avrai.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="F">Di Tebe i mali,</l>
@@ -1828,21 +1847,21 @@ ove morì –</p>
               <l part="I">Ch'io trar nel possa ai comun voti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l part="F">Il Cielo</l>
               <l>Le tue cure magnanime secondi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l>Ma dimmi intanto di Creonte dubbia</l>
               <l part="I">Non è la fede?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l part="F">Oh re, che parli? Impune</l>
@@ -1890,7 +1909,7 @@ ove morì –</p>
               <l part="I">Ratto Creonte...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="M">Eccolo, ei viene.</l>
@@ -1901,26 +1920,26 @@ ove morì –</p>
           <head>SCENA 2<hi rend="sup">a</hi>
                </head>
           <stage>EDIPPO, TESÈO, TALETE, ARCADE.</stage>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="F">Edippo,</l>
               <l part="I">Alta cagion vuol ch'io t'appelli.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">E quale?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="I">Tosto l'udrai qui dal Tebano.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Ohimè! Qual altra</l>
@@ -1928,7 +1947,7 @@ ove morì –</p>
               <l part="I">Che a nuocer me non miri?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="F">Agli agitati</l>
@@ -1936,7 +1955,7 @@ ove morì –</p>
               <l part="I">Odilo, prego.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Or ben, ma senti, io dirti</l>
@@ -1945,7 +1964,7 @@ ove morì –</p>
               <l part="I">Bensì del re.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l part="F">Grata a Tesèo, se grata</l>
@@ -1953,14 +1972,14 @@ ove morì –</p>
               <l part="I">Gran tempo Edippo, che ramingo...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Franca</l>
               <l part="I">Vani racconti, a che ne vieni?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l part="F">Il regno,</l>
@@ -1968,7 +1987,7 @@ ove morì –</p>
               <l part="I">Per te si tien, vengo ad offrirti...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">È questa</l>
@@ -1980,38 +1999,38 @@ ove morì –</p>
               <l>Che sempre fu de' suoi pensier l'oggetto?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l part="I">Pensier più grave è il ben di Tebe...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">E tale</l>
               <l>Forse era il dì, che me cacciava in bando?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l part="I">Creonte?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="M">Sì.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l part="M">Non i tuoi figli?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">I figli</l>
@@ -2029,14 +2048,14 @@ ove morì –</p>
               <l part="I">All'eccidio di Tebe?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l part="F">Al ver t'apponi</l>
               <l part="I">Ei non vel trasse, ed i tuoi figli...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">A gara</l>
@@ -2046,7 +2065,7 @@ ove morì –</p>
               <l part="I">Al trono, ecco Creonte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l part="F">Oh se tal fosse</l>
@@ -2056,7 +2075,7 @@ ove morì –</p>
               <l>Altro che il tuo suonar nome non s'ode.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l>Oh in altro suon ben più tremendo udrassi</l>
@@ -2073,7 +2092,7 @@ ove morì –</p>
               <l part="I">Da re proscritto?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l part="F">Averti in pregio, torti</l>
@@ -2082,7 +2101,7 @@ ove morì –</p>
               <l part="I">E vendicar...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Deh, che no '1 fea pur dianzi?</l>
@@ -2091,7 +2110,7 @@ ove morì –</p>
               <l part="I">Non mi mandava?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l part="F">Aspra vendetta farne</l>
@@ -2100,7 +2119,7 @@ ove morì –</p>
               <l part="I">E ferri pronti a vendicarti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Oh iniquo</l>
@@ -2118,7 +2137,7 @@ ove morì –</p>
               <l>Per cui vorria me a sua salvezza or pegno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l>Oh vedi a cui fero livor ti porta!</l>
@@ -2128,28 +2147,28 @@ ove morì –</p>
               <l part="I">Sprone a sue voglie...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">O re, fa' ch'io non l'oda,</l>
               <l part="I">Ad Antigon mi rendi...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#talete">
             <speaker>TALETE</speaker>
             <lg>
               <l part="F">E vorrai sempre</l>
               <l part="I">Negletto, e vil...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Né al tuo garrir dai fine?</l>
               <l part="I">Me stolto, che t'udia!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="F">De' tuoi rifiuti,</l>
@@ -2161,7 +2180,7 @@ ove morì –</p>
               <l>Di quei tuoi figli le infondean nel seno?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l>Non il terror, al mal oprar sol duce</l>
@@ -2178,7 +2197,7 @@ ove morì –</p>
               <l>Poi ne corrai, qual non mertata io colsi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l>Ampia mercé nel perdonar non trovi</l>
@@ -2191,7 +2210,7 @@ ove morì –</p>
               <l>Che Edippo padre era dal re ben lungi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l>Io l'era sì – Ma passò tempo – A nullo</l>
@@ -2214,7 +2233,7 @@ ove morì –</p>
               <l part="I">Mel so, lascia ch'il segua –</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="F">Appien seguirlo</l>
@@ -2226,7 +2245,7 @@ ove morì –</p>
               <l part="I">Hai d'adamante il cuor!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Purtroppo, [...]</l>
@@ -2239,7 +2258,7 @@ ove morì –</p>
               <l part="I">Per me nol posso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="F">Ah non v'ha dunque cosa,</l>
@@ -2248,14 +2267,14 @@ ove morì –</p>
               <l part="I">Che il ben de' tuoi? Dunque hai deciso...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Ho fermo</l>
               <l part="I">Morire, anzi che trarmi a Tebe –</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="F">Oh sempre</l>
@@ -2268,7 +2287,7 @@ ove morì –</p>
               <l part="I">Saprò ben certo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Oh prodi inver voi tutti</l>
@@ -2279,13 +2298,13 @@ ove morì –</p>
               <l>Non ch'a profitto, a talento vi torna...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="I">Franco tu parli, e insulti mesci...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Insulti?</l>
@@ -2298,14 +2317,14 @@ ove morì –</p>
               <l part="I">La macchia vil d'un tradimento?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="F">Dirti</l>
               <l part="I">Potrei che nome a me mentivi...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Or senti</l>
@@ -2314,14 +2333,14 @@ ove morì –</p>
               <l part="I">Me allor dannavi, di'?...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="F">Lungi da questi</l>
               <l part="I">Lidi...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Deh a che nol fai? Lasciami, mezzo</l>
@@ -2330,7 +2349,7 @@ ove morì –</p>
               <l part="I">T'avrai tu fama.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="F">Invan t'opponi, basta;</l>
@@ -2340,7 +2359,7 @@ ove morì –</p>
               <l>Grande qual fosti, e qual meni felice! –</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l>La mia grandezza, il mio ben, la mia pace</l>
@@ -2352,7 +2371,7 @@ ove morì –</p>
               <l part="I">Me... più... tranquillo rivedrai –</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="F">Frattanto</l>
@@ -2366,14 +2385,14 @@ ove morì –</p>
               <l>Ne farei, che fora ultima per Tebe.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l>E la farai, lasso! ma allor dall'urna</l>
               <l>Ergerò invano per vederla il capo!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l>Vanne alla figlia – Intero un giorno a scerre</l>
@@ -2389,7 +2408,7 @@ ove morì –</p>
           <head>SCENA 1<hi rend="sup">a</hi>
                </head>
           <stage>EDIPPO, ANTIGONE.</stage>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l>No, da quel dì, che me cacciava a forza</l>
@@ -2424,7 +2443,7 @@ ove morì –</p>
               <l part="I">Mai non verrà di gioja!...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Oh di', qual altra</l>
@@ -2432,21 +2451,21 @@ ove morì –</p>
               <l>Che il partir teco il tuo dolore immenso?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l>Partirlo?... oh ciel!... ma se un giorno forza</l>
               <l part="I">Fosse lasciarci...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Oh chi me dal tuo fianco</l>
               <l>Sveller poma, se il cuor pria non mi svelle ?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l>Oh cessa, cessa di squarciarmi l'alma!...</l>
@@ -2455,7 +2474,7 @@ ove morì –</p>
               <l part="I">Nascer gli dei per tua sventura!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Oh credi</l>
@@ -2467,26 +2486,26 @@ ove morì –</p>
               <l>Fu in te non dessi ascriver tutto ai Numi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l>Ma questi Numi istessi, se un tremendo</l>
               <l part="I">Sagrifizio...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="M">Che parli?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="M">Oh figlia!...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Segui...</l>
@@ -2499,13 +2518,13 @@ ove morì –</p>
               <l>E immobil pendi tra i rotti singhiozzi...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="I">Chi... pianger... io?...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Sì invan celarlo or tenti.</l>
@@ -2527,7 +2546,7 @@ ove morì –</p>
               <l part="I">Colle mie mani!...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Il so... tutte rimembro...</l>
@@ -2541,26 +2560,26 @@ ove morì –</p>
               <l>Pur dessi alfin questo terribil passo...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="I">Terribil! </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Sì, lasciarci è d'uopo alfine.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l>Numi, e puoi dirlo, e non vedermi estinta</l>
               <l part="I">Caderti ai piedi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Ah no, più ferma, io spero,</l>
@@ -2569,41 +2588,41 @@ ove morì –</p>
               <l part="I">Ami Creonte?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">E dubbiar l'osi? Ah quanto,</l>
               <l>E assai più certo che te amo, l'abborro.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l>Or ben, se a disbramar la sete ardente,</l>
               <l part="I">Che ha del mio sangue...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Oh mal gli sta, che in Tebe</l>
               <l part="I">Qui non siam noi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="M">Ma in reggia siam.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Ma stanza</l>
               <l part="I">Secura il re non davaci?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Securo</l>
@@ -2611,14 +2630,14 @@ ove morì –</p>
               <l part="I">Noi siam traditi...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Oh che mai dici!... dunque</l>
               <l part="I">Togliamci or via.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Deh ch'il potrebbe! Cinti,</l>
@@ -2634,32 +2653,32 @@ ove morì –</p>
               <l part="I">Cadrò d'alma, e di sangue...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Ohimè!... non avvi</l>
               <l part="I">Dunque alcun mezzo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Uno v'ha mezzo, un solo...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="I">E quale?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="M">Oh figlia!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Basta, Edippo, basta.</l>
@@ -2670,20 +2689,20 @@ ove morì –</p>
           <head>SCENA 2<hi rend="sup">a</hi>
                </head>
           <stage>ARCADE, EDIPPO, ANTIGONE.</stage>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARCADE</speaker>
             <lg>
               <l part="I">Di', risolvesti?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Or chi se' tu cui debba</l>
               <l part="I">Del far, non far render ragion?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARCADE</speaker>
             <lg>
               <l part="F">Perdona :</l>
@@ -2691,7 +2710,7 @@ ove morì –</p>
               <l part="I">Ultima chiede.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Avralla, anco l'intero</l>
@@ -2708,7 +2727,7 @@ ove morì –</p>
           <head>SCENA 3<hi rend="sup">a</hi>
                </head>
           <stage>EDIPPO, ANTIGONE.</stage>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Udisti? Or tempo, il vedi,</l>
@@ -2719,7 +2738,7 @@ ove morì –</p>
               <l part="I">Dall'altro canto scampo, scegli.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Gelo...</l>
@@ -2727,14 +2746,14 @@ ove morì –</p>
               <l part="I">Il tuo periglio mi darà...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Ma bada...</l>
               <l part="I">Di non smentirti...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Or deh!... che vale ormai</l>
@@ -2742,19 +2761,19 @@ ove morì –</p>
               <l part="I">Non abbiam noi ?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Ma non comuni i falli –</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="I">Oh che vuoi dir?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Che del paterno sangue</l>
@@ -2770,14 +2789,14 @@ ove morì –</p>
               <l part="I">Da te prova d'amor –</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Deh che m'imponi?...</l>
               <l part="I">E tu?...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Sta... fermo il mio destin... la cura</l>
@@ -2787,40 +2806,40 @@ ove morì –</p>
               <l part="I">E avrollo poscia...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Oh mie tronche... speranze</l>
               <l part="I">Di morir teco io mi pensava...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Udisti?...</l>
               <l part="I">Or di', v'andrai?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="M">Che dir poss'io?...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Ritratti</l>
               <l part="I">Dunque...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="M">E così me lasci, o padre?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Oh cielo!</l>
@@ -2834,7 +2853,7 @@ ove morì –</p>
               <l>Che il fero don d'una angosciosa vita!...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l>Ahi fero sì... dai sospir tronchi... oppressa...</l>
@@ -2859,7 +2878,7 @@ ove morì –</p>
               <l part="I">D'Antigon tua.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">D'amor che parli, o donna,</l>
@@ -2876,13 +2895,13 @@ ove morì –</p>
               <l>Scostati, va, che basto io solo quivi...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="I">Ohimè!...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Deh va, lasciami, fuggi, vola,</l>
@@ -2899,13 +2918,13 @@ ove morì –</p>
               <l>Han potuto destarvi furor tanto?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="I">Numi!... ei vaneggia... e più non m'ode...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">L'onda</l>
@@ -2917,13 +2936,13 @@ ove morì –</p>
               <l part="I">Pace una volta!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="M">Oh Edippo!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Edippo? Or quivi</l>
@@ -2947,13 +2966,13 @@ ove morì –</p>
               <l>Nostri immortali, immortai l'odio passi –</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="I">Oh padre... oh senti...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">Or sgombra il passo, donna</l>
@@ -2965,7 +2984,7 @@ ove morì –</p>
             </lg>
           </sp>
           <stage>[trae un ferro, e s'uccide].</stage>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l>Ohimè!... Chi mi soccorre?... un freddo... gelo...</l>
@@ -2977,14 +2996,14 @@ ove morì –</p>
         <div type="scene" n="Scena ultima">
           <head>SCENA ULTIMA</head>
           <stage>TESÈO, ANTIGONE, EDIPPO, ARCADE, GUARDIE.</stage>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="F">Quai grida?... Che miro?... Tua fede</l>
               <l part="I">In tal modo serbavi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l part="F">A te serbarla</l>
@@ -2992,7 +3011,7 @@ ove morì –</p>
               <l part="I">Me seppi appieno a' tuoi spergiuri...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="F">Oh come</l>
@@ -3001,7 +3020,7 @@ ove morì –</p>
               <l part="I">Colei si strappi...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="F">Oh assassin crudo, e pago</l>
@@ -3020,7 +3039,7 @@ ove morì –</p>
               <l>Ritorcer poscia nel mio petto il giuro –</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#edippo">
             <speaker>EDIPPO</speaker>
             <lg>
               <l>Oh gioja!... in questo... ultimo... amplesso... t'abbi</l>
@@ -3029,13 +3048,13 @@ ove morì –</p>
               <l>Oh Lajo... all'ire eterne... eccomi... io... scendo...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antigone">
             <speaker>ANTIGONE</speaker>
             <lg>
               <l part="I">Ei muore... ahi lassa!...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teseo">
             <speaker>TESÈO</speaker>
             <lg>
               <l part="F">Or vieni, o donna, e in breve</l>

--- a/tei/foscolo-ricciarda.xml
+++ b/tei/foscolo-ricciarda.xml
@@ -85,6 +85,25 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="guido">
+            <persName>Guido</persName>
+          </person>
+          <person xml:id="corrado">
+            <persName>Corrado</persName>
+          </person>
+          <person xml:id="ricciarda">
+            <persName>Ricciarda</persName>
+          </person>
+          <person xml:id="guelfo">
+            <persName>Guelfo</persName>
+          </person>
+          <person xml:id="averardo">
+            <persName>Averardo</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Pavia</name>Digitalizzazione</change>
@@ -148,11 +167,11 @@
         <div type="scene">
           <head rend="italic">SCENA PRIMA</head>
           <stage rend="sc">Guido, Corrado</stage>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l>Fuggi! – Il mio duol col tuo periglio accresci.</l>
           </sp>
-          <sp>
+          <sp who="#corrado">
             <speaker>CORRADO</speaker>
             <l>Che dirò al signor mio, che lagrimando</l>
             <l>Jer m'imponea di non tornarmi al campo</l>
@@ -164,7 +183,7 @@
             <l>Il figliuol suo – Me misero! m'avanza</l>
             <l part="I">Poco omai della notte.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">Se del padre</l>
             <l>Quando a forza dal suo petto mi svelsi</l>
@@ -177,16 +196,16 @@
             <l>La mia – dal dì che la serbò Ricciarda,</l>
             <l part="I">A lei tutta io la deggio.</l>
           </sp>
-          <sp>
+          <sp who="#corrado">
             <speaker>CORRADO</speaker>
             <l part="F">E che tu speri?</l>
             <l>Che Guelfo ignori che in sua reggia vivi?</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l>Non so – ma Guelfo, ahi! di Ricciarda è padre.</l>
           </sp>
-          <sp>
+          <sp who="#corrado">
             <speaker>CORRADO</speaker>
             <l>Fremi dunque in nomarlo, e vedi sempre</l>
             <l>Non di tuo padre il reo fratello in Guelfo</l>
@@ -210,7 +229,7 @@
             <l>E pria l'amante tua misera donna,</l>
             <l>Teco strascini a orribili sciagure.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l>Perché Guelfo conosco,io mai Ricciarda</l>
             <l>Non lascerò. S'oggi ei trionfa in guerra,</l>
@@ -221,11 +240,11 @@
             <l>Con lentissime angosce e sotto il ferro</l>
             <l>Sconterà allor d'avermi amato e salvo.</l>
           </sp>
-          <sp>
+          <sp who="#corrado">
             <speaker>CORRADO</speaker>
             <l part="I">Ei fia sconfitto.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">E allor più temo – allora</l>
             <l>Pria di sua man darà Salerno al foco</l>
@@ -233,13 +252,13 @@
             <l>Gli saran le rovine; e in quelle fiamme</l>
             <l>Per torla a me seppellirà la figlia.</l>
           </sp>
-          <sp>
+          <sp who="#corrado">
             <speaker>CORRADO</speaker>
             <l>Tardar l'assalto potrem noi; spianarti</l>
             <l>Più vie che intanto al campo d'Averardo</l>
             <l part="I">Guidino teco la tua donna.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">È speme</l>
             <l>Unica; – e vana! e s'io la nutro, temo</l>
@@ -254,11 +273,11 @@
             <l>Indarno io prego? E tu mi guardi, e gemi;</l>
             <l>E mi sforzi ai rimorsi e al pianto e all'ira.</l>
           </sp>
-          <sp>
+          <sp who="#corrado">
             <speaker>CORRADO</speaker>
             <l>Dunque per sempre il padre tuo ti perde?</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l>Te perde a un tempo; e di pietoso amico</l>
             <l>Mal tu le parti con mio padre adempi.</l>
@@ -280,7 +299,7 @@
             <l>Non ch'uom mortale mai, né Iddio potrebbe</l>
             <l>Far ch'io mi parta, o snudi in guerra il brando.</l>
           </sp>
-          <sp>
+          <sp who="#corrado">
             <speaker>CORRADO</speaker>
             <l>Abbi il mio pianto, o Guido; altro non posso:</l>
             <l>Ti fia dannoso or il mio sangue. Addio. –</l>
@@ -289,7 +308,7 @@
             <l>Piglierà al certo, e ov'ei non giunga in tempo,</l>
             <l>Sappia da me dove cercarti estinto.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l>Se pur fuggir salvo potrai!... ma vieni –</l>
             <l>Quinci ti fia cauto il partir: trapassa</l>
@@ -300,14 +319,14 @@
             <l>Te il ciel guidi, o Corrado. Al padre narra,</l>
             <l>Che ingrato io son – ma e più infelice. Addio.</l>
           </sp>
-          <sp>
+          <sp who="#corrado">
             <speaker>CORRADO</speaker>
             <l>Non sia questo l'amplesso ultimo nostro!</l>
           </sp>
         </div>
         <div type="scene">
           <head rend="italic">SCENA SECONDA</head>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l>Ultimo! – almen perir dovessi io solo!</l>
             <l>Non tremerei così vilmente. – O Guido,</l>
@@ -339,28 +358,28 @@
         <div type="scene">
           <head rend="italic">SCENA TERZA</head>
           <stage rend="sc">Guido, Ricciarda</stage>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="I">Guido! – Qui sei... pur ti ritrovo!</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">Ahi come</l>
             <l>Anzi ora qui? – Misero me! ti miro</l>
             <l part="I">Pallida, incerta, ed anelante.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="F">O Guido! –</l>
             <l>Io ti credea da me diviso... e spento.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l>Che spento io cada, per te sola il temo;</l>
             <l>Ma ch'io mi parta, o donna mia, potevi</l>
             <l part="I">Crederlo tu?</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="F">Te a preghi miei pietoso</l>
             <l>Spero e che alfin ti partirai; ma dianzi</l>
@@ -378,17 +397,17 @@
             <l>Ad accertarmi se cadesti illeso</l>
             <l part="I">O a raccorti morente.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">Altri in quel luogo</l>
             <l>Perì, se il cielo nol serbò pietoso</l>
             <l part="I">Al padre mio!</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="M">Qui teco altri era?</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">Occulto</l>
             <l>Venne Corrado a ricondurmi al campo.</l>
@@ -396,7 +415,7 @@
             <l>Silenzio, e poscia irati detti e pianto;</l>
             <l>E avrà, se è spento, eterno pianto – e vano!</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l>Misera! ch'io dagli occhi miei ti perda</l>
             <l>M'è sì amaro pensier, che appena il vince</l>
@@ -407,13 +426,13 @@
             <l>Di mille insidie che ti stanno intorno,</l>
             <l part="I">Per dirti addio, per non più mai...</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">Deh il versa</l>
             <l>Sovra il mio petto sempre, e meno amaro</l>
             <l part="I">Ti fia quel pianto.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="F">Da te lunge il pianto,</l>
             <l>Che or parlando mal freno, da te lunge</l>
@@ -423,7 +442,7 @@
             <l>Dal padre mio – sull'ossa ahi!... della mia</l>
             <l part="I">Madre trafitto.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">A piangermi, né un'ora</l>
             <l>Ti lascerebbe. A me crudele il temi?</l>
@@ -442,7 +461,7 @@
             <l>Il rio decreto, ov'ei talor rammenti</l>
             <l part="I">Ch'è padre.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="F">E spesso, e con pietà il rammenta.</l>
             <l>Quanto amar può chi sé medesmo ha in odio,</l>
@@ -468,11 +487,11 @@
             <l>Di me, nol niego; ma di tutti, e molto</l>
             <l>Di sé medesmo ei trema: ed io... son rea</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="I">D'amarmi?...</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="F">No, rea non mi tenni io mai</l>
             <l>D'amarti: e innanzi che a te invano il padre</l>
@@ -491,7 +510,7 @@
             <l>Se rea... – e per farmi del tuo core indegna</l>
             <l part="I">Forse.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">Tu mai, tu del mio core indegna?</l>
             <l>Tu che a virtù mi sei sprone ed esempio?</l>
@@ -504,7 +523,7 @@
             <l>Quel ch'io più bramo; e mille volte il labbro</l>
             <l>Apro, e in silenzio doloroso il chiudo.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l>Ben io lo intendo: e oserò dirlo io prima –</l>
             <l>Dì e notte tiemmi e lusinghiero e forte</l>
@@ -528,21 +547,21 @@
             <l>Ma più di me tu d'ora in ora stai</l>
             <l part="I">Sotto la scure –... Intendi?... ei vien!...</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">D'armati</l>
             <l part="I">Son passi...</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="M">Ei vien! salvati.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">E fuggir sempre?</l>
             <l>Ahi vita indegna! – assai men grave è morte.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l>O Guido mio! pietà di me ti vinca...</l>
             <l>A sera, e avrai l'ultimo addio, qui riedo;</l>
@@ -552,43 +571,43 @@
         <div type="scene">
           <head rend="italic">SCENA QUARTA</head>
           <stage rend="sc">Ricciarda, Guelfo, Uomini d'arme</stage>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="M">Tu qui?</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="M">– Signor...</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">Smarrita – esangue –</l>
             <l>Tu qui! – Che il padre ti chiedea, sapevi?</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l>Dianzi Ruggier me l'imponea... ma quando...</l>
             <l part="I">Né dove... incerto m'era.</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">E a me più incerto</l>
             <l>Se tu in mia reggia stavi; altri ti vide</l>
             <l part="I">Dianzi avviarti fuggitiva.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="F">E parte,</l>
             <l>Questa dov'io men venni, è della tua</l>
             <l part="I">Reggia...</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">E la miglior parte. – E per me dunque</l>
             <l>Qui sì ratta venivi? ma tu cerchi,</l>
             <l>Parmi anzi tempo, tra gli avelli il padre.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l>Cerco la madre mia, se pure intende</l>
             <l>Il mio lungo dolor che a uom vivente,</l>
@@ -604,7 +623,7 @@
             <l>Vita non hai, né tu l'avrai, pur troppo!</l>
             <l>Viver degg'io sol per morir tua figlia.</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l>Qui dunque, innanzi di tua madre all'urna,</l>
             <l>Ti fia men grave fra non molto udirmi –</l>
@@ -612,11 +631,11 @@
             <l>Quel traditor, che qui notturno errava.</l>
             <l part="I">Tu il sai?</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="M">Rumor men venne...</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">E se nel viso</l>
             <l>Ben ti discerno, di pietà confusa</l>
@@ -624,11 +643,11 @@
             <l>E sai che ignoto dileguossi e illeso? –</l>
             <l part="I">Ne sarai lieta.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="M">Io? – d'uom ignoto...</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">Agli altri:</l>
             <l>A me, no – E teco io lieto son ch'ei viva.</l>
@@ -639,7 +658,7 @@
             <l>Ebber ratte le piante e tardi i brandi,</l>
             <l part="I">Opra la scure.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="F">Deh padre! – Soverchio</l>
             <l>Terror a disperata ira può indurli;</l>
@@ -650,7 +669,7 @@
             <l>I cenni tuoi di che ribrezzo umano</l>
             <l part="I">Impallidisce.</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">Vil genìa, che vende</l>
             <l>Il braccio e il cor, m'atterrirà? – Ruggiero</l>
@@ -658,12 +677,12 @@
             <l>Sovra quel sangue molto oro dispensa –</l>
             <l part="I">Or vien, Ricciarda.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="F">O che oltre modo ei finge,</l>
             <l part="I">O troppo io spero, il crede in salvo...</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">Or vieni?</l>
           </sp>
@@ -674,7 +693,7 @@
         <div type="scene">
           <head rend="italic">SCENA PRIMA</head>
           <stage rend="sc">Guelfo, Ricciarda, Uomini d'arme</stage>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l>Uberto, co' Normanni esci oltre i ponti:</l>
             <l>E all'orator del mio nemico intima</l>
@@ -685,7 +704,7 @@
         <div type="scene">
           <head rend="italic">SCENA SECONDA</head>
           <stage rend="sc">Guelfo, Ricciarda</stage>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">Qui dianzi, e a gran fatica io volli</l>
             <l>Dissimulando divorarmi l'ira</l>
@@ -699,19 +718,19 @@
             <l>Né udirlo io vo', se non perché tu meco</l>
             <l part="I">Piena risposta gli darai.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="F">Che posso</l>
             <l part="I">Dir, signor mio, che tu nol voglia?</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">E dirlo</l>
             <l>Non sol dèi tu; ma qui – su le sacre ossa</l>
             <l>Di tua madre giurarlo. Ove tu il nieghi,</l>
             <l>Saprò ch'io posso giustamente odiarti.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l>E a me il giusto odio tuo, misera, manca</l>
             <l>A veder piena la sciagura mia!...</l>
@@ -719,7 +738,7 @@
             <l>Trovi conforto nel veder ch'io merto</l>
             <l part="I">La tua pietà.</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">Assai men duro assai</l>
             <l>Sarebbe il viver mio, s'io non t'amassi;</l>
@@ -750,7 +769,7 @@
             <l>Un solo scampo hai tu; ma s'oggi il perdi,</l>
             <l part="I">Meco uscir dèi d'ogni speranza.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="F">Ah tolta</l>
             <l>M'è da che teco sei crudel. Ma pena</l>
@@ -777,7 +796,7 @@
             <l>Obliando l'offese, e alla comune</l>
             <l part="I">Pace fors'io...</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">Ma e pensi tu, che nozze</l>
             <l>E Amore acquetin gli odi? Amor diè sempre</l>
@@ -815,7 +834,7 @@
             <l>Ma innanzi all'orator, sovra queste ossa</l>
             <l>Rinunzia a Guido, e l'odio mio gli giura.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l>L'odio tuo? Qui? dove sovente a Guido</l>
             <l>Amor giurai? – Tu allor m'udivi, o Madre!</l>
@@ -836,7 +855,7 @@
             <l>Pietà dal cielo, e che distor ti possa</l>
             <l part="I">Dal morir disperato?</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">E tu pur sempre</l>
             <l>Mi fai forza alle lagrime?... Chi sei</l>
@@ -852,18 +871,18 @@
         <div type="scene">
           <head rend="italic">SCENA TERZA</head>
           <stage rend="sc">Guelfo, Averardo, Corrado, Uomini d'arme</stage>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l>Com'io intenda d'udirti, abbi argomento</l>
             <l part="I">Dal loco ov'io t'accolgo.</l>
           </sp>
-          <sp>
+          <sp who="#averardo">
             <speaker>AVERARDO</speaker>
             <l part="F">I monumenti,</l>
             <l>Signor, io veggo de'tuoi padri; e gioja</l>
             <l part="I">Essi n'avran se col fratel...</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">Non ebbi</l>
             <l>Fratelli io mai. So che scendea Tancredi,</l>
@@ -886,7 +905,7 @@
             <l>S'egli nel sangue si richiama offeso,</l>
             <l part="I">Io nella fama?</l>
           </sp>
-          <sp>
+          <sp who="#averardo">
             <speaker>AVERARDO</speaker>
             <l part="F">Assai ragion di pace</l>
             <l>Stan nelle accuse tue. Esul fuggiva</l>
@@ -901,26 +920,26 @@
             <l>Cadder – ma in campo, ed han sepolcro e fama.</l>
             <l>Vinse; e ancor regni: ecco ragion di pace.</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l>Ragion di guerra è il dirlo – Astuto meco</l>
             <l part="I">Parli, ed ardito.</l>
           </sp>
-          <sp>
+          <sp who="#averardo">
             <speaker>AVERARDO</speaker>
             <l part="F">Ardito; e più il vorrebbe</l>
             <l>Forse Averardo; astuto no, se m'odi.</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="I">Ma e tu chi sei che parli?</l>
           </sp>
-          <sp>
+          <sp who="#averardo">
             <speaker>AVERARDO</speaker>
             <l part="F">Io son Corrado;</l>
             <l part="I">Guerrier d'Arrigo un dì.</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">Ben io ti vidi</l>
             <l>Tosto all'aspetto il ghibellino core.</l>
@@ -939,7 +958,7 @@
             <l>Casa Averardo?... ed io l'avrei... pur anche...</l>
             <l>Come nell'alma, conosciuto in volto.</l>
           </sp>
-          <sp>
+          <sp who="#averardo">
             <speaker>AVERARDO</speaker>
             <l>Allor che Guido occultamente il core</l>
             <l>Pose in vergin regale, e ne fu amato</l>
@@ -956,7 +975,7 @@
             <l>Che oltre molte cagioni oggi il costringe</l>
             <l>Anche l'amor per l'infelice Italia.</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l>Amor d'Italia? A basso intento è velo</l>
             <l>Spesso: e tale oggimai s'è fatta Italia,</l>
@@ -966,7 +985,7 @@
             <l>Sterminar potess'io, tutti i suoi mille</l>
             <l>Vili signori, e più la vil sua plebe.</l>
           </sp>
-          <sp>
+          <sp who="#averardo">
             <speaker>AVERARDO</speaker>
             <l>Inerme freme, e sembra vile Italia</l>
             <l>Da che i signori suoi vietano il brando</l>
@@ -1009,7 +1028,7 @@
             <l>Fia la rovina; e degli antichi al nome</l>
             <l>L'età future aggiugneranno il nostro.</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l>Se grande Italia un tempo era, nol cerco.</l>
             <l>Qual è la vedo, e la dispregio. Io patria</l>
@@ -1026,7 +1045,7 @@
             <l>Se ragioni di pace altre non rechi,</l>
             <l part="I">Ti parti.</l>
           </sp>
-          <sp>
+          <sp who="#averardo">
             <speaker>AVERARDO</speaker>
             <l part="F">Se né patria omai né fama</l>
             <l>Ti tocca il cor, di te medesmo almeno</l>
@@ -1036,14 +1055,14 @@
             <l>Al signor mio devote, alla vittoria</l>
             <l part="I">Anelanti e alla preda.</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">Antica è l'arte,</l>
             <l>Atta sol ne' codardi, onde il nemico</l>
             <l>Vuol atterrire altrui di quel terrore</l>
             <l part="I">Ch'ei per sé prova –</l>
           </sp>
-          <sp>
+          <sp who="#averardo">
             <speaker>AVERARDO</speaker>
             <l part="F">Sì;... teme Averardo</l>
             <l>Pel figlio suo unico omai, che amore</l>
@@ -1053,20 +1072,20 @@
             <l>Che tu a forza nol tragga un dì a macchiarsi</l>
             <l part="I">Del sangue tuo.</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">Io il bramo... ov'io del suo</l>
             <l>Nol possa. Ah mai, se non se morto, e d'altra</l>
             <l>Man non vorrà ch'io vegga alfin chi egli era</l>
             <l>Quel mio fratel! – E quali patti or m'offre?</l>
           </sp>
-          <sp>
+          <sp who="#averardo">
             <speaker>AVERARDO</speaker>
             <l>Che tu Salerno e le Castella e il mare:</l>
             <l>Esso Avellino e Benevento regga;</l>
             <l part="I">E Guido in moglie abbia Ricciarda.</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">Accolti</l>
             <l>Denno esser dunque da Ricciarda i patti</l>
@@ -1079,11 +1098,11 @@
         <div type="scene">
           <head rend="italic">SCENA QUARTA</head>
           <stage rend="sc">Averardo, Corrado</stage>
-          <sp>
+          <sp who="#averardo">
             <speaker>AVERARDO</speaker>
             <l part="I">Corrado!... e il figlio mio?...</l>
           </sp>
-          <sp>
+          <sp who="#corrado">
             <speaker>CORRADO</speaker>
             <l part="F">Cauto qui riedi;</l>
             <l>Da me saprà che in grave rischio stai.</l>
@@ -1095,11 +1114,11 @@
         <div type="scene">
           <head rend="italic">SCENA PRIMA</head>
           <stage rend="sc">Corrado, Guido</stage>
-          <sp>
+          <sp who="#corrado">
             <speaker>CORRADO</speaker>
             <l part="I">Deh vien!</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">... A che?... sol per mostrarmi al padre</l>
             <l>Ingrato appieno? – Eccovi soli; inermi;</l>
@@ -1110,18 +1129,18 @@
             <l>Speme alfin torvi di mia vita. Or fatto</l>
             <l>Vile davver son io... Lascia ch'io rieda...</l>
           </sp>
-          <sp>
+          <sp who="#corrado">
             <speaker>CORRADO</speaker>
             <l>E che dir deggio?</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l>Oh ciel!... – Ma vedi queste</l>
             <l>Imbelli mie lagrime vane?... al padre</l>
             <l>Dì che celarle a tutti deggio, e a lui</l>
             <l part="I">Più che ad altr'uomo... lasciami...</l>
           </sp>
-          <sp>
+          <sp who="#corrado">
             <speaker>CORRADO</speaker>
             <l part="F">Deh Guido!</l>
             <l>Anche il vederti al padre tuo contendi?</l>
@@ -1133,12 +1152,12 @@
             <l>Or destro il tempo a favellarti e il luogo:</l>
             <l part="I">Qui Guelfo ingiunse ch'ei l'attenda...</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">Vedi...</l>
             <l part="I">Fuggir nol posso... ei vien.</l>
           </sp>
-          <sp>
+          <sp who="#corrado">
             <speaker>CORRADO</speaker>
             <l part="F">Starò da lunge</l>
             <l>Vigile intorno del tiranno ai passi.</l>
@@ -1147,21 +1166,21 @@
         <div type="scene">
           <head rend="italic">SCENA SECONDA</head>
           <stage rend="sc">Guido, Averardo</stage>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="I">... Signor...</l>
           </sp>
-          <sp>
+          <sp who="#averardo">
             <speaker>AVERARDO</speaker>
             <l part="F">Oh figlio mio! – Tu piangi? – e tremi? –</l>
             <l>Dimmi tu pur, se impallidir vedesti</l>
             <l>Mai, se non oggi, di tuo padre il volto?</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l>A pianger tu... forza mi fai; tu solo.</l>
           </sp>
-          <sp>
+          <sp who="#averardo">
             <speaker>AVERARDO</speaker>
             <l>Né gemi tu per l'onor nostro? Il nome</l>
             <l>Mentir degg'io; venir furtivo e umile</l>
@@ -1172,13 +1191,13 @@
             <l>Da vincitore io dar potrei perdono,</l>
             <l part="I">Il chieggo; e a chi!... – Sangue vuol Guelfo.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">Il nostro</l>
             <l>Incerto e poco è a dissetarlo: ei pronto</l>
             <l>Tien della figlia l'innocente sangue.</l>
           </sp>
-          <sp>
+          <sp who="#averardo">
             <speaker>AVERARDO</speaker>
             <l>Dono è di lei se ancor son padre; e il paga</l>
             <l>D'acerbissime lagrime. né mai</l>
@@ -1195,16 +1214,16 @@
             <l>Il tiranno vedrai, che dal timore</l>
             <l>Proprio e dal nostro il suo furor desume.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l>Quindi il furor fia disperato – Ahi certo,</l>
             <l>Ricciarda mia, certo il tuo scempio or veggio.</l>
           </sp>
-          <sp>
+          <sp who="#averardo">
             <speaker>AVERARDO</speaker>
             <l>E teco il mio – se patria io non avessi.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l>Signor, deh corri a vendicar quel figlio,</l>
             <l>Che non moriva ingrato; abbatti l'empio;</l>
@@ -1217,13 +1236,13 @@
             <l>Posta io l'avea nella vittoria sola</l>
             <l part="I">Di Guelfo.</l>
           </sp>
-          <sp>
+          <sp who="#averardo">
             <speaker>AVERARDO</speaker>
             <l part="F">O mio misero figlio!... Al pianto,</l>
             <l>Più che all'ira mi sforzi. E sì funesto</l>
             <l part="I">Amor t'acceca?</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">Amor, io solo il sento;</l>
             <l>Sol io mi so quanto da lunge ei scerna</l>
@@ -1243,7 +1262,7 @@
             <l>T'armi e t'arrischi, onde ti sia men grave</l>
             <l part="I">Se oggi tu il perdi.</l>
           </sp>
-          <sp>
+          <sp who="#averardo">
             <speaker>AVERARDO</speaker>
             <l part="F">Tutto perder bramo,</l>
             <l>Anzi che te; ma tutto perdo io teco</l>
@@ -1251,7 +1270,7 @@
             <l>Finché ogni umano ajuto or la deserta</l>
             <l part="I">Vergine teme o sdegna.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">Morir meco,</l>
             <l>Null'altro può, né vuol Ricciarda: e questo</l>
@@ -1269,7 +1288,7 @@
             <l>Veggo lo spettro di Ricciarda; e l'odo</l>
             <l>Parlar, e dirmi – Il padre mio m'ha uccisa.</l>
           </sp>
-          <sp>
+          <sp who="#averardo">
             <speaker>AVERARDO</speaker>
             <l>Empio il conosco; non però il presumo</l>
             <l>Sì disumano. O Guido mio! non vive</l>
@@ -1279,7 +1298,7 @@
             <l>Terror t'illude per l'amata donna;</l>
             <l part="I">Terror men vano è il mio...</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">Né tu mi salvi –</l>
             <l>Or mi costringi a seguitar tuoi passi,</l>
@@ -1299,22 +1318,22 @@
         <div type="scene">
           <head rend="italic">SCENA TERZA</head>
           <stage rend="sc">Averardo, Guido, Corrado</stage>
-          <sp>
+          <sp who="#corrado">
             <speaker>CORRADO</speaker>
             <l part="F">Lontano</l>
             <l>Guelfo non è forse da noi: le guardie</l>
             <l part="I">In armi vidi.</l>
           </sp>
-          <sp>
+          <sp who="#averardo">
             <speaker>AVERARDO</speaker>
             <l part="F">Addio... se sconosciuto</l>
             <l>Pur anche io resto, rivedrai tuo padre.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="I">A morte resti... o ciel!...</l>
           </sp>
-          <sp>
+          <sp who="#averardo">
             <speaker>AVERARDO</speaker>
             <l part="F">A prova estrema</l>
             <l>Venni, e starmi degg'io fino all'estremo. –</l>
@@ -1325,16 +1344,16 @@
             <l>Priego per te rivolgerò, che padre</l>
             <l part="I">Non sia tu mai.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">Me misero! Il tuo prego</l>
             <l>Cadrà su colei ch'esser dovea tua nuora!</l>
           </sp>
-          <sp>
+          <sp who="#corrado">
             <speaker>CORRADO</speaker>
             <l part="I">Deh! t'invola.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">Purché tu viva;... ah ch'io</l>
             <l>Più mai non tocchi la tua destra, o padre;</l>
@@ -1345,13 +1364,13 @@
         <div type="scene">
           <head rend="italic">SCENA QUARTA</head>
           <stage rend="sc">Averardo, Corrado</stage>
-          <sp>
+          <sp who="#averardo">
             <speaker>AVERARDO</speaker>
             <l part="F">E tu – tu pur, Corrado,</l>
             <l>Tu, più che figlio, sovrumano amico</l>
             <l part="I">Perir vorrai?</l>
           </sp>
-          <sp>
+          <sp who="#corrado">
             <speaker>CORRADO</speaker>
             <l part="F">Or pel tuo figlio solo</l>
             <l>Tremar dèi tu; ma per la patria io tremo,</l>
@@ -1362,14 +1381,14 @@
         <div type="scene">
           <head rend="italic">SCENA QUINTA</head>
           <stage rend="sc">Averardo, Corrado, Guelfo, Ricciarda, Uomini d'arme</stage>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">Costei,</l>
             <l>Di sé donna oggimai, darà alle offerte</l>
             <l>D'Averardo risposta alta, assoluta;</l>
             <l part="I">Né forse a grado mio.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="F">Ma qual l'attende</l>
             <l>Guelfo dalla sua figlia; e il tuo signore</l>
@@ -1382,11 +1401,11 @@
             <l>Il mio signor m'impose oggi ch'io giuri...</l>
             <l part="I">D'obbliar Guido...</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="M">Odiarlo.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="F">Io né ciò posso</l>
             <l>Che non è in mia balia; ma se il potesi,</l>
@@ -1420,14 +1439,14 @@
             <l>E dove teco m'accorrai, tel giuro,</l>
             <l part="I">Infelice, e innocente.</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">Il primo è santo;</l>
             <l>Dell'altro voto io ti sciorrò. Straniero</l>
             <l>Sposo, e lontana sepoltura avrai.</l>
             <l part="I">Esci.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="F">Non morrò d'altri – Ad Averardo</l>
             <l>Dite che il suo figlio consoli... e il salvi.</l>
@@ -1436,26 +1455,26 @@
         <div type="scene">
           <head rend="italic">SCENA SESTA</head>
           <stage rend="sc">Guelfo, Averardo, Corrado, Uomini d'arme</stage>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l>T'è assai risposto. Or quanto udisti, apporta.</l>
           </sp>
-          <sp>
+          <sp who="#averardo">
             <speaker>AVERARDO</speaker>
             <l part="I">E guerra insiem?</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">E tal che poscia il piano</l>
             <l>Sotterrar possa tutti i vostri, o i miei.</l>
           </sp>
-          <sp>
+          <sp who="#averardo">
             <speaker>AVERARDO</speaker>
             <l>Da capitano il prence mio guerreggia</l>
             <l>Sino al trionfo; né alla strage anela,</l>
             <l part="I">Né morte incauto affronta.</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">E a me si cela</l>
             <l>E mi manda i più arditi. Or dunque godi</l>
@@ -1469,27 +1488,27 @@
             <l>Tutto il mio sdegno – e tal... ch'io t'abborriva</l>
             <l part="I">Com'io ti vidi.</l>
           </sp>
-          <sp>
+          <sp who="#averardo">
             <speaker>AVERARDO</speaker>
             <l part="F">Non abborro io mai;</l>
             <l>Bensì dispregio. Or tu rompi a tua posta</l>
             <l part="I">La fede.</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">E della tua chi m'assecura?</l>
           </sp>
-          <sp>
+          <sp who="#averardo">
             <speaker>AVERARDO</speaker>
             <l part="I">Inermi siam.</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">Ma non di fraudi. Guido,</l>
             <l>Ch'altri non fu di voi, non venne ei forse</l>
             <l part="I">Qui di soppiatto?</l>
           </sp>
-          <sp>
+          <sp who="#averardo">
             <speaker>AVERARDO</speaker>
             <l part="F">Se ciò fu, la tregua</l>
             <l>Fu pattuita poscia. A giusta pena</l>
@@ -1498,7 +1517,7 @@
             <l>A te il lor duce chiederan che ostaggio</l>
             <l part="I">Lasciasti a noi.</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">Se chi t'invia, qui fosse,</l>
             <l>Non sol gli umani sdegni, e le altrui vite</l>
@@ -1513,18 +1532,18 @@
             <l>Mi seguan gli altri su le rocche, e al mare.</l>
             <l>Inevitabil pugna oggi v'appresto</l>
           </sp>
-          <sp>
+          <sp who="#averardo">
             <speaker>AVERARDO</speaker>
             <l>Del dì gran parte è corsa; e fin all'alba</l>
             <l part="I">Già fermata è la tregua.</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">Io la disdico.</l>
             <l>La notte a voi farà il mio ferro e il foco</l>
             <l part="I">Orrendo più.</l>
           </sp>
-          <sp>
+          <sp who="#averardo">
             <speaker>AVERARDO</speaker>
             <l part="F">Te preverremo: e troppa</l>
             <l>Sarà la notte alla empia strage e al lutto.</l>
@@ -1536,7 +1555,7 @@
         <div type="scene">
           <head rend="italic">SCENA PRIMA</head>
           <stage rend="sc">Ricciarda</stage>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l>Torgli il pugnal degg'io. – Né omai può salvo</l>
             <l>Fuggir per or; né oggi vorrìa lasciarmi.</l>
@@ -1556,11 +1575,11 @@
         <div type="scene">
           <head rend="italic">SCENA SECONDA</head>
           <stage rend="sc">Guido, Ricciarda</stage>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="I">Langue il dì appena, e già qui stai?</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="F">Men lieve</l>
             <l>È il mio periglio, or che con molti Guelfo</l>
@@ -1569,23 +1588,23 @@
             <l>I detti estremi deggio dirti; e amaro,</l>
             <l>Amaro più ch'io non credea... l'addio.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l>Ti scorre intorno il gel di morte – Ah ch'io</l>
             <l>Trafitto almen sia teco or dal novello</l>
             <l part="I">Stral che t'uccide.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="F">Il sei, Guido – Ti ho fatto</l>
             <l>Irrevocabilmente oggi infelice.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l>Deh parla!... E che farmi infelice or teco</l>
             <l part="I">Può, ch'io nol sappia?</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="F">A te il celai finora –</l>
             <l>Sin da quel dì che tuo fratel perìa,</l>
@@ -1599,11 +1618,11 @@
             <l>Ira e pietà l'assale, e a giurarti odio</l>
             <l part="I">Traeami...</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="M">E tu?</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="F">Spergiura esser non posso –</l>
             <l>Ma né spietata figlia. Oh se vedessi,</l>
@@ -1617,37 +1636,37 @@
             <l>Dinanzi a due de' tuoi guerrier, giurai...</l>
             <l>D'amarti sì... ma <emph>di non viver tua</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l>O Averardo, che cor quando l'udisti</l>
             <l part="I">Che cor fu il tuo!</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="M">Tuo padre!</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">E vide allora</l>
             <l>Nel mio seno e nel tuo lento piantarsi</l>
             <l>Il sol pugnale ch'io temea di Guelfo.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l>Né farsi noto a me potea, né guida</l>
             <l part="I">Io farmi a lui; ch'ei per te venne.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">E il vidi!</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l>Se fosti sordo al generoso padre,</l>
             <l>Me non udrai. Colpevol di tua morte</l>
             <l part="I">Il padre mio teco farai.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">Ricciarda</l>
             <l>Pur ti lusinghi? Ancor certa non sei</l>
@@ -1670,7 +1689,7 @@
             <l>Non troncherò: ma vile, e al mondo occulta,</l>
             <l part="I">Reggerò mia vita.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="F">S'io corressi</l>
             <l>D'altr'uomo in braccio, e tollerarlo, o Guido</l>
@@ -1696,7 +1715,7 @@
             <l>Mi segua... – Un loco evvi di pace, ov'io</l>
             <l part="I">Preceder forse ti dovrò.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">Ma il varco</l>
             <l>Il tengo io primo; e dietro guardo sempre</l>
@@ -1704,7 +1723,7 @@
             <l>D'udir sonar la tua ora suprema</l>
             <l part="I">Per mostrarti la via.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="F">Tu il puoi: né un punto,</l>
             <l>A calcar l'orme del tuo sangue, un punto</l>
@@ -1721,7 +1740,7 @@
             <l>T'aspetterà... Deh Guido! a te per ora</l>
             <l part="I">Bastin le mie lagrime estreme.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">Estreme</l>
             <l>Non fien per te, se non quando tu al cielo,</l>
@@ -1729,11 +1748,11 @@
             <l>Di virtù prove, tornerai. – Ma inulte</l>
             <l>Pur non saranno. Non morrai tu inulta.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="I">Guido, dammi quel ferro.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">Anche la fama,</l>
             <l>A non mertarmi l'ira tua, darei;</l>
@@ -1744,28 +1763,28 @@
             <l>E la memoria dell'amata donna;</l>
             <l part="I">A me non già.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="F">Dammi quel ferro, Guido.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l>A te il serbava, se per te il chiedevi;</l>
             <l>Or a me il serbo, allor che disperata</l>
             <l part="I">Sia la tua vita.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="F">Ma, se vedi armata</l>
             <l part="I">Su me la man?...</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">Basta a più morti un ferro.–</l>
             <l>Ma tu volevi a me celarlo. Morte</l>
             <l>Certa, imminente – e dal padre paventi.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l>Temo il suo cor turbato e il mio che indurmi</l>
             <l>Non può che d'altri io sia – ma l'amor tuo</l>
@@ -1778,17 +1797,17 @@
             <l>E d'esecrare ogni pietà che avesse</l>
             <l part="I">Della sua figlia.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="M">Abbi il pugnale.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="F">Oh stato!...</l>
             <l>Inerme stai se il lasci; e fra non molto</l>
             <l>Ferverà orrenda la notturna pugna.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l>Occulto assai qui sto. La pugna e l'alba</l>
             <l>Chiara faran nostra vittoria appieno.</l>
@@ -1796,21 +1815,21 @@
             <l>Che lungamente in cor mi parla, certo</l>
             <l>Son di tua morte. Utile è a Guelfo il ferro.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="I">Ohimè! – Deh Guido il tieni.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">Ma funesto</l>
             <l>In mia mano gli fia; né a te più ascondo</l>
             <l part="I">Ciò che a ragion sospetti.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="M">Oh ciel!</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">Più caro</l>
             <l>Un brando avrò, se ad Averardo infauste</l>
@@ -1818,14 +1837,14 @@
             <l>Purché tu viva, o mia Ricciarda, Guelfo</l>
             <l>Trionfi e regni, e seco t'abbia ei sempre.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l>M'avrà Dio sol. Doman, s'oggi non pero,</l>
             <l>Fuggirò all'ara. Il tempio e il vel di Cristo</l>
             <l>Mi torrà agli occhi umani. – O Guido, allora</l>
             <l>Altro rival tu non avrai che Dio.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l>Meno infelice, poiché alfin non chiudi</l>
             <l>Tutte le vie di tua salute, or sono –</l>
@@ -1833,17 +1852,17 @@
             <l>Che a Guelfo mai il suo pugnal non rieda.</l>
             <l part="I">Tremando il tolgo dal mio fianco.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="F">... Ahi rio</l>
             <l>Dubbio!... Ma, se a te il lascio, a te ed al padre</l>
             <l>Funesta e iniqua io mi sarei... – Mel porgi.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l>Fuggi; e ratto il nascondi; io tremo... Addio.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l>Ti rivedrò pria che tu parta o Guido;</l>
             <l part="I">Ti rivedrò.</l>
@@ -1851,7 +1870,7 @@
         </div>
         <div type="scene">
           <head rend="italic">SCENA TERZA</head>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="F">... Né ancor fosca è la sera;</l>
             <l>Me per la reggia ognun vedrìa col ferro...</l>
@@ -1862,7 +1881,7 @@
         <div type="scene">
           <head rend="italic">SCENA QUARTA</head>
           <stage rend="sc">Ricciarda, Guelfo, Uomini d'arme</stage>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l>Qui rintracciarti io dovrò sempre?... Un'arma</l>
             <l>Di man ti cade! – O! ti conosco atroce</l>
@@ -1873,7 +1892,7 @@
           <stage>
             <emph>Silenzio</emph>
           </stage>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l>Empia donna, t'accosta. – Al furor mio,</l>
             <l>Vedi, sottentra alfine orrida calma:</l>
@@ -1882,11 +1901,11 @@
             <l>Non ti credea di questo ferro armata.–</l>
             <l part="I">Conoscil tu?</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="M">... Di Guido... era.</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">Snudato</l>
             <l>L'hai tu per anche?... Or mira – Tu nol vedi,</l>
@@ -1910,11 +1929,11 @@
             <l>D'un nemico n'armai, per saper sempre</l>
             <l>Che impugna il ferro di quel sangue intriso.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="I">O madre mia!</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">Arretrati. Con mani</l>
             <l>Empie tu quella sepoltura abbracci –</l>
@@ -1923,11 +1942,11 @@
             <l>Destrier li vidi valicare il ponte.</l>
             <l part="I">Rispondi.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="M">Io il tolsi.</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">Dove? Come? Quando?</l>
             <l>A chi? – Perfida taci? – Ecco la notte;</l>
@@ -1935,11 +1954,11 @@
             <l>Me dal pugnar. Ma vincitore, o vinto,</l>
             <l>Tornerò a darti libertà sol io.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="I">Dal ciel l'aspetto, ed innocente.</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">Ardita</l>
             <l>Ti se' fatta ad un tratto? In te più l' onta</l>
@@ -1949,7 +1968,7 @@
             <l>Mi rivedrai: tu invan, perfida, allora</l>
             <l part="I">Eluderai le mie domande.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="F">Stava</l>
             <l>Nella tua casa il ferro. A disviarlo</l>
@@ -1962,7 +1981,7 @@
             <l>Né con quel ferro, me dall'infelice</l>
             <l part="I">Mia vita sciogli...</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">Il mio periglio cresce</l>
             <l>Quanto più tardo la vendetta mia...</l>
@@ -1996,7 +2015,7 @@
           <head rend="italic">SCENA PRIMA</head>
           <stage>Notte</stage>
           <stage rend="sc">Ricciarda, Uomini d'arme</stage>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l>Più la comune che la mia sventura</l>
             <l>Pianger dèi tu. Del cor discreto, umano</l>
@@ -2017,7 +2036,7 @@
         <div type="scene">
           <head rend="italic">SCENA SECONDA</head>
           <stage rend="sc">Guelfo, Ricciarda, Uomini d'arme, Guerrieri</stage>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l>Tempo a regnar m'avanza sol ch'io possa</l>
             <l>Morir senz'esser domo. – Ite voi dunque,</l>
@@ -2031,28 +2050,28 @@
         <div type="scene">
           <head rend="italic">SCENA TERZA</head>
           <stage rend="sc">Guelfo, Ricciarda</stage>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">Or m'odi –</l>
             <l>Dicesti tu, che sovra me pendeva</l>
             <l part="I">Il ferro?</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="M">Il dissi.</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">E tel die' Guido. Ad altri</l>
             <l>Concesso ei non avria sì caro arnese.</l>
             <l>E sol d'oggi l'avesti? – Donna, al padre</l>
             <l part="I">E al ciel tu parli dal sepolcro.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="F">D'oggi.</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l>Chi fuggì all'alba un brando avea: se questo</l>
             <l>Pensatamente ei ti recava, iniqua</l>
@@ -2067,17 +2086,17 @@
             <l>Pende da un detto il viver tuo. Rispondi:</l>
             <l part="I">Dov'è?</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="F">Qui il vidi: ma non seppi io dove</l>
             <l part="I">S'andasse.</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">Parla – Breve tempo a' detti,</l>
             <l>E alla tranquilla mia ragione avanza.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l>Qui, ove ti parlo i detti estremi, il vidi.</l>
             <l>E ch'io, signor, non menta, abbine prova</l>
@@ -2085,23 +2104,23 @@
             <l>Mel chiederesti. Né del suo furore</l>
             <l part="I">Vo' farmi rea, né di sua morte...</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">O il sangue</l>
             <l>Oggi darammi, o un sempiterno pianto.</l>
             <l>Vinto non son se ho la vendetta in pugno.</l>
             <l part="I">Ei quindi, o tu non dèi più viver.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="F">Io.</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l>Colpevol sei, se per lui mori, indegna!</l>
             <l>Colpevol più, che mel sottraggi – Or mori...</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l>Sangue versi innocente! – a me quel ferro...</l>
             <l>L'immergerò dentro il mio petto io sola...</l>
@@ -2116,12 +2135,12 @@
             <l>Mai da più dì, mi die' il ferro a non trarlo</l>
             <l>Se mi vedeva in quest'orribil punto...</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l>Ahi nuova orrida angoscia!... ei parricida</l>
             <l>Può ancor vedermi, e non potrò svenarlo!</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l>A me dunque quel ferro. Eccomi presso</l>
             <l>A mia madre per sempre: in pugno l'elsa</l>
@@ -2133,7 +2152,7 @@
             <l>Il verso io stessa, onde a te innanzi il padre</l>
             <l part="I">Del mio sangue non grondi.</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">In Dio tu fidi?</l>
             <l>In Dio che solo a vendicarsi regna?</l>
@@ -2162,11 +2181,11 @@
             <l>A terra, a terra, fatal daga... O figlia...</l>
             <l>Trammi a morir... io più viver... non deggio.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="I">Vien meco, vien...</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">Profugo prence, trova</l>
             <l>Certa una tomba mai? Potente io fui,</l>
@@ -2175,25 +2194,25 @@
             <l>Arde già... Infida una città toscana</l>
             <l>L'empiea di vele; e i miei navigli incende</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l>Apre il suo grembo agl'infelici Iddio.</l>
             <l>Padre, deh! vien... Te fuggir regalmente,</l>
             <l>Solo a salvar la figlia tua, vedranno:</l>
             <l>Avran pietà di noi prostrati all'ara.</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l>L'abbian di te; d'essi non l'ebbi io mai.</l>
             <l>Obbrobrio obbrobrio mi sarà lo scettro</l>
             <l>Se nol porto sotterra! – O donna, fuggi:</l>
             <l>Sto co' miei padri che non fur mai vili.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="I">Ch'io mai ti lasci?</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">Io del legnaggio mio</l>
             <l>Unico resto, e al nuovo sol fia spento!</l>
@@ -2202,12 +2221,12 @@
             <l>Anche dal mio cadavere il tuo pianto</l>
             <l>M'involerà?... Non m'ha già tolto i figli?</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l>Ohimè! deh torci da quell'arma il guardo...</l>
             <l>Non m'ode, ahi lassa! e più truce la mira!</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l>... Torna a me dunque, o dono orrido! – Rabbia</l>
             <l>Ti mise in cor d'un mio figliuolo. Rabbia</l>
@@ -2218,7 +2237,7 @@
           <stage>
             <emph>Silenzio.</emph>
           </stage>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l>Dov'è colui?... su le reliquie sieda</l>
             <l>Anche de'morti, io nel trarrò. – Codardo,</l>
@@ -2229,14 +2248,14 @@
         <div type="scene">
           <head rend="italic">SCENA QUARTA</head>
           <stage><emph>Ricciarda sola, abbracciando silenziosa il sepolcro di sua madre, mentre Guelfo si precipita verso le volte sotterranee</emph>.</stage>
-          <sp>
+          <sp who="#guelfo">
             <speaker><emph>La voce di</emph> GUELFO</speaker>
             <stage>(<emph>lontana</emph>)</stage>
             <l part="F">La tua</l>
             <l part="I">Donna per te morrà.</l>
           </sp>
           <stage><emph>Silenzio</emph>.</stage>
-          <sp>
+          <sp who="#guelfo">
             <speaker><emph>La voce di</emph> GUELFO</speaker>
             <stage>(<emph>ravvicinandosi</emph>)</stage>
             <l part="M">Esci, codardo!</l>
@@ -2246,19 +2265,19 @@
         <div type="scene">
           <head rend="italic">SCENA QUINTA</head>
           <stage rend="sc">Guelfo, Ricciarda</stage>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l>Ma vieni tu; perfida tu, dèi farmi</l>
             <l>Scorta a trovarlo, a scoperchiar quell'arche,</l>
             <l>A sovvertir le ceneri, e dall'ossa</l>
             <l part="I">Dissotterrarlo...</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="F">Statti... oh ciel!... Col mio</l>
             <l part="I">Spirto sol lascio la tua man.</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">Codardo!</l>
             <l>Codardo! intendi, o la tua donna è morta.</l>
@@ -2269,17 +2288,17 @@
         <div type="scene">
           <head rend="italic">SCENA SESTA</head>
           <stage rend="sc">Guelfo, Ricciarda, Guido</stage>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">T'odo.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l>Non ti sciorrai fuor di mie braccia, o padre...</l>
             <l>Morta dattorno ti starò più avvinta. –</l>
             <l part="I">Tu Guido, fuggi... deh!...</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">Costei nud'ombra</l>
             <l>Ti seguirà, se fuggi. – Non far passo;</l>
@@ -2287,7 +2306,7 @@
             <l>Non ripigli il tuo ferro, il riavrai</l>
             <l>Caldo nel petto dell'amata donna.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l>A ripigliarlo accorsi, e puro ancora</l>
             <l>Del sangue suo; non già che in te presuma</l>
@@ -2308,21 +2327,21 @@
             <l>Al mar, tua degna tomba. – Ecco mie leggi.</l>
             <l>Seguo or le tue. Immobil taccio, e aspetto.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l>Trapasseran per questo petto i colpi,</l>
             <l part="I">O forsennati...</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="M">Svolgiti...</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="F">Mio Dio!</l>
             <l>Mi togli... ch'io l'empia strage... non vegga.</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l>Non le minacce tue, ma il costei pianto</l>
             <l>Fammi perplesso; e ancor per poco – Ahi d'altro</l>
@@ -2338,7 +2357,7 @@
             <l>E se per altra via giunger non posso</l>
             <l>Sino al tuo core, il piagherò per questa.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l>Donna, se a lui basta il mio sangue, or lui</l>
             <l>D'orribil colpa, e me d'orribil vita</l>
@@ -2346,27 +2365,27 @@
             <l part="I">Guelfo...</l>
           </sp>
           <stage><emph>All'avvicinarsi di Guido, Guelfo si avventa e lo ferisce, e Ricciarda torna ad afferrargli il braccio</emph>.</stage>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="M">Ahi! – non più...</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">Fu scarso il colpo; il sangue</l>
             <l>Mi sgorga a pena, e non dal core: or vedi,</l>
             <l part="I">So più morir, che tu ferire.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="F">Or Guido,</l>
             <l part="I">Sì m'ami tu?... T'arretra!...</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">E ancor l'hai salvo!...</l>
             <l>D'armi e di faci ecco la reggia è piena...</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l>Guido siam salvi! Arretrati – mio padre</l>
             <l part="I">Non ferirà la figlia sua.</l>
@@ -2375,28 +2394,28 @@
         <div type="scene">
           <head rend="italic">SCENA ULTIMA</head>
           <stage><emph rend="sc">Guelfo, Ricciarda, Guido, Averardo, Corrado. Guerrieri</emph><emph>e</emph><emph rend="sc">Uomini d'arme</emph><emph>con fiaccole</emph>.</stage>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">Nessuno</l>
             <l>S'accosti a Guelfo; o svenerà Ricciarda.</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l>Mio fratel chi è di voi? – Mostrisi omai</l>
             <l part="I">Col trucidarmi.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="F">Lasciami, o Averardo,</l>
             <l>Il padre, a me, che t'ho serbato il figlio.</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l>Tu se' Averardo! Tu? Securo stavi</l>
             <l>Fra' carnefici miei! – Tu sciagurata,</l>
             <l part="I">Già il conoscevi?</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">In me, Guelfo, in me piena</l>
             <l>Farai vendetta; in me che il merto, e insieme</l>
@@ -2405,14 +2424,14 @@
             <l>Immolerai tu per salvarmi, o Padre?</l>
             <l part="I">Mi lascia...</l>
           </sp>
-          <sp>
+          <sp who="#averardo">
             <speaker>AVERARDO</speaker>
             <l part="F">E meco andrai sotto quel ferro. –</l>
             <l>Odimi, o Guelfo. Al sangue tuo perdona;</l>
             <l>Perdona; ed abbi e vita e regno e pace;</l>
             <l part="I">E m'odia.</l>
           </sp>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">Odiarti, e la ignominia e il lutto</l>
             <l>Tollerar sempre di vederti vivo? –</l>
@@ -2428,23 +2447,23 @@
             <l>Ma certa omai, darà questa ferita.</l>
           </sp>
           <stage><emph>Trafiggendo la figlia</emph>.</stage>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l part="I">Accogli, o madre!... la tua figlia.</l>
           </sp>
-          <sp>
+          <sp who="#guido">
             <speaker>GUIDO</speaker>
             <l part="F">Crudo</l>
             <l>Più del tuo padre il mio, mi toglie a forza</l>
             <l>Di venir teco. Addio, ma per breve ora.</l>
           </sp>
-          <sp>
+          <sp who="#ricciarda">
             <speaker>RICCIARDA</speaker>
             <l>Vivi... ch'io possa rivederti. Tua</l>
             <l part="I">Moro – Perdona... al padre... mio.</l>
           </sp>
           <stage><emph>Spira</emph>.</stage>
-          <sp>
+          <sp who="#guelfo">
             <speaker>GUELFO</speaker>
             <l part="F">Ti sieguo.</l>
           </sp>

--- a/tei/foscolo-tieste.xml
+++ b/tei/foscolo-tieste.xml
@@ -75,6 +75,22 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="erope">
+            <persName>Erope</persName>
+          </person>
+          <person xml:id="ippodamia">
+            <persName>Ippodamia</persName>
+          </person>
+          <person xml:id="tieste">
+            <persName>Tieste</persName>
+          </person>
+          <person xml:id="atreo">
+            <persName>Atreo</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione - OCR</change>
@@ -114,7 +130,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>EROPE <hi rend="italic">con un fanciulletto a mano</hi>.</stage>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>D'empi rimorsi oggetto, infausto, caro</l>
@@ -144,7 +160,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>IPPODAMIA, <hi rend="italic">e detti</hi>.</stage>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Incauta! e a' suoi custodi il fanciulletto</l>
@@ -155,7 +171,7 @@
               <l>contaminata ahi! troppo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>A me dal seno</l>
@@ -178,7 +194,7 @@
             </lg>
           </sp>
           <stage rend="italic">(impugnando un ferro per uccidere il fanciulletto)</stage>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <stage rend="italic">(trattenedola)</stage>
             <lg>
@@ -191,7 +207,7 @@
               <l>ancor l'ira del Ciel?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Sangue mi grida</l>
@@ -205,7 +221,7 @@
               <l>e il Ciel sazio non fia, s'io pria non pero.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Qual da' tuoi detti feroce traluce</l>
@@ -218,7 +234,7 @@
               <l>tue prime fiamme?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Ahi! di lusinga questi,</l>
@@ -240,7 +256,7 @@
               <l>qui...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Istoria triste a che rinnovi? Solo</l>
@@ -251,13 +267,13 @@
               <l>sottentrò al suo delitto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Al suo!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Delitto</l>
@@ -265,7 +281,7 @@
               <l>a colpa?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Al suo delitto! Error comune</l>
@@ -275,14 +291,14 @@
               <l>il supplizio a cui corro, e 'l Ciel lo vuole.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Ma il figlio tuo? ma un innocente? Oh numi!</l>
               <l>Qual è il delitto suo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Di colpa è questo</l>
@@ -300,7 +316,7 @@
               <l>ti schiusi; per morir...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>A che tant'ira?</l>
@@ -309,7 +325,7 @@
               <l>ti spiri eccesso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Ippodamia, nell'alma</l>
@@ -333,14 +349,14 @@
               <l>ombra amata...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Che di'? come! tu l'ami</l>
               <l>ancor?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Io l'amo?... Io lui?... No: quando amai,</l>
@@ -360,7 +376,7 @@
               <l>fra gli attentati ondeggio e fra i rimorsi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Quanta mi fai pietà! Pur tu dovresti</l>
@@ -373,7 +389,7 @@
               <l>a' sospetti ed affanni.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Odiami; degna</l>
@@ -396,7 +412,7 @@
               <l>nella gemente stanza rimbombar.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>D'accesa fantasia, figlia, son vote</l>
@@ -405,7 +421,7 @@
               <l>Sta in te, le scaccia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Oh! mal t'apponi. E come</l>
@@ -419,14 +435,14 @@
               <l>all'inteso presagio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>E che? d'Atreo</l>
               <l>qual mai tema n'hai più?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Non è ancor caldo</l>
@@ -438,7 +454,7 @@
               <l>il suo cor?... tutto, tutto?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>I tuoi timori</l>
@@ -446,7 +462,7 @@
               <l>altri oggimai pensier...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>E quai pensieri,</l>
@@ -461,7 +477,7 @@
               <l>altro non ha pensier.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Madre gli sono,</l>
@@ -475,14 +491,14 @@
               <l>fama, che di Tieste...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>E dove mai</l>
               <l>non s'udì il mio delitto?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Or statti, e m'odi.</l>
@@ -497,14 +513,14 @@
               <l>contro Tieste, e contro noi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Pen parli.</l>
               <l>Ma tu, qual io, sei madre?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Oh che di' mai?</l>
@@ -525,7 +541,7 @@
               <l>tutta la cura a me ne lascia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>— Or prendi.</l>
@@ -540,7 +556,7 @@
             </lg>
           </sp>
           <stage rend="italic">(s'abbandona disperata sopra il fanciulletto)</stage>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Scena di lutto! Oh! figlia, Erope, al fine</l>
@@ -548,14 +564,14 @@
               <l>tal si de' a' sventurati.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>I cenni e 'l fato</l>
               <l>sono di morte, e morte voglio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Indarno</l>
@@ -574,7 +590,7 @@
               <l>rendratti forse dopo dolor tanto. —</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Sì, l'abbandono a te: </l>
@@ -592,7 +608,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>IPPODAMIA, <hi rend="italic">il Fanciulletto</hi></stage>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>E a' numi eterni</l>
@@ -617,7 +633,7 @@
         <head>ATTO II</head>
         <div type="scene">
           <head>SCENA I</head>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l>Quest'è l'empia magion: io la riveggo</l>
@@ -632,58 +648,58 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>IPPODAMIA, <hi rend="italic">e detto</hi>.</stage>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l>O madre, madre...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Oh!... Tieste!... se' tu?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l>Che fai? di'? vive</l>
               <l>Erope?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Erope? lassa!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l>Basta: intesi.</l>
               <l>Erope è morta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>No!...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l>Vive?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Sì, vive;</l>
               <l>e...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l>Oh gioia! oh mio timor falso! — Nol credo:</l>
@@ -691,26 +707,26 @@
               <l>madre, ten prego... Non temer...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l> Tel dissi:</l>
               <l>Erope vive.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l>... Ma morrà... deh! prima...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Vaneggi, figlio, tu?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l>Ma tu mel celi:</l>
@@ -718,20 +734,20 @@
               <l>dannolla a morte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Chi tel disse?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l>Argivo</l>
               <l>uom mel disse a Micene.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>E falsa nuova</l>
@@ -739,21 +755,21 @@
               <l>ciò nemmen sel pensò.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l>Pure giurommi. —</l>
               <l>Ma non perciò del mio venir mi pento.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>E qual folle pensier pasci... Tieste?...</l>
               <l>come osasti venir?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l>Erope mia</l>
@@ -775,7 +791,7 @@
               <l>vivendo in pianto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>In Delfo! O figliuol mio!</l>
@@ -783,7 +799,7 @@
               <l>il re insidie di morte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l>E men'avvidi,</l>
@@ -800,7 +816,7 @@
               <l>a liberare, od a morir.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Mal festi:</l>
@@ -813,7 +829,7 @@
               <l>d'Erope e di te stesso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l>Invan scongiuri:</l>
@@ -828,7 +844,7 @@
               <l>cessar d'amare i sventurati.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>E il chiedi?</l>
@@ -848,7 +864,7 @@
               <l>ed i fati ti portano.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l>Tel dissi:</l>
@@ -863,13 +879,13 @@
               <l>vedrò che m'ami, e che sei madre in vero.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l> (Numi! che m'inspirate?)</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l>I tuoi ritardi</l>
@@ -877,7 +893,7 @@
               <l>m'addita, e vien con Erope.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>O mio figlio!</l>
@@ -897,7 +913,7 @@
               <l>Vanne... Se n'esci, sei perduto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l>Madre,</l>
@@ -908,7 +924,7 @@
         </div>
         <div type="scene">
           <head>SCENA III</head>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Che sarà mai?</l>
@@ -928,7 +944,7 @@
           <head>SCENA IV</head>
           <stage>ATREO <hi rend="italic">seguito da una Guardia che resta nel fondo, e
 detta</hi>.</stage>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Figlio, qual nube d'oscuri pensieri</l>
@@ -938,7 +954,7 @@ detta</hi>.</stage>
               <l>deh! una volta rallegra.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>Alte cagioni</l>
@@ -949,7 +965,7 @@ detta</hi>.</stage>
               <l>vacillerammi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Infausto è il regno; e infausto</l>
@@ -964,7 +980,7 @@ detta</hi>.</stage>
               <l>uopo, Atreo, non avresti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>E di qual mai</l>
@@ -972,20 +988,20 @@ detta</hi>.</stage>
               <l>fatta è la nostra. Or ciò sol pensa, e taci.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Tuo sdegno è giusto; e del suo error Tieste</l>
               <l>la pena sconta...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>Errore!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Alma bollente,</l>
@@ -996,7 +1012,7 @@ detta</hi>.</stage>
               <l>delitto forse?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>Spaventoso, orrendo,</l>
@@ -1004,7 +1020,7 @@ detta</hi>.</stage>
               <l>che mitigar possa giammai?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Ben alta</l>
@@ -1016,7 +1032,7 @@ detta</hi>.</stage>
               <l>di sua man li troncò.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>Ben ciò rammento</l>
@@ -1035,7 +1051,7 @@ detta</hi>.</stage>
               <l>d'Erope fida.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Ah! mal conosci il core</l>
@@ -1051,7 +1067,7 @@ detta</hi>.</stage>
               <l>ond'essere infelice.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>E come vuoi,</l>
@@ -1063,7 +1079,7 @@ detta</hi>.</stage>
               <l>Tant'io non soffro.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>E tanto Erope mesta</l>
@@ -1071,7 +1087,7 @@ detta</hi>.</stage>
               <l>Atreo, ti chiede: il suo misero figlio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>E del fanciullo a te ragione, o madre,</l>
@@ -1087,7 +1103,7 @@ detta</hi>.</stage>
               <l>i voleri d'Atreo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Più consigliata</l>
@@ -1096,13 +1112,13 @@ detta</hi>.</stage>
               <l>fra le sventure contemplare un figlio!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>Se altrui lo celo, ella sel perde?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Nulla</l>
@@ -1111,7 +1127,7 @@ detta</hi>.</stage>
               <l>«Il figlio!»</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>Guardia, Erope a me. </l>
@@ -1123,7 +1139,7 @@ detta</hi>.</stage>
               <l>ove non basti, i miei comandi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Inulte</l>
@@ -1137,7 +1153,7 @@ detta</hi>.</stage>
               <l>l'orror.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>A sue querele altre più tristi</l>
@@ -1149,7 +1165,7 @@ detta</hi>.</stage>
           <head>SCENA V</head>
           <stage>EROPE, <hi rend="italic">preceduta dalla Guardia che resta nel
 fondo</hi>, ATREO, IPPODAMIA.</stage>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <stage rend="italic">(ad Erope)</stage>
             <lg>
@@ -1159,7 +1175,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>Atreo t'infonda: e tu m'abborri?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Abborro</l>
@@ -1171,7 +1187,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>al tuo cospetto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>E sì crudel sarommi,</l>
@@ -1182,7 +1198,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>ho colpe ed alma.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Io ti recai di colpa</l>
@@ -1195,7 +1211,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>me sola.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>Audaci nuovi detti ascolto,</l>
@@ -1216,7 +1232,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>pensiero a ciò?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>il chiedi? A ciò m'indusse</l>
@@ -1224,7 +1240,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>e mia discolpa è questa.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>A vera e dritta</l>
@@ -1245,7 +1261,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>ragion di stato a imbelle affetto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Pera</l>
@@ -1253,7 +1269,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>intender io.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <stage rend="italic">(ad Atreo)</stage>
             <lg>
@@ -1262,7 +1278,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>alla madre il fanciullo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>Mal tu libri</l>
@@ -1278,7 +1294,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>tranne quelle d'obbrobrio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Il figlio, il figlio,</l>
@@ -1286,7 +1302,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>Che altro debbo aspettar?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>Perduto e infranto</l>
@@ -1296,7 +1312,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>seguirti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <stage rend="italic"> (parte, seguito dalla guardia)</stage>
             <lg>
@@ -1305,7 +1321,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>mi promettevi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Il forte è saggio! Andianne.</l>
@@ -1321,13 +1337,13 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
           <stage rend="italic">Notte.</stage>
           <stage>La sala è illuminata da alcune lampade.</stage>
           <stage>EROPE, IPPODAMIA.</stage>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Ove mi traggi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l> Or tutto tace: amiche</l>
@@ -1335,13 +1351,13 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>vien...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Qual mistero!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Alta è la notte; alcuno</l>
@@ -1349,13 +1365,13 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>vien meco.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>E dove?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Ove pietà comune</l>
@@ -1366,7 +1382,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>compir dei tu.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Qual opra mi s'addice</l>
@@ -1375,13 +1391,13 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>ultima.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>E stringe il tempo: affretta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>È arcano</l>
@@ -1389,7 +1405,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>io non ti sieguo; no.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Dunque l'intendi,</l>
@@ -1397,14 +1413,14 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>meglio il saprai tu stessa.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Ippodamia,</l>
               <l>libera parla, o mi ritraggo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Ahi pena!</l>
@@ -1413,63 +1429,63 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>Tu di figlio che mormori!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Del figlio,</l>
               <l>che più non veggo, i' parlo. Amor di madre!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>E del mio figlio nulla di' tu? nulla?</l>
               <l>Fingasi Atreo, chè mal meco s'infinge.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Placati... il duol troppo ti pinge Atreo</l>
               <l>perfido... forse...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Tu da me il rapisti,</l>
               <l>e da te voglio il figlio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Altre feroci</l>
               <l>cure tu pasci?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Io no: col figliuol mio</l>
               <l>feroce? Ah! il fui! donna spietata!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l> Cessa...</l>
               <l>Tieste... Oh stato!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>— E se spietato Atreo</l>
               <l>sarà più teco, o figlio?...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l> Omai tant'ira</l>
@@ -1477,7 +1493,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>di Tieste l'ardore.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> E chi mi nomi?</l>
@@ -1487,13 +1503,13 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>gli affetti che sopir tento.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Se in Argo?...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Oh ciel! Tieste! E dov'è mai? Che il veggia;</l>
@@ -1504,19 +1520,19 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>parli; ti spiega.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l> Sì, Tieste è in Argo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>O ciel! dove m'ascondo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l> Ah! se può almeno</l>
@@ -1524,13 +1540,13 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>questo luogo abbandoni.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> È qui!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l> S'asconde</l>
@@ -1543,14 +1559,14 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>periglio, e qual su lui!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> Ch'altro n'attende</l>
               <l>più che morte? moriam.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l> Figlia, deh! cedi,</l>
@@ -1566,7 +1582,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>credi, non v'ha riparo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> Io? — No... ricuso</l>
@@ -1575,7 +1591,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>voli subito d'Argo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l> O tu crudele!</l>
@@ -1583,21 +1599,21 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>e da te il chieggio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> Del mio cor non basta</l>
               <l>lo strazio, o numi!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Io... sì, dirogli... Oh dio! </l>
             </lg>
           </sp>
           <stage rend="italic">(parte)</stage>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Io rivedrollo? ei partirà? — Deh! fugga.</l>
@@ -1610,21 +1626,21 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
         <div type="scene">
           <head>SCENA II</head>
           <stage>IPPODAMIA <hi rend="italic">seguita da</hi> TIESTE, EROPE.</stage>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l>Qual vista! Erope mia! La veggo;</l>
               <l>al fin la veggo... Erope.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> Incauto, fuggi</l>
               <l>lungi da me.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l>Dunque perigli e morte</l>
@@ -1632,7 +1648,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>guiderdone ottener!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> E ben, Tieste,</l>
@@ -1641,7 +1657,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>guiderdone a te dar che la mia vita.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l>Io sì morte ti venni a dar, ma morte</l>
@@ -1668,7 +1684,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>quel duol che tu sol mi cagioni?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> Eh, dimmi,</l>
@@ -1676,7 +1692,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>tuo amor non merto? — Sventurato io sono.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Nol merti; no: ma sol le tue sventure</l>
@@ -1685,7 +1701,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>al disperato furor tuo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> Tieste,</l>
@@ -1697,7 +1713,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>più di te lo son io.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> Crudel! non venni</l>
@@ -1709,7 +1725,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>in pace almeno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> In pace!... Or tu tel vedi.</l>
@@ -1719,26 +1735,26 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>me alla difesa di quel figlio...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> Figlio! —</l>
               <l>Come? figlio! di chi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> Tuo figlio e mio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l>Numi!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> Non ti stupir. Dall'atra notte</l>
@@ -1749,13 +1765,13 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>succhiar bambin d'un'odiata madre.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l>Ed il feroce Atreo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l> Sì; ei veglia ancora</l>
@@ -1763,7 +1779,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>poi di temer.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> Ippodamia, scordasti</l>
@@ -1776,7 +1792,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>le mie vendette».</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l> Alta minaccia in fatto!</l>
@@ -1786,7 +1802,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>quant'han possanza in uom!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> Troppo t'avvolge</l>
@@ -1794,13 +1810,13 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>tu i suoi pensier.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l> (Troppo li veggo!)</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> Omai</l>
@@ -1808,7 +1824,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>fuggi, e ne godi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> Cessa al fin tue amare</l>
@@ -1816,7 +1832,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>i giuramenti... m'ami?... ti rimembra?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Ciò per te non rileva: or vatti; ad altro</l>
@@ -1824,14 +1840,14 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>io più, nè tu per me.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> Come! non sei</l>
               <l>omai quella di pria?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> Debile e vile</l>
@@ -1842,13 +1858,13 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
             </lg>
           </sp>
           <stage rend="italic">(in atto di partire)</stage>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> Fermati... il figlio...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Il figlio? Atreo sel tien: lo disserrai,</l>
@@ -1895,7 +1911,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>per tua troppa pietà! Ma invan ten penti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l>Il figlio mio sì, il figlio a me nel seno</l>
@@ -1919,7 +1935,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>indi mi svena; eccoti il petto, il ferro.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Tu il vuoi, mel porgi; </l>
@@ -1939,7 +1955,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>Ma a che venisti mai? fuggiti, va.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l>O infernale voragine, spalancati;</l>
@@ -1948,20 +1964,20 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>orma senza di voi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <stage rend="italic"> (accostando il ferro al petto)</stage>
             <lg>
               <l> Vanne, o m'uccido.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l>Ti diedi io il ferro... ma... me sol...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> Che stai?</l>
@@ -1969,13 +1985,13 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
             </lg>
           </sp>
           <stage rend="italic">(come sopra)</stage>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l>Sì, vo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l> Trattienti; or no, chè incauto</l>
@@ -1984,51 +2000,51 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>e ratto più, e con men rischio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> E il ferro?...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>A sant'opra io lo serbo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> Esule, inerme</l>
               <l>fuggirò dunque?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> E fuggi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> Il giuro. —</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <stage rend="italic">(dandogli il ferro)</stage>
             <lg>
               <l> Or l'abbi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>T'ascondi intanto in quell'asilo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> ... Addio. </l>
@@ -2039,19 +2055,19 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
         <div type="scene">
           <head>SCENA III</head>
           <stage>AROPE, IPPODAMIA.</stage>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Ei fugge!...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l> Ahi tutto è pianto!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> A me non altro</l>
@@ -2061,7 +2077,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>l'adori ancor?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <stage rend="italic">(osservando)</stage>
             <lg>
@@ -2069,14 +2085,14 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>svelato è tutto... va.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> T'adopra... esplora. </l>
             </lg>
           </sp>
           <stage rend="italic">(parte)</stage>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Terrore solo innanzi stammi, e lutto.</l>
@@ -2087,14 +2103,14 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
         <div type="scene">
           <head>SCENA IV</head>
           <stage>ATREO, IPPODAMIA</stage>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>Qual cura or qui ti mena, in queste</l>
               <l>ore tarde di notte?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l> A pianger venni...</l>
@@ -2102,7 +2118,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>credo. — Ma tu? pur vegli.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l> Il re non dorme;</l>
@@ -2110,7 +2126,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>suon di pianto qui trassemi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l> Gemea</l>
@@ -2118,14 +2134,14 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>gemer di madre s'interdice.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>E sempre</l>
               <l>dunque in dolor vedrotti?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l> Orbata madre</l>
@@ -2133,21 +2149,21 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>a te il temprare il mio dolor, che il puoi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>Tieste vive, io tel ripeto: e forse</l>
               <l>il sai tu pure.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l> Io?... No... tu mel dicesti:</l>
               <l>ed io te spero veritier.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l> T'affida! —</l>
@@ -2155,7 +2171,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>che dal tuo duolo ti ristori calma.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <stage rend="italic">(parte)</stage>
           </sp>
@@ -2163,7 +2179,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
         <div type="scene">
           <head>SCENA V</head>
           <stage>ATREO, <hi rend="italic">poi una Guardia</hi>.</stage>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>Vive, non dubitarne; e all'odio mio</l>
@@ -2204,7 +2220,7 @@ fondo</hi>, ATREO, IPPODAMIA.</stage>
           <stage rend="italic">Notte.</stage>
           <stage rend="italic">La sala è appena illuminata da un lontano
 chiarore.</stage>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>O Tieste... Tieste... ove mi lasci?</l>
@@ -2226,35 +2242,35 @@ chiarore.</stage>
         <div type="scene">
           <head>SCENA II</head>
           <stage>TIESTE, <hi rend="italic">e detta</hi>.</stage>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <stage rend="italic"> (inoltrandosi lentamente)</stage>
             <lg>
               <l>O notte!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> (Parmi? O voce</l>
               <l>suona d'intorno?)</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> O notte! io ti consacro</l>
               <l>fraterno sangue.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> (Forsennato! Il passo</l>
               <l>qui gli fia tolto).</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> Tremo? E pende intanto</l>
@@ -2266,27 +2282,27 @@ chiarore.</stage>
               <l>vendicator, liberator, ferisci.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Qui sol ferisci.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> O! chi se' tu? Qual voce!...</l>
               <l>Erope?...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> Iniquo!</l>
             </lg>
           </sp>
           <stage rend="italic"> (accostandosi a Tieste)</stage>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> Or tu t'arretra: inciampo</l>
@@ -2294,14 +2310,14 @@ chiarore.</stage>
               <l>nè altro ci salva, che il delitto. Vanne.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Ferma: dove precipiti? Quel ferro</l>
               <l>a me, Tieste, a me.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> L'avrai... fumante. —</l>
@@ -2310,14 +2326,14 @@ chiarore.</stage>
               <l>quella, ch'ei vuol, morte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> Fraterna morte!</l>
               <l>Morte di re!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> Quest'è notte di pianto,</l>
@@ -2335,14 +2351,14 @@ chiarore.</stage>
               <l>scesero, e nulla intesi io più.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> Sospetto</l>
               <l>lieve ti tragge al fratricidio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> Oh donna!</l>
@@ -2356,7 +2372,7 @@ chiarore.</stage>
               <l>di te. — Di te che fia?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> Non sarò mai,</l>
@@ -2364,13 +2380,13 @@ chiarore.</stage>
               <l>complice mai.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> Il reo son io.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> Che! rea</l>
@@ -2381,7 +2397,7 @@ chiarore.</stage>
               <l>per trucidarti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> Trucidarmi? M'arma</l>
@@ -2391,21 +2407,21 @@ chiarore.</stage>
               <l>si prostreran.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> Nutri tua speme ad agio:</l>
               <l>ma a fin per me non giungerà.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> Dicesti?</l>
               <l>Ora mi lascia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> E quel che promettesti,</l>
@@ -2414,7 +2430,7 @@ chiarore.</stage>
               <l>creder io mai dovea?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> D'abbandonarle</l>
@@ -2424,7 +2440,7 @@ chiarore.</stage>
               <l>mi sciolga al fine, ove tu sgombri.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> Ah! fuggi:</l>
@@ -2433,7 +2449,7 @@ chiarore.</stage>
               <l>purchè libero tu.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> Nè conoscesti</l>
@@ -2443,7 +2459,7 @@ chiarore.</stage>
               <l>se te perder dovrò.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> T'affidi or tanto,</l>
@@ -2457,14 +2473,14 @@ chiarore.</stage>
               <l>porger può mai? non già Tieste.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> Or quella</l>
               <l>non se' tu che giurasti amore e morte?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Iniquo! amore a te! Non mai! non altro</l>
@@ -2482,20 +2498,20 @@ chiarore.</stage>
               <l>e in mezzo al cor tutto mel pianta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> ... Taci.</l>
               <l>Non vedi tu?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> Vaneggi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> — Ubbidirotti;</l>
@@ -2503,7 +2519,7 @@ chiarore.</stage>
               <l>Tu fremi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> — Il braccio reggi</l>
@@ -2516,7 +2532,7 @@ chiarore.</stage>
               <l>ma va; ch'io non ti vegga.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> Ombra... gigante</l>
@@ -2527,13 +2543,13 @@ chiarore.</stage>
               <l>pel braccio — Vengo, vengo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> Oh!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> Vengo, vengo:</l>
@@ -2545,20 +2561,20 @@ chiarore.</stage>
               <l>lascia, seguir. — Tu, tu, vil, mi trattieni.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Quai precipizi!... ove corri? Deh!...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> A tutto:</l>
               <l>sia che si vuole; scostati; ho risolto. —</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Oh Dio! — Giacchè non vuoi da me tu udire</l>
@@ -2572,7 +2588,7 @@ chiarore.</stage>
               <l>o mi trafiggi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> Sì. — Che fo? — T'ascolto,</l>
@@ -2585,21 +2601,21 @@ chiarore.</stage>
           <head>SCENA III</head>
           <stage>ATREO <hi rend="italic">di dentro, che poi esce preceduto da Guardie con
 faci</hi>.</stage>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>Quai grida! </l>
             </lg>
           </sp>
           <stage rend="italic"> (esce)</stage>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <stage rend="italic"> (avventandosi contro Atreo)</stage>
             <lg>
               <l> Mori.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l> Empi! — Non io;</l>
@@ -2617,13 +2633,13 @@ faci</hi>.</stage>
               <l>e tal t'appresti? — Ma fallito è 'l colpo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Son rea; tu il di'.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l> Stolidamente rei</l>
@@ -2632,7 +2648,7 @@ faci</hi>.</stage>
               <l>ch'Atreo deluder basti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> E chi può forse</l>
@@ -2651,7 +2667,7 @@ faci</hi>.</stage>
               <l>il mio proposto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l> Or vedi eroe! ti vanta</l>
@@ -2668,7 +2684,7 @@ faci</hi>.</stage>
               <l>non io Tieste insomma.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> Rapitore</l>
@@ -2690,7 +2706,7 @@ faci</hi>.</stage>
               <l>Or è l'istante.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l> Giovanile etade</l>
@@ -2713,7 +2729,7 @@ faci</hi>.</stage>
               <l>a me, e possanza per regnar mi porse.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l>Capo Cleonte in Calcide sorgea</l>
@@ -2725,7 +2741,7 @@ faci</hi>.</stage>
               <l>non fui tiranno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <stage rend="italic"> (ad Atreo)</stage>
             <lg>
@@ -2736,7 +2752,7 @@ faci</hi>.</stage>
               <l>crudo! a' tuoi piedi spirasse trafitto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>Superbo ei troppo, a me volea rimpetto</l>
@@ -2753,7 +2769,7 @@ faci</hi>.</stage>
               <l>nol desiassi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> E i tuoi sicari in Delfo,</l>
@@ -2764,7 +2780,7 @@ faci</hi>.</stage>
               <l>con dotti inganni altri, che Atreo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l> S'addice</l>
@@ -2777,7 +2793,7 @@ faci</hi>.</stage>
               <l>onde macchiar mio nome.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> O come l'arti</l>
@@ -2791,7 +2807,7 @@ faci</hi>.</stage>
               <l>chè tiranno sei vero.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <stage rend="italic"> (ad Atreo)</stage>
             <lg>
@@ -2807,7 +2823,7 @@ faci</hi>.</stage>
               <l>su noi, ten priego.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>Sì, morrà, felloni;</l>
@@ -2827,7 +2843,7 @@ faci</hi>.</stage>
         <div type="scene">
           <head>SCENA IV</head>
           <stage rend="italic">IPPODAMIA, e detti.</stage>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Oimè! che avvenne? </l>
@@ -2838,13 +2854,13 @@ faci</hi>.</stage>
               <l>Emneo. — Miei figli...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> Madre!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <stage rend="italic"> (alla Guardia)</stage>
             <lg>
@@ -2852,19 +2868,19 @@ faci</hi>.</stage>
               <l>non l'ubbidisci?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> O madre, il figlio...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l> Numi!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l>Atreo, morte.</l>
@@ -2875,7 +2891,7 @@ faci</hi>.</stage>
         <div type="scene">
           <head>SCENA V</head>
           <stage>ATREO, IPPODAMIA, Guardie nel fondo.</stage>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>Al nuovo dì tremenda</l>
@@ -2883,14 +2899,14 @@ faci</hi>.</stage>
               <l>poichè assecura il viver mio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Qual volgi</l>
               <l>cura feroce?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>No; lieve: di morte</l>
@@ -2899,26 +2915,26 @@ faci</hi>.</stage>
               <l>Di tal... quest'è dritto di re: varrommi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Tieste?...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>Ei regicida.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l> Oh ciel!... vorresti...</l>
               <l>punir delitti con maggior delitto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>Altro ve n'ha del suo maggior? — Sì... forse...</l>
@@ -2926,13 +2942,13 @@ faci</hi>.</stage>
               <l>anzi il castigo, ed il furor d'un sire.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Deh! ti scorda quell'onta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l> Onta è di sangue,</l>
@@ -2944,7 +2960,7 @@ faci</hi>.</stage>
         <div type="scene">
           <head>SCENA VI</head>
           <stage>IPPODAMIA</stage>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Figlio...</l>
@@ -2969,7 +2985,7 @@ faci</hi>.</stage>
           <head>SCENA I </head>
           <stage rend="italic">Giorno.</stage>
           <stage>ATREO, <hi rend="italic">e una Guardia</hi>.</stage>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>Udisti? Ov'ei s'arrenda, a un cenno, tutto</l>
@@ -2991,17 +3007,17 @@ faci</hi>.</stage>
         <div type="scene">
           <head>SCENA II</head>
           <stage>IPPODAMIA, ATREO.</stage>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <stage rend="italic">(in atto di gettarsi a' piedi di Atreo)</stage>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>E perchè, madre? Sorgi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>L'ultime voci di tua madre intendi:</l>
@@ -3011,7 +3027,7 @@ faci</hi>.</stage>
               <l>a' piedi tuoi prima spirar: decidi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>Parole parli di furor, di cieca</l>
@@ -3025,14 +3041,14 @@ faci</hi>.</stage>
               <l>è della legge il dritto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l> E chi t'astringe,</l>
               <l>chi il tuo poter ti toglie!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l> Altri, che Atreo,</l>
@@ -3046,7 +3062,7 @@ faci</hi>.</stage>
               <l>rigor del cielo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l> Così molti e grandi</l>
@@ -3070,7 +3086,7 @@ faci</hi>.</stage>
               <l>contenta all'ara degl'Iddii sdegnati.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>Madre, a che vuoi tu trarmi? io di tuo sangue</l>
@@ -3078,7 +3094,7 @@ faci</hi>.</stage>
               <l>forse in me vedi l'esecrabil alma?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Rimbrotta sì d'un'infelice madre</l>
@@ -3087,14 +3103,14 @@ faci</hi>.</stage>
               <l>l'amo; figli mi siete...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l> Egli tuo figlio!</l>
               <l>Ei che tramò di pur rapirten'uno?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Vedi tu questo mio braccio tremante?</l>
@@ -3103,7 +3119,7 @@ faci</hi>.</stage>
               <l>nè egli fia spento anzi di me.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l> Tieste</l>
@@ -3114,7 +3130,7 @@ faci</hi>.</stage>
               <l>fin che il fratello vive.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l> Alta, inumana</l>
@@ -3126,13 +3142,13 @@ faci</hi>.</stage>
             </lg>
           </sp>
           <stage rend="italic">(in atto di partire)</stage>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>Or dove corri?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l> Ad abbracciar morendo</l>
@@ -3150,7 +3166,7 @@ faci</hi>.</stage>
               <l>perdere io voglio l'estremo sospiro.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>A pietà tu mi sforzi: a tue materne</l>
@@ -3169,7 +3185,7 @@ faci</hi>.</stage>
               <l>forse... perdono.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l> Bada, Atreo, che fero</l>
@@ -3179,7 +3195,7 @@ faci</hi>.</stage>
               <l>Quindi io di te più temo...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l> Generoso</l>
@@ -3191,7 +3207,7 @@ faci</hi>.</stage>
           <head>SCENA III</head>
           <stage>EROPE, TIESTE, <hi rend="italic">accompagnati dalla Guardia che resta
 nel fondo</hi>, ATREO, IPPODAMIA.</stage>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <stage rend="italic">(ad Atreo)</stage>
             <lg>
@@ -3201,7 +3217,7 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>questi odiosi istanti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l> O tu, superbo</l>
@@ -3210,7 +3226,7 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
             </lg>
           </sp>
           <stage rend="italic">(la Guardia s'avanza)</stage>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <stage rend="italic">(alla Guardia)</stage>
             <lg>
@@ -3223,20 +3239,20 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>qui per me solo giungerà a ferirlo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l>Madre, t'arretra; me morir sol lascia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <stage rend="italic">(ad Atreo)</stage>
             <lg>
               <l>Così perdoni?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l> Perdonar misfatti,</l>
@@ -3258,13 +3274,13 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>e per te scegli morte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> E per me?...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l> Vita</l>
@@ -3274,20 +3290,20 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>E tu, giuri?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> Ti giuro odio, tremendo</l>
               <l>oltre l'Averno alto furor ti giuro.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>Or tu li giura, ed io li compio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l> O figli!</l>
@@ -3303,7 +3319,7 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>contaminati da men colpe.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> Cessa:</l>
@@ -3316,7 +3332,7 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>in libertà.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l> Regno tu brami? Or vola</l>
@@ -3329,7 +3345,7 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>sarieno d'onta e di ruina forse.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l>Io re non nacqui; e a questi patti il regno</l>
@@ -3353,7 +3369,7 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>a te gradito ecco mia vita.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> Indarno</l>
@@ -3378,7 +3394,7 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>a' tuoi tormenti, ove di più tu n'abbia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>Tuo figlio! ei crescerà tutto rigonfio</l>
@@ -3388,7 +3404,7 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>forse smentir suo infame nascimento?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Tiranno inesorabile! placato</l>
@@ -3408,7 +3424,7 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>non preverrammi da te spento.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l> Donna,</l>
@@ -3416,7 +3432,7 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>segnaro Atreo? — Non se' di re tu madre?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>Io di re moglie e di re figlia e madre</l>
@@ -3433,14 +3449,14 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>l'estremo... a me non sia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <stage rend="italic"> (abbracciando Ippodamia)</stage>
             <lg>
               <l> Madre...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l> E un sol mezzo,</l>
@@ -3449,7 +3465,7 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>placati...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <stage rend="italic"> (sollevandola)</stage>
             <lg>
@@ -3463,7 +3479,7 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>è a me più dura.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> Madre, Erope, figlio,</l>
@@ -3475,13 +3491,13 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
             </lg>
           </sp>
           <stage rend="italic"> (ad Atreo)</stage>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l> Perdono?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> A me fien gravi</l>
@@ -3491,7 +3507,7 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>non avrà pace mai: credi...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l> Mendaci</l>
@@ -3500,7 +3516,7 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>empio tu meco.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> Qual con me se' stato,</l>
@@ -3513,14 +3529,14 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>perdonami.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l> Ad un tratto or se' pentito</l>
               <l>veracemente!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> E che a te dir poss'io,</l>
@@ -3528,7 +3544,7 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>vendetta, Atreo, col non svenarmi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <stage rend="italic">(ad Atreo)</stage>
             <lg>
@@ -3537,7 +3553,7 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>pentito egli è.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> Fratel, ti cedo io tutto:</l>
@@ -3548,7 +3564,7 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>deh ti sia pegno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l> Cupamente finto</l>
@@ -3575,14 +3591,14 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
             </lg>
           </sp>
           <stage rend="italic">(s'abbracciano)</stage>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <stage rend="italic"> (dopo un breve silenzio)</stage>
             <lg>
               <l> Fratello! —</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <lg>
               <l>O miei figliuoli! Io pace vidi! Or meno</l>
@@ -3593,14 +3609,14 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>trista è perfin la gioia!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> O mio fratello!</l>
               <l>O madre! Erope! figlio!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <stage rend="italic"> (ad Atreo)</stage>
             <lg>
@@ -3608,7 +3624,7 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>tu generoso ora mi schiudi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l> Un sacro</l>
@@ -3616,13 +3632,13 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>nostri amistà.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> Mio figlio!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <stage rend="italic"> (alla Guardia)</stage>
             <lg>
@@ -3635,13 +3651,13 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
             </lg>
           </sp>
           <stage rend="italic"> (a Tieste)</stage>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Ov'è mio figlio?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l> Il figliuol tuo verratti.</l>
@@ -3654,7 +3670,7 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
             </lg>
           </sp>
           <stage rend="italic"> (la Guardia porge la tazza a Tieste, e parte)</stage>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> Bersaglio</l>
@@ -3667,13 +3683,13 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>amistà giuro.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l> Il figlio mio...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <stage rend="italic"> (accostando la tazza alle labbra)</stage>
             <lg>
@@ -3681,7 +3697,7 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>Sangue!... </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l> Felloni! è questo il figliuol vostro:</l>
@@ -3691,7 +3707,7 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
               <l>del misfatto godete.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> Un brando, un ferro. </l>
@@ -3702,7 +3718,7 @@ nel fondo</hi>, ATREO, IPPODAMIA.</stage>
         <div type="scene">
           <head>SCENA IV</head>
           <stage>ATREO, EROPE, IPPODAMIA</stage>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <stage rend="italic"> (corre, e poi s'arresta, guardando dal lato ov'è partito
 Tieste)</stage>
@@ -3717,11 +3733,11 @@ Tieste)</stage>
           <head>SCENA V</head>
           <stage>ATREO, EROPE, TIESTE <hi rend="italic">di dentro che poi esce seguito
 da</hi> IPPODAMIA <hi rend="italic">e da Guardie</hi>.</stage>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <stage rend="italic"> (guata stupida il sangue)</stage>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <stage rend="italic"> (di dentro)</stage>
             <lg>
@@ -3735,11 +3751,11 @@ dalle Guardie)</stage>
             </lg>
           </sp>
           <stage rend="italic"> (si ferisce)</stage>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <stage rend="italic"> (guata ancora stupida il sangue)</stage>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <stage rend="italic"> (sostenuto da Ippodamia)</stage>
             <lg>
@@ -3748,20 +3764,20 @@ dalle Guardie)</stage>
               <l>vista d'orror!... Ch'io morendo... nol veggia...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#erope">
             <speaker>EROPE</speaker>
             <lg>
               <l>Figlio! </l>
             </lg>
             <stage rend="italic"> (cade tramortita)</stage>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l> Erope... madre...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ippodamia">
             <speaker>IPPODAMIA</speaker>
             <stage rend="italic"> (sostenendo sempre Tieste)</stage>
             <lg>
@@ -3769,14 +3785,14 @@ dalle Guardie)</stage>
               <l>Ti seguirò.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tieste">
             <speaker>TIESTE</speaker>
             <lg>
               <l>Vendetta!... </l>
             </lg>
           </sp>
           <stage rend="italic"> (spira fra le braccia d'Ippodamia) </stage>
-          <sp>
+          <sp who="#atreo">
             <speaker>ATREO</speaker>
             <lg>
               <l>Vendicarvi</l>

--- a/tei/gigli-la-dirindina.xml
+++ b/tei/gigli-la-dirindina.xml
@@ -75,6 +75,19 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="don_carissimo">
+            <persName>Don Carissimo</persName>
+          </person>
+          <person xml:id="dirindina">
+            <persName>Dirindina</persName>
+          </person>
+          <person xml:id="liscione">
+            <persName>Liscione</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -97,7 +110,7 @@
     <body>
       <div>
         <head>Parte I</head>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Signora Dirindina,</l>
           <l>
@@ -105,13 +118,13 @@ Così sempre infingardo</l>
           <l>
 Al cembalo venite ogni mattina?</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Or via, che più si tarda?</l>
           <l>
 Cominciamo!</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>A voi tocca:</l>
           <l>
@@ -119,59 +132,59 @@ Aprite ben la bocca,</l>
           <l>
 Ma spurgatevi prima.</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Ach, sputo!</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>O buono:</l>
           <l>
 Badate bene al suono!</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Do, re, mi, fa, mi, do.</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Va più basso quel do!</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Do, mi, fa, re ...</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Più basso, dico!</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Do ...</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Più basso, e tre!</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Io, da due giorni in qua,</l>
           <l>
 Son tutta incatarrata!</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Il catarro è la scusa</l>
           <l>
 Di chi cantar non sa!</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Sentite don Carissimo</l>
           <l>
 Come la gola ho chiusa!</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>IL catarro certissimo,</l>
           <l>
@@ -179,23 +192,23 @@ Forse dal troppo stare a quel balcone</l>
           <l>
 Ad aspettar Liscione.</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>È la solita vostra gelosia</l>
           <l>
 Che di Liscione avete!</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>So ben figliola mia</l>
           <l>
 Quanto ben gli volete.</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Quel ben ch'a ogni altro musico si vole!</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Ma più d'ogn'altro</l>
           <l>
@@ -205,7 +218,7 @@ lo son quel che v'addestro</l>
           <l>
 Al canto!</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Egli a l'azione</l>
           <l>
@@ -215,7 +228,7 @@ Ben passeggia la scena</l>
           <l>
 E ad ogni gesto il mondo incanta.</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Egli però non canta</l>
           <l>
@@ -247,7 +260,7 @@ Mostro per voi che appena</l>
           <l>
 Il ferraiol mi slaccio!</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Non vo' che tanto impaccio</l>
           <l>
@@ -277,7 +290,7 @@ Altro amor che di scolara</l>
           <l>
 Nel mio cor per voi non è.</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>
 E questo basta a me: ma l'altre mie</l>
@@ -330,7 +343,7 @@ Mi ripone il salario al fin del mese</l>
           <l>
 In tanti bei grossini.</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>A tempo e luogo anch'io</l>
           <l>
@@ -342,33 +355,33 @@ A solfeggiar intanto,</l>
           <l>
 Per un poco torniarno.</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>A solfeggiar, sì bene, e questo bramo.</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Do, re, mi, fa, sol, mi.</l>
         </sp>
-        <sp>
+        <sp who="#liscione">
           <speaker>LISCIONE</speaker>
           <l>Miei signori, buon dì!</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Buon dì, Signor Liscione!</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Gl'occhi qui alla lezione!</l>
           <l>
 Sol, mi, fa, re, mi, fa.</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>C'è qualche novità?</l>
         </sp>
-        <sp>
+        <sp who="#liscione">
           <speaker>LISCIONE</speaker>
           <l>Col corrier di Milano
 Un foglio è giunto a me</l>
@@ -377,35 +390,35 @@ Che per cantar colà nel Coriolano</l>
           <l>
 Vi richiede, o signora.</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>La, sol, fa, mi, fa, re</l>
           <l>
 Badate qui in malora!</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Quant'è il regalo?</l>
         </sp>
-        <sp>
+        <sp who="#liscione">
           <speaker>LISCIONE</speaker>
           <l>Seicento Filippi.</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Un corno che vi strippi!</l>
           <l>
 Badate a queste note!</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>È moneta che basta a far la dote?</l>
         </sp>
-        <sp>
+        <sp who="#liscione">
           <speaker>LISCIONE</speaker>
           <l>E poi sì generosa è quella nobiltà ...</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Non occor altro: così presuntuosa
 Non è la giovinetta</l>
@@ -414,38 +427,38 @@ Che in un palco si metta</l>
           <l>
 Senza la mia presenza!</l>
         </sp>
-        <sp>
+        <sp who="#liscione">
           <speaker>LISCIONE</speaker>
           <l>Ma il Maestro di Cappella</l>
           <l>
 È colà provveduto.</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Tant'è, senza il mio aiuto</l>
           <l>
 Non verrà la Zitella!</l>
         </sp>
-        <sp>
+        <sp who="#liscione">
           <speaker>LISCIONE</speaker>
           <l>Dunque ...</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>In una parola, cercate un'altra!</l>
         </sp>
-        <sp>
+        <sp who="#liscione">
           <speaker>LISCIONE</speaker>
           <l>E un'altra cercherò!</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Non la cercate, no,
 Ch'io vo' andar a Milano,</l>
           <l>
 E v'andrò sola!</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Sola voi? Mi meraviglio!</l>
           <l>
@@ -467,7 +480,7 @@ Sciolta ancor, né asciutto il ciglio.</l>
           <l>
 Sola voi? Mi meraviglio!</l>
         </sp>
-        <sp>
+        <sp who="#liscione">
           <speaker>LISCIONE</speaker>
           <l>Sola, signora sì, sola, benissimo!</l>
           <l>
@@ -481,21 +494,21 @@ Per regalar battute,</l>
           <l>
 Se tante ne fa far al suo martello!</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Oh, che gran ribaldone!</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Sedete qui, Liscione.</l>
           <l>
 Sentite, discorriamola.</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Dirindina, finiamola!</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>La lezione appresa
 Replicar mi conviene e farne prova:</l>
@@ -504,13 +517,13 @@ Badate s'io fo bene.</l>
           <l>
 Caro Liscione, avete voi tabacco?</l>
         </sp>
-        <sp>
+        <sp who="#liscione">
           <speaker>LISCIONE</speaker>
           <l>Del miglior di Bologna,</l>
           <l>
 Ma l'odore è un po' stracco ...</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Questi di Catalogna</l>
           <l>
@@ -520,11 +533,11 @@ Che in seno mi riposi</l>
           <l>
 Daranno al morto odor concia più fina.</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Finiamola, Dirindina!</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Dal pallore del volto</l>
           <l>
@@ -532,11 +545,11 @@ Mi par che poco sonno abbiate preso</l>
           <l>
 Stanotte.</l>
         </sp>
-        <sp>
+        <sp who="#liscione">
           <speaker>LISCIONE</speaker>
           <l>Inver non ho dormito molto ...</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Giacchè il fornello è acceso,</l>
           <l>
@@ -544,11 +557,11 @@ Volete voi qualche bevanda calda</l>
           <l>
 Di rosoli condita, o pollachina?</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Finiamola, Dirindina!</l>
         </sp>
-        <sp>
+        <sp who="#liscione">
           <speaker>LISCIONE</speaker>
           <l>Prendiam ciò che v'aggrada,</l>
           <l>
@@ -558,17 +571,17 @@ Per certa lunga strada</l>
           <l>
 E fioco per gran polvere raccolta...</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Scotiamola una volta</l>
           <l>
 Dal giustacuor!</l>
         </sp>
-        <sp>
+        <sp who="#liscione">
           <speaker>LISCIONE</speaker>
           <l>Sì, cara mia, scotiamola!</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Dirindina, finiamola,</l>
           <l>
@@ -590,21 +603,21 @@ Per qualche inibitoria:</l>
           <l>
 lo non ci voglio costui!</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Con qual ragione?</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Io pago la pigione,</l>
           <l>
 E del mobile ancor pago l'affitto!</l>
         </sp>
-        <sp>
+        <sp who="#liscione">
           <speaker>LISCIONE</speaker>
           <l>Mostratemi lo scritto!</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Io mando pane e vino e companatico,</l>
           <l>
@@ -614,37 +627,37 @@ Pago i medicamenti ed il baliatico.</l>
           <l>
 Io pago a Dirinduccia ...</l>
         </sp>
-        <sp>
+        <sp who="#liscione">
           <speaker>LISCIONE</speaker>
           <l>Il benefizio</l>
           <l>
 Voi troppo rinfacciate!</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Oh, Dirindina: sarà il mio precipizio,</l>
           <l>
 Questo baron, s'ora di qui non sfratta!</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Gli vo' pria la cravatta</l>
           <l>
 Per carità distendere ...</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Non la volete intendere!</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l> ... Come fa la Fringuella e la Sabina!</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Finiamola, Dirindina!</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Commar Dirindona,</l>
           <l>
@@ -656,7 +669,7 @@ E lascia la scuola</l>
           <l>
 Per fare il bordello.</l>
         </sp>
-        <sp>
+        <sp who="#liscione #dirindina">
           <speaker>LISCIONE e DIRINDINA</speaker>
           <l>Lasciatemi dire, è savia ed è buona</l>
           <l>
@@ -664,7 +677,7 @@ son savia e son buona</l>
           <l>
 È tutto martello.</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>La vostra figliola</l>
           <l>
@@ -672,13 +685,13 @@ Di me si trastulla</l>
           <l>
 E va con l'amico.</l>
         </sp>
-        <sp>
+        <sp who="#liscione #dirindina">
           <speaker>LISCIONE e DIRINDINA</speaker>
           <l>L'amor è pudico, gl' insegno l'azione.</l>
           <l>
 m'insegna</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>L'amor di Briccone</l>
           <l>
@@ -686,25 +699,25 @@ Insegna il malanno!</l>
           <l>
 M'en vo' e più non torno.</l>
         </sp>
-        <sp>
+        <sp who="#liscione #dirindina">
           <speaker>LISCIONE e DIRINDINA</speaker>
           <l>Andate, buon giomo,</l>
           <l>
 Andate, buon anno!</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Or ora in persona</l>
           <l>
 Vo' andar dal Pretore.</l>
         </sp>
-        <sp>
+        <sp who="#liscione #dirindina">
           <speaker>LISCIONE e DIRINDINA</speaker>
           <l>È putta d'onore.</l>
           <l>
 Son</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Comar Dirindona,</l>
           <l>
@@ -712,7 +725,7 @@ Venite a spartire</l>
           <l>
 Con qualche randello!</l>
         </sp>
-        <sp>
+        <sp who="#liscione #dirindina">
           <speaker>LISCIONE e DIRINDINA</speaker>
           <l>Lasciatemi dire ch' savia, ch' buona</l>
           <l part="I">son </l>
@@ -725,17 +738,17 @@ Ch'è tutto martello!</l>
       </div>
       <div>
         <head>Parte II</head>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Ma il vostro sentimento</l>
           <l>
 È ch'io vada a Milan.</l>
         </sp>
-        <sp>
+        <sp who="#liscione">
           <speaker>LISCIONE</speaker>
           <l>Sì che v'andiate.</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Senz'aver fondamento di musica</l>
           <l>
@@ -743,7 +756,7 @@ Neppur quanto conviene</l>
           <l>
 Salirò sulle scene?</l>
         </sp>
-        <sp>
+        <sp who="#liscione">
           <speaker>LISCIONE</speaker>
           <l>Il capitale</l>
           <l>
@@ -767,11 +780,11 @@ Son due chiavi luminose</l>
           <l>
 Per concerto d'ogni Amor.</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Di voi mi fido.</l>
         </sp>
-        <sp>
+        <sp who="#liscione">
           <speaker>LISCIONE</speaker>
           <l>Io vi starò da lato</l>
           <l>
@@ -781,13 +794,13 @@ Terrò ben regolato,</l>
           <l>
 Ch'accordi gl'istrumenti al vostro tuon.</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Ma sto provvista poco</l>
           <l>
 Di gioie e vestimenti ...</l>
         </sp>
-        <sp>
+        <sp who="#liscione">
           <speaker>LISCIONE</speaker>
           <l>Terremo in casa il giuoco</l>
           <l>
@@ -819,7 +832,7 @@ Drizzando verso lor sguardi e sospiri,</l>
           <l>
 Benché dica la parte che 'l musico si miri.</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Tutto farò! Talor cascare ad arte</l>
           <l>
@@ -833,7 +846,7 @@ Mi porti 'l giorno poi qualcun de' miei</l>
           <l>
 Più fidi cicisbei.</l>
         </sp>
-        <sp>
+        <sp who="#liscione">
           <speaker>LISCIONE</speaker>
           <l>Voi siete lesta</l>
           <l>
@@ -843,11 +856,11 @@ Da imparar anche questa</l>
           <l>
 Che a Pavia seppe far la Calandrina...</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Dìte.</l>
         </sp>
-        <sp>
+        <sp who="#liscione">
           <speaker>LISCIONE</speaker>
           <l>Venne la sedia</l>
           <l>
@@ -883,11 +896,11 @@ D'esser fingea svenuta</l>
           <l>
 Al caso della figlia.</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Oh, che gran furberia! Già intendo il resto!</l>
         </sp>
-        <sp>
+        <sp who="#liscione">
           <speaker>LISCIONE</speaker>
           <l>Gli amanti presto presto,</l>
           <l>
@@ -897,7 +910,7 @@ Perch'andasse alla scena, a lei portaro</l>
           <l>
 Cento fili di perle in men d'un'ora.</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Questa sì che l'imparo!</l>
           <l>
@@ -919,7 +932,7 @@ E nel cuore a poco a poco</l>
           <l>
 Le vesciche io gli farò.</l>
         </sp>
-        <sp>
+        <sp who="#liscione">
           <speaker>LISCIONE</speaker>
           <l>Ma quel che più pillotta e che più cuoce</l>
           <l>
@@ -933,7 +946,7 @@ Ditemi: in vostra vita</l>
           <l>
 Rappresentaste mai?</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Sì! Il personaggio</l>
           <l>
@@ -945,7 +958,7 @@ Che dolente e tapina</l>
           <l>
 Col ferro sfoderato ...</l>
         </sp>
-        <sp>
+        <sp who="#liscione">
           <speaker>LISCIONE</speaker>
           <l>O bene, o bene!</l>
           <l>
@@ -953,7 +966,7 @@ Dite se vi sovviene</l>
           <l>
 Di qualche forte scena alcuna cosa.</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Aspettate... ma in prosa</l>
           <l>
@@ -963,11 +976,11 @@ Aspettate ch'io vada</l>
           <l>
 Pel pugnal che bisogna a far l'azione...</l>
         </sp>
-        <sp>
+        <sp who="#liscione">
           <speaker>LISCIONE</speaker>
           <l>Prendete la mia spada e dite.</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Sì aspettate diceva</l>
           <l>
@@ -977,19 +990,19 @@ Diceva lo dirò se al cielo piace:</l>
           <l>
 «Enea, crudo e mendace...»</l>
         </sp>
-        <sp>
+        <sp who="#liscione">
           <speaker>LISCIONE</speaker>
           <l>Mettetevi in più fiera positura!</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Il congresso ancor dura!</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>«Vattene, infido, va!»</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Che diavolo sarà?</l>
           <l>
@@ -997,27 +1010,27 @@ Vuole ammazzarlo? Via, tiragli lì!</l>
           <l>
 Mi nascondo un po' qui.</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>«Va, che 'l cielo, se è giusto,</l>
           <l>
 Ti fulmini, fellone!»</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Sta ancor fermo il barone.</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>«E vendichi gli oltraggi che facesti,</l>
           <l>
 Spergiuro, alla mia fede...»</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Il baron ride e siede!</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>«Al mio zelo, al mio onore,</l>
           <l>
@@ -1025,11 +1038,11 @@ Perfido traditore,</l>
           <l>
 Al mio letto macchiato...»</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>... Ah, tristo disgraziato!</l>
         </sp>
-        <sp>
+        <sp who="#liscione">
           <speaker>LISCIONE</speaker>
           <l>Quelle parole del macchiato letto</l>
           <l>
@@ -1037,7 +1050,7 @@ Voi non avete detto</l>
           <l>
 Così forte che il popolo le intenda.</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Sfacciataggine orrenda!</l>
           <l>
@@ -1045,7 +1058,7 @@ Voler ch'anche si pubblichi tal fatto!</l>
           <l>
 Gran furfante e gran matto!</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>«Così le sante leggi</l>
           <l>
@@ -1053,12 +1066,12 @@ Del ciel calpesti e così me dileggi</l>
           <l>
 E rompi i sacri nodi maritali?»</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>
 Con Liscione sponsali?</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>«Così da questo seno,</l>
           <l>
@@ -1070,13 +1083,13 @@ Di te lo lasci e pieno?</l>
           <l>
 Ah, spietato destino!»</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>O sbagliò la natura,</l>
           <l>
 O il suo norcino.</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>«Ma paghi or or</l>
           <l>
@@ -1086,36 +1099,36 @@ L'infausta madre e 'l figlio</l>
           <l>
 Che concepito appena...»</l>
         </sp>
-        <sp>
+        <sp who="#liscione">
           <speaker>LISCIONE</speaker>
           <l>Su, via, coraggio, via!</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>
 «... Abbia per questa piaga il suo natale!»</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Sta ferma, anima mia!</l>
           <l>
 Lo manderem piuttosto all'ospedale...</l>
         </sp>
-        <sp>
+        <sp who="#liscione">
           <speaker>LISCIONE</speaker>
           <l>O quest'è bella assai!</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Dirindina, che fai?</l>
           <l>
 E che dirà la gente?</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Ridicolo accidente!</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Perdono all'amor tuo</l>
           <l>
@@ -1133,19 +1146,19 @@ Ragliar saprà di maggio,</l>
           <l>
 Con trillo e con passaggio!</l>
         </sp>
-        <sp>
+        <sp who="#liscione">
           <speaker>LISCIONE</speaker>
           <l>Semplice di tal guisa</l>
           <l>
 Non vidi mai, io crepo dalle risa!</l>
         </sp>
-        <sp>
+        <sp who="#dirindina">
           <speaker>DIRINDINA</speaker>
           <l>Anch'io ne crepo, ohimé,</l>
           <l>
 Ah, poveretta me, mi duol la panza!</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Cattiva gravidanza!</l>
           <l>
@@ -1161,11 +1174,11 @@ Purché resti nascosto</l>
           <l>
 Al popolo il negozio ...</l>
         </sp>
-        <sp>
+        <sp who="#liscione #dirindina">
           <speaker>LISCIONE e DIRINDINA</speaker>
           <l>Non ne faremo niente.</l>
         </sp>
-        <sp>
+        <sp who="#don_carissimo">
           <speaker>DON CARISSIMO</speaker>
           <l>Dammi la man, Liscione,</l>
           <l>
@@ -1175,7 +1188,7 @@ Che la creaturina</l>
           <l>
 Legittima sarà.</l>
         </sp>
-        <sp>
+        <sp who="#liscione #dirindina">
           <speaker>LISCIONE e DIRINDINA</speaker>
           <l>Ferma, ch'io son cappone,</l>
           <l>

--- a/tei/giraldi-cinzio-cleopatra.xml
+++ b/tei/giraldi-cinzio-cleopatra.xml
@@ -77,6 +77,64 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="cleopatra">
+            <persName>Cleopatra</persName>
+          </person>
+          <person xml:id="nutrice">
+            <persName>Nutrice di Cleopatra</persName>
+          </person>
+          <person xml:id="famigliare">
+            <persName>Famigliar di Cleopatra</persName>
+          </person>
+          <person xml:id="marco_antonio">
+            <persName>Marco Antonio</persName>
+          </person>
+          <person xml:id="capitano">
+            <persName>Capitano di Marco Antonio</persName>
+          </person>
+          <person xml:id="servo">
+            <persName>Servo di Marco Antonio</persName>
+          </person>
+          <person xml:id="cameriera">
+            <persName>Cameriera di Cleopatra</persName>
+          </person>
+          <person xml:id="eunuco">
+            <persName>Eunuco di Cleopatra</persName>
+          </person>
+          <person xml:id="coro">
+            <persName>Coro</persName>
+          </person>
+          <person xml:id="secretario">
+            <persName>Segretario di Cleopatra</persName>
+          </person>
+          <person xml:id="ottavio">
+            <persName>Ottavio</persName>
+          </person>
+          <person xml:id="agrippa">
+            <persName>Agrippa</persName>
+          </person>
+          <person xml:id="mecenate">
+            <persName>Mecenate</persName>
+          </person>
+          <person xml:id="alfiere">
+            <persName>Alfier del General di Ottavio</persName>
+          </person>
+          <person xml:id="olimpo">
+            <persName>Olimpo</persName>
+          </person>
+          <person xml:id="proculeio">
+            <persName>Proculeio</persName>
+          </person>
+          <person xml:id="gallo">
+            <persName>Gallo</persName>
+          </person>
+          <person xml:id="sacerdote">
+            <persName>Sacerdote di Cleopatra</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>2003-05-06T00:00:00.000+02:00</date><name>Simona Sansavini</name><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -163,8 +221,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
           <head>
             <hi rend="sc">LE PERSONE CHE PARLANO.</hi>
           </head>
-          <castItem type="role">
-            <role>Cleopatra</role>, <roleDesc>Reina</roleDesc>.
+          <castItem type="role"><role>Cleopatra</role>, <roleDesc>Reina</roleDesc>.
           </castItem>
           <castItem type="role">
             <role>Ottavio.</role>
@@ -297,14 +354,14 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <hi rend="sc">SCENA PRIMA</hi>
           </head>
           <pb n="7"/>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>Lassa, dove più mai debbo piegare</l>
             <l>L'afflitta mente mia? mi trovo tanto</l>
             <l>Da la Fortuna combattuta, ch'io</l>
             <l>Non so a che più sperare in cosa alcuna.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l>Reina mia, queste mortali cose</l>
             <l>Non rimangono sempre in uno stato,</l>
@@ -317,7 +374,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Avete avuta la Fortuna, lieta</l>
             <l>Vi devete sperar di averla ancora.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>Così seconda un lungo tempo sempre</l>
             <l>Avuta l'ho, così felice, ch'io</l>
@@ -325,12 +382,12 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>E quanto mi alzò al sommo de la ruota,</l>
             <l>Tanto mi cacci indegnamente al fondo.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l>E che cosa è, ch' ora temer vi faccia,</l>
             <l>Che vi sia sì nimica la Fortuna?</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>Ohimé, dapoi che <name>Marco Antonio</name>, e <name>Ottavio</name></l>
             <l>Vennero a la battaglia con le navi,</l>
@@ -358,7 +415,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Ma prima cacciar vo' del corpo l'alma,</l>
             <l>Ch'a vergogna sì vil condotta io sia.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l>Che stran pensier vi turba, ohimé, la mente?</l>
             <l>Sete come colui, che in campo viene</l>
@@ -378,7 +435,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Però, senza più affliggervi, vi piaccia</l>
             <l>Voler veder de la battaglia il fine.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>Non può quegli sperar lieto successo,</l>
             <l>Che si vede Fortuna ognor contraria,</l>
@@ -395,7 +452,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Spesso è cagion, che quel, che non potero</l>
             <l>Molti soldati fare, il fanno pochi.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l>Rimaner vi dee pur, Reina, a mente</l>
             <l>Quel, ch'udito da lui più volte avete</l>
@@ -414,17 +471,17 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>E s'allor vinse, perche non debbiamo</l>
             <l>Pensar che vincitore ora anche resti?</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>De la perdita, ohimé, mi dier gli Dei</l>
             <l>Cara nutrice, allora indizio espresso</l>
             <l>Ch'egli l'armata contra <name>Ottavio</name> mosse.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l>E ch'indizio fu quel, ch'or sì v'affligge?</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>Aveano alcune rondinelle il nido</l>
             <l>Per molti giorni fatto in quella nave,</l>
@@ -437,7 +494,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l><name>Nutrice</name> mia, ch'al fin sarà scacciato</l>
             <l>Di questo regno, chi or possiede il regno.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l>Se i regni si perdessero ogni volta,</l>
             <l>Che fan guerra fra lor gli augei, <name>Reina</name>,</l>
@@ -449,7 +506,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Questo sospetto, e fia gran senno omai</l>
             <l>Ad altro dare il cor, ch'a le querele.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>Forza è, ch'al lamentar si dia colei,</l>
             <l>Che non si vede innanzi altro che pianto,</l>
@@ -461,13 +518,13 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Udrai s' avrò cagion di pianger sempre.</l>
             <l part="I">Vo' che qui l'aspettiam.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l part="F">Come vi piace.</l>
             <l>E prego Dio, che questo timor vostro</l>
             <l>Abbia tal fin, che ne restiate lieta.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>Come esser puote ciò, se congiurate</l>
             <l>Sono contra di me nel ciel le stelle?</l>
@@ -477,7 +534,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
           <head>
             <hi rend="sc">SCENA SECONDA</hi>
           </head>
-          <sp>
+          <sp who="#famigliare">
             <speaker>Famigliare</speaker>
             <l>Miser colui, cui la Fortuna volta</l>
             <l>Le spalle, e gli si mostra aspra nemica,</l>
@@ -510,12 +567,12 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Molti altri, e molti a le scelerate opre,</l>
             <l>Il che si vede chiaro in questa guerra.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>Molto afflitto si mostra questi in atto,</l>
             <l>Né altro aspettar da lui posso ch'affanno.</l>
           </sp>
-          <sp>
+          <sp who="#famigliare">
             <speaker>Famigliare</speaker>
             <l>Col mal officio, ch'ha fatto costui,</l>
             <l>A la ruina nato de l'<name>Egitto</name>,</l>
@@ -538,12 +595,12 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Contra <name>Alessandria</name><name>Ottavio</name>, e a la reina</l>
             <l>Nostra, e al regno porta ultimo eccidio.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>Veggo, nutrice mia, quanto infelice</l>
             <l part="I">Novella apporta questi.</l>
           </sp>
-          <sp>
+          <sp who="#famigliare">
             <speaker>Famigliare</speaker>
             <l part="F">O poverella,</l>
             <l>O poverella <name>Cleopatra</name>, a che ora</l>
@@ -557,21 +614,21 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Allor, misera te, fu la ruina</l>
             <l>De te medesmo, e del tuo regno espressa.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>Starai a veder, che <name>Marco Antonio</name> in questa</l>
             <l>Battaglia è stato vinto, e preso, e morto.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l part="I">Forse che no.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra </speaker>
             <l part="F">Io veggo bene quanto</l>
             <l>Dolente vien costui verso la corte.</l>
           </sp>
-          <sp>
+          <sp who="#famigliare">
             <speaker>Famigliare</speaker>
             <l>Ma vedi com'a un tratto, avrà perduto</l>
             <l>Questa reina <name>Marco Antonio</name> e il regno.</l>
@@ -580,13 +637,13 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Del suo nemico, si pensò che fusse</l>
             <l>Cleopatra cagion del tradimento.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>Io non posso soffrir tanta dimora,</l>
             <l>Andiamo a lui, nutrice. Che novella</l>
             <l part="I">Porti dal campo?</l>
           </sp>
-          <sp>
+          <sp who="#famigliare">
             <speaker>Famigliare</speaker>
             <l part="F">La peggior, Reina,</l>
             <l>Che si possa portare a real donna.</l>
@@ -595,7 +652,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Vincitor vien verso la terra armato,</l>
             <l part="I">Per far preda di voi.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l part="F">Ohimé dolente,</l>
             <l>Bene il cor mi dicea, che ciò sarebbe,</l>
@@ -605,36 +662,36 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Meno la sorte buona, ei riman solo.</l>
             <l>Ma, dimmi, è vivo <name>Marco Antonio</name>? o morto?</l>
           </sp>
-          <sp>
+          <sp who="#famigliare">
             <speaker>Famigliare</speaker>
             <l>Egli vivo è ma sciocchezza è che in lui</l>
             <l part="I">Poniate alcuna speme.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l part="F">Ch'è egli forse</l>
             <l part="I">Ne le mani di <name>Ottavio</name>?</l>
           </sp>
-          <sp>
+          <sp who="#famigliare">
             <speaker>Famigliare</speaker>
             <l part="F">Egli è pur salvo.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>Ma perché in lui non debb'io por più speme,</l>
             <l part="I">S'egli salvo è?</l>
           </sp>
-          <sp>
+          <sp who="#famigliare">
             <speaker>Famigliare</speaker>
             <l part="F">Perché per capitale</l>
             <l part="I">Nemica vi ha.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l part="F">Per capital nemica</l>
             <l part="I">Mi ha <name>Marco Antonio</name>? che ne sai tu?</l>
           </sp>
-          <sp>
+          <sp who="#famigliare">
             <speaker>Famigliare</speaker>
             <l part="F">Tosto</l>
             <l>Che si vide tradir da' suoi soldati</l>
@@ -647,12 +704,12 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Tutta la gente, che mi avevi data,</l>
             <l>Perch' io rimanga del nemico preda.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l>Che strano guiderdon del vostro amore</l>
             <l part="I">Avete, ohimè, Reina.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l part="F">Questo a punto</l>
             <l><name>Nutrice</name> è la mercede, che la ria <gap/></l>
@@ -664,7 +721,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
           </head>
           <stage>Marco Antonio, Servo, Capitano.</stage>
           <pb n="15"/>
-          <sp>
+          <sp who="#marco_antonio">
             <speaker>Marco Antonio</speaker>
             <l>Io non voglio,</l>
             <l>Fedel mio, andar in man d'<name>Ottavio</name> vivo,</l>
@@ -672,7 +729,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l><name>Cassio</name> già me 'l mostrò, me 'l mostrò</l>
             <l><name>Bruto</name>.</l>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>Capitano</speaker>
             <l>Ne vo' che morte anche vi diate, questi</l>
             <l>Non son pensier, Signor, degni di voi.</l>
@@ -681,7 +738,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>E che non goda <name>Ottavio</name> di vedere,</l>
             <l>Che noi ci diamo, da noi stessi, morte.</l>
           </sp>
-          <sp>
+          <sp who="#marco_antonio">
             <speaker>Marco Antonio</speaker>
             <l>Ahi fedel mio, quanto sarei sciocco ora,</l>
             <l>S'io pensassi poter ricuperare</l>
@@ -695,7 +752,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Et a trastull' esser de la ria Fortuna,</l>
             <l>Che contra me s'è per <name>Ottavio</name> armata.</l>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>Capitano</speaker>
             <l>Signor, sì come non si inalza il saggio</l>
             <l>Per le felicità più che convenga</l>
@@ -713,7 +770,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>E che, col valor vostro, anche potreste</l>
             <l>Ottavio indurre a battersi la guancia.</l>
           </sp>
-          <sp>
+          <sp who="#marco_antonio">
             <speaker>Marco Antonio</speaker>
             <l>Sciocco colui, che nel fondo del mare</l>
             <l>Si trova nudo, e d'ogni forza privo,</l>
@@ -721,7 +778,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>E che giunto a l'estremo de la vita,</l>
             <l>Pensa di ricovrar la sua salute.</l>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>Capitano</speaker>
             <l>Prego, Signore, che per certo abbiate,</l>
             <l>Che insin che voi non perderete voi,</l>
@@ -751,7 +808,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Si acquista pregio anche ne' casi estremi,</l>
             <l>Malgrado che se n'abbia la Fortuna.</l>
           </sp>
-          <sp>
+          <sp who="#marco_antonio">
             <speaker>Marco Antonio</speaker>
             <l>Avuto ho del futur io chiaro segno,</l>
             <l>Insino nel principio de la guerra,</l>
@@ -768,7 +825,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Presidio alcun divin, presidio umano,</l>
             <l>Che debbo io altro bramar, che morir tosto?</l>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>Capitano</speaker>
             <l>Questa non è, Signor, la prima volta,</l>
             <l>Che dato vi ha crudel Fortuna assalto,</l>
@@ -805,11 +862,11 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Vi vegga anche pregiato e grande morto,</l>
             <l>In questa indignità de la fortuna.</l>
           </sp>
-          <sp>
+          <sp who="#marco_antonio">
             <speaker>Marco Antonio</speaker>
             <l>Non so, non so, come ciò far si possa.</l>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>Capitano</speaker>
             <l>Stringianci insieme a l'ultimo bisogno,</l>
             <l>Signore invitto, e con la spada in mano</l>
@@ -835,7 +892,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Destra di valor pegno, e di fortezza,</l>
             <l>A far del sangue ostil l'erbe vermiglie.</l>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>Servo</speaker>
             <l>Signor, ben vi consiglia il <name>Capitano</name>,</l>
             <l>E quantunque io sia servo, e molto toglia</l>
@@ -847,7 +904,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Che lasciate or questo disio di morte,</l>
             <l>E vi accostiate al suo fedel consiglio.</l>
           </sp>
-          <sp>
+          <sp who="#marco_antonio">
             <speaker>Marco Antonio</speaker>
             <l>In tanto dubbio son di me medesmo,</l>
             <l>Che meglio del morir non so vedere.</l>
@@ -862,7 +919,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>In allegrezza: ora attendiamo insieme,</l>
             <l>Che novelle ci apporta questa vecchia.</l>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>Capitano</speaker>
             <l>Dio voglia, che non sia la secure</l>
             <l>Che gli levi dal collo, a un colpo, il capo,</l>
@@ -875,17 +932,17 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
           <head>
             <hi rend="sc">SCENA SESTA</hi>
           </head>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l>Ahi quanto invidiosa è la Fortuna</l>
             <l>De le allegrezze umane! Quanto fele</l>
             <l>Pone costei ne le dolcezze altrui!</l>
           </sp>
-          <sp>
+          <sp who="#marco_antonio">
             <speaker>Marco Antonio</speaker>
             <l>Ahi che mal m'indovino.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l>O <name>Cleopatra</name>,</l>
             <l>Or dove son le tue virtuti? Or dove</l>
@@ -899,46 +956,46 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Dir, che ti aver colei tradito, a cui</l>
             <l>Eri più a cor, che la sua propria vita?</l>
           </sp>
-          <sp>
+          <sp who="#marco_antonio">
             <speaker>Marco Antonio</speaker>
             <l>Io mi sento uscir fuor del corpo l'alma,</l>
             <l>Io vo' saper, che lamentare è questo,</l>
             <l>Poi che par, che costei di me si doglia.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l>Oh dolorosa me, quanto infelice,</l>
             <l>Quanto calamitoso questo giorno</l>
             <l>E' stato a questa corte, a questo regno!</l>
           </sp>
-          <sp>
+          <sp who="#marco_antonio">
             <speaker>Marco Antonio</speaker>
             <l part="I">Che vi è nutrice ?</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l part="F">Ahi Signor mio, vi è il fine</l>
             <l>D'ogni nostra allegrezza, e d'ogni bene.</l>
           </sp>
-          <sp>
+          <sp who="#marco_antonio">
             <speaker>Marco Antonio</speaker>
             <l part="I">E che?</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l part="F">Io aver non posso, Signor mio,</l>
             <l>Tanto spirto a la voce, ch'io ve 'l narri.</l>
           </sp>
-          <sp>
+          <sp who="#marco_antonio">
             <speaker>Marco Antonio</speaker>
             <l part="I">Perché? Fate ch'io il sappia.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l part="F">Perché omai</l>
             <l>Ci è tolta ogni speranza di salute.</l>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>Capitano</speaker>
             <l>Perché? perché temete <name>Ottavio</name>? Questi</l>
             <l>Sol basta a far che siamo salvi tutti!</l>
@@ -948,28 +1005,28 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Di noi, ché potrebbe egli esser perdente:</l>
             <l>Salvo il nostro signor siam salvi tutti.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l>Non bramiam più salvezza, anzi a gran grazia</l>
             <l>Fia a tutti noi la morte, poi che morto</l>
             <l>Ci è quanto ben noi avevamo al mondo.</l>
           </sp>
-          <sp>
+          <sp who="#marco_antonio">
             <speaker>Marco Antonio</speaker>
             <l part="I">Che dite voi di morte?</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l part="F">Io dico: Ahi lassa,</l>
             <l>Ch'ogni gioia mi è affanno, e che la vita</l>
             <l>Mi è morte espressa, poscia che mi è tolta</l>
             <l>Chi mi fea l'amar dolce, e il tristo lieto.</l>
           </sp>
-          <sp>
+          <sp who="#marco_antonio">
             <speaker>Marco Antonio</speaker>
             <l part="I">E chi?</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l part="F">Signor, colei che la vita era</l>
             <pb n="19"/>
@@ -978,34 +1035,34 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Reina, ohimè, ohimé, ove vi ha condutta</l>
             <l part="I">Rispetto altrui?</l>
           </sp>
-          <sp>
+          <sp who="#marco_antonio">
             <speaker>Marco Antonio</speaker>
             <l part="F">Piangete <name>Cleopatra</name></l>
             <l part="I">A quel ch'io veggo.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l part="F">Io piango lei Signore,</l>
             <l>Lei piango sol, sol lei, né più mi spero</l>
             <l>Cosa lieta veder, mentre ch'io viva.</l>
           </sp>
-          <sp>
+          <sp who="#marco_antonio">
             <speaker>Marco Antonio</speaker>
             <l>E che non vive <name>Cleopatra</name>? Ahi lasso,</l>
             <l part="I">Non vive Cleopatra?</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l part="F">No, Signore,</l>
             <l>Che vivere non volle in ira a voi;</l>
             <l>Ma volle la infelice farvi chiaro,</l>
             <l>Col suo morir, che non vi avea tradito.</l>
           </sp>
-          <sp>
+          <sp who="#marco_antonio">
             <speaker>Marco Antonio</speaker>
             <l part="I">Ohimé.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l part="F">Come mai foste, alto Signore,</l>
             <l>Dubbioso sì di lei, che la chiamaste</l>
@@ -1013,11 +1070,11 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Ohimé infelice, ahi trista me, che senza</l>
             <l>Il vostro amor viver non ha voluto.</l>
           </sp>
-          <sp>
+          <sp who="#marco_antonio">
             <speaker>Marco Antonio</speaker>
             <l>Dunque è solo per me <name>Cleopatra</name> morta?</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l>Per voi, Signor. Tantosto ch'ella udìo,</l>
             <l>Che l'amor vostro avea perduto, un grido</l>
@@ -1030,7 +1087,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Oh dolorosa me", si passò il core,</l>
             <l part="I">E cadeo morta.</l>
           </sp>
-          <sp>
+          <sp who="#marco_antonio">
             <speaker>Marco Antonio</speaker>
             <l part="F">O <name>Cleopatra</name>, adunque</l>
             <l>Viver poss' io, sapendo esser te morta?</l>
@@ -1048,7 +1105,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Mostro mi hai dunque <name>Cleopatra</name>, come</l>
             <l>Si dee far fine a le miserie umane.</l>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>Capitano</speaker>
             <l>Signore, vane son queste querele,</l>
             <l>E a voi disconvenevoli, a salvarsi.</l>
@@ -1064,22 +1121,22 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Ricovrate voi dunque, e siavi a grado</l>
             <l>Che la calamità vostra sia morta.</l>
           </sp>
-          <sp>
+          <sp who="#marco_antonio">
             <speaker>Marco Antonio</speaker>
             <l>Or taci, e fa', se mi ami, che più mai</l>
             <l>Io non oda da te queste parole.</l>
             <l>Valeva più costei, che tutto il mondo.</l>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>Capitano</speaker>
             <l>Ben avea questa un animo romano</l>
             <l part="I">Tutto in sua forza.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l part="F">Io me ne maraviglio.</l>
           </sp>
-          <sp>
+          <sp who="#marco_antonio">
             <speaker>Marco Antonio</speaker>
             <l>Nutrice, io verrei dentro a veder quella</l>
             <l>Morta, che viva era la vita mia,</l>
@@ -1090,13 +1147,13 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Però, nutrice, voi l'estremo ufficio</l>
             <l part="I">Farete verso lei.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l part="F">Non mancheremo,</l>
             <l>Signor, del nostro debito, quantunque</l>
             <l>Miserabil ne sia vederla tale.</l>
           </sp>
-          <sp>
+          <sp who="#marco_antonio">
             <speaker>Marco Antonio</speaker>
             <l>Entriamo in casa, et ivi a le mie angoscie</l>
             <l>Con la morte darò dicevol fine.</l>
@@ -1106,7 +1163,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
           <head>
             <hi rend="sc">SCENA SETTIMA</hi>
           </head>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l>Sì misera veggo or la mia reina,</l>
             <l>E sì intenta la sorte ai danni suoi,</l>
@@ -1128,7 +1185,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
           <head>
             <hi rend="sc">SCENA OTTAVA</hi>
           </head>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>In dubbio son di me medesma, insino</l>
             <l>Che novella non ho da la nutrice,</l>
@@ -1137,11 +1194,11 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <pb n="21"/>
             <l part="I">Che giù l'attendo.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>Cameriera</speaker>
             <l part="M">Io vado.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l part="F">Piaccia al Cielo,</l>
             <l>Che tal risposta abbia, dal signor mio,</l>
@@ -1155,53 +1212,53 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Con ogni mia felicità, l'amore</l>
             <l part="I">Di<name> Marco Antonio</name>.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>Cameriera</speaker>
             <l part="F">La reina</l>
             <l part="I">Vi aspetta.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l part="F">A lei veniva,</l>
             <l>Senza che mi chiamassi, a lunghi passi.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l part="I">Or ecco la nutrice.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l part="F">Io mi credea</l>
             <l>Trovarvi entro al sepolcro, e però i' era</l>
             <l part="I">Per la porta di dietro entrata.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l part="F">Ohimé</l>
             <l>Ch'uscita sono, per veder tornarti.</l>
             <l>Dimmi, cara nutrice, che novella</l>
             <l part="I">Porti da <name>Marco Antonio</name>?</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l part="F">Che mai sdegno</l>
             <l>Non spegne ardente amore. Il signor vostro</l>
             <l>E' più vostro che mai, più che mai vi ama.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l part="I">E questo è ver?</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l part="M">Ver è, Reina.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l part="F">Mi hai</l>
             <l part="I">Data la vita.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l part="F">Se questa novella</l>
             <l>A voi data ha la vita, io temo molto,</l>
@@ -1210,29 +1267,29 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Tanto turbato il vidi, et aver tanto</l>
             <l>Sé, inteso morta voi, la vita a noia.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l part="I">Ahi che mi dici?</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l part="F">Certo io gli avrei</l>
             <l>Scoperto il ver, s'io non avessi avuto</l>
             <l part="I">Timor di errare.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l part="F">Ohimé cara nutrice:</l>
             <l part="I">Ch'aspra novella a questo?</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l part="F">E' di bisogno,</l>
             <l>(Che il lamentarsi qui nulla rileva)</l>
             <l>Che cerchi a provedergli, co 'l mostrargli</l>
             <l part="I">La vita vostra.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l part="F">Vien tu eunuco fuori,</l>
             <l>E vanne a <name>Marco Antonio</name>, e digli ch'io</l>
@@ -1248,17 +1305,17 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Che sia la nostra vita, ambi commune</l>
             <l>L'abbiamo, e la compiamo ambiduo insieme.</l>
           </sp>
-          <sp>
+          <sp who="#eunuco">
             <speaker>Eunuco</speaker>
             <l part="I">Io vo, Reina.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l part="F">Io qui nel mio sepolcro</l>
             <l>Ti aspetto, e voglia Dio, che tu mi porti</l>
             <l>Novella tal, che in parte il duol mi lievi.</l>
           </sp>
-          <sp>
+          <sp who="#eunuco">
             <speaker>Eunuco</speaker>
             <l>Userò ogni mio ingegno, per addurvi</l>
             <l>Cosa, Reina mia, che vi consoli.</l>
@@ -1268,7 +1325,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
           <head>
             <hi rend="sc">SCENA NONA</hi>
           </head>
-          <sp>
+          <sp who="#capitano">
             <speaker>Capitano</speaker>
             <l>Quant'è mal consigliato uomo, che tutto</l>
             <l>Si ponga in podestà di donna ch'ami,</l>
@@ -1303,7 +1360,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Se viva, e morta gli devea far guerra.</l>
           </sp>
           <pb n="23"/>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>L'alto, eterno Motore,</l>
             <l>Che far l'uomo dispose</l>
@@ -1385,7 +1442,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
           <head>
             <hi rend="sc">SCENA PRIMA</hi>
           </head>
-          <sp>
+          <sp who="#eunuco">
             <speaker>Eunuco</speaker>
             <l>Ahi potenza d'Amor, quanto sei grande,</l>
             <l>Poi che colui, che mai non han potuto</l>
@@ -1396,24 +1453,24 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Oh come rimaner vuol la reina</l>
             <l part="I">Stordita a tal novella!</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l part="F">Par ch'indugi</l>
             <l>Molto a venir l'eunuco; io temo molto,</l>
             <l>Che qualche caso stran non lo trattenga,</l>
             <l>Ond' io n'abbia cagion di maggior doglia.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l>Io da questo tardar vo' sperar bene.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>Oda chi regge il ciel le tue parole.</l>
             <l>Ma veggo la miseria mia sì grande,</l>
             <l>Ch'ogni mal temo, e ben nessuno spero.</l>
           </sp>
-          <sp>
+          <sp who="#eunuco">
             <speaker>Eunuco</speaker>
             <l>Io non so come volterò la lingua</l>
             <l>A darle così dura, e ria novella,</l>
@@ -1421,7 +1478,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Che con spiegarle ciò le passi il core.</l>
             <l part="I">Veggola.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l part="F">Ecco l'eunuco, ecco che porta</l>
             <l>Nel viso aperto il suo dolore interno.</l>
@@ -1432,23 +1489,23 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Che sia di <name>Marco Antonio</name>. Che novella</l>
             <l part="I">Mi apporti tu?</l>
           </sp>
-          <sp>
+          <sp who="#eunuco">
             <speaker>Eunuco</speaker>
             <l part="F">Reina, io vorrei</l>
             <l>Esser senz'occhi, e senza lingua nato,</l>
             <l>Per non aver veduto, e per non dirvi</l>
             <l>Di <name>Marco Antonio</name>, quel che dir vi debbo.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l part="I">Ohimé, che stran principio.</l>
           </sp>
-          <sp>
+          <sp who="#eunuco">
             <speaker>Eunuco</speaker>
             <l part="F">Egli, Reina,</l>
             <l part="I">E' poco men che morto.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l part="F">Ahi sorte iniqua</l>
             <l>Sorte crudele, ohimé, spietata sorte,</l>
@@ -1456,33 +1513,33 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Farmi la più dolente, ch'oggi viva:</l>
             <l>E per ch'have sì presso, ohimé, la morte?</l>
           </sp>
-          <sp>
+          <sp who="#eunuco">
             <speaker>Eunuco</speaker>
             <l>Perch'egli con la spada ha sé percosso</l>
             <l>Di sì grave percossa, e tanto sangue</l>
             <l>Uscito gli è fuor de la piaga, ch'egli</l>
             <l>Puote lo spirto a gran fatica avere.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>Ahi <name>Cleopatra</name>, ahi misera <name>Cleopatra</name>,</l>
             <l>Questo colpo medesmo anche ha te uccisa.</l>
             <l part="I">Fammi sapere il tutto.</l>
           </sp>
-          <sp>
+          <sp who="#eunuco">
             <speaker>Eunuco</speaker>
             <l part="F">Egli sì tosto</l>
             <l>Che da me intese, ch'eravate viva,</l>
             <l>alquanto ricovrossi, e lieto disse:</l>
             <l>Esser più non mi può grave la morte.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>Ahi lassa, ben fia a me grave la vita,</l>
             <l>Se vita si può dir ch' abbia colei,</l>
             <l>Che ir oda a morte chi era la sua vita.</l>
           </sp>
-          <sp>
+          <sp who="#eunuco">
             <speaker>Eunuco</speaker>
             <l>Poi replicò, Non mi è grave la morte</l>
             <l>Poi che colei, per cui mi son trafisso,</l>
@@ -1491,21 +1548,21 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Levato si è con gran fatica, e vuole</l>
             <l part="I">Essere a voi condutto.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l part="F">Ahi, <name>Cleopatra</name>,</l>
             <l>Mentre dubitato hai di <name>Marco Antonio</name>,</l>
             <l>E col fingerti morta, cercato hai</l>
             <l>Di assicurarti, a lui data hai la morte.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l>Il vidi, ahi lassa, e se mi aveste detto,</l>
             <l>Ch'allor scoperto io gli avessi il vero,</l>
             <l>S'io il ritrovava a voi, qual prima, amico,</l>
             <l part="I">Ciò non saria svenuto.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l part="F">Tu di' vero,</l>
             <l>Ma fuggir non si può quel che il ciel vuole.</l>
@@ -1514,12 +1571,12 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Se scioccamente errai, con pensier saggio</l>
             <l>L'error corregerò con le mie mani.</l>
           </sp>
-          <sp>
+          <sp who="#eunuco">
             <speaker>Eunuco</speaker>
             <l>Ecco, Reina, che si fa condurre</l>
             <l>Da' suoi soldati a la presenza vostra.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>Ahi <name>Marco Antonio</name>, ahi <name>Marco Antonio</name> mio,</l>
             <l>Come si incalza ogn'or più la Fortuna</l>
@@ -1538,13 +1595,13 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Far non potete con la mano vostra,</l>
             <l>Io stessa il compirò, con la mia propria.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO.</speaker>
             <l>Ahi voglia Dio, che questo non avenga,</l>
             <l>Che ciò sarebbe una crudel secure,</l>
             <l>Che a tutte il capo ci torria dal collo.</l>
           </sp>
-          <sp>
+          <sp who="#marco_antonio">
             <speaker>Marco Antonio</speaker>
             <l>Reina, io voglio che restiate viva,</l>
             <l>Acciò che, quando pur io esca di vita,</l>
@@ -1563,7 +1620,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Che conosciuto ho singolare in voi,</l>
             <l>Mentre Fortuna e il ciel non ci ebbe a sdegno.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>Ohimé non so, non so come esser possa,</l>
             <l>Ch'essendo voi, Signor, l'anima mia,</l>
@@ -1571,7 +1628,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Cleopatra, Signor, viver non vuole,</l>
             <l>Visto morto colui, ch'è la sua vita.</l>
           </sp>
-          <sp>
+          <sp who="#marco_antonio">
             <speaker>Marco Antonio</speaker>
             <l>Entriamo, anima mia, ch'ivi averemo</l>
             <l>Agio di dir ciò, che bisogna fia,</l>
@@ -1579,11 +1636,11 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Tratto, che de la piega io mi avrò fuori</l>
             <l>Questa spada, and'io mi ho traffisso il fianco.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>Entriam Signor, ch'io vo' morir con voi.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO.</speaker>
             <l>Ohimé, s'è Dio nel ciel, che tenga cura</l>
             <l>Dei regni, degli imperi, e di chi regge</l>
@@ -1598,7 +1655,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <hi rend="sc">SCENA SECONDA</hi>
           </head>
           <pb n="27"/>
-          <sp>
+          <sp who="#eunuco">
             <speaker>Eunuco</speaker>
             <l>Il pensar d'esser lieto sempre in terra,</l>
             <l>E di passar la vita senza angoscie,</l>
@@ -1621,49 +1678,49 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Mentre egli vive, e che il dì estremo è quello,</l>
             <l>Che felice l'uom mostra, o il mostra tristo.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>Cameriera</speaker>
             <l>Ahi povera reina, che pietade</l>
             <l part="I">E' vederla sì afflitta!</l>
           </sp>
-          <sp>
+          <sp who="#eunuco">
             <speaker>Eunuco</speaker>
             <l part="F">Costei duolsi</l>
             <l>Di quel, ch'io ragionava or ora meco.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>Cameriera</speaker>
             <l>Chi pensato avria mai vederla tanto</l>
             <l>Per <name>Marco Antonio</name> gravemente afflitta,</l>
             <l>Per cui si tenne già tanto felice.</l>
           </sp>
-          <sp>
+          <sp who="#eunuco">
             <speaker>Eunuco</speaker>
             <l part="I">Che piagni?</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>Cameriera</speaker>
             <l part="F">Io piango la sciagura nostra,</l>
             <l part="I">Misera me.</l>
           </sp>
-          <sp>
+          <sp who="#eunuco">
             <speaker>Eunuco</speaker>
             <l part="F">Qual gran sciagura e questa?</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>Cameriera</speaker>
             <l>Nel trar fuor de la piaga a <name>Marco Antonio</name></l>
             <l>La spada, uscita gli è col sangue l'alma,</l>
             <l part="I">Onde morto è.</l>
           </sp>
-          <sp>
+          <sp who="#eunuco">
             <speaker>Eunuco</speaker>
             <l part="F">Deh fusse egli pur morto</l>
             <l>Il primo dì, ch'ei venne in questo regno,</l>
             <l>Ché involti non saressimo nei mali,</l>
             <l>In ch'ora siamo la reina, e noi.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>Cameriera</speaker>
             <l>O povera reina, ella ben mostra</l>
             <l>Quanto amato abbia <name>Marco Antonio</name> vivo,</l>
@@ -1679,7 +1736,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Levata che si sia di sopra il corpo</l>
             <l>Del suo morto signor, non si dia morte.</l>
           </sp>
-          <sp>
+          <sp who="#eunuco">
             <speaker>Eunuco</speaker>
             <l>Eccola ch'esce fuor, noi ritirianci,</l>
             <l>Acciò che da sé sola lagrimando</l>
@@ -1691,7 +1748,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <hi rend="sc">SCENA TERZA</hi>
           </head>
           <pb n="28"/>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>Ahi <name>Cleopatra</name>, ahi misera <name>Cleopatra</name>,</l>
             <l>E' giunto pur quell'infelice giorno </l>
@@ -1715,17 +1772,17 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>E, morto lui, tu puoi vivere ancora</l>
             <l part="I"><name>Cleopatra</name> infelice?</l>
           </sp>
-          <sp>
+          <sp who="#eunuco">
             <speaker>Eunuco</speaker>
             <l part="F">Creder voglio,</l>
             <l>Che queste grida, e questo lagrimare</l>
             <l>Scemerà a la reina in parte il duolo.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>Cameriera</speaker>
             <l part="I">Anch'io così m'istimo.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l part="F">E mirar puoi,</l>
             <l>Morto il tuo <name>Marco Antonio</name>, ancora il sole?</l>
@@ -1742,28 +1799,28 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Che come del commune sangue tinta</l>
             <l>Misera me, sarai, come fra l'ombre.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>Cameriera</speaker>
             <l>Ohimé che veggo? Ohimé, si vuol dar morte</l>
             <l part="I">La reina.</l>
           </sp>
-          <sp>
+          <sp who="#eunuco">
             <speaker>Eunuco</speaker>
             <l part="F">Corriamo ad impedire,</l>
             <l part="I">Che non si passi il core.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l part="F">Così ancora</l>
             <l>Tanto pietoso il Ciel ci sia, che i corpi</l>
             <l>Nostri sian giunti in un sepolcro insieme.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>Cameriera</speaker>
             <l part="I">Ahi Reina,</l>
           </sp>
           <pb n="29"/>
-          <sp>
+          <sp who="#eunuco">
             <speaker>Eunuco</speaker>
             <l part="F">Ahi Reina, a che vi mena</l>
             <l>Troppo dolor, troppo desio di morte?</l>
@@ -1779,7 +1836,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Vi prego, a lasciar or questo pensiero,</l>
             <l>Et ad uso miglior servarvi viva.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>Viver non posso, morto il signor mio.</l>
             <l>Egli era la mia vita, e senza lui</l>
@@ -1790,7 +1847,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Lasciate, prego, ohimé, che se ne vada</l>
             <l>Là, ove brama di gir la mia stanca alma.</l>
           </sp>
-          <sp>
+          <sp who="#eunuco">
             <speaker>Eunuco</speaker>
             <l>Non si conviene a una reina tale,</l>
             <l>Qual sete voi, sì miserabil fine.</l>
@@ -1798,7 +1855,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Vedrete quanto sconvenevol sia,</l>
             <l>Questo pensier, ch'ora vi sprona a morte.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>Differir ben potete il fine mio,</l>
             <l>Ma non già far, ch'egli non abbia effetto,</l>
@@ -1808,7 +1865,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Che mi traffigge il cor, con mille punte,</l>
             <l>Caccierà fuor di questo corpo l'alma.</l>
           </sp>
-          <sp>
+          <sp who="#eunuco">
             <speaker>Eunuco</speaker>
             <l>Entrate alta Reina, e ricovrate</l>
             <l>Il core invitto a le terrene tutte,</l>
@@ -1816,13 +1873,13 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Vincerete il dolore, e la Fortuna</l>
             <l>Vinta si rimarrà dal senno vostro.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>Non può più senno in me, non può consiglio,</l>
             <l>Né posso più non rimaner sommersa</l>
             <l>Nel mortal golfo degli affanni miei.</l>
           </sp>
-          <sp>
+          <sp who="#eunuco">
             <speaker>Eunuco</speaker>
             <l>Chi volesse apparar di aver pietade</l>
             <l>A le miserie altrui, mirasse questa</l>
@@ -1865,7 +1922,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
           <head>
             <hi rend="sc">SCENA QUARTA</hi>
           </head>
-          <sp>
+          <sp who="#secretario">
             <speaker>Secretario</speaker>
             <l>Se l'infelicità dei regni umani</l>
             <l>Avesser corpo, e tutte insieme a questi</l>
@@ -1923,7 +1980,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
           <head>
             <hi rend="sc">SCENA QUINTA</hi>
           </head>
-          <sp>
+          <sp who="#ottavio">
             <speaker>Ottavio</speaker>
             <l>Poi che ridutto ho <name>Marco Antonio</name> a tale</l>
             <l>Che difesa non ha, non ha rifugio,</l>
@@ -1940,7 +1997,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Io voglio udir in ciò il giudicio vostro.</l>
             <l part="I">Che parti Agrippa?</l>
           </sp>
-          <sp>
+          <sp who="#agrippa">
             <speaker>Agrippa</speaker>
             <l part="F">Parmi, Signor mio,</l>
             <l>Che levar la cagion di aver travaglio</l>
@@ -1978,11 +2035,11 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Che la quiete, et il riposo vostro</l>
             <l>Sia, che non resti <name>Marco Antonio</name> vivo.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>Ottavio</speaker>
             <l part="I">Che parti Mecenate?</l>
           </sp>
-          <sp>
+          <sp who="#mecenate">
             <speaker>Mecenate</speaker>
             <l part="F">Ancor che saggio</l>
             <l>Agrippa sia, Signore, e a me amico,</l>
@@ -1996,7 +2053,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Che desio de l'onore, e del ben vostro,</l>
             <l>Ora dir mi farà quanto dirovvi.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>Ottavio</speaker>
             <l>Io così credo, Mecenate, e s'io</l>
             <l>Non avessi voluto il parer vostro,</l>
@@ -2007,7 +2064,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Però di' pur ciò, che ti pare, e pensa,</l>
             <l>Ché ciò, che tu dirai mi sarà grato.</l>
           </sp>
-          <sp>
+          <sp who="#mecenate">
             <speaker>Mecenate</speaker>
             <l>Io saprei confortare ogni signore,</l>
             <l>Ancor che manifestamente offeso,</l>
@@ -2047,7 +2104,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Mostrarvi degno di grandezza tale,</l>
             <l>Che perdonar l'offesa a <name>Marco Antonio</name>.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>Ottavio</speaker>
             <l>Parriati dunque, che dopo sì gravi,</l>
             <l>E sì crudeli ingiurie ricevute,</l>
@@ -2059,7 +2116,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Dopo le paci, e i parentadi fatti,</l>
             <l>Di perder, con l'imperio, anche la vita!</l>
           </sp>
-          <sp>
+          <sp who="#mecenate">
             <speaker>Mecenate</speaker>
             <l>Questa, Signor, (e vi cheggio licenza,</l>
             <l>Di dir da fedel servo in questa parte</l>
@@ -2136,7 +2193,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Che pericol non è ch'alzi la testa</l>
             <l>Contra voi, solo imperador del mondo.</l>
           </sp>
-          <sp>
+          <sp who="#agrippa">
             <speaker>Agrippa</speaker>
             <l>Se bene a <name>Marco Antonio </name>in stato umile,</l>
             <pb n="35"/>
@@ -2158,7 +2215,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Sian quali esser si voglian le ragioni,</l>
             <l>Che voi avete, <name>Mecenate</name>, addutte.</l>
           </sp>
-          <sp>
+          <sp who="#mecenate">
             <speaker>Mecenate</speaker>
             <l>Uccidendo uno un re, minaccia molti,</l>
             <l>Ché come con timor di ognun dal cielo</l>
@@ -2187,12 +2244,12 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Fra tante, e tante, che ne mandò al cielo,</l>
             <l>Restasse il sol da alcuna d'esse offeso?</l>
           </sp>
-          <sp>
+          <sp who="#agrippa">
             <speaker>Agrippa</speaker>
             <l>No 'l cred' io già, ma ben sciocco mi parve,</l>
             <l>Chi si diede a tentare opra sì vana.</l>
           </sp>
-          <sp>
+          <sp who="#mecenate">
             <speaker>Mecenate</speaker>
             <l>Or questo essempio puo mostrarvi chiaro,</l>
             <l>Quanto si ponno aver color per pazzi,</l>
@@ -2205,7 +2262,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Più che potesse il sol quei con gli strali.</l>
           </sp>
           <pb n="36"/>
-          <sp>
+          <sp who="#agrippa">
             <speaker>Agrippa</speaker>
             <l>Mecenate, io non voglio addurvi essempi</l>
             <l>Contra gli addutti, ancor che poria dirvi,</l>
@@ -2220,12 +2277,12 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Mi par che non conosca la sua forza,</l>
             <l>E se mal glien' avien poscia, se 'l merta.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>Ottavio</speaker>
             <l>Questa <name>Mecenate</name> è ragion, che puote</l>
             <l>Farti veder quel, che in ciò far mi debba.</l>
           </sp>
-          <sp>
+          <sp who="#mecenate">
             <speaker>Mecenate</speaker>
             <l>Signore, se mi lece conferire</l>
             <l>L'umili cose a le sublime, e eccelse,</l>
@@ -2264,7 +2321,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Un re verso color, che l'hanno offeso,</l>
             <l>Quale egli vuol, che Dio sia verso lui.</l>
           </sp>
-          <sp>
+          <sp who="#agrippa">
             <speaker>Agrippa</speaker>
             <l>Et io dico: Signor, che troppo mite</l>
             <l>Mecenate ha la mente, e che se vivo</l>
@@ -2283,7 +2340,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Egli è l'alfier del generale. Udiamo</l>
             <l part="I">Che novella ei ci apporta.</l>
           </sp>
-          <sp>
+          <sp who="#alfiere">
             <speaker>Alfiere</speaker>
             <l part="F">Il generale</l>
             <l>Saper vi fa, Signor, che tutto il campo</l>
@@ -2296,7 +2353,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Vi piaccia di venir, per impedire</l>
             <l part="I">Disordine sì grave.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>Ottavio</speaker>
             <l part="F">Andiamo, e poi</l>
             <l>Che sete di parer fra voi contrario,</l>
@@ -2309,7 +2366,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Che conchiuso averete, perché noi</l>
             <l>Scegliamo quel, che ci parerà il meglio.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Io creder più non vo', che il saper nostro</l>
             <l>Regga le cose umane,</l>
@@ -2372,7 +2429,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
           <head>
             <hi rend="sc">SCENA PRIMA</hi>
           </head>
-          <sp>
+          <sp who="#olimpo">
             <speaker>Olimpo</speaker>
             <l>Poscia che il segretario a la reina,</l>
             <l>Condutto mi ebbe, e ch'io la vidi afflitta</l>
@@ -2418,18 +2475,18 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
           <head>
             <hi rend="sc">SCENA SECONDA</hi>
           </head>
-          <sp>
+          <sp who="#olimpo">
             <speaker>Olimpo</speaker>
             <l part="I">Che ci è nutrice?</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l part="F">Ci è, che la reina</l>
             <l>Vi prega, che vogliate a lei venire,</l>
             <l>E non vi avere a mal, ne avere a sdegno</l>
             <l>Quanto ella detto vi ha, dal dolor vinta.</l>
           </sp>
-          <sp>
+          <sp who="#olimpo">
             <speaker>Olimpo</speaker>
             <l>So che mutazioni, in picciol tempo,</l>
             <l>Si veggono in un core addolorato.</l>
@@ -2443,7 +2500,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Cosa che detta m'abbia, quanto ho visto,</l>
             <l>Ch'a dirmi ciò grave dolor l'ha indutta.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l>Mostrate ben, Signor d'esser quel vero</l>
             <l>Servitor, che vi vidi esser mai sempre</l>
@@ -2451,7 +2508,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Che in lei mi par veder scemare il duolo,</l>
             <l part="I">Tosto che vi vedrà.</l>
           </sp>
-          <sp>
+          <sp who="#olimpo">
             <speaker>Olimpo</speaker>
             <l part="F">Deh voglia Dio,</l>
             <l>Ch'io trovi modo di piegarla tanto,</l>
@@ -2464,7 +2521,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
           <head>
             <hi rend="sc">SCENA TERZA</hi>
           </head>
-          <sp>
+          <sp who="#mecenate">
             <speaker>Mecenate</speaker>
             <l><name>Agrippa</name>, non bisogna in questo caso,</l>
             <l>Solo considerar, che <name>Marco Antonio</name></l>
@@ -2511,7 +2568,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Vostra andarete discorrendo il tutto,</l>
             <l>Non sia per dispiacervi il parer mio.</l>
           </sp>
-          <sp>
+          <sp who="#agrippa">
             <speaker>Agrippa</speaker>
             <l>L'esser contrario a la sentenza vostra,</l>
             <l><name>Mecenate</name>, mi par cosa assai dura.</l>
@@ -2538,7 +2595,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Ora in stato non è, che la sua morte</l>
             <l part="I">Possa mover tumulto.</l>
           </sp>
-          <sp>
+          <sp who="#mecenate">
             <speaker>Mecenate</speaker>
             <l part="F">E questo a punto</l>
             <l>Può mostrar anche, che non pòn tumulti</l>
@@ -2556,7 +2613,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Porlo in custodia tal, ch'egli non possa</l>
             <l>Pur sospirar, non che destar discordie?</l>
           </sp>
-          <sp>
+          <sp who="#agrippa">
             <speaker>Agrippa</speaker>
             <l>Una prigion perpetua, <name>Mecenate</name>,</l>
             <l>A liber uom, più dura è che la morte,</l>
@@ -2564,7 +2621,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Che dargli morte, e mantenerlo in vita,</l>
             <l>Perché vivendo, egli morisse sempre.</l>
           </sp>
-          <sp>
+          <sp who="#mecenate">
             <speaker>Mecenate</speaker>
             <l>Siane ciò, ch'esser possa, in questa guisa</l>
             <l><name>Ottavio</name> non si tingeria le mani</l>
@@ -2576,11 +2633,11 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Con quella spada sanguinosa in mano,</l>
             <l>Così dolente, e conturbato in vista?</l>
           </sp>
-          <sp>
+          <sp who="#agrippa">
             <speaker>Agrippa</speaker>
             <l>Egli è un de' capitan di <name>Marco Antonio</name>.</l>
           </sp>
-          <sp>
+          <sp who="#mecenate">
             <speaker>Mecenate</speaker>
             <l>Qualche stran caso ivi sarà avenuto,</l>
             <l>Stiamo a veder ciò, che di novo apporta.</l>
@@ -2590,7 +2647,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
           <head>
             <hi rend="sc">SCENA QUARTA</hi>
           </head>
-          <sp>
+          <sp who="#capitano">
             <speaker>Capitano</speaker>
             <l>Gli avenimenti della guerra sono</l>
             <l>In guisa dubbi, che non puote alcuno</l>
@@ -2604,20 +2661,20 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Nel cominciar di questa aspra battaglia,</l>
             <l>Per aver del suo mal giuoco, e trastullo.</l>
           </sp>
-          <sp>
+          <sp who="#mecenate">
             <speaker>Mecenate</speaker>
             <l part="I">Certo che dice il vero.</l>
           </sp>
-          <sp>
+          <sp who="#agrippa">
             <speaker>Agrippa</speaker>
             <l part="F">è meglio ch'egli</l>
             <l>Si dolga, ch'a doler ci abbiamo noi.</l>
           </sp>
-          <sp>
+          <sp who="#mecenate">
             <speaker>Mecenate</speaker>
             <l part="I">Sí veramente.</l>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>Capitano</speaker>
             <l part="F">E, per mostrar ben questa</l>
             <l>Nemica de' felici avenimenti,</l>
@@ -2631,49 +2688,49 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Dopo la vile, e biasimevol fuga,</l>
             <l>Avuta ha la cagion de la sua morte.</l>
           </sp>
-          <sp>
+          <sp who="#mecenate">
             <speaker>Mecenate</speaker>
             <l>Per quel, ch'intendo, <name>Marco Antonio</name> è morto.</l>
             <l part="I">Me increscerebbe assai.</l>
           </sp>
-          <sp>
+          <sp who="#agrippa">
             <speaker>Agrippa</speaker>
             <l part="F">è morto certo.</l>
             <l>Meglio è che noi facciam ch'<name>Ottavio</name> il sappia.</l>
           </sp>
-          <sp>
+          <sp who="#mecenate">
             <speaker>Mecenate</speaker>
             <l>Egli è pur meglio ch'intendiamo certa</l>
             <l part="I">La cosa prima.</l>
           </sp>
-          <sp>
+          <sp who="#agrippa">
             <speaker>Agrippa</speaker>
             <l part="F">Che lamento è questo?</l>
             <l>Ch'importa questa spada, Capitano?</l>
           </sp>
-          <sp>
+          <sp who="#mecenate">
             <speaker>Mecenate</speaker>
             <l>Di qual sangue è ella tinta, od ove andate?</l>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>Capitano</speaker>
             <l>Ahi, Signor Mecenate, questa spada,</l>
             <l>Questa tagliente spada aperta ha il fianco</l>
             <l>Al signor nostro, e n'è rimaso estinto.</l>
           </sp>
-          <sp>
+          <sp who="#mecenate">
             <speaker>Mecenate</speaker>
             <l part="I">E perchè questo?</l>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>Capitano</speaker>
             <l part="F">Sol per <name>Cleopatra</name>.</l>
           </sp>
-          <sp>
+          <sp who="#agrippa">
             <speaker>Agrippa</speaker>
             <l part="I">Perchè per <name>Cleopatra</name>?</l>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>Capitano</speaker>
             <l part="F">S'era finta</l>
             <l>Morta essere ella, e per non sovrastare</l>
@@ -2689,7 +2746,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Ché caro avrò a morir, per la mia fede,</l>
             <l>Con quella spada, onde il signor mio è morto.</l>
           </sp>
-          <sp>
+          <sp who="#mecenate">
             <speaker>Mecenate</speaker>
             <l>Io credo, che perdon da <name>Ottavio</name> avrete,</l>
             <l>E che vi loderà de la fé vostra.</l>
@@ -2697,12 +2754,12 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Che costume è di <name>Ottavio</name> di deporre</l>
             <l part="I">Con l'arme l'odio.</l>
           </sp>
-          <sp>
+          <sp who="#agrippa">
             <speaker>Agrippa</speaker>
             <l part="F">E noi vi aiuteremo,</l>
             <l>Se bisogno vi fia d'aiuto nostro.</l>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>Capitano</speaker>
             <l>Non aspetto altro da la bontà vostra.</l>
           </sp>
@@ -2711,7 +2768,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
           <head>
             <hi rend="sc">SCENA QUINTA</hi>
           </head>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l>Che sorte, ohimé, che sorte fia la nostra</l>
             <l>In questa così grave aspra miseria?</l>
@@ -2728,7 +2785,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>O corte già d'ogni piacer ricetto,</l>
             <l>Come ora sei d'ogni dolore albergo!</l>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>Capitano</speaker>
             <l>Nutrice è ver, che quei, che son felici,</l>
             <l>Fortuna col peggio han sempre a le spalle.</l>
@@ -2742,7 +2799,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Sì piena di pericoli, e di doglie</l>
             <l>Veggo, di parte, in parte, or questa corte.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l>Figliuola il primo dì ne dà l'estremo,</l>
             <l>Ché col nostro destin tutti nasciamo.</l>
@@ -2753,7 +2810,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Non credea di vederla, mi rincresce</l>
             <l part="I">Trovarmi viva.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>Cameriera</speaker>
             <l part="F">Ohimé, nutrice, ohimé,</l>
             <l>Che ci giovano i pianti, et i sospiri,</l>
@@ -2762,7 +2819,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Né di tanti pericoli possiamo</l>
             <l>Trar la reina, e similmente noi?</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l>Figliuola mia, poscia che non poss'altro,</l>
             <l>Chiamata meco ti ho fuori di corte,</l>
@@ -2771,13 +2828,13 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Mentre in presenza er'io de la reina,</l>
             <l>E non ardia mandar fuori un sospiro.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>Cameriera</speaker>
             <l>Torniam nutrice in casa, a quella sorte,</l>
             <l>Che vorrà il cielo, a' nostri danni vòlto,</l>
             <l>Ch'abbia questa reina, e noi con lei.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l>Et aspettar la debbiam, figlia, sì grave,</l>
             <l>Che fia appo lei ogni miseria lieve.</l>
@@ -2787,7 +2844,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
           <head>
             <hi rend="sc">SCENA SESTA</hi>
           </head>
-          <sp>
+          <sp who="#mecenate">
             <speaker>Mecenate</speaker>
             <l>Alta virtù, che in nobil alma regni,</l>
             <l>Mostrar conviensi in ogni stato fuori,</l>
@@ -2832,7 +2889,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Voglio saper chi egli è. Dimmi, chi sei?</l>
             <l>Et ove vai? e che novelle porti?</l>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>Servo</speaker>
             <l>Io sono un sventurato, et infelice</l>
             <l>Servo di <name>Marco Antonio</name>, ch'ad <name>Ottavio
@@ -2842,11 +2899,11 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Con la tremante mano, e gliele manda</l>
             <l><name>Cleopatra </name>reina de l'<name>Egitto</name>.</l>
           </sp>
-          <sp>
+          <sp who="#mecenate">
             <speaker>Mecenate</speaker>
             <l part="I">E che fa <name>Cleopatra</name>?</l>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>Servo</speaker>
             <l part="F">Chi vedere</l>
             <l>Vuole il dolore in forma umana, miri</l>
@@ -2858,12 +2915,12 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Che temo molto, anzi non ho speranza</l>
             <l>Di veder contra lei benigno <name>Ottavio</name>.</l>
           </sp>
-          <sp>
+          <sp who="#mecenate">
             <speaker>Mecenate</speaker>
             <l>Va pur, che ti fo certo, che da lui</l>
             <l>Cosa non averai, se non da prence.</l>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>Servo</speaker>
             <l>Non so che possa fare un prence cosa</l>
             <l>Di gran prence più degna, che servare</l>
@@ -2871,16 +2928,16 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Se questo egli farà, mostrerà chiaro,</l>
             <l>Ch'abbia a l'impero suo l'animo uguale.</l>
           </sp>
-          <sp>
+          <sp who="#mecenate">
             <speaker>Mecenate</speaker>
             <l>Vanne con sicurezza di trovare</l>
             <l part="I">In <name>Ottavio</name> clemenza.</l>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>Servo</speaker>
             <l part="F">Il voglia Dio.</l>
           </sp>
-          <sp>
+          <sp who="#mecenate">
             <speaker>Mecenate</speaker>
             <l>Vorrei così poter disporre <name>Ottavio
 </name></l>
@@ -2907,7 +2964,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <hi rend="sc">SCENA SETTIMA</hi>
           </head>
           <pb n="46"/>
-          <sp>
+          <sp who="#servo">
             <speaker>Servo di Marco Antonio.</speaker>
             <l>Se a le parole, che da <name>Ottavio</name> ho avute,</l>
             <l>Risponde il cor, non puote <name>Cleopatra
@@ -2955,7 +3012,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
           <head>
             <hi rend="sc">SCENA OTTAVA</hi>
           </head>
-          <sp>
+          <sp who="#ottavio">
             <speaker>Ottavio</speaker>
             <l>Pòn tanto le ragioni de la patria</l>
             <l>Appresso i veri cittadin ch'ancora,</l>
@@ -2972,17 +3029,17 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Mi ha il servo suo, potuto ho rattenere</l>
             <l part="I">A pena il pianto.</l>
           </sp>
-          <sp>
+          <sp who="#mecenate">
             <speaker>Mecenate</speaker>
             <l part="F">Signor, non mi è nova</l>
             <l>L'alta vostra bontà, l'alta clemenza,</l>
             <l>Né altro pensato io mi avrei di voi.</l>
           </sp>
-          <sp>
+          <sp who="#agrippa">
             <speaker>Agrippa</speaker>
             <l part="I">Et avrei ciò anch'io pensato.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>Ottavio</speaker>
             <l part="F">Le sue lettre</l>
             <l>(Come ambidue potete aver veduto)</l>
@@ -2994,14 +3051,14 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Poscia che ne la morte ha mostro avere</l>
             <l part="I">In me tal confidenza.</l>
           </sp>
-          <sp>
+          <sp who="#mecenate">
             <speaker>Mecenate</speaker>
             <l part="F">Ben mostrate</l>
             <l>Qual voi sareste stato verso lui,</l>
             <l>Mentre viveva, s'egli fusse suto</l>
             <l>Verso voi qual volea, ch'ei fusse, il giusto.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>Ottavio</speaker>
             <l>Resta, poi che composte hai, <name>Mecenate</name>,</l>
             <l>Le cose in guisa, co' soldati aversi,</l>
@@ -3020,7 +3077,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>E seco imaginandosi d'avere</l>
             <l>Pace da noi, non cerchi darsi morte.</l>
           </sp>
-          <sp>
+          <sp who="#agrippa">
             <speaker>Agrippa</speaker>
             <l>Anderò, Signor mio, quantunque io pensi,</l>
             <l>Che malagevol fia a persuadere</l>
@@ -3029,7 +3086,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Si deve da reina, in simil caso,</l>
             <l>Sapendo l'uso dei trionfi nostri.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>Ottavio</speaker>
             <l>Gli afflitti volentier porgon gli oracchi</l>
             <l>A cosa, che lor dia speme di bene.</l>
@@ -3049,7 +3106,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>A le madri stimar più fa la vita</l>
             <l>De' figli loro, che la vita propria.</l>
           </sp>
-          <sp>
+          <sp who="#agrippa">
             <speaker>Agrippa</speaker>
             <l>Non sarà se non ben, per mio parere,</l>
             <l>Che discorriam su questo fatto insieme,</l>
@@ -3058,12 +3115,12 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Usare, in far che <name>Cleopatra</name> creda,</l>
             <l>Che non de' altro sperar da voi, che bene.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>Ottavio</speaker>
             <l>Poi che così ti pare, <name>Agrippa</name>, entriamo,</l>
             <l>E ne raggionerem tutti e tre insieme.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Se la ragione è in noi</l>
             <l>Sì presta, e sì vivace,</l>
@@ -3141,7 +3198,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
           <head>
             <hi rend="sc">SCENA PRIMA</hi>
           </head>
-          <sp>
+          <sp who="#agrippa">
             <speaker>Agrippa</speaker>
             <l>Non deve un gran signor porsi a tentare</l>
             <l>La inconstante, e volubile Fortuna,</l>
@@ -3189,7 +3246,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
           <head>
             <hi rend="sc">SCENA SECONDA</hi>
           </head>
-          <sp>
+          <sp who="#olimpo">
             <speaker>Olimpo</speaker>
             <l>Non so, che si possa uom prometter certo</l>
             <l>Ne lo stato mortal, quando veggiamo</l>
@@ -3204,21 +3261,21 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Che per non andar serva in man d'<name>Ottavio</name>,</l>
             <l>Disposta si è, che il non mangiar l'uccida.</l>
           </sp>
-          <sp>
+          <sp who="#agrippa">
             <speaker>Agrippa</speaker>
             <l>E questo è quel, che solo <name>Ottavio</name> teme.</l>
           </sp>
-          <sp>
+          <sp who="#olimpo">
             <speaker>Olimpo</speaker>
             <l>Certo egli è vero, che quanto più in alto</l>
             <l>E' asceso l'uom, tanto maggior dà il tomo.</l>
           </sp>
-          <sp>
+          <sp who="#agrippa">
             <speaker>Agrippa</speaker>
             <l>Io non vo' più tardar Signore <name>Olimpo</name>,</l>
             <l part="I">Che querele son queste?</l>
           </sp>
-          <sp>
+          <sp who="#olimpo">
             <speaker>Olimpo</speaker>
             <l part="F">Che querele?</l>
             <l>Quelle, che il destin reo vuol, che spargiamo.</l>
@@ -3230,15 +3287,15 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Non basteriano ad isfogare in parte</l>
             <l>Le gran miserie, e gli aspri affanni nostri?</l>
           </sp>
-          <sp>
+          <sp who="#agrippa">
             <speaker>Agrippa</speaker>
             <l>Così va la vicenda de le cose.</l>
           </sp>
-          <sp>
+          <sp who="#olimpo">
             <speaker>Olimpo</speaker>
             <l>Ahi quanto è a noi questa vicenda grave!</l>
           </sp>
-          <sp>
+          <sp who="#agrippa">
             <speaker>Agrippa</speaker>
             <l>Grave sempre fu il gire in forma altrui</l>
             <l>A chi usat'è di sovrastare a gli altri,</l>
@@ -3250,7 +3307,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Che bene, come voi sperar potete</l>
             <l>Dal signor nostro, ancor che siate vinti.</l>
           </sp>
-          <sp>
+          <sp who="#olimpo">
             <speaker>Olimpo</speaker>
             <l>Il potressimo creder, se la prova</l>
             <l>Saper non ne facesse quel, che fanno</l>
@@ -3259,7 +3316,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Sono de la vittoria, i più benigni</l>
             <l>Divengon crudi, et i più miti fieri.</l>
           </sp>
-          <sp>
+          <sp who="#agrippa">
             <speaker>Agrippa</speaker>
             <l>Questo aviene in color ch'hanno il cor d'orso,</l>
             <l>Ma chi ha, com'Ottavio ha, la mente umana,</l>
@@ -3268,7 +3325,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Compassione gli ha, veggendo quanto</l>
             <l>Può la Fortuna ne le cose eccelse.</l>
           </sp>
-          <sp>
+          <sp who="#olimpo">
             <speaker>Olimpo</speaker>
             <l>Così esser ben devrebbe, se mirasse</l>
             <l>A questo il vincitor, ch'è manifesto,</l>
@@ -3280,13 +3337,13 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Che dimostrarsi altiero, imaginando</l>
             <l>Di non vederla mai per lui turbata.</l>
           </sp>
-          <sp>
+          <sp who="#agrippa">
             <speaker>Agrippa</speaker>
             <l>Così benigna sempre l'abbia <name>Ottavio</name>,</l>
             <l>Come <name>Alessandria </name>il proverà benigno.</l>
             <l>Che fa, che pensa la reina vostra?</l>
           </sp>
-          <sp>
+          <sp who="#olimpo">
             <speaker>Olimpo</speaker>
             <l>Ohimé, che può ella far, se non versare</l>
             <l>Da gli occhi un mar di pianto, e imaginarsi</l>
@@ -3295,27 +3352,27 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>E non esser spettacolo a' Romani</l>
             <l>Se viva andasse al vincitore in mano.</l>
           </sp>
-          <sp>
+          <sp who="#agrippa">
             <speaker>Agrippa</speaker>
             <l>Questo non fia. Fate che con lei parli</l>
             <l>E le torrò la tema, dimostrando</l>
             <l>Quanto sperare ella da <name>Ottavio</name> debba.</l>
           </sp>
-          <sp>
+          <sp who="#olimpo">
             <speaker>Olimpo</speaker>
             <l part="I">Io so che sperare deve.</l>
           </sp>
-          <sp>
+          <sp who="#agrippa">
             <speaker>Agrippa</speaker>
             <l part="M">E che?</l>
           </sp>
-          <sp>
+          <sp who="#olimpo">
             <speaker>Olimpo</speaker>
             <l part="F">Che presto</l>
             <l>Sia a sopporsi a le leggi, ch'imporalle</l>
             <l part="I">Il vincitore.</l>
           </sp>
-          <sp>
+          <sp who="#agrippa">
             <speaker>Agrippa</speaker>
             <l part="F">Io non vi vo' già dire,</l>
             <l>Ch'<name>Ottavio </name>da lei voglia accettar leggi,</l>
@@ -3331,7 +3388,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Chi contra lui si dà ad alzar le corna.</l>
             <l part="I">Andate, ch'io vi aspetto.</l>
           </sp>
-          <sp>
+          <sp who="#olimpo">
             <speaker>Olimpo</speaker>
             <l part="F">Io vo, Signore,</l>
             <l>Né mancherà da me, ch'io non procuri,</l>
@@ -3343,7 +3400,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
           <head>
             <hi rend="sc">SCENA TERZA</hi>
           </head>
-          <sp>
+          <sp who="#agrippa">
             <speaker>Agrippa</speaker>
             <l>Eletta avrà la parte <name>Cleopatra</name></l>
             <l>Ch'elegger dee, chi da sublime stato</l>
@@ -3362,7 +3419,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <hi rend="sc">SCENA QUARTA</hi>
           </head>
           <stage>Olimpo, Agrippa.</stage>
-          <sp>
+          <sp who="#olimpo">
             <speaker>Olimpo</speaker>
             <l>Signor <name>Agrippa</name>, la reina nostra,</l>
             <l>Che chiusa si ritrova entro al sepolcro,</l>
@@ -3379,7 +3436,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Che delibererà di sè. Io fare</l>
             <l part="I">Altro non ho potuto.</l>
           </sp>
-          <sp>
+          <sp who="#agrippa">
             <speaker>Agrippa</speaker>
             <l part="F">Le direte,</l>
             <l>O le farete dir, quando non voglia</l>
@@ -3398,12 +3455,12 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Ove se viva resta, tutti voi</l>
             <l>Vi vivrete con lei lieti, e contenti.</l>
           </sp>
-          <sp>
+          <sp who="#olimpo">
             <speaker>Olimpo</speaker>
             <l>Io non mancherò, <name>Agrippa</name>, di far quanto</l>
             <l part="I">Si potrà far per me.</l>
           </sp>
-          <sp>
+          <sp who="#agrippa">
             <speaker>Agrippa</speaker>
             <l part="F">Fate 'l <name>Olimpo</name>,</l>
             <l>Perch'ella può sol lei salvare, e voi.</l>
@@ -3413,7 +3470,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
           <head>
             <hi rend="sc">SCENA QUINTA</hi>
           </head>
-          <sp>
+          <sp who="#olimpo">
             <speaker>Olimpo</speaker>
             <l>Chiunque può, senza servire altrui,</l>
             <l>Menar da sé vita onorata, e queta,</l>
@@ -3460,7 +3517,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
           <head>
             <hi rend="sc">SCENA SESTA</hi>
           </head>
-          <sp>
+          <sp who="#proculeio">
             <speaker>Proculeio</speaker>
             <l>Poscia ch'a voi, e a me commesso ha <name>Ottavio</name>,</l>
             <l>Che poniamo ogni ingegno, perché venga</l>
@@ -3492,18 +3549,18 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>E sperando da ciò qualche compenso</l>
             <l>Ai danni suoi, non negherà parlarvi.</l>
           </sp>
-          <sp>
+          <sp who="#gallo">
             <speaker>Gallo</speaker>
             <l>Da me non mancherà, ch'io non adopri</l>
             <l>Tutto il poter, tutto l'ingegno mio,</l>
             <l>Perché meniamo questo fatto al fine.</l>
           </sp>
-          <sp>
+          <sp who="#proculeio">
             <speaker>Proculeio</speaker>
             <l>Io me n'andrò co' miei compagni, e spero</l>
             <l part="I">Avere in ciò lieto successo.</l>
           </sp>
-          <sp>
+          <sp who="#gallo">
             <speaker>Gallo</speaker>
             <l part="F">Andate,</l>
             <l>Io tenterò l'udienza su la porta.</l>
@@ -3522,7 +3579,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
           <head>
             <hi rend="sc">SCENA SETTIMA</hi>
           </head>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>L'aver veduto <name>Olimpo</name>, che tagliare</l>
             <l><name>Ottavio </name>ad <name>Antilo</name> ha fatto la testa,</l>
@@ -3534,12 +3591,12 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
 </name></l>
             <l>Pur dianzi detto, con minaccie gravi.</l>
           </sp>
-          <sp>
+          <sp who="#gallo">
             <speaker>Gallo</speaker>
             <l>Cosa agevole fia che mi dia udienza,</l>
             <l>Poi che in timore ell'è de' figli suoi.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>Onde poi che la sorte mia crudele</l>
             <l>I miei figliuoli ha messi in man di <name>Ottavio</name>,</l>
@@ -3554,26 +3611,26 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>E l'eloquenza tua che piegar suole</l>
             <l>Ogni feroce core, e il dur far molle.</l>
           </sp>
-          <sp>
+          <sp who="#olimpo">
             <speaker>Olimpo</speaker>
             <l>Reina, cosa non lascerò a fare,</l>
             <l>Che per lo suo signor, servo far debba.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l part="I">Ma chi è costui, che di là viene?</l>
           </sp>
-          <sp>
+          <sp who="#olimpo">
             <speaker>Olimpo</speaker>
             <l part="F">è Gallo,</l>
             <l part="I">Famigliare di <name>Ottavio</name>.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l part="F">Ir non vo' dentro,</l>
             <l>Ché non voglio esser colta a l'improviso.</l>
           </sp>
-          <sp>
+          <sp who="#olimpo">
             <speaker>Olimpo</speaker>
             <l>Anzi io l'aspetterei, poi ch'egli è solo,</l>
             <l>Et io son qui con voi; potremmo udire</l>
@@ -3582,7 +3639,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Ritornerete nel sepolcro. Et ivi</l>
             <l>A temer non avrete di nemico.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>Di nemico? vi ho sol due cameriere,</l>
             <l>Le più fedeli, e più nobili, ch'io</l>
@@ -3592,20 +3649,20 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Fallo venir; io mi starò qui dentro,</l>
             <l>Et uscirò, quando mi chiamerai.</l>
           </sp>
-          <sp>
+          <sp who="#olimpo">
             <speaker>Olimpo</speaker>
             <l>Venite Signor, forse a la reina?</l>
           </sp>
-          <sp>
+          <sp who="#gallo">
             <speaker>Gallo</speaker>
             <l>A lei vengo per dirle alcune cose,</l>
             <l>Che a beneficio suo, mi ha imposto <name>Ottavio</name>.</l>
           </sp>
-          <sp>
+          <sp who="#olimpo">
             <speaker>Olimpo</speaker>
             <l part="I">E che cose son queste?</l>
           </sp>
-          <sp>
+          <sp who="#gallo">
             <speaker>Gallo</speaker>
             <l part="F">Sol con lei</l>
             <pb n="56"/>
@@ -3613,24 +3670,24 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Ch'ella mi presti udienza, ché dirolle</l>
             <l>Cosa che la farà restar contenta.</l>
           </sp>
-          <sp>
+          <sp who="#olimpo">
             <speaker>Olimpo</speaker>
             <l>Siate contento d'aspettar, sin ch'io</l>
             <l part="I">Vegga s'udienza ella vuoi darvi.</l>
           </sp>
-          <sp>
+          <sp who="#gallo">
             <speaker>Gallo</speaker>
             <l part="F">Aspetto.</l>
             <l>Credo che <name>Proculeio</name> abbia le scale</l>
             <l>Al sepolcro già poste, e forse è entrato.</l>
           </sp>
-          <sp>
+          <sp who="#olimpo">
             <speaker>Olimpo</speaker>
             <l>Signor, venite. Ella vi attende a l'uscio,</l>
             <l>Ma non vuole, che più le vi accostiate,</l>
             <l part="I">Ch'or io mi sia.</l>
           </sp>
-          <sp>
+          <sp who="#gallo">
             <speaker>Gallo</speaker>
             <l part="F">Pur che le parle <name>Olimpo</name>,</l>
             <l>O lontano, o vicin, nulla mi curo,</l>
@@ -3638,79 +3695,79 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Reina, <name>Ottavio</name> mio signor, salute</l>
             <l part="I">Vi manda.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l part="F">Ohimé, che ben n'avria bisogno.</l>
           </sp>
-          <sp>
+          <sp who="#gallo">
             <speaker>Gallo</speaker>
             <l>Non pensa altro, Reina, il signor mio,</l>
             <l>Che darvi segno de la sua clemenza.</l>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>Cameriera</speaker>
             <l>Ohimé Reina, ohimè, che nel sepolcro</l>
             <l>Sono i nemici, e sete presa viva,</l>
             <l>Ecco Reina che gli avete al fianco.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>Ahi traditori, anche quel non avrete,</l>
             <l>Che vi pensate aver, se questa spada</l>
             <l part="I">Non mi vien men.</l>
           </sp>
-          <sp>
+          <sp who="#proculeio">
             <speaker>Proculeio</speaker>
             <l part="F">Non fate, ohimé Reina.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>A questo modo <name>Ottavio</name> vuoi mandarmi</l>
             <l part="I">Speme di bene?</l>
           </sp>
-          <sp>
+          <sp who="#olimpo">
             <speaker>Olimpo</speaker>
             <l part="F">Ahi traditori, ahi rei,</l>
             <l part="I">Lasciate la reina.</l>
           </sp>
-          <sp>
+          <sp who="#proculeio">
             <speaker>Proculeio</speaker>
             <l part="F">E che credete</l>
             <l>Di fare, <name>Olimpo</name>? farete gran senno</l>
             <l>A starvi queto, e non cercar la morte.</l>
           </sp>
-          <sp>
+          <sp who="#olimpo">
             <speaker>Olimpo</speaker>
             <l>Et moiami, non voglio veder serva</l>
             <l part="I">La mia reina.</l>
           </sp>
-          <sp>
+          <sp who="#proculeio">
             <speaker>Proculeio</speaker>
             <l part="F">Levate la spada</l>
             <l part="I">A questo insano.</l>
           </sp>
-          <sp>
+          <sp who="#olimpo">
             <speaker>Olimpo</speaker>
             <l part="F">Ahi traditori, io spero</l>
             <l>Che il ciel farà di ciò giusta vendetta.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>Ahi traditori, ahi scelerati, ahi cani,</l>
             <l>Cani malvaggi, nati a lacerare</l>
             <l>Con insidie gli afflitti acerbamente.</l>
           </sp>
-          <sp>
+          <sp who="#proculeio">
             <speaker>Proculeio</speaker>
             <l>Reina il tutto è fatto per ben vostro.</l>
             <l>Temuto ha il signor nostro, che non fusse</l>
             <l>Più possente in vo' il duol, che la ragione.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l part="I">Ohimé misera, ohimè.</l>
           </sp>
-          <sp>
+          <sp who="#proculeio">
             <speaker>Proculeio</speaker>
             <l part="F">Sí che vi deste</l>
             <l>Morte con le man vostre, et a lui tolta</l>
@@ -3719,19 +3776,19 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Mandati n'ha, perché noi vi togliamo</l>
             <l part="I">La via di darvi morte.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l part="F">O che pietade,</l>
             <l>Ben può mostrar ciò che sperar io debba.</l>
           </sp>
           <pb n="57"/>
-          <sp>
+          <sp who="#proculeio">
             <speaker>Proculeio</speaker>
             <l>Ne la bontà del mio signor sperare</l>
             <l>Devete, et io lo vi prometto tale,</l>
             <l>Che non vi dolerà a trovarvi vinta.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>Ohimé se tale egli esser deve verso</l>
             <l>Questa infelice, e dolorosa, ohimé</l>
@@ -3743,7 +3800,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Ch'io gli possa parlar; se questo ottengo</l>
             <l part="I">Sicura io mi terrò.</l>
           </sp>
-          <sp>
+          <sp who="#proculeio">
             <speaker>Proculeio</speaker>
             <l part="F">Non dubitate</l>
             <l>Di non aver da lui ciò che vorrete.</l>
@@ -3751,7 +3808,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>E state lieta, e sicura, ché sete</l>
             <l>Non tra nemici, ma tra amici vostri.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>Attendi, <name>Olimpo</name>, s'a me viene <name>Ottavio</name></l>
             <l>E se forse verrà; tu ratto vieni</l>
@@ -3762,7 +3819,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
           <head>
             <hi rend="sc">SCENA OTTAVA</hi>
           </head>
-          <sp>
+          <sp who="#olimpo">
             <speaker>Olimpo.</speaker>
             <l>Ohimé che dura cosa è restar senza</l>
             <l>Presidio, poi ch'è vinto un re, un signore,</l>
@@ -3803,7 +3860,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
           <head>
             <hi rend="sc">SCENA NONA</hi>
           </head>
-          <sp>
+          <sp who="#ottavio">
             <speaker>Ottavio</speaker>
             <l>Vorrebbe ogni raggion, ch'al vincitore</l>
             <l>Venisse <name>Cleopatra</name>. Ma perch' io</l>
@@ -3811,16 +3868,16 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Poi che chieder mi ha fatto, io voglio andare</l>
             <l>A lei, sol per levarle ogni sospetto.</l>
           </sp>
-          <sp>
+          <sp who="#gallo">
             <speaker>Gallo</speaker>
             <l>Vedete che si è mossa ella anche, e viene</l>
             <l part="I">Verso voi con la guardia.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>Ottavio</speaker>
             <l part="F">Andianle incontro.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>Signor, poi che felice sorte ha dato</l>
             <l>A voi tal nome, e a me la rea l'ha tolto,</l>
@@ -3901,7 +3958,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Pena non merta, ma non perdono appresso</l>
             <l>D'uomo, qual sete voi, mite, e prudente.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>Ottavio</speaker>
             <l>Io vo' conceder, che necessitade</l>
             <l>Vi fesse nel principio cosa fare,</l>
@@ -3910,7 +3967,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>(Per gli partiti, che vi fé Tireo)</l>
             <l>Di cacciarlo da voi, perche no 'l feste ?</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>Quella necessità, che fu cagione,</l>
             <l>Ch'ad ubidir mi dessi a <name>Marco Antonio</name>,</l>
@@ -3954,7 +4011,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Da la vostra bontà, non vo' dolermi</l>
             <l>Né di rea sorte, né di mal sofferto.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>Ottavio</speaker>
             <l>Che pensieri son questi, che vi vanno</l>
             <l>Per l'anima, Reina? Io più tosto</l>
@@ -3972,7 +4029,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Però volgete, prego, ad altro il core,</l>
             <l>Ch'a penser di finire i giorni vostri.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>Poscia, Signor, che speme tal mi date,</l>
             <l>La vita ch'io sprezzava, ora mi è cara,</l>
@@ -3989,11 +4046,11 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Per onorare <name>Ottavia</name>, e <name>Livia</name> vostra,</l>
             <l>Finisca verso lui l'ultimo ufficio.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>Ottavio</speaker>
             <l>Ne son molto contento.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>Io vi ringrazio.</l>
             <l>E prego il Re del Ciel, che lungamente</l>
@@ -4005,7 +4062,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Come de' dei la religion vuole,</l>
             <l>Che ci hanno i modi de l'essequie dati</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>Ottavio</speaker>
             <l>Io son contento. Lascia, <name>Proculeio</name>,</l>
             <l>(Poi che religione tal qui si serva,</l>
@@ -4015,7 +4072,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Vi prego anch'io, che vi viviate lieta,</l>
             <l>E che poniate in noi tutta la speme.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l>La vi pongo, Signor, ché sarei cieca</l>
             <l>E priva d'intelletto, s'altrimente</l>
@@ -4026,17 +4083,17 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Che non bisogni, essendovi io sì cara,</l>
             <l part="I">Come veggo che sono.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>Ottavio</speaker>
             <l part="F">Gli avrò cari</l>
             <l>Come se fusser miei. A Dio, Reina,</l>
             <l part="I">Vivete lieta.</l>
           </sp>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra</speaker>
             <l part="F">Io non farò altrimente.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Alma speranza, che dal ciel venisti</l>
             <l>Per confirmare i cori</l>
@@ -4092,7 +4149,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
           <head>
             <hi rend="sc">SCENA PRIMA</hi>
           </head>
-          <sp>
+          <sp who="#olimpo">
             <speaker>Olimpo</speaker>
             <l>Esser costume suol de gli infelici,</l>
             <l>Non creder facilmente, né allegrarsi,</l>
@@ -4133,7 +4190,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
           <head>
             <hi>SCENA SECONDA</hi>
           </head>
-          <sp>
+          <sp who="#cleopatra">
             <speaker>Cleopatra.</speaker>
             <l>Dunque tu pensi <name>Ottavio</name> ch'io sia priva</l>
             <l>D'ingegno sì, sì di me stessa fuori,</l>
@@ -4240,7 +4297,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
           <head>
             <hi rend="sc">SCENA TERZA</hi>
           </head>
-          <sp>
+          <sp who="#gallo">
             <speaker>Gallo</speaker>
             <l>Dubitar fatto ha <name>Agrippa</name> al mio signore</l>
             <l>Che più, ch'uopo non era, abbia allargata</l>
@@ -4265,7 +4322,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
           <head>
             <hi rend="sc">SCENA QUARTA</hi>
           </head>
-          <sp>
+          <sp who="#famigliare">
             <speaker>Famigliar di Cleopatra</speaker>
             <l>Si suol dir, che non può l'uomo sapere</l>
             <l>S'egli è felice, od infelice mentre</l>
@@ -4313,7 +4370,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
           <head>
             <hi rend="sc">SCENA QUINTA</hi>
           </head>
-          <sp>
+          <sp who="#gallo">
             <speaker>Gallo</speaker>
             <l>Credo che sia sovra ogni stima grave</l>
             <l>Miseria, e sommo affanno il ritrovarsi</l>
@@ -4333,12 +4390,12 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>L'abbia in podestà, e mover più non possa</l>
             <l>(Se non secondo ch'egli vorrà) il piede.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>Ottavio</speaker>
             <l>E tu non sai se <name>Cleopatra</name>sia</l>
             <l part="I">Morta?</l>
           </sp>
-          <sp>
+          <sp who="#famigliare">
             <speaker>Famigliar di Cleopatra</speaker>
             <l part="F">Signor, quando mi diè le lettre,</l>
             <l>Mostrommi aver pensier d'ogni altra cosa</l>
@@ -4347,7 +4404,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Che di morire. E creder io no 'l posso,</l>
             <l part="I">Bench'ella scritto l'abbia.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>Ottavio</speaker>
             <l part="F">Veggo <name>Gallo</name></l>
             <l>Che di là viene. Egli mi saprà dire</l>
@@ -4362,7 +4419,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Udita n'hai tu forse cosa alcuna,</l>
             <l>Da Proculeio, o d'altri ne la corte?</l>
           </sp>
-          <sp>
+          <sp who="#gallo">
             <speaker>Gallo</speaker>
             <l>Nulla, Signor, anzi m'ha detto, ch'ella</l>
             <l>Facea l'ossequie a <name>Marco Antonio</name> lieta,</l>
@@ -4371,15 +4428,15 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Non vi era di più guardia. Ma dapoi</l>
             <l>Ch'a voi così piacea, gliele porria.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>Ottavio</speaker>
             <l>Va' ratto, e intendi a pien tutta la cosa.</l>
           </sp>
-          <sp>
+          <sp who="#gallo">
             <speaker>Gallo</speaker>
             <l part="I">Io vado.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>Ottavio</speaker>
             <l part="F">Veggo ch'esce Proculeio</l>
             <l>Con un de' sacerdoti de la corte,</l>
@@ -4390,19 +4447,19 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
           <head>
             <hi rend="sc">SCENA SESTA</hi>
           </head>
-          <sp>
+          <sp who="#ottavio">
             <speaker>Ottavio</speaker>
             <l part="I">è forse morta <name>Cleopatra</name>?</l>
           </sp>
-          <sp>
+          <sp who="#proculeio">
             <speaker>Proculeio</speaker>
             <l part="F">è morta.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>Ottavio</speaker>
             <l part="I">E come?</l>
           </sp>
-          <sp>
+          <sp who="#proculeio">
             <speaker>Proculeio</speaker>
             <l part="F">Io no 'l so dir. Quando mandaste</l>
             <l>Gallo a dir ch'io tenessi maggior cura</l>
@@ -4435,7 +4492,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Mandato ad avertir, ch'io le togliessi</l>
             <l>La libertà, che l'avevate data.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>Ottavio</speaker>
             <l>Vero è quel, che si dice, che la donna</l>
             <l>E' de le finzioni il proprio nido,</l>
@@ -4444,7 +4501,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Pensato, che costei chiudesse in core</l>
             <l>Disio di morte? E come si è ella uccisa?</l>
           </sp>
-          <sp>
+          <sp who="#proculeio">
             <speaker>Proculeio</speaker>
             <l>No 'l so, Signore, ella non avea ferro</l>
             <l>(Però che ricercar la volsi tutta)</l>
@@ -4466,14 +4523,14 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Io venia dimandando al sacerdote</l>
             <l part="I">Come si avesse uccisa.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>Ottavio</speaker>
             <l part="F">Poscia ch'eri</l>
             <l>Ne l'essequie con lei, et a la porta</l>
             <l>De la stanza ti stavi, ove ora è morta,</l>
             <l part="I">Dimmi tutto il successo.</l>
           </sp>
-          <sp>
+          <sp who="#sacerdote">
             <speaker>Sacerdote</speaker>
             <l part="F">La reina</l>
             <l>Tosto ch'ella impetrò da voi licenza</l>
@@ -4521,12 +4578,12 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Or vola, e ascolta i miei gravi lamenti,</l>
             <l>Et attende, che il mio si giunga a lui.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>Ottavio</speaker>
             <l>Mi commovono certo insino a l'alma</l>
             <l part="I">Queste parole.</l>
           </sp>
-          <sp>
+          <sp who="#sacerdote">
             <speaker>Sacerdote</speaker>
             <l part="F">Se le aveste udite</l>
             <l>Com'io le udì, Signor, avreste pianto</l>
@@ -4590,7 +4647,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Questo ho veduto, e udito, e tanto dire</l>
             <l>So del fin reo de la reina nostra.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>Ottavio</speaker>
             <l>Ismisurato amore, è stato quello</l>
             <l>Di ambidue questi; anco ch'aspri nemici</l>
@@ -4608,11 +4665,11 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Che si conviene ad una tal reina,</l>
             <l>La facci sepelir con <name>Marco Antonio</name>.</l>
           </sp>
-          <sp>
+          <sp who="#proculeio">
             <speaker>Proculeio</speaker>
             <l>Io farò Signor, quel che m'imponete.</l>
           </sp>
-          <sp>
+          <sp who="#sacerdote">
             <speaker>Sacerdote</speaker>
             <l>Ben segno date d'animo Romano,</l>
             <pb n="71"/>
@@ -4621,7 +4678,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Io prego il ciel, che guiderdon vi dia</l>
             <l>Degno di sì cortese, e nobile atto.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>Ottavio</speaker>
             <l>Spedito ch'avrai questo, <name>Proculeio</name>,</l>
             <l>A l'armata verrai con la tua gente,</l>
@@ -4629,7 +4686,7 @@ La scena è in <name>Alessandria</name> città d'<name>Egitto</name>.</p>
             <l>Bisognerà in <name>Egitto</name>, ce n'andiamo</l>
             <l>Finito il travagliare, insieme a <name>Roma</name>.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Quanto miseri, ohimé, sono coloro,</l>
             <l>Che perché hanno felice</l>

--- a/tei/giraldi-cinzio-egle-editio-princeps.xml
+++ b/tei/giraldi-cinzio-egle-editio-princeps.xml
@@ -73,6 +73,67 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="silvano">
+            <persName>Silvano</persName>
+          </person>
+          <person xml:id="satiro">
+            <persName>Satiro</persName>
+          </person>
+          <person xml:id="fauno">
+            <persName>Fauno</persName>
+          </person>
+          <person xml:id="sileno">
+            <persName>Sileno</persName>
+          </person>
+          <person xml:id="egle">
+            <persName>Egle</persName>
+          </person>
+          <person xml:id="choro">
+            <persName>Choro</persName>
+          </person>
+          <person xml:id="oreadi">
+            <persName>Oreadi</persName>
+          </person>
+          <person xml:id="driadi">
+            <persName>Driadi</persName>
+          </person>
+          <person xml:id="napee">
+            <persName>Napee</persName>
+          </person>
+          <person xml:id="naiadi">
+            <persName>Naiadi</persName>
+          </person>
+          <person xml:id="pane">
+            <persName>Pane</persName>
+          </person>
+          <person xml:id="siringa">
+            <persName>Siringa</persName>
+          </person>
+          <person xml:id="amadriadi">
+            <persName>Amadriadi</persName>
+          </person>
+          <person xml:id="nimphe">
+            <persName>Nimphe</persName>
+          </person>
+          <person xml:id="satiri_pioccioli">
+            <persName>Satiri Pioccioli</persName>
+          </person>
+          <person xml:id="satiri_piccioli">
+            <persName>Satiri Piccioli</persName>
+          </person>
+          <person xml:id="satiri">
+            <persName>Satiri</persName>
+          </person>
+          <person xml:id="satiro_grande">
+            <persName>Satiro Grande</persName>
+          </person>
+          <person xml:id="satiro_piccolo">
+            <persName>Satiro Piccolo</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>2003-06-10T00:00:00.000+02:00</date><name>Camilla Ghedini</name><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -262,7 +323,7 @@ DA FERRARA</hi>
             <hi rend="sc">Scena I</hi>
           </head>
           <stage>Silvano solo</stage>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Quando lo stuolo human né l' in<expan>n</expan>ocenza</l>
             <l>Prima vivea, et dava cibo a ogni uno</l>
@@ -350,18 +411,18 @@ DA FERRARA</hi>
             <hi rend="sc">Scena II</hi>
           </head>
           <stage>SATIRO, FAUNO</stage>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Amor, che mai non giunga a fine, amore</l>
             <l>Dir non si dee, ma una continua pena.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>E troppo il ver, ma se vi s'accompagna</l>
             <l>Sospetto, e gelosia, non è piu pena,</l>
             <l>Ma una continua, inevitabil morte.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Troppo tutti il proviam, dopo che <name>Giove</name>,</l>
             <l>Et gli altri dei del ciel venuti sono</l>
@@ -370,16 +431,16 @@ DA FERRARA</hi>
             <l>Ad essi ha fatto ingiuria, che per odio</l>
             <l>Debbano disturbar la pace nostra.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>Sai, frate mio, quale ingiuria han da noi</l>
             <l part="I">I dei del ciel?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="M">Non io</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="F">L'ingiuria è ch'essi</l>
             <l>Veggono la beltà di queste nimphe,</l>
@@ -387,7 +448,7 @@ DA FERRARA</hi>
             <l>Bellezza, che sia in man di pover, sia</l>
             <l>Atta a potersi haver da illustre amante.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Quanto dolore, ohime m'aggionge questo</l>
             <l>Sospetto; et quanto più m'infiamma amore,</l>
@@ -399,7 +460,7 @@ DA FERRARA</hi>
             <l>Se ne fossero tolte da le mani</l>
             <l part="I">Le nostre nimphe</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="F">Il lamentarsi è vano,</l>
             <l>Quando non ponno le querele aiuto</l>
@@ -412,7 +473,7 @@ DA FERRARA</hi>
             <l>Mentre l'habbiam qui ne le forze nostre,</l>
             <l>E da cercar, che cel godiamo noi.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Ahi che più non vi veggio modo alcuno,</l>
             <l>Come già di veder mi parea prima,</l>
@@ -427,7 +488,7 @@ DA FERRARA</hi>
             <l>Qualhor la miro, et sdegnosetta, et schiva</l>
             <l>Mi fugge, et odia, ond'io m' affliggo, e struggo,</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>Tal' è verso di me la <name>Naide</name> mia,</l>
             <l>Quale a punto è ver te la tua <name>Napea</name>,</l>
@@ -447,22 +508,22 @@ DA FERRARA</hi>
             <l>Ell' ha nel petto, ch' io non l'ami, et pregi,</l>
             <l>Et non cerchi d'haverla a le mie voglie</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Et che vogliam noi far, per goder qualche</l>
             <l>Frutto de le fatiche di tanti anni?</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>Volgio, che 'ntendiam ben prima, s'è vero,</l>
             <l>Ch' i dei celesti sian per farne ingiuria.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Che bisogna cercar, s'elle medesme</l>
             <l>L'han detto ad <name>Egle</name> del <name>Sileno</name> nostro.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>Costume è de le nimphe di mostrare</l>
             <l>Essere da Dei maggiori amate, anchora</l>
@@ -474,11 +535,11 @@ DA FERRARA</hi>
             <l>Ch'altri falce non ponga in quella messe;</l>
             <l>Ch'essere accolta dee per nostra mano.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Et come ciò potrem saper?</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="F">
               <name>Sileno</name>
@@ -496,19 +557,19 @@ DA FERRARA</hi>
             <l>Egli da noi et sacrifiti, et voti,</l>
             <l>Non ci celerà cosa, ch' egli, sappia.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Ma dove havrem <name>Sileno</name>? Egli dormire</l>
             <l>Dee pien di vino in qualche grotta, o deve</l>
             <l>Esser col <name>Chromi</name> suo col suo, <name>Mnasilo</name></l>
             <l>In giuoco, e 'n festa, o con la sua dolce <name>Egle</name></l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>Eccolo ch' egli vien co suoi compagni</l>
             <l part="I">Apunto fuor del bosco.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Ei tutto è festa,</l>
             <l>Ove noi miser siam doglia, è tormento,</l>
@@ -520,7 +581,7 @@ DA FERRARA</hi>
             <hi rend="sc">Scena III</hi>
           </head>
           <stage>Sileno, Chromi, Mnasilo, Egle</stage>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l><name>Baccho</name>, se nel nodrirti hebbi gia affanno,</l>
             <l>Tant' hor piacere ho in core</l>
@@ -584,7 +645,7 @@ DA FERRARA</hi>
             <hi rend="sc">Scena I</hi>
           </head>
           <stage>EGLE SOLA</stage>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Piu volte, et piu m'ha detto il mio <name>Sileno</name>,</l>
             <l>Narrandomi i principij de le cose,</l>
@@ -644,12 +705,12 @@ DA FERRARA</hi>
             <hi rend="sc">Scena II</hi>
           </head>
           <stage>FAUNO, SATIRO, EGLE</stage>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>Pur che la nuova sia buona, il tardare</l>
             <l part="I">Non mi dorrà</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Sia pure o buona, o rea,</l>
             <l>Me ne cal poco, i' seguirò il consiglio</l>
@@ -660,24 +721,24 @@ DA FERRARA</hi>
             <l>Cosa che ti sia cara, biasimato</l>
             <l>Non sarai unqua a porlati in sicuro.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>La tropp' audatia torna spesso indanno.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Et il troppo temer fa perder spesso</l>
             <l>Quel, c'haver si potrebbe, i' voglio audace</l>
             <l>Perder piu tosto, che timido havere.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>Io mi ricordo anchor quel, che m'avenne:</l>
             <l>Quand' <name>Hercol</name> mi gittò fuori del letto,</l>
             <l>Io mi sento dolere ancho le spalle,</l>
             <l>Per la grave percossa, ch'alhor diedi</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Già non si conveniva altra mercede</l>
             <l>A la tua gran folia, non fu l'ardire,</l>
@@ -689,31 +750,31 @@ DA FERRARA</hi>
             <l>Tu vedrai ben, che, s'io entro in questa caccia,</l>
             <l>Io non piglierò l'orso per la lepra.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Che parole son queste? aman la pace</l>
             <l part="I">Le selve, et non le liti.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="F">Non è guerra</l>
             <l><name>Egle</name> tra noi, sol' aspettiam sapere,</l>
             <l>C' habbia inteso <name>Silen</name> nostro da <name>Baccho</name>,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="I">Non vi è nulla di buono</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="F">Tu m' hai morto</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Et a me animo hai dato a la mia impresa:</l>
             <l>Narraci che ci manda a dir <name>Sileno</name></l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Vi fa saper, ch'i Dei celesti sono</l>
             <l>Non men, che voi, di queste nimphe accesi,</l>
@@ -721,27 +782,27 @@ DA FERRARA</hi>
             <l>A le cose mortai, voglion dal cielo</l>
             <l>Venirsi ne le selve a goder d' esse.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="I">Ohime</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">io non vo già per ciò dolermi,</l>
             <l>Prima di lor i' me n'andrò a la caccia</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Et ch'essi, per non esser conosciuti,</l>
             <l>Sotto mentita forma a loro verranno.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Et io v' andrò ne la medesma mia.</l>
             <l>Prima che 'l Sol s' asconda, stati, <name>Fauno</name>,</l>
             <l part="I">Tu su rispetti tuoi.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="F"><name>Satir</name> sei sciocco,</l>
             <l>Io ti dico, che 'l senno, e 'l buon consiglio</l>
@@ -750,7 +811,7 @@ DA FERRARA</hi>
             <l>In condurlo bisogna usar molt' arte:</l>
             <l>Altrimente ogni cosa andr' in sinistro.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l><name>Fauno</name> non dice mal, <name>Satir</name> sta cheto,</l>
             <l>E 'ascolta un pò quel, che vo dirti anch'io,</l>
@@ -759,12 +820,12 @@ DA FERRARA</hi>
             <l>Che, se palese forza lor vorrete</l>
             <l>Fare, n'andrà tutta la cosa in nulla.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Et perche? non siam noi per far lor forza?</l>
             <l part="I">Tu t' inganni <name>Egle</name></l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">i' non m'inganno, ascolta,</l>
             <l>O che volete ritrovarle in caccia,</l>
@@ -791,20 +852,20 @@ DA FERRARA</hi>
             <l>I lor disiri, et con inganno anchora</l>
             <l>Pensan di queste nimphe hoggi godere.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Che deviam dunque far?</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="F">prudentemente</l>
             <l part="I">Condur la cosa.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="M">Et come?</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="F">I' voglio, ch' <name>Egle</name></l>
             <l>(<name>Egle</name> vià piu d'ogni altra nimpha accorta)</l>
@@ -812,13 +873,13 @@ DA FERRARA</hi>
             <l>Ella s'adoprerà con queste nimphe)</l>
             <l>Et le disponga a non ci dar piu affanno.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Il farò volentier, perch'io vorrei</l>
             <l>Vederle nel piacer, nel qual son' io:</l>
             <l>Accio che et elle, et voi foste contenti.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>Che non si vuol venir mai a la forza,</l>
             <l>Fin che non s' è tentata ogni altra via,</l>
@@ -829,33 +890,33 @@ DA FERRARA</hi>
             <l>Vo, che con esso lei ella le 'nviti</l>
             <l>Ad una festa, che 'ntendiam di fare.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Tu non ce le corrai.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="F">Anzi verranle,</l>
             <l>Che vo, ch' ella lor dica, che noi tutti</l>
             <l>Insino a un'hora, o <num value="2">due</num> siam per partirci</l>
             <l>Di queste selve, et gir fin' in <name>Ispagna</name>.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>So, che finger tu vuoi di gir da lunge.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>Ben bisogna mostrar, che gran paesi,</l>
             <l>Et varij mari, et varij fiumi, et monti,</l>
             <l>Vogliam cercar, perche conoscan chiaro,</l>
             <l>Che facil non ne fia il tornare a loro.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Hor segui</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="F">Io voglio poi, ch'ella le dica,</l>
             <l>Ch' i nostri Satirini, e i picciol Fauni</l>
@@ -869,7 +930,7 @@ DA FERRARA</hi>
             <l>Usciremo del bosco, et farem quello</l>
             <l>A lor, ch' i Roman fero a le Sabine</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l><name>Fauno</name>, molto mi piace il tuo consiglio,</l>
             <l>I' o, tosto che le veggia, con bel modo</l>
@@ -877,13 +938,13 @@ DA FERRARA</hi>
             <l>Et, quando cio non mi soccieda, ogni arte</l>
             <l>Usero poi, perche quest'altro segua</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l><name>Egle</name>, te ne preghiamo, cosi mai</l>
             <l>Non ti manchi da ber vino soave,</l>
             <l>E 'l tuo <name>Silen</name> sovra ogni cosa t'ami.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Io non manchero in cosa, ch' io presuma,</l>
             <l>Ch' a espedir questo fatto esser possa atta,</l>
@@ -910,7 +971,7 @@ DA FERRARA</hi>
             <l>Et cosi appresso loro havro piu fede,</l>
             <l>Et piu agevol mi fia finire il tutto.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Hor vanne, <name>Egle</name> mia dolce, et faccia <name>Baccho</name>;</l>
             <l>Che riesca a buon fin questo disegno:</l>
@@ -923,7 +984,7 @@ DA FERRARA</hi>
             <hi rend="sc">Scena III</hi>
           </head>
           <stage>EGLE SOLA</stage>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Aviene di costor quello, ch'aviene</l>
             <l>Del mio <name>Silen</name>, quando a le volte beve</l>
@@ -954,45 +1015,45 @@ DA FERRARA</hi>
             <hi rend="sc">Scena IIII</hi>
           </head>
           <stage>SATIRO, CHORO,  FAUNO</stage>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Che state a fare? venite fuori homai,</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l>Tu ci hai tutti adunati, et non ci hai detto,</l>
             <l>Perche cagion tu n'hai condotti insieme;</l>
             <l part="I">Che ci hai da dire?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">una bramata cosa</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l>Non bramiamo altra cosa, che potere</l>
             <l>Godersi de le nimphe, che no' amiamo.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Et d' altro non vi ho da ragionare,</l>
             <l>Et dimostrarvi il modo, onde potremo,</l>
             <l>Tutti a un tratto, dar fine a i nostri affanni.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l>Ha, ah, ah, ah, ò <name>Baccho</name>, ò <name>Baccho</name>, ah, ah,</l>
             <l>Ò <name>Baccho</name>, òè, ò <name>Baccho</name>, òegrave;,òegrave;,</l>
             <l>Se cio ver' è, quai fian di noi piu lieti?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Siam risoluti, ch' i celesti Dei</l>
             <l>La ci vogliono fare, ad ogni modo,</l>
             <l>Et pe' l consiglio del canuto <name>Fauno</name></l>
             <l>Determinato habbiam di farla a loro.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l>Et cosi far si deve, ò <name>Baccho</name>, òegrave;,</l>
             <l>Fa, che la cosa ne soccieda, et noi</l>
@@ -1003,7 +1064,7 @@ DA FERRARA</hi>
             <l>Un napo pien di delicato vino,</l>
             <l>Ma narra il modo, che tenir dobbiamo.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>Il modo intenderete piu a bell'agio,</l>
             <l>Hor fa mestieri, che cantiamo insieme</l>
@@ -1014,17 +1075,17 @@ DA FERRARA</hi>
             <l>Per fuggir la cagion del nostro male,</l>
             <l>Et non dar noia a lor, ch'amiamo tanto.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Comincia tu che seguiremo tutti.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>Ponianci insieme a l'ombra di quel faggio,</l>
             <l>Et diam principio al lagrimevol canto:</l>
             <l>Voi <num value="4">quattro</num> rimarrete di cantare,</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO</speaker>
             <l>Non arse mai stoppia per fiamma,</l>
             <l>C' habbia bifolco in lei talhor' accesa,</l>
@@ -1096,17 +1157,17 @@ DA FERRARA</hi>
             <hi rend="sc">Scena I</hi>
           </head>
           <stage>Oreadi, Driadi, Napee, Egle, Naiadi</stage>
-          <sp>
+          <sp who="#oreadi">
             <speaker>Oreadi</speaker>
             <l>Gia apparecchiata s' è digire al bosco</l>
             <l><name>Diana</name> per cacciar con l' altre nimphe,</l>
             <l>Andiamo anchora noi a ritrovarla.</l>
           </sp>
-          <sp>
+          <sp who="#driadi">
             <speaker>Driadi</speaker>
             <l part="I">Andian</l>
           </sp>
-          <sp>
+          <sp who="#napee">
             <speaker>Napee</speaker>
             <l part="F">Andiamo a l'honoranda nostra</l>
             <l>Dea, figlia di <name>Latona</name>, et del gran <name>Giove</name>,</l>
@@ -1114,13 +1175,13 @@ DA FERRARA</hi>
             <l>Di vera castitade, et lume chiaro</l>
             <l>Del ciel, quando il Sol toglie a noi la luce.</l>
           </sp>
-          <sp>
+          <sp who="#driadi">
             <speaker>Driadi</speaker>
             <l>Andiamo a la triforme nostra Dea,</l>
             <l>Non men chiara nel ciel, ch'ella sia in terra,</l>
             <l part="I">O nel regno di <name>Dite</name></l>
           </sp>
-          <sp>
+          <sp who="#oreadi">
             <speaker>Oreadi</speaker>
             <l part="F">Honora <name>Pale</name></l>
             <l>Ogni Pastore, et <name>Cerere</name> i bifolchi,</l>
@@ -1129,14 +1190,14 @@ DA FERRARA</hi>
             <l>Apprezzian castita, quanto la vita,</l>
             <l>Devemo amar con tutto 'l cor <name>Diana</name></l>
           </sp>
-          <sp>
+          <sp who="#driadi">
             <speaker>Driadi</speaker>
             <l>Et come face sacrifitio a <name>Marte</name>,</l>
             <l>Chi segue la battaglia, et a <name>Nettunno</name>,</l>
             <l>Chiunque il tempestoso Oceano varca,</l>
             <l>Cosi a <name>Diana</name> noi deven dar voti</l>
           </sp>
-          <sp>
+          <sp who="#napee">
             <speaker>Napee</speaker>
             <l>Dunque Dea de le selve, et Dea de boschi,</l>
             <l>In segno de la pura honesta nostra,</l>
@@ -1155,7 +1216,7 @@ DA FERRARA</hi>
             <l>La faccia, o come spira tutta fuoco,</l>
             <l>So, che si vede, ch'ella serve a <name>Baccho</name></l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Gelata non son gia, come voi sete,</l>
             <l>Ne pallida mi face il ber de l'acque,</l>
@@ -1168,7 +1229,7 @@ DA FERRARA</hi>
             <l>E de la vita humana, et senza lui</l>
             <l>Nulla di lieto al mondo esser mai puote</l>
           </sp>
-          <sp>
+          <sp who="#naiadi">
             <speaker>Naiadi</speaker>
             <l>Ubriaca che tu sei, credi di darci</l>
             <l>A veder, che l'error in che tu sei</l>
@@ -1197,7 +1258,7 @@ DA FERRARA</hi>
             <l>Qual' hora habbian tal cose inanzi a gli occhi,</l>
             <l>Di darci a ber si abominevol succo.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Io ti dico incontrario di quel, c'hai</l>
             <l>Contra me detto, che non è dolcezza</l>
@@ -1229,18 +1290,18 @@ DA FERRARA</hi>
             <l>L'altrui virginita, i' ti rispondo,</l>
             <l>Che non si dee verginita apprezzare.</l>
           </sp>
-          <sp>
+          <sp who="#naiadi">
             <speaker>Naiadi</speaker>
             <l part="I">Hor va malvaggia, va.</l>
           </sp>
-          <sp>
+          <sp who="#oreadi">
             <speaker>Oreadi</speaker>
             <l part="F">Vanne impudica,</l>
             <l>Va nemica d' honore, oimè, che voce</l>
             <l>Di questa bocca scelerata è uscita?</l>
             <l>Va, va al tuo <name>Bacco</name>, et noi lascia a <name>Diana</name></l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>O poverelle che voi sete, sciocche</l>
             <l>Vi rimarrete, et io saro la saggia,</l>
@@ -1248,7 +1309,7 @@ DA FERRARA</hi>
             <l>Che differentia sia tra l'uno, et l'altro</l>
             <l part="I">Modo di vita</l>
           </sp>
-          <sp>
+          <sp who="#napee">
             <speaker>Napee</speaker>
             <l part="F">La lascivia tua</l>
             <l>Ti fa parer vertù quello, ch' è vitio,</l>
@@ -1259,7 +1320,7 @@ DA FERRARA</hi>
             <l>Et certe siam, ch'ogni thesoro avanza</l>
             <l>Questa verginita, che custodimo.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Et io vi dico ch' è di nessun pregio</l>
             <l>Questa verginita, che si lodate,</l>
@@ -1281,7 +1342,7 @@ DA FERRARA</hi>
             <l>Com'uccisi ella havesse color tutti,</l>
             <l>C'havria pottuti generare in terra.</l>
           </sp>
-          <sp>
+          <sp who="#oreadi">
             <speaker>Oreadi</speaker>
             <l>Sono proprio da te queste parole,</l>
             <l>Che chi avezzo è di star sempre nel fango,</l>
@@ -1289,7 +1350,7 @@ DA FERRARA</hi>
             <l>Pero sta tu col tuo parer con <name>Baccho</name>,</l>
             <l>Noi con <name>Diana</name> rimarem col nostro.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Et che credete voi, che se ne stia,</l>
             <l><name>Diana</name> cosi casta, che non voglia</l>
@@ -1305,7 +1366,7 @@ DA FERRARA</hi>
             <l>Si trastula, con lei, et voi vi state,</l>
             <l>senza piacere alcun, sempre digiune.</l>
           </sp>
-          <sp>
+          <sp who="#napee">
             <speaker>Napee</speaker>
             <l>Noi gia di giune di piacer non siamo,</l>
             <l>Anzi 'l maggior piacer proviam del mondo,</l>
@@ -1313,7 +1374,7 @@ DA FERRARA</hi>
             <l>Ne creder ti voglian cio, che n'hai detto</l>
             <l part="I">De la nostra <name>Diana</name></l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">di <name>Diana</name></l>
             <l>Credete voi cio, che vi piace, detto</l>
@@ -1323,13 +1384,13 @@ DA FERRARA</hi>
             <l>Dico, che commettete un'error grave:</l>
             <l part="I">Non so, se m' intendete;</l>
           </sp>
-          <sp>
+          <sp who="#driadi">
             <speaker>Driadi</speaker>
             <l part="F">Hor va tra Fauni,</l>
             <l>A la tua vita compagnia conforme;</l>
             <l>Et lascia andar noi a <name>Diana</name> al bosco.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Ben fora il meglio, che veniste a Fauni,</l>
             <l>A Satiri, a <name>Silvan</name>, poi che di lor</l>
@@ -1342,12 +1403,12 @@ DA FERRARA</hi>
             <l>Et potrian trar dal vostro fiore il frutto,</l>
             <l>Del qual voi sete debitrici al mondo</l>
           </sp>
-          <sp>
+          <sp who="#driadi">
             <speaker>Driadi</speaker>
             <l>Che noi amiam quelle bestiacce sozze?</l>
             <l>De quai cosa non ha il mondo piu brutta?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>In lor parte non è da capo a piedi,</l>
             <l>Che non sen possa haver dal ciel l'essempio,</l>
@@ -1371,7 +1432,7 @@ DA FERRARA</hi>
             <l>Pero gran torto havete a non far stima</l>
             <l>Di questi Dei, che voi chiamate sozzi.</l>
           </sp>
-          <sp>
+          <sp who="#napee">
             <speaker>Napee</speaker>
             <l>Poi che tu vuoi da Dei l'essempio torre,</l>
             <l>Di quanto hanno di sozzo in se costoro,</l>
@@ -1379,7 +1440,7 @@ DA FERRARA</hi>
             <l>Lasciar costoro, e amarci Dei del cielo;</l>
             <l>Che si mostran di noi cosi bramosi?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Udito ho sempre dir, che quello amore,</l>
             <l>Che tra dissimil nasce e amore infido,</l>
@@ -1404,13 +1465,13 @@ DA FERRARA</hi>
             <l>Che potesser gustar tra questi boschi,</l>
             <l>Potrete ben sperar, non temer male.</l>
           </sp>
-          <sp>
+          <sp who="#oreadi">
             <speaker>Oreadi</speaker>
             <l>Hor non ci dar piu noia, esser puo prima</l>
             <l>Ogni impossibil cosa, che nissuna</l>
             <l>Di noi por possa amore a questi mostri.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>I' vi so dir, che non andrete molto,</l>
             <l>Che noia piu non vi daran pe boschi,</l>
@@ -1431,12 +1492,12 @@ DA FERRARA</hi>
             <l>Per non veder restar senza i suoi Dei</l>
             <l>Le selve gia felici de l'Arcadia.</l>
           </sp>
-          <sp>
+          <sp who="#driadi">
             <speaker>Driadi</speaker>
             <l>Vadano pur, che non ne cal di loro,</l>
             <l>Come se non gli havessimo unqua visti.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>I miseri n'andranno, et sono in via,</l>
             <l>Et vi van si lontani, che piu mai</l>
@@ -1446,14 +1507,14 @@ DA FERRARA</hi>
             <l>Et testimon lasciati han questi faggi,</l>
             <l>Del lor amor, de la durezza vostra.</l>
           </sp>
-          <sp>
+          <sp who="#napee">
             <speaker>Napee</speaker>
             <l>Ben sentiti gli habiamo, et n' è piaciuto,</l>
             <l>Che seccaggine tal da noi si levi:</l>
             <l>Ma sento abbaiar cani, et sonar corni;</l>
             <l>Pero tempo è, che ce n' andiamo al bosco</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Ahi crude piu d' ogni selvaggia fiera,</l>
             <l>Piu d' ogni selce dure, et d' ogni scoglio,</l>
@@ -1470,7 +1531,7 @@ DA FERRARA</hi>
             <l>Et perche, poscia che voi lor sdegnate,</l>
             <l>Essi sdegnano cio, che non è voi.</l>
           </sp>
-          <sp>
+          <sp who="#naiadi">
             <speaker>Naiadi</speaker>
             <l>A questi Satirini, et picciol Fauni</l>
             <l>Non mancherem d'esser cortesi sempre,</l>
@@ -1482,22 +1543,22 @@ DA FERRARA</hi>
             <l>Non siam (come detto hai) crude, et spietate,</l>
             <l>Ma di gram cortesia, di pieta piene.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Fate cosa lodevole, e 'n loro vece</l>
             <l>Di tal bontade i' vi ringratio molto,</l>
             <l>Et so, che scemeram la doglia loro,</l>
             <l>Quando gli narrero nuova si buona.</l>
           </sp>
-          <sp>
+          <sp who="#napee">
             <speaker>Napee</speaker>
             <l part="I">Hor con Dio rimani <name>Egle</name></l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">Andate in pace</l>
           </sp>
-          <sp>
+          <sp who="#oreadi">
             <speaker>Oreadi</speaker>
             <l>Uno fermo proposito, che 'n donna</l>
             <l>Sia di servarsi casta, al fine vince,</l>
@@ -1510,7 +1571,7 @@ DA FERRARA</hi>
             <hi rend="sc">Scena II</hi>
           </head>
           <stage>EGLE SOLA</stage>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Non è da apperecchiare a alcuno insidie,</l>
             <l>Se non quand' ei si pensa esser sicuro,</l>
@@ -1535,7 +1596,7 @@ DA FERRARA</hi>
             <hi rend="sc">Scena III</hi>
           </head>
           <stage>SATIRO, EGLE, FAUNO</stage>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>O che sia il troppo desiderio mio</l>
             <l>D' haver la cosa amata, o pur, ch' Amore</l>
@@ -1548,12 +1609,12 @@ DA FERRARA</hi>
             <l>Mi vengon tuttavia segni maggiori,</l>
             <l>Che l'accrescono piu, che 'l fan piu fermo.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Che non puo fare Amor con la sua fiamma,</l>
             <l>Poi che dice costui cose si gravi?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Al venir fuor de la spelonca usata,</l>
             <l>Veduto ho sovra un pin <num value="2">due</num> tortorelle,</l>
@@ -1570,12 +1631,12 @@ DA FERRARA</hi>
             <l>Che d'una quercia ombrosa a lo 'mproviso</l>
             <l>Mi fece tristo augurio ne la selva</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Che pazzia è questa, che gli augelli il mondo</l>
             <l>Tema, se la natia lor voce fanno?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Poco dopo, mi venne incontro un Toro,</l>
             <l>Squallido, magro, con dolente aspetto,</l>
@@ -1590,12 +1651,12 @@ DA FERRARA</hi>
             <l>Poi, se quindi rivolgo il pensier mio</l>
             <l>A l'astuto veder de la vostra <name>Egle</name>,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Lodato <name>Bacco</name>, ch'anch' io merto lode,</l>
             <l>Et son di qualche pregio in queste selve.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>È a la simplicita di queste nimphe,</l>
             <l>In cosi gran timore ho qualche speme,</l>
@@ -1604,13 +1665,13 @@ DA FERRARA</hi>
             <l>Non verran meno a noi, che per li boschi</l>
             <l>Honoriamo ambo lor con tutto il core,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Non voglio piu tardar, di che ti dogli?</l>
             <l>Qual passion t'affligge si aspramente,</l>
             <l>Hor che siam per accor le augelle al visco?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Mi tengono tra <num value="2">due</num> speme, e timore,</l>
             <l>Et, se vince un di <num value="2">due</num>, vince la tema,</l>
@@ -1620,13 +1681,13 @@ DA FERRARA</hi>
             <l>Tu assicurar ogni temenza mia,</l>
             <l>Se buona nuova da le nimphe porti</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>Venuto son'anch'io, poi che v'ho visti</l>
             <l>Parlare insieme, per saper, se buona</l>
             <l>Nova hai da queste nostre aspre nemiche.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>La nova è, frate mio, che dopo, ch'io</l>
             <l>Non le potei dispor ad amar voi;</l>
@@ -1640,46 +1701,46 @@ DA FERRARA</hi>
             <l>Anchor partiti, e i Satirini vostri</l>
             <l part="I">Pensasser di far festa.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Ben pensasti,</l>
             <l>Che gli poteva cio dar chiaro inditio</l>
             <l part="I">Di qualche inganno.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">Adunque ov' io deveva</l>
             <l>Lo 'nvito farle, i'cercai di disporle,</l>
             <l>C'havessero pietà de picciol nostri</l>
             <l part="I">Satiri, et Fauni.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Et a qual fine questo?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Il saperai, s'ascolti, esse credendo,</l>
             <l>Che voi ne foste giti, ad una voce</l>
             <l>Dissero di voler per figli accorgli.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Non veggio anchor, che ciò nulla ne giovi,</l>
             <l part="I">O ne dia speme alcuna.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">Se sei cieco,</l>
             <l part="I">Che vuoi, ch'io te ne faccia?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Aprimi gli occhi</l>
             <l>Tanto, ch' io veggia quel, che 'nsino ad hora</l>
             <l part="I">Veder non ho saputo.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">Ite a la caccia</l>
             <l>Si sono insieme, et io nel ritornare,</l>
@@ -1688,19 +1749,19 @@ DA FERRARA</hi>
             <l>Pregar le vo, che gli accolgan per figli,</l>
             <l>Come t'ho detto, che promesso m'hanno.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>Non so veder, che quindi avenir altro</l>
             <l>Possa, se non che noi da queste nimphe</l>
             <l>Cacciati siamo, e nvece nostra i figli,</l>
             <l>Ch' a ciò non pensam, siam da loro accolti.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Veggio, misero me, che saran veri</l>
             <l>Gli auguri, di che dianzi i' dicea meco.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Lasciami, se tu vuoi, giungere al fine,</l>
             <l>Ne ti doler pria, che cagion tu n' habbi,</l>
@@ -1709,7 +1770,7 @@ DA FERRARA</hi>
             <l>Et dirle che, trovandosi con loro,</l>
             <l>Men grave gli sarà mancar de padri.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Incomincio a veder ciò, che vuoi fare,</l>
             <l>Et cosi sono d'allegrezza pieno,</l>
@@ -1717,7 +1778,7 @@ DA FERRARA</hi>
             <l>Ah, ah, ah, ah, ah, ah, dolce <name>Egle</name> mia,</l>
             <l>Esser pens' hoggi sol per te felice</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Esse, che piu non temeranno insidie,</l>
             <l>Se gli accorranno, et ne verran con loro</l>
@@ -1732,7 +1793,7 @@ DA FERRARA</hi>
             <l>Hor parti che condotta habbia il mio ingegno</l>
             <l part="I">Ogni cosa a buon fine?</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="F"><name>Egle</name> mia dolce,</l>
             <l>Tu ci hai data la preda ne le mani</l>
@@ -1744,21 +1805,21 @@ DA FERRARA</hi>
             <l>Se tu facevi, come havevam detto,</l>
             <l>Se n' andava ogni cosa a la mal' hora.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Saper bisogna usare il luoco, e 'l tempo,</l>
             <l>A chi una cosa vuol condure al fine.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>Ma entriam nel bosco a dar la nova a gli altri.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Entriam, ma vi bisogna star ascosi</l>
             <l>Si, che non diate lor di ciò sospetto.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO</speaker>
             <l>Come avaro bifolco, poi che 'n terra</l>
             <l>Il gran con piena mano</l>
@@ -1828,7 +1889,7 @@ DA FERRARA</hi>
             <hi rend="sc">Scena I</hi>
           </head>
           <stage>PANE  SOLO</stage>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Che giova a me l' esser d' <name>Arcadia</name> Dio?</l>
             <l>Et l'haver sotto me tutti i pastori?</l>
@@ -1930,7 +1991,7 @@ DA FERRARA</hi>
             <hi rend="sc">Scena II</hi>
           </head>
           <stage>SIRINGA, PANE</stage>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l>Io mi maravigliava haver vist'hoggi</l>
             <l>Le selve si quiete, et si sicure,</l>
@@ -1957,12 +2018,12 @@ DA FERRARA</hi>
             <l>Altro paese, et men fiera ventura;</l>
             <l>E 'l camin preso havean verso la spagna.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Che cosa od'io? non ho gia udito dire</l>
             <l>Hoggi di tal partenza ad alcun Fauno</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l><name>Diana</name> si mostrò di ciò assai lieta,</l>
             <l>Come colei, che ben sapea, ch'un lungo</l>
@@ -1974,24 +2035,24 @@ DA FERRARA</hi>
             <l>Andato anchora <name>Pan</name>, che tanto tempo</l>
             <l part="I">Mi ha dato noia.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">intendi, s'hai orecchio,</l>
             <l>A che termine sei de l'amor tuo,</l>
             <l part="I">O miser me, ò 'nfelice</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l part="F">Non perch'io</l>
             <l>Fossi mai per amarlo, ò per mutarmi</l>
             <l>Del mio primo pensier fisso in diamante.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Ahi miser me, dov'ho io posto speme?</l>
             <l>Per chi mi consumo io? per chi mi struggo?</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l>Ma perche non è rocca si munita,</l>
             <l>Che non brami piu tosto haver lontani</l>
@@ -2010,7 +2071,7 @@ DA FERRARA</hi>
             <l>Et cosi minacciando di ferirlo,</l>
             <l>Mal grado suo, il farò lontano starmi.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Ai <name>Siringa</name> crudel, <name>Siringa</name> ingrata,</l>
             <l>Che bisogna fuggire? ò che temere?</l>
@@ -2024,7 +2085,7 @@ DA FERRARA</hi>
             <l>Deh muta homai <name>Siringa</name> mia pensiero,</l>
             <l>Et non m'esser cagion di tanto affano.</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l>Io lo ti ho detto, <name>Pane</name>, et tel ridico,</l>
             <l>Che vò servar la mia honesta intatta;</l>
@@ -2032,7 +2093,7 @@ DA FERRARA</hi>
             <l>Divenissero mare, e i mari boschi,</l>
             <l>Ch' io ti lasciassi pur toccarmi il lembo.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l><name>Siringa</name>, tu non sai, chi tu disprezzi,</l>
             <l>Io non sono un pastor di queste selve,</l>
@@ -2066,12 +2127,12 @@ DA FERRARA</hi>
             <l>Che se tu gli vedessi scherzar meco,</l>
             <l>Per haverli, verresti assai piu pia.</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l>Non, se fussero tutti oro, et diamanti,</l>
             <l>Tienliti pur, ch'io non mi curo haverli.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Ai poco saggia nimpha, anchor che sii</l>
             <l>Più bianca, che i Ligustri, et piu vermiglia,</l>
@@ -2098,11 +2159,11 @@ DA FERRARA</hi>
             <l>Et un, che quello ha in se, che non ha <name>Giove</name>,</l>
             <l>Quantunque egli dal ciel fulmini, et tuoni.</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l>Vè, che sozzo animal si vuol far bello?</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Oltre di cio, ti puon far chiara fede</l>
             <l>Gli arbori, et l'herbe, e i fior di queste selve,</l>
@@ -2115,13 +2176,13 @@ DA FERRARA</hi>
             <l>Che contender potrei col biondo <name>Apollo</name>,</l>
             <l>Con piu felice fin, che non fe <name>Marsia</name>.</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l>Io m'llegro con te di virtù tale,</l>
             <l>Ma perciò non farai mutarmi voglia,</l>
             <l>Però non spender piu parole indarno.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l><name>Siringa</name>, se non vuoi di me far stima,</l>
             <l>Io vorrei, che di te cura tenessi,</l>
@@ -2137,12 +2198,12 @@ DA FERRARA</hi>
             <l><num value="1000">Mille</num> nimphe mi chieggion per amante,</l>
             <l>Et <num value="1000">mille</num> son da me per te sprezzate.</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l>Pero non voglio far ingiuria a l'altre,</l>
             <l>Ama, chi t'ama, et non mi dar piu noia.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Deh s'altro non mi vuoi, <name>Siringa</name>, dare</l>
             <l>In refrigerio al men del mio gran fuoco,</l>
@@ -2154,26 +2215,26 @@ DA FERRARA</hi>
             <l>Assai fuggito m'hai, lascia, ch'un giorno</l>
             <l>Con un bascio ristori i danni miei.</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l>Un bascio? donna, che cortese sia</l>
             <l>D'un bascio ad altri, puo donarli il tutto,</l>
             <l>Ch'appresso me più mai non sara casta.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Tu te inganni, <name>Siringa</name>, un bascio è poco,</l>
             <l>Anzi (per meglio dire) è come nulla,</l>
             <l>Deh non lo mi negar, vita mia cara.</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l>Non mi t'accostar, <name>Pane</name> che se questo arco</l>
             <l>Non mi vien men, ne men queste saette,</l>
             <l>Io mi ti farò andar tanto da lunge,</l>
             <l>Che non havrai piu ardir venirmi appresso</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Ahi che vuoi far, <name>Siringa</name>, t'hai pur troppo</l>
             <l>Tinte del sangue mio, crudel, le mani,</l>
@@ -2186,13 +2247,13 @@ DA FERRARA</hi>
             <l>A un fido amante, a una pietosa nimpha,</l>
             <l>In pieta muterai la crudeltade.</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l>Non mi ha voluto far la gratia il cielo,</l>
             <l>C'hoggi egli ha fatto a le compagne mie,</l>
             <l>Che co Silvestri Dei tu ti sia gito.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l><name>Siringa</name>, me n'andro pria, che sia sera,</l>
             <l>Ne qui tenuto m'ham le greggie mie,</l>
@@ -2203,7 +2264,7 @@ DA FERRARA</hi>
             <l>Però in questo partir dammi la mano,</l>
             <l>Cara <name>Siringa</name> mia, ch'io la ti tocchi.</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l>Stammi lontan, io ti ho pur ancho detto,</l>
             <l>Se 'n te non vuoi che la pharetra i' scarchi,</l>
@@ -2212,7 +2273,7 @@ DA FERRARA</hi>
             <l>Ponti in camin con i compagni tuoi:</l>
             <l>Et non mi venir più dinanzi a gli occhi.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Benche da te partendo io abbandoni</l>
             <l>Ogni ben, pur, perche mi par minore</l>
@@ -2226,51 +2287,51 @@ DA FERRARA</hi>
             <l>Che tenghi certo, che quanto amar puote</l>
             <l>Un Dio nimpha gentil, tanto io t'ho amato.</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l>Hor non piu, <name>Pan</name>, <name>Diana</name> è qui vicina,</l>
             <l>Ch'io sento il siton de corni, et veggio i cani,</l>
             <l part="I">Me ne voglio ir.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">Deh ferma nimpha il passo,</l>
             <l part="I">Non mi ti torre anchor.</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l part="F">Lasciami, <name>Pane</name>,</l>
             <l>Se non ti vuoi pentir d'havermi vista.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Deh lascia, ch'io ti tocchi almen la mano.</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l>Lasciami, dico, ch'io non son piu sola,</l>
             <l>Che veggio la mia Dea, veggio le nimphe,</l>
             <l>Et guai a te, se tu mi fai chiamarle.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Non m'esser si crudel, nimpha gentile,</l>
             <l>Habbi pieta del mio angoscioso affanno.</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l part="I">Tu mi farai gridar.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">Grida a tua voglia.</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l><name>Diana</name> aiuto, che mi vuol far forza</l>
             <l part="I">Questo villan di <name>Pane</name></l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">Ecco io ti lascio,</l>
             <l><name>Siringa</name> ingrata, ma tu via mi porti</l>
@@ -2284,7 +2345,7 @@ DA FERRARA</hi>
           <stage>
             <stage>PANE, SILVANO</stage>
           </stage>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Maledetta <name>Diana</name>, et le sue nimphe,</l>
             <l>I can, gli strali, gli archi, et le pharetre,</l>
@@ -2327,24 +2388,24 @@ DA FERRARA</hi>
             <l>Od un Faggio, od un'olmo la cagione</l>
             <l>Del tuo dolor, al far vendetta giusta.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Gravi querele son queste, ch'io odo,</l>
             <l>Et mi paion di <name>Pan</name> nostro gran Dio.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Ma c'ha voluto dir la mia <name>Siringa</name>,</l>
             <l>Quando m'ha detto, che lontani vanno</l>
             <l>I Satiri, e 'i Silvan da queste selve?</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l><name>Pane</name>, che ci è, che ti lamenti tanto?</l>
             <l>Et sei si maninconico nel giorno,</l>
             <l>Che sono tutti i Dei Silvestri in gioia?</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Scacci il duolo, chi vuole, et si rallegri,</l>
             <l>Gioia non è per me tra queste selve,</l>
@@ -2352,13 +2413,13 @@ DA FERRARA</hi>
             <l>Poi che, chi sola mi potria far lieto,</l>
             <l>Quanto piu mesto son, tanto più gode.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Et qual' è la cagion del tuo dolore?</l>
             <l>Non ti gravi di dirlami che forse</l>
             <l>Potrei al tuo languir porger rimedio.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l><name>Silvano</name>, tu non sai quello ch' è noto</l>
             <l>A le piante, a le fiere, a i sassi, a l'herbe?</l>
@@ -2370,7 +2431,7 @@ DA FERRARA</hi>
             <l>Ne per cosa, ch'io faccia, io posso havere</l>
             <l>Speme da lei di ritrovar mai pace.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l><name>Pan</name>, peggio non si puo far ne gli affanni,</l>
             <l>Che pensar non dever' esser mai lieto,</l>
@@ -2378,12 +2439,12 @@ DA FERRARA</hi>
             <l>Di momento in momento? s'hor t'attrista,</l>
             <l>Forse empir ti potrà d'allegrezza ancho.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Il so, ma come che costei si mute,</l>
             <l>Allegrezza per me non n'oscie mai.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Ma dimmi, non è ella quella nimpha,</l>
             <l>Nata in <name>Nonacria</name>, ch' è tanto a <name>Diana</name></l>
@@ -2391,16 +2452,16 @@ DA FERRARA</hi>
             <l>Tra lor l'habito, et l'arco, si potrebbe</l>
             <l>Creder, che fosse ella <name>Diana</name> istessa?</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="I">Ell' è quella, <name>Silvan</name></l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l part="F">Hor l'ho veduta</l>
             <l part="I">Gir con <name>Diana</name></l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">oime, ch'ella mi ha tolto</l>
             <l>Nel suo partire il core, et son rimaso,</l>
@@ -2409,14 +2470,14 @@ DA FERRARA</hi>
             <l>Et tanto è 'l dolor mio, ch' io non vorrei</l>
             <l part="I">Esser piu vivo.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l part="F">Ben ti stimo sciocco,</l>
             <l>Poi che brami morir per una nimpha,</l>
             <l>De quali n' è tal copia, che se n'have</l>
             <l>Per ogni stran, per ogni incolto bosco.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Pari a lei non sen' ha, <name>Silvano</name> mio,</l>
             <l>Perche è costei tra tutte l'altre nimphe,</l>
@@ -2425,7 +2486,7 @@ DA FERRARA</hi>
             <l>Una cosa, che m'ha parlando detto,</l>
             <l part="I">Et intesa i' non l'ho.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l part="F">Che cosa è questa?</l>
             <l>Ch'essendosi partiti gli altri Fauni,</l>
@@ -2433,15 +2494,15 @@ DA FERRARA</hi>
             <l>Anch' io con loro, et pur di tal partenza</l>
             <l part="I">Non sapea, ne so nulla.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l part="F">et c'hai risposto?</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="I">Ch' anch'io mi volea gir.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l part="F">Ve, come il caso</l>
             <l>Produce il tutto, non potevi meglio</l>
@@ -2450,46 +2511,46 @@ DA FERRARA</hi>
             <l>Io mi maravigliava di vederti</l>
             <l part="I">Cosi maninconioso.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">Hora ch' è questo,</l>
             <l part="I">Caro <name>Silvan</name>?</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l part="F">La tua allegrezza certa.</l>
             <l>Il tuo certo gioir, quel, che ti puote</l>
             <l>Si lieto far,che piu non sarai mesto.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Ai caro il mio <name>Silvan</name>, non mi dir fole,</l>
             <l>Non cercare ammollire il mio dolore,</l>
             <l>Con medicina falsa, perche poi</l>
             <l>Elli ritorneria più, che mai, grande,</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>I' vo, che questa sera di <name>Siringa</name></l>
             <l part="I">Tu goda.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="M">Questa sera?</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l part="F">Questa sera:</l>
             <l>Com' i Satir godranno, e i Fauni tutti</l>
             <l part="I">De le lor nimphe.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">Hor che potria più affanno</l>
             <l>Darmi, ò dolor, se questo aveniss'hoggi?</l>
             <l part="I">Dimmi il vero, <name>Silvan</name></l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l part="F">Cosi vedere</l>
             <l>Potess' io questa pianta ritornare</l>
@@ -2500,12 +2561,12 @@ DA FERRARA</hi>
             <l>I Satiri, e i Silvan, che per godere</l>
             <l part="I">Le nimphe lor.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">Ma ch' è mestier, ch'io faccia?</l>
             <l>Perche mi goda di <name>Siringa</name> anch'io</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Poi che l' hai detto di voler partirti,</l>
             <l>Non dubitar di non haverla in braccio,</l>
@@ -2524,12 +2585,12 @@ DA FERRARA</hi>
             <hi rend="sc">Scena IIII</hi>
           </head>
           <stage>AMADRIADI, ALTRE NIMPHE, EGLE, SATIRI PICCIOLI, SIRINGA</stage>
-          <sp>
+          <sp who="#amadriadi">
             <speaker>Amadriadi</speaker>
             <l>Molti mesi ha, che più felice caccia</l>
             <l>Noi fatto non habbiam di quella d' hoggi.</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l>Ell' è stata felice, ma di molto</l>
             <l>Pericol, se 'l cengial, che que <num value="2">due</num> cani</l>
@@ -2537,7 +2598,7 @@ DA FERRARA</hi>
             <l>Ci cogliea con un dente, vedevamo,</l>
             <l>Che pericolo in se tengano i boschi.</l>
           </sp>
-          <sp>
+          <sp who="#amadriadi">
             <speaker>Amadriadi</speaker>
             <l>Ben dimostro <name>Diana</name>, che suoi colpi</l>
             <l>Venian da man divina, quando l'arco</l>
@@ -2548,7 +2609,7 @@ DA FERRARA</hi>
             <l>Trafisse il suo, ma d'un cosi possente,</l>
             <l>Che subito ei resto di vita privo.</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l>Quanto fu bel veder gli aggiramenti</l>
             <l>Di quella insidiosa astuta volpe,</l>
@@ -2556,7 +2617,7 @@ DA FERRARA</hi>
             <l>Ch'alhora, ch'essi si credean d'haverla</l>
             <l>Tra denti, si tornò ne la sua macchia.</l>
           </sp>
-          <sp>
+          <sp who="#amadriadi">
             <speaker>Amadriadi</speaker>
             <l>Ma, chi havria mai pensato di vedere,</l>
             <l>Che quella gravida <name>Orsa</name>, che trafisse</l>
@@ -2565,7 +2626,7 @@ DA FERRARA</hi>
             <l>Si che l'istessa man, ch'a lei die morte,</l>
             <l>Fosse a figli cagion del nascimento?</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l>Ciò fu bello a veder, ma via piu bello,</l>
             <l>Che, mentre questa nimpha cogliea il parto,</l>
@@ -2579,11 +2640,11 @@ DA FERRARA</hi>
             <l>Che si viene ver noi fuor de la selva,</l>
             <l part="I">Vo, che qui l'aspettiam.</l>
           </sp>
-          <sp>
+          <sp who="#amadriadi">
             <speaker>Amadriadi</speaker>
             <l part="F">Come ti piace.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Figliuoli miei, bisogna, che sappiate</l>
             <l>Finger cosi, ch'i miser vostri padri</l>
@@ -2594,7 +2655,7 @@ DA FERRARA</hi>
             <l>Io non mancherò punto d'aiutarvi,</l>
             <l>Ovunque io vedrò, che sia bisogno.</l>
           </sp>
-          <sp>
+          <sp who="#satiri_pioccioli">
             <speaker>
               <expan>Satiri pioccioli</expan>
             </speaker>
@@ -2603,17 +2664,17 @@ DA FERRARA</hi>
             <l>Per ottener quel, ch'ottener bramemo,</l>
             <l>Non ne venga pur men di favor <name>Bacco</name></l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Cosi, bisogna, che facciate, andiamo,</l>
             <l>Et mostratevi tutti in viso mesti.</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l>Ti sii la ben venuta, <name>Egle</name>, che buona</l>
             <l>Nova ci apporta la venuta tua?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Nova buona non han piu queste selve:</l>
             <l>Poi ch'i Silvestri Dei se ne son giti,</l>
@@ -2626,7 +2687,7 @@ DA FERRARA</hi>
             <l>Fatevi inanzi, poveri fanciulli,</l>
             <l>Et datevi a la fe di queste nimphe.</l>
           </sp>
-          <sp>
+          <sp who="#satiri_piccioli">
             <speaker>
               <expan>Satiri piccioli</expan>
             </speaker>
@@ -2640,14 +2701,14 @@ DA FERRARA</hi>
             <l>Quai qui rimasi siam, come rimane</l>
             <l>Perduto il suo pastor greggia infelice.</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l>Non vi saremo men, che madri, pie,</l>
             <l>Ben vi preghiamo da costumi nostri</l>
             <l>Non si partire, et por tutta in oblio</l>
             <l>De Satiri maggior l'aspra lascivia.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Non è da dubitar, ch'al viver vostro</l>
             <l>Non s'assomiglin, perche da fanciulli</l>
@@ -2677,17 +2738,17 @@ DA FERRARA</hi>
             <l>Qui ci ritroveremo tutti insieme,</l>
             <l>Forse contenti piu, che non siam' hora.</l>
           </sp>
-          <sp>
+          <sp who="#amadriadi">
             <speaker>Amadriadi</speaker>
             <l>Anzi verrenvi molto volontieri,</l>
             <l>Poi che noi vi possiam venir sicure.</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l>Deh di gratia dimmi, <name>Egle</name>, se d'<name>Arcadia</name></l>
             <l>Partito s' è co gli altri Fauni <name>Pane</name>?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Partito s' è pur troppo lo 'nfelice,</l>
             <l>Et non è per vederlo <name>Arcadia</name> mai,</l>
@@ -2699,13 +2760,13 @@ DA FERRARA</hi>
             <l>Te stessa a sdegno, per haver sdegnato</l>
             <l>Amante si fedel, fuor di ragione.</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l>Dolgasi egli di se, che si è voluto</l>
             <l>Por ad amar, chi mai non senti amore,</l>
             <l>Io non lo 'ndussi mai, ch' egli m'amasse.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Estender non mi voglio in dimostrarti</l>
             <l>Quanto meglio saria, ch'amor seguissi,</l>
@@ -2714,12 +2775,12 @@ DA FERRARA</hi>
             <l>Ma tempo verrà ben, che tu te stessa</l>
             <l part="I">Riprenderai.</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l part="F">I' non son per pentirmi</l>
             <l part="I">Mai de l'honesta mia.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">Te n'avedrai,</l>
             <l>Quando il penserai men, restate in pace,</l>
@@ -2731,7 +2792,7 @@ DA FERRARA</hi>
             <hi rend="sc">Scena V</hi>
           </head>
           <stage>EGLE, SILENO</stage>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Chi fia, chi dica, che d'ingegno manchi</l>
             <l>Donna, ch' a far si dia una grande impresa,</l>
@@ -2744,7 +2805,7 @@ DA FERRARA</hi>
             <l>Veggio <name>Sileno</name>, i' gli voglio dar nova,</l>
             <l>Ch' i Satir de le nimphe havran vittoria.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l>Tu mi farai uscir del corpo l'alma</l>
             <l>Con questo tuo tardar, <num value="3">tre</num> fiaschi ho asciutti</l>
@@ -2755,45 +2816,45 @@ DA FERRARA</hi>
             <l>Insino ad hora, gaglioffetta, guai</l>
             <l>A te, se fatto tu m' havessi oltraggio.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Et, se fatto l'havessi ben, che fora?</l>
             <l>Perciò non t'averria nulla di novo,</l>
             <l>Poi c'hai le corna per natura in capo.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l>Tu mi dileggi ribaldella? dammi</l>
             <l part="I">Un bascio.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="M">Volentieri</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="F">Hor prendi 'l fiasco,</l>
             <l part="I">Et ricreati un poco.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">I' n'ho bisogno,</l>
             <l>Per la durata mia nova fatica,</l>
             <l>In ridur queste nimphe a le mie voglie.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="I">Et c' hai tu fatto?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">Lasciami ber prima.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l>Bevi, che dato i' t' ho per questo il fiasco.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>O che buon vino è questo, i' me ne sento</l>
             <l>Fender la lingua si, che viemi a l'occhio</l>
@@ -2801,24 +2862,24 @@ DA FERRARA</hi>
             <l>Nettare, e ambrosia, i' non cerco ber meglio:</l>
             <l part="I">Et onde l' hai tu avuto?</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="F">Il mio Marone</l>
             <l>Da la mensa di <name>Bacco</name> hoggi l' ha tolto.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>So, ch' ei conosce il buono, i' non mi posso</l>
             <l part="I">Satiar di ber.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="F">Vedi, s' io m' arricordo,</l>
             <l><name>Egle</name>, di te: non ne ho voluto bere,</l>
             <l>Per servarloti, un goccio, anchor ch'havessi</l>
             <l part="I">Una gran sete.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">I' ti farei ingiuria,</l>
             <l>S' io non lasciassi, che tu dessi un bascio</l>
@@ -2826,7 +2887,7 @@ DA FERRARA</hi>
             <l>Accostavi la bocca; che piu dolce</l>
             <l>Basciar questo sarà, che le mie labbra.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l>Questo non gia, che piu dolce, che manna,</l>
             <l>E questa tua boccuccia, hor lascia, ch'io</l>
@@ -2835,91 +2896,91 @@ DA FERRARA</hi>
             <l>A ragion ben lodato hai questo vino,</l>
             <l>Potta di <name>Bacco</name>, i' non bevi mai meglio.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Bevilo tutto, ch' io non ho piu sete.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l>Senza che tu mel dica, i' l' ho bevuto;</l>
             <l>Et parmi, ch' io sia fatto un Dio celeste,</l>
             <l part="I">Hor c' hai fatto pe Fauni?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">Hanno le nimphe,</l>
             <l>Sotto spetie di fe, i nemici a cerco,</l>
             <l>Et molto non andrà, saran tutte,</l>
             <l>Secondo l' ordin dato, in braccio a Fauni.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l>Ah, ah, ah, ha, i' lodo il Signor <name>Bacco</name>,</l>
             <l>Che dar non sdegna aiuto a la sua gente,</l>
             <l>Vorrei anch' io poter d' una godere.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Deh vecchiaccio, che sei, non ti par, ch'io</l>
             <l>Sia troppo a le tue forze? Hor cerca, cerca,</l>
             <l><name>Silen</name>, dun' altra, che d' unaltro anch' io</l>
             <l>(Poi ch' io non son per te) vo provedermi.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l>Non ti adirar (vita mia cara) i' giuoco</l>
             <l part="I">Con te, nol vedi?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">Non mi par bel giuoco</l>
             <l>Il minacciarmi di tormi il pan di casa,</l>
             <l>Se' l facesti, insin hor ti fo sapere,</l>
             <l>Ch' io non vorrei morirmi de la fame.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="I">Che dirai pazzarella?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">M' hai intesa,</l>
             <l>Non mi vo veder tor la vittuaglia.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l>Entriam nel bosco, che farem la pace.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="I">I' non vi vo venir.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="M">Perche?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">Non voglio.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l>Deh vien di gratia, so, che gita al naso</l>
             <l part="I">Ti è subito la colera.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">cagione</l>
             <l>Forse non me n' hai data, se non fosse</l>
             <l>L'amor, col quale io t'amo i' staria un anno,</l>
             <l part="I">Ch' io non verrei, ove tu fossi.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l part="F">Eh andiamo;</l>
             <l>Car' <name>Egle</name> mia, nel bosco: Eh vien di gratia.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Va, ch' io ti seguo: Non è cosa al mondo,</l>
             <l>Che star piu faccia uno marito al segno,</l>
@@ -2928,7 +2989,7 @@ DA FERRARA</hi>
             <l>Il cibo, che mantien le donne in vita,</l>
             <l>Et chiaro hor visto i' l'ho nel mio <name>Sileno</name></l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO</speaker>
             <l>Hor, che siam per por fine a nostri affanni,</l>
             <l>Et si mostra cortese</l>
@@ -2986,18 +3047,18 @@ DA FERRARA</hi>
             <hi rend="sc">Scena I</hi>
           </head>
           <stage>EGLE, SATIRI</stage>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Sapete, ove la cosa è gia condotta,</l>
             <l>Atro non resta piu, se non che usiate</l>
             <l>Astutia nel pigliar le fiere in caccia.</l>
           </sp>
-          <sp>
+          <sp who="#satiri">
             <speaker>Satiri</speaker>
             <l>Pericol piu non v' è, poi che ce l'hai</l>
             <l>Con l'arte tua quasi condotte in mano.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Non vo, che vi paia esser si sicuri,</l>
             <l>Che non debbiate haver tema di quello,</l>
@@ -3011,12 +3072,12 @@ DA FERRARA</hi>
             <l>Perche, se s'avedesser de lo 'nganno,</l>
             <l>Tutto quel, che fatto è, sarebbe nulla.</l>
           </sp>
-          <sp>
+          <sp who="#satiri">
             <speaker>Satiri</speaker>
             <l>Da noi non mancherà, che con ingegno</l>
             <l>Non sia provisto a ogni possibil cosa.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Dunque io me n' andrò dritto a trovarle,</l>
             <l>Et cercherò di porle in danza insieme</l>
@@ -3024,7 +3085,7 @@ DA FERRARA</hi>
             <l>State dietro a questi arbori, et il tempo</l>
             <l part="I">Pigliatevi a la preda.</l>
           </sp>
-          <sp>
+          <sp who="#satiri">
             <speaker>Satiri</speaker>
             <l part="F">Vanne, et credi,</l>
             <l>Che l'hora non veggian, che 'l fine aggiunga,</l>
@@ -3035,7 +3096,7 @@ DA FERRARA</hi>
             <l>Sian tutti pronti a la parata preda:</l>
             <l>Ecco i Satirin vengono, et le nimphe,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>lor s'appresenta, non fia molto,</l>
             <l>C'havremo ne le mani il nostro bene.</l>
@@ -3046,36 +3107,36 @@ DA FERRARA</hi>
             <hi rend="sc">Scena II</hi>
           </head>
           <stage>Nimphe, Egle, Satiri Piccioli, Satiro grande, Choro</stage>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l>State sicuri pur d' haver trovato</l>
             <l part="I">Un perpetuo riposo.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">Et voi d' havere</l>
             <l part="I">L'inciampo ritrovato.</l>
           </sp>
-          <sp>
+          <sp who="#satiri_piccioli">
             <speaker>Satiri piccioli</speaker>
             <l part="F">Certo nulla</l>
             <l>Ci par d' haver perduto, tanto amore</l>
             <l>Ci havete mostro, e tai carezze fatte.</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l>Ogni giorno haverete maggior segno;</l>
             <l>Quanto v'amiam, quanto ne siate cari,</l>
             <l part="I">Ma vedete <name>Egle</name> vostra.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">Figli miei,</l>
             <l>Come vi contentate de la vita</l>
             <l>Di queste vostre madri? Se voi sete,</l>
             <l>Contenti, ogni dolor da me è fuggito.</l>
           </sp>
-          <sp>
+          <sp who="#satiri_piccioli">
             <speaker>
               <expan>Satiri piccioli</expan>
             </speaker>
@@ -3086,19 +3147,19 @@ DA FERRARA</hi>
             <l>L'immensa cortesia di queste nimphe,</l>
             <l>C'haver non potevam maggior conforto.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Io non me ne credetti altro giamai,</l>
             <l>Tanto cortesemente i' vidi accorvi.</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l>Gli a saputo un pò strano il bever l'acqua,</l>
             <l>Ma nel resto si son cosi acquetati,</l>
             <l>Che parso n' è, ch' assai restin contenti</l>
             <l part="I">De la compagnia nostra.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">E de l' etade</l>
             <l>Tenera proprio questo, che di mente</l>
@@ -3111,7 +3172,7 @@ DA FERRARA</hi>
             <l>Molto non andrà, che 'l ber de l'acque</l>
             <l>(Posto il vino in oblio) non gli fia noia.</l>
           </sp>
-          <sp>
+          <sp who="#satiri_piccioli">
             <speaker>
               <expan>Satiri piccioli</expan>
             </speaker>
@@ -3124,7 +3185,7 @@ DA FERRARA</hi>
             <l>Non s' opponesse al voler nostro, noi</l>
             <l>Le chiederemo a far con noi un ballo.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Et perche ricusar deono lo 'nvito?</l>
             <l>Quando son famigliari accolti insieme,</l>
@@ -3133,31 +3194,31 @@ DA FERRARA</hi>
             <l>Pero i' non credo, che queste cortesi</l>
             <l>Nimphe si sdegnin di danzar con voi.</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l part="I">Non gia per nostra fe.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">Voi fate bene,</l>
             <l>Poi che 'l maggior piacer, ch' esser mai possa,</l>
             <l>Per donna al mondo, voi havete a schivo.</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l part="I">Et qual' è questo?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">Amare, et de lo amore</l>
             <l part="I">Goder d'un' huomo, che s' ami.</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l part="F">Tu sei pure?</l>
             <l part="I"><name>Egle</name>, su le sciocchezze.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">Anz' io vi dico,</l>
             <l>Che di ciò non vi vo mover parola,</l>
@@ -3165,64 +3226,64 @@ DA FERRARA</hi>
             <l>Ci possiam por con questi putti in danza,</l>
             <l>Et solazzarsi honestamente insieme.</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l part="I">Facciam, come ti par.</l>
           </sp>
-          <sp>
+          <sp who="#satiro_grande">
             <speaker>Satiro grande</speaker>
             <l part="F">Son quasi al fine</l>
             <l part="I">Le cose?</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l part="M">Vuoi, che usciamo?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">State cheti</l>
             <l>Non vi scoprite, che non è anchor tempo.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l part="I">Oime quando fia l'hora?</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l part="F">Et come in ballo</l>
             <l>Potrem condurci, non vi essendo alcuno,</l>
             <l part="I">Che tra noi suoni?</l>
           </sp>
-          <sp>
+          <sp who="#satiro_piccolo">
             <speaker>Satiro piccolo</speaker>
             <l part="M">se fosse tra noi</l>
             <l>Fistula alcuna, sonerebbe parte</l>
             <l>Di noi, et parte si daria a danzare.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Ma non sapete voi, se sempre meco</l>
             <l part="I">Porto le fistole io?</l>
           </sp>
-          <sp>
+          <sp who="#satiri_piccioli">
             <speaker>Satiri piccioli</speaker>
             <l part="F">Dalleci adunque,</l>
             <l part="I">Che sonarem.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="M">Tenete.</l>
           </sp>
-          <sp>
+          <sp who="#satiro_grande">
             <speaker>Satiro grande</speaker>
             <l part="F">State in punto,</l>
             <l>Che 'l tempo vien, che se n' entriamo in caccia.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l part="I">A l'ordine noi siamo.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">A coppia, a coppia</l>
             <l>Noi entreremo in ballo, et le carole,</l>
@@ -3235,11 +3296,11 @@ DA FERRARA</hi>
             <hi rend="sc">Scena III</hi>
           </head>
           <stage>SATIRO, CHORO, SILENO, PANE, NIMPHE</stage>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">State a l'ordine, dico.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l part="F">Sian pur troppo</l>
             <l>A l' ordine, non fu mai si tes' arco,</l>
@@ -3248,12 +3309,12 @@ DA FERRARA</hi>
             <l>Che non li diamo dentro; ci sentimo</l>
             <l part="I">Mancar la vita.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Non ' anchora il tempo</l>
             <l part="I">D'uscir, fratelli miei.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l part="F">Non veggian l' hora,</l>
             <l>Che possiamo sfogar nostro disio:</l>
@@ -3262,7 +3323,7 @@ DA FERRARA</hi>
             <l>Ò che pie scarno, et rotondetto, et vago</l>
             <l part="I">Sostien quella vittina.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Con che gratia</l>
             <l>Move la mia <name>Napea</name> l'un lato, et l'altro,</l>
@@ -3270,29 +3331,29 @@ DA FERRARA</hi>
             <l>Come si ferma, et (per dir breve) come</l>
             <l>Leggiadramente al suon col pie risponde.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l>Ma vedi, che a noi vien <name>Sileno</name>, et <name>Pane</name>,</l>
             <l><name>Pan</name> venir dee per la <name>Siringa</name> sua,</l>
             <l>Ma non so, a qual fin qui venga <name>Sileno</name>,</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Che vi è <name>Sileno</name>?</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="F">Son venuto anch' io</l>
             <l part="I">A veder questa festa.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l part="F">Deh sta indietro</l>
             <l>Con questo asino tuo ne la mal'hora,</l>
             <l>Che, s'ei ragghiasse, siam tutti disfatti,</l>
             <l part="I">Non odi tu <name>Silen</name>?</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="F">Tu mi vuoi fare</l>
             <l>Uscir si, ch' io sia visto, io quel son stato,</l>
@@ -3300,94 +3361,94 @@ DA FERRARA</hi>
             <l>Cacciar, com' una bestia? i' voglio andare</l>
             <l part="I">Fuor de la selva, va inanzi.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">Eh non fare,</l>
             <l part="I">Caro <name>Sileno</name></l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="F">I' voglio andar, va la;</l>
             <l>Vo, che tutti costor paiano bestie.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l part="I">Costui è ubriaco.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">A punto, il vin lavora.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Non ci turbar <name>Silen</name>, <name>Silen</name> mio resta,</l>
             <l>Non voler, ch'un tuo sdegno ci disfaccia.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="I">Per amor tuo mi rimarro.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pan</speaker>
             <l part="F">E <name>Siringa</name></l>
             <l part="I">Forse nel ballo.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Ella al fin de la danza</l>
             <l>Git' è con l'altre nimphe, et con lor siede.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>La veggio, ai fiera, ai soperbetta, ai schifa,</l>
             <l>Ai nemica d'amore, et di pietade,</l>
             <l>Come mi struggi il cor? come m'ancidi?</l>
             <l part="I">Ma che tardiamo piu?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Lascia, che 'n ballo</l>
             <l>Entri di novo: Ve la tua <name>Siringa</name>,</l>
             <l part="I">Che guida la carola.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">Oime che vita?</l>
             <l>Oime che leggiadria? Che movimenti?</l>
             <l>Non tardiam più, ch' io ne moio, ahi lasso,</l>
             <l part="I">Io mi dileguo.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l part="F">Tempo è di far segno,</l>
             <l part="I"><name>Satiro</name>, a gli altri.</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l part="F">Havete udito quello</l>
             <l part="I">Sibillo?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">E nulla fia qualche pastore</l>
             <l>Che chiama la sua greggia, ò chiama i cani,</l>
             <l part="I">Seguiamo il ballo.</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l part="F">Son quasi rimasa</l>
             <l part="I">Fuori di me.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">Tu temi ben di poco:</l>
             <l part="I">Su a la danza, sonate.</l>
           </sp>
-          <sp>
+          <sp who="#satiri_piccioli">
             <speaker>Satiri piccioli</speaker>
             <l part="F">Noi soniamo.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Hora animosamente tutti a un tratto</l>
             <l>Entriam, compagni miei, lieti nel campo,</l>
@@ -3399,98 +3460,98 @@ DA FERRARA</hi>
             <hi rend="sc">Scena IIII</hi>
           </head>
           <stage>Nimphe, Choro, Pane, Egle, Sileno</stage>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l>O poverelle noi nimphe, siam morte,</l>
             <l>O poverelle noi, vedete i Fauni,</l>
             <l>I Satiri, e i Silvani, ò triste noi.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l>Eh non fuggite, che temete? Siamo</l>
             <l part="I">I vostri amanti.</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l part="F">Ai <name>Egle</name>, oime malvagia,</l>
             <l part="I">O noi semplici, et sciocche.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">Eh non fuggire,</l>
             <l part="I"><name>Siringa</name>, eh non fuggire.</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l part="F">ò meschinelle</l>
             <l part="I">Che siamo.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l part="F">Andate a quel varco un di voi,</l>
             <l>Piglia questa, che vien verso la selva,</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l part="I">O noi misere, et triste.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l part="F">che tardate?</l>
             <l part="I">Correte al bosco.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">Su Satir, su Fauni,</l>
             <l>Su valorosamente, ben sarete</l>
             <l>Cosi da poco, che fuggiranno ancho;</l>
             <l part="I">Et ne le man le havrete.</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l part="F">Ahi malvagia <name>Egle</name>,</l>
             <l part="I">Quest' è la fe?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">Dove ne vai <name>Sileno</name>?</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l>Io vò per dar soccorso a miei compagni,</l>
             <l>Ch' anch' essi m' aiutar, quando io ti tolsi.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>O cho soccorso, mover non ti puoi</l>
             <l part="I">Et gli vuoi dare aiuto?</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="F">Prender voglio</l>
             <l part="I">Questa, che viene in qua.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l part="F">Tosto, non state</l>
             <l>Satiri a bada, su picciol fanciulli,</l>
             <l>Correr non le lasciate, per la mano</l>
             <l>Tenetele, pe panni, et per le gambe.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l>A questa, a questa, tutti a dosso a questa.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l>Ci fuggiran, non state a bada, al bosco,</l>
             <l>Al bosco tutti, ch'elle al bosco vanno.</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l part="I">Oime dove siam giunte?</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="F">A dosso a dosso,</l>
             <l>A dosso a questa, piglia, piglia, piglia,</l>
@@ -3499,46 +3560,46 @@ DA FERRARA</hi>
             <l>Oime, et ho fatto nulla, ch' è fuggita,</l>
             <l part="I">Oime.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">Tel dissi io ben, sei tu ben atto</l>
             <l>Correr dietro a chi fugge: in tua mal' hora</l>
             <l>Tienti al tuo fiasco, che non fugge, et lascia</l>
             <l part="I">Correr chi vuol.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="F">S'io lo facea per bene.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Havresti fatto meglio haver bevuto,</l>
             <l part="I">Hor levati, se puoi.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="F">Dammi la mano,</l>
             <l part="I">Aiutami.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">Vorravvi altro potere,</l>
             <l part="I">Che 'l mio.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="F">Dammi la mano, perche anch' io</l>
             <l>Mi sorgerò, son pur risorto alquanto,</l>
             <l>Aiutami, <name>Egle</name>, regger non mi posso,</l>
             <l part="I">Oime.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">Monta a caval, ve, che allegrezza</l>
             <l>Tu mi vuoi dar sta notte, mentre in gioia</l>
             <l>Gli altri saran; sarai tu su 'l dolerti.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l>Non mica, tosto c' haverò bevuto,</l>
             <l>Non haverò più mal, volea potere</l>
@@ -3551,7 +3612,7 @@ DA FERRARA</hi>
             <hi rend="sc">Scena V</hi>
           </head>
           <stage>SILVANO, PANE</stage>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Ogni cosa nel bosco è sotto sopra,</l>
             <l>Chi corre in qua, chi in là prendute han molte</l>
@@ -3583,50 +3644,50 @@ DA FERRARA</hi>
             <l>Da lor soavi fiori il dolce frutto;</l>
             <l>Che nel ciel potria fare invidia a <name>Giove</name></l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Haver nemico il cielo, e immaginarsi</l>
             <l>Poter condurre uno suo effetto al fine,</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Che lamentevol voce è questa, ch' odo</l>
             <l>Uscir del bosco in cosi gran letitia?</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>A chi ciò crede, avien quel, ch' è avenuto</l>
             <l>A gli altri hoggi, et a me, miser <name>Pane</name>,</l>
             <l>O <name>Pan</name> tristo, e 'nfelice, ò <name>Pan</name> dolente,</l>
             <l part="I">A che termine sei?</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l part="F">Egli mi pare</l>
             <l><name>Pane</name>, che si lamenti, et che puo havere</l>
             <l>Egli di tristo, essendo ogniuno in gioia?</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>O doloroso <name>Pane</name>, hai pur perduto,</l>
             <l part="I">Quanto di bene havevi.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l part="F">Che ci è <name>Pane</name>?</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Potrai pur poverello a voglia tua</l>
             <l>Gir per le selve, senza haver sospetto</l>
             <l part="I">D' offender la tua Nimpha.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l part="F">Ch' avenuto</l>
             <l>T' è di dolente, <name>Pan</name>, che si ti dogli?</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Oime, <name>Silvano</name>, oime, tra queste selve,</l>
             <l>Selve gia di piacere et di diletto,</l>
@@ -3634,35 +3695,35 @@ DA FERRARA</hi>
             <l>Ov' esser credevam lieti, et felici,</l>
             <l>I piu miseri siam, che fossero unqua.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Tu mi togli la vita, <name>Pan</name>, ch' è questo,</l>
             <l>Che tu mi di? quando pensar piu debbo</l>
             <l>Vedervi lieti, s'hoggi sete tristi?</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Avenuta, <name>Silvan</name>, ci è cosa tale,</l>
             <l>Che fin, c'havranno mai fronde le selve,</l>
             <l>Sempre tristi sarem, sempre dolenti.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Deh fa, ch' io sappia, <name>Pan</name>, che cosa è questa.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l><name>Silvano</name>, non voler (se m' ami) udire</l>
             <l>L' infelicita nostra, e 'l nostro affanno?</l>
             <l>Che 'ncredibile angoscia havrai a udirlo.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>I' non posso sentir doglia maggiore</l>
             <l>Di quella, c' hor per voi il cor mi preme,</l>
             <l>Pero non mi tener' hor piu sospeso.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Mentre, <name>Silvan</name>, le nostre care nimphe</l>
             <l>(Ch' io pur lo ti diro, poi che 'l ricerchi)</l>
@@ -3688,12 +3749,12 @@ DA FERRARA</hi>
             <l>Restarò si, che non si videro, altre</l>
             <l>Divenner fior ne la minuta herbetta.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Ai che mi di tu, <name>Pan</name>? che meraviglie</l>
             <l part="I">Son queste, ch' i'odo?</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">Io non ti mento punto,</l>
             <l>Ne furono alcun' altre in questo tempo,</l>
@@ -3728,12 +3789,12 @@ DA FERRARA</hi>
             <l>È star sasso nel monte, appresso a quella</l>
             <l>Nimpha, che l' havea fatto il cor di pietra.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Non credo, mai che 'n un sol giorno tante</l>
             <l part="I">Mutation fosser vedute.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">A nostro</l>
             <l>Danno servate son le maraviglie,</l>
@@ -3741,23 +3802,23 @@ DA FERRARA</hi>
             <l>Miseri siamo, et io via piu d'ogniuno</l>
             <l>Languisca sempre, et mi tormenti sempre.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Perc'hai tu, <name>Pan</name>, maggior de gli altri doglia?</l>
             <l>Perche strugger ti vuoi tu piu de gli altri?</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Perche quant' era la <name>Siringa</name> mia</l>
             <l>D'ogni nimpha piu bella, ancho maggiore</l>
             <l>Era il mio fuoco, ond'io mi doglio tanto,</l>
             <l>Quanto era bella, et quanto io gia l'amai.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Deh dimmi, <name>Pan</name>, che avenut' è di lei</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>O sventurato me, dopo ch' io vidi</l>
             <l>Mutate l' altre nimphe in varie forme,</l>
@@ -3780,35 +3841,35 @@ DA FERRARA</hi>
             <l>Oime la vidi, oime <name>Silvano</name>, oime,</l>
             <l>A pena il posso dir, mutarsi in canna.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Ne lo posso udir' io senza gran doglia,</l>
             <l>Et testimon ten faccia il pianto mio,</l>
             <l>Ma che stormento è questo, che ti pende</l>
             <l part="I">A lato?</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">oime, ch' io vo sempre haver questo</l>
             <l>Per la piu cara cosa, ch' al mondo habbia.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l part="I">Et perche: <name>Pan</name></l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">Perche di quella canna,</l>
             <l>In che mutata s' è la mia <name>Siringa</name>,</l>
             <l>Composta i' l'ho, per isfogar col suo</l>
             <l>Suon la mia doglia, e'l mio angoscioso affanno.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Et come in cor ti venne di comporre</l>
             <l part="I">Tanti calami in un?</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">Non fu mutata</l>
             <l>Cosi tosto <name>Siringa</name>, che spirando</l>
@@ -3824,7 +3885,7 @@ DA FERRARA</hi>
             <l>Con la qual risonar farò ogni selva</l>
             <l>Del caro nome suo, del mio dolore.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Felice sei tu, <name>Pan</name>, appresso gli altri,</l>
             <l>Perche con <name>Ega</name> tua antica mogliera</l>
@@ -3832,24 +3893,24 @@ DA FERRARA</hi>
             <l>Ma gli altri poverelli, che non hanno</l>
             <l>Rifugio alcun, si pon ben chiamar tristi.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Ohime, caro <name>Silvan</name>, tanto piu d'<name>Ega</name></l>
             <l>Era bella costei, quanto più belli</l>
             <l>Son gli amaranthi de minori fiori.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Et io ti dico, <name>Pan</name>, ch' è piu bell' <name>Ega</name></l>
             <l>In questa età, che mai non fu <name>Siringa</name></l>
             <l>Nel piu bel fior de suoi piu fioriti anni.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Non piu, <name>Silvan</name>, che tu m' accresci doglia,</l>
             <l>Vien meco, entra nel bosco a veder gli altri.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Entra, ch' anch' io di subito ti seguo,</l>
             <l>Non si dee desiar cosa, che neghi</l>

--- a/tei/giraldi-cinzio-egle-ms-classe-i-331.xml
+++ b/tei/giraldi-cinzio-egle-ms-classe-i-331.xml
@@ -72,6 +72,64 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="silvano">
+            <persName>Silvano</persName>
+          </person>
+          <person xml:id="satiro">
+            <persName>Satiro</persName>
+          </person>
+          <person xml:id="fauno">
+            <persName>Fauno</persName>
+          </person>
+          <person xml:id="sileno">
+            <persName>Sileno</persName>
+          </person>
+          <person xml:id="egle">
+            <persName>Egle</persName>
+          </person>
+          <person xml:id="chromi">
+            <persName>Chromi</persName>
+          </person>
+          <person xml:id="mnasilo">
+            <persName>Mnasilo</persName>
+          </person>
+          <personGrp xml:id="choro">
+            <name>Choro di Satiri</name>
+          </personGrp>
+          <personGrp xml:id="oreadi">
+            <name>Oreadi</name>
+          </personGrp>
+          <personGrp xml:id="driadi">
+            <name>Driadi</name>
+          </personGrp>
+          <personGrp xml:id="nappee">
+            <name>Nappee</name>
+          </personGrp>
+          <personGrp xml:id="naiadi">
+            <name>Naiadi</name>
+          </personGrp>
+          <person xml:id="pane">
+            <persName>Pane</persName>
+          </person>
+          <person xml:id="siringa">
+            <persName>Siringa</persName>
+          </person>
+          <personGrp xml:id="amadriadi">
+            <name>Amadriadi</name>
+          </personGrp>
+          <personGrp xml:id="nimphe">
+            <name>Nimphe</name>
+          </personGrp>
+          <person xml:id="satiri_piccioli">
+            <persName>Satiri Piccioli</persName>
+          </person>
+          <person xml:id="satiri_piccoli">
+            <persName>Satiri Piccoli</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>2003-06-10T00:00:00.000+01:00</date><name>Camilla Ghedini</name><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -90,7 +148,7 @@
           <hi rend="sc">ATTO PRIMO</hi>
         </head>
         <stage>SILVANO SOLO NARRA L' ARGO<expan>MEN</expan>TO</stage>
-        <sp>
+        <sp who="#silvano">
           <speaker>Silvano</speaker>
           <l>Quando lo stuolo human né l' in<expan>n</expan>ocenza</l>
           <l>Prima viveva, et dava cibo a ognuno</l>
@@ -210,18 +268,18 @@
             <hi rend="sc">SCENA II</hi>
           </head>
           <stage>SATIRO, FAUNO</stage>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Amor che mai non gionga al fine, amore</l>
             <l>Dir non si dee ma una continua pena</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>E troppo il ver ma se vi s' acompagna</l>
             <l>Sospetto e gelosia non e piu pena</l>
             <l>Ma una continua inevitabil morte</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Troppo tutti il proviam dopo che <name>Giove</name></l>
             <l>Et altri dei dal ciel venuti sono</l>
@@ -232,16 +290,16 @@
             <l>Non habbian fatto ingiuria, che per odio</l>
             <l>Debbano disturbar la pace nostra.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>Sai frate mio qual ingiurua han da noi</l>
             <l part="I">I dei del ciel?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="M">Non io.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="F">L'ingiuria è ch' essi</l>
             <l>Veggono la beltà di queste nimphe</l>
@@ -255,7 +313,7 @@
             <l>Et però <name>Giove</name> et gli altri dei son certi</l>
             <l>Che da le nimphe a noi saran proposti.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Quanto dolore oimè m' aggiunge questo</l>
             <l>Sospetto, et quanto più m'infiamma Amore</l>
@@ -267,7 +325,7 @@
             <l>Se ne fossero tolte da le mani</l>
             <l part="I">Le nimphe nostre.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="F">il lamentarsi è vano</l>
             <l>Quando non ponno le querele aiuto</l>
@@ -291,7 +349,7 @@
             <l>Mentre l' habbian qui ne le forze nostre</l>
             <l>E da cercar che se l godiamo noi.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Ai che piu non vi veggio modo alcuno</l>
             <l>Come già di veder mi parea prima.</l>
@@ -306,7 +364,7 @@
             <l>Qual hor la miro, et sdegnosetta, et schiva</l>
             <l>Mi fugge ove solea prima apprezzarmi</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>Tal è verso di me la <name>Naide</name> mia</l>
             <l>Qual a punto è ver te la tua <name>Napea</name>,</l>
@@ -335,12 +393,12 @@
             <l>Ell' ha nel petto ch' io non l' ami, et prezzi</l>
             <l>Et non cerchi d' haverla a le mie voglie.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Ma che vogliam noi far per goder qualche</l>
             <l>Frutto de le fatiche di tanti anni?</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>Voglio che 'ntendia<expan>n</expan> ben prima s'è vero</l>
             <l>Che sia per farne ingiuria i dei celesti,</l>
@@ -348,12 +406,12 @@
             <l>Potrebbe esser non ver, perche 'l sospetto</l>
             <l>Sempre segue l' amor, con ombra il corpo.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Che bisogna cercar s elle medesme</l>
             <l>L' han detto ad <name>Egle</name> del <name>Sileno</name> nostro.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>Costume è de le nimphe di mostrare</l>
             <l>Esser da dei maggiori amate, anchora</l>
@@ -366,11 +424,11 @@
             <l>Ch' altri non ponga falce in quella messe</l>
             <l>Ch' essere accolta dee per nostra mano.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Et come ciò potrem sapere.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="F">
               <name>Sileno</name>
@@ -387,19 +445,19 @@
             <l>Essendo noi ministri suoi e havendo</l>
             <l>Egli da noi et sacrifici et voti.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Ma dove havrem <name>Sileno</name>? Egli dormire</l>
             <l>Dee pien di vino in qualche grotta, o deve</l>
             <l>Esser col <name>Chromi</name> suo, col suo <name>Mnasilo</name></l>
             <l>In giuoco, e 'n festa o con la sua dolce <name>Egle</name>.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>Eccolo ch' egli vien co suoi compagni</l>
             <l part="I">Apunto fuor del bosco.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Ei tutto è festa</l>
             <l>Ove noi tutti siam doglia, et tormento,</l>
@@ -411,7 +469,7 @@
             <hi rend="sc">SCENA III</hi>
           </head>
           <stage>SILENO, CHROMI, MNASILO, EGLE NIMPHA</stage>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l><name>Baccho</name> se nel nutrirti hebbi gia affan<expan>n</expan>o</l>
             <l>Tant' hor piacere ho n' core</l>
@@ -437,7 +495,7 @@
             <l>Bevi vitina mia</l>
             <l>Che non bevesti mai succo migliore.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Beata quella vite ond' usci fuore</l>
             <l>Cosi soave humore</l>
@@ -445,14 +503,14 @@
             <l><name>Chromi</name>, et <name>Mnasilo</name> di disio di bere</l>
             <l>Da lor del vino anchora.</l>
           </sp>
-          <sp>
+          <sp who="#chromi">
             <speaker>Chromi</speaker>
             <l>Non son stat' io a quest' hora</l>
             <l><name>Egle</name> a gustarne, or da a <name>Mnasil</name>, che' l chere,</l>
             <l>Il vaso, et mostra havere</l>
             <l>Disio di voler darli uno gran scrollo</l>
           </sp>
-          <sp>
+          <sp who="#mnasilo">
             <speaker>Mnasilo</speaker>
             <l>Or pommi il fiasco al collo,</l>
             <l>Tanto ch' io sia satollo</l>
@@ -466,7 +524,7 @@
             <l>Idei et c' hora a lor produr me piacque</l>
             <l>Che si beve del vino in vece d' acque</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l>Beato il padre et la madre onde nacque</l>
             <l><name>Baccho</name> nostro alto duce</l>
@@ -484,27 +542,27 @@
             <hi rend="sc">SCENA IIII</hi>
           </head>
           <stage>SATIRO, FAUNO, SILENO, EGLE NIMPHA</stage>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Dio ti salvi <name>Silen</name>,</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="F">salviti Dio</l>
             <l>Et ti conservi l' allegrezza tua.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l>Et voi facia contenti il nostro <name>Bacco</name></l>
             <l>Et vi levi del core ogni tristezza.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>Ben bisogno n' habbia<expan>n</expan> caro <name>Sileno</name></l>
             <l>Che non appar mai per le selve il sole</l>
             <l>Ne mai si cela che ne vegga lieti.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l>Et che cosa è che si v' affliga? vuole</l>
             <l>Allegri <name>Baccho</name> i suoi compagni, et voi</l>
@@ -516,40 +574,40 @@
             <l>Che chi beve buon vin senza ber <name>Lethe</name></l>
             <l>Se ne beve l' oblio d' ogni dolore.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Oime ch' ogni soave cibo è tosco</l>
             <l>A un affanato cuore, altro ci vuole</l>
             <l part="I"><name>Sileno</name> a farci lieti.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="F">Se 'l vin lieti</l>
             <l>Far non vi puo per voi non ho rimedio</l>
             <l part="I">Io bevero per voi.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Anzi il rimedio</l>
             <l>E solo in te de la gran doglia nostra.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="I">Che poss' io far per voi?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Darci la vita</l>
             <l>Ne per noi soli ti cheggiamo aiuto</l>
             <l>Ma per tutto lo stuol nostro, che tutti</l>
             <l>(Se non ci aiuti tu siamo a la morte.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l>Fate ch' io sappia il mal s'havro rimedio</l>
             <l>Atto a curarlo io non ne saro scarso.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Novo non credo che ti sia, ch' ognuno</l>
             <l>Di noi arde d' amor di queste nimphe</l>
@@ -561,21 +619,21 @@
             <l>Che pensa ch' elle sian per fuggir noi</l>
             <l>Et darsi tutte a amare i dei celesti.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="I">E' vero <name>Egle</name> mia questo?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">il disser heri</l>
             <l>Mentre io le confortava a amar costoro.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l>Havete gran cagion di lamentarvi</l>
             <l>Se ver' è quel che da costui hor odo.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l><name>Silen</name> se cio avenisse ci dorrebbe</l>
             <l>Esser mai nati al mondo, pero aita</l>
@@ -583,13 +641,13 @@
             <l>Fummo per farti haver la tua cara <name>Egle</name></l>
             <l>Non n' esser hora tu di favor scarso.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l>Chidete pur ch' io non son cosi cosi ingrato</l>
             <l>Che venendo occasion ch' io vi dimostri</l>
             <l>L' animo mio voglia schivar di farlo.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>Vorremmo che sapessi tu da <name>Baccho</name></l>
             <l>(Che sappiamo che nulla egli ti cela)</l>
@@ -601,19 +659,19 @@
             <l>Me n' andro a <name>Baccho</name>, et per costei, tantosto</l>
             <l>Che' nteso il tutto havro, ven faro chiari</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">A dio <name>Sileno</name>.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="F">A dio compagni cari</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="I">Non ci mancar <name>Silen</name>.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="F">Non dubitate</l>
             <l>Ma io vi prego intanto a raccordarvi</l>
@@ -623,7 +681,7 @@
             <l>Bevi <name>Chromi</name> mio car, bevi <name>Mnasilo</name></l>
             <l>Et tu bevi <name>Egle</name>, e andiamo a trovar <name>Baccho</name></l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO DI SATIRI</speaker>
             <l>O Baccho, ò, ò, ò, ò figliuol di <name>Giove</name></l>
             <l>Et de l' amata sua semel <name>Thebana</name></l>
@@ -680,7 +738,7 @@
           <head>
             <hi rend="sc">SCENA I</hi>
           </head>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE NIMPHA</speaker>
             <l>Piu volte et piu m' ha detto il mio <name>Sileno</name></l>
             <l>Narrandomi i principi de le cose</l>
@@ -802,12 +860,12 @@
             <hi rend="sc">SCENA II</hi>
           </head>
           <stage>FAUNO, SATIRO, EGLE</stage>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>Pur che la nueva sia buona, il tardare</l>
             <l part="I">Non mi dorra.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">Sia pur buona: o rea</l>
             <l>Me ne cal poco, i' seguiro il consiglio</l>
@@ -818,17 +876,17 @@
             <l>Cosa che ti sia cara biasimato</l>
             <l>Non sarai unqua a porlati in sicuro.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>La troppa audacia torna spesso in danno.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Et il troppo temer fa perder spesso</l>
             <l>Quel c' haver si potrebbe, i' voglio audace</l>
             <l>Perder piu tosto che timido havere.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>Io mi ricordo anchor quel che m' avenne</l>
             <l>Quand' <name>Hercol</name> mi gitto fuori del letto.</l>
@@ -836,7 +894,7 @@
             <l>Per la grave percossa ch' alhor diedi.</l>
             <l>Pero so consigliar chi troppo ardisce.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Gia non si conveniva altra mercede</l>
             <l>A la tua gran folia, non fu l' ardire</l>
@@ -849,37 +907,37 @@
             <l>Tu vedrai ben che s' io entro in questa caccia</l>
             <l>Io non pigliero l'orso per la lepre.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Che parole son queste, aman la pace</l>
             <l part="I">Le selve, et non le liti.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="F">non è guerra</l>
             <l>Tra noi, sol aspettiam di saper quello</l>
             <l>C' habbia inteso <name>Silen</name> nostro da <name>Baccho</name>.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>
               <add>Egle</add>
             </speaker>
             <l part="I">Non vi e nulla di buono.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="F">tu m' hai morto.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Et a me animo hai dato a la mia impresa.</l>
             <l>Io ti so dir ch' io non staro piu a bada.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>Narraci che ci manda a dir <name>Sileno</name>.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Vi fa saper che i dei celesti sono</l>
             <l>Non men che voi di queste nimphe accesi</l>
@@ -887,27 +945,27 @@
             <l>A le cose mortai, voglion dal cielo</l>
             <l>Venirsi ne le selve a goder d' esse.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="I">Oime.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">io non vo gia per cio dolermi</l>
             <l>Prima di lor io me n' andrò a la caccia.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Et ch'essi per non esser conosciuti</l>
             <l>Sotto mentita forma a loro andranno.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Et io v' andro ne la medesma mia</l>
             <l>Prima che 'l sol s' asconda, stati <name>Fauno</name></l>
             <l part="I">Tu su rispetti tuoi.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="F"><name>Satir</name> sei sciocco</l>
             <l>Io ti dico che 'l senno, e' l buon consiglio</l>
@@ -916,7 +974,7 @@
             <l>In condurlo bisogna usar molt' arte</l>
             <l>Altrimenti ogni cosa andra in sinistro.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l><name>Fauno</name> non dice mal <name>Satir</name> sta chetto.</l>
             <l>È ascolta un po quel che vo dirti anch' io,</l>
@@ -925,12 +983,12 @@
             <l>Che se palese forza le volete</l>
             <l>Fare n' andra tutta la cosa in nulla.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Et perche non sian noi per farli forza</l>
             <l part="I">Tu te 'nganni <name>Egle</name>.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">i' non m' inganno, ascolta</l>
             <l>O che volete ritrovarle in caccia</l>
@@ -958,16 +1016,16 @@
             <l>Pensan voler godere hoggi di queste,</l>
             <l part="I">Che debbiam dunque far?</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="F">prudentemente</l>
             <l part="I">Condur la cosa.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="M">et come,</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="F">i' voglio ch' <name>Egle</name></l>
             <l><name>Egle</name> via piu d' ogn' altra nimpha accorta</l>
@@ -975,13 +1033,13 @@
             <l>Ella s' adoprera con queste nimphe)</l>
             <l>Et le disponga a non ci dar piu affanno.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Il faro volentier, perche vorrei</l>
             <l>Vederle giunte a tale, a qual son io</l>
             <l>Accio che et elle et voi fosti contenti</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>Che non si vuol venir mai a la forza,</l>
             <l>Fin che non s' è tentata ogn' altra via</l>
@@ -992,7 +1050,7 @@
             <l>Vo che con esso lei ella le 'nviti</l>
             <l>Ad una festa che 'ntendia<expan>n</expan> di fare.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Tu non ce le corrai,<name>Fauno</name></l>
             <l part="F">anzi verranle</l>
@@ -1010,7 +1068,7 @@
             <l>Uscirem del bosco, et farem quello</l>
             <l>A lor, ch' i Roman ferro a le Sabine.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Molto mi piace <name>Fauno</name> il tuo consiglio</l>
             <l>Io tosto che le vegga con bel modo</l>
@@ -1018,13 +1076,13 @@
             <l>Et quando cio non mi socceda ogn' arte</l>
             <l>Usero poi perche quest' altro segua.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l><name>Egle</name> te ne preghiamo cosi mai</l>
             <l>Non ti manchi da ber vino soave</l>
             <l>È l tuo <name>Silen</name> sovra ogni cosa t' ami</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Io non manchero in cosa che presuma</l>
             <l>Ch' a espedir questo fatto esser possa atta,</l>
@@ -1061,7 +1119,7 @@
             <hi rend="sc">SCENA III</hi>
           </head>
           <stage>EGLE SOLA</stage>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Aviene di costor quello ch' aviene</l>
             <l>Del mio <name>Silen</name>, quand' a le volte beve</l>
@@ -1099,45 +1157,45 @@
             <hi rend="sc">SCENA IIII</hi>
           </head>
           <stage>SATIRO, CHORO, FAUNO</stage>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Che state a far? Venite fuori homai.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l>Tu ci hai tutti adunati, et non ci hai detto</l>
             <l>Perche cagion tu n' hai condotti insieme</l>
             <l part="I">Che ci è da dire,</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">una bramata cosa,</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l>Non bramiamo altra cosa che potere</l>
             <l>Godersi de le nimphe che no amiamo.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Et d' altro io non vi ho a ragionare</l>
             <l>Et dimostrarvi il modo onde potremo</l>
             <l>Tutti a un tratto dar fine a i nostri affanni.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l>Ha, ha, ha, ha, ò <name>Baccho</name>, ò <name>Baccho</name>, ha, ha,</l>
             <l>Ò <name>Baccho</name>, òè, òegrave;, ò <name>Baccho</name>, 6ograve;è,</l>
             <l>Se cio ver' è, quai fien di noi piu lieti?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Siam risoluti che i celesti dei</l>
             <l>La ci vogliono fare ad ogni modo,</l>
             <l>Et per consiglio del canuto <name>Fauno</name></l>
             <l>Determinat' habbiam di farla a loro.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l>Et cosi far si deve, ò <name>Baccho</name> òegrave;,</l>
             <l>Ò <name>Baccho</name>, ha, ha, ò <name>Baccho</name> ivi, òegrave;</l>
@@ -1149,7 +1207,7 @@
             <l>Un napo pien di delicato vino.</l>
             <l>Ma narra il modo che tenir dobbiamo.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>Il modo intenderete piu a bell' agio,</l>
             <l>Hor fa mestier che noi cantiamo insieme,</l>
@@ -1160,11 +1218,11 @@
             <l>Per fuggir la cagion del nostro male</l>
             <l>Et non dar noia a lor ch' amiamo tanto.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Comincia tu che seguiremo tutti</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>Ponianci insieme a l' ombra di quel faggio</l>
             <l>Et diam principio al lagrimevol canto,</l>
@@ -1174,7 +1232,7 @@
             <l>Et col suon de le fistole quel tempo</l>
             <l>Ratti empirete che rimarria vuoto.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO</speaker>
             <l>Non arse tanto mai stoppia per fiamma</l>
             <l>C'habbia bifolco in lei talhor accesa</l>
@@ -1246,17 +1304,17 @@
             <hi rend="sc">SCENA I</hi>
           </head>
           <stage>OREADI, DRIADI, NAPPEE, EGLE, NAIADI</stage>
-          <sp>
+          <sp who="#oreadi">
             <speaker>Oreadi</speaker>
             <l>Gia apparecchiata s' è di gire al bosco</l>
             <l><name>Diana</name> per cacciar, co l'altre nimphe</l>
             <l>Andiamo anchora noi a ritrovarla.</l>
           </sp>
-          <sp>
+          <sp who="#driadi">
             <speaker>Driadi</speaker>
             <l part="I">Andiam.</l>
           </sp>
-          <sp>
+          <sp who="#nappee">
             <speaker>Nappee</speaker>
             <l part="F">andiamo a l' honoranda nostra</l>
             <l>Dea figlia di <name>Latona</name>, et del gran <name>Giove</name>,</l>
@@ -1264,13 +1322,13 @@
             <l>Di vera castitade, et lume chiaro</l>
             <l>Del ciel, quand' il sol toglie a noi la luce</l>
           </sp>
-          <sp>
+          <sp who="#driadi">
             <speaker>Driadi</speaker>
             <l>Andiamo a la triforme nostra Dea</l>
             <l>Non men chiara nel ciel ch' ella sia in terra</l>
             <l part="I">O nel regno di <name>Dite</name>.</l>
           </sp>
-          <sp>
+          <sp who="#oreadi">
             <speaker>Oreadi</speaker>
             <l part="F">Honora <name>Pale</name></l>
             <l>Ogni Pastore, et <name>Cerere</name> i Bifolchi,</l>
@@ -1279,14 +1337,14 @@
             <l>Apprezzan castita piu che la vita</l>
             <l>Devemo amar con tutto il cor <name>Diana</name> </l>
           </sp>
-          <sp>
+          <sp who="#driadi">
             <speaker>Driadi</speaker>
             <l>Et come face sacrificio a <name>Marte</name></l>
             <l>Chi segue la bataglia, et a <name>Nettuno</name></l>
             <l>Chiunque il tempestoso Oceano varca,</l>
             <l>Cosi a <name>Diana</name> noi devem dar voti</l>
           </sp>
-          <sp>
+          <sp who="#nappee">
             <speaker>Nappee</speaker>
             <l>Dunque Dea de le selve, et dea de boschi</l>
             <l>In segno de la pura honesta nostra</l>
@@ -1305,7 +1363,7 @@
             <l>La faccia, et come spira tutta fuoco,</l>
             <l>So che si vede ch' ella serve a <name>Baccho</name>.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Gelata non son gia, come voi sete,</l>
             <l>Ne pallida mi face il ber de l' acque</l>
@@ -1318,7 +1376,7 @@
             <l>E de la vita humana, et senza lui</l>
             <l>Nulla di lieto al mondo esser mai puote</l>
           </sp>
-          <sp>
+          <sp who="#nappee">
             <speaker>Nappee</speaker>
             <l>Ubriaca che sei, credi di darci</l>
             <l>A veder che l' errore in che tu sei</l>
@@ -1348,7 +1406,7 @@
             <l>Qual' hora habbian tai cose inanzi a gli occhi</l>
             <l>Di darci a ber si velenoso succo.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Io non m' estenderò molto in parole,</l>
             <l>Ma ben dirò, che tu non sai che cosa,</l>
@@ -1385,18 +1443,18 @@
             <l>L'altrui virginitade, i' ti rispondo</l>
             <l>Che non si dee virginita apprezzare.</l>
           </sp>
-          <sp>
+          <sp who="#naiadi">
             <speaker>Naiadi</speaker>
             <l part="I">Or va malvaggia va</l>
           </sp>
-          <sp>
+          <sp who="#oreadi">
             <speaker>Oreadi</speaker>
             <l part="F">Vanne impudica</l>
             <l>Va nemica d'honore, oimè che voce</l>
             <l>Di questa bocca scelerata è uscita,</l>
             <l>Va, va al tuo <name>Bacco</name>, et noi lascia a <name>Diana</name></l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>O poverelle che voi sete, sciocche</l>
             <l>Vi rimarrete, et io saro la saggia.</l>
@@ -1404,7 +1462,7 @@
             <l>Che differentia sia tra l'uno, et l'altro</l>
             <l>Modo di vita,</l>
           </sp>
-          <sp>
+          <sp who="#naiadi">
             <speaker>Naiadi</speaker>
             <l>la lascivia tua</l>
             <l>Ti fa parer virtu quello ch' è vitio,</l>
@@ -1415,7 +1473,7 @@
             <l>Et certe siam, ch'avanza ogni thesoro</l>
             <l>Questa virginita che custodimo.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Et io vi dico ch' è di nessun pregio</l>
             <l>Questa virginita che si lodate.</l>
@@ -1437,7 +1495,7 @@
             <l>Ond' ne deve esser dannata a morte</l>
             <l>Com' uccisi ella havesse color tutti</l>
           </sp>
-          <sp>
+          <sp who="#oreadi">
             <speaker>Oreadi</speaker>
             <l>Sono proprio da te queste parole</l>
             <l>Che chi avezzo è di star sempre nel fango</l>
@@ -1445,7 +1503,7 @@
             <l>Pero sta tu col tuo parer con <name>Baccho</name></l>
             <l>Noi con <name>Diana</name> rimarem col nostro.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Et che credete voi che se ne stia</l>
             <l><name>Diana</name> cosi casta che non voglia</l>
@@ -1461,7 +1519,7 @@
             <l>Si trastula con lei, et voi vi state</l>
             <l>Senza piacer alcun sempre digiune.</l>
           </sp>
-          <sp>
+          <sp who="#nappee">
             <speaker>Nappee</speaker>
             <l>Noi gia digiune di piacer non siamo</l>
             <l>Anzi il maggior piacer proviam del mondo,</l>
@@ -1469,7 +1527,7 @@
             <l>Ne creder ti vogliam cio che n' hai detto</l>
             <l part="I">De la nostra <name>Diana</name></l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">di <name>Diana</name></l>
             <l>Credete voi cio che vi piace, detto</l>
@@ -1490,13 +1548,13 @@
             <l>Da lo stelo da se fracido cade.</l>
             <l part="I">Non so se me 'ntendente.</l>
           </sp>
-          <sp>
+          <sp who="#driadi">
             <speaker>Driadi</speaker>
             <l part="F">or va tra Fauni</l>
             <l>A la tua vita compagnia conforme</l>
             <l>Et lascia andar noi a <name>Diana</name> al bosco.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Ben fora meglio che veniste a i Fauni</l>
             <l>A Satiri a i Silvan (poi che di lor</l>
@@ -1509,12 +1567,12 @@
             <l>Et potrian trar dal vostro fiore il frutto</l>
             <l>Del qual voi sete debitrici al mondo.</l>
           </sp>
-          <sp>
+          <sp who="#driadi">
             <speaker>Driadi</speaker>
             <l>Che noi amiam quelle bestiacce sozze</l>
             <l>De quai cosa non ha il mondo piu brutta?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Anzi hanno tutto il bello in se raccolto</l>
             <l>Ne parte e'n lor dal capo insino a piedi</l>
@@ -1539,7 +1597,7 @@
             <l>Pero gran torto havete a non far stima</l>
             <l>Del singolar amor di questi Dei.</l>
           </sp>
-          <sp>
+          <sp who="#nappee">
             <speaker>Nappee</speaker>
             <l>Poi che da Dei tu vuoi l'essempio torre</l>
             <l>Di quanto hanno di sozzo in se costoro</l>
@@ -1547,7 +1605,7 @@
             <l>Lasciare i <name>Fauni</name> e amar i Dei del cielo</l>
             <l>Che si mostran di noi cosi bramosi,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Udito ho sempre dir, che quell' amore</l>
             <l>Che tra dissimil nasce, e amore infido,</l>
@@ -1596,13 +1654,13 @@
             <l>Tante fatiche, et tante aspre sosten<expan>n</expan>e</l>
             <l>Et vedrete qual sia il costoro amore.</l>
           </sp>
-          <sp>
+          <sp who="#oreadi">
             <speaker>Oreadi</speaker>
             <l>Or non ci dar piu noia esser puo prima</l>
             <l>Ogni impossibil cosa che nessuna</l>
             <l>Di noi per possa amore a questi mostri.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>I' vi so dir che non andrete molto</l>
             <l>Che noia piu non vi daran pe boschi</l>
@@ -1623,7 +1681,7 @@
             <l>Per non veder restar senza e suoi Dei</l>
             <l>Le selve gia felici de l'<name>Arcadia</name>.</l>
           </sp>
-          <sp>
+          <sp who="#driadi">
             <speaker>Driadi</speaker>
             <l>Vadano pur che non ne cal di loro,</l>
             <l>Come se non gli havessero unqua visti.</l>
@@ -1654,7 +1712,7 @@
             <l>Et perche poscia che voi lor sdegnate</l>
             <l>Essi sdegnano cio che non è voi.</l>
           </sp>
-          <sp>
+          <sp who="#naiadi">
             <speaker>Naiadi</speaker>
             <l>A questi Satirini et picciol Fauni</l>
             <l>Non mancherem d'esser cortesi sempre</l>
@@ -1670,11 +1728,11 @@
             <l>Et so che scemaro la doglia loro</l>
             <l>Quand' io gli narrero nova si bona.</l>
           </sp>
-          <sp>
+          <sp who="#nappee">
             <speaker>Nappee</speaker>
             <l part="I">Or con Dio rimani <name>Egle</name></l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">andate in pace.</l>
             <l>Uno fermo proposito che 'n donna</l>
@@ -1687,7 +1745,7 @@
           <head>
             <hi rend="sc">SCENA II</hi>
           </head>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE SOLA</speaker>
             <l>Non è da apperecchiare a alcuno insidie</l>
             <l>Se non quand' ei si pensa esser sicuro.</l>
@@ -1733,7 +1791,7 @@
             <hi rend="sc">SCENA III</hi>
           </head>
           <stage>SATIRO, EGLE, FAUNO</stage>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>O che sia il troppo desiderio mio.</l>
             <l>D' haver la cosa amata, o pur ch' Amore</l>
@@ -1746,12 +1804,12 @@
             <l>Mi vengon tuttavia segni maggiori</l>
             <l>Che l'accrescono piu che'l fan piu fermo.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Che non puo far Amor con la sua fiamma</l>
             <l>Poi che dice costui cose si gravi?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>A l'uscir fuor de la spelonca usata</l>
             <l>Vedute ho sovra un Pin <num value="2">due</num> tortorelle</l>
@@ -1768,12 +1826,12 @@
             <l>Che d'una quercia ombrosa a l'improviso</l>
             <l>Mi fece tristo augurio ne la selva.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Che pazzia è questa che gli augelli il mo<expan>n</expan>do</l>
             <l>Tema se la natia lor voce fanno?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Poco dopo, mi vene incontro un Toro</l>
             <l>Squalido, et magro con dolente aspetto</l>
@@ -1788,12 +1846,12 @@
             <l>Poi se quindi rivolgo il pensier mio</l>
             <l>A l'astuto veder de la nostr' <name>Egle</name>.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Lodato <name>Baccho</name> ch'anch' io merto loda</l>
             <l>Et son di qualche pregio in queste selve.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>E a la simplicita di queste nimphe</l>
             <l>In cosi gran timore ho qualche spene.</l>
@@ -1802,13 +1860,13 @@
             <l>Non verran meno a noi, che per gli boschi</l>
             <l>Honoriamo ambo lor con tutto il core.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Non voglio piu tardar, di che ti dogli?</l>
             <l>Qual passion t'afflige si aspramente</l>
             <l>Hor che siam per accor l'augelle al visco?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Mi tengono tra <num value="2">due</num> speme et timore</l>
             <l>Et se vince un de <num value="2">due</num> vince la tema.</l>
@@ -1818,7 +1876,7 @@
             <l>Tu assicurare ogni temenza mia,</l>
             <l>Se buona nuova da le nimphe porti.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>La nuova è <name>Satir</name> mio, che dopo ch'io</l>
             <l>Non le potei disporre ad amar voi</l>
@@ -1827,35 +1885,35 @@
             <l>Vinti, ne volevate andar lontani.</l>
             <l>E' i boschi abandonar per lor d'<name>Arcadia</name>.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Non hai fatto piu oltre?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">et che piu oltre</l>
             <l>Volevi ch' io facessi? non ti pare</l>
             <l part="I">Ch'assai fatt' habbia?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">dunque tu non l' hai</l>
             <l part="I">Invitate a la festa?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="M">no</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">et per quale</l>
             <l part="I">Cagion?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="M">perché parso non m' è,</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">che giova</l>
             <l>Ubriaca a noi che credano che gire</l>
@@ -1863,76 +1921,76 @@
             <l>Ne termini di prima, mi vien voglia</l>
             <l>Cacciarti questo corno entro la pancia.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="I">Deh sta lontano bestia,</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">i' stia lontano</l>
             <l>Io non so che mi tenga che col <name>Thirso</name></l>
             <l part="I">Non ti spezzi la testa.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">che non mi fare</l>
             <l>Venire in ira ch' io faro vederti</l>
             <l>Che tanto il <name>Thirso</name> mio quanto il tuo vale.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Or cogli questa,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">tu sarai il primo.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Oime</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">cogli quest' altra, hor fatti in dietro</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">A dietro? ti vo uccider.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">stammi largo</l>
             <l part="I">Ch'io ti caccierogli occhi.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">le cervella</l>
             <l part="I">Sparger ti vo per terra.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="F">che rumore</l>
             <l>E questo ch' è tra voi, <name>Satir</name> sta indietro</l>
             <l part="I">Rattieni <name>Egle</name> il tuo <name>Thirso</name></l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">i faro bene</l>
             <l>Sozza bestiaccia che sarai modesto</l>
             <l part="I">Et deporai l'audacia,</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="F">che sciocchezze</l>
             <l part="I">Sono coteste.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">è che questo animale</l>
             <l>Vien meco in ira, perch'io ho procacciato</l>
             <l part="I">C'habbiate il voler vostro.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">il voler nostro</l>
             <l>Ella non ha invitate hoggi a la festa</l>
@@ -1941,79 +1999,79 @@
             <l>Anco tener ch'io non ti venga a dosso</l>
             <l part="I">Et non ti fiacchi tutta,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">i' non ti temo</l>
             <l part="I">Ne <num value="10">dieci</num> altri par tuoi,</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">ai lingua audace</l>
             <l part="I"><name>Satir</name> sta indietro,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">lascialo venire</l>
             <l>Che mostrar vo che non ho men le mani</l>
             <l part="I">Pronte che le parole,</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="F">a quel ch' importa</l>
             <l part="I">A ce rimasa sei.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">che voi habbiate</l>
             <l part="I">Cio che volete,</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="F">or <name>Satiro</name> che dici?</l>
             <l>Se lasciate ha invitarle, vedi come</l>
             <l part="I">Esser cio possa.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">intendi pria la cosa,</l>
             <l>Et ti lamenta poi se parra forse</l>
             <l>Che 'l debito per voi non habbia fatto.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Non ti sarei parlar se non col <name>Thirso</name></l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Tu pur provato hai se col <name>Thirso</name> anch'io</l>
             <l part="I">Risponder ti ho saputo,</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="F">or ne la selva</l>
             <l>Vatti, et me lascia ad ascoltare il resto,</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Io vo vendetta far verso di lei</l>
             <l part="I">Pria ch'io mi parta.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="F">Va che se no<expan>n</expan> vai</l>
             <l part="I">Mi farai cosa far,</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">quello ch'adesso</l>
             <l>Non faccio, faro ben sta pur sicura</l>
             <l>Che restar la non deve a questo modo,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="I">Stati con quelle,</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="F">or lascia ch'ei si vada</l>
             <l>Et fa c' homai il mio gioire intenda.</l>
@@ -2024,7 +2082,7 @@
             <hi rend="sc">SCENA IIII</hi>
           </head>
           <stage>EGLE, FAUNO</stage>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Io mi veniva piena d'allegrezza</l>
             <l>Per darvi buona nuova et questa bestia</l>
@@ -2034,11 +2092,11 @@
             <l>Et chi non lo sa usar condur non puote</l>
             <l part="I">Una cosa a buon fin.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="F">non è altrimenti,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Spesso chi impone una imbasciata pensa</l>
             <l>Bene secondo se la cosa, et poi</l>
@@ -2049,12 +2107,12 @@
             <l>Et felici ben son chi imbasciatori</l>
             <l>Han che sappian veder qual' è il lor meglio,</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>Pochi sen trovan tali, a dirti il vero,</l>
             <l part="I">Or c'hai tu fatto.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">ho mostro a queste nimphe</l>
             <l>Che voi per non noiarle et per fuggire</l>
@@ -2067,46 +2125,46 @@
             <l>Anchor partiti, e i satirini vostri</l>
             <l part="I">Pensasser di far festa.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="F">ben pensasti</l>
             <l>Che cio potiva lor dar chiaro inditio</l>
             <l part="I">Di qualche inganno.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">adunque ov'io devea</l>
             <l>Lo 'nvito farle io cercai di disporle</l>
             <l>C'havessero pieta de picciol vostri</l>
             <l part="I">Satiri, et Fauni,</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="F">et a qual fine questo?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Il saperai s'ascolti, esse credendo</l>
             <l>Che voi ne foste giti ad una voce</l>
             <l>Dissero di voler per figli accorli.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>Non veggo anchor che cio nulla ne giovi,</l>
             <l part="I">O ne dia speme alcuna.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">se sei cieco</l>
             <l part="I">Che voi ch'io te ne faccia,</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l part="F">aprimi gli occhi</l>
             <l>Tanto ch'io veggia quel che 'nsin ad hora</l>
             <l part="I">Veder non ho saputo.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">ite a la caccia</l>
             <l>Si sono insieme, et io nel ritornare</l>
@@ -2115,14 +2173,14 @@
             <l>Pregarle vo che gli accolgan per figli,</l>
             <l>Come t'ho detto che promesso m' hanno.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>Non so veder che quindi avenir altro</l>
             <l>Possa, se non che noi da queste nimphe</l>
             <l>Cacciati siamo, e 'nvece nostra i figli</l>
             <l>Ch' a cio non pensar sian da loro accolti.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Lasciami se tu vuoi giungere al fine</l>
             <l>Ne ti doler pria che cagion tu n' habbi</l>
@@ -2131,7 +2189,7 @@
             <l>Et dirli che trovandosi con loro</l>
             <l>Men grave gli sara mancar de padri</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>Fauno</speaker>
             <l>Incomincio a veder cio che vuoi fare</l>
             <l>Et cosi sono d'allegrezza pieno</l>
@@ -2154,12 +2212,12 @@
             <l>Tu ci hai data la preda ne le mani,</l>
             <l>Entrian nel bosco a dar la nuona a tutti,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Entriam, ma vi bisogna star ascosi</l>
             <l>Si che non date lor di cio sospetto.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO</speaker>
             <l>Com' avaro bifolco poi che 'n terra</l>
             <l>Il gran con piena mano</l>
@@ -2228,7 +2286,7 @@
             <hi rend="sc">SCENA I</hi>
           </head>
           <stage>PANE SOLO</stage>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Che giova a me l' esser d'<name>Arcadia</name> dio</l>
             <l>Et l' haver sotto me tutti i pastori,</l>
@@ -2332,7 +2390,7 @@
             <hi rend="sc">SCENA II</hi>
           </head>
           <stage>SIRINGA, PANE</stage>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l>Io mi maravigliava haver vist'hoggi</l>
             <l>Le selve si quiete et si sicure</l>
@@ -2359,12 +2417,12 @@
             <l>Altro paese, et men fiera ventura</l>
             <l>E 'l camin pres' havean verso la <name>Spagna</name>.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Che cosa od'io, non ho gia odito dire</l>
             <l>Hoggi di tal partenza ad alcun <name>Fauno</name></l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l><name>Diana</name> si mostro di cio assai lieta</l>
             <l>Come colei che ben sapea ch'un lungo</l>
@@ -2376,24 +2434,24 @@
             <l>Andato anchora <name>Pan</name> che tanto tempo</l>
             <l part="I">Mi ha dato noia.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">intendi s' hai orecchi</l>
             <l>A che termine sei de l' amor tuo</l>
             <l part="I">O misero, ò nfelice.</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l part="F">non perch'io</l>
             <l>Fossi mai per amarlo, ò per mutarmi</l>
             <l>Dal mio primo pensier fisso in diamante,</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Ai miser me dov' ho io posto speme?</l>
             <l>Perche mi consum'io? perche mi struggo?</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l>Non è si forte torre ò si munita</l>
             <l>Che piu tosto non brami haver lontani</l>
@@ -2413,7 +2471,7 @@
             <l>Et cosi minaciando di ferirlo</l>
             <l>Il faro (mal suo grado) lontan starmi.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Ai <name>Siringa</name> crudel, <name>Siringa</name> ingrata</l>
             <l>Che bisogna fuggire? ò che temere?</l>
@@ -2427,7 +2485,7 @@
             <l>Deh muta homai <name>Siringa</name> mia pensiero</l>
             <l>Et non m' esser cagion di tanto affano,</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l>Io lo ti ho detto <name>Pane</name>, et tel ridico</l>
             <l>che vò osservar la mia honestade intatta,</l>
@@ -2470,12 +2528,12 @@
           <l>Io gli ti serbo et son gia si lascivi</l>
           <l>Che se tu gli vedessi scherzar meco</l>
           <l>Per haverli verresti assai piu pia.</l>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l>Non se fossero tutti oro, et diamanti</l>
             <l>Tienliti pur ch'io non mi curo haverli.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Ai poco saggia nimpha anchor che sij</l>
             <l>Piu bianca che i ligustri, et piu vermiglia</l>
@@ -2504,11 +2562,11 @@
             <l>Et un che quello ha'n se che non ha <name>Giove</name>,</l>
             <l>Quantunque egli dal ciel fulmini, et tuoni.</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l>Ve che sozzo animal si vuol far bello,</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Oltre di cio ti pon far chiara fede</l>
             <l>Glia arbori, et l'herbe, e i fior di queste selve,</l>
@@ -2522,13 +2580,13 @@
             <l>Che contender potrei col biondo <name>Appollo</name></l>
             <l>Con piu felice fin che non fe <name>Marsia</name>.</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l>Io mi allegro con te di virtu tale,</l>
             <l>Ma percio non farai mutarmi voglia,</l>
             <l>Pero non spender piu parole indarno.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l><name>Siringa</name> se non vuoi di me far stima</l>
             <l>Io vorrei che di te cura tenessi</l>
@@ -2544,12 +2602,12 @@
             <l><num value="1000">Mille</num> nimphe mi chieggion per amante,</l>
             <l>Et <num value="1000">mille</num> son da me per te sprezzate.</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l>Pero i non voglio far ingiuria a l'altre</l>
             <l>Ama chi t'ama, et non mi dar piu noia.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Deh, s'altro non mi vuoi <name>Siringa</name> dare</l>
             <l>Per refrigerio almen del mio gran fuoco,</l>
@@ -2561,26 +2619,26 @@
             <l>Assai fuggito m'hai lascia ch'un giorno</l>
             <l>Con un bascio ristori i danni miei.</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l>Un bascio? donna che cortese sia</l>
             <l>D'un bascio ad altri puo donarli il tutto</l>
             <l>Ch'appresso me piu mai non sara casta.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Tu te 'nganni, <name>Siringa</name>, un bascio è poco</l>
             <l>Anzi, per meglio dir, è come nulla</l>
             <l>Deh non lo mi negar vita mia cara.</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l>Non mi t' accostar, <name>Pan</name>, che se quest'arco,</l>
             <l>Non mi vien men ne men queste saette</l>
             <l>Io mi ti faro andar tanto da lunge</l>
             <l>Che non havrai piu ardir venirmi appresso.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Ai che vuoi far, <name>Siringa</name>, t'hai pur troppo</l>
             <l>Tinte del sangue mio, crudel, le mani,</l>
@@ -2593,12 +2651,12 @@
             <l>A un fido amante a una pietosa donna</l>
             <l>In pieta muterai la crudeltade.</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l>Non mi ha voluto far la gratia il cielo</l>
             <l>Che co silvestri dei tu ti sij gito.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l><name>Siringa</name> me n'andro pria che sia sera</l>
             <l>Ne qui tenute m'han le greggie mie</l>
@@ -2610,7 +2668,7 @@
             <l>Pero in questo partir dammi la mano</l>
             <l>Cara <name>Siringa</name> mia ch'io la ti tocchi.</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l>Stammi lontan. Io ti ho pur ancho detto</l>
             <l>Se 'n te non vuoi che la pharetra i scarchi</l>
@@ -2619,7 +2677,7 @@
             <l>Ponti in camin con i compagni tuoi</l>
             <l>Et non mi venir piu dinanzi a gli occhi.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Benche da te partendo io abandoni</l>
             <l>Ogni ben, pur perche mi par minore</l>
@@ -2633,51 +2691,51 @@
             <l>Che tenghi certo che quanto amar puote</l>
             <l>Un Dio nimpha gentil tanto io t'ho amato.</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l>Or non piu, <name>Pan</name>, <name>Diana</name> è qui vicina</l>
             <l>Ch'io sento il suon de corni, et veggio i cani,</l>
             <l part="I">Me ne voglio ir,</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">deh ferma nimpha il passo</l>
             <l part="I">Non mi ti torre anchor,</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l part="F">lasciami <name>Pane</name></l>
             <l>Se non ti vuoi pentir d'havermi vista,</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Deh lascia ch'io ti tocchi almen la mano,</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l>Lasciami dico ch' io non son piu sola,</l>
             <l>Che veggio la mia dea, veggio le nimphe</l>
             <l>Et guai a te se tu mi fai chiamarle.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Non mi esser si crudel nimpha gentile</l>
             <l>Habbi pieta del mio angoscioso affanno,</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l part="I">Tu mi farai gridar,</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">grida a tua voglia,</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l><name>Diana</name> aiuto che mi vuol far forza</l>
             <l part="I">Questo villan di <name>Pane</name>,</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">ecco io ti lascio</l>
             <l><name>Siringa</name> ingrat, ma tu via mi porti</l>
@@ -2689,7 +2747,7 @@
             <hi rend="sc">SCENA III</hi>
           </head>
           <stage>PANE, SILVANO</stage>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Maledetta <name>Diana</name>, et le sue nimphe</l>
             <l>I can, gli strali, gli archi, et le pharetre.</l>
@@ -2737,24 +2795,24 @@
             <l>Od' un faggio od' un'olmo la cagione</l>
             <l>Del tuo dolore a far vendetta giusta.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Gravi querelle son queste ch'io odo</l>
             <l>Et mi paion di <name>Pan</name> nostro gran dio.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Ma c'ha voluto dir la mia <name>Siringa</name></l>
             <l>Quando m'ha detto che lontani vanno</l>
             <l>I Satiri e i Silvan da queste selve.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l><name>Pane</name> che ci è che ti lamenti tanto</l>
             <l>Et sei si maninconico nel giorno</l>
             <l>Che sono tutti i dei silvestri in gioia.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Scacci il duolo chi vuole et si rallegri</l>
             <l>Gioia per me non è tra queste selve</l>
@@ -2762,13 +2820,13 @@
             <l>Poi che chi solo mi potria far lieto</l>
             <l>Quanto piu mesto son tanto piu gode.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Et qual' è la cagion del tuo dolore?</l>
             <l>Non ti gravi di dirlami che forse</l>
             <l>Potrei al tuo languir porger rimedio.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l><name>Silvano</name> tu non sai quello ch' è noto</l>
             <l>A le piante, a le fiere, a i sassi a l'herbe,</l>
@@ -2780,7 +2838,7 @@
             <l>Ne per cosa ch'io faccia io posso havere</l>
             <l>Speme da lei di ritrovar mai pace.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Pane tant' è felice, et miser altri</l>
             <l>Quant' egli se tristo, et felice tiene,</l>
@@ -2795,7 +2853,7 @@
             <l>Il so ma come che costei si mute</l>
             <l>Allegrezza per me non n'esce mai.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Ma dimmi non è ella quella nimpha</l>
             <l>Nata in <name>Nonacria</name>? che è tanto a <name>Diana</name></l>
@@ -2803,16 +2861,16 @@
             <l>Tra lor l'habito, et l'arco, si potrebbe</l>
             <l>Creder che fosse ella <name>Diana</name> istessa.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="I">Ell' è quella <name>Silvan</name>.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l part="F">l' ho vista hor hor</l>
             <l part="I">Gir con <name>Diana</name>,</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">Oime ch' ella m' ha tolto</l>
             <l>Nel suo partir il core, et son rimaso</l>
@@ -2821,14 +2879,14 @@
             <l>Et tant' è il dolor mio ch'io non vorrei</l>
             <l part="I">Esser piu vivo,</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l part="F">ben t' istimo sciocco</l>
             <l>Poi che brami, morir per una nimpha,</l>
             <l>De quali n' è tal copia che se n'have</l>
             <l>Per ogni stran per ogni incolto bosco.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Pari a lei non se n' ha <name>Silvano</name> mio</l>
             <l>Perch' è costei tra tutte l'altre nimphe</l>
@@ -2839,7 +2897,7 @@
             <l>Una cosa che m'ha parlando detto</l>
             <l part="I">Et non l'ho intesa.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l part="F">et quale è questa cosa,</l>
             <l>Ch'essendo gli altri Satiri partiti</l>
@@ -2847,15 +2905,15 @@
             <l>Con loro anch' io, et pur di tal partenza</l>
             <l part="I">Non sapea ne so nulla,</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l part="F">et c' hai risposto?</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="I">Ch' anch'io mi volea gire,</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l part="F">ve come il caso</l>
             <l>Produce il tutto, non potevi meglio</l>
@@ -2864,46 +2922,46 @@
             <l>Io mi maravigliava di vederti</l>
             <l part="I">Cosi maninconioso,</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">Ora ch' è questo</l>
             <l part="I">Caro <name>Silvan</name>,</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l part="F">la tua allegrezza certa,</l>
             <l>Il tuo certo gioir, quel che ti puote</l>
             <l>Si lieto far,che piu non sarai mesto.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Ai caro il mio <name>Silvan</name> non mi dir folle</l>
             <l>Non cercare ammolire il mio dolore</l>
             <l>Con medicina falsa, perche poi</l>
             <l>Egli ritorneria piu che mai grande.</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l>Io vo che questa sera di <name>Siringa</name></l>
             <l part="I">Tu goda,</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="M">questa sera,</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l part="F">questa sera</l>
             <l>Com' i Satir godranno, e i fauni tutti</l>
             <l part="I">De le lor nimphe,</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">Or che potria piu affanni</l>
             <l>Darmi, ò dolor, se quest'aveniss'hoggi,</l>
             <l>Dimi il ver <name>Silvan</name>,</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>cosi vedere</l>
             <l>Potess' io questa pianta ritornare</l>
@@ -2914,12 +2972,12 @@
             <l>I Satiri e i Silvan che per godere</l>
             <l part="I">Le nimphe lor.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">ma ch' è mestier ch'io faccia</l>
             <l>Perche mi goda di <name>Siringa</name> anch' io</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Poi che l' hai detto di voler partirti</l>
             <l>Non dubitar di non haverla in braccio</l>
@@ -2932,7 +2990,7 @@
             <l>Onde vedrai c'hoggi esser puoi felice</l>
             <l>Poi che <name>Siringa</name> puo felice farti,</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Entriamo, et se cio è ver, non saro mai</l>
             <l>Satio di ringratiarti, i' vo <name>Silvano</name></l>
@@ -2947,12 +3005,12 @@
             <hi rend="sc">SCENA IIII</hi>
           </head>
           <stage>AMADRIADI, ALTRE NIMPHE, EGLE, SATIRI PICCIOLI, SIRINGA</stage>
-          <sp>
+          <sp who="#amadriadi">
             <speaker>Amadriadi</speaker>
             <l>Molti mesi ha che piu felice caccia</l>
             <l>Noi fatto non habbian di questa d' hoggi,</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l>Ell' è stata felice, ma di molto</l>
             <l>Pericol, se' l cengial che que <num value="2">due</num> cani</l>
@@ -2961,7 +3019,7 @@
             <l>Ci colgea con un dente vedevamo</l>
             <l>Che pericoli in se tengano i boschi.</l>
           </sp>
-          <sp>
+          <sp who="#amadriadi">
             <speaker>Amadriadi</speaker>
             <l>Ben dimostro <name>Diana</name>, che suoi colpi</l>
             <l>Venian da man divina quando l'arco</l>
@@ -2972,7 +3030,7 @@
             <l>Trafisse il suo, ma d'un cosi possente</l>
             <l>Che subito ei resto di vita privo,</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l>Ma non fu bel veder gli aggiramenti</l>
             <l>Di quella insidiosa astuta volpe</l>
@@ -2980,7 +3038,7 @@
             <l>Ch'alhora ch'essi si credean d' haverla</l>
             <l>Secura si torno ne la sua macchia?</l>
           </sp>
-          <sp>
+          <sp who="#amadriadi">
             <speaker>Amadriadi</speaker>
             <l>Et che piacer tra gli altri ci die quello</l>
             <l>Timido cervo, che per la campagna</l>
@@ -2990,37 +3048,37 @@
             <l>Ove l'havean ridotti i cani, et ove</l>
             <l>Trafisso fu da le saette nostre,</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l>Ma vedeste cio mai tra queste selve</l>
             <l>Tanta copia di lepri, et di conigli</l>
             <l>Quant' hoggi da le macchie uscir vedemo?</l>
           </sp>
-          <sp>
+          <sp who="#amadriadi">
             <speaker>Amadriadi</speaker>
             <l>Et ventura tra l'altre fu la mia</l>
             <l>Che quella lepre giovanella alhora</l>
             <l>Che quasi i can l'havean entro la bocca</l>
             <l>Si venisse a celare entro al mio grembo.</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l>Se fosse a me questo avenuto havrei</l>
             <l>D'ogni animal piu quella lepre cara.</l>
           </sp>
-          <sp>
+          <sp who="#amadriadi">
             <speaker>Amadriadi</speaker>
             <l>Tien certo pur ch' io non l' ho cara meno</l>
             <l>Che merti il caso ch'io la debba havere,</l>
             <l>La voglio far venir cosi vezzosa</l>
             <l>Che vo che tutte me n' habbiate invidia,</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l>Anzi non te n'havremo invidia alcuna</l>
             <l>Havremo ben piacer del tuo diletto</l>
           </sp>
-          <sp>
+          <sp who="#amadriadi">
             <speaker>Amadriadi</speaker>
             <l>Io scherzava con voi, che ben so chiaro</l>
             <l>Che la simplicitade, in cui vivemo</l>
@@ -3034,7 +3092,7 @@
             <l>Si che l'istessa man ch' a lei die morte,</l>
             <l>Fosse a figli cagion del nascimento,</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l>Cio fu bello a veder, ma via piu bello</l>
             <l>Che mentre questa nimpha colgia il parto</l>
@@ -3048,11 +3106,11 @@
             <l>Che sen viene ver noi fuor de la selva,</l>
             <l part="I">Vo che qui l'aspettiam.</l>
           </sp>
-          <sp>
+          <sp who="#amadriadi">
             <speaker>Amadriadi</speaker>
             <l part="F">come ti piace</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Figliuoli miei non per ambasciatori</l>
             <l>De vostri padri andate a queste nimphe,</l>
@@ -3070,24 +3128,24 @@
             <l>Et poi ch'accolti vi haveranno, il resto</l>
             <l>Com'ordinato habbiam, farete a pieno.</l>
           </sp>
-          <sp>
+          <sp who="#satiri_piccioli">
             <speaker>Satiri piccioli</speaker>
             <l>Et noi si sforzeremo in questa nostra</l>
             <l>Tenera eta non si mostrar fanciulli</l>
             <l>Per ottener quel ch'ottener bramemo,</l>
             <l>Non ne venga pur men di favor <name>Bacco</name></l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Cosi bisogna che facciate, andiamo,</l>
             <l>Et mostratevi tutti in viso mesti.</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l>Ti sij la ben venuta, <name>Egle</name>, che buona</l>
             <l>Nuova ci apporta la venuta tua?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Nova buona non han piu queste selve,</l>
             <l>Poi ch' i Silvestri dei se ne son giti</l>
@@ -3106,7 +3164,7 @@
             <l>Fatevi inanzi poveri fanciulli</l>
             <l>Et datevi a la fe di queste nimphe,</l>
           </sp>
-          <sp>
+          <sp who="#satiri_piccoli">
             <speaker>Satiri piccoli</speaker>
             <l>Nimphe cortesi, anchor che senza pianto</l>
             <l>Non possiam raccordarsi l'improvisa</l>
@@ -3118,7 +3176,7 @@
             <l>Quai qui rimasi siam come rimane</l>
             <l>Perduto il suo pastor greggia infelice.</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l>Habbian quella pieta figli di voi,</l>
             <l>Che merta questa eta che noi v'habbiamo,</l>
@@ -3131,12 +3189,12 @@
             <l>Che cosi ne sarete via piu grati</l>
             <l>Che non sareste i lor viti seguendo.</l>
           </sp>
-          <sp>
+          <sp who="#satiri_piccioli">
             <speaker>Satiri piccioli</speaker>
             <l>Non staremo altrimenti sotto voi,</l>
             <l>Che se ne stia sotto la madre agnello,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Non è da dubitar, ch' al viver vostro</l>
             <l>Non s' assimiglin poi che da fanciulli</l>
@@ -3169,17 +3227,17 @@
             <l>Qui si ritorneremo tutti insieme</l>
             <l>Forse contenti piu che non siamo hora.</l>
           </sp>
-          <sp>
+          <sp who="#amadriadi">
             <speaker>Amadriadi</speaker>
             <l>Anzi verrenvi molto volontieri</l>
             <l>Poi che noi vi possian venir sicure</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l>Deh di gratia dimi <name>Egle</name>, se d'<name>Arcadia</name></l>
             <l>Partito s' è co gli altri fauni <name>Pane</name>,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Partito s' è pur troppo lo 'nfelice</l>
             <l>Et non è per vederlo <name>Arcadia</name> mai,</l>
@@ -3192,13 +3250,13 @@
             <l>Te stessa a sdegno, per haver sdegnato</l>
             <l>Amante si fedel fuor di ragione,</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l>Dolgasi egli di se che si è voluto</l>
             <l>Por ad amar chi mai non senti amore,</l>
             <l>Io non lo 'ndussi mai ch' egli m' amasse,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Estender non mi voglio in dimostrarti</l>
             <l>Quanto meglio saria ch' amor seguisti,</l>
@@ -3207,12 +3265,12 @@
             <l>Ma tempo verra ben che tu te stessa</l>
             <l part="I">Riprenderai,</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>Siringa</speaker>
             <l part="F">i' non son per pentirmi</l>
             <l part="I">Mai de l' honesta mia,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">te n' avedrai</l>
             <l>Quand' il penserai men, restate in pace</l>
@@ -3224,7 +3282,7 @@
             <hi rend="sc">SCENA V</hi>
           </head>
           <stage>EGLE, SILENO</stage>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Chi fia chi dica che d'ingegno manchi</l>
             <l>Donna ch' a far si dia una grande impresa,</l>
@@ -3241,7 +3299,7 @@
             <l>Veggio <name>Sileno</name>, i gli voglio dar nuova</l>
             <l>ch' i Satir de le nimphe havran vittoria.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l>Tu mi farai uscir del corpo l' alma</l>
             <l>Con questo tuo tardar <num value="3">tre</num> fiaschi ho asciuti</l>
@@ -3252,45 +3310,45 @@
             <l>Insino ad hora, gaglioffetta guai</l>
             <l>A te se fatto tu m' havessi oltraggio.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Et se fatto l' havessi ben che fora</l>
             <l>Percio non t'averria nulla di nuovo</l>
             <l>Poi c'hai le corna per natura in capo</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l>Tu mi dilegi ribaldella? dammi</l>
             <l part="I">Un bascio.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="M">volentieri,</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="F">or prendi il fiasco</l>
             <l part="I">Et ricreati un poco,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">i' n' ho bisogno</l>
             <l>Per la durata mia nuova fatica,</l>
             <l>In ridur queste nimphe a le mie voglie,</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="I">Et c' hai tu fatto,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">lasciami ber prima</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l>Bevi, che dato i' t' ho per questo il fiasco</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>O che buon vino è questo, i' me ne sento</l>
             <l>Fender la lingua si che viemmi a l' occhio</l>
@@ -3298,24 +3356,24 @@
             <l>Nettare e ambrosia, i' non cerco ber meglio,</l>
             <l part="I">Et onde l' hai tu avuto?</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="F">il mio Marone</l>
             <l>Da la mensa di bacco hoggi l' ha tolto</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>So ch' ei conosce il buono, i' non mi posso</l>
             <l part="I">Satiar di ber,</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="F">vedi s' io mi raccordo</l>
             <l><name>Egle</name> di te non n' ho voluto bere</l>
             <l>Per servarloti un goccio, anchor ch' io havessi</l>
             <l part="I">Una gran sete.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">ti farei ingiuria</l>
             <l>S'io non lasciassi che tu dessi un bascio</l>
@@ -3323,7 +3381,7 @@
             <l>Accostavi la bocca che piu dolce</l>
             <l>Basciar questo sara che le mie labbra.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l>Questo non gia che piu dolce che manna</l>
             <l>E questa tua bocuccia, hor lascia ch'io</l>
@@ -3332,30 +3390,30 @@
             <l>A ragion ben lodato hai questo vino</l>
             <l>Potta di <name>Bacco</name>, i' non bevei mai meglio,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Bevilo tutto ch' io non ho piu sete,</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l>Senza che tu mel dica i' l'ho bevuto,</l>
             <l>Et parmi che sia fatto un dio celeste.</l>
             <l part="I">Or c' hai fatto pe Fauni,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">hanno le nimphe</l>
             <l>Sotto spetie di fe i nemichi a cerco</l>
             <l>Et molto non andra che saran tutte</l>
             <l>Secondo l' ordin dato in braccio a fauni</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l>Ha, ha, ha, ha, io lodo il signor <name>Baccho</name></l>
             <l>Che dar non sdegna aiuto a la sua gente</l>
             <l>Vorrei anch' io poter d'una godere.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Deh vecciacchio che sei, non ti par ch' io</l>
             <l>Sia troppo a le tue forze, io che non pure</l>
@@ -3365,12 +3423,12 @@
             <l>Forse una sciocca, come son stat'io,</l>
             <l>Che si sati d'haverne un pasto il mese,</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l>Non ti adirar vita mia cara, i'giuoco</l>
             <l part="I">Con te, nol vedi?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">non mi par bel giuoco</l>
             <l>Il minacciar di tormi il pan di casa,</l>
@@ -3380,49 +3438,49 @@
             <l>Mi minaci voler satiarne altrui?</l>
             <l>Et credi che star debba a questi pasti?</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="I">Che dirai, pazzerella,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">m' hai intesa,</l>
             <l>Non mi vo veder tor la vittuaglia.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l>Entriam nel bosco che farem la pace,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="I">I non vi vo venir,</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="M">perche,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">non voglio,</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l>Eh vien di gratia, so che gita al naso</l>
             <l part="I">Ti è subito la colera.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">cagione</l>
             <l>Forse non me n' hai dato se non fosse</l>
             <l>L' amor, col qual' i' t' amo i' staria un anno</l>
             <l part="I">Che non verrei ove tu fossi,</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="F">eh' andiamo</l>
             <l>Car' <name>Egle</name> mia nel bosco, eh vien de gratia.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Va ch' io ti seguo. Non è cosa al mondo</l>
             <l>Che star piu faccia uno marito al segno,</l>
@@ -3431,7 +3489,7 @@
             <l>Il cibo a lei, che tien le donne in vita</l>
             <l>Et chiaro hor visto i' l' ho nel mio <name>Sileno</name>.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO</speaker>
             <l>Hor che siam per por fine a nostri affanni</l>
             <l>Et si mostra cortese</l>
@@ -3489,18 +3547,18 @@
             <hi rend="sc">SCENA I</hi>
           </head>
           <stage>EGLE, SATIRI</stage>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Sapete ove la cosa è gia condotta</l>
             <l>Atro non resta piu che voi usiate</l>
             <l>Destrezza nel pigliar le fiere in caccia.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Satiri</speaker>
             <l>Pericol piu non v' è poi che ce l' hai</l>
             <l>Tu con l'ingegno tuo condotte in mano.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Et vi dico io che se da sciocchi voi</l>
             <l>Vi reggerete v'avrra da sciocchi,</l>
@@ -3533,11 +3591,11 @@
             <l>Perche se s'avedesser de lo 'nganno</l>
             <l>Tutto quel che fatt' è sarebbe nulla.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Satiri</speaker>
             <l><name>Egle</name> non dubbitar che sarem saggi.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Or state su l'aviso, et occupate</l>
             <l>I luoghi atti al fuggir, si che la fuga</l>
@@ -3552,12 +3610,12 @@
             <l>Detto i' v' ho cio che fa mestieri a questo</l>
             <l>Hora a voi sta condure il fatto al fine</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Satiri</speaker>
             <l>Da noi non manchera che con ingegno</l>
             <l>Non sia provisto a ogni impossibil cosa.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Dunque io me n'andro dritto a ritrovarle</l>
             <l>Et cerchero di porle in danza insieme</l>
@@ -3565,7 +3623,7 @@
             <l>State dietro a questi arbori, et il tempo</l>
             <l part="I">Pigliatevi a la preda,</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Satiri</speaker>
             <l part="F">vanne et credi</l>
             <l>Che l' hora non veggia<expan>n</expan> che 'l fine giunga,</l>
@@ -3577,7 +3635,7 @@
             <l>Ecco le nimphe vengono e i fanciulli</l>
             <l>Nostri sono con lor tutti giulivi,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>lor s'appresenta, non fia molto</l>
             <l>C'havremo ne le mani il nostro bene.</l>
@@ -3588,36 +3646,36 @@
             <hi rend="sc">SCENA II</hi>
           </head>
           <stage>NIMPHE, EGLE, SATIRI PICCIOLI, SATIRO GRANDE, CHORO</stage>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l>State sicuri pur d'haver trovato</l>
             <l part="I">Un perpetuo riposo,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">et voi d' havere</l>
             <l part="I">L' inciampo ritrovato,</l>
           </sp>
-          <sp>
+          <sp who="#satiri_piccioli">
             <speaker>Satiri piccioli</speaker>
             <l part="F">certo nulla</l>
             <l>Ci par d' haver perduto, tanto amore</l>
             <l>Ci havete mostro, et tai carezze fatte.</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l>Ogni giorno haverete maggior segno</l>
             <l>Quanto v'amiam, quanto ne siate cari,</l>
             <l part="I">Ma vedete <name>Egle</name> vostra,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">figli miei</l>
             <l>Come vi contentate de la vita</l>
             <l>Di queste vostre madri? se voi sete</l>
             <l>Contenti ogni dolor da me è fuggito</l>
           </sp>
-          <sp>
+          <sp who="#satiri_piccioli">
             <speaker>Satiri piccioli</speaker>
             <l>Ci hanno <name>Egle</name> queste nimphe mostro tanto</l>
             <l>Amore, che per dirti il vero, mai</l>
@@ -3628,19 +3686,19 @@
             <l>L' im<expan>m</expan>ensa cortesia di queste nimphe</l>
             <l>C'haver non poteva<expan>n</expan> maggior conforto.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Io non me ne credeti altro giamai</l>
             <l>Tanto cortesemente i' vidi accorvi,</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l>Gli è saputo un po strano il bever l' acqua</l>
             <l>Ma nel resto si son cosi acquetati</l>
             <l>Che parso n' è ch'assai restin contenti</l>
             <l part="I">De la compgnia nostra,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">è de l' etade</l>
             <l>Tenera proprio questo, che di mente</l>
@@ -3653,7 +3711,7 @@
             <l>Molto non andera che 'l ber de l' acque,</l>
             <l>Posto il vino in oblio, non gli fia a noia,</l>
           </sp>
-          <sp>
+          <sp who="#satiri_piccioli">
             <speaker>Satiri piccioli</speaker>
             <l>Anzi insin' hor non n' è spiacciuto il berne,</l>
             <l>Et si sentiam via piu leggiadri, et snelli</l>
@@ -3664,7 +3722,7 @@
             <l>Non s'opponesse al voler nostro, noi</l>
             <l>Le chiederem<expan>m</expan>o a far con noi un ballo.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Et perche ricusar deono lo 'nvito?</l>
             <l>Quando son famigliari accolti insieme</l>
@@ -3673,32 +3731,32 @@
             <l>Pero i' non credo che queste cortesi</l>
             <l>Nimphe si sdegnin di danzar con voi.</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l part="I">Non gia per nostra fe,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">Voi fate bene</l>
             <l>A prendervi piacere a qualche modo,</l>
             <l>Poi che 'l maggior piacir ch' esser mai possa</l>
             <l>Per donna al mondo voi havete a schifo</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l part="I">Et qual' è questo,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">amare et de l' amore</l>
             <l part="I">Goder d' un'huom che s'ami,</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l part="F">tu sei pure</l>
             <l part="I"><name>Egle</name> su le sciocchezze,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">anzi io vi dico</l>
             <l>Che di cio non vi vo mover parola,</l>
@@ -3706,66 +3764,66 @@
             <l>Si possiam por con questi putti in danza</l>
             <l>Et solazzarsi honestamente insieme.</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l part="I">Faccia<expan>n</expan> come ti par,</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Satiri</speaker>
             <l part="F">son quasi al fine</l>
             <l part="I">Tutte le cose,</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l part="M">Voi ch' usciamo,</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Satiri</speaker>
             <l part="F">state cheti</l>
             <l>Non vi scoprite che non è anchor tempo,</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l part="I">Oime quando fia l' hora,</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l part="F">et come in ballo</l>
             <l>Potrem condurci non vi essendo alcuno</l>
             <l part="I">Che tra noi suoni,</l>
           </sp>
-          <sp>
+          <sp who="#satiri_piccioli">
             <speaker>Satiri piccioli</speaker>
             <l part="F">se fosse tra noi</l>
             <l>Fistula alcuna sonerebbe parte</l>
             <l>Di noi, et parte si daria a danzare,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Ma non sapete voi se sempre meco</l>
             <l part="I">Porto le fistole io?</l>
           </sp>
-          <sp>
+          <sp who="#satiri_piccioli">
             <speaker>Satiri piccioli</speaker>
             <l part="F">dalleci adunque</l>
             <l part="I">Che sonerem,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="M">tenete,</l>
           </sp>
-          <sp>
+          <sp who="#satiri_piccioli">
             <speaker>Satiri piccioli</speaker>
             <l part="F">state in punto</l>
             <l>Che 'l tempo vien che se n' entriamo in caccia,</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>
               <add>Choro</add>
             </speaker>
             <l part="I">A l' ordine noi siamo,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">a coppia a coppia</l>
             <l>Noi entrerem in ballo, et le carolle</l>
@@ -3778,11 +3836,11 @@
             <hi rend="sc">SCENA III</hi>
           </head>
           <stage>SATIRO, CHORO, SILENO, PANE</stage>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">State a l'ordine tutti,</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l part="F">siam pur troppo</l>
             <l>A l' ordine, non fu mai si tes' arco</l>
@@ -3792,12 +3850,12 @@
             <l>Che non le diamo dentro? si sentimo</l>
             <l part="I">Rompere i nervi,</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">non è ancora tempo</l>
             <l part="I">D' uscir fratelli miei,</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l part="F">non veggiam l'hora</l>
             <l>Che possiamo sfogar nostro disio.</l>
@@ -3806,7 +3864,7 @@
             <l>Ò che pie scarno, et rotondetto, et vago</l>
             <l part="I">Sostien quella vittina,</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">con che gratia</l>
             <l>Move la mia <name>Napea</name> l' un lato, et l'altro,</l>
@@ -3814,30 +3872,30 @@
             <l>Come si ferma? et per dir breve come</l>
             <l>Legiadramente al suon col pie risponde</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l>Ma vedi ch'a noi vien <name>Sileno</name>, et <name>Pane</name>,</l>
             <l><name>Pan</name> venir dee per la <name>Siringa</name> sua</l>
             <l>Ma non so a che fin qui venga <name>Sileno</name>,</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Che vi è <name>Sileno</name>?</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="F">son venuto anch'io</l>
             <l>A veder questa festa, e ad haver gioia</l>
             <l part="I">De le vostre allegrezze,</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l part="F">deh sta indietro</l>
             <l>Con quest' asino tuo, ne la mal hora,</l>
             <l>Che s' ei raggiasse, siam tutti disfatti,</l>
             <l part="I">Non odi tu <name>Silen</name>?</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="F">tu mi vuoi fare</l>
             <l>Uscir si, ch' io sia visto, io quel son stato</l>
@@ -3845,46 +3903,46 @@
             <l>Cacciar com' una bestia? i' voglio andare</l>
             <l part="I">Fuor de la selva, va inanzi,</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">eh non fare</l>
             <l part="I">Caro <name>Sileno</name>,</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="F">i' voglio andar, va la,</l>
             <l>Vo che tutti costor paiano bestie.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="I">Costui ' ubriaco,</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l part="F">punto il vin lavora,</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Non ci turbar <name>Silen</name>, <name>Silen</name> mio resta,</l>
             <l>Non voler ch' un tuo sdegno ci disfaccia,</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>
               <add>Silvano</add>
             </speaker>
             <l part="I">Per amor tuo mi rimarro,</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">è <name>Siringa</name></l>
             <l part="I">Forse nel ballo?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">ella al fin de la danza</l>
             <l>Git' è co l' altre nimphe, et con lor siede,</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>
               <add>Pane</add>
             </speaker>
@@ -3893,13 +3951,13 @@
             <l>Come mi struggi il cor, come m'ancidi?</l>
             <l part="I">Ma che tardiamo piu?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">lascia che 'n ballo</l>
             <l>Entri di nuovo, ve la tua <name>Siringa</name></l>
             <l part="I">Che mena la carola,</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">oime che vita,</l>
             <l>Oime che leggiadria, che movimenti,</l>
@@ -3907,32 +3965,32 @@
             <l>Io mi dileguo, è tempodi far segno</l>
             <l part="I"><name>Satiro</name> a gli altri,</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l part="F">havete udito quello</l>
             <l part="I"><name>Sibillo</name>,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">è nulla, fia qualche pastore</l>
             <l>Che chiama la sua greggia, ò chiama i cani,</l>
             <l part="I">Segiamo il ballo,</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l part="F">i son quasi rimasa</l>
             <l part="I">Fuori di me,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">tu temi ben di puoco,</l>
             <l part="I">Su a la danza, sonate,</l>
           </sp>
-          <sp>
+          <sp who="#satiri_piccioli">
             <speaker>Satiri piccioli</speaker>
             <l part="F">noi soniamo</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l>Ora animosamente tutti a un tratto</l>
             <l>Entriam compagni miei lieti nel campo</l>
@@ -3944,98 +4002,98 @@
             <hi rend="sc">SCENA IIII</hi>
           </head>
           <stage>NIMPHE, CHORO, PANE, EGLE, SILENO</stage>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l>Ò poverelle noi, nimphe, siam morte</l>
             <l>Ò poverelle noi vedete i fauni</l>
             <l>E i Satiri, e i Silvani, ò triste noi,</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l>Ehe non fuggite che temete? semo</l>
             <l part="I">I vostri amanti,</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l part="F">Ai <name>Egle</name>, oime malvagia,</l>
             <l part="I">O noi semplici et sciocche,</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">eh non fuggire</l>
             <l part="I"><name>Siringa</name>, eh non fuggire,</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l part="F">ò meschinelle</l>
             <l part="I">Che siamo,</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">andate a quel varco un de voi,</l>
             <l>Piglia questa che vien verso la selva</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l part="I">O noi misere, et triste,</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">che tardate</l>
             <l part="I">Correte al bosco,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">su <name>Satir</name>, su fauni,</l>
             <l>Su valorosamente, ben sarete</l>
             <l>Cosi dapoco che fuggiranno ancho,</l>
             <l part="I">Et ne le man le havrete,</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Nimphe</speaker>
             <l part="F">Ai malvagia <name>Egle</name>,</l>
             <l part="I">Quest' è la fe?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">dove ne vai <name>Sileno</name>?</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l>Io vò per dar soccorso a miei compagni,</l>
             <l>Ch' anch' essi m'aiutar quand' io ti tolsi</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Ò cho soccorso? mover non ti puoi</l>
             <l part="I">Et gli voi dare aiuto,</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="F">prender voglio</l>
             <l part="I">Questa che viene in qua,</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>Satiro</speaker>
             <l part="F">tosto non state</l>
             <l>Satiri a bada su picciol, fanciulli</l>
             <l>Correr non le lasciate, per la mano,</l>
             <l>Tenetele, pe pani, et per le gambe.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l>A questa a questa tutti adosso a questa,</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>Choro</speaker>
             <l>Ci fuggiran non state a bada, al bosco,</l>
             <l>al bosco tutti, ch' elle al bosco vanno,</l>
           </sp>
-          <sp>
+          <sp who="#nimphe">
             <speaker>Ni<expan>m</expan>phe</speaker>
             <l part="I">Oime dove siam giunte?</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="F">adosso, a dosso</l>
             <l>Adosso a questa, piglia, piglia, piglia,</l>
@@ -4044,46 +4102,46 @@
             <l>Oime, et ho fatto nulla ch' è fuggita</l>
             <l part="I">Oime,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">tel diss' io ben sei tu ben atto</l>
             <l>Correr dietro a chi fugge, in tua malhora</l>
             <l>Tienti al tuo fiasco che non fugge, et lascia</l>
             <l part="I">Correr chi vuol,</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="F">s' io lo facea per bene,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l>Havresti fatto meglio a haver bevuto,</l>
             <l part="I">Hor levati se puoi,</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="F">dammi la mano</l>
             <l part="I">Aiutami,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F">vorravi altro potere,</l>
             <l part="I">Che 'l mio,</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l part="F">dammi la mano perch' anch'io</l>
             <l>Mi sorgero, son pur risorto un poco,</l>
             <l>Aiutami <name>Egle</name> regger non mi posso,</l>
             <l part="I">Oime,</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>Egle</speaker>
             <l part="F"> monta a caval, ve ch' allegrezza</l>
             <l>Tu mi vuoi dar sta notte mentre in gioia</l>
             <l>Gli altri saran, sarai tu sul dolerti,</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>Sileno</speaker>
             <l>Non mica, tosto c' havero bevuto,</l>
             <l>Non havro mal, i' volea pur potere</l>
@@ -4096,7 +4154,7 @@
             <hi rend="sc">SCENA V</hi>
           </head>
           <stage>SILVANO, PANE</stage>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Ogni cosa nel bosco è sotto sopra</l>
             <l>Chi corre in qua chi in la, prendut' han molte</l>
@@ -4139,50 +4197,50 @@
             <l>Da lor soavi fiori il dolce frutto,</l>
             <l>Che potrebbe invidiar sin dal ciel, <name>Giove</name>,</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>aver nemico il cielo e imaginarsi</l>
             <l>Poter condure uno suo effetto al fine,</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Che lamentevol voce è questa ch'odo?</l>
             <l>Uscir del bosco in cosi gran letitia?</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>A chi cio crede avien quel ch' è avenuto</l>
             <l>A questo meschinello, ò miser <name>Pane</name>,</l>
             <l>O <name>Pan</name> tristo e 'nfelice, ò <name>Pan</name> dolente</l>
             <l part="I">A che termine sei?</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l part="F">egli mi pare</l>
             <l><name>Pane</name> che si lamenti, et che puo havere</l>
             <l>Egli di tristo essendo ognuno in gioia?</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Ò doloroso <name>Pane</name> hai pur perduto</l>
             <l part="I">Quanto di bene havevi,</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l part="F">che ci è <name>Pane</name>?</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Potrai pur poverello a voglia tua</l>
             <l>Gir per le selve senza haver sospetto</l>
             <l part="I">D'offender la tua nimpha,</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l part="F">ch' avenuto</l>
             <l>T' è di dolente <name>Pan</name> che si ti dogli?</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Oime <name>Silvan</name> oime tra queste selve</l>
             <l>Selve gia di piacere, et di diletto</l>
@@ -4191,13 +4249,13 @@
             <l>Esser tra piu felici hoggi i piu lieti</l>
             <l>Ei piu infelici siam ch' fossero unqua.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Tu mi togli la vita <name>Pan</name> ch' è</l>
             <l>Che tu mi di? Quando pensar piu debbo</l>
             <l>Vedervi lieti s'sete tristi?</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Avenuta <name>Silvan</name> ci èle</l>
             <l>Che fin c'no mai fronde le selve</l>
@@ -4205,23 +4263,23 @@
             <l>Com'di perduto habbiamo quello</l>
             <l>Che non ci dara mai volger il cielo?</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Deh fa ch'ppia, <name>Pan</name>, che cosa è</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Deh non voler <name>Silvan</name> se n'ire</l>
             <l>La 'ita nostra, il nostro affanno,</l>
             <l>Che 'bil angoscia havrai a udirlo.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>I non posso sentir doglia maggiore</l>
             <l>Di quella c'il cor per voi mi preme,</l>
             <l>Pero non mi tenere hor piu sospeso,</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Mentre <name>Silvan</name> le nostre care nimphe</l>
             <l>(Ch'r lo ti diro poi che 'rchi)</l>
@@ -4248,12 +4306,12 @@
             <l>Restaro si che non si videro, altre</l>
             <l>Divener fior ne la minuta herbetta,</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Ai che mi ditu <name>Pan</name>, che meraviglie</l>
             <l part="I">Son queste ch'</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">i'i me<expan>n</expan>to pu<expan>n</expan>to</l>
             <l>Ne furono alcun' in questo tempo</l>
@@ -4289,12 +4347,12 @@
             <l>Et star sasso nel monte appresso a quella</l>
             <l>Nimpha che l'fatto il cor di pietra.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Non credo mai che 'ol giorno tante</l>
             <l part="I">Mutation fosser vedute,</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">nostro</l>
             <l>Danno servate son le maraviglie</l>
@@ -4302,12 +4360,12 @@
             <l>Miseri siamo, et io piu via d'</l>
             <l>Languisca sempre, et mi lamenti sempre</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Perc' <name>Pan</name> de gli altri maggior doglia?</l>
             <l>Perche strugger ti vuoi tu piu de gli altri?</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Perche quant'a <name>Siringa</name> mia</l>
             <l>D'nimpha gentil molto piu bella</l>
@@ -4316,11 +4374,11 @@
             <l>Non posso non dolermi, tanto, quanto</l>
             <l>Ell'ella, et quant'a l'</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Deh dimmi <name>Pan</name> ch'to è</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Ograve;rato me dopo ch'di</l>
             <l>Mutate l'nimphe in varie forme</l>
@@ -4344,35 +4402,35 @@
             <l>Oime la vidi, oime <name>Silvano</name>, oime</l>
             <l>Apena il posso dir, mutarsi in canna,</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Ne lo posso udir io senza gran doglia,</l>
             <l>Et testimon ten faccia il pianto mio,</l>
             <l>Ma che stormento èche ti pende</l>
             <l part="I">Al lato,</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">oime ch' sempre haver questo</l>
             <l>Per la piu cara cosa ch'al mond'habbia</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l part="I">Et perche <name>Pan</name>?</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">e di quella canna</l>
             <l><add>In</add> che mutata s'mia <name>Siringa</name></l>
             <l><add>Co</add>mposta i' per isfogar col suo</l>
             <l>Suon la mia doglia, e' angoscioso affanno,</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Et come in cor ti venne di comporre</l>
             <l part="I">Tanti calami in un,</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l part="F">non fu mutata</l>
             <l>Cosi tosto <name>Siringa</name> che spirando</l>
@@ -4388,7 +4446,7 @@
             <l>Co la qual risonar faro ogni selva</l>
             <l>Del caro nome suo, del mio dolore</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Felice <name>Pane</name> sei tu appresso gli altri</l>
             <l>Perche con <name>Ega</name> tua antica mogliera</l>
@@ -4396,14 +4454,14 @@
             <l>Ma gli altri poverelli che non hanno</l>
             <l>Rifugio alcun si pon ben chiamar tristi,</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Oime charo <name>Silvan</name> tanto piu d'</l>
             <l>Era bella <name>Siringa</name>, quanto belli</l>
             <l>Piu gli amaranti son de minor fiori,</l>
             <l>Mutar fia questo la colomba in corbo,</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Gran cosa èche dopo c'a</l>
             <l>Havete ne le man nimpha cortese</l>
@@ -4416,12 +4474,12 @@
             <l>In questa eta che mai non fu <name>Siringa</name></l>
             <l>Nel piu bel fior de suoi piu fioriti anni,</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>Pane</speaker>
             <l>Non piu <name>Silvan</name> che tu m'sci doglia</l>
             <l>Vien meco entra nel bosco a veder gli altri,</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>Silvano</speaker>
             <l>Entra ch' io di subito ti seguo,</l>
             <l>Non si dee desiar cosa che neghi</l>

--- a/tei/giraldi-cinzio-egle.xml
+++ b/tei/giraldi-cinzio-egle.xml
@@ -82,6 +82,67 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="silvano">
+            <persName>Silvano</persName>
+          </person>
+          <person xml:id="satiro">
+            <persName>Satiro</persName>
+          </person>
+          <person xml:id="fauno">
+            <persName>Fauno</persName>
+          </person>
+          <person xml:id="sileno">
+            <persName>Sileno</persName>
+          </person>
+          <person xml:id="egle">
+            <persName>Egle</persName>
+          </person>
+          <person xml:id="cromi">
+            <persName>Cromi</persName>
+          </person>
+          <person xml:id="mnasilo">
+            <persName>Mnasilo</persName>
+          </person>
+          <personGrp xml:id="coro">
+            <name>Coro</name>
+          </personGrp>
+          <personGrp xml:id="oreadi">
+            <name>Oreadi</name>
+          </personGrp>
+          <personGrp xml:id="driadi">
+            <name>Driadi</name>
+          </personGrp>
+          <personGrp xml:id="napee">
+            <name>Napee</name>
+          </personGrp>
+          <personGrp xml:id="naiadi">
+            <name>Naiadi</name>
+          </personGrp>
+          <person xml:id="pane">
+            <persName>Pane</persName>
+          </person>
+          <person xml:id="siringa">
+            <persName>Siringa</persName>
+          </person>
+          <personGrp xml:id="amadriadi">
+            <name>Amadriadi</name>
+          </personGrp>
+          <personGrp xml:id="ninfe">
+            <name>Ninfe</name>
+          </personGrp>
+          <personGrp xml:id="satiri_piccioli">
+            <name>Satiri piccioli</name>
+          </personGrp>
+          <personGrp xml:id="satiri">
+            <name>Satiri</name>
+          </personGrp>
+          <person xml:id="satiro_grande">
+            <persName>Satiro grande</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -414,7 +475,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>SILVANO<hi rend="italic">solo</hi></stage>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <lg>
               <l>Quando lo stuolo uman ne l'innocenzia</l>
@@ -502,14 +563,14 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>SATIRO, FAUNO</stage>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Amor che mai non giunga a fine, amore</l>
               <l>Dir non si dee, ma una continua pena.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>FAUNO</speaker>
             <lg>
               <l>È troppo il ver, ma se vi s'accompagna</l>
@@ -517,7 +578,7 @@
               <l>Ma una continua, inevitabil morte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Troppo tutti il proviam, dopo che Giove</l>
@@ -528,18 +589,18 @@
               <l>Debbano disturbar la pace nostra.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>FAUNO</speaker>
             <lg>
               <l>Sai, frate mio, quale ingiuria han da noi</l>
               <l>I Dei del ciel?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <l>Non io.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>FAUNO</speaker>
             <lg>
               <l>L'ingiuria è ch'essi</l>
@@ -549,7 +610,7 @@
               <l>Atta a potersi aver da illustre amante.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Quanto dolore, ohimè, m'aggionge questo</l>
@@ -563,7 +624,7 @@
               <l>Le ninfe nostre!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>FAUNO</speaker>
             <lg>
               <l>Il lamentarsi è vano,</l>
@@ -578,7 +639,7 @@
               <l>È da cercar che cel godiamo noi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Ahi che più non vi veggio modo alcuno,</l>
@@ -595,7 +656,7 @@
               <l>Mi fugge et odia, ond'io m'affliggo e struggo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>FAUNO</speaker>
             <lg>
               <l>Tal è verso di me la Naide mia,</l>
@@ -617,28 +678,28 @@
               <l>E non cerchi d'averla a le mie voglie.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>E che vogliam noi far, per goder qualche</l>
               <l>Frutto de le fatiche di tanti anni?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>FAUNO</speaker>
             <lg>
               <l>Voglio che 'ntendiam ben prima s'è vero</l>
               <l>Ch'i Dei celesti sian per farne ingiuria.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Che bisogna cercar, s'elle medesme</l>
               <l>L'han detto ad Egle di Sileno nostro?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>FAUNO</speaker>
             <lg>
               <l>Costume è de le ninfe di mostrare</l>
@@ -652,11 +713,11 @@
               <l>Ch'essere accolta dee per nostra mano.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <l>E come ciò potrem saper?</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>FAUNO</speaker>
             <lg>
               <l>Sileno</l>
@@ -674,7 +735,7 @@
               <l>Non ci celerà cosa ch'egli sappia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Ma dove avrem Sileno ? Egli dormire</l>
@@ -683,14 +744,14 @@
               <l>In giuoco e 'n festa, o con la sua dolce Egle.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>FAUNO</speaker>
             <lg>
               <l>Eccolo ch'egli vien co' suoi compagni</l>
               <l>A punto fuor del bosco.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Ei tutto è festa,</l>
@@ -702,7 +763,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>SILENO, EGLE, CROMI, MNASILO</stage>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <lg>
               <l>Bacco, se nel nodrirti ebbi già affanno,</l>
@@ -734,7 +795,7 @@
               <l>Che non bevesti mai succo migliore.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Beata quella vite ond'uscì fuore</l>
@@ -744,7 +805,7 @@
               <l>Da' lor del vino ancora.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cromi">
             <speaker>CROMI</speaker>
             <lg>
               <l>Non son stato io a questa ora, </l>
@@ -753,7 +814,7 @@
               <l>Disio di voler darli uno gran crollo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#mnasilo">
             <speaker>MNASILO</speaker>
             <lg>
               <l>Or pommi il fiasco al collo,</l>
@@ -769,7 +830,7 @@
               <l>Che si beve del vino in vece d'acque.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <lg>
               <l>Beato il padre e la madre onde nacque</l>
@@ -787,25 +848,25 @@
         <div type="scene">
           <head>SCENA IIII</head>
           <stage>SATIRO, FAUNO, SILENO, EGLE</stage>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <l>Dio ti salvi, Silen.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>FAUNO</speaker>
             <lg>
               <l>Salviti Dio</l>
               <l>E ti conservi l'allegrezza tua.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <lg>
               <l>E voi faccia contenti il nostro Bacco</l>
               <l>E vi levi del core ogni tristezza.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>FAUNO</speaker>
             <lg>
               <l>Ben bisogno n'abbiam, caro Sileno:</l>
@@ -813,7 +874,7 @@
               <l>Né mai si cela, che ne vegga lieti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <lg>
               <l>E che cosa è che sì v'affligga? Vuole</l>
@@ -827,7 +888,7 @@
               <l>Se ne beve l'oblio d'ogni dolore.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Ohimè, ch'ogni soave succo è tòsco</l>
@@ -835,7 +896,7 @@
               <l>Sileno, a farci lieti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <lg>
               <l>Se 'l vin lieti</l>
@@ -843,18 +904,18 @@
               <l>Io beverò per voi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Anzi il rimedio</l>
               <l>È solo in te de la gran doglia nostra.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <l>Che poss'io far per voi?</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Darci la vita;</l>
@@ -863,14 +924,14 @@
               <l>Se non ci aiuti tu, siamo a la morte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <lg>
               <l>Fate ch'io sappia 'l mal: s'avrò rimedio</l>
               <l>Atto a curarlo, i' non ven sarà scarso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Novo non credo che ti sia ch'ogniuno</l>
@@ -884,25 +945,25 @@
               <l>E darsi tutte a amare i Dei celesti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <l>È vero, Egle mia, questo?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Il dissero eri,</l>
               <l>Mentr'io le confortava a amar costoro.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <lg>
               <l>Avete gran ragion di lamentarvi,</l>
               <l>Se vero è quel che da costei or odo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>FAUNO</speaker>
             <lg>
               <l>Silen, se ciò avenisse, ci dorrebbe</l>
@@ -912,11 +973,11 @@
               <l>Non n'esser ora tu di favor scarso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <l>Chiedete, ch'io son tutto a' piacer vostri.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Vorremmo che sapessi tu da Bacco</l>
@@ -927,7 +988,7 @@
               <l>Non siam per tolerar scorno sì grande.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <lg>
               <l>Anzi il devete far: io immantinente</l>
@@ -935,11 +996,11 @@
               <l>Che 'l tutto inteso avrò, ven darò aviso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <l>A Dio, Sileno.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <lg>
               <l>A Dio, compagni cari.</l>
@@ -952,7 +1013,7 @@
             </lg>
           </sp>
           <stage>CORO</stage>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>O Bacco, oò, oò, figliuol di Giove</l>
@@ -1008,7 +1069,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>EGLE<hi rend="italic">sola</hi></stage>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Più volte e più m'ha detto il mio Sileno,</l>
@@ -1068,14 +1129,14 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>FAUNO, SATIRO, EGLE</stage>
-          <sp>
+          <sp who="#fauno">
             <speaker>FAUNO</speaker>
             <lg>
               <l>Pur che la nuova sia buona, il tardare</l>
               <l>Non mi dorrà.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Sia pure o buona o rea,</l>
@@ -1088,11 +1149,11 @@
               <l>Non sarai unqua a porlati in sicuro.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>FAUNO</speaker>
             <l>La tropp'audatia torna spesso in danno.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Et il troppo temer fa perder spesso</l>
@@ -1100,7 +1161,7 @@
               <l>Perder, più tosto che timido avere.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>FAUNO</speaker>
             <lg>
               <l>Io mi ricordo ancor quel che m'avenne</l>
@@ -1109,7 +1170,7 @@
               <l>Per la grave percossa ch'alor diedi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Già non si conveniva altra mercede</l>
@@ -1123,14 +1184,14 @@
               <l>Io non piglierò l'orso per la lepre.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Che parole son queste? Aman la pace</l>
               <l>Le selve e non le liti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>FAUNO</speaker>
             <lg>
               <l>Non è guerra,</l>
@@ -1138,22 +1199,22 @@
               <l>Ch'abbia inteso Silen nostro da Bacco.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l>Non vi è nulla di buono.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>FAUNO</speaker>
             <l>Tu m'hai morto.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Et a me animo hai dato a la mia impresa.</l>
               <l>Narraci che ci manda a dir Sileno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Vi fa saper ch'i Dei celesti sono,</l>
@@ -1163,25 +1224,25 @@
               <l>Venirsi ne le selve a goder d'esse.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>FAUNO</speaker>
             <l>Ohimè!</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Io non vo' già per ciò dolermi:</l>
               <l>Prima di lor i' me n'andrò a la caccia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>E ch'essi, per non esser conosciuti,</l>
               <l>Sotto mentita forma a lor verranno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Et io v'andrò ne la medesma mia,</l>
@@ -1189,7 +1250,7 @@
               <l>Tu su' rispetti tuoi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>FAUNO</speaker>
             <lg>
               <l>Satir, sei sciocco;</l>
@@ -1200,7 +1261,7 @@
               <l>Altrimente ogni cosa andrà in sinistro.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Fauno non dice mal! Satir, sta' cheto</l>
@@ -1211,14 +1272,14 @@
               <l>Fare, n'andrà tutta la cosa in nulla.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>E perché? non siam noi per far lor forza?</l>
               <l>Tu t'inganni, Egle.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Io non m'inganno, ascolta.</l>
@@ -1247,22 +1308,22 @@
               <l>Pensan di queste ninfe oggi godere.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <l>Che deviam dunque far?</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>FAUNO</speaker>
             <lg>
               <l>Prudentemente</l>
               <l>Condur la cosa.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <l>E come?</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>FAUNO</speaker>
             <lg>
               <l>I' voglio ch'Egle</l>
@@ -1272,7 +1333,7 @@
               <l>E le disponga a non ci dar più affanno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Il farò volentieri, perch'io vorrei</l>
@@ -1280,7 +1341,7 @@
               <l>Acciò che et elle e voi foste contenti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>FAUNO</speaker>
             <lg>
               <l>Che non si vuoi venir mai a la forza,</l>
@@ -1293,11 +1354,11 @@
               <l>Ad una festa che 'ntendiam di fare.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <l>Tu non ce le corrai.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>FAUNO</speaker>
             <lg>
               <l>Anzi verranle,</l>
@@ -1306,11 +1367,11 @@
               <l>Di queste selve e gir fin in Ispagna.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <l>So che finger tu vuoi di gir da lunge.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>FAUNO</speaker>
             <lg>
               <l>Ben bisogna mostrar che gran paesi</l>
@@ -1319,11 +1380,11 @@
               <l>Che facil non ne fia il tornare a loro.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <l>Or segui.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>FAUNO</speaker>
             <lg>
               <l>Io voglio poi ch'ella le dica</l>
@@ -1339,7 +1400,7 @@
               <l>A lor ch'i Roman fero a le Sabine.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Fauno, molto mi piace il tuo consiglio;</l>
@@ -1349,7 +1410,7 @@
               <l>Userò poi perché quest'altro segua.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Egle, te ne preghiamo; così mai</l>
@@ -1357,7 +1418,7 @@
               <l>E 'l tuo Silen sovra ogni cosa t'ami! </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Io non mancherò in cosa ch'io presuma</l>
@@ -1386,7 +1447,7 @@
               <l>E più agevol mi fia finire il tutto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Or vanne, Egle mia dolce, e faccia Bacco</l>
@@ -1399,7 +1460,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>EGLE <hi rend="italic">sola</hi></stage>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Aviene di costor quello ch'aviene</l>
@@ -1430,11 +1491,11 @@
         <div type="scene">
           <head>SCENA IIII</head>
           <stage>SATIRO, CORO, FAUNO</stage>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <l>Che state a far? Venite fuori omai.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Tu ci hai tutti adunati e non ci hai detto</l>
@@ -1442,18 +1503,18 @@
               <l>Che ci hai da dire?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <l>Una bramata cosa.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Non bramiamo altra cosa che potere</l>
               <l>Godersi de le ninfe che no' amiamo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>E d'altro non vi ho da ragionare</l>
@@ -1461,7 +1522,7 @@
               <l>Tutti a un tratto dar fine a i nostri affanni.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Ah ah, ah ah, o Bacco, o Bacco, ah ah,</l>
@@ -1469,7 +1530,7 @@
               <l>Se ciò ver è, quai fian di noi più lieti?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Siam risoluti ch'i celesti Dei</l>
@@ -1478,7 +1539,7 @@
               <l>Determinato abbiam di farla a loro.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>E così far si deve. O Bacco, oè,</l>
@@ -1491,7 +1552,7 @@
               <l>Ma narra il modo che tenir debbiamo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>FAUNO</speaker>
             <lg>
               <l>Il modo intenderete più a bell'agio;</l>
@@ -1504,18 +1565,18 @@
               <l>E non dar noia a lor ch'amiamo tanto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <l>Comincia tu, che seguiremo tutti.</l>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>FAUNO</speaker>
             <lg>
               <l>Poniànci insieme a l'ombra di quel faggio</l>
               <l>E diam principio al lagrimevol canto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Non arse mai tanto stoppia per fiamma,</l>
@@ -1585,7 +1646,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>OREADI, DRIADI, NAPEE, EGLE, NAIADI</stage>
-          <sp>
+          <sp who="#oreadi">
             <speaker>OREADI</speaker>
             <lg>
               <l>Già apparecchiata s'è di gire al bosco</l>
@@ -1593,13 +1654,13 @@
               <l>Andiamo ancora noi a ritrovarla.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#driadi">
             <speaker>DRIADI</speaker>
             <lg>
               <l>Andiàn.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#napee">
             <speaker>NAPEE</speaker>
             <lg>
               <l>Andiamo a l'onoranda nostra</l>
@@ -1609,7 +1670,7 @@
               <l>Del ciel, quando il sol toglie a noi la luce.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#driadi">
             <speaker>DRIADI</speaker>
             <lg>
               <l>Andiamo a la triforme nostra Dea,</l>
@@ -1617,7 +1678,7 @@
               <l>O nel regno di Dite.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#oreadi">
             <speaker>OREADI</speaker>
             <lg>
               <l>Onora Pale</l>
@@ -1628,7 +1689,7 @@
               <l>Devemo amar con tutto 'l cor Diana.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#driadi">
             <speaker>DRIADI</speaker>
             <lg>
               <l>E come face sacrifizio a Marte</l>
@@ -1637,7 +1698,7 @@
               <l>Così a Diana noi devèn dar voti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#napee">
             <speaker>NAPEE</speaker>
             <lg>
               <l>Dunque, Dea de le selve e Dea de' boschi,</l>
@@ -1658,7 +1719,7 @@
               <l>So che si vede ch'ella serve a Bacco.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Gelata non son già, come voi sete,</l>
@@ -1673,7 +1734,7 @@
               <l>Nulla di lieto al mondo esser mai puote.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#naiadi">
             <speaker>NAIADI</speaker>
             <lg>
               <l>Ubriaca che sei, credi di darci</l>
@@ -1703,7 +1764,7 @@
               <l>Di darci a ber sì abominevol succo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Io ti dico, in contrario di quel c'hai</l>
@@ -1736,11 +1797,11 @@
               <l>Che non si dee verginità apprezzare.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#naiadi">
             <speaker>NAIADI</speaker>
             <l>Or va', malvagia, va'.</l>
           </sp>
-          <sp>
+          <sp who="#oreadi">
             <speaker>OREADI</speaker>
             <lg>
               <l>Vanne, impudica,</l>
@@ -1749,7 +1810,7 @@
               <l>Va', va' al tuo Bacco, e noi lascia a Diana.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>O poverelle che voi sete, sciocche</l>
@@ -1759,7 +1820,7 @@
               <l>Modo di vita.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#napee">
             <speaker>NAPEE</speaker>
             <lg>
               <l>La lascivia tua</l>
@@ -1772,7 +1833,7 @@
               <l>Questa verginità che custodimo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Et io vi dico ch'è di nissun pregio</l>
@@ -1796,7 +1857,7 @@
               <l>Ch'avria pottuti generare in terra.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#oreadi">
             <speaker>OREADI</speaker>
             <lg>
               <l>Sono proprio da te queste parole,</l>
@@ -1806,7 +1867,7 @@
               <l>Noi con Diana rimarèn col nostro.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>E che credete voi che se ne stia</l>
@@ -1824,7 +1885,7 @@
               <l>Senza piacere alcun, sempre digiune.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#napee">
             <speaker>NAPEE</speaker>
             <lg>
               <l>Noi già digiune di piacer non siamo,</l>
@@ -1834,7 +1895,7 @@
               <l>De la nostra Diana.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Di Diana</l>
@@ -1846,7 +1907,7 @@
               <l>Non so se m'intendete.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#driadi">
             <speaker>DRIADI</speaker>
             <lg>
               <l>Or va' tra' Fauni,</l>
@@ -1854,7 +1915,7 @@
               <l>E lascia andar noi a Diana al bosco.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Ben fora il meglio che veniste a' Fauni,</l>
@@ -1869,14 +1930,14 @@
               <l>Del qual voi sete debitrici al mondo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#driadi">
             <speaker>DRIADI</speaker>
             <lg>
               <l>Che noi amiam quelle bestiaccie sozze,</l>
               <l>De' quai cosa non ha il mondo più brutta?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>In lor parte non è da capo a piedi</l>
@@ -1902,7 +1963,7 @@
               <l>Di questi Dei che voi chiamate sozzi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#napee">
             <speaker>NAPEE</speaker>
             <lg>
               <l>Poi che tu vuoi da' Dei l'essempio tòrre,</l>
@@ -1912,7 +1973,7 @@
               <l>Che si mostran di noi così bramosi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Udito ho sempre dir che quello amore</l>
@@ -1939,7 +2000,7 @@
               <l>Potrete ben sperar, non temer male.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#oreadi">
             <speaker>OREADI</speaker>
             <lg>
               <l>Or non ci dar più noia: esser può prima</l>
@@ -1947,7 +2008,7 @@
               <l>Di noi por possa amore a questi mostri.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>I' vi so dir che non andrete molto</l>
@@ -1970,14 +2031,14 @@
               <l>Le selve già felici de l'Arcadia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#driadi">
             <speaker>DRIADI</speaker>
             <lg>
               <l>Vadano pur, che non ne cal di loro,</l>
               <l>Come se non gli avessimo unqua visti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>I miseri n'andranno e sono in via</l>
@@ -1989,7 +2050,7 @@
               <l>Del lor amor, de la durezza vostra.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#napee">
             <speaker>NAPEE</speaker>
             <lg>
               <l>Ben sentiti gli abbiamo e n'è piaciuto</l>
@@ -1998,7 +2059,7 @@
               <l>Però tempo è che ce n'andiamo al bosco.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Ahi crude più d'ogni selvaggia fiera,</l>
@@ -2017,7 +2078,7 @@
               <l>Essi sdegnano ciò che non è voi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#naiadi">
             <speaker>NAIADI</speaker>
             <lg>
               <l>A questi Satirini e picciol Fauni</l>
@@ -2031,7 +2092,7 @@
               <l>Ma di gran cortesia, di pietà piene.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Fate cosa lodevole e 'n lor vece</l>
@@ -2040,15 +2101,15 @@
               <l>Quando gli narrerò nuova sì buona.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#napee">
             <speaker>NAPEE</speaker>
             <l>Or con Dio rimanti, Egle.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l>Andate in pace.</l>
           </sp>
-          <sp>
+          <sp who="#oreadi">
             <speaker>OREADI</speaker>
             <lg>
               <l>Uno fermo proposito che 'n donna</l>
@@ -2061,7 +2122,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>EGLE <hi rend="italic">sola</hi></stage>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Non è d'apparecchiare a alcuno insidie</l>
@@ -2086,7 +2147,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>SATIRO, EGLE, FAUNO</stage>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>O che sia il troppo desiderio mio</l>
@@ -2101,14 +2162,14 @@
               <l>Che l'accrescono più, che 'l fan più fermo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Che non può fare Amor con la sua fiamma,</l>
               <l>Poi che dice costui cose sì gravi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Al venir fuor de la spelonca usata,</l>
@@ -2127,14 +2188,14 @@
               <l>Mi fece tristo augurio ne la selva.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Che pazzia è questa, che gli augelli il mondo</l>
               <l>Tema, se la natia lor voce fanno?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Poco dopo mi venne incontro un toro,</l>
@@ -2151,14 +2212,14 @@
               <l>A l'astuto veder de la nostra Egle.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Lodato Bacco, ch'anch'io merto lode</l>
               <l>E son di qualche pregio in queste selve.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>E a la simplicità di queste ninfe,</l>
@@ -2169,7 +2230,7 @@
               <l>Onoriamo ambo lor con tutto il core.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Non voglio più tardar: di che ti dogli?</l>
@@ -2177,7 +2238,7 @@
               <l>Or che siam per accòr le augelle al visco?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Mi tengono tra due speme e timore,</l>
@@ -2189,7 +2250,7 @@
               <l>Se buona nuova da le ninfe porti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>FAUNO</speaker>
             <lg>
               <l>Venuto son anch io, poi che v'ho visti</l>
@@ -2197,7 +2258,7 @@
               <l>Nova hai da queste nostre aspre nemiche.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>La nova è, frate mio, che dopo ch'io</l>
@@ -2213,7 +2274,7 @@
               <l>Pensasser di far festa.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Ben pensasti,</l>
@@ -2221,7 +2282,7 @@
               <l>Di qualche inganno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Adunque ov'io deveva</l>
@@ -2230,11 +2291,11 @@
               <l>Satiri e Fauni.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <l>Et a qual fine questo?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Il saperai, s'ascolti. Esse, credendo</l>
@@ -2242,21 +2303,21 @@
               <l>Dissero di voler per figli accòrgli.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Non veggio ancor che ciò nulla ne giovi</l>
               <l>O ne dia speme alcuna.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Se sei cieco,</l>
               <l>Che vuoi ch'io te ne faccia?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Aprimi gli occhi</l>
@@ -2264,7 +2325,7 @@
               <l>Veder non ho saputo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Ite a la caccia</l>
@@ -2275,7 +2336,7 @@
               <l>Come t'ho detto che promesso m'hanno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>FAUNO</speaker>
             <lg>
               <l>Non so veder che quindi avenir altro</l>
@@ -2284,14 +2345,14 @@
               <l>Ch'a ciò non pensan, sian da loro accolti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Veggio, misero me, che saran veri</l>
               <l>Gli augurii di che dianzi i' dicea meco.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Lasciami, se tu vuoi, giungere al fine,</l>
@@ -2302,7 +2363,7 @@
               <l>Men grave gli sarà mancar de' padri.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Incomincio a veder ciò che vuoi fare,</l>
@@ -2312,7 +2373,7 @@
               <l>Esser pens'oggi sol per te felice.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Esse, che più non temeranno insidie,</l>
@@ -2329,7 +2390,7 @@
               <l>Ogni cosa a buon fine?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>FAUNO</speaker>
             <lg>
               <l>Egle mia dolce,</l>
@@ -2343,25 +2404,25 @@
               <l>Se n'andava ogni cosa a la malora.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Saper bisogna usare il luoco e 'l tempo</l>
               <l>A chi una cosa vuoi condure al fine.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#fauno">
             <speaker>FAUNO</speaker>
             <l>Ma entriam nel bosco a dar la nova a gli altri.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Entriam, ma vi bisogna stare ascosi,</l>
               <l>Sì che non diate lor di ciò sospetto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Come avaro bifolco, poi che 'n terra</l>
@@ -2429,7 +2490,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>PANE <hi rend="italic">solo</hi></stage>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Che giova a me l'esser d'Arcadia Dio,</l>
@@ -2532,7 +2593,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>SIRINGA, PANE</stage>
-          <sp>
+          <sp who="#siringa">
             <speaker>SIRINGA</speaker>
             <lg>
               <l>Io mi meravigliava aver vist'oggi</l>
@@ -2561,14 +2622,14 @@
               <l>E 'l camin preso avean verso la Spagna.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Che cosa od'io? Non ho già udito dire</l>
               <l>Oggi di tal partenza ad alcun Fauno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>SIRINGA</speaker>
             <lg>
               <l>Diana si mostrò di ciò assai lieta,</l>
@@ -2582,7 +2643,7 @@
               <l>Mi ha dato noia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Intendi, s'hai orecchio,</l>
@@ -2590,7 +2651,7 @@
               <l>O miser me, o 'nfelice!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>SIRINGA</speaker>
             <lg>
               <l>Non perch'io</l>
@@ -2598,14 +2659,14 @@
               <l>Del mio primo pensier fisso in diamante </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Ahi miser me, dov'ho io posto speme?</l>
               <l>Per chi mi consumo io? per chi mi struggo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>SIRINGA</speaker>
             <lg>
               <l>Ma perché non è rocca sì munita,</l>
@@ -2626,7 +2687,7 @@
               <l>Mal grado suo, il farò lontano starmi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Ahi Siringa crudel, Siringa ingrata,</l>
@@ -2642,7 +2703,7 @@
               <l>E non m'esser cagion di tanto affanno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>SIRINGA</speaker>
             <lg>
               <l>Io lo ti ho detto, Pane, e tel ridico,</l>
@@ -2652,7 +2713,7 @@
               <l>Ch'io ti lasciassi pur toccarmi il lembo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Siringa, tu non sai chi tu disprezzi:</l>
@@ -2689,14 +2750,14 @@
               <l>Per averli verresti assai più pia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>SIRINGA</speaker>
             <lg>
               <l>Non, se fussero tutti oro e diamanti.</l>
               <l>Tienliti pur, ch'io non mi curo averli.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Ahi poco saggia ninfa, ancor che sii</l>
@@ -2726,11 +2787,11 @@
               <l>Quantunque egli dal ciel fulmini e tuoni.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>SIRINGA</speaker>
             <l>Ve' che sozzo animal si vuol far bello!</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Oltre di ciò, ti puon far chiara fede</l>
@@ -2745,7 +2806,7 @@
               <l>Con più felice fin che non fé' Marsia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>SIRINGA</speaker>
             <lg>
               <l>Io m'[a]llegro con te di virtù tale,</l>
@@ -2753,7 +2814,7 @@
               <l>Però non spender più parole indarno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Siringa, se non vuoi di me far stima,</l>
@@ -2771,14 +2832,14 @@
               <l>E mille son da me per te sprezzate.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>SIRINGA</speaker>
             <lg>
               <l>Però non voglio fare ingiuria a l'altre:</l>
               <l>Ama chi t'ama e non mi dar più noia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Deh s'altro non mi vuoi, Siringa, dare,</l>
@@ -2792,7 +2853,7 @@
               <l>Con un bascio ristori i danni miei.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>SIRINGA</speaker>
             <lg>
               <l>Un bascio? Donna che cortese sia</l>
@@ -2800,7 +2861,7 @@
               <l>Ch'appresso me più mai non sarà casta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Tu te 'nganni, Siringa: un bascio è poco,</l>
@@ -2808,7 +2869,7 @@
               <l>Deh non lo mi negar, vita mia cara.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>SIRINGA</speaker>
             <lg>
               <l>Non mi t'accostar, Pan, che se questo arco</l>
@@ -2817,7 +2878,7 @@
               <l>Che non avrai più ardir venirmi appresso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Ahi che vuoi far, Siringa? T'hai pur troppo</l>
@@ -2832,7 +2893,7 @@
               <l>In pietà muterai la crudeltade.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>SIRINGA</speaker>
             <lg>
               <l>Non mi ha voluto far la grazia il cielo</l>
@@ -2840,7 +2901,7 @@
               <l>Che co' silvestri Dei tu ti sia gito.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Siringa, me n'andrò pria che sia sera,</l>
@@ -2854,7 +2915,7 @@
               <l>Cara Siringa mia, ch'io la ti tocchi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>SIRINGA</speaker>
             <lg>
               <l>Stammi lontan, lo ti ho pur anco detto,</l>
@@ -2865,7 +2926,7 @@
               <l>E non mi venir più dinanzi a gli occhi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Benché, da te partendo, io abbandoni</l>
@@ -2881,7 +2942,7 @@
               <l>Un Dio ninfa gentil, tanto io t'ho amato.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>SIRINGA</speaker>
             <lg>
               <l>Or non più, Pan, Diana è qui vicina,</l>
@@ -2889,25 +2950,25 @@
               <l>Me ne voglio ir.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Deh ferma, ninfa, il passo,</l>
               <l>Non mi ti tòrre ancor.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>SIRINGA</speaker>
             <lg>
               <l>Lasciami, Pane,</l>
               <l>Se non ti vuoi pentir d'avermi vista.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <l>Deh lascia ch'io ti tocchi almen la mano.</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>SIRINGA</speaker>
             <lg>
               <l>Lasciami, dico, ch'io non son più sola,</l>
@@ -2915,29 +2976,29 @@
               <l>E guai a te, se tu mi fai chiamarle.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Non m'esser sì crudel, ninfa gentile,</l>
               <l>Abbi pietà del mio angoscioso affanno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>SIRINGA</speaker>
             <l>Tu mi farai gridar.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <l>Grida a tua voglia.</l>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>SIRINGA</speaker>
             <lg>
               <l>Diana, aiuto, che mi vuoi far forza</l>
               <l>Questo villan di Pane!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Ecco io ti lascio,</l>
@@ -2949,7 +3010,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>PANE, SILVANO</stage>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Maledetta Diana e le sue ninfe,</l>
@@ -2994,14 +3055,14 @@
               <l>Del tuo dolor, al far vendetta giusta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <lg>
               <l>Gravi querele son queste, ch'i' odo,</l>
               <l>E mi paion di Pan, nostro gran Dio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Ma c'ha voluto dir la mia Siringa,</l>
@@ -3009,7 +3070,7 @@
               <l>I Satiri e i Silvan da queste selve?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <lg>
               <l>Pane, che ci è che ti lamenti tanto</l>
@@ -3017,7 +3078,7 @@
               <l>Che sono tutti i Dei silvestri in gioia?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Scacci il duolo chi vòle e si rallegri:</l>
@@ -3027,7 +3088,7 @@
               <l>Quanto più mesto son, tanto più gode.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <lg>
               <l>E qual è la cagion del tuo dolore?</l>
@@ -3035,7 +3096,7 @@
               <l>Potrei al tuo languir porger rimedio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Silvano, tu non sai quello ch'è noto</l>
@@ -3049,7 +3110,7 @@
               <l>Speme da lei di ritrovar mai pace.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <lg>
               <l>Pan, peggio non si può far ne gli affanni,</l>
@@ -3059,14 +3120,14 @@
               <l>Forse empir ti potrà d'allegrezza anco.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Il so, ma come che costei si mute,</l>
               <l>Allegrezza per me non n'escie mai.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <lg>
               <l>Ma dimmi: non è ella quella ninfa,</l>
@@ -3076,18 +3137,18 @@
               <l>Creder che fosse ella Diana istessa?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <l>Ell'è quella, Silvan.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <lg>
               <l>Or l'ho veduta</l>
               <l>Gir con Diana. </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l> Ohimè, ch'ella mi ha tolto</l>
@@ -3098,7 +3159,7 @@
               <l>Esser più vivo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <lg>
               <l>Ben ti stimo sciocco,</l>
@@ -3107,7 +3168,7 @@
               <l>Per ogni stran, per ogni incolto bosco.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Pari a lei non se n'ha, Silvano mio,</l>
@@ -3118,11 +3179,11 @@
               <l>Et intesa i' non l'ho.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <l>Che cosa è questa?</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Ch'essendosi partiti gli altri Fauni,</l>
@@ -3131,15 +3192,15 @@
               <l>Non sapea, né so nulla.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <l>E c'hai risposto?</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <l>Ch'anch'io mi volea gir.</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <lg>
               <l>Ve' come il caso</l>
@@ -3150,14 +3211,14 @@
               <l>Così maninconioso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Ora ch'è questo,</l>
               <l>Caro Silvan?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <lg>
               <l>La tua allegrezza certa,</l>
@@ -3165,7 +3226,7 @@
               <l>Sì lieto far che più non sarai mesto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Ahi caro il mio Silvan, non mi dir fole,</l>
@@ -3174,18 +3235,18 @@
               <l>Elli ritorneria più che mai grande!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <lg>
               <l>I' vo' che questa sera di Siringa</l>
               <l>Tu goda.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <l>Questa sera?</l>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <lg>
               <l>Questa sera.</l>
@@ -3193,7 +3254,7 @@
               <l>De le lor ninfe.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Or che potria più affanno</l>
@@ -3201,7 +3262,7 @@
               <l>Dimmi il vero, Silvan.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <lg>
               <l>Così vedere</l>
@@ -3214,14 +3275,14 @@
               <l>Le ninfe lor.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Ma ch'è mestier ch'io faccia,</l>
               <l>Perché mi goda di Siringa anch'io?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <lg>
               <l>Poi che l'hai detto di voler partirti,</l>
@@ -3240,14 +3301,14 @@
         <div type="scene">
           <head>SCENA IIII</head>
           <stage>AMADRIADI,<hi rend="italic">altre</hi>NINFE, EGLE, SATIRI PICCIOLI, SIRINGA</stage>
-          <sp>
+          <sp who="#amadriadi">
             <speaker>AMADRIADI</speaker>
             <lg>
               <l> Molti mesi ha che più felice caccia</l>
               <l>Noi fatto non abbiam di quella d'oggi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ninfe">
             <speaker>NINFE</speaker>
             <lg>
               <l>Ell'è stata felice, ma di molto</l>
@@ -3258,7 +3319,7 @@
               <l>Che pericolo in sé tengano i boschi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amadriadi">
             <speaker>AMADRIADI</speaker>
             <lg>
               <l>Ben dimostrò Diana ch'i suoi colpi</l>
@@ -3271,7 +3332,7 @@
               <l>Che subito ei restò di vita privo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ninfe">
             <speaker>NINFE</speaker>
             <lg>
               <l>Quanto fu bel veder gli aggiramenti</l>
@@ -3281,7 +3342,7 @@
               <l>Tra' denti, si tornò ne la sua macchia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amadriadi">
             <speaker>AMADRIADI</speaker>
             <lg>
               <l>Ma chi avria mai pensato di vedere</l>
@@ -3292,7 +3353,7 @@
               <l>Fosse a i figli cagion del nascimento?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ninfe">
             <speaker>NINFE</speaker>
             <lg>
               <l>Ciò fu bello a veder, ma via più bello</l>
@@ -3308,11 +3369,11 @@
               <l>Vo' che qui l'aspettiam.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amadriadi">
             <speaker>AMADRIADI</speaker>
             <l>Come ti piace.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Figliuoli miei, bisogna che sappiate</l>
@@ -3325,7 +3386,7 @@
               <l>Ovunque io vedrò che sia bisogno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiri_piccioli">
             <speaker>SATIRI PICCIOLI</speaker>
             <lg>
               <l> noi ci sforzeremo in questa nostra</l>
@@ -3334,21 +3395,21 @@
               <l>Non ne venga pur men di favor Bacco.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Così bisogna che facciate. Andiamo,</l>
               <l>E mostratevi tutti in viso mesti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ninfe">
             <speaker>NINFE</speaker>
             <lg>
               <l>Ti sii la ben venuta, Egle; che buona</l>
               <l>Nova ci apporta la venuta tua?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Nova buona non han più queste selve,</l>
@@ -3363,7 +3424,7 @@
               <l>E datevi a la fé di queste ninfe.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiri_piccioli">
             <speaker>SATIRI PICCIOLI</speaker>
             <lg>
               <l>Ninfe cortesi, ancor che senza pianto</l>
@@ -3377,7 +3438,7 @@
               <l>Perduto il suo pastor, greggia infelice.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ninfe">
             <speaker>NINFE</speaker>
             <lg>
               <l>Non vi saremo men che madri pie.</l>
@@ -3386,7 +3447,7 @@
               <l>De' Satiri maggior l'aspra lascivia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Non è da dubitar ch'al viver vostro</l>
@@ -3418,21 +3479,21 @@
               <l>Forse contenti più che non siam ora</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amadriadi">
             <speaker>AMADRIADI</speaker>
             <lg>
               <l>Anzi verrenvi molto volentieri,</l>
               <l>Poi che noi vi possiam venir sicure.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>SIRINGA</speaker>
             <lg>
               <l>Deh di grazia dimmi, Egle, se d'Arcadia</l>
               <l>Partito s'è co gli altri Fauni Pane?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Partito s'è pur troppo lo 'nfelice,</l>
@@ -3446,7 +3507,7 @@
               <l>Amante sì fedel, fuor di ragione.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>SIRINGA</speaker>
             <lg>
               <l>Dolgasi egli di sé, che si è voluto</l>
@@ -3454,7 +3515,7 @@
               <l>Io non lo 'ndussi mai ch'egli m'amasse.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Estender non mi voglio in dimostrarti</l>
@@ -3465,14 +3526,14 @@
               <l>Reprenderai.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#siringa">
             <speaker>SIRINGA</speaker>
             <lg>
               <l>I' non son per pentirmi</l>
               <l>Mai de l'onestà mia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Te n'avedrai</l>
@@ -3484,7 +3545,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>EGLE, SILENO</stage>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Chi fia chi dica che d'ingegno manchi</l>
@@ -3499,7 +3560,7 @@
               <l>Ch'i Satir de le ninfe avran vittoria.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <lg>
               <l>Tu mi farai uscir del corpo l'alma</l>
@@ -3512,7 +3573,7 @@
               <l>A te, se fatto tu m'avessi oltraggio!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>E se fatto l'avessi ben, che fora?</l>
@@ -3520,27 +3581,27 @@
               <l>Poi c'hai le corna per natura in capo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <lg>
               <l>Tu mi dileggi, ribaldella? Dammi</l>
               <l>Un bascio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Volentieri.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <lg>
               <l>Or prendi 'l fiasco</l>
               <l>E ricreati un poco.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>I' n'ho bisogno,</l>
@@ -3548,19 +3609,19 @@
               <l>In ridur queste ninfe a le mie voglie.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <l>E c'hai tu fatto?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l>Lasciami ber prima.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <l>Bevi, che dato i' t'ho per questo il fiasco.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>O che buon vino è questo! I' me ne sento</l>
@@ -3570,21 +3631,21 @@
               <l>Et onde l'hai tu avuto?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <lg>
               <l>Il mio Marone</l>
               <l>Da la mensa di Bacco oggi l'ha tolto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>So ch'ei conosce il buono. I' non mi posso</l>
               <l>Saziar di ber.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <lg>
               <l>Vedi s'io m'arricordo,</l>
@@ -3593,7 +3654,7 @@
               <l>Una gran sete.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>I' ti farei ingiuria,</l>
@@ -3603,7 +3664,7 @@
               <l>Basciar questo sarà che le mie labbra.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <lg>
               <l>Questo non già, che più dolce che manna</l>
@@ -3614,11 +3675,11 @@
               <l>Potta di Bacco, i' non bevi mai meglio!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l>Bevilo tutto, ch'io non ho più sete.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <lg>
               <l>Senza che tu mel dica, i' l'ho bevuto,</l>
@@ -3626,7 +3687,7 @@
               <l>Or c'hai fatto pe' Fauni?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Hanno le ninfe,</l>
@@ -3635,7 +3696,7 @@
               <l>Secondo l'ordin dato, in braccio a' Fauni.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <lg>
               <l>Ah ah, ah ah, i' lodo il Signor Bacco,</l>
@@ -3643,7 +3704,7 @@
               <l>Vorrei anch'io poter d'una godere.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Deh vecchiaccio che sei, non ti par ch'io</l>
@@ -3652,14 +3713,14 @@
               <l>(Poi ch'io non son per te) vo' provedermi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <lg>
               <l>Non ti adirar, vita mia cara, i' giuoco</l>
               <l>Con te, nol vedi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Non mi par bel giuoco</l>
@@ -3668,41 +3729,41 @@
               <l>Ch'io non vorrei morirmi de la fame.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <l>Che dirai, pazzarella?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>M'hai intesa, </l>
               <l>Non mi vo' veder tòr la vittuaglia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <l>Entriam nel bosco, che farem la pace.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l>I' non vi vo' venir.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <l>Perché?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l>Non voglio.</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <lg>
               <l>Deh vien, di grazia! So che gita al naso</l>
               <l>Ti è subito la colera.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Cagione</l>
@@ -3711,14 +3772,14 @@
               <l>Ch'io non verrei ove tu fossi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <lg>
               <l>Eh andiamo, </l>
               <l>Car'Egle mia, nel bosco. Eh vien, di grazia!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Va', ch'io ti seguo. Non è cosa al mondo</l>
@@ -3729,7 +3790,7 @@
               <l>E chiaro or visto i' l'ho nel mio Sileno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Or che siam per por fine a' nostri affanni</l>
@@ -3785,7 +3846,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>EGLE, SATIRI</stage>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Sapete ove la cosa è già condotta:</l>
@@ -3793,14 +3854,14 @@
               <l>Astuzia nel pigliar le fiere in caccia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiri">
             <speaker>SATIRI</speaker>
             <lg>
               <l>Pericol più non v'è, poi che ce l'hai</l>
               <l>Con l'arte tua quasi condotte in mano.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Non vo' che vi paia esser sì sicuri,</l>
@@ -3816,14 +3877,14 @@
               <l>Tutto quel che fatto è sarebbe nulla.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiri">
             <speaker>SATIRI</speaker>
             <lg>
               <l>Da noi non mancherà che con ingegno</l>
               <l>Non sia provisto a ogni possibil cosa.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l> Dunque io me n'andrò dritto a trovarle</l>
@@ -3833,7 +3894,7 @@
               <l>Pigliatevi a la preda.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiri">
             <speaker>SATIRI</speaker>
             <lg>
               <l>Vanne e credi</l>
@@ -3852,21 +3913,21 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>NINFE, EGLE, SATIRI PICCIOLI, SATIRO<hi rend="italic">grande</hi>CORO</stage>
-          <sp>
+          <sp who="#ninfe">
             <speaker>NINFE</speaker>
             <lg>
               <l>State sicuri pur d'aver trovato</l>
               <l>Un perpetuo riposo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>E voi d'avere</l>
               <l>L'inciampo ritrovato.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiri_piccioli">
             <speaker>SATIRI PICCIOLI</speaker>
             <lg>
               <l>Certo nulla</l>
@@ -3874,7 +3935,7 @@
               <l>Ci avete mostro e tal carezze fatte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ninfe">
             <speaker>NINFE</speaker>
             <lg>
               <l>Ogni giorno averete maggior segno</l>
@@ -3882,7 +3943,7 @@
               <l>Ma vedete Egle vostra.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Figli miei,</l>
@@ -3891,7 +3952,7 @@
               <l>Contenti, ogni dolor da me è fuggito.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiri_piccioli">
             <speaker>SATIRI PICCIOLI</speaker>
             <lg>
               <l>Ci hanno, Egle, queste ninfe tanto amore</l>
@@ -3902,14 +3963,14 @@
               <l>Ch'aver non potevam maggior conforto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Io non me ne credetti altro giamai,</l>
               <l>Tanto cortesemente i' vidi accòrvi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ninfe">
             <speaker>NINFE</speaker>
             <lg>
               <l>Gli ha saputo un po' strano il bever l'acqua,</l>
@@ -3918,7 +3979,7 @@
               <l>De la compagnia nostra.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>È de l'etade</l>
@@ -3933,7 +3994,7 @@
               <l>( Posto il vino in oblio) non gli fin noia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiri_piccioli">
             <speaker>SATIRI PICCIOLI</speaker>
             <lg>
               <l>Anzi insin or non n'è spiacciuto il berne,</l>
@@ -3946,7 +4007,7 @@
               <l>Le chiederemo a far con noi un ballo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>E perché ricusar deono lo 'nvito?</l>
@@ -3957,11 +4018,11 @@
               <l>Ninfe si sdegnin di danzar con voi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ninfe">
             <speaker>NINFE</speaker>
             <l>Non già, per nostra fé.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Voi fate bene,</l>
@@ -3969,25 +4030,25 @@
               <l>Per donna al mondo, voi avete a schivo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ninfe">
             <speaker>NINFE</speaker>
             <l>E qual è questo?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Amare e de lo amore</l>
               <l>Goder d'un uom che s'ami.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ninfe">
             <speaker>NINFE</speaker>
             <lg>
               <l>Tu sei pure,</l>
               <l>Egle, su le sciocchezze.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Anz'io vi dico</l>
@@ -3997,33 +4058,33 @@
               <l>E sollazzarsi onestamente insieme.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ninfe">
             <speaker>NINFE</speaker>
             <l>Facciam come ti par.</l>
           </sp>
-          <sp>
+          <sp who="#satiro_grande">
             <speaker>SATIRO GRANDE</speaker>
             <lg>
               <l>Son quasi al fine</l>
               <l>Le cose.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Vuoi che usciamo?</l>
           </sp>
-          <sp>
+          <sp who="#satiro_grande">
             <speaker>SATIRO GRANDE</speaker>
             <lg>
               <l>State cheti,</l>
               <l>Non vi scoprite, che non è ancor tempo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Ohimè, quando fia l'ora?</l>
           </sp>
-          <sp>
+          <sp who="#ninfe">
             <speaker>NINFE</speaker>
             <lg>
               <l>E come in ballo</l>
@@ -4031,7 +4092,7 @@
               <l>Che tra noi suoni?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiri_piccioli">
             <speaker>SATIRI PICCIOLI</speaker>
             <lg>
               <l>Se fosse tra noi</l>
@@ -4039,36 +4100,36 @@
               <l>Di noi e parte si daria a danzare.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Ma non sapete voi se sempre meco</l>
               <l>Porto le fistole io?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiri_piccioli">
             <speaker>SATIRI PICCIOLI</speaker>
             <lg>
               <l>Dalleci adunque,</l>
               <l>Che sonarem.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l>Tenete.</l>
           </sp>
-          <sp>
+          <sp who="#satiro_grande">
             <speaker>SATIRO GRANDE</speaker>
             <lg>
               <l>State in punto,</l>
               <l>Che 'l tempo vien che se n'entriamo in caccia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>A l'ordine noi siamo.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>A coppia, a coppia</l>
@@ -4083,11 +4144,11 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>SATIRO, CORO, SILENO, PANE, NINFE, [EGLE, SATIRI PICCIOLI]</stage>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <l>State a l'ordine, dico.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Siàn pur troppo</l>
@@ -4098,14 +4159,14 @@
               <l>Mancar la vita.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Non è ancora il tempo</l>
               <l>D'uscir, fratelli miei.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Non veggiàn l'ora</l>
@@ -4116,7 +4177,7 @@
               <l>Sostien quella vitina!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Con che grazia</l>
@@ -4126,7 +4187,7 @@
               <l>Leggiadramente al suon col piè risponde!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Ma vedi che a noi vien Sileno e Pane.</l>
@@ -4135,14 +4196,14 @@
               <l>Che vi è Sileno?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <lg>
               <l>Son venuto anch'io</l>
               <l>A veder questa festa.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Deh sta' indietro</l>
@@ -4151,7 +4212,7 @@
               <l>Non odi tu, Silen?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <lg>
               <l>Tu mi vuoi fare</l>
@@ -4161,54 +4222,54 @@
               <l>Fuor de la selva: va' inanzi!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Eh non fare,</l>
               <l>Caro Sileno!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <lg>
               <l>I' voglio andar: va' là!</l>
               <l>Vo' che tutti costor paiano bestie.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Costui è ubriaco.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <l>A punto il vin lavora!</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Non ci turbar, Silen; Silen mio, resta:</l>
               <l>Non voler ch'un tuo sdegno ci disfaccia!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <l>Per amor tuo mi rimarrò.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>È Siringa</l>
               <l>Forse nel ballo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Ella al fin de la danza</l>
               <l>Git'è con l'altre ninfe e con lor siede.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>La veggio: ahi fiera, ahi soperbetta, ahi schifa,</l>
@@ -4217,7 +4278,7 @@
               <l>Ma che tardiamo più?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Lascia che 'n ballo</l>
@@ -4225,7 +4286,7 @@
               <l>Che guida la carola.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Ohimè che vita!</l>
@@ -4234,21 +4295,21 @@
               <l>Io mi dileguo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Tempo è di far segno,</l>
               <l>Satiro, a gli altri.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ninfe">
             <speaker>NINFE</speaker>
             <lg>
               <l>Avete udito quello</l>
               <l>Sibilo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>È nulla: fia qualche pastore</l>
@@ -4256,25 +4317,25 @@
               <l>Seguiamo il ballo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ninfe">
             <speaker>NINFE</speaker>
             <lg>
               <l>Son quasi rimasa</l>
               <l>Fuori di me.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Tu temi ben di poco.</l>
               <l>Su a la danza, sonate!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#satiri_piccioli">
             <speaker>SATIRI PICCIOLI</speaker>
             <l>Noi soniamo.</l>
           </sp>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <lg>
               <l>Ora animosamente tutti a un tratto</l>
@@ -4286,7 +4347,7 @@
         <div type="scene">
           <head>SCENA IIII</head>
           <stage>NINFE, CORO, PANE, EGLE, SILENO</stage>
-          <sp>
+          <sp who="#ninfe">
             <speaker>NINFE</speaker>
             <lg>
               <l>O poverelle noi ninfe, siam morte!</l>
@@ -4294,53 +4355,53 @@
               <l>I Satiri e i Silvani, o triste noi!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Eh non fuggite, che temete? Siamo</l>
               <l>I vostri amanti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ninfe">
             <speaker>NINFE</speaker>
             <lg>
               <l>Ahi Egle, ohimè malvagia!</l>
               <l>O noi semplici e sciocche!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Eh non fuggire,</l>
               <l>Siringa, eh non fuggire!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ninfe">
             <speaker>NINFE</speaker>
             <lg>
               <l>O meschinelle</l>
               <l>Che siamo!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Andate a quel varco! Un di voi:</l>
               <l>Piglia questa che vien verso la selva!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ninfe">
             <speaker>NINFE</speaker>
             <l>O noi misere e triste!</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Che tardate?</l>
               <l>Correte al bosco!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Sù Satir, sù Fauni,</l>
@@ -4349,39 +4410,39 @@
               <l>E ne le man le avrete?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ninfe">
             <speaker>NINFE</speaker>
             <lg>
               <l>Ahi malvagia Egle,</l>
               <l>Quest'è la fé?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l>Dove ne vai, Sileno?</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <lg>
               <l>Io vo' per dar soccorso a' miei compagni,</l>
               <l>Ch'anch'essi m'aiutar, quando io ti tolsi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>O che soccorso ? Mover non ti puoi,</l>
               <l>E gli vuoi dare aiuto?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <lg>
               <l>Prender voglio</l>
               <l>Questa che viene in qua.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Tosto, non state,</l>
@@ -4390,22 +4451,22 @@
               <l>Tenetele, pe' panni e per le gambe!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <l>A questa, a questa, tutti a dosso a questa!</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Ci fuggiran, non state a bada! Al bosco,</l>
               <l>Al bosco tutti, ch'elle al bosco vanno!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ninfe">
             <speaker>NINFE</speaker>
             <l>Ohimè dove siam giunte?</l>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <lg>
               <l>A dosso, a dosso,</l>
@@ -4416,7 +4477,7 @@
               <l>Ohimè!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Tel dissi io ben; sei tu ben atto</l>
@@ -4425,32 +4486,32 @@
               <l>Correr chi vuoi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <l>S'io lo facea per bene.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Avresti fatto meglio aver bevuto.</l>
               <l>Or levati, se puoi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <lg>
               <l>Dammi la mano,</l>
               <l>Aiutami.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Vorravvi altro potere</l>
               <l>Che 'l mio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <lg>
               <l>Dammi la mano, perché anch'io</l>
@@ -4459,7 +4520,7 @@
               <l>Ohimè!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Monta a caval: ve' che allegrezza</l>
@@ -4467,7 +4528,7 @@
               <l>Gli altri saran, sarai tu sul dolerti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sileno">
             <speaker>SILENO</speaker>
             <lg>
               <l>Non mica: tosto ch'averò bevuto,</l>
@@ -4480,7 +4541,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>SILVANO, PANE</stage>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <lg>
               <l>Ogni cosa nel bosco è sottosopra:</l>
@@ -4514,21 +4575,21 @@
               <l>Che nel ciel potria fare invidia a Giove.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Aver nemico il cielo e immaginarsi</l>
               <l>Poter condurre uno suo effetto al fine!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <lg>
               <l>Che lamentevol voce è questa ch'odo</l>
               <l>Uscir del bosco in così gran letizia?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>A chi ciò crede avien quel ch'è avenuto</l>
@@ -4537,7 +4598,7 @@
               <l>A che termine sei?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <lg>
               <l>Egli mi pare</l>
@@ -4545,18 +4606,18 @@
               <l>Egli di tristo, essendo ogniuno in gioia?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>O doloroso Pane, hai pur perduto</l>
               <l>Quanto di bene avevi!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <l>Che ci è, Pane?</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Potrai pur poverello a voglia tua</l>
@@ -4564,14 +4625,14 @@
               <l>D'offender la tua ninfa.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <lg>
               <l>Che avenuto</l>
               <l>T'è di dolente, Pan, che sì ti dogli?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Ohimè, Silvano, ohimè, tra queste selve,</l>
@@ -4581,7 +4642,7 @@
               <l>I più miseri siam che fossero unqua.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <lg>
               <l>Tu mi togli la vita, Pan: ch'è questo</l>
@@ -4589,7 +4650,7 @@
               <l>Vedervi lieti, s'oggi sete tristi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Avenuta, Silvan, ci è cosa tale,</l>
@@ -4597,11 +4658,11 @@
               <l>Sempre tristi sarem, sempre dolenti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <l>Deh fa' ch'io sappia, Pan, che cosa è questa.</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Silvano, non voler, se m'ami, udire</l>
@@ -4609,7 +4670,7 @@
               <l>Che 'ncredibile angoscia avrai a udirlo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <lg>
               <l>I' non posso sentir doglia maggiore</l>
@@ -4617,7 +4678,7 @@
               <l>Però non mi tener or più sospeso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Mentre, Silvan, le nostre care ninfe</l>
@@ -4645,14 +4706,14 @@
               <l>Divenner fior ne la minuta erbetta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <lg>
               <l>Ahi che mi di' tu, Pan? Che maraviglie</l>
               <l>Son queste ch'i' odo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Io non ti mento punto.</l>
@@ -4690,14 +4751,14 @@
               <l>Ninfa che l'avea fatto il cor di pietra.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <lg>
               <l>Non credo mai che 'n un sol giorno tante</l>
               <l>Mutazion fosser vedute.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>A nostro</l>
@@ -4707,14 +4768,14 @@
               <l>Languisca sempre e mi tormenti sempre.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <lg>
               <l>Perc'hai tu, Pan, maggior de gli altri doglia?</l>
               <l>Perché strugger ti vuoi tu più de gli altri?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Perché quant'era la Siringa mia</l>
@@ -4723,11 +4784,11 @@
               <l>Quanto era bella e quanto io già l'amai.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <l>Deh dimmi, Pan, che avenut'è di lei?</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>O sventurato me! Dopo ch'io vidi</l>
@@ -4752,7 +4813,7 @@
               <l>A pena il posso dir, mutarsi in canna.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <lg>
               <l>Né lo posso udir io senza gran doglia,</l>
@@ -4761,18 +4822,18 @@
               <l>A lato?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Ohimè, ch'io vo' sempre aver questo</l>
               <l>Per la più cara cosa ch'al mondo abbia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <l>E perché, Pan?</l>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Perché di quella canna,</l>
@@ -4781,14 +4842,14 @@
               <l>Suon la mia doglia e 'l mio angoscioso affanno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <lg>
               <l>E come in cor ti venne di comporre</l>
               <l>Tanti calami in un?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Non fu mutata</l>
@@ -4806,7 +4867,7 @@
               <l>Del caro nome suo, del mio dolore.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <lg>
               <l>Felice sei tu, Pan, appresso gli altri,</l>
@@ -4816,7 +4877,7 @@
               <l>Rifugio alcun, si pon ben chiamar tristi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Ohimè, caro Silvan, tanto più d'Ega</l>
@@ -4824,7 +4885,7 @@
               <l>Son gli amaranti de' minori fiori.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <lg>
               <l>Et io ti dico, Pan, ch'è più bell'Ega</l>
@@ -4832,14 +4893,14 @@
               <l>Nel più bel fior de' suoi più fioriti anni.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pane">
             <speaker>PANE</speaker>
             <lg>
               <l>Non più, Silvan, che tu m'accresci doglia.</l>
               <l>Vien meco, entra nel bosco a veder gli altri.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#silvano">
             <speaker>SILVANO</speaker>
             <lg>
               <l>Entra, ch'anch'io di subito ti seguo.</l>

--- a/tei/giraldi-cinzio-gli-eudemoni.xml
+++ b/tei/giraldi-cinzio-gli-eudemoni.xml
@@ -77,6 +77,55 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="lamprino">
+            <persName>Lamprino</persName>
+          </person>
+          <person xml:id="nastagio">
+            <persName>Nastagio</persName>
+          </person>
+          <person xml:id="chelidonia">
+            <persName>Chelidonia</persName>
+          </person>
+          <person xml:id="eutiche">
+            <persName>Eutiche</persName>
+          </person>
+          <person xml:id="linda">
+            <persName>Linda</persName>
+          </person>
+          <person xml:id="castaldo">
+            <persName>Castaldo</persName>
+          </person>
+          <person xml:id="carino">
+            <persName>Carino</persName>
+          </person>
+          <person xml:id="cosmo">
+            <persName>Cosmo</persName>
+          </person>
+          <person xml:id="ragazzo">
+            <persName>Ragazzo</persName>
+          </person>
+          <person xml:id="macaria">
+            <persName>Madonna Macaria</persName>
+          </person>
+          <person xml:id="capitano">
+            <persName>Capitano della Pregione</persName>
+          </person>
+          <person xml:id="fratello">
+            <persName>Fratello del Podestà</persName>
+          </person>
+          <person xml:id="lino">
+            <persName>Lino</persName>
+          </person>
+          <person xml:id="cavaliere">
+            <persName>Cavaliere del Podestà</persName>
+          </person>
+          <person xml:id="famiglio">
+            <persName>Famiglio</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -272,7 +321,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
         <div type="scene">
           <head>SCENA I </head>
           <stage>Lamprino servo, solo. </stage>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lampr.</speaker>
             <l>Quando i padron son vecchi e innamorati, </l>
             <l>È guadagno dei servi, che altrimenti </l>
@@ -309,7 +358,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
         <div type="scene">
           <head>SCENA II </head>
           <stage>Messer Nastagio, Lamprino </stage>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l>Egli è pur ver che le sue forze adopra </l>
             <l>Amor, più in là ch'altri non istima, e tale </l>
@@ -317,16 +366,16 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Chi crederia che in questa mia vecchiezza </l>
             <l>Potessi arder d'amor. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Io il crederei </l>
             <l>E molti altri, padron, </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Chi gli è che parla? </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Gli è Lamprino.Et che pare a voi novo </l>
             <l>Se d'amor sete acceso? Novo fora </l>
@@ -335,24 +384,24 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Come voi fate. Io ben conosco cento </l>
             <l>Giovani, che non son come voi siete. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> E non è dubbio, sassi. E' son gagliardi </l>
             <l>E nel fior de l'etade, ov'io son vecchio </l>
             <l>Et debole. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Io non vo, padron, dir questo. </l>
             <l>Vo dire io pur che sete, a quel che stimo, </l>
             <l>Più gagliardo di loro et più possente. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Vorrei che fosse il ver, ma ch'hai tu fatto </l>
             <l>Con donna Chelidonia? </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> È donna schifa </l>
             <l>Et mal credente. Vuol parlar coi suoi </l>
@@ -361,14 +410,14 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>A ciò disporla. Ma se si dispone, </l>
             <l>Non si può ritrovar meglio di lei. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Ma che bisogna far per ottenere </l>
             <l>Questo da lei? Se con denar piegarla </l>
             <l>Sì che mi serva, non son per far sparmio </l>
             <l>Di cinquanta fiorin. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Questa è una posta </l>
             <l>Da ottenere lo intento. Molte cose </l>
@@ -376,35 +425,35 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Che per denar si pieghi questa donna. </l>
             <l>Et se pur s'ha a piegar, ne vorrà molti. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Vadavi ciò che vuol, io desio avere </l>
             <l>Meco costei, che è fin d'ogni mia voglia; </l>
             <l>Ma cinquanta fiorini sono un bel dono. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Gnaffe s'è bello. Non è mal tentare, </l>
             <l>Padron, questa fortuna, perché l'oro </l>
             <l>L'impossibil possibil spesso face. </l>
             <l>Però ben fia che se n'andiamo a lei. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Anzi vi voglio andar; tu meco vieni, </l>
             <l>Né mi mancare, ove mi fia bisogno. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Non dubitare, che io son per fare </l>
             <l>Ogni cosa per voi a questa volta. </l>
             <l>Vedetela, padrone, ch'ella esce fuori. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Ve come bene siam venuti a tempo. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Siate accorto a pigliarla con bel mondo. </l>
           </sp>
@@ -412,25 +461,25 @@ PER DOMENICO TADDEI E FIGLI <lb/>
         <div type="scene">
           <head>SCENA III </head>
           <stage>Messer Nastagio, Chelidonia, Lamprino. </stage>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l>Madonna! </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Chi mi chiama? </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Udite </l>
             <l>Due parole. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Madonna, egli è il padrone, </l>
             <l>Di ch'hoggi vi parlai. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Se parlar vuole </l>
             <l>Di quel che tu m'hai detto, può restarsi. </l>
@@ -440,13 +489,13 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Non voglio or io che il compiacere a lui </l>
             <l>Mi faccia vergognar di me medesma. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Madonna, cosa alcuna io non vi cheggio </l>
             <l>Se non honesta, et credo che Lamprino </l>
             <l>Il tutto v'habbia detto. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> 	Egli m'ha detto </l>
             <l>Pur troppo; ma di vendere menzogne </l>
@@ -456,17 +505,17 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Per havere l'intento; e poiché l'hanno, </l>
             <l>Si solvon tutti i giuramenti in vento. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Credetemi, che va messer Nastagio </l>
             <l>A buon fin, certo. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Io non nacqui hjer sera, </l>
             <l>Lamprino. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> E che volete dir per questo? </l>
             <l>La prenderà per moglie. Non so s'ella </l>
@@ -476,85 +525,85 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Opre, piene d'honor, di caritade </l>
             <l>Voi non vi trapponete? </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> È molto destro </l>
             <l>Lamprino in questa trama. Un huom val cento, </l>
             <l>Et non vagliono uno cento. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Opre son queste </l>
             <l>Da gir cercando, non che d'accettarle </l>
             <l>Quando s'offron da se. Mostrate alquanto </l>
             <l>Di piegarvi. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Quando essere pur tale </l>
             <l>Dovesse il fin di ciò, m'adoprerei. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Vel dirà il mio padron. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Il ver v'ha detto </l>
             <l>Lamprin, Madonna; voi datemi aiuto </l>
             <l>Che buon per voi. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Non cerco io questo. Solo, </l>
             <l>Quando a tale opra pure io mi disponga, </l>
             <l>Per amore di Dio mi movo a farlo. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Deh! benedetta siate. Hora, padrone, </l>
             <l>Fatele cortesia, che è poverella </l>
             <l>Et è donna da ben. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Questi fiorini </l>
             <l>Voi vi terrete fino a che maggiore </l>
             <l>Dimostration farovvi. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Io vi ringratio, </l>
             <l>Dio ve lo merti. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Quando sarà tempo </l>
             <l>Di ritornare a voi per la risposta? </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Che ne poss'io saper? Se n'havrò l'agio </l>
             <l>C'andrò fino ad un'hora. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Fino ad un'hora </l>
             <l>Io venirò da voi. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Se voi verrete, </l>
             <l>Io vi farò saper quel che havrò fatto. </l>
             <l>Ma sassi Dio, s'io le potrò parlare. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> So che non mancherete, andate in pace. </l>
             <l>Tu non ti pentirai, Lamprino mio, </l>
             <l>D'havermi dato aita. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> In fino ad hora </l>
             <l>I' non mi pento. Che dovrei pentirmi </l>
@@ -562,7 +611,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Venti fiorini? Io vi ho, padron, servito </l>
             <l>Con tutto il cuor. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Lamprino, io t'ho venduto, </l>
             <l>Io mi lodo di te. Vo girmi a casa. </l>
@@ -572,7 +621,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Che la parte ne porti a questa vecchia, </l>
             <l>Che haver la voglio amica. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Andrò, padrone. </l>
           </sp>
@@ -580,7 +629,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
         <div type="scene">
           <head>SCENA IV </head>
           <stage>Lamprino solo.</stage>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lampr.</speaker>
             <l> Per Dio, per Dio, che ben bisogna aprire </l>
             <l>	Gli occhi oggidì. Chi non havria creduto, </l>
@@ -608,7 +657,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
         <div type="scene">
           <head>SCENA I </head>
           <stage>Chelidonia sola. </stage>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Dappoi che cominciai pormi a quest'arte, </l>
             <l>Non ebbi mai occasion si grande </l>
@@ -642,7 +691,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
         <div type="scene">
           <head>SCENA II </head>
           <stage>Chelidonia, Eutiche. </stage>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Che vi è, dimmi, che vi è, che se' sì trista? </l>
             <l>	Io non credo che al mondo si ritrovi </l>
@@ -656,71 +705,71 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>	Vedere anco per me chiaro un dì il sole. </l>
             <l>	Che mi sapete dir, madre mia dolce? </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chelid.</speaker>
             <l> M'hai tu forse portato quel presciutto, </l>
             <l>	Ch'heri mi promettesti? </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l>.Oh, che risposta! </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chelid.</speaker>
             <l> Tu cerchi il fatto tuo, io cerco il mio. </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Il porterò dimani. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chelid.</speaker>
             <l> Anch'io dimani </l>
             <l>Havrò che dirti. </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Deh non mi sfuggite, </l>
             <l>Non vi son già mancata in fino ad hora, </l>
             <l>Che dobbiate temer. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Dammi la fede </l>
             <l>Di portarlo diman. </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Tosto che io torni </l>
             <l>Che novella mi date? </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Io non l'ho visto. </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Ahi! Guajo, oimè! son io trista e infelice </l>
             <l>Più d'ogni donna! Ov'io ho posto spene? </l>
             <l>Quanto più giustamente potrei dirmi </l>
             <l>Infelice, che Eutiche! </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Vuoi morire? </l>
             <l>Io l'ho veduto. </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Che v'ha egli detto? </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Eutiche, se havrai cor tu di far quello </l>
             <l>Ch'egli m'ha detto, sempre il goderai </l>
             <l>A voglia tua, sempre sarai felice. </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Per lo fuoco anderei, pur ch'io sapessi </l>
             <l>Di far cosa che fosse a lui a grado, </l>
@@ -729,7 +778,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Di dote del mio padre, che la sola </l>
             <l>Honestà, vo salvarla. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Come a grado </l>
             <l>T'è, fa di te medesma. Dio volesse </l>
@@ -741,31 +790,31 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Che mi ha giurato di non ti toccare, </l>
             <l>Se prima non ti prende per sua moglie. </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> O Dio volesse che ciò fosse il vero. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Vero fia certo. </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Che bisogna fare </l>
             <l>Perché ciò segua? </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Torre in collo un monte </l>
             <l>Ovver passare il mar. Far ti bisogna </l>
             <l>Una cosa da nulla ad ottenere </l>
             <l>Tanta allegrezza. </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Et che? </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Tu l'udirai, </l>
             <l>Felice sarai se il buon scerre tu voglia. </l>
@@ -783,67 +832,67 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Io non le voglio por le mani addosso, </l>
             <l>Che io non la sposi et per mia moglie l'habbia. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> A me piacque il partito et giudicai </l>
             <l>Che ben saresti sciocca s'anco adesso </l>
             <l>Ti stessi a bada. </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Parvi che sia nulla </l>
             <l>Questo da far per me? </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Ben sai che è nulla. </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Anzi è gran cosa. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Perché è cosa grande? </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Perché io son donna. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Et perché credi ch'egli </l>
             <l>Ti voglia? Et l'esser donna ti fa havere </l>
             <l>Questa ventura, pazzerella. </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Questo </l>
             <l>Femminil viso mi faria palese. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Non dubitar del viso, che tal l'hai, </l>
             <l>Che al maschio simil sei, come alla donna. </l>
             <l>Et proprio ne parrai schietto un ragazzo. </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Questo pur passerebbe, ma se poi </l>
             <l>Mi cercasse il padron? </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Tu sei pur sciocca; </l>
             <l>Pensa, pensa di te. </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Io di me penso </l>
             <l>Pensando a questo; s'ei mi ritrovasse, </l>
             <l>Che saria poi di me? </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Se il ciel cadesse </l>
             <l>Che saria degli augelli? Cerchi pure, </l>
@@ -851,12 +900,12 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>A trovarti colà? Non penserebbe </l>
             <l>Questo in mille anni. </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Et se egli vi venisse </l>
             <l>Et mi trovasse. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Se sarai mogliera </l>
             <l>Di Carino, fia d'uopo ch'ei si taccia, </l>
@@ -866,11 +915,11 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>È un partito sicuro. Et se io te fossi, </l>
             <l>Mo non vi farei su tanti pensieri. </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Ma come si farà dei panni? </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> I panni </l>
             <l>Sono qui in casa, che egli stesso hersera </l>
@@ -879,12 +928,12 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Nome d'Eutiche. Vuoi hora venire, </l>
             <l>Che gli daremo fin? </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> No, veder voglio </l>
             <l>Che fa il padron? </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Va dunque: torna tosto </l>
             <l>Fa buon pensiero, et fa che il van timore </l>
@@ -894,7 +943,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
         <div type="scene">
           <head>SCENA III </head>
           <stage>Chelidonia sola. </stage>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Io non dubito punto che l'Eutiche </l>
             <l>Non venga, che so quanto volentieri </l>
@@ -915,7 +964,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
         <div type="scene">
           <head>SCENA IV </head>
           <stage>	Linda, Chelidonia. </stage>
-          <sp>
+          <sp who="#linda">
             <speaker>Linda</speaker>
             <l> Mi tengo più obbligato a questa gonna </l>
             <l>Che io non so dire a che. Posciaché d'essa </l>
@@ -953,41 +1002,41 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Io vo saper che fatto ha Chelidonia </l>
             <l>Con Messere Nastagio. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Che v'è Linda? </l>
           </sp>
-          <sp>
+          <sp who="#linda">
             <speaker>Linda</speaker>
             <l> Altro che bene. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Credo che venuta </l>
             <l>Tu sii per girti con messer Nastagio. </l>
             <l>Ma non gli ancor parlato; sei venuta </l>
             <l>Troppo tosto. </l>
           </sp>
-          <sp>
+          <sp who="#linda">
             <speaker>Linda</speaker>
             <l> Vi prego per l'amore </l>
             <l>Di Dio che voi facciate tosto, ché io </l>
             <l>Chiesta ho licenza a messer Lino, et loco </l>
             <l>Non ho dove ridurmi. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Innanzi sera </l>
             <l>Tu v'andrai, tienlo certo. </l>
           </sp>
-          <sp>
+          <sp who="#linda">
             <speaker>Linda</speaker>
             <l> Io ve ne prego, </l>
             <l>Ché messer Lin venuto è in tanta rabbia, </l>
             <l>Poi che ho detto partirmi che ei m'habbia in odio </l>
             <l>Come nemica. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Non passerà molto </l>
             <l>Ne verrà a me messer Nastagio, et io </l>
@@ -1002,7 +1051,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
         <div type="scene">
           <head>SCENA V </head>
           <stage>Chelidonia, Messer Nastagio. </stage>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Havrà una gran ventura questo vecchio. </l>
             <l>Haver giovane tale in sua balia, </l>
@@ -1010,7 +1059,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Come una passarella. È un bocconcino </l>
             <l>Proprio da Dio. Veggiolo, egli esce. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Certamete gli è ver che non è indugio </l>
             <l>Sì grave, che agguagliar si possa a quello, </l>
@@ -1022,24 +1071,24 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>La vecchia è fuor di casa, sulla strada, </l>
             <l>Madonna. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Chi mi chiama? </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Vi chiamo io. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Siatevi il ben venuto. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Che novella </l>
             <l>Mi date della Linda? </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> O gran fatica </l>
             <l>Disporre una fanciulla, che si dia </l>
@@ -1048,45 +1097,45 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>In queste cose andare a passo a passo. </l>
             <l>Anch'io vo che vi sia il mio honor. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Saravvi, </l>
             <l>Non dubitate. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Se animo vi havete </l>
             <l>Di far cosa, che indegna de l'onore </l>
             <l>Sia di questa fanciulla, me lasciate </l>
             <l>Fuori di questa trama. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Habbiate certo </l>
             <l>Che del debito mio non verrò meno, </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Vi darò nelle man, con questa fede, </l>
             <l>L'honor mio et la fanciulla. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Quando fia </l>
             <l>Ch'ottenga quel che io bramo? </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Quanto presto </l>
             <l>Più potrò. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Ve ne prego. Et vi prometto </l>
             <l>Che, se posso per voi io cosa alcuna, </l>
             <l>Senza rispetto la chiediate. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Questo </l>
             <l>Mio mantelluccio et questa cotta sono </l>
@@ -1094,18 +1143,18 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Et lo potreste far, fareste cosa </l>
             <l>Che a Dio grata sarebbe a rivestirmi. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Il farò volentieri. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Et io farovvi </l>
             <l>Partecipe di quante perdonanze </l>
             <l>Piglio ogni giorno et di quelle orationi </l>
             <l>Che io porgo a Dio. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Io me n'andrò a casa, </l>
             <l>Et farò quanto v'ho di far promesso. </l>
@@ -1114,7 +1163,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
         <div type="scene">
           <head>SCENA VI </head>
           <stage>Chelidonia, Lamprino, Castaldo. </stage>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l>Per mezzo mio del loro amor godranno </l>
             <l>Carin, messer Nastagio, Eutiche e Linda, </l>
@@ -1123,7 +1172,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Carco di robbe. Non mi vo partire, </l>
             <l>Ché io gli vo dir ciò che s'è fatto. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Guarda </l>
             <l>Di non dire al padron di quelle robbe, </l>
@@ -1131,13 +1180,13 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Ché tristo te. Tu sai ben chi son io, </l>
             <l>Che faccio tutto, fuori. </l>
           </sp>
-          <sp>
+          <sp who="#castaldo">
             <speaker>Cast.</speaker>
             <l> Non temete </l>
             <l>Che io dica cosa alcuna. Ma che ho io a fare </l>
             <l>Ad haver la mia parte? </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Gocciolone? </l>
             <l>Non la sai tu torre? E di che temi? </l>
@@ -1147,54 +1196,54 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Tanto n'havrem, quanto sapremo torre, </l>
             <l>Et nulla più. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Veduto t'ho venire, </l>
             <l>Aspettar t'ho voluto. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Et che novella, </l>
             <l>C'è del novello amor del mio padrone? </l>
             <l>Dite di gratia. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Par che tu non sappia </l>
             <l>Che io mi sia in cose tali. Infino a un'hora </l>
             <l>Egli avrà dalla Linda ciò che ci brama. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> È vero? </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Vero. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Et gliel'havete detto? </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Partiva or or da me con questa nuova, </l>
             <l>E m'ha promesso di vestirmi tutta. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Che volete voi far di vestimenta? </l>
             <l>Poche son bone; certo è molto meglio </l>
             <l>Che pigliate i denari. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Tu procacci </l>
             <l>Tutto per te, Lamprin, ma non temere; </l>
             <l>Io mi ragguaglierò per altra via. </l>
             <l>Ma chi è costui che è teco? </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Egli è il castaldo, </l>
             <l>Al padron porta questa roba e a noi, </l>
@@ -1203,22 +1252,22 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Da signore, per Dio. Ma chi è costui, </l>
             <l>Che di quà vien sì pien d'affanni? </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> È uno </l>
             <l>Cogli traffichi miei; vattene in casa, </l>
             <l>Che io non vo che mi vegga a parlar teco. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Anchor io voglio entrar. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Darai di volta, </l>
             <l>Ché partirem tra noi tutto il guadagno. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Donna non face male in questa terra, </l>
             <l>Che non ne sia cagion questa ribalda. </l>
@@ -1227,7 +1276,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
         <div type="scene">
           <head>SCENA VII </head>
           <stage>Carino solo. </stage>
-          <sp>
+          <sp who="#carino">
             <speaker>Car.</speaker>
             <l> Io son come colui che a un lato ha i lupi, </l>
             <l>E a l'altro ha il precipizio, temo et amo; </l>
@@ -1258,65 +1307,65 @@ PER DOMENICO TADDEI E FIGLI <lb/>
         <div type="scene">
           <head>SCENA VIII. </head>
           <stage>Chelidonia, Carino. </stage>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Chi è che picchia. </l>
           </sp>
-          <sp>
+          <sp who="#carino">
             <speaker>Car.</speaker>
             <l> Son io, madonna, </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Vengo, </l>
             <l>Aspettate. </l>
           </sp>
-          <sp>
+          <sp who="#carino">
             <speaker>Car.</speaker>
             <l> Io aspetto. Se non fosse </l>
             <l>Questa vecchietta, già morto sarei. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Che c'è, messer Carino? </l>
           </sp>
-          <sp>
+          <sp who="#carino">
             <speaker>Car.</speaker>
             <l> Ecci che io sono </l>
             <l>Il più miser che io viva. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Io gli vo dare </l>
             <l>Un po' di stretta. Molto ben sapete </l>
             <l>Finger, per Dio, l'afflitto. </l>
           </sp>
-          <sp>
+          <sp who="#carino">
             <speaker>Car.</speaker>
             <l> Io non fingo, </l>
             <l>Ché fingere non puote chi ben ama. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> A questo modo dite tutti, e al fine </l>
             <l>Misere son quelle che vi dan fede. </l>
           </sp>
-          <sp>
+          <sp who="#carino">
             <speaker>Car.</speaker>
             <l> Havete torto in ciò, perché s'uno inganna, </l>
             <l>Mille et mille ve n'ha che serban fede. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Tutto il contrario; se un la fè mantiene </l>
             <l>Fra mille et mille è maraviglia expressa. </l>
           </sp>
-          <sp>
+          <sp who="#carino">
             <speaker>Car.</speaker>
             <l> Tal essere non vogl'io con la mia Eutiche, </l>
             <l>Per lo Dio che mi tien vivo nel mondo. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Giura et spergiura ogni amante, sapendo </l>
             <l>Che i falsi giuramenti degli amanti </l>
@@ -1329,148 +1378,148 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Stati sete larghissimi, e di fatti </l>
             <l>Sete scarsi et avari. </l>
           </sp>
-          <sp>
+          <sp who="#carino">
             <speaker>Car.</speaker>
             <l> Oimè, Madonna, </l>
             <l>Non m'affliggete più, che io son pur troppo </l>
             <l>Da me medesmo afflitto. Homai pietade </l>
             <l>Habbiate del mio mal. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> State pur male, </l>
             <l>Datemi il polso. </l>
           </sp>
-          <sp>
+          <sp who="#carino">
             <speaker>Car.</speaker>
             <l> Così stessi io bene, </l>
             <l>Così havessi io meco la mia vita. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Et che voi non vivete? io mai non viddi </l>
             <l>Morti parlar. </l>
           </sp>
-          <sp>
+          <sp who="#carino">
             <speaker>Car.</speaker>
             <l> Voi pur, Madonna, sete </l>
             <l>Nei giuochi, et io mi struggo. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Poverello, </l>
             <l>Molto m'incresce. </l>
           </sp>
-          <sp>
+          <sp who="#carino">
             <speaker>Car.</speaker>
             <l> Eh non mi consumate. </l>
             <l>Viver non posso, se non mi mantiene </l>
             <l>In vita la mia Eutiche. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> State bene, </l>
             <l>Che vi conviene haver da lei la vita. </l>
           </sp>
-          <sp>
+          <sp who="#carino">
             <speaker>Car.</speaker>
             <l> Qualche mal m'indovino. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Il male è fatto; </l>
             <l>Ella è per tor marito. </l>
           </sp>
-          <sp>
+          <sp who="#carino">
             <speaker>Car.</speaker>
             <l> Oimè che dite? </l>
             <l>M'havete morto. Et questo è vero? </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Che.</speaker>
             <l> Vero. </l>
           </sp>
-          <sp>
+          <sp who="#carino">
             <speaker>Car.</speaker>
             <l> Ah! Malvagia fortuna. Voi m'havete </l>
             <l>Trafitto infino alle radici il cuore. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> E vi spiace che Eutiche intanto sia </l>
             <l>Per maritarsi? Questo è il vostro bene, </l>
             <l>Ma voi nol conoscete. </l>
           </sp>
-          <sp>
+          <sp who="#carino">
             <speaker>Car.</speaker>
             <l> Il mio ben questo? </l>
             <l>Maledetto che il crede. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Ella vuol voi, </l>
             <l>Non egli è il vostro ben? </l>
           </sp>
-          <sp>
+          <sp who="#carino">
             <speaker>Car.</speaker>
             <l> Voi m'havete </l>
             <l>Risuscitato, ché più che morto era, </l>
             <l>S'ella prender volea marito un altro. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Dite per vostra fe, se io faccio ch'ella </l>
             <l>Ne venga a voi, pria che s'asconda il sole, </l>
             <l>Che mercede n'havrò. </l>
           </sp>
-          <sp>
+          <sp who="#carino">
             <speaker>Car.</speaker>
             <l> Ciò che vi piace. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Ciò che mi piace? Io vorrei sapere </l>
             <l>Certo il guadagno mio. </l>
           </sp>
-          <sp>
+          <sp who="#carino">
             <speaker>Car.</speaker>
             <l> Non vi dissi heri </l>
             <l>Che godendo di Eutiche, io vi darei </l>
             <l>Venti fiorini? </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Si, ma dove sono? </l>
           </sp>
-          <sp>
+          <sp who="#carino">
             <speaker>Car.</speaker>
             <l> Son qui, tenete. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Hor veggio ben che amate </l>
             <l>Così fassi a voler vederne il fine. </l>
           </sp>
-          <sp>
+          <sp who="#carino">
             <speaker>Car.</speaker>
             <l> Questo fia poco. Pur ch'habbia l'Eutiche </l>
             <l>Vo che siate del mio, di me signora. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Io vi rengratio, andatevene a casa, </l>
             <l>Ché l'Eutiche verrà pria che sia sera. </l>
           </sp>
-          <sp>
+          <sp who="#carino">
             <speaker>Car.</speaker>
             <l> Mi vo con questa speme. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Io nol direi </l>
             <l>Se io non havessi in man la cosa fatta. </l>
           </sp>
-          <sp>
+          <sp who="#carino">
             <speaker>Car.</speaker>
             <l> Se è vero pur che la mia Eutiche venga, </l>
             <l>Quantunque congiurate nei miei danni </l>
@@ -1492,7 +1541,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
         <div type="scene">
           <head>SCENA I </head>
           <stage>Linda, Chelidonia. </stage>
-          <sp>
+          <sp who="#linda">
             <speaker>Linda</speaker>
             <l> M'hanno così accorata le parole </l>
             <l>Della Marcella, così m'han commosso </l>
@@ -1522,30 +1571,30 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Io veggio sulla porta Chelidonia, </l>
             <l>La qual forse m'attende. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Io t'attendea </l>
             <l>Già son due hore, ché a messer Nastagio </l>
             <l>Data t'havrei. Tu mostri ben di fare </l>
             <l>Poca stima del ben, dell'util tuo. </l>
           </sp>
-          <sp>
+          <sp who="#linda">
             <speaker>Linda</speaker>
             <l> Anzi io l'estimo e sovra ogni altro. Questo </l>
             <l>Partito m'è piaciuto. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Può piacerti, </l>
             <l>Ché sarai la padrona in questa casa; </l>
             <l>Che cosa è questa ch'hai nel grembo? </l>
           </sp>
-          <sp>
+          <sp who="#linda">
             <speaker>Linda</speaker>
             <l> Sono </l>
             <l>Due casci che io vi porto. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Cara figlia, </l>
             <l>Ti benedica Dio; vedi che viene </l>
@@ -1554,11 +1603,11 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>E sta qui sulla porta fin che torno. </l>
             <l>Io vo gir verso lui. </l>
           </sp>
-          <sp>
+          <sp who="#linda">
             <speaker>Linda</speaker>
             <l>	 Andate. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Prima </l>
             <l>Non vo che questo vecchio la Linda habbia, </l>
@@ -1568,7 +1617,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
         <div type="scene">
           <head>SCENA II </head>
           <stage>Messer Nastagio, Lamprino, Chelidonia, Linda. </stage>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Lamprino, è ver che uno attempato che ami </l>
             <l>È come un vecchio legno al foco ardente, </l>
@@ -1577,36 +1626,36 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Né dì né notte pace. Né mai requie </l>
             <l>Havrò, finché non ho la Linda meco. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Ardete almen d'obbietto di voi degno, </l>
             <l>Né ve ne so incolpar se voi l'amate. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Anzi ti dico che s'io la ritrovo </l>
             <l>Tal qual esser potrebbe..... </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Chi è ingannato </l>
             <l>Suo danno. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Certamente per mogliera </l>
             <l>La mi può prender. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Io ve ne conforto. </l>
             <l>Chi sa che io non ne possa anch'io godere. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Ma ve' la Chelidonia, andianci a lei. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Linda mia, vengono a noi, statti pur cheta, </l>
             <l>Né parlar mai se io non ti faccio motto. </l>
@@ -1614,26 +1663,26 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Credito havrai con questo tuo padrone; </l>
             <l>Che altrimenti facendo. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Dio vi salvi, </l>
             <l>Madonna. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Et voi ancora. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> A che siam noi? </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Certo, messer Nastagio, che io son quasi </l>
             <l>Fuori di me, tenendo pur che qualche </l>
             <l>Vergogna non m'avvenga al fin. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Madonna, </l>
             <l>Honor solo n'haverete e non vergogna: </l>
@@ -1647,22 +1696,22 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Mancia da gentilhuomo, onde contenuta </l>
             <l>Ne rimarrete </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Lamprin mi contento </l>
             <l>De la gratia di Dio. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Contenta ancora </l>
             <l>Vo' che siate di questo. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> È giusto carca </l>
             <l>La barca non c'è dubbio. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Dio volga </l>
             <l>Per meglio la sua vela. Ecco la Linda, </l>
@@ -1671,66 +1720,66 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Tu farai quel che dei, ti fo sicura </l>
             <l>Che non ti pentirai d'esservi gita. </l>
           </sp>
-          <sp>
+          <sp who="#linda">
             <speaker>Linda</speaker>
             <l> Io non farò altrimenti, et se non deve </l>
             <l>Appo voi esser l'honestà mia salva, </l>
             <l>Lasciatemi. Che pria che la mia vita, </l>
             <l>Curo il mio honor. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Et ciò che io ho detto, dico </l>
             <l>A voi, madonna. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Già non l'havereste, </l>
             <l>S'io credessi altrimenti. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Il mio padrone </l>
             <l>È tale che non può patir disnore </l>
             <l>Alcuno che lo serva. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Ne puoi fare </l>
             <l>Tu fe', Lamprino. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Sia al nome di Dio. </l>
             <l>Va dunque. </l>
           </sp>
-          <sp>
+          <sp who="#linda">
             <speaker>Linda</speaker>
             <l> Io vado. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Et io mi terrò appresso </l>
             <l>Per la mia parte. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Fa come ti piace. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Questa è una bella caccia ch'harete hoggi </l>
             <l>Guadagnata, padron; ella mi pare </l>
             <l>Un angelo del ciel. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> È ver per Dio. </l>
             <l>Me ne vuo' gire a casa. Tu va al porto, </l>
             <l>E intendi del compar mio s'egli ha nova </l>
             <l>Alcuna oggi da Napoli. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> I'vo. Questi </l>
             <l>Sì mi vuol tor di piedi, per potere </l>
@@ -1742,7 +1791,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
         <div type="scene">
           <head>SCENA III </head>
           <stage>Chelidonia, Eutiche. </stage>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Questi son dei miracoli, che face </l>
             <l>Amore a beneficio di noi vecchie, </l>
@@ -1786,17 +1835,17 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>L'Eutiche, voglio anch'io ispedir quest'altra, </l>
             <l>Prima che io entri. Sei venuta a tempo. </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Tenete, madre mia, questo è il presciutto. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Goderol per tuo amor. Ma dimmi, figlia </l>
             <l>Hai tu disposto di volerti andare </l>
             <l>Dal tuo Carino. </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Hollo disposto et vengo </l>
             <l>Solo per questo. Et vo dirvi in che modo </l>
@@ -1829,7 +1878,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Lasciando col padron la Linda chiusa. </l>
             <l>Venuta sono ad ispedirmi. </l>
           </sp>
-          <sp>
+          <sp who="#chelidonia">
             <speaker>Chel.</speaker>
             <l> Hor saggia </l>
             <l>Ben tu mi fai conoscere, a saperti </l>
@@ -1840,7 +1889,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
         <div type="scene">
           <head>SCENA IV </head>
           <stage>Messer Cosmo, Ragazzo, Macaria, Eutiche,  Capitano della Piazza. </stage>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l>Andrai qui a man sinistra nella strada </l>
             <l>Prima che troverai, e in quella casa, </l>
@@ -1850,12 +1899,12 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>È mia donna di casa, et riporrai </l>
             <l>Le robbe ov'egli mostreratti. </l>
           </sp>
-          <sp>
+          <sp who="#ragazzo">
             <speaker>Rag.</speaker>
             <l> Il tutto </l>
             <l>Farò come mi dite appunto. </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Et voi </l>
             <l>Terrete appresso voi questa bolgetta. </l>
@@ -1865,11 +1914,11 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Dalla tempesta, onde ne semo suti </l>
             <l>Crudelmente agitati, ch'io mi sia. </l>
           </sp>
-          <sp>
+          <sp who="#macaria">
             <speaker>Mac.</speaker>
             <l> Tutto quello farò che mi imponete. </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Ora andate. Non fui unqua più in mare </l>
             <l>Con tanto mia pericolo, con quanto hoggi </l>
@@ -1883,7 +1932,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Di rendere i promessi voti a Dio, </l>
             <l>Indegno è mai d'haver da lui più gratia. </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Hammisi pure amor fatta soggetta, </l>
             <l>Poiché stimando poco il mio esser donna, </l>
@@ -1905,45 +1954,45 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Che esce di questo tempio? Dammi, Amore, </l>
             <l>Soccorso tale che ei non mi conosca. </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Ho soddisfatto ai voti. Io voglio andare </l>
             <l>A messer Fano. Oh Dio che veggio? è pure </l>
             <l>Questi il mio Eugenio. </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Oimè lassa mai dove </l>
             <l>M'hai portato, mio Amor? In questi panni </l>
             <l>È dunque mia rovina? </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> O ladrone, </l>
             <l>Non hai potuto andar così da lungi, </l>
             <l>Che colto io non t'habbia. Et qual cagione </l>
             <l>Ti fe da me fuggire? </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Voi m'havete </l>
             <l>Tolto in iscambio. Non so chi vi siate, </l>
             <l>Né fui giammai con voi. </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Con che viso </l>
             <l>Mi di' tu hor questo? Tu non sei Eugenio, </l>
             <l>Il qual nudrii alla Vallona insino </l>
             <l>Da tenero fanciullo? Io non son cieco. </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Né voi, signor, né quest'Eugenio mai </l>
             <l>Conobbi, né mai fui alla Vallona, </l>
             <l>Come voi dite. </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Ah forca, ah ladroncello! </l>
             <l>Parti; ché per haver habito nuovo, </l>
@@ -1955,7 +2004,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Por ne le man della ragione. Allhora </l>
             <l>Vedremo se sarai Eugenio. </l>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>Cap.</speaker>
             <l> Bisognava </l>
             <l>Che di qui non vi foste dipartiti </l>
@@ -1966,21 +2015,21 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Mascalzoni che siete. Ma chi è questi? </l>
             <l>Non è egli messer Cosmo? È desso certo. </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Non fuggirai per Dio. </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Non sono Eugenio. </l>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>Cap.</speaker>
             <l> Che bona nuova hora vi ha qui condotto, </l>
             <l>Caro il mio messer Cosmo? Et che vuol dire </l>
             <l>Questa tenzon che con costui havete? </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Son qui per mie faccende, et questo tristo </l>
             <l>È un mio ragazzo, che da me fuggissi </l>
@@ -1995,14 +2044,14 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Hor qui vi ritrovate così a tempo. </l>
             <l>E al podestà menatel. </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Non mi fate </l>
             <l>Per le parole di costui ingiuria; </l>
             <l>Che tanto so io quel di che egli dice, </l>
             <l>Quanto egli è voi. </l>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>Cap.</speaker>
             <l> Figliuol mio, conosco </l>
             <l>Ha più di dodici anni messer Cosmo. </l>
@@ -2010,27 +2059,27 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Però, sendo tu suo, non star sul niego, </l>
             <l>Che alfin forza sarà che il ver si scuopra. </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Io nol conosco, capitano, et Dio </l>
             <l>Non mi lasci haver ben se il viddi mai. </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> È un ghiotto, capitano. Io farò bene </l>
             <l>Fede, che io dico il ver. Menatel pure </l>
             <l>Al podestà. </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Che fia di me dolente? </l>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>Cap.</speaker>
             <l> Pigliate voi costui, che lo meniamo </l>
             <l>Ove vuol messer Cosmo. </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Ingiusto Amore, </l>
             <l>Sia maledetto il dì che ti conobbi! </l>
@@ -2039,16 +2088,16 @@ PER DOMENICO TADDEI E FIGLI <lb/>
         <div type="scene">
           <head>SCENA V </head>
           <stage>Fratello del Podestà, Capitano, Messer Cosmo, Eutiche. </stage>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Che cosa è questa, capitano. </l>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>Capit.</speaker>
             <l> Noi </l>
             <l>Il podestà chiedemmo. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l>	 È andato fuori </l>
             <l>Stamane assai per tempo, né tornare </l>
@@ -2056,7 +2105,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Che importi, noi in suo loco qui semo. </l>
             <l>Et quanto fia mestier faremo. </l>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>Capit.</speaker>
             <l> Questo </l>
             <l>Gentilhuomo m'ha fatto prender questo </l>
@@ -2064,48 +2113,48 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Gli è insin dalla Vallona. Et perché ei nega </l>
             <l>Al podestà qui il fa condurre. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> È vero </l>
             <l>Che tu sii suo ragazzo? </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Io nol conosco. </l>
           </sp>
-          <sp>
+          <sp who="fratello">
             <speaker>Frat. del p.</speaker>
             <l> Che dite Gentilhuomo? </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Io dico ch'egli </l>
             <l>È il mio ragazzo. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l>	 Poi che ei nega et voi </l>
             <l>L'affermate esser vostro, è di bisogno, </l>
             <l>Se volete convincerlo, far prova </l>
             <l>Che egli sia vostro. </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Io lo farò, massime </l>
             <l>Che io vo per testimoni. Fate porre </l>
             <l>In prigion che non fugga. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Il serreremo </l>
             <l>In prigion fin allora. </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Hora tu godi </l>
             <l>Del tuo amore infelice </l>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>Capit.</speaker>
             <l> Va in prigione. </l>
           </sp>
@@ -2113,7 +2162,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
         <div type="scene">
           <head>SCENA VI </head>
           <stage>Carino solo. </stage>
-          <sp>
+          <sp who="#carino">
             <speaker>Car.</speaker>
             <l> Tosto che divisato m'ha Bardino, </l>
             <l>I panni di colui che è stato preso, </l>
@@ -2151,7 +2200,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
         <div type="scene">
           <head>SCENA I </head>
           <stage>Messer Nastagio, Castaldo. </stage>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Io mi sono avveduto che la Linda, </l>
             <l>Come accorta che ella è, seco s'istima </l>
@@ -2174,7 +2223,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Fuggire, et nulla me ne dice insino </l>
             <l>Che fuggita non s'è. </l>
           </sp>
-          <sp>
+          <sp who="#castaldo">
             <speaker>Cast.</speaker>
             <l> Che volevate </l>
             <l>Che io dicessi, se eravate in gioja </l>
@@ -2183,18 +2232,18 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Né più né meno un asino. Gran cosa </l>
             <l>È indovinarla vosco. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Vatti in casa, </l>
             <l>Buffalo che tu sei. </l>
           </sp>
-          <sp>
+          <sp who="#castaldo">
             <speaker>Cast.</speaker>
             <l> Un buffal sono, </l>
             <l>Perché gita non è la cosa come </l>
             <l>Volevate. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Va in casa, maledetto </l>
             <l>Villano, che fiaccar ti possi il collo. </l>
@@ -2211,50 +2260,50 @@ PER DOMENICO TADDEI E FIGLI <lb/>
         <div type="scene">
           <head>SCENA II</head>
           <stage>Castaldo, Linda. </stage>
-          <sp>
+          <sp who="#castaldo">
             <speaker>Cast.</speaker>
             <l>Tu non m'odi, figliuola, vuoi andarti </l>
             <l>Ancor tu via? Che poi dica il padrone </l>
             <l>Che io sono un buffal. Entra in casa. </l>
           </sp>
-          <sp>
+          <sp who="#linda">
             <speaker>Linda</speaker>
             <l> Data </l>
             <l>M'ha licentia il padron d'andare a casa. </l>
             <l>Di questo vicin nostro. </l>
           </sp>
-          <sp>
+          <sp who="#castaldo">
             <speaker>Cast.</speaker>
             <l> Guarda bene </l>
             <l>Che non me ne dichi una per un'altra. </l>
           </sp>
-          <sp>
+          <sp who="#linda">
             <speaker>Linda</speaker>
             <l> Ella è come io ti dico. </l>
           </sp>
-          <sp>
+          <sp who="#castaldo">
             <speaker>Cast.</speaker>
             <l> Giura. </l>
           </sp>
-          <sp>
+          <sp who="#linda">
             <speaker>Linda</speaker>
             <l> Che? </l>
           </sp>
-          <sp>
+          <sp who="#castaldo">
             <speaker>Cast.</speaker>
             <l> Che il diavolo ti porti chi ti ha data </l>
             <l>Licentia. </l>
           </sp>
-          <sp>
+          <sp who="#linda">
             <speaker>Linda</speaker>
             <l> Che il diavolo ti porti ch'egli </l>
             <l>Data la mi ha. Hor guarda mo. </l>
           </sp>
-          <sp>
+          <sp who="#castaldo">
             <speaker>Cast.</speaker>
             <l> Va via. </l>
           </sp>
-          <sp>
+          <sp who="#linda">
             <speaker>Linda</speaker>
             <l> Ve che bestia tra i piè m'era venuta! </l>
             <l>Ho avuto gran piacer di questo vecchio: </l>
@@ -2288,7 +2337,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
         <div type="scene">
           <head>SCENA III </head>
           <stage>Lamprino, Castaldo. </stage>
-          <sp>
+          <sp who="#castaldo">
             <speaker>Cast.</speaker>
             <l> Io debbo ad ogni modo esser felice </l>
             <l>In questo giorno. Oh che bramata nuova </l>
@@ -2298,42 +2347,42 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Mi ha detto che gli dica a nome suo. </l>
             <l>Chi è là? </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Non mi conosci? Io son Lamprino: </l>
             <l>Ci è il padron? </l>
           </sp>
-          <sp>
+          <sp who="#castaldo">
             <speaker>Cast.</speaker>
             <l> Non ci è, gito è a cercare </l>
             <l>L'Eutiche che è fuggita. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Si è fuggita </l>
             <l>Questa bestiuola? </l>
           </sp>
-          <sp>
+          <sp who="#castaldo">
             <speaker>Cast.</speaker>
             <l> Si. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Perché? </l>
           </sp>
-          <sp>
+          <sp who="#castaldo">
             <speaker>Cast.</speaker>
             <l> Non so. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Et il padron la cerca? </l>
           </sp>
-          <sp>
+          <sp who="#castaldo">
             <speaker>Cast.</speaker>
             <l> È più d'un'hora. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Vattene a casa. Io non l'ho vista in piazza, </l>
             <l>Né al porto, né per strada. Una ventura </l>
@@ -2347,7 +2396,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
         <div type="scene">
           <head>SCENA IV </head>
           <stage>Messer Lino, Messer Nastagio, Castaldo, Linda, Cavaliere. </stage>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l>Avvenne ad huomo mai caso più strano, </l>
             <l>O sparse in un con così larga mano </l>
@@ -2386,7 +2435,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Iniuria senza pena. Andar vo a casa </l>
             <l>Di messere Nastagio. Ecco che ei viene. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Non voglio più cercar di questa bestia; </l>
             <l>Io son già tutto fioco, io vo che cerchi, </l>
@@ -2396,7 +2445,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Messer Lino per me? Sarebbe forse </l>
             <l>Egli per la sua fante in ira meco? </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Messer Nastagio, io vi ritrovo a tempo, </l>
             <l>Che vo sfogar con voi l'angoscia mia. </l>
@@ -2408,35 +2457,35 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Esser meco, perch'io vendetta pigli </l>
             <l>Di questa scellerata della Linda. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Che vi è? Havrebbe ella nel partire </l>
             <l>Qualche cosa involato ella del vostro? </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Mi ha lasciato pur troppo ella del suo! </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Che cosa è questa che io odo? </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Ingravidata </l>
             <l>M'ha la figliuola. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Dunque non è donna </l>
             <l>La Linda? </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Donna? so che m'ha mostrato </l>
             <l>Ciò che importi a fidarsi. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Voi mi fate </l>
             <l>Empir di meraviglia, e duolmi tanto </l>
@@ -2453,64 +2502,64 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>D'haverlo nelle mani. Ov'è la Linda? </l>
             <l>Dille che venga giuso. </l>
           </sp>
-          <sp>
+          <sp who="#castaldo">
             <speaker>Cast.</speaker>
             <l> È andata fuori. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Com'è che è andata fuori? Ov'ella è gita? </l>
           </sp>
-          <sp>
+          <sp who="#castaldo">
             <speaker>Cast.</speaker>
             <l> Io non le ho posto mente. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Ancho fuggire </l>
             <l>Hai lasciata quest'altra, manigoldo? </l>
           </sp>
-          <sp>
+          <sp who="#castaldo">
             <speaker>Cast.</speaker>
             <l> Non ci saremo. Il diavol m'ha menato </l>
             <l>Stamane quì. Se voi le havete data </l>
             <l>Licentia, voi; io poi la terrò? Io? </l>
             <l>O diavol, questa è bella. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Quando ho data </l>
             <l>L'ho io questa licentia? </l>
           </sp>
-          <sp>
+          <sp who="#castaldo">
             <speaker>Cast.</speaker>
             <l> Quando sete </l>
             <l>Ito fuori di casa. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Manigoldo, </l>
             <l>Chi tel'ha detto? </l>
           </sp>
-          <sp>
+          <sp who="#castaldo">
             <speaker>Cast.</speaker>
             <l> Linda. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Dunque credi </l>
             <l>A Linda. </l>
           </sp>
-          <sp>
+          <sp who="#castaldo">
             <speaker>Cast.</speaker>
             <l> Mel giurò. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Bestia insensata, </l>
             <l>Va, guarda i porci. </l>
           </sp>
-          <sp>
+          <sp who="#castaldo">
             <speaker>Cast.</speaker>
             <l> Vedrete che questi </l>
             <l>Mai non mi fuggiranno. Voi volete </l>
@@ -2518,7 +2567,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Più trappole, che non potrian guardarle </l>
             <l>Quant'occhi son nel mondo. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> M'ha lasciata </l>
             <l>Fuggir costui la serva mia et quest'altra </l>
@@ -2526,7 +2575,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>A che fin possa meco esser venuto </l>
             <l>Per fuggirsi costui. </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> La cosa è chiara: </l>
             <l>Messer Nastagio, egli si è qua venuto </l>
@@ -2534,25 +2583,25 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Non vel vedete voi; codesto è un nuovo </l>
             <l>Uccellare alle donne. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Dite il vero: </l>
             <l>Con quant'arte si vive oggi nel mondo! </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Con più che non si crede et è gran cosa </l>
             <l>Trovar fede sincera. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nst.</speaker>
             <l> È più che vero. </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Or poniamci a cercar di questo reo. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Ritiriamci ambi su questo cantone, </l>
             <l>Onde il porto si scopre et quasi tutta </l>
@@ -2562,16 +2611,16 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Patrasso il cercheremo ambidue insieme: </l>
             <l>Ma dobbiam ben haver quì prima il reo. </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Ogni cosa sta ben, purché il troviamo. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Come avvisto vi siete che ne sia </l>
             <l>Gravida vostra figlia? </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Poi che questo </l>
             <l>Malvagio si partì, da me si stava </l>
@@ -2592,12 +2641,12 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Le faceva nel corpo, a chiari segni </l>
             <l>Viddero ch'era gravida. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Per Dio! </l>
             <l>Che io v'ho compassion. </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Io comincio </l>
             <l>A riprender la moglie, a dirle male. </l>
@@ -2614,44 +2663,44 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Non morissi di doglia, conoscendo </l>
             <l>Che stato era io cagion di tutto il male. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Come essendo stato costui dalla Vallona, </l>
             <l>Come mostra al parlare et ho inteso </l>
             <l>Ben dai nostri vicini, egli ha havuta </l>
             <l>La gratia di Marcella? </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Ahi lasso! quando </l>
             <l>Io fui l'anno passato con la mia </l>
             <l>Famiglia alla Vallona, questo rio </l>
             <l>Di lei si accese. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Messer Lino, salvi </l>
             <l>Siamo. </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Perché? </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Vedete quel reo? </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Il veggio, i' gli vo' trar dal petto </l>
             <l>Con le mia mani il cor </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Non vi bisogna </l>
             <l>A questo modo far. </l>
           </sp>
-          <sp>
+          <sp who="#linda">
             <speaker>Linda</speaker>
             <l> Hor che ispedito </l>
             <l>Io son di quanto io volea far, io voglio </l>
@@ -2662,12 +2711,12 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Qual fia la mia vita? Almen potess'io </l>
             <l>Fuggire in qualche loco. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Hai così buona </l>
             <l>Custodia alla mia casa? </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Manigoldo, </l>
             <l>Sei pur nelle mie man, tu sei pur giunto </l>
@@ -2675,134 +2724,134 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>De l'opre tue. Con queste vie, ribaldo, </l>
             <l>S'assassina così gli huomini? </l>
           </sp>
-          <sp>
+          <sp who="#linda">
             <speaker>Linda</speaker>
             <l> Messere, </l>
             <l>Ho fatto poco errore, questo solo </l>
             <l>Messer Lin mi perdoni. Se pur mai </l>
             <l>Mi trova in fallo, taglimi la testa. </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Parti haver fatto poco error havendo </l>
             <l>In una città nobil come questa </l>
             <l>Una giovane nobile violata? </l>
             <l>Et quale è grande, s'è picciolo questo. </l>
           </sp>
-          <sp>
+          <sp who="#linda">
             <speaker>Linda</speaker>
             <l> Non desiderio già di farvi oltraggio, </l>
             <l>Ma Amor cagion n'è stato. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Ove hai tu fatto </l>
             <l>Fuggire Eutiche? Così male a male </l>
             <l>Aggiungere hai voluto, o scellerato. </l>
           </sp>
-          <sp>
+          <sp who="#linda">
             <speaker>Linda</speaker>
             <l> Non l'ho, signor, fatta fuggir, né meno </l>
             <l>So dove sia fuggita. </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Non più ciancie: </l>
             <l>Che io non potrei tenermi che non fessi </l>
             <l>Nel mezzo della strada la vendetta. </l>
             <l>Menianlo al podestà. </l>
           </sp>
-          <sp>
+          <sp who="#linda">
             <speaker>Linda</speaker>
             <l> Deh non mi fate </l>
             <l>Questa vergogna. </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Scellerato, temi </l>
             <l>Tu di vergogna? Io vo ch'habbi l'honore </l>
             <l>In mezzo piazza che tu merti, et io </l>
             <l>Esser vo il manigoldo. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Che direte? </l>
             <l>Non son degne di voi queste parole. </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Non mi debbo satiar del costui sangue? </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Chiamar vo il cavalier con la famiglia </l>
             <l>Del podestà. </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>Cav.</speaker>
             <l> Chi picchia? </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Cavaliere, </l>
             <l>Pigliate questo tristo, che vogliamo </l>
             <l>Al podestà menarlo. </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>Cav.</speaker>
             <l> Egli è ito fuori; </l>
             <l>Evvi ben suo fratello. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Et ci bisogna </l>
             <l>Finché il podestà torni. </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>Cav.</speaker>
             <l> Anzi vi dico </l>
             <l>Gli potrete parlare insino a un'hora. </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> ponetelo in prigion insino a tanto </l>
             <l>Che egli può darci orecchio. Ché il maggiore </l>
             <l>Tristo gli ho a far conoscere, che mai </l>
             <l>Gli venisse alle mani. </l>
           </sp>
-          <sp>
+          <sp who="#linda">
             <speaker>Linda</speaker>
             <l> Messer Lino </l>
             <l>Non mi ci fate por, vi sarò sempre </l>
             <l>Fedele. </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Più non vo tua fede: vanne </l>
             <l>Pur dove merti. </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>Cav.</speaker>
             <l> Conducete, o fanti, </l>
             <l>In prigione costui. </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>Cav.</speaker>
             <l> Messer Nastagio, </l>
             <l>Aiutatemi almen voi per l'amore </l>
             <l>Che dianzi mostravate di portarmi. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Gran cagion me n'hai dato a havermi fatto </l>
             <l>La mia serva fuggir. </l>
           </sp>
-          <sp>
+          <sp who="#linda">
             <speaker>Linda</speaker>
             <l> Non l'ho per Dio </l>
             <l>Fatta fuggir. </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Non più: servatel, pure, </l>
             <l>Finché ritornerem, nella prigione. </l>
@@ -2810,7 +2859,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Mi troverò quando mi parrà tempo </l>
             <l>Quì innanzi al podestà. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Vi sarò anch'io. </l>
             <l>Io haveva per mia fè ben posto il cuore </l>
@@ -2828,7 +2877,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
         <div type="scene">
           <head>SCENA I </head>
           <stage>Capitano della pregione, Fratello del podestà. </stage>
-          <sp>
+          <sp who="#capitano">
             <speaker>Cap.</speaker>
             <l> Io vo che il Messer sappia il tutto prima </l>
             <l>Che giunga il Vallonese. Habbiam d'havere </l>
@@ -2836,34 +2885,34 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Appunto il veggio qui sotto la loggia. </l>
             <l>Signor, io v'ho da far rider un pezzo. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Perché. </l>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>Cap.</speaker>
             <l> L'intenderete. Quel prigione, </l>
             <l>Ch'oggi fummi condotto come volpe </l>
             <l>A nome di quell'huom della Vallona, </l>
             <l>È una fanciulla. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Come un fanciulla? </l>
             <l>Et che ne sai? </l>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>Cap.</speaker>
             <l> Ella medesma detto </l>
             <l>L'ha alla mia donna, mentre ella parlava </l>
             <l>Con esso lei et si dolea con lei </l>
             <l>Della disgrazia sua. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l>Che cosa è questa? </l>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>Cap.</speaker>
             <l> Egli è com'io vi dico, et vi vo dire </l>
             <l>Che un altro, poco dopo è stato tratto </l>
@@ -2875,7 +2924,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Non vi facesse differenza, io credo </l>
             <l>Che non si scerneriano l'un dall'altro. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Questi, che da donna è vestito, certo </l>
             <l>Il ragazzo sarà del Vallonese. </l>
@@ -2890,17 +2939,17 @@ PER DOMENICO TADDEI E FIGLI <lb/>
         <div type="scene">
           <head>SCENA II </head>
           <stage>Madonna Macaria, Cosmo, Fratello del podestà. </stage>
-          <sp>
+          <sp who="#macaria">
             <speaker>Mad.</speaker>
             <l> Non dubitate ch'io non sia per dire </l>
             <l>Tutto quel che saprò. </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Io son sicuro </l>
             <l>Che vel conoscerete. </l>
           </sp>
-          <sp>
+          <sp who="#macaria">
             <speaker>Mad.</speaker>
             <l> Come? S'io </l>
             <l>Lo mi conoscerò? Volete ch'egli </l>
@@ -2908,12 +2957,12 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Che io nol conosca? Io l'ho nella memoria </l>
             <l>Vivo scolpito. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l>	 So ch'egli s'affanna </l>
             <l>Ad informar quella donna. </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Avvertire </l>
             <l>Vi bisogna che stiate in un proposto. </l>
@@ -2926,71 +2975,71 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Gli avviluppano sì, che poi non sanno </l>
             <l>I testimoni quel che debbian dire. </l>
           </sp>
-          <sp>
+          <sp who="#macaria">
             <speaker>Mad.</speaker>
             <l> Che il ver dir vuole, esser non può che franco. </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Andiamo adunque, or eccovi, messere, </l>
             <l>Che il ver vi farà veder palese </l>
             <l>Intorno al mio ragazzo. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l>	 Più bisogno </l>
             <l>Non v'è di testimoni: che io son chiaro </l>
             <l>Che non è questi quel che voi cercate. </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Pigliate le mie prove, et poscia, s'io </l>
             <l>Chiaro non vi farò che io dico il vero, </l>
             <l>Riputatemi un sciocco. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del Pod.</speaker>
             <l> I testimoni </l>
             <l>Si pigliano a provar le cose dubbie, </l>
             <l>Non le chiare et palesi come è questa. </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l>Piacciavi d'accettar le prove mie. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Se manifesto m'è che voi errate, </l>
             <l>Che volete che io faccia più di prove? </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Non so, messer, chi meglio saper possa </l>
             <l>Questa cosa di me, che l'ho nudrito </l>
             <l>Da picciolo fanciullo. Et stata è meco </l>
             <l>Questa donna quattr'anni et lo conosce. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Io voglio pur che la sententia diate </l>
             <l>Voi contra voi medesmo. Egli è huomo o donna </l>
             <l>Questo vostro ragazzo? </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Se di maschio </l>
             <l>Non è mutato in donna, era ben huomo. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Prendere havete fatta una donzella </l>
             <l>Sta mane. </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Nol vo credere. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l>	 La cosa. </l>
             <l>Chiaro ve ne farà. Ecco che viene </l>
@@ -3000,36 +3049,36 @@ PER DOMENICO TADDEI E FIGLI <lb/>
         <div type="scene">
           <head>SCENA III </head>
           <stage>Fratello del podestà, Macaria, Linda, Eutiche, Cosmo. </stage>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Che piagni tu? </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Piango che son donna, </l>
             <l>Che cagione è che io sia trista e infelice? </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Che vi par gentilhuomo? parvi forse </l>
             <l>Questi il vostro ragazzo? </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Ei mi par desso. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Et voi, Madonna, che ne dite? </l>
           </sp>
-          <sp>
+          <sp who="#macaria">
             <speaker>Mad.</speaker>
             <l> Io sono </l>
             <l>In dubbio, egli mi par nel viso quegli. </l>
             <l>Dalle parole sue tolgo la fede </l>
             <l>Parmi ch'egli sia desso. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Questo è un fermo </l>
             <l>Testimonio che havete a favor vostro. </l>
@@ -3038,44 +3087,44 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Hor intendiamo un po quel che ne avanza: </l>
             <l>Tu perché piagni. </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Perché, come io ho detto, </l>
             <l>Son più d'ogni altra misera e infelice. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Se tu misera sei, tuo il danno. Io voglio </l>
             <l>Saper chi sei, et qual cagion ti ha fatto </l>
             <l>Por questi panni indosso. </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Io son la serva </l>
             <l>Di messer Nastagio. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Tu eri serva </l>
             <l>Di quel nobil da Napoli? </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Di quello, </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Hor vedi, vedi se il figliuolo mio </l>
             <l>Haveva posto in honorato loco </l>
             <l>L'animo, et chi egli amava. </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Egli amava una </l>
             <l>Che degna è di pietade, et che se bene </l>
             <l>Povera, è honesta. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Per Dio, questi panni </l>
             <l>Mostrano aperta a ognun la sua honestade. </l>
@@ -3084,13 +3133,13 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Serva quì appresso a me. Segui: perch'hai </l>
             <l>Indosso questi panni? </l>
           </sp>
-          <sp>
+          <sp who="#eutiche">
             <speaker>Eut.</speaker>
             <l> Per venirmi </l>
             <l>Sotto la fede datami al figliuolo </l>
             <l>Vostro, il qual amo più che la mia vita. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Il mio figliuolo in così poca stima </l>
             <l>Ha dunque di me, che gli dà il cor di fare </l>
@@ -3099,77 +3148,77 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Tristerella in pregion. Ma tu perch'hai, </l>
             <l>Essendo maschio, questo habito indosso? </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Che cos'è questa ch'odo? Questi adunque, </l>
             <l>Che da donna è vestito, è huomo? </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Voi </l>
             <l>Vedete come van le cose al mondo. </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Se non fosse che io temo anch'io d'errare, </l>
             <l>Io direi che costui si fosse quegli </l>
             <l>Che si è da me fuggito. </l>
           </sp>
-          <sp>
+          <sp who="#macaria">
             <speaker>Mac.</speaker>
             <l> Anch'io mel credo. </l>
           </sp>
-          <sp>
+          <sp who="#linda">
             <speaker>Linda</speaker>
             <l> Poiché quì sono et sono mio mal grado </l>
             <l>Costretto a palesarmi, io son colui </l>
             <l>Di che cercate. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Ad ogni modo Dio </l>
             <l>Volea che ritrovassi hoggi costui. </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Ma perché ti fuggistu et perché sei </l>
             <l>Hor quì pregione in tal habito? </l>
           </sp>
-          <sp>
+          <sp who="#linda">
             <speaker>Linda</speaker>
             <l> Il grande </l>
             <l>Amore, che io portava alla figliuola </l>
             <l>Di questo messer Lin per cui son presa, </l>
             <l>Quì mi fece venir, così vestire. </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Dio voglia che non habbia qualche ingiuria </l>
             <l>Fatta a quest'huom dabbene. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Messer Lino </l>
             <l>È nobil quanto altr'huomo che sia in Patrasso: </l>
             <l>Pensate, se gli havesse fatta ingiuria </l>
             <l>Costui, a che n'uscirìa. </l>
           </sp>
-          <sp>
+          <sp who="#linda">
             <speaker>Linda</speaker>
             <l> Soccorso </l>
             <l>Datemi, messer Cosmo. </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Et che soccorso </l>
             <l>Vuoi che io ti porga? saria stato meglio </l>
             <l>Che non ti fossi mai da me fuggito. </l>
           </sp>
-          <sp>
+          <sp who="#linda">
             <speaker>Linda</speaker>
             <l> Non ha Amor legge. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Vien messer Nastagio </l>
             <l>Lascia di dir di ciò, che parlar voglio </l>
@@ -3179,36 +3228,36 @@ PER DOMENICO TADDEI E FIGLI <lb/>
         <div type="scene">
           <head>SCENA IV </head>
           <stage>Messer Nastagio, Ragazzo. </stage>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l>Et e ver che vestita da ragazzo </l>
             <l>È in corte al Podestà l'Eutiche mia? </l>
           </sp>
-          <sp>
+          <sp who="#ragazzo">
             <speaker>Rag.</speaker>
             <l> È ver. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Che dice? </l>
           </sp>
-          <sp>
+          <sp who="#ragazzo">
             <speaker>Rag.</speaker>
             <l> Io non l'ho udita </l>
             <l>Dir cosa alcuna. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Per certo è gran cosa </l>
             <l>Haver giovani serve in casa. Al fine </l>
             <l>Al fine te la cingono. </l>
           </sp>
-          <sp>
+          <sp who="#ragazzo">
             <speaker>Rag.</speaker>
             <l> Egli è vero: </l>
             <l>Ma andiamo, ché il messer m'attende. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Andiamo. </l>
           </sp>
@@ -3216,21 +3265,21 @@ PER DOMENICO TADDEI E FIGLI <lb/>
         <div type="scene">
           <head>SCENA V </head>
           <stage>Nastagio, Fratello del Podestà, Cosmo. </stage>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Io son venuto pien di maraviglia, </l>
             <l>Havendo inteso quel che m'ha costui </l>
             <l>Per parte vostra esposto. Ov'è la mia </l>
             <l>Serva gentile? </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> I' l'ho fatta tornare </l>
             <l>Ne la prigione. Io non so se vi pare </l>
             <l>Che meriti costei esser amata </l>
             <l>Da un mio figliuol. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Amor fa tali e tanti </l>
             <l>Miracoli, che a ciò non so che dire. </l>
@@ -3238,7 +3287,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Che mi usasse tal termine costei. </l>
             <l>Ma come v'è venuta nelle mani? </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Credendo questo gentilhuomo che ella </l>
             <l>Fosse un ragazzo suo perché vestita </l>
@@ -3248,51 +3297,51 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Ella il ragazzo trovato ha che è questi </l>
             <l>Che da donna è vestito. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Questo reo, </l>
             <l>Che ha fatto a messer Lin scorno sì grande! </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Che scorno gli ha egli fatto? </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Ingravidata </l>
             <l>Gli ha la figliuola. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> La figliuola? Io dissi bene </l>
             <l>Che questa veste nascondea </l>
             <l>Qualche gran scelleraggine. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Malvagio </l>
             <l>Misero te! </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Ben dite il vero. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Adunque, </l>
             <l>Gentilhuomo, questi è vostro ragazzo? </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Messer sì, è mio ragazzo; ma mi ha egli </l>
             <l>Renduto strano guidardon del bene </l>
             <l>Che fatto gli ho. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Perché? </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Perché il trovai </l>
             <l>Tredici anni fa, era Novembre, </l>
@@ -3311,30 +3360,30 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>A fare un gentilhuomo scorno sì grande. </l>
             <l>Ma suo sia il danno, tristerello. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> O Dio! </l>
             <l>Che è questo che io odo? Fate un po', di gratia, </l>
             <l>Caro Messer, condur quindi in disparte </l>
             <l>Questo pregion. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Perché, messer Nastagio? </l>
             <l>Che cosa è sopraggiunta? </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Perché io voglio </l>
             <l>Parlar, senza costui, un po' con questo </l>
             <l>Gentilhuomo da ben, se non gli è grave. </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Perché esser mi dee grave? Io farei cosa </l>
             <l>Per piacervi di questa assai maggiore. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Conducete costui quindi in disparte. </l>
           </sp>
@@ -3342,68 +3391,68 @@ PER DOMENICO TADDEI E FIGLI <lb/>
         <div type="scene">
           <head>SCENA VI </head>
           <stage>Nastagio, Cosmo, Madonna Macaria, Fratello del Podestà, Famiglio. </stage>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Ditemi, se vi è a grado, gentilhuomo, </l>
             <l>Vi è cosa alcuna che di costui fosse </l>
             <l>Quando il trovaste? </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Evvi una gemma, ch'io </l>
             <l>Gli ritrovai al collo. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Et ov'è ella? </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Non è molto lontana. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Siavi a grado </l>
             <l>Mostrarlami. </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Farollo volentieri. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Messer Nastagio, molto sottilmente </l>
             <l>Cercate questa cosa. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Vo' vedere </l>
             <l>Se tra le maraviglie d'hoggi forse </l>
             <l>Una maravigliosa ne trovassi. </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Eccolavi, pigliatela, Madonna </l>
             <l>Et levatela fuor di questa seta. </l>
           </sp>
-          <sp>
+          <sp who="#macaria">
             <speaker>Mad.</speaker>
             <l> Oimè. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Che vuol dir questo? </l>
           </sp>
-          <sp>
+          <sp who="#macaria">
             <speaker>Mad.</speaker>
             <l> Questa gemma </l>
             <l>M'ha di piacere et di gran doglia piena. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Perché Madonna? </l>
           </sp>
-          <sp>
+          <sp who="#macaria">
             <speaker>Mad.</speaker>
             <l> Perché ella mi face </l>
             <l>Certo tener, che quegli, al collo a cui </l>
@@ -3416,42 +3465,42 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Il marito e una figlia, i quali io credo </l>
             <l>Che morti siano. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Ahi, cara Elisabetta, </l>
             <l>Ah, moglie cara! </l>
           </sp>
-          <sp>
+          <sp who="#macaria">
             <speaker>Mad.</speaker>
             <l> Che volete fare? </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Io sono, moglie mia, Cesare vostro. </l>
           </sp>
-          <sp>
+          <sp who="#macaria">
             <speaker>Mad.</speaker>
             <l> Ah, caro il mio marito, io vi conosco! </l>
             <l>Pareami pur che m'avvampasse il cuore, </l>
             <l>Mentr'io vi udia cercar del nostro figlio. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Questa mi par la più mirabil cosa, </l>
             <l>Che mai ai giorni miei vedessi. Questi </l>
             <l>In Patrasso Nastagio è sempre stato, </l>
             <l>Et hora è Cesar. </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Io quest'altra ho havuta </l>
             <l>Per Macaria, hor la trovo Elisabetta. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Moglie mia cara quanto son contento! </l>
           </sp>
-          <sp>
+          <sp who="#macaria">
             <speaker>Mac.</speaker>
             <l> Né men contenta io son, marito mio, </l>
             <l>Poiché voi trovato ho, trovato ho il figlio: </l>
@@ -3460,7 +3509,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Così trovata havessimo la figlia, </l>
             <l>Che col nostro figliuol perdemmo allhora! </l>
           </sp>
-          <sp>
+          <sp who="fratello">
             <speaker>Fra. del pod.</speaker>
             <l> Messer Nastagio, s'è figliuol vostro </l>
             <l>Eugenio, è vostra figlia ancho colei </l>
@@ -3469,11 +3518,11 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Me ne dà quasi testimonio chiaro. </l>
             <l>Come si domand'ella? </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Ha nome Eutiche. </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Simile nome pose il Raguseo </l>
             <l>Alla fanciulla, ch'ei ritrovò meco, </l>
@@ -3484,67 +3533,67 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Da corsali et condotta qui in Patrasso, </l>
             <l>Dai quai la comperai cento fiorini. </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> V'ha ella detto mai u'fosse tolta? </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Da Ragusa. </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Vi ha detto forse il nome </l>
             <l>Del Raguseo? </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> La mia ha detto, et credo </l>
             <l>Ch'egli Demetrio havesse nome. </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> È desso; </l>
             <l>Senza alcun dubbio questa è vostra figlia. </l>
           </sp>
-          <sp>
+          <sp who="#macaria">
             <speaker>Mad.</speaker>
             <l> Ciò voglia Dio! Su la sinistra mamma </l>
             <l>Havea una rosa la figliuola nostra. </l>
           </sp>
-          <sp>
+          <sp who="fratello">
             <speaker>Frat. del p.</speaker>
             <l> Va ad Eufrosina, et di che ella la guati </l>
             <l>Et tornaloci a dir. Questa sarebbe </l>
             <l>Una delle venture, che di rado </l>
             <l>Venir sogliono al mondo. </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Così è certo </l>
             <l>La figlia lor colei, come io sono io. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Dio ce ne presti gratia. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Viene il messo, </l>
             <l>Che ciò chiarirà il dubbio. </l>
           </sp>
-          <sp>
+          <sp who="#famiglio">
             <speaker>Fam.</speaker>
             <l> La Eufrosina </l>
             <l>Dice che la ve l'ha. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Figliuola mia, </l>
             <l>Come t'ho havuta già quattro anni in casa, </l>
             <l>E non t'ho conosciuta? </l>
           </sp>
-          <sp>
+          <sp who="#macaria">
             <speaker>Mad.</speaker>
             <l> Et come anch'io </l>
             <l>Stata son col mio figlio poco meno, </l>
@@ -3552,7 +3601,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Io mel sentiva assai di miglior core, </l>
             <l>Che non doveva amarsi huom straniero. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Molto mi godo che così felici </l>
             <l>Vi veggia, et prego Dio che mai non turbi </l>
@@ -3567,19 +3616,19 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>E a voi Madonna, ch'egli la si prenda </l>
             <l>Per sua moglie. </l>
           </sp>
-          <sp>
+          <sp who="#macaria">
             <speaker>Mad.</speaker>
             <l> Oh allegrezza immensa! </l>
             <l>È ben stata una venuta questa </l>
             <l>Felice hoggi per me. </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Per ambi noi, </l>
             <l>Madonna; ché io non ne ho gioja minore, </l>
             <l>Ch'habbiate voi di questo vostro bene. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Credo per la mia fè, messer Nastagio, </l>
             <l>Che mai non desse a un huom in un sol giorno </l>
@@ -3588,7 +3637,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Come in Patrasso voi veniste, essendo </l>
             <l>Come ho inteso da Napoli. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Dirollo </l>
             <l>Tanto più volentier, quanto son quasi </l>
@@ -3621,13 +3670,13 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Ben son giocondi, poscia che io ritrovo </l>
             <l>Fuor d'ogni mio pensier, tutti i miei vivi. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Volea Dio che voi foste felice. </l>
             <l>Et come vi salveste voi, Madonna, </l>
             <l>Fra così gran fortuna. </l>
           </sp>
-          <sp>
+          <sp who="#macaria">
             <speaker>Mad.</speaker>
             <l> Appresa a un asse </l>
             <l>A Durazzo fui spinta et ivi fui </l>
@@ -3640,12 +3689,12 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>M'acconciai con messer Cosmo, il quale </l>
             <l>Hoggi condotta m'ha a tanta gioja. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Egli ver è certo quel che dir si suole: </l>
             <l>Chi Dio vuole aiutar, non può perire. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Messer Lin vien di qua, voglio che, prima </l>
             <l>Che andiamo a Eugenio, a Eutiche, il racchetiamo </l>
@@ -3653,12 +3702,12 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Et credo che egli anchora sia contento </l>
             <l>Ch'habbia sì lieto fin la sua gran doglia. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Deve essere contento. Non poteva </l>
             <l>Haver miglior partito in questa terra. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Gir gli vo incontro. Siete voi contenti </l>
             <l>D'aspettarmi qui insiem insin che io torni. </l>
@@ -3667,7 +3716,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
         <div type="scene">
           <head>SCENA VII </head>
           <stage>Lino, Fratello del podestà, Nastagio, Macaria, Cosmo. </stage>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Mi ha messo questo scellerato in tanto </l>
             <l>Furore e in tanta rabbia, che a fatica </l>
@@ -3675,177 +3724,177 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>A Marcella la morte. Io non veggio </l>
             <l>L'hora che egli habbia guiderdon de l'opre. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Come egli è in ira! Se ei sapesse quello </l>
             <l>Che noi sappiam, come sarebbe lieto! </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Sete molto adirato, messer Lino. </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Et forse che non ho giusta ragione? </l>
             <l>Dio vi guardi da ciò, messer Nastagio. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Rimedio ha il vostro mal pur che vogliate </l>
             <l>Che vi si dia. </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Che volete ch'io faccia? </l>
             <l>Pensate che veder voglio ogni strazio </l>
             <l>Di questo traditor. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> So che perdono </l>
             <l>Gli darete. </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Non mai. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> È messer Lino </l>
             <l>Fuor di se. </l>
           </sp>
-          <sp>
+          <sp who="#macaria">
             <speaker>Mad.</speaker>
             <l> Pur che quetar si possa </l>
             <l>A qualche modo. </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Non v'è dubbio. </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Io voglio </l>
             <l>Prima morir, se gli perdono mai. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Quando vi fosse l'honor vostro? </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Come </l>
             <l>Esser vi può il mio honore. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Andiamo insieme </l>
             <l>Là dove egli è, che lo vi troveremo. </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Vi voglio ben venir per lo suo stratio, </l>
             <l>Ma non per ciò. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Venite un poco meco, </l>
             <l>Che pensier muterete, udendo cosa </l>
             <l>Che potrà raddolcire il vostro amaro. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Vi veggio molto acceso d'ira. </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Parvi </l>
             <l>Che il mio sia caso da non adirarsi? </l>
             <l>È troppo aspra, crudele et troppo fiera </l>
             <l>La piaga che ho nel cor. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Somar lo voglio </l>
             <l>Prima che quindi vi partiate. </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> È piaga </l>
             <l>Questa d'haver rimedio in un momento? </l>
             <l>Semplice ben serei se mel credessi. </l>
           </sp>
-          <sp>
+          <sp who="fratello">
             <speaker>Frat. del p.</speaker>
             <l> A me pare altrimenti et meglio parmi </l>
             <l>Che a voi non pare. Se messer Nastagio </l>
             <l>A vostra figlia desse un suo figliuolo </l>
             <l>Per marito, sareste voi contento? </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Come puote questo, non havendo </l>
             <l>Messer Nastagio figli? </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Se ne havesse? </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> A che disegno far su conditione </l>
             <l>Che esser non puote? </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Rispondete un poco </l>
             <l>A quel che vi dimando: se n'havesse, </l>
             <l>Et ne volesse dare a vostra figlia </l>
             <l>Un per marito? </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Io ne sarei tanto </l>
             <l>Lieto, quanto hor son mesto. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Quegli adunque, </l>
             <l>Per cui sì vi volete, si è scoperto </l>
             <l>Fuor d'ogni openione esser suo figlio. </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> È gran cosa, messer, che chi è infelice </l>
             <l>Sia giuoco dei felici. </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Havete torto. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Egli è mio, messer Lino. </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Et come puote </l>
             <l>Esser questo avvenuto? </l>
           </sp>
-          <sp>
+          <sp who="#fratello">
             <speaker>Frat. del pod.</speaker>
             <l> Havrete tempo </l>
             <l>D'intendere il soccesso, rispondete </l>
             <l>Se ne siete contento? </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Se la cosa </l>
             <l>È come voi mi dite et sia contento </l>
             <l>Messer Nastagio, io non vi vo far niego, </l>
             <l>Et questo più che ogni altra cosa bramo. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Io vi ringrazio molto e assai mi piace </l>
             <l>Che se ne sia passata in parentado </l>
@@ -3856,43 +3905,43 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>La quale è divenuta oggi mogliera </l>
             <l>Del figliuol del messere. </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Mi par gran cosa </l>
             <l>Questa per certo, et son molto contento </l>
             <l>Che anch'io parte habbia in così gran letitia. </l>
             <l>Questi chi egli è? </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> È quegli che nudrito </l>
             <l>Ha il mio figliuolo et salvata la moglie: </l>
             <l>A la cui somma cortesia io debbo </l>
             <l>La maggior parte de la gioia mia. </l>
           </sp>
-          <sp>
+          <sp who="#lino">
             <speaker>Lino</speaker>
             <l> Né meno anch'io vi debbo. Sarò sempre </l>
             <l>Pronto ai piacer vostri. </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Io vi ringratio: </l>
             <l>Ma temp'è che caviam fuori d'angoscia </l>
             <l>I due sposi pregioni. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Che è costui </l>
             <l>Che di qua viene? Egli è Lamprino: io voglio </l>
             <l>Saper che nuova egli m'apporta; voi </l>
             <l>In casa ve n'andrete ai novi sposi. </l>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>Cosmo</speaker>
             <l> Come vi piace. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Io gli vo gire incontro. </l>
           </sp>
@@ -3900,7 +3949,7 @@ PER DOMENICO TADDEI E FIGLI <lb/>
         <div type="scene">
           <head>SCENA VII </head>
           <stage>Lamprino, Nastagio. </stage>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Poiché da Chelidonia io mi partii, </l>
             <l>Per l'uscio quì di dietro era ito a casa </l>
@@ -3917,20 +3966,20 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Egli il bene inteso ha che ci è avvenuto. </l>
             <l>Padron, caro padron? </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Che ci è, Lamprino? </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lam.</speaker>
             <l> Che ci è, io vi vo dare una novella, </l>
             <l>Che vi terrete esser beato al mondo. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Che cosa, è mio Lamprino? </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Messer Cosmo, </l>
             <l>Vostro compar, vi fa saper che, essendo </l>
@@ -3939,35 +3988,35 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Siete in esilio, et vi fa piena gratia </l>
             <l>E vi rintegra appien di tutto il vostro. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Questo t'ha detto il mio compar. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Questo </l>
             <l>M'ha detto con letitia tal che appena </l>
             <l>Credo che sia la vostra tal. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> O Dio, </l>
             <l>Quanto ti son tenuto! Quando mai </l>
             <l>Fosti sì largo a un huom de le tue gratie? </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Eccovi la patente, che ei m'ha data </l>
             <l>Riceputa dal Re. L'havria portata </l>
             <l>Egli, ma per lo spatio che ha in dogana, </l>
             <l>Dal porto a voi non ha potuto. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Questo sol ci mancava a far che pieni </l>
             <l>Fossimo alfin d'ogni piacere humano. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Et detto m'ha che il Re ha promessi premi </l>
             <l>Grandi a ognun, che di voi, o della moglie, </l>
@@ -3976,17 +4025,17 @@ PER DOMENICO TADDEI E FIGLI <lb/>
             <l>Poiché non s'ha se non di voi notitia, </l>
             <l>Che al Re vi manifesti. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Anzi di tutti </l>
             <l>Vo che nova gli porti: che trovati </l>
             <l>Hoggi ho la moglie et ambi i figli miei. </l>
           </sp>
-          <sp>
+          <sp who="#lamprino">
             <speaker>Lamp.</speaker>
             <l> Et come ciò è avvenuto. </l>
           </sp>
-          <sp>
+          <sp who="#nastagio">
             <speaker>Nast.</speaker>
             <l> Entriamo in casa, </l>
             <l>Ove saprai il tutto et te n'andrai </l>

--- a/tei/giraldi-cinzio-orbecche.xml
+++ b/tei/giraldi-cinzio-orbecche.xml
@@ -81,6 +81,55 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="nemesi">
+            <persName>Nemesi</persName>
+          </person>
+          <personGrp xml:id="furie">
+            <name>Furie</name>
+          </personGrp>
+          <person xml:id="ombra_di_selina">
+            <persName>Ombra di Selina</persName>
+          </person>
+          <personGrp xml:id="coro">
+            <name>Coro</name>
+          </personGrp>
+          <person xml:id="orbecche">
+            <persName>Orbecche</persName>
+          </person>
+          <person xml:id="nodrice">
+            <persName>Nodrice</persName>
+          </person>
+          <person xml:id="oronte">
+            <persName>Oronte</persName>
+          </person>
+          <person xml:id="malecche">
+            <persName>Malecche</persName>
+          </person>
+          <person xml:id="sulmone">
+            <persName>Sulmone</persName>
+          </person>
+          <person xml:id="messo">
+            <persName>Messo</persName>
+          </person>
+          <person xml:id="tamule">
+            <persName>Tamule</persName>
+          </person>
+          <person xml:id="allocche">
+            <persName>Allocche</persName>
+          </person>
+          <personGrp xml:id="semicoro">
+            <name>Semicoro</name>
+          </personGrp>
+          <personGrp xml:id="donne">
+            <name>Donne di corte</name>
+          </personGrp>
+          <person xml:id="tragedia">
+            <persName>Tragedia</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>2003-05-27T00:00:00.000+02:00</date><name>Silvia Caglioni</name><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -117,8 +166,7 @@
         <head>
           <hi rend="sc">L'ARGOMENTO</hi>
         </head>
-        <p>
-          <name>Orbecche</name> figliuola di <name>Sulmone</name> Re di
+        <p><name>Orbecche</name> figliuola di <name>Sulmone</name> Re di
           <name>Persia</name>, essendo fanciulla, fanciullescamente diede
           indizio al padre che <name>Selina</name> sua mogliera e madre di lei
           si giacca col suo primogenito. <name>Sulmone,</name> trovatigli
@@ -156,8 +204,7 @@
         </list>
       </div>
       <div type="prologue">
-        <head>
-          <hi rend="sc">DONNE DI CORTE</hi> d'<name>Orbecche</name>
+        <head><hi rend="sc">DONNE DI CORTE</hi> d'<name>Orbecche</name>
           Il Coro è di Donne di <name>Susa.</name>
         </head>
         <head>
@@ -270,10 +317,9 @@
           <head>
             <hi rend="sc">SCENA I</hi>
           </head>
-          <stage>
-            <hi rend="sc">NEMESI</hi> Dea, <hi rend="sc">FURIE</hi> infernali
+          <stage><hi rend="sc">NEMESI</hi> Dea, <hi rend="sc">FURIE</hi> infernali
           </stage>
-          <sp>
+          <sp who="#nemesi">
             <speaker>
               <hi rend="sc">NEM.</hi>
             </speaker>
@@ -380,7 +426,7 @@
             <l>Ad essequir quello che 'l sommo <name>Giove</name></l>
             <l>A strazio di <name>Sulmon</name> per me ve impone.</l>
           </sp>
-          <sp>
+          <sp who="#furie">
             <speaker>FUR.</speaker>
             <l>Eccone: siam, possente Dea, per fare</l>
             <l>Tutto quel che da te ne sarà imposto.</l>
@@ -393,7 +439,7 @@
             <l>Imponi pur ciò che noi far devemo,</l>
             <l>Che in un momento fia ispedito il tutto.</l>
           </sp>
-          <sp>
+          <sp who="#nemesi">
             <speaker>NEM.</speaker>
             <l>Empiete adunque di furor si grave</l>
             <l>Quest'empia corte ove <name>Sulmon</name> soggiorna </l>
@@ -405,11 +451,11 @@
             <l>E che 'l padre e la figlia, d'ira accesi,</l>
             <l>Non cerchino altro che dolore e morte.</l>
           </sp>
-          <sp>
+          <sp who="#furie">
             <speaker>FUR.</speaker>
             <l>Ecco ch'a pieno ora compimo il tutto.</l>
           </sp>
-          <sp>
+          <sp who="#nemesi">
             <speaker>NEM.</speaker>
             <l>Assai fatt'è; veloci omai tornate</l>
             <l>A le case di <name>Dite</name>, a i regni oscuri,</l>
@@ -426,7 +472,7 @@
             <hi rend="sc">SCENA II</hi>
           </head>
           <stage><hi rend="sc">OMBRA</hi> di <name>Selina</name>, moglie di <name>Sulmone</name></stage>
-          <sp>
+          <sp who="#ombra_di_selina">
             <speaker><hi rend="sc">OMBRA</hi> di <name>Selina</name>,</speaker>
             <l>Uscita i' son da le tartaree rive</l>
             <l>Onde si son partite or le tre Dee</l>
@@ -523,7 +569,7 @@
           <head>
             <hi rend="sc">CORO</hi>
           </head>
-          <sp>
+          <sp who="#coro">
             <speaker>
               <hi rend="sc">CORO</hi>
             </speaker>
@@ -611,18 +657,17 @@
           <head>
             <hi rend="sc">SCENA I</hi>
           </head>
-          <stage>
-            <name><hi rend="sc">ORBECCHE</hi></name> figliuola del Re
+          <stage><name><hi rend="sc">ORBECCHE</hi></name> figliuola del Re
             <name>Sulmone</name>, <hi rend="sc">NODRICE</hi>
           </stage>
-          <sp>
+          <sp who="#orbecche">
             <speaker>
               <hi rend="sc">ORB.</hi>
             </speaker>
             <l>Ai, quanto brevi sono i piacer nostri!</l>
             <l>Quanto vicin al riso è sempre il pianto! </l>
           </sp>
-          <sp>
+          <sp who="#nodrice">
             <speaker>
               <hi rend="sc">NOD.</hi>
             </speaker>
@@ -630,7 +675,7 @@
             <l>Parmi che sia la mia Reina: i' voglio</l>
             <l>Veder s'è dessa e che dolor l'afflige.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>
               <hi rend="sc">ORB.</hi>
             </speaker>
@@ -642,14 +687,14 @@
             <l>Se non ombra di bene, ma l'angoscie</l>
             <l>Son più che 'l ver veraci: et io in me il provo.</l>
           </sp>
-          <sp>
+          <sp who="#nodrice">
             <speaker>
               <hi rend="sc">NOD.</hi>
             </speaker>
             <l>E che cosa è che sì v'afflige e preme,</l>
             <l>Essendo vivo il vostro <name>Oronte</name> e i figli?</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>
               <hi rend="sc">ORB.</hi>
             </speaker>
@@ -665,7 +710,7 @@
             <l>Si trovin vivi. è ben morire a tempo</l>
             <l part="I">Un don dato dal cielo.</l>
           </sp>
-          <sp>
+          <sp who="#nodrice">
             <speaker>
               <hi rend="sc">NOD.</hi>
             </speaker>
@@ -675,14 +720,14 @@
             <l>Al vostro ragionare avete fatto!</l>
             <l>Che strano augurio, oimè misera, è questo!</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>
               <hi rend="sc">ORB.</hi>
             </speaker>
             <l>Egli è, Nodrice mia, pur troppo strano</l>
             <l>E infelice son io più d'ogni donna.</l>
           </sp>
-          <sp>
+          <sp who="#nodrice">
             <speaker>
               <hi rend="sc">NOD.</hi>
             </speaker>
@@ -691,7 +736,7 @@
             <l>Ditemi la cagion di sì gran doglia,</l>
             <l>Che forse al vostro mal sarà rimedio.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>
               <hi rend="sc">ORB.</hi>
             </speaker>
@@ -733,14 +778,14 @@
             <l>Acciò che 'n questa mia vecchiezza estrema</l>
             <l>Vegga la succession de' miei nepoti.</l>
           </sp>
-          <sp>
+          <sp who="#nodrice">
             <speaker>
               <hi rend="sc">NOD.</hi>
             </speaker>
             <l>Ben fu troppo improviso questo assalto</l>
             <l>E da devervi tòrre ogni consiglio.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>
               <hi rend="sc">ORB.</hi>
             </speaker>
@@ -782,7 +827,7 @@
             <l>Ma poi che tu di lui prima sei giunta,</l>
             <l>Dammi soccorso a l'ultimo bisogno.</l>
           </sp>
-          <sp>
+          <sp who="#nodrice">
             <speaker>
               <hi rend="sc">NOD.</hi>
             </speaker>
@@ -837,7 +882,7 @@
             <l>Non Dea (come s'istima), e 'l suo potere</l>
             <l>Forza non ha, s'altri v'oppon lo 'ngegno.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>
               <hi rend="sc">ORB.</hi>
             </speaker>
@@ -847,7 +892,7 @@
             <l>E senza darli del mio affanno indizio,</l>
             <l>Di' che con gran desio l'aspetto in casa.</l>
           </sp>
-          <sp>
+          <sp who="#nodrice">
             <speaker>
               <hi rend="sc">NOD.</hi>
             </speaker>
@@ -862,7 +907,7 @@
           <stage>
             <hi rend="sc">NODRICE, <name>ORONTE</name></hi>
           </stage>
-          <sp>
+          <sp who="#nodrice">
             <speaker>
               <hi rend="sc">NOD.</hi>
             </speaker>
@@ -979,7 +1024,7 @@
             <l>è gran pezza, Signor, che la Reina</l>
             <l>Brama vedervi e ragionar con voi.</l>
           </sp>
-          <sp>
+          <sp who="#oronte">
             <speaker>
               <hi rend="sc">ORON.</hi>
             </speaker>
@@ -993,7 +1038,7 @@
           <stage>
             <hi rend="sc"><name>ORONTE</name>, <name>ORBECCHE</name></hi>
           </stage>
-          <sp>
+          <sp who="#oronte">
             <speaker>
               <hi rend="sc">ORON.</hi>
             </speaker>
@@ -1005,14 +1050,14 @@
             <l>Senza opporsi al furor: che spesse volte</l>
             <l>Vince l'altrui valor l'aspra tempesta.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>
               <hi rend="sc">ORB.</hi>
             </speaker>
             <l>Non è meno di me misero <name>Oronte,</name></l>
             <l>Se da gli atti si può vedere il core.</l>
           </sp>
-          <sp>
+          <sp who="#oronte">
             <speaker>
               <hi rend="sc">ORON.</hi>
             </speaker>
@@ -1026,14 +1071,14 @@
             <l>Spero nel Re che 'l tutto ordina e regge</l>
             <l>Vincere al fine la fortuna iniqua.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>
               <hi rend="sc">ORB.</hi>
             </speaker>
             <l>Oimè, che sarà questo? sarà forse</l>
             <l>Giunto novo dolore al nostro affanno?</l>
           </sp>
-          <sp>
+          <sp who="#oronte">
             <speaker>
               <hi rend="sc">ORON.</hi>
             </speaker>
@@ -1043,14 +1088,14 @@
             <l>Sono, ha molt'anni, perch'io la disponga</l>
             <l>Che pigli per marito il Re <name>Selino.</name></l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>
               <hi rend="sc">ORB.</hi>
             </speaker>
             <l>Lo veggio molto tristo: ir gli vo' incontro</l>
             <l>E insieme si dorremo ambo del male.</l>
           </sp>
-          <sp>
+          <sp who="#oronte">
             <speaker>
               <hi rend="sc">ORON.</hi>
             </speaker>
@@ -1064,7 +1109,7 @@
             <l><name>Dio</name> vi dia, anima mia, pace e contento:</l>
             <l>Qual van pensiero a lagrimar vi mena?</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>
               <hi rend="sc">ORB.</hi>
             </speaker>
@@ -1078,7 +1123,7 @@
             <l>Onde bisogno fia ch'ora si scuopra</l>
             <l>Quel che ne farà sempre esser dolenti.</l>
           </sp>
-          <sp>
+          <sp who="#oronte">
             <speaker>
               <hi rend="sc">ORON.</hi>
             </speaker>
@@ -1116,7 +1161,7 @@
             <l>Che se noi stessi a desperar si demo,</l>
             <l>Chi ne porgerà aiuto o chi consiglio ?</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>
               <hi rend="sc">ORB.</hi>
             </speaker>
@@ -1128,7 +1173,7 @@
             <l>Ch'al mio fratel sia stato e a la mia madre,</l>
             <l>Quai lo spietato insieme a un colpo uccise?</l>
           </sp>
-          <sp>
+          <sp who="#oronte">
             <speaker>
               <hi rend="sc">ORON.</hi>
             </speaker>
@@ -1140,7 +1185,7 @@
             <l>Deveva il figlio, sì poco prezzasse</l>
             <l>Ch'ei con la propria madre si giacesse.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>
               <hi rend="sc">ORB.</hi>
             </speaker>
@@ -1152,7 +1197,7 @@
             <l>Per qual error uccise il suo fratello,</l>
             <l>Ch'avanzava in bontade ogni mortale?</l>
           </sp>
-          <sp>
+          <sp who="#oronte">
             <speaker>
               <hi rend="sc">ORON.</hi>
             </speaker>
@@ -1208,7 +1253,7 @@
             <l>Che, nata nel tranquil del nostro stato,</l>
             <l part="I">Sì ne minaccia.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>
               <hi rend="sc">ORB.</hi>
             </speaker>
@@ -1225,7 +1270,7 @@
             <l>E di ciò che da voi fia fatto, anch'io</l>
             <l>Mi rimarò con voi paga e contenta.</l>
           </sp>
-          <sp>
+          <sp who="#oronte">
             <speaker>
               <hi rend="sc">ORON.</hi>
             </speaker>
@@ -1233,7 +1278,7 @@
             <l>Datevi intanto voi pace e sperate</l>
             <l>Che ne saranno i Dei anco benigni.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>
               <hi rend="sc">ORB.</hi>
             </speaker>
@@ -1242,13 +1287,13 @@
             <l>Pur senza voi non mi lasciate molto,</l>
             <l>O buona che ne sia la nova o rea.</l>
           </sp>
-          <sp>
+          <sp who="#oronte">
             <speaker>
               <hi rend="sc">ORON.</hi>
             </speaker>
             <l part="I">Cosi farò: restate in pace.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>
               <hi rend="sc">ORB.</hi>
             </speaker>
@@ -1260,7 +1305,7 @@
             <hi rend="sc">SCENA IIII</hi>
           </head>
           <stage><name><hi rend="sc">ORBECCHE</hi></name> sola</stage>
-          <sp>
+          <sp who="#orbecche">
             <speaker>
               <hi rend="sc">ORBECCHE</hi>
             </speaker>
@@ -1374,7 +1419,7 @@
           <head>
             <hi rend="sc">CORO</hi>
           </head>
-          <sp>
+          <sp who="#coro">
             <speaker>
               <hi rend="sc">CORO</hi>
             </speaker>
@@ -1444,7 +1489,7 @@
             <hi rend="sc">SCENA I</hi>
           </head>
           <stage><name><hi rend="sc">MALECCHE</hi></name> solo, consiglieri del Re</stage>
-          <sp>
+          <sp who="#malecche">
             <speaker>
               <hi rend="sc">MALECCHE</hi>
             </speaker>
@@ -1543,26 +1588,26 @@
             <hi rend="sc">SCENA II</hi>
           </head>
           <stage><hi rend="sc">SULMONE</hi> Re, <hi rend="sc">MESSO</hi>, <hi rend="sc">MALECCHE</hi></stage>
-          <sp>
+          <sp who="#sulmone">
             <speaker>
               <hi rend="sc">SUL.</hi>
             </speaker>
             <l part="I">È quel ch'io veggio là <name>Malecche?</name></l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>
               <hi rend="sc">MES.</hi>
             </speaker>
             <l part="F">È desso.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>
               <hi rend="sc">SUL.</hi>
             </speaker>
             <l>Vanne a lui e li di' ch'a me ne venga</l>
             <l part="I">Con esso teco di presente.</l>
           </sp>
-          <sp>
+          <sp who="#malecche">
             <speaker>
               <hi rend="sc">MAL.</hi>
             </speaker>
@@ -1577,14 +1622,14 @@
             <l>Il poter ragionare oggi d'<name>Oronte</name></l>
             <l part="I">Mi sarà tolto.</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>
               <hi rend="sc">MES.</hi>
             </speaker>
             <l part="F">Il Re nostro vi chiede,</l>
             <l part="I">Signor <name>Malecche.</name></l>
           </sp>
-          <sp>
+          <sp who="#malecche">
             <speaker>
               <hi rend="sc">MAL.</hi>
             </speaker>
@@ -1592,7 +1637,7 @@
             <l>Dimmi, se forse il sai, che vuol dir ch'egli</l>
             <l>Si mostra sì turbato ne l'aspetto?</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>
               <hi rend="sc">MES.</hi>
             </speaker>
@@ -1603,13 +1648,13 @@
             <l>Lasciar che 'n esso possa ira né sdegno</l>
             <l>O mostrar fuor così palese il core.</l>
           </sp>
-          <sp>
+          <sp who="#malecche">
             <speaker>
               <hi rend="sc">MAL. </hi>
             </speaker>
             <l part="I">Che quel da me la vostra altezza?</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>
               <hi rend="sc">SUL. </hi>
             </speaker>
@@ -1620,14 +1665,14 @@
             <l>Conoscer fede in famigliare alcuno,</l>
             <l>Quand'i medesmi figli lor fan froda.</l>
           </sp>
-          <sp>
+          <sp who="#malecche">
             <speaker>
               <hi rend="sc">MAL.</hi>
             </speaker>
             <l>Sarà palese al Re per altra via</l>
             <l>Il tutto: ogni secreto alfin si scuopre.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>
               <hi rend="sc">SUL.</hi>
             </speaker>
@@ -1644,14 +1689,14 @@
             <l>Sangue creato insin da' suoi primi anni</l>
             <l part="I">Ne la mia corte s'è nodrito.</l>
           </sp>
-          <sp>
+          <sp who="#malecche">
             <speaker>
               <hi rend="sc">MAL.</hi>
             </speaker>
             <l part="F">E questi</l>
             <l part="I">Chi è egli stato?</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>
               <hi rend="sc">SUL.</hi>
             </speaker>
@@ -1659,14 +1704,14 @@
             <l>Che mi si dimostrava sì fedele;</l>
             <l>E due figliuoli già d'essi son nati.</l>
           </sp>
-          <sp>
+          <sp who="#malecche">
             <speaker>
               <name>MAL.</name>
             </speaker>
             <l>Et ond'avete voi saputo questo?</l>
             <l part="I">Da essi forse?</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>
               <hi rend="sc">SUL.</hi>
             </speaker>
@@ -1698,7 +1743,7 @@
             <l>Sì che bramo d'udir ciò che ti paia </l>
             <l>Ch'io debba far in casi acerba offesa.</l>
           </sp>
-          <sp>
+          <sp who="#malecche">
             <speaker>
               <hi rend="sc">MAL.</hi>
             </speaker>
@@ -1734,7 +1779,7 @@
             <l>Tant'esser dee da più tenuto quello</l>
             <l>Ch'ad atto sì cortese il core inchina.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>
               <hi rend="sc">SUL.</hi>
             </speaker>
@@ -1750,7 +1795,7 @@
             <l>E s'io saprò mostrare ad ambo loro</l>
             <l>(Com'a molti ho mostrato) esser Re vero.</l>
           </sp>
-          <sp>
+          <sp who="#malecche">
             <speaker>
               <hi rend="sc">MAL.</hi>
             </speaker>
@@ -1758,7 +1803,7 @@
             <l>O 'l far vendetta de gli oltraggi avuti </l>
             <l>Non mostraro alcun Re.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>
               <hi rend="sc">SUL.</hi>
             </speaker>
@@ -1766,7 +1811,7 @@
             <l>Ch'ei s'offra a ognun per manifesto segno</l>
             <l>Ove si drizzi ogni nefanda ingiuria?</l>
           </sp>
-          <sp>
+          <sp who="#malecche">
             <speaker>
               <hi rend="sc">MAL.</hi>
             </speaker>
@@ -1786,7 +1831,7 @@
             <l>Potrete voi mostrar d'esser Re vero,</l>
             <l>Di questa che vi s'offre ora dinanzi?</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>
               <hi rend="sc">SUL.</hi>
             </speaker>
@@ -1796,7 +1841,7 @@
             <l>E scerner non sapessi il ver dal falso?</l>
             <l part="I">Tu sei ben fuor di te.</l>
           </sp>
-          <sp>
+          <sp who="#malecche">
             <speaker>
               <hi rend="sc">MAL.</hi>
             </speaker>
@@ -1812,13 +1857,13 @@
             <l>E che m'è via più a core il vostro meglio</l>
             <l>Che 'l proprio mio, non che quel d'alcun altro.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>
               <hi rend="sc">SUL.</hi>
             </speaker>
             <l part="I">Or segui.</l>
           </sp>
-          <sp>
+          <sp who="#malecche">
             <speaker>
               <hi rend="sc">MAL.</hi>
             </speaker>
@@ -1872,14 +1917,14 @@
             <l>Che per così onorata e sì bell'opra</l>
             <l>Non alzi il vostro nome insino al cielo.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>
               <hi rend="sc">SUL.</hi>
             </speaker>
             <l>Facile è dar ne' casi altrui consiglio,</l>
             <l>Ma se tu fossi me, ciò non diresti.</l>
           </sp>
-          <sp>
+          <sp who="#malecche">
             <speaker>
               <hi rend="sc">MAL.</hi>
             </speaker>
@@ -1899,7 +1944,7 @@
             <l>In cosa tal che voi anco direste</l>
             <l>Ch'io dico il ver.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>
               <hi rend="sc">SUI.</hi>
             </speaker>
@@ -1907,7 +1952,7 @@
             <l>Senza sospetto alcun, che mi fia a grado</l>
             <l part="I">Udirti.</l>
           </sp>
-          <sp>
+          <sp who="#malecche">
             <speaker>
               <hi rend="sc">MAL.</hi>
             </speaker>
@@ -1999,14 +2044,14 @@
             <l>A quest'oltraggio, a questa grave ingiuria</l>
             <l>Che fatt'ha a <name>Oronte</name> la fortuna iniqua.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>
               <hi rend="sc">SUL.</hi>
             </speaker>
             <l>Che poss'io forse far d'una colomba</l>
             <l>Un'aquila? o d'un toppo un leon fiero?</l>
           </sp>
-          <sp>
+          <sp who="#malecche">
             <speaker>
               <hi rend="sc">MAL.</hi>
             </speaker>
@@ -2016,14 +2061,14 @@
             <l>Del regno eredi e a questo modo avrete</l>
             <l>Gener ugual al vostro eccelso stato.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>
               <hi rend="sc">SUL.</hi>
             </speaker>
             <l>Io lo farò ben Re per modo tale</l>
             <l>Che gli dorrà d'avermi unqua veduto.</l>
           </sp>
-          <sp>
+          <sp who="#malecche">
             <speaker>
               <hi rend="sc">MAL.</hi>
             </speaker>
@@ -2043,14 +2088,14 @@
             <l>Eletto<name> Oronte</name> per marito, merta</l>
             <l>Ch'ad ambedue doniate omai perdono.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>
               <hi rend="sc">SUL. </hi>
             </speaker>
             <l>Tu mi vuoi far, <name>Malecche,</name> uscir del giusto</l>
             <l part="I">Con queste tue parole.</l>
           </sp>
-          <sp>
+          <sp who="#malecche">
             <speaker>
               <hi rend="sc">MAL.</hi>
             </speaker>
@@ -2066,14 +2111,14 @@
             <l>Sovra ambo lor, ma sovra questo vecchio</l>
             <l>Che torria di morir per l'onor vostro.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>
               <hi rend="sc">SUL.</hi>
             </speaker>
             <l>Deh, se questo mi mostri, creder voglio</l>
             <l>Che si possan nodrir ne l'aria i cervi.</l>
           </sp>
-          <sp>
+          <sp who="#malecche">
             <speaker>
               <hi rend="sc">MAL.</hi>
             </speaker>
@@ -2081,13 +2126,13 @@
             <l>Deppor lo sdegno e dar benigna udienza </l>
             <l>A quel ch'io vi dirò con vera fede.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>
               <hi rend="sc">SUL.</hi>
             </speaker>
             <l part="I">Or segui.</l>
           </sp>
-          <sp>
+          <sp who="#malecche">
             <speaker>
               <hi rend="sc">MAL.</hi>
             </speaker>
@@ -2103,7 +2148,7 @@
             <l>Col suo invitto valor ben mille volte</l>
             <l>Levato ha 'n tutto da l'impero vostro.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>
               <hi rend="sc">SUL.</hi>
             </speaker>
@@ -2113,7 +2158,7 @@
             <l>Al popul mio, né via miglior di questa</l>
             <l part="I">Si potea ritrovar.</l>
           </sp>
-          <sp>
+          <sp who="#malecche">
             <speaker>
               <hi rend="sc">MAL.</hi>
             </speaker>
@@ -2153,14 +2198,14 @@
             <l>Già merta questa età canuta e grave</l>
             <l>Pace e riposo, non travaglio o guerra.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>
               <hi rend="sc">SUL.</hi>
             </speaker>
             <l>Chi volesse sempr'ir dietro a' sospetti,</l>
             <l>Non si conduria a fin mai cosa alcuna.</l>
           </sp>
-          <sp>
+          <sp who="#malecche">
             <speaker>
               <hi rend="sc">MAL.</hi>
             </speaker>
@@ -2202,7 +2247,7 @@
             <l>Ch'altro non può avenir di ciò, se voi</l>
             <l>Date in preda al furor l'animo vostro.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>
               <hi rend="sc">SUL.</hi>
             </speaker>
@@ -2214,7 +2259,7 @@
             <l>La ragion non può a l'ira in ciò por freno</l>
             <l>E veggonsi ogni dì di questo essempi.</l>
           </sp>
-          <sp>
+          <sp who="#malecche">
             <speaker>
               <hi rend="sc">MAL.</hi>
             </speaker>
@@ -2264,7 +2309,7 @@
             <l>E 'l mio lungo servir, ch'impetri pace</l>
             <l>A la vostra figliuola, al vostro <name>Oronte.</name></l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>
               <hi rend="sc">SUL.</hi>
             </speaker>
@@ -2279,7 +2324,7 @@
             <l>E spezialmente contra <name>Oronte,</name> ch'abbia</l>
             <l>Per nulla avuto farmi ingiuria tale.</l>
           </sp>
-          <sp>
+          <sp who="#malecche">
             <speaker>
               <hi rend="sc">MAL.</hi>
             </speaker>
@@ -2332,7 +2377,7 @@
             <l>Per diversi rispetti, che fia vinto</l>
             <l>Da la gioia il dolor ch'ora sentite.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>
               <hi rend="sc">SEL.</hi>
             </speaker>
@@ -2353,7 +2398,7 @@
             <l>La moglie et egli et ambo i figli insieme,</l>
             <l>Acciò che tutti io li mi goda a un tratto.</l>
           </sp>
-          <sp>
+          <sp who="#malecche">
             <speaker>
               <hi rend="sc">MAL.</hi>
             </speaker>
@@ -2372,13 +2417,13 @@
             <l>E condurolli tutti innanzi a voi,</l>
             <l>Acciò ch'abbiate insieme ugual letizia.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>
               <hi rend="sc">SUL.</hi>
             </speaker>
             <l>Et io t'aspetterò qui, ma vien tosto.</l>
           </sp>
-          <sp>
+          <sp who="#malecche">
             <speaker>
               <hi rend="sc">MAI.</hi>
             </speaker>
@@ -2394,7 +2439,7 @@
             <hi rend="sc">SCENA III</hi>
           </head>
           <stage><hi rend="sc">SULMONE</hi>solo</stage>
-          <sp>
+          <sp who="#sulmone">
             <speaker>
               <hi rend="sc">SULMONE</hi>
             </speaker>
@@ -2488,7 +2533,7 @@
           <stage>
             <hi rend="sc"><name>MALECCHE,</name><name>ORONTE,</name><name>ORBECCHE,</name><name>SULMONE,</name> CORO</hi>
           </stage>
-          <sp>
+          <sp who="#malecche">
             <speaker>
               <hi rend="sc">MAL.</hi>
             </speaker>
@@ -2499,7 +2544,7 @@
             <l>Alta Reina, e tu con lei, <name>Oronte,</name></l>
             <l>Rendete grazie lor di merto tale.</l>
           </sp>
-          <sp>
+          <sp who="#oronte">
             <speaker>
               <hi rend="sc">ORON.</hi>
             </speaker>
@@ -2522,7 +2567,7 @@
             <l>Prosperin pur i Dei le cose nostre</l>
             <l part="I">Com' incominciat'han.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>
               <hi rend="sc">ORB.</hi>
             </speaker>
@@ -2533,7 +2578,7 @@
             <l>In mezzo a l'allegrezza e temo l'amo</l>
             <l>Ascoso sotto l'esca e 'l fel nel dolce.</l>
           </sp>
-          <sp>
+          <sp who="#malecche">
             <speaker>
               <hi rend="sc">MAL.</hi>
             </speaker>
@@ -2548,7 +2593,7 @@
             <l>Che vi raccolga tutti entro le braccia,</l>
             <l>E pianger visto i' l'ho de la dolcezza.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>
               <hi rend="sc">ORB.</hi>
             </speaker>
@@ -2560,7 +2605,7 @@
             <l>In cosa tal, da me bramata tanto,</l>
             <l part="I">Non potermi allegrare.</l>
           </sp>
-          <sp>
+          <sp who="#oronte">
             <speaker>
               <hi rend="sc">ORON.</hi>
             </speaker>
@@ -2570,7 +2615,7 @@
             <l>A divinare il mal! Bene sperate</l>
             <l part="I">E bene vi averrà.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>
               <hi rend="sc">ORB.</hi>
             </speaker>
@@ -2580,7 +2625,7 @@
             <l>Sian le vostre speranze e i piacer vostri,</l>
             <l>E ch'i sospetti miei s'abbino i venti.</l>
           </sp>
-          <sp>
+          <sp who="#oronte">
             <speaker>
               <hi rend="sc">ORON.</hi>
             </speaker>
@@ -2590,7 +2635,7 @@
             <l>De la sua pace, s'ei volesse poi</l>
             <l part="I">Mancar di fé?</l>
           </sp>
-          <sp>
+          <sp who="#malecche">
             <speaker>
               <hi rend="sc">MAL.</hi>
             </speaker>
@@ -2623,14 +2668,14 @@
             <l>Che si scuopre di fore</l>
             <l>E nel viso dimostra aperto 'l core</l>
           </sp>
-          <sp>
+          <sp who="#oronte">
             <speaker>
               <hi rend="sc">ORON.</hi>
             </speaker>
             <l>è come dite, n'esser può altrimenti:</l>
             <l part="I">Però andiamosi al Re.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>
               <hi rend="sc">ORB.</hi>
             </speaker>
@@ -2641,7 +2686,7 @@
             <l>Che s'avenir mi dee cosa maligna,</l>
             <l>Pria ch'io mi vada al padre, io me ne moia.</l>
           </sp>
-          <sp>
+          <sp who="#malecche">
             <speaker>
               <hi rend="sc">MAL.</hi>
             </speaker>
@@ -2650,14 +2695,14 @@
             <l>Di fare al Re quelle parole ch'io</l>
             <l>Conoscerò opportune in questo caso.</l>
           </sp>
-          <sp>
+          <sp who="#oronte">
             <speaker>
               <hi rend="sc">ORON.</hi>
             </speaker>
             <l>Andiàn, <name>Malecche,</name> e voi parlate prima,</l>
             <l>Poi ch'avete insin qui condotto il fatto.</l>
           </sp>
-          <sp>
+          <sp who="#malecche">
             <speaker>
               <hi rend="sc">MAL.</hi>
             </speaker>
@@ -2677,14 +2722,14 @@
             <l>Che quanto detto gli ho per nome vostro,</l>
             <l>Tant'è per attenerli vostra altezza.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>
               <hi rend="sc">SUL.</hi>
             </speaker>
             <l>Non venne ad alcun men mai la mia fede</l>
             <l>Quando ad altrui con fé legata i' l'abbia.</l>
           </sp>
-          <sp>
+          <sp who="#oronte">
             <speaker>
               <hi rend="sc">ORON.</hi>
             </speaker>
@@ -2714,14 +2759,14 @@
             <l>Che conoscer potrete agevolmente</l>
             <l>Quanta sia la mia fede.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>
               <hi rend="sc">ORB.</hi>
             </speaker>
             <l>Et anch'io, padre,</l>
             <l>Perdono a vostra altezza umile i' cheggio.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>
               <hi rend="sc">SUL.</hi>
             </speaker>
@@ -2747,7 +2792,7 @@
             <l>Quanto cari mi sete! Oh quanto bene</l>
             <l>Conosco in voi il mio medesmo aspetto!</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>
               <hi rend="sc">CO.</hi>
             </speaker>
@@ -2761,7 +2806,7 @@
             <l>E così vane sian tutte l'insidie,</l>
             <l>Che 'l tuo dolce gioir nulla t'invidie.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>
               <hi rend="sc">SUL.</hi>
             </speaker>
@@ -2789,7 +2834,7 @@
           <stage>
             <hi rend="sc"><name>ORONTE,</name><name>TAMULE</name>, <name>ALLOCCHE</name></hi>
           </stage>
-          <sp>
+          <sp who="#oronte">
             <speaker>
               <hi rend="sc">ORON.</hi>
             </speaker>
@@ -2892,20 +2937,20 @@
             <l>Venite meco, che n'aspetta in casa</l>
             <l part="I"><name>Tuttatre</name> il nostro Re.</l>
           </sp>
-          <sp>
+          <sp who="#tamule">
             <speaker>
               <hi rend="sc">TAM.</hi>
             </speaker>
             <l part="F">Vengo, Signore.</l>
           </sp>
-          <sp>
+          <sp who="#allocche">
             <speaker>
               <hi rend="sc">AL.</hi>
             </speaker>
             <l>Et io: m'andate innanzi, ch'ambo noi</l>
             <l>Dietro voi si verrem così pian piano.</l>
           </sp>
-          <sp>
+          <sp who="#tamule">
             <speaker>
               <hi rend="sc">TAM.</hi>
             </speaker>
@@ -2918,7 +2963,7 @@
             <hi rend="sc">CORO.</hi>
           </head>
           <stage><hi rend="sc">NODRICE, CORO.</hi> La Nodrice parla</stage>
-          <sp>
+          <sp who="#nodrice">
             <speaker>
               <hi rend="sc">NOD.</hi>
             </speaker>
@@ -2929,7 +2974,7 @@
             <l>Ma chi ne darà i versi o chi le rime</l>
             <l>Atte a spiegare il ben che 'n se tien l'alma?</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>
               <hi rend="sc">CO.</hi>
             </speaker>
@@ -2940,7 +2985,7 @@
             <l>E lodar te, lodando il caro stato,</l>
             <l>Danne tu i versi,<name> Amor,</name> danne le voci.</l>
           </sp>
-          <sp>
+          <sp who="#nodrice">
             <speaker>
               <hi rend="sc">NOD. </hi>
             </speaker>
@@ -2951,7 +2996,7 @@
             <l>Saran così gioiosi e così lieti</l>
             <l>Che nol potrà spiegar forza di rime?</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>
               <hi rend="sc">CO.</hi>
             </speaker>
@@ -2962,7 +3007,7 @@
             <l>Cui minacciava il ciel sì amari giorni,</l>
             <l>Che temea viver sempre in duro stato.</l>
           </sp>
-          <sp>
+          <sp who="#nodrice">
             <speaker>
               <hi rend="sc">NOD.</hi>
             </speaker>
@@ -2973,7 +3018,7 @@
             <l>E scacciate sì il duol tutti da l'alma</l>
             <l>Che s'odano sol note e canti lieti.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>
               <hi rend="sc">CO.</hi>
             </speaker>
@@ -2984,7 +3029,7 @@
             <l>(Per mostrar ch'al ciel van le mortai voci),</l>
             <l>Vuol che mai non veggiam men lieti i giorni.</l>
           </sp>
-          <sp>
+          <sp who="#nodrice">
             <speaker>
               <hi rend="sc">NOD.</hi>
             </speaker>
@@ -3010,7 +3055,7 @@
           <stage>
             <hi rend="sc">MESSO, CORO</hi>
           </stage>
-          <sp>
+          <sp who="#messo">
             <speaker>
               <hi rend="sc">MES.</hi>
             </speaker>
@@ -3030,7 +3075,7 @@
             <l>Dunque cosa vist'ho via più crudele</l>
             <l>Che 'n parte alcuna unqua veder si possa.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>
               <hi rend="sc">CO.</hi>
             </speaker>
@@ -3039,7 +3084,7 @@
             <l>Col tuo sereno lume e i cori infiammi,</l>
             <l>Fa' che per noi non sian queste querele.</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>
               <hi rend="sc">MES.</hi>
             </speaker>
@@ -3055,7 +3100,7 @@
             <l>O secol reo, secol malvaggio e tristo,</l>
             <l>Come dar ci può il sol oggi la luce?</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>
               <hi rend="sc">CO.</hi>
             </speaker>
@@ -3064,7 +3109,7 @@
             <l>Sì amaro pianto ? Non tenere ascosa </l>
             <l part="I">A noi la doglia tua.</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>
               <hi rend="sc">MES.</hi>
             </speaker>
@@ -3078,7 +3123,7 @@
             <l>Ora pensate voi se può bastarmi</l>
             <l>Questa sol lingua, omai debile e fioca.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>
               <hi rend="sc">CO.</hi>
             </speaker>
@@ -3086,7 +3131,7 @@
             <l>Se non a pieno, almeno il me' che puoi:</l>
             <l>Che bramiamo d'udir quello onde piagni.</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>
               <hi rend="sc">MES.</hi>
             </speaker>
@@ -3103,14 +3148,14 @@
             <l>Pallido e tristo e la tremante voce</l>
             <l>Lo vi puote mostrar, senza ch'io il dica.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>
               <hi rend="sc">CO.</hi>
             </speaker>
             <l>Via più d'affanno n'è star sì sospese:</l>
             <l>Però da' omai principio a questa istoria.</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>
               <hi rend="sc">MES. </hi>
             </speaker>
@@ -3172,7 +3217,7 @@
             <l>Crudelmente svenollo e così morto</l>
             <l>Lo gettò a' piè del miserello <name>Oronte.</name></l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>
               <hi rend="sc">CO.</hi>
             </speaker>
@@ -3183,7 +3228,7 @@
             <l>Medolla o sangue in fibra che non tremi.</l>
             <l>Ma che fe' <name>Oronte</name> al lagrimevol caso?</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>
               <hi rend="sc">MES.</hi>
             </speaker>
@@ -3223,14 +3268,14 @@
             <l>Temi almeno li Dei ch'a l'opre buone</l>
             <l>Donano merto et a le triste pena.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>
               <hi rend="sc">CO.</hi>
             </speaker>
             <l>Non s'ammollì quel duro core alquanto</l>
             <l>A sì calde preghiere, a così giuste?</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>
               <hi rend="sc">MES.</hi>
             </speaker>
@@ -3259,7 +3304,7 @@
             <l>E pochi questi due sono a l'oltraggio</l>
             <l>C'hai con la infedeltà tua in me commesso.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>
               <hi rend="sc">CO.</hi>
             </speaker>
@@ -3267,7 +3312,7 @@
             <l>Quel del misero padre, essendo privo</l>
             <l part="I">Già d'ogni speme!</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>
               <hi rend="sc">MES.</hi>
             </speaker>
@@ -3294,13 +3339,13 @@
             <l>A le parti di <name>Dite,</name> a i regni oscuri,</l>
             <l>Ove forse sarem men che qui tristi.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>
               <hi rend="sc">CO.</hi>
             </speaker>
             <l>Ma che faceva intanto il Re crudele?</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>
               <hi rend="sc">MES.</hi>
             </speaker>
@@ -3333,7 +3378,7 @@
             <l>Percossili ambe due sì acerbamente,</l>
             <l>Ch'a' piedi suoi se ne cadderon morti.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>
               <hi rend="sc">CO.</hi>
             </speaker>
@@ -3342,7 +3387,7 @@
             <l>D'uomo, questo crudel? Non fu giamai</l>
             <l>Cosa più strana o più malvagia udita.</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>
               <hi rend="sc">MES.</hi>
             </speaker>
@@ -3351,13 +3396,13 @@
             <l>Quel che fine vi par, principio è stato</l>
             <l>A maggior male, a più scelerat'opra.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CO.</speaker>
             <l>Ma ch'esser può dopo la morte peggio?</l>
             <l>Non è ella estrema de le cose orrende?</l>
             <l>Non è ella fin de tutti e mali al mondo ?</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>
               <hi rend="sc">MES.</hi>
             </speaker>
@@ -3366,7 +3411,7 @@
             <l>Mostrar la crudeltà via più palese</l>
             <l part="I">Ne' morti corpi.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>
               <hi rend="sc">CO.</hi>
             </speaker>
@@ -3374,7 +3419,7 @@
             <l>Ne' morti incrudelir! quanto disdice</l>
             <l>Servar l'ira e 'l furor dopo la morte!</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>
               <hi rend="sc">MES.</hi>
             </speaker>
@@ -3389,7 +3434,7 @@
             <l>E 'l capo pose, e d'un zendado nero</l>
             <l>Lo ricoperse e lo si fe' servare.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>
               <hi rend="sc">CO.</hi>
             </speaker>
@@ -3402,7 +3447,7 @@
             <l>Ricevuto hanno il meritato onore.</l>
             <l>Ma che fatt'ha de' fanciullini morti?</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>
               <hi rend="sc">MES.</hi>
             </speaker>
@@ -3423,7 +3468,7 @@
             <l>A la stanza real fece portarli</l>
             <l>Et ivi posti gli ha, né so a qual fine.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>
               <hi rend="sc">CO.</hi>
             </speaker>
@@ -3440,7 +3485,7 @@
           <head>
             <hi rend="sc">CORO</hi>
           </head>
-          <sp>
+          <sp who="#coro">
             <speaker>
               <hi rend="sc">CORO</hi>
             </speaker>
@@ -3546,7 +3591,7 @@
           <stage>
             <hi rend="sc"><name>SULMONE,</name><name>ALLOCCHE</name>, <name>TAMULE</name></hi>
           </stage>
-          <sp>
+          <sp who="#sulmone">
             <speaker>SUL.</speaker>
             <l>Levata i' m'ho dal viso quella macchia</l>
             <l>Che m'avea impressa Oronte. Egli ha provato</l>
@@ -3558,12 +3603,12 @@
             <l>Che sapran per qual via debbano inviarsi</l>
             <l>Per fuggir casi crudo e fiero intoppo.</l>
           </sp>
-          <sp>
+          <sp who="#allocche">
             <speaker>AL.</speaker>
             <l>Sì bene, invitto Sir, s'avranno senno</l>
             <l part="I">E non fian più che ciechi.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>SUL.</speaker>
             <l part="F">E se fian ciechi,</l>
             <l>Io bene in guisa gli occhi aprirò loro</l>
@@ -3574,7 +3619,7 @@
             <l>Uomini ch'abbia il mondo e le lor corti</l>
             <l>Verrebbero da men che le capanne.</l>
           </sp>
-          <sp>
+          <sp who="#tamule">
             <speaker>TAM.</speaker>
             <l>E così, alto Sir, è, come voi dite,</l>
             <l>E devonsi mostrare i Re a tal modo</l>
@@ -3584,7 +3629,7 @@
             <l>Che ricevuto ha il traditor d'Oronte,</l>
             <l>E quest'è de l'imperio avere il frutto.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>SUL.</speaker>
             <l>Dicon costor che la violenzia è quella</l>
             <l>Che consuma gli stati e che l'amore</l>
@@ -3612,7 +3657,7 @@
             <l>Del cor d'Oronte, quand'egli si vide</l>
             <l part="I">Colto a la rete?</l>
           </sp>
-          <sp>
+          <sp who="#allocche">
             <speaker>AL.</speaker>
             <l part="F">Parmi ch'ei facesse</l>
             <l>Come color che son senza speranza,</l>
@@ -3634,7 +3679,7 @@
             <l>E ben felice è quattro volte e sei</l>
             <l>Chi de le 'ngiurie far vendetta puote.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>SUL.</speaker>
             <l>E perché credi tu che, potend'io</l>
             <l>Subito far morire il traditore</l>
@@ -3645,7 +3690,7 @@
             <l>L'avea de la mia corte, et io ho voluto</l>
             <l>Che la fé istessa lo conduca a morte.</l>
           </sp>
-          <sp>
+          <sp who="#allocche">
             <speaker>AL.</speaker>
             <l>Non pensava altrimenti. E per dir vero</l>
             <l>Conosciuto v'ho, Sir, sempre prudente,</l>
@@ -3655,7 +3700,7 @@
             <l>Ond'ora tengo il vostro animo invitto</l>
             <l>Dignissimo di scettro e di corona.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>SUL.</speaker>
             <l>Certo ch'anch'io mi pregio che nel fine</l>
             <l>Quasi de la mia vita abbia mostrato</l>
@@ -3666,7 +3711,7 @@
             <l>Via più d'ogn'altra cosa a un Re conviene,</l>
             <l>Quanto scemato avrei de la mia gloria!</l>
           </sp>
-          <sp>
+          <sp who="#tamule">
             <speaker>TAM.</speaker>
             <l>Che sa di ciò Malecche? Egli è nodrito</l>
             <l>Tra le donne ne gli ozii e voi misura</l>
@@ -3678,7 +3723,7 @@
             <l>Indizii son de gli animi reali:</l>
             <l>E chi far lo si dee, se i Re nol fanno?</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>SUL.</speaker>
             <l>Non è altrimenti. Ma lasciàn da parte</l>
             <l>Il ragionar di ciò: vo' che tu vada</l>
@@ -3686,11 +3731,11 @@
             <l>Ove è 'l capo d'Oronte e i figli morti</l>
             <l part="I">E di zendado ner sono coperti.</l>
           </sp>
-          <sp>
+          <sp who="#allocche">
             <speaker>AL.</speaker>
             <l part="F">I' vo, Signor.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>SUL.</speaker>
             <l>Va' tosto e tosto torna.</l>
             <l>E tu, Tamul, vatene a la mia figlia</l>
@@ -3698,49 +3743,49 @@
             <l>Che le voglio far don degno di lei</l>
             <l>E de le nozze e di sì lieto giorno.</l>
           </sp>
-          <sp>
+          <sp who="#tamule">
             <speaker>TAM.</speaker>
             <l>Vorestele mai voi, Signor, offrire</l>
             <l>Que' piati che portati avemo in casa,</l>
             <l>Ov'è 'l capo d'Oronte e i figli morti ?</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>SUL.</speaker>
             <l part="I">Cosi vo' far.</l>
           </sp>
-          <sp>
+          <sp who="#tamule">
             <speaker>TAM.</speaker>
             <l part="F">Per Dio, che fate bene,</l>
             <l>Perch'ella del suo error porti la pena,</l>
             <l>E del colpo di c'ha percosso voi</l>
             <l>è degno che ne sia percossa anch'ella.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>SUL.</speaker>
             <l part="I">Or va' e di' che non tardi.</l>
           </sp>
-          <sp>
+          <sp who="#allocche">
             <speaker>AL.</speaker>
             <l part="F">Eccomi, Sire.</l>
             <l>Ove volete ch'io mi ponga i piati?</l>
             <l part="I">Qui forse?</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>SUL.</speaker>
             <l part="F">No, ponli un po' più discosti</l>
             <l part="I">Da questo palco.</l>
           </sp>
-          <sp>
+          <sp who="#allocche">
             <speaker>AL.</speaker>
             <l part="M">Qui?</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>SUL.</speaker>
             <l part="F">	Sì: ma con ch'occhio</l>
             <l>Pensi tu che vedrà la figlia questo</l>
             <l part="I">Dono che far le voglio?</l>
           </sp>
-          <sp>
+          <sp who="#allocche">
             <speaker>AL.</speaker>
             <l part="F">Io tengo certo</l>
             <l>Che via più grave a lei fia la ferita</l>
@@ -3754,16 +3799,16 @@
             <l>Ma veggio che Tamule a noi ne viene</l>
             <l part="I">Senz'essa.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>SUL.</speaker>
             <l part="F">	E che non vien, Tamule, Orbecche?</l>
           </sp>
-          <sp>
+          <sp who="#tamule">
             <speaker>TAM.</speaker>
             <l>Dice ch'incontinenti a vostra altezza</l>
             <l>Verrà, pel don ch'aver da quella spera.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>SUL.</speaker>
             <l>Or ritiriansi un po' tutti da canto,</l>
             <l>Ch'al suo primo apparir qui non ne scorga.</l>
@@ -3776,17 +3821,17 @@
           <stage>
             <hi rend="sc">NODRICE, <name>ORBECCHE,</name> <name>SULMONE,</name> SEMICORO</hi>
           </stage>
-          <sp>
+          <sp who="#nodrice">
             <speaker>NOD.</speaker>
             <l>Qual fia quel giorno mai, alta Reina,</l>
             <l>Ch'apporti fine a le querele vostre?</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>ORB.</speaker>
             <l>Nodrice mia, per me quel giorno lieto</l>
             <l>Fia che mi mandarà morte sotterra.</l>
           </sp>
-          <sp>
+          <sp who="#nodrice">
             <speaker>NOD.</speaker>
             <l>Deh vani sian, Signora, questi augurii</l>
             <l>Che voi fuor di ragione ora vi fate.</l>
@@ -3803,7 +3848,7 @@
             <l>Deh piacciavi che dubbia e inutil tema</l>
             <l>Non turbi certa gioia e ver riposo.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>ORB.</speaker>
             <l>Non sai, Nodrice mia, che quanto lieta</l>
             <l>Si mostra a noi più la fortuna, tanto</l>
@@ -3831,12 +3876,12 @@
             <l>Materia di più acerba e cruda doglia,</l>
             <l>Non mi lascia sperar nulla di bene.</l>
           </sp>
-          <sp>
+          <sp who="#nodrice">
             <speaker>NOD.</speaker>
             <l>Che sogno è questo? Deh, di grazia fate</l>
             <l>Che lo sappia ancor io, se non v'è grave.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>ORB.</speaker>
             <l>Era questa passata notte corsa</l>
             <l>E già l'<name>Aurora</name> co' bei crini d'oro</l>
@@ -3873,7 +3918,7 @@
             <l>Sì orribil visione e da' miei scaccia</l>
             <l>Così crudele e miserabil caso.</l>
           </sp>
-          <sp>
+          <sp who="#nodrice">
             <speaker>NOD.</speaker>
             <l>Io tengo che v'abbiate in mezzo 'l core</l>
             <l>Accolta tutta la maninconia</l>
@@ -3898,7 +3943,7 @@
             <l>Come vi state in tristi, lieti i sogni</l>
             <l>Avreste avuto e non, com'ora, mesti.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>ORB.</speaker>
             <l>Par che non sappi che sovente i Dei</l>
             <l>Per monir altri de' lor casi in sogno</l>
@@ -3911,13 +3956,13 @@
             <l>Avesser dato fede, avrian schifato</l>
             <l>O fatto acerbo o abominevol morte.</l>
           </sp>
-          <sp>
+          <sp who="#nodrice">
             <speaker>NOD.</speaker>
             <l>La fé, Reina, che dal Re v'è data,</l>
             <l>Esser vi deve com'un chiaro raggio</l>
             <l>Ch'ogni nebbia di duol dal cor vi sgombri.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>ORB. </speaker>
             <l>I' so, Nodrice, per aperta prova</l>
             <l>Che la fede ben sta sempre a la porta</l>
@@ -3930,32 +3975,32 @@
             <l>Del venerabil nome de la fede</l>
             <l>Che da' gran Re sì rado oggi si serba.</l>
           </sp>
-          <sp>
+          <sp who="#nodrice">
             <speaker>NOD.</speaker>
             <l>Reina mia, lasciam omai da parte</l>
             <l>Il lamentarsi e andiam al vostro padre,</l>
             <l>Che spero che quel don ch'ei far vi vuole</l>
             <l>Vi farà rimaner tutta giuliva.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>ORB.</speaker>
             <l>Odano i Dei le voci tue!</l>
             <l>M'andiamo,</l>
             <l>Ch'egli a l'usato luoco s'è ridutto</l>
             <l part="I">E lì n'aspetta.</l>
           </sp>
-          <sp>
+          <sp who="#nodrice">
             <speaker>NOD.</speaker>
             <l part="F">Fate allegro viso</l>
             <l>Quanto più far potete e via scacciate</l>
             <l>Quanto chiude di tristo il vostro core.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>ORB.</speaker>
             <l>Così farò più che possibil fia.</l>
             <l>Che vuol da me la maestade vostra?</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>SUL.</speaker>
             <l>Non voglio se non bene. Andate in casa</l>
             <l>Voi tutti, perch'io voglio esser qui alquanto</l>
@@ -3973,7 +4018,7 @@
             <l>Quant'io di fatto tal resti contento</l>
             <l>E quanto ferma sia la pace nostra.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>ORB.</speaker>
             <l>Padre, i' non cerco aver più espresso segno</l>
             <l>Da la maestà vostra de la pace,</l>
@@ -3985,95 +4030,95 @@
             <l>Che quanto piace a voi, tanto a me piace,</l>
             <l>Accetterollo con benigna fronte.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>SUL.</speaker>
             <l>Così, figliuola mia, vo' che tu faccia.</l>
             <l>Or leva quel zendado et ivi sotto</l>
             <l>Vedrai la mia allegrezza e 'l tuo contento.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>ORB.</speaker>
             <l>Par che tema la mano avicinarsi</l>
             <l>A quel zendado, il core in mezzo il petto</l>
             <l>Mi trema e par ch'io non ardisca alzarlo.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>SUL.</speaker>
             <l>Che tardi, figlia? Leva arditamente,</l>
             <l>Che vedrai quel che t'aprirà qual sia</l>
             <l part="I">Verso di te il mio core.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>ORB.</speaker>
             <l part="F">Oimè, ch'è questo?</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>SUL.</speaker>
             <l>Il don, malvagia figlia, che d'avere</l>
             <l>Ha meritato il simolato amore</l>
             <l part="I">Verso di noi.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>ORB.</speaker>
             <l part="F">Ai trista me! ai meschina!</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>SUL.</speaker>
             <l part="I">E la tua rotta fede.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>ORB.</speaker>
             <l part="F">Oimè dolente!</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>SUL.</speaker>
             <l>E 'l poco riguardare il nostro onore.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>ORB.</speaker>
             <l>O spettacol crudele, o caso acerbo!</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>SUL.</speaker>
             <l>Egli tal è, qual meritato l'hai.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>ORB.</speaker>
             <l>Ai, di ch'aspro coltello ora trafissa</l>
             <l>M'avete, oimè!</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>SUL.</speaker>
             <l>Di quel di ch'eri degna.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>ORB.</speaker>
             <l>Oimè, pur devevate a' figli almeno</l>
             <l part="I">Usar pietà.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>SUL.</speaker>
             <l part="F">Pietà non puote dove</l>
             <l>è ingiuria così atroce.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>ORB.</speaker>
             <l>Oimè, più tosto</l>
             <l>Morta foss'io, che veder cosa tale!</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>SUL.</speaker>
             <l>Tu vedi quel contento, o scelerata,</l>
             <l>C'hai dato al padre tuo.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>ORB.</speaker>
             <l>Quant' oimè lassa</l>
             <l>Lagrimevol mi s'offre questo dono</l>
             <l>Ond'io credeva esser contenta al mondo!</l>
             <l part="I">Ai padre, ai caro padre!</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>SUL.</speaker>
             <l part="F">Or son tuo padre,</l>
             <l>Ma allor non fui che ti pigliasti questo</l>
@@ -4081,21 +4126,21 @@
             <l>Ora m'è a grado ch'abbi aperti gli occhi</l>
             <l part="I">E mi conosca.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>ORB.</speaker>
             <l part="F">Ai spettacol crudele!</l>
             <l>Oimè marito, oimè!</l>
             <l>Oimè figliuoli, oimè!</l>
             <l>Di quant'affanno, oimè, cagion mi sete!</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>SUL.</speaker>
             <l>Quanto ciò è a te dolente, è tanto lieto</l>
             <l>E piacevole a me, figlia proterva;</l>
             <l>E quanto più doler ti veggio, tanto</l>
             <l>Più me n'allegro e più men gode il core.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>ORB.</speaker>
             <l>Spiaccievol più che non m'è mi sarebbe,</l>
             <l>Padre, cosa veder così crudele</l>
@@ -4129,7 +4174,7 @@
             <l>Percotete che l'alma se ne vada</l>
             <l>Et io ne resti qui pallida e essangue.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>SUL.</speaker>
             <l>Far ben lo mi devrei, se sol guardare</l>
             <l>Volessi a l'error tuo, ma più non voglio</l>
@@ -4142,12 +4187,12 @@
             <l>Te voglio, come pria, per cara figlia</l>
             <l>E voglio che tu tenga me per padre.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>ORB.</speaker>
             <l>Non merto questo don, padre: la morte</l>
             <l>Deve emendar l'error che 'n voi commisi.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>SUL.</speaker>
             <l>Viviti pure e sii contenta meco</l>
             <l>Che morti sian chi eran di morir degni,</l>
@@ -4159,14 +4204,14 @@
             <l>Giù que' coltelli et entra meco in casa,</l>
             <l>Ove da me chiar segno avrai di pace.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>ORB.</speaker>
             <l>S'ora anco il ciel non m'è contrario, guari</l>
             <l>Non andrà, traditor, che la vendetta</l>
             <l>Farò io stessa de l'avuta ingiuria,</l>
             <l>Se non mi vengon men questi coltelli.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>SUL.</speaker>
             <l>Ai malvagia, ai crudele, oimè, ch'io moro,</l>
             <l>Oimè, che posto m'ha il coltel nel petto</l>
@@ -4175,7 +4220,7 @@
             <l>Pigliatela, uccidetela, ch'io veggia,</l>
             <l>Pria che del tutto i' moia, la vendetta.</l>
           </sp>
-          <sp>
+          <sp who="#semicoro">
             <speaker>SEM.</speaker>
             <l>Che grido, oimè, che voce è questa orrenda</l>
             <l>Del Re <name>Sulmon?</name> La figlia col coltello</l>
@@ -4185,11 +4230,11 @@
             <l>Ma questo non le basta, anco lo sgozza</l>
             <l part="I">Con un altro coltello.</l>
           </sp>
-          <sp>
+          <sp who="#sulmone">
             <speaker>SUL.</speaker>
             <l part="F">Oimè, pietade!</l>
           </sp>
-          <sp>
+          <sp who="#semicoro">
             <speaker>SEM.</speaker>
             <l>Egli è del tutto morto. Oh quanto sangue</l>
             <l>Versa d'ambo le piaghe! Ma che veggio?</l>
@@ -4252,7 +4297,7 @@
             <hi rend="sc">SCENA III</hi>
           </head>
           <stage><hi rend="sc"><name>ORBECCHE,</name> NODRICE, DONNE DI CORTE</hi> della Reina</stage>
-          <sp>
+          <sp who="#orbecche">
             <speaker>ORB.</speaker>
             <l>Or godi, traditor, de' tuoi misfatti,</l>
             <l>Godi, via più d'ogni dur <name>Scita</name> crudo</l>
@@ -4338,20 +4383,20 @@
             <l>Oimè, marito, o figli,</l>
             <l>Quant'è grave il dolor che per voi porto!</l>
           </sp>
-          <sp>
+          <sp who="#nodrice">
             <speaker>NOD.</speaker>
             <l>O che pianto, o che grida, o che querele</l>
             <l part="I">Crudeli i' sento!</l>
           </sp>
-          <sp>
+          <sp who="#donne">
             <speaker>DON. DI</speaker>
             <l part="F">Certo che son gravi,</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>COR.</speaker>
             <l>Né lontano molt'è questo lamento.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>ORB.</speaker>
             <l>O giorno sempre acerbo a gli occhi miei,</l>
             <l>Giorno sovra ogni giorno amaro e oscuro,</l>
@@ -4361,12 +4406,12 @@
             <l>La infelicità istessa; e s'aver puote</l>
             <l>Corpo mortale, ella nel mio si vive.</l>
           </sp>
-          <sp>
+          <sp who="#nodrice">
             <speaker>NOD.</speaker>
             <l>Certo ch'io n'ho pietà, senza ch'io sappia</l>
             <l>La cagione del male o chi si dolga.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>ORB.</speaker>
             <l>Ma che prolungo più la vita mia?</l>
             <l>Già verso voi finito è ogni mio ufficio,</l>
@@ -4385,12 +4430,12 @@
             <l>Congiungerà con sempiterno nodo.</l>
             <l>Oimè, caro marito, o cari figli!</l>
           </sp>
-          <sp>
+          <sp who="#nodrice">
             <speaker>NOD.</speaker>
             <l>Deh di grazia guardiam se noi vediamo</l>
             <l>Chi sparge al ciel così dogliose voci.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>ORB.</speaker>
             <l>Ben prego, se non è pietà dal mondo</l>
             <l>Sbandita in tutto, ch'una grazia almeno</l>
@@ -4398,17 +4443,17 @@
             <l>Che così come l'anime congiunte</l>
             <l part="I">Saran ne l'altra vita . . .</l>
           </sp>
-          <sp>
+          <sp who="#donne">
             <speaker>DON. DI</speaker>
             <l part="F">Oimè, Nodrice,</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>COR.</speaker>
             <l>Che la Reina nostra è che si duole!</l>
             <l>Vedila là con un coltello in mano,</l>
             <l>Che par che sé medesma uccider voglia.</l>
           </sp>
-          <sp>
+          <sp who="#nodrice">
             <speaker>NOD.</speaker>
             <l>Oimè, che 'l traditor del padre avralle</l>
             <l>Rotta la fede e l'averà costretta</l>
@@ -4420,14 +4465,14 @@
             <l>Veggendone a sé gire; e a poter nostro</l>
             <l part="I">Levianla da la morte.</l>
           </sp>
-          <sp>
+          <sp who="#orbecche">
             <speaker>ORB.</speaker>
             <l part="F">Così insieme</l>
             <l>In un medesmo luoco sian riposti</l>
             <l>I corpi nostri in questa vita ch'ora,</l>
             <l>Il petto trafigendomi, abbandono.</l>
           </sp>
-          <sp>
+          <sp who="#nodrice">
             <speaker>NOD.</speaker>
             <l>Che cosa è questa, oimè, Reina, e quale</l>
             <l>Empio furor così cieca vi mena</l>
@@ -4466,11 +4511,11 @@
             <l>Vi faria il don de lo spietato padre,</l>
             <l>Che stato vi è cagion di darvi morte.</l>
           </sp>
-          <sp>
+          <sp who="#donne">
             <speaker>DON. DI</speaker>
             <l>Misere noi, ben siam come smarrita</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>COR.</speaker>
             <l>Nave che 'n mar senza governo sia,</l>
             <l>Piene d'ogni dolore</l>
@@ -4484,7 +4529,7 @@
             <l>Ai sorte acerba, ai sorte,</l>
             <l>Com'hai a un colpo sol tutte noi morte!</l>
           </sp>
-          <sp>
+          <sp who="#nodrice">
             <speaker>NOD.</speaker>
             <l>Giusto duol bene a lamentar vi mena,</l>
             <l>Figliuole mie, ch'a voi tolt'ha la morte</l>
@@ -4532,11 +4577,11 @@
             <l>Togliendomi colei ond'io viveva,</l>
             <l>Tolta non m'hai con lei di questa vita?</l>
           </sp>
-          <sp>
+          <sp who="#donne">
             <speaker>DON. DI</speaker>
             <l>E noi che più sperar, lasse, devemo?</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>COR.</speaker>
             <l>Morta ogni nostra spene,</l>
             <l>Sol n'avanzan sospiri, angoscie e pene.</l>
@@ -4549,7 +4594,7 @@
           <head>
             <hi rend="sc">CORO</hi>
           </head>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Ben è vana e fugace</l>
             <l>Questa felicità nostra mortale,</l>
@@ -4575,7 +4620,7 @@
         <head>
           <hi rend="sc">LA TRAGEDIA A CHI LEGGE</hi>
         </head>
-        <sp>
+        <sp who="#tragedia">
           <speaker>
             <hi rend="sc">Tragedia</hi>
           </speaker>

--- a/tei/goldoni-gl-innamorati.xml
+++ b/tei/goldoni-gl-innamorati.xml
@@ -86,6 +86,43 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="eugenia">
+            <persName>Eugenia</persName>
+          </person>
+          <person xml:id="flamminia">
+            <persName>Flamminia</persName>
+          </person>
+          <person xml:id="tognino">
+            <persName>Tognino</persName>
+          </person>
+          <person xml:id="fabrizio">
+            <persName>Fabrizio</persName>
+          </person>
+          <person xml:id="roberto">
+            <persName>Roberto</persName>
+          </person>
+          <person xml:id="succianespole">
+            <persName>Succianespole</persName>
+          </person>
+          <person xml:id="lisetta">
+            <persName>Lisetta</persName>
+          </person>
+          <person xml:id="ridolfo">
+            <persName>Ridolfo</persName>
+          </person>
+          <person xml:id="fulgenzio">
+            <persName>Fulgenzio</persName>
+          </person>
+          <person xml:id="flam">
+            <persName>Flamminia</persName>
+          </person>
+          <person xml:id="clorinda">
+            <persName>Clorinda</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -246,22 +283,22 @@ in Milano.</p>
           <stage>
             <emph>Eugenia, e Flaminia.</emph>
           </stage>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Che cosa avete, signora sorella, che mi guardate
 così di mal occhio?</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Eugenia mia, compatitemi. Mi fate tanto venir la
 bile, che oramai non vi posso più guardar con amore.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Bella davvero! che cosa vi ho fatto, che non mi
 potete vedere?</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Non posso soffrire quella maniera aspra, liticosa,
 indiscreta, con cui solete trattare il signor Fulgenzio.
@@ -269,12 +306,12 @@ Egli è innamorato di voi perdutamente; si vede, si conosce,
 che spasima, che vi adora, e voi non cercate, che
 d'inquietarlo, e corrispondergli con mala grazia.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>In verità mi fareste ridere. Avete tanta compassione
 per il signor Fulgenzio?</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Ho per lui quella carità, ch'egli merita, e che
 voi dovreste usargli per giustizia, e per gratitudine. È un
@@ -291,193 +328,193 @@ fortuna. Ma voi, sorella cara, lo perderete; lo perderete
 senz'altro; e ci scommetto, che ieri sera si è più del
 solito disgustato, e starete un pezzo a vederlo.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Ed io scommetto, che non passano due ore, che
 Fulgenzio è qui, e mi prega; e se voglio, mi domanda ancora
 perdono.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Voi l'avete ingiuriato, ed egli vi chiederà il
 perdono?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Eh! non sarebbe la prima volta.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Vi fidate troppo della sua bontà.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>E anch'egli si può compromettere dell'amor mio.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>L'amate dunque, e lo trattate sì male?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>E che cosa finalmente gli ho fatto?</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Niente! In tutto il tempo, che viene qui è mai
 passato un giorno, o una sera senza, che voi lo abbiate
 fatto inquietare?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Sono sempre io quella, che lo fa inquietare? Parmi,
 ch'egli sia soffistico e puntiglioso assai più di me.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Non è vero.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Oh voi sapete assai quello, che vi dite.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Specialmente poi lo tormentate sempre sul
 proposito di sua cognata.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Sua cognata io non la posso vedere.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>E che cosa vi ha fatto quella povera donna?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Non mi ha fatto niente, ma non la posso vedere.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Quest'odio è cattivo, sorella cara. Il Cielo vi
 castigherà.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Io non le porto odio; ma non la posso vedere.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Eppure ella vi ha fatto delle finezze.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Si tenga le sue finezze; meno, che io la vedo sto
 meglio.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Che cosa vi siete cacciata in testa? Che Fulgenzio
 sia impazzito per la cognata? Sapete pure ch'egli la serve,
 e l'assiste, perché gli fu raccomandata da suo fratello.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Sì, va bene, ma che bisogno c'è, ch'egli vada a
 spasso con lei, e pianti me qui sola, come una bestia?</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Orsù, signora sorella, io vi consiglio, per vostro
 meglio abbandonare ogni cattivo pensiere, e di questa donna
 vi prego a non ne parlare.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Oh sì, vi prometto, di non parlarne mai più.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Se lo farete, farete bene. Ma torno a dire, io
 dubito, che il signor Fulgenzio per oggi almeno non si lasci
 vedere.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Possibile? non è mai stato un giorno senza venire.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Se non fosse in collera, a quest'ora forse sarebbe
 venuto.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Anzi l'aveva detto di venire questa mattina.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Oh, non viene assolutamente.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Quasi, quasi, gli manderei a dir qualche cosa.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Vi dispiace eh, che non venga?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Sicuro che me ne dispiace. Gli voglio bene davvero.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>E sempre lo disgustate.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Ho questo temperamento. Per altro lo sa, che gli
 voglio bene.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Un poco più d'umiltà, sorella.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>E voi tenete sempre da lui.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Io tengo dalla ragione. (Guai se non facessi così
 è una vipera)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Chi viene?</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>È il servitore del signor Fulgenzio.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Non ve l'ho detto? Quanto credete, che sia lontano
 il padrone?</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Aspettate prima. Chi sa, che non mandi qualche
 ambasciata, che vi dispiaccia!</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Ha della roba il servitore.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Povero galantuomo è di buonissimo core.</p>
           </sp>
@@ -487,72 +524,72 @@ ambasciata, che vi dispiaccia!</p>
           <stage>
             <emph>Tognino e dette.</emph>
           </stage>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Servo di lor signore.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Addio, Tognino. Che fa il padrone?</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Sta bene. La riverisce, e le manda questo
 viglietto.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>E qui, che ci avete?</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Un po' di frutta.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Poverino!</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Sentite, come mi scrive</p>
             <stage><emph>(a Flamminia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>È sdegnato?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Vorrebbe far lo sdegnato, ma non lo sa fare.
 Sentite, come principia: <emph>Crudelaccia!</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Via, via è parola d'amore.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>
               <emph>Mi prendo la libertà di mandarvi due frutta, perché possiate raddolcirvi la bocca, che avete per solito amareggiata di fele.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>È amore, è amore.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>
               <emph>Sarei venuto in persona, se non avessi temuto di accrescere i vostri sdegni.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Sentite?</p>
             <stage><emph>(ad Eugenia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Ma ci verrà</p>
             <stage><emph>(a Flamminia)</emph>.</stage>
@@ -560,89 +597,89 @@ Sentite, come principia: <emph>Crudelaccia!</emph>
               <emph>Vi amo teneramente, e appunto per questo, stando da voi lontano, intendo unicamente di compiacervi.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Sentite?</p>
             <stage><emph>(con più forza)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Ma ci verrà. <emph>Bramerei due righe di vostra mano per assicurarmi, se vi è rimasta nel cuore qualche scintilla d'amore per me.</emph></p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Via; rispondetegli; e usategli un poco di carità.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Siete molto compassionevole.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Oh io non posso vedere a penar nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Con questi uomini non bisogna poi essere tanto
 corrive; e non è sempre ben fatto far loro conoscere, che si
 amano tanto.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Io non l'ho mai usata questa politica, e non la
 saprei usare.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Scrivetegli voi per me.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Volete, che lo faccia davvero?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Sì, fatelo, che mi farete piacere. Io ci metto assai
 tempo a scrivere; voi scriverete meglio, e più presto.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Avvertite, ch'io voglio scrivere a modo mio.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Sì, scrivete come vi pare.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Voglio scrivere per placarlo, e non per irritarlo
 di più.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Credete, ch'io abbia piacere di disgustarlo? Signora
 no. Fate anzi una bella lettera, che lo consoli il mio caro
 coruccio bello.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>In nome vostro.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>In nome mio; ci s'intende.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Aspettate, quel giovane, che or ora vengo colla
 risposta</p>
             <stage><emph>(a Tognino)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Dove vuole, ch'io posi questo canestro?</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Date qui, date qui. Guardate, Eugenia, che belle
 frutta! Sa, che vi piacciono, e ve le manda. In vece di star
@@ -657,132 +694,132 @@ propriamente adorare</p>
           <stage>
             <emph>Eugenia, e Tognino.</emph>
           </stage>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>A che ora è venuto a casa ieri sera il vostro
 padrone?</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>È venuto prima del solito. Non erano ancor sonate
 le due.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Che ha detto sua cognata, quando l'ha veduto venir
 così presto?</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Ha mostrato d'aver piacere.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Aveva compagnia la signora Clorinda?</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Oh da lei non ci vien mai nessuno. Ella è di
 natural melanconico. Suo marito è anche qualche poco geloso;
 è andato a Genova per affari, l'ha raccomandata al fratello,
 ed ella non tratta con nessun altro.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Le fa buona compagnia il signor Fulgenzio?</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Quand'è in casa, procura di divertirla.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>La diverte bene?</p>
             <stage><emph>(con un poco di sdegno)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>(Se parlo, non vorrei far male). La diverte
 m'intendo, così, mangiano insieme.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Ridono a tavola?</p>
             <stage><emph>(placidamente)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Qualche volta.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>È grazioso veramente il vostro padrone. Mi ha detto
 che gioca qualche volta con sua cognata; è egli vero?</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Sì signora, giocano qualche volta.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>E vanno a spasso la sera.</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Io non lo so veramente.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Perché me lo volete negare? Persone mi hanno detto
 per certo, che li hanno veduti a spasso anche ieri sera.</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Può essere.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Mi fareste venir la rabbia. Può essere? dite, che è
 di sicuro.</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Lo sa di certo?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Fate conto, ch'io l'abbia veduto.</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Bene; quando lo sa, perché me lo domanda?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>(Come ci casca bene il baggiano). E a che ora sono
 tornati a casa?</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>A tre ore in circa.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Hanno cenato subito?</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Subito.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>E poi avranno giocato una partitina.</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Hanno giocato una partitina.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>(Venga da me, che sta fresco).</p>
           </sp>
@@ -792,160 +829,160 @@ tornati a casa?</p>
           <stage>
             <emph>Flamminia, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Ecco qui la lettera bell'e fatta. La volete
 sentire?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Date qui, non preme.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Signora no, ve la voglio far sentire. <emph>Mio bene...</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Ma bene bene... </p>
             <stage><emph>(con caricatura)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Cosa vorreste significare?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Niente; dico, che dite bene.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Sentite. <emph>Mi hanno tanto consolato le vostre righe, che non ho termini sufficienti per ispiegarvi il giubbilo del mio cuore.</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>E che giubbilo!</p>
             <stage><emph>(con ironia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>No forse?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Sì</p>
             <stage><emph>(con ironia caricata)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Siete pure sguaiata. <emph>Mi pare un secolo ch'io non vi vedo. Caro il mio bene...</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Ma bene.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Io non vi capisco.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Mi capisco da me.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>(Pazza). <emph>Venite a consolare la vostra cara gioietta.</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Con quella bella grazietta!</p>
             <stage><emph>(con ironia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Che modo è questo?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Ci fo la rima.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Mi fareste dir delle brutte rime. Finiamola.
 <emph>Vedrete ch'io non sono la crudelaccia; ma la vostra fedele, sincera amante. Eugenia Pandolfi.</emph> Vi pare, che non abbia
 scritto a dovere?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Ottimamente. Date qui, che la voglio sigillar io.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Eh, la so sigillare da me.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>La voglio consegnar io a Tognino, acciò possa dire
 che l'ha ricevuta da me.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Fin qui non avete il torto. Eccola</p>
             <stage><emph>(dà la lettera ad Eugenia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Venite qui, Tognino.</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Eccomi.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Dite al vostro padrone che mia sorella Flamminia in
 nome mio gli ha scritto una bella lettera, e che io
 medesima, colle mie mani l'ho lacerata</p>
             <stage><emph>(straccia la lettera)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Che! siete impazzita davvero? Mi fate di queste
 scene?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>E ditegli, che venga da me, che gli darò la risposta
 in voce</p>
             <stage><emph>(a Tognino)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Come comanda.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Non glielo dite, che ha stracciata la lettera.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Anzi, glielo deve dire. Tognino, se glielo dite, vi
 do un testone di mancia.</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Sarà per sua grazia. Non mancherò di servirla.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Dico, che non gli dite niente</p>
             <stage><emph>(a Tognino)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Perdoni. La sua signora sorella ha delle maniere
 obbliganti. Un testone vale a Milano quarantacinque soldi di
@@ -958,100 +995,100 @@ buona moneta</p>
           <stage>
             <emph>Flamminia, ed Eugenia.</emph>
           </stage>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>E perché avete fatto questa baggianata?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>L'avete mai letto il libro del Perché? Leggetelo, e
 lo saprete.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Sguaiaterie, vi dico; e ne sono stucca, e
 ristucca.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Gran premura aveva ieri sera il signor Fulgenzio
 d'andare a casa!</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>È andato via per la rabbia.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Eh pensate! è andato via, perché aveva un impegno.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>E con chi?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Col diavolo, che se lo porti.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Eugenia, voi vi volete precipitare.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Quando si tratta di quelle maladette bugie, non le
 posso soffrire.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Vi ha detto qualche cosa il servitore?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Niente.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Non istate a credere sì facilmente...</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Oh io già non credo a nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>A Fulgenzio potete credere.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Peggio.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>E a me?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Peggio.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Già chi non dice a vostro modo ha il torto presso
 di voi. Ecco qui nostro zio.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Chi diavolo c'è con lui?</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Un forastiere mi pare.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Ha sempre seco delle seccature.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Sì, chi sentirà lui sarà qualche gran personaggio.
 Sarà di costa di re. Egli magnifica tutte le cose, e si fa
@@ -1063,18 +1100,18 @@ burlare da tutti.</p>
           <stage>
             <emph>Fabrizio, Roberto, e dette.</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Signore nipoti, ecco qui un cavaliere, che vi vuol
 conoscere, e favorire: il conte d'Otricoli; una delle prime
 famiglie d'Italia, di una ricchezza immensa.</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Mi fa troppo onore il signore Fabrizio. Io non
 merito nessuno di questi elogi.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>E non serve dire, e non dire; quest'è il primo
 cavaliere del mondo. In materia di cavalleria, non c'è
@@ -1082,41 +1119,41 @@ altrettanto in tutta l'Europa. Fate il vostro dovere col
 signor Conte</p>
             <stage><emph>(alle donne con qualche risetto)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Signore, attribuisco a mia singolare fortuna
 l'onor di conoscere un cavaliere di tanta stima</p>
             <stage><emph>(a Roberto)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Posso io consolarmi...</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Vede, signor Cavaliere? Questa è Flamminia mia
 nipote. È vedova. Ha avuto per marito il primo mercante di
 Milano.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>(È morto miserabile il povero disgraziato).</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>È una donna, che per una casa non si dà la
 compagna. Non c'è in tutto Milano; non c'è in tutta l'Italia
 una donna, come Flamminia.</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Mi rallegro infinitamente colla signora.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Mio zio si diverte; non ho questi meriti.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Via, signora Eugenia, ditegli qualche cosa. Fate
 conoscere il vostro spirito, la vostra vivacità. Non c'è,
@@ -1125,74 +1162,74 @@ in una maniera, che i primi ballerini sono rimasti storditi.
 Canta poi di un gusto, che chi la sente more. Parla che non
 c'è stata mai da che mondo è mondo una parlatrice compagna.</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>È ammirabile la signora per la virtù, e per il
 merito della bellezza.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Vi prego non secondare mio zio nel piacer di
 mortificarmi.</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>È ancor zitella la signora Eugenia?</p>
             <stage><emph>(a Fabrizio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Sì signore. M'è stata richiesta dalla prima nobiltà
 di Milano; ma io non l'ho voluta dare a nessuno. Ho delle
 idee grandiose sopra di lei.</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>In fatti ella merita una fortuna corrispondente alle
 sue rare prerogative.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Al giorno d'oggi vi è poco da compromettersi. Ci
 sono più debiti, che ricchezze. Dei conti d'Otricoli non ce
 n'è che un solo al mondo.</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Io vaglio molto meno degli altri. Le mie fortune
 sono assai limitate. Quello di che mi pregio si è la
 sincerità, e l'onore.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Nipoti mie quest'è l'esempio dei cavalieri onorati;
 è il libro aperto, che insegna agli uomini la sincerità.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Lo conoscerete, ch'è un pezzo questo signore?</p>
             <stage><emph>(a Fabrizio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Quest'è la prima volta che ho l'onor di vederlo.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>(E pare, che sieno trent'anni, che lo conosce).</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>È stato diretto a me da un amico mio di Bologna,
 ch'è il fiore de' galantuomini, ed il più bravo pittore, che
 sia stato al mondo dopo Zeusi, ed Apelle. Signor Conte, ella
 si diletterà di pitture.</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Certamente, me ne diletto assaissimo.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Eh, gli uomini grandi, gli uomini di talento
 sublime, come quello del signor Conte non possono fare a
@@ -1210,17 +1247,17 @@ eh? per cento zecchini un quadro, che vale due mila doppie;
 cosa vuol dire intendersi delle cose! Oh io poi per
 conoscere non la cedo ai primi conoscitori del mondo.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>(Poveri danari gettati! Ha tutte copie, e gliele
 fanno pagar per originali).</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Si vede, che siete assai di buon gusto. Avrò
 occasion d'ammirare.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Eh picciole cose. Comparirà la miseria. Ehi fategli
 vedere quei quattro pezzi stupendi del Wandich, quelle due
@@ -1229,125 +1266,125 @@ del Guercino, quell'aurora inimitabile di Michel'Angelo
 Buonarotti, quella notte inestimabile del Correggio. Tesori,
 signor Conte, tesori.</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Voi, a quel, che sento avete una galleria da
 monarca.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Picciole cosarelle da pover'uomo. Si serva,
 favorisca di andare colle mie nipoti.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Ma noi non ce n'intendiamo di quadri, e non li
 sapremo distinguere come voi...</p>
             <stage><emph>(a Fabrizio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Che serve? Se non ve n'intendete voi; se ne intende
 il signor Cavaliere. Ho un affare per ora, che mi trattiene.
 Servitelo intanto, che poi verrò io pure, e gli farò vedere
 di quelle cose, che non avrà mai vedute.</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Mi sarà carissima la vostra compagnia (ma più quella
 delle sue nipoti).</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>(Anderò io, sorella, non v'è bisogno che voi
 venghiate)</p>
             <stage><emph>(ad Eugenia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>(Anzi ci voglio venire).</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>(Se arriva il signor Fulgenzio... )</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>(Che importa a me, che mi trovi col forastiere? Oh
 questa è bella! Va egli a spasso con sua cognata? Voglio
 ancor io trattare con chi mi aggrada)</p>
             <stage><emph>(da sé e parte)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>(Gran testa originale è costei)</p>
             <stage><emph>(parte)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Vada, signor Cavaliere, s'accomodi.</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Mi prevalerò delle vostre grazie</p>
             <stage><emph>(in atto di partire)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Eh favorisca.</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Che mi comandate?</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Oggi avrà la bontà di restare a mangiar una cattiva
 zuppa con noi.</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Oh questo poi...</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Oh non c'è risposta.</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>No, certo.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Per sicurissimo.</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Ne parleremo.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Mi dà parola?</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Contentatevi...</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Mi dà parola?</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Non so che dire.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Compatirà la miseria, ma sentirà un paio di piatti,
 che i simili non li avrà la tavola dell'Imperadore, e
 saranno fatti dalle mie mani.</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Non posso ricusare le vostre grazie. (Egli
 ingrandisce tutte le cose, ma credo, che non si dia un pazzo
@@ -1358,7 +1395,7 @@ più grande di lui)</p>
         <div type="scene">
           <head>Scena settima</head>
           <stage><emph>Fabrizio, poi Succianespole</emph>.</stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Sono in impegno di farmi onore. Voglio, che tutti
 possano dir bene di me; se vado anch'io per il mondo, mi
@@ -1367,227 +1404,227 @@ trombette. Mi dispiace, che non ci ho altri che un servitore
 solo vecchio, stordito. Ma farò io. I buoni piatti li farò
 io. Ehi, Succianespole.</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Signore.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Come stiamo in cucina?</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Bene.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>È acceso il foco?</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Gnor no.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Perché non è acceso il foco?</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Perché non c'è legna.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Non mi star a fare lo scimunito, che oggi ho da dar
 da pranzo a un'Eccellenza.</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Ci ho gusto.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Succianespole, che cosa daremo da pranzo a Sua
 Eccellenza?</p>
             <stage><emph>(ridente con confidenza)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Tutto quello, che comanda Vostra Eccellenza.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Qualche volta mi faresti arrabbiare con questa tua
 flemmaccia maladetta.</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Io son lesto.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Lo sai fare il pasticcio di maccheroni?</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Gnor sì.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Un fricandò alla francese?</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Gnor sì.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Una zuppa coll'erbuccie?</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Gnor sì.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Colle polpettine?</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Gnor sì.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>E coi fegatelli arrostiti?</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Gnor sì.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Hai danari per ispendere?</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Gnor no.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Ti ho pur dato un zecchino.</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Quanti giorni sono?</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>L'hai speso?</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Gnor sì.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>E il tuo salario, che ti ho dato l'hai speso?</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Gnor sì.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>E non hai più un quattrino?</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Gnor no.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Maladetto sia il «gnor sì», e il «gnor no». Si
 sente altro da te, che «gnor sì» e «gnor no»?</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Insegnatemi che cosa ho da dire.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Bisogna pensare a trovar danari.</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Gnor sì.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Quante posate ci sono?</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Sei, mi pare.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Sì erano dodici. Sei le ho impegnate, restano sei.
 Siamo in quattro; impegnamone due.</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Gnor sì.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Va' al monte, e spicciati.</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Gnor sì.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>E non mi fare aspettare due ore.</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Gnor no.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Andremo a spendere, quando torni.</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Gnor sì.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>C'è vino?</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Gnor no.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>C'è pane?</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Gnor no.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Che tu sia maladetto, Gnor sì, che tu sia
 bastonato...</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Gnor no</p>
             <stage><emph>(parte con una riverenza, poi torna)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Io non so, come vada. In casa mia non vi è mai il
 bisogno, e oramai ho dato fine a tutto. Ma non importa. Io
@@ -1598,12 +1635,12 @@ grano della mia testa mi ha da rendere il cento per uno. Che
 si impegni, e che si spenda; e poi? in carrozza, in
 carrozza.</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>In carretta</p>
             <stage><emph>(spuntando dalla scena, e subito parte)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Il diavolo che ti porti</p>
             <stage><emph>(gli corre dietro, e parte)</emph>.</stage>
@@ -1614,41 +1651,41 @@ carrozza.</p>
           <stage>
             <emph>Lisetta, e Ridolfo.</emph>
           </stage>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Che mi comanda il signor Ridolfo?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Ho necessità di parlare con una delle vostre
 padrone.</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Dica pure a quale di esse ho da far l'ambasciata.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Veramente l'affare appartiene alla signora Eugenia,
 ma io parlerei più volentieri alla signora Flamminia.</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Perdoni la curiosità; so, che V. S. è amico molto
 del signor Fulgenzio, ci sarebbe forse qualche novità fra
 lui e la padroncina?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Per l'appunto, vi è una novità non indiferente.</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>La prima l'ho indovinata; vo' un po' vedere se
 indovino ancor la seconda. Viene forse per trattare il come,
 e il quando per concludere queste nozze?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Tutto al contrario. Vi dirò quello, ch'io son per
 fare, poiché Fulgenzio m'ha detto di dirlo pubblicamente.
@@ -1656,37 +1693,37 @@ L'amico per mezzo mio si licenzia dalla signora Eugenia.
 Desidera farlo con civiltà, ma qui non lo vedrete mai più.
 (Se costei glielo dicesse prima di me, mi farebbe piacere).</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Ma perché questa risoluzione così repentina?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Questo poi non l'abbiamo a cercare, né voi, né io.
 Fulgenzio, e la signora Eugenia sapranno eglino la cagione.</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Oh è facile indovinare il perché. Avranno gridato
 insieme.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Può essere.</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>E se hanno gridato faranno la pace.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Mi par dificile.</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>L'hanno fatta tante altre volte.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Questa volta l'amico è risolutissimo. Per quanto gli
 abbia io suggerito di pensarvi, di star a vedere, di non
@@ -1695,25 +1732,25 @@ sodo, mi ha risposto, come un cane arrabbiato, e fino colle
 lagrime agli occhi mi ha pregato per carità, che io venissi
 a disimpegnarlo.</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Non ci credo, e non ci crederò mai. Ne ho vedute
 tante di queste scene, che non ci credo.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Orsù in ogni modo io mi vo' disimpegnare dalla mia
 commissione. Parlare con una di esse; spiegar l'intenzione
 dell'amico Fulgenzio, e nasca, quel, che sa nascere, io non
 vo' strolicar d'avvantaggio.</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Se voi parlate di ciò alla signora Eugenia, la fate
 cascar morta; almeno usatele carità. Non le date il colpo
 tutto ad un tratto.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Credetemi io lo faccio mal volentieri. Ho pregato
 l'amico di dispensarmi: gli ho anche detto che mi lagnerei
@@ -1721,44 +1758,44 @@ se dopo di aver fatto io questo passo lo riconoscessi
 pentito. Tant'è, è costantissimo, vuol ch'io lo faccia.
 Chiamatemi la signora Flamminia.</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>È di là ora con un forastiere, che per ordine di
 suo zio gli fa veder certi quadri.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>E la signora Eugenia dov'è?</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Ella pure si è messa della partita... Oh aspettate.
 Che il signor Fulgenzio abbia saputo del forastiere, e che
 sia sdegnato per questo?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Oibò; mi ha detto di certa lettera; ma non l'ho
 capito. Orsù fatemi un poco parlare o coll'una, o con
 l'altra.</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Povera padrona! Andrò, signore... Oh chi è qui?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Per bacco! È qui Fulgenzio.</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Non ve l'ho detto?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Verrà a cercare di me.</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Eh sì, verrà a cercare di voi!</p>
           </sp>
@@ -1768,42 +1805,42 @@ l'altra.</p>
           <stage>
             <emph>Fulgenzio, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>(Una parola)</p>
             <stage><emph>(a Ridolfo, chiamandolo a parte, con ansietà)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>(Non l'ho ancora potuta vedere)</p>
             <stage><emph>(piano a Fulgenzio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>(Non le avete parlato?)</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>(No, vi dico).</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>(Non sa niente la signora Eugenia di quello, che vi
 avevo raccomandato?)</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>(Ma se non ho veduto, né lei, né la sorella!)</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>(Lisetta è informata di nulla?)</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>(Sì, qualche cosa le ho detto).</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Caro amico, compatitemi per carità. Dopo, che da me
 partiste mi sono sentito gelare il sangue; sarei caduto per
@@ -1816,48 +1853,48 @@ padrona. Tenete queste poche monete, godetele per amor mio.
 E voi, Ridolfo, amatissimo perdonate le mie debolezze, e
 ricevete le mie scuse in questo tenero sincero abbraccio.</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>(Mi pareva impossibile, che non avesse ad esser
 così).</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Amico, vi compatisco, ma non mi mettete più in tali
 impegni.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Avete ragione. Ringraziamo il cielo, che è andata
 bene. Lisetta, dov'è la signora Eugenia?</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>È di là, che si veste. (Non gli dico niente del
 forastiere).</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Se volesse favorir di venire...</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Glielo dirò, signore</p>
             <stage><emph>(in atto di partire)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Ehi; è in collera?</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Non mi pare.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Via, chiamatela.</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>(Oh, questi si amano daddovero!)</p>
             <stage><emph>(parte)</emph>.</stage>
@@ -1868,23 +1905,23 @@ forastiere).</p>
           <stage>
             <emph>Fulgenzio, e Ridolfo.</emph>
           </stage>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Amico, a rivederci.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Andate via?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Volete, ch'io resti?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>No, no, se vi preme, andate pure.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Sì, vado. Conosco benissimo, che il restar solo non
 vi dispiace. Vi compatisco, ma permettetemi, che qualche
@@ -1905,7 +1942,7 @@ trasporti, e vi avvilisca a tal segno</p>
           <stage>
             <emph>Fulgenzio, poi Eugenia.</emph>
           </stage>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Dice bene l'amico, dice benissimo. Dalle donne
 qualche cosa convien soffrire, quando si sa specialmente,
@@ -1919,116 +1956,116 @@ sia di buon umore. Mi pare ilare in volto. Ma qualche volta
 sa fingere. Non vorrei, che dissimulasse. Orsù non
 principiamo a sofisticare.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Serva umilissima, signor Fulgenzio</p>
             <stage><emph>(affettando allegria)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Quest'umilissima si poteva lasciar nella penna.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Mi scappò, non volendo. La riverisco. Che fa? Sta
 bene?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Eh! sto bene io. Ed ella come sta?</p>
             <stage><emph>(intorbidandosi un poco)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Benissimo. Ottimamente.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Me ne consolo. È molto allegra questa mattina.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Quando sono in grazia sua, sono sempre allegrissima.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>(C'è del torbido: non mi vorrei inquietare, ma ho
 paura non potermi tenere).</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Che dice ella di queste belle giornate?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Con questo «ella», con questo «ella» mi ha un
 pochino sturbato, signora mia.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Questa mattina sono stata in complimenti, e mi è
 restato il «lei» fra le labbra.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>In complimenti con chi?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Con certe amiche, che sono venute a favorirmi. Anzi
 mi hanno detto, che vogliono venir questa sera, per condurmi
 a spasso con loro.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>E che cosa avete risposto?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Che ci anderò volentieri.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Senza di me?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Sicuro.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Mi piace. S'accomodi.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Oh bella! Mi avete mai condotta voi una sera a
 spasso?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Non vi ho condotta, perché non mi avete comandato
 di farlo.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Eh dite, perché avete degli altri impegni.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Io? che impegni?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Eh via, che serve? Se avete in casa qualche mazzo di
 carte, che vi avvanzi, favorite portarmelo, che mi divertirò
 un poco dopo cena, a giocare una partita con mia sorella.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Che novità è questa? che discorso è questo? cosa
 c'è sotto a questo vostro ragionamento?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Niente, signore. Faccio per non andare a letto sì
 presto. Voi avete fretta di partire la sera, e vi
@@ -2036,172 +2073,172 @@ compatisco, perché avete i vostri interessi, avete degli
 affari importanti, ed io starò a divertirmi con mia sorella,
 o anderò a spasso colle mie amiche.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Eh signora Eugenia, ci conoschiamo.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Prenderete anche ciò in mala parte?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Ci conoschiamo, vi dico, ci conoschiamo.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Sì, ci conoschiamo, e ci conoschiamo.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Ma il mio servidore in casa vostra non ci verrà
 più.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Che importa a me, che ci venga né il servitor, né il
 padrone?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Eh già; queste sono le solite sue buone grazie.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Ha tabacco?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Se sono andato a far due passi con mia cognata...</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Che cosa c'entra vostra cognata? che importa a me di
 vostra cognata?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>So quel, che dico; e non avrete più il divertimento
 di tirar giù quel balordo del mio servitore.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Mi maraviglio di voi, che parliate così. Vi torno a
 dire, non m'importa né di lui, né di voi.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Né di me? non v'importa di me? né di lui né di me?
 non ve n'importa?</p>
             <stage><emph>(passeggiando in giro con isdegno)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Fermatevi, che mi fate girar il capo.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Né di lui, né di me?</p>
             <stage><emph>(si dà un pugno nella testa)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Facciamo scene?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Né di lui, né di me?</p>
             <stage><emph>(si batte il capo a due mani)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Animo; finiamo queste sguaiaterie</p>
             <stage><emph>(fra lo sdegno, e l'amore)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Non posso più</p>
             <stage><emph>(si abbandona sopra una sedia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Avvertite, che siete pazzo davvero.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Son pazzo, son pazzo?</p>
             <stage><emph>(seguita a battersi)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Non la volete finire?</p>
             <stage><emph>(con un poco di tenerezza)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Cagna! crudele!</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Bell'amore! a ogni menoma cosa subito si sdegna, va
 in bestia, non può soffrir niente il signor delicato.
 Finalmente chi vuol bene ha da compatire; e ad una donna le
 si deve donar qualche cosa. Bella maniera da farsi amare!</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Sì, avete ragione</p>
             <stage><emph>(placato)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Ogni giorno siamo alle medesime.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Compatitemi, non farò più.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Non mi fate di queste ragazzate, che non ne voglio.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Andrete a spasso questa sera?</p>
             <stage><emph>(ridente amoroso)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Se mi parerà.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Con chi anderete?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Eh!</p>
             <stage><emph>(come sopra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Con me anderete.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Sicuro!</p>
             <stage><emph>(ironica)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Non volete venir con me?</p>
             <stage><emph>(un poco sdegnato)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Se ci veniste volentieri.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Ma cara Eugenia, possibile, che ancora non siate
 certa dell'amor mio? In un anno in circa, che ho la
@@ -2216,127 +2253,127 @@ ragionevole appagatevi dell'onesto, compatite le mie
 circostanze, e per amor del Cielo, Eugenia mia, non mi
 tormentate.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Via avete ragione. Non vi tormenterò più.
 Compatitemi; conosco, che ho fatto male...</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Basta così, che mi si spezza il core per la
 tenerezza.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Mi vorrete sempre bene?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Credetemi, che domandandomi questa cosa voi mi
 offendete.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Ve la domando, perché vorrei sentirmelo repplicare
 ogn'ora, ogni momento.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Sì, cara, ve ne vorrò in eterno; e se il Cielo
 vuole, non passerà gran tempo, che sarete mia.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>E che cosa aspettate?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Il ritorno il mio fratello.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Non potete maritarvi senza di lui?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>La convenienza vuol ch'io l'aspetti.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Io lo so perché diferite.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>E perché?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Perché avete paura di disgustare vostra cognata.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Maladetta sia mia cognata; maladetto sia quando
 parlo.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Eccolo qui, non si può parlare.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Ma se sempre mi provocate.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Mi voglio mettere a non dir più una parola.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Non potete parlare senza dire delle sciocchezze?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Le sciocchezze le dite voi, signor insolente.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Or ora vi faccio vedere qualche spettacolo.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Ehi, chi è di là?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Non chiamate</p>
             <stage><emph>(arrabiato)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Pazzo.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Anderò via.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Andate.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Non ci tornerò più.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Non m'importa.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Diavolo, portami. Portami diavolo</p>
             <stage><emph>(parte correndo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Che vita è questa? Che amor maladetto! Non posso
 resistere, non posso più</p>
@@ -2351,25 +2388,25 @@ resistere, non posso più</p>
           <stage>
             <emph>Flamminia, e Ridolfo.</emph>
           </stage>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Scusate, signor Ridolfo, la libertà che mi sono
 presa. Perdonatemi, se vi ho incomodato.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Anzi è onor mio il potervi obbedire.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Quant'è che non avete veduto il signor Fulgenzio?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>L'ho veduto qui, non sono ancora due ore. Mi figuro,
 che si saranno pacificati colla signora Eugenia.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Oh caro signor Ridolfo, sono cose da non credere,
 e da non dire. Si erano pacificati, e tutto ad un tratto,
@@ -2377,24 +2414,24 @@ sono andati giù di bel nuovo, e il signor Fulgenzio è
 partito gridando, chiamando il diavolo, che pareva un'anima
 disperata.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Possibile che abbiano sempre a far questa vita? Si
 amano o non si amano?</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Sono innamoratissimi, ma sono tutti e due
 puntigliosi. Mia sorella è sofistica. Fulgenzio è caldo,
 intollerante, subitaneo. In somma si potrebbe fare sopra di
 loro la più bella commedia di questo mondo.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>E che cosa posso far io, per servire la signora
 Flamminia?</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Vi dirò, signore. Io sono naturalmente di buon
 core, portata a far del bene a tutti, se posso. Specialmente
@@ -2417,20 +2454,20 @@ cauta per l'avvenire, che non gli darà più disgusti, che non
 parlerà più di quella tal persona, che egli sa; anzi fatemi
 il piacer di dirgli...</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Adagio, signora mia, che di tante cose non me ne
 ricorderò più nessuna.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Torniamo da capo.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Non basterebbe, ch'io gli dicessi, che venga qui?</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Sì: ma vorrei che fosse da voi prevenuto...</p>
           </sp>
@@ -2440,55 +2477,55 @@ ricorderò più nessuna.</p>
           <stage>
             <emph>Fabrizio, Succianespole colla sporta, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Flamminia, preparatemi una camiscia, che son tutto
 sudato</p>
             <stage><emph>(Ridolfo lo saluta)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Ditelo a Lisetta, signore. Ella è appunto nella
 vostra camera.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Riverisco il signor Ridolfo.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Ho fatto già il mio dovere.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Compatitemi. Ho tanto camminato, ho tanto faticato
 che mi gira la testa. Ma ho fatto poi una spesa, che né
 anche il governatore. Succianespole, è vero?</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Gnor sì.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Andate a mutarvi</p>
             <stage><emph>(a Fabrizio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Ch'io vada?</p>
             <stage><emph>(a Fabrizio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Aspetta.</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Con questo peso...</p>
             <stage><emph>(a Fabrizio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Aspetta. Lasciami veder quel cappone. Osservate. Si
 è mai veduto da che mondo è mondo un cappone compagno?
@@ -2498,21 +2535,21 @@ paese non l'ha nessuno. Signor Ridolfo, questa vitella è un
 butirro, è un balsamo. Resti a mangiarne un pezzetto con
 noi.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Vi ringrazio, signore...</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>No, no, assolutamente. Guardate queste animelle;
 che roba! che piatto! che esquisitezza! Ne avete da mangiar
 una anche voi.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Vi supplico dispensarmi...</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Non mi fate andar in collera. Io poi... io poi...
 Ah? che piccioni! Avete mai veduti piccioni simili? Signor
@@ -2521,110 +2558,110 @@ solamente per me. E sentirete, che salsa ch'io ci farò. Io,
 io, colle mie mani. E il signor Ridolfo resterà a favorire
 con noi.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Siete tanto obbligante, che non si può dire di no.</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Una parola</p>
             <stage><emph>(a Fabrizio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Cosa vuoi?</p>
             <stage><emph>(accostandosi)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>(E le posate?)</p>
             <stage><emph>(piano a Fabrizio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>(È vero. Non importa; darai a me una posata di
 stagno; mettila bene sotto la salvietta, che non si veda).</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Gnor sì.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Presto va' in cucina, va' a lavorare.</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Gnor sì</p>
             <stage><emph>(s'incamina adagio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Fa' presto.</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Gnor sì</p>
             <stage><emph>(come sopra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Ma spicciati.</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Gnor sì</p>
             <stage><emph>(come sopra, e parte)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Signor zio, a quel, ch'io vedo, vogliamo andare a
 tavola molto tardi.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Eh, non dubitate di niente. Se vado io in cucina,
 in tre quarti d'ora fo da mangiare per cinquecento persone.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Ih! che sparata!</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Per modo di dire; per modo di dire.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>E non andate a mutarvi?</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Sì, c'è tempo. Dov'è Eugenia?</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Nella sua camera.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>E il signor Conte dov'è?</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>A guardare i quadri.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Lo compatisco: non si può saziare. Andatelo a
 chiamare il signor Conte, che favorisca di venir qui.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>E perché ha da venir qui? Non istà bene dov'egli
 sta?</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Ditegli, che venga qui. Gli voglio far conoscere
 questo degno galantuomo del signor Ridolfo. Vedrete un gran
@@ -2632,12 +2669,12 @@ cavaliere, signor Ridolfo; un pezzo grosso; uno di quelli,
 che fanno tremare. Ma via, chiamatelo</p>
             <stage><emph>(a Flamminia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Senza, che m'incomodi, eccolo, ch'egli viene da
 sé.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>È un'arca di scienze, è un mostro di virtù.
 Resterete maravigliato</p>
@@ -2649,106 +2686,106 @@ Resterete maravigliato</p>
           <stage>
             <emph>Roberto, e detti, poi Lisetta.</emph>
           </stage>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Queste signore si sono annoiate di me; le compatisco
 hanno pensato meglio lasciarmi solo.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Dov'è Eugenia? Presto chiamatela</p>
             <stage><emph>(a Flamminia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Voglio far altro io, che chiamarla.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Uh! siete pure svenevole. Lisetta</p>
             <stage><emph>(chiama)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Che comanda?</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Di' subito ad Eugenia che venga qui.</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Se mi domanda il perché?</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Dille, che venga qui, che una persona la vuol
 vedere, e le vuol parlare.</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>(Può essere, che il signor Ridolfo le abbia a dir
 qualche cosa per parte del signor Fulgenzio. Con questa
 speranza la farò venire)</p>
             <stage><emph>(parte)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>(Andate, signor Ridolfo a ritrovare il signor
 Fulgenzio, e fatelo venir qui, e ditegli tutto quel, che vi
 ho detto)</p>
             <stage><emph>(piano a Ridolfo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>(Sì, se me ne ricorderò). Con sua licenza signor
 Fabrizio.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Come? Andate via? Non mi avete dato parola di
 restar con noi?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Tornerò verso l'ora del pranzo.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Vi aspetto. Non si dà in tavola senza di voi.
 Signor Conte, questi è il primo causidico di Milano, il
 primo curiale del mondo, il più bravo legale di tutto il
 regno della Giurisprudenza.</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Me ne rallegro infinitamente.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>L'amicizia, che ha per me il signor Fabrizio, lo fa
 trascendere in soverchie lodi.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Ha qualche causa in Milano il signor Conte?</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Ne avevo una, per dirla, ma siamo per convenire
 cogli avversari, e terminarla amichevolmente.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>No, non la termini amichevolmente. Si lasci servire
 dal signor Ridolfo, dal principe dei curiali; gliela farà
 guadagnare senz'altro.</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Ma se già ho i miei legali.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Che legali? che legali? Sono tutti ignoranti.
 Questi è il legale, e non ve n'è altri fuori di lui. Faccia
@@ -2756,12 +2793,12 @@ a mio modo si metta nelle di lui mani. Signor Ridolfo, vada
 a casa del signor Conte, si faccia informare, e si faccia
 consegnar le scritture.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Ma se sta per accomodarsi...</p>
             <stage><emph>(a Fabrizio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Non vi ha da essere accomodamento. Il signor Conte
 vuol essere servito da lei, e con chi crede vussignoria aver
@@ -2769,22 +2806,22 @@ che fare? Col primo cavaliere dello Stato Romano, che ha
 feudi con padronanza assoluta, che è conosciuto da tutta
 l'Europa, e stimato, e venerato da principi, e da potentati.</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Basta, basta, signor Fabrizio. Non mi mettete in
 ridicolo.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Parlo con ogni rispetto. So quel, che dico, e la
 verità s'ha da dire.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>(Andate che si fa tardi)</p>
             <stage><emph>(a Ridolfo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Con vostra permissione. Vado per ritornare tra poco</p>
             <stage><emph>(a Fabrizio, e parte)</emph>.</stage>
@@ -2795,59 +2832,59 @@ verità s'ha da dire.</p>
           <stage>
             <emph>Flamminia, Fabrizio, e Roberto, poi Succianespole.</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Grand'uomo! grand'uomo! Si chiamerà contento di
 lui</p>
             <stage><emph>(a Roberto)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>(Dica, quello che vuole, io non voglio far una lite
 per dargli gusto).</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>E così, signore zio, non vi siete mutato?</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Mi muterò. Voglio andare in cucina, a lavorar per
 il mio padrone: il signor conte d'Otricoli. Dica: gli piace
 la salsa verde?</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Sì signore, mi piace.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Bene, si farà la salsa verde per il mio padrone.
 Dica: gli piace lo stuffato?</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Anzi moltissimo.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Si farà lo stuffato per il mio padrone.
 Succianespole.</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Signore.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Lo stuffato, e la salsa verde per il mio padrone.</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Gnor sì</p>
             <stage><emph>(parte)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Succianespole poi è un omo di garbo. Non fo per
 dire, ma un servitore come lui non si trova. Fidato,
@@ -2860,26 +2897,26 @@ attento, sollecito, pontuale, bravo cuoco, buono spenditore:
           <stage>
             <emph>Eugenia, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Che mi comanda il signore zio?</p>
             <stage><emph>(melanconica)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>State qui, state a far compagnia a questo
 cavaliere.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Non c'è il signor Ridolfo? (Se lo sapeva non ci
 venivo).</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>La mia compagnia non piace alla signorina.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Eh cosa dice mai? Lo riceve per grazia, per onore,
 per gloria. Si accomodino. Una sedia al padrone</p>
@@ -2896,31 +2933,31 @@ a far il cuoco. Chi sono io? Sono il cuoco del mio padrone</p>
           <stage>
             <emph>Flamminia, Eugenia, Roberto, tutti a sedere.</emph>
           </stage>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>È sempre così gioviale il signor Fabrizio?</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Lodo la vostra modestia; dovevate dire così
 caricato.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>È di buon core, ma anche il buon core, quando
 eccede è soverchio</p>
             <stage><emph>(sempre in aria melanconica)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Che ha la signora Eugenia, che mi par melanconica?</p>
             <stage><emph>(a Flamminia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Non saprei, averà i suoi motivi.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Diteglielo liberamente, se ha piacer di saperlo. Io
 non mi vergogno di manifestare una verità, che non mi fa
@@ -2929,32 +2966,32 @@ essere mio consorte, so di avergli dato un disgusto, me ne
 dispiace, e non sono contenta, se non lo vedo pacificato.
 (Così non mi seccherà più costui colle sue sguaiataggini).</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Sentite, che bel carattere è quello di mia
 sorella? La sincerità non vi è oro, che la paghi.</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Mi piace tanto la verità in bocca di una fanciulla,
 e sono sì poco avvezzo a sperimentarla, che sempre più la
 signora Eugenia mi obbliga a riverirla, e ad amarla.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Sono tenuta alla vostra bontà; e mi rincresce, che
 inutilmente impiegate il vostro amore, e la vostra stima</p>
             <stage><emph>(con serietà)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Non per questo cesserò di sperare.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>E in che volete sperare?</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Nelle vicende della fortuna, nei casi, che possono
 impensatamente accadere; in qualche esempio di mutazioni
@@ -2964,31 +3001,31 @@ per lo più sono forzate a retrocedere, a diminuire. Caso
 mai, che il vostro amante non fosse fido, quanto voi siete,
 avrò sempre anticipata la mia onesta dichiarazione.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Non dice male il signor Conte. Il suo amore non
 pregiudica né voi, né il signor Fulgenzio, e non si possono
 prevedere i casi. (Io non vorrei veder nessuno scontento).</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Per me non vi hanno da essere altri casi. O di
 Fulgenzio, o di nessun altro.</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Così dovete dire, e mi compiaccio, che lo diciate;
 ma dei casi ne potriano succedere.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Non vorrei, che foste l'augello del mal augurio.</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>No, signora, non mi prendete in cattiva parte.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>È un cavalier di garbo, il signor Conte</p>
             <stage><emph>(ad Eugenia)</emph>.</stage>
@@ -2996,14 +3033,14 @@ ma dei casi ne potriano succedere.</p>
 compatirla. Parla così, perch'è innamorata</p>
             <stage><emph>(a Roberto)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Siatelo, che il Cielo vi benedica. Ma state allegra.
 Io non vi darò molestia su questo punto. Divertiamoci;
 parliamo di cose liete</p>
             <stage><emph>(ad Eugenia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>È impossibile, signore; ho il core troppo
 angustiato.</p>
@@ -3014,92 +3051,92 @@ angustiato.</p>
           <stage>
             <emph>Lisetta, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>(Signora, ho veduto venire il signor Fulgenzio)</p>
             <stage><emph>(ad Eugenia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>(Come l'hai veduto?)</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>(Dalla finestra).</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>(Era solo?)</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>(Parlava col signor Ridolfo).</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>(Parveti che fosse sdegnato?)</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>(Anzi mi parve allegro, e l'ho veduto venire
 saltellando verso la casa).</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>(Sia ringraziato il Cielo. Ridolfo lo avrà placato.
 Ha fatto bene mia sorella a servirsi di lui)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>(Ha degl'interessi la signora Eugenia)</p>
             <stage><emph>(piano a Flamminia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>(Credo sia venuto l'amico)</p>
             <stage><emph>(piano a Roberto)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Flamminia</p>
             <stage><emph>(con bocca ridente)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>È venuto?</p>
             <stage><emph>(ad Eugenia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Sì</p>
             <stage><emph>(come sopra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Lode al Cielo, vi vedo pure colla bocca ridente</p>
             <stage><emph>(ad Eugenia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Chi sa, se ha veduto il signor Ridolfo</p>
             <stage><emph>(ad Eugenia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Sì l'ha veduto. È allegro. Non è egli vero,
 Lisetta?</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Verissimo.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Eccolo, eccolo</p>
             <stage><emph>(ridente)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>(Fa invidia un sì bell'amore)</p>
             <stage><emph>(da sé)</emph>.</stage>
@@ -3110,7 +3147,7 @@ Lisetta?</p>
           <stage>
             <emph>Fulgenzio, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <stage>
               <emph>(entra, e vedendo Roberto resta un poco sospeso)</emph>
@@ -3118,7 +3155,7 @@ Lisetta?</p>
             <p>(Chi è costui?)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Venga, venga, signor Fulgenzio. Questo cavalier
 forastiere è venuto qui in questo momento. È vero?</p>
@@ -3127,99 +3164,99 @@ forastiere è venuto qui in questo momento. È vero?</p>
 amico di nostro zio, e parte presto di Milano. È vero?</p>
             <stage><emph>(a Roberto)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Sì signora, come comanda.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Son servitor umilissimo a quel signor forastiere, e
 a lor signore ancora</p>
             <stage><emph>(con serietà)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Si fa sempre desiderare il signor Fulgenzio</p>
             <stage><emph>(allegra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Troppe grazie, signora. Io non merito di essere
 desiderato</p>
             <stage><emph>(affettando indifferenza)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Accomodatevi</p>
             <stage><emph>(a Fulgenzio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Ben volentieri</p>
             <stage><emph>(prende una sedia, e la porta presso Flamminia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Poni qui una sedia, Lisetta. Favorisca presso di me</p>
             <stage><emph>(a Fulgenzio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Grazie. Sto ben dove sono.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Venite qui, con licenza di questo signore, vi ho da
 dir una cosa</p>
             <stage><emph>(con allegria a Fulgenzio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Non mancherà tempo</p>
             <stage><emph>(fingendo allegria)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Chi ha tempo non aspetti tempo</p>
             <stage><emph>(con allegria)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>È molto allegra la signora Eugenia. (Questa è la
 pena, che si prende, quando parto da lei sdegnato)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>La sua allegrezza è frutto della vostra venuta,
 signore.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Della mia venuta?</p>
             <stage><emph>(con serietà)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Sì, mi consolo con voi, che avete la sorte di
 possedere il più bel cuore del mondo.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Il signor forastiere venuto in questo momento, è
 stato di già informato dalla signora Eugenia?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Vi dispiace, che si sappia, che noi ci vogliamo
 bene?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Non signora; non mi dispiacerebbe, se si dicesse la
 verità.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Per parte mia non v'è dubbio; se voi poi non vi
 sentite in istato di confermarlo...</p>
@@ -3230,64 +3267,64 @@ sentite in istato di confermarlo...</p>
           <stage>
             <emph>Fabrizio col grembiale da cucina, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Flamminia.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Signore. Bella figura!</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Sapete voi, dove sia lo zucchero?</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Sì signore; è sull'armadio nella mia camera.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Voglio fare un dolce, e brusco per il mio padrone.
 Oh compatisca, signor Fulgenzio; l'avevo preso per il signor
 Ridolfo. Bravo; è venuto a favorirci, ho piacere, vuol
 restare a pranzo con noi?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Vi ringrazio, signore...</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Signor Conte, si contenta, che si inviti a pranzo
 con noi questo nobile cittadino? È una perla, veda, è oro
 colato.</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Signore, non siete padrone voi in casa vostra?</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>No, fin tanto che il signor Conte sta in Milano,
 egli è il padrone di casa mia.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Ci sta molto il signor Conte in Milano?</p>
             <stage><emph>(a Fabrizio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Oh, ci starà un pezzo. Ha una lite, e gliela dirige
 quell'uomo grande, quell'uomo celebre del signor Ridolfo.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>(E queste signore mi hanno dato ad intendere, che
 parte presto. Le bugie non si dicono a caso).</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Signor Conte, io ho degli affari; non potrò essere
 continuamente a servirla. Ecco chi la servirà. Il primo
@@ -3297,101 +3334,101 @@ Longobardi. Intendente di tutto, specialmente di quadri. Ha
 veduto la mia picciola galleria?</p>
             <stage><emph>(a Roberto)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Sì signor l'ho veduta, e ammirata.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Ma in due ore non si può veder tutto.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Sono due ore che è qui il signor Conte?</p>
             <stage><emph>(a Fabrizio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Sì certo, è venuto a favorirmi per tempo.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>(E mi dissero ch'era venuto in quel punto! Questo
 non si chiama sottilizzare. Sono bugie patenti).</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Oggi, signor Fulgenzio, avrete l'onor di pranzare
 col primo lume della nobiltà, colla prima stella d'Italia,
 col più ricco cavaliere privato dei nostri giorni.</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>(E tira innanzi così).</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Ma io, signore, non posso profittar delle vostre
 grazie.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Che serve?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>No certo.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Via, dico.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Non posso.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Ed io voglio. Comando io in questa casa... No non
 comando io, comanda il padrone, e il padrone lo pregherà di
 restare.</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Signore, s'egli non può, o non vuole, perché lo
 vogliamo obbligare?</p>
             <stage><emph>(a Fabrizio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>(Costui non vorrebbe che ci restassi; converrà,
 ch'io ci stia per iscoprire il disegno).</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>(Stupisco, che non abbia piacere di restar a pranzo
 con me. Ci pensa poco, al vedere).</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Via, signor Fulgenzio, faccia un'azione eroica.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>(Mi fa specie, che Eugenia non mi dice niente,
 ch'io resti. Segno, che non le preme).</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Mi maraviglio di voi, signor Fulgenzio, che vi
 fate tanto pregare.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Mi farei pregar meno, se non temessi di recar
 disturbo alla compagnia.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Che ragioni fiacche! dite, che non volete restare,
 perché vi preme di andare a casa, per non lasciar sola la
@@ -3399,148 +3436,148 @@ signora Clorinda vostra cognata. Ecco il perché. Ha ragione,
 signor zio. Non l'obbligate a dar un dispiacere a quella
 povera signorina</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>(Sì: vuol rimproverar me, perch'io non abbia
 occasione di rimproverar lei)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>(Ora mangia il veleno. Lo conosco. Ci ho gusto).</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>(Se fosse mia figlia, le darei degli schiaffi).</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Via, signor Fulgenzio, mi lasci andare in cucina,
 mi consoli con un bel sì.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Per far vedere, che qualcheduno s'inganna, resterò
 a godere le vostre grazie.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Oh bravo!</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>(Ora sono contenta)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>E viva il signor Fulgenzio.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Ma facciamo le cose ben fatte. Signor Fulgenzio,
 Eugenia mia nipote vi supplica di una grazia.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>(Che diavolo vorrà dire?)</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Io non son degno dei comandi della signora Eugenia.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Via, che occorre? Ci conosciamo. Eugenia mia nipote
 vi prega, vi supplica, che subito andiate a casa, che
 prendiate la signora Clorinda vostra cognata, e che la
 conduciate qui a pranzo con noi.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>La signora Eugenia mi prega di questo?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Io non mi sono mai sognata questa bestialità.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Bestialità la chiamate?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Sì, vi par cosa propria incomodar una signora a
 quest'ora?</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>È ora incomoda questa? Vi mancano due ore a mezzo
 giorno. Ha tempo quanto vuole a vestirsi, a conciarsi, e a
 venire a bell'agio.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>(Pare, che c'entri il diavolo a bella posta).</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Basta, io lascio fare al signor Fulgenzio.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Pregatelo</p>
             <stage><emph>(ad Eugenia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Oh questo poi no.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Lo prego io dunque</p>
             <stage><emph>(a Fulgenzio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Dispensatemi. Son certo, che mia cognata non ci
 verrà.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>(È certo, che non verrà; perché sa, che colei non
 mi può vedere).</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Proviamo; andate a dirglielo in nome mio.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>No certo, signore. Scusatemi non ci vado.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>E volete, che stia a mangiar sola? Non è dovere.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Piuttosto non ci resterò né men io.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Sì, piuttosto andrà con lei, a servirla di
 compagnia; lasciatelo andare.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>(Se non crepo è un prodigio).</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>(Ma giusto Cielo! che testa è quella?)</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Orsù non occor altro. (So io quel, che farò. Anderò
 io a invitarla). Succianespole.</p>
@@ -3551,64 +3588,64 @@ io a invitarla). Succianespole.</p>
           <stage>
             <emph>Succianespole, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>Signore</p>
             <stage><emph>(con una stoviglia in mano)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>(Tieni questo grembiale che or ora vengo, e, senti,
 cresci qualche cosa per due persone di più).</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>(E le posate?)</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>(Oh diavolo! come faremo?)</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>(Come faremo?)</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>(Ingegnati).</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>(Vi sono quelle di legno).</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>(Sciocco! la riputazione. Zitto, l'ho trovata. Farò
 così; me ne farò prestar due dalla signora Clorinda. È una
 donna di garbo, non dirà niente a nessuno. Farò bene?)</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>(Gnor sì).</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>(Va' a lavorare).</p>
           </sp>
-          <sp>
+          <sp who="#succianespole">
             <speaker>SUCCIANESPOLE</speaker>
             <p>(Gnor sì)</p>
             <stage><emph>(parte)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Con licenza di lor signori.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Dove va, signor zio?</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Succianespole si è scordato di comprare una cosa.
 Vado io, e torno subito. (Eh per ripieghi non c'è un par
@@ -3624,170 +3661,170 @@ Non sono morto. Chi sa?)</p>
           <stage>
             <emph>Flamminia, Eugenia, Fulgenzio, e Roberto.</emph>
           </stage>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>(In questa casa vi è il più bel divertimento del
 mondo).</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Mi dispiace del sagrifizio, che oggi deve fare il
 signor Fulgenzio.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>E a me dispiace, che ogni sagrifizio è male
 accettato.</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Signori miei, amore non si pasce di sdegno, ma di
 dolcezze</p>
             <stage><emph>(a Fulgenzio, e ad Eugenia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Bravo, dite lor qualche cosa; che non istiano
 sempre ingrugnati</p>
             <stage><emph>(a Roberto)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Sarei più fortunato, se avessi il merito del signor
 Conte.</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Io non ho merito alcuno; ma vi accerto bensì, che se
 avessi un'amante, come questa gentil signora, mi chiamerei
 fortunato.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>E chi v'impedisce una sì gran fortuna?</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Io non faccio mal'opera con nessuno...</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Se parlate per me...</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Se parlate per lui, mi rinunzia solennemente</p>
             <stage><emph>(a Roberto)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Ella interpreta i miei sentimenti, a misura delle
 sue inclinazioni.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Il signor Conte non è capace di interrompere il
 corso dei vostri amori.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Sì: è arrivato in questo momento, e parte
 prestissimo di Milano.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Io ho parlato così...</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Eh lasciatelo dire. Non sapete com'è fatto? Ha
 voglia di taroccare.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>E voi avete voglia di vedermi fare delle pazzie. Ma
 questo gusto non ve lo darò più. Ho fissato di non volermi
 più scaldare il sangue per voi. Signor Conte, da dove viene
 ora, se è lecito?</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Da Roma, signore.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Che dice di quella gran città?</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Bella, magnifica, piena di meraviglie.</p>
           </sp>
-          <sp>
+          <sp who="#flam">
             <speaker>FLAM</speaker>
             <p>A noi non importa di Roma.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Lasciatelo dire; lasciate, che si diverta.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Mi dicono, che a Roma ci sono delle belle donne, è
 egli vero?</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Sì, certo, ed hanno una galanteria sorprendente.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Sono così ostinate, come le milanesi?</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Questa poi compatitemi...</p>
             <stage>
               <emph>(a Fulgenzio)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>A Roma, signore, degli uomini incivil ve ne sono?</p>
             <stage>
               <emph>(a Roberto)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Via via, non vi lasciate trasportar dalla collera.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Andrei a Roma pur volentieri.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Andate, che sarete la consolazione di Pasquino.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Fa caldo oggi, mi pare</p>
             <stage><emph>(si alza affettando indiferenza, ma si vede che freme)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>(Signor Conte, vorrei pregarvi di una finezza).</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>(Comandatemi).</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>(Fate mostra di aver da fare qualche cosa. Andate
 di là per un poco).</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>(Sì, è giusto, lasciamoli in libertà)</p>
             <stage><emph>(a Flamminia)</emph>.</stage>
@@ -3802,45 +3839,45 @@ di lor signori</p>
           <stage>
             <emph>Flamminia, Eugenia, e Fulgenzio.</emph>
           </stage>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>E di quai casi intende di dire?</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Chi lo sa? gli badate voi? Noi non ci pensiamo né
 meno. Eugenia non lo può vedere.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Così credo ancor io.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Caro signor Fulgenzio, siete assai sospettoso.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Non parlate, sorella, che or ora lo farete dar nelle
 furie.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Oh non vi è dubbio. Non vi è pericolo che mi
 vediate infuriare. Ho preso un altro sistema; son diventato
 pacifico. Non mi riscaldo più.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Via dunque; siate buono. Mia sorella, poverina,
 credetelo vi ama di vero cuore. Io l'ho veduta piangere...</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Non è vero. Non le credete. Lo dice a posta</p>
             <stage><emph>(a Fulgenzio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>A che servono ora codeste scene? Io non le voglio
 assolutamente. Vado di là, perché il signor Conte non dica.
@@ -3860,376 +3897,376 @@ Fulgenzio)</p>
           <stage>
             <emph>Fulgenzio, ed Eugenia.</emph>
           </stage>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>(Per me ho finito d'essere innamorato)</p>
             <stage><emph>(passeggia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>(Voglio piuttosto mettermi un sasso al collo, e
 andarmi a gettar nel Naviglio)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>(Si vede chiaro, che è annoiata di me)</p>
             <stage><emph>(come sopra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>(Ha il cuore con tanto di pelo)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>(Ci scommetterei la testa, che il Conte le piace)</p>
             <stage><emph>(come sopra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>(Finto! doppio come le cipolle!)</p>
             <stage>
               <emph>(da sé)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>(Son pur pazzo io a perdere il mio tempo, e a
 perdere la salute, ed il riposo per lei)</p>
             <stage><emph>(come sopra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>(Lo vedrebbe un cieco, che ha più premura per la
 cognata, che per me)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>(Penerò un poco, ma lo supererò questo indegnissimo
 amore)</p>
             <stage><emph>(come sopra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>(Se ora mi tratta così, guai a me se fosse mio
 sposo)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>(Farò un viaggio; me ne scorderò)</p>
             <stage><emph>(come sopra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>(Ha una faccia, che pare il vero demonio)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>(E stimo, che non mi dice niente)</p>
             <stage><emph>(come sopra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>(Che ho da fare io con questo girandolone? È meglio
 che me ne vada)</p>
             <stage><emph>(in atto di partire)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Buon viaggio</p>
             <stage><emph>(forte)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Felice ritorno</p>
             <stage><emph>(si volta)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Vada, vada, che il signor Conte l'aspetta.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Perché non va a dire alla signora cognata, che resta
 a pranzo fuori di casa?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>(Maladetta!)</p>
             <stage>
               <emph>(si va sdegnando a poco a poco)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Perché non le va a chieder licenza di restar qui?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>(Le si possano seccar le labbra)</p>
             <stage><emph>(come sopra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Ma ora, che ci penso; non vorrà, che lo sappia la
 sua signora cognata, che resta qui, avrà paura, avrà
 soggezione.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>(Possa parlare per l'ultima volta)</p>
             <stage><emph>(come sopra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Mi spiacerebbe, che avesse da disgustare la sua
 signora cognata.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Lasciate star mia cognata</p>
             <stage><emph>(acceso di collera)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Oh oh quel bravo signore, che non va più in bestia!</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>(Non posso resistere)</p>
             <stage><emph>(da sé, e tira fuori il fazzoletto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Non dubiti, che avrà finito di arrabbiarsi per me.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <stage>
               <emph>(straccia il fazzoletto coi denti)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Mi duole del tempo, che ha gettato con una pazza.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <stage>
               <emph>(segue a stracciare il fazzoletto)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Ma si consoli, che dormirà i suoi sonni.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <stage>
               <emph>(tira fuori nascostamente un coltello)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>(Povera me!) Eh dico, signor Fulgenzio</p>
             <stage><emph>(timorosa, vedendo il coltello)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Che vuol da me?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Cos'avete in mano?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Niente.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Voglio vedere.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Non ho niente, vi dico.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Non facciam ragazzate.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>All'onore di riverirla</p>
             <stage><emph>(in atto di partire)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Fermatevi.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Ha qualche cosa da comandarmi?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Che c'è in quella mano?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Niente</p>
             <stage><emph>(mostra la mano vuota)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>In quell'altra?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Niente.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Non facciamo scene, vi dico.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Che scene, che scene? Le fa ella le scene. Io non
 faccio scene.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Mettete giù quel coltello.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Che cosa vi sognate voi di coltello?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Che serve? Non mi fate arrabbiar d'avvantaggio,
 datelo qui</p>
             <stage><emph>(si accosta per averlo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Che cosa credete voi, ch'io voglia fare di questo
 coltello?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Che lo so io?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Voglio mondare una mela.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Fulgenzio</p>
             <stage><emph>(intenerendosi)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Lasciatemi stare</p>
             <stage><emph>(con più caldo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Fulgenzio</p>
             <stage><emph>(come sopra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Lasciatemi stare</p>
             <stage><emph>(crescendo il caldo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Per carità.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Per me non c'è carità, né amore, né compassione</p>
             <stage><emph>(come sopra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Ascoltate una parola almeno.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Cosa volete dirmi?</p>
             <stage>
               <emph>(con isdegno)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Una parola sola.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Via, ditela</p>
             <stage><emph>(come sopra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Placatevi, se volete ch'io parli.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Ah!</p>
             <stage>
               <emph>(sospira con isdegno)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Datemi quel coltello.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Signora no.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Ve lo domando, se non per l'amore, che mi portate,
 per quello almeno, che mi avete portato.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Ah!</p>
             <stage>
               <emph>(si lascia cadere il coltello di mano)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>(Maladetto coltello!)</p>
             <stage>
               <emph>(lo prende velocemente e lo getta via)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>(Mi sento morire).</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Vi sono io così odiosa, che volete morire piuttosto
 che volermi bene?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Sì, voglio morire piuttosto, che vedervi in braccio
 ad un altro.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Ma come è possile mai, che vi passino per mente
 pensieri così indegni di voi, e di me? Io amar altri, che il
@@ -4237,15 +4274,15 @@ mio Fulgenzio? Io darmi ad altri, fuori che al mio bene,
 all'anima mia, al mio tesoro? Non sarà mai, non sarà mai.
 Morirei prima di farlo.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Lo posso credere?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Se non lo dico di core, il Cielo mi fulmini.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Ma perché addomesticarvi col signor Conte? Perché
 trattarlo subito con confidenza? e palesargli l'impegno che
@@ -4253,7 +4290,7 @@ avete meco? E perché darmi ad intendere vostra sorella,
 ch'ei parte presto, ch'era venuto poc'anzi? perché dirmi
 delle bugie? perché darmi occasione di sospettare?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Ah Fulgenzio, non sono io, che vi dà occasione di
 sospettare, ma la poca fede, che avete di me, fa inquietar
@@ -4284,7 +4321,7 @@ mio non siate, sì, ve lo giuro, io sarò sempre vostra, e lo
 sarò fin che viva, e lo sarò colla maggior tenerezza del
 cuore.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Anima mia dolcissima, cuor mio caro, vi domando
 perdono, compatitemi per carità</p>
@@ -4296,11 +4333,11 @@ perdono, compatitemi per carità</p>
           <stage>
             <emph>Fabrizio, Clorinda e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Oh, ecco qui la signora Clorinda.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Oimè! che dirà il signor Fabrizio, se mi ha veduto
 in quest'atto?</p>
@@ -4308,52 +4345,52 @@ in quest'atto?</p>
               <emph>(Fabrizio, e Clorinda restano un poco indietro ammirati)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>(Ah trema della cognata. Gli duole, che lo abbia
 veduto ai miei piedi).</p>
           </sp>
-          <sp>
+          <sp who="#clorinda">
             <speaker>CLORINDA</speaker>
             <p>(Povero signor Fulgenzio! mi dispiace che rimasto
 sia sconcertato. Compatisco l'amore, e mi sovviene, che il
 mio caro sposo faceva meco lo stesso).</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Eugenia, che cos'è stato? è venuto male al signor
 Fulgenzio?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Mi par di sì, domandatelo a lui.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Vi è venuto qualche male, signore?</p>
             <stage>
               <emph>(a Fulgenzio)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Sì, certo, mi è venuto un giramento di capo; non
 avete osservato, ch'io era caduto in terra? (Non sappia,
 ch'io mi gettava ai piedi della nipote).</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>(Si scusa per cagione della cognata).</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Ora, come vi sentite?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Un poco meglio.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Aspettate, che vi voglio guarir del tutto. Vado a
 prender un maraviglioso, stupendo arcano del famosissimo,
@@ -4366,113 +4403,113 @@ magnificentissimo Cosmopolita</p>
           <stage>
             <emph>Eugenia, Clorinda, e Fulgenzio.</emph>
           </stage>
-          <sp>
+          <sp who="#clorinda">
             <speaker>CLORINDA</speaker>
             <p>Scusate, signora Eugenia, se son venuta a recarvi
 incomodo. Il signor Fabrizio a forza di buone grazie, mi ha,
 posso dir, violentata.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>In fatti, senza una violenza non si potevano sperar
 queste grazie.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>(Oh Cieli! prevedo qualche nuovo disastro).</p>
           </sp>
-          <sp>
+          <sp who="#clorinda">
             <speaker>CLORINDA</speaker>
             <p>Voi mi mortificate, signora. Sapete che ho per voi
 quella stima, e quel rispetto, che meritate, ma daché partì
 mio marito, non sono uscita di casa.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Né anche la sera?</p>
           </sp>
-          <sp>
+          <sp who="#clorinda">
             <speaker>CLORINDA</speaker>
             <p>Ah sì, una sera con mio cognato, ve l'ha egli
 detto?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Oh non mi ha detto niente. Egli non mi usa simili
 confidenze.</p>
           </sp>
-          <sp>
+          <sp who="#clorinda">
             <speaker>CLORINDA</speaker>
             <p>Male, signor cognato, quando si ama si dice tutto.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Che ha il signor Fulgenzio che è ammutolito?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Niente signora. (Cielo, aiutami).</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Fa così in casa, signora Clorinda?</p>
           </sp>
-          <sp>
+          <sp who="#clorinda">
             <speaker>CLORINDA</speaker>
             <p>No, per dirla; è piuttosto gioviale.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Sì, non è accigliato, se non quando viene da me. Qui
 è dove gli si promove la malinconia.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Signora, non potete dire, che sia stato sempre
 così.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>È vero, è da poco tempo; da che vi sono diventata
 noiosa.</p>
           </sp>
-          <sp>
+          <sp who="#clorinda">
             <speaker>CLORINDA</speaker>
             <p>Eppure mi parla sempre di voi con un amore
 grandissimo</p>
             <stage><emph>(ad Eugenia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Gioca in casa il signor Fulgenzio?</p>
             <stage>
               <emph>(a Clorinda)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#clorinda">
             <speaker>CLORINDA</speaker>
             <p>Sì, qualche volta.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>E da me grida, bestemmia; tira fuori i coltelli.
 (Dove è andato quel maladetto coltello, che glielo voglio
 rendere or ora)</p>
             <stage><emph>(mostra di cercar il coltello)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#clorinda">
             <speaker>CLORINDA</speaker>
             <p>(Perché le fate di queste scene?)</p>
             <stage>
               <emph>(piano a Fulgenzio)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Perché, perché... Ora non posso parlare</p>
             <stage><emph>(guardandosi da Eugenia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Che cosa sono questi segreti? Se avete dei segreti
 non avete tempo di comunicarveli in casa? Anche qui venite a
@@ -4480,19 +4517,19 @@ fare <emph>ci ci</emph>? Questo è un volere provocare la mia
 sofferenza</p>
             <stage><emph>(parte)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#clorinda">
             <speaker>CLORINDA</speaker>
             <p>Che vuol dire questo discorso?</p>
             <stage>
               <emph>(a Fulgenzio)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Eh sia maladetto, quando siete venuta qui</p>
             <stage><emph>(corre dietro ad Eugenia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#clorinda">
             <speaker>CLORINDA</speaker>
             <p>Che modo e questo? Mio cognato mi perde il
 rispetto? Che Eugenia sia gelosa di me? Sarebbe un insulto
@@ -4511,47 +4548,47 @@ questa casa, ma non con quell'incivile di mio cognato</p>
           <stage>
             <emph>Lisetta, e Tognino.</emph>
           </stage>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Ma che desinare arrabiato è stato quello di questa
 mattina!</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Io non ne saprei indovinare il perché.</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Qualche briga vi è stata fra la signora Clorinda, e
 il signor Fulgenzio.</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>La mia padrona è di temperamento quieto, e
 pacifico. Non vi è mai stato che dire con suo marito; e con
 suo cognato si amavano come fratelli.</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>E quest'amore innocente, e questa loro buona
 corrispondenza è quella che fa delirar la signora Eugenia.</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Me ne sono avveduto questa mattina, quando ella mi
 ha tirato giù per saper quel che fanno, e quel che non
 fanno. Io ho parlato alla buona, non credendo mai, che fosse
 gelosa di una cognata.</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Non è vero che sia gelosa.</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>E che cos'è dunque?</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>È puntigliosa. Non le dispiacciono le attenzioni,
 che usa il signor Fulgenzio alla signora Clorinda, perché li
@@ -4574,12 +4611,12 @@ lei, e ogni cosa le fa ombra; e chi più, e chi meno, dubita,
 sospetta, s'inquieta. Ed ecco le fonti d'onde derivano le
 smanie della padrona. Amore, timore, vanità e sospetto.</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>E quale di queste passioni nel cuore della signora
 Eugenia è la dominante?</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Oh l'amore, l'amore. Se non amasse tanto, non
 sarebbe né sospettosa, né sofistica a questo segno. La
@@ -4588,190 +4625,190 @@ importerebbe a lei, che il signor Fulgenzio facesse la corte
 alla cognata, se non avesse per lui della tenerezza, e se
 non credesse di essere amata?</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Ma quando termineranno questi loro deliri?</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Subito, che il signor Fulgenzio l'avrà sposata.</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>E perché non la sposa?</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Intesi dire, che non lo fa, se non torna il di lui
 fratello.</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Io credo che debba essere qui a momenti. Una
 lettera venuta questa mattina, mi pare lo faccia poco
 lontano.</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Voglia il Cielo, che finiscano di penare. Vi
 assicuro, che delle stravaganze della signora Eugenia ne
 risento anch'io la mia parte.</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Parmi sentir del rumore di là dove mangiano.</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Sono alle bottiglie. Avranno gli spiriti in moto.</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Ho curiosità di sentire. Sempre mi trema il cuore
 per il mio padrone.</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Aspettate. Senza, che andiamo di là, da questa porta
 si può rilevar qualche cosa</p>
             <stage><emph>(va alla porta, e guarda per il buco della chiave)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>(È un po' troppo caldo il padrone).</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Oh diancine! non sono in allegria, no. Ho sentito
 delle parole di sdegno</p>
             <stage><emph>(a Tognino, scostandosi dalla porta)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Lasciate che senta</p>
             <stage><emph>(si accosta alla porta)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Guardate per il buco della chiave</p>
             <stage><emph>(a Tognino)</emph>.</stage>
             <p>(Dubito, che non
 voglia finir in bene).</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Vi sono de' guai. La mia padrona piange</p>
             <stage><emph>(scostandosi)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Piange la signora Clorinda?</p>
             <stage>
               <emph>(corre a vedere alla porta)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>(Quella buona signora non merita queste
 afflizioni).</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Il signor Fabrizio è in collera; ha gettato via la
 salvietta, e si è partito di tavola</p>
             <stage><emph>(stando presso la porta)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>E il mio padrone che cosa fa?</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Aspettate</p>
             <stage><emph>(guarda)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>(Dubito di qualche gran precipizio).</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>È sdraiato sopra la tavola, colla testa cacciata
 fra le braccia. Ho veduto che il signor Ridolfo gli parla,
 ma egli non gli risponde.</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Lasciatemi un po' vedere</p>
             <stage><emph>(si accosta alla porta)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Sì, soddisfatevi</p>
             <stage><emph>(si ritira dalla porta)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>(Non vorrei né meno conoscerlo, non che essere al
 suo servizio. Mi fa compassione)</p>
             <stage><emph>(guarda)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>(Certo, se durano a far questa vita, io non ci sto).</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>La signora Eugenia è balzata in piedi</p>
             <stage><emph>(a Lisetta)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Lasciate vedere</p>
             <stage><emph>(corre alla porta, e guarda)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Che cosa fa?</p>
             <stage><emph>(con ansietà)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Se ne va via</p>
             <stage><emph>(osserva)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>E la mia padrona?</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Si asciuga gli occhi</p>
             <stage><emph>(osserva)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>E il padrone?</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Non si move</p>
             <stage><emph>(osserva)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>E la signora Flamminia?</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Par che pianga ella pure</p>
             <stage><emph>(osserva)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>E quel forastiere?</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Prende tabacco, e non parla</p>
             <stage><emph>(osserva)</emph>.</stage>
@@ -4782,39 +4819,39 @@ suo servizio. Mi fa compassione)</p>
           <stage>
             <emph>Eugenia, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Che fate lì a quella porta?</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Niente, signora</p>
             <stage><emph>(Lisetta, e Tognino si spaventano)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Andate via.</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Perdoni</p>
             <stage><emph>(ad Eugenia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Compatisca</p>
             <stage><emph>(ad Eugenia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Levatevi di qui, vi dico.</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>(Oh, le fuma il capo davvero)</p>
             <stage><emph>(parte)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>(Povero padrone! Voglio vedere, se ha bisogno di
 nulla)</p>
@@ -4826,7 +4863,7 @@ nulla)</p>
           <stage>
             <emph>Eugenia sola.</emph>
           </stage>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <stage>
               <emph>(ponendosi a sedere con isdegno)</emph>
@@ -4860,167 +4897,167 @@ cognata; troverà un'altra amante; si mariterà.</p>
           <stage>
             <emph>Flamminia e la suddetta.</emph>
           </stage>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Che fate qui da voi sola?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Niente</p>
             <stage><emph>(nascondendo le lacrime)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Eh via, finiamola.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Lasciatemi stare</p>
             <stage><emph>(come sopra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Pare lo facciate apposta, perché il signor
 Fulgenzio si stanchi, e vi perda l'amore.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Che importa a me del suo amore?</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Eh via. Si sa, che vi preme.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>No davvero, non ci penso più.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>È quella maladetta bile, che vi fa parlare così.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Aspettate domani, e vedrete. Se è bile, o cos'è.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>E che cosa volete fare domani?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Voglio ritirarmi dal mondo.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Sì, sì, dormiteci sopra, e non sarà altro.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Sorella, voi ancora non mi conoscete.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Vi conosco pur troppo</p>
             <stage><emph>(un poco alterata)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Sono irragionevole, è vero?</p>
             <stage>
               <emph>(sdegnata)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Avete delle ore buone, ma altresì delle ore molto
 cattive.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Ora sono nelle ore pessime. Lasciatemi stare</p>
             <stage><emph>(come sopra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Nostro zio è fuori di sé.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Che gli ho fatto io?</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Che cosa avete fatto alla signora Clorinda?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Già tutti proteggono quella gran dama. Io sono il
 cane del macellaio: ossa, e busse.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Dovevate portar rispetto al padrone di casa, che
 l'ha invitata.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Ma che cosa le ho fatto?</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Che lo so io? È venuta a tavola colle lagrime
 agli occhi.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Oh! sapete perché è venuta colle lagrime agli occhi?
 Perché ha trovato qui suo cognato.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Io so, che si è doluta molto di lui, e dice, che
 le ha perduto il rispetto.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Sì, ha ragione; pretende, che non si parta da lei,
 che stia seco a pranzo, a farle fresco su la minestra, se
 scotta, e se non lo fa, dice, che le perde il rispetto.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Questa finalmente è una cosa, che dee durar poco.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Come poco?</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Se vien suo consorte, il signor Fulgenzio ha
 finito.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>E quando verrà questo suo consorte?</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Ho inteso dire, che l'aspettano oggi.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Oggi?</p>
             <stage>
               <emph>(un poco placata)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Così disse la signora Clorinda.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Eh, sì! se tornerà suo marito non seguiteranno a
 convivere insieme?</p>
@@ -5028,68 +5065,68 @@ convivere insieme?</p>
               <emph>(alterata)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Può esser di no. Se il signor Fulgenzio vi sposa,
 non sarà cosa illecita, che lo preghiate di metter casa da
 sé.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>La metterebbe poi?</p>
             <stage>
               <emph>(placata)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Son persuasa di sì. Sapete, che non vi sa negar
 cosa alcuna.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Guardate la bella premura, che ha di me. Si move,
 per venirmi a vedere? Sa staccarsi un momento dalla cognata?</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Eccolo, eccolo, ch'egli viene.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Non gli dite niente, ch'io aveva risolto
 d'abbandonarlo.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Io non fo di queste pazzie.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Vien molto adagio. Sarà sdegnato.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Parlategli con umiltà.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Ho da pregarlo? Oh questo poi no.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>L'ha fatto egli tante volte con noi.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Basta. Se sperassi, che le cose andassero come dite
 voi; e se veramente mi volesse bene...</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Se non vi amasse, non verrebbe qui...</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Zitto, zitto. Sentiamo, che cosa dice.</p>
           </sp>
@@ -5099,51 +5136,51 @@ voi; e se veramente mi volesse bene...</p>
           <stage>
             <emph>Fulgenzio e dette.</emph>
           </stage>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Signora Eugenia, mi permetterete, ch'io vi dica una
 cosa, da voi forse non prevveduta. Ho piacere che vi si
 trovi la signora Flamminia.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>(Oh, vi è del male. Non l'ho mai più veduto così
 burbero, come ora).</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>(Che sì, che vuol fare il bravo).</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Voi sapete, ch'io vi amo, ma sapete altresì, ch'io
 sono un uomo d'onore</p>
             <stage><emph>(ad Eugenia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Io non so nessuna di queste cose.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Come! mettereste in dubbio la mia onoratezza?</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Non le badate, signor Fulgenzio. Io la conosco
 questa mozzina, lo dice apposta per farvi arrabbiare.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>La signora Eugenia può dir quel, che vuole; può
 burlarsi di me, può deridermi, può insultarmi, ma non mi può
 intaccar nell'onore.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Se fossi un uomo, mi sfiderebbe alla spada.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Felice voi, che potete scherzare. Nello stato in
 cui mi ritrovo, non fo poco, se ho tanto fiato da poter
@@ -5156,7 +5193,7 @@ della famiglia. Che dirà di me mio fratello? che dirà egli,
 quando saprà, che per cagion vostra ho perduto il rispetto
 alla di lui moglie?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Oh oh, ecco qui, ecco qui, d'onde derivano le smanie
 del signor Fulgenzio. Ecco lo sforzo della delicatezza
@@ -5166,7 +5203,7 @@ d'averlo fatto. Bisogna rendere soddisfazione a questa
 illustre signora. Volete, che vada io a domandarle scusa per
 voi?</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Che manieraccia è questa? Lo voglio dire al
 signore zio</p>
@@ -5174,61 +5211,61 @@ signore zio</p>
             <p>Per l'amor del Cielo, signor Fulgenzio, non le
 badate.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Non mettete in ridicolo una cosa seria</p>
             <stage><emph>(ad Eugenia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Io voglio ridere quanto mi pare.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Ridete pure a vostro talento. La vostra ilarità in
 un caso simile dipende, o da poco amore, o, compatitemi, da
 poca ragione.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Sì, sono una pazza. Non lo sapete?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>No signora; sapete esser saggia, quando volete.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Ma questa volta son pazza. Ditelo liberamente.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Se non lo dice egli, lo dirò io.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Voi non c'entrate, signora</p>
             <stage><emph>(a Flamminia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Meritereste, che tutti vi abbandonassero.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Basta, che non mi abbandoni il Cielo.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Il Cielo non assiste a chi ha massime come le
 vostre.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Che? sono una bestia io? non merito l'assistenza del
 Cielo?</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>L'ingratitudine è odiosa agli uomini, e ai numi.
 Voi trattate male con chi vi ama; cercate di affliggere le
@@ -5236,7 +5273,7 @@ persone innocenti; odiate chi vi consiglia al bene; tradite
 voi stessa; calpestate i doni del Cielo: e non arrossite di
 voi medesima?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Via, signora Flamminia, non l'affliggete
 d'avvantaggio. Io non ho cuore di vederla mortificata.
@@ -5248,22 +5285,22 @@ trasportato. Ella non mi ha sforzato a insultar mia cognata;
 sono stato io l'incauto, il mal accorto, il furente. Eugenia
 mi ama, ed è per amore gelosa.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Io non sono gelosa di vostra cognata.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Lo so; è uno sdegno da voi concepito per timore di
 non essere preferita; ma cara Eugenia, disingannatevi; vi
 amo, e vi stimo sopra tutte le cose di questo mondo.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>(Parla, in una maniera, che farebbe intenerire i
 sassi. Possibile, ch'ella voglia essere così caparbia?)</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Se conoscete dunque il motivo delle mie
 inquietudini, perché non cercate la via di rendermi
@@ -5272,89 +5309,89 @@ consolata?</p>
               <emph>(a Fulgenzio)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Sì, cara, vi chiedo scusa della poca attenzione,
 che avessi avuta per voi; cercherò in avvenire di meglio
 meritarmi l'affetto vostro; e spero vicino il tempo di
 potervi dare la più vera testimonianza dell'amor mio.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Sarebbe tempo, che il mio cuor respirasse.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Abbiate giudizio. Se siete in pace sappiateci
 stare.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Eugenia carissima, voi mi avete da accordare una
 grazia.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Non siete voi padrone di comandarmi?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Me l'avete da far con buon animo.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Se non desidero, che compiacervi!</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Mi avete a permettere, ch'io possa ricondurre mia
 cognata alla propria casa.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Se qui l'ha condotta il signore zio, perché non può
 egli restituirla dove l'ha presa?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Il signor Fabrizio è sdegnato; non si lascia
 vedere; e poi aspettasi mio fratello, e non ho piacere che
 trovi in casa degli sconcerti.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Sì, sì, avete ragione. Accompagnatela pure</p>
             <stage><emph>(dissimulando)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Me lo dite di cuore?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Anzi.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Ho paura, che vogliate dissimulare, e che dentro di
 voi non siate contenta.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Che volete voi sottilizzar d'avvantaggio? È una
 cosa giusta; lo conosce, e l'accorda. Fate quest'atto di
 onestà, di dovere, e poi subito tornate qui</p>
             <stage><emph>(a Fulgenzio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>No, no, che non s'incomodi a ritornare.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>La sentite, signora Flamminia?</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Ho sentito tanto, che basta, e non ne voglio
 sentire di più. (Le caccierei la testa nel muro)</p>
@@ -5366,33 +5403,33 @@ sentire di più. (Le caccierei la testa nel muro)</p>
           <stage>
             <emph>Fulgenzio ed Eugenia.</emph>
           </stage>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Questa è la grazia, che avete promesso accordarmi?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Io non v'impedisco, che la conduciate.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Ma con mal animo.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Non dovete badare all'animo mio; basta, che
 soddisfacciate al vostro.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Io non sono portato per altro, che per
 l'adempimento del mio dovere.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Adempitelo.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Sì, in ogni maniera l'adempirò. Posso tutto
 sagrificarvi fuor che l'onore di me, e della mia famiglia.
@@ -5401,38 +5438,38 @@ dell'amor vostro, ne verrà in conseguenza il fine della mia
 vita, ma non per questo un uomo d'onore dee preferire al
 decoro la sua passione.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Fatemi almeno un piacere.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Oh Cielo! comandatemi.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Andate, finitela, e non tormentate di più.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>E ho da lasciarvi qui in questo stato?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Un uomo d'onore non ha da preferire la passione al
 decoro. Ma che dico io di passione? Andate, andate, che mi
 sono abbastanza disingannata.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Ah nemica della ragione, nemica di me, e di voi
 medesima!</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Avvertite, che insolenze io non ne voglio soffrire.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Farò una risoluzione da disperato.</p>
           </sp>
@@ -5442,125 +5479,125 @@ medesima!</p>
           <stage>
             <emph>Ridolfo e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Amico, una parola.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Ah Ridolfo, soccorretemi per carità!</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Soccorretelo quel povero sfortunato. Levatelo dalla
 presenza di una irragionevole, di una ingrata</p>
             <stage><emph>(a Ridolfo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Perdonatemi, signora, s'io vi dispiaccio. Mi preme
 l'onor dell'amico. La signora Clorinda ha risolto di partir
 sola. Ricusa la mia compagnia, ricusa ogni altro, se non la
 riconduce il cognato.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>E perché non va egli a servirla? È un'ora, che
 glielo dico; ed egli persiste ad importunarmi.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Via dunque rammentatevi del fratello, e fate il
 vostro dovere</p>
             <stage><emph>(a Fulgenzio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Più che restate qui, e più mi recate noia</p>
             <stage><emph>(a Fulgenzio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Andiamo</p>
             <stage><emph>(a Ridolfo sdegnoso contro Eugenia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Ogni onestà lo richiede</p>
             <stage><emph>(a Fulgenzio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Sì, andiamo</p>
             <stage><emph>(smanioso, e incerto)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Ma se ve lo dice ella stessa</p>
             <stage><emph>(a Fulgenzio accennando Eugenia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Sì, vi dico; andiamo</p>
             <stage><emph>(come sopra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Compatitelo, signora Eugenia.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Barbara!</p>
             <stage>
               <emph>(ad Eugenia fremendo)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Sono stanca.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Ingrata!</p>
             <stage><emph>(come sopra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>O andate voi, o vado io.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Andrò io, maladetta!</p>
             <stage><emph>(parte correndo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Compatitelo</p>
             <stage><emph>(ad Eugenio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Andate, andate con lui</p>
             <stage><emph>(sdegnosa)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Siete sdegnata meco?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Andate, signor protettore</p>
             <stage><emph>(come sopra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Protettore di chi?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Della parentela.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Vi compatisco, perché siete una donna</p>
             <stage><emph>(parte)</emph>.</stage>
@@ -5571,7 +5608,7 @@ vostro dovere</p>
           <stage>
             <emph>Eugenia sola.</emph>
           </stage>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Sia ringraziato il Cielo, sarà finita. È meglio
 così. Già se Fulgenzio fosse mio sposo non avrei un'ora di
@@ -5593,82 +5630,82 @@ costanza, se mi sento morire?</p>
           <stage>
             <emph>Fabrizio, Roberto, e detta.</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Cospetto di bacco! chi sono io in questa casa?
 Sono il padrone, o sono qualche stivale?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Con chi l'avete, signore zio?</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>L'ho con voi, sciocca.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Con me?</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Sì, con voi; io sono il padrone; e non ci sono in
 questa casa altri padroni, che io; e una nipote, che dipende
 da me, non dee far all'amore, senza che io lo sappia; e
 molto meno parlare di maritarsi: insolente!</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>(Or ora mi sente con queste sue baggianate).</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Signore, non la mortificate così</p>
             <stage><emph>(a Fabrizio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>La vede, signor Conte? Questa è la più stolida
 ragazza di questo mondo. Non sa, che si faccia, non sa che
 si dica; non è buona da nulla; e parla di maritarsi.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>(Non vorrei, che mi tirasse a cimento).</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Ma voi, signore, me l'avete pure lodata, avete pur
 detto che non c'è in tutto il mondo una giovane, come lei.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Mi disdico di quel, che ho detto. È una sciocca, è
 una frasca, è un'impertinente.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Signor Conte, siccome non avrete dato fede
 all'elogio, spero non crederete al biasimo, con cui vorrebbe
 discreditarmi.</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Tant'è vero, ch'io non lo credo; che se mai per
 avventura accadesser di que' casi da me previsti, non avrei
 alcuna difficoltà ad offerirvi la mano.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Come? il signor Conte si degnerebbe di sposar mia
 nipote?</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Sì, certo, e mi chiamerei felice, se avessi la sorte
 di conseguirla.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Ah nipote, questa sarebbe per voi una gran fortuna,
 e per me una gloria immortale. Il signor conte d'Otricoli,
@@ -5681,12 +5718,12 @@ Dice davvero?</p>
               <emph>(al Conte)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Io non ho tutti i pregi, dei quali mi caricate; ma
 vanto quello della sincerità; e ve lo dico di core.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Senta, signore, la collera fa dire delle pazzie,
 per altro Eugenia è un portento; fa invidia a tutte le
@@ -5695,128 +5732,128 @@ tutto, ha una mente chiarissima, ha un cuor bellissimo;
 saggia, morigerata, obbediente: ha tutte le buone parti
 immaginabili della bontà.</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Credo tutto, ma ella ha il cuor prevenuto per altro
 amante.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Siete voi impazzita per il signor Fulgenzio? per
 quello stolido? per quell'ignorante? uomo vile, indegno
 della mia casa, spiantato, vagabondo, plebeo?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Signore, non vi ricordate voi d'averlo lodato?</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Che lodare! che lodare! io non fo conto di quella
 sorta di gente. In casa mia non ci verrà più. E se voi
 ardirete d'amarlo...</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Acchetatevi; che già è finita. Fulgenzio è da me
 licenziato.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Oh brava! Sente, signor Conte? Queste si chiamano
 donne. Questo è pensar giusto, pensar con prudenza.</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Signora Eugenia, sarebbe per avventura venuto il
 caso?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>(Ah una vendetta sarebbe pure opportuna).</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Via, risolvete. In un momento potete diventare una
 gran dama, una gran signora, una principessa.</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Non tanto, signora. Ma uno stato comodo non vi
 mancherà</p>
             <stage><emph>(ad Eugenia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>(Quand'è fatta, è fatta. Può essere che
 quell'ingrato frema, e si disperi, e si penta, quando mi
 avrà perduta).</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Via. Cuor mio, risolvete</p>
             <stage><emph>(ad Eugenia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Signore disponete di me</p>
             <stage><emph>(a Fabrizio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Oh bocca d'oro! l'avete sentita?</p>
             <stage>
               <emph>(al Conte)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Tocca a voi a terminare di consolarmi</p>
             <stage><emph>(a Fabrizio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Per me ve l'accordo subito, in questo momento.</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>(Signore, vostra nipote vale un tesoro; ma le
 convenienze della mia casa esigono qualche dote)</p>
             <stage><emph>(piano a Fabrizio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>(Dote!)</p>
             <stage><emph>(a Roberto, con maraviglia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>La volete maritar senza dote?</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>(Ho sempre che fare con degli spiantati).</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Signore, la mia dote ci deve essere. Me l'ha
 lasciata mio padre, e lo zio non la può negare.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Bisogna vedere, se il signor Conte la può
 assicurare.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Un cavalier così ricco?</p>
             <stage><emph>(a Fabrizio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Ricco! ricco! che so io, se sia ricco?</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Fareste meglio, signore, a esaltar meno le persone
 non conosciute, e a risparmiare gl'insulti ai cavalieri
@@ -5830,17 +5867,17 @@ acconsentito: penserò io a farmi render giustizia</p>
           <stage>
             <emph>Fabrizio, ed Eugenia.</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Orsù, io non voglio impegni. Ho data la parola,
 converrà mantenerla</p>
             <stage><emph>(ad Eugenia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Ma signore...</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Non c'è altro signore, converrà, ch'io trovi la
 dote, e voi lo dovete sposare</p>
@@ -5852,7 +5889,7 @@ dote, e voi lo dovete sposare</p>
           <stage>
             <emph>Eugenia sola.</emph>
           </stage>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Povera me! cosa ho fatto? Ma ho fatto bene.
 Fulgenzio mi veda sposa, e crepi di gelosia. So che viverò
@@ -5875,57 +5912,57 @@ ch'io mi allontani</p>
           <stage>
             <emph>Fulgenzio, e detta.</emph>
           </stage>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Fermatevi, signora Eugenia.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Che pretendete da me?</p>
             <stage><emph>(con isdegno)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Ascoltatemi per carità.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>L'avete servita la signora Clorinda?</p>
             <stage>
               <emph>(con ironia)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>No, non è ancora partita.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>E che fa in casa mia? Perché non l'accompagnate?</p>
             <stage><emph>(con isdegno)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Finito ho l'obbligo di servirla, terminato ho
 l'incarico d'accompagnarla.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>E perché?</p>
             <stage>
               <emph>(sostenuta)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Perché è giunto in Milano il di lei consorte.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>È arrivato il signor Anselmo?</p>
             <stage><emph>(meno sostenuta)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Sì, è arrivato poc'anzi. Non ritrovò in casa la
 sposa. Seppe dov'era; è venuto egli stesso a vederla, ad
@@ -5934,31 +5971,31 @@ e colla signora Flamminia. Chiese di voi, le fu risposto che
 siete in camera ritirata, e parte a momenti accompagnata dal
 caro sposo.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>E voi?</p>
             <stage><emph>(patetica)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Resterò qui, se mel concedete.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Non volete essere col fratello a discorrere degli
 affari vostri?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>In due parole ho seco lui trattato, e concluso il
 maggior affare, che mi premesse.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Cioè gli avrete reso conto della custodia, in cui
 gli teneste la sposa.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>No, ingrata. Gli palesai l'amor mio; gli spiegai la
 brama di avervi in moglie; il mio caro fratello me l'accorda
@@ -5969,13 +6006,13 @@ permettetemi, ch'io lo dica, se il zio non vi può dar dote,
 brama ch'io sia contento, e non avrà per voi meno stima, e
 meno rispetto.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>(Ah incauta! ah ingrata! perché impegnarmi col
 Conte?)</p>
             <stage><emph>(smaniosa e piangente)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Oh stelle! così accogliete una nuova che mi
 lusingai dovesse rendervi consolata? Ardireste voi
@@ -5985,80 +6022,80 @@ l'impressione nell'animo vostro non può per ora
 scancellarsi, vi prometto, vi giuro di non trattarla, di non
 vederla mai più.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Povera me! son morta</p>
             <stage><emph>(si abbandona sopra una sedia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Eugenia, che cosa è questa?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Ah sì, Fulgenzio, maltrattatemi, disprezzatemi, che
 avete giusta ragion di farlo.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>No, cara, voglio amarvi teneramente.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Non merito l'amor vostro.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Voi sarete la mia cara sposa.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>No, non deggio esserlo; abbandonatemi.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Non dovete esserlo? Anima mia, perché mai?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Perché ad altri ho data la mia parola.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>E a chi?</p>
             <stage><emph>(tremante)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Al conte Roberto.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Quando?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Poc'anzi.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>E perché?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Per vendetta.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Contro di chi vendetta?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Contro di me medesima; contro il mio cuore, contro
 la mia colpevole debolezza. Oimè, mi sento morire</p>
             <stage><emph>(si copre col fazzoletto, e resta così)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Ah perfida! ah disleale! quest'è l'amore? questa è
 la fedeltà? No, che non aveste amore per me. Furono sempre
@@ -6073,11 +6110,11 @@ rossore; parlino per me i tuoi rimorsi; e per ultimo dono di
 chi tu sprezzi, assicurati di non vedermi più</p>
             <stage><emph>(in atto di partire)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <stage><emph>(svenuta cade sopra una sedia vicina)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <stage>
               <emph>(sentendo strepito si volta)</emph>
@@ -6091,60 +6128,60 @@ questo? Eugenia Eugenia, aiuto, soccorso!</p>
           <stage>
             <emph>Flamminia, Lisetta, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Che cos'è?</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Cos'è stato?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Soccorretela.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Sorella.</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Signora padrona</p>
             <stage><emph>(l'alzano, e la rimettono sulla sedia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>(Ah! se non mi amasse... Ma oh Cieli! potrebbe
 fingere. E perché fingere, se non mi amasse?)</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Via, via è rinvenuta.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Ah, sorella mia, ve l'ho detto. Siete nemica di
 voi medesima.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Deh lasciate ch'io mora.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Ah no, vivete. Il Cielo mi vuol infelice. Pazienza.
 Vi amerò da lontano, benché mia non sarete.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>E perché non ha da esser vostra?</p>
             <stage><emph>(a Fulgenzio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Perché ad altri si abbandonò per vendetta.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Volete dire, perché ha dato parola al conte
 Roberto?</p>
@@ -6152,11 +6189,11 @@ Roberto?</p>
               <emph>(a Fulgenzio)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Ah sì, fortunatissimo Conte.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Fortunato voi vi potete chiamare, che aveste me in
 aiuto; fortunata Eugenia, cha ha una sorella, che l'ama. Il
@@ -6165,52 +6202,52 @@ per capriccio, per disperazione. Non è sì pazzo a volersi
 nutrire una serpe nel seno; e lascia in libertà la
 fanciulla.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Oimè dite il vero?</p>
             <stage><emph>(alzandosi con tenerezza a Flamminia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Così è, sorella. Fulgenzio è vostro.</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>No, che non sarà mio.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Perché no, crudele?</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Perché non lo merito.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Lo conoscete il torto, che mi faceste?</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Via non parlate altro</p>
             <stage><emph>(a Fulgenzio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Lasciatelo dir, che ha ragione</p>
             <stage><emph>(a Flamminia, con tenerezza)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Abbandonarmi per così poco!</p>
             <stage><emph>(ad Eugenia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Ma via, dico</p>
             <stage><emph>(a Fulgenzio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Sì, insultatemi, che mi si conviene. Conosco l'amor
 grande che per me avete; so di non meritarlo. Usatemi
@@ -6218,19 +6255,19 @@ carità, se vi aggrada; siatemi rigoroso, se il vostro cuor
 lo comporta; in ogni guisa mi duole d'avervi offeso, e vi
 domando perdono.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Ah non più, idolo mio!</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Sì, perdonatemi.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>O che sian benedetti!</p>
           </sp>
-          <sp>
+          <sp who="#lisetta">
             <speaker>LISETTA</speaker>
             <p>Mi fanno piangere.</p>
           </sp>
@@ -6240,44 +6277,44 @@ domando perdono.</p>
           <stage>
             <emph>Fabrizio e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Cosa fa qui questo temerario?</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Abbiate pazienza, signore. Questi ha da essere lo
 sposo di mia sorella.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Non è degno d'imparentarsi con me.</p>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Sentite. La sposerà senza dote.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Senza dote?</p>
             <stage>
               <emph>(a Flamminia)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#flamminia">
             <speaker>FLAMMINIA</speaker>
             <p>Sì, signore.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>La prendete voi senza dote?</p>
             <stage><emph>(a Fulgenzio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Non ci ho veruna difficoltà.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Caro nipote, il Cielo vi benedica</p>
             <stage><emph>(l'abbraccia)</emph>.</stage>
@@ -6288,13 +6325,13 @@ sposo di mia sorella.</p>
           <stage>
             <emph>Roberto, Ridolfo e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Ecco qui il signor Conte, il quale persuaso dalle
 mie ragioni, si contenterà che il signor Fabrizio gli faccia
 una semplice scusa.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Scusatemi signor Conte. Il Cielo ha voluto così.
 Mia nipote merita molto, e la fortuna le ha concesso in
@@ -6302,27 +6339,27 @@ isposo il re de' galantuomini; il più bravo giovane di
 questo mondo, il più saggio, il più dotto, il più nobile
 cittadino di Milano.</p>
           </sp>
-          <sp>
+          <sp who="#roberto">
             <speaker>ROBERTO</speaker>
             <p>Scuso in voi la più sonora, la più ridicola
 caricatura del mondo.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Viva mille anni il Conte dei Conti, il Cavaliere
 dei Cavalieri!</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Deh, concedetemi, che io le porga la destra</p>
             <stage><emph>(a Fabrizio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Sì, generoso nipote; eroe del Ticino, gloria del
 nostro secolo!</p>
           </sp>
-          <sp>
+          <sp who="#eugenia">
             <speaker>EUGENIA</speaker>
             <p>Caro sposo, finalmente siete mio, vostra sono. Oh
 quante stravaganze prodotte furono dal nostro amore!

--- a/tei/goldoni-i-rusteghi.xml
+++ b/tei/goldoni-i-rusteghi.xml
@@ -84,6 +84,40 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="lucietta">
+            <persName>Lucietta</persName>
+          </person>
+          <person xml:id="margarita">
+            <persName>Margarita</persName>
+          </person>
+          <person xml:id="lunardo">
+            <persName>Lunardo</persName>
+          </person>
+          <person xml:id="maurizio">
+            <persName>Maurizio</persName>
+          </person>
+          <person xml:id="marina">
+            <persName>Marina</persName>
+          </person>
+          <person xml:id="felippetto">
+            <persName>Felippetto</persName>
+          </person>
+          <person xml:id="simon">
+            <persName>Simon</persName>
+          </person>
+          <person xml:id="felice">
+            <persName>Felice</persName>
+          </person>
+          <person xml:id="canciano">
+            <persName>Canciano</persName>
+          </person>
+          <person xml:id="riccardo">
+            <persName>Il conte Riccardo</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -344,34 +378,34 @@ cosa di più.</p>
           <stage>
             <emph>Margarita, che fila, Lucietta, che fa le calze, ambe a sedere.</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Siora madre.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Fia<note place="foot" anchored="true"><p>Figlia.</p></note> mia.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Deboto<note place="foot" anchored="true"><p>Or'ora.</p></note> xè fenìo<note place="foot" anchored="true"><p>È finito; servendo per sempre, che il <emph>xè</emph> in veneziano vuol dire «è», «<foreign xml:lang="lat">est</foreign>».</p></note> carneval.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Cossa diseu, che bei spassi, che avemo abuo<note place="foot" anchored="true"><p>Avuto.</p></note>?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>De diana! gnanca una strazza de commedia no avemo
 visto.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Ve feu maraveggia per questo? Mi gnente affato. Xè
 deboto sedese mesi, che son maridada, m'àlo mai menà in
 nissun liogo vostro sior padre?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>E sì, sàla? no vedeva l'ora, che el se tornasse a
 maridar. Co giera<note place="foot" anchored="true"><p>Quando io era.</p></note> sola, in casa, diseva tra de mi: lo
@@ -380,7 +414,7 @@ da mandarme; se el se marida, anderò co siora maregna<note place="foot" anchore
 s'ha tornà a maridar, ma per quel, che vedo, no ghe xè
 gnente né per mi, né per éla.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>El xè un orso, fia mia; nol se diverte élo, e nol
 vol, che se divertimo gnanca nu. E sì, savè? co giera da
@@ -401,18 +435,18 @@ stevimo po in casa, gh'avevimo sempre la nostra
 conversazion. Vegniva i parenti, vegniva i amici, anca
 qualche zovene; ma no ghe giera pericolo, figurarse.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(«Figurarse, figurarse»; la l'ha dito fin adesso
 sie volte).</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>No digo; che no son de quele, che ghe piasa tutto
 el zorno andar a torziando<note place="foot" anchored="true"><p>Andar gironi.</p></note>. Ma, sior sì. Qualche volta me
 piaserave anca a mi.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>E mi, poverazza, che no vago mai fora della porta? E
 nol vol mo gnanca<note place="foot" anchored="true"><p>Nemeno.</p></note> che vaga un fià<note place="foot" anchored="true"><p>Un poco.</p></note> al balcon? L'altro zorno
@@ -420,182 +454,182 @@ me son butada cusì, un pocheto in scampar; m'ha visto quella
 petazza<note place="foot" anchored="true"><p>Sguaiata.</p></note> della lasagnera<note place="foot" anchored="true"><p>Che vende le paste.</p></note>, la ghe l'ha dito, e ho credesto,
 che el me bastona.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>E a mi quante no me n'àlo dito per causa vostra?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>De diana! cossa ghe fazzio?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Vu almanco, fia mia, ve mariderè; ma mi gh'ho da
 star fin, che vivo.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>La diga, siora madre, me marideròggio?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Mi crederave de sì.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>La diga, siora madre, e quando me marideròggio?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Ve mariderè, figurarse, quando, che el Cielo vorà.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>El Cielo me marideràlo, senza che mi lo sappia?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Che spropositi! l'avè da saver anca vu.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Nissun gnancora m'ha dito gnente.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Se no i ve l'ha dito, i ve lo dirà.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Ghe xè gnente in cantier<note place="foot" anchored="true"><p>C'è niente per aria?</p></note>?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Ghe xè, e no ghe xè; mio mario no vol che ve diga
 gnente.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Cara éla, la diga.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>No dasseno, fia mia.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Cara éla, qualcossa.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Se ve digo gnente, el me salta ai occhi co fa<note place="foot" anchored="true"><p>Come.</p></note> un
 basilisco.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Noi lo saverà miga sior padre, se la me lo dise.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Oh figurarse, se no lo dirè!</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>No dasseno, figurarse, che no lo digo.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Cossa gh'intra sto «figurarse»?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>No so gnanca mi, gh'ho sto uso, el digo, che no me
 n'incorzo <emph>(ironicamente)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>(Gh'ho in testa, che la me burla mi sta frascona).</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>La diga, siora madre.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Animo laorè<note place="foot" anchored="true"><p>Via lavorate.</p></note>, l'aveu, gnancora fenìa quella calza!</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Deboto.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Se el vien a casa élo<note place="foot" anchored="true"><p>Egli, cioè s'intende il padrone di casa.</p></note>, e che la calza no sia fenìa,
 el dirà che sè stada su per i balconi, e mi no vòi
 figurarse... (sia maledeto sto vizio!)</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>La varda co spessego<note place="foot" anchored="true"><p>Come io mi sollecito.</p></note>. La me diga qualcossa de sto
 novizzo<note place="foot" anchored="true"><p>Sposo.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>De qual novizzo?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>No dìxela, che me mariderò?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Poi esser.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Cara éla, se la sa qualcossa.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>No so gnente <emph>(con un poco di collera)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Gnanca mo gnente, mo, gnanca mo<note place="foot" anchored="true"><p>Quel mo repplicato è un certo modo caricato di lamentarsi conveniente all'età di Lucietta.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Son stuffa.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Sia malignazo<note place="foot" anchored="true"><p>Lo stesso che maladetto ma con più modestia.</p></note> <emph>(con rabbia)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Coss'è sti sesti<note place="foot" anchored="true"><p>Che malegrazie son queste?</p></note>?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>No gh'ho nissun a sto mondo, che me voggia ben.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Ve ne voggio anca troppo, frascona.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Ben da maregna<note place="foot" anchored="true"><p>Matrigna.</p></note> <emph>(a mezza voce)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Cossa aveu dito?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Gnente.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Sentì, savè, no me stè a seccar, che deboto,
 deboto... <emph>(con isdegno)</emph> Davantazo<note place="foot" anchored="true"><p>Di vantaggio.</p></note> ghe ne soporto assae in sta casa. Gh'ho
@@ -603,11 +637,11 @@ un mario, che me rosega<note place="foot" anchored="true"><p>Mi rode, mi torment
 altro figurarse, che m'avesse da inrabiar anca per la
 fiastra<note place="foot" anchored="true"><p>Figliastra.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Mo cara siora madre la va in colera molto presto!</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>(La gh'ha squasi rason. No giera cusì una volta,
 son deventada una bestia. No gh'è remedio; chi sta col lovo<note place="foot" anchored="true"><p>Lupo.</p></note>
@@ -619,73 +653,73 @@ impara a urlar).</p>
           <stage>
             <emph>Lunardo, e dette.</emph>
           </stage>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>
               <emph>(entra e viene bel bello, senza parlare)</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>(Vèlo qua per diana) <emph>(s'alza)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(El vien co fa i gatti) <emph>(s'alza)</emph>. Sior padre, patron.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Sioria. No se saludemo gnanca? <emph>(a Lunardo)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Laorè, laorè. Per farme un complimento tralassè de
 laorar?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Ho laorà fin adesso. Ho deboto fenìo la calza.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Stago a véder, figurarse, che siémo pagae a
 zornada<note place="foot" anchored="true"><p>Pagate a giornata.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Vu sempre, vegnimo a dir el merito<note place="foot" anchored="true"><p>Un intercalare vizioso.</p></note>, me dè sempre de
 ste risposte.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Mo via, caro sior padre; almanco in sti ultimi zorni
 de carneval, che nol staga a criar. Se no andemo in nissun
 logo, pazenzia; stemo in pase<note place="foot" anchored="true"><p>In pace.</p></note> almanco.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Oh, élo no pol star un zorno senza criar.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Sentì che strambazza? Cossa songio? un tartaro? una
 bestia? De cossa ve podeu lamentar? Le cosse oneste le me
 piase anca a mi.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Via donca, che el ne mena un pocheto in maschera.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>In maschera? In maschera?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>(Adesso, el va zoso<note place="foot" anchored="true"><p>Va giù da fuori.</p></note>).</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>E avè tanto muso<note place="foot" anchored="true"><p>E avete tanta faccia.</p></note> de dirme, che ve mena in maschera?
 M'aveu mai visto mi, vegnimo a dir el merito, a meterme el
@@ -693,159 +727,159 @@ volto sul muso<note place="foot" anchored="true"><p>La maschera sulla faccia?</p
 maschera? No me fe parlar; le putte<note place="foot" anchored="true"><p>Le fanciulle.</p></note> no ha da andar in
 maschera.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>E le maridae?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Gnanca le maridae, siora no, gnanca le maridae.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>E per cossa donca le altre, figurarse, ghe vàle?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>«Figurarse, figurarse». Mi penso a casa mia, e no
 penso ai altri <emph>(la burla del suo intercalare)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Perché, «vegnimo a dir el merito», perché sè un
 orso <emph>(fa lo stesso)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Siora Margarita, la gh'abia giudizio.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Sior Lunardo, no la me stuzzega.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Mo via, sia malignazo! sempre cusì. No m'importa
 d'andar in maschera. Starò a casa, ma stemo in bona.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>No sentìu? Vegnimo... no sentìu? La xè éla che
 sempre...</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>
               <emph>(ride)</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Ridè, patrona? <emph>(a Margarita)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Ve n'aveu per mal, perché rido?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Via, vegnì qua tutte do<note place="foot" anchored="true"><p>Tutte due.</p></note>, sentì. Delle volte anca mi
 gh'ho qualcossa per la testa, e par, che sia fastidioso, ma
 ancuo<note place="foot" anchored="true"><p>Oggi.</p></note> son de voggia. Semo de carneval, e vòi, che se tolemo
 la nostra zornada<note place="foot" anchored="true"><p>Che ci prendiamo la nostra giornata. I capi di casa all'antica concedevano una giornata di carnovale alla famiglia. Ora tutti i giorni sono compagni.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Oh magari<note place="foot" anchored="true"><p>Il Ciel volesse.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Via mo, sentimo.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Sentì; voggio, che ancuo disnemo in compagnia.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Dove, dove, sior padre? <emph>(con allegria)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>In casa.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>In casa? <emph>(malinconica)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Siora sì, in casa. Dove voressi che andessimo?
 all'osteria?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Sior no, all'osteria.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>In casa de nissun mi no vago<note place="foot" anchored="true"><p>Non vado.</p></note>, mi no vago, vegnimo a
 dir el merito, a magnar le coste a nissun.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Via, via, no ghe tendè. Parlè con mi, figuremose,
 voleu invidar qualchedun?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Siora sì. Ho invidà della zente, e i vegnirà qua, e
 se goderemo, e staremo ben.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Chi aveu invidà?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Una compagnia de galantomeni, tra i quali ghe ne xè
 do de maridai, e i vegnirà co le so parone<note place="foot" anchored="true"><p>Padrone, cioè mogli.</p></note>, e staremo
 alliegri.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Via, via gh'ho a caro) <emph>(allegra)</emph>. Caro élo, chi xèli? <emph>(a Lunardo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Siora curiosa!</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Via, caro vecchio<note place="foot" anchored="true"><p>Parola detta per amore.</p></note> no volè, che sappiemo chi ha da
 vegnir?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>No voleu, che vel diga? Se sa. Vegnirà sior Canzian
 Tartuffola, sior Maurizio dalle Strope, e sior Simon
 Maroele.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Cospeto de diana! tre cai su la giusta! I avè ben
 trovai fora del mazzo.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Cossa voressi dir? No i xè tre omeni co se diè<note place="foot" anchored="true"><p><emph>Co se diè</emph>: è un detto del basso volgo, che spiega essere que' tali uomini di proposito, cioè come devono essere.</p></note>?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Sior sì. Tre salvadeghi come vu.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Eh, patrona, al tempo d'ancuo, vegnimo a dir el
 merito, a un omo, che gh'ha giudizio seghe dise un omo
@@ -863,59 +897,59 @@ con serietà, con reputazion, se ghe dise, vegnimo a dir el
 merito, seccaggine, omo rustego, omo salvadego. Pàrlio ben?
 Ve par che diga la verità?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Mi no vòi contender; tutto quel, che volè. Vegnirà
 donca a disnar con nu siora Felice, e siora Marina.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Siora sì. Cusì, vedeu? me piase anca mi praticar.
 Tutti col so matrimonio. Cusì no ghe xè sporchezzi<note place="foot" anchored="true"><p>Porcherie.</p></note>, no ghe
 xè, vegnimo a dir el merito... Cosa steu a ascoltar? Adesso
 no se parla con vu <emph>(a Lucietta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Xèle cosse, che mi no possa sentir? <emph>(a Lunardo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>(No vedo l'ora de destrigarmela) <emph>(piano a Margarita)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>(Come va quel negozio?) <emph>(piano a Lunardo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>(Ve conterò) <emph>(piano a Margarita)</emph>. Andè via de qua <emph>(a Lucietta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Cossa ghe fazzio?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Andè via de qua.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>De diana! el xè impastà de velen.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Andè via, che ve dago una schiaffazza in tel muso.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Séntela, siora madre?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Via, col v'ha dito, che andè, obedì <emph>(con caldezza)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Oh, se ghe fusse mia mare bona! Pazzenzia, se me
 vegnisse un scoazzer<note place="foot" anchored="true"><p>Uno di quelli, che raccolgono le immondizie.</p></note>, lo torìa) <emph>(parte)</emph>.</p>
@@ -926,204 +960,204 @@ vegnisse un scoazzer<note place="foot" anchored="true"><p>Uno di quelli, che rac
           <stage>
             <emph>Lunardo, e Margarita.</emph>
           </stage>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Caro sior Lunardo, sul so viso, no ghe dago rason,
 ma in verità sè troppo rustego con quela puta.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Vedeu? vu no savè gnente. Ghe voggio ben, ma la
 tegno in timor.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>E mai che ghe dessi un devertimento.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Le pute le ha da star a casa, e no le se mena a
 torziando.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Almanco una sera alla comedia.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Siora no. Vòi poder dir, co la marido; tolè, sior,
 ve la dago, vegnimo a dir el merito, che no la s'ha mai
 messo maschera sul viso, che no la xè mai stada a un teatro.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>E cusì, vàlo avanti sto maridozzo<note place="foot" anchored="true"><p>Trattato di matrimonio, in modo di dire bassissimo.</p></note>?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Gh'aveu dito gnente a la puta?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Mi? Gnente.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Vardè ben, vedè.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>No in verità, ve digo.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Mi credo, vedè, mi credo d'averla maridada.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Con chi? se porlo saver?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Zito, che gnanca l'aria lo sapia <emph>(guarda intorno)</emph>. Col fio de sior
 Maurizio.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Co sior Filipetto?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Sì, zito, no parlè.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Zito, zito, de diana! xèlo qualche contrabando?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>No voggio, che nissun sapia i fati mi.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Se faràlo presto?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Presto.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>L'àlo fata domandar?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>No pensè altro. Che l'ho promessa.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Anca promessa ghe l'avè?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Siora sì, ve feu maraveggia?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Senza dir gnente?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Son paron mi.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Cossa ghe deu de dota?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Quelo, che voggio mi.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Mi son una statua, donca. A mi, figurarse, no se me
 dise gnente.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>«Figurarse, figurarse», no ve lo dìghio adesso?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Sior sì, e la puta quando lo saveràla?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Co la se sposerà.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>E no i s'ha da véder avanti?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Siora no.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Seu seguro, che el gh'abia da piàser?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Son paron mi.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Ben ben; la xè vostra fia. Mi no me n'impazzo<note place="foot" anchored="true"><p>Non m'impiccio.</p></note>; fè
 pur quel, che volè vu.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Mia fia no vòi, che nissun possa dir d'averla vista,
 e quel che la vede, l'ha da sposar.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>E se col la vede nol la volesse?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>So pare m'ha dà parola.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Oh che bel matrimonio!</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Cossa voressi? che i fasse prima l'amor?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>I bate, i bate; vago a véder chi è.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>No ghe xè la serva?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>La xè a far i leti, anderò a véder mi.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Siora no. No vòi, che andè sul balcon.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Vardè che casi!</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>No vòi, che gh'andè, gh'anderò mi. Comando mi,
 vegnimo a dir el merito, comando mi <emph>(parte)</emph>.</p>
@@ -1134,91 +1168,91 @@ vegnimo a dir el merito, comando mi <emph>(parte)</emph>.</p>
           <stage>
             <emph>Margarita, poi Lunardo.</emph>
           </stage>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Mo che omo, che m'ha toccà! no gh'è el compagno
 sotto la capa del cielo<note place="foot" anchored="true"><p>Modo di dire, che è lo stesso, come se si dicesse sotto il cielo, semplicemente.</p></note>. E po el me stuffa con quel so
 «vegnimo a dir el merito»; deboto, figurarse, no lo posso
 più soportar.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Saveu chi xè?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Chi?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Sior Maurizio.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>El pare del novizzo?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Tasè. Giusto élo.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Viènlo per stabilir?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Andè de là.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Me mandè via?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Siora sì; andè via de qua.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>No volè, che senta?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Siora no.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Vardè vedè! cossa songio mi<note place="foot" anchored="true"><p>Cosa sono io?</p></note>?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Son paron mi.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>No son vostra muggier<note place="foot" anchored="true"><p>Moglie.</p></note>?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Andè via de qua, ve digo.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Mo che orso che sè!</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Destrighève<note place="foot" anchored="true"><p>Spicciatevi.</p></note>
 </p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Mo che satiro! <emph>(incaminandosi a piano)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>La fenìmio<note place="foot" anchored="true"><p>La vogliamo finire?</p></note>? <emph>(con isdegno)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Mo che bestia de omo! <emph>(parte)</emph>.</p>
           </sp>
@@ -1228,135 +1262,135 @@ più soportar.</p>
           <stage>
             <emph>Lunardo, poi Maurizio.</emph>
           </stage>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>La xè andada. Co le bone no se fa gnente. Bisogna
 criar. Ghe voggio ben assae, ghe ne voggio assae; ma in casa
 mia no gh'è altri paroni, che mi.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Sior Lunardo, patron.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Bondì siorìa, sior Maurizio.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Ho parlà con mio fio.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Gh'aveu dito, che el volè maridar?</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Ghe l'ho dito.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Cossa dìselo?</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>El dise, che el xè contento, ma el gh'averave gusto
 de véderla.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Sior no, questi no xè i nostri pati <emph>(con isdegno)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Via, via, no andè in colera, che el puto farà tuto
 quelo che voggio mi.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Co volè, vegnimo a dir el merito, la dota xè
 parecchiada. V'ho promesso sie mile ducati, e sie mile
 ducati ve dago. Li voleu in tanti zecchini, in tanti ducati
 d'arzento, o voleu, che ve li scriva in banco? comandè.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>I bezzi mi no li voggio. O zirème un capital de
 zecca, o investimoli meggio, che se pol.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Sì ben; faremo tutto quel, che volè.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>No stè a spender in abiti, che no voggio.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Mi ve la dago, come che la xè.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Gh'àla roba de sea?<note place="foot" anchored="true"><p>Di seta?</p></note>
 </p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>La gh'ha qualche strazzeto.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>In casa mia no voggio sea. Fin che son vivo mi,
 l'ha da andar co la vesta de lana, e no vòi né tabarini, né
 scuffie, né cerchi<note place="foot" anchored="true"><p>Guardinfanti.</p></note>, né toppè, né cartoline sul fronte<note place="foot" anchored="true"><p>Papigliotti.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Bravo, sieu benedeto. Cusì me piase anca mi, zoggie<note place="foot" anchored="true"><p>Gioje.</p></note>
 ghe ne feu?</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Ghe farò i so boni manini<note place="foot" anchored="true"><p>Smanigli.</p></note> d'oro, e la festa ghe
 darò un zoggielo, che giera de mia muggier, e un per de
 recchineti de perle.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Sì ben, sì ben, e no stessi a far la minchioneria,
 de far ligar sta roba a la moda.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Credeu, che sia mato? Coss'è sta moda? Le zoggie le
 xè sempre a la moda. Cossa se stima? i diamanti, o la
 ligadura?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>E pur al dì d'ancuo<note place="foot" anchored="true"><p>Al giorno d'oggi.</p></note>, vegnimo a dir el merito, se
 buta via tanti bezzi in ste ligadure.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Sior sì; fè ligar ogni dies'anni le zoggie, in cao
 de cent'anni<note place="foot" anchored="true"><p>In capo a cent'anni.</p></note> l'avè comprae do volte.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Ghe xè pochi, che pensa, come, che pensemo nu.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>E ghe xè pochi, che gh'abbia dei bezzi, come che
 gh'avemo nu.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>I dise mo, che nu no savemo gòder.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Poverazzi! ghe vèdeli drento del nostro cuor?
 Crédeli, che no ghe sia altro mondo, che quelo, che i gode
@@ -1364,103 +1398,103 @@ lori? Oh compare<note place="foot" anchored="true"><p>Termine d'amicizia.</p></n
 mio bisogno, no me manca gnente, e in t'una ocorenza posso
 meter le man su cento zecchini!</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Sior sì, e magnar ben, dei boni caponi, delle bone
 polastre, e dei boni straculi de vedèlo<note place="foot" anchored="true"><p>La coscia del vitello.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>E tutto bon, e a bon marcà, perché se paga de volta
 in volta.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>E a casa soa; senza strepiti, senza sussuri.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>E senza nissun, che v'intriga i bisi<note place="foot" anchored="true"><p>Che venga ad infastidirvi.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>E nissun sa i fati nostri.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>E semo paroni nu.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>E la muggier no comanda.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>E i fioi sta da fioi<note place="foot" anchored="true"><p>E i figliuoli stanno da figliuoli.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>E mia fia xè arlevada cusì.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Anca mio fio xè una perla. No gh'è pericolo che el
 buta via un bagatin<note place="foot" anchored="true"><p>La duodecima parte d'un soldo.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>La mia puta sa far de tuto. In casa ho volesto, che
 la faza de tuto. Fina lavar i piati.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>E a mio fio, perché no voggio, che co le serve el
 se ne impazza, gh'ho insegnà a tirar suso i busi delle
 calze, e metter i fondèli alle braghesse<note place="foot" anchored="true"><p>Le pezze ai calzoni.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Bravo <emph>(ridendo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Sì dasseno <emph>(ridendo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Via fémolo sto sposalizio; destrighemose <emph>(fregandosi le mani, e ridendo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Co volè, compare <emph>(come sopra)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Ancuo v'aspetto a disnar con mi. Za savè, che ve
 l'ho dito. Gh'ho quatro latesini<note place="foot" anchored="true"><p>Animelle.</p></note>, vegnimo a dir el merito,
 ma tanto fati.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>I magneremo.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Se goderemo.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Staremo aliegri.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>E po i dirà, che semo salvadeghi!</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Puffe!</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Martuffi! <emph>(partono)</emph>.</p>
           </sp>
@@ -1471,89 +1505,89 @@ ma tanto fati.</p>
           <stage>
             <emph>Marina, e Felippetto.</emph>
           </stage>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Coss'è, nevodo<note place="foot" anchored="true"><p>Nipote.</p></note>? Che miracolo, che me vegnì a
 trovar?</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Son vegnù via de mezà<note place="foot" anchored="true"><p>Studio.</p></note>, e avanti de andar a casa
 son vegnù un pochetin a saludarla.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Bravo, Filipeto; avè fato ben. Sentève<note place="foot" anchored="true"><p>Sedete.</p></note>, voleu
 marendar<note place="foot" anchored="true"><p>Far colazione.</p></note>?</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Grazie, sior'àmia<note place="foot" anchored="true"><p>Zia.</p></note>. Bisogna, che vaga a casa, ché
 se sior padre no me trova, povereto mi.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Disèghe, che sè stà da vostra àmia Marina, cossa
 diràlo?</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Se la savesse! nol tase mai, nol me lassa mai un
 momento de libertà.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>El fa ben, da una banda. Ma da vostr'àmia el ve
 doverave lassar vegnir.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Ghe l'ho dito; nol vol, che ghe vegna.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Mo el xè ben un satiro compagno de mio mario.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Sior barba<note place="foot" anchored="true"><p>Zio.</p></note> Simon, ghe xèlo in casa?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Nol ghe xè, ma no pol far che el vegna.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Anca élo, co el me vede, co vegno qua, el me
 cria.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Lassè, che el diga. La sarave bela. Sè mio nevodo.
 Sè fio de una mia sorela; quela poverazza xè morta, e posso
 dir, che no gh'ho altri a sto mondo, che vu.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>No vorave, che, per causa mia, el ghe criasse
 anca a éla.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Oh per mi, fio mio, no vo tolè sto travaggio. Se
 el me dise tantin, mi ghe respondo tanton. Povereta mi, se
 no fasse cusì! Su tuto el cateria da criar. No credo, che
 ghe sia a sto mondo un omo più rustego de mio mario.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Più de sior padre?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>No so, vedè, la bate là.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Mai, mai, dopo che son a sto mondo, nol m'ha mai
 dà un minimo spasso. El dì da laorar<note place="foot" anchored="true"><p>I giorni da lavoro.</p></note> a mezà, e a casa. La
@@ -1565,97 +1599,97 @@ quattro volte per Piazza, quel, che el fa élo, el vol, che
 fazza anca mi. La sera fina do ore se sta in mezà, se cena,
 se va in leto, e bondì siorìa.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Povero puto; dasseno me fè peccà. Xè vero; la
 zoventù, bisogna tegnirla in fren, ma el tropo xè tropo.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Basta; no so, se da qua avanti l'anderà cusì.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Sè in ti ani de la discrezion, el ve doverave dar
 un pocheto de libertà.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Sàla gnente, sior'àmia?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>De cossa?</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Nol gh'ha dito gnente sior padre?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Oh xè un pezzo, che no lo vedo.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>No la sa gnente donca.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>No so gnente. Cossa ghe xè de niovo?</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Se ghe lo digo, ghe lo diràla a sior padre?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>No, non v'indubitè.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>La varda ben, la veda.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Ve digo de no, ve digo.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>La senta, el me vuol maridar.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Dasseno?</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>El me l'ha dito élo.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Àlo trovà la novizza?</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Siora sì.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Chi xèla?</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Ghe lo dirò, ma, cara éla, la tasa.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Mo via, deboto me fè rabia. Cossa credeu, che sia?</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>La xè fia de sior Lunardo Cròzzola.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Sì, sì, la cognosso. Cioè, no la cognosso éla, ma
 cognosso so maregna, siora Margarita Salicola, che ha sposà
@@ -1663,69 +1697,69 @@ sior Lunardo, e el xè amigo de mio mario, un salvadego co fa
 élo. Mo i s'ha ben catà<note place="foot" anchored="true"><p>Si sono per l'appunto trovati.</p></note>, vedè, el padre del novizzo col
 padre de la novizza. L'aveu vista la puta?</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Siora no.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Avanti de serar el contrato i ve la farà véder.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Mi ho paura de no.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Oh bela! e se no la ve piase?</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Se no la me piase, mi no la togo per diana.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Sarave meggio, che la vedessi avanti.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Come vorla, che fazza?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Disèghelo a vostro sior padre.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Ghe l'ho dito, e el m'ha dà su la ose<note place="foot" anchored="true"><p>Mi ha dato su la voce.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Se savesse come far, vorave farvelo mi sto
 servizio.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Oh magari!</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Ma anca quel orso de sior Lunardo nol la lassa
 véder da nissun so fia.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Se se podesse, una festa...,</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Zito, zito che xè qua mio mario.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Vorla, che vaga via?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Fermève.</p>
           </sp>
@@ -1735,28 +1769,28 @@ véder da nissun so fia.</p>
           <stage>
             <emph>Simon e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>(Cossa falo qua sto frascon?)</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Patron, sior barba.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Sioria <emph>(bruscamente)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Un bel acèto, che ghe fè a mio nevodo!</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Mi v'ho tolto co sto pato, che in casa mia parenti
 no ghe ne voggio.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Varè<note place="foot" anchored="true"><p>Guardate.</p></note>! ve viènli a bater a la porta, e a domandarve
 qualcossa i mi parenti? No i gh'ha bisogno de vu, sior; in
@@ -1764,83 +1798,83 @@ cao de tanto<note place="foot" anchored="true"><p>Dopo tanto tempo.</p></note>, 
 brontolè<note place="foot" anchored="true"><p>Borbottate?</p></note>? Gnanca se fussimo taggialegni<note place="foot" anchored="true"><p>Se fossimo taglialegni, gente villana, nata nelle valli più incolte.</p></note>, gnanca se fussimo
 dalle valade. Vu sè un omo civil? Sè un tangaro, compatìme.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Aveu gnancora fenìo? Stamatin no gh'ho voggia de
 criar.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>No lo podè véder mio nevodo? Cossa v'àlo fato?</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Nol m'ha fato gnente; ghe voggio ben; ma savè che
 in casa mia no gh'ho gusto, che ghe vegna nissun.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Che nol se indubita, che no ghe vegnirò più.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Me farè servizio.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>E mi vòi che el ghe vegna.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>E mi no vòi, che el ghe vegna.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Sta sorte de cosse no me le avè da impedir.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Tuto quelo, che no me piase, ve lo posso, e ve lo
 voggio impedir.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Patron <emph>(in atto di partire)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Aspetè <emph>(a Filippetto)</emph>. Cossa gh'aveu co sto puto? <emph>(a Simon)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>No lo voggio.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Mo per cossa?</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Per cossa, o per gamba<note place="foot" anchored="true"><p>In veneziano «cosa» si dice «cossa», e «coscia» si dice «cossa», dunque succede l'equivoco scherzoso di <emph>cossa</emph> e <emph>gamba</emph>.</p></note>, no vòi nissun.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Sior'àmia, la me lassa andar via.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Andè, andè, nevodo. Vegnirò mi da vostro sior
 padre.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Patrona; patron, sior barba.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Sioria.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>(Oh, el ghe pol a mio padre, el xè più rustego
 diese volte) <emph>(parte)</emph>.</p>
@@ -1851,175 +1885,175 @@ diese volte) <emph>(parte)</emph>.</p>
           <stage>
             <emph>Marina, e Simon.</emph>
           </stage>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Vardè che sesti! cossa voleu, che el diga quel
 putto!</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Lo savè pur el mio temperamento. In casa mia voggio
 la mia libertà.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Che intrigo ve dàvelo mio nevodo?</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Gnente. Ma no voggio nissun.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Perché no andeu in te la vostra camera?</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Perché voggio star qua.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>In verità, che sè caro. Aveu mandà la spesa<note place="foot" anchored="true"><p>S'intende il bisognevole per il pranzo.</p></note>?</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Siora no.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>No se disna ancuo<note place="foot" anchored="true"><p>Non si pranza oggi?</p></note>?</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Siora no.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>No se disna?</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Siora no <emph>(più forte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Ghe mancarave anca questa, che andessi in collera
 anca col disnar.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Za, chi ve sente vu, mi son un strambo, un alocco.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Ma ancuo perché no se disna?</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Perché avemo da andar a disnar fora de casa <emph>(com malagrazia)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>E mel disè co sta bona grazia?</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Me fè vegnir suso el mio mal.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Caro mario, compatìme, gh'avè un natural, che de
 le volte fè rabia.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>No lo cognosseu el mio natural? Co lo cognossè,
 cossa feu ste scene?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>(Ghe vol una gran pazienzia). Dove andémio a
 disnar?</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Vegnirè con mi.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Ma dove?</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Dove, che ve menerò mi.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Per cossa no voleu, che lo sappia?</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Cossa importa, che lo sappiè? Co sè co vostro
 mario, no stè a cercar altro.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>In verità, me parè matto. Bisogna ben, che sappia
 dove che s'ha da andar, come che m'ho da vestir, che zente
 ghe xè. Se ghe xè suggizion, no voggio miga andar a farme
 smatar.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Dove, che vago mi sè segura, che no ghe xè
 suggizion.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Ma con chi andémio?</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Vegnirè con mi.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Mo la xè mo curiosa lu<note place="foot" anchored="true"><p>Questo <emph>lu</emph> dà una certa forza all'espressione, che non si può tradurre.</p></note>!</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Mo la xè curiosa seguro.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Ho da vegnir senza saver dove?</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Patrona sì.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Muème el nome<note place="foot" anchored="true"><p>Cambiatemi il nome.</p></note> se ghe vegno.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>E vu resterè a casa senza disnar.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Anderò da mio cugnà<note place="foot" anchored="true"><p>Cognato.</p></note> Maurizio.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Sior Maurizio vostro cugnà anderà a disnar dove che
 anderemo nu.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Ma dove?</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Vegnì con mi, che lo saverè <emph>(parte)</emph>.</p>
           </sp>
@@ -2029,7 +2063,7 @@ anderemo nu.</p>
           <stage>
             <emph>Marina, poi Felice, Canciano ed il conte Riccardo.</emph>
           </stage>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Mo caro! mo siestu benedetto! mo che bona grazia,
 che el gh'ha! I batte<note place="foot" anchored="true"><p>Picchiano.</p></note>. Oe, vardè che i batte <emph>(alla scena)</emph>. La xè una
@@ -2046,113 +2080,113 @@ diralo, se el vede tuta sta zente? Oe! che el diga quel che
 el vol; mi no li ho fari vegnir. Malegrazie no ghe ne vòi
 far.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Patrona, siora Marina.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Patrona, siora Felice. Patroni riveriti.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Patrona <emph>(malinconico)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>Servitore umilissimo della signora <emph>(a Marina)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Serva sua. Chi xèlo sto signor? <emph>(a Felice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Un conte, un cavalier forestier un amigo de mio
 mario; n'è vero<note place="foot" anchored="true"><p>Non è egli vero.</p></note>, sior Cancian?</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Mi no so gnente.</p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>Buon amico, e buon servitore di tutti.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Col xè amigo de sior Cancian, nol pol esser che
 una persona de merito.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Mi ve digo, che no so gnente.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Come no saveu gnente, se el vien con vu in casa
 mia?</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Con mi?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Mo con chi donca? Caro sior Conte, la compatissa.
 Semo de carneval, sàla; mio mario se deverte un pocheto. El
 vol far taroccar siora Marina; n'è vero, sior Cancian?</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>(Bisogna che ingiotta).</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>(Oh co furba, che xè custìa!) Vorle sentarse? Le
 se comoda.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Sì, sentémose un pochetin <emph>(siede)</emph>. La se comoda qua, sior
 Conte.</p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>La fortuna meglio non mi potea collocare.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>E mi dove m'hòi da sentar?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Andè là, arente<note place="foot" anchored="true"><p>Appresso.</p></note> siora Marina <emph>(a Canciano)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>No, cara fia<note place="foot" anchored="true"><p><emph>Cara fia</emph>, cara figlia, dicesi per amicizia.</p></note>, che se vien mio mario, povereta mi <emph>(piano a Felice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Vardè là; no ghe xè de le careghe<note place="foot" anchored="true"><p>Seggiole.</p></note>? <emph>(a Canciano)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Eh siora sì, la ringrazio <emph>(siede in disparte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>Amico, se volete seder qui, siete padrone; non
 facciamo cerimonie. Io andrò dall'altra parte presso della
 signora Marina <emph>(a Canciano)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Sior no, sior no, no la s'incomoda <emph>(a Riccardo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Per cossa dìsela ste fredure? Crédela fursi, che
 mio mario sia zeloso? Oe, sior Cancian, defendève<note place="foot" anchored="true"><p>Difendetevi.</p></note>. Sentì, i
@@ -2169,103 +2203,103 @@ merito, de farse onor, el gh'ha gusto, che so muggier se
 deverta, che la fazza bona figura, che la staga in bona
 conversazion. N'è vero, sior Cancian?</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Siora sì <emph>(masticando)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>Per dire la verità, io ne avea qualche dubbio; ma
 poiché voi mi disingannate, ed il signor Canciano il
 conferma, vivrò quietissimo, e mi approfitterò dell'onor di
 servirvi.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>(Son stà mi una bestia, a receverlo in casa la
 prima volta).</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Stàla un pezzo, sior Conte, a Venezia?</p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>Aveva intenzione di starci poco; ma sono tanto
 contento di questa bella città, che prolungherò il mio
 soggiorno.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>(Pussibile, che el diavolo no lo porta via?)</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>E cusì, siora Marina, ancuo disneremo insieme.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Dove?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Dove? no lo savè dove?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Mio mario m'ha dito qualcossa de sto disnar, ma el
 logo nol me l'ha dito.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Da siora Margarita.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Da sior Lunardo?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Sì ben<note place="foot" anchored="true"><p>Lo stesso che <emph>sì</emph>.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Adesso ho capìo. Fài nozze<note place="foot" anchored="true"><p>Fanno nozze in casa?</p></note>?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Che nozze?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>No savè gnente?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Mi no. Contème<note place="foot" anchored="true"><p>Raccontatemi.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Oh, novità grande.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>De chi? De Lucietta?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Sì ben; ma, zito.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Cara vu, contème <emph>(si tira appresso a Marina)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Sénteli<note place="foot" anchored="true"><p>Sentono?</p></note>? <emph>(accennando Riccardo, e Canciano)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Sior Riccardo, la ghe diga qualcossa a mio mario,
 la ghe vaga a rente; la fazza un poco de conversazion anca
@@ -2273,272 +2307,272 @@ con élo, el gh'ha gusto, che i parla con so muggier, ma nol
 vol mo gnanca élo esser lassà in t'un canton. N'è vero sior
 Cancian?</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Eh nol s'incomoda, che no me n'importa <emph>(a Riccardo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>Anzi avrò piacere di discorrere col signor
 Canciano. Lo pregherò informarmi di alcune cose <emph>(si accosta a Canciano)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>(El sta fresco).</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>E cusì? <emph>(a Marina)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Andè là, che sè una gran diavola <emph>(a Felice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Se no fosse cusì, morirave etica con quel mio
 mario.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>E mi?...</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Disème, disème. Cossa gh'è de Lucieta?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Ve dirò tuto; ma appian, che nissun ne senta <emph>(parlano piano)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>Signore, parmi che voi mi badiate poco <emph>(a Canciano)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>La compatissa, gh'ho tanti intrighi per mi, che no
 posso tòrmene per i altri.</p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>Bene dunque, non v'incomoderò più. Ma quelle
 signore parlano segretamente fra di loro, diciamo qualche
 cosa; facciamo conversazion fra di noi.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Cossa vorla, che diga? Mi son omo de poche parole;
 no stago su le novità, e no amo troppo la conversazion.</p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>(È un bel satiro costui).</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Nol l'ha vista? <emph>(a Marina)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>No, e no i vol, che el la veda.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Mo questo el xè un gran codogno<note place="foot" anchored="true"><p><emph>Codogno</emph> vuol dire un melcotogno, ma qui s'intende per uno sproposito, per una cosa malfatta.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Se savessi? pagheria qualcossa de belo che ella
 vedesse, avanti de serar el contrato<note place="foot" anchored="true"><p>Vuol dire sottoscriver la scritta.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>In casa nol ghe pol andar?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Oh gnanca per insonio<note place="foot" anchored="true"><p>Nemen per sogno.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>No se poderia co l'occasion de le maschere?...</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Disè appian, che i ne sente.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Via, che i tenda<note place="foot" anchored="true"><p>Che badino.</p></note> ai fati soi. Che no i staga a
 spionar; che i parla, che parlemo anca nu <emph>(a Riccardo)</emph>. Sentì cossa, che
 me vien in testa <emph>(a Marina, e si parlano piano)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>Dove si va questa sera?</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>A casa.</p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>E la signora?</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>A casa.</p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>Fate conversazione?</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Sior sì. In letto.</p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>In letto? A che ora?</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>A do ore<note place="foot" anchored="true"><p>A due ore di notte, cioè due ore dopo il tramontar del sole.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>Eh, mi burlate.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Sì anca da so servitor.</p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>(Sono male impicciato, per quel, ch'io vedo).</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Cossa diseu? ve piàsela? <emph>(a Marina)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Sì ben; cusì andarave pulito. Ma no so come far a
 parlar con mio nevodo. Se el mando a chiamar, mio mario va
 in bestia.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Mandèghe a dir, che el vegna da mi.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>E so pare?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>No valo anca élo a disnar da sior Lunardo? Col xè
 fora de casa, che el vegna; lassème el travaggio a mi<note place="foot" anchored="true"><p>Lasciate la cura a me.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>E po?<note place="foot" anchored="true"><p>E poi?</p></note>...</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>E po, e po! dopo el Po vien l'Adese<note place="foot" anchored="true"><p>Scherzo di parole fra il <emph>Po</emph> fiume, e <emph>po</emph> proposizione, che vuol dire «poi». <emph>Dopo el Po vien l'Adese</emph> vuol dire, che dopo il Po, si trova il fiume Adige, onde da cosa nasce cosa.</p></note>. Lassème far a
 mi, ve digo.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Adessadesso lo mando a avisar.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Coss'è, seu mutti? <emph>(a Riccardo e Canciano)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>Il signor Canciano non ha volontà di parlare.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Gramazzo! el gh'averà qualcossa per la testa. El
 xè pien d'interessi: el xè un omo de garbo, sàla, mio mario.</p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>Dubito stia poco bene.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Dasseno? Oh povereta mi; me despiaserave assae.
 Cossa gh'aveu, sior Cancian?</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Niente.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Per cossa dìselo, che el gh'ha mal? <emph>(a Riccardo)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>Perché ha detto, che vuol andar a dormire a due ore
 di notte.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Dasseno? Fè ben a governarve, fio mio <emph>(a Canciano)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Ma ghe vegnirè anca vu.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Oh, aponto, no v'arecordè, che avemo da andar a
 l'opera?</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>A l'opera mi no ghe vago.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Come? Questa è la chiave del palco; me l'avè pur
 comprada vu <emph>(a Canciano)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>L'ho comprada... l'ho comprada, perché m'avè
 incinganà; ma a l'opera mi no ghe vago, e no gh'avè d'andar
 gnanca vu.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Oh caro! el burla sàla? El burla, savè, Marina? El
 mio caro mario me vol tanto ben, el m'ha comprà el palco, e
 el vegnirà a l'opera con mi: n'è vero fio? (Senti sa, no me
 far el mato, che povereto ti) <emph>(piano a Canciano)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>(O che gaìna<note place="foot" anchored="true"><p>Finta, accorta, maliziosa.</p></note>!)</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Vorla restar servida con mi? Ghe xè logo in tel
 palco: n'è vero, sior Cancian? <emph>(a Riccardo)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>(Siestu maledeta! La me fa far tuto quel, che la
 vol).</p>
@@ -2549,116 +2583,116 @@ vol).</p>
           <stage>
             <emph>Simon e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Marina <emph>(bruscamente)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Sior.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>(Cossa xè sto baccan? Cossa vorli qua? Chi xèlo
 colù?) <emph>(accenna Riccardo)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Oh, sior Simon, la reverisso.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Patrona <emph>(a Felice)</emph>. Ah? <emph>(a Marina)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Semo vegnui a farve una visita.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>A chi?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>A vu. N'è vero, sior Cancian?</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Siora sì <emph>(a mezza bocca)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Andè via de qua, vu <emph>(a Marina)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Volè, che usa una mala creanza?</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Lassème el pensier a mi; andè via de qua.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Via, Marina, obedìlo vostro mario: anca mi, vedè,
 co sior Cancian me dise una cossa, la fazzo subito.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Brava, brava, ho capìo. Patroni.</p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>Umilissima riverenza <emph>(a Marina)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Patron <emph>(ironico al Conte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Serva sua <emph>(fa la riverenza al Conte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Patrona <emph>(contrafà la riverenza)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>(Taso, perché, perché: ma sta vita no la voggio
 far) <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Chi èlo sto sior? <emph>(a Felice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Domandèghelo a mio mario.</p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>Se volete saper chi sono, ve lo dirò io, senza, che
 fatichiate, per domandarlo. Io sono il conte Riccardo degli
 Arcolai, cavaliere d'Abruzzo; son amico del signor Canciano,
 e buon servidore della signora Felice.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>E vu lassè praticar vostra muggier co sta sorte de
 cai<note place="foot" anchored="true"><p>Con questa sorta di gente?</p></note>? <emph>(a Canciano)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Cossa voleu, che fazza?</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Puffeta<note place="foot" anchored="true"><p>Un'esclamazione, che spiega assaissimo la maraviglia, e il dispregio.</p></note>! <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Vedeu, che bella creanza, che el gh'ha? El n'ha
 impiantà qua senza dir sioria bestia. Védela, sior Conte la
@@ -2668,11 +2702,11 @@ ancuo no la podemo menar. Ma ghe dirò po mi un no so che per
 dopo disnar, e sta sera anderemo a l'opera insieme. N'è
 vero, sior Cancian?</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Ma mi ve digo...</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Eh via vegnì qua, sior pampalugo<note place="foot" anchored="true"><p>Babbeo, scioccone.</p></note> <emph>(prende per un braccio Canciano, per l'altro Riccardo, e partono)</emph>.</p>
           </sp>
@@ -2686,29 +2720,29 @@ vero, sior Cancian?</p>
           <stage>
             <emph>Margarita vestita con proprietà, e Lucietta</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Brava, siora madre. Mo co pulito, che la s'ha
 vestìo.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Cossa voleu, cara fia? Se vien sta zente ancuo,
 voleu, che staga, figurarse, co fa una massèra?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>E mi, che figura vorla, che fazza?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Vu da puta stè ben.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Eh sì sì, stago ben! Co no son amalada, stago ben.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Mi no so cossa dir, cara fia. Se podesse, me
 piaserave anca a mi che gh'avessi el vostro bisogno; ma savè
@@ -2719,53 +2753,53 @@ per no sentir a criar, no me n'impazzo; lasso, che el fazza
 élo. Finalmente no sè mia fia, no me posso tòr certe
 boniman<note place="foot" anchored="true"><p>Arbitrî</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Eh lo so, lo so, che no son so fia <emph>(mortificata)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Cossa voressi dir? No ve voggio ben fursi<note place="foot" anchored="true"><p>Forse.</p></note>?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Siora sì, la me ne vol; ma no la se scalda gnente
 per mi. Se fusse so fia, co vien zente de suggizion, no la
 lasserave miga, che stasse co<note place="foot" anchored="true"><p>Quando.</p></note> la traversa<note place="foot" anchored="true"><p>Grembiale.</p></note> davanti.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Via, cavèvela la traversa.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>E po, co me l'averò cavada?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Co ve l'averà cavada, figurarse, no la gh'averè
 più.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Eh za! crédela, che no sappia, che la me burla?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Me fè da rider. Cossa voressi?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Vorave anca mi comparir cofà<note place="foot" anchored="true"><p>Come.</p></note> le altre.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Disèghelo a vostro padre. Voleu, che manda a
 chiamar un sartor in scondon<note place="foot" anchored="true"><p>Di nascosto.</p></note>, e che ve fazza un abito? E po?
 xèlo orbo sior Lunardo? Credeu, figurarse, che nol ve l'abia
 da véder?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Mi no digo un abito; ma qualcossa almanco. La varda;
 no gh'ho gnanca un fià de cascate<note place="foot" anchored="true"><p>Manicotti.</p></note>. Gh'ho sto strazzo de
@@ -2774,16 +2808,16 @@ Per casa co sto abito no stago mal; ma ghe voria, cusì,
 qualcossa, che paresse bon. Son zovene, e no son mo gnanca
 una pitocca, me par che qualche bagatela no la me desdiga<note place="foot" anchored="true"><p>Non mi disconvenga.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Aspetè. Se volè un pèr de cascate, ve le darò mi de
 le mie. Voleu una colana de perle?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Magari.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Adesso ve la vago a tòr. (Poverazza! la compatisso.
 Nu altre donne, figurarse, semo tute cusì) <emph>(parte)</emph>.</p>
@@ -2794,7 +2828,7 @@ Nu altre donne, figurarse, semo tute cusì) <emph>(parte)</emph>.</p>
           <stage>
             <emph>Lucietta, e detta.</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Vardè! la dise, che mio sior padre no vol. Credo,
 che la sia éla mi, che no voggia. Xè vero, che sior padre xè
@@ -2807,232 +2841,232 @@ casa ghe fazzo fastidio. La me dise fia co la boca streta;
 co ghe digo siora madre, la gh'ha paura che ghe fazza
 crescer i ani.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Via, cavève quela traversa.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Siora sì, subito <emph>(si cava il ghembriale)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Vegnì qua, che ve meterò le cascate.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Cara éla, la lassa véder.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Vardè; le xè squasi nòve.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Cossa vorla, che fazza de sti<note place="foot" anchored="true"><p><emph>Scovolo</emph> in veneziano è uno spazzolino di sarmenti di biade minute, con cui si ripuliscono i tondi in cucina.</p></note> scovoli da lavar i piati?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Scovoli ghe disè? Un pèr de cascate de cambrada,
 che no le ho doperae quatro volte?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>No la vede co fiappe<note place="foot" anchored="true"><p>Appassite.</p></note> che le xè?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Vardè, che desgrazia! certo, che i ve vegnirà a
 vardar le cascate, se le xè de lissìa<note place="foot" anchored="true"><p>Di bucato.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Le soe però le xè nete.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Che cara siora! vo voressi meter co mi? Queste xè
 le cascate: se le volè, metèvele; se ghe ne volè de meggio,
 catèvene.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Via, no la vaga in colera, che me le meterò.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Vegnì qua. Za, co ste spuzzete<note place="foot" anchored="true"><p>Begli umoretti.</p></note>, più che se fa, se
 fa pezo <emph>(mettendole le cascate)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Certo! la fa assae per mi <emph>(accomodandosi le cascate)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Fazzo più de quel che me tocca <emph>(come sopra)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Cara éla, che no la se struppia <emph>(come sopra)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Sè ben insolente sta matina <emph>(come sopra tirandola)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Mo via, no la me staga a strascinar, che no son miga
 una bestia.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>No, no, no v'indubitè, che no ve vegnirò più
 intorno. Sè tropo delicata, siora. Fève servir da la serva,
 che con vu no me ne voggio impazzar.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Gh'àla le perle?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>No so gnente: no voggio più mustazzae<note place="foot" anchored="true"><p>Rimbrotti.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Via mo; cara éla.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Mata inspiritada, che son, a deventar mata co sta
 frascona.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p><emph>(piange e si asciuga col fazzoletto)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Coss'è stà? cossa gh'aveu? Pianzè? cossa v'òggio
 fato?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>La m'ha dito... de darme... una colana de perle... e
 no la me la vol... più dar <emph>(piangendo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Mo se me fè andar in colera.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Me la dàla?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Via, vegnì qua <emph>(le vuol mettere la collana)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>La lassa véder.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Trovereu da dir anca in questo? Lassè, lassè, che
 ve la zola<note place="foot" anchored="true"><p>Ch'io ve l'allacci.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>La sarà qualche antigaggia<note place="foot" anchored="true"><p>Anticaglia.</p></note> <emph>(piano, brontolando)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Cossa diseu? <emph>(allacciando la collana)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Gnente.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Sempre brontolè <emph>(come sopra)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>La varda; una perla rota <emph>(si trova una perla rotta in seno)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>E cusì? cossa importa? Slarghèle un pochetin<note place="foot" anchored="true"><p>Allargatele un poco.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Xèle tute rote?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Deboto me faressi dir...</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Quanti ani gh'àla sta colana?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Voleu zogar<note place="foot" anchored="true"><p>Volete giuocare.</p></note>, che ve la cavo, e la porto via?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>De diana! sempre la cria.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Mo se no ve contentè mai.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Staghio ben?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Stè benissimo.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Me fàla ben al viso?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Pulito, ve digo, pulito. (La gh'ha un'ambizion
 maledetonazza<note place="foot" anchored="true"><p>Maladettissima.</p></note>).</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(No ghe credo gnente, me vòi vardar) <emph>(tira fuori di tasca uno specchietto)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>El specchio gh'avè in scarsela<note place="foot" anchored="true"><p>Saccoccia.</p></note>?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Oh el xè un strazzetto<note place="foot" anchored="true"><p>Straccietto.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Se vostro sior padre ve lo vede!</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Via, no la ghe lo staga a dir.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Vèlo qua, vedè, che el vien.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Sia malignazo! No m'ho gnanca podesto véder ben
 <emph>(mette via lo specchio)</emph>.</p>
@@ -3043,16 +3077,16 @@ maledetonazza<note place="foot" anchored="true"><p>Maladettissima.</p></note>).<
           <stage>
             <emph>Lunardo, e dette.</emph>
           </stage>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Coss'è, siora? andeu al festin? <emph>(a Margarita)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Tolè. Vèlo qua. Me vesto una volta a l'anno, e el
 brontola. Aveu paura, figurarse, che ve manda in mal'ora?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Mi no m'importa, che fruessi<note place="foot" anchored="true"><p>Che logoraste.</p></note>, vegnimo a dir el
 merito, anca un abito a la setimana. Grazie al Cielo, no son
@@ -3061,48 +3095,48 @@ spender. Ma no in ste buffonarie; cossa voleu che diga quei
 galantomeni, che vien da mi? Che sè la piavola de Franza<note place="foot" anchored="true"><p>Bamboccia, che si espone in Venezia dai professori di mode.</p></note>. No
 me vòi far smatar.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Gh'ho gusto in verità, che el ghe diga roba<note place="foot" anchored="true"><p>Che le gridi.</p></note>).</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Come credeu, che vegnirà vestìe quelle altre? Co
 una scarpa, e un zoccolo?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Lassè, che le vegna come che le vol. In casa mia no
 s'ha mai praticà de ste cargadure, e no vòi scomenzar, e no
 me vòi far meter sui ventoli. M'aveu capìo?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Dasseno, sior padre, ghe l'ho dito anca mi.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Senti sa, no tòr esempio da éla... Coss'è quela
 roba? Cossa xè quei diavolezzi, che ti gh'ha al colo? <emph>(a Lucietta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Eh gnente, sior padre. Una strazzaria,
 un'antigaggia.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Càvete quele perle.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Dasseno, sior Lunardo, che ghe l'ho dito anca mi.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Via, caro élo, semo de carneval.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Cossa s'intende? che siè in maschera? No voggio sti
 putelezzi. Ancuo vien zente; se i ve vede, no voggio, che i
@@ -3111,86 +3145,86 @@ Dà qua quele perle. <emph>( va per levarle, ella si difende)</emph>.
 Cossa xè quei sbrindoli<note place="foot" anchored="true"><p>Ciondoli.</p></note>. Cascate, patrona? cascate?
 Chi v'ha dà quei sporchezzi<note place="foot" anchored="true"><p>Chi vi ha dato quelle porcherie?</p></note>?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Me l'ha dae siora madre.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Dona mata! cusì pulito arlevè mia fia? <emph>(a Margarita)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Se no la contento, la dise, che la odio, che no ghe
 vòi ben.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Da quando in qua ve xè vegnù in testa sti grili?
 <emph>(a Lucietta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>L'ho vista éla vestìa, me xè vegnù voggia anca a mi.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Sentìu? Questa xè la rason del cativo esempio.
 <emph>(a Margarita)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Ela xè pura, e mi son maridada.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Le maridae ha da dar bon esempio a le pute.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Mi no m'ho maridà, figurarse, per vegnir a deventar
 mata co i vostri fioi.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Né mi v'ho tolto, vegnimo a dir el merito, acciò,
 che vegnì a discreditar la mia casa.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Ve fazzo onor più de quelo, che meritè.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Anemo, andève subito a despoggiar. <emph>(a Margarita)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>No ve dago sto gusto gnanca se me copè.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>E vu no vegnirè a tola.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>No ghe penso né bezzo, né bagatin.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>E mi, sior padre, vegniroggio a tola?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Càvete quelle strazzarie.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Sior sì, co nol vol altro, che el toga. Mi son
 ubidiente. La varda che roba: gnanca vergogna, che me le
 meta <emph>(si cava perle e cascate)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Vedeu? Se cognosse, che la xè ben arlevada. Eh la
 mia prima muggier povereta! quela giera una donna de sesto<note place="foot" anchored="true"><p>Una donna di garbo.</p></note>.
@@ -3199,130 +3233,130 @@ giera fenìo, no ghe giera altre risposte. Siestu benedeta
 dove che ti xè<note place="foot" anchored="true"><p>Che tu sia benedetta dove sei.</p></note>. Mato inspirità, che son stà mi a tornarme a
 maridar.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Mi mi ho fato un bon negozio a tòr un satiro per
 mario.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Povera grama! ve manca el vostro bisogno? no gh'avè
 da magnar?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Certo! una dona co la gh'ha da magnar, no ghe manca
 altro!</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Cossa ve manca?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Caro vu, no me fè parlar.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Sior padre.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Cossa gh'è?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>No me meterò più gnente, senza dirghelo sàlo?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Ti farà ben.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Gnanca se me lo dirà siora madre.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Eh mozzina! se cognossemo. Sul so viso, figurarse,
 tegnì da élo, e po da drio le spale tirè zoso a campane
 doppie <emph>(a Lucietta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Mi, siora? <emph>(a Margarita)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Tasè là <emph>(a Lucietta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>La dise delle busie<note place="foot" anchored="true"><p>Bugie.</p></note> <emph>(a Lunardo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Sentìu come che la parla? <emph>(a Lunardo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Tasè là ve digo. Co la maregna no se parla cusì.
 Gh'avè da portar respeto; l'avè da tegnir in conto de mare.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>De mi no la se pol lamentar <emph>(a Lunardo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>E mi... <emph>(a Lunardo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>E vu, vegnimo a dir el merito, despoggiève, che farè
 meggio <emph>(a Margarita)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Diseu dasseno?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Digo dasseno.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Oh magari!)</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Son capace de strazzarlo sto abito in cento tocchi.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Animo scomenzè, che ve aggiuterò.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Sior padre, vien zente.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Aseni! i averze senza dir gnente? Andè via de qua <emph>(a Lucietta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Mo per cossa?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Andève a despoggiar <emph>(a Margarita)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Cossa voleu, che i diga?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Cospeto, e tacca via!<note place="foot" anchored="true"><p>Cospetto e tacca via, esclamazione bassa, collerica, per non bestemmiare.</p></note></p>
           </sp>
@@ -3332,195 +3366,195 @@ meggio <emph>(a Margarita)</emph>.</p>
           <stage>
             <emph>Simon, Marina, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Patrona, siora Margarita.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Patrona, siora Marina.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Patrona.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Patrona, fia, patrona.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Sior Simon, patron.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Patrona <emph>(ruvido)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Sior Lunardo, gnanca? Pazenzia.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>La reverisso. (Cavève)<note place="foot" anchored="true"><p>Andate via.</p></note> <emph>(a Lucietta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Gnanca se i me coppa no vago via).</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Semo qua, sior Lunardo, a ricever le vostre grazie.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>(Quela mata de mia muggier, ancuo la me vol far
 magnar tanto velen).</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Mio cugnà Maurizio nol xè gnancora vegnù <emph>(a Lunardo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>(Figurève cossa che el dirà sior Simon in tel so
 cuor, a véder sta cargadura<note place="foot" anchored="true"><p>Caricatura.</p></note> de mia muggier).</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>(Vardè che bel sesto! nol ve bada gnanca) <emph>(a Simon)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Tasè là, va; cossa gh'intreu? <emph>(a Marina)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Cara quela grazieta! <emph>(a Simon)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Via, siora Marina, la se cava zoso.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Volentiera <emph>(vuole spuntarsi il zendale)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Andè de là, siora, a cavarghe la vesta, e el zendà <emph>(con rabbia a Margarita)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Via, via, figurarse, no me magnè. Andemo, siora
 Marina.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>E despoggiève anca vu <emph>(a Margarita)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Anca mi m'ho da despoggiar? Cosa dìsela, siora
 Marina? El vol, che me despoggia. Xèlo belo mio mario? <emph>(ridendo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>De mi no la gh'ha d'aver suggizion <emph>(a Margarita)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Sentìu? che bisogno ghe giera, vegnimo a dir el
 merito, che ve vestissi in andriè? <emph>(a Margarita)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Che caro sior Lunardo! e éla, figurarse, come xèla
 vestìa?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Éla xè fora de casa, e vu sè in casa.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Anca mi ho combatù do ore co sta mata. La s'ha
 volesto vestir a so modo <emph>(a Lunardo)</emph>. Mandè a casa a tòr el vostro
 cotuss<note place="foot" anchored="true"><p>Abito assai succinto, che si usava molti anni prima.</p></note> <emph>(a Marina)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Figurève se mando!</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Andémo, andémo, siora Marina.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Vardè! gnanca se fussimo vestìe de ganzo<note place="foot" anchored="true"><p>Di broccato.</p></note>!</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>I xè cusì. Se gh'ha la roba, e no i vol, che la se
 dopera.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>I vederà siora Felice, come che la xè vestìa.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>L'aveu vista?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>La xè stada da mi.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Come gièrela, cara va?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Oe, in tabarin <emph>(con esclamazione)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>In tabarin?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>E co pulito!</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Sentìu, sior Lunardo? Siora Felice, figurarse, la
 xè in tabarin.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Mi no intro in ti fati dei altri. Ve digo a vu,
 vegnimo a dir el merito, che la xè una vergogna.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Che abito gh'avévela? <emph>(a Marina)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Arzento a sguazzo<note place="foot" anchored="true"><p>Argento in quantità.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Sentìu? Siora Felice gh'ha l'abito co l'arzento, e
 vu criè perché gh'ho sto strazzeto de sea<note place="foot" anchored="true"><p>Di seta?.</p></note>? <emph>(a Lunardo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Cavèvelo, ve digo.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Sè ben minchion, se el credè. Andémo, andémo siora
 Marina. Se ghe tendessimo a lori<note place="foot" anchored="true"><p>Se badassimo a loro.</p></note>, i ne meterave i moccoli
@@ -3528,30 +3562,30 @@ drio<note place="foot" anchored="true"><p>Mettere i moccoli dietro a qualcheduno
 fin che son zovene me la voggio gòder <emph>(a Marina)</emph>. Ma no gh'è altro;
 cusì la xè <emph>(a Lunardo, e parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Custìa la me vol tirar a cimento</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Caro sior Lunardo, bisogna compatirla. La xè
 ambiziosa; certo che no ghe giera bisogno, che per casa la
 mostrasse sta affetazion, ma la xè zovene: no la gh'ha
 gnancora el so bon intendacchio<note place="foot" anchored="true"><p>Giudizio, detto burlescamente.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Tasè là. Vardève vu, siora petegola.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Se no portasse respeto dove che son...</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Cossa diressi?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Ve diria di chi v'ha nanìo<note place="foot" anchored="true"><p>Vi direi delle villanie.</p></note>. (Orso del diavolo).<emph>(parte)</emph>.</p>
           </sp>
@@ -3561,65 +3595,65 @@ gnancora el so bon intendacchio<note place="foot" anchored="true"><p>Giudizio, d
           <stage>
             <emph>Lunardo, e Simon.</emph>
           </stage>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Maridève, che gh'averè de sti gusti.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Ve recordeu de la prima muggier? Quella giera una
 bona creatura; ma questa la xè un muschieto.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Ma mi, mato bestia, che le donne no le ho mai
 podeste soffrir, e po son andà a ingambararme co sto diavolo
 descaenà.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Al dì d'ancuo no se se pol più maridar.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Se se vol tegnir la muggier in dover, se xè
 salvadeghi; se la se lassa far, se xè alocchi.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Se no giera per quella puta che gh'ho, ve protesto
 da galantomo, vegnimo a dir el merito, che no m'intrigava
 con altre donne.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Me xè stà dito, che la maridè; xe vero?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Chi ve l'ha dito? <emph>(con isdegno)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Mia muggier.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Come l'ala savesto? <emph>(come sopra)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Credo, che ghe l'abia dito so nevodo.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Felipeto?</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Sì, Felipeto.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Frascon, petegolo; babuin! So pare ghe l'ha confidà,
 e lu subito el lo xè andà a squaquarar? Conosso, che nol xè
@@ -3627,49 +3661,49 @@ quel puto, che credeva, che el fusse. Son squasi pentìo
 d'averla promessa, e ghe mancherave poco, vegnimo a dir el
 merito, che no strazzasse el contrato.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Ve n'aveu per mal, perché el ghe l'ha dito a so
 àmia?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Sior sì; chi no sa tàser, no gh'ha prudenza, e chi
 no gh'ha prudenza, no xè omo da maridar.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Gh'avè rason, caro vecchio; ma al dì d'ancuo no ghe
 ne xè più de quei zoveni del nostro tempo. V'arecordeu? No
 se fava né più, ne manco de quel che voleva nostro sior
 pare.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Mi gh'aveva do sorele maridae: no credo averle viste
 diese<note place="foot" anchored="true"><p>Dieci.</p></note> volte in tempo de vita mia.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Mi no parlava squasi mai gnanca co mia siora mare.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Mi al dì d'ancuo no so cossa che sia un'opera, una
 comedia.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Mi i m'ha menà una sera per forza all'opera, e ho
 sempre dormìo.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Mio pare, co giera zovene, el me diseva: Vustu véder
 el Mondo niovo<note place="foot" anchored="true"><p>Quelle macchinette, che si mostrano in Piazza ai curiosi per poco prezzo.</p></note>? o vusto, che te daga do soldi? Mi me taccava
 ai do soldi.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>E mi? sunava le boneman<note place="foot" anchored="true"><p>Raccoglieva le mancie.</p></note>, e qualche soldeto, che ghe
 bruscava<note place="foot" anchored="true"><p>Ch'io gli cavava di mano.</p></note>, e ho fato cento ducati, e i ho investii al quatro
@@ -3679,36 +3713,36 @@ dir. No miga per l'avarizia dei quatro ducati, ma gh'ho
 gusto de poder dir: tolè; questi me li ho vadagnai da
 putelo.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Trovèghene uno ancuo, che fazza cusì. I li buta via,
 vegnimo a dir el merito, a palae<note place="foot" anchored="true"><p>Li gettano colla pala.</p></note>
 </p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>E pazenzia i bezzi, che i buta via. Xè che i se
 precipita in cento maniere.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>E tuto xè causa la libertà.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Sior sì, co i se sa meter le braghesse<note place="foot" anchored="true"><p>I calzoni.</p></note> da so posta,
 subito i scomenza a praticar.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>E saveu chi ghe insegna? So mare.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>No me disè altro: ho sentìo cosse, che me fa
 drezzar i cavei.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Sior sì; cusì le dise: Povero putelo! che el se
 deverta, povereto! voleu, che el mora da malinconia? Co vien
@@ -3723,99 +3757,99 @@ giudizio. Caro colù; vien qua vita mia; dàghe un baso a
 siora Lugrezia... Via; sporchezzi; vergogna; donne senza
 giudizio.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Cossa, che pagherave, che ghe fusse qua a sentirve
 sete o oto de quele donne, che cognosso mi.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Cospeto de diana! le me sgrafarave i occhi.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Ho paura de sì; e cussì, disème: aveu serà el
 contrato co sior Maurizio?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Vegnì in mezà<note place="foot" anchored="true"><p><emph>Mezzà</emph> in Venezia dicesi a quella stanza, in cui si fanno le maggiori faccende: <emph>mezzà</emph> è lo studio degli avvocati, dei ministri, dei legali, dei mercadanti; dicesi anche <emph>mezzà</emph> ad una o più, stanze che sono ad un primo piano al di sotto del piano nobile, ed alcuni ve ne sono anche a terreno.</p></note> da mi, che ve conterò tuto.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Mia muggier sarà de là co la vostra.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>No voleu?</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>No ghe sarà nissun m'imagino.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>In casa mia? no vien nissun senza che mi lo sappia.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Se savessi! da mi stamatina... basta, no digo
 altro.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Contème... cossa xè stà?</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Andémo, andémo; ve conterò. Donne, donne, e po
 donne.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Chi dise donna, vegnimo a dir el merito, dise danno.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Bravo da galantomo <emph>(ridendo, e abbracciando Lunardo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>E pur, se ho da dir la verità, no le m'ha despiasso.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Gnanca a mi veramente.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Ma in casa.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>E soli.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>E co le porte serae.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>E co i balboni inchiodai.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>E tegnirle basse.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>E farle far a nostro modo.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>E chi xè omeni, ha da far cusì <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>E chi no fa cusì no xè omeni <emph>(parte)</emph>.</p>
           </sp>
@@ -3826,161 +3860,161 @@ donne.</p>
           <stage>
             <emph>Margarita, e Marina.</emph>
           </stage>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Fème a mi sto servizio. Chiamè Lucieta, e
 disèmoghe qualcossa de sto so novizzo. Consolémola, e
 sentimo cossa, che la sa dir.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Credème, siora Marina, che no la lo merita.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Mo perché?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Perché la xè una frascona. Procuro per tuti i versi
 de contentarla, e la xè con mi, figurarse, ingrata, altiera,
 e sofistica al mazor segno.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Cara fia, bisogna compatir la zoventù.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Cossa credeu? che la sia una putela?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Quanti anni gh'averàla?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Mo la gh'averà i so disdot'ani fenii lu.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Eh via<note place="foot" anchored="true"><p>Espressione di meraviglia.</p></note>!</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Sì! da quella che son.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>E mio nevodo ghe n'ha vinti deboto.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Per età i va pulito.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Disè mo anca, che el xè un bon puto.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Se ho da dir la verità, gnanca Lucieta no xè
 cativa; ma cusì; la va a lune. De le volte la me strucola de
 carezze<note place="foot" anchored="true"><p>Mi carica di carezze.</p></note>, e de le volte la me fa inrabiar.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>I xè i so anni, fia mia. Credèmelo, che me recordo
 giusto come se fusse adesso: anca mi fava cusì con mia siora
 madre.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Ma gh'è diferenza, vedeu? Una mare pol soportar, ma
 a mi no la me xè gnente.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>La xè de vostro mario.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Giusto élo me fa passar la vogia de torme qualche
 pensier; perché se la contento, el cria; se no la contento,
 el brontola. In verità no so più quala far.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Fè de tuto, che la se destriga.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Magari doman.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>No xèli in contrato?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>No gh'è miga fondamento in sti omeni: i se pente da
 un momento a l'altro.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>E pur mi ghe scometeria qualcossa, che ancuo se
 stabilisse ste nozze.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Ancuo? per cossa?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>So che sior Lunardo ha invidà a disnar anca mio
 cugnà Maurizio. No i xè soliti a far sti invidi; vederè quel
 che digo mi.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Pol esser; ma me par impussibile, che no i diga
 gnente a la puta.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>No saveu, che zente, che i xè? I è capaci de
 dirghe dal dito al fato. Tocchève la man, e bondì sioria.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>E se la puta disesse de no?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Per questo xè megio, che l'avisemo.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Voleu, che la vaga a chiamar?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Se ve par che sia ben, chiamémola.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Cara fia, me reporto a vu.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Eh cara siora Margarita; in materia de prudenza no
 ghe xè una par vostro.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Vago, e vegno <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Povera puta! lassarghe vegnir l'acqua adosso cusì!
 sta so maregna no la gh'ha un fià<note place="foot" anchored="true"><p>Niente.</p></note> de giudizio.</p>
@@ -3991,337 +4025,337 @@ sta so maregna no la gh'ha un fià<note place="foot" anchored="true"><p>Niente.<
           <stage>
             <emph>Margarita, Lucietta, e Marina.</emph>
           </stage>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Vegnì qua, fia, che siora Marina ve vol parlar.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>La compatissa, sàla, se no son vegnua avanti,
 perché, se la savesse, ho sempre paura de falar. In sta casa
 i cata da dir sun tuto.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Xè vero; vostro sior padre xè un poco tropo
 sutilo; ma consolève, che gh'avè una maregna, che ve vol
 ben.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Siora sì <emph>(le fa cenno col gomito, che non è vero)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>(Figurarse. Se gh'avesse una fiastra, anca mi
 farave l'istesso).</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>(Ghe voggio ben, ma no vedo l'ora, che la me vaga
 fora dai occhi).</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>E cusì, siora Marina, cossa gh'àla da dirme?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Siora Margarita.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Fia mia.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Disèghe vu qualcossa.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Mi ve lasso parlar a vu.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Povereta mi! de ben, o de mal?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Oh de ben, de ben.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Mo via donca, che no la me fazza più sgangolir<note place="foot" anchored="true"><p>Penare.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Me consolo con vu, Lucieta.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>De cossa?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Che ghe lo diga? <emph>(a Margarita)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Via, tanto fa<note place="foot" anchored="true"><p>È tutt'uno.</p></note>, disèghelo<emph>(a Marina)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Me consolo, che sè novizza <emph>(a Lucietta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Oh giusto! <emph>(mortificandosi)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Vardè! no lo credè?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Mi no, la veda <emph>(come sopra)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Domandèghelo <emph>(accennando Margarita)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Xèla la verità, siora madre?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Per quel che i dise.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Oh! no ghe xè gnente de seguro<note place="foot" anchored="true"><p>Non vi è niente di certo?</p></note>?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Mi credo, che sia sicurissimo.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Oh, la burla, siora Marina.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Burlo? so anca chi xè el vostro novizzo.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Dasseno? Chi xèlo?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>No savè gnente vu?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Mi no la veda. El me par un insonio<note place="foot" anchored="true"><p>Mi pare un sogno.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Lo spiegheressi volentiera sto insonio<note place="foot" anchored="true"><p>Spiegare il sogno, s'intende verificarlo.</p></note>?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>No vorla<note place="foot" anchored="true"><p>C'è dubbio?</p></note>?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Pol esser, che ve tocca la grazia.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Magari. Xèlo zovene? <emph>(a Marina)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Figurève, in circa della vostra età.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Xèlo belo?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Più tosto.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Siestu benedetto!)</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>La s'ha mo messo, figurarse, in t'un boccon de
 gringola<note place="foot" anchored="true"><p>Allegrezza con desiderio.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Mo via no la me mortifica. Par, che ghe despiasa <emph>(a Margarita)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Oh v'inganè. Per mi piutosto stassera, che doman.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Eh lo so el perché.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Disè mo.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Lo so, lo so, che no la me pol più véder.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Sentìu, che bella maniera de parlar? <emph>(a Marina)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Via, via, care creature, butè a monte<note place="foot" anchored="true"><p>Non parlate altro.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>La diga: cossa gh'àlo nome? <emph>(a Marina)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Felipeto.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Oh che bel nome! xèlo civil?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>El xè mio nevodo.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Oh sior'àmia<note place="foot" anchored="true"><p>Si replica, che <emph>àmia</emph> vuol dire zia.</p></note>! gh'ho tanto a caro, sior'àmia, sia
 benedeto sior'àmia <emph>(con allegria bacia Marina)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Vardè, che stomeghezzi<note place="foot" anchored="true"><p>Che sguaiataggini.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Cara siora, la tasa, che l'averà fato pezo de mi.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Certo, per quela bela zoggia, che m'ha toccà<note place="foot" anchored="true"><p>Intende ironicamente del suo cattivo marito.</p></note>
 </p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Dixè, fia mia. L'aveu mai visto? <emph>(a Lucietta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Oh povereta mi! quando? dove? Se qua no ghe vien mai
 un can, se no vago mai in nissun liogo.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Se lo vederè el ve piaserà.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Dasseno? Quando lo vederoggio?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Mi no so; siora Margarita saverà qualcossa.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Siora madre, quando lo vederoggio?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Sì, sì: «siora madre, quando lo vederoggio»! Co
 ghe preme, la se raccomanda. E po gnente gnente, la ranzigna
 la schizza<note place="foot" anchored="true"><p>Aggrinza il naso.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>La sa, che ghe vòi tanto ben.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Va' là, va' là mozzina.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>(Caspita! la gh'ha de la malizia tanta, che fa
 paura).</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>La diga, siora Marina. Xèlo fio de sior Maurizio?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Sì, fia mia, e el xè fio solo.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Gh'ho tanto da caro. La diga: saràlo rustego co fa
 so sior padre?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Oh che el xè tanto bon!</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Mo quando lo vederoggio?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Per dir la verità, gh'averave gusto, che ve
 vedessi, perché se pol anca dar, che élo no ve piasa a vu, o
 che vu no ghe piasè a élo?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Pussibile, che no ghe piasa?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Cossa credeu de esser, figurarse, la dea Venere?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>No credo de esser la dea Venere, ma no credo mo
 gnanca de esser l'orco.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>(Eh, la gh'ha i so catari).</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Sentì, siora Margarita, bisogna, che ve confida
 una cossa.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Mi possio sentir?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Sì, sentì anca vo. Parlando de sto negozio co
 siora Felice, la s'ha fato de maraveggia, che avanti de
@@ -4329,86 +4363,86 @@ serar el contrato sti puti no s'abbia da véder. La s'ha
 tolto éla l'impegno de farlo. Ancuo, come savè, la vien qua
 a disnar, e sentiremo cossa, che la dirà.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Pulito, pulito dasseno.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Se fa presto a dir «pulito pulito»! e se mio
 mario se n'incorze? Chi tol de mezzo, figurarse, altri che
 mi?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Oh, per cossa vorla, che el se n'incorza?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Àlo da vegnir in casa per el luminal<note place="foot" anchored="true"><p>Finestra a tetto per dar lume al soffitto.</p></note>?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Mi no so gnente. Cossa dìsela, siora Marina?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Sentì, ve parlo schieto. Mi no ghe posso dar torto
 gnanca a siora Margarita. Sentiremo quel, che dixe siora
 Felice. Se gh'è pericolo, gnanca mi no me ne voggio
 intrigar.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Vardè; le me mette in saor<note place="foot" anchored="true"><p>Mi mettono in sapore, cioè in lusinga.</p></note>, e po, tolè suso.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Zito, me par de sentir...</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Vien zente.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Uh, se xè sior padre, vago via.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Cossa gh'aveu paura? Omeni no ghe ne xè.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Oh, saveu chi xè?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Chi?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Siora Felice in maschera. In t'un'aria
 malignazonazza<note place="foot" anchored="true"><p>Grandissima.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Xèla sola?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Sola. Chi voressi, che ghe fusse, patrona? <emph>(a Lucietta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Via, siora madre, che la sia bona, che ghe vòi tanto
 ben <emph>(allegra)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Sentiremo qualcossa.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Sentiremo qualcossa <emph>(allegra)</emph>.</p>
           </sp>
@@ -4418,7 +4452,7 @@ ben <emph>(allegra)</emph>.</p>
           <stage>
             <emph>Felice in maschera in bavuta, e dette.</emph>
           </stage>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Patrone (<emph>tutte rispondono</emph>patrona<emph>secondo il solito</emph>).</p>
           </sp>
@@ -4426,232 +4460,232 @@ ben <emph>(allegra)</emph>.</p>
             <speaker>TUTTE</speaker>
             <p>Patrona.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Molto tardi, siora Felice; v'avè fato desiderar.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>De diana<note place="foot" anchored="true"><p>Lo stesso come se si dicesse: Per Bacco!</p></note> se l'avemo desiderada.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Se savessi! Ve conterò.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Sola sè? No gh'è gnanca vostro mario?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Oh, el ghe xè quel torso de verza<note place="foot" anchored="true"><p>Tronco di cavolo.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Dove xèlo?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>L'ho mandà in mezà da vostro mario. No ho volesto,
 che el vegna de qua, perché v'ho da parlar.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Oh se la gh'avesse qualche bona niova da darme!)</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Saveu chi ghe xè in mezzà con lori?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Mio mario?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Eh sì ben, ma ghe xè un altro.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Chi?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Sior Maurizio.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(El padre del puto!) <emph>(con allegria)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Come l'aveu savesto?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Mio mario, che anca élo xè un tangaro, avanti de
 andar in mezà, l'ha volesto saver chi ghe giera, e la serva
 gh'ha dito, che ghe giera sior Simon, e sior Maurizio.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Cossa mai fàli?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Mi credo, vedè, mi credo, che i stabilissa quel
 certo negozio...</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Eh sì, sì, ho capìo.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Gh'arivo anca mi.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Anca mi gh'arivo).</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>E de quel altro interesse gh'avémio gnente da
 novo?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>De quel amigo?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Sì, de quel amigo.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Le parla in zergo<note place="foot" anchored="true"><p>Parlano in gergo.</p></note>; le crede, che no capissa).</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Podémio parlar liberamente?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Sì, cossa serve? Za Lucieta sa tutto.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Oh cara siora Felice, se la savesse quanto che ghe
 son obbligada.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Mo andè là, fia mia, che sè fortunada <emph>(a Lucietta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Per cossa?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Mi no l'aveva mai visto quel puto. V'assicuro che
 el xè una zoggia.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p><emph>(si pavoneggia da sé)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Tegnìve in bon, patrona<note place="foot" anchored="true"><p>Insuperbite.</p></note> <emph>(a Lucietta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>No fazzo per dir, che el sia mio nevodo; ma el xè
 un puto de sesto<note place="foot" anchored="true"><p>Un giovine di garbo.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p><emph>(come sopra)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Ma ghe vol giudizio, figurarse, e bisogna farse
 voler ben <emph>(a Lucietta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Co saremo a quela<note place="foot" anchored="true"><p>Quando sarà nel caso.</p></note>, farè el mio debito.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>E cusì? se vederàli sti puti? <emph>(a Felice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Mi ho speranza de sì.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Come? quando, siora Felice? quando, come?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Puta benedeta, gh'avè più pressa de mi.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>No vorla?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Sentì. Adessadesso el vegnirà qua <emph>(piano a tutte tre)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Qua! <emph>(con maraviglia)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Siora sì, qua.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Perché no porlo vegnir qua? <emph>(a Margarita)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Tasè là, vu, siora, che no savè quel che ve disè.
 Cara siora Felice, lo cognossè mio mario, vardè ben, che no
 femo pezo<note place="foot" anchored="true"><p>Peggio.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>No v'indubitè gnente. El vegnirà in maschera,
 vestìo da donna; vostro mario nol cognosserà.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Sì ben, sì ben: l'avè pensada pulito.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Eh cara siora, mio mario xè sutilo<note place="foot" anchored="true"><p>Delicato.</p></note>; se el se ne
 incorze, figurarse, povereta mi.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>No séntela? el vegnirà in maschera <emph>(allegra a MArgarita)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Eh via, frasconazza <emph>(a Lucietta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>El vegnirà vestìo da donna <emph>(mortificata a Margarita)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Credème, siora Margarita, che me fè torto. Stè
 sora de mi, no abbiè paura. No pol far che el vegna<note place="foot" anchored="true"><p>Può star poco a venire.</p></note>. Se el
@@ -4661,110 +4695,110 @@ sia vostro mario, lassème far a mi. So mi quel che gh'ho da
 dir. I se vederà come che i poderà. Un'occhiadina in
 sbrisson<note place="foot" anchored="true"><p>Un'occhiata alla sfuggita.</p></note> no ve basta?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>In sbrisson? <emph>(a Felice pateticamente)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Vegniràlo solo?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>No, cara fia; solo nol pol vegnir. Vedè ben, in
 maschera, vestìo da donna...</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Con chi vegniràlo donca<note place="foot" anchored="true"><p>Dunque.</p></note>? <emph>(a Felice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Con un forestier <emph>(a Margarita)</emph>.
 Oe con quelo de stamatina <emph>(a Marina)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Ho capìo.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Figurarse, se mio mario vuol zente in casa, che nol
 cognosse!</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>El vegnirà in maschera anca élo.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Pezo: no, no assolutamente.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Mo via, cara siora madre, la trova dificoltà in
 tuto. (La xè proprio una caga dubi).</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>So quel che digo; e mio mario, figurarse, nissun lo
 cognosse meggio de mi.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Sentì, fia mia, dal vostro al mio, semo là. I xè
 tuti do taggiai in t'una luna. Mi mo, vedeu? no me lasso far
 tanta paura.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Brava, sarè più spiritosa de mi.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>I bate.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Eh che no i bate, no.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Poverazza, la gh'ha el bataor in tel cuor.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Vedè, cara siora Margarita, che mi in sto negozio
 no gh'ho né intrar, né insir<note place="foot" anchored="true"><p> Né entrata, né uscita, cioè non ci ho interesse veruno</p></note>. L'ho fato per siora Marina, e
 anca per sta puta, che ghe voggio ben. Ma se vu po ve n'avè
 per mal...</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Eh giusto! cossa dìsela?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Eh via za, che ghe semo <emph>(a Margarita)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Ben ben; se nasserà qualcossa sarà pezo per vu
 <emph>(a Lucietta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>No la sente? I bate ghe digo <emph>(a Margarita)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Adesso sì, ch'i ha batù.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Bisogna, che la dorma culìa. Anderò mi <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Siora no, siora no, anderò mi.</p>
           </sp>
@@ -4774,46 +4808,46 @@ per mal...</p>
           <stage>
             <emph>Felice, Marina, e Lucietta.</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Cara éla, me racomando <emph>(a Felice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>No vorave desgustar siora Margarita.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>No ghe badè. Se stasse a éla, sta puta no se
 mariderave mai.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Se la savesse!</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Cossa vol dir? cossa gh'àla co sta creatura? <emph>(a Marina)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>No saveu? invidia. Gh'ha toccà un mario vecchio,
 la gh'averà rabbia, che a so fiastra ghe tocca un zovene.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Ho paura de sì mi, che la diga la verità.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Ora la dise una cossa, ora la ghe ne dise
 un'altra.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Se ve digo; no gh'è né sesto, né modelo<note place="foot" anchored="true"><p>Lo stesso che dire né dritto, né rovescio.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>No la sa dir altro, che «figurarse, figurarse».</p>
           </sp>
@@ -4823,78 +4857,78 @@ un'altra.</p>
           <stage>
             <emph>Margarita, e dette.</emph>
           </stage>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>A vu, siora Felice.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>A mi? cossa?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Maschere, che ve domanda.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Mascare, che la domanda! <emph>(allegra a Felice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Saràlo l'amigo? <emph>(a Felice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Pol darse <emph>(a Marina)</emph>. Fèlo vegnir avanti <emph>(a Margarita)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>E se vien mio mario?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Se vien vostro mario, no ghe saverò dar da
 intender qualche panchiana? No ghe posso dir, che la xè mia
 sorela maridada a Milan? Giusto l'aspetava in sti zorni, e
 la pol capitar de momento in momento.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>E la maschera omo?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Oh bela! no ghe posso dir, che el xè mio cugnà<note place="foot" anchored="true"><p>Cognato.</p></note>?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>E vostro mario cossa diralo?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Mio mario, co voggio, che el diga de sì, basta,
 che lo varda; con un'occhiada el me intende.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Siora madre, ghe n'àla più?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Cossa?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Delle dificoltà?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Me faressi dir, deboto... orsù tanto fa, che le
 staga de là quele maschere come, che le vegna de qua. A
 l'ultima de le ultime, gh'averè da pensar vu più de mi <emph>(a Lucietta)</emph>.
 Siore maschere, le favorissa, le vegna avanti <emph>(alla scena)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Oh come, che me bate el cuor!)</p>
           </sp>
@@ -4905,317 +4939,317 @@ Siore maschere, le favorissa, le vegna avanti <emph>(alla scena)</emph>.</p>
             <emph>Felippetto, in maschera da donna, il conte Riccardo,
 e dette.</emph>
           </stage>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>Servitor umilissimo di lor signore.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Patrone, siore maschere.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Serva <emph>(sostenuta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Siora maschera donna, la reverisso <emph>(a Felippetto)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p><emph>(fa la riverenza da donna)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Vardè che bon sesto)<note place="foot" anchored="true"><p>Che bel garbo!</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Maschere, andeu a spasseti?</p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>Il carnovale desta l'animo ai divertimenti.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Siora Lucieta, cossa diseu de ste maschere?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Cossa vorla, che diga? <emph>(mostrando di vergognarsi)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>(Oh cara! oh che pometo da riosa!)<note place="foot" anchored="true"><p>Mela rosa.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Siore maschere, le perdona la mala creanza; àle
 disnà ele?</p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>Io no.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>In verità, voressimo andar a disnar.</p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>Vi leveremo l'incomodo.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>(De diana! no l'ho malistente<note place="foot" anchored="true"><p>Appena.</p></note> vardada!)</p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>Andiamo, signora maschera <emph>(a Felippetto)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>(Sia malignazo!)</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Eh aspetè un pochetin <emph>(a Riccardo, e a Felippetto)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>(Me lo sento in te le recchie quel satiro de mio
 mario).</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Maschera, sentì una parola <emph>(a Felippetto)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p><emph>(si accosta a Felice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Ve piàsela? <emph>(piano a Felippetto)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Siora sì <emph>(piano a Felice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Xèla bela?</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>De diana! <emph>(come sopra)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Siora madre).</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>(Cossa gh'è?)</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Almanco, che lo podesse véder un pochetin)
 <emph>(piano a Margarita)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>(Adessadesso, ve chiapo per un brazzo, e ve meno
 via).</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Pazzenzia).</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Maschera <emph>(a Felippetto)</emph>. Ve piàsela?</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p><emph>(s'accosta a Marina)</emph>.Assae.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Toleu tabacco, maschera? <emph>(a Felippetto)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Siora sì.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Se comandè, servìve.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p><emph>(prende il tabacco colle dita, e vuole pigliarlo colla maschera al volto)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Co se tol tabacco, se se cava el volto <emph>(gli leva la maschera)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Oh co belo!) <emph>(guardandolo furtivamente)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Mo che bela puta! <emph>(verso Felippetto)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>La xè mia sorela.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(I me fa da rider) <emph>(ridendo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>(Oh co la ride pulito!)</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Vegnì qua, tirève la bauta soto la gola <emph>(gli cala la bautta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(El consola el cuor).</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Chi xè più bela de ste do pute? <emph>(di Felippetto e Lucietta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p><emph>(fa lo stesso)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>(Sono obbligato alla signora Felice, che oggi mi ha
 fatto godere la più bella commedia di questo mondo).</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Oh via, fenìmola, figurarse, che xè ora. No parlemo
 più in equivoco. Ringraziè ste signore, che ha fato sto
 contrabando, e racomandève al Cielo, che se sarè destinai,
 ve torè<note place="foot" anchored="true"><p>Se sarete destinati, vi sposerete.</p></note> <emph>(a Lucietta e Felippetto)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Via andè, maschere; contentève cusì per adesso.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>(Mi no me so destaccar).</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(El me porta via el cuor).</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Manco mal, che la xè andada ben.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Tirève su la bauta <emph>(a Felippetto)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Come se fa? No gh'ho pratica.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Vegnì qua da mi <emph>(gli accomoda la bautta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Poverazzo! nol se sa giustar la bauta) <emph>(ridendo forte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Me bùrlela? <emph>(a Lucietta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Mi no <emph>(ridendo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Furba!</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Caro colù)<note place="foot" anchored="true"><p>Colui.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Oh povereta mi! oh povereta mi!</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Coss'è stà.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Ve' qua mio mario.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Sì per diana: anca el mio.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>No xèla mia sorela?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Eh cara ela, se el me trova in busia, povereta mi.
 Presto, presto, scondève, andè in quela camera <emph>(a Felippetto, spingendolo)</emph>. Caro sior la vaga là drento <emph>(a Riccardo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>Che imbroglio è questo?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>La vaga, la vaga, sior Ricardo. La ne fazza sta
 grazia.</p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>Farò anche questo per compiacervi <emph>(entra in una camera)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>(Spionerò intanto) <emph>(entra in una camera)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Me trema le gambe, che no posso più).</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Ve l'òggio dito? <emph>(a Felice, e Marina)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Via via, no xè gnente <emph>(a Margarita)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Co anderemo a disnar i se la baterà<note place="foot" anchored="true"><p>Se ne andranno.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Son stada tropo minchiona.</p>
           </sp>
@@ -5225,195 +5259,195 @@ grazia.</p>
           <stage>
             <emph>Lunardo, Simon, Canciano, e dette.</emph>
           </stage>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Oh patrone, xèle stuffe d'aspetar? Adessadesso
 anderemo a disnar. Aspetemo sior Maurizio, e subito che el
 vien, andemo a disnar.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>No ghe gièrelo sior Maurizio?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>El ghe giera. El xè andà in t'un servizio, e el
 tornerà adessadesso. Cossa gh'àstu ti, che ti me par
 sbattueta<note place="foot" anchored="true"><p>Di malavoglia.</p></note>? <emph>(a Lucietta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Gnente. Vorlo che vaga via?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>No no, sta qua, fia mia, che anca per ti xè vegnù la
 to zornada: n'è vero, sior Simon?</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Poverazza! gh'ho a caro.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Ah! cossa diseu? <emph>(a Cancian)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Sì, in verità, la lo merita.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(No me vol andar via sto tremazzo)<note place="foot" anchored="true"><p>Tremore.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Gh'è qualche novità, sior Lunardo?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Siora sì.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Via, che sapiemo anca nu.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Za mi sarò l'ultima a saverlo <emph>(a Lunardo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Sentì, fia, ancuo disè quel che volè, che no gh'ho
 voggia de criar. Son contento, e voggio che se godemo.
 Lucieta vien qua.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p><emph>(si accosta tremando)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Cossa gh'àstu?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>No so gnanca mi <emph>(tremando)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Gh'àstu la freve<note place="foot" anchored="true"><p>Febbre.</p></note>? Ascolta, che la te passerà. In
 presenza de mia muggier, che te fa da mare; in presenza de
 sti do galantomeni, e delle so parone, te dago la niova, che
 ti xè novizza.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p><emph>(trema, piange, e quasi casca)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Olà, olà, cossa fastu? Te despiase, che
 t'abbia fato novizza?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Sior no.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Sastu chi xè el to novizzo?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Sior sì.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Ti lo sa? come lo sastu? chi te l'ha dito? <emph>(sdegnato)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Sior no, no so gnente. La compatissa, che no so
 gnanca cossa che diga.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Ah! povera inocente! così la xè arlevada, vedeu?
 <emph>(a Simon, e Cancian)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>(Se el savesse tuto) <emph>(piano a Margarita)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>(M'inspirito<note place="foot" anchored="true"><p>Tremo, ho paura.</p></note> che el lo sapia) <emph>(a Felice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>(No gh'è pericolo) <emph>(a Margarita)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Orsù sapiè che el so novizzo xè el fio de sior
 Maurizio, nevodo de siora Marina.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Dasseno? mio nevodo?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Oh cossa che ne contè!</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Mo gh'ho ben a caro, dasseno.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>De meggio no podevi trovar.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Quando se faràle ste nozze?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Ancuo.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Ancuo?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Sior sì, ancuo, adessadesso. Sior Maurizio xè andà a
 casa; el xè andà a levar<note place="foot" anchored="true"><p>A prendere.</p></note> so fio, el lo mena qua, disnemo
 insieme, e po subito i se dà la man<note place="foot" anchored="true"><p>Si sposano.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>(Oh povereta mi!)</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Cusì a la presta?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Mi no voggio brui longhi<note place="foot" anchored="true"><p>Brodi lunghi.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Adesso me trema anca le buele)<note place="foot" anchored="true"><p>Le budella.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Cossa gh'àstu? <emph>(a Lucietta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Gnente.</p>
           </sp>
@@ -5423,27 +5457,27 @@ insieme, e po subito i se dà la man<note place="foot" anchored="true"><p>Si spo
           <stage>
             <emph>Maurizio, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Oh via; seu qua? <emph>(a Maurizio)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Son qua <emph>(turbato)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Cossa gh'aveu?</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Son fora de mi.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Coss'è stà?</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Son andà a casa, ho cercà el puto. No l'ho trovà in
 nissun liogo. Ho domandà, me son informà, me xè stà dito,
@@ -5451,12 +5485,12 @@ che l'è stà visto in compagnia de un certo sior Riccardo,
 che pratica siora Felice. Chi èlo sto sior Riccardo? Chi èlo
 sto forestier? cossa gh'ìntrelo con mio fio? <emph>(a Felice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Mi de vostro fio no so gnente. Ma circa al
 forestier el xè un cavalier onorato. N'è vero, sior Cancian?</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Mi no so gnente chi el sia, e no so chi diavolo
 l'abia mandà. Ho tasesto fin adesso, ho mandà zo dei boconi
@@ -5470,157 +5504,157 @@ pele<note place="foot" anchored="true"><p>Un ingaggiator di soldati. - Era un me
           <stage>
             <emph>Riccardo, e detti; poi Felippetto.</emph>
           </stage>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>Parlate meglio dei cavalieri d'onore <emph>(a Canciano)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>In casa mia? <emph>(a Riccardo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Dove xè mio fio? <emph>(a Riccardo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>Vostro figlio è là dentro <emph>(a Maurizio)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Sconto in camera?</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Dov'èstu, desgrazià?</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Ah sior padre, per carità <emph>(s'inginocchia)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Ah sior padre, per misericordia <emph>(s'inginocchia)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Mario, no so gnente, mario <emph>(raccomandandosi)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Ti, ti me la pagherà, desgraziada <emph>(vuol dare a Margarita)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Agiuto.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Tegnìlo.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Fermèlo.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMONE</speaker>
             <p>Stè saldo.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>No fè <emph>(Simon, e Canciano strascinano dentro Lunardo, e partono in tre)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Vien qua, vien qua, furbazzo <emph>(piglia per un braccio Felippetto)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Vegnì qua, frasconazza <emph>(piglia per un braccio Lucietta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Andemo <emph>(lo tira)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Vegnì via con mi <emph>(la tira)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>A casa la giustaremo <emph>(a Felippetto)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Per causa vostra <emph>(a Lucietta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p><emph>(andando via saluta Lucietta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p><emph>(andando via, si dà de' pugni)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Povereta!</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Son desperada.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Va' via de qua <emph>(lo caccia via, e partono)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Sia maledeto co son vegnua in sta casa <emph>(parte spingendo Lucietta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Oh che sussuro, o che diavolezzo! Povera puta,
 povero mio nevodo! <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>In che impiccio mi avete messo, signora?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Xèlo cavalier?</p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>Perché mi fate questa dimanda?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Xèlo cavalier?</p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>Tale esser mi vanto.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Donca, che el vegna con mi.</p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>A qual fine?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Son una donna onorata. Ho falà, e ghe vòi
 remediar.</p>
           </sp>
-          <sp>
+          <sp who="#riccardo">
             <speaker>RICCARDO</speaker>
             <p>Ma come?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Come, come! seghe digo el come, xè fenìa la
 commedia. Andemo <emph>(partono)</emph>.</p>
@@ -5635,64 +5669,64 @@ commedia. Andemo <emph>(partono)</emph>.</p>
           <stage>
             <emph>Lunardo, Canciano, e Simon.</emph>
           </stage>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Se trata de onor, se trata, vegnimo a dir el merito,
 de reputazion de casa mia. Un omo della mia sorte. Cossa
 dirài de mi? cossa dirài de Lunardo Cròzzola?</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Quietève, caro compare. Vu no ghe n'avè colpa. Xè
 causa le donne; castighèle<note place="foot" anchored="true"><p>Castigatele.</p></note>, e tuto el mondo ve loderà.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Sì ben, bisogna dar un esempio. Bisogna umiliar la
 superbia de ste muggier cusì altiere, e insegnar ai omei a
 castigarle.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>E che i diga pur, che semo rusteghi.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>E che i diga pur, che semo salvadeghi.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Mia muggier xè causa de tuto.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Castighèla.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>E quela frasconazza, la ghe tien drio.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Mortifichèla.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>E vostra muggier ghe tien terzo <emph>(a Cancian)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>La castigherò.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>E la vostra sarà d'accordo <emph>(a Simon)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Anca la mia me la pagherà.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Cari amici, parlemo, consegiemose. Con custìe<note place="foot" anchored="true"><p>Costoro.</p></note>,
 vegnimo a dir el merito, cossa avémio da far? Per la puta xè
@@ -5702,17 +5736,17 @@ manderò a serar in t'un liogo<note place="foot" anchored="true"><p>Loco.</p></n
 muri, e la xè fenìa. Ma le muggier come le avémio da
 castigar? Disè la vostra opinion.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Veramente, confesso el vero; son un pochetin
 intrigà.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Se poderave ficcarle<note place="foot" anchored="true"><p>Metterle per forza.</p></note> anca ele in t'un retiro tra
 quatro muri, e destrigarse cussì.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Questo, vegnimo a dir el merito, sarave un castigo
 più per nu, che per ele. Bisogna spender; pagar le spese,
@@ -5720,160 +5754,160 @@ mandarle vestìe con un pocheto de pulizia, e per retirae che
 le staga, le gh'averà sempre là drento più spasso, e più
 libertà, che no le gh'ha in casa nostra. Pàrlio ben<note place="foot" anchored="true"><p>Parlo bene?</p></note>? <emph>(a Simon)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Disè benissimo. Specialmente da vu, e da mi, che no
 ghe lassemo la brena<note place="foot" anchored="true"><p>La briglia.</p></note> sul colo come mio compare Cancian.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Cossa voleu, che diga? gh'avè rason. Poderessimo
 tegnirle in casa, serae in t'una camera; menarle un pochetin
 a la festa con nu, e po tornarle a serar, e che no le
 vedesse nissun, e che no le parlasse a nissun.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Le donne serae? senza parlar con nissun? Questo xè
 un castigo, che le fa crepar in tre dì.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Tanto meggio.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Ma chi è quel omo, che voggia far l'aguzin? e po se
 i parenti lo sa, i fa el diavolo, i mete soto mezzo mondo, i
 ve la fa tirar fora, e po ancora i ve dise, che sè un orso,
 che sè un tangaro, che sè un can.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>E co avè molà<note place="foot" anchored="true"><p>E quando avete ceduto.</p></note>, o per amor, o per impegno, le ve tol
 la man, e no sé più paron de criarghe.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Giusto cusì ha fato con mi mia muggier.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>La vera saria, vegnimo a dir el merito, doperar un
 pezzo de legno.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Sì, da galantomo, e lassar, che la zente diga<note place="foot" anchored="true"><p>Lasciar che la gente dica quel che sa dire.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>E se le se revolta contra de nu?</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Se poderave dar, savè<note place="foot" anchored="true"><p>Sapete.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Mi so quel, che digo.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>In sto caso, se troveressimo in t'un bruto cimento.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>E po? no saveu? Ghe ne xè dei omeni, che bastona le
 so muggier, ma credeu, che gnanca per questo i le possa
 domar? Oibò<note place="foot" anchored="true"><p>Messer no.</p></note>; le fa pezo<note place="foot" anchored="true"><p>Peggio.</p></note>, che mai; le lo fa per despeto; se
 no i le copa, no gh'è remedio.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Coparle po no.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Mo no, certo; perché po, vòltela, ménela<note place="foot" anchored="true"><p>Volta, rivolta.</p></note>, senza
 donne no se pol star.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Mo no saràvela una contentezza, aver una muggier
 bona, quieta, ubidiente? No saràvela una consolazion?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Mi l'ho provada una volta. La mia prima, povereta,
 la giera un agnelo. Questa? la xè un basilisco.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>E la mia? Tuto a so modo la vol.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>E mi crio, strepito, e no fazzo gnente.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Tuto xè mal, ma un mal, che se pol soportar; ma in
 tel caso, che son mi adesso, vegnimo a dir el merito, se
 trata de assae. Voria ressolver, e no so quala far.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Mandèla dai so parenti.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Certo! acciò, che la me fazza smatar<note place="foot" anchored="true"><p>Svergognare, deridere.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Mandèla fora<note place="foot" anchored="true"><p>S'intende in villa.</p></note>. Fèla star in campagna.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Pezo! la me consuma le intrae<note place="foot" anchored="true"><p>Le entrate.</p></note> in quatro zorni.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Faghe parlar; trovè qualchedun che la meta in
 dover.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Eh! no l'ascolta nissun.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Provè a serarghe i abiti, a serarghe le zoggie,
 tegnìla bassa; mortifichèla.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Ho provà; se fa pezo, che mai.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Ho capìo; fè cusì, compare.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Come?</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Godèvela, come, che la xè.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Ho pensier anca mi, che no ghe sia altro remedio,
 che questo.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Sì, l'ho capìa, che xè un pezzo. Vedo anca mi, che,
 co l'è fata no ghe xè più remedio. M'aveva comodà el mio
@@ -5890,15 +5924,15 @@ colomba inocente? No me tegno; la vòi castigar, la vòi
 mortificar, se credesse, vegnimo a dir el merito, de
 precipitar.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Causa siora Felice.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Sì, causa quella mata de vostra muggier <emph>(a Cancian)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Gh'avè rason. Mia muggier me la pagherà.</p>
           </sp>
@@ -5908,108 +5942,108 @@ precipitar.</p>
           <stage>
             <emph>Felice, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Patroni reveriti, grazie del so bon amor.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Cossa feu qua?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Cossa vorla in casa mia?</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Xèla qua, per far che nassa qualche altra bela
 scena?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>I se stupisse perché son qua? Voléveli che fusse
 andada via? Credévelo sior Cancian, che fusse andada col
 forestier?</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Se anderè più con colù, ve farò véder chi son.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Disème, caro vecchio, ghe songio mai andada senza
 de vu?</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>La sarave bela!</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Senza de vu, l'òggio<note place="foot" anchored="true"><p>L'ho.</p></note> mai recevesto in casa?</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Ghe mancarave anca questa!</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>E perché donca credevi, che fusse andada con élo?</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Perché sè una mata.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>(El fa el bravo, perché el xè in compagnia).</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>(Oe la gh'ha filo)<note place="foot" anchored="true"><p>Ha timore.</p></note> <emph>(piano a Lunardo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>(El fa ben a mostrarghe el muso) <emph>(piano a Simon)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Andémo, siora, vegnì a casa con mi.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Abiè un pocheto de flema.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Me maraveggio, che gh'abiè tanto muso de vegnir
 qua.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Per cossa? cossa òggio fato?</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>No me fè parlar.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Parlè.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Andémo via.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Sior no.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Andémo, che cospeto de diana... <emph>(minacciandola)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Cospeto, cospeto... so cospetizar anca mi. Coss'è,
 sior? M'aveu trovà in t'un gatolo<note place="foot" anchored="true"><p>Quasi tutte le strade di Venezia hanno de' piccioli canaletti lateralmente, dove si uniscono le immondizie, e per dove scorre e si perde l'acqua piovana, e si chiamano <emph>gattoli</emph>.</p></note>? Songio la vostra massèra?
@@ -6027,41 +6061,41 @@ manazza, e no se dise cospetto, e no se tratta cusì. M'aveu
 capìo, sior Cancian? Abiè giudizio vu, se volè, che ghe
 n'abbia anca mi.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p><emph>(resta ammutolito)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>(Aveu sentìo che raccola<note place="foot" anchored="true"><p>Che bagatella?</p></note>?) <emph>(a Lunardo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>(Adessadesso me vien voggia, de chiaparla mi per el
 colo. E quel martuffo<note place="foot" anchored="true"><p>Sciocco.</p></note> sta zito) <emph>(a Simon)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>(Cossa voleu, che el fazza? Voleu che el
 precipita?)</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Via, sior Cancian, no la dise gnente?</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Chi ha più giudizio el dopera<note place="foot" anchored="true"><p>Lo adoperi.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Sentenza de Ciceron! Cossa dìsele ele, patroni?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Cara siora, no me fè parlar.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Perché? son vegnua a posta, acciò, che parlè; so
 che ve lamentè de mi, e gh'ho gusto de sentir le vostre
@@ -6077,85 +6111,85 @@ da diavolo co<note place="foot" anchored="true"><p>Quando.</p></note> bisogna. P
 schieto, perché me capì. Son una donna d'onor, e se gh'avè
 qualcossa, parlè.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Disème, cara siora, chi è stà, che ha fato vegnir
 quel puto in casa mia?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Son stada mi. Mi son stada, che l'ha fato vegnir.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Brava, siora!</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Pulito!</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Lodève, che avè fato una bel'azion!</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Mi no me lodo; so che giera meggio che no l'avesse
 fato; ma no la xè una cativa azion.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Chi v'ha dà licenza, che lo fè vegnir?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Vostra muggier.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Mia muggier? v'àla parlà? v'àla pregà? xèla vegnua
 éla a dirvelo, che lo menè<note place="foot" anchored="true"><p>Che lo conduciate.</p></note>?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Sior no; me l'ha dito siora Marina.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Mia muggier?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Vostra muggier.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Ala pregà éla el forestier, che tegnisse terzo<note place="foot" anchored="true"><p>Che tenesse mano.</p></note> a
 quela pura?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Sior no, el forestier l'ho pregà mi.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Vu l'avè pregà? <emph>(con isdegno)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Sior sì, mi <emph>(a Canciano con isdegno)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>(Oh che bestia! no se pol parlar!)</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Mo perché far sta cossa? mo perché menarlo? mo
 perché siora Marina se n'àla intrigà? mo perché mia muggier
 s'àla contentà?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Mo perché questo, mo perché st'altro! Ascoltème;
 sentì l'istoria come che la xè. Lassème dir; no me
@@ -6193,31 +6227,31 @@ fenito la renga; laudè el matrimonio, e compatì l'avocato<note place="foot" an
 <emph>(Lunardo,Simon, e Cancian si guardano l'un l'altro senza parlare)</emph>.
 (I ho messi in sacco, ma con rason).</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Cossa diseu, sior Simon?</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Mi, se stasse a mi, lauderave<note place="foot" anchored="true"><p>Approverei.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Gnanca mi no ghe vago in tel verde<note place="foot" anchored="true"><p>L'urna verde è quella dei voti contrari.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>E pur ho paura, che bisognerà che taggiemo<note place="foot" anchored="true"><p>Temo che si dovrà revocare.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Per cossa?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Perché el padre del puto, vegnimo a dir el merito...</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>«Vegnimo a dir el merito», al padre del puto xè
 andà a parlarghe sior Conte, el xè in impegno, che se fazza
@@ -6227,47 +6261,47 @@ sta sodisfazion; el xè un omo de garbo; el xè un omo che
 parla ben, e son segura, che sior Maurizio no saverà dir de
 no.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Cossa avémio da far?</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Caro amigo, de tante, che ghe ne avemo pensà, no
 ghe xè la meggio de questa. Tòr le cosse come che le vien.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>E l'affronto?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Che affronto? co el xè mario xè<note place="foot" anchored="true"><p>Marito.</p></note> fenìo l'affronto.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Sentì, sior Lunardo; siora Felice gh'ha anca éla le
 so debolezze, ma per dir la verità, qualche volta la xè una
 donna de garbo.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>N'è vero sior Cancian?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Mo via, cossa avémio da far?</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Prima de tuto, mi dirave de andar a disnar.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Per dirla, pareva, che el disnar s'avesse
 desmentegà<note place="foot" anchored="true"><p>Si fosse scordato.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Eh chi l'ha ordenà no xè alocco<note place="foot" anchored="true"><p>Qui l'autore parla di sé stesso, che non si scorda ciò di cui ha parlato.</p></note>. El l'ha sospeso,
 ma nol xè andà in fumo. Fè cusì, sior Lunardo, se volè, che
@@ -6276,24 +6310,24 @@ disèghe qualche cossa, brontolè al solito un pochetin, ma po
 fenìmola; aspetemo che vegna sior Riccardo, e se vien el
 puto, fenìmola.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Se vien qua mia muggier, e mia fia, ho paura de no
 poderme tegnir.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Via, sfoghève, gh'avè rason. Seu contento cussì?</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Chiamémole.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Anca mia muggier.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Mi, mi: aspettè mi <emph>(parte correndo)</emph>.</p>
           </sp>
@@ -6303,23 +6337,23 @@ poderme tegnir.</p>
           <stage>
             <emph>Lunardo, Canciano, e Simon.</emph>
           </stage>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Una gran chiaccola gh'ha quela vostra muggier.
 <emph>(a Canciano)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Vedeu! no me disè donca, che son un martuffo, se
 qualche volta me lasso menar per el naso. Se digo qualcossa,
 la me fa una <emph>renga</emph>, e mi <emph>laudo</emph><note place="foot" anchored="true"><p>Mi fa un'aringa, ed io approvo.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Gran donne! o per un verso, o per l'altro le la vol
 a so modo seguro.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Co le lassè parlar, no le gh'ha mai torto.</p>
           </sp>
@@ -6329,190 +6363,190 @@ a so modo seguro.</p>
           <stage>
             <emph>Felice, Marina, Margarita, Lucietta, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Vèle qua, velè qua. Pentie, contrite, e le ve
 domanda perdon <emph>(a Lunardo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Se me fa anca de queste? <emph>(a Margarita)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>No la ghe n'ha colpa, son causa mi <emph>(a Lunardo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Cossa meriteressistu, frasconcela! <emph>(a Lucietta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Parlè con mi, ve responderò mi <emph>(a Lunardo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>I omeni in casa? i morosi sconti?
 <emph>(a Margarita, e Lucietta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Criè co mi, che son causa mi <emph>(a Lunardo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Andève a far squartar anca vu <emph>(a Felice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>«Vegnimo a dir el merito...» <emph>(a Lunardo deridendolo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Come parleu co mia muggier? <emph>(a Lunardo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Caro vu, compatìme. Son fora de mi <emph>(a Cancian)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p><emph>(mortificata)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p><emph>(piange)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Siora Felice. Cossa n'aveu dito? Cusì pulito la xè
 giustada?</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Anca vu siora meriteressi la vostra parte <emph>(a Marina)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Mi chiapo su<note place="foot" anchored="true"><p><emph>Chiapo</emph> vuol dire prendo: qui s'intende risolvo sul momento, e vado via.</p></note>, e vago via.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>No, no, fermève. Al povero sior Lunardo ghe giera
 restà in corpo un poco de còlera: l'ha volesto butarla fora<note place="foot" anchored="true"><p>Gettarla fuori.</p></note>.
 Da resto el ve scusa, el ve perdona; e se vien el puto, el
 se contenterà, che i se sposa; n'è vero, sior Lunardo?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Siora sì, siora sì <emph>(ruvido)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Caro mario, se savessi quanta passion, che ho
 provà! Credèmelo no saveva gnente. Co xè vegnù quele
 maschere, no voleva lassarle vegnir. Xè stà... xè stà...</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Via son stada mi, cossa ocore?</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>(Disèghe anca vu qualcossa) <emph>(piano a Lucietta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Caro sior padre, ghe domando perdonanza. Mi no ghe
 n'ho colpa...</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Son stada mi, ve digo, son stada mi.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Per dir la verità, gh'ho anca mi la mia parte de
 merito.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Eh savemo, che sè una signora de spirito
 <emph>(a Marina con ironia)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Più de vu, certo.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Chi xè? <emph>(osservando fra le scene)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Oe, i xè lori<note place="foot" anchored="true"><p>Ehi, sono dessi.</p></note> <emph>(a Felice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(El mio novizzo) <emph>(da sé allegra)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Coss'è? chi xè? chi vien? Omeni? Andè via de
 qua <emph>(alle donne)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Vardè! cossa femio? Aveu paura, che i omeni ne
 magna? No semio in quarto? no ghe seu vu? Lassè, che i
 vegna.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Comandeu vu, patrona?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Comando mi.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Quel forestier no lo voggio. Se el vegnirà élo,
 anderò via mi.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Mo perché nol voleu? El xè un signor onorato.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Che el sia quel, che el vol, no lo voggio. Mia
 muggier, e mia fia no le xè use a véder nissun.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Eh per sta volta le gh'averà pazenzia, n'è vero
 fie?</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Oh mi sì.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Oh anca mi.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Mi sì, anca mi <emph>(burlandole)</emph>. Ve digo,
 che no lo voggio <emph>(a Felice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>(Mo che orso, mo che satiro!) Aspettè aspettè che
 lo farò star in drio<note place="foot" anchored="true"><p>Indietro.</p></note> <emph>(si accosta alla scena)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Eh no m'importa. Me basta uno che vegna).</p>
           </sp>
@@ -6522,55 +6556,55 @@ lo farò star in drio<note place="foot" anchored="true"><p>Indietro.</p></note> 
           <stage>
             <emph>Maurizio, Felippetto, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Patroni <emph>(sostenuto)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Siora <emph>(brusco)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p><emph>(saluta furtivamente Lucietta. Maurizio lo guarda. Felippetto finge, che non sia niente)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Sior Maurizio, aveu savesto come che la xè stada?</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Mi adesso no penso a quel, che xè stà, penso a
 quel, che ha da esser per l'avegnir. Cossa dise sior
 Lunardo?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Mi digo cusì, vegnimo a dir el merito, che i fioi,
 co i xè ben arlevai no i va in maschera, e no i va in casa,
 vegnimo a dir el merito, delle pute civil.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Gh'avè rason: andémo via de qua <emph>(a Felippetto)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>
               <emph>(piange forte)</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Desgraziada! cosa xè sto fifar<note place="foot" anchored="true"><p>Pianger, detto bassamente.</p></note>?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Mo ve digo ben la verità, sior Lunardo, «vegnimo
 a dir el merito», che la xè una vergogna. Seu omo, o seu
 putelo? Disè, desdisè, ve mutè<note place="foot" anchored="true"><p>Vi cambiate.</p></note> co fa le zirandole<note place="foot" anchored="true"><p>Ruotelle di fuochi artificiali, ed anco giocolini da bambini, che girano coll'agitazione dell'aria.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>Vardè che sesti! No ghe l'aveu promessa? no aveu
 serà el contrato? Cossa xè stà? cossa xè successo? Ve l'àlo
@@ -6578,7 +6612,7 @@ menada via? v'àlo fato disonor a la casa? Coss'è sti
 purelezzi? cossa xè ste smorfie? cossa xè sti musoni? <emph>(a Lunardo)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Ghe voggio mo intrar anca mi in sto negozio. Sior
 sì, m'ha despiasso, che el vegna: l'ha fato mal a vegnir; ma
@@ -6586,30 +6620,30 @@ col gh'ha dà la man no xè fenìo tuto? Fina a un certo segno
 me l'ho lassada passar, ma adesso mo ve digo, sior sì, el
 l'ha da tòr, el l'ha da sposar <emph>(a Lunardo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Che el la toga, che el la sposa, che el se destriga:
 son stuffo; no posso più.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Co sta rabbia i s'ha da sposar? <emph>(a Lunardo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Se el xè inrabià, so danno. Nol l'ha miga da
 sposar élo.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Via, sior Lunardo, voleu, che i se daga la man?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Aspetè un pochetin. Lassè, che me daga zoso la
 còlera.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Via, caro mario, ve compatisso. Conosso el vostro
 temperamento; sè un galantomo, sè amoroso, sè de bon cuor;
@@ -6625,233 +6659,233 @@ reputazion della casa, e se mi no merito el vostro amor,
 pazenzia, sarà de mi quel, che destinerà mio mario, la mia
 sorte, o la mia cativa desgrazia <emph>(a Lunardo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Cara siora madre, sìela benedeta, ghe domando perdon
 anca a éla de quel, che gh'ho dito, e de quel che gh'ho
 fato <emph>(piangendo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>(La me fa da pianzer anca mi).</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p><emph>(si asciuga gli occhi)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Vedeu, sior Lunardo? Co le fa cusì no se se pol
 tegnir <emph>(a Lunardo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>In suma<note place="foot" anchored="true"><p>Insomma.</p></note>, co le bone, o co le cative le fa tuto
 quel, che le vol.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>E cusì, sior Lunardo?...</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Aspetè <emph>(con isdegno)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>(Mo che zoggia!)</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Lucieta <emph>(amorosamente)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Sior.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Vien qua.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Vegno <emph>(si accosta bel bello)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Te vustu maridar?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p><emph>(si vergogna, e non risponde)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Via, respondi, te vustu maridar? <emph>(con isdegno)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Sior sì, sior sì <emph>(forte, tremando)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Ti l'ha visto ah el novizzo?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Sior sì.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Sior Maurizio.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Cossa gh'è? <emph>(ruvido)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Via, caro vecchio, no me respondè, vegnimo a dir el
 merito, cusì rustego.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Disè pur su quel, che volevi dir.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Se no gh'avè gnente in contrario, mia fia xè per
 vostro fio <emph>(i due sposi si rallegrano)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Sto baron no lo merita.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Sior padre... <emph>(in aria di raccomandarsi)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Farme un'azion de sta sorte? <emph>(senza guardar Felippetto)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Sior padre... <emph>(come sopra)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>No lo vòi maridar.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Oh povereto mi <emph>(traballando mezzo svenuto)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Tegnìlo, tegnìlo<note place="foot" anchored="true"><p>Tenetelo, sostenetelo.</p></note>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Mo via, che cuor gh'aveu<note place="foot" anchored="true"><p>Che cuore avete?</p></note>? <emph>(a Maurizio)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>El fa ben a mortificarlo.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Vien qua <emph>(a Felippetto)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Son qua.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Xèstu pentìo de quel che ti ha fato?</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Sior sì, dasseno, sior padre.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Varda ben, che anca se ti te maridi, voggio che ti
 me usi l'istessa ubbidienza, e che ti dipendi da mi.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Sior sì, ghe lo prometo.</p>
           </sp>
-          <sp>
+          <sp who="#maurizio">
             <speaker>MAURIZIO</speaker>
             <p>Varda qua, siora Lucieta, ve acceto per fia; e ti,
 el Cielo te benedissa; dàghe la man.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Come sa fa? <emph>(a Simon)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Via, dèghe la man; cusì.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>(Poverazzo!)<note place="foot" anchored="true"><p>In Venezia quelli che servono da testimonio nei matrimoni, si chiamano compari dell'anello.</p></note>
 </p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p><emph>(si asciuga gli occhi)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Sior Simon, sior Cancian, sarè vu i
 compari.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Siora sì semo qua, semo testimoni.</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>E co la gh'averà un putelo?</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p><emph>(ride, e salta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p><emph>(si vergogna)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>O via, puti, stè aliegri. Xè ora, che andémo a
 disnar.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Disè; caro sior Lunardo, quel forestier che per
 amor mio xè de là che aspeta, ve par convenienza de mandarlo
 via? El xè stà a parlar co sior Maurizio, el l'ha fato
 vegnir qua élo. La civiltà non insegna a tratar cusì.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Adesso andémo a disnar.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Invidèlo anca élo.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Siora no.</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>Vedeu? sta rusteghezza, sto salvadegume che gh'avè
 intorno xè stà causa de tuti i desordeni, che xè nati ancuo<note place="foot" anchored="true"><p>Oggi.</p></note>,
@@ -6868,54 +6902,54 @@ bon. In soma, se volè viver quieti, se volè star in bona co
 le muggier, fè da omeni, ma no da salvadeghi, comandè, no
 tiraneggiè, e amè, se volè esser amai.</p>
           </sp>
-          <sp>
+          <sp who="#canciano">
             <speaker>CANCIANO</speaker>
             <p>Bisogna po dirla; gran mia muggier!</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Seu persuaso, sior Lunardo?</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>E vu?</p>
           </sp>
-          <sp>
+          <sp who="#simon">
             <speaker>SIMON</speaker>
             <p>Mi sì.</p>
           </sp>
-          <sp>
+          <sp who="#lunardo">
             <speaker>LUNARDO</speaker>
             <p>Disèghe a quel sior forestier, che el resta a disnar
 con nu <emph>(a Margarita)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Manco mal. Vogia el Cielo, che sta lizion abia
 profità.</p>
           </sp>
-          <sp>
+          <sp who="#marina">
             <speaker>MARINA</speaker>
             <p>E vu, nevodo, come la tratereu la vostra novizza?
 <emph>(a Felippetto)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#felippetto">
             <speaker>FELIPPETTO</speaker>
             <p>Cusì; su l'ordene, che ha dito siora Felice.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Oh, mi me contento de tuto.</p>
           </sp>
-          <sp>
+          <sp who="#margarita">
             <speaker>MARGARITA</speaker>
             <p>Ghe despiase solamente co le cascate xè fiape.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Mo via no la m'ha gnancora perdonà?</p>
           </sp>
-          <sp>
+          <sp who="#felice">
             <speaker>FELICE</speaker>
             <p>A monte tuto. Andemo a disnar, che xè ora. E se el
 cuogo de sior Lunardo non ha provisto salvadeghi, a tola<note place="foot" anchored="true"><p>A tavola.</p></note> no

--- a/tei/goldoni-il-campiello.xml
+++ b/tei/goldoni-il-campiello.xml
@@ -83,6 +83,43 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="zorzetto">
+            <persName>Zorzetto</persName>
+          </person>
+          <person xml:id="lucietta">
+            <persName>Lucietta</persName>
+          </person>
+          <person xml:id="gnese">
+            <persName>Gnese</persName>
+          </person>
+          <person xml:id="orsola">
+            <persName>Orsola</persName>
+          </person>
+          <person xml:id="gasparina">
+            <persName>Gasparina</persName>
+          </person>
+          <person xml:id="pasqua">
+            <persName>Donna Pasqua Polegana</persName>
+          </person>
+          <person xml:id="catte">
+            <persName>Donna Catte Panchiana</persName>
+          </person>
+          <person xml:id="cavaliere">
+            <persName>Il Cavaliere Fabrizio</persName>
+          </person>
+          <person xml:id="sansuga">
+            <persName>Sansuga</persName>
+          </person>
+          <person xml:id="anzoletto">
+            <persName>Anzoletto</persName>
+          </person>
+          <person xml:id="fabrizio">
+            <persName>Il Cavaliere Fabrizio</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -252,36 +289,16 @@ la Commedia presente ordinata.</p>
       </prologue>
       <castList>
         <head>Personaggi</head>
-        <castItem type="role">
-          <role><emph>Gasparina</emph></role>, <roleDesc>giovine caricata, che parlando usa la lettera Z in luogo dell'S.</roleDesc>
-        </castItem>
-        <castItem type="role">
-          <role><emph>Donna Catte Panchiana</emph></role>, <roleDesc>vecchia</roleDesc>
-        </castItem>
-        <castItem type="role">
-          <role><emph>Lucietta</emph></role>, <roleDesc>fia de donna Catte</roleDesc>
-        </castItem>
-        <castItem type="role">
-          <role><emph>Donna Pasqua Polegana</emph></role>, <roleDesc>vecchia</roleDesc>
-        </castItem>
-        <castItem type="role">
-          <role><emph>Gnese</emph></role>, <roleDesc>fia de donna Pasqua</roleDesc>
-        </castItem>
-        <castItem type="role">
-          <role><emph>Orsola</emph></role>, <roleDesc>frittolera</roleDesc>
-        </castItem>
-        <castItem type="role">
-          <role><emph>Zorzetto</emph></role>, <roleDesc>fio de Orsola</roleDesc>
-        </castItem>
-        <castItem type="role">
-          <role><emph>Anzoletto</emph></role>, <roleDesc>marzer</roleDesc>
-        </castItem>
-        <castItem type="role">
-          <role><emph>Il Cavaliere Fabrizio</emph></role>, <roleDesc>zio di Gasparina</roleDesc>
-        </castItem>
-        <castItem type="role">
-          <role><emph>Sansuga</emph></role>, <roleDesc>cameriere li locanda</roleDesc>
-        </castItem>
+        <castItem type="role"><role><emph>Gasparina</emph></role>, <roleDesc>giovine caricata, che parlando usa la lettera Z in luogo dell'S.</roleDesc></castItem>
+        <castItem type="role"><role><emph>Donna Catte Panchiana</emph></role>, <roleDesc>vecchia</roleDesc></castItem>
+        <castItem type="role"><role><emph>Lucietta</emph></role>, <roleDesc>fia de donna Catte</roleDesc></castItem>
+        <castItem type="role"><role><emph>Donna Pasqua Polegana</emph></role>, <roleDesc>vecchia</roleDesc></castItem>
+        <castItem type="role"><role><emph>Gnese</emph></role>, <roleDesc>fia de donna Pasqua</roleDesc></castItem>
+        <castItem type="role"><role><emph>Orsola</emph></role>, <roleDesc>frittolera</roleDesc></castItem>
+        <castItem type="role"><role><emph>Zorzetto</emph></role>, <roleDesc>fio de Orsola</roleDesc></castItem>
+        <castItem type="role"><role><emph>Anzoletto</emph></role>, <roleDesc>marzer</roleDesc></castItem>
+        <castItem type="role"><role><emph>Il Cavaliere Fabrizio</emph></role>, <roleDesc>zio di Gasparina</roleDesc></castItem>
+        <castItem type="role"><role><emph>Sansuga</emph></role>, <roleDesc>cameriere li locanda</roleDesc></castItem>
         <castItem type="role">
           <role>
             <emph>Orbi, che sonano</emph>
@@ -327,7 +344,7 @@ scodelle, col sacchetto in mano per il gioco detto la
 Venturina, poi tutte le donne ad una per volta, dal luogo,
 che sarà accennato.</emph>
           </stage>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> Putte, chi mette al lotto?</l>
             <l>Xè qua la Venturina.</l>
@@ -338,7 +355,7 @@ che sarà accennato.</emph>
             <l>Pute, chi zoga al lotto?</l>
             <l>Chi vien a comandar?</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <stage>
               <emph>(sull'altana della sua casa)</emph>
@@ -348,108 +365,108 @@ che sarà accennato.</emph>
           <stage>
             <emph>(getta il bezzo).</emph>
           </stage>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> Brava, siora Lucietta.</l>
             <l>Za, che la prima sè, comandè vu.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Comando per el più.</l>
             <l>Se gh'avesse fortuna!</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> Vadagnerè senz'altro. Su per una.</l>
             <l part="I">Sìe bezzi amanca. </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F"> Zorzi</l>
           </sp>
           <stage>
             <emph>(dal suo poggiuolo).</emph>
           </stage>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> Comandè, siora Gnese.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="I">Tolè el mio bezzo. </l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="F">Via; buttèlo zo.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="I">Se vadagnasse almanco!</l>
           </sp>
           <stage>
             <emph>(getta il bezzo)</emph>
           </stage>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="F">Su per do.</l>
             <l>Cinque bezzi amanca.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Oe matto! ti ti xè? </l>
           </sp>
           <stage>
             <emph>(dal suo poggiuolo).</emph>
           </stage>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> Anca vu, siora mare.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="I">Quel, che ti vol. Tiò el bezzo </l>
           </sp>
           <stage>
             <emph>(getta il bezzo).</emph>
           </stage>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="F">Su per tre.</l>
             <l>Quattro bezzi amanca.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Sior'Orsola, anca vu?</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="I">Sì ben. Dixè, cossa vadagna? </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Al più.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Oe Zorzetto, zenti.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> Son qua da ela, siora Gasparina.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Chiappè </l>
           </sp>
           <stage>
             <emph>(getta il bezzo).</emph>
           </stage>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> La xè ben franca;</l>
             <l>Su per quattro. Mo via tre bezzi amanca.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l>Oe vegnì qua, Zorzetto</l>
           </sp>
@@ -459,217 +476,217 @@ che sarà accennato.</emph>
           <sp>
             <l>Anca mi vòi rischiar el mio bezzetto.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> Son da vu, donna Pasqua.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Anca vu, siora mare?</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Anca mi vòi ziogar; no se pol gnanca?</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I">Fè pur quel, che volè. </l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="F">Do bezzi amanca.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Oe, dalla Venturina </l>
           </sp>
           <stage>
             <emph>(dalla porta della sua casa).</emph>
           </stage>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> (Donna Catte Panchiana) </l>
           </sp>
           <stage>
             <emph>(da sé).</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Siora mare, anca vu?</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Anca mi. Tolè el bezzo.</l>
             <l part="I">Cossa vadagna? </l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="F">El più.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> No ze pol comandar?</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> Xè comandà, patrona.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Dazzeno? No credeva.</l>
             <l>Ze zaveva cuzì, mi no metteva.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Vardè là, che desgrazia!</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> (Zempre cuzì. Vol comandar cuztie) </l>
           </sp>
           <stage>
             <emph>(da sé).</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Animo.</l>
           </sp>
           <stage>
             <emph>(a Zorzetto)</emph>
           </stage>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> Su per sìe.</l>
             <l part="I">Destrighève, mettè. </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F">Metterò mi.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Metterò mi. </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Tolè </l>
           </sp>
           <stage>
             <emph>(getta un altro bezzo).</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I">Gran cazzada! </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F">Dei bezzi</l>
             <l>Che n'avemo anca nu.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="I">Mo via; cavemio? </l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="F">E tutti questi al più.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Vegnì da mi, Zorzetto.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Trèmelo a mi el zacchetto.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Vardè, che zentildona!</l>
             <l>Mi prima ho comandà. Mi son parona.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Mi ziora gh'ho do bezzi.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Mia fia xè più putela.</l>
             <l>Trèghe el sacchetto, che ghe tocca a ela.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> Giustève tra de vu.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Via, tràghelo a to mare.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> E tutti questi al più  </l>
           </sp>
           <stage>
             <emph>(getta il sacchetto ad Orsola).</emph>
           </stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Quezta zè un'inzolenza.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Chi songio? una massera?</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Pezo. Una frittolera.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Vardè! se fazzo frittole?</l>
             <l>La xè una profession.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Co la ferzora in ztrada zè par bon.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> Via, cavè, destrighève </l>
           </sp>
           <stage>
             <emph>(a Orsola).</emph>
           </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Vu, vu, siora, vardève.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Mi zon chi zon zorela.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Certo; chi sente ela,</l>
             <l>La viverà d'intrada.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Tutti za la cognosse in sta contrada.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Ve vorezzi, patrone,</l>
             <l part="I">Metter con mi, vu altre? </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Cossa femio?</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="I">Cavemio, o no cavemio? </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">Mio zior pare</l>
             <l>Giera un foresto, el giera galantomo;</l>
@@ -679,15 +696,15 @@ che sarà accennato.</emph>
             <l>Gneze da un zavatter,</l>
             <l>E vu da un fruttariol.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> El giera un fruttariol, ma de quei boni.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> L'ho vizto in Piazza a cuzinar maroni.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Mio mario, poveretto,</l>
             <l>El giera un zavatter,</l>
@@ -695,43 +712,43 @@ che sarà accennato.</emph>
             <l>El s'ha fatto stimar.</l>
             <l>No ghe giera un par soo per tacconar.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> E cusì cossa femio?</l>
             <l>Cavemio, o no cavemio?</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Sentì co le se vanta!</l>
             <l part="I">Tiò la bala </l>
           </sp>
           <stage><emph>(getta il sacchetto colla palla)</emph>.</stage>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="F">El sessanta.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="I">Xèlo un numero bon? </l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="F">No so gnancora.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="I">El zè bazzo, fia mia. </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F">Mo che dottora!</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="I">A vu, sior'Agnesina </l>
           </sp>
           <stage><emph>(getta il sacchetto)</emph>.</stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F"> (Lo zaveva,</l>
             <l>Che l'andava da ela.</l>
@@ -740,21 +757,21 @@ che sarà accennato.</emph>
           <stage>
             <emph>(da sé).</emph>
           </stage>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F">Oe, la Stela </l>
           </sp>
           <stage>
             <emph>(getta giù il sacchetto, e la palla).</emph>
           </stage>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> Brava. A vu, donna Pasqua </l>
           </sp>
           <stage>
             <emph>(fa cavare a donna Pasqua).</emph>
           </stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> (Che diria de zo nona,</l>
             <l>Povero zporco, el va da zo madona) </l>
@@ -762,229 +779,229 @@ che sarà accennato.</emph>
           <stage>
             <emph>(da sé).</emph>
           </stage>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Vardè, cossa òi cavà?</l>
             <l>Coss'ela sta figura?</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="I">La Morte. </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F">Malignazo! gh'ho paura.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="I">Avè ben cavà mal . </l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="F">Tolè, parona,</l>
             <l part="I">Cavè vu </l>
           </sp>
           <stage><emph>(a donna Catte)</emph>.</stage>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F">Vegnì qua <emph>(cava)</emph>. Coss'è sto piàvolo?</l>
             <l part="I">No gh'ho i occhiali. Cossa xèlo? </l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="F">El Diavolo.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Avè ben cavà pezo.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> N'importa. Òi vadagnà? </l>
           </sp>
           <stage>
             <emph>(a Zorzetto)</emph>
           </stage>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="I">No so; ghe xè de meggio. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Buttè qua </l>
           </sp>
           <stage>
             <emph>(a Zorzetto).</emph>
           </stage>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="I">Tolè </l>
           </sp>
           <stage><emph>(getta il sacchetto a Lucietta)</emph>.</stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">Mi zarò l'ultima.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="I">La Stela al più. </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F">La Stela la xè mia.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Certo, e la grazia l'ha d'aver mia fia.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Oe, ho cavà la Luna.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Brava, brava, mia fia gh'ha più fortuna.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> Presto. La Luna al più.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="I">Toccarà a mi zta volta. </l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="F">Son da vu.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Me darave dei pugni in te la testa.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> Eh, vardève da questa </l>
           </sp>
           <stage>
             <emph>(getta il sacchetto a Gasparina).</emph>
           </stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Vardè, cozza òi cavà?</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> El trenta. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I">La xè mia. </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">Ma un'altra bala,</l>
             <l>Ziora, mi ho da cavar.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Ma mi ho da vadagnar;</l>
             <l>Nissun no me la tol.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="I">Cozza òi cavà? </l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="F">Brava dasseno. El Sol.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Oe, la grazia zè mia.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Malignaza culìa</l>
             <l>Sempre la venze ela.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="I">Vorla un piattelo? </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">No; voggio una zquela.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="I">Ghe la porto. </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">Aspettè.</l>
             <l>Zta mattina ve zbanco.</l>
             <l>Zoghemo ancora, e mi comando: al manco.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> No voggio più zogar. (Sento, che peno)</l>
           </sp>
           <stage>
             <emph>(da sé).</emph>
           </stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="I">No, da zeno, patrona? </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">No da zeno </l>
           </sp>
           <stage>
             <emph>(entra in casa).</emph>
           </stage>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Xè meggio, che anca mi fazza cusì!</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="I">La va via, ziora Gneze? </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F">Ziora zì </l>
           </sp>
           <stage>
             <emph>(entra in casa).</emph>
           </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Vien su, vien su, fio mio.</l>
             <l>El spasso xè fenio.</l>
             <l>El tempo se fa scuro.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="I">El zpazzo zè fenio? </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F">Certo zeguro </l>
           </sp>
           <stage>
             <emph>(entra in casa).</emph>
           </stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Zte zporche me minchiona, ma per diana</l>
             <l>Le gh'ha da far con mi.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="I">Vorla la squela? </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">Tiéntela per ti.</l>
             <l>No m'importa de zquele,</l>
@@ -995,7 +1012,7 @@ che sarà accennato.</emph>
           <stage>
             <emph>(parte).</emph>
           </stage>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> Puto, dame una man</l>
             <l>A portar via sta cesta; sta mattina</l>
@@ -1012,17 +1029,17 @@ che sarà accennato.</emph>
           <stage>
             <emph>Donna Pasqua Polegana, e donna Catte Panchiana.</emph>
           </stage>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Cossa dixeu, comare? Stamattina</l>
             <l>Gh'ha toccà la fortuna a Gasparina.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Za me l'ho imaginada.</l>
             <l>Quela se ghe pol dir la fortunada.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Me recordo so mare,</l>
             <l>La vegniva ogni dì</l>
@@ -1030,49 +1047,49 @@ che sarà accennato.</emph>
             <l>Ora el sal, ora l'oggio, poverazza;</l>
             <l>Ela xè morta, e da so fia se sguazza.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Quel forestier, credemio,</l>
             <l part="I">Ch'el sia so barba? </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F">Oibò.</l>
             <l>Da più de diese ho sentio a dir de no.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Cossa voleu, che el sia? cossa ve par?</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Ah! no vòi mormorar.</l>
             <l>Via, via, el sarà so barba, no parlemo.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Oe, che el sia quel, ch'el vol, nu no gh'intremo.</l>
             <l>Me despiase, che in casa gh'ho una fia,</l>
             <l>Che la vede, e la sente.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Per la vostra no gh'è sto gran pericolo,</l>
             <l>Che la xè mauretta;</l>
             <l>Ma la mia, poveretta,</l>
             <l>Che no la gh'ha gnancora sedes'ani.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> E la mia quanti ani,</l>
             <l part="I">Credereu, che la gh'abbia? </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F">Mi no so.</l>
             <l>Vinti un, vinti do.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Vedeu, fia mia, che v'inganè? deboto</l>
             <l>La toccherà i disdoto.</l>
@@ -1081,87 +1098,87 @@ che sarà accennato.</emph>
             <l>E sì vecchia no son,</l>
             <l>Ma son vegnua cusì da le passion.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> E a mi, col vostro intender,</l>
             <l>Quanti ani me deu?</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Vu, fia mia, cossa seu?</l>
             <l part="I">Tra i sessanta, e i setanta?</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F">Oh che spropositi!</l>
             <l>Se cognosse, che poco ghe vedè.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="I">Quanti xèli, fia mia? </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F">Quaranta tre.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Eh, no gh'è mal. E i mii</l>
             <l part="I">Quanti ve par, che i sia? </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F">Sessanta, e va.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> I xè manco dei vostri in verità.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="I">Se no gh'avè più denti! </l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F">Cara fia,</l>
             <l>Per le flussion i me xè andadi via.</l>
             <l>Oh se m'avessi visto in zoventù!</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Come! </l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="I">Seu sorda? </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F">Un poco, da sta</l>
             <l>recchia.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Cara fia, no volè, ma sè più vecchia.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Se savessi, anca mi, quel che ho patio.</l>
             <l>Basta. El Ciel ghe perdona a mio mario.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Certo, che sti marii</l>
             <l>I xè i gran desgraziai.</l>
             <l>El pan de casa non ghe basta mai.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> La xè cusì, sorela.</l>
             <l>Anca el mio, sto baron, giera de quei,</l>
             <l>E sì el mio pan noi xè de semolei.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Mi, no fazzo per dir, ma giera un tocco!</l>
             <l>Fava la mia fegura;</l>
@@ -1174,94 +1191,94 @@ che sarà accennato.</emph>
             <l>Sentì sto dente grosso,</l>
             <l>E ste zenzive dure co fa un osso.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Magneu ben? </l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="I">Co ghe n'ho. </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F">Cusì anca mi.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Ma no se pol magnar ben ogni dì.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="I">Come! </l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="M">Me fè peccà,</l>
             <l part="F">Cusì sorda. </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Aspettè, vegnì de qua.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> No; voggio andar dessuso,</l>
             <l>Perché gh'ho quella puta</l>
             <l>Che me dà da pensar.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="I">La voleu maridar? </l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F">Oh, se podesse!</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="I">Dèghela a quel marzer. </l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F">Se el la volesse.</l>
             <l>E vu la vostra no la maridè?</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Eh cara vu, tasè.</l>
             <l>Se sto fio de sior'Orsola</l>
             <l part="I">Fusse un poco più grando! </l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F">El crescerà.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> E intanto la sta là.</l>
             <l>E mi, per confidarve al mio pensier,</l>
             <l>Vorave destrigarme;</l>
             <l>Perché dopo anca mi vòi maridarme.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Oh anca mi certo; co xè via sta puta,</l>
             <l>La fazzo, vel protesto.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Destrighemole presto.</l>
             <l part="I">Maridemose, Catte. </l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F">Sì, fia mia.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="I">Catte, bondì sioria. </l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F">Bondì, sorela.</l>
             <l>No son più una putela;</l>
@@ -1272,7 +1289,7 @@ che sarà accennato.</emph>
           <stage>
             <emph>(parte).</emph>
           </stage>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Mi ghe sento pochetto,</l>
             <l>Ma grazie al Cielo son ancora in ton,</l>
@@ -1288,7 +1305,7 @@ che sarà accennato.</emph>
           <stage>
             <emph>Gasparina sul poggiuolo, poi il Cavaliere.</emph>
           </stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Ancuo zè una zornada cuzì bela,</l>
             <l>Che proprio me vien voggia</l>
@@ -1304,49 +1321,49 @@ che sarà accennato.</emph>
             <l>Ma no ze za chi el zia. Oh, vèlo qua,</l>
             <l>Dazzeno in verità.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>
               <emph>(vien passeggiando con qualche affettazione, e avvicinandosi alla casa di Gasparina, la saluta).</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <p>
               <emph>(gli fa una riverenza).</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>
               <emph>(cammina un poco, poi torna a salutarla).</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <p>
               <emph>(repplica una riverenza).</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>
               <emph>(gira un poco, poi le fa un baciamano ridente).</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <p>
               <emph>(corrisponde con un baciamano grazioso).</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>
               <emph>(s'incammina verso la locanda, poi torna indietro mostrando di volerle parlare; poi si pente, le fa una riverenza e torna verso la locanda. Sulla porta si ferma, e le fa un baciamano, ed entra).</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Oh ghe dago in tel genio.</l>
             <l>Ze vede, che el zè cotto.</l>
@@ -1360,7 +1377,7 @@ che sarà accennato.</emph>
           <stage>
             <emph>Sansuga dalla locanda, e la suddetta.</emph>
           </stage>
-          <sp>
+          <sp who="#sansuga">
             <speaker>SANSUGA</speaker>
             <l> Cossa mai se pol far? co sti foresti,</l>
             <l>No se pol dir de no.</l>
@@ -1369,103 +1386,103 @@ che sarà accennato.</emph>
             <l>No se pol dir de no, co i ne comanda.</l>
             <l part="I">Patrona reverita. </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">Ve zaludo.</l>
           </sp>
-          <sp>
+          <sp who="#sansuga">
             <speaker>SANSUGA</speaker>
             <l> Cognossela quel sior, che xè venudo?</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="I">Mi no. Chi zèlo? </l>
           </sp>
-          <sp>
+          <sp who="#sansuga">
             <speaker>SANSUGA</speaker>
             <l part="M">Un cavalier. </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">Dazzeno?</l>
           </sp>
-          <sp>
+          <sp who="#sansuga">
             <speaker>SANSUGA</speaker>
             <l> El xè un, ch'ha per ela de la stima,</l>
             <l>E col l'ha vista el xè cascà a la prima.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="I">E mi me cognozzeu? </l>
           </sp>
-          <sp>
+          <sp who="#sansuga">
             <speaker>SANSUGA</speaker>
             <l part="F">So chi la xè.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Ben co me cognozzè,</l>
             <l>Zaverè, che con mi</l>
             <l>No ze parla cuzì.</l>
           </sp>
-          <sp>
+          <sp who="#sansuga">
             <speaker>SANSUGA</speaker>
             <l> No ghe xè mal. No voggio miga dir...</l>
             <l>Ghe basta de poderla reverir.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> No m'àlo zaludà?</l>
           </sp>
-          <sp>
+          <sp who="#sansuga">
             <speaker>SANSUGA</speaker>
             <l> Xè vero, ma nol sa,</l>
             <l>Se la l'abbia aggradido el so saludo.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Via dizèghe a quel zior, che nol reffudo.</l>
           </sp>
-          <sp>
+          <sp who="#sansuga">
             <speaker>SANSUGA</speaker>
             <l> Se el vien sulla terazza</l>
             <l part="I">Ghe dirala qualcossa? </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">Via, zior zì.</l>
           </sp>
-          <sp>
+          <sp who="#sansuga">
             <speaker>SANSUGA</speaker>
             <l part="I">Ghe piàselo quel sior? </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">Cuzì, e cuzì.</l>
           </sp>
-          <sp>
+          <sp who="#sansuga">
             <speaker>SANSUGA</speaker>
             <l> Lo vago a consolar.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Oe, lo zàlo, che zon da maridar?</l>
           </sp>
-          <sp>
+          <sp who="#sansuga">
             <speaker>SANSUGA</speaker>
             <l part="I">El lo sa certo. </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">El zàlo,</l>
             <l>Che zon puta da ben, ma poveretta?</l>
           </sp>
-          <sp>
+          <sp who="#sansuga">
             <speaker>SANSUGA</speaker>
             <l> Za l'ho informà de tuto.</l>
             <l part="I">La staga là un tantin. </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">Zioria, bel puto</l>
           </sp>
@@ -1493,7 +1510,7 @@ che sarà accennato.</emph>
           <stage>
             <emph>Lucietta sull'altana, poi il Cavallier sulla loggia.</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Gnancora no se vede</l>
             <l>A vegnir Anzoletto.</l>
@@ -1504,48 +1521,48 @@ che sarà accennato.</emph>
             <l>Oh sti puti, sti puti, i è pur baroni;</l>
             <l>No se se pol fidar.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>
               <emph>(sulla loggia guardando verso la casa di Gasparina).</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l>Vàrdelo qua? me vorlo saludar?</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Mi pare, e non mi pare.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I">Par, che el me varda mi.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>
               <emph>(si cava il cappello, e lo tien a mezz'aria, parendogli, che sia, e non sia Gasparina)</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Patron caro</l>
           </sp>
           <stage>
             <emph>(lo saluta).</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>
               <emph>(termina di salutarla, e poi con un occhiale l'osserva).</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> M'àlo visto cusì?</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Vedo, che non è quella,</l>
             <l>Ma tanto e tanto non mi par men bella</l>
@@ -1553,35 +1570,35 @@ che sarà accennato.</emph>
           <stage>
             <emph>(torna coll'occhiale).</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Se el seguita a vardar co sto bel sesto,</l>
             <l>Adessadesso mi ghe volto el cesto.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>
               <emph>(la saluta).</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> La reverisso in furia:</l>
             <l>Maneghi de melon, scorzi d'anguria.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I">Non intendo che dica</l>
           </sp>
           <stage>
             <emph>(la saluta).</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Un'altra volta.</l>
             <l part="I">Serva sua. </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F">Mi perdoni.</l>
           </sp>
@@ -1591,49 +1608,49 @@ che sarà accennato.</emph>
           <stage>
             <emph>Anzoletto colle scatole da marzer, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Aghi de Fiandra, spighetta, cordoni</l>
           </sp>
           <stage><emph>(gridando a uso di tal mestieri)</emph>.</stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I"> Anzoletto? </l>
           </sp>
           <stage>
             <emph>(chiamandolo)</emph>
           </stage>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="F">V'ho visto</l>
           </sp>
           <stage><emph>(minacciandola)</emph>.</stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Signora, se comanda.</l>
             <l part="I">Compri, che pago io. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Grazie, patron;</l>
             <l>De lu no me n'importa.</l>
             <l>Aspettème, che vegno sulla porta</l>
           </sp>
           <stage><emph>(entra)</emph>.</stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I">Quel giovine. </l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="M">Patron. </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F">Quel, ch'ella vuole,</l>
             <l>Datele; pago io.</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> (Ah sta cagna sassina m'ha tradio!) </l>
           </sp>
@@ -1646,49 +1663,49 @@ che sarà accennato.</emph>
           <stage>
             <emph>Gnesa sull'altana, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Oe marzer; vegnì qua</l>
           </sp>
           <stage><emph>(Anzoletto s'accosta)</emph>.</stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Ecco un'altra beltà.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Gh'aveu cordoni bei?</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Datele quel, che vuol, pago per lei.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Dasseno? </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Sì, servitela,</l>
             <l>Che tutto io pagherò.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="I">Vegni de su, marzer. </l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="F">Ben, vegnirò </l>
           </sp>
           <stage>
             <emph>(entra in casa d'Agnese).</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Tante bellezze unite! parmi un sogno.</l>
             <l>Servitevi, ragazza.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Me torò el mio bisogno</l>
           </sp>
@@ -1699,16 +1716,16 @@ che sarà accennato.</emph>
           <stage>
             <emph>Lucietta sulla porta, il Cavaliere sulla loggia.</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Invece de aspettarme el va da Gnese?</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Giovinetta cortese,</l>
             <l part="I">Aspettate, ora vien. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Sior sì, l'aspetto.</l>
             <l>(Vòi parlar col foresto</l>
@@ -1717,11 +1734,11 @@ che sarà accennato.</emph>
           <stage>
             <emph>(da sé).</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Come voi vi chiamate?</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Lucietta per servirla.</l>
             <l>(Farme sta azion a mi? no vòi soffrirla)</l>
@@ -1729,36 +1746,36 @@ che sarà accennato.</emph>
           <stage>
             <emph>(da sé).</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l>Lucietta.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Cossa vorla?</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I">Siete sposa? </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Sior no.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I">Siete fanciulla? </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Certo,</l>
             <l>Che qualcossa sarò.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I">Voglio venir a basso. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Chi lo tien? </l>
           </sp>
@@ -1778,34 +1795,34 @@ che sarà accennato.</emph>
           <stage>
             <emph>Donna Catte e Lucietta.</emph>
           </stage>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Oe, Lucietta</l>
           </sp>
           <stage><emph>(di dentro)</emph>.</stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Sì, sì, podè chiamarme.</l>
             <l>Fina, che no me sfogo,</l>
             <l>No vago, se i me dà, via da sto liogo.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Cossa fastu qua in strada? </l>
           </sp>
           <stage>
             <emph>(esce di casa).</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I">Gnente. </l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F">Ti è inmusonada</l>
             <l>Per cossa, cara fia?</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Quel baron del marzer...</l>
             <l>Xè passà...l'ho chiamà...</l>
@@ -1814,15 +1831,15 @@ che sarà accennato.</emph>
           <stage>
             <emph>(piangendo).</emph>
           </stage>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="I">E ti pianzi per questo? </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Siora sì.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="I">El vegnirà debotto.</l>
           </sp>
@@ -1832,46 +1849,46 @@ che sarà accennato.</emph>
           <stage>
             <emph>Il Cavaliere, e dette.</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F">Eccomi qui.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="I">Chi èlo sto sior? </l>
           </sp>
           <stage>
             <emph>(a Lucietta)</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Tasè </l>
           </sp>
           <stage><emph>(a donna Catte)</emph>.</stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I">Questa vecchia chi è? </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">La xè mia mare.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Che el se metta i occhiai; se nol ghe vede;</l>
             <l>No son vecchia, patron, come che el crede.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Compatitemi, cara.</l>
             <l>Ah! vostra figlia è una bellezza rara.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Lo so anca mi; la xè una bela puta.</l>
             <l>E po vardè, la me someggia tuta.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Ora verrà il merciaio;</l>
             <l>Provedetevi pure, ecco il danaio</l>
@@ -1883,17 +1900,17 @@ che sarà accennato.</emph>
           <stage>
             <emph>Gnese sull'altana, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Patron, sàla? m'ho tolto</l>
             <l part="I">Roba per quattro lire. </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F">Anche per trenta.</l>
             <l>Io faccio ognor così.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Ma me l'ho tolta, e l'ho pagada mi.</l>
             <l>Le pute Veneziane</l>
@@ -1907,74 +1924,74 @@ che sarà accennato.</emph>
           <stage>
             <emph>Anzoletto di casa e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Questa non fa per me, troppo eroina.</l>
             <l part="I">Via, fatevi servire</l>
           </sp>
           <stage><emph>(a Lucietta)</emph>.</stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">No vòi gnente.</l>
             <l>No me vegnir da rente,</l>
             <l>Tocco de desgrazià, baron, furbazzo</l>
           </sp>
           <stage><emph>(a Anzoletto)</emph>.</stage>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> A mi sto bel strapazzo:</l>
             <l>A mi, che gh'ho rason de lamentarme?</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Ti gh'ha rason, che qua no vòi sfogarme.</l>
             <l>Ti me l'ha da pagar.</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Chi ha d'aver, ha da dar.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Zitto; vegnì con nu</l>
           </sp>
           <stage><emph>(a Anzoletto)</emph>.</stage>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> In casa vostra no ghe vegno più </l>
           </sp>
           <stage><emph>(parte)</emph>.</stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Via, l'amante è partito.</l>
             <l>Prendete un anellino;</l>
             <l>Tenetelo, ch'è bello.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> La reverisso, e grazie dell'anello</l>
           </sp>
           <stage><emph>(parte senza prenderlo)</emph>.</stage>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="I">La diga, sior foresto. </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F">Che volete?</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="I">La me lo daga a mi. </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F">Brava; prendete.</l>
             <l>Datelo alla ragazza in nome mio:</l>
             <l>Vecchia da ben, mi raccomando, addio</l>
           </sp>
           <stage><emph>(parte)</emph>.</stage>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Oh, no ghe dago gnente.</l>
             <l>No vòi che la se instizza.</l>
@@ -1990,7 +2007,7 @@ che sarà accennato.</emph>
           <stage>
             <emph>Donna Pasqua di casa colla scopa.</emph>
           </stage>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Vòi scoar sto campiello;</l>
             <l>El xè pien de scoazze.</l>
@@ -2004,91 +2021,91 @@ che sarà accennato.</emph>
             <l>E no vòi per nissun fruar la scoa</l>
           </sp>
           <stage><emph>(va scopando dinanzi la sua porta)</emph>.</stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Oe dixè, donna Pasqua; donna Pasqua.</l>
             <l>La xè sordetta, grama!</l>
             <l part="I">Oe sentì, donna Pasqua. </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F">Chi me chiama?</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Za che gh'avè la scoa, fème un servizio,</l>
             <l>Dène una nettadina</l>
             <l>Qua davanti de nu.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Quelo, che fazzo mi, fèlo anca vu</l>
           </sp>
           <stage><emph>(spazza sul suo)</emph>.</stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> No ve faressi mal, cara madona.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> (Vardè, che zentildona!) </l>
           </sp>
           <stage><emph>(da sé)</emph>.</stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> El xè un pan, che se impresta.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> (La vol, che se ghe fazza la massera.</l>
             <l>Chi crédela, che sia sta frittolera?)</l>
           </sp>
           <stage><emph>(da sé)</emph>.</stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Slongar la scoa un tantin</l>
             <l>Xèla una gran fadiga?</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Cossa? (No sento ben quel, che la diga).</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Digo cusì, sorela, che a sto mondo</l>
             <l>Quel, che servizio fa, servizio aspetta.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="I">Che servizio? </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F">Sè sorda, poveretta.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Mi sorda? Sta mattina</l>
             <l>Ghe sentiva pulito.</l>
             <l>Una flussion se m'ha calà za un poco;</l>
             <l>Ma credo che sia causa sto siroco.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Dixè, Pasqua, sentì.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="I">Cossa voleu da mi? </l>
           </sp>
           <stage>
             <emph>(s'accosta)</emph>
           </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F">Me seu amiga?</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Sì ben, no fazzo miga</l>
             <l>Per no voler scoar la vostra porta;</l>
@@ -2097,102 +2114,102 @@ che sarà accennato.</emph>
             <l>Le me diga massera</l>
             <l>Dela comunità.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Via, via, gh'avè rason; disè, fia mia,</l>
             <l part="I">Dove xè vostra fia? </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F">La xè sentada,</l>
             <l>Che la laora: oh, no ghe xè pericolo</l>
             <l>Che in ozio la se veda in ste zornae.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> La xè una puta, che me piase assae.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Dasseno la xè bona</l>
           </sp>
           <stage><emph>(si mette a spazzare alla casa di Orsola)</emph>.</stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> No, no v'incomodè.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> De quele no la xè...</l>
             <l part="I">Se me capì... </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F">La xè una bona puta.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> E per dir quel, che xè, non la xè bruta.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="I">Caspita! la xè un fior. </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F">N'è vero, fia? </l>
           </sp>
           <stage>
             <emph>(spazza più forte)</emph>
           </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Basta; basta cusì.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Credèlo; la laora tutto el dì.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="I">Quando la marideu? </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F">Grama! magari!</l>
             <l>Ma me capiu, fia mia? fala danari.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Qualchedun la torave senza gnente.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="I">Cossa? </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F">No m'intendè? vegnì darente.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Cossa diseu, sorela?</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> La puta la xè bela,</l>
             <l>La xè bona; chi sa?</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="I">Magari! </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F">Vegnì qua.</l>
             <l>Vegnì de su da mi; vòi, che parlemo.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> (Chi sa, che co so fio no se giustemo?)</l>
           </sp>
@@ -2211,25 +2228,25 @@ che sarà accennato.</emph>
           <stage>
             <emph>Gnese e dette.</emph>
           </stage>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Siora, m'aveu chiamà?</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Sì, fia mia, vago qua</l>
             <l>Da sior'Orsola sastu?</l>
             <l>Tornerò da qua un poco.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Sior'Orsola, patrona.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Sioria, fia mia. </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> (Cossa dixeu, che tòco?) </l>
           </sp>
@@ -2245,45 +2262,45 @@ che sarà accennato.</emph>
           <stage>
             <emph>(da sé, ed entra da Orsola)</emph>
           </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="I">Gnese, steu ben? </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F">Mi sì.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Cossa laoreu, dixè?</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> M'inzegno a far dei fiori da topè.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> De quei de veludin?</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> De queli, e anca de queli de piumin.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="I">Lassè véder. </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="M">Vardè. </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F">Brava dasseno.</l>
             <l>Per chi li feu, fia mia?</l>
             <l part="I">Per quei de Marzaria? </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F">Oh, siora no;</l>
             <l>I me vien ordenai.</l>
@@ -2296,32 +2313,32 @@ che sarà accennato.</emph>
             <l>Adesso i fazzo mi con del sparagno,</l>
             <l>E gh'ho manco fadiga, e più vadagno.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="I">Saveu far scuffie?</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="M">Siora sì.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F">Dasseno?</l>
             <l>Poderessi anca far la conzateste.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="I">Ma una puta, la vede...</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F">Maridève.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Oh cossa, che la dise.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Sentì, care raìse,</l>
             <l>Ve voggio ben assae; vorave certo</l>
@@ -2336,7 +2353,7 @@ che sarà accennato.</emph>
           <stage>
             <emph>Gnese, poi Lucetta in altana.</emph>
           </stage>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Mia mare, poverazza,</l>
             <l>La me marideria.</l>
@@ -2344,89 +2361,89 @@ che sarà accennato.</emph>
             <l>Un partio de quei boni;</l>
             <l>Ma se ne catta tanti de baroni!</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Siora Gnese garbata! </l>
           </sp>
           <stage>
             <emph>(con ironia)</emph>
           </stage>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Cossa gh'aveu con mi?</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Con un'amiga no se fa cusì.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="I">Cossa v'òi fatto? </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Fève da la vila.</l>
             <l>Lo savè, che Anzoleto me vol ben,</l>
             <l>E in casa vel tirè quando che el vien?</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="I">Ho comprà de la roba. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Per comprar,</l>
             <l>De chiamarlo de su no gh'è bisogno.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Mi a vegnir su la porta me vergogno.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Vardè che casi! no ghe sè mai stada,</l>
             <l>Siora spuzzetta, in strada?</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Co gh'è mia siora mare; ma no sola.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Orsù in t'una parola,</l>
             <l part="I">Lassème star quel puto. </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F">Chi vel tocca?</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> O ve dirò quel, che me vien in bocca.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Mo no, cara Lucietta,</l>
             <l>Voggio, che siemo amighe.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Mi sì, che gh'ho buon cuor.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> E mi no ve vòi ben?</l>
             <l>Voggio donarve un fior.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I">Magari! </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="M">Mandè a tòrlo. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Ma da chi?</l>
             <l>Se no ghe xè nissun, vegnirò mi.</l>
@@ -2439,37 +2456,37 @@ che sarà accennato.</emph>
           <stage>
             <emph>Zorzetto di strada, e dette.</emph>
           </stage>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="I">Cossa voleu? </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Vorave un servizietto.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="I">Comandème. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Andè là.</l>
             <l>Gnese ve darà un fior, portèlo qua.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> Volentiera; son qua, buttèlo zo</l>
           </sp>
           <stage><emph>(a Gnese)</emph>.</stage>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="I">Oh giusto! </l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="M">Vegno suso? </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F">Missier no:</l>
             <l>Calerò zo el cestelo</l>
@@ -2478,59 +2495,59 @@ che sarà accennato.</emph>
           <sp>
             <l part="I">Portèghelo a Lucietta. </l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="F">Mo co belo!</l>
             <l>El someggia dasseno a chi l'ha fatto.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="I">Andè via, che sè matto. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Ti lo sprezzi?</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="I">No me volè più ben? </l>
           </sp>
           <stage>
             <emph>(a Gnese)</emph>
           </stage>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F">Che puttellezzi!</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> Ve degnévi una volta de ziogar</l>
             <l>Co mi alle bagatele.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Eh via, che le xè cosse da putele.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Adesso ti xè granda,</l>
             <l>Gnese, oe vàrdeme in ciera,</l>
             <l>Zogheravistu in t'un'altra maniera?</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="I">Via, ghe lo deu quel fior? </l>
           </sp>
           <stage>
             <emph>(a Zorzetto, irata)</emph>
           </stage>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="F">Subito siora.</l>
             <l>Cossa gh'aveu con mi? Mo che desgrazia!</l>
             <l part="I">Cossa mai v'oggio fatto? </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F">Uh mala grazia! </l>
           </sp>
@@ -2541,62 +2558,62 @@ che sarà accennato.</emph>
           <stage>
             <emph>Lucietta e Zorzetto.</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Zorzi, Zorzi, ghe vedo da lontan.</l>
             <l part="I">Culìa la te vol ben. </l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="F">Giusto! una volta;</l>
             <l part="I">Ma adesso no vedè. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Anzi più adesso.</l>
             <l>Co la giera putela</l>
             <l>No la pensava miga a certe cosse,</l>
             <l>Adesso la ghe pensa, e el se cognosse.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> Anca mi, se ho da dir la verità</l>
             <l>Che vòi ben in t'un modo,</l>
             <l>Che mai più l'ho provà. Ma a sti desprezzi,</l>
             <l>Cara siora Lucieta, no son uso.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Pòrteme el fior, Zorzetto, vien desuso.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> Quel che volè; gh'ho voggia,</l>
             <l>Che parlemo un tantin.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> No ti è più fantolin; quanti ani gh'àstu?</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="I">Sedese, o disisette. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Mio zerman</l>
             <l part="I">S'ha maridà de quindese. </l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="F">Mo adesso</l>
             <l>Me fè rabbia anca vu.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Povero pampalugo, vien de su.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> Vegno</l>
           </sp>
@@ -2607,48 +2624,48 @@ che sarà accennato.</emph>
           <stage>
             <emph>Anzoletto, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="I">Indrio, sior scartozzetto</l>
           </sp>
           <stage><emph>(dà una spinta a Zorzetto)</emph>.</stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Che strambazzo!</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="I">Cossa v'òi fatto? </l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="F">Indrio,</l>
             <l>Che ve dago uno schiaffazzo.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="I">Mo per cossa? </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Vardè là, che bel sesto!</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Senti, sastu? a sta porta</l>
             <l>No ghe vegnir mai più.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> Che portava sto fior. Dèghelo vu</l>
           </sp>
           <stage><emph>(getta il fiore in terra)</emph>.</stage>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> A Lucietta sto fior?</l>
             <l>Tocco de desgrazià.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> Siora mare, i me dà.</l>
           </sp>
@@ -2658,63 +2675,63 @@ che sarà accennato.</emph>
           <stage>
             <emph>Orsola sul pergolo, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Cossa te fai, fio mio?</l>
             <l>Oe, lassè star mio fio,</l>
             <l>Che per diana de dia se vegno zo,</l>
             <l>Qualcossa su la testa ve darò.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I">Via, via, manco sussuro. </l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="F">Sto spuzzetta</l>
             <l>No voggio, che el ghe parla co Lucietta.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="I">Cossa m'importa a mi? </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F">Za per culìa</l>
             <l>Sempre se fa baruffa. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Voleu, che ve la diga, che son</l>
             <l>stuffa?</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> No se ghe poi più star in sto campielo</l>
             <l>Co sta sorte de zente.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Oe, oe, come parleu?</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Vardè là, che lustrissima! Chi seu?</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Frittolera. </l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Tasè </l>
           </sp>
           <stage><emph>(a Lucietta)</emph>.</stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="I">Sporca. </l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="F">Sangue de diana,</l>
             <l>Che debotto debotto... </l>
@@ -2722,24 +2739,24 @@ che sarà accennato.</emph>
           <stage>
             <emph>(verso Orsola)</emph>
           </stage>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="I">Cossa voressi far? </l>
           </sp>
           <stage>
             <emph>(contro Anzoletto)</emph>
           </stage>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="F">Via, sior pissotto</l>
           </sp>
           <stage><emph>(minacciandolo)</emph>.</stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Lassèlo star quel puto, e vu patrona</l>
             <l>Mio fio no lo vardè.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Oh, no v'indubitè, che no vel tocco;</l>
             <l>Vardè che bel aloco!</l>
@@ -2752,44 +2769,44 @@ che sarà accennato.</emph>
           <stage>
             <emph>Gnese in altana, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="I">Cossa parleu de mi? </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Coss'è, patrona?</l>
             <l>Seu vegnua fora, perché gh'è Anzoletto?</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="I">Vardè, che sesti! </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F">Vien de su, Zorzetto.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="I">Siora no, vòi star qua. </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F">Cusì ti parli?</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> Sta volta voggio far a modo mio.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="I">Vien de suso, te digo. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Oh che gran fio!</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Vardève vu, fraschetta.</l>
           </sp>
@@ -2799,29 +2816,29 @@ che sarà accennato.</emph>
           <stage>
             <emph>Donna Catte in istrada, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Oe, no stè a strapazzar la mia Lucietta.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Mi gh'ho qualche rason, se la strappazzo.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> In sto campiello se mettemio a mazzo?</l>
             <l>L'è una puta da ben;</l>
             <l>E no la xè de quele...</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Le altre, cara siora, cossa xèle?</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Tasi, che ti ha bon tàser.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Oh no son miga muta.</l>
           </sp>
@@ -2831,39 +2848,39 @@ che sarà accennato.</emph>
           <stage>
             <emph>Donna PASQUA di casa d'Orsola, e detti; poi il CAVALIERE.</emph>
           </stage>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Cossa voressi dir de la mia puta?</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Tasè, che la ghe sente.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="I">Vegnì su, siora mare. </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F">Cossa gh'è? </l>
           </sp>
           <stage>
             <emph>(a Gnese)</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Sento gridar, si può saper perché?</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="I">Cossa gh'ìntrelo, sior? </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F">Se non vi spiace,</l>
             <l>Vi entro sol per la pace.</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> La diga, mio patron,</l>
             <l>Su quela putta gh'àlo pretension? </l>
@@ -2871,15 +2888,15 @@ che sarà accennato.</emph>
           <stage>
             <emph>(accenna Lucietta)</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I">Niente affatto. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Sentìu, sior Anzoletto?</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Io per tutte le donne ho del rispetto.</l>
             <l>Mi piace l'allegria,</l>
@@ -2889,162 +2906,162 @@ che sarà accennato.</emph>
             <l>Donne si può sapere</l>
             <l>La causa di un sì grande mormorio?</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> La diga, sior, che i lassa star mio fio.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I">Chi l'oltraggia di voi? </l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="F">Quel, che xè là.</l>
             <l>Mi no gh'ho fatto gnente, e lu el m'ha dà.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I">Per qual ragion? </l>
           </sp>
           <stage>
             <emph>(ad Angiolo)</emph>
           </stage>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="F">No voggio</l>
             <l>Che el varda quella puta,</l>
             <l>Che el vaga in casa, e che el ghe porta i fiori.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Gnese, quel fior me l'àstu donà ti?</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Mi ghe lo ho dà. Sior sì.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Orsù, che si finisca</l>
             <l>Di gridar, buona gente.</l>
             <l>Amici come prima, allegramente.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Vienstu de su, Anzoletto?</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Sempre la xè cusì.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l>Via, via, sior matto, vegnì via con mi</l>
           </sp>
           <stage>
             <emph>(prende Anzoletto per la mano, e lo conduce via).</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Brava la vecchia; lo tirò con essa.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> So fia la xè promessa</l>
             <l>Quello xè el so novizzo.</l>
             <l>No gh'è mal, sior foresto.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l>Questo si chiama un ragionare onesto.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> E ti, che ti lo sa, làsselo star.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> No, no te indubitar,</l>
             <l>Che no lo chiamo più.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Vegno, vegno, fio mio; caro colù </l>
           </sp>
           <stage><emph>(entra)</emph>.</stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Siamo di carnevale;</l>
             <l>Siamo in luogo a proposito</l>
             <l>Per fare un po' di chiasso fra di noi.</l>
             <l>Son forastier, mi raccomando a voi.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="I">Zorzi vienstu dessuso? </l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="F">Siora sì.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Vien, che t'ho da parlar, vien su, fio mio.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="I">Sior'Agnese, patrona</l>
           </sp>
           <stage><emph>(entra)</emph>. </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F">El m'ha obbedio</l>
           </sp>
           <stage>
             <emph>(entra).</emph>
           </stage>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Via, vegnìu, siora mare? Siora mare</l>
           </sp>
           <stage><emph>(forte)</emph>.</stage>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="I">Chiàmistu? </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F">Vegnìu su?</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Vegno, t'ho da parlar.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Vegnì, che mi me sento a laorar</l>
           </sp>
           <stage><emph>(vol ritirarsi)</emph>.</stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Riverisco <emph>(a Gnese)</emph>. </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="I">Patron. </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F">Ragazza addio.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Ghe fazzo un repeton</l>
           </sp>
           <stage>
             <emph>(entra).</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Ditemi, un repetone</l>
             <l part="I">Cosa vuol dir? </l>
@@ -3052,70 +3069,70 @@ che sarà accennato.</emph>
           <stage>
             <emph>(a donna Pasqua, che s'incammina verso casa, e non lo sente).</emph>
           </stage>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F">Patron.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Ditemi, che vuol dire un repeton?</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Vol dir un bel saludo.</l>
             <l>Che lo fazzo anca mi.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I">Quella è la figliuola vostra? </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F">Patron sì.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I">È una giovin di garbo. </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F">No se sàlo?</l>
             <l part="I">L'ho fatta mi. </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F">Come le piace il ballo?</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="I">Cossa dìselo? </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F">Dico,</l>
             <l part="I">Se le piace ballar. </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F">Caspita! e come!</l>
             <l>Co la fa le furlane</l>
             <l>La par una saeta:</l>
             <l>I ghe dixe la bela furlaneta.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Vo' che balliamo dunque.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> O sì, sì, caro sior,</l>
             <l>E anca mi co ghe son, me fazzo onor.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I">Ballerete con me? </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F">L'è tanto belo!</l>
             <l>No vòi balar con altri, che con elo </l>
@@ -3129,14 +3146,14 @@ che sarà accennato.</emph>
           <stage>
             <emph>Il Cavaliere, poi Gasparina.</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Oh, son pure obbligato</l>
             <l>A chi un sì bell'alloggio mi ha trovato.</l>
             <l>Nol cambierei con un palazzo augusto:</l>
             <l>Ci ho con gente simil tutto il mio gusto.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Che el diga quel che el vol zto mio zior barba.</l>
             <l>Lu coi libri el zavaria,</l>
@@ -3144,17 +3161,17 @@ che sarà accennato.</emph>
             <l>Anderò da mia zantola,</l>
             <l part="I">Che zè poco lontana. </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F"> (Ecco la giovine,</l>
             <l>Che ho veduto da prima).</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="I"> (Oh vèlo qua quel zior) </l>
           </sp>
           <stage><emph>(da sé)</emph>.</stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F"> (Mi par bellissima) </l>
           </sp>
@@ -3164,231 +3181,231 @@ che sarà accennato.</emph>
           <sp>
             <l part="I">Servitore di lei. </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">Zerva umilizzima.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> (Che vezzoso parlar!) </l>
           </sp>
           <stage>
             <emph>(da sé).</emph>
           </stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="I"> (Voggio in caza tornar) </l>
           </sp>
           <stage><emph>(s'accosta alla casa)</emph>.</stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F">Rigorosissima</l>
             <l part="I">Meco siete così? </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">Zerva umilizzima.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Io sono un cavaliere,</l>
             <l>Egli è ver, forastiere;</l>
             <l>Ma per le donne ho sentimenti onesti.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> (Oh, che i me piaze tanto zti foresti) </l>
           </sp>
           <stage>
             <emph>(da sé).</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Bramo, se fia possibile,</l>
             <l>Di servirvi l'onore, e in me vedrete</l>
             <l>Esser per voi la servitù onestissima.</l>
             <l part="I">Aggraditela almen. </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">Zerva umilizzima.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Lasciam le cirimonie, favorite.</l>
             <l part="I">Siete zitella? </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">No lo zo dazzeno.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Nol sapete? tal cosa io non comprendo.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Zto nome de zitella io non l'intendo.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I">Fanciulla voglio dir. </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">No zo capirla.</l>
             <l part="I">Ze zon puta? </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="M">Così. </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">Per obbedirla.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Troppo gentile! Avete genitori?</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> No l'intende n'è vero,</l>
             <l>Troppo el noztro parlar?</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I">Così e così. </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">Me zaverò zpiegar.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Avete genitori?</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Mio padre zono morto,</l>
             <l>E la mia genitrice ancora ezza.</l>
             <l part="I">M'intendela? </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F">Bravissima,</l>
             <l part="I">Voi parlate assai ben. </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">Zerva umilizzima.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I">Ma chi avete con voi? </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">Tengo, zignore,</l>
             <l part="I">Un altro genitore. </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F">Un altro padre?</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Oh zior no; cozza dizelo? Gh'ho un barba.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I">La barba? </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">Adezzo, che ghe penza: un zio,</l>
             <l>Che zè quel, che comanda, e zta con io.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Ora capisco; brava.</l>
             <l>Ma questo zio non vi marita ancora?</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="I">Zono un poco a bonora. </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F">È ver, voi siete</l>
             <l>Ancora giovinissima,</l>
             <l part="I">Ma graziosa però. </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">Zerva umilizzima.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Voi avete, una grazia, che innamora.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Zèlo più ztà a Venezia?</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I">Questa è la prima volta. </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">El vederà</l>
             <l>Ze ghe zè del bon gusto in zta città.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I">Lo capisco da voi. </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">No fo per dire,</l>
             <l>Ma pozzo comparire.</l>
             <l part="I">Me capìzzela? </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F">Sì che vi capisco.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Quando, ch'io voggio, zo parlar toscana,</l>
             <l>Che no par, che zia gnanca veneziana.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Avete una pronuncia, che è dolcissima.</l>
             <l part="I">Voi parlate assai bene. </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">Obbligatizzima.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I">E quell'aria! </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">La diga, m'àlo vizto</l>
             <l part="I">A caminar? </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F">Un poco,</l>
             <l>Fatemi la finezza,</l>
             <l>Voi passeggiate, che a vedervi io resto.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Vedela, zior forezto?</l>
             <l>Una volta ze andava</l>
@@ -3396,84 +3413,84 @@ che sarà accennato.</emph>
             <l>Adesso ze va via</l>
             <l>Cuzzì, cuzzì, cuzzì.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Brava in ogni maniera.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Vago da ziora zantola.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Vi servo, se degnate</l>
             <l>Quella, ch'io vi offro, servitù umilissima.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Li zono obbligatizzima.</l>
             <l>No voggio, che el zignor venga con io,</l>
             <l>Perché ho paura del zior barba zio.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Egli qui non vi vede, e non sa nulla.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Una puta fanziulla</l>
             <l>Deve ancor non veduta</l>
             <l>Aricordarzi, che è fanciulla, e puta.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Non volete onorarmi?</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> La prego dizpenzarmi.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Ritornerete presto?</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Ritornerò a diznare.</l>
             <l>M'intende? </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Sì, capisco,</l>
             <l part="I">Ritornerete a pranzo. </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">Zì, a pranzare.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Non mi private della grazia vostra.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Ella è padrone della grazia noztra.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Andate pur, non vi trattengo più.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="I">Zerva </l>
           </sp>
           <stage><emph>(s'inchina)</emph>.</stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="M">Madamigella </l>
           </sp>
           <stage><emph>(s'inchina)</emph>.</stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">Addio, monzù. </l>
           </sp>
@@ -3489,17 +3506,17 @@ che sarà accennato.</emph>
           <stage>
             <emph>Donna Catte, e Angioletto escono di casa.</emph>
           </stage>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Vegnì con mi, fio mio.</l>
             <l>Parleremo tra mi, e vu,</l>
             <l part="I">Che Lucietta no senta. </l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="F">Comandè.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Sta puta ve vol ben, vu vegnì qua;</l>
             <l>Sè anca vu inamorà;</l>
@@ -3507,17 +3524,17 @@ che sarà accennato.</emph>
             <l>A farlo ancuo no se ve pol sforzar;</l>
             <l>Ma mi la guardia no ghe vòi più far.</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="I">Cossa mo voleu dir? </l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F">Vòi dir, fio mio,</l>
             <l>Che za, che no volè sposarla adesso,</l>
             <l part="I">No vegnì cusì spesso. </l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="F">Cara siora,</l>
             <l>La sposeria, ma no se pol gnancora.</l>
@@ -3526,18 +3543,18 @@ che sarà accennato.</emph>
             <l>Come presto de far me proverò,</l>
             <l>Subito vostra fia la sposerò!</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Mi no digo, che el fè, co no podè;</l>
             <l>Ma intanto slontanève.</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Co sto parlar me fè vegnir la freve.</l>
             <l>No voria, che ghe fusse</l>
             <l part="I">Sotto qualcossa. </l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F">No dasseno, fio.</l>
             <l>Anca mi mio mario</l>
@@ -3546,49 +3563,49 @@ che sarà accennato.</emph>
             <l>Me la recordo ancora,</l>
             <l>La gh'ha dito: sior Boldo, o drento, o fora.</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Lassè, che ve prometto</l>
             <l>De far più presto, che se poderà.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Ma intanto mi no vòi, che vegnì qua.</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="I">Mo perché, cara siora? </l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F">Ve l'ho dito,</l>
             <l>No ghe vòi far la guardia.</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Xèla stà gran fadiga a star con nu</l>
             <l>Tre, o quattro ore al dì?</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Prima de tutto ve dirò de sì;</l>
             <l>E po gh'è un'altra cossa,</l>
             <l>Che no la voggio dir.</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Sì ben, sì ben, me saverò chiarir.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="I">Cossa sospettereu? </l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="F">Che gh'abbiè voggia</l>
             <l part="I">De darla a qualchedun. </l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F">No, la mia zoggia.</l>
             <l>Ve dirò, per chiarirve; caro fio,</l>
@@ -3597,75 +3614,75 @@ che sarà accennato.</emph>
             <l>Me salta i schiribizzi...</l>
             <l>No posso far la guardia a do novizzi.</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Squasi me fè da rider.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Mo per cossa rideu?</l>
             <l>Perché ho dito cusì me minchioneu?</l>
             <l>Povero sporco, se savessi tuto!</l>
             <l>Ma no ve voggio dir, perché sè puto.</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="I">Maridève anca vu. </l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F">Za ho stabilio;</l>
             <l part="I">Co ho destrigà sta puta. </l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="F">V'ho capio.</l>
             <l>Presto, presto voressi destrigarve,</l>
             <l>Per voggia, che gh'avè de maridarve.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> O per questa, o per quela</l>
             <l>Mi ve la digo schieta,</l>
             <l>Qua no vegnì, se no sposè Lucieta.</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> No voria co le scattole</l>
             <l>Zirar per la città, quando la sposo.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Oe saressi zeloso?</l>
             <l>Ca de diana de dia,</l>
             <l>Mi ve dago una fia ben arlevada,</l>
             <l>Che la podè menar in t'un'armada.</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Ma quel poco de dota,</l>
             <l>Che avè dito de darme?</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Vederò de inzegnarme,</l>
             <l>Ghe darò i so manini, el so cordon,</l>
             <l>Un letto belo, e bon coi so ninzioi,</l>
             <l>E quattro paneseli per i fioi.</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Quattro soli? no ghe n'avè de pì?</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Ghe n'ho, ma i altri i vòi salvar per mi.</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Oh che cara donetta, che vu sè.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Sior sì, cusì la xè.</l>
             <l>Ghe darò do vestine, e tre carpette</l>
@@ -3674,31 +3691,31 @@ che sarà accennato.</emph>
             <l>E po, come xè stadi i nostri pati,</l>
             <l>Mi ve darò a la man diexe ducati.</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="I">I gh'aveu mo sti bezzi? </l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F">No li gh'ho</l>
             <l>Ma presto i troverò.</l>
             <l>Se vago co la puta in do, o tre case,</l>
             <l part="I">Ghe ne faremo più de vinti. </l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="F">Piase?</l>
             <l>Volè menarla a torzìo?</l>
             <l>Questo po no, sorela.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Cossa credeu, che i li darà per ela?</l>
             <l>Per mi, vedè, per mi, che se savessi,</l>
             <l>Gh'ho più de un protetor;</l>
             <l>E co i me vede, i me darave el cuor.</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> (Orsù, ghe voggio ben, e co sta vecchia</l>
             <l>No la me par segura,</l>
@@ -3707,16 +3724,16 @@ che sarà accennato.</emph>
           <stage>
             <emph>(da sé)</emph>
           </stage>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Cusì, sior Anzoleto,</l>
             <l>Diseu de sì, o de no?</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Anca ancuo, se volè, la sposerò.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Mi ve la dago subito. Lucieta.</l>
           </sp>
@@ -3729,11 +3746,11 @@ che sarà accennato.</emph>
           <stage>
             <emph>Lucietta di dentro, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Siora. </l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Aspettè un tantin.</l>
           </sp>
@@ -3743,107 +3760,107 @@ che sarà accennato.</emph>
           <sp>
             <l>No gh'el dixè gnancora. </l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Mo perché?</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Cara siora, lassè</l>
             <l>Che fassa i fatti mii, la 'l saverà.</l>
             <l>Vòi comprarghe un anelo.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I">Aveu chiamà? </l>
           </sp>
           <stage>
             <emph>(esce di fuori).</emph>
           </stage>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F">Lucietta, me consolo.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I">De cossa? </l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="I">Mo tasè.</l>
           </sp>
           <stage>
             <emph>(piano a donna Catte).</emph>
           </stage>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="I">De gnente. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Dime, cossa gh'è, Anzoletto?</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="I">Gnente, gnente, fia mia. </l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F">Vàrdalo in ciera.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I">Mo cossa gh'è? </l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F">Ti el saverà stassera.</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="I">(No la pol tàser). </l>
           </sp>
           <stage>
             <emph>(da sé).</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Via, disème tutto.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="I">Che ghel diga? </l>
           </sp>
           <stage>
             <emph>(a Anzoletto).</emph>
           </stage>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="M">Tasè. </l>
             <stage>
               <emph>(a donna Catte).</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F">Mo se no posso,</l>
             <l>Se no me lassè dir, me vien el gosso.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I">Son curiosa dasseno. </l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="F">Via parlè.</l>
             <l>Dixè quel, che volè.</l>
             <l part="I">Vago a tòr quel servizio. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Ti va via?</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Vago, ma tornerò. Cara culìa!</l>
           </sp>
@@ -3856,55 +3873,55 @@ che sarà accennato.</emph>
           <stage>
             <emph>Lucietta, e donna Catte.</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Siora mare, contème.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Oe, sta aliegra, fia mia.</l>
             <l part="I">Ancuo, col torna, el vol sposarte. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Eh via!</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Ma mi ho fatto pulito. Gh'àstu gusto?</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> E la sartora no m'ha fatto el busto.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Eh che quel, che ti gh'ha; xè bon, e belo.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I">Dov'èlo andà Anzoletto? </l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F">A tiòr l'anelo.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I">Dasseno? </l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="M">Sì te digo. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="M">Gnese. </l>
           </sp>
           <stage>
             <emph>(chiama).</emph>
           </stage>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F">Tasi;</l>
             <l>No ghe lo dir gnancora.</l>
@@ -3915,106 +3932,106 @@ che sarà accennato.</emph>
           <stage>
             <emph>Gnese, e dette.</emph>
           </stage>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="I">Chiameu? </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Sì, vegnì fuora.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Tasi, no ghe lo dir.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I">Perché? </l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F">Chi sa? el se poderia pentir.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Me fè cascar el cuor.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Ma se el gh'ha de l'amor, el lo farà.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Cossa voleu? son qua.</l>
           </sp>
           <stage>
             <emph>(sull'altana).</emph>
           </stage>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Cossa mo ghe dirastu?</l>
           </sp>
           <stage>
             <emph>(a Lucietta).</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Gnente, gnente, giustèmola.</l>
             <l>Voleu vegnir da basso</l>
             <l part="I">A ziogar a la sémola? </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F">Magari!</l>
             <l part="I">Se mia mare volesse. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Vegnì zo.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Se la vien anca ela, vegnirò.</l>
           </sp>
           <stage>
             <emph>(entra).</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I">Tolémio el taolin? </l>
           </sp>
           <stage>
             <emph>(a donna Catte).</emph>
           </stage>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F">Quel, che ti vol.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Se consolémo un pochetin al sol.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Mi vardo, che ti gh'abbi</l>
             <l>Sta voggia de zogar.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I">Per cossa? </l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F">Perché ancuo ti ha da sposar.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Giusto per questo stago allegramente.</l>
           </sp>
           <stage>
             <emph>(va in casa).</emph>
           </stage>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Oh, se cognosse, che la xè inocente!</l>
           </sp>
@@ -4028,40 +4045,40 @@ che sarà accennato.</emph>
             <emph>Donna Pasqua, e Gnese; poi Zorzetto,
 poi Lucietta, e donna Catte.</emph>
           </stage>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="I">Dove xèle? </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="M">Lucietta. </l>
           </sp>
           <stage>
             <emph>(chiama forte).</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Vegno, vegno.</l>
           </sp>
           <stage>
             <emph>(di dentro).</emph>
           </stage>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Son qua, se me volè.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="I">Dove xèla la sémola? </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Aspettè.</l>
           </sp>
           <stage>
             <emph>(di dentro).</emph>
           </stage>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> Se se zoga a la sémola,</l>
             <l>Vòi zogar anca mi.</l>
@@ -4069,7 +4086,7 @@ poi Lucietta, e donna Catte.</emph>
           <stage>
             <emph>(di casa).</emph>
           </stage>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Sì, sì, fio mio, ti zogherà anca ti.</l>
             <l>Fèghe ciera a Zorzetto.</l>
@@ -4083,19 +4100,19 @@ poi Lucietta, e donna Catte.</emph>
             <l>Mo vien qua, caro fio;</l>
             <l>Vien arente de nu.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Giusto mo adesso no lo vardo più.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> Son qua; dove se zioga?</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="I">T'ala dito to mare? </l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="F">La m'ha dito,</l>
             <l>E la m'ha consolà.</l>
@@ -4104,7 +4121,7 @@ poi Lucietta, e donna Catte.</emph>
           <stage>
             <emph>(a Gnese).</emph>
           </stage>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F">Oh matto inspirità!</l>
             <stage>
@@ -4114,26 +4131,26 @@ poi Lucietta, e donna Catte.</emph>
               <emph>(Lucietta e donna Catte portano il tavolino colla sémola).</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I">Semo qua, semo qua. </l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F">Vòi contentarla.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I">Gh'èla to mare? </l>
           </sp>
           <stage>
             <emph>(a Zorzetto).</emph>
           </stage>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="M">Sì. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Voggio chiamarla.</l>
             <l part="I">Sior'Orsola!</l>
@@ -4147,46 +4164,46 @@ poi Lucietta, e donna Catte.</emph>
           <stage>
             <emph>Orsola di casa, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F">Chiameu?</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Vegnì anca vu, vegnì a zogar; voleu?</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="I">Sì, cara siora mare. </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F">Perché no?</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="I">Semo qua in compagnia. </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F">Ben ziogherò.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I">Un soldetto per omo. </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F">Via, salùdela.</l>
           </sp>
           <stage>
             <emph>(a Gnese).</emph>
           </stage>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="I">Patrona. </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F">Bondì, Gnese. Cossa gh'àla?</l>
           </sp>
@@ -4196,19 +4213,19 @@ poi Lucietta, e donna Catte.</emph>
           <sp>
             <l part="I">Gh'aveu dito? </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="M">Gh'ho dito. </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F">La vien rossa.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> La xè contenta; ma no la se ossa.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> (Oe siora mare, cossa gh'è de niovo</l>
             <l>In tra Gnese, e Zorzetto?).</l>
@@ -4216,19 +4233,19 @@ poi Lucietta, e donna Catte.</emph>
           <stage>
             <emph>(a donna Catte).</emph>
           </stage>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> (Credo, che i sia novizzi).</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> (Vara, che stropoletto!).</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="I">Zoghemio? </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Mettè suso;</l>
           </sp>
@@ -4238,244 +4255,244 @@ poi Lucietta, e donna Catte.</emph>
           <sp>
             <l part="I">Questo xè el mio. </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F">Anca mi.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Questi qua xè do soldi. Anca per ti.</l>
           </sp>
           <stage>
             <emph>(a Zorzetto).</emph>
           </stage>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="I">Gnese, imprèsteme un soldo. </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F">Oh, oh! varè!</l>
             <l>No la gh'ha mai un bezzo. Via, tolè.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I">Siora mare, metteu? </l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F">Metterò, aspetta.</l>
           </sp>
           <stage>
             <emph>(tira fuori uno straccio).</emph>
           </stage>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> La gh'ha i bezzi zolai co la pezzetta!</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Fazzo per no li perder. Tolè el soldo.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Zoghemo, e no criemo.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="I">Per mi, no parlo mai. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Presto, missiemo.</l>
           </sp>
           <stage>
             <emph>(mescola la sémola).</emph>
           </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="I">Vòi missiar anca mi. </l>
           </sp>
           <stage>
             <emph>(fa alcuni monti colla sémola).</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Mo za, se sa;</l>
             <l>No la xè mai contenta.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> Voggio darghe anca mi una missiadina.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> E missieremo fina domattina.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Via basta, femo i mucchi.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> I mucchi i vòi far mi.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Eh, che no savè far. Se fa cusì.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Oh, siora no, no voggio,</l>
             <l>Che m'insporchè la sémola de oggio.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Gh'ho le man nete più de vu patrona.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="I">Zitto. Li farò mi. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Via, la più vecchia.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="I">La più vecchia, sì ben. </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F">Povere matte!</l>
             <l>Mi la più vecchia? tocca a donna Catte.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="I">Vecchia cottecchia! </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F">Cossa?</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="I">Gnente. </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F">No v'ho capio.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> A monte, a monte; fali ti, fio mio.</l>
           </sp>
           <stage>
             <emph>(a Zorzetto).</emph>
           </stage>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="I">Ve contenteu? </l>
           </sp>
           <stage>
             <emph>(poi va facendo i monti).</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Provève,</l>
             <l>Quelo xè tropo picolo.</l>
             <l>Quelo xè tropo grosso.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> No ve contentè mai.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I">Fèli più destaccai. </l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="F">Tolè, i xè fatti.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I">Questo mi. </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F">Lo vòi mi.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="I">Via, femo i patti. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Aspettè, che cusì</l>
             <l>Nissun più crierà.</l>
             <l>Tolemo suso per rason d'età.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Ben, ben, mi sarò l'ultima.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> No gh'è gran diferenza tra de nu.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Donna Catte, a zernir ve tocca a vu.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Oh, ve cedo, sorela.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="I">Come! </l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F">Ve cedo de dies'ani, e più.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Povera vecchia fiappa.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Via, via, femo cusì: chi chiappa, chiappa.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="I">Oe mi no trovo gnente. </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F">Ghe n'è uno.</l>
             <l part="I">Un altro. Oe, altri do. </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F">Brava dasseno.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Quatro da vostra posta?</l>
             <l>Sì, sì, sior Zorzi, l'avè fato a posta.</l>
             <l>A monte, no ghe stago.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Se volè i quatro soldi, mi ve i dago.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta #catte">
             <speaker>LUCIETTA, CATTE</speaker>
             <l> Siora sì, siora sì.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua #orsola #zorzetto">
             <speaker>PASQUA, ORSOLA, ZORZETTO</speaker>
             <l> Siora no, siora no.</l>
           </sp>
@@ -4485,61 +4502,61 @@ poi Lucietta, e donna Catte.</emph>
           <stage>
             <emph>Fabrizio con un libro in mano sul poggiolo, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Che cos'è questo strepito?</l>
             <l>Zito, per carità.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Oh, oh, in campielo no se pol zogar?</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Giocate, se volete,</l>
             <l>Senza metter sossopra la contrada.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Nu altre semo in strada.</l>
             <l>Volemo far quel, che volemo nu.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> E volemo zigar anca de più.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="I">Vi farò mandar via. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Certo! seguro!</l>
             <l>Zoghemo da recao.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Tolè sto palpagnacco.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Tolè sto canelao.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Torno a missiar i bezzi.</l>
           </sp>
-          <sp>
+          <sp who="#orsola #pasqua #zorzetto">
             <speaker>ORSOLA, PASQUA, ZORZETTO</speaker>
             <l> Siora no, siora no.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Ma cospetto di bacco!</l>
             <l>Questa è troppa insolenza.</l>
             <l>Perderò la pazienza come va.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Volemo zogar, volemo star qua.</l>
             <l>Volemo zogar, volemo star qua.</l>
@@ -4547,16 +4564,16 @@ poi Lucietta, e donna Catte.</emph>
           <stage>
             <emph>(cantando e ballando in faccia a Fabrizio).</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> O state zitte, o mi farò stimar.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Volemo star qua, volemo zigar.</l>
             <l>Volemo star qua, volemo zigar.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Voi non mi conoscete.</l>
             <l part="I">So io quel, che farò. </l>
@@ -4568,26 +4585,26 @@ poi Lucietta, e donna Catte.</emph>
           <stage>
             <emph>(ridendo forte).</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Ad un uomo d'onor così si fa?</l>
           </sp>
-          <sp>
+          <sp who="#tutti">
             <speaker>TUTTI</speaker>
             <l> Ah ah ah.</l>
           </sp>
           <stage>
             <emph>(ridendo forte).</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Tacer non sanno chi le taglia in fette.</l>
           </sp>
-          <sp>
+          <sp who="#tutti">
             <speaker>TUTTI</speaker>
             <l> Ah ah ah ah ah ah.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Che siate maledette.</l>
           </sp>
@@ -4603,102 +4620,102 @@ poi Lucietta, e donna Catte.</emph>
           <stage>
             <emph>Il Cavaliere da una parte, Anzoletto dall'altra; e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere #anzoletto">
             <speaker>CAVALIERE, ANZOLETTO</speaker>
             <l> Zitto zitto.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Oe, tre ghe n'ho trovà.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> E mi do.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> E mi uno.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Mi son stada valente.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> E mi, gramazza, no m'ha toccà gnente.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Ma cosa mai è stato?</l>
             <l part="I">Che è accaduto di male? </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Gnente affatto.</l>
             <l>Se zogava a la sémola.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Che diavolo di gioco!</l>
             <l>Credea, che andasse la contrada a foco.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I">Anzoletto, tre soldi. </l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="F">Brava, brava!</l>
             <l>Sempre in strada a zogar?</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Oh via per questo me voreu criar?</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="I">Basta; la xè fenia. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">L'àstu portà?</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="I">Cossa? </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="M">L'anelo. </l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="F">Oh, donca lo savè.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I">Lo so, seguro, che lo so. </l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="F">Vardè.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Oh belo! Siora mare.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Cossa gh'àlo portà?</l>
           </sp>
           <stage>
             <emph>(a donna Pasqua).</emph>
           </stage>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="I">No ghe vedo. </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F">Sior'Orsola,</l>
             <l part="I">Cossa gh'àlo portà? </l>
@@ -4706,31 +4723,31 @@ poi Lucietta, e donna Catte.</emph>
           <stage>
             <emph>(piano).</emph>
           </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="M">L'anelo. </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F">Sì?</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Tasi, fia mia, ti el gh'averà anca ti.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="I">Quando? </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F">Co sarà tempo.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="I"> Ma quando? </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F">Co mio fio</l>
             <l>Sarà vostro mario.</l>
@@ -4738,53 +4755,53 @@ poi Lucietta, e donna Catte.</emph>
           <stage>
             <emph>(Gnese si volta per vergogna).</emph>
           </stage>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="I">Cossa gh'àla mia fia? </l>
           </sp>
           <stage>
             <emph>(a Orsola).</emph>
           </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F">La se vergogna.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Via, no te far nasar, che no bisogna.</l>
           </sp>
           <stage>
             <emph>(a Gnese).</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I">Gnese. </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F">Me ne consolo.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Mi lasciate così negletto, e solo?</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="I">Cossa gh'ìntrelo elo? </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F">Galantuomo,</l>
             <l>Io sono un onest'uomo;</l>
             <l>Non intendo sturbar la vostra pace.</l>
             <l>Son buon amico, e l'allegria mi piace.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> (Oe disè, siora mare,</l>
             <l>Se Anzoletto el volesse per compare!).</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Magari! aspetta mi.</l>
             <l part="I">Zenero.</l>
@@ -4792,47 +4809,47 @@ poi Lucietta, e donna Catte.</emph>
           <stage>
             <emph>(a Anzoletto).</emph>
           </stage>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="F">Me chiameu?</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> El compare el gh'aveu?</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Mi no, no l'ho trovà.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Doveressimo tòr quel, che xè là.</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Mo, se no so chi el sia.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> N'importa, za el va via;</l>
             <l>Fenio sto carneval,</l>
             <l part="I">No lo vedemo più. </l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="F">No disè mal.</l>
             <l>Cusì, quando le nozze xè fenie,</l>
             <l>No gh'averò el compare per i piè.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="I">Che ghel diga? </l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="M">Disèghelo. </l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F">L'è fatta.</l>
           </sp>
@@ -4848,49 +4865,49 @@ poi Lucietta, e donna Catte.</emph>
           <sp>
             <l>Ghe vòi dir do parole in t'un canton.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Son da voi, buona donna.</l>
           </sp>
           <stage>
             <emph>(s'accosta in disparte con donna Catte).</emph>
           </stage>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> (Una gran tribia, che xè mia madonna!).</l>
           </sp>
           <stage>
             <emph>(da sé).</emph>
           </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Disè, sior Anzoletto,</l>
             <l part="I">Quando magnemio sti confetti? </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Presto.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Oh, v'ho visto alla ciera.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I">N'è vero fio? </l>
           </sp>
           <stage>
             <emph>(ad Anzoletto).</emph>
           </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="M">Quando sposeu? </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Stassera.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> (Tolè su; donna Catte</l>
             <l>Un de sti dì la se pol maridar;</l>
@@ -4899,102 +4916,102 @@ poi Lucietta, e donna Catte.</emph>
           <stage>
             <emph>(da sé).</emph>
           </stage>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Puti, sto zentilomo</l>
             <l part="I">Sarà vostro compare. </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F">Sì, signori,</l>
             <l>È un onor, ch'io ricevo.</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Grazie. (Za me consolo, che el va via).</l>
           </sp>
           <stage>
             <emph>(da sé).</emph>
           </stage>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> El l'ha fatto, n'è vero? in grazia mia.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Ti xè contenta, che ti gh'ha l'anelo.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Puti voleu, che femo un garanghelo?</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Sì ben, un bianco, e un brun,</l>
             <l>Tutti se tanserà tanto per un.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Aspettate, a bel bello.</l>
             <l>Ditemi, che vuol dire un garanghello?</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Ghe lo spiegherò mi. Se fa un disnar;</l>
             <l>Uno se tol l'insulto de pagar;</l>
             <l>E el se rimborsa dopo de le spese,</l>
             <l>A vinti soldi, o trenta soldi al mese.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> E ho sentio a dir da tanti, che i xè avvezzi</l>
             <l>Aver oltre el disnar anca dei bezzi.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Ma in sta occasion, sior Anzoletto belo,</l>
             <l>Me par, che nol ghe calza el garanghelo.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Eh che andate pensando?</l>
             <l>Che state fra di voi garanghellando?</l>
             <l>Il compare son io,</l>
             <l>E a tutti il desinar lo vo' far io.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Bravo. </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Bravo dasseno.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Vu no gh'intrè, sorela.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Che nol me invida? La saria ben bela!</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Tutti, tutti v'invito.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Grazie, e nu vegniremo.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="I">Mi no ghe vòi vegnir. </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F">Sì, che anderemo.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l>Camerier.</l>
           </sp>
@@ -5007,29 +5024,29 @@ poi Lucietta, e donna Catte.</emph>
           <stage>
             <emph>Sansuga e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#sansuga">
             <speaker>SANSUGA</speaker>
             <l part="I">La comandi. </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F">Preparate</l>
             <l>Un desinar per tutti; e dite al cuoco,</l>
             <l part="I">Che onor si faccia. </l>
           </sp>
-          <sp>
+          <sp who="#sansuga">
             <speaker>SANSUGA</speaker>
             <l part="F">L'anderò a avisar.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> No, no, aspettè, che mi vòi ordenar.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Comandate, sposina.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Volemo i risi co la castradina,</l>
             <l>E dei boni capponi, e de la carne,</l>
@@ -5037,71 +5054,71 @@ poi Lucietta, e donna Catte.</emph>
             <l>E del vin dolce bon, e che la vaga;</l>
             <l>E fè pulito, che el compare paga.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="I">E mi farò le frittole. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Se sa.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Ma sior compare me le pagherà.</l>
           </sp>
-          <sp>
+          <sp who="#sansuga">
             <speaker>SANSUGA</speaker>
             <l> Xèla contenta de sto bel disnar?</l>
           </sp>
           <stage>
             <emph>(al Cavaliere).</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I">Io lascio far a loro. </l>
           </sp>
-          <sp>
+          <sp who="#sansuga">
             <speaker>SANSUGA</speaker>
             <l part="F">No la xè</l>
             <l>Roba da pari soi.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Se non importa a me, che importa a voi?</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="I">Che ghe sia del pan tondo. </l>
           </sp>
-          <sp>
+          <sp who="#sansuga">
             <speaker>SANSUGA</speaker>
             <l part="F">El ghe sarà.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Fène de la manestra in quantità.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Del figà de vedèlo.</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Una lengua salada.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> Quattro fette rostìe de sopressada.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> De le cervele tenere.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Bisogna sodisfarne.</l>
           </sp>
-          <sp>
+          <sp who="#sansuga">
             <speaker>SANSUGA</speaker>
             <l> Deboto è più la zonta della carne.</l>
           </sp>
@@ -5114,93 +5131,93 @@ poi Lucietta, e donna Catte.</emph>
           <stage>
             <emph>Gasparina, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="I">Cozza zè zto zuzzuro. </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F">Oh madamina!</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> No savè, Gasparina?</l>
             <l>Son novizza, disnemo in compagnia.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Favorite voi pur per cortesia.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Oh no pozzo dazzeno;</l>
             <l>Ella za, zignor mio,</l>
             <l>Che ziamo dipendente da mio zio.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I">Cossa dìsela? </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">Zente?</l>
             <l>Grame! no le capizze gnente, gnente.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Verrò, se mi è permesso,</l>
             <l>Seco a parlare, e ad invitar lui stesso.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> La vol vegnir de zu?</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I">Si può, madamigella? </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">Uì, monzù.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I">Oh cara! </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F">Oh che te pustu!</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Gradisco assai l'esibizion cortese.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Done, dizè, no l'intendè el franzeze?</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Caspita! siora sì.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Oh, lo so dir uì.</l>
           </sp>
           <stage>
             <emph>(caricata).</emph>
           </stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> La zenta, zior monzù:</l>
             <l>(La prego dezpenzarme;</l>
             <l>Perché mi con cuztie no vòi zbazzarme).</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I">Mi spiacerebbe assai. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F"> (Oe, procuremo</l>
             <l>Che la vegna con nu, che rideremo).</l>
@@ -5208,21 +5225,21 @@ poi Lucietta, e donna Catte.</emph>
           <stage>
             <emph>(a Orsola).</emph>
           </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> (Sì ben, sì ben). Via, siora Gasparina,</l>
             <l>No semo degne de disnar con vu;</l>
             <l>Ma fè sta grazia, vegnì via con nu.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Ze potezzi, verrei. Non vengo zola.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Via, che ve metteremo in cao de tola.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Ve ringrazio dazzeno.</l>
             <l>Zerto, che ze vegnizze,</l>
@@ -5230,46 +5247,46 @@ poi Lucietta, e donna Catte.</emph>
             <l>Ma no pozzo vegnir zenza el zior zio.</l>
             <l part="I">Vol dir barba, zavè. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Veh! mi credeva,</l>
             <l>Che parlessi de un fior, in verità.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> (Povere zenza zezto, no le za).</l>
           </sp>
           <stage>
             <emph>(da sé).</emph>
           </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> (Anca ti, Gnese dighe, che la vegna).</l>
           </sp>
           <stage>
             <emph>(a Gnese).</emph>
           </stage>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Via, vegnì; andemo tutte.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Zta beno in caza le fanciulle pute.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Non si conclude nulla.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Dizè, zaveu cozza vol dir fanciulla?</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Mi no lo so, sorela.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Oe, zior monzù, la ghe lo zpiega ela.</l>
           </sp>
@@ -5279,123 +5296,123 @@ poi Lucietta, e donna Catte.</emph>
           <stage>
             <emph>Fabrizio e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Ecco zior barba zio.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I">Servitore divoto. </l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="F">Padron mio.</l>
             <l part="I">Cosa si fa qui in strada? </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">Via, che el taza.</l>
             <l part="I">Me faralo nazar? </l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="F">Subito in casa.</l>
           </sp>
           <stage>
             <emph>(a Gasparina).</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Fate torto, signore,</l>
             <l>Alla nipote vostra, ch'è onestissima.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="I">Non vel fate più dir. </l>
           </sp>
           <stage>
             <emph>(a Gasparina).</emph>
           </stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">Zerva umilizzima.</l>
           </sp>
           <stage>
             <emph>(al Cavaliere).</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="I">Via. </l>
           </sp>
           <stage>
             <emph>(caricandola).</emph>
           </stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="M">La zcuzi. </l>
           </sp>
           <stage>
             <emph>(al Cavaliere).</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F">Mi spiace.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="I">Ghe zon zerva. </l>
           </sp>
           <stage>
             <emph>(s'inchina).</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="F">Un poco più.</l>
           </sp>
           <stage>
             <emph>(caricandola).</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I">Servo, madamigella. </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">Addio, monzù.</l>
           </sp>
           <stage>
             <emph>(entra in casa).</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Il suo genio bizarro, ora mi è noto.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I">Favorite, signor... </l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="F">Schiavo divoto.</l>
             <l>E voi, donne insolenti...</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Coss'è sto strappazzarne?</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Sto dirne villania?</l>
           </sp>
-          <sp>
+          <sp who="#tutti">
             <speaker>TUTTI</speaker>
             <l part="I">Vardè, dixè, sentì. </l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="F">No, vado via.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> S'ella non può venir, non so, che fare.</l>
             <l>Andiamo a desinare;</l>
@@ -5405,29 +5422,29 @@ poi Lucietta, e donna Catte.</emph>
           <stage>
             <emph>(entra in locanda).</emph>
           </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Vien via, Zorzetto; daghe man a Gnese.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Anderò da mia posta.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> Sempre cusì la fa.</l>
           </sp>
           <stage>
             <emph>(entra in locanda).</emph>
           </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Tasi, che un dì la man la te darà.</l>
           </sp>
           <stage>
             <emph>(entra in locanda con Zorzetto).</emph>
           </stage>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Vegno anca mi a disnar,</l>
             <l>Che magnada de risi, che vòi dar!</l>
@@ -5435,7 +5452,7 @@ poi Lucietta, e donna Catte.</emph>
           <stage>
             <emph>(entra in locanda).</emph>
           </stage>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Andemo, puti, andemo.</l>
             <l>Quanto più volentiera</l>
@@ -5445,7 +5462,7 @@ poi Lucietta, e donna Catte.</emph>
           <stage>
             <emph>(entra in locanda).</emph>
           </stage>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Andemo pur ancuo, femo a la granda;</l>
             <l>Ma no vòi più compari, né locanda.</l>
@@ -5453,7 +5470,7 @@ poi Lucietta, e donna Catte.</emph>
           <stage>
             <emph>(entra in locanda).</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Aspettème, Anzoletto.</l>
             <l>Ah, sento proprio, che el mio cuor s'impizza;</l>
@@ -5471,7 +5488,7 @@ poi Lucietta, e donna Catte.</emph>
           <stage>
             <emph>Il Cavaliere esce di locanda senza cappello, e senza spada.</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Io non ne posso più, confesso il vero,</l>
             <l>Non ho goduto mai una giornata</l>
@@ -5494,48 +5511,48 @@ poi Lucietta, e donna Catte.</emph>
           <stage>
             <emph>Gasparina sul poggiolo, ed il suddetto.</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Signora.</l>
           </sp>
           <stage>
             <emph>(salutandola).</emph>
           </stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Mo cozza vorlo? el vaga via in bon'ora.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I"> Domando il signor zio. </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F"> Oh ze el zavezze!</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Ditemi, cosa è stato?</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> No ghe pozzo parlar. Zon zfortunada.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Dite allo zio, che favorisca in strada.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="I"> El m'ha dito cuzzì... </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F"> Non vi esponete</l>
             <l>A un insulto novel per causa mia.</l>
             <l part="I">Ritiratevi pur. </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F">Oh, vago via.</l>
           </sp>
@@ -5546,11 +5563,11 @@ poi Lucietta, e donna Catte.</emph>
             <l>La zenta, voggio dir zta cozza zola.</l>
             <l>Zior, el m'ha dito una brutta parola.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I"> E che cosa vi ha detto? </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F"> No vorave,</l>
             <l part="I">Che el me zentizze. Vago via. </l>
@@ -5558,21 +5575,21 @@ poi Lucietta, e donna Catte.</emph>
           <stage>
             <emph>(come sopra).</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F"> Sì, brava.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Oe, la zenta, el m'ha dito: «ziete ziocca».</l>
             <l part="I">Cozza vol dir? </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F"> Stolta vuol dire, alocca.</l>
             <l>Ma andate via, che non vi trovi qui.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Oh che caro zior barba! alocca a mi?</l>
             <l>I dirà, che el zè matto,</l>
@@ -5591,11 +5608,11 @@ poi Lucietta, e donna Catte.</emph>
             <l>E quando la me par cattiva a mi,</l>
             <l>Bizogna certo, che la zia cuzì!</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I"> Signora, vostro zio. </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F"> No zon de quele,</l>
             <l>Che troppo gh'abbia piazzo a laorar;</l>
@@ -5609,11 +5626,11 @@ poi Lucietta, e donna Catte.</emph>
           <stage>
             <emph>Fabrizio di casa, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I"> Servitor suo. </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F"> Zerva, zior Cavalier,</l>
             <l>Me lazzelo cuzì?</l>
@@ -5621,58 +5638,58 @@ poi Lucietta, e donna Catte.</emph>
           <stage>
             <emph>(credendo esser ella salutata).</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="I"> La riverisco. </l>
           </sp>
           <stage>
             <emph>(a Gasparina, facendosi vedere).</emph>
           </stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F"> Oh poveretta mi!</l>
           </sp>
           <stage>
             <emph>(parte).</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Signor, parmi l'ardire un po' soverchio.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Son venuto per voi.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Che vuol da' fatti miei?</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Non si tratta così coi pari miei.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Non vi conosco, ma qualunque siate</l>
             <l>Saprete bene, che l'onor consiglia</l>
             <l>Di custodir con gelosia una figlia.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Io non l'insulto, e poi</l>
             <l>Non è una gran signora.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Chi ella si sia, voi non sapete ancora.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Chi è sono informato,</l>
             <l>So, che in misero stato è la famiglia,</l>
             <l>E che alla fin di un bottegaio è figlia.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> È ver, che mio fratello,</l>
             <l>Per ragion d'un duello,</l>
@@ -5682,125 +5699,125 @@ poi Lucietta, e donna Catte.</emph>
             <l>Misero, fu costretto a far mestiere;</l>
             <l>Povero nacque, è ver, ma cavaliere.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I"> Siete napoletani? </l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="F"> Sì signore.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Son di Napoli anch'io;</l>
             <l>Noto vi sarà forse il nome mio.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="I"> Dar si potrebbe. </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F"> Io sono</l>
             <l>Il cavaliere Astolfi.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Vi domando perdono</l>
             <l>Se il mio dovere non ho fatto in prima;</l>
             <l>Ebbi pel padre vostro della stima.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I"> Lo saprete, ch'è morto. </l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="F"> Il so pur troppo;</l>
             <l>E so, deh compatitemi</l>
             <l>Se parlovi sincero,</l>
             <l part="I">Che voi vi siete rovinato. </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F"> È vero.</l>
             <l>Son tre anni, che giro per il mondo,</l>
             <l>Ed è la borsa mia ridotta al fondo.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="I"> Che pensate di far? </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F"> Non so; l'entrate</l>
             <l>Son per altri due anni ipotecate.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Compatite, signore,</l>
             <l>Questa non è la via.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Non mi parlate di malinconia.</l>
             <l>Per questi quattro giorni</l>
             <l>Di carnevale ho del denar, che basta.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Quando terminerà?</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Non vo' pensar; quel che sarà, sarà.</l>
             <l>Voi come vi chiamate?</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="I"> Fabrizio dei Ritorti. </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F"> Oh, oh, aspettate,</l>
             <l>Siete voi quel Fabrizio,</l>
             <l>Ch'era in paese in povertà ridotto,</l>
             <l>E che ricco si è fatto con il lotto?</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Ricco no; ma son quel che ha guadagnato,</l>
             <l>Tanto, che basta a migliorar lo stato.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I"> Avrete del denaro.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="F"> Ho una nipote,</l>
             <l>Che abbisogna di dote.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Quanto le destinate?</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Se troverà marito,</l>
             <l>Darò più, darò men giusta al partito.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I"> Ella lo sa? </l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="F"> Non ne sa niente ancora.</l>
             <l>Conoscerla ho voluto, esaminarla;</l>
             <l>Ma presto, se si può, vuo' maritarla.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> (Se avesse buona dote,</l>
             <l>Quasi mi esibirei</l>
@@ -5809,7 +5826,7 @@ poi Lucietta, e donna Catte.</emph>
           <stage>
             <emph>(da sé)</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> (Tre, o quattromila scudi,</l>
             <l>E anche più, se conviene,</l>
@@ -5818,11 +5835,11 @@ poi Lucietta, e donna Catte.</emph>
           <stage>
             <emph>(da sé)</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I"> A chi vorreste darla? </l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="F"> Le occasioni</l>
             <l>Ancor non son venute.</l>
@@ -5834,138 +5851,138 @@ poi Lucietta, e donna Catte.</emph>
             <emph>Lucietta, Anzoletto, donna Catte, donna Pasqua,
 Orsola, Gnese, Zorzetto sulla loggia della locanda, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Oe, sior compare, alla vostra salute.</l>
           </sp>
           <stage>
             <emph>(beve col bicchiere).</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I"> Evviva. </l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="M"> Con licenza. </l>
           </sp>
           <stage>
             <emph>(al Cavaliere).</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F"> Dove andate?</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Fuggo da queste donne indiavolate.</l>
           </sp>
           <stage>
             <emph>(parte e va in casa).</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Mo cossa falo, che nol vien dessù?</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Ho magnà tanto, che no posso più.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Animo, buona gente,</l>
             <l part="I">Bevete allegramente. </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F"> Via bevemo.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Sior compare, ghe 'l femo.</l>
           </sp>
           <stage>
             <emph>(col bicchiere in mano).</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Bevete pure, compagnia giuliva.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="I"> Alla salute di chi paga. </l>
           </sp>
-          <sp>
+          <sp who="#tutti">
             <speaker>TUTTI</speaker>
             <l part="F"> E viva.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Zitto, che voggio far</l>
             <l>Un bel prindese in rima.</l>
             <l>«CO son in allegria, mi no me instizzo,</l>
             <l>Alla salute del mio bel novizzo».</l>
           </sp>
-          <sp>
+          <sp who="#tutti">
             <speaker>TUTTI</speaker>
             <l part="I"> E viva, e viva. </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F"> Anca mi, presto, presto.</l>
           </sp>
           <stage>
             <emph>(col bicchiere si fa dar da bevere).</emph>
           </stage>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Via sto poco de resto.</l>
           </sp>
           <stage>
             <emph>(versa col boccale il vino ad Orsola).</emph>
           </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> «CO sto gotto de vin, ch'è dolce, e bon,</l>
             <l>Fazzo un prindese in rima al più minchion».</l>
           </sp>
-          <sp>
+          <sp who="#tutti">
             <speaker>TUTTI</speaker>
             <l part="I"> E viva, e viva. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F"> Oe a chi ghe la dastu?</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Oh che gonza! No sastu?</l>
           </sp>
           <stage>
             <emph>(accenna al Cavaliere).</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Via, bravi, che si rida, e che si beva,</l>
             <l>Questo brindesi è mio, nessun mel leva.</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Anca mi, sior compare,</l>
             <l>«Un prindese ghe fazzo</l>
             <l>Co sto vin che gh'ho in man,</l>
             <l>Con patto, che el me staga da lontan».</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> «Vi rispondo ancor io, compare, amico:</l>
             <l>Di star con voi non me n'importa un fico».</l>
           </sp>
-          <sp>
+          <sp who="#tutti">
             <speaker>TUTTI</speaker>
             <l part="I"> E viva, e viva. </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F"> Son qua mi; patroni.</l>
             <l part="I">Dème da béver. </l>
@@ -5973,21 +5990,21 @@ Orsola, Gnese, Zorzetto sulla loggia della locanda, e detti.</emph>
           <stage>
             <emph>(ad Anzoletto).</emph>
           </stage>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="F"> Tolè pur vecchietta.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> No me dir vecchia, razza maledetta.</l>
             <l>«E se son vecchia no son el demonio,</l>
             <l>Alla salute del bon matrimonio».</l>
           </sp>
-          <sp>
+          <sp who="#tutti">
             <speaker>TUTTI</speaker>
             <l part="I"> E viva, e viva. </l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F"> Presto, presto a mi.</l>
           </sp>
@@ -5998,20 +6015,20 @@ Orsola, Gnese, Zorzetto sulla loggia della locanda, e detti.</emph>
             <l>«Senza mario mi no posso star più,</l>
             <l>Alla salute della zoventù».</l>
           </sp>
-          <sp>
+          <sp who="#tutti">
             <speaker>TUTTI</speaker>
             <l part="I"> E viva, e viva. </l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="F"> Un prindese anca mi</l>
             <l>Vòi far; ve contentèu?</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="I"> Falo, falo, fio mio. </l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="F"> Via, me ne deu?</l>
           </sp>
@@ -6022,92 +6039,92 @@ Orsola, Gnese, Zorzetto sulla loggia della locanda, e detti.</emph>
             <l>«Sto vin xè meggio assae dell'acqua riosa</l>
             <l>Alla salute de la mia morosa».</l>
           </sp>
-          <sp>
+          <sp who="#tutti">
             <speaker>TUTTI</speaker>
             <l part="I"> E viva, e viva. </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F"> Via, Gnese, anca ti,</l>
             <l part="I">Che ti xè cusì brava. </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F"> Fate onor!</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="I"> Dème da béver. </l>
           </sp>
           <stage>
             <emph>(a Anzoletto).</emph>
           </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F"> Fàghelo de cuor.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="I"> Voggio dàrghelo mi. </l>
           </sp>
           <stage>
             <emph>(leva la boccia di mano d'Anzoletto).</emph>
           </stage>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="F"> Olà! debotto!...</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="I"> Vardè, che sesti! </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F"> Tasi là, pissotto.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l>«CO sto vin, che xè puro, e xè dolcetto</l>
             <l part="I">Mi bevo alla salute...» </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F"> «De Zorzetto».</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> No, de sior Anzoletto.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="I"> Vardè che sesti! </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F"> Senti sa, pettazza</l>
             <l part="I">Te darò una schiaffazza. </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F"> Oe, oe, patrona?</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Schiaffi, a chi scagazzera?</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="I"> Vecchiazza. </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="M"> Tasè là. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F"> Via frittolera.</l>
           </sp>
-          <sp>
+          <sp who="#tutti">
             <speaker>TUTTI</speaker>
             <l> Cossa? via, tasè là; farò, dirò;</l>
             <l>Lassè star, vegnì qua, zito, sior no.</l>
@@ -6115,7 +6132,7 @@ Orsola, Gnese, Zorzetto sulla loggia della locanda, e detti.</emph>
           <stage>
             <emph>(tutti insieme alternativamente dicono tai parole, ed entrano).</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Dai brindesi al gridar passati sono;</l>
             <l>Questa è tutta virtù del vino buono.</l>
@@ -6133,61 +6150,61 @@ Orsola, Gnese, Zorzetto sulla loggia della locanda, e detti.</emph>
           <stage>
             <emph>Gasperina sul poggiolo, poi Fabrizio di casa.</emph>
           </stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Mo cozza zè zto ztrepito?</l>
             <l>Mo la zè una gran cozza in zto campiello;</l>
             <l>Me par, che ziemo a caza de colù.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Per dispetto lo fan, non posso più.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="I"> Dove valo, zior barba? </l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="F"> A ricercare</l>
             <l>Una casa lontana, e vuo' trovarla</l>
             <l>Innanzi domattina,</l>
             <l>Quando fosse ben anche una cantina.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Mo zì dazzeno, che anca mi zon ztuffa.</l>
             <l>Zempre zuzzuri; zempre i fa baruffa.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Mi fa stupire il cavaliere Astolfi,</l>
             <l>Che di simile gente è il protettor.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="I"> Chi zèlo zto zignor? </l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="F"> Quel, che ho veduto</l>
             <l>Fare a vossignoria più d'un saluto.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="I"> Lo cognozzelo? </l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="F"> Sì, è d'una famiglia</l>
             <l>Nobile assai, ma il suo poco giudizio</l>
             <l>Ha mandata la casa in precipizio.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="I"> La me conta qualcozza. </l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="F"> In su la strada</l>
             <l>Vi parlerò? Si vede ben che avete</l>
@@ -6200,14 +6217,14 @@ Orsola, Gnese, Zorzetto sulla loggia della locanda, e detti.</emph>
           <sp>
             <l>Oh, mandatemi giù la tabacchiera.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="I"> Zubito.</l>
           </sp>
           <stage>
             <emph>(entra).</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="F"> In questo loco</l>
             <l>Parmi d'esser nel foco. Son dei mesi,</l>
@@ -6217,26 +6234,26 @@ Orsola, Gnese, Zorzetto sulla loggia della locanda, e detti.</emph>
             <l>Perdere a me il rispetto?</l>
             <l>Meglio è, ch'io vada via di questa casa.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="I"> Zon qua. </l>
           </sp>
           <stage>
             <emph>(di casa, colla tabacchiera in mano.)</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="M"> Ma perché voi? </l>
           </sp>
           <stage>
             <emph>(irato.)</emph>
           </stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F"> Mo via, che el taza.</l>
             <l>El za pur, che la zerva zè amalada.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Io non voglio, che voi venghiate in strada.</l>
             <l>Dal balcon si poteva buttar giù.</l>
@@ -6244,42 +6261,42 @@ Orsola, Gnese, Zorzetto sulla loggia della locanda, e detti.</emph>
           <stage>
             <emph>(prende la tabacchiera con collera.)</emph>
           </stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> No ghe vegnirò più.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> La madre vi ha allevata</l>
             <l>Vil com'ella era nata, e il padre vostro</l>
             <l>Si è scordato egli pur del sangue nostro.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="I"> Zior barba, zemio nobili? </l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="F">Partite.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Me zento un no zo che de nobiltà.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Andate via di qua;</l>
             <l>Entrate in quella casa,</l>
             <l part="I">E non uscite più. </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F"> Mo via, che el taza.</l>
           </sp>
           <stage>
             <emph>(entra).</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Fino che l'ho con me, non sto più bene</l>
             <l>Vuo' maritarla al primo che mi viene.</l>
@@ -6293,16 +6310,16 @@ Orsola, Gnese, Zorzetto sulla loggia della locanda, e detti.</emph>
           <stage>
             <emph>Il Cavaliere dalla locanda, e SANSUGA.</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> L'abbiamo accomodata.</l>
           </sp>
-          <sp>
+          <sp who="#sansuga">
             <speaker>SANSUGA</speaker>
             <l> La xè una baronata;</l>
             <l>La ghe doveva metter più spavento.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Io me la prendo per divertimento.</l>
             <l>Or ora scenderanno,</l>
@@ -6310,69 +6327,69 @@ Orsola, Gnese, Zorzetto sulla loggia della locanda, e detti.</emph>
             <l>E questo è il piacer mio,</l>
             <l>Veder ballare; e vuo' ballare anch'io.</l>
           </sp>
-          <sp>
+          <sp who="#sansuga">
             <speaker>SANSUGA</speaker>
             <l part="I"> Vorla el conto? </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="M"> Vediamo. </l>
           </sp>
-          <sp>
+          <sp who="#sansuga">
             <speaker>SANSUGA</speaker>
             <l part="F"> Eccolo qua.</l>
           </sp>
           <stage>
             <emph>(gli dà il conto).</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Settanta lire! che bestialità!</l>
           </sp>
-          <sp>
+          <sp who="#sansuga">
             <speaker>SANSUGA</speaker>
             <l> Ghe ne xè più de trenta</l>
             <l>De vin, ghe lo protesto;</l>
             <l>Porlo spender de manco in tutto el resto?</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I"> Bastano tre zecchini? </l>
           </sp>
-          <sp>
+          <sp who="#sansuga">
             <speaker>SANSUGA</speaker>
             <l part="F"> No vòi gnanca,</l>
             <l part="I">Che la sia desgustada. </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F"> Eccoli qui.</l>
           </sp>
-          <sp>
+          <sp who="#sansuga">
             <speaker>SANSUGA</speaker>
             <l> E po ghe xè la bona man a mi.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I"> Ecco mezzo ducato. </l>
           </sp>
-          <sp>
+          <sp who="#sansuga">
             <speaker>SANSUGA</speaker>
             <l part="F"> Obbligatissimo.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I"> Siete contento ancor? </l>
           </sp>
-          <sp>
+          <sp who="#sansuga">
             <speaker>SANSUGA</speaker>
             <l part="F"> Son contentissimo.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Dite che ponno ritornare a basso.</l>
           </sp>
-          <sp>
+          <sp who="#sansuga">
             <speaker>SANSUGA</speaker>
             <l> Me par che i vegna; séntela che chiasso?</l>
           </sp>
@@ -6385,7 +6402,7 @@ Orsola, Gnese, Zorzetto sulla loggia della locanda, e detti.</emph>
           <stage>
             <emph>Il Cavaliere, poi Gasparina.</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Oh, se finisco il carnevale in bene,</l>
             <l>È un prodigio davvero.</l>
@@ -6398,63 +6415,63 @@ Orsola, Gnese, Zorzetto sulla loggia della locanda, e detti.</emph>
             <l>Era d'altra genia,</l>
             <l>Una dama non fu né men la mia.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="I"> El cavalier Aztolfi. </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F"> Oh mia signora,</l>
             <l>Or che so il grado vostro,</l>
             <l>Di donarvi il mio cor mi son prefisso.</l>
             <l part="I">Nobile siete, il so. </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F"> La reverizzo.</l>
           </sp>
           <stage>
             <emph>(sostenuta).</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Lo zio mi ha confidato,</l>
             <l>Ch'ambi siam d'una patria, e che ambi siamo</l>
             <l part="I">Poco più, poco men... </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F"> Già lo zappiamo.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I"> Egli vuol maritarvi. </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F"> Cozzì è.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Volesse il Ciel, che voi toccaste a me.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> La diga: èlo zelenza?</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Me la sogliono dare in qualche loco.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Che i me diga luztrizzima zè poco.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I"> Titolata sarete. </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F"> Zì dazzeno?</l>
           </sp>
@@ -6464,20 +6481,20 @@ Orsola, Gnese, Zorzetto sulla loggia della locanda, e detti.</emph>
           <sp>
             <l>Cozza zè zto fracazzo?</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Ecco la compagnia; ci ho un gusto pazzo.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Ztar qui no ze convien a una par mio.</l>
             <l part="I">La reverizzo. </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="M"> Vi son servo. </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F"> Addio.</l>
           </sp>
@@ -6496,32 +6513,32 @@ alla veneziana; donna Pasqua canta alla villotta, ballano alcune
 furlane, ed anco le vecchie. Vengono altri di strada, si uniscono,
 e ballano con un ballo in tutti, poi come segue.</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> No posso più; vien via con mi Anzoletto.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Presto, che vaga a collegarme in letto.</l>
           </sp>
           <stage>
             <emph>(parte, ed entra in casa).</emph>
           </stage>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Seu stracca? v'averè cavà la pizza.</l>
           </sp>
           <stage>
             <emph>(a Lucietta).</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Oe, no volè che balla? son novizza.</l>
           </sp>
           <stage>
             <emph>(parte, ed entra in casa).</emph>
           </stage>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Eh, co son so mario,</l>
             <l>Sangue de diana, che la gh'ha fenio.</l>
@@ -6529,37 +6546,37 @@ e ballano con un ballo in tutti, poi come segue.</emph>
           <stage>
             <emph>(parte, ed entra con Lucietta).</emph>
           </stage>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="I"> Puti, mi no ghe vedo. </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F"> Vegnì via.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Dame man, che no casca, cara fia.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Andemo, vegnì qua.</l>
           </sp>
           <stage>
             <emph>(dà una mano a donna Pasqua).</emph>
           </stage>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="I"> Gnanca un saludo? </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F"> Oh matto inspirità!</l>
           </sp>
           <stage>
             <emph>(a Zorzetto,ed entra in casa con donna Pasqua).</emph>
           </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Tasi, tasi, fio mio; no la xè usa.</l>
             <l>Ma da resto de drento la se brusa.</l>
@@ -6567,7 +6584,7 @@ e ballano con un ballo in tutti, poi come segue.</emph>
           <stage>
             <emph>(entra in casa).</emph>
           </stage>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l>So, che la me vol ben,</l>
             <l>Per questo no me togo certi affani;</l>
@@ -6576,7 +6593,7 @@ e ballano con un ballo in tutti, poi come segue.</emph>
           <stage>
             <emph>(entra in casa).</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l>Schiavo di lor signori;</l>
             <l>Or che ciascuno è sazio,</l>
@@ -6594,7 +6611,7 @@ e ballano con un ballo in tutti, poi come segue.</emph>
           <stage>
             <emph>Fabrizio con quattro Facchini, Gasparina sul poggiolo.</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Sì, sì, venite meco.</l>
             <l>Voglio, che ci spicciamo immantinente.</l>
@@ -6602,59 +6619,59 @@ e ballano con un ballo in tutti, poi come segue.</emph>
           <stage>
             <emph>(ai facchini).</emph>
           </stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Oe, zior barba, chi zè mai quela zente?</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Questi sono i facchini.</l>
             <l>La casa ho ritrovata,</l>
             <l>E di qua innanzi sera andiamo via.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Cuzì presto z'ha da far mazzaria?</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="I"> Tant'è. Venite meco.</l>
           </sp>
           <stage>
             <emph>(ai facchini).</emph>
           </stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F"> Ma, la diga.</l>
             <l>Z'ha d'andar via cuzzì?</l>
             <l>E ze la caza no me piaze a mi?</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="I"> Credo, vi piacerà. </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F"> Zèlo un palazzo?</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> È una casa civile.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Gh'è riva in caza? tegniremio barca?</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="I"> Che ne volete fare? </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F"> Almanco a un remo;</l>
             <l>O che zemo, zior barba, o che no zemo.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Son pur sazio di voi, la mia figliuola!</l>
             <l part="I">Andiam.</l>
@@ -6668,30 +6685,30 @@ e ballano con un ballo in tutti, poi come segue.</emph>
           <stage>
             <emph>Il Cavaliere, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F">Signor Fabrizio, una parola.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l>(Ecco un altro disturbo) <stage><emph>(da sé).</emph></stage>. Che comanda?</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I"> Servitore di lei. </l>
           </sp>
           <stage>
             <emph>(mostra salutare Fabrizio, e saluta Gasparina).</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="F">La riverisco.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="I"> Gli zon zerva, zignore. </l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="F"> Ora capisco.</l>
             <l>Entrate in quella casa.</l>
@@ -6703,22 +6720,22 @@ e ballano con un ballo in tutti, poi come segue.</emph>
             <l>E voi, signora, se vi contentate</l>
             <l>A unir le robe vostre principiate.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="I">Zerva zua. </l>
           </sp>
           <stage>
             <emph>(salutando il Cavaliere).</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="F">Mia padrona.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I"> A voi m'inchino. </l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="F"> Un'altra volta a me?</l>
             <stage>
@@ -6727,21 +6744,21 @@ e ballano con un ballo in tutti, poi come segue.</emph>
             <l>Bravi, me ne consolo.</l>
             <l>Subito andate via di quel poggiuolo.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="I"> (Ze me podezze maridar!). </l>
           </sp>
           <stage>
             <emph>(in atto di partire).</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="F">(Bellissima!).</l>
           </sp>
           <stage>
             <emph>(da sé).</emph>
           </stage>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> (Anca me bazterave ezzer luztrizzima).</l>
           </sp>
@@ -6754,83 +6771,83 @@ e ballano con un ballo in tutti, poi come segue.</emph>
           <stage>
             <emph>Il Cavaliere, e Fabrizio.</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Quel, che mi avete a dir sollecitate.</l>
           </sp>
           <stage>
             <emph>(al Cavaliere).</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Dirò, signor; sappiate,</l>
             <l>Che mi ha ferito il cor vostra nipote.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Piacevi Gasperina, o la sua dote?</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Desta il merito suo gli affetti miei.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> (Quasi quasi davver gliela darei).</l>
           </sp>
           <stage>
             <emph>(da sé).</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I">Voi sapete chi sono. </l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="F">Lo so certo;</l>
             <l>So come siete nato,</l>
             <l>Ma vi siete un po' troppo rovinato.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> È ver, ma sono stanco</l>
             <l>Di menar questa vita.</l>
             <l>Vo' moderar le spese;</l>
             <l>Vo' tornar con prudenza al mio paese.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="I"> Se sperar si potesse. </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F"> Ve lo giuro</l>
             <l>Da cavalier d'onore.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Ma ditemi, signore,</l>
             <l>Come rimedierete</l>
             <l>Dei disordini vostri alla rovina?</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Quanto date di dote a Gasperina?</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Ecco quel, ch'i' dicea;</l>
             <l>Della dote vi cal per consumarla.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Su i miei beni potete assicurarla.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Non sono ipotecati?</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Essere pon da voi ricuperati.</l>
             <l>Vi farò una cessione</l>
@@ -6839,65 +6856,65 @@ e ballano con un ballo in tutti, poi come segue.</emph>
             <l>Se il vostro amor mi regge, e mi consiglia,</l>
             <l>Viverò come un figlio di famiglia.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="I">Basta: vi è da pensar. </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F">Non mi tenete</l>
             <l>Più lungamente a bada.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Concludere in istrada</l>
             <l part="I">Quest'affare vorreste? </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F"> Entriamo in casa.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="I"> Parleremo domani. </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F">In questo punto</l>
             <l>Principiare vorrei</l>
             <l>A rinonziarvi gli interessi miei.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="I"> Ma! discorrer convien. </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F"> Ben, discorriamo.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="I"> (Sono fra il sì, ed il no). </l>
           </sp>
           <stage>
             <emph>(da sé).</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="M"> Vi prego. </l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l part="F">Andiamo.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> (Per me strada miglior trovar non so).</l>
           </sp>
           <stage>
             <emph>(entra in casa).</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> (S'egli dice davvero, io gliela do).</l>
           </sp>
@@ -6911,7 +6928,7 @@ e ballano con un ballo in tutti, poi come segue.</emph>
             <emph>Lucietta sull'altana, poi Gnese sull'altana,
 poi Orsola sul poggiolo.</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Bravi! I l'ha tirà drento.</l>
           </sp>
@@ -6924,31 +6941,31 @@ poi Orsola sul poggiolo.</emph>
           <stage>
             <emph>(forte chiamando).</emph>
           </stage>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="M"> Chi chiama? </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F"> Oe, no ti sa?</l>
             <l part="I">L'amigo... mio compare... </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F"> Coss'è stà?</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I"> El xè andà dall'amiga. </l>
           </sp>
           <stage>
             <emph>(accenna la casa di Gasparina).</emph>
           </stage>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="M"> Eh via. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F"> Sì anca</l>
             <l part="I">Varenta le mie tatare</l>
@@ -6957,34 +6974,34 @@ poi Orsola sul poggiolo.</emph>
           <stage>
             <emph>(chiama).</emph>
           </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="I"> Me chiameu? </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F"> Sentì: el foresto</l>
             <l>Xè andà da Gasperina.</l>
             <l part="I">La se l'ha tirà in casa. </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F"> Oh che mozzina!</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Oe, credeu che ghe sia</l>
             <l part="I">Monea d'un tràiro? </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F"> E so barba ghe xèlo?</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Vara! se el gh'è? El ghe l'ha menà elo.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Chiama, chiama to mare,</l>
             <l>Che ghe la vòi contar.</l>
@@ -6992,103 +7009,103 @@ poi Orsola sul poggiolo.</emph>
           <stage>
             <emph>(a Gnese).</emph>
           </stage>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> No, no gramazza, no, lassèla star.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I"> Cossa gh'ala? </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="M"> Tasè. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Dòrmela ancora?</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> El vin gh'ha fatto mal, l'ha buttà fuora.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Ghe l'ho dito; sta vecchia</l>
             <l part="I">La beve co fa un ludro. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F"> Anca mia mare</l>
             <l>La xè là ben conzada.</l>
             <l>Oe quattro volte la me xè cascada.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="I"> Dove xèla? </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F">Sul letto,</l>
             <l part="I">Che la ronchiza. </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F"> Dove xè Anzoletto?</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Anca elo xè qua,</l>
             <l>In canton del fogher indromenzà</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="I"> Quando spósistu? </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F"> Aspetto mio zerman,</l>
             <l>E po de longo se darà la man.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="I"> E el compare? </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F"> El compare xè liogà;</l>
             <l>Ma co lo chiameremo, el vegnirà.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Sia con bona fortuna,</l>
             <l part="I">Fia mia. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F"> Cusì anca vu.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="I"> Da qua do ani; vero Gnese? </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F"> Cossa?</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Via cossa vienstu rossa?</l>
             <l>In verità te toccherà un bon puto.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Oe, vien da mi, che te conterò tutto.</l>
           </sp>
           <stage>
             <emph>(a Lucietta).</emph>
           </stage>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l>Che bisogno ghe xè,</l>
             <l part="I">Che fè pettegolezzi? </l>
@@ -7096,19 +7113,19 @@ poi Orsola sul poggiolo.</emph>
           <stage>
             <emph>(ad Orsola).</emph>
           </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F">Oh che gran casi!</l>
             <l>No s'àla da saver? Vienstu, Lucietta?</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I"> Sì ben, fina, che i dorme. </l>
           </sp>
           <stage>
             <emph>(entra).</emph>
           </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F"> Via, da brava.</l>
           </sp>
@@ -7118,47 +7135,47 @@ poi Orsola sul poggiolo.</emph>
           <stage>
             <emph>Orsola, Gnese, poi Lucietta.</emph>
           </stage>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Sior'Orsola, patrona.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Me poderessi dir siora madona.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="I"> Oh giusto! </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F"> In verità</l>
             <l>Puta cara son stuffa</l>
             <l>De sti to stomeghezzi,</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Se me criè, mi no ve parlo più.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="I"> Cara fia... </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="M"> Vegno, vegno. </l>
           </sp>
           <stage>
             <emph>(esce di casa correndo verso la casa di Orsola).</emph>
           </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F"> Vien de su.</l>
           </sp>
           <stage>
             <emph>(entra).</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Altri do ani ghe vorà per ti.</l>
             <l>Oe, quanto pagheràvistu</l>
@@ -7173,7 +7190,7 @@ poi Orsola sul poggiolo.</emph>
           <stage>
             <emph>Gnese, poi Facchini, poi Anzoletto.</emph>
           </stage>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Le me fa tanta rabia! Lo tiorave</l>
             <l>Zorzetto, se podesse;</l>
@@ -7197,17 +7214,17 @@ poi Orsola sul poggiolo.</emph>
             <l>Cavallo no morir,</l>
             <l>Che bell'erba ha da vegnir.</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Oe disè, siora Gnese, saveu gnente</l>
             <l part="I">Dove, che sia Lucietta? </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F"> La xè andada</l>
             <l part="I">Da sior'Orsola. </l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="F">Brava, la lo sa:</l>
             <l>No vòi, che la ghe vaga, e la ghe va?</l>
@@ -7227,63 +7244,63 @@ poi Orsola sul poggiolo.</emph>
           <stage>
             <emph>Donna Catte, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F"> Chi batte?</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Vegnì da basso, che v'ho da parlar.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> De diana el ghe vol dar</l>
             <l>Avanti gnanca, che la sia sposada?</l>
             <l>Cossa faralo co l'è maridada?</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Zenero, me chiameu?</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Cossa diavolo feu?</l>
             <l>Vu dormì co fa un zocco, e vostra fia...</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="I"> Oe dove xèla? </l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="F"> La xè andada via.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Dove s'àla cazzà sta scagazzera?</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Là da la frittolera.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Via, no gh'è mal lassè, che la ghe staga.</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> No vòi, che la ghe vaga.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Oh saressi zeloso de so fio?</l>
             <l>De quel cosso scacchìo, malfatto, e bruto?</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Oe, oe, sentì no strappazzè quel puto.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Cossa gh'aveu paura?</l>
             <l>Che la ghe voggia ben?</l>
@@ -7295,7 +7312,7 @@ poi Orsola sul poggiolo.</emph>
           <stage>
             <emph>Lucietta, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F"> Seu desmissiai?</l>
             <l>Coss'è? ti me fa el muso?</l>
@@ -7304,38 +7321,38 @@ poi Orsola sul poggiolo.</emph>
           <stage>
             <emph>(ad Anzoletto).</emph>
           </stage>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="F"> Frasca. Tiò suso.</l>
           </sp>
           <stage>
             <emph>(gli dà uno schiaffo).</emph>
           </stage>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>
               <emph>(gli dà uno schiaffo).</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I"> Mo per cossa me dastu? </l>
           </sp>
           <stage>
             <emph>(piangendo).</emph>
           </stage>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F"> Sior strambazzo,</l>
             <l>Alla mia putta se ghe dà un schiaffazzo?</l>
             <l>No ti è degno d'averla,</l>
             <l part="I">No te la vogio dar. </l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="F"> No me n'importa.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Vien, vien, le mie raìse,</l>
             <l>Che no ghe xè pericolo,</l>
@@ -7344,91 +7361,91 @@ poi Orsola sul poggiolo.</emph>
           <stage>
             <emph>(piangendo).</emph>
           </stage>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="I"> Dème l'anelo indrio. </l>
           </sp>
           <stage>
             <emph>(a Lucietta).</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F"> Questo po no.</l>
           </sp>
           <stage>
             <emph>(piangendo).</emph>
           </stage>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Volè l'anelo indrio? Ve lo darò.</l>
           </sp>
           <stage>
             <emph>(va per levar l'anello a Lucietta).</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I"> Lassème star, siora.</l>
           </sp>
           <stage>
             <emph>(piangendo).</emph>
           </stage>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F">Furbazza!</l>
             <l part="I">Dàmelo quel anelo. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F"> No vel dago</l>
             <l>Gnanca se me coppè.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> El te tratta cusì</l>
             <l>E ti el tioressi ancora?</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> El voggio, siora sì.</l>
           </sp>
           <stage>
             <emph>(piangendo).</emph>
           </stage>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Oh ti meriteressi,</l>
             <l>Che el te copasse.</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Senti, t'ho dà, perché te voggio ben.</l>
           </sp>
           <stage>
             <emph>(singhiozzando).</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I"> Nol soggio? </l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F"> El xè un baron.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> No me n'importa, el voggio.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="I"> Tocco de desgrazià. </l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="F"> Via, se sè dona,</l>
             <l>Cara siora madona,</l>
             <l part="I">Compatìme anca mi. </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F"> (Mi nol torave.</l>
             <l>Gh'averave paura).</l>
@@ -7436,77 +7453,77 @@ poi Orsola sul poggiolo.</emph>
           <stage>
             <emph>(da sé).</emph>
           </stage>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Cusì se tratta co la mia creatura?</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Via, andemo. No ti vien?</l>
           </sp>
           <stage>
             <emph>(a Lucietta).</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Baron, me vustu ben?</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> No stemo qua, che la xè una vergogna.</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Causa quela carogna de Zorzetto.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Oe, oe, come parleu, sior Anzoletto?</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="I"> Parlo cusì, e disèghelo. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F"> Via strambo.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Via, no parlè cusì.</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Sanguenazzo de diana!</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Tasè. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Vien via con mi.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Andemo in casa, vegnì via con nu.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Oe, Anzoletto, me darastu più?</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Se me darè occasion.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Mi no ve fazzo gnente, sior baron.</l>
           </sp>
           <stage>
             <emph>(entra in casa).</emph>
           </stage>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Poverazza! a bonora</l>
             <l>El me l'ha pettuffada!</l>
@@ -7520,7 +7537,7 @@ poi Orsola sul poggiolo.</emph>
           <stage>
             <emph>Gnese, poi Orsola, e Zorzetto.</emph>
           </stage>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Bon pro te fazza. Povera negada!</l>
             <l part="I">Sior'Orsola. </l>
@@ -7528,7 +7545,7 @@ poi Orsola sul poggiolo.</emph>
           <stage>
             <emph>(chiama).</emph>
           </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F"> Chiameu?</l>
           </sp>
@@ -7538,15 +7555,15 @@ poi Orsola sul poggiolo.</emph>
           <stage>
             <emph>(Zorzetto sulla porta).</emph>
           </stage>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Aveu sentio, che scena?</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="I"> Mi no. Cossa xè stà? </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F"> Ve conterò.</l>
             <l>Perché Lucietta xè vegnua da vu</l>
@@ -7555,65 +7572,65 @@ poi Orsola sul poggiolo.</emph>
             <l>E po dopo el gh'ha dà</l>
             <l>Una man in tel muso.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Oh tocco de baron! Chi songio mi?</l>
             <l>Cossa gh'àlo paura?</l>
             <l>Che in casa mia se fazza</l>
             <l part="I">Urzi burzi? </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F"> Bisogna.</l>
             <l>E po a Zorzetto el gh'ha dito carogna.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="I"> Carogna a mi? </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F"> Via tasi.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> Vòi dir l'anemo mio;</l>
             <l>Che no son un pandolo.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> No, no ve n'impazzè</l>
             <l>Con quel scavezzacolo.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Via, vien drento, fio mio.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> Sì, sì (me vòi reffar).</l>
           </sp>
           <stage>
             <emph>(entra).</emph>
           </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Anca vu de contarmelo</l>
             <l>Podevi lassar star.</l>
             <l>Cossa voleu? Che nassa un precepizio?</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="I"> Ve l'ho volesto dir. </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F"> Senza giudizio.</l>
           </sp>
           <stage>
             <emph>(entra).</emph>
           </stage>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Me despiase dasseno...</l>
             <l>Siora mare, chiameu? Vegno son qua.</l>
@@ -7628,7 +7645,7 @@ poi Orsola sul poggiolo.</emph>
           <stage>
             <emph>Zorzetto, poi donna Catte, poi Orsola.</emph>
           </stage>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l>A mi carogna? Desgrazià, baron.</l>
           </sp>
@@ -7641,36 +7658,36 @@ poi Orsola sul poggiolo.</emph>
           <stage>
             <emph>(tira dei sassi nella finestra di Lucietta).</emph>
           </stage>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Coss'è ste baronae?</l>
           </sp>
           <stage>
             <emph>(sull'altana).</emph>
           </stage>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> Tocco de vecchia matta, chiappa questa.</l>
           </sp>
           <stage>
             <emph>(le tira un sasso).</emph>
           </stage>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Aggiuto; una pierada in te la testa.</l>
           </sp>
           <stage>
             <emph>(entra).</emph>
           </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="I"> Coss'è stà? cossa fastu? </l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="F"> Gnente, siora.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l>Via, vien dessuso. No ti vien gnancora?</l>
           </sp>
@@ -7681,11 +7698,11 @@ poi Orsola sul poggiolo.</emph>
             <emph>Anzoletto di casa, col palosso, poi Lucietta,
 poi Gnese, poi Zorzetto.</emph>
           </stage>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="I"> Via, sior cagadonao.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F"> Zorzi! fio mio!</l>
           </sp>
@@ -7695,54 +7712,54 @@ poi Gnese, poi Zorzetto.</emph>
           <stage>
             <emph>(Zorzetto fugge in casa).</emph>
           </stage>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Vien de fuora, baron.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I"> Anzoletto, fio mio. </l>
           </sp>
           <stage>
             <emph>(in altana).</emph>
           </stage>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F"> Zente, custion.</l>
           </sp>
           <stage>
             <emph>(in altana).</emph>
           </stage>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="I"> Baroni, mare, e fio. </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F">Tiò, desgrazià.</l>
           </sp>
           <stage>
             <emph>(dal poggiuolo gli tira un vaso).</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta #gnese">
             <speaker>LUCIETTA, GNESE</speaker>
             <l part="I"> Aggiuto! </l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="F"> Vien de fuora, se ti è bon.</l>
           </sp>
           <stage>
             <emph>(ritirandosi).</emph>
           </stage>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="I"> No gh'ho paura. </l>
           </sp>
           <stage>
             <emph>(con un bastone).</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F"> Indrio con quel baston.</l>
           </sp>
@@ -7753,26 +7770,26 @@ poi Gnese, poi Zorzetto.</emph>
             <emph>Sansuga dalla locanda, con arma alla mano,
 poi il Cavaliere, poi Orsola,  e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#sansuga">
             <speaker>SANSUGA</speaker>
             <l part="I"> Coss'è sta baronada? </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="M"> Aggiuto! </l>
           </sp>
           <stage>
             <emph>(entra).</emph>
           </stage>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F">Aggiuto!</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Coss'è questo fraccasso?</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Sior foresto, che la vaga da basso.</l>
           </sp>
@@ -7782,22 +7799,22 @@ poi il Cavaliere, poi Orsola,  e detti.</emph>
           <stage>
             <emph>(Il Cavaliere entra).</emph>
           </stage>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="I"> El vôi mazzar. </l>
           </sp>
           <stage>
             <emph>(contro Zorzetto).</emph>
           </stage>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="F">Sta' indrio.</l>
           </sp>
-          <sp>
+          <sp who="#sansuga">
             <speaker>SANSUGA</speaker>
             <l part="I"> Fermève, sanguenon. </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F"> Mio fio, mio fio.</l>
           </sp>
@@ -7807,14 +7824,14 @@ poi il Cavaliere, poi Orsola,  e detti.</emph>
         </div>
         <div type="scene">
           <head>Scena tredicesima</head>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I"> Mo vien via. </l>
           </sp>
           <stage>
             <emph>(tirando Anzoletto).</emph>
           </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F"> Vien in casa.</l>
           </sp>
@@ -7827,46 +7844,46 @@ poi il Cavaliere, poi Orsola,  e detti.</emph>
           <stage>
             <emph>(gli leva il legno).</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I"> Vien, se ti me vol ben. </l>
           </sp>
           <stage>
             <emph>(tirando Anzoletto).</emph>
           </stage>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="F">Ti gh'ha rason.</l>
           </sp>
           <stage>
             <emph>Verso Zorzetto, ed entra con Lucietta).</emph>
           </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Andè via con quell'arma.</l>
           </sp>
           <stage>
             <emph>(a Sansuga).</emph>
           </stage>
-          <sp>
+          <sp who="#sansuga">
             <speaker>SANSUGA</speaker>
             <l> Sempre cusì. Vergogna.</l>
           </sp>
           <stage>
             <emph>(entra in locanda).</emph>
           </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="I">Va' in casa, desgrazià.</l>
           </sp>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="F"> Dirme carogna?</l>
           </sp>
           <stage>
             <emph>(entra in casa).</emph>
           </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l>Nol temerave el diavolo, e so pare</l>
             <l>Sto giandussa; el xè fio de bona mare.</l>
@@ -7877,78 +7894,78 @@ poi il Cavaliere, poi Orsola,  e detti.</emph>
         </div>
         <div type="scene">
           <head>Scena quattordicesima</head>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l>Se lo saveva avanti,</l>
             <l>Ca de diana de dia,</l>
             <l>Ghe ne voleva dir quattro a culìa!</l>
             <l part="I">A quel puto carogna?</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="F"> E a mi, furbazzo,</l>
             <l>Romperme i veri, e trarme una pierada?</l>
             <l>A mi sta baronada?</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Oe, seu qua, vecchia matta?</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Coss'è? Toleu le parte de colù?</l>
             <l>Se non andè via, me refferò con vu.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Vardè là, che fegura!</l>
             <l>Gnanca per questo no me fè paura.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Anca sì, che debotto</l>
             <l>Ve chiappo per la petta.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Mi no farò cusì,</l>
             <l>Perché caveli non ghe n'avè pì.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="I"> Va' via, sorda. </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F"> Sdentada.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="I"> Vecchiazza. </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F"> Magagnada.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="I"> Vustu zogar? </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F">Vien via.</l>
           </sp>
           <stage>
             <emph>(s'attaccano).</emph>
           </stage>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="I"> Ah! Lucietta. </l>
           </sp>
           <stage>
             <emph>(chiama).</emph>
           </stage>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F">Fia mia.</l>
           </sp>
@@ -7958,67 +7975,67 @@ poi il Cavaliere, poi Orsola,  e detti.</emph>
         </div>
         <div type="scene">
           <head>Scena quindicesima</head>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I">Siora mare. </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="M"> Fermève. </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F">Desmettè.</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="I"> Lassè star mia madona. </l>
           </sp>
           <stage>
             <emph>(col palosso).</emph>
           </stage>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l part="F"> Cossa gh'è?</l>
           </sp>
           <stage>
             <emph>(col legno).</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Aggiuto! </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Aggiuto! </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Aggiuto!</l>
           </sp>
         </div>
         <div type="scene">
           <head>Scena sedicesima</head>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Oh l'istoria va lunga.</l>
             <l>Non si finisce mai? Se non tacete,</l>
             <l>Meno giù col bastone a quanti siete.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I"> I vol dar a mia mare. </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F"> La xè ela,</l>
             <l>Che xè una baruffante.</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Mi son qua per spartir.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> State zitte dich'io. S'ha da finir.</l>
             <l>Come! in giorno di nozze</l>
@@ -8029,7 +8046,7 @@ poi il Cavaliere, poi Orsola,  e detti.</emph>
           <stage>
             <emph>(a Anzoletto).</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Da' qua dàmela a mi.</l>
           </sp>
@@ -8042,123 +8059,123 @@ poi il Cavaliere, poi Orsola,  e detti.</emph>
           <stage>
             <emph>lo porta in casa, poi torna).</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="M"> Giù quel baston. </l>
           </sp>
           <stage>
             <emph>(a Zorzetto).</emph>
           </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F"> Sior sì.</l>
           </sp>
           <stage>
             <emph>(leva il bastone a Zorzetto).</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Che diavol di vergogna!</l>
             <l>Sempre sempre gridar con questo, e quello?</l>
             <l>Maledetto campiello!</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I"> Mi no crio co nissun. </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F"> No parlo mai.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> No la se sente gnanca la mia puta.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> I ghe dise la muta.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I"> Mo vu... </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F"> Mo vu, patrone...</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I"> Cossa voressi dir? </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F"> Ma siate buone.</l>
             <l>Domani io vado via.</l>
             <l>E se la compagnia torna serena,</l>
             <l>Meco verrete a divertirvi a cena.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Per mi no son in colera.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="I"> Pute, coss'àlo dito? </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F">No sentì?</l>
             <l>El n'ha dito cussì,</l>
             <l>Che se tornemo in pase</l>
             <l part="I">Ceneremo con elo. </l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="F">Sì, fia mia;</l>
             <l>Mi no desgusto mai la compagnia.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="I"> Bravissime le vecchie. </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F">Oe, Lucietta,</l>
             <l>Gh'àstu gnente con mi?</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I">Semio amighe? </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="M"> Tiò un baso. </l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="F"> Tiò anca ti.</l>
             <l part="I">Gnese, ti cossa distu? </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F"> Per mi taso.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="I"> Oe donna Catte. </l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l part="M"> Donna Pasqua.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua #catte">
             <speaker>PASQUA, CATTE</speaker>
             <l part="F"> Un baso.</l>
           </sp>
           <stage>
             <emph>(si baciano).</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> E voi altri ragazzi</l>
             <l part="I">Non vi baciate ancor? </l>
@@ -8166,35 +8183,35 @@ poi il Cavaliere, poi Orsola,  e detti.</emph>
           <stage>
             <emph>(a Zorzetto ed Anzoletto).</emph>
           </stage>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F"> Va là, Zorzetto,</l>
             <l>Dàghe un baso a Anzoletto.</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Che bisogno ghe xè?</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I"> Via, se ti me vol ben. </l>
           </sp>
           <stage>
             <emph>(a Anzoletto).</emph>
           </stage>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l part="F"> Sì ben. </l>
           </sp>
           <stage>
             <emph>(Si baciano con Anzoletto).</emph>
           </stage>
-          <sp>
+          <sp who="#zorzetto">
             <speaker>ZORZETTO</speaker>
             <l> Tolè.</l>
           </sp>
           <stage>(Si baciano con Zorzetto).</stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Or, che la pace è fatta,</l>
             <l>La cena si farà.</l>
@@ -8202,45 +8219,45 @@ poi il Cavaliere, poi Orsola,  e detti.</emph>
             <l>Sono lo sposo anch'io. Sposo stassera,</l>
             <l>E parto domattina.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I"> La novizza chi xèla? </l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l part="F"> Gasperina.</l>
           </sp>
         </div>
         <div type="scene">
           <head>Scena diciassettesima</head>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Ze podeva anca dir,</l>
             <l>Caro zior Cavalier,</l>
             <l>Che ziora Gazparina è zo muggier.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Brava. </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Me ne consolo.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Come xèlo sto caso?</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Vegnì da basso, che ve daga un baso.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Via, venite, signora,</l>
             <l>Ora più non comanda vostro zio.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> Vengo, zignor mario.</l>
           </sp>
@@ -8250,7 +8267,7 @@ poi il Cavaliere, poi Orsola,  e detti.</emph>
         </div>
         <div type="scene">
           <head>Scena diciottesima</head>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> E ver che mia nipote è vostra moglie,</l>
             <l>Ma nel vostro contratto</l>
@@ -8260,20 +8277,20 @@ poi il Cavaliere, poi Orsola,  e detti.</emph>
             <l>A gettar il danaro allegramente;</l>
             <l>E non si ha da cenar con questa gente.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> La cena è preparata;</l>
             <l>L'ho ordinata, e pagata.</l>
             <l>Lasciatemi godere,</l>
             <l>Per cortesia, quest'ultimo piacere.</l>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <l> Pur, che l'ultimo sia, ve lo concedo.</l>
             <l>Ma io non ci verrò con questa gente</l>
             <l>Indiscreta, incivil, senza creanza.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Via, sior, ghe domandemo perdonanza.</l>
             <l>Quando semo in borrezzo</l>
@@ -8289,80 +8306,80 @@ poi il Cavaliere, poi Orsola,  e detti.</emph>
             <l>Podemo dar la man,</l>
             <l>Quando che se contenta sior compare.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Fate quel, che vi pare.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Cossa distu, Anzoletto?</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Fazzo quel, che volè.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Anemo via sposè.</l>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <l> Questa xè mia muggier.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l> Questo xè mio mario.</l>
           </sp>
-          <sp>
+          <sp who="#catte">
             <speaker>CATTE</speaker>
             <l> Séntime un de sti dì te vegno drio.</l>
           </sp>
           <stage>
             <emph>(a Lucietta).</emph>
           </stage>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l> Uh! me viene l'acqua in bocca.</l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l> Sia malignazo! e mi?</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Da qua do ani a ti.</l>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <l part="I"> Do anni s'ha da star? </l>
           </sp>
-          <sp>
+          <sp who="#gnese">
             <speaker>GNESE</speaker>
             <l part="F"> Vardè, che sesto!</l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l> Eh, no t'indubitar, che i passa presto.</l>
           </sp>
         </div>
         <div type="scene">
           <head>Scena ultima</head>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l> No voleva vegnir con tanta zente.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Venite allegramente;</l>
             <l>Siamo di carnevale,</l>
             <l>È lecito di far qualche allegria;</l>
             <l>Già domani mattina andiamo via.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I"> Dove andeu, Gasparina? </l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l part="F"> Ignorantizzima,</l>
             <l>Me poderezzi dar de la luztrizzima.</l>
@@ -8370,22 +8387,22 @@ poi il Cavaliere, poi Orsola,  e detti.</emph>
             <l>E col zior barba zio,</l>
             <l>Dove più conozziuta zarò io.</l>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <l part="I">Me ne conzolo. </l>
           </sp>
-          <sp>
+          <sp who="#orsola">
             <speaker>ORSOLA</speaker>
             <l part="F">Tanto zì dazzeno.</l>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <l> Animo allegramente,</l>
             <l>Andiam tutti in locanda,</l>
             <l>Che si passi la notte in festa in brio;</l>
             <l>Poi diremo diman: Venezia addio.</l>
           </sp>
-          <sp>
+          <sp who="#gasparina">
             <speaker>GASPARINA</speaker>
             <l>Cara la mia Venezia,</l>
             <l>Me dezpiazerà certo de lazzarla;</l>

--- a/tei/goldoni-il-servitore-di-due-padroni.xml
+++ b/tei/goldoni-il-servitore-di-due-padroni.xml
@@ -86,6 +86,46 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="silvio">
+            <persName>Silvio</persName>
+          </person>
+          <person xml:id="pantalone">
+            <persName>Pantalone</persName>
+          </person>
+          <person xml:id="clarice">
+            <persName>Clarice</persName>
+          </person>
+          <person xml:id="dottore">
+            <persName>Dottore Lombardi</persName>
+          </person>
+          <person xml:id="smeraldina">
+            <persName>Smeraldina</persName>
+          </person>
+          <person xml:id="brighella">
+            <persName>Brighella</persName>
+          </person>
+          <person xml:id="truffaldino">
+            <persName>Truffaldino</persName>
+          </person>
+          <person xml:id="beatrice">
+            <persName>Beatrice</persName>
+          </person>
+          <person xml:id="servitore">
+            <persName>Servitore</persName>
+          </person>
+          <person xml:id="facchino">
+            <persName>Facchino</persName>
+          </person>
+          <person xml:id="florindo">
+            <persName>Florindo Aretusi</persName>
+          </person>
+          <person xml:id="camerieri">
+            <persName>Camerieri d'osteria</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -371,53 +411,53 @@ me a delitto, se delle cose mie discretamente mi vaglio.</p>
             <emph>Pantalone, il Dottore, Clarice, Silvio, Brighella,
 Smeraldina, un altro Servitore di Pantalone.</emph>
           </stage>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Eccovi la mia destra, e con questa vi dono tutto il
 mio cuore. <emph>(a Clarice, porgendole la mano)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Via, no ve vergognè; dèghe la man anca vu. Cusì
 sarè promessi, e presto presto sarè maridai. <emph>(a Clarice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Sì, caro Silvio, eccovi la mia destra. Prometto di
 essere vostra sposa.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Ed io prometto esser vostro. <emph>(si danno la mano)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Bravissimi; anche questa è fatta. Ora non si torna
 più indietro.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>(Oh la bella cosa! Propriamente anch'io me ne
 struggo di voglia). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Vualtri sarè testimoni de sta promission, seguida
 tra Clarice mia fia, e el sior Silvio, fio degnissimo qua,
 del nostro sior dottor Lombardi. <emph>(a Brighella ed al Servitore)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Sior sì, sior compare, e la ringrazio de sto onor,
 che la se degna farme. <emph>(a Pantalone)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Vedeu? Mi son stà compare alle vostre nozze, e vu
 sé testimonio alle nozze de me fia. Non ho volesto chiamar
@@ -428,23 +468,23 @@ nissun, ne disturberà. Cossa diseu, putti, faremio pulito?
 <emph>(a Clarice e Silvio)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Io non desidero altro, che essere vicino alla mia
 cara sposa.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>(Certo, che questa è la migliore vivanda). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Mio figlio, non è amante della vanità. Egli è un
 giovane di buon cuore. Ama la vostra figliuola, e non pensa
 ad altro.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Bisogna dir veramente, che sto matrimonio el sia
 stà destinà dal Cielo, perché se a Turin no moriva sior
@@ -453,123 +493,123 @@ l'aveva promessa a elo, e no la podeva toccar al mio caro
 sior zenero. <emph>(verso Silvio)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Certamente io posso dire di essere fortunato. Non
 so, se dira così la signora Clarice.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Caro Silvio, mi fate torto. Sapete pur, se vi amo;
 per obbedire il signor padre, averei sposato quel turinese;
 ma il mio cuore è sempre stato per voi.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Eppur è vero; il Cielo, quando ha decretato una
 cosa, la fa nascere per vie non prevedute. Come è succeduta
 la morte di Federigo Rasponi? <emph>(a Pantalone)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Poverazzo! L'è stà mazzà de notte, per causa de una
 sorella... No so gnente. I gh'ha dà una ferìa, e el xè restà
 sulla botta.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Èlo successo a Turin sto fatto? <emph>(a Pantalone)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>A Turin.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Oh, povero signor! Me ne despiase infinitamente.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Lo conossevi sior Federigo Rasponi? <emph>(a Brighella)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Siguro, che lo conosceva. So stà a Turin tre anni,
 e ho conossudo anca so Sorella. Una zovene de spirito, de
 corazzo; la se vestiva da omo, l'andava a cavallo, e lu el
 giera innamorà desta so sorella. Oh! chi l'avesse mai dito!</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ma! Le disgrazie le xè sempre pronte. Orsù no
 parlemo de malinconie. Saveu cossa, che v'ho da dir, missier
 Brighella caro? So, che ve diletè de laorar ben in cusina.
 Vorrave, che ne fessi un per de piatti a vostro gusto.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>La servirò volentiera. No fazzo per dir, ma alla
 mia locanda, tutti se contenta. I dis cusì, che in nissun
 logo i magna, come che se magna da mi. La sentirà qualcossa
 de gusto.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Bravo. Robba brodosa, vedè; che se possa bagnarghe
 drento delle molene de pan. <emph>(si sente picchiare)</emph> Oh! i
 batte. Varda chi è, Smeraldina.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Subito. <emph>(parte, e poi ritorna)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Signor padre, con vostra buona licenza.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Aspettè; vegnimo tutti. Sentimo chi xè.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p><emph>(Torna)</emph> Signore, è un servitore di un forestiere,
 che vorrebbe farvi un'imbasciata. A me non ha voluto dir
 nulla. Dice, che vuol parlar col padrone.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Disèghe, che el vegna avanti. Sentiremo cossa, che
 el vol.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Lo farò venire. <emph>(parte)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Ma io, me ne anderei, signor padre.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Dove?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Che so io? Nella mia camera.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Siora no, siora no; stè qua. (Sti novizzi non vòi
 gnancora, che i lassemo soli). <emph>(piano al Dottore)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>(Saviamente, con prudenza). <emph>(piano a Pantalone)</emph></p>
           </sp>
@@ -579,104 +619,104 @@ gnancora, che i lassemo soli). <emph>(piano al Dottore)</emph>
           <stage>
             <emph>Truffaldino, Smeraldina e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Fazz umilissima reverenza a tutti lor siori. Oh
 che bella compagnia! Oh che bella conversazion!</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Chi seu, amigo? Cossa comandeu? <emph>(a Truffaldino)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Chi èla sta garbata signora? <emph>(a Pantalone, accennando Clarice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>La xè mia fia.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Me ne ralegher.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>E di più è sposa. <emph>(a Truffaldino)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Me ne consolo. E ela chi èla? <emph>(a Smeraldina)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Sono la sua cameriera, signore.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Me ne congratulo.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Oh via, sior, a monte le cerimonie. Cossa voleu da
 mi? Chi seu? Chi ve manda?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Adasio, adasio; colle bone. Tre interrogazion in
 t'una volta l'è troppo per un pover omo.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(Mi credo, che el sia un sempio costù). <emph>(piano al Dottore)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>(Mi par piuttosto un uomo burlevole). <emph>(piano a Pantalone)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>V. S. è la sposa? <emph>(a Smeraldina)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Oh! <emph>(sospirando)</emph> Signor no.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Voleu dir chi sè, o voleu andar a far i fatti
 vostri?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Co no la vol altro, che saver chi son, in do
 parole me sbrigo. Son servitor del me padron. <emph>(a Pantalone)</emph> E cusì, tornando al nostro proposito...
 <emph>(voltandosi a Smeraldina)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Mo chi xèlo el vostro patron?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>L'è un forestier, che vorave vegnir a farghe una
 visita. <emph>(a Pantalone)</emph> Sul proposito de' sposi
 discorreremo. <emph>(a Smeraldina, come sopra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Sto forestier chi xèlo? Come se chiamelo?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Oh l'è longa. L'è el sior Federigo Rasponi
 turinese, el me padron, che la reverisse, che l'è vegnù a
@@ -685,184 +725,184 @@ vorria passar, che el me aspetta colla risposta. Èla
 contenta? Vorla saver altro? <emph>(a Pantalone. Tutti fanno degli atti di ammirazione)</emph> Tornemo a nu... <emph>(a Smeraldina, come sopra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>No vegnì qua, parlè co mi. Cossa diavolo diseu?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>E se la vol saver chi son mi; mi son Truffaldin
 Batocchio, dalle valade de Bergamo.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>No m'importa de saver chi siè vu. Vorria, che me
 tornessi a dir chi xè sto vostro patron. Ho paura de aver
 strainteso.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Povero vecchio! El sarà duro de recchie. El me
 padron l'è el sior Federigo Rasponi da Turin.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Andè via, che sè un pezzo de matto. Sior Federico
 Rasponi da Turin el xè morto.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>L'è morto?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>L'è morto seguro. Pur troppo per elo.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Diavol! Che el me padron sia morto? L'ho pur
 lassà vivo da basso!) <emph>(da sé)</emph> Disì da bon, che l'è morto?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ve digo assolutamente, che el xè morto.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Sì, è la verità; è morto; non occorre metterlo in
 dubbio.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Oh povero el me padron! Ghe sarà vegnù un
 accidente). <emph>(da sé)</emph> Con so bona grazia. <emph>(si licenzia)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>No volè altro da mi?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Co l'è morto no m'occorre altro. (Vòi ben andar a
 veder, se l'è la verità). <emph>(da sé, parte e poi ritorna)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Cossa credemio che el sia costù? Un furbo, o un
 matto?</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Non saprei. Pare, che abbia un poco dell'uno, e un
 poco dell'altro.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>A mi el me par più tosto un semplizotto. L'è
 bergamasco no crederia, che el fuss un baron.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Anche l'idea l'ha buona. (Non mi dispiace quel
 morettino). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ma cossa se insonielo de sior Federigo?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Se fosse vero, ch'ei fosse qui, sarebbe per me una
 nuova troppo cattiva.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Che spropositi! No aveu visto anca vu le lettere?
 <emph>(a Clarice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Se anche fosse egli vivo, e fosse qui, sarebbe
 venuto tardi.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p><emph>(Ritorna)</emph> Me maraveio de lor siori. No se tratta
 cusì colla povera zente. No se inganna cusì i forestieri. No
 le son azion de galantomeni. E me ne farò render conto.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(Vardemose, che el xè matto). Coss'è stà? Cossa
 v'àli fatto?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Andarme a dir, che sior Federigo Rasponi l'è
 morto?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>E cusì?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>E cusì: l'è qua, vivo, san, spiritoso, e
 brillante; che el vol reverirla, se la se contenta.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Sior Federigo?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Sior Federigo.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Rasponi?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Rasponi.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Da Turin?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Da Turin.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Fio mio, andè all'ospeal, che sè matto.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Corpo del diavolo! Me farissi bestemiar come un
 zugador. Mo se l'è qua; in casa, in sala, che ve vegna el
 malanno.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Adessadesso ghe rompo el muso.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>No, signor Pantalone, fate una cosa; ditegli, che
 faccia venire innanzi questo tale, ch'egli crede essere
 Federigo Rasponi.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Via, fèlo vegnir avanti sto morto ressuscità.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Che el sia stà morto, e che el sia ressuscità pol
 esser, mi no gh'ho niente in contrario. Ma adesso l'è vivo,
@@ -871,32 +911,32 @@ da qua avanti imparè a trattar coi forestieri, coi omeni
 della me sorte, coi bergamaschi onorati. <emph>(a Pantalone, con collera)</emph> Quella giovine, a so tempo se parleremo. <emph>(a Smeraldina, e parte)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>(Silvio mio, tremo tutta). <emph>(piano a Silvio)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>(Non dubitate; in qualunque evento sarete mia).
 <emph>(piano a Clarice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Ora ci chiariremo della verità.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Pol vegnir qualche baronato a darme da intender
 delle fandonie.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Mi, come ghe diseva, sior compare, l'ho conossudo
 el sior Federigo; se el sarà lu, vederemo.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>(Eppure quel morettino non ha una fisonomia da
 bugiardo. Voglio veder se mi riesce...) <emph>(da sé)</emph> Con buona
@@ -909,7 +949,7 @@ grazia di lor signori. <emph>(parte)</emph></p>
             <emph>Beatrice in abito da uomo, sotto nome di Federigo, e
 detti.</emph>
           </stage>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Signor Pantalone, la gentilezza che io ho ammirato
 nelle vostre lettere non corrisponde al trattamento che voi
@@ -917,44 +957,44 @@ mi fate in persona. Vi mando il servo, vi fo passar
 l'ambasciata, e voi mi fate stare all'aria aperta, senza
 degnarvi di farmi entrare, che dopo una mezz'ora?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>La compatissa... Ma chi xèla ela, patron?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Federigo Rasponi di Torino, per obbedirvi. <emph>(tutti fanno atti d'ammirazione)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>(Cossa vedio? Coss'è sto negozio? Questo no l'è
 Federigo, l'è la siora Beatrice so sorella. Vòi osservar
 dove tende sto inganno). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Mi resto attonito... Me consolo de vederla san, e
 vivo, quando avevimo avudo delle cattive nove. (Ma gnancora
 no ghe credo, savè). <emph>(piano al Dottore)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Lo so; fu detto, che in una rissa rimasi estinto.
 Grazie al Cielo, fui solamente ferito; e appena risanato
 intrapresi il viaggio di Venezia, già da gran tempo con voi
 concertato.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>No so cossa dir. La so ciera xè da galantomo: ma mi
 gh'ho riscontri certi, e seguri, che sior Federigo sia
 morto; onde la vede ben... se no la me dà qualche prova in
 contrario...</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>È giustissimo il vostro dubbio; conosco la
 necessità di giustificarmi. Eccovi quattro lettere de'
@@ -963,17 +1003,17 @@ della nostra banca. Riconoscerete le firme, e vi accerterete
 dell'esser mio. <emph>(dà quattro lettere a Pantalone, il quale le legge da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>(Ah Silvio, siamo perduti!). <emph>(piano a Silvio)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>(La vita perderò, ma non voi!). <emph>(piano a Clarice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(Oimè! Qui Brighella? Come diamine qui si ritrova
 costui? Egli mi conoscerà certamente; non vorrei, che mi
@@ -981,155 +1021,155 @@ discoprisse) <emph>(da sé, avvedendosi di Brighella)</emph> Amico, mi
 par di conoscervi. <emph>(forte a Brighella)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Sì signor, no la s'arrecorda a Turin Brighella
 Cavicchio?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Ah sì, ora vi riconosco. <emph>(si va accostando a Brighella)</emph> Bravo galantuomo, che fate in Venezia? (Per amor
 del Cielo non mi scoprite). <emph>(piano a Brighella)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>(Non gh'è dubbio). <emph>(piano a Beatrice)</emph> Fazzo el
 locandier, per servirla. <emph>(forte alla medesima)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Oh, per l'appunto; giacché ho il piacer di
 conoscervi, verrò ad alloggiare alla vostra locanda.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>La me farà grazia. (Qualche contrabbando siguro).
 <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ho sentio tutto. Certo, che ste lettere le me
 accompagna el sior Federigo Rasponi, e se ella me le
 presenta, bisognerave creder, che la fosse... come che dise
 ste lettere.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Se qualche dubbio ancor vi restasse, ecco qui
 messer Brighella; egli mi conosce, egli può assicurarvi
 dell'esser mio (Dieci doppie per te).</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Senz'altro, sior compare, lo assicuro mi; questo
 l'è el sior Federigo Rasponi. (Se pol far manco per vadagnar
 diese doppie?).</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Co la xè cusì, come l'attesta, oltre le lettere,
 anca mio com are Brighella, caro sior Federigo, me ne
 consolo con ela, e ghe domando scusa, se ho dubità.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Signor padre, quegli è dunque il signor Federigo
 Rasponi?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Mo el xè elo lu.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>(Me infelice, che sarà di noi?). <emph>(piano a Silvio)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>(Non dubitate vi dico; siete mia, e vi difenderò).
 <emph>(piano a Clarice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(Cossa diseu, Dottor, xèlo vegnù a tempo?). <emph>(piano al Dottore)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p><emph>Accidit in puncto, quod non contingit in anno</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Signor Pantalone, chi è quella signora?
 <emph>(accennando Clarice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>La xè Clarice mia fia.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Quella a me destinata in isposa?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Sior sì, giusto quella. (Adesso son in t'un
 bell'intrigo). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Signora, permettetemi, ch'io abbia l'onore di
 riverirvi. <emph>(a Clarice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Serva divota. <emph>(sostenuta)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Molto freddamente m'accoglie. <emph>(a Pantalone)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Cossa vorla far? La xè timida de natura.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>E quel signore, è qualche vostro parente? <emph>(a Pantalone, accennando Silvio)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Sior sì; el xè un mio nevodo.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>No signore, non sono suo nipote altrimenti, sono lo
 sposo della signora Clarice. <emph>(a Beatrice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>(Bravo! Non ti perdere. Di' la tua ragione, ma
 senza precipitare). <emph>(piano a Silvio)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Come! Voi sposo della signora Clarice? Non è ella
 a me destinata?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Via via. Mi scoverzirò tutto. Caro sior Federigo,
 se credeva, che fosse vera la vostra disgrazia, che fussi
@@ -1140,29 +1180,29 @@ parola. Sior Silvio, no so cossa dir; vedè coi vostri occhi
 la verità. Savè cossa, che v'ho dito, e de mi no ve podè
 lamentar.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Ma il signor Federigo non si contenterà di prendere
 una sposa, che porse ad altri la mano.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Io poi non sono sì delicato. La prenderò non
 ostante. (Voglio anche prendermi un poco di divertimento).
 <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>(Che buon marito alla moda! Non mi dispiace). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Spero, che la signora Clarice non ricuserà la mia
 mano.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Orsù, signore, tardi siete arrivato. La signora
 Clarice deve esser mia, né sperate, che io ve la ceda. Se il
@@ -1170,29 +1210,29 @@ signor Pantalone mi farà torto saprò vendicarmene; e chi
 vorrà Clarice, dovrà contenderla con questa spada. <emph>(parte)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>(Bravo, corpo di bacco!). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(No, no, per questa via non voglio morire). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Padrone mio, V. S. è arrivato un po' tardi. La
 signora Clarice l'ha da sposare mio figlio. La legge parla
 chiaro. <emph>Prior in tempore, potior in iure</emph>. <emph>(parte)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Ma voi, signora sposa, non dite nulla? <emph>(a Clarice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Dico che siete venuto per tormentarmi. <emph>(parte)</emph></p>
           </sp>
@@ -1203,12 +1243,12 @@ chiaro. <emph>Prior in tempore, potior in iure</emph>. <emph>(parte)</emph>
             <emph>Pantalone, Beatrice e Brighella, poi il Servitore di
 Pantalone.</emph>
           </stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Come, pettegola? Cossa distu? <emph>(le vuol correr dietro)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Fermatevi, signor Pantalone; la compatisco. Non
 conviene prenderla con asprezza. Col tempo spero di potermi
@@ -1216,81 +1256,81 @@ meritare la di lei grazia. Intanto andremo esaminando i
 nostri conti, che è uno dei due motivi, per cui, come vi è
 noto, mi son portato a Venezia.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Tutto xè all'ordine per el nostro conteggio. Ghe
 farò veder el conto corrente; i so bezzi xè parechiai, e
 faremo el saldo co la vorrà.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Verrò con più comodo a riverirvi; per ora, se mi
 permettete, andrò con Brighella a spedire alcuni piccioli
 affari, che mi sono stati raccomandati. Egli è pratico della
 città, potrà giovarmi nelle mie premure.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>La se serva, come che la vol; e se la gh'ha bisogno
 de gnente la comanda.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Se mi darete un poco di denaro, mi farete piacere,
 non ho voluto prenderne meco; per non discapitare nelle
 monete.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Volentiera; la servirò. Adesso no gh'è el cassier.
 Subito, che el vien ghe manderò i bezzi ma a casa. No vala a
 star da mio compare Brighella?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Certamente; vado da lui; e poi manderò il mio
 servitore; egli è fidatissimo, gli si può fidar ogni cosa.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Benissimo; la servirò come la comanda, e se la vol
 restar da mi a far penitenza, la xè parona.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Per oggi vi ringrazio. Un'altra volta sarò a
 incomodarvi.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Donca starò attendendola.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Signore, è domandato. <emph>(a Pantalone)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Da chi?</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Di là... non saprei... (Vi sono degl'imbrogli).
 <emph>(piano a Pantalone, e parte)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Vegno subito. Con so bona grazia. La scusa, se no
 la compagno. Brighella, vu sé de casa; servilo vu sior
 Federigo.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Non vi prendete pena per me.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Bisogna, che vaga. A bon reverirla. (Non voria, che
 nassesse qualche diavolezzo). <emph>(da sé, e parte)</emph></p>
@@ -1301,11 +1341,11 @@ nassesse qualche diavolezzo). <emph>(da sé, e parte)</emph></p>
           <stage>
             <emph>Beatrice e Brighella</emph>
           </stage>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Se pol saver, siora Beatrice?...</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Chetatevi, per amor del Cielo, non mi scoprite. Il
 povero mio fratello è morto, ed è rimasto ucciso, o dalle
@@ -1328,22 +1368,22 @@ anche Florindo, se ne avrà di bisogno. Guardate dove conduce
 amore! Secondatemi, caro Brighella, aiutatemi; sarete
 largamente ricompensato.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Tutto ba ven, ma no vorrave esser causa mi, che
 sior Pantalon, sotto bona fede, ghe pagasse el contante, e
 che po el restasse burlà.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Come burlato? Morto mio fratello, non sono io
 l'erede?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>L'è la verità. Ma perché no scovrirse?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Se mi scopro non faccio nulla. Pantalone
 principierà a volermi far da tutore; e tutti mi seccheranno,
@@ -1351,45 +1391,45 @@ che non istà bene, che non conviene, e che so io? Voglio la
 mia libertà. Durerà poco, ma pazienza. Frattanto qualche
 cosa sarà.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Veramente, signora, l'è sempre stada un spiritin
 bizarro. La lassa far a mi, la staga su la mia fede. La se
 lassa servir.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Andiamo alla vostra locanda.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>El so servitor dov'èlo?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Ha detto, che mi aspetterà sulla strada.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Dove l'àla tolto quel martuffo? Nol sa gnanca
 parlar.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>L'ho preso per viaggio. Pare sciocco qualche
 volta, ma non lo è, e circa la fedeltà non me ne posso
 dolere.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Ah la fedeltà l'è una bella cossa! Andemo, la
 resta servida; vardè amor cossa, che el fa far.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Questo non è niente. Amor ne fa far di peggio.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Eh, avemo principià ben. Andando in là, no se sa
 cossa possa succeder. <emph>(parte)</emph></p>
@@ -1401,7 +1441,7 @@ cossa possa succeder. <emph>(parte)</emph></p>
           <stage>
             <emph>Truffaldino solo.</emph>
           </stage>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Son stuffo d'aspettar, che no posso più. Co sto me
 patron se magna poco, e quel poco el me lo fa suspirar.
@@ -1429,122 +1469,122 @@ so far gnente.</p>
             <emph>Florindo da viaggio con un Facchino col baule in spalla, e
 detto.</emph>
           </stage>
-          <sp>
+          <sp who="#facchino">
             <speaker>FACCHINO</speaker>
             <p>Ghe digo, che no posso più; el pesa, che el mazza.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ecco qui un'insegna d'osteria, o di locanda. Non
 puoi far questi quattro passi?</p>
           </sp>
-          <sp>
+          <sp who="#facchino">
             <speaker>FACCHINO</speaker>
             <p>Aiuto; el baul va in terra.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>L'ho detto, che tu non saresti stato al caso: sei
 troppo debole; non hai forza. <emph>(regge il baule sulle spalle del Facchino)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Se podess vadagnar diese soldi). <emph>(osservando il Facchino)</emph> Signor, comandela niente da mi? La poss'io
 servir? <emph>(a Florindo)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Caro galantuomo; aiutate a portare questo baule in
 quell'albergo.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Subito; la lassa far a mi. La varda come, che se
 fa. Passa via. <emph>(va colla spalla sotto il baule, lo prende tutto sopra di sé, e caccia in terra il Facchino con una spinta)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Bravissimo.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Se nol pesa gnente! <emph>(entra nella locanda col baule)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Vedete come si fa? <emph>(al Facchino)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#facchino">
             <speaker>FACCHINO</speaker>
             <p>Mi no so far de più. Fazzo el facchin per
 desgrazia; ma son fiol de una persona civil.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Che cosa faceva vostro padre?</p>
           </sp>
-          <sp>
+          <sp who="#facchino">
             <speaker>FACCHINO</speaker>
             <p>Mio padre? El scortegava i agnelli per la città.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(Costui è un pazzo; non occorr'altro). <emph>(vuol andare nella locanda)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#facchino">
             <speaker>FACCHINO</speaker>
             <p>Lustrissimo, la favorissa.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Che cosa?</p>
           </sp>
-          <sp>
+          <sp who="#facchino">
             <speaker>FACCHINO</speaker>
             <p>I bezzi della portadura.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Quanto ti ho da dare per dieci passi? Ecco lì la
 corriera. <emph>(accenna dentro alla scena)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#facchino">
             <speaker>FACCHINO</speaker>
             <p>Mi no conto i passi; la me paga. <emph>(stende la mano)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Eccoti cinque soldi. <emph>(gli mette una moneta in mano)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#facchino">
             <speaker>FACCHINO</speaker>
             <p>La me paga. <emph>(tiene la mano stesa)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>O che pazienza! Eccotene altri cinque. <emph>(fa come sopra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#facchino">
             <speaker>FACCHINO</speaker>
             <p>La me paga. <emph>(come sopra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p><emph>(Gli dà un calcio)</emph> Sono annoiato.</p>
           </sp>
-          <sp>
+          <sp who="#facchino">
             <speaker>FACCHINO</speaker>
             <p>Adesso son pagà. <emph>(parte)</emph></p>
           </sp>
@@ -1554,140 +1594,140 @@ corriera. <emph>(accenna dentro alla scena)</emph>
           <stage>
             <emph>Florindo, poi Truffaldino</emph>
           </stage>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Che razza di umori si dànno! Aspettava proprio che
 io lo maltrattassi. Oh andiamo un po' a vedere, che albergo
 è questo...</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Signor, l'è restada servida.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Che alloggio è codesto?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>L'è una bona locanda, signor. Boni letti, bei
 specchi, una cusina bellissima, con un odor, che consola. Ho
 parlà col camerier. La sarà servida da re.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Voi, che mestiere fate?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>El servitor.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Siete veneziano?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>No son venezian, ma son qua del Stato. Son
 bergamasco, per servirla.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Adesso avete padrone?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Adesso... veramente non l'ho.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Siete senza padrone?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Eccome qua; la vede; son senza padron. (Qua nol
 gh'è el me padron; mi no digo busie). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Verreste voi a servirmi?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>A servirla? Perché no? (Se i patti fusse meggio,
 me cambieria de camisa). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Almeno per il tempo, ch'io sto in Venezia.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Benissimo. Quanto me vorla dar?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Quanto pretendete?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Ghe dirò: un altro patron, che aveva, e che adesso
 qua nol gh'ho più, el me dava un felippo al mese, e le
 spese.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Bene, e tanto vi darò io.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Bisognerave, che la me dasse qualcossetta de più.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Che cosa pretendereste di più?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Un soldetto al zorno per el tabacco.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Sì, volentieri; ve lo darò.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Co l'è cusì, stago con lu.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ma; vi vorrebbe un poco d'informazione dei fatti
 vostri.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Co no la vol altro, che informazion dei fatti mii,
 la vada a Bergamo, che tutti ghe dirà chi son.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Non avete nessuno in Venezia, che vi conosca?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Son arrivà stamattina, signor.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Orsù; mi parete un uomo da bene. Vi proverò.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>La me prova, e la vederà.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Prima d'ogni altra cosa, mi preme vedere, se alla
 posta vi siano lettere per me. Eccovi mezzo scudo andate
@@ -1695,11 +1735,11 @@ alla posta di Turino, domandate, se vi sono lettere di
 Florindo Aretusi; se ve ne sono, prendetele, e portatele
 subito, che vi aspetto.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Intanto la fazza parecchiar da disnar.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Sì, bravo; farò preparare. (È faceto; non mi
 dispiace. A poco alla volta ne farò la prova). <emph>(entra nella locanda)</emph></p>
@@ -1710,7 +1750,7 @@ dispiace. A poco alla volta ne farò la prova). <emph>(entra nella locanda)</emp
           <stage>
             <emph>Truffaldino, poi Beatrice da uomo e Brighella</emph>
           </stage>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Un soldo al zorno de più; i è trenta soldi al
 mese, no l'è gnanca vero, che quell'alter me daga un
@@ -1721,45 +1761,45 @@ no gh'ha barba, e non gh'ha giudizio. Lassemolo andar;
 andemo alla posta per sto sior... <emph>(vuol partire ed incontra Beatrice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Bravissimo. Così mi aspetti?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Son qua, signor. V'aspetto ancora.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>E perché vieni a aspettarmi qui, e non nella
 strada dove ti ho detto? È un accidente, che ti abbia
 ritrovato.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Ho spasseggià un pochetto, perché me passasse la
 fame.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Orsù, va' in questo momento alla barca del
 corriere. Fatti consegnare il mio baule, e portalo alla
 locanda di messer Brighella...</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Eccola là la mia locanda; nol pol falar.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Bene dunque, sbrigati, che ti aspetto.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Diavolo! In quella locanda!). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Tieni; nello stesso tempo anderai alla posta di
 Turino, e domanderai, se vi sono mie lettere. Anzi domanda,
@@ -1768,19 +1808,19 @@ Rasponi. Aveva da venir meco anche mia sorella, e per un
 incomodo è restata in villa; qualche amica le potrebbe
 scrivere; guarda se ci sono lettere, o per lei, o per me.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Mi no so quala far. Son l'omo più imbroià de sto
 mondo). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>(Come aspettela lettere al so nome vero, e al so
 nome finto, se l'è partida segretamente?). <emph>(piano a Beatrice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(Ho lasciato ordine, che mi si scriva ad un
 servitor mio fedele, che amministra le cose della mia casa;
@@ -1791,12 +1831,12 @@ lettere, fa' portar il baule nella locanda, ti aspetto.
 <emph>(entra nella locanda)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Sì vu el patron della locanda? <emph>(a Brighella)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Sì ben, son mi. Portève ben, e non ve dubitè che
 ve farò magnar ben. <emph>(entra nella locanda)</emph></p>
@@ -1807,7 +1847,7 @@ ve farò magnar ben. <emph>(entra nella locanda)</emph></p>
           <stage>
             <emph>Truffaldino, poi Silvio</emph>
           </stage>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Oh bella! Ghe n'è tanti, che cerca un padron, e mi
 ghe n'ho trovà do. Come diavol òia da far? Tutti do no li
@@ -1821,56 +1861,56 @@ sempre fatto una bella cossa. Animo; andemo alla posta per
 tutti do. <emph>(incamminandosi)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>(Questi è il servo di Federigo Rasponi). Galantuomo.
 <emph>(a Truffaldino)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Signor.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Dov'è il vostro padrone?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>El me padron? L'è là in quella locanda.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Andate subito dal vostro padrone, ditegli, ch'io gli
 voglio parlare, s'è uomo d'onore, venga giù; ch'io
 l'attendo.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Ma caro signor...</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Andate subito. <emph>(con voce alta)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Ma la sappia, che el me padron...</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Meno repliche, giuro al Cielo.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Ma qualo ha da vegnir?..</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Subito, o ti bastono.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(No so gnente; manderò el primo, che troverò).
 <emph>(entra nella locanda)</emph></p>
@@ -1881,7 +1921,7 @@ l'attendo.</p>
           <stage>
             <emph>Silvio, poi Florindo e Truffaldino</emph>
           </stage>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>No, non sarà mai vero, ch'io soffra vedermi innanzi
 agli occhi un rivale. Se Federigo scampò la vita una volta,
@@ -1891,200 +1931,200 @@ altra gente dalla locanda. Non vorrei essere disturbato.
 <emph>(si ritira dalla parte opposta)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Ecco là quel sior, che butta fogo da tutte le
 bande. <emph>(accenna Silvio a Florindo)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Io non lo conosco. Che cosa vuole da me? <emph>(a Truffaldino)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Mi no so gnente. Vado a tòr le lettere; con so
 bona grazia. (No voggio impegni). <emph>(da sé, e parte)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>(E Federigo non viene). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(Voglio chiarirmi della verità). <emph>(da sé)</emph> Signore,
 siete voi, che mi avete domandato? <emph>(a Silvio)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Io? Non ho nemmeno l'onor di conoscevi.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Eppure quel servitore, che ora di qui è partito, mi
 ha detto, che con voce imperiosa, e con minaccie avete
 preteso di provocarmi.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Colui m'intese male, dissi, che parlar volevo al di
 lui padrone.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Bene; io sono il di lui padrone.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Voi, il suo padrone?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Senz'altro. Egli sta al mio servizio.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Perdonate dunque; o il vostro servitore è simile ad
 un altro, che ho veduto stamane, o egli serve qualche altra
 persona.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Egli serve me; non ci pensate.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Quand'è così, torno a chiedervi scusa.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Non vi è male. Degli equivoci ne nascon sempre.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Siete voi forestiere, signore?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Turinese, a' vostri comandi.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Turinese appunto era quello, con cui desideravo
 sfogarmi.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Se è mio paesano, può essere, ch'io lo conosca, e
 s'egli vi ha disgustato, m'impiegherò volentieri per le
 vostre giuste soddisfazioni.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Conoscete voi un certo Federigo Rasponi?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ah! l'ho conosciuto pur troppo.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Pretende egli per una parola avuta dal padre
 togliere a me una sposa, che questa mane mi ha giurato la
 fede.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Non dubitate, amico, Federigo Rasponi non può
 involarvi la sposa. Egli è morto.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Sì, tutti credevano, ch'ei fosse morto; ma stamane
 giunse vivo, e sano in Venezia per mio malanno, per mia
 disperazione.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Signore, voi mi fate rimaner di sasso.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Ma! ci sono rimasto anch'io.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Federigo Rasponi vi assicuro, che è morto.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Federigo Rasponi vi assicuro, che è vivo.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Badate bene, che v'ingannerete.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Il signor Pantalone de' Bisognosi, padre della
 ragazza, ha fatto tutte le possibili diligenze per
 assicuarsene, ed ha certissime prove, che sia egli proprio
 in persona.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(Dunque non restò ucciso, come tutti credettero
 nella rissa!) <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>O egli, o io abbiamo da rinunziare agli amori di
 Clarice, o alla vita.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(Qui Federigo? Fuggo dalla giustizia, e mi trovo a
 fronte il nemico!). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>È molto, che voi non lo abbiate veduto. Doveva
 alloggiare in codesta locanda.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Non l'ho veduto; qui m'hanno detto, che non vi era
 forestiere nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Avrà cambiato pensiere. Signore, scusate, se vi ho
 importunato. Se lo vedete, ditegli, che per suo meglio,
 abbandoni l'idea di cotali nozze. Silvio Lombardi è il mio
 nome; avrò l'onore di riverirvi.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Gradirò sommamente la vostra amicizia. (Resto pieno
 di confusione). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Il vostro nome, in grazia, poss'io saperlo?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(Non vo' scoprirmi). <emph>(da sé)</emph> Orazio Ardenti per
 obbedirvi.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Signor Orazio, sono a' vostri comandi. <emph>(parte)</emph></p>
           </sp>
@@ -2094,7 +2134,7 @@ obbedirvi.</p>
           <stage>
             <emph>Florindo solo.</emph>
           </stage>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Come può darsi, che una stoccata, che lo passò dal
 petto alle reni non l'abbia ucciso? Lo vidi pure io stesso
@@ -2119,77 +2159,77 @@ Beatrice, e detto. Truffaldino s'avanza alcuni passi col
 Facchino, poi accorgendosi di Florindo e dubitando esser
 veduto, fa ritirare il Facchino.</emph>
           </stage>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Andemo con mi... Oh diavol! L'è qua quest'alter
 padron. Retirete camerada, e aspettème su quel canton. <emph>(il Facchino si ritira)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(Sì, senz'altro. Ritornerò a Turino). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Son qua, signor...</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Truffaldino, vuoi venir a Turino con me?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Quando?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ora; subito.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Senza disnar?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>No, si pranzerà, e poi ce n'anderemo.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Benissimo; disnando, ghe penserò.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Sei stato alla posta?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Signor sì.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Hai trovato mie lettere?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Ghe n'ho trovà.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Dove sono?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Adesso, le troverò. <emph>(tira fuori di tasca tre lettere)</emph> (Oh diavolo! Ho confuso quelle de un patron con
 quelle dell'altro. Come faroio a trovar fora le soe? Mi no
 so lezer). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Animo; da' qui le mie lettere.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Adesso, signor. (Son imbroiado). <emph>(da sé)</emph> Ghe
 dirò, signor; ste tre lettere, no le vien tutte a V.S. Ho
@@ -2199,145 +2239,145 @@ pregà, che veda se gh'era niente per el so padron. Me par
 che ghe ne fusse una, ma no la conosso più; non so quala,
 che la sia.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Lascia vedere a me; prenderò le mie e l'altra te la
 renderò.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Tolì, pur. Me preme de servir l'amigo.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(Che vedo? Una lettera diretta a Beatrice Rasponi?
 A Beatrice Rasponi in Venezia!) <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>L'avì trovada quella del me camerada?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Chi è questo tuo camerata, che ti ha dato una tale
 incombenza?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>L'è un servitor... che gh'ha nome Pasqual.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Chi serve costui?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Mi no lo so, signor.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ma se ti ha detto di cercar le lettere del suo
 padrone, ti avrà dato il nome.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Naturalmente. (L'imbroio cresse). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ebbene, che nome ti ha dato?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>No me l'arrecordo.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Come!...</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>El me l'ha scritto su un pezzo de carta.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>E dov'è la carta?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>L'ho lassada alla posta.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(Io sono in un mare di confusioni). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Me vado inzegnando alla meio). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Dove sta di casa questo Pasquale?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Non lo so, in verità.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Come potrai recapitargli la lettera?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>El m'ha dito, che se vederemo in piazza</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(Io non so, che pensare). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Se la porto fora netta, l'è un miracolo). <emph>(da sé)</emph> La me favorissa quella lettera, che vederò de trovarlo.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>No; questa lettera voglio aprirla.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Oibò; no la fazza sta cossa. La sa pur, che pena
 gh'è a avrir le lettere.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Tant'è, questa lettera m'interessa troppo. È
 diretta a persona, che mi appartiene per qualche titolo.
 Senza scrupolo la posso aprire. <emph>(l'apre)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Schiavo, siori. El l'ha fatta). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>
               <emph>(Legge)</emph>
               <emph>Illustrissima signora padrona. La di lei partenza da questa città ha dato motivo di discorrere a tutto il paese; e tutti capiscono, ch'ella abbia fatto tale risoluzione per seguitare il signor Florindo. La Corte ha penetrato, ch'ella sia fuggita in abito da uomo, e non lascia di far diligenze per rintracciarla, e farla arrestare. Io non ho spedito la presente da questa posta di Torino per Venezia a dirittura, per non iscoprire il paese, dove ella mi ha confidato, che pensava portarsi ma l'ho inviata ad un amico di Genova, perché poi di là la trasmettesse a Venezia. Se avrò novità di rimarco, non lascerò di comunicargliele collo stesso metodo, e umilmente mi rassegno. Umilissimo e fedelissimo servitore Tognin della Doira.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Che bell'azion! Lezer i fatti d'i altri!). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(Che intesi mai? Che lessi? Beatrice partita di
 casa sua? in abito d'uomo? per venire in traccia di me? Ella
@@ -2348,29 +2388,29 @@ chi sia il suo padrone, se uomo, se donna. Rileva dove sia
 alloggiato, e se puoi, conducilo qui da me, che a te, e a
 lui darò una mancia assai generosa.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Dème la lettera; procurerò de trovarlo.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Eccola; mi raccomando a te. Questa cosa mi preme
 infinitamente.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Ma ghe l'ho da dar cusì averta?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Digli, che è stato un equivoco, un accidente. Non
 mi trovare difficoltà.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>E a Turin, se va più per adesso?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>No, non si va più per ora. Non perder tempo.
 Procura di ritrovar Pasquale. (Beatrice in Venezia, Federigo
@@ -2383,7 +2423,7 @@ tutte le diligenze possibili per rinvenirla). <emph>(da sé, e parte)</emph></p>
           <stage>
             <emph>Truffaldino solo, poi il Facchino col baule.</emph>
           </stage>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Ho gusto da galantomo, che no se vada via. Ho
 volontà de veder come me riesce sti do servizi. Vòi provar
@@ -2402,16 +2442,16 @@ pulito! Oh no m'arrecordava più del facchin. Camerada, vegnì
 avanti, tolì su el baul. <emph>(verso la scena)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#facchino">
             <speaker>FACCHINO</speaker>
             <p><emph>(Col baule in spalla)</emph> Son qua; dove l'avemio da
 portar?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Portel in quella locanda, che adess vegno anca mi.</p>
           </sp>
-          <sp>
+          <sp who="#facchino">
             <speaker>FACCHINO</speaker>
             <p>E chi pagherà?</p>
           </sp>
@@ -2421,152 +2461,152 @@ portar?</p>
           <stage>
             <emph>Beatrice, che esce dalla locanda, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>È questo il mio baule? <emph>(a Truffaldino)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Signor sì.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Portatelo nella mia camera. <emph>(al Facchino)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#facchino">
             <speaker>FACCHINO</speaker>
             <p>Qual èla la so camera?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Domandatelo al cameriere.</p>
           </sp>
-          <sp>
+          <sp who="#facchino">
             <speaker>FACCHINO</speaker>
             <p>Semo d'accordo trenta soldi.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Andate, che vi pagherò.</p>
           </sp>
-          <sp>
+          <sp who="#facchino">
             <speaker>FACCHINO</speaker>
             <p>Che la fazza presto.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Non mi seccate.</p>
           </sp>
-          <sp>
+          <sp who="#facchino">
             <speaker>FACCHINO</speaker>
             <p>Adessadesso ghe butto el baul in mezzo alla
 strada. <emph>(entra nella locanda)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Gran persone gentili, che son sti facchini!</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Sei stato alla posta?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Signor sì.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Lettere mie ve ne sono?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Ghe n'era una de vostra sorella.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Bene, dov'è?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Eccola qua. <emph>(le dà la lettera)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Questa lettera è stata aperta.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Averta? Oh! no pol esser.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Aperta, e sigillata ora col pane.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Mi no saveria mai, come che la fusse.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Non lo sapresti eh? Briccone, indegno, chi ha
 aperto questa lettera? Voglio saperlo.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Ghe dirò, signor, ghe confesserò la verità. Semo
 tutti capaci de falar. Alla posta gh'era una lettera mia; so
 poco lezer; e in falo, in vece de averzer la mia, ho averto
 la soa. Ghe domando perdon.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Se la cosa fosse così, non vi sarebbe male.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>L'è così da povero fiol.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>L'hai letta questa lettera? Sai che cosa contiene?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Niente affatto. L'è un carattere, che no capisso.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>L'ha veduta nessuno?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Oh! <emph>(meravigliandosi)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Bada bene, veh!</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Uh! <emph>(come sopra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(Non vorrei, che costui m'ingannasse). <emph>(legge piano)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Anca questa l'è tacconada). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(Tognino è un servitore fedele. Gli ho
 dell'obbligazione). <emph>(da sé)</emph> Orsù io vado per un interesse
@@ -2581,37 +2621,37 @@ premono queste monete). <emph>(da sé, parte)</emph></p>
           <stage>
             <emph>Truffaldino, poi Pantalone</emph>
           </stage>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Mo l'è andada ben, che no la podeva andar meio.
 Son un omo de garbo; me stimo cento scudi de più de quel,
 che no me stimava.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Disè, amigo, el vostro patron xèlo in casa?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Sior no; nol ghe xè.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Saveu dove, che el sia?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Gnanca.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Vienlo a casa a disnar?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Mi crederave de sì.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Tolè, col vien a casa dèghe sta borsa co sti cento
 ducati. No posso trattegnirme, perché gh'ho da far. Ve
@@ -2623,86 +2663,86 @@ reverisso. <emph>(parte)</emph></p>
           <stage>
             <emph>Truffaldino, poi Florindo</emph>
           </stage>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>La diga, la senta. Bon viazo. Nol m'ha gnanca dito
 a qual dei mi patroni ghe l'ho da dar.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>E bene, hai tu ritrovato Pasquale?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Sior no, no l'ho trovà Pasqual; ma ho trovà uno,
 che m'ha dà una borsa con cento ducati.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Cento ducati? Per farne che?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Disim la verità, sior patron, aspetteu dinari da
 nissuna banda?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Sì, ho presentata una lettera ad un mercante.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Donca sti quattrini i sarà vostri.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Che cosa ha detto chi te li ha dati?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>El m'ha dit, che li daga ai me padron.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Dunque sono miei senz'altro. Non sono io il tuo
 padrone? Che dubbio c'è?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(No i sa gnente de quell'alter padron). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>E non sai chi te gli abbia dati?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Mi no so, me par quel viso averlo visto un'altra
 volta, ma no me ricordo.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Sarà un mercante, a cui sono raccomandato.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>El sarà lu senz'altro.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ricordati di Pasquale.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Dopo disnar lo troverò.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Andiamo dunque a sollecitare il pranzo. <emph>(entra nella locanda)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Andemo pur. Manco mal, che stavolta non ho fallà.
 La borsa l'ho data a chi l'aveva d'aver. <emph>(entra nella locanda)</emph></p>
@@ -2714,98 +2754,98 @@ La borsa l'ho data a chi l'aveva d'aver. <emph>(entra nella locanda)</emph></p>
           <stage>
             <emph>PANTALONE e CLARICE, poi SMERALDINA</emph>
           </stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Tant'è; sior Federigo ha da esser vostro mario. Ho
 dà la parola, e no son un bambozzo.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Siete padrone di me, signor padre, ma questa,
 compatitemi, è una tirannia.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Quando sior Federigo v'ha fatto domandar, ve l'ho
 ditto; vu non m'avè resposo de no volerlo. Allora dovevi
 parlar; adesso no sé più a tempo.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>La soggezione, il rispetto, mi fecero ammutolire.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Fè, che el rispetto, e la suggizion fazza l'istesso
 anca adesso.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Non posso, signor padre.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>No? per cossa?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Federigo non lo sposerò certamente.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ve despiaseio tanto?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>È odioso agli occhi miei.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Anca sì, che mi ve insegno el modo de far, che el
 ve piasa?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Come mai, signore?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Desmenteghève sior Silvio, e vederè, che el ve
 piaserà.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Silvio è troppo fortemente impresso nell'anima mia;
 e voi coll'approvazione vostra lo avete ancora più radicato.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(Da una banda la compatisso). <emph>(da sé)</emph> Bisogna far
 de necessità vertù.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Il mio cuore non è capace di uno sforzo sì grande.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Fève animo; bisogna farlo...</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Signor padrone, è qui il signor Federigo, che vuol
 riverirla.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ch'el vegna, che el xè patron.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Oimè Che tormento! <emph>(piange)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Che avete, signora padrona? Piangete? In verità
 avete torto. Non avete veduto com'è bellino il signor
@@ -2813,11 +2853,11 @@ Federigo? Se toccasse a me una tal fortuna, non vorrei
 piangere no; vorrei ridere con tanto di bocca. <emph>(parte)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Via fia mia, no te far veder a pianzer.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Ma se mi sento scoppiar il cuore!</p>
           </sp>
@@ -2827,46 +2867,46 @@ piangere no; vorrei ridere con tanto di bocca. <emph>(parte)</emph>
           <stage>
             <emph>Beatrice da uomo, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Riverisco il signor Pantalone.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Patron reverito. Ala recevesto una borsa con cento
 ducati?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Io no.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Che l'ho dada za un poco al so servitor. La m'ha
 dito, che el xè un omo fidà.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Sì, non vi è pericolo. Non l'ho veduto; me li
 darà, quando torno a casa. (Che ha la signora Clarice, che
 piange?). <emph>(piano a Pantalone)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(Caro sior Federigo, bisogna compatirla. La nova
 della so morte xè stada causa de sto mal. Col tempo spero,
 che la se scambierà). <emph>(piano a Beatrice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(Fate una cosa, signor Pantalone, lasciatemi un
 momento in libertà con lei, per vedere se mi riuscisse
 d'aver una buona parola). <emph>(come sopra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Sior sì; vago, e vegno. (Voggio provarle tutte).
 <emph>(da sé)</emph> Fia mia, aspettème, che adesso torno. Tien un poco
@@ -2878,139 +2918,139 @@ de compagnia al to novizzo. (Via abbi giudizio). <emph>(piano a Clarice, e parte
           <stage>
             <emph>Beatrice e Clarice</emph>
           </stage>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Deh, signora Clarice...</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Scostatevi, e non ardite d'importunarmi.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Così severa con chi vi è destinato in consorte?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Se sarò strascinata per forza alle vostre nozze,
 avrete da me la mano, ma non il cuore.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Voi siete sdegnata meco, eppure io spero placarvi.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>V'aborrirò in eterno.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Se mi conosceste, voi non direste così.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Vi conosco abbastanza per lo sturbatore della mia
 pace.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Ma io ho il modo di consolarvi.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>V'ingannate; altri che Silvio consolare non mi
 potrebbe.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Certo, che non posso darvi quella consolazione,
 che darvi potrebbe il vostro Silvio, ma posso contribuire
 alle vostre felicità.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Mi par assai, signore, che parlandovi io in una
 maniera la più aspra del mondo, vogliate ancor tormentarmi.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(Questa povera giovane mi fa pietà; non ho cuore
 di vederla penare). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>(La passione mi fa diventare ardita, temeraria,
 incivile). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Signora Clarice, vi ho da confidare un segreto.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Non vi prometto la segretezza. Tralasciate di
 confidarmelo.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>La vostra austerità mi toglie il modo di potervi
 render felice.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Voi non mi potete rendere, che sventurata.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>V'ingannate; e per convincervi vi parlerò
 schiettamente. Se voi non volete me, io non saprei, che fare
 di voi. Se avete ad altri impegnata la destra, anch'io con
 altri ho impegnato il cuore.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Ora cominciate a piacermi.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Non vel dissi, che aveva io il modo di consolarvi?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Ah temo, che mi deludiate.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>No, signora, non fingo. Parlovi con il cuore sulle
 labbra; e se mi promettete quella segretezza, che mi negaste
 poc'anzi, vi confiderò un arcano, che metterà in sicuro la
 vostra pace.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Giuro di osservare il più rigoroso silenzio.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Io non sono Federigo Rasponi, ma Beatrice di lui
 sorella.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Oh! che mi dite mai! Voi donna?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Sì, tale io sono. Pensate, se aspiravo di cuore
 alle vostre nozze!</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>E di vostro fratello, che nuova ci date?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Egli morì purtroppo d'un colpo di spada che lo
 passò dal petto alle reni. Fu creduto autore della di lui
@@ -3024,67 +3064,67 @@ ragazza da potersi compromettere di segretezza; per ultimo,
 perché il vostro Silvio mi ha minacciato, e non vorrei, che
 sollecitato da voi, mi ponesse in qualche cimento.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>A Silvio mi permettete voi, ch'io lo dica?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>No, anzi ve lo proibisco assolutamente.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Bene, non parlerò.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Badate, che mi fido di voi.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Ve lo giuro di nuovo, non parlerò.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Ora non mi guarderete più di mal occhio.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Anzi vi sarò amica; e, se posso giovarvi, disponete
 di me.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Anch'io vi giuro eterna la mia amicizia. Datemi la
 vostra mano.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Eh, non vorrei...</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Avete paura, ch'io non sia donna? Vi darò evidenti
 riprove della verità.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Credetemi, ancora mi pare un sogno.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Infatti la cosa non è ordinaria.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>È stravagantissima.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Orsù, io me ne voglio andare. Tocchiamoci la mano,
 in segno di buona amicizia, e di fedeltà.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Ecco la mano; non ho nessun dubbio, che
 m'inganniate.</p>
@@ -3095,95 +3135,95 @@ m'inganniate.</p>
           <stage>
             <emph>Pantalone e dette.</emph>
           </stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Bravi! Me ne rallegro infinitamente. (Fia mia, ti
 t'ha giustà molto presto). <emph>(a Clarice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Non vel dissi, signor Pantalone, che io l'averei
 placata?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Bravo! Avè fatto più vu in quattro minuti, che no
 averave fatto mi in quattr'anni.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>(Ora sono in un laberinto maggiore). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Donca stabiliremo presto sto matrimonio. <emph>(a Clarice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Non abbiate tanta fretta, signore.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Come! Se se tocca le manine in scondon, e non ho
 d'aver pressa? No, no, no voggio, che me succeda desgrazie.
 Doman se farà tutto.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Sarà necessario, signor Pantalone, che prima
 accomodiamo le nostre partite, che vediamo il nostro
 conteggio.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Faremo tutto. Queste le xè cosse, che le se fa in
 do ore. Doman daremo l'anello.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Deh, signor padre...</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Siora fia, vago in sto ponto a dir le parole a sior
 Silvio.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Non lo irritate per amor del Cielo.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Coss'è? Che ne vustu do?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Non dico questo. Ma...</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ma, e mo, la xè finia. Schiavo, siori. <emph>(vuol partire)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Udite... <emph>(a Pantalone)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Sè mario, e muggier. <emph>(partendo)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Piuttosto... <emph>(a Pantalone)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Stassera la discorreremo. <emph>(parte)</emph></p>
           </sp>
@@ -3193,51 +3233,51 @@ Silvio.</p>
           <stage>
             <emph>Beatrice e Clarice</emph>
           </stage>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Ah signora Beatrice, esco da un affanno, per
 entrare in un altro.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Abbiate pazienza. Tutto può succedere, fuor ch'io
 vi sposi.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>E se Silvio mi crede infedele?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Durerà per poco l'inganno.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Se gli potessi svelare la verità...</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Io non vi disimpegno dal giuramento.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Che devo fare dunque?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Soffrire un poco.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Dubito, che sia troppo penosa una tal sofferenza.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Non dubitate, che dopo i timori, dopo gli affanni,
 riescono più graditi gli amorosi contenti. <emph>(parte)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Non posso lusingarmi di provar i contenti finché mi
 vedo circondata da pene. Ah purtroppo egli è vero; in questa
@@ -3254,40 +3294,40 @@ gode. <emph>(parte)</emph></p>
           <stage>
             <emph>Silvio e il Dottore</emph>
           </stage>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Signor padre, vi prego lasciarmi stare.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Fermati; respondimi un poco.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Sono fuori di me.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Per qual motivo sei tu venuto nel cortile del
 signor Pantalone?</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Perché voglio, o che egli mi mantenga quella parola,
 che mi ha dato, o che mi renda conto del gravissimo
 affronto.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Ma questa è una cosa, che non conviene farla nella
 propria casa di Pantalone. Tu sei un pazzo a lasciarti
 trasportar dalla collera.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Chi tratta male con noi, non merita alcun rispetto.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>È vero, Pantalone manca al dovere di galantuomo,
 ma non per questo si ha da precipitare. Lascia fare a me,
@@ -3297,15 +3337,15 @@ Ritirati in qualche loco, e aspettami; esci di questo
 cortile, non facciamo scene. Aspetterò io il signor
 Pantalone.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Ma io, signor padre...</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Ma io, signor figliuolo, voglio poi esser obbedito.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Sì, v'obbedirò. Me n'anderò. Parlategli. Vi aspetto
 dallo speziale. Ma se il signor Pantalone persiste, averà
@@ -3317,62 +3357,62 @@ che fare con me. <emph>(parte)</emph></p>
           <stage>
             <emph>Il Dottore, poi Pantalone</emph>
           </stage>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Povero figliuolo, lo compatisco. Non doveva mai il
 signor Pantalone lusingarlo a tal segno, prima di essere
 certo della morte del turinese. Vorrei pure vederlo quieto,
 e non vorrei, che la collera me lo facesse precipitare.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(Cossa fa el Dottor in casa mia?). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Oh signor Pantalone, vi riverisco.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Schiavo, sior Dottor. Giusto adesso vegniva a
 cercar de vu, e de vostro fio.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Sì? Bravo; m'immagino, che dovevate venire in
 traccia di noi, per assicurarci, che la signora Clarice sarà
 moglie di Silvio.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Anzi vegniva per dirve... <emph>(mostrando difficoltà di parlare)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>No, non c'è bisogno di altre giustificazioni.
 Compatisco il caso, in cui vi siete trovato. Tutto vi si
 passa in grazia della buona amicizia.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Siguro, che considerando la promessa fatta a sior
 Federigo... <emph>(titubando, come sopra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>E colto all'improvviso da lui, non avete avuto
 tempo a riflettere; e non avete pensato all'affronto, che si
 faceva alla nostra casa.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>No se pol dir affronto, quando con un altro
 contratto...</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>So che cosa volete dire. Pareva a prima vista, che
 la promessa col turinese fosse indissolubile, perché
@@ -3380,110 +3420,110 @@ stipulata per via di contratto. Ma quello era un contratto
 seguito fra voi, e lui, e il nostro è confermato dalla
 fanciulla.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Xè vero; ma...</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>E sapete bene, che in materia di matrimoni:
 <emph>Consensus, et non concubitus facit virum</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Mi no so de latin; ma ve digo...</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>E le ragazze non bisogna sacrificarle.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Aveu altro da dir?</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Per me ho detto.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Aveu fenio?</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Ho finito.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Poss'io parlar?</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Parlare.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Sior Dottor caro, con tutta la vostra dottrina...</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Circa alla dote ci aggiusteremo. Poco più, poco
 meno, non guarderò.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Semo da capo. Voleu lassarme parlar?</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Parlate.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ve digo, che la vostra dottrina xè bella, e bona,
 ma in sto caso no la conclude. Sior Federigo el xè dessù in
 camera co mia fia, e se vu savè tutte le regole dei
 sposalizi, credo, che a questo no ghe manca gnente.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Come! È fatto ogni cosa?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Tutto.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>L'amico è in camera?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ghe l'ho lassà za un poco.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>E la signora Clarice lo ha sposato, così su due
 piedi, senza la minima difficoltà?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>No saveu come, che le xè le donne? Le se volta come
 le bandiere.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>E voi comporterete, che segua un tal matrimonio?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Per mi giera impegnà, che no me podeva cavar. Mia
 fia xè contenta; che difficoltà poss'io aver? Vegniva a
 posta a cercar de vu, o de sior Silvio, per dirve sta cossa.
 La me despiase assae, ma non ghe vedo remedio.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Non mi maraviglio della vostra figliuola, mi
 maraviglio di voi, che trattiate sì malamente con me. Se non
@@ -3512,112 +3552,112 @@ dovrete pagare: sì, verrà il tempo: <emph>omnia tempus habent</emph>.
           <stage>
             <emph>Pantalone, poi Silvio</emph>
           </stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Andè, che ve mando. No me n'importa un figo, e no
 gh'ho paura de vu. Stimo più la casa Rasponi, de cento case
 Lombardi. Un fio unico, e ricco desta qualità, se stenta a
 trovarlo. L'ha da esser cusì.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>(Ha bel dire mio padre. Chi si può tenere, si tenga)
 <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(Adesso, alla segonda de cambio). <emph>(da sé, vedendo Silvio)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Schiavo suo, signore. <emph>(bruscamente)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Patron reverito. (La ghe fuma). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Ho inteso da mio padre un certo non so che; crediamo
 poi, che sia la verità?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Co ghe l'ha dito so sior padre, sarà vero.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Sono dunque stabiliti gli sponsali della signora
 Clarice col signor Federigo?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Sior sì, stabilidi, e conclusi.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Mi maraviglio, che me lo diciate con tanta temerità.
 Uomo indegno, senza parola, senza riputazione.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Come parlela, patron? Co un omo vecchio della mia
 sorte la tratta cusì?</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Se non foste vecchio, come siete, vi pelerei quella
 barba.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Poderave anca esser, che mi ghe tagiasse i
 garettoli.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Non so chi mi tenga, che non vi passi da parte a
 parte.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>No son miga una rana, patron. In casa mia se vien a
 far ste bulae?</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Venite fuori di questa casa.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Me maraveggio de ela, sior.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Fuori, se siete un uomo d'onore.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ai omeni della mia sorte seghe porta respetto.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Siete un vile, un codardo, un plebeo.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Sè un tocco de temerario.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Eh, giuro al Cielo... <emph>(mette mano alla spada)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Agiuto. <emph>(mette mano al pistolese)</emph></p>
           </sp>
@@ -3627,43 +3667,43 @@ far ste bulae?</p>
           <stage>
             <emph>Beatrice colla spada alla mano, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Eccomi; sono io in vostra difesa. <emph>(a Pantalone, e rivolta la spada contro Silvio)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Sior zenero, me raccomando. <emph>(a Beatrice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Con te per l'appunto desideravo di battermi. <emph>(a Beatrice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(Son nell'impegno). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Rivolgi a me quella spada. <emph>(a Beatrice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ah sior zenero... <emph>(timoroso)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Non è la prima volta, che io mi sia cimentato. Son
 qui, non ho timore di voi. <emph>(presenta la spada a Silvio)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Aiuto. No gh'è nissun?
 <emph>(Parte correndo verso la strada. Beatrice e Silvio si battono. Silvio cade e lascia la spada in terra, e Beatrice gli presenta la punta al petto.)</emph></p>
@@ -3674,12 +3714,12 @@ qui, non ho timore di voi. <emph>(presenta la spada a Silvio)</emph>
           <stage>
             <emph>Clarice e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Oimè! Fermate. <emph>(a Beatrice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Bella Clarice, in grazia vostra dono a Silvio la
 vita, e voi in ricompensa della mia pietà, ricordatevi del
@@ -3691,199 +3731,199 @@ giuramento. <emph>(parte)</emph></p>
           <stage>
             <emph>Silvio e Clarice</emph>
           </stage>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Siete salvo, o mio caro?</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Ah, perfida ingannatrice! Caro a Silvio? Caro ad un
 amante schernito, ad uno sposo tradito?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>No, Silvio, non merito i vostri rimproveri. V'amo,
 v'adoro, vi son fedele.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Ah menzognera! Mi sei fedele eh? Fedeltà chiami
 prometter fede ad un altro amante?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Ciò non feci, né farò mai. Morirò, prima
 d'abbandonarvi.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Vostro padre assicurò il mio, delle vostre nozze con
 Federigo.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Mio padre non poteva dirlo.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Potea egli dire, che Federigo era con voi. Nella
 vostra camera?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Non so negarlo.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>E vi par poco? E pretendete, che io vi creda fedele,
 quand'altri è ammesso da voi ad una confidenza sì grande?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Clarice sa custodir l'onor suo.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Clarice non doveva lasciarsi avvicinare un amante,
 che la pretende in isposa.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Mio padre lo lasciò meco.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>E voi non lo vedeste malvolentieri.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Sarei fuggita con molto piacere.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Sento, che vi ha impegnato con un giuramento.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Il giuramento non mi obbligava di trattenermi.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Che cosa dunque giuraste?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Caro Silvio, compatitemi, non posso dirlo.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Per qual ragione?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Perché giurai di tacere.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Segno dunque, che siete colpevole.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>No; sono innocente.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Gl'innocenti non tacciono.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Eppure questa volta, rea mi farei parlando.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Questo silenzio a chi l'avete giurato?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>A Federigo.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>E con tanto zelo l'osserverete?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>L'osserverò per non divenire spergiura.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>E dite di non amarlo? Semplice chi vi crede. Non vi
 credo io già, barbara, ingannatrice! Toglietevi dagli occhi
 miei.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Se non vi amassi, non sarei corsa qui a precipizio
 per difendere la vostra vita.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Odio anche la vita, se ho da riconoscerla da
 un'ingrata.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Vi amo con tutto il cuore.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Vi abborrisco con tutta l'anima.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Morirò, se non vi placate.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Vedrei il vostro sangue più volentieri della
 infedeltà vostra.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Saprò soddisfarvi. <emph>(toglie la spada di terra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Ed io vi starò a vedere. (Già so, che non avrà cuore
 di farlo).</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Questa spada vi renderà dunque contento. (Vo'
 vedere fin dove arriva la sua crudeltà).</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Quella spada potrebbe vendicare i miei torti.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Così barbaro colla vostra Clarice?</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Voi mi avete insegnata la crudeltà.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Dunque bramate la morte mia?</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Io non so dire, che cosa brami.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Vi saprò compiacere. <emph>(volta la punta al proprio seno)</emph></p>
           </sp>
@@ -3893,7 +3933,7 @@ vedere fin dove arriva la sua crudeltà).</p>
           <stage>
             <emph>Smeraldina e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Fermatevi; che diamine fate? <emph>(leva la spada a Clarice)</emph> E voi, cane rinnegato, l'avreste lasciata morire?
 <emph>(a Silvio)</emph> Che cuore avete di tigre, di leone, di diavolo?
@@ -3905,7 +3945,7 @@ uomini non ne mancano, m'impegno avanti sera trovarvene una
 dozzina. <emph>(getta la spada in terra, e Silvio la prende)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p><emph>(Piangendo)</emph> Ingrato! Possibile, che la mia morte
 non vi costasse un sospiro? Sì, mi ucciderà il dolore;
@@ -3920,37 +3960,37 @@ piangerete la mia sventura, e la vostra barbara crudeltà.
           <stage>
             <emph>Silvio e Smeraldina</emph>
           </stage>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Questa è una cosa, che non so capire. Veder una
 ragazza, che si vuol ammazzare, e star lì a guardarla, come
 se vedeste rappresentare una scena di commedia.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Pazza che sei! Credi tu, ch'ella si volesse uccider
 davvero?</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Non so altro io; so, che se non arrivava a tempo,
 la poverina sarebbe ita.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Vi voleva ancor tanto prima, che la spada giungesse
 al petto.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Sentite, che bugiardo! Se stava lì, lì, per
 entrare.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Tutte finzioni di voi altre donne.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Sì, se fossimo, come voi. Dirò come dice il
 proverbio: noi abbiamo le voci, e voi altri avete le noci.
@@ -3970,7 +4010,7 @@ diventerebbero boschi. <emph>(parte)</emph></p>
           <stage>
             <emph>Silvio solo.</emph>
           </stage>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Sì, che Clarice è infedele. Confessa essere stata da
 sola a sola con Federigo, e col pretesto di un giuramento
@@ -3989,7 +4029,7 @@ laterali.</stage>
           <stage>
             <emph>TRUFFALDINO, poi FLORINDO</emph>
           </stage>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Mo gran desgrazia che l'è la mia! De do padroni,
 nissun è vegnudo ancora a disnar. L'è do ore, che è sonà
@@ -3998,68 +4038,68 @@ volta, e mi sarò imbroiado; tutti do no li poderò servir, e
 se scovrirà la fazzenda. Zitto, zitto, che ghe n'è qua un.
 Manco mal.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>E bene, hai ritrovato codesto Pasquale?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>No avemio dito, signor, che el cercherò dopo, che
 averemo disnà?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Io sono impaziente.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>El doveva vegnir a disnar un poco più presto.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(Non vi è modo, ch'io possa assicurarmi se qui si
 trovi Beatrice). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>El me dis, andemo a ordinar el pranso, e po el va
 fora de casa. La robba sarà andada de mal.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Per ora, non ho volontà di mangiare. (Vo' tornare
 alla posta. Ci voglio andare da me; qualche cosa forse
 rileverò). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>La sappia, signor, che in sto paese bisogna
 magnar, e chi no magna, s'ammala.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Devo uscire, per un affar di premura. Se torno a
 pranzo, bene; quando no, mangerò questa sera. Tu se vuoi,
 fatti dar da mangiare.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Oh non occorr'altro. Co l'è cusì, che el se
 comoda, che l'è patron.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Questi danari mi pesano; tieni; mettigli nel mio
 baule. Eccoti la chiave. <emph>(dà a Truffaldino la borsa dei cento ducati e la chiave)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>La servo, e ghe porto la chiave.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>No, no, me la darai. Non mi vo' trattenere. Se non
 torno a pranzo, vieni alla piazza; attenderò con impazienza,
@@ -4071,142 +4111,142 @@ che tu abbia ritrovato Pasquale. <emph>(parte)</emph></p>
           <stage>
             <emph>Truffaldino, poi Beatrice con un foglio in mano.</emph>
           </stage>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Manco mal, che l'ha dito, che me fazza dar da
 magnar; cusì andaremo d'accordo. Se nol vol magnar lu, che
 el lassa star. La mia complession no l'è fatta per dezunar.
 Vòi metter via sta borsa, e po subito...</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Ehi, Truffaldino?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Oh diavolo!). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Il signor Pantalone de' Bisognosi ti ha dato una
 borsa con cento ducati?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Sior sì, el me l'ha dada.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>E perché dunque non me la dai?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Mo, vienla a vossioria?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Se viene a me? Che cosa ti ha detto, quando ti ha
 dato la borsa?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>El m'ha dit, che la daga al me patron.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Bene, il tuo padrone chi è?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Vossioria.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>E perché domandi dunque, se la borsa è mia?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Donca la sarà soa.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Dov'è la borsa?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Eccola qua. <emph>(gli dà la borsa)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Sono giusti?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Mi no li ho toccadi, signor.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(Li conterò poi). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Aveva falà mi, colla borsa; ma con giudizio ho
 rimedià. Cossa dirà quell'altro? Se no iera soi, nol dirà
 niente). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Vi è il padrone della locanda?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>El gh'è, signor sì.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Digli, che averò un amico a pranzo con me; che
 presto presto proccuri di accrescer la tavola più che può.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Come vorla restar servida? Quanti piatti
 comandela?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Il signor Pantalone de' Bisognosi non è uomo di
 gran soggezione. Digli, che faccia cinque, o sei piatti;
 qualche cosa di buono.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Se remettela in mi?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Sì, ordina tu, fatti onore. Vado a prender
 l'amico, che è qui poco lontano; e quando torno, fa', che
 sia preparato. <emph>(in atto di partire)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>La vederà, come la sarà servida.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Tieni questo foglio, mettilo nel baule. Bada bene
 veh, che è una lettera di cambio di quattro mila scudi.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>No la se dubita, la metterò via subito.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Fa' che sia tutto pronto. (Povero signor
 Pantalone, ha avuto la gran paura. Ha bisogno di essere
@@ -4218,7 +4258,7 @@ divertito). <emph>(da sé, e parte)</emph></p>
           <stage>
             <emph>Truffaldino, poi Brighella</emph>
           </stage>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Qua bisogna veder de farse onor. La prima volta,
 che sto me padron me ordena un disnar, vòi farghe veder se
@@ -4229,116 +4269,116 @@ Chiaméme missier Brighella, disèghe che ghe vòi parlar.
 pietanze, ma in tel bon ordine; val più una bella
 disposizion, che no val una montagna de piatti.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Cossa gh'è, sior Truffaldin? Cossa comandeu da mi?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>El me padron el gh'ha un amigo a disnar con lu; el
 vol che radoppiè la tavola, ma presto, subito. Aveu el
 bisogno in cusina?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Da mi gh'è sempre de tutto. In mezz'ora posso
 meter all'ordene qualsesia disnar.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Ben donca. Disìme cossa, che ghe darè.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Per do persone, faremo do portade de quattro
 piatti l'una; anderà ben?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(L'ha dito cinque, o sie piatti; sie, o otto, no
 gh'è mal). Anderà ben. Cossa ghe sarà in sti piatti?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Nella prima portada, ghe daremo la suppa, la
 frittura, el lesso e un fracandò.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Tre piatti li cognosso; el quarto no so cossa che
 el sia.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Un piatto alla franzese, un intingolo, una bona
 vivanda.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Benissimo, la prima portada va ben; alla segonda.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>La segonda ghe daremo: l'arrosto, l'insalata, un
 pezzo de carne pastizzada, e un bodin.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Anca qua gh'è un piatto, che no cognosso; coss'è
 sto budellin?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Ho dito un bodin, un piatto all'inglese, una cossa
 bona.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Ben, son contento; ma come disponeremio le vivande
 in tavola?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>L'è una cossa facile. El camerier farà lu.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>No, amigo, me preme la scalcaria; tutto consiste
 in saver metter in tola ben.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Se metterà per esempio qua la soppa, qua el
 fritto, qua l'alesso, e qua el fracandò. <emph>(accenna una qualche distribuzione)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>No, no me piase; e in mezzo no ghe mettè gnente?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Bisognerave, che fessimo cinque piatti.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Ben, far cinque piatti.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>In mezzo ghe metteremo una salsa per el lesso.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>No, no savè gnente, caro amigo; la salsa no va ben
 in mezzo; in mezzo ghe va la minestra.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>E da una banda metteremo el lesso, e da st'altra
 la salsa...</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Oibò, oibò, no faremo gnente. Voi altri locandieri
 savì cusinar, ma no savi metter in tola. Ve insegnerò mi. Fè
@@ -4351,11 +4391,11 @@ salsa, e qua el piatto, che no cognosso. <emph>(con altri due pezzi della letter
 Cossa ve par? Cusì anderala ben? <emph>(a Brighella)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Va ben; ma la salsa l'è troppo lontana dal lesso.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Adesso, vederemo come se pol far a tirarla più da
 visin.</p>
@@ -4366,135 +4406,135 @@ visin.</p>
           <stage>
             <emph>Beatrice, Pantalone e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Che cosa fai ginocchioni? <emph>(a Truffaldino)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Stava qua disegnando la scalcaria. <emph>(s'alza)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Che foglio è quello?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Oh diavolo! la lettera, che el m'ha dà!) <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Quella è la mia cambiale.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>La compatissa. La torneremo a unir...</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Briccone! Così tieni conto delle cose mie? Di cose
 di tanta importanza? Tu meriteresti, che io ti bastonassi.
 Che dite, signor Pantalone? Si può vedere una sciocchezza
 maggior di questa?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>In verità, che la xè da rider. Sarave mal, se no
 ghe fusse caso de remediarghe; ma co mi ghe ne fazzo
 un'altra, la xè giustada.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Tant'era, se la cambiale veniva di lontan paese.
 Ignorantaccio!</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Tutto el mal l'è vegnù, perché Brighella no sa
 metter i piatti in tola.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>El trova difficoltà in tutto.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Mi son un omo, che sa...</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Va' via di qua. <emph>(a Truffaldino)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Val più el bon ordine...</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Va' via, ti dico.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>In materia de scalcheria no ghe la cedo al primo
 marescalco del mondo. <emph>(parte)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>No lo capisso quell'omo; qualche volta l'è furbo,
 e qualche volta l'è allocco.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Lo fa lo sciocco, il briccone. E bene, ci darete
 voi da pranzo? <emph>(a Brighella)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Se la vol cinque piatti per portada, ghe vol un
 poco de tempo.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Coss'è ste portade? Coss'è sti cinque piatti? Alla
 bona, alla bona. Quattro risi, un per de piatti, e schiavo.
 Mi no son omo da suggizion.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Sentite? Regolatevi voi. <emph>(a Brighella)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Benissimo; ma averia gusto, se qualcossa ghe
 piasesse, che la me lo disesse.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Se ghe fosse delle polpette, per mi, che stago mal
 de denti, le magneria volentiera.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Sentite? Delle polpette. <emph>(a Brighella)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>La sarà servida. La se comoda in quella camera,
 che adessadesso ghe mando in tola.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Dite a Truffaldino, che venga a servire.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Ghe lo dirò, signor. <emph>(parte)</emph></p>
           </sp>
@@ -4504,12 +4544,12 @@ che adessadesso ghe mando in tola.</p>
           <stage>
             <emph>Beatrice, Pantalone, poi Camerieri, poi Truffaldino</emph>
           </stage>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Il signor Pantalone si contenterà di quel poco,
 che ci daranno.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Me maraveggio, cara ela; xè anca troppo l'incomodo,
 che la se tol; quel, che averave da farmi con elo, el fa elo
@@ -4519,21 +4559,21 @@ accettà le so grazie, per divertirme un pochetto; tremo
 ancora dalla paura. Se no gieri vu, fio mio, quel cagadonao
 me sbasiva.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Ho piacere d'essere arrivato in tempo. <emph>(I Camerieri portano nella camera indicata da Brighella tutto l'occorrente per preparare la tavola, con bicchieri, vino, pane ecc.)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>In sta locanda i xè molto lesti.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Brighella è un uomo di garbo. In Turino serviva un
 gran cavaliere, e porta ancora la sua livrea.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ghe xè anca una certa locanda sora Canal Grando in
 fazza alle Fabbriche de Rialto, dove, che se magna molto
@@ -4542,12 +4582,12 @@ della bona stampa, e son stà cusì ben, che co me l'arrecordo
 ancora me consolo. Tra le altre cosse me recordo d'un certo
 vin de Borgogna, che el dava el becco alle stelle,</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Non vi è maggior piacere al mondo, oltre quello di
 essere in buona compagnia.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Oh se la savesse che compagnia, che xè quella! Se
 la savesse, che cuori tanto fatti! Che sincerità! Che
@@ -4556,39 +4596,39 @@ alla Zuecca! Siei benedetti! Sette, o otto galantomeni, che
 no ghe xè i so compagni a sto mondo. <emph>(i Camerieri escono dalla stanza e tornano verso la cucina)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Avete dunque goduto molto con questi?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>L'è che spero de goder ancora.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p><emph>(Col piatto in mano della minestra o della zuppa)</emph> La resta servida in camera, che porto in tola. <emph>(a Beatrice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Va' innanzi tu; metti giù la zuppa.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Eh la resti servida prima lei. <emph>(fa le cerimonie)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>El xè curioso sto so servitor. Andemo. <emph>(entra in camera)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Io vorrei meno spirito, e più attenzione. <emph>(a Truffaldino, ed entra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Guardè, che bei trattamenti! Un piatto alla volta!
 I spende i so quattrini, e no i gh'ha niente de bon gusto.
@@ -4603,21 +4643,21 @@ Eh! no gh'è mal; la poderave esser pezo. <emph>(entra in camera)</emph></p>
             <emph>Un Cameriere con un piatto, poi Truffaldino, poi Florindo,
 poi Beatrice ed altri Camerieri</emph>
           </stage>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Quanto sta costui a venir a prendere il lesso?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p><emph>(Dalla camera)</emph> Son qua, camerada; cossa me deu?</p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Ecco il lesso. Vado a prender un altro piatto.
 <emph>(parte)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Che el sia castrà, o che el sia vedèlo? El me par
 castrà. Sentimolo un pochetin. <emph>(ne assaggia un poco)</emph> No
@@ -4625,99 +4665,99 @@ l'è né castrà, né vedèlo, l'è pegora bella, e bona.
 <emph>(s'incammina verso la camera di Beatrice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Dove si va? <emph>(l'incontra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Oh poveretto mi!) <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Dove vai con quel piatto?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Metteva in tavola, signor.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>A chi?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>A vussioria.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Perché metti in tavola, prima ch'io venga a casa?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>V'ho visto a vegnir dalla finestra (Bisogna
 trovarla). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>E dal lesso princìpi a metter in tavola, e non
 dalla zuppa?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Che dirò, signor, a Venezia la minestra la se
 magna in ultima, per insalata.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Io costumo diversamente. Voglio la minestra.
 Riporta il lesso in cucina.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Signor sì, la sarà servida.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>E spicciati, che voglio poi riposare.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Subito, signor. <emph>(mostra di ritornare in cucina)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(Questa Beatrice non la ritroverò mai). <emph>(da sé; entra nell'altra camera in prospetto) (Truffaldino, entrato Florindo in camera, corre col piatto e lo porta a Beatrice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p><emph>(Torna con una vivanda)</emph> E sempre bisogna
 aspettarlo. Truffaldino. <emph>(chiama)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p><emph>(Esce di camera di Beatrice)</emph> Son qua. Presto,
 andè a parecchiar in quell'altra camera, che l'è arrivado
 quell'altro forestier; e portè la minestra subito.</p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Subito. <emph>(parte)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Sta piettanza coss'èla mo? Bisogna che el sia el
 fracastor. <emph>(assaggia)</emph> Bona, bona, da galantomo. <emph>(la porta in camera di Beatrice) (Camerieri passano e portano l'occorrente per preparare la tavola in camera di Florindo)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Bravi. Pulito. I è lesti come gatti. Oh se me
 riussisse de servir a tavola sti do patroni; mo la saria la
@@ -4725,108 +4765,108 @@ gran bella cossa!
 <emph>(Camerieri escono dalla camera di Florindo e vanno verso la cucina)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Presto fioi, la menestra.</p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Pensate alla vostra tavola; e noi penseremo a
 questa. <emph>(parte)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Vorria pensar a tutte do, se podesse.
 <emph>(Cameriere torna colla minestra per Florindo)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Dè qua a mi, che ghe la porterò mi; andè a
 parecchiar la roba per quell'altra camera.
 <emph>(Leva la minestra di mano al Cameriere e la porta in camera di Florindo)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>È curioso costui. Vuol servire di qua e di là. Io
 lascio fare: già la mia mancia bisognerà, che me la diano.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>
               <emph>(Esce di camera di Florindo)</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Truffaldino. <emph>(dalla camera lo chiama)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Eh! servite il vostro padrone. <emph>(a Truffaldino)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Son qua. <emph>(entra in camera di Beatrice) (Camerieri portano il bollito per Florindo)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Date qui. <emph>(lo prende; Camerieri partono) (Truffaldino esce di camera di Beatrice con i tondi sporchi)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Truffaldino. <emph>(dalla camera lo chiama forte)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Dè qua. <emph>(vuol prendere il piatto del bollito dal Cameriere)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Questo lo porto io.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>No sentì, che el me chiama mi? <emph>(gli leva il bollito di mano e lo porta a Florindo)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>È bellissima. Vuol far tutto.
 <emph>(Camerieri portano un piatto di polpette, lo danno al Cameriere e partono)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Lo porterei io in camera, ma non voglio aver che
 dire con costui.
 <emph>(Truffaldino esce di camera di Florindo con i tondi sporchi)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Tenete, signor facendiere; portate queste polpette
 al vostro padrone.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Polpette? <emph>(prendendo il piatto in mano)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Sì, le polpette ch'egli ha ordinato. <emph>(parte)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Oh bella! A chi le òi da portar? Chi diavol de sti
 do padroni le averà ordinade? Se ghel vago a domandar in
@@ -4841,62 +4881,62 @@ vòi, che nissun se n'abbia per mal, me la magnerò mi.
 questo. <emph>(mette in terra l'altro tondo, e ne porta uno da Beatrice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p><emph>(Con un bodino all'inglese)</emph> Truffaldino.
 <emph>(chiama)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Son qua. <emph>(esce dalla camera di Beatrice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Portate questo bodino...</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Aspettè, che vegno. <emph>(prende l'altro tondino di polpette, e lo porta a Florindo)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Sbagliate; le polpette vanno di là.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Sior sì, lo so, le ho portade de là; e el me
 patron manda ste quattro a regalar a sto forestier.
 <emph>(entra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Si conoscono dunque, sono amici. Potevano desinar
 insieme.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p><emph>(Torna in camera di Florindo)</emph> E cusì, coss'èlo
 sto negozio? <emph>(al Cameriere)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Questo è un bodino all'inglese.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>A chi valo?</p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Al vostro padrone. <emph>(parte)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Che diavolo è sto bodin? L'odor l'è prezioso, el
 par polenta. Oh, se al foss polenta, la saria pur una bona
@@ -4905,139 +4945,139 @@ l'è polenta, ma el ghe someia. <emph>(mangia)</emph> L'è meio della
 polenta. <emph>(mangia)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Truffaldino. <emph>(dalla camera lo chiama)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Vegno. <emph>(risponde colla bocca piena)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Truffaldino. <emph>(lo chiama dalla sua camera)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Son qua. <emph>(risponde colla bocca piena, come sopra)</emph> Oh che roba preziosa! Un altro bocconcin, e vegno.
 <emph>(segue a mangiare)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p><emph>(Esce dalla sua camera e vede Truffaldino che mangia; gli dà un calcio e gli dice)</emph> Vieni a servire.
 <emph>(torna nella sua camera)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>
               <emph>(Mette il bodino in terra, ed entra in camera di Beatrice)</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p><emph>(Esce dalla sua camera)</emph> Truffaldino. <emph>(chiama)</emph>
 Dove diavolo è costui?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p><emph>(Esce dalla camera di Beatrice)</emph> L'è qua.
 <emph>(vedendo Florindo)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Dove sei? Dove ti perdi?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Era andà a tòr dei piatti, signor.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Vi è altro da mangiare?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Anderò a veder.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Spicciati, ti dico che ho bisogno di riposare.
 <emph>(torna nella sua camera)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Subito. Camerieri; gh'è altro? <emph>(chiama)</emph> Sto
 bodin, me lo metto via per mi. <emph>(lo nasconde)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Eccovi l'arrosto. <emph>(porta un piatto con l'arrosto)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Presto, i frutti. <emph>(prende l'arrosto)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Gran furia! Subito. <emph>(parte)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>L'arrosto lo porterò a questo. <emph>(entra da Florindo)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Ecco la frutta, dove siete? <emph>(con un piatto di frutta)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Son qua. <emph>(di camera di Florindo)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Tenete. <emph>(gli dà le frutta)</emph> Volete altro?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Aspettè. <emph>(porta le frutta a Beatrice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Salta di qua, salta di là; è un diavolo costui.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Non occorr'altro. Nissun vol altro.</p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Ho piacere.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Parecchiè per mi.</p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Subito. <emph>(parte)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Togo su el me bodin, e viva, e l'ho superada;
 tutti è contenti; no i vol alter; i è stadi servidi. Ho
@@ -5052,7 +5092,7 @@ quattro. <emph>(parte)</emph></p>
           <stage>
             <emph>Smeraldina, poi il Cameriere della locanda.</emph>
           </stage>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Oh, guardate, che discretezza della mia padrona!
 Mandarmi con un viglietto ad una locanda! Ad una locanda una
@@ -5065,68 +5105,68 @@ per la state, e l'altro per l'inverno. Basta... Io nella
 locanda non entro certo. Chiamerò; qualcheduno uscirà. O di
 casa! o dalla locanda!</p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Che cosa volete quella giovine?</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>(Mi vergogno davvero, davvero). <emph>(da sé)</emph> Ditemi...
 Un certo signor Federigo Rasponi è alloggiato in questa
 locanda?</p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Sì, certo. Ha finito di pranzare, che è poco.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Avrei da dirgli una cosa.</p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Qualche ambasciata? Potete passare.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Ehi, chi vi credete, ch'io sia? Sono la cameriera
 della sua sposa.</p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Bene, passate.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Oh non ci vengo io là dentro.</p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Volete, ch'io lo faccia venire sulla strada? Non mi
 pare cosa ben fatta; tanto più, ch'egli è in compagnia col
 signor Pantalone de' Bisognosi.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Il mio padrone? Peggio! Oh non ci vengo.</p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Manderò il suo servitore, se volete.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Quel moretto?</p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Per l'appunto.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Sì, mandatelo.</p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>(Ho inteso. Il moretto le piace. Si vergogna a venir
 dentro. Non si vergognerà a farsi scorgere in mezzo alla
@@ -5138,394 +5178,394 @@ strada). <emph>(entra)</emph></p>
           <stage>
             <emph>Smeraldina, poi Truffaldino</emph>
           </stage>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Se il padrone mi vede, che cosa le dirò? Dirò, che
 venivo in traccia di lui; eccola bella, e accomodata. Oh non
 mi mancano ripieghi.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p><emph>(Con un fiasco in mano, ed un bicchiere, ed un tovagliolino)</emph> Chi è che me domanda?</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Sono io, signore. Mi dispiace avervi incomodato.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Niente; son qua a ricever i so comandi.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>M'immagino, che foste a tavola per quel, ch'io
 vedo.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Era a tavola, ma ghe tornerò.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Davvero me ne dispiace.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>E mi gh'ho gusto. Per dirvela, ho la panza piena e
 quei bei occhietti i è giusto a proposito per farme digerir.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>(Egli è pure grazioso!). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Metto zo el fiaschetto, e son qua da vu, cara.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>(Mi ha detto cara). <emph>(da sé)</emph> La mia padrona manda
 questo viglietto al signor Federigo Rasponi; io nella
 locanda non voglio entrare, onde ho pensato di dar a voi
 quest'incomodo che siete il suo servitore.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Volentiera, ghe lo porterò; ma prima sappiè, che
 anca mi v'ho da far un'imbassada.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Per parte di chi?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Per parte de un galantomo. Disime, conossive vu un
 certo Truffaldin Batocchio?</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Mi pare averlo sentito nominare una volta, ma non
 me ne ricordo. (Avrebbe a esser lui questo). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>L'è un bell'omo; bassotto, traccagnotto,
 spiritoso, che parla ben. Maestro de cerimonie...</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Io non lo conosco assolutamente.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>E pur lu el ve cognosse; e l'è innamorado de vu.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Oh! mi burlate.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>E se el podesse sperar un tantin de
 corrispondenza, el se daria da cognosser.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Dirò, signore; se lo vedessi, e mi desse nel genio,
 sarebbe facile, che io gli corrispondessi.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Vorla, che ghe lo fazza veder?</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Lo vederò volentieri.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Adesso subito. <emph>(entra nella locanda)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Non è lui dunque.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>
               <emph>(Esce dalla locanda, fa delle riverenze a Smeraldina, le passa vicino; poi sospira ed entra nella locanda)</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Quest'istoria non la capisco.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>L'àla visto? <emph>(tornando a uscir fuori)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Chi?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Quello, che è innamorado delle so bellezze.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Io non ho veduto altri, che voi.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Mah! <emph>(sospirando)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Siete voi forse quello, che dice di volermi bene?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Son mi. <emph>(sospirando)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Perché non me l'avete detto alla prima?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Perché son un poco vergognosetto.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>(Farebbe innamorate i sassi). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>E cusì, cossa me dìsela?</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Dico che...</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Via, la diga.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Oh anch'io sono vergognosetta.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Se se unissimo insieme, faressimo el matrimonio de
 do persone vergognose.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>In verità; voi mi date nel genio.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Èla putta ela?</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Oh non si domanda nemmeno.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Che vol dir: no, certo.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Anzi vuol dir, sì certissimo.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Anca mi son putto.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Io mi sarei maritata cinquanta volte, ma non ho mai
 trovato una persona, che mi dia nel genio.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Mi possio sperar de urtarghe in tela simpatia?</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>In verità, bisogna, che io lo dica, voi avete un
 non so che... Basta, non dico altro.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Uno, che la volesse per muier, come averielo da
 far?</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Io non ho né padre, né madre. Bisognerebbe dirlo al
 mio padrone, o alla mia padrona.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Benissimo, se ghel dirò, cossa dirali?</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Diranno, che se sono contenta io...</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>E ela cossa dirala?</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Dirò... che se sono contenti loro...</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Non occorr'altro. Saremo tutti contenti. Dème la
 lettera, e co ve porterò la risposta discorreremo.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Ecco la lettera.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Savìu mo cossa, che la diga sta lettera?</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Non lo so; e se sapeste che curiosità, che averei
 di saperlo!</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>No vorria, che la fuss una qualche lettera de
 sdegno, e che m'avess da far romper el muso.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Chi sa? D'amore non dovrebbe essere.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Mi no vòi impegni. Se no so cossa, che la diga, mi
 no ghe la porto.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Si potrebbe aprirla... ma poi a serrarla ti voglio.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Eh lassè far a mi; per serrar le lettere son fatto
 a posta; no se cognosserà gnente affatto.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Apriamola dunque.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Savìu lezer vu?</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Un poco. Ma voi saprete legger bene.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Anca mi un pochettin.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Sentiamo dunque.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Averzimola con pulizia. <emph>(ne straccia una parte)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Oh! che avete fatto?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Niente. Ho el segreto d'accomodarla. Eccola qua,
 l'è averta.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Via leggetela.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Lezila vu. El carattere della vostra padrona
 l'intenderè meio de mi.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Per dirla io non capisco niente. <emph>(osservando la lettera)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>E mi gnanca una parola. <emph>(fa lo stesso)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Che serviva dunque aprirla?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Aspettè; inzegnémose; qualcossa capisso. <emph>(tiene egli la lettera)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Anch'io intendo qualche lettera.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Provèmose un po' per un. Questo non èlo un <emph>emme</emph>?</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Oibò; questo è un <emph>erre</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Dall'<emph>erre</emph> all'<emph>emme</emph> gh'è poca differenza.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p><emph>Ri</emph>, <emph>ri</emph>, <emph>a</emph>, <emph>ria</emph>. No, no, state cheto, che
 credo sia un <emph>emme</emph>: <emph>mi</emph>, <emph>mi</emph>, <emph>a</emph>, <emph>mia</emph></p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>No dirà <emph>mia</emph>, dirà <emph>mio</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>No, che vi è la codetta.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Giusto per questo: <emph>mio</emph>.</p>
           </sp>
@@ -5535,122 +5575,122 @@ credo sia un <emph>emme</emph>: <emph>mi</emph>, <emph>mi</emph>, <emph>a</emph>
           <stage>
             <emph>Beatrice e Pantalone dalla locanda, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Cossa feu qua? <emph>(a Smeraldina)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Niente, signore, venivo in traccia di voi.
 <emph>(intimorita)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Cossa voleu da mi? <emph>(a Smeraldina)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>La padrona vi cerca. <emph>(come sopra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Che foglio è quello? <emph>(a Truffaldino)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Niente, l'è una carta... <emph>(intimorito)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Lascia vedere. <emph>(a Truffaldino)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Signor sì. <emph>(gli dà il foglio tremando)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Come! Questo è un viglietto, che viene a me.
 Indegno! Sempre si aprono le mie lettere?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Mi no so niente, signor...</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Osservate, signor Pantalone, un viglietto della
 signora Clarice, in cui mi avvisa delle pazze gelosie di
 Silvio; e questo briccone me l'apre.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>E ti, ti ghe tien terzo? <emph>(a Smeraldina)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Io non so niente, signore.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Chi l'ha aperto questo viglietto?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Mi no.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Nemmen io.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Mo chi l'ha portà?</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Truffaldino lo portava al suo padrone.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>E Smeraldina l'ha portà a Truffaldin.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>(Chiacchierone, non ti voglio più bene).</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ti, pettegola desgraziada, ti ha fatto sta
 bell'azion? Non so chi me tegna, che no te daga una man in
 tel muso.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Le mani nel viso non me le ha date nessuno; e mi
 maraviglio di voi.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Cusì ti me respondi? <emph>(le va da vicino)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Eh non mi pigliate. Avete degl'impedimenti, che non
 potete correre. <emph>(parte correndo)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Desgraziada, te farò veder se posso correr; te
 chiaperò. <emph>(parte correndo dietro a Smeraldina)</emph></p>
@@ -5662,77 +5702,77 @@ chiaperò. <emph>(parte correndo dietro a Smeraldina)</emph></p>
             <emph>Beatrice, Truffaldino, poi Florindo alla finestra della
 locanda.</emph>
           </stage>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Se savess come far a cavarme). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(Povera Clarice, ella è disperata per la gelosia
 di Silvio; converrà ch'io mi scopra, e che la consoli).
 <emph>(osservando il viglietto)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Par che nol me veda. Vòi provar de andar via).
 <emph>(piano piano se ne vorrebbe andare)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Dove vai?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Son qua. <emph>(si ferma)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Perché hai aperta questa lettera?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>L'è stada Smeraldina. Signor, mi no so gnente.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Che Smeraldina? Tu sei stato, briccone. Una, e una
 due. Due lettere mi hai aperte in un giorno. Vieni qui.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Per carità, signor. <emph>(accostandosi con paura)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Vien qui, dico.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Per misericordia. <emph>(s'accosta tremando)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>
               <emph>(Leva dal fianco di Truffaldino il bastone, e lo bastona ben bene, essendo voltata colla schiena alla locanda)</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p><emph>(Alla finestra della locanda)</emph> Come! Si bastona il
 mio servitore? <emph>(parte dalla finestra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>No più, per carità.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Tieni, briccone. Imparerai a aprirle lettere.
 <emph>(getta il bastone per terra e parte)</emph></p>
@@ -5743,43 +5783,43 @@ mio servitore? <emph>(parte dalla finestra)</emph>
           <stage>
             <emph>Truffaldino, poi Florindo dalla locanda.</emph>
           </stage>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p><emph>(Dopo partita Beatrice)</emph> Sangue de mi! Corpo de
 mi! Cusì se tratta coi omeni della me sorte? Bastonar un par
 mio? I servitori co no serve i se manda via, no i se
 bastona.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Che cosa dici? <emph>(uscito dalla locanda non veduto da Triffaldino)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Oh!). <emph>(avvedendosi di Florindo)</emph> No se bastona i
 servitori de i altri in sta maniera. Quest l'è un affronto,
 che ha ricevudo el me patron. <emph>(verso la parte per dove è andata Beatrice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Sì, è un affronto, che ricevo io. Chi è colui, che
 ti ha bastonato?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Mi no lo so, signor; nol conosso.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Perché ti ha battuto?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Perché... perché gh'ho spudà su una scarpa.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>E ti lasci bastonare così? E non ti muovi, e non ti
 difendi nemmeno? Ed esponi il tuo padrone ad un affronto, ad
@@ -5787,7 +5827,7 @@ un precipizio? Asino, poltronaccio che sei. <emph>(prende il bastone di terra)</
 darò gusto, ti bastonerò ancora io. <emph>(lo bastona, e poi entra nella locanda)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Adesso posso dir, che son servitor de do padroni:
 ho tirà el salario da tutti do. <emph>(entra nella locanda)</emph></p>
@@ -5802,7 +5842,7 @@ ho tirà el salario da tutti do. <emph>(entra nella locanda)</emph></p>
           <stage>
             <emph>TRUFFALDINO solo, poi due CAMERIERI</emph>
           </stage>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Con una scorladina ho mandà via tutto el dolor
 delle bastonade; ma ho magnà ben; ho disnà ben, e sta sera
@@ -5816,40 +5856,40 @@ fora i bauli, e farò pulito. Bisogna, che me fazza aiutar.
 Camerieri. <emph>(chiama)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p><emph>(Viene in compagnia d'un garzone)</emph> Che volete?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Vorria, che me dessi una man a tirar fora certi
 bauli da quelle camere, per dar un poco de aria ai vestidi.</p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Andate; aiutategli. <emph>(al garzone)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Andemo, che ve darò de bona man una porzion de
 quel regalo, che m'ha fatto i me patroni. <emph>(entra in una camera col garzone)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Costui pare sia un buon servitore. È lesto, pronto,
 attentissimo; però qualche difetto anch'egli averà. Ho
 servito anch'io, e so come la va. Per amore non si fa
 niente. Tutto si fa, o per pelar il padrone, o per fidarlo.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p><emph>(Dalla suddetta camera col garzone, portando fuori un baule)</emph> A pian; mettemolo qua. <emph>(lo posano in mezzo alla sala)</emph> Andemo a tòr st'altro. Ma femo a pian, che el
 padron l'è in quell'altra stanza, che el dorme. <emph>(entra col garzone nella camera di Florindo)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Costui o è un grand'uomo di garbo, o è un gran
 furbo; servir due persone in questa maniera, non ho più
@@ -5857,29 +5897,29 @@ veduto. Da vero voglio stare un po' attento; non vorrei, che
 un giorno, o l'altro col pretesto di servir due padroni,
 tutti due gli spogliasse.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p><emph>(Dalla suddetta camera col garzone con l'altro baule)</emph> E questo mettemolo qua. <emph>(lo posano in poca distanza da quell'altro)</emph> Adesso, se volè andar, andè; che no me
 occorre altro. <emph>(al garzone)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Via, andate in cucina. <emph>(al garzone che se ne va)</emph>
 Avete bisogno di nulla? <emph>(a Truffaldino)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Gnente affatto. I fatti mii li fazzo da per mi.</p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Oh va', che sei un omone; se la duri, ti stimo.
 <emph>(parte)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Adesso farò le cosse pulito, con quiete, e senza,
 che nissun me disturba. <emph>(tira fuori di tasca una chiave)</emph>
@@ -5900,12 +5940,12 @@ gh'ha, né sto abito, né sta perrucca.</p>
           <stage>
             <emph>Florindo nella sua camera, e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Truffaldino. <emph>(chiamandolo dalla camera)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>O sia maledetto! El s'ha sveià. Se el diavol fa,
 che el vegna fora, e el veda st'alter baul, el vorrà
@@ -5913,235 +5953,235 @@ saver... Presto, presto, lo serrerò; e dirò, che no so de
 chi el sia. <emph>(va riponendo le robe)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Truffaldino. <emph>(come sopra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>La servo. <emph>(risponde forte)</emph> Che metta via la
 roba. Ma! No me recordo ben sto abito, dove, che el vada. E
 ste carte no me recordo dove che le fusse.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Vieni, o vengo a prenderti con un bastone? <emph>(come sopra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Vegno subito. <emph>(forte, come sopra)</emph> Presto, avanti
 che el vegna. Co l'anderà fora de casa, giusterò tutto.
 <emph>(mette le robe a caso nei due bauli, e li serra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p><emph>(Esce dalla sua stanza in veste da camera)</emph> Che
 cosa diavolo fai? <emph>(a Truffaldino)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Caro signor, no m'àla dito, che repulissa i pani?
 Era qua, che fava l'obbligo mio.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>E quell'altro baule di chi è?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>No so gnente; el sarà d'un altro forestier.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Dammi il vestito nero.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>La servo. <emph>(apre il baule di Florindo, e gli dà il suo vestito nero; Florindo si fa levare la veste da camera, e si pone il vestito; poi, mettendo le mani in tasca, trova il ritratto)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Che è questo? <emph>(meravigliandosi del ritratto)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Oh diavolo! Ho falà. In vece de metterlo in tel
 vestido de quell'alter, l'ho mess in questo. El color m'ha
 fatto falar). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(Oh Cieli! Non m'inganno io già. Questo è il mio
 ritratto; Il mio ritratto, che donai io medesimo alla mia
 cara Beatrice). Dimmi, tu, come è entrato nelle tasche del
 mio vestito questo ritratto, che non vi era?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Adesso mo; no so come covrirla. Me inzegnerò).
 <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Animo, dico, parla, rispondi. Questo ritratto,
 com'è nelle mie tasche?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Caro sior patron, la compatissa la confidenza, che
 me son tolto. Quel ritratt l'è robba mia; per no perderlo,
 l'aveva nascosto là drento. Per amor del Ciel, la me
 compatissa.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Dove hai avuto questo ritratto?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>L'ho eredità dal me padron.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ereditato?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Sior sì, ho servido un padron; l'è morto, el m'ha
 lassà delle bagatelle, che le ho vendude, e m'è restà sto
 ritratto.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Oimè! Quanto tempo è, che è morto questo tuo
 padrone?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Sarà una settimana. (Digo quel, che me vien alla
 bocca). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Come chiamavasi questo tuo padrone?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Nol so, signor; el viveva incognito.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Incognito? Quanto tempo lo hai tu servito?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Poco: diese, o dodese zorni.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(O Cieli! Sempre più tremo, che non sia stata
 Beatrice! Fuggì in abito d'uomo... viveva incognita... Oh me
 infelice, se fosse vero!). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Col crede tutto, ghe ne racconterò delle belle).
 <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Dimmi, era giovine il tuo padrone? <emph>(con affanno)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Sior sì, zovene.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Senza barba?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Senza barba.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(Era ella senz'altro). <emph>(da sé, sospirando)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Bastonade spereria de no ghe n'aver). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Sai la patria almeno del tuo defonto padrone?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>La patria la saveva, e no me l'arecordo.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Turinese forse?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Sior sì, turinese.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(Ogni accento di costui è una stoccata al mio
 cuore). <emph>(da sé)</emph> Ma dimmi, è egli veramente morto questo
 giovine turinese?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>L'è morto siguro.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Di qual male è egli morto?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Gh'è vegnù un accidente, e l'è andà. (Cusì me
 destrigo). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Dove è stato sepolto?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Un altro imbroio). <emph>(da sé)</emph> No l'è stà sepolto,
 signor, perché un alter servitor so patriotto, l'ha avù la
 licenza de metterlo in t'una cassa e mandarlo al so paese.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Questo servitore era forse quello, che ti fece
 stamane ritirar dalla posta quella lettera?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Sior sì, giusto Pasqual.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(Non vi è più speranza. Beatrice è morta. Misera
 Beatrice! i disagi del viaggio, i tormenti del cuore
@@ -6154,7 +6194,7 @@ mio dolore). <emph>(da sé, ed entra nella sua camera)</emph></p>
           <stage>
             <emph>Truffaldino, poi Beatrice e Pantalone</emph>
           </stage>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Coss'è st'imbroio? L'è adolorà, el pianze, el se
 despera. No vorria mi co sta favola averghe sveià
@@ -6167,118 +6207,118 @@ qua quell'alter patron, stavolta se divide la servitù e se
 me fa el ben servido. <emph>(accennando le bastonate)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Credetemi, signor Pantalone, che l'ultima partita
 di specchi, e cere è duplicata.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Poderia esser, che i zoveni avesse falà. Faremo
 passar i conti un'altra volta col scrittural; incontreremo,
 e vederemo la verità.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Ho fatto anch'io un estratto di diverse partite
 cavate dai nostri libri. Ora lo riscontreremo. Può darsi,
 che si dilucidi, o per voi, o per me, Truffaldino?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Signor.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Hai tu le chiavi del mio baule?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Sior sì; eccole qua.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Perché l'hai portato in sala il mio baule?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Per dar un poco de aria ai vestidi.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Hai fatto?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Ho fatto.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Apri e dammi... Quell'altro baule di chi è?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>L'è d'un altro forestier, che è arrivado.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Dammi un libro di memorie, che troverai nel baule.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Sior sì. (El Ciel me la manda bona). <emph>(da sé, apre e cerca il libro)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Poi esser come ghe digo, che i abbia falà. In sto
 caso, error no fa pagamento.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>E può essere, che così vada bene; lo
 riscontreremo.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Èlo questo? <emph>(presenta un libro di scritture a Beatrice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Sarà questo. <emph>(lo prende senza molto osservarlo, e lo apre)</emph> No, non è questo... Di chi è questo libro?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(L'ho fatta). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(Queste sono due lettere da me scritte a Florindo.
 Oimè! Queste memorie, questi conti appartengono a lui! Sudo,
 tremo, non so in che mondo mi sia). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Cossa gh'è, sior Federigo? Se sentelo gnente?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Niente. (Truffaldino, come nel mio baule evvi
 questo libro, che non è mio?). <emph>(piano a Truffaldino)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Mi... no saveria...</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Presto, non ti confondere, dimmi la verità.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Ghe domando scusa dell'ardir, che ho avudo de
 metter quel libro in tel so baul. L'è robba mia, e per non
@@ -6286,78 +6326,78 @@ perderlo, l'ho messo là. (L'è andada ben con quell'alter,
 pol esser che la vada ben anca con questo). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Questo libro è tuo, e non lo conosci, e me lo dai
 in vece del mio?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Oh questo l'è ancora più fin). <emph>(da sé)</emph> Ghe
 dirò, l'è poc tempo, che l'è mio, e cusì subito no lo
 conosso.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>E dove hai avuto tu questo libro?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Ho servido un padron a Venezia, che è morto, e ho
 eredità sto libro.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Quanto tempo è?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Che soia mi? Dies, o dodese zorni.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Come può darsi, se io ti ho ritrovato a Verona?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Giust allora vegniva via da Venezia per la morte
 del me padron.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(Misera me!) <emph>(da sé)</emph> Questo tuo padrone aveva
 nome Florindo?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Sior sì, Florindo.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Di famiglia Aretusi?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Giusto Aretusi.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Ed è morto sicuramente?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Sicurissimamente.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Di che male è egli morto? Dove è stato sepolto?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>L'è cascà in canal, el s'ha negà, e nol s'ha più
 visto.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Oh me infelice! Morto è Florindo, morto è il mio
 bene, morta è l'unica mia speranza. A che ora mi serve
@@ -6377,44 +6417,44 @@ Oimè! Il dolore mi opprime. Più non veggo la luce. Idolo
 mio, caro sposo, ti seguirò disperata. <emph>(parte smaniosa, ed entra nella sua camera)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p><emph>(Inteso con ammirazione tutto il discorso, e la disperazione di Beatrice)</emph> Truffaldino!</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Sior Pantalon!</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Donna!</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Femmena!</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Oh che caso!</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Oh che maraveia!</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Mi testo confuso.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Mi son incantà.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ghe io vago a dir a mia fia. <emph>(parte)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Non so più servitor de do patroni, ma de un
 patron, e de una patrona. <emph>(parte)</emph></p>
@@ -6426,87 +6466,87 @@ patron, e de una patrona. <emph>(parte)</emph></p>
           <stage>
             <emph>Dottore, poi Pantalone dalla locanda.</emph>
           </stage>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Non mi posso dar pace di questo vecchiaccio di
 Pantalone. Più che ci penso, più mi salta la bile.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Dottor caro, ve reverisso. <emph>(con allegria)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Mi maraviglio, che abbiate anche tanto ardire di
 salutarmi.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>V'ho da dar una nova. Sappiè...</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Volete forse dirmi, che avete fatto le nozze? Non
 me n'importa un fico.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>No xè vero gnente. Lassème parlar in vostra malora.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Parlate, che il canchero vi mangi.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(Adessadesso me vien voggia de dottorarlo a pugni).
 <emph>(da sé)</emph> Mia fia, se volè, la sarà muggier de vostro fio.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Obbligatissimo, non v'incomodate. Mio figlio non è
 di sì buono stomaco; non vuole gli avanzi di nessuno. Datela
 al signor turinese.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Co saverè chi xè quel turinese, no dirè cusì.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Sia chi essersi voglia. Vostra figlia è stata
 veduta con lui, <emph>et hoc sufficit</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ma no xè vero, che el sia...</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Non voglio sentir altro.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Se no me ascolterè, sarà pezo per vu.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Lo vedremo per chi sarà peggio.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Mia fia la xè una putta onorata; e quella...</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Il diavolo che vi porti.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Che ve strascina.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Vecchio senza parola, e senza riputazione.
 <emph>(parte)</emph></p>
@@ -6517,108 +6557,108 @@ veduta con lui, <emph>et hoc sufficit</emph>.</p>
           <stage>
             <emph>Pantalone e poi Silvio</emph>
           </stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Siestu maledetto. El xè una bestia vestìo da omo
 costù. Gh'òggio mai podesto dir, che quella xè una donna?
 Mo, sior no, nol vol lassar parlar. Ma xè qua quel spuzzetta
 de so fio; m'aspetto qualche altra insolenza.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>(Ecco Pantalone. Mi sento tentato di cacciargli la
 spada nel petto). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Sior Silvio, con so bona grazia, averave da darghe
 una bona niova, se la se degnasse de lassarme parlar, e che
 no la fusse, come quella masena da molin de so sior pare.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Che avete a dirmi? Parlate.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>La sappia, che el matrimonio de mia fia co sior
 Federigo xè andà a monte.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>È vero? Non m'ingannate?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ghe digo la verità, e se la xè più de quell'umor,
 mia fia xè pronta a darghe la man.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Oh Cielo! Voi mi ritornate da morte a vita.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(Via, via, nol xè tanto bestia, come so pare). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Ma! oh Cieli! Come potrò stringere al seno colei,
 che con un altro sposo ha lungamente parlato?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Alle curte. Federigo Rasponi xè doventà Beatrice so
 sorella.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Come! Io non vi capisco.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Sè ben duro de legname. Quel, che se credeva
 Federigo, s'ha scoverto per Beatrice.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Vestita da uomo?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Vestia da omo.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Ora la capisco.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Alle tante.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Come andò? Raccontatemi.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Andemo in casa. Mia fia non sa gnente. Con un
 racconto solo soddisferò tutti do.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Vi seguo, e vi domando umilmente perdono, se
 trasportato dalla passione...</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>A monte; ve compatisso. So cossa, che xè amor.
 Andemo, fio mio, vegnì con mi. <emph>(parte)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Chi più felice è di me? Qual cuore può esser più
 contento del mio? <emph>(parte con Pantalone)</emph></p>
@@ -6634,66 +6674,66 @@ quella da Brighella, e questi dal CAMERIERE della locanda; e
 s'avanzano in modo che i due amanti non si vedono fra di
 loro.</emph>
           </stage>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>La se fermi. <emph>(afferrando la mano a Beatrice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Lasciatemi per carità. <emph>(si sforza per liberarsi da Brighella)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>Questa è una disperazione. <emph>(a Florindo, trattenendolo)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Andate al diavolo. <emph>(si scioglie dal Cameriere)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Non vi riuscirà d'impedirmi. <emph>(si allontana da Brighella. Tutti due s'avanzano, determinati di volersi uccidere, e vedendosi e riconoscendosi, rimangono istupiditi)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Che vedo!</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Florindo!</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Beatrice!</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Siete in vita?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Voi pur vivete?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Oh sorte!</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Oh anima mia! <emph>(si lasciano cadere i ferri, e si abbracciano)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Tolè su quel sangue, che nol vada de mal. <emph>(al Cameriere scherzando, e parte)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>(Almeno voglio avanzare questi coltelli. Non glieli
 do più). <emph>(prende i coltelli da terra, e parte)</emph></p>
@@ -6704,84 +6744,84 @@ do più). <emph>(prende i coltelli da terra, e parte)</emph></p>
           <stage>
             <emph>Beatrice, Florindo, poi Brighella</emph>
           </stage>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Qual motivo vi aveva ridotta a tale disperazione?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Una falsa novella della vostra morte.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Chi fu che vi fece credere la mia morte?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Il mio servitore.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ed il mio parimente mi fece credere voi estinta, e
 trasportato da egual dolore volea privarmi di vita.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Questo libro fu cagion, ch'io gli prestai fede.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Questo libro era nel mio baule. Come passò nelle
 vostre mani? Ah sì, vi sarà pervenuto come nelle tasche del
 mio vestito ritrovai il mio ritratto; ecco Il mio ritratto,
 ch'io diedi a voi in Turino.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Quei ribaldi de' nostri servi, sa il Cielo che
 cosa avranno fatto. Essi sono stati la causa del nostro
 dolore, e della nostra disperazione.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Cento favole il mio mi ha raccontato di voi.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Ed altrettante ne ho io di voi dal servo mio
 tollerate.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>E dove sono costoro?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Più non si vedono.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Cerchiamo di loro, e confrontiamo la verità. Chi è
 di là? Non vi è nessuno? <emph>(chiama)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>La comandi.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>I nostri servidori dove son eglino?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Mi no lo so, signor. I se pol cercar.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Procurate di ritrovarli, e mandateli qui da noi.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Mi no ghe ne conosso altro, che uno; lo dirò ai
 camerieri; lori li cognosserà tutti do. Me rallegro con
@@ -6795,107 +6835,107 @@ Servitor de lor signori. <emph>(parte)</emph></p>
           <stage>
             <emph>Florindo e Beatrice</emph>
           </stage>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Voi pure siete in questa locanda alloggiata?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Ci sono giunta stamane.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ed io stamane ancora. E non ci siamo prima veduti?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>La fortuna ci ha voluto un po' tormentare.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ditemi: Federigo, vostro fratello, è egli morto?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Ne dubitate? Spirò sul colpo.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Eppure mi veniva fatto credere, ch'ei fosse vivo, e
 in Venezia.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Quest'è un inganno di chi sinora mi ha preso per
 Federigo. Partii di Turino con questi abiti, e questo nome
 sol per seguire...</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Lo so, per seguir me, o cara; una lettera scrittavi
 dal vostro servidor di Turino, mi assicurò di un tal fatto.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Come giunse nelle vostre mani?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Un servidore, che credo sia stato il vostro, pregò
 il mio, che ne ricercasse alla posta. La vidi, e trovandola
 a voi diretta, non potei a meno di non aprirla.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Giustissima curiosità di un amante.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Che dirà mai Turino della vostra partenza?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Se tornerò colà vostra sposa, ogni discorso sarà
 finito.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Come posso io lusingarmi di ritornarvi sì presto,
 se di là sono capitalmente bandito? Se della morte di vostro
 fratello sono io caricato?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>I capitali, ch'io porterò di Venezia vi potranno
 liberare dal bando; finalmente voi non l'avete ucciso.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ma questi servi ancor non si vedono.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Che mai li ha indotti a darci sì gran dolore?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Per saper tutto non conviene usar con essi il
 rigore. Convien prenderli colle buone.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Mi sforzerò di dissimulare.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Eccone uno. <emph>(vedendo venir Truffaldino)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Ha cera di essere il più briccone.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Credo che non diciate male.</p>
           </sp>
@@ -6906,58 +6946,58 @@ rigore. Convien prenderli colle buone.</p>
             <emph>Truffaldino, condotto per forza da Brighella e dal
 Cameriere, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Vieni, vieni, non aver paura.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Non ti vogliamo fare alcun male.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Eh! me recordo ancora delle bastonade). <emph>(parte)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Questo l'avemo trovà, se troveremo quell'altro lo
 faremo vegnir.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Sì, è necessario, che ci sieno tutti due in una
 volta.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>(Lo conosseu vu quell'altro?). <emph>(piano al Cameriere)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>(Io no). <emph>(a Brighella)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>(Domanderemo in cusina. Qualchedun lo cognosserà).
 <emph>(al Cameriere, e parte)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#camerieri">
             <speaker>CAMERIERI</speaker>
             <p>(Se ci fosse, l'avrei da conoscere ancora io).
 <emph>(parte)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Orsù, narraci un poco, come andò la faccenda del
 cambio del ritratto, e del libro, e perché tanto tu, che
 quell'altro briccone vi uniste a farci disperare.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p><emph>(Fa cenno col dito a tutti due che stiano cheti)</emph>
 Zitto. <emph>(a tutti due)</emph> La favorissa, una parola in disparte.
@@ -6976,87 +7016,87 @@ tant v'avess da despiaser che fusse morto quel, che l'aveva.
 Eccove contà l'istoria, come che l'è, da quell'omo sincero,
 da quel servitor fedel, che ve son).</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(Gran discorso lungo gli fa colui. Son curiosa di
 saperne il mistero). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(Dunque colui, che ti fece pigliar alla posta la
 nota lettera era servitore della signora Beatrice?). <emph>(piano a Truffaldino)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Sior sì, el giera Pasqual). <emph>(piano a Florindo)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(Perché tenermi nascosta una cosa, di cui con tanta
 premura ti avea ricercato?). <emph>(piano a Truffaldino)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(El m'aveva pregà, che no lo disesse). <emph>(piano a Florindo)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(Chi?). <emph>(come sopra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Pasqual). <emph>(come sopra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(Perché non obbedire al tuo padrone?). <emph>(come sopra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Per amor de Pasqual). <emph>(come sopra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(Converrebbe, che io bastonassi Pasquale, e te
 nello stesso tempo). <emph>(come sopra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(In quel caso me toccherave a mi le mie, e anca
 quelle de Pasqual). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>È ancor finito questo lungo esame?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Costui mi va dicendo...</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Per amor del Cielo, sior padron, no la descoverza
 Pasqual. Piuttosto la diga, che son stà mi, la me bastona
 anca, se la vol, ma no la me ruvina Pasqual). <emph>(piano a Florindo)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(Sei così amoroso per il tuo Pasquale?). <emph>(piano a Truffaldino)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Ghe vòi ben, come s'el fuss me fradel. Adess vòi
 andar da quella signora, vòi dirghe, che son stà mi, che ho
@@ -7064,23 +7104,23 @@ fate; vòi che i me grida, che i me strapazza, ma che se
 salva Pasqual). <emph>(come sopra, e si scosta da Florindo)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(Costui è di un carattere molto amoroso). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Son qua da ela. <emph>(accostandosi a Beatrice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(Che lungo discorso hai tenuto con signor
 Florindo)? <emph>(piano a Truffaldino)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(La sappia, che quel signor el gh'ha un servitor,
 che gh'ha nome Pasqual; l'è el più gran mamalucco del mondo;
@@ -7091,98 +7131,98 @@ etecetera. E anca adess a sior Florindo gh'ho ditt, che mi
 son stà causa de tutto). <emph>(piano sempre a Beatrice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(Perché accusarti di una colpa, che asserisci di
 non avere?). <emph>(a Truffaldino, come sopra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Per l'amor che porto a Pasqual). <emph>(come sopra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(La cosa va un poco in lungo). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Cara ela, la prego, no la lo precipita). <emph>(piano a Beatrice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(Chi?). <emph>(come sopra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Pasqual). <emph>(come sopra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(Pasquale, e voi siete due bricconi). <emph>(come sopra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Eh, sarò mi solo). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Non cerchiamo altro, signora Beatrice, i nostri
 servidori non l'hanno fatto a malizia, meritano essere
 corretti; ma in grazia delle nostre consolazioni, si può
 loro perdonare il trascorso.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>È vero, ma il vostro servitore...</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Per amor del Cielo, no la nomina Pasqual).
 <emph>(piano a Beatrice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Orsù, io andar dovrei dal signor Pantalone de'
 Bisognosi, vi sentireste voi di venir con me? <emph>(a Florindo)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ci verrei volentieri, ma devo attendere un
 banchiere a casa. Ci verrò più tardi, se avete premura.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Sì, voglio andarvi subito. Vi aspetterò dal signor
 Pantalone, di là non parto, se non venite.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Io non so dove stia di casa.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Lo so mi, signor, lo compagnerò mi.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Bene, vado in camera a terminar di vestirmi.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(La vada, che la servo subito). <emph>(piano a Beatrice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Caro Florindo, gran pene che ho provate per voi.
 <emph>(entra in camera)</emph></p>
@@ -7193,23 +7233,23 @@ Pantalone, di là non parto, se non venite.</p>
           <stage>
             <emph>Florindo e Truffaldino</emph>
           </stage>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Le mie non sono state minori. <emph>(dietro a Beatrice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>La diga, sior patron, no gh'è Pasqual; siora
 Beatrice no gh'ha nissun, che l'aiuta a vestir, se
 contentelo, che vada mi a servirla in vece de Pasqual?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Sì, vanne pure; servila con attenzione, averò
 piacere.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(A invenzion, a prontezza, a cabale, sfido el
 primo sollicitador de Palazzo). <emph>(da sé; entra nella camera di Beatrice)</emph></p>
@@ -7220,7 +7260,7 @@ primo sollicitador de Palazzo). <emph>(da sé; entra nella camera di Beatrice)</
           <stage>
             <emph>Florindo, poi Beatrice e Truffaldino</emph>
           </stage>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Grandi accidenti accaduti sono in questa giornata!
 Pianti, lamenti, disperazioni, e all'ultimo consolazione, e
@@ -7228,58 +7268,58 @@ allegrezza. Passar dal pianto al riso è un dolce salto, che
 fa scordare gli affanni, ma quando dal piacere si passa al
 duolo, è più sensibile la mutazione.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Eccomi lesta.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Quando cambierete voi quelle vesti?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Non istò bene vestita così?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Non vedo l'ora di vedervi colla gonnella, e col
 busto. La vostra bellezza non ha da essere soverchiamente
 coperta.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Orsù, vi aspetto dal signor Pantalone; fatevi
 accompagnare da Truffaldino.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>L'attendo ancora un poco, e se il banchiere non
 viene, ritornerà un'altra volta.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Mostratemi l'amor vostro nella vostra
 sollecitudine. <emph>(s'avvia per partire)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Comandela, che resta a servir sto signor?).
 <emph>(piano a Beatrice, accennando Florindo)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(Sì, lo accompagnerai dal signor Pantalone). <emph>(a Truffaldino)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(E da quella strada lo servirò, perché no gh'è
 Pasqual). <emph>(come sopra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Servilo, mi farai cosa grata. (Lo amo più di me
 stessa). <emph>(da sé, e parte)</emph></p>
@@ -7290,105 +7330,105 @@ stessa). <emph>(da sé, e parte)</emph></p>
           <stage>
             <emph>Florindo e Truffaldino</emph>
           </stage>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Tolì; nol se vede. El patron se veste, el va fora
 de casa, e nol se vede.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Di chi parli?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>De Pasqual. Ghe voio ben, l'è me amigo, ma l'è un
 poltron. Mi son un servitor che valo per do.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Viemmi a vestire. Frattanto verrà il banchiere.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Sior padron, sento, che vussioria ha d'andar in
 casa de sior Pantalon.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ebbene, che vorresti tu dire?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Vorria pregarlo de una grazia.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Sì, te lo meriti davvero, per i tuoi buoni
 portamenti.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Se è nato qualcossa, la sa, che l'è stà Pasqual.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ma dov'è questo maledetto Pasquale? Non si può
 vedere?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>El vegnirà sto baron. E cusì, sior patron, vorria
 domandarghe sta grazia.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Che cosa vuoi?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Anca mi, poverin, son innamorado.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Sei innamorato?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Signor sì; e la me morosa l'è la serva de sior
 Pantalon; e vorria mo, che vussioria...</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Come c'entro io?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Oh, no digo, che la ghe intra; ma essendo mi el so
 servitor, che la disess una parola per mi al sior Pantalon.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Bisogna vedere, se la ragazza ti vuole.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>La ragazza me vol. Basta una parola al sior de sta
 carità.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Sì, lo farò; ma come la manterrai la moglie?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Farò quel, che poderò. Me raccomanderò a Pasqual.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Raccomandati a un poco più di giudizio. <emph>(entra in camera)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Se non fazzo giudizio sta volta, no lo fazzo mai
 più. <emph>(entra in camera, dietro a Florindo)</emph></p>
@@ -7400,14 +7440,14 @@ più. <emph>(entra in camera, dietro a Florindo)</emph></p>
           <stage>
             <emph>Pantalone, il Dottore, Clarice, Silvio, Smeraldina</emph>
           </stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Via, Clarice, non esser cusì ustinada. Ti vedi, che
 l'è pentio sior Silvio, che el te domanda perdon; se l'ha dà
 in qualche debolezza, el l'ha fatto per amor, anca mi gh'ho
 perdonà i strambezzi; ti ghe li ha da perdonar anca ti.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Misurate dalla vostra pena la mia, signora Clarice,
 e tanto più assicuratevi, che vi amo davvero, quanto più il
@@ -7416,13 +7456,13 @@ felici, non vi rendete ingrata alle beneficenze del Cielo.
 Coll'immagine della vendetta non funestate il più bel giorno
 di nostra vita.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Alle preghiere di mio figliuolo aggiungo le mie.
 Signora Clarice, mia cara nuora, compatitelo il poverino; è
 stato lì, lì, per diventar pazzo.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Via, signora padrona, che cosa volete fare? Gli
 uomini, poco più, poco meno, con noi sono tutti crudeli.
@@ -7432,19 +7472,19 @@ morire. Già con uno, o con l'altro avete da maritarvi; dirò,
 come si dice agli ammalati, giacché avete da prender la
 medicina, prendetela.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Via, sentistu? Smeraldina al matrimonio la ghe dise
 medicamento. No far che el te para tossego. (Bisogna veder
 de devertirla). <emph>(piano al Dottore)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Non è né veleno, né medicamento, no, il matrimonio
 è una confezione, un giulebbe, un candito.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Ma, cara Clarice mia, possibile che un accento non
 abbia a uscire dalle vostre labbra? So, che merito da voi
@@ -7453,29 +7493,29 @@ non con il vostro silenzio. Eccomi a' vostri piedi; movetevi
 a compassione di me. <emph>(s'inginocchia)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Crudele! <emph>(sospirando verso Silvio)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(Aveu sentio quella sospiradina? Bon segno).
 <emph>(piano al Dottore)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>(Incalza l'argomento). <emph>(piano a Silvio)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>(Il sospiro è come il lampo: foriero di pioggia).
 <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Se credessi, che pretendeste il mio sangue in
 vendetta della supposta mia crudeltà, ve lo esibisco di buon
@@ -7483,22 +7523,22 @@ animo. Ma oh Dio! in luogo del sangue delle mie vene,
 prendetevi quello, che mi sgorga dagli occhi. <emph>(piange)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(Bravo!). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Crudele! <emph>(come sopra, e con maggior tenerezza)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>(È cotta). <emph>(piano a Pantalone)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Animo, levève su. <emph>(a Silvio, alzandolo)</emph> Vegnì
 qua. <emph>(al medesimo, prendendolo per la mano)</emph> Vegnì qua anca
@@ -7507,70 +7547,70 @@ toccar la man; fè pase, no pianzè più, consolève, fenila,
 tolè; el Cielo ve benediga. <emph>(unisce le mani d'ambidue)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Via; è fatta.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Fatta, fatta.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Deh, signora Clarice, per carità. <emph>(tenendola per la mano)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Ingrato!</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Cara.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Inumano!</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Anima mia.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Cane!</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Viscere mie.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Ah! <emph>(sospira)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(La va). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Perdonatemi per amor del Cielo.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Ah! vi ho perdonato!</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(La xè andada).</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Via, Silvio, ti ha perdonato.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>L'ammalato è disposto, dategli il medicamento.</p>
           </sp>
@@ -7580,73 +7620,73 @@ tolè; el Cielo ve benediga. <emph>(unisce le mani d'ambidue)</emph>
           <stage>
             <emph>Brighella e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Con bona grazia, se pol vegnir? <emph>(entra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Vegnì qua mo, sior compare Brighella. Vu sè quello,
 che m'ha dà da intender ste belle fandonie, che m'ha
 assicurà, che sior Federigo giera quello, ah?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Caro signor, chi non s'averave ingannà? I era do
 fradelli, che se someggiava come un pomo spartido. Con quei
 abiti averia zogà la testa, che el giera lu.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Basta; la xè passada. Cossa gh'è da niovo?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>La signora Beatrice l'è qua, che la li vorria
 reverir.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Che la vegna pur, che la xè parona.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Povera signora Beatrice, mi consolo, che sia in
 buono stato.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Avete compassione di lei?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Sì, moltissima.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>E di me?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Ah briccone!</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Sentìu, che parole amorose? <emph>(al Dottore)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Mio figliuolo poi ha maniera. <emph>(a Pantalone)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Mia fia, poverazza, la xè de bon cuor. <emph>(al Dottore)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>(Eh, tutti due sanno fare la loro parte). <emph>(da sé)</emph></p>
           </sp>
@@ -7656,103 +7696,103 @@ buono stato.</p>
           <stage>
             <emph>Beatrice e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Signori, eccomi qui a chiedervi scusa, a
 domandarvi perdono, se per cagione mia aveste dei
 disturbi...</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Niente, amica, venite qui. <emph>(l'abbraccia)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Ehi? <emph>(mostrando dispiacere di quell'abbraccio)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Come! Nemmeno una donna? <emph>(verso Silvio)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>(Quegli abiti ancora mi fanno specie). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Andè là, siora Beatrice, che per esser donna, e per
 esser zovene gh'avè un bel coraggio.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Troppo spirito, padrona mia. <emph>(a Beatrice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Amore fa fare delle gran cose.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>I s'ha trovà, né vero, col so moroso? Me xè stà
 contà.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Sì, il Cielo mi ha consolata.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Bella riputazione! <emph>(a Beatrice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Signore, voi non c'entrate ne' fatti miei. <emph>(al Dottore)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Caro signor padre, lasciate che tutti facciano il
 fatto loro; non vi prendete di tai fastidi. Ora, che sono
 contento io, vorrei che tutto il mondo godesse. Vi sono
 altri matrimoni da fare? Si facciano.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Ehi, signore, vi sarebbe il mio. <emph>(a Silvio)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Con chi?</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Col primo, che viene.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Trovalo, e son qua io.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Voi? Per far che? <emph>(a Silvio)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Per un poco di dote.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Non vi è bisogno di voi.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>(Ha paura che glielo mangino. Ci ha preso gusto).
 <emph>(da sé)</emph></p>
@@ -7763,90 +7803,90 @@ altri matrimoni da fare? Si facciano.</p>
           <stage>
             <emph>Truffaldino e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Fazz reverenza a sti signori.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Il signor Florindo dov'è? <emph>(a Truffaldino)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>L'è qua, che el vorria vegnir avanti, se i sè
 contenta.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Vi contentate, signor Pantalone, che passi il
 signor Florindo?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Xèlo l'amigo sì fatto? <emph>(a Beatrice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Sì, il mio sposo.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Che el resta servido.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Fa', che passi. <emph>(a Truffaldino)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Zovenotta, ve reverisso. <emph>(a Smeraldina, piano)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Addio, morettino. <emph>(piano a Truffaldino)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Parleremo. <emph>(come sopra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Di che? <emph>(come sopra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Se volessi. <emph>(fa cenno di darle l'anello, come sopra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Perché no? <emph>(come sopra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Parleremo. <emph>(come sopra, e parte)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Signora padrona, con licenza di questi signori,
 vorrei pregarla di una carità. <emph>(a Clarice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Che cosa vuoi? <emph>(tirandosi in disparte per ascoltarla)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>(Anch'io sono una povera giovine, che cerco di
 collocarmi, vi è il servitore della signora Beatrice, che mi
@@ -7855,28 +7895,28 @@ contentasse, ch'ei mi prendesse, spererei di fare la mia
 fortuna). <emph>(piano a Clarice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>(Sì, cara Smeraldina, lo farò volentieri; subito,
 che potrò parlare a Beatrice con libertà, lo farò
 certamente). <emph>(torna al suo posto)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Cossa xè sti gran secreti? <emph>(a Clarice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Niente, signore. Mi diceva una cosa.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>(Posso saperla io?). <emph>(piano a Clarice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>(Gran curiosità! E poi diranno di noi altre donne).
 <emph>(da sé)</emph></p>
@@ -7887,350 +7927,350 @@ certamente). <emph>(torna al suo posto)</emph>
           <stage>
             <emph>Florindo, Truffaldino e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Servitor umilissimo di lor signori. <emph>(tutti lo salutano)</emph> È ella il padrone di casa? <emph>(a Pantalone)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Per servirla.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Permetta, ch'io abbia l'onore di dedicarle la mia
 servitù, scortato a farlo dalla signora Beatrice di cui,
 siccome di me, note gli saranno le vicende passate.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Me consolo de conoscerla, e de reverirla, e me
 consolo de cuor delle so contentezze.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>La signora Beatrice deve esser mia sposa, e se voi
 non isdegnate onorarci, sarete pronubo delle nostre nozze.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Quel che s'ha da far, che el se fazza subito. Le se
 daga la man.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Son pronto, signora Beatrice.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Eccola, signor Florindo.</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>(Eh non si fanno pregare). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Faremo po el saldo dei nostri conti. Le giusta le
 so partie, che po giusteremo le nostre.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Amica, me ne consolo. <emph>(a Beatrice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Ed io di cuore con voi. <emph>(a Clarice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Signore, mi riconoscete voi? <emph>(a Florindo)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Sì, vi riconosco; siete quello, che voleva fare un
 duello.</p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Anzi l'ho fatto per mio malanno. Ecco chi mi ha
 disarmato, e poco meno, che ucciso. <emph>(accennando Beatrice)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Potere dire chi vi ha donato la vita. <emph>(a Silvio)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>Sì, è vero.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>In grazia mia però. <emph>(a Silvio)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#silvio">
             <speaker>SILVIO</speaker>
             <p>È verissimo.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Tutto xè giustà, tutto xè fenio.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Manca el meggio, signori.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Cossa manca?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Con so bona grazia, una parola. <emph>(a Florindo, tirandolo in disparte)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(Che cosa vuoi?) <emph>(piano a Truffaldino)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(S'arrecordel, cossa, ch'el m'ha promesso?).
 <emph>(piano a Florindo)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(Che cosa? Io non me ne ricordo). <emph>(piano a Truffaldino)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(De domandar a sior Pantalon Smeraldina per me
 muier?). <emph>(come sopra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(Sì, ora me ne sovviene. Lo faccio subito). <emph>(come sopra)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Anca, mi pover omo, che me metta all'onor del
 mondo). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Signor Pantalone, benché sia questa la prima volta
 sola, ch'io abbia l'onore di conoscervi, mi fo ardito di
 domandarvi una grazia.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>La comandi pur. In quel, che posso, la servirò.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Il mio servitore bramerebbe per moglie la vostra
 cameriera, avreste voi difficoltà di accordargliela?</p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>(Oh bella! Un altro, che mi vuole. Chi diavolo è?
 Almeno che lo conoscessi).</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Per mi son contento. Cossa dìsela ela, patrona? <emph>(a Smeraldina)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>Se potessi credere d'avere a star bene...</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Xèlo omo da qualcossa sto so servitor? <emph>(a Florindo)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Per quel poco tempo, ch'io l'ho meco, è fidato
 certo, e mi pare di abilità.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Signor Florindo; voi mi avete prevenuta in una
 cosa, che dovevo far io. Doveva io proporre le nozze della
 mia cameriera per il servitore della signora Beatrice. Voi
 l'avete chiesta per il vostro; non occorr'altro.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>No, no; quando voi avete questa premura, mi ritiro
 affatto, e vi lascio in pienissima libertà.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Non sarà mai vero, che voglia io permettere, che le
 mie premure sieno preferite alle vostre. E poi non ho, per
 dirvela, certo impegno. Proseguite pure nel vostro.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Voi lo fate per complimento. Signor Pantalone, quel
 che ho detto sia per non detto. Per il mio servitore non vi
 parlo più, anzi non voglio, che la sposi assolutamente.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Se non la sposa il vostro, non l'ha da sposare
 nemmeno quell'altro. La cosa ha da essere per lo meno del
 pari.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>(Oh bella! Lori fa i complimenti, e mi resto senza
 muier). <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#smeraldina">
             <speaker>SMERALDINA</speaker>
             <p>(Sto a vedere, che di due, non ne averò nessuno).
 <emph>(da sé)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Eh via, che i se giusta; sta povera putta gh'ha
 voggia de maridarse dèmola all'uno, o all'altro.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Al mio no. Non voglio certo far torto alla signora
 Clarice.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Né io permetterò mai, che sia fatto al signor
 FIorindo.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Siori, sta faccenda l'aggiusterò mi. Sior
 Florindo, non ala domandà Smeraldina per el so servitor?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Sì; non l'ha sentito tu stesso?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>E ela siora Clarice non àla destinà Smeraldina per
 el servitor de siora Beatrice?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Dovevo parlarne sicuramente.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Ben, co l'è cusì Smeraldina dème man.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Mo per cossa voleu, che a vu la ve daga la man? <emph>(a Truffaldino)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Perché mi; mi, son servitor de sior Florindo, e de
 siora Beatrice.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Come?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Che dici?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Un pochetto de flemma: sior Florindo, chi v'ha
 pregado de domandar Smeraldina al sior Pantalon?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Tu mi hai pregato.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>E ela siora Clarice, de chi intendevela, che
 l'avesse da esser Smeraldina?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Di te.</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Ergo Smeraldina l'è mia.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Signora Beatrice, il vostro servitore dov'è?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>eccolo qui. Non è Truffaldino?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Truffaldino? Questi è il mio servitore.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Il vostro non è Pasquale?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Pasquale? Doveva essere il vostro.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Come va la faccenda? <emph>(verso Truffaldino)</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>
               <emph>(Con lazzi muti domanda scusa)</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ah briccone!</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Ah galeotto!</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Tu hai servito due padroni nel medesimo tempo?</p>
           </sp>
-          <sp>
+          <sp who="#truffaldino">
             <speaker>TRUFFALDINO</speaker>
             <p>Sior sì, mi ho fatto sta bravura. Son intrà in sto
 impegno senza pensarghe; m'ho volesto provar. Ho durà poco è

--- a/tei/goldoni-il-teatro-comico.xml
+++ b/tei/goldoni-il-teatro-comico.xml
@@ -86,6 +86,49 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="ottavio">
+            <persName>Ottavio</persName>
+          </person>
+          <person xml:id="florindo">
+            <persName>Florindo</persName>
+          </person>
+          <person xml:id="rosaura">
+            <persName>Rosaura</persName>
+          </person>
+          <person xml:id="pantalone">
+            <persName>Pantalone</persName>
+          </person>
+          <person xml:id="colombina">
+            <persName>Colombina</persName>
+          </person>
+          <person xml:id="brighella">
+            <persName>Brighella</persName>
+          </person>
+          <person xml:id="arlecchino">
+            <persName>Arlecchino</persName>
+          </person>
+          <person xml:id="beatrice">
+            <persName>Beatrice</persName>
+          </person>
+          <person xml:id="dottore">
+            <persName>Dottore</persName>
+          </person>
+          <person xml:id="lelio">
+            <persName>Lelio</persName>
+          </person>
+          <person xml:id="suggeritore">
+            <persName>Il Suggeritore</persName>
+          </person>
+          <person xml:id="eleonora">
+            <persName>Eleonora</persName>
+          </person>
+          <person xml:id="staffiere">
+            <persName>Staffiere</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -288,123 +331,123 @@ figurandosi esser di giorno, senza lumi, e senza spettatori.</p>
           <stage>
             <emph>Ottavio, poi Florindo.</emph>
           </stage>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Fermatevi, fermatevi, non alzate la tenda, fermatevi <emph>(verso la scena)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Perché, signor Ottavio, non volete, che si alzi la
 tenda?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Per provare un terzo atto di commedia non ci è
 bisogno di alzar la tenda.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>E non ci è ragione di tenerla calata.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Signor sì, che vi è ragione di tenerla calata,
 signor sì. Voi altri signori non pensate a quello che penso
 io. Calate giù quella tenda <emph>(verso la scena)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Fermatevi <emph>(verso la scena)</emph>. Se si cala la tenda,
 non ci si vede più, onde per provare le nostre scene, signor
 capo di compagnia, vi converrà far accender de' lumi.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Quand'è così, sarà meglio alzare la tenda. Tiratela
 su, che non voglio spendere in lumi <emph>(verso la scena)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Bravo, viva l'economia.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Oh amico caro, se non avessi un poco d'economia, le cose anderebbero in precipizio. I comici non si
 arrichiscono, quanti ne acquistano, tanti ne spendono.
 Felici quelli che in capo all'anno la levano del pari; ma
 per lo più l'uscita è maggiore dell'entrata.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Vorrei sapere per qual causa non volevate alzare la
 tenda.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Acciocché non si vedesse da nessuno a provare le
 nostre scene.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>A mezza mattina, chi ha da venire al teatro?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Oh vi sono de' curiosi, che si leverebbero avanti
 giorno.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>La nostra compagnia è stata altre volte veduta, non
 vi sarà poi tanta curiosità.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Abbiamo de' personaggi nuovi.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>È vero; questi non si dee lasciarli vedere alle
 prove.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Quando si vuol mettere in grazia un personaggio,
 conviene farlo un poco desiderare, e per farlo comparire,
 bisogna dargli poca parte, ma buona.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Eppur vi sono di quelli, che pregano i poeti,
 acciocché facciano due terzi di commedia sopra di loro.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Male, malissimo. Se sono buoni annoiano, se sono
 cattivi, fanno venir la rabbia.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ma qui si perde il tempo, e non si fa cosa alcuna.
 Questi signori compagni non vengono.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>L'uso comune de' commedianti; levarsi sempre tardi.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>La nostra maggior pena sta nelle prove.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Ma le prove sono quelle, che fanno buono il comico.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ecco la prima donna.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Non è poco, che sia venuta prima degli altri. Per
 usanza le prime donne hanno la vanità di farsi aspettare.</p>
@@ -415,26 +458,26 @@ usanza le prime donne hanno la vanità di farsi aspettare.</p>
           <stage>
             <emph>Rosaura, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Ecco qui; io son la prima di tutti. Queste signore donne non favoriscono? Signor Ottavio, se tardano io me ne vado.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Cara signora Rosaura, siete venuta in questo
 momento, e di già v'inquietate? Abiate pazienza; ne ho tanta
 io; abbiatene un poca voi ancora.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Parmi, che a me si potesse mandarne l'avviso, quando
 tutti stati fossero ragunati.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(Sentite? Parla da prima donna) <emph>(piano ad Ottavio)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>(Ci vuol politica; convien sofferirla). Signora mia,
 vi ho pregata a venir per tempo, e ho desiderato, che
@@ -442,99 +485,99 @@ veniste prima degli altri, per poter discorrere fra voi e
 me, qualche cosa toccante la direzione delle nostre
 commedie.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Non siete il capo della compagnia? Voi potete
 disporre senza dipendere.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Posso disporre, egli è vero, ma ho piacere, che
 tutti siano di me contenti; e voi specialmente, per cui ho
 tutta la stima.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(Volete voi dipendere da' suoi consigli?) <emph>(piano ad Ottavio)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>(Questa è la mia massima; ascolto tutti, e poi fo a
 mio modo) <emph>(piano a Florindo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Ditemi, signor Ottavio, qual'è la commedia, che
 avete destinato di fare domani a sera?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Quella nuova intitolata: <emph>Il Padre rivale del figlio</emph>. Ieri abbiamo provato il primo, e il secondo atto, e
 oggi proveremo il terzo.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Per provarla non ho difficoltà, ma per farla domani
 a sera, non sono persuasa.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(Sentite? Non l'approva) <emph>(piano ad Ottavio)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>(E che sì, che l'approverà?) <emph>(piano a Florindo)</emph>.
 Qual altra commedia credereste voi, che fosse meglio
 rappresentare?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Il poeta, che somministra a noi le commedie, ne ha
 fatte in quest'anno sedici tutte nove, tutte di carattere,
 tutte scritte. Facciamone una di quelle.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Sedici commedie in un anno! Pare impossibile.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Sì certamente, egli le ha fatte. Si è impegnato di
 farle, e le ha fatte.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Quali sono i titoli delle sedici commedie fatte in
 un anno?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Ve le dirò io: <emph>Il teatro comico</emph>, <emph>I puntigli delle donne</emph>, <emph>La bottega del caffè</emph>, <emph>Il bugiardo</emph>,
 <emph>L'adulatore</emph>, <emph>I poeti</emph>, <emph>La Pamela</emph>, <emph>Il cavalier di buon gusto</emph>, <emph>Il giuocatore</emph>, <emph>Il vero amico</emph>, <emph>La finta ammalata</emph>, <emph>La donna prudente</emph>, <emph>L'incognita perseguitata dal bravo impertinente</emph>, <emph>L'avventuriere onorato</emph>, <emph>La donna volubile</emph>, <emph>I pettegolezzi delle donne</emph>, comedia veneziana.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Fra queste non è la commedia, che abbiamo a fare
 domani a sera. Non è forse anch'essa del medesimo autore?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Sì, è sua; ma è una picciola farsa, ch'egli non
 conta nel numero delle sue commedie.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Perché dunque vogliamo fare una farsa, e non più
 tosto una delle migliori commedie?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Cara signora Rosaura, sapete pure, che ci mancano
 due parti serie, un uomo, ed una donna. Questi si aspettano,
 e se non giungono, non si potranno fare commedie di
 carattere.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Se facciamo le Commedie dell'Arte, vogliamo star
 bene. Il mondo è annoiato di veder sempre le cose istesse,
@@ -547,11 +590,11 @@ commedia non è di carattere, è almeno condotta bene, e si
 sentono ben maneggiati gli affetti. Per altro, se non si
 compie la compagnia, potete anche far di meno di me.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Ma frattanto...</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Orsù signor Ottavio, sono stata in piedi tanto che
 basta. Vado nel mio camerino a sedere. Quando si prova,
@@ -564,32 +607,32 @@ avvezzino a far aspettare la prima donna <emph>(via)</emph>.</p>
           <stage>
             <emph>Ottavio, e Florindo.</emph>
           </stage>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Io crepo dalle risa.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Voi ridete, e io bestemmierei.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Non mi avete detto, che ci vuoi pazienza?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Sì, la pazienza ci vuole, ma il veleno mi rode.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ecco il Pantalone.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Caro amico, fatemi un piacere, andate a sollecitar
 coteste donne.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Volentieri, anderò. Già preveggo di ritrovarle, o
 in letto, o alla tavoletta. Queste sono le loro principali
@@ -601,47 +644,47 @@ incombenze, o riposare, o farsi belle <emph>(parte)</emph>.</p>
           <stage>
             <emph>Ottavio, poi Pantalone.</emph>
           </stage>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Ben levato signor Pantalone.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Patron riverito.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Che avete, che mi parete turbato?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>No so, gnanca mi. Me sento un certo tremazzo a
 torno, che me par d'aver la freve.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Lasciate, ch'io senta il polso.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Tolè pur, Compare, sappième dir, se el bate a tempo
 ordinario, o in tripola.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Voi non avete febbre, ma il polso è molto agitato;
 qualche cosa avete, che vi disturba.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Saveu cosa, che gh'ho? Una paura, che non so in che
 mondo che sia.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Avete paura? Di che?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Caro sior Ottavio, buttemo le burle da banda, e
 parlemo sul sodo. Le commedie de carattere le ha butà
@@ -654,7 +697,7 @@ se sfadiga a studiar, e che el trema sempre ogni volta, che
 se fa una niova commedia, dubitando, o de no saverla quanto
 basta, o de no sostegnir el carattere come xè necessario.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Siamo d'accordo, signor Pantalone, che questa nuova
 maniera di recitare esige maggior fatica, e maggior
@@ -664,7 +707,7 @@ avreste mai riscosso l'applauso, che avete avuto nell'<emph>Uomo Prudente</emph>
 nelle quali il poeta si è compiaciuto di preeleggere il
 Pantalone?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Xè vero; son contentissimo, ma tremo sempre. Me par
 sempre, che el sbalzo sia troppo grando, e me arecordo quei
@@ -672,77 +715,77 @@ versi del Tasso:</p>
             <l>Mentre ai voli troppo alti e repentini</l>
             <l>Sogliono i precipizi esser vicini.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Sapete il Tasso? Si vede, che siete pratico di
 Venezia, e del gusto di essa quanto al Tasso, che vi si
 canta quasi comunemente.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Oh in materia de Venezia, so anca mi de barca
 menar.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Vi siete divertito in essa da giovine?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Che cade! Ho fatto un poco de tutto.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Colle belle donne come ve la siete passata?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <l>E porto in me di quelle donne istesse</l>
             <l>le onorate memorie ancora impresse.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Bravo signor Pantalone; mi piace il vostro brio,
 la vostra giovialità; spesse volte vi sento cantare.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Sior sì; co no gh'ho bezzi canto sempre.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Fatemi un piacere, fino a tanto, che i nostri
 carissimi signori compagni ci favoriscono di venire,
 cantatemi una canzonetta.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Dopo, che ho studià tre ore, volè che canta?
 Compatime, no ve posso servir.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Già siamo soli, nessuno ci sente.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>In verità, che no posso; un'altra volta ve servirò.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Fatimi questo piacere. Bramo di sentire, se state
 bene di voce.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>E se stago ben, me voleu farsi far cantar in
 teatro?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Perché no?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Voleu, che ve diga? Mi fazzo da Pantalon, e no da
 musico, e se avesse volesto far da musico, no gh'averia
@@ -754,58 +797,58 @@ l'incomodo della barba <emph>(parte)</emph>.</p>
           <stage>
             <emph>Ottavio, poi Colombina.</emph>
           </stage>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Dice così, ma è compiacente. Se farà di bisogno, son
 certo, ch'ei canterà.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Riverisco il signor Ottavio.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Oh, signora Colombina, vi sono schiavo; voi siete
 delle più diligenti.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Io faccio sempre volentieri il mio debito, e che ciò
 sia la verità osservate: siccome la parte, che mi è toccata
 nella commedia, che oggi si prova, è lunga un dito, ne ho
 presa un altra in mano, e a vado studiando.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Bravissima, così mi piace. Di che commedia è la
 parte, che avete in mano?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Questa è la parte di <emph>Catte</emph> nella <emph>Putta onorata</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Ah, ah! vi piace quel caratterino di Pelarina?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Sulla scena sì, ma fuori della scena no.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Eh! o poco, o molto, le donne pelano sempre.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Una volta pelavano, ma adesso son finiti i polastri.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>E pure si vede anche adesso dei giovanotti pelati
 fino all'osso.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Sapete perché? Ve lo dirò io. Prima di tutto perché
 le penne son poche, poi una penna al giuoco, un'altra a
@@ -813,70 +856,70 @@ crapola, una ai teatri, una ai festini; per le povere donne
 non restano, che le picciole penne matte, e qualche volta
 tocca a noi altre a rivestire cotesti poveri spennacchiati.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Voi ne avete mai rivestito alcuno?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Oh io non son gonza.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Certo, che saprete il fatto vostro, siete
 commediante.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>So il fatto mio quanto basta per non lasciarmi
 infinocchiare, per altro circa l'essere commediante, vi sono
 di quelle, che non girano il mondo; vi sono delle
 casalinghe, che ne fanno cento volte più di noi.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Sicché dunque per esser furba, basta esser donna.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>È vero, ma sapete perché, le donne son furbe?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Perché?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Perché gli uomini insegnano loro la malizia.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Per altro, se non fossero gli uomini, sareste
 innocentissime.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Senza dubbio.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>E noi saremmo innocenti se non foste voi altre
 donne.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Eh galeotti maledetti!</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Eh streghe in diavolate!</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Orsù, signor Ottavio, cosa facciamo? Si prova, o non
 si prova?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Mancano ancora le signore donne, l'Arlecchino, e il
 Brighella.</p>
@@ -887,79 +930,79 @@ Brighella.</p>
           <stage>
             <emph>Brighella, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Brighella l'è qua per servirla.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Oh bravo.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Son sta' fin'adesso a discorrer con un poeta.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Poeta? Di qual genere?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Poeta comico.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>È un certo signor Lelio?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Giusto el sior Lelio.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>È stato anche a trovar me, e subito che l'ho
 veduto, l'ho raffigurato per poeta.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Per qual cagione?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Perché era miserabile, e allegro.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Da questi segni l'avete raffigurato per poeta?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Sì, signore. I poeti a fronte delle miserie, si
 divertiscono colle Muse, e stanno allegri.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Oh ghe n'è dei altri, che fa cusì.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>E quali sono?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>I commedianti.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>È vero, è vero; anch'essi, quando non hanno danari
 vendono, e impegnano per star allegri.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Ghe n'è de quei, che i è pieni de cucche, e i va'
 intrepidi come paladini.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Perdonatemi, signori miei, fate torto a voi stessi
 parlando così. In tutta l'arte comica vi saranno pur troppo
@@ -968,23 +1011,23 @@ arti qualcheduno se ne ritrova. Il vero comico deve essere,
 come tutti gli altri onorato, deve conoscere il suo dovere,
 e deve essere amante dell'onore, e di tutte le morali virtù.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>El comico pol aver tutte le virtù, fora d'una.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>E qual'è quella virtù, che non può avere?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>L'economia.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Appunto come il poeta.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Eppure, se vi è nessuno, che abbia bisogno
 dell'economia, il recitante delle commedie dovrebbe essere
@@ -992,41 +1035,41 @@ quegli, perché essendo l'arte comica soggetta a infinite
 peripezie, l'utile è sempre incerto, e le disgrazie
 succedono facilmente.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Sto poeta lo volemio sentir?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Noi non ne abbiamo bisogno.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>N'importa; sentimolo per curiosità.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Per semplice curiosità non lo sentirei. Degli uomini
 dotti dobbiamo aver rispetto. Ma perché, voi me lo
 proponete, lo sentirò volentieri: e se averà qualche buona
 idea, non sarò lontano dall'accettarla.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>E il nostro poeta non se l'avrebbe a male?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Niente. Conosco il suo carattere. Egli se l'avrebbe
 a male se cotesto signor Lelio volesse strapazzare i
 componimenti suoi, ma se sarà un uomo di garbo, e un savio e
 discreto critico, son certo, che gli sarà buon amico.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Donca lo vado a introdur?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Sì, e fatemi il piacere d'avvisare gli altri,
 acciocché si trovino tutti qui a sentirlo. Ho piacere, che
@@ -1034,7 +1077,7 @@ ognuno dica il suo sentimento. I commedianti, ancorché non
 abbiano l'abilità di comporre le commedie, hanno però
 bastante cognizione per discernere le buone dalle cattive.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Sì, ma gh'è de quelli, che pretende giudicar della
 commedia dalla so parte. Se la parte l'è longa, i dise, che
@@ -1051,32 +1094,32 @@ el comico sarà degno di laude.</p>
           <stage>
             <emph>Ottavio, e Colombina.</emph>
           </stage>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Ecco i soliti versi. Una volta tutte le scene si
 terminavano così.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>È verissimo; tutti i dialoghi si finivano in
 canzonetta. Tutti i recitanti all'improvviso diventavano
 poeti.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Oggidì essendosi rinnovato il gusto delle commedie,
 si è moderato l'uso di tali versi.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Gran novità si sono introdotte nel teatro comico.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Pare a voi, che chi ha introdotto tali novità abbia
 fatto più male, o più bene?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Questa è una quistione, che non è per me. Ma però
 vedendo, che il mondo vi applaudisce, giudico, che averà
@@ -1091,138 +1134,138 @@ per voi ha fatto bene, perché la cassetta vi frutta meglio
           <stage>
             <emph>Ottavio, poi Arlecchino.</emph>
           </stage>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Tutti fanno i conti sulla cassetta, e non pensano
 alle gravi spese, che io ho! Se un anno va male, addio
 signor capo. Oh ecco l'Arlecchino.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Signor Ottavio, siccome ho l'onore di favorirla
 colla mia insufficienza, così son venuto a ricever
 l'incomodo delle so grazie.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Viva il signor Arlecchino. (No so se parli da
 secondo zanni, o creda di parlar bene).</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Mi hanno detto, ch'io venga allo sconcerto, e non ho
 mancato, anzi ero in una bottega, che bevevo il caffè, e per
 far presto, ho rotto la chiccara per servirla...</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Mi dispace d'essere stato cagione di questo male.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Niente, niente, <emph>Post factum nullum consilium</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>(È un bell'umore davvero). Mi dica, signor
 Allecchino, come le piace Venezia?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Niente affatto.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>No! Perché?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Perché ieri sera son cascado in canale.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Povero signore Arlecchino, come ha fatto?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Vi dirò: siccome la navicella...</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Ma ella parla toscano?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Sempre a rotta de collo.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Il secondo zanni non deve parlar toscano.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Caro signor, la me diga, in che linguaggio parla el
 secondo zane?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Dovrebbe parlare bergamasco.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Dovrebbe! Lo so anch'io dovrebbe. Ma come parla?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Non lo so nemmen io.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Vada dunque a imparare come parlano gl'Arlecchini, e
 poi venga a correggere noi. La lara, la lara <emph>(canticchiando con aria)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>(Fa ridere ancora me). Ditemi un poco, come avete
 fatto a cadere in aqua?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>In tel smontar da una gondola, ho messo un piede in
 terra, e l'altro sulla banda della barca. La barca s'ha
 slontanà dalla riva, e mi de bergamasco son diventà
 venezian.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Signor Arlecchino, domani a sera bisogna andar in
 scena colla commedia nuova.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Son qua, muso duro, fazza tosta, gnente paura.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Arriccordatevi, che non si recita più all'antica.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>E nu reciteremo alla moderna.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Ora si è rinnovato il buon gusto.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>El bon, el piase anca ai bergamaschi.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>E gli uditori non si contentano di poco.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Vu fè de tutto per metterme in suggezion, e no farè
 gnente. Mi fazzo un personaggio, che ha da far rider, se ho
@@ -1233,38 +1276,38 @@ udienza, per carità, per cortesia, che se i me vol onorar de
 qualche dozena de pomi, in vece de crudi, che i li toga
 cotti.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Lodo la vostra franchezza. In qualche altra persona
 potrebbe dirsi temerità, ma in un Arlecchino, il quale, come
 dite voi, deve far ridere, questa giovialità, questa
 intrepidezza è un bel capitale.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p><emph>Audaces Fortuna iuvat, timidosque</emph>, con quel che
 segue.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Tra poco devo sentire un poeta, e poi voglio, che
 proviamo qualche scena.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Se volì un poeta, son qua mi.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Siete anche poeta?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Eccome!</p>
             <l>Anch'io de' pazzi ho il triplicato onore.</l>
             <l>Son poeta, son musico, e pittore <emph>(parte)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Buono, buono. Mi piace assai. In un Arlecchino
 anche i versi son tollerabili. Ma cotesti signori non
@@ -1279,20 +1322,20 @@ volontà <emph>(parte)</emph>.</p>
           <stage>
             <emph>Beatrice, ed il Dottore senza maschera.</emph>
           </stage>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Via signor Dottore favoritemi, andiamo. Voglio che
 siate voi il mio cavaliere servente.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>in cielo me ne liberi.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Per qual cagione?</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>Perché in primo luogo, io non son così pazzo che
 voglia assoggettarmi all'umore stravagante di una donna. In
@@ -1301,49 +1344,49 @@ compagnia, che chi ha giudizio porta la puzza lontano da
 casa; e in terzo luogo, perché con lei farei per l'appunto
 la parte dal Dottore nella commedia intitolata: <emph>La Suocera, e la Nuora</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Che vuol dire?</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>Per premio della mia servitù, non potrei attendere
 altro, che un bicchier d'acqua nel viso.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Sentite, io non bado a queste cose. Serventi non
 ne ho mai avuto, e non ne voglio, ma quando dovessi averne,
 gli vorrei giovani.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>Le donne s'attaccano sempre al loro peggio.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Non è mai peggio quello che piace.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>Non s'ha da cercar quel che piace, ma quel che
 giova.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Veramente non siete buono da altro, che da dar
 buoni consigli.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>Io son buono per dargli, ma ella a quanto veggo non
 è buona da ricevergli.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Quando sarò vecchia, gli riceverò.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p><emph>Principiis obsta; sero medicina paratur</emph>.</p>
           </sp>
@@ -1353,64 +1396,64 @@ buoni consigli.</p>
           <stage>
             <emph>Ottavio, Florindo, Rosaura, e i detti.</emph>
           </stage>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Buon giorno, signora Rosaura.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Riverisco la signora Beatrice.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Come sta? Sta bene?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Benissimo per servirla. E ella?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Eh così, così! Un poco abbattuta dal viaggio.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>O che gran patimenti sono questi viaggi!</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Mi fanno ridere quelli che dicono, che noi andiamo a spasso, a divertirci pel mondo.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Spasso eh? Si mangia male, si dorme peggio, si patisce ora il caldo, e ora il freddo. Questo spasso lo lascierei pur volentieri.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Signore mie, hanno terminato i loro complimenti?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>I miei complimenti gli finisco presto.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Io pure non m'ingolfo colle cerimonie.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Sediamo dunque. Servitori, dove siete. Portate da
 sedere <emph>(I servitori portano le sedie, tutti siedono, le donne stanno vicine)</emph>. Or ora sentiremo un poeta da nuovo.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Lo sentirò volentieri.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Eccolo, che viene.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>Poverino! È molto magro.</p>
           </sp>
@@ -1420,199 +1463,199 @@ sedere <emph>(I servitori portano le sedie, tutti siedono, le donne stanno vicin
           <stage>
             <emph>Lelio, e i detti.</emph>
           </stage>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Servitor umilissimo a loro signori <emph>(tutti lo salutano)</emph>. Mi favoriscano di grazia; qual è di queste
 signore la prima donna?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Ecco qui la signora Rosaura.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Permetta, che con tutto il rispetto eserciti un
 atto del mio dovere <emph>(le bacia la mano)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Mi onora troppo, signore io non lo merito.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Ella, signora, è forse la seconda donna? <emph>(a Beatrice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Per servirla.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Permetta, che ancora seco... <emph>(come sopra)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>No certamente <emph>(la ritira)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>La supplico... <emph>(torna a provare)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Non s'incomodi <emph>(come sopra)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>È mio debito.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Come comanda <emph>(gliela bacia)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Questo poeta è molto cerimonioso <emph>(a Florindo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>I poeti colle donne sono quasi tutti così <emph>(ad Ottavio)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Ella dunque è il signor Lelio, celebre compositore
 di commedie, non è così?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>A' suoi comandi. Chi è V. S. se è lecito di saperlo?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Sostengo la parte di primo amoroso, e sono il capo
 della compagnia.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Lasci dunque, che eserciti seco gli atti del mio
 rispetto <emph>(lo riverisce con affettazione)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>La prego non s'incomodi. Eh là, dategli da sedere.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Ella mi onora con troppa bontà <emph>(servi portano una sedia vicino a Florindo, e partono)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>S'accomodi.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Ora, se mi permette anderò vicino a queste belle
 signore.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Ella sta volentieri vicino alle donne.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Vede bene. Le Muse son femmine. Viva il bel sesso.
 Viva il bel sesso.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>Signor poeta, le son servitore.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Schiavo suo. Chi è ella, mio padrone?</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>Il dottor per servirla.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Bravo, me ne rallegro. Ho una bella commedia fatta
 per lei.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>Com'è intitolata?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p><emph>Il Dottore ignorante</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>Mi diletto anch'io sa ella di comporre, ed ho fatto
 ancor io una commedia.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Sì? Com'è intitolata?</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p><emph>Il Poeta matto</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Viva il signor Dottore. Madama, ho delle scene di tenerezza, fatte apposta per voi, che faranno piangere non
 solo gl'uditori, ma gli scanni stessi <emph>(a Rosaura)</emph>.
 Signora, ho per voi delle scene di forza, che faranno
 battere le mani anco a' palchi medesimi <emph>(a Beatrice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(Piangere li scanni, battere le mani a' palchi.
 Questo è un poeta del Seicento) <emph>(da sé)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Ci favorisca di farci godere qualche cosa di bello.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Questa è una commedia a soggetto, che ho fatta in
 tre quarti d'ora.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>Si può ben dire, che è fatta -
 precipitevolissimevolmente.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Senta il titolo. <emph>Pantalone padre amoroso, con Arlecchino servo fedele, Brighella mezzano per interesse, Ottavio economo in villa, e Rosaura delirante per amore</emph>.
 Ah, che ne dite? È bello? Vi piace? <emph>(alle donne)</emph>. <emph>(verso la scena</emph></p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>È un titolo tanto lungo, che non me lo ricordo più.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>È un titolo che comprende quasi tutta la
 compagnia.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Questo è il bello; far che il titolo serva
 d'argomento alla commedia.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Mi perdoni, signor Lelio. Le buone commedie devono
 avere l'unità dell'azione; uno deve essere l'argomento, e
 semplice deve essere il loro titolo.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Bene. Meglio è abbondare, che mancare. Questa
 commedia ha cinque titoli, prendete di essi qual più vi
@@ -1620,87 +1663,87 @@ piace. Alzi fate così, ogni anno che tornate a recitarla,
 mutate il titolo, e averete per cinque anni una commedia,
 che parerà sempre nuova.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Andiamo avanti. Sentiamo come principia.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Ah Madama, gran piacere proverò io, se avrò l'onore
 di scrivere qualche cosa per voi <emph>(a Rosaura)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Mi dispiace, ch'io le farò poco onore.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Quanto mi piace la vostra idea! Siete fatta apposta
 per sostenere il carattere di una bellezza tiranna <emph>(A Beatrice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Il signor poeta mi burla.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Lo dico con tutto il core.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>Signor poeta, di grazia, ha ella mai recitato?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Ho recitato nelle più celebri accademie d'Italia.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>Mi pare, che V. S. sia fatto appunto per le scene
 di caricatura.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>E così, signore si può sentire questo soggetto?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Eccomi, subito vi servo: <emph>Atto primo. Strada. Pantalone, e Dottore. Scena d'amicizia</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Anticaglia, anticaglia.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Ma di grazia ascoltatemi. <emph>Il Dottore chiede la figlia a Pantalone</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>E Pantalone gliela promette.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Bravo, è vero. <emph>E Pantalone gliela promette. Il Dottore si ritira. Pantalone picchia, e chiama Rosaura</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>E Rosaura viene in istrada.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Sì signore, e Rosaura viene in istrada.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Con sua buona grazia, non voglio sentir altro
 <emph>(s'alza)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Perché? Cosa c'è di male?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Questa enorme improprietà di far venire le donne, in
 istrada è stata tollerata in Italia per molti anni con
@@ -1708,29 +1751,29 @@ iscapito del nostro decoro. Grazie al Cielo l'abbiamo
 corretta, l'abbiamo abolita, e non si ha più da permettere
 sul nostro teatro.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Facciamo così. <emph>Pantalone va in casa della figlia, e il Dottor resta</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>E frattanto che Pantalone sta in casa, cosa deve dir
 il Dottore?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p><emph>Mentre Pantalone è in casa, il Dottore... dice quel, che vuole. In questo</emph>, sentite. <emph>In questo Arlecchino servo del Dottore viene pian piano, e dà una bastonata al padrone</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Oibò, oibò sempre peggio.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>Se il poeta facesse da Dottore, il lazzo anderebbe
 bene.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Che il servo bastoni il padrone è una indignità.
 Purtroppo è stato praticato da' comici questo bel lazzo, ma
@@ -1739,71 +1782,71 @@ bastona il padrone, e il padrone lo soffre perché è faceto?
 Signor poeta, se non ha qualche cosa di più moderno, la
 prego, non s'incomodi più oltre.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Sentite almeno questo dialogo.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Sentiamo il dialogo.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p><emph>Dialogo primo. Uomo prega, donna scaccia.</emph> (Uomo)
 <emph>Tu sorda più del vento, non odi il mio lamento?</emph> (Donna)
 <emph>Olà, vammi lontano, insolente qual mosca, o qual tafano.</emph>
 (Uomo) <emph>Idolo mio diletto...</emph></p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Non posso più.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>
               <emph>Abbiate compassione...</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Andategli a cantar sul colascione <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p><emph>(S'accosta a Florindo)</emph> (Donna) <emph>Quanto più voi mi amate, tanto più mi secate.</emph> (Uomo) <emph>Barbaro core ingrato.</emph></p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Anch'io signor poeta, son seccato <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Donna) <emph>(va dal Dottore)</emph> <emph>Va' pure amante insano, già tu mi preghi invano.</emph> (Uomo) <emph>Sentimi o Donna o Dea.</emph></p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>Oh mi ha fatto venir la diarrea <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Donna). <emph>(va da Beatrice)</emph> <emph>Fuggi vola sparisci.</emph>
 (Uomo) <emph>Fermati, o cruda Arpia.</emph></p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Vado via, vado via <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>
               <emph>Non far di me strapazzo (verso Rosaura).</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Signor Poeta mio, voi siete pazzo <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Donna) <emph>Non sperar da me pietà, che pietà di te non ho.</emph> (Uomo) <emph>Se pietà da te non ho, disperato morirò.</emph>
 Come! tutti si sono partiti? Mi hanno piantato? Così
@@ -1827,51 +1870,51 @@ danari, quanti ne ha fatti per tanti anni il gran <emph>Convitato di Pietra</emp
           <stage>
             <emph>Lelio, e Brighella.</emph>
           </stage>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Signor Brighella, son disperato.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Ma, caro signor, la ghe va a proponer per prima
 commedia una strazza d'un soggetto, che no l'è gnanca bon
 per una compagnia de bambocci.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>In quanto al soggetto mi rimetto, ma il mio
 dialogo, non lo dovevano strapazzare così.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Ma no sàla, che dialoghi, uscite, soliloqui,
 rimproveri, concetti, disperazion, tirade, le son cosse, che
 no le usan più?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Ma presentemente che cosa si usa?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Commedie de carattere.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Oh delle commedie di carattere, ne ho quante ne
 vogliono.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Perché donca no ghe n'àla proposto qualcheduna al
 nostro capo?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Perché non credeva, che gl'Italiani avessero il
 gusto delle commedie di carattere.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Anzi l'Italia adesso corre drio unicamente a sta
 sorte de commedie, e ghe dirò de più, che in poco tempo ha
@@ -1879,11 +1922,11 @@ tanto profità el bon gusto nell'animo delle persone, che
 adesso anca la zente bassa decide francamente sui caratteri,
 e su i difetti delle commedie.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Quella è una cosa assai prodigiosa.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Ma ghe dirò anca el perché. La commedia l'è stada
 inventada per corregger i vizi, e metter in ridicolo i
@@ -1900,12 +1943,12 @@ carattere, che se rappresenta, i sa discerner se la passion
 sia ben sostegnuda, se il carattere sia ben condotto, e
 osservà.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Signor Brighella, voi parlate in una maniera, che
 parete più poeta, che commediante.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Ghe dirò, patron. Colla maschera son Brighella,
 senza maschera son un omo, che se non è poeta per
@@ -1913,67 +1956,67 @@ l'invenzion, ha però quel discernimento, che basta per
 intender el so mistier. Un comico ignorante no pol riuscir
 in nessun carattere.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Ho gran timore, che questi comici ne sappiano più
 di me). Caro amico, fatemi il piacere di dire al vostro capo
 di compagnia, che ho delle commedie di carattere.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Ghe lo dirò, e la pol tornar stassera, o
 domattina, che gh'averò parlà.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>No; avrei fretta di farlo adesso.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>La vede; s'ha da concertar alcune scene de
 commedia per doman de sera; adesso nol ghe poderà abbadar.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Se non mi ascolta subito, vado via, e darò le mie
 commedie a qualche altra compagnia.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>La se comodi pur. Nu no ghe n'avemo bisogno.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Il vostro teatro perderà molto.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Ghe vorrà pazienza.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Domani devo partire; se ora non mi ascolta non
 faremo più a tempo.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>La vaga a bon viazo.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Amico, per dirvi tutto col cuore sulle labbra, non
 ho denari, e non so come far a mangiare.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Questa l'è una bella rason, che me persuade.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Mi raccomando alla vostra assistenza; dite una
 buona parola per me.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Vado da sior Ottavio, e spero, che el vegnirà a
 sentir subito cossa che la gh'ha, circa ai caratteri. (Ma
@@ -1986,7 +2029,7 @@ el poeta affamado) <emph>(da sé, e parte)</emph>.</p>
           <stage>
             <emph>Lelio, poi Rosaura.</emph>
           </stage>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Sono venuto in una congiuntura pessima. I comici
 sono oggidì illuminati; ma non importa. Spirito, e
@@ -1994,26 +2037,26 @@ franchezza. Può darsi, che mi riesca di far valere
 l'impostura. Ma ecco la prima donna che torna. Io credo di
 aver fatta qualche impressione sullo spirito di lei.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Signor Lelio ancora qui?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Sì mia signora, qual invaghita farfalla mi vo
 raggirando intorno al lume delle vostre pupille.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Signore, se voi seguiterete questo stile, vi farete
 ridicolo.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Ma i vostri libri, che chiamate <emph>generici</emph> non sono
 tutti pieni di questi concetti?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>I miei libri, che contenevano tali concetti gli ho
 tutti abbruciati, e così hanno fatto tutte quelle recitanti,
@@ -2022,90 +2065,90 @@ più commedie di carattere, premeditate, ma quando ci accade
 di parlare all'improvviso, ci serviamo dello stil familiare,
 naturale, e facile, per non distaccarsi dal verisimile.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Quand'è così, vi darò io delle commedie scritte con
 uno stile sì dolce, che nell'impararle v'incanteranno.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Basta che non sia stile antico, pieno d'<emph>antitesi</emph>,
 e di <emph>traslati</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>L'<emph>antitesi</emph> forse non fa bell'udire? Il
 contrapposto delle parole non suona bene all'orecchio?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Fin che l'<emph>antitesi</emph> è <emph>figura</emph>, va bene; ma quando
 diventa <emph>vizio</emph> è insoffribile.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Gli uomini della mia sorta, sanno dai <emph>vizi</emph> trar
 le <emph>figure</emph>, e mi dà l'animo di rendere una graziosa figura
 di <emph>repetizione</emph> la più ordinaria <emph>cacofonia</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Sentirò volontieri le belle produzioni dello spirito
 di lei.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Ah, signora Rosaura, voi avete ad essere la mia
 sovrana, la mia stella, il mio nume.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Questa <emph>figura</emph> mi pare <emph>iperbole</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Andrò investigando colla mia più fina <emph>retorica</emph>
 tutti i <emph>luoghi topici</emph> del vostro cuore.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>(Non vorrei, che la sua <emph>retorica</emph> intendesse di
 passare all'<emph>umanità</emph> ).</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Dalla vostra bellezza <emph>argomento filosoficamente</emph> la
 vostra bontà.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Piuttosto che <emph>filosofo</emph>, mi parete un bel
 <emph>matematico</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Mi renderò <emph>speculativo</emph> nelle prerogative del
 vostro merito.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Fallate il <emph>conto</emph>, siete un cattivo <emph>aritmetico</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Spero, che colla perfezione dell'<emph>optica</emph> potrò
 <emph>speculare</emph> la vostra bellezza.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Anche in questo siete un pessimo <emph>astrologo</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>È possibile, che non vogliate esser <emph>medica</emph>
 amorosa delle mie piaghe?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Sapete cosa sarò? Un <emph>giudice legale</emph>, che vi farà
 legare, e condurre allo spedale de' pazzi. (Se troppo stessi
@@ -2119,7 +2162,7 @@ quei concetti, che sono proibiti, come le pistole corte)
           <stage>
             <emph>Lelio, poi Ottavio.</emph>
           </stage>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Queste principesse di teatro pretendono d'aver
 troppa sovranità su i poeti, e se non fossimo noi, non
@@ -2127,43 +2170,43 @@ riscuoterebbero dall'udienza gli applausi. Ma ecco il signor
 capo; conviene contenersi con esso con umiltà. Oh fame,
 fame, sei pur dolorosa!</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Mi ha detto il signor Brighella, che V. S. ha delle
 commedie di carattere, e ancorché io non ne abbia bisogno,
 tuttavolta per farle piacere, ne prenderò qualcheduna.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Le sarò eternamente obbligato.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Da sedere <emph>(servi portano due sedie, e partono)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Fortuna aiutami) <emph>(da sé)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Favoritemi, e mostratemi qualche cosa di bello.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Ora vi servo subito. Questa è una commedia tradotta
 dal francese, ed è intitolata...</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Non occorre altro. Quando è una commedia tradotta
 non fa per me.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Perché? Disprezzate voi l'opere dei Francesi?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Non le disprezzo; le lodo, le stimo, le venero, ma
 non sono il caso per me. I Francesi hanno trionfato
@@ -2190,12 +2233,12 @@ commedia. Vogliono tante infinite cose, che troppo lungo
 sarebbe il dirle, e solamente, coll'uso, colla pratica, e
 col tempo si può arrivar a conoscerle, e ad eseguirle.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Ma quando poi una commedia ha tutte queste buone
 qualità, in Italia, piace a tutti?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Oh signor no. Perché, siccome ognuno, che va alla
 commedia pensa in un modo particolare, così fa in lui vario
@@ -2206,7 +2249,7 @@ non averanno l'applauso universale. Ma la verità però si è,
 che quando sono buone, alla maggior parte piacciono, quando
 sono cattive quasi a tutti dispiacciono.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Quand'è così, io ho una commedia di carattere di
 mia invenzione, che son sicuro che piacerà alla maggior
@@ -2215,25 +2258,25 @@ ma quando non li avessi tutti adempiuti, son certo d'avere
 osservato il più essenziale, che è quello della scena
 stabile.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Chi vi ha detto, che la scena stabile sia un
 precetto essenziale?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Aristotile.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Avete letto Aristotile?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Per dirla, non l'ho letto, ma ho sentito a dire
 così.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Vi spiegherò io cosa dice Aristotile. Questo buon
 filosofo intorno alla commedia ha principiato a scrivere, ma
@@ -2263,33 +2306,33 @@ siscena stabile, si faccia; ma se per l'unità della scena,
 si hanno a introdurre degli assurdi; è meglio cambiar la
 scena, e osservare le regole del verisimile.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Ed io ho fatto tanta fatica per osservare questo
 precetto.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Può essere, che la scena stabile vada bene. Qual è
 il titolo della vostra commedia?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p><emph>Il padre mezzano delle proprie figliuole</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Oimè! Cattivo argomento. Quando il protagonista
 della commedia è di cattivo costume, o deve cambiar
 carattere contro i buoni precetti, o deve riescire la
 commedia stessa una scelleraggine.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Dunque non si hanno a mettere sulla scena i cattivi
 caratteri per correggerli, e svergognarli?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>I cattivi caratteri si mettono in iscena, ma non i
 caratteri scandolosi, come sarebbe questo di un padre, che
@@ -2299,46 +2342,46 @@ mette di fianco, e non in prospetto, che vale a dire, per
 episodio, in confronto del carattere virtuoso, perché
 maggiormente si esalti la virtù, e si deprima il vizio.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Signor Ottavio, non so più cosa dire. Io non ho
 altro da offerirvi.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Mi spiace infinitamente, ma quanto mi avete offerito
 non fa per me.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Signor Ottavio, le mie miserie sono grandi.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Mi rincresce, ma non so come soccorrervi.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Una cosa mi resta a offerirvi, e spero, che non vi
 darà il cuore di sprezzarla.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Ditemi in che consiste?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Nella mia stessa persona.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Che cosa dovrei fare di voi?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Farò il comico, se vi degnate accettarmi.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p><emph>(s'alza)</emph> Voi vi esibite per comico? Un poeta, che
 deve esser maestro de' comici, discende al grado di
@@ -2349,7 +2392,7 @@ dicendovi per ultimo, che v'ingannate, se credete che i
 comici onorati, come noi siamo, diano ricetto a' vagabondi
 <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Vadano al diavolo i soggetti, le commedie, e la
 poesia. Era meglio, che mi mettessi a recitare alla prima.
@@ -2367,35 +2410,35 @@ potendo essere capitano, si contentò del grado di tamburino
             <emph>Il Suggeritore con fogli in mano, e cerino. Poi ROSAURA, e
 FLORINDO.</emph>
           </stage>
-          <sp>
+          <sp who="#suggeritore">
             <speaker>SUGGERITORE</speaker>
             <p>Animo, signori, che l'ora vien tarda. Vengano a
 provare le loro scene. Tocca a Rosaura, e a Florindo.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Eccomi, io son pronta.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Son qui, suggerite <emph>(al suggeritore)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Avvertite bene, signor suggeritore: dove so la
 parte, suggerite piano, dove non la so, suggerite forte.</p>
           </sp>
-          <sp>
+          <sp who="#suggeritore">
             <speaker>SUGGERITORE</speaker>
             <p>Ma come farò io a conoscere dove la sa, e dove non
 la sa?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Se sapete il vostro mestiere, l'avete a conoscere.
 Andate, e se mi farete sbagliare, povero voi.</p>
           </sp>
-          <sp>
+          <sp who="#suggeritore">
             <speaker>SUGGERITORE</speaker>
             <p>(Già, è l'usanza de' commedianti: quando non sanno
 la parte, danno la colpa al suggeritore) <emph>(entra e va a suggerire)</emph>.</p>
@@ -2406,56 +2449,56 @@ la parte, danno la colpa al suggeritore) <emph>(entra e va a suggerire)</emph>.<
           <stage>
             <emph>Rosaura e Florindo</emph>
           </stage>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>
               <emph>Caro Florindo, mi fate torto se dubitate della mia</emph>
               <emph>fede. Mio padre non arriverà mai a disporre della mia mano.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>
               <emph>Non mi fa temer vostro padre, ma il mio. Può darsi che il signor Dottore, amandovi teneramente, non voglia la vostra rovina; ma l'amore, che ha per voi mio padre, mi mette in angoscia, e non ho cuore per dichiararmi ad esso rivale.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>
               <emph>Mi credete voi tanto sciocca, che voglia consentire alle nozze del signor Pantalone? Ho detto che sarò sposa in casa Bisognosi ma fra me intesi del figliuolo, e non del padre.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>
               <emph>Eppure egli si lusingava di possedervi, e guai a me, se discoprisse la nostra corrispondenza.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>
               <emph>Terrò celato il mio amore fino a tanto, che dal mio silenzio mi venga minacciata la vostra perdita.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>
               <emph>Addio, mia cara, conservatemi la vostra fede.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>
               <emph>E mi lasciate sì tosto?</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>
               <emph>Se il vostro genitore vi sorprende, sarà svelato ogni arcano.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>
               <emph>Egli non viene a casa per ora.</emph>
@@ -2467,258 +2510,258 @@ la parte, danno la colpa al suggeritore) <emph>(entra e va a suggerire)</emph>.<
           <stage>
             <emph>Pantalone, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(di dentro) <emph>O de casa; se pol vegnìr?</emph></p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>
               <emph>Oimè. mio padre.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>
               <emph>Nascondetevi in quella camera.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>
               <emph>Verrà a parlarvi d'amore.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>
               <emph>Lo seconderò per non dar sospetto.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>
               <emph>Secondatelo fino a un certo segno.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>
               <emph>Presto, presto, partite.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p><emph>Oh amor fatale, che mi obbliga ad essere geloso di mio padre medesimo</emph> (si ritira)<emph>.</emph></p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>
               <emph>Gh'è nissun? Se pol vegnìr?</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>
               <emph>Venga, venga, signor Pantalone.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>
               <emph>Siora Rosaura, patrona reverita. Xèla sola?</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>
               <emph>Sì, signore, son sola. Mio padre è fuori di casa.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>
               <emph>Se contentela, che me ferma un pochetto con ela, o vorla, che vaga via?</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>
               <emph>Ella è il padrone di andare, e di stare, a suo piacere.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>
               <emph>Grazie, la mia cara fia. Benedetta quella bocchetta, che dise quele bele parole.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>
               <emph>Mi fa ridere, signor Pantalone.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>
               <emph>Cuor aliegro el Ciel l'aiuta. Gh'ho gusto, che ridè, che stè alegra, e quando ve vedo de bona vogia, sento propriamente, che el cuor me bagola.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>
               <emph>M'imagino che sarà venuto per ritrovare mio padre.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>
               <emph>No, colonna mia, no speranza mia, che no son vegnù per el papà, son vegnù per la tata.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>
               <emph>E chi è questa tata?</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>
               <emph>Ah furbetta! Ah ladra de sto cuor! Lo savè, che spasemo, che muoro per vu?</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>
               <emph>Vi sono molto tenuta del vostro amore.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>
               <emph>Ale curte. Za, che semo soli, e nissun ne sente, ve contenteu, ve degneu, de compagnarve in matrimonio con mi?</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>
               <emph>Signore, bisognerà parlarne a mio padre.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>
               <emph>Vostro sior pare xè mio bon amigo, e spero che nol me dirà de no. Ma vorave sentir da vu le mie care viscere, do parole, che consolasse el mio povero cuor. Vorrave, che vu me disessi: Sior sì; sior Pantalon lo tiorò, ghe voggio tutto el mio ben, siben, che l'è vecchio, el me piase tanto; se me disè cusì, me fe andar in bruo de lasagne.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>
               <emph>Io queste cose non le so dire.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>
               <emph>Disè, fia mia, aveu mai fatto l'amor?</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>
               <emph>Non, signore, mai.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>
               <emph>No savè, come che se fazza a far l'amor?</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>
               <emph>Non lo so, in verità.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>
               <emph>Ve l'insegnerò mi, cara; ve l'insegnerò mi.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>
               <emph>Queste non mi paiono cose per la sua età.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>
               <emph>Amor no porta respetto a nissun. Tanto el ferisce i zoveni, quanto i vecchi; e tanto i vecchi, quanto i zoveni bisogna compatirli co i xè innamorai.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>
               <emph>Dunque avrete compassione ancora a me, se sono innamorato.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>
               <emph>Come? Qua ti xè?</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>
               <emph>Sì; signore, son qui per quella stessa cagione, che fa qui essere voi.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>
               <emph>Confesso el vero, che tremo dala colera, e dal rossor vedendo in fazza de mio fio scoverte le mie debolezze. Xè granda la temerità da comparirme davanti in t'una congiuntura tanto pericolosa, ma sta sorpresa, sto scoprimento servirà de fren ai to dessegni, e alle mie passion. Per remediar al mal esempio, che t'ho dà in sta occasion, sappi che me condanno da mi medesimo, che confesso esser stà tropo debole, tropo facile, tropo matto. Se ho dito, che i vecchi, e i zoveni che s'innamora, merita compatimento, l'è stà un trasporto dell'amorosa passion. Per altro i vecchi, che gh'ha fioi, no i s'ha da innamorar con pregiudizio della so famegia. I fioi, che gh'ha pare, no i s'ha da incapriciar senza el consenso de quello, che li ha messi al mondo. Onde fora tutti do desta casa. Mi per elezion, ti per obbedienza. Mi per remediar al scandalo, che t'ho dà: ti per imparar a viver con cautela, con più giudizio, e con più respetto a to pare.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>
               <emph>Ma, signore...</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>
               <emph>Animo, digo, fora subito de sta casa.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>
               <emph>Permetetemi...</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>
               <emph>Obedissi, o te trarrò zoso della scala con le mie man.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p><emph>(Maledettissima gelosia, che mi rendesti impaziente)</emph> (parte).</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p><emph>Siora Rosaura, no so cossa dir. V'ho volesto ben, ve ne vogio ancora, e ve ne vorrò. Ma un momento solo ha deciso de vu, e de mi. De vu, che no sarè più tormentada da sto povero vecchio; de mi, che morirò quanto prima, sacrificando la vita al mio decoro, alla mia estimazion.</emph>
 (parte)</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p><emph>Oimè! Qual gelo mi ricerca le vene? In qual'agitazione si ritrova il mio core?</emph> (Dite piano, che la
 parte la so). <emph>(verso il suggeritore)</emph> <emph>Florindo, scoperto dal padre, non verrà più in mia casa, non sarà più mio sposo? Ahi, che il dolore mi uccide. Ahi, che l'affanno...</emph>
@@ -2731,7 +2774,7 @@ voglio dir altro <emph>(parte)</emph>.</p>
           <stage>
             <emph>Suggeritore col libro in mano, poi COLOMBINA.</emph>
           </stage>
-          <sp>
+          <sp who="#suggeritore">
             <speaker>SUGGERITORE</speaker>
             <p>Animo Colombina. Tocca a <emph>Colombina</emph>, e poi ad
 <emph>Arlecchino</emph>. Non la finiscono mai. Maladetto questo
@@ -2740,15 +2783,15 @@ poi i signori comici sempre gridano, e non si contentano
 mai. Sono vent'ore sonate, e sa il Cielo, se il signor capo
 di compagnia mi darà nemmeno da pranzo. Colombina <emph>(chiama forte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Son qui, son qui.</p>
           </sp>
-          <sp>
+          <sp who="#suggeritore">
             <speaker>SUGGERITORE</speaker>
             <p>Animo, che è tardi <emph>(entra, e va a suggerire)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>
               <emph>Povera signora Rosaura, povera la mia padrona! Che cosa mai ha che piange, e si dispera? Eh so ben io cosa vi vorrebbe pel suo male! Un pezzo di giovinotto ben fatto, che le fa cesse passare la malinconia. Ma il punto sta, che anch'io ho bisogno dello stesso medicamento. Arlecchino, e Brighella sono ugualmente accesi delle mie strepitose bellezze, ma non saprei a qual di loro dar dovessi la preferenza. Brighella è troppo furbo, Arlecchino è troppo sciocco. L'accorto vorrà fare a modo suo, l'ignorante non saprà fare a modo mio. Col furbo starò male di giorno, e collo sciocco starò male di notte. Se vi fosse qualcheduno a cui potessi chiedere consiglio, glielo chiederei volontieri.</emph>
@@ -2760,248 +2803,248 @@ di compagnia mi darà nemmeno da pranzo. Colombina <emph>(chiama forte)</emph>.<
           <stage>
             <emph>Brighella, e Arlecchino, che ascoltano, e detta.</emph>
           </stage>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>
               <emph>Basta andrò girando per la città, e a quante donne incontrerò, voglio dimandare, se sia meglio prendere un marito accorto, o un marito ignorante.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p><emph>Accorto, accorto.</emph> (s'avanza)</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p><emph>Ignorante, ignorante.</emph> (s'avanza)</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>
               <emph>Ognuno difende la propria causa.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>
               <emph>Mi digo el vero.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>
               <emph>Mi gh'ho rason.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>
               <emph>E te lo proverò con argomenti in forma.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>
               <emph>E mi lo proverò con argomenti in scarpa.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>
               <emph>Bene, chi di voi mi persuaderà, sarà mio marito.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>
               <emph>Mi come omo accorto, sfadigherò, suderò, perché in casa no te manca mai da magnar.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>
               <emph>Questo è un buon capitale.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>
               <emph>Mi come omo ignorante, che no sa far gnente, lasserò, che i boni amici porta in casa da magnar, e da bever.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>
               <emph>Anche così, potrebbe andar bene.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>
               <emph>Mi, come omo accorto, che sa sostegnir el ponto d'onor, te farò respettar da tutti.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>
               <emph>Mi piace.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>
               <emph>Mi, come omo ignorante, e pacifico, farò, che tutti te voia ben.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>
               <emph>Non mi dispiace.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>
               <emph>Mi come omo accorto, regolerò perfettamente la</emph>
               <emph>casa.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>
               <emph>Buono.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>
               <emph>Mi, come omo ignorante, lasserò che ti la regoli ti.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>
               <emph>Meglio.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>
               <emph>Se ti vorrà divertimenti, mi te condurrò da per tutto.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>
               <emph>Benissimo.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>
               <emph>Mi, se ti vorrà andar a spasso, te lasserò andar sola dove ti vol.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>
               <emph>Ottimamente.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>
               <emph>Mi, se vederò, che qualche zerbinoto vegna per insolentarte, lo scazzerò colle brutte.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>
               <emph>Bravo.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>
               <emph>Mi, se vederò qualchedun, che te zira d'intorno darò logo alla fortuna.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>
               <emph>Bravissimo.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>
               <emph>Mi, se troverò qualchedun in casa el copperò!</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>
               <emph>E mi torrò ed candelier, e ghe farò lume.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>
               <emph>Cossa dixeu?</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>
               <emph>Cossa te par?</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p><emph>Ora, che ho sentite le vostre ragioni, concludo, che Brighella pare troppo rigoroso, e Arlecchino troppo paziente. Onde, fate così, impastatevi tutti due, fate di due pazzi un uomo savio, ed allora vi sposerò.</emph> (parte)</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>
               <emph>Arlecchin?</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>
               <emph>Brighella?</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>
               <emph>Com'ela?</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>
               <emph>Com'ela?</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>
               <emph>Ti, che ti è un maccaron, ti te pol impastar facilmente.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>
               <emph>Piuttosto ti, che ti è una lasagna senza dreto, e senza roverso.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>
               <emph>Basta, no l'è mio decoro, che me metta in compatenza con ti.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>
               <emph>Sastu cossa, che podemo far? Colombina sa far la furba, e l'accorta, quando che la vol; ergo impastemose tutti do con ela, e faremo de tre paste una pasta da far biscotto per le galere.</emph>
@@ -3013,30 +3056,30 @@ di compagnia mi darà nemmeno da pranzo. Colombina <emph>(chiama forte)</emph>.<
           <stage>
             <emph>Brighella, poi Ottavio, e Florindo.</emph>
           </stage>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>
               <emph>Costù per quel che vedo, l'è goffo, e destro; ma no saria mio decoro, che me lassasse da lu superar. Qua ghe vol spirito, ghe vol inzegno. Qual piloto, che trovandose in alto mar colla nave, osservando dalla bussola della calamita, che el vento sbalza da garbin a sirocco, ordena ai marineri zirar le vele; cusì anca mi, ai marineri dei mi pensieri...</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Basta così, basta così.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Obbligatissimo alle lo grazie <emph>(si cava la maschera)</emph>. Perché no volela, che fenissa la mia scena?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Perché queste comparazioni, queste allegorie non si
 usano più.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>E pur quando le se fa, la zente sbate le man.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Bisogna vedere chi è, che batte. La gente dotta non
 s'appaga di queste freddure. Che diavolo di bestialità?
@@ -3045,23 +3088,23 @@ dire: <emph>I marineri dei miei pensieri</emph>! Queste cose il poeta
 non le ha scritte. Questo è un paragone recitato di vostra
 testa.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Donca non ho da dir paralleli?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Signor no.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Non ho da cercar allegorie?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Nemmeno.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Manco fadiga, e più sanità <emph>(parte)</emph>.</p>
           </sp>
@@ -3071,19 +3114,19 @@ testa.</p>
           <stage>
             <emph>Ottavio, e Florindo</emph>
           </stage>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Vedete signor Florindo? Ecco la ragione per cui
 bisogna procurar di tenere i commedianti legati al
 premeditato, perché facilmente cadono nell'antico, e
 nell'inverisimile.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Dunque s'hanno da abolire intieramente le commedie
 all'improviso?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Intieramente no; anzi va bene, che gl'Italiani si
 mantengano in possesso di far quello, che non hanno avuto
@@ -3097,23 +3140,23 @@ trionfo con merito, e con applauso l'ammirabile prerogativa
 di parlare a soggetto, con non minor eleganza di quello che
 potesse fare un poeta scrivendo.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ma le maschere ordinariamente patiscono a dire il
 premeditato.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Quando il premeditato è grazioso, e brillante, bene
 adattato al carattere del personaggio, che deve dirlo, ogni
 buona maschera volentieri lo impara.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Dalle nostre commedie di carattere non si
 potrebbero levar le maschere?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Guai a noi, se facessimo una tal novità: non è ancor
 tempo di farla. In tutte le cose non è da mettersi di fronte
@@ -3129,12 +3172,12 @@ non bisogna levarle del tutto, anzi convien cercare di bene
 allogarle, e di sostenerle con merito nel loro carattere
 ridicolo anco a fronte del serio più lepido, e più grazioso.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ma questa è una maniera di comporre assai
 difficile.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>È una maniera ritrovata, non ha molto, alla di cui
 comparsa tutti si sono invaghiti, e non andrà gran tempo,
@@ -3147,43 +3190,43 @@ come desidera di buon cuore, chi l'ha inventata.</p>
           <stage>
             <emph>Dottore coll'abito, ma colla maschera alzata, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>Servitor di lor signori.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Riverisco il signor Dottore.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>Voleva provar ancor io le mie scene, ma parmi, che
 ci sia poco buona disposizione.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Per questa mattina basta così. Proveremo qualche
 altra cosa dopo pranso.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>Io sto lontano di casa, mi rincresce aver d'andare,
 e tornare.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Eh resterete qui a pranso dal signor Ottavio, già
 faccio conto di restarvi ancor io.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>Quando è così, mi cavo la maschera.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Padroni; s'accommodino.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>È il nostro capo di compagnia, non ci mancherebbe
 altro.</p>
@@ -3195,139 +3238,139 @@ altro.</p>
             <emph>Il Suggeritore dalla scena, e poi Brighella senza
 maschera, Lelio, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#suggeritore">
             <speaker>SUGGERITORE</speaker>
             <p>Quand'è così, starò anch'io a ricevere le sue
 grazie <emph>(ad Ottavio)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Sì signore, mi maraviglio <emph>(suggeritore entra)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Sior Ottavio, so che l'ha tanta bontà per mi, che
 no la me negherà una grazia.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p><emph>(fa riverenze)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Dite pure; in quel che posso, vi servirò.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p><emph>(come sopra)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>L'è qua el sior Lelio. El desidera de far el
 comico: el gh'ha del spirito, dell'abilità; sta compagnia la
 gh'ha bisogno d'un altro moroso; la me fazza sta finezza; la
 lo riceva in grazia mia.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p><emph>(come sopra)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Per compiacere il mio caro signor Brighella, lo
 farei volentieri, ma chi mi assicura, che possa riuscire?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Fermo cusì; provemolo. Se contentela sior Lelio,
 de far una piccola prova?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Sono contentissimo. Mi rincresce, che ora non
 posso, mentre non avendo bevuto la cioccolata, sono di
 stomaco, e di voce un poco debole.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Faremo così; torni dopo pranzo, e si proverà.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Ma frattanto dove avrei io d'andare?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Vada a casa, poi torni.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Casa io non ne ho.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Ma dove è alloggiato?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>In nissun luogo.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Quant'e, che è in Venezia?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Da ieri in qua.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>E dove ha mangiato ieri?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>In nessun luogo.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Ieri non ha mangiato?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Né ieri, né stamattina.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Ma dunque come farà...</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Signor poeta, venga a pranzo dal capo di compagnia.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Riceverò le sue grazie, signor capo; perché questi
 appunto sono gl'incerti de' poeti.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Io non la ricevo per poeta, ma per comico.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>Venga, venga, signore, questo è un incerto anco dei
 comici quando si fa la prova.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Oh mi perdoni! Mi tornerebbe un bel conto.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Questa è fatta, non se ne parla più. Oggi vedrà la
 mia abilità.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>E la principieremo a vedere alla tavola.</p>
           </sp>
@@ -3337,33 +3380,33 @@ mia abilità.</p>
           <stage>
             <emph>Colombina, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Signor Ottavio, è arrivata alla porta una forestiera
 piena di ricciolini, tutta brio, col tabarrino, col
 cappellino, e domanda del capo di compagnia.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Venga avanti.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Non sarebbe meglio riceverla dopo desinare?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Sentiamo cosa vuole.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Ora la faccio passare.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Mandiamo un servitore.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Eh io fo la serva da burla, la farò anche davvero
 <emph>(parte)</emph>.</p>
@@ -3374,28 +3417,28 @@ cappellino, e domanda del capo di compagnia.</p>
           <stage>
             <emph>Rosaura, Beatrice, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Grand'aria! grand'aria!</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Bellezze grandi! bellezze grandi!</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Che cosa c'è, signore mie?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Vien su della scala una forestiera, che incanta.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Ha il servitore colla livrea, sarà qualche gran
 signora.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Or ora la vedremo. Eccola.</p>
           </sp>
@@ -3405,262 +3448,262 @@ signora.</p>
           <stage>
             <emph>Eleonora con un Staffiere, e i detti.</emph>
           </stage>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Serva a lor signori.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Servitor ossequiosissimo, mia signora <emph>(le donne le fan riverenza, e tutti gli uomini stanno col cappello in mano)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Sono comici, lor signori?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Sì, signora, per servirla.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Chi è il capo della compagnia?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Io per ubbidirla.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>È questa è la prima donna? <emph>(verso Rosaura)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>A' suoi comandi <emph>(con una riverenza)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Brava ragazza; so, che vi fate onore.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Grazie alla sua bontà.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Io pure vado volentieri alle commedie, e quando
 vedo le vostre buffonerie, rido, come una pazza.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Ci favorisca di grazia, acciò ch'io non mancassi del
 mio dovere; mi dica con chi ho l'onor di parlare.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Sono una virtuosa di musica <emph>(tutti si guardano fra di loro, e si mettono il cappello in testa)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Ella è dunque una cantatrice?</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Cantatrice? Sono una virtuosa di musica.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Insegna forse la musica?</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Non signore, canto.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Dunque è cantatrice.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Fate voi da prima donna? <emph>(ad Eleonora)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Qualche volta.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Brava ragazza, vi verrò a vedere <emph>(burlandola)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>Anch'io, signora, quando sento le smorfie delle
 cantatrici, crepo dalle risa.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Perdoni in grazia, non è ella la signora Eleonora?</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Sì signore per l'appunto.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Non si ricorda, che ha recitato in un mio dramma?</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Dove? Non mi sovviene.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>A Firenze.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Il dramma com'era intitolato?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p><emph>La Didone in bernesco</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Sì, signore, è vero. Io faceva la prima parte.
 Anzi l'impressario andò fallito per cagione del libro.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Tutti dicevano a cagione della prima donna; per
 altro, mi rimetto.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Dunque ella recita in opere buffe?</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Sì signora, qualche volta.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>E viene a ridere delle buffonerie dei commedianti?</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Vi dirò. Mi piace tanto il vostro modo di
 trattare, che verrei volentieri ad unirmi con voi.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Vuol fare la commediante?</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Io la commendiante? Mi maraviglio di voi. Una
 virtuosa mia pari, non si abbassa a tal segno.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Ma dunque cosa vuol fare con noi?</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Per far la fortuna della vostra compagnia, verrò a
 cantar gl'intermezzi.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Obbligatissimo alle sue grazie.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Sentite; il compagno lo troverò io, e con
 cinquecento zecchini vi assolverete dalla spesa di tutti
 due.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Non più di cinquecento zecchini?</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Viaggi, alloggi, piccolo vestiario, queste sono
 cose, che ci s'intendono.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Eh benissimo, cose, che si usano.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Gl'intermezzi gli abbiamo noi; ne faremo quattro
 per obbligo in ogni piazza, e volendone di più, ci farete un
 regalo di dieci zecchini per ogni muta.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Anche qui non c'è male.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>L'orchestra poi, deve esser magnifica.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Questo s'intende.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Abiti sempre nuovi.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Ho il sarto in casa.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Il mio staffiere fa la parte muta, e si contenterà
 di venti scudi il mese.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Anche il servitore è discreto.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Tutto va bene.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Va benissimo.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>La cosa è aggiustata.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Aggiustatissima.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Dunque...</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Dunque può andarsene, che noi non abbiamo bisogno di
 lei.</p>
           </sp>
-          <sp>
+          <sp who="#tutti">
             <speaker>TUTTI</speaker>
             <p>Bravo, bravo <emph>(con allegria)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Come! Mi disprezzate così?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Cosa credete, signora mia, che i comici abbiano
 bisogno per far fortuna, dell'animo della vostra musica? Pur
@@ -3677,12 +3720,12 @@ imboccare un paio di arie, come i pappagalli, e a forza di
 uscir di tuono vi fate batter le mani. Signora virtuosa, la
 riverisco <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Ecco qui. I comici sono sempre nemici dei virtuosi
 di musica.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Non è vero, signora, non è vero. I comici sanno
 rispettare quei musici, che hanno del merito, della virtù;
@@ -3695,12 +3738,12 @@ fra' comici mediocri, come siamo noi, che fra i cattivi
 musici, coi quali sarete sin'ora stata. Signora virtuosa a
 lei m'inchino <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Questa prima donna avrà fatto da principessa, e si
 crede di esser ancora tale.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Come voi, che avrete veduti i cartoni di qualche
 libro di musica, e vi date a credere di essere virtuosa. È
@@ -3710,178 +3753,178 @@ pieno di nobiltà, e se prima venivano da voi per ammirare, e
 da noi per ridere; ora vengono da noi per goder la commedia,
 e da voi per la conversazione <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Sono ardite davvero queste commedianti, signori
 miei, non mi credeva d'avere un simile trattamento.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Sareste stata meglio trattata, se foste venuta con
 miglior maniera a parlarci.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Noi altre virtuose parliamo quasi tutte così.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>E noi altri comici rispondiamo così <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Sia maladetto quando son qui venuta.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>Certo che ha fatto male a venir a sporcare i
 virtuosi suoi piedi sulle tavole della commedia.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Voi, chi siete?</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>Il Dottor per servirla.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Dottor di commedia?</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>Com'ella virtuosa di teatro.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Che vuol dire, Dottore senza dottrina.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>Che vuol dire: virtuosa senza saper né legger; né
 scrivere <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Ma questo è troppo; se qui testo, ci va della mia
 riputazione. Staffiere, voglio andar via.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Siora virtuosa, se la volesse restar servida a
 magnar quattro risi coi commedianti, l'è padrona.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Oh voi siete un uomo proprio, e civile.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Mi no son padron de casa, mal el capo di compagnia
 l'è tanto mio amigo, che se ghe la condurrò su, so che el la
 vederà volentiera.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Ma le donne, mi perderanno il rispetto?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Basta, che la se contegna con prudenza, e la
 vederà, che tutte le ghe farà ciera.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Andate ditelo al capo di compagnia, e s'egli
 m'invita, può essere, che mi lasci indurre a venire.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Vado subito. (Ho inteso. La musica de sta patrona,
 l'è compagna della poesia del sior Lelio. Fame tanta, che fa
 paura) <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Signora Eleonora, a me che sono vostro conoscente
 antico, potete parlare con libertà. Come vanno le cose
 vostre?</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Male assai. L'impresario dell'opera, in cui io
 recitava, è fallito; ho perduta la paga, ho dovuto far il
 viaggio a mie spese, e per dirvi tutto, non ho altro, che
 quello, che mi vedete intorno.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Anch'io, signora mia, sono nello stesso caso, e se
 volete prendere il partito, che ho preso io, starete bene
 ancor voi.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>A che cosa vi siete voi appigliato?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>A fare il comico.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Ed io dovrò abbassarmi a tal segno?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Signora mia, come state d'appetito?</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Alquanto bene.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Ed io benissimo. Andiamo a desinare, che poi ne
 parleremo.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Il capo di compagnia non mi ha mandato l'invito.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Non importa: andiamo, che è galantuomo. Non vi
 rifiuterà.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Ho qualche difficoltà.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Se avete difficoltà voi, non l'ho io. Vado a
 sentire l'armonia de' cucchiai, che è la più bella musica di
 questo mondo <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Staffiere, che facciamo?</p>
           </sp>
-          <sp>
+          <sp who="#staffiere">
             <speaker>STAFFIERE</speaker>
             <p>Io ho una fame, che non posso più.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Andiamo, o non andiamo?</p>
           </sp>
-          <sp>
+          <sp who="#staffiere">
             <speaker>STAFFIERE</speaker>
             <p>Andiamo per amor del Cielo.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Bisognerà superar la vergogna. Ma che farò? Mi
 lascierò persuadere a far la comica? Mi regolerò secondo la
@@ -3900,22 +3943,22 @@ mormorare <emph>(parte collo staffiere)</emph>.</p>
           <stage>
             <emph>Ottavio, e Florindo.</emph>
           </stage>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ora la compagnia è veramente compiuta. Il signor
 Lelio, e la signora Eleonora suppliscono a due persone,
 ch'erano necessarie.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Chi sa se saranno buoni da recitare?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Gli proverete; ma io giudico, che abbiano a
 riuscire ottimamente.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Poi converrà osservare il loro modo di vivere. Uno
 ha in capo la poesia, l'altra la musica; non vorrei che
@@ -3924,58 +3967,58 @@ fo capitale della quiete nella mia compagnia, che stimo più
 un personaggio di buoni costumi, che un bravo comico, che
 sia torbido, e di mal talento.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>E così va fatto. La buona armonia fra compagni
 contribuisce al buon esito delle commedie. Dove sono
 dissensioni, gare, invidie, gelosie, tutte le cose vanno
 male.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Io non so come la signora Eleonora siasi indotta in
 un momento a voler far la comica.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>La necessità la conduce a procacciarsi questo poco
 di pane.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Quando sarà rimessa in buono stato, farà come tanti
 altri, non si ricorderà del benefizio, e ci volterà le
 spalle.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Il mondo è sempre stato così.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>L'ingratitudine è una gran colpa.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Eppure tanti sono gl'ingrati.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Osservate il signor Lelio, che medita qualche cosa
 per far prova della sua abilità.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ora verrà da voi a farsi sentire. Non gli voglio
 dar soggezione.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Sì fate bene a partire. Andate dalla signora
 Eleonora, e quando mi sarò sbrigato dal poeta, mandatemi la
 virtuosa.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Poeta salvatico, e virtuosa ridicola <emph>(parte)</emph>.</p>
           </sp>
@@ -3985,44 +4028,44 @@ virtuosa.</p>
           <stage>
             <emph>Ottavio, poi Lelio.</emph>
           </stage>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Ecco il signor Lelio, che viene con passo grave.
 Farà probabilmente qualche scena.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p><emph>Sono stato per rivedere la mia bella, e non avendo avuto la fortuna di ritrovarla, voglio portarmi a rintracciarla al mercato</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Signor Lelio, con chi intendete di parlare?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Non vedete, ch'io recito?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Capisco, che recitate; ma recitando, con chi
 parlate?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Parlo da me stesso. Questa è un'uscita, un
 soliloquio.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>E parlando da voi medesimo, dite: <emph>Sono stato a riveder la mia bella</emph>? Un uomo da se stesso, non parla così.
 Pare, che venghiate in scena a raccontare a qualche persona
 dove siete stato.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Ebbene, parlo col popolo.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Qui vi voleva. E non vedete, che col popolo non si
 parla? Che il comico deve immaginarsi, quando è solo, che
@@ -4030,48 +4073,48 @@ nessuno lo senta, e che nessuno lo veda? Quello di parlare
 col popolo è un vizio intollerabile, e non si deve
 permettere in verun conto.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Ma se quasi tutti quelli, che recitano
 all'improvviso fanno così. Quasi tutti, quando escono soli
 vengono a raccontare al popolo dove sono stati, e dove
 vogliono andare.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Fanno male, malissimo, e non si devono seguitare</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Dunque non si faranno mai soliloqui.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Signor sì, i soliloqui sono necessari per ispiegare
 gl'interni sentimenti del cuore, dar cognizione al popolo
 del proprio carattere, e mostrar gl'effetti, e i cambiamenti
 delle passioni.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Ma come si fanno i soliloqui senza parlare al
 popolo?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Con una somma facilità: sentite il vostro discorso
 regolato, e naturale. In vece di dire: <emph>Sono stato dalla mia bella, e non l'ho ritrovata; voglio andarla a ricercare, ecc.</emph> Si dice così: <emph>Fortuna ingrata, tu che mi vietasti il contento di rivedere nella propria casa il mio bene, concedimi che possa rinvenirla</emph>...</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Al mercato.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Oh questa è più graziosa! Volete andar a ritrovare
 la vostra bella al mercato?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Sì signore, al mercato. Mi figuro, che la mia bella
 sia una rivendugliola, e se mi aveste lasciato finire,
@@ -4079,7 +4122,7 @@ avreste sentito nell'argomento, chi sono io, chi è colei,
 come ci siamo innamorati, e come penso di conchiudere le
 nostre nozze.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Tutta questa roba volevate dire da voi solo? Vi
 serva di regola, che mai non si fanno gli argomenti della
@@ -4094,41 +4137,41 @@ si è dividere l'argomento stesso in più scene, e a poco, a
 poco andarlo dilucidando, con piacere, e con sorpresa degli
 ascoltanti.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Orsù, signor Ottavio, all'improvviso non voglio
 recitare. Voi avete delle regole, che non sono comuni, ed io
 che sono principiante, le so meno degli altri. Reciterò
 nelle commedie studiate.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Bene; ma vi vuol tempo avanti che impariate una
 parte, e che io vi possa sentire.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Vi reciterò qualche cosa del mio.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Benissimo; dite su, che v'ascolto.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Vi reciterò un pezzo di commedia in versi.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>In versi? Mi dispiace.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Eppure le buone commedie italiane devono essere
 scritte in versi. Così hanno fatto i nostri antichi, e così
 vogliono che si faccia alcuni moderni.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Venero gl'antichi, rispetto i moderni, ma non sono
 di ciò persuaso. La commedia deve essere in tutto
@@ -4137,24 +4180,24 @@ verso. Oh mi direte, il verso non si ha da conoscere, e dee
 all'orecchio parer prosa. Se non si ha da conoscere il
 verso, se deve parer prosa, dunque scrivete in prosa.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Non volete, che vi reciti questi versi?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Recitateli pure. Ma ditemi in confidenza, sono
 vostri?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Ho paura di no.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>E di chi sono?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Ve lo dirò poi. Questa è una scena, che fa il padre
 colla figlia, persuadendola a non maritarsi.</p>
@@ -4179,53 +4222,53 @@ colla figlia, persuadendola a non maritarsi.</p>
               <l>Per consigliarti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Questi effettivamente non paiono versi, e duro
 fatica a credere, che siano versi.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Volete sentire se sono versi? Ecco, udite, come si
 fanno conoscere quando si vuole <emph>(recita i medesimi versi declamandoli per far conoscere il metro)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>È vero, sono versi, e non paiono versi. Caro amico,
 ditemi di chi sono?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Voi gli dovreste conoscere.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Eppure non gli conosco.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Sono dell'autore delle vostre commedie.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Com'è possibile, s'egli non ha mai fatto commedie in
 versi, e ha protestato di non volerne fare?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Effettivamente non ne vol fare; ma a me, che sono
 poeta mi ha confidato questa sua scena.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Dunque lo conoscete?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Lo conosco, e spero arrivar anch'io a comporre
 delle commedie com'egli ha fatto.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Eh figliuolo, bisogna prima consumar sul teatro
 tanti anni, quanti ne ha egli consumati, e poi potrete
@@ -4236,23 +4279,23 @@ studio, una lunga pratica, ed una continova instancabile
 osservazione del teatro; dei costumi, e del genio delle
 nazioni.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Alle corte, sono buono da recitare?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Siete sufficiente.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Mi accettate nella vostra compagnia?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Vi accetto con ogni soddisfazione.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Quand'è così, son contento. Attenderò a recitare, e
 lascierò l'umore del comporre; giacché per quel, che sento,
@@ -4265,21 +4308,21 @@ dire le parole, che la compongono.</p>
           <stage>
             <emph>Ottavio, poi Eleonora.</emph>
           </stage>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Questo giovine ha del brio. Pare un poco girellaio,
 come dicono i fiorentini, ma per la scena vi vuole sempre
 uno, a cui addattar si possano i caratteri più brillanti.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Serva, signor Ottavio.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Riverisco la signora virtuosa.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Non mi mortificate d'avvantaggio. So benissimo,
 che con poco garbo mi sono a voi presentata, che aveva
@@ -4291,7 +4334,7 @@ smentita la massima di chi crede, che le femmine del teatro,
 siano poco ben costumate, e traggano il loro guadagno parte
 dalla scena, e parte dalla casa.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Per nostra consolazione, non solo è sbandito
 qualunque reo costume nelle persone, ma ogni scandalo dalla
@@ -4301,12 +4344,12 @@ gesti scorretti, scene lubriche, di mal esempio. Vi possono
 andar le fanciulle, senza timor d'apprendere cose immodeste,
 o maliziose.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Orsù, signor Ottavio, io voglio essere comica, e
 mi raccomando alla vostra assistenza.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Raccomandatevi a voi medesima; che vale a dire,
 studiate, osservate gli altri, imparate bene le parti, e
@@ -4317,19 +4360,19 @@ Un tale applauso suol essere equivoco. Molti battono per
 costume, altri per passione, alcuni per genio, altri per
 impegno, e molti ancora, perché sono pagati dai protettori.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Io protettori non ne ho.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Siete stata cantatrice, e non avete protettori?</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Io non ne ho, e mi raccomando a voi.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Io sono il capo di compagnia; io amo tutti
 ugualmente, e desidero, che tutti si facciano onore per il
@@ -4337,64 +4380,64 @@ loro, e per il mio interesse: ma non uso parzialità a
 nessuno, e specialmente alle donne, perché, per quanto siano
 buone, fra loro s'invidiano.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Ma non volete nemmeno provarmi, se sono capace di
 sostenere il posto, che mi date di terza donna?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Oh questo poi sì, mentre il mio interesse vuole, che
 mi assicuri della vostra abilità.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Vi dirò qualche pezzo di recitativo, che so.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Ma non in musica.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Lo dirò senza musica. Reciterò una scena della
 <emph>Didone bernesca</emph>, composta dal signor Lelio.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Di quella, che ha fatto fallire l'impresario?</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Sentite <emph>(si volta verso Ottavio a recitare)</emph>:
 <emph>Enea d'Asia splendore</emph>...</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Con vostra buona grazia. Voltate la vita verso
 l'udienza.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Ma se ho da parlare con Enea.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Ebbene; si tiene il petto verso l'udienza, e con
 grazia si gira un poco il capo verso il personaggio;
 osservate:
 <emph>Enea d'Asia splendore</emph>...</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>In musica, non mi hanno insegnato così.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Eh lo so, che voi altre non badate ad altro, che
 alle cadenze.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <lg rend="italic">
               <l>Enea d'Asia splendore,</l>
@@ -4405,15 +4448,15 @@ alle cadenze.</p>
               <l>Ballano la furlana anco le torri? </l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Basta così; non dite altro per amor del Cielo.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Perché? recito tanto male?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>No quanto al recitare sono contento, ma non posso
 sofferire di sentir a porre in ridicolo i bellissimi, e
@@ -4424,12 +4467,12 @@ ma si guarderà egli di farlo mai più. Troppo obbligo abbiamo
 alle opere di lui, dalle quali tanto profitto abbiamo noi
 ricavato.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Dunque vi pare, ch'io possa sufficientemente
 passare per recitante?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Per una principiante siete passabile; la voce non è
 ferma, ma questa si fa coll'uso del recitare. Badate bene di
@@ -4460,23 +4503,23 @@ arriva inaspettata la parola del suggeritore, e si recita
 con sgarbo, e senza naturalezza; tutte cose che tendono a
 rovinar il mestiere, e a precipitare le commedie.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Vi ringrazio dei buoni documenti, che voi mi date;
 procurerò di metterli in pratica.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Quando siete in libertà; e che non recitate, andate
 agli altri teatri. Osservate come recitano i buoni comici,
 mentre questo è un mestiere, che s'impara più colla pratica,
 che colle regole.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Anche questo non mi dispiace.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Un altro avvertimento voglio darvi, e poi andiamo, e
 lasciamo, che i comici provino il resto della commedia, che
@@ -4492,7 +4535,7 @@ vi vede mal volentieri, dissimulate; mentre l'adulazione è
 vizio, ma una savia dissimulazione è sempre stata virtù
 <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Questo capo di compagnia, mi ha dato più
 avvertimenti di quello, che faccia un maestro di collegio il
@@ -4507,58 +4550,58 @@ prime, non delle ultime almeno <emph>(parte)</emph>.</p>
           <stage>
             <emph>Il Suggeritore, poi Rosaura, ed il Dottore con maschera.</emph>
           </stage>
-          <sp>
+          <sp who="#suggeritore">
             <speaker>SUGGERITORE</speaker>
             <p>Animo, signori, che il tempo passa, e vien sera.
 Tocca a Rosaura, e al Dottore <emph>(entra)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>
               <emph>Figliuola mia, da che procede mai questa tua malinconia? È possibile, che tu non lo voglia confidare ad un padre, che ti ama?</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p><emph>Per amor del Cielo, non mi tormentate</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p><emph>Vuoi un abito? Te lo farò. Vuoi che andiamo in campagna? Ti condurrò. Vuoi una festa di ballo? La ordinerò. Vuoi marito? Te lo</emph>...</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p><emph>Ahi!</emph> (sospirando).</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>
               <emph>Sì, te lo darò. Dimmi un poco, la mia ragazza, sei tu innamorata?</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p><emph>Signor padre, compatite la mia debolezza, sono innamorata pur troppo</emph> (piangendo).</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>
               <emph>Via, non piangere, ti compatisco. Sei in età da marito, ed io non lascierò di consolarti, se sarà giusto. Dimmi; chi è l'amante, per cui sospiri?</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p><emph>È il figlio del signor Pantalone de' Bisognosi</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p><emph>Il giovane non può essere migliore. Son contentissimo. S'egli ti brama, te lo darò</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p><emph>Ahi!</emph> (respirando)</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p><emph>Sì, te lo darò, te lo darò</emph>.</p>
           </sp>
@@ -4568,83 +4611,83 @@ Tocca a Rosaura, e al Dottore <emph>(entra)</emph>.</p>
           <stage>
             <emph>Colombina, e i detti.</emph>
           </stage>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p><emph>Poverino. Non ho core da vederlo penare</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>
               <emph>Cosa c'è Colombina?</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p><emph>Vi è un povero giovinotto, che passeggia sotto le finestre di questa casa, e piange, e si dispera, e dà la testa nelle muraglie</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p><emph>Oimè! Chi è egli? Dimmelo</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p><emph>È il povero signor Florindo</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p><emph>Il mio bene, il mio cuore, l'anima mia. Signor padre, per carità</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p><emph>Sì, cara figlia voglio consolarti. Presto, Colombina, chiamalo, e digli, ch'io gli voglio parlare</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p><emph>Subito, non perdo tempo; quando si tratta di far servizio alla gioventù, mi consolo tutta</emph> (parte).</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p><emph>Caro il mio caro padre, che mi vuol tanto bene</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p><emph>Sei l'unico frutto dell'amor mio</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>
               <emph>Me lo darete per marito?</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p><emph>Te lo darò, te lo darò</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p><emph>Ma vi è una difficoltà</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>
               <emph>E quale?</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p><emph>Il padre di Florindo non si contenterà</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>
               <emph>No? Per qual ragione?</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p><emph>Perché anche il buon vecchio è innamorato di me</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p><emph>Lo so, lo so, ma non importa; rimedieremo anche a questo</emph>.</p>
           </sp>
@@ -4654,77 +4697,77 @@ Tocca a Rosaura, e al Dottore <emph>(entra)</emph>.</p>
           <stage>
             <emph>Florindo, e i detti.</emph>
           </stage>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p><emph>Ecco, eccolo, che muore dalla consolazione</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p><emph>(Benedetti quegli occhi; mi fanno tutta sudare)</emph>
 (da sé).</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p><emph>Signor Dottore, perdoni, se incorraggito da Colombina... perché se la signora Rosaura... Ma anzi il suo signor padre... Compatisca, non so cosa mi dica</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>
               <emph>Intendo, intendo; siete innamorato della mia figliuola, e la vorreste per moglie, non è così?</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p><emph>Altro non desidero</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p><emph>Ma sento a dire, che vostro padre abbia delle pretensioni ridicole</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p><emph>Il padre è rivale del figlio</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p><emph>Dunque non si ha da perder tempo. Bisogna levargli la speranza di poterla ottenere</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>
               <emph>Ma come?</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p><emph>Dando immediatamente la mano a Rosaura</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p><emph>Questa è una cosa, che mi rallegra</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p><emph>Questa è una cosa, che mi consola</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p><emph>Questa è una cosa, che mi fa crepar dall'invidia</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p><emph>Animo dunque, che si conchiuda, datevi la mano</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p><emph>Eccola, unita al mio cuore</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p><emph>Eccola, in testimonio della mia fede</emph> (si dànno la
 mano).</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p><emph>Oh cari! Oh che bella cosa! Mi sento venir l'acqua in bocca</emph>.</p>
           </sp>
@@ -4734,80 +4777,80 @@ mano).</p>
           <stage>
             <emph>Pantalone, e i detti.</emph>
           </stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>
               <emph>Com'èla? Coss'è sto negozio?</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p><emph>Signor Pantalone, benché non vi siete degnato di parlar meco, ho rilevata la vostra intenzione, ed io ciecamente l'ho secondata</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>
               <emph>Come? Intenzion de cossa?</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>
               <emph>Ditemi di grazia; non avete voi desiderato, che mia figlia fosse sposa del signor Florindo?</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p><emph>No xè vero gnente</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p><emph>Avete pur detto a lei di volerla maritare in casa vostra</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p><emph>Sior sì, ma no co mio fio</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>
               <emph>Dunque con chi?</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p><emph>Con mi, con mi</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p><emph>Non credeva mai, che in questa età vi sorprendesse una simile malinconia. Compatitemi, ho equivocato, ma questo equivoco ha prodotto il matrimonio di vostro figlio con Rosaura mia figlia</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p><emph>No sarà mai vero, no l'accorderò mai</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p><emph>Anzi sarà senz'altro. Se non l'accordate voi, l'accordo io. Voi, e vostro figlio avete fatto all'amore con la mia figliuola; dunque o il padre, o il figlio l'aveva a sposare. Per me, tanto m'era uno, quanto l'altro. Ma siccome il figlio è più giovine, è più lesto di gamba, egli è arrivato prima, e voi, che siete vecchio, non avete potuto finir la corsa, e siete rimasto a mezza strada</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p><emph>È il solito de' vecchi dopo quattro passi bisogna che si riposino</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p><emph>Ve digo, che questa la xè una baronada, che un pare, non ha da far el mezzan alla putta, per trappolar el fio d'un galantomo, d'un omo d'onor</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p><emph>Via, signor padre, non andate in colera</emph> (a
 Pantalone).</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p><emph>E un galantuomo, un uomo d'onore, non ha da sedurre la figlia di un buon amico, contro le leggi dell'ospitalità, e della buona amicizia</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p><emph>Per amor del Cielo, non vi alterate</emph> (al Dottore).</p>
           </sp>
@@ -4817,7 +4860,7 @@ Pantalone).</p>
           <stage>
             <emph>Lelio, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Bravi, signori comici, bravi. Veramente questa è
 una bella scena. Il signor capo di compagnia mi va dicendo,
@@ -4825,30 +4868,30 @@ che il teatro si è riformato, che ora si osservano tutte le
 buone regole, e pur questa vostra scena è uno sproposito;
 non può stare, e non si può fare così.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Perché non può stare? Qual è lo sproposito, che
 notate voi in questa scena?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>È uno dei più grandi, e dei più massicci, che dir
 si possa.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Chi èla ela, patron? El proto delle commedie?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>È un poeta famosissimo <emph>(fa il cenno, che mangia bene)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Sa perfettamente a memoria la <emph>Buccolica</emph> di
 Virgilio.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>So, e non so; ma so che questa è una cattiva scena.</p>
           </sp>
@@ -4858,27 +4901,27 @@ Virgilio.</p>
           <stage>
             <emph>Ottavio, e i detti.</emph>
           </stage>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Cosa c'è? non si finisce di provare?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Abbiamo quasi finito, ma il signor Lelio grida, e
 dice, che questa scena va male.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Per qual cagione lo dice, signor Lelio?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Perché ho inteso dire, che Orazio nella sua
 <emph>Poetica</emph> dia per precetto, che non si facciano lavorare in
 scena più di tre persone in una volta, e in questa scena
 sono cinque.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Perdonatemi, dite a chi ve l'ha dato ad intendere,
 che Orazio non va inteso così. Egli dice: <emph>Nec quarta loqui</emph>
@@ -4894,11 +4937,11 @@ uno disturbi l'altro, come accordano tutti i migliori
 autori, li quali hanno interpretato il passo d'Orazio da voi
 allegato.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Anche qui dunque ho detto male.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Prima di parlare sopra i precetti degli antichi,
 conviene considerare due cose; la prima: il vero senso, con
@@ -4907,13 +4950,13 @@ quel, che hanno scritto; mentre siccome si è variato il modo
 di vestire, di mangiare, e di conversare, così è anche
 cangiato il gusto, e l'ordine delle commedie.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>E così questo gusto varierà ancora, e le commedie
 da voi adesso portate in trionfo, diverranno anticaglie,
 come la <emph>Statua</emph>, il <emph>Finto Principe</emph>, e <emph>Madama Pataffia</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Le commedie diverranno antiche dopo averle fatte, e
 rifatte, ma la maniera di far le commedie spererei, che
@@ -4923,57 +4966,57 @@ caratteri infiniti in genere, sono infiniti in spezie,
 mentre ogni virtù, ogni vizio, ogni costume, ogni difetto,
 prende aria diversa dalla varietà delle circostanze.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Sapete cosa piacerà sempre sul teatro?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>E che cosa?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>La critica.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Basta che sia moderata. Che prenda di mira
 l'universale, e non il particolare, il vizio, e non il
 vizioso; che sia mera critica, e non inclini alla satira.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Signor capo di compagnia, con sua buona grazia, una
 delle due, o ci lasci finir di provare, o permetta, che ce
 n'andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Avete ragione. Questo signor comico novello, mi fa
 usare una mala creanza. Quando i comici provano, non
 s'interrompono <emph>(a Lelio)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Io credeva, che avessero finito quando <emph>Florindo</emph>,
 e <emph>Rosaura</emph> si sono sposati, mentre si sa, che tutte le
 commedie finiscono coi matrimoni.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Non tutte, non tutte.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Oh quasi tutte, quasi tutte.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Sior Ottavio, mi fenisso in te la commedia prima
 dei altri, se contentela, che diga la mia scena, e che vaga
 via?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Sì, fate come volete.</p>
           </sp>
@@ -4983,160 +5026,160 @@ via?</p>
           <stage>
             <emph>Il Suggeritore, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#suggeritore">
             <speaker>SUGGERITORE</speaker>
             <p>Cospetto del diavolo! Si finisce, o non si finisce
 questa maledetta commedia?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Son qua, dixè su, che ve vegno drio.</p>
           </sp>
-          <sp>
+          <sp who="#suggeritore">
             <speaker>SUGGERITORE</speaker>
             <p>Sian maladette le prove.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Ma voi sempre gridate. Quando si prova, vorreste,
 che si andasse per le poste per finir presto. Quando si fa
 la commedia, se qualcheduno parla dietro le scene,
 taroccate, che vi si sentono da per tutto.</p>
           </sp>
-          <sp>
+          <sp who="#suggeritore">
             <speaker>SUGGERITORE</speaker>
             <p>Se tarocco, ho ragione, mentre la scena è sempre
 piena di gente, che fa romore, e mi maraviglio di lei, che
 lasci venir tanta gente in scena, che non ci possiamo
 movere.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Per l'avvenire non sarà così. Voglio assolutamente
 la scena sgombrata.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Io non so, che piacere abbiano a venire a veder la
 commedia in scena.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Lo fanno per non andare nella platea.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Eppure la commedia si gode meglio in platea, che in
 scena.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Sì, ma taluni, sputano dai palchi, e infastidiscono
 le persone, che sono giù.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Veramente per perfezionare il buon ordine de'
 teatri, manca l'osservanza di questa onestissima pulizia.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Manca un'altra cosa, che non ardisco dirla.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Siamo tra di noi, potete parlare con libertà.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Che nei palchetti non facciano tanto romore.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>È difficile assai.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Per dirla è una gran pena per noi altri comici
 recitare allora quando si fa strepito nell'udienza. Bisogna
 sfiatarsi per farsi sentire, e non basta.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>In un pubblico bisogna aver pazienza. E alle volte,
 che si sentono certi fischietti, certe cantatine da gallo?
 Gioventù allegra; vi vuol pazienza.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Mi dispiace, che disturbano gli altri.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>E quando si sentono a sbadigliare?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Segno, che la commedia non piace.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>Eh qualche volta lo fanno con malizia; e per lo più
 nelle prime sere delle commedie nuove, per rovinarle, se
 possono.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Sapete cosa cantano quelli, che vanno alla
 commedia? La canzonetta d'un intermezzo: <emph>Signor mio, non vi è riparo, io qui spendo il mio denaro, voglio far quel, che mi par</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#suggeritore">
             <speaker>SUGGERITORE</speaker>
             <p>Vado, o non vado?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Via, andè, che ve mando.</p>
           </sp>
-          <sp>
+          <sp who="#suggeritore">
             <speaker>SUGGERITORE</speaker>
             <p>Come parla, signor Pantalone?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Colla bocca, compare.</p>
           </sp>
-          <sp>
+          <sp who="#suggeritore">
             <speaker>SUGGERITORE</speaker>
             <p>Avverta bene, e mi porti rispetto, altrimenti si
 pentirà. Le farò dire degli spropositi in scena, se non mi
 tratterrà bene. Mentre se i commedianti si fanno onore, è a
 cagione della mia buona maniera di suggerire.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Certamente tutto contribuisce al buon esito delle
 cose.</p>
           </sp>
-          <sp>
+          <sp who="#suggeritore">
             <speaker>SUGGERITORE</speaker>
             <p><emph>So, che non vorreste, che vostro figlio</emph> (di
 dentro suggerendo)<emph>. So che non vorreste, che vostro figlio</emph>
 (più forte).</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Dottor, a vu.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTAVIO</speaker>
             <p>Ah son qui. <emph>So, che non vorreste, che vostro figlio si ammogliasse, perché voi siete innamorato della mia figliuola, ma questa vostra debolezza fa torto al vostro carattere, alla vostra età. Rosaura non si sarebbe mai persuasa di sposar voi; dunque era inutile il vostro amore, ed è un atto di giustizia, che contentate il vostro figlio; e se amate Rosaura, farete un'azione eroica, da uomo onesto, da uomo savio, e prudente a cederla a una persona, che la renderà felice, e contenta, e avrete voi la consolazione di essere stato la causa della sua più vera felicità</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p><emph>Siben, son un galantomo, son un omo d'onor, vogio ben a sta puta, e vogio far un sforzo per desmostrarghe l'amor, che ghe porto. Florindo sposerà vostra fia, ma perché vostra fia l'ho vardada con qualche passion, e no me la posso desmentegar, no vogio metterme a rischio, avendola in casa, de viver continuamente all'inferno. Florindo, fio mio, el Cielo te benediga. Sposa siora Rosaura; che la lo merita, e resta in casa con ela, e co so sior pare, fina che vivo mi, e te passerò un onesto, e comodo trattamento. Niora, za, che no m'avè volesto ben a mi, vogiè ben a mio fio. Trattelo con amor, e con carità, e compatì le debolezza de un povero vecchio, orbà più dal vostro merito, che dalle vostre bellezze. Dottor caro, vegnì da mi, che metteremo in carta ogni cosa. Se ve bisogna robba, bezzi, son qua. Spenderò, farò tutto, ma in sta casa no ghe vegno mai più. Oimè, gh'ho el cuor ingroppà me sento, che no posso più</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p><emph>Povero padre mi fa pietà</emph>.</p>
           </sp>
@@ -5146,49 +5189,49 @@ dentro suggerendo)<emph>. So che non vorreste, che vostro figlio</emph>
           <stage>
             <emph>Brighella, Arlecchino, e i detti.</emph>
           </stage>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p><emph>E cusì per tornar al nostro proposito. Colombina dème la man</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p><emph>Colombina non farà sto torto a Brighella</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Signor Ottavio, ecco appunto, come termina il mio
 soggetto, che voi non avete voluto sentire <emph>(cava il foglietto, e legge)</emph>. <emph>Florindo sposa Rosaura. Arlecchino Colombina; e coi matrimoni termina la commedia</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Siete veramente spiritoso.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Anzi vi dirò di più...</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Sior Ottavio, gh'è altro da provar?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Per ora basta così.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>La podeva aver anca la bontà de sparagnarme sta gran
 fadiga <emph>(si cava la maschera)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Perché?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Perché sta sorte de scene, le fazzo co dormo.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Non dite così, signor Arlecchino, non dite così.
 Anco nelle piccole scene si distingue l'uomo di garbo. Le
@@ -5201,55 +5244,55 @@ tutte, e guardarsi da quelle stroppiature, che sono comuni a
 tutti i secondi zanni. Bisogna crear sempre qualche cosa del
 suo, e per creare bisogna studiare.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>La me perdona, che se pol crear anca senza studiar.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Ma come?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Far come che ho fatto mi, maridarse, e far nascer
 dei fioi <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Questa non è stata cattiva.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Se non si prova altro, anderò via ancor</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Ora anderemo tutti.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Possiamo andare dal nostro signor capo, che ci darà
 il caffè.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Padroni, vengano pure.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Una cosa voleva dirvi per ultimo, e poi ho finito.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Dica pure...</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Il mio soggetto finiva con un sonetto, vorrei, che
 mi diceste, se sia ben fatto, o malfatto terminare la
 commedia con un sonetto.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Dirò; i sonetti in qualche commedia stanno bene, e
 in qualche commedia stanno male. Anche il nostro poeta
@@ -5264,11 +5307,11 @@ potevano risparmiare; e nelle altre non ha fatto sonetti al
 fine, perché questi assolutamente senza una ragione non si
 possono, e non si devono fare.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Manco male, che ha errato anche il vostro poeta.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Egli è uomo, come gl'altri, e può facilmente
 ingannarsi, anzi colle mie stesse orecchie l'ho sentito dir
@@ -5280,12 +5323,12 @@ si contenta di aver dato uno stimolo alle persone dotte, e
 di spirito, per rendere un giorno la riputazione al teatro
 italiano.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Signor Ottavio, sono stanca di star in piedi, avete
 ancor finito di chiaccherare?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Andiamo pure: è terminata la prova, e da quanto
 abbiamo avuto occasione di discorrere, e di trattare in

--- a/tei/goldoni-il-ventaglio.xml
+++ b/tei/goldoni-il-ventaglio.xml
@@ -84,6 +84,52 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="evaristo">
+            <persName>Evaristo</persName>
+          </person>
+          <person xml:id="barone">
+            <persName>Barone del Cedro</persName>
+          </person>
+          <person xml:id="limoncino">
+            <persName>Limoncino</persName>
+          </person>
+          <person xml:id="candida">
+            <persName>Signora Candida</persName>
+          </person>
+          <person xml:id="geltruda">
+            <persName>Signora Geltruda</persName>
+          </person>
+          <person xml:id="conte">
+            <persName>Conte di Rocca Marina</persName>
+          </person>
+          <person xml:id="timoteo">
+            <persName>Timoteo</persName>
+          </person>
+          <person xml:id="crespino">
+            <persName>Crespino</persName>
+          </person>
+          <person xml:id="coronato">
+            <persName>Coronato</persName>
+          </person>
+          <person xml:id="scavezzo">
+            <persName>Scavezzo</persName>
+          </person>
+          <person xml:id="moracchio">
+            <persName>Moracchio</persName>
+          </person>
+          <person xml:id="giannina">
+            <persName>Giannina</persName>
+          </person>
+          <person xml:id="susanna">
+            <persName>Signora Susanna</persName>
+          </person>
+          <person xml:id="tognino">
+            <persName>Tognino</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -156,386 +202,386 @@ porta del palazzino, e sulla facciata del medesimo. Alzata la tenda,
 tutti restano qualche momento senza parlare, ed agendo come si è
 detto, per dar tempo all'uditorio di esaminare un poco la scena.</emph>
           </stage>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Che vi pare di questo caffè? (<emph>al Barone</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Mi par buono.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Per me lo trovo perfetto. Bravo, signor Limoncino,
 questa mattina vi siete portato bene.</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker>LIMONCINO</speaker>
             <p>La ringrazio dell'elogio, ma la prego di non
 chiamarmi con questo nome di Limoncino.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Oh bella! Tutti vi conoscono per questo nome, siete
 famoso col nome di Limoncino. Tutti dicono: andiamo alle
 Case nove a bevere il caffè da Limoncino, e ve ne avete a
 male per questo?</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker>LIMONCINO</speaker>
             <p>Signore questo non è il mio nome.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Oh via da qui innanzi vi chiameremo signor Arancio,
 signor Bergamotto (<emph>bevendo il caffè</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker>LIMONCINO</speaker>
             <p>Le dico che io non son fatto per far il buffone.</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>(<emph>ride forte</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Che ne dice signora Candida?</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>(<emph>si fa fresco col ventaglio e lo rimette sul poggio</emph>). Che vuole ch'io dica? Sono cose da ridere
 veramente.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Via signori, lasciatelo stare quel buon ragazzo,
 egli fa del buon caffè, ed è sotto la mia protezione.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Oh quando è sotto la protezione della signora
 Geltruda, gli si porterà rispetto. (Sentite la buona vedova
 lo protegge) (<emph>piano ad Evaristo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Non dite male della signora Geltruda. Ella è la più
 saggia, e la più onesta donna del mondo (<emph>piano al barone</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Tutto quel che volete, ma si dà aria di protezione
 come lei... il signor Conte, che siede e legge con un'aria
 da giurisdicente (<emph>come sopra</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Oh in quanto a lui, non avete il torto, è una vera
 caricatura, ma è troppo ingiusta la comparazione colla
 signora Geltruda (<emph>come sopra</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Un per un verso, l'altra per l'altro, per me li
 trovo ridicoli tutti due (<emph>come sopra</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>E cosa trovate di ridicolo nella signora Geltruda?</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Troppa dottrina, troppo contegno, troppa
 sufficienza.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Scusatemi, voi non la conoscete (<emph>piano fra loro</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Stimo più la signora Candida cento volte.
 (<emph>Il barone ed Evaristo finiscono di bere il caffè. Si alzano, rendono le tazze a Limoncino. Tutti e due vogliono pagare. Il barone previene; Evaristo lo ringrazia piano. Limoncino con le tazze, e i denari va in  bottega. In questo tempo Timoteo pesta più forte</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Sì, è vero... La nipote ha del merito... (Non
 vorrei che costui mi fosse rivale) (<emph>da sé</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Eh! signor Timoteo (<emph>grave</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>TIMOTEO</speaker>
             <p>Che mi comanda?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Questo vostro pestamento m'annoia.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>TIMOTEO</speaker>
             <p>Perdoni... (<emph>battendo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Non posso leggere, mi rompete la testa.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>TIMOTEO</speaker>
             <p>Perdoni, or ora ho finito (<emph>seguita, staccia, e ripesta</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Ehi Coronato (<emph>lavorando e ridendo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Cosa volete mastro Crespino?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Il signor Conte non vuole che si batta (<emph>batte forte sulla forma</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Che diavolo d'impertinenza! Non la volete finire
 questa mattina?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Signor illustrissimo non vede cosa faccio?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>E cosa fate? (<emph>con sdegno</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Accomodo le sue scarpe vecchie.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Zitto là impertinente (<emph>si mette a leggere</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Coronato! (<emph>ridendo batta, e Timoteo batte</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Or ora non posso più (<emph>dimenandosi sulla sedia</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#scavezzo">
             <speaker>SCAVEZZO</speaker>
             <p>Moracchio (<emph>chiamandolo e ridendo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Cosa c'è Scavezzo?</p>
           </sp>
-          <sp>
+          <sp who="#scavezzo">
             <speaker>SCAVEZZO</speaker>
             <p>Il signor Conte! (<emph>ridendo e burlandosi del Conte</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Zitto, zitto che finalmente è un signore...</p>
           </sp>
-          <sp>
+          <sp who="#scavezzo">
             <speaker>SCAVEZZO</speaker>
             <p>Affamato.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Moracchio (<emph>chiamandolo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Cosa vuoi?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Cosa ha detto Scavezzo?</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Niente, niente bada a te, e fila.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Oh è gentile veramente il mio signor fratello. Mi
 tratta sempre così. (Non vedo l'ora di maritarmi) (<emph>con sdegno volta la sedia, e fila con dispetto</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Cos'è Giannina? Che cosa avete?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Oh se sapeste signora Susanna! Non credo che si
 dia al mondo un uomo più grossolano di mio fratello.</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Eh bene! Son quel che sono. Cosa vorresti dire?
 Finché state sotto di me...</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Sotto di te? Oh, spero che vi starò poco
 (<emph>con dispetto fila</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Via cosa c'è? (<emph>a Moracchio</emph>). Voi sempre
 tormentate questa povera ragazza. (<emph>s'accosta a lei</emph>).
 E non lo merita, poverina.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Mi fa arrabbiare.</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Vuol saper tutto.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Via via basta così.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>È compassionevole il signor Evaristo (<emph>a Candida</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Pare anche a me veramente (<emph>con un poco di passione</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Gran cosa! Non si fa che criticare le azioni
 altrui, e non si prende guardia alle proprie (<emph>a Candida</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>(Ecco questi sono que' dottoramenti ch'io non posso
 soffrire).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>(Povera Giannina! Quando sarà mia moglie, quel
 galeotto non la tormenterà più) (<emph>da sé lavorando</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>(Sì la voglio sposare se non fosse che per levarla
 da suo fratello).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Ebbene signor Barone volete che andiamo?
 (<emph>accostandosi a lui</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Per dirvi la verità, questa mattina non mi sento in
 voglia d'andar alla caccia. Sono stanco di ieri...</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Fate come vi piace. Mi permetterete che ci vada io?</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Accomodatevi. (Tanto meglio per me. Avrò comodo di
 tentare la mia sorte colla signora Candida).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Moracchio.</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Signore.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Il cane ha mangiato?</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Signor sì.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Prendete lo schioppo, e andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Vado a prenderlo subito. Tieni (<emph>a Giannina</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Cosa ho da tenere?</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Tieni questo cane fin che ritorno.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Date qui mala grazia (<emph>prende il cane e lo accarezza, Moracchio va in casa</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>(È proprio una giovane di buon cuore. Non vedo
 l'ora ch'ella divenga mia) (<emph>da sé</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>(Che bella grazia che ha a far carezze! Se le fa
 ad un cane tanto più le farà ad un marito).</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Scavezzo.</p>
           </sp>
-          <sp>
+          <sp who="#scavezzo">
             <speaker>SCAVEZZO</speaker>
             <p>Signore (<emph>si avanza</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Prendete questo schioppo e portatelo nella mia
 camera.</p>
           </sp>
-          <sp>
+          <sp who="#scavezzo">
             <speaker>SCAVEZZO</speaker>
             <p>Sì, signore. (Questo almeno è ricco e generoso.
 Altro che quello spiantato del Conte!) (<emph>porta lo scoppio nell'osteria</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Pensate voi di restar qui per oggi? (<emph>al Barone</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Sì, mi riposerò all'osteria.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Fate preparare che verrò a pranzo con voi.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Ben volentieri, vi aspetto. Signore a buon
 riverirle (<emph>alle signore</emph>). (Partirò per non dar sospetto) (<emph>da sé</emph>).
 Vado nella mia camera, ed oggi preparate per due (<emph>a Coronato ed entra</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>S'accomodi, sarà servita.</p>
           </sp>
@@ -545,130 +591,130 @@ Vado nella mia camera, ed oggi preparate per due (<emph>a Coronato ed entra</emp
           <stage>
             <emph>MORACCHIO, EVARISTO, e dette</emph>
           </stage>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>(<emph>collo scoppio esce di casa, e si fa dare il cane da Giannina</emph>)Eccomi, signore sono con lei.(<emph>ad Evaristo</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Andiamo(<emph>a Moracchio</emph>). Signore mie, se me lo permettono
 vado a divertirmi un poco collo schioppetto(<emph>verso le due signore e prende lo schioppo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>S'accomodi, e si diverta bene.</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>L'auguro buona preda, e buona fortuna.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Son sicuro d'essere fortunato, se sono favorito da'
 suoi auspizi<emph>(a Candida, e va accomodando lo schioppo e gli attrezzi di caccia</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>(Veramente è gentile il signor Evaristo!) (<emph>a Geltruda</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>(Sì è vero. È gentile e compito. Ma nipote mia
 non vi fidate, di chi non conoscete perfettamente).</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>(Per che cosa dite questo signora zia?)</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>(Perché da qualche tempo ho ragione di dirlo).</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>(lo non credo di poter esser condannata...)</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>(No non mi lamento di voi, ma vi prevengo perché
 vi conserviate sempre così).</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>(Ah, è tardo il suo avvertimento. Sono innamorata
 quanto mai posso essere)(<emph>da sé</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Oh tutto è all'ordine: andiamo <emph>(a Moracchio</emph>).
 Nuovamente servitor umilissimo di lor signore <emph>(saluta le due signore in atto di partire</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Serva(<emph>si alza per farli riverenza</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Serva umilissima (<emph>s'alza ancor ella, urta e il ventaglio va in strada</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Oh!(<emph>raccoglie il ventaglio</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Niente, niente.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>La non s'incomodi.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Il ventaglio è rotto, me ne dispiace infinitamente.</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Eh non importa, è un ventaglio vecchio.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Ma io sono la cagione ch'è rotto.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Non si metta in pena di ciò.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Permettano ch'abbia l'onore...(<emph>vorrebbe portarlo in casa</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>La non s'incomodi. Lo dia al servo Tognino(<emph>chiama</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Signora(<emph>a Geltruda</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Prendete quel ventaglio.</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Favorisca(<emph>lo dimanda ad Evaristo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Quando non mi vonno permettere... tenete...(<emph>dà il ventaglio a Tognino che lo prende e va dentro</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Guardate quanta pena si prende, perché si è rotto
 il ventaglio!(<emph>a Geltruda</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Un uomo pulito, non può agir altrimenti. (Lo
 conosco, che c'entra della passione).</p>
@@ -680,216 +726,216 @@ conosco, che c'entra della passione).</p>
             <emph>Tognino sulla terrazza dà il ventaglio alle donne, esse lo
 guardano, e l'accomodano. Evaristo, Susanna, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>(Mi spiace infinitamente, che quel ventaglio si sia
 rotto per causa mia; ma vo' tentare di rimediarvi). Signora
 Susanna(<emph>piano sulla testa</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Signore.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Vorrei parlarvi. Entriamo in bottega.</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Resti servita. S'accomodi (<emph>s'alza</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Moracchio.</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Signore.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Andate innanzi. Aspettatemi all'entrata del bosco,
 ch'or ora vengo (<emph>entra con Susanna</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Se perde il tempo così prenderemo delle zucche, e
 non del selvatico (<emph>via col cane</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Manco male, che mio fratello è partito. Non vedo
 l'ora di poter dire due parole a Crespino; ma non vorrei,
 che Ci fosse quel diavolo di Coronato. Mi perseguita, e non
 lo posso soffrire (<emph>da sé, filando</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Oh oh bella, bellissima (<emph>leggendo</emph>). Signora Geltruda.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Cosa ha trovato di bello signor Conte?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Eh cosa c'entrate voi? Cosa sapete voi che siete un
 ignorantaccio?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>(Ci scometto che ne so più di lei) (<emph>batte forte sulla forma</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Che mi comanda il signor Conte?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Voi che siete una donna di spirito, se sentiste
 quello, ch'io leggo presentemente è un capo d'opera.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>È qualche istoria?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Eh! (<emph>con sprezzatura</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Qualche trattato di filosofia?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Oh! (<emph>come sopra</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Qualche bel pezzo di poesia?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>No (<emph>come sopra</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>E ch'è dunque?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Una cosa stupenda, meravigliosa, tratta dal
 francese: è una novella, detta volgarmente una favola.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>(Maledetto! Una favola! stupenda! maravigliosa!)
 (<emph>batte forte</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>È di Esopo?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>No.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>È di monsieur de la Fontaine?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Non so l'autore, ma non importa... La volete
 sentire?</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Mi farà piacere.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Aspettate. Oh ch'ho perduto il segno. La troverò...
 (<emph>cerca la carta</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Voi che leggete de' buoni libri amate di sentir
 delle favole? (<emph>a Geltruda</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Perché no? Se sono scritte con sale, istruiscono,
 e divertono infinitamente.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Oh, l'ho trovata. Sentite...</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>(Maledetto! legge le favole!) (<emph>pesta forte</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Oh principiate a battere? (<emph>a Crespino</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Non vol che li metta li soprattacchi? (<emph>al Conte, e batte</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>TIMOTEO</speaker>
             <p>(<emph>torna a pestar forte nel mortaio</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ecco qui quest'altro canchero che viene a pestar di
 nuovo. La volete finire? (<emph>a Timoteo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>TIMOTEO</speaker>
             <p>Signore io faccio il mio mestiere (<emph>pesta</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sentite. «Eravi una donzella di tal bellezza...» (<emph>a Geltruda</emph>). Ma quietatevi, o andate a pestare in un altro luogo (<emph>a Timoteo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>TIMOTEO</speaker>
             <p>Signore, mi scusi. Io pago la mia pigione, e non ho
 miglior luogo di questo(<emph>pesta</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Eh andate al diavolo con questo maledetto mortaio.
 Non si può leggere, non si può resistere. Signora Geltruda
 verrò da voi. Sentirete, che pezzo, che robba, che novità(<emph>batte sul libro ed entra in casa di Geltruda</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>È un poco troppo ardito questo signor speziale.
 Andiamo a ricevere il signor Conte(<emph>a Candida</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Andate pure, sapete che le favole non mi divertono.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Non importa, venite, che la convenienza lo vuole.</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Oh questo signor Conte! (<emph>con sprezzo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Nipote mia; rispettate, se volete essere
 rispettata. Andiamo via.</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Sì sì verrò per compiacervi. (<emph>s'alza per andare</emph>).</p>
           </sp>
@@ -900,335 +946,335 @@ rispettata. Andiamo via.</p>
             <emph>Evaristo e Susanna escono dalla bottega. Candida, Susanna,
 e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Come! Ancora qui il signor Evaristo! Non è andato
 alla caccia? Son ben curiosa di sapere il perché (<emph>osserva in dietro</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>La non si lagni di me, perché le assicuro, che le ho
 dato il ventaglio a buonissimo prezzo (<emph>a Evaristo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>(Non v'è più la signora Candida!) Mi dispiace che
 non sia qualche cosa di meglio.</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Non ne ho né di meglio, né di peggio: questo è il
 solo, questo è l'ultimo, che m'era restato in bottega.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Benissimo mi converrà valermi di questo.</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>M'immagino, che ne vorrà fare un presente (<emph>ridendo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Certo ch'io non l'avrò comprato per me.</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Alla signora Candida?</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>(È un poco troppo curiosa la signora Susanna).
 Perché credete voi, ch'io voglia darlo alla signora Candida?</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Perché ho veduto, che si è rotto il suo.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>No, no il ventaglio l'ho disposto diversamente.</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Bene bene lo dia a chi vuole. Io non cerco i fatti
 degl'altri (<emph>siede e lavora</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>(Non li cerca ma li vuol sapere. Questa volta però,
 non l'è andata fatta) (<emph>da sé, e si accosta a Giannina</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Gran segreti colla merciaia. Sarei bene curiosa di
 sapere qualche cosa (<emph>s'avanza un poco</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Giannina (<emph>piano accostandosi a lei</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Signore (<emph>sedendo e lavorando</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Vorrei pregarvi d'una finezza.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Oh cosa dice! comandi se la posso servire.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>So che la signora Candida ha dell'amore per voi.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Sì signor per sua grazia.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Anzi m'ha ella parlato, perché m'interessi presso
 di vostro fratello.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Ma è una gran disgrazia la mia! Sono restata senza
 padre, e senza madre, e mi tocca essere soggetta ad un
 fratello, ch'è una bestia, signore, è veramente una bestia (<emph>fila con sdegno</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Ascoltatemi.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Parli pure, che il filare non mi tura l'orecchie (<emph>altiera filando</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>(Suo fratello è stravagante, ma ha anche ella il
 suo merito mi pare) (<emph>ironico</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>(Che avesse comprato il ventaglio per Giannina, non
 credo mai) (<emph>da sé</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>(Interessi colla merciaia, interessi con Giannina!
 non capisco niente) (<emph>da sé, e si avanza sulla terrazza</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Posso pregarvi di una finezza? (<emph>a Giannina</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Non le ho detto di sì? Non le ho detto che mi
 comandi? Se la rocca le dà fastidio, la butterò via (<emph>s'alza e getta la rocca con dispetto</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>(Quasi quasi non direi altro, ma ho bisogno di
 lei).</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>(Cosa sono mai queste smanie?) (<emph>da sé</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>(Getta via la rocca?) (<emph>da sé, e colla scarpa e martello in mano s'alza e si avanza un poco</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>(Mi pare che si riscaldino col discorso!) (<emph>col libro s'alza e si avanza un poco</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>(Se le facesse un presente non andrebbe in collera) (<emph>da sé osservando</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Via eccomi qua mi comandi (<emph>ad Evaristo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Siate buona, Giannina.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Io non so d'essere mai stata cattiva.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Sapete che la signora Candida ha rotto il
 ventaglio?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Signor sì (<emph>con muso duro</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Ne ho comprato uno dalla merciaia.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Ha fatto bene(<emph>come sopra</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Ma non vorrei lo sapesse la signora Geltruda.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Ha ragione(<emph>come sopra</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>E vorrei che voi glie lo deste secretamente.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Non lo posso servire(<emph>come sopra</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>(Che risposta villana!)</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>(Mi dà ad intendere che va alla caccia, e si ferma
 qui).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>(Quanto pagherei sentire!) (<emph>s'avanza e mostra di lòavorare</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>(Sempre più mi cresce la curiosità) (<emph>s'avanza, fingendo sempre di conteggiare</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Perché non volete farmi questo piacere? (<emph>a Giannina</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Perché non ho ancora imparato questo bel mestiere.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Voi prendete la cosa sinistramente. La signora
 Candida ha tanto amore per voi.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>È vero ma in queste cose...</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Mi ha detto, che vorreste maritarvi a Crespino...(<emph>dicendo così si volta, e vede li due, che ascoltano</emph>).Che fate voi altri? Che baronata è questa?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Io lavoro, signore (<emph>torna a sedere</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Non posso scrivere, e passeggiare? (<emph>torna a sedere</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>(Hanno dei segreti importanti) (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>(Che diavolo ha costei, che tutti gl'uomini le
 corrono dietro?)</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Se non ha altro da dirmi, torno a prendere la mia
 rocca (<emph>prende la rocca</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Sentite: mi ha pregato la signora Candida, acciò
 m'interessi per voi, per farvi avere delle doti, e acciò
 Crespino sia vostro marito.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Vi ha pregato? (<emph>cangia tuono, e getta via la rocca</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Sì, ed io sono impegnatissimo perché ciò segua.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Dov'avete il ventaglio?</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>L'ho qui in tasca.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Date qui, date qui, ma che nessuno veda.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Eccolo (<emph>glielo dà di nascosto</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>(Le dà qualche cosa) (<emph>da sé tirando il collo</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>(Cosa mai le ha dato?) (<emph>da sé tirando il collo</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>(Assolutamente le ha donato il ventaglio) (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>(Ah sì, Evaristo mi tradisce. Il Conte ha detto la
 verità).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Ma vi raccomando la segretezza (<emph>a Giannina</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Lasci far a me, e non dubiti niente.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Addio.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>A buon riverirla.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Mi raccomando a voi.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Ed io a lei (<emph>riprende la rocca, siede e fila</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>(<emph>vuol partire, si volta e vede Candida sulla terrazza</emph>)
 (Oh, eccola un'altra volta sulla terrazza. Se potessi prevenirla!)
@@ -1240,337 +1286,337 @@ Sì sì, è così, non può essere diversamente. Ma bisogna rompere
 questo silenzio, bisogna parlare alla signora Geltruda, ed ottenere
 da lei il prezioso dono di sua nipote (<emph>via</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>In verità sono obbligata alla signora Candida, che
 si ricorda di me. Posso far meno per lei? Fra noi altre
 fanciulle sono piaceri che si fanno, e che si cambiano senza
 malizia (<emph>filando</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>(<emph>s'alza e s'accosta a Giannina</emph>) Grand'interessi, gran segreti col signor Evaristo!</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>E cosa c'entrate voi? e cosa deve premere a voi?</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Se non mi premesse non parlerei.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>(<emph>s'alza pian piano dietro Coronato per ascoltare</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Voi non siete niente del mio, e non avete alcun
 potere sopra di me.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Se non sono ora niente del vostro, lo sarò quanto
 prima.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Chi l'ha detto? (<emph>con forza</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>L'ha detto e l'ha promesso, e mi ha data parola, chi
 può darla, e chi può disporre di voi.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Mio fratello forse... (<emph>ridendo</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Sì vostro fratello, e gli dirò i segreti, le
 confidenze, i regali...</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Alto alto padron mio! (<emph>entra fra li due</emph>).
 Che pretensione avete voi sopra questa ragazza?</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>A voi non deggio rendere questi conti.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>E voi che confidenza avete col signor Evaristo? (<emph>a Giannina</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Lasciatemi star tutti due, e non mi rompete la
 testa.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Voglio saperlo assolutamente (<emph>a Giannina</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Cos'è questo voglio? Andate a comandare a chi
 v'appartiene. Giannina m'è stata promessa da suo fratello.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Ed io ho la parola da lei, e val più una parola
 della sorella che cento parole di suo fratello.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Su questo ci toccheremo la mano (<emph>a Crespino</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Cosa vi ha dato il signor Evaristo? (<emph>a Giannina</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Un diavolo che vi porti.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Eh ora ora. L'ho veduto sortire dalla merciaia. La
 merciaia me lo dirà (<emph>corre da Susanna</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Che abbia comprato qualche galanteria? (<emph>va dalla medesima</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>(Oh, io non dico niente sicuro... Non vorrei che
 Susanna...)</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Ditemi in grazia. Che cosa ha comprato da voi il
 signor Evaristo? (<emph>a Susanna</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Un ventaglio (<emph>ridendo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Sapete voi che cosa ha donato a Giannina?</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Oh bella! Il ventaglio(<emph>ridendo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Non è vero niente (<emph>ctro Susanna</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Come non è vero niente? (<emph>a Giannina alzandosi</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Lasciate veder quel ventaglio (<emph>a Giannina con forza</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Voi non c'entrate (<emph>dà una spinta a Coronato</emph>).
 Voglio veder quel ventaglio (<emph>a Giannina</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>(<emph>alza la mano e minaccia Crespino</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>(<emph>lo stesso</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Per causa vostra (<emph>a Susanna</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Per causa mia? (<emph>a Giannina con sdegno</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Siete una pettegola.</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>A me pettegola? (<emph>s'avanza minacciando</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Alla larga che giuro al Cielo... (<emph>alza la rocca</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Vado via perché ci perdo del mio (<emph>ritirandosi</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Ci perde del suo?</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Siete una contadina, trattate da quella che siete (<emph>corre via in bottega</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>(<emph>vorrebbe seguirla. Crespino la trattiene</emph>).
 Lasciatemi stare.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Lasciatemi vedere il ventaglio (<emph>con forza</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Io non ho ventaglio.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Cosa vi ha dato il signor Evaristo? (<emph>a Giannina</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Vi dico ch'è un'impertinenza la vostra (<emph>a Coronato</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Voglio saperlo (<emph>si accosta a Giannina</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Non tocca a voi vi dico (<emph>lo respinge</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Non si tratta così colle fanciulle onorate (<emph>s'accosta alla sua casa</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Ditelo a me Giannina (<emph>accostandosi a lei</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Signor no (<emph>s'accosta di più alla porta</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Io, io ho da saperlo (<emph>respinge Crespino e s'accosta a Giannina</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Andate al diavolo (<emph>entra in casa, e li serra la porta in faccia</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>A me quest'affronto? (<emph>a Crespino</emph>). Per causa
 vostra (<emph>minacciandolo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Voi siete un impertinente.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>(<emph>minacciandosi</emph>) Non mi fate riscaldare il sangue.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>(<emph>minacciandosi</emph>) Non ho paura di voi.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Giannina dev'esser mia (<emph>con forza</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>No, non lo sarà mai. E se questo fosse, giuro al
 Cielo...</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Cosa sono queste minaccie? Con chi credete di aver
 che fare?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Io sono un galantuomo, e son conosciuto.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Ed io cosa sono?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Non so niente.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Sono un oste onorato.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Onorato?</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Come! ci avreste voi qualche dubbio?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Non sono io che lo mette in dubbio.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>E chi dunque?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Tutto questo villaggio.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Eh amico non è di me che si parla. Io non vendo il
 cuoio vecchio per il cuoio nuovo.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Né io vendo l'acqua per vino, né la pecora per
 castrato, né vado di notte a rubbar i gatti per venderli o
 per agnelli, o per lepre.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Giuro al Cielo... (<emph>alza la mano</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Ehi!... (<emph>fa lo stesso</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Corpo di bacco! (<emph>mette la mano in tasca</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>La mano in tasca! (<emph>corre al banchetto per qualche ferro</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Non ho coltello... (<emph>corre, e prende la sua banchetta</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>(<emph>lascia i ferri e prende un seggiolone dello speciale, e si vogliono dare</emph>).</p>
           </sp>
@@ -1580,357 +1626,357 @@ per agnelli, o per lepre.</p>
           <stage>
             <emph>Timoteo,Scavezzo, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#timoteo">
             <speaker> TIMOTEO</speaker>
             <p>(<emph>dalla sua bottega col pistetto in mano</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker> LIMONCINO</speaker>
             <p>(<emph>DAL CAFFè CON UN LEGNO</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#scavezzo">
             <speaker> SCAVEZZO</speaker>
             <p>(<emph>dall'osteria con uno spiedo</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>(<emph>dalla casa di Geltruda per dividere</emph>).Alto, alto,
 fermatevi, ve lo comando. Sono io, bestie, sono il conte di
 Roccamonte; ehi bestie, fermatevi, ve lo comando (<emph>temendo però di buscare</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Hai ragione che porto rispetto al signor Conte (<emph>a Coronato</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Sì, ringrazia il signor Conte, altrimenti t'avrei
 fracassato l'ossa.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Animo, animo, basta così. Voglio saper la contesa.
 Andate via voi altri. Ci sono io, e non c'è bisogno di
 nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>TIMOTEO</speaker>
             <p>C'è alcuno che sia ferito? (<emph>Limoncino e Scavezzo partono</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Voi vorreste, che si avessero rotto il capo,
 scavezzate le gambe, slogato un braccio, non è egli vero?
 Per avere occasione di esercitare il vostro talento, la
 vostra abilità.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>TIMOTEO</speaker>
             <p>Io non cerco il mal di nessuno, ma se avessero
 bisogno, se fossero feriti, storpiati, fracassati, li
 servirei volentieri. Sopra tutti servirei di cuore in uno di
 questi casi <abbr>V.</abbr> <abbr>S.</abbr> illustrissima.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sei un temerario, ti farò mandar via.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>TIMOTEO</speaker>
             <p>I galantuomini non si mandano via così facilmente.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Si mandano via i speciali ignoranti, temerari,
 impostori, come voi siete.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>TIMOTEO</speaker>
             <p>Mi maraviglio, ch'ella parli così, signore; ella che
 senza le mie pillole sarebbe morto.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Insolente!</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>TIMOTEO</speaker>
             <p>E le pillole non me l'ha ancora pagate (<emph>via</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>(Il Conte in questo caso mi potrebbe giovare) (<emph>da sé</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ebbene cosa è stato? cos'avete? qual è il motivo
 della vostra contesa?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Dirò, signore... Non ho riguardo di dirlo in
 faccia di tutto il mondo... Amo Giannina...</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>E Giannina dev'esser mia.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ah, ah ho capito. Guerra amorosa. Due campioni di
 Cupido. Due valorosi rivali. Due pretendenti della bella
 Venere, della bella dea delle Case nove (<emph>ridendo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Se ella crede di volermi porre in ridicolo... (<emph>vuol partire</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>No. Venite qui (<emph>lo ferma</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>La cosa è seriosa, glie l'assicuro.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sì lo credo. Siete amanti, e siete rivali. Cospetto
 di bacco! guardate le combinazioni! Pare la favola ch'ho
 letto alla signora Geltruda (<emph>mostrando il libro e legge</emph>).
 «Eravi una donzella d'una bellezza sì rara...»</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>(Ho capito). Con sua licenza.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Dov'andate? Venite qui.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Se mi permette, vado a terminar di accomodare le
 sue scarpe.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Oh sì, andate che siano finite per domattina.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>E sopra tutto che non siano accomodate col cuoio
 vecchio.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Verrò da voi per avere del cuoio nuovo (<emph>a Coronato</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Per grazia del Cielo, io non faccio né il
 ciabattino, né il calzolaro.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Non importa, mi darete della pelle di cavallo,
 della pelle di gatto (<emph>via</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>(Certo colui ha da morire per le mie mani) (<emph>da sé</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Che ha detto di gatti? Ci fareste voi mangiare del
 gatto?</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Signore, io sono un gilantuomo, e colui è un
 impertinente, che mi perseguita a torto.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Questo è un effetto della passione, della rivalità.
 Siete voi dunque amante di Giannina?</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Sì signore, ed anzi voleva raccomandarmi alla di lei
 protezione.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Alla mia protezione? (<emph>con aria</emph>). Bene si vedrà.
 Siete voi sicuro ch'ella vi corrisponda?</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Veramente dubito, ch'ella sia portata più per colui,
 che per me.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Male.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Ma io ho la parola di suo fratello.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Non è da fidarsene molto.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Moracchio me l'ha promessa sicuramente.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Questo va bene, ma non si può violentare una
 donna (<emph>con forza</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Suo fratello può disporre di lei.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Non è vero: il fratello non può disporre
 di lei (<emph>con caldo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Ma la di lei protezione...</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>La mia protezione è bella e buona; la mia
 protezione è valevole; la mia protezione è potente. Ma un
 cavaliere, come son io, non arbitra, e non dispone del cuor
 di una donna.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Finalmente è una contadina.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Che importa questo? La donna è sempre donna;
 distinguo i gradi, le condizioni, ma in massima rispetto il
 sesso.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>(Ho capito la sua protezione non val niente).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Come state di vino? Ne avete provveduto di buono?</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Ne ho del perfetto, dell'ottimo, dell'esquisito.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Verrò a sentirlo. Il mio quest'anno è riuscito
 male.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>(Son due anni che l'ha venduto).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Se il vostro è buono mi provvederò da voi.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>(Non mi curo di questo vantaggio) (<emph>da sé</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Avete capito?</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Ho capito.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ditemi una cosa. S'io parlassi alla giovane, e con
 buona maniera la disponessi?</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Le sue parole potrebbero forse oprar qualche cosa in
 mio vantaggio.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Voi finalmente meritate d'essere preferito.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Mi parrebbe che da me a Crespino...</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Oh, non vi è paragone. Un uomo, come voi, proprio,
 civile, galantuomo...</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Ella ha troppo bontà per me.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>E poi rispetto alle donne, è vero, ma appunto per
 questo trattandole, com'io le tratto, vi assicuro, che fanno
 per me quel che non farebbero per nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Questo è quello che pensavo anch'io, ma ella mi
 voleva disperare.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Io faccio, come quegli avvocati, che principiano
 dalle difficoltà. Amico, voi siete un uomo, che ha una buona
 osteria, che può mantenere una moglie con proprietà,
 fidatevi di me, mi voglio interessare per voi.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Mi raccomando alla sua protezione.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ve l'accordo, e ve la prometto.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Se volesse darsi l'incomodo di venir a sentir il mio
 vino...</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ben volentieri. In casa vostra non vi ho alcuna
 difficoltà.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Resti servita.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Buon galantuomo! (<emph>gli mette la mano sulla spalla</emph>).
 Andiamo (<emph>entra</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Due o tre barili di vino non saranno mal impiegati (<emph>entra</emph>).</p>
           </sp>
@@ -1944,7 +1990,7 @@ Andiamo (<emph>entra</emph>).</p>
             <emph>Susanna sola ch'esce dalla bottega, e accomoda la roba
 della mostra.</emph>
           </stage>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Gran poche faccende si fanno in questo villaggio!
 Non ho venduto che un ventaglio fin ora, ed anche l'ho dato
@@ -1974,7 +2020,7 @@ non posso soffrire le male grazie (<emph>siede e lavora</emph>).</p>
           <stage>
             <emph>Candida ch'esce dal palazzino, e detta.</emph>
           </stage>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Non son quieta, se non vengo in chiaro di
 qualche cosa. Ho veduto Evaristo sortire dalla merciaia, e
@@ -1984,133 +2030,133 @@ zia, non bisogna fidarsi delle persone, senza bene
 conoscerle. Povera me! Se lo trovassi infedele! È il mio
 primo amore. Non ho amato altri che lui (<emph>a poco a poco s'avanza verso Susanna</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Oh signora Candida, serva umilissima (<emph>si alza</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Buon giorno, signora Susanna che cosa lavorate di
 bello?</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Mi diverto, metto assieme una cuffia.</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Per vendere?</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Per vendere, ma il Cielo sa quando.</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Può essere, ch'io abbia bisogno d'una cuffia da
 notte.</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Ne ho di fatti. Vuol restar servita?</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>No no, c'è tempo, un altra volta.</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Vuol accomodarsi qui un poco? (<emph>le offre la sedia</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>E voi?</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Oh, io prenderò un'altra sedia (<emph>entra in bottega, e piglia una sedia di paglia</emph>). S'accomodi qui che starà meglio.</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Sedete anche voi, lavorate (<emph>siede</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Mi fa grazia a degnarsi della mia compagnia (<emph>siede</emph>).
 Si vede ch'è nata bene. Chi è ben nato si degna di tutti. E questi
 villani sono superbi come luciferi, e quella Giannina poi...</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>A proposito di Giannina, avete osservato quando le
 parlava il signor Evaristo?</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Se ho osservato? e come!</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Ha avuto una lunga conferenza con lei.</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Sa dopo cosa è succeduto? Sa la baruffa ch'è stata?</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Ho sentito uno strepito, una contesa. Mi hanno
 detto che Coronato, e Crespino si volevano dare.</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Certo, e per causa di quella bella grazia, di quella
 gioia.</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Ma perché?</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Per gelosia fra di loro, per gelosia del signor
 Evaristo.</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Credete voi, che il signor Evaristo abbia qualche
 attacco con Giannina?</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Io non so niente, non bado ai fatti degli altri, e
 non penso mal di nessuno, ma l'oste, e il calzolaio se sono
 gelosi di lui, avranno le loro ragioni.</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>(Povera me! L'argomento è troppo vero in mio
 danno!)</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Perdoni, non vorrei commettere qualche fallo.</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>A proposito di che?</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Non vorrei, ch'ella avesse qualche parzialità per il
 signor Evaristo...</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Oh io! non ce n'ho nessuna. Lo conosco, perché
 viene qualche volta in casa; è amico di mia zia.</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Le dirò la verità. (Non credo, ch'ella si potrà
 offendere di questo). Credeva quasi, che fra lei, ed il
@@ -2118,30 +2164,30 @@ signor Evaristo vi fosse qualche buona corrispondenza...
 lecita e onesta, ma dopo ch'è stato da me questa mattina, mi
 sono affatto disingannata.</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>È stato da voi questa mattina?</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Sì signora, le dirò... È venuto a comprar un
 ventaglio.</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Ha comprato un ventaglio? (<emph>con premura</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Sì certo, e come io aveva veduto, ch'ella aveva
 rotto il suo, quasi per causa di quel signore, dissi subito
 fra me: lo comprerà per darlo alla signora Candida...</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>L'ha dunque comprato per me?</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Oh signora no; anzi le dirò, che ho avuto la
 temerità di domandarglielo, se lo comprava per lei. In
@@ -2149,54 +2195,54 @@ verità mi ha risposto in una maniera, come se io l'avessi
 offeso; non tocca a me, dice, cosa c'entro io colla signora
 Candida? L'ho destinato altrimenti.</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>E che cosa ha fatto di quel ventaglio?</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Cosa ne ha fatto? L'ha regalato a Giannina.</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>(Ah, son perduta, son disperata!) (<emph>agitandosi</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Signora Candida (<emph>osservando la sua inquietudine</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>(Ingrato! Infedele! E perché? per una villana?)</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Signora Candida (<emph>con premura</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>(L'offesa è insopportabile).</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>(Povera me l'ho fatta!) Signora s'acquieti la cosa
 non sarà così.</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Credete voi, ch'egli abbia dato a Giannina il
 ventaglio?</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Oh, in quanto a questo l'ho veduto io con questi
 occhi.</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>E cosa dunque mi dite, che non sarà?</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Non so... non vorrei vederla per causa mia...</p>
           </sp>
@@ -2206,100 +2252,100 @@ occhi.</p>
           <stage>
             <emph>Geltruda sulla porta del palazzino.</emph>
           </stage>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Oh, ecco la sua signora zia (<emph>a Candida</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Per amor del cielo, non dite niente (<emph>a Susanna</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Non v'è pericolo. (E voleva dirmi di no. Suo danno,
 perché non dirmi la verità?) (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Che fate qui nipote? (<emph>Candida e Susanna si alzano</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>È qui a favorirmi, a tenermi un poco di compagnia.</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Son venuta a vedere se ha una cuffia da notte.</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Sì è vero, me l'ha domandata. Oh, non dubiti niente,
 che con me può esser sicura. Non sono una frasca, e in casa
 mia non vien nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Non vi giustificate fuor di proposito signora
 Susanna.</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Oh io sono assai dilicata signora.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Perché non dirlo a me se avete bisogno d'una
 cuffia?</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Voi eravate nel vostro gabinetto a scrivere; non ho
 voluto sturbarvi.</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Vuol vederla? La vado a prendere. S'accomodi qui,
 favorisca (<emph>dà la sua sedia a Geltruda ed entra in bottega</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Avete saputo niente di quella contesa ch'è stata
 qui fra l'oste, ed il calzolaio? (<emph>a Candida, e siede</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Dicono per amore, per gelosie (<emph>siede</emph>). Dicono
 che sia stata causa Giannina.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Mi dispiace, perché è una buona ragazza.</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Oh signora zia scusatemi, ho sentito delle cose di
 lei, che sarà bene, che non la facciamo più venire per casa.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Perché? cosa hanno detto?</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Vi racconterò poi. Fate a modo mio signora, non la
 ricevete più, che farete bene.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Siccome ella veniva più da voi, che da me, vi
 lascio in libertà di trattarla, come volete.</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>(Indegna! Non avrà più l'ardire di comparirmi
 dinnanzi).</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>(<emph>che torna</emph>). Ecco le cuffie signora, guardi, scelga, e si
 soddisfi (<emph>tutte tre si occupano alla scelta delle cuffie, e parlano piano fra loro</emph>).</p>
@@ -2310,16 +2356,16 @@ soddisfi (<emph>tutte tre si occupano alla scelta delle cuffie, e parlano piano 
           <stage>
             <emph>Il Conte ed il Barone escono insieme dell'osteria.</emph>
           </stage>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ho piacere, che mi abbiate fatto la confidenza.
 Lasciatevi servire da me, e non dubitate.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>So che siete amico della signora Geltruda.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Oh amico vi dirò. Ella è una donna, che ha qualche
 talento, io amo la letteratura, mi diverto con lei più
@@ -2328,146 +2374,146 @@ povera cittadina. Suo marito le ha lasciato quella casuppola
 con qualche pezzo di terra, e per essere rispettata in
 questo villaggio ha bisogno della mia protezione.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Viva il signor Conte, che protegge le vedove, che
 protegge le belle donne.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Che volete? A questo mondo bisogna essere buoni da
 qualche cosa.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Mi farete dunque il piacere...</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Non dubitate, le parlerò, le domanderò la nipote
 per un cavaliere mio amico; e quando gliela dimando io son
 sicuro, che non avrà ardire, che non avrà coraggio di dire
 di no.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Ditele chi sono.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Che serve? Quando gliela domando io.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Ma la domandate per me?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Per voi.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Sapete voi bene chi sono?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Non volete che io vi conosca? Non volete, che io
 sappia i vostri titoli, le vostre facoltà, i vostri
 impieghi? Eh fra noi altri titolati ci conosciamo.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>(Oh come me lo goderei, se non avessi bisogno di
 lui!)</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Oh, collega amatissimo... (<emph>con premura</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Cosa c'è?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ecco la signora Geltruda con sua nipote.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Sono occupate, credo, che non ci abbiano veduto.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>No certo. Se Geltruda mi avesse veduto, si sarebbe
 mossa immediatamente.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Quando le parlerete?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Subito se volete.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Non è bene, che io ci sia. Parlatele, io anderò a
 trattenermi dallo speciale.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Perché dallo speciale?</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Ho bisogno di un poco di reobarbaro per la
 digestione.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Del reobarbaro? Vi darà della radica di sambuco.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>No no lo conosco. Se non sarà buono non lo prenderò.
 Mi raccomando a voi.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Collega amatissimo (<emph>lo abbraccia</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Addio collega carissimo. (È il più bel pazzo di
 questo mondo) (<emph>entra nella bottega dello speziale</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Signora Geltruda (<emph>chiama forte</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Oh, signor Conte, perdoni, non l'aveva veduta (<emph>si alza</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Una parola in grazia.</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Favorisca se comanda si servi qui; è padrone.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>No no; ho qualche cosa da dirvi segretamente.
 Scusate l'incomodo, ma vi prego di venir qui (<emph>a Geltruda</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>La servo subito. Mi permetta di pagar una cuffia,
 che abbiamo preso, e sono da lei (<emph>tira fuori una borsa per pagare Susanna, e per tirare in lungo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Vuol pagar subito! questo vizio io non l'ho mai
 avuto.</p>
@@ -2479,311 +2525,311 @@ avuto.</p>
             <emph>Coronato esce dell'osteria con Scavezzo, che porta
 un barile di vino in spalla.</emph>
           </stage>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Illustrissimo questo è un barile che viene a lei.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>E l'altro?</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Dopo questo si porterà l'altro; dove vuol che si
 porti?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Al mio palazzo.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>A chi vuole, che si consegni?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Al mio fattore, se c'è.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Ho paura, che non vi sarà.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Consegnatelo a qualcheduno.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Benissimo, andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#scavezzo">
             <speaker>SCAVEZZO</speaker>
             <p>Mi darà poi la buona mano il signor Conte.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Bada bene a non bever il vino, e non vi metter
 dell'acqua (<emph>a Scavezzo</emph>). Non lo lasciate andar solo (<emph>a Coronato</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Non dubiti, non dubiti, ci sono anch'io (<emph>via</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#scavezzo">
             <speaker>SCAVEZZO</speaker>
             <p>(Sì sì non dubiti, che fra io ed il padrone,
 l'abbiamo accomodato a quest'ora) (<emph>via</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>(<emph>ha pagato, e si avanza verso il Conte. Susanna siede e lavora. Candida resta a sedere, e parlano piano fra di loro</emph>).
 Eccomi da lei signor Conte. Cosa mi comanda?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>In poche parole. Mi volete dar vostra nipote?</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Dare? Cosa intendete per questo dare?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Diavolo! non capite? In matrimonio.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>A lei?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Non a me, ma a una persona, che conosco io, e che
 vi propongo io.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Le dirò signor Conte, ella sa, che mia nipote ha
 perduto i suoi genitori, e ch'essendo figliuola d'un unico
 mio fratello, mi sono io caricata di tenerle luogo di madre.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Tutti questi, compatitemi sono discorsi inutili.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Mi perdoni. Mi lasci venire al proposito della sua
 proposizione.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Bene, e così?</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Candida non ha ereditato dal padre tanto, che
 basti per maritarla secondo la sua condizione.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Non importa, non vi è questione di ciò.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Ma mi lasci dire. Io sono stata beneficata da mio
 marito.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Lo so.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Non ho figliuoli...</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>E voi le darete una dote... (<emph>impaziente</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Sì signore, quando il partito le convenirà (<emph>con caldo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Oh ecco il proposito necessario. Lo propongo io, e
 quando lo propongo io, le convenirà.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Son certa, che il signor Conte non è capace, che
 di proporre un soggetto accettabile, ma spero, che mi farà
 l'onore di dirmi, chi è.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>È un mio collega.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Come? Un suo collega?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Un titolato, come son io.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Signore...</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Non ci mettete difficoltà.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Mi lasci dire se vuole; e se non vuole gli leverò
 l'incomodo, e me n'anderò.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Via via siate buona; parlate, vi ascolterò. Colle
 donne sono civile, sono compiacente; vi ascolterò.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>In poche parole le dico il mio sentimento. Un
 titolo di nobiltà fa il merito di una casa, ma non quello di
 una persona. Non credo mia nipote ambiziosa, né io lo sono
 per sacrificarla all'idolo della vanità.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Eh si vede, che voi avete letto le favole (<emph>scherzando</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Questi sentimenti non s'imparano né dalle favole,
 né dalle storie. La natura gl'ispira, e l'educazione li
 coltiva.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>La natura, la coltivazione, tutto quel che volete.
 Quello ch'io vi propongo è il barone del Cedro.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Il signor Barone è innamorato di mia nipote?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p><emph>Oui madame</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Lo conosco, ed ho tutto il rispetto per lui.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Vedete che pezzo ch'io vi propongo?</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>È un cavaliere di merito...</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>È mio collega.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>È un poco franco di lingua, ma non c'è male.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Animo dunque. Cosa mi rispondete?</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Adagio, adagio, signor Conte, non si decidono
 queste cose così sul momento. Il signor Barone avrà la bontà
 di parlare con me...</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Quando lo dico io, scusatemi, non si mette in
 dubbio, io ve la domando per parte sua, e si è raccomandato,
 e mi ha pregato, e mi ha supplicato, ed io vi parlo, vi
 supplico, non vi supplico, ma ve la domando.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Supponiamo, che il signor Barone dica davvero.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Cospetto! Cos'è questo supponiamo? La cosa è certa;
 e quando lo dico io...</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Via la cosa è certa. Il signor Barone la brama.
 Vossignoria la domanda. Bisogna bene, ch'io senta se Candida
 vi acconsente.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Non lo saprà, se non glie lo dite.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Abbia la bontà di credere, che glielo dirò (<emph>ironica</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Eccola lì, parlatele.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Li parlerò.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Andate, e vi aspetto qui.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Mi permetta, e sono da lei (<emph>fa riverenza</emph>).
 (Se il Barone dicesse davvero, sarebbe una fortuna per mia nipote. Ma
 dubito, ch'ella sia prevenuta) (<emph>da sé, e va verso la merciaia</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Oh, io poi colla mia buona maniera faccio fare alle
 persone tutto quello, che io voglio (<emph>tira fuori il libro, si mette sulla banchetta, e legge</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Candida andiamo a fare due passi. Ho necessità di
 parlarvi.</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Se vogliono restar servite nel mio giardinetto,
 saranno in pienissima libertà (<emph>si alzano</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Sì andiamo, che sarà meglio, perché devo tornar
 qui subito (<emph>entra in bottega</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Cosa mai vorrà dirmi? Son troppo sfortunata, per
 aspettarmi alcuna consolazione (<emph>entra in bottega</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>È capace di farmi star qui un'ora ad aspettarla.
 Manco male, che ho questo libro, che mi diverte. Gran bella
@@ -2796,7 +2842,7 @@ non è mai solo (<emph>legge piano</emph>).</p>
           <stage>
             <emph>Giannina di casa, e il Conte.</emph>
           </stage>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Oh via, il desinare è preparato, quando verrà
 quell'animale di Moracchio non griderà. Nessuno mi vede; è
@@ -2804,325 +2850,325 @@ meglio che vada ora a portar il ventaglio alla signora
 Candida. Se posso darglielo senza che la zia se ne accorga
 glielo do; se no aspetterò un altro incontro.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Oh ecco Giannina. Ehi! quella giovine (<emph>s'incamminano al palazzino</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Signore (<emph>dove si trova voltandosi</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Una parola (<emph>la chiama a sé</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Ci mancava quest'impiccio ora (<emph>si avanza bel bello</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>(Non bisogna che io mi scordi di Coronato. Gli ho
 promesso la mia protezione, e la merita) (<emph>si alza e mette via il libro</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Son qui, cosa mi comanda?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Dove eravate indirizzata?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>A fare i fatti miei, signore (<emph>rusticamente</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Così mi rispondete? Con quest'audacia? con
 quest'impertinenza?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Come vuol, ch'io parli? Parlo, come so, come sono
 avezza a parlare. Parlo così con tutti, e nessuno mi ha
 detto, che sono una impertinente.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Bisogna distinguere con chi si parla.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Oh io non so altro distinguere. Se vuol qualche
 cosa, me lo dica; se vuol divertirsi, io non ho tempo da
 perdere con vossignoria...</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Illustrissima.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>E eccellentissima ancora se vuole.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Venite qui.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Son qui.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Vi volete voi maritare?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Signor sì.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Brava, così mi piace.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Oh io quel che ho in core ho in bocca.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Volete, che io vi mariti?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Signor no.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Come no?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Come no? perché no. Perché per maritarmi non ho
 bisogno di lei.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Non avete bisogno della mia protezione?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>No in verità, niente affatto.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sapete voi quel che io posso in questo villaggio?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Potrà tutto in questo villaggio, ma non può niente
 nel mio matrimonio.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Non posso niente?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Niente in verità, niente affatto (<emph>ridendo dolcemente</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Voi siete innamorata in Crespino.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Oh, per me ha dello spirito che mi basta.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>E lo preferite a quel galantuomo, a quell'uomo
 ricco, a quell'uomo di proposito di Coronato?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Oh, lo preferirei bene ad altri che a Coronato.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Lo preferireste a degli altri?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Se sapesse a chi lo preferirei! (<emph>ridendo, ed a moti si spiega per lui</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>E a chi lo preferireste?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Cosa serve? non mi faccia parlare.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>No, perché sareste capace di dire qualche
 insolenza.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Comanda altro da me?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Orsù io proteggo vostro fratello, vostro fratello
 ha dato parola per voi a Coronato, e voi dovete maritarvi
 con Coronato.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Vossignoria...</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Illustrissima.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Vossignoria illustrissima protegge mio fratello? (<emph>affettata</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Così è, sono impegnato.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>E mio fratello ha dato parola a Coronato?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sicuramente.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Oh, quando è così...</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>E bene?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Mio fratello sposerà Coronato.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Giuro al Cielo, Crespino non lo sposarete.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>No? perché?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Lo farò mandar via di questo villaggio.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Anderò a cercarlo dove sarà.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Lo farò bastonare.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Oh in questo ci penserà lui.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Lo farò accoppare.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Questo mi dispiacerebbe veramente.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Cosa fareste s'egli fosse morto?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Non so.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ne prendereste un altro?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Potrebbe darsi di sì.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Fate conto ch'egli sia morto.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Signor non so né leggere, né scrivere, né far
 conti.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Impertinente!</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Mi comanda altro?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Andate al diavolo.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>M'insegni la strada.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Giuro al cielo, se non foste una donna!</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Cosa mi farebbe?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Andate via di qua.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Subito l'obbedisco, e poi mi dirà ch'io non so le
 creanze (<emph>s'incammina verso il palazzino</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Creanze, creanze! Va via senza salutare (<emph>sdegnato dietro a Giannina</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Oh, perdoni. Serva di vossignoria...</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Illustrissima (<emph>sdegnato</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Illustrissima (<emph>ridendo corre nel palazzino</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p><foreign xml:lang="lat">Rustica progenies nescit habere modum</foreign>.
 (<emph> sdegnato</emph>). Non so cosa fare, se non vuol Coronato, io non la
@@ -3138,69 +3184,69 @@ l'effetto della mia protezione.</p>
             <emph>Geltruda, e Candida fuori della bottega della merciaia,
 e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>E così, signora Geltruda?</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Signore, mia nipote è una giovane saggia e
 prudente.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>E così, alle corte.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Ma ella m'affatica in verità, signor Conte.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Scusatemi; se sapeste quel ch'ho passato con una
 donna! è vero, che un'altra donna... (Ma tutte donne!) E
 così cosa dice la saggia e prudente signora Candida?</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Supposto, che il signor Barone...</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Supposto, maledetti i vostri supposti!</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Dato, concesso, assicurato, concluso, come comanda
 vossignoria.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Illustrissima (<emph>fra' denti da sé</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Signore (<emph>domandandogli cosa ha detto</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Niente niente, tirate innanzi.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Accordate le condizioni e le convenienze, mia
 nipote è contenta di sposare il signor Barone.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Brava, bravissima. (<emph>a Candida</emph>). (Questa volta
 almeno ci sono riuscito) (<emph>da sé</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>(Sì, per vendicarmi di quel perfido d'Evaristo) (<emph>da sé</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>(Non credeva, certo, ch'ella v'acconsentisse. Mi
 pareva impegnata in certo amoretto... ma mi sono ingannata).</p>
@@ -3211,112 +3257,112 @@ pareva impegnata in certo amoretto... ma mi sono ingannata).</p>
           <stage>
             <emph>Giannina sulla terrazza, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>(Non c'e, non la trovo in nessun luogo). Oh,
 eccola lì.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Così dunque la signora Candida sposerà il signor
 barone del Cedro.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>(Cosa sento? cosa risponderà?)</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Ella lo farà quando le condizioni... (<emph>al Conte</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Quali condizioni ci mettete voi? (<emph>a Candida</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Nessuna, signore, lo sposerò in ogni modo (<emph>al Conte</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Viva la signora Candida, così mi piace. (Eh! quando
 mi meschio io negli affari, tutto va a meraviglia) (<emph>si pavoneggia</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>(Questa è una cosa terribile. Povero signor
 Evaristo! È inutile ch'io le dia il ventaglio) (<emph>via</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>(Mi sono ingannata. Ella amava il Barone, ed io la
 credeva accesa del signor Evaristo) (<emph>da sé</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Se mi permette, vado a dare questa buona nuova al
 Barone, al mio caro amico, al mio caro collega.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>E dov'è il signor Barone?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Mi aspetta dallo speziale. Fate una cosa. Andate a
 casa; ed io ve lo conduco immediatamente.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Cosa dite nipote?</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Sì, parlerà con voi (<emph>a Geltruda</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>E con voi (<emph>a Candida</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Mi rimetto a quello che farà la signora zia.
 (Morirò, ma morirò vendicata) (<emph>da sé</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Vado subito. Aspettateci. Verremo da voi... Come
 l'ora è un poco avanzata non sarebbe male, che gli offeriste
 di tenerlo a pranzo (<emph>a Geltruda</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Oh per la prima volta!</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Eh queste sono delicatezze superflue. L'accetterà
 volentieri, mi impegno io, e per obbligarlo ci resterò ancor
 io (<emph>parte, ed entra dallo speziale</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Andiamo ad attenderli adunque (<emph>a Candida</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Andiamo (<emph>melanconica</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Che cosa avete? Lo fate voi di buon animo? (<emph>a Candida</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Sì, di buon animo. (Ho data la mia parola, non vi è
 rimedio).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>(Povera fanciulla, la compatisco. In questi casi
 (<emph>s'incammina verso il palazzino</emph>) malgrado l'amore, si sente
@@ -3328,67 +3374,67 @@ sempre un poco di confusione) (<emph>come sopra</emph>).</p>
           <stage>
             <emph>Giannina dal palazzino, e Candida.</emph>
           </stage>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Oh signora Candida.</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Cosa fate voi qui? (<emph>in collera</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Veniva in traccia di lei...</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Andate via, e in casa nostra non ardite più di
 mettervi il piede.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Come! A me quest'affronto?</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Che affronto! Siete un'indegna, e non deggio, e non
 posso più tollerarvi (<emph>entra nel palazzino</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>(È un poco troppo veramente).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>(Io resto di sasso!) Signora Geltruda...</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Mi dispiace della mortificazione, che avete
 provata, ma mia nipote è una giovane di giudizio, e se vi ha
 trattata male, avrà le sue ragioni per farlo.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Che ragioni può avere? Mi maraviglio di lei.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Ehi portate rispetto. Non alzate la voce.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Voglio andare a giustificarmi... (<emph>in atto di partire</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>No no fermatevi. Ora non serve, lo farete poi.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Ed io le dico, che voglio andare adesso (<emph>vuol andare</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Non ardirete di passare per questa porta (<emph>si mette sulla porta</emph>).</p>
           </sp>
@@ -3399,102 +3445,102 @@ trattata male, avrà le sue ragioni per farlo.</p>
             <emph>Conte, e Barone dallo speciale per andar al palazzino, e
 dette.</emph>
           </stage>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Andiamo, andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Ci verrò per forza.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Impertinente! (<emph>a Giannina, poi entra e chiude la porta  nell'atto, che si presentano il Conte, ed il Barone non veduti da lei</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>(<emph>arrabbiata s'allontana e smania</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>(<emph>resta senza parlare, guardando la porta</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Come ci chiude la porta in faccia?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>In faccia? Non è possibile.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Non è possibile? Non è possibile quel ch'è di fatto?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>A me un affronto? (<emph>da sé passeggiando e fremendo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Andiamo a battere, a vedere, a sentire (<emph>al Barone</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>No, fermatevi, non ne vo' saper altro. Non voglio
 espormi a novelli insulti. Mi son servito di voi male a
 proposito. V'hanno deriso voi, ed hanno posto in ridicolo me
 per cagion vostra.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Che maniera di parlare è codesta? (<emph>si scalda</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>E ne voglio soddisfazione.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Da chi?</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Da voi.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Come?</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Colla spada alla mano.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Colla spada? Sono vent'anni, che sono in questo
 villaggio, e che non adopero più la spada.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Colla pistola dunque.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sì, colle pistole. Anderò a prendere le mie
 pistole (<emph>vuol partire</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>No, fermatevi. Eccone due. Una per voi e una per
 me (<emph>le tira di saccoccia</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Pistole? Ehi gente. Aiuto, pistole.
 Si ammazzano (<emph>corre in casa</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>(<emph>imbarazzato</emph>)</p>
           </sp>
@@ -3505,174 +3551,174 @@ Si ammazzano (<emph>corre in casa</emph>).</p>
             <emph>Geltruda sulla terrazza, e detti (poi Limoncino e
 Tognino).</emph>
           </stage>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Signori miei, cos'è questa novità?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Perché ci avete serrata la porta in faccia? (<emph>a  Geltruda</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Io? Scusatemi. Non sono capace di un'azione
 villana con chi che sia. Molto meno con voi, e col signor
 Barone, che si degna di favorir mia nipote.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sentite (<emph>al Barone</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Ma, signora mia nell'atto che volevamo venir da voi,
 ci è stata serrata la porta in faccia.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Vi protesto, che non vi aveva veduti, ed ho
 serrato la porta per impedire che non entrasse quella
 scioccherella di Giannina.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>(<emph>mette fuori la testa con pausa dalla sua porta</emph>).
 Cos'è questa scioccarella? (<emph>caricando con disprezzo, e torna  dentro</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Zitto lì impertinente (<emph>contro Giannina</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Se vogliono favorire darò ordine, che sieno
 introdotti (<emph>via</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sentite? (<emph>al Barone</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Non ho niente che dire.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Cosa volete fare di quelle pistole?</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Scusate la delicatezza d'onore... (<emph>mette via le  pistole</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>E volete presentarvi a due donne colle pistole in
 saccoccia?</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Le porto in campagna per mia difesa.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ma se lo sanno, che abbiate quelle pistole: sapete
 cosa sono le donne, non vorranno, che vi accostiate.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Avete ragione. Vi ringrazio di avermi prevenuto, e
 per segno di buona amicizia, ve ne faccio un presente (<emph>le torna  a tirar fuori, e gliele presenta</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Un presente a me? (<emph>con timore</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Sì, spero, che non lo ricusarete.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Le accetterò perché vengono dalle vostre mani. Sono
 cariche?</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Che domanda! Volete ch'io porti le pistole vuote?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Aspettate. Ehi dal caffè.</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker>LIMONCINO</speaker>
             <p>(<emph>dalla bottega del caffè</emph>). Cosa mi comanda?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Prendete queste pistole, e custoditele, che le
 manderò a pigliare.</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker>LIMONCINO</speaker>
             <p>Sarà servito (<emph>prende le pistole del Barone</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Badate bene che sono cariche.</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker>LIMONCINO</speaker>
             <p>Eh ch'io le so maneggiare (<emph>scherza colle pistole</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ehi, ehi non fate la bestia (<emph>con timore</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker>LIMONCINO</speaker>
             <p>(È valoroso il signor Conte) (<emph>via</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Vi ringrazio, e ne terrò conto. (Dimani le
 venderò).</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>(<emph>dal palazzino</emph>). Signori, la padrona li aspetta.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ah! che ne dite? Sono uomo io? Eh collega
 amatissimo. Noi altri titolati! La nostra protezione val
 qualche cosa (<emph>s'incammina</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>(<emph>di casa, pian piano va dietro di loro per entrare.  Il Conte , ed il Barone entrano introdotti da Tognino, che resta  sulla porta. Giannina vorrebbe entrare, e Tognino la ferma</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Voi non ci avete che fare.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Signor sì, ci ho che fare.</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Ho ordine di non lasciarvi entrare (<emph>entra e chiude  la porta</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Ho una rabbia a non potermi sfogare, che sento
 proprio, che la bile mi affoga (<emph>avanzandosi</emph>). A me un affronto?
@@ -3686,317 +3732,317 @@ A una giovane della mia sorte? (<emph>smania per la scena</emph>)</p>
 collo scoppio in mano, una sacchetta col salvatico, ed il cane
 attaccato alla corda, e detta (poi Tognino).</emph>
           </stage>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Tenete, portate il mio schioppo da voi. Custodite
 quelle pernici fino che io ne dispongo. Vi raccomando il
 cane (<emph>siede al caffè, piglia il tabacco, e s'accomoda</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Non dubiti, che sarà tutto ben custodito (<emph>ad Evaristo</emph>).
 Il desinare è all'ordine? (<emph>a Giannina avanzandosi</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>È all'ordine (<emph>arrabbiata</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Cosa diavolo hai? Sei sempre in collera con tutto il
 mondo, e poi ti lamenti di me.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Oh è vero. Siamo fratelli, non vi è niente che
 dire...</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Via andiamo a desinare ch'è ora (<emph>a Giannina</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Sì sì va' avanti che poi verrò. (Voglio parlare
 col signor Evaristo).</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Se vieni, vieni, se non vieni mangerò io (<emph>entra  in casa</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Se ora mangiassi, mangerei del veleno.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>(Non si vede nessuno nella terrazza. Saranno a
 pranzo probabilmente. È meglio ch'io vada all'osteria. Il
 Barone mi aspetta) (<emph>si alza</emph>). Ebbene Giannina avete niente da
 dirmi? (<emph>vedendo Giannina</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Oh sì signore ho qualche cosa da dirli (<emph>bruscamente</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Avete dato il ventaglio?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Eccolo qui il suo maladetto ventaglio.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Che vuol dire? non avete potuto darlo?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Ho ricevuto mille insulti, mille impertinenze, e
 mi hanno cacciato di casa come una briccona.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Si è forse accorta la signora Geltruda?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Eh, non è stata solamente la signora Geltruda. Le
 maggiori impertinenze me l'ha dette la signora Candida.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Perché? Cosa li avete fatto?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Io non le ho fatto niente, signore.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Le avete detto, che avevate un ventaglio per lei?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Come poteva dirglielo, se non mi ha dato tempo, e
 mi hanno scacciata come una ladra?</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Ma ci deve esser il suo perché.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Per me so di non averle fatto niente. E tutto
 questo maltrattamento son certa, son sicura, che me lo ha
 fatto per causa vostra.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Per causa mia? La signora Candida che mi ama tanto?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Vi ama tanto la signora Candida?</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Non vi è dubbio, ne son sicurissimo.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Oh sì vi assicuro anch'io, che vi ama bene, bene,
 ma bene.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Voi mi mettete in una agitazione terribile.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Andate, andate a ritrovare la vostra bella, la
 vostra cara (<emph>ironica</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>E perché non vi posso andare?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Perché il posto è preso.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Da chi? (<emph>affannato</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Dal signor barone del Cedro.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Il Barone è in casa? (<emph>con maraviglia</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Che difficoltà c'è che sia in casa, se è lo sposo
 della signora Candida?</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Giannina, voi sognate, voi delirate, voi non fate
 che dire degli spropositi.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Non mi credete, andate a vedere, e saprete, s'io
 dico la verità.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>In casa della signora Geltruda...</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>E della signora Candida.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Vi è il Barone?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Del Cedro...</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Sposo della signora Candida...</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>L'ho veduto con questi occhi, e sentito con queste
 orecchie.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Non può stare, non può essere, voi dite delle
 bestialità.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Andate, vedete, sentite, e vedrete s'io dico delle
 bestialità (<emph>cantando</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Subito immediatamente (<emph>corre al palazzino  e batte</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Povero sciocco! Si fida dell'amore d'una giovane
 di città! Non sono come noi no, le cittadine.
 (<emph>Evaristo freme e torna a battere</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>(<emph>apre e si fa vedere sulla porta</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>E bene!</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Perdoni, io non posso introdur nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Avete detto che sono io?</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>L'ho detto.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Alla signora Candida?</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Alla signora Candida.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>E la signora Geltruda non vuole ch'io entri?</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Anzi la signora Geltruda aveva detto di lasciarla
 entrare, e la signora Candida non ha voluto.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Non ha voluto? Ah, giuro al Cielo! Entrerò (<emph>vuol  sforzare e Tognino li serra la porta in faccia</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Ah! cosa le ho detto io?</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Son fuor di me. Non so in che mondo mi sia.
 Chiudermi la porta in faccia?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Oh, non si maravigli. L'hanno fatto anche a me
 questo bel trattamento.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Com'è possibile, che Candida m'abbia potuto
 ingannare?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Quel ch'è di fatto non si può mettere in dubbio.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Ancora non lo credo, non lo posso credere, non lo
 crederò mai.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Non lo crede?</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>No, vi sarà qualche equivoco, qualche mistero,
 conosco il cuore di Candida; non è capace.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Bene. Si consoli così. Speri, e se la goda, che
 buon pro le faccia.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Voglio parlar con Candida assolutamente.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Se non l'ha voluto ricevere!</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Non importa. Vi sarà qualche altra ragione. Andrò
 in casa del caffettiere. Mi basta di vederla, di sentire una
 parola da lei. Mi basta un cenno per assicurarmi della mia
 vita, o della mia morte.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Tenga.</p>
           </sp>
@@ -4008,245 +4054,245 @@ vita, o della mia morte.</p>
 Scavezzo va addirittura all'osteria. Coronato resta in disparte
 ad ascoltare, e detti (poi Crespino).</emph>
           </stage>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Cosa volete darmi?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Il ventaglio.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Tenetelo, non mi tormentate.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Me lo dona il ventaglio?</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Sì tenetelo, ve lo dono. (Son fuor di me stesso).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Quand'è così, la ringrazio.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>(Oh oh, ora ho Saputo cos'è il regalo. Un
 ventaglio) (<emph>senza esser veduto entra nell'osteria</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Ma se Candida non si lascia da me vedere, se per
 avventura non si affaccia alle sue finestre, se vedendomi
 ricusa di ascoltarmi, se la zia glielo vieta, sono in un
 mare di agitazioni, di confusioni.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>(<emph>con un sacco in spalla di curame e scarpe <abbr>ecc.</abbr> va  per andare alla sua bottega, vede li due si ferma ad ascoltare</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Caro signor Evaristo ella mi fa pietà, mi fa
 compassione.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Sì, Giannina mia lo merito veramente.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Un signore sì buono, sì amabile, sì cortese!</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Voi conoscete il mio core, voi siete testimonio
 dell'amor mio.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>(Buono, sono arrivato a tempo) (<emph>col sacco in spalla  da sé</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>In verità, se sapessi io la maniera di consolarlo!</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>(Brava!)</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Sì ad ogni costo voglio tentar la mia sorte. Non
 voglio potermi rimproverare di aver trascurato di
 sincerarmi. Vado al caffè, Giannina, vado e vi vado
 tremando. Conservatemi l'amor vostro, e la vostra bontà (<emph>la  prende per mano, ed entra nel caffè</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Da una parte mi fa ridere, dall'altra mi fa
 compassione.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>(<emph>mette qui il sacco, tira fuori le scarpe <abbr>ecc.</abbr>, le mette sul  banchetto e in bottega senza dir niente</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Oh, ecco Crespino. Ben ritornato. Dove siete stato
 sin ora?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Non vedete? A comprare del cuoio, e a prendere
 delle scarpe d'accomodare.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Ma voi non fate che accomodar delle scarpe
 vecchie. Non vorrei, che dicessero... Sapete che non vi sono
 che delle male lingue.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Eh le male lingue avranno da divertirsi più sopra
 di voi che sopra di me (<emph>lavorando</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Sopra di me? che cosa possono dire di me?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Cosa m'importa che dicano, ch'io faccio più il
 ciabattino, che il calzolaro? Mi basta d'essere un
 galantuomo, e di guadagnarmi il pane onoratamente (<emph>lavorando</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Ma io non vorrei mi dicessero la ciabattina.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Quando?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Quando sarò vostra moglie.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Eh!</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Eh! cosa questo eh? cosa vuol dir questo eh?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Vuol dire, che la signora Giannina non sarà né
 ciabattina, né calzolaia, ch'ella ha delle idee vaste e
 grandiose.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Siete pazzo, o avete bevuto questa mattina?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Non son pazzo, non ho bevuto, ma non sono né orbo,
 né sordo.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>E che diavolo volete dire? Spiegatevi, se volete
 ch'io vi capisca (<emph>si avanza</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Vuol che mi spieghi? Mio spiegherò. Credete ch'io
 non abbia sentito le belle parole col signor Evaristo?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Col signor Evaristo?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p><emph>Sì Giannina mia... voi conoscete il mio core... voi siete testimonio dell'amor mio</emph> (<emph>contrafacendo  Evaristo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Oh matto! (<emph>ridendo</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p><emph>In verità se sapessi la maniera di consolarlo!</emph>
 (<emph>contrafacendo Giannina</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Oh matto! (<emph>come sopra</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p><emph>Giannina conservatemi l'amor vostro e la vostra bontà</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Matto, e poi matto.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Io matto?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Sì, voi, voi, matto, stramatto, e di là di matto.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Corpo del diavolo non ho veduto io? Non ho sentito
 la bella conversazione col signor Evaristo?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Matto.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>E quello che gli avete risposto?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Matto.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Giannina finite con questo matto, che farò da
 matto da vero (<emph>minacciando</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Ehi ehi! (<emph>con serietà, poi cangia tuono</emph>).
 Ma credete voi, che il signor Evaristo abbia della premura per me?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Non so niente.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>E ch'io sia così bestia per averne per lui?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Non so niente.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Venite qua, sentite. (<emph>dice presto presto</emph>).
 Il signor Evaristo è amante della signora Candida, e la signora Candida
@@ -4254,82 +4300,82 @@ lo ha burlato, e vuol sposare il signor Barone. E il signor Evaristo è
 disperato, è venuto a sfogarsi meco, ed io lo compassionava
 per burlarmi di lui, ed egli si consolava con me. Avete capito?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Né anche una parola.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Siete persuaso della mia innocenza?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Non troppo.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Quando è così, andate al diavolo. Coronato mi
 brama, Coronato mi cerca. Mio fratello gli ha dato parola.
 Il signor Conte mi stimola, mi prega. Sposerò Coronato (<emph>presto</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Adagio, adagio. Non andate subito sulle furie.
 Posso assicurarmi che dite la verità? Che non avete niente a
 che fare col signor Evaristo?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>E non volete, che vi dica matto? Caro il mio
 Crespino, che vi voglio tanto bene, che siete l'anima mia,
 il mio caro coccolo, il mio caro sposino (<emph>accarezzandolo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>E cosa vi ha donato il signor Evaristo? (<emph>dolcemente</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Niente.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Niente sicuro? niente?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Quando vi dico niente, niente. (Non voglio che
 sappia del ventaglio, che subito sospetterebbe).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Posso esser certo?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Ma via non mi tormentate.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Mi volete bene?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Sì vi voglio bene.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Via facciamo la pace (<emph>le tocca la mano</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Matto (<emph>ridendo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Ma perché matto? (<emph>ridendo</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Perché siete un matto.</p>
           </sp>
@@ -4339,81 +4385,81 @@ sappia del ventaglio, che subito sospetterebbe).</p>
           <stage>
             <emph>Coronato, ch'esce dall'osteria, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Finalmente ho saputo il regalo, che ha avuto la
 signora Giannina.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Cosa c'entrate con me voi?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Da chi ha avuto un regalo? (<emph>a Coronato</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Dal signor Evaristo.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Non è vero niente.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Non è vero niente?</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Sì sì, e so che regalo è (<emph>a Giannina</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Sia quel ch'esser si voglia, a voi non deve
 importare, io amo Crespino, e sarò moglie del mio Crespino.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>E bene che regalo è? (<emph>a Coronato</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Un ventaglio.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Un ventaglio? (<emph>a Giannina in collera</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>(Maladetto colui).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Avete ricevuto un ventaglio? (<emph>a Giannina</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Non è vero niente.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Tanto è vero che lo avete ancora in saccoccia.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Voglio veder quel ventaglio.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Signor no (<emph>a Crespino</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Troverò io la maniera di farvelo metter fuori.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Siete un impertinente.</p>
           </sp>
@@ -4423,69 +4469,69 @@ importare, io amo Crespino, e sarò moglie del mio Crespino.</p>
           <stage>
             <emph>Moracchio di casa colla salvietta e mangiando, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Cos'è questo baccanale?</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Vostra sorella ha avuto un ventaglio in regalo, lo
 ha in saccoccia, e nega di averlo.</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>A me quel ventaglio (<emph>a Giannina con comando</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Lasciatemi stare (<emph>a Moracchio</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Dammi quel ventaglio, che giuro al Cielo... (<emph>minacciandola</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Maladetto! Eccolo qui (<emph>lo fa vedere</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>A me, a me (<emph>lo vorrebbe prendere</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Lo voglio io (<emph>con collera lo vuole prendere</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Lasciatemi stare, maladetti.</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Presto, da' qui, che lo voglio io.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Signor no (<emph>a Moracchio</emph>). Piuttosto lo voglio dare
 a Crespino.</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Da' qui dico.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>A Crespino (<emph>dà il ventaglio a Crespino, e corre in  casa</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Date qui.</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Date qui.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Non l'avrete (<emph>tutti due sono attorno a Crespino  per averlo, egli fugge via per le quinte, e loro appresso</emph>).</p>
           </sp>
@@ -4496,69 +4542,69 @@ a Crespino.</p>
             <emph>Conte sulla terrazza, Timoteo alla balconata (poi il
 Barone e detti).</emph>
           </stage>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ehi, signor Timoteo (<emph>forte con premura</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>TIMOTEO</speaker>
             <p>Cosa comanda?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Presto, presto, portate dei spiriti, dei cordiali.
 È venuto male alla signora Candida.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>TIMOTEO</speaker>
             <p>Subito vengo (<emph>entra in bottega</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Che diavolo ha avuto a quella finestra? Bisogna che
 nel giardino del caffettiere vi siano delle piante
 avvelenate (<emph>entra</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>(<emph>traversa il teatro, e va dall'altra parte correndo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>CORONATO MORACCHIO</speaker>
             <p>(<emph>gli corrono dietro senza dir niente, e tutti via</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>(<emph>dal palazzino va a sollecitare lo speziale</emph>)Animo
 presto signor Timoteo.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>TIMOTEO</speaker>
             <p>Eccomi, eccomi.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Presto che vi è bisogno di voi (<emph>corre nel palazzino</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>TIMOTEO</speaker>
             <p>Son qui, son qui (<emph>va per entrare</emph>).
 (<emph>Crespino, Coronato, Moracchio da un'altra quinta corrono come sopra. Urtano Timoteo, e lo fanno cadere con tutte le sue boccette, che si fracassano, Crespino casca e perde il ventaglio. Coronato lo prende e lo porta via. Timoteo si alza e torna in bottega</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Eccolo, eccolo lo ho avuto io (<emph>a Moracchio</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Ci ho gusto, tenetelo voi. Giannina mi renderà conto
 da chi l'ha avuto (<emph>entra in casa</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Intanto gliel'ho fatta vedere, l'ho avuto io (<emph>entra nell'osteria</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Oh maladetti! Mi hanno stroppiato. Ma pazienza. Mi
 dispiace più, che Coronato abbia avuto il ventaglio.
@@ -4608,70 +4654,70 @@ mangia, ride ed entra. CRESPINO tira fuori il ventaglio, lo guarda
 e ride, e poi lo rimette, poi seguita a mangiare e bere. (Qui termina
 la scena muta). Il CONTE e il BARONE escono dal palazzino.</emph>
           </stage>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>No, amico, scusatemi, non vi potete doler di
 niente.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Vi assicuro, che non ho nemmeno ragione di lodarmi.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Se la signora Candida si è trovata male, è un
 accidente, vi vuol pazienza. Sapete che le donne sono
 soggette ai vapori, agli affetti sterili.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Sterili? Isterici vorrete dire...</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sì, isterici, isterici come volete. In somma, se
 non vi ha fatto tutta l'accoglienza, non è colpa sua, è
 colpa della malattia.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Ma quando siamo entrati, non era ammalata, e appena
 mi ha veduto si è ritirata nella sua camera.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Perché si sentiva il cominciamento del male.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Avete osservato la signora Geltruda, quando è
 sortita dalla camera della nipote, con che premura, con che
 ammirazione leggeva alcuni fogli, che parevano de'
 viglietti?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>È una donna che ha degli affari assai. Saranno
 viglietti arrivati allora di fresco.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>No, erano viglietti vecchi. Ci scommetto, ch'è
 qualche cosa, che ha trovato o sul tavolino, o indosso della
 signora Candida.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Siete curioso, collega mio, siete caro, siete
 particolare. Cosa vi andate voi immaginando?</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>M'immagino quel che potrebbe essere. Ho sospetto,
 che vi sia dell'intelligenza fra la signora Candida, ed
 Evaristo.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Oh non vi è dubbio. Se fosse così lo saprei. Io so
 tutto. Non si fa niente nel villaggio, che io non sappia. E
@@ -4680,7 +4726,7 @@ acconsentito alla vostra proposizione? Ch'ella avrebbe
 ardito di compromettere la mediazione di un cavaliere della
 mia sorte?</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Questa è una buona ragione. Ella ha detto di sì
 senza farsi pregare. Ma la signora Geltruda dopo la lettura
@@ -4688,55 +4734,55 @@ di quei viglietti, non mi ha fatte più le gentilezze di
 prima, anzi in certo modo ha mostrato piacere, che ce ne
 andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Vi dirò. Tutto quello, di cui si possiamo dolere
 della signora Geltruda si è, ch'ella non ci abbia proposto
 di restar a pranzo da lei.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Per questo non mi fa spezie.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Le ho dato io qualche tocco, ma ha mostrato di non
 intendere.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Vi assicuro, ch'ella aveva gran volontà, che le si
 levasse l'incomodo.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Mi dispiace per voi... Dove pranzate oggi?</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Ho ordinato all'oste il desinare per due.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Per due?</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Aspetto Evaristo ch'è andato alla caccia.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Se volete venire a pranzo da me...</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Da voi?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ma il mio palazzo è mezzo miglio lontano.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Vi ringrazio, perché il pranzo è di già ordinato.
 Ehi dall'osteria. Coronato.</p>
@@ -4747,385 +4793,385 @@ Ehi dall'osteria. Coronato.</p>
           <stage>
             <emph>Coronato dall'osteria, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Mi comandi.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>È venuto il signor Evaristo?</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Non l'ho ancora veduto, signore. Mi dispiace, che il
 pranzo è all'ordine, e che la robba patisce.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Evaristo è capace di divertirsi alla caccia fin
 sera, e farvi star senza pranzo.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Cosa volete, che io faccia? Ho promesso aspettarlo.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Aspettarlo, va bene fino ad un certo segno. Ma caro
 amico, non siete fatto per aspettare un uomo di una
 condizione inferiore alla vostra. Accordo la civiltà,
 l'umanità, ma, collega amatissimo, sosteniamo il decoro.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Quasi quasi vi pregherei di venir a occupare il
 posto del signor Evaristo.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Se non volete aspettare, e se vi rincresce di
 mangiar solo, venite da me, e mangeremo quello che ci sarà.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>No caro Conte fatemi il piacere di venir con me.
 Mettiamoci a tavola, e se Evaristo non ha discrezione a suo
 danno.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Che impari la civiltà (<emph>contento</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Ordinate, che diano in tavola (<emph>a Coronato</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Subito resti servita. (Avanzerà poco per la cucina) (<emph>da sé</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Andrò a vedere, che cosa ci hanno preparato da
 pranzo (<emph>entra</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Avete portato l'altro barile di vino? (<emph>a Coronato</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Signor sì l'ho mandato.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>L'avete mandato? Senz'accompagnarlo? Mi faranno
 qualche baronata.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Le dirò, ho accompagnato il garzone fino alla punta
 dello stradone, ho incontrato il suo uomo...</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Il mio fattore?</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Signor no.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Il mio cameriere?</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Signor no.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Il mio lacchè?</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Signor no.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>E chi dunque?</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Quell'uomo, che sta con lei, che va a vendere i
 frutti, l'insalata, gli erbaggi...</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Come! quello...</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Tutto quel che comanda. L'ho incontrato, gli ho
 fatto veder il barile, ed egli ha accompagnato il garzone.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>(Diavolo! colui che non vede mai vino è capace di
 bevere la metà del barile) (<emph>vuol entrare</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Favorisca.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Cosa c'è? (<emph>brusco</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Ha parlato per me a Giannina?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sì, l'ho fatto.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Cosa ha detto?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Va bene, va bene (<emph>imbarazzato</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Va bene?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Parleremo, parleremo poi (<emph>in atto di entrare</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Mi dica qualche cosa.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Andiamo, andiamo, che non voglio far aspettare il
 Barone (<emph>entra</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>(Ci ho buona speranza... È un uomo che quando vi si
 mette... qualche volta ci riesce). Giannina (<emph>amoroso, e brusco</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>(<emph>fila, e non risponde</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Almeno lasciatevi salutare.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Fareste meglio a rendermi il mio ventaglio (<emph>senza  guerdar, e filando</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Sì... (Uh, a proposito mi ho scordato il ventaglio
 in cantina!) Sì sì, parlaremo poi del ventaglio. (Non vorrei
 che qualcheduno lo portasse via) (<emph>entra</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>(<emph>ride forte</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Avete il cuor contento signor Crespino, ridete molto
 di gusto.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Rido perché ho la mia ragione di ridere.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Voi ridete, ed io mi sento rodere dalla rabbia (<emph>a Crespino</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Rabbia? E di che avete rabbia?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Che quel ventaglio sia nelle mani di Coronato.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Sì, è nelle mani di Coronato (<emph>ridendo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>E per che cosa ridete?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Rido perché è nelle mani di Coronato (<emph>si alza, prende gl'avanzi del desinare, ed entra in bottega</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>È un ridere veramente da sciocco.</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Non credeva, che il mio ventaglio avesse da passare
 per tante mani (<emph>lavorando</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Il vostro ventaglio? (<emph>voltandosi con dispetto</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Sì, dico il mio ventaglio, perché è sortito dalla
 mia bottega.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>M'immagino, che ve l'avranno pagato.</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Ci s'intende. Senza di questo non l'avrebbero avuto.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>E l'avranno anche pagato il doppio di quel che
 vale.</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Non è vero, e se fosse anche vero, cosa v'importa?
 Per quello, che vi costa lo potete prendere.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Cosa sapete voi quello che mi costi?</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Oh se vi costa poi qualche cosa... non so niente
 io... Se chi ve l'ha dato ha delle obbligazioni... (<emph>con flemma caricata, satirica</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Che obbligazioni? Cosa parlate d'obbligazioni? Mi
 maraviglio de' fatti vostri (<emph>balza in piedi</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Ehi, ehi non crediate di farmi paura.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>(<emph>dalla bottega</emph>). Cosa c'è? Sempre strepiti, sempre gridori.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>(Ho una volontà di rompere questa rocca) (<emph>da sé siede, e fila</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Non fa che pungere, e non vuol che si parli.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Siete in collera Giannina? (<emph>siede, e si mette a lavorare</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Io in collera? Non vado mai in collera io (<emph>filando</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Oh ella è pacifica, non si altera mai (<emph>ironica</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Mai, quando non mi tirano per li capelli, quando
 non mi dicono delle impertinenze, quando non pretendono di
 calpestarmi (<emph>in modo, che Susanna senta</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker> SUSANNA</speaker>
             <p>(<emph>mena la testa, e brontola da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Sono io che vi maltratta, che vi calpesta? (<emph>lavorando</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Io non parlo per voi (<emph>filando con dispetto</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>No non parla per voi, parla per me (<emph>burlandosi</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Gran cosa! In questo recinto di quattro case non
 si può stare un momento in pace.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Quando vi sono delle male lingue...</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Tacete, ch'è vergogna...</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Insulta, e poi non vuol che si parli.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Parlo con ragione, e con fondamento.</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Oh è meglio, ch'io taccia, ch'io non dica niente.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Certo, ch'è meglio tacere, che dire delle
 scioccherie.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>E vuol esser l'ultima.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Oh sì anche in fondo d'un pozzo.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>TIMOTEO</speaker>
             <p>(<emph>dal palazzino colla sottocoppa, e caraffe</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Chi mi vuole mi prenda, e chi non mi vuole mi lasci.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Zitto, zitto non vi fate sentire.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>TIMOTEO</speaker>
             <p>(In questa casa non ci vado più. Che colpa ci ho io,
 se queste acque non vagliano niente? Io non posso dare che
@@ -5134,110 +5180,110 @@ ritrovare le delizie della città. E poi cosa sono i spiriti,
 gli elisiri, le quintessenze? Ciarlatanate. Questi sono i
 cardini della medicina: acqua, china e mercurio) (<emph>da sé, ed entra nella speziaria</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Bisogna che ci sia qualcheduno d'ammalato in casa
 della signora Geltruda (<emph>verso Giannina</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Sì quella cara gioia della signora Candida (<emph>con disprezzo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Povera signora Candida! (<emph>forte</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Che male ha?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Che so io, che male abbia! Pazzia.</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Eh, so io, che male ha la signora Candida.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Che male ha? (<emph>a Susanna</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Dovrebbe saperlo anche la signora Giannina (<emph>caricata</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Io? Cosa c'entro io?</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Sì, perché è ammalata per causa vostra.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Per causa mia? (<emph>balza in piedi</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Già con voi non si può parlare.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Vorrei ben sapere, come va quest'imbroglio (<emph>si alza</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Non siete capace che di dire delle bestialità (<emph>a Susanna</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Via, via la non si scaldi.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Lasciatela dire (<emph>a Giannina</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Con qual fondamento potete dirlo? (<emph>a Susanna</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Non parliamo altro.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>No, no parlate.</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>No Giannina non mi obbligate a parlare.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Se siete una donna d'onore parlate.</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Oh quando è così, parlerò.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Zitto zitto, viene la signora Geltruda, non
 facciamo scene dinnanzi a lei (<emph>si ritira al lavoro</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Oh, voglio, che mi renda ragione di quel che ha
 detto (<emph>da sé camminando verso la sua casa</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>(Vuol che si parli? Sì parlerò) (<emph>siede e lavora</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>(Se posso venire in chiaro di quest'affare...) (<emph>siede e lavora</emph>).</p>
           </sp>
@@ -5247,163 +5293,163 @@ detto (<emph>da sé camminando verso la sua casa</emph>).</p>
           <stage>
             <emph>Geltruda dal palazzino, e li suddetti.</emph>
           </stage>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Dite voi. È ritornato vostro fratello? (<emph>a Giannina con gravità</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Signora sì (<emph>con malagrazia, e camminando verso casa sua</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Sarà tornato anche il signor Evaristo (<emph>come sopra</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Signora sì (<emph>come sopra</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Sapete dove sia il signor Evaristo? (<emph>a Giannina</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Non so niente (<emph>con dispetto</emph>). Serva sua (<emph>entra in casa</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>(Che maniera gentile!) Crespino.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Signora (<emph>si alza</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Sapete voi dove si trovi il signor Evaristo?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>No signora, in verità non lo so.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Fatemi il piacere di andare a vedere se fosse
 nell'osteria.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>La servo subito (<emph>va nell'osteria</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Signora Geltruda (<emph>sottovoce</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Che volete?</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Una parola (<emph>si alza</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Sapete niente voi del signor Evaristo?</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Eh signora mia so delle cose assai. Avrei delle cose
 grandi da dirle.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Oh Cieli! Ho delle cose anch'io che m'inquietano.
 Ho veduto delle lettere, che mi hanno sorpreso. Ditemi,
 illuminatemi, ve ne prego.</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Ma qui in pubblico?... Si ha da fare con delle teste
 senza ragione... Se vuole ch'io venga da lei...</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Vorrei prima vedere il signor Evaristo.</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>O se vuol venire da me...</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Piuttosto. Ma aspettiamo Crespino.</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Eccolo.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>(<emph>dall'osteria</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>E così?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Non c'è, signora. L'aspettavano a pranzo, e non è
 venuto.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Eppure dalla caccia dovrebbe essere ritornato.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Oh, è ritornato sicuramente. L'ho veduto io.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Dove mai può essere?</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Al caffè non c'è (<emph>guarda in bottega</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Dallo speziale nemmeno (<emph>guarda dallo speziale</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Vedete un poco. Il villaggio non è assai grande,
 vedete, se lo ritrovate.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Vado subito per servirla.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Se lo trovate, ditegli che mi preme parlargli, e
 che l'aspetto qui in casa della merciaia (<emph>a Crespino</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Sarà servita (<emph>s'incammina</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Andiamo, ho ansiosità di sentire (<emph>entra in bottega</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Vada, vada; sentirà delle belle cose (<emph>entra</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Vi sono degl'imbrogli con questo signor Evaristo.
 E quel ventaglio... Ho piacere di averlo io nelle mani.
@@ -5432,94 +5478,94 @@ più, poco meno. Le voglio bene. Cosa mai sarà? (<emph>va per partire</emph>).<
           <stage>
             <emph>Limoncino dal caffè, e detto (poi Coronato).</emph>
           </stage>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Oh, mi sapreste dire dove sia il signor Evaristo?</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker>LIMONCINO</speaker>
             <p>Io? Cosa sono? Il suo servitore?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Gran cosa veramente! non potrebbe esser nella
 vostra bottega?</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker>LIMONCINO</speaker>
             <p>Se ci fosse lo vedreste (<emph>si avanza</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Limoncino del diavolo.</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker>LIMONCINO</speaker>
             <p>Cos'è questo Limoncino?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Vieni vieni a farti rappezzare le scarpe (<emph>via</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker>LIMONCINO</speaker>
             <p>Birbante! Subito anderò a dirgli, che il signor
 Evaristo è nel nostro giardino. Ora ch'è in giubilo, in
 consolazione, non ha bisogno di essere disturbato. Ehi
 dall'osteria (<emph>chiama</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>(<emph>alla porta</emph>) Cosa c'è?</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker>LIMONCINO</speaker>
             <p>Ha mandato a dire il signor Evaristo, che dite al
 signor Barone, che desini, e non l'aspetti, perché è
 impegnato, e non può venire.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Ditegli, che l'ambasciata è arrivata tardi, e che il
 signor Barone ha quasi finito di pranzare.</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker>LIMONCINO</speaker>
             <p>Bene, bene, glie lo dirò quando lo vedrò (<emph>va per partire</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Dite quel giovane.</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker>LIMONCINO</speaker>
             <p>Comandate.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>A caso, avreste sentito a dire, che qualcheduno
 avesse ritrovato un ventaglio?</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker>LIMONCINO</speaker>
             <p>Io no.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Se mai sentiste a parlare, vi prego farmi avvisato.</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker>LIMONCINO</speaker>
             <p>Signor sì, volentieri. L'avete perduto voi?</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>L'aveva io. Non so come diavolo si sia perduto.
 Qualche briccone l'ha portato via, e quei stolidi de' miei
 garzoni non sanno nemmeno chi sia stato a prender del vino.
 Ma se lo scopro! Se lo scopro! Mi raccomando a voi (<emph>entra</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker>LIMONCINO</speaker>
             <p>Dal canto mio farò il possibile (<emph>s'incammina</emph>).</p>
           </sp>
@@ -5529,100 +5575,100 @@ Ma se lo scopro! Se lo scopro! Mi raccomando a voi (<emph>entra</emph>).</p>
           <stage>
             <emph>Il Conte alla finestra dell'osteria, e Limoncino (poi Giannina).</emph>
           </stage>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ho sentito la voce di Limoncino. Ehi quel giovane
 (<emph>forte</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker>LIMONCINO</speaker>
             <p>Signore (<emph>si volta</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Portateci due buoni caffè.</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker>LIMONCINO</speaker>
             <p>Per chi, illustrissimo?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Per me.</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker>LIMONCINO</speaker>
             <p>Tutti due per lei?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Uno per me, ed uno per il Barone del Cedro.</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker>LIMONCINO</speaker>
             <p>Sarà servita.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Subito, e fatto a posta (<emph>entra</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker>LIMONCINO</speaker>
             <p>(Ora che so che vi è il Barone che paga, glieli
 porterò) (<emph>s'incammina</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>(<emph>di casa senza la rocca</emph>) Ehi Limoncino.</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker>LIMONCINO</speaker>
             <p>Anche voi volete seccarmi con questo nome di
 Limoncino?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Via via non andate in collera. Non vi ho detto né
 rava, né zucca, né cocomero, né melenzana.</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker>LIMONCINO</speaker>
             <p>Ne avete ancora?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Venite qui, ditemi: il signor Evaristo e ancor là?
 (<emph>placidamente</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker>LIMONCINO</speaker>
             <p>Dove là?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Da voi.</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker>LIMONCINO</speaker>
             <p>Da noi?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Sì da voi (<emph>si scalda un poco</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker>LIMONCINO</speaker>
             <p>La bottega è lì, se ci fosse lo vedreste.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Puh! nel giardino.</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker>LIMONCINO</speaker>
             <p>Puh! non so niente (<emph>via ed entra in bottega</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Pezzo d'animalaccio! Se avessi la rocca gliela
 scavezzerei sul collo. E poi dicono ch'io son cattiva. Tutti
@@ -5637,44 +5683,44 @@ maledetti quanti che siete.</p>
             <emph>Evaristo dal caffè correndo con allegria, e detta (poi
 Coronato).</emph>
           </stage>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Oh eccola, eccola. Son fortunato (<emph>a Giannina</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Ih! ih! Cosa vuol dir quest'allegria?</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Oh Giannina, sono l'uomo il più felice, il più
 contento del mondo.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Bravo, me ne consolo. Spero, che mi farete dare
 soddisfazione delle impertinenze, che m'hanno detto.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Sì tutto quel volete. Sappiate, Giannina mia, che
 voi eravate presa in sospetto. La signora Candida ha saputo,
 ch'io aveva dato il ventaglio, credeva, che lo avessi
 comprato per voi, era gelosa di me, era gelosa di voi.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Era gelosa di me?</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Sì, certo.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Ah che ti venga la rabbia! (<emph>verso il palazzino</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Si voleva maritar con altri per sdegno, per
 vendetta, per disperazione. Mi ha veduto, è caduta, è
@@ -5685,196 +5731,196 @@ saltato il muro, mi son gettato a' suoi piedi; ho pianto, ho
 pregato, l'ho sincerata, l'ho vinta, è mia, è mia, non vi è
 più da temere (<emph>con giubilo e affannoso</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Me ne rallegro, me ne congratulo, me ne consolo.
 Sarà sua, sua sempre sua, ne ho piacer, ne ho contento, ne
 ho soddisfazione (<emph>lo carica un poco</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Una sola condizione ella ha posto alla mia sicura,
 alla mia intera felicità.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>E qual è questa condizione?</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Per giustificare me intieramente, per giustificar
 voi nel medesimo tempo, e per dar a lei una giusta
 soddisfazione, è necessario, ch'io le presenti il ventaglio (<emph>come sopra</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Ora stiamo bene.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Ci va del mio, e del vostro decoro. Parerebbe,
 ch'io l'avessi comprato per voi, si darebbe credito a' suoi
 sospetti. So che siete una giovane saggia, e prudente.
 Favoritemi quel ventaglio (<emph>sempre con premura</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Signore... Io non l'ho più il ventaglio (<emph>confusa</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Oh via, avete ragione. Ve l'ho donato, e non lo
 domanderei, se non mi trovassi in questa estrema necessità.
 Ve ne comprerò un altro. Un altro molto meglio di quello; ma
 per amor del cielo datemi subito quel che vi ho dato.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Ma vi dico signore, ch'io non l'ho più.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Giannina si tratta della mia vita, e della vostra
 riputazione (<emph>con forza</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Vi dico sull'onor mio, e con tutti i giuramenti
 del mondo, che io non ho quel ventaglio.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Oh cielo! cosa dunque ne avete fatto? (<emph>con caldo</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Hanno saputo, ch'io aveva quel ventaglio, mi sono
 saltati intorno come tre cani arrabbiati...</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Chi? (<emph>infuriato</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Mio fratello...</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Moracchio... (<emph>corre a chiamarlo alla casa</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>No fermate, non l'ha avuto Moracchio.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Ma chi dunque? (<emph>battendo i piedi</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Io l'ho dato a Crespino...</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Ehi? Dove siete? Crespino! (<emph>corre alla bottega</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Ma venite qui, sentite...</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Son fuor di me.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Non l'ha più Crespino.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Ma chi lo ha? Chi lo ha? Presto.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Lo ha quel birbante di Coronato.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Coronato? Subito. Coronato? (<emph>all'osteria</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Signore.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Datemi quel ventaglio.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Qual ventaglio?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Quello che avevo io, e ch'è robba sua.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Animo, subito, senza perder tempo.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Signore, me ne dispiace infinitamente...</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Che?</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Ma il ventaglio non si trova più.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Non si trova più?</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Per distrazione l'ho messo sopra una botte. L'ho
 lasciato lì, son andato, son ritornato, non l'ho trovato
 più, qualcheduno l'ha portato via.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Che si trovi.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Dove? Ho fatto di tutto.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Dieci, venti, trenta zecchini lo potrebbero far
 ritrovare?</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Quando non c'è, non c'è.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Son disperato.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Mi dispiace, ma non so cosa farle (<emph>entra</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Voi siete la mia rovina, il mio precipizio (<emph>contro Giannina</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Io? Che ci ho colpa io?</p>
           </sp>
@@ -5884,113 +5930,113 @@ ritrovare?</p>
           <stage>
             <emph>Candida sulla terrazza, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Signor Evaristo (<emph>lo chiama</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>(Eccola, eccola: son disperato).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Che diavolo! È finito il mondo per questo?</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Signor Evaristo! (<emph>torna a chiamarlo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Ah Candida mia dilettissima sono l'uomo più
 afflitto, più mortificato del mondo.</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Eh che sì che il ventaglio non si può più avere?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>(L'ha indovinata alla prima).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Quante combinazioni in mio danno! Sì pur troppo è
 la verità. Il ventaglio è smarrito, e non è possibile di
 ritrovarlo per ora (<emph>a Candida</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Oh, so dove sarà.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Dove? dove? Se aveste qualche indizio per
 ritrovarlo...</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Chi sa? Può essere che qualcheduno l'abbia
 trovato (<emph>ad Evaristo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Sentiamo (<emph>a Giannina</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Il ventaglio sarà nelle mani di quella, a cui lo
 avete donato, e non vuol renderlo, ed ha ragione.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Non è vero niente (<emph>a Candida</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Tacete.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Vi giuro sull'onor mio...</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Basta così. Il mio partito è preso. Mi meraviglio
 di voi, che mi mettete a fronte di una villana (<emph>via</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Cos'è questa villana? (<emph>alla terrazza</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Giuro al cielo, voi siete cagione della mia
 disperazione, della mia morte (<emph>contro Giannina</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Ehi, ehi non fate la bestia.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Ella ha preso il suo partito. Io deggio prendere il
 mio. Aspetterò il mio rivale, l'attaccherò colla spada, o
 morirà l'indegno, o sagrificherò la mia vita... Per voi, per
 voi a questo duro cimento.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Oh è meglio che vada via. Ho paura che diventi
 matto (<emph>va pian piano verso la casa</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Ma come! la passione mi opprime il core; mi manca
 il respiro. Non mi regge il piede; mi si abbagliano gli
 occhi. Misero me! chi m'aiuta? (<emph>si lascia cadere su una sedia del caffè, a si abbandona affatto</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>(<emph>voltandosi lo vede cadere</emph>) Cos'è? cos'è? More
 povero diavolo! More, aiuto gente, ehi Moracchio! Ehi dal caffè!</p>
@@ -6003,191 +6049,191 @@ povero diavolo! More, aiuto gente, ehi Moracchio! Ehi dal caffè!</p>
 all'osteria; Moracchio dalla casa accorre in aiuto di evaristo
 (seguono Crespino e Timoteo, poi il Conte).</emph>
           </stage>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>(<emph>di strada</emph>) Oh eccolo qui il signor Evaristo.
 Cos'è stato?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Dell'acqua, dell'acqua (<emph>a Limoncino</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Del vino, del vino (<emph>corre in bottega</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker>LIMONCINO</speaker>
             <p>Dategli del vino. Io porterò il caffè all'osteria
 (<emph>parte</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Animo, animo, signor Evaristo. Alla caccia, alla
 caccia.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Sì altro che caccia! È innamorato. Ecco tutto il
 suo male.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>TIMOTEO</speaker>
             <p>(<emph>dalla speziaria</emph>) Cosa c'è?</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Venga qui, venga qui, signor Timoteo.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Venga a soccorrere questo povero galantuomo.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>TIMOTEO</speaker>
             <p>Che male ha?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>È in accidente.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>TIMOTEO</speaker>
             <p>Bisogna cavargli sangue.</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>È capace vossignoria?</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>TIMOTEO</speaker>
             <p>In caso di bisogno si fa di tutto (<emph>va alla speziaria</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>(Oh povero signor Evaristo, lo stroppia
 assolutamente).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>(<emph>dalla bottega con un fiasco di vino</emph>) Ecco, ecco,
 questo lo farà rinvenire, è vino vecchio di cinque anni.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Pare che rinvenga un poco.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Oh questo fa risuscitare i morti.</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Animo animo si dia coraggio.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>TIMOTEO</speaker>
             <p>(<emph>dalla speziaria con bicchiere, pezze, e rasoio</emph>) Eccomi
 qui, presto, spogliatelo.</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>E cosa volete far del rasoio?</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>TIMOTEO</speaker>
             <p>In caso di bisogno serve meglio di una lancetta.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Un rasoio?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Un rasoio?</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Chi è che vuol assassinarmi con un rasoio? (<emph> pa- teticamente alzandosi</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Il signor Timoteo.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>TIMOTEO</speaker>
             <p>Son un galantuomo, non assassino alcuno, e quando si
 fa quello, che si può, e quello che si sa, nessuno ha
 occasione di rimproverare. (Che mi chiamino un'altra volta
 che or verrò!) (<emph>entra in bottega</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Vuol venire da me, signor Evaristo? Riposerà sul mio
 letto.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Andiamo dove volete.</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Mi dia il braccio, s'appoggi.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Quanto meglio saria per me che terminassi questa
 misera vita! (<emph>s'incammina sostenuto da Moracchio</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>(Se ha volontà di morire basta che si raccomandi
 allo speziale).</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Eccoci alla porta. Andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Pietà inutile a chi non desidera che di morire
 (<emph>entrano</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Giannina, vieni ad accomodar il letto per il signor
 Evaristo (<emph>sulla porta ed entra</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>(<emph>vorrebbe andare anch'ella</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Giannina? (<emph>la chiama</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Cos'è?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Siete molto compassionevole per quel signore!</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Faccio il mio debito perché io e voi siamo la
 causa del suo male.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Per voi non so che dire. Ma io? Come c'entro io?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Per causa di quel maladetto ventaglio.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Maladetto ventaglio! L'avrò sentito nominare un
 milione di volte. Ma ci ho gusto per quell'ardito di
@@ -6199,267 +6245,267 @@ in qualche imbarazzo. Ho sentito a dire, che in certe
 occasioni i stracci vanno all'aria. Ed io i pochi che ho, me
 li vo' conservare (<emph>va al banco suo, e prende il ventaglio</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker>LIMONCINO</speaker>
             <p>Ed il...</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>(<emph>dall'osteria</emph>) Vien qui aspetta (<emph>prende un pezzetto di zucchero e se lo mette in bocca</emph>). Per il raffreddore.</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker>LIMONCINO</speaker>
             <p>Per la gola.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Che?</p>
           </sp>
-          <sp>
+          <sp who="#limoncino">
             <speaker>LIMONCINO</speaker>
             <p>Dico, che fa bene alla gola (<emph>parte e va in bottega</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>(Quasi, quasi... Sì questo è il meglio di tutto) (<emph>s'avanza col ventaglio</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Oh buon giorno, Crespino.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Servitor di <abbr>V.</abbr> <abbr>S.</abbr> illustrissima.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sono accomodate le scarpe? (<emph>piano</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Domani sarà servita (<emph>fa vedre il ventaglio</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Che cosa avete di bello in quella carta?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>È una cosa che ho trovato per terra vicino
 all'osteria della posta.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Lasciate vedere.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Si servi (<emph>glie lo dà</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Oh un ventaglio! Qualcheduno passando l'averà
 perduto. Cosa volete fare di questo ventaglio?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Io veramente non saprei cosa farne.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Lo volete vendere?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Oh venderlo! Io non saprei cosa domandarne. Lo
 crede di prezzo questo ventaglio?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Non so, non me n'intendo. Vi sono delle figure...
 ma un ventaglio trovato in campagna non può valere gran
 cosa.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Io avrei piacere che valesse assai.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Per venderlo bene.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>No in verità, illustrissimo. Per aver il piacere
 di farne un presente a <abbr>V.</abbr> <abbr>S.</abbr> illustrissima.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>A me? Me lo volete donare a me? (<emph>contento</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Ma come non sarà cosa da par suo...</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>No no, ha il suo merito, mi par buonino. Vi
 ringrazio, caro. Dove posso, vi esibisco la mia protezione.
 (Ne farò un regalo, e mi farò onore).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Ma la supplico d'una grazia.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>(Oh, già lo sapevo. Costoro non danno niente senza
 interesse). Cosa volete? Parlate.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>La prego non dire di averlo avuto da me.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Non volete altro?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Niente altro.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>(Via via è discreto). Quando non volete altro... ma
 ditemi in grazia, non volete che si sappia, che l'ho avuto
 da voi? Per avventura l'avreste rubbato?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Perdoni illustrissimo, non son capace...</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ma perché non volete che si sappia, che l'ho avuto
 da voi? Se l'avete trovato, e se il padrone non lo domanda,
 io non ci so vedere la ragione.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Eh c'è la sua ragione (<emph>ridendo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>E qual è?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Le dirò. Io ho un'amorosa.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Lo so benissimo. È Giannina.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>E se Giannina sapesse, che io aveva questo
 ventaglio, e che non l'ho donato a lei se ne avrebbe a male.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Avete fatto bene a non darglielo. Non è ventaglio
 per una contadina (<emph>lo mette via</emph>). Non dubitate, non dirò niente
 d'averlo avuto da voi. Ma a proposito: come vanno gli affari vostri
 con Giannina? Avete veramente volontà di sposarla?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Per dirle la verità... Le confesso il mio debole.
 La sposerei volontieri.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Quand'è così non dubitate. Ve la faccio sposar
 questa sera, se voi volete.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Davvero!</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Che sono io? Cosa val la mia protezione!</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Ma Coronato che la pretende?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Coronato?... Coronato è uno sciocco. Vi vuol bene
 Giannina?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Assai.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Bene dunque. Voi siete amato, Coronato non lo può
 soffrire: fidatevi della mia protezione.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Fin qui l'intendo ancor io. Ma il fratello?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Che fratello? che fratello? Quando la sorella è
 contenta, cosa c'entra il fratello? Fidatevi della mia
 protezione.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Mi raccomando dunque alla sua bontà.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sì, alla mia protezione.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Vado a terminare d'accomodar le sue scarpe.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Dite piano. Ne avrei bisogno d'un paio di nuove.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>La servirò.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Eh! le voglio pagare, sapete? Non credeste mai...
 Io non vendo la mia protezione.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Oh per un paio di scarpe!</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Andate, andate a fare le vostre faccende.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Vado subito (<emph>va per andare al banco</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>(<emph>tira fuori il ventaglio, e a poco a poco lo esamina</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>(Oh cospetto di bacco! Mi era andato di mente. Mi
 ha mandato la signora Geltruda a cercar il signor Evaristo,
@@ -6470,7 +6516,7 @@ Moracchio. Farò così, anderò a ritrovare la signora
 Geltruda. Le dirò, che il signor Evaristo è in casa di
 Giannina, e lo manderà a chiamare da chi vorrà) (<emph>entra nella bottega della merciaia</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Eh! Guarda e riguarda: è un ventaglio. Che può
 costar?... che so io? Sette o otto paoli. Se fosse qualche
@@ -6478,23 +6524,23 @@ cosa di meglio, lo donerei alla signora Candida, che questa
 mattina ha rotto il suo. Ma perché no? Non è poi tanto
 cattivo.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>(<emph>alla finestra</emph>)  (Non vedo Crespino.
 Dove sarà andato a quest'ora?)</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Queste figure non sono ben dipinte, ma mi pare che
 non siano mal disegnate.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>(Oh cosa vedo! Il ventaglio in mano del signor
 Conte! Presto presto andiamo a risvegliare il signor
 Evaristo) (<emph>via</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Basta, non si ricusa mai niente. Qualche cosa farò.</p>
           </sp>
@@ -6504,135 +6550,135 @@ Evaristo) (<emph>via</emph>).</p>
           <stage>
             <emph>Barone dall'osteria e detto (poi Tognino).</emph>
           </stage>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Amico, mi avete piantato lì.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ho veduto che non avevate volontà di parlare.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Sì, è vero; non posso ancor darmi pace... Ditemi, vi
 pare, che possiamo ora tentar di riveder queste signore?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Perché no? Mi viene ora in mente una cosa buona.
 Volete, ch'io vi faccia un regalo? Un regalo, con cui vi
 potete far onore colla signora Candida.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Cos'è questo regalo?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sapete, che questa mattina ella ha rotto il suo
 ventaglio?</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>È vero; m'è stato detto.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ecco un ventaglio. Andiamola a ritrovare, e
 presentateglielo voi colle vostre mani (<emph>lo dà al Barone</emph>).
 Guardate, guardate non è cattivo.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>E volete dunque...</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sì, presentatelo come voi. Io non voglio farmi
 alcun merito. Lascio tutto l'onore a voi.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Accetterò volentieri quest'occasione, ma mi
 permetterete, che dimandi cosa vi costa?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Cosa v'importa a sapere quel che mi costa?</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Per soddisfarne il prezzo.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Oh cosa serve! Mi meraviglio. Anche voi mi avete
 donato quelle pistole...</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Non so che dire. Accetterò le vostre finezze. (Dove
 diavolo ha trovato questo ventaglio? Mi pare impossibile,
 ch'egli l'abbia comprato) (<emph>guardandolo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ah cosa dite? Non è una galanteria? Non è venuto a
 tempo? Oh io in queste occasioni so quel che ci vuole. So
 prevedere. Ho una camera piena di queste galanterie per le
 donne. Orsù andiamo, non perdiamo tempo (<emph>corre e batte al palazzino</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>(<emph>sulla terrazza</emph>) Cosa comanda?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Si può riverire queste signore?</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>La signora Geltruda è fuori di casa, e la signora
 Candida è nella sua camera, che riposa.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Subito che si sveglia avvisateci.</p>
           </sp>
-          <sp>
+          <sp who="#tognino">
             <speaker>TOGNINO</speaker>
             <p>Sarà servita (<emph>via</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Avete sentito?</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Bene, bisogna aspettare. Ho da scrivere una lettera
 a Milano, andrò a scriverla dallo speziale. Se volete venire
 anche voi...</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>No no da colui vi vado mal volentieri. Andate a
 scrivere la vostra lettera, io resterò qui ad aspettare
 l'avviso del servitore.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Benissimo. Ad ogni cenno sarò con voi.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Fidatevi di me, e non dubitate.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>(Ah, mi fido poco di lui, meno della zia, e meno
 ancora della nipote) (<emph>va dallo speziale</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Mi divertirò col mio libro; colla mia preziosa
 raccolta di favole meravigliose (<emph>tira fuori il libro e siede</emph>).</p>
@@ -6643,7 +6689,7 @@ raccolta di favole meravigliose (<emph>tira fuori il libro e siede</emph>).</p>
           <stage>
             <emph>Evaristo dalla casa di Giannina, e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>(Oh, eccolo ancora qui, dubitava, ch'ei fosse
 partito. Non so come il sonno abbia potuto prendermi fra
@@ -6651,184 +6697,184 @@ tante afflizioni. La stanchezza... la lassitudine. Ora mi
 par di rinascere. La speranza di ricuperar il ventaglio...)
 Signor Conte la riverisco divotamente.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Servitor suo (<emph>leggendo, e ridendo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Permette, ch'io possa dirle una parola?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Or ora son da voi (<emph>come sopra</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>(Se non ha il ventaglio in mano, io non so come
 introdurmi a parlare).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>(<emph>si alza ridendo, mette via il libro e s'avanza</emph>)
 Eccomi qui. Cosa posso fare per servirvi?</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Perdonate se vi ho disturbato (<emph>osservando se vede il ventaglio</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Niente, niente finirò la mia favola un'altra volta.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Non vorrei, che mi accusaste di troppo ardito.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Cosa guardate? Ho qualche macchia d'intorno?
 (<emph>si guarda</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Scusatemi. Mi è stato detto, che voi avevate un
 ventaglio.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Un ventaglio? (<emph>confondendosi</emph>) È vero, l'avete
 forse perduto voi?</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Sì signor l'ho perduto io.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ma vi sono bene dei ventagli al mondo. Cosa sapete,
 che sia quello che avete perduto?</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Se volete aver la bontà di lasciarmelo vedere...</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Caro amico mi dispiace, che siete venuto un po'
 tardi.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Come tardi?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Il ventaglio non è più in mano mia.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Non è più in mano vostra? (<emph>agitato</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>No, l'ho dato ad una persona.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>E a qual persona l'avete dato? (<emph>riscaldandosi</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Questo è quello, ch'io non voglio dirvi.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Signor Conte mi preme saperlo; mi preme aver quel
 ventaglio, e mi avete a dire chi l'ha.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Non vi dirò niente.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Giuro al cielo, voi lo direte (<emph>trasportato</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Come! mi perdereste il rispetto?</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Lo dico, e lo sosterrò; non è azione da galantuomo
 (<emph>con caldo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sapete voi, che ho un paio di pistole cariche? (<emph>caldo</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Che importa a me delle vostre pistole? Il mio
 ventaglio signore.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Che diavolo di vergogna! Tanto strepito per uno
 straccio di ventaglio, che valerà cinque paoli.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Vaglia quel che sa valere, voi non sapete quello
 che costa, ed io darei per riaverlo... Sì, darei cinquanta
 zecchini.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Dareste cinquanta zecchini!</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Sì, ve lo dico, e ve lo prometto. Se si potesse
 ricuperare darei cinquanta zecchini.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>(Diavolo, bisogna che sia dipinto da Tiziano, o da
 Raffaelo d'Urbino).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Deh signor Conte fatemi questa grazia, questo
 piacere.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Vedrò se si potesse ricuperare, ma sarà difficile.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Se la persona che l'ha, volesse cambiarlo in
 cinquanta zecchini, disponetene liberamente.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Se l'avessi io, mi offenderei d'una simile
 proposizione.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Lo credo benissimo. Ma può essere che la persona
 che l'ha non si offenda.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Oh in quanto a questo, la persona si offenderebbe
 quanto me, e forse forse... Amico, vi assicuro che sono
 estremamente imbrogliato.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Facciamo così, signor Conte. Questa è una scattola
 d'oro, il di cui solo peso val cinquantaquattro zecchini.
@@ -6836,60 +6882,60 @@ Sapete che la fattura raddoppia il prezzo; non importa, per
 ricevere quel ventaglio, ne offerisco il cambio assai
 volentieri. Tenete (<emph>glie la dà</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ci sono de' diamanti in quel ventaglio? Io non ci
 ho badato.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Non ci sono diamanti, non val niente, ma per me è
 prezioso.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Bisognerà vedere di contentarvi.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Vi prego, vi supplico, vi sarò obbligato.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Aspettate qui. (Sono un poco imbrogliato!) Farò di
 tutto per soddisfarvi... e volete, ch'io dia in cambio la
 tabacchiera?</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Sì datela liberamente.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Aspettate qui (<emph>s'incammina</emph>). E se la persona
 mi rendesse il ventaglio, e non volesse la tabacchiera?</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Signore la tabacchiera l'ho data a voi, è cosa
 vostra, fatene qual uso che vi piace.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Assolutamente?</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Assolutamente.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>(Il Barone finalmente è galantuomo, è mio amico).
 Aspettate qui. (Se fossero i cinquanta zecchini non li
 accetterei, ma una tabacchiera d'oro? Sì signore, è un
 presente da titolato) (<emph>va alla spezieria</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Sì per giustificarmi presso dell'idol mio farei
 sagrifizio del mio sangue medesimo, se abbisognasse.</p>
@@ -6900,127 +6946,127 @@ sagrifizio del mio sangue medesimo, se abbisognasse.</p>
           <stage>
             <emph>Crespino dalla bottega della merciaia, e detti (poi Giannina).</emph>
           </stage>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>(Oh, eccolo qui). Signore la riverisco. La signora
 Geltruda vorrebbe parlar con vossignoria. È qui in casa
 dalla merciaia, e la prega di darsi l'incomodo di andar colà
 che l'aspetta.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Dite alla signora Geltruda, che sarò a ricevere i
 suoi comandi, che la supplico d'aspettar un momento, tanto
 ch'io vedo se viene una persona, che mi preme vedere, e
 verrò subito ad obbedirla.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Sarà servito. Come sta? Sta meglio?</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Grazie al cielo sto meglio assai.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Me ne consolo infinitamente. E Giannina sta bene?</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Io credo di sì.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>È una buona ragazza Giannina.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Sì è vero; e so che vi ama teneramente.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>L'amo anch'io, ma...</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Ma che?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Mi hanno detto certe cose...</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Vi hanno detto qualche cosa di me?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Per dir la verità, signor sì.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Amico io sono un galantuomo, e la vostra Giannina è
 onesta.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>(Oh sì, lo credo anch'io. Non mancano mai delle
 male lingue).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>(<emph>sulla porta della spezieria che torna</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Oh andate dalla signora Geltruda, e ditele, che
 vengo subito (<emph>a Crespino</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Signor sì (<emph>s'incammina</emph>). Son sicuro, non vi è
 pericolo, son sicuro (<emph>passa vicino al Conte</emph>). Mi raccomando a
 lei per Giannina.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Fidatevi della mia protezione.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Non vedo l'ora (<emph>entra da Susanna</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Ebbene, signor Conte?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ecco il ventaglio (<emph>lo fa vedere</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Oh, che piacere! Oh quanto vi sono obbligato!
 (<emph>lo prende con avidità</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Guardate se è il vostro?</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Sì, è il mio senza altro (<emph>vuol partire</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>E la tabacchiera?</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Non ne parliamo più. Vi son schiavo (<emph>corre ed entra dalla merciaia</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Cosa vuol dire non conoscere le cose perfettamente!
 Io lo credevo un ventaglio ordinario, e costa tanto! Costa
@@ -7032,73 +7078,73 @@ ventaglio, ma avendogli detto, ch'io lo presenterò in nome
 suo, si è un poco acquietato. Ne comprerò uno di tre, o
 quattro paoli, che farà la stessa figura.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>(<emph>che torna dalla merciaia</emph>) Manco male che la
 mia commissione è poi andata assai bene. La signora Geltruda merita
 d'esser servita. Oh, signor Conte, adunque ella mi dà buone speranze?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Buonissime. Oggi è una giornata per me fortunata, e
 tutte le cose mi vanno bene.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Se gli andasse bene anche questa!</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sì, subito aspettate. Ehi Giannina.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>(<emph>di casa</emph>) Signore, cosa vuole? Cosa
 pretende? (<emph>in collera</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Non tanta furia, non tanto caldo. Voglio farvi del
 bene, e maritarvi.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Io non ho bisogno di lei.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Sente? (<emph>al Conte</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Aspettate (<emph>a Crespino</emph>). Voglio maritarvi a modo
 mio (<emph>a Giannina</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Ed io gli dico di no.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>E voglio darvi per marito Crespino.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Crespino? (<emph>contenta</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ah! cosa dite? (<emph>a Giannina</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Signor sì, con tutta l'anima, con tutto il core.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Vedete l'effetto della mia protezione? (<emph>a Crespino</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Sì signore lo vedo.</p>
           </sp>
@@ -7108,46 +7154,46 @@ mio (<emph>a Giannina</emph>).</p>
           <stage>
             <emph>Moracchio di casa, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Cosa fate qui?</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Cosa c'entrate voi?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Giannina si ha da maritare sotto gli auspici della
 mia protezione.</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Signor sì, son contento, e tu vi acconsentirai o per
 amore, o per forza.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Oh vi acconsentirò volentieri (<emph>con serietà</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Sarà meglio per te.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>E per farti vedere, che vi acconsento, do la mano
 a Crespino.</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Signor Conte (<emph>con affanno</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Lasciate fare (<emph>placidamente</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Non era ella signor Conte impegnata per Coronato?</p>
           </sp>
@@ -7157,92 +7203,92 @@ a Crespino.</p>
           <stage>
             <emph>Coronato dall'osteria, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Chi mi chiama?</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Venite qui, vedete. Il signor Conte vuol, che mia
 sorella si mariti.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Signor Conte... (<emph>con smania</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Io sono un cavalier giusto, un protettor
 ragionevole, umano. Giannina non vi vuole, ed io non posso,
 non deggio, e non voglio usarle violenza.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Signor sì, voglio Crespino a dispetto di tutto il
 mondo.</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Cosa dite voi? (<emph>a Moracchio</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Cosa dite voi? (<emph>a Coronato</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Non me n'importa un fico. Chi non mi vuol, non mi
 merita.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Così va detto.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ecco l'effetto della mia protezione (<emph>a  Crespino</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>Signor Conte ho mandato l'altro barile di vino.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Portatemi il conto, e vi pagherò (<emph>dicendo così tira fuori la scatola d'oro, e prende tabacco</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#coronato">
             <speaker>CORONATO</speaker>
             <p>(Ha la scatola d'oro, mi pagherà) (<emph>via</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Hai poi voluto fare a modo tuo (<emph>a Giannina</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Mi par di sì.</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Se te ne pentirai sarà tuo danno.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Non se ne pentirà mai; avrà la mia protezione.</p>
           </sp>
-          <sp>
+          <sp who="#moracchio">
             <speaker>MORACCHIO</speaker>
             <p>Pane, pane, e non protezione (<emph>entra in casa</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>E così quando si faranno le vostre nozze?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Presto.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Anche subito.</p>
           </sp>
@@ -7252,15 +7298,15 @@ merita.</p>
           <stage>
             <emph>Barone dalla speziaria, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Ebbene signor Conte, avete veduta la signora Candida? Le avete dato il ventaglio? Perché non avete voluto, che avessi io il contento di presentarglielo? </p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>(Come! non l'ha avuto il signor Evaristo?) </p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Io non ho ancora veduto la signora Candida, e circa il ventaglio ne ho degli altri, e ve ne ho destinato un migliore. Oh ecco qui la signora Geltruda.</p>
           </sp>
@@ -7271,35 +7317,35 @@ merita.</p>
             <emph>Geltruda, Evaristo, Susanna, tuttitre dalla bottega
 di Susanna.</emph>
           </stage>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Favoritemi di far discendere mia nipote, ditele,
 che li ho da parlare, che venga qui (<emph>a Susanna</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Sarà servita (<emph>va al palazzino batte, aprono, ed entra</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Non ho piacere che il signor Conte, ed il signor
 Barone entrino in casa. A quest'ora possiamo discorrere qui (<emph>piano ad Evaristo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Signora Geltruda, appunto il signor Barone, ed io
 volevamo farvi una visita.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Obbligatissima. Adesso è l'ora del passeggio,
 prenderemo un poco di fresco.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Ben tornato signor Evaristo (<emph>serio</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Vi son servitore (<emph>brusco</emph>).</p>
           </sp>
@@ -7309,303 +7355,303 @@ prenderemo un poco di fresco.</p>
           <stage>
             <emph>Candida, e Susanna dal palazzino, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Che mi comanda la signora zia?</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Andiamo a far quattro passi.</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>(Ah, è qui quel perfido d'Evaristo!)</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Ma che vuol dire che non avete il ventaglio?
 (<emph>a Candida</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Non sapete che questa mattina si è rotto?</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Ah sì è vero; se si potesse trovarne uno!</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>(Ora è il tempo di darglielo) (<emph>piano al Conte urtandolo con premura</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>(No in pubblico, no) (<emph>piano al Barone</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Signor Evaristo, ne avrebbe uno a sorte?</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Eccolo a' vostri comandi (<emph>a Geltruda lo fa vedere, ma non lo dà</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>(<emph>si volta dall'altra parte con dispetto</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>(Il vostro ventaglio) (<emph>piano al Conte</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>(Diavolo! oibò) (<emph>al Barone</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>(Fuori il vostro) (<emph>al Conte</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>(No, ora no) (<emph>al Barone</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Nipote non volete ricevere le grazie del signor
 Evaristo?</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>No signora, scusatemi; non ne ho di bisogno.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>(Vedete non l'accetta) (<emph>al Barone</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>(Date a me, date a me il vostro) (<emph>al Conte</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>(Volete far nascere una disfida?) (<emph>al Barone</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Si potrebbe sapere, perché non volete ricevere
 quel ventaglio?</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Perché non è mio, perché non era destinato per me
 (<emph>a Geltruda con caricatura</emph>). E perché non è mio, né vostro
 decoro, ch'io lo riceva.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Signor Evaristo a voi tocca a giustificarvi.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Lo farò, se mi vien permesso.</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Con licenza (<emph>vuol andar via</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Restate qui, che ve lo comando (<emph>Candida resta</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>(Che imbroglio è questo?) (<emph>al Conte</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>(Io non so niente) (<emph>al Barone</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Signora Susanna conoscete voi questo ventaglio?</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Sì signore, è quello che avete comprato da me questa
 mattina, e ch'io imprudentemente ho creduto, che l'aveste
 comprato per Giannina.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Oh così mi piace: imprudentemente! (<emph>a Susanna</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Sì, confesso il mio torto, e voi imparate da me a
 render giustizia alla verità. Per altro io aveva qualche
 ragione, perché il signor Evaristo ve l'aveva dato.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Perché vi aveva io dato questo ventaglio?
 (<emph>a Giannina</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Per darlo alla signora Candida: ma quando voleva
 darglielo mi ha strapazzato; e non mi ha lasciato parlare.
 Io poi voleva rendervelo, voi non l'avete voluto, ed io lo
 ho dato a Crespino.</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Ed io son caduto, e Coronato l'ha preso.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Ma dov'è Coronato? Come poi è sortito dalle mani di
 Coronato?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Zitto, non lo stiano a chiamare, che giacché non
 c'è dirò io la verità. Piccato sono entrato nell'osteria per
 trovar del vino, l'ho trovato a caso, e l'ho portato via.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>E che cosa ne avete fatto?</p>
           </sp>
-          <sp>
+          <sp who="#crespino">
             <speaker>CRESPINO</speaker>
             <p>Un presente al signor Conte.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ed io un presente al signor Barone.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Voi l'avete riavuto! (<emph>al Conte con sdegno</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sì, e l'ho rimesso nelle mani del signor Evaristo.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Ed io lo presento alle mani della signora Candida.</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>(<emph>fa una riverenza, prende il ventaglio, e ridendo si consola</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Che scena è questa? Che impiccio è questo? Sono io
 messo in ridicolo per cagione vostra? (<emph>al Conte</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Giuro al Cielo, giuro al Cielo signor Evaristo!</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>Via via signor Conte si quieti. Siamo amici, mi dia
 una presa di tabacco.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Io son così, quando mi prendono colle buone non
 posso scaldarmi il sangue.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Se non ve lo scaldate voi, me lo scalderò io.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Signor Barone...</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>E voi signora vi prendete spasso di me? (<emph>a Geltruda</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Scusatemi, voi mi conoscete poco, signore. Non ho
 mancato a tutti i numeri del mio dovere. Ho ascoltate le
 vostre proposizioni, mia nipote le aveva ascoltate, ed
 accettate, ed io con piacere vi acconsentiva.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sentite? Perché le avevo parlato io (<emph>al Barone</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>E voi, signora, perché lusingarmi? Perché
 ingannarmi?</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Vi domando scusa, signore. Ero agitata da due
 passioni contrarie. La vendetta mi voleva far vostra, e
 l'amore mi ridona ad Evaristo.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Oh qui non c'entro.</p>
           </sp>
-          <sp>
+          <sp who="#evaristo">
             <speaker>EVARISTO</speaker>
             <p>E se foste stato amante meno sollecito, ed amico
 mio più sincero, non vi sareste trovato in caso tale.</p>
           </sp>
-          <sp>
+          <sp who="#barone">
             <speaker>BARONE</speaker>
             <p>Sì è vero, confesso la mia passione, condanno la mia
 debolezza. Ma detesto l'amicizia, e la condotta del signor
 Conte (<emph>saluta e via</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Eh niente, siamo amici. Si scherza. Fra noi altri
 colleghi ci conosciamo. Animo facciamo queste nozze, questo
 matrimonio.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Entriamo in casa, e spero, che tutto si adempirà
 con soddisfazione comune.</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>(<emph>si fa fresco col ventaglio</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Siete contenta d'aver nelle mani quel sospirato ventaglio?</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>Non posso spiegare l'eccesso della mia contentezza.</p>
           </sp>
-          <sp>
+          <sp who="#giannina">
             <speaker>GIANNINA</speaker>
             <p>Gran ventaglio! ci ha fatto girar la testa dal
 primo all'ultimo.</p>
           </sp>
-          <sp>
+          <sp who="#candida">
             <speaker>CANDIDA</speaker>
             <p>È di Parigi questo Ventaglio?</p>
           </sp>
-          <sp>
+          <sp who="#susanna">
             <speaker>SUSANNA</speaker>
             <p>Vien di Parigi ve l'assicuro.</p>
           </sp>
-          <sp>
+          <sp who="#geltruda">
             <speaker>GELTRUDA</speaker>
             <p>Andiamo; v'invito tutti a cena da noi. Beveremo
 alla salute di chi l'ha fatto (<emph>ai comici</emph>). E ringrazieremo

--- a/tei/goldoni-la-bottega-del-caffe.xml
+++ b/tei/goldoni-la-bottega-del-caffe.xml
@@ -87,6 +87,46 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="ridolfo">
+            <persName>Ridolfo</persName>
+          </person>
+          <person xml:id="trappola">
+            <persName>Trappola</persName>
+          </person>
+          <person xml:id="pandolfo">
+            <persName>Pandolfo</persName>
+          </person>
+          <person xml:id="don_marzio">
+            <persName>Don Marzio</persName>
+          </person>
+          <person xml:id="eugenio">
+            <persName>Eugenio</persName>
+          </person>
+          <person xml:id="garzone">
+            <persName>Garzone</persName>
+          </person>
+          <person xml:id="lisaura">
+            <persName>Lisaura</persName>
+          </person>
+          <person xml:id="leandro">
+            <persName>Leandro</persName>
+          </person>
+          <person xml:id="placida">
+            <persName>Placida</persName>
+          </person>
+          <person xml:id="vittoria">
+            <persName>Vittoria</persName>
+          </person>
+          <person xml:id="cameriere">
+            <persName>Cameriere</persName>
+          </person>
+          <person xml:id="capitano">
+            <persName>Capitano</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -245,138 +285,138 @@ porte e finestre praticabili.</p>
         <div type="scene">
           <head>Scena prima</head>
           <stage>Ridolfo, Trappola e altri garzoni.</stage>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Animo, figliuoli portatevi bene; siate lesti, e pronti a servir gli avventori, con civiltà, con proprietà:
 perché tante volte dipende il credito d'una bottega, dalla
 buona maniera di quei che servono.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Caro signor padrone, per dirvi la verità: questo
 levarsi di buon'ora non è niente fatto per la mia
 complessione.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p> Eppure bisogna levarsi presto. Bisogna servir tutti.
 A buon'ora vengono quelli che hanno da far viaggio, i
 lavoranti, i barcaruoli, i marinai, tutta gente che si alza
 di buon mattino.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>È veramente una cosa, che fa crepar di ridere,
 vedere anche i facchini venir a bevere il loro caffè.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Tutti cercan di fare quello che fanno gli altri. Una
 volta correva l'acquavite, adesso è in voga il caffè.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>E quella signora, dove porto il caffè tutte le
 mattine, quasi sempre mi prega, che io le compri quattro
 soldi di legna, e pur vuol bevere il suo caffè.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>La gola è un vizio, che non finisce mai, ed è quel
 vizio, che cresce sempre quanto più l'uomo invecchia.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Non si vede venir nessuno a bottega; si poteva
 dormire un'altra oretta.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Or ora verrà della gente; non è poi tanto di
 buon'ora. Non vedete? Il barbiere è aperto, e in bottega
 lavorano di parrucche. Guarda, anco il botteghino del gioco
 è aperto.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Oh in quanto poi a questa biscazza è aperta che è
 un pezzo. Hanno fatto nottata.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Buono. A messer Pandolfo averà fruttato bene.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>A quel cane frutta sempre bene; guadagna nelle
 carte, guadagna negli scrocchi, guadagna a far di balla co i
 baratori. I denari di chi va là dentro, sono tutti suoi.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Non v'innamoraste mai di questo guadagno, perché la
 farina del diavolo va tutta in crusca.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Quel povero signor Eugenio! Lo ha precipitato.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Guardate anche quello, che poco giudizio! Ha moglie,
 una giovane di garbo, e di proposito, e corre dietro a tutte
 le donne, e poi di più giuoca da disperato.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Piccole galanterie della gioventù moderna.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Giuoca con quel conte Leandro, e gli ha persi
 sicuri.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Oh quel signor Conte, è un bel fior di virtù.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Oh via, andate a tostare il caffè, per farne una
 caffettiera di fresco.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Vi metto degli avanzi di ieri sera?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>No, fatelo buono.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Signor padrone, ho poca memoria. Quant'è che avete
 aperto bottega?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Lo sapete pure. Saranno in circa otto mesi.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>È tempo da mutar costume.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Come sarebbe a dire?</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Quando si apre una bottega nuova, si fa il caffè
 perfetto. Dopo sei mesi al più, acqua calda, e brodo lungo</p>
             <stage><emph>(parte)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>È grazioso costui. Spero che farà bene per la mia
 bottega; perché in quelle botteghe, dove vi è qualcheduno,
@@ -389,199 +429,199 @@ che sappia fare il buffone, tutti corrono.</p>
             <emph>Ridolfo e messer Pandolfo dalla bottega del giuoco,
 strofinandosi gli occhi come assonnato.</emph>
           </stage>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Messer Pandolfo, volete il caffè?</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Sì, mi farete piacere.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Giovani, date il caffè a messer Pandolfo. Sedete,
 accomodatevi.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>No, no, bisogna che io lo beva presto, e che
 ritorni al travaglio.</p>
             <stage><emph>(Un giovane porta il caffè a Pandolfo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Giocano ancora in bottega?</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Si lavora a due telai.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Così presto?</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Giocano da ieri in qua.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>A che giuoco?</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>A un giuoco innocente: prima, e seconda.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>E come va?</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Per me va bene.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Vi siete divertito anche voi a giuocare?</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Sì, anch'io ho tagliato un poco.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Compatite, amico, io non ho da entrare ne' vostri
 interessi; ma non istà bene, che il padrone della bottega
 giuochi anche lui; perché se perde, si fa burlare, e se
 guadagna, fa sospettare.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>A me basta, che non mi burlino; del resto poi, che
 sospettino quanto vogliono, non ci penso.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Caro amico, siamo vicini, e non vorrei, che vi
 accadessero delle disgrazie. Sapete che per il vostro giuoco
 siete stato dell'altre volte in cattura.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Mi contento di poco. Ho buscati due zecchini, e non
 ho voluto altro.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Bravo, pelar la quaglia senza farla gridare. A chi
 gli avete vinti?</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Ad un garzone d'un orefice.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Male, malissimo così si dà mano ai giovani, perché
 rubino ai loro padroni.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Eh non mi venite a moralizzare! Chi è gonzo stia a
 casa sua. Io tengo giuoco per chi vuol giuocare.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Tener giuoco stimo il meno; ma voi siete preso di
 mira per giuocator di vantaggio e in questa sorta di cose si
 fa presto a precipitare.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Io bricconate non ne fo. So giocare; son fortunato,
 e per questo vinco.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Bravo, tirate innanzi così. Il signor Eugenio ha
 giuocato questa notte?</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Giuoca anche adesso. Non ha cenato, non ha dormito,
 e ha perso tutti i denari.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>(Povero giovine!)</p>
             <stage><emph>(da sé)</emph>.</stage>
             <p>Quanto averà perduto?</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Cento zecchini in contanti; e ora perde sulla
 parola.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Con chi giuoca?</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Col signor Conte.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Con quello sì fatto?</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Appunto con quello.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>E con chi altri?</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Loro due soli; a testa, a testa.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Poveraccio! Sta fresco davvero.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Glie li lascia, che fa la bella voglia.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>E voi di queste cose godete?</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Che m'importa? A me basta, che scozzino delle carte
 assai.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Non terrei giuoco, se credessi di farmi ricco.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>No? Per qual ragione?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Mi pare, che un galantuomo non debba soffrire di
 vedere assassinar la gente.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Eh, amico, se sarete così delicato di pelle, farete
 pochi quattrini.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Non me ne importa niente. Fin ora sono stato a
 servire, e ho fatto il mio debito onoratamente. Mi sono
@@ -590,78 +630,78 @@ d'allora, ch'era il padre, come sapete, del signor Eugenio,
 ho aperta questa bottega, e con questa voglio vivere
 onestamente, e non voglio far torto alla mia professione.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Oh anche nella vostra professione vi sono de bei
 capi d'opera!</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Ve ne sono in tutte le professioni. Ma da quelli non
 vanno le persone riguardevoli, che vengono alla mia bottega.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Avete anche voi gli stanzini segreti.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>È vero; ma non si chiude la porta.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Il caffè, non potete negarlo a nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Le chicchere non si macchiano.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Eh via! Si serra un occhio.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Non si serra niente; in questa bottega non vien
 altro che gente onorata.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Sì, sì, siete principiante.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Che vorreste dire?</p>
             <stage><emph>(Gente dalla bottega del giuoco chiama «carte»)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>La servo </p>
             <stage><emph>(verso la sua bottega)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Per carità levate dal tavolino quel povero signor
 Eugenio.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Per me, che perda anche la camicia, non ci penso</p>
             <stage><emph>(s'incammina verso la sua bottega)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Amico, il caffè ho da notarlo?</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Niente, lo giocheremo a primiera.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Io non son gonzo, amico.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Via che serve? Sapete pure, che i miei avventori si
 servono alla vostra bottega. Mi maraviglio, che attendiate a
@@ -671,7 +711,7 @@ queste piccole cose </p>
 servo </p>
             <stage><emph>(entra nel giuoco)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Bel mestiere! Vivere sulle disgrazie, sulla rovina
 della gioventù! Per me non vi sarà mai pericolo, che tenga
@@ -686,135 +726,135 @@ più?</p>
           <stage>
             <emph>Don Marzio e Ridolfo.</emph>
           </stage>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>(Ecco qui quel, che non tace mai, e che sempre vuole
 aver ragione)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Caffè.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Subito sarà servita.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Che vi è di nuovo, Ridolfo?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Non saprei, signore.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Non si è ancora veduto nessuno a questa vostra
 bottega?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>È per anco buon'ora.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Buon'ora? Sono sedici ore sonate.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Oh illustrissimo no, non sono ancora quattordici.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Eh via, buffone.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Le assicuro io, che le quattordici non son sonate.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Eh via, asino.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Ella mi strapazza senza ragione.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Ho contate in questo punto le ore, e ti dico, che
 sono sedici; e poi guarda il mio orologio; questo non
 fallisce mai </p>
             <stage><emph>(gli mostra l'orologio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Bene, se il suo orologio non fallisce, osservi:
 tredici, e tre quarti.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Eh non può essere </p>
             <stage><emph>(cava l'occhialetto e guarda)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Che dice?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Il mio orologio va male. Sono sedici ore. Le ho
 sentite io.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Dove l'ha comprato quell'orologio?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>L'ho fatto venir di Londra.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>L'hanno ingannata.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Mi hanno ingannato? Perché?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Le hanno mandato un orologio cattivo</p>
             <stage><emph>(ironicamente)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Come cattivo? È uno dei più perfetti, che abbia
 fatto il Quarè.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Se fosse buono, non fallirebbe di due ore.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Questo va sempre bene, non fallisce mai.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Ma se fa quattordici ore meno un quarto, e son
 sedici.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Il mio orologio va bene.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Dunque saranno or ora quattordici, come dico io.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Sei un temerario. Il mio orologio va bene, tu di'
 male, e guarda ch'io non ti dia qualche cosa nel capo.</p>
@@ -822,7 +862,7 @@ male, e guarda ch'io non ti dia qualche cosa nel capo.</p>
               <emph>(Un giovane porta il caffè)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>È servita del caffè </p>
             <stage><emph>(con isdegno)</emph>.</stage>
@@ -830,15 +870,15 @@ male, e guarda ch'io non ti dia qualche cosa nel capo.</p>
 bestiaccia!)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Si è veduto il signor Eugenio?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Illustrissimo signor no.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Sarà in casa a carezzare la moglie. Che uomo
 effemminato! Sempre moglie! Sempre moglie! Non si lascia più
@@ -846,36 +886,36 @@ vedere; si fa ridicolo. È un uomo di stucco. Non sa quel
 che si faccia. Sempre moglie, sempre moglie </p>
             <stage><emph>(bevendo il caffè)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Altro che moglie! È stato tutta la notte a giuocare
 qui da messer Pandolfo.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Se lo dico io; sempre gioco! Sempre gioco! </p>
             <stage><emph>(dà la chicchera, e s'alza)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>(Sempre gioco; sempre moglie; sempre il diavolo, che
 se lo porti)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>È venuto da me l'altro giorno con tutta segretezza,
 a pregarmi, che gli prestassi dieci zecchini sopra un paio
 d'orecchini di sua moglie.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Vede bene; tutti gli uomini sono soggetti ad avere
 qualche volta bisogno; ma non hanno piacere poi che si
 sappia, e per questo sarà venuto da lei, sicuro che non dirà
 niente a nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Oh io non parlo. Fo volentieri servizio a tutti, e
 non me ne vanto. Eccoli qui; questi son gli orecchini di sua
@@ -885,19 +925,19 @@ al coperto?</p>
               <emph>(mostra gli orecchini in una custodia)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Io non me ne intendo, ma mi par di sì.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Avete il vostro garzone?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Vi sarà.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Chiamatelo. Ehi Trappola.</p>
           </sp>
@@ -907,90 +947,90 @@ al coperto?</p>
           <stage>
             <emph>Trappola dall'interno della bottega, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Eccomi pronto, e lesto.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Vieni qui. Va' dal gioielliere qui vicino, fagli
 vedere questi orecchini, che sono della moglie del signor
 Eugenio, e dimandali da parte mia, se io sono al coperto di
 dieci zecchini, che gli ho prestati.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Sarà servita. Dunque questi orecchini sono della
 moglie del signor Eugenio?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Sì, or ora non ha più niente, è morto di fame.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>(Meschino, in che mani è capitato!)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>E al signor Eugenio non importa niente di far
 sapere i fatti suoi a tutti?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Io sono una persona, alla quale si può confidare un
 segreto.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Ed io sono una persona, alla quale non si può
 confidar niente.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Perché?</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Perché ho un vizio, che ridico tutto con facilità.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Male, malissimo; se farai così, perderai il credito,
 nessuno si fiderà di te.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Ma come ella l'ha detto a me, così io posso dirlo
 ad un altro.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Va' a vedere, se il barbiere è a tempo per farmi la
 barba.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>La servo. (Per dieci quattrini vuol bevere il
 caffè, e vuole un servitore al suo comando) </p>
             <stage><emph>(da sé, entra dal barbiere)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Ditemi, Ridolfo: che cosa fa quella ballerina qui
 vicina?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>In verità, non ne so niente.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Mi è stato detto, che il conte Leandro la tiene
 sotto la sua tutela.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Con grazia, signore, il caffè vuol bollire. (Voglio
 badare a' fatti miei) </p>
@@ -1002,79 +1042,79 @@ badare a' fatti miei) </p>
           <stage>
             <emph>Trappola e Don Marzio.</emph>
           </stage>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Il barbiere ha uno sotto; subito che averà finito
 di scorticar quello, servirà V. S. illustrissima.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Dimmi: sai niente tu di quella ballerina, che sta
 qui vicino?</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Della signora Lisaura?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Sì.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>So, e non so.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Raccontami qualche cosa.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Se racconterò i fatti degli altri, perderò il
 credito, e nessuno si fiderà più di me.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>A me lo puoi dire; sai chi sono, io non parlo. Il
 conte Leandro la pratica?</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Alle sue ore, la pratica.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Che vuol dire alle sue ore?</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Vuol dire quando non è in caso di dar soggezione.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Bravo; ora capisco. È un amico di buon cuore, che
 non vuole recarle pregiudizio.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Anzi desidera, che la si profitti per far
 partecipe anche lui delle sue care grazie.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Meglio! Oh, che Trappola malizioso! Va' via, va' a
 far vedere gli orecchini.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Al gioielliere lo posso dire, che sono della
 moglie del signor Eugenio?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Sì, diglielo pure.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>(Fra il signor don Marzio, ed io, formiamo una
 bellissima segreteria) </p>
@@ -1086,25 +1126,25 @@ bellissima segreteria) </p>
           <stage>
             <emph>Don Marzio, poi Ridolfo.</emph>
           </stage>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Ridolfo.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Signore.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Se voi non sapete niente della ballerina, vi
 racconterò io.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Io per dirgliela, dei fatti degli altri, non me ne
 curo molto.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Ma sta bene saper qualche cosa, per potersi
 regolare. Ella è protetta da quella buona lama del conte
@@ -1113,58 +1153,58 @@ prezzo della sua protezione. In vece di spendere, mangia
 tutto a quella povera diavola; e per cagione di lui forse è
 costretta a fare quello, che non farebbe. Oh che briccone!</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Ma io son qui tutto il giorno, e posso attestare,
 che in casa sua non vedo andare altri, che il conte Leandro.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Ha la porta di dietro; pazzo, pazzo! Sempre, flusso,
 e riflusso. Ha la porta di dietro, pazzo!</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Io bado alla mia bottega, s'ella ha la porta di
 dietro che importa a me? Io non vado a dar di naso a
 nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Bestia! Così parli con un par mio?</p>
             <stage>
               <emph>(s'alza)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Le domando perdono, non si può dire una facezia?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Dammi un bicchier di rosolio.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>(Questa barzelletta mi costerà due soldi)</p>
             <stage><emph>(fa cenno ai giovani che dieno il rosolio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>(Oh questa poi della ballerina, voglio che tutti la
 sappiano) </p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Servita del rosolio.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Flusso, e riflusso, per la porta di dietro </p>
             <stage><emph>(bevendo il rosolio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Ella starà male quando ha il flusso e riflusso per
 la porta di dietro.</p>
@@ -1176,58 +1216,58 @@ la porta di dietro.</p>
             <emph>Eugenio dalla bottega del giuoco, vestito da notte e
 stralunato, guardando il cielo e battendo i piedi; e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Schiavo, signor Eugenio.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Che ora è?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Sedici ore sonate.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>E il suo orologio va bene.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Caffè.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>La servo subito </p>
             <stage><emph>(va in bottega)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Amico, com'è andata?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Caffè </p>
             <stage><emph>(non abbadando a don Marzio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Subito </p>
             <stage><emph>(di lontano)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Avete perso?</p>
             <stage>
               <emph>(ad Eugenio)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Caffè </p>
             <stage><emph>(gridando forte)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>(Ho inteso, li ha persi tutti) </p>
             <stage><emph>(da sé, va a sedere)</emph>.</stage>
@@ -1238,32 +1278,32 @@ stralunato, guardando il cielo e battendo i piedi; e detti.</emph>
           <stage>
             <emph>Pandolfo dalla bottega del giuoco, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Signor Eugenio, una parola </p>
             <stage><emph>(lo tira in disparte)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>So quel che volete dirmi. Ho perso trenta zecchini
 sulla parola. Son galantuomo, li pagherò.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Ma il signor Conte è là che aspetta. Dice che ha
 esposto al pericolo i suoi denari, e vuol esser pagato.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>(Quanto pagherei a sentire che cosa dicono)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Ecco il caffè </p>
             <stage><emph>(ad Eugenio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Andate via </p>
             <stage><emph>(a Ridolfo)</emph>.</stage>
@@ -1271,127 +1311,127 @@ esposto al pericolo i suoi denari, e vuol esser pagato.</p>
 contanti; mi pare che non abbia gettata via la notte </p>
             <stage><emph>(a Pandolfo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Queste non sono parole da giuocatore; V. S. sa
 meglio di me come va l'ordine in materia di giuoco.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Signore, il caffè si raffredda </p>
             <stage><emph>(ad Eugenio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Lasciatemi stare</p>
             <stage><emph> (a Ridolfo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Se non lo voleva...</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Andate via.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Lo beverò io </p>
             <stage><emph>(si ritira col caffè)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>(Che cosa dicono?) </p>
             <stage><emph>(a Ridolfo, che non gli risponde)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>So ancor io, che, quando si perde, si paga, ma
 quando non ve n'è, non si può pagare </p>
             <stage><emph>(a Pandolfo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Sentite, per salvare la vostra reputazione, son
 uomo capace di ritrovare trenta zecchini.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Oh bravo! Caffè </p>
             <stage><emph>(chiama forte)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Ora, bisogna farlo </p>
             <stage><emph>(ad Eugenio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Sono tre ore, che domando caffè, e ancora non
 l'avete fatto?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>L'ho portato, ed ella mi ha cacciato via.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Gliel'ordini con premura, che lo farà da suo pari.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Ditemi, vi dà l'animo di farmi un caffè, ma buono,
 via, da bravo </p>
             <stage><emph>(a Ridolfo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Quando mi dia tempo, la servo </p>
             <stage><emph>(va in bottega)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>(Qualche grand'affare. Son curioso di saperlo) </p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Animo, Pandolfo, trovatemi questi trenta zecchini.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Io ho un amico, che li darà, ma pegno, e regalo.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Non mi parlate di pegno, che non facciamo niente. Ho
 quei panni a Rialto, che voi sapete, obbligherò quei panni,
 e quando gli venderò, pagherò.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>(Pagherò. Ha detto pagherò. Ha perso sulla parola)
  </p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Bene; che cosa vuol dar di regalo?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Fate voi, quel che credete a proposito.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Senta; non vi vorrà meno di uno zecchino alla
 settimana.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Uno zecchino di usura alla settimana?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <stage>
               <emph>(col caffè)</emph>
@@ -1399,44 +1439,44 @@ settimana.</p>
             <p>Servita del caffè </p>
             <stage><emph>(ad Eugenio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Andate via </p>
             <stage><emph>(a Ridolfo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>La seconda di cambio.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Uno zecchino alla settimana?</p>
             <stage>
               <emph>(a Pandolfo)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Per trenta zecchini è una cosa discreta.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Lo vuole, o non lo vuole?</p>
             <stage>
               <emph>(ad Eugenio)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Andate via che ve lo getto in faccia </p>
             <stage><emph>(a Ridolfo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>(Poveraccio! Il giuoco l'ha ubriacato) </p>
             <stage><emph>(da sé, porta il caffè in bottega)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <stage>
               <emph>(s'alza, e va vicino ad Eugenio)</emph>
@@ -1444,70 +1484,70 @@ settimana.</p>
             <p>Signor Eugenio,
 vi è qualche differenza? Volete, che l'aggiusti io?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Niente, signor don Marzio, la prego lasciarmi stare.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Se avete bisogno, comandate.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Le dico, che non mi occorre niente.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Messer Pandolfo; che avete voi col signor Eugenio?</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Un piccolo affare, che non abbiamo piacere di farlo
 sapere a tutto il mondo.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Io sono amico del signor Eugenio, so tutti i fatti
 suoi, e sa, che non parlo con nessuno. Gli ho prestati anche
 dieci zecchini sopra un paio d'orecchini; non è vero? E non
 l'ho detto a nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Si poteva anche risparmiare di dirlo adesso.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Eh, qui con messer Pandolfo si può parlare con
 libertà. Avete perso sulla parola? Avete bisogno di nulla?
 Son qui.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Per dirgliela, ho perso sulla parola trenta
 zecchini.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Trenta zecchini, e dieci, che ve ne ho dati sono
 quaranta; gli orecchini non possono valer tanto.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Trenta zecchini, glieli troverò io.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Bravo; trovategliene quaranta; mi darete i miei
 dieci, e vi darò i suoi orecchini.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>(Maladetto sia quando mi sono impicciato con
 costui!)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Perché non prendere il danaro, che vi offerisce il
 signor Pandolfo?</p>
@@ -1515,67 +1555,67 @@ signor Pandolfo?</p>
               <emph>(ad Eugenio)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Perché vuole uno zecchino alla settimana.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Io per me non voglio niente; è l'amico, che fa il
 servizio, che vuol così.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Fate una cosa; parlate col signor Conte, ditegli che
 mi dia tempo ventiquattr'ore; son galantuomo, lo pagherò.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Ho paura, ch'egli abbia da andar via, e che voglia
 il denaro subito.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Se potessi vendere una pezza, o due di quei panni,
 mi spiccerei.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Vuole, che veda io di ritrovare il compratore?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Sì, caro amico, fatemi il piacere, che vi pagherò la
 vostra senseria.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Lasci, ch'io dica una parola al signor Conte, e
 vado subito </p>
             <stage><emph>(entra nella bottega del giuoco)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Avete perso molto?</p>
             <stage>
               <emph>(ad Eugenio)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Cento zecchini, che aveva riscossi ieri, e poi
 trenta sulla parola.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Potevate portarmi i dieci, che vi ho prestati.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Via, non mi mortificate più; ve gli darò i vostri
 dieci zecchini.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <stage><emph>(col tabarro e cappello, dalla sua bottega)</emph>.</stage>
             <p> Il
@@ -1584,11 +1624,11 @@ Intanto vado a vedere di far quel servizio. Se si risveglia,
 ho lasciato l'ordine al giovane, che gli dica il bisogno. V.
 S. non si parta di qui.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Vi aspetto in questo luogo medesimo.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>(Questo tabarro è vecchio; ora è il tempo di
 farmene un nuovo a ufo)</p>
@@ -1600,159 +1640,159 @@ farmene un nuovo a ufo)</p>
           <stage>
             <emph>Don Marzio ed Eugenio, poi Ridolfo.</emph>
           </stage>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Venite qui, sedete, beviamo il caffè.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Caffè.</p>
             <stage>
               <emph> (siedono)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>A che giuoco giuochiamo, signor Eugenio? Si prende
 spasso de' fatti miei?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Caro amico, compatite, sono stordito.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Eh caro signor Eugenio se V. S. volesse badare a me,
 la non si troverebbe in tal caso.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Non so che dire, avete ragione.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Vado a farle un altro caffè, e poi la discorreremo</p>
             <stage><emph>(si ritira in bottega)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Avete saputo della ballerina, che pareva non volesse
 nessuno? Il Conte la mantiene.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Credo di sì, che possa mantenerla, vince gli
 zecchini a centinaia.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Io ho saputo tutto.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Come l'avete saputo, caro amico?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Eh, io so tutto. Sono informato di tutto. So quando
 vi va, quando esce. So quel che spende, quel che mangia, so
 tutto.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Il Conte è poi solo?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Oibò; vi è la porta di dietro.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <stage><emph>(col caffè)</emph>.</stage>
             <p> Ecco qui il terzo caffè </p>
             <stage><emph>(ad Eugenio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Ah! Che dite, Ridolfo? So tutto io della ballerina?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Io le ho detto un'altra volta, che non me ne
 intrico.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Grand'uomo son io, per saper ogni cosa! Chi vuol
 sapere quel che passa in casa di tutte le virtuose e di
 tutte le ballerine, ha da venire da me.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Dunque questa signora ballerina è un capetto
 d'opera.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>L'ho veramente scoperta come va. È roba di tutto
 gusto. Ah, Ridolfo, lo so io?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Quando V. S. mi chiama in testimonio, bisogna ch'io
 dica la verità. Tutta la contrada la tiene per una donna da
 bene.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Una donna da bene? Una donna da bene?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Io le dico, che in casa sua non vi va nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Per la porta di dietro flusso, e riflusso.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Eh sì, ella pare una ragazza più tosto savia.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Sì savia! Il conte Buonatesta la mantiene. Poi vi va
 chi vuole.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Io ho provato qualche volta a dirle le belle parole,
 e non ho fatto niente.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Avete un filippo da scommettere? Andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>(Oh che lingua!)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Vengo qui a bever il caffè ogni giorno; e per dirla
 non ho veduto andarvi nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Non sapete, che ha la porta segreta qui nella
 stradella? Vanno per di là.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Sarà così?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>È senz'altro.</p>
           </sp>
@@ -1762,68 +1802,68 @@ stradella? Vanno per di là.</p>
           <stage>
             <emph>Il Garzone del barbiere, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#garzone">
             <speaker>GARZONE</speaker>
             <p>Illustrissimo, se vuol farsi la barba, il padrone
 l'aspetta </p>
             <stage><emph>(a don Marzio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Vengo. È così come io vi dico. Vado a farmi la
 barba; e come torno vi dirò il resto </p>
             <stage><emph>(entra dal barbiere, e poi a tempo ritorna)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Che dite, Ridolfo? La ballerina si è tratta fuori.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Cred'ella al signor don Marzio? Non sa la lingua
 ch'egli è?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Lo so, che ha una lingua, che taglia, e cuce. Ma
 parla con tanta franchezza, che convien dire, che ei sappia
 quello che dice.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Osservi, quella è la porta della stradella. A star
 qui la si vede; e giuro da uomo d'onore, che per di là in
 casa non va nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Ma il Conte la mantiene?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Il Conte va per casa, ma si dice, che la voglia
 sposare.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Se fosse così, non vi sarebbe male; ma dice il
 signor don Marzio, che in casa vi va chi vuole.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Ed io le dico, che non vi va nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <stage><emph>(esce dal barbiere col panno bianco al collo e la saponata sul viso)</emph>.</stage>
             <p> Vi dico, che vanno per la porta di
 dietro.</p>
           </sp>
-          <sp>
+          <sp who="#garzone">
             <speaker>GARZONE</speaker>
             <p>Illustrissimo, l'acqua si raffredda.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Per la porta di dietro </p>
             <stage><emph>(entra dal barbiere col Garzone)</emph>.</stage>
@@ -1834,114 +1874,114 @@ dietro.</p>
           <stage>
             <emph>Eugenio e Ridolfo.</emph>
           </stage>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Vede? È un uomo di questa razza. Colla saponata sul
 viso.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Sì, quando si è cacciata una cosa in testa, vuole
 che sia in quel modo.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>E sempre dice male di tutti.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Non so come faccia a parlar sempre de' fatti degli
 altri.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Le dirò: egli ha pochissime facoltà; ha poco da
 pensare a' fatti suoi, e per questo pensa sempre a quelli
 degli altri.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Veramente è fortuna il non conoscerlo.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Caro signor Eugenio, come ha ella fatto a intricarsi
 con lui? Non aveva altri da domandare dieci zecchini in
 prestito?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Anche voi lo sapete?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>L'ha detto qui pubblicamente in bottega, e ha
 mandato Trappola mio garzone, a farli veder dall'orefice.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Caro amico, sapete come la va: quando uno ha bisogno
 si attacca a tutto.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Anche questa mattina, per quel che ho sentito, V. S.
 si è attaccato poco bene.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Credete che messer Pandolfo mi voglia gabbare?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Vedrà, che razza di negozio le verrà a proporre.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Ma che devo fare? Bisogna che io paghi trenta
 zecchini, che ho persi sulla parola. Mi vorrei liberare dal
 tormento di don Marzio. Ho qualche altra premura; se posso
 vendere due pezze di panno fo tutti i fatti miei.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Che qualità di panno è quello, che vorrebbe esitare?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Panno padovano, che vale quattordici lire veneziane
 il braccio.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Vuol ella, che veda io di farglielo vendere con
 riputazione?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Vi sarei bene obbligato.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Mi dia un poco di tempo, e lasci operare a me.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Tempo? volentieri. Ma quello aspetta i trenta
 zecchini.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Venga qui, favorisca, mi faccia un ordine, che mi
 sieno consegnate due pezze di panno, ed io medesimo le
 impresterò i trenta zecchini.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Sì, caro, vi sarò obbligato. Saprò le mie
 obbligazioni.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Mi maraviglio, non pretendo nemmeno un soldo. Lo
 farò per le obbligazioni, ch'io ho colla buona memoria del
@@ -1949,27 +1989,27 @@ suo signor padre, che è stato mio buon padrone, e dal quale
 riconosco la mia fortuna. Non ho cuor di vederla assassinare
 da questi cani.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Voi siete un gran galantuomo.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Favorisca di stender l'ordine in carta.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Son qui: dettatelo voi, ch'io scriverò.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Che nome ha il primo giovine del suo negozio?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Pasquino de' Cavoli.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>
               <emph>Pasquino de' Cavoli...</emph>
@@ -1979,29 +2019,29 @@ da questi cani.</p>
             </stage>
             <p>Consegnerete a messer Ridolfo Gamboni... pezze due panno padovano... a sua elezione, acciò egli ne faccia esito per conto mio... avendomi prestato gratuitamente... zecchini trenta... Vi metta la data, e si sottoscriva.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Ecco fatto.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Si fid'ella di me?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Capperi! Non volete?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Ed io mi fido di lei. Tenga, questi sono trenta
 zecchini </p>
             <stage><emph>(gli numera trenta zecchini)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Caro amico, vi sono obbligato.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Signor Eugenio, glieli do acciò possa comparir
 puntuale, e onorato; le venderò il panno io, acciò non le
@@ -2022,7 +2062,7 @@ ascolterà, sarà meglio per lei </p>
           <stage>
             <emph>Eugenio solo, poi Lisaura alla finestra.</emph>
           </stage>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Non dice male; confesso, che non dice male. Mia
 moglie, povera disgraziata, che dirà? Questa notte non mi ha
@@ -2042,136 +2082,136 @@ così! </p>
 Ho paura di sì, io, che vi sia la porticina col giocolino).
 Padrona mia riverita.</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Serva umilissima.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>È molto, signora, che è alzata dal letto?</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>In questo punto</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Ha bevuto il caffè?</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>È ancora presto. Non l'ho bevuto.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Comanda, che io la faccia servire?</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Bene obbligata. Non s'incomodi.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Niente. Mi maraviglio: giovani, portate a quella
 signora, caffè, cioccolata, tutto quel ch'ella vuole. Pago
 io.</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>La ringrazio, la ringrazio. Il caffè, e la
 cioccolata la faccio in casa.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Avrà della cioccolata buona.</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Per dirla, è perfetta.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>La sa far bene?</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>La mia serva s'ingegna.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Vuole, che venga io, a darle una frullatina?</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>È superfluo, che s'incomodi.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Verrò a beverla con lei, se mi permette.</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Non è per lei, signore.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Io mi degno di tutto; apra via, che staremo
 un'oretta insieme.</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Mi perdoni, non apro con questa facilità.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Ehi, dica, vuole, che io venga per la porta di
 dietro?</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Le persone, che vengono da me, vengono
 pubblicamente.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Apra via, non facciamo scene.</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Dica in grazia, signore Eugenio, ha veduto ella il
 conte Leandro?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Così non lo avessi veduto!</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Hanno forse giuocato insieme la scorsa notte?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Pur troppo; ma che serve, che stiamo qui a far
 sentire a tutti i fatti nostri? Apra, che le dirò ogni cosa.</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Vi dico, signore, che io non apro a nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Ha forse bisogno, che il signor Conte le dia
 licenza? Lo chiamerò.</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Se cerco del signor Conte, ho ragione di farlo.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Ora la servo subito. È qui in bottega, che dorme.</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Se dorme, lasciatelo dormire.</p>
           </sp>
@@ -2181,49 +2221,49 @@ licenza? Lo chiamerò.</p>
           <stage>
             <emph>Leandro dalla bottega del giuoco, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Non dormo no, non dormo. Son qui, che godo la bella
 disinvoltura del signor Eugenio.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Che ne dite dell'indiscretezza di questa signora?
 Non mi vuole aprir la porta.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Chi vi credete, che ella sia?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Per quel che dice don Marzio, flusso, e riflusso.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Mente don Marzio, e chi lo crede.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Bene! Non sarà così: ma col vostro mezzo non potrei
 io aver la grazia di riverirla?</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Fareste meglio a darmi li miei trenta zecchini.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>I trenta zecchini ve gli darò. Quando si perde sulla
 parola, vi è tempo a pagare ventiquattr'ore.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Vedete, signora Lisaura? Questi sono quei gran
 soggetti, che si piccano di onoratezza. Non ha un soldo, e
 pretende di fare il grazioso.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>I giovani della mia sorta, signor Conte caro, non
 sono capaci di mettersi in un impegno senza fondamento di
@@ -2235,7 +2275,7 @@ Tenete i vostri trenta zecchini, e imparate a parlare coi
 galantuomini della mia sorta </p>
             <stage><emph>(va a sedere in bottega del caffè)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>(Mi ha pagato, dica ciò che vuole, che non
 m'importa)</p>
@@ -2243,35 +2283,35 @@ m'importa)</p>
             <p> Aprite </p>
             <stage><emph>(a Lisaura)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Dove siete stato tutta questa notte?</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Aprite.</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Andate al diavolo.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Aprite </p>
             <stage><emph>(versa gli zecchini nel cappello, acciò Lisaura li veda)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Per questa volta vi apro </p>
             <stage><emph>(si ritira, ed apre)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Mi fa grazia, mediante la raccomandazione di queste
 belle monete </p>
             <stage><emph>(entra in casa)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Subito dentro, subito si vede; egli sì, ed io no?
 Non son chi sono, se non gliela faccio vedere.</p>
@@ -2282,165 +2322,165 @@ Non son chi sono, se non gliela faccio vedere.</p>
           <stage>
             <emph>Placida, da pellegrina, ed Eugenio.</emph>
           </stage>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Un poco di carità alla povera pellegrina.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>(Ecco qui; corre la moda delle pellegrine)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Signore, per amor del Cielo, mi dia qualche cosa</p>
             <stage><emph>(ad Eugenio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Che vuol dir questo, signora pellegrina? Si va così
 per divertimento, o per pretesto?</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Né per l'un, né per l'altro.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Dunque per qual causa si gira il mondo?</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Per bisogno.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Bisogno, di che?</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Di tutto.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Anche di compagnia?</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Di questa non avrei di bisogno, se mio marito non
 mi avesse abbandonata.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>La solita canzonetta. Mio marito mi ha abbandonata.
 Di che paese siete, signora?</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Piemontese.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>E vostro marito?</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Piemontese egli pure.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Che facev'egli al suo paese?</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Era scritturale d'un mercante.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>E perché se n'è andato via?</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Per poca volontà di far bene.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Questa è una malattia, che l'ho provata anch'io e
 non sono ancora guarito.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Signore, aiutatemi per carità. Sono arrivata in
 questo punto a Venezia. Non so dove andare; non conosco
 nessuno; non ho denari; son disperata.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Che cosa siete venuta a fare a Venezia?</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>A vedere se trovo quel disgraziato di mio marito.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Come si chiama?</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Flamminio Ardenti.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Non ho mai sentino cotesto nome.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Ho timore, che il nome se lo sia cambiato.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Girando per la città, può darsi, che se vi è, lo
 troviate.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Se mi vedrà, fuggirà.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Dovreste far così. Siamo ora di carnevale, dovreste
 mascherarvi, e così più facilmente lo trovereste.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Ma come posso farlo, se non ho alcuno, che mi
 assista? Non so nemmeno dove alloggiare.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>(Ho inteso, or ora vado in pellegrinaggio ancor io)</p>
             <stage><emph>(da sé)</emph>.</stage>
             <p> Se volete, questa è una buona locanda.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Con che coraggio ho da presentarmi alla locanda, se
 non ho nemmeno da pagare il dormire?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Cara pellegrina, se volete un mezzo ducato, ve lo
 posso dare. (Tutto quello che mi è avanzato dal giuoco)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Ringrazio la vostra pietà. Ma più del mezzo ducato,
 più di qual si sia moneta, mi sarebbe cara la vostra
 protezione.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>(Ho inteso; non vuole il mezzo ducato; vuole qualche
 cosa di più)</p>
@@ -2452,53 +2492,53 @@ cosa di più)</p>
           <stage>
             <emph>Don Marzio dal barbiere, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>(Eugenio con una pellegrina! Sarà qualche cosa di
 buono!)</p>
             <stage><emph>(siede al caffè, guardando la pellegrina coll'occhialetto)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Fatemi la carità; introducetemi voi alla locanda;
 raccomandatemi al padrone di essa, acciò vedendomi così
 sola, non mi scacci, o non mi maltratti.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Volentieri. Andiamo, che vi accompagnerò; il
 locandiere mi conosce, e a riguardo mio spero, che vi userà
 tutte le cortesie, che potrà.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>(Mi pare di averla veduta altre volte)</p>
             <stage><emph>(da sé, guarda di lontano coll'occhialetto)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Vi sarò eternamente obbligata.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Quando posso faccio del bene a tutti. Se non
 ritroverete vostro marito, vi assisterò io. Son di buon
 cuore.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>(Pagherei qualche cosa di bello a sentir cosa
 dicono)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Caro signore, voi mi consolate colle vostre
 cortesissime esibizioni. Ma la carità d'un giovine, come
 voi, ad una donna, che non è ancor vecchia, non vorrei, che
 venisse sinistramente interpretata.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Vi dirò, signora; se in tutti i casi si avesse
 questo riguardo, si verrebbe a levare agli uomini la libertà
@@ -2510,25 +2550,25 @@ sospettare da un'azion buona, o indifferente, tutta la colpa
 d'esser anch'io, uomo di mondo; ma mi picco insieme d'esser
 un uomo civile, ed onorato.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Sentimenti d'animo onesto, nobile, e generoso.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Amico, chi è questa bella pellegrina?</p>
             <stage>
               <emph>(ad Eugenio)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>(Eccolo qui, vuol dar di naso per tutto)</p>
             <stage><emph>(da sé)</emph>.</stage>
             <p>Andiamo in locanda </p>
             <stage><emph>(a Placida)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Vi seguo </p>
             <stage><emph>(entra in locanda con Eugenio)</emph>.</stage>
@@ -2539,7 +2579,7 @@ un uomo civile, ed onorato.</p>
           <stage>
             <emph>Don Marzio, poi Eugenio dalla locanda.</emph>
           </stage>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Oh che caro signore Eugenio! Egli applica a tutto;
 anche alla pellegrina. Colei mi pare certamente sia quella
@@ -2551,129 +2591,129 @@ denari, che sono pochi li voglio spendere bene. Ragazzi, non
 che mi ha dati in pegno per dieci zecchini il signor
 Eugenio?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Che cosa dice de' fatti miei?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Bravo; colla pellegrina!</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Non si può assister una povera creatura, che si
 ritrova in bisogno?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Sì, anzi fate bene. Povera diavola! Dall'anno
 passato in qua non ha trovato nessuno che la ricoveri?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Come dall'anno passato! La conoscete quella
 pellegrina?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Se la conosco? E come! È vero, che ho corta vista,
 ma la memoria mi serve.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Caro amico, ditemi chi ella è.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>È una che veniva l'anno passato a questo caffè ogni
 sera, a frecciare questo e quello.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Se ella dice, che non è mai più stata in Venezia.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>E voi glielo credete? Povero gonzo!</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Quella dell'anno passato, di che paese era?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Milanese.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>E questa è piemontese.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Oh sì, è vero; era di Piemonte.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>È moglie d'un certo Flamminio Ardenti.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Anche l'anno passato aveva con lei uno, che passava
 per suo marito.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Ora non ha nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>La vita di costoro; ne mutano uno al mese.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Ma come potete dire, che sia quella?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Se la conosco!</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>L'avete ben veduta?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Il mio occhialetto non isbaglia; e poi l'ho sentita
 parlare.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Che nome aveva quella dell'anno passato?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Il nome poi non mi sovviene.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Questa ha nome Placida.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Appunto; aveva nome Placida.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Se fossi sicuro di questo, vorrei ben dirle le mie
 sillabe.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Quando dico una cosa io, la potete credere. Colei è
 una pellegrina, che in vece d'essere alloggiata, cerca di
 alloggiare.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Aspettate, che ora torno. (Voglio ben saper la
 verità)</p>
@@ -2685,135 +2725,135 @@ verità)</p>
           <stage>
             <emph>Don Marzio, poi Vittoria mascherata.</emph>
           </stage>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Non può essere altro, che quella assolutamente:
 l'aria, la statura, anche l'abito mi par quello. Non l'ho
 veduta bene nel viso, ma è quella senz'altro; e poi, quando
 mi ha veduto, subito si è nascosta nella locanda.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Signor don Marzio, la riverisco </p>
             <stage><emph>(si smaschera)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Oh signora mascheretta; vi sono schiavo.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>A sorte, l'avreste voi veduto mio marito?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Sì signora, l'ho veduto.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Mi sapreste dire dove presentemente egli sia?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Lo so benissimo.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Vi supplico dirmelo per cortesia.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Sentite </p>
             <stage><emph>(la tira in disparte)</emph>.</stage>
             <p>È qui in questa
 locanda con un pezzo di pellegrina; ma! co' fiocchi.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Da quando in qua?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Or ora; in questo punto; è capitata qui una
 pellegrina, l'ha veduta, gli è piaciuta, ed è insaccato
 subitamente nella locanda.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Uomo senza giudizio! Vuol perdere affatto la
 riputazione.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Questa notte l'averete aspettato un bel pezzo!</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Dubitava gli fosse accaduta qualche disgrazia.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Chiamate poca disgrazia, aver perso cento zecchini
 in contanti, e trenta sulla parola?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Ha perso tutti questi danari?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Sì! Ha perso altro! Se giuoca tutto il giorno, e
 tutta la notte, come un traditore.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>(Misera me! Mi sento strappar il cuore)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Ora gli converrà vendere a precipizio quel poco di
 panno, e poi ha finito.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Spero, che non sia in istato di andar in rovina.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Se ha impegnato tutto!</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Mi perdoni; non è vero.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Lo volete dire a me?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Io l'averei a saper più di voi.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Se ha impegnato a me... Basta. Son galantuomo, non
 voglio dir altro.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Vi prego dirmi, che cosa ha impegnato. Può essere,
 che io non lo sappia.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Andate, che avete un bel marito.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Mi volete dire, che cosa ha impegnato?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Son galantuomo, non vi voglio dir nulla.</p>
           </sp>
@@ -2823,21 +2863,21 @@ che io non lo sappia.</p>
           <stage>
             <emph>Trappola colla scatola degli orecchini, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Oh son qui; ha detto il gioielliere... (Uh! Che
 mai vedo! La moglie del signore Eugenio; non voglio farmi
 sentire)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Ebbene cosa dice il gioielliere?</p>
             <stage>
               <emph>(piano a Trappola)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Dice, che saranno stati pagati più di dieci
 zecchini ma che non glieli darebbe.</p>
@@ -2845,57 +2885,57 @@ zecchini ma che non glieli darebbe.</p>
               <emph>(piano a don Marzio)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Dunque non sono al coperto?</p>
             <stage>
               <emph>(a Trappola)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Ho paura di no.</p>
             <stage><emph>(a don Marzio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Vedete le belle baronate che fa vostro marito?</p>
             <stage><emph>(a Vittoria)</emph>.</stage>
             <p>Egli mi dà in pegno questi orecchini per dieci
 zecchini, e non vagliono nemmeno sei.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Questi sono i miei orecchini.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Datemi dieci zecchini, e ve li do.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Ne vagliono più di trenta.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Eh trenta fichi! Siete d'accordo anche voi.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Teneteli fin a domani, ch'io troverò li dieci
 zecchini.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Fin a domani? Oh voi mi corbellate. Voglio andarli a
 far vedere da tutti i gioiellieri di Venezia.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Almeno, non dite, che sono miei, per la mia
 riputazione.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Che importa a me della vostra riputazione! Chi non
 vuol, che si sappia, non faccia pegni </p>
@@ -2905,91 +2945,91 @@ vuol, che si sappia, non faccia pegni </p>
         <div type="scene">
           <head>Scena diciannovesima</head>
           <stage><emph>Vittoria e Trappola</emph>.</stage>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Che uomo indiscreto! Incivile! Trappola, dov'è il
 vostro padrone?</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Non lo so; vengo ora a bottega.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Mio marito dunque, ha giuocato tutta la notte?</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Dove l'ho lasciato iersera, l'ho ritrovato questa
 mattina.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Maledettissimo vizio! E ha perso cento, e trenta
 zecchini?</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Così dicono.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Indegnissimo giuoco! E ora se ne sta con una
 forestiera in divertimenti?</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Signorsì, sarà con lei. L'ho veduto varie volte
 girarle d'intorno; sarà andato in casa.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Mi dicono, che questa forestiera sia arrivata poco
 fa.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>No signora; sarà un mese, che la c'è.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Non è una pellegrina?</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Oibò pellegrina; ha sbagliato, perché finisce in
 <emph>ina</emph>; è una ballerina.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>E sta qui alla locanda?</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Signora no, sta qui in questa casa </p>
             <stage><emph>(accennando la casa)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Qui? Se mi ha detto il signor don Marzio, ch'egli
 ritrovasi in quella locanda con una pellegrina!</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Buono! Anche la pellegrina?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Oltre la pellegrina, vi è anche la ballerina? Una
 di qua, e una di là?</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Sì signora, farà per navigar col vento sempre in
 poppa. Orza e poggia secondo soffia la tramontana, o lo
 scirocco.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>E sempre ha da far questa vita? Un uomo di quella
 sorta, di spirito, di talento, ha da perdere così
@@ -3000,15 +3040,15 @@ ma non balorda; non voglio, che il mio tacere faciliti la
 sua mala condotta. Parlerò: dirò le mie ragioni, e se le
 parole non bastano, ricorrerò alla giustizia.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>È vero, è vero. Eccolo, che viene dalla locanda.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Caro amico, lasciatemi sola.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Si serva pure, come più le piace </p>
             <stage><emph>(entra nell'interno della bottega)</emph>.</stage>
@@ -3017,13 +3057,13 @@ parole non bastano, ricorrerò alla giustizia.</p>
         <div type="scene">
           <head>Scena ventesima</head>
           <stage><emph>Vittoria, poi Eugenio dalla locanda</emph>.</stage>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Voglio accrescere la di lui sorpresa, col
 mascherarmi </p>
             <stage><emph>(si maschera)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Io non so quel ch'io m'abbia a dire, questa nega, e
 quel tien sodo. Don Marzio, so che è una mala lingua. A
@@ -3031,187 +3071,187 @@ queste donne che viaggiano, non è da credere. Mascheretta? A
 buon'ora! Andate per il Mastico? Siete mutola? Volete caffè?
 Volete niente? Comandate.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Non ho bisogno di caffè, ma di pane </p>
             <stage><emph>(si smaschera)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Come! Che cosa fate voi qui?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Eccomi qui strascinata dalla disperazione.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Che novità è questa? A quest'ora in maschera?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Cosa dite eh? Che bel divertimento! A quest'ora in
 maschera.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Andate subito, a casa vostra.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Anderò a casa, e voi resterete al divertimento.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Voi andate a casa, ed io resterò dove mi piacerà di
 restare.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Bella vita signor consorte!</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Meno ciarle, signora, vada a casa, che farà meglio.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Sì, anderò a casa; ma anderò a casa mia, non a casa
 vostra.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Dove intendereste d'andare?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Da mio padre, il quale nauseato de' mali
 trattamenti, che voi mi fate, saprà farsi render ragione del
 vostro procedere, e della mia dote.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Brava, signora, brava. Questo è il gran bene che mi
 volete, questa è la premura, che avete di me, e della mia
 riputazione.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Ho sempre sentito dire, che crudeltà consuma amore.
 Ho tanto sofferto, ho tanto pianto; ma ora non posso più.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Finalmente che cosa vi ho fatto?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Tutta la notte al giuoco.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Chi vi ha detto, che io abbia giuocato?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Me l'ha detto il signor don Marzio, e che avete
 perso cento zecchini in contanti, e trenta sulla parola.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Non gli credete, non è vero.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>E poi, a' divertimenti con la pellegrina.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Chi vi ha detto questo?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Il signor don Marzio.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>(Che tu sia maledetto!)</p>
             <stage><emph>(da sé)</emph>.</stage>
             <p>Credetemi, non è
 vero.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>E di più impegnare la roba mia, prendermi un paio
 di orecchini, senza dirmi niente? Sono azioni da farsi ad
 una moglie amorosa, civile, e onesta, come sono io?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Come avete saputo degli orecchini?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Me l'ha detto il signor don Marzio.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Ah lingua da tanaglia!</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Già dice il signor don Marzio, e lo diranno tutti,
 che uno di questi giorni sarete rovinato del tutto, ed io
 prima che ciò succeda, voglio assicurarmi della mia dote.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Vittoria, se mi voleste bene, non parlereste così.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Vi voglio bene anche troppo, e se non vi avessi
 amato tanto, sarebbe stato meglio per me.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Volete andare da vostro padre?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Sì, certamente.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Non volete più star con me?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Vi starò, quando averete messo giudizio.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Oh, signora dottoressa, non mi stia ora a seccare</p>
             <stage><emph>(alterato)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Zitto; non facciamo scene per la strada.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Se aveste riputazione, non verreste a cimentare
 vostro marito in una bottega da caffè.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Non dubitate, non ci verrò più.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Animo; via di qua.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Vado, vi obbedisco, perché una moglie onesta deve
 obbedire anche un marito indiscreto. Ma forse, forse
@@ -3225,7 +3265,7 @@ lontana, ma non saprò così spesso i torti che voi mi fate.
 V'amerò sempre, ma non mi vedrete mai più </p>
             <stage><emph>(parte)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Povera donna! Mi ha intenerito. So che lo dice, ma
 non è capace di farlo; le andrò dietro alla lontana, e la
@@ -3243,95 +3283,95 @@ collera, quattro carezze bastano per consolarla </p>
           <stage>
             <emph>Ridolfo dalla strada, poi Trappola dalla bottega interna.</emph>
           </stage>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Ehi? giovani, dove siete?</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Son qui padrone.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Si lascia la bottega sola eh?</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Ero là coll'occhio attento, e coll'orecchio in
 veglia. E poi che volete voi, che rubino? Dietro al banco
 non vien nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Possono rubar le chicchere. So io, che vi è
 qualcheduno, che si fa l'assortimento di chicchere,
 sgrafignandole una alla volta ai poveri bottegai.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Come quelli, che vanno dove sono rinfreschi per
 farsi provvisione di tazze, e di tondini.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Il signor Eugenio è andato via?</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Oh, se sapeste! È venuta sua moglie; oh che
 pianti! oh che lamenti! Barbaro, traditore, crudele! Un poco
 amorosa, un poco sdegnata. Ha fatto tanto, che lo ha
 intenerito, e se ne è andato con lei.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>E dove è andato?</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Che domande! Stanotte non è stato a casa, sua
 moglie lo viene a ricercare; e domandate dove è andato?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Ha lasciato nessun ordine?</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>È tornato per la porticina di dietro a dirmi, che
 a voi si raccomanda per il negozio dei panni, perché non ne
 ha uno.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Le due pezze di panno le ho vendute a tredici lire
 il braccio, ed ho tirato il denaro; ma non voglio, ch'egli
 lo sappia; non glieli voglio dar tutti, perché, se gli ha
 nelle mani, gli farà saltare in un giorno.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Quando sa che gli avete, gli vorrà subito.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Non gli dirò d'averli avuti, gli darò il suo
 bisogno, e mi regolerò con prudenza.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Eccolo, che viene.<foreign xml:lang="lat">Lupus est in fabula</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Cosa vuol dire questo latino?</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Vuol dire: il lupo pesta la fava </p>
             <stage><emph>(si ritira in bottega ridendo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>È curioso costui. Vuol parlar latino, e non sa
 nemmeno parlare italiano.</p>
@@ -3342,84 +3382,84 @@ nemmeno parlare italiano.</p>
           <stage>
             <emph>Ridolfo ed Eugenio.</emph>
           </stage>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Ebbene, amico Ridolfo, avete fatto niente?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Ho fatto qualche cosa.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>So che avete avute le due pezze di panno; il giovine
 me lo ha detto. Le avete esitate?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Le ho esitate.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>A quanto?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>A tredici lire il braccio.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Mi contento; denari subito?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Parte alla mano, e parte col respiro.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Oimè! Quanto alla mano?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Quaranta zecchini.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Via, non vi è male. Datemeli, che vengono a tempo.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Ma piano, signor Eugenio, V. S. sa pure, che gli ho
 prestati trenta zecchini.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Bene, vi pagherete quando verrà il restante del
 panno.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Questo, la mi perdoni, non è un sentimento onesto da
 par suo. Ella sa come l'ho servita con prontezza
 spontaneamente, senza interesse, e la mi vuol fare
 aspettare? Anch'io, signore, ho bisogno del mio.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Via, avete ragione. Compatitemi, avete ragione.
 Tenetevi gli trenta zecchini, e date quei dieci a me.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Con questi dieci zecchini non vuol pagare il signor
 don Marzio? Non si vuol levar d'intorno codesto diavolo
 tormentatore?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Ha il pegno in mano, aspetterà.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Così poco stima V. S. la sua riputazione? Si vuol
 lasciar malmenare dalla lingua d'un chiacchierone? Da uno,
@@ -3427,49 +3467,49 @@ che fa servizio apposta per vantarsi d'averlo fatto, e che
 non ha altro piacere, che metter in discredito i
 galantuomini?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Dite bene, bisogna pagarlo. Ma ho io da restar senza
 denari? Quanto respiro gli avete accordato al compratore?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Di quanto avrebbe di bisogno?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Che so io? Dieci, dodici zecchini.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Servita subito. Questi son dieci zecchini, e quando
 viene il signor don Marzio, io recupererò gli orecchini.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Questi dieci zecchini, che mi date, di qual ragione
 s'intende, che sieno?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Gli tenga, e non pensi altro. A suo tempo
 conteggeremo.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Ma quando tireremo il resto del panno?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>La non ci pensi. Spenda quelli, e poi qualche cosa
 sarà; ma badi bene di spenderli a dovere, di non gettarli.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Sì, amico, vi sono obbligato de la vita. Ricordatevi
 nel conto del panno tenervi la vostra senseria.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Mi maraviglio; fo il caffettiere, e non fo il
 sensale. Se m'incomodo per un padrone, per un amico, non
@@ -3481,13 +3521,13 @@ ricompensato, se di questi denari, che onoratamente gli ho
 procurati, se ne servirà per profitto della sua casa, per
 risarcire il suo decoro, e la sua estimazione.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Voi siete un uomo molto proprio e civile; è peccato
 che facciate questo mestiere; meritereste meglio stato, e
 fortuna maggiore.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Io mi contento di quello, che il Cielo mi concede, e
 non scambierei il mio stato con tanti altri, che hanno più
@@ -3501,7 +3541,7 @@ uomini, e all'onesto divertimento di chi ha bisogno di
 respirare </p>
             <stage><emph>(entra in bottega)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Costui è un uomo di garbo; non vorrei però, che
 qualcheduno dicesse, che è troppo dottore. In fatti per un
@@ -3515,73 +3555,73 @@ tanto, quanto egli ne ha.</p>
         <div type="scene">
           <head>Scena terza</head>
           <stage><emph>Conte Leandro, di casa di Lisaura, ed Eugenio</emph>.</stage>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Signor Eugenio, questi sono i vostri denari; eccoli
 qui tutti in questa borsa; se volete, che ve gli renda,
 andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Son troppo sfortunato, non giuoco più.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Dice il proverbio: Una volta corre il cane, e
 l'altra la lepre.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Ma io sono sempre la lepre, e voi sempre il cane.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Ho un sonno, che non ci vedo. Son sicuro di non
 poter tenere le carte in mano; eppure per questo maladetto
 vizio non m'importa di perdere, purché giuochi.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Anch'io ho sonno. Oggi non giuoco certo.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Se non avete denari, non importa, io vi credo.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Credete, che sia senza denari? Questi sono zecchini;
 ma non voglio giuocare </p>
             <stage><emph>(mostra la borsa con li dieci zecchini)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Giuochiamo almeno una cioccolata.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Non ne ho volontà.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Una cioccolata per servizio.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Ma se vi dico...</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Una cioccolata sola sola, e chi parla di giuocar di
 più, perda un ducato.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Via, per una cioccolata, andiamo. (Già Ridolfo non
 mi vede)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>(Il merlotto è nella rete)</p>
             <stage><emph>(entra con Eugenio nella bottega del giuoco)</emph>.</stage>
@@ -3592,7 +3632,7 @@ mi vede)</p>
           <stage>
             <emph>Don Marzio, poi Ridolfo dalla bottega.</emph>
           </stage>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Tutti gli orefici gioiellieri mi dicono, che non
 vagliono dieci zecchini. Tutti si maravigliano, che Eugenio
@@ -3600,139 +3640,139 @@ m'abbia gabbato. Non si può far servizio; non do più un
 soldo a nessuno, se lo vedessi crepare. Dove diavolo sarà
 costui? Si sarà nascosto per non pagarmi.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Signore, ha ella gli orecchini del signor Eugenio?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Eccoli qui, questi belli orecchini non vagliono un
 corno; mi ha trappolato. Briccone! si è ritirato per non
 pagarmi; è fallito, è fallito.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Prenda signore, e non faccia altro fracasso; questi
 sono dieci zecchini, favorisca darmi i pendenti.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Sono di peso?</p>
             <stage><emph>(osserva coll'occhialetto)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Glieli mantengo di peso, e se calano, son qua io.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Gli mettete fuori voi?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Io non c'entro; questi sono denari del signor
 Eugenio.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Come ha fatto a trovare questi denari?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Io non so i fatti suoi.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Gli ha vinti al giuoco?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Le dico, che non lo so.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Ah, ora che ci penso, avrà venduto il panno. Sì, sì,
 ha venduto il panno; gliel'ha fatto vendere messer Pandolfo.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Sia come essersi voglia, prenda i denari, e
 favorisca rendere a me gli orecchini.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Ve gli ha dati da sé il signor Eugenio, o ve gli ha
 dati Pandolfo?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Oh, l'è lunga! Gli vuole, o non gli vuole?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Date qua, date qua. Povero panno! L'averà
 precipitato.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Mi dà gli orecchini?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Gli avete da portar a lui?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>A lui.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>A lui, o a sua moglie?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>O a lui, o a sua moglie </p>
             <stage><emph>(con impazienza)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Egli dov'è?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Non lo so.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Dunque gli porterete a sua moglie?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Gli porterò a sua moglie.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Voglio venire anch'io.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Gli dia a me, e non pensi altro. Sono un galantuomo.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Andiamo, andiamo, portiamoli a sua moglie</p>
             <stage><emph>(s'incammina)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>So andarvi senza di lei.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Voglio farle questa finezza. Andiamo, andiamo</p>
             <stage><emph>(parte)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Quando vuole una cosa non vi è rimedio. Giovani,
 badate alla bottega </p>
@@ -3744,7 +3784,7 @@ badate alla bottega </p>
           <stage>
             <emph>Garzoni in bottega, Eugenio dalla biscazza.</emph>
           </stage>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Maladetta fortuna! Gli ho persi tutti. Per una
 cioccolata ho perso dieci zecchini. Ma l'azione che mi ha
@@ -3755,19 +3795,19 @@ giuocare fino a domani. Dica Ridolfo quel che sa dire;
 bisogna che mi dia degli altri denari. Giovani, dov'è il
 padrone?</p>
           </sp>
-          <sp>
+          <sp who="#garzone">
             <speaker>GARZONE</speaker>
             <p>È andato via in questo punto.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Dov'è andato?</p>
           </sp>
-          <sp>
+          <sp who="#garzone">
             <speaker>GARZONE</speaker>
             <p>Non lo so, signore.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Maladetto Ridolfo! Dove diavolo sarà andato? Signor
 Conte aspettatemi, che or ora torno </p>
@@ -3781,122 +3821,122 @@ Conte aspettatemi, che or ora torno </p>
           <stage>
             <emph>Pandolfo dalla strada, e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Dove, dove, signor Eugenio, così riscaldato?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Avete veduto Ridolfo?</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Io no.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Avete fatto niente del panno?</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Signor sì, ho fatto.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Via, bravo; che avete fatto?</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Ho ritrovato il compratore del panno, ma con che
 fatica! L'ho fatto vedere da più di dieci, e tutti lo
 stimano poco.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Questo compratore quanto vuol dare?</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>A forza di parole l'ho tirato a darmi otto lire al
 braccio.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Che diavolo dite? Otto lire al braccio? Ridolfo me
 ne ha fatto vendere due pezze a tredici lire.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Denari subito?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Parte subito, e il resto con respiro.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Oh che buon negozio! Col respiro! Io vi fo dare
 tutti i denari uno sopra l'altro. Tante braccia di panno,
 tanti bei ducati d'argento veneziani.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>(Ridolfo non si vede! Vorrei denari, son punto)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Se avessi voluto vendere il panno a credenza,
 l'avrei venduto anche sedici lire. Ma col denaro alla mano,
 al dì d'oggi, quando si possono pigliare, si pigliano.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Ma se costa a me dieci lire.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Cosa importa perder due lire al braccio nel panno,
 se avete i quattrini per fare i fatti vostri, e da potervi
 ricattare di quel che avete perduto?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Non si potrebbe migliorare il negozio? Darlo per il
 costo?</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Non vi è speranza di crescere un quattrinello.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>(Bisogna farlo per necessità)</p>
             <stage><emph>(da sé)</emph>.</stage>
             <p>Via, quel
 che s'ha da fare si faccia subito.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Fatemi l'ordine per aver le due pezze di panno, e
 in mezz'ora vi porto qui il denaro.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Son qui subito. Giovani, datemi da scrivere.</p>
             <stage><emph>(I garzoni portano il tavolino, col bisogno per scrivere)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Scrivete al giovine, che mi dia quelle due pezze di
 panno, che ho segnate io.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Benissimo, per me è tutt'uno </p>
             <stage><emph>(scrive)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>(Oh che bell'abito, che mi voglio fare!)</p>
             <stage><emph>(da sé)</emph>.</stage>
@@ -3907,164 +3947,164 @@ panno, che ho segnate io.</p>
           <stage>
             <emph>Ridolfo dalla strada, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>(Il signor Eugenio scrive d'accordo con messer
 Pandolfo. Vi è qualche novità)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>(Non vorrei, che costui mi venisse a interrompere
 sul più bello)</p>
             <stage><emph>(da sé, vedendo Ridolfo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Signor Eugenio, servitor suo.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Oh, vi saluto </p>
             <stage><emph>(seguitando a scrivere)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Negozi, negozi, signor Eugenio? Negozi?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Un piccolo negozzietto </p>
             <stage><emph>(scrivendo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Posso esser degno di saper qualche cosa?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Vedete, cosa vuol dire a dar la roba a credenza? Non
 mi posso prevalere del mio; ho bisogno di denari, e conviene
 ch'io rompa il collo ad altre due pezze di panno.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Non si dice, che rompa il collo a due pezze di
 panno, ma che le venda, come si può.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Quanto le danno al braccio?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Mi vergogno a dirlo. Otto lire.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Ma i suoi quattrini un sopra l'altro.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>E V. S. vuol precipitar la sua roba così
 miseramente?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Ma se non posso fare a meno! Ho bisogno di denari.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Non è anche poco, da un'ora all'altra trovar i
 denari, che gli bisognano.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Di quanto avrebbe di bisogno?</p>
             <stage>
               <emph>(ad Eugenio)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Che? Avete da darmene?</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>(Sta a vedere, che costui mi rovina il negozio)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Se bastassero sei, o sette zecchini gli troverei.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Eh via! Freddure, freddure! Ho bisogno di denari</p>
             <stage><emph>(scrive)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>(Manco male!)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Aspetti; quanto importeranno le due pezze di panno a
 otto lire il braccio?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Facciamo il conto. Le pezze tirano sessanta braccia
 l'una: due via sessanta, cento e venti. Cento e venti ducati
 d'argento.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Ma vi è poi la senseria da pagare.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>A chi si paga la senseria?</p>
             <stage>
               <emph>(a Pandolfo)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>A me, signore, a me </p>
             <stage><emph>(a Ridolfo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Benissimo. Cento e venti ducati d'argento, a lire
 otto l'uno, quanti zecchini fanno?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Ogni undici, quattro zecchini. Dieci via undici,
 cento e dieci, e undici cento e vent'uno. Quattro via
 undici, quarantaquattro. Quarantaquattro zecchini meno un
 ducato. Quarantatré e quattordici lire, moneta veneziana.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Dica pure quaranta zecchini. I rotti vanno per la
 senseria.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Anche i tre zecchini vanno ne' rotti?</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Certo, ma i denari subito.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Via, via, non importa. Ve gli dono.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>(Oh che ladro!)</p>
             <stage><emph>(da sé)</emph>.</stage>
@@ -4072,47 +4112,47 @@ senseria.</p>
 signor Eugenio, quanto importano le due pezze di panno a
 tredici lire?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Oh, importano molto più!</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Ma col respiro; e non può fare i fatti suoi.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Faccia il conto.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Ora lo farò colla penna. <emph>Cento e venti braccia, a lire tredici il braccio. Tre via nulla; due via tre sei; un via tre; un via nulla; un via due; un via uno; somma: nulla; sei; due e tre cinque; uno. Mille cinquecento e sessanta lire</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Quanti zecchini fanno?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Subito ve lo so dire </p>
             <stage><emph>(conteggia)</emph>.</stage>
             <p>Settanta
 zecchini, e venti lire.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Senza la senseria.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Senza la senseria.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Ma aspettarli chi sa quanto. Val più una pollastra
 oggi, che un cappone domani.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Ella ha avuto da me; prima trenta zecchini, e poi
 dieci, che fan quaranta, e dieci degli orecchini, che ho
@@ -4121,17 +4161,17 @@ quest'ora dieci zecchini di più di quello, che gli dà
 subito, alla mano, un sopra l'altro, questo onoratissimo
 signor sensale.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>(Che tu sia maladetto!)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>È vero, avete ragione; ma adesso ho necessità di
 denari.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Ha necessità di denari? Ecco i denari; questi sono
 venti zecchini, e venti lire, che formano il resto di
@@ -4140,13 +4180,13 @@ braccia di panno, a tredici lire il braccio, senza pagare un
 soldo di senseria; subito alla mano, un sopra l'altro, senza
 ladronerie, senza scrocchi, senza bricconate da truffatori.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Quand'è così, Ridolfo caro, sempre più vi ringrazio;
 straccio quest'ordine, e da voi, signor sensale, non mi
 occorre altro.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>(Il diavolo l'ha condotto qui. L'abito è andato in
 fumo)</p>
@@ -4154,168 +4194,168 @@ fumo)</p>
             <p>Bene, non importa, averò gettati via i miei
 passi.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Mi dispiace del vostro incomodo.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Almeno da bevere l'acquavite.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Aspettate, tenete questo ducato </p>
             <stage><emph>(cava un ducato dalla borsa che gli ha dato Ridolfo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Obbligatissimo. (Già vi cascherà un'altra volta)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>(Ecco come getta via i suoi denari)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Mi comanda altro?</p>
             <stage>
               <emph>(ad Eugenio)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>La grazia vostra.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>(Vuole?)</p>
             <stage><emph>(gli fa cenno se vuol giuocare, in maniera che Ridolfo non veda)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>(Andate, che vengo)</p>
             <stage><emph>(di nascosto egli pure a Pandolfo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>(Già se gli giuoca prima del desinare)</p>
             <stage><emph>(va nella sua bottega e poi torna fuori)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Come è andata, Ridolfo? Avete veduto il debitor così
 presto? Vi ha dati subito gli denari?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Per dirgli la verità, gli avevo in tasca sin dalla
 prima volta; ma io non glieli voleva dar tutti subito, acciò
 non gli mandasse male sì presto.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Mi fate torto a dirmi così; non sono già un ragazzo.
 Basta... dove sono gli orecchini?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Quel caro signor don Marzio, dopo aver avuti i dieci
 zecchini, ha voluto per forza portar gli orecchini colle sue
 mani alla signora Vittoria.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Avete parlato voi con mia moglie?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Ho parlato certo; sono andato anch'io col signor don
 Marzio.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Che dice?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Non fa altro, che piangere; poverina! Fa
 compassione.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Se sapeste come era arrabbiata contro di me! Voleva
 andar da suo padre, voleva la sua dote, voleva far delle
 cose grandi.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Come l'ha accomodata?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Con quattro carezze.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Si vede, che le vuol bene; è assai di buon cuore.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Ma quando va in collera, diventa una bestia.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Non bisogna poi maltrattarla. È una signora nata
 bene, allevata bene. M'ha detto, che s'io lo vedo gli dica,
 che vada a pranzo a buon'ora.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Sì, sì, ora vado.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Caro signor Eugenio, la prego, badi al sodo, lasci
 andar il giuoco; non si perda dietro alle donne; giacché V.
 S. ha una moglie giovine, bella, e che gli vuol bene; che
 vuol cercar di più?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Dite bene, vi ringrazio davvero.</p>
             <stage>
               <emph>(Pandolfo dalla sua bottega si spurga, acciò Eugenio lo senta e lo guardi. Eugenio si volta. Pandolfo fa cenno che Leandro l'aspetta a giuocare. Eugenio colla mano fa cenno che anderà; Pandolfo torna in bottega. Ridolfo non se ne avvede)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Io la consiglierei andar a casa adesso. Poco manca
 al mezzo giorno. Vada, consoli la sua cara sposa.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Sì, vado subito. Oggi ci rivedremo.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Dove posso servirla, la mi comandi.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Vi sono tanto obbligato </p>
             <stage><emph>(vorrebbe andare al giuoco, ma teme che Ridolfo lo veda)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Comanda niente? Ha bisogno di niente?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Niente, niente. A rivederci.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Le son servitore </p>
             <stage><emph>(si volta verso la sua bottega)</emph>.</stage>
@@ -4329,7 +4369,7 @@ al mezzo giorno. Vada, consoli la sua cara sposa.</p>
           <stage>
             <emph>Ridolfo, poi Don Marzio.</emph>
           </stage>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Spero un poco alla volta tirarlo in buona strada. Mi
 dirà qualcuno: perché vuoi tu romperti il capo per un
@@ -4340,60 +4380,60 @@ obbligazioni? Questo nostro mestiere ha dell'ozio assai. Il
 tempo, che avanza molti l'impiegano o a giuocare, o a dir
 male del prossimo. Io l'impiego a far del bene se posso.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Oh che bestia! Oh che bestia! Oh che asino!</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Con chi l'ha, signor don Marzio?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Senti, senti, Ridolfo, se vuoi ridere. Un medico
 vuol sostenere, che l'acqua calda sia più sana dell'acqua
 fredda.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Ella non è di quest'opinione?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>L'acqua calda debilita lo stomaco.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Certamente rilassa la fibra.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Cos'è questa fibra?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Ho sentito dire, che nel nostro stomaco vi sono due
 fibre, quasi come due nervi, dalle quali si macina il cibo,
 e quando queste fibre si rallentano si fa una cattiva
 digestione.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Sì signore, sì signore; l'acqua calda rilassa il
 ventricolo, e la <emph>sistole</emph> e la <emph>diastole</emph> non possono
 triturare il cibo.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Come c'entra la sistole, e la diastole?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Che cosa ne sai tu, tu che sei un somaro? <emph>Sistole</emph>
 e <emph>diastole</emph> sono i nomi delle due fibre, che fanno la
 triturazione del cibo digestivo.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>(Oh che spropositi! Altro, che il mio Trappola!)</p>
             <stage><emph>(da sé)</emph>.</stage>
@@ -4404,135 +4444,135 @@ triturazione del cibo digestivo.</p>
           <stage>
             <emph>Lisaura alla finestra, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Ehi? L'amica della porta di dietro </p>
             <stage><emph>(a Ridolfo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Con sua licenza, vado a badare al caffè </p>
             <stage><emph>(va nell'interno della bottega)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Costui è un asino, vuol serrar presto la bottega.
 Servitor suo padrona mia </p>
             <stage><emph>(a Lisaura, guardandola di quando in quando col solito occhialetto)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Serva umilissima.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Sta bene?</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Per servirla.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Quant'è, che non ha veduto il conte Leandro?</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Un'ora in circa.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>È mio amico il Conte.</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Me ne rallegro.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Che degno galantuomo!</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>È tutta sua bontà.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Ehi? È vostro marito?</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>I fatti miei, non li dico sulla finestra.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Aprite, aprite, che parleremo.</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Mi scusi, io non ricevo visite.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Eh via!</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>No davvero.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Verrò per la porta di dietro.</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Anche ella si sogna, della porta di dietro? Io non
 apro a nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>A me non avete a dir così. So benissimo, che
 introducete la gente per di là.</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Io sono una donna onorata.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Volete che vi regali quattro castagne secche?</p>
             <stage><emph>(le cava dalla tasca)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>La ringrazio infinitamente.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Sono buone sapete. Le fo seccare io ne miei beni.</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Si vede, che ha buona mano a seccare.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Perché?</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Perché ha seccato anche me.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Brava! Spiritosa! Se siete così pronta a far le
 capriole, sarete una brava ballerina.</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>A lei non deve premere, che sia brava, o non brava.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>In verità, non me ne importa un fico.</p>
           </sp>
@@ -4543,58 +4583,58 @@ capriole, sarete una brava ballerina.</p>
             <emph>Placida da pellegrina, alla finestra della locanda, e
 detti.</emph>
           </stage>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>(Non vedo più il signor Eugenio)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Ehi? Avete veduto la pellegrina?</p>
             <stage><emph>(a Lisaura, dopo aver osservato Placida coll'occhialetto)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>E chi è colei?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Una di quelle del buon tempo.</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>E il locandiere riceve gente di quella sorta?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>È mantenuta.</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Da chi?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Dal signor Eugenio.</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Da un uomo ammogliato? Meglio!</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>L'anno passato, ha fatto le sue.</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Serva sua </p>
             <stage><emph>(ritirandosi)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Andate via?</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Non voglio stare alla finestra, quando in faccia vi
 è una donna di quel carattere </p>
@@ -4606,124 +4646,124 @@ detti.</emph>
           <stage>
             <emph>Placida alla finestra, Don Marzio nella strada.</emph>
           </stage>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Oh, oh, oh, questa è bella! La ballerina si ritira
 per paura di perdere il suo decoro! Signora pellegrina, la
 reverisco </p>
             <stage><emph>(coll'occhialetto)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Serva devota.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Dov'è il signore Eugenio?</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Lo conosce ella il signore Eugenio?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Oh, siamo amicissimi. Sono stato poco fa a ritrovare
 sua moglie.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Dunque il signor Eugenio ha moglie?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Sicuro, che ha moglie; ma ciò nonostante gli piace
 divertirsi coi bei visetti: avete veduto quella signora, che
 era a quella finestra?</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>L'ho veduta; mi ha fatto la finezza di chiudermi la
 finestra in faccia, senza fare alcun motto, dopo avermi ben
 bene guardata.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Quella è una, che passa per ballerina, ma!
 M'intendete.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>È una poco di buono?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Sì; e il signore Eugenio è uno dei suoi protettori.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>E ha moglie.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>E bella ancora.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Per tutto il mondo vi sono de' giovani scapestrati.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Vi ha forse dato ad intendere, che non era
 ammogliato?</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>A me poco preme, che lo sia, o non lo sia.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Voi siete indifferente. Lo ricevete com'e.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Per quello, che ne ho da far io, mi è tutt'uno.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Già si sa. Oggi uno, domani un altro.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Come sarebbe a dire? Si spieghi.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Volete quattro castagne secche?</p>
             <stage><emph>(le cava di tasca)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Bene obbligata.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Davvero se volete, ve le do.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>È molto generoso, signore.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Veramente al vostro merito, quattro castagne sono
 poche. Se volete, aggiugnerò alle castagne un par di lire.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Asino, senza creanza </p>
             <stage><emph>(serra la finestra, e parte)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Non si degna di due lire, e l'anno passato si
 degnava d'un trairo. Ridolfo </p>
@@ -4735,47 +4775,47 @@ degnava d'un trairo. Ridolfo </p>
           <stage>
             <emph>Ridolfo e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Signore?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Carestia di donne. Non si degnano di due lire.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Ma ella le mette tutte in un mazzo.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Roba, che gira il mondo? Me ne rido.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Gira il mondo anche della gente onorata.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Pellegrina! Ah, buffone!</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Non si può saper chi sia quella pellegrina.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Lo so, lo so. È quella dell'anno passato.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Io non l'ho più veduta.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Perché sei un balordo.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Grazie alla sua gentilezza. (Mi vien volontà di
 pettinargli quella parucca)</p>
@@ -4787,81 +4827,81 @@ pettinargli quella parucca)</p>
           <stage>
             <emph>Eugenio dal giuoco, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Schiavo signori, padroni cari </p>
             <stage><emph>(allegro e ridente)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Come! Qui il signore Eugenio?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Certo; qui sono. E come sono qui! </p>
             <stage>
               <emph>(ridendo)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Avete vinto?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Sì signore, ho vinto, sì signore.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Oh! che miracolo!</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Che gran caso! Non posso vincere io? Chi sono io?
 Son forse un mammalucco?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Signor Eugenio, è questo il proponimento di non
 giuocare?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>State zitto. Ho vinto.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>E se perdeva?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Oggi non potevo perdere.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>No? Perché?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Quando ho da perdere me la sento.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>E quando se la sente, perché giuoca?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Perché ho da perdere.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>E a casa quando si va?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Via mi principierete a seccare?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Non dico altro (Povere le mie parole!)</p>
             <stage><emph>(da sé)</emph>.</stage>
@@ -4872,113 +4912,113 @@ giuocare?</p>
           <stage>
             <emph>Leandro dalla bottega del giuoco, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Bravo, bravo; mi ha guadagnati li miei denari; e
 s'io non lasciava stare, mi sbancava.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Ah? Son uomo io? In tre tagli ho fatto il servizio.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Mette, da disperato.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Metto da giuocatore.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Quanto vi ha guadagnato?</p>
             <stage><emph>(a Leandro)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Assai.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Ma pure, quanto avete vinto?</p>
             <stage><emph>(ad Eugenio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Ehi; sei zecchini </p>
             <stage><emph>(con allegria)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>(Oh pazzo maladetto! Da ieri in qua, ne ha perduti
 cento e trenta, e gli pare aver vinto un tesoro, a averne
 guadagnati sei)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>(Qualche volta bisogna lasciarsi vincere per
 allettare)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Che volete voi fare di quei sei zecchini?</p>
             <stage><emph>(ad Eugenio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Se volete, che gli mangiamo, io ci sono.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Mangiamoli pure.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>(O povere le mie fatiche!)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Andiamo all'osteria? Ognuno pagherà la sua parte.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>(Non vi vada, la tireranno a giocare)</p>
             <stage><emph>(piano ad Eugenio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>(Lasciali fare; oggi sono in fortuna)</p>
             <stage><emph>(piano a Ridolfo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>(Il male non ha rimedio)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>In vece di andare all'osteria, potremmo far
 preparare qui sopra, nei camerini di messer Pandolfo.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Sì, dove volete; ordinaremo il pranzo qui alla
 locanda, e lo faremo portar là sopra.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Io, con voi altri, che siete galantuomini vengo per
 tutto.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>(Povero gonzo! Non se ne accorge)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Ehi; messer Pandolfo.</p>
           </sp>
@@ -4988,164 +5028,164 @@ tutto.</p>
           <stage>
             <emph>Pandolfo dal giuoco, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Son qui a servirla.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Volete farci il piacere di prestarci i vostri
 stanzini per desinare?</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Son padroni; ma vede, anch'io... pago la pigione...</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Si sa, pagheremo l'incomodo.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Con chi credete aver che fare? Pagheremo tutto.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Benissimo; che si servano. Vado a far ripulire </p>
             <stage><emph>(va in bottega del giuoco)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>(Ehi? Carte).</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>(Ma, di balla).</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>(Basta il quinto?).</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>(Sì, son contento).</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Via; chi va a ordinare?</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Tocca a voi, come più pratico del paese </p>
             <stage><emph>(ad Eugenio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Sì, fate voi! </p>
             <stage>
               <emph>(ad Eugenio)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Che cosa ho da ordinare?</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Fate voi.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Ma dice la canzona: «L'allegria non è perfetta;
 quando manca la donnetta».</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>(Anche di più vuol la donna!)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Il signor Conte potrebbe far venire la ballerina.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Perché no? In una compagnia d'amici non ho
 difficoltà di farla venire.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>È vero, che la volete sposare?</p>
             <stage><emph>(a Leandro)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Ora non è tempo di parlare di queste cose.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Ed io vedrò di far venire la pellegrina.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Chi è questa pellegrina?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Una donna civile, e onorata.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>(Sì, sì, l'informerò io di tutto)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Via; andate a ordinare il pranzo.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Quanti siamo? Noi tre, due donne, che fanno cinque.
 Signor don Marzio avete dama?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Io no. Son con voi.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Ridolfo, verrete anche voi a mangiare un boccone con
 noi.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Le rendo grazie; io ho da badare alla mia bottega.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Eh via; non vi fate pregare.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>(Mi pare assai, che abbia tanto cuore)</p>
             <stage><emph>(piano ad Eugenio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Che volete voi fare? Giacché ho vinto, voglio
 godere.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>E poi?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>E poi, buona notte; all'avvenire, ci pensan gli
 astrologhi </p>
             <stage><emph>(entra nella locanda)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>(Pazienza! Ho gettata via la fatica)</p>
             <stage><emph>(da sé, si ritira)</emph>.</stage>
@@ -5156,154 +5196,154 @@ astrologhi </p>
           <stage>
             <emph>Don Marzio e il Conte Leandro.</emph>
           </stage>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Via, andate a prendere la ballerina.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Quando sarà preparato, la farò venire.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Sediamo. Che cosa v'è di nuovo delle cose del mondo?</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Io di nuove non me ne diletto </p>
             <stage><emph>(siedono)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Avete saputo, che le truppe moscovite sono andate a
 quartiere d'inverno?</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Hanno fatto bene; la stagione lo richiedeva.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Signor no, hanno fatto male; non dovevano
 abbandonare il posto, che avevano occupato.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>È vero. Dovevano soffrire il freddo, per non
 perdere l'acquistato.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Signor no; non avevano da arrischiarsi a star lì,
 con pericolo di morire nel ghiaccio.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Dovevano dunque tirare avanti.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Signor no. Oh che bravo intendente di guerra!
 Marciare nella stagione d'inverno!</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Dunque, che cosa avevano da fare?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Lasciate, ch'io veda la carta geografica, e poi vi
 dirò per l'appunto, dove avevano a andare.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>(Oh che bel pazzo!)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Siete stato all'opera?</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Signor sì.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Vi piace?</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Assai.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Siete di cattivo gusto.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Pazienza.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Di che paese siete?</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Di Torino.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Brutta città.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Anzi passa per una delle belle d'Italia.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Io sono napoletano. Vedi Napoli, e poi mori.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Vi darei la risposta del veneziano, ma il cuor
 lavora.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Avete tabacco?</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Eccolo </p>
             <stage><emph>(gli apre la scatola)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Oh che cattivo tabacco!</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>A me piace così.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Non ve n'intendete. Il vero tabacco è il rapè.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>A me piace il tabacco di Spagna.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Il tabacco di Spagna è una porcheria.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Ed io vi dico, che è il miglior tabacco, che si
 possa prendere.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Come! A me volete insegnare, che cos'è tabacco? Io
 ne faccio, ne faccio fare, ne compro di qua, ne compro di
@@ -5311,13 +5351,13 @@ là. So quel che è questo, so quel che è quello. Rapè, rapè
 vuol essere, rapè </p>
             <stage><emph>(gridando forte)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <stage><emph>(forte ancor esso)</emph>.</stage>
             <p>Signor sì, rapè, rapè, è vero;
 il miglior tabacco è il rapè.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Signor no. Il miglior tabacco non è sempre il rapè.
 Bisogna distinguere, non sapete quel che vi dite.</p>
@@ -5328,110 +5368,110 @@ Bisogna distinguere, non sapete quel che vi dite.</p>
           <stage>
             <emph>Eugenio ritorna dalla locanda, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Che è questo strepito?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Di tabacco, non la cedo a nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Come va il desinare?</p>
             <stage><emph>(ad Eugenio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Sarà presto fatto.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Viene la pellegrina?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Non vuol venire.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Via, signor dilettante di tabacco, andate a prendere
 la vostra signora.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Vado. (Se a tavola fa così, gli tiro un piatto nel
 mostaccio)</p>
             <stage><emph>(picchia dalla ballerina)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Non avete le chiavi?</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Signor no </p>
             <stage><emph>(gli aprono ed entra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Averà quelle della porta di dietro </p>
             <stage><emph>(ad Eugenio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Mi dispiace, che la pellegrina non vuol venire.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Farà per farsi pregare.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Dice, che assolutamente non è più stata in Venezia.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>A me non lo direbbe.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Siete sicuro, che sia quella?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Sicurissimo; e poi, se poco fa ho parlato con lei, e
 mi voleva aprire... Basta, non sono andato, per non far
 torto all'amico.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Avete parlato con lei?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>E come!</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Vi ha conosciuto?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>E chi non mi conosce? Sono conosciuto più della
 bettonica.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Dunque fate una cosa. Andate voi a farla venire.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Se vi vado io, averà soggezione. Fate così;
 aspettate, che sia in tavola; andatela a prendere, e senza
 dir nulla conducetela su.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Ho fatto quanto ho potuto, e m'ha detto liberamente,
 che non vuol venire.</p>
@@ -5445,82 +5485,82 @@ tondini, posate, vino, pane, bicchieri e pietanze in bottega
 di Pandolfo, andando e tornando varie volte; poi LEANDRO,
 LISAURA e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#cameriere">
             <speaker>CAMERIERE</speaker>
             <p>Signori, la minestra è in tavola </p>
             <stage><emph>(va cogli altri in bottega del giuoco)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Il Conte dov'è?</p>
             <stage>
               <emph>(a don Marzio)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <stage><emph>(batte forte alla porta di Lisaura)</emph>.</stage>
             <p>Animo, presto,
 la zuppa si fredda.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <stage><emph>(dando mano a Lisaura)</emph>.</stage>
             <p>Eccoci, eccoci.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Padrona mia riverita </p>
             <stage><emph>(a Lisaura)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Schiavo suo </p>
             <stage><emph>(a Lisaura, guardandola coll'occhialetto)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Serva di lor signori.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Godo, che siamo degni della sua compagnia </p>
             <stage><emph>(a Lisaura)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Per compiacere il signor Conte.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>E per noi niente?</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Per lei particolarmente, niente affatto.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Siamo d'accordo. (Di questa sorta di roba non mi
 degno)</p>
             <stage><emph>(piano ad Eugenio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Via, andiamo, che la minestra patisce; resti servita</p>
             <stage><emph>(a Lisaura)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Con sua licenza </p>
             <stage><emph>(entra con Leandro nella bottega del giuoco)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Ehi! Che roba! Non ho mai veduta la peggio </p>
             <stage><emph>(ad Eugenio, col suo occhialetto, poi entra nella bisca)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Né anche la volpe non voleva le ciriegie. Io per
 altro mi degnerei </p>
@@ -5532,7 +5572,7 @@ altro mi degnerei </p>
           <stage>
             <emph>Ridolfo dalla bottega.</emph>
           </stage>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Eccolo lì, pazzo più che mai. A gozzovigliare, a
 tripudiare con donne, e sua moglie sospira, e sua moglie
@@ -5547,44 +5587,44 @@ della biscaccia, aprono le tre finestre che sono sopra le
 tre botteghe, ove sta preparato il pranzo, e si fanno vedere
 dalle medesime. RIDOLFO in istrada, poi TRAPPOLA.</emph>
           </stage>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Oh che bell'aria! Oh che bel sole! Oggi non è niente
 freddo </p>
             <stage><emph>(alla finestra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Pare propriamente di primavera </p>
             <stage><emph>(ad altra finestra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Qui almeno si gode la gente che passa </p>
             <stage><emph>(ad altra finestra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Dopo pranzo, vedremo le maschere </p>
             <stage><emph>(vicina a Leandro)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>A tavola, a tavola </p>
             <stage><emph>(siedono, restando Eugenio e Leandro vicini alla finestra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Signor padrone, che cos'è questo strepito?</p>
             <stage><emph>(a Ridolfo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Quel pazzo del signor Eugenio col signor don Marzio,
 ed il Conte colla ballerina, che pranzano qui sopra nei
 camerini di messer Pandolfo.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Oh bella! </p>
             <stage><emph>(vien fuori, guarda in alto)</emph>.</stage>
@@ -5592,68 +5632,68 @@ camerini di messer Pandolfo.</p>
 a lor signori </p>
             <stage><emph>(verso le finestre)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <stage><emph>(dalla finestra)</emph>.</stage>
             <p>Trappola, evviva.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Evviva. Hanno bisogno d'aiuto?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Vuoi venire a dar da bere?</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Darò da bere, se mi daranno da mangiare.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Vieni, vieni, che mangerai.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Signor padrone, con licenza </p>
             <stage><emph>(a Ridolfo. Va per entrare nella bisca, ed un Cameriere lo trattiene)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#cameriere">
             <speaker>CAMERIERE</speaker>
             <p>Dove andate?</p>
             <stage>
               <emph>(a Trappola)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>A dar da bere ai miei padroni.</p>
           </sp>
-          <sp>
+          <sp who="#cameriere">
             <speaker>CAMERIERE</speaker>
             <p>Non hanno bisogno di voi: ci siamo noi altri.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Mi è stato detto una volta, che oste in latino
 vuol dir nemico, osti veramente nemici del pover'uomo!</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Trappola, vieni su.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Vengo. A tuo dispetto </p>
             <stage><emph>(al Cameriere, ed entra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#cameriere">
             <speaker>CAMERIERE</speaker>
             <p>Badate ai piatti, che non si attacchi sui nostri
 avanzi </p>
             <stage><emph>(entra in locanda)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Io non so, come si possa dare al mondo gente di così
 poco giudizio! Il signor Eugenio vuole andare in rovina, si
@@ -5663,12 +5703,12 @@ corrisponde così? Mi burla, mi fa degli scherzi? Basta: quel
 che ho fatto, l'ho fatto per bene, e del bene non mi pentirò
 mai.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Signor don Marzio, e viva questa signora </p>
             <stage><emph>(forte, bevendo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#tutti">
             <speaker>TUTTI</speaker>
             <p>E viva, e viva.</p>
           </sp>
@@ -5679,29 +5719,29 @@ mai.</p>
             <emph>Vittoria mascherata, e detti. Vittoria passeggia avanti la
 bottega del caffè, osservando se vi è suo marito.</emph>
           </stage>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Che c'è, signora maschera, che comanda?</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>E viva i buoni amici </p>
             <stage><emph>(bevendo)</emph>.</stage>
             <stage><emph>(Vittoria sente la voce di suo marito, si avanza, guarda in alto, lo vede e smania)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Signora maschera, alla sua salute </p>
             <stage><emph>(col bicchiere di vino fuor della finestra, fa un brindisi a Vittoria, non conoscendola)</emph>.</stage>
             <stage><emph>(Vittoria freme e dimena il capo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Comanda restar servita? È padrona, qui siamo tutti
 galantuomini </p>
             <stage><emph>(a Vittoria, come sopra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Chi è questa maschera, che volete invitare?</p>
             <stage><emph>(dalla finestra)</emph>.</stage>
@@ -5714,84 +5754,84 @@ galantuomini </p>
             <emph>CAMERIERI con altra portata vengono dalla locanda, ed
 entrano nella solita bottega; e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>E chi paga? Il gonzo.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Signora maschera, se non vuol venir, non importa.
 Qui abbiamo qualche cosa meglio di lei </p>
             <stage><emph>(a Vittoria, come sopra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Oimè! Mi sento male. Non posso più.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Signora maschera, si sente male?</p>
             <stage><emph>(a Vittoria)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Ah Ridolfo, aiutatemi per carità </p>
             <stage><emph>(si leva la maschera)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Ella è qui?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Son io pur troppo.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Beva un poco di rosolio.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>No, datemi dell'acqua.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Eh no acqua, vuol esser rosolio. Quando gli spiriti
 sono oppressi, vi vuol qualche cosa, che gli metta in moto.
 Favorisca, venga dentro.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Voglio andar su da quel cane; voglio ammazzarmi
 sugli occhi suoi.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Per amor del Cielo, venga qui, s'acquieti.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>E viva quella bella giovanotta. Cari quegli occhi!</p>
             <stage>
               <emph>(bevendo)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Lo sentite il briccone? Lo sentite? Lasciatemi
 andare.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Non sarà mai vero, che io la lasci precipitare </p>
             <stage><emph>(la trattiene)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Non posso più. Aiuto, ch'io moro </p>
             <stage><emph>(cade svenuta)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Ora sto bene </p>
             <stage><emph>(la va aiutando e sostenendo alla meglio)</emph>.</stage>
@@ -5802,7 +5842,7 @@ andare.</p>
           <stage>
             <emph>Placida sulla porta della locanda, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Oh Cielo! Dalla finestra mi parve sentire la voce
 di mio marito; se fosse lui, sarei giunta bene in tempo a
@@ -5812,28 +5852,28 @@ svergognarlo </p>
 giovine, ditemi in grazia, chi vi è lassù in quei camerini?</p>
             <stage><emph>(al Cameriere che viene dalla biscaccia)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#cameriere">
             <speaker>CAMERIERE</speaker>
             <p>Tre galantuomini. Uno il signor Eugenio, l'altro il
 signor don Marzio napoletano, ed il terzo il signor conte
 Leandro Ardenti.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>(Fra questi non vi è Flamminio, quando non si fosse
 cangiato nome)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>E viva la bella fortuna del signor Eugenio</p>
             <stage><emph>(bevendo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#tutti">
             <speaker>TUTTI</speaker>
             <p>E viva.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>(Questi è mio marito senz'altro)</p>
             <stage><emph>(da sé)</emph>.</stage>
@@ -5842,41 +5882,41 @@ galantuomo, fatemi un piacere, conducetemi su da questi
 signori, che voglio loro fare una burla </p>
             <stage><emph>(al Cameriere)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#cameriere">
             <speaker>CAMERIERE</speaker>
             <p>Sarà servita. (Solita carica dei camerieri)</p>
             <stage><emph>(da sé; l'introduce per la solita bottega del giuoco)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Animo, prenda coraggio, non sarà niente </p>
             <stage><emph>(a Vittoria)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Io mi sento morire </p>
             <stage><emph>(rinviene)</emph>.</stage>
             <stage><emph>(Dalle finestre dei camerini si vedono alzarsi tutti da tavola in confusione, per la sorpresa di Leandro vedendo Placida, e perché mostra di volerla uccidere)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>No, fermatevi.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Non fate.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Levati di qui.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Aiuto, aiuto </p>
             <stage><emph>(fugge via per la scala)</emph>.</stage>
             <stage><emph>(Leandro vuol seguirla colla spada. Eugenio lo trattiene. Trappola con un tondino di roba in un tovagliuolo, salta da</emph><emph>una finestra e fugge in bottega del caffè. Placida esce dalla bisca correndo, e fugge nella locanda. Eugenio con arme alla mano in difesa di Placida, contro Leandro che la inseguisce)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <stage><emph>(esce pian piano dalla biscaccia e fugge via, dicendo)</emph>.</stage>
             <p><emph>Rumores fuge</emph>.</p>
@@ -5884,22 +5924,22 @@ signori, che voglio loro fare una burla </p>
               <emph>(I camerieri della bisca passano nella locanda e serrano la porta. Vittoria resta in bottega, assistita da Ridolfo)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Liberate il passo. Voglio entrare in quella locanda</p>
             <stage><emph>(colla spada alla mano, contro Eugenio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>No, non sarà mai vero. Siete un barbaro contro la
 vostra moglie, ed io la difenderò sino all'ultimo sangue.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Giuro al Cielo ve ne pentirete </p>
             <stage><emph>(incalza Eugenio colla spada)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Non ho paura di voi </p>
             <stage><emph>(incalza Leandro e l'obbliga rinculare tanto che, trovando la casa della ballerina aperta, entra in quella e si salva)</emph>.</stage>
@@ -5910,34 +5950,34 @@ vostra moglie, ed io la difenderò sino all'ultimo sangue.</p>
           <stage>
             <emph>Eugenio, Vittoria e Ridolfo.</emph>
           </stage>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Vile, codardo, fuggi? Ti nascondi? Vien fuori, se
 hai coraggio </p>
             <stage><emph>(bravando verso la porta della ballerina)</emph>.</stage>
             <p>Giuro al Cielo che ti caverò tutto il sangue.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Se volete sangue, spargete il mio </p>
             <stage><emph>(si presenta ad Eugenio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Andate via di qui, donna pazza, donna senza
 cervello.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Non sarà mai vero, ch'io mi stacchi viva da voi.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Corpo di bacco, andate via, che farò qualche
 sproposito </p>
             <stage><emph>(minacciandola colla spada)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <stage><emph>(con arme alla mano, corre in difesa di Vittoria, e si presenta contro Eugenio)</emph>.</stage>
             <p>Che pretende di fare, padron
@@ -5949,7 +5989,7 @@ anche minacciarla? Signora venga con me, e non abbia timor
 di niente </p>
             <stage><emph>(a Vittoria)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>No, caro Ridolfo; se mio marito vuol la mia morte,
 lasciate che si sodisfaccia. Via, ammazzami cane, assassino,
@@ -5959,7 +5999,7 @@ senza cuore, senza coscienza.</p>
               <emph>(Eugenio rimette la spada nel fodero senza parlare, mortificato)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Ah, signor Eugenio, vedo che già è pentito, ed io le
 domando perdono, se troppo temerariamente ho parlato. V. S.
@@ -5974,7 +6014,7 @@ signora Vittoria, osservi il signor Eugenio </p>
             <p>Piange, è intenerito, si pentirà, muterà vita,
 stia sicura, che le vorrà bene.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Lacrime di coccodrillo. Quante volte mi ha promesso
 di mutar vita! Quante volte colle lacrime agli occhi mi ha
@@ -5988,20 +6028,20 @@ più.</p>
           <stage>
             <emph>Vittoria e Ridolfo.</emph>
           </stage>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Che vuol dire, che non parla?</p>
             <stage><emph>(a Ridolfo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>È confuso.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Che si sia in un momento cambiato?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Credo di sì. Le dirò, se tanto ella, che io, non
 facevamo altro che piangere, e che pregare, si sarebbe
@@ -6010,21 +6050,21 @@ fatto, quel poco di bravata, l'ha messo in soggezione, e
 l'ha fatto cambiare. Conosce il fallo, vorrebbe scusarsi, e
 non sa come fare.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Caro Ridolfo, andiamolo a consolare.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Questa è una cosa, che l'ha da fare V. S. senza di
 me.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Andate prima voi, sappiatemi dire, come ho da
 contenermi.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Volentieri. Vado a vedere; ma lo spero pentito</p>
             <stage><emph>(entra in bottega)</emph>.</stage>
@@ -6035,73 +6075,73 @@ contenermi.</p>
           <stage>
             <emph>Vittoria, poi Ridolfo.</emph>
           </stage>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Questa è l'ultima volta, che mi vede piangere. O si
 pente, e sarà il mio caro marito; o persiste, e non sarò più
 buona a soffrirlo!</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Signora Vittoria, cattive nuove; non vi è più! È
 andato via per la porticina.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Non ve l'ho detto ch'è perfido, ch'è ostinato?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Ed io credo, che sia andato via per vergogna, pieno
 di confusione, per non aver coraggio di chiedere scusa, di
 domandarle perdono.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Eh che da una moglie tenera, come son io, sa egli
 quanto facilmente può ottenere il perdono.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Osservi. È andato via senza il cappello </p>
             <stage><emph>(prende il cappello in terra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Perché è un pazzo.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Perché è confuso; non sa quel che si faccia.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Ma se è pentito, perché non dirmelo?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Non ha coraggio.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Ridolfo, voi mi lusingate.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Faccia così: si ritiri nel mio camerino; lasci che
 io vada a ritrovarlo, e spero di condurglielo qui, come un
 cagnuolino.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Quando sarebbe meglio, che non ci pensassi più!</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Anche per questa volta faccia a modo mio, e spero
 non si pentirà.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Sì, così farò. Vi aspetterò nel camerino. Voglio
 poter dire, che ho fatto tutto il fattibile per un marito.
@@ -6109,7 +6149,7 @@ Ma se egli se ne abusa, giuro di cambiare in altrettanto
 sdegno l'amore </p>
             <stage><emph>(entra nella bottega interna)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Se fosse un mio figlio, non averei tanta pena. Sono
 stato allevato in casa sua, lo assisto per inclinazione, per
@@ -6123,7 +6163,7 @@ gratitudine, e per compassione </p>
             <emph>Lisaura dalla bottega del giuoco, osservando se vi è
 nessuno che la veda.</emph>
           </stage>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Oh! Povera me, che paura! Ah, Conte briccone! Ha
 moglie, e mi lusinga di volermi sposare! In casa mia non lo
@@ -6140,30 +6180,30 @@ senza fatica </p>
         <div type="scene">
           <head>Scena prima</head>
           <stage><emph>Leandro, scacciato di casa da Lisaura</emph>.</stage>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>A me un simile trattamento?</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <stage><emph>(sulla porta)</emph>.</stage>
             <p>Sì, a voi, falsario, impostore.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Di che vi potete dolere di me? D'aver abbandonata
 mia moglie per causa vostra?</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Se avessi saputo, ch'eravate ammogliato, non vi
 averei ricevuto in mia casa.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Non sono stato io il primo a venirvi.</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Siete però stato l'ultimo.</p>
           </sp>
@@ -6173,50 +6213,50 @@ averei ricevuto in mia casa.</p>
           <stage>
             <emph>Don marzio, che osserva coll'occhialetto e ride fra sé; e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Non avete meco gittato il tempo.</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Sì, sono stata, anch'io a parte de' vostri indegni
 profitti. Arrossisco in pensarlo; andate al diavolo, e non
 vi accostate più a questa casa.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Ci verrò a prendere la mia roba.</p>
             <stage><emph>(Don Marzio ride e burla di nascosto Leandro)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>La vostra roba vi sarà consegnata dalla mia serva</p>
             <stage><emph>(entra e chiude la porta)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>A me un insulto di questa sorta? Me la pagherai</p>
             <stage><emph>(Don Marzio ride, e voltandosi Leandro, si ricompone in serietà)</emph>.</stage>
             <p>Amico, avete veduto?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Che cosa? Vengo in questo punto.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Non avete veduto la ballerina sulla porta?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>No certamente, non l'ho veduta.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>(Manco male)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Venite qua; parlatemi da galantuomo; confidatevi con
 me, e state sicuro, che i fatti vostri non si sapranno da
@@ -6226,203 +6266,203 @@ assistenza, consiglio, e sopratutto secretezza, son qua io.
 Fate capitale di me. Di cuore, con premura, da buon amico;
 senza che nessun sappia niente.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Giacché con tanta bontà vi esibire di favorirmi,
 aprirò a voi tutto il mio cuore; ma per amor del Cielo vi
 raccomando la segretezza.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Quanta ne volete; andiamo avanti.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Sappiate, che la pellegrina è mia moglie.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Buono!</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Che l'ho abbandonata in Torino.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>(Oh che briccone!)</p>
             <stage><emph>(da sé, guardandolo con l'occhialetto)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Sappiate, ch'io non sono altrimenti il conte
 Leandro.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>(Meglio!)</p>
             <stage><emph>(da sé, come sopra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>I miei natali non sono nobili.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Non sareste già figliuolo di qualche birro?</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Mi maraviglio, signore, son nato povero, ma di
 gente onorata.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Via, via: tirate avanti.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Il mio esercizio era di scritturale....</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Troppa fatica, non è egli vero?</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>E desiderando vedere il mondo...</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Alle spalle de' gonzi.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Son venuto a Venezia...</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>A far il birbante.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Ma voi mi strapazzate. Questa non è la maniera di
 trattare.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Sentite; io ho promesso proteggervi, e lo farò. Ho
 promesso segretezza, e la osserverò; ma fra voi, e me avete
 da permettermi, che possa dirvi qualche cosa amorosamente.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Vedete il caso in cui mi ritrovo; se mia moglie mi
 scopre, sono esposto a qualche disgrazia.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Che pensereste voi di fare?</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Si potrebbe vedere di far cacciar via di Venezia
 colei.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Via, via. Si vede, che siete un briccone.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Come parlate, signore?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Fra voi, e me, amorosamente.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Dunque anderò via io; basta, che colei non lo
 sappia.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Da me, non lo saprà certamente.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Mi consigliate ch'io parta?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Sì, questo è il miglior ripiego. Andate subito.
 Prendete una gondola; fatevi condurre a Fusina, prendete le
 poste, e andatevene a Ferrara.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Anderò questa sera; già poco manca alla notte.
 Voglio prima levar le mie poche robe, che sono qui in casa
 della ballerina.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Fate presto, e andate via subito. Non vi fate
 vedere.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Uscirò per la porta di dietro, per non esser
 veduto.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>(Lo diceva io; si serve per la porta di dietro)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Sopra tutto vi raccomando la segretezza.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Di questa siete sicuro.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Vi prego d'una grazia; datele questi due zecchini;
 poi mandatela via; scrivetemi, e torno subito </p>
             <stage><emph>(gli dà due zecchini)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Le darò i due zecchini. Andate via.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Ma assicuratevi, che ella parta...</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Andate, che siate maledetto.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Mi scacciate?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Ve lo dico amorosamente, per vostro bene; andate che
 il diavolo vi porti.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>(Oh che razza di uomo! Se strapazza gli amici, che
 farà poi coi nemici!)</p>
             <stage><emph>(va in casa di Lisaura)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Il signor Conte! Briccone! Il signor Conte! Se non
 si fosse raccomandato a me, gli farei romper l'ossa di
@@ -6434,118 +6474,118 @@ bastonate.</p>
           <stage>
             <emph>Placida dalla locanda, e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Sì, nasca quel che può nascere. Voglio ritrovare
 quell'indegno di mio marito.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Pellegrina, come va?</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Voi, se non m'inganno, siete uno di quelli, che
 erano alla tavola con mio marito.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Sì, son quello delle castagne secche.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Per carità, ditemi dove si trova quel traditore.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Io non lo so, e quando anco lo sapessi, non ve lo
 direi.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Per che causa?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Perché se lo trovate farete peggio. Vi ammazzerà.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Pazienza! Avrò terminato almeno di penare.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Eh spropositi! bestialità! Ritornate a Torino.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Senza mio marito?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Sì senza vostro marito. Ormai che volete fare? È un
 briccone.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Pazienza! Almeno vorrei vederlo.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Oh non lo vedete più.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Per carità ditemi se lo sapete; è egli forse
 partito?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>È partito, e non è partito.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Per quel che vedo, V. S. sa qualche cosa di mio
 marito.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Io? So, e non so, ma non parlo.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Signore, movetevi a compassione di me.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Andate a Torino, e non pensate ad altro. Tenete, vi
 dono questi due zecchini.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Il Cielo vi rimeriti la vostra carità; ma non
 volete dirmi nulla di mio marito? Pazienza! Me ne anderò
 disperata </p>
             <stage><emph>(in atto di partire piangendo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>(Povera donna!)</p>
             <stage><emph>(da sé)</emph>.</stage>
             <p>Ehi! </p>
             <stage><emph>(la chiama)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Signore.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Vostro marito è qui in casa della ballerina, che
 prende la sua roba, e partirà per la porta di dietro</p>
             <stage><emph>(parte)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>È in Venezia! Non è partito! È in casa della
 ballerina! Se avessi qualcheduno, che mi assistesse, vorrei
@@ -6558,85 +6598,85 @@ insulto.</p>
           <stage>
             <emph>Ridolfo ed Eugenio, e detta.</emph>
           </stage>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Eh via, cosa sono queste difficoltà? Siamo tutti
 uomini, tutti soggetti ad errare. Quando l'uomo si pente, la
 virtù del pentimento cancella tutto il demerito dei
 mancamenti.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Tutto va bene, ma mia moglie non mi crederà più.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Venga con me; lasci parlare a me. La signora
 Vittoria le vuol bene; tutto si aggiusterà.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Signor Eugenio.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Il signor Eugenio si contenti di lasciarlo stare. Ha
 altro che fare, che badare a lei.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Io non pretendo di sviarlo da' suoi interessi. Mi
 raccomando a tutti nello stato miserabile in cui mi ritrovo.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Credetemi, Ridolfo, che questa povera donna, merita
 compassione; è onestissima, e suo marito è un briccone.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Egli mi ha abbandonata in Torino. Lo ritrovo in
 Venezia, tenta uccidermi, ed ora è sulle mosse per fuggirmi
 nuovamente di mano.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Sa ella dove egli sia?</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>È qui in casa della ballerina; mette insieme le
 sue robe, e fra poco se ne anderà.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Se anderà via, lo vedrà.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Partirà per la porta di dietro, ed io non lo vedrò,
 o se sarò scoperta, mi ucciderà.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Chi ha detto, che anderà via per la porta di dietro?</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Quel signore, che si chiama don Marzio.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>La tromba della comunità. Faccia così; si ritiri in
 bottega qui dal barbiere; stando lì si vede la porticina
 segreta. Subito che lo vede uscire, mi avvisi, e lasci
 operare a me.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>In quella bottega non mi vorranno.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Ora. Ehi, messer Agabito?</p>
             <stage><emph>(chiama)</emph>.</stage>
@@ -6647,24 +6687,24 @@ operare a me.</p>
           <stage>
             <emph>Il Garzone del barbiere dalla sua bottega, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#garzone">
             <speaker>GARZONE</speaker>
             <p>Che volete messer Ridolfo?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Dite al vostro padrone, che mi faccia il piacere di
 tener questa pellegrina in bottega per un poco, fino, che
 vengo io a ripigliarla.</p>
           </sp>
-          <sp>
+          <sp who="#garzone">
             <speaker>GARZONE</speaker>
             <p>Volentieri. Venga, venga padrona, che imparerà a
 fare la barba. Benché per pelare, la ne saprà più di noi
 altri barbieri </p>
             <stage><emph>(rientra in bottega)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Tutto mi convien soffrire per causa di
 quell'indegno. Povere donne! È meglio affogarsi, che
@@ -6677,103 +6717,103 @@ maritarsi così </p>
           <stage>
             <emph>RIDOLFO ed EUGENIO.</emph>
           </stage>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Se posso, voglio vedere di far del bene, anche a
 questa povera diavola. E nello stesso tempo, facendola
 partire con suo marito, la signora Vittoria non averà più di
 lei gelosia. Già mi ha detto qualche cosa della pellegrina.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Voi siete un uomo di buon cuore. In caso di bisogno
 troverete cento amici, che s'impiegheranno per voi.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Prego il Cielo di non aver bisogno di nessuno. In
 tal caso non so che cosa potessi sperare. Al mondo vi è
 dell'ingratitudine assai.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Di me potrete disporre, finch'io viva.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>La ringrazio infinitamente. Ma badiamo a noi. Che
 pens'ella di fare? Vuol andar in camerino da sua moglie, o
 vuol farla venire in bottega? Vuol andar solo? Vuole che
 venga anch'io? Comandi.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>In bottega non istà bene; se venite anche voi averà
 soggezione. Se vado solo mi vorrà cavare gli occhi... Non
 importa, ch'ella si sfoghi, che poi la collera passerà.
 Anderò solo.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Vada pure col nome del Cielo.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Se bisogna, vi chiamerò.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Si ricordi, che io non servo per testimonio.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Oh, che caro Ridolfo! Vado.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Via, bravo.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Che cosa credete, che abbia da essere?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Bene.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Pianti, o graffiature?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Un poco di tutto.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>E poi?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>«Ognun dal canto suo cura si prenda».</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Se non chiamo, non venite.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Già ci s'intende.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Vi racconterò tutto.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Via, operate da bravo.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>(Gran buon uomo è Ridolfo! Gran buon amico!)</p>
             <stage><emph>(entra nella bottega interna)</emph>.</stage>
@@ -6784,42 +6824,42 @@ Anderò solo.</p>
           <stage>
             <emph>Ridolfo, poi Trappola e Giovani.</emph>
           </stage>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Marito, e moglie? Gli lascio stare quanto vogliono.
 Ehi Trappola, giovani, dove siete?</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Son qui.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Badate alla bottega, che io vado qui dal barbiere.
 Se il signor Eugenio mi vuole, chiamatemi, che vengo subito.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Posso andar io a far compagnia al signor Eugenio?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Signornò, non avete da andare, e badate bene, che là
 dentro non vi vada nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Ma perché?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Perché no.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Anderò a veder se vuol niente.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Non andar, se non chiama. (Voglio intendere un po'
 meglio dalla pellegrina, come va questo suo negozio, e se
@@ -6832,99 +6872,99 @@ posso, voglio vedere di accomodarlo)</p>
           <stage>
             <emph>Trappola, poi Don Marzio.</emph>
           </stage>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Appunto, perché mi ha detto, che non vi vada, son
 curioso d'andarvi.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Trappola, hai avuto paura?</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Un poco.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Si è più veduto il signor Eugenio?</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Sì signore, si è veduto; anzi è lì dentro. Ma...
 zitto.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Dove?</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Zitto: nel camerino.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Che vi fa? Giuoca?</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Signor sì, giuoca </p>
             <stage><emph>(ridendo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Con chi?</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Con sua moglie </p>
             <stage><emph>(sotto voce)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Vi è sua moglie?</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Vi è; ma zitto.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Voglio andarlo a ritrovare.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Non si può.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Perché?</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Il padrone non vuole.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Eh via, buffone </p>
             <stage><emph>(vuol andare)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Le dico, che non si va </p>
             <stage><emph>(lo ferma)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Ti dico, che voglio andare </p>
             <stage><emph>(come sopra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Ed io dico, che non anderà </p>
             <stage><emph>(come sopra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Ti caricherò di bastonate.</p>
           </sp>
@@ -6934,24 +6974,24 @@ zitto.</p>
           <stage>
             <emph>Ridolfo dalla bottega del barbiere, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Che c'è?</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Vuol andar per forza a giuocar in terzo col
 matrimonio.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Si contenti, signore, che là dentro non vi si va.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Ed io ci voglio andare.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>In bottega mia comando io, e non vi anderà. Porti
 rispetto, se non vuol, che ricorra. E voi, finché torno, là
@@ -6964,11 +7004,11 @@ dentro non lasciate entrar chicchessia </p>
           <stage>
             <emph>Don Marzio, Trappola e Garzoni; poi Pandolfo.</emph>
           </stage>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Ha sentito? Al matrimonio si porta rispetto.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>(A un par mio? Non vi anderà?... Porti rispetto?...
 A un par mio? E sto cheto? E non parlo? E non lo bastono?
@@ -6977,28 +7017,28 @@ Briccone! Villanaccio! A me? A me?)</p>
             <p>Caffè </p>
             <stage><emph>(siede)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Subito </p>
             <stage><emph>(va a prendere il caffè, e glielo porta)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Illustrissimo, ho bisogno della sua protezione.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Che c'è, biscacciere?</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>C'è del male.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Che male c'è? Confidami, che t'aiuterò.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Sappia, signore, che ci sono dei maligni invidiosi,
 che non vorrebbero veder bene i poveri uommi. Vedono, che io
@@ -7006,7 +7046,7 @@ m'ingegno onoratamente per mantenere con decoro la mia
 famiglia, e questi bricconi mi hanno dato una querela di
 baro di carte.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Bricconi! Un galantuomo della tua sorta! Come l'hai
 saputo?</p>
@@ -7014,60 +7054,60 @@ saputo?</p>
               <emph>(ironico)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Me l'ha detto un amico. Mi confido però, che non
 hanno prove, perché nella mia bottega praticano tutti
 galantuomini, e niuno può dir male di me.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Oh, s'io avessi da esaminarmi contro di te, ne so
 delle belle della tua abilità!</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Caro illustrissimo, per amor del Cielo, la non mi
 rovini; mi raccomando alla sua carità, alla sua protezione,
 per le mie povere creature.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Via, sì, t'assisterò, ti proteggerò. Lascia fare a
 me. Ma bada bene. Carte segnate ne hai in bottega?</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Io non le segno... Ma qualche giuocatore si
 diletta...</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Presto, abbruciale subito. Io non parlo.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Ho paura non aver tempo per abbruciarle.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Nascondile.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Vado in bottega, e le nascondo subito.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Dove le vuoi nascondere?</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Ho un luogo segreto sotto le travature, che né
 anche il diavolo le ritrova </p>
             <stage><emph>(entra in bottega del giuoco)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Va' là, che sei un gran farabutto!</p>
           </sp>
@@ -7078,152 +7118,152 @@ anche il diavolo le ritrova </p>
             <emph>Don Marzio, poi un Capo di Birri mascherato ed altri birri
 nascosti; poi TRAPPOLA.</emph>
           </stage>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Costui è alla vigilia della galera. Se trova alcuno,
 che scopra la metà delle sue bricconate, lo pigliano
 prigione immediatamente.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>CAPITANO</speaker>
             <p>Girate qui d'intorno, e quando chiamo venite </p>
             <stage><emph>(ai Birri sulla cantonata della strada, i quali si ritirano)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>(Carte segnate! Oh che ladri!)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>CAPITANO</speaker>
             <p>Caffè </p>
             <stage><emph>(siede)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>La servo </p>
             <stage><emph>(va per il caffè, e lo porta)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>CAPITANO</speaker>
             <p>Abbiamo delle belle giornate.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Il tempo, non vuol durare.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>CAPITANO</speaker>
             <p>Pazienza! Godiamolo finché è buono.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Lo goderemo per poco.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>CAPITANO</speaker>
             <p>Quando è mal tempo si va in un casino, e si giuoca.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Basta andare in luoghi dove non rubino.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>CAPITANO</speaker>
             <p>Qui, questa bottega vicina mi pare onorata.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Onorata? È un ridotto di ladri.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>CAPITANO</speaker>
             <p>Mi pare sia messer Pandolfo il padrone.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Egli per l'appunto.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>CAPITANO</speaker>
             <p>Per dir il vero, ho sentito dire, che sia un
 giuocator di vantaggio.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>È un baro solennissimo.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>CAPITANO</speaker>
             <p>Ha forse truffato ancora a lei?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>A me no, che non son gonzo. Ma quanti capitano,
 tutti gli tira al trabocchetto.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>CAPITANO</speaker>
             <p>Bisogna, ch'egli abbia qualche timore, che non si
 vede.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>È dentro in bottega, che nasconde le carte.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>CAPITANO</speaker>
             <p>Perché mai nasconde le carte?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>M'immagino, perché sieno fatturate.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>CAPITANO</speaker>
             <p>Certamente. E dove le nasconderà?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Volete ridere? Le nasconde in un ripostiglio sotto
 le travature.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>CAPITANO</speaker>
             <p>(Ho rilevato tanto che basta)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Voi, signore, vi dilettate di giuocare?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>CAPITANO</speaker>
             <p>Qualche volta.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Non mi par di conoscervi.</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>CAPITANO</speaker>
             <p>Or ora mi conoscerete </p>
             <stage><emph>(s'alza)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Andate via?</p>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>CAPITANO</speaker>
             <p>Ora torno.</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Ehi! Signore, il caffè </p>
             <stage><emph>(al Capo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>CAPITANO</speaker>
             <p>Or ora lo pagherò </p>
             <stage><emph>(si accosta alla strada e fischia)</emph>.</stage>
@@ -7237,19 +7277,19 @@ le travature.</p>
 attentamente, senza parlare. Trappola osserva anch'egli
 attentamente.</emph>
           </stage>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Trappola...</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Signor don Marzio!...</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Chi sono coloro?</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Mi pare l'onorata famiglia.</p>
           </sp>
@@ -7259,26 +7299,26 @@ attentamente.</emph>
           <stage>
             <emph>Pandolfo legato, Birri e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Signor don Marzio, le sono obbligato.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>A me? Non so nulla.</p>
           </sp>
-          <sp>
+          <sp who="#pandolfo">
             <speaker>PANDOLFO</speaker>
             <p>Io anderò forse in galera, ma la sua lingua merita
 la berlina </p>
             <stage><emph>(va via coi Birri)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#capitano">
             <speaker>CAPITANO</speaker>
             <p>Si signore, l'ho trovato, che nascondeva le carte</p>
             <stage><emph>(a Don Marzio, e parte)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Voglio andargli dietro, per veder dove va</p>
             <stage><emph>(parte)</emph>.</stage>
@@ -7289,7 +7329,7 @@ la berlina </p>
           <stage>
             <emph>Don Marzio solo.</emph>
           </stage>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Oh diavolo, diavolo! Che ho io fatto? Colui, che io
 credeva un signore di conto, era un birro travestito. Mi ha
@@ -7302,49 +7342,49 @@ con facilità.</p>
           <stage>
             <emph>Ridolfo e Leandro di casa della ballerina, e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Bravo; così mi piace; chi intende la ragione fa
 conoscere, che è uomo di garbo; finalmente in questo mondo
 non abbiamo altro, che il buon nome, la fama, la riputazione</p>
             <stage><emph>(a Leandro)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Ecco lì quello, che mi ha consigliato a partire.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Bravo, signor don Marzio; ella dà di questi buoni
 consigli? Invece di procurare di unirlo con la moglie, lo
 persuade abbandonarla, e andar via?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Unirsi con sua moglie? È impossibile, non la vuole
 con lui.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Per me è stato possibile; io con quattro parole l'ho
 persuaso. Tornerà con la moglie.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>(Per forza per non esser precipitato)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Andiamo a ritrovar la signora Placida, che è qui dal
 barbiere.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Andate a ritrovare quella buona razza di vostra
 moglie.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Signor don Marzio, vi dico in confidenza tra voi, e
 me, che siete una gran lingua cattiva </p>
@@ -7356,7 +7396,7 @@ me, che siete una gran lingua cattiva </p>
           <stage>
             <emph>Don Marzio, poi Ridolfo.</emph>
           </stage>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Si lamentano della mia lingua, e a me pare di parlar
 bene. È vero, che qualche volta dico di questo, e di
@@ -7364,27 +7404,27 @@ quello, ma credendo dire la verità, non me ne astengo. Dico
 facilmente quello che so; ma lo faccio, perché son di buon
 cuore.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <stage><emph>(dalla bottega del barbiere)</emph>.</stage>
             <p>Anche questa è
 accomodata. Se dice davvero, è pentito. Se finge, sarà
 peggio per lui.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Gran Ridolfo! Voi siete quello, che unisce i
 matrimoni.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>E ella è quello, che cerca di disunirli.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Io ho fatto per far bene.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Chi pensa male, non può mai sperar di far bene. Non
 s'ha mai da lusingarsi, che da una cosa cattiva, ne possa
@@ -7392,31 +7432,31 @@ derivare una buona. Separar il marito dalla moglie, è
 un'opera contro tutte le leggi, e non si può sperare, che
 disordini, e pregiudizi.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Sei un gran dottore! </p>
             <stage><emph>(con disprezzo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Ella intende più di me; ma mi perdoni, la mia lingua
 si regola meglio della sua.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Tu parli da temerario.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Mi compatisca, se vuole; e se non vuole, mi levi la
 sua protezione.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Te la leverò, te la leverò. Non ci verrò più a
 questa tua bottega.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>(Oh il Ciel lo volesse!)</p>
             <stage><emph>(da sé)</emph>.</stage>
@@ -7427,28 +7467,28 @@ questa tua bottega.</p>
           <stage>
             <emph>Un Garzone della bottega del caffè, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#garzone">
             <speaker>GARZONE</speaker>
             <p>Signor padrone, il signore Eugenio vi chiama.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Vengo subito; con sua licenza </p>
             <stage><emph>(a Don Marzio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Riverisco il signor politico. Che cosa guadagnate in
 questi vostri maneggi?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Guadagno il merito di far del bene; guadagno
 l'amicizia delle persone; guadagno qualche marca d'onore,
 che stimo sopra tutte le cose del mondo </p>
             <stage><emph>(entra in bottega)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Che pazzo! Che idee da ministro, da uomo di conto!
 Un caffettiere fa l'uomo di maneggio! E quanto s'affatica! E
@@ -7461,23 +7501,23 @@ in un quarto d'ora.</p>
           <stage>
             <emph>Ridolfo, Eugenio, Vittoria dal caffè, e Don Marzio.</emph>
           </stage>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>(Ecco i tre pazzi. Il pazzo discolo, la pazza
 gelosa, e il pazzo glorioso)</p>
             <stage><emph>(da sé)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>In verità provo una consolazione infinita </p>
             <stage><emph>(a Vittoria)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Caro Ridolfo, riconosco da voi la pace, la quiete,
 e posso dire la vita.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Credete, amico, che ero stufo di far questa vita, ma
 non sapevo come fare a distaccarmi dai vizi. Voi, siate
@@ -7489,11 +7529,11 @@ durabile il mio cambiamento, a nostra consolazione, a gloria
 vostra, e a esempio degli uomini savi, onorati, e dabbene,
 come voi siete.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Dice troppo, signore, io non merito tanto.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Sino ch'io sarò viva, mi ricorderò sempre del bene
 che mi avete fatto. Mi avete restituito il mio caro
@@ -7505,76 +7545,76 @@ lagrime d'amore, e di tenerezza, che m'empiono l'anima di
 diletto, che mi fanno scordare ogni affanno passato,
 rendendo grazie al Cielo, e lode alla vostra pietà.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Mi fa piangere dalla consolazione.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>(Oh pazzi maledetti!)</p>
             <stage><emph>(guardando sempre con l'occhialetto)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Vittoria, volete che andiamo a casa?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Mi dispiace, ch'io sono ancora tutta lagrime,
 arruffata, e scomposta. Vi sarà mia madre, e anche altra mia
 parente, ad aspettarmi; non vorrei che mi vedessero col
 pianto agli occhi.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Via, racchetatevi; aspettiamo un poco.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Ridolfo non avete uno specchio? Vorrei un poco
 vedere come sto.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>(Suo marito le averà guastato il tuppè)</p>
             <stage><emph>(da sé, coll'occhialetto)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Se si vuol guardar nello specchio, andiamo qui sopra
 nei camerini del giuoco.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>No, là dentro non vi metto più il piede.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Non sa la nuova? Pandolfo è ito prigione.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Sì? Se lo merita. Briccone! Me ne ha mangiati tanti!</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Andiamo caro consorte.</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Quando non vi è nessuno, andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Così arruffata, non mi posso vedere </p>
             <stage><emph>(entra nella bottega del giuoco, con allegria)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Poverina! Giubbila dalla consolazione! </p>
             <stage><emph>(entra, come sopra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Vengo ancor io a servirgli </p>
             <stage><emph>(entra, come sopra)</emph>.</stage>
@@ -7585,55 +7625,55 @@ nei camerini del giuoco.</p>
           <stage>
             <emph>Don Marzio, poi Leandro e Placida.</emph>
           </stage>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Io so perché Eugenio è tornato in pace con sua
 moglie. Egli è fallito, e non ha più da vivere. La moglie è
 giovane, e bella... Non l'ha pensata male, e Ridolfo gli
 farà il mezzano.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Andiamo dunque alla locanda, a prendere il vostro
 piccolo bagaglio </p>
             <stage><emph>(uscendo dal barbiere)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Caro marito, avete avuto tanto cuore di
 abbandonarmi?</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Via non ne parliamo più. Vi prometto di cambiar
 vita.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Lo voglia il Cielo.</p>
             <stage><emph>(S'avvicinano alla locanda)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Servo di vosustrissima, signor Conte </p>
             <stage><emph>(a Leandro, burlandolo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Reverisco il signor protettore, il signor buona
 lingua.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>M'inchino alla signora Contessa </p>
             <stage><emph>(a Placida, deridendola)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Serva, signor cavaliere delle castagne secche</p>
             <stage><emph>(entra in locanda con Leandro)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Anderanno tutt'e due in pellegrinaggio a battere la
 birba. Tutta la loro entrata consiste in un mazzo di carte.</p>
@@ -7644,36 +7684,36 @@ birba. Tutta la loro entrata consiste in un mazzo di carte.</p>
           <stage>
             <emph>Lisaura alla finestra, e DON MARZIO.</emph>
           </stage>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>La pellegrina è tornata alla locanda con quel
 disgraziato di Leandro. S'ella ci sta troppo me ne vado
 assolutamente di questa casa.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Schiavo, signora ballerina </p>
             <stage><emph>(coll'occhialetto)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Ehi! Cameriere! </p>
             <stage><emph>(bruscamente)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#cameriere">
             <speaker>CAMERIERE</speaker>
             <p>Signora?</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Mi maraviglio del vostro padrone, che tenga nella
 sua locanda una tal sorta di gente.</p>
           </sp>
-          <sp>
+          <sp who="#cameriere">
             <speaker>CAMERIERE</speaker>
             <p>Di chi intende parlare?</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Parlo di quella pellegrina, la quale è la donna di
 mal affare, e in questi contorni non ci sono mai state di
@@ -7685,69 +7725,69 @@ queste porcherie.</p>
           <stage>
             <emph>Placida dalla finestra della locanda, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Eh, signorina! Come parlate de' fatti miei? Io sono
 una donna onorata. Non so se così si possa dire di voi.</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Se foste una donna onorata, non andereste pel mondo
 birboneggiando.</p>
             <stage><emph>(Don Marzio ascolta e osserva di qua e di là coll'occhialetto, e ride)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Sono venuta in traccia di mio marito.</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Sì, e l'anno passato in traccia di chi eravate?</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Io a Venezia non ci son più stata.</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Siete una bugiarda. L'anno passato avete fatta una
 trista figura in questa città.</p>
             <stage><emph>(Don Marzio osserva e ride, come sopra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Chi vi ha detto questo?</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Eccolo lì, il signor don Marzio me l'ha detto.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Io? Non ho detto nulla.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Egli non può aver detto una tal bugia; ma di voi sì
 mi ha narrata la vita, e i bei costumi. Mi ha egli informata
 dell'esser vostro, e che ricevete le genti di nascosto per
 la porta di dietro.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Io non l'ho detto </p>
             <stage><emph>(sempre coll'occhialetto di qua e di là)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Sì che l'avete detto.</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>È possibile, che il signor don Marzio abbia detto
 di me una simile iniquità?</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Vi dico, che non l'ho detto.</p>
           </sp>
@@ -7759,42 +7799,42 @@ di me una simile iniquità?</p>
 simile, poi Vittoria dall'altra, aprendole di mano in mano;
 e detti a' loro luoghi.</emph>
           </stage>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Sì, che l'ha detto, e l'ha detto anche a me, e
 dell'una, e dell'altra. Della pellegrina, che è stata l'anno
 passato a Venezia a birboneggiare; e della signora
 ballerina, che riceve le visite per la porta di dietro.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Io l'ho sentito dir da Ridolfo.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Io non son capace di dir queste cose. Abbiamo anzi
 altercato per questo. Io sosteneva l'onore della signora
 Lisaura, e V. S. voleva, che fosse una donna cattiva.</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Oh disgraziato!</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Sei un bugiardo.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>A me ancora ha detto, che mio marito teneva pratica
 colla ballerina, e colla pellegrina; e me l'ha dipinte per
 due scelleratissime femmine.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Ah scellerato!</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Ah maladetto!</p>
           </sp>
@@ -7804,58 +7844,58 @@ due scelleratissime femmine.</p>
           <stage>
             <emph>Leandro sulla porta della locanda, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Signor sì, signor sì, V. S. ha fatto nascere mille
 disordini; ha levata la riputazione colla sua lingua a due
 donne onorate.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Anche la ballerina onorata?</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Tale mi vanto di essere. L'amicizia col signor
 Leandro non era che diretta a sposarlo, non sapendo che egli
 avesse altra moglie.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>La moglie l'ha, e sono io quella.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>E se avessi abbadato al signor don Marzio, l'avrei
 nuovamente sfuggita.</p>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Indegno!</p>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Impostore!</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Maldicente!</p>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Ciarlone!</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>A me questo? A me, che sono l'uomo il più onorato
 del mondo?</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Per essere onorato non basta non rubare, ma bisogna
 anche trattar bene.</p>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Io non ho mai commessa una mala azione.</p>
           </sp>
@@ -7865,20 +7905,20 @@ anche trattar bene.</p>
           <stage>
             <emph>Trappola e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Il signor don Marzio l'ha fatta bella.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Che ha fatto?</p>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Ha fatto la spia a messer Pandolfo, l'hanno
 legato, e si dice, che domani lo frusteranno.</p>
           </sp>
-          <sp>
+          <sp who="#ridolfo">
             <speaker>RIDOLFO</speaker>
             <p>Lo spione! Via dalla mia bottega </p>
             <stage><emph>(parte dalla finestra)</emph>.</stage>
@@ -7889,7 +7929,7 @@ legato, e si dice, che domani lo frusteranno.</p>
           <stage>
             <emph>Il GARZONE del barbiere, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#garzone">
             <speaker>GARZONE</speaker>
             <p>Signore spione, non venga più a farsi fare la barba
 nella nostra bottega </p>
@@ -7901,46 +7941,46 @@ nella nostra bottega </p>
           <stage>
             <emph>Il Cameriere della locanda, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#cameriere">
             <speaker>CAMERIERE</speaker>
             <p>Signore spione, non venga più a far desinari alla
 nostra locanda </p>
             <stage><emph>(entra nella locanda)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Signor protettore; tra voi e me in confidenza; far
 la spia è azione da briccone </p>
             <stage><emph>(entra nella locanda)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#placida">
             <speaker>PLACIDA</speaker>
             <p>Altro, che castagne secche! Signor soffione </p>
             <stage><emph>(parte dalla finestra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#lisaura">
             <speaker>LISAURA</speaker>
             <p>Alla berlina, alla berlina </p>
             <stage><emph>(parte dalla finestra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>O che caro signor don Marzio! Quei dieci zecchini,
 che ha prestati a mio marito, saranno stati una paga di
 esploratore </p>
             <stage><emph>(parte dalla finestra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#eugenio">
             <speaker>EUGENIO</speaker>
             <p>Reverisco il signor confidente </p>
             <stage><emph>(parte dalla finestra)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#trappola">
             <speaker>TRAPPOLA</speaker>
             <p>Le fo reverenza al signor riferendario </p>
             <stage><emph>(entra in bottega)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#don_marzio">
             <speaker>DON MARZIO</speaker>
             <p>Sono stordito, sono avvilito, non so in qual mondo
 mi sia. Spione a me? A me spione? Per avere svelato

--- a/tei/goldoni-la-famiglia-dell-antiquario.xml
+++ b/tei/goldoni-la-famiglia-dell-antiquario.xml
@@ -86,6 +86,43 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="anselmo">
+            <persName>Conte Anselmo Terrazzani</persName>
+          </person>
+          <person xml:id="brighella">
+            <persName>Brighella</persName>
+          </person>
+          <person xml:id="isabella">
+            <persName>Contessa Isabella</persName>
+          </person>
+          <person xml:id="doralice">
+            <persName>Doralice</persName>
+          </person>
+          <person xml:id="giacinto">
+            <persName>Conte Giacinto</persName>
+          </person>
+          <person xml:id="colombina">
+            <persName>Colombina</persName>
+          </person>
+          <person xml:id="dottore">
+            <persName>Dottore Anselmi</persName>
+          </person>
+          <person xml:id="cavaliere">
+            <persName>Cavaliere del bosco</persName>
+          </person>
+          <person xml:id="arlecchino">
+            <persName>Arlecchino</persName>
+          </person>
+          <person xml:id="pantalone">
+            <persName>Pantalone de' Bisognosi</persName>
+          </person>
+          <person xml:id="pancrazio">
+            <persName>Pancrazio</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -184,177 +221,177 @@ e altre cose antiche.</stage>
 poltrona, esaminando alcune medaglie, con uno scrigno sul
 tavolino medesimo; poi Brighella</emph>
           </stage>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Gran bella medaglia! Questo è un <emph>Pescenio</emph> originale. Quattro zecchini? L'ho avuto per un pezzo di pane.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Lustrissimo. (<emph>con vari fogli in mano</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Guarda, Brighella, se hai veduto mai una medaglia
 più bella di questa.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Bellissima. De medaggie no me ne intendo troppo,
 ma la sarà bella.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>I <emph>Pesceni</emph> sono rarissimi; e questa pare coniata
 ora.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Gh'è qua ste do polizze...</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Ho fatto un gran bell'acquisto?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Comandela, che vada via?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Hai da dirmi qualche cosa?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Gh'o qua ste do polizze. Una del mercante da vin,
 e l'altra de quello della farina.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Gran bella testa! Gran bella testa! (<emph>osservando la medaglia</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>I xè qua de fora, i voleva intrar, ma gh'ò dito,
 che la dorme.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Hai fatto bene. Non voglio essere disturbato. Quanto
 avanzano?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Uno sessanta scudi, e l'altro cento, e trenta.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Tieni questa borsa, pagali, e mandali al diavolo.
 (<emph>leva una borsa dallo scrigno</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>La sarà servida. (<emph>parte</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Ora posso sperare di fare la collana perfetta
 degl'imperatori romani. Il mio museo a poco a poco si
 renderà famoso in Europa.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Lustrissimo. (<emph>torna con altri fogli</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Cosa c'è? Se venisse quell'Armeno con i camei, fallo
 passare immediatamente.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Benissimo; ma son capitadi altri tre creditori; el
 mercante de' panni, quel della tela, e il padron de casa,
 che vuol l'affitto.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Hanno date le loro polizze?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Lustrissimo sì; eccole qua. Dusento scudi in
 tutto.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>E ben, pagali, e mandali al diavolo.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>In te la borsa, no gh'è tanto.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Prendi ancor questa.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Da qua avanti no la sarà tormentada dai creditori.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Certo che no. Ho liberate tutte le mie entrate. Sono
 padrone del mio.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Per la confidenza, che Vusustrissima se degna de
 donarme, ardisso dir, l'ha fatto un buon negozio a maridar
 l'illustrissimo signor Contin, suo degnissimo fiol, con la
 fia del sior Pantalon.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Certo, che i ventimila scudi di dote, che mi ha
 portato in casa in tanti bei denari contanti è stato il
 risorgimento della mia casa. Io avevo ipotecate, come sai,
 tutte le mie rendite.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Za, che la xè in pagar debiti; la sappia, che co
 vago fora de casa, no me posso salvar; quattro ducati qua,
 tre là: a chi diese lire, a chi otto, a chi sie; s'ha da dar
 a un mondo de botteghieri.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>E bene; che si paghino, che si paghino. Se quella
 borsa non basta; vi è ancor questa, e poi è finito. (<emph>mostra un'altra borsa, che è nello scrigno</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>De vintimile scudi, no la ghe n'ha altri?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Per dir tutto a te, che sei il mio servitor fedele;
 ho riposto duemila scudi per il mio museo, per investirli in
 tante statue, in tante medaglie.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>La me perdona; ma buttar via tanti bezzi in ste
 cosse...</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Buttar via? Buttar via? Ignorantaccio. Senti, se
 vuoi avere la mia protezione, non mi parlar mai contro il
 buon gusto dell'antichità, altrimenti ti licenzierò di casa
 mia.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Diseva cussì, per quello, che sento a dir in casa;
 per altro accordo anca mi, che el studio delle medagie l'è
@@ -370,7 +407,7 @@ adularlo). (<emph>da sé, parte</emph>)</p>
           <stage>
             <emph>Il conte Anselmo solo.</emph>
           </stage>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Bravo. Brighella è un servitore di merito. Ecco un
 bell'anello etrusco. Con questi anelli gl'antichi Toscani
@@ -384,130 +421,130 @@ de' morti. Ma a forza d'oro, l'averò senz'altro.</p>
           <stage>
             <emph>La contessa Isabella e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>(Ecco qui; la solita pazzia delle medaglie). (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Oh, Contessa mia, ho fatto il bell'acquisto! Ho
 ritrovato un <emph>Pescenio</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Voi colla vostra gran mente fate sempre de' buoni
 acquisti.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Direste forse, che non è vero?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Sì, è verissimo. Avete fatto anche l'acquisto di
 una nobilissima nuora.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Che! sono stati cattivi ventimila scudi?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Per il vilissimo prezzo di ventimila scudi avete
 sagrificato il tesoro della Nobiltà.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Eh via, che l'oro non prende macchia. Siam nati
 nobili, siamo nobili, e una donna venuta in casa per
 accomodare i nostri interessi, non guasta il sangue delle
 nostre vene.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Una mercantessa mia nuora? Non lo soffrirò mai.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Orsù; non mi rompete il capo. Andate via, che ho da
 mettere in ordine le mie medaglie.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>E il mio gioiello, quando me lo riscuotete?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Subito. Anche adesso, se volete.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>L'ebreo lo ha portato; ed è in sala, che aspetta.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Quanto vi vuole?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Cento zecchini coll'usura.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Eccovi cento zecchini. Ehi! Sono di quelli della
 mercantessa.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Non mi nominate colei.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Se temete che vi sporchino le mani nobili,
 lasciateli stare.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Date qua, date qua, già che il diavolo vuol così.
 (<emph>li prende</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Volesse il cielo che avessi un altro figliuolo.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>E che vorreste fare?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Un'altra intorbidata alla purezza del sangue con
 altri ventimila scudi.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Animo vile! così vi lasciate contaminar dal denaro?
 Mi vergogno di essere vostra moglie.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Quanto sarebbe stato meglio, che voi ancora mi
 aveste portato in casa meno grandezze, e più denari.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Orsù, non entriamo in ragazzate. Ho bisogno di un
 abito.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Benissimo. Farlo.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Per la casa abbisognano cento cose.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Orsù tenete. Questi con i cento zecchini, che vi ho
 dato sono quattrocento zecchini. Fate quello bisogna per
@@ -515,40 +552,40 @@ voi, per la casa, per la sposa. Io non me ne voglio
 impacciare. Lasciatemi in pace se potete. Ma ehi! Questi
 danari sono della mercantessa.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Lo fate apposta per farmi arrabbiare.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Se non fosse stata lei, la faressimo magra.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>In grazia delle vostre medaglie.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>In grazia della vostra albagia.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Son chi sono.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Ma senza questi, non si fa niente. (<emph>accenna i denari</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Avvertite bene; che Doralice non venga nelle mie
 camere.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Chi? Vostra nuora?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Mia nuora, mia nuora; giacché il diavolo vuol così.
 (<emph>parte</emph>)</p>
@@ -559,7 +596,7 @@ camere.</p>
           <stage>
             <emph>Il conte Anselmo solo.</emph>
           </stage>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>È pazza, è pazza la poverina. Prevedo, che fra
 suocera, e nuora vi voglia essere il solito divertimento. Ma
@@ -576,154 +613,154 @@ stemprata la perla, alla famosa cena di Marcantonio.</p>
           <stage>
             <emph>Doralice e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Serva, signor suocero.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Schiavo nuora, schiavo. Ditemi v'intendete voi di
 anticaglie?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Sì, signore, me n'intendo.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Brava! me ne rallegro, e come ve n'intendete?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Me n'intendo, perché tutte le mie gioie, e tutti i
 miei vestiti sono anticaglie.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Brava! Spiritosa! Vostro padre prima di maritarvi
 doveva vestirvi alla moda.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Lo avrebbe fatto, se voi non aveste preteso i
 ventimila scudi in danari contanti, e non aveste promesso di
 farmi il mio bisogno per comparire.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Orsù, lasciatemi un po' stare; non ho tempo da
 perdere in simili fraschierie.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Vi pare una bella cosa, che io non abbia nemmeno
 un vestito da sposa?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Mi pare, che siate decentemente vestita.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Questo è l'abito, che avevo ancor da fanciulla.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>E perché siete maritata non vi sta bene? Anzi sta
 benissimo, e quando occorrerà, si allargherà.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Non è vostro decoro, ch'io vada vestita, come una
 serva.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>(Non darei questa medaglia per cento scudi). (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Finalmente ho portato in casa ventimila scudi.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>(A compir la collana, mi mancano ancora sette
 medaglie). (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Avete voluto fare il matrimonio segreto, ed io non
 ho parlato.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>(Queste sette medaglie, le troverò). (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Non avete invitato nessuno de' miei parenti;
 pazienza.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>(Vi sono ancora duemila scudi, le troverò). (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Ma ch'io debba stare confinata in casa, perché non
 ho vestiti da comparire, è una indiscretezza.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>(Oh sono pure annoiato!) (<emph>da sé</emph>) Andate da vostra
 suocera; ditele il vostro bisogno; a lei ho dato
 l'incombenza; ella farà quello, che sarà giusto.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Con la signora suocera, non voglio parlare di
 queste cose. Ella non mi vede di buon occhio. Vi prego
 datemi voi il denaro per un abito, che io penserè a
 provederlo.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Denaro io non ne ho.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Non ne avete? I ventimila scudi dove sono andati?
 (<emph>parla sempre flemmaticamente</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>A voi non devo rendere questi conti.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Li renderete a mio marito. La dote è sua; voi non
 gliel'avete a mangiare.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>E lo dite con questa flemma?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Per dir la sua ragione, non vi è bisogno di
 scaldarsi il sangue.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Orsù; fatemi il piacere; andate via di qua; ché se
 il sangue non si scalda a voi; or ora si scalda a me.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Mi maraviglio di mio marito. È un uomo
 ammogliato, e si lascia strapazzare così.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Per carità, andate via.</p>
           </sp>
@@ -733,62 +770,62 @@ ammogliato, e si lascia strapazzare così.</p>
           <stage>
             <emph>Il conte Giacinto e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Ha ragione mia moglie; ha ragione, una sposa non va
 trattata così.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>(Uh povere le mie medaglie!) (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Nemmeno un abito?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Andate da vostra madre. Le ho dato quattrocento
 zecchini.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Voi signor padre, siete il capo di casa.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Io non posso abbadare a tutto.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Maladette quelle anticaglie!</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Dei ventimila scudi dice, che non ne ha più.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Non ne ha più? Dove sono andati?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Per me non si è speso un soldo.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Io non ho avuto un quattrino.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Signor suocero, come va questa faccenda?</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Signor padre, ho moglie, sono obbligato a prevedere
 il futuro.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>(Non posso più. Non posso più. Ho tanto di testa.
 Non posso più). (<emph>da sé, prende le medaglie, le mette nello scrigno, e le porta via</emph>)</p>
@@ -799,293 +836,293 @@ Non posso più). (<emph>da sé, prende le medaglie, le mette nello scrigno, e le
           <stage>
             <emph>Il conte Giacinto e Doralice</emph>
           </stage>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Che ne dite eh? Ci ha data questa bella risposta.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Che volete, ch'io dica? Le medaglie lo hanno
 incantato.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Si è incantato lui; non siete incantato voi.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Cosa mi consiglierete di fare?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Dir le vostre, e le mie ragioni.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Finalmente è mio padre; non posso, e non deggio
 mancare al dovuto rispetto.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Avete sentito? Vostra madre ha quattrocento
 zecchini da spendere. Fate che ne spenda ancora per me.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Sarà difficile cavarglieli dalle mani.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Se non vuol colle buone, obbligatela colle
 cattive.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>È mia madre.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Ed io son vostra moglie.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Vi vorrei pur vedere in pace.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>È difficile.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Ma perché?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Perché ella è troppo superba.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>E voi convincetela coll'umiltà. Sentite, Doralice
 mia, due donne, che gridano sono come due porte aperte,
 dalle quali entra furiosamente il vento; basta chiuderne
 una, perché il vento si moderi.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>La mia collera è un vento, che in casa non fa
 rumore.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Sì, è vero; è un vento leggiero; ma non tanto fino,
 ed acuto, che penetra nelle midolle dell'ossa.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Vuole atterrar tutti colla sua furia.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>E voi non vi fate stare colla vostra flemma.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Sempre mette in campo la sua nobilità.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>E voi la vostra dote.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>La mia dote è vera.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>E la sua nobilità non è cosa ideale.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Dunque date ragione a vostra madre, e date torto a
 me?</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Vi do ragione quando l'avete.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Ho forse torto a pretendere d'essere vestita
 decentemente?</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>No, ma per mia madre desidero, che abbiate un poco
 più di rispetto.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Orsù sapete, che farò? Per rispettarla, per non
 inquietarla, anderò a star con mio padre.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Vedete? Ecco il vento leggiero leggiero, ma fino ed
 acuto. Con tutta placidezza, vorreste fare la peggior cosa
 del mondo.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Farei sì gran male a tornar con mio padre?</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Fareste malissimo a lasciare il marito.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Potete venire ancor voi.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Ed io farei peggio ad escire di casa mia.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Dunque stiamo qui, e tiriamo avanti così.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>È poco che siete in casa.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Dal buon mattino si conosce qual esser debba la
 buona sera.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Mia madre, vi prenderà amore.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Non lo credo.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Procurate di farvi ben volere.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>È impossibile con quella bestia.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Bestia a mia madre?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Sì, bestia; è una bestia.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>E lo dite con quella flemma?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Io non mi voglio scaldare il sangue.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Cara Doralice, abbiate giudizio.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Ne ho anche troppo.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Via, se mi volete bene, regolatevi con prudenza.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Fate, che io abbia quello, che mi si conviene, e
 sarò pazientissima.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Il merito della virtù consiste nel soffrire.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Sì soffrirò, ma voglio un abito.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>L'averete, l'averete.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Lo voglio, se credessi, che mi andasse la testa,
 sono impuntata, lo voglio.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Vi dico, che lo averete.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>E presto lo voglio, presto.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Or ora vado per il mercante. (Bisogna in qualche
 maniera acquietarla). (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Dite; che abito avete intenzione di farmi?</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Vi farò un abito buono.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>M'immagino vi sarà dell'oro, o dell'argento nel
 drappo.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>E se fosse di seta schietta; non sarebbe a
 proposito?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Mi pare, che ventimila scudi di dote, possino
 meritare un abito con un poco di oro.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Via, vi sarà dell'oro.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Mandatemi la cameriera, ché le voglio ordinare una
 scuffia.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Sentite; anche con Colombina siate tollerante. È
 cameriera antica di casa; mia madre le vuol bene, e può
 mettere qualche buona parola.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Che! dovrò aver sogezione anche della cameriera?
 Mandatela, mandatela, ché ne ho bisogno.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>La mando subito. (Sto fresco. Madre colerica.
 Moglie puntigliosa. Due venti contrari. Voglia il cielo, che
@@ -1097,7 +1134,7 @@ non facciano naufragare la casa). (<emph>da sé, parte</emph>)</p>
           <stage>
             <emph>Doralice e poi Colombina</emph>
           </stage>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Oh! In quanto a questo poi non mi voglio lasciar
 soverchiare. La mia ragione la voglio dir certamente. Mio
@@ -1106,109 +1143,109 @@ alterarmi. Mi pare di far meglio così. Chi va pazzamente in
 collera, pregiudica alla sua salute, e fa ridere i suoi
 nemici.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Il signor Contino m'ha detto, che la padrona mi
 domanda, ma non la vedo. È forse andata via?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Io sono la padrona, che ti domanda.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Oh! Mi perdoni, la mia padrona è l'illustrissima
 signora Contessa.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Io in questa casa son padrona?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Io servo la signora Contessa.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Per domani mi farai una scuffia.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Davvero, che non posso servirla.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Perché?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Perché ho da fare per la padrona.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Padrona sono anch'io; e voglio esser servita, o ti
 farò cacciar via.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Sono dieci anni, ch'io sono in questa casa.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>E che vuoi dire per questo?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Voglio dire, che forse non le riuscirà di farmi
 andar via.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Villana! Malcreata!</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Io villana? La non mi conosce bene, signora.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Oh, chi è Vusignoria? Me lo dica acciò non manchi
 al mio debito.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Mio padre vendeva nastri, e spille per le strade.
 Siamo tutti mercanti.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Siamo tutti mercanti! Non vi è differenza da uno,
 che va per le strade, e un mercante di piazza?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>La differenza consiste in un poco più di denari.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Sai, Colombina, che sei una bella impertinente?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>A me signora impertinente? A me che sono dieci anni,
 che sono in questa casa? Che sono più padrona della padrona
 medesima?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>A te, sì, a te; se non mi porterai rispetto
 vederai quello, che farò.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Cosa farete! Cosa farete?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Ti darò uno schiaffo. (<emph>glielo dà, e parte</emph>)</p>
           </sp>
@@ -1218,7 +1255,7 @@ vederai quello, che farò.</p>
           <stage>
             <emph>Colombina sola.</emph>
           </stage>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>A me uno schiaffo? E me lo dà, e poi dice: te lo
 darò? Così a sangue freddo, senza scaldarsi? Non me
@@ -1237,7 +1274,7 @@ soffrire. (<emph>parte</emph>)</p>
           <stage>
             <emph>La contessa Isabella, poi il conte Giacinto</emph>
           </stage>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Questa signora nuora è un'acqua morta, che a poco a
 poco si va dilatando; e s'io non vi riparo per tempo, ci
@@ -1249,196 +1286,196 @@ ricca, può tirar gente dal suo partito. In casa mia non
 voglio essere soverchiata. Non sono ancora in età da cedere
 l'armi al tempio.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Riverisco la signora madre.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Buon giorno, buon giorno.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Che avete, signora, che mi parete turbata?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Povero figlio! tu sei sagrificato.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Io sagrificato? Perché?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Tuo padre, tuo padre ti ha assassinato.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Mio padre? Cosa m'ha fatto?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Ti ha dato una moglie, che non è degna di te.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>In quanto a mia moglie, ne sono contentissimo;
 l'amo teneramente, e ringrazio il Cielo d'averla avuta.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>E la tua nobiltà?</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>La nostra nobiltà era in pericolo senza la dote di
 Doralice.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Si poteva trovare una ricca, che fosse nobile.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Era difficile nel disordine, in cui si ritrovava la
 nostra casa.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Con questi sentimenti, non mi comparir più davanti.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Signora sono venuto da voi per un affar di rilievo.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Come sarebbe a dire?</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>A una sposa, che ha portato in casa vintimile scudi
 mi pare, che sia giusto di farle un abito.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Per la comparsa, che deve fare, è vestita anche
 troppo bene.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Se non le si fa un abito buono, io non la posso
 condurre in veruna conversazione.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Che? La vorresti condurre nelle conversazioni? Un
 bell'onore, che faresti alla nostra famiglia. Se le faranno
 un affronto, la nostra casa torrà di mezzo.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Dovrà dunque star sempre in casa?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Signor sì, signor sì, sempre in casa. Ritirata,
 senza farsi vedere da chi si sia.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Ma tutti sanno, che Doralice è mia moglie; gli
 amici verranno a visitarla. Alcune dame me l'hanno fatto
 sapere.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Chi vuol venire in questa casa ha da mandare a me
 l'ambasciata. Io sono la padrona; e chiunque ardirà venirvi
 senza la mia intelligenza, ritroverà la porta serrata.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Via si farà tutto quello che voi volete. Ma anche
 lei poverina bisogna contentarla. Bisogna farle un abito.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Per contentar lei niente affatto; ma per te, perché
 ti voglio bene, lo faremo. Di che cosa lo vuoi? Di baracane,
 o di cambellotto?</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Diavolo! Vi pare, che questa sia roba da dama?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Colei non è nata dama.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>È mia moglie.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Ebbene di che vorresti, che si facesse?</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>D'un drappo moderno con oro, o con argento.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Sei pazzo? Sei pazzo? Non si gettano i denari in
 questa maniera.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Ma finalmente mi pare di poterlo pretendere.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Cos'è questo pretendere? Questa parola non l'hai
 più detta a tua madre. Ecco i frutti delle belle lezioni
 della tua sposa. Fraschetta, fraschetta!</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Ma che ha da fare quella povera donna in questa
 casa?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Mangiare, bere, lavorare, e allevare i figliuoli,
 quando ne avrà.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Così non può durare.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>O così, o peggio.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Signora madre, un poco più di carità.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Signor figliuolo un poco più di giudizio.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Fatele quest'abito, se mi volete bene.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Prendi, ecco sei zecchini, e fagli l'abito.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Sei zecchini? Fatelo alla vostra serva. (<emph>parte</emph>)</p>
           </sp>
@@ -1448,212 +1485,212 @@ quando ne avrà.</p>
           <stage>
             <emph>La contessa Isabella, poi il Dottore</emph>
           </stage>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>È diventato un bell'umorino costui. Causa
 quell'impertinente di Doralice.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Con permissione; posso venire? (<emph>di dentro</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Venite, venite, Dottore venite.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Faccio riverenza alla signora Contessa.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>È qualche tempo, che non vi lasciate vedere.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Ho avuto in questi giorni di molti affari.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Eh! Le amicizie vecchie si raffreddano un poco per
 volta.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Oh signora mi perdoni! La non può dire così. Dal
 primo giorno, che ella mi ha onorato della sua buona grazia,
 non può dire che io abbia mancato di servirla in tutto
 quello, ho potuto.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Datemi quella sedia.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Subito la servo. (<emph>le porta una sedia</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Avete tabacco? (<emph>sedendo</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Per dirla m'ho scordata la tabacchiera.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Guardate in quel cassetino, che vi è una
 tabacchiera, portatela qui.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Sì signora. (<emph>va a prendere la tabacchiera</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>(Mi piace il Dottore, perché conosce i suoi doveri,
 non fa come quelli, che quando hanno un poco di confidenza,
 se ne prendono di soverchio). (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Eccola. (<emph>presenta la tabacchiera alla Contessa</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Sentite questo tabacco. (<emph>gli offerisce il tabacco</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Buono per verità.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Tenete ve lo dono.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Anco la tabacchiera?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Anco la tabacchiera.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Oh le sono bene obbligato.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Oggi starete a pranzo con me.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Mi fa troppo onore. Ho piacere, così vederò anche
 la signora Doralice, che non ho mai veduta.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Doralice non mangia alla mia tavola.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>No? Perché?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Io non mi degno di mangiar con lei.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>È pur la moglie di suo figliuolo.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Se l'ha presa, che se la goda.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>È vero, che ella non è nobile; ma gl'ha portato
 una bella dote.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Oh, anche voi mi rompete il capo con questa dote.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>La non vada in collera, non parlo più.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Cos'ha portato? Cos'ha portato?</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Oh! Cos'ha portato? Quattro stracci.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Non era degna di venire in questa casa.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Dice bene, la non era degna. Io mi sono
 maravigliato quando ho sentito concludere un tal matrimonio.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Mi vengono i rossori sul viso.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>La compatisco. Non lo doveva mai accordare.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Ma voi pure mi avete consigliata a farlo.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Io? Non me ne ricordo.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>M'avete detto, che la nostra casa era in disordine,
 e che bisognava pensare a remediarvi.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Può essere, ch'io l'abbia detto.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Mi avete fatto vedere, che i ventimille scudi di
 dote potevano rimetterla in piedi.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>L'averò detto; e infatti il signor Conte, ha
 ricuperati tutti i suoi beni, ed io ho fatto l'instrumento
 della ricupera.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>L'entrate dunque sono libere.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Liberissime.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Non si penerà più di giorno in giorno. Non avremo
 più occasione d'incomodare gli amici. Anche voi caro
 Dottore, mi avete più volte favorita. Non me lo scordo.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Non parliamo di questo. Dove posso la mi comandi.</p>
           </sp>
@@ -1663,41 +1700,41 @@ Dottore, mi avete più volte favorita. Non me lo scordo.</p>
           <stage>
             <emph>Colombina e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Signora padrona, è qui il signor Cavaliere del
 Bosco. (<emph>mesta, quasi piangendo</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Andate; andate, che viene il signor Cavaliere. (<emph>al Dottore</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Perdoni, non ha detto ch'io resti?...</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Chi v'ha insegnato la creanza? Quando vi dico che
 andiate, dovete andare.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Pazienza. Anderò. Le son servitore. (<emph>partendo</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Ehi! A pranzo vi aspetto.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Ma se ella va in collera così presto...</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Manco ciarle. Andate, e venite a pranzo.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>(Sono tanti anni, che pratico in questa casa, e non
 ho ancora imparato a conoscere il suo temperamento). (<emph>da sé, parte</emph>)</p>
@@ -1708,43 +1745,43 @@ ho ancora imparato a conoscere il suo temperamento). (<emph>da sé, parte</emph>
           <stage>
             <emph>La contessa Isabella e Colombina</emph>
           </stage>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>È il signor Cavaliere?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Signora sì. (<emph>mesta come sopra</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Da Doralice vi è stato nessuno?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Signora no. (<emph>come sopra</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Che hai, che piangi?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>La signora Doralice mi ha dato uno schiaffo.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Come? Che dici? Colei ti ha dato uno schiaffo? Uno
 schiaffo alla mia cameriera? Perché? Contami: com'è stato?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Perché voleva dire, che ella è padrona, che
 Vusustrissima non conta più niente, che è vecchia. Io mi
 sono riscaldata per difendere la mia padrona, ed ella mi ha
 dato uno schiaffo. (<emph>piangendo</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Ah indegna, petulante, sfacciata! Me la pagherà, me
 la pagherà. Giuro al Cielo, me la pagherà.</p>
@@ -1755,28 +1792,28 @@ la pagherà. Giuro al Cielo, me la pagherà.</p>
           <stage>
             <emph>Il Cavaliere del bosco e dette.</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Permette la signora Contessa?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Cavalier, siete venuto a tempo. Ho bisogno di voi.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Comandate, signora. Disponete di me.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Se mi siete veramente amico, ora è tempo di
 dimostrarlo.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Farò tutto per obbedirvi.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Doralice, che per mia disgrazia è sposa di mio
 figliuolo, mi ha gravemente offesa; pretendo le mie
@@ -1786,70 +1823,70 @@ mio figlio, è innamorato della moglie, e non mi abbaderà.
 Voi siete Cavaliere, voi siete il mio più confidente, tocca
 a voi a sostenere le mie ragioni.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>In che consiste l'offesa?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Ha dato uno schiaffo a me.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Non vi è altro male?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Vi par poco dare uno schiaffo alla mia cameriera?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Dieci anni sono, ch'io servo in questa casa.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Non mi pare motivo per accendere un sì gran fuoco.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Ma bisogna sapere, perché l'ha fatto.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Oh! Qui sta il punto.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Via, perché l'ha fatto?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Tremo solamente in pensarlo. Non posso dirlo.
 Colombina, diglielo tu.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Ha detto, che la mia padrona non comanda più.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Che vi pare? (<emph>al Cavaliere</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Ha detto che è vecchia...</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Zitta bugiarda; non ha detto così. Pretende voler
 ella comandare. Pretende essere a me preferita, e perché la
 mia cameriera tiene da me, le dà uno schiaffo?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Signora Contessa, non facciamo tanto rumore.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Come? Dovrò dissimulare un'offesa di questa sorta?
 E voi me lo consigliereste? Andate, andate che siete un mal
@@ -1857,59 +1894,59 @@ Cavaliere; e se non volete voi abbracciare l'impegno,
 ritroverò chi avrà più spirito, chi avrà più convenienza di
 voi.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Bisogna secondarla). (<emph>da sé</emph>) Cara Contessa, non
 andate in collera; ho detto così, per acquietarvi un poco;
 per altro l'offesa è gravissima, e merita risarcimento.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Dare uno schiaffo alla mia cameriera!</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>È una temerità intollerabile.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Dir ch'io non comando più!</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>È una petulanza. E poi dire che siete vecchia!</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Questo vi dico, che non l'ha detto; non lo poteva
 dire; e non l'ha detto.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>L'ha detto in coscienza mia.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Va' via di qua.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>E ha detto di più, che avete da stare accanto al
 fuoco.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Va' via di qua. Sei una bugiarda.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Se non è vero mi caschi il naso.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Va' via di qua, o ti bastono.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Se non l'ha detto possa crepare. (<emph>parte</emph>)</p>
           </sp>
@@ -1919,66 +1956,66 @@ fuoco.</p>
           <stage>
             <emph>La contessa Isabella e il Cavaliere del bosco</emph>
           </stage>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Non le credete: Colombina dice delle bugie.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Dunque non sarà vero nemmeno dello schiaffo.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Oh! Lo schiaffo poi gliel'ha dato.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Lo sapete di certo?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Lo so di certo. E qui bisogna pensare a farmi avere
 le mie soddisfazioni.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ci penserò. Studierò l'articolo, e vederò qual
 compenso si può trovare, perché siate soddisfatta.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Ricordatevi, ch'io son dama, ed ella no.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Benissimo.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Ch'io sono la padrona di casa.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Dite bene. E che anco per ragione d'età vi si deve
 maggior rispetto.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Cosa c'entra l'età?... Per questo capo, non
 pretendo ragione alcuna.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Voglio dire...</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>M'avete inteso. Ditelo al Conte mio marito, ditelo
 al Contino mio figlio, ch'io voglio le mie soddisfazioni,
 altrimenti so io quel che farò. Cavaliere, vi attendo colla
 risposta. (<emph>parte</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Poco mi costa secondar l'umore di questa pazza,
 tanto più, che con questa occasione spero introdurmi dalla
@@ -1993,69 +2030,69 @@ signora Doralice, la quale è più giovane; e più bella.
             <emph>Brighella ed Arlecchino vestito all'armena, con barba
 finta.</emph>
           </stage>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Cusì, come ve diseva, el me padron l'è impazzido
 per l'antichità; el tol tutto, el crede tutto, el butta via
 i so denari in cosse ridicole, in cosse, che non val niente.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Cossa avì intenzion? Che el me toga mi per
 un'antigaia?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>V'ho vestito co sti abiti, e v'ho fatto metter sta
 barba, per condurve dal mio padron, darghe da intender che
 sì un antiquario, e farghe comprar tutte quelle strazzarìe,
 che v'ho dà. E po i denari li spartirem metà per uno.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Ma se el sor Cont me scovre, e in vezze de denari el
 me favorisce delle bastonade, le spartiremo metà per un?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Nol v'ha mai visto; nol ve conosce. È po co sta
 barba, e po co sti abiti parì un Armeno d'Armenia.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Ma se d'Armenia no so parlar!</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Ghe vol tanto a finzer de esser Armeno? Gnanca lu
 nol l'intende quel linguaggio; basta terminar le parole in
 <emph>ira</emph>, in <emph>ara</emph>, e el ve crede un Armeno italianà.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Volira, vedira, comprara: dighia ben?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Benissimo. Arecordev i nomi che v'ho dito per
 vendergh le rarità, e faremo polito.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Un gran ben, che volì al voster padron!</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Ve dirò. Ho procurà de illuminarlo, de
 disingannarlo, ma nol vol. El butta via i so denari con
 questo, e con quello; za che la cà se brusa, me vòi scaldar
 anca mi.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Bravissimo. Tutt sta, che me recorda tutto.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Vardè no fallar... Oh eccolo, che el vien.</p>
           </sp>
@@ -2065,208 +2102,208 @@ anca mi.</p>
           <stage>
             <emph>Il conte Anselmo e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Signor padron, l'è qua l'Armeno dalle antigagge.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Oh bravo! Ha delle cose buone?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Cose belle! Cose stupende!</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Amico, vi saluto. (<emph>ad Arlecchino</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Saludara, patrugna cara. (Digha ben?). (<emph>a Brighella</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>(Pulito).</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Cosa avete di bello da mostrarmi?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>(<emph>Fa vedere un lume da olio, ad uso di cucina</emph>)
 Questo stara... stara... (cossa stara?). (<emph>piano a Brighella</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>(Lume eterno). (<emph>piano ad Arlecchino</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Stara luma lanterna; trovata in palamida de getto,
 in sepolcro Bartolomeo.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Cosa diavolo dice? Io non l'intendo.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>L'aspetta; mi intendo un pochetto l'armeno.
 Aracapi, nicoscopi, ramarcara. (<emph>finge parlare armeno</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>La racaracà, taratapatà, baracacà, curucù, caracà.
 (<emph>finge risponder armeno a Brighella</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Vedela? Ho inteso tutto. El dis, che l'è un lume
 eterno trovà nelle piramidi d'Egitto, nel sepolcro de
 Tolomeo.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Stara, stara.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Ho inteso, ho inteso (Oh che cosa rara! Se lo posso
 avere, non mi scappa dalle mani). (<emph>da sé</emph>) Quanto ne
 volete?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Vinta zecchina.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Oh! È troppo. Se me lo dasse per dieci, ancor
 ancora lo prenderei.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>No podira, no podira.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Finalmente... non è una gran rarità. (Oh! Lo voglio
 assolutamente). (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Volela, che l'aggiusta mi?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Sì, vedi, se lo desse con dodici. (<emph>gli fa cenno con le mani che gli offerisca dodici zecchini</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Lamacà, volenich, calabà.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Salamin, salamon, salamà.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Curich, maradas, chiribara.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Sarich, micon, tiribio.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>(Che linguaggio curioso! E Brighella l'intende!)
 (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Sior padron l'è aggiustada.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Sì? Quanto?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Quattordese zecchini.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Non vi è male. Son contento. Galantuomo quattordici
 zecchini?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Stara, stara.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Sì, stara, stara. Ecco i vostri denari. (<emph>glieli conta</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Obligara, obligara.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>E se avera, altra... altra... rara, portara.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Sì portara, vegnira, cuccara.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Cosa vuol dir cuccara? (<emph>a Brighella</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Vuol dir distinguer da un altro.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Benissimo: se cuccara mi, mi cuccara ti. (<emph>ad Arlecchino</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Mi cuccara ti, ma ti no cuccara mi.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Sì, promettera.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Andara, andara.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Saludara. Patrugna; (se poterà Brighella
 minchionara). (<emph>parte</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Aspettara, aspettara. (<emph>vuol seguirlo</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Senti. (<emph>a Brighella</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>La lassa, che lo compagna... (<emph>in atto di andarsene</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Ma senti. (<emph>lo vuol trattenere</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Vegnira; vegnira. Pol esser, che el gh'abbia
 qualcossa altro. (Maledetto! I mi sette zecchini). (<emph>parte correndo</emph>)</p>
@@ -2277,7 +2314,7 @@ qualcossa altro. (Maledetto! I mi sette zecchini). (<emph>parte correndo</emph>)
           <stage>
             <emph>Il conte Anselmo, poi Pantalone</emph>
           </stage>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Gran fortuna è stata la mia! Questa sorte
 d'antichità non si trova così facilmente. Gran Brighella per
@@ -2286,52 +2323,52 @@ tanto desiderato, e poi trovarlo sì raro! Di quei d'Egitto?
 Quello di Tolomeo! Voglio farlo legare in oro come una
 gemma.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Con grazia; se pol vegnir? (<emph>di dentro</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>È il signor Pantalone? Venga, venga.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Servitor umilissimo, sior Conte.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Buon giorno il mio buon amico. Voi che siete
 mercante, uomo di mondo, e intendete di cose rare, stimatemi
 questa bella antichità.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>La me ha ben in concetto de un bravo mercante a
 farme stimar una luse da oggio!</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Povero signor Pantalone, non sapete niente. Questo è
 il lume eterno del sepolcro di Tolomeo.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(<emph>Ride</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Sì, di Tolomeo, ritrovato in una delle piramidi
 d'Egitto.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(<emph>Ride</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Ridete? Perché non ve n'intendete.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Benissimo, mi son ignorante, ella xè vertuoso, e
 non vòi catar bega su questo. Ghe digo ben, che tutta la
@@ -2339,12 +2376,12 @@ città se fa maraveggia, che un Cavalier della so sorte perda
 el so tempo, e sacrifica i so bezzi, in sta sorte de
 minchionerie.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>L'invidia fa parlare i malevoli; e quei stessi, che
 mi condannano in pubblico mi applaudiscono in privato.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>No gh'è nessun, che gh'abbia invidia della so
 galleria, che consiste in t'un capital de strazze. No gh'è
@@ -2354,55 +2391,55 @@ che gh'ho dà el mio sangue non posso far de manco da no
 sentir con della passion le pasquinate, che se fa della so
 mala condotta.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Ognuno in questo mondo ha qualche divertimento. Chi
 gioca, chi fa l'amore, chi va all'osteria; io ho il
 divertimento delle antichità.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Me despiase de mia fia, daresto no ghe penso un
 figo.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Vostra figlia sta bene, e non gli manca niente.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>No ghe manca gnente; ma no la gh'à gnanca un
 strazzo de abito, d'andar fora de casa.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Sentite, amico; io in queste cose non me ne voglio
 impicciare.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ma qua bisogna trovarghe rimedio assolutamente.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Andate da mia moglie, parlate con lei, intendetevi
 con lei, non mi rompete il capo.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>E se no la ghe remedierà ela, ghe remedierò mi.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Lasciatemi in pace; ho da badare alle mie medaglie,
 al mio museo, al mio museo.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Perché mia fia, la xè fia de un galantomo, e la pol
 star al pari de chi se sia.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Io non so che cosa vi dite. So che questo lume
 eterno, è una gioia. Signor Pantalone vi riverisco.
@@ -2414,91 +2451,91 @@ eterno, è una gioia. Signor Pantalone vi riverisco.
           <stage>
             <emph>Pantalone, poi Doralice</emph>
           </stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Cusì el me ascolta? A so tempo se parleremo. Ma
 vien mia fia; bisogna regolarse con prudenza.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Caro signor padre, venite molto poco a vedermi.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Cara fia, savè che gh'ho i mi interessi. E po no
 vegno tanto spesso, per no sentir pettegolezzi.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Quello, che vi ho scritto in quella polizza è
 purtroppo la verità.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Mo za; vu altre donne disè sempre la verità.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Dopo, ch'io sono in questa casa, non ho avuto
 un'ora di bene.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Vostro mario come ve trattelo?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Di lui non mi posso dolere. È buono, mi vuol
 bene, e non mi dà mai un disgusto.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Cossa voleu de più? Non ve basta?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Mia suocera non mi può vedere.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Andè colle bone; procurè de segondarla, dissimulè
 qualcossa; fè finta de no saver; fè finta de no sentir. Col
 tempo anca ela la ve vorà ben.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>In casa tutti si vestono, tutti spendono, tutti
 godono, ed io niente.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Abbiè pazenzia; vegnirà el zorno, che starè ben
 anca vu. Sè ancora novella in casa; gnancora non podè
 comandar.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Sino la cameriera mi maltratta, e non mi vuol
 obbedire.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>La xè cameriera vecchia de casa; la crede da esser
 più parona de vu.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Però le ho dato un schiaffo.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Gh'avè dà un schiaffo?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>E come, che gliel'ho dato! E buono!</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>E me lo contè a mi? E me lo disè co sta bella
 disinvoltura? Quatro zorni, che sé in sta casa, scomenzè
@@ -2522,97 +2559,97 @@ gh'avè. Portè rispetto ai vostri maggiori; siè umile, siè
 paziente, siè bona, e allora sarè nobile, sarè ricca, sarè
 respettada.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Signor padre, vi ringrazio dell'amorosa
 correzione, che mi fate.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Vostra madonna sarà in tutte le furie, e con rason.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Non so ancora, se lo abbia saputo.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Procurè, che no la lo sappia. E se mai la lo avesse
 savesto; arecordeve de far el vostro debito.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Qual è questo mio debito?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Andè da vostra madonna, e domandeghe scusa.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Domandarle scusa poi, non mi par cosa da mia pari.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>No la ve par cossa da par vostro? Cossa seu vu? Chi
 seu? Seu qualche Principessa? Povera sporca! Via, sè matta
 la vostra parte.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Non andate in collera. Le domanderò scusa. Ma
 voglio assolutamente, che mi faccia quest'abito.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Adesso, dopo la strambaria, che avè fatto, no xè
 tempo da domandarghelo.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Dunque starò senza? Dunque non anderò in nessun
 luogo? Sia maledetto quando sono venuta in questa casa.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Via, vipera, via subito maledir.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Ma se mi veggio trattata peggio di una serva.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Orsù, vegni qua; per stavolta vòi remediar mi a sti
 desordini. Tolè sti cinquanta zecchini; fève el vostro
 bisogno; ma arrecordeve ben, che no senta mai più rechiami
 dei fatti vostri.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Vi ringrazio, signor padre, vi ringrazio. Vi
 assicuro, che non avrete a dolervi di me. Un'altra cosa mi
 avereste a regalare, e poi non vi disturbo mai più.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Cossa voressi, via; cossa voressi?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Quell'orologio. Voi ne avete altri due.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Vòi contentarve anca in questo. Tiolè. (No gh'ho
 altro che sta puta). (<emph>da sé</emph>) Ma ve torno a dir, abbiè
 giudizio e fève voler ben. (<emph>le dà il suo orologio d'oro</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Non dubitate; sentirete, come mi conterrò.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Via, cara fia, dame un puoco de consolazion. No
 gh'ò altri a sto mondo, che ti. Dopo la mia morte, ti sarà
@@ -2628,51 +2665,51 @@ me casca el cuor, me vien la morte, pianzo co fa un putello.
           <stage>
             <emph>Doralice, poi Brighella</emph>
           </stage>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Povero padre; è molto buono. Non somiglia a queste
 bestie, che sono qui in casa. Se non fosse per mio marito,
 non ci starei un momento.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Signora, gh'è qua un cavalier, che ghe vorave far
 visita.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Un Cavaliere? Chi è?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Il signor Cavalier del Bosco.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Mi dispiace, che sono così in confidenza. Venga,
 non so che dire. Ehi, sentite.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>La comandi.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Andate subito da un mercante, e ditegli, che mi
 porti, tre, o quattro pezze di drappo con oro, o argento per
 farmi un abito.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>La sarà servida. Ma, la perdona, lo sàlo el
 padron?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Che impertinenza! Fate quello, che vi ordino, e
 non pensate altro.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>(Eh, la se farà, la se farà!). (<emph>da sé, parte</emph>)</p>
           </sp>
@@ -2682,360 +2719,360 @@ non pensate altro.</p>
           <stage>
             <emph>Doralice, poi il Cavaliere del bosco</emph>
           </stage>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>In questa casa hanno molto avvezzata male la
 servitù; ma io col tempo vi porrò la riforma. Oh, non ha
 d'andare così! Un poco colle buone, un poco colle cattive,
 ha da venire il tempo, che ho da essere io la padrona.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Madama, vi sono schiavo.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Vi son serva.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Perdonate, se mi son preso l'ardire di venirvi a
 fare una visita.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>È molto, che il signor Cavaliere si sia degnato
 di venire da me. Favorisce tutti i giorni questa casa, ma la
 mia camera mai.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Non ardiva di farlo, per non darvi incomodo.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Dite per non dispiacere alla signora Contessa
 Isabella.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>A proposito, madama, avrei da discorrervi qualche
 poco di un affare, che interessa tutte due egualmente.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>V'ascolterò volentieri. Elà; da sedere. (<emph>viene un servitore che porta le sedie</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>So, che voi, o signora, siete piena di bontà, onde
 spero riceverete in buon grado un officio amichevole, ch'io
 sono per farvi.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Quando saprò di che volete trattarmi vi
 risponderò.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ditemi, signora Contessa, che cosa avete fatto voi
 alla cameriera di vostra suocera?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Le ho dato un schiaffo. E per questo? Se è
 cameriera sua, è cameriera anco mia. Voglio essere servita;
 e non mi si ha da perdere il rispetto, e se questa volta le
 ho dato uno schiaffo, un'altra volta le romperò la testa.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Signora, credo, che voi scherzate.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Perché lo credete?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Perché mi dite queste cose con placidezza, e si
 vede, che non siete in collera.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Questo è il mio naturale. Io vado in collera
 sempre così.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>La signora Contessa Isabella si chiama offesa.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Mi dispiace.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>E sarebbe bene vedere di aggiustar la cosa, prima,
 che gl'animi s'intorbidassero soverchiamente.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Io non ci penso più.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Lo credo, che voi non ci pensate più. Ma ci pensa la
 signora suocera, che è restata offesa.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>E così, cosa pretenderebbe?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Trovaremo il modo dell'aggiustamento.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Il modo è facile, ve l'insegnerò io. Cacciar di
 casa la cameriera.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>In questa maniera la parte offesa pagherebbe la
 pena.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Orsù, signor Cavaliere, o mutiamo discorso o vi
 levo l'incomodo.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Signora mia, quando il discorso vi offende, lo
 tralascio subito. (No la vuo' disgustare). (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Mi pareva impossibile, che foste venuto a
 visitarmi, per farmi una finezza.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Perché, signora, perché?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Perché so di non essere degna. La signora suocera
 mi tien lontana dalle conversazioni, dubito sia, perché
 tema, ch'io gl'usurpi gl'adoratori.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(È furba quanto il diavolo). (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Ma, non dubiti, non dubiti. Io prima non sono, né
 bella, né avvenente, e poi abbado a mio marito, e non altro.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Sdegnereste dunque l'offerta d'un Cavaliere, che
 senza offesa della vostra modestia, aspirasse a servirvi?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>E chi volete, che si perda con me?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Io mi chiamerei fortunato, se vi compiaceste
 ricevermi per vostro servo.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Signor Cavaliere, siete impegnato colla Contessa
 Isabella.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Io sono amico di casa; per essa non ho alcuna
 parzialità. Ella ha il suo Dottore; quello è il suo cicisbeo
 antico.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>È antica ancor lei.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Sì, ma non vuol esserlo.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Non si vergogna mettersi colla gioventù. Se
 vengono visite sempre avanti lei, sempre in mezzo lei. Ella
 fa le grazie con tutti, vuol saper di tutto, vuol entrare in
 tutto. Mi fa una rabbia, che non la posso soffrire.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>È avvezzata così.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Bene, ma è passato il suo tempo. Adesso deve
 cedere il loco.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Deve cedere il loco a voi.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Mi parrebbe di sì.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Eppure ancora ha i suoi grilli in capo.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Causa quel pazzo di suo marito.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Signora, direte ch'io sono temerario, a supplicarvi
 di una grazia, il primo giorno, che ho l'onore di offerirvi
 la mia servitù.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Comandate; dove posso vi servirò.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Vorrei, che mi faceste comparir bene colla signora
 Contessa Isabella.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Se lo dico; avete paura di lei.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ma se possiamo coltivare la nostra amicizia con
 pace, e quiete, non è meglio?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Con quella bestiaccia sarà impossibile.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Vorrei vedere, se potessi essere amico di tutte
 due). (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Lo sapete pure. Mia suocera è una pazza.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Sì è vero, è una pazza.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Come pensareste di accomodare questa gran cosa?
 Non credo mai vi venirà in capo di consigliarmi cedere.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Anzi avete a stare sulle vostre.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Scusa non mi pare, che tocchi a me doman darla.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>No; certamente, non tocca a voi.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>(E mio padre mi diceva; che toccava a me). (<emph>da</emph>
 <emph>sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Sono imbrogliato più che mai). (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>La servitù mi ha da portare rispetto.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Senz'altro.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>E a chi mi perde il rispetto, non devo perdonare.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>No, certamente.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>(Oh guardate! Mio padre, che mi vorrebbe umile!)
 (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ma pure qualche maniera bisogna ritrovare per
 accomodare questa differenza.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Purch'io non resti pregiudicata, qualche cosa
 farò.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Faremo così. Procurerò, che vi troviate a caso in un
 medesimo luogo. Dirò io qualche cosa per l'una, e per
 l'altra. Mi basta, che voi vi contentiate di salutar prima
 la vostra suocera.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Salutarla prima? Perché?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Perché è suocera.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Oh! Questo non fa il caso.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Perché è più vecchia di voi.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Oh! Perché è più vecchia, lo farò.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Eccola, che viene.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Mi si rimescola tutto il sangue quando la vedo.
 (<emph>s'alzano</emph>)</p>
@@ -3046,12 +3083,12 @@ la vostra suocera.</p>
           <stage>
             <emph>La contessa Isabella e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Signor Cavaliere, vi siete divertito bene? Me ne
 rallegro.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(<emph>La tira in disparte</emph>) Signora Contessa ho fatto
 tutto, la signora Doralice è pentita del suo trascorso. È
@@ -3059,26 +3096,26 @@ pronta a domandarvi scusa, ma voi, savia, prudente non avete
 a permettere. Vi avete a contentare della sua disposizione;
 e per prova di questa, basta, ch'ella sia prima a salutarvi.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Salutarmi, e non altro? (<emph>piano al Cavaliere</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Adesso, adesso; aspettate). (<emph>da sé</emph>) Signora
 Contessina, a voi. Compiacetemi di fare quello, che avete
 detto. (<emph>piano a Doralice</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Signora; perché siete più vecchia di me, vi
 riverisco. (<emph>alla contessa Isabella, e parte</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Temeraria! Me la pagherai. (<emph>parte</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ecco fatto l'aggiustamento. (<emph>parte</emph>)</p>
           </sp>
@@ -3092,91 +3129,91 @@ riverisco. (<emph>alla contessa Isabella, e parte</emph>)</p>
           <stage>
             <emph>Doralice ed il conte Giacinto</emph>
           </stage>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Gran disgrazia! Gran disgrazia! In questa nostra
 casa non si può vivere un giorno in pace.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Lo dite a me? Io non do fastidio a nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Eh Doralice mia, se mi voleste bene, non vi
 regolereste così.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Ma di che mai vi potete dolere?</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Voi non volete rispettare mia madre.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Che cosa pretenderete, ch'io faccia, per darle un
 segno del mio rispetto? Volete, che vada a darle l'acqua da
 lavare le mani? Che vada a tirargli le calze, quando va a
 letto?</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Oh benedetta! benedetta! no la vogliam finir bene.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Dite: non lo sapete, ch'io sono stata stamattina
 la prima a salutarla?</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Sì, e nel salutarla, l'avete strapazzata.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>L'ho strapazzata? Non è vero.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Le avete detto, che è vecchia.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Oh, oh! Mi fate ridere. Perché le ho detto
 vecchia, s'intende, ch'io l'abbia strapazzata? Pretende ella
 forse di esser giovane?</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Non è una giovanetta; ma non le si può dire ancor
 vecchia.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>È vostra madre.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Quando sarete voi di quell'età, avrete piacere, che
 vi dichino vecchia?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Quando sarò di quell'età vi risponderò.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Fate con gl'altri quello, che voreste, che fosse
 fatto con voi.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Se a mia suocera le dicessi, che è giovane, mi
 parrebbe in verità di burlarla.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Che bisogno c'è, che le diciate giovane, o vecchia?
 Questo è il discorso più odioso, che possa farsi a voi altre
@@ -3187,128 +3224,128 @@ diecine, a dozzine. Voi adesso avete ventitré anni; scometto
 qualche cosa di bello, che da qui a dieci anni ne avrete
 ventiquattro.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Via, bravo. Se volete, che vostra madre sia più
 giovane di me, lo sarà.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Queste sono tutte freddure. Vorrei, vi torno a
 dire, che consideraste, che ella è mia madre, che le
 portaste un poco più di rispetto.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Sì; le farò carezze; le ballerò anche una
 furlanetta alla veneziana.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Orsù vedo, che non posso sperar niente; ci converrà
 pensare al rimedio.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Se foste un uomo, a quest'ora ci avreste pensato.
 Ma compatitemi, siete ancora ragazzo.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Io? Perché?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Perché se foste un uomo di senno, non avereste
 permesso, che vostro padre, e vostra madre consumassero
 miseramente ventimila scudi, senza nemmeno fare un abito
 alla vostra moglie.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>A proposito, l'abito mi ha detto mia madre, che si
 farà...</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Non ho bisogno di lei. Lo farò senza di lei,
 questi sono denari; e or ora verrà il mercante. (<emph>gli fa vedere una borsa</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Chi ve li ha dati, Doralice, chi ve li ha dati?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Mio padre, me li ha regalati.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Sono molti?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Sono cinquanta zecchini.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>E li spenderete tutti per voi?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Per farvi vedere, ch'io vi voglio bene, tenete
 quest'orologio, ve lo dono.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Chi ve l'ha dato?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Mio padre.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Cara Doralice vi ringrazio.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Siete il mio caro marito.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Addio, vado in piazza, e or ora torno.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Fatemi un piacere; mandatemi Colombina.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Non vorrà venire.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Mandatela con qualche pretesto. Non le dite, ch'io
 sia in questa camera; mi preme di parlarle.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Per amor del Cielo, non fate peggio.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Non dubitate.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Averei piacere, che vedeste mia madre.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Se mi vuol vedere, questa è la mia camera.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Non so che dire; vi vuol pazienza. (<emph>parte</emph>)</p>
           </sp>
@@ -3318,7 +3355,7 @@ sia in questa camera; mi preme di parlarle.</p>
           <stage>
             <emph>Doralice sola.</emph>
           </stage>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Ragazzo senza giudizio! Facilmente si fa piegare
 dove, e come si vuole. Mi preme tenerlo forte, e costante
@@ -3332,109 +3369,109 @@ voglio, che così subito mi veda, acciò non fugga.</p>
           <stage>
             <emph>Colombina e detta.</emph>
           </stage>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Oh, questa è bella! Tutti mi comandano. Anche il
 signor Contino si vuol far servire da me. Basta, più
 volentieri servirò lui, che quella pettegola di sua moglie.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Colombina.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>(Uh! povera me). Signora, non ho parlato di voi.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Hai parlato di me, ma ti compatisco. Poverina! Ti
 ho dato quello schiaffo, e me ne dispiace infinitamente.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Ancora sento il bruciore.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Vieni qua; voglio che facciamo la pace.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>La mia padrona tant'anni, ch'io la servo non mi ha
 mai toccato.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>La tua padrona?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Signora sì, signora sì, la mia padrona.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Dimmi un poco, quanto ti dà di salario la tua
 padrona?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Mi dà uno scudo il mese.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Povera ragazza, non ti dà altro che uno scudo il
 mese? Ti dà molto poco.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Certo per dirla; mi dà poco, perché a servirla come
 la servo io!...</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Quando io ero a casa mia, la mia cameriera aveva
 da mio padre un zecchino il mese.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Un zecchino?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Sì un zecchino, e gl'incerti arrivavano fino a una
 doppia.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Oh se capitasse a me una fortuna simile!</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Lasceresti la tua padrona?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Per raddoppiare il salario, sarei ben pazza, se non
 la lasciassi.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Senti, Colombina, se vuoi, l'occasione è pronta.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Oh il cielo lo volesse! E con chi?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Con me, se non isdegni di venirmi a servire.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Con voi signora?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Sì, con me. Vedi bene, che senza una cameriera non
 posso stare, e mio padre supplirà al salario. Io, benché
@@ -3443,116 +3480,116 @@ una giovane di abilità, fedele, e attenta, onde se non
 ricusi l'offerta, eccoti due zecchini per il salario
 anticipato dei due primi mesi.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Vusignoria illustrissima mi obbliga in una maniera,
 che non posso dir di no.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Dunque starai al mio servizio.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Illustrissima sì.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Ma mia suocera cosa dirà?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Questo è il punto. Cosa dirà.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Trovaremo la maniera di farglielo sapere. Per oggi
 non le diciamo nulla.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Benissimo, farò quello, che comanda Vusignoria
 illustrissima. Ma se la signora Isabella mi chiama, se mi
 ordina qualche cosa l'ho da servire?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Sì, l'hai da servire. Anzi non hai da mostrare di
 essere per me, prima, che di ciò le sia parlato.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Ma io sono la cameriera di Vusignoria illustrissima.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Per ora mi basta, che tu non mi sia nemica, e che
 fedelmente mi riporti tutto quello, che mia suocera dice di
 me.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Oh! Circa alla fedeltà, potete di me star sicura. Vi
 dirò tutto; anzi, per farvi vedere, che sono finalmente al
 vostro servizio, principierò fin da ora a dirvi alcune
 cosarelle, che ha dette di voi la mia padrona vecchia.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Dimmele, dimmele, che ti sarò grata.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Ha detto... Ma per amor del Cielo non le dite nulla.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Non dubitate; non parlerò.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Ha detto, che siete una donna ordinaria, che non si
 degna di voi, e che vi tiene come la sua serva.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Ha detto questo?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>L'ha detto in conscienza mia.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Ha detto altro?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Ha detto, che vostro marito fa male a volervi bene,
 e che vuol far di tutto perché vi prenda odio.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Ha detto?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Ve lo giuro sull'onor mio.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Ha detto altro?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Non me ne ricordo; ma starò attenta; e tutto quello,
 che saprò ve lo dirò.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Non occorr'altro, ci siamo intese.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Vado per non dar sospetto. (Per un zecchino il mese,
 non solo riporterò quello, che si dice di lei; ma vi
@@ -3564,7 +3601,7 @@ aggiungerò anche qualche cosa del mio). (<emph>da sé, parte</emph>)</p>
           <stage>
             <emph>Doralice, poi Colombina</emph>
           </stage>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Io sono una donna ordinaria? Una donna ordinaria?
 Ardita, petulante, sfacciata! Non si degna di me? Io non mi
@@ -3575,23 +3612,23 @@ farmi odiare da suo figliuolo? È difficile poiché ho io
 delle maniere da farmi amar da chi voglio, e da mettere in
 disperazione chi non mi va a genio.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Illustrissima.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Che c'è?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Il signor Cavaliere del Bosco vorrebbe riverirla.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Digli, che passi.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>La servo subito. A Vusignoria illustrissima sta bene
 un poco di Cavalier servente. Ma la signora Isabella
@@ -3603,150 +3640,150 @@ dovrebbe aver finito. (<emph>parte</emph>)</p>
           <stage>
             <emph>Doralice, poi il Cavaliere del bosco</emph>
           </stage>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Questi due zecchini, li ho spesi bene.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Madama, compatite, s'io torno a darvi il secondo
 incomodo.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Signor Cavaliere, conosco non meritare le vostre
 grazie, e perciò permettetemi, che prima d'ogn'altra cosa,
 vi faccia una interrogazione.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>V'ascolterò con la maggior premura del mondo.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Ditemi in grazia (ma non mi adulate, perché vi
 riuscirà di farlo per poco).</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Vi giuro la più rigorosa sincerità.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Ditemi se siete venuto a favorirmi per qualche
 bontà, che abbiate concepita per me, oppure perché
 unicamente vi prema di riconciliarmi colla Contessa
 Isabella.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Se ciò mi riuscisse di fare, sarei contento; ma in
 ogni modo vi accerto, o signora, che unicamente mi preme
 l'onore della vostra grazia.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Siete disposto a preferirmi a mia suocera?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Lo esige il vostro merito; e una rispettosissima
 inclinazione, mi obbliga a desiderarlo.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Non avrete dunque difficoltà a dichiararvi anco in
 faccia della medesima.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Mi basta non mancare alla civiltà, per non offendere
 il mio carattere.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Non sono capace di chiedervi una mala azione.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Comandate, e farò tutto per obbedirvi.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Sappiate, ch'io sono da mia suocera gravemente
 offesa.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ma come? Anzi mi pare, perdonatemi, che voi
 l'abbiate molto bene beffata.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Eh queste sono bagatelle. Le offese che ella mi ha
 fatte, sono dì maggior rilievo.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Sono passate poche ore, da che ho avuto l'onor di
 vedervi. È succeduto qualche cosa di nuovo?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>È accaduto tanto, che mia suocera, vuol vedere la
 rovina di casa sua.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Per amor del Cielo non dite così.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Che non dica così? Che non dica così? Dunque avete
 ancora della parzialità per lei.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ma Contessina mia la rovina di questa casa viene a
 comprendere vostro marito, e voi medesima.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Vada tutto, ma la cosa non ha da passare così.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Son curiosissimo di sapere cosa sia stato.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Colei ha avuto la temerità di dire, che mio marito
 fa male a volermi bene, e che vuol far il possibile, perché
 mi odi.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Signora mia, l'avete sentita voi a dir queste cose?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Non l'ho sentita, ma lo so di certo.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Duro fatica a crederlo; non mi pare ragionevole.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Mi credete capace di rappresentarvi una falsità?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Non ardisco ciò pensare di voi. Ma chi vi ha
 riportate queste ciarle può avere errato, o per malizia, o
 per ignoranza.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Adesso. Colombina! (<emph>chiama</emph>)</p>
           </sp>
@@ -3756,92 +3793,92 @@ per ignoranza.</p>
           <stage>
             <emph>Colombina e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Illustrissima.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Dimmi un poco, che cosa ha detto mia suocera di
 me?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Signora... mi perdoni.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>No, non aver riguardo. Già il signor Cavaliere non
 parla.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Oh non parlo non dubitate.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Via, di' su cos'ha detto quella cara signorina, di
 me?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Ha detto, che siete una donna ordinaria...</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Taci. No dico di questo. Cosa ha detto di mio
 marito?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Che fa male a volervi bene.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Sentite? E poi?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Che vi vuol far odiare da lui.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Avete inteso?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Perché siete una donna ordinaria.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Va' via di qui. Queste pettegole vi aggiungono
 sempre qualche cosa del loro.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>E poi ha detto, che non si degna...</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Va' via, non voglio altro.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Per amor del Cielo, non mi assassinate. (<emph>al Cavaliere</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Per me non dubitare, che non parlerò.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Ha detto anche qualche cosa di voi... (<emph>al Cavaliere</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>E cosa ha detto di me?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Che siete un Cavaliere, che pratica per le case, e
 non dona mai niente alla servitù. (<emph>parte</emph>)</p>
@@ -3852,219 +3889,219 @@ non dona mai niente alla servitù. (<emph>parte</emph>)</p>
           <stage>
             <emph>Doralice ed il Cavaliere del bosco</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Cara Signora Contessa, volete credere a questa sorta
 di gente?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Me lo ha detto in una maniera, che mi assicura
 essere la verità.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Sapete pure, che ella è cameriera antica della
 Contessa Isabella.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Appunto per questo, se non fosse la verità, non mi
 avrebbe detto cosa, che potesse pregiudicare alla sua
 padrona.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Lei averà gridato; sarà disgustata.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Signor Cavaliere, la riverisco. (<emph>vuol partire</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Perché privarmi delle vostre grazie?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Perché siete parziale della signora suocera.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Io son servitor vostro. Ma vorrei vedervi quieta e
 contenta.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Una delle due: o siete per me, o siete per lei.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Da Cavaliere, ch'io sono per voi.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Se siete per me, non mi avete da contradire.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Dirò tutto quello, che dite voi.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Fra mia suocera, e me, chi ha ragione?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Voi.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Chi è l'offesa?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Voi.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Chi ha da pretendere risarcimento?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Voi.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Chi ha da cedere?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Voi...</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Io?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Voi no, volevo dire...</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Ella ha da cedere.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Certamente.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Se c'incontriamo, chi ha da essere la prima a
 parlare?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Direi...</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Come più vecchia non la posso nemmeno salutare.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Si potrebbe vedere...</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Alle corte. Ella ha da essere la prima a parlarmi.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Sì, lo dicevo. Tocca a lei.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>L'accordate anche voi?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Non posso contradirlo.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Quando l'accordate voi, che siete un Cavaliere di
 garbo, son sicura di non fallare.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ma io, perdonatemi...</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Se mi parlerà con amore, io le risponderò con
 rispetto.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Brava, bravissima. Lodo la vostra rassegnazione.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>E mi diranno poi, ch'io son cattiva.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Siete la più buona dama del mondo.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Credetemi, che altro non desidero, che farmi voler
 bene da tutti.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Si vede in effetto.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>La servitù mi adora.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Anco Colombina?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Colombina è tutta mia. Starà con me, e le ho dato
 due zecchini.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Se farete così, sarete adorabile.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Mia suocera, che ha avuto ventimille scudi, non mi
 puol vedere.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Perché, perché...</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Perché è una donna cattiva.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Sarà così.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>È così senz'altro.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Sì, senz'altro.</p>
           </sp>
@@ -4074,72 +4111,72 @@ puol vedere.</p>
           <stage>
             <emph>Colombina e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Illustrissima, vi è l'illustrissimo suo signor padre
 che vorrebbe dirle una parola.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Digli, che venga.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Non vuol venire; l'aspetta nella camera dell'arcova.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Vorrà farmi fare qualche figura ridicola con mia
 suocera.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Se il padre comanda...</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Eh, ora ha finito di comandare. Son maritata.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Sì, ma da lui potete sempre sperare qualche cosa.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Oh! Per questo lo ascolto. Se non fosse lui,
 povero vecchio. Basta, se vorrà ch'io parli alla Contessa
 Isabella, quando ella sia la prima lo farò. Cavaliere quando
 è partito mio padre v'aspetto. (<emph>parte</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Che vuol dir Colombina, così attenta a servire la
 Contessina?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Io sono una ragazza di buon cuore. Faccio servizio
 volentieri, a chi è generoso con me.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Orsù, sentite; acciò la vostra padrona non dica,
 ch'io non do mai nulla alla servitù, tenete questo mezzo
 ducato.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Grazie. Sapete ora che cosa dirà?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>E che dirà?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Che avete fatto una gran cascata. (<emph>parte</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Che maledettissima cameriera! Costei è causa
 principale delli scandali di questa casa. Ella riporta a
@@ -4160,202 +4197,202 @@ una famiglia, dalla lingua di una serva, o di un servitore.
             <emph>Il conte Anselmo con un libro grosso manoscritto e
 Brighella</emph>
           </stage>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Quanto mi dispiace non intendere la lingua greca!
 Questo manoscritto è un tesoro, ma non l'intendo. Brighella.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Illustrissimo.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Ho trovato un manoscritto greco, antichissimo, che
 vale cento zecchini; e l'ho avuto per dieci.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>(De questi a mi non me ne tocca). (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Questo è un codice originale.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Una bagattella! Un codice original? Cara ela, cosa
 contienlo?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Sono i trattati di pace fra la repubblica di Sparta,
 e quella d'Atene.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Oh, che bella cossa!</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Questo posso dir, che è una gioia, perché è l'unica
 copia, che vi sia al mondo. E poi senti, e stupisci. È
 scritto di propria mano di Demostene.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Cospetto del diavolo! Cossa me tocca a sentir? Che
 la sia po cusì?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Sarei un bell'antiquario, se non conoscessi i
 caratteri degli antichi.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Cara ella, la prego. La me leza almanco el titolo.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Ti ho pur detto tante volte, che non intendo il
 greco.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Ma come conoscela el carattere, se no la intende
 la lingua?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Oh bella! Come uno, che conosce le pitture, e non sa
 dipingere.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>(Sa el cielo, chi gh'à magnà sti diese zecchini.
 Za che el vol andar in malora, l'è meggio, che me profitta
 mi, che un altro). (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Gran bel libro; gran bel codice! Pare scritto ora.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>La diga, sior padron, conoscela el signor
 capitanio Saraca?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Lo conosco, lo conosco. Egli pretende avere una
 sontuosa galleria, ma non ha niente di buono.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Eppur l'ha speso dei denari assai.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Avrà speso in vent'anni più di dieci mille scudi. Ma
 non ha niente di buono.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>La sappia, che l'ha avudo una desgrazia. L'ha
 bisogno de quattrini, e el vol vender la galeria.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>La vuol vendere? Oh! Là vi sarebbe da fare de' buoni
 acquisti.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Se la vol, adesso xè el tempo.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Le cose migliori, le prenderò io.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>El vuol vender tutto in una volta.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Ma vorrà de' migliaia di zecchini.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Manco de quello, che la se pensa. Con tre mille
 scudi se porta via tutta quella gran robba.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Con tre mille scudi? Questo è un negozio da
 impegnarsi la camicia per farlo. Se l'avessi saputo quattro
 giorni prima, non avrei consumato il denaro con
 quegl'impertinenti de' creditori.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>La senta, se no la gh'à tutti i denari, no
 importa; m'impegno de farghe dar la robba parte col denaro
 contante, e parte con un biglietto.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Oh il Cielo volesse! Caro Brighella, sarebbe la mia
 fortuna. Quanto danaro credi tu, che vi vorrà alla mano?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Almanco due mille scudi.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Io non ne ho altri, che mille cinquecento, gl'altri
 gl'ho spesi tutti.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Vederò, che el se contenta de questi.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Brighella mio non bisogna perder tempo; va' subito a
 serrar il contratto.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Bisognerà darghe caparra.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Sì, tieni questi venti zecchini. Daglieli per
 caparra.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Vado subito.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Ma avverti farti dar l'inventario; incontra cosa per
 cosa, poi viemmi ad avvisare, che verrò a vedere ancor io.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Vado, perché se se perde tempo, el negozio pol
 andar in qualch'altra man.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>No, per amor del Cielo. Mi appicherei dalla
 disperazione.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>(È vero, che el signor Capitanio vol vender la
 galleria; ma con questi venti zecchini comprerò i so scarti,
@@ -4368,358 +4405,358 @@ gnente, li pagherà a caro prezzo). (<emph>da sé, parte</emph>)</p>
           <stage>
             <emph>Il conte Anselmo, poi Pantalone</emph>
           </stage>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Non mi sarei mai creduto un incontro simile. Ma la
 fortuna capita, quando men si crede.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Se puol vegnir? (<emph>di dentro</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Ecco qui quel buon uomo di Pantalone. Non sa niente,
 non sa niente. Venite, venite, signor Pantalone.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Fazo reverenza al sior Conte.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Ditemi, voi che avete delle corrispondenze per il
 mondo. Sapete la lingua greca?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>La so perfettamente. Son stà dies'anni a Corfù, ho
 scomenzà là a far el marcante, e tutto el mio divertimento
 giera a imparar quel linguaggio.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Dunque saprete leggere le scritture greche.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ghe dirò: altro xè el greco litteral, altro xè el
 greco volgar. Me n'intendo però un pochetto dell'un, e
 dell'altro.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Quand'è così, vi voglio far vedere una bella cosa.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>La vederò volentiera.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Un codice greco.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Bon; ghe n'ho visto dei altri.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Scritto propria mano di Demostene.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>El sarà una bella cossa.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Osservate, e se sapete leggere, leggete.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(<emph>Osserva</emph>) Questo xè scritto da Demostene?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Sì, e sono i trattati di pace fra Sparta, e Atene.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>I trattati di pace, tra Sparta, e Atene? Sàla
 cossa, che contien sto libro?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Via, cosa contiene? Io giuro, che non l'intendete.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Questo xè un libro de canzonette alla grega, che
 canta i putelli a Corfù.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Già lo sapevo. Voi non sapete leggere il greco.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>La senta: mattiamù, mattachiamù, callispera,
 mattiamù.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Ebbene questi saranno i nomi propri dei Spartani o
 de' Tebani.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Vol dir: vita mia, bonassera vita mia.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Non sapete leggere. Questo è un codice greco, che mi
 costa dieci zecchini, e ne val più di cento.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>El formaggier no ghe dà tre soldi.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Andatevene a intender de panni, e di sete, e non di
 scritture antiche.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Me despiase sior Conte, che per quel, che vedo,
 andemo de mal in pezo.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Come sarebbe a dire?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ella se perde in ste fredure, e la so casa va in
 precipizio.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Io mi diverto, senza incomodare la casa. L'entrate
 le maneggia mia moglie, né io pregiudico agl'interessi della
 famiglia.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>E alla pase, alla quiete de casa no la ghe pensa?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Io penso a me, e non penso agli altri.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Mo no sàla, che quando el capo de casa no gh'abada,
 tutto va alla roversa?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Quando tacciono son capo; quando gridano son coda.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Dise mia fia, che l'è stada offesa dalla siora
 Contessa Isabella.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>E dice mia moglie, che è stata offesa da vostra
 figlia; ora guardate con che razza di matti abbiamo da fare.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>E pur bisogna remediarghe.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Io vi consiglierei a fare quello, che faccio io.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Che vuol dir?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Lasciarle frigere nel proprio grasso.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ma se ste cosse le va avanti, no so cossa, che
 possa succeder.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Cosa volete, che succeda?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Siora Contessa xè un poco altiera.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>E vostra figlia è troppo fastidiosa.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Volemio veder de far sta pase tra niora, e madonna?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Cosa vi vuole per far questa pace?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Mi ho parlà con mia fia; e so che la farà a mio
 modo.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>È inutile che parli a mia moglie.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Perché?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Perché mai abbiamo fatto, né ella a mio modo, né io
 al suo.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ma questa l'averia da esser una pase general de
 tutta la fameggia.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Io non sono in collera con nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Mo no l'è gnanca so decoro, voler comparir un omo
 de stucco.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Cosa volete ch'io faccia?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Avemo da procurar, che ste do creature se unissa.
 Avemo da far, che le se parla, che le se giustifica, che le
 se pacifica, e xè ben, che la ghe sia anca ella.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Via, vi sarò.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Bisogna metter qualche bona parola.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>La metterò.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ho parlà anca colla siora Contessa; e la m'ha
 promesso de vegnir in camera d'udienza, dove ghe sarà anca
 mia fia.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Buono, avete fatto assai.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Saremo nualtri soli; ela, mi, so consorte, mia fia,
 e mio zenero.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>E non altri?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>No gh'à da esser altri.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Sarà difficile.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Perché? Chi gh'à da esser?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Le donne hanno sempre i loro consiglieri.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Mia fia no credo, ch'abbia nissun.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Eh, l'averà, l'averà.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Siora Contessa lo gh'àla?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Oh se l'ha? E come!</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>E ela lo comporta?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Io abbado alle medaglie.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Mio zenero no farà cusì.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Ognun dal canto suo cura si prenda.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Questa no xè la regola, che ha da tegnir un capo de
 casa.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Ditemi quant'anni avete?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Sessanta, per servirla.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Volete vivere fino a cento?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Magari, ch'el Ciel volesse!</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Se volete vivere fino a cent'anni prendetevi quei
 fastidi, che mi prendo io. (<emph>parte</emph>)</p>
@@ -4730,7 +4767,7 @@ fastidi, che mi prendo io. (<emph>parte</emph>)</p>
           <stage>
             <emph>Pantalone solo.</emph>
           </stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Vardè, che bell'omo! Vardè in che bella casa, che
 ho messo la mia povera fia! Un de sti dì, co ste so
@@ -4750,43 +4787,43 @@ canal, e ho negà la putta.</p>
           <stage>
             <emph>Arlecchino, travestito con altr'abito, e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>(Oh, se trovass sto sior Conte, ghe vorria piantar
 dell'altre belle antichità, senza spartir l'utile con
 Brighella). (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(Chi diavolo xè costù?). (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>(Sto barbetta mi nol conoss). (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Galantomo chi seu? Chi domandeu?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Inanz, che mi responda, l'am favorissa de dirme chi
 l'è Vussioria.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Son un amigo del sior Conte Anselmo.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Se dilettela de antichità?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Oh assae. Compro tutto. (Sta a veder, che l'è un de
 quei, che lo tira in trappola). (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Za, che Vussioria se diletta de antichità, la
 sappia, che mi son un antiquari. Son vegnù per far la
@@ -4794,118 +4831,118 @@ fortuna del sior Conte Anselmo, ma se vussioria me
 obbligherà con qualch bona maniera, ghe darò a lu tutte ste
 zoggie, che ho portà con mi.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(Vòi torme spasso, e scoverzer terren). (<emph>da sé</emph>)
 Caro amigo, se me farè a mi sto piaser, oltre al pagamento,
 ve servirò in quel, che poderò, in quel, che ve occorrerà.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Za che ved, che l'è un galantomo, l'osserva, che
 roba? L'osserva, che antichità, che rarità, che preziosità!
 Vedel questa? (<emph>mostra una pantofola vecchia</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Questa la par una pantofola vecchia.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Questa l'era la pantofola de Neron, colla qual l'ha
 dà quel terribil calzo a Poppea, quand el l'ha scazzada del
 tron.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Bravo! Oh che rarità! Gh'aveu altro? (oh che
 ladro!) (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Vedel questa? (<emph>mostra una treccia di capelli</emph>)
 Questa l'è la drezza de cavelli de Lugrezia romana, restada
 in man a Sesto Tarquini, quando el la voleva sforzar.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Bellissima! (ah tocco de furbazzo!) (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>La vederà...</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>No vòi veder altro. Baron, ladro, desgrazià!
 Credistu, che sia un mamalucco? A mi ti me dà da intender
 ste fandonie? Furbazzo, te farò andar in galìa.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Ah signor, per amor del cielo, ghe domando pietà.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Chi t'ha introdotto in sta casa?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>L'è stà Brighella, signor.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Come! Brighella?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Sior sì, avem spartì l'altra volta metà per un.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Donca Brighella sassina el so paron?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>El fa anca lu, come che fa tanti alter.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Orsù vegnì con mi. (Voggio co sto mezzo disingannar
 sior Conte). (<emph>da sé</emph>) Vegnì con mi.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Dove?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>No ve dubitè. Vegni con mi; e non abbiè paura.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Abbiè carità de un pover'omo.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Meriteressi da andar in preson; ma no son capace de
 farlo. Me basta, che dixè a sior Conte quel che àve dito a
 mi, e no vòi altro.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Sior sì, dirò tutt quel, che volì.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Andemo.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Son qua. (Tolì, anca a robar ghe vol grazia, e ghe
 vol fortuna). (<emph>s'incammina</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Femo sta pase, e po con costù farò veder al Conte,
 che tutti lo burla, che tutti lo sassina. (<emph>partono</emph>)</p>
@@ -4917,104 +4954,104 @@ che tutti lo burla, che tutti lo sassina. (<emph>partono</emph>)</p>
           <stage>
             <emph>La contessa Isabella e il Dottore</emph>
           </stage>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Anche voi mi rompete la testa?</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Io non parlo; ma ella ha sentito cos'ha detto il
 signor Pantalone?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Come c'entra quel vecchio in casa mia? Qui comando
 io, e poi mio marito.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Benissimo, non pretende già voler far da padrone,
 egli mostra dell'amore per questa casa, e desidera di vedere
 in tutti la concordia, e la pace.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Se vuol, che vi sia la pace, faccia, che sua figlia
 abbia giudizio.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Egli protesta, ch'ella è innocente.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>È innocente? È innocente? E voi ancora lo dite?
 Sia maledetto quando il diavolo vi porta qui!</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>È il signor Pantalone, che dice, ch'ella è
 innocente. Io non lo dico.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Basta; se vi sentite di dirlo, andate fuori di
 questa camera.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Questa è una bellissima cosa. Ora mi vuole, ora mi
 scaccia.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Se mi fate rabbia. Andatemi a prender da bere.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Vado. (<emph>si parte per prendere da bere</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Maledettissima! A me vecchia?</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Eccola servita. (<emph>le porta un bicchier di vino colla sottocoppa</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Non voglio vino.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Anderò a pigliar dell'acqua. (<emph>si parte, come sopra</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Vi saluto, perché siete più vecchia di me?</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Ecco l'acqua. (<emph>porta un bicchier d'acqua</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Maledetto fredda me la portate?</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Ma la calda dov'è?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Al foco, al foco.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>La prenderò calda. (<emph>si parte, come sopra</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Questa parola non me l'ha ancora detta nessuno. Ma
 che faceva il signor Cavaliere in compagnia di colei?
@@ -5027,115 +5064,115 @@ Voglio un poco chiarirmi. Colombina!</p>
           <stage>
             <emph>Colombina e detta.</emph>
           </stage>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Signora.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Dimmi un poco, hai veduto quando il Cavaliere è
 andato nelle camere di Doralice?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>L'ho veduto benissimo.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Quanto vi è stato?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Più di due ore; e poi poco fa vi è tornato.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Vi è tornato?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Sì signora vi è tornato.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Sei punto stata in camera? Hai sentito nulla?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Oh io in quella camera non ci vado. Servo la mia
 padrona, e non servo altri.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Che balorda! Né anche andar in camera a sentir
 qualche cosa, per sapermelo dire! Va' che sei una scimunita.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Balorda! Scimunita! Non voleva dirvelo; ma ci sono
 stata.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Si? Contami, cosa facevano?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Delle smorfie tante.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>La serve il Cavaliere?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Eccome! Anzi io credo, che l'abbia regalata.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>L'ha regalata?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Credo di sì. Ho veduto un orologio d'oro al signor
 contino Giacinto. Egli ha detto averlo avuto da sua moglie;
 il Cavaliere ne aveva uno simile, onde credo senz'altro,
 l'abbia egli donato alla signora Doralice.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>L'orologio d'oro, lei non l'aveva; senz'altro glie
 l'ha donato il Cavaliere.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Ha donato anche a me questo mezzo ducato.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Per qual motivo?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Acciò non parli.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Discorrevano forse di me?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Sicuro.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Cosa dicevano? Cosa dicevano?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Che siete fastidiosa, soffistica, e che so io.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Cavaliere malnato!</p>
           </sp>
@@ -5145,88 +5182,88 @@ l'ha donato il Cavaliere.</p>
           <stage>
             <emph>Il Dottore con l'acqua calda, e dette.</emph>
           </stage>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Femmina impertinente!</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Ecco l'acqua calda.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Andate al diavolo, non sentite che scotta? (<emph>la prende, le pare bollente, e gettandola via, coglie il Dottore</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Obbligatissimo alle sue grazie.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Di grazia, che vi averò stroppiato!</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Io non parlo.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>E così, cos'altro hanno detto di me? (<emph>a Colombina</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Non ho potuto sentir altro. Ma se sentirò, dirò
 tutto.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Sta' attenta; ascolta, e osserva, che mi preme
 infinitamente.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Signora padrona, vi ricordate quant'è che mi avete
 promesso un paio di scarpe?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Tieni, comprale a tuo modo. (<emph>le dà un ducato</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Che siate benedetta! (Così si macina a due mulini).
 (<emph>da sé, parte</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>(Il Cavaliere mi tratta così?). (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Vuole, ch'io le vada a prendere dell'acqua un poco
 tiepida?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>(In casa mia? Su gli occhi miei?). (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Signora, è in collera? Non l'ho fatto apposta.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>(Bell'azione!) (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Dica, signora Contessa...</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Non mi rompete la testa.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Ma cosa le ho fatto? Sempre la mi strapazza, sempre
 la mi mortifica.</p>
@@ -5237,16 +5274,16 @@ la mi mortifica.</p>
           <stage>
             <emph>Il conte Giacinto, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Signora madre, se l'amor mio può nulla nel vostro
 cuore, sono a pregarvi di non negarmi una grazia.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Cosa volete?</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Mia moglie, fra le persuasive mie, e quelle di suo
 padre, è dispostissima a darvi tutti i segni possibili di
@@ -5254,144 +5291,144 @@ rassegnazione, e rispetto; vi supplico, vi scongiuro,
 vederla, sentirla, perdonarle il passato, e amarla, per
 l'avvenire.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Che avete costà? Un orologio?</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Sì signora, un orologio.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Lasciate vedere.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Eccolo.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Chi ve l'ha dato?</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Mia moglie.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>E voi avete sì poca riputazione di portare questo
 orologio?</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Perché? Cosa vi è di male?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Sapete da chi vostra moglie lo ha avuto?</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Da suo padre.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Non è vero. L'ha avuto dal suo cicisbeo.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Cicisbeo mia moglie?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Signor sì. Anch'ella si è messa all'onor del mondo.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Voi mi fate restar stordito. E chi è questo, che
 voi chiamate col nome di cicisbeo?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Il Cavalier del Bosco.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Eh, questo è un amico di casa.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>È amico di casa. Ma a lei ha donato l'orologio.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Il Cavaliere glie l'ha donato?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Sì egli appunto.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Mi perdoni s'io entro dove non son chiamato;
 quell'orologio mi par di conoscerlo, mi par, che fosse del
 signor Pantalone.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Cosa sapete voi, che siete vecchio cadente, e non
 ci vedete? Così è: il caro signor Cavaliere ha fatto questo
 bel regalo alla vostra sposa.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Voi mi mettete in una gran gelosia.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Povero figlio! Te l'ho detto, che sei assassinato.
 Ecco, non basta, che sia una plebea, è anche una fraschetta.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Mi pare ancora impossibile.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Lo vedrai.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>In camera di udienza ci aspettano, se volete
 venire.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Sì vengo vengo (Può essere, che mi riesca di
 scoprir qualche cosa).</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Ma l'orologio?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Per ora lo tengo io. Dottore, datemi mano.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>La servo. Per carità, che la non mi gridi.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Via, via, meno ciarle. Contentatevi così.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Pazienza. (<emph>parte dando braccio alla Contessa</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Mia madre, e mia moglie sono due nemiche. Non so
 che credere, non so che pensare. Il Cavaliere dare un
@@ -5405,54 +5442,54 @@ Il tempo scoprirà il vero.</p>
           <stage>
             <emph>Il conte Anselmo e Pantalone</emph>
           </stage>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Eccomi qui, eccomi qui. Ma quanto ci doverò stare?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Aspettemo, che le vegna. Disemo quattro parole;
 femo sto aggiustamento, e l'anderà dove, che la vol.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>(Brighella non si vede colla risposta della
 galleria). (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Vien zente. Chi èla questa, che no ghe vedo troppo?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>È mia moglie.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>E con ella, chi gh'è?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Non ve l'ho detto? Il suo consigliere.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>L'è il dottor Balanzoni!</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Cose vecchie, cose vecchie.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ma cossa gh'intrelo? Averia gusto, che fussimo
 soli.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Eh lasciatelo venire; cosa v'importa?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(Che bel carattere, che xè sto sior Conte!) (<emph>da sé</emph>)</p>
           </sp>
@@ -5463,27 +5500,27 @@ soli.</p>
             <emph>La contessa Isabella col Dottore, che le dà mano, ed il
 conte Giacinto, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Ben venuti, ben venuti.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Fo riverenza al signor Conte.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Siora Contessa, ghe son umilissimo servitor.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>La reverisco.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(La ghe diga qualcossa. Femo pulito). (<emph>piano al Conte</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>(Orsù, giacché ci siamo, bisogna fare uno sforzo).
 Contessa mia, vi ho fatto qui venire per un affar
@@ -5494,38 +5531,38 @@ e che alla mia presenza torniate come il primo giorno, che
 Doralice è venuta in casa. Avete inteso? Voglio che si
 faccia così. (<emph>alterato</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Voglio?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Signora sì, voglio. Questa parola la dico una volta
 l'anno, ma quando la dico, la sostengo. (<emph>come sopra</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>E volete dunque...</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Quello, ch'io voglio l'avete inteso. Non vi è
 bisogno di repliche.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>(So, che qualche volta è una bestia, non voglio
 irritarlo). (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>(Che dite? Mi sono portato bene?). (<emph>a Pantalone</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Benissimo.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>(Ho fatto una fatica terribile). (<emph>da sé</emph>)</p>
           </sp>
@@ -5535,424 +5572,424 @@ irritarlo). (<emph>da sé</emph>)</p>
           <stage>
             <emph>Doralice servita dal Cavalier del bosco, e detti</emph>
           </stage>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>(Eccola coll'amico). (<emph>a Giacinto</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(Cossa gh'intra quel sior con mia fia?). (<emph>ad Anselmo</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>(Non ve l'ho detto? Il suo consigliere).</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Padroni miei; con tutto il rispetto.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Serva de lor signori.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>E voi, signora, non dite niente? (<emph>ad Isabella</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Divotissima, divotissima. (<emph>sostenuta</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Sediamo un poco. Non stiamo in piedi. (<emph>tutti siedono</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Signor Cavaliere, che ora è?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Non lo so davvero.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Non avete l'orologio?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>L'ho dato ad accomodare.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Guarderò io. (<emph>guarda sull'orologio avuto da Giacinto</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(Oe! Come gh'ala, el relogio, che ho dà a mia
 fia?). (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Avete un bell'orologio. Lasciatemelo un poco vedere.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Eccolo. Miratelo pure; e in esso contemplate il
 bell'onore della nostra casa.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>È necessario un orologio, dove ognora si
 scandagliano i quarti della nobiltà.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Mi piace questo cameo. Sarà antico non è vero?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Io non lo so. Domandatelo a chi ha portato
 quest'orologio in casa.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Voi da chi l'avete avuto?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Da Giacinto.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>E a te Giacinto, chi te l'ha dato?</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Mia moglie.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>E a me l'ha dato mio padre.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Oh, oh, oh, suo padre? (<emph>ridendo forte</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Siora sì, ghe l'ho dà mi, siora sì.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Bravo, bravo (senti come il padre fa bene il
 mezzano alla figlia). (<emph>piano a Giacinto</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Questo cameo è bellissimo.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(Orsù vorla, che scomenzemo a parlar? Vorla dir
 ela?). (<emph>piano ad Anselmo</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Guardate la chioma di quella sirena, se può essere
 più bella. La voglio veder colla lente. (<emph>tira fuori una lente, e osserva il cameo, e non bada a chi parla</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(El tempo passa). (<emph>come sopra</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Principiate voi, poi dirò io. Intanto lasciatemi
 prender gusto in questo cameo.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Signore; se le me permette, qua per ordene del sior
 Conte mio paron, del qual ho l'onor de esser anca parente...</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Per mia disgrazia.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Tasè là, siora, e fin che parlo no m'interrompè!
 Come diseva, se le me permette, farò un piccolo discorsetto.
 Pur troppo xè vero, che tra la madonna, e la niora poche
 volte se va d'accordo...</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Quando la nuora non ha giudizio.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Quando la suocera è presontuosa.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Cara ela, per carità, la prego, la me lassa parlar;
 la sentirà con che rispetto, con che venerazion, con che
 giustizia parlerò de ela. (<emph>ad Isabella</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Io non apro bocca.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>E vu tasè. (<emph>a Doralice</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Non parlo.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Credo, che per ordinario le dissension, che nasce
 tra ste do persone le dipenda da chiaccole, e pettegolezzi.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Questa volta son cose vere.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Vere, verissime.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Oh poveretto mi! Me lassele dir?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Avete finito? Vorrei parlar anch'io.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Una volta per uno; toccherà ancora a me.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Mo se non ho gnancora principià. Patrona sì, le
 chiaccole, i pettegolezzi per el più guasta al sangue, e fa
 deventar nemici i parenti. Per questo vorria pregar siora
 Contessa Isabella...</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>La signora Contessa Isabella, la ringrazia delle
 sue finezze.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Che diavolo avete fatto, non gl'avete dato
 dell'Illustrissima?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Se me l'avesse dato, avrebbe fatto il suo debito.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Si sa, lo dico per questo.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Sior Conte, la parla ela, che mi non posso più.
 (<emph>ad Anselmo</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Avete finito? Si sono aggiustate? È fatta la pace?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Dov'èlo stà fina adesso? No l'ha sentio ste do
 campane, che no tase mai?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Con un cameo di questa sorta davanti gl'occhi, non
 si sentirebbero le cannonate.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Cossa avemio da far?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Parlate voi, che poi parlerò io. (<emph>torna ad osservare il cameo</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Me proverò un'altra volta. Lustrissima siora
 Contessa Isabella, voria pregarla de dir i motivi dei so
 desgusti contro mia fia.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Oh sono assai...</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>I miei sono molto più.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Tasè là, siora; lassè che la parla ela, e po
 parlerè vu.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Ah sì, deve parlare prima lei, perché... (Ho quasi
 detto, perché è più vecchia). (<emph>al Cavaliere</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Avreste fatto una bella scena).</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>La favorissa de dirghene qualchedun. (<emph>ad Isabella</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Non so da qual parte principiare.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Signor suocero, se aspettiamo, che esse dicano
 tutto con regola, e quiete è impossibile. Io che so le
 doglianze dell'una, e dell'altra, parlerò io per tutte due.
 Signora madre, vi contentate ch'io parli?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Parlate pure. (Già m'aspetto che tenga dalla
 consorte).</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>E voi Doralice, vi contentate, che parli anco per
 voi?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Sì, sì, quel che volete (Già terrà dalla madre).</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Prima di tutto mia madre si lamenta, che Doralice
 le abbia detto vecchia.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Via di qua, temerario. (<emph>a Giacinto</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Dicevo...</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Va' via, che ti do una mano nel viso.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Perdonatemi...</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Va', ti dico, impertinente.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>(Anderò per non irritarla. Eh! lo vedo, lo vedo;
 qui non si può più stare). (<emph>parte</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>(Mi ha dato più gusto, che se avessi guadagnato
 cento zecchini). (<emph>al Cavaliere</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Quella parola, le fa paura).</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Cossa dìsela, sior Conte? No se pol miga andar
 avanti.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Orsù; la finirò io. Signore mie... Ma prima, che mi
 scordi; questo cameo si potrebbe avere?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>El xè de mia fia, la ghe lo domanda a ela.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Mi volete vendere questo cameo? (<emph>a Doralice</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Venderlo? Mi meraviglio. Se ne servi, è padrone.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Me lo donate?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Se si degna.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Vi ringrazio la mia cara nuora, vi ringrazio.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Ringraziate chi glie l'ha donato.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Chi ghe l'ha dà, son stà mi.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Eh sappiamo tutto, sappiamo tutto.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Cossa sala? La diga, cossa sala?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Oh, ne sentirete di belle.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Orsù sia, chi esser si voglia, che l'abbia dato, non
 me ne importa. Il cameo mi piace, me lo ha donato, e la
 ringrazio. Lo staccherò, e vi renderò l'orologio.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Via ora che la vostra dilettissima signora nuora vi
 ha fatto quel bel regalo, pronunciate la sentenza in di lei
 favore.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>A proposito. Ora, già, che ci siamo, bisogna
 terminare questa faccenda. Signore mie, in casa non vi è la
@@ -5970,184 +6007,184 @@ delle mie deliberazioni. Principiamo dunque.</p>
           <stage>
             <emph>Brighella, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Sior padron. (<emph>al conte Anselmo</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Cosa c'è?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>El negozio è fatto, la galleria è nostra, e gh'ho
 qua l'inventario.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Con licenza de lor signori. (<emph>s'alza</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Tornela presto?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Per oggi non torno più. (<emph>parte con Brighella</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Bella da galantomo!</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Possiamo andarcene ancora noi.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Andate pure, questa è camera mia.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>La camera d'udienza è di tutti.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Disgrazia, che verrete ancor voi a ricever visite
 nella camera d'udienza!</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Ci posso venire, e ci verrò.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Oh, non ci verrete!</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Sentite? Sempre così. (<emph>a Pantalone</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Ogni giorno crescono le sue pretensioni.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Senza el sior Conte gh'è remedio, che vegnimo in
 chiaro del motivo de ste discordie?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Ecco qui il signor Dottore; è qualche anno, che mi
 conosce. Mi ha tenuta in braccio da bambina, e sa chi sono.
 Dica lui, se io vado in collera senza ragione.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Oh, è vero! Ella non parla mai senza il suo
 fondamento.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Il signor Cavaliere è buon testimonio di quello ha
 detto di me la signora suocera, e sa egli se con ragion mi
 lamento.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Signore, lasciamo queste leggerezze da parte. Stiamo
 allegramente in buona pace; con buona armonia.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Leggerezze le chiamate? Leggerezze? Mi avete pure
 accordato anco voi, che io ho ragione, che io sono offesa,
 che non tocca a me cedere.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Bravo, signor Cavaliere! Lei è quello, che
 consiglia la signora Doralice.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Io non consiglio nessuno; ma parlo come l'intendo.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Siete un Cavaliere indegno.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Signora siete dama, ma non vi conviene perdermi il
 rispetto.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Voleu, che ve la diga patroni? Sè una chebba de
 matti. Destrighevela tra de vualtri, e chi ha la rogna, se
 la grata.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>No voi non sapete il trattare. (<emph>al Cavaliere</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>In quanto a questo, mostrate di saperlo poco anche
 voi.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Impertinente! Così parlate con una dama? E voi
 state qui, come un asino, e non dite nulla? (<emph>al Dottore</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Signor Cavaliere, Vusignoria parla male; non si
 tratta così.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ho piacere, che voi prendiate le parti della
 Contessa Isabella. Con lei, come donna, non potevo prendermi
 veruna soddisfazione; voi mi renderete conto delle ingiurie,
 che ella mi ha dette. (<emph>parte</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>(Ora sono nel bell'imbroglio!) (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Animo. Signora, andate nelle vostre camere.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Vi torno a dire, che qui ci posso stare ancor io.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>La vostra impertinenza, mi provocherebbe a
 mortificarvi colle mie mani.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Le mani, le ho ancor io.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Ma le donne civili non vengono alle mani. Queste
 son cose riserbate per le donne vili, e plebee. Sono offesa;
 saprò vendicarmi; ma la mia vendetta sarà da dama qual sono.
 (<emph>parte</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Oh, quanto mi fa ridere!</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Ed io, che non sono Cavaliere, converrà, che per
 riputazione mi faccia ammazzare alla cavalleresca. Per
@@ -6156,7 +6193,7 @@ la troppa confidenza, che un si prende con le persone di
 rango, a lungo andare precipita, chi ha questa pazza
 ambizione.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>A buon conto l'ho superata. Ella è partita, ed io
 sono restata qui nella camera d'udienza. M'impegno colla mia
@@ -6173,75 +6210,75 @@ mondo.</p>
           <stage>
             <emph>Il conte Anselmo, e Brighella</emph>
           </stage>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Ecco qua. Per tre mille scudi, la varda quanta
 gran roba!</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Caro Brighella, son fuor di me dall'allegrezza. Qual
 è la cassa delli crostacei?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>El numero I l'è la cassa dei crostacei, dove ghe
 sarà drento tremilla capi de frutti marini, cioè ostreghe,
 cappe, e cose simili, trovade sulle cime dei monti.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Questi soli vagliono i tremile scudi.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>El numero II l'è una cassa de pesci petrificadi de
 tutte le sorte, e fra i altri gh'è un branzin impietrido
 colle baise, rosse, che le par de coral.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Questo sarebbe per la galleria d'un monarca.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>El numero III l'è una cassa con una raccolta de
 mumie d'Aleppo; tutte de animali, uno differente dall'altro,
 fra i quali gh'è un basilisco.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>V'è anche il basilisco?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>E come! L'è grando come un quaggiotto.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Si sa da dove l'abbino portato?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Se sa tutto. L'è nato da un uovo de gallo.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Sì, sì, ho inteso dire, che i galli dopo tanti anni
 fanno un uovo, da cui nasce poi il basilisco. L'ho sempre
 creduta una favola.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>No l'è favola, e là drento gh'è la prova della
 verità.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Brighella ti sono obbligato. M'hai fatto fare dei
 preziosi acquisti.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Son un omo fatto a posta per sti negozi; gnancora
 no la me cognosse intieramente; fra poco la me cognoscerà
@@ -6254,7 +6291,7 @@ salvo mi, e sti bezzi, che gh'ò cuccà). (<emph>parte</emph>)</p>
           <stage>
             <emph>Il conte Anselmo, poi Pantalone</emph>
           </stage>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Io ho qui da divertirmi per due, o tre mesi. Fino,
 che non ho posto in ordine, tutta questa roba, non vado in
@@ -6264,20 +6301,20 @@ portar qui anco un lettino da campagna, e dormir qui; così
 non averò lo stordimento di quella fastidiosissima mia
 consorte. Non voglio nessuno, non voglio nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Sior Conte, se pol vegnir? (<emph>di dentro</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Non voglio nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>La senta, ghe xè sior Pancrazio, quel famoso
 antiquario.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Oh venga venga è padrone! Capperi! Ha saputo, che ho
 fatta questa bella spesa, e lui corre.</p>
@@ -6288,251 +6325,251 @@ fatta questa bella spesa, e lui corre.</p>
           <stage>
             <emph>Pantalone, Pancrazio, e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Caro sior Conte, la sa, che ghe son bon amigo.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Compatitemi, ero imbarazzato. Signor Pancrazio, che
 fortuna è la mia, che siete venuto a favorirmi?</p>
           </sp>
-          <sp>
+          <sp who="#pancrazio">
             <speaker>PANCRAZIO</speaker>
             <p>Ho saputo che V. S. ha fatto una bella compra di
 antichità, sono venuto, se mi permette, a vedere le sue
 belle cose.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>L'ho menà mi sior Conte, l'ho menà mi; perché anca
 mi ho savesto, che l'ha fatto una bella spesa. (Credo che
 l'abbia buttà i bezzi in canal, e pol esser, che me riessa
 d'illuminarlo). (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Sentite, signor Pancrazio, ora posso dire, che in
 questa città niuno possa arrivare alla mia galleria. Ho
 delle cose preziose.</p>
           </sp>
-          <sp>
+          <sp who="#pancrazio">
             <speaker>PANCRAZIO</speaker>
             <p>Le vederò volentieri. V. S. sa, che io ne ho
 cognizione.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>È vero; voi siete il più pratico, e il più
 intendente antiquario di Palermo. Date un'occhiata a quelle
 casse, e vedete se sono piene di piccoli tesoretti.</p>
           </sp>
-          <sp>
+          <sp who="#pancrazio">
             <speaker>PANCRAZIO</speaker>
             <p>Con sua licenza. (<emph>va a vedere nelle casse</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Caro signor Pantalone, compatite, se vi ho piantato,
 quando eravamo in camera colle due pazze. Moriva di voglia
 di veder queste belle cose.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Sior Conte, possibile, che alla so casa no la ghe
 voggia pensar gnente?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Se ci penso? Eccome! Ditemi, come è andata la cosa?
 Come si è terminato il congresso?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ghe dirò; dopo, che la xè andada via ela...</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Ebbene, signor Pancrazio, che dite? Sono cose
 stupende, cose rare, non più vedute?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(Vardè come, che el m'ascolta). (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#pancrazio">
             <speaker>PANCRAZIO</speaker>
             <p>Signor Conte, mi permetta, ch'io parli con
 libertà?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Sì, dite liberamente il vostro parere.</p>
           </sp>
-          <sp>
+          <sp who="#pancrazio">
             <speaker>PANCRAZIO</speaker>
             <p>Prima di tutto, crede ella, ch'io sia un uomo
 d'onore?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Vi tengo per un uomo illibatissimo, come siete, e
 come vi decanta tutto Palermo.</p>
           </sp>
-          <sp>
+          <sp who="#pancrazio">
             <speaker>PANCRAZIO</speaker>
             <p>Crede, ch'io abbia cognizione di queste cose?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Dopo di me, non vi è nessuno meglio di voi.</p>
           </sp>
-          <sp>
+          <sp who="#pancrazio">
             <speaker>PANCRAZIO</speaker>
             <p>Quanto ha pagato tutta questa robba?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Sentite, ma in confidenza, che nessuno lo sappia;
 l'ho avuta a un prezzo disfatto. Per 3000 scudi.</p>
           </sp>
-          <sp>
+          <sp who="#pancrazio">
             <speaker>PANCRAZIO</speaker>
             <p>Signor Conte, in confidenza, che nessuno ci senta,
 questa è robba che non vale 3000 soldi.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Come non vale 3000 soldi?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(Bella da galantomo!)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>L'avete bene osservata?</p>
           </sp>
-          <sp>
+          <sp who="#pancrazio">
             <speaker>PANCRAZIO</speaker>
             <p>Ho veduto quanto basta, per assicuraimi di ciò.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Ma i crostacei?</p>
           </sp>
-          <sp>
+          <sp who="#pancrazio">
             <speaker>PANCRAZIO</speaker>
             <p>Sono ostriche, trovate nell'immondizie, o gettate
 dal mare quando è in burrasca.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Trovae sui monti del poco giudizio.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>E i pesci petrificati?</p>
           </sp>
-          <sp>
+          <sp who="#pancrazio">
             <speaker>PANCRAZIO</speaker>
             <p>Sono sassi un poco lavorati col scalpello per
 ingannare, chi crede.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ghe sarà anca petrificà, e indurio el cervello de
 qualche antiquario.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>E le mummie?</p>
           </sp>
-          <sp>
+          <sp who="#pancrazio">
             <speaker>PANCRAZIO</speaker>
             <p>Sono cadaveri di piccoli cani, e di gatti, e di
 sorci sventrati e seccati.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Ma il basilisco?</p>
           </sp>
-          <sp>
+          <sp who="#pancrazio">
             <speaker>PANCRAZIO</speaker>
             <p>È un pesce marino, che i ciarlatani sogliono
 accomodare in figura di basilisco, e se ne servono per
 trattenere i contadini in piazza, quando vogliono vendere il
 loro balsamo.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Signor Pancrazio, voi m'uccidete, voi mi cavate il
 cuore. E i quadri, le pitture, le miniature?</p>
           </sp>
-          <sp>
+          <sp who="#pancrazio">
             <speaker>PANCRAZIO</speaker>
             <p>Per quel poco, che ho veduto sono cose, che
 possono valere cento scudi, se vi arrivano.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Dubito, o che vi vogliate prender spasso di me, o
 che lo facciate per indurmi a vendervi queste robbe a buon
 mercato, ma v'ingannate, se lo credete.</p>
           </sp>
-          <sp>
+          <sp who="#pancrazio">
             <speaker>PANCRAZIO</speaker>
             <p>Io sono un uomo d'onore. Non son capace
 d'ingannarvi, ma vi dico bensì, che siete stato tradito.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>E chi l'ha tradio xè quel baron de Brighella.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Brighella è onorato.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Brighella xè un furbazzo, e ghe lo proverò.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Come le potete dire? Come me lo potete provare?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Se recordela dell'Armeno, che gh'à vendù el lume
 eterno delle piramidi d'Egitto e tutte quell'altre belle
 cosse?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Me ne ricordo sicuro, e quella pure è stata
 un'ottima spesa.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Con so bona grazia l'aspetta un momento; el xè qua,
 che el fazzo vegnir. (<emph>parte</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Avrà qualche altra cosa rara da vendere.</p>
           </sp>
-          <sp>
+          <sp who="#pancrazio">
             <speaker>PANCRAZIO</speaker>
             <p>Caro signor Conte mi dispiace sentire, ch'ella
 getti malamente i suoi denari.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Compatitemi, non ne sono ancor persuaso. Brighella
 mi ha fatto fare questo negozio. Brighella se ne intende
 quanto voi, e non è capace d'ingannarmi.</p>
           </sp>
-          <sp>
+          <sp who="#pancrazio">
             <speaker>PANCRAZIO</speaker>
             <p>Brighella se ne intende quanto me? Mi fa un
 bell'onore. Signor Conte, io son venuto per illuminarla,
@@ -6540,16 +6577,16 @@ mosso dall'onestà di galantuomo, ed eccitato a farlo dal
 signor Pantalone. Vusignoria è attorniato da bricconi, che
 l'ingannano, e gli fanno comprare delle porcherie, e però...</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Mi maraviglio; me n'intendo; non sono uno sciocco.
 (<emph>alterato</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#pancrazio">
             <speaker>PANCRAZIO</speaker>
             <p>Servitore umilissimo. (<emph>parte</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Che caro signor Pancrazio! Parla per invidia.
 Vorrebbe discreditare la mia galleria, per accreditare la
@@ -6561,112 +6598,112 @@ sua. Me n'intendo; conosco; non mi lascio gabbare.</p>
           <stage>
             <emph>Pantalone, Arlecchino, e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(<emph>Conducendo per mano Arlecchino</emph>) Vegnì qua sior,
 no ve vergognè, no ve tirè indrio; confessè al sior Anselmo
 la bella vendita, ch'avè fatto, e chi ve l'ha fatta far.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Siori, ve domando perdon...</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Questo è l'Armeno. Siete voi l'Armeno?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Sior sì, son un Armeno da Bergamo.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Come!</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Chi v'ha introdotto in sta casa? Parlè. (<emph>ad Arlecchino</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Brighella. (<emph>sempre timoroso</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>A cossa far?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>A vender de le strazze al sior antiquario.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Sentela, patron?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Come, stracci? Il lume eterno...</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>L'è una luse da oggio, che val do soldi.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Oimè! Non è il lume eterno trovato nelle piramidi
 d'Egitto?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Stara, stara, e mi cucara.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Ah son tradito, sono assassinato! Ladro infame
 anderai prigione.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>El ladro, el baron, xè Brighella, che l'ha menà in
 casa, e s'ha servio de sto martuffo per tor in mezzo el
 patron.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>E mi, che aveva imparà da quel buon maestro, son po
 vegnù colle drezze de Lugrezia romana.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Dove sono le treccie di Lucrezia romana?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Eh no vedela, che le xè furbarie? Mi l'ho scoverto;
 e gh'ò tolto de man tutte quelle cargadure, che el vegniva a
 venderghe a ela.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Ah scellerato! Signor Pantalone, mandiamo a chiamare
 li sbirri. Facciamolo cacciar prigione.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Mi no voggio altri impegni, l'ho tegnù qua per
 disingannarla, e me basta cusì. Va' là, tocco de furbazzo.
 Va' lontan de sta casa, e ringrazia el Cielo, che la te
 passa cusì.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Grazie della so carità... (<emph>in atto di partire</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Maledetto! Ti accopperò. (<emph>vuol seguirlo</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>No me cuccara, no me cuccara. (<emph>correndo parte</emph>)</p>
           </sp>
@@ -6676,51 +6713,51 @@ passa cusì.</p>
           <stage>
             <emph>Il conte Anselmo, e Pantalone.</emph>
           </stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Cossa dìsela, sior Conte, Brighella xèlo un
 galantomo?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>È un briccone, è un traditore.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Cossa vorla far de sti mobili?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Non saprei... lascamoli qui, serviranno per
 accrescere la galleria.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ah donca la vol seguitar a tegnir galleria.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Ma cosa vorreste, ch'io facessi, senza questo poco
 divertimento?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Vorria, che l'abbadasse alla so fameggia. Vorria,
 che se giustasse ste differenze tra niora, e madonna.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Bene aggiustiamole.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Se ghe vorla metter de cuor?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Mi ci metterò con tutto lo spirito.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Se la farà cusì, no mancherò de assisterla dove,
 che poderò. Me preme mia fia; no gh'ò altri al mondo, che
@@ -6728,54 +6765,54 @@ ela. La vorrave veder quieta, e contenta; se se pol, ben, se
 no, sàla cosa che farò? La torò suso, e la menerò a casa
 mia.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Signor Pantalone, preme anche a me la mia pace.
 Voglio, che ci mettiamo in quest'affare con tutto lo
 spirito.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>La me consola; me vien tanto de cuor.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Caro amico, giacché avete dell'amore per me, fatemi
 una finezza.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Comandela qualcossa? Son a servirla.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Prestatemi otto, o dieci zecchini, che poi
 ricuperando quei di Brighella, ve li renderò.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>La toga, e la se serva.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Ve li renderò.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Me maraveggio. Vago da mia fia. La vaga ella dalla
 siora Contessa, e vedemo de pacificarle.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Oprate voi, e operarò ancor io.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Vorrave aver da giustar un fallimento in piazza,
 più tosto, che trattar una pase tra niora, e madonna.
 (<emph>parte</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Giacché ho questi dieci zecchini, non voglio
 tralasciare di comprare quei due ritratti del Petrarca, e
@@ -6793,64 +6830,64 @@ laterale, ogn'uno parla verso la porta di dove esce, senza
 vedere quell'altro, e s'incontrano poi nel mezzo della
 scena.</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Sì signora, son qui per sostenere le vostre parti.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Si rimetta in me, lasci fare a me.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Il Dottore non averà la temerità d'opporsi.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Il signor Cavaliere non mi fa paura.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Lo troverò. (<emph>vede il Dottore</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Oh diavolo! (<emph>vedendo il Cavaliere</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Signor Dottore pensate a rendermi conto
 dell'ingiurie, che ho ricevute.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Da me non ha Vossignoria ricevuto ingiuria alcuna.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Le ho ricevute dalla dama, e voi che avete prese le
 di lei parti, voi siete in obbligo di darmi soddisfazione.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Colla spada sarà difficile, perché io no la so
 maneggiare.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Non ve la passate in barzellette.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Caro, signor Cavaliere, giacché siamo qui soli, e
 che nessuno ci sente, mi permette, ch'io gli dica quattro
 parole da uomo, da suo servitore, e da buono amico?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Dite pure v'ascolto.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Prima di tutto torno a dirgli non sono uomo da
 spada, ma da toga, né so che razza di soddisfazione da me
@@ -6863,12 +6900,12 @@ Contessa Isabella, poniamo in silenzio queste freddure.
 Perché, signor Cavaliere mio, dalle contese dei pretendenti,
 resta prima di tutto oltraggiata la riputazione della dama.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ma la signora Contessa Isabella con poca prudenza mi
 ha offeso, e voi avete approvato le sue parole.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Protesto, che non l'ho fatto per offenderla, ma
 unicamente per acquietar la collera della dama irritata, la
@@ -6877,39 +6914,39 @@ sempre più nelle smanie. Favorisca di grazia, non sarebbe
 meglio, che lei per la parte della nuora, ed io per la parte
 della suocera, procurassimo di far questa pace?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Io non ho questa autorità sopra la signora Doralice.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Né meno io sopra la signora Isabella, ma spero, che
 se le parlerò, si rimetterà in me.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Così spererei anch'io della Contessina.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Facciamo una cosa, proviamo, e se ci riesce di far
 questo bene, averemo il merito di mettere in quiete, e in
 concordia, tutta questa famiglia.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Benissimo vado a ricevere le commissioni dalla
 signora Doralice.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Ed io nello stesso tempo dalla signora Isabella.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Attendetemi, che ora torno. (<emph>entra nell'appartamento di Doralice</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Se posso colle buone, anderà bene; altrimenti non
 voglio impegni.</p>
@@ -6920,109 +6957,109 @@ voglio impegni.</p>
           <stage>
             <emph>La contessa Isabella, e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Signor Dottore, che discorsi avete avuti col
 Cavaliere?</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>La collera gl'è passata, tanto lui, che io
 desideriamo di procurare la sua quiete, la sua pace, la sua
 tranquillità.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Fino, che colei sta in questa casa non l'averò mai.
 Ditemi il Cavaliere continova a dichiararsi per Doralice?</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Egli è un galantuomo, che fa per una, e per l'altra
 parte. Mi creda. Si fidi di me, si rimetta in me, e le
 prometto, che ella sarà contenta.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Benissimo; io mi rimetto in voi.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Quello, che farò io, sarà ben fatto?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Sarà ben fatto.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Lo approverà?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>L'approverò.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Dunque stia quieta, e non pensi altro.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Avvertite però non risolver niente senza, che io lo
 sappia.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>In questa maniera la non si rimette in me.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Vi lascio la libertà di trattare.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Ma non di concludere?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Signor no di concludere no.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Dunque tratteremo.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Il primo patto, che Doralice vada fuori di questa
 casa.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>E la dote?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Prima la mia, e poi la sua.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>S'ha da rovinare la casa?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Rovinar la casa, ma via Doralice.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Eccola.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Temeraria! Ha tanto ardire di venirmi d'avanti gli
 occhi? Il sangue mi bolle tutto. Non la voglio vedere.
 Venite con me. (<emph>entra nel suo appartamento</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Vengo. Ho paura che non facciamo niente. (<emph>entra con lei</emph>)</p>
           </sp>
@@ -7032,116 +7069,116 @@ Venite con me. (<emph>entra nel suo appartamento</emph>)</p>
           <stage>
             <emph>Doralice e il Cavaliere dal suo appartamento.</emph>
           </stage>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Vedete? Io vengo per parlare con lei, ed ella mi
 fugge.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Volevate forse pacificarvi?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Signor no. Volevo dirle, che se ella non vuole,
 ch'io vada nella sua camera d'udienza, nemmeno lei venga qui
 nel mio appartamento.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>E bene dunque se ne è andata; così avete risparmiata
 una nuova rissa.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Per dirle queste quattro parole, non vi era motivo
 di attaccare una rissa.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Credete forse, che lei non si fosse riscaldata?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Buon viaggio. A me non me ne sarebbe importato.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>E voi non vi sareste niente alterata?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Signor no. Lo sapete; io dico la mia ragione,
 senza, che il sangue mi si riscaldi.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ma con tutto il vostro sangue freddo, contessina
 mia, la casa è in sussurro, e non vi è pace fra voi.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Ne sono forse io la cagione?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>No certamente.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Dunque, cavalierino mio, non mi mortificate senza
 ragione.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Giacché siete tanto discreta, e ragionevole, mi date
 licenza, che salve tutte le vostre convenienze, tratti
 l'aggiustamento con vostra suocera?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Sì, mi farete piacere.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Volete rimettervi in me?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Vi do ampla facoltà di far tutto.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Mi date la parola di dama?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Ve la do, con patto però, che l'aggiustamento sia
 fatto a modo mio.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Prescrivetemi le condizioni.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Una delle due, o che io debba essere la padrona in
 questa casa, senza, che la suocera se ne abbia da ingerire
 punto, né poco; o ch'io voglio la mia dote, e tornarmene in
 casa di mio padre.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Troveremo qualche temperamento da combinare le cose
 con grazia.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Sì, via, trovate de' mezzi termini, de' buoni
 temperamenti, ma ricordatevi, che non voglio restare al
 disotto una punta di spilla. (<emph>va al suo appartamento</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Oh, questo è un grande imbarazzo! Ma ecco il
 Dottore. Sentiamo che cosa dice della Contessa Isabella.</p>
@@ -7152,57 +7189,57 @@ Dottore. Sentiamo che cosa dice della Contessa Isabella.</p>
           <stage>
             <emph>Il Dottore dall'appartamento d'Isabella, e detto</emph>
           </stage>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Signor Cavaliere ha parlato colla signora Doralice?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Signor sì, ho parlato; ed ho la facoltà di trattare.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Io pure ho l'istessa facoltà da quest'altra.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Dunque trattiamo. Vi faccio a prima giunta un
 progetto alternativo. O la signora Doralice vuol essere
 padrona in questa casa, o vuole la sua dote, e se n'anderà
 con suo padre.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Rispondo per la signora Contessa. Se vuole andare
 se ne vada; ma prima s'ha da levare la dote della suocera, e
 poi quella della nuora.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Facciamo così, che la signora Isabella dia il
 maneggio alla nuora di 400 scudi l'anno, e penserà lei
 alle spese per sé, e per la cameriera.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Con licenza, ora torno. (<emph>va da Isabella, e poi torna</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Non può risolvere. Anch'egli ha lo stesso arbitrio,
 che ho io. Questa sarebbe la meglio. Ognuna pensar per sé.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>(<emph>Ritorna dall'appartamento d'Isabella</emph>) Quattro
 cento scudi non si possono accordare. Se n'accorderanno
 trecento.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Attendetemi, che ora vengo.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>È plenipotenziario anch'egli, come sono io.</p>
           </sp>
@@ -7212,41 +7249,41 @@ trecento.</p>
           <stage>
             <emph>Pantalone dalla porta di mezzo, e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Sior Dottor, la riverisso. (<emph>incamminandosi verso l'appartamento di Doralice</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Dove, signor Pantalone?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Da mia fia.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Ora si tratta l'aggiustamento fra lei, e la
 suocera.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>E chi lo tratta sto aggiustamento?</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Per la sua parte il Cavaliere del Bosco.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Come gh'intrelo sto sior Cavalier?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(<emph>Ritorna dall'appartamento di Doralice</emph>)
 L'aggiustamento è fatto.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Sì? Come, cara ela?</p>
           </sp>
@@ -7256,56 +7293,56 @@ L'aggiustamento è fatto.</p>
           <stage>
             <emph>Il conte Anselmo dalla porta di mezzo, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Signor Conte, l'aggiustamento è fatto.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Ne godo, ne godo, e come?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>La signora Doralice si contenta di trecento scudi
 l'anno.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>E la signora Contessa Isabella gli li accorda.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Xèla matta mia fia? Adesso mo. (<emph>va da Doralice, poi torna</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>È spiritata mia moglie? ora mi sentirà. (<emph>va da Isabella</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Questi vecchi vogliono guastare il nostro maneggio.
 (<emph>al Dottore</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Questa era una convenzione onesta perché, per
 dirla, la signora Doralice è troppo inquieta.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ha ragione, se vede di mal occhio la suocera, per
 tutto quello, che ha saputo dire di lei.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Anzi la nuora ha strappazzata la suocera
 fieramente.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Siete male informato.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Ehei, Colombina.</p>
           </sp>
@@ -7315,143 +7352,143 @@ fieramente.</p>
           <stage>
             <emph>Colombina dalla camera d'Isabella, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Signore.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Dimmi un poco, che cosa ha detto la signora
 Doralice della Contessa Isabella?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Oh! Io non so nulla.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Non crediate a costei, mentre ella alla signora
 Doralice ha detto tutto il male della sua padrona.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Io non ho detto nulla.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Credetemelo, da Cavaliere.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Dunque la ciarliera di Colombina, ha messo male fra
 queste due signore.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Senz'altro.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Vado dalla Contessa Isabella. (<emph>va da Isabella, poi torna</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Avete fatto una bella cosa! (<emph>al Cavaliere</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Bricconcella, tu sei stata quella, che ha detto male
 della nuora, alla suocera? Ora vado dalla signora Doralice a
 scuoprire le tue iniquità. (<emph>va da Doralice, poi torna</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Oh questa è bella! Se mi pagano, acciò dica male,
 non l'ho da fare?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>(<emph>Ritorna dall'appartamento d'Isabella</emph>) Tu,
 disgraziata, sei cagione di tutto. (<emph>va da Doralice, poi torna</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Anche questo stolido l'ha con me.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>(<emph>Dall'appartamento d'Isabella</emph>) Or ora si scoprirà
 ogni cosa. (<emph>va nell'appartamento di Doralice</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Mi vogliono tutti mangiare.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(<emph>Dall'appartamento di Doralice</emph>) Xè vero,
 desgraziada, che ti ha ditto mal de mia fia alla to parona?</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Io non so niente.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Aspetta, aspetta. (<emph>va da Isabella</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Credono di farmi paura.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>(<emph>Dall'appartamento di Doralice</emph>) Or ora, ho
 scoperto tutto. Te n'accorgerai. (<emph>va da Isabella</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Principio avere un poco di paura.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>(<emph>Dall'appartamento di Doralice</emph>) Non me l'averei
 mai creduto; oh che lingua! (<emph>va da Isabella</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Sono in cattura davvero.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(<emph>Dall'appartamento di Doralice</emph>) Colombina, sei
 scoperta. Tu sei quella, che hai riportato le ciarle da una
 parte, e dall'altra. Ora tutte sono contro di te, e
 vogliono, che tu ne paghi la pena. Ti consiglio andartene.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Ma dove? povera me! Dove?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Presto, va' nella tua camera, e chiuditi dentro.
 Vederò io d'aiutarti.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Per amor del Cielo, non mi abbandonate.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Presto, che vien gente.</p>
           </sp>
-          <sp>
+          <sp who="#colombina">
             <speaker>COLOMBINA</speaker>
             <p>Maledetta fortuna! È stato quel zecchino il mese
 che m'ha acciecato. (<emph>parte per la porta di mezzo</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ora, che si è scoperta la malizia di costei, è più
 facile l'accomodamento.</p>
@@ -7462,165 +7499,165 @@ facile l'accomodamento.</p>
           <stage>
             <emph>Il conte Giacinto dalla porta di mezzo, e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Cavaliere, che ha Colombina, che piange, e pare
 spaventata?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>È stata scoperta essere quella, che ha seminato
 discordie fra suocera, e nuora; ed ora fra esse trattasi
 l'aggiustamento.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Voglia il cielo, che segua!</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>(<emph>Dall'appartamento d'Isabella</emph>) La signora
 Isabella è persuasa di tutto, e se la signora Doralice verrà
 nella sua camera a riverirla, l'abbraccierà con amore, e con
 tenerezza.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Vado a dirlo alla signora Doralice. (<emph>va da Doralice</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Dunque mia madre è placata?</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Placatissima; tutto è accomodato.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Sia ringraziato il Cielo!</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(<emph>dall'appartamento di Doralice</emph>) La signora
 Doralice è prontissima a ricever l'abbraccio dalla signora
 Isabella, ma che venga lei a riveder la nuora nella sua
 camera.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Glie lo dirò, ma dubito non si farà nulla. (<emph>va da Isabella</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Mi pare veramente, che tocchi a mia moglie.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Pretende lei di essere l'offesa.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(<emph>Dall'appartamento d'Isabella, e detti</emph>) Mia fia
 non vol vegnir da so madonna? Aspettè, aspettè, che anderò
 mi a farla vegnir, e la vegnirà. (<emph>va da Doralice</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Vedete? Anche suo padre le dà torto.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Il buon vecchio fa per metter bene.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>(<emph>Dall'appartamento d'Isabella</emph>) Oh questa sì, ch'è
 bella! La suocera anderà ad umiliarsi alla nuora?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(<emph>Dall'appartamento di Doralice</emph>) La xè giustada.
 Mia fia vegnirà da siora Contessa; basta, che la ghe vegna
 incontra co la la vede per darghe coraggio.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Bene, bene, lo farà. Vado a dirlo a mia moglie. (<emph>va da Isabella</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Vardè cossa, che ghe vol a unir ste do donne!</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Voi l'avete ridotta a fare un bel passo. (<emph>a Pantalone</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Lodo la vostra prudenza. (<emph>a Pantalone</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>(<emph>Dall'appartamento di Isabella</emph>) Signor Pantalone,
 dite pure a vostra figlia, che la non s'incommodi altro.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Perché?</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Perché la signora Contessa dice così, che essendo
 dama, non si deve movere dalla sedia per venire a riceverla.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ora vado io a dirlo alla signora Doralice. (<emph>va da Doralice</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Vardè, che catarri; vardè che freddure!</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Anderò io da mia madre, e vederò di persuaderla.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Sì caro fio: fè sto ben.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Mia madre a me non dirà di no. (<emph>va da Isabella</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>E a vu mo, la ve par una bella cossa? (<emph>al Dottore</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>La pretensione non è stravagante.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Mia fia mo vedeu, no la gh'à tante pretension.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(<emph>Dall'appartamento di Doralice</emph>) Dice la signora
 Doralice, che non è dama, ma ha portato ventimille scudi di
 dote, e non vuol essere strapazzata.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Vado subito a dirlo alla signora Contessa.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Vegni qua, fermeve.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Viene, o non viene?</p>
           </sp>
@@ -7631,102 +7668,102 @@ dote, e non vuol essere strapazzata.</p>
             <emph>Doralice sulla porta, e detti, poi la contessa Isabella
 dal suo appartamento.</emph>
           </stage>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Signor no, non vengo. Dite alla vecchia, che se
 vuol venga lei.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Sfacciatella, a me vecchia?</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Signora giovinetta, la riverisco. (<emph>parte</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>O via lei, o via io. (<emph>parte</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Oh poveretto mi! Coss'è sta cossa?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>La signora Doralice ha ragione.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Avete sentito vostra figlia? (<emph>a Pantalone</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Oh che donne! Oh che donne!</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>(<emph>Dall'appartamento d'Isabella</emph>) Le mie medaglie, le
 mie medaglie. Mai più m'intrico con queste pazze. Dite quel
 che volete voglio spendere il mio tempo nelle mie medaglie.
 (<emph>parte per la porta di mezzo</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Oh, che matti! Oh, che casa da matti!</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>(<emph>Dalla camera d'Isabella</emph>) Signor suocero, son
 disperato.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Coss'è stà?</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Avete sentito? Mia moglie ha detto vecchia a mia
 madre; mia madre ha detto sfacciatella a mia moglie. Vi è il
 diavolo in questa casa, vi è il diavolo. (<emph>parte per la porta di mezzo</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Se ghe xè el diavolo, che el ghe staga. No so cossa
 farghe; gh'ò tanto de testa. No so in che mondo che sia.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Anderò io a placare la signora Doralice.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>E io anderò a calmare la signora Isabella.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>E mi credo, che vualtri siè quelli, che le fazza
 deventar sempre pezo.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Io sono un Cavaliere onorato.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Io non sono un ragazzo.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Saprà la signora Doralice il torto, che voi mi fate.
 (<emph>va da Doralice</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Voglio dire alla signora Contessa in qual concetto
 mi tiene il signor Pantalone. (<emph>va da Isabella</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Oh, che mazzai! Ma stimo quel vecchio matto. Se pol
 dar! Come che el se mette anca elo in riga de protettor? E
@@ -7743,45 +7780,45 @@ roverso. (<emph>parte</emph>)</p>
           <stage>
             <emph>Il conte Anselmo, poi il conte Giacinto.</emph>
           </stage>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Se avessi atteso solamente alle medaglie, e ai
 camei, non mi sarebbe successo quello, che mi è successo.
 Maledetto Brighella! Mi ha rovinato.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Brighella non si trova più. Egli è partito di
 Palermo, e non si sa per qual parte.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Pazienza! Mi ha rovinato.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Ah signor padre, siamo rovinati tutti! Dei
 ventimille scudi non ve ne sono più. Alla raccolta vi è
 tempo. E per mangiare, ci converrà far dei debiti.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Se lo dico; Brighella mi ha rovinato.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>E per condimento delle nostre felicità, abbiamo una
 moglie per uno, che formano una bella pariglia.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Io non ci penso più.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>E chi ci ha da pensare?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Oh! Non ci penso più. M'hanno fatto impazzire tanto,
 che basta.</p>
@@ -7792,185 +7829,185 @@ che basta.</p>
           <stage>
             <emph>Pantalone, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Con so bona grazia.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>(Eccolo qui il mio tormento). (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Sior Conte, sior zenero, i me compatissa, se vegno
 avanti arditamente. Se tratta de assae; se tratta de tutto,
 e qua bisogna trovarghe qualche remedio.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Io lascio fare a voi.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ella vol tender alle so medaggie.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Fin che posso, non le voglio lasciare.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>E vu, sior zenero, cossa diseu? Ve par, che se
 possa tirar avanti cussì? Ve par, che vaga ben i negozi
 della vostra casa?</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Io dico, che in poco tempo ci ridurremo miserabili
 più di prima.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Sior Conte, sentela cossa, che dise so fio?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Lo sento, ma non so come rimediarvi.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Se vorla redurse a non aver da magnar?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Ci sono l'entrate.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Co le se magna in erba, no le frutta el terzo. E de
 ste care niora, e madonna cossa dìsela?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Io dico, che non si può far peggio.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>No la pensa a remediarghe?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Io non ci vedo rimedio.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ghe lo vederave ben mi, se gh'avesse un poco
 d'autorità in sta casa.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Caro signor Pantalone, io vi do tutta l'autorità,
 che volete.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Sì, caro signor suocero, prendete voi l'economia
 della nostra casa. Assisteteci per amor del Cielo; fatelo
 per vostra figlia, per il vostro sangue.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Me despiase, che anca ela xè mezza matta. Ma in
 casa mia no la giera cusì; la s'ha fatto dopo, che la xè
 qua, onde spereria con facilità redurla in tel stato de
 prima.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Anche mia moglie una volta era una buona donna; ora
 è divenuta un serpente.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Credeme padroni, che ste donne le xè messe suso da
 sti do conseggieri.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Credo anch'io, ch'ella sia così.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Ne dubito ancora io.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Qua ghe vol resoluzion. Vorla, che mi ghe fazza da
 fattor, da spendidor, da mistro de casa, senza vadagnar un
 soldo, e solamente, per l'amor che porto a mia fia, a mio
 zenero, e a tutta sta casa?</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Lo volesse il cielo!</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Non mi levate le mie medaglie, e per il resto vi do
 amplissima facoltà di far tutto.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Do righe de scrittura, che me fazza arbitro del
 manizo e dell'economia della casa, e m'impegno, che in pochi
 anni la se vederà qualche centener de zecchini; e criori ghe
 ne sarà pochi.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Fate la carta, ed io la sottoscriverò.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>La carta non ho aspettà adesso a farla; xè un
 pezzo, che vedo el bisogno, che ghe ne giera. Ghe da zontar
 do, o tre capitoleti, e credo, che l'anderà ben. Andemola a
 lezer in tel so mezà.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Non vi è bisogno di leggerla. La sottoscrivo senza
 altro.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Sior no! Vòi, che la la senta, e che la la
 sottoscriva alla presenza de' testimoni; e cusì anca el sior
 zenero.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Lo farò con tutto il cuore.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Andiamo; ma ci siamo intesi. Il primo patto, che non
 mi toccate le mie medaglie. (<emph>parte</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Poverazzo! Anche questa xè una malattia; chi vol
 varirlo no bisogna farlo violentemente, ma un pochetto alla
 volta.</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Caro signor suocero vi raccomando la quiete della
 nostra famiglia. Mio padre non è atto per questa briga; fate
 voi da capo di casa; e son certo, che se il capo averà
 giudizio, tutte le cose anderanno bene. (<emph>parte</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Questa xè la verità. El capo de casa xè quello, che
 fa bona, e cattiva la fameggia. Vòi veder, se me riesse de
@@ -7985,91 +8022,91 @@ ponzerle.</p>
           <stage>
             <emph>La contessa Isabella, ed il Dottore.</emph>
           </stage>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Non mi parlate più di riconciliarmi con Doralice
 perché è impossibile.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Ella ha ragione signora Contessa.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Può darsi una impertinente maggior di questa?</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>È una petulante.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Assolutamente, assolutamente, la voglio fuori di
 questa casa.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Savissima risoluzione.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Io sono la padrona.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>È verissimo.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>E non è degna di stare in casa con me.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Non è degna.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Se non fosse perché, perché, le darei delli
 schiaffi.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>E sariano ben dati.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Dottore, se mio marito non la manda via, voglio che
 le fate fare un precetto.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Ma! Vole accendere una lite?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Non siete capace di sostenerla?</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Per me la sosterrò; ma s'ella anderà via, vorrà la
 dote.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>La dote, la dote! Sempre si mette in mezzo la dote.
 V'ho detto un'altra volta, che prima vi è la mia.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>È verissimo, ma la dote della signora Doralice
 ascende a ventimille scudi, e la sua non è, che di due
 mille.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Siete un ignorante, non sapete niente.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>(Già; quando non si dice a modo suo si comparisce
 ignorante).</p>
@@ -8080,50 +8117,50 @@ ignorante).</p>
           <stage>
             <emph>Pantalone, il conte Anselmo, e detta.</emph>
           </stage>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Che cosa c'è, signori miei, qualche altra bella
 novità al solito?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>La novità la sentirete or ora.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>La compatissa, se vegno a darghe un poco
 d'incomodo.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Vostra figlia ha poco giudizio.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Adesso adesso, la sarà qua anca ela.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Ella qui? Cosa c'entra nelle mie camere?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Deve venire per un affar d'importanza.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>E non vi è altro luogo, che questo?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Avemo fatto per non incomodarla ela, fora della so
 camera.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>La riceverò come merita.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>La la riceva, come che la vol, che n'importa.</p>
           </sp>
@@ -8133,37 +8170,37 @@ camera.</p>
           <stage>
             <emph>Doralice, Giacinto, Il Cavaliere del bosco, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Servitor umilissimo di lor signori.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Che ne dite? Ha sempre il Cavaliere al fianco. (<emph>al Dottore</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Sediamo, sediamo. (<emph>tutti siedono</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Si può sapere, per che cosa mi avete condotta qui?
 (<emph>a Giacinto</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#giacinto">
             <speaker>GIACINTO</speaker>
             <p>Or ora lo saprete.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Moglie mia carissima, nuora mia dilettissima,
 sappiate, che io non sono più capo di casa.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Già si sa; quest'impiccio ha da toccare a me.</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Non dubitate, l'impiccio non tocca a voi. Il signor
 Pantalone ha assunto l'impegno di regolare la nostra casa.
@@ -8171,95 +8208,95 @@ Mio figlio, ed io abbiamo cedute a lui tutte le nostre
 azioni, e ragioni, e abbiamo sottoscritti alcuni capitoli,
 che ora anche voi sentirete.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Questo è un torto, che fate a me.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>In quanto a questo poi, in mancanza del capo di
 casa, tocca a me.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Io sono la padrona principale.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Brava!</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Io ho liberate l'entrate colla mia dote.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>È vero, è vero.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Orsù, un poco de silenzio. Mi lezerò i capitoli
 della convenzion fermada, e sottoscritta, e che i l'ascolta
 perché ghe xè qualcosa per tutti. <emph>Capitoli convenzionali. Primo.</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Che io possa divertirmi colle medaglie.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>
               <emph>Primo: che domino Pantalon dei Bisognosi abbia da riscuotere tutte le entrate appartenenti alla casa del Conte Anselmo Terrazzani, tanto di città, che di campagna.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>E consegnar il denaro, o a mio marito, o a me.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>(La signora economa!)</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>
               <emph>Secondo: che domino Pantalon abbia da provveder la casa di detto Conte Anselmo di vitto, e vestito a tutti della casa medesima.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Ho bisogno di tutto, che non ho niente di buono.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>
               <emph>Terzo: che sia in arbitrio di detto Pantalon, di procurar i mezzi per la quiete della famiglia, e sopra tutto per far, che stiano in pace la suocera, e la nuora di detta casa.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>È impossibile, è impossibile.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>È un demonio, è un demonio.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>
               <emph>Quarto: che né una, né l'altra di dette due signore abbiano d'avere amicizie, continue, e fisse, e quella che ne volesse avere, possa essere obbligata andar ad abitare in campagna.</emph>
             </p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Oh, questo è troppo!</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Questo capitolo offende la civiltà.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Questo capitolo offende me. L'intendo signori miei
 l'intendo; e giacché vedo, che la mia servitù colla signora
@@ -8268,124 +8305,124 @@ mentre un Cavalier ben nato, non deve in verun modo
 contribuire all'inquietudine delle famiglie. (Mai più vado
 in veruna casa ove vi siano suocera, e nuora). (<emph>parte</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Se è andato via il Cavaliere, non resterà nemmeno
 il Dottore.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Cossa dìsela, sior Dottor, àla visto con che
 prudenza ha operà el sior Cavalier?</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Il signor Dottore, non ha da partire di casa mia.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>La nostra è amicizia vecchia.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Giusto per questo la s'averia da fenir.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>La finirò; anderò via, e non ci tornerò più, ma
 vorrei sapere per che causa con una sì bella frase si
 licenzia di casa un galantuomo della mia sorte.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Co nol savè, ve lo dirò mi, sior. Perché vualtri,
 che volè far i ganimedi, no sè boni da altro, che da
 segondar i matezzi delle povere donne.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Ho secondato la signora Contessa Isabella, perché
 quando si ha della stima per una persona, non le si può
 contraddire. Vado via signora Contessa.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>L'ho sempre detto, che siete un Dottore senza
 spirito, e senza dottrina.</p>
           </sp>
-          <sp>
+          <sp who="#dottore">
             <speaker>DOTTORE</speaker>
             <p>Sentono i miei signori? Dopo, che ho l'onore di
 servirla, queste sono le finezze, che ho sempre avute.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Andemo avanti coi capitoli. <emph>Quinto: che ste due signore suocera, e nuora per maggiormente conservar la pace fra loro, abbiano d'abitare in due diversi appartamenti, una di sopra, ed una di sotto.</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Quello di sopra lo voglio io.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Io prenderò quello di sotto, che farò meno scale.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Sentìu? Le se scomenza a accomodar. <emph>Sesto: che si licenzi di casa Colombina.</emph>
 </p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Sì, sì licenziarla.</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Sì, mandarla via.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Anca qua le xè d'accordo. Via, me consolo; da
 brave, alla presenza dei so maridi che le se abbrazza, che
 le se basa in segno de pase.</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>Oh questo poi no!</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>Non sarà mai vero.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Via, quella, che sarà la prima a abbrazzar, e a
 basar quell'altra, la gh'averà sto anello de diamanti.
 (<emph>mostra un anello</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#isabella #doralice">
             <speaker>ISABELLA e DORALICE</speaker>
             <p>(<emph>Tutte due s'alzano un poco in atto di andar ad abbracciare l'altra, poi si pentono, e tornano a sedere</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#isabella">
             <speaker>ISABELLA</speaker>
             <p>(Più tosto crepare!)</p>
           </sp>
-          <sp>
+          <sp who="#doralice">
             <speaker>DORALICE</speaker>
             <p>(Più tosto senza anelli tutto il tempo di vita
 mia!). (<emph>da sé</emph>)</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Gnanca per un anello de diamanti?</p>
           </sp>
-          <sp>
+          <sp who="#anselmo">
             <speaker>ANSELMO</speaker>
             <p>Se è antico lo prenderò io.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Orsù; vedo che xè impossibile de far, che le se
 abbrazza, che le se basa, che le se pacifica, e se le lo

--- a/tei/goldoni-la-locandiera.xml
+++ b/tei/goldoni-la-locandiera.xml
@@ -86,6 +86,34 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="marchese">
+            <persName>Marchese di Forlipopoli</persName>
+          </person>
+          <person xml:id="conte">
+            <persName>Conte d'Albafiorita</persName>
+          </person>
+          <person xml:id="fabrizio">
+            <persName>Fabrizio</persName>
+          </person>
+          <person xml:id="cavaliere">
+            <persName>Cavaliere di Ripafratta</persName>
+          </person>
+          <person xml:id="mirandolina">
+            <persName>Mirandolina</persName>
+          </person>
+          <person xml:id="servitore">
+            <persName>Servitore</persName>
+          </person>
+          <person xml:id="ortensia">
+            <persName>Ortensia</persName>
+          </person>
+          <person xml:id="dejanira">
+            <persName>Dejanira</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -295,137 +323,137 @@ questa comodità.</p>
           <stage>
             <emph>Il Marchese di Forlipopoli ed il Conte D'Albafiorita</emph>
           </stage>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Fra voi, e me vi è qualche differenza.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sulla locanda tanto vale il vostro denaro, quanto
 vale il mio.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Ma se la locandiera usa a me delle distinzioni, mi
 si convengono più che a voi.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Per qual ragione?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Io sono il marchese di Forlipopoli.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ed io sono il conte d'Albafiorita.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Sì, conte! Contea comprata.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Io ho comprata la contea, quando voi avete venduto
 il marchesato.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Oh basta: son chi sono, e mi si deve portar
 rispetto.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Chi ve lo perde il rispetto? Voi siete quello, che
 con troppa libertà parlando...</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Io sono in questa locanda, perché amo la
 locandiera. Tutti lo sanno, e tutti devono rispettare una
 giovane, che piace a me.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Oh quest'è bella! Voi mi vorreste impedire, che io
 non amassi Mirandolina? Perché credete, ch'io sia in
 Firenze? Perché credete, ch'io sia in questa locanda?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Oh bene. Voi non farete niente.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Io no, e voi sì?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Io sì, e voi no, io son chi sono. Mirandolina ha
 bisogno della mia protezione.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Mirandolina ha bisogno di denari, e non di
 protezione.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Denari?... non ne mancano.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Io spendo uno zecchino il giorno, signor Marchese,
 e la regalo continuamente.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Ed io quel che fo non lo dico.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Voi non lo dite, ma già si sa.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Non si sa tutto.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sì, caro signor Marchese, si sa. I camerieri lo
 dicono. Tre paoletti, il giorno.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>A proposito di camerieri; vi è quel cameriere, che
 ha nome Fabrizio, mi piace poco. Parmi, che la locandiera lo
 guardi assai di buon occhio.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Può essere, che lo voglia sposare. Non sarebbe cosa
 mal fatta. Sono sei mesi, che è morto il di lei padre. Sola
 una giovane alla testa d'una locanda si troverà imbrogliata.
 Per me, se si marita, le ho promesso trecento scudi.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Se si mariterà, io sono il suo protettore, e farò
 io... E so io quello, che farò.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Venite qui: facciamola da buoni amici. Diamole
 trecento scudi per uno.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Quel che io faccio, lo faccio segretamente, e non
 me ne vanto. Son chi sono. Chi è di là?</p>
             <stage>(<emph>chiama</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>(Spiantato! povero, e superbo!).</p>
             <stage>(<emph>da sé</emph>)</stage>
@@ -436,112 +464,112 @@ me ne vanto. Son chi sono. Chi è di là?</p>
           <stage>
             <emph>Fabrizio e detti</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Mi comandi signore?</p>
             <stage>(<emph>al Marchese</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Signore? Chi ti ha insegnato la creanza?</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>La perdoni.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ditemi: come sta la padroncina?</p>
             <stage>(<emph>a Fabrizio</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Sta bene, illustrissimo.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>È alzata dal letto?</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Illustrissimo sì.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Asino.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Perché, illustrissimo signore?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Che cos'è questo illustrissimo?</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>È il titolo, che ho dato anche a quell'altro
 cavaliere.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Tra lui, e me, vi è qualche differenza.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sentite?</p>
             <stage>(<emph>a Fabrizio</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>(Dice la verità. Ci è differenza; me ne accorgo nei
 conti).</p>
             <stage>(<emph>piano al Conte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Di' alla padrona, che venga da me, che le ho da
 parlare.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Eccellenza sì. Ho fallato questa volta?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Va bene. Sono tre mesi, che lo sai; ma sei un
 impertinente.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Come comanda, Eccellenza.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Vuoi vedere la differenza, che passa fra il
 Marchese, e me?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Che vorreste dire?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Tieni. Ti dono uno zecchino. Fa', che anch'egli te
 ne doni un altro.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Grazie, illustrissimo.</p>
             <stage>(<emph>al Conte</emph>)</stage>
             <p>Eccellenza...</p>
             <stage>(<emph>al Marchese</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Non getto il mio, come i pazzi. Vattene.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Illustrissimo signore, il Cielo la benedica.</p>
             <stage>(<emph>al Conte</emph>)</stage>
@@ -556,50 +584,50 @@ quattrini).</p>
           <stage>
             <emph>Il Marchese ed il Conte</emph>
           </stage>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Voi credete di soverchiarmi con i regali, ma non
 farete niente. Il mio grado val più di tutte le vostre
 monete.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Io non apprezzo quel che vale, ma quello, che si
 può spendere.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Spendete pure a rotta di collo. Mirandolina non fa
 stima di voi.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Con tutta la vostra gran nobiltà, credete voi di
 essere da lei stimato? Vogliono esser denari.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Che denari? Vuol esser protezione. Esser buono in
 un incontro di far un piacere.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sì esser buoni in un incontro di prestar cento
 doppie.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Farsi portar rispetto bisogna.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Quando non mancano denari tutti rispettano.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Voi non sapete quel che vi dite.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>L'intendo meglio di voi.</p>
           </sp>
@@ -609,45 +637,45 @@ doppie.</p>
           <stage>
             <emph>Il Cavaliere di Ripafratta dalla sua camera, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Amici, che cos'è questo romore? Vi è qualche
 dissensione fra di voi altri?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Si disputava sopra un bellissimo punto.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Il Conte disputa meco sul merito della Nobiltà.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Io non levo il merito alla Nobiltà; ma sostengo,
 che per cavarsi dei capricci, vogliono esser denari.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Veramente, Marchese mio...</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Orsù, parliamo d'altro.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Perché siete venuti a simil contesa?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Per un motivo il più ridicolo della terra.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Sì, bravo! il Conte mette tutto in ridicolo.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Il signor Marchese ama la nostra locandiera. Io
 l'amo ancor più di lui. Egli pretende corrispondenza come un
@@ -655,16 +683,16 @@ tributo alla sua nobiltà. Io la spero come una ricompensa
 alle mie attenzioni. Pare a voi, che la questione non sia
 ridicola?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Bisogna sapere con quanto impegno io la proteggo.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Egli la protegge, ed io spendo.</p>
             <stage>(<emph>al Cavaliere</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>In verità non si può contendere per ragione alcuna,
 che lo meriti meno. Una donna vi altera, vi scompone? Una
@@ -674,128 +702,128 @@ con nessuno. Non le ho mai amate, non le ho mai stimate, e
 ho sempre creduto, che sia la donna per l'uomo una infermità
 insopportabile.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>In quanto a questo poi, Mirandolina ha un merito
 estraordinario.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sin qua il signor Marchese ha ragione. La nostra
 padroncina della locanda è veramente amabile.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Quando l'amo io, potete credere, che in lei vi sia
 qualche cosa di grande.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Non averei speso più di mille scudi in pochi mesi,
 se non conoscessi, che sono bene impiegati.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>In verità mi fate ridere. Che mai può avere di
 stravagante costei, che non sia comune all'altre donne?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Ha un tratto nobile, che incatena.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>È bella, parla bene, veste con pulizia, è di un
 ottimo gusto.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Tutte cose, che non vagliono un fico. Sono tre
 giorni, ch'io sono in questa locanda, e non mi ha fatto
 specie veruna.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Guardatela, e forse ci troverete del buono.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Eh, pazzia! L'ho veduta benissimo. È una donna come
 l'altre.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Non è come l'altre, ha qualche cosa di più. Io che
 ho praticate le prime dame, non ho trovato una donna, che
 sappia unire come questa, la gentilezza, e il decoro.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Cospetto di bacco! Io era avvezzo con pochi paoli,
 a battere a tante porte. Ho speso tanto con costei, e non ho
 potuto toccarle un dito.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Arte, arte sopraffina. Poveri gonzi! Le credete, eh?
 A me non la farebbe. Donne? Alla larga tutte quante elle
 sono.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Non siete mai stato innamorato?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Mai, né mai lo sarò. Hanno fatto il diavolo per
 darmi moglie, né mai l'ho voluta.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Ma siete unico della vostra casa; non volete
 pensare alla successione?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ci ho pensato più volte, ma quando considero, che
 per aver figliuoli mi converrebbe soffrire una donna, mi
 passa subito la volontà.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Che volete voi fare delle vostre ricchezze?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Godermi quel poco, che ho con i miei amici.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Bravo, Cavaliere, bravo; ci goderemo.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>E alle donne non volete dar nulla?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Niente affatto. A me non ne mangiano sicuramente.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ecco la nostra padrona. Guardatela, se non è
 adorabile.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Oh la bella cosa! Per me stimo più di lei quattro
 volte un bravo cane da caccia.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Se non la stimate voi, la stimo io.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ve la lascio, se fosse più bella di Venere.</p>
           </sp>
@@ -805,161 +833,161 @@ volte un bravo cane da caccia.</p>
           <stage>
             <emph>Mirandolina e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>M'inchino a questi cavalieri. Chi mi domanda di
 lor signori?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Io vi domando, ma non qui.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Dove mi vuole, Eccellenza?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Nella mia camera.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Nella sua camera? Se ha bisogno di qualche cosa,
 verrà il cameriere a servirla.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>(Che dite di quel contegno?).</p>
             <stage>(<emph>al Cavaliere</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Quello, che voi chiamate contegno, io lo chiamerei
 temerità, impertinenza).</p>
             <stage>(<emph>al Marchese</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Cara Mirandolina, io vi parlerò in pubblico, non vi
 darò l'incomodo di venire nella mia camera. Osservate questi
 orecchini. Vi piacciono?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Belli.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sono diamanti, sapete?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Oh, gli conosco. Me ne intendo anch'io dei
 diamanti.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>E sono al vostro comando.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Caro amico, voi li buttate via).</p>
             <stage>(<emph>piano al Conte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Perché mi vuol ella donare quegli orecchini?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Veramente sarebbe un gran regalo! Ella ne ha de'
 più belli al doppio.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Questi son legati alla moda. Vi prego riceverli per
 amor mio.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Oh che pazzo!).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>No, davvero, signore...</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Se non gli prendete, mi disgustate.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Non so che dire... mi preme tenermi amici gli
 avventori della mia locanda. Per non disgustare il signor
 Conte, gli prenderò.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Oh che forca!).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>(Che dite di quella prontezza di spirito?).</p>
             <stage>(<emph>al Cavaliere</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Bella prontezza! Ve gli mangia, e non vi ringrazia
 nemmeno).</p>
             <stage>(<emph>al Conte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Veramente, signor Conte, vi siete acquistato un
 gran merito. Regalare una donna in pubblico per vanità!
 Mirandolina, vi ho da parlare a quattr'occhi fra voi, e me;
 son cavaliere.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>(Che arsura! Non gliene cascano).</p>
             <stage>(<emph>da sé</emph>)</stage>
             <p>Se
 altro non mi comandano, io me n'anderò.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ehi! padrona. La biancheria, che mi avete dato, non
 mi gusta. Se non ne avete di meglio mi provvederò.</p>
             <stage>(<emph>con disprezzo</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Signore, ve ne sarà di meglio. Sarà servita, ma
 mi pare che la potrebbe chiedere con un poco di gentilezza.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Dove spendo il mio denaro, non ho bisogno di far
 complimenti.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Compatitelo. Egli è nemico capitale delle donne.</p>
             <stage>(<emph>a Mirandolina</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Eh, che non ho bisogno di essere da lei compatito.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Povere donne! che cosa le hanno fatto? Perché
 così crudele con noi, signor Cavaliere?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Basta così. Con me non vi prendete maggior
 confidenza. Cambiatemi la biancheria. La manderò a prender
@@ -972,34 +1000,34 @@ pel servitore. Amici vi sono schiavo.</p>
           <stage>
             <emph>Il Marchese, il Conte E Mirandolina</emph>
           </stage>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Che uomo salvatico! Non ho veduto il compagno.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Cara Mirandolina, tutti non conoscono il vostro
 merito.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>In verità, son così stomacata del suo mal
 procedere, che or ora lo licenzio a dirittura.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Sì; e se non vuol andarsene, ditelo a me, che lo
 farò partire immediatamente. Fate pur uso della mia
 protezione.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>E per il denaro, che aveste a perdere, io supplirò,
 e pagherò tutto. (Sentite, mandate via anche il Marchese,
 che pagherò io).</p>
             <stage>(<emph>piano a Mirandolina</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Grazie, signori miei, grazie. Ho tanto spirito,
 che basta per dire ad un forestiere, ch'io non lo voglio, e
@@ -1011,31 +1039,31 @@ circa all'utile, la mia locanda non ha mai camere in ozio.</p>
           <stage>
             <emph>Fabrizio e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Illustrissimo, c'è uno, che la domanda.</p>
             <stage>(<emph>al Conte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sai chi sia?</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Credo, ch'egli sia un legatore di gioie.
 (Mirandolina, giudizio; qui non istate bene).</p>
             <stage>(<emph>piano a Mirandolina, e parte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Oh sì, mi ha da mostrare un gioiello. Mirandolina,
 quegli orecchini, voglio che gli accompagniamo.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Eh no, signor Conte...</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Voi meritate molto, ed io i denari non gli stimo
 niente. Vado a vedere questo gioiello. Addio, Mirandolina;
@@ -1048,105 +1076,105 @@ signor Marchese, la riverisco.</p>
           <stage>
             <emph>Il Marchese e Mirandolina</emph>
           </stage>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>(Maledetto Conte! Con questi suoi denari mi
 ammazza).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>In verità il signor Conte s'incomoda troppo.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Costoro hanno quattro soldi, e gli spendono per
 vanità, per albagia. Io gli conosco, so il viver del mondo.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Eh il viver del mondo, lo so ancor io.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Pensano, che le donne della vostra sorta si
 vincano con i regali.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>I regali non fanno male allo stomaco.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Io crederei di farvi un'ingiuria, cercando di
 obbligarvi con i donativi.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Oh certamente il signor Marchese non mi ha
 ingiuriato mai.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>E tali ingiurie non ve le farò.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Lo credo sicurissimamente.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Ma, dove posso, comandatemi.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Bisognerebbe, ch'io sapessi, in che cosa può
 Vostra Eccellenza?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>In tutto. Provatemi.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Ma, verbigrazia, in che?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Per bacco! Avete un merito, che sorprende.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Troppe grazie, Eccellenza.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Ah! direi quasi uno sproposito. Maledirei quasi la
 mia Eccellenza.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Perché, signore?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Qualche volta mi auguro di essere nello stato del
 Conte.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Per ragione forse de' suoi danari?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Eh! Che denari! Non gli stimo un fico. Se fossi un
 conte ridicolo come lui...</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Che cosa farebbe?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Cospetto del diavolo... vi sposerei.</p>
             <stage>(<emph>parte</emph>)</stage>
@@ -1157,7 +1185,7 @@ conte ridicolo come lui...</p>
           <stage>
             <emph>Mirandolina sola</emph>
           </stage>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Uh, che mai ha detto! L'eccellentissimo signor
 marchese Arsura mi sposerebbe? E pure se mi volesse sposare,
@@ -1195,103 +1223,103 @@ la bella madre natura.</p>
           <stage>
             <emph>Fabrizio e detta.</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Ehi, padrona.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Che cosa c'è?</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Quel forestiere, che è alloggiato nella camera di
 mezzo grida della biancheria; dice che è ordinaria, e che
 non la vuole.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Lo so, lo so. Lo ha detto anche a me, e lo voglio
 servire.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Benissimo. Venitemi dunque a metter fuori la roba,
 che gliela possa portare.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Andate, andate, gliela porterò io.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Voi, gliela volete portare?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Sì, io.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Bisogna, che vi prema molto questo forestiere!</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Tutti mi premono. Badate a voi.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>(Già me n'avvedo. Non faremo niente. Ella mi
 lusinga; ma non faremo niente).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>(Povero sciocco! Ha delle pretensioni. Voglio
 tenerlo in speranza, perché mi serva con fedeltà).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Si è sempre costumato, che i forestieri gli serva
 io.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Voi con i forestieri siete un po' troppo ruvido.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>E voi siete un poco troppo gentile.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>So quel che fo, non ho bisogno di correttori.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Bene, bene. Provvedetevi di cameriere.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Perché, signor Fabrizio? è disgustato di me?</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Vi ricordate voi, che cosa ha detto a noi due
 vostro padre, prima ch'egli morisse?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Sì; quando mi vorrò maritare, mi ricorderò di
 quel che ha detto mio padre.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Ma io sono delicato di pelle, certe cose non le
 posso soffrire.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Ma che credi tu ch'io mi sia? Una frasca? Una
 civetta? Una pazza? Mi maraviglio di te. Che voglio fare io
@@ -1305,7 +1333,7 @@ di me. Son grata. Conosco il merito... Ma io non son
 conosciuta. Basta, Fabrizio, intendetemi, se potete.</p>
             <stage>(<emph>parte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Chi può intenderla è bravo davvero. Ora pare che la
 mi voglia, ora che la non mi voglia. Dice che non è una
@@ -1324,11 +1352,11 @@ Il meglio sarà sempre per me.</p>
           <stage>
             <emph>Il Cavaliere ed un Servitore</emph>
           </stage>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Illustrissimo, hanno portato questa lettera.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Portami la cioccolatta.</p>
             <stage>(<emph>Il Servitore parte</emph>)</stage>
@@ -1350,43 +1378,43 @@ quartana.</p>
           <stage>
             <emph>Il Marchese e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Amico, vi contentate, ch'io venga a stare un poco
 con voi?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Mi fate onore.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Almeno fra me, e voi possiamo trattarci con
 confidenza; ma quel somaro del Conte, non è degno di stare
 in conversazione con noi.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Caro Marchese compatitemi; rispettate gli altri, se
 volete essere rispettato voi.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Sapete il mio naturale. Io fo le cortesie a tutti,
 ma colui non lo posso soffrire.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Non lo potete soffrire, perché vi è rivale in amore?
 Vergogna! Un cavaliere della vostra sorta innamorarsi d'una
 locandiera! Un uomo savio, come siete voi, correr dietro a
 una donna!</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Cavaliere mio; costei mi ha stregato.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Oh! pazzie! debolezze! Che stregamenti! Che vuol
 dire, che le donne non mi stregheranno? Le loro
@@ -1394,16 +1422,16 @@ fattucchierie consistono nei loro vezzi, nelle loro
 lusinghe, e chi ne sta lontano, come fo io, non ci è
 pericolo, che si lasci ammaliare.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Basta! ci penso, e non ci penso; quel che mi dà
 fastidio, e che m'inquieta, è il mio fattor di campagna.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Vi ha fatto qualche porcheria?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Mi ha mancato di parola.</p>
           </sp>
@@ -1413,53 +1441,53 @@ fastidio, e che m'inquieta, è il mio fattor di campagna.</p>
           <stage>
             <emph>Il Servitore con una cioccolata, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Oh mi dispiace... Fanne subito un'altra.</p>
             <stage>(<emph>al Servitore</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>In casa per oggi non ce n'ho altra, illustrissimo.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Bisogna, che ne provveda. Se vi degnate di questa...</p>
             <stage>(<emph>al Marchese</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <stage>(<emph>Prende la cioccolata, e si mette a berla senza complimenti, seguitando poi a discorrere e bere, come segue</emph>)</stage>
             <p>Questo mio fattore come io vi diceva...</p>
             <stage>(<emph>beve</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Ed io resterò senza).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Mi aveva promesso mandarmi con l'ordinario...</p>
             <stage>(<emph>beve</emph>)</stage>
             <p>venti zecchini...</p>
             <stage>(<emph>beve</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Ora viene con una seconda stoccata).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>E non me gli ha mandati...</p>
             <stage>(<emph>beve</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Gli manderà un'altra volta.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Il punto sta... il punto sta...</p>
             <stage>(<emph>finisce di bere</emph>)</stage>
@@ -1468,69 +1496,69 @@ fastidio, e che m'inquieta, è il mio fattor di campagna.</p>
             <p>Il punto
 sta, che sono in un grande impegno, e non so come fare.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Otto giorni più, otto giorni meno...</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Ma voi, che siete cavaliere, sapete quel che vuol
 dire il mantener la parola. Sono in impegno; e... corpo di
 bacco! Darei delle pugna in Cielo.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Mi dispiace di vedervi scontento. (Se sapessi come
 uscirne con riputazione!).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Voi, avreste difficoltà per otto giorni, di farmi
 il piacere?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Caro Marchese, se potessi, vi servirei con il core;
 se ne avessi, ve li averei esibiti a dirittura. Ne aspetto,
 e non ne ho.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Non mi darete ad intendere d'esser senza denari?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Osservate. Ecco tutta la mia ricchezza. Non arrivano
 a due zecchini.</p>
             <stage>(<emph>mostra uno zecchino e varie monete</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Quello è uno zecchino d'oro.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Sì, è l'ultimo; non ne ho più.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Prestatemi quello, che vedrò intanto...</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ma io poi...</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Di che avete paura? Ve lo renderò.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Non so che dire; servitevi.</p>
             <stage>(<emph>gli dà lo zecchino</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Ho un affar di premura... amico; obbligato per
 ora: ci rivedremo a pranzo.</p>
@@ -1542,7 +1570,7 @@ ora: ci rivedremo a pranzo.</p>
           <stage>
             <emph>Il Cavaliere solo.</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Bravo! Il signor Marchese mi voleva frecciare a
 venti zecchini, e poi si è contentato di uno. Finalmente uno
@@ -1557,160 +1585,160 @@ chi sono. Son cavaliere. Oh garbatissimo cavaliere!</p>
           <stage>
             <emph>Mirandolina colla biancheria, e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Permette illustrissimo?</p>
             <stage>(<emph>entrando con qualche soggezione</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Che cosa volete?</p>
             <stage>(<emph>con asprezza</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Ecco qui della biancheria migliore.</p>
             <stage>(<emph>s'avanza un poco</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Bene. Mettetela lì.</p>
             <stage>(<emph>accenna il tavolino</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>La supplico almeno degnarsi vedere se è di suo
 genio.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Che roba è?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Le lenzuola sono di rensa.</p>
             <stage>(<emph>s'avanza ancor più</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Rensa?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Sì signore, di dieci paoli al braccio. Osservi.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Non pretendevo tanto. Bastavami qualche cosa meglio
 di quel che mi avete dato.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Questa biancheria l'ho fatta per personaggi di
 merito; per quelli, che la sanno conoscere; e in verità,
 illustrissimo, la do per esser lei, ad un altro non la
 darei.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>«Per esser lei!» Solito complimento.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Osservi il servizio di tavola.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Oh! Queste tele di Fiandra, quando si lavano perdono
 assai. Non vi è bisogno, che le insudiciate per me.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Per un cavaliere della sua qualità, non guardo a
 queste piccole cose. Di queste salviette, ne ho parecchie, e
 le serberò per V.S. illustrissima.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Non si può però negare, che costei non sia una
 donna obbligante).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>(Veramente ha una faccia burbera da non piacergli
 le donne).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Dare la biancheria al mio cameriere, o ponetela lì,
 in qualche luogo. Non vi è bisogno, che v'incomodiate per
 questo.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Oh io non m'incomodo mai, quando servo cavalieri
 di sì alto merito.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Bene, bene, non occorr'altro. (Costei vorrebbe
 adularmi. Donne? Tutte così).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>La metterò nell'arcova.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Sì, dove volete.</p>
             <stage>(<emph>con serietà</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>(Oh! vi è del duro. Ho paura di non far niente).</p>
             <stage>(<emph>da sé; va a riporre la biancheria</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(I gonzi sentono queste belle parole, credono a chi
 le dice, e cascano).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>A pranzo, che cosa comanda?</p>
             <stage>(<emph>ritornando senza la biancheria</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Mangerò quello, che vi sarà.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Vorrei pur sapere il suo genio. Se le piace una
 cosa più dell'altra, lo dica con libertà.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Se vorrò qualche cosa, lo dirò al cameriere.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Ma in queste cose gli uomini non hanno
 l'attenzione, e la pazienza, che abbiamo noi altre donne. Se
 le piacesse qualche intingoletto, qualche salsetta,
 favorisca di dirlo a me.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Vi ringrazio; ma né anche per questo verso, vi
 riuscirà di far con me quello che avete fatto col Conte, e
 col Marchese.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Che dice della debolezza di quei due cavalieri?
 Vengono alla locanda per alloggiare, e pretendono poi di
@@ -1720,19 +1748,19 @@ nostro interesse; se diamo loro delle buone parole, lo
 facciamo per tenerli a bottega, e poi, io principalmente
 quanto vedo che si lusingano, rido come una pazza.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Brava! Mi piace la vostra sincerità.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Oh! non ho altro di buono, che la sincerità.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ma però con chi vi fa la corte sapete fingere.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Io fingere? Guardimi il Cielo. Domandi un poco a
 quei due signori, che fanno gli spasimati per me, se ho mai
@@ -1746,130 +1774,130 @@ non son bella, ma ho avuto delle buone occasioni; eppure non
 ho mai voluto maritarmi, perché stimo, infinitamente la mia
 libertà.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Oh sì, la libertà è un gran tesoro.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>E tanti la perdono scioccamente.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>So ben io quel che faccio. Alla larga.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Ha moglie V.S. illustrissima?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Il Cielo me ne liberi. Non voglio donne.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Bravissimo. Si conservi sempre così. Le donne,
 signore... Basta a me non tocca a dirne male.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Voi siete per altro la prima donna, ch'io senta
 parlar così.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Le dirò: noi altre locandiere, vediamo, e
 sentiamo delle cose assai; e in verità compatisco quegli
 uomini, che hanno paura del nostro sesso.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(È curiosa costei).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Con permissione di V.S. illustrissima.</p>
             <stage>(<emph>finge voler partire</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Avete premura di partire?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Non vorrei esserle importuna.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>No, mi fate piacere; mi divertite.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Vede, signore? Così fo con gli altri. Mi
 trattengo qualche momento; sono piuttosto allegra, dico
 delle barzellette per divertirli, ed essi subito credono...
 Se la m'intende, e' mi fanno i cascamorti.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Questo accade, perché avete buona maniera.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Troppa bontà, illustrissimo.</p>
             <stage>(<emph>con una riverenza</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ed essi s'innamorano.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Guardi, che debolezza! Innamorarsi subito di una
 donna!</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Questa io non l'ho mai potuta capire.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Bella fortezza! Bella virilità! Avvilirsi subito
 per due smorfiette.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Debolezze! Miserie umane!</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Questo è il vero pensare degli uomini. Signor
 Cavaliere, mi porga la mano.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Perché volete, ch'io vi porga la mano?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Favorisca; si degni; osservi; sono pulita.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ecco la mano.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Questa è la prima volta, che ho l'onore d'aver
 per la mano un uomo, che pensa veramente da uomo.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Via, basta così.</p>
             <stage>(<emph>ritira la mano</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Ecco. Se io avessi preso per la mano uno di que'
 due signori sguaiati, averebbe tosto creduto, ch'io
@@ -1882,11 +1910,11 @@ servirla, mi comandi con autorità, e avrò per lei
 quell'attenzione, che non ho mai avuto per alcuna persona di
 questo mondo.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Per qual motivo avete tanta parzialità per me?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Perché, oltre il suo merito, oltre la sua
 condizione, sono almeno sicura, che con lei posso trattare
@@ -1895,53 +1923,53 @@ delle mie attenzioni, e che mi tenga in qualità di serva,
 senza tormentarmi con pretensioni ridicole, con caricature
 affettate.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Che diavolo ha costei di stravagante, ch'io non
 capisco!).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>(Il satiro si anderà a poco a poco
 addomesticando).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Orsù, se avete da badare alle cose vostre, non
 restate per me.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Sì signore, vado ad attendere alle faccende di
 casa. Queste sono i miei amori, i miei passatempi. Se
 comanderà qualche cosa, manderò il cameriere.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Bene... Se qualche volta verrete anche voi, vi
 vederò volentieri.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Io veramente non vado mai nelle camere dei
 forestieri, ma da lei ci verrò qualche volta.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Da me... Perché?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Perché, illustrissimo signore, ella mi piace
 assaissimo.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Vi piaccio io?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Mi piace, perché non è effemminato, perché non è
 di quelli che s'innamorano. (Mi caschi il naso se avanti
@@ -1954,7 +1982,7 @@ domani non l'innamoro).</p>
           <stage>
             <emph>Il Cavaliere solo.</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Eh! So io quel che fo. Colle donne? Alla larga.
 Costei sarebbe una di quelle, che potrebbero farmi cascare
@@ -1974,39 +2002,39 @@ donne.</p>
           <stage>
             <emph>Ortensia, Dejanira, Fabrizio</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Che restino servite qui, illustrissime. Osservino
 quest'altra camera. Quella per dormire, e questa per
 mangiare, per ricevere, per servirsene come comandano.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Va bene, va bene. Siete voi padrone, o cameriere?</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Cameriere, ai comandi di V.S. illustrissima.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>(Ci dà delle illustrissime).</p>
             <stage>(<emph>piano a Ortensia, ridendo</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>(Bisogna secondare il lazzo). Cameriere?</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Illustrissima.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Dite al padrone, che venga qui, voglio parlar con
 lui per il trattamento.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Verrà la padrona, la servo subito. (Chi diamine
 saranno queste due signore così sole? All'aria, all'abito
@@ -2019,60 +2047,60 @@ paiono dame).</p>
           <stage>
             <emph>Dejanira e Ortensia</emph>
           </stage>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Ci dà dell'illustrissime. Ci ha creduto due dame.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Bene. Così ci tratterà meglio.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Ma ci farà pagare di più.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Eh, circa i conti, averà da fare con me. Sono degli
 anni assai, che cammino il mondo.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Non vorrei, che con questi titoli, entrassimo in
 qualche impegno.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Cara amica siete di poco spirito. Due commedianti,
 avezze a far sulla scena da contesse, da marchese, e da
 principesse, avranno difficoltà a sostenere un carattere
 sopra di una locanda?</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Verranno i nostri compagni, e subito ci
 sbianchiranno.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Per oggi non possono arrivare a Firenze. Da Pisa a
 qui in navicello, vi vogliono almeno tre giorni.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Guardate che bestialità! Venire in navicello!</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Per mancanza di lugagni. È assai, che siamo venute
 noi in calesse.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>È stata buona quella recita di più, che abbiamo
 fatto.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Sì, ma se non istavo io alla porta non si faceva
 niente.</p>
@@ -2083,70 +2111,70 @@ niente.</p>
           <stage>
             <emph>Fabrizio e dette.</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>La padrona or ora sarà a servirle.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Bene.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Ed io le supplico a comandarmi. Ho servito altre
 dame; mi darò l'onor di servir con tutta attenzione anche le
 signorie loro illustrissime.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Occorrendo, mi varrò di voi.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>(Ortensia queste parti le fa benissimo).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Intanto le supplico, illustrissime signore,
 favorirmi il loro riverito nome per la consegna.</p>
             <stage>(<emph>tira fuori un calamaio ed un libriccino</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>(Ora viene il buono).</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Perché ho da dar il mio nome?</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Noi altri locandieri, siamo obbligati a dar il
 nome, il casato, la patria, e la condizione di tutti i
 passeggieri, che alloggiano alla nostra locanda. E se non lo
 facessimo, meschini noi.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>(Amica i titoli sono finiti).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Molti daranno anche il nome finto.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>In quanto a questo poi, noi altri scriviamo il
 nome, che ci dettano, e non cerchiamo di più.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Scrivete. La baronessa Ortensia del Poggio,
 palermitana.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>(Siciliana? Sangue caldo).</p>
             <stage>(<emph>scrivendo</emph>)</stage>
@@ -2154,62 +2182,62 @@ palermitana.</p>
 illustrissima?</p>
             <stage>(<emph>a Dejanira</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Ed io... (Non so che mi dire).</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Via, contessa Dejanira, dategli il vostro nome.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>La supplico.</p>
             <stage>(<emph>a Dejanira</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Non l'avete sentito?</p>
             <stage>(<emph>a Fabrizio</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>L'illustrissima signora contessa Dejanira....</p>
             <stage>(<emph>scrivendo</emph>)</stage>
             <p>Il cognome?</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Anche il cognome?</p>
             <stage>(<emph>a Fabrizio</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Sì, dal Sole, romana.</p>
             <stage>(<emph>a Fabrizio</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Non occorr'altro. Perdonino l'incomodo. Ora verrà
 la padrona. (L'ho io detto, che erano due dame? Spero, che
 farò de' buoni negozi. Mancie non ne mancheranno).</p>
             <stage>(<emph>parte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Serva umilissima della signora Baronessa.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Contessa a voi m'inchino.</p>
             <stage>(<emph>si burlano vicendevolmente</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Qual fortuna mi offre la felicissima congiuntura
 di rassegnarvi il mio profondo rispetto?</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Dalla fontana del vostro cuore, scaturir non
 possono, che torrenti di grazie.</p>
@@ -2220,242 +2248,242 @@ possono, che torrenti di grazie.</p>
           <stage>
             <emph>Mirandolina e dette.</emph>
           </stage>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Madama, voi mi adulate.</p>
             <stage>(<emph>ad Ortensia, con caricatura</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Contessa, al vostro merito si converrebbe assai più.</p>
             <stage>(<emph>fa lo stesso</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>(Oh, che dame cerimoniose!).</p>
             <stage>(<emph>da sé, in disparte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>(Oh quanto mi vien da ridere!).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Zitto; è qui la padrona.</p>
             <stage>(<emph>piano a Dejanira</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>M'inchino a queste dame.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Buon giorno, quella giovane.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Signora padrona, vi riverisco.</p>
             <stage>(<emph>a Mirandolina</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Ehi!</p>
             <stage>(<emph>fa cenno a Dejanira, che si sostenga</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Permetta ch'io le baci la mano.</p>
             <stage>(<emph>ad Ortensia</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Siete obbligante.</p>
             <stage>(<emph>le dà la mano</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <stage>(<emph>Ride da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Anche ella, illustrissima.</p>
             <stage>(<emph>chiede la mano a Dejanira</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Eh, non importa...</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Via, gradite le finezze di questa giovane. Datele la
 mano.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>La supplico.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Tenete.</p>
             <stage>(<emph>le dà la mono, si volta, e ride</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Ride, illustrissima? Di che?</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Che cara Contessa! Ride ancora di me. Ho detto uno
 sproposito, che l'ha fatta ridere.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>(Io giuocherei, che non son dame. Se fossero
 dame, non sarebbero sole).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Circa il trattamento, converrà poi discorrere.</p>
             <stage>(<emph>a Mirandolina</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Ma! Sono sole? Non hanno cavalieri, non hanno
 servitori, non hanno nessuno?</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Il Barone mio marito...</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <stage>(<emph>Ride forte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Perché ride, signora?</p>
             <stage>(<emph>a Dejanira</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Via, perché ridete?</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Rido del Barone di vostro marito.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Sì, è un cavaliere giocoso; dice sempre delle
 barzellette; verrà quanto prima col conte Orazio, marito
 della Contessina.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <stage>(<emph>Fa forza per trattenersi da ridere</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>La fa ridere anche il signor Conte?</p>
             <stage>(<emph>a Dejanira</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Ma via, Contessina, tenetevi un poco nel vostro
 decoro.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Signore mie, favoriscano in grazia. Siamo sole,
 nessuno ci sente. Questa contea, questa baronia, sarebbe
 mai...</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Che cosa vorreste voi dire? Mettereste in dubbio la
 nostra nobiltà?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Perdoni, illustrissima, non si riscaldi, perché
 farà ridere la signora Contessa.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Eh via, che serve?</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Contessa, Contessa!</p>
             <stage>(<emph>minacciandola</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Io so, che cosa voleva dire, illustrissima.</p>
             <stage>(<emph>a Dejanira</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Se l'indovinate, vi stimo assai.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Voleva dire: Che serve, che fingiamo d'esser due
 dame, se siamo due pedine? Ah! non è vero?</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>E che sì, che ci conoscete?</p>
             <stage>(<emph>a Mirandolina</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Che brava commediante! Non è buona da sostenere un
 carattere.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Fuori di scena io non so fingere.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Brava, signora Baronessa; mi piace il di lei
 spirito. Lodo la sua franchezza.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Qualche volta mi prendo un poco di spasso.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Ed io amo infinitamente le persone di spirito.
 Servitevi pure nella mia locanda, che siete padrone; ma vi
 prego bensì, se mi capitassero persone di rango, cedermi
 quest'appartamento, ch'io vi darò dei camerini assai comodi.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Sì, volentieri.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Ma io, quando spendo il mio denaro, intendo volere
 esser servita come una dama, e in questo appartamento ci
 sono, e non me ne anderò.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Via, signora Baronessa, sia buona... Oh! Ecco un
 cavaliere, che è alloggiato in questa locanda. Quando vede
 donne, sempre si caccia avanti.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>È ricco?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Io non so i fatti suoi.</p>
           </sp>
@@ -2465,172 +2493,172 @@ donne, sempre si caccia avanti.</p>
           <stage>
             <emph>Il Marchese e dette.</emph>
           </stage>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>È permesso? Si può entrare?</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Per me è padrone.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Servo di lor signore.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Serva umilissima.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>La riverisco divotamente.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Sono forestiere?</p>
             <stage>(<emph>a Mirandolina</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Eccellenza sì. Sono venute ad onorare la mia
 locanda.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>(È un'Eccellenza! Capperi!).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>(Già Ortensia lo vorrà per sé).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>E chi sono queste signore?</p>
             <stage>(<emph>a Mirandolina</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Questa è la baronessa Ortensia del Poggio; e
 questa la contessa Dejanira dal Sole.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Oh compitissime dame!</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>E ella, chi è, signore?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Io sono il marchese di Forlipopoli.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>(La locandiera vuol seguitare a far la commedia).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Godo aver l'onore di conoscere un cavaliere così
 compito.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Se vi potessi servire, comandatemi. Ho piacere che
 siate venute ad alloggiare in questa locanda. Troverete una
 padrona di garbo.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Questo cavaliere è pieno di bontà. Mi onora della
 sua protezione.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Sì, certamente. Io la proteggo; e proteggo tutti
 quelli, che vengono nella sua locanda; e se vi occorre
 nulla, comandate.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Occorrendo, mi prevarrò delle sue finezze.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Anche voi, signora Contessa, fate capitale di me.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Potrò ben chiamarmi felice, se avrò l'alto onore
 di essere annoverata nel ruolo delle sue umilissime serve.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>(Ha detto un concetto da commedia).</p>
             <stage>(<emph>ad Ortensia</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>(Il titolo di contessa l'ha posta in soggezione).</p>
             <stage>(<emph>a Mirandolina</emph>)</stage>
             <stage>(<emph>Il Marchese tira fuori di tasca un bel fazzoletto di seta, lo spiega, e finge volersi asciugar la fronte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Un gran fazzoletto, signor Marchese!</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Ah! Che ne dite? È bello? Sono di buon gusto io?</p>
             <stage>(<emph>a Mirandolina</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Certamente è di ottimo gusto.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Ne avete più veduti di così belli?</p>
             <stage>(<emph>ad Ortensia</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>È superbo. Non ho veduto il compagno. (Se me lo
 donasse, lo prenderei).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Questo viene da Londra.</p>
             <stage>(<emph>a Dejanira</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>È bello, mi piace assai.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Son di buon gusto io?</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>(E non dice a' vostri comandi).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>M'impegno, che il Conte non sa spendere. Getta via
 il denaro, e non compra mai una galanteria di buon gusto.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Il signor Marchese conosce, distingue, sa, vede,
 intende.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <stage>(<emph>Piega il fazzoletto con attenzione</emph>)</stage>
             <p>Bisogna
@@ -2638,132 +2666,132 @@ piegarlo bene, acciò non si guasti. Questa sorta di roba,
 bisogna custodirla con attenzione. Tenete.</p>
             <stage>(<emph>lo presenta a Mirandolina</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Vuole, ch'io lo faccia mettere nella sua camera?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>No. Mettetelo nella vostra.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Perché nella mia?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Perché... ve lo dono.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Oh, Eccellenza, perdoni...</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Tant'è. Ve lo dono.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Ma io non voglio...</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Non mi fate andar in collera.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Oh, in quanto a questo poi; il signor Marchese lo
 sa; io non voglio disgustar nessuno. Acciò non vada in
 collera, lo prenderò.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>(Oh che bel lazzo!).</p>
             <stage>(<emph>ad Ortensia</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>(E poi dicono delle commedianti!).</p>
             <stage>(<emph>a Dejanira</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Ah! Che dite? Un fazzoletto di quella sorta, l'ho
 donato alla mia padrona di casa.</p>
             <stage>(<emph>ad Ortensia</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>È un cavaliere generoso.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Sempre così.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>(Questo è il primo regalo, che mi ha fatto; e non
 so come abbia avuto questo fazzoletto).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Signor Marchese, se ne trovano di quei fazzoletti
 in Firenze? Avrei volontà d'averne uno compagno.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Compagno di quello sarà difficile. Ma vedremo.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>(Brava la signora Contessina).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Signor Marchese, voi che siete pratico della città,
 fatemi il piacere di mandarmi un bravo calzolaro, perché ho
 bisogno di scarpe.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Sì, vi manderò il mio.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>(Tutte alla vita; ma non sanno, che non ve n'è
 uno per la rabbia).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Caro signor Marchese favorirà tenerci un poco di
 compagnia.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Favorirà a pranzo con noi.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Sì, volentieri. (Ehi Mirandolina, non abbiate
 gelosia son vostro, già lo sapete).</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>(S'accomodi pure; ho piacere che si diverta).</p>
             <stage>(<emph>al Marchese</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Voi sarete la nostra conversazione.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Non conosciamo nessuno. Non abbiamo altri che voi.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Oh care le mie damine! Vi servirò di cuore.</p>
           </sp>
@@ -2773,114 +2801,114 @@ gelosia son vostro, già lo sapete).</p>
           <stage>
             <emph>Il Conte e detti</emph>
           </stage>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Mirandolina, io cercava di voi.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Son qui con queste dame.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Dame? M'inchino umilmente.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Serva divota. (Questo è un guasco più badial di
 quell'altro).</p>
             <stage>(<emph>piano a Dejanira</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>(Ma io non sono buona per miccheggiare).</p>
             <stage>(<emph>piano ad Ortensia</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>(Ehi! Mostrare al Conte il fazzoletto).</p>
             <stage>(<emph>piano a Mirandolina</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Osservi, signor Conte, il bel regalo che mi ha
 fatto il signor Marchese.</p>
             <stage>(<emph>mostra il fazzoletto al Conte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Oh me ne rallegro! Bravo, signor Marchese.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Eh niente, niente. Bagatelle. Riponetelo via; non
 voglio che lo dichiate. Quel che fo non s'ha da sapere.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>(Non s'ha da sapere, e me lo fa mostrare. La
 superbia contrasta con la povertà).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Con licenza di queste dame, vorrei dirvi una
 parola.</p>
             <stage>(<emph>a Mirandolina</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>S'accomodi con libertà.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Quel fazzoletto in tasca lo manderete a male.</p>
             <stage>(<emph>a Mirandolina</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Eh lo riporrò nella bambagia, perché non si
 ammacchi!</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Osservate questo piccolo gioiello di diamanti.</p>
             <stage>(<emph>a Mirandolina</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Bello assai.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>È compagno degli orecchini, che vi ho donato.</p>
             <stage>(<emph>Ortensia e Dejanira osservano, e parlano piano fra loro</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Certo, è compagno, ma è ancora più bello.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>(Sia maledetto il Conte, i suoi diamanti, i suoi
 denari, e il suo diavolo, che se lo porti).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ora, perché abbiate il fornimento compagno; ecco
 ch'io vi dono il gioiello.</p>
             <stage>(<emph>a Mirandolina</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Non lo prendo assolutamente.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Non mi farete questa mala creanza.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Oh! delle male creanze non ne faccio mai. Per non
 disgustarla, lo prenderò.</p>
@@ -2888,160 +2916,160 @@ disgustarla, lo prenderò.</p>
             <p> Ah! Che ne dice
 signor Marchese? Questo gioiello non è galante?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Nel suo genere il fazzoletto è più di buon gusto.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sì, ma da genere, a genere vi è una bella distanza.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Bella cosa! Vantarsi in pubblico di una grande
 spesa.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sì, sì, voi fate i vostri regali in segreto.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>(Posso ben dire con verità questa volta, che fra
 due litiganti il terzo gode).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>E così, damine mie sarò a pranzo con voi.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Quest'altro signore chi è?</p>
             <stage>(<emph>al Conte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sono il conte d'Albafiorita per obbedirvi.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Capperi! È una famiglia illustre, io la conosco.</p>
             <stage>(<emph>anch'ella s'accosta al Conte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sono a' vostri comandi.</p>
             <stage>(<emph>a Dejanira</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>È qui alloggiato?</p>
             <stage>(<emph>al Conte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sì, signora.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Si trattiene molto?</p>
             <stage>(<emph>al Conte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Credo di sì.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Signore mie, sarete stanche di stare in piedi,
 volete ch'io vi serva nella vostra camera?</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Obbligatissima.</p>
             <stage>(<emph>con disprezzo</emph>)</stage>
             <p> Di che paese è
 signor Conte?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Napolitano.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Oh! Siamo mezzi patriotti. Io sono palermitana.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Io son romana; ma sono stata a Napoli, e appunto
 per un mio interesse desiderava parlare con un cavaliere
 napolitano.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Vi servirò, signore. Siete sole? Non avete uomini?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Ci sono io, signore, e non hanno bisogno di voi.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Siamo sole, signor Conte. Poi vi diremo il perché.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Mirandolina?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Signore?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Fate preparare nella mia camera per tre. Vi
 degnerete di favorirmi?</p>
             <stage>(<emph>ad Ortensia e Dejanira</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Riceveremo le vostre finezze.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Ma io sono stato invitato da queste dame.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Esse sono padrone di servirsi, come comandano, ma
 alla mia piccola tavola in più di tre non ci si sta.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Vorrei vedere anche questa...</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Andiamo, andiamo, signor Conte. Il signor Marchese
 ci favorirà un'altra volta.</p>
             <stage>(<emph>parte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Signor Marchese, se trova il fazzoletto, mi
 raccomando.</p>
             <stage>(<emph>parte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Conte, Conte, voi me la pagherete.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Di che vi lagnate?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Son chi sono, e non si tratta così. Basta... Colei
 vorrebbe un fazzoletto? Un fazzoletto di quella sorta? Non
@@ -3050,21 +3078,21 @@ sorta non se ne trovano. Dei diamanti se ne trovano, ma dei
 fazzoletti di quella sorta non se ne trovano.</p>
             <stage>(<emph>parte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>(Oh che bel pazzo!).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Cara Mirandolina, avrete voi dispiacere, ch'io
 serva queste due dame?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Niente affatto, signore.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Lo faccio per voi. Lo faccio per accrescer utile,
 ed avventori alla vostra locanda, per altro io son vostro, è
@@ -3078,7 +3106,7 @@ quali disponetene liberamente, che io vi faccio padrona.</p>
           <stage>
             <emph>Mirandolina sola</emph>
           </stage>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Con tutte le sue ricchezze, con tutti li suoi
 regali, non arriverà mai ad innamorarmi; e molto meno lo
@@ -3111,85 +3139,85 @@ pranzo e sedie.</stage>
 Cavaliere passeggia con un libro. Fabrizio mette la zuppa in
 tavola.</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Dite al vostro padrone, se vuol restare servito,
 che la zuppa è in tavola.</p>
             <stage>(<emph>al Servitore</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Glielo potete dire anche voi.</p>
             <stage>(<emph>a Fabrizio</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>È tanto stravagante, che non gli parlo niente
 volentieri.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Eppure non è cattivo. Non può veder le donne, per
 altro cogli uomini è dolcissimo.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>(Non può veder le donne? Povero sciocco! Non
 conosce il buono).</p>
             <stage>(<emph>da sé, parte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Illustrissimo se comanda, è in tavola.</p>
             <stage>(<emph>Il Cavaliere mette giù il libro, e va a sedere a tavola</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Questa mattina parmi che si pranzi prima del solito.</p>
             <stage>(<emph>al Servitore, mangiando</emph>)</stage>
             <stage>(<emph>Il Servitore dietro la sedia del Cavaliere, col tondo sotto il braccio</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Questa camera è stata servita prima di tutte. Il
 signor conte d'Albafiorita strepitava, che voleva essere
 servito il primo, ma la padrona ha voluto, che si desse in
 tavola prima a V.S. illustrissima.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Sono obbligato a costei per l'attenzione che mi
 dimostra.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>È una assai compita donna, illustrissimo. In tanto
 mondo, che ho veduto, non ho trovato una locandiera più
 garbata di questa.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ti piace eh?</p>
             <stage>(<emph>voltandosi un poco indietro</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Se non fosse per far torto al mio padrone, vorrei
 venire a stare con Mirandolina per cameriere.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Povero mammalucco! Che cosa vorresti, ch'ella
 facesse di te?</p>
             <stage>(<emph>gli dà il tondo, ed egli lo muta</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Una donna di questa sorta, la vorrei servir come un
 cagnolino.</p>
             <stage>(<emph>va per un piatto</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Per bacco! Costei incanta tutti. Sarebbe da ridere,
 che incantasse anche me! Orsù domani me ne vado a Livorno.
@@ -3203,43 +3231,43 @@ vuol altro.</p>
           <stage>
             <emph>Il Servitore col lesso ed un altro piatto, e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Ha detto la padrona, che se non le piacesse il
 pollastro, le manderà un piccione.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Mi piace tutto. E questo che cos'è?</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Dice la padrona, ch'io le sappia dire se a V.S.
 illustrissima piace questa salsa, che l'ha fatta ella colle
 sue mani.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Costei mi obbliga sempre più.</p>
             <stage>(<emph>l'assaggia</emph>)</stage>
             <p> È
 preziosa. Dille che mi piace, che la ringrazio.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Glielo dirò, illustrissimo.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Vaglielo a dir subito.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Subito. (Oh che prodigio! Manda un complimento a
 una donna!).</p>
             <stage>(<emph>da sé, parte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>È una salsa squisita. Non ho sentita la meglio.</p>
             <stage>(<emph>va mangiando</emph>)</stage>
@@ -3256,38 +3284,38 @@ finte, bugiarde, lusinghiere. Ma quella bella sincerità...</p>
           <stage>
             <emph>Il Servitore e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Ringrazia V.S. illustrissima della bontà, che ha
 di aggradire le sue debolezze.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Bravo, signor cerimoniere, bravo.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Ora sta facendo colle sue mani un altro piatto; ma
 non so dire, che cosa sia.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Sta facendo?</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Sì signore.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Dammi da bere.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>La servo.</p>
             <stage>(<emph>va a prendere da bere</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Orsù, con costei bisognerà corrispondere con
 generosità. È troppo compita; bisogna pagare il doppio.
@@ -3296,50 +3324,50 @@ Trattarla bene, ma andar via presto.</p>
             <p> Il Conte è andato a pranzo?</p>
             <stage>(<emph>beve</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Illustrissimo sì, in questo momento. Oggi fa
 trattamento. Ha due dame a tavola con lui.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Due dame? Chi sono?</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Sono arrivate a questa locanda, poche ore sono. Non
 so chi sieno.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Le conosceva il Conte?</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Credo di no; ma appena le ha vedute, le ha invitate
 a pranzo seco.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Che debolezza! Appena vede due donne subito
 s'attacca. Ed esse accettano. E sa il Cielo chi sono; ma
 sieno quali esser vogliono, sono donne, e tanto basta. Il
 Conte si rovinerà certamente. Dimmi; il Marchese è a tavola?</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>È uscito di casa, e non si è ancora veduto.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>In tavola.</p>
             <stage>(<emph>fa mutare il tondo</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>La servo.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>A tavola con due donne! Oh che bella compagnia!
 Colle loro smorfie, mi farebbero passar l'appetito.</p>
@@ -3349,313 +3377,313 @@ Colle loro smorfie, mi farebbero passar l'appetito.</p>
           <head>Scena quarta</head>
           <stage><emph>Mirandolina con un tondo in mano, ed il Servitore, e
 detto</emph>.</stage>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>È permesso?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Chi è di là?</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Comandi.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Leva là quel tondo di mano.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Perdoni. Lasci, ch'io abbia l'onore di metterlo
 in tavola colle mie mani.</p>
             <stage>(<emph>mette in tavola la vivanda</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Questo non è offizio vostro.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Oh signore, chi son io? Una qualche signora? Sono
 una serva di chi favorisce venire alla mia locanda.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Che umiltà!).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>In verità, non avrei difficoltà di servire in
 tavola tutti, ma non lo faccio per certi riguardi: non so
 s'ella mi capisca. Da lei vengo senza scrupoli, con
 franchezza.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Vi ringrazio. Che vivanda è questa?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Egli è un intingoletto fatto colle mie mani.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Sarà buono. Quando lo avete fatto voi, sarà buono.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Oh! troppa bontà, signore. Io non so far niente
 di bene. Ma bramerei saper fare, per dar nel genio ad un
 cavalier sì compito.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Domani a Livorno).</p>
             <stage>(<emph>da sé</emph>)</stage>
             <p> Se avete che fare, non
 istate a disagio per me.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Niente, signore; la casa è ben provveduta di
 cuochi, e servitori. Avrei piacer di sentire, se quel piatto
 le dà nel genio.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Volentieri, subito.</p>
             <stage>(<emph>lo assaggia</emph>)</stage>
             <p> Buono, prezioso.
 Oh che sapore! Non conosco che cosa sia.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Eh, io signore, ho de' segreti particolari.
 Queste mani sanno far delle belle cose!</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Dammi da bere.</p>
             <stage>(<emph>al Servitore, con qualche passione</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Dietro questo piatto, signore, bisogna beverlo
 buono.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Dammi del vino di Borgogna.</p>
             <stage>(<emph>al Servitore</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Bravissimo. Il vino di Borgogna è prezioso.
 Secondo me per pasteggiare è il miglior vino, che si possa
 bere.</p>
             <stage>(<emph>Il Servitore presenta la bottiglia in tavola, con un bicchiere</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Voi siete di buon gusto in tutto.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>In verità, che poche volte m'inganno.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Eppure questa volta, voi v'ingannate.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>In che, signore?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>In credere, ch'io meriti d'essere da voi distinto.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Eh, signor Cavaliere...</p>
             <stage>(<emph>sospirando</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Che cosa c'è? Che cosa sono questi sospiri?</p>
             <stage>(<emph>alterato</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Le dirò: delle attenzioni ne uso a tutti, e mi
 rattristo, quando penso, che non vi sono, che ingrati.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Io non vi sarò ingrato.</p>
             <stage>(<emph>con placidezza</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Con lei non pretendo di acquistar merito, facendo
 unicamente il mio dovere.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>No, no, conosco benissimo... Non sono cotanto rozzo,
 quanto voi mi credete. Di me non averete a dolervi.</p>
             <stage>(<emph>versa il vino nel bicchiere</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Ma... signore... io non l'intendo.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Alla vostra salute.</p>
             <stage>(<emph>beve</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Obbligatissima; mi onora troppo.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Questo vino è prezioso.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Il Borgogna è la mia passione.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Se volete, siete padrona.</p>
             <stage>(<emph>le offerisce il vino</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Oh! Grazie, signore.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Avete pranzato?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Illustrissimo sì.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ne volete un bicchierino?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Io non merito queste grazie.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Davvero, ve lo do volentieri.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Non so che dire. Riceverò le sue finezze.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Porta un bicchiere.</p>
             <stage>(<emph>al Servitore</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>No, no, se mi permette; prenderò questo.</p>
             <stage>(<emph>prende il bicchiere del Cavaliere</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Oibò. Me ne sono servito io.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Beverò le sue bellezze.</p>
             <stage>(<emph>ridendo</emph>)</stage>
             <stage>(<emph>Il Servitore mette l'altro bicchiere nella sottocoppa</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Eh galeotta!</p>
             <stage>(<emph>versa il vino</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Ma: è qualche tempo che ho mangiato; ho timore,
 che mi faccia male.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Non vi è pericolo.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Se mi favorisse un bocconcino di pane.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Volentieri. Tenete.</p>
             <stage>(<emph>le dà un pezzo di pane</emph>)</stage>
             <stage>(<emph>Mirandolina col bicchiere in una mano, e nell'altra il pane, mostra di stare in disagio, e non saper come fare la zuppa</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Voi state in disagio! Volete sedere?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Oh! Non son degna di tanto, signore.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Via, via, siamo soli. Portale una sedia.</p>
             <stage>(<emph>al Servitore</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>(Il mio padrone vuol morire; non ha mai fatto
 altrettanto).</p>
             <stage>(<emph>da sé; va a prendere la sedia</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Se lo sapessero il signor Conte, ed il signor
 Marchese, povera me!</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Perché?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Cento volte mi hanno voluto obbligare a bere
 qualche cosa, o a mangiare, e non ho mai voluto farlo.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Via, accomodatevi.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Per obbedirla.</p>
             <stage>(<emph>siede, e fa la zuppa nel vino</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Senti.</p>
             <stage>(<emph>al Servitore, piano</emph>)</stage>
             <p> (Non lo dire a
 nessuno, che la padrona sia stata a sedere alla mia tavola).</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>(Non dubiti).</p>
             <stage>(<emph>piano</emph>)</stage>
@@ -3663,105 +3691,105 @@ nessuno, che la padrona sia stata a sedere alla mia tavola).</p>
 sorprende).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Alla salute di tutto quello, che dà piacere al
 signor Cavaliere.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Vi ringrazio, padroncina garbata.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Di questo brindisi alle donne non ne tocca.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>No? perché?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Perché so, che le donne non le può vedere.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>È vero, non le ho mai potute vedere.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Si conservi sempre così.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Non vorrei...</p>
             <stage>(<emph>si guarda dal Servitore</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Che cosa, signore?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Sentite.</p>
             <stage>(<emph>le parla nell'orecchio</emph>)</stage>
             <p> (Non vorrei, che
 voi mi faceste mutar natura).</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Io, signore? Come?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Va' via.</p>
             <stage>(<emph>al Servitore</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Comanda in tavola?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Fammi cucinare due ova, e quando sono cotte,
 portale.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Come le comanda le ova?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Come vuoi, spicciati.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>(Ho inteso. il padrone si va riscaldando).</p>
             <stage>(<emph>da sé, parte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Mirandolina, voi siete una garbata giovine.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Oh signore, mi burla.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Sentite. Voglio dirvi una cosa vera, verissima, che
 ritornerà in vostra gloria.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>La sentirò volentieri.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Voi siete la prima donna di questo mondo, con cui ho
 avuto la sofferenza di trattar con piacere.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Le dirò, signor Cavaliere; non già ch'io meriti
 niente; ma alle volte si danno questi sangui, che
@@ -3769,12 +3797,12 @@ s'incontrano. Questa simpatia, questo genio si dà anche fra
 persone, che non si conoscono. Anch'io provo per lei quello,
 che non ho sentito per alcun altro.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ho paura, che voi mi vogliate far perdere la mia
 quiete.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Oh via, signor Cavaliere, se è un uomo savio,
 operi da suo pari. Non dia nelle debolezze degli altri. In
@@ -3785,56 +3813,56 @@ ha in odio le donne; e che forse, forse, per provarmi, e poi
 burlarsi di me, viene ora con un discorso nuovo a tentarmi;
 signor Cavaliere, mi favorisca un altro poco di Borgogna.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Eh! Basta...</p>
             <stage>(<emph>versa il vino in un bicchiere</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>(Sta lì, lì per cadere).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Tenete.</p>
             <stage>(<emph>le dà il bicchiere col vino</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Obbligatissima. Ma ella non beve?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Sì, beverò. (Sarebbe meglio, ch'io mi ubriacassi. Un
 diavolo scaccerebbe l'altro).</p>
             <stage>(<emph>da sé, versa il vino nel suo bicchiere</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Signor Cavaliere.</p>
             <stage>(<emph>con vezzo</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Che c'è?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Tocchi.</p>
             <stage>(<emph>gli fa toccare il bicchiere col suo</emph>)</stage>
             <p>Che vivano i buoni amici.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Che vivano.</p>
             <stage>(<emph>un poco languente</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Viva... chi si vuol bene... senza malizia tocchi.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>E viva...</p>
           </sp>
@@ -3844,25 +3872,25 @@ diavolo scaccerebbe l'altro).</p>
           <stage>
             <emph>Il Marchese e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Son qui ancor io. E che viva?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Come, Signor Marchese?</p>
             <stage>(<emph>alterato</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Compatite, amico. Ho chiamato. Non c'è nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Con sua licenza...</p>
             <stage>(<emph>vuol andar via</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Fermatevi.</p>
             <stage>(<emph>a Mirandolina</emph>)</stage>
@@ -3870,41 +3898,41 @@ diavolo scaccerebbe l'altro).</p>
 voi cotanta libertà.</p>
             <stage>(<emph>al Marchese</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Vi domando scusa. Siamo amici. Credeva che foste
 solo. Mi rallegro vedervi accanto alla nostra adorabile
 padroncina. Ah! Che dite? Non è un capo d'opera?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Signore, io era qui per servire il signor
 Cavaliere. Mi è venuto un poco di male, ed egli mi ha
 soccorso con un bicchierin di Borgogna.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>È Borgogna quello?</p>
             <stage>(<emph>al Cavaliere</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Sì, è Borgogna.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Ma di quel vero?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Almeno l'ho pagato per tale.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Io me n'intendo. Lasciate che lo senta, e vi saprò
 dire se è, o se non è.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ehi!</p>
             <stage>(<emph>chiama</emph>)</stage>
@@ -3915,271 +3943,271 @@ dire se è, o se non è.</p>
           <stage>
             <emph>Il Servitore colle ova, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Un bicchierino al Marchese.</p>
             <stage>(<emph>al Servitore</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Non tanto piccolo il bicchierino. Il Borgogna non
 è liquore. Per giudicarne bisogna beverne a sufficienza.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Ecco le ova.</p>
             <stage>(<emph>vuol metterle in tavola</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Non voglio altro.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Che vivanda è quella?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ova.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Non mi piacciono.</p>
             <stage>(<emph>il Servitore le porta via</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Signor Marchese, con licenza del signor
 Cavaliere, senta quell'intingoletto fatto colle mie mani.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Oh sì. Ehi? Una sedia.</p>
             <stage>(<emph>Il Servitore gli reca una sedia e mette il bicchiere sulla sottocoppa</emph>)</stage>
             <p> Una forchetta.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Via, recagli una posata.</p>
             <stage>(<emph>il Servitore la va a prendere</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Signor Cavaliere, ora sto meglio. Me n'anderò.</p>
             <stage>(<emph>s'alza</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Fatemi il piacere, restate ancora un poco.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Ma signore, ho da attendere a' fatti miei; e poi
 il signor Cavaliere...</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Vi contentate, ch'ella resti ancora un poco?</p>
             <stage>(<emph>al Cavaliere</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Che volete da lei?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Voglio farvi sentire un bicchierino di vin di
 Cipro, che da che siete al mondo, non avrete sentito il
 compagno. E ho piacere, che Mirandolina lo senta, e dica il
 suo parere.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Via, per compiacere il signor Marchese, restate.</p>
             <stage>(<emph>a Mirandolina</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Il signor Marchese mi dispenserà.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Non volete sentirlo?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Un'altra volta, Eccellenza.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Via, restate.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Me lo comanda?</p>
             <stage>(<emph>al Cavaliere</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Vi dico, che restiate.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Obbedisco.</p>
             <stage>(<emph>siede</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Mi obbliga sempre più).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Oh che roba! Oh che intingolo! Oh che odore! Oh
 che sapore!</p>
             <stage>(<emph>mangiando</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Il Marchese averà gelosia, che siate vicina a me).</p>
             <stage>(<emph>piano a Mirandolina</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>(Non m'importa di lui né poco, né molto).</p>
             <stage>(<emph>piano al Cavaliere</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Siete anche voi nemica degli uomini?).</p>
             <stage>(<emph>piano a Mirandolina</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>(Come ella lo è delle donne).</p>
             <stage>(<emph>come sopra</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Queste mie nemiche si vanno vendicando di me).</p>
             <stage>(<emph>come sopra</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>(Come, signore?).</p>
             <stage>(<emph>come sopra</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Eh, furba! Voi vedrete benissimo...).</p>
             <stage>(<emph>come sopra</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Amico, alla vostra salute.</p>
             <stage>(<emph>beve il vino di Borgogna</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>E bene? Come vi pare?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Con vostra buona grazia, non val niente. Sentirete
 il mio vin di Cipro.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ma dov'è questo vino di Cipro?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>L'ho qui, l'ho portato con me, voglio che ce lo
 godiamo; ma! È di quello! Eccolo.</p>
             <stage>(<emph>tira fuori una bottiglia assai piccola</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Per quel che vedo, signor Marchese, non vuole,
 che il suo vino ci vada alla testa.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Questo? Si beve a goccie, come lo spirito di
 melissa. Ehi? Li bicchierini.</p>
             <stage>(<emph>apre la bottiglia</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <stage>(<emph>Porta de' bicchierini da vino di Cipro</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Eh son troppo grandi. Non ne avete de' più
 piccoli?</p>
             <stage>(<emph>copre la bottiglia colla mano</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Porta quei da rosolio.</p>
             <stage>(<emph>al Servitore</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Io credo, che basterebbe odorarlo.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Uh caro! Ha un odor, che consola.</p>
             <stage>(<emph>lo annusa</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <stage>(<emph>Porta tre bicchierini sulla sottocoppa</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <stage>(<emph>Versa pian piano, e non empie li bicchierini, poi lo dispensa al Cavaliere, a Mirandolina, e l'altro per sé, turando bene la bottiglia</emph>)</stage>
             <p> Che nettare! Che ambrosia!
 Che manna distillata!</p>
             <stage>(<emph>bevendo</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Che vi pare di questa porcheria?).</p>
             <stage>(<emph>a Mirandolina, piano</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>(Lavature di fiaschi).</p>
             <stage>(<emph>al Cavaliere, piano</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Ah! Che dite?</p>
             <stage>(<emph>al Cavaliere</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Buono, prezioso.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Ah! Mirandolina, vi piace?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Per me, signore, non posso dissimulare; non mi
 piace, lo trovo cattivo, e non posso dir, che sia buono.
 Lodo chi sa fingere. Ma chi sa fingere in una cosa, saprà
 fingere nell'altre ancora.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Costei mi dà un rimprovero; non capisco il perché).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Mirandolina, voi di questa sorta di vini non ve ne
 intendete. Vi compatisco. Veramente il fazzoletto, che vi ho
@@ -4187,46 +4215,46 @@ donato, l'avete conosciuto, e vi è piaciuto, ma il vin di
 Cipro non lo conoscete.</p>
             <stage>(<emph>finisce di bere</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>(Sente come si vanta?).</p>
             <stage>(<emph>al Cavaliere, piano</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Io non farei così).</p>
             <stage>(<emph>a Mirandolina, piano</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>(Il di lei vanto sta nel disprezzare le donne).</p>
             <stage>(<emph>come sopra</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(E il vostro nel vincere tutti gli uomini).</p>
             <stage>(<emph>come sopra</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>(Tutti no).</p>
             <stage>(<emph>con vezzo al Cavaliere</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Tutti sì).</p>
             <stage>(<emph>con qualche passione, piano a Mirandolina</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Ehi! Tre bicchierini politi.</p>
             <stage>(<emph>al Servitore, il quale glieli porta sopra una sottocoppa</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Per me non ne voglio più.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>No, no, non dubitate; non faccio per voi.</p>
             <stage>(<emph>mette del vino di Cipro nei tre bicchierini</emph>)</stage>
@@ -4235,33 +4263,33 @@ licenza del vostro padrone, andate dal conte d'Albafiorita e
 ditegli per parte mia, forte, che tutti sentano, che lo
 prego di assaggiare un poco del mio vino di Cipro.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Sarà servita. (Questo non gli ubriaca certo).</p>
             <stage>(<emph>da sé; parte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Marchese, voi siete assai generoso.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Io? Domandatelo a Mirandolina.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Oh certamente!</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>L'ha veduto il fazzoletto il Cavaliere?</p>
             <stage>(<emph>a Mirandolina</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Non lo ha ancora veduto.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Lo vedrete.</p>
             <stage>(<emph>al Cavaliere</emph>)</stage>
@@ -4269,52 +4297,52 @@ prego di assaggiare un poco del mio vino di Cipro.</p>
 balsamo me lo salvo per questa sera.</p>
             <stage>(<emph>ripone la bottiglia con un dito di vino avanzato</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Badi, che non gli faccia male, signor Marchese.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Eh! Sapete, che cosa mi fa male?</p>
             <stage>(<emph>a Mirandolina</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Che cosa?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>I vostri begli occhi.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Davvero?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Cavaliere mio, io sono innamorato di costei
 perdutamente.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Me ne dispiace.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Voi non avete mai provato amor per le donne? Oh,
 se lo provaste, compatireste ancora me!</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Sì, vi compatisco.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>E son geloso, come una bestia. La lascio stare
 vicino a voi, perché so chi siete; per altro non lo
 soffrirei per cento mila doppie.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Costui principia a seccarmi).</p>
             <stage>(<emph>da sé</emph>)</stage>
@@ -4325,25 +4353,25 @@ soffrirei per cento mila doppie.</p>
           <stage>
             <emph>Il Servitore con una bottiglia sulla sottocoppa, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Il signor Conte ringrazia V.E. e le manda questa
 bottiglia di vino di Canarie.</p>
             <stage>(<emph>al Marchese</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Oh, oh, vorrà mettere il suo vin di Canarie, col
 mio vino di Cipro? Lascia vedere. Povero pazzo! È una
 porcheria, lo conosco all'odore.</p>
             <stage>(<emph>s'alza, e tiene la bottiglia in mano</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Assaggiatelo prima.</p>
             <stage>(<emph>al Marchese</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Non voglio assaggiar niente. Questa è una
 impertinenza, che mi fa il Conte, compagna di tante altre.
@@ -4361,88 +4389,88 @@ non voglio soffrire simili affronti.</p>
           <stage>
             <emph>Il Cavaliere, Mirandolina ed il Servitore</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Il povero Marchese è pazzo.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Se a caso mai la bile gli facesse male, ha
 portato via la bottiglia per ristorarsi.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>È pazzo, vi dico. E voi lo avete fatto impazzare.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Sono io di quelle, che fanno impazzare gli
 uomini?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Sì, voi siete...</p>
             <stage>(<emph>con affanno</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Signor Cavaliere, con sua licenza.</p>
             <stage>(<emph>s'alza</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Fermatevi.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Perdoni; io non faccio impazzare nessuno.</p>
             <stage>(<emph>andando</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ascoltatemi.</p>
             <stage>(<emph>s'alza, ma resta alla tavola</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Scusi.</p>
             <stage>(<emph>andando</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Fermatevi, vi dico.</p>
             <stage>(<emph>con imperio</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Che pretende da me?</p>
             <stage>(<emph>con alterezza voltandosi</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Nulla.</p>
             <stage>(<emph>si confonde</emph>)</stage>
             <p> Beviamo un altro bicchier di
 Borgogna.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Via, signore, presto, presto, che me ne vada.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Sedete.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>In piedi, in piedi.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Tenete.</p>
             <stage>(<emph>con dolcezza le dà il bicchiere</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Faccio un brindisi, e me ne vado subito. Un
 brindisi che mi ha insegnato mia nonna.</p>
@@ -4462,18 +4490,18 @@ brindisi che mi ha insegnato mia nonna.</p>
           <stage>
             <emph>Il Cavaliere, ed il Servitore</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Bravissima, venite qui; sentite. Ah malandrina! Se
 n'è fuggita. Se n'è fuggita, e mi ha lasciato cento diavoli,
 che mi tormentano.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Comanda le frutta in tavola?</p>
             <stage>(<emph>al Cavaliere</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Va' al diavolo ancor tu.</p>
             <stage>(<emph>il Servitore parte</emph>)</stage>
@@ -4492,240 +4520,240 @@ anderò mai più.</p>
           <head>Scena decima</head>
           <stage>Camera del Conte.
 <emph>Il Conte D'Albafiorita, Ortensia e Dejanira</emph></stage>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Il marchese di Forlipopoli è un carattere
 curiosissimo. È nato nobile, non si può negare; ma fra suo
 padre, e lui hanno dissipato tutto, ed ora non ha appena da
 vivere. Tuttavolta gli piace fare il grazioso.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Si vede, che vorrebbe essere generoso, ma non ne ha.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Dona quel poco, che può, e vuole, che tutto il
 mondo lo sappia.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Questo sarebbe un bel carattere per una delle
 vostre commedie.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Aspetti, che arrivi la compagnia, e che si vada in
 teatro, e può darsi, che ce lo godiamo.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Abbiamo noi dei personaggi, che per imitar i
 caratteri sono fatti a posta.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ma se volete, che ce lo godiamo, bisogna, che con
 lui seguitiate a fingervi dame.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Io lo farò certo. Ma Dejanira, subito dà di bianco.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Mi vien da ridere, quando i gonzi mi credono una
 signora.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Andate, che siete una bella dritta.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Con me, avete fatto bene a scoprirvi. In questa
 maniera mi date campo di poter far qualche cosa in vostro
 vantaggio.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Il signor Conte, sarà il nostro protettore.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Siamo amiche, goderemo unitamente le di lei
 grazie.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Vi dirò, care mie. Vi parlerò con sincerità. Vi
 servirò, dove potrò farlo, ma ho un certo impegno, che non
 mi permetterà frequentare la vostra casa.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Ha qualche amoretto il signor Conte?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sì; ve lo dirò in confidenza. La padrona della
 locanda.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Capperi! Veramente una gran signora! Mi maraviglio
 di lei signor Conte, che si perda con una locandiera!</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Sarebbe minor male, che si compiacesse di
 impiegare le sue finezze per una comica.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Il far all'amor con voi altre, per dirvela, mi
 piace poco. Ora ci siete, ora non ci siete.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Non è meglio così, signore? In questa maniera, anzi
 non si eternano le amicizie, e gli uomini non si rovinano.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ma io, tant'è, sono impegnato; le voglio bene, e
 non la vo' disgustare.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Ma che cosa ha di buono costei?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Oh! Ha del buono assai.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Ehi, Dejanira. È bella, rossa.</p>
             <stage>(<emph>fa cenno che si belletta</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ha un grande spirito.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Oh, in materia di spirito, la vorreste metter con
 noi?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ora basta. Sia come esser si voglia; Mirandolina mi
 piace, e se volete la mia amicizia, avete a dirne bene,
 altrimenti fate conto di non avermi mai conosciuto.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Oh signor Conte, per me dico, che Mirandolina è una
 dea Venere.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Sì, sì, è vero. Ha dello spirito, parla bene.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ora mi date gusto.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Quando non vuol altro, sarà servito.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Oh! Avete veduto quello, ch'è passato per sala?</p>
             <stage>(<emph>osservando dentro la scena</emph>)</stage>
             <p> Ed è andato verso la cucina?</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>L'ho veduto.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Quello è un altro bel carattere da commedia.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>In che genere?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>È uno, che non può vedere le donne.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Oh che pazzo!</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Avrà qualche brutta memoria di qualche donna.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Oibò; non è mai stato innamorato. Non ha mai voluto
 trattar con donne. Le sprezza tutte, e basta dire ch'egli
 disprezza ancora Mirandolina.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Poverino! Se mi ci mettessi attorno io, scommetto,
 che lo farei cambiare oppinione.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Veramente una gran cosa! Questa è un'impresa che
 la vorrei pigliare sopra di me.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sentite, amiche. Così per puro divertimento. Se vi
 dà l'animo di innamorarlo, da cavaliere vi faccio un bel
 regalo.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Io non intendo essere ricompensata per questo; lo
 farò per mio spasso.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Se il signor Conte vuol usarci qualche finezza,
 non l'ha da fare per questo. Sinché arrivano i nostri
 compagni ci divertiremo un poco.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Dubito, che non farete niente.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Signor Conte, ha ben poca stima di noi.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Non siamo vezzose come Mirandolina; ma finalmente
 sappiamo qualche poco il viver del mondo.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Volete, che lo mandiamo a chiamare?</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Faccia come vuole.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ehi? Chi è di là?</p>
           </sp>
@@ -4735,111 +4763,111 @@ sappiamo qualche poco il viver del mondo.</p>
           <stage>
             <emph>Il Servitore del Conte, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Di' al cavaliere di Ripafratta, che favorisca venir
 da me, che mi preme parlargli.</p>
             <stage>(<emph>al Servitore</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Nella sua camera so, che non c'è.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>L'ho veduto andar verso la cucina. Lo troverai.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Subito.</p>
             <stage>(<emph>parte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>(Che mai è andato a far verso la cucina? Scommetto,
 che è andato a strapazzare Mirandolina, perché gli ha dato
 mal da mangiare).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Signor Conte, io aveva pregato il signor Marchese,
 che mi mandasse il suo calzolaio, ma ho paura di non
 vederlo.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Non pensate altro. Vi servirò io.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>A me aveva il signor Marchese promesso un
 fazzoletto. Ma! ora me lo porta!</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>De' fazzoletti ne troveremo.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Egli è, che ne avevo proprio di bisogno.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Se questo vi gradisce, siete padrona. È pulito.</p>
             <stage>(<emph>le offre il suo di seta</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Obbligatissima alle sue finezze.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Oh! Ecco il Cavaliere. Sarà meglio, che
 sostenghiate il carattere di dame, per poterlo meglio
 obbligare ad ascoltarvi per civiltà. Ritiratevi un poco in
 dietro, che se vi vede, fugge.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Come si chiama?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Il cavaliere di Ripafratta; toscano.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Ha moglie?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Non può vedere le donne.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>È ricco?</p>
             <stage>(<emph>ritirandosi</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sì. Molto.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>È generoso?</p>
             <stage>(<emph>ritirandosi</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Piuttosto.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Venga, venga.</p>
             <stage>(<emph>si ritira</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Tempo, e non dubiti.</p>
             <stage>(<emph>si ritira</emph>)</stage>
@@ -4850,105 +4878,105 @@ dietro, che se vi vede, fugge.</p>
           <stage>
             <emph>Il Cavaliere e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Conte, siete voi, che mi volete?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sì; io v'ho dato il presente incomodo.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Che cosa posso far per servirvi?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Queste due dame, hanno bisogno di voi.</p>
             <stage>(<emph>gli addita le due donne, le quali subito s'avanzano</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Disimpegnatemi. Io non ho tempo di trattenermi.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Signor Cavaliere; non intendo di recargli incomodo.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Una parola, in grazia, signor Cavaliere.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Signore mie, vi supplico perdonarmi. Ho un affar di
 premura.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>In due parole vi sbrighiamo.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Due paroline, e non più, signore.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Maledettissimo Conte!).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Caro amico, due dame che pregano; vuole la civiltà,
 che si ascoltino.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Perdonate. In che vi posso servire?</p>
             <stage>(<emph>alle donne, con serietà</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Non siete voi toscano, signore?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Sì, signora.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Avrete degli amici in Firenze.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ho degli amici, e ho de' parenti.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Sappiate, signore... Amica, principiate a dir voi.</p>
             <stage>(<emph>ad Ortensia</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Dirò, signor Cavaliere... Sappia, che un certo
 caso...</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Via, signore vi supplico. Ho un affar di premura.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Orsù, capisco, che la mia presenza vi dà
 soggezione. Confidatevi con libertà al cavaliere, ch'io vi
 levo l'incomodo.</p>
             <stage>(<emph>partendo</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>No, amico, restate.... sentite...</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>So il mio dovere. Servo di lor signore.</p>
             <stage>(<emph>parte</emph>)</stage>
@@ -4959,74 +4987,74 @@ levo l'incomodo.</p>
           <stage>
             <emph>Ortensia, Dejanira ed il Cavaliere</emph>
           </stage>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Favorisca, sediamo.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Scusi non ho volontà di sedere.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Così rustico colle donne?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Favoriscano dirmi, che cosa vogliono.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Abbiamo bisogno del vostro aiuto, della vostra
 protezione, della vostra bontà.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Che cosa vi è accaduto?</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Dirò, Signore... Dejanira; principiate voi.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Oh mi seccano!).</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>I nostri mariti ci hanno abbandonate.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Abbandonate? Come! Due dame abbandonate? Chi sono i
 vostri mariti?</p>
             <stage>(<emph>con alterezza</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Amica, non vado avanti sicuro.</p>
             <stage>(<emph>ad Ortensia</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>(È tanto indiavolato, che or ora mi confondo ancor
 io).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Signore, vi riverisco.</p>
             <stage>(<emph>in atto di partire</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Come! Così ci trattate?</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Un cavaliere tratta così?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Perdonatemi. Io son uno, che amo assai la mia pace.
 Sento due dame abbandonate dai loro mariti. Qui ci saranno
@@ -5034,196 +5062,196 @@ degl'impegni non pochi; io non sono atto a' maneggi. Vivo a
 me stesso, Dame riveritissime, da me non potete sperare né
 consiglio, né aiuto.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Oh via dunque; non lo tenghiamo più in soggezione il
 nostro amabilissimo cavaliere.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Sì, parliamogli con sincerità.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Che nuovo linguaggio è questo?</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Noi, non siamo dame.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>No?</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Il signor Conte ha voluto farvi uno scherzo.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Lo scherzo è fatto. Vi riverisco.</p>
             <stage>(<emph>vuol partire</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Fermatevi un momento.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Che cosa volete?</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Degnateci per un momento della vostra amabile
 conversazione.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ho che fare. Non posso trattenermi.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Non vi vogliamo già mangiar niente.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Non vi leveremo la vostra riputazione.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Sappiamo, che non potete vedere le donne.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Se lo sapete, l'ho a caro. Vi riverisco.</p>
             <stage>(<emph>vuol partire</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Ma, sentire; noi non siamo donne, che possano darvi
 ombra.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Chi siete?</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Diteglielo voi, Dejanira.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Glielo potete dire anche voi.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Via, chi siete?</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Siamo due commedianti.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Due commedianti! Parlate, parlate, che non ho più
 paura di voi. Sono ben prevenuto in favore dell'arte vostra.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Che vuol dire? Spiegarevi.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>So, che fingete in scena e fuori di scena; e con tal
 prevenzione non ho paura di voi.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Signore, fuori di scena, io non so fingere.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Come si chiama ella? La signora Sincera?</p>
             <stage>(<emph>a Dejanira</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Io mi chiamo...</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>È ella la signora Buona lana?</p>
             <stage>(<emph>ad Ortensia</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Caro signor Cavaliere...</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Come si diletta di miccheggiare?</p>
             <stage>(<emph>ad Ortensia</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Io non sono...</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>I gonzi come li tratta lei?</p>
             <stage>(<emph>a Dejanira</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Non son di quelle...</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Anch'io so parlar in gergo.</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Oh che caro signor Cavaliere!</p>
             <stage>(<emph>vuol prenderlo per un braccio</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Basse le cere.</p>
             <stage>(<emph>dandole nelle mani</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>Diamine! Ha più del contrasto, che del cavaliere.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Contrasto, vuol dir contadino. Vi ho capito. E vi
 dirò, che siete due impertinenti.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>A me questo?</p>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>A una donna della mia sorte?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Bello quel viso trionfato.</p>
             <stage>(<emph>ad Ortensia</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#ortensia">
             <speaker>ORTENSIA</speaker>
             <p>(Asino!).</p>
             <stage>(<emph>parte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Bello quel tuppè finto!</p>
             <stage>(<emph>a Dejanira</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>(Maledetto!).</p>
             <stage>(<emph>parte</emph>)</stage>
@@ -5234,7 +5262,7 @@ dirò, che siete due impertinenti.</p>
           <stage>
             <emph>Il Cavaliere, poi il di lui Servitore</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ho trovata ben io la maniera di farle andare. Che si
 pensavano? Di tirarmi nella rete? Povere sciocche! Vadano
@@ -5250,60 +5278,60 @@ rovinarmi?</p>
             <stage>(<emph>pensa</emph>)</stage>
             <p> Sì; facciamo una risoluzione da uomo.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Signore?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Che cosa vuoi?</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Il signor Marchese è nella di lei camera, che
 l'aspetta, perché desidera di parlargli.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Che vuole codesto pazzo? Denari non me ne cava più
 di sorto. Che aspetti, e quando sarà stracco di aspettare,
 se n'anderà. Va' dal cameriere della locanda e digli, che
 subito porti il mio conto.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Sarà obbedita.</p>
             <stage>(<emph>in atto di partire</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Senti. Fa', che da qui a due ore siano pronti i
 bauli.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Vuol partir forse?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Sì. Portami qui la spada, ed il cappello, senza che
 se n'accorga il Marchese.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Ma se mi vede fare i bauli?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Dica ciò che vuole. M'hai inteso.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>(Oh, quanto mi dispiace andar via per causa di
 Mirandolina!).</p>
             <stage>(<emph>da sé, parte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Eppur è vero. Io sento nel partire di qui una
 dispiacenza nuova, che non ho mai provata. Tanto peggio per
@@ -5317,69 +5345,69 @@ male, ancora quando ci volete fare del bene.</p>
           <stage>
             <emph>Fabrizio e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>È vero signore, che vuole il conto?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Sì, l'avete portato?</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Adesso la padrona lo fa.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ella fa i conti?</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Oh sempre ella. Anche quando viveva suo padre.
 Scrive, e sa far di conto meglio di qualche giovane di
 negozio.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Che donna singolare è costei!).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Ma vuol ella andar via così presto?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Sì, così vogliono i miei affari.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>La prego di ricordarsi del cameriere.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Portate il conto, e so quello, che devo fare.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Lo vuol qui il conto?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Lo voglio qui; in camera per ora non ci vado.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Fa bene; in camera sua vi è quel seccatore del
 signore Marchese. Carino! Fa l'innamorato della padrona. Ma
 può leccarsi le dita. Mirandolina deve esser mia moglie.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Il conto.</p>
             <stage>(<emph>alterato</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>La servo subito.</p>
             <stage>(<emph>parte</emph>)</stage>
@@ -5390,7 +5418,7 @@ può leccarsi le dita. Mirandolina deve esser mia moglie.</p>
           <stage>
             <emph>Il Cavaliere solo</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Tutti sono invaghiti di Mirandolina. Non è
 maraviglia, se ancor io principiava sentirmi accendere. Ma
@@ -5405,48 +5433,48 @@ quest'ultimo assalto. Già da qui a due ore io parto.</p>
           <stage>
             <emph>MIRANDOLINA con un foglio in mano, e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Signore.</p>
             <stage>(<emph>mestamente</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Che c'è, Mirandolina?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Perdoni.</p>
             <stage>(<emph>stando indietro</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Venite avanti.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Ha domandato il suo conto; l'ho servita.</p>
             <stage>(<emph>mestamente</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Date qui.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Eccolo.</p>
             <stage>(<emph>si asciuga gli occhi col grembiale, nel dargli il conto</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Che avete? Piangete?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Niente, signore, mi è andato del fumo negli
 occhi.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Del fumo negli occhi? Eh! basta... quanto importa il
 conto?</p>
@@ -5454,49 +5482,49 @@ conto?</p>
             <p> Venti paoli? In quattro giorni un
 trattamento sì generoso; venti paoli?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Quello è il suo conto.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>E i due piatti particolari, che mi avete dato questa
 mattina non ci sono nel conto?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Perdoni. Quel, ch'io dono, non lo metto in conto.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Me gli avete voi regalati?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Perdoni la libertà. Gradisca per un atto di...</p>
             <stage>(<emph>si copre, mostrando di piangere</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ma che avete?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Non so se sia il fumo, o qualche flussione di
 occhi.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Non vorrei, che aveste patito, cucinando per me
 quelle due preziose vivande.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Se fosse per questo, lo soffrirei...
 volentieri...</p>
             <stage>(<emph>mostra trattenersi di piangere</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Eh, se non vado via!)</p>
             <stage>(<emph>da sé</emph>)</stage>
@@ -5504,7 +5532,7 @@ volentieri...</p>
 sono due doppie. Godetele per amor mio... e compatitemi...</p>
             <stage>(<emph>s'imbroglia</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <stage>(<emph>Senza parlare, cade come svenuta sopra una sedia</emph>)</stage>
             <p>Mirandolina? Ahimè! Mirandolina? È
@@ -5517,7 +5545,7 @@ ampolle. Chi è di là? Vi è nessuno? Presto.... Anderò io.
 Poverina! Che tu sia benedetta!</p>
             <stage>(<emph>parte, e poi ritorna</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Ora poi è caduto affatto. Molte sono le nostre
 armi, colle quali si vincon gli uomini. Ma quando sono
@@ -5525,7 +5553,7 @@ ostinati, il colpo di riserva sicurissimo è uno svenimento.
 Torna, torna.</p>
             <stage>(<emph>si mette come sopra</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <stage>(<emph>Torna con un vaso d'acqua</emph>)</stage>
             <p>Eccomi, eccomi. E non
@@ -5541,29 +5569,29 @@ partirò più per ora.</p>
           <stage>
             <emph>Il Servitore colla spada e cappello, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Ecco la spada, ed il cappello.</p>
             <stage>(<emph>al Cavaliere</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Va' via.</p>
             <stage>(<emph>al Servitore, con ira</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>I bauli...</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Va' via, che tu sia maledetto.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Mirandolina...</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Va', che ti spacco la testa.</p>
             <stage>(<emph>lo minaccia col vaso; il Servitore parte</emph>)</stage>
@@ -5577,64 +5605,64 @@ occhi. Parlatemi con libertà.</p>
           <stage>
             <emph>Il Marchese ed il Conte, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Cavaliere?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Amico?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Oh maledetti!).</p>
             <stage>(<emph>va smaniando</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Mirandolina.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Oimè!</p>
             <stage>(<emph>s'alza</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Io l'ho fatta rinvenire.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Mi rallegro, signor Cavaliere.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Bravo quel signore, che non può vedere le donne.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Che impertinenza?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Siete caduto?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Andate al diavolo quanti siete.</p>
             <stage>(<emph>getta il vaso in terra, e lo rompe verso il Conte ed il Marchese, e parte furiosamente</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Il Cavaliere è diventato pazzo.</p>
             <stage>(<emph>parte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Di questo affronto voglio soddisfazione.</p>
             <stage>(<emph>parte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>L'impresa è fatta. Il di lui cuore è in fuoco, in
 fiamma, in cenere. Restami solo per compiere la mia
@@ -5652,89 +5680,89 @@ degli uomini presontuosi, e ad onore del nostro sesso.</p>
           <stage>
             <emph>Mirandolina, poi Fabrizio</emph>
           </stage>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Orsù, l'ora del divertimento è passata. Voglio
 ora badare a' fatti miei. Prima che questa biancheria si
 prosciughi del tutto, voglio stirarla. Ehi, Fabrizio?</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Signora.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Fatemi un piacere. Portatemi il ferro caldo.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Signora sì.</p>
             <stage>(<emph>con serietà, in atto di partire</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Scusate, se do a voi questo disturbo.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Niente, signora. Finché io mangio il vostro pane
 son obbligato a servirvi.</p>
             <stage>(<emph>vuol partire</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Fermatevi; sentire. Non siete obbligato a
 servirmi in queste cose; ma so che per me lo fate
 volentieri, ed io... basta non dico altro.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Per me vi porterei l'acqua colle orecchie. Ma vedo,
 che tutto è gettato via.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Perché gettato via? Sono forse un'ingrata?</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Voi non degnate i poveri uomini. Vi piace troppo la
 nobiltà.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Uh povero pazzo! Se vi potessi dir tutto! Via,
 via, andatemi a pigliar il ferro.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Ma se ho veduto io con questi miei occhi...</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Andiamo, meno ciarle. Portatemi il ferro.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Vado, vado. Vi servirò, ma per poco.</p>
             <stage>(<emph>andando</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Con questi uomini, più che loro si vuol bene, si
 fa peggio.</p>
             <stage>(<emph>mostrando parlar da sé, ma per esser sentita</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Che cosa avete detto?</p>
             <stage>(<emph>con tenerezza, tornando indietro</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Via, mi portare questo ferro?</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Sì, ve lo porto. (Non so niente. Ora la mi tira su,
 ora la mi butta giù. Non so niente).</p>
@@ -5744,7 +5772,7 @@ ora la mi butta giù. Non so niente).</p>
         <div type="scene">
           <head>Scena seconda</head>
           <stage><emph>Mirandolina, poi il Servitore del Cavaliere</emph>.</stage>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Povero sciocco! Mi ha da servire a suo marcio
 dispetto. Mi par di ridere a far che gli uomini facciano a
@@ -5752,123 +5780,123 @@ modo mio. E quel caro signor Cavaliere, ch'era tanto nemico
 delle donne? Ora, se volessi, sarei padrona di fargli fare
 qualunque bestialità.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Signora Mirandolina.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Che c'è, amico?</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Il mio padrone la riverisce, e manda a vedere come
 sta.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Ditegli, che sto benissimo.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Dice così, che beva un poco di questo spirito di
 melissa, che le farà assai bene.</p>
             <stage>(<emph>le dà una boccetta d'oro</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>È d'oro questa boccetta?</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Sì signora, d'oro, lo so di sicuro.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Perché non mi ha dato lo spirito di melissa,
 quando mi è venuto quell'orribile svenimento?</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Allora questa boccetta egli non l'aveva.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Ed ora, come l'ha avuta?</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Sentite. In confidenza. Mi ha mandato ora a chiamar
 un orefice, l'ha comprata, e l'ha pagata dodici zecchini; e
 poi mi ha mandato dallo speziale a comprar lo spirito.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Ah, ah, ah.</p>
             <stage>(<emph>ride</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Ridete?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Rido, perché mi manda il medicamento, dopo che
 son guarita del male.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Sarà buono per un'altra volta.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Via, ne beverò un poco per preservativo.</p>
             <stage>(<emph>beve</emph>)</stage>
             <p>Tenete, ringraziatelo.</p>
             <stage>(<emph>gli vuol dar la boccetta</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Oh! la boccetta è vostra.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Come mia?</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Sì. Il padrone l'ha comprata a posta.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>A posta per me?</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Per voi; ma zitto.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Portategli la sua boccetta, e ditegli che lo
 ringrazio.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Eh via.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Vi dico, che gliela portiate, che non la voglio.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Gli volete far quest'affronto?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Meno ciarle. Fate il vostro dovere. Tenete.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Non occorr'altro. Gliela porterò. (Oh che donna!
 Ricusa dodici zecchini! Una simile non l'ho più ritrovata, e
@@ -5881,89 +5909,89 @@ durerò fatica a trovarla).</p>
           <stage>
             <emph>Mirandolina, poi Fabrizio</emph>
           </stage>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Uh è cotto, stracotto, e biscottato. Ma siccome
 quel che ho fatto con lui, non l'ho fatto per interesse,
 voglio ch'ei confessi la forza delle donne, senza poter
 dire, che sono interessate, e venali.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Ecco qui il ferro.</p>
             <stage>(<emph>sostenuto, col ferro da stirare in mano</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>È ben caldo?</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Signora sì, è caldo; così foss'io abbruciato.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Che cosa vi è di nuovo?</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Questo signor Cavaliere manda le ambasciate, manda
 i regali. Il servitore me l'ha detto.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Signor sì, mi ha mandato una boccettina d'oro, ed
 io gliel'ho rimandata indietro.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Gliel'avete rimandata indietro?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Sì, domandatelo al servitore medesimo.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Perché gliel'avete rimandata indietro?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Perché... Fabrizio... non dica... Orsù non
 parliamo altro.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Cara Mirandolina, compatitemi.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Via, andate, lasciatemi stirare.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Io non v'impedisco di fare...</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Andatemi a preparare un altro ferro, e quando è
 caldo, portatelo.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Sì, vado. Credetemi, che se parlo...</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Non dite altro. Mi fate venire la rabbia.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Sto cheto. (Ell'è una testolina bizzarra, ma le
 voglio bene).</p>
             <stage>(<emph>da sé, parte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Anche questa è buona. Mi faccio merito con
 Fabrizio d'aver ricusata la boccetta d'oro del Cavaliere.
@@ -5977,200 +6005,200 @@ dica, ch'io faccio torto al sesso.</p>
         <div type="scene">
           <head>Scena quarta</head>
           <stage><emph>Il Cavaliere e detta</emph>.</stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Eccola. Non ci volevo venire, e il diavolo mi ci ha
 strascinato).</p>
             <stage>(<emph>da sé, indietro</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>(Eccolo, eccolo).</p>
             <stage>(<emph>lo vede colla coda dell'occhio, e stira</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Mirandolina?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Oh signor Cavaliere! Serva umilissima.</p>
             <stage>(<emph>stirando</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Come state?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Benissimo per servirla.</p>
             <stage>(<emph>stirando senza guardarlo</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ho motivo di dolermi di voi.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Perché, signore?</p>
             <stage>(<emph>guardandolo un poco</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Perché avete ricusato una piccola boccettina, che vi
 ho mandato.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Che voleva, ch'io ne facessi?</p>
             <stage>(<emph>stirando</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Servirvene nelle occorrenze.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Per grazia del Cielo, non sono soggetta agli
 svenimenti. Mi è accaduto oggi quello, che non mi è accaduto
 mai più.</p>
             <stage>(<emph>stirando</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Cara Mirandolina... non vorrei esser io stato
 cagione di quel funesto accidente.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Eh sì ho timore, che ella appunto ne sia stata la
 causa.</p>
             <stage>(<emph>stirando</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Io? Davvero?</p>
             <stage>(<emph>con passione</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Mi ha fatto bere quel maledetto vino di Borgogna,
 e mi ha fatto male.</p>
             <stage>(<emph>stirando con rabbia</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Come? Possibile?</p>
             <stage>(<emph>rimane mortificato</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>È così senz'altro. In camera sua non ci vengo
 mai più.</p>
             <stage>(<emph>stirando</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>V'intendo. In camera mia non ci verrete più? Capisco
 il mistero. Sì, lo capisco. Ma veniteci, cara, che vi
 chiamerete contenta.</p>
             <stage>(<emph>amoroso</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Questo ferro è poco caldo; ehi, Fabrizio? se
 l'altro ferro è caldo portatelo.</p>
             <stage>(<emph>forte verso la scena</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Fatemi questa grazia, tenete questa boccetta.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>In verità, signor Cavaliere, dei regali io non ne
 prendo.</p>
             <stage>(<emph>con disprezzo, stirando</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Gli avete pur presi dal conte d'Albafiorita.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Per forza. Per non disgustarlo.</p>
             <stage>(<emph>stirando</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>E vorreste fare a me questo torto? e disgustarmi?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Che importa a lei, che una donna la disgusti? Già
 le donne non le può vedere.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ah, Mirandolina! ora non posso dire così.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Signor Cavaliere, a che ora fa la luna nuova?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Il mio cambiamento non è lunatico. Questo è un
 prodigio della vostra bellezza, della vostra grazia.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Ah, ah, ah.</p>
             <stage>(<emph>ride forte, e stira</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ridete?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Non vuol che rida? Mi burla, e non vuol ch'io
 rida?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Eh furbetta! Vi burlo eh? Via prendete questa
 boccetta.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Grazie, grazie.</p>
             <stage>(<emph>stirando</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Prendetela, o mi farete andare in collera.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Fabrizio, il ferro.</p>
             <stage>(<emph>chiamando forte, con caricatura</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>La prendete, o non la prendete?</p>
             <stage>(<emph>alterato</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Furia, furia.</p>
             <stage>(<emph>prende la boccetta, e con disprezzo la getta nel paniere della biancheria</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>La gettate così?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Fabrizio!</p>
             <stage>(<emph>chiama forte, come sopra</emph>)</stage>
@@ -6181,76 +6209,76 @@ boccetta.</p>
           <stage>
             <emph>Fabrizio col ferro, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Son qua.</p>
             <stage>(<emph>vedendo il Cavaliere, s'ingelosisce</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>È caldo bene?</p>
             <stage>(<emph>prende il ferro</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Signora sì.</p>
             <stage>(<emph>sostenuto</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Che avete, che mi parete turbato?</p>
             <stage>(<emph>a Fabrizio, con tenerezza</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Niente, padrona, niente.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Avete male?</p>
             <stage>(<emph>come sopra</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Datemi l'altro ferro, se volete, che lo metta nel
 fuoco.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>In verità, ho paura, che abbiate male.</p>
             <stage>(<emph>come sopra</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Via, dategli il ferro, e che se ne vada.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Gli voglio bene, sa ella a Fabrizio. È il mio
 cameriere fidato.</p>
             <stage>(<emph>al Cavaliere</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Non posso più).</p>
             <stage>(<emph>da sé, smaniando</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Tenete, caro, scaldatelo.</p>
             <stage>(<emph>dà il ferro a Fabrizio</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Signora padrona...</p>
             <stage>(<emph>con tenerezza</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Via, via, presto.</p>
             <stage>(<emph>lo scaccia</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>(Che vivere è questo! Sento, che non posso più).</p>
             <stage>(<emph>da sé, parte</emph>)</stage>
@@ -6261,19 +6289,19 @@ cameriere fidato.</p>
           <stage>
             <emph>Il Cavaliere e Mirandolina</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Gran finezze, signora, al suo cameriere!</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>E per questo, che cosa vorrebbe dire?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Si vede, che ne siete invaghita.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Io innamorata di un cameriere? Mi fa un bel
 complimento, signore; non sono di sì cattivo gusto io.
@@ -6281,243 +6309,243 @@ Quando volessi amare, non getterei il mio tempo sì
 malamente.</p>
             <stage>(<emph>stirando</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Voi meritereste l'amore di un re.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Del re di spade, o del re di coppe?</p>
             <stage>(<emph>stirando</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Parliamo sul serio, Mirandolina, e lasciamo gli
 scherzi.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Parli pure, che io l'ascolto.</p>
             <stage>(<emph>stirando</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Non potreste per un poco lasciar di stirare?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Oh perdoni! Mi preme allestire questa biancheria
 per domani.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Vi preme dunque quella biancheria più di me?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Sicuro.</p>
             <stage>(<emph>stirando</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>E ancora lo confermate?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Certo. Perché di questa biancheria me ne ho da
 servire, e di lei non posso far capitale di niente.</p>
             <stage>(<emph>stirando</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Anzi potete dispor di me con autorità.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Eh che ella non può vedere le donne.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Non mi tormentate più. Vi siete vendicata a
 bastanza. Stimo voi, stimo le donne, che sono della vostra
 sorte, se pur ve ne sono. Vi stimo, vi amo, e vi domando
 pietà.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Sì signore, glielo diremo.</p>
             <stage>(<emph>stirando in fretta, si fa cadere un manicotto</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <stage>(<emph>Leva di terra il manicotto, e glielo dà</emph>)</stage>
             <p>Credetemi...</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Non s'incomodi.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Voi meritate di esser servita.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Ah, ah, ah.</p>
             <stage>(<emph>ride forte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ridete?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Rido, perché mi burla.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Mirandolina, non posso più.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Le vien male?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Sì, mi sento mancare.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Tenga il suo spirito di melissa.</p>
             <stage>(<emph>gli getta con disprezzo la boccetta</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Non mi trattate con tanta asprezza. Credetemi, vi
 amo, ve lo giuro.</p>
             <stage>(<emph>vuol prenderle la mano, ed ella col ferro lo scotta</emph>)</stage>
             <p> Aimè!</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Perdoni; non l'ho fatto apposta.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Pazienza! Questo è niente. Mi avete fatto una
 scottatura più grande.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Dove, signore?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Nel cuore.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Fabrizio.</p>
             <stage>(<emph>chiama ridendo</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Per carità, non chiamate colui.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Ma se ho bisogno dell'altro ferro.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Aspettate... (ma no...) chiamerò il mio servitore.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Eh pensi lei. Fabri...</p>
             <stage>(<emph>vuol chiamar Fabrizio</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Giuro al Cielo, se viene colui gli spacco la testa.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Oh, questa è bella! Non mi potrò servire della
 mia gente?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Chiamate un altro; colui non lo posso vedere.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Mi pare ch'ella si avanzi un poco troppo, signor
 Cavaliere.</p>
             <stage>(<emph>si scosta dal tavolino col ferro in mano</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Compatitemi... son fuor di me.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Anderò io in cucina, e sarà contento.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>No, cara, fermatevi.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>È una cosa curiosa questa.</p>
             <stage>(<emph>passeggiando</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Compatitemi.</p>
             <stage>(<emph>le va dietro</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Non posso chiamar chi voglio?</p>
             <stage>(<emph>passeggia</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Lo confesso. Ho gelosia di colui.</p>
             <stage>(<emph>le va dietro</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>(Mi vien dietro come un cagnolino).</p>
             <stage>(<emph>da sé, passeggiando</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Questa è la prima volta ch'io provo, che cosa sia
 amore.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Nessuno mi ha mai comandato.</p>
             <stage>(<emph>camminando</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Non intendo di comandarvi; vi prego.</p>
             <stage>(<emph>la segue</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Che cosa vuole da me?</p>
             <stage>(<emph>voltandosi con alterezza</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Amore, compassione, pietà.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Un uomo, che stamattina non poteva veder le
 donne, oggi chiede amore, e pietà? Non gli abbado, non può
@@ -6529,7 +6557,7 @@ disprezzare le donne).</p>
         <div type="scene">
           <head>Scena settima</head>
           <stage><emph>Cavaliere solo</emph>.</stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Oh maledetto il punto, in cui ho principiato a mirar
 costei! Son caduto nel laccio, e non vi è più rimedio. Nasca
@@ -6545,115 +6573,115 @@ sarò risoluto con lei.</p>
           <stage>
             <emph>Il Marchese e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Cavaliere, voi mi avete insultato.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Compatitemi, fu un accidente.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Mi maraviglio di voi.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Finalmente il vaso non vi ha colpito.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Una gocciola d'acqua mi ha macchiato il vestito.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Torno a dir, compatitemi.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Questa è una impertinenza.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Non l'ho fatto apposta. Compatitemi per la terza
 volta.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Voglio soddisfazione.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Se non volete compatirmi, se volete soddisfazione,
 son qui, non ho soggezione di voi.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Ho paura che questa macchia non voglia andar via;
 questo è quello, che mi fa andare in collera.</p>
             <stage>(<emph>cangiandosi</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Quando un cavaliere vi chiede scusa, che pretendete
 di più?</p>
             <stage>(<emph>con isdegno</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Se non l'avete fatto a malizia, lasciamo andare.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Vi dico, che son capace di darvi qualunque
 soddisfazione.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Via, non parliamo altro.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Cavaliere malnato.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Oh questa è bella! A me è passata la collera, e
 voi ve la fate venire.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ora per l'appunto mi avete trovato in buona luna.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Vi compatisco; so che male avete.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>I fatti vostri io non gli ricerco.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Signor inimico delle donne, ci siete caduto eh?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Io? Come?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Sì, siete innamorato...</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Sono il diavolo, che vi porti.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Che serve nascondersi?...</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Lasciatemi stare, che giuro al Cielo ve ne farò
 pentire.</p>
@@ -6665,7 +6693,7 @@ pentire.</p>
           <stage>
             <emph>Marchese solo.</emph>
           </stage>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>È innamorato, si vergogna, e non vorrebbe, che si
 sapesse. Ma forse non vorrà, che si sappia perché ha paura
@@ -6689,196 +6717,196 @@ melissa. Tant'e tanto sarà buono. Voglio provare.</p>
           <stage>
             <emph>Dejanira e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Signor Marchese, che fa qui solo? Non favorisce
 mai?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Oh signora Contessa. Veniva or ora per riverirla.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Che cosa stava facendo?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Vi dirò. Io sono amantissimo della pulizia. Voleva
 levare questa piccola macchia.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Con che, signore?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Con questo spirito di melissa.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Oh perdoni, lo spirito di melissa non serve, anzi
 farebbe venire la macchia più grande.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Dunque, come ho da fare?</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Ho io un segreto per cavar le macchie.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Mi farete piacere a insegnarmelo.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Volentieri. M'impegno con uno scudo far andar via
 quella macchia, che non si vedrà nemmeno dove sia stata.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Vi vuole uno scudo?</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Sì, signore, vi pare una grande spesa?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>È meglio provare lo spirito di melissa.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Favorisca; è buono quello spirito?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Prezioso: sentite.</p>
             <stage>(<emph>le dà la boccetta</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Oh io ne so fare del meglio.</p>
             <stage>(<emph>assaggiandolo</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Sapete fare degli spiriti?</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Sì, signore, mi diletto di tutto.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Brava, damina, brava. Così mi piace.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Sarà d'oro questa boccetta?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Non volete? È oro sicuro. (Non conosce l'oro dal
 princisbech).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>È sua signor Marchese?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>È mia, e vostra, se comandate.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Obbligatissima alle sue grazie.</p>
             <stage>(<emph>la mette via</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Eh! so che scherzate.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Come? Non me l'ha esibita?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Non è cosa da vostra pari. È una bagattella. Vi
 servirò di cosa migliore, se ne avete voglia.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Oh, mi maraviglio! È anche troppo. La ringrazio,
 signor Marchese.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Sentite. In confidenza. Non è oro. È princisbech.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Tanto meglio. La stimo più, che se fosse oro. E
 poi quel, che viene dalle sue mani è tutto prezioso.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Basta. Non so che dire; servitevi, se vi degnate.
 (Pazienza! Bisognerà pagarla a Mirandolina. Che cosa può
 valere? Un filippo?).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Il signor Marchese è un cavalier generoso.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Mi vergogno a regalar queste bagattelle. Vorrei,
 che quella boccetta fosse d'oro.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>In verità pare propriamente oro.</p>
             <stage>(<emph>la tira fuori, e la osserva</emph>)</stage>
             <p> Ognuno s'ingannerebbe.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>È vero, chi non ha pratica dell'oro, s'inganna;
 ma io lo conosco subito.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Anche al peso par, che sia oro.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>E pur non è vero.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Voglio farla vedere alla mia compagna.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Sentite, signora Contessa, non la fate vedere a
 Mirandolina. È una ciarliera. Non so, se mi capite.</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Intendo benissimo. La fo vedere solamente ad
 Ortensia.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Alla Baronessa?</p>
           </sp>
-          <sp>
+          <sp who="#dejanira">
             <speaker>DEJANIRA</speaker>
             <p>Sì, sì, alla Baronessa.</p>
             <stage>(<emph>ridendo parte</emph>)</stage>
@@ -6889,71 +6917,71 @@ Ortensia.</p>
           <stage>
             <emph>Il Marchese, poi il Servitore del Cavaliere</emph>
           </stage>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Credo, che se ne rida, perché mi ha levato con
 quel bel garbo la boccettina. Tant'era, se fosse stata
 d'oro. Manco male, che con poco l'aggiusterò. Se Mirandolina
 vorrà la sua boccetta, gliela pagherò, quando ne averò.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <stage>(<emph>Cerca sul tavolino</emph>)</stage>
             <p>Dove diamine sarà questa
 boccetta?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Che cosa cercate galantuomo?</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Cerco una boccettina di spirito di melissa. La
 signora Mirandolina la vorrebbe. Dice che l'ha lasciata qui,
 ma non la ritrovo.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Era una boccettina di princisbech?</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>No signore, era d'oro.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>D'oro?</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Certo che era d'oro. L'ho veduta comprar io per
 dodici zecchini.</p>
             <stage>(<emph>cerca</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>(Oh povero me!)</p>
             <stage>(<emph>da sé</emph>)</stage>
             <p> Ma come lasciar così una
 boccetta d'oro?</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Se l'è scordata, ma io non la trovo.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Mi pare ancora impossibile, che fosse d'oro.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Era oro, gli dico. L'ha forse veduta V.E.?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Io?... Non ho veduto niente.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Basta. Le dirò, che non la trovo. Suo danno. Doveva
 mettersela in tasca.</p>
@@ -6965,7 +6993,7 @@ mettersela in tasca.</p>
           <stage>
             <emph>Il Marchese, poi il Conte</emph>
           </stage>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Oh povero marchese di Forlipopoli! Ho donata una
 boccetta d'oro, che val dodici zecchini, e l'ho donata per
@@ -6975,35 +7003,35 @@ ridicolo presso di lei; se Mirandolina viene a scoprire
 ch'io l'abbia avuta, è in pericolo il mio decoro. Son
 cavaliere. Devo pagarla. Ma non ho danari.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Che dite, signor Marchese della bellissima novità?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Di qual novità?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Il cavaliere selvatico, il disprezzator delle donne
 è innamorato di Mirandolina.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>L'ho caro. Conosca suo malgrado il merito di
 questa donna; veda che io non m'invaghisco di chi non
 merita; e peni, e crepi per gastigo della sua impertinenza.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ma se Mirandolina gli corrisponde?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Ciò non può essere. Ella non farà a me questo
 torto. Sa chi sono. Sa cosa ho fatto per lei.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Io ho fatto per essa, assai più di voi. Ma tutto è
 gettato. Mirandolina coltiva il cavaliere di Ripafratta; ha
@@ -7012,19 +7040,19 @@ né a voi, né a me; e vedesi che, colle donne, più che si fa,
 meno si merita, e che burlandosi esse di chi le adora,
 corrono dietro a chi le disprezza.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Se ciò fosse vero... ma non può essere.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Perché non può essere?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Vorreste mettere il Cavaliere a confronto di me?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Non l'avete veduta voi stesso sedere alla di lui
 tavola? Con noi ha praticato mai un atto di simile
@@ -7034,7 +7062,7 @@ servidori vedono tutto, e parlano. Fabrizio freme di
 gelosia. E poi quello svenimento, vero, o finto, che fosse,
 non è segno manifesto d'amore?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Come? Al Cavalier biancheria da tavola nuova, e a
 me salviette con tante di buche? A lui si fanno gl'intingoli
@@ -7042,188 +7070,188 @@ saporiti, e a me carnaccia di bue, e minestra di riso lungo?
 Sì, è vero, questo è uno strapazzo al mio grado, alla mia
 condizione.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Ed io, che ho speso tanto per lei?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Ed io, che la regalava continuamente? Le ho fino
 dato da bere di quel mio vino di Cipro così prezioso. Il
 Cavaliere non averà fatto con costei una minima parte di
 quello, che abbiamo fatto noi.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Non dubitate, che anch'egli l'ha regalata.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Sì? Che cosa le ha donato?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Una boccettina d'oro con dello spirito di melissa.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>(Oimè!)</p>
             <stage>(<emph>da sé</emph>)</stage>
             <p> Come lo avete saputo?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Il di lui servidore l'ha detto al mio.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>(Sempre peggio. Entro in un impegno col
 Cavaliere).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Vedo, che costei è un'ingrata; voglio assolutamente
 lasciarla. Voglio partire or ora da questa locanda indegna.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Sì, fate bene, andate.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>E voi, che siete un cavaliere di tanta riputazione,
 dovreste partire con me.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Ma... dove dovrei andare?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Vi troverò io un alloggio. Lasciate pensare a me.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Quest'alloggio... sarà per esempio...</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Andremo in casa di un mio paesano. Non spenderemo
 nulla.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Basta, siete tanto mio amico, che non posso dirvi
 di no.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Andiamo, e vendichiamoci di questa femmina
 sconoscente.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Sì, andiamo. (Ma come sarà poi della boccetta? Son
 cavaliere, non posso fare una mal'azione).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Non vi pentite, signor Marchese, andiamo via di
 qui. Fatemi questo piacere, e poi comandatemi dove posso,
 che vi servirò.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Vi dirò. In confidenza, ma che nessuno lo sappia.
 Il mio fattore mi ritarda qualche volta le mie rimesse...</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Le avete forse da dar qualche cosa?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Sì, dodici zecchini.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Dodici zecchini? Bisogna che sia dei mesi che non
 pagate.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Così è, le devo dodici zecchini. Non posso di qua
 partire senza pagarla. Se voi mi faceste il piacere...</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Volentieri. Eccovi dodici zecchini.</p>
             <stage>(<emph>tira fuori la borsa</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Aspettate. Ora che mi ricordo, sono tredici.
 (Voglio rendere il suo zecchino anche al Cavaliere).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Dodici, o tredici, è lo stesso per me. Tenete.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Ve li renderò quanto prima.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Servitevi quanto vi piace. Danari a me non me ne
 mancano; e per vendicarmi di costei, spenderei mille doppie.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Sì, veramente è un'ingrata. Ho speso tanto per
 lei, e mi tratta così.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Voglio rovinare la sua locanda. Ho fatto andar via
 anche quelle due commedianti.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Dove sono le commedianti?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Erano qui: Ortensia e Dejanira.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Come! Non sono dame?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>No. Sono due comiche. Sono arrivati i loro
 compagni, e la favola, è terminata.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>(La mia boccetta!)</p>
             <stage>(<emph>da sé</emph>)</stage>
             <p> Dove sono alloggiate?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>In una casa vicino al teatro.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>(Vado subito a ricuperare la mia boccetta).</p>
             <stage>(<emph>da sé, parte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Con costei mi voglio vendicare così. Il Cavaliere
 poi, che ha saputo fingere per tradirmi, in altra maniera me
@@ -7235,7 +7263,7 @@ ne renderà conto.</p>
           <head>Scena tredicesima</head>
           <stage>Camera con tre porte.</stage>
           <stage><emph>Mirandolina sola</emph>,</stage>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Oh meschina me! Sono nel brutto impegno! Se il
 Cavaliere mi arriva sto fresca. Si è indiavolato
@@ -7263,57 +7291,57 @@ mia riputazione, senza pregiudicare alla mia libertà.</p>
             <emph>Il Cavaliere di dentro, e detta; poi Fabrizio. Il
 Cavaliere batte per di dentro alla porta.</emph>
           </stage>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Battono a questa porta: chi sarà mai?</p>
             <stage>(<emph>s'accosta</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Mirandolina.</p>
             <stage>(<emph>di dentro</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>(L'amico è qui).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Mirandolina, apritemi.</p>
             <stage>(<emph>come sopra</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>(Aprirgli? Non sono sì gonza). Che comanda,
 signor Cavaliere?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Apritemi.</p>
             <stage>(<emph>di dentro</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Favorisca andare nella sua camera, e mi aspetti,
 che or ora sono da lei.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Perché non volete aprirmi?</p>
             <stage>(<emph>come sopra</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Arrivano de' forestieri. Mi faccia questa grazia,
 vada, che or ora sono da lei.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Vado: se non venite, povera voi.</p>
             <stage>(<emph>parte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Se non venite, povera voi? Povera me, se vi
 andassi. La cosa va sempre peggio. Rimediamoci, se si può.
@@ -7328,60 +7356,60 @@ io certe manierine, certe occhiatine, certe smorfiette, che
 bisogna, che caschino, se fossero di macigno. Fabrizio?</p>
             <stage>(<emph>chiama ad un'altra porta</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Avete chiamato?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Venite qui; voglio farvi una confidenza.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Son qui.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Sappiate, che il cavaliere di Ripafratta si è
 scoperto innamorato di me.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Eh, me ne son accorto.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Sì? Ve ne siete accorto? Io in verità, non me ne
 sono mai avveduta.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Povera semplice! Non ve ne siete accorta! Non avete
 veduto quando stiravate col ferro, le smorfie, che vi
 faceva? La gelosia, che aveva di me?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Io che opero senza malizia, prendo le cose con
 indifferenza. Basta; ora mi ha dette certe parole, che in
 verità, Fabrizio, mi hanno fatto arrossire.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Vedete; questo vuol dire, perché siete una giovane
 sola, senza padre, senza madre, senza nessuno. Se foste
 maritata, non anderebbe così.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Orsù capisco, che dite bene; ho pensato di
 maritarmi.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Ricordatevi di vostro padre.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Sì, me ne ricordo.</p>
           </sp>
@@ -7392,64 +7420,64 @@ maritarmi.</p>
             <emph>Il Cavaliere di dentro e detti. Il Cavaliere batte alla
 porta dove era prima.</emph>
           </stage>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Picchiano.</p>
             <stage>(<emph>a Fabrizio</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Chi è che picchia?</p>
             <stage>(<emph>forte verso la porta</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Apritemi.</p>
             <stage>(<emph>di dentro</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Il Cavaliere.</p>
             <stage>(<emph>a Fabrizio</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Che cosa vuole?</p>
             <stage>(<emph>s'accosta per aprirgli</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Aspettate ch'io parta.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Di che avete timore?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Caro Fabrizio; non so, ho paura della mia onestà.</p>
             <stage>(<emph>parte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Non dubitate, io vi difenderò.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Apritemi giuro al Cielo.</p>
             <stage>(<emph>di dentro</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Che comanda, signore? Che strepiti sono questi? In
 una locanda onorata non si fa così.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Apri questa porta.</p>
             <stage>(<emph>si sente che la sforza</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Cospetto del diavolo! Non vorrei precipitare.
 Uomini, chi è di là? Non ci è nessuno?</p>
@@ -7460,158 +7488,158 @@ Uomini, chi è di là? Non ci è nessuno?</p>
           <stage>
             <emph>Il Marchese ed il Conte dalla porta di mezzo, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Che c'è?</p>
             <stage>(<emph>sulla porta</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Che rumore è questo?</p>
             <stage>(<emph>sulla porta</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Signori, li prego; il signor cavaliere di
 Ripafratta vuole sforzar quella porta.</p>
             <stage>(<emph>piano, che il Cavaliere non senta</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Aprimi, o la getto abbasso.</p>
             <stage>(<emph>di dentro</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Che sia diventato pazzo? Andiamo via.</p>
             <stage>(<emph>al Conte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Apritegli.</p>
             <stage>(<emph>a Fabrizio</emph>)</stage>
             <p> Ho volontà per appunto di
 parlar con lui.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Aprirò; ma le supplico...</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Non dubitate. Siamo qui noi.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>(Se vedo niente, niente, me la colgo).</p>
             <stage>(<emph>da sé</emph>)</stage>
             <stage>(<emph>Fabrizio apre, ed entra il Cavaliere</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Giuro al Cielo, dov'è?</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Chi cerca, signore?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Mirandolina dov'è?</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Io non lo so.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>(L'ha con Mirandolina. Non è niente).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Scellerata, la troverò.</p>
             <stage>(<emph>s'incammina, e scopre il Conte e il Marchese</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Con chi l'avete?</p>
             <stage>(<emph>al Cavaliere</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Cavaliere, noi siamo amici.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Oimè! Non vorrei per tutto l'oro del mondo, che
 nota fosse questa mia debolezza).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Che cosa vuole, signore, dalla padrona?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>A te non devo rendere questi conti. Quando comando
 voglio esser servito. Pago i miei denari per questo, e giuro
 al Cielo, ella averà che fare con me.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>V.S. paga i suoi denari per essere servito nelle
 cose lecite, e oneste, ma non ha poi da pretendere, la mi
 perdoni, che una donna onorata...</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Che dici tu? Che sai tu? Tu non entri ne' fatti
 miei. So io quel che ho ordinato a colei...</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Le ha ordinato di venire nella sua camera.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Va' via, briccone, che ti rompo il cranio.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Mi maraviglio di lei.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Zitto.</p>
             <stage>(<emph>a Fabrizio</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Andate via.</p>
             <stage>(<emph>a Fabrizio</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Vattene via di qui.</p>
             <stage>(<emph>a Fabrizio</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Dico, signore...</p>
             <stage>(<emph>riscaldandosi</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Via.</p>
             <stage>(<emph>lo caccia via</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Via.</p>
             <stage>(<emph>lo caccia via</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>(Corpo di bacco! Ho proprio voglia di precipitare).</p>
             <stage>(<emph>da sé, parte</emph>)</stage>
@@ -7622,27 +7650,27 @@ miei. So io quel che ho ordinato a colei...</p>
           <stage>
             <emph>Il Cavaliere, il Marchese ed il Conte</emph>
           </stage>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Indegna! Farmi aspettar nella camera?).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>(Che diamine ha?).</p>
             <stage>(<emph>piano al Conte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>(Non lo vedete? È innamorato di Mirandolina).</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(E si trattiene con Fabrizio? E parla seco di
 matrimonio?).</p>
             <stage><emph> (da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>(Ora è il tempo di vendicarmi).</p>
             <stage>(<emph>da sé</emph>)</stage>
@@ -7650,230 +7678,230 @@ matrimonio?).</p>
 Cavaliere, non conviene ridersi delle altrui debolezze,
 quando si ha un cuor fragile come il vostro.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Di che intendete voi di parlare?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>So, da che provengono le vostre smanie.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Intendete voi di che parli?</p>
             <stage>(<emph>alterato, al Marchese</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Amico, io non so niente.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Parlo di voi, che col pretesto di non poter
 soffrire le donne, avete tentato rapirmi il cuore di
 Mirandolina, ch'era già mia conquista.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Io?</p>
             <stage>(<emph>alterato, verso il Marchese</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Io non parlo.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Voltatevi a me, a me rispondete. Vi vergognate
 forse di aver mal proceduto?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Io mi vergogno d'ascoltarvi più oltre, senza dirvi,
 che voi mentite.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>A me una mentita?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>(La cosa va peggiorando).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Con qual fondamento potete voi dire?... (Il Conte
 non sa ciò, che si dica).</p>
             <stage>(<emph>al Marchese, irato</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Ma io non me ne voglio impicciare.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Voi, siete un mentitore.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Vado via.</p>
             <stage>(<emph>vuol partire</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Fermatevi.</p>
             <stage>(<emph>lo trattiene per forza</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>E mi renderete conto...</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Sì, vi renderò conto... Datemi la vostra spada.</p>
             <stage>(<emph>al Marchese</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Eh via; acquietatevi tutti due. Caro Conte, cosa
 importa a voi, che il Cavaliere ami Mirandolina?...</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Io l'amo? Non è vero; mente chi lo dice.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Mente?... La mentita non viene a me. Non sono io
 che lo dico.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Chi dunque?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Io lo dico, e lo sostengo, e non ho soggezione di
 voi.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Datemi quella spada.</p>
             <stage>(<emph>al Marchese</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>No, dico.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Siete ancora voi mio nemico?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Io sono amico di tutti.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Azioni indegne son queste. Azioni da traditori, da
 gente infame.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Oh giuro al Cielo!</p>
             <stage>(<emph>leva la spada al Marchese, la quale esce col fodero</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Non mi perdete il rispetto.</p>
             <stage>(<emph>al Cavaliere</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Se vi chiamate offeso, darò soddisfazione anche a
 voi.</p>
             <stage>(<emph>al Marchese</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Via; siete troppo caldo. (Mi dispiace...).</p>
             <stage>(<emph>da sé, rammaricandosi</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Io voglio soddisfazione.</p>
             <stage>(<emph>si mette in guardia</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Ve la darò.</p>
             <stage>(<emph>vuol levar il fodero, e non può</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Quella spada non vi conosce...</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Oh maledetta!</p>
             <stage>(<emph>sforza per cavarlo</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Cavaliere; non farete niente...</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Non ho più sofferenza.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Eccola.</p>
             <stage>(<emph>cava la spada, e vede essere mezza lama</emph>)</stage>
             <p>Che è questo?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Mi avete rotta la spada.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Il resto dov'è? Nel fodero non v'è niente.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Sì, è vero; l'ho rotta nell'ultimo duello; non me
 ne ricordavo.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Lasciatemi provveder d'una spada.</p>
             <stage>(<emph>al Conte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Giuro al Cielo, voi non mi fuggirete di mano.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Che fuggire? Ho cuore di farvi fronte anche con
 questo pezzo di lama.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>È lama di Spagna, non ha paura.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Non tanta bravura, signor gradasso.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Sì, con questa lama.</p>
             <stage>(<emph>s'avventa verso il Conte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Indietro.</p>
             <stage>(<emph>si pone in difesa</emph>)</stage>
@@ -7884,65 +7912,65 @@ questo pezzo di lama.</p>
           <stage>
             <emph>Mirandolina, Fabrizio e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Alto, alto, padroni.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Alto, signori miei, alto.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Ah maledetta!).</p>
             <stage>(<emph>vedendo Mirandolina</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Povera me! Colle spade?</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Vedete? Per causa vostra.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Come per causa mia?</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Eccolo lì il signor Cavaliere. È innamorato di
 voi.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Io innamorato? Non è vero; mentite.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Il signor Cavaliere innamorato di me? Oh no,
 signor Conte, ella s'inganna. Posso assicurarla, che
 certamente s'inganna.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Eh che siete voi pur d'accordo...</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Si sa; si vede...</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Che si sa? Che si vede?</p>
             <stage>(<emph>alterato, verso il Marchese</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Dico che quando è, si sa... Quando non è non si
 vede.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Il signor Cavaliere innamorato di me? Egli lo
 nega, e negandolo in presenza mia, mi mortifica, mi
@@ -7958,79 +7986,79 @@ ho fatto niente. È vero signore? Ho fatto, ho fatto, e non
 ho fatto niente.</p>
             <stage>(<emph>al Cavaliere</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Ah! Non posso parlare).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Lo vedete? Si confonde.</p>
             <stage>(<emph>a Mirandolina</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Non ha coraggio di dir di no.</p>
             <stage>(<emph>a Mirandolina</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Voi non sapete quel che vi dite.</p>
             <stage>(<emph>al Marchese, irato</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>E sempre l'avete con me.</p>
             <stage>(<emph>Al Cavaliere, dolcemente</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Oh il signor Cavaliere non s'innamora. Conosce
 l'arte. Sa la furberia delle donne: alle parole non crede;
 delle lagrime non si fida. Degli svenimenti poi se ne ride.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Sono dunque finte le lagrime delle donne, sono
 mendaci gli svenimenti?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Come? Non lo sa, o finge di non saperlo?</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Giuro al Cielo! Una tal finzione meriterebbe uno
 stile nel cuore.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Signor Cavaliere, non si riscaldi, perché questi
 signori, diranno, ch'è innamorato davvero.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sì, lo è, non lo può nascondere.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Si vede negli occhi.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>No, non lo sono.</p>
             <stage>(<emph>irato al Marchese</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>E sempre con me.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>No signore, non è innamorato. Lo dico, lo
 sostengo, e son pronta a provarlo.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Non posso più).</p>
             <stage>(<emph>da sé</emph>)</stage>
@@ -8038,31 +8066,31 @@ sostengo, e son pronta a provarlo.</p>
 troverete provveduto di spada.</p>
             <stage>(<emph>getta via la mezza spada del Marchese</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Ehi! la guardia costa denari.</p>
             <stage>(<emph>la prende di terra</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Si fermi, signor Cavaliere, qui ci va della sua
 riputazione. Questi signori credono ch'ella sia innamorato;
 bisogna disingannarli.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Non vi è questo bisogno.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Oh sì signore; vi è. Si trattenga un momento.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Che far intende costei?).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Signori, il più certo segno d'amore è quello
 della gelosia, e chi non sente la gelosia, certamente non
@@ -8070,48 +8098,48 @@ ama. Se il signor Cavaliere mi amasse, non potrebbe
 soffrire, ch'io fossi d'un altro, ma egli lo soffrirà, e
 vedranno...</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Di chi volete voi essere?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Di quello a cui mi ha destinato mio padre.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Parlate forse di me?</p>
             <stage>(<emph>a Mirandolina</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Sì, caro Fabrizio, a voi in presenza di questi
 cavalieri, vo' dar la mano di sposa.</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>(Oimè! Con colui? non ho cuor di soffrirlo).</p>
             <stage>(<emph>da sé, smaniando</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>(Se sposa Fabrizio, non ama il Cavaliere).</p>
             <stage>(<emph>da sé</emph>)</stage>
             <p> Sì, sposatevi, e vi prometto trecento scudi.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Mirandolina, è meglio un ovo oggi, che una gallina
 domani. Sposatevi ora, e vi do subito dodici zecchini.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Grazie, signori, non ho bisogno di dote. Sono una
 povera donna senza grazia, senza brio, incapace di innamorar
 persone di merito. Ma Fabrizio mi vuol bene, ed io in questo
 punto alla presenza loro lo sposo...</p>
           </sp>
-          <sp>
+          <sp who="#cavaliere">
             <speaker>CAVALIERE</speaker>
             <p>Sì, maledetta, sposati a chi tu vuoi. So, che tu
 m'ingannasti, so che trionfi dentro di te medesima d'avermi
@@ -8133,15 +8161,15 @@ disprezzarlo, ma ci conviene fuggirlo.</p>
           <stage>
             <emph>Mirandolina, il Conte, il Marchese e Fabrizio</emph>
           </stage>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Dica ora di non essere innamorato.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Se mi dà un'altra mentita, da cavaliere lo sfido.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Zitto, signori, zitto. È andato via, e se non
 torna, e se la cosa mi passa così, posso dire di essere
@@ -8149,20 +8177,20 @@ fortunata. Pur troppo, poverino, mi è riuscito
 d'innamorarlo, e mi son messa ad un brutto rischio. Non ne
 vo' saper altro. Fabrizio, vien qui, caro, dammi la mano.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>La mano? Piano un poco, signora. Vi dilettate di
 innamorar la gente in questa maniera, e credete ch'io vi
 voglia sposare?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Eh via pazzo! È stato uno scherzo, una
 bizzarria, un puntiglio. Ero fanciulla, non avevo nessuno,
 che mi comandasse. Quando sarò maritata, so io quel che
 farò.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Che cosa farete?</p>
           </sp>
@@ -8172,147 +8200,147 @@ farò.</p>
           <stage>
             <emph>Il Servitore del Cavaliere e detti</emph>
           </stage>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Signora padrona, prima di partire son venuto a
 riverirvi.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Andate via?</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Sì. Il padrone va alla posta. Fa attaccare: mi
 aspetta colla roba, e ce ne andiamo a Livorno.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Compatite, se non vi ho fatto...</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Non ho tempo da trattenermi. Vi ringrazio, e vi
 riverisco.</p>
             <stage>(<emph>parte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Grazie al Cielo, è partito. Mi resta qualche
 rimorso; certamente è partito con poco gusto. Di questi
 spassi non me ne cavo mai più.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Mirandolina, fanciulla, o maritata che siate, sarò
 lo stesso per voi.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Fate pur capitale della mia protezione.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Signori miei, ora che mi marito, non voglio
 protettori, non voglio spasimati, non voglio regali. Sin ora
 mi sono divertita, e ho fatto male, e mi sono arrischiata
 troppo, e non lo voglio fare mai più. Questi è mio marito...</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Ma piano, signora...</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Che piano? Che cosa c'è? Che difficoltà ci sono?
 Andiamo. Datemi quella mano.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Vorrei che facessimo prima i nostri patti.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Che patti? Il patto è questo; o dammi la mano, o
 vattene al tuo paese.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Vi darò la mano... ma poi...</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Ma poi, sì caro, sarò tutta tua; non dubitare di
 me, ti amerò sempre, sarai l'anima mia.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>Tenete, cara, non posso più.</p>
             <stage>(<emph>le dà la mano</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>(Anche questa è fatta).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Mirandolina, voi siete una gran donna, voi avete
 l'abilità di condur gli uomini dove volete.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Certamente la vostra maniera obbliga
 infinitamente.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Se è vero, ch'io possa sperar grazie da lor
 signori, una ne chiedo loro per ultimo.</p>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Dite pure.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Parlate.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>(Che cosa mai adesso domanderà?).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Li supplico per atto di grazia, a provvedersi
 d'un'altra locanda.</p>
           </sp>
-          <sp>
+          <sp who="#fabrizio">
             <speaker>FABRIZIO</speaker>
             <p>(Brava; ora vedo, che la mi vuol bene).</p>
             <stage>(<emph>da sé</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <p>Sì, vi capisco, e vi lodo. Me n'anderò, ma dovunque
 io sia, assicuratevi della mia stima.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Ditemi; avete voi perduta una boccettina d'oro?</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Sì signore.</p>
           </sp>
-          <sp>
+          <sp who="#marchese">
             <speaker>MARCHESE</speaker>
             <p>Eccola qui. L'ho io ritrovata, e ve la rendo.
 Partirò per compiacervi, ma in ogni loco fate pur capitale
 della mia protezione.</p>
           </sp>
-          <sp>
+          <sp who="#mirandolina">
             <speaker>MIRANDOLINA</speaker>
             <p>Queste espressioni mi saran care, nei limiti
 della convenienza, e dell'onestà. Cambiando stato, voglio

--- a/tei/goldoni-la-sposa-persiana.xml
+++ b/tei/goldoni-la-sposa-persiana.xml
@@ -84,6 +84,37 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="tamas">
+            <persName>Tamas</persName>
+          </person>
+          <person xml:id="ali">
+            <persName>Alí</persName>
+          </person>
+          <person xml:id="ircana">
+            <persName>Ircana</persName>
+          </person>
+          <person xml:id="curcuma">
+            <persName>Curcuma</persName>
+          </person>
+          <person xml:id="machmut">
+            <persName>Machmut</persName>
+          </person>
+          <person xml:id="osmano">
+            <persName>Osmano</persName>
+          </person>
+          <person xml:id="fatima">
+            <persName>Fatima</persName>
+          </person>
+          <person xml:id="ibraima">
+            <persName>Ibraima</persName>
+          </person>
+          <person xml:id="zama">
+            <persName>Zama</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -453,21 +484,21 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Tamas, ed Alí.</emph>
           </stage>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Non mi annoiare, Alí: son dal dolore oppresso;</l>
             <l>Odio gli altrui consigli, odio perfin me stesso.</l>
             <l>L'oppio, che pur sai, quanto suole alterar gli spirti,</l>
             <l>Nulla giovommi; oh pensa... Vanne; non voglio udirti.</l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l> Sì, me ne andrò: che importa a me, che voi parliate?</l>
             <l>Io sarò sempre Alí, ancor quando crepiate;</l>
             <l>E sarò sempre stato vostro fedele amico,</l>
             <l>Ancor, che de' miei detti non ve ne caglia un fico.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Come parli? Che stile inusitato, e nuovo?</l>
             <l>Fra tai sconce parole, Alí più non ritrovo.</l>
@@ -475,7 +506,7 @@ che introduce al serraglio di Tamas.</p>
             <l>Ridicolo costume in Ispaan sconviene.</l>
             <l>Come favelli? Hai d'oppio la dose caricata?</l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l> Sì, amico; doppia dose per voi ne ho trangugiata:</l>
             <l>Per voi, che pur vorrei colla letizia mia</l>
@@ -485,20 +516,20 @@ che introduce al serraglio di Tamas.</p>
             <l>Gioia mi desta in petto inusitata, e strana.</l>
             <l part="I">Tamas, gioite meco. </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F">Ogni tua cura è vana:</l>
             <l>Gioir non mi farebbe né scettro, né corona;</l>
             <l>Vedi se potrà farlo un ebrio, che ragiona.</l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l> Ebrio son io, nol niego, pel sonnifero amaro,</l>
             <l>Non pel vietato vino, dolce al palato, e caro;</l>
             <l>E pur (ve lo confido) in quattro ier di sera</l>
             <l>Un orcio ne bevemmo nella <emph>caravanzera</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Cosa tu mi confidi da me con sdegno udita;</l>
             <l>Vino non bevvi mai pel corso di mia vita.</l>
@@ -507,94 +538,94 @@ che introduce al serraglio di Tamas.</p>
             <l>E dove non arriva la forza di chi regge,</l>
             <l>Vincola nei recessi dell'onestà la legge.</l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l> Sì, giovine bennato, alma di virtù piena,</l>
             <l>Alma, ch'esser tranquilla dovrebbe, e più serena;</l>
             <l>Poiché se un giovin pio ripieno ha il cor di doglie,</l>
             <l>Chi fia che ad imitarlo nella bontà s'invoglie?</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> In te cresce de' spirti l'alterazion funesta;</l>
             <l>Per tai ragionamenti ora importuna è questa.</l>
             <l part="I">Lasciami, te ne priego. </l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l part="F"> Io non vi lascio al certo,</l>
             <l>Se il duol, che avete in seno, non mi mostrate aperto;</l>
             <l>Non vi darò consigli, non vi sarò molesto;</l>
             <l part="I">Altro da voi non bramo. </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="M"> Altro non vuoi? </l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l part="F"> Che questo.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Sai tu, che il padre mio sposa mi ha destinata</l>
             <l part="I">La figliuola di Osmano? </l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l part="F">Ella era appena nata,</l>
             <l>E voi d'un lustro appena; senz'ara, e senza Nume</l>
             <l>Foste legati insieme, giusta il Perso costume.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Empio costume, e rio, che il maggior ben ci fura;</l>
             <l>Che toglie a noi l'arbitrio, e offende la natura.</l>
             <l>Ecco, amico, la fonte del mio dolore estremo;</l>
             <l>La sposa oggi s'aspetta, l'ora s'appressa, io tremo.</l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l> Ed io, ridete amico, ed io sarei contento,</l>
             <l>Non se una sola sposa aspettassi, ma cento.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Vanne, lo dissi, il veggio, hai la ragion perduta.</l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l part="I">Vado... È brutta la sposa? </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F">Non so, non l'ho veduta.</l>
             <l>Sai pur che le fanciulle serbansi ritirate,</l>
             <l>E scopronsi allo sposo dopo esser maritate.</l>
             <l part="I">Ma tu deliri, vanne. </l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l part="F">Un'altra cosa sola.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I">Teco non vuo' parlare. </l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l part="F">Udite una parola.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I">Che sofferenza! Parla. </l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l part="F">Fra l'ebrio, e fra l'astuto</l>
             <l>Vuo' domandarvi: avete forse il cor prevenuto?</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Ah sì, d'Ircana mia, della mia schiava acceso,</l>
             <l>Soffrir non potrò mai d'un altro nodo il peso.</l>
@@ -603,15 +634,15 @@ che introduce al serraglio di Tamas.</p>
             <l>L'alma quei suoi begli occhi a vagheggiare avvezza,</l>
             <l>Odia d'ogni altra il nome, ogni beltà disprezza.</l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l part="I">Tamas, il mio consiglio... </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F">Vattene, io non l'ascolto.</l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l> Vado, ma prima udite i sensi d'uno stolto,</l>
             <l>D'uno, che in fretta in fretta vi dice il suo pensiere,</l>
@@ -639,7 +670,7 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Tamas solo.</emph>
           </stage>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Quest'ultime parole non son d'ebrio, o di stolto;</l>
             <l>Ragion trovo in que' detti, e la ragion m'ha colto.</l>
@@ -670,46 +701,46 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Ircana, e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Tamas, perché sì lento a riveder ritorni</l>
             <l>Quella, che per te solo mena felici i giorni?</l>
             <l>Sai pur, che oltre il vederti non provo altro contento,</l>
             <l>Un secolo mi sembra lungi da te un momento.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Molto non è, che al bagno io ti lasciai, mia vita;</l>
             <l>Tosto più dell'usato sei fuor dell'acque uscita.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Ah son tre giorni interi, ch'io piango, e mi dispero.</l>
             <l part="I">Barbaro tu mi lasci. </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F">No, [non] sarà mai vero.</l>
             <l>D'amarti fin ch'io viva sacra ti do parola.</l>
             <l part="I">Bastati? </l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="M">No. </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F">Che brami? </l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Voglio, che mi ami sola.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I">Oh ciel! </l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="F">Lo vedi, ingrato? Lo vedi se m'inganni?</l>
             <l>Lo so perché sospiri, [lo so] perché t'affanni.</l>
@@ -724,7 +755,7 @@ che introduce al serraglio di Tamas.</p>
             <l>Dopo lusinghe tante, schiava negletta, oppressa,</l>
             <l>Saprei svenarmi in faccia della tua sposa istessa.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Fra noi tal è il costume di chi suddito nasce;</l>
             <l>Fatima, ed io dal padre fummo legati in fasce.</l>
@@ -735,7 +766,7 @@ che introduce al serraglio di Tamas.</p>
             <l>Consolati, ben mio, se umile al genitore,</l>
             <l>Darò ad altra la mano, tuo sarà sempre il core.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Eh che mai si divide da chi ha la destra in pegno,</l>
             <l>De' forsennati il cuore con un affetto indegno.</l>
@@ -748,28 +779,28 @@ che introduce al serraglio di Tamas.</p>
             <l>«Faccia Macon, ch'io trovi signor, che mi ami sola,</l>
             <l>O tolgami dal petto lo spirto, e la parola».</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Sensi d'alma bennata, voti di cor sincero;</l>
             <l part="I">Sì, ti amerò: te sola... </l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="F">Non lo dir, non lo spero.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I">Ma se lo giuro... </l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="M">Taci. </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F">Lo giuro al Ciel... </l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Gli audaci</l>
             <l>Beltà rende spergiuri, amor rende mendaci.</l>
@@ -780,11 +811,11 @@ che introduce al serraglio di Tamas.</p>
             <l>Aprimi queste porte, dove rinchiusa io sono;</l>
             <l>Dammi, d'amore in vece, la libertade in dono.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Ah crudel, sì penosa parti la mia catena!</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Tu lo sai, se finora n'ebbi diletto, o pena.</l>
             <l>La libertà ti chiedo, non per lusinga insana,</l>
@@ -792,7 +823,7 @@ che introduce al serraglio di Tamas.</p>
             <l>Ma per lasciarti in pace accanto alla consorte,</l>
             <l>Senza, che ti funesti l'orror della mia morte.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Ah, che ogni tua parola è a questo cuor ferita:</l>
             <l>Non lascierotti, Ircana, non morirai mia vita.</l>
@@ -803,11 +834,11 @@ che introduce al serraglio di Tamas.</p>
             <l>In altra guisa aspetti vedermi all'Ottomano</l>
             <l>Tra le persiane genti andar col ferro in mano...</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="I">Dunque? </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F">Non più; se temi, se del mio amor diffidi,</l>
             <l>Tamas, che pietà merta, tu crudelmente uccidi.</l>
@@ -824,7 +855,7 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Ircana sola.</emph>
           </stage>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Nulla intentato io voglio lasciar per un tal bene,</l>
             <l>Per l'unico fra' beni, che a noi sperar conviene.</l>
@@ -843,7 +874,7 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Curcuma, e detta.</emph>
           </stage>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Ircana, ove t'aggiri? Posso io bene aspettarti,</l>
             <l>Non vieni questa mane a pulirti, a lisciarti?</l>
@@ -854,7 +885,7 @@ che introduce al serraglio di Tamas.</p>
             <l>Sono le tue compagne lisciate come specchi,</l>
             <l>E tu senz'artifizio accorlo ti apparecchi?</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> S'adorni e si profumi, e s'unga, e si colori</l>
             <l>Chi di natura ha d'uopo di corregger gli errori.</l>
@@ -865,7 +896,7 @@ che introduce al serraglio di Tamas.</p>
             <l>A te fido l'arcano; son lieta, e son contenta,</l>
             <l>E la temuta sposa or più non mi spaventa.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Sì, qualche volta, è vero, l'amante si diletta</l>
             <l>Nel vagheggiar di furto la femina negletta,</l>
@@ -878,21 +909,21 @@ che introduce al serraglio di Tamas.</p>
             <l>Ma allor, che dalla mano fia la beltà accresciuta,</l>
             <l>La donna è sempre bella, ancor quando è svenuta.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Orsù, più d'esser bella calsemi veder lui</l>
             <l>Per tempo, e i dolci accenti udir dai labbri sui.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="I">E t'ha promesso amarti? </l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="F">Sacra mi diè parola</l>
             <l>(Questo è quel che mi cale) d'amarmi sempre, e sola.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Figlia, se tal promessa a te fia poi serbata,</l>
             <l>Poi dir, che la fenice in Persia hai ritrovata;</l>
@@ -905,33 +936,33 @@ che introduce al serraglio di Tamas.</p>
             <l>E se d'[un] uomo solo dee contentarsi, almeno</l>
             <l>Posto è da pari legge anche ai mariti il freno.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Chi sa? La dura legge spero per me corretta.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Ma se la nuova sposa Tamas in breve aspetta?</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Tamas in questo punto, del genitore al piede,</l>
             <l>Spinto dalle mie fiamme, a ricusarla andiede.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="I">E se volesse il padre?... </l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="F">Tu mi tormenti invano.</l>
             <l part="I">Esser dee mio quel core. </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F">E sarà tua la mano?</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Sì, lo spero: tu mi ami, e so, che di te niuna</l>
             <l>Brama più del mio cuore la pace, e la fortuna.</l>
@@ -944,7 +975,7 @@ che introduce al serraglio di Tamas.</p>
             <l>Tu puoi del di lui cuore spiar gli occulti arcani:</l>
             <l>Per madre mia ti eleggo, io son nelle tue mani.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Figlia, perché lo merti, al desir tuo mi unisco,</l>
             <l>Non già per questa gemma, che per amor gradisco;</l>
@@ -955,22 +986,22 @@ che introduce al serraglio di Tamas.</p>
             <l>Una malìa faremo sì forte, e portentosa,</l>
             <l>Che strugga in pochi giorni e l'amante e la sposa.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="I">No, l'amante. </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F">Sta cheta; l'amante sino a tanto</l>
             <l>Che della nuova sposa viva giulivo a canto;</l>
             <l>Indi fedel tornando sia d'ogni mal guarito,</l>
             <l>D'esserti impaziente, non più signor, marito.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="I">Hai tal poter? </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F">Sì, cara, vedrai portenti strani,</l>
             <l>Vedrai quel che san fare di Curcuma le mani.</l>
@@ -989,7 +1020,7 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Ircana sola.</emph>
           </stage>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Ah voglia il ciel, che mai abbiasi a usar tal'arte:</l>
             <l>Laddove amor fa d'uopo, rigor non abbia parte.</l>
@@ -1026,7 +1057,7 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Machmut accompagnato da quattro Officiali, che attendono gli ordini suoi.</emph>
           </stage>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l> Olà, ciascun s'impieghi: i schiavi, i servi, i cuochi;</l>
             <l>Si preparin le mense, i vasi, i cibi, i giuochi.</l>
@@ -1065,51 +1096,51 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Tamas e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I">Signor, a' piedi vostri... </l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="F">Perché sì mesto in viso?</l>
             <l>Lungi non è la sposa, n'ebbi testé l'avviso.</l>
             <l>Accoglierla a momenti dovrai fra le tue braccia.</l>
             <l>E ti disponi a farlo torvo? turbato in faccia?</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Signor pria che la sposa giunga fra i muri nostri,</l>
             <l>Eccomi a voi prostrato, eccomi a' piedi vostri. <emph>(s'inginocchia)</emph></l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l> Alzati... Olà, che dici? Sei tu di lei pentito?</l>
             <l>È tardi; ella ti aspetta, esser le dei marito.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I">Ma se il mio cor... </l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="F">T'accheta, nel vincolarsi il figlio</l>
             <l>Prenda dal genitore, non dal suo cor, consiglio.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I">E se l'odiassi? </l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="F">Degna d'amor Fatima io stimo,</l>
             <l>Ma se la sposa odiassi, tu non saresti il primo.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Che nozze! che sponsali! che barbaro costume!</l>
             <l>L'approvano le leggi, e lo comporta il Nume?</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l> Sì, di Maccone stesso, d'Alí, ch'indi si onora,</l>
             <l>E dei dodici Imanni, che venner dopo ancora,</l>
@@ -1124,12 +1155,12 @@ che introduce al serraglio di Tamas.</p>
             <l>Ricchi smanigli e gemme, schiavi ti reca in dote:</l>
             <l>Queste son beltà vere, l'altre a me sono ignote.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Dunque per gemme, e schiavi, per vesti, perle ed oro,</l>
             <l>Perder dovranno i figli di libertà il tesoro?</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l> Odi, vuo' consolarti. Fatima la tua sposa</l>
             <l>Ricca non è soltanto, ma è bella, ed è vezzosa.</l>
@@ -1158,7 +1189,7 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Tamas solo.</emph>
           </stage>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> E vi sarà d'Ircana donna più bella ancora?</l>
             <l>Di Fatima il ritratto nell'udirlo innamora.</l>
@@ -1194,21 +1225,21 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Ircana e Curcuma.</emph>
           </stage>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Ah Curcuma, e fia vera la nova dolorosa?</l>
             <l>Tamas andò egli istesso ad incontrar la sposa?</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Questi occhi lo han veduto, e, qual da giovinetta</l>
             <l>Conservo (grazie al cielo) la vista ancor perfetta.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="I">Ohimè! </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F">Non vi affliggete, di già ci siamo intese;</l>
             <l>M'impegno, che la sposa viva non dura un mese.</l>
@@ -1219,23 +1250,23 @@ che introduce al serraglio di Tamas.</p>
             <l>Ho l'antimonio, il sale, il solfo e l'orpimento,</l>
             <l>E mancami soltanto dell'oro, e dell'argento.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="I">Eccome, prendi questo. <emph>(si strappa uno smaniglio)</emph> </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F">Piano non lo strappate;</l>
             <l>Spiacemi, che d'un fregio la bella man spogliate.</l>
             <l>E pur fia necessario scioglierlo in una tazza.</l>
             <l>(Sciogliere lo smaniglio? Affé, non son sì pazza). <emph>(da sé)</emph></l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Ma incontro alla sua sposa è volontario andato</l>
             <l>Tamas, o da suo padre a forza strascinato?</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Non so; ma l'ho veduto montar sul suo destriere,</l>
             <l>Tutto coperto d'oro, che a mirarlo è un piacere,</l>
@@ -1258,12 +1289,12 @@ che introduce al serraglio di Tamas.</p>
             <l>Tale è in Persia il costume, ahi troppo dolorosa</l>
             <l>Disparità, che passa tra una schiava, e una sposa!</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Curcuma, tu mi uccidi, tu m'empi di dispetto,</l>
             <l>Vedrai morire Ircana con uno stile in petto.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Sì, quando al fianco vostro Curcuma non aveste,</l>
             <l>E di costei, che vi ama, fidar non vi poteste.</l>
@@ -1272,7 +1303,7 @@ che introduce al serraglio di Tamas.</p>
             <l>In ogni guisa certa io son del vostro bene...</l>
             <l>Sentite i gridi, i suoni; ecco la sposa viene.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Ah non voglio vederla; ah non fia mai, che a quella</l>
             <l>Fia destinata Ircana servir schiava, ed ancella.</l>
@@ -1289,7 +1320,7 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Curcuma sola.</emph>
           </stage>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> La compatisco in parte, ma in parte la condanno;</l>
             <l>Perché per una sposa prendersi tanto affanno?</l>
@@ -1324,7 +1355,7 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Machmut, Fatima coperta da un velo, ed Osmano, preceduti da vari instrumenti; e seguito di schiavi, che portano su vari bacini la dote della sposa.</emph>
           </stage>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l> Figlia, questo che premi, è del tuo sposo il suolo:</l>
             <l>Fuor del paterno impero, devi obbedir lui solo.</l>
@@ -1363,7 +1394,7 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Machmut, Fatima e li suddetti.</emph>
           </stage>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l> Olà, parta ciascuno; in libertà qui resti</l>
             <l>Dello sposo la sposa ai primi sguardi onesti.</l>
@@ -1401,7 +1432,7 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Fatima sola.</emph>
           </stage>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Misera me, che sento? Qual rio serpe geloso</l>
             <l>Prevenuto ha il momento da scoprirmi allo sposo?</l>
@@ -1418,7 +1449,7 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Tamas, e detta.</emph>
           </stage>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> (Eccomi al gran cimento. Ah quel ch'io temo in quella</l>
             <l>È, che d'Ircana sia più vezzosa, e più bella</l>
@@ -1431,46 +1462,46 @@ che introduce al serraglio di Tamas.</p>
             <l>Quest'è il primier momento, che ad uom scoprir vi lice:</l>
             <l>Svelatevi a' miei lumi; fatemi omai felice.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Dolce obbedire a sposo, che può volere, e prega;</l>
             <l>Squarcierò il velo ingrato, che disciogliersi niega.</l>
             <l>Ecco la sposa vostra, ecco la vostra ancella <emph>(si scuopre)</emph>,</l>
             <l part="I">Che v'ama, che v'adora. </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F">(No, che non è più quella).</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Signor, se questi luci a voi non sembran vaghe,</l>
             <l>Se in me non v'è beltade, che il genio vostro appaghe,</l>
             <l>Non disprezzate almeno le fiamme d'una sposa,</l>
             <l part="I">Che a voi destina il cielo. </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F">(Ircana è più vezzosa) <emph>(da sé).</emph></l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> (Misera, son perduta; ogni speranza è estinta) <emph>(da sé).</emph></l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> (Fatima è bella, è vero, ma nel confronto è vinta) <emph>(da sé).</emph></l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> (Vezzi di sposa amante, arte di moglie onesta,</l>
             <l>Deh non mi abbandonate in occasion funesta) <emph>(da sé).</emph></l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> (Ma che farò? Mi duole darle un sì rio tormento) <emph>(da sé).</emph></l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Tamas, nel vostro volto veggo un fier turbamento;</l>
             <l>Quelle nozze, a cui fummo dal genitor costretti,</l>
@@ -1486,7 +1517,7 @@ che introduce al serraglio di Tamas.</p>
             <l>Ditemi se m'odiate, per mio infelice aspetto,</l>
             <l>O se beltà più vaga v'abbia ferito il petto.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Fatima, non lo niego; a forza i' son marito,</l>
             <l>Questo sen, questo cuore, è ver, fu già ferito.</l>
@@ -1501,31 +1532,31 @@ che introduce al serraglio di Tamas.</p>
             <l>Vi scopriste, v'ammiro: bella e vezzosa siete;</l>
             <l>Ma cancellar quell'altra dal cuor non mi potete.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Né cancellarla io spero, né in me vuo' che si dica,</l>
             <l>Che in vece d'una sposa, trovaste una nemica.</l>
             <l>Ma di me sventurata, signor, che sarà mai?</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Fatima, non so dirlo; ancor non ci pensai.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Sposi noi siamo, è vero, ma niun de' nostri petti</l>
             <l>Può esaminar gli ardori, può discoprir gli affetti.</l>
             <l>Celisi in faccia al mondo, che il volto mio vi spiace,</l>
             <l>Io soffrirò, che amiate la mia rivale in pace.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Bella virtù, che merta amante a voi più grato!</l>
             <l>Fatima, lo confesso, compiango il vostro stato;</l>
             <l>Poco chiedete, in premio d'un cor di virtù pieno,</l>
             <l>E il poco, che chiedete, posso accordar nemeno.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Misera me! Vorreste col rossor d'un rifiuto</l>
             <l>Rendermi d'una schiava vergognoso tributo?</l>
@@ -1537,11 +1568,11 @@ che introduce al serraglio di Tamas.</p>
             <l>Senza oltraggiar l'amato signor di queste soglie).</l>
             <l>Che vol di più? Lo dica; farlo vi do parola.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Gelosa è del cuor mio; brama regnarvi sola.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Sola? Di sì bel regno l'arbitra non io sono,</l>
             <l>Voi sugli affetti vostri, dar le potete il trono.</l>
@@ -1552,12 +1583,12 @@ che introduce al serraglio di Tamas.</p>
             <l>Ed a soffrir le insegni, senza esserne sdegnosa,</l>
             <l>L'esempio avanti agli occhi d'una non vile, e sposa <emph>(piange)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> (Muove pietà col pianto, misera donna oppressa.</l>
             <l>Se la vedesse Ircana, pietà ne avrebbe anch'essa) <emph>(da sé).</emph></l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Da voi sposata appena, se lungi mi scacciate,</l>
             <l>Pensate a qual destino, signor, mi condannate.</l>
@@ -1570,7 +1601,7 @@ che introduce al serraglio di Tamas.</p>
             <l>Ed io, che di adorarvi, misera, ancor mi vanto,</l>
             <l>Per voi, non per me stessa, mi struggerei nel pianto <emph>(piange).</emph></l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Fatima, non piangete, a voi torno a momenti.</l>
             <l>(Che stile inusitato! che amor! che dolci accenti!</l>
@@ -1583,7 +1614,7 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Fatima sola.</emph>
           </stage>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Padre mio, se veduta m'avessi in tal periglio,</l>
             <l>Diresti, che seguito non abbia il tuo consiglio?</l>
@@ -1618,85 +1649,85 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Curcuma e detta.</emph>
           </stage>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Sposa gentil, e vaga, degna d'eterna lode,</l>
             <l>Curcuma a voi s'inchina, delle donne custode.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Sì, cara mia, prendete, d'aggradimento in segno,</l>
             <l>Questo di vero affetto amichevole pegno <emph>(s'abbracciano)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Siete gentil davvero; bella siete, e graziosa.</l>
             <l>(E parmi, che esser debba discreta e generosa) <emph>(da sé).</emph></l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Ditemi: quante schiave Tamas ha in suo potere?</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> (Principia dalle schiave). Dieci ne suole avere</l>
             <l>
               <emph>(Principia dalle schiave lo dice da sé).</emph>
             </l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="I">Son belle? son vezzose? </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F">Oibò, non ve n'è alcuna</l>
             <l>Che delle grazie vostre possa vantarne una.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Però non mi crediate soggetta a gelosia:</l>
             <l>Codesta in un serraglio sarebbe una follia.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="I">Certamente. </l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="F">Ma pure bramo sapere anch'io</l>
             <l>Qual sia la più diletta, fra voi, del signor mio.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Vi dirò; veramente, ha per me qualche affetto,</l>
             <l>Ma statene sicura, non abbiate sospetto.</l>
             <l>Se meco qualche volta accendersi lo veggo,</l>
             <l>Gli batto su le mani, lo sgrido, e lo correggo.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Né per il grado vostro, né per la vostra etade,</l>
             <l part="I">Si può temer. </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F">No, dite, perché amo l'onestade.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Tamas non ha di voi, chi più gli punga il cuore?</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Eh disgraziato! Basta; non vuo' darvi dolore.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Via, lo so, d'una schiava egli è perduto amante:</l>
             <l>Ditemi, come ha ricco di grazie il bel sembiante?</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Eh! mi fareste dire; con voi, la mia fanciulla,</l>
             <l>Le grazie di colei non vagliono per nulla.</l>
@@ -1705,7 +1736,7 @@ che introduce al serraglio di Tamas.</p>
             <l>Di lisci, e di pomate io son maestra antica;</l>
             <l>Tutte per farsi belle mi vorrebbono amica.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Sinora io non usai, sien brutte, o sieno belle,</l>
             <l>Su queste guancie mie di mascherar la pelle.</l>
@@ -1714,112 +1745,112 @@ che introduce al serraglio di Tamas.</p>
             <l>Ma inutil la bellezza, inutile è l'amore,</l>
             <l>Con un, che ad altra amante abbia donato il cuore.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="I">Proviam? </l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="M">No; non mi piace. </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F">Le mani almen potete...</l>
             <l>Ah quante belle gemme su queste mani avete!</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Ecco un altro costume, di cui farei di meno:</l>
             <l>S'ornano inutilmente le dita, il collo, il seno.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Affé, per caricarvi troppi denari han speso;</l>
             <l>Io, cara, m'esibisco di allegerirvi il peso.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> No, no, tener le deggio di notte al chiaro lume.</l>
             <l>Anche sì bella pompa delle spose è in costume.</l>
             <l>Vanità senza frutto, far pompa di splendore,</l>
             <l>Quando tra le gramaglie piagne dolente il cuore.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Voi, più d'un apparato di gioje strepitoso,</l>
             <l>Bramate di godere la gioia dello sposo!</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="I">Sì, il di lui cor sospiro. </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F">Ogni lusinga è vana.</l>
             <l>Il di lui cor, figliuola, l'ha donato ad Ircana.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Voi di costei sarete fida compagna, e amica.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Io? Non passa un momento, che non la maledica.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="I">Perché? </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F">Perché è superba, inquieta, fastidiosa:</l>
             <l>Non vuol servir da schiava, vuol comandar da sposa.</l>
             <l>E se voi non farete quel che insegnarvi io voglio,</l>
             <l>Colei col piè sul collo vi terrà per orgoglio.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> (Scoprasi, non mi fido). Dite, madonna, come</l>
             <l>Trattar dovrei la schiava, quella, che Ircana ha nome?</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Par, che quell'anellino non istia ben con quelli;</l>
             <l>Scomparisce, meschino, fra tanti a lui più belli.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="I">Meglio sarebbe dunque, che al dito lo levassi,</l>
             <l part="F">Ed alla mia custode in dono io lo recassi.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Meglio sarebbe. </l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Ho inteso, domani lo faremo.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Quel che può farsi adesso perché il differiremo?</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Perché il mio genitore questa sera al convito</l>
             <l>Voglio che me lo veda con l'altre gemme in dito.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Bene bene, domani sarò di bon mattino</l>
             <l>A darvi l'ova fresche, e a prender l'anellino.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Ma intanto non potreste darmi d'amor consiglio,</l>
             <l>Per reggermi più franca a fronte d'un periglio?</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Figlia, il consiglio è questo: la quiete non sperate,</l>
             <l>D'una rivale ardita se voi non vi disfate;</l>
@@ -1830,7 +1861,7 @@ che introduce al serraglio di Tamas.</p>
             <l>Chiedete il mio consiglio? Eccolo: vi rispondo</l>
             <l>Che con un thè la schiava mandasi all'altro mondo.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Ed io rispondo a voi, perfida vecchia indegna,</l>
             <l>Che all'anime ben nate a tradir non s'insegna.</l>
@@ -1847,124 +1878,124 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Curcuma, poi Ircana.</emph>
           </stage>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Sì? Saprò vendicarmi. A me? Non son chi sono,</l>
             <l>Se tu non me la paghi; mai più te la perdono.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="I">Dimmi: è colei la sposa? </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="M">Sì. </l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="F">Che ti pare? È bella?</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Con voi sembra un vapore in faccia di una stella.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="I">Come è vezzosa? </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="M">Niente. </l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="F">Parla bene? </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Nemmeno.</l>
             <l>Altro non ha di bello, che delle gioie al seno.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="I">Delle gemme non parlo; il viso? </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F">Scolorito.</l>
             <l>Altro non ha di bello, che delle gemme in dito.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Posso io dunque sperare, che Tamas la disprezzi?</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Sì, quando egli le gemme non preferisca ai vezzi.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="I">Tamas gioie non cura. </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F">Ma sono belle assai.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="I">Di me parlotti forse? </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F">Parlommi, e m'irritai.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="I">Che disseti l'audace? </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F">Ch'ella è la sposa, e voi</l>
             <l>Dovete obbediente servire a' cenni suoi.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="I">Tamas dov'è? </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="M">Nol vidi. </l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="F"> Cercalo, o cielo! io fremo.</l>
             <l>Obbedirla? servirla? Curcuma, io sudo, io tremo.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="I"> Le dissi... </l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="M"> Eccolo: parti. </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F"> Dissi, che voi... </l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> T'invola.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="I"> Voi siete la padrona... </l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="F"> Va' via, lasciami sola.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Affé, se avrà il coraggio d'alzar la testa un poco...</l>
             <l>Vo' a porre in questo punto le pentoline al foco <emph>(parte)</emph>.</l>
@@ -1975,43 +2006,43 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Ircana poi Tamas.</emph>
           </stage>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Vedrem sin dove arriva l'amore, o la incostanza</l>
             <l>D'un cor, che nel mio seno ebbe finor sua stanza.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I"> Ircana. </l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="M"> E ben, che rechi? </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F"> Odimi... </l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Ti confondi?</l>
             <l>Parte la sposa tua? Resta con te? Rispondi.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Partirà, se lo vuoi, ma che nol voglia, io spero.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="I">Speri che non lo voglia? </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F"> Frena lo spirto altero.</l>
             <l>La vidi; ella ti cede in merto, ed in bellezza;</l>
             <l part="I">Ma soffri, che io tel dica... </l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="F"> Mi supera in dolcezza!</l>
             <l>E non è scarso pregio, ancorché non sia vaga,</l>
@@ -2019,7 +2050,7 @@ che introduce al serraglio di Tamas.</p>
             <l>Le sciocche non invidio; io son femina audace.</l>
             <l>Eleggi delle due; sciegli qual più ti piace... <emph>(altera)</emph></l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Ho scelto; e tu lo sai, crudel, se preferita</l>
             <l>Ti ho alla sposa non solo, ma al padre, ed alla vita.</l>
@@ -2031,32 +2062,32 @@ che introduce al serraglio di Tamas.</p>
             <l>Non la temer rivale, l'avrai compagna, e amica.</l>
             <l part="I">Che ti par? </l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="M"> Non lo credo. </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F">T'inganni, idolo mio.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Son donna, e delle donne l'arte conosco anch'io.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I"> Che puoi temer? </l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="F"> Che finga non essere gelosa,</l>
             <l>E di vendetta in seno covi la serpe ascosa.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> No, non può darsi. In viso troppo è modesta, e umile.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Questo delle alme accorte, questo è l'usato stile.</l>
             <l>Tamas, tu non sai quanto sotto un placido aspetto</l>
@@ -2070,20 +2101,20 @@ che introduce al serraglio di Tamas.</p>
             <l>Tu, se di lei ti cale, vibrami un ferro in petto,</l>
             <l>E se di me ti preme, scacciala a suo dispetto.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Vedila, Ircana, almeno; odi parlar quel labro.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Misero! Ti ha incantato la bocca di cinabro?</l>
             <l part="I">No, vederla non voglio. </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="M"> Dunque... </l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="F"> O Fatima, o io,</l>
             <l>Fuori di queste mura, o fuor del mondo. Addio <emph>(parte)</emph>.</l>
@@ -2091,7 +2122,7 @@ che introduce al serraglio di Tamas.</p>
         </div>
         <div type="scene">
           <head>Scena undicesima</head>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> A qual misero stato femina, o ciel, mi pone?</l>
             <l>Oltre del proprio foco non ode altra ragione.</l>
@@ -2131,75 +2162,75 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Ibrima, Zama ed altre Schiave.</emph>
           </stage>
-          <sp>
+          <sp who="#ibraima">
             <speaker>IBRAIMA</speaker>
             <l part="I">Vedesti ancor la sposa? </l>
           </sp>
-          <sp>
+          <sp who="#zama">
             <speaker>ZAMA</speaker>
             <l part="F"> Poc'anzi l'ho veduta.</l>
           </sp>
-          <sp>
+          <sp who="#ibraima">
             <speaker>IBRAIMA</speaker>
             <l part="I">Come ti piace? </l>
           </sp>
-          <sp>
+          <sp who="#zama">
             <speaker>ZAMA</speaker>
             <l part="M">Assai. </l>
           </sp>
-          <sp>
+          <sp who="#ibraima">
             <speaker>IBRAIMA</speaker>
             <l part="F"> A me pure è piacciuta.</l>
             <l>Parlar non le potei, ma sembrami gentile.</l>
           </sp>
-          <sp>
+          <sp who="#zama">
             <speaker>ZAMA</speaker>
             <l> Si conosce dal volto, ch'è affettuosa, umile.</l>
           </sp>
-          <sp>
+          <sp who="#ibraima">
             <speaker>IBRAIMA</speaker>
             <l part="I"> E pure, udisti Ircana? </l>
           </sp>
-          <sp>
+          <sp who="#zama">
             <speaker>ZAMA</speaker>
             <l part="F"> In lei parla lo sdegno.</l>
           </sp>
-          <sp>
+          <sp who="#ibraima">
             <speaker>IBRAIMA</speaker>
             <l part="I"> E Curcuma? </l>
           </sp>
-          <sp>
+          <sp who="#zama">
             <speaker>ZAMA</speaker>
             <l part="F"> La vecchia ha tal costume indegno,</l>
             <l>Che a te di me parlando, te esalta, e me deprime;</l>
             <l>E meco fa lo stesso, quando di te si esprime.</l>
           </sp>
-          <sp>
+          <sp who="#ibraima">
             <speaker>IBRAIMA</speaker>
             <l> Prego di cuore il cielo, che ami il padron la sposa,</l>
             <l>E umiliata resti Ircana orgogliosa.</l>
           </sp>
-          <sp>
+          <sp who="#zama">
             <speaker>ZAMA</speaker>
             <l> E vedasi costei, cui servitude è grave,</l>
             <l>Al bagno, ed alla mensa servir colle altre schiave.</l>
           </sp>
-          <sp>
+          <sp who="#ibraima">
             <speaker>IBRAIMA</speaker>
             <l> Qual merto aver presume la lusinghiera astuta?</l>
             <l>Ella è, quali noi siamo schiava al signor venduta.</l>
           </sp>
-          <sp>
+          <sp who="#zama">
             <speaker>ZAMA</speaker>
             <l> E ancor per poco prezzo. Machmut l'ebbe alle mani</l>
             <l>Per cento <emph>mamoède</emph>, che forman due <emph>tomani</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#ibraima">
             <speaker>IBRAIMA</speaker>
             <l> Per me ne hanno sborsato quatordeci i meschini,</l>
             <l>Che formano dugento gialli, europei zecchini.</l>
           </sp>
-          <sp>
+          <sp who="#zama">
             <speaker>ZAMA</speaker>
             <l> Io so, che Machmut, avido di comprarmi,</l>
             <l>Saziar non si potea di soppiato in mirarmi.</l>
@@ -2212,30 +2243,30 @@ che introduce al serraglio di Tamas.</p>
             <l>E co la mano aperta, che suol valer per cento,</l>
             <l>Mostrossi il padre mio del prezzo esser contento.</l>
           </sp>
-          <sp>
+          <sp who="#ibraima">
             <speaker>IBRAIMA</speaker>
             <l part="I"> Ma non aperse il pugno, che conta mille. </l>
           </sp>
-          <sp>
+          <sp who="#zama">
             <speaker>ZAMA</speaker>
             <l part="F">Alfine</l>
             <l>Noi siam Circasse, e siam del più colto confine.</l>
             <l>E Ircana non è degna né men di starci a fronte.</l>
           </sp>
-          <sp>
+          <sp who="#ibraima">
             <speaker>IBRAIMA</speaker>
             <l> E soffrirem da lei busse, minaccie ed onte?</l>
             <l part="I">Affé se mi ci metto... </l>
           </sp>
-          <sp>
+          <sp who="#zama">
             <speaker>ZAMA</speaker>
             <l part="F"> Se mi ci metto anch'io...</l>
           </sp>
-          <sp>
+          <sp who="#ibraima">
             <speaker>IBRAIMA</speaker>
             <l part="I"> Vuo' svellerle le chiome. </l>
           </sp>
-          <sp>
+          <sp who="#zama">
             <speaker>ZAMA</speaker>
             <l part="F"> Vuo' fare il dover mio.</l>
             <l>Ora che vi è la sposa non conta più niente;</l>
@@ -2247,40 +2278,40 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Fatima e dette.</emph>
           </stage>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> (Desio mirarla in viso questa rival sì bella;</l>
             <l>Qui con le schiave unite vi sarà forse anch'ella) <emph>(da sé).</emph></l>
           </sp>
-          <sp>
+          <sp who="#ibraima">
             <speaker>IBRAIMA</speaker>
             <l part="I">Vedi? <emph>(a Zama)</emph> </l>
           </sp>
-          <sp>
+          <sp who="#zama">
             <speaker>ZAMA</speaker>
             <l part="F"> La sposa <emph>(a Ibraima)</emph>. </l>
           </sp>
-          <sp>
+          <sp who="#ibraima">
             <speaker>IBRAIMA</speaker>
             <l> O bella! </l>
           </sp>
-          <sp>
+          <sp who="#zama">
             <speaker>ZAMA</speaker>
             <l> Mira che luci oneste!</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> (La schiava fortunata qual mai sarà di queste?).</l>
           </sp>
-          <sp>
+          <sp who="#ibraima">
             <speaker>IBRAIMA</speaker>
             <l part="I"> Via; faciamole onore. </l>
           </sp>
-          <sp>
+          <sp who="#zama">
             <speaker>ZAMA</speaker>
             <l part="F"> Sì, l'obligo lo vuole.</l>
           </sp>
-          <sp>
+          <sp who="#ibraima">
             <speaker>IBRAIMA</speaker>
             <l> Signora, che coi lumi splendete al par del sole,</l>
             <l>Che a Venere in bellezza potete muover guerra,</l>
@@ -2288,7 +2319,7 @@ che introduce al serraglio di Tamas.</p>
             <l>Possano i cari figli, che voi darete al mondo</l>
             <l>Regger dell'universo coi loro cenni il pondo.</l>
           </sp>
-          <sp>
+          <sp who="#zama">
             <speaker>ZAMA</speaker>
             <l> Di quelle lunghe chiome possano ai fili neri</l>
             <l>In numero esser pari de' figliuoli gl'imperi.</l>
@@ -2297,40 +2328,40 @@ che introduce al serraglio di Tamas.</p>
             <l>Degna, che Persia tutta vi veneri e v'adori,</l>
             <l>Regina delle donne, bell'idolo de' cuori.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Donne, l'usato stile d'Oriente io non ammetto;</l>
             <l>Adulazion mi spiace, candor bramo, ed affetto.</l>
             <l>Al ver quest'alma avvezza, del ver s'appaga, e gode.</l>
             <l>Serbate a chi l'apprezza l'iperbolica lode.</l>
           </sp>
-          <sp>
+          <sp who="#ibraima">
             <speaker>IBRAIMA</speaker>
             <l part="I"> Senti? Questa è virtude <emph>(a Zama).</emph> </l>
           </sp>
-          <sp>
+          <sp who="#zama">
             <speaker>ZAMA</speaker>
             <l part="F"> Virtude, che innamora <emph>(a Ibraima)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> (Qual sia Ircana fra queste, non ben discerno ancora) <emph>(da sé).</emph></l>
           </sp>
-          <sp>
+          <sp who="#ibraima">
             <speaker>IBRAIMA</speaker>
             <l> Sposa del signor nostro, che di lui donna siete,</l>
             <l>Usate il poter vostro, e di me disponete.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="I">(Questa non è) <emph>(da sé).</emph> </l>
           </sp>
-          <sp>
+          <sp who="#zama">
             <speaker>ZAMA</speaker>
             <l part="F">Signora, sempre più in me si desta</l>
             <l part="I">Il desio di servirvi. </l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="F"> (Non è nemeno questa.</l>
             <l>Fra quelle, che stan chete forse saravvi anch'ella</l>
@@ -2342,115 +2373,115 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Ircana e dette.</emph>
           </stage>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Olà, qual ozio è questo? Le schiave in concistoro?</l>
             <l>Itene immantinente ai giardini, al lavoro.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> (Eccola, me l'addita quell'altero sembiante).</l>
           </sp>
-          <sp>
+          <sp who="#ibraima">
             <speaker>IBRAIMA</speaker>
             <l part="I"> Frenate quell'orgoglio <emph>(a Fatima e parte).</emph> </l>
           </sp>
-          <sp>
+          <sp who="#zama">
             <speaker>ZAMA</speaker>
             <l part="F">Punite l'arrogante <emph>(fa lo stesso)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> (Chi è costei, che non parte?) <emph>(da sé).</emph></l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> (Numi, consiglio, aita) <emph>(da sé).</emph></l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> (Ah sì la veggio; è questa la rivale abborrita</l>
             <l part="I">Fuggasi) <emph>(da sé).</emph> </l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="M"> Ircana. </l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="F"> A nome chi sei tu, che m'appelli?</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Di Tamas la consorte questa è, con cui favelli.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="I"> E ben? che dir vorresti? che io son tua schiava? </l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="F"> Invano</l>
             <l>Temi, che usar io voglia teco il poter sovrano.</l>
             <l>Non servono con l'altre le schiave, che han l'onore</l>
             <l>D'aver incatenato del signor loro il cuore.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Né comandare è dato a sposa non amata,</l>
             <l>Per obbedire il padre, dal giovane sposata.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> È ver, non lo contrasto; tu sei la più felice.</l>
             <l part="I">Vuoi, che io ti serva? Imponi! </l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="F">A te servir non lice.</l>
             <l>Donna fra suoni, e canti al talamo venuta,</l>
             <l>Schiava obbedir non deve da' parenti venduta.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Tal legge in un serraglio rare volte si osserva</l>
             <l>Spesso il signor confonde colla sposa la serva.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> E chi tal legge soffre mal volentier, sen rieda,</l>
             <l>Pria che all'onta privata la pubblica succeda.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> L'onte sfuggir non cura chi soffre, e non s'aggrava.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Donna, che soffre i torti è più vil di una schiava.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Qual torto, se non mi ama sposo, di te invaghito?</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Non vi è ragion, che approvi le ingiurie d'un marito.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Con tai ragion condanni te sol di contumace.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Condanno te, se resti, se lo sopporti in pace.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Ma se ne' lumi tuoi merto maggiore io vedo,</l>
             <l part="I">Se Tamas compatisco, se amo il tuo ben... </l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="F">Nol credo.</l>
             <l>Fingi ben, lo conosco, fingi soffrir suoi lacci,</l>
@@ -2462,84 +2493,84 @@ che introduce al serraglio di Tamas.</p>
             <l>Io d'un amor schernito non soffrirei gli affanni</l>
             <l>Tu, se il tuo cuor lo soffre, o sei stolta, o m'inganni.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="I">Stolta sarò. </l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="F"> Non dice d'esserlo chi è in diffetto.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="I">Dunque?</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="F"> Dunque tu celi colla pace il dispetto.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> E tu con labro sciolto ad insultare avvezzo</l>
             <l>Aggiungi all'altrui danno con l'ingiurie il disprezzo.</l>
             <l>Vuoi, che lo sdegno io nutra? tu pur lo nutri in seno,</l>
             <l>Ma con parole audaci non ne fo pompa almeno.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="I"> Taci; or siamo scoperte, sei mia nemica. </l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="F"> Ed io</l>
             <l>Dovrei a chi m'insulta giurar lo sdegno mio.</l>
             <l>Ma non temer, son tale, che a chi m'insulta ancora</l>
             <l>Non posso il cor sincero serbar nemico un'ora.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="I"> Segno di tua viltade. </l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="F"> T'inganni; un segno è questo,</l>
             <l>Che dell'anime vili la vendetta detesto,</l>
             <l>E se la virtù stessa vuoi che per te mi aggrave,</l>
             <l>Segno è, che non mi cale di altercar colle schiave.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Schiava son io che puote far tremare un'altera.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Anche di gallo il canto fa tremar una fera.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> O parti, o Tamas d'una di noi vedrà la morte.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Veggala; ambe moriamo; ma dentro a queste porte.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="I"> Perfida! </l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="M"> Io non t'insulto. </l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="F"> Più il tuo tacer m'affanna.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Non la mia sofferenza, il tuo furor condanna.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Parto perché il tuo volto mi provoca, e m'uccide;</l>
             <l>Più della morte ho in odio donna, che freme, e ride <emph>(parte).</emph></l>
@@ -2550,7 +2581,7 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Fatima sola.</emph>
           </stage>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> No, non vogl'io pentirmi d'aver sofferto in pace,</l>
             <l>Senza cambiar le offese, senza insultar l'audace.</l>
@@ -2577,112 +2608,112 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Tamas e detta.</emph>
           </stage>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> (Eccola quell'audace; creduto ah non l'avrei...</l>
             <l>Onte, insulti ad Ircana? Provi gli sdegni miei) <emph>(da sé).</emph></l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="I"> Sposo? </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="M"> T'accheta, e parti. </l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="F">A me che parta? Oh cielo!</l>
             <l part="I">Tamas, alla tua sposa? </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F"> Torna a riporti il velo.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="I"> Come? </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="M"> Divorzio io chiedo. </l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="F"> Senza ragion? </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Ragione?</l>
             <l>È il mio voler, t'accheta: femmina invan s'oppone.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Io vi dissento; è legge nell'Alcoran firmata,</l>
             <l>Che non sia moglie a forza senza ragion scacciata.</l>
             <l>Al Cadì si ricorra, egli, che il dritto regge,</l>
             <l>Esamini le colpe, interpetri la legge.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Che parli di Cadì, di legge, e d'Alcorano?</l>
             <l>Io son nei tetti miei l'interpetre, e il sovrano.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Ah signor qual mia colpa v'arma a sì ria vendetta?</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Non merta l'amor mio colei, che nol rispetta.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="I"> Che dir volete? Ircana... </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F"> Sì, l'insultasti, audace.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="I">Ah non è ver. </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F"> T'accheta; non è Ircana mendace.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Ella che l'insultassi può sostenere? L'afferma</l>
             <l part="I">Francamente il suo labbro? </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F"> E Curcuma il conferma.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Curcuma? scellerata! Quella, che un rio veleno...</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Doveva alla mia schiava dar, per tua legge, al seno.</l>
             <l part="I">Ma il cielo... </l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="M">Ah non è vero. </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F">Perfida! </l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Ah son tradita.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Indegna d'uno sposo, indegna della vita.</l>
             <l>Togliti agli occhi miei; non vi sarà chi invano</l>
@@ -2690,7 +2721,7 @@ che introduce al serraglio di Tamas.</p>
             <l>E se volesse il padre, a forza, e a mio dispetto,</l>
             <l>Ti caccerei, ribalda, questo pugnale in petto <emph>(sfodra un pugnale)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Aita...</l>
           </sp>
@@ -2700,57 +2731,57 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Machmut, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="I"> Olà, che tenti? </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F">Minaccio, e non ferisco.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="I"> Chi minacci? </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="M"> Un'indegna. </l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="F"> Sei tu? <emph>(a Fatima)</emph> (Non lo capisco) <emph>(da sé).</emph></l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Son io quell'infelice, che ha la gran colpa in seno</l>
             <l part="I">D'aver alla sua bella... </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F"> Preparato il veleno.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Ah mi fulmini il cielo! orrida sepoltura</l>
             <l part="I">M'apra quindi la terra, se ciò fia ver. </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F"> Spergiura!</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="I"> Fatima, ti allontana. </l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="M"> Pietà! </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F"> Parti. </l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Obbedisco.</l>
             <l>Miratemi signore, m'insulta, ed io languisco <emph>(a Machmut)</emph>.</l>
@@ -2777,31 +2808,31 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Machmut e Tamas.</emph>
           </stage>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="I"> Misera, sventurata! </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="M"> Colei... </l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="F"> Taci, e m'ascolta.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I"> Non conoscete il cuore... </l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="F"> Rispettami una volta!</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I">Vi ascolterò. </l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="F"> Tu celi sotto ragion mendace</l>
             <l>L'amor, che nutri in seno per una schiava audace.</l>
@@ -2810,27 +2841,27 @@ che introduce al serraglio di Tamas.</p>
             <l>Tace, e tollera un padre, lo fa la sposa istessa;</l>
             <l>Tu il genitore insulti, vuoi la consorte oppressa...</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I"> Una consorte indegna... </l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="M"> Taci. </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F"> Che per vendetta...</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="I"> Taci. </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="M"> Non parlo. </l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="F"> Ardito! m'ascolta, e mi rispetta.</l>
             <l>Che far puote in un giorno, anzi in poch'ore appena,</l>
@@ -2846,11 +2877,11 @@ che introduce al serraglio di Tamas.</p>
             <l>Ma perché un uom lascivo, pien di scorrette voglie</l>
             <l>Al piacer d'una schiava sagrifica una moglie.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I"> Permettete, ch'io parli? </l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="F"> Oh traccotanza estrema!</l>
             <l>Non lo permetto ancora; odimi, audace, e trema.</l>
@@ -2891,45 +2922,45 @@ che introduce al serraglio di Tamas.</p>
             <l>Di', che ti pare? Ircana merta d'avere il vanto</l>
             <l>Che il suo signor per lei s'accenda, e arrischi tanto?</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I">Posso parlar, signore? </l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="F"> Parla, sì, tel concedo.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I">Padre, se per Ircana... </l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="F"> Osmano è quel, ch'io vedo <emph>(osservando verso la scena)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I"> Se per Ircana il petto... </l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="M"> Parti. </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F"> Ma dunque invano</l>
             <l part="I">Potrò sperar, signore... </l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="F"> Lasciami con Osmano.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> (Non so che dir; dal padre il cor mi si divide,</l>
             <l>Fatima mi tormenta, ed Ircana mi uccide) <emph>(da sé e parte)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l> Parmi commosso, oh cieli! Tamas, lo sai, se ti amo,</l>
             <l>Ma il periglioso laccio veder troncato io bramo.</l>
@@ -2940,23 +2971,23 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Osmano e Machmut.</emph>
           </stage>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="I"> Che ha Fatima, che piange? </l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="F"> Non lo chiedesti a lei?</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="I"> Mostra di non saperlo. </l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="F"> Io più nol chiederei.</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l> Odimi: due poeti del seguito festoso</l>
             <l>Cantano della sposa le lodi, e dello sposo;</l>
@@ -2971,7 +3002,7 @@ che introduce al serraglio di Tamas.</p>
             <l>Dimmi tu, che il saprai, chi è quest'ardita Ircana;</l>
             <l>Che potrebbe a mia figlia comandar da sovrana?</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l> Ah indegni, scellerati satirici cantori,</l>
             <l>Che or fanno i maldicenti, or fan gli adulatori,</l>
@@ -2984,106 +3015,106 @@ che introduce al serraglio di Tamas.</p>
             <l>Odimi, Osmano, il vero celar fia cosa vana</l>
             <l>Mio figlio ama una schiava, il di cui nome è Ircana.</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l> Che ami una schiava, è poco; ne ami anche dieci, è nulla;</l>
             <l>Sposa soffrir lo deve, sia donna, o sia fanciulla.</l>
             <l>Basta, che non ardisca per un amore insano</l>
             <l>Tenere a lei soggetta la figliuola di Osmano.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="I">No, non temer. </l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="F"> Se invano temer ciò si dovesse,</l>
             <l>Non sentiriansi i vati cantar satire espresse;</l>
             <l>Le donne dagli eunuchi han preso l'argomento,</l>
             <l>E Fatima è ormai resa l'altrui divertimento.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l> Da un padre, e da un amico chiedo consiglio, e aita.</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l> Odimi: a quante schiave questa superba è unita?</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l> Quelle del genitore non son quelle del figlio.</l>
             <l part="I">Le sue dieci saranno. </l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="F"> Eccoti il mio consiglio.</l>
             <l>Dieci donne son troppe; vendi l'audace Ircana.</l>
             <l>Cesserà ogni periglio, quando è costei lontana.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="I"> Facciasi. </l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="F">Ogni dimora può assassinare il cuore</l>
             <l part="I">Di un figlio affascinato. </l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="F">Si cerchi il compratore.</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="I"> Come è costei? </l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="M"> Vezzosa. </l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="F"> Giovine? </l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l> Giovinetta.</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="I"> Lavora? </l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="F"> Nel ricamo l'ho trovata perfetta.</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="I"> La comprerò. </l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="M"> A qual prezzo? </l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="F"> Vederla, e si contratti.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l> Fra due, che giusti sono brevi saranno i patti.</l>
             <l part="I">Olà... Curcuma io voglio <emph>(esce un eunuco e parte)</emph>. </l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="F"> Chi è costei? </l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l> La custode.</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l> Queste son ne' serragli maestre d'ogni frode.</l>
           </sp>
@@ -3093,68 +3124,68 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Curcuma e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Eccomi: (oh me meschina!) un uom, che mi ha veduta.</l>
             <l>Presto, pria, che si dica, che ho l'onestà perduta <emph>(vuol coprirsi)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="I"> Odimi. </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="M">Sì, signore. </l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="F">Qual timore improviso?</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Non v'è un uomo? mi sento i rossori sul viso.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l> Vieni; l'età canuta ti salva dal rigore.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Eh, se sono canuta, è per troppo calore.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="I"> Odimi. </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="M"> Dite pure. </l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="F">Eh scopriti, schifosa.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Signor sì; sono stata sempre un po' vergognosa.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l> Fa, che Ircana a me venga, e se venir non vuole,</l>
             <l>Usa la forza, quando non vaglian le parole;</l>
             <l>Legata dagli eunuchi, guidala al mio cospetto.</l>
             <l>Eseguisci il comando, sollecita ti aspetto.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Legata? strascinata? oh povera ragazza!</l>
             <l part="I">Più tosto son qua io... </l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="F"> Vanne: sei vecchia, e pazza.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Oh questo maltrattarmi, signor padron mio caro,</l>
             <l>Dirmi che sono vecchia è un boccon troppo amaro.</l>
@@ -3167,20 +3198,20 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Machmut e Osmano.</emph>
           </stage>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="I">(Giovine sventurato!) <emph>(da sé).</emph> </l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="F">Machmut, che pensi? </l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l> Ah penso</l>
             <l>Qual dolore il mio figlio proverà crudo, intenso!</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l> Dagli una sciabla, un arco, dagli un agil destriero,</l>
             <l>Meco in tre giorni al campo dilegua ogni pensiero;</l>
@@ -3197,12 +3228,12 @@ che introduce al serraglio di Tamas.</p>
             <l>Articoli di legge tengono in aspra guerra,</l>
             <l>Due principi fra loro formidabili in terra.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l> Tu nel parlar di guerra perdi te stesso: osserva:</l>
             <l part="I">Ecco la schiava. </l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="F">A forza guidano la proterva.</l>
           </sp>
@@ -3212,86 +3243,86 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Ircana tenuta legata da due eunuchi, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l>Ah signor, perché in lacci? Misera! in che peccai?</l>
             <l part="I">Che da me si pretende? </l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="F">Chetati, e lo saprai.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Fammi coprire almeno dinnanzi a uno straniero.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="I"> (Mirala qual ti sembra?) <emph>(a Osmano)</emph>. </l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="F"> (Ha il portamento altero) <emph>(a Machmut)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l> Piaceti? </l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="I"> Non mi spiace. </l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="F"> Se la vuoi contrattiamo.</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="I">Sotto il manto le mani <emph>(pongono le mani sotto le vesti)</emph>. </l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="F"> Prestamente accordiamo.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> (Ah che il crudel mi vende! In tal modo fu fatto</l>
             <l>Già da Machmut istesso col padre mio il contratto) <emph>(da sé).</emph></l>
             <l>Misera me! lasciate, perfidi, un'infelice <emph>(tenta liberarsi dalle catene)</emph>.</l>
             <l>Tamas più non m'ascolta, sperar più non mi lice.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="I"> Basta così, son pago. </l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="F"> Avrai tosto il contante;</l>
             <l>Avrai zecchini cento, del nuovo giorno innante.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Ah per pietà, signore, a qual destin funesto?... <emph>(a Machmut)</emph></l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l> Schiava mai più non sei, il tuo signore è questo <emph>(parte)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l> Seguimi <emph>(ad Ircana)</emph>. </l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Ah pria di trarmi lungi da questo tetto,</l>
             <l>Pensate, che di Tamas son io l'unico affetto.</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l> E tu pensa, ch'io sono padre della sua sposa;</l>
             <l>Ti tratterò qual merti, femina orgogliosa <emph>(parte)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l> Ahimè? che intesi mai? Ahimè, l'amor, la vita...</l>
             <l>Tamas, Tamas, mio bene, io parto; io son tradita <emph>(parte con gli eunuchi)</emph>.</l>
@@ -3305,169 +3336,169 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>TAMAS, tenendo per mano CURCUMA.</emph>
           </stage>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I"> Vieni qui, scellerata. </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F"> Aiuto; io non so nulla;</l>
             <l>Portatemi rispetto, che sono ancor fanciulla.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I"> Presto: Ircana dov'è? </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F"> Ve lo dirò, aspettate.</l>
             <l>(Se gliela dico tutta, m'accoppa a bastonate) <emph>(da sé).</emph></l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I">Dov'è Ircana, dich'io? </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="M"> Ircana? <emph>(tremante)</emph> </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F">Oh me tapino!</l>
             <l part="I">Presto: me l'han rapita? <emph>(sdegnato)</emph> </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F"> Eh, signor no: è in giardino.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I">Vanne a lei... </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="M"> Sì signore... <emph>(vuol partire)</emph> </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F">Fermati. </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="I"> Ahimè! ci sono.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F"> Anderò io a vedere. <emph>(in atto di partire)</emph> </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="I"> Signor, chiedo perdono.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F"> Come? non è in giardino? </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Non è <emph>(tremando)</emph>. </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Vecchia, m'inganni?</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Sempre mi dite vecchia, e non ho ancor trent'anni.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Io troncherò ben presto il corso a' giorni tuoi:</l>
             <l part="I">Ti ucciderò, ribalda. </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F">Via uccidetemi, e poi?...</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I"> Parla. </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="M"> Io non so nulla. </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F"> Dov'è Ircana? </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="I"> Non so...</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="M"> Non è più nel serraglio? </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F"> Ho paura di no.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Ah indegna, scellerata: Ircana se ne andrà</l>
             <l part="I">Senza che tu lo sappia? <emph>(minacciandola)</emph> </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F"> Eh signor, vi sarà.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I"> Sì, vi sarà; ma dove? </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F"> Là dentro. (Oh me meschina!) <emph>(da sé).</emph></l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Vado, se non la trovo, ti vo' conciar, bambina <emph>(in atto di partire)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Eh sì, la troverete. (Oh se fuggir potessi!).</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I"> Ma non ti credo; olà <emph>(torna indietro, chiama gli eunuchi)</emph>. </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l>(Egrave; meglio ch'io confessi).</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F"> Legatela colei <emph>(a gli eunuchi)</emph>. </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="I">Ah signor... </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F">Non tardate <emph>(a gli eunuchi)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Legate con modestia, le man non mi toccate <emph>(a gli eunuchi)</emph></l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Resti costei legata fin ch'io ritorni: vecchia,</l>
             <l>Se Ircana non ritrovo, a morir ti apparecchia <emph>(parte)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Signore... Ah sul mio dorso qualche flagello aspetto!</l>
             <l>Mi ha fatta legar stretta, e poi <emph>vecchia</emph> mi ha detto.</l>
@@ -3489,50 +3520,50 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Tamas, e detta.</emph>
           </stage>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I">Perfida! <emph>(furiosamente, con arma alla mano)</emph> </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="M"> Ahimè meschina! </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F"> Presto a colei sien date</l>
             <l>Sulle piante de' piedi trecento bastonate.</l>
             <l>Viva poi sotterrata fino alla gola, i cani</l>
             <l>Vengano il capo indegno a lacerarle in brani.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="I"> E poi... </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F"> Poi d'ingannarmi avrai finito, insana.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> E poi voi non saprete dove sia ita Ircana.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I"> A forza di tormenti dir lo dovrai. </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F"> Pazienza!</l>
             <l>Ma son donna capace di dirvelo anche senza.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Presto</l>
             <l>
               <emph>(gli eunuchi, credendo dica a loro, vogliono legar Curcuma).</emph>
             </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Fermi bricconi, e ben, che cosa ci è?</l>
             <l>Ei non l'ha detto a voi <emph>presto</emph>, l'ha detto a me.</l>
@@ -3541,25 +3572,25 @@ che introduce al serraglio di Tamas.</p>
             <l>E quei, che l'han condotta a così bel mercato</l>
             <l>Son questi scellerati, che mi hanno assassinato.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Ah traditori indegni!</l>
             <l>
               <emph>(con un pugnale ferisce uno degli eunuchi, e tutti fuggono).</emph>
             </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> (Affé, gli sta a dovere.</l>
             <l part="I">Ah se fuggir potessi!). </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F"> Perfida, in tuo potere</l>
             <l>Non era il custodirla, difenderla, avvisarmi?</l>
             <l>Il ciel nelle mie mani ti lasciò per sfogarmi <emph>(minacciandola)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Ah ci sono!</l>
           </sp>
@@ -3569,111 +3600,111 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Alí, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Deh, amico, venite in mio soccorso.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> (Io non so, se ferita m'abbia la testa, o il dorso).</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I"> Ircana mia... <emph>(ad Alí)</emph> </l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l part="F"> La vidi <emph>(parla confuso, come se fosse briaco).</emph></l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Ohimè! da voi veduta?</l>
             <l>Dove? </l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l part="I"> Per via. </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="M"> Ma quando? </l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l part="F"> Ora. </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I"> Perché? </l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l part="F"> Venduta.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Ah ciel! penar mi fate i cenni, e le parole.</l>
             <l>L'oppio che tende audaci, instupidir poi suole.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="I"> (Ah di me si scordasse!) <emph>(da sé).</emph> </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F"> Chi l'ha comprata? </l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l> Osmano.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I"> Chi la scorta? </l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l part="F"> Due schiavi. </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I">Colle catene? </l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l part="F"> A mano.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I"> Vado. </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="M"> (Sen va) <emph>(con letizia)</emph>. </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F"> Deh, amico, pietà d'un uomo tradito.</l>
             <l>Deh, non mi abbandonate; andiam. </l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l> Sono stordito.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I"> Maledetto sia l'oppio; solo ne andrò. </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F"> (Buon viaggio.</l>
             <l>Di me non si ricorda, quest'è un buon avantaggio) <emph>(da sé).</emph></l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l>Perfida, non mi scordo: ripiglierem l'istoria <emph>(a Curcuma, e parte)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Obligata davvero della buona memoria.</l>
           </sp>
@@ -3683,19 +3714,19 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Alí e Curcuma.</emph>
           </stage>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l> Caffè <emph>(a Curcuma)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Non mi guardate, portatemi rispetto.</l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l part="I"> Tempo già fu; sei vecchia. </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F"> (Che tu sia maledetto!</l>
             <l>Ma se m'ha detto <emph>vecchia</emph>, non vo' scandalizzarmi,</l>
@@ -3705,7 +3736,7 @@ che introduce al serraglio di Tamas.</p>
               <emph>accomoda due guanciali nel mezzo della scena per sedere).</emph>
             </l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l> Troppo ne ho trangugiato.</l>
             <l>Ho dormito sei ore, né ben son risvegliato.</l>
@@ -3718,7 +3749,7 @@ che introduce al serraglio di Tamas.</p>
             <l>Favole della Grecia agli Europei narrate,</l>
             <l>Credo sieno i veleni amici a Mitridate.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Ecco il caffè, signore, caffè in Arabia nato</l>
             <l><emph>(Alí beve il caffè mentre ella raghiona)</emph>,</l>
@@ -3732,38 +3763,38 @@ che introduce al serraglio di Tamas.</p>
             <l>Usarlo indi conviene di fresco macinato,</l>
             <l>In luogo caldo, e asciutto con gelosia guardato.</l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l part="I"> Caffè buono, e ben fatto <emph>(rendendo la tazza)</emph>. </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F"> A farlo vi vuol poco;</l>
             <l>Mettervi la sua dose, e non versarlo al fuoco.</l>
             <l>Far sollevar la spuma, poi abbassarla a un tratto,</l>
             <l>Sei sette volte almeno, il caffè presto è fatto.</l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l> Sciolti del tutto ancora i spirti miei non sono.</l>
             <l part="I">Recatemi tabacco. </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F"> Signor, chiedo perdono.</l>
             <l part="I">Volete il kaliam? </l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l part="F"> Sì il kaliam mi aggrada,</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> (Per farmi un protettore vo cercando la strada;</l>
             <l>È ver, che sperar posso qualche cosa dal merto,</l>
             <l>Ma quel delle finezze è il segreto più certo) <emph>(parte)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l> Tamas mi sta nel cuore; misero! in tal periglio</l>
             <l>Non recargli un amico, né aiuto, né consiglio?</l>
@@ -3781,11 +3812,11 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Tamas, guidando Ircana, col ferro in mano, conducendola nel serraglio, e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Andiam, mia vita <emph>(parte con Ircana correndo)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l> Ecco l'amico vostro, eccomi in vostra aita...</l>
             <l>Tutto di sangue è tinto, il misero infelice.</l>
@@ -3797,37 +3828,37 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Curcuma, e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="I">Pietà, misericordia. </l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l part="F">Vecchia, che cosa è stato?</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Vecchia, quel, che volete, il padrone sdegnato</l>
             <l>Minaccia, mi vuol morta; or ora viene qui,</l>
             <l>A voi mi raccomando. Ihi, ihi, ihi <emph>(piangendo)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l part="I"> Celati. </l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="M"> E se mi trova? </l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l part="F"> A me lascia la cura.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l> Ah non vorrei canuta venir per la paura <emph>(parte)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l> Anche fra' suoi spaventi pensa all'irsute chiome.</l>
             <l>Femina più che morte, odia di vecchia il nome.</l>
@@ -3838,89 +3869,89 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Tamas, e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Quell'indegna dov'è? Perfida! spera invano</l>
             <l>Sottrarsi dalla morte, fuggir dalla mia mano.</l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l> Perché cotanto sdegno contro una vecchia insana?</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Ella con tradimento pose fra' lacci Ircana.</l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l part="I">La liberaste alfine. </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F"> È ver, con mano ardita</l>
             <l>Ricuperai la donna, ed arrischiai la vita.</l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l> Di chi è il sangue, che nero, vi lorda e vesti, e mano?</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Di due schiavi svenati del mio suocero Osmano.</l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l part="I">Egli lo sa? </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F"> Non vi era; ma avuti avrà gli avvisi</l>
             <l>D'Ircana sprigionata, de' suoi custodi uccisi.</l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l part="I"> La fierezza d'Osmano?... </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F">Non la temo.</l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l> Vedete: <emph>(guardando alla porta del serraglio)</emph></l>
             <l>Vuol femmina velata venir, se il concedete.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I"> È Fatima colei? </l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l part="F"> Fatima vostra sposa?</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Quella, che agli occhi miei è più di morte odiosa.</l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l part="I"> Par, che per me s'arresti <emph>(in atto di partire)</emph>. </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F"> Fermate. </l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l>No, sì ardito</l>
             <l>Non son di dispiacere, o alla moglie, o al marito.</l>
             <l part="I">Permettete signore... <emph>(in atto di partire)</emph> </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F"> Peggio per lei se viene.</l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l> A voi serbar prudenza, partire a me conviene <emph>(parte)</emph>.</l>
           </sp>
@@ -3930,88 +3961,88 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Fatima, Tamas, poi Osmano colla sciabla alla mano.</emph>
           </stage>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="I">Sposo? </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="M"> Che cerchi? </l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="F">Ah, mori.... <emph>(drizzando un colpo a Tamas)</emph> </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="I"> Nelle mie stanze? </l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="F"> Indegno!</l>
             <l>Le stanze del Soffì non tratterrian mio sdegno.</l>
             <l part="I">Sì, mori, scellerato <emph>(volendolo ferire)</emph>. </l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="M"> Ah caro padre! <emph>(si frappone)</emph> </l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="F"> Ah figlia!</l>
             <l>Qual destin ti conduce? qual follia ti consiglia?</l>
             <l>Scostati, forsennata; lascia, che l'empio mora,</l>
             <l>O d'essere tuo padre potrò scordarmi ancora.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Scordati d'esser padre, ma Fatima non osa</l>
             <l>Scordar con quel di figlia il bel nome di sposa.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l> Lascia che avvanzi il passo quell'aggressore ardito,</l>
             <l>O io più facilmente mi scordo esser marito <emph>(a Fatima)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Ambi stendete il ferro, a me date la morte.</l>
             <l>In me sfoghi lo sdegno il padre, ed il consorte.</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l> Perfido! <emph>(avventandosi contro Tamas)</emph></l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l> Ecco il mio petto <emph>(si pone innazi al padre)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="I"> Ingrata! <emph>(ritirandosi)</emph> </l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F"><emph>(ad Osmano)</emph> Il colpo arresti?</l>
             <l>I Tartari famosi, gli eroi persian son questi?</l>
             <l>Eccomi: io non ti temo, odio ho per te, e dispetto;</l>
             <l>Ruota quel ferro, audace, a piè fermo ti aspetto.</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l> Perfido! insulti ancora? l'ira non ha più freno:</l>
             <l>Scostati temeraria... <emph>(a Fatima)</emph> Indegno! <emph>(contro Tamas)</emph></l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker> FATIMA</speaker>
             <l><emph>(come sopra)</emph> Eccoti il seno.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker> TAMAS</speaker>
             <l>E che t'arresta? Dimmi, l'amor di genitore,</l>
             <l>O, di un giovine a fronte, il codardo timore?</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker> OSMANO</speaker>
             <l>Giuro a Maccon! tai onte ha da soffrire Osmano,</l>
             <l>Che ben dodici volte fe' fuggir l'Ottomano,</l>
@@ -4026,19 +4057,19 @@ che introduce al serraglio di Tamas.</p>
             <l>L'ira, l'onor m'infiamma, tra gli insulti infierisco;</l>
             <l>Parti, resta, frapponti, nulla mi cal, ferisco <emph>(s'avventa contro Tamas)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker> FATIMA</speaker>
             <l>Ohimè! <emph>(sviene, e cade sui guanciali dove prima si è seduto Alí)</emph></l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker> OSMANO</speaker>
             <l>Sei tu ferita? morta sei tu caduta?</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker> TAMAS</speaker>
             <l>Né spenta, né ferita; è pel timore svenuta.</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker> OSMANO</speaker>
             <l>Mirala, cuor di tigre, mirala, in quale stato</l>
             <l>La misera è ridotta per uno sposo ingrato!</l>
@@ -4051,12 +4082,12 @@ che introduce al serraglio di Tamas.</p>
             <l>Perfido, se ti cale, ch'ella ti lasci, e mora,</l>
             <l>Svenala, scellerato, svena suo padre ancora <emph>(getta la spada)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker> TAMAS</speaker>
             <l>Di sangue non mi pasco, non son disumanato,</l>
             <l>Non odio, che me stesso, io sono un disperato <emph>(parte)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker> OSMANO</speaker>
             <l>Fatima, figlia; oh Numi! conosco or come fura</l>
             <l>Tutti gli affetti a un padre l'affetto di natura.</l>
@@ -4069,48 +4100,48 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Curcuma, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="I">È partito?</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="M">Deh vieni.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F">È partito il padrone?</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker> OSMANO</speaker>
             <l part="I">Sì, soccorri la sposa.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F">Che le ha fatto il guidone?</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker> OSMANO</speaker>
             <l>Vedila, se respira; cuor non ho di mirarla.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker> CURCUMA</speaker>
             <l>Eh sì, signore, è viva; sarà bene slacciarla.</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker> OSMANO</speaker>
             <l part="I">Basti tu?</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F">Sì signore (oh queste gioie belle</l>
             <l>Non mi escon dalle mani se mi cavan la pelle) <emph>(leva le gioie a Fatima, e le ripone)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker> OSMANO</speaker>
             <l part="I">Non rinviene?</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F">Mi pare, ma con tal peso intorno</l>
             <l>Rinvenir non potrebbe né meno in tutto il giorno <emph>(seguita a cavarle le gioie)</emph>.</l>
@@ -4121,91 +4152,91 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Machmut, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="I">Stelle! Osmano?</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="F">Machmut, vedi mia figlia al suolo.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker> MACHMUT</speaker>
             <l part="I">Morta?</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="F">No, tramortita per eccesso di duolo.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker> MACHMUT</speaker>
             <l>Tamas mio figlio io viddi da fier dolore oppresso.</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker> OSMANO</speaker>
             <l>Di Fatima l'affanno vien da tuo figlio istesso.</l>
             <l>Ma s'ella non cadeva sugli occhi miei svenuta,</l>
             <l>La testa di tuo figlio fora al mio piè caduta.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker> MACHMUT</speaker>
             <l part="I">Di mio figlio?</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F">Signori, par che riprenda fiato.</l>
             <l>(Rinvenga quando vuole, il meglio l'ho intascato).</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker> FATIMA</speaker>
             <l part="I">Ohimè!</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="M">Figlia?</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="F">Consorte? <emph>(verso Machmut)</emph></l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l>Il suocero son io.</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker> OSMANO</speaker>
             <l part="I">Volgiti al genitore.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="F">Dov'è lo sposo mio?</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker> OSMANO</speaker>
             <l>Pensa alla tua salute non a quell'alma ingrata.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker> CURCUMA</speaker>
             <l>Con un po' di marito è bella, e risanata.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker> FATIMA</speaker>
             <l part="I">Tamas dov'è? <emph>(a Machmut)</emph></l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="F">Non lungi.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="I">Vive? <emph>(ad Osmano)</emph></l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="F">Sì, per tuo zelo,</l>
             <l part="I">Perché tu lo salvasti.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="F">Ah benedetto il cielo!</l>
             <l>Benedetta la mano del genitor pietoso,</l>
@@ -4213,46 +4244,46 @@ che introduce al serraglio di Tamas.</p>
             <l>Vive poi? Deh signore, Tamas, il caro figlio,</l>
             <l>Respira, o langue, è in libertà, o in periglio?</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker> MACHMUT</speaker>
             <l part="I">Sì, respira, sta lieta.</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="F">Ancor l'ami cotanto?</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker> MACHMUT</speaker>
             <l>Ira ho contro il mio figlio, e tu mi movi al pianto.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker> CURCUMA</speaker>
             <l>In tant'anni, ch'io faccio di custode il mestiero</l>
             <l>Quest'è la prima volta, che vedo un amor vero.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker> FATIMA</speaker>
             <l part="I">Dove son le mie gioie? <emph>(a Curcuma)</emph></l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F">Son qui, ve le ho serbate.</l>
             <l>(Credea fra tanti affanni se le avesse scordate).</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker> MACHMUT</speaker>
             <l part="I">Itene a riposare. <emph>(a Fatima)</emph></l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="M">Tamas?</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="F">Non dubitate,</l>
             <l part="I">A voi verrà fra poco.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="F">Oh Dio! non m'ingannate.</l>
             <l>Padre, suocero, io sono d'amor sì ardente, accesa,</l>
@@ -4316,50 +4347,50 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Machmut, Osmano e Curcuma.</emph>
           </stage>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="I">Seguila. <emph>(a Curcuma)</emph></l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F">Sì, signore. Poverina, è pietosa;</l>
             <l>Anch'io son per natura tenera, ed amorosa <emph>(parte)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker> MACHMUT</speaker>
             <l part="I">Osmano, se ti lascio, forza è d'amore.</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="F">Io stesso</l>
             <l part="I">Teco verrò.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="F">Fra donne non si chiede l'accesso.</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker> OSMANO</speaker>
             <l part="I">V'è mia figlia.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="F">E vi sono giovani schiave, ancelle.</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker> OSMANO</speaker>
             <l>E la perfida Ircana si asconderà fra quelle.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker> MACHMUT</speaker>
             <l part="I">Nol so.</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="F">Sappilo, e rendi la schiava a me venduta,</l>
             <l>O con quella del figlio temi la tua caduta.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker> MACHMUT</speaker>
             <l>Non minacciate, Osmano, ché alle minaccie avvezzo</l>
             <l>Machmut non è mai stato; v'amo, vi stimo, e apprezzo.</l>
@@ -4370,7 +4401,7 @@ che introduce al serraglio di Tamas.</p>
             <l>Ma vel ridico in pace, l'amico rispettate.</l>
             <l>Quando parlate meco, Osman, non minacciate.</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker> OSMANO</speaker>
             <l>Basta, che tu m'inganni, o che il tuo figlio indegno</l>
             <l>Provochi, temerario, il mio foco, il mio sdegno:</l>
@@ -4391,11 +4422,11 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Ircana, e Curcuma, ambe in spoglie virili alla foggia degli eunuchi.</emph>
           </stage>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="I">Tremo.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F">Venite meco; la notte si fa oscura</l>
             <l>Non ci conosceranno, non abbiate paura.</l>
@@ -4404,33 +4435,33 @@ che introduce al serraglio di Tamas.</p>
             <l>Quest'abito è di quello, cui Tamas ha ferito</l>
             <l>Il vostro è di colui, che col veleno è ito.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker> IRCANA</speaker>
             <l>Ma tu, che di malìe maestra ti facesti,</l>
             <l>Perché non usar quelle, anzi che queste vesti?</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker> CURCUMA</speaker>
             <l>Oh quando il fato avverso vuol favorire i tristi,</l>
             <l>Nascono di quei casi, che non si son previsti;</l>
             <l>Tamas, pien di furore, nella mia stanza è entrato,</l>
             <l>Le pentole m'ha rotto, e tutto ha rovesciato.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker> IRCANA</speaker>
             <l>Tamas adunque infido, per soggezion d'Osmano</l>
             <l>Strinse la sposa al seno? strinse a colei la mano?</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker> CURCUMA</speaker>
             <l>E di più vi direi qualche altra bella cosa;</l>
             <l>Ma sotto queste spoglie sono ancor vergognosa.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker> IRCANA</speaker>
             <l part="I">Vadasi.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F">Non per questo s'ha da fuggir, mia cara,</l>
             <l>Ma per quel sciropetto, che Osmano vi prepara.</l>
@@ -4445,12 +4476,12 @@ che introduce al serraglio di Tamas.</p>
             <l>Onde, se non fuggite, Tamas è già perduto,</l>
             <l>E perderete il resto, senza sperare aiuto.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker> IRCANA</speaker>
             <l>Partir senza vendetta? Ah questa è maggior pena</l>
             <l>D'una barbara morte, d'una crudel catena.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker> CURCUMA</speaker>
             <l>Se di vendetta un giorno poteste lusingarvi,</l>
             <l>Io stessa vi direi: pensate a vendicarvi;</l>
@@ -4459,7 +4490,7 @@ che introduce al serraglio di Tamas.</p>
             <l>E voi, che di natura siete delicatina,</l>
             <l>Vi manda all'altro mondo senz'altra medicina.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker> IRCANA</speaker>
             <l>Fuggasi, giacché il fato ha tronca ogni speranza</l>
             <l>Ecco l'indegno frutto di soverchia baldanza.</l>
@@ -4476,28 +4507,28 @@ che introduce al serraglio di Tamas.</p>
             <l>Or la rivale è viva, io fuggo invendicata,</l>
             <l>Da Tamas, non so bene, se amata, o disamata.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker> CURCUMA</speaker>
             <l>Orsù l'ora s'appressa d'andarsene bel bello,</l>
             <l>Sorella. Ah no, sorella; caro eunuco fratello.</l>
             <l>Vedete a che m'espongo per compassion di voi.</l>
             <l>(Curcuma non è pazza, anch'ella ha i fini suoi) <emph>(da sé).</emph></l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker> IRCANA</speaker>
             <l>Tamas creder mi fece, che foste a me nemica.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker> CURCUMA</speaker>
             <l>Ecco smentito il falso; ecco, se sono amica;</l>
             <l>Per voi l'onore arrischio, la vita, ed ogni cosa.</l>
             <l>(Ma parto, e meco porto le gioie della sposa) <emph>(da sé).</emph></l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker> IRCANA</speaker>
             <l>Ohimè! dimmi qual traccia noi nel fuggir terremo?</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker> CURCUMA</speaker>
             <l>Fuori dell'uscio appena Bulganzar troveremo;</l>
             <l>Egli che sa le vie, sa gli usi, e sa il costume,</l>
@@ -4511,86 +4542,86 @@ che introduce al serraglio di Tamas.</p>
             <l>E vuo' che scommettiamo, così per oppinione,</l>
             <l>A chi faran di noi maggior esibizione.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker> IRCANA</speaker>
             <l>Ah voglia il ciel non sia peggior la mia caduta!</l>
             <l>Ma tutto arrischiar dee donna, che è già perduta.</l>
             <l>L'ora del partir nostro guarda, che invan non passi.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker> CURCUMA</speaker>
             <l>No, no: più certo è il colpo, quando più tardo fassi.</l>
             <l part="I">Gioie ne avete prese?</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="F">Fatto ho un fardello in fretta.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker> CURCUMA</speaker>
             <l part="I">Dove l'avete?</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="M">In tasca.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F">Dar mel potete.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="I">Aspetta;</l>
             <l part="M">Eccolo; dove sei?</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F">Son qui; datelo pure.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker> IRCANA</speaker>
             <l part="I">Bada!</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F">Non dubitate: le mie man son sicure.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker> IRCANA</speaker>
             <l part="I">Parmi di sentir gente;</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="M">Pare anche a me.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="F">Chi viene?</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker> CURCUMA</speaker>
             <l>Per ora in qualche parte nasconderci conviene.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker> IRCANA</speaker>
             <l part="I">Dove?</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker>CURCUMA</speaker>
             <l part="F">Venite meco.</l>
             <l>
               <emph>(va ritirandosi in modo che Ircana non la trovi)</emph>
             </l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker> IRCANA</speaker>
             <l>Ma dove? io non ti trovo.</l>
           </sp>
-          <sp>
+          <sp who="#curcuma">
             <speaker> CURCUMA</speaker>
             <l>(Se posso fuggir sola colle gioie, mi provo) <emph>(da sé; parte)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker> IRCANA</speaker>
             <l>Curcuma? ah me infelice! Curcuma? ah, che è fuggita!</l>
             <l>Ecco un lume, ecco un uscio; mi celo: ah son tradita!</l>
@@ -4601,7 +4632,7 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Tamas, poi Ibraima, e Zama.</emph>
           </stage>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l>Che confusion d'affetti, che turba di pensieri</l>
             <l>Mi si affollano in mente, ora pietosi, or fieri!</l>
@@ -4619,11 +4650,11 @@ che introduce al serraglio di Tamas.</p>
             <l>Movasi un grato sposo almeno a rispettarla.</l>
             <l>Olà, Fatima sappia, che meco or la desio <emph>(alle schiave)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#ibraima">
             <speaker> IBRAIMA</speaker>
             <l>(Volesse il ciel, meschina!) <emph>(da sé, e parte)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#zama">
             <speaker> ZAMA</speaker>
             <l>(Ah prego il ciel anch'io!) <emph>(da sé, e parte)</emph>.</l>
           </sp>
@@ -4633,7 +4664,7 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Tamas sedendo.</emph>
           </stage>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l>Fatima i primi segni abbia d'un giusto amore,</l>
             <l>Ma non usurpi a Ircana una porzion del cuore.</l>
@@ -4648,7 +4679,7 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Ircana, e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l>Tamas la sposa invita? Ah tolgano gli Dei</l>
             <l>Ch'io vegga una rivale gioir sugli ochi miei!</l>
@@ -4666,49 +4697,49 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Fatima, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="I">Guardati... <emph>(forte da lontano a Tamas).</emph></l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F">Oh giusto ciel! ah qual destra inumana?</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker> FATIMA</speaker>
             <l>Alzati <emph>(alla voce di Fatima s'alza in tempo, e Ircana cade sull'origliere).</emph></l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker> IRCANA</speaker>
             <l part="I">Non toccarmi.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F">Stelle, che vedo?... Ircana?</l>
             <l part="I">Tanta di sangue hai sete?</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="F">Sì, ma dal ferro istesso</l>
             <l>Anche Ircana svenata ti giacerebbe appresso.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker> TAMAS</speaker>
             <l>Perfida, in ricompensa di tanto amor tal sdegno?</l>
             <l>Va', il feroce tuo cuore di mia pietade è indegno.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker> FATIMA</speaker>
             <l>(Fatima, è questi il tempo colla pietà e l'amore</l>
             <l>Di guadagnar lo sposo, d'incatenargli il core) <emph>(da sé).</emph></l>
             <l part="I">Tamas?...</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F">So, che vuoi dirmi; è la seconda volta</l>
             <l part="I">Questa, che tu mi salvi.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="F">No le mie voci ascolta.</l>
             <l>Questo, che Ircana opprime eccessivo furore</l>
@@ -4716,28 +4747,28 @@ che introduce al serraglio di Tamas.</p>
             <l>Da questo amor tiranno, oppressa al par di lei,</l>
             <l>Tamas, te lo confesso, non so quel ch'io farei.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker> TAMAS</speaker>
             <l>Tu in suo favor mi parli, perché a colei mi doni?</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker> FATIMA</speaker>
             <l>No perché tu l'adori, ma perché le perdoni.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker> TAMAS</speaker>
             <l part="I">Odila, Ircana.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="F">Io l'odo; odo di scaltra i detti,</l>
             <l>Che guadagnar procura con dolcezza gli affetti.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker> TAMAS</speaker>
             <l part="I">Quell'ostinato orgoglio mi stancherà.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="F">Non vedi,</l>
             <l>Ch'ella d'amor delira? Tu a Fatima non credi? <emph>(ad Ircana).</emph></l>
@@ -4746,11 +4777,11 @@ che introduce al serraglio di Tamas.</p>
             <l>D'una rivale ardita chiedo al tuo cuor vendetta,</l>
             <l part="I">La pretendo, la voglio. <emph>(a Tamas)</emph></l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="F"><emph>(a Fatima)</emph> Ora ti credo.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l>Aspetta.</l>
             <l>Sì vendetta vogl'io, ma non di stragi, e sangue,</l>
@@ -4760,28 +4791,28 @@ che introduce al serraglio di Tamas.</p>
             <l><emph>(ad Ircana).</emph> Ecco di te, spietata, qual vendetta desio,</l>
             <l>Bastami, che arrossisca il tuo cuore del mio.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker> IRCANA</speaker>
             <l part="I">(Ah, costei mi avvilisce!) <emph>(da sé).</emph></l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F">Alma di virtù piena,</l>
             <l part="I">Degna sei di pietade, degna d'amor <emph>(a Fatima)</emph>. </l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="F">(Che pena!) <emph>(da sé).</emph></l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker> TAMAS</speaker>
             <l>Il genitore. <emph>(veggendo venir Machmut di lontano avvisa Ircana).</emph></l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker> IRCANA</speaker>
             <l>Oh cielo! mi scopre; io son perduta.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker> FATIMA</speaker>
             <l>Fuggi da queste soglie, fin che sei sconosciuta.</l>
             <l>Vattene, ardito eunuco, e più venir non osa,</l>
@@ -4794,79 +4825,79 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Machmut, Fatima e Tamas.</emph>
           </stage>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="I">Chi è l'audace? <emph>(a Fatima)</emph></l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="F">Perdona, s'io lo celo.</l>
             <l>Sono importuni i servi talor per troppo zelo.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker> TAMAS</speaker>
             <l>(Qual duro cor spietato potria negar d'amarla?</l>
             <l>Mirabile se tace, adorabil se parla) <emph>(da sé).</emph></l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker> MACHMUT</speaker>
             <l>Sposi, sperar in voi posso un amor sincero?</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker> FATIMA</speaker>
             <l part="I">Signor, Tamas m'adora.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="F">Tamas, è vero?</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l>È vero.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker> MACHMUT</speaker>
             <l>Grazie, o numi del cielo, mi scordo ogni tormento,</l>
             <l>Toglietemi la vita; sì, morirò contento.</l>
             <l>Figlio, per la tua sposa dunque spiegasti il core?</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker> TAMAS</speaker>
             <l>Sì, che Fatima è degna di rispetto, e d'amore,</l>
             <l>Padre amarla prometto, ed amerò lei sola.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker> FATIMA</speaker>
             <l part="I">Labbro, che mi ristora!</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F">Voce, che mi consola!</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker> MACHMUT</speaker>
             <l>Ma non vorrei, parlando... e pur parlarne è forza,</l>
             <l>Figlio, se onesta fiamma le triste fiamme ammorza,</l>
             <l part="I">Perché Ircana nascondi?</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="M">Io non l'ascondo.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="F">Invano</l>
             <l>La cercai pel serraglio, e la pretende Osmano.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker> FATIMA</speaker>
             <l part="I">Più di lei non si parli.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="F">Il padre tuo sdegnato...</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker> FATIMA</speaker>
             <l>Anche di lui lo sdegno spero mirar placato.</l>
           </sp>
@@ -4876,7 +4907,7 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Osmano e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l>Machmut, tu pensi invano, ch'io rieda a' miei contorni,</l>
             <l>Se Ircana alle mie mani colle tue man non torni.</l>
@@ -4887,69 +4918,69 @@ che introduce al serraglio di Tamas.</p>
             <l>Indi usciran tremanti dalle rovine, o vinte</l>
             <l>Dal rossor, dal timore, vi rimarranno estinte.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker> MACHMUT</speaker>
             <l part="I">Odilo. <emph>(a Fatima).</emph></l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="M">Ah genitore!</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="F">La schiava non s'asconda.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker> MACHMUT</speaker>
             <l part="I">Figlio, rispondi almeno <emph>(a Tamas).</emph></l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F">Fatima gli risponda.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker> FATIMA</speaker>
             <l>Padre, mirate ormai lieta la figlia in viso,</l>
             <l>Miratela ripiena di giubilo improviso;</l>
             <l>Arde lo sposo mio d'amor, non più d'orgoglio,</l>
             <l part="I">Tamas, padre, m'adora, godete...</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="F">Ircana io voglio.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker> FATIMA</speaker>
             <l>Che vi cal d'una schiava, che Tamas più non cura?</l>
             <l>Che l'amor, che la pace a Fatima non fura?</l>
             <l>Pianga le colpe andate vicina, ovver lontana,</l>
             <l part="I">Gl'insulti, e le vendette scordate.</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="F">Io voglio Ircana.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker> FATIMA</speaker>
             <l part="I">Ma se...</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="F">Ma se ritarda Machmut al nuovo giorno,</l>
             <l>I Tartari, che meco condotti ho qui d'intorno,</l>
             <l>Di lui, non che dei muri, faran strage inaudita;</l>
             <l>Salvati, figlia, meco, o perderai la vita.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker> FATIMA</speaker>
             <l part="I">(Misera me!) <emph>(da sé).</emph></l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="F">Tu sdegni d'udir minaccie invano <emph>(a Machmut).</emph></l>
             <l>Coi scherni, e cogl'insulti non sa tacere Osmano.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker> TAMAS</speaker>
             <l>Ma invano si pretende con onte, e con furore</l>
             <l>Di Tamas, di Machmut, vil che si renda il cuore.</l>
@@ -4958,20 +4989,20 @@ che introduce al serraglio di Tamas.</p>
             <l>Da noi, da' schiavi nostri, da' nostri servi armati</l>
             <l>Difesi moriremo, ma non invendicati.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker> MACHMUT</speaker>
             <l>Sì, figlio, il valor s'usi, quando il pregar non giova.</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker> OSMANO</speaker>
             <l>Del valor che vantate, su, si venga alla prova.</l>
             <l>Olà <emph>(chiama)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="I">Deh, padre amato...</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="F">Chetati, figlia insana.</l>
           </sp>
@@ -4981,7 +5012,7 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Ircana e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l>Cessin le stragi, e l'onte; ecco, spietato, Ircana <emph>(ad Osmano)</emph>.</l>
             <l>Non la nasconde il padre, non la nasconde il figlio,</l>
@@ -4993,28 +5024,28 @@ che introduce al serraglio di Tamas.</p>
             <l>Per non soffrir tuoi lacci, barbaro, al tuo cospetto,</l>
             <l>Mi passerò io stessa con questo ferro il petto <emph>(tenta di uccidersi)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker> FATIMA</speaker>
             <l part="I">Ferma <emph>(le trattiene il colpo)</emph>.</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="F">No, non mi curo d'averti viva, o estinta,</l>
             <l>Purché da' lacci miei, perfida, tu sii cinta</l>
             <l>O si confessi almeno, che quel che chiedo, e voglio,</l>
             <l>È ragione, è dovere, non violenza, o orgoglio.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker> MACHMUT</speaker>
             <l>Niun ti negò, che Ircana a te non si dovesse;</l>
             <l>Ma chi sapea, che in spoglia viril si nascondesse?</l>
             <l part="I">Prendila.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker>IRCANA</speaker>
             <l part="M">Io mi ferisco.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="F">Fermati; e voi m'udite,</l>
             <l>Uditemi, se in core pietade, amor sentite:</l>
@@ -5045,34 +5076,34 @@ che introduce al serraglio di Tamas.</p>
             <l>Soffrir da me, trafitta con sofferenza amara,</l>
             <l>Quella virtù, che forse non ben conosci, impara.</l>
           </sp>
-          <sp>
+          <sp who="#ircana">
             <speaker> IRCANA</speaker>
             <l>
               <emph>(sospirando, confusa parte).</emph>
             </l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker> MACHMUT</speaker>
             <l part="I">Figlia, la tenerezza il cor m'opprime.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="F">Oh Dei!</l>
             <l part="I">Tamas, tu non mi guardi?</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F">Ah l'idolo mio tu sei!</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker> FATIMA</speaker>
             <l part="I">E tu, padre, che dici?</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="M">Ah!</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l part="F">Sì, lo sdegno è stinto</l>
             <l>L'amor vero trionfa, io son felice, ho vinto.</l>
@@ -5083,64 +5114,64 @@ che introduce al serraglio di Tamas.</p>
           <stage>
             <emph>Alí, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l part="I">Tamas, la real guardia...</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker>TAMAS</speaker>
             <l part="F">Dei due schiavi svenati</l>
             <l part="I">Vuol, che io paghi la pena?</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="F">No, figlio, ho già pagati</l>
             <l>Quatrocento <emph>tomani</emph>, che erano un monte d'oro.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker> TAMAS</speaker>
             <l part="I">Ah genitor, perdono.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="F">Sì, tu vali un tesoro.</l>
             <l>Ma non tradir te stesso, la sposa, e il genitore.</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker> TAMAS</speaker>
             <l>Di quanti mali è fonte uno scorretto amore!</l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker> ALÍ</speaker>
             <l>Udite, non è cosa da trascurar cotesta...</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker> TAMAS</speaker>
             <l part="I">Parla, amico.</l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l part="F">La guardia, che ogni or fra l'ombre è desta</l>
             <l>Sotto spoglie virili donna trovò fugace.</l>
             <l>L'arrestò, la scoperse, ed è Curcuma audace.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker> FATIMA</speaker>
             <l part="I">Le mie gioie?</l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker>ALÍ</speaker>
             <l part="F">Di gioie seco avea due fardelli</l>
             <l>Con pendenti, smanigli, auree collane, e anelli.</l>
             <l>Di Fatima un di questi d'essere ha confessato;</l>
             <l>L'altro disse ad Ircana averlo trafugato...</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker> FATIMA</speaker>
             <l>Misera Ircana! ah tosto (le mie gemme non curo)</l>
             <l>Per le sue si proveda, che involate le furo.</l>
           </sp>
-          <sp>
+          <sp who="#ali">
             <speaker> ALÍ</speaker>
             <l>Son nelle man sicure del <emph>Rabdar</emph> maggiore,</l>
             <l>Che non trovando il furto, sarebbe il debitore,</l>
@@ -5149,12 +5180,12 @@ che introduce al serraglio di Tamas.</p>
             <l>Poiché per tai delitti il rigor, la fierezza,</l>
             <l>Forma la nostra pace, la nostra sicurezza.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker> FATIMA</speaker>
             <l>E non per questo solo la puniranno i Numi,</l>
             <l>Ma per i rei dissegni e i perfidi costumi.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker> MACHMUT</speaker>
             <l>Orsù, non più di colpe parlisi, ovver di sdegno,</l>
             <l>Di renderci giulivi amor prenda l'impegno.</l>
@@ -5162,19 +5193,19 @@ che introduce al serraglio di Tamas.</p>
             <l>Facciasi de' congiunti, e degli amici invito.</l>
             <l part="I">Osman, sei tu contento?</l>
           </sp>
-          <sp>
+          <sp who="#osmano">
             <speaker>OSMANO</speaker>
             <l part="M">Lo sono.</l>
           </sp>
-          <sp>
+          <sp who="#machmut">
             <speaker>MACHMUT</speaker>
             <l part="F"><emph>(a Tamas)</emph> E tu sei lieto?</l>
           </sp>
-          <sp>
+          <sp who="#tamas">
             <speaker> TAMAS</speaker>
             <l>Lieto son io, se il core di Fatima è quieto.</l>
           </sp>
-          <sp>
+          <sp who="#fatima">
             <speaker>FATIMA</speaker>
             <l>Felicità maggiore bramare io non potrei,</l>
             <l>Grazie alla pietà vostra, grazie agli eterni Dei!</l>

--- a/tei/goldoni-le-baruffe-chiozzotte.xml
+++ b/tei/goldoni-le-baruffe-chiozzotte.xml
@@ -88,6 +88,55 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="lucietta">
+            <persName>Lucietta</persName>
+          </person>
+          <person xml:id="orsetta">
+            <persName>Orsetta (Orsolina)</persName>
+          </person>
+          <person xml:id="pasqua">
+            <persName>Madonna Pasqua</persName>
+          </person>
+          <person xml:id="libera">
+            <persName>Madonna Libera</persName>
+          </person>
+          <person xml:id="checca">
+            <persName>Checca (Francesca) </persName>
+          </person>
+          <person xml:id="toffolo">
+            <persName>Toffolo (Cristofolo)</persName>
+          </person>
+          <person xml:id="canocchia">
+            <persName>Canocchia</persName>
+          </person>
+          <person xml:id="vicenzo">
+            <persName>Padron Vicenzo</persName>
+          </person>
+          <person xml:id="toni">
+            <persName>Padron Toni (Antonio)</persName>
+          </person>
+          <person xml:id="beppo">
+            <persName>Beppo (Giuseppe)</persName>
+          </person>
+          <person xml:id="titta">
+            <persName>Titta Nane (Giambattista)</persName>
+          </person>
+          <person xml:id="fortunato">
+            <persName>Padron Fortunato</persName>
+          </person>
+          <person xml:id="isidoro">
+            <persName>Isidoro</persName>
+          </person>
+          <person xml:id="comandador">
+            <persName>Il Comandador</persName>
+          </person>
+          <person xml:id="servitore">
+            <persName>Servitore</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -292,143 +341,143 @@ ch'è piacevole, ha il diritto di far ridere».</p>
 Checca dall'altra. Tutte a sedere sopra seggiole di paglia, lavorando
 merletti sui loro cuscini, posti ne' loro scagnetti.</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Creature, cossa diseu de sto tempo?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Che ordene xèlo?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Mi no so, varè. Oe, cugnà, che ordene xèlo? </p>
             <stage>(<emph>a Pasqua</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>No ti senti, che boccon de sirocco?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Xèlo bon da vegnire de sottovento?</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Sì ben, sì ben. Si i vien i nostri omeni, i gh'ha
 el vento in poppe.</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Ancùo o doman i doverave vegnire.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCHA</speaker>
             <p>Oh! bisogna donca che spessega a laorare: avanti
 che i vegna, lo vorave fenire sto merlo.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Di', Checca: quanto te n'amanca a fenire?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Oh! me n'amanca un brazzo.</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Ti laori molto puoco, fia mia </p>
             <stage>(<emph>a Checca</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Oh! quanto xè, che gh'ho sto merlo su sto balon?</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Una settemana.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Ben! una settemana?</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Destrìghete, se ti vuol la carpetta.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Oe, Checca, che carpetta te fastu?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Una carpetta niova de caliman.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Dasseno? Te mettistu in donzelon?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>In donzelon? No so miga cossa, che voggia dire.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>O che pandola! No ti sa, che co una putta xè
 granda, se ghe fa el donzelon; e che co la gh'ha el
 donzelon, xè segno, che i soi i la vuol maridare?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Oe, sorella! </p>
             <stage>(<emph>a Libera</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Fia mia.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Me voleu maridare?</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Aspetta, che vegna mio mario.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Donna Pasqua: mio cugnà Fortunato no xèlo andà a
 pescare co paron Toni?</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Sì, no lo sàstu, che el xè in tartana col mio
 paron, e co Beppe so fradelo?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>No ghe xè anca Titta Nane co lori?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Sì ben: cossa voressistu dire? Cossa
 pretenderavistu da Titta Nane? </p>
             <stage>(<emph>a Checca</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Mi? gnente.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>No ti sa, che xè do anni, che mi ghe parlo? E
 che col vien in terra, el m'ha promesso de darme el segno?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>(Malignaza culìa! La i vol tutti per ela!)</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Via, via, Lucietta, no star a bacilare. Avanti
 che Checca mia sorella se maride, m'ho da maridare mi, m'ho
@@ -436,24 +485,24 @@ da maridare. Co vegnirà in terra Beppe to fradello, el me
 sposerà mi, e se Titta Nane vorrà, ti te poderà sposare anca
 ti. Per mia sorela, gh'è tempo.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Oh! vu, siora, no voressi mai, che me maridasse</p>
             <stage>(<emph>a Orsetta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Tasi là; tendi al to laoriere.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Se fusse viva mia dona mare...</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Tasi, che te trago el balon in coste.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>(Sì, sì, me voggio maridare, se credesse de aver
 da tiòre un de quei squartai, che va a granzi).</p>
@@ -464,170 +513,170 @@ da tiòre un de quei squartai, che va a granzi).</p>
           <stage>
             <emph>Toffolo, e le suddette, poi Canocchia.</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Oe, bondì, Toffolo.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Bondì, Lucietta.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Sior mamara, cossa sémio nualtre?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Se averè pazenzia, ve saluderò anca vualtre.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>(Anca Toffolo me piaserave).</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Coss'è, putto? No laorè ancùo?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Ho laorà fin adesso. So stà col battelo sotto
 marina a cargar dei fenochi: i ho portai a Brondolo al
 corrier de Ferrara, e ho chiapà la zornada.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Ne pagheu gnente?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Sì ben; comandè.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>(Uh! senti, che sfazzada?) </p>
             <stage>(<emph>a Orsetta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Aspettè. Oe! zucche barucche </p>
             <stage>(<emph>chiama</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#canocchia">
             <speaker>CANOCCHIA</speaker>
             <stage>(<emph>con una tavola, con sopra vari pezzi di zucca gialla cotta</emph>).</stage>
             <p>Comandè, paron.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Lassè véder.</p>
           </sp>
-          <sp>
+          <sp who="#canocchia">
             <speaker>CANOCCHIA</speaker>
             <p>Adesso: varè, la xè vegnua fora de forno.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Voleu, Lucietta? </p>
             <stage>(<emph>le offerisce un pezzo di zucca</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Sì ben, dè qua.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>E vu, donna Pasqua, voleu?</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>De diana! la me piase tanto la zucca barucca!
 Dèmene un pezzo.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Tolè. No la magnè, Lucietta?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>La scotta. Aspetto che la se giazze.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Oe! bara Canocchia.</p>
           </sp>
-          <sp>
+          <sp who="#canocchia">
             <speaker>CANOCCHIA</speaker>
             <p>So qua.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Dèmene anca a mi un bezze.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>So qua mi; ve la pagherò mi.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Sior no, no voggio.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Mo per cossa?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Perché no me degno.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>S'ha degnà Lucietta.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Sì, sì, Lucietta xè degnevole, la se degna de
 tutto.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Coss'è, siora? Ve ne aveu per mal, perché so
 stada la prima mi?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Mi co vu, siora, no me n'impazzo. E mi no togo
 gnente da nissun.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>E mi cossa tóghio?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Siora sì, avè tolto anca i trìgoli dal putto
 donzelo de bara Losco.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Mi, busiara?</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>A monte.</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>A monte, a monte.</p>
           </sp>
-          <sp>
+          <sp who="#canocchia">
             <speaker>CANOCCHIA</speaker>
             <p>Gh'è nissun, che voggia altro?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Andè a bon viazo.</p>
           </sp>
-          <sp>
+          <sp who="#canocchia">
             <speaker>CANOCCHIA</speaker>
             <p>Zucca barucca, barucca calda </p>
             <stage>(<emph>gridando parte</emph>).</stage>
@@ -638,336 +687,336 @@ donzelo de bara Losco.</p>
           <stage>
             <emph>I suddetti, fuor di Canocchia.</emph>
           </stage>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>(Accordève, siora Checca, che m'avè dito che de
 mi no ve degnè).</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>(Andè via, che no ve tendo).</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>(E sì, mare de diana, gh'aveva qualche bona
 intenzion).</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>(De cossa?)</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>(Mio santolo me vol metter suso peota, e co son a
 traghetto, anca mi me vòi maridare).</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>(Dasseno?)</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>(Ma vu avè dito che no ve degnè).</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>(Oh! ho dito della zucca, no ho miga dito de vu).</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Oe, oe, digo: cossa xè sti parlari?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Varè? vardo a laorare.</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Andè via de là, ve digo.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Cossa ve fazzio? Tolè; anderò via </p>
             <stage>(<emph>si scosta, e va bel bello dall'altra parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>(Sia malignazo!)</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>(Mo via, cara sorela, se el la volesse, savè che
 putto che el xè: no ghe la voressi dare?)</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Cossa diseu, cugnà? La se mette suso a bonora).</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>(Se ti savessi che rabbia, che la me fa!) </p>
             <stage>(<emph>a Lucietta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Varè che fusto! Viva cocchietto! la voggio far
 desperare) </p>
             <stage>(<emph>da sé</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Sfadighève a pian, donna Pasqua.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Oh! no me sfadigo, no, fio: no vedè, che mazzete
 rosse? El xè merlo da diese soldi.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>E vu, Lucietta?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Oh! el mio xè da trenta.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>E co belo, che el xè!</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Ve piàselo?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Mo co pulito! Mo cari quei deolini.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Vegnì qua, sentève.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>(Oh! qua son più alla bonazza) </p>
             <stage>(<emph>siede</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>(Oe! cossa diseu?) </p>
             <stage>(<emph>a Orsetta, facendole osservare Toffolo vicino a Lucietta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>(Lassa, che i fazza, no te n'impazzare) </p>
             <stage>(<emph>a Checca</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>(Se starò qua, me bastonerali?) </p>
             <stage>(<emph>a Lucietta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Oh che matto!) </p>
             <stage>(<emph>a Toffolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>(Cossa diseu?) </p>
             <stage>(<emph>a Libera, accennando Lucietta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Donna Pasqua, voleu tabacco?</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Xèlo bon?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>El xè de quello de Malamocco.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Dàmene una presa.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Volentiera.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>(Se Titta Nane lo sa, poveretta ela) </p>
             <stage>(<emph>da sé</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>E vu, Lucietta, ghe ne voleu?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Dè qua, sì ben. Per far despetto a culìa)</p>
             <stage>(<emph>accenna Checca</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>(Mo che occhi baroni!) </p>
             <stage>(<emph>a Lucietta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Oh giusto! No i xè miga queli de Checca) </p>
             <stage>(<emph>a Toffolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>(Chi? Checca? gnanca in mente) </p>
             <stage>(<emph>a Lucietta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Vardè, co bela che la xè!) </p>
             <stage>(<emph>a Toffolo, accennando Checca con derisione</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>(Vara chiòe!) </p>
             <stage>(<emph>a Lucietta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>(Anca sì, che i parla de mi) </p>
             <stage>(<emph>da sé </emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(No la ve piase?) </p>
             <stage>(<emph>a Toffolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>(Made) </p>
             <stage>(<emph>a Lucietta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(I ghe dise puinetta) </p>
             <stage>(<emph>a Toffolo sorridendo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>(Puinetta i ghe dise?) </p>
             <stage>(<emph>a Lucietta sorridendo, e guardando Checca</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Oe, digo, no so miga orba, varè. La voleu fenire?</p>
             <stage>(<emph>forte verso Toffolo, e Lucietta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Puina fresca, puina </p>
             <stage>(<emph>forte, imitando quelli, che vendono la puina, cioè la ricotta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Cossa xè sto parlare? Cossa xè sto puinare? </p>
             <stage>(<emph>s'alza</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>No te n'impazzare </p>
             <stage>(<emph>a Checca, e s'alza</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Tendi a laorare </p>
             <stage>(<emph>a Orsetta e Checca alzandosi</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Che el se varda elo, sior Toffolo Marmottina.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Coss'è sto Marmottina?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Sior sì; credeu, che nol sapiemo, che i ve dise
 Toffolo Marmottina?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Varè che sesti! Varè che bela prudenzia!</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Eh! via, cara siora Lucietta Panchiana.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Cossa xè sta Panchiana? Tendè a vu, siora
 Orsetta Meggiotto.</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>No stè a strapazzar mie sorele, che mare di
 diana...</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Portè respetto a mia cugnà </p>
             <stage>(<emph>s'alza</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Eh! tasè, donna Pasqua Fersora.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Tasè vu, donna Libera Galozzo.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Se no fussi donne, sangue de un anguria...</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Vegnirà el mio paron.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Vegnirà Titta Nane. Ghe vòi contare tutto, ghe vòi
 contare.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Cóntighe. Cossa m'importa?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Che el vegna paron Toni Canestro...</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Sì, sì, che el vegna paron Fortunato Baìcolo...</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Oh che temporale!</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Oh che sùsio!</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Oh che bissabuova!</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Oh che stramanìo!</p>
           </sp>
@@ -977,230 +1026,230 @@ contare.</p>
           <stage>
             <emph>Paron Vicenzo, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Olà, olà! zitto, donne. Cossa diavolo gh'aveu?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Oe, vegnì qua, paron Vicenzo.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Oe, sentì paron Vicenzo Lasagna.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Quietève, che xè arivà in sto ponto la tartana de
 paron Toni.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Oe, zitto, che xè arivà mio mario </p>
             <stage>(<emph>a Lucietta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Uh, ghe sarà Titta Nane! </p>
             <stage>(<emph>a Pasqua</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Oe, putte, no fè, che vostro cugnà sappia gnente.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Zitto, zitto, che gnanca Beppe no sappia.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Lucietta, so qua mi, no ve stè a stremire.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Va' via </p>
             <stage>(<emph>a Toffolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Via </p>
             <stage>(<emph>a Toffolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>A mi? sangue d'un bisatto!</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Va' a ziogare al trottolo.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Va' a ziogare a chiba.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>A mi, mare de diana? Anderò mo giusto, mo, da
 Checchina </p>
             <stage>(<emph>s'accosta a Checca</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Via, sporco.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Càvete.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Va' in malora.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>A mi sporco? A mi va' in malora? </p>
             <stage>(<emph>con sdegno</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Va' in burchio.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Olà, olà, paron Vicenzo </p>
             <stage>(<emph>con caldo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Va' a tirar l'alzana </p>
             <stage>(<emph>gli dà uno scappellotto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Gh'avè rason, che no voggio precipitare </p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Dove xèli co la tartana? </p>
             <stage>(<emph>a Vicenzo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>In rio xè secco, no i ghe può vegnire. I xè ligai
 a Vigo. Se volè gnente, vago a vedere se i gh'ha del pesse,
 e se i ghe n'ha, ghe ne vòi comprare per mandarlo a vendere
 a Pontelongo.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Oe, no ghe disè gnente </p>
             <stage>(<emph>a Vicenzo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Oe, paron Vicenzo, no ghe stessi miga a contare.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Che cade!</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>No ghe stessi a dire...</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Mo no stè a bacilare </p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Via, no fermo, che i nostri omeni n'abbia da
 trovare in baruffa.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Oh! mi presto la me monta, e presto la me passa.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Checca, xèstu in colera?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>No ti sa far altro, che far despetti.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>A monte a monte. Sémio amighe?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>No voleu, che lo siemo?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Dàme un baso, Lucietta.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Tiò, vissere </p>
             <stage>(<emph>si baciano</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Anca ti Checca.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>(No gh'ho bon stomego).</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Via, matta.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Via, che ti xè doppia co fa le ceóle.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Mi? Oh! ti me cognossi puoco. Viè qua; dàme un
 baso.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Tiò. Varda ben, no me minchionare.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Tiò el to balon, e andemo in cà, che po anderemo
 in tartana </p>
             <stage>(<emph>piglia lo scagno col cuscino, e parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Putte, andemo anca nu, che li anderemo a
 incontrare </p>
             <stage>(<emph>parte col suo scagno</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>No vedo l'ora de véderlo el mio caro Beppe</p>
             <stage>(<emph>parte col suo scagno</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Bondì, Checca </p>
             <stage>(<emph>prende il suo scagno</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Bondì. Vòggieme ben </p>
             <stage>(<emph>prende il suo scagno, e parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>No t'indubitare </p>
             <stage>(<emph>prende il suo scagno, e parte</emph>).</stage>
@@ -1214,92 +1263,92 @@ tartana di paron TONI.</stage>
             <emph>Paron Fortunato, Beppo, Titta Nane, e altri uomini
 nella tartana, e Paron TONI in terra, poi Paron VICENZO.</emph>
           </stage>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Via, da bravi, a bel belo, mettè in terra quel
 pesse.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Ben vegnuo, paron Toni.</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Schiao, paron Vicenzo.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Com'èla andada?</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Eh! no se podemo descontentare.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Cossa gh'aveu in tartana?</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Gh'avemo un puoco de tutto, gh'avemo.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Me dareu quattro cai de sfoggi?</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Pare sì.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Me dareu quattro cai de barboni?</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Pare sì.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Bòseghe ghe n'aveu?</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Mare de diana, ghe n'avemo de cusì grande, che le
 pare, co buò respetto lengue de manzo, le pare.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>E rombi?</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Ghe n'aémo sié, ghe n'aémo, co è el fondi d'una
 barila.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Se porlo véder sto pesse?</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Andè in tartana, che ghe xè paron Fortunato; avanti
 che lo spartimo, fèvelo mostrare.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Anderò a véde, se se podemo giustare.</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Andè a pian. Oe, deghe man a paron Vicenzo.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>(Gran boni omeni, che xè i pescaori!) </p>
             <stage>(<emph>va in tartana</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Magari lo podessimo vende tutto a bordo el pesse,
 che lo venderia volentiera. Se andemo in man de sti
@@ -1308,29 +1357,29 @@ Nualtri, poverazzi, andemo a rischiare la vita in mare, e
 sti marcanti col bareton de veludo i se fa ricchi co le
 nostre fadighe.</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <stage>(<emph>scende di tartana con due canestri</emph>).</stage>
             <p>Oe, fradello?</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Coss'è, Beppe? Cossa vustu?</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Se ve contentessi, vorria mandar a donare sto cao
 de barboni al Lustrissimo.</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Per cossa mo ghe li vustu donare?</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>No savè, che l'ha da essere mio compare?</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Ben! màndegheli, se ti ghe li vuol mandare. Ma cossa
 credistu? Che in t'un bisogno, che ti gh'avessi, el se
@@ -1341,16 +1390,16 @@ nol s'arecorda più dei barboni: nol te gh'ha gnanca in
 mente; nol te cognosse più, né per compare, né per prossimo,
 né per gnente a sto mondo.</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Cossa voleu, che fazze? Per sta volta, lassè, che
 ghe li mande.</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Mi no te digo che no ti li mandi.</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Chiò, Ménola. Porta sti barboni a sior Cavaliere;
 dìghe che ghe lo mando mi sto presente </p>
@@ -1362,46 +1411,46 @@ dìghe che ghe lo mando mi sto presente </p>
           <stage>
             <emph>Pasqua, Lucietta, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Paron! </p>
             <stage>(<emph>a Toni</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Oh muggiere!</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Fradello! </p>
             <stage>(<emph>a Toni</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Bondì, Lucietta.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Bondì, Beppe.</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Stastu ben, sorela?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Mi, sì. E ti?</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Ben, ben. E vu, cugnà, steu ben?</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Sì, fio. Aveu fatto bon viazo? </p>
             <stage>(<emph>a Toni</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Cossa parleu de viazo? Co semo in terra, no se
 recordemo più de quel, che s'ha passao in mare. Co se pesca,
@@ -1409,242 +1458,242 @@ se fa bon viazo, e co se chiapa, no se ghe pensa a rischiar
 la vita. Avemo portà del pesse, e semo aliegri, e semo tutti
 contenti.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Via via, manco mal. Seu stai in porto?</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Sì ben, semo stai a Senegaggia.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Oe, m'aveu portà gnente?</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Sì, t'ho portà do pera de calze sguarde, e un
 fazzoletto da colo.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Oh! caro el mio caro fradelo; el me vol ben mio
 fradelo.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>E a mi, sior, m'aveu portà gnente?</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Anca a vu v'ho portao da farve un còttolo e una
 vestina.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>De cossa?</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Vederè.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Mo de cossa?</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Vederè, ve digo, vederè.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>E ti m'àstu portà gnente? </p>
             <stage>(<emph>a Beppo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Vara, chiòe! Cossa vustu, che mi te porte? Mi ho
 comprà l'anelo per la mia novizza.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Xè bello?</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Vèlo qua eh! Varda </p>
             <stage>(<emph>le mostra l'anello</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Oh co belo, che el xè! Per culìa sto anelo?</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Per cossa mo ghe distu culìa?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Se ti savessi, cossa che la n'ha fatto!
 Domandighe a la cugnà: quella frascona de Orsetta, e
 quell'altra scagazzera de Checca, comuodo che le n'ha
 strapazzao. Oh! cossa che le n'ha dito!</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>E donna Libera n'àla dito puoco? Ne podévela
 malmenare più de quello che la n'ha malmenao?</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Coss'è? Coss'è stà?</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Cossa xè successo?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Gnente. Lengue cattive. Lengue da tenaggiare.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Semo là sulla porta, che laoremo col nostro
 balon...</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Nu no se n'impazzemo...</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Se savessi! Causa quel baron de Toffolo
 Marmottina.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Le gh'ha zelusia de quel bel suggetto.</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Cossa! Le ha parlà co Toffolo Marmottina?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Se ve piase.</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>O via, no vegnì adesso a metter suso sto putto, e a
 far nassere delle custion.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Uh se savessè!</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Tasi, tasi, Lucietta, che debotto toremo de mezo
 nu.</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Con chi parlàvelo Marmottina?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Con tutte.</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Anca con Orsetta?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Me par de sì.</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Sangue de Diana!</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Oh! via, fenìmola, che no voggio sussuri.</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>No, Orsetta, no la voggio altro, e Marmottina,
 corpo de una balena, el me l'ha da pagare.</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Anemo, andemo a casa.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Titta Nane dove xèlo?</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>El xè in tartana </p>
             <stage>(<emph>con sdegno</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Almanco lo voria saludare.</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Andemo a casa, ve digo.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Via, che pressa gh'aveu?</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Podevi far de manco de vegnire qua a sussurare.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Vedeu, cugnà? Avevimo dito de no parlare.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>E chi xè stada la prima a schittare?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Oh! mi coss'òggio dito?</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>E mi coss'òggio parlà?</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Avè dito tanto, che se fusse qua Orsetta, ghe daria
 un schiaffazzo in tel muso. Da culìa no vòi altro. Voggio
 vender l'anelo.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Dàmelo a mi, dàmelo.</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>El diavolo, che ve porta.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Oh che bestia!</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>To danno, ti meriti pezo. A casa, te digo. Subito, a
 casa.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Varè, che sesti! Cossa songio? La vostra
 massera? Sì, sì, no v'indubitè, che co vu no ghe voggio
@@ -1652,21 +1701,21 @@ stare. Co vederò Titta Nane, ghe lo dirò. O che el me sposa
 subito, o per diana de dia, voggio andar più tosto a
 servire.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Mo gh'avè dei gran tiri da matto.</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Voleu ziogar che debotto... </p>
             <stage>(<emph>fa mostra di volerle dare</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Mo, che omeni! Mo, che omeni malignazi </p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Mo, che donne; mo, che donne da pestare co fa i
 granzi per andare a pescare </p>
@@ -1679,141 +1728,141 @@ granzi per andare a pescare </p>
             <emph>Fortunato, Titta Nane, Vicenzo, che scendono
 dalla tartana, con uomini carichi di canestri.</emph>
           </stage>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Cossa diavolo xè stà quel sussuro?</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Gnente, fradelo, no saveu? Donna Pasqua Fersora
 la xè una donna, che sempre cria.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Con chi criàvela?</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Con so mario.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Lucietta ghe gièrela?</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Me par de sì, che la ghe fusse anca ela.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Sia maledìo. Giera là sotto prova a stivare el
 pesse: no ho gnanca podesto vegnire in terra.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Oh che caro Titta Nane! Aveu paura de no véderla
 la vostra novizza?</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Se savessi! Muoro de voggia.</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Parò Izenzo </p>
             <stage>(<emph>parla presto, e chiama paron Vicenzo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Coss'è, paron Fortunato?</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Questo xè otto pesse. Quato cai foggi, do cai
 baboni, sie, sie, sie boseghe, e un cao baccole.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Cossa?</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>E un cao baccole.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>No v'intendo miga.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>No intendè? Quattro cai de sfoggi, do cai de
 barboni, sie boseghe, e un cao de baracole.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>(El parla in t'una certa maniera...)</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Mandè a casa e pesse, vegniò po mi a tò i
 bezzi.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Missier sì, co volè i vostri bezzi, vegnì, che i
 sarà parecchiai.</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Na pesa abacco.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Come?</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Tabacco, tabacco.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Ho capìo. Volentiera </p>
             <stage>(<emph>gli dà tabacco</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Ho perso a scattoa in mare, e in tartana gh'è
 puochi e tò tabacco. A Senegaggia e n'ho comprao un puoco,
 ma no xè e nostro da Chioza. Tabacco, tabacco de Senegaggia,
 e tabacco e pare balini chioppo.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Compatìme, paron Fortunato, mi no v'intendo una
 maledetta.</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Oh bella, bella bella! no intendè? Bella! no
 parlo mia foeto, parlo chiozzotto, parlo.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Ho capìo. A revéderse, paron Fortunato.</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Sioìa, paó Izenzo.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Schiavo, Titta Nane.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Paron, ve saludo.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Putti, andemo. Portè quel pesse con mi. (Mo caro
 quel paron Fortunato! El parla, che el consola) </p>
@@ -1825,47 +1874,47 @@ quel paron Fortunato! El parla, che el consola) </p>
           <stage>
             <emph>Fortunato, e Titta Nane.</emph>
           </stage>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Voleu che andemo, paron Fortunato?</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Petè.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Cossa voleu, che aspettemo?</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Petè.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Petè, petè, cossa ghe xè da aspettare?</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>I ha a potare i terra de atro pesse, e de a
 faìna. Petè.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Petémo </p>
             <stage>(<emph>caricandolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Coss'è to bulare? Coss'è to ciare, coss'è to
 zigare?</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Oh! tasè, paron Fortunato. Xè qua vostra muggiere
 co so sorella Orsetta, e co so sorella Checchina.</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Oh, oh mia muggiere, mia muggiere!</p>
             <stage>(<emph>con allegria</emph>).</stage>
@@ -1876,285 +1925,285 @@ co so sorella Orsetta, e co so sorella Checchina.</p>
           <stage>
             <emph>Libera, Orsetta, Checca, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Paron, cossa feu, che non vegnì a casa?</p>
             <stage>(<emph>a Fortunato</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Apetto e pesse, apetto. Ossa fàtu, muggiere?
 Tàtu ben, muggiere?</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Stago ben, fio: e vu steu ben?</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Tago ben, tago. Cugnà, saudo; saudo, Checca,
 saudo </p>
             <stage>(<emph>saluta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Sioria, cugnà.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Cugnà, bondì sioria.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Sior Titta Nane gnanca?</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Patrone.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Stè molto alla larga, sior. Cossa, gh'aveu paura?
 Che Lucietta ve diga roba?</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Cossa fàla Lucietta? Stàla ben?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Eh! la sta ben, sì, quella cara zoggia.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Coss'è, no sè più amighe?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Oh! e come che semo amighe </p>
             <stage>(<emph>ironico</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>La ne vol tanto ben! </p>
             <stage>(<emph>con ironia</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Via, putte, tasè. Avemo donà tutto; avemo dito de
 no parlare, e no voggio che le possa dire de madesì, e de
 qua, de là, che vegnimo a pettegolare.</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Oe, muggiere, ho portao de a faìna da
 sottovento, de a faìna, e sogo tucco, e faemo a poenta,
 faemo.</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Bravo! avè portà della farina, de sorgo turco?
 Gh'ho ben a caro dasseno.</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>E ho portao...</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Vorave, che me disessi... </p>
             <stage>(<emph>a Libera</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Lassè parlare i omeni, lassè parlare </p>
             <stage>(<emph>a Titta Nane</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Caro vu, quietève un pochetto </p>
             <stage>(<emph>a Fortunato</emph>).</stage>
             <p>Vorave, che me disessi, cossa ghe xè stà con Lucietta </p>
             <stage>(<emph>a Libera</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Gnente </p>
             <stage>(<emph>con malizia</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Gnente?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Gnente via gnente </p>
             <stage>(<emph>urtando Libera</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Xè meggio cussì, gnente </p>
             <stage>(<emph>urtando Orsetta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Oe, putti poté in terra e sacco faìna</p>
             <stage>(<emph>verso la tartana</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Mo, via, care creature, se gh'è stà qualcossa,
 disèlo. Mi no voggio, che siè nemighe. So, che vualtre sè
 bona zente. So, che anca Lucietta la xè una perla.</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Oh caro!</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Oh che perla!</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Oh co palicaria!</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Cossa podeu dire de quela putta?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Gnente.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Domandèghelo a Marmottina.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Chi èlo sto Marmottina?</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Mo via, putte, tasè. Cossa diavolo gh'aveu, che no
 ve podè tasentare?</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>E chi èlo sto Marmottina?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>No lo cognossè Toffolo Marmottina?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Quel battelante, no lo cognossè? </p>
             <stage>(<emph>scendono di tartana col pesce, e un sacco</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Andemo, andemo, el pesse, e a faìna </p>
             <stage>(<emph>a Titta Nane</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Eh! sia maledetto </p>
             <stage>(<emph>a Fortunato</emph>).</stage>
             <p>Cossa gh'ìntrelo con Lucietta?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>El se ghe senta darente.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>El vol imparar a laorare a mazzette.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>El ghe paga la zucca barucca.</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>E po sto baron, per causa soa, el ne strapazza.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Mo, me la disè ben grandonazza.</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>A casa, a casa, a casa </p>
             <stage>(<emph>alle donne</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Oe, el n'ha manazzà fina </p>
             <stage>(<emph>a Titta Nane</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>El m'ha dito puinetta.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Tutto per causa della vostra perla.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Dov'èlo? dove stallo? dove zìrelo? dove lo
 poderavio trovare? </p>
             <stage>(<emph>affannoso</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Oe, el sta de casa in cale della Corona, sotto el
 sottoportego in fondi per sboccar in canale.</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>El sta in casa co bara Trìgolo.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>E el battelo el lo gh'ha in rio de Palazzo, in
 fazza a la pescaria, arente al battelo de Checco Bòdolo.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>A mi; lassé far a mi: se lo trovo, lo taggio in
 fette co fa l'asiao.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Eh! se lo volè trovare, lo troverè da Lucietta.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Da Lucietta?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Sì, dalla vostra novizza.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>No, no la xè più la mia novizza. La voggio lassare,
 la voggio impiantare; e quel galiotto de Marmottina, sangue
 de diana, che lo voggio scanare </p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Anemo, a casa ve digo; andemo a casa, andemo.</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Sì, andemo, burattaora, andemo.</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Cossa seu egnue a dire? Cossa seu egnue a fare?
 Cossa seu egnue a tegolare? A fare precipitare a fare? Mae e
@@ -2162,7 +2211,7 @@ diana! Se nasse gnente, gnente se nasse, e oggio maccare el
 muso, e oggio maccare, e oggio fae stae in letto, e oggio:
 in letto, in letto, maleettonazze in letto.</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Tolè suso! Anca mio mario me manazza. Per causa de
 vualtre pettazze, me tocca sempre a tiòre de mezzo a mi, me
@@ -2171,43 +2220,43 @@ promesso de no parlare, e po vegnì a dire, e po vegnì a
 fare. Mare de tròccolo, che me volè far desperare </p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Séntistu?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Oe, cossa gh'àstu paura?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Mi? gnente.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Se Lucietta perderà el novizzo, so danno.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Mi lo gh'ho intanto.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>E mi me lo saverò trovare.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Oh che spasemi!</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Oh che travaggi!</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Gnanca in mente!</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Gnanca in ti busi del naso </p>
             <stage>(<emph>partono</emph>).</stage>
@@ -2219,7 +2268,7 @@ fare. Mare de tròccolo, che me volè far desperare </p>
           <stage>
             <emph>Toffolo, poi Beppo.</emph>
           </stage>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Sì ben, ho fatto male; ho fatto male, ho fatto
 male. Co Lucietta no me ne doveva impazzare. La xè novizza;
@@ -2234,106 +2283,106 @@ serada; no so, se i ghe sia in casa, o se no i ghe sia in
 casa </p>
             <stage>(<emph>si accosta alla casa</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Vèlo qua, quel furbazzo! </p>
             <stage>(<emph>uscendo dalla sua casa</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Se podesse, vorave un puoco spionare </p>
             <stage>(<emph>si accosta di più</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Olà! olà! sior Marmottina.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Coss'è sto Marmottina?</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Càvete.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Vara, chiòe! Càvete! Coss'è sto càvete?</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Vustu ziogare, che te dago tante peae, quante, che
 ti ghe ne può portare?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Che impazzo ve daghio?</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Cossa fàstu qua?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Fazzo quel, che voggio, fazzo.</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>E mi qua no voggio, che ti ghe staghe.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>E mi ghe voggio mo stare. Ghe voggio stare, ghe
 voggio.</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Va' via, te digo.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Made.</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Va' via, che te dago una sberla.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Mare de diana, ve trarò una pierada </p>
             <stage>(<emph>raccoglie delle pietre</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>A mi, galiotto? </p>
             <stage>(<emph>mette mano a un coltello</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Làsseme stare, làsseme.</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Càvete, te digo.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>No me voggio cavare gnente, no me voggio cavare.</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Va' via, che te sbuso.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Sta' da lonzi, che te spacco la testa </p>
             <stage>(<emph>con un sasso</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Tìreme, se ti gh'ha cuor.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <stage>(<emph>tira dei sassi, e Beppo tenta cacciarsi sotto</emph>).</stage>
           </sp>
@@ -2344,69 +2393,69 @@ voggio.</p>
             <emph>Paron Toni esce di casa, poi rientra, e subito ritorna a sortire;
 poi Pasqua, e Lucietta</emph>
           </stage>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Cossa xè sta cagnara?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <stage>(<emph>tira un sasso a paron Toni</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Agiuto; i m'ha dà una pierà.
 Aspetta, galiotto, che vòi, che ti me la paghe </p>
             <stage>(<emph>entra in casa</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Mi no fazzo gnente a nissun, no fazzo. Cossa me
 vegniu a insolentare? </p>
             <stage>(<emph>prendendo sassi</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Metti zo quelle piere.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Metti via quel cortelo.</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Via, che te taggio a tocchi </p>
             <stage>(<emph>sorte con un pistolese</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Paron, fermève </p>
             <stage>(<emph>trattenendo paron Toni</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Fradei, fermève </p>
             <stage>(<emph>trattenendo paron Toni</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Lo volemo mazzare.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Via, strambazzo férmete </p>
             <stage>(<emph>trattiene Beppo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Stè in drio, che ve coppo </p>
             <stage>(<emph>minacciando con sassi</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Zente! </p>
             <stage>(<emph>gridando</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Creature! </p>
             <stage>(<emph>gridando</emph>).</stage>
@@ -2418,122 +2467,122 @@ vegniu a insolentare? </p>
             <emph>Paron Fortunato, Libera, Orsetta, Checca. Uomini
 che portano pesce e farina, ed i suddetti.</emph>
           </stage>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Com'èla? Com'èla? Forti, forti, com'èla?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Oe! custion.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Custion? poveretta mi! </p>
             <stage>(<emph>corre in casa</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Inspiritai, fermève.</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Per causa vostra </p>
             <stage>(<emph>alle donne</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Chi? cossa?</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Me maraveggio de sto parlare.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Sì, sì, vualtre tegnì tenzon.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Sì, sì, vualtre sè zente da precipitare.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Sentì, che sproposità!</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Sentì, che lengue!</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Ve lo mazzerò su la porta.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Chi?</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Quel furbazzo de Marmottina.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Via, che mi no son Marmottina </p>
             <stage>(<emph>tira de' sassi</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Paron, in casa </p>
             <stage>(<emph>spingendo Toni</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>In casa, fradelo, in casa </p>
             <stage>(<emph>spingendo Beppo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Stè ferma.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>In casa, ve digo, in casa </p>
             <stage>(<emph>lo fa entrare in casa con lei</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Lasseme stare </p>
             <stage>(<emph>a Lucietta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Va' drento, te digo, matto; va' drento </p>
             <stage>(<emph>lo fa entrare con lei. Serrano la porta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Baroni, sassini, vegnì fuora, se gh'avè coraggio.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Va' in malora </p>
             <stage>(<emph>a Toffolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Vatte a far squartare </p>
             <stage>(<emph>lo spinge via</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Coss'è sto spenzere? Cossa xè sto parlare?</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Va' la, va' la, che debotto, se te metto e ma a
 torno, te fazzo egnì fuora e buele pe a bocca.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Ve porto respetto, ve porto, perché sè vecchio, e
 perché sè cugnà de Checchina. Ma sti baroni, sti cani sangue
@@ -2546,103 +2595,103 @@ de diana, me l'ha da pagare </p>
           <stage>
             <emph>Titta Nane con pistolese, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Vàrdete, che te sbuso </p>
             <stage>(<emph>contro Toffolo, battendo il pistolese per terra</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Agiuto! </p>
             <stage>(<emph>si tira alla porta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Saldi. Fermève </p>
             <stage>(<emph>lo ferma</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>No fè!</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Tegnilo.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Lassème andare, lassème </p>
             <stage>(<emph>si sforza contro Toffolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Agiuto! </p>
             <stage>(<emph>dà nella porta, che si apre, e cade dentro</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Titta Nane, Titta Nane, Titta Nane</p>
             <stage>(<emph>tenendolo e tirandolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Menèlo in casa, menèlo </p>
             <stage>(<emph>a Fortunato</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>No ghe voggio vegnire </p>
             <stage>(<emph>sforzandosi</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Ti gh'ha ben da egnire </p>
             <stage>(<emph>lo tira in casa per forza</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Oh che tremazzo!</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Oh che batticuore!</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <stage>(<emph>cacciando di casa Toffolo</emph>).</stage>
             <p>Va' via de qua.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <stage>(<emph>cacciando Toffolo</emph>).</stage>
             <p>Va' in malora.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Scarcavalo </p>
             <stage>(<emph>via</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Scavezzacolo </p>
             <stage>(<emph>via, e serra la porta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Cossa diseu, creature? </p>
             <stage>(<emph>a Libera e Orsetta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>To danno </p>
             <stage>(<emph>via</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Magari pezo </p>
             <stage>(<emph>via</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Sangue de diana, che li vòi querelare </p>
             <stage>(<emph>parte</emph>).</stage>
@@ -2658,167 +2707,167 @@ de diana, me l'ha da pagare </p>
             <emph>Isidoro al tavolino scrivendo, poi Toffolo, poi il
 Comandadore.</emph>
           </stage>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <stage>(<emph>sta scrivendo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Lustrissimo sió Canciliere.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Mi no son el Cancelier; son el Cogitor.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Lustrissimo sió Cogitore.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Cossa vustu?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>L'abbia da savere, che un baron, lustrissimo,
 m'ha fatto impazzo, e el m'ha manazao col cortelo, e el me
 voleva dare, e po dopo xè vegnù un'altra canaggia,
 lustrissimo...</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Siestu maledetto! Lassa star quel lustrissimo.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Mo no, sió Cogitore, la me staga a sentire, e
 cussì, comuodo, ch'a ghe diseva, mi no ghe fazzo gnente, e i
 m'ha dito, che i me vuol amazzare.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Vien qua; aspetta </p>
             <stage>(<emph>prende un foglio per scrivere</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>So qua, lustrissimo. (Maledii! I me la gh'ha da
 pagare).</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Chi èstu ti?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>So battelante, lustrissimo.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Cossa gh'àstu nome?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Toffolo.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>El cognome?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Zavatta.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Ah! no ti xè <emph>Scarpa</emph>, ti xè zavata.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Zavatta, lustrissimo.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Da dove xèstu?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>So chiozzotto, da Chiozza.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Àstu padre?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Mio pare, lustrissimo, el xè morto in mare.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Cossa gh'avevelo nome?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Toni Zavatta, Baracucco.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>E ti gh'àstu nissun sorannome?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Mi no, lustrissimo.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Xè impossibile, che no ti gh'abbi anca ti el to
 sorannome.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Che sorannome vuolla, che gh'abbia?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Dime, caro ti: no xèstu stà ancora, me par, in
 canceleria?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Sió sì, una volta me son vegnù a esaminare.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Me par, se no m'ingano, d'averte fatto citar col
 nome de Toffolo Marmottina.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Mi so Zavatta, no so Marmottina. Chi m'ha messo
 sto nome, xè stao una carogna, lustrissimo.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Debotto te dago un lustrissimo su la copa.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>L'abbia la bontà de compatire.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Chi xè quei che t'ha manazzà?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Paron Toni Canestro, e so fradello, Beppe
 Cospettoni, e po dopo Titta Nane Moletto.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Gh'aveveli arme?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Mare de diana se i ghe n'aveva! Beppe Cospettoni
 gh'aveva un cortelo da pescaore. Paron Toni xè vegnuo fuora
@@ -2826,119 +2875,119 @@ con un spadon da taggiare la testa al toro, e Titta Nane
 gh'aveva una sguèa de quele che i tien sotto pope in
 tartana.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>T'hai dà? T'hai ferìo?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Made. I m'ha fatto paura.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Per cossa t'hai manazzà? Per cossa te voleveli
 dar?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Per gnente.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Aveu crià? Ghe xè stà parole?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Mi no gh'ho dito gnente.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Xèstu scampà? T'àstu defeso? Come xèla fenìa?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Mi so stà là... cussì... Fradei, digo, se me volè
 mazzare, mazzème, digo.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Ma come xèla fenìa?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Xè arrivao delle buone creature, e i li ha fatti
 desmettere, e i m'ha salvao la vita.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Chi xè stà ste creature?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Paron Fortunato Cavicchio, e so muggiere donna
 Libera Galozzo, e so cugnà Orsetta Meggiotto, e un'altra so
 cugnà Checca Puinetta.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>(Sì, sì, le cognosso tutte custìe. Checca tra le
 altre xè un bon tocchetto) </p>
             <stage>(<emph>scrive</emph>).</stage>
             <p>Ghe giera altri presenti?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Ghe giera donna Pasqua Fersora e Lucietta
 Panchiana.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>(Oh! anca queste so chi le xè). </p>
             <stage>(<emph>scrive</emph>).</stage>
             <p>Gh'àstu altro da dir?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Mi no, lustrissimo.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Fàstu nissuna istanza ala giustizia?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>De cossa?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Domandistu, che i sia condanai in gnente?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Lustrissimo sì.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>In cossa?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>In galìa, lustrissimo.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Ti sulle forche, pezzo de aseno.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Mi, sior? Per cossa?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Via, via pampalugo. Basta cussì, ho inteso tutto</p>
             <stage>(<emph>scrive in un piccolo foglio</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>(No vorave, che i me vegnisse anca lori a
 querelare, perché gh'ho tratto delle pierae. Ma che i vegna
@@ -2946,83 +2995,83 @@ pure; mi so stà el primo a vegnire, e chi è 'l primo, porta
 via la bandiera) </p>
             <stage>(<emph>da sé</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <stage>(<emph>suona il campanello</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#comandador">
             <speaker>COMANDADOR</speaker>
             <p>Lustrissimo.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Andè a citar sti testimoni </p>
             <stage>(<emph>s'alza</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#comandador">
             <speaker>COMANDADOR</speaker>
             <p>Lustrissimo sì, la sarà servida.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Lustrissimo, me raccomando.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Bondì, Marmottina.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Zavatta, per servirla.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Sì, zavatta, senza siòla, senza tomera, senza
 sesto, e senza modelo </p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>El me vol ben el sió cogitore </p>
             <stage>(<emph>al Comandatore ridendo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#comandador">
             <speaker>COMANDADOR</speaker>
             <p>Sì, me n'accorzo. Xèli per vu sti testimoni?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Sió sì, sió comandadore.</p>
           </sp>
-          <sp>
+          <sp who="#comandador">
             <speaker>COMANDADOR</speaker>
             <p>Ve preme, che i sia citai?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Me preme seguro, sió comandadore.</p>
           </sp>
-          <sp>
+          <sp who="#comandador">
             <speaker>COMANDADOR</speaker>
             <p>Me paghereu da bever?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Volentiera, sió comandadore.</p>
           </sp>
-          <sp>
+          <sp who="#comandador">
             <speaker>COMANDADOR</speaker>
             <p>Ma mi no so miga dove, che i staga.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Ve l'insegnerò mi, sió comandadore.</p>
           </sp>
-          <sp>
+          <sp who="#comandador">
             <speaker>COMANDADOR</speaker>
             <p>Bravo sior Marmottina.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Sieu maledetto, sió comandadore </p>
             <stage>(<emph>partono</emph>).</stage>
@@ -3036,36 +3085,36 @@ sesto, e senza modelo </p>
 loro sedie di paglia, i loro scagni, e i loro cuscini, e siedono, e si
 mettono a lavorare merletti.</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Àle mo fatto una bella cossa quelle pettazze?
 Andare a dire a Titta Nane, che Marmottina m'è vegnù a
 parlare?</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>E ti àstu fatto ben a dire ai to fradei quelo, che
 ti gh'ha dito?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>E vu, siora? No avè dito gnente, siora?</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Sì ben; ho parlà anca mi, e ho fatto mal a
 parlare.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Malignazo! Aveva zurà anca mi de no dire.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>La xè cussì, cugnà, credème, la xè cussì. Nualtre
 femene, se no parlemo, crepemo.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Oe; no voleva parlare, e no m'ho podesto
 tegnire. Me vegniva la parola ala bocca, procurava a
@@ -3074,105 +3123,105 @@ da quell'altra i diseva: parla. Oe, ho serà la recchia del
 tasi, e ho slargà la recchia del parla; e ho parlà fina che
 ho podesto.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Me despiase, che i nostri omeni i ha avuo da
 precipitare.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Eh! gnente. Toffolo xè un martuffo; no sarà
 gnente.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Beppe vol licenziar Orsetta.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Ben! El ghe ne troverà un'altra; a Chiozza no
 gh'è carestia de putte.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>No, no; de quarantamile aneme, che semo, mi credo,
 che ghe ne sia trentamile de donne.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>E quante, che ghe ne xè da maridare!</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Per questo, védistu? me despiase, che se Titta
 Nane te lassa, ti stenterà a trovarghene un altro.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Cossa gh'òggio fatto mi a Titta Nane?</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Gnente non ti gh'ha fatto; ma quele pettegole l'ha
 messo suso.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Se el me volesse ben, nol ghe crederave.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>No sàstu, che el xè zeloso?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>De cossa? No se può gnanca parlare? No se può
 ridere? No se se può devertire? I omeni i sta diese mesi in
 mare; e nualtre avemo da star qua muffe muffe a tambascare
 co ste malignaze mazzocche?</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Oe, tasi, tasi; el xè qua Titta Nane.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Oh! el gh'ha la smara. Me n'accorzo, col gh'ha
 la smara.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>No ghe star a fare el muson.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Se el me lo farà elo, ghe lo farò anca mi.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Ghe vustu ben?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Mi sì.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Mòlighe, se ti ghe vol ben.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Mi no, varè.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Mo via, no buttare testarda.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Oh! piuttosto crepare.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Mo che putta morgnona!</p>
           </sp>
@@ -3182,166 +3231,166 @@ la smara.</p>
           <stage>
             <emph>Titta Nane, e dette.</emph>
           </stage>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>(La voria licenziare; ma no so come fare) </p>
             <stage>(<emph>da sé</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>(Vàrdelo un poco) </p>
             <stage>(<emph>a Lucietta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Eh! che ho da vardare il mio merlo mi, ho da
 vardare) </p>
             <stage>(<emph>a Pasqua</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>(Ghe pesterave la testa su quel balon!) </p>
             <stage>(<emph>da sé</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>(No la me varda gnanca. No la me gh'ha gnanca in
 mente).</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Sioria, Titta Nane.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Sioria.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>(Saludilo) </p>
             <stage>(<emph>a Lucietta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Figurève, se voggio esser la prima mi!)</p>
             <stage>(<emph>a Pasqua</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Gran premura de laorare.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Cossa diseu? Semio donne de garbo, fio?</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Sì, sì, co se puol, se fa ben a spessegare, perché
 co vien dei zoveni a sentarse arente, no se puol laorare.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <stage>(<emph>tossisce con caricatura</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>(Mòlighe) </p>
             <stage>(<emph>a Lucietta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Made).</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Donna Pasqua, ve piase la zucca barucca?</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Varè vedè! Per cossa me lo domandeu?</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Perché gh'ho la bocca.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <stage>(<emph>sputa forte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Gran cataro, patrona!</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>La zucca me fa spuare </p>
             <stage>(<emph>lavorando senza alzar gli occhi</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Cussì v'avessela soffegà </p>
             <stage>(<emph>con isdegno</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Possa crepare chi me vuol male </p>
             <stage>(<emph>come sopra</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>(Orsù, l'ho dita, e la voggio fare). Donna Pasqua,
 parlo co vu, che sè donna. A vu v'ho domandà vostra cugnà
 Lucietta, e a vu ve digo, che la licenzio.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Varè che sesti! Per cossa?</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Per cossa, per cossa!...</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>lucietta</speaker>
             <stage>(<emph>s'alza per andar via</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Dove vastu?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Dove, che voggio </p>
             <stage>(<emph>va in casa, e a suo tempo ritorna</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>No stè a badare ai pettegolezzi </p>
             <stage>(<emph>a Titta Nane</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>So tutto, e me maraveggio de vu, e me maraveggio de
 ela.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Mo se la ve vol tanto ben.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Se la me volesse ben, no la me volterave le spale.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Poverazza! La sarà andada a pianzere, la sarà
 andada.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Per chi a pianzer? Per Marmottina?</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Mo no, Titta Nane, mo no, che la ve vol tanto ben!
 che co la ve vede andar in mare, ghe vien l'angossa. Co vien
@@ -3350,237 +3399,237 @@ causa vostra. La se leva suso la notte, la va al balcon a
 vardar el tempo. La ve xè persa drio, no la varda per altri
 occhi, che per i vostri.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>E perché mo no dirme gnanca una bona parola?</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>No la puol; la gh'ha paura; la xè propriamente
 ingropà.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>No gh'ho rason fursi de lamentarme de ela?</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Ve conterò mi, come che la xè stà.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Sior no; vòi, che ela mel diga, e che la confessa,
 e che la me domanda perdon.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Ghe perdonereu?</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Chi sa? Poderave esser de sì. Dove xèla andà?</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Vèla qua, vèla qua, che la vien.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Tolè, sior, le vostre scarpe, le vostre cordele,
 e la vostra zendalina che m'avè dà </p>
             <stage>(<emph>getta tutto in terra</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Oh poveretta mi! Xèstu matta? </p>
             <stage>(<emph>raccoglie la roba, e la mette sulla seggiole</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>A mi sto affronto?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>No m'aveu licenzià? Tolè la vostra roba, e
 pettèvela.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Se parlerè co Marmottina, lo mazzerò.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Oh viva diana! M'avè licenzià, e me voressi anca
 mo comandare?</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>V'ho licenzià per colù, v'ho licenzià.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Me maraveggio anca, che crediè, che Lucietta se
 voggia taccare con quel squartao.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>So brutta, so poveretta, so tutto quel che volè;
 ma gnanca co un battelante no me ghe tacco.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Per cossa ve lo feu sentar arente? Per cossa toleu
 la zucca barucca?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Varè, che casi!</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Varè, che gran criminali!</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Mi, co fazzo l'amore, no voggio, che nissun possa
 dire. E la voggio cussì, la voggio. Mare de diana! A Titta
 Nane nissun ghe l'ha fatta tegnire. Nissun ghe la farà
 portare.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Varè là, che spuzzetta </p>
             <stage>(<emph>si asciuga gli occhi</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Mi so omo, saveu? so omo. E no son un putelo,
 saveu?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <stage>(<emph>piange mostrando di voler piangere</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Cossa gh'àstu? </p>
             <stage>(<emph>a Lucietta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Gnente </p>
             <stage>(<emph>piangendo dà una spinta a donna Pasqua</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Ti pianzi?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Da rabbia, da rabbia, che lo scanerave co le mie
 man.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Via, digo! Cossa xè sto fifare? </p>
             <stage>(<emph>accostandosi a Lucietta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Andè in malora.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Sentìu, siora? </p>
             <stage>(<emph>a donna Pasqua</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Mo no gh'àla rason? Se sè pezo d'un can.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Voleu ziogare, che me vago a trar in canale?</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Via, matto!</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Lassè, che el vaga, lassè </p>
             <stage>(<emph>come sopra, piangendo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Via, frascona!</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Gh'ho volesto ben, gh'ho volesto </p>
             <stage>(<emph>intenerendosi</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>E adesso no più? </p>
             <stage>(<emph>a Titta Nane</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Cossa voleu? Se no la me vuole.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Cossa distu, Lucietta?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Lassème stare, lassème.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Tiò le to scarpe, tiò la to cordela, tiò la to
 zendalina </p>
             <stage>(<emph>a Lucietta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(No voggio gnente, no voggio).</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Vien qua, senti.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Lassème stare.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Dighe una parola.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>No.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Vegnì qua, Titta Nane.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Made.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Mo via </p>
             <stage>(<emph>a Titta Nane</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>No voggio.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Debotto ve mando tutti do a far squartare.</p>
           </sp>
@@ -3590,66 +3639,66 @@ zendalina </p>
           <stage>
             <emph>Il Comandadore, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#comandador">
             <speaker>COMANDADOR</speaker>
             <p>Seu vu, donna Pasqua, muggier de paron Toni
 Canestro? </p>
             <stage>(<emph>a Psqua</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Missiersì, cossa comandeu?</p>
           </sp>
-          <sp>
+          <sp who="#comandador">
             <speaker>COMANDADOR</speaker>
             <p>E quella xèla Lucietta, sorella de paron Toni?</p>
             <stage>(<emph>a Pasqua</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Sior sì: cossa voressi da ela?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Oh poveretta mi! Cossa vuorlo el comandadore?)</p>
           </sp>
-          <sp>
+          <sp who="#comandador">
             <speaker>COMANDADOR</speaker>
             <p>Ve cito per ordine de chi comanda, che andè
 subito a Palazzo in cancelaria a esaminarve.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Per cossa?</p>
           </sp>
-          <sp>
+          <sp who="#comandador">
             <speaker>COMANDADOR</speaker>
             <p>Mi no so altro. Andè, e obbedì, pena diese
 ducati, se no gh'andè.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>(Per la custion) </p>
             <stage>(<emph>a Lucietta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Oh! mi no ghe voggio andare).</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>(Oh! bisognerà ben, che gh'andemo).</p>
           </sp>
-          <sp>
+          <sp who="#comandador">
             <speaker>COMANDADOR</speaker>
             <p>Xèla quella la casa de paron Vicenzo?</p>
             <stage>(<emph>a Pasqua</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Sior sì, quella.</p>
           </sp>
-          <sp>
+          <sp who="#comandador">
             <speaker>COMANDADOR</speaker>
             <p>No occorr'altro. La porta xè averta, anderò de
 suso </p>
@@ -3661,24 +3710,24 @@ suso </p>
           <stage>
             <emph>Pasqua, Lucietta, e Titta Nane.</emph>
           </stage>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Aveu sentìo, Titta Nane?</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Ho sentìo. Quel furbazzo de Marmottina m'averà
 querelao. Bisogna, che me vaghe a retirare.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>E mio mario?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>E i mi fradeli?</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Oh poverete nu! Va' là, va' a la riva va'a vede,
 se ti li catti, vàli a avisare. Mi anderò a cercare paron
@@ -3693,63 +3742,63 @@ oro, la mia povera ca, la mia povera ca! </p>
           <stage>
             <emph>Lucietta, e Titta Nane.</emph>
           </stage>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Vedeu, siora? Per causa vostra.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Mi? Coss'òggio fatto? Per causa mia?</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Perché no gh'avè giudicio; perché sè una frasca.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Va' in malora, strambazzo.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Anderò via bandìo, ti sarà contenta.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Bandìo ti anderà? Viè qua. Per cossa bandìo?</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Ma se ho d'andare, se m'ha da bandire; Marmottina
 lo vòi mazzare.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Xèstu matto?</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>E ti, e ti, ti me l'ha da pagare </p>
             <stage>(<emph>a Lucietta minacciandola</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Mi? Che colpa ghe n'òggio?</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Vàrdete da un desperao, vàrdete.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Oe, oe, vien el comandadore.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Poveretto mi! Presto, che no i me vede, che no i me
 fazze chiapare </p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Can, sassin, el va via, el me manazza. Xèlo
 questo el ben, che el me vuole? Mo, che omeni! Mo, che
@@ -3763,65 +3812,65 @@ andar a negare </p>
           <stage>
             <emph> Il Comandadore di casa ecc. e paron Fortunato.</emph>
           </stage>
-          <sp>
+          <sp who="#comandador">
             <speaker>COMANDADOR</speaker>
             <p>Mo, caro paron Fortunato, sè omo, savè cossa che
 xè ste cosse.</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Mi a suso no e so mai stao, a suso. Cancelaìa
 mai stao mi cancelaìa.</p>
           </sp>
-          <sp>
+          <sp who="#comandador">
             <speaker>COMANDADOR</speaker>
             <p>No ghe sè mai stà in cancelaria?</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Sió no, sió no, so mai stao.</p>
           </sp>
-          <sp>
+          <sp who="#comandador">
             <speaker>COMANDADOR</speaker>
             <p>Un'altra volta no dirè più cussì.</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>E pe cossa gh'ha a andà mia muggiere?</p>
           </sp>
-          <sp>
+          <sp who="#comandador">
             <speaker>COMANDADOR</speaker>
             <p>Per esaminarse.</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Le cugnae anca?</p>
           </sp>
-          <sp>
+          <sp who="#comandador">
             <speaker>COMANDADOR</speaker>
             <p>Anca ele.</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Anca e putte a andare? E putte, anca e putte?</p>
           </sp>
-          <sp>
+          <sp who="#comandador">
             <speaker>COMANDADOR</speaker>
             <p>No vàle co so sorella maridada? Cossa gh'àle
 paura?</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>E pianse, e ha paura, no le vuò andare.</p>
           </sp>
-          <sp>
+          <sp who="#comandador">
             <speaker>COMANDADOR</speaker>
             <p>Se no le gh'anderà, sarà pezo per ele. Mi ho
 fatto el mio debito. Farò la riferta, che sè citai, e
 pensèghe vu </p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Bisogna andare, bisogna; bisogna andare,
 muggiere. Muggiere, méttite el ninzoetto, muggiere. Cugnà
@@ -3841,41 +3890,41 @@ ve vegnio a petubare </p>
           <stage>
             <emph>Isidoro, e paron Vicenzo.</emph>
           </stage>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>La vede, lustrissimo, la xè una cossa da gnente.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Mi no ve digo, che la sia una gran cossa. Ma ghe
 xè l'<emph>indolenza</emph> ghe xè la nomina dei testimoni; xè <emph>incoà</emph>
 el processo: la Giustizia ha d'aver el so logo.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Crédela mo, lustrissimo: che colù, che xè vegnù a
 querelare, sia innocente? L'ha tratto anca elo dele pierae.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Tanto meggio. Co la formazion del processo
 rileveremo la verità.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>La diga, lustrissimo: no la se poderave giustare?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Ve dirò: se ghe fusse la pase de chi xè offeso,
 salve le spese del processo, la se poderave giustar.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Via, lustrissimo; la me cognosse, so qua mi, la
 me varda mi.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Ve dirò, paron Vicenzo. V'ho dito, che la se
 poderave giustar; perché fin adesso dal costituto
@@ -3893,39 +3942,39 @@ no me ne vien, e no ghe ne voggio. Son galantomo, me
 interesso volentiera per tutti; se poderò farve del ben, ve
 farò del ben.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Ela parla da quel signor, che la xè; e mi so
 quel, che averò da fare.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Per mi, ve digo, no voggio gnente.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Via, un pesse, un bel pesse.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Oh! fina un pesse, sì ben. Perché gh'ho la tola,
 ma anca a mi me piase far le mie regolette.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Eh! lo so, che sió cogitore el xè de bon gusto,
 sió cogitore.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Cossa voleu far? Se laora; bisogna anca
 devertirse.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>E ghe piase i ninzoletti a sió cogitore.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Orsù bisogna, che vada a spedir un omo. Stè qua.
 Se vien sta zente, disèghe, che adesso torno. Disèghe ale
@@ -3940,7 +3989,7 @@ marzapan </p>
           <stage>
             <emph>Vicenzo solo.</emph>
           </stage>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Sió sì, el xè un galantomo; ma in casa mia nol
 ghe bàzzega. Dale mie donne nol vien a far careghetta. Sti
@@ -3957,73 +4006,73 @@ gh'è nissun.</p>
             <emph>Pasqua, Lucietta, Orsetta, Checca, tutte in
 ninzoletto. Paron FORTUNATO, ed il suddeto.</emph>
           </stage>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Dove sémio?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Dove andémio?</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Oh poveretta mi! No ghe so mai vegnua in sto
 liogo.</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Parò Izenzo, sioria, parò Izenzo</p>
             <stage>(<emph>saluta paron Vicenzo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Paron Fortunato </p>
             <stage>(<emph>salutandolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Me trema le gambe, me trema.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>E mi? Oh che spasemo, che me sento!</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Doe xèlo e sió canceliere? </p>
             <stage>(<emph>a Vicenzo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Nol ghe xè; el xè a Venezia el sió canceliere. Ve
 vegnirà a esaminare el sió cogitore.</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>(Oe, el cogitore!) </p>
             <stage>(<emph>a Orsetta urtandola, facendo vedere, che lo conoscono molto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>(Oe, quel lustrissimo inspiritao) </p>
             <stage>(<emph>a Checca urtandola, e ridendo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>(Àstu sentìo? Ne esaminerà el cogitore) </p>
             <stage>(<emph>a  Lucietta con piacere</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Oh! gh'ho da caro. Almanco lo cognossemo)</p>
             <stage>(<emph>a Pasqua</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>(Sì, el xè bonazzo) </p>
             <stage>(<emph>a Lucietta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(V'arecordeu, che l'ha comprà da nu sie brazza
 de merlo da trenta soldi, e el ne l'ha pagà tre lire?) </p>
@@ -4035,78 +4084,78 @@ de merlo da trenta soldi, e el ne l'ha pagà tre lire?) </p>
           <stage>
             <emph>Isidoro, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Cossa feu qua?</p>
           </sp>
-          <sp>
+          <sp who="#tutte_le_donne">
             <speaker>TUTTE LE DONNE</speaker>
             <p>Lustrissimo, lustrissimo.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Cossa voleu? Che ve esamina tutti in t'una volta?
 Andè in sala, aspettè; ve chiamerò una alla volta.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Prima nu.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Prima nu.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Semo vegnue prima nu.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Mi no fazzo torto a nissun: ve chiamerò per
 ordene, come che troverò i nomi scritti in processo. Checca
 xè la prima. Che Checca resta, e vualtre andè fora.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Mo za, seguro, la xè zovenetta </p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>No basta miga. Bisogna esser fortunae </p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>(Gran donne! Le vol dir certo. Le vol dir, se le
 credesse de dir la verità).</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Andemo fuoa, andemo fuoa andemo </p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Oe, sió cogitore: no la ne fazza star qua tre
 ore, che gh'avemo da fare, gh'avemo </p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Sì, sì ve destrigherò presto.</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Oe, ghe la raccomando, sàlo? El varda ben, che la
 xè una povera innocente </p>
             <stage>(<emph>a Isidoro</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>In sti loghi no ghe xè pericolo de ste cosse.</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>(El xè tanto ingalbanìo, che me fido puoco) </p>
             <stage>(<emph>parte</emph>).</stage>
@@ -4117,71 +4166,71 @@ xè una povera innocente </p>
           <stage>
             <emph>Isidoro, e Checca, poi il Comandadore.</emph>
           </stage>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Vegnì qua, fia, sentève qua </p>
             <stage>(<emph>siede</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Eh! sior no, stago ben in piè.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Sentève, no ve voggio véder in piè.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Quel, che la comanda </p>
             <stage>(<emph>siede</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Cossa gh'aveu nome?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>G'ho nome Checca.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>El cognome?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Schiantina.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Gh'aveu nissun soranome?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Oh giusto soranome!</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>No i ve dise Puinetta?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Oh! certo, anca elo me vuol minchionare </p>
             <stage>(<emph>s'ingrugna</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Via se sè bella, siè anca bona. Respondème: Saveu
 per cossa che siè chiamada qua a esaminarve?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Sior sì, per una baruffa.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Contème come, che la xè stada.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Mi no so gnente, che mi no ghe giera. Andava a ca
 co mia sorella Libera, e co mia sorella Orsetta, e co mio
@@ -4189,208 +4238,208 @@ cugnà Fortunato; e ghe giera paron Toni, e Beppe Cospettoni,
 e Titta Nane, che i ghe voleva dare a Toffolo Marmottina, e
 elo ghe trava delle pierae.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Per cossa mo ghe voléveli dar a Toffolo
 Marmottina?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Perché Titta Nane fa l'amore co Lucietta
 Panchiana, e Marmottina ghe xè andao a parlare, e el gh'ha
 pagao la zucca barucca.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Ben; ho capio, basta cussì. Quanti anni gh'aveu?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>El vuol saver anca i anni?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Siora sì; tutti chi se esamina, ha da dir i so
 anni; e in fondo dell'esame se scrive i anni. E cussì quanti
 ghe n'aveu?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Oh! mi no me li scondo i mi anni. Disisette
 fenii.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Zurè d'aver dito la verità.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>De cossa?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Zurè, che tutto quel, che avè dito nel vostro
 esame, xè la verità!</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Sior sì, zuro, che ho dito la verità.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>El vostro esame xè finio.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Posso andar via donca.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>No, fermève un pochetto. Come steu de morosi?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Oh! mi no ghe n'ho morosi.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>No disè busie.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Òggio da zurare?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>No, adesso no avè più da zurar; ma le busie no
 sta ben a dirle. Quanti morosi gh'aveu?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Oh mi! nissun me vuol, perché son poveretta.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Voleu, che ve fazza aver una dota?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Magari!</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Se gh'avessi la dota, ve marideressi?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Mi sì, lustrissimo, che me marideria.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Gh'aveu nissun per le man?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Chi vorlo, che gh'abbia?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Gh'aveu nissun, che ve vaga a genio?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>El me fa vergognare.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>No ve vergognè, semo soli; parlème con libertà.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Titta Nane, se lo podesse avere, mi lo chiorave.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>No xèlo el moroso de Lucietta?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>El la gh'ha licenzià.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Se el l'ha licenziada, podemo véder, se el ve
 volesse.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>De quanto sarala la dota?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>De cinquanta ducati.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Oh sior sì! Cento me ne dà mio cugnà. Altri
 cinquanta me ne ho messi da banda col mio balon. Mi credo,
 che Lucietta no ghe ne daghe tanti.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Voleu, che ghe fazza parlar a Titta Nane?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Magari, lustrissimo!</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Dove xèlo?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>El xè retirà.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Dove?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Ghel dirò in t'una recchia, che no voria, che
 qualcun me sentisse </p>
             <stage>(<emph>gli parla nell'orecchia</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Ho inteso. Lo manderò a chiamar. Ghe parlerò mi,
 e lassè far a mi. Andè, putta, andè, che no i diga, se me
 capì </p>
             <stage>(<emph>suona il campanello</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Uh! caro lustrissimo benedetto.</p>
           </sp>
-          <sp>
+          <sp who="#comandador">
             <speaker>COMANDADOR</speaker>
             <p>La comandi.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Che vegna Orsetta.</p>
           </sp>
-          <sp>
+          <sp who="#comandador">
             <speaker>COMANDADOR</speaker>
             <p>Subito </p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Ve saverò dir. Ve vegnirò a trovar.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Lustrissimo sì </p>
             <stage>(<emph>s'alza</emph>).</stage>
@@ -4403,314 +4452,314 @@ Lucietta! Magari!</p>
           <stage>
             <emph>Orsetta, e detti, poi il Comandadore.</emph>
           </stage>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>(Tanto ti xè stada? Cossa t'àlo esaminà?)</p>
             <stage>(<emph>piano a Checca</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>(Oh sorela! Che bel esame, che ho fatto! Te
 conterò tutto) </p>
             <stage>(<emph>a Orsetta e parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Vegnì qua, sentève.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Sior sì </p>
             <stage>(<emph>siede con franchezza</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>(Oh, la xè più franca custìa!) Cossa gh'aveu
 nome?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Orsetta Schiantina.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Detta?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Coss'è sto detta?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Gh'aveu soranome?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Che soranome vorlo, che gh'abbia?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>No ve dìseli de soranome Meggiotto?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>In veritae, lustrissimo, che se no fusse dove che
 son, ghe vorave pettenare quella perucca.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Oe parlè con rispetto.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Cossa xè sto Meggiotto? I meggiotti a Chiozza xè
 fatti col semolei e colla farina zala; e mi no son né zala
 né del color dei meggiotti.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Via no ve scaldè, patrona, che questo no xè logo
 da far ste scene. Respondème a mi. Saveu la causa, per la
 qual sè vegnua a esaminarve?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Sior no.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Ve lo podeu immaginar?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Sior no.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Saveu gnente de una certa baruffa?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>So, e no so.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Via, contème quel, che savè.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Che el me interoga, che responderò.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>(Custìa xè de quele, che fa deventar matti i
 poveri cogitori). Conosseu Toffolo Zavatta?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Sior no.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Toffolo Marmottina?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Sior sì.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Saveu, che nissun ghe volesse dar?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Mi no posso saver, che intenzion che gh'abbia la
 zente.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>(Oh che dretta!) Aveu visto nissun con de le arme
 contro de elo?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Sior sì.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Chi gièrili?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>No m'arecordo.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Se i nominerò, ve i arecordereu?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Se la i nominerà, ghe responderò.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>(Siestu maladetta! La me vuol far star qua fin
 sta sera) Ghe giera Titta Nane Moletto?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Sior sì.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Ghe giera paron Toni Canestro?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Sior sì.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Ghe giera Beppo Cospettoni?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Sior sì.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Brava, siora Meggiotto.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>El diga: gh'àlo nissun soranome elo?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Via via manco chiaccole </p>
             <stage>(<emph>scrivendo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>(Oh! ghe lo metterò mi: el sior cogitore
 giazzao).</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Toffolo Marmottina àlo tratto de le pierae?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Sior sì, el ghe n'ha tratto (Magari in te la
 testa del cogitore).</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Cossa diseu?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Gnente, parlo da mia posta. No posso gnanca
 parlare?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Per cossa xè nato sta contesa?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Cossa vorlo, che sappia?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>(Oh son debotto stuffo!) Saveu gnente, che Titta
 Nane gh'avesse zelusia de Toffolo Marmottina?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Sior sì; per Lucietta Panchiana.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Saveu gnente, che Titta Nane abbia licenzià
 Lucietta Panchiana?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Sior sì, ho sentìo a dir, che el la gh'ha
 licenzià.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>(Checca ha dito la verità. Vederò de farghe sto
 ben). Oh! via, debotto sè destrigada. Quanti anni gh'aveu?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Oh ca de dia! Anca i anni el vuol savere?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Siora sì, anca i anni.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>El li ha da scrivere?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>I ho da scriver.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Ben; che el scriva... disnove.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <stage>(<emph>scrive</emph>).</stage>
             <p>Zurè d'aver dito la verità.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Ho da zurare?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Zurè d'aver dito la verità.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Ghe dirò: co ho da zurare, veramente ghe n'ho
 venti quattro.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Mi no ve digo, che zurè di anni, che a vualtre
 donne sto zuramento nol se pol dar. Ve digo che zurè, che
 quel, che avè dito in te l'esame, xè la verità.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Oh sior sì, zuro.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <stage>(<emph>suona il campanello</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#comandador">
             <speaker>COMANDADOR</speaker>
             <p>Chi vorla?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Donna Libera.</p>
           </sp>
-          <sp>
+          <sp who="#comandador">
             <speaker>COMANDADOR</speaker>
             <p>La servo </p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>(Varè. Anca i anni se gh'ha da dire!) </p>
             <stage>(<emph>s'alza</emph>).</stage>
@@ -4721,131 +4770,131 @@ quel, che avè dito in te l'esame, xè la verità.</p>
           <stage>
             <emph>Donna Libera, e detti, poi il Comandadore.</emph>
           </stage>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>(T'àstu destrigà?) </p>
             <stage>(<emph>ad Orsetta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>(Oe, sentì. Anca i anni, che se gh'ha, el vuol
 savere).</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>(Bùrlistu?).</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>(E bisogna zurare) </p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>(Varè che sùghi! s'ha da dire i so anni, e s'ha da
 zurare? So ben quel, che farò mi. Oh! i mi anni no li voggio
 dire, e no voggio zurare).</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>O via, vegnì qua, sentève.</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <stage>(<emph>non risponde</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Oe, digo, vegnì qua, sentève </p>
             <stage>(<emph>facendole cenno, che si sieda</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <stage>(<emph>va a sedere</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Chi seu?</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <stage>(<emph>non risponde</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Respondè, chi seu? </p>
             <stage>(<emph>urtandola</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Sior.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Chi seu?</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Cossa dìsela?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Seu sorda? </p>
             <stage>(<emph>forte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Ghe sento puoco.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>(Stago fresco!) Cossa gh'aveu nome?</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Piase?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>El vostro nome.</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>La diga un poco più forte.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Eh! che no voggio deventar matto </p>
             <stage>(<emph>suona il campanello</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#comandador">
             <speaker>COMANDADOR</speaker>
             <p>La comandi.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Che vegna drento quell'omo.</p>
           </sp>
-          <sp>
+          <sp who="#comandador">
             <speaker>COMANDADOR</speaker>
             <p>Subito </p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Andè a bon viazo </p>
             <stage>(<emph>a Libera</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Sior?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Andè via de qua </p>
             <stage>(<emph>spingendola, perchè se ne vada</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>(Oh! l'ho scapolada pulito. I fatti mì, no ghe li
 voggio dire) </p>
@@ -4857,66 +4906,66 @@ voggio dire) </p>
           <stage>
             <emph>Isidoro, poi paron Fortunato, poi il Comandadore.</emph>
           </stage>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Sto mistier xè bello, civil, decoroso, anca
 utile. Ma delle volte xè cosse da deventar matti.</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Tissimo sió cogitore, tissimo.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Chi seu?</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Fortunato Aichio.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Parlè schietto, se volè che v'intenda. Capisso
 per discrezione: paron Fortunato Cavicchio. Saveu per cossa,
 che siè cità a esaminarve?</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Sió sì, sió.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Via donca: disè per cossa, che sè vegnù?</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>So egnù, peché me ha dito e comandadore.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Bella da galantomo! So anca mi, che sè vegnù,
 perché ve l'ha dito el comandador. Saveu gnente de una certa
 baruffa?</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Sió sì, sió.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Via, disème, come che la xè stada.</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>L'ha a saere, che ancuò so egnù da mare, e so
 rivao a Igo co a tatana; e xè egnuo mia muggiere, e a cugnà
 Ossetta, e a cugnà Checca.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Se no parlè più schietto, mi no ve capisso.</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Sió sì, sió. Andando a ca co mia muggiere, e co
 mia cugnà, ho isto paró Toni, ho isto, e bara Beppe ho isto,
@@ -4926,73 +4975,73 @@ Maottina <emph>tuffe, tuffe</emph> pierae. È egnuo Titta Nane, è egnuo
 Titta Nane. <emph>Lago, lago</emph> co paosso, <emph>lago</emph>. Tia, mola,
 baacca. Maottina è caccao, e mi no so atro. M'àla capio?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Gnanca una parola.</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Mi pao chiozzotto, utissimo. De che paese xèla,
 utissimo?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Mi son venezian; ma no ve capisso una maledetta.</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Omàndela e tona a die?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Cossa?</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Comàndela e tona a dire? a dire? a dire?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Va' in malora, va' in malora, va' in malora.</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Tissimo </p>
             <stage>(<emph>partendo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Papagà maledetto!</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Tissimo </p>
             <stage>(<emph>allontanandosi</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Se el fusse un processo de premura poveretto mi!</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Sió cogitore! Tissimo </p>
             <stage>(<emph>sulla porta, e parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>El diavolo, che te porta! </p>
             <stage>(<emph>suona il campanello</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#comandador">
             <speaker>COMANDADOR</speaker>
             <p>Son a servirla.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Licenziè quelle donne, mandèle via, che le vaga
 via, che no vòi sentir altro.</p>
           </sp>
-          <sp>
+          <sp who="#comandador">
             <speaker>COMANDADOR</speaker>
             <p>Subito </p>
             <stage>(<emph>parte</emph>).</stage>
@@ -5003,126 +5052,126 @@ via, che no vòi sentir altro.</p>
           <stage>
             <emph>Isidoro, poi Pasqua, e Lucietta, poi il Comandadore.</emph>
           </stage>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Bisogna dar in impazienze per forza.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Per cossa ne màndelo via? </p>
             <stage>(<emph>con calore</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Per cossa no ne vorlo esaminare?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Perché son stuffo.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Sì, sì, caretto, savemo tutto.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>L'ha sentìo quele, che g'ha premesto, e nualtre
 semo scoazze.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>La fenìmio?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Puinetta el l'ha tegnua più d'un'ora.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>E Meggiotto quanto ghe xèla stada?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Ma nu anderemo da chi s'ha d'andare.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>E se faremo fare giustizia.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>No savè gnente. Sentì.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Cossa voravelo dire?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Cossa ne voravelo infenocchiare?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Vualtre sè parte interessada; no podè servir per
 testimonio.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>No xè vero gnente, no xè vero gnente. No semo
 interessà, no xè vero gnente.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>E anca nu volemo testimoniare.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Fenìla, una volta.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>E se faremo sentire.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>E saveremo parlare.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Sieu maledette.</p>
           </sp>
-          <sp>
+          <sp who="#comandador">
             <speaker>COMANDADOR</speaker>
             <p>Lustrissimo.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Cossa gh'è?</p>
           </sp>
-          <sp>
+          <sp who="#comandador">
             <speaker>COMANDADOR</speaker>
             <p>Xè vegnù el lustrissimo sior cancelier.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Oh! giusto elo.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Anderemo da elo.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Andè, dove diavolo che volè. Bestie, diavoli,
 satanassi </p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Mare de diana! che ghe la faremo tegnire </p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Viva cocchietto, che ghe la faremo portare </p>
             <stage>(<emph>parte</emph>).</stage>
@@ -5137,7 +5186,7 @@ satanassi </p>
           <stage>
             <emph>Beppo solo.</emph>
           </stage>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>No m'importa; che i me chiappe, se i me vo'
 chiapare. Anderò in preson; no m'importa gnente; ma mi
@@ -5158,180 +5207,180 @@ che te voggio giustare.</p>
             <emph>Libera, Orsetta, e Checca col ninzoletto sulle spalle,
 e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Beppe! </p>
             <stage>(<emph>amorosamente</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>El mio caro Beppe!</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>In malora, va'.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Con chi la gh'àstu?</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>A chi in malora?</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>In malora quante che sè.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Vaghe ti in malórzega </p>
             <stage>(<emph>a Beppo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Tasi </p>
             <stage>(<emph>a Checca</emph>).</stage>
             <p>Cossa t'avémio fatto?</p>
             <stage>(<emph>a Beppo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Ti sarà contenta, anderò in preson; ma avanti, ch'a
 ghe vaghe...</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>No, no t'indubitare. No sarà gnente.</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Paron Vicenzo l'ha dito cussì, ch'a no se stemo a
 travaggiare, che la cossa sarà giustà.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>E po gh'avemo per nu el cogitore.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Se può savere con chi ti la gh'ha almanco?</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Con ti la gh'ho.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Co mi?</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Sì, con ti.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Cossa t'òggio fatto?</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Cossa te vastu a impazzare co Marmottina? Perché
 ghe pàrlistu? Per cossa te vienlo a cattare?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Mi?</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Ti.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Chi te l'ha dito?</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Mia cugnà e mia sorella me l'ha dito.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Busiare!</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Busiare!</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Oh che busiare!</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>El xè vegnù a parlare con Checca.</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>E po el se xè andao a sentare da to sorella.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>E el gh'ha pagao la zucca.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Basta dire, che Titta Nane ha licenziao Lucietta.</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>L'ha licenzià mia sorella? Per cossa?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Per amore de Marmottina.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>E mi cossa gh'òggio da intrare?</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Marmottina no xè vegnù a parlare co ti?</p>
             <stage>(<emph>a Orsetta</emph>).</stage>
             <p>L'ha parlao co Lucietta? E Titta Nane l'ha licenzià?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Sì, can, no ti me credi, baron? No ti credi alla
 to povera Orsetta, che te vol tanto ben; che ho fatto tanti
 pianti per ti; che me desconisso per causa toa?</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Cossa donca me vienle a dire quelle petazze?</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Per scaregarse ele le ne càrega nu.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Nu no ghe femo gnente, e ele le ne vuol male.</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Che le vegna a ca, che le vegna! </p>
             <stage>(<emph>in aria minacciosa</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Zitto, che le xè qua.</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Tasè.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>No ghe disè gnente.</p>
           </sp>
@@ -5341,131 +5390,131 @@ pianti per ti; che me desconisso per causa toa?</p>
           <stage>
             <emph>Pasqua, e Lucietta col ninzoletto sulle spalle, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Coss'è? </p>
             <stage>(<emph>a Beppo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Cossa fastu qua? </p>
             <stage>(<emph>a Beppo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Cossa me seu vegnue a dire? </p>
             <stage>(<emph>con isdegno</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Senti.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Viè qua, senti.</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Cossa v'andeu a inventare?...</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Mo viè qua, presto </p>
             <stage>(<emph>con affanno</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Presto, poveretto ti!</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Coss'è? Cossa gh'è da niovo? </p>
             <stage>(<emph>si accosta, e lo prendono in mezzo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Va'via.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Vatte a retirare </p>
             <stage>(<emph>intanto le altre tredonne si cavano i ninzoletti</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Mo se le m'ha dito, che non xè gnente.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>No te fidare.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Le te vol sassinare.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Semo stae a Palazzo, e nu no i n'ha gnanca
 volesto ascoltare.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Ele i le gh'ha riceveste, e nualtre i n'ha cazzao
 via</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>E Orsetta xè stada drento più de un'ora col
 cogitore.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Ti xè processà!</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Ti xè in cattura.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Vatte a retirare.</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Comuodo? a sta via se sassina i omeni? </p>
             <stage>(<emph>a Orsetta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Coss'è stà?</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Tegnirme qua per farme precipitare?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Chi l'ha dito?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>L'ho dito mi, l'ho dito.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Eh savemo tutto, savemo.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Va' via </p>
             <stage>(<emph>a Beppo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Va' via </p>
             <stage>(<emph>a Beppo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Vago, via... ma me l'averè da pagare </p>
             <stage>(<emph>a Orsetta</emph>).</stage>
@@ -5476,46 +5525,46 @@ cogitore.</p>
           <stage>
             <emph>Paron Toni, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Marìo!</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Fradello!</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Andè via.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>No ve lassè trovare.</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Tasè, tasè, non abbiè paura, tasè. Xè vegnuo a
 trovarme paron Vicenzo, e el m'ha dito, che l'ha parlà co
 sior canceliere, che tutto xè accomodao, che se può
 caminare.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Sentìu?</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Ve l'avémio dito?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Sémio nu le busiare?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Sémio nu, che ve vuol sassinare?</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Cossa v'insunieu? Cossa v'andeu a inventare?</p>
             <stage>(<emph>a Pasqua, e Lucietta</emph>).</stage>
@@ -5526,45 +5575,45 @@ caminare.</p>
           <stage>
             <emph>Paron Vicenzo, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Vèlo qua paron Vicenzo. No xè giustà tutto, paron
 Vicenzo?</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>No xè giustà gnente.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Come no xè giustà gnente?</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>No gh'è caso, che quel musso ustinà de Marmottina
 voggia dar la pase, e senza la pase no se puol giustare.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Oe, sentìu?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>No ve l'òggio dito?</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>No ghe credè gnente.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>No xè giustà gnente.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>No ve fidè a caminare.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Andève subito a retirare.</p>
           </sp>
@@ -5574,24 +5623,24 @@ voggia dar la pase, e senza la pase no se puol giustare.</p>
           <stage>
             <emph>Titta Nane, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Oh! Titta Nane, cossa feu qua?</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Fazzo quelo, che voggio, fazzo.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>(Oh! no la ghe xè gnancora passà).</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>No gh'avè paura dei zaffi? </p>
             <stage>(<emph>a Titta Nane</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>No gh'ho paura de gnente </p>
             <stage>(<emph>a Lucietta, con sdegno</emph>).</stage>
@@ -5599,7 +5648,7 @@ voggia dar la pase, e senza la pase no se puol giustare.</p>
 camine quanto che voggio, e che no staghe più a bacilare</p>
             <stage>(<emph>a paron Vicenzo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Parlè mo adesso, se gh'avè fià de parlare </p>
             <stage>(<emph>a Lucietta</emph>).</stage>
@@ -5611,27 +5660,27 @@ camine quanto che voggio, e che no staghe più a bacilare</p>
           <stage>
             <emph>Comandadore, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#comandador">
             <speaker>COMANDADOR</speaker>
             <p>Paron Toni Canestro, Beppo Cospettoni e Titta
 Nane Moletto, vegnì subito a Palazzo con mi da sior
 cancelier </p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Oh poveretta mi!</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Semo sassinai.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Che fondamento ghe xè in te le vostre parole?</p>
             <stage>(<emph>a Orsetta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>De cossa ve podeu fidare de quel panchiana del
 cogitore? </p>
@@ -5643,26 +5692,26 @@ cogitore? </p>
           <stage>
             <emph>Isidoro, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Uh!) </p>
             <stage>(<emph>vedendo Isidoro</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Chi è, che me favorisse?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Vèla là lustrissimo. Mi no so gnente </p>
             <stage>(<emph>accennando Lucietta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Cossa vorli da i nostri omeni? Cossa ghe vorli
 fare?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Gnente; che i vegna con mi, e che no i gh'abbia
 paura de gnente. Son galantomo. Me son impegnà de giustarla,
@@ -5671,30 +5720,30 @@ a cercar Marmottina, e fè de tutto de menarlo da mi; e se
 nol vol vegnir per amor, disèghe che lo farò vegnir mi per
 forza.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Sior sì, so qua, co se tratta de far del ben.
 Vago subito. Beppe, paron Toni, vegnì co mi, che v'ho da
 parlare.</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>So co vu, compare. Co so co vu, so seguro.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>(Oe! mi no me slontano dal cogitore).</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Orsetta, a revéderse.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Xèstu in còlera? </p>
             <stage>(<emph>a Beppo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Via, che cade? A monte, a monte. Se parleremo.</p>
             <stage>(<emph>parte con paron Toni, e paron Vicenzo</emph>).</stage>
@@ -5705,81 +5754,81 @@ parlare.</p>
           <stage>
             <emph>Isidoro, Checca, Pasqua, e Titta Nane.</emph>
           </stage>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>(La diga, lustrissimo?) </p>
             <stage>(<emph>a Isidoro piano</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>(Coss'è, fia?)</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>(Gh'àlo parlà?)</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>(Gh'ho parlà).</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>(Coss'àlo dito?)</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>(Per dirvela, nol m'ha dito né sì, né no. Ma me
 par, che i dusento ducati no ghe despiasa).</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>(Me raccomando).</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>(Lassè far a mi). Via andemo, Titta Nane.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>So qua con ela </p>
             <stage>(<emph>in atto di partire</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Gnanca, patron? Gnanca un strazzo de saludo?</p>
             <stage>(<emph>a Titta Nane</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Che creanza gh'aveu? </p>
             <stage>(<emph>a Titta Nane</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Patrone </p>
             <stage>(<emph>con disprezzo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Via, saludè Checchina </p>
             <stage>(<emph>a Titta Nane</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Bella putta, ve saludo </p>
             <stage>(<emph>con buona grazia. Lucietta smania</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Siorìa, Titta Nane.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>(Gh'ho gusto, che la magna l'agio Lucietta, gh'ho
 gusto; me voggio refare) </p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>(Anca questo per mi xè un divertimento) </p>
             <stage>(<emph>parte</emph>).</stage>
@@ -5790,159 +5839,159 @@ gusto; me voggio refare) </p>
           <stage>
             <emph>Lucietta, Orsetta, Checca, Pasqua, e Libera.</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Aveu sentìo cossa che el gh'ha dito? Bella
 putta el gh'ha dito).</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>(Mo via cossa vustu andar a pensare?)</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>E ela? Siorìa, Titta Nane, siorìa, Titta Nane</p>
             <stage>(<emph>caricandola forte, che sentano</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Coss'è, siora me burleu?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Dìghe, che la se varda ela.</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Che la gh'ha el so bel da vardare.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Mi? Oh de mi ghe xè puoco da dire; che cattive
 azion mi no ghe ne so fare.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Via, tasi, no te n'impazzare. No sastu, chi la xè?
 Tasi </p>
             <stage>(<emph>a Lucietta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Cossa sémio?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Cossa voressi dire? </p>
             <stage>(<emph>a Libera</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Via; chi ha più giudizio, el dopera </p>
             <stage>(<emph>a Orsetta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Oh la savia Sibilla! Le putte, che gh'ha
 giudizio, parona, le lassa star i novizzi, e no le va a
 robar i morosi.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>A vu cossa ve robémio?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Titta Nane xè mio novizzo.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Titta Nane v'ha licenzià.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>No xè vero gnente.</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Tutta la contrà l'ha sentìo.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Via, che sè una pettegola.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Tasè là donna stramba.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Sentì, che sbrenà!</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Sentì, che bella putta! </p>
             <stage>(<emph>con ironia e collera</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Meggio de to sorella.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>No ti xè gnanca degna de minzonarme.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Povera sporca!</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Come parlistu? </p>
             <stage>(<emph>s'avanzano in zuffa</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Voleu ziogare, che ve petuffo?</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Chi?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Mare de diana! che te sflazelo, vara.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Oh che giandussa!</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Parla ben, parla </p>
             <stage>(<emph>le dà sulla mano</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Oe! </p>
             <stage>(<emph>alza le mani per dare</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Tìrete in là, oe! </p>
             <stage>(<emph>spingendo Pasqua</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Coss'è sto spenze </p>
             <stage>(<emph>spingendo Libera</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Oe, oe! </p>
             <stage>(<emph>si mette a dare, e tutte due si danno gridando</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#tutte">
             <speaker>TUTTE</speaker>
             <p>Oe, oe!</p>
           </sp>
@@ -5952,39 +6001,39 @@ robar i morosi.</p>
           <stage>
             <emph>Paron Fortunato, e dette.</emph>
           </stage>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Fermève, fermève, donne, donne, fermève.</p>
             <stage>(<emph>Le donne seguono a darsi, gridando sempre. Fortunato in mezzo, finché gli riesce di separarle, e caccia le sue in casa</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Ti gh'ha rason </p>
             <stage>(<emph>entra</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Ti me l'ha da pagare </p>
             <stage>(<emph>entra</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Ve vòi cavare la petta, vara.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Maledetta! Se no me fava male a sto brazzo, te
 voleva collegare per terra </p>
             <stage>(<emph>entra</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>E vu, savè, sior carogno, se no ghe farè far
 giudizio a culìe, ve trarò sulla testa un de quei pitteri
 che spuzza </p>
             <stage>(<emph>entra</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Andè là, puh! Maledìe! Donne, donne, sempre
 bauffe, sempre chià. Dise be e proverbio: Donna danno; donna
@@ -5998,7 +6047,7 @@ malanno, malanno, danno, malanno </p>
           <stage>
             <emph>Isidoro, e Titta Nane.</emph>
           </stage>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Vegnì con mi, non abbiè suggizion: qua no semo a
 Palazzo, qua no semo in cancelaria. Semo in casa de un
@@ -6008,19 +6057,19 @@ adesso de sta casa son paron mi, e qua s'ha da far sta pase,
 e s'ha da giustar tutti i pettegolezzi, perché mi son amigo
 di amici, e a vualtri Chiozzotti ve voggio ben.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Per so grazia, sió cogitore.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Vegnì qua, za che semo soli...</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Dove xèli sti altri?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Paron Vicenzo xè andà a cercar Marmottina, e el
 vegnirà qua, che za el sa dove, che l'ha da vegnir. Paron
@@ -6029,30 +6078,30 @@ servitor, perché vòi che sigilemo sta pase con un per de
 fiaschetti. E Beppo, co v'ho da dir la verità, el xè andà a
 chiamar donna Libera, e paron Fortunato.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>E se Marmottina no volesse vegnire?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Se nol vorrà vegnir, lo farò portar. Orsù za che
 semo soli, respondème a ton sul proposito, che v'ho parlà.
 Checchina ve piàsela? La voleu?</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Co gh'ho da dire la giusta veritae, la me piase
 puoco, e fazzo conto de no la volere.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Come! No m'avè miga dito cussì stamattina.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Cossa gh'òggio dito?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>M'avè dito: no so, son mezzo impegnà. M'avè
 domandà, cossa che la gh'ha de dota. Mi v'ho anca dito, che
@@ -6060,7 +6109,7 @@ la gh'aveva dusento, e passa ducati. M'ha parso, che la dota
 ve comoda; m'ha parso, che la putta ve piasa. Cossa me
 scambieu adesso le carte in man?</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Lustrissimo, mi no ghe scambio gnente, lustrissimo.
 L'abbia da saere, che a Lucietta, lustrissimo, xè do anni,
@@ -6074,93 +6123,93 @@ mare de diana! lustrissimo, no la posso lassare; e ghe
 voggio ben, ghe voggio. La m'ha affrontao, la gh'ho
 licenzià; ma me schioppa el cuor.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Oh bela da galantomo! E mi ho mandà a chiamar
 donna Libera, e paron Fortunato, per parlarghe de sto
 negozio, e domandarghe Checca per vu.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Grazie, lustrissimo </p>
             <stage>(<emph>con dispiacere</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>No la volè donca?</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Grazie alla so bontae </p>
             <stage>(<emph>come sopra</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Sì? o no?</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Co bo respetto: mi no, lustrissimo.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Andève a far squartar che no me n'importa.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Comuodo pàrlela lustrissimo? So poveromo, so un
 povero pescaore; ma so galantomo, lustrissimo.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Me despiase, perché gh'averave gusto de maridar
 quella putta.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Lustrissimo, la me compatissa, se no ghe fasse
 affronto, ghe vorave dire do parole, ghe vorave dire.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Disè pur: cossa me voressi dir?</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Caro lustrissimo, la prego, no la se n'abbia per
 male.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>No, no me n'averò per mal. (Son curioso de
 sentir, cossa che el gh'ha in testa de dirme).</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Mi parlo co tutto e respetto. Baso dove, che zappa
 e sió cogitore; ma se m'avesse da maridare, no voria, che un
 lustrissimo gh'avesse tanta premura per mia muggier.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Oh che caro Titta Nane! Ti me fa da rider, da
 galantomo. Per cossa credistu, che gh'abbia sta premura per
 quella putta?</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Che cade? Affin de ben, affin de ben, che cade?</p>
             <stage>(<emph>ironico</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Son un zovene onesto, e non son capace...</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Eh! via che cade?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>(Oh che galiotto!)</p>
           </sp>
@@ -6170,202 +6219,202 @@ quella putta?</p>
           <stage>
             <emph>Paron Vicenzo, e detti, poi Toffolo.</emph>
           </stage>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>So qua, lustrissimo. Finalmente l'ho persuaso a
 vegnire.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Dov'èlo?</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>El xè de fuora: che lo chiame?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Chiamèlo.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Toffolo, vegnì a nua.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>So qua, pare, Tissimo </p>
             <stage>(<emph>a Isidoro, salutandolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Vien avanti.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Lustrissimo sió cogitore </p>
             <stage>(<emph>salutandolo ancora</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Dime un poco, per cossa no vustu dar la pase a
 quei tre omeni, coi quali ti ha avù stamattina quela
 contesa?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Perché, lustrissimo, i me vuol amazzare.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Co i te domanda la pase, no i te vol mazzar.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>I xè galiotti, lustrissimo.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Olà, olà! </p>
             <stage>(<emph>a Toffolo minacciandolo, acciò parli con rispetto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Quietève. </p>
             <stage>(<emph>a Titta</emph>).</stage>
             <p>E ti parla ben, o te farò
 andar in t'un camerotto.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Quel che la comanda, lustrissimo.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Sastu, che per le pierae, che ti ha tratto, ti
 meriti anca ti d'esser processà, e che stante la malizia, co
 la qual ti xè vegnù a querelar, ti sarà condanà in te le
 spese?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Mi so pover omo, lustrissimo; mi no posso
 spendere. Vegnì qua, mazzème; so pover omo, mazzème.</p>
             <stage>(<emph>a Vicenzo e Titta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>(Costù el par semplice; ma el gh'ha un fondo de
 malizia de casa del diavolo).</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Daghe la pase, e la xè fenìa.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Voggio esser seguro della mia vita.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Ben, e mi te farò assicurar. Titta Nane, me deu
 parola a mi de no molestarlo?</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Mi sì, lustrissimo. Basta, che el lassa stare
 Lucietta, e che nol bàzzega per quele contrae.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Mi, fradelo, Lucietta no la gh'ho gnanca in
 mente, e no ziro colà per ela, no ziro.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Per chi ziristu donca?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Lustrissimo, anca mi so da maridare.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Mo via, di' suso, Chi gh'àstu da quele bande?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Lustrissimo...</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Orsetta?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Made.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Checca fursi?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Ah, ah! bravo lustrissimo, bravo </p>
             <stage>(<emph>ridendo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Ti xè un busiaro.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Per cossa busiaro?</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Perché Checca m'ha dito, e donna Libera, e Orsetta
 m'ha dito, che ti t'ha sentao da Lucietta, e ti gh'ha pagao
 da marenda.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Per fare despetto l'ho fatto.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>A chi?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Quietève. </p>
             <stage>(<emph>a Titta Nane</emph>).</stage>
             <p>Distu dasseno, che
 ti ghe vol ben a Checca?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Mi sì, da putto.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>La toréssistu per muggier?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Mare de diana, se la chiorave!</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>E ela mo te voràla?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Vara chiòe! Per cossa no m'averàvela da volere?
 La m'ha dito de le parole, la m'ha dito, che no le posso mo
 gnanca dire. So sorela m'ha descazzao, da resto... e co
 metto peota a Vigo, la poderò mantegnire.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>(Mo el sarave giusto a proposito per Checchina).</p>
           </sp>
@@ -6375,112 +6424,112 @@ metto peota a Vigo, la poderò mantegnire.</p>
           <stage>
             <emph>Paron Toni, un Servitore con fiaschi, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Xè qua el servitor, lustrissimo.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Bravo. Metti zoso quei fiaschi, e va' de là in
 cusina, e varda in quel armeretto, che gh'è dei gotti </p>
             <stage>(<emph>servitore parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>(Com'èla, paron Vicenzo?)</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>(Ben, ben! S'ha scoverto delle cosse... Anderà
 tutto ben).</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Toffolo, allegramente, che vòi, che femo sto
 matrimonio.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Magari, lustrissimo!</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Olà, Toffolo, con chi?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Con Checchina.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>E mio fradello Beppe sposerà Orsetta.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Bravi! E Titta Nane sposerà Lucietta.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Se la vegnirà co le bone, può essere, che mi la
 spose.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>A monte tutto. No gh'ha da esser puntigli. Avemo
 da far ste nozze, e vegnì qua tutti, e sposève qua.
 Provederò mi i confetti, e ceneremo, e faremo un festin, e
 staremo allegri.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Paró Toni, alliegri.</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Alliegri, paró Vicenzo.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Alliegri.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Via, Titta Nane, anca vu alliegri.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>So qua, so qua, no me cavo.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Via, fè pase.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Pase </p>
             <stage>(<emph>abbraccia Toni</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Pase </p>
             <stage>(<emph>abbraccia Toffolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Amigo </p>
             <stage>(<emph>abbraccia Titta Nane</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Amigo </p>
             <stage>(<emph>abbraccia Toffolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Paró Vicenzo </p>
             <stage>(<emph>abbraccia Vicenzo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Amici, amici.</p>
           </sp>
@@ -6490,30 +6539,30 @@ staremo allegri.</p>
           <stage>
             <emph>Beppo, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Amigo, pase, parente, amigo </p>
             <stage>(<emph>saluta, ed abbraccia Beppo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Férmete. Oh che strepiti! Oh che sussuri! Fradello,
 no ve posso fenir de dire.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Coss'è stà?</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Le ha criao, le s'ha dao, le s'ha petuffao </p>
             <stage>(<emph>parla delle donne</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Chi?</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Mia cugnà Pasqua, Lucietta, donna Libera, Checca,
 Orsetta. So andao per andare, come che m'ha dito e sió
@@ -6522,33 +6571,33 @@ Orsetta m'ha serrao el balcon in tel muso. Lucietta no vol
 più Titta Nane. Le cria, che le s'averze, e ho paura, che le
 se voggia tornar a dare.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Sangue de diana! Com'èla? Sangue de diana!</p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Voggio andar a defendere mia muggiere </p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Se daremo, se daremo, faremo custion, se daremo.</p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Fermève, fermève; no stè a precipitare </p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Che i lassa stare Checca, oe! che i la lassa
 stare </p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Sieu maledetti, sieu maledetti, sieu maledetti! </p>
             <stage>(<emph>parte</emph>).</stage>
@@ -6561,84 +6610,84 @@ stare </p>
             <emph>Lucietta, e Orsetta alle finestre delle loro case, donna
 PASQUA di dentro.</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Coss'è? No ti vol più mio fradello? No ti xè
 gnanca degna d'averlo.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Oh! ghe vuol puoco a trovare de meggio.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Chi troverastu?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Rulo.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Ghe mancherave puoco, che no te fasse la rima.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>No se sàlo, che ti xè una sboccà.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Sì, se fusse co fa ti.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Tasi sa, che son una putta da ben.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Se tale ti fussi, tale ti operaressi.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Via, sussurante.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Catta baruffe.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Lucietta vien drento, Lucietta </p>
             <stage>(<emph>di dentro chiamandola forte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Ti gh'anderà via ve' de sta contrà.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Chi?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Ti.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Lucietta! </p>
             <stage>(<emph>di dentro</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Chiò, vara </p>
             <stage>(<emph>si batte nel gomito</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Va' al turo </p>
             <stage>(<emph>si ritira</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Povera sporca! Con chi credistu aver da fare? Mi
 sì, che me mariderò; ma ti? No ti troverà nissun, che te
@@ -6646,96 +6695,96 @@ voggia. Uh! quel povero desgrazià, che te voleva, el stava
 fresco; el giera conzà co le ceolette. Nol te vol più, ve',
 Titta Nane, no, ve', nol te vol più, ve'.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <stage>(<emph>torna al balcone</emph>).</stage>
             <p>Mi no me n'importa;
 che anca se el me volesse, mi no lo voggio.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>La volpe no vol ceriese.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Sì, sì, el sposerà quella sporca de to sorella.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Oe! parla ben.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Lucietta </p>
             <stage>(<emph>di dentro</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>A mi, se ghe ne voggio, no me n'amanca.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Eh! lo so, che ti gh'ha el protettore.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Tasi, sa, che ti farò desdire.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Lucietta, Lucietta! </p>
             <stage>(<emph>di dentro</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Oh che paura! </p>
             <stage>(<emph>burlandosi di Lucietta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Te farò vegnire l'angossa.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Marameo, squaquarà, marameo.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Vago via, perché no me degno </p>
             <stage>(<emph>si ritira</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Va' via, va' via, no te far smattare </p>
             <stage>(<emph>si ritira</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Meggiotto </p>
             <stage>(<emph>torna, chiamandola col suo soprannome</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Panchiana </p>
             <stage>(<emph>torna, e fa lo stesso</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Tuffe </p>
             <stage>(<emph>si ritira</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Malagrazia </p>
             <stage>(<emph>si ritira</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <stage>(<emph>torna</emph>).</stage>
             <p>Mo che bella zoggia. </p>
             <stage>(<emph>con ironia e disprezzo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Mo, che boccoletto da riosa! </p>
             <stage>(<emph>torna, e lo dice con ironia, e disprezzo</emph>).</stage>
@@ -6746,67 +6795,67 @@ che anca se el me volesse, mi no lo voggio.</p>
           <stage>
             <emph>Titta Nane, poi Toni, e Beppo, e dette.</emph>
           </stage>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Coss'è? Cossa àstu dito dei fatti mii? </p>
             <stage>(<emph>a Lucietta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Va' in malora. Va' a parlare con Checca </p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>No ghe tendo, che la xè una matta </p>
             <stage>(<emph>a Titta Nane</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Che muodo xè questo de strapazzare? </p>
             <stage>(<emph>a Orsetta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Via, che sè tutta zente cattiva </p>
             <stage>(<emph>a Toni</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Orsetta, Orsetta!</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Vàtte a far squartare </p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>E ti no stare più a vegnire per casa, che no te
 voggio </p>
             <stage>(<emph>a Titta Nane</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>E no bazzegare qua oltra, che no te volemo </p>
             <stage>(<emph>a Titta Nane</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Giusto, mo, per questo, mo ghe voggio vegnire.</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Se a Marmottina ghe l'ho prometue a ti, mare de
 diana! te le darò, vara </p>
             <stage>(<emph>entra in casa</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Chiò sto canelao </p>
             <stage>(<emph>fa un atto di disprezzo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>In tartana da mi no ghe stare a vegnire. Provedite
 de paron, che mi me provederò de omo </p>
@@ -6819,92 +6868,92 @@ de paron, che mi me provederò de omo </p>
             <emph>Titta Nane, poi paron Vicenzo, poi Toffolo,
 poi Isidoro.</emph>
           </stage>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Corpo de una gaggiandra! qualchedun me l'ha da
 pagare.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Titta Nane, com'èla?</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Petto de diana! petto de diana! Arme, fora arme.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Va' via, matto. No star a precipitare.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Voggio farme piccare, ma avanti, sangue de diana,
 ghe ne voggio colegare tre, o quattro!</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>So qua. Come xèla?</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Arme, fora arme.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Mi no so gnente </p>
             <stage>(<emph>corre via, e s'incontra violentemente con Isidoro urtandosi, ed Isidoro dà una spinta a  Toffolo, e lo getta in terra</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Ah bestia!</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Aiuto.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Con chi la gh'àstu? </p>
             <stage>(<emph>a Toffolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>I me vol dare </p>
             <stage>(<emph>alzandosi</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Chi è, che te vuol dar?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Titta Nane.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>No xè vero gnente.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Va' via de qua subito </p>
             <stage>(<emph>a Titta Nane</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Nol la gh'ha co elo, lustrissimo; el la gh'ha co
 Beppo, e con paron Toni.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Va' via de qua, te digo </p>
             <stage>(<emph>a Titta Nane</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Via, andemo, cognè obbedire, cognè </p>
             <stage>(<emph>a Titta Nane</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>(Menèlo via, paron Vicenzo, e tegnilo con vu, e
 trattegnive sotto el portego in piazza, dal barbier, o dal
@@ -6912,28 +6961,28 @@ marzeretto, che se vorò, se ghe sarà bisogno, ve manderò po
 a chiamar) </p>
             <stage>(<emph>a Vicenzo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>(Sarà obedìa, lustrissimo). Andemo </p>
             <stage>(<emph>a Titta Nane</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>No voggio vegnire.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Andemo co mi, no te dubitare. So omo, so
 galantomo, viè co mi, no te dubitare.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Via, va' con elo; e fa' quel, che te dise paron
 Vicenzo, e abbi pasenzia, e aspetta, che pol esser, che ti
 sii contento, e che te fazza dar quanta sodisfazion, che ti
 vol.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Me raccomando a ela, lustrissimo. So poveromo, so
 galantomo, sió cogitore; me raccomando a ela, sió cogitore
@@ -6946,67 +6995,67 @@ lustrissimo </p>
           <stage>
             <emph>Isidoro, e Toffolo.</emph>
           </stage>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>(Mi so, cossa ghe voria per giustarli. Un pezzo
 de legno ghe voria. Ma averave perso el devertimento). Vien
 qua, Toffolo. </p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Lustrissimo.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Vustu, che parlemo a sta putta, e che vedemo, se
 se pol concluder sto maridozzo?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Magari, lustrissimo! Ma bisogna parlare co donna
 Libera so sorella, e co so cugnà paró Fortunato.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Sarali in casa sta zente?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>No so, lustrissimo. Adesso, se la vuò che
 chiame...</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Andemo drento piutosto.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Mi in ca no ghe posso vegnire.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Perché no ghe pustu vegnir?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>A Chiozza, lustrissimo, un putto donzelo nol ghe
 può andare, dove ghe xè de le putte da maridare.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>E pur so, che tra vualtri se fa continuamente
 l'amor. </p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>In stra lustrissimo, se fa l'amore; e po
 la se fa domandare, e co la s'ha domandà, se può andare.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Chiamémole in strada donca.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Olà, paró Fortunato ghe seu? Donna Libera, olà.</p>
           </sp>
@@ -7016,169 +7065,169 @@ la se fa domandare, e co la s'ha domandà, se può andare.</p>
           <stage>
             <emph>Donna Libera, e tutti, poi paron Fortunato.</emph>
           </stage>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>(Eh! co sta sorda no me ne voggio impazzar).</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Coss'è? Cossa vustu?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Qua e sió cogitore...</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Lustrissimo, cossa comàndelo?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Com'èla? No sè più sorda?</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Oh! lustrissimo, no. Gh'aveva una flussion. So
 varìa.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Cussì presto?</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Da un momento all'altro.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Anca sì, che gieri deventada sorda, per no dir...</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Tissimo </p>
             <stage>(<emph>a Isidoro</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Ho gusto, che sia qua anca compare burataora. Son
 qua per dirve, se marideressi Checchina.</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Magari, lustrissimo! Me la destrigheria
 volentiera.</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Mi, utissimo, gh'ho pomesso cento ucati.</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>E altri cinquanta ghe li averemo sunai.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>E mi ghe farò aver una grazia de altri cinquanta.</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Sìelo benedetto! Gh'àlo qualche partio?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Vardè: ve piàselo quel partio? </p>
             <stage>(<emph>accenna Toffolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Toffao? Toffao? Catta bauffe, catta bauffe.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Mi no dago impazzo a nissun, co i me lassa
 stare...</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Con un puo' de battelo, come l'àlo da mantegnire?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>No metteroggio suso peota, no metteroggio?</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>E dove la menerastu, se no ti gh'ha né tetto, né
 cà?</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>La ustu menare i battelo la novizza a dormire?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Ve podè tegnire i cento ducati, ve podè tegnire,
 e farme le spese a mi, e a mia muggiere.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Sì ben; nol dise mal, el gh'ha più giudizio, che
 no credeva. Podè per qualche tempo tegnirlo in casa.</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Mo per quanto, lustrissimo?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>A conto de sti cento ducati, per quanto
 voressistu, che i te fasse le spese?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>No so, almanco sié anni.</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Puffeta! puffeta! Sié anni? Puffeta!</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Ti voressi ben spender poco.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Che la fazza ela, lustrissimo.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Via, per un anno ve comoda? </p>
             <stage>(<emph>a Libera</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Cossa diseu, paron? </p>
             <stage>(<emph>a Fortunato</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Fè vu, parona; parona fè vu, parona </p>
             <stage>(<emph>a  Libera</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Mi stago a tutto, lustrissimo.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Chiamè la putta. Sentimo, cossa che la dise </p>
             <stage>(<emph>a  Libera</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Oe, Checca!</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Checca, Checca! </p>
             <stage>(<emph>chiama forte</emph>).</stage>
@@ -7189,100 +7238,100 @@ voressistu, che i te fasse le spese?</p>
           <stage>
             <emph>Checca, e detti, poi Lucietta.</emph>
           </stage>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>So qua: cossa voleu?</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>No ti sa?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Eh! ho sentìo tutto.</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Bava! E tà a pionare, bava!</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>E cussì, cossa diseu? </p>
             <stage>(<emph>a Checca</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>La senta una parola </p>
             <stage>(<emph>a Isidoro</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Son qua.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>(De Titta Nane no ghe xè speranza?) </p>
             <stage>(<emph>a Isidoro</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>(El m'ha dito un de no tanto fatto) </p>
             <stage>(<emph>a Checca</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>(Anca in recchia el ghe parla?) </p>
             <stage>(<emph>con sdegno</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>(Mo per cossa?) </p>
             <stage>(<emph>a Isidoro</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>(Perché el xè innamorà de Lucietta) </p>
             <stage>(<emph>a Checca</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Lustrissimo sió cogitore.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Cossa gh'è?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Vorave sentire anca mi, vorave.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Via, destrighève. Lo voleu, o no lo voleu? </p>
             <stage>(<emph>a Checca</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Cossa diseu, sorella? </p>
             <stage>(<emph>a Libera</emph>).</stage>
             <p>Cossa diseu, cugnà? </p>
             <stage>(<emph>a Fortunato</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Cossa distu ti? Lo vustu? </p>
             <stage>(<emph>a Checca</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Perché no?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Oh cara, la me vuole, oh cara! </p>
             <stage>(<emph>giubilando</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Fioli, co gh'intro mi in te le cosse, mi no
 voggio brui longhi. Destrighémose, e maridève.</p>
@@ -7293,104 +7342,104 @@ voggio brui longhi. Destrighémose, e maridève.</p>
           <stage>
             <emph>Orsetta, e detti, poi Beppo.</emph>
           </stage>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Comuodo? Checca s'ha da maridare avanti de mi? Mi
 che xè tre anni, che so in donzelon, no m'averò gnancora da
 maridare; e custìa, che xè la minore, s'ha da sposare avanti
 della maggiore?</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Sì bè, sì bè, a gh'ha rason, sì bè.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Gh'àstu invidia? Marìdete. Chi te tien, che no ti
 te maridi?</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Sió sì, sió sì, marìdete, se ti te vuò
 maridare.</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Ti lo gh'avevi el novizzo. Per cossa lo xèstu andà
 a desgustare? </p>
             <stage>(<emph>a Orsetta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Ah! per cossa? </p>
             <stage>(<emph>a Orsetta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>No gièrelo Beppo el so novizzo? </p>
             <stage>(<emph>a Libera</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Sior sì, Beppo.</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Beppo.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Aspettè. Beppo ghe xèlo in casa? </p>
             <stage>(<emph>alla sua casa</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>So qua, lustrissimo.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Per cossa seu andà in còlera con Orsetta?</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Mi, lustrissimo? L'è stada ela, che m'ha
 strapazzao; l'è stada ela, che m'ha descazzao.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Sentìu, siora?</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>No sàla, che la còlera orba che no se sa de le
 volte quel, che se diga!</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Sentìu? No la xè più in còlera </p>
             <stage>(<emph>a Beppo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Anca mi son uno, che presto me la lasso passare.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Via donca; la xè giustada. Se no volè, che Checca
 se marida prima de vu, e vu dèghe la man a Beppo avanti de
 ela </p>
             <stage>(<emph>a Orsetta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Cossa diseu, sorella? </p>
             <stage>(<emph>a Libera</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>A mi ti me domandi?</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Fala bela, Orsetta. Fala bela, fala bela </p>
             <stage>(<emph> eccita con allegria Orsetta a maritarsi</emph>).</stage>
@@ -7401,106 +7450,106 @@ ela </p>
           <stage>
             <emph>Lucietta, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Come, puoco de bon! Sior omo senza reputazion,
 averessi tanto ardire de sposare culìa, che n'ha strapazzà </p>
             <stage>(<emph>a Beppo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>(Meggio da galantomo!)</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Cossa xè sta culìa? </p>
             <stage>(<emph>a Lucietta, con collera</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Oe, no se femo in vissere.</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Olà, olà, olà.</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Mi no so cossa dire, mi no so cossa fare; mi me vòi
 maridare.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Mi prima m'ho da maridare; e fin che ghe so mi
 in ca, altre cugnà no ghe n'ha da vegnire.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Mo perché no la marideu? </p>
             <stage>(<emph>a Beppo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Perché Titta Nane la gh'ha licenzià.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Va' là, Toffolo; va' in piazza sotto el portego
 dal barbier; dìghe a paron Vicenzo, che el vegna qua, e che
 el mena qua Titta Nane, e che i vegna subito.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Tissimo sì. Checca, vegno ve', vegno </p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Co Checca xè novizza co Marmottina, mi de Titta
 Nane no gh'ho più zelusia) </p>
             <stage>(<emph>da sé</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Ghe xè caso, donne, donne, che no digo altro; che
 voggiè far pase, che voggiè tornar a esser amighe?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Se ele no gh'ha gnente co mi; mi no gh'ho gnente
 co ele.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Cossa diseu? </p>
             <stage>(<emph>a Libera, Orsetta e Checca</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Mi da là a là no gh'è altro.</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Mi? Co no son tirada per i cavei, no parlo mai co
 nissun.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>E vu, Checca?</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>De diana! A mi me piase stare in pase co tutti.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Via donca pacifichève, basève.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Mi sì.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>So qua.</p>
           </sp>
@@ -7510,29 +7559,29 @@ nissun.</p>
           <stage>
             <emph>Pasqua, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Cossa? cossa fastu? Ti vuò far pase? Con custìe?
 co sta zente?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Oh! vegnireu vu adesso a romper le scatole?</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Me maraveggio: le m'ha strapazzà.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Quietève anca vu, fenìmola.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>No me voggio quietare; me diole ancora sto brazzo.
 No me voggio quietare.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>(Magari l'avessio strupià).</p>
           </sp>
@@ -7542,66 +7591,66 @@ No me voggio quietare.</p>
           <stage>
             <emph>Paron Toni, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Oe, paron Toni.</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Lustrissimo.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Se no farè far giudizio a vostra muggier...</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Ho sentìo, ho sentìo, lustrissimo, ho sentìo. Animo;
 fa' pase </p>
             <stage>(<emph>a Pasqua</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>No voggio.</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Fa' pase </p>
             <stage>(<emph>minacciandola</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>No, no voggio.</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>Fa' pase, te digo; fa' pase </p>
             <stage>(<emph>tira fuori un legno</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Sì, sì, mario, farò pase </p>
             <stage>(<emph>mortificata s'accosta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Oh bravo! Oh bravo! Oh co bravo!</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Viè qua, Pasqua.</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>So qua </p>
             <stage>(<emph>s'abbracciano</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Anca vu, putte </p>
             <stage>(<emph>tutte s'abbracciano, e si baciano</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Brave, e viva; e che la dura fin che la se rompe.</p>
           </sp>
@@ -7612,145 +7661,145 @@ fa' pase </p>
             <emph>Paron Vicenzo, Titta Nane, Toffolo e detti, poi
 Servitore.</emph>
           </stage>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Semo qua, lustrissimo.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Oh! vegnì qua, Titta Nane adesso xè el tempo, che
 mi ve fazza cognosser, se ve vòi ben, e che vu fè cognosser,
 che sè omo.</p>
           </sp>
-          <sp>
+          <sp who="#vicenzo">
             <speaker>VICENZO</speaker>
             <p>Gh'ho tanto dito anca mi a Titta Nane, che el me
 par mezzo a segno; e gh'ho speranza, che el farà tutto
 quello, che vuole el lustrissimo sió cogitore.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Via donca, mandè a monte tutto. Tornè amigo de
 tutti, e disponève a sposar Lucietta.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Mi, lustrissimo? No la sposo, gnanca se i me
 picche.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Oh bella!</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>(Mo no xèle cosse da pestarlo co fa el bacalà!)</p>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Oe, senti; se ti credessi, che t'avesse da toccare
 Checca, vara ve': la s'ha da sposare co Toffolo </p>
             <stage>(<emph>a Titta Nane</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>E mi cento uccati e dago.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Mi no ghe ne penso, che la se spose co chi la
 vuole.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>E perché no voleu più Lucietta? </p>
             <stage>(<emph>a Titta Nane</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Perché la m'ha dito: va' in malora, la m'ha dito.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Oh, vara ve'! E a mi cossa no m'àstu dito?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Orsù chi vol, vol: e chi no vol, so danno.
 Vualtri a bon conto, Checca, e Toffolo, deve la man.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>So qua.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>So qua anca mi.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Sior no, fermève, che m'ho da maridar prima mi.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Animo, Beppo, da bravo.</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Oe, mi no me farò pregare.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Sior no, se no me marido mi, no ti t'ha da
 maridar gnanca ti </p>
             <stage>(<emph>a Beppo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>E la gh'ha rason Lucietta.</p>
           </sp>
-          <sp>
+          <sp who="#toni">
             <speaker>TONI</speaker>
             <p>E mi cossa soggio? Mi no gh'ho da intrare? A mi no
 s'ha da parlare?</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Voleu, che ve la diga? Andè al diavolo quanti che
 sè, che son stuffo </p>
             <stage>(<emph>in atto di partire</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Via, che nol vaga </p>
             <stage>(<emph>a Isidoro</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Tissimo </p>
             <stage>(<emph>a Isidoro</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Che el se ferma </p>
             <stage>(<emph>a Isidoro</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>Tissimo </p>
             <stage>(<emph>a Isidoro fermandolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Che el gh'abbia pazenzia </p>
             <stage>(<emph>a Isidoro</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Per causa vostra tutti i altri torà de mezzo</p>
             <stage>(<emph>a Lucietta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Via, lustrissimo, che nol me mortifica più
 davantazo. Per causa mia no voggio, che toga de mezo nissun.
@@ -7761,203 +7810,203 @@ gh'ho perdonà; e se elo no me vol perdonare, xè segno, che
 nol me vuol ben </p>
             <stage>(<emph>piange</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#pasqua">
             <speaker>PASQUA</speaker>
             <p>Lucietta? </p>
             <stage>(<emph>con passione</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Oe la pianze </p>
             <stage>(<emph>a Titta Nane</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>La pianze </p>
             <stage>(<emph>a Titta Nane</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>La me fa peccao </p>
             <stage>(<emph>a Titta Nane</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>(Maledìo! Se no me vergognasse?...)</p>
           </sp>
-          <sp>
+          <sp who="#libera">
             <speaker>LIBERA</speaker>
             <p>Mo via, pussibile, che gh'abbiè sto cuor?
 Poverazza! Vardè, se no la farave muover i sassi </p>
             <stage>(<emph>a Titta Nane</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Cossa gh'àstu? </p>
             <stage>(<emph>a Lucietta rusticamente</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Gnente </p>
             <stage>(<emph>piangendo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Via, animo </p>
             <stage>(<emph>a Lucietta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Cossa vustu?</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Coss'è sto fiffare?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Can, sassin </p>
             <stage>(<emph>a Titta Nane con passione</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Tasi </p>
             <stage>(<emph>con imperio</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Ti me vuol lassare?</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Me farastu più desperare?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>No.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Me vorastu ben?</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Sì.</p>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Paron Toni, donna Pasqua, lustrissimo, co bona
 licenzia. Dàme la man </p>
             <stage>(<emph>a Lucietta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Tiò </p>
             <stage>(<emph>gli dà la mano</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#titta">
             <speaker>TITTA</speaker>
             <p>Ti xè mia muggiere </p>
             <stage>(<emph>sempre ruvido</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Oh bella! Oe, Sansuga? </p>
             <stage>(<emph>al Servitore</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Lustrissimo.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Va' subito a far quel, che t'ho dito.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Subito </p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>A vu, Beppo. Sotto, vu.</p>
           </sp>
-          <sp>
+          <sp who="#beppo">
             <speaker>BEPPO</speaker>
             <p>Mi? La varda co che facilitae. Paron Fortunato,
 donna Libera, lustrissimo, co so bona grazia </p>
             <stage>(<emph>dà la mano a Orsetta</emph>).</stage>
             <p>Mario, e muggiere.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Oh! adesso mo, marìdete anca ti, che no me
 n'importa </p>
             <stage>(<emph>a Checca</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Toffolo, chi è de volta?</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Mi prima barca. Paró Fortunato, donna Libera,
 lustrissimo, co so bona licenzia </p>
             <stage>(<emph>dà la mano a Checca</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Oe, la dota </p>
             <stage>(<emph>a Isidoro</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Son galantomo, ve la prometto.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Tiò la man </p>
             <stage>(<emph>a Toffolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>Muggiere.</p>
           </sp>
-          <sp>
+          <sp who="#checca">
             <speaker>CHECCA</speaker>
             <p>Mario.</p>
           </sp>
-          <sp>
+          <sp who="#toffolo">
             <speaker>TOFFOLO</speaker>
             <p>E viva.</p>
           </sp>
-          <sp>
+          <sp who="#fortunato">
             <speaker>FORTUNATO</speaker>
             <p>E viva allegramente. Muggiere, anca mi so in
 grìngola. </p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Xè qua tutti, co la comanda </p>
             <stage>(<emph>a Isidoroe</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Novizzi allegramente. V'ho parecchià un poco de
 rinfresco; gh'ho un per de sonadori: vegnì con mi, che vòi,
 che se devertimo. Andemo, che baleremo quattro furlane.</p>
           </sp>
-          <sp>
+          <sp who="#orsetta">
             <speaker>ORSETTA</speaker>
             <p>Qua, qua balemo, qua.</p>
           </sp>
-          <sp>
+          <sp who="#isidoro">
             <speaker>ISIDORO</speaker>
             <p>Sì ben, dove che volè. Animo, portè fuora delle
 careghe. Fè vegnir avanti quei sonadori; e ti, Sansuga, va'
 al casin, e porta qua quel rinfresco.</p>
           </sp>
-          <sp>
+          <sp who="#lucietta">
             <speaker>LUCIETTA</speaker>
             <p>Sior sì, balemo, devertìmose, za che semo
 novizzi; ma la senta, lustrissimo, ghe vorave dire do

--- a/tei/goldoni-le-femmine-puntigliose.xml
+++ b/tei/goldoni-le-femmine-puntigliose.xml
@@ -86,6 +86,52 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="florindo">
+            <persName>Don Florindo Aretusi</persName>
+          </person>
+          <person xml:id="rosaura">
+            <persName>Donna Rosaura</persName>
+          </person>
+          <person xml:id="brighella">
+            <persName>Brighella</persName>
+          </person>
+          <person xml:id="pantalone">
+            <persName>Pantalone de' Bisognosi</persName>
+          </person>
+          <person xml:id="lelio">
+            <persName>Conte Lelio</persName>
+          </person>
+          <person xml:id="beatrice">
+            <persName>Contessa Beatrice</persName>
+          </person>
+          <person xml:id="arlecchino">
+            <persName>Arlecchino</persName>
+          </person>
+          <person xml:id="onofrio">
+            <persName>Conte Onofrio</persName>
+          </person>
+          <person xml:id="eleonora">
+            <persName>Contessa Eleonora</persName>
+          </person>
+          <person xml:id="ottavio">
+            <persName>Conte Ottavio</persName>
+          </person>
+          <person xml:id="clarice">
+            <persName>Contessa Clarice</persName>
+          </person>
+          <person xml:id="servitore">
+            <persName>Servitore</persName>
+          </person>
+          <person xml:id="paggio">
+            <persName>Paggio</persName>
+          </person>
+          <person xml:id="bravo">
+            <persName>Bravo</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -570,137 +616,137 @@ Florindo, e donna Rosaura.</stage>
           <stage>
             <emph>Donna Rosaura, e Don Florindo.</emph>
           </stage>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Signora consorte carissima, credo, che ce ne
 possiamo tornare al nostro paese, e se aveste aderito a
 quello, che io diceva, non saremmo nemmeno venuti a Palermo.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Che avrebbero mai detto di noi le donne del nostro
 rango, se dentro il primo anno del nostro matrimonio non
 fossimo venuti a far qualche sfarzo nella città capitale?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>E che cosa diranno di noi, se torneremo alla
 patria, senza che una dama di questo paese siasi degnata di
 ammetterci alla sua conversazione?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Ciò basterebbe a farmi morir di dolore.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Penso che sarebbe stato meglio, se in luogo di
 aspirare alla conversazione delle dame, ci fossimo
 contentati di quella delle mercantesse della nostra
 condizione.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Oh, questo poi no. Sono venuta a Palermo per
 acquistare qualche cosa di più. Per esser distinta a
 Castell'a Mare, basta ch'io possa dire, sono stata in
 Palermo alla conversazion delle dame.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ma se questa conversazione, non si può ottenere?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Il Conte Lelio mi ha dato speranza, che forse, forse
 si otterrà.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Il Conte Lelio, e molti altri cavalieri ci
 trattano, ci favoriscono, mostrano desiderio d'introdurci
 per tutto; ma so, che le dame non vogliono ammetterci
 assolutamente.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Eppure sono stata a casa di alcune, e mi hanno
 ricevuta.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Sì. In privato tutte ci faranno delle finezze, ma
 in pubblico non è possibile.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Mi ha promesso il Conte Lelio, che la Contessa
 Beatrice prenderà ella l'impegno d'introdurmi.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Questa dama non la conosco. Non le ho portato
 veruna lettera di raccomandazione.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>La lettera di raccomandazione, che dovremo noi
 presentarle, sarà un piccolo regaletto di cento doppie.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Cento doppie? A che motivo?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Per gl'incomodi, che si dovrà prendere per causa
 nostra.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>E sarà tanto vile, per vendere a denaro contante la
 sua protezione?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Il Conte Lelio maneggia l'affare: io gliel'ho
 promesse, e son certa che in questo non mi farete scorgere.
 Purché ottenghiamo l'intento nostro, che importa a voi il
 sagrificio di cento doppie?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Quando riesca la cosa bene, le sagrifico
 volentieri, unicamente per compiacervi.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Anzi ho divisato donare al Conte Lelio un orologio
 d'oro per gratitudine dei buoni uffici, che fa per noi.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ed egli l'accetta?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Perché volete, che lo ricusi?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Per quel, ch'io vedo, si vende la protezione, come
 il panno, e la seta.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Ci siamo, bisogna starci.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>In otto giorni, che siamo qui, abbiamo speso più di
 trecento scudi, senza veder cosa alcuna.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Non voglio andare in nessun luogo, senza una dama,
 che mi conduca.</p>
@@ -711,72 +757,72 @@ che mi conduca.</p>
           <stage>
             <emph>Brighella, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Signori...</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Villanaccio <emph>(a Brighella con isdegno gittandogli un fazzoletto in faccia)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Lustrissima...</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Dammi, quel fazzoletto.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Lustrissima sì. Gh'è qua l'illustrissimo sior
 Pantalon, che li voria reverir.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Pantalone non è illustrissimo.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>La perdona, signora...</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Asino!</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Illustrissima, la me compatissa.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Digli che passi.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Signor sì... Illustrissimo sì. (No me posso
 avvezzar) <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Non voglio sentire le seccature di questo vecchio.
 Vado nella mia camera; se viene il Conte Lelio, mandatelo da
 me.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Sarete servita.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Se questa dama ci favorisce, bisognerà trattarla.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Siamo forestieri, probabilmente sarà ella la prima
 a trattarci.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Basta; purché si spunti, si ha da spendere senza
 riguardo <emph>(parte)</emph>.</p>
@@ -787,45 +833,45 @@ riguardo <emph>(parte)</emph>.</p>
           <stage>
             <emph>Don Florindo, poi Pantalone.</emph>
           </stage>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Bel negozio, che ho fatto a prendere questa signora
 sposa! Ella mi ha dato una ricca dote, ma credo, che al
 terminar dell'anno sarà finita.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Sior don Florindo, mio patron reverito.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Buon giorno, il mio caro signor Pantalone.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Son vegnù a reverirla, e in tel medesimo tempo a
 dirghe, che ho recevesto la lettera d'avviso per pagarghe i
 mille zecchini, a tenor della lettera de cambio, che gieri
 lu m'ha fatto presentar.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Non v'era bisogno, che per questo v'incomodaste,
 mentre ieri, anco prima della lettera d'avviso, avete con
 bontà accettata la mia cambiale.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Gh'ò tanta stima per la so degna persona, gh'ò
 tanto credito alla so dita, che anca senza lettera de cambio
 l'averia servida, se la s'avesse degnà de commanderme.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Vi sono molto tenuto per la bontà, che mi
 dimostrate.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>La sarave bella! Semo stai tanto amici col sior
 Anselmo so barba, che gierimo, se pol dir, fradei. Quello el
@@ -833,37 +879,37 @@ giera un omo! Quello ha fatto i bezzi! Con mille ducati, che
 gh'à dà so pare, in manco de dies'anni, l'ha fatto un
 capital de cinquantamille.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Veramente a mio zio Anselmo ho tutta
 l'obbligazione.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Credo de sì, l'ha lassà tutto a ela, co l'è morto,
 el giera la prima dita de sti paesi, e ela, la me permetta,
 che ghe diga, se la seguiterà el bon ordine de so sior
 barba, la sarà un dei primi mercanti della Sicilia.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Io, caro signor Pantalone, sono in un grado di non
 aver più bisogno di far il mercante. Ho tanti capitali, ho
 tanti crediti, ho tanto danaro in cassa da poter vivere
 comodamente, senza continuare la mercatura.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>La me perdona se me avanzo troppo. Cossa gh'àla
 d'investìo?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Oh poco! A riserva d'un bel palazzo per villeggiare
 con tre, o quattro campi tirati a giardino; non ho poi
 comprato né terreni, né case.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>La senta, e l'ascolta un omo vecchio, pratico delle
 cosse del mondo, e interessà per i so vantazi. I bezzi i se
@@ -880,13 +926,13 @@ fazza conto de ste parole, e la le receva da un omo, che per
 etae, per amor, e per debito, se protesta d'esserghe come
 pare.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Caro il mio amatissimo signor Pantalone; voi siete
 pieno di bontà per me, vi ringrazio de' salutevoli
 documenti, e vi prometto di porli in pratica.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Quando la crede, che mi ghe diga la verità, e che
 la sia persuasa de voler mantegnir in credito la so dita, mi
@@ -894,55 +940,55 @@ la conseggio andar al so paese, tender ai so negozi, e
 seguitar le pratiche, le usanze, e le corrispondenze de so
 sior barba.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ho i miei ministri, che agiscono in mia vece.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>I ministri i xè bei, e boni; ma col paron no
 gh'abada, le cosse no le va mai ben. Tutti cerca el proprio
 interesse, e pochi xè quei, che s'impegna con zelo, e con
 calor in favor dei so principali.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Quanto prima tornerò a Castell'a Mare; ma giacché
 sono in Palermo, non è giusto, ch'io parta senza far vedere
 alla mia sposa le cose principali della città.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Se la commanda, mi la farò servir.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Vi vorrebbe qualche signora, che si prendesse
 l'incomodo di accompagnare mia moglie.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Gh'ò una nezza maridada in t'un dei primi marcanti.
 La gh'à carrozza, la gh'à staffieri, la la servirà ela.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ma poi, s'anderà in veruna conversazione?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>M'impegno, che i ghe farà tre, o quattro sontuose
 conversazion, e che la sarà trattada, come una principessa.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Quand'è così, riceveremo le vostre grazie.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Vado subito a avvisar mia nezza.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Trattenetevi un momento, tanto, che avvisi di ciò
 la mia sposa. Ehi, signora Rosaura? <emph>(la chiama)</emph>.</p>
@@ -954,31 +1000,31 @@ la mia sposa. Ehi, signora Rosaura? <emph>(la chiama)</emph>.</p>
             <emph>Donna Rosaura nell'altra camera, e poi esce, e detti, poi
 Brighella.</emph>
           </stage>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Cosa volete? <emph>(di dentro)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Favorite, venite qui, che vi ho da parlare.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Non vi è nessuno, che alzi la portiera? <emph>(come sopra)</emph></p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Non vi è nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Gh'àla mal ai brazzi? La servirò mi <emph>(alza la portiera)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Obbligatissima alle sue grazie <emph>(esce)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Il signor Pantalone è tutto bontà, tutto
 gentilezza. Sentite le belle esibizioni, ch'egli ci fa. Ci
@@ -986,141 +1032,141 @@ offerisce la buona grazia d'una signora sua nipote, la quale
 ci favorirà colla sua carrozza, e ci condurrà alla
 conversazione.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>È dama questa sua nipote? <emph>(a Pantalone)</emph></p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>No la xè dama, ma la xè una delle prime mercantesse
 de sta città.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Va alla conversazione delle dame?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>La va alle conversazion de par soo; de signore
 tutte oneste, e civil; signore, che non xè nobili; ma che
 gh'à dei soldi.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Signor Pantalone, la riverisco <emph>(vuol partire)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Come! No la se degna de lassarse servir da mia
 nezza?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Sì, anzi, mi farà piacere <emph>(sprezzante)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Vago subito a dirghe, che la se prepara per
 vegnirla a riverir.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>No, no, per oggi non s'incomodi. Mi duole il capo.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Donca la vegnirà doman.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Se starò bene, vi avviserò.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Mo gh'àla mal?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Mi duole il capo. Non posso nemmeno sentir parlare.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Co l'è cusì, per non disturbarla de più, vago via.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Scusi di grazia. Quando mi duole il capo non so che
 cosa mi dica.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Me despiase infinitamente. Sior don Florindo,
 bisogna remediarghe; no sentela, che alla sposa ghe dol la
 testa?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Lo so pur troppo. (Mia moglie ha il suo male nella
 testa, e mi dispiace, che non vi è rimedio) <emph>(da sé)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Lustrissima, el sior Conte Lelio desidera de
 reverirla <emph>(a Rosaura)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Venga, è padrone <emph>(a Brighella, che parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Mo se ghe dol la testa, come farala a sentirlo a
 parlar? <emph>(a Rosaura)</emph></p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>La ragione per cui egli viene, interessa tutte le
 mie premure. Fate una cosa, signor Florindo, servite in
 un'altra camera il signor Pantalone, e lasciatemi col Conte
 Lelio a trattar l'affare, che voi sapete.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ma non potremmo noi prevalerci del signor
 Pantalone, che ci esibisce una sua nipote?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Mi maraviglio di voi. Sapete l'impegno, in cui sono.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Signor Pantalone; andiamo, se vi contentate
 <emph>(stringendosi nelle spalle)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(Poverazzo! El se lassa menar per el naso) <emph>(da sé)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>(Ehi! per vostra regola, acciò non facciate qualche
 cattivo giudizio, osservate ho preso le cento doppie)
 <emph>(piano a Florindo, e gli mostra la borsa)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(Si potrebbero pur risparmiare) <emph>(piano a Rosaura)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Son chi sono; voglio così <emph>(adirata)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Andiamo, andiamo, signor Pantalone <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>(Questi i xè de quei dolori de testa, che patisce
 le muggier, co le gh'à per marii de sta sorta de mamalucchi)
@@ -1132,120 +1178,120 @@ le muggier, co le gh'à per marii de sta sorta de mamalucchi)
           <stage>
             <emph>Donna Rosaura, poi il Conte Lelio, e Brighella.</emph>
           </stage>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>La nipote del signor Pantalone? Farei una gran
 figura, se andassi con lei!</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Riverente m'inchino alla signora donna Rosaura.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Serva, signor Conte, chi è di là? <emph>(chiama)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Lustrissima.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Da sedere.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Lustrissima sì <emph>(porta due sedie)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Galantuomo, siete forestiere? <emph>(a Brighella)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Signor sì.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Dimmi, il moro è in casa? <emph>(a Brighella)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Lustrissima sì.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Siete lombardo? <emph>(a Brighella)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Signor sì.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Va' via <emph>(a Brighella)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Lustrissima sì.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Sentite una parola <emph>(a Brighella)</emph>. Mi date licenza
 ch'io dica un non so che al vostro servitore? <emph>(a Rosaura)</emph></p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Siete padrone.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Voglio un poco vedere, perché a lei dà
 dell'illustrissima, e a me del signore). (Ditemi quel
 giovine, al vostro paese che regola si usa nel dar i
 titoli?) <emph>(a Brighella a parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Ghe dirò, signor, in certi paesi dove, che ho
 praticà mi: chi li merita non li cura, e a chi non li merita
 i se ghe dà per burlarli.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Bravo, mi piacete. Se vi occorre nulla, sarò per
 voi.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Signor sì.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Portateci la cioccolata.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Lustrissima sì <emph>(caricato, e parte; e a suo tempo ritorna)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Così con bella maniera costui si burla della sua
 padrona) <emph>(da sé)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Favorite d'accomodarvi.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Ricevo le vostre grazie <emph>(siede)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Che buone nuove mi recate del nostro affare?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Il tutto è accomodato. La Contessa Beatrice verrà
 da qui a pochi momenti a visitarvi; voi le anderete a render
@@ -1253,177 +1299,177 @@ la visita; in casa sua farà, che si trovino varie dame. Vi
 introdurrà con esse, e vi condurrà pubblicamente nella loro
 conversazione.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Caro Contino, siete adorabile. Non poteva sperare
 diversamente dal vostro spirito, dalla vostra buona
 condotta.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Circa alle cento doppie, bisogna condur la cosa con
 buona maniera.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Le si potrebbe dare un anello, che fosse di tal
 valore.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>No, un anello non accomoderà i suoi interessi.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Il danaro è pronto. Disponetene come vi aggrada.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Faremo così; procureremo, che accada di fare una
 scommessa di cento doppie fra voi, e la Contessa Beatrice;
 voi perderete la scommessa, ed ella averà il danaro
 contante.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>In questa maniera, non riconoscerà da me il dono, ma
 dalla sorte.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Se la cosa è prima concertata, lo riconoscerà
 unicamente da voi.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Se si concerta così, può anche ricevere le cento
 doppie, senza far la scommessa.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Signora no; ella pretende salvar con ciò la
 delicatezza del suo decoro.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Può salvarla presso di tutti gli altri, quando non
 lo sappiano altri che ella, ed io.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Non vuole scomparire nemmeno con voi.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Ma se io ho a sapere la verità.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Non importa; le resta sempre un rimorso di meno; e
 ancorché ella sia certa, che la scommessa sia inventata per
 regalarla, ciò nonostante, vanterà con voi medesima il suo
 bello spirito nell'aver saputo trionfare coll'oppinione.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>E qual è la scommessa che dobbiamo fare?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>La scommessa caderà sopra le ore. Voi per esempio
 direte, che sono sedici. Ella dirà, che sono diciassette. Si
 farà la scommessa; io deciderò in favore della Contessa, e
 voi le darete le cento doppie.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Benissimo; per decidere con fondamento, favorite,
 tenete quest'orologio <emph>(gli dà un orologio d'oro)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Credo che il mio sarà sufficiente.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Non pretendo sprezzare il vostro, ma questo è uno
 dei migliori di Londra. Tenetelo, e state certo che non
 isbaglierete.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Ve lo renderò dopo la scommessa.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Spero che non mi farete un simile torto.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Donna Rosaura, voi siete troppo obbligante.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Un Cavaliere, che mi dimostra tanta parzialità, può
 anche permettermi, ch'io mi possa prendere con esso lui una
 simile confidenza.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Per dir il vero, la premura, ch'io nutrisco delle
 vostre soddisfazioni non è senza interesse, ma la mercede, a
 cui aspira il mio cuore, val molto più di quello mi avete
 graziosamente donato.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>E qual è la mercede, che a misura del vostro merito
 possiate da me ottenere?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Qualche generosa porzione della vostra grazia.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Oh via, signor Conte, vedo, che vi prendete spasso
 di me.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Mostrerei di essere poco conoscitore del merito, se
 non aspirassi all'onore di essere da voi ben veduto.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Ben veduto, stimato, e venerato voi siete.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>E niente più?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Che cosa pretendereste di più?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Niente amato? Niente affatto?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Onestamente, posso anche amarvi.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Oh si sa! Onestamente.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Caro Conte, ditemi con sincerità. Siete impegnato
 con alcuna dama?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Cinque ne ho servite in un anno, e tutte cinque si
 sono disgustate di me per femminili puntigli. La prima,
@@ -1437,133 +1483,133 @@ d'andarla a prendere alla conversazione. All'ultimo, mi sono
 posto a servire la Contessa Beatrice, la quale non è tanto
 puntigliosa quanto le altre.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Presto, presto, essa pure vi scarterà.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Per qual motivo?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Può essere per causa mia.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Per sì bella cagione, rinunzierei tutte le più
 belle dame del mondo.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Mi burlate?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Dico davvero.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Caro Conte!</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Adorabile madamina!</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Lustrissima. La signora Contessa Beatrice, l'è
 fermada colla carrozza alla porta; e la manda a veder, se
 Vosustrissima è in casa, e se la pol vegnir a farghe una
 visita.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Padrona <emph>(s'alza)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>(Adesso la camisa no ghe tocca el preterito)
 <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Veramente è sollecita questa dama.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Spero, che resterete contenta.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Ha marito?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Sì. Il Conte Onofrio. È un buonissimo uomo;
 mangia, e beve, e non pensa ad altro.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Lascia far tutto alla moglie?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Tutto.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Felici quelle donne, che possono far così.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Bisognerà andarle incontro.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Ma dove?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Io direi alla scala.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Oh no, Contino mio, basterà, ch'io vada alla porta
 di camera.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Per la prima volta, che viene a visitarvi, potete
 far qualche cosa di più.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Se lo facessi una volta, sarei obbligata di farlo
 sempre.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Abbondare in gentilezza è cosa sempre ben fatta.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Chi troppo si abbassa non esige rispetto.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Finalmente è una dama.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Ed io non sono la sua cameriera.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Presto, andatele incontro. Vedetela, è qui alla
 porta.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Basta, che mi veda disposta per incontrarla <emph>(fa qualche passo verso la porta)</emph>.</p>
           </sp>
@@ -1573,370 +1619,370 @@ porta.</p>
           <stage>
             <emph>La contessa Beatrice, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>È qui la signora Rosaura?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Oh! Servitori ignoranti! Non mi hanno avvisata.
 Sarei venuta a riceverla.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Non importa, non importa.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Serva umilissima, signora Contessa.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Serva sua, signora donna Rosaura. Addio Conte.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Con tutto il rispetto <emph>(inchinandosi)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Mi rincresce, che la signora Contessa siasi preso
 l'incomodo di venire sin qui; sarei venuta io a riverirla.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Il Conte Lelio mi ha procurato l'incontro di
 conoscere una signora di merito particolare, ed io non ho
 tardato ad accellerarmi un tal piacere.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>S'accomodi. (Parla molto sostenuta) <emph>(piano a Lelio)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Si serve dei veri termini) <emph>(piano a Rosaura)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>(Converrà misurar le parole) <emph>(da sé)</emph>. Ma favorite
 d'accomodarvi <emph>(a Beatrice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Eccomi accomodata <emph>(siedono tutti tre uniti; Beatrice alla dritta, Rosaura in mezzo, il Conte alla sinistra)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Così non istiamo bene. La Contessa non ha il suo
 posto) <emph>(piano a Rosaura)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Conte, avete fatto ammobiliar voi questo
 appartamento per la signora Rosaura?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Sì signora, ho avuto io una tale incombenza.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>E i suoi servitori, gli avete procurati voi?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Ne ho ritrovati alcuni, per la pratica della città.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Perdonatemi; l'avete servita male. Cattivi mobili,
 e pessimi servitori.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Perché dite questo, signora Contessa?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Non vedete? Siete pur Cavaliere. In una camera di
 udienza, le sedie tutte eguali non istanno bene. E i
 servitori non le sanno disporre.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Non ve l'ho detto? La Contessa non ha il suo
 posto, e vi voleva una sedia distinta) <emph>(piano a Rosaura)</emph>.
 Signora, regolerò io le mancanze del servitore, giacché per
 i mobili non vi è rimedio <emph>(s'alza, porta la sua sedia in distanza di Rosaura, e fa che Beatrice resti alla dritta della medesima)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>(Ho piacer d'imparare; anch'io a Castell'a Mare farò
 così) <emph>(da sé)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Conte mio, vi siete preso un incomodo, che lo
 potevate risparmiare. L'errore non consisteva nella vostra
 sedia, ma nella mia. Il sole di quella finestra mi offende
 la vista.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Ho capito). Permettetemi ch'io vi rimedi <emph>(s'alza; fa alzare Beatrice, e porta la di lei sedia in distanza di Rosaura colla spalliera verso la finestra, cosicché viene a restare in faccia a Rosaura nel primo luogo della camera d'udienza)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(Conte, se l'ho da condurre alla conversazione
 delle dame, insegnatele qualche cosa) <emph>(piano al Conte, e siede)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>(Questa poi non l'intendo) <emph>(piano al Conte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Quello è il primo luogo. Nella camera d'udienza,
 sempre la persona, che si riceve, va collocata in faccia la
 padrona di casa, e in faccia alla porta, o almeno di fianco)
 <emph>(piano a Rosaura)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>(Anche questa è buona per Castell'a Mare) <emph>(da sé)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Su via, signore mie, diciamo qualche cosa di bello
 <emph>(torna a portare la sua sedia vicino a Rosaura, e gira alquanto quella di essa Rosaura, acciò resti in faccia alla Contessa Beatrice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>E così, signora Rosaura, come vi piace la città di
 Palermo?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Non posso dirlo, perché non l'ho ancora veduta.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Quant'è, che ci siete?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Saranno otto giorni.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>In otto giorni, sarete stata in qualche luogo.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Non sono uscita di casa, altro che una volta sola.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Per qual ragione?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Per non aver avuto una dama, che mi favorisse.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(Che pretensione ridicola!) E partirete di Palermo
 senza vederlo?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Spero che la signora Contessa mi onorerà della sua
 compagnia.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Conte, che ora abbiamo?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Non lo so davvero; il mio orologio va male; voi che
 venite ora di fuori, potreste saperlo meglio di me <emph>(a Beatrice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Ma pure, che ora direste voi, che fosse?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Signora Rosaura, dite voi la vostra opinione.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Io dico, che saranno sedici ore.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Ed io dico, che saranno diciassette.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Quando la signora Contessa lo dice, sarà così.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Oh diavolo! E la scommessa?) <emph>(piano a Rosaura)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>(È vero, non ci ho pensato). Signora Contessa, io
 scommetto che sono sedici ore.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>O sedici, o diciassette non ci penso. Ma è ora che
 vi levi l'incomodo, e me ne vada <emph>(sostenuta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Sentite? Se l'ha avuto per male) <emph>(piano a Rosaura)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>(È molto puntigliosa!) <emph>(piano a Lelio)</emph></p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Eppure è delle più correnti, e facili, che vi
 sieno) <emph>(piano a Rosaura)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>A mezzogiorno devo esser a casa, ove alcune dame
 saranno per favorirmi.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>A che ora suona il mezzogiorno?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Alle diciassette.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Dite alle diciotto) <emph>(piano a Rosaura)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Perdoni, signora Contessa, ella s'inganna; il
 mezzogiorno suona alle diciotto.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Lo volete insegnare a me? Suona alle diciassette.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Ora è il tempo) <emph>(piano a Rosaura)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Scommetto che suona alle diciotto.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Scommetto, che suona alle diciassette.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Animo, che cosa volete scommettere, signore mie?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Tutto quello, che vuole la signora Rosaura.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Scommetto cento doppie.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Doppie di Spagna?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Vi s'intende.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Benissimo. Accetto la scommessa. Cento doppie di
 Spagna, che mezzogiorno suona alle diciassette.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Che suona alle diciotto.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Ma chi deciderà la scommessa?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Io, signore, se vi contentate. Ecco un giornale
 veridico, ed accreditato. Ecco qui: <emph>Tavola del mezzogiorno: undici Aprile, a ore diciassette</emph>. Signora donna Rosaura,
 avete perduto la scommessa.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Ho vinto, ho vinto <emph>(con allegria)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Benissimo, ed io sono pronta a pagare. Ecco, signora
 Contessa, una borsa con cento doppie di Spagna. Contatele se
 ne avete dubbio.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Mi maraviglio. Mi fido di voi.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Anche questa è andata bene, che non credevo) <emph>(da sé)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Il mezzogiorno dunque suona alle ore diciassette;
 ma presentemente, che ora sarà?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Io direi, che fossero sedici.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Ed io scommetto, che sono diciassette.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Signora Contessa, siete troppo brava; con voi non
 scommetto più. (Ne piglierebbe altre cento) <emph>(da sé)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Orsù; volete venire con me? <emph>(a Rosaura)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Dove?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>A casa mia, dove vi saranno quattro, o cinque dame
 invitate unicamente per voi.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Riceverò volentieri le vostre grazie. Ma prima, se
 vi contentate, beviamo la cioccolata. Chi è di là?
@@ -1948,82 +1994,82 @@ vi contentate, beviamo la cioccolata. Chi è di là?
           <stage>
             <emph>Arlecchino, e detti, poi Brighella.</emph>
           </stage>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Comandar.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Porta la cioccolata.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Subito servir <emph>(in atto di partire)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Che grazioso moretto!</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Mi star graziosa moretta, e ti star galanta
 bianchetta <emph>(a Beatrice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Come ti chiami?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Mi chiamar con bocca.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Va' via di qua, impertinente.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Lasciatelo dire, che la Contessa avrà piacere. È
 il più caro moro del mondo.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Per ti star cara <emph>(a Lelio)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Per me sei caro? Perché?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Perché non aver quattrini, per mi comprar.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Bravo moretto, bravo!</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Oh cara! Quanto star bella! Mi voler bena. Mi, se ti
 voler, far razza mezza bianca, e mezza mora <emph>(a Beatrice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Va' via, briccone. Porta la cioccolata.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Per ti, e per ti portar cioccolata <emph>(a Rosaura, e Beatrice)</emph>. E per ti polentina <emph>(a Lelio, e parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>È maledetto costui!</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Dove l'avete avuto? <emph>(a Rosaura)</emph></p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Vi dirò; questo è un moro, che quando fu preso, fu
 portato a Venezia, dove ha principiato a parlar italiano, e
@@ -2032,70 +2078,70 @@ Egli poi venne in Sicilia sopra una nave, e piacendomi
 infinitamente il suo spirito, e le sue facezie, l'ho
 comprato dal capitano.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Che nome ha?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Perché è tanto burlevole, e giocoso; gli ho messo
 nome Arlecchino.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Ma gli Arlecchini sono goffi, e costui è furbo come
 il diavolo.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>In oggi i buoni Arlecchini sono più spiritosi, che
 goffi.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>L'illustrissimo sior Conte Onofrio vorria
 riverirla <emph>(a Rosaura)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Mio consorte <emph>(a Rosaura)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Favorisca, è padrone. Presto, un'altra sedia. Lì lì,
 presso la signora Contessa <emph>(a Brighella)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Che volete, ch'io faccia di mio marito vicino?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Aspetta <emph>(a Brighella)</emph>. (Dove l'abbiamo da
 mettere?) <emph>(piano a Lelio)</emph></p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Appresso di voi) <emph>(piano a Rosaura)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>(Di sopra, o di sotto!) <emph>(come sopra)</emph></p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Oh di sopra, di sopra!)</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Mettila qui <emph>(a Brighella)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>(Se i mi padroni i sta troppo qua, i deventa
 matti) <emph>(mette la sedia, e parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(Questa povera donna è in una gran confusione)
 <emph>(da sé)</emph>.</p>
@@ -2106,116 +2152,116 @@ matti) <emph>(mette la sedia, e parte)</emph>.</p>
           <stage>
             <emph>Il conte Onofrio, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Schiavo di lor signori.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Amico, vi son servo.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Signor Conte posso bene annoverarmi fra le donne più
 fortunate, se vi degnate di onorar la mia casa
 coll'autorevole vostra presenza.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Oh garbata signorina! Chi è questa signora? <emph>(a Beatrice)</emph></p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Questa è la signora donna Rosaura, moglie del
 signor Florindo Aretusi di Castell'a Mare.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Mercante, non è vero? <emph>(a Rosaura)</emph></p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Fu mercante.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Ed ora, che cosa è?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Vive del suo, signore.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Non si è ancora fatto nobile?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Quanto prima, comprerà un titolo.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Se vuole il mio, glielo vendo <emph>(ridendo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Siete qui sempre colle vostre barzelette <emph>(al conte Onofrio)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Il Conte Onofrio è sempre di buon umore.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Contessa, sono venuto ad avvisarvi, che la Contessa
 Eleonora, e la Contessa Clarice, col Conte Ottavio, sono a
 casa nostra, che vi aspettano. (Ditemi, avete bevuto la
 cioccolata?) <emph>(piano a Beatrice)</emph></p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(Or ora la portano). È molto tempo che ci sono?</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Sarà mezz'ora.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Signora donna Rosaura, queste due dame le ho fatte
 venire per voi; se volete, che andiamo, principierete a
 conoscere queste, e vi servirà d'introduzione all'altre.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Sì, signora, andiamo: non le facciamo aspettare, non
 commettiamo questa mala creanza.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Io non so commettere male creanze <emph>(alterata)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Voglio dire... Vi s'intende. Se aspettan me....</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>No, no, non aspettano voi.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Dunque io non ci ho da venire?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Sì, verrete con me.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>(Io mi confondo) <emph>(da sé)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(Poverina! È imbrogliata a voler far da signora)
 <emph>(da sé)</emph>.</p>
@@ -2228,46 +2274,46 @@ commettiamo questa mala creanza.</p>
           </stage>
           <stage><emph>(Arlecchino con una guantiera con quattro chicchere di
 cioccolata, e vari biscottini)</emph>.</stage>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Ecco la cioccolata.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Ma l'ora si fa tarda, e le dame aspettano.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Che aspettino. Quando avremo bevuto la cioccolata,
 anderemo.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Vi prego; accomodatevi <emph>(a Beatrice, perché prenda la cioccolata)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Potreste intanto prendere il ventaglio, e
 prepararvi per montare in carrozza <emph>(a Rosaura)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Ho tempo d'accomodarmi la testa?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Eh, che siete accomodata abbastanza!</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Servitevi della cioccolata; vengo subito. Ehi?
 <emph>(chiama. Brighella viene)</emph></p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Alza quella portiera <emph>(a Brighella, e passa nell'altra camera)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>(Se i la vedesse a Castell'a Mar, i creperia da
 rider) <emph>(parte)</emph>.</p>
@@ -2279,80 +2325,80 @@ rider) <emph>(parte)</emph>.</p>
             <emph>Il conte Onofrio, la contessa Beatrice, il conte Lelio e
 Arlecchino</emph>
           </stage>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Sediamo; la cioccolata si raffredda <emph>(siede, e prende una chicchera di cioccolata col biscottino)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Per quella panza, no volir cioccolata, ma polenta.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Moretto, è buona questa cioccolata? <emph>(ne prende una chicchera)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Star bona, perché star color de moretta <emph>(porta la cioccolata a Lelio)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Non ne voglio. L'ho presa.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Bevetela che è buona <emph>(a Lelio)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>No, no, mi mette troppo calore.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Bever, bever, che ti star pover giazzada <emph>(a Lelio)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Se non portassi rispetto alla tua padrona, ti
 bastonerei.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Ehi? <emph>(ad Arlecchino; mette giù la chicchera vota, e ne prende un'altra piena col biscottino)</emph></p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Star Cavalier de bona fama.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Prendi <emph>(mette giù la sua chicchera)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Voler quest'altra? <emph>(a Beatrice)</emph></p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Non voglio altro; bevila tu.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>A mi no piaser; piaser maccarugna.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Ehi? <emph>(mette giù la chicchera vota, e prende la terza piena col biscottino, e beve)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Evviva scrocca!</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Quel Conte Onofrio, è veramente sordido!) <emph>(da sé)</emph></p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(Mio marito non si contenta mai) <emph>(da sé)</emph>.</p>
           </sp>
@@ -2362,130 +2408,130 @@ bastonerei.</p>
           <stage>
             <emph>Donna Rosaura, e Don Florindo, poi Brighella, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Signora Contessa, mio marito vuol aver l'onore di
 rassegnarle la sua servitù.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Rendo infinite grazie alla signora Contessa per la
 bontà, con cui si degna favorire mia moglie, e la prego
 ricevere me pure nel numero de' suoi servidori.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Signora donna Rosaura, avete un bel giovinotto per
 marito.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>E questo signore chi è? <emph>(a Lelio, accennando il conte Onofrio)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>È il signor Conte Onofrio, consorte della Contessa
 Beatrice.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Permetta, che con lei pure... <emph>(ad Onofrio)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Schiavo, schiavo, senza cerimonie <emph>(voltandogli le spalle)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>(Questo trattamento non mi finisce) <emph>(da sé)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Signora Rosaura, avete della cioccolata molto
 buona.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Ne ho portata un poco per me, se comandate, la
 spartiremo.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Mi farete piacere, vi sarò obbligato.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Ehi? <emph>(chiama)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Lustrissima.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Senti, porta subito, subito venti libbre di
 cioccolata a casa della Contessa Beatrice <emph>(piano a Brighella)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Subito la servo <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>O via andiamo. Conte Onofrio, date mano alla
 signora donna Rosaura.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Volentieri, son qui la mia ragazza <emph>(a Rosaura)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Florindo, servite la signora Contessa.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Eh, no, non v'incomodate. Conte Lelio, favorite
 <emph>(chiama Lelio)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Ma se si esibisce l'amico Florindo...</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Andiamo, andiamo <emph>(prende Lelio per la mano)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Mio marito verrà in carrozza con noi? <emph>(a Beatrice)</emph></p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>In carrozza non vi si sta più di quattro. Verrà a
 piedi.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Basta... abbiamo anche noi la nostra carrozza.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Dunque verrà colla vostra <emph>(parte con Lelio)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Florindo, abbiate pazienza.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Ehi? Avete buon cuoco? <emph>(a Florindo)</emph></p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Sì signore, buono.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Lo proveremo <emph>(parte con Rosaura)</emph>.</p>
           </sp>
@@ -2495,7 +2541,7 @@ piedi.</p>
           <stage>
             <emph>Don Florindo solo.</emph>
           </stage>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ed io ho da andare a piedi, o solo nella mia
 carrozza a vettura? E il signor Conte Onofrio mi usa questa
@@ -2519,243 +2565,243 @@ la riconduco a Castell'a Mare <emph>(parte)</emph>.</p>
             <emph>La contessa Eleonora, la contessa Clarice, ed il conte
 Ottavio.</emph>
           </stage>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Per assoluto, voglio andar via.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Ma perché, signora Contessa Eleonora, v'impazientite
 voi tanto?</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>La Contessa Beatrice non sa il trattare. Ci manda
 l'ambasciata, perché venghiamo da lei a sedici ore e sono
 ormai diciassette.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Vi ha pur fatto dire da suo marito, che abbiate la
 bontà di trattenervi, se ella tardasse alcun poco a venir a
 casa.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Queste ambasciate si fanno fare alle serve, non
 alle dame, che sono al par di lei, e qualche cosa più di
 lei. Si vede bene, che i vizi di suo marito le hanno fatto
 non solo consummare l'entrate, ma perdere ancora la civiltà.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Anche voi vi riscaldate, Contessina Clarice?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Mi riscaldo con ragione, e se non avessi licenziato
 la mia carrozza, me ne anderei assolutamente.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Venite nella mia, andiamo. Già io sto poco di qua
 lontano. Vi contenterete, che smonti al mio palazzo, e vi
 farete servire a casa.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>(Vuol esser servita prima lei?) No, no, vi
 ringrazio. Aspetterò ancora un poco.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Sentite una carrozza, sarà quella della Contessa
 Beatrice.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Sarà la mia, sarà la mia.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Or ora ve lo saprò dire <emph>(parte per assicurarsene, e poi torna)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Per che causa mai ci ha fatto venir qui
 stamattina?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Non lo so nemmen io. Ma suo marito, che è stato a
 invitarmi, mi ha fatto una gran premura.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>È stato il Conte Onofrio a invitarvi?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Egli in persona</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Ed a me ha mandato il bracciere, non so perché
 abbia a usar questa differenza.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Ha voluto far a me questa finezza.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Dunque voi restate, ed io partirò <emph>(in atto di andarsene)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Per dove, signora Contessa? <emph>(incontrandola)</emph></p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Dove mi pare, e piace.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Così risoluta?</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Risolutissima; e voi che mi avete accompagnata
 qui, riaccompagnatemi sino a casa.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Brava, e io resterò sola come una pazza.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Io non posso dividermi in due.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>E bene, di chi era la carrozza? <emph>(ad Ottavio)</emph></p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Non era né la vostra, né quella della Contessa
 Beatrice.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Dunque di chi?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Era della Contessa Flamminia.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>E per qual ragione non è smontata?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Sarà stata invitata come noi; non ha trovato la
 dama in casa, e se ne sarà andata.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Ha fatto benissimo, andiamo anche noi.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Epure non è partita per questo.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Dunque perché?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Mentre voleva smontare, ha veduto venire la carrozza
 della Marchesa Ortensia, e per non essere obbligata a
 salutarla, ha ordinato al suo cocchiere tirar di lungo.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Se s'incontravano, a chi toccava di loro a
 salutare l'altra?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Toccava alla Marchesa, perché la Contessa era
 ferma, ed ella andava.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Ma la Marchesa Ortensia è qualche cosa di più
 della Contessa Flamminia. Siamo cugine di sangue.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Circa al sangue, la Contessa Flamminia non è punto
 inferiore; e imparentata anche colla mia casa.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Sentite un'altra carrozza.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Sarà la mia, sarà la mia.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Ne domanderò ai servitori <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Se viene la Contessa Flamminia vado via subito.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Non siete amiche?</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Non sapete, che cosa mi ha fatto?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Non lo so da donna d'onore.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>L'altro giorno, che eravamo alle nozze della
 Baronessa Lucrezia, mi passò dinanzi due volte senza nemmen
 salutarmi.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Ma per che causa?</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Ve lo dirò io perché. Ha collera con me, perché
 nell'ultimo festino, che abbiam fatto al casino, io ho
 ballato dodici minuetti, ed ella solamente otto.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Oh, in quanto a quella pazza si disgusta con tutte.
 Una volta è stata un mese senza guardarmi in viso, perché
 nel giorno, che ella si è messo un abito nuovo, io ne ho
 rinnovato uno più bello del suo. Ecco la Contessa Beatrice.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Eccola, eccola la Contessa senza creanza.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Non ne ha mai avuta, e non ne avrà mai.</p>
           </sp>
@@ -2766,340 +2812,340 @@ rinnovato uno più bello del suo. Ecco la Contessa Beatrice.</p>
             <emph>La contessa Beatrice servita dal conte Lelio, Rosaura dal
 conte Onofrio, il conte Ottavio, e dette.</emph>
           </stage>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Vi dimando scusa, se vi ho fatto aspettare <emph>(ad Eleonora ed a Clarice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Niente, Contessina mia, niente <emph>(a Beatrice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>In verità, aveva del rammarico per causa vostra
 <emph>(come sopra)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Voi siete piena di gentilezza; abbiamo aspettato
 pochissimo <emph>(a Beatrice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Chi è questa dama? <emph>(a Beatrice accennando Rosaura)</emph></p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Una vostra umilissima serva <emph>(inchinandosi ad Eleonora)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Appunto, io desiderava di farla conoscere a voi
 due, che siete le più compite dame della nostra
 conversazione <emph>(ad Eleonora ed a Clarice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Per parte mia vi sono molto tenuta, dandomi questo
 vantaggio.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Io pure mi chiamerò fortunata per questo felice
 incontro.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Sediamo, se vi contentate. Chi è là? Da sedere <emph>(i servidori portano le sedie)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>(Io non so qual abbia ad essere il mio posto) <emph>(da sé)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Contessa Beatrice, fateci il piacere, ponete a
 sedere quella dama vicino a noi.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Ecco il suo posto. In mezzo.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Signora donna Rosaura compiacete quelle due dame.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Per obbedirle anderò <emph>(s'incammina, poi siede in mezzo alle due dame suddette)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>(Avete sentito? Le ha detto: signora donna
 Rosaura; non è titolata) <emph>(a Clarice, piano)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>(Non importa, basta che sia nobile) <emph>(ad Eleonora)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(Dimmi, è stata portata certa cioccolata?) <emph>(ad un servitore, piano)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>(Illustrissima sì).</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(Presto corri a farne tre chicchere).</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>(Subito; già l'acqua è calda) <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Conte Ottavio, accomodatevi lì presso la Contessa
 Clarice.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Obbedisco <emph>(vuol sedere presso Clarice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Si obbediscono volentieri questi dolci comandi
 <emph>(con ironia ad Ottavio)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>I comandi della Contessa Beatrice sono da me in ogni
 tempo stimati.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Ma specialmente adesso, che vi fanno sedere vicino
 a una bella dama <emph>(accennando Clarice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Ah, ah; ora vi ho inteso. Conte Ottavio, questo non
 è il luogo vostro.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Ma qual è il mio luogo?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Cercatelo; questo assolutamente non è.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Io non credeva di meritarmi di essere discacciato
 <emph>(si alza, e parte di là)</emph>. Sarà più discreta a soffrirmi la
 Contessa Eleonora <emph>(va a sedere presso Eleonora)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Io non servo per ripiego a nessuno <emph>(si alza, e gli volta la schiena)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Fermatevi.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Andate dove siete stato sinora.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Signora Contessa Beatrice, in casa vostra decidete
 voi.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>In casa mia non comando, quando vi sono delle
 dame, alle quali per debito, e per rispetto devo cedere
 tutta l'autorità.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Sicché dunque me ne posso andare.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>(Conte Ottavio, sentite una parola: frattanto che
 queste pazze puntigliose taroccano fra di loro, volete venir
 con me in cucina a mangiar quattro polpette?) <emph>(ad Ottavio, piano)</emph></p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>(Vi ringrazio, per ora non ho appetito) <emph>(ad Onofrio)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Conte Lelio, venite qui.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Dove comanda la Contessa Beatrice.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Sì, sì, sedete presso di lei, ch'io sederò qui
 vicino a voi.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Posso aver l'onore di sedervi appresso? <emph>(a Beatrice)</emph></p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Siete padrone, se queste dame non s'oppongono.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Oh siete pur buona! Accettarlo voi, quando lo
 hanno rifiutato l'altre!</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Dice il proverbio, che i bocconi rifiutati sono i
 migliori.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Sì, sì, tanto più ch'è un boccon grosso.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>E voi siete un bocconcino... <emph>(verso Eleonora)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Via tacete <emph>(ad Ottavio con imperio)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Ma se due dame...</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Basta così, non dite altro <emph>(col medesimo tuono)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Contessa Beatrice...</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Via, quando lo dicono, tacete.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>(Ecco qui. Le donne sono tutte puntigli, e noi
 abbiamo da soffrire senza parlare) <emph>(da sé)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Io sederò presso di voi, se vi contentate <emph>(a Clarice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Mi fate onore.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Contessa Beatrice, favorite dirci, chi è questa
 dama.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>È una signora di Castell'a Mare.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Ehi! di Castell'a Mare! <emph>(guardando Clarice)</emph></p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Castellana! <emph>(guardando Eleonora)</emph></p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Principiano ad arruffare il naso) <emph>(piano a Beatrice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>(Contessa, siete in un brutto impegno) <emph>(piano a Beatrice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>La nostra signora donna Rosaura, è piena di
 merito. Oltre le ricchezze non ordinarie della sua casa,
 possiede poi molto spirito, e molta virtù.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>È ricca? Me ne rallegro <emph>(deridendola)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>È virtuosa? Brava <emph>(fa lo stesso)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Io non sono né ricca, né virtuosa; ma quello, di cui
 mi pregio, è di essere vostra umilissima serva.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Obbligatissima, ah, ah, ah <emph>(ride, guardando Clarice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>La ringrazio, ah, ah, ah <emph>(ride, guardando Eleonora)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>(Come! Mi deridono? E la Contessa Beatrice non
 parla?) <emph>(da sé)</emph></p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Prevedo, che voglia nascere qualche brutta scena)
 <emph>(piano a Beatrice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>(Le avete scelte dal mazzo queste due signore)
 <emph>(piano alla detta)</emph>.
 <emph>(Servitori con tre cioccolate)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Ecco la cioccolata per chi non l'ha bevuta. Noi
 l'abbiamo presa <emph>(i servitori la portano ad Eleonora)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Non ne voglio <emph>(i servitori la presentano a Clarice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>L'ho bevuta.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Non la volete? La beverò io <emph>(ne prende una chicchera. Servitore va da Ottavio)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Obbligato. L'ho presa.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Questa signora ha molta stima per le dame
 palermitane; ed è venuta apposta a Palermo per conoscerne
@@ -3107,11 +3153,11 @@ alcuna delle più cortesi, e poter poi rappresentare al di
 lei paese con quanta urbanità, e pulitezza si trattino da
 noi le persone di merito come lei.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>La signora Contessa Beatrice mi fa troppo onore.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Infatti presso le persone del secondo ordine passa
 la nostra nobiltà per austera, e troppo sostenuta; non è mal
@@ -3120,137 +3166,137 @@ ringraziare la signora donna Rosaura, che ci abbia offerta
 l'occasione di far conoscere al mondo, che sappiamo
 distinguere il merito in ogni rango, e in ogni carattere.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Sentimenti propri d'un Cavalier generoso.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Mi pare, che il signor don Florindo abbia
 tralasciato di negoziare <emph>(a Rosaura)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Sì signore. Sono più di tre mesi.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>E poi, una bella donna si ammette per tutto.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Quel giovine, guardate se è venuta la mia carrozza
 <emph>(ad un servitore, e s'alza)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Contessa, è tardi, bisogna ch'io vada <emph>(a Beatrice, e tutti s'alzano)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>(Ho inteso. Queste dame non mi vogliono; ma la
 Contessa Beatrice me ne renderà conto) <emph>(da sé)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(Cara amica, vi prego, fatemi questa finezza,
 dissimulate qualche poco. Soffrite per amor mio. Se sapeste
 in qual impegno mi trovo, mi compatireste) <emph>(va vicino a Clarice, e le parla piano)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>(Vi pare una cosa ben fatta? Mettermi a sedere
 vicino ad una mercantessa?) <emph>(a Beatrice, piano)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Cara signora Contessa non fate questo dispiacere
 alla Contessa Beatrice, non le fate un affronto di questa
 sorta) <emph>(ad Eleonora, piano)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>(L'affronto l'ha fatto a me, invitandomi a questa
 bella conversazione) <emph>(a Lelio, piano)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(È una giovane propria, e civile, mi è stata
 raccomandata da un ministro della corte. Ella ha
 dell'altissime protezioni. Credetemi, che questa cosa vuol
 esser la mia rovina) <emph>(a Clarice, piano)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>(Se fossi sola, non m'importerebbe, ma ho riguardo
 per la Contessa Eleonora. La conoscete; sapete chi è. Una
 ciarliera, che lo direbbe per tutto. Fate ch'ella se ne
 vada, e vedrete se le farò delle cortesie) <emph>(piano a Beatrice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Finalmente non è una plebea; è una signora ricca,
 onesta, e civile; possibile che abbiate cuore di
 mortificarla così?) <emph>(piano ad Eleonora)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>(A casa mia, o a casa sua non averei difficoltà di
 trattarla, ma qui dove vi sono due altre dame, guardimi il
 Cielo) <emph>(piano a Lelio)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Illustrissima, la carrozza non è venuta <emph>(a Clarice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Grand'asino quel cocchiere! Non la finisce mai.
 Contessa Eleonora, se volete andare, non restate per me,
 ch'io aspetterò la carrozza.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Dunque anderò io. Amica, compatitemi, non posso
 più trattenermi <emph>(a Beatrice)</emph>. Signora Rosaura, vi
 riverisco <emph>(sostenuta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Serva sua <emph>(mortificata)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>(Povera ragazza, mi fa compassione) <emph>(a Lelio)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Volete, che andiamo a casa sua a consolarla?)</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>(Se credessi, che non si sapesse, lo farei
 volentieri).</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Oggi ci parleremo) <emph>(ad Eleonora)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Conte Ottavio, andiamo <emph>(gli dà la mano)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Sono a' vostri comandi. Vedete, se anche voi, vi
 degnate del boccon rifiutato? <emph>(ad Eleonora, dandole mano)</emph></p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Signor no, non mi degno. Non ho bisogno di voi
 <emph>(parte scacciando da sé Ottavio)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Che maladetti puntigli! Non si sa come vivere, non
 si sa nemmeno come parlare. Tutto prendono in mala parte;
@@ -3264,13 +3310,13 @@ delle donne fanno impazzire i poveri uomini <emph>(parte)</emph>.</p>
             <emph>La contessa Beatrice, la contessa Clarice, Donna Rosaura,
 il conte Onofrio, il conte Lelio.</emph>
           </stage>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>La carrozza della signora Contessa Clarice non è
 ancora venuta, onde per non farla maggiormente arrossire
 colla mia conversazione anderò via, se mi date licenza <emph>(a Beatrice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Oh cara donna Rosaura, che dite? Voi avete preso in
 sinistra parte le mie parole. Godo infinitamente della
@@ -3279,157 +3325,157 @@ per altro vi pregherei lasciarvi servire nella mia carrozza,
 e vi condurrei per Palermo, senza alcuna difficoltà. (Il
 dirlo non mi costa niente) <emph>(da sé)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Mi sorprende questa vostra inaspettata
 dichiarazione, la quale non corrisponde certamente al
 trattamento, che ho ricevuto fin ora da voi e dalla Contessa
 Eleonora.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Oh, in quanto a quella pazza di Eleonora, non
 occorre abbadarvi. Ella è sempre così. Anzi mi sarò burlata
 delle sue caricature, e voi avrete creduto, ch'io ridessi di
 voi. Me ne dispiace infinitamente.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Che femmine accorte! Che femmine maliziose!).</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>(Che dite amica, vi do piacere?) <emph>(piano a Beatrice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(Vi sarò eternamente obbligata). Posso
 assicurarvi, signora donna Rosaura, che la Contessa Clarice
 è piena di buon cuore, e non è né superba, né puntigliosa.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Guardimi il Cielo. Voglio bene a tutti. Tratto bene
 con tutti, e non fo male creanze a nessuno. Anzi, per farvi
 vedere, che fo stima di voi, oggi verrò a visitarvi <emph>(a Rosaura)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Sarò infinitamente obbligata alle vostre finezze.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(Cara amica, quanto vi sono tenuta) <emph>(piano a Clarice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>(Lo fo unicamente per voi) <emph>(piano a Beatrice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Ditemi, fate mai venir del salvaggiume dal vostro
 paese? <emph>(a Rosaura)</emph></p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Sì signore; spessissimo. Anzi ieri sera mi hanno
 mandato delle starne.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Oh buone!</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Due fagiani.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Oh cari!</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>E due cotorni.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Oh vita mia!</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Se volete venir questa sera a favorirmi, li
 mangieremo insieme.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Sì, vengo, vengo. Quando si tratta di salvaggiume,
 non mi fo pregare.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Se queste dame si degnassero, lo riceverei per
 onore.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Non ricuserei le vostre grazie, ma non so, se la
 Contessa Clarice vorrà venire all'albergo.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Cara Contessa Beatrice, queste cose non si dicono
 nemmeno.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Facciamo una cosa. Mandate qui, e si cenerà qui da
 noi <emph>(a Rosaura)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Questo sarà per voi troppo incomodo.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Niente affatto. Staremo meglio, e con libertà.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>E la signora Contessa Clarice ci sarà?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>In casa mia, spererei non dicesse di no.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Quando non vi sia soggezione, verrò volentieri.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>A tavola non ha da venir altri: siamo anche troppi.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>Illustrissima, è qui la sua carrozza <emph>(a Clarice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Contessa, a rivederci <emph>(a Beatrice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Ricordatevi che vi aspettiamo.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Verrò senz'altro.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Spero di godere anticipatamente le vostre grazie <emph>(a Clarice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Oggi sarò da voi. (Vi andrò presto, in ora, che
 probabilmente non sarò veduta da alcuna dama) <emph>(parte)</emph>.</p>
@@ -3441,83 +3487,83 @@ probabilmente non sarò veduta da alcuna dama) <emph>(parte)</emph>.</p>
             <emph>La contessa Beatrice, Donna Rosaura, il conte Lelio, ed il
 conte Onofrio.</emph>
           </stage>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Questa sera, se la signora Beatrice l'accorda, si
 potrebbe anche fare una piccola festa di ballo.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Perché no? Che dite, signora donna Rosaura?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Io mi rimetto.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>(Amico, la cera costa cara) <emph>(piano a Lelio)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(La signora Rosaura ne ha portato due casse).</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Bene, via, faremo la festa da ballo.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Signora Contessa, potete per il ballo invitare
 qualche altra dama <emph>(a Beatrice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Per il ballo sì, ma per la cena no.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Non vorrei mi nascesse qualche altro sconcerto.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>In casa vostra, potete far ballare chi volete.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Per la mia cara Rosaura, farò di tutto.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Vi sono molto obbligata. Permettetemi, ch'io torni a
 casa. Mio marito non si è veduto, e mi aspetterà.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Son qui, vi servirò io.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Riceverò le grazie del signor Conte Onofrio. A
 rivederci questa sera <emph>(a Beatrice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Ehi! Non mi aspettate a pranzo, che non vengo <emph>(a Beatrice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>E dove andate?</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Resto colla signora donna Rosaura.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Ma non so, se questa mattina vi sarà salvaggiume.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Non importa. So che avete un bravo cuoco. Ci sarà
 qualche buona zuppa <emph>(parte con Rosaura)</emph>.</p>
@@ -3528,70 +3574,70 @@ qualche buona zuppa <emph>(parte con Rosaura)</emph>.</p>
           <stage>
             <emph>La contessa Beatrice, ed il conte Lelio.</emph>
           </stage>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>E voi, Conte Lelio, potete restare a pranzo con
 me.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Riceverò le vostre grazie.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Non vi sarà la tavola della signora Rosaura.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Vi sarete voi, e tanto basta.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Che ne dite di quelle due dame?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Dico, che vi è più fumo, che arrosto.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Ma sono nell'impegno, voglio spuntarla.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Se non altro, in grazia della scommessa di cento
 doppie.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Ecco qui, subito un rimprovero delle cento doppie.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Siamo tra noi.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Siete incivile. Non si mortificano le dame così.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Ma se nessuno ci sente.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Vi sento io, e tanto basta.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Via, compatitemi. Andiamo a pranzo.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Andate al diavolo. Io non pranzo con gente, che
 non sa trattar colle dame <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Ecco, che cosa si avanza colle donne. Sempre
 puntigli, sempre puntigli! Per buone, per umili, per
@@ -3608,53 +3654,53 @@ puntigliosissime.</p>
           <stage>
             <emph>Don Florindo, Pantalone, e Brighella.</emph>
           </stage>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Subito, Brighella, ma subito, subito, senza perder
 tempo, va' alla posta, fa' attaccare al mio carrozzino
 quattro cavalli, e fa' che il postiglione venga qui col
 legno immediatamente.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Ma volela partir subito? Senza disnar?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Non cercar di più, fa' quello, che ti ordino, e
 torna colla risposta.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Vado senz'altro. (Oh che matti! Oh che matti!
 Qualche volta i troppi bezzi i fa dar volta al cervello)
 <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Donca, la vol andar via?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Quando ritorna a casa la mia signora consorte,
 voglio che trovi il carrozzino pronto, e che ritorni meco a
 Castell'a Mare.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ma perché sta resoluzion repentina?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Non voglio soggiacere a maggiori affronti. Ne ho
 sofferti abbastanza.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ma, la me perdona, l'esser pontiglioso xè proprio
 delle donne; vorla esser pontiglioso anca ela?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Il mio risentimento non può chiamarsi puntiglio,
 mentre, come voi m'insegnate, il puntiglio non è, che una
@@ -3662,30 +3708,30 @@ pretensione, o ridicola, o ingiusta, o eccedente. Ma io non
 ho, che a dolermi del trattamento, che qui ricevo, e voglio
 assolutamente partire.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Se la se fusse degnada de accettar le mie
 esibizion, no ghe sarabe successo sti inconvenienti.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Dite bene; quella pazza di mia moglie, col
 fanatismo della nobiltà in capo, mi vuole esposto agli
 scherni, e alle derisioni.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>E ela la xè tanto debole de lassarse guidar da una
 donna? Da una donna, che gh'à sta sorte de pregiudizi in
 testa? Da una donna, che va cercando el precipizio della so
 casa?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Io sono uomo di bon cuore. Amo mia moglie, e cerco
 di compiacerla.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Amar la muggier xè una cossa bona, ma no bisogna
 amarla a costo della propria rovina. L'amor bisogna
@@ -3704,29 +3750,29 @@ commanda, la vol, la pretende, e el pover'omo xè obbligà a
 accordarghe per forza quello, che troppo facilmente el gh'à
 accordà per amor.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Sentite, signor Pantalone, è vero, che amo
 teneramente mia moglie, come vi ho detto, ma se devo dirvi
 la verità, non è stato l'amore, che ho per lei, che mi abbia
 unicamente indotto a venir a Palermo.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Xèla vegnua per negozi? La podeva vegnir senza
 muggier; perché no va per el mondo a negoziar colla muggier
 altro che quelli, che fa marcanzia de lumaghe.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Io non intendo questa vostra frase.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ho gusto, che no la l'intenda, perché la xè una
 barzeletta, che m'è scampada senza che me ne accorza.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Veramente vi sono venuto più per impegno, che per
 volontà. Quasi tutti i mercanti del nostro rango, prendendo
@@ -3735,7 +3781,7 @@ una specie di obbligo di far un viaggio con essa, di
 condurla in qualche città capitale, per darle divertimento,
 e per far quello, che fanno gli altri.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Questa xè la più forte rason de tutte. Per far
 quel, che fa i altri; andar in malora per complimento, farse
@@ -3757,97 +3803,97 @@ cattivi le finisse presto con rossor de quei medesimi che le
 fa, e le lode de i boni le dà credito, le consola, e le
 stabilisse la quiete dell'omo savio, e da ben.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Voi dite bene, signor Pantalone; ma se sapeste che
 cosa vuol dire aver una moglie d'intorno, che non s'acquieta
 mai, forse, forse compatireste anche me.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Mi, per grazia del cielo, non ho avù de sta sorte
 de rompimenti de testa, perché no m'ho mai volesto maridar;
 ma me par, che se fusse stà maridà, m'averave volesto
 inzegnar de far a mio modo.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ma, come avreste fatto?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Con una somma facilità, senza andar in colera.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Per amor del Cielo, ditemi, come avreste fatto?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>L'averia lassada dir, senza responderghe, e senza
 abbadarghe.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>E se tutto il giorno vi fosse stata intorno a
 tormentarvi?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Averia procurà de star con ela manco, che fosse
 possibile; saria stà in tel mio mezzà, a tender a i mi
 negozi.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>E se a tavola non avesse fatto altro che
 rimproverarvi?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Quattro bocconi in pressa, e via.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>E se a letto non vi avesse lasciato dormire, per
 tenzonare, e gridare?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Saria andà a dormir in t'un'altra camera.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>E se vi fosse venuta dietro per tutto a strillare,
 a mortificarvi?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>L'averia bastonada <emph>(con impazienza)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Bastonare una donna civile?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Bastonarla in una camera serrada, che nissun
 savesse gnente, per salvar el decoro; ma bastonarla.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>E poi?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>E po, la sarave vegnua via umile, umile come un
 agneletto.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Dunque mi consigliereste bastonare mia moglie?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>No digo sta cossa. No son capace de darghe sta
 sorte de conseggi. Ma una cossa ghe avverto, e po vago via.
@@ -3865,7 +3911,7 @@ brazzi per gramolar. Sior don Florindo, a bon reverirla
           <stage>
             <emph>Don Florindo, poi Arlecchino.</emph>
           </stage>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Veramente il signor Pantalone dice bene. Son uomo,
 sono marito, tocca a me a comandare. Mia moglie dovrà
@@ -3874,65 +3920,65 @@ saprò farmi stimare. Non dico di bastonarla, perché ella
 forse bastonerebbe me; ma troverò il modo di ridurla senza
 strepito, e senza violenza. Ehi, moro, dove sei?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Comandar, patron.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Hai finito di spazzare i miei panni? Sono
 all'ordine per riporli?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Mi aver fatto tutto.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Presto dunque, riponi ogni cosa in quei bauli, che
 or ora abbiamo a partire.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Come! Partir avanti magnar?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Si mangerà per viaggio.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Ah patron, se mi andar viaggio senza magnar, cascar
 morto in mezzo de strada.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Via, mangerai qualche cosa prima di partire.
 Sbrigati, e termina que' bauli.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Dove star maledetto Brighella?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Brighella è andato fuori di casa d'ordine mio.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>E mi far tutto? Ma se mi fadigar come aseno, seguro
 voler magnar come porco, patron <emph>(va, e torna con un abito da uomo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Oh come vuol arrivar nuova a mia moglie questa mia
 risoluzione!</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Patron, sentir carrozza; vegnir patrona <emph>(con l'abito)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Presto, presto, termina il baule, e s'ella
 t'ordinasse diversamente, seguita a fare il fatto tuo.
@@ -3940,16 +3986,16 @@ Dille, ch'io te l'ho comandato, che sei in necessità
 d'obbedirmi, e avverti bene, che se non eseguirai i miei
 ordini, ti caricherò ben bene di bastonate.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Per so grazia, no per mio merito.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Voglio terminar di vestirmi, per essere pronto a
 partire <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p><emph>(mette l'abito nel baule, se ne va a prendere un altro da donna, e mentre va per riporlo, incontra quelli che vengono)</emph>.</p>
           </sp>
@@ -3959,89 +4005,89 @@ partire <emph>(parte)</emph>.</p>
           <stage>
             <emph>Donna Rosaura, il conte Onofrio, e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Che cosa fai? <emph>(ad Arlecchino)</emph></p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Metter in baula.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Ma perché?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Patron commandar.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Non istanno bene gli abiti nel guardaroba?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>No star ben roba Palermo, se patron andar per viazo.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Come? Il padrone in viaggio?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Andar Castella Mar subito senza disnar.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>(Oh questa ci vorrebbe!) <emph>(da sé)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>E se egli vuoi andarsene, per che causa ha da portar
 seco la roba mia?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Andar patron, andar patrona, e anca povera moretta
 senza disnar.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>(Peggio) <emph>(da sé)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>È impazzito mio marito?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>No saver altro: mi metter in baula.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Porta via quell'abito; ponilo dov'era.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Oh no poder.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Portalo dico, che è roba mia.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>No certo, mi no lassar.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Se non lo porti, l'averai a far meco.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Se no metter baula, aver da far con patrugna.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>O portalo dov'era, o con questo bastone te lo farò
 portar io <emph>(prende il bastone di mano al Conte)</emph>.</p>
@@ -4052,128 +4098,128 @@ portar io <emph>(prende il bastone di mano al Conte)</emph>.</p>
           <stage>
             <emph>Florindo con bastone, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>O metti quell'abito nel baule, o ti rompo le
 braccia <emph>(ad Arlecchino)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>(Star fresca, star fresca) <emph>(da sé)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Che intenzione avete, signor consorte?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Che andiamo immediatamente a casa nostra.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Senza desinare?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Come? Perché?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Or ora verrà il postiglione col carrozzino
 attaccato.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>L'ho da saper ancor io. Porta via quell'abito <emph>(ad Arlecchino minacciandolo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Lascia lì quell'abito <emph>(al medesimo minacciandolo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>E perché vorreste fare una simile bestialità?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Perché degli affronti ne ho ricevuti abbastanza.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Niente per altro? Porta l'abito nel guardaroba <emph>(ad Arlecchino come sopra)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Metti l'abito nel baule <emph>(al medesimo, come sopra)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>(Star fresco, star fresco) <emph>(da sé con paura)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Amico, queste risoluzioni repentine, sono per lo
 più sconsigliate, e importune. Pensateci un poco. Fate una
 cosa; desinate, e frattanto avrete luogo a riflettere <emph>(a Florindo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Vi ho pensato tanto che basta. E voi signor Conte
 Onofrio, in questo non ci avete da entrare.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>C'entro, perché siete mio buon amico.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Se foste mio amico, non mi avreste piantato qui
 come un villano, obbligandomi a venire a piedi, quando voi
 andavate in carrozza.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Veramente mio marito non dice male, e se non avessi
 avuto riguardo alla Contessa Beatrice, non sarei nemmen io
 venuta nella vostra carrozza.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ho piacere che ancor voi comprendiate la verità <emph>(a Rosaura)</emph>. Metti quell'abito nel baule <emph>(ad Arlecchino come sopra)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Lascia stare. Portalo nel guardaroba <emph>(al medesimo, come sopra)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Io resto stordito di questa cosa. Non ci ho
 abbadato. Se mi dicevate qualche cosa, vi dava volentieri il
 mio posto, ed io sarei restato qui ad aspettarvi, e mi sarei
 divertito col vostro cuoco.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Sentite? Non l'ha fatto a malizia, non l'ha fatto
 per disprezzo, ma con inavvertenza. Vi domanda scusa, che
 cosa volete di più? <emph>(a don Florindo)</emph> Moro, va' via con
 quell'abito <emph>(ad Arlecchino)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Fermati <emph>(ad Arlecchino)</emph>. Ma che abbiamo da fare
 in Palermo? Che cosa possiamo sperare da queste dame?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Oh se sapeste, marito mio, quante cortesie ho
 ricevute, voi stupireste. Non è vero, Conte Onofrio?</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Verissimo.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Vi era la Contessa Eleonora; che galante dama! Vi
 era la Contessa Clarice; che dama compita! Mi hanno fatto
@@ -4183,71 +4229,71 @@ Stasera verranno tutte alla festa di ballo della Contessa
 Beatrice, staranno colà a cena, e noi balleremo e ceneremo
 con tutte le dame.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>E voi ci manderete il vostro salvaggiume, e il
 vostro cuoco <emph>(a Florindo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>(Tutto voglio, che mandiate. Tutto, anco la cera per
 il festino) <emph>(piano a Florindo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ma, come tutto in una volta, queste dame si sono
 mutate?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Basta che una dia principio, tutte le altre corrono
 dietro. Siamo obbligati alla Contessa Beatrice.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Porto, o metto? <emph>(a Florindo, e Rosaura)</emph></p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Vanne.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Fermati.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Se sapeste quanto ho operato per voi! Basta, ne
 parleremo con comodo. Non andate ancora a desinare?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Il Conte Onofrio, oggi favorisce di pranzar con noi.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Mi rincresce, che per la risoluzione di partire non
 ho fatto preparar nulla.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Oh! Cosa avete fatto? Dov'è il cuoco? <emph>(a Florindo)</emph></p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Sarà in cucina.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Presto, presto; cuoco, dove siete? Cuoco. Animo
 legne, carbone, in quattro salti facciamo tutto <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Presto; al cameriere, che trovi il bisogno
 <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Presto, la padrona di casa, che dia fuori la
 biancheria <emph>(parte)</emph>.</p>
@@ -4258,39 +4304,39 @@ biancheria <emph>(parte)</emph>.</p>
           <stage>
             <emph>Arlecchino, poi Brighella.</emph>
           </stage>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Oh, questa star bella. Cossa mo aver da far? Se star
 qua, no magnar; se metter robba baula, padrona bastonar; se
 portar guardaroba, padron romper brazza. Mi star imbroiada
 come pulesa in perucca tegnosa.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Dov'è el padron?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Brighella, star vegnuda a tempo.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Cossa voler?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Tegnir abita <emph>(gli dà l'abito)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Cossa aver da far?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Quel, che ti voler. Cusì mi no metter, mi no portar:
 né patron, né patrona mi bastonar <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Costù l'è un gran matto. Vado a avvisar el patron,
 che el carrozzin l'è pronto <emph>(parte)</emph>.</p>
@@ -4302,7 +4348,7 @@ che el carrozzin l'è pronto <emph>(parte)</emph>.</p>
           <stage>
             <emph>Donna Rosaura sola.</emph>
           </stage>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Manco male, che mi è riuscito di acquietar mio
 marito. L'aveva fatta la risoluzione, e s'io non arrivava in
@@ -4326,115 +4372,115 @@ farei qualunque gran sagrifizio.</p>
           <stage>
             <emph>Brighella, e detta.</emph>
           </stage>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Lustrissima. Gh'è la siora Contessa Clarice in
 carrozza, che la manda l'imbassada per vegnirla a reverir,
 se la se contenta.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>È padrona. Chi ha mandato?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>El braccier.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Digli, ch'è padrona, e poi torna qui.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>A Castell'a Mar donca, no se va più.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>No, non si va per ora.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Se la sentisse, cossa che dise el postiglion.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Bene, che cosa dice?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>El dise robba del diavolo. El canta de musica come
 un sopran (e mi sotto ghe fazzo el basso) <emph>(da sé; parte, e poi torna)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Si vede, che la Contessa Clarice fa stima di me,
 manda a farmi l'ambasciata per il bracciere, e non per lo
 staffiere.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Ghe l'ho dito <emph>(torna)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Presto, prepara le seggiole.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Subito <emph>(tira innanzi due seggiole della camera)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>No, no, va' in sala, prendi una sedia grande coi
 bracciuoli.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>La servo <emph>(va, e torna con un seggiolone antico, e pesante)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Ho imparato come si fa. Non mi fo più burlare.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Eccola qua, la pesa, che l'ammazza.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Metti lì <emph>(gli addita il luogo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Dove? Qua?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>No, un poco più là.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Qua, come el trono.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>E qui la mia <emph>(in distanza dell'altra)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>E qua la sua.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Vanne, vanne, che vien la Contessa. Alza la
 portiera.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>(Figureve cosa, che l'ha da far al so paese. L'ha
 da far smattir tutta la servitù) <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Voglio incontrarla sulla porta.</p>
           </sp>
@@ -4444,289 +4490,289 @@ da far smattir tutta la servitù) <emph>(parte)</emph>.</p>
           <stage>
             <emph>Clarice, e Rosaura, poi Brighella.</emph>
           </stage>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Riverisco la signora donna Rosaura.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Serva della signora Contessa.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Vedete, se vi voglio bene, se vi sono venuta a
 vedere?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Onor, ch'io non merito; grazia, ch'io ricevo col più
 rispettoso sentimento del cuore.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Avete desinato?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Signora no, non ho desinato. Ho bevuto la
 cioccolata, e mi riserbo a cenar questa sera dalla Contessa
 Beatrice. Vi supplico accomodarvi.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Perché mi volete mettere in sedia d'appoggio?
 Questa è sufficiente <emph>(accenna l'altra, che Rosaura teneva per sé)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Di grazia fatemi quest'onore. Quella è la vostra
 sedia, e quello è il vostro luogo.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Ma se non m'importa.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Ma se vi prego di questa grazia.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>(Che ridicola affettazione!) Per compiacervi,
 sederò dove volete <emph>(si prova a mettersi a sedere, ma col guardinfante non v'entra a cagion de' bracci del seggiolone)</emph>. Signora donna Rosaura, non sono in grado di
 ricevere le vostre finezze.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Perché, signora Contessa?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Non vedete? I bracci di questa sedia son tanto
 stretti, che il guardinfante non ci capisce.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>(È vero; non so trovare il ripiego). Mi dispiace,
 che in questo appartamento non vi sono altre sedie distinte.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>E a me non m'importa niente. Vi dico, che sederò
 qui <emph>(va a sedere sulla sedia, ch'era per Rosaura)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Siete padrona di servirvi come v'aggrada. Ehi!
 <emph>(chiama)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Lustrissima.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Senti. Con vostra licenza <emph>(a Clarice, poi parla nell'orecchio a Brighella)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Lustrissima sì <emph>(parte, e poi torna)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>E voi, signora, non sedete?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Or ora sederò, se mi date licenza.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p><emph>(viene con un piccolo panchettino, su cui Rosaura siede)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>(Oh che freddure, oh che caricature!) <emph>(da sé)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>(E viva i matti!) <emph>(parte, poi torna)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Nel vostro paese, che è porto di mare, e porto
 mercantile, vi saranno delle stoffe d'oro magnifiche, e di
 buon gusto?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Qualche volta ne vengono delle superbe. Ultimamente
 ne ho reso tre tagli per far tre abiti, che mi lusingo sieno
 qualche cosa di particolare.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Gli avete portati con voi?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Sì signora, con idea di farmi far gli abiti da un
 sarto palermitano.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Mi fareste il piacere di lasciarmi vedere queste
 stoffe?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Subito vi servo. Ehi! <emph>(chiama)</emph></p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Lustrissima.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Osserva in guardaroba, che vi sono quelle tre pezze
 di stoffa d'oro; portale qui, e portaci un picciolo
 tavolino.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>La servo subito (Sta' a veder, che la lustrissima
 vol far botteghetta). Volela anche el brazzolar?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Animo, sbrigati.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>(La vorrà guadagnar el viazo) <emph>(parte, poi torna)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Mi dispiace darvi quest'incomodo.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>È onor mio il potervi servire.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Vi prego d'una grazia, se vedete la Contessa
 Eleonora, non le dite nulla, ch'io sia stata qui da voi.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Sarete obbedita. Ma per qual motivo non volete, che
 mi glori d'aver ricevuto e vostre grazie?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Se sapesse, ch'io son venuta da voi senza dirlo a
 lei, lo avrebbe per male.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>È puntigliosa?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>E come! Basta dire, che un'altra volta si è
 disgustata con me per essermi vestita da estate, senza
 averla avvisata.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p><emph>(col tavolino, e le tre pezze di stoffa, poi parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Ecco quanto ho portato meco in tal proposito.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Questa è vaga, ma poco ricca.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Riesce meno pesante.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Questo è un colore, che non mi piace.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>È colore moderno.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Oh questa poi, mi piace infinitamente.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Veramente non può negarsi, che non sia di buon
 gusto.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Quante braccia sono?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Ventiquattro.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Il bisogno per un andrienne. Ditemi, ve ne
 privereste?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Veramente l'ho provveduta per mio uso, ma quando si
 tratta di servire la signora Contessa, non ho difficoltà di
 privarmene.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Vi ringrazio infinitamente. Quanto vi costa il
 braccio?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Quando vi degnate riceverla dalle mie mani, non
 avete da curarvi di saper quanto costi.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Oh, non sarà mai vero, ch'io la riceva senza, ch'io
 vi rimborsi del valore.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Non posso meritar questa grazia?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>No assolutamente.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Quand'è così, per obbedirvi, vi dirò, ch'ella mi
 costa tre zecchini il braccio.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Non è cara. In tutto quanto importa?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Il conto, io non lo so fare.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Aspettate lo farò io. Ventiquattro braccia, a tre
 zecchini il braccio. Tre volte ventiquattro. Venti e venti
@@ -4735,72 +4781,72 @@ quattro dodici; sessanta, e dodici quanto fa? Sessanta, e
 dieci settanta, e due settantadue. Importa settantadue
 zecchini.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>È verissimo. Settantadue zecchini.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Stasera vi porterò il danaro dalla Contessa
 Beatrice.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Siete padrona.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Che bella stoffa! Non si può far di più. Il disegno
 è vago a maraviglia, l'oro non può esser più bello. È un
 drappo che in Palermo non ho veduto il compagno.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Ho piacere, che la signora Contessa sia contenta.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Credetemi, che oltre il pagamento, mi avete fatto
 un gran regalo. Bisogna poi dirla, gran Parigi! In Italia,
 non sanno fare di queste stoffe.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Eppure, signora Contessa, assicuratevi, che questa
 stoffa è fatta in Italia.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>In Italia! Dove?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Io so di certo, ch'è stata fatta in Venezia.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Quando non è di Francia, compatitemi, non la
 voglio.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Ma s'è tanto bella; se non si può fare di più!</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Non importa; per esser bella deve esser di Francia.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Queste altre due pezze, sono di Francia, e non hanno
 che fare con questa.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Lo voleva dire, che queste due erano di Francia.
 Vedete che finezza d'oro?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Eh, signora Contessa, è l'oppinione che opera. In
 Italia sanno lavorare al pari di Francia, ma fra noi altre
@@ -4812,94 +4858,94 @@ sagrificando al maggior guadagno la propria estimazione, si
 scredita la povera Italia, per la falsa opinione
 degl'italiani medesimi.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Dite quel, che volete; ma io non porto stoffa, se
 non è forestiera.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Queste altre due sono forestiere.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Non mi piacciono.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Dunque?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Dunque scusate l'incomodo, che vi ho recato
 <emph>(s'alza)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Volete privarmi delle vostre grazie?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>In altro tempo goderò della vostra conversazione.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Questa sera, dalla Contessa Beatrice. Credo che vi
 sarà qualche poco di ballo.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Fa invito?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Non lo so. Voi siete attesa.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Verrò a vedere. (Mi daranno regola le circostanze).
 Signora donna Rosaura, vi riverisco <emph>(s'incammina per partire)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Serva divota <emph>(resta al suo posto)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>(Non fa grazia d'accompagnarmi nemmeno alla porta?)
 <emph>(da sé, e si ferma)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Signora, vi occorre qualche cosa?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Queste tappezzerie, l'avete portate voi?
 <emph>(camminando)</emph></p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Signora no <emph>(la seguita)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>In quest'altra camera qui, chi ci sta?
 <emph>(camminando)</emph></p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Vi è il guardaroba <emph>(la seguita)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Da questa porta si va in sala? <emph>(camminando sino alla porta)</emph></p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Signora sì <emph>(la segue sino alla porta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Basta così. Non occorr'altro <emph>(parte)</emph>.</p>
           </sp>
@@ -4909,7 +4955,7 @@ Signora donna Rosaura, vi riverisco <emph>(s'incammina per partire)</emph>.</p>
           <stage>
             <emph>Rosaura, poi Brighella.</emph>
           </stage>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Ora capisco. Si è voluta far accompagnare sino alla
 porta. Sin dove arriva il puntiglio! Ambisce di essere
@@ -4920,37 +4966,37 @@ una pubblica conversazione di dame, son contenta, ma se ciò
 non mi riesce, prima di partir da Palermo voglio lasciare
 qualche memoria di me.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Lustrissima, un'altra visita. L'è qua la signora
 Contessa Eleonora.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>La Contessa Eleonora? Che stravaganza è questa! E
 dov'è ella?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>In carrozza, che l'aspetta la risposta
 dell'ambassada.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Ha veduto la Contessa Clarice?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>L'è arrivada giusto in tempo, che la signora
 Contessa Clarice montava in carrozza. Le s'ha fermà tutte
 do, le ha fatto un atto d'amirazion, e po le s'ha parlà
 sotto vose, ma mi ho sentido tutto.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>E che cosa hanno detto?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Ha dito la signora Contessa Eleonora a
 quell'altra: che cosa fate qui? Responde la signora Contessa
@@ -4959,15 +5005,15 @@ ventiquattro braccia di stoffa d'oro. Brava! (ha dito la
 signora Contessa Eleonora); ed io vengo a comprare della
 tela d'Olanda.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Possibile, che abbiano parlato così?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Le ha dito cusì in coscienza mia.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>(Ecco il puntiglio! Una non vuol far credere
 all'altra d'aver della stima per me. Ma ancora mi convien
@@ -4976,12 +5022,12 @@ via questo tavolino con queste stoffe, acciò non dica, ch'io
 vendo la roba a braccio, e di' al bracciere, che venga pure,
 ch'è padrona.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>(Che bella cosa! Vegnir a Palermo a spender i so
 quattrini per farse burlar) <emph>(parte col tavolino, poi torna)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Parmi un sogno, che la Contessa Eleonora venga a
 casa mia, dopo la scena fatta in casa della Contessa
@@ -4991,50 +5037,50 @@ Ma siccome saprei far buon uso delle sue giustificazioni,
 così saprei anche rispondere alle sue impertinenze. E bene,
 dov'è la Contessa Eleonora? <emph>(vedendo ritornar Brighella)</emph></p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>No la s'incomoda, che l'è tornada indrio.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>È ritornata indietro? Perché?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Perché Vosustrissima ha fatto aspettar el braccier
 avanti da darghe la risposta.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Asinaccio, sei stato tu, che l'ha fatto aspettare.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Mi co la m'ha dito, che vada, son andà.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Dovevi andar subito.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Mo se la m'ha fatto dir...</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Presto, corri; raggiungi la carrozza della Contessa
 Eleonora; dille che il mancamento è provenuto da te, ch'io
 le domando scusa, e che la prego degnarsi di favorirmi.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Ma la carrozza la va a forte. La sarà lontana...</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Va' subito, che ti caschi la testa.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Mi son staffier, e no son el lacchè.</p>
           </sp>
@@ -5044,53 +5090,53 @@ le domando scusa, e che la prego degnarsi di favorirmi.</p>
           <stage>
             <emph>Donna Rosaura, poi il conte Onofrio, poi Don Florindo.</emph>
           </stage>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Questo disordine mi dispiace infinitamente. La
 Contessa Eleonora veniva a domandarmi scusa, e il diavolo ha
 fatto, che se n'è andata.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p><emph>(col tovagliuolo sulle spalle senza spada, mangiando)</emph> Animo, signora donna Rosaura, che la zuppa è in
 tavola.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Dispensatemi, che oggi non desino.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>No? Pazienza, mangeremo noi <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Ho altro in capo che mangiare. Mi sta sul cuore
 questo inconveniente colla signora Contessa Eleonora, spero
 per altro che si appagherà delle mie giustificazioni, e che
 ritornerà a visitarmi.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Perché, non volete venir a pranzo? <emph>(a Rosaura)</emph></p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Perché non ho volontà di mangiare.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Venite almeno per compagnia.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Lasciatemi in pace; non mi disturbate da vantaggio.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Vi è successo qualche inconveniente?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Mi è succeduto quello, che suol succedere, quando si
 tiene servitù in casa, che non sa il suo mestiere. Una dama
@@ -5098,16 +5144,16 @@ tiene servitù in casa, che non sa il suo mestiere. Una dama
 risposta al bracciere, e la dama si è chiamata offesa, ed è
 ritornata indietro.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Toccava a voi a mandar subito la risposta.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Ho spedito Brighella di volo dietro la carrozza per
 far le mie scuse colla Contessa.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Eccolo, che ritorna.</p>
           </sp>
@@ -5118,29 +5164,29 @@ far le mie scuse colla Contessa.</p>
             <emph>Brighella, e detti, poi il conte Onofrio, che torna come
 sopra.</emph>
           </stage>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Ohimè, non posso più <emph>(affannato)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Presto, che ha detto la Contessa Eleonora? Vuole
 tornare a vedermi?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>La me lassa chiappar fià. Ho corso come un daino,
 no posso più.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Sbrigati, asinaccio.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Via, abbiate un poco di carità <emph>(a Rosaura)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Son arrivado alla carrozza, e l'ho fatta fermar.
 Me son presentà alla dama, ho principià a parlar; l'ha
@@ -5149,140 +5195,140 @@ de parlar con un staffier; mi voleva seguitar a dir, e ela
 m'ha fatto dar dal cocchier una scuriada in tel muso, e l'è
 tirada de longo.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Va' via di qua <emph>(a Brighella con collera)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Subito la servo. (Questo l'è quel, che se guadagna
 a servir de sta sorte de matti) <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Un affronto al mio staffiere?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Vostro danno. Impacciatevi con gente par vostra.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>E voi ve la passate così placidamente?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>E che volete, ch'io faccia? La dama ha ragione.
 Quando le volevate far una scusa non conveniva mandare uno
 staffiere.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>E chi avevo da mandare, se voi avete licenziato il
 cameriere?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>L'ho licenziato stamattina, quando avevo risoluto
 di andarmene.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Florindo, venite, o non venite?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Caro signor Conte, compatitemi: ho sempre di questi
 maladetti imbarazzi.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Se non vuol venir ella, almeno venite voi.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Volete usare questa mala creanza al signor Conte?
 Non volete venire a tavola? <emph>(a Rosaura)</emph></p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Il signor Conte mi dispenserà.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Sì, vi dispenso. Anche voi Florindo, se volete
 restare, restate, basta ch'io lo sappia, del resto mangerò
 anche solo, quando si tratta di compiacervi.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Signor Conte, favorite mandarmi il moro.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Subito ve lo mando. (Oh che cappone! Ha tanto di
 lardo) <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Che cosa volete fare del moro?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Voglio mandarlo a far le mie scuse colla Contessa
 Eleonora.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Il moro? fareste peggio.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Il moro non è staffiere.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>È un servitore, è uno schiavo, e un buffone.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Dunque andateci voi.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Io non vi anderei, se mi deste mille zecchini.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Dunque vi anderò io.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>A buon viaggio.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>E se poi non mi ricevesse?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Lustrissima, el Conte Lelio.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Venga, venga, che viene a tempo.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>(Qua no se patisse de indigestion. Sempre in moto)
 <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Il Conte Lelio mi darà norma, come devo contenermi;
 andate a tener compagnia al Conte Onofrio.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Quando mai finiremo d'impazzire? <emph>(parte)</emph></p>
           </sp>
@@ -5292,134 +5338,134 @@ andate a tener compagnia al Conte Onofrio.</p>
           <stage>
             <emph>Donna Rosaura, ed il conte Lelio.</emph>
           </stage>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Conte Lelio, avete saputo la scena, che ha fatto la
 Contessa Eleonora?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>So tutto, e tutto è accomodato.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Dite davvero? Mi consolate.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Siccome la Contessa Eleonora si era ridotta a farvi
 una visita per le mie insinuazioni, così è venuta a cercare
 di me al casino, e mi ha detto, che l'avete fatta aspettare
 tre quarti d'ora.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Non è vero, nemmeno dieci minuti.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Basta; l'ho acquietata, l'ho persuasa a venire
 stasera dalla Contessa Beatrice, dove la vedrete, e potrete
 anche voi far le vostre scuse.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Caro Conte, quanto mai vi sono obbligata!</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Che non farei per meritarmi l'onore della vostra
 grazia?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>La mia grazia val troppo poco in paragone del vostro
 merito.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Con quanto garbo voi proferite quelle dolci parole!</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Volete sedere, Contino?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Riceverò le vostre grazie.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Ehi... <emph>(vuol chiamare il servo, e Lelio la trattiene)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Zitto. I vostri servitori mangiano. Povera gente
 lasciategli stare.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>E volete voi...</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Sì, vi servirò io. Quando sono con qualche bella
 signora, mai servitori <emph>(porta due sedie, e siedono)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Credete voi, Contino mio, che avrò questo piacere,
 di stare tutta una sera in una conversazione di dame?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Io ne son quasi certo, questa sera alla festa di
 ballo vi saranno parecchie dame.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Ma che cosa dicono di me?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Vi lodano infinitamente.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Mi lodano? Che dicono del mio discorso?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Piace a tutte universalmente.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Il mio modo di vestire incontra?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Assai.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Spero, che se mi vedranno ballare, faranno miglior
 concetto di me.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Eh, signora mia, il vostro discorso è elegante, il
 vostro portamento è grazioso, ma il vostro volto è
 adorabile.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Via, via; non ho desinato, e non volete ch'io ceni.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Voi state su gli scherzi, ed io languisco per voi.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Caro Conte, voi mi fate arrossire.</p>
           </sp>
@@ -5429,198 +5475,198 @@ adorabile.</p>
           <stage>
             <emph>La contessa Beatrice, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Conte Lelio, chi vi vuol ritrovare, ha da venire
 dalla signora donna Rosaura.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Ora sto fresco) <emph>(s'alzano)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Signora Contessa, voi qui?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Se vi do incomodo, vado via.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Se aveste favorito mandarmi l'ambasciata, sareste
 stata meglio ricevuta.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Già voi non vi sareste incomodata fuori della
 vostra camera.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>In casa mia non si fa cattivo trattamento a nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>E in casa mia si ricevono degli affronti per causa
 vostra.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Quand'è così, non ci verrò più.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Se non ci verrete, sarà vostro danno.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Signora Contessa, quanto volete scommettere, che non
 ci vengo più?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(Mi tocca sul vivo) <emph>(da sé)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Scommettiamo cento doppie, che non ci vengo più.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Ecco qui, per causa vostra tutte le mie fatiche,
 tutte le mie attenzioni saranno inutili, e la signora donna
 Rosaura invece di ringraziarmi, mi darà de' rimproveri <emph>(a Lelio)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Per causa mia?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Sì, per causa vostra. Avevo bisogno di voi, mi
 siete sparito dagli occhi senza che me n'avveda, e per
 ritrovarvi sono stata costretta a venir sin qui.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Ma se vengo dalla signora Rosaura, voi sapete il
 perché.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Vi adirate, perché è venuto da me? <emph>(a Beatrice)</emph></p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Non mi lagno, che sia venuto da voi, ma che lo
 abbia fatto senza dirmelo.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>È questa una colpa sì grande?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Colle dame non si tratta così.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>E un mancamento del signor Lelio vi obbliga a venire
 in casa mia senza avvisarmi?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Per dirvela, non mi prendo poi questa gran
 soggezione.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Certo, quando si va a visitare la balia, non si
 osservano le cerimonie.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Andiamo, signor Conte <emph>(sostenuta)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Buon viaggio a lei <emph>(con disprezzo, a Beatrice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Contessa, per amor del cielo, non precipitate
 l'affare. Se non andaste in collera, vi ricorderei la
 scommessa) <emph>(piano a Beatrice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Non sentite, che la signora Rosaura prende in mala
 parte tutte le mie parole? Ella è stanca della mia amicizia,
 ella ricompensa con ingratitudine l'amore, che ho concepito
 per lei.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Cara signora Contessa, non sono poi una donna di
 stucco.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Ma non vedete, che se sono venuta in casa vostra
 senza l'ambasciata è stata una confidenza, che mi son presa
 per l'amore, che vi porto?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Se aveste detto così alla prima, non averei
 replicato.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Via, se non l'ha detto prima, lo dice adesso. Vi
 basta? Siete contenta? <emph>(a Rosaura)</emph></p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Io sono contentissima.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Avete più collera colla signora donna Rosaura? <emph>(a Beatrice)</emph></p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Con lei non ho collera. Osservate <emph>(dà un bacio a Rosaura)</emph>. Ma con voi a tempo, e luogo mi sfogherò.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Cosa vi ho fatto?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Basta così. Signora donna Rosaura, questa sera vi
 aspetto. L'invito alle dame è corso. Spero, che resterete
 contenta.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Non diffido della vostra buona condotta.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Anderà tutto bene?) <emph>(a Beatrice, piano)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(Io faccio quel che posso, se non anderà bene, non
 so che farci) <emph>(a Lelio piano)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>A che ora si principierà il festino?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Presto, perché le notti son corte. Ma la sera si
 va avvicinando. Vado innanzi, e vi aspetto <emph>(a Rosaura)</emph>.</p>
@@ -5632,39 +5678,39 @@ va avvicinando. Vado innanzi, e vi aspetto <emph>(a Rosaura)</emph>.</p>
             <emph>Il conte Onofrio con la spada, il bastone e il cappello,
 tutto in mano, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Ehi, Contessa, aspettatemi <emph>(a Beatrice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Siete ancor qui? <emph>(ad Onofrio)</emph></p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Abbiamo finito di desinare in questo momento.
 Voglio venire in carrozza ancor io. Ho tanto mangiato, che
 non posso più stare in piedi.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Andiamo, andiamo <emph>(a Lelio)</emph>. Gran ghiottone!</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(È venuta a interromperci sul più bello).</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Oh che cappone! Oh che zuppa! Oh che ragù! Oh che
 fricassè. <emph>(a Rosaura)</emph></p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Mi dispiace, che questa sera non vi farete onore col
 salvaggiume.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Non mi farò onore? Vi farò stordire. Da qui a
 mezz'ora torno ad esser fresco, come la mattina a digiuno
@@ -5676,7 +5722,7 @@ mezz'ora torno ad esser fresco, come la mattina a digiuno
           <stage>
             <emph>Donna Rosaura sola.</emph>
           </stage>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Eppure si danno questi stomachi, che digeriscono
 tutto. Io non so come facciano. Così parimente vi sono di
@@ -5699,7 +5745,7 @@ prudenza, quando si prevede di dover cedere con dispiacere
             <emph>Il conte Ottavio, poi un Paggio della contessa Eleonora
 con viglietto.</emph>
           </stage>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Servir dama? Gran miseria al dì d'oggi! Sempre
 puntigli, sempre puntigli. L'uomo più flemmatico del mondo,
@@ -5707,21 +5753,21 @@ quando si mette a servire una donna, ha da perder la
 pazienza, voglia, o non voglia. Ecco un paggio della
 Contessa Eleonora.</p>
           </sp>
-          <sp>
+          <sp who="#paggio">
             <speaker>PAGGIO</speaker>
             <p>La mia padrona manda questo viglietto a V. S.
 illustrissima.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Che fa la vostra padrona?</p>
           </sp>
-          <sp>
+          <sp who="#paggio">
             <speaker>PAGGIO</speaker>
             <p>Sta alla tavoletta a correggere i difetti della
 natura <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Ma il difetto di essere puntigliosa non lo
 correggerà mai. Vediamo, che cosa contiene questo foglio. È
@@ -5753,46 +5799,46 @@ e di suo marito, forse qualche cosa saprà.</p>
           <stage>
             <emph>Pantalone, e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Riverisco il signor Pantalone.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Servitor devotissimo, sior Conte.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Ditemi in grazia, quant'è che non avete veduto il
 vostro amico, il signor don Florindo?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Da stamattina in qua.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Sapete che sia succeduto alcun disordine in casa
 sua?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Mi no so gente. So che l'aveva destinà de partir, e
 che l'averia fatto da omo a andar via; ma so, che quella
 cara zoggia de so muggier la l'ha tornà a voltar, e la l'ha
 fatto restar a Palermo.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Io dubito, che sua moglie voglia essere la sua
 rovina.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>No la saria una gran maraveggia, perché per el più
 le femmene, le xè la rovina delle fameggie.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Giacché voi siete amico di casa sua, voglio farvi
 una confidenza da uomo onesto. Sappiate che una dama si
@@ -5800,38 +5846,38 @@ chiama offesa dalla signora Rosaura; questa sera si vedranno
 a una festa di ballo, e non vorrei le succedesse qualche
 disgrazia.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Mi no so cossa dir. A sior don Florindo ghe voggio
 ben, e per elo faria de tutto; ma a casa soa son stà adesso,
 e nol ghe xè. Debotto xè notte, e mi no so dove andarlo a
 trovar: me sàla dir chi sia la dama offesa?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Ve la dirò in confidenza, ma non mi fate autore. È
 la Contessa Eleonora.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Stemo freschi. So che muschietto che la xè.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Lo so ancor io pur troppo.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>La me perdona, se parlo con libertà. La sa de che
 umor stravagante, che la xè, e la la serve con tanta
 attenzion?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Che volete ch'io faccia? Ho principiato a servirla;
 son nell'impegno, e non so come fare a staccarmi.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Gran cossa xè questa! I omeni i xè arrivai a un
 segno, che debotto no i gh'à de omo altro che el nome. Le
@@ -5852,12 +5898,12 @@ trionfa, e i omeni se reduse schiavi in caéna, idolatri
 della bellezza, profanatori del so decoro, e scandolo della
 zoventù.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Signor Pantalone, per dir il vero, le vostre massime
 sono ottime, la vostra morale è molto giusta.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Sàla quante volte, che ho fatto de ste lezion anca
 a sior don Florindo? Ma gnente, no i me ascolta. Onde xè
@@ -5868,7 +5914,7 @@ perché el gh'à una muggier fatta sul gusto delle donne
 moderne. Volubile in tel ben, e ustinata in tel mal
 <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Questi vecchi parlano bene, ma non si ascoltano.
 Conosco anch'io, che dice il vero, ma non trovo la via di
@@ -5885,18 +5931,18 @@ di cera, ed una accesa.</stage>
             <emph>Il conte Onofrio, e Servitori che accomodano le candele.
 Suonatori per la festa.</emph>
           </stage>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Basta così; la sala è bene illuminata. (Queste sei
 candele le cambierò collo speziale in tanto zucchero)
 <emph>(parte colle sei candele, poi torna)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#servitore">
             <speaker>SERVITORE</speaker>
             <p>(M'immagino, che all'ultimo si prenderà anche i
 moccoli) <emph>(da sé con rabbia)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Via, andate in cucina, preparate ogni cosa, che
 vogliono cenar presto. Vi raccomando quei cotornici. Dite al
@@ -5910,31 +5956,31 @@ alla settimana.</p>
             <emph>Brighella con un bacile di confettura sotto il tabarro, ed
 il conte ONOFRIO.</emph>
           </stage>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Con buona grazia de Vusustrissima.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Venite, galantuomo. Che cosa avete là sotto?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>La padrona la prega perdonar la confidenza, che la
 se tol. La gh'à sto poco de confettura; e la ghe la manda,
 la se ne servirà stasera alla festa da ballo.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Benissimo; ha fatto benissimo. Lasciate vedere
 <emph>(prende due, o tre manciate di confetti)</emph>. Andate,
 consegnate il bacile alla cameriera.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>(El gha dà la so castradina) <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Questi sono buoni per divertirsi, mentre ballano.</p>
           </sp>
@@ -5946,47 +5992,47 @@ consegnate il bacile alla cameriera.</p>
 ed uomini con sorbettiere, ed il conte ONOFRIO, poi la
 contessa Beatrice, ed il conte Lelio.</emph>
           </stage>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Poder vegnir?</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Venir, venir. Che cosa aver?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Portar acqua, per refrescar.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Lassar veder <emph>(prende due boccette, e se le beve)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Maledetto! E mai no crepar?</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Tegnir, andar <emph>(ripone le due boccette sulla guantiera)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Mi andar, e ti mandar <emph>(parte cogli uomini)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Quel vino di Canarie mi ha eccitato la sete.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Ecco le dame, che principiano a venire.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Io me ne vado; e vi aspetto a cena <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Sonatori, principiate la sinfonia <emph>(suonatori suonano)</emph>.</p>
           </sp>
@@ -6027,32 +6073,32 @@ arrestarle s'alza, e le seguita. Rosaura vedendo andar via
 la gente, prima di terminare il minuè, si rivolta a
 Beatrice, che va smaniando. I sonatori si fermano.</emph>
           </stage>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Come? A me un affronto di questa sorta? <emph>(a Beatrice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>L'affronto lo ricevo io, e lo ricevo per causa
 vostra.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Andiamo, andiamo, me ne farò render conto <emph>(a Rosaura)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Da chi ve ne farete render conto?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Da quello scrocco di vostro marito.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Sia maledetto, quando vi ho conosciuto.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Da una dama della vostra sorta, nulla potevo sperar
 di meglio <emph>(parte)</emph>.</p>
@@ -6064,51 +6110,51 @@ di meglio <emph>(parte)</emph>.</p>
             <emph>La contessa Beatrice, poi il conte LELIO, poi il conte
 Onofrio.</emph>
           </stage>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Un affronto alla mia casa? Come mai risarcirlo?
 Non si parlerà d'altro per i caffè. Sarò io la favola di
 Palermo.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Son partite. Non vi è stato rimedio di trattenerle.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>E dove sono andate?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Tutte in casa della Contessa Eleonora.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Voglio andarvi ancor io.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Non fate; vi rimedieremo.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Voglio andarvi per assoluto. Se non volete venir
 voi, non m'importa <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Vi servirò, se così volete.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Che cosa c'è? <emph>(a Lelio)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Perché la signora Rosaura ha ballato il primo
 minuè, tutte le dame, sono andate via <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Non vi è altro male? Quando è all'ordine la cena,
 io non aspetto nessuno <emph>(parte)</emph>.</p>
@@ -6123,103 +6169,103 @@ io non aspetto nessuno <emph>(parte)</emph>.</p>
           <stage>
             <emph>Donna Rosaura, e Don Florindo.</emph>
           </stage>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Tant'è, voglio sfidar alla spada, quel mangione del
 Conte Onofrio.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Quando lo volete sfidare?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Subito; domani mattina.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Mi parrebbe di commettere un'azione indegna, se
 restassi a Palermo sino a domani. Mandate subito a prendere
 il carrozzino; ordinate, che attacchino i quattro cavalli, e
 avanti che suoni la mezza notte usciamo da questa città.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>E mi persuadereste partire senza dimostrare
 dell'affronto ricevuto un qualche risentimento?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Questa è una cosa, alla quale tocca a pensare a me.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ci devo pensar io, che sono vostro marito.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>No, Florindo, fidatevi questa volta di me. Può
 essere, che mi riesca far le vostre vendette, senza
 sfoderare la spada.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Eh, che per fare a vostro modo, sinora ho fatto
 delle bestialità, non voglio, che mi meniate più per il
 naso.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Ora non vi domando di secondarmi per un capriccio,
 per un piacere, ma solamente vi chiedo, che siccome sono io
 stata la cagione di questo male, lasciate fare a me a
 procurare il rimedio.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ditemi che cosa avete intenzione di fare.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>No, non lo voglio dire. Bastivi sapere, che il
 pensiero è tutto mio, che la vendetta è sicura, e che
 mancherà il tempo di farla se inutilmente ci trattenghiamo.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Dunque che abbiamo a fare?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Mandate subito a ordinare il carrozzino con i
 quattro cavalli.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>E la roba?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>La roba si consegnerà al padron dell'albergo, e la
 manderà poi a Castell'a Mare.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Volete far uccidere qualcheduno?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Eh, pensate! La vendetta ha da essere senza sangue.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Io non vi so capire.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Sollecitate, e saprete la mia intenzione.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Brighella? <emph>(chiama)</emph>.</p>
           </sp>
@@ -6229,57 +6275,57 @@ manderà poi a Castell'a Mare.</p>
           <stage>
             <emph>Brighella e detti, poi Arlecchino.</emph>
           </stage>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Lustrissimo.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Va' subito alla posta, ordina nuovamente il
 carrozzino con i quattro cavalli, e di' al postiglione, che
 venga immediatamente, poiché voglio da qui a pochi momenti
 partire.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>A st'ora? Sàla, che sarà tre ore de notte?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>La porta si farà aprire. Va' subito; non tardare.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>(Oh, cosa che vol rider el postiglion!) <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Bravo, ora vedo che mi volete bene, e che vi fidate
 di me.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ma si può sapere che cosa abbiate intenzione di
 fare?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Or ora lo saprete. Moro? <emph>(chiama)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Commandar.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Ascolta bene ciò, che ti ordino, e bada di non
 fallare.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Mi star omo, mi no fallar.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Informati dove è il palazzo della Contessa Eleonora
 del Poggio. Introduciti bel bello nel primo ingresso, e
@@ -6287,33 +6333,33 @@ domanda a quei servitori, se colà vi sono ancora le dame,
 ch'erano al festino della Contessa Beatrice, e portami
 subito la risposta.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>No voler altro?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Questo, e non altro; mi preme subito.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>In do salti andar, e in quattro salti tornar.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Dunque le dame, che erano al festino, sono andate
 dalla Contessa Eleonora?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Così mi ha detto il cocchiere.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>E voi che pensate di fare dopo, che sarete di ciò
 assicurata?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Gran curiosità! Lo saprete da qui a poco tempo.</p>
           </sp>
@@ -6323,55 +6369,55 @@ assicurata?</p>
           <stage>
             <emph>Brighella, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Ho trovà el postiglion per strada. Gh'ò dà
 l'ordine, e adessadesso el sarà qua.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Presto; mettiamoci all'ordine.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Io monto in carrozzino tale, qual mi vedete.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Gh'è l'illustrissimo sio Conte Lelio, che li voria
 reverir.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Digli che non ci sono.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Sentiamo che cosa dice.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Non lo voglio ricevere.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Cosa gh'òio da dir?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Digli che non ci siamo, e se non lo crede, digli che
 io non lo voglio ricevere.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>La sarà servida <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Credete, che il Conte Lelio, abbia colpa
 nell'affronto che ci hanno fatto?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>O colpa, o non colpa, non voglio più nessuno di
 costoro d'intorno. Vado nella mia camera, e quando viene il
@@ -6383,27 +6429,27 @@ carrozzino, avvisatemi <emph>(parte)</emph>.</p>
           <stage>
             <emph>Don Florindo, poi Brighella.</emph>
           </stage>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ora conosce mia moglie la pazzia, che aveva nel
 capo; spero che ciò le servirà di regola, e per l'avvenire
 non darà in simili debolezze.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>L'è andà via.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Che cosa ha detto?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>El s'ha accorto benissimo, che no i l'ha volesto,
 e l'ha dito mastegando: "Questo è quello, che si avanza a
 usar finezze a questa sorta di gente".</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>A questa sorta di gente? Giuro al cielo! Mia moglie
 dice di vendicarsi, ma non so che cosa farà, e dubito di
@@ -6411,67 +6457,67 @@ qualche freddura; anch'io voglio cavarmi una soddisfazione.
 Senti, Brighella, so che sei uomo, e che farai con esattezza
 quanto ti ordino.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>La comanda pur, e la vederà, se so far.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Sei pratico di Palermo?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Ghe son stà tanti anni.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Sapresti ritrovarmi quattro bravi uomini, che
 fossero buoni da menar le mani?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Alla bettola se ne trova quanti se vol.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Tieni. Questi sono sei zecchini, trova quattro
 uomini, dà loro uno zecchino per uno, conducili al palazzo
 della Contessa Eleonora, e ordina ad essi, che bastonino
 tutti i servidori, che escono da quella casa.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>I servidori?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Sì, i servitori.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Che colpa gh'à i poveri servidori?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Questa è una vendetta, che ho veduta praticare da
 molti. Bastonar il servo per far un affronto al padrone.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Poverazzi! I me fa peccà.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Se lo fai, guadagni li due zecchini, che avanzano;
 se non lo fai, ti licenzio dal mio servizio.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Lo farò; ma confesso el vero, che me despiase,
 perché l'è un pan, che me pol esser reso anca a mi
 <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Almeno potrò vantarmi di aver fatto una qualche
 vendetta; si parlerà almeno di me con qualche stima, con
@@ -6483,15 +6529,15 @@ qualche rispetto.</p>
           <stage>
             <emph>Pantalone, e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Se pol vegnir? <emph>(di dentro)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Venite, venite, signor Pantalone.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>L'ho cercada per tutto a bonora, per dirghe una
 cossa de premura, e no l'ho trovada. Se l'avesse trovà in
@@ -6500,66 +6546,66 @@ che sento a dir, che sia nato. Com'è? Xè la verità, che gh'è
 stà fatto un affronto? Giera a casa, e i me lo xè vegnù a
 contar.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Pur troppo è la verità.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Se la me avesse badà a mi, no ghe saria successo
 sto inconveniente.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Causa mia moglie.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Causa el mario, e no la muggier. Col mario no
 segonda, la muggier no pol gnente.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Basta, avete fatto bene a venirmi a favorire,
 mentre aspetto il carrozzino, e subito parto.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>La farà come stamattina.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Non ci è pericolo.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>E la consorte cossa dìxela?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>È stata ella, che mi ha fatto risolvere a partir
 subito.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ah donca la va via per conseggio della muggier? Co
 la lo fa perché la muggier lo conseggia, anca sta volta la
 farà un sproposito.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Mi persuadereste voi, ch'io restassi a Palermo?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Sior sì, stamattina l'averia persuaso a andar via.
 Stassera ghe digo, che el doveria restar qua.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Da che nasce la varietà della vostra opinione?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Dalla varietà delle circostanze. Stamattina
 l'andava via avanti, che ghe fusse stà fatto sto affronto, e
@@ -6567,43 +6613,43 @@ la so partenza giera un atto de virtù, che prevegniva i
 disordini. Adesso, che l'affronto è seguìo, la so partenza
 xè un atto de viltà, che mazormente faria rider i so nemici.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Prima però di partire, daremo segni del nostro
 risentimento.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Come, cara ela?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Mia moglie ha in mente il disegno di vendicarsi a
 dovere, senza far strepito.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ecco qua: tutto la muggier. Mo cossa xèlo elo? La
 me perdona, un papagalo?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Io per la mia parte ho fatto quello che dovevo; e
 domani si saprà, che ho spirito per risarcire le offese
 fattemi.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Poderavela a un omo, che ghe vol ben come mi,
 confidar qual sia la so resoluzion?</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ho mandato quattr'uomini a bastonare i servitori di
 quelle Dame, e di quei Cavalieri, che al festino mi hanno
 fatto l'affronto.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Oh bella vendetta! Veramente eroica, e da omo de
 garbo! No me posso tegnir, bisogna che diga quel che sento,
@@ -6622,12 +6668,12 @@ che lusinga i omeni, e ghe dà da intender, che la vendetta
 più facile sia la più vera, e che per vendicarse del reo,
 sia lecito opprimer anca l'innocente.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ma dunque, signor Pantalone, che specie di vendetta
 mi consigliereste voi, che io facessi?</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Prima de tutto ghe dirò, che la vendetta non xè mai
 cossa lecita in nissun tempo, in nissun caso. Ma molto manco
@@ -6643,32 +6689,32 @@ osservanza, gh'à fatto un affronto, l'offesa no se pol dir
 prodotta da un'ingiustizia, ma più tosto cercada da chi l'ha
 recevuda.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Dunque, da quel che dite, io ho torto.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>La gh'à torto siguro, a pretender quel che no se
 ghe convien.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Il male l'ha fatto la Contessa Beatrice, la quale
 per cento doppie ha preso l'impegno d'introdurci nelle
 adunanze di nobiltà.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Benissimo, el so risentimento la lo revolta contro
 la Contessa Beatrice.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Per questo, voleva sfidare alla spada il Conte
 Onofrio suo marito.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Coss'è sta spada? Coss'è sta spada? Anca ela xè de
 quei che crede, che un duello possa resarcir ogni offesa?
@@ -6687,22 +6733,22 @@ la poderà dir: no son stà in pubblico colle Dame, e coi
 Cavalieri, ma le Dame, e i Cavalieri m'ha fatto delle
 onestà, e delle finezze in privato.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Questa è una cosa, che mi piace infinitamente; ma
 non so che cosa avrà risoluto mia moglie.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>Ma no la se lassa dominar dalla muggier.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Sentirò la di lei intenzione: se sarà uniforme al
 vostro buon consiglio, l'approverò; quando no, cercherò
 d'impedirla.</p>
           </sp>
-          <sp>
+          <sp who="#pantalone">
             <speaker>PANTALONE</speaker>
             <p>La fazza quel che ghe detta la so prudenza; mi no
 so più cossa dir. Son vecchio, xè tardi, vago a casa, e vago
@@ -6711,7 +6757,7 @@ auguro bon viazo, se la resta se vederemo doman. Ghe auguro
 la bona notte, bona salute, e la me permetta de dirghe,
 meggio condotta, e un poco più de giudizio <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Che buon vecchio è il signor Pantalone; mi ha
 veramente penetrato nell'animo. Non vorrei, che Brighella
@@ -6728,31 +6774,31 @@ Eleonora.</stage>
           <stage>
             <emph>BRIGHELLA con quattro uomini intabarrati.</emph>
           </stage>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>M'avè inteso; un zecchinetto per uno, e bastonè
 tutti i servitori che vien fora de sto palazzo.</p>
           </sp>
-          <sp>
+          <sp who="#bravo">
             <speaker>BRAVO</speaker>
             <p>E se venissero a sei, a otto, e bastonassero noi?</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Usè prudenza. Tolèli coi vien a uno, a do alla
 volta.</p>
           </sp>
-          <sp>
+          <sp who="#bravo">
             <speaker>BRAVO</speaker>
             <p>Credo, che dopo il primo, non ne potremo aver
 altri.</p>
           </sp>
-          <sp>
+          <sp who="#brighella">
             <speaker>BRIGHELLA</speaker>
             <p>Fè quel che podè. Tolè i vostri bezzi, che mi no
 vòi altri fastidi. A revederse <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#bravo">
             <speaker>BRAVO</speaker>
             <p>Ritiriamoci dietro di questa casa, e aspettiamo che
 n'esca uno <emph>(si ritirano)</emph>.</p>
@@ -6764,7 +6810,7 @@ n'esca uno <emph>(si ritirano)</emph>.</p>
             <emph>Arlecchino dal palazzo della contessa Eleonora, poi
 quattro uomini rimpiattati.</emph>
           </stage>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Aver inteso, aver inteso. Star tutte dame palazzo.
 Andar subito dir patrona <emph>(escono li quattro uomini, e bastonano ben bene Arlecchino, sinché egli cade in terra, e poi partono)</emph>. Ahi, aiuto, chi star? Chi me aiutar? No saver
@@ -6777,68 +6823,68 @@ morto.</p>
           <stage>
             <emph>Don Florindo, e detto.</emph>
           </stage>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>O Brighella non è ancora qui capitato, o l'ordine è
 già corso. Parmi veder un uomo disteso in terra.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Star morto, star morto <emph>(con voce fioca)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Fosse mai uno dei servitori, che ho fatto
 bastonare? Me ne dispiacerebbe infinitamente.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Star morto, star morto <emph>(come sopra)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Galantuomo, chi siete voi?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Morto, morto.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Moro, sei tu?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>No star moro, star morto.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Oh povero sventurato! Dimmi, sei stato forse
 bastonato?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Ahi, patron; povero moretto! Tanto tanto bastonar
 <emph>(s'alza un poco)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Chi ti ha dato?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Mi no saver. Ahi! brazzi tanto doler.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Dove andavi? Da dove venivi?</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Esser vegnù de palazzo, e andar da padrona per
 risposta portar. Ahi, quanto doler!</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Ora capisco. È uscito dal palazzo della Contessa,
 gli uomini trovati da Brighella l'avranno creduto un servo
@@ -6846,30 +6892,30 @@ dei Cavalieri, e lo hanno bastonato. Ecco il solito effetto
 della vendetta; cade sempre in danno del vendicatore. Levati
 povero moro, levati.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>No poder.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Vieni qui, che t'aiuterò.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Caro patron. Poveretto, moretto, tanto bastonar
 <emph>(s'alza)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Andiamo, ti farò medicare.</p>
           </sp>
-          <sp>
+          <sp who="#arlecchino">
             <speaker>ARLECCHINO</speaker>
             <p>Maladetto, chi ha fatto mi bastonar, possa diavolo
 portar, chi fatto mi bastonar. Chi mi fatto bastonar, possa
 per boia impiccar <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#florindo">
             <speaker>FLORINDO</speaker>
             <p>Tutte queste imprecazioni vengono a me. Tutti gli
 innocenti oppressi gridano vendetta contro i loro oppressori
@@ -6884,105 +6930,105 @@ e sedie.</stage>
             <emph>La contessa Eleonora, la contessa Clarice, il conte
 Ottavio. Cavalieri, e dame a sedere indietro giocando.</emph>
           </stage>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Può darsi temerità maggiore di questa? Una
 mercantessa sedere in mezzo di tante dame?</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>E di più ballare il primo minuè? Principiar ella
 il ballo?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>È una cosa che fa inorridire. Pare impossibile,
 che si dia un caso di questa sorta.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Circa il ballo è stato il ballerino, che ha mancato
 al suo dovere.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Meriterebbe colui, che gli si facessero romper le
 gambe, acciò non ballasse più.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Io son capace di fargli fare questo servizio.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Gli fareste una bella burla.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Pezzo d'asino! Non sa come si tratta! Il primo
 minuetto toccava a me.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>O a voi, o a me <emph>(le dame che sono indietro ridono)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Sentite quelle signorine; credo, che ridano di noi
 <emph>(a Clarice)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>O di voi, o di me.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Eh che non ridono di alcuna di voi! (Or ora si
 attaccano fra di loro) <emph>(da sé)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Ma di tutto è causa la Contessa Beatrice.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Veramente, la Contessa Beatrice, si è portata
 malissimo.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Qualche gran cosa l'ha messa in quest'impegno.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Una raccomandazione di un gran ministro.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Per veder d'impiegar suo marito.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Vedrete che quanto prima averà qualche carica.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Dopo che ha mangiato tutto il suo, anderà a
 mangiare quello degli altri.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Signore mie, questa è mormorazione.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Oh il signor precettore!</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Il signor morale!</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Non parlo più.</p>
           </sp>
@@ -6992,131 +7038,131 @@ mangiare quello degli altri.</p>
           <stage>
             <emph>Il conte Lelio, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Oh signor protettore, che fa la sua castellana?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Non mi parlate più di colei.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Che vuol dire? Si è disgustato?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Spiacendomi d'averla veduta partire in quella
 maniera dalla festa di ballo, sono andato a casa per
 ritrovarla, e mi ha fatto dire, che non vi era, e non mi ha
 voluto ricevere.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Vostro danno.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Imparate a servire delle mercantesse.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Si sarà vergognata, e per questo non vi avrà
 ricevuto, non già con intenzione d'offendervi.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Mi volevo maravigliare, che il signor Conte non la
 difendesse <emph>(verso Ottavio)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Non parlo più.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Mai più m'impaccio con questa sorta di gente.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Contino, giacché non vi è la Contessa Beatrice,
 dite, vi dava qualche poco nel genio, non è così?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Se vi ho da confessare la verità, non mi
 dispiaceva.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Ehi! Come è andata?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Non ho avuto tempo.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Per altro...</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Figuratevi.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Regali le ne avete fatti?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Più d'uno.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Se lo sa la Contessa Beatrice, povero voi.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Che dice Beatrice di noi?</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>È nelle furie al maggior segno.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Merita peggio.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Anzi voleva venire a trovarvi qui.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Doveva venire, che ci avrebbe sentito.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Farla sedere nel primo luogo!</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Farla ballare il primo minuè!</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>M'aspetto, che di questa gran cosa, ne parliate
 ancora da qui a dieci mesi.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Quanto vogliamo noi.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Che caro signor correttore!</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Non parlo più.</p>
           </sp>
@@ -7126,133 +7172,133 @@ ancora da qui a dieci mesi.</p>
           <stage>
             <emph>La contessa Beatrice, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Brave, brave, avete fatto una bella cosa.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Voi l'avete fatta più bella.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Abbiamo sofferto anche troppo.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>(Ora viene la bella scena) <emph>(da sé)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Andarla a metter al primo posto.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Ecco lì il signor protettore, l'ha messa lui
 <emph>(verso Lelio)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Bravo.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Bravissimo.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Io non ho fatto questa cosa. Non ero io il padrone
 di casa.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Se sapeste tutto, è innamorato morto di colei.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>E voi lo soffrite? <emph>(a Beatrice)</emph></p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>E voi gli fate la mezzana? <emph>(alla medesima)</emph></p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Che volete ch'io faccia? Me l'ha saputa dare ad
 intendere; son di buon cuore, non ho potuto dire di no.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Non sanno niente del negozio delle cento doppie)
 <emph>(da sé)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>E poi, cara Contessa, farla ballare il primo
 minuè?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Questa è colpa del ballerino.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>E voi ve la passate con questa disinvoltura? Non
 gli fate romper le ossa?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>A quest'ora credo se ne sia pentito.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Sì signora, ha avuto di già il suo castigo. Egli è
 a tavola col Conte Onofrio, che si mangia i fagiani.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Briccone! Me la pagherà. Ma voi altre, che siete
 amiche, piantarmi così? Andarvene senza dir nulla?</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>In queste cose, non vi vogliono complimenti.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Vi andava del nostro decoro.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Eh via! Che siete puntigliose.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Brava, siamo puntigliose? Perché non l'avete
 condotta qui quella signora di tanto merito?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Per me non la tratterò più certamente.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Non avete impegno con un ministro?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Quando devo dirvi tutto, l'ho fatto per compiacere
 unicamente il caro signor Conte Lelio.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Sicché il signor Conte Lelio è causa di tutto.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Non vi credeva capace di ciò <emph>(a Lelio)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>(Se potessi dir tutto, non parlereste così) <emph>(a Beatrice)</emph>.</p>
           </sp>
@@ -7262,29 +7308,29 @@ unicamente il caro signor Conte Lelio.</p>
           <stage>
             <emph>Donna Rosaura, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Come!</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Qui?</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Che temerità è questa?</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Signore mie, per grazia, per clemenza. Non vengo in
 conversazione, non vengo per framischiarmi con voi, vengo a
 chiedervi scusa, vengo a domandarvi perdono.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Oh, via, signora donna Rosaura, questo è troppo.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Conte Ottavio, giacché voi mostrate essere penetrato
 dalla mia umiliazione, impetratemi voi da queste dame la
@@ -7296,23 +7342,23 @@ trattenermi in conversazione, ma per dar loro una ben giusta
 soddisfazione, posso essere ascoltata, senza offendere le
 leggi rigorose delle loro adunanze.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Signore mie, che cosa dite? Siete persuase
 dell'istanza, senza che vi aggiunga niente del mio per
 indurvi ad ascoltare una donna, che con tanta civiltà ve ne
 supplica?</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Sentiamo che cosa sa dire.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Parlate, signora donna Rosaura; queste dame ve lo
 permettono.</p>
           </sp>
-          <sp>
+          <sp who="#rosaura">
             <speaker>ROSAURA</speaker>
             <p>Ringrazio queste dame della loro bontà; le ringrazio
 delle finezze, che alcuna di esse si è degnata farmi in
@@ -7359,44 +7405,44 @@ ingannatrice, e venale <emph>(parte)</emph>.</p>
           <stage>
             <emph>I suddetti fuori di donna Rosaura, che è partita.</emph>
           </stage>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>A me questo? Temeraria, a me questo?</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Fermatevi, Contessa Beatrice, non inveite contro
 di essa, senza prima giustificarvi. Avete voi avuto le cento
 doppie?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Le cento doppie le ho vinte per una scommessa.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>E che cosa avete scommesso?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Cadde la scommessa sull'ora del mezzogiorno.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Eh, che non si scommettono cento doppie per queste
 freddure! Se le aveste perse, come le avereste pagate?</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Se nol credete, chiedetelo al Conte Lelio.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Conte, in via d'onore, da Cavaliere qual siete, e
 sotto pena di essere dichiarato mendace se non dite la
 verità, narrate voi la cosa com'è.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Voi mi astringete a farlo con un forte scongiuro, e
 la signora donna Rosaura mi fa arrossire con i suoi giusti
@@ -7404,12 +7450,12 @@ risentimenti. Contessa Beatrice, voi avete avuto le cento
 doppie per introdurla, ed io per mia confusione ho stabilito
 il contratto.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>E voi in prezzo della mediazione avete avuto
 l'orologio d'oro.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Oimè! Che orribili cose ci tocca a' giorni nostri a
 sentire! Una dama vende la sua protezione, mercanteggia
@@ -7425,55 +7471,55 @@ con indegne azioni, questo è il vero puntiglio della
 Nobiltà. La contessa Beatrice, il conte Lelio non sono degni
 della nostra conversazione.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Voi mentite, e mi renderete conto colla spada alla
 mano dell'ingiurie colle quali vi fate lecito d'insultarmi.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Uscite da questo luogo, e preparatevi a battervi con
 quanti siamo, mentre ciascheduno di noi vi reputa per
 indegno, e mal Cavaliere.</p>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <p>Ad uno, ad uno vi farò conoscere se io... Come la
 vostra arditezza... (Il rimorso mi confonde. Il nuovo sole
 non mi vedrà più in Palermo) <emph>(parte)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>A una dama mia pari, si fanno di questi insulti?</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Tacete, che le dame non trattano come voi.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Siete indegna di questo nome e per vostra cagione
 si faranno in Palermo delle risate sopra tutte noi.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Informerò tutto il mio parentado della vostra
 insolenza.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Anch'io per mia sventura sono vostra parente, e mi
 vergogno di esserlo.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>Domani ne parleremo.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Domani vostro marito sarà chiamato da chi s'aspetta.</p>
           </sp>
-          <sp>
+          <sp who="#beatrice">
             <speaker>BEATRICE</speaker>
             <p>(Domani anderò in campagna, e non mi vedranno mai
 più) <emph>(parte)</emph>.</p>
@@ -7485,7 +7531,7 @@ più) <emph>(parte)</emph>.</p>
             <emph>La contessa Eleonora, la contessa Clarice, il conte
 Ottavio, dame e cavalieri.</emph>
           </stage>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Signore mie, per rimediare in parte al discapito
 della nostra riputazione, direi che fosse ben fatto unire
@@ -7493,15 +7539,15 @@ fra di noi le cento doppie, e farle avere alla signora
 Rosaura, prima della sua partenza. Io ne esibisco trenta,
 che tengo in questa borsa <emph>(fa vedere una borsa con varie monete)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Per parte mia, eccone sei <emph>(mette sei doppie nella suddetta borsa)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Ed io ve ne posso dar otto <emph>(fa lo stesso)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>E voi dame, e voi Cavalieri, concorrete a
 quest'opera degna di noi? <emph>(va dai Cavalieri, e dalle Dame, e tutti gli danno denari)</emph> Ecco raccolte le cento doppie.
@@ -7515,47 +7561,47 @@ donna Rosaura <emph>(parte)</emph>.</p>
             <emph>La Contessa Eleonora, la Contessa Clarice, Cavalieri e
 Dame, poi il Conte Onofrio.</emph>
           </stage>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Il conte Ottavio è veramente Cavaliere.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Ma il conte Lelio non ha restituito l'orologio.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Donna Rosaura di quello non ha parlato.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Dov'è mia moglie?</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Dama indegna! <emph>(verso il Conte Onofrio)</emph></p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Cavaliere senza riputazione! <emph>(allo stesso)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Scroccone! <emph>(al medesimo)</emph></p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Parasito <emph>(al medesimo)</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Scorno della nobiltà! <emph>(al medesimo)</emph></p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Obbrobrio della nazione! <emph>(al medesimo)</emph></p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Parlate con me? <emph>(con flemma)</emph></p>
           </sp>
@@ -7565,51 +7611,51 @@ Dame, poi il Conte Onofrio.</emph>
           <stage>
             <emph>Conte Ottavio, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Non siamo più in tempo; la signora Rosaura è
 partita. Però se approvate il mio consiglio, con queste
 cento doppie compreremo un anello, e a lei lo manderemo fino
 alla di lei patria.</p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>Fate quello credete meglio, purché si salvi il
 nostro decoro.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Tutto si faccia, per la riputazione del nostro
 nome.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>Questo è il vero puntiglio. Conservar la fama del
 nostro rango con azioni degne, eroiche, cavalleresche.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Dov'è la Signora donna Rosaura?</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>È partita, è ritornata a Castell'a Mare.</p>
           </sp>
-          <sp>
+          <sp who="#onofrio">
             <speaker>ONOFRIO</speaker>
             <p>Mi dispiace non averlo saputo; ma l'anderò a
 ritrovare. Oh che starne! Oh che coturnici! Oh che vino!
 <emph>(parte)</emph></p>
           </sp>
-          <sp>
+          <sp who="#eleonora">
             <speaker>ELEONORA</speaker>
             <p>La Contessa Beatrice non la pratico più.</p>
           </sp>
-          <sp>
+          <sp who="#clarice">
             <speaker>CLARICE</speaker>
             <p>Né men io mi degno più di farmi vedere con lei.</p>
           </sp>
-          <sp>
+          <sp who="#ottavio">
             <speaker>OTTAVIO</speaker>
             <p>In questa occasione non disapprovo, che facciate le
 puntigliose. Non è decoro delle persone onorate trattar con

--- a/tei/goldoni-le-smanie-per-la-villeggiatura.xml
+++ b/tei/goldoni-le-smanie-per-la-villeggiatura.xml
@@ -86,6 +86,46 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="leonardo">
+            <persName>Leonardo</persName>
+          </person>
+          <person xml:id="paolo">
+            <persName>Paolo</persName>
+          </person>
+          <person xml:id="cecco">
+            <persName>Cecco</persName>
+          </person>
+          <person xml:id="vittoria">
+            <persName>Vittoria</persName>
+          </person>
+          <person xml:id="berto">
+            <persName>Berto</persName>
+          </person>
+          <person xml:id="ferdinando">
+            <persName>Ferdinando</persName>
+          </person>
+          <person xml:id="filippo">
+            <persName>Filippo</persName>
+          </person>
+          <person xml:id="guglielmo">
+            <persName>Guglielmo</persName>
+          </person>
+          <person xml:id="giacinta">
+            <persName>Giacinta</persName>
+          </person>
+          <person xml:id="brigida">
+            <persName>Brigida</persName>
+          </person>
+          <person xml:id="fulgenzio">
+            <persName>Fulgenzio</persName>
+          </person>
+          <person xml:id="leon">
+            <persName>Leonardo</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -174,45 +214,45 @@ in quella di Filippo.</p>
           <stage>Camera in casa di Leonardo.</stage>
           <stage><emph>Paolo, che sta riponendo degli abiti e della biancheria in un
 baule, poi Leonardo</emph>.</stage>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Che fate qui in questa camera? Si han da far
 cento cose, e voi perdete il tempo, e non se ne eseguisce
 nessuna (<emph>a Paolo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Perdoni, signore. Io credo, che allestire il baule
 sia una delle cose necessarie da farsi.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Ho bisogno di voi per qualche cosa di più
 importante. Il baule fatelo riempir dalle donne.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Le donne stanno intorno della padrona; sono
 occupate per essa, e non vi è caso di poterle nemen vedere.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Quest'è il diffetto di mia sorella. Non si contenta
 mai. Vorrebbe sempre la servitù occupata per lei. Per andare
 in villeggiatura non le basta un mese per allestirsi. Due
 donne impiegate un mese per lei. È una cosa insoffribile.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Aggiunga, che non bastandole le due donne, ne ha
 chiamate due altre ancora in aiuto.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>E che fa ella di tanta gente? Si fa fare in casa
 qualche nuovo vestito?</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Non, signore. Il vestito nuovo glielo fa il sarto.
 In casa da queste donne fa rinovare i vestiti usati. Si fa
@@ -222,7 +262,7 @@ pizzi, di nastri, di fioretti, un arsenale di roba; e tutto
 questo per andare in campagna. In oggi la campagna è di
 maggior soggezione della città.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Sì, è pur troppo vero, chi vuol figurare nel mondo,
 convien che faccia quello che fanno gli altri. La nostra
@@ -233,22 +273,22 @@ più di quello che far vorrei. Però ho bisogno di voi. Le ore
 passano, si ha da partir da Livorno innanzi sera, e vo' che
 tutto sia lesto, e non voglio, che manchi niente.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Ella comandi, ed io farò tutto quello, che potrò
 fare.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Prima di tutto, facciamo un poco di scandaglio di
 quel, che c'è, e di quello, che ci vorrebbe. Le posate ho
 timore che siano poche.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Due dozzine dovrebbero essere sufficienti.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Per l'ordinario lo credo anch'io. Ma chi mi
 assicura, che non vengano delle truppe d'amici? In campagna
@@ -256,23 +296,23 @@ si suol tenere tavola aperta. Convien essere preparati. Le
 posate si mutano frequentemente, e due coltelliere non
 bastano.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>La prego perdonarmi, se parlo troppo liberamente.
 Vossignoria non è obbligata di fare tutto quello, che fanno
 i marchesi fiorentini, che hanno feudi e tenute grandissime,
 e cariche, e dignità grandiose.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Io non ho bisogno, che il mio cameriere mi venga a
 fare il pedante.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Perdoni; non parlo più.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Nel caso, in cui sono, ho da eccedere le bisogna.
 Il mio casino di campagna è contiguo a quello del signor
@@ -280,94 +320,94 @@ Filippo. Egli è avvezzo a trattarsi bene; è uomo splendido,
 generoso; le sue villeggiature sono magnifiche, ed io non ho
 da farmi scorgere, non ho da scomparire in faccia di lui.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Faccia tutto quello, che le detta la sua prudenza.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Andate da monsieur Gurland, e pregatelo per parte
 mia, che mi favorisca prestarmi due coltelliere, quattro
 sottocoppe, e sei candelieri d'argento.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Sarà servita.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Andate poscia dal mio droghiere, fatevi dare dieci
 libbre di caffè, cinquanta libbre di cioccolata, venti
 libbre di zucchero, e un sortimento di spezierie per cucina.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Si ha da pagare?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>No, ditegli, che lo pagherò al mio ritorno.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Compatisca; mi disse l'altrieri, che sperava prima
 ch'ella andasse in campagna, che lo saldasse del conto
 vecchio.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Non serve. Ditegli, che lo pagherò al mio ritorno.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Benissimo.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Fate, che vi sia il bisogno di carte da giuoco con
 quel che può occorrere per sei, o sette tavolini, e
 soprattutto, che non manchino candele di cera.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Anche la cereria di Pisa, prima di far conto nuovo,
 vorrebbe esser pagata del vecchio.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Comprate della cera di Venezia. Costa più, ma dura
 più, ed è più bella.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Ho da prenderla coi contanti?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Fatevi dare il bisogno; si pagherà al mio ritorno.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Signore, al suo ritorno ella avrà una folla di
 creditori, che l'inquieteranno.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Voi m'inquietate più di tutti. Sono dieci anni, che
 siete meco, e ogni anno diventate più impertinente. Perderò
 la pazienza.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Ella è padrona di mandarmi via; ma io, se parlo,
 parlo per l'amore, che le professo.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Impiegate il vostro amore a servirmi, e non a
 seccarmi. Fate quel che vi ho detto, e mandatemi Cecco.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Sarà obbedita. (Oh! vuol passar poco tempo, che le
 grandezze di villa lo vogliono ridurre miserabile nella
@@ -377,7 +417,7 @@ città) (<emph>parte</emph>).</p>
         <div type="scene">
           <head>Scena seconda</head>
           <stage><emph>Leonardo, poi Cecco</emph>.</stage>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Lo veggo anch'io, che faccio più di quello, che
 posso fare; ma lo fanno gli altri, e non voglio esser di
@@ -386,11 +426,11 @@ vuole. Ma se i conti non fallano, ha da crepare prima di me,
 e se non vuol fare un'ingiustizia al suo sangue, ho da esser
 io l'erede delle sue facoltà.</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>Comandi.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Va' dal signor Filippo Ghiandinelli; se è in casa,
 fagli i miei complimenti, e digli, che ho ordinato i cavalli
@@ -404,7 +444,7 @@ bene dalla gente di casa, se vi sia stato, se ha mandato, e
 se credono, ch'ei possa andarvi. Fa' bene tutto, e torna
 colla risposta.</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>Sarà obbedita (<emph>parte</emph>).</p>
           </sp>
@@ -412,7 +452,7 @@ colla risposta.</p>
         <div type="scene">
           <head>Scena terza</head>
           <stage><emph>Leonardo, poi Vittoria</emph>.</stage>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Non posso soffrire, che la signora Giacinta tratti
 Guglielmo. Ella dice, che dee tollerarlo per compiacere il
@@ -421,125 +461,125 @@ inclinazione per lui; ma io non sono in obbligo di creder
 tutto, e questa pratica non mi piace. Sarà bene, che io
 medesimo solleciti di terminare il baule.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Signor fratello, è egli vero, che avete ordinato i
 cavalli di posta, e che si ha da partir questa sera?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Sì certo. Non si stabilì così fin da ieri?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Ieri vi ho detto, che sperava di poter essere
 all'ordine per partire; ma ora vi dico che non lo sono, e
 mandate a sospendere l'ordinazion dei cavalli, perché
 assolutamente per oggi non si può partire.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>E perché per oggi non si può partire?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Perché il sarto non mi ha terminato il mio
 <emph>mariage</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Che diavolo è questo <emph>mariage</emph>?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>È un vestito all'ultima moda.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Se non è finito, ve lo potrà mandare in campagna.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>No, certo. Voglio, che me lo provi, e lo voglio
 veder finito.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Ma la partenza non si può differire. Siamo in
 concerto d'andar insieme col signor Filippo, e colla signora
 Giacinta, e si ha detto di partir oggi.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Tanto peggio. So, che la signora Giacinta è di buon
 gusto, e non voglio venire col pericolo di scomparire in
 faccia di lei.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Degli abiti ne avete in abbondanza; potete
 comparire al par di chi che sia.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Io non ho, che delle anticaglie.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Non ve ne avete fatto uno nuovo anche l'anno
 passato?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Da un anno all'altro gli abiti non si possono più
 dire alla moda. È vero, che li ho fatti rifar quasi tutti;
 ma un vestito novo ci vuole, è necessario, e non si può far
 senza.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Quest'anno corre il <emph>mariage</emph> dunque.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Sì, certo. L'ha portato di Torino madama Granon.
 Finora in Livorno non credo, che se ne siano veduti, e spero
 d'esser io delle prime.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Ma che abito è questo? Vi vuol tanto a farlo?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Vi vuol pochissimo. È un abito di seta di un color
 solo, colla guarnizione intrecciata di due colori. Tutto
 consiste nel buon gusto di scegliere colori buoni, che si
 uniscano bene, che risaltino, e non facciano confusione.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Orsù, non so che dire. Mi spiacerebbe di vedervi
 scontenta; ma in ogni modo s'ha da partire.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Io non vengo assolutamente.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Se non ci verrete voi, ci anderò io.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Come! Senza di me? Avrete cuore di lasciarmi in
 Livorno?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Verrò poi a pigliarvi.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>No, non mi fido. Sa il Cielo, quando verrete, e se
 resto qui senza di voi, ho paura, che quel tisico di nostro
@@ -547,39 +587,39 @@ zio mi obblighi a restar in Livorno con lui; e se dovessi
 star qui, in tempo che l'altre vanno in villeggiatura, mi
 ammalerei di rabbia, di disperazione.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Dunque risolvetevi di venire.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Andate dal sarto, ed obbligatelo a lasciar tutto,
 ed a terminare il mio <emph>mariage</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Io non ho tempo da perdere. Ho da far cento cose.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Maledetta la mia disgrazia!</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Oh gran disgrazia invero! Un abito di meno è una
 disgrazia lacrimosa, intollerabile, estrema.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Sì, signore, la mancanza di un abito alla moda può
 far perder il credito a chi ha fama di essere di buon gusto.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Finalmente siete ancora fanciulla, e le fanciulle
 non s'hanno a mettere colle maritate.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Anche la signora Giacinta è fanciulla, e va con
 tutte le mode, con tutte le gale delle maritate. E in oggi
@@ -589,24 +629,24 @@ passare per zotica, per anticaglia; e mi maraviglio che voi
 abbiate di queste massime, e che mi vogliate avvilita, e
 strapazzata a tal segno.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Tanto fracasso per un abito?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Piuttosto, che restar qui, o venir fuori senza il
 mio abito, mi contenterei d'avere una malattia.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Il Cielo vi conceda la grazia.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Che mi venga una malattia? (<emph>con isdegno</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>No, che abbiate l'abito, e che siate contenta.</p>
           </sp>
@@ -614,16 +654,16 @@ mio abito, mi contenterei d'avere una malattia.</p>
         <div type="scene">
           <head>Scena quarta</head>
           <stage><emph>Berto, e detti</emph>.</stage>
-          <sp>
+          <sp who="#berto">
             <speaker>BERTO</speaker>
             <p>Signore, il signor Ferdinando desidera
 riverirla (<emph>a Leonardo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Venga, venga, è padrone.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Sentimi. Va' immediatamente dal sarto, da monsieur
 de la Réjouissance, e digli, che finisca subito il mio
@@ -631,22 +671,22 @@ vestito, che lo voglio prima ch'io parta per la campagna,
 altrimenti me ne renderà conto, e non farà più il sarto in
 Livorno.</p>
           </sp>
-          <sp>
+          <sp who="#berto">
             <speaker>BERTO</speaker>
             <p>Sarà servita (<emph>parte</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Via, acchetatevi, e non vi fate scorgere dal signor
 Ferdinando.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Che importa a me del signor Ferdinando? Io non mi
 prendo soggezione di lui. M'immagino, che anche quest'anno
 verrà in campagna a piantare il bordone da noi.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Certo, mi ha dato speranza di venir con noi, e
 intende di farci una distinzione; ma siccome è uno di
@@ -657,12 +697,12 @@ sapesse le vostre smanie per l'abito, sarebbe capace di
 porvi in ridicolo in tutte le compagnie, in tutte le
 conversazioni.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>E perché dunque volete condur con noi questo
 canchero, se conoscete il di lui carattere?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Vedete bene: in campagna è necessario aver della
 compagnia. Tutti procurano d'aver più gente, che possono; e
@@ -673,25 +713,25 @@ Gioca a tutto, è sempre allegro, dice delle buffonerie,
 mangia bene, fa onore alla tavola, soffre la burla, e non se
 ne ha a male di niente.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Sì, sì, è vero; in campagna questi caratteri sono
 necessari. Ma che fa, che non viene?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Eccolo lì, ch'esce dalla cucina.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Che cosa sarà andato a fare in cucina?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Curiosità. Vuol saper tutto. Vuol saper quel che si
 fa, quel che si mangia, e poi lo dice per tutto.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Manco male, che di noi non potrà raccontare
 miserie.</p>
@@ -700,81 +740,81 @@ miserie.</p>
         <div type="scene">
           <head>Scena quinta</head>
           <stage><emph>Ferdinando, e detti</emph>.</stage>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Padroni miei riveriti. Il mio rispetto alla signora
 Vittoria.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Serva, signor Ferdinando.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Siete, amico, siete dei nostri?</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Sì, sarò con voi. Mi sono liberato da quel
 seccatore del conte Anselmo, che mi voleva seco per forza.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Il conte Anselmo non fa una buona villeggiatura?</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Sì, si tratta bene, fa una buona tavola; ma da lui
 si fa una vita troppo metodica. Si va a cena a quattr'ore, e
 si va a letto alle cinque.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Oh! io non farei questa vita per tutto l'oro del
 mondo. Se vado a letto prima dell'alba, non è possibile,
 ch'io prenda sonno.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Da noi sapete come si fa. Si gioca, si balla; non
 si va mai a cena prima delle otto; e poi col nostro
 carissimo <emph>faraoncino</emph> il più delle volte si vede il sole.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Questo si chiama vivere.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>E per questo ho preferito la vostra villeggiatura a
 quella del conte Anselmo. E poi quell'anticaglia di sua
 moglie è una cosa insoffribile.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Sì, sì, vuol fare ancora la giovinetta.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>L'anno passato, i primi giorni sono stato io il
 cavalier servente; poi è capitato un giovanetto di ventidue
 anni, e ha piantato me per attaccarsi a lui.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Oh! che ti venga il bene. Con un giovanetto di
 ventidue anni?</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Sì, e mi piace di dire la verità; era un biondino,
 ben cincinato, bianco, e rosso come una rosa.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Mi maraviglio di lui, che avesse tal sofferenza.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Sapete, com'è? È uno di quelli, che non hanno il
 modo, che si appoggiano qua, e là, dove possono; e si
@@ -782,63 +822,63 @@ attaccano ad alcuna di queste signore antichette, le quali
 pagano loro le poste, e danno loro qualche zecchino ancor
 per giocare.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>(È una buona lingua per altro).</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>A che ora si parte?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Non si sa ancora. L'ora non è stabilita.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>M'immagino, che anderete in una carrozza da quattro
 posti.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Io ho ordinato un calesso per mia sorella, e per
 me, ed un cavallo per il mio cameriere.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Ed io come vengo?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Come volete.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Via, via. Il signor Ferdinando verrà con me, voi
 anderete nello sterzo col signor Filippo e la signora
 Giacinta. (Farò meglio figura a andar in calesso con lui,
 che con mio fratello).</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Ma siete poi risolta di voler partire? (<emph>a Vittoria</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Che? Ci ha qualche difficoltà?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Vi potrebbe essere una picciola difficoltà.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Se non siete sicuri di partire, ditemelo
 liberamente. Se non vado con voi, andrò con qualchedun
 altro. Tutti vanno in campagna, e non voglio, che dicano,
 ch'io resto a far la guardia a Livorno.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>(Sarebbe anche per me una grandissima
 mortificazione).</p>
@@ -847,54 +887,54 @@ mortificazione).</p>
         <div type="scene">
           <head>Scena sesta</head>
           <stage><emph>Cecco, e detti</emph>.</stage>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>Son qui, signore... (<emph>a Leonardo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Accostati (<emph>a Cecco</emph>). Con licenza (<emph>a Ferdinando</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>(Il signor Filippo la riverisce, e dice che circa
 ai cavalli da posta, riposa sopra di lei. La signora
 Giacinta sta bene; lo sta attendendo, e lo prega
 sollecitare, perché di notte non ha piacer di viaggiare).</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>(E di Guglielmo mi sai dir niente?)</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>(Mi assicurano, che questa mattina non si è
 veduto).</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>(Benissimo: son contento). Andrai ad avvisare il
 fattore della posta, che siano lesti i cavalli per
 ventun'ora.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Ma se quell'affare non fosse in ordine?...</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Ci sia, o non ci sia. Venite, o non venite, io vo'
 partire alle ventun'ora...</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Ed io per le vent'una sarò qui preparato.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Vorrei vedere ancor questa...</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Sono in impegno, e per una scioccheria voi non mi
 farete mancare. Se vi fussero delle buone ragioni, pazienza;
@@ -904,64 +944,64 @@ ma per uno straccio d'abito non si ha da restare (<emph>a Vittoria, e parte</emp
         <div type="scene">
           <head>Scena settima</head>
           <stage><emph>Vittoria, Ferdinando, e Cecco</emph>.</stage>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>(Povera me, in che condizione miserabile, che mi
 trovo! Non son padrona di me; ho da dipendere dal fratello.
 Non veggo l'ora di maritarmi; niente per altro, che per
 poter fare a mio modo).</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Ditemi in confidenza, signora, se si può dire: che
 cosa vi mette in dubbio di partire, o di non partire?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Cecco.</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>Signora.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Sei tu stato dalla signora Giacinta?</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>Sì, signora.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>L'hai veduta?</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>L'ho veduta.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>E che cosa faceva?</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>Si provava un abito.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Un abito nuovo?</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>Novissimo.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>(Oh maledizione! Se non ho il mio, non parto
 assolutamente).</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>(E che sì, ch'ella pure vorrebbe un vestito nuovo,
 e non ha denari per farselo? Già tutti lo dicono: fratello e
@@ -969,43 +1009,43 @@ sorella sono due pazzi. Spendono più di quello, che possono,
 e consumano in un mese a Montenero quello, che basterebbe
 loro un anno in Livorno).</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Cecco.</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>Signora.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>E com'è quest'abito della signora Giacinta?</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>Per dir la verità, non ci ho molto badato, ma credo
 sia un vestito da sposa.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Da sposa? Hai tu sentito dire, che si faccia la
 sposa?</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>Non l'ho sentito dire precisamente. Ma ho inteso
 una parola francese, che ha detto il sarto, che mi par di
 capirla.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Intendo anch'io il francese. Che cosa ha detto?</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>Ha detto <emph>mariage</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>(Ah! sì, ora ho capito; si fa ella pure il
 <emph>mariage</emph>: mi pareva impossibile, che non lo facesse). Dov'è
@@ -1013,16 +1053,16 @@ Berto? Guarda, se trovi Berto. Se non c'è, corri dal mio
 sartore, digli, che assolutamente in termine di tre ore vo',
 che mi porti il mio <emph>mariage</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p><emph>Mariage</emph>, non vuol dir matrimonio?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Il diavolo, che ti porti. Va' subito, corri. Fa'
 quel, che ti dico, e non replicare.</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>Sì, signora, subito corro (<emph>parte</emph>).</p>
           </sp>
@@ -1030,26 +1070,26 @@ quel, che ti dico, e non replicare.</p>
         <div type="scene">
           <head>Scena ottava</head>
           <stage><emph>Vittoria, e Ferdinando</emph>.</stage>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Signora, dite la verità, sareste in dubbio di
 partire per la mancanza dell'abito?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>E bene? Mi dareste il torto per questo?</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>No, avete tutte le ragioni del mondo: è una cosa
 necessarissima. Lo fanno tutte, lo fanno quelle che non lo
 potrebbono fare. Conoscete la signora Aspasia?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>La conosco.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Se n'è fatto uno ella pure, e ha preso il drappo in
 credenza per pagarlo uno scudo al mese. E la signora
@@ -1057,16 +1097,16 @@ Costanza? La signora Costanza per farsi l'abito nuovo ha
 venduto due paia di lenzuola, ed una tovaglia di Fiandra, e
 ventiquattro salviette.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>E per qual impegno, per qual premura hanno fatto
 questo?</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Per andare in campagna.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Non so, che dire, la campagna è una gran passione,
 le compatisco; se fossi nel caso loro, non so anch'io, che
@@ -1074,40 +1114,40 @@ cosa farei. In città non mi curo di far gran cose; ma in
 villa ho sempre paura di non comparire bastantemente...
 Fatemi un piacere, signor Ferdinando, venite con me.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Dove abbiamo d'andare?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Dal sarto, a gridare, a strapazzarlo ben bene.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>No, volete, ch'io v'insegni a farlo sollecitare?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>E come direste voi, che io facessi?</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Perdonate; lo pagate subito?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Lo pagherò al mio ritorno.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Pagatelo presto, e sarete servita presto.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Lo pago, quando voglio, e vo', che mi serva, quando
 mi pare (<emph>parte</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Bravissima, bel costume! Far figura in campagna, e
 farsi maltrattare in città (<emph>parte</emph>).</p>
@@ -1117,18 +1157,18 @@ farsi maltrattare in città (<emph>parte</emph>).</p>
           <head>Scena nona</head>
           <stage>Camera in casa di Filippo.</stage>
           <stage><emph>Filippo e Guglielmo incontrandosi</emph>.</stage>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Oh, signor Guglielmo, che grazie, che finezze son
 queste?</p>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <p>Il mio debito, signor Filippo; il mio debito, e
 niente più. So, che oggi ella va in campagna, e sono venuto
 ad augurarle buon viaggio, e buona villeggiatura.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Caro amico, sono obbligato all'amor vostro, alla
 vostra attenzione; oggi finalmente si anderà in campagna. In
@@ -1139,12 +1179,12 @@ ma allora si andava per fare il vino, ora si va per
 divertimento, e si sta in campagna col freddo, e si vedono
 seccar le foglie sugli alberi.</p>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <p>Ma non siete voi il padrone? Perché non andate,
 quando vi pare, e non tornate, quando vi comoda?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Sì, dite bene, lo potrei fare; ma sono stato sempre
 di buon umore, mi ha sempre piacciuto la compagnia, e
@@ -1156,43 +1196,43 @@ grugno, e non ho altri al mondo, che la mia Giacinta, e
 desidero soddisfarla. Si va, quando vanno gli altri, ed io
 mi lascio regolar dagli altri.</p>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <p>Veramente quello, che si fa dalla maggior parte, si
 dee credere, che sia sempre il meglio.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Non sempre, non sempre, ci sarebbe molto, che dire.
 Voi dove fate quest'anno la vostra villeggiatura?</p>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <p>Non so; non ho ancora fissato. (Ah! se potessi
 andare con lui; se potessi villeggiare coll'amabile sua
 figliuola!)</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Vostro padre era solito villeggiare sulle colline di
 Pisa.</p>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <p>È verissimo. Colà sono situati i nostri poderi, e
 vi è un'abitazione passabile. Ma io son solo, e dirò come
 dite voi, star solo in campagna è un morir di malinconia.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Volete venir con noi?</p>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <p>Oh! signor Filippo, io non ho alcun merito, né
 oserei di dare a voi quest'incomodo.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Io non son uomo di ceremonie. Posso adattarmi allo
 stile moderno in tutt'altro, fuor che nell'uso de'
@@ -1200,59 +1240,59 @@ complimenti. Se volete venire, vi esibisco un buon letto,
 una mediocre tavola, ed un cuore sempre aperto agli amici, e
 sempre eguale con tutti.</p>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <p>Non so che dire. Siete così obbligante, ch'io non
 posso ricusare le grazie vostre.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Così va fatto. Venite, e stateci fin che vi pare;
 non pregiudicate i vostri interessi, e stateci fin che vi
 pare.</p>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <p>A che ora destinate voi di partire?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Non lo so; intendetevi col signor Leonardo.</p>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <p>Viene con voi il signor Leonardo?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Sì, certo, abbiamo destinato d'andare insieme con
 lui, e con sua sorella. Le nostre case di villa sono vicine,</p>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <p>(Questa compagnia me dispiace. Ma né siamo amici, e
 anderemo insieme anche per ciò voglio perdere l'occasione
 favorevole di essere in compagnia di Giacinta).</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Ci avete delle difficoltà?</p>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <p>Non, signore. Pensava ora, se dovea prendere un
 calesso, o, essendo solo, un cavallo da sella.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Facciamo così. Noi siamo in tre, ed abbiamo un legno
 da quattro, venite dunque con noi.</p>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <p>Chi è il quarto, se è lecito?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Una mia cognata vedova, che viene con noi per
 custodia di mia figliuola; non già, ch'ella abbia bisogno di
@@ -1260,35 +1300,35 @@ essere custodita, ché ha giudizio da sé, ma per il mondo,
 non avendo madre, è necessario, che vi sia una donna
 attempata.</p>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <p>Va benissimo. (Procurerò ben io di cattivarmi
 l'animo della vecchia).</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>E così? Vi comoda di venir con noi?</p>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <p>Anzi è la maggiore finezza, che io possa ricevere.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Andate dunque dal signor Leonardo, e ditegli che non
 s'impegni con altri per il posto, che è destinato per voi.</p>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <p>Non potreste farmi voi il piacere di mandar
 qualcheduno?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>I miei servitori sono tutti occupati. Scusatemi, non
 mi pare di darvi sì grande incomodo.</p>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <p>Non dico diversamente. Aveva un certo picciolo
 affare. Basta non occorr'altro. Anderò io ad avvisarlo.
@@ -1296,11 +1336,11 @@ affare. Basta non occorr'altro. Anderò io ad avvisarlo.
 pare, ci penso poco, e non ho soggezione di lui). Signor
 Filippo, a buon rivederci.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Non vi fate aspettare.</p>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <p>Sarò sollecito. Ho degli stimoli, che mi faranno
 sollecitare (<emph>parte</emph>).</p>
@@ -1309,7 +1349,7 @@ sollecitare (<emph>parte</emph>).</p>
         <div type="scene">
           <head>Scena decima</head>
           <stage><emph>Filippo, poi Giacinta, e Brigida</emph>.</stage>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Or, che ci penso. Non vorrei, che mi criticassero,
 invitando un giovane a venir con noi, avendo una figliuola
@@ -1324,98 +1364,98 @@ usa in villa quel rigore, che si pratica nelle città; e poi
 in casa mia, so quanto mi posso compromettere: mia figlia è
 savia, è bene educata. Eccola, che tu sia benedetta!</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Signor padre, mi favorisca altri sei zecchini.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>E per che fare, figliuola mia?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Per pagare la sopravveste di seta da portar per
 viaggio per ripararsi dalla polvere.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>(Poh! non si finisce mai). Ed è necessario, che sia
 di seta?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Necessarissimo. Sarebbe una villania portare la
 <emph>polverina</emph> di tela; vuol essere di seta, e col capuccietto.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Ed a che fine il capuccietto?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Per la notte, per l'aria, per l'umido, per quando è
 freddo.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Ma non si usano i cappellini? I cappellini non
 riparano meglio?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Oh, i cappellini!</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Oh, oh, oh, i cappellini!</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Che ne dici, eh, Brigida? I cappellini!</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Fa morir di ridere il signor padrone. I cappellini!</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Che! ho detto qualche sproposito? Qualche
 bestialità? A che far tante maraviglie? Non si usavano forse
 i cappellini?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Goffaggini, goffaggini.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Anticaglie, anticaglie.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Ma quanto sarà, che non si usano più i cappellini?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Oh! due anni almeno.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>E in due anni sono venuti anticaglie?</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Ma non sapete, signore, che quello che si usa un
 anno, non si usa l'altro?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Sì, è vero. Ho veduto in pochissimi anni cuffie,
 cuffiotti, cappellini, cappelloni; ora corrono i
 capuccietti; m'aspetto, che l'anno venturo vi mettiate in
 testa una scarpa.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Ma voi, che vi maravigliate tanto delle donne,
 ditemi un poco, gli uomini non fanno peggio di noi? Una
@@ -1425,66 +1465,66 @@ grosse; ora portano anch'eglino la <emph>polverina</emph>, gli
 scappinetti colle fibie di brilli, e montano in calesso
 colle calzoline di seta.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>E non usano più il bastone.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Ed usano il pallossetto ritorto.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>E portano l'ombrellino per ripararsi dal sole.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>E poi dicono di noi.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Se fanno peggio di noi.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Io non so niente di tutto questo. So, che come
 s'andava cinquant'anni sono, vado ancora presentemente.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Questi sono discorsi inutili. Favoritemi sei
 zecchini.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Sì, veniamo alla conclusione; lo spendere è sempre
 stato alla moda.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Mi pare di essere delle più discrete.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Oh! signore, non sapete niente. Date un'occhiata in
 villa a quel, che fanno le altre, e me la saprete poi
 raccontare.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Sicché dunque devo ringraziare la mia figliuola, che
 mi fa la finezza di farmi risparmiare moltissimo.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Vi assicuro, che una fanciulla più economa non si
 dà.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Mi contento del puro bisognevole, e niente più.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Figliuola mia, sia bisognevole, o non sia
 bisognevole, sapete, ch'io desidero soddisfarvi, e i sei
@@ -1493,145 +1533,145 @@ saranno. Ma circa all'economia, studiatela un poco più,
 perché se vi maritate, sarà difficile, che troviate un
 marito del carattere di vostro padre.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>A che ora si parte?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>(A proposito). Io pensavo verso le ventidue.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Oh! credo, che si partirà prima. E chi viene in
 carrozza con noi?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Ci verrò io, ci verrà vostra zia, e per quarto un
 galantuomo, un mio amico, che conoscete anche voi.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Qualche vecchio forse?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Vi dispiacerebbe, che fusse un vecchio?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Oh! non, signore. Non ci penso, basta, che non sia
 una marmotta. Se è anche vecchio, quando sia di buon umore,
 son contentissima.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>È un giovane.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Tanto meglio.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Perché tanto meglio?</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Perché la gioventù naturalmente è più vivace, è più
 spiritosa. Starete allegri; non dormirete per viaggio.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>E chi è questo signore?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>È il signor Guglielmo.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Sì, sì, è un giovane di talento.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Il signor Leonardo, mi figuro, andrà in calesso con
 sua sorella.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Probabilmente.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Ed io, signore, con chi anderò?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Tu andrai, come sei solita andare; per mare in una
 feluca, colla mia gente, e con quella del signor Leonardo.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Ma, signore, il mare mi fa sempre male, e l'anno
 passato ho corso pericolo d'annegarmi, e quest'anno non ci
 vorrei andare.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Vuoi, ch'io ti prenda un calesso apposta?</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Compatitemi, con chi va il cameriere del signor
 Leonardo?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Appunto; il suo cameriere lo suol condurre per
 terra. Povera Brigida, lasciate, che ella vada con esso lui.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Col cameriere!</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Sì, cosa avete paura? Ci siamo noi; e poi sapete
 che Brigida è una buona fanciulla.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>In quanto a me, vi protesto, monto in sedia, mi
 metto a dormire, e non lo guardo in faccia nemmeno</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>È giusto, ch'io abbia meco la mia cameriera.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Tutte le signore la conducono presso di loro.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Per viaggio mi possono abbisognar cento cose.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Almeno son lì pronta per assistere, per servir la
 padrona.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Caro signor padre.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Caro signor padrone.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Non so, che dire; non so dir di no, non son capace
 di dir di no, e non dirò mai di no (<emph>parte</emph>).</p>
@@ -1640,75 +1680,75 @@ di dir di no, e non dirò mai di no (<emph>parte</emph>).</p>
         <div type="scene">
           <head>Scena undicesima</head>
           <stage><emph>Giacinta, e Brigida</emph>.</stage>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Sei contenta?</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Brava la mia padrona.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Oh! io poi ho questo di buono; faccio far alla
 gente tutto quello, che io voglio.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Ma, come andrà la faccenda col signor Leonardo?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Su che proposito?</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Sul proposito del signor Guglielmo; sapete quanto è
 geloso; e se lo vede in carrozza con voi...</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Converrà, che lo soffra.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Io ho paura, che si disgusterà.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Con chi?</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Con voi.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Eh! per appunto. Gliene ho fatte soffrir di peggio.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Compatitemi, signora padrona, il poverino vi vuol
 troppo bene.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Ed io non gli voglio male.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Ei si lusinga, che siate un giorno la di lui sposa.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>E può anche essere, che ciò succeda.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Ma se avesse questa buona intenzione, procurate un
 poco più di renderlo soddisfatto.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Anzi per lo contrario, prevedendo, ch'ei possa un
 giorno essere mio marito, vo' avvezzarlo per tempo a non
@@ -1719,68 +1759,68 @@ soggezione, è finita: sarò schiava perpetuamente. O mi vuol
 bene, o non mi vuol bene. Se mi vuol bene, s'ha da fidare,
 se non mi vuol bene, che se ne vada.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Dice per altro il proverbio: chi ama, teme, e se
 dubita, dubiterà per amore.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Questo è un amore, che non mi comoda.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Diciamola fra di noi; voi l'amate pochissimo il
 signor Leonardo.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Io non so quanto l'ami; ma so, che l'amo più di
 quello, ch'io abbia amato nessuno; e non avrei difficoltà a
 sposarlo, ma non a costo di essere tormentata.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Compatitemi, questo non è vero amore.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Non so, che fare. Io non ne conosco di meglio.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Mi pare di sentir gente.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Va' a vedere chi è.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Oh! appunto è il signor Leonardo.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Che vuol dir, che non viene innanzi?</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>E che sì, che ha saputo del signor Guglielmo?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>O prima, o dopo l'ha da sapere.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Non viene. C'è del male. Volete, che io vada a
 vedere?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Sì, va' a vedere, fallo venire innanzi.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>(Capperi; non mi preme per lui; mi preme per il
 cameriere) (<emph>parte</emph>).</p>
@@ -1789,208 +1829,208 @@ cameriere) (<emph>parte</emph>).</p>
         <div type="scene">
           <head>Scena dodicesima</head>
           <stage><emph>Giacinta, poi Leonardo</emph>.</stage>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Sì, lo amo, lo stimo, lo desidero, ma non posso
 soffrire la gelosia.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Servitor suo, signora Giacinta (<emph>sostenuto</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Padrone, signor Leonardo (<emph>sostenuta</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Scusi, se son venuto ad incomodarla.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Fa grazia, signor ceremoniere, fa grazia (<emph>con ironia</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Sono venuto ad augurarle buon viaggio.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Per dove?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Per la campagna.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>E ella non favorisce?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Non, signora.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Perché, se è lecito?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Perché non le vorrei essere di disturbo.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Ella non incomoda mai; favorisce sempre. È così
 grazioso, che favorisce sempre (<emph>con ironia</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Non sono io il grazioso. Il grazioso lo averà seco
 lei nella sua carrozza.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Io non dispongo, signore. Mio padre è il padrone,
 ed è padrone di far venire chi vuole.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Ma la figliuola si accomoda volentieri.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Se volentieri, o malvolentieri, voi non avete da
 far l'astrologo.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Alle corte, signora Giacinta. Quella compagnia non
 mi piace.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>È inutile, che a me lo diciate.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>E a chi lo devo dire?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>A mio padre.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Con lui non ho libertà di spiegarmi.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Né io ho l'autorità di farlo fare a mio modo.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Ma se vi premesse la mia amicizia, trovereste la
 via di non disgustarmi.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Come? Suggeritemi voi la maniera.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Oh! non mancano pretesti, quando si vuole.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Per esempio?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Per esempio si fa nascere una novità, che
 differisca l'andata, e si acquista tempo; e quando preme, si
 tralascia d'andare, piuttosto che disgustare una persona,
 per cui si ha qualche stima.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Sì, per farsi ridicoli questa è la vera strada.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Eh! dite, che non vi curate di me.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Ho della stima, ho dell'amore per voi; ma non
 voglio per causa vostra fare una trista figura in faccia del
 mondo.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Sarebbe un gran male, che non andaste un anno in
 villeggiatura?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Un anno senza andare in villeggiatura! Che
 direbbero di me a Montenero? Che direbbero di me a Livorno?
 Non avrei più ardire di mirar in faccia nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Quand'è così, non occorr'altro. Vada, si diverta, e
 buon pro le faccia.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Ma ci verrete anche voi.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Non, signora, non ci verrò.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Eh! sì, che verrete (<emph>amorosamente</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Con colui non ci voglio andare.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>E che cosa vi ha fatto colui?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Non lo posso vedere.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Dunque l'odio, che avete per lui, è più grande
 dell'amore, che avete per me.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Io l'odio appunto per causa vostra.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Ma per qual motivo?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Perché, perché,... non mi fate parlare.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Perché ne siete geloso?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Sì, perché ne sono geloso.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Qui vi voleva. La gelosia, che avete di lui, è
 un'offesa, che fate a me, e non potete essere di lui geloso,
@@ -2003,7 +2043,7 @@ mio dovere, e non vo' gelosie, e non voglio dispetti, e non
 voglio farmi ridicola per nessuno, e in villa ci ho
 d'andare, ci devo andare, e ci voglio andare (<emph>parte</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Va', che il diavolo ti strascini. Ma no; può
 essere, che tu non ci vada. Farò tanto forse, che non ci
@@ -2021,115 +2061,115 @@ campagna (<emph>parte</emph>).</p>
           <head>Scena prima</head>
           <stage>Camera di Leonardo.</stage>
           <stage><emph>Vittoria, e Paolo</emph>.</stage>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Via, via, non istate più a taroccare. Lasciate, che
 le donne finiscano di fare quel, che hanno da fare, e
 piuttosto v'aiuterò a terminare il baule per mio fratello.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Non so, che dire. Siamo tanti in casa, e pare,
 ch'io solo abbia da fare ogni cosa.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Presto, presto. Facciamo, che quando torna il
 signor Leonardo, trovi tutte le cose fatte. Ora son
 contentissima, a mezzo giorno avrò in casa il mio abito
 nuovo.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Gliel'ha poi finito il sarto?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Sì, l'ha finito; ma da colui non mi servo più.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>E perché, signora? Lo ha fatto male?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>No, per dir la verità, è riuscito bellissimo. Mi
 sta bene, è un abito di buon gusto, che forse forse farà la
 prima figura, e farà crepar qualcheduno d'invidia.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>E perché dunque è sdegnata col sarto?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Perché mi ha fatto un'impertinenza. Ha voluto i
 danari subito per la stoffa, e per la fattura.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Perdoni, non mi par, che abbia gran torto. Mi ha
 detto più volte, che ha un conto lungo, e che voleva esser
 saldato.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>E bene, doveva aggiungere alla lunga polizza anche
 questo conto, e sarebbe stato pagato di tutto.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>E quando sarebbe stato pagato?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Al ritorno della villeggiatura.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Crede ella di ritornar di campagna con dei
 quattrini?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>È facilissimo. In campagna si gioca. Io sono
 piuttosto fortunata nel gioco, e probabilmente l'avrei
 pagato senza sagrificare quel poco, che mio fratello mi
 passa per il mio vestito.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>A buon conto quest'abito è pagato, e non ci ha più
 da pensare.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Sì, ma sono restata senza quattrini.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Che importa? Ella non ne ha per ora da spendere.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>E come ho da far a giocare?</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>A' giochetti si può perder poco.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Oh! io non gioco a' giochetti. Non ci ho piacere,
 non vo' applicare. In città gioco qualche volta per
 compiacenza; ma in campagna il mio divertimento, la mia
 passione, è il faraone.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Per quest'anno le converrà aver pazienza.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Oh, questo poi, no. Vo' giocare, perché mi piace
 giocare. Vo' giocare, perché ho bisogno di vincere, ed è
@@ -2137,26 +2177,26 @@ necessario che io giochi, per non far dir di me la
 conversazione. In ogni caso io mi fido, io mi comprometto di
 voi.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Di me?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Sì, di voi. Sarebbe gran cosa, che mi anticipaste
 qualche danaro, a conto del mio vestiario dell'anno venturo?</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Perdoni. Mi pare che ella lo abbia intaccato della
 metà almeno.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Che importa? Quando l'ho avuto, l'ho avuto. Io non
 credo, che vi farete pregare per questo.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Per me la servirei volentieri, ma non ne ho. È
 vero che, quantunque io non abbia, che il titolo, ed il
@@ -2166,77 +2206,77 @@ così ristretta, che non arrivo mai a poter pagare quello,
 che alla giornata si spende; e per dirle la verità, sono
 indietro anch'io di sei mesi del mio onorario.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Lo dirò a mio fratello, e mi darà egli il bisogno.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Signora, si accerti, che ora è più che mai in
 ristrettezze grandissime, e non si lusinghi, perché non le
 può dar niente.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Ci sarà del grano in campagna.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Non ci sarà nemmeno il bisogno per fare il pane,
 che occorre.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>L'uva non sarà venduta.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>È venduta anche l'uva.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Anche l'uva?</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>E se andiamo di questo passo, signora...</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Non sarà così di mio zio.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Oh! quello ha il grano, il vino e i danari.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>E non possiamo noi prevalerci di qualche cosa?</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Non, signora. Hanno fatto le divisioni. Ciascheduno
 conosce il suo. Sono separate le fattorie. Non vi è niente
 da sperare da quella parte.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Mio fratello dunque va in precipizio.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Se non ci rimedia.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>E come avrebbe da rimediarci?</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Regolar le spese. Cambiar sistema di vivere.
 Abbandonar soprattutto la villeggiatura.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Abbandonar la villeggiatura? Si vede bene, che
 siete un uomo da niente. Ristringa le spese in casa. Scemi
@@ -2246,28 +2286,28 @@ Livorno. Ma la villeggiatura si deve fare, e ha da essere da
 par nostro, grandiosa secondo il solito, e colla solita
 proprietà.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Crede ella, che possa durar lungo tempo?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Che duri fin che io ci sono. La mia dote è in
 deposito, e spero, che non tarderò a maritarmi.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>E intanto?...</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>E intanto terminiamo il baule.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Ecco il padrone.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Non gli diciamo niente per ora. Non lo mettiamo in
 melanconia. Ho piacere, che sia di buon animo, che si parta
@@ -2277,170 +2317,170 @@ con allegria. Terminiamo di empir il baule (<emph>si affrettano tutti e due a ri
         <div type="scene">
           <head>Scena seconda</head>
           <stage><emph>Leonardo, e detti</emph>.</stage>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>(Ah! vorrei nascondere la mia passione, ma non so,
 se sarà possibile. Sono troppo fuor di me stesso).</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Eccoci qui, signor fratello, eccoci qui a lavorare
 per voi.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Non vi affrettate. Può essere, che la partenza si
 differisca.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>No, no, sollecitatela pure. Io sono in ordine, il
 mio <emph>mariage</emph> è finito. Son contentissima, non vedo l'ora
 d'andarmene.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Ed io, sul supposto di far a voi un piacere, ho
 cambiato disposizione, e per oggi non si partirà.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>E ci vuol tanto a rimettere le cose in ordine per
 partire?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Per oggi, vi dico, non è possibile.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Via, per oggi pazienza. Si partirà domattina pel
 fresco; non è così?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Non lo so. Non ne son sicuro.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Ma voi mi volete far dare alla disperazione.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Disperatevi, quanto volete, non so, che farvi.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Bisogna dire, che vi siano de' gran motivi.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Qualche cosa di più della mancanza d'un abito.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>E la signora Giacinta va questa sera?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Può essere, ch'ella pure non vada.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Ecco la gran ragione. Eccolo il gran motivo. Perché
 non parte la bella, non vorrà partire l'amante. Io non ho,
 che fare con lei, e si può partire senza di lei.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Partirete, quando a me parerà di partire.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Questo è un torto, questa è un'ingiustizia, che voi
 mi fate. Io non ho da restar in Livorno, quando tutti vanno
 in campagna, e la signora Giacinta mi sentirà, se resterò a
 Livorno per lei.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Questo non è ragionare da fanciulla propria, e
 civile, come voi siete. E voi, che fate colà ritto, ritto,
 come una statua? (<emph>a Paolo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Aspetto gli ordini. Sto a veder, sto a sentire. Non
 so, s'io abbia a seguitar a fare, o a principiar a disfare.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Seguitate a fare.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Principiate a disfare.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Fare, e disfare è tutto lavorare (<emph>levando dal baule</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Io butterei volentieri ogni cosa dalla finestra.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Principiate a buttarvi il vostro <emph>mariage</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Sì, se non vado in campagna, lo straccio in cento
 mila pezzi.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Che cosa c'è in questa cassa? (<emph>Paolo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Il caffè, la cioccolata, lo zucchero, la cera e le
 spezierie.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>M'immagino, che niente di ciò sarà stato pagato.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Con che vuol ella, ch'io abbia pagato? So bene, che
 per aver questa roba a credito, ho dovuto sudare; e i
 bottegai mi hanno maltrattato, come se io l'avessi rubbata.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Riportate ogni cosa a chi ve l'ha data, e fate, che
 depennino la partita.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Sì, signore. Ehi! chi è di là? Aiutatemi (<emph>vien servito</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>(Oh, povera me! La villeggiatura è finita).</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Bravo, signor padrone: così va bene. Far manco
 debiti, che si può.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Il malan, che vi colga. Non mi fate il dottore, che
 perderò la pazienza.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>(Andiamo, andiamo, prima che si penta. Si vede, che
 non lo fa per economia, lo fa per qualche altro diavolo, che
@@ -2450,71 +2490,71 @@ ha per il capo) (<emph>porta via la cassetta, e parte</emph>).</p>
         <div type="scene">
           <head>Scena terza</head>
           <stage><emph>Vittoria, e Leonardo</emph>.</stage>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Ma si può sapere il motivo di questa vostra
 disperazione?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Non lo so nemmen io.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Avete gridato colla signora Giacinta?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Giacinta è indegna dell'amor mio, è indegna
 dell'amicizia della mia casa, e ve lo dico, e ve lo comando,
 non vo', che la pratichiate.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Eh! già, quando penso una cosa, non fallo mai. L'ho
 detto, e così è. Non si va più in campagna per ragione di
 quella sguaiata, ed ella ci anderà, ed io non ci potrò
 andare. E si burleranno di me.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Eh! corpo del diavolo, non ci anderà nemmen ella.
 Farò tanto, che non ci anderà.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Se non ci andasse Giacinta, mi pare che mi
 spiacerebbe meno di non andar io. Ma ella sì, ed io no? Ella
 a far la graziosa in villa, ed io restar in città? Sarebbe
 una cosa, sarebbe una cosa da dar la testa nelle muraglie.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Vedrete, che ella non anderà. Per conto mio, ho
 levato l'ordine de' cavalli.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Oh sì, peneranno assai a mandar eglino alla posta!</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Eh! ho fatto qualche cosa di più. Ho fatto dir
 delle cose al signor Filippo, che se non è stolido, se non è
 un uomo di stucco, non condurrà per ora la sua figliuola in
 campagna.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Ci ho gusto. Anch'ella sfoggierà il suo grand'abito
 in Livorno. La vedrò a passeggiar sulle mura. Se l'incontro,
 le vo' dar la baia a dovere.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Io non voglio, che le parliate.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Non le parlerò, non le parlerò. So corbellare senza
 parlare.</p>
@@ -2523,81 +2563,81 @@ parlare.</p>
         <div type="scene">
           <head>Scena quarta</head>
           <stage><emph>Ferdinando da viaggio, e detti</emph>.</stage>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Eccomi qui, eccomi lesto, eccomi preparato pel
 viaggio.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Oh! sì, avete fatto bene ad anticipare.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Caro amico, mi dispiace infinitamente, ma sappiate,
 che per un mio premuroso affare, per oggi non parto più.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Oh, cospetto di bacco! Quando partirete? Domani?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Non so, può essere che differisca, per qualche
 giorno, e può anche essere, che per quest'anno i miei
 interessi m'impediscano di villeggiare.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>(Povero diavolo! Sarà per mancanza di calor
 naturale).</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>(Quando ci penso, per altro, mi vengono i sudori
 freddi).</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Voi potrete andare col conte Anselmo.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Eh! a me non mancano villeggiature. Il conte
 Anselmo l'ho licenziato; fo il mio conto, che andrò col
 signor Filippo, e colla signora Giacinta.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Oh! la signora Giacinta per quest'anno potrebbe
 anch'ella morir colla voglia in corpo.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Io vengo di là in questo punto, e ho veduto, che
 sono in ordine per partire, ed ho sentito, che hanno mandato
 a ordinare i cavalli per ventunora.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Sente, signor Leonardo?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>(Il signor Fulgenzio non avrà ancora parlato al
 signor Filippo).</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Eh, in quella casa non tremano. Il signor Filippo
 si tratta da gran signore, e non ha impicci in Livorno, che
 gl'impediscano la sua magnifica villeggiatura.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Sente, signor Leonardo?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Sento, sento, ed ho sentito, ed ho sofferto
 abbastanza. Mi è noto il vostro stile satirico. In casa mia,
@@ -2611,17 +2651,17 @@ me. (Scrocchi insolenti, mormoratori indiscreti!) (<emph>parte</emph>).</p>
         <div type="scene">
           <head>Scena quinta</head>
           <stage><emph>Vittoria, e Ferdinando</emph>.</stage>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>È impazzito vostro fratello? Che cosa ha egli con
 me? Di che può lamentarsi de' fatti miei?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Veramente pare dal vostro modo di dire, che noi non
 possiamo andare in campagna per mancanza del bisognevole.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Io? Mi maraviglio. Per gli amici mi farei
 ammazzare; difenderei la vostra riputazione colla spada alla
@@ -2636,82 +2676,82 @@ signor Leonardo, e stimo la prudenza vostra, che sa
 addattarsi alle congionture; e si fa quello, che si può, e
 che si rovinino quelli, che si vogliono rovinare.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Ma siete curioso per altro. Mio fratello non resta
 in Livorno per il bisogno.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Lo so; ci resta per la necessità.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Necessità di che?</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Di accudire agli affari suoi.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>E la signora Giacinta credete voi, che ci vada in
 campagna?</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Senz'altro.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Sicuro?</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Infallibilmente.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>(Io ho paura, che mio fratello me la voglia dare ad
 intendere. Che dica di non andare, e poi mi pianti, e se ne
 vada da sé).</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Ho veduto l'abito della signora Giacinta.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>È bello?</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Bellissimo.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Più del mio?</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Più del vostro non dico; ma è bello assai; e in
 campagna ha da fare una figura strepitosissima.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>(Ed io ho da restare col mio bell'abito a spazzar
 le strade in Livorno?)</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Quest'anno io credo, che si farà a Montenero una
 bellissima villeggiatura.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Per qual ragione?</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Vi hanno da essere delle signore di più, delle
 spose novelle, tutte magnifiche, tutte in gala, e le donne
@@ -2719,54 +2759,54 @@ traggono seco gli uomini, e dove vi è della gioventù, tutti
 corrono. Vi sarà gran gioco, gran feste di ballo. Ci
 divertiremo infinitamente.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>(Ed io ho da stare in Livorno?)</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>(Si rode, si macera. Ci ho un gusto pazzo).</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>(No, non ci voglio stare. Se credessi cacciarmi per
 forza con qualche amica).</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Signora Vittoria, a buon riverirla.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>La riverisco.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>A Montenero comanda niente?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Eh! può essere, che ci vediamo.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Se verrà, ci vedremo. Se non verrà, le faremo un
 brindisi.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Non vi è bisogno, ch'ella s'incomodi.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Viva il bel tempo! Viva l'allegria, viva la
 villeggiatura! Servitore umilissimo.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>La riverisco divotamente.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>(Se non va in campagna, ella crepa prima che
 termini questo mese) (<emph>parte</emph>).</p>
@@ -2775,7 +2815,7 @@ termini questo mese) (<emph>parte</emph>).</p>
         <div type="scene">
           <head>Scena sesta</head>
           <stage><emph>Vittoria sola</emph>.</stage>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Ma! La cosa è così pur troppo. Quando si è sul
 candeliere, quando si è sul piede di seguitare il gran
@@ -2799,12 +2839,12 @@ cambiare temperamento (<emph>parte</emph>).</p>
           <head>Scena settima</head>
           <stage>Camera in casa di Filippo.</stage>
           <stage><emph>Filippo, e Brigida</emph>.</stage>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Sicché dunque il signor Leonardo ha mandato a
 dire, che non può partire per ora?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Sì, certo, l'ha mandato a dire. Ma ciò non sarebbe
 niente. Può essergli sopraggiunto qualche affare d'impegno.
@@ -2813,46 +2853,46 @@ levar l'ordine dei cavalli per lui, e dei cavalli per me,
 come s'egli avesse paura, ch'io non pagassi, e che dovessi
 toccar a lui a pagare.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>(L'ho detto io, l'ho detto. La padrona vuol far di
 sua testa, che il Cielo la benedica).</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Io non mi aspettava da lui questo sgarbo.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>E così, signor padrone, come avete pensato di fare?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Ho pensato, che posso andar in campagna senza di
 lui, che posso avere i cavalli senza di lui, e li ho mandati
 a ordinare per oggi.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Se è lecito, quanti cavalli avete ordinato?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Quattro, secondo il solito, per il mio carrozzino.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>E per me, poverina?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Bisognerà, che tu ti accomodi a andar per mare.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Oh! per mare non ci vado assolutamente.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>E come vorresti tu, ch'io facessi? Ch'io levassi per
 te una sedia? Fino che ci fosse stato il cameriere del
@@ -2860,26 +2900,26 @@ signor Leonardo, per una metà avrei supplito alla spesa, ma
 per l'intiero sarebbe troppo, e mi maraviglio che tu abbia
 tanta indiscretezza per domandarlo.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Io non lo domando, io mi accomodo a tutto. Ma
 fatemi grazia: il signor Ferdinando non viene anch'egli con
 voi?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Sì, è vero: doveva andar col signor Leonardo, ed è
 venuto poco fa a dirmi, che verrà con me.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Bisognerà, che pensiate voi a condurlo.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>E perché ci ho da pensar io?</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Perché egli intende di venire per farvi grazia.
 Perché egli è solito andar in campagna, non per
@@ -2893,58 +2933,58 @@ conduceste anche me; e se non vado in calesso col cameriere
 del signor Leonardo, posso andare in calesso col signor
 Cavaliere del dente.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Brava, io non ti credeva sì spiritosa. Hai fatto un
 bel panegirico al signor Ferdinando. Basta, se sarò
 costretto a pagar il viaggio al signor Cavaliere del dente,
 sarà servita la signora Contessa della buona lingua.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Sarà per sua grazia, non per mio merito.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Chi c'è in sala?</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>C'è gente.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Guarda un poco.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>È il signor Fulgenzio (<emph>dopo averlo osservato</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Domanda di me forse?</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Probabilmente.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Va' a veder cosa vuole.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Subito. Chi sa che non sia un altro ospite
 rispettoso, che venga ad esibirvi la sua umile servitù in
 campagna?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Padrone. Mi farebbe piacere. Con lui ho delle
 obbligazioni non poche, e poi in campagna io non ricuso
 nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Non ci dubitate, signore, non vi mancherà
 compagnia. Dove c'è miglio, gli uccelli volano, e dove c'è
@@ -2954,45 +2994,45 @@ buona tavola, gli scrocchi fioccano (<emph>parte</emph>).</p>
         <div type="scene">
           <head>Scena ottava</head>
           <stage><emph>Filippo, poi Giacinta</emph>.</stage>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>A quest'ora, signore, vi potrebbero risparmiare le
 seccature. Vien tardi, a ventunora si ha da partire. Mi ho
 da vestir da viaggio da capo a piedi, e abbiamo ancora da
 desinare.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Ma io ho da sentire, che cosa vuole il signor
 Fulgenzio.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Fategli dire, che avete che fare, che avete
 premura, che non potete...</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Voi non sapete quello, che vi diciate; ho con lui
 delle obbligazioni, non lo deggio trattare villanamente.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Spicciatevi presto, dunque.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Più presto, che si potrà.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>È un seccatore, non finirà sì presto.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Eccolo, che viene.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Vado, vado. (Non lo posso soffrire. Ogni volta che
 viene qui, ha sempre qualche cosa da dire sul vivere,
@@ -3003,33 +3043,33 @@ dice qualche cosa di me) (<emph>parte</emph>).</p>
         <div type="scene">
           <head>Scena nona</head>
           <stage><emph>Filippo, poi Fulgenzio</emph>.</stage>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Gran cosa di queste ragazze! Quel giorno, che hanno
 d'andar in campagna, non sanno quel che si facciano, non
 sanno quel che si dicano, sono fuori di lor medesime.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Buon giorno, signor Filippo.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Riverisco il mio carissimo signor Fulgenzio. Che
 buon vento vi conduce da queste parti?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>La buona amicizia, il desiderio di rivedervi prima
 che andiate in villa, e di potervi dare il buon viaggio.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Son obbligato al vostro amore, alla vostra
 cordialità, e mi fareste una gran finezza, se vi compiaceste
 di venir con me.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>No, caro amico, vi ringrazio. Sono stato in
 campagna alla raccolta del grano, ci sono stato alla semina,
@@ -3037,14 +3077,14 @@ sono tornato per le biade minute, e ci anderò per il vino.
 Ma son solito di andar solo, e di starvi quanto esigono i
 miei interessi, e non più.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Circa agl'interessi della campagna, poco più, poco
 meno, ci abbado anch'io, ma solo non ci posso stare. Amo la
 compagnia, ed ho piacere nel tempo medesimo di agire, e di
 divertirmi.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Benissimo, ottimamente. Dee ciascuno operare
 secondo la sua inclinazione. Io amo star solo, ma non
@@ -3052,18 +3092,18 @@ disapprovo chi ama la compagnia. Quando però la compagnia
 sia buona, sia conveniente, e non dia occasione al mondo di
 mormorare.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Me lo dite in certa maniera, signor Fulgenzio, che
 pare abbiate intenzione di dare a me delle staffilate.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Caro amico, noi siamo amici da tanti anni. Sapete,
 se vi ho sempre amato, se nelle occasioni vi ho dati dei
 segni di cordialità.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Sì, me ne ricordo, e ve ne sarò grato fino ch'io
 viva. Quando ho avuto bisogno di denari, me ne avete sempre
@@ -3072,7 +3112,7 @@ restituiti, e i mille scudi che l'altro giorno mi avete
 prestati, li avrete, come mi sono impegnato, da qui a tre
 mesi.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Di ciò son sicurissimo, e prestar mille scudi ad un
 galantuomo, io lo calcolo un servizio da nulla. Ma
@@ -3089,7 +3129,7 @@ dir male di voi, e fra quelli, che voi trattate
 amorosamente, vi è qualcheduno, che pregiudica al vostro
 decoro, ed alla vostra riputazione.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Cospetto! voi mi mettete in un'agitazione
 grandissima. Rispetto allo spendere qualche cosa di più, e
@@ -3100,7 +3140,7 @@ fino ch'io campo. Mi fa specie, che voi diciate, che vi è
 chi pregiudica al mio decoro, alla mia riputazione. Come
 potete dirlo, signor Fulgenzio?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Lo dico con fondamento, e lo dico appunto,
 riflettendo, che avete una figliuola da maritare. Io so, che
@@ -3109,132 +3149,132 @@ domandarvela, perché voi la lasciate troppo addomesticar
 colla gioventù, e non avete riguardo di ammettere zerbinotti
 in casa, e fino di accompagnarli in viaggio con esso lei.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Volete voi dire del signor Guglielmo?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Io dico di tutti, e non voglio dir di nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Se parlaste del signor Guglielmo, vi accerto, che è
 un giovane il più savio, il più dabbene del mondo.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Ella è giovane.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>E mia figlia è una fanciulla prudente.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Ella è donna.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>E vi è mia sorella, donna attempata...</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>E vi sono delle vecchie più pazze assai delle
 giovani.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Era venuto anche a me qualche dubbio su tal
 proposito, ma ho pensato poi, che tanti altri si conducono
 nella stessa maniera...</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Caro amico, de' casi ne avete mai veduti a
 succedere? Tutti quelli, che si conducono, come voi dite, si
 sono poi trovati della loro condotta contenti?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Per dire la verità, chi sì, e chi no.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>E voi siete sicuro del sì? Non potete dubitare del
 no?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Voi mi mettete delle pulci nel capo. Non veggo l'ora
 di liberarmi di questa figlia. Caro amico, e chi è quegli,
 che dite voi, che la vorrebbe in consorte?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Per ora non posso dirvelo.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Ma perché?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Perché per ora non vuol essere nominato. Regolatevi
 diversamente, e si spiegherà.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>E che cosa dovrei fare? Tralasciar d'andare in
 campagna? È impossibile; son troppo avvezzo.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Che bisogno c'è, che vi conduciate la figlia?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Cospetto di bacco! se non la conducessi, ci sarebbe
 il diavolo in casa.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Vostra figlia dunque può dire anch'ella la sua
 ragione.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>L'ha sempre detta.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>E di chi è la colpa?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>È mia, lo confesso, la colpa è mia. Ma son di buon
 cuore.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Il troppo buon cuore del padre fa essere di cattivo
 cuore le figlie.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>E che vi ho da fare presentemente?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Un poco di buona regola. Se non in tutto, in parte.
 Staccatele dal fianco la gioventù.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Se sapessi come fare a liberarmi dal signor
 Guglielmo!</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Alle corte: questo signor Guglielmo vuol essere il
 suo malanno. Per causa sua il galantuomo, che la vorrebbe,
@@ -3243,72 +3283,72 @@ parli, e che si tratti, fate a buon conto, che non si veda
 questa mostruosità, che una figliuola abbia da comandar più
 del padre.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Ma ella in ciò non ne ha parte alcuna. Sono stato
 io, che l'ha invitato a venire.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Tanto meglio. Licenziatelo.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Tanto peggio; non so come licenziarlo.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Siete uomo, o che cosa siete?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Quando si tratta di far malegrazie, io non so come
 fare.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Badate, che non facciano a voi delle malegrazie,
 che puzzino.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Orsù, bisognerà, ch'io lo faccia.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Fatelo, che ve ne chiamerete contento.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Potreste ben farmi la confidenza di dirmi, chi sia
 l'amico, che aspira alla mia figliuola.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Per ora non posso, compatitemi. Deggio andare per
 un affare di premura.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Accomodatevi, come vi pare.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Scusatemi della libertà, che mi ho preso.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Anzi vi ho tutta l'obbligazione.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>A buon rivederci.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Mi raccomando alla grazia vostra.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>(Credo di aver ben servito il signor Leonardo. Ma
 ho inteso di servire alla verità, alla ragione,
@@ -3318,7 +3358,7 @@ all'interesse e al decoro dell'amico Filippo) (<emph>parte</emph>).</p>
         <div type="scene">
           <head>Scena decima</head>
           <stage><emph>Filippo, poi Giacinta</emph>.</stage>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Fulgenzio mi ha dette delle verità irrefragabili, e
 non sono sì sciocco, ch'io non le conosca, e non le abbia
@@ -3329,175 +3369,175 @@ bisogna usare maggior prudenza. Orsù in ogni modo mi convien
 licenziare il signor Guglielmo, a costo di non andare in
 campagna.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Mi consolo, signore, che la seccatura è finita.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Chiamatemi un servitore.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Se volete, che diano in tavola, glielo posso dire
 io medesima.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Chiamatemi un servitore. L'ho da mandare in un loco.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Dove lo volete mandare?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Siete troppo curiosa. Lo vo' mandare, dove mi pare.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Per qualche interesse, che vi ha suggerito il
 signor Fulgenzio?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Voi vi prendete con vostro padre più libertà, di
 quello che vi conviene.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Chi ve l'ha detto, signore? Il signor Fulgenzio?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Finitela, e andate via, vi dico.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Alla vostra figliuola? Alla vostra cara Giacinta?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>(Non sono avvezzo a far da cattivo, e non lo so
 fare).</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>(Ci scommetterei la testa, che Leonardo si è
 servito del signor Fulgenzio per ispuntarla. Ma non ci
 riuscirà).</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>C'è nessuno di là? C'è nessuno servitore?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Ora, ora, acchetatevi un poco. Anderò io a chiamar
 qualcheduno.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Fate presto.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Ma non si può sapere, che cosa vogliate fare del
 servitore?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Che maledetta curiosità! Lo voglio mandare dal
 signor Guglielmo.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Avete paura che egli non venga? Verrà pur troppo.
 Così non venisse.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Così non venisse?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Sì, signore, così non venisse. Godremmo più
 libertà, e potrebbe venire con noi quella povera Brigida,
 che si raccomanda.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>E non avreste piacere d'aver in viaggio una
 compagnia da discorrere, da divertirvi?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Io non ci penso, e non v'ho mai pensato. Non siete
 stato voi, che l'ha invitato? Ho detto niente io, perché lo
 facciate venire?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>(Mia figliuola ha più giudizio di me). Ehi chi è di
 là? Un servitore.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Subito lo vado io a chiamare. E che volete far dire
 al signor Guglielmo?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Che non s'incomodi, e che non lo possiamo servire.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Oh bella scena! bella, bella, bellissima scena (<emph>con ironia</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Glielo dirò con maniera.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Che buona ragione gli saprete voi dire?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Che so io?... Per esempio... che nella carrozza ha
 da venire la cameriera, e che non c'è loco per lui.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Meglio, meglio, e sempre meglio (<emph>come sopra</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Vi burlate di me, signorina?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Io mi maraviglio certo di voi, che siate capace di
 una simile debolezza. Che cosa volete, ch'ei dica? Che cosa
 volete, che dica il mondo? Volete esser trattato da uomo
 incivile, da malcreato?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Vi pare cosa ben fatta, che un giovane venga in
 sterzo con voi?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Sì, è malissimo fatto, e non si può far peggio; ma
 bisognava pensarvi prima. Se l'avessi invitato io, potreste
 dir: non lo voglio; ma l'avete invitato voi.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>E bene io ho fatto il male, ed io ci rimedierò.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Basta, che il rimedio non sia peggiore del male.
 Finalmente s'ei viene con me, c'è la zia, ci siete voi, è
@@ -3510,13 +3550,13 @@ Chi dirà: il padre si è accorto di qualche cosa. Chi
 sparlerà di voi, chi sparlerà di me; e per non fare una cosa
 innocente, ne patirà la nostra riputazione.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>(Quanto pagherei, che ci fusse Fulgenzio, che la
 sentisse!) Non sarebbe meglio che lasciassimo stare d'andar
 in campagna?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Sarebbe meglio per una parte; ma per l'altra poi si
 farebbe peggio. Figurarsi! quelle buone lingue di Montenero,
@@ -3528,76 +3568,76 @@ Dovevano mangiar meno, dovevano trattar meno. Quello che si
 vedeva, era fumo, non era arrosto. Mi par di sentirle; mi
 vengono i sudori freddi.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Che cosa dunque abbiamo da fare?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Tutto quel che volete.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>S'io fuggo dalla padella, ho paura di cader nelle
 bragie.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>E le bragie scottano, e convien salvar la
 riputazione.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Vi parrebbe dunque meglio fatto, che il signor
 Guglielmo venisse con noi?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Per questa volta, giacché è fatta. Ma mai più,
 vedete, mai più. Vi serva di regola, e non lo fate mai più.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>(È una figliuola di gran talento).</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>E così? Volete, che chiami il servitore, o che non
 lo chiami?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Lasciamo stare; giacché è fatta.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Sarà meglio, che andiamo a pranzo.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>E in villa abbiamo da tenerlo in casa con noi?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Che impegni avete presi con lui?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Io l'ho invitato, per dirla.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>E come volete fare a mandarlo via?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Ci dovrà stare dunque.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Ma mai più, vedete, mai più.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Mai più, figliuola, che tu sia benedetta, mai più! (<emph>parte</emph>).</p>
           </sp>
@@ -3605,7 +3645,7 @@ lo chiami?</p>
         <div type="scene">
           <head>Scena undicesima</head>
           <stage><emph>Giacinta, poi Brigida</emph>.</stage>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Nulla mi preme del signor Guglielmo. Ma non voglio,
 che Leonardo si possa vantare d'averla vinta. Già son
@@ -3615,51 +3655,51 @@ caldo. E se mi vuol bene davvero, com'egli dice, imparerà a
 regolarsi per l'avvenire con più discrezione, ché non sono
 nata una schiava, e non voglio essere schiava.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Signora, una visita.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>E chi è a quest'ora?</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>La signora Vittoria.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Le hai detto che ci sono?</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Come voleva, ch'io dicessi, che non ci è?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Ora mi viene in tasca davvero: e dov'è?</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Ha mandato il servitore innanzi. È per la strada,
 che viene.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Valle incontro. Converrà, ch'io la soffra. Ho anche
 curiosità di sapere, se viene, o se non viene in campagna;
 se vi è novità veruna. Venendo ella a quest'ora, qualche
 cosa ci avrebbe a essere.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Ho saputo una cosa.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>E che cosa?</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Ch'ella pure si è fatto un vestito nuovo, e non lo
 poteva avere dal sarto, perché, credo, che il sarto volesse
@@ -3671,7 +3711,7 @@ da mettere nelle gazzette (<emph>parte</emph>).</p>
         <div type="scene">
           <head>Scena dodicesima</head>
           <stage><emph>Giacinta, poi Vittoria</emph>.</stage>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>È ambiziosissima. Se vede qualche cosa di novo ad
 una persona, subito le vien la voglia d'averla. Avrà saputo,
@@ -3679,324 +3719,324 @@ ch'io mi ho fatto il vestito novo, e l'ha voluto ella pure.
 Ma non avrà penetrato del <emph>mariage</emph>. Non l'ho detto a
 nessuno; non avrà avuto tempo a saperlo.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Giacintina amica mia carissima.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Buon dì, la mia cara gioia (<emph>si baciano</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Che dite, eh? È una bell'ora questa da
 incomodarvi?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Oh! incomodarmi? Quando vi ho sentito venire, mi si
 è allargato il core d'allegrezza.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Come state? State bene?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Benissimo. E voi? Ma è superfluo il domandarvi:
 siete grassa, e fresca, il Cielo vi benedica, che consolate.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Voi, voi avete una ciera, che innamora.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Oh! cosa dite mai? Sono levata questa mattina per
 tempo, non ho dormito, mi duole lo stomaco, mi duole il
 capo, figurarsi, che buona ciera, ch'io posso avere.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Ed io non so cosa m'abbia, sono tanti giorni, che
 non mangio niente; niente, niente, si può dir quasi niente.
 Io non so di che viva, dovrei essere come uno stecco.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Sì, sì, come uno stecco! Questi bracciotti non sono
 stecchi.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Eh! a voi non vi si contano l'ossa.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>No, poi. Per grazia del Cielo, ho il mio
 bisognetto.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Oh cara la mia Giacinta!</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Oh benedetta la mia Vittorina! (<emph>si baciano</emph>).
 Sedete, gioia; via sedete.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Aveva tanta voglia di vedervi. Ma voi non vi
 degnate mai di venir da me (<emph>siedono</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Oh! caro il mio bene, non vado in nessun loco. Sto
 sempre in casa.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>E io? Esco un pochino la festa, e poi sempre in
 casa.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Io non so, come facciano quelle, che vanno tutto il
 giorno a girone per la città.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>(Vorrei pur sapere, se va, o se non va a Montenero,
 ma non so, come fare).</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>(Mi fa specie, che non mi parla niente della
 campagna).</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>È molto, che non vedete mio fratello?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>L'ho veduto questa mattina.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Non so, cos'abbia. È inquieto, è fastidioso.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Eh! non lo sapete? Tutti abbiamo le nostre ore
 buone, e le nostre ore cattive.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Credeva quasi, che avesse gridato con voi.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Con me? Perché ha da gridare con me? Lo stimo, e lo
 venero, ma egli non è ancora in grado di poter gridare con
 me. (Ci gioco io, che l'ha mandata qui suo fratello).</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>(È superba, quanto un demonio).</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Vittorina, volete restar a pranzo con noi?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Oh! no, vita mia, non posso. Mio fratello mi
 aspetta.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Glielo manderemo a dire.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>No, no assolutamente non posso.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Se volete favorire, or ora qui da noi si dà in
 tavola.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>(Ho capito. Mi vuol mandar via). Così presto andate
 a desinare?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Vedete bene. Si va in campagna, si parte presto,
 bisogna sollecitare.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>(Ah! maledetta la mia disgrazia).</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>M'ho da cambiar di tutto, m'ho da vestire da
 viaggio.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Sì, sì, è vero; ci sarà della polvere. Non torna il
 conto rovinare un abito buono (<emph>mortificata</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Oh! in quanto a questo poi, me ne metterò uno
 meglio di questo. Della polvere non ho paura. Mi ho fatto
 una sopravveste di cambellotto di seta col suo capuccietto,
 che non vi è pericolo, che la polvere mi dia fastidio.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>(Anche la sopravveste col capuccietto! La voglio
 anch'io se dovesse vendere de' miei vestiti).</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Voi non l'avete la sopravveste col capuccietto?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Sì, sì, ce l'ho ancor io; me l'ho fatta fin
 dall'anno passato.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Non ve l'ho veduta l'anno passato.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Non l'ho portata, perché se vi ricordate, non c'era
 polvere.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Sì, sì, non c'era polvere. (È propriamente
 ridicola).</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Quest'anno mi ho fatto un abito.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Oh! io me ne ho fatto un bello.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Vedrete il mio, che non vi dispiacerà.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>In materia di questo, vedrete qualche cosa di
 particolare.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Nel mio non vi è né oro, né argento, ma per dir la
 verità è stupendo.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Oh! moda, moda. Vuol esser moda.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Oh! circa la moda, il mio non si può dir, che non
 sia alla moda.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Sì, sì, sarà alla moda (<emph>sogghignando</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Non lo credete?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Sì, lo credo. (Vuol restare quando vede il mio
 <emph>mariage</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>In materia di mode poi, credo di essere stata
 sempre io delle prime.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>E che cos'è il vostro abito?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>È un <emph>mariage</emph>!</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p><emph>Mariage</emph>! (<emph>maravigliandosi</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Sì, certo. Vi par, che non sia alla moda?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Come avete voi saputo, che sia venuta di Francia la
 moda del <emph>mariage</emph>?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Probabilmente, come l'avrete saputo anche voi.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Chi ve l'ha fatto?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Il sarto francese monsieur de la Réjouissance.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Ora ho capito. Briccone! Me la pagherà. Io l'ho
 mandato a chiamare. Io gli ho dato la moda del <emph>mariage</emph>. Io
 che aveva in casa l'abito di madama Granon.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Oh! madama Granon è stata da me a farmi visita il
 secondo giorno, che è arrivata a Livorno.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Sì, sì, scusatelo. Me l'ha da pagare senza altro.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Vi spiace, ch'io abbia il <emph>mariage</emph>?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Oibò, ci ho gusto.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Volevate averlo voi sola?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Perché? Credete voi, ch'io sia una fanciulla
 invidiosa? Credo, che lo sappiate, che io non invidio
@@ -4006,11 +4046,11 @@ nuovo certo. E voglio esser servita subito, e servita bene,
 perché pago, pago puntualmente, e il sarto non lo faccio
 tornare più d'una volta.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Io credo, che tutte paghino.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>No, tutte non pagano. Tutte non hanno il modo, o la
 delicatezza, che abbiamo noi. Vi sono di quelle, che fanno
@@ -4018,181 +4058,181 @@ aspettare degli anni, e poi se hanno qualche premura, il
 sarto s'impunta. Vuole i danari sul fatto, e nascono delle
 baruffe. (Prendi questa, e sappiatemi dir, se è alla moda).</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>(Non crederei, che parlasse di me. Se potessi
 credere, che il sarto avesse parlato, lo vorrei trattar,
 come merita).</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>E quando ve lo metterete questo bell'abito?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Non so, può essere, che non me lo metta nemeno. Io
 son così; mi basta d'aver la roba, ma non mi curo poi di
 sfoggiarla.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Se andate in campagna, sarebbe quella l'occasione
 di metterlo. Peccato, poverina, che non ci andiate in
 quest'anno!</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Chi v'ha detto, che io non ci vada?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Non so; il signor Leonardo ha mandato a licenziar i
 cavalli.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>E per questo? Non si può risolvere da un momento
 all'altro? E lo credete, che non possa andare senza di lui?
 Credete ch'io non abbia delle amiche, delle parenti da poter
 andare?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Volete venire con me?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>No, no, vi ringrazio.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Davvero, vi vedrei tanto volentieri.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Vi dirò, se posso ridurre una mia cugina a venire
 con me a Montenero, può essere, che ci vediamo.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Oh! che l'avrei tanto a caro.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>A che ora partite?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>A ventunora.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Oh! dunque c'è tempo. Posso trattenermi qui ancora
 un poco. (Vorrei vedere questo abito se potessi).</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Sì, sì, ho capito. Aspettate un poco (<emph>verso la scena</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Se avete qualche cosa da fare, servitevi.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Eh! niente. M'hanno detto, che il pranzo è
 all'ordine, e che mio padre vuol desinare.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Partirò, dunque.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>No, no, se volete restare, restate.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Non vorrei, che il vostro signor padre si avesse a
 inquietare.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Per verità, è fastidioso un poco.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Vi leverò l'incomodo (<emph>s'alza</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Se volete restar con noi, mi farete piacere.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>(Quasi, quasi, ci resterei, per la curiosità di
 quest'abito).</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Ho inteso; non vedete? Abbiate creanza (<emph>verso la scena</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Con chi parlate?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Col servitore che mi sollecita. Non hanno niente di
 civiltà costoro.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Io non ho veduto nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Eh, l'ho ben veduto io.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>(Ho capito). Signora Giacinta, a bon rivederci.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Addio, cara. Vogliatemi bene, ch'io vi assicuro che
 ve ne voglio.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Siate certa, che siete corrisposta di cuore.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Un bacio almeno.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Sì, vita mia.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Cara la mia gioia (<emph>si baciano</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Addio.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Addio.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>(Faccio de' sforzi a fingere, che mi sento
 crepare) (<emph>parte</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Le donne invidiose io non le posso soffrire (<emph>parte</emph>).</p>
           </sp>
@@ -4204,54 +4244,54 @@ crepare) (<emph>parte</emph>).</p>
           <head>Scena prima</head>
           <stage>Camera di Leonardo.</stage>
           <stage><emph>Leonardo, e Fulgenzio</emph>.</stage>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Voi mi date una nuova, signor Fulgenzio, che mi
 consola infinitamente. Ha dunque dato parola il signor
 Filippo di liberarsi dall'impegno, che aveva col signor
 Guglielmo?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Sì, certo mi ha promesso di farlo.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>E siete poi sicuro, che non vi manchi?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Son sicurissimo. Passano delle cose fra lui, e me,
 che mi rendono certo della sua parola; e poi l'ho trovato
 assai pontuale in affari di rimarco. Non dubito di
 ritrovarlo tale anche in questo.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Dunque Guglielmo non andrà in campagna colla
 signora Giacinta.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Questo è certissimo.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Son contentissimo. Ora ci andrò io volentieri.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Ho detto tanto, ho fatto tanto, che quel buon uomo
 si è illuminato. Egli ha un ottimo cuore. Non crediate,
 ch'ei manchi per malizia; manca qualche volta per troppa
 bontà.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>E credo, che la sua figliuola lo faccia fare a suo
 modo.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>No, non è cattiva fanciulla. Mi ha confessato il
 signor Filippo, ch'ella non avea parte alcuna nell'invito
@@ -4259,56 +4299,56 @@ del signor Guglielmo; e ch'egli l'avea anzi pregato d'andar
 con loro, per quella passione, ch'egli ha d'aver compagnia,
 e di farsi mangiare il suo.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Ho piacere, che la signora Giacinta non ne abbia
 parte. Mi pareva quasi impossibile, sapendo quel, che è
 passato fra lei, e me.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>E che cosa è passato fra lei, e voi?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Delle parole, che l'assicurano, ch'io l'amo, e che
 mi fanno sperare, ch'ella mi ami.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>E il padre suo non sa niente?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Per parte mia non lo sa.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>E convien credere, ch'ei non lo sappia, perché,
 dicendogli, che vi sarebbe un partito per sua figliuola, non
 gli è caduto in mente di domandarmi di voi.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Non lo saprà certamente.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Ma è necessario, ch'egli lo sappia.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Un giorno glielo faremo sapere.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>E perché non adesso?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Adesso si sta per andare in campagna.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Amico, parliamo chiaro. Io vi ho servito assai
 volentieri presso il signor Filippo, per far ch'ei staccasse
@@ -4326,31 +4366,31 @@ dichiaratevi col signor Filippo, o gli farò, riguardo a voi,
 quella lezione medesima, che gli ho fatto rispetto al signor
 Guglielmo.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>E che cosa mi consigliate di fare?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>O chiederla a drittura, o ritirarvi dalla sua
 conversazione.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>E come ho da fare a chiederla in questi brievi
 momenti?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Questa è una cosa, che si fa presto. Mi esibisco io
 di servirvi.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Non si potrebbe aspettare al ritorno dalla
 campagna?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Eh! in una villeggiatura non si sa quel, che possa
 accadere. Sono stato giovane anch'io; per grazia del Cielo,
@@ -4358,69 +4398,69 @@ pazzo non sono stato, ma ho veduto delle pazzie. L'obbligo
 mio vuol, ch'io parli chiaro all'amico, o per domandargli la
 figlia, o per avvertirlo, che si guardi da voi.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Quand'è così, domandiamola dunque.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Con che condizione volete voi, ch'io gliela
 domandi?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Circa alla dote, si sa, che le ha destinato otto
 mila scudi, e il corredo.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Siete contento?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Contentissimo.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Quanto tempo volete prendere per isposarla?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Quattro, sei, otto mesi, come vuole il signor
 Filippo.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Benissimo. Gli parlerò.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Ma avvertite, che oggi si dee partire per
 Montenero.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Non si potrebbe differir qualche giorno?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Non c'è caso, non si può differire.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Ma, l'affare di cui si tratta, merita, che si
 sagrifichi qualche cosa.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Se si trattiene il signor Filippo, mi tratterrò
 ancor io, ma vedrete, che sarà impossibile.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>E perché impossibile?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Perché tutti vanno, e il signor Filippo vorrà
 andare, e la signora Giacinta infallibilmente oggi vorrà
@@ -4428,7 +4468,7 @@ partire, e mia sorella mi tormenta all'estremo per
 l'impazienza d'andare, e per cento ragioni io non mi potrò
 trattenere.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Poh! fin dove è arrivata la passione del
 villeggiare! Un giorno pare un secolo. Tutti gli affari
@@ -4448,16 +4488,16 @@ Vado a servirvi immediatamente (<emph>parte</emph>).</p>
         <div type="scene">
           <head>Scena seconda</head>
           <stage><emph>Leonardo, poi Cecco</emph>.</stage>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Eh! dice bene; mi saprò regolare; metterò la testa
 a partito. Ehi, chi è di là?</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>Signore.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Va' subito dal signor Filippo, e dalla signora
 Giacinta. Di' loro, che mi sono liberato da' miei affari, e
@@ -4466,16 +4506,16 @@ Montenero. Soggiungi, che avrei una compagnia da dare a mia
 sorella in calesso, e che, se me lo permettono, andrò io
 nella carrozza con loro. Fa' presto, e portami la risposta.</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>Sarà obbedita.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Di' al cameriere, che venga qui, e che venga
 subito.</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>Sì, signore. (Oh quante mutazioni in un giorno!) (<emph>parte</emph>).</p>
           </sp>
@@ -4483,7 +4523,7 @@ subito.</p>
         <div type="scene">
           <head>Scena terza</head>
           <stage><emph>Leonardo, poi Paolo</emph>.</stage>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Ora, che nella carrozza loro non va Guglielmo, non
 ricuseranno la mia compagnia; sarebbe un torto manifesto,
@@ -4494,87 +4534,87 @@ d'andar io. Con mia sorella vedrò, che ci vada il signor
 Ferdinando. Già so, com'egli è fatto, non si ricorderà più
 quello, che gli ho detto.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Eccomi a' suoi comandi.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Presto, mettete all'ordine quel, che occorre, e
 fate ordinare i cavalli, che a ventun'ora s'ha da partire.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Oh! bella!</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>E spicciatevi.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>E il desinare?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>A me non importa il desinare. Mi preme, che siamo
 lesti per la partenza.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Ma io ho disfatto tutto quello, che aveva fatto.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Tornate a fare.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>È impossibile.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Ha da esser possibile, e ha da esser fatto.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>(Maledetto sia il servire in questa maniera).</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>E voglio il caffè, la cera, lo zucchero, la
 cioccolata.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Io ho reso tutto ai mercanti.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Tornate a ripigliare ogni cosa.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Non mi vorranno dar niente.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Non mi fate andar in collera.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Ma, signore...</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Non c'è altro da dire. Spicciatevi.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Vuole che gliela dica? Si faccia servire da chi
 vuole, ch'io non ho abilità per servirla.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>No, Paolino mio, non mi abbandonate. Dopo tanti
 anni di servitù, non mi abbandonate. Si tratta di tutto. Vi
@@ -4586,7 +4626,7 @@ necessità di fare gli ultimi sforzi per comparire? Avrete
 core ora di dirmi, che non si può, che è impossibile, che
 non mi potete servire?</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Caro signor padrone, la ringrazio della confidenza,
 che si è degnato di farmi: farò il possibile; sarà servita.
@@ -4596,14 +4636,14 @@ Se credessi di far col mio, la non dubiti, sarà servita (<emph>parte</emph>).</
         <div type="scene">
           <head>Scena quarta</head>
           <stage><emph>Leonardo, poi Vittoria</emph>.</stage>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>È un buon uomo, amoroso, fedele; dice, che farà,
 se credesse di far col suo. Ma m'immagino già, che quel che
 ora è suo, una volta sarà stato mio. Frattanto vo' rimettere
 in ordine il mio baule.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Orsù, signor fratello, vengo a dirvi liberamente,
 che da questa stagione in Livorno non ci sono mai stata, e
@@ -4611,77 +4651,77 @@ non ci voglio stare, e voglio andare in campagna. Ci va la
 signora Giacinta, ci vanno tutti, e ci voglio andar ancor
 io (<emph>con caldo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>E che bisogno c'è, che mi venite ora a parlare con
 questo caldo?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Mi scaldo; perché ho ragione di riscaldarmi, e
 andrò in campagna con mia cugina Lucrezia, e con suo marito.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>E perché non volete venire con me?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Quando?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Oggi.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Dove?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>A Montenero.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Voi?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Io.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Oh!</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Sì, da galantuomo.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Mi burlate?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Dico davvero.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Davvero, davvero?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Non vedete, ch'io fo il baule?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Oh! fratello mio, come è stata?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Vi dirò: sappiate che il signor Fulgenzio...</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Sì, sì, mi racconterete poi. Presto, donne, dove
 siete? Donne, le scattole, la biancheria, le scuffie, gli
@@ -4691,7 +4731,7 @@ abiti, il mio <emph>mariage</emph> (<emph>parte</emph>).</p>
         <div type="scene">
           <head>Scena quinta</head>
           <stage><emph>LEONARDO, poi CECCO</emph>.</stage>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>È fuor di sé dalla consolazione. Certo, che se
 restava in Livorno, non le se poteva dare una mortificazione
@@ -4700,15 +4740,15 @@ fa fare delle gran cose. L'amore fa fare degli spropositi.
 Per un puntiglio, per una semplice gelosia, sono stato in
 procinto di abbandonare la villeggiatura.</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>Eccomi di ritorno.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>E così, che hanno detto?</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>Li ho trovati padre, e figlia, tutti e due insieme.
 M'hanno detto di riverirla; che avranno piacere della di lei
@@ -4716,60 +4756,60 @@ compagnia per viaggio, ma che circa il posto nella carrozza,
 abbia la bontà di compatire, che non la possono servire,
 perché sono impegnati a darlo al signor Guglielmo.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Al signor Guglielmo?</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>Così m'hanno detto.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Hai tu capito bene? Al signor Guglielmo?</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>Al signor Guglielmo.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>No, non può essere. Sei uno stolido, sei un
 balordo.</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>Io le dico, che ho capito benissimo, e in segno
 della mia verità, quando io scendeva le scale, saliva il
 signor Guglielmo col suo servitore col valigino.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Povero me! non so dove mi sia. Mi ha tradito
 Fulgenzio, mi scherniscono tutti, son fuor di me. Sono
 disperato (<emph>siede</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>Signore.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Portami dell'acqua.</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>Da lavar le mani?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Un bicchier d'acqua, che tu sia maladetto (<emph>s'alza</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>Subito. (Non si va più in campagna) (<emph>parte</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Ma come mai quel vecchio, quel maladetto vecchio,
 ha potuto ingannarmi? L'averanno ingannato. Ma se mi ha
@@ -4782,58 +4822,58 @@ dipende. Sarà dunque stato Fulgenzio; ma per qual ragione mi
 ha da tradire Fulgenzio? Non so niente, son io la bestia, il
 pazzo, l'ignorante...</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>(<emph>viene coll'acqua</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#leon">
             <speaker>LEON</speaker>
             <p>Sì, pazzo, bestia (<emph>non vedendo Cecco</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>Ma! perché bestia?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Sì, bestia, bestia (<emph>prendendo l'acqua</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>Signore, io non sono una bestia.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Io, io sono una bestia, io (<emph>beve l'acqua</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>(In fatti le bestie bevono l'acqua, ed io bevo il
 vino).</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Va' subito dal signor Fulgenzio. Guarda, s'è in
 casa. Digli, che favorisca venir da me, o che io andrò da
 lui.</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>Dal signor Fulgenzio, qui dirimpetto?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Sì, asino, da chi dunque?</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>Ha detto a me?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>A te.</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>(Asino, bestia, mi pare che sia tutt'uno) (<emph>parte</emph>).</p>
           </sp>
@@ -4841,62 +4881,62 @@ lui.</p>
         <div type="scene">
           <head>Scena sesta</head>
           <stage><emph>Leonardo, poi Paolo</emph>.</stage>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Non porterò rispetto alla sua vecchiaia, non
 porterò rispetto a nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Animo, animo, signore, stia allegro, che tutto sarà
 preparato.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Lasciatemi stare.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Perdoni; io ho fatto il debito mio, e più del
 debito mio.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Lasciatemi stare, vi dico.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Vi è qualche novità?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Sì, pur troppo.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>I cavalli sono ordinati.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Levate l'ordine.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Un'altra volta?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Oh! maledetta la mia disgrazia!</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Ma che cosa gli è accaduto mai?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Per carità, lasciatemi stare.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>(Oh! povero me! andiamo sempre di male in peggio).</p>
           </sp>
@@ -4904,57 +4944,57 @@ debito mio.</p>
         <div type="scene">
           <head>Scena settima</head>
           <stage><emph>Vittoria con un vestito piegato, e detti</emph>.</stage>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Fratello, volete vedere il mio <emph>mariage</emph>?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Andate via.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Che maniera è questa?</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>(Lo lasci stare) (<emph>piano a Vittoria</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Che diavolo avete?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Sì, ho il diavolo; andate via.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>E con questa bella allegria si ha da andare in
 campagna?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Non vi è più campagna; non vi è più villeggiatura,
 non vi è più niente.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Non volete andare in campagna?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>No, non ci vado io, e non ci anderete nemmeno voi.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Siete diventato pazzo?</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>(Non lo inquieti di più per amor del Cielo) (<emph>a Vittoria</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Eh! non mi seccate anche voi (<emph>a Paolo</emph>).</p>
           </sp>
@@ -4962,67 +5002,67 @@ non vi è più niente.</p>
         <div type="scene">
           <head>Scena ottava</head>
           <stage><emph>Cecco e detti</emph>.</stage>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>Il signor Fulgenzio non c'è (<emph>a Leonardo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Dove il diavolo se l'ha portato?</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>Mi hanno detto, che è andato dal signor Filippo.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Il cappello, e la spada (<emph>a Paolo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Signore...</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Il cappello, e la spada (<emph>a Paolo più forte</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Subito (<emph>va a prendere il cappello, e la spada</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Ma si può sapere? (<emph>a Leonardo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Il cappello, e la spada.</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Eccola servita (<emph>gli dà il cappello, e la spada</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Si può sapere, che cosa avete? (<emph>a Leonardo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Lo saprete poi (<emph>parte</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Ma che cosa ha? (<emph>a Paolo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Non so niente. Gli vo' andar dietro alla lontana.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Sai tu, che cos'abbia? (<emph>a Cecco</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#cecco">
             <speaker>CECCO</speaker>
             <p>Io so, che m'ha detto asino; non so altro (<emph>parte</emph>).</p>
           </sp>
@@ -5030,7 +5070,7 @@ non vi è più niente.</p>
         <div type="scene">
           <head>Scena nona</head>
           <stage><emph>Vittoria, poi Ferdinando</emph>.</stage>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Io resto di sasso, non so, in che mondo mi sia.
 Vengo a casa, lo trovo allegro, mi dice: Andiamo in
@@ -5041,98 +5081,98 @@ mai. Se questa di mio fratello è una malatia, addio
 campagna, addio Montenero. Va' là tu pure, maladetto abito.
 Poco ci mancherebbe, che non lo tagliassi in minuzzoli (<emph>getta il vestito sulla sedia</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Eccomi qui a consolarmi colla signora Vittoria.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Venite anche voi a rompermi il capo?</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Come, signora? Io vengo qui per un atto di
 urbanità, e voi mi trattate male?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Che cosa siete venuto a fare?</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>A consolarmi, che anche voi anderete in campagna.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Oh! se non fosse perché, perché... mi sfogherei con
 voi di tutte le consolazioni, che ho interne.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Signora, io sono compiacentissimo. Quando si tratta
 di sollevar l'animo di una persona, si sfoghi con me, che le
 do licenza.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Povero voi, se vi facessi provar la bile, che mi
 tormenta.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Ma cosa c'è? Cosa avete? Cosa v'inquieta?
 Confidatevi meco. Con me potete parlare con libertà. Siete
 sicura, ch'io non lo dico a nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Sì, certo, confidatevi alla tromba della comunità.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Voi mi avete in mal credito, e non mi pare di
 meritarlo.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Io dico quello, che sento dire da tutti.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Come possono dire, ch'io dica i falli degli altri?
 Ho mai detto niente a voi di nessuno?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Oh! mille volte; e della signora Aspasia, e della
 signora Flamminia, e della signora Francesca.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Ho detto io?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Sicuro.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Può essere, che l'abbia fatto, senza avvedermene.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Eh già, quel che si fa per abito, non si ritiene.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>In somma dunque siete arrabbiata, e non mi volete
 dire il perché?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>No, non vi voglio dir niente.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Sentite. O sono un galantuomo, o sono una mala
 lingua. Se sono un galantuomo, confidatevi, e non abbiate
@@ -5140,56 +5180,56 @@ paura. Se fossi una mala lingua, sarebbe in arbitrio mio
 interpretare le vostre smanie, e trarne quel ridicolo, che
 più mi paresse.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Volete ch'i' ve la dica? Davvero davvero, siete un
 giovane spiritoso (<emph>ironica</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Son galantuomo, signora. E quando si può parlare,
 parlo, e quando s'ha da tacere, taccio.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Orsù, perché non crediate quel, che non è; e non
 pensiate quel, che vi pare, vi dirò, che per me medesima non
 ho niente, ma mio fratello è inquietissimo, è fuor di sé, è
 delirante, e per cagione sua divento peggio di lui.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Sì, sarà delirante per la signora Giacinta. È una
 frasca, è una civetta, dà retta a tutti, si discredita, si
 fa ridicola da pertutto.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Per altro voi non dite mal di nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Dov'è il signor Leonardo?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Io credo, che sia andato da lei.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Con licenza.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Dove, dove?</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>A ritrovare l'amico, a soccorrerlo, a consigliarlo.
 (A raccogliere qualche cosa per la conversazione di
 Montenero) (<emph>parte</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Ed io, che cosa ho da fare? Ho da aspettar mio
 fratello, o ho da andare da mia cugina? Bisognerà che io
@@ -5205,43 +5245,43 @@ ci anderò a suo dispetto (<emph>parte</emph>).</p>
           <head>Scena decima</head>
           <stage>Camera in casa del signor Filippo.</stage>
           <stage><emph>Filippo, e Fulgenzio</emph>.</stage>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Per me vi dico, son contentissimo. Il signor
 Leonardo è un giovane proprio, civile, di buona nascita, ed
 ha qualche cosa del suo. È vero che gli piace a spendere, e
 specialmente in campagna, ma si regolerà.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Eh! per questa parte, non avete occasion di
 rimproverarlo.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Volete dire, perché faccio lo stesso anch'io? Ma vi
 è qualche differenza da lui a me.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Basta, non so, che dire. Voi lo conoscete. Voi
 sapete il suo stato, dategliela, se vi pare; se non vi pare,
 lasciate.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Io gliela do volentieri. Basta, ch'ella ne sia
 contenta.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Eh! mi persuado, che non dirà di no.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Sapete voi qualche cosa?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Sì, so più di voi, e so quello, che dovreste saper
 meglio voi. Un padre dee tener gli occhi aperti sulla sua
@@ -5253,86 +5293,86 @@ diceva: è donna. Con tutta la sua saviezza, con tutta la sua
 prudenza sono passati degli amoretti fra lei e il signor
 Leonardo.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Oh! sono passati degli amoretti?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Sì, e ringraziate il Cielo, che avete a fare con un
 galantuomo; e dategliela, che farete bene.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Sicuramente. Gliela darò, ed ei l'ha da prendere, ed
 ella l'ha da volere. Fraschetta! Amoretti, eh!</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Cosa credete? Che le ragazze siano di stucco?
 Quando si lasciano praticare...</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Ha detto di venir qui il signor Leonardo?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>No, anderò io da lui; e lo condurrò da voi, e che
 concludiamo.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Sempre più mi confesso obbligato al vostro amore,
 alla vostra amicizia.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Vedete se ho fatto bene io a persuadervi a staccare
 dal fianco di vostra figlia il signor Guglielmo?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>(Oh diavolo! E l'amico è in casa).</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Leonardo non l'intendeva, ed aveva ragione, e se il
 signor Guglielmo andava in campagna con voi, non la prendeva
 più certamente.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>(Povero me! Sono più che mai imbarazzato).</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>E badate bene, che il signor Guglielmo non si trovi
 più in compagnia di vostra figliuola.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>(Se Giacinta non trova ella qualche ragione, io non
 la trovo sicuro).</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Parlate con vostra figlia, ch'io intanto andrò a
 ritrovare il signor Leonardo.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Benissimo... Bisognerà vedere...</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Vi è qualche difficoltà?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Niente, niente.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>A buon rivederci, dunque. Or ora sono da voi
 (<emph>in atto di partire</emph>).</p>
@@ -5341,92 +5381,92 @@ ritrovare il signor Leonardo.</p>
         <div type="scene">
           <head>Scena undicesima</head>
           <stage><emph>Guglielmo, e detti</emph>.</stage>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <p>Signore, le ventuna sono poco lontane. Se comandate
 anderò io a sollecitare i cavalli.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Cosa vedo? Guglielmo?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>(Che tu sia maladetto!) No, no, non importa; non si
 partirà più così presto. Ho qualche cosa da fare... (Non so
 nemmeno quel, che mi dica).</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Si va in campagna, signor Guglielmo?</p>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <p>Per obbedirla.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>(Io non ho coraggio di dirgli niente).</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>E con chi va in campagna, se è lecito?</p>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <p>Col signor Filippo.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>In carrozza con lui?</p>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <p>Per l'appunto.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>E colla signora Giacinta?</p>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <p>Sì, signore.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>(Buono!)</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>O via, andate a sollecitare i cavalli (<emph>a Guglielmo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <p>Ma se dite, che vi è tempo.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>No, no, andate, andate.</p>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <p>Io non vi capisco.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Fate, che diano loro la biada, e fatemi il piacere
 di star lì presente, perché la mangino, e che gli stallieri
 non gliela levino.</p>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <p>La pagate voi la biada?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>La pago io. Andate.</p>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <p>Non occorr'altro. Sarete servito (<emph>parte</emph>).</p>
           </sp>
@@ -5434,42 +5474,42 @@ non gliela levino.</p>
         <div type="scene">
           <head>Scena dodicesima</head>
           <stage><emph>Fulgenzio e Filippo</emph>.</stage>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>(Finalmente se n'è andato).</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Bravo, signor Filippo.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Bravo, bravo... quando si dà una parola...</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Sì, mi avete dato parola, e me l'avete ben
 mantenuta.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>E non aveva io data prima la parola a lui?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>E se non volevate mancar a lui, perché promettere a
 me?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Perché aveva intenzione di fare quello, che mi avete
 detto di fare.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>E perché non l'avete fatto?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Perché... d'un male minore, si poteva fare un male
 peggiore; perché avrebbero detto... perché avrebbero
@@ -5477,90 +5517,90 @@ giudicato... oh, cospetto di bacco! Se aveste sentito le
 ragioni che ha detto mia figlia, vi sareste ancora voi
 persuaso.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Ho capito. Non si tratta così coi galantuomini pari
 miei. Non sono un burattino da farmi far di queste figure.
 Mi giustificherò col signor Leonardo. Mi pento d'esserci
 entrato. Me ne lavo le mani, e non c'entrerò più (<emph>in atto di partire</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>No, sentite.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Non vo' sentir altro.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Sentite una parola.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>E che cosa mi potete voi dire?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Caro amico, sono così confuso, che non so in che
 mondo mi sia.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Mala condotta, scusatemi, mala condotta.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Rimediamoci per carità.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>E come ci volete voi rimediare?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Non siamo in tempo ancora di licenziare il signor
 Guglielmo?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Non l'avete mandato a sollecitare i cavalli?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Per levarmelo d'attorno, che miglior pretesto potea
 trovare?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>E quando tornerà coi cavalli?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Sono in un mare di confusioni.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Fate così, piuttosto tralasciate d'andare in
 campagna.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>E come ho da fare?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Fatevi venir male.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>E che male m'ho da far venire?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Il cancaro che vi mangi (<emph>sdegnato</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Non andate in collera.</p>
           </sp>
@@ -5568,31 +5608,31 @@ campagna.</p>
         <div type="scene">
           <head>Scena tredicesima</head>
           <stage><emph>Leonardo, e detti</emph>.</stage>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Ho piacere di ritrovarvi qui tutti e due. Chi è di
 voi, che si prende spasso di me? Chi è, che si burla de'
 fatti miei? Chi mi ha fatto l'insulto?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Rispondetegli voi (<emph>a Filippo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Caro amico, rispondetegli voi (<emph>a Fulgenzio</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Così si tratta coi galantuomini? Così si tratta coi
 pari miei? Che modo è questo? Che maniera impropria,
 incivile?</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Ma rispondetegli (<emph>a Filippo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Ma se non so cosa dire! (<emph>a Fulgenzio</emph>).</p>
           </sp>
@@ -5600,29 +5640,29 @@ incivile?</p>
         <div type="scene">
           <head>Scena quattordicesima</head>
           <stage><emph>Giacinta e detti</emph>.</stage>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Che strepito è questo? Che piazzate son queste?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Signora, le piazzate non le fo io. Le fanno quelli,
 che si burlano de' galantuomini, che mancano di parola, che
 tradiscono sulla fede.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Chi è il reo? Chi è il mancatore? (<emph>con caricatura</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Parlate voi (<emph>a Filippo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Favoritemi di principiar voi (<emph>a Fulgenzio</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Orsù, ci va del mio in quest'affare. Poiché il
 diavolo mi ci ha fatto entrare, a tacere ci va del mio, e se
@@ -5632,98 +5672,98 @@ dato parola, che il signor Guglielmo non sarebbe venuto con
 voi, mancargli, farlo venire, condurlo in villa, è un'azion
 poco buona, è un trattamento incivile.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Che dite voi, signor padre?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Ha parlato con voi. Rispondete voi.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Favorisca in grazia, signor Fulgenzio, con qual
 autorità pretende il signor Leonardo di comandare in casa
 degli altri?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Con quell'autorità che un amante...</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Perdoni, ora non parlo con lei (<emph>a Leonardo</emph>).
 Mi risponda il signor Fulgenzio. Come ardisce il signor Leonardo pretendere
 da mio padre, e da me, che non si tratti chi pare a noi, e
 non si conduca in campagna chi a lui non piace?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Voi sapete benissimo...</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Non dico a lei; mi risponda il signor Fulgenzio.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>(Oh! non sarà vero degli amoretti, non parlerebbe
 così).</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Poiché volete, che dica io, dirò io. Il signor
 Leonardo non direbbe niente, non pretenderebbe niente, se
 non avesse intenzione di pigliarvi per moglie.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Come! Il signor Leonardo ha intenzione di volermi
 in isposa? (<emph>a Fulgenzio</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Possibile, che vi giunga nuovo?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Perdoni. Mi lasci parlar col signor Fulgenzio (<emph>a Leonardo</emph>).
 Dite, signore, con qual fondamento potete voi asserirlo? (<emph>a Fulgenzio</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Col fondamento, che io medesimo, per commissione
 del signor Leonardo, ne ho avanzata testé a vostro padre la
 proposizione.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Ma veggendomi ora sì maltrattato...</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Di grazia, s'accheti. Ora non tocca a lei; parlerà,
 quando toccherà a lei (<emph>a Leonardo</emph>). Che dice su di ciò il signor padre?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>E che cosa direste voi?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>No, dite prima quel, che pensate voi. Dirò poi
 quello, che penso io.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Io dico che, in quanto a me, non ci avrei
 difficoltà.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Ma io dico presentemente...</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Ma se ancora non tocca a lei! Ora tocca parlare a
 me. Abbia la bontà d'ascoltarmi, e poi, se vuole, risponda.
@@ -5769,31 +5809,31 @@ mi amate. Se vi preme il cuore o la mano. La mano è pronta,
 se la volete. Ma il cuore, meritatelo, se desiderate di
 conseguirlo.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Ah! che dite? (<emph>a Fulgenzio</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>(Io non la prenderei, se avesse cento mila scudi di
 dote) (<emph>piano a Filippo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>(Sciocco!)</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Non so, che dire, vi amo, desidero sopra tutto il
 cuor vostro. Mi avete dette delle ragioni, che mi
 convincono. Non voglio esservi ingrato. Servitevi, come vi
 pare, ed abbiate pietà di me.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>(Uh, il baccellone!)</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>(Niente m'importa, che venga meco Guglielmo. Basta,
 che non mi contraddica Leonardo).</p>
@@ -5802,24 +5842,24 @@ che non mi contraddica Leonardo).</p>
         <div type="scene">
           <head>Scena quindicesima</head>
           <stage><emph>Brigida, e detti</emph>.</stage>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Signore, è qui la sua signora sorella col di lei
 cameriere.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Con permissione; che passino.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>(Si va, o non si va?) (<emph>piano a Giacinta</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>(Si va, si va) (<emph>piano a Brigida</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>(Aveva una paura terribile, che non si andasse) (<emph>parte</emph>).</p>
           </sp>
@@ -5827,184 +5867,184 @@ cameriere.</p>
         <div type="scene">
           <head>Scena sedicesima</head>
           <stage><emph>Vittoria, Paolo, Brigida, e detti</emph>.</stage>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>È permesso? (<emph>melanconica</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Sì, vita mia, venite.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>(Eh, vita mia, vita mia!) Come vi sentite, signor
 Leonardo? (<emph>come sopra</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Benissimo, grazie al Cielo. Paolino, presto, fate,
 che tutto sia lesto e pronto. Il baule, i cavalli, tutto
 quel, che bisogna. Noi partirem fra poco.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Si parte? (<emph>allegra</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Sì, vita mia, si parte. Siete contenta?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Sì, gioia mia, sono contentissima.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Ho piacere, che fra cognate si amino (<emph>piano a Fulgenzio</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Io credo, che si amino, come il lupo e la pecora
 (<emph>a Filippo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>(Che uomo fantastico!)</p>
           </sp>
-          <sp>
+          <sp who="#paolo">
             <speaker>PAOLO</speaker>
             <p>Sia ringraziato il Cielo, che lo vedo rasserenato (<emph>parte</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Via, fratello, andiamo anche noi.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Siete molto impaziente.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Poverina! è smaniosa per andare in campagna.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Sì, poco più, poco meno, come voi all'incirca.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>E volete andare in campagna senza concludere, senza
 stabilire il contratto?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Che contratto?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Prima di partire si potrebbe fare la scritta.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Che scritta?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Io son prontissimo a farla.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>E che cosa avete da fare?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Si chiamano due testimoni.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Che cosa far di due testimoni?</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Non lo sa? (<emph>a Vittoria</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Non so niente.</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Se non lo sa, lo saprà.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Signor fratello.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Comandi.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Si fa lo sposo?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Per obbedirla.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>E a me non si dice niente?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Se mi darete tempo, ve lo dirò.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>È questa la vostra sposa?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Sì, cara, sono io, che ha questa fortuna. Mi
 vorrete voi bene?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Oh quanto piacere! Quanta consolazione ne sento!
 Cara la mia cognata (<emph>si baciano</emph>). (Non ci mancava altro, che venisse in
 casa costei).</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>(Prego il Cielo, che vada presto fuori di casa).</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>(Quei baci, credo, che non arrivino al core).</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>(Vedete, se si vogliono bene!) (<emph>a Fulgenzio</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>(Sì, lo vedo. Voi non conoscete le donne) (<emph>a Filippo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>(Mi fa rabbia).</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Eccoli, eccoli; ecco due testimoni.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>(Ah! ecco Guglielmo, egli è la mia disperazione;
 non lo posso vedere) (<emph>da sé, osservando fra le scene</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>(Che caro signor fratello! Prender moglie, prima di
 dare marito a me! Sentirà, sentirà, se gli saprò dire
@@ -6014,174 +6054,174 @@ l'animo mio...)</p>
         <div type="scene">
           <head>Scena ultima</head>
           <stage><emph>Guglielmo, Ferdinando e detti</emph>.</stage>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <p>I cavalli son lesti.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Animo, animo, che fa tardi. Come sta l'amico
 Leonardo? Vi è passata la melanconia?</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Che cosa sapete voi di melanconia?</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Eh! ha detto un non so che la signora Vittoria.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Non è vero niente, non v'ho detto niente.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Eh! una mentita da una donna si può soffrire.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Signori, prima di partire si ha da fare una cosa. Il
 signor Leonardo ha avuto la bontà di domandarmi la mia
 figliuola, ed io gliel'ho promessa. Si faranno le nozze...
 Quando vorreste voi si facessero? (<emph>a Leonardo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Io direi dopo la villeggiatura.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Benissimo, si faranno dopo la villeggiatura, e
 intanto si ha da fare, la scritta. Onde siete pregati ad
 esser voi testimoni.</p>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <p>(Questa è una novità, ch'io non m'aspettava).</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Son qui; molto volentieri. Facciamo presto quello,
 che si ha da fare, e partiamo per la campagna. Ma a
 proposito, signori miei, a me qual luogo vien destinato?</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Non saprei... Che dite voi, Giacinta?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Tocca a voi a disporre.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>E il signor Guglielmo? Mi dispiace... Come si farà?</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Permettetemi, che io dica una cosa (<emph>a Filippo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Trovate voi l'espediente, signora.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Io dico che se mio fratello è promesso colla
 signora Giacinta, tocca a lui a andare in carrozza colla sua
 sposa.</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Così vorrebbe la convenienza, signor Filippo.</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>Che cosa dice Giacinta?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Io non invito nessuno, e non ricuso nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Cosa dice il signor Guglielmo?</p>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <p>Io dico, che se sono d'incomodo, tralascierò di
 venire.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>No, no, verrete in calesso con me.</p>
           </sp>
-          <sp>
+          <sp who="#guglielmo">
             <speaker>GUGLIELMO</speaker>
             <p>(La convenienza vuole, ch'io non insista). Se il
 signor Leonardo me lo permette, accetterò le grazie della
 signora Vittoria.</p>
           </sp>
-          <sp>
+          <sp who="#leonardo">
             <speaker>LEONARDO</speaker>
             <p>Sì, caro amico, ed io della vostra compiacenza vi
 sarò eternamente obbligato.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>(Quando ha ceduto da sé, non m'importa. Io ho
 sostenuto il mio punto).</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>(Ah! che dite? Va bene ora?) (<emph>a Fulgenzio</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>(Non va troppo bene per la signora Vittoria) (<emph>a Filippo</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#filippo">
             <speaker>FILIPPO</speaker>
             <p>(Eh! freddure) (<emph>a Fulgenzio</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Ed io con chi devo andare?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Signore, se vi degnaste di andar colla mia
 cameriera?</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>In calesso?</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>In calesso.</p>
           </sp>
-          <sp>
+          <sp who="#ferdinando">
             <speaker>FERDINANDO</speaker>
             <p>Sì, gioia bella, avrò il piacere di godere la
 vostra amabile compagnia (<emph>a Brigida</emph>).</p>
           </sp>
-          <sp>
+          <sp who="#brigida">
             <speaker>BRIGIDA</speaker>
             <p>Oh! sarà una gloria per me strabocchevole. (Sarei
 andata più volentieri col cameriere).</p>
           </sp>
-          <sp>
+          <sp who="#fulgenzio">
             <speaker>FULGENZIO</speaker>
             <p>Bravi, bene, tutti d'accordo.</p>
           </sp>
-          <sp>
+          <sp who="#vittoria">
             <speaker>VITTORIA</speaker>
             <p>Oh! via finiamola una volta. Andiamo a questa
 benedetta campagna.</p>
           </sp>
-          <sp>
+          <sp who="#giacinta">
             <speaker>GIACINTA</speaker>
             <p>Sì, facciamo la scritta, e subitamente partiamo.
 Finalmente siamo giunti al momento tanto desiderato d'andare

--- a/tei/goldoni-una-delle-ultime-sere-di-carnovale.xml
+++ b/tei/goldoni-una-delle-ultime-sere-di-carnovale.xml
@@ -87,6 +87,55 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="zamaria">
+            <persName>Zamaria</persName>
+          </person>
+          <person xml:id="baldissera">
+            <persName>Baldissera</persName>
+          </person>
+          <person xml:id="martin">
+            <persName>Martin</persName>
+          </person>
+          <person xml:id="cosmo">
+            <persName>Cosmo</persName>
+          </person>
+          <person xml:id="domenica">
+            <persName>Domenica</persName>
+          </person>
+          <person xml:id="elenetta">
+            <persName>Elenetta</persName>
+          </person>
+          <person xml:id="agustin">
+            <persName>Agustin</persName>
+          </person>
+          <person xml:id="marta">
+            <persName>Marta</persName>
+          </person>
+          <person xml:id="bastian">
+            <persName>Bastian</persName>
+          </person>
+          <person xml:id="momolo">
+            <persName>Momolo</persName>
+          </person>
+          <person xml:id="alba">
+            <persName>Alba</persName>
+          </person>
+          <person xml:id="lazaro">
+            <persName>Lazaro</persName>
+          </person>
+          <person xml:id="polonia">
+            <persName>Polonia</persName>
+          </person>
+          <person xml:id="anzoletto">
+            <persName>Anzoletto</persName>
+          </person>
+          <person xml:id="madama">
+            <persName>Madama Gatteau</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -298,28 +347,28 @@ e del mio soggiorno in Francia.</p>
           <stage>
             <emph>Zamaria, Baldissera, Cosmo, e Martin.</emph>
           </stage>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Putti, vegnì qua. Stassera ve dago festa. Semo in
 ti ultimi zorni de carneval. Dago da cena ai mi amici; dopo
 cena se balerà quatro menueti; vualtri darè una man, se
 bisogna, e po magnerè, goderè, ve devertirè.</p>
           </sp>
-          <sp>
+          <sp who="#baldissera">
             <speaker>BALDISSERA</speaker>
             <p>Sior sì, sior patron; grazie al so bon amor.</p>
           </sp>
-          <sp>
+          <sp who="#martin">
             <speaker>MARTIN</speaker>
             <p>Semo qua a servirla, e goderemo anca nu le so
 grazie.</p>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>COSMO</speaker>
             <p>Oe, stassera no sentiremo la realtina al teler</p>
             <stage>(<emph>agli altri giovani</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Ah! baron, veh! lo so, che ti gh'ha manco voggia dei
 altri de laorar. Peccà, peccà, che no ti applichi, che no ti
@@ -328,12 +377,12 @@ ti volessi, ti deventeressi el più bravo testor de sto
 paese. Ma, sia dito a to onor, e gloria, no ti gh'ha volontà
 de far ben.</p>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>COSMO</speaker>
             <p>No so cossa dir. Pol esser anca, che la diga la
 verità.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Oh! via, per stassera no disemo altro. Devertìmose,
 e che tutti goda. Doman po, sior Cosmo carissimo, dè drio a
@@ -342,80 +391,80 @@ dal manganer, a véder se i ha dà l'onda a quel amuer, e vu,
 sior Martin, scomenzerè a ordir quel camelotto color de
 gazìa</p>
           </sp>
-          <sp>
+          <sp who="#martin">
             <speaker>MARTIN</speaker>
             <p>Benissimo; e adesso cossa vorla, che femo?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Adesso, andè de là; vardè, se a mia fia ghe bisogna
 gnente; fè qualcossa, se ghe n'avè voggia; e se no savè
 cossa far, tolè el trottolo, e devertive.</p>
           </sp>
-          <sp>
+          <sp who="#martin">
             <speaker>MARTIN</speaker>
             <p>Oh, che caro sior patron! Almanco el xè sempre
 aliegro</p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#baldissera">
             <speaker>BALDISSERA</speaker>
             <p>La diga. Balerémio anca nu un per de balloni?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Sior sì. No se sàlo? Ha da balar tutti; balerò anca
 mi.</p>
           </sp>
-          <sp>
+          <sp who="#baldissera">
             <speaker>BALDISSERA</speaker>
             <p>Grazie; e viva; oh che gusto! (El xè un
 vecchietto, che propriamente el fa voggia)</p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>COSMO</speaker>
             <p>La diga, sior patron: me dàla licenza, che alla
 festa fazza vegnir una putta?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Una putta?</p>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>COSMO</speaker>
             <p>La vegnirà co so madre.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Chi èla?</p>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>COSMO</speaker>
             <p>Tognina, fia de siora Gnese, che incana sea.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Coss'è? Com'èla? Gh'è pericolo, che sta putta perda
 el giudizio?</p>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>COSMO</speaker>
             <p>Per cossa?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Gh'è pericolo, che la te creda?</p>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>COSMO</speaker>
             <p>Cossa songio?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Un furbazzo, un galiotto, che ghe n'ha burlà cinque.</p>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>COSMO</speaker>
             <p>E una sie. Patron, grazie. La farò vegnir. A bon
 reverirla</p>
@@ -427,7 +476,7 @@ reverirla</p>
           <stage>
             <emph>Zamaria, poi Domenica.</emph>
           </stage>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Peccà de costù! el gh'ha un'abilitadazza teribile;
 ma nol ghe tende. I fa cussì costori. I laora co i gh'ha
@@ -438,33 +487,33 @@ son quel, che son a forza de tenderghe, e de laorar. Sior
 sì, sfadigarse co se ghe xè, e gòder i amici ai so tempi,
 alle so stagion.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Oh! son qua, sior padre. Òggio fatto presto a
 vestirme?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Brava! chi t'ha conzà</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Mi; da mia posta.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Mo va là, che ti par conzada dal <emph>Veronese</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>E sì, tra conzarme e vestirme, a un'ora, e un quarto
 no ghe son arivada.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Brava! Ti xè una putta de garbo.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>E avanti de prencipiar, son andada in cusina; ho dà
 i mi ordeni; ho agiutà a far suso i raffioi; ho fatto metter
@@ -475,81 +524,81 @@ polpette; ho dà fora el vin; ho messo fora la biancaria. No
 me manca altro che tirar fora le possae, le sottocoppe, e
 quelle quatro bottiglie de vin de Cipro.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Mo via; mo se lo so; mo se ti xè una donetta de
 garbo.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>A cena, in quanti sarémio, sior padre?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Aspetta. No m'arecordo. Mio compare Lazaro co so
 muggier.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Credémio, che la vegna sior'Alba?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>La m'ha dito de sì. Per cossa no averàvela da
 vegnir?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>No sàlo, che cossa lessa, che la xè? La gh'ha sempre
 mal. No la magna, no la parla, no la sa zogar: ora ghe diol
 la testa, ora ghe diol el stomego, ora ghe vien le fumane.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Cossa vustu far? Sior Lazaro el xè mio compare. El
 xè anca élo de la mia profession; gh'avemo insieme de'
 negozieti. Qualcossa bisogna ben soportar.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>E chi altri ghe sarà?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Ho invidà sior Bastian.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Sior Bastian Caparetti?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Siora sì. Anca élo; perché el xè mercante da sea,
 ch'el me dà tutto l'anno da laorar.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>E so muggier?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Anca siora Marta.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Siora Marta se degnerala mo de vegnir?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Per cossa no s'averàvela da degnar?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>So che la sta sull'aria, che la pratica tutte le
 prime signore de Marzaria; che la va in te le prime
 conversazion.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>E per questo? Nu cossa sémio? No podemo star al pari
 de chi se sia? Sóngio qualche laorante? Son paron anca mi.
@@ -559,28 +608,28 @@ Credeu, perché la sta ben, perché la gh'ha dei bezzi, che la
 sia superba? Gnanca per insonio; vederè, vederè, co
 allegramente che la ne farà star.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>E chi altri vien, sior padre? Vienla sior'Elenetta?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Siora sì. No voleu, che abbia invidà mia fiozza
 Elenetta?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>E so mario?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>S'intende. Anca mio fiozzo Agustin.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Mo, co a bon'ora che quel putto s'ha maridà!</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>El s'ha maridà, perché bisognava, ch'el se
 maridasse. Sto matrimonio l'ho fatto mi. El xè restà fio
@@ -589,155 +638,155 @@ mistro testor. L'ha tolto in casa sta putta; la gh'ha dà dei
 bezzetti; la gh'ha una madre, che per el teler xè un
 oracolo; la sta con lori...</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>So madona sarà un oracolo; ma Agustin xè el più bel
 pampalugo, del mondo.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Cossa saveu?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>No se védelo!</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>El xè ben altrettanto bon.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Bon el xè? E mi ho sentio a dir, che tutto el dì
 mario e muggier no i fa altro che rosegarse.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Saveu perché? Perché i se vol ben. I xè tutti do
 zelosi; e per questo ogni men de che i ha qualcossa da
 tarocar; da resto, quel putto? el xè l'istessa bontà. Cussì
 te ne capitasse uno a ti.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Mi? de diana! Un mario alocco, no lo torave, se el
 me cargasse de oro.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Cossa voréssistu? Un spuzzetta? Un scartozzetto? Che
 te magnasse tutto? Che te fasse patir la fame?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>No ghe n'è dei putti, che gh'ha del spirito, e che
 xè boni?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Mi ho paura de no.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Eh! sior sì, che ghe n'è</p>
             <stage>(<emph>modestamente, ma con artifizio, mostrando ch'ella ne ha qualcheduno in veduta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Molto pochi, fia mia.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>E cussì? I àlo minzonai tutti queli, che ha da
 vegnir?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Aspettè. Chi òggio dito?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>No me par, che l'aveva dito de invidar sior
 Anzoletto dessegnador?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Ah! sì ben. Anca élo.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Questo giera quello, che me premeva).</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Tornemo a dir: mio compare...</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Eh! sior sì; m'arecordo tutti. I xè sette, e nu do,
 che fa nove.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>E la mistra, che fa diese.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Quala mistra?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>La filaoro.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Oh! gh'ho gusto, che vegna siora Polonia. El doveva
 invidar anca sior Momolo manganer.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>L'ho invidà, l'ho pregà; ho fatto de tutto per
 obligarlo a vegnir, e no gh'è stà caso. El dise, ch'el gh'ha
 un impegno, che nol pol vegnir.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Me despiase; perché el xè unico per tegnir in viva
 una conversazion. Donca co la mistra saremo diese.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Siora sì, a tola saremo diese; e fè parechiar de là
 per i putti.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Sior sì.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>E dèghe anca a lori le so possade d'arzento, e la so
 bozzetta de vin de Cipro.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Eh! a lori podemo dar del moscato.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Siora no; vòi, che i magna, e che i beva de tutto
 quel, che magnemo, e bevemo anca nu.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Oh! xè qua sior'Elena, e sior Agustin.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Oh! via, bravi; i ha fatto ben a vegnir. Scomenzemo
 a aver un pocheto de compagnia.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Mi vorave, che vegnisse sior Anzoletto).</p>
           </sp>
@@ -747,298 +796,298 @@ a aver un pocheto de compagnia.</p>
           <stage>
             <emph>Agustin, Elenetta, e i suddetti.</emph>
           </stage>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Oe, fiozza!</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Sior santolo, patron</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Bondì, fiozzo.</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Patrona, siora Domenica.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Sior'Elena, patrona.</p>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Patrona</p>
             <stage>(<emph>a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Patron</p>
             <stage>(<emph>a Agustin</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Semo qua a incomodarli.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Cossa dìsela? La ne fa finezza.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Oh! via. A monte le cerimonie. Mettè zoso el tabaro,
 e 'l capelo</p>
             <stage>(<emph>a Agustin</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <stage>(<emph>vuol metter il tabarro sul tavolino</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>De là, de là, in quell'altra camera.</p>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <stage>(<emph>va a metter giù <abbr>ecc.</abbr> e poi torna</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>La vegna qua; la resta servida</p>
             <stage>(<emph>fa sedere Elenetta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Fiozza, senza gnente in testa sè? No gh'avè paura de
 sfredirve?</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Cossa volévelo, che me mettesse el zendà?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>No gh'avè una prigioniera?</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>La gh'ho, ma no me l'ho messa.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Mo, che caro sior padre! L'ha da balar, e el vol,
 che la se desconza la testa!</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>In verità, che vualtre done sè bele; sè bele, da
 galantomo. Ora ve mettè in testa un stramazzo, ora andè
 colla testa nua.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Eh! via, caro élo; cossa sàlo élo?</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Voleva metterme qualcossa in testa, e Agustin no ha
 volesto.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Per cossa no àlo volesto?</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Perché el m'ha conzà élo.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Oh bella! el v'ha conzà élo? Per cossa?</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Perché mio mario no vol perucchieri per casa.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>El v'ha conzà élo? Bravo, pulito. Oe, fiozzo, vegnì
 qua. L'avè conzada da frìzer vostra muggier.</p>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Per cossa?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>No seu stà vu, che l'ha infarinada?</p>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Oh! che caro sior santolo!</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>La diga, sior'Elenetta: cossa fa so siora madre?</p>
             <stage>(<emph>a Elenetta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Eh! cussì, cussì. La m'ha dito, che la reverissa</p>
             <stage>(<emph>con un poco di sussiego</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Grazie.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Perché no xèla vegnua anca ela vostra madona?</p>
             <stage>(<emph>a Agustin</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>No so... No la xè vegnua; ma la xè stada a casa
 malvolentiera.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Oh bela! Perché no vegnir?</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Caro sior santolo, perché volévelo, che la
 vegnisse? No la xè miga invidada.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>E per questo? Mi no son andà drio a quelo. No
 gièrela patrona, se la voleva?</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Oh! no sàlo:</p>
             <l>Che chi va, e no xè invidai,</l>
             <l>Xè mal visti, o descazzai.</l>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Andè là, fiozzo, andèla a levar</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>No, no, no stè a andar, che za no la vegnirà</p>
             <stage>(<emph>a Agustin</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Se no la vol vegnir, che la lassa star.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Vardè dove, che se cazza l'ira! Le gh'ha bisogno, e
 le gh'ha tanta superbia!)</p>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Elena, voleu, che vaga?</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Sior no; no voggio, che andè.</p>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Mo per cossa?</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Perché no voggio.</p>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Vardè, che sesti; no la vol, che vaga!</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Sior no: no me fè inrabiar.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Animo, buttè a monte. No crie; che la xè una
 vergogna. Stè in pase. Voggiève ben.</p>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Mi? De diana! che la 'l diga ela, se ghe voggio
 ben.</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>E mi, sior? Podeu dir, che no ve ne voggia?</p>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Mi no digo ste cosse.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>V'avè tolto con tanto amor.</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>E se no l'avesse fatto, la torneria a far.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Sentìu, come che la parla?</p>
             <stage>(<emph>a Agustin</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>In quanto a questo, anca mi, se no l'avesse
 sposada, la sposeria.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Via, sièu benedetti! Me consolo de cuor.</p>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Ma quela so ustinazion, mi no la posso soffrir.</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Cossa ve fazzio?</p>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Tutto el dì la me brontola.</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Perché gh'ho rason.</p>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Per cossa gh'aveu rason?</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Perché gh'ho rason.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Oe! volémio fenirla? Fiozzo, vegnì con mi, che ve
 vòi mostrar un drapeto, che gh'ho sul teler, che no ve
 despiaserà.</p>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Sior sì. Lo vederò volentiera.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Sentì, fioi; mi ve parlo schietto. Sta sera gh'ho
 voggia de devertirme; v'ho invidà con tanto de cuor; ma
@@ -1053,114 +1102,114 @@ Andémo</p>
           <stage>
             <emph>Elena, e Domenica.</emph>
           </stage>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>In verità dasseno, per non darghe desturbo, squasi,
 squasi anderave via.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Eh! via, cara ela, la lassa andar.</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Mo, no séntela?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Ghe vorla veramente bene a sior Agustin?</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Se ghe voggio ben? De diana! Se stago un'ora senza
 de élo, me par de esser persa.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>No dìseli, ch'el xè tanto un bon putto?</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Siora sì, dasseno.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>E i cria donca?</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Cossa dìsela? Se volemo ben, e tutto el dì se
 magnemo i occhi.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>A mi mo, védela, sto ben nol me comoderia gnente
 affatto.</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>E mi son contenta, che no scambierave el mio stato
 con chi se sia.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>La gh'ha gusto a criar?</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Crio, ma ghe voggio ben.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>E lu?</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>E lu el cria, e el me vol ben.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Oh! cari.</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Cussì la xè.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Chi contenta gode.</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Mi son contenta, e godo.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Oh siestu! e po te pustu!) Oh! xè qua siora Marta
 co so mario.</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Chi xèli?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>No la li cognosse?</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Oh! mi no cognosso nissun.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>I xè marcanti da sea; ma de queli, sàla? che ghe
 piove la roba in casa da tutte le bande.</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Sia malignazo! Gh'ho suggizion. Me vergogno.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Eh! via, cara ela; la lassa, che la vaga a
 incontrar</p>
@@ -1172,61 +1221,61 @@ incontrar</p>
           <stage>
             <emph>Marta, Bastian, e dette</emph>
           </stage>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>(Anderave più volentiera dessuso con mio mario).</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Patrona riverita.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Patrona, siora Domenica.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Che grazie, che favori xè questi?</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Cossa dìsela? Semo qua a darghe incomodo.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Anzi el xè un onor, che nol meritemo.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Patrona; son qua anca mi a ricever le so care
 grazie.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Patron, sior Bastian. La se comoda; la me daga a mi
 el tabarin</p>
             <stage>(<emph>a Marta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Quel, che la comanda</p>
             <stage>(<emph>si cava il tabarin, e lo dà a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Anca élo, sior Bastian, el me daga el tabaro, e 'l
 capelo.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Eh! anderò mi...</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Sior no, sior no; cossa serve? Che el daga qua. Za
 ho d'andar de là a far un servizieto!</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Me despiase de incomodarla</p>
             <stage>(<emph>si cava <abbr>ecc.</abbr> e dà tutto a Domenica, ed ella parte</emph>).</stage>
@@ -1237,177 +1286,177 @@ ho d'andar de là a far un servizieto!</p>
           <stage>
             <emph>Marta, Bastian, ed Elena.</emph>
           </stage>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Patrona mia riverita</p>
             <stage>(<emph>ad Elena sedendo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Serva.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>(La cognosseu?)</p>
             <stage>(<emph>a Bastian</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>(Mi no)</p>
             <stage>(<emph>a Marta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Cossa dìsela de sto fredo?</p>
             <stage>(<emph>a Elena</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Cossa vorla? Semo in tel cuor de l'inverno</p>
             <stage>(<emph>a  Marta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>(Son ben curioso de saver chi la xè)</p>
             <stage>(<emph>da sé, andando dall'altra parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>La xè zovene assae. La lo sentirà poco el fredo.</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Oh! cossa dìsela? No son tanto zovene. Xè un ano,
 che son maridada.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Maridada la xè!</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Servirla.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Vardè, vedè! Mi no credeva.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Perméttela?</p>
             <stage>(<emph>siede presso di Elena</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>(Oh caro! Perché no se séntela arente de so
 muggier?)</p>
             <stage>(<emph>guardando verso la scena, e scostandosi</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Coss'è? No la vol, che me senta arente de ela?</p>
             <stage>(<emph>accostandosi</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>La se comoda pur. Con grazia</p>
             <stage>(<emph>s'alza e va a sedere dall'altra parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>(Mo, la godo ben dasseno).</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Coss'è, signora? Cossa gh'àla paura? Cossa crédela,
 che mi sia?</p>
             <stage>(<emph>a Elena</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Caro élo, el compatissa. So, che fazzo una mala
 creanza; ma se vien mio mario, poveretta mi.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Xèlo qualche vecchio sto so mario?</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Oh! sior no; el xè zovene più de mi.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>E patisse sto boccon de malinconia?</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Chi xèlo so consorte?</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Sior Agustin Menueli.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>(Oh! lo cognosso. No me dago gnente de maraveggia).</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>(L'ho dito, che nol podeva esser altro, che un
 pampalugo).</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Cossa vol dir, che nol xè qua anca élo, sior
 Agustin?</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Siora sì, che 'l ghe xè. El xè andà de suso co sior
 santolo Zamaria. De diana! la vorave, che fosse vegnua senza
 mio mario?</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Saràvelo un gran delitto? In casa de persone
 oneste, e civil, no se pol andar qualche volta senza so
 mario?</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Oh! mi no vago fora della porta senza de élo.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>E sior Agustin lo làssela andar? Lo làssela
 praticar?</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>De dia! che sgrafferave i occhi.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Oh! se fusse mi so mario...</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Cossa faràvelo?</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Ghe taggierave le ongie.</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Che 'l se consola, che so muggier no lo sgrafferà.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Dasseno! cossa voràvela dir?</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>(Eh! no ghe badè. No vedeu cossa, che la xè?)</p>
             <stage>(<emph>a Marta</emph>).</stage>
@@ -1418,115 +1467,115 @@ praticar?</p>
           <stage>
             <emph>Domenica, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Oh! son qua; che i compatissa, se son stada un
 pocheto tropo. I m'ha chiamà in cusina; son andada a dar
 un'occhiada. Perché, sàla? se no fusse mi in sta casa, no se
 farave mai gnente.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Eh! savemo, che puta, che la xè.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Quando magnémio sti confetti, siora Domenica?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Oh! per mi? l'ha ancora da nasser.</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>(Sarave ora, che 'l fusse nato).</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>La diga: quanto xè, che no la vede sior Anzoletto?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Qualo sior Anzoletto?</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Qualo? Quelo...</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Chi quelo?</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Mo via con quela bocca, che no pol tàser</p>
             <stage>(<emph>a Bastian</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Mi no digo gnente.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Come l'àli savesto, che tra Anzoletto, e mi ghe xè
 qualche prencipio? Non l'ho dito a nissun; no lo sa gnanca
 mio padre).</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>(Mo che zente, che se ne vol impazzar, dove che no
 ghe tocca!)</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Oh! vardè chi xè qua!</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Chi? sior Anzoletto?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Magari!) Sior Momolo, el manganer.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Gh'ho ben gusto dasseno. El xè el più caro matto
 del mondo.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>El belo xè, che sior padre l'aveva invidà, e 'l
 gh'ha dito, che nol podeva vegnir.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>No sàla? Lu gh'ha l'abilità de zirar in t'un zorno
 sette, o otto conversazion.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Cossa fàlo, che nol vien avanti?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>L'è capace d'averse fermà coi zoveni, a dirghe cento
 mile minchionerie.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Fermo de tutto, che 'l staga qua stassera.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Oh! mi no lo lasso andar via seguro.</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>(Cossa mai fàlo sto mio marìo, che nol vien? El me
 fa pensar cento cosse).</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Vèlo qua, vèlo qua sior Momolo.</p>
           </sp>
@@ -1536,38 +1585,38 @@ fa pensar cento cosse).</p>
           <stage>
             <emph>Momolo, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Patrone riverite.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Bravo, sior Momolo.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Bondì, Momolo.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Paron benedetto</p>
             <stage>(<emph>a Bastian</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Cossa feu qua? Meriteressi giusto, che ve mandassimo
 via.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Saldi; le se ferma, che ghe conterò, come che la xè
 stada.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Mo che panchiana!</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Gnente. L'ascolta un omo, col parla. Giera impegnà
 d'andar a cena in t'un logo. Son andà; m'ho informà chi ghe
@@ -1576,15 +1625,15 @@ una certa signora, che 'l so sangue no se confà col mio; e
 mi ho fatto dir alla parona de casa, che me xè vegnù la
 freve; e ho chiappà suso, e son vegnù via.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Bravo; avè fatto ben.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Panchiane! panchiane!</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Sì, anca da putto, che la xè cussì</p>
             <stage>(<emph>si volta</emph>).</stage>
@@ -1593,30 +1642,30 @@ riverenza, el tabaro; perché giera sora pensier. Me premeva, no so se
 la me capissa...</p>
             <stage>(<emph>a Elena</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Eh! sior sì, l'ho capio</p>
             <stage>(<emph>voltandosi con disprezzo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Chi èla sta signora?</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>No la cognossé? Sior'Elena, muggier de sior Agustin
 Menueli.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>La me permetta, che fazza el mio debito</p>
             <stage>(<emph>a Elena</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Momolo, abbiè giudizio.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Fermève</p>
             <stage>(<emph>a Bastian</emph>).</stage>
@@ -1624,74 +1673,74 @@ Menueli.</p>
 aver l'onor de conoscerla. Sior Agustin xè mio amigo, e mio bon paron;
 e la prego anca ela degnarse...</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Grazie, grazie.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Se la gh'avesse qualcossa da manganar.</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Oh! mi in ste cosse no me n'impazzo.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Se la me permette, la vegnirò a reverir.</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Mi no ricevo visite; da mi no vien nissun.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>La se ferma. Sàla chi son mi?</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>A mi no m'importa de saver.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Mo via, no la me fazza inspasemar.</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Son stuffa.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>De cossa?</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Siora Domenica, co so bona grazia</p>
             <stage>(<emph>s'alza</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Che la se comoda.</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>(Anderò a véder, dove che s'ha ficcà mio mario)</p>
             <stage>(<emph>in atto di partire</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Patrona.</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Patron</p>
             <stage>(<emph>andando via</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Gnanca?</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Oh! mi non son de quelle da sbuffonar</p>
             <stage>(<emph>parte. Tutti ridono</emph>).</stage>
@@ -1702,216 +1751,216 @@ e la prego anca ela degnarse...</p>
           <stage>
             <emph>Domenica, Marta, Bastian, Momolo.</emph>
           </stage>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>In fatti: gh'aveva bisogno di sentarme; senza che
 nissun s'incomoda, i m'ha favorio la carega.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Cavève el tabaro.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>La se fermi. Me lo caverò adessadesso.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Cavèvelo, co volè; per mi no me movo.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Dove xèlo sior Zamaria?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>El xè dessuso co sior Agustin.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Cossa diralo, col me vederà?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Meriteressi, che 'l ve disesse...</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Va' via, che no te voggio. E mi ghe dirave: fermève,
 che ghe son, e ghe voggio star.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>L'è, che se volessi andar via, siora Domenica no ve
 lasserave andar.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Per so grazia, e non per mio merito.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Manco mal, che ve cognossè!</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Mi almanco, in bon ponto lo possa dir, tutti me vol
 ben.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Per cossa mo credeu, che i ve voggia ben?</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Perché son belo.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Va' via, malagrazia.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>E mi cossa sóngio?</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Sìela benedetta; la xè la mia parona anca ela; ma no
 me n'impazzo. Lasso fari onori de la casa a mio compare
 Bastian.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Momolo, quanto xè, che no andè a la comedia?</p>
             <stage>(<emph>a Momolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Xè un pezzo. In sti ultimi zorni mi no ghe vago. Me
 piase più cussì, quatro amici, un gotto de vin, una fersora
 de maroni.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Stassera cenerè con nu.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>No la posso servir.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Per cossa? Averessi ardir de impiantarne?</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Mi no; stago qua fin doman, fin doman l'altro; fin
 sta quaresema, fin che la vol.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Cossa donca disèu de no voler cenar?</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Digo cussì, perché gh'averave voggia de servirla
 ben, e xè otto dì che desordeno, e gh'ho paura de no farme
 onor.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Eh! no v'indubitè, che qua da nu no ghe sarà da
 desordenar.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Ghe n'è più de quel vin da galantomeni?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Ghe ne xè ancora.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Co gh'è de quelo, gnente paura.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Via, andè de là, andève a cavar el tabaro.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Con so bona grazia</p>
             <stage>(<emph>in atto di andare</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Saveu chi vien stassera da nu?</p>
             <stage>(<emph>a Momolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Chi, cara ela?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Siora Polonia.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Cara culìa; ghe vòi proprio ben; ma semo in baruffa.
 Me raccomando a ele; le diga do parolete, cussì senza
 malizia; le fazza del ben a sto povero pupillo</p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>L'assicuro, che in t'una compagnia el xè un
 oracolo.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Stimo, che 'l xè sempre de sto bon umor.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Sempre cussì; el xè nato cussì, e 'l morirà cussì.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Xè vero, che tra lu e Polonia ghe sia qualcossa?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Oh! la se fegura. El dise. Ma in quela testa
 crédela, che ghe sia fondamento? Ela sì piutosto, credo, che
 la ghe tenderia se 'l disesse dasseno.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Ghe dirò: el xè cussì alegro, maturlo; ma ai so
 interessi el ghe tende.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Sior sì, sior sì; el xè onorato, co fa una perla.
 Oh! vien zente.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Chi xèli?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Sior'Alba co so mario. Con grazia</p>
             <stage>(<emph>s'alza, e va incontro</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Xèla quela, che gh'ha sempre mal?</p>
             <stage>(<emph>a Marta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Sì, chi la sente ela, la xè sempre amalada: ma no
 la starave a casa una sera, chi la copasse</p>
@@ -1923,180 +1972,180 @@ la starave a casa una sera, chi la copasse</p>
           <stage>
             <emph>Alba, Lazaro, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Patrona, sior'Alba.</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Patrona</p>
             <stage>(<emph>si baciano</emph>).</stage>
             <p>Patrona</p>
             <stage>(<emph>a Marta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Patrona</p>
             <stage>(<emph>si baciano</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Compare Lazaro.</p>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Patron sior Bastian</p>
             <stage>(<emph>si baciano Bastian e Lazaro fra di loro</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Cossa fàla? Stàla ben?</p>
             <stage>(<emph>ad Alba</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Gh'ho un dolorazzo de testa, che no ghe vedo.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>La se senta. La me daga qua el tabarin.</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>No, no, la lassa; che gh'ho piuttosto fredo. Gh'ho
 un tremazzo intorno...</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Vorla un poco de fogo?</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>La me farà grazia.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Adesso gh'anderò a tiòr el scaldapiè. E ela ghe ne
 vorla?</p>
             <stage>(<emph>a Marta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Oh! mi no, la veda, stago benissimo.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Le compatissa, vago mi, perché la donna no pol. (La
 podeva far de manco de vegnir sta giazzèra)</p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Co gh'avevi mal, dovevi star a casa, cara fia.</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Eh! me passerà.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>(Bisogna, che ghe sia vegnù mal per strada. Se la
 s'avesse sentio qualcossa a casa, no la sarave vegnua).</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>(Ghe credeu vu, che la gh'abbia mal?)</p>
             <stage>(<emph>a Bastian</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Cossa ve sentìu?</p>
             <stage>(<emph>ad Alba</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Gnente.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Mo via, la staga alegra, la se diverta.</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Gh'ho una mancanza de respiro, che no posso tirar el
 fià.</p>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Voleu gnente? Voleu andarve a molar el busto?</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Eh! sior no; n'importa.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>(El gh'ha una gran pazzenzia. Mi no sarave bon).</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Son qua col fogo. La resta servida</p>
             <stage>(<emph>vuol mettere lo scaldapiè <abbr>ecc.</abbr></emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>No la s'incomoda</p>
             <stage>(<emph>vuol mettersi lo scaldapiè, e non può</emph>).</stage>
             <p>Gh'ho sto busto cussì stretto, che non me posso
 gnanca sbassar.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>La servirò mi</p>
             <stage>(<emph>mette lo scaldapiè</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Ma no voleu star mal con quel busto cussì serà? Andè
 là, cara fia, andève a molar.</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Eh!</p>
             <stage>(<emph>con disprezzo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Fè a vostro modo, che viverè dies'anni de più.</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Gh'àla un garòfolo?</p>
             <stage>(<emph>a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Anderò de là a tòrghelo.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Mi, mi se la vol</p>
             <stage>(<emph>vuol tirar fuori un garofano <abbr>ecc.</abbr></emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Vorla un diavolon?</p>
             <stage>(<emph>apre una scatoletta <abbr>ecc.</abbr></emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Sior sì.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Cossa se séntela?</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>No so gnanca mi. Gh'ho un affanno!...</p>
           </sp>
@@ -2106,70 +2155,70 @@ là, cara fia, andève a molar.</p>
           <stage>
             <emph>Momolo, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Oh! son qua.</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Oh! sior Momolo, sior Momolo</p>
             <stage>(<emph>rallegrandosi</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Sior'Alba, ghe son servitor.</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Anca élo xè qua?</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>No sàla? Mi penetro per tutto, co fa la luse del
 sol.</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Ah! ah!</p>
             <stage>(<emph>ride moderatamente</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Ghe xè passà?</p>
             <stage>(<emph>ad Alba</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Un pochetto.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Gh'àla mal? Vorla, che mi ghe daga un <emph>recipe</emph> per
 varir?</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Via mo; che <emph>recipe</emph>?</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p><emph>Recipe</emph>, no ghe pensar. <emph>Recipe</emph>, devertirse.
 <emph>Recipe</emph>, sior sì, e ste cosse.</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Oh! che matto: ah ah ah ah, oh che matto!</p>
             <stage>(<emph>ridendo forte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Oh! via via, me consolo: la xè varìa.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>No ghe voleva altri, che sior Momolo a farla varir.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Vorle, che ghe ne conta una bela? Son stà de su da
 sior Zamaria. Ho trovà i do novizzi, uno in t'un canton,
@@ -2180,194 +2229,194 @@ novizza. Le indivina mo? Vien qua, va' via; sentì, làsseme
 star: i m'ha strazzà un manegheto</p>
             <stage>(<emph>mostra il manichetto rotto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Oh bela! oh bela! Oh che gusto! oh bela!</p>
             <stage>(<emph>ridendo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Grazie del so bon amor</p>
             <stage>(<emph>ad Alba</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Via, via; ve darò mi una camisa.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>N'importa; lo ficco sotto</p>
             <stage>(<emph>nasconde il manichetto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Bisogna ben, che ve muè, s'avè da balar.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Se bala anca?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>I dise. Balerala anca ela, sior'Alba?</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Siora sì; no vorla?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Oh! via, me consolo.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>(La gh'ha tanto mal ela, quanto che ghe n'ho mi).</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Ghe digo ben, che ho visto desuso in teler un drapo,
 che no ho visto el più belo. Un dessegno de sior Anzoletto,
 che xè una cossa d'incanto, che no gh'ha invidia a uno dei
 più beli de Franza.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Cossa serve? I nostri drapi, co se vol, che i
 riessa, i riesse. Gh'avemo omeni, che xè capaci; gh'avemo
 sede; gh'avemo colori; gh'avemo tutto.</p>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Cossa disèu, sior Bastian, de quei drapi, che
 st'anno xè vegnui fora dai mii teleri?</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Stupendi: i me li ha magnai da le man. V'arecordeu
 quel raso con quei finti màrtori? Tutti lo credeva de
 Franza. I voleva fina scometter; ma per grazia del Cielo,
 roba forestiera in te la mia bottega no ghe ne vien.</p>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>I me fa da rider! Che i ordena, e che i paga, e i
 vederà, se savemo far.</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <stage>(<emph>butta via lo scaldapiedi, e il tabarin</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Coss'è?</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Cossa gh'àla?</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Me vien una fumana.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Com'èla? Saldi, sior'Alba; saldi, sior'Alba.</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Eh! andè via de qua; no me rompè la testa.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Me cavo: fogo in camin; me cavo.</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Son tutta in t'un'acqua.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Vorla despogiarse?</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Siora no.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Vorla, che ghe metta un fazzoleto in te le spalle?</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Oh! giusto.</p>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Voleu gnente, fia?</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>No voggio gnente.</p>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Voleu, che andemo a casa?</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>La me favorissa el mio tabarin.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>La toga.</p>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Andémo; le compatissa.</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Se la me dà licenza, voggio andar dessuso a véder
 sto drapo</p>
             <stage>(<emph>a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Ghe xè passà?</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Me xè passà. Sior Momolo, la favorissa.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>La comandi.</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>El me compagna dessuso.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Volentiera.</p>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Ve compagnerò mi</p>
             <stage>(<emph>ad Alba</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Fermève</p>
             <stage>(<emph>a Lazaro</emph>).</stage>
             <p>So qua a servirla. Benedeta
 la mia parona! Saldi, sior'Alba.</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Coss'è sto saldi?</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Gnente. Saldi. Perché son debole de zonture</p>
             <stage>(<emph>parte con Alba</emph>).</stage>
@@ -2378,63 +2427,63 @@ la mia parona! Saldi, sior'Alba.</p>
           <stage>
             <emph>Domenica, Marta, Bastian, Lazaro.</emph>
           </stage>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>(Se vede, che tutto el so mal la lo gh'ha in te la
 testa).</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Via, che i vaga anca lori.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Eh! mi l'ho visto; so, che drapo, ch'el xè.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Che i vaga; che i vaga a trovar sior padre.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Coss'è? Vorle restar sole?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Sior sì; volemo restar sole.</p>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Andemo, sior Bastian. Se savessi! gh'ho sempre
 paura, che a mia muggier no ghe vegna mal!</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Gh'avè una gran pazzenzia, compare!</p>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Cossa voleu far? La xè mia muggier.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Voleu, che mi v'insegna a varirla?</p>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Come?</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Se ghe dise: Àstu mal? sta in casa. Anca sì, che
 ghe passa el dolor de stomego?</p>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>No son bon; no gh'ho cuor; no me basta l'anemo</p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>To danno; gòditela donca, che bon pro te fazza</p>
             <stage>(<emph>parte</emph>).</stage>
@@ -2445,156 +2494,156 @@ ghe passa el dolor de stomego?</p>
           <stage>
             <emph>Domenica, e Marta.</emph>
           </stage>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Manco mal, che semo un pocheto sole. Gh'ho voggia de
 parlar con ela.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Son qua, siora Domenica; cossa gh'àla da
 comandarme?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>La diga: cossa intendévelo de dir sior Bastian, col
 parlava de sior Anzoletto?</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Mi no so in verità.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Eh! via, cara ela. La gh'ha pur dito, ch'el tasa.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Ghe dirò, co la vol, che ghe diga la verità: ne xè
 stà dito, che sior Anzoleto gh'ha de la stima per ela; e che
 anca ela no lo vede mal volentiera.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Ghe xè mal per questo?</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Gnente; anzi in verità dasseno, ho dito co mio
 mario; el sarave un negozio a proposito per tutti do.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Anca mi, per parlarghe col cuor in man, ghe dirò,
 che sior Anzoletto, co l'occasion, ch'el vien qua da sior
 padre a portar i dessegni...</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Via. Cossa serve? Nualtri marcanti gh'avemo bisogno
 de' testori; i testori ha bisogno del dessegnador...</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Siora sì. Co l'occasion, che 'l vien qua...</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Ho capio; i xè zoveni tutti do...</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Ma gnente, sàla? No averemo dito trenta parole.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Via!</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>El m'ha domandà, se gh'ho morosi.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Bon!</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>El m'ha tratto un moto, se ghe tenderave.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Gh'àla dito de sì?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Mai.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Mo per cossa?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Oh! la vede ben</p>
             <stage>(<emph>con modestia</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>No so cossa dir.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>La mistra Polonia, la tiraoro, la conóssela?</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>La conosso.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Ela, védela, ela m'ha dito qualcossa.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>E ela gh'àla fatto dir gnente?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Gnente. S'avemo scritto una polizeta.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Sì ben, sì ben. La gh'àla sta polizeta?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Siora sì. La vorla véder?</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Magari!</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Adesso ghe la mostro</p>
             <stage>(<emph>si guarda in tasca</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>(Eh, sì ben. Trenta parole, e una polizeta xè quel,
 che basta).</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Oh! xè qua la mistra Polonia</p>
             <stage>(<emph>ripone la carta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Gh'àla suggizion?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>No vorave, che la disesse... Ghe la mostrerò
 un'altra volta.</p>
@@ -2605,208 +2654,208 @@ un'altra volta.</p>
           <stage>
             <emph>Polonia col danzale sulle spalle, e dette.</emph>
           </stage>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Patrone riverite.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Siora Polonia!</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Patrona, siora Polonia.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Sola sè?</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>M'ho fato compagnar da un zovene.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Coss'è, che me parè scalmanada?</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Gnente, gnente. La lassa, che me cava el zendà.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Saveu, chi ghe xè dessuso?</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Chi?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Sior Momolo.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>El manganer?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Siora sì dasseno.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Uh! sìelo malignazo anca élo. Asti omeni no gh'è da
 creder; no gh'è da fidarse: i xè tutti compagni.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Disè: cossa xè stà?</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>La lassa, che me cava el zendà</p>
             <stage>(<emph>va a porre il zendale sul tavolino</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Bisogna, che ghe sia nato qualcossa.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Sentiremo. Son curiosa anca mi.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Gh'ho da parlar</p>
             <stage>(<emph>a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>A mi?</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>A ela.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>De cossa?</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>De un no so che.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Parlè, parlè liberamente. De siora Marta (la xè
 tanto bona) mi no gh'ho suggizion.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Se le vol parlar in secreto, le se comoda pur.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Oh! giusto. Cossa gh'è?</p>
             <stage>(<emph>a Polonia</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Gh'ho da parlar dell'amigo.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>De sior Anzoletto?</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Giusto de élo.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Mo via, parlè.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Sàla gnente, siora Marta?</p>
             <stage>(<emph>a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Parlè, ve digo; no abbiè suggizion.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Per so grazia, la m'ha dito qualcossa.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Co l'è cussì donca, ghe conterò una bella novità.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Che xè mo?</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Che xè? Che ho savesto de certo, e de seguro, che
 sior Anzoletto ha avù una lettera da Moscovia; che ghe xè
 dei testori italiani, che vol, che 'l vaga là a far el
 dessegnador.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Poveretta mi!</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>E élo, cossa dìselo?</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>El va.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>El va?</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Ma siora sì, lu, che 'l va.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Lo saveu de seguro?</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Segurissimo.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Come l'aveu savesto?</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Che dirò... No vorave, che 'l me sentisse.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Eh! no v'indubitè, che nol ghe xè, no. E chi sa
 gnanca, se 'l vien.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Eh! el vien, el vien; e 'l pol esser poco lontan. Co
 ho passà el ponte de Canareggio, l'ho visto su la fondamenta
 in bottega de quel dal tabaco.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Disè, contème</p>
             <stage>(<emph>mortificata</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Ghe xè a Venezia una recamadora franzese, che vien
 da nu a tòr de l'oro per recamar, che la va in Moscovia anca
@@ -2814,60 +2863,60 @@ ela, e la m'ha contà tutto, e la m'ha mostrà la lettera,
 dove che i ghe scrive de sior Anzoletto, e la m'ha anca
 dito, che la va in Moscovia con élo.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Come! Anca con una donna el va via?</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Oh! la xè vecchia, sàla? La xè vecchia; la gh'averà
 più de sessant'anni. La xè madama Gatteau. La conóssela?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Sì, la conosso. Ho parlà con ela; la xè stada anca
 in casa mia.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Mo ve digo mo ben la verità, che 'l me despiase
 assae, ma assae.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Eh! cara ela, la me 'l lassa dir a mi, che me
 despiase.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Dasseno me despiase anca a mi; perché in materia de
 drapi, la sa, che ogni ano ghe vol de le novità; e lu, per
 dir quel che xè, per la nostra bottega, l'ha sempre trovà
 qualcossa, che ha dà in tel genio all'universal.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Zito, zito; el xè qua.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Me vien voggia da darghe una strapazzada...</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>No, cara ela, no la fazza scene. No la diga gnente,
 che ghe l'abia dito mi.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Taserò fin che poderò.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>La me lassa parlar a mi</p>
             <stage>(<emph>siedono</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>La prego de no me minzonar, per amor de quella
 vecchia recamadora; che se la savesse, che raccola, che la
@@ -2879,243 +2928,243 @@ xè!</p>
           <stage>
             <emph>Anzoletto, e dette; poi Cosmo.</emph>
           </stage>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Patrone mie riverite.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Patron.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(E co allegro, che 'l xè!)</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Son qua anca mi a recever le grazie de siora
 Domenica, e de sior Zamaria.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Le mie no, la veda. Mi no despenso grazie a nissun.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>(Xè impossibile, che la tasa).</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Cossa gh'àla, siora Domenica?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Me dol la testa.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Me despiase ben.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>La mastega del reobarbaro, che 'l ghe farà ben. La
 manda alla spezieria; la procura de farse dar de quel de
 Moscovia</p>
             <stage>(<emph>a Domenica, con caricatura</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>De Moscovia?</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Sior sì. No xè vero, che 'l meggio reobarbaro xè de
 quelo, che vien de Moscovia?</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Mi no so. Mi no me n'intendo.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Che bon tabaco àlo tolto, sior Anzoleto?</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Padoan. M'àla visto a comprarlo?</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Sior sì. Che 'l me ne daga una presa.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>M'ha parso anca a mi de véderla a trapassar</p>
             <stage>(<emph>dà il tabacco <abbr>ecc.</abbr></emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>(Me pento adesso de aver parlà).</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Comàndela?</p>
             <stage>(<emph>offre tabacco a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Grazie. No ghe ne togo</p>
             <stage>(<emph>con disprezzo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Pazzenzia. E ela, comàndela?</p>
             <stage>(<emph>a Marta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Ch'el diga: ghe n'àlo comprà assae de sto tabaco?</p>
             <stage>(<emph>prendendo tabacco</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>No la vede? Mez'onza.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Credeva, che 'l ghe n'avesse comprà do, o tre lire.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Perché tanto?</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Credeva, che 'l s'avesse fatto la provision per el
 viazo.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Per el viazo?</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Che 'l diga, sior Anzoleto...</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>La prego: de che viazo pàrlela?</p>
             <stage>(<emph>a Marta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Eh! gnente; ho falà. Diseva de quel de la
 recamadora franzese.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>(Porla tàser, in so tanta malora?)</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Siora, capisso benissimo...</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Eh! via, cara siora Marta, la tasa. I omeni xè
 paroni de la so libertà. Vorlo andar? che 'l vaga.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>La me permetta...</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Ben, che 'l vaga. Nissun ghe lo pol impedir. Ma
 perché no dirlo almanco?</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>La prego...</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Oh! questo po sì. Sperava anca mi, che 'l gh'avesse
 almanco tanta proprietà de farme sta confidenza.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Perméttele?...</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Bisogna véder...</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>La lassa, ch'el parla.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Che 'l diga pur.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>(Podeva pur anca mi aspettar a doman).</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Ghe dirò. Xè vero, che ho una lettera de Moscovia,
 che là i me chiama a esercitarme in tel mio mestier. Xè
 vero, che la proposizion me convien; xè vero anca, che l'ho
 accettada. Ma xè vero altresì...</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Belo quel «altresì»; el scomenza a parlar
 forestier.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Tutto quelo, che la comanda. Parlerò venezian. Ma xè
 anca vero, che ancuo solamente ho risolto; e che prima de
 adesso no ghe lo podeva comunicar.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Tutte chiaccole, che no val un bezzo.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Basta. Se per élo ha da esser ben, me consolo.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>No so cossa dir. Sarà quel, che piaserà al Cielo.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Sentì, fio caro; lassemo le burle da banda. Mi
 vorave, che fessi del ben. Ma finalmente, qua sè ben visto;
 e in Moscovia, no savè come che la ve possa andar.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>De dia! No digo, che sior Anzoleto sia un cativo
 dessegnador. Ma che ghe sia in Moscovia sta carestia de
 dessegnadori, che i abbia de grazia de vegnirghene a cercar
 uno a Venezia?</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Ghe dirò, patrona...</p>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>COSMO</speaker>
             <p>Sior Anzoletto, che 'l vegna dessù dal patron, che
 'l ghe vol parlar.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Vegno. Andè; disèghe, che vegno subito</p>
             <stage>(<emph>a Cosmo, che parte</emph>).</stage>
@@ -3147,36 +3196,36 @@ per mi tanta clemenza e tanta benignità</p>
           <stage>
             <emph>Domenica, Marta, e Polonia.</emph>
           </stage>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Respondèghe, se ve basta l'anemo.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>El xè andà via, perché no ghe responda; ma ghe ne
 dirò tante, che spero, che no l'anderà.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Vorla, che ghe insegna, mi cossa che l'ha da far? La
 parla con quela vecchia recamadora; altri che ela no
 poderave trovar la strada de farlo restar.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Ghe parleria volentiera; ma la parla tanto poco
 italian, che stento a intenderla, che mai più.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Se stenta, ma se capisse. La fazza a mio modo, la
 parla con madama Gatteau.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Come poderàvio far a parlarghe?</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Oe! la sta qua ai «do Ponti». Vago a véder, se de
 là ghe xè el putto, che m'ha compagnà; e se no, ghel digo a
@@ -3193,39 +3242,39 @@ no fazzo per dir, ma semo proprio da imbalsamar</p>
           <stage>
             <emph>Marta, e Domenica.</emph>
           </stage>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Siora Domenica, cossa gh'àla intenzion de far?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>No so gnanca mi.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Ma pur?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Vorla, che andémo dessuso anca nu?</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Quel che la comanda.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>La resta servida, che adessadesso vegno anca mi.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Vorla restar qua?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Un pochetto. Se la me permette?</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>La se comoda. (Ho capio; la se vol conseggiar da so
 posta. Che la varda de no far pezo. Ho sempre sentio a dir,
@@ -3239,7 +3288,7 @@ pericolo de cascar in t'un fosso)</p>
           <stage>
             <emph>Domenica sola.</emph>
           </stage>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>No so quala far. No voria, che l'andasse; ma no
 vorave gnanca esser causa mi, che 'l perdesse la so fortuna.
@@ -3264,29 +3313,29 @@ tosto che far una mala azion</p>
           <stage>
             <emph>Zamaria, e Anzoletto.</emph>
           </stage>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Vegnì qua mo, sior Anzoleto.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Son qua a servirla, sior Zamaria.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Com'èla, compare? Xè vero quel, che i dise? Xèla la
 verità, che andè via?</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Sior sì, xè verissimo. Son chiamà in Moscovia.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Seu mo veramente chiamà, o seu vu che ha brogià per
 andar?</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>V'assicuro, da omo d'onor, che mi a sta cossa no ghe
 pensava; ve posso mostrar le lettere. Le ha viste i mii
@@ -3298,22 +3347,22 @@ Considerè un'altra cossa. I me paga i viazi. Co se cerca, co
 se prega, co se fa brogio, ve par a vu, che se possa sperar
 i viazi d'andar, e tornar?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Fè conto de tornar donca.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Se el Cielo me lassa in vita, lo spero, lo desidero,
 e lo farò.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>No so cossa dir; andè che 'l Cielo ve benediga. Me
 despiase, che fin che stè via, no gh'averemo dei vostri
 dessegni.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>E per questo? Manca in sto paese dei ottimi
 dessegnadori? Venezia no xè scarsa de bei talenti. In tutte
@@ -3322,7 +3371,7 @@ adesso più che mai in ste lagune fiorisse i bei spiriti, e
 'l bon gusto, e le novità. Per mi ho fatto troppo. Son stà
 più sofferto de quel, che merito.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Mi no so gnente. Savè, che nualtri testori no semo
 boni da altro, che da eseguir; e no tocca a nu a giudicar.
@@ -3330,65 +3379,65 @@ Ma gièrimo usai con vu. I mii teleri principalmente i giera
 provisti da vu, e la nostra roba incontrava, e i nostri
 aventori giera contenti.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Caro sior Zamaria, vu parlè con tropa bontà. De
 cento, e più dessegni, che ho fatto, qualchedun ghe n'è andà
 mal, e qualche volta avè butà la seda, l'oro, e l'arzento
 per causa mia.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Mi no digo cussì. So, che i mii drapi laorai sui
 vostri dessegni, se no i ho smaltii a Venezia, i ho smaltii
 in terraferma; e se in qualcun ho descapità, m'ho reffatto
 sora la brocca con quelli, che xè andai ben.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Sièu benedeto! Vu sè un omo onesto. Vu sè un omo da
 ben. Ma ghe xè dei altri testori, che no parla cussì.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Vegnì qua, sentì. No poderessi, fin che stè via,
 mandarme dei dessegni da dove che sè?</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Perché no? Se ve compiasessi de comandarme, e se ve
 fidessi de mi, ve servirave con tutto el cuor.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Sior sì; mandèghene, e non ve dubitè.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Ghe ne manderò.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>V'impegneu?</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>M'impegno.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Me prometteu?</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Ve prometto.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Vardè ben, che su la vostra parola torò l'impegno
 coi mii aventori.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Gh'ho tanto respetto, e tante obligazion coi
 aventori de sta bottega, che sarave un ingrato, se
@@ -3396,7 +3445,7 @@ trascurasse de corisponder a le finezze, che i m'ha praticà.
 Se vu disè dasseno; se volè, se ve preme, anca mi
 v'assicuro, no mancherò.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Bravo, son contento; me fido de vu. No parlemo
 altro. Devertìmose, godémose in bona pase. Oe, zente, dove
@@ -3408,295 +3457,295 @@ seu? Animo, vegnì de qua.</p>
           <stage>
             <emph>Tutti.</emph>
           </stage>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Son qua, paron, comandè.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>E vu prima de tutti.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Son qua mi; capo de ballo mi.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Adesso no se bala. Se balerà dopo cena. Che ora xè?</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>No so; ho lassà el reloggio dal reloggier.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Xè tre ore, sior Zamaria.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Tre, e do cinque. A cinqu'ore anderemo a cena. Via
 intanto, che i fazza qualcossa, che i se deverta. Presto,
 carte, luse, taolini</p>
             <stage>(<emph>verso la scena</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Gh'ho altra voggia mi, che zogar)</p>
             <stage>(<emph>da sé</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Zoghemo a un zogo, che zoga tutti.</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Per mi, che i me lassa fora.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Siora no; l'ha da zogar anca ela</p>
             <stage>(<emph>ad Alba</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Mi no so zogar.</p>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Eh! sì, cara fia, che savè zogar.</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>No so, me stuffo, vago via co la testa; fazzo dei
 spropositi, e i cria, e mi co i cria, butto le carte in
 tola.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Oh! via, a cossa se zoga?</p>
             <stage>(<emph>a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>A quel, che i comanda lori. Mi za no zogo.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Gnanca ela no zoga? Oh! bella. Donca lassemo star
 de zogar. (Ho capio; el reobarbaro gh'ha fatto mal).</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Oe, Domenica, xèstu matta? Coss'è ste scene?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Via, via; per no desgustar la compagnia, zogherò
 anca mi.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>A cossa podémio zogar?</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>La se ferma. Mi gh'ho in scarsela la facoltà de
 cinquanta soldi; se le vol, che li taggia, le servo.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>No, compare, in casa mia no se zoga a la <emph>basseta</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Zoghemo al <emph>marcante in fiera</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Sior no, sior no. Mi me piase zogar co le carte in
 man.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Dixè vu, compare Lazaro. Trovè un zogo, che piasa
 anca a vostra muggier.</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Mo se mi no zogo.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Mo se mi vòi, che la zoga.</p>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Zoghemo a <emph>barba Valerio</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Oh! che zogo sempio che 'l trova fora. Più tosto po
 a la <emph>tondina</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Ih! un zogo, che no fenisse mai. Vorli, che diga
 mi?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Sì, la diga ela.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Zoghemo a la <emph>meneghela</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Sì, per diana. A la meneghela.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>In quanti sémio? Chi zoga?</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Mi, per no me perder.</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Mi no seguro.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Giusto mo vu, comare, avè da zogar per la prima.
 Zogherè con mi.</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Mo se mi no so.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>E élo, sior Zamaria, ghe ne sàlo?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Mi sarà vint'ani che no ho zogà.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Bisogna compagnar un che sa, e un che no sa. Via,
 la fazza ela, siora Domenica; la unissa ela i zogadori; da
 brava.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Mi no so, no gh'ho pratica; la fazza ela.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Vorla, che fazza mi?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Sì, la me fa finezza.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Sior'Alba...</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>La me metta con uno, che ghe ne sappia, perché,
 prima mi no ghe ne so, e po me diol la testa, che la me va
 in pezzi.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>La zogherà con mio mario, che 'l xè bravo.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>(Cospetto! M'àla fatto un bel regalo mia muggier!)</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Sior Momolo zogherà co siora Eleneta.</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Siora?</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>La zogherà co sior Momolo.</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Mi no, la veda.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>La me refuda</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Via, via, ho inteso. La zogherà co so mario.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>La se ferma. Son qua; chi me vol? Son reffudà. I
 bocconi reffudai xè meggio dei altri.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Vu zogherè con siora Polonia.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>No lo voggio.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Chi no me vol, no me merita.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Varè, che fusto!</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Via, via, destrighémose, che vien tardi. L'è dita.
 Siora Polonia, e sior Momolo. Mi zogherò co sior Lazaro, e
 siora Domenica co sior Anzoleto.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>(Sì ben; sto incontro lo desiderava)</p>
             <stage>(<emph>si accosta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>No, cara siora Marta, mi la me lassa fora.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Coss'è? Farastu anca ti de le putelae?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Mi ho da tender de là.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Ghe tenderò mi.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Aponto. Nol gh'ha compagno, sior Zamaria?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Mi no m'importa; che i zoghi loro. Za mi no so, e po
 anca ghe vedo poco. Animo, la taolada xè fatta. Putti, portè
@@ -3706,88 +3755,88 @@ carte, e un piatelo</p>
             <p>Gh'àli soldoni?
 Gh'àli bisogno de soldoni?</p>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>(Sior santolo, caro élo, el me impresta un da
 vinti).</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>(Coss'è, fiozzo? No gh'avè bezzi?)</p>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>(Sior no; mia muggier no voi, che porta bezzi in
 scarsella).</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Oe, fiozza</p>
             <stage>(<emph>ad Elena</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Sior</p>
             <stage>(<emph>a Zamaria</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>(Che diavolo de vergogna! Gnanca vinti soldi in
 scarsella no volè, che gh'abbia vostro mario?)</p>
             <stage>(<emph>ad Elena</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>(Eh! caro sior; coi omeni gh'ha dei bezzi in
 scarsela, no se sa, che occasion, che ghe possa vegnir)</p>
             <stage>(<emph>a Zamaria</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>(Da una banda no la gh'ha gnanca torto. Digo ben,
 che xè assae, che Agustin ghe staga). (Tolè, fiozzo, queste
 xè tre lire).</p>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>(Cossa vorlo, che fazza de tanti bezzi?)</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>(Podè perder anca de più).</p>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>(Oh! mi no perdo più de un da vinti).</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Animo, patroni. Tutti ai so posti.</p>
           </sp>
           <stage>(<emph>Si dispongono tutti a sedere. Domenica in principio della tavola; poi Anzoletto, poi Marta, poi Lazaro, poi Alba, poi Bastian, poi Elena, poi Agostino, poi Polonia, poi Momolo.</emph>)</stage>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>(Gh'ho ben piacer de aver l'onor de zogar con ela.
 La fortuna m'ha volesto beneficar).</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Eh! via, caro sior, ch'el vaga a burlar in qualche
 altro logo)</p>
             <stage>(<emph>ad Anzoletto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>(La me permetta, che me possa giustificar).</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Zitto, zitto; za che mio padre no ha savesto gnente
 fin adesso, no voggio, che 'l se n'incorza, e che 'l m'abbia
 da criar senza sugo)</p>
             <stage>(<emph>siedono ai loro posti</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Mettemo suso do soldi per omo. Semo in diese; do
 fia diese vinti. La prima carta tira sette. La segonda sie,
@@ -3795,165 +3844,165 @@ perché se lassa el soldo dell'invido; e in ultima resta
 sette</p>
             <stage>(<emph>tutti pongono il loro soldo nel tondino</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>(Ghe vòi più ben de quelo, che la se imagina)</p>
             <stage>(<emph>a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Eh! caro sior, s'el me volesse ben, no l'anderave
 in Moscovia)</p>
             <stage>(<emph>ad Anzoletto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>(Ma la prego de considerar...)</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Zitto, zitto, ch'el tasa).</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>La diga, siora Domenica. M'imagino, che faremo
 l'invido ligà.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Per mi, quel, che la comanda.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Che no se passa un traero.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Oh! per un traero no se pol far cazzate! Cossa
 dìsela ela?</p>
             <stage>(<emph>ad Alba</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Che i fazza pur quel, che i vol</p>
             <stage>(<emph>a Marta</emph>).</stage>
             <p>Me casca i occhi da sonno</p>
             <stage>(<emph>a Bastian</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>(Stago fresco! M'ha toccà una bona compagna).</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <stage>(<emph>dando le carte per veder a chi tocca</emph>).</stage>
             <p>Mi diria, che se podesse invidar almanco do traeri.</p>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Mi no voggio, che se invida più de do soldi.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Tanto fa, che lassemo star.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Via, fiozzo, no siè cussì spilorza. Co se ghe xè, se
 ghe sta.</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Ben; co avemo perso un da vinti, no zoghemo altro.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Gh'aveu paura? Zoghè per mi.</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Eh! sior no; zogheremo per nu.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Oh! tocca a far le carte a siora Polonia</p>
             <stage>(<emph>passano il mazzo a Polonia</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <stage>(<emph>va girando dietro le sedie, e guarda coll'occhialetto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Vorla, che le fazza mi per ela?</p>
             <stage>(<emph>a Polonia</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Eh! sior no, le so far anca mi</p>
             <stage>(<emph>a Momolo</emph>).</stage>
             <p>Se fa lissìa?</p>
             <stage>(<emph>mescolando le carte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Siora sì. No vorla?</p>
             <stage>(<emph>a Polonia</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Via, da bravi, e fè de le bele cazzade.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Sior'Alba gh'ha sonno. La me darà licenza, che
 parla qualche volta con ela</p>
             <stage>(<emph>a Elena</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>(Eh! sior no; che 'l tenda a la so compagna)</p>
             <stage>(<emph>a Bastian</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>(Mo via, no la sia cussì cattiva)</p>
             <stage>(<emph>a Elena</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>(Cossa te dìselo?)</p>
             <stage>(<emph>a Elena</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>(Se ti savessi! el me fa una rabia!...)</p>
             <stage>(<emph>a Agostino</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>(Vien qua da mi, che mi vegnirò là)</p>
             <stage>(<emph>Agostino, ed Elena si mutano di posto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>(Mo che razza de zente).</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Coss'è? Coss'è ste muanze?</p>
             <stage>(<emph>ad Agostino, e ad Elena</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Oh! védelo? Mi bisogna, che regola el zogo; de là
 no podeva, e qua son a bona man.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>(Mo che scempiezzi!)</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Putto, fè a modo mio. Stè a casa, no andè in nissun
 logo, perché al tempo d'ancuo, i ve tacherà i moccoli drio</p>
@@ -3965,161 +4014,161 @@ logo, perché al tempo d'ancuo, i ve tacherà i moccoli drio</p>
           <stage>
             <emph>Tutti, fuori di Zamaria.</emph>
           </stage>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Alzè</p>
             <stage>(<emph>a Momolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Se almanco alzasse la <emph>meneghela</emph></p>
             <stage>(<emph>alzando</emph>).</stage>
             <p>Dèmele bone, che son bon anca mi</p>
             <stage>(<emph>a Polonia</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>(Sì, sì, sior baron)</p>
             <stage>(<emph>dando fuori le carte, che si fanno passare di mano in mano</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>(Mo via, che sè la mia cara colona)</p>
             <stage>(<emph>a Polonia</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>(No ve credo una maledetta)</p>
             <stage>(<emph>a Momolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>(Mettème a la prova, e vederè, se digo la verità)</p>
             <stage>(<emph>a Polonia</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>(Ben, ben. Vederemo)</p>
             <stage>(<emph>a Momolo facendo lissìa</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Mo che carte, che la n'ha dà; se pol far pezo?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Mi no gh'ho gnente; tanto fa, che le butta a
 monte)</p>
             <stage>(<emph>ad Anzoletto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>(No, no; la tegna le carte in man. Vardando le
 carte, se pol dir qualche paroleta)</p>
             <stage>(<emph>a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Cossa serve parlar? Le xè parole buttade via)</p>
             <stage>(<emph>ad Anzoletto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>(Me preme de dirghe le mie rason)</p>
             <stage>(<emph>a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>El re de bastoni</p>
             <stage>(<emph>giuocando</emph>).</stage>
             <p>Buttè zo quela</p>
             <stage>(<emph>ad Agostino</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Sior no; questa.</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>E mi voggio questa</p>
             <stage>(<emph>leva una carta delle tre di Agostino, e la butta in tavola</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <stage>(<emph>dà giù la sua carta</emph>).</stage>
             <p>Via, la responda</p>
             <stage>(<emph>ad Alba</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Cossa òggio da responder?</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>No la vede? Bastoni.</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Quala òggio da dar?</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Mo via. L'asso</p>
             <stage>(<emph>le fà dar giù l'asso di bastoni</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Sia malignazo! Subito l'asso</p>
             <stage>(<emph>tutti gettano la loro carta in tavola</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>(Che 'l tegna su le so carte. Vorlo, che i ghe veda
 la <emph>meneghella</emph>?)</p>
             <stage>(<emph>a Lazaro, piano</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>(Eh no gh'è pericolo, che nissun me la veda)</p>
             <stage>(<emph>piano a Marta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Via, la zoga</p>
             <stage>(<emph>ad Alba</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Cossa òi da zogar?</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Quel fante.</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Qual fante?</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Mo quelo, quelo. No la ghe vede?</p>
             <stage>(<emph>con impazienza</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Mi deboto buto le carte in tola.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Mo no la vaga in colera. El fante de danari</p>
             <stage>(<emph>giuocando la carta di sior'Alba</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Ve sentìu gnente?</p>
             <stage>(<emph>ad Alba giuocando, e si lascia veder le carte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Gnente</p>
             <stage>(<emph>a Lazaro</emph>).</stage>
@@ -4127,344 +4176,344 @@ la <emph>meneghella</emph>?)</p>
 <emph>meneghella</emph>)</p>
             <stage>(<emph>piano a Bastian ridendo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Vorlo tegnir su le so carte?</p>
             <stage>(<emph>a Lazaro</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Coss'è, patroni, gh'àli la <emph>meneghela</emph>?</p>
             <stage>(<emph>a Marta, e Lazaro</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Eh! gh'avemo dei totani</p>
             <stage>(<emph>rispondendo per sé, e per Lazaro</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Danari no ghe n'avemo</p>
             <stage>(<emph>rispondendo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Sti maledetti danari xè queli, che lo fa andar
 via)</p>
             <stage>(<emph>ad Anzoletto, rispondendo colla carta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>(No solamente i danari, ma anca un pocheto de onor)</p>
             <stage>(<emph>a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>El cavalo, saràvelo bon?</p>
             <stage>(<emph>giuocando</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Sior no; gh'avemo el re</p>
             <stage>(<emph>giuocando</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>E mi l'asso.</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Sì! i gh'ha tutti i assi del mondo.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Tiremo tredese soldi; e quel soldo chi vol véder la
 mia carta</p>
             <stage>(<emph>tira i soldi dal piatto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Nualtri un soldeto per omo</p>
             <stage>(<emph>mettono due soldi in piatto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Nu no volemo gnente.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Un soldeto mi.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Eh! no, caro vu, che i gh'ha la <emph>meneghela</emph></p>
             <stage>(<emph>a Momolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Vedémola.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Mi no voggio.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Co no volè, sè parona. Co una donna dise no voggio,
 me rendo subito.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Gh'è altri, che voggia gnente?</p>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Mi un soldo.</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Sior no.</p>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Un soldo!</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Sparagnémolo.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>E lori, vorli gnente?</p>
             <stage>(<emph>a Bastian, e ad Alba</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Gnente a sto mondo.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Vostro danno. Vedeu? V'avè fatto cognosser che la
 gh'avè</p>
             <stage>(<emph>a Lazaro tirando il piatto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Mi? Come?</p>
             <stage>(<emph>tutti mettono di nuovo i loro due soldi nel tondo, fuori di Domenica, e Anzoletto, perchè parlano, e non badano</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Eh! sì, sì, careto; no stè ben a rente vostra
 muggier.</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Poverazzo! el xè de bon cuor mio mario</p>
             <stage>(<emph>ridendo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Tocca a far le carte a sior'Elenetta</p>
             <stage>(<emph>dà le carte ad Elena</emph>).</stage>
             <p>Via, chi manca a metter su?</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Mancheremo nualtri</p>
             <stage>(<emph>prende i quattro soldi</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>(Mo i compatisso, poverazzi!)</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>(Se la savesse, quanto che me despiase)</p>
             <stage>(<emph>a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(De cossa?)</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>(De doverla lassar)</p>
             <stage>(<emph>mettendo i soldi nel piatto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Busiaro!)</p>
             <stage>(<emph>ad Anzoletto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Che la leva</p>
             <stage>(<emph>a Polonia dandole le carte, perché alzi</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>(Siora Domenica, come vàla?)</p>
             <stage>(<emph>a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Qua no se sente altro, che de le busie)</p>
             <stage>(<emph>a Marta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>(Se sè un putto civil, tratè almanco con
 sincerità)</p>
             <stage>(<emph>ad Anzoletto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>(Per farghe véder, che no son busiaro, ghe farà una
 proposizion)</p>
             <stage>(<emph>a Domenica che senta anche Marta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Che xè?)</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>(Vorla vegnir in Moscovia con mi?)</p>
             <stage>(<emph>come sopra</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>(Sì ben, che l'accetta. Nol dise mal)</p>
             <stage>(<emph>a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Come?)</p>
             <stage>(<emph>ad Anzoletto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>(Col consenso de so sior padre)</p>
             <stage>(<emph>come sopra</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>(Se gh'intende)</p>
             <stage>(<emph>a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Sposai?)</p>
             <stage>(<emph>ad Anzoletto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>(No vorla?)</p>
             <stage>(<emph>come sopra</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>(Bravo, bravo dasseno)</p>
             <stage>(<emph>ad Anzoletto, rimettendosi al giuoco</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Spade, che la vegna</p>
             <stage>(<emph>giuocando</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Spade? Chi zoga spade?</p>
             <stage>(<emph>con allegria</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Mi; el cinque de spade.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>E mi el cavalo</p>
             <stage>(<emph>allegra butta giù la carta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>L'aspetta, che no tocca a ela</p>
             <stage>(<emph>a Domenica</emph>).</stage>
             <p>(Adesso la se confonde per l'allegrezza). Via a lori</p>
             <stage>(<emph>a Bastian, e ad Alba</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>El re</p>
             <stage>(<emph>dando giù la carta</emph>).</stage>
             <p>A ela, la responda</p>
             <stage>(<emph>ad Alba</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Son stuffa</p>
             <stage>(<emph>rispondendo con sprezzo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>(Anca mi).</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Mi ghe metto l'asso; ma ghe scometto, che vien fora
 la <emph>meneghella</emph></p>
             <stage>(<emph>dà giù la carta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Via, che 'l responda</p>
             <stage>(<emph>ad Anzoletto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>(Me preme, che la me responda ela)</p>
             <stage>(<emph>a Domenica, giuocando</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Ghe responderò)</p>
             <stage>(<emph>ad Anzoletto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Presto, che i se destriga</p>
             <stage>(<emph>a Momolo, e Polonia</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Cossa serve?</p>
             <stage>(<emph>risponde</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Vienla?</p>
             <stage>(<emph>ad Elena, rispondendo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Vèla qua</p>
             <stage>(<emph>dà giù la meneghella con allegrazza</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Cara culìa!</p>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Che i la paga</p>
             <stage>(<emph>con allegria</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Xèla sforzada?</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Siora sì</p>
             <stage>(<emph>raccoglie i soldi</emph>).</stage>
@@ -4473,22 +4522,22 @@ la <emph>meneghella</emph></p>
             <p>Coppe, el sette</p>
             <stage>(<emph>giuoca</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>El re</p>
             <stage>(<emph>giuoca</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>No tiremo mai</p>
             <stage>(<emph>giuoca</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Me vien l'accidia</p>
             <stage>(<emph>giuoca, e si tocca la testa</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>No ghe n'ho coppe</p>
             <stage>(<emph>giuoca</emph>).</stage>
@@ -4496,459 +4545,459 @@ la <emph>meneghella</emph></p>
 quel baston</p>
             <stage>(<emph>a Lazaro</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Se mio padre volesse...)</p>
             <stage>(<emph>ad Anzoletto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>(Se podemo provar)</p>
             <stage>(<emph>a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Via, che i responda</p>
             <stage>(<emph>a Domenica e ad Anzoletto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Cossa zógheli?</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Coppe.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Cossa gh'è de coppe?</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>El re. No la vede?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Ghe n'avémio nu coppe? Ah! sì, l'asso</p>
             <stage>(<emph>giuoca, e poi parla piano ad Anzoletto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Malignazzo! e tanto la sta?</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>(Mi la compatisso)</p>
             <stage>(<emph>da sé</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Bon pro ve fazza, compare Anzoleto</p>
             <stage>(<emph>forte ad Anzoletto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>De cossa?</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Eh! gnente; de quel asso de coppe, che avè zogà.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Xela nostra?</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>No vorla? El xè l'asso, e xè zoso la <emph>meneghela</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>La <emph>meneghela</emph> xè zo? Aspettè. Tutti quei bezzi chi
 vol véder la mia carta.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Ih! ih!</p>
             <stage>(<emph>maravagliandosi</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Sior no, sior no.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Ben. Chi no vol, vaga via.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>A monte, a monte</p>
             <stage>(<emph>a Momolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Mi mo la vederia volentiera.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>E mi no.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Ghe scometto, che la xè una bulada in credenza.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Voleu véderla? Soddisfève.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Cossa dìsela ela colla so prudenza?</p>
             <stage>(<emph>ad Elenetta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Mi? che 'l fazza el so zogo</p>
             <stage>(<emph>a Momolo ruvidamente</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Mo via, no la me tratta mal, che son una persona
 civil.</p>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>La fenìmio, sior Momolo?</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Fermève. Quanto àli dito su la so carta?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Sette soldi, seu sordo?</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Mora l'avarizia, e crepa la gnagnera: sette soldi</p>
             <stage>(<emph>mette i soldi in piatto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Che xè altri?</p>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Ghe semo nu.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>E nu gnente</p>
             <stage>(<emph>getta via le carte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Oh! figurève, se vòi buttar via sette soldi. Dè
 qua, dè qua</p>
             <stage>(<emph>prende le carte di Agostino e le butta a monte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Mo via, siora, seu patrona vu?</p>
             <stage>(<emph>a Elena</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Mi la voggio cussì</p>
             <stage>(<emph>ad Agostino</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Debotto, debotto...</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Coss'è sto debotto?</p>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Insolente.</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Musso.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Le se ferma.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Mo no fali stomego?</p>
             <stage>(<emph>a Lazaro, parlando di Agostino, e di Elena</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Via, ghe xè altri?</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Vorla, che i mettemo?</p>
             <stage>(<emph>ad Alba</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Cossa?</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Sti sette soldi?</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Per mi, che 'l ghe ne metta anca trenta, cossa
 m'importa?</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Mo la zoga molto de gusto! Ecco qua sette soldi.</p>
             <stage>(<emph>li mette</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Questo xè el fante de danari</p>
             <stage>(<emph>scopre la carta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Vedeu, siora?</p>
             <stage>(<emph>ad Elena</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>E cussì?</p>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Col re la m'ha fatto andar via.</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Chi se podeva imaginar, che co una strazza de carta
 la andasse a invidar sette soldi? Se vede, che la gh'ha dei
 bezzi da buttar via.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Cara siora, se zoga; se fa per tegnir el zogo in
 viva. No gh'avemo bezzi da buttar via; ma no semo gnanca
 spilorzi.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>La se ferma. Su quel fante altri diese soldeti</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Vorla, che ghe tegnimo?</p>
             <stage>(<emph>ad Alba</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>A mi el me domanda? Co sto sussuro me va atorno la
 testa che no ghe vedo.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Son qua mi con diese soldeti.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Cossa dìsela ela?</p>
             <stage>(<emph>a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Per mi, no vòi altro.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Questo qua xè el lustrissimo sior cavalo.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Altri diese soldetti su quel lustrissimo sior
 cavalo</p>
             <stage>(<emph>li mette in piatto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>El re xè a monte; la <emph>meneghela</emph> xè zoso; no gh'è
 altro, che l'asso. O l'asso, o una cazzada. A Momolo
 manganer cazzae no se ghe ne fa. Son qua, diese soldi,
 compare Bastian.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Aspettè; avanti che i mettè suso, voleu, che
 spartimo?</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>No, compare, o tutti vostri, o tutti mii</p>
             <stage>(<emph>li mette</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Co l'è cussì, tirèveli.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Grazie</p>
             <stage>(<emph>vuol tirar il piatto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Fermève. Questo xè l'asso, compare.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Tegnìme la tesa, tegnìme la testa.</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Védistu?</p>
             <stage>(<emph>ad Agostino</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Ti gh'ha rason</p>
             <stage>(<emph>ad Elena</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Tiremo sto piatelo</p>
             <stage>(<emph>tira il piatto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Xèli tutti nostri?</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Tutti nostri.</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Tutti nostri?</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Tutti nostri.</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Oh! bravo sior Bastian, bravo sior Bastian, bravo
 sior Bastian</p>
             <stage>(<emph>ridendo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Vedeu? Questo xè un bel incontro. Nu de ste fortune
 no ghe n'avemo</p>
             <stage>(<emph>a Lazaro</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Gh'ho gusto, che mia muggier se diverta. Àla
 sentio, come che l'ha ridesto?</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Vardè, vedè! Fè sbarar i mascoli per sta bela
 cossa. Oh! via, che i metta suso, patroni. Tocca a far le
 carte a sior Agustin</p>
             <stage>(<emph>Agostino mescola le carte, e tutti mettono</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Caro sior Anzoleto, saria troppo felice, se
 succedesse sta cossa!)</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>(Se sior Zamaria se contenta, mi la gh'ho per
 fatibile).</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Mettemo suso.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Son qua mi. (Se la vol, mi ghe parlerò)</p>
             <stage>(<emph>a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Magari!)</p>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Alza, via, da brava, alza la <emph>meneghela</emph></p>
             <stage>(<emph>ad Elena</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Vèla qua, vèla qua</p>
             <stage>(<emph>alza la meneghella</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>El piato, el piato</p>
             <stage>(<emph>tira il piatto, e passa le carte a Bastian</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Brava, me consolo con ela</p>
             <stage>(<emph>ad Elena</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>(Ghe scometto, che so mario ha fatto qualche fufigna
 per far alzar la <emph>meneghela</emph>)</p>
             <stage>(<emph>a Momolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>(Sì, ho visto tutto; la <emph>meneghela</emph> giera fora del
 mazzo)</p>
             <stage>(<emph>a Polonia</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Animo, patroni. Bisogna tornar a metter suso.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>(Subito, che s'ha fenio de zogar, mi ghe parlo).</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Se savesse, come far a fenir)</p>
             <stage>(<emph>mettono i denari nel tondo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Via, da bravo, alzèla anca vu</p>
             <stage>(<emph>ad Agostino, dandogli da alzare</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Eh! sior no. (Basta una volta)</p>
             <stage>(<emph>alza</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>(<emph>dà fuori le carte</emph>).</p>
           </sp>
@@ -4958,219 +5007,219 @@ mazzo)</p>
           <stage>
             <emph>Zamaria e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Come vàla?</p>
             <stage>(<emph>a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Eh! la va ben</p>
             <stage>(<emph>con allegria</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Vadagneu?</p>
             <stage>(<emph>a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Ho speranza de vadagnar</p>
             <stage>(<emph>guardando Anzoletto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Cussì spero anca mi</p>
             <stage>(<emph>guardando Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>E qua, come vàla?</p>
             <stage>(<emph>a Lazaro, e Mrta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Ben, sior compare.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Ben disè? Se perdemo.</p>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Oe, mia muggier xè de bona voggia</p>
             <stage>(<emph>a Zamaria</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Sì? Me consolo. Come vàla, siora comare?</p>
             <stage>(<emph>ad Alba</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Oimei; che odor gh'àlo intorno, sior compare?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Pol esser, che me sapia le man da nosa muschiada.</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Oh! che 'l vaga via, che no posso soffrir sta
 spuzza.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Spuzza, ghe disè?</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Che 'l vaga via, che debotto me vien mal.</p>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Mo, andè via, caro sior compare</p>
             <stage>(<emph>alzandosi un poco</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Ih! ih! cossa gh'òggio intorno? El contagio? E qua
 come xèla?</p>
             <stage>(<emph>a Momolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Mi son el tipo del delirio. Sfortunà al zogo;
 sfortunà in amor. Chi me scazza, chi me brontola, chi me
 cria; all'ultima de le ultime, fazzo conto, che anderò in
 Moscovia anca mi.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Cossa andereu a far in Moscovia?</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>A impastar el caviaro.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Oh! che caro matto</p>
             <stage>(<emph>va bel bello girando dietro le sedie</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Oh! via, a chi tocca a zogar?</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Aspettè, che fazza la mia lissìa</p>
             <stage>(<emph>fa la scelta delle carte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Se 'l savesse! gh'ho una paura, che 'l diga de no
 mio padre, che tremo)</p>
             <stage>(<emph>ad Anzoletto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>(Crédela, che a mi nol me la voggia dar?)</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Se 'l stasse a Venezia, no gh'averia nissun dubbio;
 ma andando via, nol gh'ha altro, che mi; e so che l'ha dito
 cento volte, che lontana da élo, nol vol assolutamente, che
 vaga).</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>(Questa la me despiaserave infinitamente).</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <stage>(<emph>arriva sopra la sedia di Domenica, senza ch'ella se ne accorga</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(E per questo s'avemio da abandonar?)</p>
             <stage>(<emph>ad Anzoletto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>(Mi no me perdo de coragio cussì per poco)</p>
             <stage>(<emph>a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>(Che interessi gh'àli sti siori?)</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Via, che la zoga quel asso</p>
             <stage>(<emph>ad Alba</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>L'asso de coppe</p>
             <stage>(<emph>giuocando</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Oh! qua el xè?</p>
             <stage>(<emph>a Zamaria scoprendolo, mortificata</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>De cossa se descorre, patroni?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Consegiévimo le nostre carte.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>E cossa parlèvi de abandonar?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>De abandonar?</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Sior sì; ghe par a élo, che queste sia carte da
 abandonar? Ghe par a élo, che qua no se possa chiapar? La
 voleva buttar via le so carte; no, digo mi, tegnìmole suso.
 Mi no me perdo de coragio per cussì poco.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Sì ben; se i zoga qua, se ghe dà questa, e co
 st'altra se pol far zogo.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>A proposito de abandonar, aveu savesto sior
 Zamaria, che sior Anzoleto ne abandona?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Sior sì, l'ho savesto; ma el m'ha anca promesso, che
 'l me manderò dei dessegni; n'è vero, fio mio?</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Sior sì, ho promesso, e li manderè.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Caro sior Anzoleto, co andè via vu, cossa serve,
 che mandè i dessegni? Co no sè vu assistente al teler,
 credeu che i testori possa redur i drappi segondo la vostra
 intenzion?</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Caro sior Bastian, la perdona. La fa torto, a dir
 cussì, a persone che gh'ha la pratica, che gh'ha esperienza,
@@ -5183,34 +5232,34 @@ s'indubita; gh'ho tanta speranza, che i aventori sarà
 contenti; e che 'l so servitor Anzoleto no ghe sarà desutile
 gnanca lontan.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Cossa disèu, sior Lazaro? Seu persuaso?</p>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Mi sì, che 'l manda pur, e che nol se dubita gnente.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>E po, cossa serve? No dìselo, che 'l tornerà?</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Oh! mi mo credo, che nol torna altro,</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Per cossa crédelo, che non abbia più da tornar?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Che i zoga, che i zoga, che co i averà fenio de
 zogar, parleremo. Gh'ho una cossa in mente. Chi sa? Co se
 vol, che 'l torna, so mi quel, che ghe vol per farlo tornar.
 Via, che i se destriga, che debotto xè ora da andar a cena.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Nu gh'avemo in tola l'asso de coppe</p>
             <stage>(<emph>tutti rispondono</emph>).</stage>
@@ -5223,46 +5272,46 @@ Via, che i se destriga, che debotto xè ora da andar a cena.</p>
           <stage>
             <emph>Cosmo, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#cosmo">
             <speaker>COSMO</speaker>
             <p>Siora Polonia, xè qua una franzese, che la domanda
 ela.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Dasseno? (Me despiase, che semo qua)</p>
             <stage>(<emph>da sé</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Chi èla sta franzese, che ve domanda?</p>
             <stage>(<emph>a Polonia</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>La sarà madama Gatteau, la recamadora.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Sì, la cognosso. Se volè, fela vegnir avanti.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>(Madama Gatteau!)</p>
             <stage>(<emph>a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Sior sì, ghe conterò tutto)</p>
             <stage>(<emph>ad Anzoletto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Via; za che sior Zamaria se contenta, disèghe, che
 la resta servida</p>
             <stage>(<emph>a Cosmo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>COSMO</speaker>
             <p>Benissimo. (La par la marantega vestia da festa)</p>
             <stage>(<emph>parte</emph>).</stage>
@@ -5273,7 +5322,7 @@ la resta servida</p>
           <stage>
             <emph>Madama Gatteau, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Messieurs, mesdames. J'ai l'honneur de vous
@@ -5281,215 +5330,215 @@ saluer</foreign>
             </p>
             <stage>(<emph>fa riverenza a tutti</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Madama, la reverisso.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Votre servante, monsieur.</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Servo, madama Gatteau.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Bon soir, mon cher Anjoletto</foreign>
             </p>
             <stage>(<emph>riverenza amorosa</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Madama Gatteau</p>
             <stage>(<emph>chiamandola</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Me voici, madamoiselle</foreign>
             </p>
             <stage>(<emph>fa riverenza a tutti, e passa vicino a Polonia</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <stage>(<emph>si agita, e fa dei contorcimenti</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Forti. Com'èla?</p>
             <stage>(<emph>verso sior'Alba, alzandosi</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Coss'è? Cossa gh'àla?</p>
             <stage>(<emph>ad Alba</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Ghe vien le fumane?</p>
             <stage>(<emph>ad Alba</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Cossa gh'aveu, fia mia?</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Ho sentio un odor, che me fa morir</p>
             <stage>(<emph>come sopra</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Anca mi ho sentio qualcossa, ma no capisso.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Lavanda, sampareglie, odori che consola el cuor.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Odori de madama Gatteau.</p>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Sia maledìo sti odori.</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Me vien mal.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Fermève, che so qua mi</p>
             <stage>(<emph>s'alza</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Presto, va là, agiùtila. No ti vedi?</p>
             <stage>(<emph>a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Cossa vorlo? Che impianta qua madama Gatteau? Le xè
 tante)</p>
             <stage>(<emph>a Zamaria</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>La vegna qua, sior'Elena, la me daga una man.</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Son qua. Poveretta! la me fa peccà.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Siora Polonia, cara fia, menèla in te la mia camera</p>
             <stage>(<emph>a Polonia</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Siora sì, volentiera. (Sia malignazo sti muri de
 meza piera)</p>
             <stage>(<emph>Polonia e Marta conducono via sior'Alba</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Aséo, bulgaro, assa fetida, pezza brusada; presto,
 miedego, chirurgo, spizier. Mi vago intanto a darme una
 scaldadina</p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Caro sior Zamaria, che 'l vegna de là con mi.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>No ghe xè tre done?</p>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Se bisognasse mandar a chiamar qualchedun.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Podè andar anca va, se bisogna.</p>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Mi no gh'ho cuor de abandonar mia muggier</p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Anca mi gh'ho qualcossa da far.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Anderò mi, sior Zamaria, anderò mi. Cara madama,
 con quei vostri odori...</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Pardonnez-moi, monsieur. Je n'ai pas de mauvaises
 odeurs.</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Pardonnez-moi, madame; vous avez des odeurs
 détestables</p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Fy donc, fy donc.</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>(Dove che xè mia muggier, ghe posso andar anca mi)</p>
             <stage>(<emph>in atto di partire</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Dove andeu, fiozzo?</p>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Vago de là un pocheto.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Aveu paura, che i ve magna vostra muggier?</p>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Oh! giusto; vago cussì, per véder se bisognasse
 qualcossa.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Mo el xè ridicolo quel, che sta ben.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>(Sior Zamaria; za che gh'avemo sto poco de tempo, se
 me dè licenza, ve vorave parlar).</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Sior sì, volentiera; vegnì de là con mi</p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Prego el Cielo, che nol me diga de no. Quella povera
 putta me despiaserave tropo a lassarla</p>
@@ -5501,200 +5550,200 @@ putta me despiaserave tropo a lassarla</p>
           <stage>
             <emph>Domenica, e Madama Gatteau.</emph>
           </stage>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Ve prego de compatir, madama, se siora Polonia, per
 causa mia, v'ha mandà a incomodar.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">C'est un honneur pour moi</foreign>
             </p>
             <stage>(<emph>riverenza</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Mo fème el servizio de parlar italian.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>Io so poco parlare, poco.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Eh! che parlè benissimo.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Vous êtes bien bonne, mademoiselle</foreign>
             </p>
             <stage>(<emph>riverenza</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Disème, cara madama; sior Anzoleto dessegnador xèlo
 veramente impegnà d'andar in Moscovia?</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Oui, mademoiselle, il est engagé, très engagé.</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>E gh'avè d'andar anca vu?</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Oui, mademoiselle. Nous irons ensemble. Il y aura
 une voiture à nous deux.</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Mo fème el servizio de parlar italian.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p><foreign xml:lang="fra">Alons toujours</foreign> italiano; parlare sempre italiano.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Disème, cara madama; se 'l menasse con élo una
 zovene, no l'anderave in sedia con vu?</p>
             <stage>(<emph>scherzando</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p><foreign xml:lang="fra">Ah fy, mademoiselle! Me connoissez-vous bien? Je
 suis honnête femme, et en outre...</foreign> e oltre questo, come
 potrebbe esser possibile, ch'io vedessi altra femmina con
 Anjoletto, <foreign xml:lang="fra">qui est mon cher ami, mon cher amour, mon mignon?</foreign></p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Come! sè innamorada de sior Anzoleto?</p>
             <stage>(<emph>con maraviglia</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Hélas! mademoiselle, je ne vous le cacherai pas.</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Oh! vecchia del diavolo. Squasi squasi me l'ho
 imaginada. Ma, grazie al Cielo, no la me dà zelosia). Lo
 sàlo élo, che ghe sè inamorada?</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Mademoiselle; pas encore tout affait.</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Perché no ghe l'aveu dito?</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p><foreign xml:lang="fra">Ah! la pudeur...</foreign> Come voi dite? Il rossore me lo
 ha impedito.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Seu ancora da maridar?</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p><foreign xml:lang="fra">Non, mademoiselle.</foreign> Io ho avuto trois mariti.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>E ve xè restà ancora <emph>la pudeur</emph>?</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p><foreign xml:lang="fra">Oui</foreign>, per la grazia du Ciel.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>E andar con élo da sola a solo da Venezia fin a
 Moscovia, no patiria gnente <emph>la pudeur</emph>?</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>Io son sicura della mia virtù.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Sì, per la vostra virtù, e anca un pocheto per la
 vostra età.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p><foreign xml:lang="fra">Pour mon âge? Pour mon âge, vous dites,
 mademoiselle?</foreign> Quanti anni mi donate voi?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Mi no saveria; no vorave dir un sproposito.
 Sessanta? (per farghe grazia).</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Beaucoup moins, beaucoup moins.</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Come? Cossa disèu?</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>Molto meno, molto meno.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Cinquanta?</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>Molto meno.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Quaranta?</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>Un poco meno.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Bisogna dir, madama, che le donne al vostro paese,
 de tre mesi le parla, de tre ani le se marida, de vinti ani
 le sia vecchie, e de quaranta decrepite.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Vous vous moquez de moi, mademoiselle</foreign>
             </p>
             <stage>(<emph>sdegnosa</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Mi no moco gnente. Digo cussì per modo de dir.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>Io amo molto monsieur Anjoletto; e il Cielo lo ha
 fatto nascere per la mia consolassione. Lui faira suoi
@@ -5702,33 +5751,33 @@ dissegni; je fairai miei ricami, e guadagneremo beaucoup
 d'argento, e viveremo ensemble in perfecta pace, in perfecto
 amore; je l'adorerai, il m'adorera.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Ho paura, madama, che 'l v'adorerà poco.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Pourquoi donc, s'il vous plaît?</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p><emph>Purquè</emph>, <emph>purquà</emph> el xè inamorà de una zovene.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Est-il possible?</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>La xè cussì, come che ve digo mi; e ve dirò mo anca
 de più: che pol esser, che sta zovene el la voggia sposar,
 che 'l la voggia menar in Moscovia con élo.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p><foreign xml:lang="fra">Je ne puis pas croire; mais si tout è</foreign> vero quel,
 che voi dite; si monsieur Anjoletto è amoroso di un'altra
@@ -5736,52 +5785,52 @@ giovine, je fairai le diable à quatre; et monsieur Anjoletto
 non anderà più in Moscovia. <foreign xml:lang="fra">Je n'irai pas, mais il n'ira
 pas; oui: je n'irai pas, mais il n'ira pas.</foreign></p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Poveretta! me despiase de averve dà sto travaggio.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>E chi è questa femmina, che mi vuol rapire <foreign xml:lang="fra">mon
 petit coeur?</foreign></p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>No so; no so ben chi la sia.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Si vous ne la connoissez-pas, je me flate,
 mademoiselle...</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Cossa? Ve vien el flato?</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p><foreign xml:lang="fra">Point de plesanteries; je</foreign> dico, ch'io mi lusingo,
 che monsieur Anjoletto non sarà amoroso di altra, che de
 moi.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>E mi ve digo de certo, che 'l xè amoroso de
 un'altra, e che son squasi segura, che 'l la sposerà.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Non, non; je ne le crois pas.</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Se volè crepar, mi no so cossa farve.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p><foreign xml:lang="fra">Je dis</foreign>, non lo credo, non lo credo. Il faut que je
 lui parle; bisogna, che io gli parli, che io lo veda. <foreign xml:lang="fra">Il
@@ -5792,7 +5841,7 @@ femme: je n'irai pas en Russie, mais il n'ira pas; je n'irai
 pas, mais il n'ira pas</foreign></p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Mo va là, fia mia, che ti xè un capo d'opera.
 Pàrleghe quanto, che ti vol, che per grazia del Cielo no ti
@@ -5831,87 +5880,87 @@ cento, che gh'averà da caro, che 'l resta</p>
           <stage>
             <emph>Domenica, e Polonia.</emph>
           </stage>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>La xè cussì, fia mia, come che ve conto.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Tutto averave credesto, ma no mai, che quela vecchia
 s'avesse incapricià de quel putto.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Poverazza! La vorave el quarto mario.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>E se vede, che la 'l vol zovene.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>No crederave mai, che Anzoleto fasse sta bestialità.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>No lo credo cussì minchion; e po no m'àla dito, che
 'l s'ha dichiarà de volerla sposar?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Sì, cussì l'ha dito; ma bisogna sentir cossa, che
 dirà mio sior padre.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Sentiremo. No pàrleli insieme adesso?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>I parla; ma i va drio molto un pezzo. Se savessi, co
 curiosa, che son!</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Mi la compatisso.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Ho paura, che sior padre no me voggia lassar andar.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>No se xè gnancora seguri, che sior Anzoleto abbia
 d'andar. Per quel, che ha dito la vecchia, no xèlo ancora in
 forsi d'andar?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Basta; sia quel, ch'esser se voggia; che 'l vaga, o
 che 'l staga, me basta, che 'l sia mio mario.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>El Cielo ghe conceda la grazia.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>E va, fia, co sior Momolo, come vàla?</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>No védela, che corlo che 'l xè? Come pòssio fidarme?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Mettèlo alle strette, e che 'l ve resolva; o un bel
 sì, o un bel no.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Certo, che cussì mi no voggio più star.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Oh! xè qua siora Marta. Sentimo, cossa che fa
 sior'Alba.</p>
@@ -5922,105 +5971,105 @@ sior'Alba.</p>
           <stage>
             <emph>Marta, e dette.</emph>
           </stage>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Mo quante scene! mo quante smorfie! mo quante
 scene!</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>De chi, siora Marta?</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>De quela cara sior'Alba.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Causa so mario. Se so mario no la segondasse, no la
 le farave.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Ghe xè passà?</p>
             <stage>(<emph>a Marta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Ghe xè passà, ghe xè tornà; ghe xè tornà a passar.
 Ora la pianze, ora la ride; la xè una cossa, che se i la
 mettesse in comedia, no i lo crederia.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Debotto xè ora de andar a cena. Vegnirala a tola
 sior'Alba?</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Rèstela qua la recamadora franzese?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Sior padre l'ha invidada; no so, pol esser de sì,
 che la resta; ma per certe scenette, che xè nate, pol esser
 anca de no.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Oh! se la ghe xè ela, sior'Alba no vien a tola
 seguro.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Per i odori forsi?</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Per i odori.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Adesso, adesso anderò mi de là; e sentirò dove
 diavolo, che la gh'ha sti odori; e vederò, se ghe li posso
 levar.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Sì, cara fia, andè de là; parlèghe, e vedè de scavar
 circa quel negozio, che vu savè.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Siora sì; la lassa far a mi. Mi con madama gh'ho
 confidenza; posso parlarghe con libertà.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Fè per mi, che anca mi farò qualcossa per vu.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Ghe raccomando; se la pol dirghe do parole a Momolo,
 la senta, che intenzion, che 'l gh'ha.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Siora sì; lo farò volentiera.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Brave! Da bone amighe: ve aggiutè una con l'altra.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Cossa vorla far? Una man lava l'altra.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>E tutte do, cossa làvele?</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Tutto quel, che la vol</p>
             <stage>(<emph>parte</emph>).</stage>
@@ -6031,27 +6080,27 @@ la senta, che intenzion, che 'l gh'ha.</p>
           <stage>
             <emph>Domenica, e Marta.</emph>
           </stage>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Ghe xè gnente da novo de sior Anzoleto?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>No so; el xè de là co sior padre.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Sperémio ben?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Chi sa?</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Vèlo qua; vèlo qua sior Anzoleto.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Oimè! propriamente me trema el cuor.</p>
           </sp>
@@ -6061,33 +6110,33 @@ la senta, che intenzion, che 'l gh'ha.</p>
           <stage>
             <emph>Anzoletto, e dette.</emph>
           </stage>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Com'èla, sior Anzoleto?</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Mal.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Come mal?</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>No gh'è caso; ho dito tutto quel, che podeva dir; e
 nol se vol persuàder, e no gh'è remedio, che 'l se voggia
 piegar.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Poveretta mi!</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Mo, per cossa?</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Per dir la verità, el m'ha parlà con tanto amor, e
 con tanta bontà, che 'l m'ha intenerio. El dise, e 'l
@@ -6099,11 +6148,11 @@ più; nol vol restar solo, senza nissun dal cuor. No so cossa
 dir, el m'ha fato pianzer; me diol in te l'anema, me sento a
 morir; ma co no gh'è remedio, bisogna rassegnarse al destin.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Ah! pazzenzia.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Cara siora Domenica, el Cielo sa, se ghe voggio ben.
 Ghe prometto alla presenza de sta signora, sull'onor mio, in
@@ -6111,83 +6160,83 @@ fede de galantomo, de omo onesto, e da ben: altre che ela no
 sposerò. La lassa, che vaga; tornerò presto; vegnirò a
 sposarla; ghe lo zuro con tutto el cuor.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>(Propriamente me intenerisso anca mi). Via, siora
 Domenica, cossa vorla far? No séntela? El ghe promette de
 vegnirla a sposar.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Eh! cara ela, col sarà via de qua, nol s'arecorderà
 più de mi.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>No son capace de usar ingratitudine con chi che sia,
 molto manco con ela, verso la qual gh'ho tanta stima, tanto
 debito, e tanto amor.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Mo, caro sior Anzoleto, za che professè a siora
 Domenica tanto amor; perché no ve resolveu de restar?</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>No posso; son in impegno. Ho dà parola; bisogna
 andar.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Ma seu seguro veramente de andar?</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Se vivo, son segurissimo.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Aveu parlà con madama Gatteau?</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Mi no. Cosa dìsela? Apponto; cossa xèla vegnua a far
 qua?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>No savè, che la ve vol ben? Che la xè inamorada de
 vu?</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>De mi?</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Disèu dasseno, siora Domenica?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Pur tropo digo la verità.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Pur tropo, la dise? Cossa xè sto pur tropo? Me
 crederàvela cussì matto?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Eh! caro sior; la xè vecchia, xè vero; ma soli, in
 t'un calesse, in t'un viazo cussì lontan, no se sa quel, che
 possa nasser.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Cossa diavolo voleu, che nassa?</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Se credesse, che sta cossa ghe fasse ombra, anderò
 solo, no m'importa de compagnia. Intanto ho accettà d'andar
@@ -6195,29 +6244,29 @@ con madama, in quanto m'ha parso, che la so età me podesse
 assicurar da ogni critica, e da ogni mormorazion. Da resto,
 no m'importa d'andar con ela, e no gh'anderò.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Sì; ma la se protesta, che se ghe negherè
 corespondenza al so amor, no l'anderà ela, e no anderè
 gnanca vu.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Cossa gh'ìntrela in t'i fatti mii? Xèla ela forsi,
 che me fa andar?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Mi no so altro; ve digo, che a mi colla so bocca la
 m'ha dito cussì.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Sior sì; la xè capace de scriver de le lettere
 contra de vu; de farve perder el credito, e de farve del
 mal.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Mi no so cossa dir. Se la gh'ha sto cuor, che la 'l
 fazza, che gnanca per questo mi no me saverò vendicar. Mi
@@ -6233,63 +6282,63 @@ de no pezorar ne le mie. Fazza madama quel, che ghe par; mi
 anderò in Moscovia, e sarà de mi quel, che 'l Cielo
 destinerà.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Sior sì; parla, parla. La conclusion xè questa:
 anderò in Moscovia.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>E mi poverazza resterò qua.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>La veda ela, se ghe basta l'anemo co so sior
 padre...</p>
             <stage>(<emph>a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Vorla, che ghe parlemo? Vorla, che andémo insieme a
 parlarghe?</p>
             <stage>(<emph>a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Sì, cara ela. La me fazza sto ben. La vegna de là
 con mi. Da mia posta no gh'averia coraggio de parlar.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Andémo.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Prego el Cielo, che le gh'abia più fortuna de mi.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Lo disèu de cuor?</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>El Cielo me fulmina, se no digo la verità.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Andémo, siora Domenica, andémo, che gh'ho bona
 speranza. Mi, co me metto in te le cosse, ghe riesso</p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Caro Anzoleto, e averessi cuor de lassarme?</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>No so cossa dir... La vede, in che stato, che son...</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Mo andè là, che saressi un gran can</p>
             <stage>(<emph>parte</emph>).</stage>
@@ -6300,7 +6349,7 @@ speranza. Mi, co me metto in te le cosse, ghe riesso</p>
           <stage>
             <emph>Anzoletto, poi Madama Gatteau.</emph>
           </stage>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Veramente a sta putta xè qualche tempo, che ghe
 voggio ben; ma la so modestia no ha mai fatto, che conossa
@@ -6313,53 +6362,53 @@ piutosto: <emph>nol va, perché no i lo vol. L'ha parlà senza fondamento; no i 
 ste cosse ghe son avezzo. No le me fa certo specie; ma la
 prudenza insegna de schivarle, co le se pol schivar.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>Ah! mon cher Anjoletto...</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Coss'è, madama, cossa me voressi dir?</p>
             <stage>(<emph>alterato</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Doucement, mon ami, doucement, s'il vous plaît.</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Scusème. Son un poco alterà.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">J'ai quelque chose à vous dire.</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Avè da dirme qualcossa?</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Oui, mon cher ami.</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>E ben; cossa voleu dirme?</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">J'ai de la peine à me déclarer; mais il le faut
 pour ma tranquillité. Hélas! je meurs pour vous.</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Permettème madama, che ve diga con pienissima
 libertà, che ve ringrazio de l'amor che gh'avè per mi; ma
@@ -6379,7 +6428,7 @@ che ve pol render oggetto de derision</p>
         </div>
         <div type="scene">
           <head>Scena sesta</head>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Oh Ciel! quel coup de foudre! Suis-je moi-même?
@@ -6398,11 +6447,11 @@ Ah! malheureuse Gatteau.</foreign>
           <stage>
             <emph>Zamaria, e la suddetta, poi Cosmo.</emph>
           </stage>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Coss'è, madama? cossa xè stà?</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Ce n'est rien, ce n'est rien, monsieur; c'est une
@@ -6410,60 +6459,60 @@ fleur, que je ne sçaurois placer, qui me met en colère</foreign>
             </p>
             <stage>(<emph>mostra accomodarsi un fiore della cuffia</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Parlè italian, se volè, che ve intenda.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>Je dis, ch'io sono arrabbiata con un fiore della
 mia cuffia.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Mo via, cara madama, no ve desperè per sta sorte de
 cosse. (Oh! povereto mi! Xèla questa per mi una sera de
 carneval, o xèla la sera dei desperai?)</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>Dite, monsieur Jamaria: pare a voi, ch'io sia
 vecchia, ch'io sia brutta, ch'io sia detestabile?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>No, madama; chi v'ha dito sta cossa? Vu brutta? No
 xè vero gnente. Sè in bona età, sè pulita, fè la vostra
 fegura.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Ah! l'honnêt homme, que vous êtes, monsieur
 Jamaria!</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>(Per dir la verità, la gh'ha i so anetti, ma la i
 porta ben, e la xè una dona de sesto).</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>Monsieur Anjoletto ha avuto la témérité de me dire
 des sottises, des impertinences.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Cara fia, i xè cussì i zoveni; no i gh'ha giudizio.
 No i pensa, che i ha da vegnir vecchi anca lori.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>Est-il vrai, monsieur Jamaria, che vostra figlia
 ira in Moscovia avec monsieur Anjoletto?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Cara vu, tasè. No so gnente. M'ha parlà el putto, e
 gh'ho dito de no; m'ha parlà la putta, m'ha parlà siora
@@ -6472,7 +6521,7 @@ speranza, per non desturbar la conversazion. Se volè andar
 in Moscovia con Anzoleto, comodève, che mia fia no gh'ho
 intenzion, che la vaga.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p><foreign xml:lang="fra">Non, monsieur Jamaria; monsieur Anjoletto non è
 pas digne de moi.</foreign> Il a avuto la témérité di sprezzarmi. Je
@@ -6482,70 +6531,70 @@ con me molto argento, e avrei bisogno de la compagnie di un
 onest'uomo; mais e aborrisco questi giovani impertinenti, e
 je voudrois accompagnarmi con un uomo avanzato.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Sì ben, ve lodo, e sarà meggio per vu.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Est-il vrai, monsieur Jamaria, que vous êtes veuf?</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Come? Se mi son vovi?</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>Voglio dire: è vero che voi siete vedovo?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Siora sì; son veduo.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>Oh! la miserabile vita, ch'è quella di noi poveri
 vedovelli! <foreign xml:lang="fra">Pourquoi</foreign> non vi maritate, <foreign xml:lang="fra">monsieur</foreign> Jamaria?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Oh! che cara madama. Ve par, che mi sia in stato de
 maridarme?</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p><foreign xml:lang="fra">Comment, monsieur?</foreign> Un homme, come voi siete,
 potrebbe svegliare le fiamme <foreign xml:lang="fra">de Cupidon dans le coeur d'une
 jolie dame.</foreign></p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Oh! che cara madama.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>Voi siete fresco, robusto, adorabile.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Disèu dasseno?</p>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>COSMO</speaker>
             <p>Sior padron, la vegna de là in cusina a dar
 un'occhiada, e ordenar cossa che s'ha da metter in tola.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Dove xè mia fia?</p>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>COSMO</speaker>
             <p>La xè de là con quelle altre signore.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Vegno mi donca</p>
             <stage>(<emph>Cosmo parte</emph>).</stage>
@@ -6553,32 +6602,32 @@ un'occhiada, e ordenar cossa che s'ha da metter in tola.</p>
 madama, vago de là, perché i vol metter in tola. Se volè andar in
 camera da mia fia, comodève.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>Non, monsieur, je resterai ici, se voi mi donate
 la permission.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Comodève, come volè. A revéderse a tola.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>Ricordatevi, ch'io voglio a table sedere appresso
 di voi.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Arente de mi?</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Oui, monsieur, si vous plaît</foreign>
             </p>
             <stage>(<emph>riverenza</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>(Oh! che cara madama. La xè godibile, da galantomo)</p>
             <stage>(<emph>parte</emph>).</stage>
@@ -6589,7 +6638,7 @@ di voi.</p>
           <stage>
             <emph>Madama Gatteau, poi Momolo.</emph>
           </stage>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Oui, monsieur Jamaria seroit mieux mon fait. Il
@@ -6603,22 +6652,22 @@ yeux sont toujours frippons. La colère m'a fait changer. Mettons
 du rouge</p>
             <stage>(<emph>tira fuori una scatoletta, e si dà il balletto col pennello</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Madama, vostro servitor tre tombole.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Monsieur, votre servante</foreign>
             </p>
             <stage>(<emph>fa la riverenza, e seguita a bellettarsi</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Brava! pulito, cussì me piase; senza suggizion.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>Monsieur, so bene, che questo si fa in Italia
 segretamente; mais nous en France ci diamo il rosso
@@ -6626,184 +6675,184 @@ pubblicamente, et parmi nous ce n'est pas un inganno, mais
 un usage, une galanterie</p>
             <stage>(<emph>ripone il tutto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Siora sì; la xè un'usanza, che no me despiase.
 Piutosto una riosa de so man, che un cogumero de so piè. La
 favorissa de vegnir al <emph>supè</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Pardonnez-moi, monsieur. Je n'ai pas l'honneur de
 vous connoître.</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>No la me conosse? Mi son e! complimentario de la
 <foreign xml:lang="fra">maison</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Êtes vous de ces messieurs? De ces ouvriers en
 soie?</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Coman, madama? Io non intender.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>Siete voi di questi signori... Come si dice? Che
 fanno: tri, tra, tri, tra, tri, tra?</p>
             <stage>(<emph>fa il moto di quei, che tessono</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>No, madama. Io sono di queli che fano: i, u, i, u,
 i, u</p>
             <stage>(<emph>fa il moto della ruota del mangano</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>Êtes vous gondoliere?</p>
             <stage>(<emph>fa il cenno di vogare</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>No, diable, no star barcariolo. Star patron de
 mangano.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>Che cosa vuol dir mangano?</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Vuol dir gran pietra, gran pietra, e metter sopra
 tutto quel, che voler; e dar onda, e manganar, sea, lana,
 tela, e anca vecchia, se bisognar.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p><foreign xml:lang="fra">Oui, oui,</foreign><emph>la calandre</emph>, <emph>la calandre</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>La calandra, la calandra.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Eh bien, monsieur, ne m'avez vous pas dit, qu'on a
 servi?</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Comuòdo?</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>Non m'avete voi detto, che hanno servito la soupe?</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>I ha servio la sopa?</p>
             <stage>(<emph>con maraviglia, non intendendo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>Oui, che hanno messo in tavola?</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Uì, uì, hanno messo in tavola.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Alons donc, si vous plaît.</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Comàndela, che la serva?</p>
             <stage>(<emph>le offerisce la mano</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Bien obligée, monsieur Manganò.</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>M'àla tolto mi per el mangano?</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Êtes vous marié?</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Siora no, son putto.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>Et pourquoi no vi maritate?</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>No me marido, perché nessuna me vol.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Cependant, vous meritez beaucoup.</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Grazie a la so bontà.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Je ne puis pas dire d'avantage.</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Chi l'impedisce, che non la parla?</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">C'est la pudeur.</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Mo cara quela <emph>pudor</emph>! Mo cara! mo benedetta!</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Frippon, coquin, badin!</foreign>
             </p>
             <stage>(<emph>vezzosamente</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Me vorla ben?</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">(Mais non; il est trop babillard). Alons,
@@ -6811,19 +6860,19 @@ monsieur, si vous plaît</foreign>
             </p>
             <stage>(<emph>sostenuta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Son qua a servirla</p>
             <stage>(<emph>le dà la mano</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Bien obligée, monsieur Manganò</foreign>
             </p>
             <stage>(<emph>gli dà la mano con una riverenza</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Andémo. (Che pùssistu esser manganada!)</p>
             <stage>(<emph>partono</emph>).</stage>
@@ -6836,218 +6885,218 @@ tondi, posate, sedie <abbr>ecc.</abbr> con quattro lumi in tavola, e varie pieta
 in mezzo, fra le quali dei ravioli, un cappone, delle paste sfogliate
 <abbr>ecc.</abbr> Una credenziera in fondo, con lumi, tondi, bicchieri, boccie,
 bottiglie <abbr>ecc.</abbr> <emph>Si tira avanti la tavola. Tutti, fuorché Madama, e Momolo.</emph></stage>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Animo; presto, che i raffioi se giazza.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(El m'ha dà speranza. Nol m'ha dito de no)</p>
             <stage>(<emph>ad Anzoletto piano</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>(Mo via; gh'ho un poco più de consolazion)</p>
             <stage>(<emph>a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>(No i voggio miga arente quei putti). Siora Marta,
 la se senta qua</p>
             <stage>(<emph>quasi in mezzo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Sior sì, dove che 'l comanda</p>
             <stage>(<emph>siede</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Sior Anzoleto, vegnì qua arente de siora Marta.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>(Oh! questa no me l'aspettava)</p>
             <stage>(<emph>s'incammina mortificato, spiacendogli non dover sedere vicino a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Poveretta mi! Sta cossa me mette in agitazion)</p>
             <stage>(<emph>per la stessa causa</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Perché no se sentémio, come che gièrimo sentai ala
 <emph>meneghela</emph>?</p>
             <stage>(<emph>a Zamaria</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Per stavolta la se contenta cussì; gh'ho gusto de
 disponer mi. Sior Anzoleto qua</p>
             <stage>(<emph>gli assegna la sedia vicino a Marta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Son qua</p>
             <stage>(<emph>siede melanconico</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>(Coss'è, putto? I ve l'ha fatta, ah!)</p>
             <stage>(<emph>ad Anzoletto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>(La tasa, cara ela, che son fora de mi)</p>
             <stage>(<emph>a Marta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Siora comare, qua</p>
             <stage>(<emph>ad Alba</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Do done arente?</p>
             <stage>(<emph>a Zamaria</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Eh! siora no, qua in mezzo vegnirà sior Momolo, che
 'l sa trinzar. Dov'èlo sior Momolo? Vardè, chiamèlo, che 'l
 vegna; che vegna anca madama Gatteau. Qua, siora comare</p>
             <stage>(<emph>a Alba</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Che 'l varda ben, che madama no gh'abbia odori, che
 se la gh'ha odori, mi scampo via</p>
             <stage>(<emph>siede</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>No la s'indubita, sior'Alba, che gh'ho fatto la
 visita mi, e odori no la ghe n'ha più.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Qua, Sior Bastian.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>(Per dia, che anca a tola m'ha da toccar sto
 sorbetto impetrìo!)</p>
             <stage>(<emph>siede presso sior'Alba</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Vegnì qua, siora Polonia, sentève qua.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Volentiera, dove che 'l vol</p>
             <stage>(<emph>siede presso a Bastian</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>E qua, sior compare</p>
             <stage>(<emph>a Lazaro</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Mo caro, sior compare...</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Coss'è, no stè ben? Ve metto arente mia fia.
 Domenica se senterà qua</p>
             <stage>(<emph>nell'ultimo luogo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Pazzenzia! Me toccherà a magnar del velen)</p>
             <stage>(<emph>siede</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Via, no ve sentè, sior compare?</p>
             <stage>(<emph>a Lazaro</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Son tropo lontan da mia mugier.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Com'èla? Seu deventà zeloso anca vu?</p>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Eh! giusto. Xè, che mi so el so natural, e a tola
 son avezzo a governarmela mi.</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Eh! per quel, che magno mi, no gh'è pericolo che me
 fazza mal.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>E po, son qua mi; no ve dubitè gnente. La governerò
 mi</p>
             <stage>(<emph>a Lazaro</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Caro sior Bastian ve la raccomando</p>
             <stage>(<emph>siede</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Qua mia fiozza</p>
             <stage>(<emph>a Elena presso Bastian</emph>).</stage>
             <p>E qua mio fiozzo</p>
             <stage>(<emph>ad Agostin, presso a Elena</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Mi qua?</p>
             <stage>(<emph>Agostino va presso Bastian</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>No, no, qua ela, e vu qua</p>
             <stage>(<emph>a Agostino</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Eh! sior no, mi stago ben qua</p>
             <stage>(<emph>presso Agostino</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Sior no, ve digo omo, e donna. Che diavolo! No ve
 basta a esser arente a vostra muggier? Cossa gh'aveu paura?
 Sior Anzoleto savè, che putto, che 'l xè.</p>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Caro sior santolo, se el me vol ben, che el me
 lassa star qua</p>
             <stage>(<emph>a Zamaria</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Stè, dove, diavolo, che volè</p>
             <stage>(<emph>a Agostino</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>(Magnerò de più gusto)</p>
             <stage>(<emph>a Elena, sedendo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>(Anca mi starò con più libertà)</p>
             <stage>(<emph>a Agostin, sedendo</emph>).</stage>
@@ -7058,55 +7107,55 @@ lassa star qua</p>
           <stage>
             <emph>Momolo, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>La se fermi, che so qua anca mi.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Via, destrighève. Dove xè madama?</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Madama gh'ha riguardo a vegnir, per amor <emph>de la pudeur</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Eh! andè là; disèghe, che la vegna.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>No, dasseno, sul sodo. La gh'ha riguardo a vegnir
 per amor de sior Anzoleto.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Per mi disèghe, che no la se toga nissun pensier.
 Quel che xè stà, xè stà. Se l'ha parlà per rabia, la merita
 qualche compatimento. Ghe sarò bon amigo; basta che la me
 lassa star.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Co l'è cussì, la vago donca a levar. Sàle, chi son
 mi? Monsieur Manganò per servirle</p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Mo, che caro matto, che 'l xè!</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>(Gh'àla po dito gnente, siora Domenica?)</p>
             <stage>(<emph>a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Cara fia, ve prego, lassème star)</p>
             <stage>(<emph>a Polonia</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>(Poveretta! la compatisso). No se pol miga dir:
 La lontananza ogni gran piaga sana.
@@ -7120,16 +7169,16 @@ La lontananza fa mazor la piaga</p>
           <stage>
             <emph>Madama Gatteau, Momolo, e detti.</emph>
           </stage>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Largo, largo al complimentario</p>
             <stage>(<emph>dando braccio a Madama, e la conduce presso a Zamaria</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Oh! via, manco mal; ghe semo tutti.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">J'ai l'honneur de présenter mon très-humble
@@ -7137,296 +7186,296 @@ respect à toute la compagnie</foreign>
             </p>
             <stage>(<emph>facendo la riverenza, ed è risalutata</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Son qua, madama; avè dito de voler restar arente de
 mi, e v'ho salvà el posto.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Fermève, che madama ha da star in mezzo</p>
             <stage>(<emph>a Zamaria</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Sior no, che in mezzo avè da star vu per taggiar.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Mi, compare, fazzo conto de sentarme qua</p>
             <stage>(<emph>presso Elena</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Sior no.</p>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Sior no.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Andè là, ve digo; andève a sentar in mezzo.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Sior sì; gh'avè rason. Son el più belo, ho da star
 in mezzo</p>
             <stage>(<emph>va a sedere</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Sentève qua, madama</p>
             <stage>(<emph>le assegna l'ultimo posto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Bien obligée à votre politesse. Je vous remercie</foreign>
             </p>
             <stage>(<emph>fa una riverenza a Zamaria, e siede</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Fiozza, ve contenteu, che me senta qua?</p>
             <stage>(<emph>ad Elena, sedendo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Oh sior sì; no xèlo patron?</p>
             <stage>(<emph>a Zamaria</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>(No ghe star tanto d'arente)</p>
             <stage>(<emph>ad Elena</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>(Oh! no lo tocco, no t'indubitar)</p>
             <stage>(<emph>a Agostino</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <stage>(<emph>dà i ravioli a tutti. Tutti si mettono la salvietta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Faites-moi l'honneur, monsieur</foreign>
             </p>
             <stage>(<emph>a Zamaria, facendosi puntare la salvietta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Saveroggio far?</p>
             <stage>(<emph>si mette gli occhiali per puntare la salvietta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Très-parfaitement; obligée, monsieur.</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Siora Marta. Sior Anzoletto</p>
             <stage>(<emph>dando i ravioli</emph>).</stage>
             <p>Siora... Com'èla? Xè falà el scacco. Una pedina fora de logo</p>
             <stage>(<emph>vedendo, che Agostino è presso Anzoletto, e non una donna</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>Dè qua, dè qua, destrighève</p>
             <stage>(<emph>a Momolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Tolè, compare; e questi... tolè: drio man</p>
             <stage>(<emph>fa passare i tondi</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>A mia muggier.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Vedeu? Non ardisso gnanca de nominarla</p>
             <stage>(<emph>ad Agostino, burlandosi di lui</emph>).</stage>
             <p>Questi a sior Zamaria; e questi a madama.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Bien obligée, monsieur</foreign>
             </p>
             <stage>(<emph>si mette a mangiare col cucchiaro, e forchetta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>(Cossa distu? Co pochi, che 'l me n'ha dà?)</p>
             <stage>(<emph>a Agostino</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>(E a mi? Varda. El lo fa per despetto)</p>
             <stage>(<emph>a Elena</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Muggier?</p>
             <stage>(<emph>a sior'Alba</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Cossa gh'è?</p>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Ve piàseli?</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Oh! mi, savè, che de sta roba no ghe ne magno.</p>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Poverazza! Mi no so de cossa, che la viva</p>
             <stage>(<emph>a Polonia</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>(No voleu, che no la gh'abbia fame? Avanti de vegnir
 de qua, la xè andada in cusina, e la s'ha fatto far tanto de
 zàina de pan in brodo)</p>
             <stage>(<emph>a Lazaro</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>(Sì, ah! poverazza. Bisogna, che no la podesse più)</p>
             <stage>(<emph>a Polonia</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Forti, siora Domenica. Coss'è? No la magna?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Siora sì, magno. (Me sento, che no posso più).</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>(Poverazza! la compatisso)</p>
             <stage>(<emph>ad Anzoletto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>(No so, chi staga pezo da ela a mi)</p>
             <stage>(<emph>a Marta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Ve piàseli sti rafioletti?</p>
             <stage>(<emph>a Madama</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Ils sont délicieux, sur ma parole</foreign>
             </p>
             <stage>(<emph>a Zamaria</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Fème servizio de parlar italian</p>
             <stage>(<emph>a Madama</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>(Oui, monsieur. Non so per voi, che cosa non
 facessi)</p>
             <stage>(<emph>a Zamaria</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>(Per mi?)</p>
             <stage>(<emph>a Madama</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>(Per voi, mon cher)</p>
             <stage>(<emph>a Zamaria</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>(Cossa xè sto ser?)</p>
             <stage>(<emph>a Madama</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>(Vuol dire, mio caro)</p>
             <stage>(<emph>a Zamaria</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>(Caro, a mi me disè?)</p>
             <stage>(<emph>a Madama</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Patroni: chi vol del figà, se ne toga.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Dè qua, dèmene una fetta a mi.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>A vu, fia mia? No solamente el figà, ma el cuor ve
 darave, el cuor</p>
             <stage>(<emph>a Polonia, dandole il fegato</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Ah! le bon morceau qu'est le coeur</foreign>
             </p>
             <stage>(<emph>a Zamaria</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Cossa, fia?</p>
             <stage>(<emph>a Madama</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>Il cuore è il miglior boccone del mondo</p>
             <stage>(<emph>a Zamaria</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Ve piàselo?</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>Oui, molto mi piace il cuore; ma tutti i cuori non
 farebbero il mio piacere. Il vostro, monsieur Jamaria, il
 vostro cuore mi potrebbe fare contenta</p>
             <stage>(<emph>a Zamaria</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Disèu dasseno?</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Sior Zamaria, com'èla?</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Oe, me consolo, sior Zamaria.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Le se ferma</p>
             <stage>(<emph>alle donne</emph>).</stage>
@@ -7434,315 +7483,315 @@ vostro cuore mi potrebbe fare contenta</p>
 intanto taggierò sto capon</p>
             <stage>(<emph>a Zamaria. Taglia una cappone, poi lo presenta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Coss'è, male lengue? Cossa voressi dir? No se pol
 discorer gnanca?</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Lassè, che i diga, sior Zamaria; co capita de ste
 fortune, no le se lassa scampar</p>
             <stage>(<emph>ridendo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Mo vardèli, se no i par do sposini! Se no i fa
 invidia a la zoventù!</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Eh! co gh'è la salute, i ani no i stimo gnente.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>I xè tutti do prosperosi; el Ciel li benediga, che
 i consola el cuor.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Disè quel che volè, che mi no ve bado. (Tendémo a
 nu)</p>
             <stage>(<emph>a Madama</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>(On parle per rabbia, per rabbia)</p>
             <stage>(<emph>a Zamaria</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Che i se serva de capon; co i s'averà po servio,
 taggieremo st'altro, se bisognerà.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Patroni: a la salute de chi se vol ben</p>
             <stage>(<emph>beve</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Je vous fais raison, madame, et que vive l'amour</foreign>
             </p>
             <stage>(<emph>guardando Zamaria, e beve</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Evviva l'amor</p>
             <stage>(<emph>beve</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>E viva sior Zamaria</p>
             <stage>(<emph>beve</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Evviva madama Gatteau</p>
             <stage>(<emph>beve</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Vous me faites bien de l'honneur.</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Fermève. A la salute del più belo de tutti; e viva
 mi; grazie a la so bontà</p>
             <stage>(<emph>beve</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Oh! a la salute de tutta sta compagnia</p>
             <stage>(<emph>beve</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>A la confermazion del detto</p>
             <stage>(<emph>beve</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>A la salute de mia muggier</p>
             <stage>(<emph>beve</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Grazie. A la salute de mio mario</p>
             <stage>(<emph>beve acqua ridendo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Co l'acqua me lo fè el prindese?</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Con cossa? No saveu, che no bevo vin?</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>(In cusina la ghe n'ha bevù tanto de gotto)</p>
             <stage>(<emph>a Lazaro</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>(Sì ben; per qualche volta el miedego ghe l'ha
 ordenà)</p>
             <stage>(<emph>a Polonia</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Via, nol beve, sior Anzoleto? Portèghe un gotto de
 vin, che 'l fazza un prindese almanco.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>E ela, siora Domenica, no la beve? Via, portèghe da
 bever a la padroncina.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>No, no; no ve incomodè, che no bevo</p>
             <stage>(<emph>ai servitori</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Cossa fastu? No ti magni, no ti bevi, ti pianzi el
 morto</p>
             <stage>(<emph>a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Eh! caro sior padre, mi lasso, che 'l se diverta
 élo.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Coss'è? Cossa voréssistu dir?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Mi? Gnente.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Caro sior Zamaria, no vorlo, che quella povera
 putta sia malinconica? El xè causa élo.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Mo per cossa?</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>El parla in t'una maniera, e po el se contien in
 t'un'altra. El ghe dà de le bone speranze, e po, e po... no
 digo altro.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Co gh'ho dà speranza, che la gh'abbia pazzenzia.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>E per cossa méttelo sti putti uno a Mestre, e
 l'altro a Malghera?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Mo, cara siora Marta...</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Mo, caro sior Zamaria...</p>
             <stage>(<emph>con calore</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Fermève.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Tasè, quietève, no interompè</p>
             <stage>(<emph>a Momolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Lassè parlar i omeni.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Lassè parlar mia muggier.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Gh'ho parlà mi a sior Zamaria; so quel, che 'l m'ha
 dito a mi</p>
             <stage>(<emph>verso Bastian</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>La se fermi.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Tasè.</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <stage>(<emph>s'alza con impeto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Coss'è? Ghe vien mal?</p>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Coss'è stà?</p>
             <stage>(<emph>s'alza</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Ghe domando scusa; che i compatissa. Gh'ho tanto de
 testa. Mi in mezzo a ste ose no ghe posso star.</p>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Voleu, che andémo a casa?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Mo via, compare, mo via, siora comare, quietève per
 carità.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>La vaga là in tel posto de siora Domenica, che so
 mario no la stordirà.</p>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Sì ben, vegnì qua. Se conténtela?</p>
             <stage>(<emph>a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Per mi, che la se comoda pur</p>
             <stage>(<emph>s'alza</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Mi son cussì; le me compatissa. Gh'ho una testa
 cussì debole, che la se me scalda per gnente</p>
             <stage>(<emph>parte dal suo posto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Poverazza la xè delicata</p>
             <stage>(<emph>a Polonia</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Anca mi voggio star arente de mio mario</p>
             <stage>(<emph>va a sedere presso Bastian</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Per cossa sta novità?</p>
             <stage>(<emph>a Marta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>(Eh! tasé vu, che no savè gnente)</p>
             <stage>(<emph>a Bastian piano</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Perché no vala al so posto?</p>
             <stage>(<emph>a Marta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Perché stago ben qua.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>E mi, dove vorla, che vaga?</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>No ghe xè una carega voda?</p>
             <stage>(<emph>accenna, dov'ella era prima, presso Anzoletto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Vorlo vegnir qua élo, sior padre?</p>
             <stage>(<emph>a Zamaria</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Pardonnez-moi, mademoiselle, monsieur votre père,
@@ -7750,50 +7799,50 @@ ne me faira pas cette incivilité</foreign>
             </p>
             <stage>(<emph>a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Me senterò mi donca</p>
             <stage>(<emph>siede</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>(Cossa òggio da far? Bisogna, che gh'abbia
 pazzenzia)</p>
             <stage>(<emph>vedendo Domenica presso Anzoletto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>(Sia ringrazià el Cielo!)</p>
             <stage>(<emph>a Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Ghe son po arivada)</p>
             <stage>(<emph>a Anzoletto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>(No podeva più).</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Siora Domenica?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Siora.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>(Òggio fatto pulito?)</p>
             <stage>(<emph>alzandosi davanti a Momolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>(Pulitissimo)</p>
             <stage>(<emph>alzandosi davanti a Momolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Vorle, che ghe diga, patrone? che sto vegnir davanti
 dei galantomeni in sta maniera no la sta ben, e no la par
@@ -7801,198 +7850,198 @@ bon. Voggio ben esser tutto quel, che le vol; ma gnanca per
 el so zogattolo no le m'ha da tòr</p>
             <stage>(<emph>con faccia soda</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Coss'è? Seu matto?</p>
             <stage>(<emph>a Momolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Che grilo ve xè saltà?</p>
             <stage>(<emph>a Momolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Momolo. Cossa xè stà? Cossa v'àli fatto?</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Caro sior Bastian, la me fazza la finezza de vegnir
 qua, perché ste signore le me tol un pochetto troppo per
 man</p>
             <stage>(<emph>s'alza</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Son qua, compare. No ve scaldè, perché qua no ghe
 vedo rason de scaldarse</p>
             <stage>(<emph>s'alza dal suo posto, e va nell'altro</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>No me par d'averve struppià</p>
             <stage>(<emph>a Momolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Le se ferma, che me xè passà</p>
             <stage>(<emph>sedendo presso Polonia, e ridendo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Spieghèmola mo</p>
             <stage>(<emph>a Momolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Adesso ghe la spiego in volgar. Tutti xè arente a la
 so colona, e anca mi me son rampegà. Cossa disèu, vita mia?
 Òggio fatto ben?</p>
             <stage>(<emph>a Polonia</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Mo quando, quando fareu giudizio?</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>El mese de mai, quando vienlo?</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Andè là, che m'avevi fatto vegnir suso el mio
 caldo. Ma stimo, con che muso duro!</p>
             <stage>(<emph>a Momolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>(Nu almanco no se scambiemo)</p>
             <stage>(<emph>a Elena</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>(Oh! nu stemo ben)</p>
             <stage>(<emph>a Agostino</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <p>(Oh! che magnada, che ho dà).</p>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>(No xè miga gnancora fenio).</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>E cussì, gh'è altri prindesi?</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Son qua mi. Al bon viazo de compare Anzoleto</p>
             <stage>(<emph>beve</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Petèvelo el vostro prindese.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Per cossa me l'òi da petar?</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Co no va via anca siora Domenica, petèvelo.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Dème da bever. Al bon viazo de sior Anzoleto, e
 siora Domenica</p>
             <stage>(<emph>beve</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Petèvelo</p>
             <stage>(<emph>a Momolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Anca questo m'ho da petar?</p>
             <stage>(<emph>a Marta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Co sior Zamaria no dise de sì, petèvelo</p>
             <stage>(<emph>a Momolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Dème da bever</p>
             <stage>(<emph>forte ai servitori</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Compare, ve ne <emph>peterè</emph> de quei pochi.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Fermève, dème da bever.</p>
             <l>Alla salute de sior Zamaria,</l>
             <l>Che la so putta lasserà andar via</l>
             <stage>(<emph>beve</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Petèvelo</p>
             <stage>(<emph>a Momolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Dème da bever</p>
             <stage>(<emph>forte ai servitori</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Oe, seu matto?</p>
             <stage>(<emph>gli leva il bicchiere</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>La se fermi</p>
             <stage>(<emph>a Polonia</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>No vòi, che bevè altro, ve digo.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>Alons, monsieur, alons, facciamo la partita in
 quattro. Monsieur Anjoletto, e mademoiselle Dominique.
 Monsieur Jamaria, et moi.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Animo, da bravo, sior Zamaria.</p>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Sior compare?</p>
             <stage>(<emph>a Zamaria</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Cossa gh'è?</p>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Badème a mi. Un poco de muggier la xè una gran bela
 cossa.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Disèu dasseno?</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Fermève. Ascoltè un omo, che parla. Chi sóngio mi?
 Sior Momolo manganer. Un bon putto, un putto civil, che
@@ -8003,173 +8052,173 @@ Vago a tórzio co fa le barche rotte. Marìdete. Me mariderò.
 Quando? Quando? Co sta zoggia vorrà</p>
             <stage>(<emph>accennando Polonia</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Fè giudizio, e ve sposerò</p>
             <stage>(<emph>a Momolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Sposème, e farò giudizio</p>
             <stage>(<emph>a Polonia</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>No me fido</p>
             <stage>(<emph>a Momolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Provè</p>
             <stage>(<emph>a Polonia</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Orsù, sior Momolo, fenìla. Maridève, se volè: se no
 volè, lassé star; ma a nu ne preme, che se marida siora
 Domenica, e sior Anzoleto.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Patrona, in sta cossa gh'ho da intrar anca mi?</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Sior sì; ma che dificoltà ghe xè?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Ghe xè, che no gh'ho altri a sto mondo, che ela, e
 che no gh'ho cuor de lassarla andar.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>E per el ben, che ghe volè, voleu véderla
 desperada? Voleu, che la se ve inferma in t'un letto?</p>
             <stage>(<emph>a Zamaria</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>In sto stato ti xè?</p>
             <stage>(<emph>a Domenica pateticamente</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Caro sior padre, mi so so cossa dir. Ghe confesso la
 verità; la mia passion xè granda; e no so cossa, che sarà de
 mi.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>E ti gh'averà cuor de lassarme? In sta età, senza
 nissun dal cuor, te darà l'anemo de abandonarme?</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Per cossa non andeu con ela, sior Zamaria?</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Perché no ve marideu?</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Perché non andeu con madama?</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Tolè esempio da un omo. Maridève, compare.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>E andè via co la vostra creatura.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>E i mii interessi? E i mii teleri? E la mia bottega?</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Caro sior padre, co tornerà sior Anzoleto, torneremo
 anca nu.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Ma intanto, averàvio da spiantar qua el mio negozio?
 Da perder el mio inviamento? Da abandonar i mii teleri?</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Fermève, compare. Se avè bisogno de un agente, de un
 direttor, pontual, onorato; me conossè, savè chi son. Son
 qua mi.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>E mi ve prometto, che per el mio negozio no lasserò
 che servirme dei vostri omeni, e dei vostri teleri; basta
 che s'impegna sior Anzoleto, anca che vu no ghe siè, de
 mandar i dessegni, che l'ha promesso.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Sior sì; quel, che ho dito a sior Zamaria, lo
 ratifico a sior Lazaro, e a sior Agustin. Manderò i mii
 dessegni, e no ghe ne lasserò mai mancar.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>E cussì, cossa resòlvelo, sior Zamaria?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>No so gnente. No le xè cosse da resolver cussì in
 t'un fià.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>Ascoltate, monsieur Jamaria. Voi avete del bene, e
 qui non lo perderete. Io poi ho tanto in mio pouvoir, che
 potreste essere très-contento di passare avec moi vostra
 vita.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Madama, fème una finezza, vegnì un pocheto de là con
 mi</p>
             <stage>(<emph>s'alza</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Très-volontiers, monsieur</foreign>
             </p>
             <stage>(<emph>s'alza</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Domenica, vien de là anca ti.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Sior sì, sior pare, vegno anca mi. (Stè alliegro,
 Anzoleto, che spero ben)</p>
             <stage>(<emph>s'alza</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>(Voggio véder prima in quanti piè de acqua, che
 son). Patroni, con so bona grazia</p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Messieurs, avec votre permission</foreign>
             </p>
             <stage>(<emph>parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Prego el Cielo, che la vaga ben</p>
             <stage>(<emph>parte</emph>).</stage>
@@ -8181,38 +8230,38 @@ son). Patroni, con so bona grazia</p>
             <emph>Tutti, fuorché i tre suddetti. Tutti s'alzano, vengono avanti.
 I servitori sparecchiano. Agostino ed Elena restano indietro.</emph>
           </stage>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Sior Anzoleto, me ne consolo.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Spèrela ben?</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Oh! mi sì; mi ve la dago per fatta.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>El xè un omo cauto sior Zamaria. El vorrà segurarse
 del stato de madama.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Eh! madama gh'ha dei bezzi, gh'ha delle zoggie; la
 sta ben, ben; ma tre volte ben.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>No àla avù tre marii? Un poco de pele de uno, un
 poco de pele de un altro, la s'averà fatto el borson.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Ne scriveralo, sior Anzoleto?</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>No vorla? Scriverò ai mii cari amici; scriverò ai
 mii patroni; se saverà frequentemente de mi; e se saverà
@@ -8221,11 +8270,11 @@ mondo, che la schiettezza de cuor, la verità in bocca, e la
 sincerità su la penna</p>
             <stage>(<emph>Agostino, ed Elena parlando piano fra di loro, partono</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Oe! i do zelosi se l'ha moccada.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Lassè, che i fazza. Bisogna soffrir tutti col so
 difetto. Specialmente co i xè de quei, che no dà molestia a
@@ -8234,27 +8283,27 @@ conoscer i caratteri de le persone, e prevalerse del bon
 esempio, e correger se stessi, vedendo in altri quele cosse,
 che no par bon.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Scrivène spesso, sior Anzoleto.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Scriverò; ma che i scriva anca lori.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Mi ve scriverò le novità.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Me farè un piaser grandissimo.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>E se vien fora critiche, voleu che ve le manda?</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Ve dirò; se le xè critiche, sior sì; se le xè
 satire, sior no. Ma al dì d'ancuo, par che sia dificile el
@@ -8264,98 +8313,98 @@ le cosse contra de mi, pazzenzia: za el responder no serve a
 gnente; perché se gh'avè torto, fè pezo a parlar; e se
 gh'avè rason, o presto, o tardi, el mondo ve la farà</p>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>COSMO</speaker>
             <p>Patroni, dise sior Zamaria, che i se contenta de
 andar tutti de là.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Dove?</p>
           </sp>
-          <sp>
+          <sp who="#cosmo">
             <speaker>COSMO</speaker>
             <p>In portego, che xè parechià per balar.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Andémo, sior Anzoleto; bon augurio, andémo</p>
             <stage>(<emph>prende Anzoletto per mano</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>E pur ancora me trema el cuor.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Mario, vegnì anca va, andémo</p>
             <stage>(<emph>prende anch'ella Bastian per mano</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Mia muggier almanco xè de bon cuor</p>
             <stage>(<emph>parte con Marta, e Anzoletto</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Comàndela, che la serva?</p>
             <stage>(<emph>a Polonia</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Magari, che sior Zamaria ve lassasse vu diretor del
 so negozio de testor.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Ve par, che saria capace de portarme ben?</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Sè un poco matturlo; ma gh'avè de l'abilità, e sè un
 zovene pontual.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Oh! sia benedeto, chi me vol ben</p>
             <stage>(<emph>a Polonia</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Animo, animo, andémo</p>
             <stage>(<emph>lo prende per un braccio</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Con so portazion</p>
             <stage>(<emph>a Lazaro e Alba, e parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Via, muggier, andémo. Andémose a devertir.</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Mi anderave in letto più volentiera.</p>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Voleu, che andémo a casa?</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Cossa voleu? Che i se n'abbia per mal?</p>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Voleu andarve a buttar sul letto un tantin?</p>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Andémo de là, che voggio balar</p>
             <stage>(<emph>s'alza, e parte</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>(Brava! Mo che cara cossa, che xè sta mia muggier!)</p>
             <stage>(<emph>parte</emph>).</stage>
@@ -8369,144 +8418,144 @@ zovene pontual.</p>
 con altre persone, tutti a sedere. Poi Marta, Anzoletto, e
 Bastian, poi Polonia, e Momolo, poi Alba, poi Lazaro.</emph>
           </stage>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Semo qua, sior Zamaria.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <stage>(<emph>s'alza dal suo posto, e corre incontro a Anzoletto</emph>).</stage>
             <p>Vegnì qua, sior Anzoleto, vegnì qua, fio mio. Ho
 risolto, ho stabilio: ve darò mia fia, vegnirò con vu. Sieu
 benedetto; sè mio zenero, sè mio fio.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Evviva, evviva siora Domenica, me ne consolo.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Grazie, grazie</p>
             <stage>(<emph>alzandosi</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Caro sior Zamaria, no gh'ho termini che basta per
 ringraziarlo; l'allegrezza me impedisce el parlar.</p>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Me consolo co sior Anzoleto, e co siora Domenica.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Compare Anzoleto, anca mi co tanto de cuor.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Anca mi, con tutti, dasseno.</p>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Bravi, bravi; anca mi gh'ho consolazion. Muggier,
 vegnì qua anca va, sentì</p>
             <stage>(<emph>ad Alba</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#alba">
             <speaker>ALBA</speaker>
             <p>Eh! ho sentio; me ne consolo</p>
             <stage>(<emph>colla solita flemma</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Poverazza! la xè debole; no la pol star in piè</p>
             <stage>(<emph>a tutti</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#elenetta">
             <speaker>ELENETTA</speaker>
             <p>Sior santolo, siora Domenica, me ne consolo.</p>
           </sp>
-          <sp>
+          <sp who="#agustin">
             <speaker>AGUSTIN</speaker>
             <stage>(<emph>prende Elena per mano, e la conduce a sedere dov'erano prima</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Scampè, vedè, che no i ve la sorba. Sior Momolo,
 vegnì qua.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Comandè, paron.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Za che v'avè esebìo de favorirme; fazzo conto de
 lassarve a va el manizo dei mii interessi.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>E mi pontualmente ve servirò.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Ve darò un tanto a l'anno, e un terzo dei utili,
 acciò che v'interessè con amor.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Tutto quello, che comandè.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Ma fè da omo.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Se ho da far da omo, bisogna, che me marida.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Maridève.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Me mariderò, se sta cara zoggia me vol.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Sior sì: adesso, co sto poco de fondamento, ve
 sposerò!</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Oh! via, le candele se brusa. Prencipiemo a balar.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Siora sì, subito; ma avanti de prencipiar: putti,
 destrighève, dève la man</p>
             <stage>(<emph>a Anzoletto e Domenica</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Son qua, con tutta la consolazion.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Son fora de mi da la contentezza.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Mario, e muggier</p>
             <stage>(<emph>si danno la mano</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#bastian">
             <speaker>BASTIAN</speaker>
             <p>Sior Anzoleto, novamente me ne consolo. Andè a bon
 viazo, e no ve desmenteghè de nu.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Cossa dìsela mai, caro sior Bastian? Mi scordarme de
 sto paese? De la mia adoratissima patria? Dei mii patroni?
@@ -8525,40 +8574,40 @@ compenserà el despiaser de star lontan da chi me vol ben.
 Conservème el vostro amor, cari amici, el Cielo ve
 benedissa, e ve lo diga de cuor.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Via, no parlemo altro. No disè altro, che debotto
 me fè contaminar. Sior Zamaria, prencipiemo a balar.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Un momento de tempo. La lassa, che destriga un'altra
 picola facendetta, e po son con ela. Madama</p>
             <stage>(<emph>chiamandola</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Que voulez-vous, monsieur?</foreign>
             </p>
             <stage>(<emph>s'alza</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Favorì de vegnir qua.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Me voici à vos ordres</foreign>
             </p>
             <stage>(<emph>s'accosta</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Mia fia xè maridada.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Madame, monsieur</foreign>
@@ -8566,100 +8615,100 @@ picola facendetta, e po son con ela. Madama</p>
             <stage>(<emph>a Domenica e Anzoletto</emph>).</stage>
             <p>Je vous fais mon compliment.</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Se volè, se podemo sposar anca nu.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Quel bonheur! quel plaisir! que je suis heureuse,
 mon cher ami!</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Voleu, o no voleu, in bon italian?</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Voici la main, mon petit coeur</foreign>
             </p>
             <stage>(<emph>gli dà la mano</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Mario, e muggier.</p>
           </sp>
-          <sp>
+          <sp who="#madama">
             <speaker>MADAMA</speaker>
             <p>
               <foreign xml:lang="fra">Ah mon mignon!</foreign>
             </p>
             <stage>(<emph>a Zamaria</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Fermève. Con un ambo se vadagna poco. Siora Polonia,
 ghe vol el terno.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Ho capio. Me voressi sposar co sto sugo?</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Sti altri con che sugo s'àli sposà?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Via, siora Polonia, fè anca vu quel, che avemo fatto
 nu.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Me conséggielo, che la fazza?</p>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Sì, ve conseggio, e me sarà de consolazion.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Co l'è cussì, son qua co volè</p>
             <stage>(<emph>a Momolo</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Mia muggier.</p>
           </sp>
-          <sp>
+          <sp who="#polonia">
             <speaker>POLONIA</speaker>
             <p>Mio mario.</p>
           </sp>
-          <sp>
+          <sp who="#marta">
             <speaker>MARTA</speaker>
             <p>Bravi.</p>
           </sp>
-          <sp>
+          <sp who="#lazaro">
             <speaker>LAZARO</speaker>
             <p>Pulito.</p>
           </sp>
-          <sp>
+          <sp who="#anzoletto">
             <speaker>ANZOLETTO</speaker>
             <p>Me ne consolo.</p>
           </sp>
-          <sp>
+          <sp who="#momolo">
             <speaker>MOMOLO</speaker>
             <p>Fermève. Che ho prencipià a far giudizio</p>
             <stage>(<emph>serio</emph>).</stage>
           </sp>
-          <sp>
+          <sp who="#zamaria">
             <speaker>ZAMARIA</speaker>
             <p>Oh! adesso andémo a balar.</p>
           </sp>
-          <sp>
+          <sp who="#domenica">
             <speaker>DOMENICA</speaker>
             <p>Andémo, che anca mi balerò de cuor. Mi circa l'andar
 via, no serve, che diga gnente: ha dito tanto che basta sior

--- a/tei/guarini-la-idropica.xml
+++ b/tei/guarini-la-idropica.xml
@@ -76,6 +76,64 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="grillo">
+            <persName>Grillo</persName>
+          </person>
+          <person xml:id="nica">
+            <persName>Nica</persName>
+          </person>
+          <person xml:id="zenobio">
+            <persName>Zenobio</persName>
+          </person>
+          <person xml:id="patrizio">
+            <persName>Patrizio</persName>
+          </person>
+          <person xml:id="pistofilo">
+            <persName>Pistofilo</persName>
+          </person>
+          <person xml:id="lurco">
+            <persName>Lurco</persName>
+          </person>
+          <person xml:id="notaio">
+            <persName>Notaio</persName>
+          </person>
+          <person xml:id="antonio">
+            <persName>Antonio</persName>
+          </person>
+          <person xml:id="flavio">
+            <persName>Flavio</persName>
+          </person>
+          <person xml:id="lisca">
+            <persName>Lisca</persName>
+          </person>
+          <person xml:id="cavalier">
+            <persName>Cavalier del Podestà</persName>
+          </person>
+          <person xml:id="tragualcia">
+            <persName>Tragualcia</persName>
+          </person>
+          <person xml:id="moschetta">
+            <persName>Moschetta</persName>
+          </person>
+          <person xml:id="gostanza">
+            <persName>Gostanza</persName>
+          </person>
+          <person xml:id="loretta">
+            <persName>Loretta</persName>
+          </person>
+          <person xml:id="cassandra">
+            <persName>Cassandra</persName>
+          </person>
+          <person xml:id="radicchio">
+            <persName>Radicchio</persName>
+          </person>
+          <person xml:id="bernardo">
+            <persName>Bernardo</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -92,24 +150,24 @@
       </prologue>
       <castList>
         <head>PERSONE DELLA FAVOLA</head>
-        <castItem type="role"><role>PATRIZIO</role> <roleDesc>padre di Pistofilo</roleDesc>.</castItem>
-        <castItem type="role"><role>PISTOFILO</role> <roleDesc>amante di Gostanza</roleDesc>.</castItem>
-        <castItem type="role"><role>ANTONIO</role> <roleDesc>padovano</roleDesc>.</castItem>
-        <castItem type="role"><role>FLAVIO</role> <roleDesc>amante di Cassandra</roleDesc>.</castItem>
-        <castItem type="role"><role>BERNARDO</role> <roleDesc>raugeo</roleDesc>.</castItem>
-        <castItem type="role"><role>ZENOBIO</role> <roleDesc>pedante</roleDesc>.</castItem>
+        <castItem type="role"><role>PATRIZIO</role><roleDesc>padre di Pistofilo</roleDesc>.</castItem>
+        <castItem type="role"><role>PISTOFILO</role><roleDesc>amante di Gostanza</roleDesc>.</castItem>
+        <castItem type="role"><role>ANTONIO</role><roleDesc>padovano</roleDesc>.</castItem>
+        <castItem type="role"><role>FLAVIO</role><roleDesc>amante di Cassandra</roleDesc>.</castItem>
+        <castItem type="role"><role>BERNARDO</role><roleDesc>raugeo</roleDesc>.</castItem>
+        <castItem type="role"><role>ZENOBIO</role><roleDesc>pedante</roleDesc>.</castItem>
         <castItem type="role"><role>NOTAIO</role>.</castItem>
-        <castItem type="role"><role>LURCO</role> <roleDesc>padrigno di Gostanza</roleDesc>.</castItem>
-        <castItem type="role"><role>GRILLO</role> <roleDesc>servitore in casa di Nica</roleDesc>.</castItem>
-        <castItem type="role"><role>MOSCHETTA</role> <roleDesc>servitore di Patrizio</roleDesc>.</castItem>
-        <castItem type="role"><role>RADICCHIO</role> <roleDesc>servitore di Bernardo</roleDesc>.</castItem>
-        <castItem type="role"><role>CAVALIER</role> <roleDesc>del Podestà</roleDesc>.</castItem>
-        <castItem type="role"><role>TRAGUALCIA</role> <roleDesc>birro</roleDesc>.</castItem>
-        <castItem type="role"><role>CASSANDRA</role> <roleDesc>creduta idropica</roleDesc>.</castItem>
-        <castItem type="role"><role>GOSTANZA</role> <roleDesc>amante di Pistofilo</roleDesc>.</castItem>
-        <castItem type="role"><role>NICA</role> <roleDesc>governatrice di Cassandra</roleDesc>.</castItem>
-        <castItem type="role"><role>LISCA</role> <roleDesc>serva in casa di Nica</roleDesc>.</castItem>
-        <castItem type="role"><role>LORETTA</role> <roleDesc>cortigiana</roleDesc>.</castItem>
+        <castItem type="role"><role>LURCO</role><roleDesc>padrigno di Gostanza</roleDesc>.</castItem>
+        <castItem type="role"><role>GRILLO</role><roleDesc>servitore in casa di Nica</roleDesc>.</castItem>
+        <castItem type="role"><role>MOSCHETTA</role><roleDesc>servitore di Patrizio</roleDesc>.</castItem>
+        <castItem type="role"><role>RADICCHIO</role><roleDesc>servitore di Bernardo</roleDesc>.</castItem>
+        <castItem type="role"><role>CAVALIER</role><roleDesc>del Podestà</roleDesc>.</castItem>
+        <castItem type="role"><role>TRAGUALCIA</role><roleDesc>birro</roleDesc>.</castItem>
+        <castItem type="role"><role>CASSANDRA</role><roleDesc>creduta idropica</roleDesc>.</castItem>
+        <castItem type="role"><role>GOSTANZA</role><roleDesc>amante di Pistofilo</roleDesc>.</castItem>
+        <castItem type="role"><role>NICA</role><roleDesc>governatrice di Cassandra</roleDesc>.</castItem>
+        <castItem type="role"><role>LISCA</role><roleDesc>serva in casa di Nica</roleDesc>.</castItem>
+        <castItem type="role"><role>LORETTA</role><roleDesc>cortigiana</roleDesc>.</castItem>
       </castList>
       <set>
         <p>La scena si finge in Padova</p>
@@ -121,331 +179,331 @@
         <div type="scene">
           <head>SCENA PRIMA</head>
           <stage>GRILLO, NICA</stage>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>E così, monna Nica, la nostra idropica in capo a nove mesi sarà guarita.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Sta cheto, per vita tua: noi siam qui sulla strada.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>E chi volete voi che ci senta? Le mura? È troppo ancora per tempo, che le genti vadano attorno.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Grillo, questo è un gran caso! Se Cassandra si scopre gravida, guai a me!</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Infatti è vero il proverbio: “Donna tentata è mezza guadagnata; difendila dagli assalti, se la vuoi salva”. Monna Nica, voi, dite il vero: questo è un gran caso. E se dianzi m'aveste detto: “Cassandra è gravida”, io vi avrei data quella ragione che or vi do con mio grandissimo dispiacere.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Aiutami tu, dunque, e non m'abbandonare, ché in te solo, e nell'amore e nella fede tua, Grillo mio, la mia speranza tutta ho riposta.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Non dubitate già, monna Nica, che son per aiutarvi co 'l sangue proprio. Ma bisogna ch'io sappia molto ben prima come sta il fatto: ché le più volte chi è male informato, suol fare di molti errori.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Tu di' bene. Ma tu ne sai gran parte, se male non mi ricordo.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>So quella della idropica io, ma quella della gravida, no.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Or ascoltami dunque.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Sarà meglio che ascoltiate voi prima me, acciocché, ridicendovi quel ch'io so, scemi a voi la fatica di dirlo a me.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Tu parli bene: di' su.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Voi mi diceste in prima in prima che 'l padre di questa nostra Cassandra si chiama Bernardo Càttari, nobile di Raugia, il quale, essendo giovane allora e governando certa ragion del padre in Vinegia, ebbe questa figliuola. E' così?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Così sta. Ebbela furtivamente di certa giovanetta che si godeva, e che nel parto di lei morì.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Chi di gallina nasce, convien che razzoli. Non voleva il dovere ch'ella fosse da meno della sua mamma. Questo particolare voi non m'avete detto mai più, madonna no; e non era già da tacere. Ma come fu ella poi condotta a Raugia? Ché di ciò troppo bene non mi ricordo.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Hottelo detto ancora che in questo tempo Bernardo fu richiamato dal padre.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Sì, sì. Ed esso, partendo poi di Vinegia, lasciolla, così com'era bambina, in man della balia. Ricordatemi il nome.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Maddalena: appresso la quale stette sin che Bernardo, per la morte del padre, lei, ch'era già grandicella, a Raugia fece condurre.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Il resto mi ricordo io troppo bene. Ch'ella quivi infermò d'un gran male; cappita, un mal terribile! Sta così?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Così sta.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Così sta, eh? O donne, donne, chi può fuggire le vostre trappole, ha ben Giove per ascendente.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Quanti credi tu, Grillo, che sarebbono sotto il segno di Capricorno, se la sagacità delle donne non li coprisse? Poveretti a voi, se le femmine non sapessero far la coda alle lucciole!</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Ah, ah, ah, voi avete una gran ragione.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Seguita dunque.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Ma poco più ne debbo sapere io. Che da Raugia fu condotta qui per sanarsi, in casa di madonna Ginevra, sorella di Bernardo, la quale fu, vivendo, nostra padrona, che l'ha lasciata reda di venti mila ducati: erro io?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Forse anche più.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>E che questo nostro vicino... Come si chiama egli?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Patrizio degli Orsi.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Nobile padovano, eh?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Sì, co 'l malanno che Dio gli dia.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>... corso al boccone di sì gran dote, al figliuolo maritar la vorrebbe. E 'l nome del figliuolo, sapreste 'l voi?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Oh Dio! Non mi sovviene.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Orsù, non vi stillate il cervello, ché poco importa.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Pistofilo; io l'ho carpito.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>E che alla fine questo è quel che vi cuoce. Più non ne so, e credeva di saper tutto.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Ora ascolta. Dissiti che Cassandra fu lasciata bambina in man della balia, che nomavasi Maddalena, con la quale crebbe e visse, fin che, venuta grande, messer Bernardo, suo padre, la fe' condurre a Raugia. Quella sua balia, per quanto intendo, era cattiva donna; e non è maraviglia se la fanciulla apprese mali costumi.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Ve' tu se si poteva salvare? Sarebbe stato miracolo!</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Non si finì la festa che in capo l'anno ella si fu invaghita d'un suo vicino, leggiadro e avvenente giovane certo, ma di bassa fortuna, che Flavio de' Riccati si noma. La giovane molto viva e poco guardata, la matrigna senza amore e senza cervello, l'amante fuor di modo sollecito, la commodità grande: che debbo dirti? La paglia appresso il foco: tu sai.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Oh, voi ci lasciate il più bello.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>E che?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Monna Nica, amorevole a' bisognosi.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Uh, uh, che dirai?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Che dirò? Non m'avete voi detto ch'ella dormiva con esso voi?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Sì che l'ho detto, ma...</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Ma eravate voi che dormivate, e non essa, eh? O per dir meglio, v'infingevate.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>E che volevi tu ch'io facessi?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Quello che avete fatto.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Mi dava ad intendere che altro non passava tra loro che favellargli da una finestra, e mi pregava, e piagneva; e io che son tenera di natura, gliene avea compassione. Ché se tal cosa avessi creduta, uh! sarei prima morta che comportargliela.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Oh pessima finestra! Fu cagion ella di tutto il male.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Assassina, la conficcai subito subito.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Dopo il fatto, eh? Buon avviso! ah, ah, ah.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Io non so, Grillo, come domine si facessero.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>E pur è buia la camera.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Cassandra si trovò gravida, il cuor mi trema a ridirlo. In verità ch'io ebbi a impazzare: ma che? Il fatto era fatto, e frastornare non si poteva.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Troppo è vero.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>lo me n'avvidi prima di lei; e avendola confortata a starsi nel letto, feci credere al padre che fosse inferma di malaria poco men che incurabile. Onde fu agevol cosa che, per guarirla, egli si risolvesse a' conforti del nostro medico, che era (vedi ventura!) parente stretto di Flavio, di mandarla qui in casa di madonna Ginevra, che fu nostra padrona e di lui sorella, come tu sai, venuta in questa terra, due anni avanti, per curarsi d'un suo catarro, che l'ha poi finalmente condotta a morte. Ora la zia, che grandemente l'amava, inteso l'accidente, n'ebbe compassione, e scrisse al fratello che Cassandra era idropica, ma che, con l'aiuto di Dio e de potenti rimedi, si sarebbe sanata. Così la nostra barca, che era già salva, ora, per la morte della padrona, è ricaduta in più tempesta che mai. Perciocché, avvisando la zia di far gran bene alla nipote, d'ogni sua sostanza lasciolla reda, con questa condizione però, che non prendesse altro marito che padovano.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Oh cotesto non sapev'io; e perché ciò?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Perché portasse le sue vergogne lunge da casa, o dubitando per avventura che, potendosi maritare di suo capriccio, non prendesse il suo Flavio. Mosso dunque da sì gran dote, questo nostro vicino halla fatta richiedere al padre stesso, fino a Raugia, e ottenutala per Pistofilo suo figliuolo. Al qual vecchio ho sempre per parole date parole. Ma poiché vien a' fatti e mostra commessione e lettera di Bernardo medesimo, con la quale ordina ch'io la consegni in mano di detto vecchio, non so più che mi dire, né che mi fare.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Ma di Flavio, che fu?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Si fuggì. Guai a lui, se ciò si fosse mai risaputo!</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>E dove ricoverò?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>A Palermo, in casa d'un suo parente, mercante ricco; e quivi è stato sempre fuor di pericolo, aspettando che fine debbia avere la sua sciagura.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Oh quanto importarebbe che fosse qui!</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Oh Dio 'l volesse: parrebbemi d'esser fuori d'ogni pericolo. Noi l'abbiamo sempre avvisato della nostra venuta a Padova e della morte della padrona, pregandolo a venir subito, e pur non viene. Alle prime lettere ci rispose; alle seconde, no. Ho grand'oppenione ch'elle non gli sien capitate in mano.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>E Cassandra, che pensa ella di fare?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Morire prima che non esser moglie di Flavio.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Né si cura di perder sì ricca dote?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Se fosse tre volte tanta.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Volete ch'io v'insegni? Scoprite la gravidezza, che Patrizio non la vorrà, e molto meno Pistofilo.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Del figliuolo io son certa, ma del padre non so. L'avarizia può troppo. E poi, vivendo il padre di lei, guardimi Dio. Questo è un rimedio che si vuole serbar per l'ultimo. No, no, il meglio è che noi troviamo un dottore, come t'ho detto.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Ma che potrà far qui un dottore?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Che potrà, eh? Trattenere, intricare, fin tanto che Cassandra ci tragga di questo affanno: ché 'l suo parto non può molto indugiare. E poi di cosa nasce cosa, e 'l tempo la governa. Potrebbe venir Flavio, chi sa? Va, dunque, e trova messer Isidoro; sai tu il compare della padrona? Un uomo di conto, e tutto di casa nostra.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>So qual voi dite. Ma s'egli non fosse in casa, a qual segno di Palazzo troveroll'io? Al Montone, al Bue?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>A quello della Volpe non puoi fallire, ché quivi capita spesso.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Dio voglia che non sia a quello dell'Asino! Ditemi un poco: non è egli, questo dottore, quel forastiero sì profumato che fa il <foreign xml:lang="lat">coram vobis</foreign>, il cortegiano, il poeta, l'innamorato, che stava le ore intere in camera con madonna?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Questi è desso.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Non son il caso.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Perché?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Perché un dì gli volli pelar il mento; e se troppo mi stuzzicava... Andateci voi, e farà tutto quel che vorrete. Conosco ben io le mie bestie.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Vuoi tu che io vada in Palazzo?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Forse il troverete in casa. E poi che monta? Avete voi paura di perdere il vostro onore? Fate a mio senno: in questo mezzo andrò pensando io di far alcun'altra cosa in vostro servigio.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Perché a questo tu mi consigli, proverò mia ventura. Addio.</p>
           </sp>
@@ -453,327 +511,327 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>ZENOBIO, GRILLO</stage>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Sta bene. Oh <foreign xml:lang="lat">admirabile</foreign>!</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Ecco 'l pedante; vo' far vista di non vederlo.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Che Petrarca? <quote xml:lang="lat">Lenta salix quantum pallenti cedit olivae</quote>.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Che non guardi? Oh, siete voi! Perdonatemi.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>O lepidissimo mio capitulo!</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>O messer Zenobio onorando.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Io non t'avea veduto. Questo furor poetico, quand'io sono afflato da lui, mi fa uscir fuori di me medesimo; perdonami.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Non importa, messer Zenobio, che l'esser urtato da pari vostri è favore.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Tu burli? E chi sa che nel venire inverso di te, ripieno d'estro poetico (così lo chiamano i dotti, sai?), non t'inopinassi questo furor divino, e divenissi tu ancor poeta?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>(Di minestra e di vino sento pur troppo che sei ripieno. Anco il ciacco a questo modo è poeta).</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Che di' tu di poeta?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Dico che non mi curo di diventar poeta.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>So che tu fai del grande, io, Grillo, e non ti lasci più vedere, come solevi prima ch'entrassi in casa di quella buona femmina d'Epidauro. <foreign xml:lang="lat">Proficiat</foreign>, i grilli s'imbucano volentieri, eh?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Ma chi s'imbuca più di voi, messer Zenobio? Che, dopo la partita vostra di casa Papafava, non ho potuto mai più vedervi.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p><foreign xml:lang="lat">Tu solus advena</foreign>? Non sai dunque ch'i' ho la mia libertà vendicata e, quinci non molto lunge, aperto ancora un pubblico gimnasio, anzi pure una socratica stoa, a tutti i giovanetti della città?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Non l'ho inteso per certo; e come vi privaste voi mai di quella casa sì principale?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Male lingue, fratello! La invidia, ch'è nemica della virtù! Cominciarono a dire ch'io era troppo plagoso.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Di grazia, parlatemi che v'intenda.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Che troppo adoperassi la verga.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>La verga? Che cosa è ella cotesta verga?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>La scutica magistrale, lo staffile.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Oh dite così, in nome di Dio. Or v'intendo. E perciò vi fu data licenza, eh?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Mi fu data, ma discretissima, e quale conveniva a un par mio.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Non fu dunque vero che in su la mezza notte vi mettessero fuor di casa, no?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Anzi verissimo, e perciò la chiamo discreta.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>A me, che sono di grossa pasta, par altrimenti; e però fate, per vita vostra, che intenda come la chiamate discreta.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Discreta, perché tacita.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>E una cotal licenza chiamate tacita?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p><foreign xml:lang="lat">Per amica silentia noctis</foreign>. Sta cheto, che è di Virgilio. Ve' quanto importa il sapere! Tacita, per la notte ch'è tacita, intendi tu?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Mi par di sì. Come sarebbe a dire, se quel cavaliere v'avesse licenziato con un pezzo di legno?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p><foreign xml:lang="lat">Bona verba, quaeso</foreign>. A un par mio?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Io dico: quando l'avesse fatto, intendetemi sanamente, perché il bastone non sente nulla, neanche voi avreste sentite le bastonate; una cosa sì fatta.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Tu non l'intendi, messer no. Non è la medesima genologia dal legno alla schiena ch'è dalla notte alla licenza.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>E che vuol dire cotesta genologia? Ch'io non v'intendo, perché sappiate.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Te 'l credo. Ha pochi pari Zenobio. È una parola greca che non fa per te, Grillo.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Del vin greco m'intendo assai bene, ma del parlar non ne mangio. (Dio sa se questo animale non dice qualche sproposito).</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Ma <foreign xml:lang="lat">aedepol paenitebit</foreign>: tardi s'accorgerà d'aver perduto un tal uomo. Pochi Zenobi son oggi al mondo, credilo a me. Io fui discepolo di quel famoso Fidenzio, gimnasiarca dell'universo. Per tutto poi, dove ho dato opera all'auree umane lettere, ho lasciato memoria del nome mio; e più d'altrove nell'inclita città di Venezia, dove apersi i tesori della mia grande erudizione. Oh che disciplinata gioventù! Oh che morigerati discepoli! più dei socratici pazienti e più de' pitagorici taciturni. Di quella gentil città non mi sarei partito giammai, se l'amor di Gostanza non mi avesse tirato in qua.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Che, siete innamorato?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p><foreign xml:lang="lat">Heu me</foreign>!</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>E qual è ella cotesta traditora che vi fa sospirare? Ah ah ah.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>La figliuola di Lurco: il quale, per mio maggior lenocinio (<foreign xml:lang="lat">Dij boni</foreign>), è venuto a stare in questa contrada. Guata, Grillo, di grazia, s'ella fosse al balcone.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>A me par dì sì.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>O cara <foreign xml:lang="lat">animula</foreign>!</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Ah ah ah, guata viso che fa! Guata ceffo!</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Eh, Grillo, tu m'hai beffato.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>V'ho detto il vero, io. Ma chi v'aspetterebbe con questi vostri occhialacci? Farebbono spiritare.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Caro Grillo, per amor di costei, la cui <foreign xml:lang="lat">plusquam humana</foreign> e, posso dir, metafisica pulchritudine è sola degna della mia penna, ho pur ora fatto un sonetto che non ha pari. Odilo, Grillo, per vita tua.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Volontieri. Ma voglio prima sapere come voi siete bene ricambiato di cotesto vostro sì grande amore.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Oh queste non sono cose da dimandare, se già tu non l'avessi per pazza! E perché credi tu che ella mi porti cotanto amore?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Per la vostra virtù.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Tu l'hai detto; con questo mezzo cerca d'immortalarsi, perciocché questo, ch'io ti vo' far sentìre, è il quingentesimo sonetto ch'i' ho fatto in sua lode. Non v'è mai giunto il Petrarca, ve'. E che sonetti! <foreign xml:lang="lat">Dij boni</foreign>, tutti hanno la coda; senza la quale non è sonetto che vaglia.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>E che sorte di bestie son eglino?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Come bestie? Ah ah ah. <quote xml:lang="lat">Dij immortales! Homini homo quid praestat? Stulto intelligens quid interest?</quote> Un sonetto chiami una bestia. Ah, ah.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Non dite voi ch'hanno la coda? La coda è delle bestie, se non son bestia io. (O tu più tosto).</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>La coda <foreign xml:lang="lat">metaphorice</foreign>. Ah, ah, ah, tu non intendi questi misteri, Grillo. Quando io dico la coda, io dico perfezione, acciocché tu sappi.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>E come? Insegnatemi un poco.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Ora ascoltami, e sì l'intenderai. Ma queste sono bene lezioni che vagliono talenti, sai? La coda non è ella l'ultima parte dell'animale?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Mi par di sì.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>L'ultima parte, non è ella il fine di tutte le cose?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Così credo che sia.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Il fine non è egli la perfezione?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Bene; e che volete inferire?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>O ingegno obtuso, stolido e inerudito. Non senti dunque la forza dell'argomento?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Che vuol dir argomento?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Ah ah ah. Tu se' pur tondo. Dico che tu raziocini: se la coda è l'ultima parte, l'ultima il fine, e 'l fine la perfezione, <foreign xml:lang="lat">ergo</foreign>?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p><foreign xml:lang="lat">ergo</foreign> siate voi; che vuol dir <foreign xml:lang="lat">ergo</foreign>?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Ah, ah, ah. Concludi, stupidaccio, dal primo all'ultimo, su.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Oh questa sarà da ridere, che costui mi voglia far saper oggi quel ch'io non so, né vorrei sapere, ch'è un'altra cosa. Che volete ch'io concluda?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Che la coda è perfezione.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>E io, arzigogolando dall'ultimo al primo, tanto ne so ora quanto ne sapeva testé.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Or passiamo a più sottili meditazioni.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Èccene ancora?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>La Gostanza (oh nome aureo), la Gostanza è virtù, la virtù è perfezione, dunque la Gostanza è perfezione: intendi ora il misterio?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Comincio a intenderla. Ma udite voi ancora le mie ragioni. Se la coda è perfezione e Gostanza parimenti perfezione, dunque Gostanza sarà una coda. E così la vostra diva avrà guadagnato, da cotesta vostra coduta poesia, grandemente. Ah ah ah.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Hui, hui, sofistico, elenchico, pecca in materia e in forma.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Non so il più bel matto di voi, io. Che vuol dir matto? O non mi dite villania, messer Zenobio. Come, ch'io pecco in materia? Non fui mai né matto, né poeta.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Ah ah ah. Non t'ho detto villania, no. Hai ben tu bestemmiato, a chiamar coda quella lucida stella.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Anzi holla onorata. Quante stelle vi sono in cielo codute, assai più belle dell'altre?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Or ti vo' dir il sonetto, e poi andarmene verso la casa della mia bella Gostanza.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Che volete voi fare, a dir a me, che sono ignorante, le vostre dotte composizioni?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Hai ben appresso il dottore. Ascolta pure, che non sentisti mai meglio.</p>
             <lg>
@@ -803,23 +861,23 @@
             </lg>
             <p>Che te ne pare?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Che mi pare, eh? Stupendissimo!</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Un'aItra volta, Grillo, ascolta.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>No, per l'amor di Dio, che passerebbe l'ora di veder Gostanza.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Tu di' vero. Addio.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Ti raccomando, messer Zenobio. Oh balordo! A impazzar daddovero non ti mancava altro che l'esser innamorato e poeta. Umori che non entrano in capo alcuno, donde prima non sia uscito tutto il cervello. Ma se non era Gostanza, m'avrebbe assediate l'orecchie a furia di frottole e di stampite. Or non è meglio che non perda qui il tempo e me ne vada in Palazzo, per veder di spiare se questo vecchio di Patrizio macchina qualche cosa contra di noi? Certo sì, ch'egli è meglio. Ma voglio per ogni buon rispetto, chiavar la porta, poiché Nica ha ella ancor la sua chiave.</p>
           </sp>
@@ -827,95 +885,95 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>PATRIZIO, PISTOFILO</stage>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Ventimila ducati? È un bel boccone, Pistofilo. Le sì fatte venture vengon di rado; e perciò, figliuolo mio, non è da perderci tempo, ché “tra la bocca e 'l pomo.”, tu sai ben il proverbio. Un sol punto ce la dà vinta. Come la giovane sia sposata, è mozzo il dire. E potrai ben vantarti d'esser un ricco sposo e invidiato da molti. Ti par così? Tu non parli.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Tacendo son sicuro di non dir cosa che v'abbia ad offendere, signor padre.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Anzi m'offendi tu non parlando. Ma senza che tu parli, credo d'averti inteso. Tu dubiti che le nozze, perché non vedi apparecchio di sorte alcuna, non passino a tuo modo. Non dubitar, no. Per istasera ci de' bastare d'averla in casa, e sposata. Faremo poi a suo tempo le nozze quanto vorrai più belle e più sontuose.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Quando avessi a parlare, di questo certo non parlerei.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Orsù sta cheto, ché ti darò da spendere; vuoi tu altro?</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Di ciò vi rendo ben molte grazie, ma altra cosa è pur quella che, quando avessi a dire, io direi.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>E che cosa può ella esser cotesta? Non credo già che tu pensassi a non ubbidirmi.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Se assolutamente mi comandate ch'io prenda moglie e stia cheto, io sarei temerario, se quel pensassi di fare che al filial rispetto non si conviene. Ma siccome vi son io stato sempre ubbidiente figliuolo, non potendovi voi dolere ch'io non abbia tenuta quella vita e quelle pratiche, e atteso a quegli esercizi che più vi sono piaciuti, così mi par d'aver meritato che quello, che non può farsi senza il mio consentimento, vi debbia piacere ancora che senza il mio contentamento seguir non debbia.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Che parlar è cotesto tuo, Pistofilo? Non sai tu che, essendo unico in casa nostra, bisogna che prendi moglie? E, dovendola prendere, quando ciò potresti tu fare in miglior punto di questo?</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Io non ricuso di prender moglie, ma non vorrei già prenderla così tosto, né sì per tempo perder la mia libertà. Sono ancor giovane, e posso aspettar ancora qualche anno.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Dice libertà! Dio m'aiuti. È dunque servitù il prennon ti parrebbe di perder la libertà, vendendola a colui che con un pezzo di pane ti compera per ischiavo, e parli ora di perderla, accompagnandoti con tal donna che, con ventimila ducati, te compera per signore? Povero a te! Non dire queste sciocchezze.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Quella si può lasciare, ma questa no.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>O Pistofilo, sì fatte servitù ti legassero pure spesso! Le ricche donne fanno le case ricche. Ho io veduto di quelli che furno già poveri fantaccini, e per le grandi eredità delle mogli son oggi conti e marchesi, sai? Lasciati, lasciati governare, e disponti a far a mio senno.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Sallo Dio ch'io vorrei poter farlo per ubbidirvi. Ma come quel che sperava di goder libero questo fiore della mia giovanezza, almeno per due o tre anni, duro fatica. E se grazia veruna posso impetrar da voi, io vi supplico a non legarmi sì tosto, ché altro alfine io non vi chieggio che tempo.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>E a te pare di chieder poco, eh? E come te 'l poss'io dare cotesto tempo, s'io non l'ho? Fammi sicuro tu del partito, ch'io ti farò contento del tempo. Due anni, eh? Non così tosto sarà scoperta la lepre, che mille cani le saranno alla coda; che, a dirne il vero, è troppo bello il boccone. Guardici Dio dal provarlo.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Alle nostre facoltà non mancheranno mai donne, e se non tanto ricche, almeno più sane.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Oh oh! Queste sono parole di quella femmina maladetta, la quale ha preso amore a sì ricca facoltà che maneggia, e va essa così spargendo queste menzogne. Dio sa s'ella ha male di sorte alcuna.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Come male? È idropica marcia, che così ne corre la voce.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Eh che sono tutti d'accordo. E poi quand'ella non fosse così ben sana (che quanto a quella idropica, me ne rido), perché l'avresti tu a rifiutare? O ella guarrà, o no, Pistofilo. Se guarrà, l'avrai sana, e goderaitela bella e ricca. E siccome se fosse sana e dopo che entrata ci fosse in casa cadesse inferma, sarebbe inumana cosa l'abbandonarla; così, avanti che tu la prenda, il rifiutarla, perché ella non sia sana, non è buona ragione. La faremo guarire, piacendo a Dio. Anzi la guarrai tu, ché, alfine, le fanciulle da marito non hanno mai altro male che 'l non aver marito. Ma s'ella guarrà, dimmi un poco, figliuolo mio, non guadagni tu in una notte diecimila ducati almeno? Per tre scudi un soldato va baldanzoso a farsi ammazzare; e tu, per tanti mila ducati, non potrai sofferir una mala notte, eh?</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>(Una notte che basta sola farmi morire. Che maladetto sia quel dì che la carogna ci capitò).</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Che parli tu da te stesso, che di' tu?</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Dico che alla fine le male notti saran le mie. Chi non ha a fare, ha bel dire.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>O Pistofilo, io t'ho parlato infin a qui da fratello, ti parlo ora da padre. Disposto o non disposto che tu sii, hai a prender moglie stasera, e quella donna che in casa ti condurrò: tu m'hai inteso. Va, e pensaci bene, e guardati dal malanno. (<stage>Pist. parte</stage>). Or va tu, e fa bene a chi no 'l conosce. Ma costui certo ha altra paglia in becco. Questa sua così insolita resistenza (ché suole intendermi a cenno) non può venire da buona cosa. Hollo anco veduto questi dì tutto astratto, tutto pensoso. Poveri padri! Se tu li tieni a freno, padre duro! padre inumano! Se gli lasci far a lor modo, traboccano in mille errori. Se fai loro mal viso, t'odiano; se buono, insolentiscono. Se non dai loro da spendere, tu sei avaro; se ne dai, sei cagione di mille loro sciagurataggini, di mille loro pericoli; e finalmente puo' far, se sai: ti vorrebbero veder morto. Colpa della corrotta usanza! Così oggi, per tutto, la pubblica educazione vien trascurata. Che giova egli a' poveri padri l'allevar con buoni costumi i figliuoli, se essi poi per le piazze e ne' trebbi trovano istromenti e compagni scandalosissimi d'ogni male e d'ogni licenza? E quanto più sono scapestrati, trovano tanto più chi dà lor, contra il padre, mille ragioni. Dio voglia che 'l mio non balli a cotesto suono. Ma per quello ch'io vo vedendo, son a mal termine di far nozze: costui non vuole, colei non vuole, faremo tosto. Con tutto questo io non mi perdo d'animo, no: con l'uno darò di mano all'autorità e con l'altra alla giustizia, se questa carta non mi vien meno. Voglio andar in Palazzo.</p>
           </sp>
@@ -923,79 +981,79 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>LURCO, NOTAIO</stage>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Che Pistofilo? Sfacciatella, al tuo marcio dispetto ti condurrò. E perché più gli doglia, domattina ti vo' condurre; ve', se lo stimo. Parti egli che s'ingalluzzi costei, con cotesto suo Ganimede; poi che gli ha pieno il capo di vento, non ci si può più vivere. Ma se ha fatto te insolente, me non farà già egli beccone. E se ei si crede di passar per bel giovane, s'avvedrà che si può meglio volar senz'ali che far l'amore senza denari. L'amore è come il campo, che non rende a chi non gli dà. Guardate un poco, messer Onofrio, a che termine son condotto per una femmina, con la qual maritandomi credetti d'uscire di po- vertà, e son entrato per essa poco men che in miseria: poiché altro non ho di suo che costei da farci le spese.</p>
           </sp>
-          <sp>
+          <sp who="#notaio">
             <speaker>NOTAIO.</speaker>
             <p>E come ti lasciasti tu consigliare? So io pure che solevi esser delle femmine così vago com'è il cane delle mazzate.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Che so io? Maestro Bertaccio sarto, marito di Maddalena... No 'l conosceste voi?</p>
           </sp>
-          <sp>
+          <sp who="#notaio">
             <speaker>NOTAIO.</speaker>
             <p>Come, s'io 'l conobbi? Aveva la sua bottega in Rialto, presso all'orafo della Vecchia.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Quegli era desso. E fu, vivendo, mio grande amico, usando del continuo insieme, egli nella mia casa (quando io stava a Vinegia) e io nella sua. Ond'egli avvenne che, dopo la sua morte, la buona Maddalena cominciò a domesticarsi con esso meco di sorte che, per dirla in poche parole, non passò un mese che fummo marito e moglie, facendo così mio conto: costei ha di molti anni e di molta ciarpa, avrò le spese mentre che vive e, dopo morte, l'eredità. E certo l'un disegno mi riuscì, ma l'altro no: perciocché ella morì ben tosto e, invece di farmi erede, fece quel testamento, anzi pur quell'imbroglio che voi sapete. E 'n tanto non ho nulla, e mi muoio di fame e stento come un bell'asino.</p>
           </sp>
-          <sp>
+          <sp who="#notaio">
             <speaker>NOTAIO.</speaker>
             <p>Secondo me, Lurco, non farai nulla. Tu hai sentito il buon uffizio che ho fatto per te, e com'ella per tutto ciò non si smove; e si risolve di voler anzi morire che andar in altre mani che di Pistofilo.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>O messer Onofrio, che non mi date voi quelle robe? Niun se ne serve, e si potrebbono ben guastare anzi che no.</p>
           </sp>
-          <sp>
+          <sp who="#notaio">
             <speaker>NOTAIO.</speaker>
             <p>E come, se lo 'nventario loro è registrato nel testamento?</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>A questo voi, che siete il maestro della scrittura, agevolmente provvederete.</p>
           </sp>
-          <sp>
+          <sp who="#notaio">
             <speaker>NOTAIO.</speaker>
             <p>Io ti dico che non si può. Non sai tu ch'elle furono depositate in mia mano, con obbligo di restituirle a Gostanza?</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Basterebbe che costei fosse stata la dogaressa! Ma quello, che non ho potuto aver dalla madre, m'ingegnerò ben io di trarre dalla figliuola.</p>
           </sp>
-          <sp>
+          <sp who="#notaio">
             <speaker>NOTAIO.</speaker>
             <p>E come farai tu? A me pare che tu ci sii male in acconcio finora.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Costei è innamorata di Pistofilo che mena smanie, sperando ch'egli l'abbia a sposare; e forse che 'l disegno le potrebbe riuscire. E perché Patrizio suo padre gli vorrebbe oggi dar moglie, bisogna batter il ferro mentr'egli è caldo: ché se le nozze seguissero, gnaffe, i dugento ducati, che m'ha promesso Pistofilo, e le robe dello inventario, che costei mi promette, sempre che ella sia di Pistofilo, andrebbono a babbo riveggoli. E a fine che oggi possa fargli a sapere che domattina la può condurre a Vinegia, ho lasciata aperta la camera che risponde qui su la strada, acciocché, trovandosi ella commodità di parlargli, faccia, senza avvedersene, la innamorata per lei e la ruffiana per me.</p>
           </sp>
-          <sp>
+          <sp who="#notaio">
             <speaker>NOTAIO.</speaker>
             <p>Tu se' tristo daddovero, ma troppo ingordo. Questo è rubare, acciocché tu sappi.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>O messer Onofrio, che dite voi? Forse non sapete che ora pochi di rubar si fanno coscienza? Non vedete voi che ognun ruba? Né altra differenza è da ladro a ladro, se non che d'alcuni si tien ragione, e d'alcuni no. E dove la roba di malo acquisto ti solea mandar su le forche, ora te ne difende. Perché credete voi che i furfanti s'impicchino? Per rubare? Messer no: s'impiccano perché non sanno né rubar, né nascondere. Ma quei che rubano alla grande sono onorati e rispettati. E che pensate voi che sia il ladroneccio? Un qualche poveraccio, pidocchioso, mendico? Messer no, vedete: gli è un gran signore; perché sappiate: né va oggi attorno persona né me' veduta, né più stimata di lui. E benché muti nome, non muta vezzo. In ogni luogo è furto, ma in ogni luogo non ha il suo nome. E che be' titoli ha! Che be' visi!. Che belle maschere! Insomma, governa il mondo. Né si può viver senza rubare, perché non si può fare di non esser rubato.</p>
           </sp>
-          <sp>
+          <sp who="#notaio">
             <speaker>NOTAIO.</speaker>
             <p>Lurco, non vuò contender teco, ché ne sai troppo. Se altro posso per te, comandami; e poiché Gostanza è nel diciottesimo anno, ad ogni suo piacere aprirò il testamento. Ma fa ch'io abbia la fede del nascimento, senza la quale non posso aprirlo, sai?</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Io so d'averla in serbo autentica come va; andrò per essa, e bisognando, sarò con voi.</p>
           </sp>
-          <sp>
+          <sp who="#notaio">
             <speaker>NOTAIO.</speaker>
             <p>Addio, Lurco.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Addio, messer Onofrio.</p>
           </sp>
@@ -1003,59 +1061,59 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>ANTONIO padovano, FLAVIO sotto nome di Ortensio medico</stage>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO.</speaker>
             <p>Più di quello che avete inteso non vi so dir, messer Flavio. E questo ancora ho io raccolto da più persone, secondo che si va ragionando. Quella che colà voi vedete, è la casa ove abitava la raugea, la quale, come v'ho detto, è morta un mese fa. Ho io a far altra cosa per voi? Messer Panfilo, mio compare, mi ha la vostra persona in modo raccomandata, ch'io son tenuto a farvi ogni servigio per me possibile.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Messer Antonio, voi m'avete ben tanto d'amorevolezza mostrato in quelle poche ore che sono stato con esso voi, che, dove i fatti parlano, le parole stimo soverchie: se altro mi bisognerà, mi vedrete. Pregovi sopra tutto a tenermi segreto.</p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO.</speaker>
             <p>Non dubitate. Ma vi voglio ben avvertire che buona cura v'abbiate. Cotesto vostro andar così travestito non è la più sicura cosa del mondo. Voi siete giovane, forestiero, solo, mal pratico della terra, e potreste ben dare ne' mali spiriti, anzi che no. Né vo' già io sapere quali sieno in quella casa i vostri interessi; ma ben vi dico che, essendo quella giovane maritata e dovendo esser istasera, siccome avete inteso, in casa di messer Patrizio degli Orsi, suo suocero, vi guardiate di non dar ombra a tale che potesse farvi poco piacere. Messer Patrizio è de' primi e più riputati della nostra città: ha di molte ricchezze e di molto seguito. Governatevi saviamente; e perdonatemi, se troppo libero vi paressi, ché tutto ho detto per vostro bene.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Come, ch'io vi perdoni? Anzi da ciò conosco che voi mi amate e che dite il vero. Ma giunsi, come sapete, iersera a notte; e quando che io ci fussi il più conosciuto uomo del mondo, bastava il buio a nascondermi. Stamane, poi, sono uscito con questi panni, i quali ho presi per alcuni rispetti che voi saprete, né per più d'oggi m'hanno a servire. Ma che dite, per vita vostra? Come vi paio ben travisato?</p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO.</speaker>
             <p>Eccellentemente; non è uomo che vi stimasse quel che voi siete. Parete proprio un medico. E quegli occhiali non potrebbon calzar meglio. Orsù vo io.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Andate in nome di Dio.</p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO.</speaker>
             <p>Arrivederci a ora di desinare.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>No, ascoltate messer Antonio, s'io non venissi, non m'aspettate.</p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO.</speaker>
             <p>Venite o non venite, siete padrone.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Udite: come ha nome colui che sta in casa la raugea?</p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO.</speaker>
             <p>Grillo, volete dire.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Sì, m'era uscito della memoria. Di grazia, ricordatevi di trattenerlo più che potete, acciocché torni quanto più sia possibile tardi a casa, intendete?</p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO.</speaker>
             <p>Tanto farò (<stage>parte</stage>).</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Oh sventurato e misero Flavio! Dunque per tanto mare, per tanti monti, per sì lungo cammino, non sarai giunto qui a far altro che a vederti privare sì subito di colei che speravi d'avere sì subito nelle braccia? Maraviglia, o traditora Fortuna! che 'l mare e 'l vento m'agevolasti, perch'io giungessi più tosto a morte. O Cassandra (non dirò più mia, se oggi sarai d'altrui), ètti dunque uscito del cuor quel Flavio del quale hai nelle viscere tanta parte? Patirai tu d'abbandonar il tuo Flavio, di tradir il tuo onore, di scoprire le tue vergogne? E tu, qualunque sei, uomo avaro che la solleciti, potrà tanto in te l'oro, che di dare al figliuolo non ti vergogni donna gravida per isposa? Ma che farò? S'io mi discuopro, costoro m'ammazzeranno; e son ridotto a tale che non ho pur sicuro il discoprirmi né anche a lei. La quale, per avventura, sarà d'accordo co 'l suocero, amando meglio d'avere marito nobile e ricco che servar fede a povero amante. So io che della morte di madonna Ginevra, né della ricca eredità, non m'ha avvisato né scritto mai. La cosa è intesa. Non ti voleva qui, Flavio. Oh misero! Ah Cassandra, saresti tu mai sì cruda che, quando per amante e per marito mi rifiutassi, volessi come nemico perseguitarmi? Non credo mai. E molto meno ancora vo' credere che s'abbian oggi a far quelle nozze che non possono già seguire senza tua infamia. Non vo' perder più tempo. Cosa fatta capo ha. Sol ch'io ne parli, mi chiarirò. Vo' bussare.</p>
           </sp>
@@ -1063,147 +1121,147 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>LISCA fantesca, FLAVIO</stage>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>Chi bussa?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Il medico.</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>Oh guata ceffo di barbagianni! Chi bussa? dico.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Il medico, il medico.</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>Come, il medico? Che novità è questa? Chi vi manda, messere?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Oh mal aggia cotesto nome sì fastidioso. Me l'ho pur anche scordato.</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>Che tresca è questa! Su, chi vi manda? Rispondete, o ch'io vi pianto.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Quell'uomo qui di casa. (Sia maledetto...).</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>Qual uomo? (Deve farneticare).</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Quell'animaletto che sta ne' buchi.</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>Mancano gli animali che stan ne' buchi! Certo costui è pazzo. Siete voi medico, o l'andate cercando? Che, per quanto mi pare, il vostro cervello n'ha gran bisogno.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Grillo, in nome di Dio; l'ho pur trovato.</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>E Grillo chiamate animaletto? So ben io s'egli è grande e grosso, che ogni dì l'ho per mano e governolo. E Grillo v'ha mandato?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Dico di sì.</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>(Costui certo non dice il vero; e giurerei ch'egli fosse una spia di quel pessimo vecchio nostro vicino).</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Eh di grazia, bella giovane, apritemi, ch'egli m'ha mandato a visitar l'ammalata.</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>Qual ammalata?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>L'idropica, non sapete?</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>Non c'è niuna in casa che abbia cotesto nome, no certo.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>E non c'è niuna malata?</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>Niuna, se non io.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Voi non ne avete già viso. E che male è 'l vostro? D'amore, bella figliuola?</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>Forse che sì.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Son ben uomo per guarir voi ancora, sì.</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>Con quel mostaccio eh? Sarete voi mai uno di quei ceretani che vendono le ricette?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Sì, un di quegli (Ho dato in buono! Costei è bergola, m'aprirà).</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>(Oh se venisse Grillo! Vo' trattenerlo). Quanta voglia avev'io di abbattermi in un vostro pari! Ve', come il destro me n'è venuto.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Perché? Avete voi qualche male? Non guardate a questo mostaccio; ché quando verremo a' fatti, vi chiamerete di me contenta. Se avete piaga, pizzicore, ho ricette mirabili. S'avete mal di madre.</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>Questo appunto è il mio male; ché 'l medico me l'ha detto.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Ho una radice in tasca che subito vi guarrà. Apritemi dunque, e non mi fate più star qui fuori.</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>S'io 'l credessi, affè che v'aprirei. Fate, per vita vostra, ch'io la possa vedere. Mostratela, e sì vi crederò.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Ma non la posso mostrar in strada. Apritemi, se vi piace, graziosa giovane, ché non ho tempo da perder, io. V'avrei già fatto il servigio, e sareste bella e guarita, sì certo.</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>Ma io non mi diletto di far le mie faccende sì in fretta, sapete, caro vecchietto.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Per quel ch'io veggo, non avete quel male; perciocché subito m'aprireste.</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>Ben sapete ch'io non l'ho sempre; ma quando egli mi viene, è tanto furioso ch'arrabbio. (Ma ecco Grillo, oh come a tempo!).</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>La mia radice è sì vigorosa, che immantinente vi sanerà.</p>
           </sp>
@@ -1211,75 +1269,75 @@
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>GRILLO, LISCA, FLAVIO</stage>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>(Poiché Lisca m'accenna...).</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>Io son contenta, vi voglio aprire.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>(... starò un poco a vedere che tresca è questa).</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>Accostatevi all'uscio, che tirerò la fune del saliscendi; intendete?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>O siate voi benedetta! Eccomi, aprite.</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>O, rispignete la porta.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Rispingola, ma non giova.</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>Ve' pecora ch'io sono, ve'! La porta è chiusa a chiave; e m'era uscito di mente che dianzi Grillo mi chiavò in casa.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Oh sgraziato! Come faremo?</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>Andrò per quella della mazza e gitterollavi, acciocché voi medesimo dischiaviate la porta, intendete?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Sì, fate presto.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>(Or'io comincio a intenderla, per mia fè).</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Son a cavallo.</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>Eccola, sere. Ma guardate che non vi percotesse. Accostatevi più alla porta e getterolla in mezzo la strada.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Sto ben così?</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>Non potreste star meglio; e io la scaglio più lontano che posso. Prendi Grillo, bastonalo, ch'egli è una spia, dàlli, dàlli.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Oh, io ci sono prima di te, manigoldo. Or prendi questa, e questa...</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>Ah, ah, ah, so ch'egli mena le gambe, io, e non par vecchio a fuggire; e Grillo il seguita d'una santa ragione. Oh come è calzata bene! Possa fiaccarsi il collo, con quante spie si trovano al mondo, canaglie maladette da Dio...</p>
           </sp>
@@ -1290,207 +1348,207 @@
         <div type="scene">
           <head>SCENA PRIMA</head>
           <stage>GRILLO, NICA</stage>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Non ho potuto bastonarlo a mio senno, il manigoldo: perché prima e' menava le gambe non mica da vecchio, no, e poi vi traevan le genti poco meno che accorr'uomo. E son restato di più seguirlo.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Ve' maladetto vecchio ch'è quello! Aveva egli mandato certo quel soppiattone. Buona fu che ti ci trovassi tu.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>E sappiate che a caso mi ci trovai. Perciocché io, non guari dopo la partita vostra, deliberai di seguirvi per aiutarvi se fosse stato bisogno. E di primo colpo mi condussi in Palazzo; e colà non trovandovi, andai a casa il dottore, là dove intesi ch'eravate partita; ond'io, credendo di trovarvi qui, diedi volta per la cagione che 'ntenderete. Avendoci poi trovato quello spione, ho fatto quello che avete inteso. E nel tornare di nuovo a casa, credendo pure di ritrovarvici, v'ho incontrata.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Io ti dirò. Partita dal dottore, andai alla messa, e per questo non m'hai trovata.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Ma parliamo di quello che importa più. Ch'avete voi fatto? Nulla, eh?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Tu 'l dicesti. Quand'io giunsi a casa il dottore, trovailo con la camera piena di molta gente; e tutti ad uno ad uno volle spedire, prima che, non che altro, pur un po' mi guatasse. Quando poi volli cominciar a parlargli, appena che gli paresse d'avermi mai conosciuta. Né altro della bocca potei mai trargli, se non: “Copia e tempo, madonna; copia e tempo”. Pensa tu s'abbiam tempo.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>E altro non vi ha risposto?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Io ti dico di no. Si parlava tra denti, che pareva insensato. Alla fin fine vedendo io che non c'era tempo da perdere, il pregava perché meco ne venisse dal Podestà. Sì, sì, mi rispose ch'egli aveva a fare un consulto, mostrandomi i danari che pur allora gli erano stati dati.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>La cosa è intesa.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Talché vedendo io la sua villania, mi ridussi, non potendo far altro, a ripregarlo che quanto prima si contentasse d'andarci.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Impetrastelo voi?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Appena; dicendomi ch'io gliene dessi un memoriale.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Ben, ben. Desteglie 'l voi?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Per buona sorte Cecchino si trovò quivi, e sì me 'l fece.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>E poi, che vi diss'egli? Che faceva intanto?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Mentre Cecchino questo faceva, andava egli per mano ravogliendosi que' danari, che testé ti diceva.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Nota quella! E quando il memoriale fu fatto?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Appena gliel'ebbi porto che cominciò a fare il viso dell'arme.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>E che dicea?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Che altro ci bisognava.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Ma, troppo era vero.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>All'ultimo mi promise d'andarci.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>E' non ci andrà. Ditemi un poco, non gli avete portati i danari, eh?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Come danari? Hanne egli dato a me, quando l'ho servito?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Eh, monna Nica, non conoscete i dottori: questo è il loro mestiero; e' non vivono d'altro. Certo voi non gli avete dato il buon memoriale.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Qual è cotesto, il danaro?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Questo appunto. I dottori, acciocché voi sappiate, non han memoria.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Son dottori, e non han memoria?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Non l'hanno, madonna no. E quando son loro portati i processi e le scritture, di quelle sol si ricordano che hanno seco il memoriale: tutte l'altre, che sono senza, vanno in dimenticanza; dove la vostra capiterà, se Dio non l'aita. Per questo solo parlava in croce: per questo maneggiava i danari. Questi erano tutti segni della memoria smarrita.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Sarà dunque ben fatto ch'io gliene porti; e quanti, Grillo?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Niente men di due scudi: uno perché vi serva, l'altro perché non v'assassini.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>E' potrà esser che gli tolga?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Come, che gli tolga? Tanti gliene portaste!</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Insomma questo è un male comune a tutti: dove va il danaio, amico fatti con Dio.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Io vi lascio pensare com'egli averebbe trattato me, avendo sì gentilmente spacciata voi.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>E chi mai l'avrebbe creduto? Non ti ricordi tu, Grillo, com'egli, al tempo della padrona, mi lusingava, m'accarezzava? Le proferte grandi che mi faceva?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Eh monna Nica, le carezze fatte per interesse son come l'ombre, che vengon co 'l corpo loro e co 'l corpo loro partono ancora. Mentre era viva madonna, avea bisogno di voi, perché madonna avea bisogno di lui; e per questo vi careggiava. Morta madonna, messere non vi conosce.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Ingrataccio! I' gli ho fatti più servigi! Dio 'l sa bene. Orsù parliam d'altro. Ma tu, che hai fatto, Grillo, per la tua parte?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Meglio di voi, che ho trattato nell'andar a Palazzo, come v'ho detto, con più cortesi persone; dalle quali sono stato avvertito che non ci fidiam del Vicario, perché Patrizio lo presentò l'altrieri.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Sì, eh? Sai tu 'l presente?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Madonna sì. Il presente fu di bellissime frutta.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Ma se per frutta può guadagnarsi, presenteremolo noi ancora di que' nostri sì belli e sì saporiti fichi, sai, Grillo?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Tutto che i nostri fichi siano assai vizzi, nondimeno se gli saran portati in una bella coppa d'argento e lasciati i fichi e la coppa, siccome ha fatto messer Patrizio, potrebbe essere che il disegno vi riuscisse.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Ed egli se l'ha tolta, eh?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Ah, ah, ah. Se l'ha tolta, dice: poco fu; e torranne da voi ancora, se gliene porterete, vi so dir io.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>E s'io fossi sì pazza, come potrebb'egli sodisfare all'uno e all'altra?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>All'un co' fatti, all'altra con le parole; e queste toccherebbono a voi. Sono anche stato avvertito ch'egli ha pensato di venirci a far un sopruso: ond'io mi sono avacciato di tornarmene a casa: che s'ei ci viene...</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>E che disegno credi tu che sia quel di Patrizio?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Che so io? Farci paura come a' bambini. Ma eccol ve', ritirianci. Stiamo un poco a vedere quel ch'e' vuol fare.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Oh Dio ci aiuti! Grillo, vo' entrar in casa; resta tu fuori.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Non abbiate paura, no.</p>
           </sp>
@@ -1498,151 +1556,151 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>PATRIZIO, CAVALIERO del Podestà, NICA, TRAGUALCIA birro, GRILLO</stage>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Monna Nica, non vi partite, ché ho bisogno di voi.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Chi è colui che mi chiama?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Son io. Ascoltatemi, se vi piace.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Per l'amor di Dio, messer Patrizio, badate a' fatti vostri, e lasciatemi vivere. Dovreste pur sapere, oggimai, che seminate in arena.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Non vi turbate, madonna, e statemi ad udire, vi prego, ché le parole non sono mica saette.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Ascoltatelo, monna Nica, né dubitate, ch'io non ci sono per nulla, no.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Purché di Cassandra non mi parliate, dite pur quel che vi piace.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Anzi, d'altro non intendo di parlarvi.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Non andate più innanzi, ché v'intend'io troppo bene; e vi dico che non siete mai per averla. E vel dissi iersera pur tanto chiaro, che vi potrebbe bastar per sempre.</p>
           </sp>
-          <sp>
+          <sp who="#cavalier">
             <speaker>CAVALIERO.</speaker>
             <p>Madonna, avvertite bene che pentire alla fine voi vi potreste di cotesto vostro cervel caparbio; e farete gran bene, credete a me, concedendo quel per amore che per forza poi dare, vostro malgrado, vi converrà. Hòvvelo detto.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Dalle cose, che altri fa con ragione, pentimento non può seguire. Messer Bernardo, suo padre, mi dié Cassandra, e messer Bernardo solo può anche torlami: m'intendete? E sebben'io son donna, non vi pensate d'aggirarmi il cervello con un pezzo di carta; ché, alla croce di Dio, sarete gli aggirati pur voi.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Se messer Bernardo suo padre avesse potuto condursi a Padova, non avrei bisogno di questa carta per ottenere la sua figliuola; ma perciocché egli si trova ora nel maestrato, ha voluto supplire, con mezzo tale, a quello che mandar ad effetto non può egli con la presenza. Non sapete voi meglio di me gli ordini di Raugia, che non permettono a' rettori della città di partirsi dal territorio, mentre dura il carico loro? Ma che differenza fate voi della persona del detto messer Bernardo e questa scrittura sua, nella quale ha egli il suo volere sì efficacemente, e con termini sì legittimi e sì valevoli, dichiarato?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Che differenza? Voi mi fate ben ridere, mi fate. Quella medesima ch'è tra le cose vere e le false. E s'a voi pare che sia 'l medesimo, servitevi di tal mezzo, ch'io son molto contenta che voi abbiate Cassandra, immaginando d'averla: e, se vi aggrada, darovvene anche molto volentieri un ritratto; vedete s'io son cortese. Ma troppo son io pazza a star qui cicalando fuor di proposito.</p>
           </sp>
-          <sp>
+          <sp who="#cavalier">
             <speaker>CAVALIERO.</speaker>
             <p>Madonna, per quel ch'io veggio, bisogna mutar registro co 'l fatto vostro: conoscetemi voi?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Lasciate parlar a me, monna Nica. E quando ella t'avrà conosciuto, che sarà poi?</p>
           </sp>
-          <sp>
+          <sp who="#cavalier">
             <speaker>CAVALIERO.</speaker>
             <p>O, o, o, tu se' bravo, tu se'. Ho ben anche de' pari tuoi gastigati, sì. Ma per ora non parlo teco.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Quando parli con questa donna, tu parli meco; e son bravo per certo, e se tu non...</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Sai tu quel che tu vai cercando? D'andar in prigione, sì, per mia fè. Tu non conosci costui, eh? Egli è 'l Cavalier del signor Podestà; e se tu 'l vai stuzzicando, tanto te n'avverrà!</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Perdonatemi, signor Cavaliere, ch'io non vi aveva conosciuto; né mi sarebbe nell'animo mai capito che sergente alcuno della Giustizia fosse intervenuto a quest'atto.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>E perché?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Come perché?</p>
           </sp>
-          <sp>
+          <sp who="#cavalier">
             <speaker>CAVALIERO.</speaker>
             <p>Orsù, non accade qui far commenti. Madonna, non siete voi quella Nica che ha in governo la figliuola di messer Bernardo Càttari, nobile raugeo, che ha nome Cassandra?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Sì, sono.</p>
           </sp>
-          <sp>
+          <sp who="#cavalier">
             <speaker>CAVALIERO.</speaker>
             <p>Io, che son Mazzasette, Cavaliero del Podestà, vi fo commessione e precetto, in nome di Sua illustrissima Signoria, che per tutt'oggi debbiate aver consignata nelle mani del signor Patrizio degli Orsi, che è qui presente, la detta giovane, destinata dal padre per legittima sposa del suo figliuolo, come più ampiamente nel mandato di lui si vede: sotto pena di star due anni in prigione e d'altre pene arbitrarie, secondo che la Giustizia richiederà. E se voi pretendete cosa in contrario, comparite alle diciotto ore davanti al signor Vicario, ché vi sarà fatta giustizia.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Buona pezza!</p>
           </sp>
-          <sp>
+          <sp who="#cavalier">
             <speaker>CAVALIERO.</speaker>
             <p>Ordina ancora che questo uffiziale per tutt'oggi non parta di casa vostra. Fatti innanzi, Tragualcia.</p>
           </sp>
-          <sp>
+          <sp who="#tragualcia">
             <speaker>TRAGUALCIA.</speaker>
             <p>Che comandate?</p>
           </sp>
-          <sp>
+          <sp who="#cavalier">
             <speaker>CAVALIERO.</speaker>
             <p>Entra in cotesta casa; e non andar di sopra a sturbare li fatti loro, ma, standoti sotto il portico, guarda bene di non lasciar entrar né uscir persona alcuna. Hai tu inteso?</p>
           </sp>
-          <sp>
+          <sp who="#tragualcia">
             <speaker>TRAGUALCIA.</speaker>
             <p>Signor sì, sarà fatto.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Fermati un poco. Dunque non volete che noi possiamo andare innanzi e 'n dietro pe' fatti nostri? Questa sarebbe ben disonesta!</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Hai ragione, e mi contento che tu e monna Nica soli possiate entrare e uscire a vostro piacere; ma altri, no. E, sopra tutto, avvertici di non lasciar portare fuori di casa roba di sorte alcuna; intendi tu?</p>
           </sp>
-          <sp>
+          <sp who="#tragualcia">
             <speaker>TRAGUALCIA.</speaker>
             <p>Intendo; e tanto farò.</p>
           </sp>
-          <sp>
+          <sp who="#cavalier">
             <speaker>CAVALIERO.</speaker>
             <p>E tanto eseguirete, guardandovi dalla mala ventura. Andiamo, signor Patrizio.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Avete fatti i vostri colpi, e noi faremo i nostri. Ci sarà ben giustizia per noi ancora, sì bene.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>S'io credessi affogarla, tu non l'avrai, vecchio manigoldo.</p>
           </sp>
-          <sp>
+          <sp who="#tragualcia">
             <speaker>TRAGUALCIA.</speaker>
             <p>Or entriamo, su; che si bada?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>O, o, tu hai la gran fretta. Eccoti l'uscio aperto, ma non di sopra, ve', se non vuoi ch'io ti suoni una danza; e sai se n'ho pizzicore? Non chiuder quella porta, e aspetta, ché ora vengo.</p>
           </sp>
@@ -1650,39 +1708,39 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>NICA, GRILLO</stage>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Grillo, noi siam perduti. Che faremo, meschina me! uh, uh, uh!</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Non piangete, non dubitate, ché, alla peggio peggio, ce n'andrem con Dio.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>E come, meschina a me, se noi abbiamo la guardia in casa?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Udite quello ch'io ho pensato. E' non bisogna ch'io mi allontani di qui, per cagion di costui. Prendete questi due scudi, e prima che l'ora venga più tarda, andate a casa il dottore, e quivi aspettatelo, ché, appressandosi l'ora del desinare, non può star a venire: dategli que' due scudi, e fate opera di condurlo con esso voi all'udienza del Vicario, che il nostro Scatolino ha da me ordine d'introdurvi, intendete?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Intendo; ma che debb'io dire al dottore?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Informatelo del precetto, e procurate ch'egli il faccia o revocare o sospendere, fin a tanto che si scriva a Raugia e venga la risposta del padre di Cassandra, non essendo il dovere ch'ella sia data altrui, se suo padre non è prima informato d'alcuni particolari troppo importanti. Insomma, faccia ogni opera per tirar la cosa in lungo più che si può: ché altro, finalmente, non ci bisogna. Poi chi ha tempo ha vita, e chi scampa d'un punto scampa di cento. Se ciò s'ottiene, siamo a cavallo. Scriveremo poi tanto male a messer Bernardo di cotesti padre e figliuolo, che, quando non ci facesse mai altro, s'avrà il beneficio, che noi cerchiamo, del tempo. Se non s'ottiene, ci condurremo subito, con quel meglio che noi abbiamo, al Portello; e quivi presa una barca, ce n'andremo a Vinegia, dove non mi manca luogo commodo e onorato da porre in serbo sicuramente Cassandra, finché a Dio piaccia di far maturo il suo parto, il quale, secondo che voi mi dite, non può esser molto lontano.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>O Grillo, questa fuga è un gran fatto. Ma per fuggir vergogna, si vuol far ogni cosa; purché si possa colorir il disegno. Ma io non so; tu di' che ce n'andremo, e non fai conto co 'l birro, tu.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Qualche cosa faremo pure. L'inebriaremo, l'ingollerem di danari, l'uccideremo, quando altro far non si possa. Ma non perdete più tempo, voi. Serberovvi alcuna cosa per desinare, o piuttosto per merenda.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Io vo. Tu va in casa, e guardati da colui. O Iddio lodato sia tu sempre, che mi mettesti in cuore di scoprir il mio segreto a costui; senza il quale che averei io potuto mai fare in tanti travagli?</p>
           </sp>
@@ -1690,7 +1748,7 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>PISTOFILO solo</stage>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>O questa sì, ch'è miseria da non poter sofferire: poiché se mille cuori avessi, a me certo non basterebbono, né per amar Gostanza, ch'è la mia vita, né per odiar quella carogna, ch'è la mia morte. E pur con un cuor solo mi convien sostenere l'immenso amore dell'una e l'insopportabil odio dell'altra. Che farai dunque, infelice? Oggi tu hai a perdere o la grazia del padre, o l'amor di Gostanza. La quale, come sia certa delle tue nozze, così subito o ti s'invola, o d'altrui ti vien involata. E tu potrai sofferirlo? Potrai tu vivere senza lei? Potrai vederla nell'altrui braccia? Io morrò prima. Oh perché non m'è lecito colla fuga provvedere al mio scampo? Ché dove ora il paterno sdegno mi sfida, la pietà forse m'affiderebbe; e forse coll'esiglio impedirei quelle nozze che d'altro modo impedire non avessi potuto. Ma son legato da troppo forte necessità, da troppo dolce catena. Abbandonare la mia Gostanza? Allontanarmi dalla mia vita? È per me cosa impossibile. Dovrei fuggire il padre adirato, il pericolo delle nozze, la casa di questa fracida; e pure sono tirato a forza in queste contrade, per veder, non che altro, le mura sole che chiudono il mio tesoro. Potessi almeno comperarlo col vivo sangue, poiché con altro mezzo non posso trarlo dalle mani di quel suo tanto iniquo e dispietato padrigno. Che partito prenderai dunque, misero, non giovandoti punto né il restar né il fuggire? Al male ch'è più vicino provvederò non consentendo alle nozze. Ma tuo padre ti sforzarà: no 'l farà certo. Tu non potrai resistere: sì, farò. Condurrà in casa la raugea: e conducala, allo sposarla ci parleremo. Senza me, certo far non si può. No 'l farò mai. Ma vo' provar mia ventura, s'io potessi veder l'anima mia.</p>
           </sp>
@@ -1698,135 +1756,135 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>MOSCHETTA, ANTONIO padovano</stage>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Solenni bestie per certo dovevano esser gli uomini di quel tempo, che si pascevano di ghiande e d'acqua. E ci sono oggi ancora delle canaglie che chiamano quella vita l'età dell'oro. L'età dell'orso, piuttosto la dire' io. Gente fallita o d'appetito o di borsa, così credono di coprir i difetti loro e le loro meschinità. Che ne dite, messer Antonio?</p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO.</speaker>
             <p>Nel fatto della buccolica, a Moschetta non si può contradire, ché ne sa troppo.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Ma che diremo noi di coloro che hanno il modo di mangiar sei volte il dì, non che quattro, e si riducono ad una sola? Oh vigliacchi se ciò fanno per avarizia, e sciocchi se lo fanno per sanità! Vedete se han cervello: per mangiar non si vive?</p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO.</speaker>
             <p>Certamente. Se altri non mangiasse, non viverebbe.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Or se 'l mangiar ci dà vita, quanto più si mangia, tanto più si vive.</p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO.</speaker>
             <p>A me par che tu abbi una gran ragione.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Come, s'io l'ho! Tanto avessi il modo di farla a questo non mai satollo mio ventre e sempre digiuno! Ché mi darebbe l'animo di vivere più di Matusalemme. Ascoltate, per vita vostra, messer Antonio. Capitò una volta a Vinegia uno che chiamavano Matomago.</p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO.</speaker>
             <p>Ah, ah, ah. Matematico, tu vuoi dire.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Credo di sì, io.</p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO.</speaker>
             <p>Un astrologo.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Strolago, sì. Buon dì! Un uom di conto. Non si può dir quant'era onorato. Io gli senti' pur dire la bella cosa. Non me l'ho mai scordata.</p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO.</speaker>
             <p>E che bella cosa fu ella?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Che si trovava un certo paese dove si mangia almeno trecento sessanta sei volte il dì. O Moschetta, se vi potessi mai giungere!</p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO.</speaker>
             <p>Ah, ah, ah. E' ti piantò una carota, Moschetta.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Sì, che non c'erano degli altri quando e' lo disse, e dottori e uomini riputati che l'affermavano? E non ridevano mica di lui, come ora voi fate di me. E poi faceva egli ben i suoi conti, e parlava co' libri in mano: se aveste sentito!</p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO.</speaker>
             <p>Ma dimmi tu, voragine delle mense: come puoi stare in casa messer Patrizio, che vive tanto assegnatamente?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Ma la gola, messer Antonio, è maestra di tutte l'arti. Cosa troppo ingegnosa! Guai a me se stassi a' suoi pasti! Quando ci venni, che non sono più di due mesi, egli mi deputò al servigio di Pistofilo, suo figliuolo, e però rade volte di me si serve. Testé mandommi alla villa, e io v'andai volentieri, perché ho fatto già parentela colla gastalda; intendete?</p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO.</speaker>
             <p>Come, se intendo?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Di Pistofilo poi son io padrone a bacchetta. Quanti danari ha, tutti son di Moschetta; ma il peggio è che ne ha pochi. A quanto in casa può dar di piglio, è mia rigaglia; e poi fuori di casa, mi vo ingegnando, messer Antonio.</p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO.</speaker>
             <p>E che servigi di cotanto merito gli fai tu? Che ufficio è il tuo?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Quello che nelle corti fa grandi gli uomini e favoriti: quello che si può dire l'oppressione de' buoni, il purgo de' benemeriti, il padron de' padroni. Io stava una volta con un gran cortigiano che 'l medesimo ufficio aveva, il qual era villano di schiatta e per avanti era stato staffiere, così bene com'era io; e per santa Nafissa, bisognava che tutti gli s'inchinassero. Insomma, egli è il re di tutti gli uffici.</p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO.</speaker>
             <p>Con assai meno di parole potevi dire: “io son ruffiano”. Ma io non so vedere come questa tua arte ti possa poi satollare, quando non trovi in casa la tavola ben fornita.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>In casa, eh? Mai non ci desino. Come prima ho vestito il padrone, così esco in foraggio, e secondo il mio traffico mi dimeno. All'ora solita vo in Palazzo, conosco ognuno e ognuno conosce me, perciocché tutti si servono di Moschetta: dico ognuno che metta tavola, ché degli altri nulla mi cale. Quivi pianto il mio squadro. S'io miro per avventura uno di questi montoni d'oro, gonfi di vento, m'inchino un miglio lontano, poi destramente mi accosto, e con mille inchini gli dico: “Buondì alla Signoria Vostra illustrissima”. Ed esso: “Moschetta mio, come si sta?”. E io: “Non posso star se non bene, ogni volta ch'ella mi tenga in sua buona grazia, padron mio caro; e meglio ancora starò, quand'io abbia bevuto un tratto, che n'ho bisogno”. “Vien meco a desinare, soggiunge egli, che a tuo modo ti farò bere”. E io, baciandogli il mantello, riverentemente il ringrazio; e poi m'avvio con esso lui, sempre mai lusingandolo e adulandolo: ché chi non sa piaggiare, si muor di fame. A quell'altro poi che fa dell'Orlando e del maestro di scherma: “Signore, due gentiluomini son venuti a contesa d'una certa guardia fantastica: io mi ci sono abbattuto, e hogli accordati nel sapientissimo parere della Signoria Vostra illustrissima”. Ed egli intanto si gonfia; e io, sotto: “Sicché, signor mio, sarà forza ch'ella si degni di dare questa sentenza”. Mi piglia per la cappa e mi conduce a casa; dov'io, mostrandogli un colpo ch'io mi sono sognato, il fo far tombole e menar le mani che pare un pazzo. E io sogghigno: “Oh buono! Oh bravo! Non è uomo che la sapesse trovare”; e poi a' circostanti mi volgo, e dico in guisa ch'egli sentir mi possa: “Tutto 'l regno di Spagna non ha 'l più bravo cavalier di costui”. Intanto si porta in tavola, e io, senz'altro invito, come canina mosca m'attacco e meno le mani molto meglio di lui, perciocché quivi ho io una botta ch'è troppo franca. Quell'altro vanerello, profumatuzzo, spezza cuor di tutte le donne, subito che mi vede, mi chiama a sé. Io, che so 'l giuoco, gli dico: “Oh signore, avesse mille ducati chi parlava di voi stamane!”. “E dove, Moschetta mio? Basta mo'. Dimmi, di grazia, chi fu?” E io, nell'orecchio: “La più bella figliuola di tutta Padova, ah, ah, ah”. E quivi il pongo in dolcezza; e intanto vo accompagnandolo a casa. Dove giunti, mi dice: “Caro Moschetta, non mi tacere chi fu la bella giovane che è sì vaga di mentovarmi”. E io: “Sarebbe troppo lunga la storia: è meglio che prima noi desiniamo”. “Dimmi, almeno, quel che dicea”. “Che voi siete il più bel giovine, che con due occhi veder si possa”. Oh quivi non può dirsi com'egli si ringalluzzi; e come, datasi una stropicciatella alle tempie, va tutto in succhio! E io addosso: “Voi la fate morir, voi la fate, quella meschina”. Quivi comanda subito che si porti malvagìa, biscottelli e altre galanterie. Vien poi madonna santa e venerabil vivanda, odorosa, fumante, ohimè, che mi pare d'averla in bocca. Egli mi vuole appresso, e tutti i buoni bocconi son di Moschetta: perciocché egli si pasce dell'aria d'un bel viso e pensa a quel ch'io gli ho detto; e io meno le mani e 'l dente come una macina. Dopo desinar, torno a casa: il padron vecchio perché gli pare che mangi poco, il giovane perché gli arreco buone novelle, mi veggono volentieri. E così vivo allegramente e mi procaccio le buone spese, alla barba di mille scimuniti collitorti.</p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO.</speaker>
             <p>Infatti tu se' cima d'uomo. Ma dimmi, per vita tua, queste nozze farannosi elleno?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Come, se si faranno? E che bella roba ho io per ciò condotta di villa!</p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO.</speaker>
             <p>E quel bel giovane soffrirà d'accostarsi a quella femmina mezza fracida?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Non sono mica fracidi tanti belli ducati che porterà in quella casa; co' quali avrà ben modo di trovarne di belle e di saporite e di godersele allegramente.</p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO.</speaker>
             <p>Sarà dunque venuta la tua ventura, Moschetta, di satollarti a tuo modo.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>A mio modo no, ma quanto più si potrà. Pensate pure ch'io merrò le mani come un piffero: io maestro di casa, io scalco, io dispensiero, io sopracuoco, io credenziere: io tutto, perché il vecchio non vorrà tante macine, no, per casa. Io vi lascio pensare, se Moschetta saprà fare buon lavorio. Oh perché non ho io mille bocche! Natura traditora, un sol palato a mille appetiti, eh? Questa è la volta ch'io vo' provarmi, se mi venisse mai fatto di mangiar quelle trecento e tante fiate che quello strolago disse.</p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO.</speaker>
             <p>Ah, ah, ah. Tu se' ben sì valente che puoi sperarlo. Ma ecco 'l tuo padrone, ve'. Addio, Moschetta.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Addio.</p>
           </sp>
-          <sp>
+          <sp who="#antonio">
             <speaker>ANTONIO.</speaker>
             <p>Tu stai fresco, povero Flavio. Male nuove ti recherò io, per certo.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Non potea venir più a tempo.</p>
           </sp>
@@ -1834,151 +1892,151 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>MOSCHETTA, PATRIZIO</stage>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Dio vi salvi, padrone, io son qui.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>E sai ch'io mi credeva che tu fussi alle Molucche, cotanto hai tu penato a tornarci? E perché non venisti tu ieri? Son pur tre giorni che te n'andasti, infingardaccio.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Perché, prima il mal tempo...</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Non andar più innanzi, ché, senz'altro, io so la seconda.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Forse anche no.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Il mal tempo la prima, e la poltroneria la seconda. Anzi, pur questa è la prima. Oh quanto ti fa egli, Pistofilo, infingardo!</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Sta bene affè! E se questo infingardaccio non si fosse trattenuto ieri alla villa, vi sareste voi avveduto la valentia di qual altro avesse potuto guarentir il vostro pollaio.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Si, eh?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Questo è 'l merito di cotanta fatica.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>E che fatica è stata la tua, valentuomo? Prender i polli, riporli nella stia, fargli condurre a barca e, dormendo, lasciarsi portare al fiume, eh? Grande impresa per certo hai fatta!</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Lavorar tutto 'l giorno, vegghiar tutta la notte, sudare, trafelare, combatter con le bestie per salvar il vostro pollaio: queste sono state le imprese mie, signor sì.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>E perché? Starà pur a vedere che gran miracoli sien questi.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Perché 'l martorello...</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Che di' tu di martorello?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>(La pace è fatta). Che dico, eh? Bisogna dire quel ch'egli ha fatto, e quello che ho provveduto io ch'ei non faccia.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Nel mio pollaio?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>No; l'avrà fatto nel mio.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Cacasangue! La cosa va daddovero.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>(Oh che bella menzogna!).</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Or dimmi, come sta il fatto?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Giunsi ieri l'altro a sera, colle vostre commessioni; e perché i polli non si potevan prender se non la sera o la mattina per tempo, la gastalda pensò che fosse meglio lasciarli riposar quella notte. La mattina seguente, entrati nel pollaio per levar quelli che comanda la lista, noi vi trovammo due de' maggiori e de' più vecchi capponi che vi fossero...</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Morti?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Che morti? Anzi, pur lacerati per sì fatta maniera che v'era appena l'avanzo de' pie, dell'ossa, delle penne e del becco.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Oh bestia maledetta! Un paio eh? Guardasti poi ben, Moschetta, di non errare? Io vo' dire che fosse stato un solo, e ti fosser paruti due, sai?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Come, s'io 'l vidi bene? (L'un fu lesso e l'altro arrostito). Purtroppo il vedemmo noi bene: perciocché v'erano quattro piedi e due becchi. E poi tanti ve ne mancavano al numero.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>O roba di Patrizio, come vai tu! Non ho pur uno voluto mangiarne mai, per conservare intero quel bel pollaio, e una bestia se gli ha mangiati. Ma, Moschetta, e' bisogna che siano state due bestie, avendone guasti due: il maschio e la femmina.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Credo anch'io. (E così, Moschetta, tu se' una bestia).</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Or seguita, Moschetta.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Veduto questo, ci risolvemmo di côrre il malfattore su 'l frodo e liberarne il pollaio.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Oh ben fatto, ben fatto!</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>E tutta questa notte abbiam fatta la sentinella, fin tanto che egli entrò nel pollaio. Oh com'era egli grande! Come prima e' vi fu, mi diedi a turar il pertugio; sapete quello della gastalda, che risponde in cucina?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Sì, intendo. Entrava per quello, eh?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Per quello appunto. Avendolo ben turato, sì che non potesse più ritornarsene, entrammo ambedue insieme e gli fummo addosso, menando l'uno e l'altra colpi di schiena, io con un sodo palo ed ella con una pertica, che avereste detto: “costoro fanno a gara chi me' si dimena”. Ultimamente menammo tanto, che restò morta. Oh che valente donna è colei! Né crediate che alla prima morisse, no: tornammo a quel trastullo ben tre fiate. Per Dio, che un asino, padrone, non sarebbe durato alla gran fatica che ho fatt'io questa notte. Or non mi dite mai più infingardo.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>O Moschetta mio caro, quant'obbligato ti sono per sì buon'opra. E' se gli avrebbe mangiati tutti. Hai tu poscia turata ben quella buca?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Se fosse qui la gastalda, ne potreste chieder a lei, ché miglior testimonio darvene non potrei. (Sì è ella ben radicata?)</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Or dimmi, hai condotto la roba salva?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>La roba ora può esser al Bassanello, che, quand'io la lasciai, partiva la barca ancora.</p>
           </sp>
@@ -1986,163 +2044,163 @@
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>PISTOFILO, PATRIZIO, MOSCHETTA</stage>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>(Ecco Moschetta; ma c'è mio padre).</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Con essa dunque non se' venuto?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Le robe appena si son potute condurre, per mancamento di piena.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>(Io vo' star ad udire).</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>O padrone, che bella roba! Voi vi farete un onor mirabile.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>(Parla de' polli che ha condotti).</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Ho sempre fatta professione d'aver in casa mia belle bestie.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Cominciando da te.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Che di' tu?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Dico, cominciando da me.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>(Oh che ribaldo!).</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Oh come voglio sfamarmi per una volta! Ma perché l'ora è tarda, sarà meglio ch'io vada per la bolletta, e faccia condur la roba.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Sì, tu di' bene. Va via, mentre vo io a fornir la lite in Palazzo.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Oh giornata felice! Che mangerà Moschetta? Un'oca e una porchetta.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>O Moschetta, Moschetta. È pur meglio ch'essi la facciano questa spesa.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Chiamatemi voi?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Sì, hai tu la lista de' polli?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Eccola.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Or va con essa a casa il Collaterale: sai tu quel cipriotto, che sta all'Arena?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Come, s'io 'l so? Oh che cuoco mirabile! Non andate più innanzi, che senz'altro v'ho inteso. Ch'io mostri a quel suo cuoco la lista, e sì gli dica da parte vostra...</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Che cianci tu di cuoco? Va dico a casa il Collaterale, e trova quel suo maestro di casa, e digli...</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Che volete voi far di maestro di casa? Non vi servirò io meglio di lui?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Tu farnetichi, neh vero? Che umori sono cotesti tuoi? Che maestro di casa vuoi tu far, ignorante? Egli è un uomo grande, di pelo tra biondo e bigio, ricciuto, sai?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Quanto a questo, io lo conosco purtroppo.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Digli che son venute quelle robe ch'io gli promisi; e se le vuole, mi mandi prima i danari del costo, secondo l'accordo fatto, e poi a casa se le conduca, acciocché egli faccia la spesa della condotta. Ha' tu inteso?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Quali robe? Quelle cinque sacca di grano e sette di lana, che ho condotte insieme co' polli?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Che grano, che lana vai tu sognando, balordo? Dico i polli di quella lista.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>(Oh questa sì, ch'è da ridere!).</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Di questa lista?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Di cotesta lista, sì.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Ah sì, volete dire ch'io gli dia questa lista e che poi faccia i polli condurre a casa. Io v'intendo: tanto farò.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Dove vai? Fermati. Se' tu ebro, o fai del buffone? Io dico che tu gli dia la lista insieme co' polli, quand'egli il prezzo loro m'abbia mandato. La vuoi più chiara?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>La lista e i polli? E per far che?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Guarda animal ch'è questo! Che vuoi tu sapere de' fatti loro? Perché suo padrone aspetta un gran signore. Orsù, se' tu chiaro?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Dunque con queste robe non volete far un convito?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Che convito! Dio me ne guardi. Sciocchezze del tempo antico.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>(To' to').</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Eh, padrone, dite voi daddovero? Voi siete pur piacevole; e par ben che parliate dal maladetto senno. Forse voi vi credete che i manicamenti mi piacciano, e per ciò volete darmi martello. Poco me ne curo io, vedete. Ciò dissi solo per onor vostro, io. Orsù farò far la bolletta, e condurrò (ch'egli è tardi) le robe a casa. Sì, sì. Assai vi siete voi preso gabbo del fatto mio. Oh come siete voi dolce!</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>(Te n'avvedrai. Oh i' l'ho caro).</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Vuoi che t'insegni, Moschetta... Non mi andare più stuzzicando, e fa quanto io t'ho detto. S'io torno a casa, che ciò non abbi esequito, ti pentirai d'avermi veduto mai.</p>
           </sp>
@@ -2150,187 +2208,187 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>PISTOFILO, MOSCHETTA</stage>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Che mangerà Moschetta? Un gufo e una civetta. Ah, ah, ah. Tu se' mutolo, sì. O Moschetta, Moschetta. Egli è morto il poverello. Ah, ah, ah. Mi convien ridere, e non ho voglia. O Moschetta! Bisogna scuoterlo daddovero costui. O Moschetta! To' to', gli cade di man la lista, cotanto è fuori di sentimento. Si vede bene che la tua vita è 'l mangiare. Io gli vo' gridar nell'orecchio. O Moschetta, Moschetta!</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Ohimè, i' son morto.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Anzi no; tu se' vivo, e mio padre ti vuol fare un solennissimo stravizzo: non dubitare.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Oh traditore, manigoldo, poltrone, imperador de' poltroni! Hammi quasi fatto morire. Ma creda pur che Moschetta farà la sua vendetta.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Abbi pur pazienza, Moschetta. Tu te l'hai guadagnata.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>E perché?</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Quanto l'ho caro! Per la 'ngordigia di satollarti m'avevi abbandonato, eh? Ve' quello che te n'avviene. Come l'ho caro!</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Oh assassino, a questo modo eh? Farmi venir la lupa in corpo, e poi levarmi il modo di pascerla con pericolo che di dentro mi divori il fegato, la corata e 'l polmone con tutto il resto delle budella. Sento ben io come sto.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Ah, ah, tuo danno. Eri fatto ancor tu consiglier delle nozze, provveditor del convito, introduttor dell'idropica. Pistofilo, a sua posta. Il manicare più t'importava che l'amor di Pistofilo, eh?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Datemi qua la mano. Moschetta oggi farà vedervi quel che possa una lingua aguzzata dall'appetito, un appetito ingannato dalla speranza. Io dirò tanto, che sturberò queste nozze.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>O Moschetta, mia vita, mia salute, mio bene, quanto caramente t'abbraccio! Se questo fai, beato me, beato te; ma no 'l farai.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>No 'l farò? E perché?</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Mari e monti nelle parole.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Forse ch'io starò troppo? Datemi tanto solo di tempo ch'io mi tragga non so che della tasca; e sì potrete chiarirvi, s'io fo parole. Vedete voi questo viluppo?</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Da mal capo la prendi, se da viluppo cominci.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>O se sapeste dond'egli viene! Inchinatevi infin a terra.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Non diss'io che coteste sarebbon cicalerie prette prette?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Ora statemi ad udire, e sì vedrete se sono fatti. Venendo dalla barca per trovar vostro padre e avvisarlo di quella roba (ohimè), di quella che mi fa sospirare...</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Lasciala andare, in nome di Dio, che non c'è più rimedio, e io prometto di ristorartene in mille doppi. Sta di buon animo, e seguita.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Nel venir dunque da barca, passando per quel chiassolino che è qui di dietro alla casa di Lurco, sento chiamarmi: “Moschetta, o Moschetta”. Io m'arresto, e parendomi ch'ella venisse d'alto, guardo alle finestre, né vi veggio persona. Ed ella, richiamandomi, “più su, dice, più su”; tanto che, rivolti gli occhi là su, vidi Gostanza essere quella che mi chiamava.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Gostanza? Oh ben mio! E dove era ella?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Sapete voi quel terrazzo ch'è sopra il tetto, dove, già due dì sono, voi la vedeste che stendeva il bucato?</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Fin lassù, eh? Che faceva?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Si faceva biondi i capegli: che, per quanto intesi già dalla Lena, questa è quanta commodità gli ha data Lurco il padrigno suo. O Pistofilo, se quella fila d'oro aveste vedute! Quel bianco seno, quelle candide braccia poco meno che ignude, quel volto che par d'un angelo!</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Ahi, tesori della mia vita che mi fanno morir mendico.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Poiché le fui vicino, istantemente pregommi ch'io mi fermassi e aspettassila un cotal poco. Il che feci; e non istette guari che mi gittò di lassù questa, che voi vedete, fettuccia di panno vecchio, così legata.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Oh ben mio! Dallami.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Io la raccolsi, con animo, a dirvi il vero...</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Di non darlami, eh?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Anzi sì, ma dopo fatte le nozze.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Dopo le nozze, eh? Traditore!</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Ma poiché la speranza mi va fallita, questa e ogn'altra cosa, in servigio vostro, di fare son dispostissimo; prendete.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Oh ben nato fascetto, venuto di paradiso!</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>E scioglietelo voi: ché né pur voglia ne venne a me, come quegli che tutto 'l mio pensiero, tutto 'l mio cuore nelle pentole avea riposto.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Oh benedetta carta! Così potessi baciar colei che ti manda!</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Voi vi turbate, leggendola: che c'è di rotto?</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Qualche male incontrato le sarà certo.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Ben, che dice ella? Voi vi grattate in capo. Qualche novella che non vi piace, eh?</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Io son tra il bene e il male, Moschetta mio. Dice la carta che Lurco è ito a Santa Giustina, donde per buona pezza non tornerà; e che di cosa molto importante mi vuol parlar a certa finestra, che risponde qui, ferriata. La qual certo de' esser quella.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>E voi dubitate di questa nuova?</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Par che presago m'avvisi il cuore che questa necessità, non venga da buona cosa.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Ma ecco Gostanza.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>E dove?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Non è, no; era una gatta.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Ohimè, non mi dare di queste angoscie, Moschetta.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Oh valentuomo! Che farete voi, quando l'averete innanzi?</p>
           </sp>
@@ -2338,127 +2396,127 @@
         <div type="scene">
           <head>SCENA NONA</head>
           <stage>GOSTANZA, PISTOFILO, MOSCHETTA</stage>
-          <sp>
+          <sp who="#gostanza">
             <speaker>GOSTANZA.</speaker>
             <p>O Pistofilo! Pistofilo?</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Ma eccola daddovero. Oh ben mio!</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Padrone, datemi quella lista.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Che, Moschetta? Oh cuor mio, e come, oh Dio!...</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Puuu, <foreign xml:lang="lat">in cimbalis</foreign>. Oh padrone, la lista che testè raccoglieste, ch'io la porti a quel cipriotto.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Si, va via, non mi dar noia.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Fui un gran pazzo a non gli chieder la cappa.</p>
           </sp>
-          <sp>
+          <sp who="#gostanza">
             <speaker>GOSTANZA.</speaker>
             <p>Deh guardate, di grazia, che altri non ci vegga, Pistofilo.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Non c'è persona, cuor mio. Ma che ventura è stata oggi la nostra? Tanto più cara, quanto meno aspettata!</p>
           </sp>
-          <sp>
+          <sp who="#gostanza">
             <speaker>GOSTANZA.</speaker>
             <p>Ventura, eh, Pistofilo? Ventura che mi farà morir di dolore.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Ohimè, che è quel che voi dite? Così dunque la mia vista v'offende?</p>
           </sp>
-          <sp>
+          <sp who="#gostanza">
             <speaker>GOSTANZA.</speaker>
             <p>Anzi il troppo gioirne è cagione che 'l vedervi ora, per non avervi a riveder forse mai più, noiosa quella vista mi rende, che per altro m'è sì soave.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Come mai più? Se 'l ciel ci ha data questa commodità, ce ne darà ben anche dell'altre, malgrado di quel crudele e iniquo vostro padrigno.</p>
           </sp>
-          <sp>
+          <sp who="#gostanza">
             <speaker>GOSTANZA.</speaker>
             <p>Eh Pistofilo, mio padrigno ha data la sentenza della mia morte, e domattina l'esequirà.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Come sentenza? Ohimè, che pensa egli di fare? Deh non piagnete, cuor mio.</p>
           </sp>
-          <sp>
+          <sp who="#gostanza">
             <speaker>GOSTANZA.</speaker>
             <p>Mi vuol condurre a Vinegia.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Domattina?</p>
           </sp>
-          <sp>
+          <sp who="#gostanza">
             <speaker>GOSTANZA.</speaker>
             <p>Domattina, Pistofilo, né voi potrete impedirlo.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>O cielo, fammi prima morire, che veder questo. Oh come son io stato di così tristo annunzio certo indovino! Non sarà vero mai che siate d'altri che mia.</p>
           </sp>
-          <sp>
+          <sp who="#gostanza">
             <speaker>GOSTANZA.</speaker>
             <p>Vostra son, perch'io v'amo, perché del mio cuore v'ho fatto libero dono; ma vostra non son già in quella guisa che ho sperato, e che merita l'amor mio, e che voi m'avete promesso.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>S'io credessi di lasciarci la vita, sarete mia.</p>
           </sp>
-          <sp>
+          <sp who="#gostanza">
             <speaker>GOSTANZA.</speaker>
             <p>Il tempo è troppo breve, Pistofilo. Bisognava pensarci prima. Ma se fosse in voi quella fede, nella quale ho vanamente sperato, un'ora sola ci basterebbe. Che quand'io fussi vostra per legittimo matrimonio già divenuta, che ragione potrebbe avere in me né 'l padrigno, né uom del mondo?</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Ah Gostanza, voi non sapete di che importanza sia questo fatto.</p>
           </sp>
-          <sp>
+          <sp who="#gostanza">
             <speaker>GOSTANZA.</speaker>
             <p>Io so che, quand'amore è del buono, agevolmente vince ogni cosa. Io, che fanciulla sono e posso dir prigioniera, curando poco le minaccie del mio fiero padrigno, ho, suo malgrado, prolungato due mesi interi (che tanti sono appunto che ci venimmo) la pratica di quel mercatante, a cui egli mi ha venduta. E così, povera com'io sono, ho rifiutata, per esser vostra, l'eredità della madre; e voi, che siete uomo libero e ricco, in tanto tempo non avete saputo mai trovar modo di trar di bocca a sì fiero lupo questa innocente e misera vostra agnella?</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Se così fosse padrigno il mio, com'è 'l vostro, fare'vi ben io vedere chi di noi fusse più fedele e più ardente. Troppo son io legato.</p>
           </sp>
-          <sp>
+          <sp who="#gostanza">
             <speaker>GOSTANZA.</speaker>
             <p>Eh! Dio voglia che non vi leghino i lacci d'oro; e che la roba non vi consigli ad esser anzi marito di ricca donna che di fanciulla povera, com'io sono.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>E se quella ricca donna fosse in mia mano di possedere, e pure per amor vostro non solo non la volessi, ma l'abborrissi, che ne direste? Ah non sapete il fiero tormento, che per ciò sostenere dal padre mio mi conviene.</p>
           </sp>
-          <sp>
+          <sp who="#gostanza">
             <speaker>GOSTANZA.</speaker>
             <p>Se cotesto è pur vero, che io no 'l so, assai più di timore che di conforto m'arreca. Che se quel cattivello, il quale confessando sa di morire, non può resistere a chi 'l tormenta, che si de' creder di voi, potendo, non colla morte, ma colle ricche nozze terminar il vostro tormento? Se ora non v'ha vinto, un'altra volta vi vincerà; e quella sola basta a farmi morire.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Potess'io pure così voi liberare dal pericolo di Vinegia, com'io quel delle nozze saprò fuggire.</p>
           </sp>
-          <sp>
+          <sp who="#gostanza">
             <speaker>GOSTANZA.</speaker>
             <p>Domattina dunque, Pistofilo, io me n'andrò, portando in questo misero cuore eternamente scolpita la rimembranza sola di voi, poiché altro non mi resta dell'amor vostro. Io dico eternamente, non già ch'io speri di poter molto vivere senza voi; ma perché voglio amarvi, s'e' si può, ancora dopo la morte. Ricevete voi queste lagrime, ultimo dono e miserabile del cuor mio. E se degna non sono stata d'amorosa mercede, fatemi degna almeno di cortese compassione. Non la negate a questa misera serva, che né dolor, né fortuna, né lontananza, né paterno rigore, né qual altra si voglia potenza umana, avrà mai forza di separare, o viva o morta, da voi.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Non più pianto, Gostanza, non più querele. Io solo ho da stagnar queste lagrime, io solo da saldare le nostre ferite. Oggi farò vedervi s'io vi amo. Sprezzerò le minacce del padre, romperò il freno della modestia, non temerò di pericolo, sforzerò, involerò, penetrerò quelle mura; o domattina, nel cammino, vi rapirò. Né sarà impresa ch'io non ardisca. Non vo' patti colla fortuna, no, no: o tutto misero, o tutto lieto. Tra la vita e la morte non cerco mezzo: o io vi avrò, o io morrò.</p>
           </sp>
@@ -2466,7 +2524,7 @@
         <div type="scene">
           <head>SCENA DECIMA</head>
           <stage>GRILLO solo</stage>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Che fo io? Lo star inutilmente, in tempo di cotanto bisogno, non mi par bene. Debb'io andare o restare? Par che mi dica il cuore che quella povera donna abbia di me bisogno; e pur mi pesa di lasciare la casa sola. Che fo? Voglio andare. Il Palazzo è vicino: quel birro non può andar di sopra, ché io ho chiusa la porta della scala. Non farò molto indugio: lasciami andare fin colassù.</p>
           </sp>
@@ -2477,99 +2535,99 @@
         <div type="scene">
           <head>SCENA PRIMA</head>
           <stage>NICA, GRILLO</stage>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>O Grillo, tu ci venisti pur tanto a tempo! Dio ti spirò.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>E sapete ch'io stetti per non venire?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Guai a noi. Egli s'era impuntato di mandarci (ohimè, che 'l cuore mi triema ancora!) a levare Cassandra allor allora di casa.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>E perché così subito? Che gli era entrato nel capo?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Perché il dottore è stato come la rana, la quale o salta o sta. Dianzi non volle fare; e oggi ha voluto strafare.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Sapeva ben io che, a far saltare le sì fatte ranocchia, non ci voleva altro che 'l boccon d'oro.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Nel difender la causa gli scappò della bocca non so che d'ingiustizia. Buon dì! Il Vicario, collerico di natura, che s'era di già scoperto parzialissimo di Patrizio e sapeva, in coscienza sua, che faceva ingiustizia, sentendo rimproverarlasi, fieramente adirato lo cacciò via. E non solo non volle a me, che umilmente ne 'l supplicava e piagneva, conceder la richiesta sospensione, ma fe' di più chiamare subito il Cavaliere, per ordinargli che immantenente ce la levasse di casa. Grillo mio, i' non ebbi mai la maggiore angoscia di quella; né credo che la morte possa esser più dolorosa.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Mirate furia da pazzo! Che colpa avevate voi, anzi pur la giustizia, dell'altrui fallo? E forse che non si tien un gran savio? Infatti, chi non sa regger se stesso, non è atto a regger altrui. E i gran savi, per lo più, fanno le gran pazzie.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>E tu, com'hai poi fatto a incantarlo?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Con uno scudo, che io piantai 'n mano a Scatolino: ed esso fu che trattenne il Cavaliere, acciò non andasse. E poi, entrato subito in camera, cominciò a dire delle solite sue novelle, e seppe sì ben fare, che mise il Vicario in succhio e ottenne la grazia che s'esequisca il primo comandamento: cioè che per tutt'oggi Cassandra non ci sia tolta.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Così dunque si lascia egli aggirare a un cinciglione com'è colui?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Oh sta bene. I buffoni, i ruffiani, i parassiti, gli adulatori, gli spioni e simil gente son gl'idoli de' padroni. Questi li ben veduti, gli accarezzati, i favoriti, i premiati: alla barba di quanti scimuniti, goffi e sgraziati virtuosi stentano al mondo.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Or che s'ha a fare? Meschini a noi! Sei ore sole di tempo, eh?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Hovvelo detto fin da principio: fuggire. A' casi nostri non c'è altro rimedio.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Ohimè, Grillo, fuggire? E dove? E come? E quando? Grillo, pensaci bene, ch'egli è un gran passo.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Senza pericolo, monna Nica, non si scampa di gran pericolo. Voi avete a gustare uno di questi due amari calici: o lasciare svergognata Cassandra, o fuggire con essa. Qual volete voi prima?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Anzi morta che svergognata.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Prendiamo dunque la fuga, e lasciatene a me la cura. Che s'altra via (che no 'l credo) men perigliosa di questa mi portasse innanzi la sorte, assicuratevi pure ch'io serberò il fuggire per l'ultima. Ma ditemi, credete voi che Cassandra potrà, senza sconciarsi, camminare infin al Portello?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Anzi credo che, essendo ella nei nove mesi, questo moto per far agevole il suo parto le gioverà.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Andate in casa; e fatto un fastello de' panni suoi e de' vostri, riponetelo in un forziere, ch'io condurrò un facchino per esso. Prendete ancora que' pochi danari e ori che voi avete, e aspettatemi.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Ma il birro?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Poiché 'l vino non l'ha inebriato, l'inebrieremo con l'oro. Queste canaglie si lasciano aggirare per uno scudo, com'altri vuole. Due paia che gli si donino: farà veduta di dormire, infingendosi d'esser ebbro, e lasceracci fare quel che vorremo. Quattro scudi: non gli vede in quattr'anni! Ma mi scordavo del meglio. Crediam noi che Cassandra voglia venire?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Se vorrà? Dice che andrebbe in capo del mondo, per sfuggire la sua vergogna e le nozze. Oh se tu la sentissi! “Misera me, dice ella, avesse almen voluto la mia disgrazia che questo parto, infelicissimo testimonio dell'amor mio, o fosse stato maturo avanti che scoperte le mie vergogne si fossero, o prima del tempo uscendo, m'avesse, quasi vipera, uccisa. Ma, viva o morta, non fia mai vero che altri mi possegga che tu, Flavio mio. Né per altro m'è cara la ricca eredità che m'astringe a prender marito padovano, se non per farti sicuro che la mia fede non è vinta dall'oro”. O vedi s'ella verrà!</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Or via, non perdete tempo. Oh nelle sue miserie felicissima giovane! Se tutte fossero di tal animo, che bel mondo! Del quale, alla fin fine, le donne sono il vero ornamento. Oh sesso nobile! Oh sesso caro! Sesso gentile! Questa vita, senza te, sarebbe un inferno. Tu ristoro dell'uman genere, tu fonte delle dolcezze, tu consolazion degli affanni, tu condimento delle allegrezze, tu finalmente nido d'amore. Donne: non donne, angeli della terra. Ma volta carta, e fa che manchi loro la fede: diavoli incarnati, che ti vanno per casa!</p>
           </sp>
@@ -2577,303 +2635,303 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>MOSCHETTA, LURCO, GRILLO</stage>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Aspetta almeno tutto dimani.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Questi vostri dimani non arrivano mai. Né cotesto dimani sarà niente più oggi di quel che sia quest'oggi, rispetto a quel che fu ieri: e così l'uno va dietro all'altro. Non ne vo' più.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>(Che domine hanno costor di traffico? Io vo' star un poco a udirgli).</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Lurco, non possa io veder altr'oggi, se non verrà il dimani che io ti dico.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>So ben anch'io che verrà. Gran segreto! Ma quello de' danari non sarà già.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Io dico quel de' danari.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>E io replico che, per le tue parole e per quelle del tuo Pistofilo, ho mille occasioni perdute di far bene li fatti miei, e che non voglio perder quest'altra. Danari e non parole voglion esser, Moschetta.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>(Sì, eh? Comincio a intenderla).</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Fammi questo servigio, per vita tua.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Per la vita tu mi scongiuri, eh? Non sai tu che la mia vita è 'l danaro?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Per la nostra antica amicizia.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>E perché questa duri, non ti voglio far credito.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Per l'amor di Dio.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Per l'amor di dugento ducati Gostanza ti sarà data.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Tu se' pur crudo; chi ti fece mai tale?</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>La povertà, fratello, che è più cruda di me.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Deh, abbi compassione a quel povero giovane che si muor per amore.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Compassione a me, che mi muoio di fame. E poi che tresca è cotesta vostra? Non so io che Pistofilo prende moglie?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>E qual è questa sua moglie?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>(Oh come a tempo ci son venuto!).</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Oh, tu no 'l sai. Forse che andremo lunge a cercarla. La figliuola di quella sì ricca greca che morì un mese fa, e abita in quella casa.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Si vede ben che tu se' male informato, e che siccome falli nel nome, falli anche nel resto. Io t'intendo per discrezione. Ma odi, Lurco: tu vedrai prima il lupo congiungersi con l'agnella che Pistofilo con colei.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>E perché?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Perché l'odia come la peste: più della morte.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>(O questa è pur la gran nuova! Non è tempo da starsi). Che mercati sono cotesti vostri? Puossi egli sapere?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Grillo, tu giungi a tempo: hai tu inteso?</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Moschetta, addio.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Ove vai? Che creanza è cotesta tua di volertene andare subito ch'io sia giunto?</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>In mezzo a duo ribaldi, eh?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Oh! ci puoi star per terzo tu, meglio del mondo.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Che per terzo? Per primo, dico io. Ascolta, Grillo, se tu sentissi mai la più fiera cosa! Costui ha una giumenta ch'io vorrei comperare pe 'l mio padrone; oggi non ho i danari, dimani prometto darglili; e costui è sì sfiduciato, che non vuol credermi e la vuol vender altrui.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Se costui avesse tanti danari quanti ha dimani, già è buon pezzo che 'l mercato sarebbe fatto. Ma ho bisogno d'un oggi, e non di mille dimani. Parti onesto ch'io non venda a chi mi paga la roba mia?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Quanto importa cotesto prezzo?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Dugento ducati importa.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>E' un gran pagare! Bisogna ch'ella sia bella.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Ne val più di trecento; e ho più d'uno che me gli dà.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Vuo' tu fare a mio senno?</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Secondo che cosa. Di' mo'.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Pistofilo ha il modo di dartene ben duemila, non che dugento.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Credo che gli abbia, ma non per me. Ma egli non ha voglia; no certo.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Oh fagliene tu venire.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>E come?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Lasciagliela cavalcare una volta, e invaghirassene di maniera che trecento te ne darà.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Oh vedi che ho dato in buono!</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>E perché no? I giovani son vogliosi.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Disse ben io ch'era in mezzo a duo sciaurati. Addio.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Fermati un poco; non tanta fretta, no.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Caro Lurco, dove fu mai che si facesse mercato senza qualche dilazione?</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>I mercati delle donne non si fanno con credito.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Perché no?</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Perciocché questa è una merce che porta, a chi la compera, pentimento. Sicché quel prezzo che non hai tratto dall'appetito, indarno è che tu speri di trarlo mai dalla fede.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Egli è tristo daddovero.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Orsù bisogna ch'io v'apra il foglio. Holla promessa a chi caparra me ne ha già data. Forse voi pensavate che un anno a vostra posta la volessi tenere? Siete cortesi certo. Avete un bel garbo da far incetta di donne.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Tu l'hai promessa?</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Promessa, sì; e perché?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Tu te ne pentirai, credilo a me.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Gnaffe. E per non avermene a pentire, oggi la vo' condurre a Vinegia.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Orsù Lurco, non t'adirare, vien qua. (Non bisogna attizzarlo, Moschetta).</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Credi tu di farmi paura? Ora io vo.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Non ti partire di grazia, Lurco, e parla con esso meco; ché costui è uno scemo.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>(Se questo è vero, tu stai fresco, Pistofilo).</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Ascolta, Lurco. E' troppo malagevole cosa a un figliuolo di famiglia, e figliuolo di padre avaro, il trovare dugento ducati così in un subito.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Tu parli contra di te, pover'uomo. Quanto è maggior la fatica, tanto meno io t'ho a credere.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Daratti un mallevadore.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Non vo' piatire.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Daratti un pegno.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Non son ebreo. Grillo, queste sono parole vane. M'accorgerò ben io se Pistofilo n'avrà voglia. Per amor suo son contento d'aspettar per tutt'oggi. Domattina, sull'alba, la sentenza è data. Statti con Dio.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Ascolta, fermati un poco.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Purtroppo mi son fermato.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Aspettaci almeno in casa.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Sì, quasi io non abbia altra faccenda che questa. Addio.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Moschetta, tu la 'ntendi. Senza danari, abbiam perduta la causa. Ma il mio caso è in peggior termine assai del tuo. Tu, non guadagnando, non perdi nulla; ma se oggi quella povera giovane ci vien tolta, così inferma com'ella è, senza alcun fallo, la misera si morrà.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Che, dunque anch'ella non consente alle nozze?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Questo non so; ma so bene che non vorrebbe venirti in casa, e che noi facciamo ogni cosa perch'ella non ci venga e non ci sia tolta. Ti par egli onesta cosa?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>To', to': cotesto non sapev'io, ed è ben daddovero un gran punto. Grillo, poiché amenduni camminiamo ad un fine, aiutianci, per vita tua. Alleghiamoci insieme, per trovar modo io d'acquistar una donna, tu per non perder la tua.</p>
           </sp>
@@ -2881,283 +2939,283 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>PISTOFILO, MOSCHETTA, GRILLO</stage>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Sbandito a tua posta, pur ch'io goda la mia Gostanza, pur ch'io possegga l'anima mia. Oh lagrime preziose! Oh sangue del cuor mio! Ch'io t'abbandoni? Ch'io ti vegga in altre mani che in queste? Al primo colpo, taglia una gamba a quel manigoldo, e tutto a un tempo raddoppia il colpo sopra alcun altro che seco fosse: messigli in terra, becco su la mia vita. Oh cuor mio!</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Se quella che tagliate è una torta, un buon pezzo per me, di grazia.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>O Moschetta, a tempo ti trovo.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Voi fate un gran menar di mani.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Fratello, tu sai bene che quel tristo di Lurco... Tirati 'n qua, che colui non c'intenda.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Non dubitate, ch'è nostro amico, e non mi replicate parola; ché quanto dir mi volete, tutto so.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Pistofilo, non vi guardate da me, ch'io son de' vostri, nientemeno di quello che sia Moschetta: poiché, per quanto mi par d'intendere, la mia padrona e voi v'accordate meglio del mondo. Voi non volete lei, ed ella molto men voi, non già per poco merito vostro, ma perché, avendo inteso dell'avarizia grande di vostro padre, famosa per tutta Padova, si morrebbe piuttosto ch'entrarvi in casa.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Che vi diss'io?</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>O Moschetta, dice egli il vero costui, o s'infinge?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Ancor non mi crede.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Come, se dice? Non ha forse ragione? Ella ci morrebbe di fame, la poveretta.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Oh come a tempo! De' esser bravo, ché ha la spada. Affé che sarà buona per aiutarci a rapir Gostanza.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Rapir Gostanza? Parliamo d'altro.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Che hai paura della pancia, poltrone?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Piuttosto della schiena, che è calamita del remo; che, quanto alla pancia, non ha ella paura d'altri che di vostro padre, a dirvi la verità.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Come hai tu nome?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Grillo, al vostro servigio.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Grillo, se questo è vero, mi dai la miglior nuova del mondo.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Come, s'è vero? Io vi farò conoscere che meno di voi non bramo la rovina di queste nozze.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Per due sposi, che si hanno a fare istasera, non si vide mai meglio.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Oh Dio! sarà possibile mai che due così lontani d'animo e di volere sian per unirsi?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Eh padrone, aveste voi creduto a Moschetta,che sareste ora fuori d'ogni fastidio. Quante volte v'ho io detto: “Pistofilo, se volete costei, non ci perdete tempo, ché suo padrigno ve la condurrà un dì a Vinegia. Rompete quel granaio, schiodate quella cassa, impegnate quelle robe”. Ma non avete mai saputo risolvervi. O tutto buono o tutto reo bisogna esser, padrone. Se ora noi avessimo apparecchiato il danaro, mi darebbe il cuore di porvi in braccio a Gostanza.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>E dimmi un poco, Moschetta, quando tu avessi i dugento ducati, provvederesti tu poi al resto?</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Perché, Grillo? Sai forse dove poterli avere? Saresti ben l'idol mio.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Non dico già io d'avergli; ma dico bene che se la via si trovasse di frastornar queste nozze, sarei uomo per accattargli. Mille grilli mi vanno per la testa, da che tu mi motteggiasti di que' danari.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Guardati dal proferire.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Guardati pur tu dal vantarti.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Accordatevi, io vi prego: parlate chiaro, e levatemi di tormento.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Se costui oggi trova i contanti da dar a Lurco, per trargli di man Gostanza, mi va per l'animo la più sottile invenzione, e più agevole da fornire, che mai sentiste. Ma egli farnetica d'accattar oggi i dugento ducati.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Io farnetico? Primieramente, io so dove avere il pegno per tanti. In casa sempre l'avrò. Ma per dirti, ho pensato meglio, Moschetta. Non ci sarebbe il mi' onore, se di gioco di testa io mi lasciassi vincer da te. Emmi sovvenuto che quello scemo di Zenobio pedante è innamorato, che spasima di Gostanza.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Di Gostanza mia?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Di Gostanza vostra.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Oh insolente! So ben io quello che va cercando. Gostanza mia, eh?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Non dubitate che gli faremo pagar la pena.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>E quella pecora è innamorata?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Sì; e di tal sorte che mi dà il cuore di fargli fare ciò ch'io vorrò.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Non farai nulla, Grillo. Da colui dugento ducati? Egli è un poveraccio.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Più di cinquecento n'ha ben egli, per quello che mi mostrò in tanti bei pezzi d'oro, fin quando stava a Vinegia. So ben io che ve l' farò sdrucciolare. Il terreno va troppo bene alla vanga. E poi egli è innamorato fin dove può mai andare.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>O Grillo mio caro, caro! Senza te, noi eravamo perduti. E tu, Moschetta, che pensi ora di fare? Già noi possiamo dir d'aver il danaro. Che di' tu? Quanto dubito che cotesta tua sì miserabile invenzione non sia uno scoppio vanissimo di vessica!</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Sarà scoppio d'una bombarda, e colpirà sì fattamente nel segno, che le macchine de' nemici tutte n'andranno a terra. Ma, prima d'ogn'altra cosa, Moschetta vuol sapere quel che n'ha a guadagnare.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Sai che, Moschetta, non è tempo da patti: è tempo da fatti. E poi bisogna che prima tu ne faccia sapere quel che pensi di fare.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Tu non la 'ntendi, tu. Vo' prima esser sicuro della mercede, sai, Grillo? Io voglio che mi facciate un solennissimo manicare, Pistofilo.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Sì, sì, quanto saprai desiderarlo maggiore.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Oh ti venga il fistolo, manigoldo. Io mi credeva che tu volessi qualche gran prezzo, io.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>E questo non è grande? Ma son io troppo avvezzo a esser ingannato, e però...</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Eh non perder il tempo, Moschetta, né dubitare; ch'io ti darò tutto quello che tu vorrai.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Ma voi m'avete a giurar, sapete?</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Io ti giuro. Orsù.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Dite pure come dirò io.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Ohimè, ohimè!</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Su dite: io ti giuro. Su.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Io ti giuro.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Per vita di Gostanza.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Per vita di Gostanza. Ohimè, che mi fai dire!</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Ah, ah, ah. Oh ribaldo! So che ha saputo trovare il buon santo, io.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Di far a te, Moschetta. Su, dite, via.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Di far a te, Moschetta.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Un solennissimo stravizzo.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Un solennissimo stravizzo.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Che duri fin ch'avrai fame.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Non fate; ch'egli manicherà voi, me, Gostanza e ce ne fossero pur degli altri.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Tanto che ti satollerai. Orsù...</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Né questo ancora, diavolo.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Grillo, tu se' fastidioso; impacciati ne' fatti tuoi, e non mi dar in bocca, ché non saremo amici, te 'l dico io.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Tanto che basti a fare che tu non ci mangi. Orsù, contentati.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Or la cosa comincia a passare pe'l suo verso. M'è venuto un sì fatto appetito, con la memoria sola del manicare, che vo in deliquio. Ma io non voglio che stiamo qui; che se per mala sorte il vecchio malizioso sopravvenisse, vedendoci alle strette, non sospettasse. Ritiriamci qui nelle Scuole, Pistofilo e io; e tu Grillo va, procaccia il danaro. E se questo avrai tanto sicuro quanto ho io il mio pensiero, la cosa è fatta.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Saprei pur volentieri ancor io quel che n'ha essere.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Trova il danaro, e troppo bene il saprai. Addio.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Addio, Grillo. A rivederci con buone nuove.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Addio. Ma che invenzione troverò io che sia buona? Nel cammino l'andrò tessendo. E dove il troverò io? Disse d'andar a veder Gostanza, ma ciò fu innanzi desinare. Certo il troverò a casa il Collaterale, ché quivi spesso a quel buon tavolone ridur si suole.</p>
           </sp>
@@ -3165,275 +3223,275 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>ZENOBIO, GRILLO</stage>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Oh sole opposito al sole, oh auree chiome, oh seno, oh braccia, oh mani, oh tergo meraviglioso! Ma ecco Grillo: oh come a tempo! O Grillo.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Chi mi chiama? (Oh sii tu il mal venuto! Sì tosto non ti voleva già io).</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Volgiti in qua, ché son io.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Oh siete voi, messer Zenobio mio caro? (Che cosa gli dirò io?).</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Appunto di te cercava, per teco le mie rare avventure comunicare.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Io vi ho da dare la miglior nuova che mai aveste a' dì vostri. Oh che nuova! Oh che nuova rara! Che nuova miracolosa! (È stato agevole il cominciare; a finirla ti voglio).</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>E io ne reco a te una maggiore assai della tua.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>È impossibile. Questa è regina di tutte le altre nuove. (Non so andare più innanzi io).</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Vuoi tu contender meco di nuove, se testé ho veduta Gostanza mia?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Sì, la vostra, a petto alla mia, non val nulla, no certo.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Dunque dimmi la tua.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>(Il tutto sta ch'io la sappia). Io credo certo che la fortuna mi v'abbia mandato innanzi per vostro bene. Oh che nuova! Oh che nuova!</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Oh che nuova, oh che nuova; oh dillami una volta!</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>S'io non vi ritrovava, guai a voi. Pensate, io v'ho cercato tutt'oggi. (E la cerco tutt'ora, e trovar non la posso).</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Se questa è quanta nuova mi sai tu dare, <foreign xml:lang="lat">frustra</foreign> t'ho ritrovato.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>(Per mia fè, ch'io la tengo). Che volete giucare che la mia di gran lunga è maggiore assai della vostra? Non dite voi che avete veduta Gostanza? E dove fu cotesto?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Là sopra 'l tetto, che quivi s'asciugava i capegli: oh aurei capegli!</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>(Oh gran diavolo! Là su non la voleva già io. Anzi pur sì: ella ci va di brocca).</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Ma che pensi tu?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>O, o, o, la mia senza dubbio avanza la vostra. Voi avete a sapere che Gostanza vostra...</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Oh nuova miracolosa, poiché comincia dalla mia cara suaviola!</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>È innamorata di maniera che spasima.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Oh questo, infin'a qui, non m'è nuovo.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>E dico innamorata di Pistofilo, figliolo di messer Patrizio degli Orsi, che sta in quella casa. Fin qui non è menzogna. Conoscetelo voi?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Hui, hui, Grillo mio facetissimo, così fai prova di martellarmi? Ma troppo bene so io che Gostanza mi ama perditamente. E poi non la lascerebbe un par mio, persona virile, uomo d'ingegno, poeta illustre, per un ragazzo com'è colui.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Dunque credete voi ch'io dica menzogne?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Di grazia, non mi far di queste paure; ch'io sono per natura sì delicato di spiriti, ch'ogni picciola mozione d'animo mi perturba.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Messer Zenobio, mi duole d'avervelo a dire, ma io mi offero di farvi toccar con mano ciò ch'io vi dico.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Ohimè! Dunque non beffi? È dunque vero che Gostanza mia per altri mi abbia posto in non cale?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Non so di cale. Io vi dico che la cosa sta pur così. (I' ho 'l vento in poppa).</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p><quote xml:lang="lat">Varium et mutabile semper femina</quote>. E questa è la buona nuova che tu mi dai, eh?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Ho voluto prima darvi la rea, perché la buona, ch'io son per darvi, è tanto eccellente, che l'allegrezza averebbe potuto uccidervi. Ma voglio che le vostre armi medesime vi convincano. Che credete voi che facesse Gostanza sopra quel tetto, dove voi dite d'averla veduta?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Per brama di vedermi, avrei creduto io prima ch'io ti parlassi.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Oh pover'uomo! Come mostrate bene di non aver pratica delle donne. Credete voi che un solo amor le contenti? E' ci sono di quelle che fanno de' loro amanti le liste tanto lunghe, vedete, per potersene ricordare: tanti ne hanno elleno! Sapete quello che vi faceva, e che vi ha fatto? Volendola suo padrigno condur domattina a Vinegia, ha concertato di tirarsi oggi in casa Pistofilo travestito da burattino.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Eh queste sono buone novelle? Oh infelice ascalato! oh funesto e importuno bubone!</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>(Che domine cinguetta egli? Mi dice villania certo).</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Ma che sai tu di cotesto?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>(Tirala Grillo, sta in cervello). Lurco, padrigno suo, me l'ha detto, il quale si è trovato in luogo dove ha potuto sentirlo. E perché molto di me si fida, mi ha pregato ch'io voglia esser con esso lui e dargli un carico di buone bastonate.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Ai giovanetti, com'egli è, ancora teneri, non conviene il bastone. Il suo vero gastigo sarebbe la mia scutica. Oh come il servirei io bene! Ma in qual abito ha egli divisato di travestirsi?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Da burattino.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Guata tu s'egli ha viso di sapere abburattare! Che per quell'esercizio potrebbe stare molt'anni ancora sotto il maestro.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Con una barba posticcia s'avea pensato di contraffarsi. Ma per tornar a proposito: io, che so quanto voi siate acceso dell'amor di Gostanza, ho così meco discorso che, quell'abito voi prendendo, potrete troppo bene e commodamente, in vece di Pistofilo, andar in casa e godere.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Per esserci ricevuto con un pezzo di legno? Oh questo non farò io. E così, Grillo, le tue buone novelle si risolvono in male busse.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Non vi smarrite, ché non c'è male alcuno: perciocché io, bramoso di servirvi, ho fatto consapevole Lurco dell'amor vostro.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Ohimè, che hai tu fatto, Grillo, che hai tu fatto? <foreign xml:lang="lat">Perii, perii</foreign>; prostituta è la mia dignità.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Ohimè, ohimè, voi siete pure impaziente. Lasciatemi finire, e poi doletevi, se vi parrà d'averne cagione. E perché Pistofilo avea promesso di dare, per prezzo di Gostanza, dugento ducati a Lurco, poiché egli non ha potuto trovarli mai, ho in nome vostro data io la parola a Lurco, ed egli se ne contenta. Sicché sborsandogli voi il danaro, vi lascerà con quell'abito, in vece di Pistofilo, entrar in casa.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Grillo, a dirti il vero, non vo' più di queste tue buone nuove. Io son chiaro: come, dugento ducati? <foreign xml:lang="lat">Non emo tanti poenitere</foreign> no, no; <foreign xml:lang="lat">nequaquam minime</foreign>, messer no.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Dove andate, messer Zenobio? Non vi partite, ché non sapete ancora tutta la storia.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Di quella ch'io so, mi basta. Troppo n'ho inteso.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Voi adombrate come cavallo. Ascoltatemi, e vedrete che l'ombre vi sembrano montagne.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Ombre chiami tu dugento ducati?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Forse che non gli avete? Per quel ch'io veggio, non siete innamorato, no certo. Se i danari fossero sangue, vi svenereste.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Innamorato son ben io, Grillo; ma il mio amor non val tanto.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Orsù, non voglio più tenervi in affanno. Se avessi trovato modo di farvi aver Gostanza per niente, che ne direste?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Oh, oh, io direi che tu fossi valentuomo <foreign xml:lang="lat">terque quaterque</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Messer Zenobio, lasciatevi governar a chi vi vuol bene. Io fo più stima di voi e della grazia vostra, che di quanti ruffiani può aver il mondo. Vorreste dunque che Grillo, amico vostro di tanto tempo, pensasse mai d'ingannarvi? Il ciel me ne guardi. Or ascoltatemi, ch'io vo' condurvi in braccio di quella tenera mammoletta, con tanta agevolezza che stupirete!</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Oh Grillo mio lepidissimo e soavissimo! Se cotesto è vero, tu mi farai, u, u, u, tutto, tutto andar in dolcitudine liquefatto.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>S'io 'l farò, dite? Mo', mo' il vedrete. Io voglio che, preso l'abito come dianzi v'ho divisato, quando farete per entrar in casa di Lurco, abbiate due moccichini, che Grillo ve gli darà, tanto simili in fra di loro, che l'un dall'altro non si conosca. Nell'un voglio che riponiate dugento di que' vostri sì be' ducati d'oro, sapete, che già voi mi mostraste a Vinegia; nell'altro, altrettanti pezzi d'ottone stampati sì vagamente, che paion monete d'oro forbito. Io sarò quivi con esso voi, e dirò a Lurco che, per sicurezza e cautela vostra, è molto ben il dovere che non gli diate i danari prima che non abbiate il vostro fine ottenuto, dovendogli bastare che voi gli abbiate sicuri in tasca. E così gli mostrerete il moccichino dell'oro, annoverando i ducati, e poi riponendolo. Dopo 'l fatto, gli darete quel degli ottoni, intendete? Che per esser tanto simili, l'accetterà senz'altro per quel dell'oro. Che vi par di questo trovato? Non è egli di tutta botta?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Ma dimmi, Grillo: come vuoi tu che Gostanza non mi conosca, ancorché io sia travestito?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Non potrà ella, no: perciocché voi avete a condurvi con esso lei in una camera al buio, nella quale ha pensato di ricever l'amante. E poi badate pur a fare, e a non parlare. Come volete che vi conosca?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Sta bene: oh mirabile astuzia! Non credo che quel Davo terenziano trovasse mai la più bella. Ma quando si sarà egli poi avveduto della menzogna, che fia di me? Non mi potrebbe egli far qualche scorno?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Che scorno volete voi che vi faccia? Per chiamarvi in giudicio, nulla farebbe, mancandogli i testimoni. Offendervi nella vita, se ne guarderà bene; e avrà anche di grazia a star cheto, quand'egli sappia che Grillo sia per difendervi. Guai a lui!</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>O Grillo mio, quanto ti son io grandemente ubbligato!</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Or non badate, su, provvedetevi quanto prima degli abiti, ch'io v'ho detto, da burattino, e travestitevi co 'l cavalletto e staccio a bell'ordine, apparecchiando i danari. E non avendo voi gli ottoni, li darò io, che gli ho i più belli del mondo; e, sopra il tutto, una barba posticcia, acciocché Gostanza non sospettasse, uscendo voi di metafora; poiché così Pistofilo ha concertato di dover fare, intendete?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p><foreign xml:lang="lat">Optume</foreign>! E so dove avere ogni cosa: da un burattino, che sta nella medesima casa dove sto io. Tu porta il resto, sai, Grillo.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Sì, ma aspettatemi voi in casa; ché quando ne sarà il tempo, verrò per voi.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Così farò <stage>(parte)</stage>.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Oh pover'uomo, se altro senno non impari tu da' tuoi libri, vendigli pure. Non ho io fatta una bella impresa? Sì certo. Ma la sciocchezza dell'uccellato assai mi scema del pregio. Or vommene a trovar Lurco, per avvisarlo del fatto e di quello che resta a fare; e poi farò provvisione d'una fantina da mettere sotto al pedante, in vece della Gostanza, nella camera oscura, perché non possa conoscerla.</p>
           </sp>
@@ -3441,123 +3499,123 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>LURCO, GRILLO, MOSCHETTA</stage>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Tutto ho inteso, e sta bene.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>(Ve' gli qua).</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>E purché vengano i danari, fate quel che vi piace. Ma tu mi hai ben narrata la più bella novella che mai udissi.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Ah, ah, ah.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Tu non potevi giugner più a tempo, Grillo.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Ridete meco, per vita vostra; ch'i' ho da raccontarvi la più solenne beffa del mondo.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Addio, Grillo; tu non ti degni più, eh? So che tu peni a lasciarti veder, io.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Se ogni volta ch'io starò molto a vederti, t'apporterò il guadagno ch'ora t'arreco, potresti ben contentarti di non vedermi in capo degli anni.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Dimmi, di grazia, avrestù mai dal pedante tratti i danari?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Sì; e con sì bello artificio, che non è uomo al mondo che se 'l pensasse.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Oh Grillo, re de gli uomini! Lurco, questi sono i danari che testé ti dicea.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Guardate pure, sciaurati, di non volere cavar i granchi con l'altrui mani e fare la beffa a me, ché 'l disegno non vi riuscirà: intendete?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Lurco, non dubitare, ch'io ti farò 'l partito tanto sicuro, che potrai dire d'averli in mano. Ascolta come.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>E' meglio che per istrada tu me 'l vada dicendo.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Perché? Dove vuo' tu essere?</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>A casa il notaio, il quale vo' far venire prima che altro segua, affine che Gostanza consenta che 'l testamento di sua madre sia aperto, e faccia insieme la rinunzia di quelle robe che da lei mi sono state promesse. E non sta molto di qui lontano.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Andianne. Ma odi cosa che 'mporta, Bisognerebbe, per far la beffa al pedante, trovar una fantina d'amore. Saprestine tu alcuna che fosse pronta?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>A sì buona derrata avessimo noi la vitella, come avremo la vacca. Ma non se' tu da ciò così buono come son io?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Messer no: tu se' il poeta de' chiassi. E poi bisogna ch'io torni qua, per condurre il pedante. Non dir altro, ché questo è tuo proprio ufficio, Moschetta.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>La Zoppina ti piacerebbe?</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>È troppo vecchia. La Loschetta assai più.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Dio guardi! Un unguento da cancheri!</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>E l'altre che son elleno? Sì ch'è gentile e accorta molto.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Orsù non mancherannoci, no. Hacci la Gibetta, la Truffina, la Guinzaietta, la Bruna, l'Uncina, la Volpuccia, la Sadocca, la Zanchetta, e mill'altre che ora non mi ricordo.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>So che n'hai il registro, io. Ascolta, bisognerebbe che fusse simile di persona alla tua Gostanza, sai, Lurco.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Holla trovata io.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Di' mo'.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Loretta.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Non potrebb'essere più al caso; ed è tutta mia, e sta per buona sorte qui di dietro al Palazzo. Sarà ottima; tanto più che fa professione di star sempre pulita. Andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Andiamo, Lurco, ch'io verrò poi a casa per informar monna Nica del tutto, e insegnarle quel che de' dire a messer Patrizio.</p>
           </sp>
@@ -3565,191 +3623,191 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>PATRIZIO, FLAVIO in abito di medico</stage>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Voi siete venuto a tempo, messer Sofronio; e per me, che ho bisogno di voi, e per voi, che larga ricompensa riceverete delle vostre fatiche, se voi sarete quel valentuomo che mi promette messer Antonio.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Signor mio, non so fare belle parole: l'opera sarà quella che, giustamente e con modestia, mi loderà.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Or ascoltatemi. Sto oggi per condur nuora, la quale sta in quella casa che vedete colà.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Oimè!</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Sospirate?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Sospiro per l'acerba memoria che ora in me rinnovate. Ebbi nuora anch'io, ma poco mi giovò averla, ché 'l mio figliuolo unico... Uh, uh, uh.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Pover'uomo! Mi fa compassione: morissi, eh?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>In capo al mese, signor sì.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Gran colpo per certo! Ma quello che non ha rimedio si vuoi portar in pazienza.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Troppo voi dite vero; or seguite.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Io vi diceva ch'ella sta in quella casa; e perché mi vien detto ch'ella è inferma d'un male poco meno che incurabile, procuro di sapere se così è, e se compenso alcuno per guarirla trovar si può. Messer Antonio mi ha detto meraviglie della vostra sufficienza: se vi bastasse l'anima di sanarla, io vi donerei un paio de' più begli e de' migliori e più traboccanti ducati ch'io abbia in cassa.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Oh è troppo gran presente cotesto!</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Ma io so spendere: e largamente, quando n'è tempo, vi so dir io.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Oh si vede, e di che sorte! Ma i pari vostri non si servon per danari; io li voglio servire per cortesia.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Oh siate voi benedetto! Così fatti dovrebbono esser i medici eccellenti, senza avarizia, senza tenacità: vizio, fra tutti gli altri, il più abominevole! Dio lodato sempre sei tu, non son già tocco io di tal peste. Ora a' fatti, eccellente messer Sofronio. La prima cosa, ch'io vorrei sapere, è se 'l suo male è incurabile, o no.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Di questo non vi date pensiero. Non è male alcuno appresso di me incurabile. Quanti, poco men che cadaveri, abbandonati da altri medici, ho io alla pristina sanità ritornati? Anzi in questo, più ch'altrove, s'esercita l'arte mia. Febbri, doglie, catarri, mali ordinari e triviali, non me ne degno. Io sano etici, fisici, matimatici.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Anche i matti?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Signore sì.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Oh che valentuomo!</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>I paraplitici, i parpatetici, gli orpelati, gl'idropici.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Oh questo appunto è 'l male di questa giovane!</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Certo?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Così da tutti vien detto.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Se questo è, io ve la do guarita in un mese.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>E pure dicono che cotesto è un male incurabile.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>A qualche medico da dozzina, ma non a me, che fui discepolo di quel famoso Zafferielle, fulmine degl'ignoranti che non sanno quel che si pescano in medicina.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Sì, eh? Oh che valentuomo!</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Questi miseri stracorari comanderebbono immantenente che quella giovane non beesse. Vedete voi se la 'ntendono. E io vo' ch'ella bea quant'ella può, e del migliore e più generoso vino che abbia. E chi non sa che, s'ella ha sete, bisogna darle da bere? Oltre che il vin potente caccia quell'umor freddo e umido che la gonfia. Ma non de' esser idropisia, voi vedrete.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>L'ho detto anch'io. Oh che valentuomo! Infatti chi vuol farsi eccellente, non uccelli alle borse. Ma onde avviene che nel curare l'idropisia sì grandemente s'ingannano i nostri medici?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Perché non sono filosafi, signor no; e non hanno penetrato nelle viscere della potente natura, come ho fatt'io. Dice il grande Ippocarso, nel terzo dei <emph>Raffianismi</emph> questa bella sentenza: “<foreign xml:lang="lat">Quod sapor nurat</foreign>”.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Parla dunque della mia nuora, eh?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Parla, signore sì; e vuol dire che quello che le sa buono, le gusta; e che 'l buono non è cattivo. <foreign xml:lang="lat">Videlicet</foreign>, che, s'ella gusta del dolce, il dolce concedere le si de'.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>E da che nasce quel gonfiamento, se non è idropisia? Dite di grazia, ché, per quanto mi pare, voi sapete ogni cosa, sapete.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Io vi dirò. Galieno nel primo delle <title>metamorfosi</title>, paragrafo terzo, dice che due cose sono di ciò potissime le cagioni: l'una è la natura, e l'altra il naturale. Questo è ben altro che specchiarsi in un orinale, ordinar quattro pillole e un cristeo: vanità solite di coloro che vanno oggidì mendicando piuttosto che medicando, e non sanno covelle. Il naturale, adunque, e la natura cagionano il gonfiamento. Ambidue sono forti, sono terribili, come quelli che s'empiono d'impetuosi vapori procedenti dalla superessenziale qualificazione degli alimenti: passati prima per la circonlocuzione di tutti i cieli, per gli altissimi flussi e reflussi di tutte quante le stelle, per la indissolubile stabilità dei pianeti, tirando, ricevendo; spingendo, sforzando, corrompendo e alla fin penetrando in concentrazione viscerium, mediante la quadratura del circolo straccapotico e astrolabico.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Oh che valentuomo! Per certo, ch'io mai più non ho sentito sì alte e nuove cose, e concetti, in bocca de' nostri medici.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>La natura nel concavo della Luna prende sua forza; e genera tanta copia di flauti, che bene spesso si sentono sonar di sopra e di sotto. Il naturale, poi, altresì dalla circonfluenza del sole, quando è montato nel carro perpendiculo di Fetonte e ha Venere e Marte per ascendente, riceve tutta la sua possanza; per modo che, mediante l'affissazion di Mercurio, s'indura tanto e s'ingrossa per la multiplicità di vapori ignicoli, ch'egli genera, che niun altro umore del corpo umano gli può resistere.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Oh che valentuomo! So che la intende, io.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Or questi due parosismi tanto grandi ricercano, dentro e fuori, tutta l'incorporatura dell'uomo: e quando un membro e quando un altro, secondo la compassione di ciascheduno, e buona e cattiva, grandemente travagliano. E così, separati l'uno dall'altra, cagionano di gravissime malattie. Ma se per avventura s'incontrano e, a guisa di montoni che cozzino, tutte le forze loro sfogano ne' ventricoli della pancia, fanno quel gonfiamento che non è idropisia, no, ma una massa d'amori genitali, che bisogna risolvere co' rimedi che soli da questo vostro servitore sono conosciuti. E tal m'immagino che sia quella che travaglia la vostra nuora, la quale in poco meno d'un mese vi do guarita.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Oh sia lodato Dio e la vostra virtù! Quanto vorrei che Pistofilo fosse stato presente a questo discorso! Ma voglio che parli con esso voi, perch'egli resti chiaro del vero. Or uditemi, eccellentissimo messer Sofronio. Oggi spero d'aver in casa la giovane; come prima sia giunta, così subito manderò per voi, intendete?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Ma avvertite che non bisogna per niente muoverla da quel luogo dove ella è, signor no. Perciocché quegli umorazzi son tanto fieri, che tutti si metterebbono in moto e la potrebbono soffocare.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>È tanto breve il cammino che, portandola ben co- perta, alterazione di sorte alcuna non sentirà.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Signor no, vi dico: a patto alcuno non è da muoverla. So quello ch'io vi dico; altramenti non me ne voglio impacciare; e ve 'l protesto, no, no.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>È un gran fatto cotesto. Orsù, poiché così consigliate, così faremo.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Bene sta; e credetemi che altramenti non si può fare. Ma s'io dovrò andare in quella casa, a me non basta l'animo d'entrarvi senza il vostro comandamento.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Sì, sì, son io padrone della fanciulla; lasciate a me la cura di questo. Tornatevene a casa messer Antonio e quivi attendetemi; ché, come ne sia il tempo, verrò per voi.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Così farò. Mi raccomando alla signoria vostra.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Addio. Ma i miei libri, messere, cotesto non m'insegnano certo. O sana o inferma, o viva o morta, so ben io che in casa la vo' stasera. Io vo' tornar in Palazzo, per intendere se altro ci resta a fare; poi condurrò Pistofilo al medico, acciocché resti ben persuaso che 'l male di quella giovane non è, com'egli crede, insanabile, e si rechi per ciò a fare più agevolmente la volontà mia.</p>
           </sp>
@@ -3757,7 +3815,7 @@
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>ZENOBIO travestito</stage>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>L'inesplebile desiderio ch'è in me, di trovarmi con la mia dolce Gostanza, mi fa ora sì impaziente che, secondo l'ordine del mio Grillo, non ho potuto più lungamente aspettare, temendo non qualche impedimento si fraponga, come si dice, <quote xml:lang="lat">inter os et offam</quote>. E poi non vedea l'ora di levarmi di scuola, essendo travestito di questo modo; però che dice Nasone: “<quote xml:lang="lat">Non bene conveniunt, nec in una sede morantur, maiestas et amor</quote>”. Talché, avendo nella catedra magistrale deposta la mia toga virile, quanto prima sono uscito di casa, tanto più ch'io portava pericolo d'esser veduto d'alcuno de' miei scolari: i quali ancora ch'io abbia licenziati, ne resta però sempre alcuno qui d'intorno, per bisogno che hanno essi di me e io di loro. Deh, Grillo mio, perché vai tu cotanto procrastinando? Saresti tu mai pentito di farmi questo servigio? O tu, Gostanza, avresti forse sotto qualche altra forma fatto venire a te Pistofilo? Ah traditora, tu mi hai pur ingannato! Ma sarai tu ora, <foreign xml:lang="lat">me Hercule</foreign>, la ingannata: ché, credendo di ricevere il tuo Pistofilo, riceverai Zenobio, che sotto questi candidi panni, quasi novello Giove sotto le piume d'un bianchissimo cigno, sen vien a te, sua Leda. Augurio da te non già meritato, poiché, per un levissimo ragazzotto, lasci colui che altro dì e notte non pensa che di farti co' suoi versi immortale. Intanto a te mi volgo, o Dea de' teneri amori: se de' pur meritar il suo premio l'avere già tante volte con versi elegantissimi la tua deità celebrata e con dottissima elucubrazione, nel mio famoso suggesto, condotto fuor del troiano incendio e delle pugne latine il tuo grande Enea, vieni, benigno nume, e per le fiamme amorose siemi tu ancora previa. Scendi tu ne' miei lombi, e questo tuo tirone all'insueta palestra rendi così robusto, che possa avere plenissima vittoria della spergiura e rubellante nemica sua. Ch'io ti prometto, <quote xml:lang="lat">o hominum Divumque voluptas</quote>, di consecrarti una votiva tabella di cento venustissimi endecasillabi. Né ti sdegnare, o Diva, che per l'addietro io t'abbia disprezzata e la tua dolce cura postabita, abusando l'ignito stimolo del tuo figlio, il quale non ebbe mai potere di penetrare ne' miei precordi; perché fu sempre instituto de' più eccellenti e chiari professori della tanto oggidì celebrata Ciclopedia di sempre postergare le tue lascivie.</p>
           </sp>
@@ -3765,47 +3823,47 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>GRILLO e ZENOBIO</stage>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Certo questo è il pedante: avea paura di non venir a tempo. Oh pover'uomo! Messer Zenobio?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>O Grillo, come mi hai fatto stare un pezzo hesitabundo e dolente? Perché sì tardi se' tu venuto?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Tardo non sono stato io, ma voi troppo sollecito: bench'io vi scusi, ché l'esser diligente è proprio degli amanti. Avete voi li danari?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Eccogli.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>E io vi arreco quegli che vi ho promessi. Vedete come son begli lucidi? Paion d'oro.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Or dove sono li moccichini?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Sono qui: datemi voi i danari.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Oh come sono eleganti! Dono di qualche tua favorita, eh?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Credete d'esser voi solo innamorato? Or prendete. Questo bisogna stringer ben bene, acciocché egli, volendolo sgruppare, vi dia tempo di potervi recar in salvo. Or vedete, non è già una differenza al mondo tra un gruppo e l'altro: chi non s'ingannerebbe?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Oh che beffa solenne!</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Sì, per mia fè, la vedrete. Riponetelo dunque nella tasca a man destra, acciocché nell'uscire l'abbiate assai più pronto per dare a Lurco; e tenete in mano questo dell'oro, finché Lurco l'abbia veduto; poi riponetelo nella tasca sinistra, ma guardate di non errare e ch'egli non se n'avvegga: intendete? Ma ecco Lurco; ritiriamci un poco, per far prova se vi conosce in quest'abito.</p>
           </sp>
@@ -3813,51 +3871,51 @@
         <div type="scene">
           <head>SCENA NONA</head>
           <stage>LURCO, GRILLO, ZENOBIO</stage>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Il non aver trovato in casa questo notaio non mi lascia far pro la felice riuscita de' miei disegni: perciocché di due cose ch'io desiderava, l'una, che sono i danari, posso dir d'aver nella borsa; ma l'altra non mi dà il cuore di poter fare, avanti ch'ella si parta. E benché io abbia lasciato ordine a casa sua che, tornato, subito venga co 'l testamento di Maddalena, è nondimeno sì corto il termine, che dubito assai non tarda sia per esser la sua venuta. Che farò dunque? Guarda, Lurco, quel che tu fai, ché s'ella t'esce di casa, sospirerai. Ma che vo io facendomi paura con l'ombra mia? Se avessi a fare con Patrizio, suo padre, ragionevolmente potrei temere; ma trattandosi con fanciullo innamorato, che dubbio o che sospetto aver se ne de'? E poi non ardirebbono mai né l'un né l'altro di negar quello che tante volte mi han promesso, temendo, e con molta ragione, ch'io non scoprissi tutto l'inganno. Ma non è questo Grillo? Sì per mia fè, e ha seco il tordo che ha dato nella ragna. O burattino mio gentilissimo, vuo' mi tu abburattare un sacco di farina?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>So che di subito l'hai scoperto, io!</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Ti par questa presenza, da potersi nascondere? In ogni tempo e in qual si voglia abito si fa conoscer troppo bene per quel ch'egli è.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>O Lurco, la tua Gostanza, da quel primo dì ch'io la vidi, mi conciò di tal sorte che mi fa smaniare e insanire, come tu vedi.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Tutto quello che fanno gli innamorati, per ottener il fin loro, non può star se non bene. Oh quanti ce ne sono de' satrapi, che fanno peggio di voi!</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Lurco, questi sono li dugento ducati che ti ha recati messer Zenobio, secondo la promessa che ti fu da me fatta in suo nome. Ma perché egli ha voto, in così fatte mercatanzie, di non pagare avanti tratto, e non già certo perché di te non si fidi, vorrebbe che tu ti contentassi di lasciarlo godere, avanti che ti desse i danari. Esso te gli mostrerà e novererà prima che entri nello steccato, tenendogli appresso di sé; e poi non uscirà di casa tua, che profumati te gli darà.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Come vi pare: purché io sia sicuro d'avergli, o prima o dapoi che m'importa? Non so io che sono in mano d'uomini dabbene?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Eccogli dunque ve', in tante doble d'oro. Ti so dir io che sono dei fini; e di qui puoi conoscere se sono innamorato ben bene, dando a te, in un'ora sola, tutto quello che ho guadagnato in tanti anni.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Messer Zenobio mio venerando, begli sono i vostri ducati, e più bel siete voi. Oh questi sono innamorati da farne conto! Alla barba di certi bricconcelli falliti che non ispenderebbono un picciolo. Ma sarà meglio ch'entriamo in casa, a noverargli sotto 'l portico, dove io dirò poi quello che avete a fare per ingannar Gostanza; e non v'incresca d'aspettar così un poco, perché non è ancor l'ora ch'ella ha data a Pistofilo; intendete? Anzi è necessario che voi vi tratteniate in una camera terrena ch'è dalla parte di dietro, perfino che Gostanza, credendosi ch'io non sia in casa, venga nel luogo con Pistofilo concertato. Ché, come prima ci sarà giunta, verrò per voi, e conducendovi a lei, in cambio di Pistofilo sarete ricevuto pur voi: sapete?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>A te sta comandare, Lurco mio bene, Lurco mio refrigerio.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Entrate pur voi, ché non v'ho che far io; e vi de' ben bastare ch'io v'abbia condotto al campo.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p><foreign xml:lang="lat">I prae, sequar</foreign>: che essendo in questi panni, non ho ora a tenere il mio grado, e però va pur innanzi.</p>
           </sp>
@@ -3865,107 +3923,107 @@
         <div type="scene">
           <head>SCENA DECIMA</head>
           <stage>LORETTA, MOSCHETTA</stage>
-          <sp>
+          <sp who="#loretta">
             <speaker>LORETTA.</speaker>
             <p>Come io mi maritassi poi e come restassi vedova, e quale fosse, e prima e dapoi, della mia vita il tenore, se credessi d'aver tempo a bastanza, a pieno ti conterei con tanto tuo gusto quanto forse abbi sentito mai altra cosa.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Anzi, questo ci servirà per trattenimento, poiché, per non esser ancora aperto l'uscio di Lurco, ci bisogna aspettar qui di fuori, finché, aprendolo, ne dia segno d'entrare; e però di' pur, Loretta, quanto tu voi, che mi sarà carissimo di sentire la storia della tua vita, che non può essere se non bella.</p>
           </sp>
-          <sp>
+          <sp who="#loretta">
             <speaker>LORETTA.</speaker>
             <p>Vorrei, Moschetta, che la mia lingua sapesse così ben dire le mie prodezze, com'io le seppi ben fare; che, per mia fè, vedresti un ritratto di femmina sì forbita e di maestra tanto eccellente, che pari, o simigliante, né Roma, né Vinegia, né Napoli mai non l'ebbe: e finalmente, quali dovrebbon esser tutte le donne, ah, ah, ah.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Oh, oh, si vede bene dove sei stata a messa stamane, tanto se' tu allegra e cianci fuor del tuo solito.</p>
           </sp>
-          <sp>
+          <sp who="#loretta">
             <speaker>LORETTA.</speaker>
             <p>Io credo che al nascer mio s'accoppiassero tutti gli influssi che hanno virtù di produrre in donna animo tenacissimo in corpo liberalissimo. Nacqui di madre spagnuola e di padre napoletano.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Lega di finissimo argento.</p>
           </sp>
-          <sp>
+          <sp who="#loretta">
             <speaker>LORETTA.</speaker>
             <p>E nacqui nella città di Vinegia, dove, dopo le ruine del regno di Napoli, ambidue si ritrassero, per fuggir l'ira d'un certo mastro di campo che voleva far impiccar mio padre, per gran somma di danari che aveva in quella guerra truffati. Non ti saprei già dire com'egli da Vinegia passasse poi a Vicenza, perciocché io tanto era bambina allora, ch'appena me ne ricordo. Io cominciai, fin dalle fasce, a dar indizio del mio valore, e prima, per quel ch'io credo, imparai di mentire che di parlare, e prima d'ingannare che di conoscere.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Per Giove, che d'altra tempra non ti voleva oggi, Loretta mia saporita.</p>
           </sp>
-          <sp>
+          <sp who="#loretta">
             <speaker>LORETTA.</speaker>
             <p>Crescend'io poscia di mano in mano e venuta in età di sett'anni, fui più vana che non sono le altre di sedici. Lo specchio era il mio naspo, il pettine la conocchia. Non l'ago da cucire, ma gli spilletti per adattarmi la veste, per conciarmi le treccie, facevano il mio lavorio. In cambio della tela e del lino, la pezzuola, il bambagesso, i ricci, le bionde, i belletti erano, insomma, gli esercizi delle mie mani, i pensieri della mia vita.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Questo è un gran principio!</p>
           </sp>
-          <sp>
+          <sp who="#loretta">
             <speaker>LORETTA.</speaker>
             <p>Non aspettai d'esser giunta ai dodici anni ch'io cominciai a far all'amore, e senza altra maestra ti so dir io che seppi far il mestiere. Talché vedendo mia madre (perché già la sua macina faceva più crusca assai che farina) la buona piega della mia vita, pensò di rinverdire nella mia giovanezza le sue passate prodezze; e avendomi fatte imparare le sette arti liberali, aperse casa a tutta Vicenza, cominciando a tener trebbi d'ogni sorta: io, sempre in mezzo di tutti! Or pensa tu, Moschetta, se, avend'io sì largo campo d'esercitarmi, mi fei perfetta. Se quivi si giucava, er'io capo del giuoco, né mai perdea; se si teneva d'alcuna cosa profitto, er'io sempre il zimbel di tutti: chi motteggiava di qua, chi pizzicava di là; e insomma non andò guari ch'io perdei quanta vergogna avea, in luogo della quale entrò la schiera delle virtù cortigiane.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Oh furor divino, quanto puoi tu! Costei confessa a me, oggi, non ricercata, quello che non direbbe al confessoro. Che confessoro? Anzi quello che non le farebbon dire le funi della colla.</p>
           </sp>
-          <sp>
+          <sp who="#loretta">
             <speaker>LORETTA.</speaker>
             <p>Beato chi potea avere un mio favoruzzo; e più mi valeva un nastro di seta, o un mendico anellin d'oro, o velo, o altra chiappoleria ch'io donassi, che l'usure non vagliono degli Ebrei.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Ma come facevi poi tu a trattenere tanti rivali?</p>
           </sp>
-          <sp>
+          <sp who="#loretta">
             <speaker>LORETTA.</speaker>
             <p>Come? Questa fu l'arte. Lo sguardo solo reggeva a voglia sua quella greggia. Il pianto ebbe sì pronto, la faccia così mutabile, le parole, le maniere e l'animo sì subiti a trasformarsi, che quel mostro marino (come lo chiamano questi cicaloni poeti?) non ebbe tante, né sì subite faccie mai. Io dispensai sì gentilmente le grazie mie, adoperando secondo il bisogno destramente il rasoio, ch'io feci sempre parer leggiero, per grande ch'egli si fosse, ogni male. I troppo arditi con le repulse si reprimevano, i timidi colle mani s'assicuravano, gli appassionati d'un occulto sospiro, i disperati di verisimili promesse, ma però false, si soccorrevano. Le finte lagrime furono la tortura degli avari, l'adulazione de' vani. La gelosia mantenn'io sempre tra loro aspersa leggiermente, per conservare e condire ad uso di sale piuttosto che d'unguento da cancheri, come usano di fare oggidì queste semplici femmine, che non sanno fare il mestiere. Sopra tutto era in quella casa una regola generale: che a tutti i ricchi si dava indifferentemente ricapito; i poveri stavan di fuori. I bei giovani si pascevan di vanità; i poeti si accettavano per trastullo della brigata, i quali però m'erano in tanta noia caduti, che non poteva vedergli più.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>E chi domin potrebbe tollerare pratiche sì noiose? Colpo colpo ti sfoderano qualche frottola, e come sansughe ti s'attaccano e ti seccan le orecchie. Guai a colui che digiuno dà lor tra piedi. E come sono agevoli a cadere nel pecoreccio, e se ne ubbriacano più che non hai fatto tu stamattina, Loretta!</p>
           </sp>
-          <sp>
+          <sp who="#loretta">
             <speaker>LORETTA.</speaker>
             <p>Queste furono l'arti mie; e con questo alternare, quando d'orza e quando di poggia, scorsi il pelago della mia giovanezza: ahi, con troppo sfortunato successo, perciocché, venuta al tempo e alla prova di maritarmi, trovai che tale mi vagheggiò per amante che per moglie qual vipera m'abborriva. Talché fui costretta d'accompagnarmi a quel vecchio che poco fa ti diceva, il qual avesse piuttosto sofferenza d'esser governato che cura di governarmi; poiché, solo fra tanti drudi, avea bastato l'animo a lui di sposarmi. Ben è vero ch'egli vi durò poco, e morissi.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Appena mille giovani, non che un vecchio solo, vi sarebber durati.</p>
           </sp>
-          <sp>
+          <sp who="#loretta">
             <speaker>LORETTA.</speaker>
             <p>E 'l buon pecorone mi lasciò anche tanto che, se fossi stata savia, beata me! Ma poscia ch'io restai vedova e ch'io mi vidi in una tale ampiezza di vita, sciolta dalla cura materna e dall'ubbidienza del marito, reina mi parve d'essere; e pensai che 'l mondo non dovesse né mancare, né nuocere, né noiarmi giammai. Or quivi quel ch'io facessi, che vita fusse la mia, com'io mi scapricciassi a mio modo, troppo lunga novella sarebbe da raccontarti. Ma per venire al fine, ti dirò solo che, per gastigo delle passate mie vanità, volle il cielo ch'io m'intrigassi d'amore (quel che a' dì miei non m'avvenne mai più) con un rompicollo che, facendo di me quel medesimo che avea già fatt'io di mill'altri, in men d'un anno mi consumò tutta quella facoltà che m'avea lasciato il marito mio; e per ultima mia ruina se ne fuggì, portandomi via mille ducati, che sarebbono stati sostegno del viver mio. E questi furono quelli che testé ti diceva avere anche speranza di ricovrare. Né altro il manigoldo mi lasciò di se stesso che pianto, pentimento e dolore, e così fino e gran mal francese che per cinque anni sono stata nel letto.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Buon dì! A te questa, pedante.</p>
           </sp>
-          <sp>
+          <sp who="#loretta">
             <speaker>LORETTA.</speaker>
             <p>Talché, ridotta in estrema miseria, s'i' ho voluto vivere, m'è convenuto andare a Vinegia, dove tu prima mi conoscesti, a vendere il corpo mio bene spesso per un marcello, dove già un solo mio sguardo valse un tesoro.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Con tale fine m'hai tu fatto così dolce discorso parer amaro. Povere femmine! Se voi sapeste conservar le vostre ricchezze, beate voi! Ma è tempo che tu ten vada, Loretta, ché veggio aperto l'uscio di Lurco.</p>
           </sp>
-          <sp>
+          <sp who="#loretta">
             <speaker>LORETTA.</speaker>
             <p>Quando ti piace.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Va destra, ve'; e avvertisci di tener ben a mente il nome di Pistofilo, sai? E come prima sarai sbrigata da quella bestia, vientene via, acciocché egli per mala sorte non ti vedesse; e io me n'andrò a trovare il padrone. Rimbeccami il contrapunto; hai tu fatto per modo che quel cordovano non s'accorga della banda sbasita?</p>
           </sp>
-          <sp>
+          <sp who="#loretta">
             <speaker>LORETTA.</speaker>
             <p>A Siena son andata, e holla messa in campagna, con una lenza fratenga.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Calati dunque nel cosco, e portati bene, sai? Ché monel fra tanto andrà a canzonar co 'l grimo.</p>
           </sp>
@@ -3976,7 +4034,7 @@
         <div type="scene">
           <head>SCENA PRIMA</head>
           <stage>NICA</stage>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Lodato Dio, che abbiamo pur trovato scampo a sì gran pericolo; e benché, dovendo io intervenire a tal fatto, la cosa non è sicura che sopra a me alla fine tutto il male non si riversi, nientedimeno è pur meglio aver danno che vergogna; tanto più che Cassandra, perdendo questa, non perde la sua ventura. E così avrem coperto e prolungato il suo parto; il quale purché non venga in luce, poco mi curo di tutto 'l resto. Non saprò io dir a suo padre che Pistofilo, d'altra femmina invaghito, l'odiava, l'abborriva, non la voleva? E che la povera figliuola temeva di non morire in casa di quel vecchio tenace? No, no, purché la nostra barca si salvi da questo scoglio, non mancheranno porti da ricovrare. Ma ecco a tempo messer Patrizio.</p>
           </sp>
@@ -3984,59 +4042,59 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>PATRIZIO, MOSCHETTA, NICA</stage>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>O Moschetta mio caro, quanto ubbligato ti sono, poiché le tue parole hanno potuto quello con Pistofilo adoperare che a me, il quale pur gli son padre, è stato sì malagevole ed era per avventura impossibile d'ottenere</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Padrone, non è sempre ben fatto, né si vuol in tutte le cose, né con tutti, metter mano alla forza: massimamente nel dar moglie a' figliuoli, co' quali, se troppo si tira l'arco, e' si rompe. Se io con le piacevolezze non l'avessi acquistato, o egli non l'avrebbe mai presa, o guai a voi che gliel'aveste condotta in casa; e misera lei, che non moglie, ma schiava sarebbe stata</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Ma non è questa Nica? Ormai s'appressa il tempo di dar Cassandra. Monna Nica, che fate voi qui di fuori? Vi andate forse immaginando qualche buona chimera per negarmi la nuora mia? Fate presto, ché la giornata spira</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Messer Patrizio, non fu mai cosa al mondo che, senza aver contrasto, perfetta far si potesse; né colui forte o robusto chiamar si può, che molte volte al paragone non sia venuto, e fatta prova del suo valore prima non abbia. Se io, fin da quel primo dì che mi faceste istanza d'aver Cassandra, ve l'avessi ceduta, non avreste già voi per ottenerla tentato il mezzo della Giustizia, che però solo, essend'io donna forestiera, mal pratica e gelosa di lei, che amo come figliuola, e come tale fummi raccomandata, era solo bastevole a giustificare appresso il padre di lei nel guardarla, nel custodirla, il debito mio. Se fin qui dunque ve l'ho negata, non è stato difetto d'animo interessato o mal disposto verso di voi; ma piuttosto un acuto e latente stimolo che v'avesse a render tanto sollecito e aguzzarvi sì fattamente l'ingegno, a trovar ogni modo possibile per averla, che la necessità del concederla fosse per onestare la causa mia. Or che la vostra istanza, mediante la industria mia, si è già fatta, com'io voleva, aperta e ragionevole forza, non solo non intendo di più contendere, ma vengo ad offerirvi Cassandra, più vostra, ora, che mia: la quale come nuora amorevole sarà pronta di entrarvi in casa e ubbidirvi ad ogni vostro piacere</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Co 'l bastone si gastigano i pazzi, Moschetta, sai? Monna Nica, siccome negar non posso che l'ostinazione vostra non mi sia stata di gran travaglio cagione e, per dirvi il vero, non senza molto sospetto ancora di qualche vostro interesse, così ora confesso che questa larga dimostrazione che voi mi fate, o sia di bontà, o sia di paura (che io non vo' ora cercar più innanzi), ha scancellato in me tutto quel mal talento che, con molta ragione, contra voi avea conceputo. E vi prometto di farvi da quinci innanzi conoscere che io non so meno scordarmi i dispiaceri emendati che vendicarmi de' ricevuti: in fede di che questa mano vi sia certissimo pegno. Andate a porre in ordine la fanciulla, che quanto prima voglio che venga a casa, mentre che Pistofilo si trova in questa buona disposizione; sai, Moschetta?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Sì, sì, è ben fatto, ché talora non si pentisse, ah, ah, ah</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Ma non crediate già che co' suoi piedi possa far ella questo ancorché poco viaggio, siccome quella che ordinariamente non si move del letto; e in particolare, non bisogna che vegga l'aria, ché, sopra ogn'altro disordine, questo come più detestabile le hanno sempre tutt'i medici proibito; e, quel ch'è peggio, quanto più si travaglia, tanto più le dà noia un certo subitaneo accidente che spessissime volte, e non senza pericolo della vita, fieramente l'assale</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>La faremo portare sì ben coperta e sì comoda, che né l'aria né 'l moto non potrà nuocerle. Or mi sovviene che quel valente medico mi predisse il pericolo che portava nel moto</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Abbiamo in casa noi una seggia che fece far appunto suo padre per questo effetto, quando la conducemmo, accomodata assai maestrevolmente a uso di trabacca, per potervi adattar sopra o drappo, o lenzuolo, o altra cosa simile; ed è sì bene all'ordine, che ad ogni nostro talento potrem servircene. Anzi, per dirvi tutto, ho già fatto che la fanciulla s'è messa all'ordine al meglio ch'ella ha potuto, e altro non aspetta se non ch'io vada per essa</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Or non perdete tempo</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Comandate, di grazia, a questo vostro fante che ci venga a por mano, perciocché non basta un solo a portarla</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Sì, sì, va via, Moschetta</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Sapea ben io che senza me non si poteva far questa festa. Se si trattasse d'andar a tavola, Moschetta ci sarebbe per nulla</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Se la paura della pena non ti avesse fatto risolvere, indarno avrei potuto aspettare che dirittura d'animo ti movesse. E per dirti, sorella, son vecchio anch'io; ma mi sono contentato di crederti cotesta tua simulata buona coscienza, poiché nulla m'importa. Holla io fatta divenir mansueta? Così si fa. Or come prima Cassandra mi sarà in casa, farò ogni cosa perché Pistofilo si trattenga con esso lei, né la lasci finché, fatto venir il prete, solennemente la sposi. E mentre che essi staranno insieme, farò condurre a casa le robe, acciocché non andassero per mala sorte in commenda. E quel notaio appunto, che mi dié copia del testamento di madonna Ginevra, mi diede ancora quella dell'inventario. Io l'ho pur vinta. Infatti non bisogna cozzare con questa testa. Ingannar me, eh? Bisogna ben che sia cima d'uomo. Che dirà ora quella femmina maledetta di mogliama, che tutto dì mi rimbrotta, tutto dì mi rimprovera ch'io non so far i fatti miei punto punto? e che mi lascio uccellar da questo e da quello, e che questa pratica non mi sarebbe mai riuscita? Manda'la ieri a bello studio alla villa, perché non mi stesse a intronar il cervello. Ma eccogli.</p>
           </sp>
@@ -4044,155 +4102,155 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>GRILLO, MOSCHETTA, PATRIZIO, NICA, CASSANDRA, TRAGUALCIA</stage>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Va destramente, Moschetta; che credi tu di portare?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>O vigliacco, portassi tu così sodo. Non vedi che non puoi reggerla sulle braccia?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Eh, per l'amor di Dio, non v'affrettate tanto. Accordatevi nel portarla soavemente; e guardate di non la scuoter, ch'io temo...</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Oh gli è costui che cammina troppo.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Il difetto sta nelle tue braccia, e non nelle mie gambe, sai, Grillo?</p>
           </sp>
-          <sp>
+          <sp who="#tragualcia">
             <speaker>TRAGUALCIA.</speaker>
             <p>O messere, è egli di vostro consentimento ch'ella si levi di questa casa?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Sì, sì, lasciala pur condurre.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Che vuoi tu ora dir, manigoldo? Che quasi mi hai fatta rinnegar la pazienza!</p>
           </sp>
-          <sp>
+          <sp who="#tragualcia">
             <speaker>TRAGUALCIA.</speaker>
             <p>Avete voi a riprendermi perché fo il debito mio?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Dio vi salvi, figliuola mia. Io son il suocero vostro: come vi sentite voi? Bene?</p>
           </sp>
-          <sp>
+          <sp who="#cassandra">
             <speaker>CASSANDRA.</speaker>
             <p>Non troppo, padre mio caro.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>E che volete voi fare di quella ampolla che avete in man, monna Nica?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Questo è un rimedio mirabile al suo tanto pericoloso e subitano accidente; e trovollo un eccellente medico raugeo. Se questo non fosse stato, misera lei!</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>(Or è il tempo).</p>
           </sp>
-          <sp>
+          <sp who="#cassandra">
             <speaker>CASSANDRA.</speaker>
             <p>Oimè, oimè, monna Nica, aiutatemi, ch'io son morta.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Oh sfortunata me! Non dubitare, figliuola mia, no.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Sia maladetto, non ve 'l diss'io?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Entra subito in questa casa; va tosto su. Oh radice del cuor mio! Ci son donne in questa casa? Un po' di fuoco, presto; state di fuori, voi uomini.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Questo è un gran male, per certo.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Padrone, non dubitate. Voi vedrete: come prima questa fanciulla sia in casa vostra, sarà guerita.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Scaldate voi di grazia quel panno, mentre io scaldo l'unguento; e venite subito. U, u, poverina, non dubitare figliuola mia; non dubitare.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>E come adopera ella quel liquor così raro?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Le n'unge il ventre, e gli pon sopra una pezza di lino calda; e subito torna in sé. Ora ella de' esser in agonia.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Questo è un mirabil segreto!</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Se ciò non fosse stato, non sarebbe viva a quest'ora. È fatto di muschio, d'ambra e di balsamo: cosa preziosissima! </p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>E che male è cotesto suo, caro Grillo?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Che so io? Dicono i medici che è stato un certa cosa penetrativa che gonfia la matrice. Una carnosità, no: una ventosa... che so io.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Sì, sì, t'intendo. Tu vuoi dire una forte ventosità della matrice: quel medico me lo disse. Un flato, sì, un flato.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>(Fu Flavio, e non un flato, ah, ah, ah).</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Su, figliuola mia; su, da valente donna. Entrate voi a levarla: non udite, eh, che con l'aiuto di Dio le son tornati gli spiriti?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Andiam, Grillo, ch'ella ci chiama.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Oh come ha fatto presto! Se quella ampolla si perdesse, guai a lei! A quante infermità è sottoposto questo nostro corpaccio!</p>
           </sp>
-          <sp>
+          <sp who="#tragualcia">
             <speaker>TRAGUALCIA.</speaker>
             <p>Padrone, ho io a far più nulla per voi?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>No, no, fratello, va pure.</p>
           </sp>
-          <sp>
+          <sp who="#tragualcia">
             <speaker>TRAGUALCIA.</speaker>
             <p>E chi mi paga?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Non accade far più parole, ché di te sono soddisfattissimo.</p>
           </sp>
-          <sp>
+          <sp who="#tragualcia">
             <speaker>TRAGUALCIA.</speaker>
             <p>Che danza è cotesta vostra? Il tutto sta che sia io di voi.</p>
           </sp>
@@ -4200,39 +4258,39 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>NICA, PATRIZIO, GRILLO, TRAGUALCIA</stage>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>O che fatiche, messer Patrizio! Se 'l darle marito non la guarisce, son disperata io della salute sua. Ma vi so dire che a lei ancora vengono i sudori della morte. Voi la vedrete talmente infocata nel volto, che stupirete: perciocché que' vapori sì terribili di matrice le vanno al capo e la infiamman di fuori, mortificandola però dentro. Vi parrà sana e gagliarda più di noi altri. Ma gran ventura è stata che quell'uscio sia stato aperto!</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Sì, in verità. Orsù, andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#tragualcia">
             <speaker>TRAGUALCIA.</speaker>
             <p>Padrone, datemi la mia mercede, e finiamola.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Non gli date nulla, ch'egli ha bevuto più che non vale.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Non tengo questi conti io, stiamo freschi: va pure pe' fatti tuoi.</p>
           </sp>
-          <sp>
+          <sp who="#tragualcia">
             <speaker>TRAGUALCIA.</speaker>
             <p>Vi fo sapere che vo' esser pagato.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Vuoi tu ch'io t'insegni un bel passo? O levati di qua, se non che le tue braccia te 'l sapran dire, se tu m'aspetti.</p>
           </sp>
-          <sp>
+          <sp who="#tragualcia">
             <speaker>TRAGUALCIA.</speaker>
             <p>Voi mi pagherete, se sarà giustizia in questa terra, bricconi, svergognati.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Ma il medico che m'aspetta? Che 'mporta? Non ho per ora più bisogno di lui, poiché Pistofilo si contenta. Ci consiglieremo poi, egli e io, se l'abbiamo a chiamare, o no.</p>
           </sp>
@@ -4240,7 +4298,7 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>RADICCHIO</stage>
-          <sp>
+          <sp who="#radicchio">
             <speaker>RADICCHIO.</speaker>
             <p>Colui che fu il primiero a spor la vita alle tempeste del mare aveva ben il petto d'acciaio. Io per me, poiché 'l cielo m'ha campato da morte, per non tentar mai più quel mostro sì terribile e sì spaventevole, torrò anzi a non vedere mai più Raugia, ancorché mia patria, e vivere in queste parti il rimanente della mia vita. Non credo che mi si levi mai più del capo il travaglio e lo stordimento del mare. Ma chi saprà insegnarmi la casa di questa Nica, governatrice della figliola del patron mio?</p>
           </sp>
@@ -4248,59 +4306,59 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>MOSCHETTA, GRILLO, NICA, RADICCHIO</stage>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>La nave è giunta in porto. Questo è il guadagno che tu hai fatto, avarone. Non ti diss'io che altamente mi sarei vendicato? Grillo, statti con Dio: è forza ch'io vada a bere un tratto, ch'io muoio di sete.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Va pur Moschetta, ché fra poco ti seguo anch'io.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Tanto farò.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Ma chi è costui vestito da Levantino?</p>
           </sp>
-          <sp>
+          <sp who="#radicchio">
             <speaker>RADICCHIO.</speaker>
             <p>Costoro, forse, me ne sapranno dar indirizzo. O valentuomo, saprestimi tu insegnare dove abiti una monna Nica raugea?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Che ci va, monna Nica, che costui è fante di Flavio, il quale, per buon rispetto, avrà voluto mandar innanzi costui? Dimmi, di grazia, chi ti ha inviato qua, un raugeo?</p>
           </sp>
-          <sp>
+          <sp who="#radicchio">
             <speaker>RADICCHIO.</speaker>
             <p>Maisì, per imparar la casa di detta Nica; ché da Vinegia siamo giunti mezz'ora fa.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Oh lodato Dio! E' verrà pure una volta. Questa è la donna che vai cercando.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Oh felice giornata! Or venga che mal si voglia, di nulla più non tem'io. E dove è egli, valentuomo?</p>
           </sp>
-          <sp>
+          <sp who="#radicchio">
             <speaker>RADICCHIO.</speaker>
             <p>In sala di Palazzo, che quivi appunto m'aspetta.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Or va volando, e menalo in questa casa, sai? Ché quivi Cassandra sua troverà. Ma va tosto, di grazia.</p>
           </sp>
-          <sp>
+          <sp who="#radicchio">
             <speaker>RADICCHIO.</speaker>
             <p>Tanto farò.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Voi, monna Nica, portatene la novella a Cassandra, e poi tornate a casa a preparar la stanza per Flavio, mentre io vo in piazza a provvedergli da cena; e poi mi fermerò alla Camatta, dove abbiamo a ritrovarci Moschetta e io; intendete?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Intendo. Questo si può ben dire un giorno di primavera, or turbato, or sereno. Ma sia lodato Dio, poiché 'l migliore ha pur vinto.</p>
           </sp>
@@ -4308,7 +4366,7 @@
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>LORETTA.</stage>
-          <sp>
+          <sp who="#loretta">
             <speaker>LORETTA.</speaker>
             <p>Tutte monete d'oro: oh felice Loretta! Oh pover'uomo! So ch'hai pagato caro il tuo fallo, io; e quanto a me, benché tutta ne sia dolente e pesta della persona, al sicure te la perdono. Oh che be' pezzi d'oro! Mentre egli facea le doppie, e io rubava le doble. Oh ventura! Oh giornata felice! Chi crederebbe mai che per un nulla avessi, da un pidocchioso come costui, tratta sì ricca paga, quando da questi miseri cortegiani, tutti vestiti di seta e d'oro, non ho mai guadagnato più d'un fallito mocenico o un marcello? E forse che non sono solleciti? Or vo' andarmene a casa; e tolto il meglio ch'io abbia, tirar alla volta di Vinegia e godermi co 'l mio dolcissimo Taccola, allegramente, questa ventura.</p>
           </sp>
@@ -4316,7 +4374,7 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>NICA</stage>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Che tesor di San Marco? Che casnà del Gran Turco? Per mia fè, se io le avessi arrecato quant'oro e quante gemme portano o siano mai per portar le flotte indiane, non credo che sì allegra fosse mai stata: se partoriva in quel punto, non sentiva dolore. Oh quanto bene! Oh quanto amore! Oh quanto giubila! Oh quanto è lieta! Or vo' ire a dar un poco di buon assetto alla casa e preparare la stanza a Flavio; e poi tornerò a Cassandra, la quale, come si faccia buio, condurremo subito a casa.</p>
           </sp>
@@ -4324,163 +4382,163 @@
         <div type="scene">
           <head>SCENA NONA</head>
           <stage>LURCO, ZENOBIO</stage>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Voi potete appena reggervi in piedi; o che valentuomo!</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Oh infelice Tantalo; oh <foreign xml:lang="lat">cornu sine copia</foreign>! oh <foreign xml:lang="lat">copia sine cornu</foreign>! </p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Che cosa v'è incontrata? Che male avete messer Zenobio?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>O Lurco, <foreign xml:lang="lat">vox faucibus haeret</foreign>. </p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>(Qualche disgrazia gli sarà certo avvenuta, con quella volpe maliziosa di Loretta. Ma saprollo da lei. Or voglio attender a quello che importa più).</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Lurco, vo' andarmi a riposare; piglia i danari, e vatti con Dio.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Andate pure, messer Zenobio. Ma ditemi, son ben elleno tutte buone d'oro e di peso, eh, queste doble?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>(<foreign xml:lang="lat">Deus bene vertat</foreign>). Sono quelle medesime ch'io ti diedi testé, addio.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>O messer Zenobio, non vi partite sì tosto, no.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Lasciami andare, caro fratello.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Oh! questo non è oro; mi pare ottone, a me. Che ne dite?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>(<foreign xml:lang="lat">Perii</foreign>). Come ottone? È quell'oro medesimo che testé ti mostrai: riconoscilo al moccichino, sì certo.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Non vi partite, vi dico; ché non voglio ottone per oro, io. (Vo' fare di costui quel che fa la gatta del topo). Che vorrà esser questo? Messer Zenobio, sarebbonsi eglino mai trasformati?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>(<foreign xml:lang="lat">Salva res est</foreign>). Per Giove, ch'Edipo sei, non Lurco.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>E cotesti miracoli s'usan poi?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Come, se s'usano? Non hai tu lette le <title>Metamorfosi</title>? Leggile, e vedrai cose molto più stupende di queste. Piglia da me l'esempio: chi direbbe ch'io fossi ora Zenobio? E pur son desso.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Affè ch'ella mi entra, s'egli è vero quel che voi dite; e io credo a un par vostro, che sapete ogni cosa.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Oh sta bene; lasciami dunque andare, che, siccome io tornerò Zenobio, così essi torneranno altresì elegantissime doble d'oro.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Oh come scaltro! Sapete quello che vi vo' dire? La vostra tasca de' aver una sì fatta virtù. Proviamo un poco se quell'altra avesse forza di farle ritornar d'oro.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Deh lasciami, ti prego, e abbimi compassione, Lurco, ché io son tutto molle. Vuoi tu ch'io muoia?</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Lasciatemi provare solamente, se questo giova.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Eh non far Lurco, ché la mia tasca non può avere una tal virtù.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Non ci mettete la mano voi, ché tutta potreste ben levarle la forza. Lasciate far a me.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p><foreign xml:lang="lat">Ehu, ehu</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Che cosa avete, che vi duole?</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Tu 'l vedrai bene.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Levate voi la mano di qui, dico, e lasciate ch'io vi ponga la mia, se volete; e poi anche se non volete.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p><foreign xml:lang="lat">Nec mihi, nec tibi</foreign>. </p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Questa non è quella dell'oro.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Né quest'altra, ch'è peggio.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Che dite voi? Oh questa sì sarebbe da registrare: che l'uccellato foss'io!</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Hai tu ora provato assai? Lasciami dunque andare.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Eh fermati, se non vuoi ch'io ti lasci andar su 'l mostaccio una mano che ti tragga i denti di bocca.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>A un par mio, Lurco? <foreign xml:lang="lat">Ah scelus indignum</foreign>!</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Tu mi hai a trovar dugento ducati, sai? E ti dico su 'l saldo, se io credessi di spogliarti tutto da capo a piedi.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Ah Lurco, <foreign xml:lang="lat">miserere, miserere</foreign>, che sono stato ingannato anch'io.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Ingannato son io, ribaldo: a questo modo, eh? Io vo' condurti a Moschetta, il quale ha detto d'esser alla Camatta; e sappi certo che un di voi mi ha a pagare, scellerati, ghiottoni.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Deh, Lurco, lasciami almen mutar di panni, ch'io mi sento propriamente andar in diliquio.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Va là, manigoldo; e questa pigliati per caparra.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Oimè, l'osso maestro, oimè.</p>
           </sp>
@@ -4488,19 +4546,19 @@
         <div type="scene">
           <head>SCENA DECIMA</head>
           <stage>BERNARDO, RADICCHIO</stage>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Insomma, quand'io vo bene fra me medesimo discorrendo delle cose del mondo, trovo che la prudenza umana è piuttosto una cotale prerogativa usurpata dagli uomini che quella certa regola del governo che altri vanamente pretende: imperocché tanti son gli accidenti che s'attraversano, e quasi sempre i disegni nostri interrompono, che si può sempre, o temere da faccenda ben consigliata riuscita infelice, o sperare da mal guidata impresa prospero fine. Talché possiamo fermamente concludere che altra più sicura prudenza aver non possiamo che una salda rettitudine di coscienza e fermo proponimento di ricevere ogni fortuna, o buona o rea ch'ella sia, con animo ben composto, lasciando poi la cura del resto a chi meglio di noi la intende e di lassù ci governa. Quand'io mandai Cassandra, mia figliuola, qua per sanarsi, tutti gli amici e parenti miei di così fatta deliberazione mi biasimavano, allegando il cammin malagevole, la stagione pericolosa, l'infirmità grave e molte altre opposizioni; alle quali se io, come forse richiedeva il dovere, avessi prestate orecchie, Cassandra mia non sarebbe ora né tanto ricca, né sì ben maritata, né forse viva. E certo è stato voler di Dio che così presso al luogo, dove ella nacque, abbia trovato sì buono e sì onorato partito. Ma dimmi, qual è la casa di Cassandra?</p>
           </sp>
-          <sp>
+          <sp who="#radicchio">
             <speaker>RADICCHIO.</speaker>
             <p>Questa mi fu mostrata da un servitore, secondo che mi parve, di casa propria.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Entriamo dunque.</p>
           </sp>
-          <sp>
+          <sp who="#radicchio">
             <speaker>RADICCHIO.</speaker>
             <p>Ella appunto si trova aperta.</p>
           </sp>
@@ -4508,7 +4566,7 @@
         <div type="scene">
           <head>SCENA UNDECIMA</head>
           <stage>PATRIZIO</stage>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Pistofilo è stato appunto come quel sonatore, il quale, prima che s'inducesse a sonare, fu necessario che egli s'accordasse la cetra; poi sonò tanto che, per farlo tacere, bisognò rompergliela sulla testa. Chi vide mai cervello più di lui ostinato nell'odiar quella giovane? Che certo, se io m'avessi lasciato vincer dalla disperazione, avrei dato nel pazzo. Ora è cosa da non credere come egli le fa vezzi; diresti ch'egli ne fosse stato lungamente invaghito. Subito che fu in casa, serraronsi in una camera, dove ancora sono; ed essend'io stato all'uscio origliando, hogli sentiti sonar a doppio, ti so dir io. Tanti risi, tante tresche e tante moine, che, in buona fè, m'hanno fatto mezzo mezzo risentire, così vecchio com'io mi sono. Ma ella è una bellissima giovane, e ha piuttosto viso da far infermo altrui che d'esser inferma ella. Certamente se Pistofilo l'avesse da principio veduta, averebbe quel medesimo fatto che ora fa. Per me, non credo che altro medico ci bisogni. Pistofilo l'ha guerita. Ho pur condotta a fine la bella impresa! Io son pur tanto contento, e che la cosa mi sia sì ben riuscita, e che la giovane mi sia in casa, e che Pistofilo se la goda ben sodisfatto. Or son sicuro, or son fuori d'ogni pericolo. Insomma io l'ho saputa condurre da valentuomo. Oh felicissimo giorno! Io scoppio dell'allegrezza. Voglio mandar una giustina di pane all'orfanelle: cappita, bisogna nell'allegrezze ricordarsi della limosina, e largamente, come fo io. Ma fin qui non ho fatto nulla; e di questa favola, che cominciò da tragedia, non manca se non fare l'ultimo atto. Bisogna che i danari vengano a casa. Farò domattina fare il mandato a nome di Pistofilo e di Cassandra, e subito me n'andrò a Vinegia a levar del banco i venti mila ducati. Ma questo è un poco mobile, se 'l valor delle robe non avanzasse la quantità della lista: la voglio un poco trascorrere, prima ch'io vada a riconoscerle dentro.</p>
           </sp>
@@ -4516,187 +4574,187 @@
         <div type="scene">
           <head>SCENA DUODECIMA</head>
           <stage>BERNARDO, RADICCHIO, PATRIZIO</stage>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Tanta istanza mi faceva messer Patrizio di queste nozze e tanta sollecitudine ne mostrava, ch'io mi credeva di trovar Cassandra già gravida, non che sposa; e trovola ancora in casa, sola, male in assetto e, per quel che posso vedere, tanto malinconosa e poco meno che stupida, ch'io non so quello che me ne debbia pensare, se non ch'ella di queste nozze sia mal contenta.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>(Fin qui, son quasi tutte stracci e stoviglie).</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>All'entrar mio nella camera parve che sbigottisse: vedestila tu, Radicchio?</p>
           </sp>
-          <sp>
+          <sp who="#radicchio">
             <speaker>RADICCHIO.</speaker>
             <p>Io era di dietro a voi, e non potetti avvertirlo. Ma forse il sangue per l'allegrezza di vedervi le si commosse.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Abbracciola poi, e le chiedo com'ella sta, ed essa appena che mi risponda, e sì confusamente ancora che non la 'ntesi. Pareva che non sapesse formar parola. Io torno a domandarla: <add resp="#ed">se</add> si è pur ancora sposata, e perché è così sola e di malavoglia, e dove è Nica; ed ella ad ogni cosa mi risponde sì freddamente, che ho potuto a gran fatica trarne cosa di certo. Quanto mi meraviglio che Nica sia fuor di casa! Dalla quale, senza alcun dubbio, avrei potuto rinvenir di ciò la certezza. Tu va, Radicchio, alla dogana, e libera le robe.</p>
           </sp>
-          <sp>
+          <sp who="#radicchio">
             <speaker>RADICCHIO.</speaker>
             <p>Tanto farò.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>(Val più la carta che la scrittura: pur non sarà se non bene di farle condurre a casa. Ma chi è costui vestito da forestiero? Ha viso di Levantino, e d'uomo di conto).</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>In questi contorni bisogna che abbia la stanza sua, per quello ch'egli mi scrisse, che stava dalla casa di mia sorella poco lontano. Ecco chi forse saprà insegnarlami. O gentiluomo, saprestemi voi dire dove abiti messer Patrizio degli Orsi?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Perché? Vorreste voi forse alloggiare con esso lui?</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Forse che sì.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>(Guarda un poco chi mi viene a sturbare in tempo di nozze). E chi siete voi? Che cosa avete da trattare con esso lui?</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Di questo non vi pigliate pensiero voi; ma solo, se vi piace, insegnatemi la sua casa.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>(Fa buon animo, che quel “forse” mostra che non è risoluto). A dirvi il vero, son io Patrizio degli Orsi; ma son un poco impedito.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Voi siete messer Patrizio?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Sì, se vi piace.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>O messer Patrizio, come ha forza di trasformarci l'età! Poiché, levata ogni memoria delle nostre prime sembianze, né voi avete me ravvisato, né io voi; e pur siam lungamente stati compagni e, posso dir, fratelli cari e amorevoli insieme! Io son Bernardo Cattari.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Voi siete messer Bernardo? O dolcissimo da me sommamente amato e desiderato messer Bernardo, l'arrivo vostro mancava alla consolazione di questo giorno. Perdonatemi, io vi prego, se, non conoscendovi, fui tardo a palesarmivi. Messer Bernardo mio caro, quanto vi vegg'io volentieri! Credo bene di parer tanto diverso a voi, quanto voi siete paruto a me, da quell'età sì fresca nella quale ci godevamo sì dolcemente.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Il tempo vola, messer Patrizio, e sì di nascosto, che non ce n'avveggiamo se non quando si viene a così fatti paragoni: o de' nostri figliuoli che crescendo ci dan licenza, o di noi medesimi ricordandoci del passato. Mi contento io nondimeno di questa mia vecchiezza; e ringrazio Dio che m'abbia preservato a vedere in sì stretta e sì desiderabile parentela terminar la nostra amicizia, parendomi che più felicemente io non potessi chiuder il corso della mia vita che con l'acquisto di queste benedette nozze.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Se voi, che 'l sangue e la roba vostra dato mi avete, stimate sì gran ventura l'esservi in parentado meco legato, quanto la debbo più stimar io che ho donna sì ricca e sì onorata ricevuta da voi? Ma non mi scriveste voi, dianzi, che, per esser allora rettore della vostra città, non v'era lecito di partire?</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Ho finito l'uffizio, il qual non dura se non un mese, e subito son venuto; e sarei stato anche qui molto prima, se 'l vento non mi avesse impedito.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Avete dunque travagliato in mare, eh?</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>E di tal sorte che siamo stati per affogare. Noi uscimmo del porto con un levante assai ben gagliardo, che buon viaggio ci prometteva, ma non sì tosto passammo i nostri Pettini che cessò; e in sua vece sorse un maestro, il quale, ancorché fosse contrario, non era però sì fiero che ci togliesse il prender porto in Lesina, dove stemmo duo dì, fin che vento migliore ci richiamasse al cammino. Il terzo giorno, invitati da un piacevol sirocco, facemmo vela, ma tanto solo durò quanto noi potemmo ricoverare nel porto di Sebenico. L'altro dì noi scorremmo pur fino a Zara, e di là, non senza qualche speranza di miglior tempo, ci assicurammo di passar il Quarnaro; ma non sì tosto fummo a mezzo del golfo, che si scoperse una tramontana così terribile che, rispingendoci in alto mare, ci fracassò l'antenna e disarmocci gran parte della sponda sinistra. Noi ci sforzammo un pezzo di stare forti, ma finalmente, vinti dalla tempesta, lasciando la gomona per occhio, ci mettemmo a vele basse, scorrendo, fin che piacque alla bontà di Iddio che, scoperto il porto d'Ancona, pigliammo terra, ma tanto afflitti, che i nocchieri medesimi non potevano regger più. Quinci poscia partimmo felicemente, e in una sola velata fummo questa mattina nello spuntar dell'alba a Vinegia.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>È dunque bene che noi andiamo a dar la buona sera alla sposa; e poi vi riposiate, ché dovete essere molto stanco.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Facciamo come vi piace.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Bisogna che voi vegniate per di qua; ché questa è la mia casa.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Per di qua?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Per di qua, sì; ch'al volger di quel canto si va verso la porta.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Non avete voi detto che andiamo a dar la buona sera alla sposa?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Sì, se vi piace.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Oh, se volete la sposa, ci bisogna entrar qui.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Come costì? Dio m'aiuti.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>In questa casa, dove poco fa l'ho veduta e parlato ancora con esso lei.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Eh messer Bernardo, voi v'ingannate.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Sarà forse una casa medesima, ancorché fuori paian due.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Vostra figliuola è in casa mia, e lasciaila testé co 'l suo sposo; e so certo che indi non è partita.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Caro messer Patrízio, io son ben vecchio, ma ho pur eziandio tanto di memoria e di vista, quanto mi basta a riconoscer la mia figliuola. Io vi dico che l'ho testé veduta e lasciata in questa casa, e son entrato per questa porta; credete ch'io sia pazzo?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>In quella casa?</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>In questa.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Eh, voi siete in errore. Qui sta un cotale viniziano.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>(Qualche posta è qui sotto).</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Venite meco in casa; ché se non ve la mostro, dite che non son io.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Venite voi meco in questa; ché se non ve la mostro, spacciatemi per pazzo.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>(Dio voglia ch'egli non sia). Oimè, messer Bernardo, voi mi volete far disperar, volete. È sì gran cosa l'entrar in casa con esso meco?</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Orsù, io son contento di soddisfarvi. Andate là, ch'io vi seguo. Ma Dio voglia che n'usciamo tutti d'accordo.</p>
           </sp>
@@ -4707,23 +4765,23 @@
         <div type="scene">
           <head>SCENA PRIMA</head>
           <stage>LURCO, ZENOBIO</stage>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>No, no, ribaldi, vi giungerò ben io senza corrervi dietro. Per Dio, che sempre non vi varrà il nascondervi e lo sfuggire; e crederete d'aver fatta la truffa a me, e avretela pure fatta a voi stessi. Io scoprirò le vostre malvagità, di tal sorte che mille ne potreste ben pagar de' ducati, e non aver involato a me li dugento. E tu, manigoldo, porterai la pena per tutti; stanne sicuro.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Ah Lurco, non far più strazio di me, che troppo ho io patito senza colpa mia. Siati almeno raccomandata la mia existimatione. Dammi una dozzina di bastonate, e lasciami andare.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Avrai l'uno e l'altro, non dubitare. Pensa pure che sopra te vo' fare le mie vendette.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>O d'un alpestre scopulo più rigido!</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Qui starai tu prigione, fin ch'io riabbia li miei danari. Io vo' trovare messer Patrizio; e tutta da capo a piedi gli vo' contare la ribalderia di costoro. E poi faremo ragione insieme.</p>
           </sp>
@@ -4731,119 +4789,119 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>BERNARDO, PATRIZIO, LURCO</stage>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Io vi dico, messer Patrizio, che questa non è la mia figliuola; e maravigliomi ben di voi che v'abbiate dato ad intendere di potermi così palesemente ingannare, quasi ch'io sia un fanciullo, o privo in tutto di senno.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>E io vi replico, messer Bernardo, che questa giovane ho per vostra figliuola ricevuta da Nica, governatrice di lei, e per tale la tengo io, e tienla Pistofilo mio figliuolo: intendete? E se voi, in questa guisa, voleste avermi data una donna senza danari, siete in grandissimo errore, messer Bernardo; ché c'è giustizia in questa terra, vi so dir io.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>E se vi pensate voi di rubar venti mila ducati alla mia figliuola, co 'l supposito d'un'altra femmina, v'ingannereste ben di gran lunga. Io mi credea, venendo in qua, d'essermi allontanato da' Turchi; ma e' mi pare d'esserci infin agli occhi, alle vanìe che ci trovo. E se qui è giustizia, e' ci bisogna, vi so dir io; ma ella ci sarà mal per voi.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Ma che tante parole, messer Bernardo? Andiamo speditamente dove si chiariscono gli ostinati.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>(Chi domin'è costui che fa parole con messer Patrizio? E s'io non erro, parla eziandio della medesima cosa. Sia chi si voglia).</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Io non intendo di venir così subito alla Giustizia, prima che non abbia ancor io inteso, da' miei di casa, come sta il fatto.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Messer Patrizio, fermatevi, prima ch'io vi dica altro: o rendetemi Gostanza, mia figliastra, che avete in casa; o datemi i dugento ducati che promessi e pattoviti mi ha per lei Pistofilo, vostro figliuolo.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Starà pur a vedere novello intrico. Che cianci tu di dugento ducati? Per l'amor di Dio, non mi far arrabbiare più di quel ch'io mi sia.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Eh pover'uomo, come siete voi uccellato! E forse che non vi date a intendere di vedere ogni pulce che vi salta per casa, e non vedete gli elefanti che vi calpestano?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>E quali son cotesti elefanti?</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Que' duo' scelerati di Pistofilo e di Moschetta. Vi fanno le commedie in casa sì bene! hannovi condotta Gostanza, mia figliastra, in vece di quella raugea.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Ecco, Patrizio, non vi diss'io che quella non è la mia figliuola Cassandra? Lodato Dio, che siam pur chiari qual di noi abbia il torto.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Tu dèi esser ubbriaco; o che ambiduo vi siete accordati, per farmi dar l'anima a Satanasso. E come può egli esser cotesto?</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Quando voi la faceste condurre dalla sua casa alla vostra, e passò dinanzi alla mia, vi ricordate voi di quel subito svenimento, di quel dolore, di quello spasimo, di quell'ampolla, di quell'unguento, di quelle furberie? Allora Gostanza mia fu messa nella seggia e fuvvi, in vece di quell'altra, portata in casa: la quale è rimasa poi nella mia. E così ve l'hanno cacciata, messer Patrizio. Non vi pare che sian fantini da porre una sposa a letto?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>È possibile, Lurco, che ciò sia vero? Oh scelerati!</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Parvi egli che coteste siano ribalderie delle fine? Forca, forca!</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Oh traditori! Come può esser tanta audacia e tanta sfacciataggine in un garzone di diciott'anni? Che quanto a quel tristo di Moschetta, non me ne maraviglio. E a che fine ciò hanno fatto?</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Perché Pistofilo era guasto dell'una, e non voleva sentir dell'altra.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Oh Patrizio insensato! Questo era il male: di qui nacque il suo prima non voler moglie, poi la finta mutazione e i tanti vezzi che faceva alla sposa. Assassini! Io ve ne pagherò.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Quel tristo di Moschetta, cagion del tutto, merita mille paia di forche, siccome quegli che ha fatto torre a un povero pedante dugento ducati, promettendoli a me per lo prezzo di mia figliastra, e subito hagli rubati all'uno e all'altro.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Ma dimmi, valentuomo, perché acconsentì Cassandra a questo baratto?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Come perché? Ve 'l dirò io: per obbedire a quella sua malvagia governatrice, che fu sempre contraria alla conclusione di queste nozze. Messer Bernardo, se questo è vero, voi avete una gran ragione. Né io saprei dir altro se non dolermi della mia mala fortuna, benché quello che non s'è fatto potrà pur farsi di novo, piacendo a voi: perché Pistofilo, acciocché sappiate, non ha sposata colei, la qual, pagandosi a costui dugento ducati, leverommi di casa. E se Pistofilo vorrà essere mio figliuolo, bisognerà che l'una lasci e l'altra si tolga.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>(Trova pur i danari, babbo mio, che Pistofilo non vorrà già egli lasciarla, ti so dir io).</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>E tu, scelerato, non ti vergogni a vender l'onestà della tua quantunque figliastra? Alla Giustizia ti vo' far gastigare.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Che vender l'onestà? Gostanza è moglie di Pistofilo, acciocché sappiate: che senza questo non mi sarebbe uscita di casa; né egli, se non fosse marito, l'averebbe mai posseduta.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Messer Bernardo, lasciate pur dir costui, ch'egli mente.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Messer Patrizio, quantunque costui mentisse, non vorrei però dar mia figliuola a garzone di sì cattivi costumi: ché s'egli è perduto dietro ad una tristarella a quel modo, sarebbe un porla nel purgatorio. Vo' entrar in casa e porle questo ferro alla gola: farolla ben confessar io. Andiamo, Lurco, ti prego; menami in casa tua, ch'io son il padre di quella misera.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Siete venuto a tempo; entrate pure. Vo' chiudere il pedante in una camera, acciocché in questi rumori non mi scappasse.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Oh povero Patrizio! Or è ben tempo che tu t'impicchi: non mi starai in casa un'ora, ribalda. Ma ecco la cagione di tutt'il male: ecco la manigolda.</p>
           </sp>
@@ -4851,103 +4909,103 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>NICA, PATRIZIO</stage>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Io non avrò già più quel vecchio alle spalle.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Il manigoldo ci avrai ben tosto, femmina scelerata.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Uu povera me! Hammi sentito. Io non parlava di voi, messer Patrizio, non in verità.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Di te parlo ben io, ribalda.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Potensinterra! Una parola sola mi fa ribalda? Caro messer Patrizio, quando eziandio avessi detto di voi, meriterebbe quello che ho fatto in servigio vostro che m'aveste a dir villania? Ma ditemi, che fa Cassandra? Io vo' venire a stare un poco con esso lei.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Cassandra eh, traditora.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Haccene più delle villanie? Che domin avete in capo?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Sapresti metter una sposa a letto, eh?, manigolda!</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Dio m'aiti.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Giuochi di mani, traveggole, una donna per un'altra, sapreste 'l fare, eh?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Io non v'intendo, messer Patrizio, né so pensare che novità sien coteste.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>No, eh? Seggie, trabacche, svenimenti, dolori, bossoli, empiastri: sapete ora quel che si sieno?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>(Oimè, son morta).</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Perversa e maladetta femmina, che tu sei.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Sapete quello ch'io vi vo' dire, messer Patrizio? Non pretendo nulla da voi, né dei servigi fattivi; non ho sperato mai tanto, vedete, sicché ora con un vostro goffo pretesto ve ne vogliate assolvere: messer no, mai no.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Non ti dar già pensiero, ché avrai delle tue sceleraggini una sì fatta mercede, che tutto 'l tempo di tua vita n'avrai memoria.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Io son donna dabbene, io, al dispetto vostro, sapete?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Ve' fronte di sfacciata, ve'! Hai anche ardire.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Ho ardire, e perché? Andate a smaltir il vino, vecchio... voi mi fareste dire...</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Se domattina io non ti fo frustare, se non ti fo metter in berlina, e se con queste mani non ti ci fo morire a furia di sassi...</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Io voglio che mi diate... vecchio pazzo!</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>E io non ti trarrò gli occhi?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>State ne' vostri termini, ché, per santa Nafissa, vi pelerò la barba.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Non vo' perder più tempo co 'l fatto tuo: farottele ben costar care io, manigolda. Vo' prima cavarmi colei di casa, e poi...</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Oh povera Nica, tu se' spedita! Chi può esser mai stato quel traditore che ha scoperto il frodo? È stato certo quel medico, che ci ha egli a' fianchi tenuto sempre per ispia. Hollo ben detto io, meschina me! Uu uu! Sarò io quella che porterà la pena per tutti. Che debbo fare? Fuggire. Troverò Grillo alla Camatta, che mi provegga di qualche luogo da recarmici in salvo; ché mi par sempre avere i birri alle spalle.</p>
           </sp>
@@ -4955,71 +5013,71 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>PATRIZIO, PISTOFILO</stage>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Avrà dunque ardimento una sfacciatella di volermi star in casa al mio marcio dispetto? Trarrottene d'un modo, che tu non 'l pensi. Dal manigoldo ti farò strascinare, e non che dai birri.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Signor padre?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Che signor padre? E tu ancora, vituperoso, che se' cagione di tutto 'l male, mi pagherai la pena della sua colpa, non meno che della tua.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Fate ciò che vi piace, ché da me sarete sempre ubbidito. Ma io vi supplico che vi piaccia di dar intanto luogo alla collera, ch'io possa dirvi quattro parole.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Più di venti n'hai dette tu fin a qui; e potevi anche tacerle. Di' su.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Che cagione avete voi di dolervi, perché ora colei non abbia voluto...</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Tu mi faresti... Che cagion, dici? Non ne vo' più, no, no.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Deh, per l'amor di Dio, lasciatemi finire; e poi sia fatto quel che vi piace. Voi l'avete voluta cacciar di casa; che poteva ella far altro, per onor suo, che resistere e contrastare, per non esser sulla pubblica strada vituperata? Paghiamoci di ragione: che poteva ella far altro? Se in casa non la volete, sta bene, siete padrone; ma fatela uscire, in modo che non faccia correre il vicinato, con vituperio di lei e nostro, che fôra il peggio.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>E chi n'è cagione, se non tu solo, eh? Di' su, sfacciato, chi n'è cagione?</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Io, signor padre? Che male ho fatto?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Vedi, insolente, vedi? Ancora hai fronte di dirmi in faccia: che male ho fatto? Condurmi in casa...</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Io l'ho condotta? Io, ch'era in camera mia? Non me l'avete data voi, signor padre?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Questa no, scelerato: ma tu, sfacciatamente ingannandomi, te l'hai tolta.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Come, ch'io me l'ho tolta? Non mi comandaste voi che quella moglie io prendessi che in casa mi aveste oggi condotta? Or chi n'è stato il condottiere? Chi me l'ha messa in camera, se non voi?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Ve' pure, ve' con che fronte gli basta l'animo di difendere una sì fatta menzogna!</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Voi potete dire quel che vi piace; ma se voi siete stato ingannato da altri, che colpa ne ha Pistofilo? Doletevi di coloro che l'han condotta, e non di me, che quello ho mandato ad effetto che mi fu da voi comandato. Che femmina sapeva io ch'ella fusse? Informatevi s'io n'ho colpa; e non credete sì tosto a Lurco, di cui non ha la città di Padova, né di Vinegia insieme, il più infame ghiottone, il più solenne ribaldo.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>A te, a te, su 'l tuo viso, su quella sfacciata fronte, il farò dire, a te, sì; andiam pure.</p>
           </sp>
@@ -5027,187 +5085,187 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>LURCO, BERNARDO, PATRIZIO, PISTOFILO</stage>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Son un fanciullo, io, da darmi a intendere le novelle, ah?</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Non so di novelle io. Tu l'hai 'ntesa, tu, così bene come ho fatt'io.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Non so quello che abbia inteso, ché non m'importa. So bene che se non mi levate costei di casa, non vi varranno i giuochi di testa, non al certo. Di grazia, non aspettate ch'io ve la faccia saltar in strada.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Eccolo appunto, ve': su 'l tuo mostaccio te 'l dirà egli, sì bene. O Lurco.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Mancherebbe quest'altra alle mie buone venture, che costei mi facesse figliuoli in casa.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Figliuoli in casa? E di chi parli tu?</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Della figliuola di quest'uomo, che, con sue favole, se ne vorrebbe sgravare.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>E Cassandra vostra figliuola, che de' esser mia nuora, è gravida, messer Bernardo?</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Così foss'ella morta, com'è ben vero.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Miracoli, miracoli!</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Gravida, eh? Oh giudicio di Dio! Questo era ben altro fallo che 'l cambio. Anzi fallo sarebbe stato, se non si fosse cambiata.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Orsù, signori, non moltiplichiamo in parole: l'uno mi lievi la figliuola di casa, e l'altro mi numeri il pattuito danaro per la figliastra mia ch'egli ha avuta.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>La tua figliastra ti sarà resa, non dubitare.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Gran mercé. Or ch'ella è un'altra cosa, me la volete render, ah? Buon avviso per certo. Chi ha tagliato il mellone l'ha a pagare, messer Patrizio: intendetemi voi?</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Ascoltate, messer Patrizio: voi non sapete dove sta il punto. Il levar di casa a costui Cassandra non vuol dir nulla; ch'io saprei farlo anch'io, nella casa medesima rimettendola ond'ella è uscita. Hassi a vedere di cui ella ha da essere.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Che pensereste voi dunque di darla a me? Parliam pur d'altro: a me, eh?</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Non ho voluto dir questo, Pistofilo: io dico che s'ha a vedere s'ella è figliuola mia, o figliastra di Lurco.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Io non intendo ancora questo enigma.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Signor sì, perché ora ch'egli la trova gravida, vorrebbe scaricarsene, e forbirsi dal viso la sua vergogna con farle dire ch'essa è la mia figliastra, e Gostanza la sua figliuola. Chimere raugee per avventura.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>A bell'agio, fratello. Voi sapete, messer Patrizio, che testé mi condussi in casa costui, dove Cassandra è stata furtivamente condotta, per intender da lei qual cagion l'abbia mossa a consentir al cambio che si fece di lei; e 'n pochi salti presi la fiera: perciocché ella, vinta dalla paura, non mi seppe negar il vero e confessommi subito che, per non iscoprire la sua pregnezza, a ciò commettere s'era indotta.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Or intendo le menzogne e arti di Nica, e mezze gliele perdono.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Immaginatevi com'io restassi dolente e tanto attonito, che non mi sovvenne pur di richiederla di cui gravida ella fosse. Io credo certo che, se tale non fosse stata, viva non mi sarebbe uscita di mano. E non so anche quello ch'io m'avessi fatto, se non giungeva costui, che da farle mai mi ritenne. Or udite, ché qui sta il punto.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Io vi lascio dire le vostre favole; dirò poi ancora io le mie vere ragioni in poche parole.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Io l'avea di già lasciata e stava in capo alla scala, per venirmene a basso, quando costei, seguendomi, instantemente si diede a supplicarmi ch'io l'ascoltassi. Io mi rivolsi; ed ella, gittatamisi con molte lagrime a' piedi, a così dire s'incominciò: “Messer Bernardo, poscia che io né per lo fallo ardisco, né per natura posso chiamarvi padre, consolatevi, che se giustissima cagione vi ho data di dolervi di me, or voglio che la medesima ancora abbiate di sommamente lodarmene”.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Che domin può esser questo?</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Udite pure.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Udite, sì, sì, ché 'l Boccaccio non fece mai la più bella.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Seguitò ella dicendo: “Quando voi mandaste a Vinegia per levar la vostra figliuola, Maddalena, la mia vera madre, così mi disse: - Cassandra, quel raugeo, che ha mandato per te, non è tuo padre, come infin a qui ho cercato sempre di farti credere. La tua compagna Cassandra, la quale da qui avanti voglio chiamar Gostanza, è la vera figliuola sua, tu la mia. Tu te n'andrai colà, e sarai ben maritata. Ricordati ch'io ti son madre: sovvieni, ché potrai farlo con onesto colore, alla vecchiezza e povertà mia. Ma guarda di mai non lo scoprire a persona, per molto confidente ch'ella ti fosse, ché tu saresti la tua ruina e la mia”.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Come può esser ch'una fanciulla sappia ordire una sì fatta menzogna? Femmine, eh? Hanno 'l diavolo addosso!</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>“Io nondimeno - dice ella -, vedendo di potervi ora ricompensare la vergogna fattavi in casa co 'l palesarvi la vostra vera figliuola, ho anzi eletto di perder una sì ricca eredità che nascondervi il vero: acciocché conosciate che, se poco pudica fui, non son però sì malvagia ch'io la voglia rubar a vostra figliuola”.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Co 'l pugnale alla gola l'avete costretta voi a trovare queste pure menzogne. Che ci va che, s'io mi reco nel medesimo modo addosso alla mia Gostanza, la farò dire tutto 'l roverscio?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>A questo modo, tutte al luogo loro tornerebbono l'ossa.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Eterno Dio, fa tu, che far il puoi, che queste cose sian vere.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Maddalena, mogliama, fu una donna dabbene; e non averebbe fatte queste ribalderie, messer no.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Tu dunque fusti marito di Maddalena, che la mia figliuola allevò?</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Fui di lei secondo marito, e però Gostanza è figliastra mia.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Oh tu dovresti pur sapere di questo cambio.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Non so di cambio, io; ché, quando mi maritai, altra figliuola non avea Maddalena mia che Gostanza.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Il cambio fu forse fatto al tempo del suo primo marito, poiché costui dice d'essere stato il secondo.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Io le domando poi: “Che sai tu di Gostanza?”. Ed ella subito mi risponde: “Noi ci siam riconosciute, quand'ella entrò nella seggia, e fu portata in mia vece a casa messer Patrizio”.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Il medesimo ha detto Gostanza a me, signor sì.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Testimonio di Montefalco.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Ma, Lurco, non accade a farsene beffe; ché se Gostanza fosse vera figliuola di messer Bernardo, tu non avresti che far in lei; e vi dico che comincio a crederne qualche cosa.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Che crederne qualche cosa? Vi pensate voi dunque di levarmi con vostre favole mia figliastra? E con le sole e mentite parole d'una fanciulla, che le ha dette a forza di minacce, trarmi dal mio possesso? Sapete che... Non mi lasciate andare alla Giustizia, ché vi svergognerò. Bench'io mi rido di cotesti vostri vani concerti; perciocché io, senza forza alcuna di schiena, co 'l testamento solo di Maddalena, che Gostanza nomina per sua figliuola, vi chiarirò.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Non potrebb'essere che per figliuola la nominasse, e tuttavia non fosse?</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Umbè, noi vederemo a cui sarà per dare la Giustizia fede maggiore e qual sarà più valevole, o 'l vostro verisimile o la mia carta, signor dottore fatto di nuovo. Io vo' trovar il notaio, che dovrebbe pur esser qui, secondo l'ordine dato. Apparecchiate intanto i danari, signor dottore; e voi altri trovate cosa, per onor vostro, che abbia un po' più di garbo che non ha questa; né ci perdete tempo, ché all'aprirsi del testamento siete spediti. Io ve 'l dico per carità; ché ho compassione de' casi vostri, sì, per mia fè.</p>
           </sp>
@@ -5215,27 +5273,27 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>PISTOFILO, BERNARDO, PATRIZIO</stage>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Vedi arrogante, che si fa anche lecito di beffarci!</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Piacesse a Dio che così fosse vera la cosa, com'io temo ben al contrario. Dubito molto che colei s'abbia finta questa chimera, per mitigar il mio giustissimo sdegno; poiché, quanto al perder l'eredità della zia, Dio sa quant'ella se ne curi, e se non ama meglio d'essere a colui, benché povero, maritata, di cui è gravida, ch'esser moglie ricca d'un altro. Le femmine incapricciate maggiori cose di queste sogliono fare.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>La cosa passava bene; ma temo grandemente del testamento.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>Non si potrebbe egli o contradirgli o negarlo? Stiam saldi noi sulle parole di quella giovane, e diciamo di non voler sapere di testamento.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Non gioverà. E ci bisognerebbe andar alla Giustizia, e niente altro ne seguirebbe che maggiormente scoprir le nostre vergogne.</p>
           </sp>
-          <sp>
+          <sp who="#pistofilo">
             <speaker>PISTOFILO.</speaker>
             <p>(A sua posta; voglio andarmene in casa a guardar Gostanza. Ho fuggite le nozze dell'una: qualche cosa sarà dell'altra. Chi vorrà trarlami dalle braccia, farà conto con l'oste).</p>
           </sp>
@@ -5243,211 +5301,211 @@
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>NOTAIO, LURCO, BERNARDO, PATRIZIO</stage>
-          <sp>
+          <sp who="#notaio">
             <speaker>NOTAIO.</speaker>
             <p>Io vi dirò: il collegio nostro ha fatto un notaio, e non ho potuto prima spedirmi; ma io veniva diritto a voi, secondo l'ordine dato.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Orsù, siete a tempo. Avete voi il testamento?</p>
           </sp>
-          <sp>
+          <sp who="#notaio">
             <speaker>NOTAIO.</speaker>
             <p>S'io son venuto per questo! Eccolo.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Signori, questo è quel testamento che ci ha a chiarire. Dite, per vita vostra, come ve ne sta il cuore. Ah, ah, ah.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Tu se' pur arrogante.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Ditemi, sere, che testamento è cotesto?</p>
           </sp>
-          <sp>
+          <sp who="#notaio">
             <speaker>NOTAIO.</speaker>
             <p>Di Maddalena, moglie che fu, in secondo matrimonio, di Lurco, ch'è qui presente: la quale, venuta a morte, due ne fe' scrivere d'un tenore medesimo a un procuratore suo compare, che furono sottoscritti poi di mia mano, senza che io sapessi però il contenuto loro. E fui anche rogato della mano e dei suggelli di quelli che chiamati vi furon per testimoni, siccome vedete qui tutti l'un dopo l'altro.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>E perché due?</p>
           </sp>
-          <sp>
+          <sp who="#notaio">
             <speaker>NOTAIO.</speaker>
             <p>Perché uno di loro fu da lei dato al medesimo suo compare e l'altro a me, vietandomi e facendomi giurare di non l'aprire, finché Gostanza non avesse diciott'anni, nomandola allora di sedeci.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>E che venne poi di quel procuratore?</p>
           </sp>
-          <sp>
+          <sp who="#notaio">
             <speaker>NOTAIO.</speaker>
             <p>Credo, s'io non m'inganno, che fosse uno tra que' tanti viniziani che furon presi da' Turchi sulla nave <emph>Vittoria</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Sì, mi ricordo: tutti morirono, per non aver voluto rinnegare la fè di Cristo.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Orsù, apritelo omai; che mi pare un'ora mill'anni di chiarire tutti costoro.</p>
           </sp>
-          <sp>
+          <sp who="#notaio">
             <speaker>NOTAIO.</speaker>
             <p>La prima cosa, Lurco, guatalo bene, e riconoscilo per quel vero che tu segnasti co 'l tuo suggello, di propria mano tu ancora.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Veggolo, e riconoscolo troppo bene; e poi non so io chi voi siete? Sta bene.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Fermatevi, messere, ché non vogliamo sapere noi cosa che sia di suo testamento. Abbiamo il testimonio di quella giovane; e ciò ne basta.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Dice il vero, messer Bernardo: che abbiamo noi a fare del testimonio de' morti, s'abbiamo quello de' vivi?</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Umbè, ci troveremo ripiego: la Giustizia vi chiarirà. Andiam, messer Nofrio.</p>
           </sp>
-          <sp>
+          <sp who="#notaio">
             <speaker>NOTAIO.</speaker>
             <p>Non ti partir, Lurco, che farogli ben io capaci. Signori, vi piace egli che io vi dica quel che vuole il dovere, e anche il vostro vantaggio?</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Dite pur, sere.</p>
           </sp>
-          <sp>
+          <sp who="#notaio">
             <speaker>NOTAIO.</speaker>
             <p>Se voi avete oppenione che in questo testamento sia alcuna cosa che vi pregiudichi, l'ascoltarla non vi può nuocere: anzi piuttosto, avendola udita, potrete meglio consigliare le cose vostre; e però lasciatelo aprire, che questo è un atto privato e non pubblico.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Dice il vero, messer Patrizio; e però ascoltiamo quel che contiene.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Ascoltiamolo: ma non voglio già io lasciar di fargli un protesto. Odi, Lurco, e udite voi, sere: noi protestiamo di non acconsentire a qualsivoglia cosa, che sia in quel testamento, di pregiudizio alle nostre vive e buone ragioni.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Gran senno, certo! Gran protesto, messer Patrizio, è cotesto! O voi mi riuscite un eccellente dottore, mi riuscite: cappita! Ah, ah, ah.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Tu ridi? Son elle cose da rider queste?</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>E chi non riderebbe? Orsù, a' fatti, che così, caldo caldo, il vostro protesto vi vo' rimettere, perché 'l serbiate in fra le cose vostre più preziose.</p>
           </sp>
-          <sp>
+          <sp who="#notaio">
             <speaker>NOTAIO.</speaker>
             <p>Ora essendo venuto il tempo d'aprir questo testamento, per l'autorità concedutami dalla testatrice e dall'età della giovane, della quale ho fede appresso di me, io l'apro ad istanza qui di Lurco, crede in parte, com'ella disse, della suddetta Maddalena sua moglie. <foreign xml:lang="lat">Invocato prius Altissimi nomine</foreign>. Perciocché, <foreign xml:lang="lat">humanum est peccare, diabolicum perseverare, angelicum emendare...</foreign> Strano principio di testamento.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Strano principio? Quasi voi non sappiate che tutti i testamenti sono per lettera.</p>
           </sp>
-          <sp>
+          <sp who="#notaio">
             <speaker>NOTAIO.</speaker>
             <p>Monna Maddalena, venuta a morte, ha eletto me, Alberto da Verona...</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Hollo io conosciuto questo procuratore; era uom molto religioso, e per tale conosciuto da ognuno.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Ha più viso di predica che di testamento, fin qui.</p>
           </sp>
-          <sp>
+          <sp who="#notaio">
             <speaker>NOTAIO.</speaker>
             <p>...ora procuratore e suo compare, per porre in carta le infrascritte parole da lei dettate.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Or attendete, ché questo è 'l punto. O Pistofilo, dove siete? Questa a voi. Siete fuggito, eh? Or seguite, messer Nofrio.</p>
           </sp>
-          <sp>
+          <sp who="#notaio">
             <speaker>NOTAIO.</speaker>
             <p>Io confesso d'aver con isperanza di guadagno, ma sceleratamente, cambiata la figliuola di messer Bernardo Cattari raugeo (oimè, che cosa è questa!), al quale mandai la mia Cassandra, in vece della sua, quando egli mandò per lei a Vinegia. E poiché Dio mi abbia a perdonare il mio peccato, ho voluto rivelare questa verità con una scrittura simile a questa: pregando voi, signor Alberto mio compare, che la vogliate far avere a messer Bernardo, suo padre, fin a Raugia. Io lascio poi erede mia universale Cassandra, mia legittima e vera figliuola, che ora si trova nelle mani del suddetto messer Bernardo a Raugia.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>O laccio, o laccio, aspettami pur ch'io vengo.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Ove va egli con tanta furia costui? A 'mpiccarsi? Ha gittato il cappello in terra: è disperato ben daddovero. Oh gran caso! Oh gran caso!</p>
           </sp>
-          <sp>
+          <sp who="#notaio">
             <speaker>NOTAIO.</speaker>
             <p>Oh miracolo della bontà di Dio! Il quale non ha patito la dannazione d'un'anima, la perdita d'una figliuola e sì notabile inganno!</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Oh stupendissimo caso! Nel quale io non so ben dire quel che ammirare si debba più, o la grandezza del fallo e 'nsieme del pentimento di Maddalena, o la costanza e fede di costei, nella quale ha potuto più amore e il vero che l'avarizia di venti mila ducati.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>O tu se' qui: io credeva che tu ti fussi andato a 'mpiccare, io.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Lasciatemi un po' vedere questa carta.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>O Cassandra, figliuola mia, non ha potuto l'inganno altrui privarti di me, né di quel bene ch'apparecchiato t'aveva il cielo.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Questo è bene il nuovo caso che si sentisse mai; e credo, certo, che chi mettesse insieme tutte le storie non trovarebbe tal cosa.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Egli è quello in effetto! Che possan esser arse quante femmine ha il mondo, acciocché se ne spenga il mal seme. Dovrò io dunque prender costei e farle rabbiosamente le spese? Venture che mi corrono dietro! Ma, per mia fè, tu t'inganni: va pur a trovar il tuo drudo, ch'io non ho pane da dare alle tue pari, io.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Non dubitare no, ch'io mi obbligo, così piacendo a lei, di condurla a Raugia.</p>
           </sp>
-          <sp>
+          <sp who="#notaio">
             <speaker>NOTAIO.</speaker>
             <p>Gentiluomini, io me n'andrò, serbando il testamento appresso di me, tra l'altre mie scritture, a beneficio di chiunque v'abbia interesse; facendovi anche sapere che le robe, lasciatemi in serbo dalla testatrice, sono in mia casa sane e salve, a requisizion dell'erede; rallegrandomi con tutti voi delle vostre consolazioni.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Il malanno che Dio ti dia! Se queste sono consolazioni per me, ne possi aver tu altrettante. Mi consolo che 'l pedante è nelle mie forze, dalle quali non si riscat- terà già egli senza pagarmi. Signori, poiché la fortuna mi ha condotto a questo termine, abbiatemi compassione, e siatemi cortesi in tante vostre consolazioni di qualche aiuto.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Or va, ch'io son contento donarti li dugento ducati che hai perduti.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Oh siate benedetto, padron mio caro, padron mio generoso! Io vo' veder se trovo Moschetta.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>E noi, messer Bernardo, è ben che ce n'andiamo in casa a confortare li nostri sposi, raccontando lor tutto 'l fatto.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Facciamo come vi piace. Ma vorrei pure saper di Nica.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Oh non può stare a comparire essa ancora, quand'ella sappia che i rumori sien racchetati.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Andiamo, ché torneremo poi a cercarne.</p>
           </sp>
@@ -5455,239 +5513,239 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>GRILLO, FLAVIO, NICA, LISCA</stage>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Affè, che non mi scapperai questa volta.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Eh, per l'amor di Dio!</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Tenete'l, monna Nica, voi ancora; tenete'l forte, che non ci fugga.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Ah monna Nica!</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Che monna Nica? Spione: tu sai ben il mio nome, sì? To' questo, perché tu 'l sai. Dàlli Grillo, ch'egli è stato cagione di tutto 'l male, questo ribaldo: egli ci ha scoperti.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Scoperto io, sopra che? Deh, lasciatemi, che non v'ho fatto mai dispiacere.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Fermati, se non ch'io ti pianto questo passerino nel seno, sai? Vecchio, non mi far adirare.</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>A tempo mi sono affacciata, ve'.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>A un povero forastiero s'usano questi termini, eh?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>A gli spioni tuoi pari sì, e molto peggio ancora di questo.</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>Vo' ben esser a questa tresca ancora io, sì.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Oh come a tempo tu ci venisti! Tiello ancora tu, Lisca, tiello ben fermo, ve'.</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>Aspettate pure, ch'io mi sciolga questo cintolino di gamba.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Orsù, eccomi, non vo' fuggire: che volete da me, che v'ho fatto? Prego Dio che mi faccia morire, se mai v'offesi, ch'io sappia. Eccomi a' vostri piedi.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Che vuoi tu far, pazza?</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>Afferrarlo così nel collo, vedete.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Non tirar: vuoi tu affogarlo?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Misero me! Uu uu: io vi domando misericordia.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Che misericordia, ladrone, tu ci hai rovinati! Non può essere stato altri che tu, il quale andavi spiando tutto quello che facevamo.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Se questo è vero...</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Spione, traditore, io non vo' mancarti di fede. Promisi di pelargli il mento, non vo' mentire. Io te la vo' pelar quella barba, sì bene.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Ahi ahi!</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Tenetegli voi le mani.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Oh Dio! ohimè!</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Tutta ad un tratto te l'ho sterpata. O manigoldo, la barba posticcia, eh?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Io vi domando la vita.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Fermati, Grillo, fermati. Oh meschina me, che veggio? Non se' tu Flavio?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Oh monna Nica, purtroppo io sono.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>O figliuol mio dolce, figliuol mio caro, perdonami delle offese che io t'ho fatte, perdonami, cuor mio; leva su.</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>Uh che bel giovane! Fui pur la gran bestia a non aprirgli la porta.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Miracoli! È questo Flavio, monna Nica?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Sì, Grillo, sì. E come vai tu in questi abiti sconosciuto? Perché non ti scoprire subito a noi?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Vi domando perdono anch'io, Flavio: che se v'avessi conosciuto, Dio guardi...</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Perdono a tutti, purché a me non mi si nieghi una grazia.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Chiedi, che ogni cosa è tua.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Anche Cassandra?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Pur quella è tua più che mai.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Oh se questo avessi saputo, Flavio felice!</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>Madonna, anch'io vorrei far la pace: io l'ho schernito, ben sapete.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Sì, è dovere.</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>Ma voglio fare la buona pace, sapete?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>E qual è cotesta tua buona pace?</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>La pace di Marcone.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>E che sai tu di Marcone?</p>
           </sp>
-          <sp>
+          <sp who="#lisca">
             <speaker>LISCA.</speaker>
             <p>Ben sapete che la 'mparai da uno che mi diceva ch'ella era sì buona cosa.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Sì, eh? Buon avviso!</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Non mandasti tu, Flavio, un tuo fante innanzi, due ore fa?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Io? Madonna no. Mi guardava da voi, per questo andava io così sconosciuto.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Dio te 'l perdoni: e perché? Di cui temevi?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>A bell'agio l'intenderete.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Di cui fu dunque il fante che venne, Grillo?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Che so io, che trasecolo a sentire sì strani accidenti?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Orsù, andiamo a trovar Cassandra: oh novella!</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Andiamo, ché ho bisogno di riposare: di sì santa ragione m'avete pesto.</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Poveretto! Andiamo. Tu resta, Grillo; e ricordati d'aver cura ch'io non vada prigione; che ci verresti tu ancora, sai?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Lasciate 'l pensiero a me: sopra la mia parola siete tornata; con questa vita farovvi scudo.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker>FLAVIO.</speaker>
             <p>Come prigione? E perché?</p>
           </sp>
-          <sp>
+          <sp who="#nica">
             <speaker>NICA.</speaker>
             <p>Saprai tutta la storia: andiam pure.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Questo povero giovane dovea certo temere, a quel che ne dice, d'esser caduto in odio a Cassandra, come avviene per lo più delle donne, le quali co 'l mutar di fortuna cangiano amore. Il pagherei del sangue a non l'avere sì mal trattato: ma sotto que' panni chi l'averebbe creduto Flavio? Io sto pur a pensare che domin può essere stato quel raugeo che mandò il fante. A me parve pur che dicesse ch'era di Flavio; o che sogno?</p>
           </sp>
@@ -5695,199 +5753,199 @@
         <div type="scene">
           <head>SCENA NONA</head>
           <stage>PATRIZIO, GRILLO, BERNARDO</stage>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Oh quanto sono allegri que' nostri sposi, messer Bernardo! Si può dir più?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>(Bernardo, eh?).</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Non vidi tal cosa mai d'allegrezza: Dio gli benedica.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Santa deliberazione che fu la vostra a venir in qua.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>E sapete ch'io stetti su quello di non venire?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>(Che sì, che questo è il padre di Cassandra: sta pur a vedere).</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>In quale intrigo, senza la persona vostra, mi sare'io trovato! E chi l'avrebbe mai sviluppato, se non sol voi, questo gruppo?</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Io non credetti già io mai d'incontrarmi in sì fatti accidenti, quand'io parti' da Raugia.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>(Raugia? Buon dì: questo fu il raugeo che mandò il fante, ve'. Noi siam disfatti).</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Considerate, di grazia, maraviglia di caso! Puossi egli dare maggior inganno, né più enorme ribalderia di quella ch'è stata ordita contra di noi? Cambiataci a voi già la figliuola, e a me, oggi, la nuora.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>(L'un cambio intendo, ma l'altro no).</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Dall'altra parte, si poteva egli far cambio né più giusto né più santo né più opportuno né più necessario di questo? Mediante il quale a voi è stata restituita quella figliuola che la malvagità della balia v'avea rubata, e a me quella nuora che giustamente mi si doveva?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>(To', to', ecco nuovo accidente! Oh giornata piena di maraviglia; ma spero ancora di gioia).</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Messer Patrizio, io 'l dicea pur testé: questa nostra prudenza vede sì poco lunge, ch'io non so quello che dir ne debbia. Se non s'apriva oggi quel testamento di Maddalena, co 'l quale si è manifestato l'inganno, non sarebbe egli, senza alcun fallo, seguito il matrimonio della supposita? Or lascio pensar a voi quanti scandali ne potevan succedere.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>(Quel testamento nel quale Lurco sperava tanto, ve'. Oh che sento, oh che sento!).</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Ma dove è Nica, che non la veggio?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>La povera femmina non si de' attentare di comparirvi davanti, or che la gravidezza di quella giovane, che tien per vostra figliuola, avete scoperta. E in verità, stante l'error seguito, il quale d'altra materia corregger non si poteva che occultandolo, non avrebbe ella potuto più saviamente portarsi; ond'ella è non solo scusabile, ma comendabile ancora.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Di lei non cerco per mal veruno, in verità, ma per sapere come sta il fatto. E però venga pure, ch'io la vedrò volontieri.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>(Oh sia lodato Dio!).</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Oh quanto bene, messer Bernardo! Andiamo dunque a confortar quella giovane, la quale, se condurrete a Raugia, come dianzi voi prometteste, sarà opera certo di carità.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>(Or è tempo). Signori, non m'abbiate per importuno, se interrompo i vostri ragionamenti, perciocché non intendo di dirvi altro che cosa di vostro comodo.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Chi è costui, messer Patrizio?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Questi è Grillo, che sta nella medesima casa con Nica vostra; e serviva la buona memoria di madonna Ginevra, vostra sorella.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Che di' tu, valentuomo?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Io giunsi testè di piazza, e stava per entrarmene in casa, quando mi parve udire la Signoria Vostra dir non so che di condurre la mia padrona a Raugia.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Qual è la tua padrona?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Cassandra, che fu nipote di madonna Ginevra.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Be', che vuoi dire?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Io vo' dire che, se io credessi di poter impetrar una sola grazia da voi, la fatica di tal condotta vi leverei.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Secondo che grazia. Io certo, se fare onestamente il potessi, assai volentieri di cotal imbarazzo mi sgraverei. Dimmi dunque che grazia è cotesta; e poi vedremo se ci possiamo accordare.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>La grazia è questa, che voi vi contentiate di perdonare a Flavio.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Che mi ha fatto in casa quel disonore? Cotesto è troppo, fratello.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Altro disonore non v'ha egli fatto alla fine che di celatamente venirci, benché questo eziandio non è indegno di scusa. Del resto Cassandra era sua sposa prima che la toccasse.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>A me coteste ciance non si danno ad intender, fratello.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Orsù, messer Bernardo, nelle comuni nostre allegrezze sarebbe troppo disdicevole cosa che altri fosse lieto e altri dolente.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Oh egli non è qui; e però non può esser partecipe delle nostre consolazioni.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Sarà ben la sua sposa partecipe e dolente dello sdegno che mostrate di lui. Orsù, messer Bernardo, per amor mio, voglio che voi gli perdoniate; non dite altro.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>A Raugia prometto di perdonargli.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>E non qui?</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Oh se e' non c'è.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>E se e' ci fosse, e ve 'l domandasse?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Su allegramente, messer Bernardo, non ci pensate: non gli perdonereste? Sì, sì. Di grazia, non ce 'l negate più lungamente.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Orsù, vi dico, che s'e' ci fosse e mi chiedesse perdono, l'impetrerebbe.</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Or Flavio è in quella casa; e chiederavvi umilmente mille perdoni.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Di' tu vero?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Verissimo.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>E quando venne?</p>
           </sp>
-          <sp>
+          <sp who="#grillo">
             <speaker>GRILLO.</speaker>
             <p>Tutto saprete: io vo a darne la nuova a Flavio.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Assai dunque fia consolata Cassandra, senza l'opera mia. Se Flavio verrà in casa vostra, messer Patrizio, e chiederammi il perdono, per amor vostro no 'l negherò.</p>
           </sp>
@@ -5895,179 +5953,179 @@
         <div type="scene">
           <head>SCENA DECIMA</head>
           <stage>MOSCHETTA, LURCO, PATRIZIO, BERNARDO</stage>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Lurco, tu sei a nulla, se credi di trarglimi dalle mani.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>E perché, son eglino tuoi?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Ecco 'l padrone, che ne sia 'l giudice. Oh signori, di grazia contentatevi d'ascoltarci.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Oh, oh, buone pezze. A quest'ora tu torni, eh?</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Chi è colui che ci chiama, messer Patrizio?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Egli è un mio fante, o furfante, come volete.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Primieramente io mi rallegro delle vostre consolazioni, signori, e delle maraviglie che Lurco mi ha testé raccontate; né vi chieggio perdono, perciocché io pretendo, anzi, di meritare grossa mercede, essendo io stato autore di quel cambio che vi ha fatto venir in luce del vero. Ma che diss'io, cambio? Cambio sarebbe stato, se altrimenti fatto si fosse: perciocché io, con la mia industria, vi ho quella giovane messa in casa, che legittima vostra nuora doveva essere. Né di tal beneficio altra mercede intendo di conseguire se non che ascoltiate le mie ragioni, e mi facciate giustizia.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Con chi l'hai tu?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Con cotestui.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Non saprei dire qual di voi fosse peggio abbattuto.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Or il vedremo. Questi sono li dugento ducati che promise il pedante a costui...</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Memoria nobilissima delle vostre ribalderie!</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>... per lo prezzo della figliastra. E per ingannar il pedante, gli fu messa in camera un'altra femmina, acciocché con essa, in vece di Gostanza, si trastullasse.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Oh ghiottoni!</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Ora, mentre il pedante stava sulle dolcezze, la ladroncella gli trasse della tasca i danari che dovevan esser pagati a Lurco.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Ah, ah, ah: oh che tresca solenne! e così ella gl'ingannò amenduni.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Or se io non l'avessi trovata e toltogli i danari, la ribalda se gli sarebbe portati via; né costui era già egli per riavergli mai più, che s'ella fosse giunta a Vinegia, dov'era incamminata, cercala tu! Di questi dunque, come di cosa senza speranza alcuna da lui perduta e da me con fatica grandissima guadagnata, intendo d'esser giusto e legittimo possessore. E per tale vi prego che dichiarare voi mi vogliate.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>A questo che di' tu, Lurco?</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Io dico, primieramente, non esser vero che costui s'inducesse a fare il cambio per carità; fecelo per vendetta, non avendo la Signoria Vostra voluto empiergli il ventre d'alcune robe che e' condusse di villa.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Oh manigoldo! Sarai tu mai satollo?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Non è vero, padrone, lasciatel dire.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Signor sì. Dico, poi, che que' danari son miei, come quelli che furono a me promessi, numerati e ubbligati per patto espresso. E finalmente che costui non è stato solo a ricoverargli: perciocché, se non ci fossi sopraggiunto io per soccorso, non era uomo mai per avergli, sì fortemente si difendeva colei!</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Messer no: che quando tu ci venisti, io già gli aveva ricoverati.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Sapete che io vi vo' dire? Meritereste ambidue di maritar una forca, ghiottoni.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Lurco, se questa è la sentenza, cedo alla causa, e a te la rinunzio.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Dimmi tu, Lurco, non t'ho promesso io di donare dugento ducati?</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Signor sì.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Dunque non ti contenti, ché anche vorresti gli altri?</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Voleva tenergli in serbo, finché questo cortese gentiluomo m'avesse dati i promessi.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>In serbo, eh? Buona detta, e miglior coscienza per certo.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Da' qua tu que' danari, Moschetta.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Eccogli.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Lurco.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Padrone, se voi glieli date, ci ammazzeremo, ve 'l dico io.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Lurco, dov'è il pedante?</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>In casa mia.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Va per lui. Quanti sono, Moschetta? Io gli vo' annoverare.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Settantatré pezzi d'oro vorrebbon essere.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Uno, due, tre, quattro, cinque, sei, sette, otto, nove, diece...</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Non credo che ce ne manchi pur uno.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Doveva esser ancor egli innamorato, il pedante, eh?</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Signor sì. Se voi vedeste che ceffo, che mostaccio, che figura d'innamorato, ne stupireste.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>O pover'uomo! Egli sonava, e altri faceva la danza.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Tutti ci sono, appunto.</p>
           </sp>
@@ -6075,111 +6133,111 @@
         <div type="scene">
           <head>SCENA UNDICESIMA</head>
           <stage>LURCO, ZENOBIO, PATRIZIO, BERNARDO, MOSCHETTA</stage>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Non abbiate vergogna, messer lo sposo; venite.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>O Lurco, che cosa mi fai tu fare? Il mio decoro è prostituto.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Bisogna ben che vegniate, se volete i vostri danari.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>I mie danari? Eh, tu mi beffi.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>No certo.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Chi mai gli tolse? Gostanza? Per farmi una beffa, eh? Vengo, vengo.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Signori, <foreign xml:lang="lat">ecce</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Non vi maravigliate, gentiluomini, di vedere un par mio in questi panni: perciocché <quote xml:lang="lat">omnia vincit Amor</quote>. Ricordatevi che una femmina fece filare quel domator de' mostri terribile.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Questo è un pedante? Mi par un burattino a me.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Messer Zenobio, che abito è cotesto? O pover uomo, il troppo studio gli ha levato il cervello.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Orsù, pazzarone, lascialo stare. Messere, ecco i vostri danari. Imparate di attendere a' vostri fancíulli, e lasciate star le femmine, che non fanno pe' pari vostri.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>O <foreign xml:lang="lat">manus vere aurea, quam ego reverenter et merito te deosculor! Tibi vero, undequaque praestantissime vir patritie, ex patritia vere genite gente, quamquam ingenioli mei vires...</foreign></p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Messer Patrizio, io so come son fatti questi pedanti, quando danno nel pecoreccio. E' ci terrà quel poco qui a disagio.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p><foreign xml:lang="lat">Quamquam</foreign> (dico) <foreign xml:lang="lat">ingenioli mei vires...</foreign></p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Non v'affaticate, messer Zenobio, ch'io sono assai sicuro dell'eloquenza e gratitudine vostra.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Deh, signore, lasciatemi fare il debito mio. <foreign xml:lang="lat">Quamquam ingenioli mei vires...</foreign></p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>E' non sa andar più innanzi, per quel ch'io veggio. Credo che sarà molto meglio, messer Zenobio, che voi facciate un di que' vostri bellissimi sonetti in laude della Sua Signoria.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Credi tu, Lurco?</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>Sì, dice il vero. A me certo sarà più caro, messer Zenobio.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Con la coda, eh?</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>Sì, con la coda.</p>
           </sp>
-          <sp>
+          <sp who="#zenobio">
             <speaker>ZENOBIO.</speaker>
             <p>Poiché così vi piace, farollo elegantissimo. <foreign xml:lang="lat">Valete</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>In buonora, messer Zenobio. Se Lurco non ce ne liberava, guai a noi.</p>
           </sp>
-          <sp>
+          <sp who="#bernardo">
             <speaker>BERNARDO.</speaker>
             <p>Lurco, vientene meco in casa, ch'io ti farò la polizza de' dugento ducati, i quali subito avrai su 'l banco de' Quirini a Vinegia.</p>
           </sp>
-          <sp>
+          <sp who="#lurco">
             <speaker>LURCO.</speaker>
             <p>E io di nuovo ve ne rendo grazie infinite, padron mio caro e dabbene.</p>
           </sp>
-          <sp>
+          <sp who="#patrizio">
             <speaker>PATRIZIO.</speaker>
             <p>E tu, Moschetta, poiché quel cipriotto non mi ha mandati i danari di quelle robe che dianzi conducesti di villa, va per esse alla barca e falle portar a casa, ché c'è ben tanto ancora di giorno che potrai farlo: perciocché voglio che noi facciamo, doman da sera, un solennissimo convito, insieme con ambedue le spose e gli sposi, e che tu possa satollarti a tuo modo. Andiamo, messer Bernardo.</p>
           </sp>
-          <sp>
+          <sp who="#moschetta">
             <speaker>MOSCHETTA.</speaker>
             <p>Oh questo sì ch'è un miracolo il più stupendo di quanti oggi n'abbiam veduti! Oh Moschetta felice! Spettatori, il resto delle nostre allegrezze si farà dentro. Bastivi di sapere che la favola nostra ci abbia fatti tutti contenti. E se voi siete così contenti, e di lei e di noi, datecene, vi preghiamo, il vostro cortesissimo e lieto segno.</p>
           </sp>

--- a/tei/guidi-endimione.xml
+++ b/tei/guidi-endimione.xml
@@ -81,6 +81,25 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="amore">
+            <persName>Amore</persName>
+          </person>
+          <person xml:id="cintia">
+            <persName>Cintia</persName>
+          </person>
+          <personGrp xml:id="coro">
+            <name>Coro</name>
+          </personGrp>
+          <person xml:id="endimione">
+            <persName>Endimione</persName>
+          </person>
+          <personGrp xml:id="coro_di_ninfe">
+            <name>Coro di ninfe</name>
+          </personGrp>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -297,7 +316,7 @@ ARCADE</salute>
     <body>
       <div type="act">
         <head>ATTO I</head>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>Felici piagge, avventurosi colli,</l>
@@ -307,7 +326,7 @@ ARCADE</salute>
             <l>Cintia scesa dal cielo.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Ombre solinghe, alti silenzi, oh quanto</l>
@@ -316,7 +335,7 @@ ARCADE</salute>
             <l>nemico di mia pace in seno avete.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>Io per queste sì dolci</l>
@@ -329,7 +348,7 @@ ARCADE</salute>
             <l>regno sovra Saturno e sovra Giove.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Qual piacer mi lusinga</l>
@@ -348,7 +367,7 @@ ARCADE</salute>
             <l>la cura d'infiammar ninfe e pastori.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>Ne la reggia e dentro 'l bosco</l>
@@ -372,7 +391,7 @@ ARCADE</salute>
             <l>di sospirar per deità celeste.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Fede negar non lice</l>
@@ -395,7 +414,7 @@ ARCADE</salute>
             <l>che, dovunque io mi volga, io sono Amore.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Se di me tu favelli,</l>
@@ -406,7 +425,7 @@ ARCADE</salute>
             <l>ma là, dove sei dio, sarai tiranno.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>Io da i fieri trastulli</l>
@@ -419,7 +438,7 @@ ARCADE</salute>
             <l>s'io son nume o tiranno.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>So che a i popoli tuoi</l>
@@ -454,7 +473,7 @@ ARCADE</salute>
             <l>e m'invola al mio desio -.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>I tuoi fati non hanno</l>
@@ -476,7 +495,7 @@ ARCADE</salute>
           </lg>
         </sp>
         <p>***</p>
-        <sp>
+        <sp who="#coro">
           <speaker>CORO</speaker>
           <lg>
             <l>Poiché 'l destin che in suo governo tiene</l>
@@ -514,7 +533,7 @@ ARCADE</salute>
       </div>
       <div type="act">
         <head>ATTO II</head>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>Seguendo un mio desir, che mi diparte</l>
@@ -581,7 +600,7 @@ ARCADE</salute>
           </lg>
         </sp>
         <p>***</p>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Quante ghirlande intorno</l>
@@ -603,7 +622,7 @@ ARCADE</salute>
             <l>più le bell'arti d'illustrar le selve.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>O dea, che far degg'io?</l>
@@ -614,7 +633,7 @@ ARCADE</salute>
             <l rend="italic">e degli eroi superbi aspro governo.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Non ben comprende il vero,</l>
@@ -634,7 +653,7 @@ ARCADE</salute>
             <l>il tuo bel nome adorna.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>Lascieranno l'api i fiori,</l>
@@ -647,7 +666,7 @@ ARCADE</salute>
             <l>onde Amor l'alma mi prese.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Dunque d'amar ti riconsigli e schivi</l>
@@ -657,7 +676,7 @@ ARCADE</salute>
             <l>or di fermarti al guardo tuo non lice.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>Andrò con le mie pene ove mi sforza</l>
@@ -665,7 +684,7 @@ ARCADE</salute>
           </lg>
         </sp>
         <p>***</p>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Fortunato pastor, se tu vedessi</l>
@@ -697,7 +716,7 @@ ARCADE</salute>
           </lg>
         </sp>
         <p>***</p>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>Non son, come altri crede, un dio feroce,</l>
@@ -729,7 +748,7 @@ ARCADE</salute>
           </lg>
         </sp>
         <p>***</p>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>Se per desio de la mia morte vieni</l>
@@ -742,7 +761,7 @@ ARCADE</salute>
             <l>nel misero mio cor vibra te stesso.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>Ingrato Endimion, di che ti lagni?</l>
@@ -754,7 +773,7 @@ ARCADE</salute>
             <l rend="italic">per l'emula del sole ardi e sospiri.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l rend="italic">E ben di ciò mi dolgo,</l>
@@ -773,7 +792,7 @@ ARCADE</salute>
             <l>a viver di desio fuor di speranza.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>E ti rechi ad oltraggio</l>
@@ -790,7 +809,7 @@ ARCADE</salute>
             <l>E tu vèr lui t'adiri?</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>Amore, omai</l>
@@ -799,7 +818,7 @@ ARCADE</salute>
             <l>carco sempre di pianto e di dolore?</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>Dona tregua</l>
@@ -812,7 +831,7 @@ ARCADE</salute>
             <l>Ardi e spera.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>Ben tal volta mi lusingo</l>
@@ -825,14 +844,14 @@ ARCADE</salute>
             <l>io dispero.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>Nulla t'affidi e forse ancor non sai</l>
             <l>che non ponno giamai mentir gli dei.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>Ecco Cintia sen viene,</l>
@@ -840,14 +859,14 @@ ARCADE</salute>
           </lg>
         </sp>
         <p>***</p>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Amor, se giusto sei,</l>
             <l>miei preghi ascolta e mia ragione intendi.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>Indarno meco a favellar tu prendi.</l>
@@ -862,19 +881,19 @@ ARCADE</salute>
             <l rend="italic">le famose vittorie e i gran trofei.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Troppo è tua legge imperiosa e grave.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>È 'l mio giogo soave.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Perché mal grado mio</l>
@@ -882,7 +901,7 @@ ARCADE</salute>
             <l>trasformare il desio?</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>Se pure ancora io sono</l>
@@ -891,7 +910,7 @@ ARCADE</salute>
           </lg>
         </sp>
         <p>***</p>
-        <sp>
+        <sp who="#coro">
           <speaker>CORO</speaker>
           <lg>
             <l>Quando d'un'alma Amor preso ha l'impero,</l>
@@ -910,7 +929,7 @@ ARCADE</salute>
       </div>
       <div type="act">
         <head>ATTO III</head>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>Io son sì stanco di soffrir lo scempio</l>
@@ -955,7 +974,7 @@ ARCADE</salute>
           </lg>
         </sp>
         <p>***</p>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Qual prenderò consiglio</l>
@@ -1029,7 +1048,7 @@ ARCADE</salute>
             <l>l'alte menti a' tuoi bei rai.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l rend="italic">Quando nel costui regno io posi il piede,</l>
@@ -1037,27 +1056,27 @@ ARCADE</salute>
             <l rend="italic">e m'empiro di lagrime e d'orrore.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Di che sogna e favella?</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>Ben ho cagion d'aver in odio il giorno</l>
             <l>in cui conobbi Amore.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Ah ben vaneggia Endimion, ché solo</l>
             <l>a me così di ragionar conviensi.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>Il sanno i monti, il sanno</l>
@@ -1065,7 +1084,7 @@ ARCADE</salute>
             <l>che risposer sovente a la mia doglia.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Tu segui ancora in sì turbati accenti</l>
@@ -1092,7 +1111,7 @@ ARCADE</salute>
           </lg>
         </sp>
         <p>***</p>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>Odi la dea ritrosa,</l>
@@ -1100,13 +1119,13 @@ ARCADE</salute>
             <l>la famosa d'Amore aspra nemica?</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Il mio troppo desire hammi tradita.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>Tu fuggi, o dea, né più ti pregi o vanti</l>
@@ -1132,21 +1151,21 @@ ARCADE</salute>
             <l>tutto pieno di gioia e di salute.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>E chi rompe i silenzi a me sì cari</l>
             <l>e turba la mia pace?</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>Pastor, ti riconforta,</l>
             <l>ché felici novelle Amor ti porta.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>Tu m'involi a i riposi,</l>
@@ -1167,7 +1186,7 @@ ARCADE</salute>
             <l>lascia di lusingarmi o pur m'uccidi.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>Qual uom che sogna e di sua mente è incerto,</l>
@@ -1176,14 +1195,14 @@ ARCADE</salute>
             <l>strane e gioconde, a tutto il mondo ascose.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>A me sperar non lice</l>
             <l>sorte così felice.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>Per questo dardo e per la face eterna</l>
@@ -1201,14 +1220,14 @@ ARCADE</salute>
             <l>torsi a' lacci d'Amor, più s'incatena.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>È ben sovra gli dei certo felice</l>
             <l>chi sospirar fa Cintia.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>Ella mirando</l>
@@ -1219,7 +1238,7 @@ ARCADE</salute>
             <l>a l'amorose menti.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>Non sono, Amor, non sono</l>
@@ -1227,7 +1246,7 @@ ARCADE</salute>
             <l>possenti ad invaghir cose celesti.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>Qual da bel velo, Endimion, traluce</l>
@@ -1256,7 +1275,7 @@ ARCADE</salute>
             <l>la schiera de gli dei.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>Amor, tu mi lusinghi</l>
@@ -1265,7 +1284,7 @@ ARCADE</salute>
             <l rend="italic">Cintia il rigido suo fero talento?</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>Sia pur sdegnosa, altera</l>
@@ -1274,19 +1293,19 @@ ARCADE</salute>
             <l>che quel vano piacer d'esser severa.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>E che sperar degg'io da tanto nume?</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>Ama, ch'amando non si reca oltraggio.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>Io troppo in alto miro</l>
@@ -1294,7 +1313,7 @@ ARCADE</salute>
             <l>onde sempre sospiro.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>Avvalora te stesso</l>
@@ -1302,7 +1321,7 @@ ARCADE</salute>
             <l rend="italic">ch'amor fu sempre alta cagion d'amore.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>È un martìr l'essere amante,</l>
@@ -1316,7 +1335,7 @@ ARCADE</salute>
             <l>ed è duro il non amar.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>Svela pure i tuoi tormenti,</l>
@@ -1332,7 +1351,7 @@ ARCADE</salute>
           </lg>
         </sp>
         <p>***</p>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>Di quest'anima mia stanno al governo</l>
@@ -1373,7 +1392,7 @@ ARCADE</salute>
           </lg>
         </sp>
         <p>***</p>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Dolce forza d'Amor, che 'l tutto movi</l>
@@ -1408,7 +1427,7 @@ ARCADE</salute>
           </lg>
         </sp>
         <p>***</p>
-        <sp>
+        <sp who="#coro_di_ninfe">
           <speaker>CORO DI NINFE</speaker>
           <lg>
             <l>Già l'usato</l>
@@ -1474,7 +1493,7 @@ ARCADE</salute>
       </div>
       <div type="act">
         <head>ATTO IV</head>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>Amor, che m'infiammasti ed or mi guidi</l>
@@ -1487,7 +1506,7 @@ ARCADE</salute>
             <l>che quest'anima mia per lei sospiri.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Che ragioni d'Amor? Qual dea rammenti?</l>
@@ -1498,7 +1517,7 @@ ARCADE</salute>
             <l>per amorosi affanni?</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>Da così bella e luminosa parte</l>
@@ -1507,7 +1526,7 @@ ARCADE</salute>
             <l>senza oltraggiar gli dei.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>E co 'l favor de' numi</l>
@@ -1515,7 +1534,7 @@ ARCADE</salute>
             <l>Endimion, presumi?</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>Amor m'ha date l'ali</l>
@@ -1530,7 +1549,7 @@ ARCADE</salute>
             <l>la colpa che t'offende.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>E tanto lice ad ardimento umano?</l>
@@ -1543,7 +1562,7 @@ ARCADE</salute>
             <l>che l'alta offesa spira.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>Amor, che in queste selve alberga e regna,</l>
@@ -1554,7 +1573,7 @@ ARCADE</salute>
             <l>né disperar conforto al tuo dolore -.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>E tu credi ad Amore,</l>
@@ -1570,7 +1589,7 @@ ARCADE</salute>
           </lg>
         </sp>
         <p>***</p>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>Passa l'amata dea sdegnosa, altera</l>
@@ -1632,7 +1651,7 @@ ARCADE</salute>
           </lg>
         </sp>
         <p>***</p>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>Arde Cintia d'amor, né si consiglia</l>
@@ -1656,7 +1675,7 @@ ARCADE</salute>
           </lg>
         </sp>
         <p>***</p>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Tardi conobbi, Amore,</l>
@@ -1674,7 +1693,7 @@ ARCADE</salute>
             <l>e 'l tuo gran nume offesi.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>Che giova l'esser dio</l>
@@ -1683,27 +1702,27 @@ ARCADE</salute>
             <l>l'onor de' regni miei?</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Di che ti lagni, Amor, se nulla ponno</l>
             <l>contra la tua possanza uomini e dei?</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>Del mio sì grave affanno</l>
             <l>sola cagion tu sei.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Meco tu scherzi, Amore.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>Come potresti mai</l>
@@ -1714,14 +1733,14 @@ ARCADE</salute>
             <l>sentire aprirsi il petto?</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Che pastor? che ferite? e quando rea</l>
             <l>fu la mia deità di colpa atroce?</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>È ver che l'arco tese</l>
@@ -1735,7 +1754,7 @@ ARCADE</salute>
             <l>su l'aspra istoria de' suoi tristi amori.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>In nome de le Furie uscì da l'arco</l>
@@ -1743,14 +1762,14 @@ ARCADE</salute>
             <l>Or dunque giace il bel pastore estinto?</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>Estinto no, ma da crudel ferita</l>
             <l>langue piagato a morte.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Ricuso d'esser dea</l>
@@ -1760,14 +1779,14 @@ ARCADE</salute>
             <l>senza 'l caro splendor de' lumi suoi.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>Or cela amor, se puoi.</l>
           </lg>
         </sp>
         <p>***</p>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Ben tu fuggisti, Amor; ma qui me sola</l>
@@ -1803,7 +1822,7 @@ ARCADE</salute>
           </lg>
         </sp>
         <p>***</p>
-        <sp>
+        <sp who="#coro">
           <speaker>CORO</speaker>
           <lg>
             <l>Tratte avessi di man del sommo Giove</l>
@@ -1832,7 +1851,7 @@ ARCADE</salute>
       </div>
       <div type="act">
         <head>ATTO V</head>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>Amor e 'l mio destino,</l>
@@ -1844,14 +1863,14 @@ ARCADE</salute>
             <l>giamai di dominar questa mia vita.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Qual possente virtude in sì brev'ora</l>
             <l>sanò l'aspra ferita?</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>E quando mai si vide</l>
@@ -1860,47 +1879,47 @@ ARCADE</salute>
             <l>sanar piaga d'Amore?</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Te pur ferì poc'anzi</l>
             <l>d'Elpinia il fero strale.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>Io porto il cor sicuro</l>
             <l>da l'arme di beltà caduca e frale</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Non favello de' dardi,</l>
             <l>ch'Elpinia ha ne' begli occhi.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>Né co' suoi dolci sguardi,</l>
             <l>né con la destra armata ella m'offese.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>E pur lo disse Amore.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>Se 'l disse Amor, favolleggiare intese.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Empio diletto in ver fingere i mali</l>
@@ -1911,14 +1930,14 @@ ARCADE</salute>
             <l>la mente in parte adombra e turba il ciglio.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>Quanta pietà de' miseri mortali</l>
             <l>nutre il cor degli dei!</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Quella pietà che spesso</l>
@@ -1947,7 +1966,7 @@ ARCADE</salute>
             <l>a gli occhi miei cosa mortal rimembra.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>O sia forza d'Amore o tua virtute,</l>
@@ -1980,7 +1999,7 @@ ARCADE</salute>
             <l>esser non le dovea cagion di pianto.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Segui Amor ch'a tanta luce</l>
@@ -1993,7 +2012,7 @@ ARCADE</salute>
             <l>nel consorzio de gli dei.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l rend="italic">Pur gli eventi acerbi e rei</l>
@@ -2009,7 +2028,7 @@ ARCADE</salute>
             <l>per disdegni.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l rend="italic">Sì funeste memorie</l>
@@ -2025,7 +2044,7 @@ ARCADE</salute>
             <l rend="italic">de' tuoi piacer governo.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>Più beato</l>
@@ -2036,21 +2055,21 @@ ARCADE</salute>
             <l>mai non cangi le sue tempre.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l rend="italic">Amiam sempre</l>
             <l rend="italic">in profonda, amica pace.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>Sia d'Amor la bella face</l>
             <l>nostra luce e nostro ardore.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Tutto è pena e tutto è orrore,</l>
@@ -2058,7 +2077,7 @@ ARCADE</salute>
           </lg>
         </sp>
         <p>***</p>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>Che fate qui fra le terrene cose,</l>
@@ -2066,7 +2085,7 @@ ARCADE</salute>
             <l>Il piacer di là sù nulla vi move?</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Io l'ambrosia immortal non chiedo a Giove</l>
@@ -2074,7 +2093,7 @@ ARCADE</salute>
             <l>è la mia mente accesa.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>E quest'anima intesa</l>
@@ -2084,7 +2103,7 @@ ARCADE</salute>
             <l>o nulla a lei rimane o più non lice.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l rend="italic">Pur se tanto t'infiamma e ti conforta</l>
@@ -2098,7 +2117,7 @@ ARCADE</salute>
             <l>splendon gli dei ne la lor propria luce.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>Quale nova nel cor gioia mi desta</l>
@@ -2113,7 +2132,7 @@ ARCADE</salute>
             <l>e far numi i servi tuoi.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>O sempre caro ed onorato giorno,</l>
@@ -2121,7 +2140,7 @@ ARCADE</salute>
             <l>e 'l mio destino in sì bel nodo strinse!</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>Giunto colà sovra l'eccelse sfere,</l>
@@ -2163,7 +2182,7 @@ ARCADE</salute>
             <l>e le vere obliar cose immortali.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>Voi, dello spirto mio celesti scorte,</l>
@@ -2174,14 +2193,14 @@ ARCADE</salute>
             <l>nel centro de' suoi rai la gloria vostra.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#cintia">
           <speaker>CINTIA</speaker>
           <lg>
             <l>Tu scorgerai quanto è a' seguaci suoi</l>
             <l>Amor liberalissimo e fedele.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <lg>
             <l>Il mio poter si svele</l>
@@ -2190,14 +2209,14 @@ ARCADE</salute>
             <l>a l'immortali sfere.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#endimione">
           <speaker>ENDIMIONE</speaker>
           <lg>
             <l>Le tue promesse, Amor, quanto son vere!</l>
           </lg>
         </sp>
         <p>***</p>
-        <sp>
+        <sp who="#coro">
           <speaker>CORO</speaker>
           <lg>
             <l>Chi potrà mai dentro i consigli tuoi</l>

--- a/tei/leopardi-telesilla.xml
+++ b/tei/leopardi-telesilla.xml
@@ -82,6 +82,37 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="pastore_1">
+            <persName>Un pastorello</persName>
+          </person>
+          <person xml:id="pastore_2">
+            <persName>Un altro pastorello</persName>
+          </person>
+          <person xml:id="pastorella">
+            <persName>Una pastorella</persName>
+          </person>
+          <person xml:id="danaino">
+            <persName>Danaino</persName>
+          </person>
+          <person xml:id="donna">
+            <persName>Una donna</persName>
+          </person>
+          <person xml:id="girone">
+            <persName>Girone</persName>
+          </person>
+          <person xml:id="telesilla">
+            <persName>Telesilla</persName>
+          </person>
+          <person xml:id="cacciatore_1">
+            <persName>I° cacciatore</persName>
+          </person>
+          <person xml:id="cacciatore_2">
+            <persName>II° cacciatore</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LEXIS</name>Digitalizzazione</change>
@@ -126,200 +157,200 @@
     <body>
       <div>
         <head>Parte 1</head>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l>Spingiamo il gregge sotto a queste querce:</l>
           <l part="I">Ve' come piove?</l>
         </sp>
-        <sp>
+        <sp who="#pastore_2">
           <speaker>II PASTORE</speaker>
           <l part="M">Io no.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l part="F">Mira d'incontro</l>
           <l part="I">A quelle piante.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_2">
           <speaker>II PASTORE</speaker>
           <l part="F">Or sento l'acqua in viso.</l>
           <l>Presto al coperto; in là, che vi potreste</l>
           <l>Immollar tutte, e par che l'acqua ingrossi.</l>
         </sp>
-        <sp>
+        <sp who="#pastorella">
           <speaker>PASTORELLA</speaker>
           <l>Oimè ch'ella n'ha colti in un momento.</l>
           <l>Se dura infino a notte, io non so come</l>
           <l>Ricondurrem le pecorelle a casa.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l>Non temer no, che 'l cielo è chiaro, e questo</l>
           <l part="I">Nuvoletto è legger.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_2">
           <speaker>II PASTORE</speaker>
           <l part="F">Croscia pur, croscia</l>
           <l>Che 'l gregge avrà più fresca la pastura;</l>
           <l>E ben di piova al prato era bisogno.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l>Se ponente non s'alza, in poco d'ora</l>
           <l part="I">Torna il sereno.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_2">
           <speaker>II PASTORE</speaker>
           <l part="F">Ecco già 'l nembo allenta.</l>
           <l part="I">Oh fu pur breve cosa.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l part="F">Ei non potea</l>
           <l part="I">Fare altrimenti.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_2">
           <speaker>II PASTORE</speaker>
           <l part="F">Ecco vien fuora il sole,</l>
           <l>E 'l canto de gli uccei si rinnovella:</l>
           <l>Pur sento a strepitar l'acqua nel fosso.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l>Via fuori a pascolar, che così fresco</l>
           <l>Fil d'erba non provaste assai gran tempo.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_2">
           <speaker>II PASTORE</speaker>
           <l>Vien qua, veggiam di qui chi prima coglie</l>
           <l part="I">D'un sasso in quel troncon.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l part="F">Via togli un sasso,</l>
           <l part="I">E traggi.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_2">
           <speaker>II PASTORE</speaker>
           <l part="F">Io trarrò poscia, e tu davanti.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l>Io no, se 'l colpo tuo prima non veggio.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_2">
           <speaker>II PASTORE</speaker>
           <l part="I">Ned io trarrò.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l part="F">Ned io: tu che sfidasti</l>
           <l part="I">Dei gire innanzi.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_2">
           <speaker>II PASTORE</speaker>
           <l part="F">Io ti sfidai, ma 'l patto</l>
           <l>È ch'i' non deggia trar se non da poi.</l>
         </sp>
-        <sp>
+        <sp who="#pastorella">
           <speaker>PASTORELLA</speaker>
           <l>Date un sasso, io trarrò, ben ch'io non sappia.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_2">
           <speaker>II PASTORE</speaker>
           <l>Sta qui, tien questo, e tira. Oh oh, gli è gito</l>
           <l>A ritrovar le stelle, e 'l tronco è in terra.</l>
         </sp>
-        <sp>
+        <sp who="#pastorella">
           <speaker>PASTORELLA</speaker>
           <l part="I">Io 'l dissi già ch'io non sapeva.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l part="F">Io, io.</l>
           <l part="I">Guata. Oimè ch'io fallai.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_2">
           <speaker>II PASTORE</speaker>
           <l part="F">Mel credea bene.</l>
           <l>Or vo che diate mente a questo tratto.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l>Deh lascia ch'io mi provi un'altra volta</l>
           <l part="I">S'io ci so cor.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_2">
           <speaker>II PASTORE</speaker>
           <l part="F">Ti proverai dappresso</l>
           <l>Quant'avrai voglia; or è dover ch'io tragga.</l>
           <l part="I">Vedi tu? vedi?</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l part="F">Io saprò fare anch'io:</l>
           <l part="I">Lasciami il loco.</l>
         </sp>
-        <sp>
+        <sp who="#pastorella">
           <speaker>PASTORELLA</speaker>
           <l part="F">Oimè, guardate indietro.</l>
           <l>Io veggio un cavaliero armato in sella.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_2">
           <speaker>II PASTORE</speaker>
           <l>Eh pazza, ell'è una pianta. Oimè ch'io temo</l>
           <l part="I">Che dica vero.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l part="F">Io pure io pur lo scorgo.</l>
           <l part="I">Vien dritto inverso noi.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_2">
           <speaker>II PASTORE</speaker>
           <l part="M">Fuggiamo.</l>
         </sp>
-        <sp>
+        <sp who="#pastorella">
           <speaker>PASTORELLA</speaker>
           <l part="F">Oh tristi</l>
           <l part="I">Oh persi noi.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l part="F">Che fate? oh Dio, mi spiace</l>
           <l>Di queste pecorelle: io non ritrovo</l>
           <l>Che m'aggia a far: bisognerà ch'io fugga.</l>
         </sp>
-        <sp>
+        <sp who="#danaino">
           <speaker>DANAINO</speaker>
           <stage>(a cavallo)</stage>
           <l>Olà quel pastorel, fermati; un motto;</l>
           <l>Ascolta, dove corri? ascolta un poco,</l>
           <l part="I">Non mi fuggir.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l part="F">Che vuoi? lasciami andare.</l>
         </sp>
-        <sp>
+        <sp who="#danaino">
           <speaker>DANAINO</speaker>
           <l>Hai tanta fretta? o ch'io ti fo paura?</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l>Forse che non me n'hanno a far quell'armi?</l>
         </sp>
-        <sp>
+        <sp who="#danaino">
           <speaker>DANAINO</speaker>
           <l>Fa cor, vien qua, non dubitar, non fanno</l>
           <l part="I">Male a nessuno.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l part="F">Or non vegg'io quell'asta</l>
           <l part="I">Insanguinata?</l>
         </sp>
-        <sp>
+        <sp who="#danaino">
           <speaker>DANAINO</speaker>
           <l part="F">È sangue d'un nemico,</l>
           <l>Ch'ucciso ho poco lungi. A gl'inimici</l>
@@ -327,20 +358,20 @@
           <l>Non fa discortesia. Dimmi, non usi</l>
           <l part="I">Pascere in questo colle?</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l part="M">Io sì.</l>
         </sp>
-        <sp>
+        <sp who="#danaino">
           <speaker>DANAINO</speaker>
           <l part="F">Vedesti</l>
           <l part="I">Passare oggi verun?</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l part="M">Veruno.</l>
         </sp>
-        <sp>
+        <sp who="#danaino">
           <speaker>DANAINO</speaker>
           <l part="F">Omai</l>
           <l>Dunque avranno a passar di questo loco</l>
@@ -356,58 +387,58 @@
           <l>Di più dimora, e tornerà domani</l>
           <l part="I">A Maloalto.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l part="F">Come io gli abbia visti</l>
           <l part="I">Conterò loro il tutto.</l>
         </sp>
-        <sp>
+        <sp who="#danaino">
           <speaker>DANAINO</speaker>
           <l part="F">Avrollo caro,</l>
           <l>E ti farò quel ben che tu vorrai</l>
           <l>S'accadrà ch'io ti veggia in Maloalto.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l part="I">Tu dunque se' di Maloalto?</l>
         </sp>
-        <sp>
+        <sp who="#danaino">
           <speaker>DANAINO</speaker>
           <l part="F">Io sono</l>
           <l>Il signor del castello. Or tieni a mente</l>
           <l part="I">Quel che ti convien dire?</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l part="F">A motto a motto.</l>
         </sp>
-        <sp>
+        <sp who="#danaino">
           <speaker>DANAINO</speaker>
           <l part="I">Bene sta. Dio ti guardi.</l>
         </sp>
-        <sp>
+        <sp who="#pastorella">
           <speaker>PASTORELLA</speaker>
           <l part="M">È gito?</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l part="F">È gito.</l>
           <l>T'accosta, non temer, ch'ei non fa male</l>
           <l part="I">A i pastorelli.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_2">
           <speaker>II PASTORE</speaker>
           <l part="F">Udito abbiam da lungi</l>
           <l>Tutto quanto e' dicea, ch'e' parlav'alto</l>
           <l>Però che anco tu stavi a udir da lungi.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l>Ben timor m'avea posto al primo tratto,</l>
           <l>Ma poscia ho preso core. Io non credea</l>
           <l>Che i cavalier parlassero a quel modo.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_2">
           <speaker>II PASTORE</speaker>
           <l>In ver ch'a le parole ei rassomiglia</l>
           <l>A la gente che d'arme non si veste.</l>
@@ -417,70 +448,70 @@
           <l>Favellan come fosser de la gente,</l>
           <l>Come noi siam, che non fa danno altrui.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l>S'avvien ch'io lo riveggia, io vo' far prova</l>
           <l>Di chiedergli qualcosa. Or guata come</l>
           <l>Tutte le pecorelle son disperse</l>
           <l>Per tema del cavallo e del guerriero.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_2">
           <speaker>II PASTORE</speaker>
           <l>Pon mente a quelle, io vo da questo lato.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l part="I">Bada a quella che fugge.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_2">
           <speaker>II PASTORE</speaker>
           <l part="F">Al tutto vuolsi</l>
           <l part="I">Fiaccare il collo: io pur l'ho giunta.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l part="F">Oh Dio,</l>
           <l>Quell'agnella s'è fitta entro la macchia.</l>
           <l>Or venganela a trar chi n'avrà modo.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_2">
           <speaker>II PASTORE</speaker>
           <l>Fa cor, ch'io la riveggio. Ecco vien fuora</l>
           <l>Da per se stessa, e tutte son raccolte.</l>
         </sp>
-        <sp>
+        <sp who="#pastorella">
           <speaker>PASTORELLA</speaker>
           <l>U' u', che cosa è quel che va saltando?</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l>Un grillo, un grillo. Oh s'io lo ritrovassi,</l>
           <l>Che già pronta ho la gabbia è tanto tempo,</l>
           <l part="I">Nè mai n'ho colto un solo.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_2">
           <speaker>II PASTORE</speaker>
           <l part="F">Aspetta aspetta,</l>
           <l>Ch'ei sta qui dentro. Cheti, ch'e' non fugga.</l>
           <l>Lasciate far: veggiamo a poco a poco.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l part="I">Dov'è ch'io nol ritrovo?</l>
         </sp>
-        <sp>
+        <sp who="#pastorella">
           <speaker>PASTORELLA</speaker>
           <l part="F">Io non lo veggio.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_2">
           <speaker>II PASTORE</speaker>
           <l>Forz'è ch'e' sia fuggito, io non so dove.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l part="I">Mi duol.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_2">
           <speaker>II PASTORE</speaker>
           <l part="F">Non te ne caglia: agevolmente</l>
           <l>Ne troverem più che non brami. Oh guata:</l>
@@ -490,90 +521,90 @@
           <l>Che non ci fuggiran questi da gli occhi</l>
           <l part="I">Sì come il grillo.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l part="F">Oh quanto è grosso e bianco</l>
           <l part="I">Questo ch'i' ho colto.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_2">
           <speaker>II PASTORE</speaker>
           <l part="F">Io n'ho ben de' più belli.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l part="I">Dove son?</l>
         </sp>
-        <sp>
+        <sp who="#pastore_2">
           <speaker>II PASTORE</speaker>
           <l part="M">Vedi questo.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l part="F">Io troveronne</l>
           <l part="I">Un che sia meglio.</l>
         </sp>
-        <sp>
+        <sp who="#pastorella">
           <speaker>PASTORELLA</speaker>
           <l part="F">Ecco, io ne veggio, appresso</l>
           <l>A quella pianta, un micolin più dietro.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l part="I">Questa? è una foglia secca.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_2">
           <speaker>II PASTORE</speaker>
           <l part="F">E tu che badi?</l>
           <l>Che non vieni a cor funghi, e pieno è il prato.</l>
         </sp>
-        <sp>
+        <sp who="#pastorella">
           <speaker>PASTORELLA</speaker>
           <l>Lasciatemi filar, ch'io non ho voglia</l>
           <l>Di gire al sol, però ch'annera il viso.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_2">
           <speaker>II PASTORE</speaker>
           <l>Dilicata, ei non ha forza nessuna</l>
           <l>Or ch'ei tramonta, e battemi ne gli occhi</l>
           <l>Senza danno. E ben puoi tenerti a l'ombra</l>
           <l part="I">Or ch'è sì lunga.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l part="F">Io vo' che tu riceva</l>
           <l>Nel grembial questi funghi, ond'ho già pieno</l>
           <l>Tutto il cappello, e non m'avanza loco.</l>
         </sp>
-        <sp>
+        <sp who="#pastorella">
           <speaker>PASTORELLA</speaker>
           <l part="I">Versagli pur.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_2">
           <speaker>II PASTORE</speaker>
           <l part="F">Lascia ch'io versi anch'io</l>
           <l part="I">Questi che ho colti.</l>
         </sp>
-        <sp>
+        <sp who="#pastorella">
           <speaker>PASTORELLA</speaker>
           <l part="M">Orsù.</l>
         </sp>
-        <sp>
+        <sp who="#donna">
           <speaker>DONNA</speaker>
           <l part="F">Figliuoli miei.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l>Guata; questi son funghi: abbiamgli colti</l>
           <l>Tutti dopo la piova, e son assai</l>
           <l part="I">Come vedi.</l>
         </sp>
-        <sp>
+        <sp who="#donna">
           <speaker>DONNA</speaker>
           <l part="F">Io n'ho gusto. Io son venuta</l>
           <l>Per richiamarvi a casa, ch'egli è tempo</l>
           <l>Di ricondur la greggia al pecorile.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l>Io voleva aspettar che visto avessi</l>
           <l>Certi che qui vicino a passar hanno</l>
@@ -581,7 +612,7 @@
           <l>Da un cavalier che qui passava, e detto</l>
           <l>Hammi da ridir loro alcune cose.</l>
         </sp>
-        <sp>
+        <sp who="#donna">
           <speaker>DONNA</speaker>
           <l>Figliuol mio, l'ora è tarda, e già calato</l>
           <l>È 'l sol, nè più coloro oggi, cred'io,</l>
@@ -592,32 +623,32 @@
           <l>Nè sta sicuro il gregge se non chiuso</l>
           <l part="I">Come il sole è corcato.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_1">
           <speaker>I PASTORE</speaker>
           <l part="F">A me non cale</l>
           <l part="I">Del cavalier gran fatto.</l>
         </sp>
-        <sp>
+        <sp who="#pastorella">
           <speaker>PASTORELLA</speaker>
           <l part="F">Io questi funghi</l>
           <l part="I">Porterò.</l>
         </sp>
-        <sp>
+        <sp who="#donna">
           <speaker>DONNA</speaker>
           <l part="F">Voi mettetevi la greggia</l>
           <l part="I">Dinanzi.</l>
         </sp>
-        <sp>
+        <sp who="#pastore_2">
           <speaker>II PASTORE</speaker>
           <l part="F">Or via, su, tosto, al pecorile.</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <l>Poniamci a riposar sopra quest'erba,</l>
           <l>Ch'ameno è 'l sito, e quinci a Maloalto</l>
           <l part="I">Non è gran tratto.</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l part="F">Oh come fanno scuro</l>
           <l>Queste piante, se bene anco non debbe</l>
@@ -627,7 +658,7 @@
           <l>Di nessuno abituro, e non si sente</l>
           <l>Altro suon che de' grilli e de le rane.</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <l>Fors'hai qualche temenza? Esser non puote</l>
           <l>Ch'altri ti faccia danno infin ch'io viva:</l>
@@ -641,76 +672,76 @@
           <l>Io fremo dal diletto ogni qual volta</l>
           <l part="I">Io mel figuro.</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l part="F">Oh non dir questo mai,</l>
           <l>Che mi si stringe il cor. Se tu morissi,</l>
           <l part="I">Allora io pur morrei.</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <l part="F">Che vuol dir questo?</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l>Ch'altro, se non ch'io vo' che tu sia vivo?</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <l>Mi vuoi tu soddisfar d'una dimanda?</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l part="I">Che c'è da dimandar?</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <l part="F"> Narrami il vero</l>
           <l>O Telesilla mia: forse tu m'ami?</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l part="I">Io t'amo?</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <l part="F">I' sapea ben ch'era un inganno.</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l part="I">Che inganno?</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <l part="F">Io mi credea che tu m'amassi,</l>
           <l part="I">Pazzo ch'io fui.</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l part="M">Deh perchè pazzo?</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <l part="F">Al tutto</l>
           <l>Pazzo è chi crede quel ch'esser non puote.</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l part="I">Perchè non può? se tu sapessi.</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <l part="F">Oh cara,</l>
           <l part="I">M'ami?</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l part="F">Deh taci oh Dio, che non ti senta</l>
           <l>Veruno, e Danain che nol risappia.</l>
           <l>Oimè. che cosa io dissi? io già non dissi</l>
           <l part="I">D'amarti, ch'ei non lice.</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <l part="F">O Telesilla,</l>
           <l>Io lo so bene. Ed io? forse ch'io posso</l>
@@ -725,31 +756,31 @@
           <l>Nè spiegar non si puote. Oh se vedessi</l>
           <l part="I">Questo mio core.</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l part="M">E questo?</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <l part="F">O mia beltade,</l>
           <l>Quant'è che quest'affetto in sen ti nacque?</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l part="I">Gran tempo.</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <l part="F">E non ne desti alcun segnale?</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l>Io mi credea d'averne dato assai,</l>
           <l>E temea che palese il tutto fosse,</l>
           <l>Anzi che tu 'l sapessi, e non per questo</l>
           <l part="I">Ti calesse di me.</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <l part="F">Questo ti parse</l>
           <l>O poverella? Ed io come sovente</l>
@@ -774,7 +805,7 @@
           <l>Anzi non veggio pur come tu sia</l>
           <l part="I">Bastata a sopportarlo.</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l part="F">Oh me dolente:</l>
           <l>Sperimentato io l'ho più fera cosa</l>
@@ -786,7 +817,7 @@
           <l>E cruciato ch'io mai non ho speranza</l>
           <l part="I">Di racquetarlo.</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <l part="F">O Telesilla mia,</l>
           <l>S'i' avessi questa mane avuto a scerre</l>
@@ -801,73 +832,73 @@
           <l>Su via, guardami in volto, oh come tutta</l>
           <l part="I">Se' pallida e sudata.</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l part="F">Oimè, non sei</l>
           <l>Tu pur lo stesso? oh che sembiante è questo</l>
           <l>Di spaurito anzi a morir vicino.</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <l>Deh chi sperato avria così da presso</l>
           <l>Già mai veder quest'occhi e queste labbra?</l>
           <l part="I">Noi siam qui soli?</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l part="M">Il vedi.</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <l part="F">E certo è lungi</l>
           <l>Danaino, e farà lunga dimora?</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l part="I">Tel disse egli partendo.</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <l part="F">E l'ora è tarda,</l>
           <l>Nè più secreto loco ha ne' dintorni.</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l>O mio Girone, io tremo tutta, e 'l fiato</l>
           <l part="I">Mi manca.</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <l part="F">Io sudo freddo, e 'l cor mi batte</l>
           <l>Più forte che provato io non ho mai.</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l>Deh chi n'ha posti insieme in questo loco</l>
           <l part="I">E in questo tempo?</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <l part="F">In ver che 'l tutto ad arte</l>
           <l>Par fatto, e non a caso, e non darassi</l>
           <l>A noi tal congiuntura un'altra volta</l>
           <l part="I">Fin che vivremo.</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l part="F">Oh Dio, taci: non pensi</l>
           <l>Che noi bramiamo alfin quel che non lice?</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <l>Tu parli ver, ma certo io sono al tutto</l>
           <l part="I">Fuori del senno.</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l part="M">Oh Danain.</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <l part="F">Deh come</l>
           <l>Potrò far ch'io t'offenda amico mio,</l>
@@ -883,12 +914,12 @@
           <l>Non temer, non sarà, pria mi vo' torre</l>
           <l part="I">Con questa man la vita.</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l part="F">Oh non foss'egli</l>
           <l part="I">Partito mai.</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <l part="F">Deh così fosse; ch'io;</l>
           <l>Mi sento preso e strascinato in modo</l>
@@ -899,41 +930,41 @@
           <l>Già mai dal pentimento e dal desio</l>
           <l part="I">Non avrò pace.</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l part="F">Oimè, dunqu'or nessuna</l>
           <l>Difficoltà ci vieta il desir nostro?</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <l part="I">Ben ch'io cerchi, nessuna.</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l part="F">Oh tristi noi.</l>
           <l part="I">Ma divulgar mai non potrassi?</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <l part="F">E come?</l>
           <l>Se non ci vede o sente anima viva.</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l part="I">Nè pentiremci poi?</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <l part="F">Non so, ma parmi</l>
           <l>Che quando io l'abbia fatto, acqueterommi.</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l>Io tutta abbrividisco, e le ginocchia</l>
           <l>Mi sento sciorre, ed ogni cosa al guardo</l>
           <l>Mi traballa: io son presso a venir manco.</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <stage>(levato in piedi)</stage>
           <l>Oh cielo oh cielo, a questa colpa quale</l>
@@ -941,21 +972,21 @@
           <l>Affanno se 'l fuggirla è in nostra mano?</l>
           <l part="I">Certo che noi siam folli.</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l part="F">Oh mio Girone.</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <l>Io nol vo' far già mai; pur quand'io voglia,</l>
           <l part="I">Farollo un'altra volta.</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l part="F">Un'altra volta,</l>
           <l part="I">Non ora.</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <l part="F"> Io veggio ben che ci conviene</l>
           <l>Deliberarci adesso, e che già mai</l>
@@ -975,21 +1006,21 @@
           <l>Ogni pensier di questi fatti: ad altro</l>
           <l part="I">Volgiamo il favellar.</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l part="F"> Tu ben ragioni.</l>
           <l>Io sento al petto rallargar la chiusa,</l>
           <l>E la foga del cor s'allenta: io provo</l>
           <l part="I">Alquanto di conforto.</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <stage>(assiso)</stage>
           <l part="F">Io vo' che 'l dove</l>
           <l>E 'l perchè tu mi narri e 'l quando accesa</l>
           <l part="I">Di me ti fosti.</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l part="F">Il giorno ch'io ti vidi</l>
           <l>Nel castel de le Suore al torniamento,</l>
@@ -1019,7 +1050,7 @@
           <l>E ancor non m'avvedea che fosse amore;</l>
           <l part="I">Nè me n'avvidi altro che tardi.</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <l part="F"> O mia</l>
           <l>Povera Telesilla, or vedi come</l>
@@ -1071,22 +1102,22 @@
           <l>Cordoglio struggerammi, avrai tu nullo</l>
           <l part="I">Pensier di questo sfortunato?</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l part="F">Oh mai</l>
           <l>Non favellar così. Ma forse in breve</l>
           <l part="I">Se' per lasciarmi?</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <l part="F">È forza, e immantinente</l>
           <l>Come t'ho ricondotta a Maloalto.</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l part="I"> Oimè, dunque sì tosto?</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <l part="F">O cara, al pianto</l>
           <l>Siam prodotti ambedue. Non ci vedremo</l>
@@ -1103,23 +1134,23 @@
           <stage>(Levato in piedi)</stage>
           <l part="M">Dammi la man.</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l part="F">Girone.</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <l>Dammi la mano. O Telesilla, oh quanto</l>
           <l part="I">Se' bella.</l>
         </sp>
-        <sp>
+        <sp who="#telesilla">
           <speaker>TELESILLA</speaker>
           <l part="F">Oh caro oh caro: io più non veggio.</l>
         </sp>
       </div>
       <div>
         <head>Parte 2</head>
-        <sp>
+        <sp who="#cacciatore_1">
           <speaker>I CACCIATORE</speaker>
           <l>Io sento urlare i lupi, e s'io non fallo</l>
           <l>Non denno esser da lungi. Andiam più ratti</l>
@@ -1132,7 +1163,7 @@
           <l>Poco tempo n'avanza, ed è ben presso</l>
           <l part="I">Al giorno.</l>
         </sp>
-        <sp>
+        <sp who="#cacciatore_2">
           <speaker>II CACCIATORE</speaker>
           <l part="F">Aspetta un poco: ei non s'arriva</l>
           <l>Da questo colle a discoprire un tratto</l>
@@ -1143,7 +1174,7 @@
           <l>Già la marina è chiara, e la diana</l>
           <l part="I">È già levata.</l>
         </sp>
-        <sp>
+        <sp who="#cacciatore_1">
           <speaker>I CACCIATORE</speaker>
           <l part="F">Orsù non ci conviene</l>
           <l>Punto indugiar, che starà poco il sole.</l>
@@ -1155,7 +1186,7 @@
           <l>A latrar i mastini. Abbi riguardo</l>
           <l>A l'armi che non dien luce nè suono.</l>
         </sp>
-        <sp>
+        <sp who="#girone">
           <speaker>GIRONE</speaker>
           <stage>(dietro alle piante)</stage>
           <l>Chi è? chi sei? che voce è questa? Alcuno</l>

--- a/tei/machiavelli-clizia.xml
+++ b/tei/machiavelli-clizia.xml
@@ -81,6 +81,37 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="palmede">
+            <persName>Palmede</persName>
+          </person>
+          <person xml:id="cleandro">
+            <persName>Cleandro</persName>
+          </person>
+          <person xml:id="eustachio">
+            <persName>Eustachio</persName>
+          </person>
+          <person xml:id="nicomaco">
+            <persName>Nicomaco</persName>
+          </person>
+          <person xml:id="pirro">
+            <persName>Pirro</persName>
+          </person>
+          <person xml:id="sofronia">
+            <persName>Sofronia</persName>
+          </person>
+          <person xml:id="damone">
+            <persName>Damone</persName>
+          </person>
+          <person xml:id="doria">
+            <persName>Doria</persName>
+          </person>
+          <person xml:id="ramondo">
+            <persName>Ramondo</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -136,175 +167,175 @@
         <div type="scene">
           <head>SCENA PRIMA</head>
           <stage>Palamede, Cleandro</stage>
-          <sp>
+          <sp who="#palmede">
             <speaker>PAL.</speaker>
             <p>Tu esci sì a buon'ora di casa?</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Tu, donde vieni sì a buon'ora?</p>
           </sp>
-          <sp>
+          <sp who="#palmede">
             <speaker>PAL.</speaker>
             <p>Da fare una mia faccenda. </p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Ed io vo a farne un'altra, o, a dire meglio, a cercarla di fare, perché s'io la farò, non ne ho certezza alcuna.</p>
           </sp>
-          <sp>
+          <sp who="#palmede">
             <speaker>PAL.</speaker>
             <p>È ella cosa che si possa dire?</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Non so, ma io so bene che la è cosa, che con difficultà si può fare.</p>
           </sp>
-          <sp>
+          <sp who="#palmede">
             <speaker>PAL.</speaker>
             <p>Orsù, io me ne voglio ire, che io veggo come lo stare accompagnato t'infastidisce; e per questo io ho sempre fuggito la pratica tua, perché sempre ti ho trovato mal disposto e fantastico. </p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Fantastico no, ma innamorato sì.</p>
           </sp>
-          <sp>
+          <sp who="#palmede">
             <speaker>PAL.</speaker>
             <p>Togli! Tu mi racconci la cappellina in capo!</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Palamede mio, tu non sai mezze le messe. Io sono sempre vivuto disperato, ed ora vivo più che mai. </p>
           </sp>
-          <sp>
+          <sp who="#palmede">
             <speaker>PAL.</speaker>
             <p>Come così?</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Quello ch'io t'ho celato per lo adrieto, io ti voglio manifestare ora, poiché mi sono redutto al termine che mi bisogna soccorso da ciascuno.</p>
           </sp>
-          <sp>
+          <sp who="#palmede">
             <speaker>PAL.</speaker>
             <p>Se io stavo mal volentieri teco in prima, io starò peggio ora, perché io ho sempre inteso, che tre sorte di uomini si debbono fuggire: cantori, vecchi ed innamorati. Perché, se usi con uno cantore e narrigli uno tuo fatto, quando tu credi che t'oda, e' ti spicca uno ut, re, mi, fa, sol, la, e gorgogliasi una canzonetta in gola. Se tu sei con uno vecchio, e' ficca el capo in quante chiese e' truova, e va a tutti gli altari a borbottare uno paternostro. Ma di questi duoi lo innamorato è peggio, perché non basta che, se tu gli parli, e' pone una vigna che t'empie gli orecchi di rammarichii e di tanti suoi affanni, che tu sei sforzato a moverti a compassione: perché, s'egli usa con una cantoniera, o ella lo assassina troppo, o ella lo ha cacciato di casa, sempre vi è qualcosa che dire; s'egli ama una donna da bene mille invidie, mille gelosie, mille dispetti lo perturbano; mai non vi manca cagione di dolersi. Pertanto, Cleandro mio, io userò tanto teco, quanto tu arai bisogno di me, altrimenti io fuggirò questi tuoi dolori.</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Io ho tenute occulte queste mie passioni infino ad ora per coteste cagioni, per non essere fuggito come fastidioso o uccellato come ridiculo, perché io so che molti, sotto spezie di carità, ti fanno parlare, e poi ti ghignano drieto. Ma, poiché ora la Fortuna m'ha condotto in lato, che mi pare avere pochi rimedii, io te lo voglio conferire, per sfogarmi in parte, e anche perché, se mi bisognassi il tuo aiuto, che tu me lo presti.</p>
           </sp>
-          <sp>
+          <sp who="#palmede">
             <speaker>PAL.</speaker>
             <p>Io sono parato, poiché tu vuoi, ad ascoltar tutto, e così a non fuggire né disagi né pericoli, per aiutarti.</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Io lo so. Io credo che tu abbia notizia di quella fanciulla, che noi ci abbiamo allevata.</p>
           </sp>
-          <sp>
+          <sp who="#palmede">
             <speaker>PAL.</speaker>
             <p>Io l'ho veduta. Donde venne?</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Dirottelo. Quando, dodici anni sono, nel 1494, passò il re Carlo per Firenze, che andava con uno grande essercito alla impresa del Regno, alloggiò in casa nostra uno gentile uomo della compagnia di monsignor di Fois, chiamato Beltramo di Guascogna. Fu costui da mio padre onorato, ed egli, perché uomo da bene era, riguardò ed onorò la casa nostra; e dove molti feciono una inimicizia con quelli Franzesi avevano in casa, mio padre e costui contrassono una amicizia grandissima.</p>
           </sp>
-          <sp>
+          <sp who="#palmede">
             <speaker>PAL.</speaker>
             <p>Voi avesti una gran ventura più che gli altri, perché quelli che furono messi in casa nostra ci feciono infiniti mali.</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Credolo; ma a noi non intervenne così. Questo Beltramo ne andò con il suo re a Napoli; e, come tu sai, vinto che Carlo ebbe quel regno, fu constretto a partirsi, perché 'l papa, imperadore, Viniziani e duca di Milano se gli erano conlegati contro. Lasciate, pertanto, parte delle sue gente a Napoli, con il resto se ne venne verso Toscana; e, giunto a Siena, perch'egli intese la Lega avere uno grossissimo essercito sopra il Taro, per combatterlo allo scendere de' monti, gli parve da non perdere tempo in Toscana; e perciò, non per Firenze, ma per la via di Pisa e di Pontremoli, passò in Lombardia. Beltramo sentito il romore de' nimici, e dubitando, come intervenne, non avere a fare la giornata con quelli, avendo in tra la preda fatta a Napoli questa fanciulla, che allora doveva avere cinque anni, d'una bella aria e tutta gentile, deliberò di tôrla d'inanzi a' pericoli, e per uno suo servidore la mandò a mio padre, pregandolo che per suo amore dovessi tanto tenerla, che a più commodo tempo mandassi per lei; né mandò a dire se la era nobile o ignobile: solo ci significò che la si chiamava Clizia. Mio padre e mia madre, perché non avevano altri figliuoli che me, subito se ne innamororono.</p>
           </sp>
-          <sp>
+          <sp who="#palmede">
             <speaker>PAL.</speaker>
             <p>Innamorato te ne sarai tu!</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Lasciami dire! E come loro cara figliuola la trattorono. Io, che allora avevo dieci anni, mi cominciai, come fanno e fanciulli, a trastullare seco, e le posi uno amore estraordinario, il quale sempre con la età crebbe; di modo che, quando ella arrivò alla età di dodici anni, mio padre e mia madre cominciorono ad avermi gli occhi alle mani, in modo che, se io solo gli parlavo, andava sottosopra la casa. Questa strettezza (perché sempre si desidera più ciò che si può avere meno) raddoppiò lo amore, ed hammi fatto e fa tanta guerra, che io vivo con più affanni, che s'io fussi in inferno.</p>
           </sp>
-          <sp>
+          <sp who="#palmede">
             <speaker>PAL.</speaker>
             <p>Beltramo, mandò mai per lei?</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Di cotestui non si intese mai nulla: crediamo che morissi nella giornata del Taro.</p>
           </sp>
-          <sp>
+          <sp who="#palmede">
             <speaker>PAL.</speaker>
             <p>Così dovette essere. Ma dimmi: che vuoi tu fare? A che termine sei? Vuo'la tu tôr per moglie, o vorrestila per amica? Che t'impedisce, avendola in casa? Può essere che tu non ci abbia rimedio?</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Io t'ho a dire dell'altre cose, che saranno con mia vergogna, perciò ch'io voglio che tu sappi ogni cosa.</p>
           </sp>
-          <sp>
+          <sp who="#palmede">
             <speaker>PAL.</speaker>
             <p>Di' pure.</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>E' mi vien voglia, disse colei, di ridere, ed ho male! Mio padre se n'è innamorato anch'egli.</p>
           </sp>
-          <sp>
+          <sp who="#palmede">
             <speaker>PAL.</speaker>
             <p>Chi, Nicomaco?!</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Nicomaco, sì. </p>
           </sp>
-          <sp>
+          <sp who="#palmede">
             <speaker>PAL.</speaker>
             <p>Puollo fare Iddio? </p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>E' lo può fare Iddio e' santi! </p>
           </sp>
-          <sp>
+          <sp who="#palmede">
             <speaker>PAL.</speaker>
             <p>Oh! questo è il più bel caso, ch'io sentissi mai: e' non se ne guasta se non una casa. Come vivete insieme? che fate? a che pensate? tua madre, sa queste cose? </p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>E' lo sa mia madre, le fante, e famigli: egli è una tresca el fatto nostro! </p>
           </sp>
-          <sp>
+          <sp who="#palmede">
             <speaker>PAL.</speaker>
             <p>Dimmi: infine, dove è ridotta la cosa? </p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Dirottelo. Mio padre, per moglie, quando bene e' non ne fussi innamorato, non me la concederebbe mai, perché è avaro, ed ella è sanza dota. Dubita anche che la non sia ignobile. Io, per me, la tôrrei per moglie, per amica, ed in tutti quelli modi ch'io la potessi avere. Ma di questo non accade ragionare ora. Solo ti dirò dove noi ci troviamo. </p>
           </sp>
-          <sp>
+          <sp who="#palmede">
             <speaker>PAL.</speaker>
             <p>Io l'arò caro. </p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Tosto che mio padre si innamorò di costei, che debbe essere circa uno anno, e desiderando di cavarsi questa voglia, che lo fa proprio spasimare, pensò che non c'era altro rimedio che maritarla ad uno che poi gliene accomunassi, perché tentare d'averla prima che maritata gli debbe parere cosa impia e brutta; e, non sapendo dove si gittare, ha eletto per il più fidato a questa cosa Pirro, nostro servo, e menò tanta segreta questa sua fantasia che ad uno pelo la fu per condursi, prima che altri se ne accorgessi. Ma Sofronia, mia madre, che prima un pezzo dello innamoramento si era avveduta, scoperse questo agguato, e con ogni industria, mossa da gelosia ed invidia, attende a guastare. Il che non ha potuto far meglio, che mettere in campo uno altro marito, e biasimare quello; e dice volerla dare ad Eustacchio, nostro fattore. E benché Nicomaco sia di più autorità, nondimeno l'astuzia di mia madre, gli aiuti di noi altri, che, sanza molto scoprirci, gli facciamo, ha tenuta la cosa in ponte più settimane. Tuttavia Nicomaco ci serra forte, ed ha deliberato, a dispetto di mare e di vento, fare oggi questo parentado, e vuole che la meni questa sera, ed ha tolto a pigione quella casetta, dove abita Damone, vicino a noi e dice che gliene vuole comperare, fornirla di masserizie, aprirgli una bottega, e farlo ricco. </p>
           </sp>
-          <sp>
+          <sp who="#palmede">
             <speaker>PAL.</speaker>
             <p>A te che importa che l'abbia più Pirro che Eustacchio? </p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Come, che m'importa? Questo Pirro è il maggiore ribaldello che sia in Firenze, perché, oltre ad averla pattuita con mio padre, è uomo che mi ebbe sempre in odio, di modo ch'io vorrei che l'avessi più tosto el diavolo dell'inferno. Io scrissi ieri al fattore, che venissi a Firenze: maravigliomi ch'e' non venne iersera. Io voglio star qui, a vedere s'io lo vedessi comparire. Tu, che farai? </p>
           </sp>
-          <sp>
+          <sp who="#palmede">
             <speaker>PAL.</speaker>
             <p>Andrò a fare una mia faccenda. </p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Va', in buon'ora. </p>
           </sp>
-          <sp>
+          <sp who="#palmede">
             <speaker>PAL.</speaker>
             <p>Addio. Temporeggiati il meglio puoi, e, se vuoi cosa alcuna, parla. </p>
           </sp>
@@ -312,7 +343,7 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>Cleandro solo</stage>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Veramente chi ha detto che lo innamorato ed il soldato si somigliono ha detto il vero. El capitano vuole che i suoi soldati sien giovani, le donne vogliono che i loro amanti non sieno vecchi. Brutta cosa vedere un vecchio soldato, bruttissima è vederlo innamorato. I soldati temono lo sdegno del capitano, gli amanti non meno quello delle loro donne. I soldati dormono in terra allo scoperto, gli amanti su per muricciuoli. I soldati perseguono infino a morte i loro nimici, gli amanti i loro rivali. I soldati, per la oscura notte, nel più gelato verno, vanno per il fango, esposti alle acque ed a' venti, per vincere una impresa, che faccia loro acquistare la vittoria; gli amanti, per simil' vie e con simili e maggiori disagi, di acquistare la loro amata cercano. Ugualmente, nella milizia e nello amore è necessario il secreto, la fede e l'animo, sono e pericoli uguali, ed il fine il più delle volte è simile: il soldato more in una fossa, lo amante more disperato. Così dubito io che non intervenga a me. Ed ho la dama in casa, veggola quanto io voglio, mangio sempre seco! Il che credo che mi sia maggior dolore: perché, quanto è più propinquo l'uomo ad uno suo desiderio, più lo desidera, e, non lo avendo, maggior dolore sente. A me bisogna pensare per ora di sturbare queste nozze; dipoi, nuovi accidenti mi arrecheranno nuovi consigli e nuova fortuna. È egli possibile che Eustachio non venga di villa? E scrissigli che ci fussi infino iersera! Ma io lo veggo spuntare là, da quel canto. Eustachio! o Eustachio! </p>
           </sp>
@@ -320,35 +351,35 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>Eustachio, Cleandro</stage>
-          <sp>
+          <sp who="#eustachio">
             <speaker>EU. </speaker>
             <p>Chi mi chiama? O Cleandro! </p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Tu hai penato tanto a comparire! </p>
           </sp>
-          <sp>
+          <sp who="#eustachio">
             <speaker>EU. </speaker>
             <p>Io venni infino iersera, ma io non mi sono appalesato, perché, poco innanzi che io avessi la tua lettera, ne avevo avuta una da Nicomaco, che mi imponeva uno monte di faccende, e perciò io non volevo capitargli innanzi, se prima io non ti vedevo. </p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Hai ben fatto. Io ho mandato per te, perché Nicomaco sollecita queste nozze di Pirro; le quale tu sai non piacciono a mia madre, perché, poiché di questa fanciulla si ha a fare bene ad uno uomo nostro, vorrebbe che la si dessi a chi la merita più. Ed invero le tue condizioni sono altrimenti fatte che quelle di Pirro; che, a dirlo qui fra noi, egli è uno sciagurato. </p>
           </sp>
-          <sp>
+          <sp who="#eustachio">
             <speaker>EU. </speaker>
             <p>Io ti ringrazio; e veramente io non avevo il capo a tôr donna, ma, poiché tu e madonna volete, io voglio ancora io. Vero è ch'io non vorrei anche arrecarmi nimico Nicomaco, perché poi alla fine, el padrone è egli. </p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Non dubitare, perché mia madre ed io non siamo per mancarti, e ti trarremo d'ogni pericolo. Io vorrei bene che tu ti rassettassi uno poco. Tu hai cotesto gabbano, che ti cade di dosso, hai el tocco polveroso, una barbaccia... Va' al barbieri, làvati el viso, setolati cotesti panni, acciò che Clizia non ti abbia a rifiutare per porco. </p>
           </sp>
-          <sp>
+          <sp who="#eustachio">
             <speaker>EU. </speaker>
             <p>Io non sono atto a rimbiondirmi. </p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Va', fa' quel ch'io ti dico, e poi te ne vai in quella chiesa vicina, e quivi mi aspetta. Io me ne andrò in casa, per vedere a quel che pensa el vecchio. </p>
           </sp>
@@ -375,7 +406,7 @@
         <div type="scene">
           <head>SCENA PRIMA</head>
           <stage>Nicomaco solo</stage>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Che domine ho io stamani intorno agli occhi? E' mi pare avere e bagliori, che non mi lasciono vedere lume e iersera io arei veduto el pelo nell'uovo. Are' io beuto troppo? Forse che sì. O Dio, questa vecchiaia ne viene con ogni mal mendo! Ma io non sono ancora sì vecchio, ch'io non rompessi una lancia con Clizia. È egli però possibile che io mi sia innamorato a questo modo? E, quello che è peggio, mogliama se ne è accorta, ed indovinasi perch'io voglia dare questa fanciulla a Pirro. Infine, e' non mi va solco diritto. Pure, io ho a cercare di vincere la mia. Pirro! o Pirro! vien' giù, esci fuora! </p>
           </sp>
@@ -383,59 +414,59 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>Pirro, Nicomaco</stage>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Eccomi! </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Pirro, io voglio che tu meni questa sera moglie in ogni modo. </p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Io la merrò ora. </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Adagio un poco! A cosa, a cosa, disse 'l Mirra. E' bisogna anche fare le cose in modo che la casa non vadia sottosopra. Tu vedi: mogliama non se ne contenta, Eustacchio la vuole anch'egli, parmi che Cleandro lo favorisca, e' ci si è volto contro Iddio e 'l diavolo. Ma sta' tu pur forte nella fede di volerla; non dubitare, ch'io varrò per tutti loro, perché, al peggio fare, io te la darò a loro dispetto, e chi vuole ingrognare, ingrogni! </p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Al nome di Dio, ditemi quel che voi volete che io facci. </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Che tu non ti parta di quinci oltre, acciò che, s'io ti voglio, che tu sia presto. </p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Così farò, ma mi era scordato dirvi una cosa. </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Quale? </p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Eustachio è in Firenze. </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Come, in Firenze? Chi te l'ha detto? </p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Ser Ambruogio, nostro vicino in villa, e mi dice che entrò dentro alla porta iarsera con lui. </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Come, iarsera? Dove è egli stato stanotte? </p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Chi lo sa? </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Sia, in buon'ora. Va' via, fa' quello ch'io t'ho detto. [Pirro parte]. Sofronia arà mandato per Eustachio, e questo ribaldo ha stimato più le lettere sue che le mie, che gli scrissi che facessi mille cose, che mi rovinano, se le non si fanno. Al nome di Dio, io ne lo pagherò! Almeno sapessi io dove egli è e quel che fa! Ma ecco Sofronia, che esce di casa. </p>
           </sp>
@@ -443,180 +474,180 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>Sofronia, Nicomaco</stage>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <stage>[sola]</stage>
             <p>Io ho rinchiusa Clizia e Doria in camera. E' mi bisogna guardare questa povera fanciulla dal figliuolo, dal marito, da' famigli: ognuno l'ha posto il campo intorno. </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Ove si va? </p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Alla messa. </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Ed è per carnesciale: pensa quel che tu farai di quaresima! </p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Io credo che s'abbia a fare bene d'ogni tempo, e tanto è più accetto farlo in quelli tempi che gli altri fanno male. Ma e' mi pare che, a fare bene, noi ci facciamo da cattivo lato! </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Come? Che vorresti tu che si facessi? </p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Che non si pensassi a chiacchiere; e, poiché noi abbiamo in casa una fanciulla buona, d'assai, e bella, abbiamo durato fatica ad allevarla, che si pensi di nolla gittare or via; e, dove prima ogni uomo ci lodava, ogni uomo ora ci biasimerà, veggendo che noi la diano ad uno ghiotto, sanza cervello, e non sa fare altro che un poco radere, che è un'arte che non ne viverebbe una mosca! </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Sofronia mia, tu erri. Costui è giovane, di buono aspetto (e, se non sa, è atto a imparare), vuol bene a costei: che son tre gran parte in uno marito, gioventù, bellezza ed amore. A me non pare che si possa ire più là, né che di questi partiti se ne truovi ad ogni uscio. Se non ha roba, tu sai che la roba viene e va; e costui è uno di quegli, che è atto a farne venire; ed io non lo abbandonerò, perch'io fo pensiero, a dirti il vero, di comperarli quella casa, che per ora ho tolta a pigione da Damone, nostro vicino, ed empierolla di masserizie; e di più, quando mi costassi quattrocento fiorini, per metterliene... </p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Ah, ah, ah! </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Tu ridi? </p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Chi non riderebbe? Dove liene vuoi tu mettere? </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Sì, che vuoi tu dire? ... per metterliene in su 'n una bottega, non sono per guardarvi. </p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>È egli possibile però che tu voglia con questo partito strano tôrre al tuo figliuolo più che non si conviene, e dare a costui più che non merita? Io non so che mi dire: io dubito che non ci sia altro, sotto. </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Che vuoi tu che ci sia? </p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Se ci fussi chi non lo sapessi, io glielo direi; ma, perché tu lo sai, io non te lo dirò. </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Che so io? </p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Lasciamo ire! Che ti muove a darla a costui? Non si potrebbe con questa dote o con minore maritarla meglio? </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Sì credo. Nondimeno, e' mi muove l'amore, ch'io porto all'una ed all'altro, che avendoceli allevati tutti a dua, mi pare da benificarli tutti a dua. </p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Se cotesto ti muove, non ti hai tu ancora allevato Eustachio, tuo fattore? </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Sì, ho; ma che vuoi tu che la faccia di cotestui, che non ha gentilezza veruna ed è uso a stare in villa fra' buoi e tra le pecore? Oh! se noi gliene dessimo, la si morrebbe di dolore. </p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>E con Pirro si morrà di fame. Io ti ricordo che le gentilezze delli uomini consistono in avere qualche virtù, sapere fare qualche cosa, come sa Eustachio, che è uso alle faccende in su' mercati, a fare masserizia, ad avere cura delle cose d'altri e delle sua, ed è uno uomo, che viverebbe in su l'acqua: tanto che tu sai che gli ha un buono capitale. Pirro, dall'altra parte, non è mai se non in sulle taverne, su pe' giuochi, un cacapensieri, che morrebbe di fame nello Altopascio! </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Non ti ho io detto quello che io li voglio dare? </p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Non ti ho io risposto che tu lo getti via? Io ti concludo questo, Nicomaco, che tu hai speso in nutrir costei, ed io ho durato fatica in allevarla; e per questo, avendoci io parte, io voglio ancora io intendere come queste cose hanno ad andare: o io dirò tanto male e commetterò tanti scandoli, che ti parrà essere in mal termine, che non so come tu ti alzi el viso. Va', ragiona di queste cose con la maschera! </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Che mi di' tu? Se' tu impazata? Or mi fa' tu venir voglia di dargliene in ogni modo; e, per cotesto amore, voglio io che la meni stasera, e merralla, se ti schizzassino gli occhi! </p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>O la merrà, o e' non la merrà. </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Tu mi minacci di chiacchiere; fa' ch'io non dica. Tu credi forse che io sia cieco, e che io non conosca e giuochi di queste tua bagatelle? Io sapevo bene che le madre volevano bene a' figliuoli, ma non credevo che le volessino tenere le mani alle loro disonestà! </p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Che di' tu? Che cosa è disonesta? </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Deh! non mi fare dire. Tu m'intendi, ed io t'intendo. Ognuno di noi sa a quanti dì è san Biagio. Facciamo, per tua fé, le cose d'accordo, che, se noi entriamo in cetere, noi sareno la favola del popolo. </p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Entra in che cetere tu vuoi. Questa fanciulla non s'ha a gittar via, o io manderò sottosopra, non che la casa, Firenze. </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Sofronia, Sofronia, chi ti pose questo nome non sognava! Tu se' una soffiona, e se' piena di vento! </p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Al nome d'Iddio, io voglio ire alla messa! Noi ci rivedreno. </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Odi un poco: sarebbeci modo a raccapezzare questa cosa, e che noi non ci facessimo tenere pazzi? </p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Pazzi no, ma tristi sì. </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Ei ci sono in questa terra tanti uomini dabbene, noi abbiamo tanti parenti, e' ci sono tanti buoni religiosi! Di quello che noi non siamo d'accordo noi, domandianne loro, e per questa via o tu o io ci sgarereno. </p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Che? vogliamo noi cominciare a bandire queste nostre pazzie? </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Se noi non vogliamo tôrre amici o parenti, togliamo uno religioso, e non si bandiranno; e rimettiamo in lui questa cosa in confessione. </p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>A chi andremo? </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>E' non si può andare ad altri che a fra' Timoteo, che è nostro confessoro di casa, ed è uno santerello, ed ha fatto già qualche miracolo. </p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Quale? </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Come, quale? Non sai tu che, per le sue orazioni, mona Lucrezia di messer Nicia Calfucci, che era sterile, ingravidò? </p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Gran miracolo, un frate fare ingravidare una donna! Miracolo sarebbe se una monaca la facessi ingravidare ella! </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>È egli possibile che tu non mi attraversi sempre la via con queste novelle? </p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Io voglio ire alla messa, e non voglio rimettere le cose mia in persona. </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Orsù, va' e torna: io ti aspetterò in casa. <stage>[Sofronia parte]</stage>. Io credo che sia bene non si discostare molto, perché non trafugassino Clizia in qualche lato. </p>
           </sp>
@@ -624,7 +655,7 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>Sofronia sola</stage>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Chi conobbe Nicomaco uno anno fa, e lo pratica ora, ne debbe restare maravigliato, considerando la gran mutazione, che gli ha fatta, perché soleva essere uno uomo grave, resoluto, respettivo. Dispensava il tempo suo onorevolmente, e si levava la mattina di buon'ora, udiva la sua messa, provedeva al vitto del giorno; dipoi, s'egli aveva faccenda in piazza, in mercato, o a' magistrati, e' le faceva; quanto che no, o e' si riduceva con qualche cittadino tra ragionamenti onorevoli, o e' si ritirava in casa nello scrittoio, dove raguagliava sue scritture, riordinava suoi conti; dipoi, piacevolmente con la sua brigata desinava; e, desinato, ragionava con il figliuolo, ammunivalo, davagli a conoscere gli uomini, e con qualche essemplo antico e moderno gl'insegnava vivere; andava dipoi fuora, consumava tutto il giorno o in faccende o in diporti gravi ed onesti; venuta la sera, sempre l'Avemaria lo trovava in casa: stavasi un poco con esso noi al fuoco, se gli era di verno; dipoi, se n'entrava nello scrittoio, a rivedere le faccende sue; alle tre ore si cenava allegramente. Questo ordine della sua vita era uno essemplo a tutti gli altri di casa, e ciascuno si vergognava non lo imitare. E così andavano le cose ordinate e liete. Ma, dipoi che gli entrò questa fantasia di costei, le faccende sue si straccurano, e poderi si guastono, e trafichi rovinano; grida sempre, e non sa di che, entra ed esce di casa ogni dì mille volte, sanza sapere quello che si vada faccendo; non torna mai ad ora, che si possa cenare o desinare a tempo; se tu gli parli, o e' non ti risponde, o e' ti risponde non a proposito. I servi, vedendo questo, si fanno beffe di lui, il figliuolo ha posto giù la reverenzia, ognuno fa a suo modo, ed infine niuno dubita di fare quello che vede fare a lui: in modo che io dubito, se Iddio non ci remedia, che questa povera casa non rovini. Io voglio pure andare alla messa, e raccomandarmi a Dio quanto io posso. Io veggo Eustachio e Pirro che si bisticciano: be' mariti che si apparecchiano a Clizia! </p>
           </sp>
@@ -632,87 +663,87 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>Pirro, Eustachio</stage>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Che fa' tu in Firenze, trista cosa? </p>
           </sp>
-          <sp>
+          <sp who="#eustachio">
             <speaker>EU. </speaker>
             <p>Io non l'ho a dire a te. </p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Tu se' così razzimato! Tu mi pari un cesso ripulito!</p>
           </sp>
-          <sp>
+          <sp who="#eustachio">
             <speaker>EU. </speaker>
             <p>Tu hai sì poco cervello, che io mi maraviglio ch'e fanciulli non ti gettino drieto e sassi.</p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Presto ci avvedremo chi arà più cervello, o tu o io.</p>
           </sp>
-          <sp>
+          <sp who="#eustachio">
             <speaker>EU. </speaker>
             <p>Prega Iddio che 'l padrone non muoia, che tu andrai un dì accattando!</p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Hai tu veduto Nicomaco?</p>
           </sp>
-          <sp>
+          <sp who="#eustachio">
             <speaker>EU. </speaker>
             <p>Che ne vuoi tu sapere, se io l'ho veduto o no?</p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>E' toccherà bene a te a saperlo, che se e' non si rimuta, se tu non torni in villa da te, e' vi ti farà portare a' birri.</p>
           </sp>
-          <sp>
+          <sp who="#eustachio">
             <speaker>EU. </speaker>
             <p>E' ti dà una gran briga questo mio essere in Firenze!</p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>E' dà più briga ad altri che a me.</p>
           </sp>
-          <sp>
+          <sp who="#eustachio">
             <speaker>EU. </speaker>
             <p>E però ne lascia el pensiero ad altri.</p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Pure le carne tirano.</p>
           </sp>
-          <sp>
+          <sp who="#eustachio">
             <speaker>EU. </speaker>
             <p>Tu guardi, e ghigni.</p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Guardo che tu saresti el bel marito.</p>
           </sp>
-          <sp>
+          <sp who="#eustachio">
             <speaker>EU. </speaker>
             <p>Orbè, sai quello ch'io ti voglio dire? Ed anche il duca murava! Ma, s'ella prende te, la sarà salita in su' muricciuoli. Quanto sarebbe meglio che Nicomaco la affogassi in quel suo pozzo! Almeno la poverina morrebbe ad uno tratto.</p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Doh! villan poltrone, profumato nel litame! Part'egli avere carni da dormire allato a sì dilicata figlia?</p>
           </sp>
-          <sp>
+          <sp who="#eustachio">
             <speaker>EU. </speaker>
             <p>Ell'arà bene carni teco! che, se la sua trista sorte te la dà, o ella in uno anno diventerà puttana, o ella si morrà di dolore: ma del primo ne sarai tu d'accordo seco, che, per uno becco pappataci, tu sarai desso!</p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Lasciamo andare! Ognuno aguzzi e sua ferruzzi: vedreno a chi e' dirà meglio. Io me ne voglio ire in casa, ch'io t'arei a rompere la testa.</p>
           </sp>
-          <sp>
+          <sp who="#eustachio">
             <speaker>EU. </speaker>
             <p>Ed io mi tornerò in chiesa.</p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Tu fai bene a non uscire di franchigia!</p>
           </sp>
@@ -742,92 +773,92 @@
         <div type="scene">
           <head>SCENA PRIMA</head>
           <stage>Nicomaco, Cleandro</stage>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Cleandro! o Cleandro!</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Messere! </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Esci giù, esci giù, dico io! Che fai tu, tanto el dì, in casa? Non te ne vergogni tu, che dài carico a cotesta fanciulla? Sogliono a simili dì di carnasciale e giovani tuoi pari andarsi a spasso veggendo le maschere, o ire a fare al calcio. Tu se' uno di quelli uomini, che non sai far nulla, e non mi pari né morto né vivo.</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Io non mi diletto di coteste cose, e non me ne dilettai mai, e piacemi più lo stare solo che con coteste compagnie, e tanto più stavo ora volentieri in casa veggendovi stare voi, per potere, se voi volevi cosa alcuna, farla. </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Deh! guarda dove l'aveva! Tu se' el buon figliuolo! Io non ho bisogno di averti tuttodì drieto! Io tengo dua famigli ed uno fattore, per non avere a comandare a te.</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Al nome d'Iddio! e' non è però che quello ch'io fo no 'l faccia per bene. </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Io non so per quel che tu te 'l fai, ma io so bene che tua madre è una pazza, e rovinerà questa casa. Tu faresti el meglio a ripararci.</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>O lei, o altri. </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Chi altri?</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Io non so. </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>E' mi pare bene che tu no 'l sappi. Ma che di' tu di questi casi di Clizia?</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <stage>[a parte]</stage>
             <p>Vedi che vi capitamo! </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Che di' tu? Di' forte, ch'io t'intenda.</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Dico ch'io non so che me ne dire. </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Non ti par egli che questa tua madre pigli un granchio, a non volere che Clizia sia moglie di Pirro?</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Io non me ne intendo. </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Io son chiaro! tu hai preso la parte sua! E' ci cova sotto altro che favole! Parrebbet'egli però che la stessi bene con Eustachio?</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Io non lo so, e non me ne intendo.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Di che diavolo t'intendi tu?</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Non di cotesto. </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Tu ti sei pur inteso di far venire in Firenze Eustachio, e trafugarlo, perché io non lo vegga, e tendermi lacciuoli per guastare queste nozze. Ma te e lui caccerò io nelle Stinche; a Sofronia renderò io la sua dota, e manderolla via, perché io voglio essere io signore di casa mia, e ognuno se ne sturi gli orecchi! E voglio che questa sera queste nozze si faccino, o io, quando non arò altro rimedio, caccerò fuoco in questa casa. Io aspetterò qui tua madre, per vedere s'io posso essere d'accordo con lei; ma quando io non possa, ad ogni modo ci voglio l'onor mio, che io non intendo ch'e paperi menino a bere l'oche. Va', pertanto, se tu desideri el bene tuo e la pace di casa, a pregarla che facci a mio modo. Tu la troverrai in chiesa, ed io aspetterò te e lei qui in casa. E se tu vedi quel ribaldo di Eustachio digli che venghi a me, altrimenti non farà bene e casi suoi.</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Io vo. </p>
           </sp>
@@ -835,7 +866,7 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>Cleandro solo</stage>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>O miseria di chi ama! Con quanti affanni passo io il mio tempo! Io so bene che qualunque ama una cosa bella, come è Clizia, ha di molti rivali, che gli dànno infiniti dolori; ma io non intesi mai che ad alcuno avvenissi di avere per rivale il padre; e, dove molti giovani hanno trovato appresso al padre qualche remedio, io vi truovo el fondamento e la cagione del male mio; e, se mia madre mi favorisce, la non fa per favorire me, ma per disfavorire la impresa del marito. E perciò io non posso scoprirmi in questa cosa gagliardamente, perché subito la crederrebbe che io avessi fatti quelli patti con Eustachio che mio padre ha fatti con Pirro, e come la credesse questo, mossa dalla conscienzia, lascerebbe ire l'acqua alla china, e non se ne travaglierebbe più, e io al tutto sarei spacciato, e ne piglierei tanto dispiacere, ch'io non crederrei più vivere. Io veggio mia madre, che esce di chiesa: io voglio parlare seco, ed intendere la fantasia sua, e vedere quali rimedii ella apparecchi contro a' disegni del vecchio. </p>
           </sp>
@@ -843,63 +874,63 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>Cleandro, Sofronia</stage>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Dio vi salvi, madre mia! </p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>O Cleandro! Vieni tu di casa?</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Madonna sì. </p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Sèvvi tu stato tuttavia, poi ch'io vi ti lasciai?</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Sono. </p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Nicomaco, dove è?</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>È in casa, e per cosa che sia accaduta non è uscito. </p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Lascialo fare, al nome d'Iddio! Una ne pensa el ghiotto, e l'altra el tavernaio. Hatt'egli detto cosa alcuna?</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Un monte di villanie; e parmi che gli sia entrato el diavolo addosso. E' vuole mettere nelle Stinche Eustachio e me, a voi vuole rendere la dota, e cacciarvi via, e minaccia, nonché altro, di cacciare fuoco in casa, e mi ha imposto ch'io vi truovi e vi persuada a consentire a queste nozze, altrimenti non si farà per voi. </p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Tu, che ne di'?</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Dicone quello che voi, perché io amo Clizia come sorella, e dorrebbemi infino all'anima, che la capitassi in mano di Pirro. </p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Io non so come tu te la ami, ma io ti dico bene questo, che s'io credessi trarla delle mani di Nicomaco e metterla nelle tua, che io non me ne impaccerei. Ma io penso che Eustachio la vorrebbe per sé, e che il tuo amore, per la sposa tua (che siamo per dartela presto), si potessi cancellare.</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Voi pensate bene; e però io vi prego, che voi facciate ogni cosa, perché queste nozze non si faccino; e, quando non si possa fare altrimenti che darla ad Eustachio, dìesili; ma, quando si possa, sarebbe meglio, secondo me, lasciarla stare così, perché l'è ancora giovinetta, e non le fugge il tempo: potrebbono e Cieli farle trovare e sua parenti, e, quando e' fussino nobili, arebbono un poco obligo con voi, trovando che voi l'avessi maritata o ad uno famiglio, o ad uno contadino! </p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Tu di' bene: io ancora ci avevo pensato, ma la rabbia di questo vecchio mi sbigottisce. Nondimeno, e' mi si aggirano tante cose per il capo, che io credo che qualcuna gli guasterà ogni suo disegno. Io me ne voglio ire in casa, perché io veggo Nicomaco aliare intorno all'uscio. Tu, va' in chiesa, e di' ad Eustachio che venga a casa, e non abbia paura di cosa alcuna.</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Così farò. </p>
           </sp>
@@ -907,130 +938,130 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>Nicomaco, Sofronia</stage>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <stage>[solo]</stage>
             <p>Io veggo mogliama, che torna: io la voglio un poco berteggiare, per vedere se le buone parole mi giovano. <stage>[A Sofronia]</stage>O fanciulla mia, ha' tu però a stare sì malinconosa, quando tu vedi la tua speranza? Sta' un poco meco!</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Lasciami ire!</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Fermati, dico!</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Io non voglio: tu mi par' cotto!</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Io ti verrò drieto.</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Se' tu impazzato?</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Pazzo, perch'io ti voglio troppo bene?</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Io non voglio che tu me ne voglia.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Questo non può essere!</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Tu m'uccidi! Uh, fastidioso!</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Io vorrei che tu dicessi il vero.</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Credotelo.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Eh! guatami un poco, amor mio.</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Io ti guato, ed odoroti anche: tu sai di buono! Bembè, tu mi riesci!</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <stage>[a parte]</stage>
             <p>Ohimé, che la se ne è avveduta! Che maladetto sia quel poltrone, che me l'arrecò dinanzi!</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Onde son venuti questi odori, di che sai tu, vecchio impazzato?</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>E' passò dianzi uno di qui, che ne vendeva: io gli trassinai, e mi rimase di quello odore addosso.</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <stage>[a parte]</stage>
             <p>Egli ha già trovato la bugia! <stage>[A Nicomaco]</stage>. Non ti vergogni tu di quello che tu fai da uno anno in qua? Usi sempre con sei giovanetti, vai alla taverna, ripariti in casa femmine, e dove si giuoca, spendi sanza modo. Begli essempli, che tu dai al tuo figliuolo! Date moglie a questi valenti uomini!</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Ah! moglie mia, non mi dir tanti mali ad un tratto! Serba qualche cosa a domani! Ma non è egli ragionevole che tu faccia più tosto a mio modo, che io a tuo?</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Sì, delle cose oneste.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Non è egli onesto maritare una fanciulla?</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Sì, quando ella si marita bene.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Non starà ella bene con Pirro?</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>No.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Perché?</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Per quelle cagioni, ch'io t'ho dette altre volte.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Io m'intendo di queste cose più di te. Ma, se io facessi tanto con Eustachio, ch'e' non la volessi?</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>E se io facessi con Pirro tanto, che non la volessi anch'egli?</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Da ora innanzi, ciascuno di noi si pruovi, e chi di noi dispone el suo, abbi vinto.</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Io son contenta. Io vo in casa a parlare a Pirro, e tu parlerai con Eustachio, che io lo veggo uscir di chiesa.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Sia fatto.</p>
           </sp>
@@ -1038,78 +1069,78 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>Eustachio, Nicomaco</stage>
-          <sp>
+          <sp who="#eustachio">
             <speaker>EU. </speaker>
             <stage>[solo]</stage>
             <p>Poiché Cleandro mi ha detto che io vadia a casa e non dubiti, io voglio fare buono cuore, ed andarvi.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <stage>[a parte]</stage>
             <p>Io volevo dire a questo ribaldo una carta di villanie, e non potrò, poiché io l'ho a pregare. <stage>[Ad Eustachio]</stage>. Eustachio!</p>
           </sp>
-          <sp>
+          <sp who="#eustachio">
             <speaker>EU. </speaker>
             <p>O padrone!</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Quando fusti tu in Firenze?</p>
           </sp>
-          <sp>
+          <sp who="#eustachio">
             <speaker>EU. </speaker>
             <p>Iarsera.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Tu hai penato tanto a lasciarti rivedere! Dove se' tu stato tanto?</p>
           </sp>
-          <sp>
+          <sp who="#eustachio">
             <speaker>EU. </speaker>
             <p>Io vi dirò. Io mi cominciai iermattina a sentir male: e' mi doleva el capo, avevo una anguinaia, e parevami avere la febre; ed essendo questi tempi sospetti di peste, io ne dubitai forte, e iersera venni a Firenze, e mi stetti all'osteria, né mi volli rappresentare, per non fare male a voi o a la famiglia vostra, se pure e' fussi stato desso. Ma, grazia di Dio, ogni cosa è passata via, e sentomi bene.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <stage>[a parte]</stage>
             <p>E' mi bisogna fare vista di crederlo. <stage>[Ad Eustachio]</stage>. Ben facesti tu! Se' or bene guarito?</p>
           </sp>
-          <sp>
+          <sp who="#eustachio">
             <speaker>EU. </speaker>
             <p>Messer sì.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>[a parte]. Non del tristo. [Ad Eustachio]. Io ho caro che tu ci sia. Tu sai la contenzione, che è tra me e mogliama circa al dar marito a Clizia: ella la vuole dare a te, ed io la vorrei dare a Pirro.</p>
           </sp>
-          <sp>
+          <sp who="#eustachio">
             <speaker>EU. </speaker>
             <p>E dunque, volete meglio a Pirro che a me?</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Anzi, voglio meglio a te che a lui. Ascolta un poco. Che vuoi tu fare di moglie? Tu hai oggimai trentotto anni, ed una fanciulla non ti sta bene; ed è ragionevole che, come la fussi stata teco qualche mese, che la cercassi un più giovane di te, e viveresti disperato. Dipoi, io non mi potrei più fidare di te, perderesti lo aviamento, diventeresti povero, ed andresti, tu ed ella, accattando.</p>
           </sp>
-          <sp>
+          <sp who="#eustachio">
             <speaker>EU. </speaker>
             <p>In questa terra, chi ha bella moglie non può essere povero: e del fuoco e della moglie si può essere liberale con ognuno, perché quanto più ne dai, più te ne rimane.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Dunque, vuoi tu fare questo parentado, per farmi dispiacere?</p>
           </sp>
-          <sp>
+          <sp who="#eustachio">
             <speaker>EU. </speaker>
             <p>Anzi, lo vo' fare, per fare piacere a me!</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Or tira, vanne in casa. Io ero pazzo, s'io credevo avere da questo villano una risposta piacevole. Io muterò teco verso. Ordina di rimettermi e conti, e di andarti con Dio, e fa' stima d'essere il maggior nimico ch'io abbia, e ch'io ti abbia a fare il peggio che io posso.</p>
           </sp>
-          <sp>
+          <sp who="#eustachio">
             <speaker>EU. </speaker>
             <p>A me non dà briga nulla, purch'io abbia Clizia.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Tu arai le forche!</p>
           </sp>
@@ -1117,82 +1148,82 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>Pirro, Nicomaco</stage>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <stage>[Verso l'interno, a Sofronia]</stage>
             <p>Prima ch'io facessi ciò che voi volete, io mi lascerei scorticare!</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <stage>[a parte]</stage>
             <p>La cosa va bene. Pirro sta nella fede. <stage>[A Pirro]</stage>. Che hai tu? Con chi combatti tu, Pirro?</p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Combatto ora con chi voi combattete sempre.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Che dic'ella? Che vuol ella?</p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Pregami che io non tolga Clizia per donna.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Che l'hai tu detto?</p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Che io mi lascerei prima ammazzare, che io la rifiutassi.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Ben dicesti.</p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Se io ho ben detto, io dubito non avere mal fatto, perché io mi sono fatto nimico la vostra donna, ed il vostro figliuolo, e tutti gli altri di casa.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Che importa a te? Sta' bene con Cristo, e fatti beffe de' santi!</p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Sì, ma se voi morissi, i santi mi tratterebbono assai male.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Non dubitare, io ti farò tal parte, ch'e santi ti potranno dare poca briga; e, se pur e' volessino, e magistrati e le legge ti difenderanno, purch'io abbia facultà, per tuo mezzo, di dormire con Clizia.</p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Io dubito che voi non possiate, tanta infiammata vi veggio contro la donna.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Io ho pensato che sarà bene, per uscire una volta di questo farnetico, che si getti per sorte di chi sia Clizia; da che la donna non si potrà discostare.</p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Se la sorte vi venissi contro?</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Io ho speranza in Dio, che la non verrà.</p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <stage>[a parte]</stage>
             <p>O vecchio impazzato! Vuol che Dio tenga le mani a queste sua disonestà! <stage>[A Nicomaco]</stage>. Io credo, che se Dio s'impaccia di simil' cose, che Sofronia ancora speri in Dio.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Ella si speri! E, se pur la sorte mi venissi contro, io ho pensato al rimedio. Va', chiamala, e dilli che venga fuora con Eustachio.</p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>O Sofronia! Venite, voi ed Eustachio, al padrone.</p>
           </sp>
@@ -1200,150 +1231,150 @@
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>Sofronia, Nicomaco, Eustachio, Pirro</stage>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Eccomi: che sarà di nuovo?</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>E' bisogna pur pigliare verso a questa cosa. Tu vedi, poiché costoro non si accordano, e' conviene che noi ci accordiano.</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Questa tua furia è estraordinaria. Quel che non si farà oggi, si farà domani.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Io voglio farla oggi.</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Faccisi, in buon'ora. Ecco qui tutti a duoi e competitori. Ma come vuoi tu fare?</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Io ho pensato, poiché noi non consentiano l'uno all'altro, che la si rimetta nella Fortuna.</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Come nella Fortuna?</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Che si ponga in una borsa e nomi loro, ed in un'altra el nome di Clizia ed una polizza bianca, e che si tragga prima el nome d'uno di loro e che, a chi tocca Clizia, se l'abbia, e l'altro abbi pazienza. Che pensi tu? Non rispondi?</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Orsù, io son contenta.</p>
           </sp>
-          <sp>
+          <sp who="#eustachio">
             <speaker>EU. </speaker>
             <stage>[a Sofronia]</stage>
             <p>Guardate quel che voi fate.</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <stage>[ad Eustachio]</stage>
             <p>Io guardo, e so quel ch'io fo. Va' 'n casa, scrivi le polizze, e reca dua borse, ch'io voglio uscire di questo travaglio, o io enterrò in uno maggiore.</p>
           </sp>
-          <sp>
+          <sp who="#eustachio">
             <speaker>EU. </speaker>
             <p>Io vo.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>A questo modo ci accordereno noi. Prega Dio, Pirro, per te.</p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Per voi!</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Tu di' bene, a dire per me: io arò una gran consolazione che tu l'abbia.</p>
           </sp>
-          <sp>
+          <sp who="#eustachio">
             <speaker>EU. </speaker>
             <p>Ecco le borse e le sorte.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Da' qua. Questa, che dice? Clizia. E quest'altra? È bianca. Sta bene. Mettile in questa borsa di qua. Questa, che dice? Eustachio. E quest'altra? Pirro. Ripiegale, e mettile in quest'altra. Serrale, tienvi su gli occhi, Pirro, che non ci andassi nulla in capperuccia: e' ci è chi sa giucare di macatelle!</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Gli uomini sfiducciati non son buoni.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Son parole, coteste! Tu sai che non è ingannato, se non chi si fida. Chi voglian noi che tragga?</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Tragga chi ti pare.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Vien' qua, fanciullo.</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>E' bisognerebbe che fussi vergine.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Vergine o no, io non v'ho tenute le mani. <stage>[Al fanciullo]</stage>.Tra' di questa borsa una polizza, detto che io ho certe orazioni: O santa Apollonia, io prego te e tutti e santi e le sante avvocate de' matrimonii, che concediate a Clizia tanta grazia, che di questa borsa esca la polizza di colui, che sia per essere più a piacere nostro. Trai, col nome di Dio! Dàlla qua. Ohimé, io son morto! Eustachio.</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Che avesti? O Dio! fa' questo miracolo, acciò che costui si disperi.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <stage>[al fanciullo]</stage>
             <p>Tra' di quell'altra. Dalla qua. Bianca. Oh, io sono resucitato! Noi abbiam vinto, Pirro! Buon pro ti faccia! Eustachio è caduto morto. Sofronia, poiché Dio ha voluto che Clizia sia di Pirro, vogli anche tu.</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Io voglio.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Ordina le nozze.</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Tu hai sì gran fretta: non si potrebb'egli indugiare a domani?</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>No, no, no! Non odi tu che no? Che? vuoi tu pensare a qualche trappola?</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Voglian noi fare le cose da bestie? Non ha ella a udir la messa del congiunto?</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>La messa della fava! La la può udire un altro dì! Non sai tu che si dà le perdonanze a chi si confessa poi, come a chi s'è confessato prima?</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Io dubito che la non abbia l'ordinario delle donne.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Adoperi lo straordinario delli uomini! Io voglio che la meni stasera . E' par che tu non mi intenda.</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Menila, in mal'ora! Andianne in casa, e fa' questa imbasciata tu a questa povera fanciulla, che non fia da calze!</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>La fia da calzoni! Andiano dentro.</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <stage>[a parte]</stage>
             <p>Io non voglio già venire, perché io vo' trovar Cleandro, perché e' pensi, se a questo male è rimedio alcuno.</p>
@@ -1376,27 +1407,27 @@
         <div type="scene">
           <head>SCENA PRIMA</head>
           <stage>Cleandro, Eustachio</stage>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Come è egli possibile che mia madre sia stata sì poco avveduta, che la si sia rimessa a questo modo alla sorta d'una cosa, che ne vadi in tutto l'onore di casa nostra? </p>
           </sp>
-          <sp>
+          <sp who="#eustachio">
             <speaker>EU. </speaker>
             <p>Egli è come io t'ho detto.</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Ben sono sventurato! Ben sono infelice! Vedi s'i' trovai appunto uno, che mi tenne tanto a bada, che si è, sanza mia saputa, concluso el parentado, e deliberate le nozze ed ogni cosa! E seguirà secondo el desiderio del vecchio! O Fortuna, tu suòi pure, sendo donna, essere amica de' giovani: a questa volta tu se' stata amica de' vecchi! Come non ti vergogni tu, ad avere ordinato che sì dilicato viso sia da sì fetida bocca scombavato, sì dilicate carne da sì tremanti mani, da sì grinze e puzzolente membra tocche? Perché, non Pirro, ma Nicomaco, come io mi stimo, la possederà. Tu non mi possevi fare la maggior ingiuria, avendomi con queste colpo tolto ad un tratto l'amata e la roba, perché Nicomaco, se questo amore dura, è per lasciare delle sue sustanze più a Pirro che a me. E' mi par mille anni di vedere mia madre, per dolermi e sfogarmi con lei di questo partito. </p>
           </sp>
-          <sp>
+          <sp who="#eustachio">
             <speaker>EU. </speaker>
             <p>Confortati, Cleandro, che mi parve che la ne andassi in casa ghignando, in modo che mi pare essere certo che 'l vecchio non abbia ad avere questa pera monda, come e' crede. Ma ecco che viene fuora, egli e Pirro, e son tutti allegri.</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Vanne, Eustachio, in casa: io voglio stare da parte, per intendere qualche loro consiglio, che facessi per me. </p>
           </sp>
-          <sp>
+          <sp who="#eustachio">
             <speaker>EU. </speaker>
             <p>Io vo.</p>
           </sp>
@@ -1404,116 +1435,116 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>Nicomaco, Cleandro, Pirro</stage>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Oh, come è ella ita bene! Hai tu veduto come la brigata sta malinconosa, come mogliama sta disperata? Tutte queste cose accrescono la mia allegrezza; ma molto più sarò allegro, quando io terrò in braccio Clizia, quando io la toccherò, bacerò, strignerò. O dolce notte! giugnerovv'io mai? E questo obligo, che io ho teco, io sono per pagarlo a doppio!</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <stage>[a parte]</stage>
             <p>O vecchio impazzato!</p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Io lo credo; ma io non credo già che voi possiate fare cosa nessuna questa sera, né ci veggo commodità alcuna.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Come?! Io ti vo' dire come io ho pensato di governare la cosa.</p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Io l'arò caro.</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <stage>[a parte]</stage>
             <p>Ed io molto più, che potrei udir cosa, che guasterebbe e fatti d'altri, e racconcerebbe e mia. </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Tu cognosci Damone, nostro vicino, da chi io ho tolto la casa a pigione per tuo conto?</p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Sì, cognosco.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Io fo pensiero che tu la meni stasera in quella casa, ancora ch'egli vi abiti e che non l'abbia sgombera, perch'io dirò ch'io voglio che tu la meni in casa dove l'ha a stare.</p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Che sarà poi?</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <stage>[a parte]</stage>
             <p>Rizza gli orecchi, Cleandro! </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Io ho imposto a mogliama che chiami Sostrata, moglie di Damone, perché gli aiuti ad ordinare queste nozze ed acconciare la nuova sposa; ed a Damone dirò che solleciti che la donna vi vadia. Fatto questo, e cenato che si sarà, la sposa da queste donne sarà menata in casa di Damone, e messa teco in camera e nel letto, ed io dirò di volere restare con Damone ad albergo e Sostrata ne verrà con Sofronia qui in casa. Tu, rimaso solo in camera, spegnerai il lume, e ti baloccherai per camera, faccendo vista di spogliarti; intanto io, pian piano, me ne verrò in camera, e mi spoglierò, ed enterrò allato a Clizia. Tu ti potrai stare pianamente in sul lettuccio. La mattina, avanti giorno, io mi uscirò del letto, mostrando di volere ire ad orinare, rivestirommi, e tu enterrai nel letto.</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <stage>[a parte]</stage>
             <p>O vecchio poltrone! Quanta è stata la mia felicità intendere questo tuo disegno! Quanta la tua disgrazia ch'io l'intenda. </p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>E' mi pare che voi abbiate divisata bene questa faccenda. Ma e' conviene che voi vi armiate in modo che voi paiate giovane, perché io dubito che la vecchiaia non si riconosca al buio.</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <stage>[a parte]</stage>
             <p>E' mi basta quel che io ho inteso: io voglio ire a raguagliare mia madre. </p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Io ho pensato a tutto, e fo conto, a dirti il vero, di cenare con Damone, ed ho ordinato una cena a mio modo. Io piglierò prima una presa d'uno lattovaro, che si chiama satirionne.</p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Che nome bizzarro è cotesto?</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Gli ha più bizzarri e fatti, perché gli è un lattovare, che farebbe, quanto a quella faccenda, ringiovanire uno uomo di novanta anni, nonché di settanta, come ho io. Preso questo lattovaro, io cenerò poche cose, ma tutte sustanzevole: in prima, una insalata di cipolle cotte; dipoi, una mistura di fave e spezierie...</p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Che fa cotesto?</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Che fa? Queste cipolle, fave e spezierie, perché sono cose calde e ventose, farebbono far vela ad una caracca genovese. Sopra queste cose si vuole uno pippione grosso arrosto, così verdemezzo, che sanguini un poco.</p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Guardate che non vi guasti lo stomaco, perché bisognerà, o che vi sia masticato, o che voi lo 'ngoiate intero: non vi vegg'io tanti o sì gagliardi denti in bocca!</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Io non dubito di cotesto, ché, bench'io non abbia molti denti, io ho le mascella che paiono d'acciaio.</p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Io penso che, poi che voi ne sarete ito, ed io entrato nel letto, che io potrò fare sanza toccarla, perché io ho viso di trovare quella povera fanciulla fracassata.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Bàstiti ch'io arò fatto l'ufficio tuo e quel d'un compagno.</p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Io ringrazio Dio, poiché mi ha dato una moglie in modo fatta, ch'io non arò a durare fatica né a 'mpregnarla, né a darli le spese.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Vanne in casa, sollecita le nozze, ed io parlerò un poco con Damone, ch'io lo veggo uscir di casa sua.</p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Così farò.</p>
           </sp>
@@ -1521,23 +1552,23 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>Nicomaco, Damone</stage>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Egli è venuto quello tempo, o Damone, che mi hai a mostrare se tu mi ami. E' bisogna che tu sgomberi la casa, e non vi rimanga né la tua donna, né altra persona, perché io vo' governare questa cosa, come io t'ho già detto.</p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>Io son parato a fare ogni cosa, purché io ti contenti.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Io ho detto a mogliama che chiami Sostrata tua, che vadia ad aiutarla ordinare le nozze. Fa' che la vadia subito, come la chiama, e che vadia con lei la serva, sopratutto.</p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>Ogni cosa è ordinato: chiamala a tua posta.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Io voglio ire infino allo speziale a fare una faccenda, e tornerò ora: tu aspetti qui, che mogliama eschi fuora, e chiami la tua. Ecco che la viene: sta' parato. Addio.</p>
           </sp>
@@ -1545,58 +1576,58 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>Sofronia, Damone</stage>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <stage>[sola]</stage>
             <p>Non maraviglia che 'l mio marito mi sollecitava ch'io chiamassi Sostrata di Damone! E' voleva la casa libera, per potere giostrare a suo modo. Ecco Damone di qua. O specchio di questa città, e colonna del suo quartieri, che accomoda la casa sua a sì disonesta e vituperosa impresa! Ma io gli tratterò in modo, che si vergogneranno sempre di loro medesimi. E voglio or cominciare ad uccellare costui.</p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <stage>[stesso gioco]</stage>
             <p>Io mi maraviglio che Sofronia si sia ferma, e non venga avanti a chiamare la mia donna. Ma ecco che la viene. <stage>[A Sofronia]</stage> Dio ti salvi, Sofronia!</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>E te, Damone! Ove è la tua donna?</p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>La è in casa, ed è parata a venire, se tu la chiami, perché el tuo marito me ne ha pregato. Vo io a chiamarla?</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>No, no! la debbe avere faccenda.</p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>Non ha faccenda alcuna.</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Lasciala stare, io non le voglio dare briga: io la chiamerò, quando fia tempo.</p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>Non ordinate voi le nozze?</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Sì, ordiniamo.</p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>Non hai tu necessità di chi ti aiuti?</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>E' vi è brigata un mondo, per ora.</p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <stage>[a parte]</stage>
             <p>Che farò ora io? Ho fatto uno errore grandissimo a cagione di questo vecchio impazzato, bavoso, cisposo, e sanza denti. E' mi ha fatto offerire la donna per aiuto a costei, che non la vuole, in modo che la crederrà ch'io vadi mendicando un pasto, e terrammi uno sciagurato.</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <stage>[stesso gioco]</stage>
             <p>Io ne rimando costui tutto inviluppato. Guarda come ne va ristretto nel mantello! E' mi resta ora ad uccellare un poco el mio vecchio. Eccolo che viene dal mercato. Io voglio morire, se non ha comperato qualche cosa, per parere gagliardo o odorifero!</p>
@@ -1605,29 +1636,29 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>Nicomaco, Sofronia</stage>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <stage>[solo]</stage>
             <p>Io ho comperato el lattovaro e certa unzione appropriata a fare risentire le brigate. Quando si va armato alla guerra, si va con più animo la metà. Io ho veduta la donna: ohimé, che la m'arà sentito!</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <stage>[a parte]</stage>
             <p>Sì, ch'io t'ho sentito, e con tuo danno e vergogna, s'io vivo insino a domattina!</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Sono ad ordine le cose? Hai tu chiamata questa tua vicina, che ti aiuti?</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Io la chiamai, come tu mi dicesti, ma questo tuo caro amico le favellò non so che nell'orecchio, in modo che la mi rispose che non poteva venire.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Io non me ne maraviglio, perché tu se' un poco rozza, e non sai accomodarti con le persone, quando tu vuoi alcuna cosa da loro.</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Che volevi tu, ch'io lo toccassi sotto 'l mento? Io non son usa a fare carezze a' mariti d'altri. Va', chiamala tu, poiché ti giova andare drieto alle moglie d'altri, ed io andrò in casa ad ordinare il resto.</p>
           </sp>
@@ -1635,44 +1666,44 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>Damone, Nicomaco</stage>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <stage>[solo]</stage>
             <p>Io vengo a vedere, se questo amante è tornato dal mercato. Ma eccolo davanti all'uscio. <stage>[A Nicomaco]</stage>. Io venivo appunto a te.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Ed io a te, uomo da farne poco conto! Di che t'ho io pregato? Di che t'ho io richiesto? Tu m'hai servito così bene!</p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>Che cosa è?</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Tu mandasti mogliata! Tu hai vòta la casa di brigata, che fu un sollazzo! In modo che, alle tua cagione, io son morto e disfatto!</p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>Va' t'impicca! Non mi dices'tu che mogliata chiamerebbe la mia?</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>La l'ha chiamata, e non è voluta venire.</p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>Anzi, che gliene offersi! Ella, non volle che la venissi; e così mi fai uccellare, e poi ti duoli di me. Che 'l diavolo ne 'l porti, te e le nozze ed ognuno!</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Infine, vuoi tu che la venga?</p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>Sì, voglio, in mal'ora! ed ella, e la fante, e la gatta, e chiunque vi è! Va', se tu hai a fare altro: io andrò in casa, e, per l'orto, la farò venire or ora.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <stage>[solo]</stage>
             <p>Ora, m'è costui amico! Ora, andranno le cose bene! Ohimè! ohimè! che romore è quel che è in casa?</p>
@@ -1681,95 +1712,95 @@
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>Doria, Nicomaco</stage>
-          <sp>
+          <sp who="#doria">
             <speaker>DO.</speaker>
             <stage>[rivolta verso l'interno]</stage>
             <p>Io son morta! Io son morta! Fuggite, fuggite! Toglietele quel coltello di mano! Fuggitevi, Sofronia!</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Che hai tu, Doria? Che ci è?</p>
           </sp>
-          <sp>
+          <sp who="#doria">
             <speaker>DO.</speaker>
             <p>Io son morta!</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Perché se' tu morta?</p>
           </sp>
-          <sp>
+          <sp who="#doria">
             <speaker>DO.</speaker>
             <p>Io son morta, e voi spacciato!</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Dimmi quel che tu hai!</p>
           </sp>
-          <sp>
+          <sp who="#doria">
             <speaker>DO.</speaker>
             <p>Io non posso per lo affanno! Io sudo! Fatemi un poco di vento col mantello!</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Deh! dimmi quel che tu hai, ch'io ti romperò la testa!</p>
           </sp>
-          <sp>
+          <sp who="#doria">
             <speaker>DO.</speaker>
             <p>Ah! padron mio, voi siate troppo crudele!</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Dimmi quel che tu hai, e qual romore è in casa!</p>
           </sp>
-          <sp>
+          <sp who="#doria">
             <speaker>DO.</speaker>
             <p>Pirro aveva dato l'anello a Clizia, ed era ito ad accompagnare el notaio infino all'uscio di drieto. Ben sai che Clizia, non so da che furore mossa, prese uno pugnale, e, tutta scapigliata, tutta furiosa, grida: – Ove è Nicomaco? Ove è Pirro? Io gli voglio ammazzare! – Cleandro, Sofronia, tutte noi la volavamo pigliare, e non potemo. La si è arrecata in uno canto di camera, e grida che vi vuole ammazzare in ogni modo, e per paura chi fugge di qua e chi di là. Pirro si è fuggito in cucina, e si è nascosto drieto alla cesta de' capponi. Io son mandata qui, per avvertirvi, che voi non entriate in casa.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Io son il più misero di tutti gli uomini! Non si può egli trarle di mano il pugnale?</p>
           </sp>
-          <sp>
+          <sp who="#doria">
             <speaker>DO.</speaker>
             <p>Non, per ancora.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Chi minacc'ella?</p>
           </sp>
-          <sp>
+          <sp who="#doria">
             <speaker>DO.</speaker>
             <p>Voi e Pirro.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Oh! che disgrazia è questa! Deh! figliuola mia, io ti prego che tu torni in casa, e con buone parole vegga, che se le cavi questa pazzia del capo, e che la ponga giù il pugnale; ed io ti prometto ch'io ti comperrò un paio di pianelle ed uno fazzoletto. Deh! va', amor mio!</p>
           </sp>
-          <sp>
+          <sp who="#doria">
             <speaker>DO.</speaker>
             <p>Io vo: ma non venite in casa, se io non vi chiamo.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <stage>[solo]</stage>
             <p>O miseria! O infelicità mia! Quante cose mi si intraversano, per fare infelice questa notte, ch'io aspettavo felicissima! <stage>[Verso l'interno, a Doria]</stage>. Ha ella posto giù il coltello? Vengo io?</p>
           </sp>
-          <sp>
+          <sp who="#doria">
             <speaker>DO.</speaker>
             <stage>[dall'interno]</stage>
             <p>Non, ancora! non venite!</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>O Iddio! che sarà poi? <stage>[Verso l'interno, a Doria]</stage>. Poss'io venire?</p>
           </sp>
-          <sp>
+          <sp who="#doria">
             <speaker>DO.</speaker>
             <stage>[uscendo]</stage>
             <p>Venite, ma non entrate in camera, dove ella è. Fate che la non vi vegga. Andate in cucina, da Pirro.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Io vo.</p>
           </sp>
@@ -1777,7 +1808,7 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>Doria sola</stage>
-          <sp>
+          <sp who="#doria">
             <speaker>DO.</speaker>
             <p>In quanti modi uccelliamo noi questo vecchio! Che festa è egli vedere e travagli di questa casa! Il vecchio e Pirro sono paurosi in cucina, in sala son quelli che apparecchiano la cena; ed in camera sono le donne, Cleandro, ed il resto della famiglia; ed hanno spogliato Siro, nostro servo, e de' sua panni vestita Clizia, e de' panni di Clizia vestito Siro, e vogliono che Siro ne vadia a marito in scambio di Clizia; e perché il vecchio e Pirro non scuoprino questa fraude, gli hanno, sotto ombra che Clizia sia cruciata, confinati in cucina. Che belle risa! Che bello inganno! Ma ecco fuora Nicomaco e Pirro.</p>
           </sp>
@@ -1785,27 +1816,27 @@
         <div type="scene">
           <head>SCENA NONA</head>
           <stage>Nicomaco, Doria, Pirro</stage>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Che fai tu costì, Doria? Clizia è quietata?</p>
           </sp>
-          <sp>
+          <sp who="#doria">
             <speaker>DO.</speaker>
             <p>Messer sì, ed ha promesso a Sofronia di volere fare ciò che voi volete. Egli è ben vero che Sofronia giudica che sia bene che voi e Pirro non li capitiate innanzi, acciò che non se li riaccendessi la collera; poi, messa che la fia al letto, se Pirro non la saprà dimesticare, suo danno!</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Sofronia ci consiglia bene, e così faremo. Ora, vattene in casa; e, perché gli è cotto ogni cosa, sollecita che si ceni; Pirro ed io ceneremo a casa Damone; e, come gli hanno cenato, fa' che la menino fuora. Sollecita, Doria, per l'amore d'Iddio, che sono già sonate le tre ore, e non è bene stare tutta notte in queste pratiche.</p>
           </sp>
-          <sp>
+          <sp who="#doria">
             <speaker>DO.</speaker>
             <p>Voi dite el vero. Io vo.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Tu, Pirro, riman' qui: io andrò a bere un tratto con Damone. Non andare in casa, acciò che Clizia non si infuriassi di nuovo; e, se cosa alcuna accade, corri a dirmelo.</p>
           </sp>
-          <sp>
+          <sp who="#pirro">
             <speaker>PI.</speaker>
             <p>Andate, io farò quanto mi imponete. <stage>[Nicomaco parte]</stage>. Poiché questo mio padrone vuole ch'io stia sanza moglie e sanza cena, io son contento. Né credo che in uno anno intervenghino tante cose, quante sono intervenute oggi e dubito non ne intervenghino dell'altre, perché io ho sentito per casa certi sghignazzamenti, che non mi piacciano. Ma ecco ch'io veggo apparire un torchio: e debbe uscir fuora la pompa, la sposa ne debbe venire. Io voglio correre per il vecchio. O Nicomaco! O Damone! Venite da basso! La sposa ne viene.</p>
           </sp>
@@ -1813,23 +1844,23 @@
         <div type="scene">
           <head>SCENA DECIMA</head>
           <stage>Nicomaco, Sofronia, Sostrata, Damone</stage>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Eccoci. Vanne, Pirro, in casa, perché io credo che sia bene che la non ti vegga. Tu, Damone, pàramiti innanzi, e parla tu con queste donne. Eccoli tutti fuora.</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>O povera fanciulla! la ne va piangendo. Vedi che la non si lieva el fazzoletto dagli occhi.</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Ella riderà domattina! Così usano di fare le fanciulle. Dio vi dia la buona sera, Nicomaco e Damone!</p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>Voi siate le ben venute. Andatevene su, voi donne, mettete al letto la fanciulla, e tornate giù. Intanto, Pirro sarà ad ordine anche egli.</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Andiamo, col nome d'Iddio.</p>
           </sp>
@@ -1837,15 +1868,15 @@
         <div type="scene">
           <head>SCENA UNDECIMA</head>
           <stage>Nicomaco, Damone</stage>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Ella ne va molto malinconosa. Ma hai tu veduto come l'è grande? La si debbe essere aiutata con le pianelle.</p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>La pare anche a me maggiore, che la non suole. O Nicomaco, tu se' pur felice! La cosa è condotta dove tu vuoi. Portati bene, altrimenti tu non vi potrai tornare più.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Non dubitare! Io sono per fare el debito, che, poi ch'io presi il cibo, io mi sento gagliardo come una spada. Ma ecco le donne, che tornano.</p>
           </sp>
@@ -1853,35 +1884,35 @@
         <div type="scene">
           <head>SCENA DUODECIMA</head>
           <stage>Nicomaco, Sostrata, Damone, Sofronia</stage>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Avetela voi messa al letto?</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Sì, abbiamo.</p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>Bene sta; noi fareno questo resto. Tu, Sostrata, vanne con Sofronia a dormire e Nicomaco rimarrà qui meco.</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Andianne, che par lor mille anni di avercisi levate dinanzi.</p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>Ed a voi il simile. Guardate a non vi far male.</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Guardatevi pur voi, che avete l'arme: noi siamo disarmate.</p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>Andiamone in casa.</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>E noi ancora. <stage>[A parte]</stage>. Va' pur là, Nicomaco, tu troverrai riscontro, perché questa tua dama sarà come le mezzine da Santa Maria Impruneta.</p>
           </sp>
@@ -1907,7 +1938,7 @@
         <div type="scene">
           <head>SCENA PRIMA</head>
           <stage>Doria sola</stage>
-          <sp>
+          <sp who="#doria">
             <speaker>DO.</speaker>
             <p>Io non risi mai più tanto, né credo mai più ridere tanto; né, in casa nostra, questa notte si è fatto altro che ridere. Sofronia, Sostrata, Cleandro, Eustachio, ognuno ride. E si è consumata la notte in misurare el tempo, e dicevàno: – Ora entra in camera Nicomaco, or si spoglia, or si corica allato alla sposa, or le dà la battaglia, ora è combattuto gagliardamente –. E, mentre noi stavamo in su questi pensieri, giunsono in casa Siro e Pirro, e ci raddoppiorno le risa; e, quel che era più bel vedere, era Pirro, che rideva più di Siro: tanto che io non credo che ad alcuno sia tocco, questo anno, ad avere il più bello, né il maggiore piacere. Quelle donne mi hanno mandata fuora, sendo già giorno, per vedere quel che fa il vecchio, e come egli comporta questa sciagura. Ma ecco fuora egli e Damone. Io mi voglio tirare da parte, per vedergli, ed avere materia di ridere di nuovo.</p>
           </sp>
@@ -1915,104 +1946,104 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>Damone, Nicomaco, Doria</stage>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>Che cosa è stata questa, tutta notte. Come è ella ita? Tu stai cheto. Che rovigliamenti di vestirsi, di aprire uscia, di scender e salire in sul letto sono stati questi, che mai vi siate fermi? Ed io, che nella camera terrena vi dormivo sotto, non ho mai potuto dormire; tanto che per dispetto mi levai, e truovoti, che tu esci fuori tutto turbato. Tu non parli? Tu mi par' morto. Che diavolo hai tu?</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Fratel mio, io non so dove io mi fugga, dove io mi nasconda, o dove io occulti la gran vergogna, nella quale io sono incorso. Io sono vituperato in eterno, non ho più rimedio, né potrò mai più innanzi a mogliama, a' figliuoli, a' parenti, a' servi capitare. Io ho cerco il vituperio mio, e la mia donna me lo ha aiutato a trovare: tanto che io sono spacciato; e tanto più mi duole, quanto di questo carico tu anche ne participi, perché ciascuno saprà che tu ci tenevi le mani.</p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>Che cosa è stata? Hai tu rotto nulla?</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Che vuoi tu ch'io abbia rotto? che rotto avess'io el collo!</p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>Che è stato, adunque? Perché non me lo di'?</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Uh! uh! uh! Io ho tanto dolore ch'io non credo poterlo dire.</p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>Deh! tu mi pari un bambino! Che domine può egli essere?</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Tu sai l'ordine dato, ed io, secondo quell'ordine, entrai in camera, e chetamente mi spogliai; ed in cambio di Pirro, che sopra el lettuccio s'era posto a dormire, non vi essendo lume, allato alla sposa mi coricai.</p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>Orbè, che fu poi?</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Uh! uh! uh! Accosta'migli. Secondo l'usanza de' nuovi mariti, vollile porre le mani sopra il petto, ed ella, con la sua, me le prese, e non mi lascio. Vollila baciare, ed ella con l'altra mano mi spinse el viso indrieto. Io me li volli gittare tutto addosso: ella mi porse un ginocchio, di qualità che la m'ha infranto una costola. Quando io viddi che la forza non bastava, io mi volsi a' prieghi, e con dolce parole ed amorevole, pur sottovoce, che la non mi cognoscessi, la pregavo fussi contenta fare e piacer' miei, dicendoli: – Deh! anima mia dolce, perché mi strazii tu? Deh! ben mio, perché non mi concedi tu volentieri quello, che l'altre donne a' loro mariti volentieri concedano? – Uh! uh! uh!</p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>Rasciùgati un poco gli occhi.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Io ho tanto dolore, ch'io non truovo luogo, né posso tenere le lacrime. Io potetti cicalare: mai fece segno di volerme, nonché altro, parlare. Ora, veduto questo, io mi volsi alle minacce, e cominciai a dirli villania, e che le farei, e che le direi. Ben sai che, ad un tratto, ella raccolse le gambe, e tirommi una coppia di calci, che, se la coperta del letto non mi teneva, io sbalzavo nel mezzo dello spazzo.</p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>Può egli essere?</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>E ben che può essere! Fatto questo, ella si volse bocconi, e stiacciossi col petto in su la coltrice, che tutte le manovelle dell'Opera non l'arebbono rivolta. Io, veduto che forza, preghi e minacci non mi valevano, per disperato le volsi le stiene, e deliberai di lasciarla stare, pensando che verso el dì la fussi per mutare proposito.</p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>Oh, come facesti bene! Tu dovevi, el primo tratto, pigliar cotesto partito, e, chi non voleva te, non voler lui!</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Sta' saldo, la non è finita qui: or ne viene el bello. Stando così tutto smarrito, cominciai, fra per il dolore e per lo affanno avuto, un poco a sonniferare. Ben sai che, ad un tratto, io mi sento stoccheggiare un fianco, e darmi qua, sotto el codrione, cinque o sei colpi de' maladetti. Io, così, fra il sonno, vi corsi subito con la mano, e trovai una cosa soda ed acuta, di modo che, tutto spaventato, mi gittai fuora del letto, ricordandomi di quello pugnale, che Clizia aveva il dì preso, per darmi con esso. A questo romore, Pirro, che dormiva, si risentì; al quale io dissi, cacciato più dalla paura che dalla ragione, che corressi per uno lume, che costei era armata, per ammazzarci tutti a dua. Pirro corse, e, tornato con il lume, in scambio di Clizia vedemo Siro, mio famiglio, ritto sopra il letto, tutto ignudo che per dispregio (uh! uh! uh! ) e' mi faceva bocchi (uh! uh! uh! ) e manichetto dietro.</p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>Ah! ah! ah!</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Ah! Damone, tu te ne ridi?</p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>E' m'incresce assai di questo caso; nondimeno egli è impossibile non ridere.</p>
           </sp>
-          <sp>
+          <sp who="#doria">
             <speaker>DO.</speaker>
             <stage>[a parte]</stage>
             <p>Io voglio andare a raguagliare di quello, che io ho udito, la padrona, acciò che se le raddoppino le risa.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Questo è il mal mio, che toccherà a ridersene a ciascuno, ed a me a piagnerne! E Pirro e Siro, alla mia presenzia, or si dicevano villania, or ridevano; dipoi, così vestiti a bardosso, se n'andorno, e credo che sieno iti a trovare le donne, e tutti debbono ridere. E così ognuno rida, e Nicomaco pianga!</p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>Io credo che tu creda che m'incresca di te e di me, che sono, per tuo amore, entrato in questo lecceto.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Che mi consigli ch'io faccia? Non mi abbandonare, per lo amor d'Iddio!</p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>A me pare, che se altro di meglio non nasce, che tu ti rimetta tutto nelle mani di Sofronia tua, e dicale che, da ora innanzi, e di Clizia e di te faccia ciò che la vuole. La doverrebbe anch'ella pensare all'onore tuo, perché, sendo suo marito, tu non puoi avere vergogna, che quella non ne participi. Ecco che la vien fuora. Va', parlale, ed io n'andrò intanto in piazza ed in mercato, ad ascoltare, s'io sento cosa alcuna di questo caso, e ti verrò ricoprendo el più ch'io potrò.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Io te ne priego.</p>
           </sp>
@@ -2020,76 +2051,76 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>Sofronia, Nicomaco</stage>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <stage>[sola]</stage>
             <p>Doria, mia serva, mi ha detto che Nicomaco è fuora, e che egli è una compassione a vederlo. Io vorrei parlargli, per vedere quel ch'e' dice a me di questo nuovo caso. Eccolo di qua. <stage>[A Nicomaco]</stage>. O Nicomaco!</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Che vuoi?</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Dove va' tu sì a buon'ora? Esci tu di casa sanza fare motto alla sposa? Hai tu saputo, come lo abbia fatto questa notte con Pirro?</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Non so.</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Chi lo sa, se tu non lo sai, che hai messo sottosopra Firenze, per fare questo parentado? Ora che gli è fatto, tu te ne mostri nuovo e malcontento!</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Deh, lasciami stare! Non mi straziare!</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Tu, se' quello che mi strazii, che, dove tu dovresti racconsolarmi, io ho da racconsolare te; e, quando tu gli aresti a provedere, e' tocca a me, che vedi ch'io porto loro queste uova.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Io crederrei che fussi bene che tu non volessi il giuoco di me affatto. Bastiti averlo avuto tutto questo anno, e ieri e stanotte più che mai.</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Io non lo volli mai, el giuoco di te; ma tu, sei quello che lo hai voluto di tutti noi altri, ed alla fine di te medesimo! Come non ti vergognavi tu, ad avere allevata in casa tua una fanciulla con tanta onestade, ed in quel modo che si allevano le fanciulle da bene, di volerla maritare poi ad uno famiglio cattivo e disutile, perché fussi contento che tu ti giacessi con lei? Credevi tu però avere a fare con ciechi o con gente che non sapessi interrompere le disonestà di questi tuoi disegni? Io confesso avere condotti tutti quelli inganni, che ti sono stati fatti, perché, a volerti fare ravvedere, non ci era altro modo, se non giugnerti in sul furto, con tanti testimonii, che tu te ne vergognassi, e dipoi la vergogna ti facessi fare quello, che non ti arebbe potuto fare fare niuna altra cosa. Ora, la cosa è qui: se tu vorrai ritornare al segno, ed essere quel Nicomaco che tu eri da uno anno indrieto, tutti noi vi tornereno, e la cosa non si risaprà; e, quando la si risapessi, egli è usanza errare ed emendarsi.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Sofronia mia, fa' ciò che tu vuoi: io sono parato a non uscire fuora de' tua ordini, pure che la cosa non si risappia.</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Se tu vuoi fare cotesto, ogni cosa è acconcio.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Clizia, dove è?</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Manda'la, subito che si fu cenato iersera, vestita con panni di Siro, in uno monistero.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Cleandro, che dice?</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>È allegro che queste nozze sien guaste, ma egli è ben doloroso, che non vede come e' si possa avere Clizia.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Io lascio avere ora a te il pensiero delle cose di Cleandro; nondimeno, se non si sa chi costei è, non mi parrebbe da dargliene.</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>E' non pare anche a me; ma conviene differire il maritarla, tanto che si sappia di costei qualcosa, o che gli sia uscita questa fantasia; ed intanto si farà annullare il parentado di Pirro.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Governala come tu vuoi. Io voglio andare in casa a riposarmi, che per la mala notte, ch'io ho avuta, io non mi reggo ritto, ed anche perché io veggo Cleandro ed Eustachio uscir fuora, con i quali io non mi voglio abboccare. Parla con loro tu, di' la conclusione fatta da noi, e che basti loro avere vinto, e di questo caso più non me ne ragionino.</p>
           </sp>
@@ -2097,43 +2128,43 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>Cleandro, Sofronia, Eustachio</stage>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Tu hai udito come el vecchio n'è ito chiuso in casa; e debbe averne tocco una rimesta da Sofronia. E' par tutto umile! Accostianci a lei, per intendere la cosa. <stage>[A Sofronia]</stage>. Dio vi salvi, mia madre! Che dice Nicomaco? </p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>È tutto scorbacchiato, il povero uomo! Pargli essere vituperato; hammi dato il foglio bianco, e vuole ch'io governi per lo avvenire a mio senno ogni cosa.</p>
           </sp>
-          <sp>
+          <sp who="#eustachio">
             <speaker>EU. </speaker>
             <p>E' l'andrà bene! Io doverrò avere Clizia!</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Adagio un poco! E' non è boccone da te. </p>
           </sp>
-          <sp>
+          <sp who="#eustachio">
             <speaker>EU. </speaker>
             <p>Oh, questa è bella! Ora, che io credetti avere vinto, ed io arò perduto, come Pirro?</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Né tu, né Pirro l'avete avere, né tu, Cleandro, perché io voglio che la stia così.</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Fate almeno che la torni a casa, acciò ch'io non sia privo di vederla. </p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>La vi tornerà, e non vi tornerà, come mi parrà. Andianne noi a rassettare la casa; e tu, Cleandro, guarda, se tu vedi Damone, perché gli è bene parlargli, per rimanere come s'abbia a ricoprire il caso seguito.</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Io sono mal contento. </p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Tu ti contenterai un'altra volta.</p>
           </sp>
@@ -2141,40 +2172,40 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>Cleandro, Damone</stage>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <stage>[solo]</stage>
             <p>Quando io credo essere navigato, e la Fortuna mi ripigne nel mezzo al mare e tra più turbide e tempestose onde! Io combattevo prima con lo amore di mio padre; ora combatto con la ambizione di mia madre. A quello io ebbi per aiuto lei, a questo sono solo: tanto che io veggo meno lume in questo, che io non vedevo in quello. Duolmi della mia male sorte, poiché io nacqui, per non avere mai bene e posso dire, da che questa fanciulla ci venne in casa, non avere cognosciuti altri diletti che di pensare a lei; dove sono sì radi stati e piaceri, che i giorni di quegli si annoverrebbono facilmente. Ma chi veggo io venire verso me? È egli Damone? Egli è esso, ed è tutto allegro. <stage>[A Damone]</stage>. Che ci è, Damone, che novelle portate? Donde viene tanta allegrezza? </p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>Né migliori novelle, né più felice, né che io portassi più volentieri potevo sentire!</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Che cosa è? </p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>Il padre di Clizia vostra è venuto in questa terra, e chiamasi Ramondo, ed è gentiluomo napolitano, ed è ricchissimo, ed è solamente venuto, per ritrovare questa sua figliuola.</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Che ne sai tu? </p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>Sòllo, ch'io gli ho parlato, ed ho inteso il tutto, e non c'è dubbio alcuno.</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Come sta la cosa? Io impazzo per la allegrezza. </p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>Io voglio che voi la intendiate da lui. Chiama fuora Nicomaco e Sofronia, tua madre.</p>
           </sp>
-          <sp>
+          <sp who="#cleandro">
             <speaker>CLE.</speaker>
             <p>Sofronia! o Nicomaco! Venite da basso a Damone. </p>
           </sp>
@@ -2182,39 +2213,39 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>Nicomaco, Damone, Ramondo, Sofronia</stage>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Eccoci! Che buone novelle?</p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>Dico che 'l padre di Clizia, chiamato Ramondo, gentiluomo napolitano, è in Firenze, per ritrovare quella, ed hogli parlato, e già l'ho disposto di darla per moglie a Cleandro, quando tu voglia.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Quando e' fia cotesto, io sono contentissimo. Ma dove è egli?</p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>Alla Corona, e gli ho detto ch'e' venga in qua. Eccolo che viene. Egli è quello che ha dirieto quelli servidori. Faccianceli incontro.</p>
           </sp>
-          <sp>
+          <sp who="#nicomaco">
             <speaker>NI.</speaker>
             <p>Eccoci. Dio vi salvi, uomo da bene!</p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>Ramondo, questo è Nicomaco, e questa è la sua donna, ed hanno con tanto onore allevato la figliuola tua; e questo è il loro figliuolo, e sarà tuo genero, quando ti piaccia.</p>
           </sp>
-          <sp>
+          <sp who="#ramondo">
             <speaker>RA.</speaker>
             <p>Voi siate tutti e ben trovati! E ringrazio Iddio, che mi ha fatto tanta grazia, che, avanti ch'io muoia, rivegga la figliuola mia, e possa ristorare questi gentiluomini, che l'hanno onorata. Quanto al parentado, a me non può essere più grato, acciò che questa amicizia, fra noi per i meriti vostri cominciata, per il parentado si mantenga.</p>
           </sp>
-          <sp>
+          <sp who="#damone">
             <speaker>DA.</speaker>
             <p>Andiamo dentro, dove da Ramondo tutto il caso intenderete appunto, e queste felice nozze ordinerete.</p>
           </sp>
-          <sp>
+          <sp who="#sofronia">
             <speaker>SO.</speaker>
             <p>Andiamo. <stage>[Agli spettatori]</stage>. E voi, spettatori, ve ne potrete andare a casa, perché, sanza uscir più fuora, si ordineranno le nuove nozze, le quali fieno femmine, e non maschie, come quelle di Nicomaco.</p>
           </sp>

--- a/tei/machiavelli-mandragola.xml
+++ b/tei/machiavelli-mandragola.xml
@@ -82,6 +82,34 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="callimaco">
+            <persName>Callimaco</persName>
+          </person>
+          <person xml:id="siro">
+            <persName>Siro</persName>
+          </person>
+          <person xml:id="nicia">
+            <persName>Nicia</persName>
+          </person>
+          <person xml:id="ligurio">
+            <persName>Ligurio</persName>
+          </person>
+          <person xml:id="sostrata">
+            <persName>Sostrata</persName>
+          </person>
+          <person xml:id="timoteo">
+            <persName>Fra' Timoteo</persName>
+          </person>
+          <person xml:id="donna">
+            <persName>Una Donna</persName>
+          </person>
+          <person xml:id="lucrezia">
+            <persName>Lucrezia</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -247,205 +275,205 @@
         <div type="scene">
           <head>scena prima</head>
           <stage>CALLIMACO, SIRO</stage>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>Siro, non ti partire, io ti voglio un poco.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p>Eccomi.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>Io credo che tu ti maravigliassi assai della mia sùbita partita da Parigi; ed ora ti maraviglierai, sendo io stato qui già un mese sanza fare alcuna cosa.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p>
 Voi dite el vero.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>Se io non ti ho detto infino a qui quello che io ti dirò ora, non è stato per non mi fidare di te, ma per iudicare che le cose che l'uomo vuole non si sappino, sia bene non le dire, se non forzato. Pertanto, pensando io di potere avere bisogno della opera tua, ti voglio dire el tutto.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p>
 Io vi sono servidore: e servi non debbono mai domandare el padrone d'alcuna cosa, né cercare alcuno loro fatto, ma quando per loro medesimi le dicano, debbono servirgli con fede; e così ho fatto e sono per fare io.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
 Già lo so. Io credo che tu mi abbi sentito dire mille volte, ma e' non importa che tu lo intenda mille una, come io avevo dieci anni quando da e mia tutori, sendo mio padre e mia madre morti, io fui mandato a Parigi, dove io sono stato venti anni. E perché in capo de' dieci cominciorono, per la passata del re Carlo, le guerre in Italia, le quali ruinorono quella provincia, delibera'mi di vivermi a Parigi e non mi ripatriare mai, giudicando potere in quel luogo vivere più sicuro che qui.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p>
 Egli è così.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
 E commesso di qua che fussino venduti tutti e mia beni, fuora che la casa, mi ridussi a vivere quivi, dove sono stato dieci altri anni con una felicità grandissima...</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p>
 Io lo so.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
 ...avendo compartito el tempo parte alli studii, parte a' piaceri, e parte alle faccende, ed in modo mi travagliavo in ciascuna di queste cose, che l'una non mi impediva la via dell'altra. E per questo, come tu sai, vivevo quietissimamente, giovando a ciascuno, ed ingegnandomi di non offendere persona: talché mi pareva essere grato a' borghesi, a' gentiluomini, al forestiero, al terrazzano, al povero ed al ricco.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p>
 Egli è la verità.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
 Ma, parendo alla Fortuna che io avessi troppo bel tempo, fece che e' capitò a Parigi uno Cammillo Calfucci.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p>
  Io comincio a 'ndovinarmi del male vostro.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Costui, come li altri fiorentini, era spesso convitato da me; e, nel ragionare insieme, accadde un giorno che noi venimo in disputa dove erano più belle donne, o in Italia o in Francia. E perché io non potevo ragionare delle italiane, sendo sì piccolo quando mi parti', alcuno altro fiorentino, che era presente, prese la parte franzese, e Cammillo la italiana, e, dopo molte ragione assegnate da ogni parte, disse Cammillo, quasi che irato, che, se tutte le donne italiane fussino monstri, che una sua parente era per riavere l'onore loro.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p>
  Io sono or chiaro di quello che voi volete dire.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> E nominò madonna Lucrezia, moglie di messer Nicia Calfucci: alla quale e' dette tante laude e di bellezza e di costumi, che fece restare stupidi qualunque di noi ed in me destò tanto desiderio di vederla, che io, lasciato ogni altra deliberazione, né pensando più alle guerre o alle pace d'Italia, mi messi a venire qui. Dove arrivato, ho trovato la fama di madonna Lucrezia essere minore assai che la verità, il che occorre rarissime volte, e sommi acceso in tanto desiderio d'esser seco, che io non truovo loco.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p> Se voi me n'avessi parlato a Parigi, io saprei che consigliarvi; ma ora non so io che mi vi dire.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Io non ti ho detto questo per voler tua consigli, ma per sfogarmi in parte, e perché tu prepari l'animo adiutarmi, dove el bisogno lo ricerchi.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p>
  A cotesto son io paratissimo; ma che speranza ci avete voi?</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Ehimè! nessuna.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p>
  O perché?</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Dirotti. In prima mi fa guerra la natura di lei, che è onestissima ed al tutto aliena dalle cose d'amore; l'avere el marito ricchissimo e che al tutto si lascia governare da lei, e, se non è giovane, non è al tutto vecchio, come pare; non avere parenti o vicini, con chi ella convenga ad alcuna vegghia o festa o ad alcuno altro piacere, di che si sogliono dilettare le giovane. Delle persone meccaniche non gliene capita a casa nessuna; non ha fante né famiglio, che non triemi di lei: in modo che non c'e luogo ad alcuna corruzione.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p>
  Che pensate, adunque, di poter fare?</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  E' non è mai alcuna cosa sì disperata, che non vi sia qualche via da poterne sperare; e benché la fussi debole e vana, e la voglia e 'l desiderio, che l'uomo ha di condurre la cosa, non la fa parere così.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p>
  Infine, e che vi fa sperare?</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Dua cose: l'una, la semplicità di messer Nicia, che, benché sia dottore, egli è el più semplice ed el più sciocco uomo di Firenze; l'altra la voglia che lui e lei hanno d'avere figliuoli, che, sendo stata sei anni a marito e non avendo ancora fatti, ne hanno, sendo ricchissimi, un desiderio che muoiono. Una terza ci è, che la sua madre è suta buona compagna, ma la è ricca, tale che io non so come governarmene.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p>
  Avete voi per questo tentato per ancora cosa alcuna?</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Sì ho, ma piccola cosa.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p>
  Come?</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Tu conosci Ligurio, che viene continuamente a mangiar meco. Costui fu già sensale di matrimoni, dipoi s'è dato a mendicare cene e desinari; e perché gli è piacevole uomo, messer Nicia tiene con lui una stretta dimestichezza, e Ligurio l'uccella; e benché non lo meni a mangiare seco, li presta alle volte danari. Io me l'ho fatto amico, e gli ho comunicato el mio amore: lui m'ha promesso d'aiutarmi con le mane e co' piè.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p>
 Guardate e' non v'inganni: questi pappatori non sogliono avere molta fede.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Egli è el vero. Nondimeno, quando una cosa fa per uno, si ha a credere, quando tu gliene communichi, che ti serva con fede. Io gli ho promesso, quando e' riesca, donarli buona somma di danari; quando e' non riesca, ne spicca un desinare ed una cena, ché ad ogni modo i' non mangerei solo.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p>
  Che ha egli promesso, insino a qui, di fare?</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Ha promesso di persuadere a messer Nicia che vada con la sua donna al bagno in questo maggio.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p>
  Che è a voi cotesto?</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Che è a me! Potrebbe quel luogo farla diventare d'un'altra natura, perché in simili lati non si fa se non festeggiare; ed io me n'andrei là, e vi condurrei di tutte quelle ragion' piaceri che io potessi, né lascerei indrieto alcuna parte di magnificenzia; fare'mi familiar suo, del marito... che so io? Di cosa nasce cosa, e 'l tempo la governa.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p>
  E' non mi dispiace.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Ligurio si partì questa mattina da me, e disse che sarebbe con messer Nicia sopra questa cosa, e me ne risponderebbe.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p>
  Eccogli di qua insieme.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Io mi vo' tirare da parte, per essere a tempo a parlare con Ligurio, quando si spicca dal dottore. Tu, intanto, ne va' in casa alle tue faccende; e, se io vorrò che tu faccia cosa alcuna, io tel dirò.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p>
  Io vo.</p>
@@ -454,72 +482,72 @@ Guardate e' non v'inganni: questi pappatori non sogliono avere molta fede.</p>
         <div type="scene">
           <head>scena seconda</head>
           <stage>MESSER NICIA, LIGURIO</stage>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Io credo ch'e tua consigli sien buoni, e parla'ne iersera alla donna: disse che mi risponderebbe oggi; ma, a dirti el vero, io non ci vo di buone gambe.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Perché?</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Perché io mi spicco mal volentieri da bomba; dipoi, ad avere a travasare moglie, fante, masserizie, ella non mi quadra. Oltr'a questo, io parlai iersera a parecchi medici: l'uno dice che io vadia a San Filippo, l'altro alla Porretta, e l'altro alla Villa; e' mi parvono parecchi uccellacci; e a dirti el vero, questi dottori di medicina non sanno quello che si pescano.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  E' vi debbe dar briga, quello che voi dicesti prima, perché voi non sete uso a perdere la Cupola di veduta.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Tu erri. Quando io ero più giovane, io sono stato molto randagio: e' non si fece mai la fiera a Prato, che io non vi andassi, e' non c'è castel veruno all'intorno, dove io non sia stato; e ti vo' dir più là: io sono stato a Pisa ed a Livorno, o va'!</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Voi dovete avere veduto la carrucola di Pisa.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Tu vuo' dire la Verucola.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Ah! sì, la Verucola. A Livorno, vedesti voi el mare?</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Ben sai che io il vidi!</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Quanto è egli maggior che Arno?</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Che Arno? Egli è per quattro volte, per più di sei, per più di sette, mi farai dire: e' non si vede se non acqua, acqua, acqua.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Io mi maraviglio, adunque, avendo voi pisciato in tante neve, che voi facciate tanta difficultà d'andare ad uno bagno.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Tu hai la bocca piena di latte. E' ti pare a te una favola avendo a sgominare tutta la casa? Pure, io ho tanta voglia d'avere figliuoli, che io son per fare ogni cosa. Ma parlane un po' tu con questi maestri, vedi dove e' mi consigliassino che io andassi; ed io sarò intanto con la donna, e ritroverrenci.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Voi dite bene.</p>
@@ -528,91 +556,91 @@ Guardate e' non v'inganni: questi pappatori non sogliono avere molta fede.</p>
         <div type="scene">
           <head>scena terza</head>
           <stage>LIGURIO, CALLIMACO</stage>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p><stage><add resp="#ed"><emph>solo</emph></add></stage>. Io non credo che sia nel mondo el più sciocco uomo di costui; e quanto la fortuna lo ha favorito! Lui ricco, lui bella donna, savia, costumata, ed atta a governare un regno. E parmi che rare volte si verifichi quel proverbio ne' matrimoni, che dice: «Dio fa gli uomini, e' s'appaiono»; perché spesso si vede uno uomo ben qualificato sortire una bestia, e, per avverso, una prudente donna avere un pazzo. Ma della pazzia di costui se ne cava questo bene, che Callimaco ha che sperare. —Ma eccolo. <stage><add resp="#ed"><emph>A Callimaco</emph></add></stage>. Che vai tu appostando Callimaco?</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Io t'avevo veduto col dottore, ed aspettavo che tu ti spiccassi da lui, per intendere quello avevi fatto.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Egli è uno uomo della qualità che tu sai, di poca prudenzia, di meno animo, e partesi mal volentieri da Firenze; pure, io ce l'ho riscaldato: e' mi ha detto infine che farà ogni cosa, e credo che, quando e' ti piaccia questo partito, che noi ve lo condurreno, ma io non so se noi ci fareno el bisogno nostro.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Perché?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Che so io? Tu sai che a questi bagni va d'ogni qualità gente, e potrebbe venirvi uomo a chi madonna Lucrezia piacessi come a te, che fussi ricco più di te, che avessi più grazia di te: in modo che si porta pericolo di non durare questa fatica per altri, e che c'intervenga che la copia de' concorrenti la faccino più dura, o che, dimesticandosi, la si volga ad un altro e non a te.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Io conosco che tu di' el vero. Ma come ho a fare? Che partito ho a pigliare? Dove mi ho a volgere? A me bisogna tentare qualche cosa, sia grande, sia periculosa, sia dannosa, sia infame. Meglio è morire che vivere così. Se io potessi dormire la notte, se io potessi mangiare, se io potessi conversare, se io potessi pigliare piacere di cosa veruna, io sarei più paziente ad aspettare el tempo; ma qui non c'è rimedio; e, se io non sono tenuto in speranza da qualche partito, i' mi morrò in ogni modo; e, veggendo d'avere a morire, non sono per temere cosa alcuna, ma per pigliare qualche partito bestiale, crudele, nefando.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Non dire così, raffrena cotesto impeto dello animo.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Tu vedi bene che, per raffrenarlo io mi pasco di simili pensieri. E però è necessario o che noi seguitiamo di mandare costui al bagno, o che noi entriano per qualche altra via, che mi pasca d'una speranza, se non vera, falsa almeno, per la quale io nutrisca un pensiero, che mitighi in parte tanti mia affanni.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Tu hai ragione, ed io sono per farlo.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Io lo credo, ancora che io sappia che e pari tuoi vivino di uccellare li uomini. Nondimanco, io non credo essere in quel numero, perché quando tu el facessi ed io me ne avvedessi, cercherei valermene, e perderesti per ora l'uso della casa mia, e la speranza di avere quello che per lo avvenire t'ho promesso.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Non dubitare della fede mia, che quando e' non ci fussi l'utile che io sento e che io spero, e' c'è che 'l tuo sangue si confà col mio, e desidero che tu adempia questo tuo desiderio presso a quanto tu. Ma lasciamo ir questo. El dottore mi ha commesso che io truovi un medico, e intenda a quale bagno sia bene andare. Io voglio che tu faccia a mio modo, e questo è che tu dica di avere studiato in medicina, e che abbi fatto a Parigi qualche sperienzia: lui è per crederlo facilmente per la semplicità sua, e per essere tu litterato e poterli dire qualche cosa in gramatica.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  A che ci ha a servire cotesto?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Serviracci a mandarlo a qual bagno noi vorreno, ed a pigliare qualche altro partito che io ho pensato, che sarà più corto, più certo, più riuscibile che 'l bagno.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Che di' tu?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Dico che, se tu arai animo e se tu confiderai in me, io ti do questa cosa fatta, innanzi che sia domani questa otta. E, quando e' fussi uomo che non è, da ricercare se tu se' o non se' medico, la brevità del tempo, la cosa in sé farà o che non ne ragionerà o che non sarà a tempo a guastarci el disegno, quando bene e' ne ragionassi.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Tu mi risuciti. Questa è troppa gran promessa, e pascimi di troppa gran speranza. Come farai?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Tu el saprai, quando e' fia tempo; per ora non occorre che io te lo dica, perché el tempo ci mancherà a fare, nonché dire. Tu, vanne in casa, e quivi m'aspetta, ed io andrò a trovare el dottore, e, se io lo conduco a te, andrai seguitando el mio parlare ed accomodandoti a quello.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Così farò, ancora che tu mi riempia d'una speranza, che io temo non se ne vadia in fumo.</p>
@@ -641,75 +669,75 @@ Guardate e' non v'inganni: questi pappatori non sogliono avere molta fede.</p>
         <div type="scene">
           <head>scena prima</head>
           <stage>LIGURIO, MESSER NICIA, SIRO</stage>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Come io vi ho detto, io credo che Iddio ci abbia mandato costui, perché voi adempiate el desiderio vostro. Egli ha fatto a Parigi esperienzie grandissime; e non vi maravigliate se a Firenze e' non ha fatto professione dell'arte, che n'è suto cagione, prima, per essere ricco, secondo, perché egli è ad ogni ora per tornarsi a Parigi.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Ormai, frate sì, cotesto bene importa; perché io non vorrei che mi mettessi in qualche lecceto, e poi mi lasciassi in sulle secche.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Non dubitate di cotesto; abbiate solo paura che non voglia pigliare questa cura; ma, se la piglia, e' non è per lasciarvi infino che non ne veda el fine.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Di cotesta parte io mi vo' fidare di te, ma della scienzia io ti dirò bene io, come io gli parlo, s'egli è uomo di dottrina, perché a me non venderà egli vesciche.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  E perché io vi conosco, vi meno io a lui, acciò li parliate. E se, parlato li avete, e' non vi pare per presenzia, per dottrina, per lingua uno uomo da metterli il capo in grembo, dite che io non sia desso.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Or sia, al nome dell'Agnol santo! Andiamo. Ma dove sta egli?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Sta in su questa piazza, in quello uscio che voi vedete al dirimpetto a noi.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Sia con buona ora. Picchia.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Ecco fatto.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p><stage><add resp="#ed"><emph>affacciandosi alla porta</emph></add></stage>. Chi è?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p><stage><add resp="#ed"><emph>a Siro</emph></add></stage>. Èvi Callimaco?</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p>
  Sì, è. <stage><add resp="#ed"><emph>Rientra in casa</emph></add>.</stage>
 </p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p><stage><add resp="#ed"><emph>a Ligurio</emph></add></stage>. Che non di' tu maestro Callimaco?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  E' non si cura di simil' baie.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Non dir così, fa' 'l tuo debito, e s'e' l'ha per male, scingasi!</p>
@@ -718,119 +746,119 @@ Guardate e' non v'inganni: questi pappatori non sogliono avere molta fede.</p>
         <div type="scene">
           <head>scena seconda</head>
           <stage>CALLIMACO, MESSER NICIA LIGURIO</stage>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Chi è quel che mi vuole?</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
               <foreign xml:lang="lat">Bona dies, domine magister.</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
               <foreign xml:lang="lat">Et vobis bona, domine doctor.</foreign>
             </p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p><stage><add resp="#ed"><emph>piano, a Nicia</emph></add></stage>. Che vi pare?</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p><stage><add resp="#ed"><emph>piano, a Ligurio</emph></add></stage>. Bene, alle guagnele!</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Se voi volete che io stia qui con voi, voi parlerete in modo che io v'intenda, altrimenti noi fareno duo fuochi.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Che buone faccende?</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Che so io? Vo cercando duo cose ch'un altro per avventura fuggirebbe: questo è di dare briga a me e ad altri. Io non ho figliuoli, e vorre'ne, e, per avere questa briga, vengo a dare impaccio a voi.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  A me non fia mai discaro fare piacere a voi ed a tutti li uomini virtuosi e da bene come voi; e non mi sono a Parigi affaticato tanti anni per imparare per altro, se non per potere servire a' pari vostri.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Gran mercé; e, quando voi avessi bisogno dell'arte mia, io vi servirei volentieri. Ma torniamo <foreign xml:lang="lat">ad rem nostram</foreign>. Avete voi pensato che bagno fussi buono a disporre la donna mia ad impregnare? Che io so che qui Ligurio vi ha detto quel che vi s'abbi detto.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Egli è la verità; ma, a volere adempiere el desiderio vostro, è necessario sapere la cagione della sterilità della donna vostra, perché le possono essere più cagione: <foreign xml:lang="lat">nam cause sterilitatis sunt: aut in semine, aut in matrice, aut in instrumentis seminariis, aut in virga, aut in causa extrinseca.</foreign>
 </p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p><stage><add resp="#ed"><emph>a parte</emph></add></stage>. Costui è il più degno uomo che si possa trovare!</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Potrebbe, oltr'a di questo, causarsi questa sterilità da voi, per impotenzia; che quando questo fussi, non ci sarebbe rimedio alcuno.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Impotente io? Oh! voi mi farete ridere! Io non credo che sia el più ferrigno ed il più rubizzo uomo in Firenze di me.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Se cotesto non è, state di buona voglia, che noi vi troverremo qualche remedio.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Sarebbeci egli altro remedio che bagni? Perché io non vorrei quel disagio, e la donna uscirebbe di Firenze mal volentieri.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Sì, sarà! Io vo' rispondere io: Callimaco è tanto respettivo, che è troppo. <add resp="#ed"><emph>A Callimaco</emph></add>. Non m'avete voi detto di sapere ordinare certe pozione che indubitatamente fanno ingravidare!</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Sì, ho; ma io vo rattenuto con gli uomini che io non conosco, perché io non vorrei mi tenessino un cerretano.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Non dubitate di me, perché voi mi avete fatto maravigliare di qualità, che non è cosa io non credessi o facessi per le vostre mani.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p><stage><add resp="#ed"><emph>a Callimaco</emph></add></stage>. Io credo che bisogni che voi veggiate el segno.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Sanza dubbio, e' non si può fare di meno.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p><stage><add resp="#ed"><emph>piano, a Callimaco</emph></add></stage>. Chiama Siro, che vadia con el dottore a casa per esso, e torni qui; e noi l'aspetteremo in casa.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p><stage><add resp="#ed"><emph>ad alta voce, verso l'interno della casa</emph></add></stage>. Siro! <stage><add resp="#ed"><emph>A Siro, che esce di casa</emph></add></stage>. Va' con lui. <stage><add resp="#ed"><emph>A messer Nicia</emph></add></stage>. E, se vi pare, messere, tornate qui subito, e pensereno a qualche cosa di buono.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Come, se mi pare? Io tornerò qui in uno stante, che ho più fede in voi che gli Ungheri nelle spade. <stage><add resp="#ed"><emph>Callimaco e Ligurio rientrano in casa</emph></add></stage>.</p>
@@ -839,62 +867,62 @@ Guardate e' non v'inganni: questi pappatori non sogliono avere molta fede.</p>
         <div type="scene">
           <head>scena terza</head>
           <stage>MESSER NICIA, SIRO</stage>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Questo tuo padrone è un gran valente uomo.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p>
  Più che voi non dite.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  El re di Francia ne de' far conto.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p>
  Assai.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  E per questa ragione e' debbe stare volentieri in Francia.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p>
  Così credo.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  E' fa molto bene: in questa terra non ci è se non cacastecchi, non ci si apprezza virtù alcuna. S'egli stessi qua, non ci sarebbe uomo che lo guardassi in viso. Io ne so ragionare, che ho cacato le curatelle per imparare dua hac, e se io ne avessi a vivere, io starei fresco, ti so dire!</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p>
  Guadagnate voi l'anno cento ducati?</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Non cento lire, non cento grossi, o va'! E questo è che, chi non ha lo stato in questa terra, de' nostri pari, non truova can che gli abbai; e non sian buoni ad altro che andare a' mortori o alle ragunate d'un mogliazzo, o a starci tuttodì in sulla panca del Proconsolo a donzellarci. Ma io ne li disgrazio, io non ho bisogno di persona: così stessi chi sta peggio di me! Ma non vorrei però ch'elle fussino mia parole, che io arei di fatto qualche balzello o qualche porro di drieto, che mi fare' sudare.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p>
  Non dubitate.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Noi siamo a casa. Aspettami qui: io tornerò ora.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p>
  Andate.</p>
@@ -903,7 +931,7 @@ Guardate e' non v'inganni: questi pappatori non sogliono avere molta fede.</p>
         <div type="scene">
           <head>scena quarta</head>
           <stage>SIRO SOLO</stage>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p>
  Se gli altri dottori fussin fatti come costui, noi faremo a' sassi pe' forni: che sì, che questo tristo di Ligurio e questo impazzato di questo mio padrone lo conducono in qualche loco, che gli faranno vergogna! E veramente io lo desiderrei, quando io credessi che non si risapessi, perché, risapendosi, io porto pericolo della vita, el padrone della vita e della roba. Egli è già diventato medico: non so io che disegno si sia el loro, e dove si tenda questo loro inganno... —Ma ecco el dottore che ha uno orinale in mano: chi non riderebbe di questo uccellaccio?</p>
@@ -912,21 +940,21 @@ Guardate e' non v'inganni: questi pappatori non sogliono avere molta fede.</p>
         <div type="scene">
           <head>scena quinta</head>
           <stage>MESSER NICIA, SIRO</stage>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p><stage><add resp="#ed"><emph>verso l'interno, rivolgendosi a Lucrezia</emph></add></stage>. Io ho fatto d'ogni cosa a tuo modo: di questo vo' io che tu facci a mio. Se io credevo non avere figliuoli io arei preso più tosto per moglie una contadina che te. <stage><add resp="#ed"><emph>A Siro, porgendogli l'orinale</emph></add></stage>. To' costì, Siro; viemmi drieto. Quanta fatica ho io durata a fare che questa mia mona sciocca mi dia questo segno! E non è dire che la non abbi caro di fare figliuoli, che la ne ha più pensiero di me; ma, come io le vo' far fare nulla, egli è una storia.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p>
  Abbiate pazienzia: le donne si sogliono con le buone parole condurre dove altri vuole.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Che buone parole! ché mi ha fracido. Va' ratto, di' al maestro ed a Ligurio che io son qui.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p>
  Eccogli che vengon fuori.</p>
@@ -935,253 +963,253 @@ Guardate e' non v'inganni: questi pappatori non sogliono avere molta fede.</p>
         <div type="scene">
           <head>scena sesta</head>
           <stage>LIGURIO, CALLIMACO, MESSER NICIA</stage>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p><stage><add resp="#ed"><emph>piano, a Callimaco</emph></add></stage>. El dottore fia facile a persuadere: la difficultà fia la donna, ed a questo non ci mancherà modi.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p><stage><add resp="#ed"><emph>a messer Nicia</emph></add></stage>. Avete voi el segno?</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  E' l'ha Siro, sotto.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p><stage><add resp="#ed"><emph>a Siro</emph></add></stage>. Dàllo qua. <stage><add resp="#ed"><emph>Dopo aver osservato il segno</emph></add></stage>. Oh! questo segno mostra debilità di rene.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  E' mi par torbidiccio; eppur l'ha fatto ora ora.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Non ve ne maravigliate. <foreign xml:lang="lat">Nam mulieris urine sunt semper maioris grossitiei et albedinis, et minoris pulchritudinis quam virorum. Huius autem, inter cetera, causa est amplitudo canalium, mixtio eorum que ex matrice exeunt cum urinis</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p><stage><add resp="#ed"><emph>a parte</emph></add></stage>. Oh! uh! potta di san Puccio! Costui mi raffinisce in tralle mani; guarda come ragiona bene di queste cose!</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Io ho paura che costei non sia la notte mal coperta, e per questo fa l'orina cruda.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Ella tien pure adosso un buon coltrone; ma la sta quattro ore ginocchioni ad infilzar paternostri, innanzi che la se ne venghi al letto, ed è una bestia a patir freddo.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Infine, dottore, o voi avete fede in me, o no; o io vi ho ad insegnare un rimedio certo, o no. Io, per me, el rimedio vi darò. Se voi arete fede in me voi lo piglierete; e se, oggi ad uno anno, la vostra donna non ha un suo figliuolo in braccio, io voglio avervi a donare dumilia ducati.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Dite pure, che io son per farvi onore di tutto, e per credervi più che al mio confessoro.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Voi avete ad intender questo, che non è cosa più certa ad ingravidare una donna che dargli bere una pozione fatta di mandragola. Questa è una cosa esperimentata da me dua paia di volte, e trovata sempre vera; e, se non era questo, la reina di Francia sarebbe sterile, ed infinite altre principesse di quello stato.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  È egli possibile?</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Egli è come io vi dico. E la Fortuna vi ha in tanto voluto bene che io ho condutto qui meco tutte quelle cose che in quella pozione si mettono, e potete averla a vostra posta.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Quando l'arebbe ella a pigliare?</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Questa sera dopo cena, perché la luna è ben disposta, ed el tempo non può essere più appropriato.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Cotesto non fia molto gran cosa. Ordinatela in ogni modo: io gliene faro pigliare.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>E' bisogna ora pensare a questo: che quello uomo che ha prima a fare seco, presa che l'ha, cotesta pozione, muore infra otto giorni, e non lo camperebbe el mondo.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Cacasangue! Io non voglio cotesta suzzacchera! A me non l'apiccherai tu! Voi mi avete concio bene!</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  State saldo, e' ci è rimedio.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Quale?</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Fare dormire subito con lei un altro che tiri, standosi seco una notte, a sé tutta quella infezione della mandragola: dipoi vi iacerete voi sanza periculo.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Io non vo' fare cotesto.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Perché?</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Perché io non vo' fare la mia donna femmina e me becco.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Che dite voi, dottore? Oh! io non vi ho per savio come io credetti. Sì che voi dubitate di fare quello che ha fatto el re di Francia e tanti signori quanti sono là?</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Chi volete voi che io truovi che facci cotesta pazzia? Se io gliene dico, e' non vorrà; se io non gliene dico, io lo tradisco, ed è caso da Otto: io non ci vo' capitare sotto male.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Se non vi dà briga altro che cotesto, lasciatene la cura a me.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Come si farà?</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Dirovelo: io vi darò la pozione questa sera dopo cena; voi gliene darete bere e, subito, la metterete nel letto, che fieno circa a quattro ore di notte. Dipoi ci travestiremo, voi, Ligurio, Siro ed io, e andrencene cercando in Mercato Nuovo, in Mercato Vecchio, per questi canti; ed el primo garzonaccio che noi troverremo scioperato, lo imbavagliereno, ed a suon di mazzate lo condurreno in casa ed in camera vostra al buio. Quivi lo mettereno nel letto, direngli quel che gli abbia a fare, non ci fia difficultà veruna. Dipoi, la mattina, ne manderete colui innanzi dì, farete lavare la vostra donna, starete con lei a vostro piacere e sanza periculo.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Io sono contento, poiché tu di' che e re e principi e signori hanno tenuto questo modo. Ma, sopratutto, che non si sappia, per amore degli Otto!</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Chi volete voi che lo dica?</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Una fatica ci resta, e d'importanza.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Quale?</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Farne contenta mogliama, a che io non credo ch'ella si disponga mai.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Voi dite el vero. Ma io non vorrei innanzi essere marito, se io non la disponessi a fare a mio modo.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Io ho pensato el rimedio.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Come?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Per via del confessoro.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Chi disporrà el confessoro, tu?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Io, e danari, la cattività nostra, loro.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Io dubito, non che altro, che per mio detto la non voglia ire a parlare al confessoro.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Ed anche a cotesto è rimedio.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p>
  Dimmi.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Farvela condurre alla madre.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  La le presta fede.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Ed io so che la madre è della opinione nostra. Orsù! avanziam tempo, che si fa sera. <stage><add resp="#ed"><emph>Piano, a Callimaco</emph></add></stage>. Vatti, Callimaco, a spasso, e fa' che alle ventitré ore noi ti ritroviamo in casa con la pozione ad ordine. Noi n'andreno a casa la madre, el dottore ed io, a disporla, perché è mia nota. Poi ne andreno al frate, e vi raguagliereno di quello che noi areno fatto.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p><stage><add resp="#ed"><emph>piano a Ligurio</emph></add></stage>. Deh! non mi lasciar solo.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p><stage><add resp="#ed"><emph>stesso gioco, a Callimaco</emph></add></stage>. Tu mi par' cotto.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p><stage><add resp="#ed"><emph>stesso gioco</emph></add></stage>. Dove vuoi tu ch'io vadia ora?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p><stage><add resp="#ed"><emph>stesso gioco</emph></add></stage>. Di là, di qua, per questa via, per quell'altra: egli è sì grande Firenze!</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p><stage><add resp="#ed"><emph>stesso gioco</emph></add></stage>. Io son morto.</p>
           </sp>
@@ -1209,22 +1237,22 @@ Guardate e' non v'inganni: questi pappatori non sogliono avere molta fede.</p>
         <div type="scene">
           <head>scena prima</head>
           <stage>SOSTRATA, MESSER NICIA, LIGURIO</stage>
-          <sp>
+          <sp who="#sostrata">
             <speaker>SOS.</speaker>
             <p>
  Io ho sempremai sentito dire che gli è ufizio d'un prudente pigliare de' cattivi partiti el migliore: se, ad avere figliuoli, voi non avete altro rimedio che questo, si vuole pigliarlo, quando e' non si gravi la coscienzia.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Egli è così.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Voi ve ne andrete a trovare la vostra figliuola, e messere ed io andreno a trovare fra' Timoteo, suo confessoro, e narreregli el caso, acciò che non abbiate a dirlo voi: vedrete quello che vi dirà.</p>
           </sp>
-          <sp>
+          <sp who="#sostrata">
             <speaker>SOS.</speaker>
             <p>
  Così sarà fatto. La via vostra è di costà; ed io vo a trovare la Lucrezia, e la merrò a parlare al frate, in ogni modo.</p>
@@ -1233,102 +1261,102 @@ Guardate e' non v'inganni: questi pappatori non sogliono avere molta fede.</p>
         <div type="scene">
           <head>scena seconda</head>
           <stage>MESSER NICIA, LIGURIO</stage>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Tu ti maravigli forse, Ligurio, che bisogni fare tante storie a disporre mogliama; ma se tu sapessi ogni cosa, tu non te ne maraviglieresti.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Io credo che sia, perché tutte le donne sono sospettose.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Non è cotesto. Ella era la più dolce persona del mondo e la più facile; ma, sendole detto da una sua vicina che, s'ella si botava d'udire quaranta mattine la prima messa de' Servi, ch'ella impregnerebbe, la si botò, ed andovi forse venti mattine. Ben sapete che un di que' fratacchioni le cominciò andare da torno, in modo che la non vi volle più tornare. Egli è pur male però che quegli che ci arebbono a dare buoni essempli sien fatti così. Non dich'io el vero?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Come diavol, s'egli è vero!</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Da quel tempo in qua ella sta in orecchi come la lepre, e, come se le dice nulla, ella vi fa dentro mille difficultà.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Io non mi maraviglio più. Ma, quel boto, come si adempié?</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Fecesi dispensare.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Sta bene. Ma datemi, se voi avete, venticinque ducati, che bisogna, in questi casi, spendere, e farsi amico el frate presto, e darli speranza di meglio.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Pigliagli pure; questo non mi dà briga, io farò masserizia altrove.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Questi frati sono trincati, astuti; ed è ragionevole, perché e' sanno e peccati nostri, e loro, e chi non è pratico con essi potrebbe ingannarsi e non li sapere condurre a suo proposito. Pertanto io non vorrei che voi nel parlare guastassi ogni cosa, perché un vostro pari, che sta tuttodì nello studio, s'intende di que' libri, e delle cose del mondo non sa ragionare. <stage><add resp="#ed"><emph>A parte</emph></add></stage>. Costui è sì sciocco, che io ho paura non guasti ogni cosa.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Dimmi quel che tu vuoi ch'io faccia.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Che voi lasciate parlare a me, e non parliate mai, s'io non vi accenno.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Io sono contento. Che cenno farai tu?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Chiuderò un occhio; morderommi el labro... Deh! no, facciàno altrimenti. Quanto è egli che voi non parlasti al frate?</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  È più di dieci anni.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Sta bene. Io gli dirò che voi sete assordato, e voi non risponderete e non direte mai cosa alcuna, se noi non parliamo forte.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  Così farò.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Oltre a questo, non vi dia briga che io dica qualche cosa che e' vi paia disforme a quel che noi vogliamo, perché tutto tornerà a proposito.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p>
  In buon'ora.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p>
  Ma io veggo el frate che parla con una donna. Aspettian che l'abbi spacciata.</p>
@@ -1337,51 +1365,51 @@ Guardate e' non v'inganni: questi pappatori non sogliono avere molta fede.</p>
         <div type="scene">
           <head>scena terza</head>
           <stage>FRA' TIMOTEO, UNA DONNA</stage>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p>
 Se voi vi volessi confessare, io farò ciò che voi volete.</p>
           </sp>
-          <sp>
+          <sp who="#donna">
             <speaker>DONNA</speaker>
             <p>
  Non, per oggi; io sono aspettata: e' mi basta essermi sfogata un poco, così ritta ritta. Avete voi dette quelle messe della Nostra Donna?</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p>
 Madonna sì.</p>
           </sp>
-          <sp>
+          <sp who="#donna">
             <speaker>DONNA</speaker>
             <p>
  Togliete ora questo fiorino, e direte dua mesi ogni lunedì la messa de' morti per l'anima del mio marito. Ed ancora che fussi un omaccio, pure le carne tirono: io non posso fare non mi risenta, quando io me ne ricordo. Ma credete voi che sia in purgatorio?</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Sanza dubio.</p>
           </sp>
-          <sp>
+          <sp who="#donna">
             <speaker>DONNA</speaker>
             <p> Io non so già cotesto. Voi sapete pure quel che mi faceva qualche volta. Oh, quanto me ne dolsi io con esso voi! Io me ne discostavo quanto io potevo; ma egli era sì importuno! Uh, nostro Signore!</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Non dubitate, la clemenzia di Dio è grande: se non manca a l'uomo la voglia, non gli manca mai el tempo a pentersi.</p>
           </sp>
-          <sp>
+          <sp who="#donna">
             <speaker>DONNA</speaker>
             <p> Credete voi che 'l Turco passi questo anno in Italia?</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Se voi non fate orazione, sì.</p>
           </sp>
-          <sp>
+          <sp who="#donna">
             <speaker>DONNA</speaker>
             <p> Naffe! Dio ci aiuti, con queste diavolerie! Io ho una gran paura di quello impalare. Ma io veggo qua in chiesa una donna che ha certa accia di mio: io vo ire a trovarla. Fate col buon dì.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Andate sana.</p>
           </sp>
@@ -1389,127 +1417,127 @@ Madonna sì.</p>
         <div type="scene">
           <head>scena quarta</head>
           <stage>FRA' TIMOTEO, LIGURIO, MESSER NICIA</stage>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p><stage><add resp="#ed"><emph>solo</emph></add></stage>. Le più caritative persone che sieno sono le donne, e le più fastidiose. Chi le scaccia, fugge e fastidii e l'utile; chi le intrattiene, ha l'utile ed e fastidii insieme. Ed è 'l vero che non è el mele sanza le mosche. <stage><add resp="#ed"><emph>A Ligurio e a Nicia</emph></add></stage>. Che andate voi facendo, uomini da bene? Non riconosco io messer Nicia?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Dite forte, che gli è in modo assordato, che non ode quasi nulla.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Voi sete el ben venuto, messere!</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Più forte!</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> El ben venuto!</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> El ben trovato, padre!</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Che andate voi faccendo?</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Tutto bene.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Volgete el parlare a me, padre, perché voi, a volere che v'intendessi, aresti a mettere a romore questa piazza.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Che volete voi da me?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Qui messer Nicia ed un altro uomo da bene, che voi intenderete poi, hanno a fare distribuire in limosine parecchi centinaia di ducati.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Cacasangue!</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p><stage><add resp="#ed"><emph>piano, a Nicia</emph></add></stage>. Tacete, in malora, e' non fien molti! <stage><add resp="#ed"><emph>Rivolgendosi ancora al Frate</emph></add></stage>. Non vi maravigliate padre, di cosa che dica, che non ode, e pargli qualche volta udire, e non risponde a proposito.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Séguita pure, e lasciagli dire ciò che vuole.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> De' quali danari io ne ho una parte meco; ed hanno disegnato che voi siate quello che li distribuiate.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Molto volentieri.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Ma egli è necessario, prima che questa limosina si faccia, che voi ci aiutiate d'un caso strano intervenuto a messere, che solo voi ci potete aiutare, dove ne va al tutto l'onore di casa sua.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Che cosa è?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Io non so se voi conoscesti Cammillo Calfucci, nipote qui di messere.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Sì, conosco.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Costui n'andò per certe sua faccende, uno anno fa, in Francia; e, non avendo donna, che era morta, lasciò una sua figliuola da marito in serbanza in uno monistero, del quale non accade dirvi ora el nome.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Che è seguito?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> È seguito che, o per straccuraggine delle monache o per cervellinaggine della fanciulla, la si truova gravida di quattro mesi; di modo che, se non si ripara con prudenzia, el dottore, le monache, la fanciulla, Cammillo, la casa de' Calfucci è vituperata; ed il dottore stima tanto questa vergogna che s'è botato, quando la non si palesi, dare trecento ducati per l'amore di Dio.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p><stage><add resp="#ed"><emph>a parte</emph></add></stage>. Che chiacchiera!</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p><stage><add resp="#ed"><emph>piano a Nicia</emph></add></stage>. State cheto! <stage><add resp="#ed"><emph>Rivolgendosi ancora al Frate</emph></add></stage>. E daragli per le vostre mani; e voi solo e la badessa ci potete rimediare.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Come?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Persuadere alla badessa che dia una pozione alla fanciulla per farla sconciare.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Cotesta è cosa da pensarla.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Come, cosa da pensarla? Guardate, nel far questo, quanti beni ne resulta: voi mantenete l'onore al munistero, alla fanciulla, a' parenti; rendete al padre una figliuola; satisfate qui a messere, a tanti sua parenti; fate tante elemosine, quante con questi trecento ducati potete fare; e, dall'altro canto, voi non offendete altro che un pezzo di carne non nata, sanza senso, che in mille modi si può sperdere; ed io credo che quel sia bene, che facci bene a' più, e che e più se ne contentino.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Sia, col nome di Dio! Faccisi ciò che voi volete, e, per Dio e per carità, sia fatto ogni cosa. Ditemi el munistero, datemi la pozione, e, se vi pare, cotesti danari, da potere cominciare a fare qualche bene.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Or mi parete voi quel religioso che io credevo che voi fussi. Togliete questa parte de' danari. El munistero è... Ma aspettate, egli è qui in chiesa una donna che mi accenna: io torno ora ora; non vi partite da messer Nicia, io le vo' dire dua parole.</p>
           </sp>
@@ -1517,31 +1545,31 @@ Madonna sì.</p>
         <div type="scene">
           <head>scena quinta</head>
           <stage>FRA' TIMOTEO, MESSER NICIA</stage>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p><stage><add resp="#ed"><emph>alzando la voce</emph></add></stage>. Questa fanciulla, che tempo ha?</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Io strabilio.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Dico, quanto tempo ha questa fanciulla?</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Mal che Dio gli dia!</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Perché?</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Perché se l'abbia!</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> E' mi pare essere nel gagno. Io ho a fare con uno pazzo e con un sordo: l'un si fugge, l'altro non ode. <stage><add resp="#ed"><emph>soppesando la borsa con i danari</emph></add></stage>. Ma se questi non sono quarteruoli, io ne farò meglio di loro! Ecco Ligurio, che torna in qua.</p>
           </sp>
@@ -1549,55 +1577,55 @@ Madonna sì.</p>
         <div type="scene">
           <head>scena sesta</head>
           <stage>LIGURIO, FRA' TIMOTEO, MESSER NICIA</stage>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p><stage><add resp="#ed"><emph>piano, a messer Nicia</emph></add></stage>. State cheto, messere. <stage><add resp="#ed"><emph>Al Frate</emph></add></stage>. Oh! io ho la gran nuova, padre.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Quale?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Quella donna con chi io ho parlato, mi ha detto che quella fanciulla si è sconcia per sé stessa.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p><stage><add resp="#ed"><emph>a parte</emph></add></stage>. Bene! questa limosina andrà alla Grascia.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Che dite voi?</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Dico che voi tanto più doverrete fare questa limosina.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> La limosina si farà, quando voi vogliate: ma e' bisogna che voi facciate un'altra cosa in benefizio qui del dottore.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Che cosa è?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Cosa di minor carico, di minor scandolo, più accetta a noi, e più utile a voi.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Che è? Io sono in termine con voi, e parmi avere contratta tale dimestichezza, che non è cosa che io non facessi.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Io ve lo vo' dire in chiesa, da me e voi, ed el dottore fia contento d'aspettare qui e prestarmi dua parole. <stage><add resp="#ed"><emph>A Nicia, alzando la voce</emph></add></stage>. Aspettate qui; noi torniamo ora.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p><stage><add resp="#ed"><emph>a parte</emph></add></stage>.Come disse la botta a l' erpice!</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Andiamo.</p>
           </sp>
@@ -1605,7 +1633,7 @@ Madonna sì.</p>
         <div type="scene">
           <head>scena settima</head>
           <stage>MESSER NICIA SOLO</stage>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> È egli di dì o di notte? Sono io desto o sogno? Sono io obliàco, e non ho beuto ancora oggi, per ire drieto a queste chiacchiere? Noi rimagnan di dire al frate una cosa, e' ne dice un'altra; poi volle che io facessi el sordo e bisognava io m'impeciassi gli orecchi come el Danese, a volere che io non avessi udite le pazzie, che gli ha dette, e Dio il sa con che proposito! Io mi truovo meno venticinque ducati, e del fatto mio non si è ancora ragionato; ed ora m'hanno qui posto, come un zugo, a piuolo. Ma eccogli che tornano: in mala ora per loro, se non hanno ragionato del fatto mio!</p>
           </sp>
@@ -1613,27 +1641,27 @@ Madonna sì.</p>
         <div type="scene">
           <head>scena ottava</head>
           <stage>FRA' TIMOTEO, LIGURIO, MESSER NICIA</stage>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p><stage><add resp="#ed"><emph>a Ligurio</emph></add>.</stage>Fate che le donne venghino. Io so quello ch'i' ho a fare; e, se l'autorità mia varrà, noi concluderemo questo parentado questa sera.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p><stage><add resp="#ed"><emph>a Nicia, parlando ad alta voce</emph></add></stage>. Messer Nicia, fra' Timoteo è per fare ogni cosa. Bisogna vedere che le donne venghino.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Tu mi ricrii tutto quanto. Fia egli maschio?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p><stage><add resp="#ed"><emph>come sopra</emph></add></stage>. Maschio.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Io lacrimo per la tenerezza.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Andatevene in chiesa, io aspetterò qui le donne. State in lato che le non vi veggano; e partite che le fieno, vi dirò quello che l'hanno detto.</p>
           </sp>
@@ -1641,7 +1669,7 @@ Madonna sì.</p>
         <div type="scene">
           <head>scena nona</head>
           <stage>FRA' TIMOTEO SOLO</stage>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Io non so chi si abbi giuntato l'uno l'altro. Questo tristo di Ligurio ne venne a me con quella prima novella, per tentarmi, acciò, se io li consentivo quella, m'inducessi più facilmente a questa; se io non gliene consentivo, non mi arebbe detta questa, per non palesare e disegni loro sanza utile, e di quella che era falsa non si curavano. Egli è vero che io ci sono suto giuntato; nondimeno, questo giunto è con mio utile. Messer Nicia e Callimaco sono ricchi, e da ciascuno, per diversi rispetti, sono per trarre assai; la cosa convien stia secreta, perché l'importa così a loro, a dirla, come a me. Sia come si voglia, io non me ne pento. È ben vero che io dubito non ci avere dificultà, perché madonna Lucrezia è savia e buona: ma io la giugnerò in sulla bontà. E tutte le donne hanno alla fine poco cervello; e come ne è una sappi dire dua parole, e' se ne predica, perché in terra di ciechi chi vi ha un occhio è signore. Ed eccola con la madre, la quale è bene una bestia, e sarammi uno grande adiuto a condurla alle mia voglie.</p>
           </sp>
@@ -1649,19 +1677,19 @@ Madonna sì.</p>
         <div type="scene">
           <head>scena decima</head>
           <stage>SOSTRATA, LUCREZIA</stage>
-          <sp>
+          <sp who="#sostrata">
             <speaker>SOS.</speaker>
             <p> Io credo che tu creda, figliuola mia, che io stimi l'onore ed el bene tuo quanto persona del mondo, e che io non ti consiglierei di cosa che non stessi bene. Io ti ho detto e ridicoti, che se fra' Timoteo ti dice che non ti sia carico di conscienzia, che tu lo faccia sanza pensarvi.</p>
           </sp>
-          <sp>
+          <sp who="#lucrezia">
             <speaker>LU.</speaker>
             <p> Io ho sempremai dubitato che la voglia, che messer Nicia ha d'avere figliuoli, non ci facci fare qualche errore; e per questo, sempre che lui mi ha parlato di alcuna cosa, io ne sono stata in gelosia e sospesa, massime poi che m'intervenne quello che vi sapete, per andare a' Servi. Ma di tutte le cose, che si son tentate, questa mi pare la più strana, di avere a sottomettere el corpo mio a questo vituperio, ad esser cagione che uno uomo muoia per vituperarmi: perché io non crederrei, se io fussi sola rimasa nel mondo e da me avessi a risurgere l'umana natura, che mi fussi simile partito concesso.</p>
           </sp>
-          <sp>
+          <sp who="#sostrata">
             <speaker>SOS.</speaker>
             <p> Io non ti so dire tante cose figliuola mia. Tu parlerai al frate, vedrai quello che ti dirà, e farai quello che tu dipoi sarai consigliata da lui, da noi, da chi ti vuole bene.</p>
           </sp>
-          <sp>
+          <sp who="#lucrezia">
             <speaker>LU.</speaker>
             <p> Io sudo per la passione.</p>
           </sp>
@@ -1669,72 +1697,72 @@ Madonna sì.</p>
         <div type="scene">
           <head>scena undecima</head>
           <stage>FRA' TIMOTEO, LUCREZIA, SOSTRATA</stage>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Voi siate le ben venute. Io so quello che voi volete intendere da me perché messer Nicia m'ha parlato. Veramente, io sono stato in su' libri più di dua ore a studiare questo caso; e, dopo molte essamine, io truovo di molte cose che, ed in particulare ed in generale, fanno per noi.</p>
           </sp>
-          <sp>
+          <sp who="#lucrezia">
             <speaker>LU.</speaker>
             <p> Parlate voi da vero o motteggiate?</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p>Ah, madonna Lucrezia! Sono, queste, cose da motteggiare? Avetemi voi a conoscere ora?</p>
           </sp>
-          <sp>
+          <sp who="#lucrezia">
             <speaker>LU.</speaker>
             <p> Padre, no; ma questa mi pare la più strana cosa che mai si udissi.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Madonna, io ve lo credo, ma io non voglio che voi diciate più così. E' sono molte cose che discosto paiano terribili, insopportabili, strane, che, quando tu ti appressi loro, le riescono umane, sopportabili, dimestiche; e però si dice che sono maggiori li spaventi che e mali: e questa è una di quelle.</p>
           </sp>
-          <sp>
+          <sp who="#lucrezia">
             <speaker>LU.</speaker>
             <p> Dio el voglia!</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Io voglio tornare a quello, ch'io dicevo prima. Voi avete, quanto alla conscienzia, a pigliare questa generalità, che, dove è un bene certo ed un male incerto, non si debbe mai lasciare quel bene per paura di quel male. Qui è un bene certo, che voi ingraviderete, acquisterete una anima a messer Domenedio; el male incerto è che colui che iacerà, dopo la pozione, con voi, si muoia; ma e' si truova anche di quelli che non muoiono. Ma perché la cosa è dubia, però è bene che messer Nicia non corra quel periculo. Quanto allo atto, che sia peccato, questo è una favola, perché la volontà è quella che pecca, non el corpo, e la cagione del peccato è dispiacere al marito, e voi li compiacete; pigliarne piacere, e voi ne avete dispiacere. Oltr'a di questo, el fine si ha a riguardare in tutte le cose: el fine vostro si è riempiere una sedia in paradiso, e contentare el marito vostro. Dice la Bibia che le figliuole di Lotto, credendosi essere rimase sole nel mondo usorono con el padre; e, perché la loro intenzione fu buona, non peccorono.</p>
           </sp>
-          <sp>
+          <sp who="#lucrezia">
             <speaker>LU.</speaker>
             <p> Che cosa mi persuadete voi?</p>
           </sp>
-          <sp>
+          <sp who="#sostrata">
             <speaker>SOS.</speaker>
             <p> Làsciati persuadere, figliuola mia. Non vedi tu che una donna, che non ha figliuoli, non ha casa? Muorsi el marito, resta come una bestia, abandonata da ognuno.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Io vi giuro, madonna, per questo petto sacrato, che tanta conscienzia vi è ottemperare in questo caso al marito vostro, quanto vi è mangiare carne el mercoledì, che è un peccato che se ne va con l'acqua benedetta.</p>
           </sp>
-          <sp>
+          <sp who="#lucrezia">
             <speaker>LU.</speaker>
             <p> A che mi conducete voi, padre?</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Conducovi a cose, che voi sempre arete cagione di pregare Dio per me; e più vi satisfarà questo altro anno che ora.</p>
           </sp>
-          <sp>
+          <sp who="#sostrata">
             <speaker>SOS.</speaker>
             <p> Ella farà ciò che voi volete. Io la voglio mettere stasera al letto io. <stage><add resp="#ed"><emph>A Lucrezia</emph></add></stage>. Di che hai tu paura, moccicona? E' ci è cinquanta donne, in questa terra, che ne alzerebbono le mani al cielo.</p>
           </sp>
-          <sp>
+          <sp who="#lucrezia">
             <speaker>LU.</speaker>
             <p> Io sono contenta: ma io non credo mai essere viva domattina.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Non dubitar, figliuola mia: io pregherrò Iddio per te, io dirò l'orazione dell'Angiolo Raffaello, che ti accompagni. Andate, in buona ora, e preparatevi a questo misterio, che si fa sera.
 	</p>
           </sp>
-          <sp>
+          <sp who="#sostrata">
             <speaker>SOS.</speaker>
             <p> Rimanete in pace, padre.</p>
           </sp>
-          <sp>
+          <sp who="#lucrezia">
             <speaker>LU.</speaker>
             <p> Dio m'aiuti e la Nostra Donna, che io non capiti male.</p>
           </sp>
@@ -1742,59 +1770,59 @@ Madonna sì.</p>
         <div type="scene">
           <head>scena duodecima</head>
           <stage>FRA' TIMOTEO, LIGURIO, MESSER NICIA</stage>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Ligurio, uscite qua!</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Come va?</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Bene. Le ne sono ite a casa disposte a fare ogni cosa, e non ci fia difficultà, perché la madre s'andrà a stare seco, e vuolla mettere al letto lei.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Dite voi el vero?</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Bembè, voi sete guarito del sordo?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Santo Chimenti gli ha fatto grazia.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> E' si vuol porvi una immagine, per rizzarci un poco di baccanella, acciò che io abbia fatto quest'altro guadagno con voi.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Non entriano in cetere. Farà la donna difficultà di fare quel ch'io voglio?</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Non, vi dico.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Io sono el più contento uomo del mondo.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Credolo. Voi vi beccherete un fanciul mastio; e chi non ha non abbia.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Andate, frate, a le vostre orazioni, e, se bisognerà altro, vi verreno a trovare. Voi, messere, andate a lei, per tenerla ferma in questa opinione, ed io andrò a trovare maestro Callimaco che vi mandi la pozione; ed a l'un'ora fate che io vi rivegga, per ordinare quello che si de' fare alle quattro.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Tu di' bene. Addio!</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Andate sani.</p>
           </sp>
@@ -1820,7 +1848,7 @@ Madonna sì.</p>
         <div type="scene">
           <head>scena prima</head>
           <stage>CALLIMACO SOLO</stage>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Io vorrei pure intendere quello che costoro hanno fatto. Può egli essere che io non rivegga Ligurio? E, nonché le ventitré, le sono le ventiquattro ore! In quanta angustia d'animo sono io stato e sto! Ed è vero che la Fortuna e la Natura tiene el conto per bilancio: la non ti fa mai un bene, che, a l'incontro, non surga un male. Quanto più mi è cresciuta la speranza, tanto mi è cresciuto el timore. Misero a me! Sarà egli mai possibile che io viva in tanti affanni e perturbato da questi timori e queste speranze? Io sono una nave vessata da dua diversi venti, che tanto più teme, quanto ella è più presso al porto. La semplicità di messer Nicia mi fa sperare, la prudenzia e durezza di Lucrezia mi fa temere. Ohimé, che io non truovo requie in alcuno loco! Talvolta io cerco di vincere me stesso, riprendomi di questo mio furore, e dico meco: Che fai tu? Se' tu impazzato? Quando tu l'ottenga, che fia? Conoscerai el tuo errore, pentira'ti delle fatiche e de' pensieri che hai auti. Non sai tu quanto poco bene si truova nelle cose che l'uomo desidera, rispetto a quello che l'uomo ha presupposto trovarvi? Da l'altro canto, el peggio che te ne va è morire ed andarne in inferno: e' son morti tanti degli altri! e' sono in inferno tanti uomini da bene! Ha'ti tu a vergognare d'andarvi tu? Volgi el viso alla sorte; fuggi el male, o, non lo potendo fuggire, sopportalo come uomo; non ti prosternere, non ti invilire come una donna. E così mi fo di buon cuore; ma io ci sto poco su, perché da ogni parte mi assalta tanto desio d'essere una volta con costei, che io mi sento, dalle piante de' piè al capo, tutto alterare: le gambe triemano, le viscere si commuovono, el cuore mi si sbarba del petto, le braccia s'abandonono, la lingua diventa muta, gli occhi abarbagliano, el cervello mi gira. Pure, se io trovassi Ligurio, io arei con chi sfogarmi. Ma ecco che ne viene verso me ratto: el rapporto di costui mi farà o vivere allegro qualche poco, o morire affatto.</p>
           </sp>
@@ -1828,275 +1856,275 @@ Madonna sì.</p>
         <div type="scene">
           <head>scena seconda</head>
           <stage>LIGURIO, CALLIMACO</stage>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p><stage><add resp="#ed"><emph>solo</emph></add></stage>. Io non desiderai mai più tanto di trovare Callimaco, e non penai mai più tanto a trovarlo. Se io li portassi triste nuove, io l'arei riscontro al primo. Io sono stato a casa, in Piazza, in Mercato, al Pancone delli Spini, alla Loggia de' Tornaquinci, e non l'ho trovato. Questi innamorati hanno l'ariento vivo sotto e piedi, e non si possono fermare.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p><stage><add resp="#ed"><emph>a parte</emph></add></stage>. Che sto io ch'io non lo chiamo? E' mi par pure allegro! <stage><add resp="#ed"><emph>A Ligurio</emph></add></stage>. Oh, Ligurio! Ligurio!</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Oh Callimaco! dove se' tu stato?</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Che novelle?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Buone.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Buone in verità?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Ottime.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> È Lucrezia contenta?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Sì.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> El frate fece el bisogno?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Fece.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Oh, benedetto frate! Io pregherrò sempre Dio per lui.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Oh, buono! Come se Idio facessi le grazie del male, come del bene! El frate vorrà altro che prieghi!</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Che vorrà?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Danari.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Darégliene. Quanti ne gli hai tu promessi?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Trecento ducati</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Hai fatto bene.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> El dottore ne ha sborsati venticinque.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Come?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Bastiti che gli ha sborsati.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> La madre di Lucrezia, che ha fatto?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Quasi el tutto. Come la 'ntese che la sua figliuola aveva avere questa buona notte sanza peccato, la non restò mai di pregare, comandare, confortare la Lucrezia, tanto che ella la condusse al frate, e quivi operò in modo che la li consentì.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Oh, Iddio! Per quali mia meriti debbo io avere tanti beni? Io ho a morire per l'alegrezza!</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p><stage><add resp="#ed"><emph>rivolgendosi al pubblico</emph></add></stage>. Che gente è questa? Ora per l'alegrezza, ora pel dolore, costui vuole morire in ogni modo. <stage><add resp="#ed"><emph>A Callimaco</emph></add></stage>. Hai tu ad ordine la pozione?</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Sì, ho.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Che li manderai?</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Un bicchiere d'ipocrasso, che è a proposito a racconciare lo stomaco, rallegra el cervello... Ohimé, ohimé, ohimé, i' sono spacciato!</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Che è? Che sarà?</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> E' non ci è remedio.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Che diavol fia?</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> E' non si è fatto nulla, i' mi son murato in un forno.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Perché? Che non lo di'? Levati le mani dal viso.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> O non sai tu che io ho detto a messer Nicia che tu, lui, Siro ed io piglieremo uno per metterlo a lato a la moglie?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Che importa?</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Come, che importa? Se io sono con voi, non potrò essere quel che sia preso; s'io non sono, e' s'avvedrà dello inganno.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Tu di' el vero. Ma non c'è egli rimedio?</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Non, credo io.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Sì, sarà bene.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Quale?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Io voglio un poco pensallo.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Tu m'ha' chiaro: io sto fresco se tu l'hai a pensare ora!</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Io l'ho trovato.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Che cosa?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Farò che 'l frate, che ci ha aiutato infino a qui, farà questo resto.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> In che modo?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Noi abbiamo tutti a travestirci. Io farò travestire el frate: contrafarà la voce, el viso, l'abito; e dirò al dottore che tu sia quello; e' se 'l crederrà.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Piacemi, ma io che farò?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Fo conto che tu ti metta un pitocchino indosso, e con un liuto in mano te ne venga costì, dal canto della sua casa, cantando un canzoncino.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> A viso scoperto?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Sì, che se tu portassi una maschera, e' gli enterrebbe sospetto.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> E' mi conoscerà.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Non farà, perché io voglio che tu ti storca el viso, che tu apra, aguzzi o digrigni la bocca, chiugga un occhio. Pruova un poco.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Fo io così?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> No.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Così?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Non basta.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> A questo modo?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Sì, sì, tieni a mente cotesto. Io ho un naso in casa: i' voglio che tu te l'appicchi.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Orbè, che sarà poi?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Come tu sarai comparso in sul canto, noi saren quivi, torrénti el liuto, piglierenti, aggirerenti, condurrenti in casa, metterenti al letto. El resto doverrai tu fare da te!</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Fatto sta condursi costì.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Qui ti condurrai tu. Ma a fare che tu vi possa ritornare, sta a te, e non a noi.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Come?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Che tu te la guadagni in questa notte, e che, innanzi che tu ti parta, te le dia a conoscere, scuoprale lo 'nganno, mostrile l'amore li porti, dicale el bene le vuoi, e come sanza sua infamia la può esser tua amica, e con sua grande infamia tua nimica. È impossibile che la non convenga teco, e che la voglia che questa notte sia sola.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Credi tu cotesto?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Io ne son certo. Ma non perdian più tempo: e' son già dua ore. Chiama Siro, manda la pozione a messer Nicia, e me aspetta in casa. Io andrò per il frate: farollo travestire, e condurrollo qui, e troverreno el dottore, e fareno quello manca.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Tu di' bene. Va' via.</p>
           </sp>
@@ -2104,51 +2132,51 @@ Madonna sì.</p>
         <div type="scene">
           <head>scena terza</head>
           <stage>CALLIMACO, SIRO</stage>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> O Siro!</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p> Messere!</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Fatti costì.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p> Eccomi.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Piglia quel bicchiere d'argento che è drento allo armario di camera, e coperto con un poco di drappo, portamelo, e guarda a non lo versare per la via.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p> Sarà fatto. <stage><add resp="#ed"><emph>Siro parte</emph></add></stage>.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Costui è stato dieci anni meco, e sempre m'ha servito fedelmente. Io credo trovare, anche in questo caso, fede in lui; e, benché io non gli abbi comunicato questo inganno, e' se lo indovina, ché gli è cattivo bene, e veggo che si va accomodando.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p><stage><add resp="#ed"><emph>rientrando</emph></add></stage>. Eccolo.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Sta bene. Tira, va' a casa messer Nicia, e digli che questa è la medicina, che ha a pigliare la donna dipo' cena subito; e quanto prima cena, tanto sarà meglio; e, come noi sareno in sul canto ad ordine, al tempo, ch'e' facci d'esservi. Va' ratto.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p> Io vo. <stage><add resp="#ed"><emph>Si avvia</emph></add></stage>.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Odi qua. Se vuole che tu l'aspetti, aspettalo, e vientene qui con lui; se non vuole, torna qui da me, dato che tu glien'hai, e fatto che tu gli arai l'ambasciata. Intendi?</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p> Messer, sì.</p>
           </sp>
@@ -2156,7 +2184,7 @@ Madonna sì.</p>
         <div type="scene">
           <head>scena quarta</head>
           <stage>CALLIMACO SOLO</stage>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Io aspetto che Ligurio torni col frate; e chi dice che gli è dura cosa l'aspettare, dice el vero. Io scemo ad ogni ora dieci libre, pensando dove io sono ora, dove io potrei essere di qui a dua ore, temendo che non nasca qualche caso, che interrompa el mio disegno. Che se fussi, e' fia l'ultima notte della vita mia, perché o io mi gitterò in Arno, o io m'impiccherò, o io mi gitterò da quelle finestre, o io mi darò d'un coltello in sull'uscio suo. Qualche cosa farò io, perché io non viva più. Ma veggo io Ligurio? Egli è desso. Egli ha seco uno che pare scrignuto, zoppo: e' fia certo el frate travestito. Oh, frati! Conoscine uno, e conoscigli tutti! Chi è quell'altro, che si è accostato a loro? E' mi pare Siro, che arà digià fatto l'ambasciata al dottore. Egli è esso. Io gli voglio aspettare qui, per convenire con loro.</p>
           </sp>
@@ -2164,91 +2192,91 @@ Madonna sì.</p>
         <div type="scene">
           <head>scena quinta</head>
           <stage>SIRO, LIGURIO, CALLIMACO, FRA' TIMOTEO TRAVESTITO</stage>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p> Chi è teco, Ligurio?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Un uom da bene.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p> È egli zoppo, o fa le vista?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Bada ad altro.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p> Oh! gli ha el viso del gran ribaldo!</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Deh! sta' cheto, che ci hai fracido! Ove è Callimaco?</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Io son qui. Voi sete e ben venuti!</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> O Callimaco! avvertisci questo pazzerello di Siro: egli ha detto già mille pazzie.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Siro, odi qua: tu hai questa sera a fare tutto quello che ti dirà Ligurio; fa' conto, quando e' ti comanda, ch'e' sia io; e ciò che tu vedi, senti o odi, hai a tenere segretissimo, per quanto tu stimi la roba, l'onore, la vita mia ed il bene tuo.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p> Così si farà.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Desti tu el bicchiere al dottore?</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p> Messer, sì.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Che disse?</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p> Che sarà ora ad ordine di tutto.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> È questo Callimaco?</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Sono, a' comandi vostri. Le proferte tra noi sien fatte: voi avete a diporre di me e di tutte le fortune mia, come di voi.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Io l'ho inteso e credolo, e sommi messo a fare quel per te, che io non arei fatto per uomo del mondo.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Voi non perderete la fatica.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> E' basta che tu mi voglia bene.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Lasciamo stare le cirimonie. Noi andreno a travestirci, Siro ed io. Tu Callimaco, vien' con noi, per potere ire a fare e fatti tua. El frate ci aspetterà qui: noi torneren subito, ed andreno a trovare messer Nicia.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Tu di' bene. Andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Io vi aspetto.</p>
           </sp>
@@ -2256,7 +2284,7 @@ Madonna sì.</p>
         <div type="scene">
           <head>scena sesta</head>
           <stage>FRA' TIMOTEO TRAVESTITO</stage>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> E' dicono el vero quelli che dicono che le cattive compagnie conducono li uomini alle forche. E molte volte uno capita male così per essere troppo facile e troppo buono, come per essere troppo tristo. Dio sa che io non pensavo ad iniuriare persona, stavomi nella mia cella, dicevo el mio ufizio, intrattenevo e mia devoti: capitommi innanzi questo diavol di Ligurio, che mi fece intignere el dito in uno errore, donde io vi ho messo el braccio, e tutta la persona, e non so ancora dove io mi abbia a capitare. Pure mi conforto che, quando una cosa importa a molti, molti ne hanno aver cura. Ma ecco Ligurio e quel servo che tornano.</p>
           </sp>
@@ -2264,35 +2292,35 @@ Madonna sì.</p>
         <div type="scene">
           <head>scena settima</head>
           <stage>FRA' TIMOTEO, LIGURIO, SIRO TRAVESTITI</stage>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Voi sete e ben tornati.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Stian noi bene?</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Benissimo.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> E' ci manca el dottore. Andian verso casa sua: e' son più di tre ore, andian via!</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p> Chi apre l'uscio suo? È egli el famiglio?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> No: gli è lui. Ah, ah, ah, uh!</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p> Tu ridi?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Chi non riderebbe? Egli ha un guarnacchino indosso, che non gli cuopre el culo. Che diavolo ha egli in capo? E' mi pare un di questi gufi de' canonici, ed uno spadaccin sotto: ah, ah! e' borbotta non so che. Tirianci da parte, ed udireno qualche sciagura della moglie.</p>
           </sp>
@@ -2300,7 +2328,7 @@ Madonna sì.</p>
         <div type="scene">
           <head>scena ottava</head>
           <stage>MESSER NICIA TRAVESTITO</stage>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Quanti lezzi ha fatto questa mia pazza! Ella ha mandato le fante a casa la madre, e 'l famiglio in villa. Di questo io la laudo; ma io non la lodo già che, innanzi che la ne sia voluta ire al letto, ell'abbi fatto tante schifiltà: Io non voglio!... Come farò io?... Che mi fate voi fare?... Ohimé, mamma mia!... E, se non che la madre le disse el padre del porro, la non entrava in quel letto. Che le venga la contina! Io vorrei ben vedere le donne schizzinose, ma non tanto, che ci ha tolto la testa, cervel di gatta! Poi ch'i dicessi: – Che impiccata sia la più savia donna di Firenze – la direbbe: – Che t'ho io fatto? – Io so che la Pasquina enterrà in Arezzo, ed innanzi che io mi parta da giuoco, io potrò dire, come mona Ghinga: – Di veduta, con queste mani –. Io sto pur bene! Chi mi conoscerebbe? Io paio maggiore, più giovane, più scarzo: e' non sarebbe donna, che mi togliessi danari di letto. Ma dove troverrò io costoro?</p>
           </sp>
@@ -2308,177 +2336,177 @@ Madonna sì.</p>
         <div type="scene">
           <head>scena nona</head>
           <stage>LIGURIO, MESSER NICIA, FRA' TIMOTEO, SIRO</stage>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Buona sera, messere.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Oh! uh! eh!</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Non abbiate paura noi sian noi.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Oh! voi sete tutti qui? S'io non vi conoscevo presto, io vi davo con questo stocco, el più diritto che io sapevo! Tu, se' Ligurio? e tu, Siro? e quell'altro? el maestro, eh?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Messer, sì.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Togli! Oh, e' si è contraffatto bene! e' non lo conoscerebbe Va-qua-tu!</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Io gli ho fatto mettere dua noce in bocca, perché non sia conosciuto alla boce.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Tu se' ignorante.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Perché?</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Che non me 'l dicevi tu prima? Ed are'mene messo anch'io dua: e sai se gli importa non essere conosciuto alla favella!</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Togliete, mettetevi in bocca questo.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Che è ella?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Una palla di cera.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Dàlla qua... <stage><add resp="#ed"><emph>Dopo essersela messa in bocca</emph></add></stage>. Ca, pu, ca, co, che, cu, cu, spu... Che ti venga la seccaggine, pezzo di manigoldo!</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Perdonatemi, che io ve ne ho data una in scambio, che io non me ne sono avveduto.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Ca, ca, pu, pu... Di che, che, che, che era?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> D'aloe.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Sia, in malora! Spu, pu... Maestro, voi non dite nulla?</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Ligurio m'ha fatto adirare.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Oh! voi contraffate bene la voce.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Non perdian più tempo qui. Io voglio essere el capitano, ed ordinare l'essercito per la giornata. Al destro corno sia preposto Callimaco, al sinistro io, intra le dua corna starà qui el dottore; Siro fia retroguardo, per dar sussidio a quella banda che inclinassi. El nome sia san Cuccù.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Chi è san Cuccù?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> È el più onorato santo che sia in Francia. Andian via, mettian l'aguato a questo canto. State a udire: io sento un liuto.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Egli è esso. Che vogliàn fare?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Vuolsi mandare innanzi uno esploratore a scoprire chi egli è, e, secondo ci riferirà, secondo fareno.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Chi v'andrà?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Va' via, Siro. Tu sai quello hai a fare. Considera, essamina, torna presto, referisci.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p> Io vo.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Io non vorrei che noi pigliassimo un granchio, che fussi qualche vecchio debole o infermiccio, e che questo giuoco si avessi a rifare domandassera.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Non dubitate, Siro è valent'uomo. Eccolo, e' torna. Che truovi, Siro?</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p> Egli è el più bello garzonaccio, che voi vedessi mai! Non ha venticinque anni, e viensene solo, in pitocchino, sonando el liuto.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Egli è el caso, se tu di' el vero. Ma guarda, che questa broda sarebbe tutta gittata addosso a te!</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p> Egli è quel ch'io vi ho detto.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Aspettian ch'egli spunti questo canto, e subito gli sareno addosso.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Tiratevi in qua, maestro: voi mi parete uno uom di legno. Eccolo.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p><stage><add resp="#ed"><emph>cantando</emph></add></stage>.
 Venir vi possa el diavolo allo letto,
 Dapoi ch'io non vi posso venir io!</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p><stage><add resp="#ed"><emph>afferrando Callimaco</emph></add></stage>. Sta' forte. Da' qua questo liuto!</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Ohimé! Che ho io fatto?</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Tu 'l vedrai! Cuoprigli el capo, imbavaglialo!</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Aggiralo!</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Dagli un'altra volta! Dagliene un'altra! Mettetelo in casa!</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Messer Nicia, io m'andrò a riposare, ché mi duole la testa, che io muoio. E, se non bisogna, io non tornerò domattina.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Sì, maestro, non tornate: noi potren far da noi.</p>
           </sp>
@@ -2486,7 +2514,7 @@ Dapoi ch'io non vi posso venir io!</p>
         <div type="scene">
           <head>scena decima</head>
           <stage>FRA' TIMOTEO TRAVESTITO SOLO</stage>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> E' sono intanati in casa, ed io me n'andrò al convento. E voi, spettatori, non ci appuntate, perché in questa notte non ci dormirà persona, sì che gli Atti non sono interrotti dal tempo: io dirò l'uffizio; Ligurio e Siro ceneranno, che non hanno mangiato oggi; el dottore andrà di camera in sala, perché la cucina vadia netta; Callimaco e madonna Lucrezia non dormiranno, perché io so, se io fussi lui e se voi fussi lei, che noi non dormiremo.</p>
           </sp>
@@ -2514,7 +2542,7 @@ Dapoi ch'io non vi posso venir io!</p>
         <div type="scene">
           <head>scena prima</head>
           <stage>FRA' TIMOTEO SOLO</stage>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Io non ho potuto questa notte chiudere occhio, tanto è el desiderio che io ho d'intendere come Callimaco e gli altri l'abbino fatta. Ed ho atteso a consumare el tempo in varie cose: io dissi mattutino, lessi una vita de' Santi Padri, andai in chiesa ed accesi una lampana che era spenta, mutai un velo ad una Nostra Donna, che fa miracoli. Quante volte ho io detto a questi frati che la tenghino pulita! E si maravigliono poi se la divozione manca! Io mi ricordo esservi cinquecento immagine, e non ve ne sono oggi venti: questo nasce da noi, che non le abbiamo saputa mantenere la reputazione. Noi vi solavamo ogni sera doppo la compieta andare a procissione, e facevànvi cantare ogni sabato le laude. Botavànci noi sempre quivi, perché vi si vedessi delle immagine fresche; confortavamo nelle confessioni gli uomini e le donne a botarvisi. Ora non si fa nulla di queste cose, e poi ci maravigliamo che le cose vadin fredde! Oh, quanto poco cervello è in questi mia frati! Ma io sento un gran romore da casa messer Nicia. Eccogli, per mia fé! E' cavon fuora el prigione. Io sarò giunto a tempo. Ben si sono indugiati alla sgocciolatura: e' si fa appunto l'alba. Io voglio stare ad udire quel che dicono sanza scoprirmi.</p>
           </sp>
@@ -2522,147 +2550,147 @@ Dapoi ch'io non vi posso venir io!</p>
         <div type="scene">
           <head>scena seconda</head>
           <stage>MESSER NICIA, CALLIMACO, LIGURIO, SIRO TRAVESTITI</stage>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Piglialo di costà, ed io di qua, e tu, Siro, lo tieni per il pitocco, di drieto.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Non mi fate male!</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Non aver paura, va' pur via.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Non andian più là.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Voi dite bene. Lasciànl'ir qui: diàngli dua volte, che non sappi donde e' si sia venuto. Giralo, Siro!</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p> Ecco.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Giralo un'altra volta.</p>
           </sp>
-          <sp>
+          <sp who="#siro">
             <speaker>SI.</speaker>
             <p> Ecco fatto.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> El mio liuto!</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Via, ribaldo, tira via! S'io ti sento favellare, io ti taglierò el collo!</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> E' si è fuggito. Andianci a sbisacciare: e vuolsi che noi uscian fuori tutti a buona ora, acciò che non si paia che noi abbiam vegghiato questa notte.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Voi dite el vero.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Andate, Ligurio e Siro, a trovar maestro Callimaco, e li dite che la cosa è proceduta bene.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Che li possiamo noi dire? Noi non sappiamo nulla. Voi sapete che, arrivati in casa, noi ce n'andamo nella volta a bere: voi e la suocera rimanesti alle man' seco, e non vi rivedemo mai se non ora, quando voi ci chiamasti per mandarlo fuora.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Voi dite el vero. Oh! io vi ho da dire le belle cose! Mogliama era nel letto al buio. Sostrata m'aspettava al fuoco. Io giunsi su con questo garzonaccio, e, perché e' non andassi nulla in capperuccia, io lo menai in una dispensa, che io ho in sulla sala, dove era un certo lume annacquato, che gittava un poco d'albore, in modo ch'e' non mi poteva vedere in viso.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Saviamente.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Io lo feci spogliare: e' nicchiava; io me li volsi come un cane, di modo che gli parve mille anni di avere fuora e panni, e rimase ignudo. Egli è brutto di viso: egli aveva un nasaccio, una bocca torta... Ma tu non vedesti mai le più belle carne: bianco, morbido, pastoso! E dell'altre cose non ne domandare.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> E' non è bene ragionarne. Che bisognava vederlo tutto?</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Tu vuoi el giambo! Poi che io avevo messo mano in pasta, io ne volli toccare el fondo. Poi volli vedere s'egli era sano: s'egli avessi auto le bolle, dove mi trovavo io? Tu ci metti parole!</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Avevi ragion voi.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Come io ebbi veduto che gli era sano, io me lo tirai drieto, ed al buio lo menai in camera, messilo al letto; ed innanzi che mi partissi, volli toccare con mano come la cosa andava, che io non sono uso ad essermi dato ad intendere lucciole per lanterne.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Con quanta prudenzia avete voi governata questa cosa!</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Tocco e sentito che io ebbi ogni cosa, mi usci' di camera, e serrai l'uscio, e me n'andai alla suocera, che era al fuoco, e tutta notte abbiamo atteso a ragionare.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Che ragionamenti son suti e vostri?</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Della sciocchezza di Lucrezia, e quanto egli era meglio che, sanza tanti andirivieni, ella avessi ceduto al primo. Dipoi ragionamo del bambino, che me lo pare tuttavia avere in braccio, el naccherino! Tanto che io senti' sonare le tredici ore; e, dubitando che il dì non sopragiugnessi, me n'andai in camera. Che direte voi, che io non potevo fare levare quel ribaldone?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Credolo!</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> E' gli era piaciuto l'unto! Pure, e' si levò, io vi chiamai, e lo abbiamo condutto fuora.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> La cosa è ita bene.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Che dirai tu, che me ne incresce?</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Di che?</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Di quel povero giovane, ch'egli abbia a morire sì presto, e che questa notte gli abbia a costar sì cara.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Oh! voi avete e pochi pensieri! Lasciatene la cura a lui.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Tu di' el vero. Ma e mi par ben mille anni di trovare maestro Callimaco, e rallegrarmi seco.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> E' sarà fra una ora fuora. Ma egli è già chiaro el giorno: noi ci andreno a spogliare; voi, che farete?</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Andronne anch'io in casa, a mettermi e panni buoni. Farò levare e lavare la donna, farolla venire alla chiesa ad entrare in santo. Io vorrei che voi e Callimaco fussi là, e che noi parlassimo al frate, per ringraziarlo e ristorarlo del bene che ci ha fatto.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Voi dite bene: così si farà. A Dio.</p>
           </sp>
@@ -2670,7 +2698,7 @@ Dapoi ch'io non vi posso venir io!</p>
         <div type="scene">
           <head>scena terza</head>
           <stage>FRA' TIMOTEO SOLO</stage>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Io ho udito questo ragionamento, e mi è piaciuto tutto, considerando quanta sciocchezza sia in questo dottore; ma la conclusione ultima mi ha sopra modo dilettato. E poiché debbono venire a trovarmi a casa, io non voglio stare più qui, ma aspettargli alla chiesa, dove la mia mercatanzia varrà più. Ma chi esce di quella casa? E' mi pare Ligurio, e con lui debb'essere Callimaco. Io non voglio che mi vegghino, per le ragioni dette: pur, quando e' non venissino a trovarmi, sempre sarò a tempo ad andare a trovare loro.</p>
           </sp>
@@ -2678,23 +2706,23 @@ Dapoi ch'io non vi posso venir io!</p>
         <div type="scene">
           <head>scena quarta</head>
           <stage>CALLIMACO, LIGURIO</stage>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Come io ti ho detto, Ligurio mio, io stetti di mala voglia infino alle nove ore; e, benché io avessi gran piacere, e' non mi parve buono. Ma, poi che io me le fu' dato a conoscere e ch'io l'ebbi dato ad intendere l'amore che io le portavo, e quanto facilmente, per la semplicità del marito, noi potavamo viver felici sanza infamia alcuna, promettendole che, qualunque volta Dio facessi altro di lui, di prenderla per donna; ed avendo ella, oltre alle vere ragioni, gustato che differenzia è dalla ghiacitura mia a quella di Nicia, e da e baci d'uno amante giovane a quelli d'uno marito vecchio, doppo qualche sospiro, disse: – Poiché l'astuzia tua, la sciocchezza del mio marito, la semplicità di mia madre e la tristizia del mio confessoro mi hanno condutto a fare quello che mai per me medesima arei fatto, io voglio giudicare che venga da una celeste disposizione, che abbi voluto così, e non sono sufficiente a recusare quello che 'l Cielo vuole che io accetti. Però, io ti prendo per signore, patrone, guida: tu mio padre, tu mio defensore, e tu voglio che sia ogni mio bene, e quel che 'l mio marito ha voluto per una sera voglio ch'egli abbia sempre. Fara'ti adunque suo compare, e verrai questa mattina a la chiesa, e di quivi ne verrai a desinare con esso noi; e l'andare e lo stare starà a te, e potreno ad ogni ora e sanza sospetto convenire insieme –. Io fui, udendo queste parole, per morirmi per la dolcezza. Non potetti rispondere a la minima parte di quello che io arei desiderato. Tanto che io mi truovo el più felice e contento uomo che fussi mai nel mondo; e, se questa felicità non mi mancassi o per morte o per tempo, io sarei più beato ch'e beati, più santo ch'e santi.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Io ho gran piacere d'ogni tuo bene, ed ètti intervenuto quello che io ti dissi appunto. Ma che faccian noi ora?</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Andian verso la chiesa, perché io le promissi d'essere là, dove la verrà lei, la madre ed il dottore.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Io sento toccare l'uscio suo: le sono esse, che escono fuora, ed hanno el dottore drieto.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Avvianci in chiesa, e là aspetteremole.</p>
           </sp>
@@ -2702,47 +2730,47 @@ Dapoi ch'io non vi posso venir io!</p>
         <div type="scene">
           <head>scena quinta</head>
           <stage>MESSER NICIA, LUCREZIA, SOSTRATA</stage>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Lucrezia, io credo che sia bene fare le cose con timore di Dio, e non alla pazzeresca.</p>
           </sp>
-          <sp>
+          <sp who="#lucrezia">
             <speaker>LU.</speaker>
             <p> Che s'ha egli a fare, ora?</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Guarda come la risponde! La pare un gallo!</p>
           </sp>
-          <sp>
+          <sp who="#sostrata">
             <speaker>SOS.</speaker>
             <p> Non ve ne maravigliate: ella è un poco alterata.</p>
           </sp>
-          <sp>
+          <sp who="#lucrezia">
             <speaker>LU.</speaker>
             <p> Che volete voi dire?</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Dico che gli è bene che io vadia innanzi a parlare al frate, e dirli che ti si facci incontro in sull'uscio della chiesa, per menarti in santo, perché gli è proprio, stamani, come se tu rinascessi.</p>
           </sp>
-          <sp>
+          <sp who="#lucrezia">
             <speaker>LU.</speaker>
             <p> Che non andate?</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Tu se' stamani molto ardita! Ella pareva iersera mezza morta.</p>
           </sp>
-          <sp>
+          <sp who="#lucrezia">
             <speaker>LU.</speaker>
             <p> Egli è la grazia vostra!</p>
           </sp>
-          <sp>
+          <sp who="#sostrata">
             <speaker>SOS.</speaker>
             <p> Andate a trovare el frate. Ma e' non bisogna, egli è fuora di chiesa.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Voi dite el vero.</p>
           </sp>
@@ -2750,119 +2778,119 @@ Dapoi ch'io non vi posso venir io!</p>
         <div type="scene">
           <head>scena sesta</head>
           <stage>FRA' TIMOTEO, MESSER NICIA, LUCREZIA, CALLIMACO, LIGURIO, SOSTRATA</stage>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p><stage><add resp="#ed"><emph>solo</emph></add></stage>. Io vengo fuora, perché Callimaco e Ligurio m'hanno detto che el dottore e le donne vengono alla chiesa. Eccole.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Bona dies, padre!</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Voi sete le ben venute, e buon pro vi faccia, madonna, che Dio vi dia a fare un bel figliuolo mastio!</p>
           </sp>
-          <sp>
+          <sp who="#lucrezia">
             <speaker>LU.</speaker>
             <p> Dio el voglia!</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> E lo vorrà in ogni modo.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Veggh'io in chiesa Ligurio e maestro Callimaco?</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Messer sì.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Accennategli.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p><stage><add resp="#ed"><emph>a Callimaco e a Ligurio</emph></add></stage>. Venite!</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Dio vi salvi!</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Maestro, toccate la mano qui alla donna mia.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Volentieri.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Lucrezia, costui è quello che sarà cagione che noi aremo uno bastone che sostenga la nostra vecchiezza.</p>
           </sp>
-          <sp>
+          <sp who="#lucrezia">
             <speaker>LU.</speaker>
             <p> Io l'ho molto caro, e vuolsi che sia nostro compare.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Or benedetta sia tu! E voglio che lui e Ligurio venghino stamani a desinare con esso noi.</p>
           </sp>
-          <sp>
+          <sp who="#lucrezia">
             <speaker>LU.</speaker>
             <p> In ogni modo.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> E vo' dar loro la chiave della camera terrena d'in su la loggia, perché possino tornarsi quivi a loro comodità, che non hanno donne in casa, e stanno come bestie.</p>
           </sp>
-          <sp>
+          <sp who="#callimaco">
             <speaker>CAL.</speaker>
             <p> Io l'accetto, per usarla quando mi accaggia.</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Io ho avere e danari per la limosina.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Ben sapete come, domine, oggi vi si manderanno.</p>
           </sp>
-          <sp>
+          <sp who="#ligurio">
             <speaker>LIG.</speaker>
             <p> Di Siro non è uomo che si ricordi?</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Chiegga, ciò che i' ho è suo. Tu, Lucrezia, quanti grossi hai a dare al frate, per entrare in santo?</p>
           </sp>
-          <sp>
+          <sp who="#lucrezia">
             <speaker>LU.</speaker>
             <p> Io non me ne ricordo.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Pure, quanti?</p>
           </sp>
-          <sp>
+          <sp who="#lucrezia">
             <speaker>LU.</speaker>
             <p> Dategliene dieci.</p>
           </sp>
-          <sp>
+          <sp who="#nicia">
             <speaker>NI.</speaker>
             <p> Affogaggine!</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> E voi, madonna Sostrata, avete, secondo che mi pare, messo un tallo in sul vecchio.</p>
           </sp>
-          <sp>
+          <sp who="#sostrata">
             <speaker>SOS.</speaker>
             <p> Chi non sarebbe allegra?</p>
           </sp>
-          <sp>
+          <sp who="#timoteo">
             <speaker>FRATE.</speaker>
             <p> Andianne tutti in chiesa, e quivi direno l'orazione ordinaria. Dipoi doppo l' ufizio, ne andrete a desinare a vostra posta. —Voi, aspettatori, non aspettate che noi usciàn più fuora: l'ufizio è lungo, io mi rimarrò in chiesa, e loro, per l'uscio del fianco, se n'andranno a casa. Valete!</p>
           </sp>

--- a/tei/maffei-merope.xml
+++ b/tei/maffei-merope.xml
@@ -74,6 +74,31 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="polifonte">
+            <persName>Polifonte</persName>
+          </person>
+          <person xml:id="merope">
+            <persName>Merope</persName>
+          </person>
+          <person xml:id="adrasto">
+            <persName>Adrasto</persName>
+          </person>
+          <person xml:id="ismene">
+            <persName>Ismene</persName>
+          </person>
+          <person xml:id="egisto">
+            <persName>Egisto</persName>
+          </person>
+          <person xml:id="euriso">
+            <persName>Euriso</persName>
+          </person>
+          <person xml:id="polidoro">
+            <persName>Polidoro</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -115,7 +140,7 @@
         <div type="scene">
           <head>SCENA PRIMA </head>
           <stage>POLIFONTE <emph>e</emph> MEROPE.</stage>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>Merope, il lungo duol, l'odio, il sospetto</l>
@@ -133,7 +158,7 @@
               <l>come saggia che sei, spargi d'oblio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>O ciel, qual nuova spezie di tormento</l>
@@ -143,7 +168,7 @@
               <l>lasciami in preda al mio dolor trilustre.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>Mira, s'ei non è ver che suol la donna</l>
@@ -153,7 +178,7 @@
               <l part="I">che ricovrar l'antico regno?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Un regno</l>
@@ -166,7 +191,7 @@
               <l>ricercarmi le vene un freddo orrore.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>Deh! come mai ti stanno fisse in mente</l>
@@ -188,7 +213,7 @@
               <l>darebbe Giove questi doni indarno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Barbari sensi! L'urna e le divine</l>
@@ -220,7 +245,7 @@
               <l>A questo ancor mi riserbaste, o dèi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>Merope, omai t'accheta; tu se' donna,</l>
@@ -237,7 +262,7 @@
               <l>dar fede e in grazia tua mi stetti cheto?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Il mio picciol Cresfonte, ch'era ancora</l>
@@ -258,7 +283,7 @@
               <l>rubasse a te l'aspro piacer del colpo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>Ch'ei non morì, in Messene a tutti è noto.</l>
@@ -268,14 +293,14 @@
               <l>la tua vita sì ben, come l'altrui?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Ecco il don dei tiranni; a lor rassembra,</l>
               <l>morte non dando altrui, di dar la vita.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>Ma lasciam tutto ciò, lasciam le amare</l>
@@ -287,7 +312,7 @@
               <l>più d'ammenda presente antichi errori?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Deh dimmi, o Polifonte: e come mai</l>
@@ -299,7 +324,7 @@
               <l>oltre al settimo lustro omai sen varca?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>Quel ch'ora i' bramo, ognor bramai; ma il duro</l>
@@ -319,7 +344,7 @@
               <l>far pago il mio, fin qui soppresso, amore.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Amore, eh? Sempre chi in poter prevale</l>
@@ -340,7 +365,7 @@
               <l>è quel dolce pensier che in te si desta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>Donna non vidi mai di te più pronta</l>
@@ -356,7 +381,7 @@
               <l part="I">l'indagar la cagion.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Sì, se avess'io</l>
@@ -367,7 +392,7 @@
               <l>insuperabil odio estinguer mai.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>Or si tronchi il garrir. Al suo signore</l>
@@ -377,7 +402,7 @@
               <l part="I">Adrasto, e come qui? T'accosta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Ismene,</l>
@@ -388,14 +413,14 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>ADRASTO, ISMENE <emph>e detti</emph>.</stage>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l part="F">In questo, punto,</l>
               <l part="I">signore, i' giungo</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <stage>(<emph>in disparte</emph>)</stage>
             <lg>
@@ -404,20 +429,20 @@
               <l part="I">perché ti veggio sì turbata?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Il tutto</l>
               <l part="I">saprai fra poco.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l part="F">E che ci rechi, Adrasto?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l>Un omicida entro Messene io trassi,</l>
@@ -427,26 +452,26 @@
               <l part="I">le nostre leggi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l part="M">E chi è costui?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l part="F">Di questa</l>
               <l>terra ei non è, ma passagger mi sembra.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l part="I">E l'ucciso?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l part="F">Nol so, perché il suo corpo</l>
@@ -468,14 +493,14 @@
               <l>ed in vesti plebee di nobil volto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l part="I">Fa ch'io 'l vegga.</l>
             </lg>
             <stage>(<emph>Adrasto parte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <stage>(<emph>in disparte</emph>)</stage>
             <lg>
@@ -484,7 +509,7 @@
               <l part="I">un carnefice.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l part="F">Al certo s'ogni morte,</l>
@@ -497,19 +522,19 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>ADRASTO <emph>con</emph> EGISTO <emph>e detti</emph>.</stage>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l part="I">Eccoti il reo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Mira gentile aspetto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>In così verde età sì scelerato!</l>
@@ -517,7 +542,7 @@
               <l part="I">pensavi indirizzar?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">Di padre servo</l>
@@ -525,14 +550,14 @@
               <l>d'Elide e verso Sparta il piè movea.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>Che hai, regina? Oimé quali improvise</l>
               <l>lagrime ti vegg'io sgorgar dagli occhi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>O Ismene, nell'aprir la bocca ai detti</l>
@@ -541,7 +566,7 @@
               <l>e me 'l ritrasse sì com'io 'l vedessi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>Or ti pensavi tu forse che in questo</l>
@@ -551,7 +576,7 @@
               <l>or qui non fusse e ch'io regnassi in vano?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l>Né ciò pensai, né a far ciò che pur feci</l>
@@ -610,14 +635,14 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">ed a dar morte altrui?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l part="F">Onesta è sempre</l>
               <l>la causa di colui che parla solo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>Ma in van, per non aver chi parli incontra,</l>
@@ -626,7 +651,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">l'avversario sarò.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Non correr tosto,</l>
@@ -636,7 +661,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">ch'egli merti pietà.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l part="F">Nulla si nieghi</l>
@@ -645,14 +670,14 @@ m'avesser spinto a ricercar periglio</l>
               <l>non ben conviensi il far più qui dimora.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>Non un'ora già mai, non un momento</l>
               <l>abbandona il sospetto i re malvagi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>Tua cura, Adrasto, fia ch'egli frattanto</l>
@@ -660,7 +685,7 @@ m'avesser spinto a ricercar periglio</l>
             </lg>
             <stage>(<emph>Polifonte parte</emph>)</stage>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Adrasto, usa pietade</l>
@@ -685,13 +710,13 @@ m'avesser spinto a ricercar periglio</l>
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>EGISTO <emph>e</emph> ADRASTO.</stage>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="I">Dimmi, ti priego, chi è colei?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l part="F">Reina</l>
@@ -699,7 +724,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">fra poco.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">I sommi dèi l'esaltin sempre</l>
@@ -720,7 +745,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">ch'or fa struggere in pianto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l part="F">In tuo vantaggio</l>
@@ -740,7 +765,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">fu l'ucciso da te.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">Tu pur se' fisso</l>
@@ -750,7 +775,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>Credilo e sappi ch'io mentir non soglio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l>Veggo più tosto che mentir non sai:</l>
@@ -758,14 +783,14 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">in fortuna servil si giace?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">Il dissi</l>
               <l part="I">e 'l dico.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l part="F">Or dunque in tuo paese i servi</l>
@@ -774,7 +799,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>ad un dito regal non sconverrebbe.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l>A ciò non so che dir, né del suo prezzo</l>
@@ -791,7 +816,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">m'incenerisca.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l part="F">Un'arme è il giuramento</l>
@@ -804,7 +829,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">altrui no 'l faccia mai.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">Tanto prometto,</l>
@@ -814,7 +839,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">di quella gemma un don.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l part="F">Leggiadro dono</l>
@@ -829,7 +854,7 @@ m'avesser spinto a ricercar periglio</l>
         <div type="scene">
           <head>SCENA PRIMA</head>
           <stage>EURISO <emph>e</emph> ISMENE.</stage>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>No, Euriso, di veder Merope il tempo</l>
@@ -840,7 +865,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">sciagura il cor le opprima.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="F">Io già pur ora</l>
@@ -849,7 +874,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>nozze, e per accertarmi a lei correa.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>Questo a lei sembra atroce mal; ma questo</l>
@@ -857,7 +882,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>ch'altro maggior l'alma le ingombra e preme.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l>Che avvenne mai? Forse del figlio, ch'ella</l>
@@ -866,7 +891,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">novella infausta è giunta?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l part="F">Ah! tu 'l pensasti,</l>
@@ -887,7 +912,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">dieci volte chiedea.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="F">Non ti dar pena</l>
@@ -900,7 +925,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">abbiasi di Cresfonte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l part="F">È giunto Arbante,</l>
@@ -910,14 +935,14 @@ m'avesser spinto a ricercar periglio</l>
               <l>ne cerca invan, né sa di lui novella.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l>O speme tronca, o regno afflitto, o estinto</l>
               <l part="I">sangue de' nostri re!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l part="F">Ma tu mi sembri</l>
@@ -926,7 +951,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">che la sua morte ei rechi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="F">Sì, ma credi</l>
@@ -935,7 +960,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>gli avrà teso l'aguato e l'avrà colto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>Nulla di questo: afferma Polidoro</l>
@@ -951,7 +976,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>ei stesso in traccia, investigando l'orme.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l>Oh! questo è un male assai minore, e forse</l>
@@ -962,7 +987,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">la madre afflitta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l part="F">Oh sì, ti so dir io</l>
@@ -982,7 +1007,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">parmi che il senno suo vacilli.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="F">O figlia,</l>
@@ -992,7 +1017,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>Quando tu 'l proverai, vedrai s'io mento.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>Per me non proverollo al certo, ch'io</l>
@@ -1000,26 +1025,26 @@ m'avesser spinto a ricercar periglio</l>
               <l>è 'l girsi a procacciar sì gran dolore.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l>Questo è un dolor che con piacer s'acquista.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>Credimi pur che in tal pensier son fissa.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l>Ma bramata e richiesta il pensi in vano,</l>
               <l>che 'l tuo sembiante al tuo pensier fa guerra.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l part="I">Ecco Merope.</l>
@@ -1029,20 +1054,20 @@ m'avesser spinto a ricercar periglio</l>
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>MEROPE <emph>e detti</emph></stage>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">O Euriso, nel vederti</l>
               <l>ripiglia il lagrimar l'usata via.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="I">Pur or l'avviso udii.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Questo è ben altro</l>
@@ -1054,7 +1079,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>sul tiranno crudel la sua vendetta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l>Ma perdona, o reina: e chi distrusse</l>
@@ -1065,32 +1090,32 @@ m'avesser spinto a ricercar periglio</l>
               <l>Tu omai nel pianto la ragion sommergi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Ah! tu non sai da qual timor sia vinta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="I">Dillo, reina.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Già due giorni, al ponte</l>
               <l>che le due strade unisce, un uom fu ucciso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l>Il so, ché Adrasto l'omicida ha colto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Or quell'ucciso io temo — e piaccia al cielo</l>
@@ -1098,7 +1123,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">non sia stato Cresfonte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="F">O eterni numi!</l>
@@ -1106,7 +1131,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">i motivi d'affanno!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Troppo forti</l>
@@ -1123,13 +1148,13 @@ m'avesser spinto a ricercar periglio</l>
               <l>qua sen veniva per tentar sua sorte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l>Piccioli indizi per sì gran sospetto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Io penso ancor ch'Adrasto, del tiranno</l>
@@ -1140,14 +1165,14 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">né alcuno il vegga?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="F">Deh! quanto ingegnosa</l>
               <l part="I">tu sei per tormentarti!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Ah! ch'io ne' miei</l>
@@ -1159,7 +1184,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">ciò che richiesi in suo favore?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l part="F">In fatti</l>
@@ -1168,7 +1193,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>che diverso è pur troppo il suo costume.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l>Ma gioverebbe in questo caso a lui</l>
@@ -1176,21 +1201,21 @@ m'avesser spinto a ricercar periglio</l>
               <l>per troncare a chi l'odia ogni speranza.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Non già, ché troppo il popol questa nuova</l>
               <l>atrocità commoverebbe a sdegno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l>Ma come vuoi ch'egli abbia or di repente</l>
               <l part="I">scoperto il figlio tuo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Chi de' tiranni</l>
@@ -1199,7 +1224,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">e dipoi s'è scoperto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="F">Or io di questo</l>
@@ -1212,7 +1237,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">quanto basti a chiarirci.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Ottimo in vero</l>
@@ -1220,7 +1245,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>ma fallo tosto, non frappor dimora.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l>Non dubitar, ma in tanto ne' tuoi danni</l>
@@ -1228,7 +1253,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>e non crearti con la mente i mali.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>O caro Euriso, i' veggio ben che questo</l>
@@ -1253,21 +1278,21 @@ m'avesser spinto a ricercar periglio</l>
               <l>parmi che tutto soffrirei con pace.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>Regina, odi romor; qua Polifonte</l>
               <l part="I">sen viene.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Io mi sottraggo; Euriso, a core</l>
               <l part="I">ti sia cercar Adrasto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="F">Egli senz'altro</l>
@@ -1279,7 +1304,7 @@ m'avesser spinto a ricercar periglio</l>
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>POLIFONTE <emph>e</emph> ADRASTO.</stage>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>Or dimmi: pârti che deponga omai</l>
@@ -1287,7 +1312,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>città superba e 'l procelloso volgo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l>La turba vil, che peggiorar non puote,</l>
@@ -1295,7 +1320,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>e 'l re che più non ha, stima il migliore.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>Troppo è vero; qualor le vie trascorro</l>
@@ -1303,7 +1328,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>e leggo il tradimento in ogni fronte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l>Affretta, o re, queste tue nozze; affretta</l>
@@ -1311,31 +1336,31 @@ m'avesser spinto a ricercar periglio</l>
               <l>di giustizia e di pace il popol pazzo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>Meglio sarìa far di costoro scempio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l>Tu stesso a te torresti allora il regno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>In voto regno almen sarei sicuro.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l>Ma ciò bramar, non già sperar ti lice.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>E credi tu che sia per poter tanto</l>
@@ -1343,7 +1368,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>veder del regio onor Merope cinta?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l>Sol l'incerto romor che di ciò corre</l>
@@ -1352,25 +1377,25 @@ m'avesser spinto a ricercar periglio</l>
               <l>risvegliar di Cresfonte in te i costumi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>Sciocco pensier. Ma se costei ricusa?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l>La donna, come sai, ricusa e brama.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>Mal da l'uso comun questa misuri.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l>Di raddolcir la disdegnosa mente</l>
@@ -1389,13 +1414,13 @@ m'avesser spinto a ricercar periglio</l>
               <l>qual fin che ha vita, aver tu non puoi pace.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>Questa è la spina che nel cor sta fissa.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l>Ciò potrebbe avvenir; ma se persiste</l>
@@ -1410,7 +1435,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>de la famiglia a lor cotanto cara.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>Adrasto, vaglia il ver, tu ben ragioni.</l>
@@ -1425,7 +1450,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>spargi con arte e in mio favor l'adorna.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l>Saggiamente risolvi; ad ubbidirti</l>
@@ -1436,13 +1461,13 @@ m'avesser spinto a ricercar periglio</l>
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>ISMENE <emph>e</emph> POLIFONTE.</stage>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l part="M">Che m'imponi o re?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l part="F">Dirai</l>
@@ -1458,7 +1483,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>dee far grata, qual sia, la man che il porge.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>Come, signor? Il fermo tuo volere</l>
@@ -1466,7 +1491,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">che a così strano cangiamento...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l part="F">E voglio</l>
@@ -1485,7 +1510,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>volto e le membra circondar di pompa.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>Sappi, o re, ch'ella da alcun tempo, in quelle</l>
@@ -1495,7 +1520,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>donare è forza a rinfrancar suoi spirti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>Il comando intendesti; or tuo dovere</l>
@@ -1506,7 +1531,7 @@ m'avesser spinto a ricercar periglio</l>
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>ISMENE, <emph>poi</emph> MEROPE.</stage>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>Sventurata reina! A tanti affanni</l>
@@ -1516,19 +1541,19 @@ m'avesser spinto a ricercar periglio</l>
               <l>con Polifonte. O misero destino!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Da te che volle Polifonte, Ismene?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>Oimé, sposa ti vuole al sol novello.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Di Cresfonte il pensier tanto mi strinse</l>
@@ -1539,7 +1564,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">contezza aver.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l part="F">Aggiunse che quel reo,</l>
@@ -1547,7 +1572,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">ei da morte assicura.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Or vedi, Ismene,</l>
@@ -1556,7 +1581,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>un lampo di desir che in me tralusse?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>Ecco Euriso che torna e con sereno</l>
@@ -1568,7 +1593,7 @@ m'avesser spinto a ricercar periglio</l>
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>EURISO <emph>e detti</emph>.</stage>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l>Lodato il ciel, regina; io questa volta</l>
@@ -1576,14 +1601,14 @@ m'avesser spinto a ricercar periglio</l>
               <l>trar ti potessi in questo modo un giorno!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Tu mi rallegri, Euriso; e che mi rechi</l>
               <l part="I">di così certo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="F">Io con Adrasto appena</l>
@@ -1592,7 +1617,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">il tuo figlio non fu.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Grazie agli dèi,</l>
@@ -1601,7 +1626,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>aver potesti tu sì chiare pruove?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l>Io ten dirò una sola: il tuo Cresfonte,</l>
@@ -1610,13 +1635,13 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">che vada errando.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="M">È ver purtroppo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="F">Or sappi</l>
@@ -1624,7 +1649,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">e ricchi arredi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Se quest'è, Cresfonte</l>
@@ -1633,7 +1658,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">sono?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="F">Io di esse questa sola gemma</l>
@@ -1642,7 +1667,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">se un tesoro non vale.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">O quanto, Euriso,</l>
@@ -1651,32 +1676,32 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">punto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l part="M">Che sarà mai?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="F">Pensar nol posso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Ah ch'io non erro! È dessa. Questa gemma</l>
               <l>avea dunque colui che fu trafitto?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="I">Aveala; or che ti turba?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Avete vinto,</l>
@@ -1684,19 +1709,19 @@ m'avesser spinto a ricercar periglio</l>
               <l>vibrato hai pur l'ultimo colpo; o dèi!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="I">Io son confuso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l part="F">Il cor palpita e trema.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Questo è l'anel che col bambino io diedi</l>
@@ -1705,26 +1730,26 @@ m'avesser spinto a ricercar periglio</l>
               <l>etade; egli vi giunse, oimé, ma in vano.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="I">Deh che mai sento!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l part="M">O maraviglia!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Io madre</l>
               <l>già più non sono; ogni speranza è a terra.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>Deh che forse tu sbagli! E come vuoi</l>
@@ -1733,7 +1758,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>non si pôn dar due somiglianti gemme?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Che somigliar, che sbagli? Un lustro intero</l>
@@ -1745,7 +1770,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">spesso improntare il re solea.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="F">Ma forse</l>
@@ -1753,32 +1778,32 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">involata gli fu.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Non già, ché Arbante</l>
               <l>custodita appo lui sempre la vide.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="I">È forza di destino!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l part="F">Il cor gliel disse.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l>Presentimento hanno le madri ignoto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Or che più bado? E in questa vita amara</l>
@@ -1799,7 +1824,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>estinti tutti, ove scoccar non resta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l>Il funesto, impensato, orribil caso</l>
@@ -1824,7 +1849,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>e sai che 'l comandâr gli stessi dèi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>O Euriso, non avrian già mai gli dèi</l>
@@ -1854,7 +1879,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>per cui son tutti dichiarati i dèi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l>Sì stretto ho 'l cor che in vece di parole</l>
@@ -1868,7 +1893,7 @@ m'avesser spinto a ricercar periglio</l>
         <div type="scene">
           <head>SCENA PRIMA</head>
           <stage>POLIFONTE <emph>e</emph> ADRASTO.</stage>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>Con sì gran fretta io ti richiesi, Adrasto,</l>
@@ -1880,7 +1905,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">incomincio a regnar.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l part="F">Veduto ho sempre</l>
@@ -1888,7 +1913,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">E chi recò sì gran novella?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l part="F">Un servo</l>
@@ -1902,14 +1927,14 @@ m'avesser spinto a ricercar periglio</l>
               <l>di fabricarsi una maggior sventura.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l>E tu a lei presti fede? E perché mai</l>
               <l>chi mentito ha vent'anni or dirà il vero?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>Tu sospetti a ragion; ma io no 'l credo</l>
@@ -1927,13 +1952,13 @@ m'avesser spinto a ricercar periglio</l>
               <l>e parte e riede e di querele assorda.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l part="I">Ma come mai ciò rilevò?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l part="F">Ben chiaro</l>
@@ -1941,7 +1966,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">che a dubitar loco non resta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l part="F">Or dunque</l>
@@ -1952,7 +1977,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">di risparmiare a te il delitto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l part="F">Ho imposto</l>
@@ -1969,7 +1994,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">femmina non perdona.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l part="F">Anzi ora è il tempo</l>
@@ -1990,7 +2015,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>come per publicar ciò che ti giova.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>Tutto si faccia, e poiché vuol Messene</l>
@@ -2018,7 +2043,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>Anche da sé ferma i domìni il tempo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l>Certo negar non si potrà che nato</l>
@@ -2030,7 +2055,7 @@ m'avesser spinto a ricercar periglio</l>
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>EGISTO <emph>e detti</emph>.</stage>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l>Eccelso re che i miseri difendi</l>
@@ -2039,7 +2064,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>letizia e pace e ogni desir t'adempia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>Il tuo delitto — se pur dee delitto</l>
@@ -2048,7 +2073,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>grazia seppe acquistar nel mio pensiero.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l>Qual si fosse il vigor che in quell'incontro</l>
@@ -2056,19 +2081,19 @@ m'avesser spinto a ricercar periglio</l>
               <l>sarò pronto ad usarlo in tua difesa.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l part="I">Qual è il tuo nome?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">Egisto è il nome mio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>Or io vorrei che di colui che oppresso</l>
@@ -2076,7 +2101,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">più precisa contezza.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">Io già ne dissi</l>
@@ -2084,7 +2109,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">nulla aggiunger potrei.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l part="F">E pur si trova</l>
@@ -2099,7 +2124,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>ciò che togliesti tu, ciò che rimase.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l>Signore, i' veggio Ismene, indizio certo</l>
@@ -2112,7 +2137,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">non le si desti in cor.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l part="F">Ben pensi, Adrasto,</l>
@@ -2123,13 +2148,13 @@ m'avesser spinto a ricercar periglio</l>
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>MEROPE, EGISTO <emph>e</emph> ISMENE.</stage>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l part="I">Egli è qui solo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Iniquo, orribil ceffo!</l>
@@ -2137,7 +2162,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">non ci frammetta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">O regal donna, o esempio</l>
@@ -2171,27 +2196,27 @@ m'avesser spinto a ricercar periglio</l>
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>EURISO, ISMENE <emph>e detti</emph>.</stage>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="I">Eccomi a' cenni tuoi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Tosto di lui</l>
               <l part="I">t'assicura.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="F">Son pronto; or più non fugge,</l>
               <l part="I">se questo braccio non ci lascia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">Come!</l>
@@ -2203,27 +2228,27 @@ m'avesser spinto a ricercar periglio</l>
               <l>Ch'io t'offra inerme il petto? eccoti il petto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>Chi crederia che sotto un tanto umìle</l>
               <l>sembiante tanta iniquità s'asconda?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Spiega la fascia, e ad un di questi marmi</l>
               <l>l'annoda in guisa che fuggir non possa.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="I">O ciel, che stravaganza!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="F">Or qua spediamci,</l>
@@ -2231,7 +2256,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">di repugnare o di far forza.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">E credi</l>
@@ -2242,13 +2267,13 @@ m'avesser spinto a ricercar periglio</l>
               <l>non ho temuto d'affrontare io solo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l>Ciancia a tuo senno, pur ch'io qui ti leghi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l>Mira, colei mi lega, ella mi toglie</l>
@@ -2258,14 +2283,14 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">t'avrei percosso al suol.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Non tacerai</l>
               <l>temerario? Affrettar cerchi il tuo fato?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l>Regina, io cedo, io t'ubbidisco, io stesso</l>
@@ -2276,19 +2301,19 @@ m'avesser spinto a ricercar periglio</l>
               <l>queste misere membra e tu le annoda.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>Or non cred'io che dar potesse un crollo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="I">Or va, rècami un'asta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">Un'asta! O sorte!</l>
@@ -2297,32 +2322,32 @@ m'avesser spinto a ricercar periglio</l>
               <l>a qual fine son io qui avvinto e stretto?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>China quegli occhi, traditore, a terra.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l part="I">Eccoti il ferro.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="F">Io 'l prendo e, se t'è in grado,</l>
               <l part="I">gliel presento a la gola.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">A me quel ferro.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l>Così dunque morir degg'io, qual fiera</l>
@@ -2330,7 +2355,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">saperne la cagion?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Non la sai eh?</l>
@@ -2342,19 +2367,19 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">riconoscestil tu?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">Che mai favelli?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Non t'infinger, ladron, ché tutto è in vano.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l>Regina, in qualche error tua mente è corsa;</l>
@@ -2362,7 +2387,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">né pur intendo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Empio assassin, tuo scempio</l>
@@ -2370,21 +2395,21 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">non mi rispondi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">O giusti numi, e come</l>
               <l>risponder posso a ciò che non intendo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Che non intendo? Polifonte adunque</l>
               <l part="I">tu non conosci?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">Oggi il conobbi, oggi</l>
@@ -2393,20 +2418,20 @@ m'avesser spinto a ricercar periglio</l>
               <l>Giove da le tue mani or non mi salvi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>Hanno il lor Giove i malandrini ancora?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l>Ma quel sangue innocente e chi t'indusse</l>
               <l part="I">a sparger dunque?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">Di colui che uccisi</l>
@@ -2416,28 +2441,28 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">questi fûr che m'indussero.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">O fortuna,</l>
               <l>così dunque perir dovea Cresfonte!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l>Ma com'esser può mai che tanto importi</l>
               <l part="I">d'un vil ladron la morte?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Audacia estrema!</l>
               <l>Tu vile, tu ladron, tu scelerato!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l>Eterni dèi, ch'io venerai mai sempre,</l>
@@ -2445,7 +2470,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>con occhi di pietà la mia innocenza.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Dimmi: pria di spirar, quell'infelice</l>
@@ -2454,7 +2479,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">Merope?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">o non udii da lui parola.</l>
@@ -2462,7 +2487,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">che mai s'asconde qui?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="F">Donna, tu perdi</l>
@@ -2470,32 +2495,32 @@ m'avesser spinto a ricercar periglio</l>
               <l>di leggèr può arrivar chi ti frastorni.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="I">Mora dunque il crudele.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">O cara madre,</l>
               <l part="I">se in questo punto mi vedessi!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Hai madre?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="I">Che gran dolor fia 'l tuo!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Barbaro, madre</l>
@@ -2504,7 +2529,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">Morrai, fiero ladrone.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">Ah padre mio,</l>
@@ -2512,20 +2537,20 @@ m'avesser spinto a ricercar periglio</l>
               <l>dal por già mai nella Messenia il piede.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="I">Nella Messenia? E perché mai?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">Bisogna</l>
               <l part="I">credere ai vecchi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Un vecchio è il padre tuo?</l>
@@ -2541,13 +2566,13 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">che nome ha...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l part="F">Ecco servi, ecco il tiranno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>O stelle avverse! Fuggi, Euriso, fuggi</l>
@@ -2558,7 +2583,7 @@ m'avesser spinto a ricercar periglio</l>
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>POLIFONTE, MEROPE <emph>ed</emph>EGISTO.</stage>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">Accorri</l>
@@ -2570,20 +2595,20 @@ m'avesser spinto a ricercar periglio</l>
               <l>poiché appo te seppe acquistare e lode.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Egli l'approva e loda? E mostrò prima</l>
               <l>d'infuriarne tanto. Ah fui delusa!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l part="I">Colui si sciolga.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">O giusto re, la vita</l>
@@ -2593,7 +2618,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>dal furor di costei mi faccia schermo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>Vanne e nulla temer; mortal delitto</l>
@@ -2603,14 +2628,14 @@ m'avesser spinto a ricercar periglio</l>
               <l>le imprese altrui più celebrate avanza.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Che dubitar? Misera, ed io da un nulla</l>
               <l part="I">trattener mi lasciai.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">Or de l'avversa</l>
@@ -2623,7 +2648,7 @@ m'avesser spinto a ricercar periglio</l>
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>POLIFONTE <emph>e</emph> MEROPE.</stage>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>Merope, omai troppo t'arroghi. Adunque,</l>
@@ -2637,7 +2662,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>in mia offesa sì tosto armi i miei doni.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>A te che regni e che prestar pur déi</l>
@@ -2646,7 +2671,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>sovra un empio ladron scenda la pena.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>Quanto instabil tu sei! Non se' tu quella</l>
@@ -2657,26 +2682,26 @@ m'avesser spinto a ricercar periglio</l>
               <l>se vedi ch'io l'assolva, e tu 'l condanni.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Io non sapeva allor quant'egli è reo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>Ed io seppi ora sol quant'è innocente.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Pria mi donasti la sua vita, adesso</l>
               <l part="I">donami la sua morte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l part="F">Iniquo fôra</l>
@@ -2689,7 +2714,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">al disagio non resse.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Ah! scelerato,</l>
@@ -2740,7 +2765,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>qual vil bifolco da torrente oppresso...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>Non cetre o lire mi fûr mai sì grate</l>
@@ -2755,7 +2780,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>che del spento rival fan certa fede.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Ma perché dunque, o dèi, salvarlo allora?</l>
@@ -2784,7 +2809,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>tienti il tuo regno e 'l figlio mio mi rendi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>Il pianto femminil non ha misura.</l>
@@ -2793,7 +2818,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>tutti i tuoi mali copriran d'oblio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Nel sempiterno oblio saprò ben tosto</l>
@@ -2809,7 +2834,7 @@ m'avesser spinto a ricercar periglio</l>
         <div type="scene">
           <head>SCENA PRIMA</head>
           <stage>ADRASTO <emph>e</emph> ISMENE.</stage>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l>In somma tutto si restringe in questo</l>
@@ -2824,33 +2849,33 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">senz'altro rechi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l part="F">O ferità inaudita!</l>
               <l>non più intesi di barbarie esempi!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l>Non si dolga del mal chi 'l ben ricusa.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>Ahi questo è un ben che tutti i mali avanza.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l>il vano immaginar fa inganno ai sensi</l>
               <l>e d'ogn'altro gioir sa far dolore.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>Gioir ti sembra il soffrir nozze in tempo</l>
@@ -2858,80 +2883,80 @@ m'avesser spinto a ricercar periglio</l>
               <l>non le desta nel seno altro che pianto?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l>Di lei così han disposto il cielo e 'l fato.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>Il ciel l'ha abbandonata e 'l fato oppressa.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l>Quanto passò, taccia una volta e oblii.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>Può ben tacere, ma obliar non puote;</l>
               <l>ché 'l silenzio è in sua man, ma non l'oblio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l>Di sé si dolga chi al peggior s'appiglia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>Nulla è peggio per lei del re crudele.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l>Crudel chi le offre onor, gioia e diletto?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>Diletto amaro a chi col cor ripugna.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l>Perché ripugna a ciò ch'ogn'altra brama?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>Ella brama più tosto e strazio e morte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l>Sì, se non fosse morte altro che un nome.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>La virtù di costei tu non conosci.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l>Dunque se di virtù cotanto abbonda,</l>
@@ -2947,7 +2972,7 @@ m'avesser spinto a ricercar periglio</l>
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>ISMENE, <emph>poi</emph>EGISTO.</stage>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>Deh qual fine avrà mai l'amaro giuoco,</l>
@@ -2959,7 +2984,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>e gli occhi e 'l core. O lagrimevol sorte!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l>Deh, se t'arrida il ciel, leggiadra figlia,</l>
@@ -2972,14 +2997,14 @@ m'avesser spinto a ricercar periglio</l>
               <l>penso che prenda, m'assicura appena.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>Sgombra il timor, vano timor che troppo</l>
               <l>fa torto a lui che regna e a te fa scudo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l>Ciò mi rincora, sì; ma per mia pace</l>
@@ -2987,7 +3012,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>di qual error non so, ma pur perdono.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>Uopo di ciò non hai, perché il furore,</l>
@@ -2995,7 +3020,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">per sé si dileguò.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">Grazie agli dèi.</l>
@@ -3006,7 +3031,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">ladron selvaggio in van si cruccia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l part="F">Il tutto</l>
@@ -3015,21 +3040,21 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">cura or mi chiama altrove.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">Io volentieri</l>
               <l part="I">t'attendo quanto vuoi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l part="F">Ma non partire</l>
               <l>e non far poi ch'io qua ritorni indarno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l>Mia fé do in pegno, e dove gir dovrei?</l>
@@ -3042,7 +3067,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">sarò difeso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l part="F">Io dunque a te fra poco</l>
@@ -3052,7 +3077,7 @@ m'avesser spinto a ricercar periglio</l>
         </div>
         <div type="scene">
           <head>SCENA TERZA</head>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">O di perigli piene,</l>
@@ -3088,7 +3113,7 @@ m'avesser spinto a ricercar periglio</l>
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>EURISO <emph>e</emph> POLIDORO.</stage>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l>Eccoti, o peregrin, qual tu chiedesti,</l>
@@ -3099,7 +3124,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>cader ti veggo in su le guance il pianto?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l>O figlio, se sapessi quante dolci</l>
@@ -3116,7 +3141,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">grazie ti rendo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="F">Assai più volentieri</l>
@@ -3126,7 +3151,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">ristorar si potessero.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">Io ti priego</l>
@@ -3134,13 +3159,13 @@ m'avesser spinto a ricercar periglio</l>
               <l>di chi mi fu così cortese il nome?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="I">Euriso di Nicandro.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">Di Nicandro</l>
@@ -3148,25 +3173,25 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">era al buon re Cresfonte?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="F">Per l'appunto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="I">Viv'egli ancora?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="F">Ei chiuse il giorno estremo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l>O quanto me ne duole! Egli era umano</l>
@@ -3183,7 +3208,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">che noi diam loco!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="F">La contezza, amico,</l>
@@ -3193,7 +3218,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>per mio piacere a tuo piacer ti vaglia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l>Altro per or da te non bramo, Euriso,</l>
@@ -3201,7 +3226,7 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">con chi che sia di me ragioni.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="F">In questo</l>
@@ -3212,7 +3237,7 @@ m'avesser spinto a ricercar periglio</l>
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>POLIDORO <emph>e</emph> EGISTO.</stage>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l>Ben mia ventura fu l'essermi in questo</l>
@@ -3241,7 +3266,7 @@ m'avesser spinto a ricercar periglio</l>
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>ISMENE, <emph>poi</emph> MEROPE.</stage>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l part="F">Or se ti piace,</l>
@@ -3256,13 +3281,13 @@ m'avesser spinto a ricercar periglio</l>
               <l part="I">profondamente.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="M">Ed in qual parte?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l part="F">Mira,</l>
@@ -3270,7 +3295,7 @@ m'avesser spinto a ricercar periglio</l>
               <l>il ti poteva presentar fortuna.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>È vero, i giusti dèi l'han tratto al varco.</l>
@@ -3284,38 +3309,38 @@ m'avesser spinto a ricercar periglio</l>
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>POLIDORO <emph>e detti</emph>.</stage>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l>Ferma, reina; oimé ferma, ti dico.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="I">Qual temerario!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">O dèi, o dèi, soccorso!</l>
               <l part="I">Pur ancor questa furia!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Sì, sì, fuggi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="I">T'arresta oimé, t'accheta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Fuggi pure
@@ -3324,13 +3349,13 @@ non sempre fuggirai, non se credessi
 di trucidarti a Polifonte in braccio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="I">O dèi, ché non m'ascolti?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Ma tu, pazzo,
@@ -3338,19 +3363,19 @@ tu pagherai... la tua canizie il colpo
 m'arresta. E qual delirio? e quale ardire?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l>Dunque più non conosci Polidoro?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="I">Che?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">Sì, t'accheta, ecco il tuo servo antico;
@@ -3358,26 +3383,26 @@ quegli son io, e quei che uccider vuoi</l>
               <l part="I">quegli è Cresfonte, è 'l figlio tuo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Che? vive?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l>Se vive! Nol vedesti? Non vivrebbe</l>
               <l part="I">già più, s'io qui non era.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="M">Oimé!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">Sostienla,</l>
@@ -3392,7 +3417,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l part="I">spettacolo!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l part="F">Son io tanto confusa</l>
@@ -3401,19 +3426,19 @@ quegli son io, e quei che uccider vuoi</l>
               <l>torna, fa core; ora è di viver tempo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l>Vedi che già si muove, or si riscuote.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Dove, dove son io? sogno? vaneggio?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>Né sogni, né vaneggi. Eccoti innanzi</l>
@@ -3422,14 +3447,14 @@ quegli son io, e quei che uccider vuoi</l>
               <l>leggiadro, forte e, posso dir, presente.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="I">Mi deludete voi? Se' veramente</l>
               <l>tu Polidoro?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">Guarda pur, rimira;</l>
@@ -3439,28 +3464,28 @@ quegli son io, e quei che uccider vuoi</l>
               <l>a cercar di Cresfonte e perché insieme...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Sì che se' desso; sì ch'io ti ravviso,</l>
               <l part="I">benché invecchiato di molto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">Ma il tempo</l>
               <l part="I">non perdona.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">E m'accerti ch'è mio figlio</l>
               <l part="I">quel giovinetto? E non t'inganni?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">Come</l>
@@ -3471,7 +3496,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l part="I">t'accecava la mente?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">O caro servo,</l>
@@ -3483,14 +3508,14 @@ quegli son io, e quei che uccider vuoi</l>
               <l part="I">ch'ei rapito l'avesse.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">Ei da me l'ebbe,</l>
               <l part="I">benché con ordin d'occultarlo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">O stelle,</l>
@@ -3500,7 +3525,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l part="I">donna del mondo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">Tu di tenerezza</l>
@@ -3509,7 +3534,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l>voi siete e quanto il nostro core è frale!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>O cielo, ed io strinsi due volte il ferro</l>
@@ -3519,14 +3544,14 @@ quegli son io, e quei che uccider vuoi</l>
               <l>mi raccapriccio e mi si strugge il core.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>Con così strani avvenimenti uom forse</l>
               <l>non vide mai favoleggiar le scene.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Lode ai pietosi, eterni dèi che tanta</l>
@@ -3540,31 +3565,31 @@ quegli son io, e quei che uccider vuoi</l>
               <l part="I">in stringerlo, in baciarlo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">Ove ten corri?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="I">Perché m'arresti?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="M">Sta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="M">Lascia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">Vaneggi.</l>
@@ -3598,14 +3623,14 @@ quegli son io, e quei che uccider vuoi</l>
               <l>nulla ha mai fatto chi non compie l'opra.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>O fido servo mio, tu se' pur sempre</l>
               <l part="I">quel saggio Polidor.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">on tutti i mali</l>
@@ -3615,25 +3640,25 @@ quegli son io, e quei che uccider vuoi</l>
               <l>e se vacilla il piè, fermo è 'l consiglio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Or dimmi: il mio Cresfonte è vigoroso?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="I">Quanto altri mai.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="M">Ha egli cor?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">Se ha core!</l>
@@ -3644,14 +3669,14 @@ quegli son io, e quei che uccider vuoi</l>
               <l part="I">orma in lui di timor.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Ma sarà forse</l>
               <l part="I">indocile e feroce.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">Nulla meno.</l>
@@ -3666,7 +3691,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l part="I">a le lagrime il corso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">O me beata!</l>
@@ -3689,7 +3714,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l>darti già mai mercé che i merti agguagli?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l>Il mio stesso servir fu premio, ed ora</l>
@@ -3703,28 +3728,28 @@ quegli son io, e quei che uccider vuoi</l>
               <l part="I">darei per giovinezza.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Giovinezza</l>
               <l part="I">per certo è un sommo ben.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">Ma questo bene</l>
               <l>chi l'ha no 'l tien, che, mentre l'ha, lo perde.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Or vien, ché sarai lasso e di riposo</l>
               <l part="I">sommo bisogno avrai.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">M'è intervenuto</l>
@@ -3738,7 +3763,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l part="I">qui lasciar non si vuol.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Benché in balia</l>
@@ -3750,7 +3775,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l part="I">in avvenir.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">Facciam, facciam noi pure</l>
@@ -3766,7 +3791,7 @@ quegli son io, e quei che uccider vuoi</l>
         <div type="scene">
           <head>SCENA PRIMA </head>
           <stage>POLIDORO<emph>e</emph> EGISTO.</stage>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l>Padre, non più, non più; ché se creduto</l>
@@ -3779,13 +3804,13 @@ quegli son io, e quei che uccider vuoi</l>
               <l>ch'ebbi a bastanza nell'error la pena.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l>Ma così va chi a senno suo si regge.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l>Tu mai più declinar da' tuoi voleri</l>
@@ -3795,39 +3820,39 @@ quegli son io, e quei che uccider vuoi</l>
               <l>partirmi e tornar teco al suol natio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l>S'ami il tuo suol natio, partir non déi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l>Vuoi che lasci in dolor la madre antica?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="I">La madre tua qui ti desia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">Qui? forse</l>
               <l part="I">perch'ora ho il padre appresso?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">Anzi la madre</l>
               <l part="I">hai presso e il padre troppo lungi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">Come?</l>
@@ -3835,56 +3860,56 @@ quegli son io, e quei che uccider vuoi</l>
               <l>sempre sarò; vuol Merope il mio sangue.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l>Anzi ella il sangue suo per te darebbe.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l>Se già due volte trucidar mi volle!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l>Odio pareva, ed era estremo amore.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l>Me n'accorgeva io ben, se il re non era.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l>Ma non t'accorgi ancor ch'ei vuolti estinto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l>Se dall'altrui furore ei mi difese!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l>Amor pareva, ed odio era mortale.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l>Padre, che parli? Quai viluppi e quali</l>
               <l part="I">nuovi enigmi son questi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">O figlio mio,</l>
@@ -3897,14 +3922,14 @@ quegli son io, e quei che uccider vuoi</l>
               <l part="I">scoprir ti deggio alfin.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">Tu mi sospendi</l>
               <l>l'animo, sì che il cor mi balza in petto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l>Sappi che tu non se' chi credi; sappi</l>
@@ -3912,14 +3937,14 @@ quegli son io, e quei che uccider vuoi</l>
               <l>né tu d'un servo, ma di re sei figlio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l>Padre, mi beffi tu? scherzi, o ti prendi</l>
               <l part="I">gioco?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">Non scherzo no, ché non è questa</l>
@@ -3930,14 +3955,14 @@ quegli son io, e quei che uccider vuoi</l>
               <l part="I">ebbe tre figli?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">Udillo, e come uccisi</l>
               <l part="I">fur pargoletti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">Non già tutti uccisi</l>
@@ -3945,13 +3970,13 @@ quegli son io, e quei che uccider vuoi</l>
               <l part="I">se' tu.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="M">Deh che mai narri!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">Il ver ti narro:</l>
@@ -3962,14 +3987,14 @@ quegli son io, e quei che uccider vuoi</l>
               <l>e a la vendetta ti serbassi e al regno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l>Son fuor di me per meraviglia e in forse</l>
               <l part="I">mi sto s'io creda o no.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">Creder mi déi,</l>
@@ -3980,7 +4005,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l>e l'omicida in te di te cercava.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l>Ora intendo, o gran Giove. Ed è pur vero</l>
@@ -3989,7 +4014,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l part="I">mio questo regno, io son l'erede.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">È vero,</l>
@@ -3997,7 +4022,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l part="I">Ma quanto e quanto...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">In queste vene adunque</l>
@@ -4014,7 +4039,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l>che spronava i pensier, né sapea dove.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l>E perciò appunto a te celar te stesso</l>
@@ -4023,7 +4048,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l part="I">sue varie frodi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">In questo suolo adunque</l>
@@ -4037,68 +4062,68 @@ quegli son io, e quei che uccider vuoi</l>
               <l>segua; del resto avranne cura il cielo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="I">Ferma.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="M">Che vuoi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="M">Dove ne vai?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">Mi lascia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l>O cieca gioventù! Dove ti guida</l>
               <l part="I">sconsigliato furor?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">Perché t'affanni?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="I">La morte...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="M">Altrui la porto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">A te l'affretti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="I">Lasciami al fin.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">Deh, figlio mio — ché figlio</l>
@@ -4111,7 +4136,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l>de la madre, del regno e di te stesso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l>Padre, ché padre ben mi fosti, sorgi;</l>
@@ -4120,7 +4145,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l>Ma non vuoi tu ch'omai m'armi a vendetta?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l>Sì, voglio; a questo fin tutto sinora</l>
@@ -4136,7 +4161,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l part="I">Non ci son più di quelle menti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">E credi</l>
@@ -4146,7 +4171,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l>non pugnasse per me l'antica fede?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l>Qual fede? O figlio, or non son più que' tempi.</l>
@@ -4156,13 +4181,13 @@ quegli son io, e quei che uccider vuoi</l>
               <l part="I">narrarlo: erasi...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">Taci, esce il tiranno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l>Fuggiam, ci occulteremo dietro quelle</l>
@@ -4173,14 +4198,14 @@ quegli son io, e quei che uccider vuoi</l>
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>POLIFONTE <emph>e</emph> ADRASTO.</stage>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l part="F">Tu m'affretti assai per tempo,</l>
               <l part="I">ben sollecito sei.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l part="F">Già tutto è in punto.</l>
@@ -4191,7 +4216,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l>turba è raccolta e già festeggia e applaude.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <lg>
               <l>Or Merope si chiami. Io di condurla</l>
@@ -4219,86 +4244,86 @@ quegli son io, e quei che uccider vuoi</l>
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>MEROPE, ISMENE <emph>e</emph> ADRASTO.</stage>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>O qual supplizio, Ismene, o qual tormento!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l part="I">Fa core al fin.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Mai non mi diero i dèi</l>
               <l>senza un ugual disastro una ventura.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>Vinci te stessa e ai lieti dì ti serba.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Cresfonte mio, per te soffrir m'è forza.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l>Reina, io pur t'attendo: or che più badi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Di malvagio signor servo peggiore.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l>Ad opra così lieta in mesto ammanto?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Del sommo interno affanno esso fa fede.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l>Offende quest'affanno il tuo consorte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Che dì'tu? Non per anco è mio consorte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l>O questo, o de' tuoi cari un fiero scempio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Pensamento maligno, empio, infernale!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <stage>(<emph>in disparte</emph>)</stage>
             <lg>
@@ -4306,7 +4331,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l>resti il gran colpo già a scoccar vicino.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Questo è il solo pensier che pur mi frena</l>
@@ -4316,7 +4341,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l>l'animo e si disdegna e inorridisce.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l>Se di strage novella or or non vuoi</l>
@@ -4324,13 +4349,13 @@ quegli son io, e quei che uccider vuoi</l>
               <l>condur per me si dee la sposa al tempio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="I">Di' più tosto la vittima.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <lg>
               <l part="F">E che? Forse</l>
@@ -4338,7 +4363,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l>regal donna esser vittima di stato?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Ma si vada: sul fatto i dèi fors'anco</l>
@@ -4350,14 +4375,14 @@ quegli son io, e quei che uccider vuoi</l>
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>EGISTO <emph>e</emph> POLIDORO.</stage>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">Quella è mia madre,</l>
               <l part="I">ch'or strascinata è là?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">Ben duro passo</l>
@@ -4368,14 +4393,14 @@ quegli son io, e quei che uccider vuoi</l>
               <l>han cangiato in antidoto il veleno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l>Io men vo' gire al tempio e la solenne</l>
               <l part="I">pompa veder.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">Vanne; curiosa brama</l>
@@ -4390,7 +4415,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l>l'occhio sopra di te cader non possa.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l>Vano è che tu di ciò pensier ti prenda.</l>
@@ -4400,7 +4425,7 @@ quegli son io, e quei che uccider vuoi</l>
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>POLIDORO <emph>e poi</emph> EURISO.</stage>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l>Ben ebbe avverse al nascer suo le stelle</l>
@@ -4415,7 +4440,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l>più atroci i casi, più le cure acerbe.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l>Ospite, ancor se' qui? Molto m'è caro</l>
@@ -4423,7 +4448,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l>in reggia scelerata, in suol crudele.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l>Amico, il mondo tutto è pien di guai;</l>
@@ -4435,7 +4460,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l>sperando il bene e sostenendo il male.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l>Ma perché tu, che forastier qui sei,</l>
@@ -4443,7 +4468,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l part="I">del ricco sagrificio?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">Oh! curioso</l>
@@ -4460,7 +4485,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l part="I">l'imeneo de' tuoi re.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="F">Deh, se sapessi</l>
@@ -4469,13 +4494,13 @@ quegli son io, e quei che uccider vuoi</l>
               <l>presente a sì funesto, orribil caso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="I">Qual caso avvenir può?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="F">S'hai già contezza</l>
@@ -4496,7 +4521,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l part="I">sventurata reina!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">Oh come il core</l>
@@ -4506,21 +4531,21 @@ quegli son io, e quei che uccider vuoi</l>
               <l part="I">d'una tanta reina!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="F">Ma non odi</l>
               <l part="I">dal vicin tempio alto romor?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">Ben parmi</l>
               <l part="I">d'udire alcuna cosa.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="F">Al certo è fatto</l>
@@ -4532,7 +4557,7 @@ quegli son io, e quei che uccider vuoi</l>
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>POLIDORO, <emph>poi</emph> ISMENE.</stage>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l>O me infelice! E che giovaron mai</l>
@@ -4540,7 +4565,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l part="I">che più far si potrà?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l part="F">Pietosi numi,</l>
@@ -4548,13 +4573,13 @@ quegli son io, e quei che uccider vuoi</l>
               <l part="I">aita.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">Oimé, figlia, ove vai? Deh ascolta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>Vecchio, che fai tu qui? Non sai tu nulla?</l>
@@ -4562,51 +4587,51 @@ quegli son io, e quei che uccider vuoi</l>
               <l part="I">vittima regia...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">O destino! In qual punto</l>
               <l part="I">mi traesti tu qua!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l part="F">Che hai? Tu dunque,</l>
               <l part="I">tu piangi Polifonte?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="F">Polifonte?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>Sì, Polifonte; entro il suo sangue ei giace.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="I">Ma chi l'uccise?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l part="F">Il figlio tuo l'uccise.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l>Colà, nel tempio? O smisurato ardire!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l>Taci ch'ei fece un colpo, onde il suo nome</l>
@@ -4685,7 +4710,7 @@ quegli son io, e quei che uccider vuoi</l>
           <head>SCENA SETTIMA</head>
           <stage>POLIDORO, <emph>poi</emph> MEROPE, EGISTO, EURISO</stage>
           <stage><emph>con séguito d'altri</emph>.</stage>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l>Senza del vostro alto, immortal consiglio</l>
@@ -4695,7 +4720,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l>Come pronto e feroce or io... Ma ecco...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Sì sì, o messeni, il giuro ancora: è questi,</l>
@@ -4728,13 +4753,13 @@ quegli son io, e quei che uccider vuoi</l>
               <l>mel manda innanzi, il vecchio che nodrillo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l part="I">Io, io...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Ma che? che testimon? che prove?</l>
@@ -4747,7 +4772,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l part="I">sia conduttor sì fatto eroe?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#euriso">
             <speaker>EURISO</speaker>
             <lg>
               <l part="F">Reina,</l>
@@ -4765,7 +4790,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l>avrà nel nostro petto argine e scudo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l>Timor si sgombri; ché se meco amici</l>
@@ -4776,34 +4801,34 @@ quegli son io, e quei che uccider vuoi</l>
         <div type="scene">
           <head>SCENA ULTIMA</head>
           <stage>ISMENE <emph>e detti</emph>.</stage>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l part="I">Che fai, regina? Che più badi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l part="F">Oimé,</l>
               <l part="I">che porti?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l part="F">Il gran cortil... non odi i gridi?</l>
               <l part="I">Corri e conduci il figlio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l part="F">Io, io v'accorro.</l>
               <l part="I">Resta, reina.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <lg>
               <l part="F">Il gran cortile è pieno</l>
@@ -4818,7 +4843,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l>credi, egli è forza lagrimar di gioia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>O lodato sia tu che tutto reggi</l>
@@ -4828,14 +4853,14 @@ quegli son io, e quei che uccider vuoi</l>
               <l>finché bolle nei cor sì bel desio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l>Credete, amici, che sì cara madre</l>
               <l>m'è assai più caro d'acquistar che il regno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#polidoro">
             <speaker>POLIDORO</speaker>
             <lg>
               <l>Giove, or quando ti piace, ai giorni miei</l>
@@ -4843,7 +4868,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l>veduta è già la meta; altro non chieggio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#egisto">
             <speaker>EGISTO</speaker>
             <lg>
               <l>Reina, a questo vecchio io render mai</l>
@@ -4851,7 +4876,7 @@ quegli son io, e quei che uccider vuoi</l>
               <l>che a tenerlo per padre io segua ognora.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#merope">
             <speaker>MEROPE</speaker>
             <lg>
               <l>Io più di te gli debbo, e assai mi piace</l>

--- a/tei/manzoni-adelchi.xml
+++ b/tei/manzoni-adelchi.xml
@@ -76,6 +76,121 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="vermondo">
+            <persName>Vermondo</persName>
+          </person>
+          <person xml:id="desiderio">
+            <persName>Desiderio</persName>
+          </person>
+          <person xml:id="adelchi">
+            <persName>Adelchi</persName>
+          </person>
+          <person xml:id="ermengarda">
+            <persName>Ermengarda</persName>
+          </person>
+          <person xml:id="anfrido">
+            <persName>Anfrido</persName>
+          </person>
+          <person xml:id="albino">
+            <persName>Albino</persName>
+          </person>
+          <person xml:id="fedeli">
+            <persName>Fedeli longobardi</persName>
+          </person>
+          <person xml:id="indolfo">
+            <persName>Indolfo</persName>
+          </person>
+          <person xml:id="farvaldo">
+            <persName>Farvaldo</persName>
+          </person>
+          <person xml:id="ervigo">
+            <persName>Ervigo</persName>
+          </person>
+          <person xml:id="ildechi">
+            <persName>Ildechi</persName>
+          </person>
+          <person xml:id="svarto">
+            <persName>Svarto</persName>
+          </person>
+          <personGrp xml:id="altri_duchi">
+            <name>Altri duchi</name>
+          </personGrp>
+          <person xml:id="duchi">
+            <persName>Duchi</persName>
+          </person>
+          <person xml:id="pietro">
+            <persName>Pietro</persName>
+          </person>
+          <person xml:id="carlo">
+            <persName>Carlo</persName>
+          </person>
+          <person xml:id="arvino">
+            <persName>Arvino</persName>
+          </person>
+          <person xml:id="martino">
+            <persName>Martino</persName>
+          </person>
+          <person xml:id="scudiere">
+            <persName>Scudiere</persName>
+          </person>
+          <person xml:id="altro_scudiere">
+            <persName>Altro scudiere</persName>
+          </person>
+          <person xml:id="baudo">
+            <persName>Baudo</persName>
+          </person>
+          <person xml:id="soldato">
+            <persName>Soldato</persName>
+          </person>
+          <person xml:id="altro_soldato">
+            <persName>Altro soldato</persName>
+          </person>
+          <personGrp xml:id="molti_soldati">
+            <name>Molti soldati</name>
+          </personGrp>
+          <person xml:id="rutlando">
+            <persName>Rutlando</persName>
+          </person>
+          <person xml:id="conte">
+            <persName>Conte</persName>
+          </person>
+          <person xml:id="altro_conte">
+            <persName>Altro conte</persName>
+          </person>
+          <person xml:id="franco">
+            <persName>Franco</persName>
+          </person>
+          <person xml:id="longobardi">
+            <persName>Longobardi</persName>
+          </person>
+          <person xml:id="giselberto">
+            <persName>Giselberto</persName>
+          </person>
+          <person xml:id="ansberga">
+            <persName>Ansberga</persName>
+          </person>
+          <person xml:id="prima_suora">
+            <persName>Prima suora</persName>
+          </person>
+          <person xml:id="seconda_suora">
+            <persName>Seconda suora</persName>
+          </person>
+          <person xml:id="donzella">
+            <persName>Donzella</persName>
+          </person>
+          <person xml:id="guntigi">
+            <persName>Guntigi</persName>
+          </person>
+          <person xml:id="amri">
+            <persName>Amri</persName>
+          </person>
+          <person xml:id="teudi">
+            <persName>Teudi</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -152,7 +267,7 @@
           <castItem type="role"><role>SOLDATI</role>,</castItem>
           <castItem type="role"><role>LONGOBARDI</role>:</castItem>
           <castItem type="role"><role>DONZELLE</role>,</castItem>
-          <castItem type="role"><role>SUORE</role> <roleDesc>NEL MONASTERO DI ANSBERGA.</roleDesc>
+          <castItem type="role"><role>SUORE</role><roleDesc>NEL MONASTERO DI ANSBERGA.</roleDesc>
             —
           </castItem>
           <castItem type="role"><role>CONTI FRANCHI</role>,</castItem>
@@ -171,7 +286,7 @@
             <emph>Palazzo reale in Pavia.</emph>
           </stage>
           <stage>DESIDERIO, ADELCHI, VERMONDO.</stage>
-          <sp>
+          <sp who="#vermondo">
             <speaker>VERMONDO</speaker>
             <lg>
               <l>O mio re Desiderio, e tu del regno</l>
@@ -198,7 +313,7 @@
               <l part="I">L'annunzio ad arrecar.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">L'ira del cielo</l>
@@ -218,7 +333,7 @@
               <l part="I">Quando oltraggiasti una innocente.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">O padre;</l>
@@ -232,7 +347,7 @@
               <l>Una voce d'amor che la conforti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l>Figlio, rimanti. E tu fedel Vermondo,</l>
@@ -256,7 +371,7 @@
         <div type="scene">
           <head>SCENA II </head>
           <stage>DESIDERIO, ADELCHI</stage>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Adelchi;</l>
@@ -272,7 +387,7 @@
               <l part="I">È conforto e vendetta!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">Oh prezzo amaro</l>
@@ -284,7 +399,7 @@
               <l part="I">La sventura onorar!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Quando all'oltraggio</l>
@@ -312,7 +427,7 @@
               <l part="I">Contra l'iniquo usurpator.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">Ma incerta</l>
@@ -329,7 +444,7 @@
               <l part="I">Per le città rapite.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Ebben, ricusi:</l>
@@ -347,7 +462,7 @@
               <l part="I">Sgombro darà.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">Debellator dei Greci,</l>
@@ -367,7 +482,7 @@
               <l part="I">L'ugna dei Franchi corridor.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Che parli</l>
@@ -397,7 +512,7 @@
               <l>Nel mio figliuol, mi colmeria di gioja.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l>Deh perché non è qui! Perché non posso</l>
@@ -409,14 +524,14 @@
               <l>Una parola dal tuo labbro uscia!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l>Questa è voce d'Adelchi. Ebben, quel giorno</l>
               <l part="I">Che tu brami, io l'affretto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">O padre, un altro</l>
@@ -438,7 +553,7 @@
               <l>Deggio dall'uom che mi combatte al fianco.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l>Chi mai regnò senza nemici? il core</l>
@@ -450,7 +565,7 @@
               <l>Fuorché l'ardir? Tu, che proponi al fine?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l>Quel, che signor di gente invitta e fida,</l>
@@ -459,7 +574,7 @@
               <l part="I">Siam d'Adriano: ei lo desia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Perire,</l>
@@ -474,13 +589,13 @@
           <head>SCENA III</head>
           <stage><emph>Detti</emph>, VERMONDO <emph>che precede</emph> ERMENGARDA,</stage>
           <stage>DONZELLE <emph>che l'accompagnano</emph>.</stage>
-          <sp>
+          <sp who="#vermondo">
             <speaker>VERMONDO</speaker>
             <lg>
               <l part="F">O regi; ecco Ermengarda.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="I">Vieni, o figlia; fa cor.</l>
@@ -489,7 +604,7 @@
               <emph>(Vermondo parte: le donzelle si scostano).</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">Sei nelle braccia</l>
@@ -499,7 +614,7 @@
               <l part="I">D'allor che ne partisti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ermengarda">
             <speaker>ERMENGARDA</speaker>
             <lg>
               <l part="F">Oh benedetta</l>
@@ -520,21 +635,21 @@
               <l part="I">Hanno così questa reietta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">Ah! nostro</l>
               <l part="I">È il tuo dolor, nostro l'oltraggio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">E nostro</l>
               <l part="I">Sarà il pensier della vendetta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ermengarda">
             <speaker>ERMENGARDA</speaker>
             <lg>
               <l part="F">O padre</l>
@@ -549,7 +664,7 @@
               <l part="I">Esser pegno dovea.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Di quell'iniquo</l>
@@ -557,7 +672,7 @@
               <l part="I">Tu l'ameresti ancor?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ermengarda">
             <speaker>ERMENGARDA</speaker>
             <lg>
               <l part="F">Padre, nel fondo</l>
@@ -582,7 +697,7 @@
               <l part="I">Ivi potrò chiudere i giorni.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">Al vento</l>
@@ -593,7 +708,7 @@
               <l part="I">Torre ogni gioja.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ermengarda">
             <speaker>ERMENGARDA</speaker>
             <lg>
               <l part="F">Oh! non avesse mai</l>
@@ -603,21 +718,21 @@
               <l part="I">Né gli occhi volti sopra me!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Vendetta,</l>
               <l part="I">Quanto lenta verrai!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ermengarda">
             <speaker>ERMENGARDA</speaker>
             <lg>
               <l part="F">Trova il mio prego</l>
               <l part="I">Grazia appo te?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Sollecito fu sempre</l>
@@ -632,40 +747,40 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage><emph>Detti</emph>,ANFRIDO.</stage>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Che rechi, Anfrido?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#anfrido">
             <speaker>ANFRIDO</speaker>
             <lg>
               <l>Sire, un legato è nella reggia, e chiede</l>
               <l>Gli sia concesso appresentarsi ai regi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="I">Donde vien? chi l'invia?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#anfrido">
             <speaker>ANFRIDO</speaker>
             <lg>
               <l part="F">Da Roma ei viene,</l>
               <l part="I">Ma legato è d'un re.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ermengarda">
             <speaker>ERMENGARDA</speaker>
             <lg>
               <l part="F">Padre, concedi</l>
               <l part="I">Ch'io mi ritragga.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">O donne, alle sue stanze</l>
@@ -675,20 +790,20 @@
             </lg>
             <stage><emph>(Ermengarda parte con le donzelle)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">D'un re dicesti, Anfrido?</l>
               <l part="I">Un legato... di Carlo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#anfrido">
             <speaker>ANFRIDO</speaker>
             <lg>
               <l part="F">O re, l'hai detto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l>Che pretende costui? quali parole</l>
@@ -696,7 +811,7 @@
               <l part="I">Che di morte non sia?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#anfrido">
             <speaker>ANFRIDO</speaker>
             <lg>
               <l part="F">Di gran messaggio</l>
@@ -705,21 +820,21 @@
               <l part="I">Favella in atto di blandir.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Conosco</l>
               <l part="I">L'arti di Carlo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">Al suo stromento il tempo</l>
               <l part="I">D'esercitarle non si dia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Raguna</l>
@@ -728,21 +843,21 @@
             </lg>
             <stage><emph>(Anfrido parte) </emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Il giorno della prova è giunto;</l>
               <l part="I">Figlio, sei tu con me?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">Sì dura inchiesta</l>
               <l part="I">Quando, o padre, mertai?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Venuto è il giorno</l>
@@ -750,7 +865,7 @@
               <l part="I">Dì, l'abbiam noi? Che pensi far?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">Risponda</l>
@@ -758,14 +873,14 @@
               <l part="I">Attender penso, ed eseguirli.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">E quando</l>
               <l part="I">A' tuoi disegni opposti sieno?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">O padre!</l>
@@ -779,7 +894,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>DESIDERIO, ADELCHI, ALBINO, <emph>Fedeli longobardi</emph>.</stage>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l>Duchi, e Fedeli; ai vostri re mai sempre</l>
@@ -787,7 +902,7 @@
               <l>Come nel campo. — Ambasciator, che rechi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#albino">
             <speaker>ALBINO</speaker>
             <lg>
               <l>Carlo, il diletto a Dio sire dei Franchi</l>
@@ -797,7 +912,7 @@
               <l>L'uomo illustre Pipin fe' dono a Piero?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l>Uomini Longobardi! in faccia a tutto</l>
@@ -817,7 +932,7 @@
               <l part="I">Non darne alcuna.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#albino">
             <speaker>ALBINO</speaker>
             <lg>
               <l part="F">E tal risposta è guerra.</l>
@@ -832,7 +947,7 @@
               <l part="I">Star del vostro peccato.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Al tuo re torna</l>
@@ -842,13 +957,13 @@
               <l part="I">Rispondete a costui.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#fedeli">
             <speaker>FEDELI</speaker>
             <lg>
               <l part="M">Guerra!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#albino">
             <speaker>ALBINO</speaker>
             <lg>
               <l part="F">E l'avrete,</l>
@@ -858,7 +973,7 @@
               <l part="I">Già si rimette in via.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Spieghi ogni duca</l>
@@ -874,7 +989,7 @@
               <l part="I">Questo invito riporta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">E digli ancora,</l>
@@ -894,33 +1009,33 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>DUCHI <emph>rimasti</emph>.</stage>
-          <sp>
+          <sp who="#indolfo">
             <speaker>INDOLFO</speaker>
             <lg>
               <l part="I">Guerra, egli ha detto!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#farvaldo">
             <speaker>FARVALDO</speaker>
             <lg>
               <l part="F">In questa guerra è il fato</l>
               <l part="I">Del regno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#indolfo">
             <speaker>INDOLFO</speaker>
             <lg>
               <l part="M">E il nostro.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ervigo">
             <speaker>ERVIGO</speaker>
             <lg>
               <l part="F">E inerti ad aspettarlo</l>
               <l part="I">Staremci?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ildechi">
             <speaker>ILDECHI</speaker>
             <lg>
               <l part="F">Amici, di consulte il loco</l>
@@ -932,7 +1047,7 @@
         <div type="scene">
           <head>SCENA VII </head>
           <stage><emph>Casa di Svarto </emph>.</stage>
-          <sp>
+          <sp who="#svarto">
             <speaker>SVARTO</speaker>
             <lg>
               <l>Un messagger dei Franchi! Un qualche evento,</l>
@@ -969,14 +1084,14 @@
         <div type="scene">
           <head>SCENA VIII </head>
           <stage>SVARTO, ILDECHI, <emph>quindi altri che sopraggiungono</emph>.</stage>
-          <sp>
+          <sp who="#ildechi">
             <speaker>ILDECHI</speaker>
             <lg>
               <l part="F">Il ciel ti salvi, o Svarto:</l>
               <l part="I">Nessuno è qui?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#svarto">
             <speaker>SVARTO</speaker>
             <lg>
               <l part="F">Nessun. Quai nuove, o duca?</l>
@@ -986,39 +1101,39 @@
               <l part="I">Del guiderdon per tutti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#svarto">
             <speaker>SVARTO</speaker>
             <lg>
               <l part="F">Io nulla attendo,</l>
               <l part="I">Fuor che da voi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ildechi">
             <speaker>ILDECHI</speaker>
             <stage><emph>(a</emph> FARVALDO <emph>che sopraggiunge)</emph>.</stage>
             <lg>
               <l part="F">Farvaldo, alcun ti segue?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#farvaldo">
             <speaker>FARVALDO</speaker>
             <lg>
               <l part="I">Vien sui miei passi Indolfo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ildechi">
             <speaker>ILDECHI</speaker>
             <lg>
               <l part="M">Eccolo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#indolfo">
             <speaker>INDOLFO</speaker>
             <lg>
               <l part="F">Amici!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ildechi">
             <speaker>ILDECHI</speaker>
             <lg>
               <l part="I">Vila! Ervigo!</l>
@@ -1037,33 +1152,33 @@
               <l part="I">Per chi voleva un altro re?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#indolfo">
             <speaker>INDOLFO</speaker>
             <lg>
               <l part="F">Nessuna</l>
               <l part="I">Pace con lor.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#altri_duchi">
             <speaker>ALTRI DUCHI</speaker>
             <lg>
               <l part="M">Nessuna!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ildechi">
             <speaker>ILDECHI</speaker>
             <lg>
               <l part="F">È d'uopo un patto</l>
               <l part="I">Stringer con Carlo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#farvaldo">
             <speaker>FARVALDO</speaker>
             <lg>
               <l part="M">Al suo legato...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ervigo">
             <speaker>ERVIGO</speaker>
             <lg>
               <l part="F">È cinto</l>
@@ -1071,7 +1186,7 @@
               <l>Porglisi al fianco; e fu pensier d'Adelchi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ildechi">
             <speaker>ILDECHI</speaker>
             <lg>
               <l>Vada adunque un di noi; rechi le nostre</l>
@@ -1079,20 +1194,20 @@
               <l part="I">O le rimandi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#indolfo">
             <speaker>INDOLFO</speaker>
             <lg>
               <l part="M">Bene sta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ildechi">
             <speaker>ILDECHI</speaker>
             <lg>
               <l part="F">Chi piglia</l>
               <l part="I">Quest'impresa?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#svarto">
             <speaker>SVARTO</speaker>
             <lg>
               <l part="F">Io v'andrò. Duchi, m'udite.</l>
@@ -1116,14 +1231,14 @@
               <l part="I">Tosto mi sgombrerà.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ildechi">
             <speaker>ILDECHI</speaker>
             <lg>
               <l part="F">— Svarto, io da tanto</l>
               <l part="I">Non ti credea.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#svarto">
             <speaker>SVARTO</speaker>
             <lg>
               <l part="F">Necessità lo zelo</l>
@@ -1131,20 +1246,20 @@
               <l part="I">Non è mestier che di prontezza.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ildechi">
             <speaker>ILDECHI</speaker>
             <lg>
               <l part="F">Amici!</l>
               <l part="I">Ch'ei vada?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#duchi">
             <speaker>DUCHI</speaker>
             <lg>
               <l part="M">Ei vada.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ildechi">
             <speaker>ILDECHI</speaker>
             <lg>
               <l part="F">Al dì novello in pronto</l>
@@ -1159,7 +1274,7 @@
           <head>SCENA I</head>
           <stage><emph>Campo dei Franchi in Val di Susa</emph>.</stage>
           <stage>CARLO, PIETRO</stage>
-          <sp>
+          <sp who="#pietro">
             <speaker>PIETRO</speaker>
             <lg>
               <l>Carlo invitto, che udii? Toccato ancora</l>
@@ -1177,7 +1292,7 @@
               <l part="I">Volle un momento, e disperò.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="F">Quant'io</l>
@@ -1231,7 +1346,7 @@
               <l part="I">Non se ne parli più.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pietro">
             <speaker>PIETRO</speaker>
             <lg>
               <l part="F">Re, all'umil servo</l>
@@ -1254,7 +1369,7 @@
               <l>Fia risoluta in fra noi due la lite.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l>A che ritenti questa piaga? In vani</l>
@@ -1287,7 +1402,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage><emph>Detti</emph>, ARVINO.</stage>
-          <sp>
+          <sp who="#arvino">
             <speaker>ARVINO</speaker>
             <lg>
               <l part="F">Sire, nel campo</l>
@@ -1295,20 +1410,20 @@
               <l part="I">Chiede.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pietro">
             <speaker>PIETRO</speaker>
             <lg>
               <l part="M">Un Latin?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="F">Donde arrivò? Le Chiuse</l>
               <l part="I">Come varcò?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#arvino">
             <speaker>ARVINO</speaker>
             <lg>
               <l part="F">Per calli sconosciuti,</l>
@@ -1316,7 +1431,7 @@
               <l part="I">Grande avviso recar.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="F">Fa ch'io gli parli.</l>
@@ -1333,14 +1448,14 @@
           <head>SCENA III</head>
           <stage><emph>Detti</emph>, MARTINO <emph>introdotto da</emph> ARVINO.</stage>
           <stage><emph>(Arvino si ritira)</emph>).</stage>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l>Tu se' latino, e qui? tu nel mio campo,</l>
               <l part="I">Illeso, inosservato?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#martino">
             <speaker>MARTINO</speaker>
             <lg>
               <l part="F">Inclita speme</l>
@@ -1351,19 +1466,19 @@
               <l part="I">La via.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="M">Qual via?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#martino">
             <speaker>MARTINO</speaker>
             <lg>
               <l part="M">Quella ch'io feci.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="F">E come</l>
@@ -1371,7 +1486,7 @@
               <l part="I">Pensier ti venne?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#martino">
             <speaker>MARTINO</speaker>
             <lg>
               <l part="F">All'ordin sacro ascritto</l>
@@ -1383,14 +1498,14 @@
               <l part="I">Presenta il pianto e d'Adrian.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="F">Tu vedi</l>
               <l part="I">Il suo legato.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pietro">
             <speaker>PIETRO</speaker>
             <lg>
               <l part="F">Ch'io la man ti stringa,</l>
@@ -1398,14 +1513,14 @@
               <l part="I">Angel di gioia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#martino">
             <speaker>MARTINO</speaker>
             <lg>
               <l part="F">Uom peccator son io;</l>
               <l>Ma la gioia è dal cielo, e non fia vana.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l>Animoso Latin; ciò che veduto,</l>
@@ -1413,7 +1528,7 @@
               <l part="I">Tutto mi narra.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#martino">
             <speaker>MARTINO</speaker>
             <lg>
               <l part="F">Di Leone al cenno,</l>
@@ -1434,14 +1549,14 @@
               <l part="I">Strugger la possa il braccio tuo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="F">Toccasti</l>
               <l part="I">Il campo lor? qual'è? che fan?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#martino">
             <speaker>MARTINO</speaker>
             <lg>
               <l part="F">Securi</l>
@@ -1464,14 +1579,14 @@
               <l part="I">La via cercarne, e la rinvenni.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="F">E come</l>
               <l>Nota a te fu? come al nemico ascosa?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#martino">
             <speaker>MARTINO</speaker>
             <lg>
               <l>Dio gli accecò, Dio mi guidò. Dal campo</l>
@@ -1566,14 +1681,14 @@
               <l>Dio ringraziai, li benedissi, e scesi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l>Empio colui, che non vorrà la destra</l>
               <l part="I">Qui riconoscer dell'Eccelso!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pietro">
             <speaker>PIETRO</speaker>
             <lg>
               <l part="F">E quanto</l>
@@ -1581,7 +1696,7 @@
               <l part="I">A cui l'Eccelso ti destina!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="F">Ed io</l>
@@ -1594,7 +1709,7 @@
               <l part="I">Dar può la via che percorresti?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#martino">
             <speaker>MARTINO</speaker>
             <lg>
               <l part="F">Il puote.</l>
@@ -1604,7 +1719,7 @@
               <l part="I">D'inutile portento?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="F">Oggi a riposo</l>
@@ -1614,14 +1729,14 @@
               <l>Che il fior di Francia alla tua scorta affido.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#martino">
             <speaker>MARTINO</speaker>
             <lg>
               <l>Con lor sarò: di mie promesse pegno</l>
               <l part="I">Il mio capo ti fia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="F">Se di quest'alpe</l>
@@ -1639,7 +1754,7 @@
             </lg>
             <stage><emph>(Arvino parte)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <stage>
               <emph>(al legato ed a Martino) </emph>
@@ -1654,7 +1769,7 @@
         </div>
         <div type="scene">
           <head>SCENA IV</head>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l>Così, Carlo reddiva. Il riso amaro</l>
@@ -1695,7 +1810,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>CARLO, CONTI e VESCOVI.</stage>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <stage><emph>(ai Conti)</emph>.</stage>
             <lg>
@@ -1769,14 +1884,14 @@
             <emph>Campo dei Longobardi. Piazza dinanzi alla tenda di Adelchi.</emph>
           </stage>
           <stage>ADELCHI, ANFRIDO</stage>
-          <sp>
+          <sp who="#anfrido">
             <speaker>ANFRIDO</speaker>
             <stage><emph>(che sopraggiunge)</emph>.</stage>
             <lg>
               <l part="I">Signor!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">Diletto Anfrido; ebben; che fanno</l>
@@ -1784,7 +1899,7 @@
               <l part="I">Le tende al tutto di levar?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#anfrido">
             <speaker>ANFRIDO</speaker>
             <lg>
               <l part="F">Nessuno</l>
@@ -1801,7 +1916,7 @@
               <l>Ritrarsi agogna, ed il momento agguata.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l>E lo potrà, pur troppo! Ei parte, il vile</l>
@@ -1824,7 +1939,7 @@
               <l part="I">Che lunge ei sia dalla mia spada!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#anfrido">
             <speaker>ANFRIDO</speaker>
             <lg>
               <l part="F">O dolce</l>
@@ -1841,7 +1956,7 @@
               <l part="I">Dovranno or più che mai.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">La gloria? il mio</l>
@@ -1862,14 +1977,14 @@
               <l part="I">Certa ed agevol fia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#anfrido">
             <speaker>ANFRIDO</speaker>
             <lg>
               <l part="F">Torna agli antichi</l>
               <l part="I">Disegni il re?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">Dubbiar ne puoi? Securo</l>
@@ -1906,7 +2021,7 @@
               <l part="I">E balzato dal vento.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#anfrido">
             <speaker>ANFRIDO</speaker>
             <lg>
               <l part="F">Alto infelice!</l>
@@ -1929,7 +2044,7 @@
           <head>SCENA II</head>
           <stage>ADELCHI, DESIDERIO.</stage>
           <stage><emph>(Anfrido si ritira)</emph>.</stage>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l>Figlio, a te rege qual son io, m'è tolto</l>
@@ -1949,7 +2064,7 @@
               <l part="I">L'ultima fronda, e la più bella.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">A quale</l>
@@ -1957,7 +2072,7 @@
               <l part="I">Obbediente seguiratti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">E a tanto</l>
@@ -1965,27 +2080,27 @@
               <l part="I">Spinger ti può?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">Questa è in mia mano; e intera</l>
               <l part="I">L'avrai, fin ch'io respiro!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Obbediresti</l>
               <l part="I">Biasmando?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="M">Obbedirei.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Gloria e tormento</l>
@@ -1999,38 +2114,38 @@
         <div type="scene">
           <head>SCENA III </head>
           <stage><emph>Detti, uno </emph>SCUDIERO <emph>frettoloso ed atterrito</emph>.</stage>
-          <sp>
+          <sp who="#scudiere">
             <speaker>SCUDIERE</speaker>
             <lg>
               <l part="F">I Franchi! i Franchi!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="I">Che dici insano?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#altro_scudiere">
             <speaker>ALTRO SCUDIERE</speaker>
             <lg>
               <l part="M">I Franchi, o re.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Che Franchi?</l>
             </lg>
             <stage><emph>(la scena si affolla di Longobardi fuggitivi. Entra Baudo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="I">Baudo, che fu?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#baudo">
             <speaker>BAUDO</speaker>
             <lg>
               <l part="F">Morte e sventura! Il campo</l>
@@ -2038,20 +2153,20 @@
               <l part="I">Piombano i Franchi ad assalirci.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">I Franchi!</l>
               <l part="I">Per qual via?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#baudo">
             <speaker>BAUDO</speaker>
             <lg>
               <l part="M">Chi lo sa?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">Corriamo; ei fia</l>
@@ -2059,20 +2174,20 @@
             </lg>
             <stage><emph>(in atto di partire)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#baudo">
             <speaker>BAUDO</speaker>
             <lg>
               <l part="F">Un'oste intera:</l>
               <l>Gli sbandati siam noi: tutto è perduto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="I">Tutto è perduto?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">Ebben, compagni; i Franchi?</l>
@@ -2090,13 +2205,13 @@
               <l part="I">Anfrido!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#anfrido">
             <speaker>ANFRIDO</speaker>
             <lg>
               <l part="M">O re, son teco.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <stage><emph>(avviandosi)</emph>.</stage>
             <lg>
@@ -2107,7 +2222,7 @@
               <emph>(parte seguito da Anfrido, da Baudo e da alcuni longobardi).</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <stage><emph>(ai fuggitivi che attraversano la scena)</emph>.</stage>
             <lg>
@@ -2118,14 +2233,14 @@
             </lg>
             <stage><emph>(sopraggiungono soldati fuggitivi dalla parte opposta a quella donde è partito Adelchi)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#soldato">
             <speaker>SOLDATO</speaker>
             <lg>
               <l part="F">O re, tu qui? Deh! fuggi.</l>
             </lg>
             <stage><emph>(attraversa la scena)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l>Infame! al re questo consiglio? E voi,</l>
@@ -2141,7 +2256,7 @@
               <l part="I">Perché fuggite dalle Chiuse?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#soldato">
             <speaker>SOLDATO</speaker>
             <lg>
               <l part="F">I Franchi</l>
@@ -2150,7 +2265,7 @@
               <l part="I">Son dispersi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Tu menti. Il figliuol mio</l>
@@ -2158,7 +2273,7 @@
               <l part="I">A quei pochi nemici. Indietro!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#soldato">
             <speaker>SOLDATO</speaker>
             <lg>
               <l part="F">O sire,</l>
@@ -2168,7 +2283,7 @@
               <l part="I">Non li raguna: siam traditi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <stage><emph>(ai fuggitivi che si affollano) </emph>.</stage>
             <lg>
@@ -2177,7 +2292,7 @@
               <l part="I">Restar si può.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#soldato">
             <speaker>SOLDATO</speaker>
             <lg>
               <l part="F">Sono deserte: i Franchi</l>
@@ -2186,21 +2301,21 @@
               <l part="I">Resta alla fuga; or or fia chiuso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Ebbene;</l>
               <l part="I">Moriam qui da guerrier.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#altro_soldato">
             <speaker>ALTRO SOLDATO</speaker>
             <lg>
               <l part="F">Siamo traditi:</l>
               <l part="I">Siam venduti al macello.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#altro_soldato">
             <speaker>ALTRO SOLDATO</speaker>
             <lg>
               <l part="F">In giusta guerra</l>
@@ -2208,19 +2323,19 @@
               <l part="I">Non isgozzati a tradimento.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#altro_soldato">
             <speaker>ALTRO SOLDATO</speaker>
             <lg>
               <l part="F">I Franchi!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#molti_soldati">
             <speaker>MOLTI SOLDATI</speaker>
             <lg>
               <l part="I">Fuggiamo!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Ebben, correte; anch'io con voi</l>
@@ -2235,7 +2350,7 @@
             <emph>Parte del campo abbandonato dai Longobardi, sotto alle Chiuse. </emph>
           </stage>
           <stage>CARLO<emph>circondato da Conti franchi</emph>, SVARTO.</stage>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l>Ecco varcate queste Chiuse. A Dio</l>
@@ -2256,14 +2371,14 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage><emph>Detti</emph>, RUTLANDO..</stage>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="F">E che? Rutlando,</l>
               <l part="I">Tu riedi dal conflitto?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rutlando">
             <speaker>RUTLANDO</speaker>
             <lg>
               <l part="F">O re, ti chiamo</l>
@@ -2273,14 +2388,14 @@
               <l part="I">Io non l'inseguo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="F">E non trovasti alcuno</l>
               <l part="I">Che mostrasse la fronte?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rutlando">
             <speaker>RUTLANDO</speaker>
             <lg>
               <l part="F">Incontro io vidi</l>
@@ -2295,7 +2410,7 @@
               <l part="I">Mosso di Francia non sarei.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="F">T'accheta,</l>
@@ -2306,7 +2421,7 @@
             </lg>
             <stage><emph>(entra il CONTE spedito da Carlo) </emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <stage><emph>(a Carlo) </emph>.</stage>
             <lg>
@@ -2317,13 +2432,13 @@
               <l>Che da lui ci divide, or or fia sgombro.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="I">Esser dovea così.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#conte">
             <speaker>CONTE</speaker>
             <lg>
               <l part="F">Vidi un drappello,</l>
@@ -2331,20 +2446,20 @@
               <l part="I">Venìa correndo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#altro_conte">
             <speaker>ALTRO CONTE</speaker>
             <lg>
               <l part="M">È qui.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="F">Svarto, son quelli</l>
               <l part="I">Che m' annunziasti?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#svarto">
             <speaker>SVARTO</speaker>
             <lg>
               <l part="M">Il son. — Compagni!</l>
@@ -2354,20 +2469,20 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage><emph>Detti</emph>, ILDECHI <emph>ed altri Duchi, Giudici e Soldati longobardi</emph>.</stage>
-          <sp>
+          <sp who="#ildechi">
             <speaker>ILDECHI</speaker>
             <lg>
               <l part="F">O Svarto!</l>
               <l part="I">Il re!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="M">Son desso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ildechi">
             <speaker>ILDECHI</speaker>
             <stage><emph>(s'inginocchia e pone le sue mani fra quelle di Carlo)</emph>.</stage>
             <lg>
@@ -2378,27 +2493,27 @@
               <l part="I">A te promesso da gran tempo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="F">Svarto,</l>
               <l part="I">Conte di Susa!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#svarto">
             <speaker>SVARTO</speaker>
             <lg>
               <l part="M">O re, qual grazia? ...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="F">Il nome</l>
               <l part="I">Dimmi di questi a me devoti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#svarto">
             <speaker>SVARTO</speaker>
             <lg>
               <l part="F">Il duca</l>
@@ -2408,7 +2523,7 @@
               <l part="I">Giudici son; questi guerrieri.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="F">Alzatevi,</l>
@@ -2436,7 +2551,7 @@
             </lg>
             <stage><emph>(i Longobardi partono) </emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <stage><emph>(a Rutlando in disparte) </emph>.</stage>
             <lg>
@@ -2444,13 +2559,13 @@
               <l part="I">Prodi costor?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rutlando">
             <speaker>RUTLANDO</speaker>
             <lg>
               <l part="M">Pur troppo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="F">Errato ha il labbro</l>
@@ -2464,26 +2579,26 @@
         <div type="scene">
           <head>SCENA VII</head>
           <stage><emph>Detti</emph>, ANFRIDO <emph>ferito, portato da due</emph>FRANCHI.</stage>
-          <sp>
+          <sp who="#rutlando">
             <speaker>RUTLANDO</speaker>
             <lg>
               <l part="I">Ecco un nemico. Ove si pugna?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#franco">
             <speaker>FRANCO</speaker>
             <lg>
               <l part="F">Il solo</l>
               <l part="I">Che pugnasse, è costui.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="M">Solo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#franco">
             <speaker>FRANCO</speaker>
             <lg>
               <l part="F">Gran parte</l>
@@ -2508,7 +2623,7 @@
               <l part="I">Ci arrendemmo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="F">E ben feste: a chi resiste</l>
@@ -2519,27 +2634,27 @@
               <l part="F">Il riconosci?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#svarto">
             <speaker>SVARTO</speaker>
             <lg>
               <l part="I">Anfrido egli è, scudier d'Adelchi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="F">Anfrido,</l>
               <l part="I">Tu solo andavi contro alor?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#anfrido">
             <speaker>ANFRIDO</speaker>
             <lg>
               <l part="F">Bisogno</l>
               <l part="I">Fa di compagni per morir?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="F">Rutlando!</l>
@@ -2553,7 +2668,7 @@
               <l>Guerrier restavi e non prigion di Carlo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#anfrido">
             <speaker>ANFRIDO</speaker>
             <lg>
               <l>Io viver tuo guerrier, quand'io potea</l>
@@ -2568,7 +2683,7 @@
               <l>Nessun mortale: un che si muor tel dice.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <stage><emph>(ai Conti) </emph>.</stage>
             <lg>
@@ -2598,7 +2713,7 @@
           <head>SCENA VIII</head>
           <stage><emph>Bosco solitario</emph>.</stage>
           <stage>DESIDERIO, VERMONDO, <emph>altri</emph>LONGOBARDI <emph>fuggiaschi in disordine</emph>.</stage>
-          <sp>
+          <sp who="#vermondo">
             <speaker>VERMONDO</speaker>
             <lg>
               <l>Siamo in salvo, o mio re: scendi, e su queste</l>
@@ -2610,13 +2725,13 @@
               <l part="I">Cinto non sei che di leali.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">E Adelchi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vermondo">
             <speaker>VERMONDO</speaker>
             <lg>
               <l>Or or fia qui, lo spero: alla sua traccia</l>
@@ -2625,20 +2740,20 @@
               <l>E a questa posta de' leali il guidi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l>O mio Vermondo; il vecchio rege è stanco,</l>
               <l part="I">È stanco — dalla fuga.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vermondo">
             <speaker>VERMONDO</speaker>
             <lg>
               <l part="F">Ahi traditori!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l>Vili! Nel fango han trascinato i bianchi</l>
@@ -2652,7 +2767,7 @@
               <l part="I">Che mi farà codesto Carlo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vermondo">
             <speaker>VERMONDO</speaker>
             <lg>
               <l part="F">O nostro</l>
@@ -2662,7 +2777,7 @@
               <l>Città munite: e Adelchi vive, io spero.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l>Maladetto quel dì che sopra il monte</l>
@@ -2676,13 +2791,13 @@
               <l>Che una esecranda ora d'infamia ha spento!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#vermondo">
             <speaker>VERMONDO</speaker>
             <lg>
               <l part="I">Il re!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="M">Figlio, sei tu?</l>
@@ -2692,20 +2807,20 @@
         <div type="scene">
           <head>SCENA IX </head>
           <stage><emph>Detti</emph>, ADELCHI.</stage>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">Padre, ti trovo!</l>
             </lg>
             <stage><emph>(si abbracciano) </emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="I">S'io t'avessi ascoltato!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">Oh! che rammenti?</l>
@@ -2715,7 +2830,7 @@
               <l part="I">Come ti regge?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Oh! per la prima volta</l>
@@ -2724,7 +2839,7 @@
               <l part="I">Per fuggire un nemico.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <stage><emph>(ai Longobardi) </emph>.</stage>
             <lg>
@@ -2732,19 +2847,19 @@
               <l part="I">Il vostro re.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#longobardi">
             <speaker>LONGOBARDI</speaker>
             <lg>
               <l part="F">Noi morirem per lui!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#longobardi">
             <speaker>MOLTI LONGOBARDI</speaker>
             <lg>
               <l part="I">Tutti morrem!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">Quand'è così, salvargli</l>
@@ -2754,7 +2869,7 @@
               <l part="I">La vostra fede?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#longobardi">
             <speaker>LONGOBARDI</speaker>
             <lg>
               <l part="F">Ai tuoi guerrieri, Adelchi,</l>
@@ -2764,7 +2879,7 @@
               <l part="I">Segno de' fidi è questo omai.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">V'ha dunque</l>
@@ -2783,14 +2898,14 @@
               <l part="I">L'uom che restar debba al tuo fianco.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Il duca</l>
               <l part="I">D'Ivrea.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <stage>(<emph>a</emph>GUNTIGI, <emph>che s'avanza</emph>).</stage>
             <lg>
@@ -2798,14 +2913,14 @@
               <l part="I">Il duca di Verona ov'è?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#giselberto">
             <speaker>GISELBERTO</speaker>
             <stage><emph>(si avanza) </emph>.</stage>
             <lg>
               <l part="F">Tra i fidi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l>Meco verrai: nosco trarrem Gerberga.</l>
@@ -2837,27 +2952,27 @@
             </lg>
             <stage><emph>(partono gli indicati da Adelchi). </emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">O figlio!</l>
               <l>Tu m'hai renduto il mio vigor: partiamo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l>Padre, io t'affido a questi prodi: or ora</l>
               <l part="I">Anch'io teco sarò.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="M">Che attendi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">Anfrido.</l>
@@ -2870,14 +2985,14 @@
               <l part="I">Non partirò, fin ch'ei non giunga.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">E teco</l>
               <l part="I">Aspetterò.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="M">Padre...</l>
@@ -2887,26 +3002,26 @@
               <l part="F">Vedesti Anfrido?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#soldato">
             <speaker>SOLDATO</speaker>
             <lg>
               <l part="I">Re, che mi chiedi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="M">O ciel! favella.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#soldato">
             <speaker>SOLDATO</speaker>
             <lg>
               <l part="F">Il vidi</l>
               <l part="I">Morto cader.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">Giorno d'infamia e d'ira,</l>
@@ -3020,7 +3135,7 @@
           <head>SCENA I</head>
           <stage><emph>Giardino nel monastero di San Salvadore in Brescia</emph>.</stage>
           <stage>ERMENGARDA<emph>sostenuta da due donzelle</emph>, ANSBERGA.</stage>
-          <sp>
+          <sp who="#ermengarda">
             <speaker>ERMENGARDA</speaker>
             <lg>
               <l part="I">Qui sotto il tiglio, qui.</l>
@@ -3067,7 +3182,7 @@
               <l>Ineffabile strazio Ei qui mi tenga?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ansberga">
             <speaker>ANSBERGA</speaker>
             <lg>
               <l>Cara infelice, non temer: lontane</l>
@@ -3084,7 +3199,7 @@
               <l part="I">Lungo conflitto...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ermengarda">
             <speaker>ERMENGARDA</speaker>
             <lg>
               <l part="F">Io nol vedrò: disciolta</l>
@@ -3112,13 +3227,13 @@
               <l>Di mia gente nemico approssimarsi...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ansberga">
             <speaker>ANSBERGA</speaker>
             <lg>
               <l part="I">Carlo!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ermengarda">
             <speaker>ERMENGARDA</speaker>
             <lg>
               <l part="F">Tu l'hai nomato: e sì gli dica:</l>
@@ -3132,7 +3247,7 @@
               <l part="I">Ch'io gli perdono. — Lo farai?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ansberga">
             <speaker>ANSBERGA</speaker>
             <lg>
               <l part="F">Le estreme</l>
@@ -3140,7 +3255,7 @@
               <l part="I">Queste tue mi son sacre.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ermengarda">
             <speaker>ERMENGARDA</speaker>
             <lg>
               <l part="F">Amata! e d'una</l>
@@ -3159,7 +3274,7 @@
               <l part="I">Dee la morte attestarlo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ansberga">
             <speaker>ANSBERGA</speaker>
             <lg>
               <l part="F">Oh! da te lunge</l>
@@ -3172,7 +3287,7 @@
               <l part="I">Cosa l'obblìo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ermengarda">
             <speaker>ERMENGARDA</speaker>
             <lg>
               <l part="F">Che mi proponi, Ansberga?</l>
@@ -3185,14 +3300,14 @@
               <l part="I">In fronte all'uom! Ma — d'altri io sono.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ansberga">
             <speaker>ANSBERGA</speaker>
             <lg>
               <l part="F">Oh mai</l>
               <l part="I">Stata nol fossi!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ermengarda">
             <speaker>ERMENGARDA</speaker>
             <lg>
               <l part="F">Oh mai! ma quella via,</l>
@@ -3207,13 +3322,13 @@
               <l>Talor dei vivi son più forti assai.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ansberga">
             <speaker>ANSBERGA</speaker>
             <lg>
               <l part="I">Oh! nol farà.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ermengarda">
             <speaker>ERMENGARDA</speaker>
             <lg>
               <l part="F">Tu pia, tu poni un freno</l>
@@ -3222,46 +3337,46 @@
               <l>Far che ripari, chi lo fece, il torto?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ansberga">
             <speaker>ANSBERGA</speaker>
             <lg>
               <l>No, sventurata, ei nol farà. — Nol puote.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ermengarda">
             <speaker>ERMENGARDA</speaker>
             <lg>
               <l part="I">Come? perché nol puote?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ansberga">
             <speaker>ANSBERGA</speaker>
             <lg>
               <l part="F">O mia diletta</l>
               <l part="I">Non chieder oltre; obblia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ermengarda">
             <speaker>ERMENGARDA</speaker>
             <lg>
               <l part="F">Parla! alla tomba</l>
               <l part="I">Con questo dubbio non mandarmi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ansberga">
             <speaker>ANSBERGA</speaker>
             <lg>
               <l part="F">Oh! l'empio</l>
               <l part="I">Il suo delitto consumò.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ermengarda">
             <speaker>ERMENGARDA</speaker>
             <lg>
               <l part="F">Prosegui!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ansberga">
             <speaker>ANSBERGA</speaker>
             <lg>
               <l>Caccialo al tutto dal tuo cor. Di nuove</l>
@@ -3282,13 +3397,13 @@
               <l>Le dà? Vedete: il suo dolor l'uccide.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#prima_suora">
             <speaker>PRIMA SUORA</speaker>
             <lg>
               <l part="I">Fa core; ella respira.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#seconda_suora">
             <speaker>SECONDA SUORA</speaker>
             <lg>
               <l part="F">O sventurata!</l>
@@ -3296,27 +3411,27 @@
               <l part="I">Soffrir!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#donzella">
             <speaker>DONZELLA</speaker>
             <lg>
               <l part="M">Dolce mia donna!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#prima_suora">
             <speaker>PRIMA SUORA</speaker>
             <lg>
               <l part="F">Ecco le luci</l>
               <l part="I">Apre.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ansberga">
             <speaker>ANSBERGA</speaker>
             <lg>
               <l part="M">Oh che sguardo! Ciel! che fia?</l>
             </lg>
             <stage><emph>(in delirio) </emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ermengarda">
             <speaker>ERMENGARDA</speaker>
             <lg>
               <l part="F">Cacciate</l>
@@ -3325,7 +3440,7 @@
               <l part="I">Prender la mano al re?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ansberga">
             <speaker>ANSBERGA</speaker>
             <lg>
               <l part="F">Svegliati! Oh Dio</l>
@@ -3333,7 +3448,7 @@
               <l>Questi fantasmi; il nome santo invoca.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ermengarda">
             <speaker>ERMENGARDA</speaker>
             <stage><emph>(in delirio)</emph>.</stage>
             <lg>
@@ -3362,14 +3477,14 @@
               <l part="I">Nelle sue braccia... io muoio! ...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ansberga">
             <speaker>ANSBERGA</speaker>
             <lg>
               <l part="F">Oh! mi farai</l>
               <l part="I">Teco morir!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ermengarda">
             <speaker>ERMENGARDA</speaker>
             <stage><emph>(in delirio) </emph>.</stage>
             <lg>
@@ -3403,14 +3518,14 @@
             </lg>
             <stage><emph>(ricade) </emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ansberga">
             <speaker>ANSBERGA</speaker>
             <lg>
               <l part="F">Tranquilla</l>
               <l part="I">Ella morìa!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ermengarda">
             <speaker>ERMENGARDA</speaker>
             <stage><emph>(in delirio) </emph>.</stage>
             <lg>
@@ -3422,14 +3537,14 @@
             </lg>
             <stage><emph>(ricade in letargo)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#ansberga">
             <speaker>ANSBERGA</speaker>
             <lg>
               <l part="F">O donna</l>
               <l part="I">Del ciel soccorri a questa afflitta!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#prima_suora">
             <speaker>PRIMA SUORA</speaker>
             <lg>
               <l part="F">Oh! vedi:</l>
@@ -3437,21 +3552,21 @@
               <l part="I">Sotto la man più non trabalza.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ansberga">
             <speaker>ANSBERGA</speaker>
             <lg>
               <l part="F">O suora!</l>
               <l part="I">Ermengarda! Ermengarda!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ermengarda">
             <speaker>ERMENGARDA</speaker>
             <stage><emph>(riavendosi)</emph>.</stage>
             <lg>
               <l part="F">Oh! chi mi chiama?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ansberga">
             <speaker>ANSBERGA</speaker>
             <lg>
               <l>Guardami; io sono Ansberga: a te d'intorno</l>
@@ -3459,7 +3574,7 @@
               <l part="I">Che per la pace tua pregano.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ermengarda">
             <speaker>ERMENGARDA</speaker>
             <lg>
               <l part="F">Il cielo</l>
@@ -3468,7 +3583,7 @@
               <l part="I">Io mi risveglio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ansberga">
             <speaker>ANSBERGA</speaker>
             <lg>
               <l part="F">Misera! travaglio</l>
@@ -3476,7 +3591,7 @@
               <l part="I">Quiete.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ermengarda">
             <speaker>ERMENGARDA</speaker>
             <lg>
               <l part="F">È ver: tutta la lena è spenta.</l>
@@ -3657,20 +3772,20 @@
           <head>SCENA II</head>
           <stage><emph>Notte. Interno d'un battifredo su le mura di Pavia</emph>.</stage>
           <stage>GUNTIGI, AMRI</stage>
-          <sp>
+          <sp who="#guntigi">
             <speaker>GUNTIGI</speaker>
             <lg>
               <l part="I">Amri, sovvienti di Spoleti?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amri">
             <speaker>AMRI</speaker>
             <lg>
               <l part="F">E posso</l>
               <l part="I">Obbliarlo, signor?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guntigi">
             <speaker>GUNTIGI</speaker>
             <lg>
               <l part="F">D'allor che morto</l>
@@ -3682,7 +3797,7 @@
               <l part="I">Che mi giuravi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amri">
             <speaker>AMRI</speaker>
             <lg>
               <l part="F">Obbedienza e fede</l>
@@ -3690,20 +3805,20 @@
               <l part="I">Ho il giuro mai?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guntigi">
             <speaker>GUNTIGI</speaker>
             <lg>
               <l part="F">No; ma l'istante è giunto</l>
               <l part="I">Che tu lo illustri con la prova.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amri">
             <speaker>AMRI</speaker>
             <lg>
               <l part="F">Imponi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guntigi">
             <speaker>GUNTIGI</speaker>
             <lg>
               <l>Tocca quest'armi consacrate, e giura</l>
@@ -3712,7 +3827,7 @@
               <l part="I">Mai dal tuo labbro rivelato.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amri">
             <speaker>AMRI</speaker>
             <stage><emph>(ponendo le mani sull'armi) </emph>.</stage>
             <lg>
@@ -3722,7 +3837,7 @@
               <l part="I">Divenir servo d'un Romano.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guntigi">
             <speaker>GUNTIGI</speaker>
             <lg>
               <l part="F">Ascolta.</l>
@@ -3750,14 +3865,14 @@
               <l part="I">Entra ed avvisa.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amri">
             <speaker>AMRI</speaker>
             <lg>
               <l part="F">Come imponi, io tutto</l>
               <l part="I">Farò.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guntigi">
             <speaker>GUNTIGI</speaker>
             <lg>
               <l part="F">Tu servi a gran disegno, e grande</l>
@@ -3768,7 +3883,7 @@
         </div>
         <div type="scene">
           <head>SCENA III </head>
-          <sp>
+          <sp who="#guntigi">
             <speaker>GUNTIGI</speaker>
             <lg>
               <l>Fedeltà! — Che il tristo amico</l>
@@ -3846,13 +3961,13 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>GUNTIGI, SVARTO <emph>condotto da</emph> AMRI.</stage>
-          <sp>
+          <sp who="#svarto">
             <speaker>SVARTO</speaker>
             <lg>
               <l part="I">Guntigi!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guntigi">
             <speaker>GUNTIGI</speaker>
             <lg>
               <l part="M">Svarto!</l>
@@ -3863,13 +3978,13 @@
               <l>Non incontrasti?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amri">
             <speaker>AMRI</speaker>
             <lg>
               <l part="I">Alcun.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guntigi">
             <speaker>GUNTIGI</speaker>
             <lg>
               <l part="F">Qui intorno veglia.</l>
@@ -3880,21 +3995,21 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>GUNTIGI, SVARTO.</stage>
-          <sp>
+          <sp who="#svarto">
             <speaker>SVARTO</speaker>
             <lg>
               <l>Guntigi, io vengo, e il capo mio commetto</l>
               <l part="I">Alla tua fede.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guntigi">
             <speaker>GUNTIGI</speaker>
             <lg>
               <l part="F">E tu n'hai pegno: entrambi</l>
               <l part="I">Un periglio corriamo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#svarto">
             <speaker>SVARTO</speaker>
             <lg>
               <l part="F">E un premio immenso</l>
@@ -3902,7 +4017,7 @@
               <l part="I">D'un popolo e la tua?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guntigi">
             <speaker>GUNTIGI</speaker>
             <lg>
               <l part="F">Quando quel Franco</l>
@@ -3921,13 +4036,13 @@
               <l part="I">Carlo nel suo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#svarto">
             <speaker>SVARTO</speaker>
             <lg>
               <l part="M">Dubbiar ne puoi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guntigi">
             <speaker>GUNTIGI</speaker>
             <lg>
               <l part="F">Ch'io sappia</l>
@@ -3936,7 +4051,7 @@
               <l part="I">Né resta a me che un titol vano.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#svarto">
             <speaker>SVARTO</speaker>
             <lg>
               <l part="F">E giova</l>
@@ -3952,7 +4067,7 @@
               <l part="M">Sei di Pavia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guntigi">
             <speaker>GUNTIGI</speaker>
             <lg>
               <l part="F">Da questo istante</l>
@@ -3961,7 +4076,7 @@
               <l part="I">Nunziami, o Svarto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#svarto">
             <speaker>SVARTO</speaker>
             <lg>
               <l part="F">Ei vuol Pavia; captivo</l>
@@ -3980,7 +4095,7 @@
               <l part="I">Ei regna, e guerra più non v'è.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guntigi">
             <speaker>GUNTIGI</speaker>
             <lg>
               <l part="F">Sì, certo:</l>
@@ -3999,7 +4114,7 @@
               <l part="I">Sfuggir non può.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#svarto">
             <speaker>SVARTO</speaker>
             <lg>
               <l part="F">Felice me, che a Carlo</l>
@@ -4013,7 +4128,7 @@
               <l>L'altra già fu, questa vittoria estrema?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guntigi">
             <speaker>GUNTIGI</speaker>
             <lg>
               <l>Stanchi e sfidati i più, sotto il vessillo</l>
@@ -4028,14 +4143,14 @@
               <l part="I">Ormai nulla sperando...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#svarto">
             <speaker>SVARTO</speaker>
             <lg>
               <l part="F">Ebben, prometti;</l>
               <l part="I">Tutti guadagna.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guntigi">
             <speaker>GUNTIGI</speaker>
             <lg>
               <l part="F">Inutil rischio ei fia.</l>
@@ -4043,7 +4158,7 @@
               <l part="I">Tutto compir si può.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#svarto">
             <speaker>SVARTO</speaker>
             <lg>
               <l part="F">Guntigi, ascolta.</l>
@@ -4055,7 +4170,7 @@
               <l part="I">Di salvati da noi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guntigi">
             <speaker>GUNTIGI</speaker>
             <lg>
               <l part="F">Fiducia, o Svarto,</l>
@@ -4068,7 +4183,7 @@
               <l>Posto in non cal chi glielo diede in mano.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#svarto">
             <speaker>SVARTO</speaker>
             <lg>
               <l>Saggio tu parli e schietto. — Odi; per noi</l>
@@ -4085,20 +4200,20 @@
               <l part="I">Saranno miei.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guntigi">
             <speaker>GUNTIGI</speaker>
             <lg>
               <l part="F">La tua parola, o Svarto,</l>
               <l part="I">Prendo, e la mia ti fermo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#svarto">
             <speaker>SVARTO</speaker>
             <lg>
               <l part="F">In vita e in morte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guntigi">
             <speaker>GUNTIGI</speaker>
             <lg>
               <l part="I">Pegno la destra.</l>
@@ -4109,13 +4224,13 @@
               <l part="I">Reca l'omaggio mio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#svarto">
             <speaker>SVARTO</speaker>
             <lg>
               <l part="M">Doman!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guntigi">
             <speaker>GUNTIGI</speaker>
             <lg>
               <l part="F">Domani.</l>
@@ -4126,21 +4241,21 @@
               <l part="M">È sgombro lo spalto?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amri">
             <speaker>AMRI</speaker>
             <lg>
               <l part="F">È sgombro; e tutto</l>
               <l part="I">Tace d'intorno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#guntigi">
             <speaker>GUNTIGI</speaker>
             <stage><emph>(AD Amri, accennando Svarto)</emph>.</stage>
             <lg>
               <l part="M">Il riconduci.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#svarto">
             <speaker>SVARTO</speaker>
             <lg>
               <l part="F">Addio.</l>
@@ -4154,7 +4269,7 @@
           <head>SCENA I</head>
           <stage><emph>Palazzo Reale in Verona</emph>.</stage>
           <stage>ADELCHI, GISELBERTO<emph>duca di Verona</emph>.</stage>
-          <sp>
+          <sp who="#giselberto">
             <speaker>GISELBERTO</speaker>
             <lg>
               <l>Costretto, o re, dell'oste intera io vengo</l>
@@ -4181,7 +4296,7 @@
               <l part="I">Chieggono il fine.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">Esci: la mia risposta</l>
@@ -4191,7 +4306,7 @@
         </div>
         <div type="scene">
           <head>SCENA II</head>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">Va, vivi, invecchia in pace;</l>
@@ -4280,52 +4395,52 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>ADELCHI, TEUDI</stage>
-          <sp>
+          <sp who="#teudi">
             <speaker>TEUDI</speaker>
             <lg>
               <l part="M">Mio re.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">Restano amici ancora</l>
               <l part="I">Al re che cade?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teudi">
             <speaker>TEUDI</speaker>
             <lg>
               <l part="F">Sì: color che amici</l>
               <l part="I">Eran d'Adelchi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">E che partito han preso?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teudi">
             <speaker>TEUDI</speaker>
             <lg>
               <l part="I">L'aspettano da te.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">Dove son essi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teudi">
             <speaker>TEUDI</speaker>
             <lg>
               <l>Qui nel palazzo tuo, scevri dai tristi</l>
               <l>A cui sol tarda d'esser vinti appieno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l>Tristo, o Teudi, il valor disseminato</l>
@@ -4346,7 +4461,7 @@
               <l part="I">Riposo, o Teudi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#teudi">
             <speaker>TEUDI</speaker>
             <lg>
               <l part="F">Oh! la secondi il cielo.</l>
@@ -4358,7 +4473,7 @@
           <head>SCENA IV </head>
           <stage><emph>Tenda nel campo di Carlo sotto Verona</emph>.</stage>
           <stage>CARLO,<emph>un</emph> ARALDO, ARVINO, CONTI.</stage>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l>Vanne, araldo, in Verona; e al duca, a tutti</l>
@@ -4370,26 +4485,26 @@
             </lg>
             <stage><emph>(l'Araldo parte)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#arvino">
             <speaker>ARVINO</speaker>
             <lg>
               <l>Il vinto re chiede parlarti, o sire.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="I">Che vuol?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#arvino">
             <speaker>ARVINO</speaker>
             <lg>
               <l part="F">Nol disse; ma pietosa istanza</l>
               <l part="I">Egli ne fea.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="M">Venga.</l>
@@ -4411,7 +4526,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>CARLO, DESIDERIO.</stage>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l>A che vieni, infelice? E che parola</l>
@@ -4435,7 +4550,7 @@
               <l part="I">Dono ha Carlo per te.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Re del mio regno,</l>
@@ -4453,27 +4568,27 @@
               <l>È giudizio di sangue a chi lo sdegna.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="I">Parla.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">In difesa d'Adrian, tu il brando</l>
               <l part="I">Contro di me traesti?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="F">A che mi chiedi</l>
               <l part="I">Quello che sai?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Sappi tu ancor che solo</l>
@@ -4484,13 +4599,13 @@
               <l part="I">Mai sempre oppose: indarno!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="M">Ebben?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Compiuta</l>
@@ -4504,14 +4619,14 @@
               <l part="I">Più ti domanda Iddio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="F">Tu legge imponi</l>
               <l part="I">Al vincitor?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Legge? Oh! ne' detti miei</l>
@@ -4524,13 +4639,13 @@
               <l>Gli smisurati desideri il cielo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="I">Cessa.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Ah! m'ascolta: un dì tu ancor potresti</l>
@@ -4555,14 +4670,14 @@
               <l part="I">Che il figliuol mio...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="F">Non più: cosa mi chiedi</l>
               <l>Tu! che da me non otterria Bertrada.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l>Io ti pregava! io, che per certo a prova</l>
@@ -4573,7 +4688,7 @@
               <l>Calca i prostrati, e sali; a Dio rincresci...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l>Taci, tu che sei vinto. E che? pur ieri</l>
@@ -4635,7 +4750,7 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>CARLO, DESIDERIO, ARVINO.</stage>
-          <sp>
+          <sp who="#arvino">
             <speaker>ARVINO</speaker>
             <lg>
               <l>Viva re Carlo! Al cenno tuo, dai valli</l>
@@ -4644,20 +4759,20 @@
               <l>Ognun s'affolla, ed all'omaggio accorre.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l>Ahi dolente, che ascolto! e che mi resta</l>
               <l part="I">Ad ascoltar!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="M">Né alcun vi manca?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#arvino">
             <speaker>ARVINO</speaker>
             <lg>
               <l part="F">Alcuno.</l>
@@ -4667,40 +4782,40 @@
               <l part="I">Presso al morire.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="M">E son?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#arvino">
             <speaker>ARVINO</speaker>
             <lg>
               <l part="F">Tale è presente,</l>
               <l>A cui troppo dorrà, se tutto io dico.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="I">Nunzio di morte, tu l'hai detto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="F">Adelchi</l>
               <l part="I">Dunque perì?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <stage><emph>(ad Arvino)</emph>.</stage>
             <lg>
               <l part="F">Parla, o crudele, al padre.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#arvino">
             <speaker>ARVINO</speaker>
             <lg>
               <l>La luce ei vede, ma per poco, offeso</l>
@@ -4708,14 +4823,14 @@
               <l part="I">E te pur anco, o sire.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">E questo ancora</l>
               <l part="I">Mi negherai?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="F">No, sventurato. — Arvino,</l>
@@ -4727,7 +4842,7 @@
         <div type="scene">
           <head>SCENA VII </head>
           <stage>CARLO, DESIDERIO.</stage>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Oh! come grave</l>
@@ -4750,7 +4865,7 @@
               <l>Innanzi ad uom che in ascoltarli esulta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l>Veglio, t'inganna il tuo dolor. Pensoso,</l>
@@ -4763,7 +4878,7 @@
               <l part="I">La nimistà d'un pio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Dono funesto</l>
@@ -4777,60 +4892,60 @@
         <div type="scene">
           <head>SCENA VIII</head>
           <stage>CARLO, DESIDERIO, ADELCHI <emph>ferito e portato</emph>.</stage>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="I">Ahi, figlio!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">O padre, io ti riveggio! Appressa,</l>
               <l part="I">Tocca la mano del tuo figlio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Orrendo</l>
               <l part="I">M'è il vederti così.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">Molti sul campo</l>
               <l part="I">Cadder così per la mia mano.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Ahi, dunque</l>
               <l>Insanabile, o caro, è questa piaga?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="I">Insanabile.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Ahi lasso! ahi guerra atroce!</l>
               <l>Io crudel che la volli; io che t'uccido!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l>Non tu, né questi, ma il Signor d'entrambi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l>O desiato da quest'occhi, oh quanto</l>
@@ -4840,7 +4955,7 @@
               <l part="I">Ora di pace.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">Ora per me di pace,</l>
@@ -4848,7 +4963,7 @@
               <l part="I">Te dal dolor qua giù non lasci.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Oh fronte</l>
@@ -4856,7 +4971,7 @@
               <l part="I">Che spiravi il terror!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">Cessa i lamenti,</l>
@@ -4888,14 +5003,14 @@
               <l part="I">Questi è un uom che morrà.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Ma ch' io ti perdo,</l>
               <l part="I">Figlio, di ciò chi mi consola?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">Il Dio</l>
@@ -4907,7 +5022,7 @@
               <l part="I">Nemico mio...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="F">Con questo nome, Adelchi,</l>
@@ -4916,7 +5031,7 @@
               <l part="I">Credilo, in cor cape di Carlo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">E amico</l>
@@ -4941,7 +5056,7 @@
               <l part="I">Che vassallo il tradì.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="F">Porta all'avello</l>
@@ -4950,7 +5065,7 @@
               <l part="I">È parola di Carlo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">Il tuo nemico</l>
@@ -4961,7 +5076,7 @@
         <div type="scene">
           <head>SCENA IX</head>
           <stage>ARVINO, CARLO, DESIDERIO, ADELCHI.</stage>
-          <sp>
+          <sp who="#arvino">
             <speaker>ARVINO</speaker>
             <lg>
               <l part="F">Impazienti,</l>
@@ -4969,13 +5084,13 @@
               <l part="I">D'essere ammessi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="M">Carlo!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#carlo">
             <speaker>CARLO</speaker>
             <lg>
               <l part="F">Alcun non osi</l>
@@ -4990,27 +5105,27 @@
         <div type="scene">
           <head>SCENA X</head>
           <stage>DESIDERIO, ADELCHI</stage>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="M">Ahi, mio diletto!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">O padre,</l>
               <l part="I">Fugge la luce da quest'occhi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Adelchi,</l>
               <l part="I">No, non lasciarmi!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#adelchi">
             <speaker>ADELCHI</speaker>
             <lg>
               <l part="F">O Re dei re, tradito</l>
@@ -5019,7 +5134,7 @@
               <l part="I">Accogli.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#desiderio">
             <speaker>DESIDERIO</speaker>
             <lg>
               <l part="F">Ei t'ode: oh ciel! tu manchi! Ed io...</l>

--- a/tei/manzoni-il-conte-di-carmagnola.xml
+++ b/tei/manzoni-il-conte-di-carmagnola.xml
@@ -76,6 +76,67 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="il_doge">
+            <persName>Francesco Foscari</persName>
+          </person>
+          <person xml:id="il_conte">
+            <persName>Conte di Carmangnola</persName>
+          </person>
+          <person xml:id="marino">
+            <persName>Marino</persName>
+          </person>
+          <person xml:id="marco">
+            <persName>Marco</persName>
+          </person>
+          <person xml:id="molti_senatori">
+            <persName>Molti senatori</persName>
+          </person>
+          <person xml:id="pergola">
+            <persName>Pergola</persName>
+          </person>
+          <person xml:id="malatesti">
+            <persName>Carlo Malatesti</persName>
+          </person>
+          <person xml:id="sforza">
+            <persName>Francesco Sforza</persName>
+          </person>
+          <person xml:id="fortebraccio">
+            <persName>Fortebraccio (Nicolò Piccinino)</persName>
+          </person>
+          <person xml:id="torello">
+            <persName>Guido Torello</persName>
+          </person>
+          <person xml:id="soldato">
+            <persName>Soldato</persName>
+          </person>
+          <person xml:id="orsini">
+            <persName>Paolo Francesco Orsini</persName>
+          </person>
+          <person xml:id="tolentino">
+            <persName>Nicolò da Tolentino</persName>
+          </person>
+          <person xml:id="primo_commissario">
+            <persName>Primo Commissario</persName>
+          </person>
+          <person xml:id="secondo_commissario">
+            <persName>Secondo Commissario</persName>
+          </person>
+          <person xml:id="un_prigione">
+            <persName>Un prigione</persName>
+          </person>
+          <person xml:id="gonzaga">
+            <persName>Giovan Francesco Gonzaga</persName>
+          </person>
+          <person xml:id="matilde">
+            <persName>Matilde</persName>
+          </person>
+          <person xml:id="antonietta">
+            <persName>Antonietta Visconti</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -171,7 +232,7 @@
             <emph>Sala del Senato, in Venezia.</emph>
           </stage>
           <stage>IL DOGE <emph>e</emph>SENATORI<emph>seduti.</emph></stage>
-          <sp>
+          <sp who="#il_doge">
             <speaker>IL DOGE</speaker>
             <lg>
               <l>È giunto il fin de' lunghi dubbi, è giunto,</l>
@@ -229,7 +290,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>IL CONTE <emph>e detti</emph>.</stage>
-          <sp>
+          <sp who="#il_doge">
             <speaker>IL DOGE</speaker>
             <lg>
               <l>Conte di Carmagnola, oggi la prima</l>
@@ -245,7 +306,7 @@
               <l>Scudo di vigilanza e di vendetta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l>Serenissimo Doge, ancor null'altro</l>
@@ -261,7 +322,7 @@
               <l>Vostr'alta cortesia posta non era.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_doge">
             <speaker>IL DOGE</speaker>
             <lg>
               <l>Certo gran cose, ove il bisogno il chiegga,</l>
@@ -273,7 +334,7 @@
               <l part="I">Non farà picciol peso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">E senno e braccio</l>
@@ -285,14 +346,14 @@
               <l>Un cuor che agogna sol d'esser ben noto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_doge">
             <speaker>IL DOGE</speaker>
             <lg>
               <l>Dite: a questa adunanza indifferente</l>
               <l>Cosa che a cor vi stia giunger non puote.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l>Serenissimo Doge, Senatori;</l>
@@ -351,7 +412,7 @@
               <l part="I">Che giusta cosa imprende.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_doge">
             <speaker>IL DOGE</speaker>
             <lg>
               <l part="F">E tal vi tiene</l>
@@ -365,7 +426,7 @@
               <l>Il vostro schietto consigliar ci sia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l>Lieto son'io che un tal consiglio io possa</l>
@@ -414,7 +475,7 @@
               <l>Questo momento: ardir prudenza or fia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_doge">
             <speaker>IL DOGE</speaker>
             <lg>
               <l>Conte, su questo fedel vostro avviso</l>
@@ -428,7 +489,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>IL DOGE <emph>e</emph> SENATORI.</stage>
-          <sp>
+          <sp who="#il_doge">
             <speaker>IL DOGE</speaker>
             <lg>
               <l>Dissimil certo da sì nobil voto</l>
@@ -455,7 +516,7 @@
               <l>Genti da terra abbia il comando il Conte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marino">
             <speaker>MARINO</speaker>
             <lg>
               <l>Contro sì giusta e necessaria guerra</l>
@@ -505,7 +566,7 @@
               <l>La nostra sconoscenza, e i suoi gran merti?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_doge">
             <speaker>IL DOGE</speaker>
             <lg>
               <l>Il Conte un Prence abbandonò; ma quale?</l>
@@ -525,7 +586,7 @@
               <l>Un cauto e franco cavalier non voglia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marino">
             <speaker>MARINO</speaker>
             <lg>
               <l>Poiché sì certo è di quest'uomo il Doge,</l>
@@ -533,7 +594,7 @@
               <l>Vuolsi egli far mallevador del Conte?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_doge">
             <speaker>IL DOGE</speaker>
             <lg>
               <l>A sì preciso interrogar, preciso</l>
@@ -549,7 +610,7 @@
               <l>E braccio che invisibile il raggiunga?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>MARCO</speaker>
             <lg>
               <l>Perché i principj di sì bella impresa</l>
@@ -572,13 +633,13 @@
               <l part="I">Sia da noi ricevuto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#molti_senatori">
             <speaker>MOLTI SENATORI</speaker>
             <lg>
               <l part="F">Ai voti, ai voti!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_doge">
             <speaker>IL DOGE</speaker>
             <lg>
               <l>Si raccolgano i voti — e ognun rammenti</l>
@@ -595,7 +656,7 @@
           <stage>
             <emph>Casa del Conte.</emph>
           </stage>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l>Profugo — o condottiero. — O come il vecchio</l>
@@ -627,19 +688,19 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>MARCO<emph>e il</emph>CONTE.</stage>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l>O dolce amico — ebben che nunzio arrechi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>MARCO</speaker>
             <lg>
               <l>La guerra è risoluta, e tu sei duce.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l>Marco, ad impresa io non m'accinsi mai</l>
@@ -654,7 +715,7 @@
               <l part="I">E alla grandezza sua. —</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>MARCO</speaker>
             <lg>
               <l part="F">Dolce disegno!</l>
@@ -662,13 +723,13 @@
               <l part="I">O tu medesmo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="M">Io — come?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>MARCO</speaker>
             <lg>
               <l part="F">Al par di tutti</l>
@@ -685,14 +746,14 @@
               <l>Come nel tempio del mio cor, rinchiusa.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l>Forse io l'ignoro? E forse ad uno ad uno</l>
               <l part="I">Non so quai sièno i miei nemici?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>MARCO</speaker>
             <lg>
               <l part="F">E sai</l>
@@ -716,7 +777,7 @@
               <l>Nel senno tuo, quando tu vuoi, la trovi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l>Troppo è il tuo dir verace: il tuo consiglio</l>
@@ -741,7 +802,7 @@
               <l part="I">Rispondi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>MARCO</speaker>
             <lg>
               <l part="F">È ver: se v'ha mortal di cui</l>
@@ -778,7 +839,7 @@
               <l>Signor di sé che non pensava in prima.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l>Tu hai ragione. Il ciel si piglia al certo</l>
@@ -792,7 +853,7 @@
               <l part="I">Di tue parole.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>MARCO</speaker>
             <lg>
               <l part="F">Or la mia gioja è intera.</l>
@@ -814,7 +875,7 @@
             <emph>Parte del campo ducale con tende.</emph>
           </stage>
           <stage>MALATESTI e PERGOLA.</stage>
-          <sp>
+          <sp who="#pergola">
             <speaker>PERGOLA</speaker>
             <lg>
               <l>Sì, condottier; come ordinaste, in pronto</l>
@@ -824,7 +885,7 @@
               <l part="I">Non diam battaglia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#malatesti">
             <speaker>MALATESTI</speaker>
             <lg>
               <l part="F">Anzian d'anni e di fama,</l>
@@ -838,7 +899,7 @@
               <l part="I">Che saria danno e scorno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pergola">
             <speaker>PERGOLA</speaker>
             <lg>
               <l part="F">A pochi è dato,</l>
@@ -878,7 +939,7 @@
               <l>Senza svantaggio almanco, si decida.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#malatesti">
             <speaker>MALATESTI</speaker>
             <lg>
               <l>Due grandi schiere a fronte stanno; e grande</l>
@@ -899,7 +960,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>SFORZA FORTEBRACCIO <emph>e detti</emph>.</stage>
-          <sp>
+          <sp who="#malatesti">
             <speaker>MALATESTI</speaker>
             <lg>
               <l part="F">Ditelo, o Sforza,</l>
@@ -908,7 +969,7 @@
               <l part="I">Che possiamo sperarne?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sforza">
             <speaker>SFORZA</speaker>
             <lg>
               <l part="F">Ogni gran cosa.</l>
@@ -922,7 +983,7 @@
               <l>Parea dicesse: o condottier, v'intendo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#fortebraccio">
             <speaker>FORTEBRACCIO</speaker>
             <lg>
               <l>E tai son tutti: allor ch'io venni a' miei,</l>
@@ -945,7 +1006,7 @@
               <l part="I">Con tal ordine ormai?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pergola">
             <speaker>PERGOLA</speaker>
             <lg>
               <l part="F">Dal parlar vostro</l>
@@ -954,7 +1015,7 @@
               <l part="I">Obbediscano.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#fortebraccio">
             <speaker>FORTEBRACCIO</speaker>
             <lg>
               <l part="F">O Pergola, i soldati</l>
@@ -965,7 +1026,7 @@
               <l part="I">Dell'inimico.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pergola">
             <speaker>PERGOLA</speaker>
             <lg>
               <l part="F">Ed io conduco genti</l>
@@ -974,7 +1035,7 @@
               <l>Del condottiero, ed a fidarsi in lui.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#malatesti">
             <speaker>MALATESTI</speaker>
             <lg>
               <l>Dimentichiamo or noi che numerati</l>
@@ -986,7 +1047,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>TORELLO<emph>e detti</emph>.</stage>
-          <sp>
+          <sp who="#sforza">
             <speaker>SFORZA</speaker>
             <lg>
               <l part="F">Ebben, Torello,</l>
@@ -994,7 +1055,7 @@
               <l part="I">L'animo ardente de' soldati?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torello">
             <speaker>TORELLO</speaker>
             <lg>
               <l part="F">Il vidi;</l>
@@ -1039,13 +1100,13 @@
               <l part="I">Di battaglia per noi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#malatesti">
             <speaker>MALATESTI</speaker>
             <lg>
               <l part="M">Dunque?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torello">
             <speaker>TORELLO</speaker>
             <lg>
               <l part="F">Si muti.</l>
@@ -1053,7 +1114,7 @@
               <l part="I">Dove lo siam.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#malatesti">
             <speaker>MALATESTI</speaker>
             <lg>
               <l part="F">Così Maclodio a lui</l>
@@ -1062,7 +1123,7 @@
               <l part="I">Più che due giorni.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torello">
             <speaker>TORELLO</speaker>
             <lg>
               <l part="F">Il so; ma non si tratta</l>
@@ -1070,7 +1131,7 @@
               <l part="I">Trattasi dello Stato.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sforza">
             <speaker>SFORZA</speaker>
             <lg>
               <l part="F">E di che mai</l>
@@ -1088,14 +1149,14 @@
               <l part="I">Sfacciato insulta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torello">
             <speaker>TORELLO</speaker>
             <lg>
               <l part="F">E questo è segno, o Sforza,</l>
               <l part="I">Ch'ei brama una battaglia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sforza">
             <speaker>SFORZA</speaker>
             <lg>
               <l part="F">Oh, che puot'egli</l>
@@ -1103,7 +1164,7 @@
               <l part="I">Colla spada nel fodero?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pergola">
             <speaker>PERGOLA</speaker>
             <lg>
               <l part="F">Che puote</l>
@@ -1114,7 +1175,7 @@
               <l part="I">Ripigliar con gli eserciti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#fortebraccio">
             <speaker>FORTEBRACCIO</speaker>
             <lg>
               <l part="F">Con quali?</l>
@@ -1129,7 +1190,7 @@
               <l part="I">Perché lasciarli irrugginir?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sforza">
             <speaker>SFORZA</speaker>
             <lg>
               <l part="F">Torello,</l>
@@ -1144,20 +1205,20 @@
               <l>Dovunque sia, sul suo terreno è sempre.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#fortebraccio">
             <speaker>FORTEBRACCIO</speaker>
             <stage><emph>(a Pergola e Torello)</emph>.</stage>
             <lg>
               <l part="I">Siete convinti?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torello">
             <speaker>TORELLO</speaker>
             <lg>
               <l part="M">Sofferite...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#malatesti">
             <speaker>MALATESTI</speaker>
             <lg>
               <l part="F">Io il sono.</l>
@@ -1187,19 +1248,19 @@
               <l>Retrocedere a voi non ci vedrete.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#fortebraccio">
             <speaker>FORTEBRACCIO</speaker>
             <lg>
               <l part="I">Non ci vedrete, no.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sforza">
             <speaker>SFORZA</speaker>
             <lg>
               <l part="F">Siatene certi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#fortebraccio">
             <speaker>FORTEBRACCIO</speaker>
             <lg>
               <l>Sia lode al ciel, combatteremo alfine:</l>
@@ -1207,7 +1268,7 @@
               <l>Per fare il suo mestier contender tanto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pergola">
             <speaker>PERGOLA</speaker>
             <lg>
               <l>O Carmagnola, tu pensasti che oggi</l>
@@ -1215,7 +1276,7 @@
               <l>Prevarrebbe dei vecchi: e ti apponesti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#fortebraccio">
             <speaker>FORTEBRACCIO</speaker>
             <lg>
               <l>Sì, la prudenza è la virtù dei vecchi:</l>
@@ -1223,26 +1284,26 @@
               <l part="I">Che alfin diventa...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pergola">
             <speaker>PERGOLA</speaker>
             <lg>
               <l part="M">Ebben, dite.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#fortebraccio">
             <speaker>FORTEBRACCIO</speaker>
             <lg>
               <l part="F">Paura;</l>
               <l>Poi che volete ad ogni modo udirlo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#malatesti">
             <speaker>MALATESTI</speaker>
             <lg>
               <l part="I">Fortebraccio!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pergola">
             <speaker>PERGOLA</speaker>
             <lg>
               <l part="F">L'hai detto. Ad un soldato</l>
@@ -1251,7 +1312,7 @@
               <l part="I">Oggi tu il primo hai detto...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#malatesti">
             <speaker>MALATESTI</speaker>
             <lg>
               <l part="F">Da quel lato,</l>
@@ -1261,7 +1322,7 @@
               <l>un traditor: pensatamente il dico.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pergola">
             <speaker>PERGOLA</speaker>
             <lg>
               <l>Ritratto il voto che dapprima io diedi;</l>
@@ -1271,7 +1332,7 @@
               <l part="I">Io son per la battaglia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#malatesti">
             <speaker>MALATESTI</speaker>
             <lg>
               <l part="F">Accetto il voto,</l>
@@ -1279,20 +1340,20 @@
               <l part="I">Sul capo del nemico.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pergola">
             <speaker>PERGOLA</speaker>
             <lg>
               <l part="F">O Fortebraccio,</l>
               <l part="I">Tu m'hai offeso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#malatesti">
             <speaker>MALATESTI</speaker>
             <lg>
               <l part="M">Or via...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#fortebraccio">
             <speaker>FORTEBRACCIO</speaker>
             <lg>
               <l part="F">Se così credi,</l>
@@ -1302,7 +1363,7 @@
               <l part="I">Dalle labbra mi sia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#malatesti">
             <speaker>MALATESTI</speaker>
             <stage><emph>(in atto di partire)</emph>.</stage>
             <lg>
@@ -1310,7 +1371,7 @@
               <l part="I">A Filippo, mi segua.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pergola">
             <speaker>PERGOLA</speaker>
             <lg>
               <l part="F">Io vi prometto</l>
@@ -1322,13 +1383,13 @@
               <l part="I">Intatto il tuo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#fortebraccio">
             <speaker>FORTEBRACCIO</speaker>
             <lg>
               <l part="M">Che vuoi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pergola">
             <speaker>PERGOLA</speaker>
             <lg>
               <l part="F">Dammi il tuo posto.</l>
@@ -1339,7 +1400,7 @@
               <l part="I">Ch'io non ho... tu m'intendi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#fortebraccio">
             <speaker>FORTEBRACCIO</speaker>
             <lg>
               <l part="F">Io son contento,</l>
@@ -1355,7 +1416,7 @@
               <l part="I">Pensavi tu?...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pergola">
             <speaker>PERGOLA</speaker>
             <lg>
               <l part="F">Nulla pensai: tu parli</l>
@@ -1367,7 +1428,7 @@
               <l part="I">Voi consentite al cambio?...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#malatesti">
             <speaker>MALATESTI</speaker>
             <lg>
               <l part="F">Io v'acconsento;</l>
@@ -1375,7 +1436,7 @@
               <l part="I">Tutta cader sovra il nemico.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torello">
             <speaker>TORELLO</speaker>
             <stage><emph>(allo Sforza)</emph>.</stage>
             <lg>
@@ -1384,7 +1445,7 @@
               <l part="I">Non vi parrà...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sforza">
             <speaker>SFORZA</speaker>
             <lg>
               <l part="F">V'intendo; e con lui state</l>
@@ -1392,7 +1453,7 @@
               <l>Combatterem; poco m'importa il dove.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#malatesti">
             <speaker>MALATESTI</speaker>
             <lg>
               <l>Non più ritardi. Iddio sarà coi prodi.</l>
@@ -1404,20 +1465,20 @@
           <head>SCENA IV </head>
           <stage><emph>Campo veneziano. Tenda del Conte</emph>.</stage>
           <stage>IL CONTE,<emph>poi un Soldato che sopraggiunge</emph></stage>
-          <sp>
+          <sp who="#soldato">
             <speaker>SOLDATO</speaker>
             <lg>
               <l>Signor, l'oste nemica è in movimento:</l>
               <l>La vanguardia è sull'argine, e s'avanza.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="I">I condottieri dove son?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#soldato">
             <speaker>SOLDATO</speaker>
             <lg>
               <l part="F">Qui tutti</l>
@@ -1425,7 +1486,7 @@
               <l part="I">Gli ordin vostri aspettando.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">Entrino tosto.</l>
@@ -1435,7 +1496,7 @@
         </div>
         <div type="scene">
           <head>SCENA V</head>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l>Eccolo il dì ch'io bramai tanto. — Il giorno</l>
@@ -1456,7 +1517,7 @@
         <div type="scene">
           <head>SCENA VI </head>
           <stage>IL CONTE, GONZAGA, ORSINI, TOLENTINO, <emph>altri</emph> CONDOTTIERI.</stage>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">Compagni, udiste</l>
@@ -1472,13 +1533,13 @@
               <l part="I">Son pronti i tuoi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#orsini">
             <speaker>ORSINI</speaker>
             <lg>
               <l part="M">Sì.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">Corri all'imboscate</l>
@@ -1494,21 +1555,21 @@
               <l>Provochi, o fugga, oggi dev'esser vinto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#orsini">
             <speaker>ORSINI</speaker>
             <lg>
               <l part="I">Ei lo sarà.</l>
             </lg>
             <stage><emph>(parte)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#tolentino">
             <speaker>TOLENTINO</speaker>
             <lg>
               <l part="F">T'ubbidirem, vedrai.</l>
             </lg>
             <stage><emph>(parte)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <stage>
               <emph>(agli altri).</emph>
@@ -1693,13 +1754,13 @@
           <head>SCENA I</head>
           <stage><emph>Tenda del Conte</emph>.</stage>
           <stage>IL CONTE <emph>e il</emph> PRIMO COMMISSARIO.</stage>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="I">Siete contenti?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#primo_commissario">
             <speaker>PRIMO COMMISSARIO</speaker>
             <lg>
               <l part="F">Udir l'alto trionfo</l>
@@ -1720,7 +1781,7 @@
               <l part="I">Ei sarà pari al merto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">Io già lo tengo.</l>
@@ -1730,20 +1791,20 @@
               <l part="I">Dimenticato; ho vinto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#primo_commissario">
             <speaker>PRIMO COMMISSARIO</speaker>
             <lg>
               <l part="F">Ed or si vuole</l>
               <l>Assicurar della vittoria il frutto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="I">... Questa è mia cura.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#primo_commissario">
             <speaker>PRIMO COMMISSARIO</speaker>
             <lg>
               <l part="F">Or che dal vostro brando</l>
@@ -1752,26 +1813,26 @@
               <l>Che non si giunga del nemico al trono.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="I">Quando fia tempo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#primo_commissario">
             <speaker>PRIMO COMMISSARIO</speaker>
             <lg>
               <l part="F">E che? Voi non volete</l>
               <l part="I">Inseguire i fuggenti?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">Or non lo voglio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#primo_commissario">
             <speaker>PRIMO COMMISSARIO</speaker>
             <lg>
               <l>Ma il Senato lo crede... E noi ben certi</l>
@@ -1780,34 +1841,34 @@
               <l part="I">Nel proseguirla, abbiamo a lui...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">Vi siete</l>
               <l part="I">Troppo affrettati.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#primo_commissario">
             <speaker>PRIMO COMMISSARIO</speaker>
             <lg>
               <l part="F">E che dirà mai quando</l>
               <l part="I">Udrà che ancor siam qui?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">Dirà, che il meglio</l>
               <l>È di fidarsi a chi per lui già vinse.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#primo_commissario">
             <speaker>PRIMO COMMISSARIO</speaker>
             <lg>
               <l part="I">Ma... che pensate far?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">Ve l'avrei detto</l>
@@ -1818,13 +1879,13 @@
               <l>Voglio un solo nemico, e quello in faccia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#primo_commissario">
             <speaker>PRIMO COMMISSARIO</speaker>
             <lg>
               <l part="I">Or dunque i nostri voti...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">I vostri voti</l>
@@ -1833,13 +1894,13 @@
               <l>È che mi sento dir pur ch'io m'affretti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#primo_commissario">
             <speaker>PRIMO COMMISSARIO</speaker>
             <lg>
               <l part="I">Ma pensaste abbastanza?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">E che! Sì nuova</l>
@@ -1853,7 +1914,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>IL SECONDO COMMISSARIO <emph>e detti</emph>.</stage>
-          <sp>
+          <sp who="#secondo_commissario">
             <speaker>SECONDO COMMISSARIO</speaker>
             <lg>
               <l part="F">Signor, se tosto</l>
@@ -1862,13 +1923,13 @@
               <l>Sì gran vittoria; e già l'ha fatto in parte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="I">Come?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#secondo_commissario">
             <speaker>SECONDO COMMISSARIO</speaker>
             <lg>
               <l part="F">I prigioni escon del campo a torme;</l>
@@ -1877,19 +1938,19 @@
               <l part="I">Fuor che un vostro comando.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">Un mio comando?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#secondo_commissario">
             <speaker>SECONDO COMMISSARIO</speaker>
             <lg>
               <l part="I">Esitereste a darlo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">È questo un uso</l>
@@ -1902,7 +1963,7 @@
               <l>Son generosi, perché ier fur prodi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#secondo_commissario">
             <speaker>SECONDO COMMISSARIO</speaker>
             <lg>
               <l>Sia generoso chi per sé combatte,</l>
@@ -1911,7 +1972,7 @@
               <l part="I">Sono i prigioni.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">E voi potete adunque</l>
@@ -1921,7 +1982,7 @@
               <l part="I">Nol crederan sì di leggieri.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#primo_commissario">
             <speaker>PRIMO COMMISSARIO</speaker>
             <lg>
               <l part="F">È questa</l>
@@ -1930,7 +1991,7 @@
               <l part="I">Fia la vittoria?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">Io già l'udii, di novo</l>
@@ -1964,14 +2025,14 @@
               <l>Li comprerà... Comprateli, e son vostri.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#primo_commissario">
             <speaker>PRIMO COMMISSARIO</speaker>
             <lg>
               <l>Quando assoldammo chi dovea con essi</l>
               <l>Pugnar, comprarli noi credemmo allora.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#secondo_commissario">
             <speaker>SECONDO COMMISSARIO</speaker>
             <lg>
               <l>Signor, Venezia in voi si fida; in voi</l>
@@ -1980,26 +2041,26 @@
               <l part="I">Che si faccia da voi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">Tutto ch'io posso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#secondo_commissario">
             <speaker>SECONDO COMMISSARIO</speaker>
             <lg>
               <l>Ebben, che non potete in questo campo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l>Quel che chiedete: un uso antico, un uso</l>
               <l>Caro ai soldati violar non posso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#secondo_commissario">
             <speaker>SECONDO COMMISSARIO</speaker>
             <lg>
               <l>Voi cui nulla resiste, a cui sì pronto</l>
@@ -2009,7 +2070,7 @@
               <l part="I">Fare una legge, e mantenerla?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">Io dissi</l>
@@ -2020,13 +2081,13 @@
               <l>Apertamente rifiutar. — Soldati!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#secondo_commissario">
             <speaker>SECONDO COMMISSARIO</speaker>
             <lg>
               <l part="I">Ma... che disegno è il vostro?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">Or lo vedrete.</l>
@@ -2036,14 +2097,14 @@
               <l part="I">Quanti prigion restano ancora?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#soldato">
             <speaker>SOLDATO</speaker>
             <lg>
               <l part="F">Io credo</l>
               <l part="I">Quattrocento, signor.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">Chiamali... chiama</l>
@@ -2070,7 +2131,7 @@
               <l part="I">M'astringerete a dubitar...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#secondo_commissario">
             <speaker>SECONDO COMMISSARIO</speaker>
             <lg>
               <l part="F">Che dite!</l>
@@ -2080,7 +2141,7 @@
         <div type="scene">
           <head>SCENA III </head>
           <stage>I PRIGIONI,<emph>fra i quali</emph> PERGOLA <emph>figlio, e detti</emph></stage>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <stage><emph> (ai Prigioni)</emph>.</stage>
             <lg>
@@ -2089,7 +2150,7 @@
               <l>Siete alla trista prigionia serbati?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#un_prigione">
             <speaker>UN PRIGIONE</speaker>
             <lg>
               <l>Tale, eccelso signor, non era il nostro</l>
@@ -2100,13 +2161,13 @@
               <l>Minor di voi, caddero in mano; e noi...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="I">Voi, di chi siete prigionier?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#un_prigione">
             <speaker>UN PRIGIONE</speaker>
             <lg>
               <l part="F">Noi fummo</l>
@@ -2118,7 +2179,7 @@
               <l>Ma reliquie de' vinti, — al drappel vostro...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l>Voi siete quelli? Io son contento, amici</l>
@@ -2129,7 +2190,7 @@
               <l part="I">Piacevol tresca esservi a fronte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#un_prigione">
             <speaker>UN PRIGIONE</speaker>
             <lg>
               <l part="F">Ed ora</l>
@@ -2147,7 +2208,7 @@
               <l>Esser piuttosto ad inventarla il primo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l>Voi gli udite, o Signori... Ebben, che dite? ...</l>
@@ -2173,14 +2234,14 @@
               <l part="I">Con gli altri, e taci?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pergola">
             <speaker>PERGOLA</speaker>
             <lg>
               <l part="F">O capitano, i vinti</l>
               <l part="I">Non han nulla da dir.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">Questa fortuna</l>
@@ -2188,7 +2249,7 @@
               <l part="I">D'una miglior. Quale è il tuo nome?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pergola">
             <speaker>PERGOLA</speaker>
             <lg>
               <l part="F">Un nome</l>
@@ -2197,20 +2258,20 @@
               <l part="I">Pergola è il nome mio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">Che? Tu sei figlio</l>
               <l part="I">Di quel valente?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pergola">
             <speaker>PERGOLA</speaker>
             <lg>
               <l part="M">Io il son.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">Vieni ed abbraccia</l>
@@ -2226,14 +2287,14 @@
               <l part="I">Ch'ei non volea questa battaglia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#pergola">
             <speaker>PERGOLA</speaker>
             <lg>
               <l part="F">Ah! certo,</l>
               <l>Non la volea; ma fur parole al vento.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l>Non ti doler: del capitano è l'onta</l>
@@ -2258,7 +2319,7 @@
         <div type="scene">
           <head>SCENA IV </head>
           <stage><emph>I due</emph> COMMISSARI.</stage>
-          <sp>
+          <sp who="#secondo_commissario">
             <speaker>SECONDO COMMISSARIO</speaker>
             <stage><emph>(dopo qualche silenzio)</emph>.</stage>
             <lg>
@@ -2274,7 +2335,7 @@
               <l part="I">Vi basta questo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#primo_commissario">
             <speaker>PRIMO COMMISSARIO</speaker>
             <lg>
               <l part="F">C'è di più. Gli dissi</l>
@@ -2282,27 +2343,27 @@
               <l part="I">Ei ricusò.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#secondo_commissario">
             <speaker>SECONDO COMMISSARIO</speaker>
             <lg>
               <l part="M">Ma che rispose?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#primo_commissario">
             <speaker>PRIMO COMMISSARIO</speaker>
             <lg>
               <l part="F">Ei vuole</l>
               <l>Assicurarsi delle rocche... ei teme...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#secondo_commissario">
             <speaker>SECONDO COMMISSARIO</speaker>
             <lg>
               <l>Cauto ad un tratto è divenuto — e dopo</l>
               <l part="I">Una vittoria.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#primo_commissario">
             <speaker>PRIMO COMMISSARIO</speaker>
             <lg>
               <l part="F">La parola a stento</l>
@@ -2311,7 +2372,7 @@
               <l>Il tuo segreto che per nulla il tocca.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#secondo_commissario">
             <speaker>SECONDO COMMISSARIO</speaker>
             <lg>
               <l>Ma — l'ha poi detto il suo segreto? E questo</l>
@@ -2319,7 +2380,7 @@
               <l>Vi parve il solo suo motivo — il vero?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#primo_commissario">
             <speaker>PRIMO COMMISSARIO</speaker>
             <lg>
               <l>Nol so, non vi badai, tempo non ebbi</l>
@@ -2328,7 +2389,7 @@
               <l part="I">Inusitate ai pari nostri</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#secondo_commissario">
             <speaker>SECONDO COMMISSARIO</speaker>
             <lg>
               <l part="F">E s'egli</l>
@@ -2353,13 +2414,13 @@
               <l>Sovr'ogni cosa il comandar davvero?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#primo_commissario">
             <speaker>PRIMO COMMISSARIO</speaker>
             <lg>
               <l part="I">Tutto io m'aspetto da costui.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#secondo_commissario">
             <speaker>SECONDO COMMISSARIO</speaker>
             <lg>
               <l part="F">Teniamo</l>
@@ -2379,7 +2440,7 @@
               <l>Col suo confuso de' Visconti il sangue?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#primo_commissario">
             <speaker>PRIMO COMMISSARIO</speaker>
             <lg>
               <l>Come parlò! Come passò dall'ira</l>
@@ -2395,7 +2456,7 @@
               <l part="I">Che avviso è il vostro?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#secondo_commissario">
             <speaker>SECONDO COMMISSARIO</speaker>
             <lg>
               <l part="F">Avvene due? Soffrire,</l>
@@ -2411,7 +2472,7 @@
               <l>Scriverne ai Dieci, ed aspettar comandi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#primo_commissario">
             <speaker>PRIMO COMMISSARIO</speaker>
             <lg>
               <l>Viver così! Che si diria di noi?</l>
@@ -2420,7 +2481,7 @@
               <l part="I">Diviene?...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#secondo_commissario">
             <speaker>SECONDO COMMISSARIO</speaker>
             <lg>
               <l part="F">È sempre glorioso il posto</l>
@@ -2439,13 +2500,13 @@
               <l>E nel pensiero de' nemici in cima.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#primo_commissario">
             <speaker>PRIMO COMMISSARIO</speaker>
             <lg>
               <l part="I">Ma siamo in tempo? Ei già sospetta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#secondo_commissario">
             <speaker>SECONDO COMMISSARIO</speaker>
             <lg>
               <l part="F">Il siamo.</l>
@@ -2463,7 +2524,7 @@
               <l part="I">Saremmo ancora i Signor noi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#primo_commissario">
             <speaker>PRIMO COMMISSARIO</speaker>
             <lg>
               <l part="F">Sta bene.</l>
@@ -2481,14 +2542,14 @@
             <emph>Sala dei Capi del Consiglio dei Dieci, in Venezia.</emph>
           </stage>
           <stage>MARCO <emph>Senatore, e</emph> MARINO <emph>uno dei Capi.</emph></stage>
-          <sp>
+          <sp who="#marco">
             <speaker>MARCO</speaker>
             <lg>
               <l>Eccomi al cenno degli eccelsi Capi</l>
               <l part="I">Del Consiglio dei Dieci.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marino">
             <speaker>MARINO</speaker>
             <lg>
               <l part="F">Io parlo in nome</l>
@@ -2498,7 +2559,7 @@
               <l part="I">Coscienza il diravvi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>MARCO</speaker>
             <lg>
               <l part="F">Ella mi dice</l>
@@ -2507,7 +2568,7 @@
               <l part="I">Alla fede ed al cor.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marino">
             <speaker>MARINO</speaker>
             <lg>
               <l part="F">La patria! È un nome</l>
@@ -2517,13 +2578,13 @@
               <l part="I">De' suoi nemici.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>MARCO</speaker>
             <lg>
               <l part="M">Ed io...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marino">
             <speaker>MARINO</speaker>
             <lg>
               <l part="F">Per chi parlaste</l>
@@ -2534,7 +2595,7 @@
               <l part="I">Voi solo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>MARCO</speaker>
             <lg>
               <l part="F">Io so davanti a chi mi trovo.</l>
@@ -2545,7 +2606,7 @@
               <l part="I">Pur disposto son io.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marino">
             <speaker>MARINO</speaker>
             <lg>
               <l part="F">Tutto che puote</l>
@@ -2558,14 +2619,14 @@
               <l>La vostra vita interrogar che un giorno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>MARCO</speaker>
             <lg>
               <l>E che? fors'altro mi si appon? Di nulla</l>
               <l part="I">Temer poss'io; la mia condotta...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marino">
             <speaker>MARINO</speaker>
             <lg>
               <l part="F">È nota</l>
@@ -2574,14 +2635,14 @@
               <l part="I">Il nostro libro non obblia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>MARCO</speaker>
             <lg>
               <l part="F">Di tutto</l>
               <l part="I">Ragion darò.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marino">
             <speaker>MARINO</speaker>
             <lg>
               <l part="F">Voi la darete quando</l>
@@ -2647,7 +2708,7 @@
               <l>Porre il segreto dello Stato in salvo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>MARCO</speaker>
             <lg>
               <l>Signor, tutto a voi lice. Innanzi a voi</l>
@@ -2659,7 +2720,7 @@
               <l part="I">A me non men che altrui.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marino">
             <speaker>MARINO</speaker>
             <lg>
               <l part="F">Volete alfine</l>
@@ -2670,7 +2731,7 @@
               <l part="I">È gran clemenza.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>MARCO</speaker>
             <lg>
               <l part="F">Io sono amico al Conte:</l>
@@ -2760,13 +2821,13 @@
               <l>Per tirarlo nel laccio... allor, nol nego...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marino">
             <speaker>MARINO</speaker>
             <lg>
               <l part="I">Più non pensaste che all'amico.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>MARCO</speaker>
             <lg>
               <l part="F">Allora,</l>
@@ -2786,7 +2847,7 @@
               <l part="I">Senza farsi...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marino">
             <speaker>MARINO</speaker>
             <lg>
               <l part="F">Non più: se tanto udii</l>
@@ -2810,13 +2871,13 @@
               <l>Compir si dèe. — Voi, che pensieri avete?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>MARCO</speaker>
             <lg>
               <l part="I">Quale inchiesta, Signor!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marino">
             <speaker>MARINO</speaker>
             <lg>
               <l part="F">Voi siete a parte</l>
@@ -2824,7 +2885,7 @@
               <l part="I">Che a vòto ei vada — non è ver?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>MARCO</speaker>
             <lg>
               <l part="F">Che importa</l>
@@ -2833,7 +2894,7 @@
               <l part="I">Il desiderio, ma il dover.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marino">
             <speaker>MARINO</speaker>
             <lg>
               <l part="F">Qual pegno</l>
@@ -2843,13 +2904,13 @@
               <l>Quel che si serba ai traditor, v'è noto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>MARCO</speaker>
             <lg>
               <l part="I">Io... Che si vuol da me?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marino">
             <speaker>MARINO</speaker>
             <lg>
               <l part="F">Riconoscete</l>
@@ -2862,14 +2923,14 @@
               <l part="I">La strada al pentimento.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>MARCO</speaker>
             <lg>
               <l part="F">Al pentimento!</l>
               <l part="I">Ebben, che strada?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marino">
             <speaker>MARINO</speaker>
             <lg>
               <l part="F">Il Musulman disegna</l>
@@ -2879,13 +2940,13 @@
               <l part="I">Voi partirete.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>MARCO</speaker>
             <lg>
               <l part="M">Ubbidirò.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marino">
             <speaker>MARINO</speaker>
             <lg>
               <l part="F">Ma un'arra</l>
@@ -2899,14 +2960,14 @@
               <l part="I">Sottoscrivete.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>MARCO</speaker>
             <stage><emph>(legge)</emph>.</stage>
             <lg>
               <l part="F">E che, signor? Non basta? ...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marino">
             <speaker>MARINO</speaker>
             <lg>
               <l>E per ultimo, udite. Il messo è in via</l>
@@ -2923,14 +2984,14 @@
             </lg>
             <stage><emph>(gli porge il foglio)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#marco">
             <speaker>MARCO</speaker>
             <lg>
               <l part="F">Io scrivo. —</l>
             </lg>
             <stage><emph>(piglia il foglio e lo sottoscrive)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#marino">
             <speaker>MARINO</speaker>
             <lg>
               <l>Tutto è posto in obblio. La vostra fede</l>
@@ -2944,7 +3005,7 @@
         </div>
         <div type="scene">
           <head>SCENA II</head>
-          <sp>
+          <sp who="#marco">
             <speaker>MARCO</speaker>
             <lg>
               <l>Dunque è deciso! ... un vil son io! ... fui posto</l>
@@ -3036,13 +3097,13 @@
           <head>SCENA III</head>
           <stage><emph>Tenda del Conte</emph>.</stage>
           <stage>IL CONTE <emph>e</emph> GONZAGA.</stage>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="I">Ebben, che raccogliesti?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#gonzaga">
             <speaker>GONZAGA</speaker>
             <lg>
               <l part="F">Io favellai,</l>
@@ -3059,13 +3120,13 @@
               <l>Commessa al senno ed al voler d'un solo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="I">Che dicon essi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#gonzaga">
             <speaker>GONZAGA</speaker>
             <lg>
               <l part="F">Si mostrar convinti</l>
@@ -3078,7 +3139,7 @@
               <l part="I">Da te l'ammenda aspettano.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">Tu il vedi,</l>
@@ -3095,7 +3156,7 @@
               <l part="I">Saggi sempre e cortesi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#gonzaga">
             <speaker>GONZAGA</speaker>
             <lg>
               <l part="F">E non pertanto</l>
@@ -3107,13 +3168,13 @@
               <l>Se pur può dirsi che sia vinta ancora.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="I">Che dubbj hai tu?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#gonzaga">
             <speaker>GONZAGA</speaker>
             <lg>
               <l part="F">Tu, che certezza? Io veggio</l>
@@ -3122,7 +3183,7 @@
               <l part="I">Altri ne ha forse?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">No: di questo io nulla</l>
@@ -3137,14 +3198,14 @@
               <l>È meno assai di quel che al mondo appare.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#gonzaga">
             <speaker>GONZAGA</speaker>
             <lg>
               <l>Se pur non era di lor arte il colmo</l>
               <l part="I">Il parer tali a te.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">No: tu li vedi</l>
@@ -3161,14 +3222,14 @@
               <l part="I">Io lo saprei ben tosto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#gonzaga">
             <speaker>GONZAGA</speaker>
             <lg>
               <l part="F">Il Ciel non voglia</l>
               <l part="I">Che tu t'inganni.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">— Altro mi duol — son stanco</l>
@@ -3190,7 +3251,7 @@
               <l part="M">Che rechi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#soldato">
             <speaker>SOLDATO</speaker>
             <lg>
               <l part="F">Un foglio</l>
@@ -3198,7 +3259,7 @@
             </lg>
             <stage><emph> (gli porge un foglio e parte)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="M">Veggiam.</l>
@@ -3211,26 +3272,26 @@
               <l part="I">Braman di ciò. Vuoi tu seguirmi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#gonzaga">
             <speaker>GONZAGA</speaker>
             <lg>
               <l part="F">Io vengo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="I">Che dì' tu di tal pace?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#gonzaga">
             <speaker>GONZAGA</speaker>
             <lg>
               <l part="F">Ad un soldato</l>
               <l part="I">Tu lo domandi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">È ver; — ma questa è guerra? —</l>
@@ -3250,7 +3311,7 @@
           <head>SCENA I </head>
           <stage><emph>Notte. Sala del Consiglio dei Dieci illuminata</emph>.</stage>
           <stage>IL DOGE, <emph>i</emph> DIECI, <emph>e il</emph> CONTE, <emph>seduti</emph>.</stage>
-          <sp>
+          <sp who="#il_doge">
             <speaker>IL DOGE</speaker>
             <stage><emph>(al Conte)</emph>.</stage>
             <lg>
@@ -3258,7 +3319,7 @@
               <l>Su ciò chiede il Consiglio il parer vostro.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l>Signori, un altro io ve ne diedi; e molto</l>
@@ -3281,7 +3342,7 @@
               <l part="I">Accettate gli accordi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_doge">
             <speaker>IL DOGE</speaker>
             <lg>
               <l part="F">Il parlar vostro</l>
@@ -3289,7 +3350,7 @@
               <l part="I">Parer vi si domanda.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">Uditel dunque.</l>
@@ -3301,7 +3362,7 @@
               <l>Sperar non lice da chi tal non sia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marino">
             <speaker>MARINO</speaker>
             <lg>
               <l>Non l'eravate voi quando i prigioni</l>
@@ -3311,7 +3372,7 @@
               <l part="I">Forse concesso non l'avreste.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">Avrei</l>
@@ -3320,13 +3381,13 @@
               <l>Vòto or sarebbe, o sederiavi un altro.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_doge">
             <speaker>IL DOGE</speaker>
             <lg>
               <l part="I">Vasti disegni avete.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">E l'adempirli</l>
@@ -3334,7 +3395,7 @@
               <l>Che la man che il dovea sciolta non era.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marino">
             <speaker>MARINO</speaker>
             <lg>
               <l>A noi si disse altra cagion: che il Duca</l>
@@ -3343,7 +3404,7 @@
               <l>Sovra i presenti il rovesciaste intero.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l>Questo vi fu riferto? Ella è sventura</l>
@@ -3353,7 +3414,7 @@
               <l part="I">Le parole ascoltar.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#marino">
             <speaker>MARINO</speaker>
             <lg>
               <l part="F">Sventura è vostra</l>
@@ -3361,7 +3422,7 @@
               <l>Che il rio linguaggio lo confermi, e il vinca.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l>Il vostro grado io riverisco in voi,</l>
@@ -3373,58 +3434,58 @@
               <l part="I">Altro pensiero.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_doge">
             <speaker>IL DOGE</speaker>
             <lg>
               <l part="F">Uno è il pensier di tutti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="I">E qual?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_doge">
             <speaker>IL DOGE</speaker>
             <lg>
               <l part="M">L'udiste.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">È del Consiglio il voto</l>
               <l part="I">Quello che udii?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_doge">
             <speaker>IL DOGE</speaker>
             <lg>
               <l part="F">Sì, il crederete al Doge.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="I">Questo dubbio di me? ...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_doge">
             <speaker>IL DOGE</speaker>
             <lg>
               <l part="F">Già da gran tempo</l>
               <l part="I">Non è più dubbio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">E m'invitaste a questo?</l>
               <l part="I">E taceste finor?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_doge">
             <speaker>IL DOGE</speaker>
             <lg>
               <l part="F">Sì, per punirvi</l>
@@ -3432,7 +3493,7 @@
               <l part="I">Per consumarlo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">Io traditor! Comincio</l>
@@ -3463,14 +3524,14 @@
               <l part="I">I tradimenti miei?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_doge">
             <speaker>IL DOGE</speaker>
             <lg>
               <l part="F">Gli udrete or ora</l>
               <l part="I">Dal Collegio segreto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">Io lo ricuso</l>
@@ -3482,13 +3543,13 @@
               <l>Che il mondo ascolti le difese, e veggia...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_doge">
             <speaker>IL DOGE</speaker>
             <lg>
               <l part="I">Passato è il tempo di voler.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">Qui dunque</l>
@@ -3496,7 +3557,7 @@
             </lg>
             <stage>(alzando la voce fa per uscire).</stage>
           </sp>
-          <sp>
+          <sp who="#il_doge">
             <speaker>IL DOGE</speaker>
             <lg>
               <l part="F">Sono</l>
@@ -3508,13 +3569,13 @@
               <l part="I">Le vostre guardie.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="M">Or son tradito!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_doge">
             <speaker>IL DOGE</speaker>
             <lg>
               <l part="F">Un saggio</l>
@@ -3523,21 +3584,21 @@
               <l>Farsi ribelle un traditor potria.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l>Anche un ribelle, sì: come v'aggrada</l>
               <l part="I">Omai potete favellar.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_doge">
             <speaker>IL DOGE</speaker>
             <lg>
               <l part="F">Sia tratto</l>
               <l part="I">Al tribunal segreto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">Un breve istante</l>
@@ -3566,7 +3627,7 @@
               <l part="I">Ch'io vi tradissi. È tempo ancora.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_doge">
             <speaker>IL DOGE</speaker>
             <lg>
               <l part="F">È tardi.</l>
@@ -3575,7 +3636,7 @@
               <l part="I">Tempo era allor d'antiveggenza.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">Indegno.</l>
@@ -3593,13 +3654,13 @@
           <head>SCENA II</head>
           <stage><emph>Casa del Conte</emph>.</stage>
           <stage>ANTONIETTA, <emph>e</emph> MATILDE</stage>
-          <sp>
+          <sp who="#matilde">
             <speaker>MATILDE</speaker>
             <lg>
               <l>Ecco l'aurora; e il padre ancor non giunge.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antonietta">
             <speaker>ANTONIETTA</speaker>
             <lg>
               <l>Ah! tu nol sai per prova: i lieti eventi</l>
@@ -3615,7 +3676,7 @@
               <l part="I">Ei sarà nostro e per gran tempo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#matilde">
             <speaker>MATILDE</speaker>
             <lg>
               <l part="F">O madre,</l>
@@ -3628,7 +3689,7 @@
               <l>Forse colui che sospirate, or muore.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antonietta">
             <speaker>ANTONIETTA</speaker>
             <lg>
               <l>Oh rio pensier! ma almen per ora è lunge.</l>
@@ -3638,13 +3699,13 @@
               <l>Portò l'insegne de' nemici al tempio?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#matilde">
             <speaker>MATILDE</speaker>
             <lg>
               <l part="I">Oh giorno!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antonietta">
             <speaker>ANTONIETTA</speaker>
             <lg>
               <l part="F">Ognun parea minor di lui;</l>
@@ -3655,13 +3716,13 @@
               <l>Il cor tremava, e ripetea: siam sue,</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#matilde">
             <speaker>MATILDE</speaker>
             <lg>
               <l part="I">Felici istanti!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antonietta">
             <speaker>ANTONIETTA</speaker>
             <lg>
               <l part="F">Che avevam noi fatto</l>
@@ -3674,7 +3735,7 @@
               <l part="I">Con queste angosce.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#matilde">
             <speaker>MATILDE</speaker>
             <lg>
               <l part="F">Ah! son finite... ascolta;</l>
@@ -3683,7 +3744,7 @@
               <l>O madre, io vedo un'armatura; è lui.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antonietta">
             <speaker>ANTONIETTA</speaker>
             <lg>
               <l>Chi mai saria s'egli non fosse? ... O sposo..</l>
@@ -3694,7 +3755,7 @@
         <div type="scene">
           <head>SCENA III </head>
           <stage>GONZAGA, <emph>e dette</emph>.</stage>
-          <sp>
+          <sp who="#antonietta">
             <speaker>ANTONIETTA</speaker>
             <lg>
               <l>Gonzaga! ... ov'è il mio sposo? ov'è? ... Ma voi</l>
@@ -3702,27 +3763,27 @@
               <l part="I">Annunzia una sventura.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#gonzaga">
             <speaker>GONZAGA</speaker>
             <lg>
               <l part="F">Ah che pur troppo</l>
               <l part="I">Annunzia il vero!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#matilde">
             <speaker>MATILDE</speaker>
             <lg>
               <l part="M">A chi sventura?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#gonzaga">
             <speaker>GONZAGA</speaker>
             <lg>
               <l part="F">O donne!</l>
               <l>Perché un incarco sì crudel m'è imposto?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antonietta">
             <speaker>ANTONIETTA</speaker>
             <lg>
               <l>Ah! voi volete esser pietoso, e siete</l>
@@ -3730,79 +3791,79 @@
               <l part="I">Di Dio, parlate; ov'è il mio sposo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#gonzaga">
             <speaker>GONZAGA</speaker>
             <lg>
               <l part="F">Il cielo</l>
               <l>Vi dia la forza d'ascoltarmi. Il Conte...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#matilde">
             <speaker>MATILDE</speaker>
             <lg>
               <l part="I">Forse è tornato al campo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#gonzaga">
             <speaker>GONZAGA</speaker>
             <lg>
               <l part="F">Ah! più non torna!</l>
               <l>Egli è in disgrazia de' Signori; è preso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antonietta">
             <speaker>ANTONIETTA</speaker>
             <lg>
               <l part="I">Egli preso! perché?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#gonzaga">
             <speaker>GONZAGA</speaker>
             <lg>
               <l part="F">Gli danno accusa</l>
               <l part="I">Di tradimento.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antonietta">
             <speaker>ANTONIETTA</speaker>
             <lg>
               <l part="M">Ei traditore?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#matilde">
             <speaker>MATILDE</speaker>
             <lg>
               <l part="F">Oh padre!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antonietta">
             <speaker>ANTONIETTA</speaker>
             <lg>
               <l>Or via, seguite: preparate al tutto</l>
               <l part="I">Siam noi: che gli faran?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#gonzaga">
             <speaker>GONZAGA</speaker>
             <lg>
               <l part="F">Dal labbro mio</l>
               <l part="I">Voi non l'udrete.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antonietta">
             <speaker>ANTONIETTA</speaker>
             <lg>
               <l part="M">Ahi l'hanno ucciso!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#gonzaga">
             <speaker>GONZAGA</speaker>
             <lg>
               <l part="F">Ei vive;</l>
               <l part="I">Ma la sentenza è proferita.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antonietta">
             <speaker>ANTONIETTA</speaker>
             <lg>
               <l part="F">Ei vive?</l>
@@ -3829,7 +3890,7 @@
               <emph>(in atto di partire).</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#gonzaga">
             <speaker>GONZAGA</speaker>
             <lg>
               <l part="F">Oh ciel, perché non posso</l>
@@ -3844,13 +3905,13 @@
               <l part="I">Sarà con voi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#matilde">
             <speaker>MATILDE</speaker>
             <lg>
               <l part="M">Non v'è speranza?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antonietta">
             <speaker>ANTONIETTA</speaker>
             <lg>
               <l part="F">Oh figlia!</l>
@@ -3861,7 +3922,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage><emph>Prigione</emph>.</stage>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l>A quest'ora il sapranno.— Oh perché almeno</l>
@@ -3896,26 +3957,26 @@
         <div type="scene">
           <head>SCENA V </head>
           <stage>ANTONIETTA, MATILDE, GONZAGA, <emph>e il</emph> CONTE.</stage>
-          <sp>
+          <sp who="#antonietta">
             <speaker>ANTONIETTA</speaker>
             <lg>
               <l part="M">Mio sposo! ...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#matilde">
             <speaker>MATILDE</speaker>
             <lg>
               <l part="F">Oh padre!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antonietta">
             <speaker>ANTONIETTA</speaker>
             <lg>
               <l>Così ritorni a noi? Questo è il momento</l>
               <l part="I">Bramato tanto? ...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">O misere, sa il cielo</l>
@@ -3936,7 +3997,7 @@
               <l part="I">Quanto per me sei sventurata!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antonietta">
             <speaker>ANTONIETTA</speaker>
             <lg>
               <l part="F">O sposo</l>
@@ -3945,20 +4006,20 @@
               <l>Bramar non posso di non esser tua.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l>Sposa, il sapea quel che in te perdo — ed ora</l>
               <l part="I">Non far che troppo il senta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#matilde">
             <speaker>MATILDE</speaker>
             <lg>
               <l part="F">Oh gli omicidi!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l>No, mia dolce Matilde; il tristo grido</l>
@@ -4013,13 +4074,13 @@
               <l part="I">Ai lor congiunti?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#gonzaga">
             <speaker>GONZAGA</speaker>
             <lg>
               <l part="M">Io tel prometto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">Or sono</l>
@@ -4040,26 +4101,26 @@
               <l part="I">Morir sul campo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antonietta">
             <speaker>ANTONIETTA</speaker>
             <lg>
               <l part="F">Oh Dio, pietà di noi!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l>Sposa, Matilde, ormai vicina è l'ora;</l>
               <l part="I">Convien lasciarci — addio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#matilde">
             <speaker>MATILDE</speaker>
             <lg>
               <l part="M">No, padre...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l part="F">Ancora</l>
@@ -4067,7 +4128,7 @@
               <l part="I">E per pietà partite.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antonietta">
             <speaker>ANTONIETTA</speaker>
             <lg>
               <l part="F">Ah no! dovranno</l>
@@ -4075,13 +4136,13 @@
             </lg>
             <stage><emph>(si ode uno strepito di armati)</emph>.</stage>
           </sp>
-          <sp>
+          <sp who="#matilde">
             <speaker>MATILDE</speaker>
             <lg>
               <l part="M">Oh qual fragor!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#antonietta">
             <speaker>ANTONIETTA</speaker>
             <lg>
               <l part="F">Gran Dio!</l>
@@ -4093,7 +4154,7 @@
               <p><emph> il capo di esse si avanza verso il Conte: le due donne cadono svenute)</emph>.</p>
             </stage>
           </sp>
-          <sp>
+          <sp who="#il_conte">
             <speaker>IL CONTE</speaker>
             <lg>
               <l>O Dio pietoso, tu le involi a questo</l>

--- a/tei/marchese-il-crispo.xml
+++ b/tei/marchese-il-crispo.xml
@@ -75,6 +75,37 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="costantino">
+            <persName>Costantino Magno</persName>
+          </person>
+          <person xml:id="crispo">
+            <persName>Crispo</persName>
+          </person>
+          <person xml:id="firmiano">
+            <persName>Firmiano</persName>
+          </person>
+          <person xml:id="fausta">
+            <persName>Fausta</persName>
+          </person>
+          <person xml:id="nutrice">
+            <persName>Nutrice</persName>
+          </person>
+          <person xml:id="licinio">
+            <persName>Licinio</persName>
+          </person>
+          <person xml:id="flavio">
+            <persName>Flavio</persName>
+          </person>
+          <personGrp xml:id="coro">
+            <name>Coro</name>
+          </personGrp>
+          <person xml:id="leto">
+            <persName>Leto</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT-Salerno</name>Digitalizzazione</change>
@@ -164,7 +195,7 @@
             <hi rend="Italic">Scena prima</hi>
           </head>
           <stage><hi rend="sc">C</hi>OSTANTINO, <hi rend="sc">C</hi>RISPO <hi rend="Italic">e</hi><hi rend="sc">F</hi>IRMIANO</stage>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Degno mio germe, per cui sol vedrassi</l>
             <l>A l'orgoglioso persa, al fero scita</l>
@@ -183,7 +214,7 @@
             <l>E trionfante al Campidoglio riedi, </l>
             <l>Per volger poi l'arme vittrici altrove.</l>
           </sp>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l>L'alto desio, padre e signor, che accende</l>
             <l>Mio cor, è sol d'essere ognor qual deggio</l>
@@ -211,7 +242,7 @@
             <l>E del più chiaro Augusto in ogni ‘mpresa,</l>
             <l>Non che compagna, ebbi la sorte ancella.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>A l'umana virtù guerra più dura</l>
             <l>Fa la benigna che l'avversa sorte,</l>
@@ -231,7 +262,7 @@
             <l>In tanto io vo’ che l'apprestate schiere</l>
             <l>Tu ‘ncominci a condur là dove imposi.</l>
           </sp>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l>Sovra ogn'altra virtude onoro e colo</l>
             <l>Quella, signor, che voi padre ed Augusto</l>
@@ -245,7 +276,7 @@
             <l>Scorta, ond'io possa ognor securo e lieto</l>
             <l>Poggiar là dove il sommo bene ha il soglio.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>O età felice in cui rifulge uom tale,</l>
             <l>Che co’ detti e con l'opre il ver sentiero</l>
@@ -254,7 +285,7 @@
             <l>Se a render sì perfetto il mio figliuolo</l>
             <l>V'ebbe gran parte lo tuo studio e zelo.</l>
           </sp>
-          <sp>
+          <sp who="#firmiano">
             <speaker><hi rend="sc">F</hi>IRMIANO</speaker>
             <l>Suo generoso spirto e ‘l nobil vostro</l>
             <l>Sangue ch'è in lui, e ‘l sol porgli davanti</l>
@@ -264,7 +295,7 @@
             <l>Ebber difetti di maestri e norme</l>
             <l>A farsi ta’ quai poscia unqua non furo.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Ciò non renda minor tua gloria. Intanto</l>
             <l>Ir voglio, o Crispo, al campo, ed ivi in mostra</l>
@@ -272,12 +303,12 @@
             <l>Venir, mi segui e, se star vuoi, rimanti:</l>
             <l>Ch'è nostra voglia sol ciò che a te piace.</l>
           </sp>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l>Vuol non lieve cagion, se mel consente</l>
             <l part="I">Vostra bontà, ch'io qui rimanga.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l part="F">Adunque</l>
             <l>Resta, che ‘l meglio ognor so che disponi.</l>
@@ -288,13 +319,13 @@
             <hi rend="Italic">Scena seconda</hi>
           </head>
           <stage><hi rend="sc">F</hi>IRMIANO <hi rend="Italic">e</hi><hi rend="sc">C</hi>RISPO</stage>
-          <sp>
+          <sp who="#firmiano">
             <speaker><hi rend="sc">F</hi>IRMIANO</speaker>
             <l>Deh perché, signor mio, d'Augusto i passi</l>
             <l>Non seguitaste? e qual or qui richiede</l>
             <l>Opra degna di voi vostra presenza?</l>
           </sp>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l>Sai, Firmian, che nostre schiere a prova</l>
             <l>M'onoran tutte, e i più festanti e chiari</l>
@@ -303,13 +334,13 @@
             <l>Che quel di Costantin sonar s'udria,</l>
             <l>S'io seco andassi, e ciò dritto non parmi.</l>
           </sp>
-          <sp>
+          <sp who="#firmiano">
             <speaker><hi rend="sc">F</hi>IRMIANO</speaker>
             <l>Degno è ‘l pensier d'uom giusto, accorto, e saggio,</l>
             <l>Più che di figlio, i cui be’ vanti al padre</l>
             <l>Apportan gloria sovra ogn'altra cara.</l>
           </sp>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l>Altro pensiero, o mio fedel, confonde</l>
             <l>Mia dubbia mente, e tuo consiglio or cheggio:</l>
@@ -322,14 +353,14 @@
             <l>Rozzezza e, se vi vo, noia le apporto,</l>
             <l>E l'uno e l'altro a me di pari incresce.</l>
           </sp>
-          <sp>
+          <sp who="#firmiano">
             <speaker><hi rend="sc">F</hi>IRMIANO</speaker>
             <l>Se ‘n lei nasce il dolor da suoi difetti,</l>
             <l>Il duol pena le sia de l'ira ingiusta;</l>
             <l>Né difender da quel voi la dovete</l>
             <l part="I">Col proprio fallo.</l>
           </sp>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l part="F">Or dunque, se ‘l consigli,</l>
             <l>Pria si scosti più il sol dal mar profondo,</l>
@@ -342,7 +373,7 @@
             <hi rend="Italic">Scena terza</hi>
           </head>
           <stage><hi rend="sc">F</hi>AUSTA <hi rend="Italic">e poi</hi><hi rend="sc">N</hi>UTRICE</stage>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Potesse il Reno, oimè, potesse il Gange,</l>
             <l>O pur l'onda del Nilo, ov'ha più mostri,</l>
@@ -364,7 +395,7 @@
             <l>O almen tu mi consiglia, or che non posso</l>
             <l>Tacer più il duolo, e disvelar nol deggio.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>Augusta, e sarà ver che prieghi e pianti</l>
             <l>Io supplicante in van porga e diffonda,</l>
@@ -375,7 +406,7 @@
             <l>Confidate sì poco, onde si debba</l>
             <l>Tacer ciò che voi strugge e me consuma?</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Cara nutrice, a’ tuoi pietosi pianti</l>
             <l>Indurai mio mal grado il tristo core,</l>
@@ -389,7 +420,7 @@
             <l>Fia che declini col sol d'oggi, e questo</l>
             <l>Cresce al tristo pensier novelli affanni.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>Or tutto intendo, è l'odiato Crispo</l>
             <l>Cagion del vostro duol, morto il bramate,</l>
@@ -397,7 +428,7 @@
             <l>Temete, non in vano, allor ch'è lungi,</l>
             <l>Apriate a me ciò che ‘l cuor vostro brama.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Non l'intendi che ‘n parte (a che più taccio,</l>
             <l>Che più resisto al fato?) è ver ch'è Crispo</l>
@@ -407,12 +438,12 @@
             <l>Ahi vergogna, ahi dolor! l'alma mi scalda</l>
             <l>D'ira non già, ma del più ‘ntenso amore.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>Ma come in voi cedeo tant'odio loco</l>
             <l>Ad un amor di lui più indegno e fero?</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Quand'io di nuova maschia prole Augusto</l>
             <l>Fei lieto, al bel figliuol di <rs type="name">Minervina</rs></l>
@@ -431,7 +462,7 @@
             <l>Di desir, di sospetto, e di timore,</l>
             <l>D'orror, di dubbio, di vergogna, e d'ira.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>Lasciate al vulgo vil querele e pianti,</l>
             <l>Del gran <rs type="name">Massimian</rs> voi figlia altera,</l>
@@ -460,13 +491,13 @@
             <l>Ver cui forza mortal che può, che vale,</l>
             <l>Se la superna ancor vinta li cede?</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Il tuo dolce parlar fa meno indegna</l>
             <l>La mia fiamma al pensier, ma qual poss'io</l>
             <l>Sperar da Crispo mai grato conforto?</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>Quel ch'ebber già mille madrigne e mille</l>
             <l>Da’ freschi figli de’ lor vecchi sposi,</l>
@@ -480,14 +511,14 @@
             <l>Stesso l'accolse, in cui svenato in prima</l>
             <l>Le avea <rs type="name">Geta</rs> suo figlio e a lui germano.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Tolga il destin che io mai brami la morte</l>
             <l>Al mio sposo innocente, e al Ciel piacesse</l>
             <l>Che dal petto scacciar potessi il foco</l>
             <l>Senza macchiar suo letto, anzi me stessa.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>Dunque pensiam solo a’ furtivi amori,</l>
             <l>Agevoli nel vero: è Crispo molto</l>
@@ -496,7 +527,7 @@
             <l>A’ cari prieghi d'un'amante Augusta</l>
             <l>Non piegherebbe intenerito e molle.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>O dolce madre mia, fido sostegno</l>
             <l>D'ogni mia speme, or quali odo diversi</l>
@@ -505,7 +536,7 @@
             <l>D'onor, di fasto le sentenze gravi</l>
             <l>In queste sì pietose a’ miei martiri.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>Allor che il vostro genitore Augusto,</l>
             <l>Per la più saggia me tra  mille scelse</l>
@@ -521,17 +552,17 @@
             <l>Che cadrà tosto. Or non più indugi, io vado.</l>
             <l part="I">Qui fra poco mi avrete.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l part="F">Ah ferma, e lascia</l>
             <l part="I">Ch'io me vi pensi.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l part="F">Anco il pensier contrasta</l>
             <l>Al vostro ben, se poco tempo avanza.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Vanne, fa ciò che vuoi, poiché non posso</l>
             <l>Altro sperar. Chi mai su rotta nave</l>
@@ -544,7 +575,7 @@
             <hi rend="Italic">Scena quarta</hi>
           </head>
           <stage><hi rend="sc">L</hi>ICINIO <hi rend="Italic">solo</hi></stage>
-          <sp>
+          <sp who="#licinio">
             <speaker><hi rend="sc">L</hi>ICINIO</speaker>
             <l>Già l'aquile superbe in mille insegne</l>
             <l>Spiegansi, e ‘l suon de le guerriere trombe</l>
@@ -582,7 +613,7 @@
             <hi rend="Italic">Scena quinta</hi>
           </head>
           <stage><hi rend="sc">F</hi>LAVIO <hi rend="Italic">e</hi><hi rend="sc">L</hi>ICINIO</stage>
-          <sp>
+          <sp who="#flavio">
             <speaker><hi rend="sc">F</hi>LAVIO</speaker>
             <l>Signor, la vostra fiamma appieno esposi</l>
             <l>Di Fausta a la fedel cara nutrice,</l>
@@ -593,7 +624,7 @@
             <l>La promessa non fia, fidate adunque</l>
             <l>Lieto ne l'opra sua, nel nostro affetto.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><hi rend="sc">L</hi>ICINIO</speaker>
             <l>Ah quando fia il bel dì ch'io solo in trono</l>
             <l>Leggi al mondo darò per esser grato</l>
@@ -602,7 +633,7 @@
             <l>Grazie, piaceri, onor, tesori, impero,</l>
             <l>S'avvien che per te solo io goda e regni.</l>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><hi rend="sc">F</hi>LAVIO</speaker>
             <l>Ampia mercè mi fia, signor, mirarvi</l>
             <l>Nel solio, e sposo de l'amabil Fausta,</l>
@@ -610,7 +641,7 @@
             <l>Fra l'alte cure di vendetta e ‘mpero,</l>
             <l>Loco trovar nel vostro saldo petto.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><hi rend="sc">L</hi>ICINIO</speaker>
             <l>Desio di regno e di vendetta al core</l>
             <l>Impresser lei che di me tutto è donna.</l>
@@ -628,7 +659,7 @@
             <l>Che ‘n lui ferve ugualmente, anzi ha più loco</l>
             <l>L'amoroso desio che quel d'impero.</l>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><hi rend="sc">F</hi>LAVIO</speaker>
             <l>Altra cagion più che l'amor sovente</l>
             <l>Sospigne alcuno a bramar donna, e poi</l>
@@ -644,7 +675,7 @@
             <hi rend="Italic">Scena sesta</hi>
           </head>
           <stage><hi rend="sc">N</hi>UTRICE <hi rend="Italic">e</hi><hi rend="sc">D</hi>ETTI</stage>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>Tutto, signor, mi è noto, ogni mia possa</l>
             <l>Userò per far voi contento appieno:</l>
@@ -655,13 +686,13 @@
             <l>Quanto è di forza in me d'ingegno e d'arte,</l>
             <l>Non ne incolpate le mie fide voglie.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><hi rend="sc">L</hi>ICINIO</speaker>
             <l>De le speranze mie sostegno e lume,</l>
             <l>Dimmi in qual guisa, e donde attender posso</l>
             <l>Pace e conforto a’ miei desiri ardenti.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>Gran tela ordisco, ma sì dubbio il fine</l>
             <l>Per or ne veggio, ch'io spero e pavento.</l>
@@ -674,20 +705,20 @@
             <l>Che pria che ‘l sole in mar si tuffi, io spero</l>
             <l>O far certe o troncar vostre speranze.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><hi rend="sc">L</hi>ICINIO</speaker>
             <l>Qual fia mia sorte dal tuo labbro aspetto</l>
             <l>In questo dì, tu mi consiglia intanto</l>
             <l>Ciò che far debbo, e se de l'opra nostra</l>
             <l part="I">Hai pur bisogno.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l part="F">Quinci omai partite,</l>
             <l>Che se ‘l disegno richiedesse vostra</l>
             <l part="I">Mano, o presenzia, a voi fia noto.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><hi rend="sc">L</hi>ICINIO</speaker>
             <l part="F">Io parto,</l>
             <l>Da che ‘l consigli, ed or prometto e giuro</l>
@@ -697,7 +728,7 @@
           </sp>
         </div>
         <div type="epilogue">
-          <sp>
+          <sp who="#coro">
             <speaker><hi rend="sc">C</hi>ORO</speaker>
             <lg type="canzone">
               <lg>
@@ -796,7 +827,7 @@
             <hi rend="Italic">Scena prima</hi>
           </head>
           <stage><hi rend="sc">C</hi>RISPO <hi rend="Italic">solo</hi></stage>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l>Fra le glorie e’ piacer, che amico fato</l>
             <l>Con larga mano al viver mio diffonde,</l>
@@ -820,17 +851,17 @@
             <hi rend="Italic">Scena seconda</hi>
           </head>
           <stage><hi rend="sc">F</hi>AUSTA, <hi rend="sc">N</hi>UTRICE <hi rend="Italic">e</hi><hi rend="sc">C</hi>RISPO</stage>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Lassa, il mio sangue tutto al cor s'accoglie,</l>
             <l>Già tutta agghiaccio e mi vacilla il piede.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>Fa cuore, o figlia, or che da questo solo</l>
             <l>Vostra salute ed ogni ben dipende.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Dunque, signor, per cignere l'altera</l>
             <l>Fronte di nuovi allori, omai già presto</l>
@@ -841,7 +872,7 @@
             <l>Qual grave danno, o qua’ disprezzi ed onte</l>
             <l>Da me soffriste, ond'io tant'odio merti?</l>
           </sp>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l>Non odio, Augusta, ma rispetto e tema</l>
             <l>Di non recarvi noia mi ritenne,</l>
@@ -849,7 +880,7 @@
             <l>Del vostro volto io vi credei nel petto</l>
             <l>Ver me de l'odio di madrigna accesa.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Mal conoscete chi mi pinga al volto</l>
             <l>Spesso i colori, e chi gli muova e cangi.</l>
@@ -865,7 +896,7 @@
             <l>Rene di Arabia, e farvi scudo in guerra</l>
             <l>Col proprio petto a mille spade incontro.</l>
           </sp>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l>Tal nel campo troian <rs type="name">Pentesilea</rs>,</l>
             <l>E <rs type="name">Ippolita</rs>, e <rs type="name">Talestri</rs> abbiansi vanto,</l>
@@ -877,14 +908,14 @@
             <l>De’ sudor nostri, e vi fia gloria e vanto</l>
             <l>Quindi impor leggi a chi vince ed impera.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Impor leggi non dee chi d'un tiranno</l>
             <l>Voler è serva…  Ah, Flaviana amica,</l>
             <l>L'ardir mi manca, tutta triemo, e ‘l gielo</l>
             <l>Rattiene in mezzo de le fauci i detti.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>Suppliscan l'opre ove il parlar vi manca;</l>
             <l>Meglio con queste l'amorose voglie</l>
@@ -894,12 +925,12 @@
             <l>Rimote stanze più fedeli, ed atte</l>
             <l>Il segreto a celar, qui entrar potrete.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Saggiamente consiglia. A voi non gravi,</l>
             <l part="I">Prenze, seguirmi.</l>
           </sp>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l part="F">Le vostre orme seguo.</l>
             <l>Che mai fie ciò? Si turba, impallidisce,</l>
@@ -914,7 +945,7 @@
             <hi rend="Italic">Scena terza</hi>
           </head>
           <stage><hi rend="sc">N</hi>UTRICE  <hi rend="Italic">sola</hi></stage>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>Ben farà il lungo favellare e ‘l loco,</l>
             <l>Che suo mal grado al fin apra l'interna</l>
@@ -941,11 +972,11 @@
           <stage>
             <emph>(da dentro)</emph>
           </stage>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l>Rea femmina, ti scosta.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>Odo già voci onde a Licinio sorge</l>
             <l>Di goder, d'imperar alta speranza.</l>
@@ -956,7 +987,7 @@
             <hi rend="Italic">Scena quarta</hi>
           </head>
           <stage><hi rend="sc">C</hi>RISPO <hi rend="Italic">e</hi><hi rend="sc">N</hi>UTRICE</stage>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l>Che scelerati detti! oimè, che voglie</l>
             <l>Temerarie, impudiche, infami, indegne,</l>
@@ -967,13 +998,13 @@
             <l>L'alma innocente sbigottisce, e ‘l core</l>
             <l part="I">È pien d'orror.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l part="F">Per Dio, signor, tacete,</l>
             <l>Pensate al fin che l'infelice Augusta</l>
             <l>È scelerata e rea sol perché v'ama.</l>
           </sp>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l>Empia nutrice di malvagia figlia,</l>
             <l>Chiudi l'infame bocca, amor tu appelli</l>
@@ -987,7 +1018,7 @@
             <l>Torre al più mi poria vita ed impero,</l>
             <l>Ma non macchiar l'onor, la fede, e l'alma.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>Se <rs type="name">Aletto</rs> in lei destò la fatal fiamma,</l>
             <l>Che colpa ella al suo male? e se a pungenti</l>
@@ -995,11 +1026,11 @@
             <l>Odiar potrete chi per voi si espone</l>
             <l>A perigli, a ripulse, ad onte, a scorni.</l>
           </sp>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l part="I">Ed osi ancora …</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l part="F">Io ciò, signor, non dico</l>
             <l>Già per piegar l'inessorabil core</l>
@@ -1009,7 +1040,7 @@
             <l>Quantunque indegna, onor non toglie, e molto</l>
             <l>Falsa accusa talor lo annebbia e strugge.</l>
           </sp>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l>Stolta, a chi dir mai ciò potrassi, e come?</l>
             <l>Forse al mondo svelar debbo i rei scorni</l>
@@ -1019,7 +1050,7 @@
             <l>Ma tu vegliarda a lei corri; che oppressa</l>
             <l>Dagl'empi affetti svenne, e al suol sen giace.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>E sì l'abbandonaste, ah ingrato, ah crudo!</l>
           </sp>
@@ -1029,7 +1060,7 @@
             <hi rend="Italic">Scena quinta</hi>
           </head>
           <stage><hi rend="sc">C</hi>RISPO <hi rend="Italic">solo</hi></stage>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l>E donde Fausta mai sperar poteo</l>
             <l>Ch'a l'ingiusto voler l'alma piegassi?</l>
@@ -1053,12 +1084,12 @@
             <hi rend="Italic">Scena sesta</hi>
           </head>
           <stage><hi rend="sc">F</hi>AUSTA <hi rend="Italic">e</hi><hi rend="sc">N</hi>UTRICE</stage>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Ma che disse l'ingrato allor che al suolo</l>
             <l>Stesa lasciommi quasi in grembo a morte?</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>Non vidi mai su teatrale arena</l>
             <l>Leon ferito sì di rabbia e d'ira,</l>
@@ -1068,7 +1099,7 @@
             <l>Che tigri ed orsi in feritade avanza,</l>
             <l>Poiché sì v'odia sol perché l'amate.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Lassa, che feci! or me ne avveggio, io dunque</l>
             <l>Sì vilmente prostarmi al piè superbo</l>
@@ -1076,12 +1107,12 @@
             <l>A tanta ‘ndegnitade il cor piegai?</l>
             <l part="I">Ma pur, che disse?</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l part="F">Scelerata, infame,</l>
             <l>Fur le men aspre note ond'e’ vi offese.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Ah malamente consigliasti: or io</l>
             <l>Sarò de’ suoi disprezzi il vile obbietto,</l>
@@ -1089,40 +1120,40 @@
             <l>Avermi vista supplice a’ suoi piedi,</l>
             <l>E che negletta e dispregiata m'abbia?</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>Mal consigliai, se da’ successi solo</l>
             <l>I mie’ consigli misurar volete,</l>
             <l>Chi potea ferità creder cotanta</l>
             <l>In cuor uman ver un'amante Augusta?</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Or come mai potrò l'odiato aspetto</l>
             <l>Di lui soffrire, o de’ suoi vanti il grido?</l>
             <l>O con qual pena gli occhi miei vedranno,</l>
             <l>S'ei riede vincitor, i suoi trionfi?</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>Convien di finzion, di sofferenza</l>
             <l>Armar lo cor, se ‘n voi paura alberga,</l>
             <l>O d'orgoglio e furor se avete ardire.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l part="I">Ei pronto è a la vendetta.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l part="F">E Crispo ingrato</l>
             <l part="I">Cadrà.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l part="M">Ma come?</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l part="F">A voi sorte presenta</l>
             <l>Uom, onde vendicar voi stessa, e i vostri</l>
@@ -1131,25 +1162,25 @@
             <l>Per voi d'amor si strugge, e tutto è sdegno</l>
             <l part="I">Ver Costantino, e ‘n un ver Crispo.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l part="F">Egli arde</l>
             <l part="I">Per me d'amore?</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l part="F">Ei tutto avvampa,</l>
             <l>Ciò per or basti, a le vostre ire ardenti</l>
             <l>Or servan di Licinio ambi gli affetti,</l>
             <l>E per lui caggia Costantino e Crispo.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>E ‘n che m'offese Costantin, che a torto</l>
             <l>Sì lo condanni? e’ sempre fido e amante</l>
             <l>I mie’ pensier non che’ mie’ detti adora.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>Né ‘n tanti anni d'impero anco apprendeste</l>
             <l>Che se l'esser altrui grata o pietosa</l>
@@ -1164,14 +1195,14 @@
             <l>Taccio que’ che al germano, al padre, al figlio,</l>
             <l>Per sue voglie appagar, dier cruda morte.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Qual gran peccato mai d'essempi è privo?</l>
             <l>Ma troppo al core, ed al pensiero incresce</l>
             <l>Del mio consorte l'innocente sangue,</l>
             <l part="I">Ahi, ch'è troppa empietà.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l part="F">Chi brama in parte</l>
             <l>Esser malvagio e ‘n parte pio, sovente</l>
@@ -1183,38 +1214,38 @@
             <l>Sembra il vostro consorte, eccolo reo,</l>
             <l>Per qual comando a voi fu il padre anciso?</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Egli a lui morte avea tentato in prima.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>Tolse al vostro german vita ed impero.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Tolse a <rs type="luogo">Roma</rs> un tiranno, e fe’ più vasto</l>
             <l part="I">Il mio dominio.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l part="F">È reo, se a vostri sguardi</l>
             <l part="I">Più non piace il suo aspetto.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l part="F">E ‘n ciò che colpa?</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>Al fin fia reo, se malagevol rende</l>
             <l part="I">La bramata vendetta.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l part="F">Al fine è padre.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>Viva egli dunque, e seco viva e ‘mperi</l>
             <l>Lo ‘ngrato Crispo, e sua real presenza</l>
@@ -1223,14 +1254,14 @@
             <l>Che sì villan fuggir da voi poteo,</l>
             <l>Suggetti umili ad un superbo Augusto.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Vivendo il lor gran genitore, avranno</l>
             <l>D'impero i figli miei non poca parte,</l>
             <l>Ma s'egli cade, e se Licinio regna,</l>
             <l part="I">Che lor resta a sperar?</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l part="F"> Licinio forse</l>
             <l>Ave altri figli? In lui v'addito, Augusta,</l>
@@ -1246,18 +1277,18 @@
             <l>Cader dovrà con Costantino, o seco</l>
             <l>Regnar per vostro eterno scorno ed onta.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Né l'un cader poria senza che l'altro</l>
             <l part="I">Seco perisse?</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l part="F">Allor Costantin fora</l>
             <l>Vendicator del figlio, ed ognun teme</l>
             <l>Rischio sì certo, ed opra tal s'arresta.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Non più, già tutta al tuo voler mi rendo,</l>
             <l>Fa che vuoi, vo’ vendetta, e sia qual puossi,</l>
@@ -1270,7 +1301,7 @@
             <hi rend="Italic">Scena settima</hi>
           </head>
           <stage><hi rend="sc">N</hi>UTRICE, <hi rend="Italic">e poi</hi><hi rend="sc">L</hi>ICINIO <hi rend="Italic">e</hi><hi rend="sc">F</hi>LAVIO</stage>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>Giunse al segno lo stral, per opra nostra</l>
             <l>Già di Licinio fia Fausta e lo ‘mpero,</l>
@@ -1282,12 +1313,12 @@
             <l>Già vostra è Fausta, e seco ancor fia vostro</l>
             <l>Lo ‘mpero tutto, or v'accignete a l'opra.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><hi rend="sc">L</hi>ICINIO</speaker>
             <l>Che far mai debbo? ognor pronto ed audace</l>
             <l>Ne’ gran perigli scorgerai mio petto.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>Tutto fa, tutto tenta un ch'ama, ed uno</l>
             <l>Ch'ha di regnar desio; voi dunque, o forte,</l>
@@ -1300,18 +1331,18 @@
             <l>Fausta medesma, e tutto il suo soccorso</l>
             <l part="I">V'offre, e promette.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><hi rend="sc">L</hi>ICINIO</speaker>
             <l part="F">Or di’, consiglia, imponi,</l>
             <l>Pronte a le stragi ho già le voglie e l'alma.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>Armate schiere ancor non miro in campo</l>
             <l>A’ vostri cenni, onde a sì ‘ncerta impresa</l>
             <l>È d'uopo audacia, e via più ‘ngegno ed arte.</l>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><hi rend="sc">F</hi>LAVIO</speaker>
             <l>Tentisi adunque de’ nemici alteri</l>
             <l>La furtiva caduta; io che di Crispo</l>
@@ -1320,7 +1351,7 @@
             <l>Passargli il core, allor ch'e’ giacerassi</l>
             <l part="I">Dal sonno oppresso.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l part="F">E a Costantin pur fia</l>
             <l>Agevole l'entrata aver con l'oro:</l>
@@ -1334,24 +1365,24 @@
             <l>Questi, ma pur sien pochi, a te fa grati,</l>
             <l>Lor dona ed offri più, tutto prometti.</l>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><hi rend="sc">F</hi>LAVIO</speaker>
             <l>Ciò fia mia cura, e v'è tra lor chi prezza</l>
             <l>Nostra amistade, e più chi l'avrà ancora,</l>
             <l part="I">Ma che chieder lor debbo?</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l part="F">Che lor cura</l>
             <l>Sia d'introdur ne le guardate soglie,</l>
             <l>E ch'indi ancora uscir libero possa,</l>
             <l>Chi darà loro un destinato segno.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><hi rend="sc">L</hi>ICINIO</speaker>
             <l part="I">Questi io stesso esser voglio.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l part="F">Ed è ben dritto,</l>
             <l>Né un tanto colpo ad altra man si fidi,</l>
@@ -1359,13 +1390,13 @@
             <l>Si sappia allor ch'a voi fia servo il mondo;</l>
             <l>Vostro nome a ciascun per or si taccia.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><hi rend="sc">L</hi>ICINIO</speaker>
             <l>Molto sai, saggia parli, ed altro pensi,</l>
             <l>E spero ancor che ‘l tuo senno, ed ingegno</l>
             <l>Nel governo del mondo a me fia scorta.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>Sarò vostra fedel suggetta e serva.</l>
             <l>Ma vien Augusta, or voi maggior coraggio</l>
@@ -1377,7 +1408,7 @@
             <hi rend="Italic">Scena ottava</hi>
           </head>
           <stage><hi rend="sc">F</hi>AUSTA <hi rend="Italic">e poi</hi><hi rend="sc">D</hi>ETTI</stage>
-          <sp>
+          <sp who="#licinio">
             <speaker><hi rend="sc">L</hi>ICINIO</speaker>
             <l>Augusta, e sarà ver che quella fiamma,</l>
             <l>Onde ‘l cor tutto mi si strugge e avvampa,</l>
@@ -1389,14 +1420,14 @@
             <l>Dal caro labbro? O me felice appieno</l>
             <l>S?a sì dolci diletti il cor non manca!</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Licinio, or non convien di dolci amori</l>
             <l>Il parlar molle, a fornir sol si badi</l>
             <l>Contra il rio Costantin l?alta vendetta</l>
             <l>Del mio gran padre, e del fratello anciso.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><hi rend="sc">L</hi>ICINIO</speaker>
             <l>A la vendetta adunque, e un colpo solo</l>
             <l>Renda voi paga, e me contento appieno.</l>
@@ -1404,7 +1435,7 @@
             <l>Chi a voi più aggrada, ch?io corona e manto</l>
             <l>A voi libero cedo, e sol fia vostro.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Servite, o prenze, a l?ira nostra, e serva</l>
             <l>Il mondo a voi signor di lui ben degno,</l>
@@ -1412,7 +1443,7 @@
             <l>Il serto imperial, ancor che tanto</l>
             <l>Per retaggio non fosse a voi dovuto?</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><hi rend="sc">L</hi>ICINIO</speaker>
             <l>Per merto, per retaggio, e per la forza</l>
             <l>Ch?hanno sovra il mio core i vostri sguardi,</l>
@@ -1424,13 +1455,13 @@
             <l>Vedrete quanto fia per me ‘l periglio</l>
             <l part="I">Debil ritegno.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l part="F">Ah tolga il Ciel che ‘l forte</l>
             <l>Vendicator de le mie genti esponga</l>
             <l>A certo rischio sì pregevol vita.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>Tutto il periglio è del mio Flavio, a lui</l>
             <l>Del grande affar ben tutto attiensi il pondo,</l>
@@ -1439,7 +1470,7 @@
             <l>Diran suo nome le guerriere trombe,</l>
             <l>Allor che liete il grideranno Augusto.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Flavio a me vegna adunque, ed oro e gemme</l>
             <l>Tolga a tal?opre necessarie, intanto</l>
@@ -1452,38 +1483,38 @@
             <l>De l?ira nostra, e non già come amante,</l>
             <l part="I">Ne fo degno presente.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><hi rend="sc">L</hi>ICINIO</speaker>
             <l part="F"> Il dono accetto</l>
             <l>Reverente, e da lui prendo gli auguri</l>
             <l part="I">Per me felici.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l part="F">In vani detti il tempo</l>
             <l part="I">Non si consumi.</l>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><hi rend="sc">F</hi>LAVIO</speaker>
             <l part="F"> Io tutto ardor m?accingo</l>
             <l>A l?alta impresa, ed o Licinio Augusto</l>
             <l>Vedrassi in trono o le mie membra sparte.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Molto, o Flavio, ti debbo, io vado, o prence,</l>
             <l>Ratta a compier ciò che promisi, e voi</l>
             <l>Non esporrete a gran perigli il petto,</l>
             <l>S?è ver che Fausta in quello ha sì gran parte.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><hi rend="sc">L</hi>ICINIO</speaker>
             <l>Or sì la vita, ch?io spregiai finora,</l>
             <l>Sol cara a me sarà perch?a voi piace.</l>
           </sp>
         </div>
         <div type="epilogue">
-          <sp>
+          <sp who="#coro">
             <speaker><hi rend="sc">C</hi>ORO</speaker>
             <lg type="canzone">
               <lg>
@@ -1573,7 +1604,7 @@
             <hi rend="Italic">Scena prima</hi>
           </head>
           <stage><hi rend="sc">F</hi>LAVIO <hi rend="Italic">solo</hi></stage>
-          <sp>
+          <sp who="#flavio">
             <speaker><hi rend="sc">F</hi>LAVIO</speaker>
             <l>Cortese il fato a’ miei disegni arride:</l>
             <l>Tra destinati a la notturna guardia</l>
@@ -1599,7 +1630,7 @@
             <hi rend="Italic">Scena ottava</hi>
           </head>
           <stage><hi rend="sc">C</hi>OSTANTINO <hi rend="Italic">e poi</hi><hi rend="sc">C</hi>RISPO</stage>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Di sì presto ritorno, e per sì ascoso</l>
             <l>Sentier la meraviglia a te sia tolta</l>
@@ -1619,7 +1650,7 @@
             <l>Libera uscita ancor poscia ch?egli abbia</l>
             <l>Ferro crudel ne le mie vene immerso.</l>
           </sp>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l>Che ascolto, oimè? qual più inumano petto</l>
             <l>Può mai nudrir voglie sì ‘ndegne, ed onde</l>
@@ -1627,7 +1658,7 @@
             <l>Ma qual finora al grave mal tentaste</l>
             <l part="I">Opportuno compenso?</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l part="F">A Leto imposi</l>
             <l>Che a me il guerrier, che ‘l fido foglio scrisse,</l>
@@ -1635,7 +1666,7 @@
             <l>Ma pria proccuri che nessuno ponga</l>
             <l part="I">Il piede fuor de l?ampia corte.</l>
           </sp>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l part="F">Intanto,</l>
             <l>Cangiar io voglio la sospetta gente</l>
@@ -1644,7 +1675,7 @@
             <l>Perché il riposo a voi cura o sospetto</l>
             <l>Non turbi, guarderò l?ultime soglie.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Or vanne, o caro, valoroso e saggio</l>
             <l>Mio figlio, e pon ciò che pensasti in opra.</l>
@@ -1652,7 +1683,7 @@
             <l>Qual mai nuocer potrammi inganno o forza?</l>
             <l>Che io qui d?intorno il fido Leto aspetto.</l>
           </sp>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l>Quai di sdegno e d?amor inique fiamme</l>
             <l>Ardon di Costantin ne l?alta reggia,</l>
@@ -1669,7 +1700,7 @@
             <hi rend="Italic">Scena terza</hi>
           </head>
           <stage><hi rend="sc">F</hi>AUSTA <hi rend="Italic">e poi</hi><hi rend="sc">N</hi>UTRICE</stage>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Par che la sorte con turbato ciglio</l>
             <l>Già l?ultime ruine a noi minacci,</l>
@@ -1682,7 +1713,7 @@
             <l>Che’ rei punisce, e agl?innocenti ognora</l>
             <l>La vita con l?onor salva e difende?</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>Se non chiudete a’ vili sensi il petto,</l>
             <l>Fia più che disperato il nostro scampo</l>
@@ -1701,7 +1732,7 @@
             <l>Porrete, forse far saprem bugiardo</l>
             <l>Lo cor che tanto ‘n voi grida e minaccia.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Non basta, oimè, con sì protervi modi</l>
             <l>L?aver aperta la mia fiamma, e a Crispo,</l>
@@ -1709,7 +1740,7 @@
             <l>Congiurata la morte, e aggiugner brami</l>
             <l>A ta’ misfatti la calunnia? è troppo.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>Ciò basti adunque e, poi ch?altro v?incresce,</l>
             <l>Moriamo, e caggia il nostro onore, e’ nostri</l>
@@ -1718,13 +1749,13 @@
             <l>Da cui v?arresta vil timor, vi piace</l>
             <l>Perder de l?altre il necessario frutto.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Sol questo a farmi scelerata appieno</l>
             <l>Mancava, or ciò pur la ria salma aggravi,</l>
             <l part="I">Dunque…</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l part="F">Direte che ‘l paterno letto</l>
             <l>Crispo acceso per voi d?impuro foco</l>
@@ -1733,11 +1764,11 @@
             <l>Nel dir. Ma che ricordo a saggia donna</l>
             <l>Ciò che far sanno le milense ancora?</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l part="I">Che mai da ciò si spera?</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l part="F">I vostri detti</l>
             <l>A quel ch?altri dirà, tanta credenza</l>
@@ -1747,23 +1778,23 @@
             <l>Che a la crinita occasione a tempo</l>
             <l part="I">Saprà stender la man.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l part="F">Ma se creduto</l>
             <l part="I">Crispo fia più di me?</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l part="F">Ciò non tem?io,</l>
             <l>Poiché un marito amante assai più crede</l>
             <l>I falsi detti de la scaltra moglie,</l>
             <l>Che ‘l ver, ch?ei quasi co’ propri occhi veggia.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l part="I">Qui viene Augusto.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l part="F">Io vado. Ardire, o figlia,</l>
             <l>Dal vostro labbro il bene, e ‘l mal dipende.</l>
@@ -1774,7 +1805,7 @@
             <hi rend="Italic">Scena quarta</hi>
           </head>
           <stage><hi rend="sc">C</hi>OSTANTINO <hi rend="Italic">e</hi><hi rend="sc">F</hi>AUSTA</stage>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Udiste, o mia consorte, i rei disegni</l>
             <l>D?alma ribelle, al nuovo sol voi forse</l>
@@ -1783,99 +1814,99 @@
             <l>Non vi avesse l?amara libertate</l>
             <l>Colui che torre a me volea la vita.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>L?udii, signor, e ne le vene il sangue</l>
             <l>Tutto gelommi, ed obbliò suo corso,</l>
             <l>Tal che mi svenni a mie donzelle in braccia.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Or si conforti il vostro cor, che sgombra</l>
             <l>L?alta cura di Leto, e del mio Crispo</l>
             <l part="I">Ogni periglio.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l part="M">Che? di Crispo?</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l part="F">Ei cangia</l>
             <l>I sospetti custodi, e tra più fidi</l>
             <l>Per nostra guardia sceglierà i migliori.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Per Dio, Signor, né a lui, né a sue genti</l>
             <l>Più fidate voi stesso; in me si avanza,</l>
             <l>Non si scema il timor pe’ vostri detti.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>E donde in voi sì rio sospetto ha loco?</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Guardatevi da lui, sposo, e ciò basti.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Ognor fido il conobbi, e giusto, e saggio.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l part="I">Tal io non già.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l part="F">Che d?invida noverca</l>
             <l>Forse il mirate con torti occhi e biechi.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>E pur me da madrigna egli non guarda.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Qual madre ognor egli v?onora e cole.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l part="I">Troppo innocente il riputate.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l part="F">E voi</l>
             <l>Mel fingete pur troppo empio ed infido.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l part="I">Ah fosse pur quale il credete.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l part="F">In core</l>
             <l>Di madrigna tal voglia unqua non nacque.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Tacerei, se minor fusse il periglio.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Creder non debbo a chi ‘l buon Crispo accusa.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Per vostro ben pur non creduta, io voglio</l>
             <l part="I">Dir ciò che deggio.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l part="F">A non mentir badate.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>So ben che saggia donna a sposo altero</l>
             <l>Mai non discopre chi l?onor le ‘nsidia,</l>
@@ -1890,7 +1921,7 @@
             <l>E Crispo, Crispo a ciò mi strigne. Or voi</l>
             <l>Se m?intendete ben, fate ch?io taccia.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Più v?intendo che credo, in lui non trova</l>
             <l>Ciò che virtù non è breve ricetto,</l>
@@ -1899,7 +1930,7 @@
             <l>Sospetto è ‘l labbro che l?accusa, e chiara</l>
             <l>È troppo agli occhi miei quella innocenza.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Io son dunque la rea, dunque io bugiarda</l>
             <l>D?infame colpa un innocente accuso?</l>
@@ -1912,11 +1943,11 @@
             <l>Volge il desire, anco la vita e al regno</l>
             <l part="I">Tender può insidie.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l part="F">E quando, e dove, e come?</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Questo dì stesso, a le mie stanze. In pria</l>
             <l>Con dolci detti, e poi con amorosi</l>
@@ -1934,7 +1965,7 @@
             <l>Sospende, allor dagli occhi suoi mi tolsi,</l>
             <l>Ed e’ partissi minacciante, irato.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Già mia mente vacilla, oimè, già dubbio</l>
             <l>Son di sua lealtade, egli non volle</l>
@@ -1947,14 +1978,14 @@
             <hi rend="Italic">Scena quinta</hi>
           </head>
           <stage><hi rend="sc">C</hi>RISPO <hi rend="Italic">e</hi><hi rend="sc">D</hi>ETTI</stage>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l>Signor, dal campo nuova gente aspetto</l>
             <l>Per vostra guardia, e fra l?armate schiere</l>
             <l>Sceglierà Flavio i più fedeli, e forti:</l>
             <l part="I">Ciò a lui commisi.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l part="F">Or non ravvisi, o Crispo,</l>
             <l>Qui del tuo genitor l?Augusta moglie?</l>
@@ -1977,14 +2008,14 @@
             <l>Periglio; or parti, scelerato, e togli</l>
             <l>Dagli occhi miei così spiacente obbietto.</l>
           </sp>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l>E Fausta accusar me d?impuro foco</l>
             <l>Ardisce? Padre mio resto di sasso,</l>
             <l>E lo stupore immenso al labbro toglie</l>
             <l part="I">Ogni difesa.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l part="F">Io sofferir non posso</l>
             <l>Sì oltraggioso parlar, signor, men vado,</l>
@@ -1997,11 +2028,11 @@
             <hi rend="Italic">Scena sesta</hi>
           </head>
           <stage><hi rend="sc">C</hi>RISPO <hi rend="Italic">e</hi><hi rend="sc">C</hi>OSTANTINO</stage>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l part="I">Signor sì ree calunni…</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l part="F">Ah non sol Fausta</l>
             <l>Scopre tua colpa, ma pur l?opre e ‘l volto;</l>
@@ -2010,7 +2041,7 @@
             <l>In uno disleal, ben è sospetto</l>
             <l>D?ogn?altro fallo, ed esser dee temuto.</l>
           </sp>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l>Io giustamente da sì rea menzogna</l>
             <l>Provocato poria di vie più grave</l>
@@ -2033,7 +2064,7 @@
             <l>Non merta fede no, signor, chiunque</l>
             <l>Me di lascivia, e così enorme, accusa.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Questo sfrenato orgoglio, onde superbo</l>
             <l>Oltra l?usato di te parli, mostra</l>
@@ -2041,7 +2072,7 @@
             <l>Che cangiato abbia ancor voglie e costumi,</l>
             <l>Chi tutt?altro è ‘n parlar da quel ch?egli era.</l>
           </sp>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l>Non di superbia, ma di zelo è figlio</l>
             <l>Il mio parlar, se troppo il cor mi pugne</l>
@@ -2052,13 +2083,13 @@
             <l>Più giustizia farà, che non voi, cui</l>
             <l>Sì grave inganno or gli occhi appanna e fascia.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Ed osi ancor di Fausta il nome augusto</l>
             <l>Aver nel labbro? Ah non più doglia e stizza</l>
             <l>Suscitar nel mio cor. Perfido, vanne.</l>
           </sp>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l>Padre, e signor l?ubbidir voi m?è caro</l>
             <l>Sovra ogni cosa, io partirò, ma piagno</l>
@@ -2084,13 +2115,13 @@
             <l>Ma più m?addoglia, s?innocente o reo,</l>
             <l>Esser deggio di voi pena e tormento.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Non son sì molle, onde a’ mendaci detti</l>
             <l>D?un disleal intenerir mi deggia.</l>
             <l>Or parti, e taci, indi saprai tua sorte.</l>
           </sp>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l>Padre, per ubbidirvi, io taccio e parto.</l>
           </sp>
@@ -2100,7 +2131,7 @@
             <hi rend="Italic">Scena settima</hi>
           </head>
           <stage><hi rend="sc">C</hi>OSTANTINO <hi rend="Italic">solo</hi></stage>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Quai voci oimè, quai sensi, e da chi usciro?</l>
             <l>Sensi e voci da far tenere ancora</l>
@@ -2123,18 +2154,18 @@
             <hi rend="Italic">Scena ottava</hi>
           </head>
           <stage><hi rend="sc">L</hi>ETO <hi rend="Italic">e ‘l</hi><hi rend="sc">D</hi>ETTO </stage>
-          <sp>
+          <sp who="#leto">
             <speaker><hi rend="sc">L</hi>ETO</speaker>
             <l>Signor, in ceppi è già colui che duce</l>
             <l part="I">Era de l?empia e ria congiura.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l part="F">Narra</l>
             <l>Chi fu lo ‘ndegno, e qual furor lo spinse</l>
             <l>A tanto eccesso, e come in tua man venne.</l>
           </sp>
-          <sp>
+          <sp who="#leto">
             <speaker><hi rend="sc">L</hi>ETO</speaker>
             <l>È Flavio il reo, che de le scelte genti,</l>
             <l>Che ‘n guardia son di Crispo, è il primo duce,</l>
@@ -2153,7 +2184,7 @@
             <l>Quando pur giunse nostra gente, e ‘l tenne,</l>
             <l>Ed or vivo in prigion morde suoi lacci.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Lasso, qual?altri ancor non dubbi segni</l>
             <l>Per far Crispo più reo, me più ‘nfelice</l>
@@ -2170,14 +2201,14 @@
             <l>Indi a me riedi, poiché mal sì grave</l>
             <l>Ben fia lieve a curar, quando è scoperto.</l>
           </sp>
-          <sp>
+          <sp who="#leto">
             <speaker><hi rend="sc">L</hi>ETO</speaker>
             <l>Signor, con quanto è in me d?ingegno, e forza,</l>
             <l>Veloce adempierò vostri comandi.</l>
           </sp>
         </div>
         <div type="epilogue">
-          <sp>
+          <sp who="#coro">
             <speaker><hi rend="sc">C</hi>ORO</speaker>
             <lg type="canzone">
               <lg>
@@ -2279,7 +2310,7 @@
             <hi rend="Italic">Scena prima</hi>
           </head>
           <stage><hi rend="sc">C</hi>RISPO <hi rend="Italic">e</hi><hi rend="sc">F</hi>IRMIANO</stage>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l>Se lo ‘mpero e la vita or sol tentasse</l>
             <l>Tormi fortuna, io con sicura fronte</l>
@@ -2292,7 +2323,7 @@
             <l>Trovasti, o fato, al fin l?armi possenti</l>
             <l>A vincer del mio cor l?antico ardire.</l>
           </sp>
-          <sp>
+          <sp who="#firmiano">
             <speaker><hi rend="sc">F</hi>IRMIANO</speaker>
             <l>Lasciam, signore, i favolosi e vani</l>
             <l>Nomi di sorte, di fortuna e fato.</l>
@@ -2314,7 +2345,7 @@
             <l>Incontro a’ gli empi accusator bugiardi,</l>
             <l>Ed e’, che sa lo ‘nterno, il resto curi.</l>
           </sp>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l>Oimè, troppo a’ miei danni armata pugna</l>
             <l>Infame schiera di menzogne rie,</l>
@@ -2329,7 +2360,7 @@
             <l>Di tante ch?io sostenni alte fatiche</l>
             <l>Nel cammin di virtude alpestre e duro.</l>
           </sp>
-          <sp>
+          <sp who="#firmiano">
             <speaker><hi rend="sc">F</hi>IRMIANO</speaker>
             <l>Di se stessa è virtù frutto e mercede,</l>
             <l>Né vero onor va mai da lei disgiunto,</l>
@@ -2346,7 +2377,7 @@
             <hi rend="Italic">Scena seconda</hi>
           </head>
           <stage><hi rend="sc">L</hi>ETO <hi rend="Italic">e i</hi><hi rend="sc">D</hi>ETTI</stage>
-          <sp>
+          <sp who="#leto">
             <speaker><hi rend="sc">L</hi>ETO</speaker>
             <l>Signor, m?è grave che de vostri lacci</l>
             <l>Io sia messo e ministro. Augusto il vuole,</l>
@@ -2354,7 +2385,7 @@
             <l>A me cediate, ed in prigion vi meni.</l>
             <l>Il Ciel ben sallo se mi pesa e duole.</l>
           </sp>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l>Il brando, o Leto, che mi cinse al fianco</l>
             <l>Il signor nostro, a lui tu rendi, e dilli</l>
@@ -2366,19 +2397,19 @@
             <l>Sue brame adempio, e perché vien da lui,</l>
             <l>Sia giusto o no, qualunque duol m?è caro.</l>
           </sp>
-          <sp>
+          <sp who="#firmiano">
             <speaker><hi rend="sc">F</hi>IRMIANO</speaker>
             <l>Misero prence! e da qual?occhi un fiume</l>
             <l>D?amaro pianto non trarria pietade,</l>
             <l>D?un uom, ch?è reo, perché la colpa abborre.</l>
           </sp>
-          <sp>
+          <sp who="#leto">
             <speaker><hi rend="sc">L</hi>ETO</speaker>
             <l>Signor, il vostro generoso petto</l>
             <l>Ira non prenda, se l?uficio rio</l>
             <l>Adempio sol per ubbidire Augusto.</l>
           </sp>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l>Anzi io voglio così, vo’ che fedele</l>
             <l>Servi ad Augusto, e grazie ancor ten rendo.</l>
@@ -2386,11 +2417,11 @@
             <l>Sol perché tale il genitor mi crede,</l>
             <l>Son prigioniero, andiam dov?egli impose.</l>
           </sp>
-          <sp>
+          <sp who="#leto">
             <speaker><hi rend="sc">L</hi>ETO</speaker>
             <l>Sieguo vostr?orme addolorato e mesto.</l>
           </sp>
-          <sp>
+          <sp who="#firmiano">
             <speaker><hi rend="sc">F</hi>IRMIANO</speaker>
             <l>Io deggio ben, infin che posso, e lice</l>
             <l>Seguirlo, indi tornare al grande Augusto,</l>
@@ -2403,19 +2434,19 @@
             <hi rend="Italic">Scena terza</hi>
           </head>
           <stage><hi rend="sc">C</hi>OSTANTINO <hi rend="Italic">e</hi><hi rend="sc">F</hi>AUSTA</stage>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>E al fin già chiaro il tradimento enorme,</l>
             <l>E ‘l traditore, oimè, scorgo in un figlio.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>E figlio è ancor chi al letto, al regno, al sangue</l>
             <l>Del proprio genitor l?empio desire</l>
             <l>Volger ardio? Ma come a voi palese</l>
             <l>L?autore e ‘l modo è de la ria congiura?</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Flavio, cui sol palese era l?arcano</l>
             <l>Del crudel tradimento, al solo aspetto</l>
@@ -2431,7 +2462,7 @@
             <l>O nel mio figlio un traditor conservo</l>
             <l part="I">A la mia morte.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l part="F">Eh, caro sposo, è forza</l>
             <l>Talor aprir le proprie vene, ed indi</l>
@@ -2441,13 +2472,13 @@
             <l>Sangue da voi pur da gran tempo uscito,</l>
             <l>Ed or sì guasto, ch?è a voi rischio e danno?</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Ah, Fausta, è figlio. Ogni tesoro e regno</l>
             <l>Cederei pronto, e morrei lieto ancora,</l>
             <l>Pur ch?e’ fosse innocente, altri mendace.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>E’ nondimeno è reo. Ma che? temete</l>
             <l>Con lui perder ancor di padre il nome?</l>
@@ -2458,7 +2489,7 @@
             <l>Quella stragge farò che del mio padre</l>
             <l>Seppi soffrir da l?ira vostra ultrice.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Saggia parlate, e consigliate il dritto;</l>
             <l>Ma non so che fareste al duro caso</l>
@@ -2469,7 +2500,7 @@
             <l>Debbo a natura, a la giustizia, a <rs type="luogo">Roma</rs>.</l>
             <l part="I">Disporrò poi ciò che fia meglio.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l part="F">Ancora</l>
             <l>Di vostra sicurtà paga non sono,</l>
@@ -2477,7 +2508,7 @@
             <l>Ed altri rei la gran congiura asconde,</l>
             <l>E far degli empi a mio piacer vendetta.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>A me riserbo il giudicar di Crispo:</l>
             <l>Di tutti gli altri, o libertade o morte</l>
@@ -2490,7 +2521,7 @@
             <hi rend="Italic">Scena quarta</hi>
           </head>
           <stage><hi rend="sc">F</hi>AUSTA <hi rend="Italic">e poi</hi><hi rend="sc">N</hi>UTRICE</stage>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Omai già stanco è di mentire il labbro,</l>
             <l>Quante calunnie, e quanti rei consigli,</l>
@@ -2515,7 +2546,7 @@
             <l>Ah Flaviana, gli empi, e scelerati</l>
             <l>Tuoi detti, quanto son per me funesti.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>E sempre, o Augusta, con turbato ciglio,</l>
             <l>Sempre in affanni, e non volgete un guardo</l>
@@ -2526,14 +2557,14 @@
             <l>Flavio ritrova fede, opra sicuro</l>
             <l>Licinio, or qual cagion resta di duolo?</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Quella che ‘n tristo cor non mai scompagna</l>
             <l>La colpa ancor ne’ più lieti successi.</l>
             <l>Quell?amaro, che sempre attosca il dolce,</l>
             <l>Di quanto l?uom con vizio e ‘nganno ottiene.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>Effetti son di non avvezzo core</l>
             <l>A l?opre accorte, ma ‘l successo, e l?uso</l>
@@ -2547,7 +2578,7 @@
             <l>Torti modi e’ pur giugne ove desia,</l>
             <l>Del suo vano timor si ride, e pente.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Chi puote induri a tante colpe il core,</l>
             <l>Ch?io già diffido, e quando altri felice</l>
@@ -2557,7 +2588,7 @@
             <l>Minaccianti sgridarmi a tutte l?ore,</l>
             <l>O vada, o seggia, o parli, o vegghi, o dorma.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>Suol chi ‘n vedovo letto afflitta giace</l>
             <l>Mirar tai larve, ma d?amante sposo</l>
@@ -2568,13 +2599,13 @@
             <l>Miro intrepida un figlio, e nulla temo,</l>
             <l>Poiché sa porre i miei consigli in opra.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>È in mio poter sua libertade, Augusto</l>
             <l>Diemmi, ch?ogni prigion si stringa, e sferri</l>
             <l>Al cenno mio, sol Crispo a sé riserba.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker><hi rend="sc">N</hi>UTRICE</speaker>
             <l>Tolsevi il meglio, ma vo’ Flavio in ceppi,</l>
             <l>Fin che Crispo vivrà, fin che non fia</l>
@@ -2587,7 +2618,7 @@
             <l>Aver in dubbie imprese ognora intento</l>
             <l>L?udito e ‘l guardo a quel che giova e nuoce.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>E in questo il tuo consiglio anco si adempia.</l>
           </sp>
@@ -2597,7 +2628,7 @@
             <hi rend="Italic">Scena quinta</hi>
           </head>
           <stage><hi rend="sc">C</hi>OSTANTINO <hi rend="Italic">e</hi><hi rend="sc">F</hi>IRMIANO</stage>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Che dir potrai mio Firmiano, e quali</l>
             <l>Argomenti addur puoi che me ‘nnocente</l>
@@ -2605,7 +2636,7 @@
             <l>Qual tu cerchi mostrarlo, e impero, e vita</l>
             <l>Volentier cederei per tal desio.</l>
           </sp>
-          <sp>
+          <sp who="#firmiano">
             <speaker><hi rend="sc">F</hi>IRMIANO</speaker>
             <l>Signor, dirò con fido cor nel labbro,</l>
             <l>Che da somma innocenzia a somma empiezza</l>
@@ -2630,7 +2661,7 @@
             <l>Creder potrà che ‘n tanti empi misfatti</l>
             <l>E’ traboccato in un sol punto sia?</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Potrei per tue ragion a quel ch?io veggio</l>
             <l>Non dar credenza, ma qual argomento</l>
@@ -2648,7 +2679,7 @@
             <l>Che adunque mai potrò creder di lui,</l>
             <l>Se non lascivia, ambizione, orgoglio?</l>
           </sp>
-          <sp>
+          <sp who="#firmiano">
             <speaker><hi rend="sc">F</hi>IRMIANO</speaker>
             <l>Credasi in altri ogni menzogna, e quanto</l>
             <l>Può lo ‘nganno trovar frodi più ascose,</l>
@@ -2658,100 +2689,100 @@
             <l>Lo scuopron senza colpa i detti e l'opre,</l>
             <l>Che di sua bocca e di sua mano usciro.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Come porian, se qual tu dici e’ fosse,</l>
             <l>Tanti segni mostrarlo iniquo e reo?</l>
           </sp>
-          <sp>
+          <sp who="#firmiano">
             <speaker><hi rend="sc">F</hi>IRMIANO</speaker>
             <l part="I">Se ‘l volete, il dirò.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l part="F">Libero parla.</l>
           </sp>
-          <sp>
+          <sp who="#firmiano">
             <speaker><hi rend="sc">F</hi>IRMIANO</speaker>
             <l part="I">Può Fausta anco mentir.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l part="F">E que’ pallori?</l>
           </sp>
-          <sp>
+          <sp who="#firmiano">
             <speaker><hi rend="sc">F</hi>IRMIANO</speaker>
             <l>Per l?altrui colpe uom giusto ancora imbianca.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l part="I">Flavio è suo duce.</l>
           </sp>
-          <sp>
+          <sp who="#firmiano">
             <speaker><hi rend="sc">F</hi>IRMIANO</speaker>
             <l part="F">Ma non caro a lui.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l part="I">Perché il soffriva?</l>
           </sp>
-          <sp>
+          <sp who="#firmiano">
             <speaker><hi rend="sc">F</hi>IRMIANO</speaker>
             <l part="F">Voi gliel deste in prima.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Egli per lui fuor de la reggia uscio.</l>
           </sp>
-          <sp>
+          <sp who="#firmiano">
             <speaker><hi rend="sc">F</hi>IRMIANO</speaker>
             <l>Per chiamar nuova gente in vostra aita.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Sol tentar può chi vuol regnar mia morte.</l>
           </sp>
-          <sp>
+          <sp who="#firmiano">
             <speaker><hi rend="sc">F</hi>IRMIANO</speaker>
             <l>Né il solo Crispo al sommo impero aspira.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Ma chi può ciò saper sol Crispo accusa.</l>
           </sp>
-          <sp>
+          <sp who="#firmiano">
             <speaker><hi rend="sc">F</hi>IRMIANO</speaker>
             <l>Di qual credenza un reo fellone è degno?</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>A chi creder degg?io, s?altri ciò ignora?</l>
           </sp>
-          <sp>
+          <sp who="#firmiano">
             <speaker><hi rend="sc">F</hi>IRMIANO</speaker>
             <l part="I">A l'antiche opre sue.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l part="F">Ciò mi si toglie.</l>
           </sp>
-          <sp>
+          <sp who="#firmiano">
             <speaker><hi rend="sc">F</hi>IRMIANO</speaker>
             <l part="I">Da chi?</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l part="F">Da nuovi e sì contrari segni.</l>
           </sp>
-          <sp>
+          <sp who="#firmiano">
             <speaker><hi rend="sc">F</hi>IRMIANO</speaker>
             <l part="I">Credesi adunque a un reo?</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l part="F">Ragion mi sforza.</l>
           </sp>
-          <sp>
+          <sp who="#firmiano">
             <speaker><hi rend="sc">F</hi>IRMIANO</speaker>
             <l>Dunque un fellon potrà timor fingendo</l>
             <l>Accusar lo ‘nnocente, e acquistar fede,</l>
@@ -2778,7 +2809,7 @@
             <l>Chiaro veduto l?altrui bene, e ‘l giusto,</l>
             <l>Ch?oggi per mal comun mi sembran chiusi.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Con tuoi detti a bramarlo induci il core,</l>
             <l>Ma non la mente a crederlo non reo,</l>
@@ -2787,7 +2818,7 @@
             <l>Ma tu, che sì ragioni, or che faresti,</l>
             <l>Se t?ingombrasser tanti miei sospetti?</l>
           </sp>
-          <sp>
+          <sp who="#firmiano">
             <speaker><hi rend="sc">F</hi>IRMIANO</speaker>
             <l>Io che so qual sia Crispo, unqua fra’ lacci</l>
             <l>Non l?avrei stretto, ma le ‘ngiuste accuse</l>
@@ -2800,19 +2831,19 @@
             <l>De’ tormenti, ma il duolo, insegna il vero</l>
             <l>Dire a color ch?han di mentire usanza.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Ciò è lieve cosa, e se non giova, almeno</l>
             <l>Nuocer non può. Vedrem Flavio in tormenti,</l>
             <l>Che narrerà, ma certo in van si tenta.</l>
           </sp>
-          <sp>
+          <sp who="#firmiano">
             <speaker><hi rend="sc">F</hi>IRMIANO</speaker>
             <l>Spero in colui che muove e frena il tutto,</l>
             <l>Che pel sincero mio consiglio sia</l>
             <l>Squarciato il velo agli occhi vostro avvolto.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Egli il comun desio nostro secondi.</l>
           </sp>
@@ -2822,7 +2853,7 @@
             <hi rend="Italic">Scena sesta</hi>
           </head>
           <stage><hi rend="sc">F</hi>AUSTA <hi rend="Italic">sola</hi></stage>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Intesi a tempo: e troverassi ancora</l>
             <l>Scudo novello che difenda e copra</l>
@@ -2851,7 +2882,7 @@
             <hi rend="Italic">Scena settima</hi>
           </head>
           <stage><hi rend="sc">L</hi>ICINIO <hi rend="Italic">e</hi><hi rend="sc">F</hi>AUSTA</stage>
-          <sp>
+          <sp who="#licinio">
             <speaker><hi rend="sc">L</hi>ICINIO</speaker>
             <l>Benché a’ nostri desir la sorte arrida,</l>
             <l>Fin ch?io non colga il desiato frutto</l>
@@ -2863,7 +2894,7 @@
             <l>La vita ancor, col regal manto, e ‘l trono,</l>
             <l>Quai sol per esser di voi degno or bramo.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>A miglior tempo, o mio Licinio, il vostro</l>
             <l>Labbro parli d?amor. Si badi ad altro,</l>
@@ -2873,35 +2904,35 @@
             <l>Che questi vinto al fin da l?aspro duolo,</l>
             <l>Seco noi tragga a inevitabil morte.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><hi rend="sc">L</hi>ICINIO</speaker>
             <l>Giusto è ‘l timor; per fermo a lui daransi</l>
             <l>Tormenti eguali al grande alto segreto,</l>
             <l>Pronto rimedio un tanto mal prevegna.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Sua libertade è già ‘n mia possa, or questa</l>
             <l>E lui difenda, e noi dal gran periglio.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><hi rend="sc">L</hi>ICINIO</speaker>
             <l>Debil difesa, poiché troppo lunge</l>
             <l>Stendesi il braccio di sdegnato Augusto,</l>
             <l>E chiaro indizio ancor daria tal fuga,</l>
             <l part="I">Del favor nostro a pro di Flavio.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l part="F">Or quale</l>
             <l part="I">A noi rimane altro riparo?</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><hi rend="sc">L</hi>ICINIO</speaker>
             <l part="F">Un solo,</l>
             <l part="I">E questo è la sua morte.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l part="F">Ah non sia vero</l>
             <l>Ch?opra sì ‘ngrata unqua di me si narri.</l>
@@ -2911,7 +2942,7 @@
             <l>Che l?ampia strada al solio v?apre, e tanto</l>
             <l part="I">Ad amar voi mi scalda.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><hi rend="sc">L</hi>ICINIO</speaker>
             <l part="F"> O come lunge</l>
             <l>Dal vero il pensier vostro in ciò travia.</l>
@@ -2931,7 +2962,7 @@
             <l>Non per ben nostro, ma per suo vantaggio,</l>
             <l>Or che necessità sì ria ne preme.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Da che vi piace, a la salvezza nostra</l>
             <l>Ceda al fin vinto il natural desio</l>
@@ -2941,17 +2972,17 @@
             <l>Quello diria, che per celare oprato</l>
             <l>Avremmo ciò che tanto l?alma abborre.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><hi rend="sc">L</hi>ICINIO</speaker>
             <l part="I">Col figlio cada anco la madre.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l part="F">Or questa</l>
             <l>D?ogn?altra immanità fora maggiore.</l>
             <l>Si muoia, o prence, o un?altra via si tenti.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><hi rend="sc">L</hi>ICINIO</speaker>
             <l>Altra via non veggio, e sol da questa pende</l>
             <l>L?onor, lo ‘mpero, e vostra vita, e mia,</l>
@@ -2962,7 +2993,7 @@
             <l>Duo traditor? prendete adunque Augusta</l>
             <l>O disonor e morte, o ‘l sangue loro.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Che far mai debbo? Ah Flaviana, ah quanto</l>
             <l>Ti pugnan contro contro i tuo’ propri consigli,</l>
@@ -2975,14 +3006,14 @@
             <l>E talor con sua man lo getta e perde,</l>
             <l>Per iscampar se stesso, in mar cruccioso.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><hi rend="sc">L</hi>ICINIO</speaker>
             <l>Nuocer può la tardanza, or voi lor morte</l>
             <l>Ite ad imporre, indi trovar fia lieve</l>
             <l>Cagion, per cui ciò prenda in grado Augusto,</l>
             <l>Ch?io vo dove mi chiama il gran disegno.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Oh com in un sol giorno in tanti eccessi</l>
             <l>Involger mi potei: qual folta schiera</l>
@@ -3001,7 +3032,7 @@
           </sp>
         </div>
         <div type="epilogue">
-          <sp>
+          <sp who="#coro">
             <speaker><hi rend="sc">C</hi>ORO</speaker>
             <lg type="canzone">
               <lg>
@@ -3072,7 +3103,7 @@
             <hi rend="Italic">Scena prima</hi>
           </head>
           <stage><hi rend="sc">C</hi>OSTANTINO <hi rend="Italic">solo</hi></stage>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Speranza è troppo debile e fallace</l>
             <l>Quella di Firmian. Chiare ben veggio</l>
@@ -3105,7 +3136,7 @@
             <hi rend="Italic">Scena seconda</hi>
           </head>
           <stage><hi rend="sc">L</hi>ETO <hi rend="Italic">e</hi><hi rend="sc">C</hi>OSTANTINO</stage>
-          <sp>
+          <sp who="#leto">
             <speaker><hi rend="sc">L</hi>ETO</speaker>
             <l>Signor, le schiere tutte armate a guerra</l>
             <l>Chieggion libero Crispo, e minaccianti</l>
@@ -3119,7 +3150,7 @@
             <l>E gridan tutti: o libertade a Crispo,</l>
             <l>O chi la vieta, crudel guerra e morte.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Or che dispongo in sì dubbio periglio?</l>
             <l>Se la sua libertà, che mai da quella</l>
@@ -3136,7 +3167,7 @@
             <l>Leto, col tuo consiglio omai soccorri</l>
             <l>Nel grave dubbio a la confusa mente.</l>
           </sp>
-          <sp>
+          <sp who="#leto">
             <speaker><hi rend="sc">L</hi>ETO</speaker>
             <l>Sol dir poss?io che ‘l gran periglio attende</l>
             <l>Presto riparo, o libertade o morte,</l>
@@ -3150,7 +3181,7 @@
             <hi rend="Italic">Scena terza</hi>
           </head>
           <stage><hi rend="sc">L</hi>ICINIO <hi rend="Italic">e</hi><hi rend="sc">D</hi>ETTI</stage>
-          <sp>
+          <sp who="#licinio">
             <speaker><hi rend="sc">L</hi>ICINIO</speaker>
             <l>Augusto e zio, chi de la gran congiura</l>
             <l>Inteso fu, già tra le schiere spande</l>
@@ -3165,7 +3196,7 @@
             <l>Che gioioso andrò ‘ncontro a quella morte,</l>
             <l>Che a me fia nobil gloria, e a voi salute.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Chiaro nipote, da te <rs type="luogo">Roma</rs> aspetta</l>
             <l>Ampio ristoro a questi suoi gran danni,</l>
@@ -3173,7 +3204,7 @@
             <l>Figlio e sostegno, in vece di colui</l>
             <l>Che fier nemico, e traditor divenne.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><hi rend="sc">L</hi>ICINIO</speaker>
             <l>Per me pregiato è di fedel suggetto</l>
             <l>Il solo vanto, ma per or si badi</l>
@@ -3187,7 +3218,7 @@
             <l>E col protesto reo di salvar Crispo,</l>
             <l>Ognun disfogherà l?empie sue voglie.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Che più penso? or che a <rs type="luogo">Roma</rs> il gran periglio</l>
             <l>Sovrasta di servir sì rio tiranno:</l>
@@ -3208,12 +3239,12 @@
             <l>Leto, va’ tosto, pria che pentimento</l>
             <l>L?opra distolga intrepida e diritta.</l>
           </sp>
-          <sp>
+          <sp who="#leto">
             <speaker><hi rend="sc">L</hi>ETO</speaker>
             <l>Dolente vado ad ubbidirvi, o sire,</l>
             <l>Ah miser Crispo, ah più ‘nfelice padre!</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>E tu non indugiar, Licinio; vanne,</l>
             <l>E a le schiere prometti ampio perdono,</l>
@@ -3222,7 +3253,7 @@
             <l>Con lusinghe e minacce, e fa ch?io veggia</l>
             <l>Per tua virtute a tanto mal riparo.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><hi rend="sc">L</hi>ICINIO</speaker>
             <l>Vado, signore, a palesar con l?opre</l>
             <l>Quanta ho ver voi ne l?alma e fede e zelo.</l>
@@ -3233,7 +3264,7 @@
             <hi rend="Italic">Scena quarta</hi>
           </head>
           <stage><hi rend="sc">C</hi>OSTANTINO <hi rend="Italic">e poi</hi><hi rend="sc">F</hi>AUSTA</stage>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Abbia chi vuole, e scettro, e manto, e alloro,</l>
             <l>Che troppo in questi a me fa l?empia sorte</l>
@@ -3262,20 +3293,20 @@
             <l>Via ne rimane a fuggir tanti affanni,</l>
             <l>Se nulla valmi, e a ciò morte non basta?</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Col sangue, o sposo, di duo fier nemici</l>
             <l>Un incendio smorzai, ch?a nostro danno</l>
             <l>Era a surger già presso alto e vorace.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Nulla più temo, or che ‘l più grave danno,</l>
             <l>Che affligger mi poteva, è certo: cade</l>
             <l>Già Crispo, Augusta omai gioisci e godi,</l>
             <l part="I">Già morte opprime il tuo nemico.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l part="F">Io solo</l>
             <l>Per nemico il conobbi allor che volle</l>
@@ -3288,12 +3319,12 @@
             <l>In me punto frenò l?ira novella,</l>
             <l>Infiammata dal vostro alto periglio.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>E Flavian ancor? narra, che mai</l>
             <l>Quest?empia contra me tentar poteo?</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Per liberar de la prigione il figlio,</l>
             <l>Raccolta avea torma d?infide genti,</l>
@@ -3313,7 +3344,7 @@
             <hi rend="Italic">Scena quinta</hi>
           </head>
           <stage><hi rend="sc">F</hi>LAVIO <hi rend="Italic">e</hi><hi rend="sc">D</hi>ETTI</stage>
-          <sp>
+          <sp who="#flavio">
             <speaker><hi rend="sc">F</hi>LAVIO</speaker>
             <l>Qualor l?uomo, signor, che per natura</l>
             <l>Al giusto inchina, a l?ingiustizia è volto,</l>
@@ -3332,20 +3363,20 @@
             <l>Il tutto oprai da Flaviana indutto,</l>
             <l>Mia madre, e rea cagion d?ogni mio danno.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Che ascolto? olà, chi ha più veloce il piede</l>
             <l>A la prigione or corra, e a Leto imponga</l>
             <l>Ch?adempier cessi il mio decreto, e meni</l>
             <l part="I">Qui Crispo, e tu, malvagia…</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l part="F">Eh, tanta fede</l>
             <l>Trova il parlar d?un traditor mendace,</l>
             <l>Che fa rei gl?innocenti e assolve i rei?</l>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><hi rend="sc">F</hi>LAVIO</speaker>
             <l>Così feci finor, ma cangio stile,</l>
             <l>Poiché ingrata mi foste, e con la morte</l>
@@ -3354,7 +3385,7 @@
             <l>Che primo a lei donaste, ella vi renda,</l>
             <l>Che ‘n pegno di su’ amor donollo al drudo.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Non più, già scorgo il tradimento indegno,</l>
             <l>Ah dolce speme mia, figlio innocente,</l>
@@ -3369,7 +3400,7 @@
             <hi rend="Italic">Scena sesta</hi>
           </head>
           <stage><hi rend="sc">F</hi>LAVIO <hi rend="Italic">e</hi><hi rend="sc">F</hi>AUSTA</stage>
-          <sp>
+          <sp who="#flavio">
             <speaker><hi rend="sc">F</hi>LAVIO</speaker>
             <l>Nulla più teme chi salvar non spera</l>
             <l>Più la vita e l?onore, e questa morte,</l>
@@ -3380,7 +3411,7 @@
             <l>Avrò degno gastigo al mio gran fallo,</l>
             <l>In un tempo avrò ancor giusta vendetta.</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Tua morte, o vile, a gran ragion tentai,</l>
             <l>Che ben degg?io d?un traditor temere,</l>
@@ -3389,7 +3420,7 @@
             <l>Quest?empio, sì che l?odiato aspetto</l>
             <l part="I">Più non turbi mia vista.</l>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><hi rend="sc">F</hi>LAVIO</speaker>
             <l part="F">Or l?ubbidite</l>
             <l>Ma il vero è già, vogliate o no, palese.</l>
@@ -3400,7 +3431,7 @@
             <hi rend="Italic">Scena settima</hi>
           </head>
           <stage><hi rend="sc">F</hi>AUSTA <hi rend="Italic">sola</hi></stage>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l>Fausta, che più si spera? e che più resta</l>
             <l>A far d?inganni enormi e d?opre inique?</l>
@@ -3456,7 +3487,7 @@
             <hi rend="Italic">Scena ottava</hi>
           </head>
           <stage><hi rend="sc">C</hi>OSTANTINO <hi rend="Italic">e</hi><hi rend="sc">F</hi>AUSTA ferita sopra una sedia</stage>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l part="F">Dove avrai scampo</l>
             <l>Vedovo padre e dispregiato Augusto,</l>
@@ -3474,7 +3505,7 @@
             <l>Spettacolo qui miro! uccisa giace</l>
             <l part="I">Fausta! …</l>
           </sp>
-          <sp>
+          <sp who="#fausta">
             <speaker><hi rend="sc">F</hi>AUSTA</speaker>
             <l part="F">Deh Costantin, gli ultimi accenti</l>
             <l>D?un cor pentito, benché in vano, ascolta.</l>
@@ -3486,7 +3517,7 @@
             <l>L?odio non passi ne’ miei figli, e in quelli</l>
             <l part="I">Innocenti ri…</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l part="F">Ah misera reina,</l>
             <l>Ecco dove la colpa al fin t?ha scorta,</l>
@@ -3522,14 +3553,14 @@
             <p><hi rend="sc">L</hi>ETO<hi rend="Italic">co’ soldati</hi> (un de’ quali porterà un bacino coperto)
  <hi rend="Italic">e</hi> <hi rend="sc">C</hi>OSTANTINO </p>
           </stage>
-          <sp>
+          <sp who="#leto">
             <speaker><hi rend="sc">L</hi>ETO</speaker>
             <l part="F">Augusto,</l>
             <l>Ecco il teschio superbo a voi presento</l>
             <l>D?un tiranno crudel, con cui reciso</l>
             <l>Il vostro cadde, ed il comun periglio.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Leto, deh togli sì spiacente vista,</l>
             <l>Non avanzar mio duolo, or che mi mena</l>
@@ -3538,7 +3569,7 @@
             <l>Per mia sventura, s?or che nulla giova</l>
             <l>Conosco il fallo di sua morte ingiusta.</l>
           </sp>
-          <sp>
+          <sp who="#leto">
             <speaker><hi rend="sc">L</hi>ETO</speaker>
             <l>Ingiusta! ah ben v?intendo, invitto sire.</l>
             <l>Rallegratevi omai, che il teschio è questo</l>
@@ -3546,26 +3577,26 @@
             <l>Crispo innocente, e di voi degno figlio.</l>
             <l>Tolgasi il velo; or qui volgete un guardo.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>E ‘l mio figlio diletto? or s?egli è vivo,</l>
             <l>Deh perché tarda a consolar suo padre,</l>
             <l>Col suo sì caro e desiato aspetto?</l>
           </sp>
-          <sp>
+          <sp who="#leto">
             <speaker><hi rend="sc">L</hi>ETO</speaker>
             <l>Egli è rimaso ad acchetar le turbe,</l>
             <l>Che per lui solo armato avean il braccio,</l>
             <l part="I">E a voi verrà tra poco.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l part="F">Or narra intanto</l>
             <l>Del gran successo gli accidenti strani,</l>
             <l>E come in un sol punto il fero aspetto</l>
             <l part="I">Cangiò fortuna in sì giulivo.</l>
           </sp>
-          <sp>
+          <sp who="#leto">
             <speaker><hi rend="sc">L</hi>ETO</speaker>
             <l part="F">Il vostro</l>
             <l>Decreto ad esseguir men gia dolente</l>
@@ -3616,12 +3647,12 @@
             <l>Irato volse, e lacerati in mille</l>
             <l>Pezzi furo in un punto i rei compagni.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Ma come de le irate e ribellanti</l>
             <l>Schiere Licinio si fe’ scorta e duce?</l>
           </sp>
-          <sp>
+          <sp who="#leto">
             <speaker><hi rend="sc">L</hi>ETO</speaker>
             <l>Narra costui, che lo seguì dal campo,</l>
             <l>E l?armi poscia a pro di Crispo volse,</l>
@@ -3643,7 +3674,7 @@
             <l>Viva il vendicator de’ nostri danni,</l>
             <l>E seguir ebbri di furor suoi passi.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Il traditor credea Crispo già spento,</l>
             <l>Poiché udio ciò che imposi, e se pietoso</l>
@@ -3653,7 +3684,7 @@
             <l>Ma troppo tarda il caro figlio, ed io</l>
             <l part="I">Più resister non posso, andiam.</l>
           </sp>
-          <sp>
+          <sp who="#leto">
             <speaker><hi rend="sc">L</hi>ETO</speaker>
             <l part="F">Già viene.</l>
           </sp>
@@ -3663,7 +3694,7 @@
             <hi rend="Italic">Scena ultima</hi>
           </head>
           <stage><hi rend="sc">C</hi>RISPO <hi rend="Italic">e</hi><hi rend="sc">D</hi>ETTI </stage>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l>Eccovi, Augusto, il vostro figlio, e reo</l>
             <l>Benché non sia se lo bramate estinto,</l>
@@ -3677,7 +3708,7 @@
             <l>Prezzo per ubbidirvi è scettro, e vita,</l>
             <l>Imponete; che al tutto io son già pronto.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Sorgi, o saggio, o magnanimo, o cortese,</l>
             <l>O generoso mio figlio, e conforto,</l>
@@ -3687,7 +3718,7 @@
             <l>Che allor sol ebbi un figlio, ed or racquisto</l>
             <l>In un figlio un eroe; nel sen ti stringo.</l>
           </sp>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l>S?oggi rinasco, il viver mio cominci</l>
             <l>Nobil principio, a’ vostri piè ritorno,</l>
@@ -3697,7 +3728,7 @@
             <l>Tragger vogl?io dal gran passato rischio,</l>
             <l>A chi m?offese l?ottener mercede.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Caddero in parte, a Flaviana un laccio</l>
             <l>Tolse l?indegna vita, a Fausta un ferro,</l>
@@ -3706,22 +3737,22 @@
             <l>Gli altri, che men colparo, abbian lo ‘ntero</l>
             <l>Perdono, e godan l?alta tua clemenza.</l>
           </sp>
-          <sp>
+          <sp who="#crispo">
             <speaker><hi rend="sc">C</hi>RISPO</speaker>
             <l>Vostri decreti adoro, e quinci apprendo</l>
             <l>Del perdonare e del punir le norme.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Ancor si premi chi fedel mostrossi,</l>
             <l>E più d?ogni altro Firmiano e Leto.</l>
           </sp>
-          <sp>
+          <sp who="#leto">
             <speaker><hi rend="sc">L</hi>ETO</speaker>
             <l>Alta mercede a me la nobil vita</l>
             <l>Sia di prenze sì degno, e ‘l gaudio vostro.</l>
           </sp>
-          <sp>
+          <sp who="#costantino">
             <speaker><hi rend="sc">C</hi>OSTANTINO</speaker>
             <l>Pria che tu vada a la prescritta impresa,</l>
             <l>Io vo’ che <rs type="luogo">Roma</rs> in tua presenzia applauda</l>
@@ -3742,7 +3773,7 @@
           </sp>
         </div>
         <div type="epilogue">
-          <sp>
+          <sp who="#coro">
             <speaker><hi rend="sc">C</hi>ORO</speaker>
             <lg type="canzone">
               <lg>

--- a/tei/marchese-l-ermenegildo.xml
+++ b/tei/marchese-l-ermenegildo.xml
@@ -75,6 +75,52 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="igonda">
+            <persName>Igonda</persName>
+          </person>
+          <person xml:id="leandro">
+            <persName>Leandro</persName>
+          </person>
+          <person xml:id="ermenegildo">
+            <persName>Ermenegildo</persName>
+          </person>
+          <person xml:id="recaredo">
+            <persName>Recaredo</persName>
+          </person>
+          <personGrp xml:id="coro">
+            <name>Coro</name>
+          </personGrp>
+          <person xml:id="genserico">
+            <persName>Genserico</persName>
+          </person>
+          <person xml:id="leovigildo">
+            <persName>Leovigildo</persName>
+          </person>
+          <person xml:id="gundimaro">
+            <persName>Gundimaro</persName>
+          </person>
+          <person xml:id="messaggiero">
+            <persName>Messaggiero</persName>
+          </person>
+          <personGrp xml:id="coro_1">
+            <name>Coro dell'atto primo</name>
+          </personGrp>
+          <personGrp xml:id="coro_2">
+            <name>Coro dell'atto secondo</name>
+          </personGrp>
+          <personGrp xml:id="coro_3">
+            <name>Coro dell'atto terzo</name>
+          </personGrp>
+          <personGrp xml:id="coro_4">
+            <name>Coro dell'atto quarto</name>
+          </personGrp>
+          <personGrp xml:id="coro_5">
+            <name>Coro dell'atto quinto</name>
+          </personGrp>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT-Salerno</name>Digitalizzazione</change>
@@ -156,7 +202,7 @@
             <hi rend="Italic">Scena prima</hi>
           </head>
           <stage><hi rend="sc">I</hi>GONDA <hi rend="Italic">e</hi><hi rend="sc">L</hi>EANDRO</stage>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l>Qui mentre il fosco ciel d'incerto lume</l>
             <l>L'alba ancor non imbianca, a noi sì mesto</l>
@@ -166,7 +212,7 @@
             <l>Ch'oppor compenso a grave mal si tenta:</l>
             <l>Deh, non far che sospesa oltre ne chiegga.</l>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker><hi rend="sc">L</hi>EANDRO</speaker>
             <l>Quel grave mal, che in orrida sembianza</l>
             <l>Da lungi io vidi, alta reina, è presso.</l>
@@ -180,13 +226,13 @@
             <l>Che, per privato, falso ben, gli detta</l>
             <l>Con finto zelo ogni empietà più cruda.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l>Già l'alma grande con sicura fronte</l>
             <l>Sua sorte aspetta e sa che il mal che nasce</l>
             <l>Dal ben oprar in ben sempre ritorna.</l>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker><hi rend="sc">L</hi>EANDRO</speaker>
             <l>Or mentre io chiuse avea le luci al sonno,</l>
             <l>Odo di trombe e squille e di confuse</l>
@@ -223,13 +269,13 @@
             <l>Si scorge, e quindi ancor gli aurei lavori,</l>
             <l>Pronti ad ogni uopo dell'amato eroe.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l>Questo dall'opre sue bel frutto or miete;</l>
             <l>E a <rs type="name">Serse</rs>, a <rs type="name">Creso</rs> far può invidia ancora</l>
             <l>Chi ‘l fido amor de’ suoi non l'oro apprezza.</l>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker><hi rend="sc">L</hi>EANDRO</speaker>
             <l>E ben pregiai più che tesori e regni</l>
             <l>In ogni bocca udir sue laudi eccelse:</l>
@@ -255,7 +301,7 @@
             <l>Ordin, qual potrò meglio, indi ritorno</l>
             <l>Farò a lei, ch'è di me la miglior parte”.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l>Sotto le insegne gloriose e sante</l>
             <l>Militar saprò anch'io, che ben sovente</l>
@@ -267,7 +313,7 @@
             <l>Quand'io fra poco andar debbo laddove</l>
             <l>L'alto periglio sua presenzia chiede?</l>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker><hi rend="sc">L</hi>EANDRO</speaker>
             <l>Ei medesmo il dirà, che a noi già viene;</l>
             <l>Sicché al vostro fedel tenero amore</l>
@@ -280,7 +326,7 @@
             <hi rend="Italic">Scena seconda</hi>
           </head>
           <stage><hi rend="sc">E</hi>RMENEGILDO <hi rend="Italic">e</hi><hi rend="sc">I</hi>GONDA</stage>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>Forse, Igonda, fia questo il giorno estremo</l>
             <l>In cui m'è dato il vagheggiar tuoi lumi,</l>
@@ -289,7 +335,7 @@
             <l>Che tua candida mano io stringa, e in essa,</l>
             <l>Col cuor sul labbro, il bacio ultimo imprima.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l>Il giorno estremo, che da te divisa</l>
             <l>Veder potrammi, sarà quel di morte:</l>
@@ -302,7 +348,7 @@
             <l>Spero lungi da te? Qual'avrà pace</l>
             <l>Quest'alma, incerta ognor di tua salvezza?</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>O dolce del mio duol causa e conforto,</l>
             <l>Lungi andar non dovrai: sarà tua stanza</l>
@@ -312,7 +358,7 @@
             <l>Del regnante, al cui piè, qual deve un figlio,</l>
             <l>Deporrò il brando, ed offrirò la vita.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l>Qual improvvisa folgore percuote</l>
             <l>Mio cuor, mia mente, e mie speranze atterra?</l>
@@ -334,7 +380,7 @@
             <l>Sol reo di morte, perché a morte offristi</l>
             <l>Vita sì bella e necessaria al mondo.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>Deh, con l'amare tue lagrime, e queste</l>
             <l>Penetranti parole, al cor costante</l>
@@ -355,7 +401,7 @@
             <l>Dal primo eterno Sol lume e vigore,</l>
             <l>Onde il dritto sentier conosca, e prema.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l>E piace al Ciel che volontario a morte</l>
             <l>S'esponga un prenze? Il Cielo è sol che l'armi</l>
@@ -367,129 +413,129 @@
             <l>Che l'innocenzia tua, l'amor di tutti,</l>
             <l>La vera fede, e ‘l dritto anco ti porge?</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>E vuoi che contra il genitor regnante,</l>
             <l>Quelle che a me fidò cittadi e genti,</l>
             <l>Volga rubelle, e quest'aura di vita,</l>
             <l>Che per lui spiro, a lui sia danno ed onta?</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l>Danno ed onta gli sia, se in te s'ancide</l>
             <l>Un tanto figlio, un successor sì degno.</l>
             <l>Toglilo pur da tal sorte con l'armi,</l>
             <l>E merto fia ciò ch'or sembra delitto.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>Mal far, per vietar male, ad uom non lice.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l part="I">Lice ad uom la difesa.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">Allor ch'è giusta.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l>Dritto è contro gli armati opponer l'armi.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>Ma non se armato vien chi a l'armi impera.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l>Giusto impero non ha chi i giusti opprime.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>Giudicar de’ regnanti a noi si vieta.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l>Lor misfatti impedir ben dee chi puote.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="I">Non già con farsi reo.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l part="F">Reo chi si salva?</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>E per salvarsi divenir rubello?</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l>Tal non è chi non reca al prenze oltraggio.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>È tal chi contro l'armi sue gli volge.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l part="I">Se’ tu figlio ed erede.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">E ancor vassallo.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l part="I">Come tal…</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">Doppiamente a lui tenuto.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l part="I">Morasi dunque.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">Il Ciel cura ne prenda.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l>Cura ne prende il Ciel, tu la rifiuti.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>Sa il Ciel prender, se vuol, mezzi più degni.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l>Ciò che scende di là più degno è sempre.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>Di là non mosse mai cagion di colpa.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l part="I">Chi ‘l popol arma?</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">Esser potria l'Inferno.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l part="I">L'Inferno a tuo favor!</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">Per farmi iniquo.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l>Fiero, ostinato, e di tua morte ingordo,</l>
             <l>Se le lagrime mie, ragioni, e prieghi,</l>
@@ -501,13 +547,13 @@
             <l>Del vero lume in rischiarar tua mente,</l>
             <l>Pur l'abbia in torla da pensier sì acerbo.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>Folle superbia è il rifiutar consiglio</l>
             <l>Da uom saggio, ma, sper'io, che non diverso</l>
             <l part="I">Sarà dal nostro.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l part="F">A noi venga Leandro.</l>
           </sp>
@@ -517,12 +563,12 @@
             <hi rend="Italic">Scena terza</hi>
           </head>
           <stage><hi rend="sc">L</hi>EANDRO <hi rend="Italic">e</hi><hi rend="sc">D</hi>ETTI&gt;</stage>
-          <sp>
+          <sp who="#leandro">
             <speaker><hi rend="sc">L</hi>EANDRO</speaker>
             <l>Ecco al cenno de’ suoi signor sovrani</l>
             <l part="I">Umil vassallo.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l part="F">A noi sempre sicura</l>
             <l>Scorta fedele, or al grand'uopo esponi</l>
@@ -543,7 +589,7 @@
             <l>Gole di feri ed affamati lupi</l>
             <l>Certa si porge volontaria preda.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>Più di certo periglio, incerta colpa</l>
             <l>Fuggir si deve; Igonda vuol che pugni</l>
@@ -558,7 +604,7 @@
             <l>Mente di lei, che a me cangia in tormento</l>
             <l>Quel da me sempre suo gradito affetto.</l>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker><hi rend="sc">L</hi>EANDRO</speaker>
             <l>In tal di puro amor nobil contesa,</l>
             <l>Scorgo gli affetti di fedel consorte,</l>
@@ -582,14 +628,14 @@
             <l>E l'odiato suo figlio il piè veloce</l>
             <l part="I">Porti fuor del gran regno.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">Ah, ch'io pavento</l>
             <l>Che dell'irato genitor lo sdegno</l>
             <l>Tutto d'Igonda mia rivolga a danno</l>
             <l>La invan tentata contro me vendetta.</l>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker><hi rend="sc">L</hi>EANDRO</speaker>
             <l>Da l'altrui mente è l'ira sua commossa,</l>
             <l>Che vendetta non vuol, ma solo agogna</l>
@@ -600,13 +646,13 @@
             <l>Quindi sua vita, e libertà, sicura</l>
             <l>De l'empio consiglier fia da l'inganno.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l>E dove mai tra perigliose, ignote,</l>
             <l>Alpestri vie vorrai tu che ramingo</l>
             <l part="I">Vada il tuo prenze?</l>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker><hi rend="sc">L</hi>EANDRO</speaker>
             <l part="F">Ovunque i passi ei volga,</l>
             <l>De’ cristian regni, qual eroe sovrano</l>
@@ -614,17 +660,17 @@
             <l>I più eccelsi regnanti offrirgli immensi</l>
             <l>Doni ed ospizio, e navi e genti ed armi.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l part="I">Io seguirollo.</l>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker><hi rend="sc">L</hi>EANDRO</speaker>
             <l part="F">Del gran prenze ispano</l>
             <l>A la consorte, ed all'eccelsa figlia</l>
             <l>Di <rs type="name">Sigisberto</rs>, ogni ragion ciò vieta.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l>L'ostinato volere, ond'egli a morte</l>
             <l>Correr volea, men dura al cor mi rende</l>
@@ -632,13 +678,13 @@
             <l>E al tempestoso mar le merci amate</l>
             <l>Di sua man perde ad iscampar sol vita.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>Al tuo consiglio, in cui scende e sfavilla</l>
             <l>Fiamma celeste, umil mi rendo e pronto:</l>
             <l>Il modo e ‘l tempo or tu pensa e disponi.</l>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker><hi rend="sc">L</hi>EANDRO</speaker>
             <l>Pria che l'aurora il ciel faccia vermiglio,</l>
             <l>A la città ritorna, ove il regnante</l>
@@ -647,7 +693,7 @@
             <l>Cauto sarai da pochi tuoi più fidi</l>
             <l>Accompagnato, e da gran gemme e oro.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l>L'oro e le gemme ad apprestar men vado,</l>
             <l>E quindi uniti la città noi vegga,</l>
@@ -660,7 +706,7 @@
             <hi rend="Italic">Scena quarta</hi>
           </head>
           <stage><hi rend="sc">L</hi>EANDRO <hi rend="Italic">ed</hi><hi rend="sc">E</hi>RMENEGILDO</stage>
-          <sp>
+          <sp who="#leandro">
             <speaker><hi rend="sc">L</hi>EANDRO</speaker>
             <l>Ben sai, signor, che ne l'opposta riva</l>
             <l>De l'ampio fiume, sovra agevol colle,</l>
@@ -679,13 +725,13 @@
             <l>Del regnante i Romani accoglier lieti</l>
             <l>Sapranno il successor del regno ispano.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>Tolga il Ciel ch'accoglienze abbia e soccorso</l>
             <l>Del mio re da’ nemici; andrò per l'onde,</l>
             <l>Dove divin voler sia che mi scorga.</l>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker><hi rend="sc">L</hi>EANDRO</speaker>
             <l>Lodo pensier sì generoso e fido.</l>
             <l>Te dunque il fiume infino al mar conduca,</l>
@@ -697,14 +743,14 @@
             <l>Avrai tranquilla ed onorata sede,</l>
             <l>Finch'altro fia dal Ciel di te prescritto.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>Seguirò tuoi consigli, e sol mi cale</l>
             <l>Serbar pura ed intatta a Dio la fede</l>
             <l>E al re mio genitor sempre, qual deve</l>
             <l>Figlio, e suddito umil, ossequio, e amore.</l>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker><hi rend="sc">L</hi>EANDRO</speaker>
             <l>O di padre miglior figlio ben degno!</l>
             <l>Il Cielo, il Cielo ha sol premio che agguaglia</l>
@@ -713,7 +759,7 @@
             <l>Da tue guardie qui viene, e ‘l volto asconde</l>
             <l part="I">Sotto l'elmo fulgente?</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">Egli non sembra</l>
             <l>Al portamento signoril persona</l>
@@ -725,19 +771,19 @@
             <hi rend="Italic">Scena quinta</hi>
           </head>
           <stage><hi rend="sc">R</hi>ECAREDO <hi rend="Italic">e</hi><hi rend="sc">D</hi>ETTI&gt;</stage>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="F">A te solo, o regnante,</l>
             <l part="I">Favellar voglio.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">Ognun seco mi lasci.</l>
             <l>Vanne tu ancor, Leandro; e in tanto il duolo</l>
             <l>Scema ad Igonda mia, co’ tuoi veraci</l>
             <l part="I">Santi consigli.</l>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker><hi rend="sc">L</hi>EANDRO</speaker>
             <l part="F">Il sommo Dio conceda</l>
             <l>Lena al mio basso dir, che tutto adempia</l>
@@ -749,22 +795,22 @@
             <hi rend="Italic">Scena sesta</hi>
           </head>
           <stage><hi rend="sc">E</hi>RMENEGILDO <hi rend="Italic">e</hi><hi rend="sc">R</hi>ECAREDO</stage>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">Chi se’? Favella.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="I">Mio re, caro german.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">Mio Recaredo!</l>
             <l>Unica speme mia, qual nuova e grande</l>
             <l>Occasion qui sconosciuto e solo</l>
             <l part="I">A me ti guida?</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="F">Fedeltade e amore.</l>
             <l>Troppo fu grave a me l'ira paterna</l>
@@ -783,74 +829,74 @@
             <l>Trassi a pregarti col più caldo affetto</l>
             <l part="I">Per tua salute.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">E qual fia tuo consiglio?</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l>Che nuovamente la fé d'<rs type="name">Arrio</rs> abbracci.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>E se cotesta fé l'alme tradite</l>
             <l>Piombar facesse negli eterni pianti?</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="I">Ciò è fola e sogno.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">Ma se ver ciò fosse?</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l>Folle chi per amor di vita o regno</l>
             <l part="I">La seguisse saria.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">Tal sarei dunque.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="I">Ma se lungi dal ver…</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">Lungi dal vero</l>
             <l>Non è, caro german, ciò ch'io ti narro.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="I">Dunque?</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">Sprezzar per la verace fede</l>
             <l part="I">So regno e vita.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="M">Ah, meglio pensa.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">Il meglio</l>
             <l part="I">Così pensai.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="M">Chi t'assicura?</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">Il chiaro</l>
             <l>Celeste lume, e la ragion, che vince</l>
             <l part="I">L'umane menti.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="F">Oimè, vedo che nulla</l>
             <l>Potran miei detti, e tornar debbo al campo</l>
@@ -867,12 +913,12 @@
             <l>Che non debil farai contrasto all'armi</l>
             <l part="I">Del furibondo padre.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">Eh no: tutt'altro</l>
             <l part="I">È il mio disegno; or sappi…</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="F">A me lo cela,</l>
             <l>Che mio malgrado sarò tuo nemico,</l>
@@ -888,20 +934,20 @@
             <l>Ei sì farà che ne l'ispano suolo</l>
             <l>Passin le ispane lance i petti ispani.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>German, se ascolti ciò che far son fermo,</l>
             <l part="I">Vedrai…</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="F">Pensi tornare al culto antico?</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="I">Tolgalo il Ciel.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="F">E udir altro non lice,</l>
             <l>Cui degli aperti tuoi disegni un giorno</l>
@@ -913,7 +959,7 @@
             <hi rend="Italic">Scena settima</hi>
           </head>
           <stage><hi rend="sc">E</hi>RMENEGILDO <hi rend="Italic">solo</hi></stage>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>Odi…, ma ratto ei va. Lume Superno,</l>
             <l>Che al ben scorgesti, e al ben salda terrai</l>
@@ -925,7 +971,7 @@
             <l>Esser potria del vero culto, e ‘l sacro</l>
             <l>Vessillo alzarne in su l'Iberia tutta.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker><hi rend="sc">C</hi>ORO</speaker>
             <lg type="canzone">
               <lg>
@@ -993,7 +1039,7 @@
           </head>
           <stage><hi rend="sc">L</hi>EOVIGILDO, <hi rend="sc">G</hi>ENSERICO <hi rend="Italic">e</hi><hi rend="sc">R</hi>ECAREDO
 	</stage>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Questo è il Palagio in cui su ‘l vago aprile</l>
             <l>Far col prenze solea lieto soggiorno</l>
@@ -1002,34 +1048,34 @@
             <l>Fu del nostro gran padre <rs type="name">Arrio</rs> la fede</l>
             <l>Da ria calogna calpestata e oppressa.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>E qui vogl'io che le superbe sale,</l>
             <l>A sì ria scuola destinate, e scelte,</l>
             <l part="I">Vadano a terra.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="F">L'ampie stanze adorne</l>
             <l part="I">Volte ad uso miglior potriano…</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Il dissi,</l>
             <l>E ciò che il regal labbro unqua dispone</l>
             <l>Seguir dee sempre, ancor che costi un regno.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="I">(Rio, dannoso pensiero!) Almen…</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Consiglio</l>
             <l>Da te non chiedo, e in così verde etade,</l>
             <l>Sol da me impara di regnar le norme.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>O eccelso eroe, che il valor goto antico,</l>
             <l>Che vincer seppe i domator del mondo,</l>
@@ -1047,11 +1093,11 @@
             <l>Da la perfidia lacere e combuste;</l>
             <l>E grida a tanto mal, mio re, compenso.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="I">Non s'inganna, se spera.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l part="F">A la speranza</l>
             <l>Va compagna la tema; io che discerno</l>
@@ -1063,12 +1109,12 @@
             <l>In un paterno cor che possa, è noto</l>
             <l part="I">Al vulgo ancora.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Il vil forse misura</l>
             <l part="I">L'alme de’ re con le vulgari?</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l part="F">E spesso</l>
             <l>Vulgari son l'alme de’ re, ma quella</l>
@@ -1078,42 +1124,42 @@
             <l>A pochi è dato, e sol da l'opre il mondo</l>
             <l part="I">Scorge l'anime grandi.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">E sol per queste</l>
             <l part="I">Fia che scorga la mia.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l part="F">So ben che invano</l>
             <l>Teme che vinto alfine il re dal padre</l>
             <l>Ceda l'amor di gloria a quel di figlio,</l>
             <l part="I">Ma chi toglier può tal temenza?</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Io solo,</l>
             <l>Io, che prometto che quel giorno stesso</l>
             <l>Che in possa avrollo, se dal cor non caccia</l>
             <l>Il servil culto, gli farò dal seno…</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="I">Padre, che di’…</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Cacciar l'alma rubella.</l>
             <l>E tu con detti temerari opporti</l>
             <l>Pur osi a’ voler miei? su ‘l capo infido</l>
             <l>Già l'ultimo scagliai fatal decreto.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l>(Ahi con qual arte già dal regal labbro</l>
             <l>Strappato ha l'empio la fatal sentenza!)</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Spero che il prenze dal suo cieco errore</l>
             <l>Smosso a noi rieda: ma perché tuo illustre</l>
@@ -1123,18 +1169,18 @@
             <l>Per la patria dier essi i figli a morte,</l>
             <l part="I">Tu per la fede.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="M">(Ah scellerato…)</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Intanto</l>
             <l>Scorger vogl'io da la più eccelsa parte</l>
             <l>Come disponsi a la cittade intorno</l>
             <l part="I">Il fero assedio.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l part="F">Un re guerriero addoppia</l>
             <l>Valor col guardo a sue legion possenti.</l>
@@ -1145,14 +1191,14 @@
             <hi rend="Italic">Scena seconda</hi>
           </head>
           <stage><hi rend="sc">G</hi>ENSERICO <hi rend="Italic">e</hi><hi rend="sc">R</hi>ECAREDO</stage>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>A che, prenze regal, di sdegno accesi</l>
             <l>E quasi ancor di pianto umidi i lumi</l>
             <l>In te ravviso? A che l'altrui periglio</l>
             <l>Piangi, e non curi l'alte tue speranze?</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l>E vorresti ch'io goda, or che spietato</l>
             <l>Inesorabil re sentenzia, e sdegna</l>
@@ -1165,7 +1211,7 @@
             <l>E più che ‘l danni da consiglio infame</l>
             <l>Persuaso, e tradito, il duol m'accresce.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Più ch'ogni vizio, è perigliosa al mondo</l>
             <l>Da virtù colpa accompagnata e adorna,</l>
@@ -1178,19 +1224,19 @@
             <l>In te, giovane invitto, ogni virtude,</l>
             <l part="I">Ogni regal costume, ogni…</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="F">Deh, serba</l>
             <l>Per chi gli ha in grado i lusinghieri accenti,</l>
             <l>Né paragon sì grande il mio cuor molce:</l>
             <l part="I">Vorrei salvo il german.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l part="F">Pur la sua morte</l>
             <l>Consolar ti potria con darti un regno.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l>Ascender brama per le altrui ruine</l>
             <l>Chi di salir per altra guisa è indegno.</l>
@@ -1202,13 +1248,13 @@
             <l>Ma vo’, per gloria mia, del mio sovrano</l>
             <l>Condur le schiere, e a lui far degni acquisti.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Di mente giovanil or son cotesti</l>
             <l>Pensier che nutri, ma non fian diversi</l>
             <l>In crescer gli anni i sensi tuoi da’ nostri.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l>Gli anni crescendo, s'aver debbo iguali</l>
             <l>Miei sensi a’ tuoi, lo Ciel prego che svella</l>
@@ -1239,7 +1285,7 @@
             <hi rend="Italic">Scena terza</hi>
           </head>
           <stage><hi rend="sc">G</hi>ENSERICO </stage>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Garzon feroce, se al parlar tu accorto</l>
             <l>Fossi quanto al conoscere, potresti</l>
@@ -1270,14 +1316,14 @@
             <hi rend="Italic">Scena quarta</hi>
           </head>
           <stage><hi rend="sc">L</hi>EOVIGILDO <hi rend="Italic">e</hi><hi rend="sc">G</hi>UNDIMARO</stage>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Qual destro caso a noi sì presto e lieto,</l>
             <l>Gundimaro, ti rende? io ben da l'alto</l>
             <l>D'armati cavalier cinto e seguito,</l>
             <l>Quasi in trionfo, qui venir ti scorsi.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l>Se la più fera guerra e più funesta</l>
             <l>È la civil, che la vittoria istessa</l>
@@ -1288,11 +1334,11 @@
             <l>Signor, tue glorie addoppi; al suo regnante,</l>
             <l>Non a l'armi del re, <rs type="luogo">Siviglia</rs> or cede.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="I">Ed in qual guisa?</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l part="F">Eran mie schiere appena</l>
             <l>Giunte là donde in più parti divise</l>
@@ -1305,11 +1351,11 @@
             <l>E a me del re domanda, onde a’ tuoi piedi</l>
             <l>Un sì gradito messaggier conduco.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="I">Ei qui s'ascolti.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l part="F">Al regal cenno or viene.</l>
           </sp>
@@ -1319,7 +1365,7 @@
             <hi rend="Italic">Scena quinta</hi>
           </head>
           <stage><hi rend="sc">L</hi>EOVIGILDO <hi rend="Italic">e</hi><hi rend="sc">L</hi>EANDRO</stage>
-          <sp>
+          <sp who="#leandro">
             <speaker><hi rend="sc">L</hi>EANDRO</speaker>
             <l>Signor, cui servir sempre è gloria, e vanto</l>
             <l>A quante terre l'ispan regno abbraccia,</l>
@@ -1338,7 +1384,7 @@
             <l>Qual tua nuora regal si deve accolta.</l>
             <l part="I">Ella è ben tal, che…</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Per Igonda priega!</l>
             <l>E perché mai d'Ermenegildo tace?</l>
@@ -1347,7 +1393,7 @@
             <l>E ‘l proprio sangue offrio, fatto rubello,</l>
             <l>Per l'amato tiranno, al suo regnante.</l>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker><hi rend="sc">L</hi>EANDRO</speaker>
             <l>Al genitor ribelle esser non crede</l>
             <l>Chi salva il figlio: pur se mai delitto,</l>
@@ -1360,41 +1406,41 @@
             <l>Toglier essi il volean dal re sdegnato,</l>
             <l>Ed al placato genitor poi darlo.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Per qual nuova cagion più a lui non pensa</l>
             <l>La volubil pietà del vulgo insano?</l>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker><hi rend="sc">L</hi>EANDRO</speaker>
             <l part="I">La di lui fé gliel vieta.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Ad <rs type="name">Arrio</rs> infido</l>
             <l part="I">Forse il popol l'abborre?</l>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker><hi rend="sc">L</hi>EANDRO</speaker>
             <l part="F">Anzi l'adora,</l>
             <l>Ma quella fé, che a te serba il gran figlio,</l>
             <l>Più che difesa, fa ch'ei morte scelga.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="I">Dov'è dunque egli?</l>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker><hi rend="sc">L</hi>EANDRO</speaker>
             <l part="F">È a la cittade ignoto.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Su la già nata aurora io so quai voci</l>
             <l>Ebbe d'applausi, allor che la consorte</l>
             <l part="I">Portò dentro le mura.</l>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker><hi rend="sc">L</hi>EANDRO</speaker>
             <l part="F">Il ver sapesti:</l>
             <l>Allor ch'e’ giunse, al Siviglian ritegno</l>
@@ -1450,7 +1496,7 @@
             <l>Chi al ben pubblico intende, a me commise,</l>
             <l>Che a te sponessi ciò, ch'umil già dissi.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l><del resp="#cod">.</del>Non lieve dubbio nel pensier mi sorge.</l>
             <l>Vegna qui Genserico, e tu da lui</l>
@@ -1462,7 +1508,7 @@
             <hi rend="Italic">Scena sesta</hi>
           </head>
           <stage><hi rend="sc">L</hi>EOVIGILDO <hi rend="Italic">e poi</hi><hi rend="sc">G</hi>ENSERICO</stage>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Qual funesto pensier m'agita e preme</l>
             <l>La conturbata mente, e qual virtute</l>
@@ -1491,7 +1537,7 @@
             <l>Costi, perché non sia scoccato invano.</l>
             <l part="I">Ma Genserico viene.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l part="F">Inclito, e grande</l>
             <l>Signor, le glorie tue per tutto ho sparse,</l>
@@ -1503,30 +1549,30 @@
             <l>Applaude sì ch'inaspettato fine</l>
             <l part="I">A tal guerra già t'offre.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Il meglio or manca,</l>
             <l>Ond'a tal guerra sia termin sicuro.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l part="I">Ermenegildo?</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="M">Appunto.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l part="F">E chi te ‘l toglie?</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>In <rs type="luogo">Siviglia</rs> di lui nulla più sanno.</l>
             <l>S'offre al mio scettro una città suggetta,</l>
             <l part="I">Egli non già.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l part="F">Di spaventosa guerra</l>
             <l>Esser potria ciò seme: una cittade</l>
@@ -1540,11 +1586,11 @@
             <l>Signor, per lui, non per Siviglia armato</l>
             <l part="I">A <rs type="luogo">Siviglia</rs> scendesti.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">E che far posso?</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Da la città sul chiaro giorno uscito</l>
             <l>Esser non può, che troppo facil preda</l>
@@ -1558,7 +1604,7 @@
             <l>Resterà pur sepolto il prence ascoso,</l>
             <l part="I">S'Ella no ‘l rende.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Può seguir l'effetto</l>
             <l>Che si desia. Tu intanto al messo accorto</l>
@@ -1566,13 +1612,13 @@
             <l>Perch'ei ti scopra il gran secreto: io dissi</l>
             <l part="I">Che da te aspetti la risposta.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l part="F">Acconcia</l>
             <l>L'occasion mi porgi, onde s'adempia</l>
             <l part="I">Il tuo comando.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">A te qui venga il messo.</l>
           </sp>
@@ -1582,7 +1628,7 @@
             <hi rend="Italic">Scena settima</hi>
           </head>
           <stage><hi rend="sc">G</hi>ENSERICO <hi rend="Italic">e poi</hi><hi rend="sc">L</hi>EANDRO</stage>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Amor di gloria e gelosia di regno</l>
             <l>Ponno in lui sì che a mio talento il volgo</l>
@@ -1602,12 +1648,12 @@
             <l>Potrò, sprezzando il re medesmo. Or vegna</l>
             <l part="I">Il siviglian.</l>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker><hi rend="sc">L</hi>EANDRO</speaker>
             <l part="F">Da la tua bocca aspetto</l>
             <l part="I">Il regal cenno.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l part="F">Amico, assai gravosa</l>
             <l>Necessità crudel risposta impone.</l>
@@ -1619,49 +1665,49 @@
             <l>I gran palagi, l'arator fra poco</l>
             <l>Drizzar solco, e scostar l'ossa insepolte.</l>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker><hi rend="sc">L</hi>EANDRO</speaker>
             <l part="I">Ad espor vado il fier decreto.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l part="F">O assai</l>
             <l>Stupido ambasciador; come! t'incresce</l>
             <l>In sì grand'uopo profferir accenti</l>
             <l part="I">De la patria in servigio?</l>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker><hi rend="sc">L</hi>EANDRO</speaker>
             <l part="F">Ella non chiede</l>
             <l>Ch'io d'eloquenza inutil pompa or faccia.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l part="I">Forse inutil non fora.</l>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker><hi rend="sc">L</hi>EANDRO</speaker>
             <l part="F">Allor che i detti</l>
             <l>Spargessi in alma, che si pieghi, e soglia,</l>
             <l>In cangiando desio, cangiar decreto.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Parli con uom che lo consiglia, e puote</l>
             <l part="I">Su quell'alma non poco.</l>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker><hi rend="sc">L</hi>EANDRO</speaker>
             <l part="F">Il so; ma ‘l tuo</l>
             <l>Consiglio a lui non tornerà diverso</l>
             <l>Da quel ch'hai dato, per ragion, per prieghi,</l>
             <l part="I">Ch'io sparga.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l part="M">Perché mai?</l>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker><hi rend="sc">L</hi>EANDRO</speaker>
             <l part="F">Prieghi, e ragioni</l>
             <l>Abbatter non potranno i pensier vasti</l>
@@ -1670,17 +1716,17 @@
             <l>Di ammollirti pietà, né dir saprei</l>
             <l part="I">Cosa a te nuova.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l part="F">E pur, se a me dicessi</l>
             <l>Cosa a me nuova, a te fora di merto</l>
             <l>Appo il regnante, e la città salute.</l>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker><hi rend="sc">L</hi>EANDRO</speaker>
             <l part="I">Che mai dir debbo?</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l part="F">Tu ben sai che raro</l>
             <l>Da gente uscir tumultuante accesa</l>
@@ -1692,14 +1738,14 @@
             <l>Questo si sveli, e se no ‘l sai, discovri</l>
             <l part="I">Chi può saperlo.</l>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker><hi rend="sc">L</hi>EANDRO</speaker>
             <l part="F">Uom suole accorto, e saggio,</l>
             <l>Che tradimenti a’ cittadin propone,</l>
             <l>Ricoprirne l'orror sotto il fallace</l>
             <l part="I">Vel di pubblico ben.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l part="F">Dunque fia meglio</l>
             <l>Ch'entro <rs type="luogo">Siviglia</rs> il predator guerriero</l>
@@ -1712,7 +1758,7 @@
             <l>Ch'il prenze non da lei speri difesa,</l>
             <l part="I">Ma dal padre perdono.</l>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker><hi rend="sc">L</hi>EANDRO</speaker>
             <l part="F">A me se nota</l>
             <l>Fosse sua stanza ancor, prima farei</l>
@@ -1721,12 +1767,12 @@
             <l>A vicenda si spargono parole</l>
             <l>Per far me disleale e te pietoso.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Vanne, e de’ tuoi superbi audaci detti</l>
             <l>Brieve il vanto sarà, certa la pena.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker><hi rend="sc">C</hi>ORO</speaker>
             <lg type="canzone">
               <lg>
@@ -1824,7 +1870,7 @@
           </head>
           <stage><hi rend="sc">L</hi>EOVIGILDO <hi rend="Italic">e</hi><hi rend="sc">G</hi>UNDIMARO
 	</stage>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Giunga l'audacia a tal ch'una rubelle</l>
             <l>Città contro un esercito si scagli,</l>
@@ -1832,18 +1878,18 @@
             <l>Vincan il campo mio, da te guidato,</l>
             <l>Di troppa acerba punta il cor trafigge.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l>Consiglio non su mai gente suggetta</l>
             <l>Far che disperi; e aver co’ disperati</l>
             <l>Guerra è follia: se vita sol da l'armi</l>
             <l>Aspetta, ancora il vil diviene audace.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="I">Narra distinto il fero caso.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l part="F">Intento</l>
             <l>A formar vallo a la cittade intorno</l>
@@ -1912,13 +1958,13 @@
             <l>Il tuo gran figlio, ch'è fra lor rimaso,</l>
             <l part="I">O estinto, o prigioniere.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F"> Oimè, che troppo</l>
             <l>Quest'odiata credenza oggi mi costa!</l>
             <l part="I">Né di lui s'ode altra novella?</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l part="F">È noto</l>
             <l>Solo il valore ond'ei depresse e vinse</l>
@@ -1928,32 +1974,32 @@
             <l>In sull'entrar, e le ferrate porte</l>
             <l>Come fur chiuse poi, né più s'intese.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Che farò, lasso, in tai sventure, e quale</l>
             <l>Consiglio fia che tanto mal compensi?</l>
             <l part="I">Genserico a me venga.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l part="F">Ei quindi è lungi,</l>
             <l>Da che <rs type="name">Vitige</rs> suo nipote udio</l>
             <l part="I">Esser già spento.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Estinto anco <rs type="name">Vitige</rs>!</l>
             <l>Con troppa audacia il giovanile ardore</l>
             <l>L'avrà condotto al rio periglio incontro.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l>Ei fu il primo a fuggir: tosto seguito</l>
             <l>Fu l'esemplo da’ suoi; le mie rampogne</l>
             <l>Alquanto l'arrestaro, indi le terga</l>
             <l>Volse a guerrier, che lo raggiugne, e atterra.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Ma che penso a <rs type="name">Vitige</rs>, or che pavento</l>
             <l>Spente del sangue mio l'alte speranze,</l>
@@ -1975,28 +2021,28 @@
             <hi rend="Italic">Scena seconda</hi>
           </head>
           <stage><hi rend="sc">R</hi>ECAREDO <hi rend="Italic">e</hi><hi rend="sc">D</hi>ETTI</stage>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="F">Ecco a tue piante,</l>
             <l>Signor, quei che cattivo or piangi o spento.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Figlio! e fia ver ch'io ti rivegga e abbracci!</l>
             <l>E donde mai sì inaspettata sorte?</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l>Da generosa man, che l'armi adopra</l>
             <l>Per sua difesa, e non per nostro oltraggio,</l>
             <l part="I">Ebbi la libertà.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">L'alte avventure</l>
             <l part="I">Tosto mi narra.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="F">Sai ch'entro le mura</l>
             <l>Io penetrai pugnando, e come esclusi</l>
@@ -2016,25 +2062,25 @@
             <l>Il volto, e invece del consorte, Igonda</l>
             <l part="I">Scorgo chiusa in quell'armi.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Igonda adunque</l>
             <l part="I">Ha tanto oprato in questa pugna!</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="F">Igonda.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l>Più ch'uom apparve, e non già donna, in guerra</l>
             <l part="I">Feroci schiere dissipando.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Or siegui.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l>Da tanta cortesia vinto, e ricolmo</l>
             <l>Di stupor, di vergogna, e di riguardo</l>
@@ -2067,55 +2113,55 @@
             <l>Umil ossequio, obbedienza, e fede</l>
             <l part="I">Ver te conobbi.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">E da lei nulla udisti</l>
             <l part="I">D'Ermenegildo?</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="F">Ben di lui sovente</l>
             <l>Ragionò, tutta di pietate, e amore</l>
             <l part="I">Accesa.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="M">E dov'egli s'asconda?</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="F">Il credo</l>
             <l>Fuor di <rs type="luogo">Siviglia</rs>, né di ciò convenne</l>
             <l part="I">Troppo chieder a lei.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Questa mendace</l>
             <l part="I">Virtute accresce i miei sospetti.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="F">E quale</l>
             <l>Sarà vera virtù, se falsa è questa?</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Chi l'esca insidiosa a’ pesci espone</l>
             <l part="I">Stimi tu liberal?</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="F">Sì nobil esca,</l>
             <l part="I">A qual può intender preda?</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Al Regno intero;</l>
             <l>Dagli animi che alletta ella il proccura.</l>
             <l>Qui Genserico venga allor ch'empiuti</l>
             <l>Gli ufici estremi ha del nipote estinto.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l>Ei ciò die’ ad altri in cura, e solo or bada</l>
             <l>A raccogliere di lui gli opimi arredi,</l>
@@ -2128,13 +2174,13 @@
             <hi rend="Italic">Scena terza</hi>
           </head>
           <stage><hi rend="sc">G</hi>ENSERICO <hi rend="Italic">e</hi><hi rend="sc">D</hi>ETTI</stage>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l part="F">Inclito re, la vita</l>
             <l>Del mio <rs type="name">Vitige</rs>, ch'ha per te fra l'armi</l>
             <l>Speso, or fa ch'io l'invidi, e non che ‘l pianga.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Un tuo nipote, un mio fedel vassallo,</l>
             <l>Genserico, in lui ploro, e vie più cresce</l>
@@ -2146,7 +2192,7 @@
             <l>Onde ciò, ch'è in lei fermo, ad empier vaglia,</l>
             <l part="I">Con saggio avviso aprite.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l part="F">O s'io potessi</l>
             <l>Sparger invece di parole il sangue,</l>
@@ -2179,12 +2225,12 @@
             <l>Sì l'esercito nostro, alfin riporti</l>
             <l part="I">La vittoria bramata.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">A Gundimaro</l>
             <l>Se resta in tal pensier dubbio, l'esponga.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l>Più che farmi a te grato, esser fedele</l>
             <l>A te voglio, mio re, sicché il consiglio</l>
@@ -2242,24 +2288,24 @@
             <l>Da te segnato in man d'Igonda, e chiami</l>
             <l part="I">A’ tuoi piedi il german.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="F">Padre, se ponno</l>
             <l>I prieghi miei su la regal tua mente,</l>
             <l>Deh, generoso al tuo figlio concedi,</l>
             <l>E a la gran nuora tua pace e perdono.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>È Recaredo ancor preso agl'incanti</l>
             <l part="I">Di sì ria <rs type="name">Circe</rs>!</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="F">Ah infame labbro, ed osi</l>
             <l part="I">Così parlar d'un'eroina?</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Il solo</l>
             <l>Ascoltar vien permesso a te, cui gli anni</l>
@@ -2268,18 +2314,18 @@
             <l>Né pungenti parole. A te, se resta,</l>
             <l part="I">Gundimaro, che dir, siegui.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l part="F">Già dissi.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Dirne sol resta a consiglier, che tanto</l>
             <l>Prevede, e annunzia, che mai far si debba</l>
             <l>Il Re, se il figlio anco il romano errore</l>
             <l part="I">Seguir vuole ostinato.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l part="F">Ampio discorso</l>
             <l>Ciò merteria, se prigioniero ei fosse:</l>
@@ -2287,7 +2333,7 @@
             <l>In quella fé, che a lui, che a’ nostri Ispani,</l>
             <l>Che a tanti regni ancor sembra più vera.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Come dal prisco tuo senno, e valore</l>
             <l>Diverso, o duce, la fé d'<rs type="name">Arrio</rs> offendi</l>
@@ -2300,7 +2346,7 @@
             <l>Tutto si perda, pur che resti intatto</l>
             <l part="I">L'onor del mio gran re.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l part="F">Qual onor serba</l>
             <l>Il nostro re, se tutto perde? E tutto</l>
@@ -2313,127 +2359,127 @@
             <l>Volti al culto roman, talché divenga</l>
             <l>Quella, ch'oggi è difesa, alfin ruina.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Troppo incerto è il periglio, e certa è l'onta.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l>Ma l'onta è lieve al gran periglio a fronte.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Spesso men grave è del timor l'effetto.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l>Come il mostra ragion, l'aspetta il saggio.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>E ‘l saggio ancora in sua ragion s'inganna.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l>Non perciò deve abbandonarsi al caso.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Chi vuol troppo veder resta, e non opra.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l>E chi cieco sen corre inciampa, e cade.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Dunque ceda il regnante, <rs type="name">Arrio</rs> s'abbatta.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l>Al re si serbi il regno, <rs type="name">Arrio</rs> s'onori.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Chi soffre il roman culto Arrio disprezza.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l>Chi più ‘l pone in cimento è suo nemico.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>E al re che giova senza gloria il regno?</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l>Se ‘l perde, ei perde ancora onor e speme.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Gloria gli fia serbar sua fede intatta.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l>Ma scorno il danno de la fede, e ‘l nostro.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Se da chiar' opre avvien, fia gloria il danno.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l>Le perdite non mai furon chiar' opre.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Lo son, se n'è cagion la nobil costanza.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l>Dannosa al regno la costanza è colpa.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Oprar sempre il gran re dee da regnante.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l>Ciò fa chi del suo regno al ben intende.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Serbar sua legge antica è il ben più grande.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l>Se per tutto serbar tutto si perde?</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l part="I">Faccia il re ciò che dee.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l part="F">Far deve il meglio.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l part="I">Ei salvi adunque il tutto.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l part="F">O ciò che puote.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l part="I">Ei potrà ciò che vuole.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l part="F">Ed in quai forme?</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>La fera scossa, che per man di donna</l>
             <l>Oggi tu avesti, precipizio, e mare</l>
@@ -2451,7 +2497,7 @@
             <l>I Galli ad altro penseran che a noi?</l>
             <l part="I">Ciò può tutto avvenir.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l part="F">Ma tutto è strano,</l>
             <l>Né su stranezze mai speme si fonda.</l>
@@ -2484,7 +2530,7 @@
             <l>Più che al senno, fidar mio campo in parte:</l>
             <l part="I">Incominciò da lui…</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Non più, che troppo</l>
             <l>Scorgo la gloria mia caduta al fondo,</l>
@@ -2509,7 +2555,7 @@
             <hi rend="italic">Scena quarta</hi>
           </head>
           <stage><hi rend="sc">E</hi>RMENEGILDO <hi rend="Italic">e</hi><hi rend="sc">D</hi>ETTI</stage>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">A le paterne piante</l>
             <l>Ecco quel figlio che rubelle, ed empio,</l>
@@ -2517,31 +2563,31 @@
             <l>Tutto il rigore, e a me, se vuoi, pur togli</l>
             <l part="I">Questa vita, ch'è tua.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Fia larva, o sogno!</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Non sogni; il Cielo a le tue glorie arride,</l>
             <l>Questi son quei, chi sa, che uom saggio ignora.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l>Né previsti da te, poiché a vil alma</l>
             <l>Fia strano ogni atto generoso e grande.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="I">Quanto, o caro german…</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">L'audacia è giunta</l>
             <l>D'un miscredente ad infestarmi ancora</l>
             <l part="I">Coll'importuno aspetto!</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">Ah no, ch'io vengo</l>
             <l>Vittima all'ira tua, né far può oltraggio</l>
@@ -2554,22 +2600,22 @@
             <l>In me adunque ogni scempio, in me si volga;</l>
             <l part="I">S'abbia pace il tuo regno.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">E in un sol punto</l>
             <l>Giunse all'empio tuo cor questa pietate?</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="I">Non mai pensier ebbi diverso.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">E come</l>
             <l>Perir lasciasti ne la fera uscita</l>
             <l part="I">Le nostre genti, e tue?</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">Magion lontana</l>
             <l>Di là dal fiume avea me accolto, e ascoso,</l>
@@ -2586,7 +2632,7 @@
             <l>Ed il mio sangue in un plachi il tuo sdegno,</l>
             <l part="I">E ‘l loro amor punisca.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Ah, figlio, ahi troppo</l>
             <l>La tua follia mi costa! In alma adorna,</l>
@@ -2608,7 +2654,7 @@
             <l>Da te le carte a lui contrarie, al suolo</l>
             <l part="I">Lacere ed arse…</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">Anzi io cada percosso</l>
             <l>Da carnefice vil pria che si nieghi</l>
@@ -2619,7 +2665,7 @@
             <l>Il primo Amor farà che d'alto scenda</l>
             <l part="I">A te lume sì bello, io so che…</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Ed osi</l>
             <l>Tentar me ancora! e temerario ardisci</l>
@@ -2628,7 +2674,7 @@
             <l>E seguir la tua setta? A tanto intende</l>
             <l>Il tuo folle parlar di lume e Cielo?</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>Per tant'opra non ho mente che basti,</l>
             <l>Né merto in me, che cotant'alto aspiri,</l>
@@ -2636,7 +2682,7 @@
             <l>Ma venni sol perché mia morte estingua</l>
             <l part="I">Ogni mal fra tue genti.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="F">Ah, ch'il maggiore</l>
             <l>D'ogni più acerbo mal fora tua morte.</l>
@@ -2645,7 +2691,7 @@
             <l>E de l'Iberia, che sì t'ama, e tante</l>
             <l part="I">Alte speranze ha in te.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F"> Troppo crudele</l>
             <l>Ver me sarei, mio Recaredo amato,</l>
@@ -2657,13 +2703,13 @@
             <l>Spero di sua virtù, che in premio un giorno</l>
             <l>Il ver discerna, ch'è in miei detti ascoso.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Troppo ingannato è il prenze, e troppo ancora</l>
             <l>Dannoso al regno un tanto error sarebbe,</l>
             <l part="I">Se Leovigildo non regnasse.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l part="F">In questo</l>
             <l>Reo d'alta colpa anco l'eroe si chiude,</l>
@@ -2673,7 +2719,7 @@
             <l>Non da l'alte promesse, o rie minacce,</l>
             <l>Ma qualor da ragion vinto rimanga.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Troppo il ver dici. Ermenegildo, pensa</l>
             <l>A cangiar voglia: or taci intanto, e parti.</l>
@@ -2682,7 +2728,7 @@
             <l>Sì che ritorni al sentier primo, e tolga</l>
             <l>Se dal gravoso rischio, e me d'affanni.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Farò quanto m'imponi. Il Ciel secondi</l>
             <l>Tue voglie, e sì bel vanto a me conceda.</l>
@@ -2693,36 +2739,36 @@
             <hi rend="italic">Scena quinta</hi>
           </head>
           <stage><hi rend="sc">G</hi>ENSERICO <hi rend="Italic">e</hi><hi rend="sc">R</hi>ECAREDO</stage>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Prenze, se non t'incresce, umil ti prego,</l>
             <l>Che i miei detti, e ragioni udir ti piaccia,</l>
             <l>Or che del tuo germano al pro fian volte.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l>Benché poca speranza in me s'alletti</l>
             <l>Dall'opre tue, pur a me stesso ascosa</l>
             <l>Cagione il desir mio spinge ad udirti.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Ed in me perché mai speme sì scarsa?</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="I">Perché nulla ho in te fede.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l part="F">E chi mi rende</l>
             <l part="I">Sì reo nel tuo pensier?</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="F">Tuo rio costume.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Due grandi ufici in me ravvisi, in uno</l>
             <l>Ragion di stato mi sospinge, e sforza</l>
@@ -2732,7 +2778,7 @@
             <l>Il mestier sacro di Prelato, e ‘n questo</l>
             <l part="I">Merto almen tua credenza.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="F">Udito ho sempre</l>
             <l>Ch'uom, al cui senno sacri riti, ed alme</l>
@@ -2742,11 +2788,11 @@
             <l>Toglie da lungi il ricco frutto, è indegno</l>
             <l>Del sacro grado, e ‘l profan male adempie.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Chi serve al re non è men caro a Dio.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l>Caro è a Dio sol chi al suo dover intende,</l>
             <l>E ‘l tuo non è di consigliar regnanti,</l>
@@ -2757,18 +2803,18 @@
             <l>A pro del popol, tuo dover, che tanto</l>
             <l>Calpesti, in cose assai difformi immerso.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Se il prenze a nostra fé render m'è dato,</l>
             <l>L'opra fia tal ch'ogni ben uguagli.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l>Strano mi sembreria che per bugiardo</l>
             <l>Labbro piacesse al Ciel mostrargli ‘l vero.</l>
             <l part="I">Dal successo vedrem.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l part="F">Troppo mi punge</l>
             <l>Questi co’ detti ingiuriosi, e troppo</l>
@@ -2778,7 +2824,7 @@
             <l>Se han forza accorgimenti, e frodi,</l>
             <l>Chi fia che da venen salvi lor vita?</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker><hi rend="sc">C</hi>ORO</speaker>
             <lg type="canzone">
               <lg>
@@ -2843,7 +2889,7 @@
             <hi rend="italic">Scena prima</hi>
           </head>
           <stage><hi rend="sc">G</hi>ENSERICO <hi rend="sc">E</hi>RMENEGILDO <hi rend="Italic">e</hi><hi rend="sc">R</hi>ECAREDO</stage>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Prenze, troppo venen bevve tua mente,</l>
             <l>E compenso non ho che il mal ripari.</l>
@@ -2851,13 +2897,13 @@
             <l>Prevenuto se’ troppo, e invan m'adopro:</l>
             <l part="I">Dissi quanto dir seppi.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">Ed io risposi</l>
             <l>Ciò che mi detta quel bel lume ardente,</l>
             <l>Che vien dal Ciel, e dove vuol riluce.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Dunque tra tanti chiari Goti illustri,</l>
             <l>E d'alto ingegno, solo a te concede</l>
@@ -2867,7 +2913,7 @@
             <l>Che solo al Ciel si ascende, il vero ascose</l>
             <l>Per nabissargli negli eterni pianti!</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>Scende dal primo Sol luce che basta</l>
             <l>A rischiarar chi di superbia sgombro</l>
@@ -2878,7 +2924,7 @@
             <l>Penetrar può con mortal guardo, e ‘n quelli</l>
             <l part="I">Scorger l'alte cagioni?</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l part="F">I loro effetti,</l>
             <l>Sovente ravvisar le sanno in parte,</l>
@@ -2895,7 +2941,7 @@
             <l>Ch'egli è a Dio caro, e inver tal non sarebbe,</l>
             <l part="I">Se ria setta seguisse.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">I Persi adunque,</l>
             <l>Gli Assiri, i Greci, ed i Roman seguiro</l>
@@ -2912,12 +2958,12 @@
             <l>Lor tronche membra per cittadi, e campi,</l>
             <l>Non fur seguaci d'arriane norme?</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l>(Del nostro difensor l'armi son frali,</l>
             <l>Ond'è per ogni via confuso, e vinto.)</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>In tua falsa ragion chiuso, ti fingi</l>
             <l>Vera questa tua fé, ma non sì cieca</l>
@@ -2941,7 +2987,7 @@
             <l>A che, nemico di te stesso, esporti</l>
             <l>A certo strazio, anzi a non dubbia morte?</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>Uno fu sempre il ver, sempre fallace</l>
             <l>Sarà ciò che gli è opposto, ed uom non mai</l>
@@ -2960,36 +3006,36 @@
             <l>Sarei nemico allor che a me gradito</l>
             <l>Fosse il viver mortal più che l'eterno.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Il Signor nostro punirà tuo folle</l>
             <l>Ostinato volere, e fero esemplo</l>
             <l>A le genti sarà tua morte infame.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>Tal morte infame eletta palma e pregio</l>
             <l>Per me sarà, più che trionfo altero.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l>T'impose il re che sol ragioni e prieghi</l>
             <l>Col figlio oprassi, e non minacce ed onte.</l>
             <l>Questi, cui fero, e oltracotante or parli,</l>
             <l part="I">Egli è tuo prenze ancora.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l part="F">Al re men vado.</l>
             <l>Tosto vedrete che non mie né vane</l>
             <l part="I">Son le minacce.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="F">Or va’, ch'uom mai non spera</l>
             <l>Cosa da l'opre tue da te diversa.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>Il tuo tenero amor, nobil costume,</l>
             <l>Tue generose, oneste voglie il Cielo</l>
@@ -3003,7 +3049,7 @@
             <hi rend="italic">Scena seconda</hi>
           </head>
           <stage><hi rend="sc">R</hi>ECAREDO</stage>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l>Questa dunque è la fé che ben sovente</l>
             <l>Fra nostre liete mense il vile oggetto</l>
@@ -3031,32 +3077,32 @@
             <hi rend="italic">Scena terza</hi>
           </head>
           <stage><hi rend="sc">L</hi>EOVIGILDO <hi rend="Italic">e</hi><hi rend="sc">G</hi>ENSERICO</stage>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Non basta adunque la tua scienza ed arte</l>
             <l part="I">A vincer l'ostinato?</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l part="F">Ei più s'indura,</l>
             <l>Quanto è più da ragion costretto e vinto:</l>
             <l part="I">Che non fei, che non dissi!</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Ei che risponde?</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Oscuri e dubbi, ed a se stesso ignoti</l>
             <l>Sensi sovente, e per miei detti il vidi</l>
             <l>Persuaso non mai, sempre convinto.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="I">Ed or, che farem noi?</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l part="F">Nulla a me resta,</l>
             <l>Da che sua voglia pertinace abborre</l>
@@ -3067,12 +3113,12 @@
             <l>Sì che un'opra a fornir, dura cotanto,</l>
             <l part="I">È a te serbato.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">E potran mai preghiere</l>
             <l part="I">Piegar quell'alma?</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l part="F">Ov' il periglio è certo,</l>
             <l>E son dubbi i ripari, i più remoti</l>
@@ -3089,22 +3135,22 @@
             <l>Troppo a te, troppo a noi, però d'amaro</l>
             <l>Pianto fora cagione atto sì illustre.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Se pertinace, com'io temo, ei sprezza</l>
             <l part="I">I prieghi miei, che far più debbo?</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l part="F">Ah, tolga</l>
             <l part="I">Il Ciel sì tristi auguri.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Ogni altra è chiusa</l>
             <l part="I">Strada a la speme?</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l part="F">Se superbo indura</l>
             <l>In sua credenza, almen finga, e riceva</l>
@@ -3125,11 +3171,11 @@
             <l>Di Leovigildo, e s'è sua gioia ancora</l>
             <l>Ogni tua gioia, il tuo dolor l'è duolo.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Ma che più dir potrai, s'ei ciò ricusa?</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>È ver ch'amo il gran prenze, e quant'ho sangue</l>
             <l>Per sua vita darei, ma dell'onore</l>
@@ -3149,12 +3195,12 @@
             <l>Io porgerò, perché sua mente allumi,</l>
             <l>Ed al dritto sentier lo scorga, e meni.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Va’ dunque, amico, ed a me venga il figlio</l>
             <l>Reo d'alta colpa, e di mia pena atroce.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>(Folle se al mio duol crede, e a la speranza,</l>
             <l>Che sol per trarlo a l'orrid'opra io fingo.)</l>
@@ -3165,7 +3211,7 @@
             <hi rend="italic">Scena quarta</hi>
           </head>
           <stage><hi rend="sc">L</hi>EOVIGILDO <hi rend="Italic">e poi</hi><hi rend="sc">E</hi>RMENEGILDO</stage>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Non mai doglioso reo, che dubbio aspetta</l>
             <l>Fatal sentenza, sì ristretta ha l'alma,</l>
@@ -3175,13 +3221,13 @@
             <l>Sospesa tien la scure. Eccolo! Ahi, quanto</l>
             <l part="I">Cresce mia pena ora in mirarlo!</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">A’ cenni,</l>
             <l>Sian regali o paterni, umile, e chino,</l>
             <l part="I">Signor, ne vengo.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Ognor paterni e cari</l>
             <l>Esser debbono a te miei cenni, o dolce</l>
@@ -3197,7 +3243,7 @@
             <l>Pace, ed Igonda più che pria felice</l>
             <l part="I">Goda teco, ed imperi.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">E quai poss'io</l>
             <l>Render per tanto ben grazie? Se grave</l>
@@ -3208,7 +3254,7 @@
             <l>Fermo il desire, e per me ancora acerba</l>
             <l part="I">Saria d'Igonda ogni sventura.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">A questi</l>
             <l>Del mio fervido amor segni s'accresca</l>
@@ -3219,13 +3265,13 @@
             <l>A quelle che ognor fanno a me d'intorno</l>
             <l part="I">Sicurtade e splendore.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">A tanta altezza</l>
             <l>Non giugne il mio desir: mia brama, e vanto</l>
             <l>È l'esserti leal suggetto, e figlio.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Io re ti voglio, e che le pene, e i premi</l>
             <l>Tu disponghi a tuo senno, e solo io chiedo</l>
@@ -3239,17 +3285,17 @@
             <l>Legge de’ Goti, e ‘l genitor, che tanto</l>
             <l>T'ama, deh figlio, per pietà, consola.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>Di che acerba ferita il sen trafigga,</l>
             <l>Signore, un tuo desir che solo al mondo</l>
             <l>Seguir non posso; lo sa ben quest'alma.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="I">Te ‘l vieta Igonda?</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">Alto dover me ‘l vieta.</l>
             <l>Deh, imponi pur che dove il mar s'indura</l>
@@ -3260,7 +3306,7 @@
             <l>Che ad ogni asprezza, ed ad ogni rio periglio</l>
             <l part="I">Correrò lieto ad ubbidirti.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Io bramo</l>
             <l>Toglier tua vita dal periglio estremo,</l>
@@ -3271,7 +3317,7 @@
             <l>Tanto accrebbi, sia suo dominio, e forse</l>
             <l>Pria che sonno mortal chiuda mie luci.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>Se quanti imperi il terren globo serra</l>
             <l>Mi offrisse d'<rs type="name">Arrio</rs> la mendace setta,</l>
@@ -3284,18 +3330,18 @@
             <l>Dov'è ogni ben, ed ogni mal eterno,</l>
             <l>Serbansi a le nostr'opre, o giuste od empie.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Credea che ben di Genserico i detti</l>
             <l part="I">Convinto avesser la tua mente.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">Ei dica</l>
             <l>Se a sue false ragioni il Ciel non pose</l>
             <l>Su la mia bocca a pro del ver difesa.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Tropp'ostinato oimè, ti scorgo, e invano</l>
             <l>Spargo e detti, e ragioni, e offerte, e prieghi,</l>
@@ -3324,7 +3370,7 @@
             <l>Indi ragiona: or dal tuo labbro pende</l>
             <l>La mia felicità, la tua salvezza.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>Lieve a te sembra il fingere diversa</l>
             <l>Religion, e per infida mano,</l>
@@ -3339,107 +3385,107 @@
             <l>Del Nume eterno, se da Dio discese,</l>
             <l>Lascia, deh padre mio, che a lui sen torni.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="I">Chi ciò le toglie?</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">Un tuo comando il tenta.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="I">Cerco sol tua salute.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">Anzi la morte.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="I">Tu le vai ‘ncontro.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">E pur così ne scampo.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="I">Scampi morendo?</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">Eterna vita acquisto.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Goder puoi la mortale, indi l'eterna.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>Se così l'una io serbo, or l'altra perdo.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Gran colpa è simular brievi momenti?</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>Chi tradir finge è reo di doppio fallo.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Virtù è il finger talora, e non misfatto.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="I">Colpa fu sempre.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Almen degna di scusa.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>Scusa non ha mai scellerata frode.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="I">Qual frode?</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">E qual peggior che finger fede?</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="I">Serbar la vita uom dee.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">Così l'abborra.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="I">Ella è dono del Ciel.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">Per lui si spenda.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Più tosto ella per Dio s'adopri, e serbi.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>Come meglio di lui la gloria chiede.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="I">Or che chiede sua gloria?</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">Ella m'impone</l>
             <l>Che pria ch'un atto sol menomo e lieve</l>
@@ -3450,7 +3496,7 @@
             <l>Di letizia immortal, d'ardente zelo,</l>
             <l part="I">Impaziente, la sospira.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Ah ingrato,</l>
             <l>Che godi al mio dolor, gioisci al pianto,</l>
@@ -3472,7 +3518,7 @@
             <l>Quanto tu fosti un dì mia gloria e gioia,</l>
             <l>Se’ mia vergogna e mio tormento. Parti.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>Padre, ogni oltraggio fier da te m'è caro:</l>
             <l>Umil ti bacio il regal manto, e parto.</l>
@@ -3483,7 +3529,7 @@
             <hi rend="italic">Scena quinta</hi>
           </head>
           <stage><hi rend="sc">L</hi>EOVIGILDO, <hi rend="sc">I</hi>GONDA  <hi rend="italic">e</hi><hi rend="sc">R</hi>ECAREDO  </stage>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Ogni mia speme inaridita, e sparsa</l>
             <l>In polve io scorgo, oimè nulla più resta.</l>
@@ -3496,7 +3542,7 @@
             <l>Rio dolor non mi svenga? e qual…, ma veggio</l>
             <l part="I">Che a me Igonda ne viene!</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l part="F">Io stessa, o grande</l>
             <l>Signor d'Iberia, e mio sovrano, e padre,</l>
@@ -3527,7 +3573,7 @@
             <l>Se avesser sensi, porgerian; ripensa:</l>
             <l>Indi, se puoi, con le tue man l'ancidi.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l>Questa, che innanzi a te prostrata or miri,</l>
             <l>Sai ch'è del re d'Austrasia inclita figlia,</l>
@@ -3551,7 +3597,7 @@
             <l>A lei dona il consorte: e qual più giusta</l>
             <l>Mercè dar le potrai che ‘l merto agguagli?</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Te d'ogni nostro mal ravviso, Igonda,</l>
             <l>Sola cagione, e sol tue rie lusinghe</l>
@@ -3568,7 +3614,7 @@
             <l>Salvo il mio onor, s'hai tu mezzo che scampi</l>
             <l>Sì gran figlio da morte, oggi l'addita.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l>Non manca all'onor suo regnante eccelso</l>
             <l>Che sue minacce orrende troppo e fere</l>
@@ -3579,18 +3625,18 @@
             <l>Sdegnato, argin non pone a ciò che detta</l>
             <l>L'immensa sua pietà, <rs type="luogo">Ninive</rs> il dica.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Pianse <rs type="luogo">Ninive</rs> i falli, or questo ingrato</l>
             <l>Disprezza il mio perdono, e a scempio corre,</l>
             <l>Qual cerva sitibonda a limpid'acque.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l>In lui fallo non è; va lieto a morte,</l>
             <l part="I">Sol perché sì t'aggrada.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Io cerco, e bramo</l>
             <l>Per salvarlo ogni mezzo: e a lui non chiedo</l>
@@ -3608,7 +3654,7 @@
             <l>Talor più vezzo femminil che speme,</l>
             <l>Timor, consiglio, o autorità sovrana.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l>A lui dirò ciò ch' un amor sincero</l>
             <l>Per sua salute mi consiglia, e detta.</l>
@@ -3619,16 +3665,16 @@
             <hi rend="italic">Scena sesta</hi>
           </head>
           <stage><hi rend="sc">E</hi>RMENEGILDO <hi rend="Italic">e</hi><hi rend="sc">D</hi>ETTI </stage>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Ermenegildo, ancor toglier potresti</l>
             <l>Noi dal duol, te da morte: Igonda ascolta.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="I">Che mai consigliar puote?</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l part="F">Ascolta Igonda,</l>
             <l>Ch'opra non detterà di te non degna.</l>
@@ -3654,7 +3700,7 @@
             <l>Muoiasi adunque, ed il tuo sangue beva</l>
             <l>Chi reo ti salva, ed innocente ancide.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Questo, o barbara donna, è quel che vanti</l>
             <l>Amor del tuo consorte! Or ben sia paga</l>
@@ -3668,14 +3714,14 @@
             <l>Che si credono eroi; tosto fian l'opre</l>
             <l>Di me, di vostra reità più degne.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l>Deh, a più tranquilla, e riposata mente</l>
             <l>L'opre, o mio genitor, riserba, e pensa;</l>
             <l>Ch' uom da giudice oprar non deve allora</l>
             <l part="I">Che d'ira serve.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">La fatal sentenza</l>
             <l>Contro quest'empio fulminò serena</l>
@@ -3686,7 +3732,7 @@
             <l>S'abbia l'iniquo, ed il suo sangue sparso</l>
             <l>Sia per gli empi ribelli, esemplo e freno.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l>De l'irato regnante è forza i passi</l>
             <l>Seguire, a mitigar sua fervid'ira.</l>
@@ -3699,7 +3745,7 @@
             <hi rend="italic">Scena settima</hi>
           </head>
           <stage><hi rend="sc">E</hi>RMENEGILDO <hi rend="Italic">e</hi><hi rend="sc">I</hi>GONDA </stage>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l>Or che siam soli, e libertate ha il pianto,</l>
             <l>Deh, permetti che sgorghi, e l'affannato</l>
@@ -3708,7 +3754,7 @@
             <l>A te questo mio duol, ma tu perdona</l>
             <l>Al fido mio vivace amor, e al sesso.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>Igonda, anima mia, tu piangi! e dove</l>
             <l>Fuggio quella fortezza onde al regnante</l>
@@ -3722,7 +3768,7 @@
             <l>Per Dio t'accheta, or ch'il mio fato è degno</l>
             <l>Sol de l'invidia tua, non del tuo duolo.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l>Qualor quest'alma dal mortal s'innalza</l>
             <l>In sua pura ragion s'allegra, e vede</l>
@@ -3733,7 +3779,7 @@
             <l>Deh, mi concedi, or che rimango in questo</l>
             <l>Crudel esiglio tormentata e sola.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>S'io non sapessi che dal Ciel pietoso</l>
             <l>Vien sempre inaspettato alto soccorso,</l>
@@ -3747,7 +3793,7 @@
             <l>Segni sarian que’ di letizia e gioia,</l>
             <l part="I">E non questi sì amari.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l part="F">Ah, ch'io ravviso</l>
             <l>Che nascer dal tuo ben mi dee conforto:</l>
@@ -3768,13 +3814,13 @@
             <l>Fan quest'orrende immagini ch'io perda</l>
             <l>Ogni conforto, salvo quel del pianto.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>Se vuoi ch'io vada interamente lieto</l>
             <l>Al mio supplicio, al vero ben costante</l>
             <l>Pensa, ed il lieve obblia fugace danno.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l>Ciò far vorrei, ma, oimè lassa, se in questo</l>
             <l>Ultimo tuo voler manco, perdona</l>
@@ -3785,13 +3831,13 @@
             <l>Da che teco viss'io la prima offesa</l>
             <l>Che ti fo, mio malgrado, e fia l'estrema.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>Mia cara, addio, che non resiste a tanta</l>
             <l>Pietà il mio petto, né già il pianto amaro</l>
             <l>Versar mi lice in così fausto giorno.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l>Di questi ultimi ancor dolci momenti</l>
             <l>Privar mi vuoi! deh, lascia opra sì cruda</l>
@@ -3799,7 +3845,7 @@
             <l>Che mi strappi da te spietata forza,</l>
             <l part="I">Che un tuo comando.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l part="F">Troppo desti al molle</l>
             <l>Pianto, di tua virtù, di tua grand'alma,</l>
@@ -3816,18 +3862,18 @@
             <hi rend="italic">Scena ottava</hi>
           </head>
           <stage><hi rend="sc">G</hi>ENSERICO, <hi rend="sc">R</hi>ECAREDO <hi rend="Italic">e</hi><hi rend="sc">D</hi>ETTI </stage>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>No, ferma, o prenze, che divisa Igonda</l>
             <l>Non vuol da te regal sovrano impero.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l>Forse il re vuol ch'io seco muoia? E quale</l>
             <l>Annuncio recar puoi più fausto e lieto?</l>
             <l part="I">Palesa i sensi suoi.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l part="F">Tanta pietate</l>
             <l>Non ha di te, che ti condanni a morte:</l>
@@ -3838,13 +3884,13 @@
             <l>Il popol tutto, e in lui l'odio più cresca</l>
             <l>Contro la colpa di cotanto danno.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l>Ho cuor che basta a sostener col guardo</l>
             <l>L'orrido aspetto, e ‘l popolar furore,</l>
             <l>Ed onta, e strazio, ed aspra vita, e morte.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Quanto tuo duro fato cor m'affanni,</l>
             <l>Ermenegildo, il sa colui che i petti</l>
@@ -3855,12 +3901,12 @@
             <l>Di nostra fede il ver fin su l'estremo</l>
             <l>Punto, e sii sempre di pentirti in tempo.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>Non mai si pente chi ben opra: or puoi</l>
             <l>Qui restar, se tuoi detti ognor fian vani.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Troppo m'è cara tua salvezza, e speme</l>
             <l>N'avrò fin che tu spiri, unqua rimosso</l>
@@ -3870,7 +3916,7 @@
             <l>Girne fra le voraci ardenti fiamme,</l>
             <l>V'anderei lieto, ed arderei contento.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l>Come mai, traditor, finger tuo labbro</l>
             <l>Può tai menzogne! Ei sol empio ministro</l>
@@ -3885,7 +3931,7 @@
             <l>A ribaldi non fo tua morte, e a <rs type="name">Giuda</rs></l>
             <l>Ne l'infamia sarai pari o da presso.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>No, mio german, ch'ogni più cruda offesa</l>
             <l>A lui perdono, e da te prego ancora</l>
@@ -3893,13 +3939,13 @@
             <l>Crede sua setta, necessario al regno</l>
             <l>Ben a ragione il mio supplicio stima.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l>Il perdon, che per lui chiedi, e ti scopre</l>
             <l>Ognor più adorno di virtù sublime,</l>
             <l>Il fallo atroce di quest'empio accresce.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>Se Ermenegildo per la fé ch'ei siegue</l>
             <l>Va sestante a morir, anch'io gli oltraggi</l>
@@ -3907,7 +3953,7 @@
             <l>Me, vassallo fedel, qual sia più grave</l>
             <l>Ingiuria, che da te, prenze, ricevo.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l>Volpe malvagia e vil, dove men noto</l>
             <l>Se’ tu, cotesta bontà fingi, e ascondi</l>
@@ -3919,7 +3965,7 @@
             <l>Tanto infausto d'Iberia a l'ampio regno,</l>
             <l>A la gloria de’ Goti, al nostro sangue.</l>
           </sp>
-          <sp>
+          <sp who="#ermenegildo">
             <speaker><hi rend="sc">E</hi>RMENEGILDO</speaker>
             <l>Del mal presente non vedrai funesti</l>
             <l>Forse gli effetti: avrà di me più degno</l>
@@ -3940,12 +3986,12 @@
             <l>Ma che più indugi? Ché più si ritarda</l>
             <l>La mia felicità? Germano, addio.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l>Teco sarò fin dove alto divieto</l>
             <l>No ‘l toglie, e poi ti seguirò col pianto.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l>Eterno Dio, dammi vigor, che possa</l>
             <l>Con magnanimo cor l'orrido aspetto</l>
@@ -3953,12 +3999,12 @@
             <l>Ogni virtù da questa miser alma.</l>
             <l>E ciò a maggior tuo pregio anco mi serva.</l>
           </sp>
-          <sp>
+          <sp who="#genserico">
             <speaker><hi rend="sc">G</hi>ENSERICO</speaker>
             <l>La gran'opra è in sicuro: oggi l'un muoia,</l>
             <l>E l'altro non vivrà, se avrem noi vita.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker><hi rend="sc">C</hi>ORO</speaker>
             <lg type="canzone">
               <lg>
@@ -4004,7 +4050,7 @@
             <hi rend="italic">Scena prima</hi>
           </head>
           <stage><hi rend="sc">L</hi>EOVIGILDO</stage>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>A che speranza ancor debile e manca</l>
             <l>Molce quel che mi strugge aspro tormento?</l>
@@ -4044,16 +4090,16 @@
             <hi rend="italic">Scena seconda</hi>
           </head>
           <stage><hi rend="sc">G</hi>UNDIMARO <hi rend="Italic">e</hi><hi rend="sc">D</hi>ETTO</stage>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l part="I">Non cedè ancora al fato.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">E che di lui</l>
             <l part="I">Finora avvenne?</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l part="F">Genserico avea</l>
             <l>Con suo comando a la fier opra il tutto</l>
@@ -4096,13 +4142,13 @@
             <l>Dal pietoso spettacolo, che troppo</l>
             <l part="I">Sentia stringermi il cor.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Né v'ha speranza</l>
             <l>Che il miser folle a la sua fé natia</l>
             <l part="I">Ritornar voglia?</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l part="F">Genserico ogni opra</l>
             <l>Fa per ritrarlo: con ragioni, e prieghi</l>
@@ -4111,7 +4157,7 @@
             <l>A l'ombre il nostro suol sarà che siegua</l>
             <l part="I">Tanta sventura.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Ei così disse. Intanto</l>
             <l>Ho sì confusa ed agitata l'alma</l>
@@ -4119,7 +4165,7 @@
             <l>Tu dunque or dimmi qual pronto riparo</l>
             <l part="I">Assi al tumulto che minaccia?</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l part="F">Un solo.</l>
             <l>Chi a cose odiate, ancorché invan, s'oppone</l>
@@ -4132,7 +4178,7 @@
             <l>Che prende di leggier voglia conforme</l>
             <l>A la cagion, c'ha innanzi, e l'altre obblia.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Recaredo a me venga: ei ch'è la sola</l>
             <l>E del padre, e del regno alta speranza,</l>
@@ -4144,13 +4190,13 @@
             <hi rend="italic">Scena terza</hi>
           </head>
           <stage><hi rend="sc">R</hi>ECAREDO <hi rend="Italic">e</hi><hi rend="sc">D</hi>ETTI</stage>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l>Benché più che d'oprar di pianger vago,</l>
             <l>Signor, mi sia, pur a seguir son pronto</l>
             <l part="I">Ciò ch'imporrai.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Ben a ragion si piange</l>
             <l>Da te un german, da me infelice un figlio,</l>
@@ -4163,7 +4209,7 @@
             <l>Passar può contro me, se tua virtute</l>
             <l part="I">Lor non farà contrasto.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="F">Al tuo periglio</l>
             <l>Sarà scudo fedel questo mio petto:</l>
@@ -4179,7 +4225,7 @@
             <l>Sì che lieto ancor io men corro a morte,</l>
             <l part="I">Se ciò t'aggrada.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Oimè, te ancor mi toglie</l>
             <l>Venen sì contaggioso! e te pur devo</l>
@@ -4192,7 +4238,7 @@
             <l>Tutto è periglio, tutto è dubbio, in tutto</l>
             <l>Incontro, per mio mal, vergogna e pena.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l>Signor, mentre fra te consigli, e pensi,</l>
             <l>Ermenegildo al fato estremo è presso,</l>
@@ -4201,7 +4247,7 @@
             <l>Resti l'orribil colpo. In tempo ognora</l>
             <l>A dar morte sarai, ma non già vita.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Dal tuo consiglio non dissento, e puote</l>
             <l>Da novella cagion nuovo decreto</l>
@@ -4209,7 +4255,7 @@
             <l>Qui Ermenegildo; almen s'abbia tal bene</l>
             <l>Da questa inaspettata aspra sventura.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l>Spero giugnere a tempo, e spero ancora</l>
             <l>Che a te non ogni mal venga per danno.</l>
@@ -4220,7 +4266,7 @@
             <hi rend="italic">Scena quarta</hi>
           </head>
           <stage><hi rend="sc">L</hi>EOVIGILDO <hi rend="Italic">e</hi><hi rend="sc">R</hi>ECAREDO </stage>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Tu trema intanto che del mio furore</l>
             <l>Il più rio colpo sopra te non cada:</l>
@@ -4234,7 +4280,7 @@
             <l>Solo una volta, che a suo pro bugiarde</l>
             <l>Ragioni udisti, ti ribelli e cangi!</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l>Ha tal possanza in nostre menti il vero</l>
             <l>Che in un sol tratto fulminar può quanto</l>
@@ -4251,7 +4297,7 @@
             <l>Che fia mia sorte. Chi la vita sprezza</l>
             <l part="I">Mortal forza non teme.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">E l'empia setta</l>
             <l>I suoi seguaci temerari rende</l>
@@ -4278,16 +4324,16 @@
             <hi rend="italic">Scena quinta</hi>
           </head>
           <stage><hi rend="sc">G</hi>UNDIMARO <hi rend="Italic">e</hi><hi rend="sc">D</hi>ETTI</stage>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l part="I">Signor, ti salva.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Che rechi d'infausto?</l>
             <l>Come sì tosto a noi, duce, tu riedi?</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l>Quel ch'io previdi, rio tumulto or ferve:</l>
             <l>Sento, per via, che ribellanti schiere</l>
@@ -4299,13 +4345,13 @@
             <l>Tentan nuovi misfatti, e saran questi</l>
             <l>Il torti il regno, e forse anco la vita.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>S'Ermenegido è salvo, io lieto ancora</l>
             <l>Il mio periglio e la ruina abbraccio,</l>
             <l>Né di fuga atto vil mio onore offenda.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l>Salvo lo credo, perché troppo insano</l>
             <l>Saria chi di salvarlo ardir non ebbe,</l>
@@ -4314,12 +4360,12 @@
             <l>Non a te, ma al tuo regno: ogni suo bene</l>
             <l part="I">Pende da tua salvezza.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="F">Ove a te piaccia</l>
             <l>Spender mia vita in tua difesa è pronta.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Nulla temer io debbo infin che vive</l>
             <l>Il generoso figlio: io so qual serba</l>
@@ -4331,7 +4377,7 @@
             <l>Più al cor palese, e ciò farà, ch'io ponga</l>
             <l part="I">Ogni colpa in obblio.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="F">Ecco un guerriero</l>
             <l>Di polve, di sudor, coverto e molle,</l>
@@ -4343,25 +4389,25 @@
             <hi rend="italic">Scena sesta</hi>
           </head>
           <stage><hi rend="sc">M</hi>ESSAGGIERO <hi rend="Italic">e</hi><hi rend="sc">D</hi>ETTI</stage>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">A noi che porti?</l>
           </sp>
-          <sp>
+          <sp who="#messaggiero">
             <speaker><hi rend="sc">M</hi>ESSAGGIERO</speaker>
             <l>Aspre novelle, alti perigli, e certe</l>
             <l part="I">Ruine, o mio gran re.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Deh, pria sol dimmi</l>
             <l part="I">Se vive o è spento Ermenegildo?</l>
           </sp>
-          <sp>
+          <sp who="#messaggiero">
             <speaker><hi rend="sc">M</hi>ESSAGGIERO</speaker>
             <l part="F">È spento.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Altro saper non voglio: è disperata</l>
             <l>Ogni mia speme, ogni desire estinto.</l>
@@ -4379,23 +4425,23 @@
             <l>E qual mai scempio inusitato, ed aspro</l>
             <l part="I">A me caro non fia?</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="M">Padre…</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l part="F">Signore…</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Che padre, che signor, dite tiranno.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="I">Almeno ascolta.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Udir nulla più voglio,</l>
             <l>Né alcun mi siegua. Al mio dolore in braccio</l>
@@ -4407,21 +4453,21 @@
             <hi rend="italic">Scena settima</hi>
           </head>
           <stage><hi rend="sc">R</hi>ECAREDO, <hi rend="sc">G</hi>UNDIMARO  <hi rend="Italic">e</hi><hi rend="sc">M</hi>ESSAGGIERO</stage>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l>A qual passo crudel superbia, ed empio</l>
             <l>Consiglier trasse il misero regnante!</l>
             <l>Agitato da furie, incerti passi</l>
             <l part="I">Forma veloce, e geme ed urla.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="F">Amico,</l>
             <l>Narra il nostro mal certo, indi il periglio.</l>
             <l>Poiché l'inclito prenze il palco ascese,</l>
             <l part="I">Di lui che avvenne?</l>
           </sp>
-          <sp>
+          <sp who="#messaggiero">
             <speaker><hi rend="sc">M</hi>ESSAGGIERO</speaker>
             <l part="F">Il consigliero iniquo</l>
             <l>Salì pur seco, e intrepida con essi</l>
@@ -4482,15 +4528,15 @@
             <l>Ad Igonda il sermone, e ‘l teschio amato</l>
             <l>A lei strappa inumano, e al suol lo scaglia.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l part="I">Ah scellerato!</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="F">E tanto ardisce un vile?</l>
           </sp>
-          <sp>
+          <sp who="#messaggiero">
             <speaker><hi rend="sc">M</hi>ESSAGGIERO</speaker>
             <l>All'atto indegno trattener più l'ira</l>
             <l>Non può la gente generosa, e misti</l>
@@ -4516,21 +4562,21 @@
             <l>Fato da lei dipende, e a darvi io corsi</l>
             <l>Il tristo annuncio su destrier veloce.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l>Che farem noi? qual forsennato in braccio</l>
             <l>Al suo duol freme il re misero, e intanto</l>
             <l>S'avanza Igonda, e ‘l rio periglio è presso.</l>
             <l part="I">Correr vo’ a la difesa.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l part="F">Il tutto è vano,</l>
             <l>Di tua vita non temo, e sol vorrei</l>
             <l>Servar per ora il regal capo. Ei riede</l>
             <l part="I">A noi tutto agitato.</l>
           </sp>
-          <sp>
+          <sp who="#recaredo">
             <speaker><hi rend="sc">R</hi>ECAREDO</speaker>
             <l part="F">Or la tua fede</l>
             <l part="I">In ciò s'adopri. Io vado.</l>
@@ -4541,39 +4587,39 @@
             <hi rend="italic">Scena ottava</hi>
           </head>
           <stage><hi rend="sc">L</hi>EOVIGILDO, <hi rend="sc">G</hi>UNDIMARO  <hi rend="Italic">e poi</hi><hi rend="sc">M</hi>ESSAGGIERO</stage>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Or quali strida</l>
             <l>Assordan l'aere? par che la mia morte</l>
             <l>Ognun brami, ognun chieda, e alcun non osa</l>
             <l>Con la pietosa man passarmi il petto!</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l>Signor, sospendi i disperati accenti,</l>
             <l>E de’ fedeli tuoi ripara al rischio.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="I">Che v'ha di peggio?</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l part="F">La cittade, il campo</l>
             <l>Seguendo Igonda, a nostri danni or giugne.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Qual governo esser puote in uom cui preme</l>
             <l>Disperato dolor? Per me disponga</l>
             <l part="I">Col suo consiglio Genserico.</l>
           </sp>
-          <sp>
+          <sp who="#gundimaro">
             <speaker><hi rend="sc">G</hi>UNDIMARO</speaker>
             <l part="F">Ei giacque</l>
             <l>Lacero e spento da le turbe irate.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>E dove io più mi volgo? un figlio estinto</l>
             <l>Giace per mio comando, e l'altro è reo</l>
@@ -4582,7 +4628,7 @@
             <l>Mie schiere, e tentan queste anco vendetta</l>
             <l part="I">Contro mia vita! sì vengan…</l>
           </sp>
-          <sp>
+          <sp who="#messaggiero">
             <speaker><hi rend="sc">M</hi>ESSAGGIERO</speaker>
             <l part="F">Signore,</l>
             <l>Da lor furie primiere almen t'ascondi,</l>
@@ -4591,13 +4637,13 @@
             <l>L'inclito Recaredo al gran torrente,</l>
             <l part="I">Che tutto inonda.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l part="F">Or dove son le spade,</l>
             <l>Che al viver mio dian fine? Io stesso incontro</l>
             <l part="I">Vo’ girne a la mia morte.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l part="F">Ecco, o tiranno,</l>
             <l>De l'orgoglioso tuo furore il frutto.</l>
@@ -4612,7 +4658,7 @@
             <l>A queste mura, l'esecrabil nome</l>
             <l>Oltraggian d'<rs type="name">Arrio</rs>, ed a morir son pronti.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Furia più ch'infernale, a qual han tratto</l>
             <l>L'arti tue lusinghiere ultimo scempio</l>
@@ -4625,7 +4671,7 @@
             <l>Da te chiede vendetta, e tu sospesa</l>
             <l>La ritardi così! Femmina vile.</l>
           </sp>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l>No, Leovigildo; la verace fede,</l>
             <l>Pietà, perdono, e non vendetta insegna:</l>
@@ -4641,7 +4687,7 @@
             <l>Or salvai su le soglie, avrà sì chiaro</l>
             <l>Titol principio, ed avrà fin col mondo.</l>
           </sp>
-          <sp>
+          <sp who="#leovigildo">
             <speaker><hi rend="sc">L</hi>EOVIGILDO</speaker>
             <l>Meglio mi svena, che mostrarmi adorno</l>
             <l>Di virtù tanta chi difende, e siegue</l>
@@ -4654,7 +4700,7 @@
           <stage>
             <hi rend="Italic">[parte]</hi>
           </stage>
-          <sp>
+          <sp who="#igonda">
             <speaker><hi rend="sc">I</hi>GONDA</speaker>
             <l>Or voi, re eccelsi, e imperadori augusti,</l>
             <l>Che il cattolico nome a gloria avrete,</l>
@@ -4664,7 +4710,7 @@
             <l>Onorate di lui l'alta memoria,</l>
             <l>E a lui prieghi sian porti, incensi e voti.</l>
           </sp>
-          <sp>
+          <sp who="#coro_1">
             <speaker><hi rend="sc">C</hi>ORO DELL'ATTO PRIMO</speaker>
             <lg type="sestina">
               <lg>
@@ -4725,7 +4771,7 @@
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro_2">
             <speaker><hi rend="sc">C</hi>ORO DELL'ATTO SECONDO</speaker>
             <lg type="sestina">
               <lg>
@@ -4762,7 +4808,7 @@
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro_3">
             <speaker><hi rend="sc">C</hi>ORO DELL'ATTO TERZO</speaker>
             <lg type="quartina">
               <lg>
@@ -4803,7 +4849,7 @@
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro_4">
             <speaker><hi rend="sc">C</hi>ORO DELL'ATTO QUARTO</speaker>
             <lg type="quinario">
               <lg>
@@ -4836,7 +4882,7 @@
               </lg>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro_5">
             <speaker><hi rend="sc">C</hi>ORO DELL'ATTO QUINTO</speaker>
             <lg type="quartina">
               <lg>

--- a/tei/martelli-tullia.xml
+++ b/tei/martelli-tullia.xml
@@ -81,6 +81,43 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="lucio">
+            <persName>Lucio Tarquino</persName>
+          </person>
+          <person xml:id="demarato">
+            <persName>Demarato</persName>
+          </person>
+          <person xml:id="tullia">
+            <persName>Tullia</persName>
+          </person>
+          <personGrp xml:id="coro">
+            <name>Coro di donne</name>
+          </personGrp>
+          <person xml:id="nutrice">
+            <persName>Nutrice</persName>
+          </person>
+          <person xml:id="regina">
+            <persName>Regina</persName>
+          </person>
+          <person xml:id="nunzio">
+            <persName>Nunzio</persName>
+          </person>
+          <person xml:id="servio">
+            <persName>Servio</persName>
+          </person>
+          <personGrp xml:id="semicoro">
+            <name>Semicoro</name>
+          </personGrp>
+          <person xml:id="ombra">
+            <persName>Ombra</persName>
+          </person>
+          <person xml:id="romolo">
+            <persName>Romolo</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Pavia</name>Digitalizzazione</change>
@@ -128,7 +165,7 @@
     <body>
       <div>
         <head>ATTO I</head>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>O più degli occhi miei caro fratello,</l>
           <l>Che del nostro avo antico il nome serbi</l>
@@ -156,7 +193,7 @@
           <l>S'a mie voglie il destin non s'attraversa,</l>
           <l>E non fa vane sue promesse il Cielo.</l>
         </sp>
-        <sp>
+        <sp who="#demarato">
           <speaker>Demarato</speaker>
           <l>Gradisce Iddio sopra le forti stelle</l>
           <l>Gli uomini saggi, e quando il saggio e 'l dritto</l>
@@ -170,7 +207,7 @@
           <l>Dimmi quel che dir dèi, che forte e fido</l>
           <l>Compagno avra'mi a terminar tue imprese.</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Ben sei nato di stirpe alta e pregiata,</l>
           <l>Ben sei di gloria amico, e ben ne mostra</l>
@@ -246,7 +283,7 @@
           <l>Che s'un falso parlar salute reca,</l>
           <l>Non se ne dee temer vergogna o scempio.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>O chiara luce, se recando il giorno</l>
           <l>Dal pigro sonno gli animali svegli,</l>
@@ -377,7 +414,7 @@
           <l>Non si deve aiutar chi vive in pena.</l>
           <l>Sia felice chi vince, e mai non pera.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <lg>
             <l>Quante lagrime, ohimè, quanti sospiri</l>
@@ -443,7 +480,7 @@
       </div>
       <div>
         <head>ATTO II</head>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Nobile schiera amica,</l>
           <l>Che vieni a consolarmi in tante pene,</l>
@@ -460,7 +497,7 @@
           <l>Conoscendo che vano</l>
           <l>È loro oprare, e l'ascoltare è nulla.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>I casi avversi sono</l>
           <l>Quei che palesi fan gli stolti e i saggi.</l>
@@ -471,7 +508,7 @@
           <l>Puonno dolore et ira,</l>
           <l>Ch'a noi doglia, a te fora alta rovina.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Qual mai rovina estrema</l>
           <l>Giunger potrebbe altrui,</l>
@@ -502,7 +539,7 @@
           <l>E 'l badar longo e 'ncerto,</l>
           <l>E forse il danno, lassa, ond'io sì temo.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Per le cose passate</l>
           <l>Non si dee già nodrir tanto dolore.</l>
@@ -513,7 +550,7 @@
           <l>Lassa, sempre potrai</l>
           <l>Vivere in pena, ma non sempre in gioia.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>O dolce compagnia,</l>
           <l>Più de la vita, ch'io gradisco solo</l>
@@ -536,13 +573,13 @@
           <l>Perché di par mi vanno</l>
           <l>Le cagion e la doglia entro la mente.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Il gran disio che d'acquetarti avea</l>
           <l>Così mi fea parlar, donna gradita.</l>
           <l>Or s'io t'offendo, taccio e piango teco.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Qual fu mai donna, o donne, sotto il sole</l>
           <l>Che per troppo languir peccasse meno</l>
@@ -605,54 +642,54 @@
           <l>Dandogli in man la spada,</l>
           <l>Che può sola adempir pruova sì degna.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Egli è nato di tal, che saprà bene</l>
           <l>Prender l'occasione, il loco e 'l tempo</l>
           <l>Di recarti salute e vendicarsi;</l>
           <l>E vederlo mi par, tanto il disio.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Se 'l tempo è quel che voi chiamate morte,</l>
           <l>Certo io l'attendo; ma s'ei son diversi,</l>
           <l>Morte verrà lasciando il tempo a dietro,</l>
           <l>Che può solo appagar l'anima stanca.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Ornamento è 'l badar, a l'uom ch'è saggio,</l>
           <l>Ne le più perigliose imprese grevi.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Taci, che 'l sol precipitato ardire</l>
           <l>A' valorosi spirti acquista fama.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Sì, ne le cose che si puonno in uno</l>
           <l>Volger d'occhio operar; et a quelle anco</l>
           <l>Si dovrebbe pensar non picciol tempo.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Tanto omai l'ha pensato il mio marito,</l>
           <l>Che si truova esser veglio; e s'ei più bada,</l>
           <l>E le forze e l'ardir gli torran gli anni.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>L'oprare estremo a chi ben guida il tutto</l>
           <l>È quel che meno in ogni impresa è greve.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Io vorrei pur saper da te che giova,</l>
           <l>Poscia ch'un sa quel ch'ei far deve e vuole,</l>
           <l>Il menar vani i suoi giorni migliori.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Chi vuol fuggir vergogna e danno eterno,</l>
           <l>E forse morte assai più d'altra vile,</l>
@@ -673,7 +710,7 @@
           <l>Et egli è tal. ch'ogni salute spero</l>
           <l>Da suoi consigli saggi e da sue mani.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Lassa, col tuo parlar però non fai</l>
           <l>Ergermi a speme, o scemar pur l'affanno,</l>
@@ -681,13 +718,13 @@
           <l>E sol pensando in me che la mia vita</l>
           <l>Omai corta esser deve, ho qualche pace.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Tullia, non parliam più, ch'io vedo fore</l>
           <l>Venir la tua nodrice, ch'olocausti</l>
           <l>E vasi, e cose sepolcrali ha seco.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Lassa, ch'io vedo qua Tullia infelice</l>
           <l>Con altre donne ragionar dolente,</l>
@@ -711,20 +748,20 @@
           <l>Porta il tanto dolor, fin ch'ei s'annulle,</l>
           <l>Mercé di morte o di pietosa stella.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Non mi chiamar più figlia, o vecchia amica,</l>
           <l>Che 'l nome solo mi spaventa e 'naspra:</l>
           <l>Che seco il nome cria di padre e madre,</l>
           <l>I quai sempre odio, e de' miei mali incolpo.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Ah, di' parole oneste: ei pur son quegli</l>
           <l>Che ti diedero al mondo, e questo solo</l>
           <l>Appagar doverrebbe ogn'alta offesa.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Taci, cara nutrice, mai non fia</l>
           <l>Ch'io renda grazie a chi m'ha posto in doglia:</l>
@@ -733,30 +770,30 @@
           <l>L'esser nel mondo; or poi che pur ci sono,</l>
           <l>L'esser nata di lor m'è grave.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Tu non aresti parte in sì bel regno?</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Ch'ho io di questo regno altro che pianto?</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Rechi che vuole il fato, tu pur sei</l>
           <l>E figlia e sposa del Signor di Roma.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>L'un m'è nemico e l'altro è sì lontano,</l>
           <l>Ch'io temo di morir prima ch'ei torni.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>L'un t'hai fatto nemico, e l'altro è lunge</l>
           <l>Per sua troppa fierezza e troppo sdegno.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>S'io fussi crudel contra mio padre,</l>
           <l>In contra mio marito sarei cruda.</l>
@@ -766,23 +803,23 @@
           <l>Che n'ha dato pietà, perché noi siamo</l>
           <l>Più degli altri animai di bene amici.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Nati semo mortali, e i pensier nostri</l>
           <l>Deon esser uguali al poter nostro.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Se noi cerchiam di far quel ch'altri ha fatto,</l>
           <l>Come dee questo mai vietarne il Cielo?</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>S'ei fusse stato a vostre imprese amico,</l>
           <l>Non avria poste in voi le voglie avverse,</l>
           <l>Che fur cagion de le seconde morti.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Se le prime empie furo, le seconde</l>
           <l>Furon pietose e sante, che ben face</l>
@@ -796,13 +833,13 @@
           <l>Di ricovrarne il regno, in cor ne pose</l>
           <l>D'uccider quei ch'a ciò fussero avversi.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Fera stella sovente ha forza tale,</l>
           <l>Ch'ella ne fa bramar nostra rovina,</l>
           <l>S'animo saggio il suo furor non tempra.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Duque mi vuoi tu dir che questo fia</l>
           <l>Nostra rovina estrema: or se fia questo,</l>
@@ -812,7 +849,7 @@
           <l>Viva sarò regina, e morta nulla;</l>
           <l>Così porrò pur fine ai miei lamenti.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Deh, non t'armar di tanta asprezza il core,</l>
           <l>E s'a tempo miglior tornar pur dèi,</l>
@@ -822,19 +859,19 @@
           <l>A chi più t'ama, et io n'andrò lieta</l>
           <l>(Ch'omai posso star poco) a l'altra vita.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Come può starsi in pace una che guerra</l>
           <l>Sen portò da le fasce e da la culla,</l>
           <l>Sol per lasciarla in su 'l funereo rogo?</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Non t'è grave l'offesa de' nimici</l>
           <l>Ne la parte millesima ch'è quella</l>
           <l>Che 'n contra te medesma accresci ognora.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Allor m'offenderei ch'io m'acquetassi:</l>
           <l>Che gli spirti gentii s'amano allora</l>
@@ -842,11 +879,11 @@
           <l>Erra quei che de' suoi danni non piange,</l>
           <l>Come chi non gradisce i ben del Cielo.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Dimmi, che ti fanno ora i tuoi parenti?</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Or che mi puon far peggio i miei nemici,</l>
           <l>Che non fare altro che godersi in gioia?</l>
@@ -858,7 +895,7 @@
           <l>Pur devresti operar con tue parole</l>
           <l>Sì ch'io sapessi i lor pensieri ascosi.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Non per altrui preghiera o sdegno mio</l>
           <l>Teco Tullia ragiono in questa guisa,</l>
@@ -883,7 +920,7 @@
           <l>Quando dal petto amico mi ti tolse</l>
           <l>Chi ti volea cibar d'altra esca omai.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Deh, che mi torna a mente: o dolce etate,</l>
           <l>Che non hai senso di dolor pur uno!</l>
@@ -894,99 +931,99 @@
           <l>Ma dimmi or brevemente, quai parole</l>
           <l>Fur quelle onde tu sei paurosa e trista?</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Ei ragionano in casa accesi ognora.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Il ragionar non è quel che m'ancide.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Di trovar modo che tu taccia omai.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Io non vo' più tacer, pur troppo taccio.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>O con tenerti eternamente in casa.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Non potrò io gridar mai sempre in casa?</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>O con legarti in chiusa tomba oscura.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Pur odiran le genti i dolor miei.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>O con mandarti in perigliosa selva.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Io chiamerò le fere a pianger meco.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>O con farti morir, s'altro non giova.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Io non spero da lor tanta pietate.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Tu ti lasci accecar da troppo sdegno.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Anzi giusta pietate a ciò m'adduce.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Ov'è la mente tua, dolce mia vita?</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Mai non fu quanto or meco, né sì saggia.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Credi a chi t'ama, et è canuta e bianca.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Più 'nsegna spesso un dì, ch'infiniti anni.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Grave ti fia soffrir nuovi martiri.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Io non chiamo martir quel che mi sana.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Morir per picciol fallo è cosa vile.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Come poss'io fuggir chi m'have in preda?</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Il tacer solo, Tullia, t'assicura.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Più m'è grave silenzio assai, che morte.</l>
           <l>E loro è la viltà, se per lor moro.</l>
@@ -998,35 +1035,35 @@
           <l>Com'a loro il regnar, poi ch'ei son regi,</l>
           <l>E ch'ogni mio sperar sen porta il vento.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Tu 'mpetreresti ancor da lor pietate?</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Tu m'offendi or vie più che i miei nemici.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Piaccinti, Tullia mia, queste parole.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Come poss'io lodar parlar sì reo?</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>O Tullia, o Tullia, ad or vorrai lodarle,</l>
           <l>Che più tempo non fia, credemi, taci:</l>
           <l>La tua doglia m'ancide, e te tien viva.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Tu ti vedrai cader morta davante</l>
           <l>Questa vecchia angosciosa: dille almeno</l>
           <l>Che vadia a terminar l'ordita impresa.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Se tu mi porti, come mostri, amore,</l>
           <l>A te dee pur piacer quel ch'a me piace,</l>
@@ -1040,59 +1077,59 @@
           <l>Partiti omai da me, ma dimmi pria,</l>
           <l>Per cui si fanno i santi sagrifici?</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>La Regina mi manda al gran sepolcro</l>
           <l>Di suo padre e sua madre, e vuol ch'io facci</l>
           <l>Sepolcral sacrificio per placarli.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Da' suoi crudi nemici vuol mercede?</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Da quei (poi che tu vuoi ch'io così dica)</l>
           <l>Ch'ell'uccise, là vado a far quest'opra.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Fa' pria ch'io sappi qual pietà novella,</l>
           <l>O consiglio d'amici a ciò l'adduca.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Non già consiglio altrui, non pietà nuova,</l>
           <l>Ma notturno spavento n'è cagione.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Fate, seguite il resto, o Dii del Cielo!</l>
           <l>Non potre' io saper che cosa è questa?</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Tanto non ne so io, ch'altro che poco</l>
           <l>Dir te ne possi, ch'un'oscura fama</l>
           <l>Me ne giunse a l'orecchie dianzi in casa.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Poche parole altere imprese spesso</l>
           <l>Han fatto fare altrui; dimmi quel poco.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Io 'l ti dirò; ma ben che questo</l>
           <l>Tra te restasse e me, ch'altri nol sappi,</l>
           <l>Che molto può punir, chi molto puote.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Io vo' che questa amica schiera il sappi,</l>
           <l>Che m'è fida compagna; or dillo adunque.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Presso al mattin de la passata notte,</l>
           <l>Orribil sogno ha fatto la Regina,</l>
@@ -1113,7 +1150,7 @@
           <l>Più non so già, se non che questa tema</l>
           <l>È la vera cagion de l'andar mio.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Se tu sei di pietate amica, e mia,</l>
           <l>Odi, sostegno mio, queste parole.</l>
@@ -1159,29 +1196,29 @@
           <l>E se tu la mi fai cortese, a pena</l>
           <l>Potrà far morte che già mai l'oblii.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Tu non le puoi negar quel ch'ella chiede,</l>
           <l>Se tu le sei (come tu mostri) amica,</l>
           <l>E com'esser devresti: io so ben quanto</l>
           <l>Sempre è vivo l'amor de le nutrici.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Chi m'assecura, ohimè, ch'ella nol sappi,</l>
           <l>E non facci patir nuovo martire</l>
           <l>A Tullia, e me per disleale uccida?</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Chi ti può mai veder? Noi taceremo.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>I freddi sangui e le 'mbiancate tempie</l>
           <l>Fanno costei temer quel ch'è securo.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Tullia, io 'l farò per contentarti; voi</l>
           <l>Tacete. O Dio, chi vive ha pur talora</l>
@@ -1196,7 +1233,7 @@
           <l>Ov'or son serva? Ahi, questa servitute</l>
           <l>I giovin forti inaspra e i vecchi stanca.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <lg>
             <l>Quando noi semo in dolce sonno involti,</l>
@@ -1292,7 +1329,7 @@
       </div>
       <div>
         <head>ATTO III</head>
-        <sp>
+        <sp who="#regina">
           <speaker>Regina</speaker>
           <l>Ahi figlia, ahi figlia folle! Ancor non vuoi</l>
           <l>Por fine a' tanti tuoi vani lamenti,</l>
@@ -1335,7 +1372,7 @@
           <l>Di nuova stirpe. Or fammi conti adunque,</l>
           <l>Anzi ch'io parta, i tuoi pensieri ascosi.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Poi ch'io posso parlar come a me piace,</l>
           <l>E so in che stato or mi mantiene il Cielo,</l>
@@ -1431,7 +1468,7 @@
           <l>Io ho ben anco altri pensier nel core,</l>
           <l>Che mai dir non potrebbe umana voce.</l>
         </sp>
-        <sp>
+        <sp who="#regina">
           <speaker>Regina</speaker>
           <l>Io sarei più di te del senno in bando,</l>
           <l>S'io credessi parlando acquetar ora</l>
@@ -1556,7 +1593,7 @@
           <l>Ma come fanno i rei, tolto ne avete</l>
           <l>A noi ogni pietate, et a voi il regno.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Già non sei giusta e pia, come tu vuoi</l>
           <l>Ch'altri pel tuo parlar, perfida, creda.</l>
@@ -1608,13 +1645,13 @@
           <l>Quella vita e i martir, ch'a noi dati hai,</l>
           <l>Che piangiamo i tuoi, e tu n'hai gioia.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Questo molto furor, che 'l suo dir mostra,</l>
           <l>Esser potrebbe ancor la sua rovina.</l>
           <l>Ma di che dee temer, chi morte sprezza?</l>
         </sp>
-        <sp>
+        <sp who="#regina">
           <speaker>Regina</speaker>
           <l>Io non vo' che tu creda al mio dir vero.</l>
           <l>Credi quel ch'a te piace, e me pur chiama</l>
@@ -1632,13 +1669,13 @@
           <l>Ne tegna in vita; et offrirò legumi</l>
           <l>Varii, quanti puon mai nascerne al mondo.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Tullia, s'io ti vedessi a sperar volta,</l>
           <l>Io ti direi che la Regina teme,</l>
           <l>Per quel ch'io vidi in su la sua partita.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Io son volta a sperar: sai quel ch'io spero?</l>
           <l>Spero che 'l sdegno suo morte mi rechi;</l>
@@ -1660,17 +1697,17 @@
           <l>Come di quella dei buon vecchi occisi.</l>
           <l>Chi ved'io qua venir, donne mie care?</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Greci paiono a me, se 'l ver ne mostra</l>
           <l>La vista e i panni, e 'l portamento altero.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Deh, porterebber mai qualche novella</l>
           <l>Del mio caro marito? Io vo' saperlo.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Affrena il tuo voler, ch'a donna onesta</l>
           <l>Non è bello il parlar con genti strane.</l>
@@ -1683,33 +1720,33 @@
           <l>Allor fia cortesia dar lor risposta,</l>
           <l>E potrai domandar del tuo marito.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Ohimè, quanta paura il cor m'agghiaccia!</l>
           <l>Io non posso sperar ch'ei portin bene,</l>
           <l>Sì vedo avaro il Ciel de' miei martiri.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Io vedo Servio giunto in su la porta</l>
           <l>Et un che i forestier gli mostra a dito.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>State d'avanti a me, ch'ei non mi scorga,</l>
           <l>E drizzate al suo dir l'orecchie intente.</l>
         </sp>
-        <sp>
+        <sp who="#nunzio">
           <speaker>Nunzio</speaker>
           <l>Questi son, signor mio, quei Greci ch'io</l>
           <l>Dicea d'aver veduti in questa terra.</l>
         </sp>
-        <sp>
+        <sp who="#servio">
           <speaker>Servio</speaker>
           <l>Qual fato, qual disio, qual vento spinti</l>
           <l>V'ha ne la mia cittade, e di qual parte?</l>
         </sp>
-        <sp>
+        <sp who="#demarato">
           <speaker>Demarato</speaker>
           <l>Le tue parole e l'alta nobiltade,</l>
           <l>di ch'è tua vista adorna, ne fan chiaro</l>
@@ -1728,11 +1765,11 @@
           <l>De' valorosi spirti e di virtute,</l>
           <l>E de la vera nobiltà natia.</l>
         </sp>
-        <sp>
+        <sp who="#servio">
           <speaker>Servio</speaker>
           <l>Perché fuggite i dolci patrii lidi?</l>
         </sp>
-        <sp>
+        <sp who="#demarato">
           <speaker>Demarato</speaker>
           <l>Quella doglia mortal, che si rinfresca</l>
           <l>Nel contar le cagion di nostra fuga,</l>
@@ -1788,34 +1825,34 @@
           <l>Che con la scorta fida degli Iddii</l>
           <l>Sem venuti a pigliar patria novella.</l>
         </sp>
-        <sp>
+        <sp who="#servio">
           <speaker>Servio</speaker>
           <l>Libera è la mia terra, e fa securo,</l>
           <l>Chi ch'ei si sia, qualunche in lei s'accoglie,</l>
           <l>E dà mercede ai giusti, et a' rei pena.</l>
           <l>Quant'ha che voi partiste di Corinto?</l>
         </sp>
-        <sp>
+        <sp who="#demarato">
           <speaker>Demarato</speaker>
           <l>Otto giorni, signor, ché i venti amici</l>
           <l>Hanno empiute le vele, et hanci a volo</l>
           <l>Fatto solcar le salse onde tranquille.</l>
         </sp>
-        <sp>
+        <sp who="#servio">
           <speaker>Servio</speaker>
           <l>Saprestemi voi dir vera novella</l>
           <l>D'un Lucio Tarquino, che là vive?</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Io ho sentito dir Lucio Tarquino.</l>
         </sp>
-        <sp>
+        <sp who="#demarato">
           <speaker>Demarato</speaker>
           <l>S'altro segno non aggio, in non ho a mente</l>
           <l>Di conoscer colui che nomat'hai.</l>
         </sp>
-        <sp>
+        <sp who="#servio">
           <speaker>Servio</speaker>
           <l>Ei fu figliolo d'un, che fu già signore</l>
           <l>Di questa terra, e la sua stirpe vera</l>
@@ -1825,66 +1862,66 @@
           <l>E me lassò ne l'onorato seggio,</l>
           <l>Che tenne il padre suo molt'anni in pace.</l>
         </sp>
-        <sp>
+        <sp who="#demarato">
           <speaker>Demarato</speaker>
           <l>Piacciati, signor mio, di non far forza</l>
           <l>Di voler or saper di lui novelle.</l>
         </sp>
-        <sp>
+        <sp who="#servio">
           <speaker>Servio</speaker>
           <l>Altro non cerco, che di lui novelle:</l>
           <l>Dimmen senza temer quel che ne sai.</l>
         </sp>
-        <sp>
+        <sp who="#demarato">
           <speaker>Demarato</speaker>
           <l>Nessun ama chi porta empia novella.</l>
         </sp>
-        <sp>
+        <sp who="#servio">
           <speaker>Servio</speaker>
           <l>Né per l'empie novelle assai m'attristo,</l>
           <l>Né per le buone assai divegno altero.</l>
           <l>Tu mi farai pensar, tacendo, peggio</l>
           <l>Di quel che puon le tue parole dirmi.</l>
         </sp>
-        <sp>
+        <sp who="#demarato">
           <speaker>Demarato</speaker>
           <l>Io sarò forse giunto in porto (ahi lasso),</l>
           <l>Che sarà porto ancor de la mia vita.</l>
         </sp>
-        <sp>
+        <sp who="#servio">
           <speaker>Servio</speaker>
           <l>Sarebbe mai costui di vita casso?</l>
         </sp>
-        <sp>
+        <sp who="#demarato">
           <speaker>Demarato</speaker>
           <l>Se tu n'avrai gran doglia, a me fia grave:</l>
           <l>Ben sai, ch'ei non è più tra' vivi in terra.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Lassa, ch'è quel ch'io sento? Ascolta, taci!</l>
         </sp>
-        <sp>
+        <sp who="#servio">
           <speaker>Servio</speaker>
           <l>È morto adunque? Or come? Or di che morte?</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Ohimè. Ch'io sento ragionar di morte.</l>
         </sp>
-        <sp>
+        <sp who="#demarato">
           <speaker>Demarato</speaker>
           <l>Poco so io del suo caso infelice:</l>
           <l>Ch'io ne senti' parlar per la cittade</l>
           <l>Confusamente, e so per vero appunto</l>
           <l>Ch'ei più non vive, e non posso altro dirti.</l>
         </sp>
-        <sp>
+        <sp who="#servio">
           <speaker>Servio</speaker>
           <l>Entriamo in casa, io vo' da te sapere</l>
           <l>Il confuso parlar ch'udito n'hai.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Or come fia mai vero? O sommo Giove,</l>
           <l>Vedi tu queste cose? O pur te indarno</l>
@@ -1900,42 +1937,42 @@
           <l>Biasimando del Ciel le torte leggi,</l>
           <l>E lamentando il mio fero destino.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Quanta dolcezza, avventurosa donna,</l>
           <l>Ebbe nel mondo unquanco, non agguaglia</l>
           <l>La millesima parte di mia gioia.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Non mi parlar, nutrice, ch'io non voglio,</l>
           <l>Mentr'io vivo, parlar con gente allegra.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Io ti reco riposo, e pace eterna</l>
           <l>Agli angosciosi tuoi pianti e sospiri.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>A tal son giunti i miei penosi giorni,</l>
           <l>Ch'io avrò morte omai con questa noia.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Ascolta, Tullia mia, poche parole.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Quella fia la mia pace e 'l mio riposo.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Al tuo grave martir non puon mai pena</l>
           <l>Giunger poche parole; ascolta, peggio</l>
           <l>Udir non puoi di quel che dianzi udisti.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Io ho trovato che novellamente</l>
           <l>Son stati fatti santi sagrifici</l>
@@ -1943,7 +1980,7 @@
           <l>Coronato di treccie e fior novelli:</l>
           <l>E potrebb'esser stato il tuo marito.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Ahi, quanti strazii mi destina il Cielo!</l>
           <l>O felice colui che muore in fasce!</l>
@@ -1951,7 +1988,7 @@
           <l>Mandatela a gioir con quei di casa,</l>
           <l>E non stia qui chi non vuol pianger meco.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Vanne in casa, o pietosa vecchiarella,</l>
           <l>Et udirai novella per costei</l>
@@ -1959,7 +1996,7 @@
           <l>Non può far sagrifici, anzi gli chiede,</l>
           <l>S'aver puon tal disio l'anime sciolte.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Ohimè, ch'è quel ch'io odo? Adunque è morta</l>
           <l>Ogni nostra speranza? O sommo Giove,</l>
@@ -1968,18 +2005,18 @@
           <l>Subito in tristi i miei pensier sì lieti?</l>
           <l>Ond'è venuta a noi sì rea novella?</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>In casa intenderai quel che tu cerchi:</l>
           <l>Partiti omai, ch'a Tullia sei molesta.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>Nutrice</speaker>
           <l>Io son pur giunta a tal, che più non posso</l>
           <l>Pregare il Ciel, o far cosa che sia</l>
           <l>Utile o cara a Tullia, ahi lassa, ahi lassa!</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Troppo dolce sarebbe il morir ora,</l>
           <l>Et io cosa non vo', che dolce sia.</l>
@@ -2016,13 +2053,13 @@
       </div>
       <div>
         <head>ATTO IV</head>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Tutta lieta vien fuor l'empia Regina,</l>
           <l>E ben mostra d'aver novella udita,</l>
           <l>Che l'assecuri e la riponga in pace.</l>
         </sp>
-        <sp>
+        <sp who="#regina">
           <speaker>Regina</speaker>
           <l>Amico avemo il Cielo, e l'alme sciolte</l>
           <l>(Per quanto io vedo) han giù posto ogni orgoglio</l>
@@ -2034,7 +2071,7 @@
           <l>Al biondo Apollo, poi che 'l sogno mio</l>
           <l>Agli nimici miei rovina porta.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>O figliuol di Saturno, e Re del Cielo,</l>
           <l>Più non si può sperar per noi salute,</l>
@@ -2051,7 +2088,7 @@
           <l>Servire a reo signor, quanto soave</l>
           <l>L'esser soggetto ad un signor benigno.</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Donne, che di pietà m'empiete il core</l>
           <l>Con l'angosciosa vista in cui si vede</l>
@@ -2059,7 +2096,7 @@
           <l>Sarebbe questo mai l'alto palagio</l>
           <l>Del sommo imperador di questa terra?</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>L'alto palagio che tu cerchi è questo.</l>
           <l>Ma dinne, o forestier, se Dio ti facci</l>
@@ -2067,47 +2104,47 @@
           <l>Onde sei tu venuto in questa terra?</l>
           <l>E qual porti novella al signor nostro?</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Donne cortesi, di Corinto vegno:</l>
           <l>Cara novella al signor vostro porto,</l>
           <l>Ma non già cara a l'infelice donna,</l>
           <l>Ch'ha 'l suo marito in questo picciol vaso.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Ohimè, infelice, ohimè!</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Che fai, Tullia, che fai?</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Più non son viva, o donne,</l>
           <l>Perché l'alma si parte.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Deh, sollieva te stessa,</l>
           <l>Tullia, io ti porgo aita.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Più non ho membro (ahi lassa)</l>
           <l>Ch'aggia parte di vita.</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Io son presago omai</l>
           <l>De l'alta doglia vostra.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Quest'è quella infelice</l>
           <l>Di cui morto è 'l marito.</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Quanta pietà mi stringe</l>
           <l>L'alma de' suoi martiri!</l>
@@ -2121,7 +2158,7 @@
           <l>De la sua morte, e dirle</l>
           <l>Per lui poche parole.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Deh torna, anima vaga,</l>
           <l>In queste membra lasse.</l>
@@ -2141,18 +2178,18 @@
           <l>E per le vene e i polsi,</l>
           <l>Tornar l'alma affannosa.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Ohimè 'nfelice, ohimè!</l>
           <l>Quant'è men reo 'l morire</l>
           <l>Di questo mio martire!</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Tullia, reggi te stessa,</l>
           <l>Et ascolta costui.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Troppo s'è udito, o donne:</l>
           <l>Che ascoltar più si deve,</l>
@@ -2160,7 +2197,7 @@
           <l>Già le costui parole</l>
           <l>Nol torneranno in vita.</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Donna, io promisi al suo partir di vita</l>
           <l>A Lucio vostro di portarvi questo</l>
@@ -2179,7 +2216,7 @@
           <l>Feci al vostro marito, eccovi il vaso,</l>
           <l>Ch'esser molle da voi di pianto deve.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Deh, lassatemi sola,</l>
           <l>Donne pietose. E voi,</l>
@@ -2192,7 +2229,7 @@
           <l>Aggia l'anima ancora</l>
           <l>Che queste membra regge.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Andiam tutte in disparte,</l>
           <l>Ma non sì che si perda</l>
@@ -2202,7 +2239,7 @@
           <l>Ch'ad altra è stato il duolo</l>
           <l>Cagion di morte rea.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <lg>
             <l> O ricetto infelice</l>
@@ -2313,66 +2350,66 @@
       </div>
       <div>
         <head>ATTO V</head>
-        <sp>
+        <sp who="#semicoro">
           <speaker>Semicoro</speaker>
           <l>Io vedo Tullia, io vedo</l>
           <l>Da tanta doglia oppressa</l>
           <l>Ch'ella non può temprar gli orditi pianti.</l>
         </sp>
-        <sp>
+        <sp who="#semicoro">
           <speaker>Semicoro</speaker>
           <l>Andiam tosto, ch'io credo</l>
           <l>Ch'a l'uccider se stessa</l>
           <l>Vicina sia, s'io scorgo i suoi sembianti.</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Donne, correte avanti,</l>
           <l>Ch'a voi più si conviene</l>
           <l>Ch'a noi porgerle aita.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Folle chi resta in vita,</l>
           <l>Morto il dolce sperar che 'n pace il tiene.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Che fai, Tullia, che fai?</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Cerco fine a' miei guai.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Non è fine di doglia,</l>
           <l>Ma radice di pena</l>
           <l>Il finir gli anni suoi per fero sdegno.</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Lasso, tanto m'addoglia</l>
           <l>Veder costei, ch'appena</l>
           <l>Il pianto e 'l nome mio celato tegno.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Io vegno, Lucio, io vegno.</l>
           <l>Deh, lassatemi gire</l>
           <l>Là 've chiamar mi sento.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Ben è grave il tormento</l>
           <l>Che sa far l'uomo vago di morire.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Poco mi sete amiche</l>
           <l>A nodrir mie fatiche.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Affrena il gran furor che ti trasporta,</l>
           <l>Et ascolta il mio dir: se i tuoi nemici</l>
@@ -2403,7 +2440,7 @@
           <l>Di quel ch'ei forse avrà veduto pria,</l>
           <l>E star potrà in santa pace eterna.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Poi che l'empio martire</l>
           <l>Dee far di me sì dolorosa preda,</l>
@@ -2422,7 +2459,7 @@
           <l>Ch'io non son di me stessa,</l>
           <l>Ch'ei finirà i martir, ch'io tegno in vita.</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>S'ei si puote alleggiar, donna, il dolore</l>
           <l>Che senza fallo esser ti deve eterno,</l>
@@ -2636,7 +2673,7 @@
           <l>Datemi il vaso, ch'io finisca l'opra</l>
           <l>Per ch'io son oggi in questa terra vostra.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Ohimè, lassa, ohimè!</l>
           <l>Anima folle, or come</l>
@@ -2659,75 +2696,75 @@
           <l>Che mormorando inviti</l>
           <l>A pianger chi verrà dopo mill'anni.</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Come soffr'io già mai</l>
           <l>L'udir sì rei lamenti?</l>
           <l>Donna, finite il pianto,</l>
           <l>Ch'alta pietà di voi l'alma m'ancide.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Vòi tu ch'io ponga fine</l>
           <l>Agli lamenti miei</l>
           <l>Al cominciar de' mali?</l>
           <l>Quest'è 'l vero principio de' miei danni.</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Esser potrebbe il fine.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Senza morte non puote.</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Io dico senza morte.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>E dopo morte ancor voglio dolermi.</l>
           <l>O Lucio, o Lucio, ohimè,</l>
           <l>Debb'io lassarti mai</l>
           <l>Senza mai più vederti?</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Ohimè lasso, ohimè!</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Tu hai di me pietate.</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Donna, tropp'empio petto</l>
           <l>Saria quel che pietate</l>
           <l>Non avesse di voi.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Tu solo sei de' miei martir pietoso.</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Fors'a me si conviene</l>
           <l>Più ch'ad altrui pietate.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Chi saresti già mai</l>
           <l>Ch'aver possi di me debita doglia?</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Io potrei oggi in gioia</l>
           <l>Tornare i pensier vostri,</l>
           <l>E darvi eterna pace,</l>
           <l>Et in voi porre oblio de' tempi a dietro.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>S'a questo cener caro</l>
           <l>Non ritorna il suo spirto,</l>
@@ -2738,62 +2775,62 @@
           <l>Altro da te non spero,</l>
           <l>Ch'un subito morir nel darti il vaso.</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>S'io vi dicessi come</l>
           <l>È vano il pianto vostro,</l>
           <l>E vi tornassi lieta,</l>
           <l>Voi m'areste più caro assai che 'l vaso.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Esser non può già vano</l>
           <l>Il mio sì giusto pianto:</l>
           <l>Da sì crude cagioni</l>
           <l>Tratt'è de l'alma fuor per gli occhi miei.</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Perché piangete, o donna?</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Perché perdut'ho quello,</l>
           <l>Che mi fu padre, e madre,</l>
           <l>E marito, e tesoro, e pace, e vita.</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Mal chiamate perduto,</l>
           <l>Quel che davanti avete.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>E questo è 'l mio martire,</l>
           <l>Ch'io l'ho davanti, e 'l chiamo, e non risponde.</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Drizzate in lui le luci,</l>
           <l>A lui parlate, et egli</l>
           <l>Vi renderà risposta.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Come può dar risposta un che non vive?</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Certo, madonna, ei vive,</l>
           <l>Se i vivi già non sono</l>
           <l>I morti, e i morti vivi.</l>
           <l>E con voi parla. </l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Tu se' Lucio, adunque?</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Poss'io senza sospetto</l>
           <l>Di queste donne aprirti</l>
@@ -2801,36 +2838,36 @@
           <l>Tullia, Lucio son io,</l>
           <l>Che vegno a darti pace.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Io non spero dal Cielo</l>
           <l>Sì fatta grazia, e te non raffiguro.</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Vedi se questo anello</l>
           <l>È quel ch'a mia partita</l>
           <l>Di questo dito trassi.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>O Lucio, o Lucio mio, chi mi ti rende?</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Affrena il tuo gioire,</l>
           <l>Ch'altro vuol questo giorno.</l>
           <l>Ben verrà tosto il tempo</l>
           <l>Che ne farà il gioir dolce e securo.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>O Lucio, o Lucio mio,</l>
           <l>Chi può tenermi a freno?</l>
           <l>O donne, o donne amiche,</l>
           <l>Ecco il non isperato Lucio nostro!</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Fa' che 'l troppo gioir non ne dia pena.</l>
           <l>Torninti a mente gli passati mali,</l>
@@ -2838,14 +2875,14 @@
           <l>In loco omai, dove bisogna un'opra</l>
           <l>Subita et alta, e non parole vane.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Io sento venir fuore</l>
           <l>Servio parlando: o voi,</l>
           <l>Fate ch'ei non vi veda</l>
           <l>Alteri e lieti insieme.</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Addoppia i tuoi lamenti,</l>
           <l>Et a me rendi il vaso.</l>
@@ -2859,7 +2896,7 @@
           <l>Ch'alteramente parla</l>
           <l>Al mio caro fratel, colmo di gioia.</l>
         </sp>
-        <sp>
+        <sp who="#servio">
           <speaker>Servio</speaker>
           <l>Or potranno sperar gli amici miei,</l>
           <l>E gli nemici che saranno saggi</l>
@@ -2869,31 +2906,31 @@
           <l>Chi fia quest'altro greco, che qua viene</l>
           <l>E porta un picciol vaso in la man destra?</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Se tu se' 'l Re di questa gran cittade,</l>
           <l>Come il sembiante tuo mi mostra, Dio</l>
           <l>Glorioso ti facci in ogni impresa.</l>
         </sp>
-        <sp>
+        <sp who="#servio">
           <speaker>Servio</speaker>
           <l>Ben sai ch'io sono il Re. Che vuoi tu dirmi?</l>
           <l>Perché ti vedo in questa terra mia?</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Per fare un'opra pia venuto sono,</l>
           <l>Che piacer ti dovrebbe, perché a Dio</l>
           <l>Piace l'alta pietà sovr'ogn'altra opra,</l>
           <l>E i buon regi han da Dio la forza e 'l senno.</l>
         </sp>
-        <sp>
+        <sp who="#servio">
           <speaker>Servio</speaker>
           <l>Io mantegno pietà dov'esser debbe,</l>
           <l>Ché non è sempre ben l'esser pietoso.</l>
           <l>Ma dimmi brieve omai quel che dir dèi.</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>In questo vaso, o sommo Re, s'accoglie</l>
           <l>Il cener freddo del tuo gran nemico</l>
@@ -2902,122 +2939,122 @@
           <l>A chiederti per lui la sepoltura</l>
           <l>U' post'è l'uno e l'altro suo parente.</l>
         </sp>
-        <sp>
+        <sp who="#servio">
           <speaker>Servio</speaker>
           <l>Taci, più non parlar, uom troppo audace.</l>
           <l>Più non voglio ascoltar le tue parole.</l>
           <l>Sì ch'io deggio far grazia a l'empio e reo</l>
           <l>Ch'a me morte chiedea, più ch'a sé vita?</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Più non è tuo nemico, s'ei non vive.</l>
         </sp>
-        <sp>
+        <sp who="#servio">
           <speaker>Servio</speaker>
           <l>Il spirto è vivo, che mi fu nemico.</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Io non chieggio mercede al spirto sciolto.</l>
           <l>Solo il riposo a questo cener chiedo.</l>
         </sp>
-        <sp>
+        <sp who="#servio">
           <speaker>Servio</speaker>
           <l>Taci. Io non vo' dar gioia a' miei nemici.</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Il trionfar de' suoi nemici vivi</l>
           <l>È bello e caro, il perseguirli morti</l>
           <l>A l'alme altere come brutto spiace.</l>
         </sp>
-        <sp>
+        <sp who="#servio">
           <speaker>Servio</speaker>
           <l>Per te vuoi morte, se per lui mercede.</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Se tu hai tolto a lui la patria e 'l regno,</l>
           <l>Ben donar gli potresti sepoltura.</l>
         </sp>
-        <sp>
+        <sp who="#servio">
           <speaker>Servio</speaker>
           <l part="I">O superbo, o ritroso!</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l part="F">O reo tiranno!</l>
         </sp>
-        <sp>
+        <sp who="#servio">
           <speaker>Servio</speaker>
           <l>Offender mi vuoi tu nel regno mio?</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>I' ho di te più parte in questo regno.</l>
           <l>Prima che 'l sol col dì da noi si parta,</l>
           <l>Avrai negli occhi oscura notte eterna.</l>
         </sp>
-        <sp>
+        <sp who="#servio">
           <speaker>Servio</speaker>
           <l part="I">E tu contra mi sei?</l>
         </sp>
-        <sp>
+        <sp who="#demarato">
           <speaker>Demarato</speaker>
           <l part="F">Contra ti sono,</l>
           <l>E son fratel di Lucio: e Lucio è questo.</l>
         </sp>
-        <sp>
+        <sp who="#servio">
           <speaker>Servio</speaker>
           <l>Così son preda, ohimè, de' miei nimici?</l>
           <l>Così son giunto al fin de' giorni miei?</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Quest'è l'ultimo dì de la tua vita.</l>
           <l>Quest'è la fida spada di mio padre,</l>
           <l>Ch'oggi dee far di lui piena vendetta.</l>
         </sp>
-        <sp>
+        <sp who="#servio">
           <speaker>Servio</speaker>
           <l>Ohimè lasso, ohimè!</l>
           <l>Ohimè lasso, ohimè!</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Traetel dentro prestamente, et ivi,</l>
           <l>Senz'udir sue parole,</l>
           <l>Dateli sol la meritata morte.</l>
         </sp>
-        <sp>
+        <sp who="#servio">
           <speaker>Servio</speaker>
           <l>Ahi figlia, ahi figlia cruda!</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Va', va' perfido a morte,</l>
           <l>Non padre, empio nimico!</l>
         </sp>
-        <sp>
+        <sp who="#servio">
           <speaker>Servio</speaker>
           <l>O volgo, o volgo amico,</l>
           <l>Porgimi aiuto, porgi,</l>
           <l>Ch'io son per forza tratto</l>
           <l>A finire i miei giorni.</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Più non vedrai la luce.</l>
           <l>Or chiudete le porte</l>
           <l>Di quest'alto palagio.</l>
         </sp>
-        <sp>
+        <sp who="#servio">
           <speaker>Servio</speaker>
           <l>Ohimè lasso, ohimè!</l>
           <l>Ohi oh ohi oh oh!</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Or avrem noi salute,</l>
           <l>E per la via già semo</l>
@@ -3029,7 +3066,7 @@
           <l>Se lungo è stato il mio martir, pur ora</l>
           <l>Vedo 'l porto apparir de' danni miei.</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Getta sopra le soglie</l>
           <l>L'empie nimiche membra,</l>
@@ -3037,7 +3074,7 @@
           <l>Poi fa' che, senz'aver mai sepoltura,</l>
           <l>E di fere e d'augei diventin esca.</l>
         </sp>
-        <sp>
+        <sp who="#ombra">
           <speaker>Ombra</speaker>
           <l>A Dio, cara consorte, io vado altrove</l>
           <l>Spirito sciolto, e son da te diviso</l>
@@ -3056,7 +3093,7 @@
           <l>Io so che deggio andar molt'anni errando,</l>
           <l>E star più non vo' teco. A Dio, a Dio.</l>
         </sp>
-        <sp>
+        <sp who="#regina">
           <speaker>Regina</speaker>
           <l>Or se' tu 'l mio marito? O Servio, o Servio,</l>
           <l>Aspetta, o Servio mio, ch'io parli teco.</l>
@@ -3103,7 +3140,7 @@
           <l>Fate tenaci nodi</l>
           <l>Coi venenosi crin a l'alma insana!</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Ecco qua cieca e furiosa quella</l>
           <l>Che beata pur or colma di gioia</l>
@@ -3113,7 +3150,7 @@
           <l>Or sapem noi per pruova quanto è vero</l>
           <l>Quel che ne mostra in sogno anima pura.</l>
         </sp>
-        <sp>
+        <sp who="#regina">
           <speaker>Regina</speaker>
           <l>Ove son, donne, i dispietati e rei</l>
           <l>Ch'hanno il marito mio di vita casso?</l>
@@ -3137,23 +3174,23 @@
           <l>Mostrivi il sommo Giove</l>
           <l>Quanto la morte d'un buon Re gli spiace.</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Questo piacer gli dia,</l>
           <l>Se la pena de' rei gli porta gioia.</l>
         </sp>
-        <sp>
+        <sp who="#regina">
           <speaker>Regina</speaker>
           <l>E tu, perfida figlia,</l>
           <l>Come già mai soffristi</l>
           <l>Sì dispietata morte al padre tuo?</l>
         </sp>
-        <sp>
+        <sp who="#tullia">
           <speaker>Tullia</speaker>
           <l>Come tu quelle indegna</l>
           <l>De' tuoi giusti parenti.</l>
         </sp>
-        <sp>
+        <sp who="#regina">
           <speaker>Regina</speaker>
           <l>O peste iniqua e grave!</l>
           <l>Togliati al mondo Giove,</l>
@@ -3163,77 +3200,77 @@
           <l>Ch'han potuto soffrire</l>
           <l>Di vedere squarciar lor padre vivo.</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Non prenderete voi tosto costei?</l>
           <l>Non la merrete in parte</l>
           <l>Ov'ella elegga o foco, o ferro, o laccio,</l>
           <l>Che la traggia di vita?</l>
         </sp>
-        <sp>
+        <sp who="#regina">
           <speaker>Regina</speaker>
           <l>Sia corto ogni tuo bene,</l>
           <l>Pien di sospetto e d'ira.</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Chiudetele la bocca.</l>
         </sp>
-        <sp>
+        <sp who="#regina">
           <speaker>Regina</speaker>
           <l>Odiar ti possa il Cielo.</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Toglietemi d'avanti</l>
           <l>Sì furioso mostro.</l>
         </sp>
-        <sp>
+        <sp who="#regina">
           <speaker>Regina</speaker>
           <l>Oh oh oh oh oh!</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Poi che costei saput'ha la novella</l>
           <l>Del suo morto marito, per la terra</l>
           <l>Avrà fama portati i fatti nostri.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Io vedo, ohimè, correndo a noi venire</l>
           <l>Un uom pauroso e travagliato in vista.</l>
         </sp>
-        <sp>
+        <sp who="#nunzio">
           <speaker>Nunzio</speaker>
           <l part="I">Ov', ov'è Lucio?</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l part="F">È qua dentro.</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Che vuoi?</l>
         </sp>
-        <sp>
+        <sp who="#nunzio">
           <speaker>Nunzio</speaker>
           <l>Io son venuto a te correndo, ch'io</l>
           <l>Vist'ho la plebe a la tua morte intenta.</l>
           <l>Prendi partito in un momento, prendi!</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Se gli nimici miei s'arman, che fanno</l>
           <l>I miei fedeli amici, ond'io sperava</l>
           <l>Alta difesa a le fortune mie?</l>
         </sp>
-        <sp>
+        <sp who="#nunzio">
           <speaker>Nunzio</speaker>
           <l>O la paura gli tiene a freno,</l>
           <l>Od ei non han questa novella udita:</l>
           <l>Nessun si vede in tuo favore ancora.</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>O valorosi miei compagni fidi,</l>
           <l>Non dubitate, che dal Ciel s'attende</l>
@@ -3293,36 +3330,36 @@
           <l>Facci lui vincitor di genti strane,</l>
           <l>Et aggiunga al suo 'mpero e l'Indo e 'l Mauro.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l>Ohimè, ch'io vedo comparir le genti</l>
           <l>Con foco et armi, e con feroci gridi.</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l>Tempra l'alto furor, dandone segno,</l>
           <l>Alto Signor, de la tua salda voglia,</l>
           <l>S'una vera umiltà merta mercede.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l part="I">Or vedi, or odi!</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l part="M">L'alto beato segno</l>
           <l>N'ha dato il Cielo.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l part="F">O che soave luce</l>
           <l>Ved'io scender tra noi da l'alto Cielo.</l>
         </sp>
-        <sp>
+        <sp who="#lucio">
           <speaker>Lucio</speaker>
           <l part="I">Quest'è messo di Dio.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l part="F">Perfido è bene</l>
           <l>Chi non crede che 'n Cielo il fonte sia</l>
@@ -3332,7 +3369,7 @@
           <l>E la plebe smarrita, e quasi morta,</l>
           <l>S'arresta e mira, e con timor s'acqueta.</l>
         </sp>
-        <sp>
+        <sp who="#romolo">
           <speaker>Romolo</speaker>
           <l>Dall'alte case de' celesti Dei</l>
           <l>Vedut'avemo il tuo sfrenato ardire,</l>
@@ -3348,7 +3385,7 @@
           <l>Lassate Lucio omai nel regno in pace,</l>
           <l>Fin che ne 'l traggia destinato giorno.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>Coro</speaker>
           <l> Troppo saria colui saggio e felice</l>
           <l>Ch'antivedesse de' suoi giorni il fine.</l>

--- a/tei/metastasio-achille-in-sciro.xml
+++ b/tei/metastasio-achille-in-sciro.xml
@@ -75,6 +75,52 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <personGrp xml:id="baccanti">
+            <name>Coro di baccanti</name>
+          </personGrp>
+          <personGrp xml:id="cantori">
+            <name>Coro di cantori</name>
+          </personGrp>
+          <person xml:id="deidamia">
+            <persName>Deidamia</persName>
+          </person>
+          <person xml:id="achille">
+            <persName>Achille</persName>
+          </person>
+          <person xml:id="nearco">
+            <persName>Nearco</persName>
+          </person>
+          <person xml:id="ulisse">
+            <persName>Ulisse</persName>
+          </person>
+          <person xml:id="arcade">
+            <persName>Arcade</persName>
+          </person>
+          <person xml:id="licomede">
+            <persName>Licomede</persName>
+          </person>
+          <person xml:id="teagene">
+            <persName>Teagene</persName>
+          </person>
+          <personGrp xml:id="voci">
+            <name>Voci</name>
+          </personGrp>
+          <person xml:id="gloria">
+            <persName>La Gloria</persName>
+          </person>
+          <person xml:id="tempo">
+            <persName>Il Tempo</persName>
+          </person>
+          <person xml:id="amore">
+            <persName>Amore</persName>
+          </person>
+          <personGrp xml:id="coro">
+            <name>Coro</name>
+          </personGrp>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Pavia</name>Digitalizzazione</change>
@@ -232,21 +278,21 @@
             </lg>
           </sp>
           <stage>(Ad un improvviso suon di trombe, che odesi in lontano verso la marina, tace il coro, s'interrompe il ballo e s'arrestan tutti in attitudine di timore, riguardando verso il mare</stage>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="I">Udisti? <stage>(ad Achille</stage></l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="M">Udii.</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">Chi temerario ardisce</l>
             <l>Turbar col suon profano</l>
             <l>Dell'orgie venerate il rito arcano?</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l>Non m'ingannai: lo strepito sonoro</l>
             <l>Parte dal mar. Ma non saprei... Non veggo</l>
@@ -254,25 +300,25 @@
             <l>Eccone la cagion. Due navi, osserva,</l>
             <l part="I">Vengono a questo lido.</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="M">Aimè!</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">Che temi?</l>
             <l part="I">Son lungi ancor.</l>
           </sp>
           <stage>(Compariscono in lontananza due navi. Sentesi di nuovo il suono delle trombe suddette. Tutti partono fuggendo, toltone Achille e Deidamia</stage>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="M">Fuggiam!</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="M">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">Non sai</l>
             <l>Che d'infami pirati</l>
@@ -286,19 +332,19 @@
             <l>Chi sa che ancora in quelle</l>
             <l>Insidiose navi... Oh dèi! vien meco.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l>Di che temi, mia vita? Achille è teco.</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="I">Taci.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="M">E se teco è Achille...</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F"><stage>(guardandosi intorno)</stage> Ah! taci: alcuno</l>
             <l>Potrebbe udirti; e, se scoperto sei,</l>
@@ -309,7 +355,7 @@
             <l>(Solo in pensarlo io moro),</l>
             <l>Se mai scopre che in Pirra Achille adoro?</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="I">Perdona, è vero.</l>
           </sp>
@@ -317,7 +363,7 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>NEARCO e detti.</stage>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l part="F">(Ecco gli amanti). E deggio</l>
             <l>Sempre così tremar per voi? Vel dissi</l>
@@ -328,42 +374,42 @@
             <l>Ne parla ognuno. Andate al re. Son tutte</l>
             <l>L'altre già nella reggia.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l><stage>(intento ad altro, non l'ascolta)</stage> Il suon guerriero</l>
             <l>Che da que' legni uscì, d'armati e d'armi</l>
             <l part="I">Mostra che vengan gravi.</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F"><stage>(piano a Nearco)</stage> (Oh, come in volto</l>
             <l>Già tutto avvampa! Usar conviene ogni arte</l>
             <l part="I">Per trarlo altrove).</l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l part="M">E non partite?</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">Or ora,</l>
             <l>Principessa, verrò. Que' legni in porto</l>
             <l part="I">Bramo veder.</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F"><stage>(turbata)</stage> Come! ch'io parta e lasci</l>
             <l>Te in periglio sì grande? Ah! tu, lo vedo,</l>
             <l>Ne saresti capace, e dal tuo core</l>
             <l part="I">Misuri il mio. So già, crudele...</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">Andiamo!</l>
             <l>Non ti sdegnar. Con tuo sguardo irato</l>
             <l part="I">Mi fai morir.</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">No, non è vero, ingrato!</l>
             <lg>
@@ -384,45 +430,45 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>NEARCO e di nuovo ACHILLE</stage>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l>Di pacifiche ulive <stage>(guardando il porto</stage></l>
             <l>Han le prore adornate! Amiche navi</l>
             <l part="I">Queste dunque saran.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F"><stage>(tornando indietro)</stage> Nearco, osserva</l>
             <l>Come splende fra l'armi</l>
             <l part="I">Quel guerrier maestoso.</l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l part="F">Ah! va: non lice</l>
             <l>A te, che una donzella</l>
             <l>Comparisci alle spoglie, in questo loco</l>
             <l part="I">Scompagnata restar.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F"><stage>(con isdegno)</stage> Ma non ti crede</l>
             <l>Ognuno il padre mio? Qual meraviglia</l>
             <l>Che appresso al genitor resti una figlia?</l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l part="I">Si sdegnerà Deidamia.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="M">E' ver. <stage>(rimesso, parte, e poi si ferma</stage></l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l part="F">(Che pena</l>
             <l part="I">E' il nascondere Achille!)</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F"><stage>(considerando il guerriero che è sulla nave</stage> Oh! se ancor io</l>
             <l>Quell'elmo luminoso</l>
@@ -431,53 +477,53 @@
             <l>Di più vedermi in questa gonna imbelle;</l>
             <l part="I">E ormai...</l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l part="F">Che dici? Oh stelle! E non rammenti</l>
             <l part="I">Quanto giova al tuo amor?</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="M">Sì... Ma...</l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l part="F">Deh! parti.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l>Lasciami un sol momento</l>
             <l part="I">A vagheggiar quell'armi.</l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l part="F">(Aimè!) Sì, resta</l>
             <l>Pur quanto vuoi; ma Deidamia intanto</l>
             <l part="I">Sarà col tuo rival.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="M"><stage>(in atto feroce)</stage> Che?</l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l part="F">Giunto or ora</l>
             <l>E' di Calcide il prence; e Licomede</l>
             <l>Vuol che la man di sposo</l>
             <l part="I">Oggi porga alla figlia.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="M">Oh numi!</l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l part="F">E' vero</l>
             <l>Che è tuo quel cor; ma, se il rivale accorto</l>
             <l>Può lusingarla inosservata e sola,</l>
             <l>Chi sa, pensaci, Achille, ei te l'invola.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <lg>
               <l>Involarmi il mio tesoro!</l>
@@ -496,7 +542,7 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>NEARCO e poi ULISSE ed ARCADE delle navi.</stage>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l>Che difficile impresa,</l>
             <l>Tetide, m'imponesti! Ogni momento</l>
@@ -520,57 +566,57 @@
             <l>Senza dirmi chi sei. Questa è la legge:</l>
             <l>Il mio re la prescrisse.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l>Si ubbidisca alla legge: io sono Ulisse.</l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l>Ulisse! I detti audaci</l>
             <l>Scusa, eroe generoso. Al re men volo</l>
             <l>Con sì lieta novella. <stage>(vuol partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l><stage>(considerandolo attentamente)</stage> Odi. E tu sei</l>
             <l part="I">Servo di Licomede?</l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l part="M">Appunto.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Il nome?</l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l part="I">Nearco.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Ove nascesti?</l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l part="I">Nacqui in Corinto.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">E da' paterni lidi</l>
             <l part="I">Perché mai qui venisti?</l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l part="F">Io venni... Oh Dio!</l>
             <l>Signor, troppo m'arresti; e il re frattanto</l>
             <l>Non sa chi giunse in porto.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="I">Va dunque. </l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l part="F">(Ah! ch'io fingea s'è quasi accorto). <stage>(parte</stage></l>
           </sp>
@@ -578,16 +624,16 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>ULISSE ed ARCADE</stage>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l>Arcade, il Ciel seconda</l>
             <l part="I">La nostra impresa.</l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l part="M">Onde la speme?</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Udisti?</l>
             <l>Rimirasti colui? Sappi che il vidi</l>
@@ -601,17 +647,17 @@
             <l>Se alcuno è seco. Ogni leggiero indizio</l>
             <l part="I">Può servirne di scorta.</l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l part="M">Io vado.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Ascolta.</l>
             <l>Che d'Achille si cerchi,</l>
             <l>Pensa a non dar sospetto ancor lontano.</l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l>A un tuo seguace un tal ricordo è vano. <stage>(parte</stage></l>
           </sp>
@@ -641,17 +687,17 @@
           <head>SCENA SETTIMA</head>
           <stage>Appartamenti di Deidamia.</stage>
           <stage>LICOMEDE e DEIDAMIA</stage>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l>Ma, se ancor nol vedesti, onde lo sai</l>
             <l part="I">Che piacerti non può?</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">Già molto intesi</l>
             <l part="I">Parlar di Teagene.</l>
           </sp>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l part="F">E vuoi di lui</l>
             <l>Su la fé giudicar degli occhi altrui?</l>
@@ -659,32 +705,32 @@
             <l>Nel giardino real; colà fra poco</l>
             <l part="I">Col tuo sposo verrò.</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="M">Già sposo!</l>
           </sp>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l part="F">Ei venne</l>
             <l part="I">Su la mia fé: tutto è disposto. <stage>(partendo</stage></l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">Almeno...</l>
             <l part="I">Padre... Ah! senti.</l>
           </sp>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l part="F">M'attende</l>
             <l>Il greco ambasciador. Più non opporti:</l>
             <l part="I">Siegui il consiglio mio.</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">Dunque un comando</l>
             <l part="I">Non è questo, signor.</l>
           </sp>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l part="F">Sempre a una figlia</l>
             <l>Comanda il genitor, quando consiglia.</l>
@@ -704,12 +750,12 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>DEIDAMIA, indi ACHILLE</stage>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l>All'idol mio mancar di fede! Ah! prima</l>
             <l>Ch'altro sposo...</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l><stage>(con ironia sdegnosa)</stage> E' permesso</l>
             <l>A Deidamia l'ingresso? Io non vorrei</l>
@@ -717,11 +763,11 @@
             <l>Dov'è lo sposo? A tributarti affetti</l>
             <l part="I">Qui sperai ritrovarlo.</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">E già sapesti...</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l>Tutto, ma non da te: prova sublime</l>
             <l>Della bella tua fede. A me, crudele!</l>
@@ -729,7 +775,7 @@
             <l>Più di me stesso? a me, che, in queste spoglie</l>
             <l part="I">Avvilito per te... Barbara!...</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">Oh Dio!</l>
             <l>Non m'affligger, ben mio: di queste nozze</l>
@@ -737,11 +783,11 @@
             <l>Venne a proporle. Istupidii, m'intesi</l>
             <l part="I">Tutto il sangue gelar.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">Pur, che farai?</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l>Tutto, fuor che lasciarti. E prieghi e pianti</l>
             <l>A svolger Licomede</l>
@@ -752,22 +798,22 @@
             <l>Che sia l'ultimo Achille. Ah! mi vedrai</l>
             <l>Morir, cor mio, pria che tradirti mai.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l>Oh dolcissimi accenti! e qual mercede</l>
             <l part="I">Posso renderti, o cara?</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">Eccola: io chiedo,</l>
             <l>Se possibile è pur, che abbi più cura</l>
             <l part="I">Di non scoprirti.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">E questa gonna è poco?</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l>Che val, se la smentisce</l>
             <l>Ogni tuo sguardo, ogni tuo moto? I passi</l>
@@ -780,29 +826,29 @@
             <l>Escon dagli occhi tuoi lampi e faville:</l>
             <l>Pirra si perde e comparisce Achille.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l>Ma il cambiar di natura</l>
             <l part="I">E' impresa troppo dura.</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">E' dura impresa</l>
             <l>Anche l'opporsi a un genitor. Poss'io</l>
             <l>Dunque con questa scusa</l>
             <l part="I">Accettar Teagene.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">Ah! no, mia vita:</l>
             <l part="I">Farò quanto m'imponi.</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">Or lo prometti;</l>
             <l part="I">Ma poi...</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">No: questa volta</l>
             <l>T'ubbidirò. Terrò gli sdegni a freno,</l>
@@ -819,11 +865,11 @@
         <div type="scene">
           <head>SCENA NONA</head>
           <stage>ULISSE e detti.</stage>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l>Taci: v'è chi t'ascolta. </l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l><stage>(ad Ulisse, pieno di sdegno)</stage> E tu chi sei,</l>
             <l>Che temerario ardisci</l>
@@ -831,83 +877,83 @@
             <l>Che vuoi? Parla! rispondi!</l>
             <l part="I">O pentir ti farò...</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="M">Pirra!</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">(Che fiero</l>
             <l part="I">Sembiante è quello!)</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="M"><stage>(piano ad Achille)</stage> (E la promessa?)</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F"><stage>(ravvedendosi)</stage> (E' vero).</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l>Non son di Licomede</l>
             <l part="I">Queste le stanze?</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="M">No.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Straniero errai:</l>
             <l part="I">Perdona. <stage>(vuol partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">Odi. E che brami</l>
             <l part="I">Dal re?</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">La Grecia chiede</l>
             <l>Da lui navi e guerrieri, or che s'affretta</l>
             <l>D'unirsi armata alla comun vendetta.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="I">(Felice chi v'andrà!)</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">(Tutto nel volto</l>
             <l part="I">Già si cambiò).</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">S'apre al valore altrui</l>
             <l>Oggi una illustre via. Corrono a questa</l>
             <l part="I">Impresa anche i più vili.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">(E Achille resta!)</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l>(Periglioso discorso!) A Licomede, <stage>(ad Ulisse</stage></l>
             <l part="I">Stranier, quella è la via. <stage>(ad Achille)</stage> Sieguimi.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F"><stage>(tornando indietro)</stage> Amico,</l>
             <l>Dimmi: le greche navi</l>
             <l>Dove ad unirsi andranno?</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="I">Pirra... ma...</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">Già ti sieguo. (Oh amor tiranno!) <stage>(partono</stage></l>
           </sp>
@@ -915,7 +961,7 @@
         <div type="scene">
           <head>SCENA DECIMA</head>
           <stage>ULISSE e poi ARCADE</stage>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l>O il desio di trovarlo</l>
             <l>Per tutto mel dipinge, o Pirra è Achille.</l>
@@ -931,25 +977,25 @@
             <l>Tardi, fin che è maturo,</l>
             <l>Il gran colpo a scoppiar, ma sia sicuro.</l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l part="I">Ulisse!</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Arcade! e in queste</l>
             <l part="I">Stanze t'inoltri?</l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l part="F">Entrar ti vidi, e venni</l>
             <l part="I">Su l'orme tue.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Che raccogliesti intanto?</l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l>Poco, o signor. Sol che Nearco è giunto</l>
             <l>In questa terra, or compie l'anno; ha seco</l>
@@ -957,32 +1003,32 @@
             <l>La real principessa</l>
             <l part="I">Straordinario amor.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Come si appella?</l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l part="I">Pirra.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="M">Pirra!</l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l part="F">E per lei Nearco ha loco</l>
             <l part="I">Fra' reali ministri.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">E questo è poco?</l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l part="I">Ma ciò che giova?</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Ah! mio fedel, facciamo</l>
             <l>Gran viaggio a momenti. Odi, e dirai...</l>
@@ -991,20 +1037,20 @@
         <div type="scene">
           <head>SCENA UNDICESIMA</head>
           <stage>NEARCO e detti.</stage>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l>Signor, vieni: che fai?</l>
             <l part="I">T'attende il re.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="M">Qual è il cammino?</l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l part="F">E' questo.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l>Ti sieguo: andiam. Non posso dirti il resto. <stage>(ad Arcade; indi parte con Nearco</stage></l>
           </sp>
@@ -1041,58 +1087,58 @@
           <head>SCENA TREDICESIMA</head>
           <stage>Deliziosa nella regia di Licomede.</stage>
           <stage>ACHILLE e DEIDAMIA, poi LICOMEDE e TEAGENE</stage>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l>No, Achille, io non mi fido</l>
             <l>Di tue promesse. A Teagene in faccia</l>
             <l>Non saprai contenerti: il tuo calore</l>
             <l part="I">Ti scoprirà. Parti, se m'ami.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">Almeno</l>
             <l>Qui tacito in disparte</l>
             <l part="I">Lascia ch'io vegga il mio rival.</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">Oh Dio!</l>
             <l part="I">T'esponi a gran periglio. Eccolo.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F"><stage>(turbandosi)</stage> Ah! questo</l>
             <l part="I">Dunque è l'audace? E ho da soffrir?...</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">Nol dissi?</l>
             <l part="I">Già ti trasporti.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">Un impeto primiero</l>
             <l>Fu questo: è già sedato. Or son sicuro.</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="I">Tu parlerai.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">Non parlerò, tel giuro. <stage>(si ritira in disparte</stage></l>
           </sp>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l>Amata figlia, ecco il tuo sposo; ed ecco,</l>
             <l>Illustre Teagene,</l>
             <l part="I">La sposa tua.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">(Qui tollerar conviene).</l>
           </sp>
-          <sp>
+          <sp who="#teagene">
             <speaker>TEAG.</speaker>
             <l>Chi ascolta, o principessa,</l>
             <l>Ciò che de' pregi tuoi la fama dice,</l>
@@ -1100,62 +1146,62 @@
             <l>La ritrova maligna. Io, che già sono</l>
             <l>Tuo prigionier, t'offro quest'alma in dono.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="I">(Che temerario!) <stage>(considerando sdegnosamente Teagene s'avanza senza avvedersene</stage></l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">A così alto segno</l>
             <l>Non giunge il merto mio: tanto esaltarlo</l>
             <l part="I">Non déi... Pirra! che vuoi? Parti. <stage>(avvedendosi che Achille è già vicino a Teagene</stage></l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">Non parlo. <stage>(si ritira in disparte, come sopra</stage></l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l>(Dèi! qual timor m'assale?)</l>
           </sp>
-          <sp>
+          <sp who="#teagene">
             <speaker>TEAG.</speaker>
             <l part="I">Chi è mai questa donzella?</l>
           </sp>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l part="F">E' il tuo rivale.</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="I">(Son morta!)</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="M">(Ah, mi conosce!)</l>
           </sp>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l part="F">E' Pirra il solo</l>
             <l>Amor di Deidamia. Altre non vide</l>
             <l>Più tenere compagne il mondo intero.</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l>(Ei parlava da scherzo, e disse il vero).</l>
           </sp>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l>Deidamia, or che ti sembra</l>
             <l part="I">Di sì degno consorte?</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">I pregi, o padre,</l>
             <l>Ne ammiro, ne comprendo;</l>
             <l part="I">Ma...</l>
           </sp>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l part="F">Tu arrossisci! il tuo rossore intendo.</l>
             <lg>
@@ -1175,17 +1221,17 @@
         <div type="scene">
           <head>SCENA QUATTORDICESIMA</head>
           <stage>ACHILLE, DEIDAMIA e TEAGENE</stage>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="I">(Ah, se altre spoglie avessi!)</l>
           </sp>
-          <sp>
+          <sp who="#teagene">
             <speaker>TEAG.</speaker>
             <l part="F">Or che siam soli,</l>
             <l>Principessa gentil, soffri ch'io spieghi</l>
             <l>L'ardor di questo sen; soffri ch'io dica...</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l>Non parlarmi d'amor: ne son nemica.</l>
             <lg>
@@ -1206,77 +1252,77 @@
             </lg>
           </sp>
           <stage>(parte con Achille, il quale si ferma nell'entrare</stage>
-          <sp>
+          <sp who="#teagene">
             <speaker>TEAG.</speaker>
             <l>Giusti numi, e in tal guisa</l>
             <l>Deidamia mi accoglie! In che son reo?</l>
             <l part="I">Che fu? Seguasi. <stage>(vuol seguire Deidamia</stage></l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F"><stage>(arrestandolo</stage> Ferma! ove t'affretti?</l>
           </sp>
-          <sp>
+          <sp who="#teagene">
             <speaker>TEAG.</speaker>
             <l>A Deidamia appresso:</l>
             <l part="I">Raggiungerla desio.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F"><stage>(risoluto)</stage> Non è permesso!</l>
           </sp>
-          <sp>
+          <sp who="#teagene">
             <speaker>TEAG.</speaker>
             <l part="I">Chi può vietarlo?</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="M">Io!</l>
           </sp>
-          <sp>
+          <sp who="#teagene">
             <speaker>TEAG.</speaker>
             <l part="M">Tu?</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">Sì: né giammai,</l>
             <l>Sappilo, io parlo in vano. <stage>(parte lentamente</stage></l>
           </sp>
-          <sp>
+          <sp who="#teagene">
             <speaker>TEAG.</speaker>
             <l>(Delle ninfe di Sciro il genio è strano.</l>
             <l>E pur quella fierezza</l>
             <l>Ha un non so che, che piace). Odi. Ma dimmi</l>
             <l>Almen perché.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="I"><stage>(partendo lentamente)</stage> Dissi abbastanza.</l>
           </sp>
-          <sp>
+          <sp who="#teagene">
             <speaker>TEAG.</speaker>
             <l part="F">E credi</l>
             <l>Che di te sola io tema?</l>
             <l part="I">Credi bastar tu sola?</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F"><stage>(con aria feroce)</stage> Io basto, e trema!</l>
           </sp>
-          <sp>
+          <sp who="#teagene">
             <speaker>TEAG.</speaker>
             <l>(Quell'ardir m'innamora).</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l>(Ah! mancator, non sei contento ancora?)</l>
           </sp>
           <stage>(Nell'atto che Achille si rivolge per partire, incontra su la scena Deidamia, che gli dice sdegnata il verso suddetto e lo lascia confuso</stage>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="I">(Misero! è ver, trascorsi).</l>
           </sp>
-          <sp>
+          <sp who="#teagene">
             <speaker>TEAG.</speaker>
             <l part="F">Ascolta: io voglio,</l>
             <l>Bella ninfa, ubbidirti; e per mercede</l>
@@ -1285,7 +1331,7 @@
             <l>Mi guardi! ti confondi!</l>
             <l>Qual cambiamento è il tuo? Parla! rispondi!</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <lg>
               <l>Risponderti vorrei;</l>
@@ -1330,7 +1376,7 @@
           <head>SCENA PRIMA</head>
           <stage>Logge terrene adornate di statue rappresentanti varie imprese d'Ercole.</stage>
           <stage>ULISSE ed ARCADE</stage>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l>Tutto, come imponesti,</l>
             <l>Signor, già preparai. Son pronti i doni</l>
@@ -1342,16 +1388,16 @@
             <l>Sì confuso comando:</l>
             <l>Tutto ciò che ti giova? e dove? e quando?</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l>Fra mille ninfe e mille</l>
             <l part="I">Per distinguere Achille.</l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l part="M">E come?</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Intorno</l>
             <l>A quell'elmo lucente, a quell'usbergo</l>
@@ -1361,11 +1407,11 @@
             <l>Quel fuoco, a forza oppresso,</l>
             <l>Scoppiar feroce e palesar se stesso.</l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l part="I">Di troppo ti lusinghi.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Io so d'Achille</l>
             <l>L'indole bellicosa; io so che all'armi</l>
@@ -1378,11 +1424,11 @@
             <l>Già di nuovo son chiare:</l>
             <l>Abbandona le piume e corre al mare.</l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l part="I">Hai pur tant'altri indizi.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Ogni altro indizio,</l>
             <l>Solo, è dubbioso: a questa prova unito,</l>
@@ -1390,13 +1436,13 @@
             <l>Arcade, più sicura,</l>
             <l>Dove co' moti suoi parla natura.</l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l>Ma se, come supponi,</l>
             <l>Ama Deidamia, anche palese, a lei</l>
             <l part="I">Toglierlo non potrem.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Con l'arti occulte</l>
             <l>Pria s'astringa a scoprirsi; indi, scoperta,</l>
@@ -1405,22 +1451,22 @@
             <l>Fiamme d'onor gli desterò nel seno:</l>
             <l part="I">Arrossir lo farò.</l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l part="F">Sì, ma non veggo</l>
             <l>Agio a parlargli. E' custodito in guisa...</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l>L'occasion si attenda; e, se non giunge,</l>
             <l part="I">Nascer si faccia. Io tenterò...</l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l part="F">T'accheta:</l>
             <l part="I">Vien Pirra a noi. Parlale adesso.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Eh! lascia</l>
             <l>Che venga per se stessa. Ad altro inteso</l>
@@ -1431,7 +1477,7 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>ACHILLE in disparte e detti.</stage>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">(Ecco il guerriero)</l>
             <l>Che la Grecia inviò. Se la mia bella</l>
@@ -1439,15 +1485,15 @@
             <l>Di ragionar con lui! Muoverla ad ira,</l>
             <l part="I">Ch'io l'osservi, non dee).</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="M"><stage>(piano ad Arcade)</stage> (Che fa?)</l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l part="F"><stage>(piano ad Ulisse)</stage> (Ti mira).</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l>Di questo albergo in vero</l>
             <l>Ogni arredo è real. Gli sculti marmi <stage>(guardando le statue</stage></l>
@@ -1457,11 +1503,11 @@
             <l>Gli ha l'industre maestro in fronte accolta.</l>
             <l>(Guarda se m'ode). <stage>(piano ad Arcade</stage></l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l><stage>(piano ad Ulisse)</stage> (Attentamente ascolta).</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l>Ecco quando dal suolo</l>
             <l>Solleva Anteo per atterrarlo; e l'arte</l>
@@ -1472,19 +1518,19 @@
             <l>Oh magnanimo eroe! Vivrà il tuo nome</l>
             <l>Mille secoli e mille.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l>(Oh dèi, così non si dirà d'Achille!)</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="I">(Ed or?) <stage>(piano ad Arcade</stage></l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l part="M">(S'agita e parla). <stage>(piano ad Ulisse</stage></l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">(Osserva adesso).</l>
             <l>Che miro! Ecco l'istesso <stage>(volgendosi ad altra parte</stage></l>
@@ -1495,28 +1541,28 @@
             <l>Avvilir lo scalpello:</l>
             <l>Qui Alcide da pietà; non è più quello.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l>(E' vero, è vero. Oh mia vergogna estrema!)</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="I">(Arcade, che ti par?)</l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l part="F">(Parmi che frema).</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l>(Dunque si assalga). <stage>(s'incammina verso Achille</stage></l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l><stage>(trattenendo Ulisse)</stage> (Il re. Guarda che tutto</l>
             <l>Il disegno non scopra).</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l>(Ah! m'interrompe in sul finir dell'opra).</l>
           </sp>
@@ -1524,19 +1570,19 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>LICOMEDE e detti.</stage>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l>Pirra, appunto ti bramo. Attendi, Ulisse.</l>
             <l>Vedi che il sol di già tramonta: onori</l>
             <l>Un ospite sì grande</l>
             <l part="I">Le mense mie.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Mi sarà legge il cenno.</l>
             <l part="I">Invittissimo re. <stage>(in atto di ritirarsi, si ferma per ascoltar quanto gli dice Licomede</stage></l>
           </sp>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l part="F">Le navi e l'armi,</l>
             <l>Che a chieder mi venisti, al nuovo giorno</l>
@@ -1544,7 +1590,7 @@
             <l>Superai la richiesta, ed a qual segno</l>
             <l>Gli amici onoro e un messaggier sì degno.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l>Sempre eguale a se stesso</l>
             <l>E' del gran Licomede</l>
@@ -1574,46 +1620,46 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>LICOMEDE, ACHILLE e poi NEARCO</stage>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l>Vezzosa Pirra, il crederai? dipende</l>
             <l part="I">Da te la pace mia.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="M">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l part="F">Se vuoi</l>
             <l>Impiegarti a mio pro, rendi felice</l>
             <l part="I">Un grato re.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="M">Che far poss'io?</l>
           </sp>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l part="F">M'avveggo</l>
             <l>Che a Deidamia spiace</l>
             <l>Unirsi a Teagene.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="I"><stage>(comincia a turbarsi)</stage> E ben?</l>
           </sp>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l part="F">Tu puoi</l>
             <l part="I">Tutto sul cor di lei.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">Come! e vorresti</l>
             <l part="I">Da me...</l>
           </sp>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l part="F">Sì, che la scelta</l>
             <l>Tu le insegnassi a rispettar d'un padre;</l>
@@ -1622,49 +1668,49 @@
             <l>Le inspirassi nel seno, onde l'accolga</l>
             <l>Com'è il dover d'un'amorosa moglie.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l>(Questo pur deggio a voi, misere spoglie!) <stage>(con ira</stage></l>
           </sp>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l part="I">Che dici?</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">E tu mi credi <stage>(reprimendosi a forza</stage></l>
             <l>Opportuno istromento... Ah! Licomede,</l>
             <l>Mal mi conosci. Io!... Numi eterni, io!... Cerca</l>
             <l part="I">Mezzo miglior.</l>
           </sp>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l part="F">Che ti sgomenta? E' forse</l>
             <l>Teagene uno sposo</l>
             <l part="I">Che non meriti amor?</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">(Mi perdo. Io sento</l>
             <l part="I">Che soffrir più non posso).</l>
           </sp>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l part="F">Al fin la figlia,</l>
             <l>Dimmi, a qual altro mai</l>
             <l part="I">Meglio unir si potea?</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">(Soffersi assai).</l>
             <l part="I">Signor... <stage>(risoluto</stage></l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l part="F">Le regie mense,</l>
             <l part="I">Licomede, son pronte.</l>
           </sp>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l part="F">Andiamo. Udisti,</l>
             <l>Pirra, i miei sensi: a te mi fido. Ah! sia</l>
@@ -1686,17 +1732,17 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>ACHILLE e poi NEARCO</stage>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l>Non parlarmi, Nearco,</l>
             <l>Più di riguardi: ho stabilito. Adesso</l>
             <l part="I">Non sperar di sedurmi. Andiamo.</l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l part="F">E dove?</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l>A depor queste vesti. E che! degg'io</l>
             <l>Passar così vilmente</l>
@@ -1707,11 +1753,11 @@
             <l>I falli miei rimproverar mi sento.</l>
             <l>Son stanco d'arrossirmi ogni momento.</l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l part="I">Un rossor ti figuri...</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">Ah! taci: assai</l>
             <l>Ho tollerato i tuoi</l>
@@ -1728,18 +1774,18 @@
             <l>Tu non serbi altro segno</l>
             <l>Che la cetra avvilita ad uso indegno.</l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l>Basta, signor: più non m'oppongo. Al fine</l>
             <l part="I">Son persuaso anch'io.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">Ti par, Nearco,</l>
             <l>Quest'ozio vergognoso</l>
             <l part="I">Degno di me?</l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l part="F">No: lo conosco; è tempo</l>
             <l>Che dal sonno ti desti,</l>
@@ -1752,13 +1798,13 @@
             <l>N'abbia a morir, non t'arrestar per lei:</l>
             <l>Vagliono la sua vita i tuoi trofei.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l>Morir! Dunque tu credi</l>
             <l>Che non abbia costanza</l>
             <l part="I">Di vedersi lasciar?</l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l part="F">Costanza! E come</l>
             <l>Potrebbe averne una donzella amante,</l>
@@ -1766,11 +1812,11 @@
             <l>Della sua tenerezza, il sol conforto,</l>
             <l part="I">L'unica speranza?</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="M">Oh dèi!</l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l part="F">Non sai</l>
             <l>Che, se ti scosti mai</l>
@@ -1780,16 +1826,16 @@
             <l>Come credi che stia? Già non ha pace,</l>
             <l part="I">Già dubbiosa e tremante...</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="M">Andiamo!</l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l part="F">E sei</l>
             <l>Pronto a partir?</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l>No: ritorniamo a lei.</l>
             <lg>
@@ -1854,58 +1900,58 @@
               <l>Che un istante si venga a turbar.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l>Fumin le tazze intorno</l>
             <l part="I">Di cretense liquor.</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">Pirra, lo sai:</l>
             <l>Se di tua man non viene,</l>
             <l>L'ambrosia degli dèi</l>
             <l>Vil bevanda parrebbe a' labbri miei.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l>Ubbidisco. Ah! da questa</l>
             <l>Ubbidienza mia</l>
             <l>Vedi se fido sia di Pirra il core.</l>
           </sp>
-          <sp>
+          <sp who="#teagene">
             <speaker>TEAG.</speaker>
             <l part="I">(Che strano affetto!) <stage>(guardando Deidamia ed Achille</stage></l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">(Oh tirannia d'amore!) <stage>(nell'andar a prender la tazza</stage></l>
           </sp>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l>Quando da' greci lidi i vostri legni</l>
             <l part="I">L'àncora scioglieranno? <stage>(ad Ulisse</stage></l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Al mio ritorno.</l>
           </sp>
-          <sp>
+          <sp who="#teagene">
             <speaker>TEAG.</speaker>
             <l part="I">Son già tutti raccolti?</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Altro non manca</l>
             <l part="I">Che il soccorso di Sciro.</l>
           </sp>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l part="F">Oh, qual mi toglie</l>
             <l>Spettacolo sublime</l>
             <l part="I">La mia canuta età!</l>
           </sp>
           <stage>(Un paggio porge la tazza ad Achille: egli, nel prenderla, resta attonito ad ascoltare il discorso artifizioso di Ulisse</stage>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">(Non si trascuri</l>
             <l>L'opportuno momento). E' di te degna,</l>
@@ -1919,15 +1965,15 @@
             <l>La gioventù proterva</l>
             <l>Corre all'armi fremendo. (Arcade, osserva).</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="I">Pirra! <stage>(si riscuote, prende la tazza, s'incammina, poi torna a fermarsi</stage></l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="M">E' ver.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Chi d'onore</l>
             <l>Sente stimoli in sen, chi sa che sia</l>
@@ -1937,24 +1983,24 @@
             <l>Necessità trattien, col Ciel s'adira,</l>
             <l>Come tutti gli dèi l'abbiano in ira.</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="I">Ma Pirra!</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="M">Eccomi. <stage>(va colla tazza a Deidamia</stage></l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F"><stage>(piano ad Achille, nel prendere la tazza</stage> (Ingrato!</l>
             <l>Questi di poco amor segni non sono?)</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l>(Non ti sdegnar, bell'idol mio: perdono!)</l>
           </sp>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l>Olà! rechisi a Pirra</l>
             <l>L'usata cetra. A lei, Deidamia, imponi</l>
@@ -1962,29 +2008,29 @@
             <l>La voce unisca e la maestra mano:</l>
             <l part="I">Tutto farò per te.</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">Pirra, se m'ami,</l>
             <l>Seconda il genitore.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l>Tu il vuoi? Si faccia. (Oh tirannia d'amore!)</l>
           </sp>
           <stage>(Un paggio gli presenta la cetra: altri pongono un sedile da un de' lati a vista della mensa</stage>
-          <sp>
+          <sp who="#teagene">
             <speaker>TEAG.</speaker>
             <l>(Tanto amor non comprendo).</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="I">(Arcade, adesso è tempo: intendi?) <stage>(piano ad Arcade</stage></l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l part="F"><stage>(piano ad Ulisse)</stage> (Intendo). <stage>(parte</stage></l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <lg>
               <l><stage>(canta accompagnandosi con la lira</stage> Se un core annodi,</l>
@@ -2008,7 +2054,7 @@
               <l>Tiranno Amor?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <lg>
               <l>Se in bianche piume</l>
@@ -2032,7 +2078,7 @@
               <l>Tiranno Amor?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <lg>
               <l>De' tuoi seguaci</l>
@@ -2057,11 +2103,11 @@
             </lg>
           </sp>
           <stage>(Al comparir dei doni portati da' seguaci di Ulisse s'interrompe il canto d'Achille</stage>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l part="I">Questi chi son?</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Son miei seguaci; e al piede</l>
             <l>Portan di Licomede</l>
@@ -2071,80 +2117,80 @@
             <l>Giusto è che siegua anch'io. Se troppo osai,</l>
             <l part="I">Il costume m'assolva.</l>
           </sp>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l part="F">Eccede i segni</l>
             <l part="I">Sì generosa cura.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">(Oh Ciel, che miro!) <stage>(avvedendosi d'un'armatura, che venne fra' doni</stage></l>
           </sp>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l>Mai non si tinse in Tiro</l>
             <l>Porpora più vivace. <stage>(ammirando le vesti</stage></l>
           </sp>
-          <sp>
+          <sp who="#teagene">
             <speaker>TEAG.</speaker>
             <l><stage>(ammirando i vasi)</stage> Altri fin ora</l>
             <l>Sculti vasi io non vidi</l>
             <l>Di magistero egual.</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l><stage>(ammirando le gemme)</stage> L'eoa marina</l>
             <l>Non ha lucide gemme al par di quelle.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l>Ah, chi vide fin ora armi più belle! <stage>(si leva, per andare a veder più da vicino le armi</stage></l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l>Pirra, che fai? Ritorna</l>
             <l>Agl'interrotti carmi.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="I">(Che tormento crudele!) <stage>(torna a sedere</stage></l>
           </sp>
-          <sp>
+          <sp who="#voci">
             <speaker>VOCI.</speaker>
             <l part="F"><stage>(di dentro)</stage> All'armi! all'armi!</l>
           </sp>
           <stage>(S'ode strepito d'armi. e di stromenti militari. Tutti si levano spaventati: solo Achille resta, sedendo in atto feroce</stage>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l part="I">Qual tumulto è mai questo?</l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l part="F"><stage>(esce simulando spavento)</stage> Ah! corri Ulisse,</l>
             <l>Corri l'impeto insano</l>
             <l part="I">De' tuoi seguaci a raffrenar.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F"><stage>(fingendo esser sorpreso)</stage> Che avvenne?</l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l>Non so per qual cagion fra lor s'accese</l>
             <l>E i custodi reali</l>
             <l>Feroce pugna. Ah! qui vedrai fra poco</l>
             <l part="I">Lampeggiar mille spade.</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">Aita, o numi!</l>
             <l>Dove corro a celarmi? <stage>(parte intimorita</stage></l>
           </sp>
-          <sp>
+          <sp who="#teagene">
             <speaker>TEAG.</speaker>
             <l part="I">Fermati, principessa. <stage>(parte seguendola</stage></l>
           </sp>
-          <sp>
+          <sp who="#voci">
             <speaker>VOCI.</speaker>
             <l part="F"><stage>(di dentro)</stage> All'armi! all'armi!</l>
           </sp>
@@ -2153,7 +2199,7 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>ACHILLE, ed ULISSE con ARCADE in disparte.</stage>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l>Ove son? che ascoltai? Mi sento in fronte</l>
             <l>Le chiome sollevar! Qual nebbia i lumi</l>
@@ -2161,11 +2207,11 @@
             <l>Onde sento avvamparmi?</l>
             <l>Ah! frenar non mi posso: all'armi! all'armi! <stage>(s'incammina furioso, e poi si ferma, avvedendosi d'avere in mano la cetra</stage></l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="I">(Guardalo). <stage>(piano ad Arcade</stage></l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">E questa cetra</l>
             <l>Dunque è l'arme d'Achille? Ah! no; la sorte</l>
@@ -2177,15 +2223,15 @@
             <l>A ravvisar me stesso. Ah, fossi a fronte</l>
             <l>A mille squadre e mille!</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l>E qual sarà, se non è questo, Achille? <stage>(palesandosi</stage></l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="I">Numi! Ulisse, che dici?</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Anima grande,</l>
             <l>Prole de' numi, invitto Achille, al fine</l>
@@ -2201,30 +2247,30 @@
             <l>Non aspetta che te. L'Asia nemica</l>
             <l part="I">Non trema che al tuo nome. Andiam!</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F"><stage>(risoluto)</stage> Sì, vengo.</l>
             <l part="I">Guidami dove vuoi... Ma... <stage>(si ferma</stage></l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Che t'arresta?</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="I">E Deidamia?</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">E Deidamia un giorno</l>
             <l>Ritornar ti vedrà cinto d'allori</l>
             <l part="I">E più degno d'amore.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="M">E intanto...</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">E intanto</l>
             <l>Che d'incendio di guerra</l>
@@ -2248,7 +2294,7 @@
             <l>Lo puoi veder. Guardati, Achille. <stage>(gli leva lo scudo</stage> Dimmi:</l>
             <l>Ti riconosci? <stage>(presentandogli lo scudo</stage></l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l><stage>(lacerando le vesti)</stage> Oh vergognosi, oh indegni</l>
             <l>Impacci del valor, come fin ora</l>
@@ -2256,7 +2302,7 @@
             <l>L'armi a vestir. Fra questi ceppi avvinto</l>
             <l part="I">Più non farmi penar.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Sieguimi. (Ho vinto). <stage>(s'incamminano</stage></l>
           </sp>
@@ -2264,35 +2310,35 @@
         <div type="scene">
           <head>SCENA NONA</head>
           <stage>NEARCO e detti.</stage>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l>Pirra, Pirra, ove corri?</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l><stage>(rivolgendosi con isdegno)</stage> Anima vile!</l>
             <l>Quel vergognoso nome</l>
             <l>Più non t'esca da' labbri: i miei rossori</l>
             <l>Non farmi rammentar. <stage>(partendo</stage></l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l>Senti: tu parti?</l>
             <l>E la tua principessa?</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l><stage>(rivolgendosi)</stage> A lei dirai...</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l>Achille, andiam.</l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l>Che posso dirle mai?</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <lg>
               <l>Dille che si consoli;</l>
@@ -2311,7 +2357,7 @@
         <div type="scene">
           <head>SCENA DECIMA</head>
           <stage>NEARCO, poi DEIDAMIA</stage>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l>Eterni dèi, qual fulmine improvviso</l>
             <l>Strugge ogni mia speranza! Ove m'ascondo,</l>
@@ -2319,37 +2365,37 @@
             <l>M'involerà? Tanti sudori, oh stelle!</l>
             <l part="I">Tant'are, tanta cura...</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">Ov'è, Nearco,</l>
             <l part="I">Il mio tesoro?</l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l part="F">Ah! principessa, Achille</l>
             <l part="I">Non è più tuo.</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="M">Che!</l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l part="M">T'abbandona.</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">I tuoi</l>
             <l>Vani sospetti io già conosco. Ognora</l>
             <l part="I">Così mi torni a dir.</l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l part="F">Volesse il Cielo</l>
             <l>Ch'or m'ingannassi. Ah! l'ha scoperto Ulisse,</l>
             <l part="I">L'ha sedotto, il rapisce.</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">E tu, Nearco,</l>
             <l>Così partir lo lasci? Ah, corri! ah, vola!...</l>
@@ -2357,7 +2403,7 @@
             <l>Troppo il colpo è inumano!</l>
             <l part="I">Che fai? non parti?</l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l part="F">Io partirò, ma in vano. <stage>(parte</stage></l>
           </sp>
@@ -2365,7 +2411,7 @@
         <div type="scene">
           <head>SCENA UNDICESIMA</head>
           <stage>DEIDAMIA poi TEAGENE</stage>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l>Achille m'abbandona!</l>
             <l>Mi lascia Achille! E sarà vero? E come,</l>
@@ -2380,46 +2426,46 @@
             <l>Né pur questo mi giovi, almen sul lido</l>
             <l>Spirar mi vegga, e parta poi l'infido.</l>
           </sp>
-          <sp>
+          <sp who="#teagene">
             <speaker>TEAG.</speaker>
             <l>Amata principessa.</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l><stage>(con impazienza)</stage> (Oh me infelice!</l>
             <l part="I">Che inciampo è questo!)</l>
           </sp>
-          <sp>
+          <sp who="#teagene">
             <speaker>TEAG.</speaker>
             <l part="F">Io del tuo cor vorrei</l>
             <l part="I">Intender meglio...</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="M">Or non è tempo. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#teagene">
             <speaker>TEAG.</speaker>
             <l part="F"><stage>(seguendola)</stage> Ascolta.</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="I">Non posso.</l>
           </sp>
-          <sp>
+          <sp who="#teagene">
             <speaker>TEAG.</speaker>
             <l part="M">Un solo istante.</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="M"><stage>(impaziente)</stage> Oh numi!</l>
           </sp>
-          <sp>
+          <sp who="#teagene">
             <speaker>TEAG.</speaker>
             <l part="F">Al fine</l>
             <l>Mia sposa al nuovo giorno...</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l>Ma, per piet, non mi venir d'intorno!</l>
             <lg>
@@ -2464,7 +2510,7 @@
           <head>SCENA PRIMA</head>
           <stage>Portici della reggia corrispondenti al mare. Navi poco lontane dalla riva.</stage>
           <stage>ULISSE, ed ACHILLE in abito militare.</stage>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l>Achille, or ti conosco. Oh, quanta parte</l>
             <l>Del maestoso tuo real sembiante</l>
@@ -2474,7 +2520,7 @@
             <l>Mentre s'annoda e scioglie,</l>
             <l>Che altera sia delle cambiate spoglie.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l>Sì, tua mercé, gran duce, io torno in vita,</l>
             <l>Respiro al fin; ma, qual da' lacci appena</l>
@@ -2483,16 +2529,16 @@
             <l>Del racchiuso soggiorno;</l>
             <l>Mi sento il suon delle catene inotrno.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="I">(Ed Arcade non vien!) <stage>(guardando intorno</stage></l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">Son queste, Ulisse,</l>
             <l part="I">Le navi tue?</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Sì; né superbo meno</l>
             <l>Andran del peso loro, che quella d'Argo</l>
@@ -2500,17 +2546,17 @@
             <l>Di tanti eroi lo stuolo</l>
             <l>E i tesori di Frisso Achille solo.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="I">Dunque, che più si tarda?</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Olà! nocchieri,</l>
             <l>Appressatevi a terra. (E pur non miro</l>
             <l part="I">Arcade ancora). <stage>(Guardando intorno</stage></l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">Ah, perché mai le sponde</l>
             <l>Del nemico Scamandro</l>
@@ -2523,7 +2569,7 @@
             <l>Co' novelli trofei,</l>
             <l>Che parlar non potrà de' falli miei.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l>Oh sensi! oh voci! oh pentimento! oh ardori</l>
             <l>Degni d'Achille! E si volea di tanto</l>
@@ -2545,7 +2591,7 @@
               <l>Piani, monti, foreste e città.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l>Ecco i legni alla sponda:</l>
             <l part="I">Ulisse, io ti precedo. <stage>(s'incammina al mare</stage></l>
@@ -2554,93 +2600,93 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>ARCADE frettoloso e detti.</stage>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Arcade, oh quanto</l>
             <l part="I">Tardi a venir!</l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l part="F">Partiam, signor, t'affretta;</l>
             <l part="I">Noi ci arrestiam.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="M">Che mai t'avvenne?</l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l part="F">Andiamo.</l>
             <l part="I">Tutto saprai.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Ma con un cenno almeno...</l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l>Oh numi! ebbra d'amor, cieca di sdegno,</l>
             <l>Deidamia ci siegue. Io non potei</l>
             <l part="I">Più trattenerla, e la prevenni. <stage>(piano ad Ulisse</stage></l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Ah! questo</l>
             <l part="I">Fiero assalto s'evìti.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">Or che si attende? <stage>(tornando impaziente dalla riva del mare</stage></l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="I">Eccomi.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">Sì turbato,</l>
             <l>Arcade? Che recasti?</l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l part="I">Nulla.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="M">Partiam.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F"><stage>(ad Arcade)</stage> Ma che vuol dir quel tanto</l>
             <l>Volgerti indietro e rimirar? Che temi?</l>
             <l part="I">Parla.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="M">(Oh stelle!)</l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l part="F">Signor... Temo... Potrebbe</l>
             <l>Il re saper la nostra</l>
             <l>Partenza inaspettata,</l>
             <l part="I">Ed a forza impedirla.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">A forza? Io sono</l>
             <l>Dunque suo prigionier; dunque pretende...</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l>No; ma è saggio consiglio</l>
             <l part="I">Fuggir gl'inciampi. <stage>(vuol prenderlo per mano</stage></l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="M"><stage>(scostandosi)</stage> A me fuggir!</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Tronchiamo</l>
             <l>Le inutili dimore. Al mare, al mare,</l>
@@ -2650,34 +2696,34 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>DEIDAMIA e detti.</stage>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l>Achille, ah! dove vai? Fermati, Achille!</l>
           </sp>
           <stage>(Achille si rivolge, vede Deidamia, e s'arrestano entrambi guardandosi attentamente senza parlare</stage>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l>(Or sì ch'io mi sgomento!) <stage>(avendo lasciato Achille</stage></l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l>(E la gloria e l'amore ecco a cimento).</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l>Barbaro! è dunque vero? <stage>(con passione, ma senza sdegno</stage></l>
             <l part="I">Dunque lasciar mi vuoi?</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F"><stage>(piano ad Achille)</stage> (Se a lei rispondi,</l>
             <l>Sei vinto).</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="I"><stage>(ad Ulisse)</stage> (Tacerò).</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">Questa, o crudele,</l>
             <l>Questa bella mercede</l>
@@ -2689,38 +2735,38 @@
             <l>Tutto pose in oblio;</l>
             <l>Parte, mi lascia, e senza dirmi addio.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="I">Ah!</l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l part="M">(Non resiste).</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">E qual cagion ti rese</l>
             <l>Mio nemico in un punto? Io che ti feci?</l>
             <l>Misera me! di qual delitto è pena</l>
             <l part="I">Quest'odio tuo?</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="M">No, principessa...</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Achille!</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="I">Due soli accenti. <stage>(ad Ulisse</stage></l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="M">(Aimè!)</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">No, principessa,</l>
             <l>Non son, qual tu mi chiami,</l>
@@ -2735,23 +2781,23 @@
             <l>Non mi fidai dell'altro. Io so che m'ami,</l>
             <l part="I">Cara, più di te stessa; io sento...</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Achille!</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="I">Eccomi!</l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l part="M">(E pur non viene).</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">Io sento in petto...</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l>Non più: troppo, lo veggo,</l>
             <l>Troppo trascorsi. Al grande amor perdona</l>
@@ -2768,89 +2814,89 @@
             <l>Tanto spazio a morir; temer degg'io</l>
             <l part="I">Ch'abbia a negarsi a me?</l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l part="F">(Se un giorno ottiene,</l>
             <l part="I">Tutto otterrà).</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">Pensi? non parli? e fisse</l>
             <l part="I">Tieni le luci al suol?</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">Che dici, Ulisse? <stage>(ad Ulisse, quasi con timore</stage></l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l>Che, signor di te stesso,</l>
             <l>Puoi partir, puoi restar; che a me non lice</l>
             <l>Premer più questo suolo;</l>
             <l>Che a venir ti risolva, o parto solo.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l>(Che angustia!)</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="I">E ben, rispondi.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">Io resterei,</l>
             <l part="I">Ma... udisti?</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="M">E ben, risolvi.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">Io verrei teco,</l>
             <l part="I">Ma... vedi? <stage>(accennandogli Deidamia</stage></l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">Eh! già comprendo:</l>
             <l>Già di partir scegliesti.</l>
             <l part="I">Va, ingrato! Addio! <stage>(mostrando partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="M"><stage>(seguendola)</stage> Ferma, Deidamia!</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Intendo:</l>
             <l>Hai la dimora eletta.</l>
             <l part="I">Resta, imbelle! io ti lascio. <stage>(mostrando partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">Ulisse, aspetta!</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="I">Che vuoi?</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="M">Che brami?</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">A compiacerti... <stage>(a Deidamia, poi da sé</stage> (Oh stelle!</l>
             <l>E' debolezza). <stage>(ad Ulisse)</stage> A seguitarti... (Oh numi!</l>
             <l>E' crudeltà). Sì, ma la gloria esige...</l>
             <l>No, l'amor mio non soffre... Oh gloria! oh amore!</l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l>(E' dubbio ancor chi vincerà quel core).</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l>E ben, giacché ti costa</l>
             <l>Sì picciola pietà pena sì grande,</l>
@@ -2866,31 +2912,31 @@
             <l>Arbitra di mia sorte,</l>
             <l>Se vita mi niegò, mi dia la morte. <stage>(piange</stage></l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l part="I">(Io cederei).</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="M">L'ultimo dono...</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">Ah! taci;</l>
             <l>Ah! non pianger, mia vita. Ulisse, ormai</l>
             <l part="I">L'opporsi è tirannia.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="M">Lo veggo.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">Al fine</l>
             <l>Non chiede che un sol giorno. Un giorno solo</l>
             <l part="I">Ben puoi donarmi.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Oh! questo no. Men vado</l>
             <l>D'Achille a' duci argivi</l>
@@ -2901,11 +2947,11 @@
             <l>Già la tua spada; e di qual serie augusta</l>
             <l>Va per te di trofei la fama onusta.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="I">Ma valor non si perde...</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Eh! di valore</l>
             <l>Più non parlar. Spoglia quell'armi; a Pirra</l>
@@ -2913,53 +2959,53 @@
             <l>La gonna al nostro eroe. Riposi ormai,</l>
             <l>Ché sotto l'elmo ha già sudato assai.</l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l part="I">(Vuol destarlo, e lo punge).</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">Io Pirra! Oh dèi!</l>
             <l part="I">La gonna a me! <stage>(ad Ulisse</stage></l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">No? D'animo virile</l>
             <l>Desti gran prova in ver. Non sei capace</l>
             <l part="I">Di vincere un affetto.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">Ah! meglio impara</l>
             <l part="I">A conoscere Achille. Andiam! <stage>(risoluto</stage></l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">Mi lasci?</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="I">Sì!</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="M">Come!</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">All'onor mio</l>
             <l>E' funesto restar; Deidamia, addio.</l>
           </sp>
           <stage>(Achille parte risoluto ed ascende il ponte della nave, dove poi s'arresta. Ulisse ed Arcade il van seguendo: Deidamia rimane alcun tempo immobile</stage>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l part="I">(Sentì lo sprone).</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">(E pur non son sicuro).</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l>Ah, perfido! ah, spergiuro!</l>
             <l>Barbaro! traditor! Parti? E son questi</l>
@@ -2980,49 +3026,49 @@
             <l>S'ei non è più qual era, io son qual fui:</l>
             <l>Per lui vivea; voglio morir per lui. <stage>(sviene sopra un sasso</stage></l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="I">Lasciami! <stage>(ad Ulisse</stage></l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Dove corri?</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="I">A Deidamia in aiuto.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="M">Ah! dunque...</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">E speri</l>
             <l part="I">Ch'io l'abbandoni in questo stato?</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">E' questa</l>
             <l part="I">Di valore una prova.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F"><stage>(sdegnoso)</stage> Eh! tu pretendi</l>
             <l>Prove di crudeltà, non di valore.</l>
             <l part="I">Scostati, Ulisse! <stage>(si fa strada con impeto e corre a Deidamia</stage></l>
           </sp>
-          <sp>
+          <sp who="#arcade">
             <speaker>ARC.</speaker>
             <l part="F">(Ha trionfato Amore).</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l>Principessa! ben mio! sentimi! Oh numi!</l>
             <l>L'infelice non ode. Apri le luci,</l>
             <l part="I">Guardami: Achille è teco.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Arcade, il tempo</l>
             <l>Di sperar più vittoria ora non parmi.</l>
@@ -3032,49 +3078,49 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>ACHILLE, DEIDAMIA, poi NEARCO</stage>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="I">Aimè!</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">Lode agli dèi,</l>
             <l>Comincia a respirar. No, mia speranza,</l>
             <l part="I">Achille non partì.</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">Sei tu? m'inganno?</l>
             <l part="I">Che vuoi?</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="M">Pace, cor mio.</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">Potesti, ingrato,</l>
             <l part="I">Negarmi un giorno solo! Ed or...</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">Non fui</l>
             <l>Io che m'opposi; eccoti il reo... Ma... come!</l>
             <l part="I">Non veggo Ulisse! Ah! mi lasciò...</l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l part="F">Se cerchi</l>
             <l>D'Ulisse, ei corre al re: dal re ti vuole,</l>
             <l part="I">Or che scoperto sei.</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F"><stage>(s'alza da sedere)</stage> Questa sventura</l>
             <l>Sol mancava fra tante. Ecco palese</l>
             <l part="I">Al padre il nostro arcano.</l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l part="F">Infino ad ora</l>
             <l>Nascosto non gli fu. Già Teagene</l>
@@ -3082,13 +3128,13 @@
             <l>Ritrovò la cagione: al re sen corse,</l>
             <l part="I">Ed ancora è con lui.</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">Misera! oh dèi,</l>
             <l>Che fia di me! Se m'abbandoni, Achille,</l>
             <l part="I">A chi ricorrerò?</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">Ch'io t'abbandoni</l>
             <l>In periglio sì grande! Ah! no: sarebbe</l>
@@ -3114,17 +3160,17 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>DEIDAMIA e NEARCO</stage>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="I">Nearco, io tremo: ah! mi consola.</l>
           </sp>
-          <sp>
+          <sp who="#nearco">
             <speaker>NEAR.</speaker>
             <l part="F">E come</l>
             <l>Consolarti poss'io, se son più oppresso,</l>
             <l part="I">Più confuso di te?</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">Numi clementi,</l>
             <l>Se puri, se innocenti</l>
@@ -3178,12 +3224,12 @@
           <head>SCENA SETTIMA</head>
           <stage>Reggia.</stage>
           <stage>LICOMEDE, ACHILLE, TEAGENE, con numeroso corteggio.</stage>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l>Né di risposta ancora</l>
             <l part="I">Licomede mi degna?</l>
           </sp>
-          <sp>
+          <sp who="#teagene">
             <speaker>TEAG.</speaker>
             <l part="F">E' troppo ormai,</l>
             <l>Gran re, lungo il silenzio. I prieghi miei,</l>
@@ -3210,12 +3256,12 @@
             <l>Attenderne dovrai, se tutti eroi</l>
             <l>Furon gli avi d'Achille e gli avi tuoi!</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l>(Chi mai sperato avrebbe</l>
             <l part="I">In Teagene il mio sostegno!)</l>
           </sp>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l part="F">Achille,</l>
             <l>Sì grande questo nome</l>
@@ -3227,7 +3273,7 @@
             <l>Sì strani eventi; e, rispettoso, in loro</l>
             <l>Del consiglio immortal gli ordini adoro.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l>Ah, Licomede!... Ah, Teagene!... Andate</l>
             <l>La mia sposa, il mio bene,</l>
@@ -3236,7 +3282,7 @@
             <l>Come a sì caro dono</l>
             <l part="I">Grato potrò mostrarmi?</l>
           </sp>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l part="F">A Licomede</l>
             <l>L'esser padre a tal figlio è gran mercede.</l>
@@ -3257,36 +3303,36 @@
         <div type="scene">
           <head>SCENA ULTIMA</head>
           <stage>ULISSE, poi DEIDAMIA, e detti; indi tutti.</stage>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l>Ah! vieni, Ulisse. I miei felici eventi</l>
             <l part="I">Sapesti forse?</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l part="F">Assai diversa cura</l>
             <l>Qui mi cconduce. Eccelso re, conviene</l>
             <l>Che, deposto ogni velo, al fin t'esponga</l>
             <l part="I">Della Grecia il voler. Sappi...</l>
           </sp>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l part="F">Già tutto</l>
             <l>Mi è noto: a parte a parte alle richieste</l>
             <l>Risponderò.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l><stage>(incontrandola)</stage> Mia cara sposa, al fine</l>
             <l>Giungesti pur. Non tel diss'io? La sorte</l>
             <l part="I">Non cambiò di sembianza?</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F"><stage>(inginocchiandosi)</stage> A' piedi tuoi,</l>
             <l part="I">Mio re, mio genitor... </l>
           </sp>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l part="F">Sorgi. <stage>(Deidamia si alza)</stage> E' soverchio</l>
             <l>Ciò che dir mi vorresti. Io già de' fati</l>
@@ -3308,26 +3354,26 @@
             <l>Del sudor si ristori,</l>
             <l>E col sudore i suoi riposi onori.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="I">Sposa, Ulisse, che dite?</l>
           </sp>
-          <sp>
+          <sp who="#deidamia">
             <speaker>DEID.</speaker>
             <l part="F">Alle paterne</l>
             <l>Giuste leggi m'accheto.</l>
           </sp>
-          <sp>
+          <sp who="#ulisse">
             <speaker>ULI.</speaker>
             <l>Lieta il saggio decreto</l>
             <l part="I">Ammirerà la Grecia.</l>
           </sp>
-          <sp>
+          <sp who="#achille">
             <speaker>ACH.</speaker>
             <l part="F">Or non mi resta</l>
             <l part="I">Che desiar.</l>
           </sp>
-          <sp>
+          <sp who="#licomede">
             <speaker>LIC.</speaker>
             <l part="F">Gl'illustri sposi unisca</l>
             <l>Il bramato da lor laccio tenace;</l>
@@ -3350,7 +3396,7 @@
           </sp>
           <stage>(Mentre cantasi il coro che precede, scenderà dall'alto denso globo di nuvole, che prima ingombrerà, dilatandosi, gran parte della reggia, e scoprirà poi agli spettatori il luminoso tempio della Gloria, tutto adornato de' simulacri di coloro ch'ella rese immortali. Si vedranno in aria innanzi al tempio medesimo la Gloria, Amore ed il Tempo, ed in sito men sollevato numerose schiere di lor seguaci</stage>
           <stage>La GLORIA, AMORE, ed il TEMPO</stage>
-          <sp>
+          <sp who="#gloria">
             <speaker>GLO.</speaker>
             <l>E quale a me vi guida,</l>
             <l>Rivali dèi, nuova cagione? Amore,</l>
@@ -3360,11 +3406,11 @@
             <l>Cambia costume, e l'uno e l'altro amico</l>
             <l>Orma in volto non ha dell'odio antico!</l>
           </sp>
-          <sp>
+          <sp who="#tempo">
             <speaker>TEM.</speaker>
             <l part="I">Non v'è più sdegno in Cielo.</l>
           </sp>
-          <sp>
+          <sp who="#amore">
             <speaker>AMO.</speaker>
             <l part="F">A' numi ancora</l>
             <l>Questa lucida aurora</l>
@@ -3390,7 +3436,7 @@
             <l>Se alimento ha da te, tanto prevale,</l>
             <l>Tuo seguace son io, non tuo rivale.</l>
           </sp>
-          <sp>
+          <sp who="#tempo">
             <speaker>TEM.</speaker>
             <l>Né me, dea degli eroi,</l>
             <l>Tuo nemico chiamar. Come oscurarti</l>
@@ -3405,7 +3451,7 @@
             <l>Inestinguibil lode</l>
             <l>Farò tesoro e ne sarò custode.</l>
           </sp>
-          <sp>
+          <sp who="#gloria">
             <speaker>GLO.</speaker>
             <l>Giunse dunque una volta il dì felice,</l>
             <l>Di cui tanto nel cielo</l>
@@ -3417,31 +3463,31 @@
             <l>A pro de' chiari sposi</l>
             <l part="I">Tutte le nostre cure.</l>
           </sp>
-          <sp>
+          <sp who="#amore">
             <speaker>AMO.</speaker>
             <l part="F">Al nobil fuoco,</l>
             <l>Che in lor destai, somministrar vogl'io</l>
             <l part="I">Sempre nuovo alimento.</l>
           </sp>
-          <sp>
+          <sp who="#tempo">
             <speaker>TEM.</speaker>
             <l part="F">Io de' lor anni</l>
             <l>Lunghissimo e tranquillo</l>
             <l part="I">Il corso reggerò.</l>
           </sp>
-          <sp>
+          <sp who="#amore">
             <speaker>AMO.</speaker>
             <l part="F">Per me d'eroi,</l>
             <l>Il talamo reale</l>
             <l part="I">Sarà fecondo.</l>
           </sp>
-          <sp>
+          <sp who="#tempo">
             <speaker>TEM.</speaker>
             <l part="F">Io serberò gli esempi</l>
             <l>Degli atavi remoti</l>
             <l part="I">Ai più tardi nipoti.</l>
           </sp>
-          <sp>
+          <sp who="#gloria">
             <speaker>GLO.</speaker>
             <l part="F">Io fui di quelli,</l>
             <l>Io di questi sarò compagna e duce:</l>

--- a/tei/metastasio-adriano-in-siria.xml
+++ b/tei/metastasio-adriano-in-siria.xml
@@ -76,6 +76,31 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <personGrp xml:id="soldati">
+            <name>Coro di soldati romani</name>
+          </personGrp>
+          <person xml:id="aquilio">
+            <persName>Aquilio</persName>
+          </person>
+          <person xml:id="adriano">
+            <persName>Adriano</persName>
+          </person>
+          <person xml:id="farnaspe">
+            <persName>Farnaspe</persName>
+          </person>
+          <person xml:id="osroa">
+            <persName>Osroa</persName>
+          </person>
+          <person xml:id="emirena">
+            <persName>Emirena</persName>
+          </person>
+          <person xml:id="sabina">
+            <persName>Sabina</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT-Pavia</name>Digitalizzazione</change>
@@ -129,7 +154,7 @@
           <head>SCENA PRIMA</head>
           <stage>Gran piazza d'Antiochia magnificamente adorna di trofei militari, composti d'insegne, armi ed altre spoglie de' barbari superati. Trono imperiale da un lato. Ponte sul fiume Oronte, che divide la città suddetta.</stage>
           <stage>Di qua dal fiume, ADRIANO sollevato sopra gli scudi da' soldati romani, AQUILIO, guardie e popolo. Di là dal fiume, FARNASPE ed OSROA, con séguito di Parti, che conducono varie fiere ed altri doni da presentare ad ADRIANO.</stage>
-          <sp>
+          <sp who="#soldati">
             <speaker>CORO DI SOLDATI ROMANI</speaker>
             <lg>
               <l>Vivi a noi, vivi all'impero,</l>
@@ -151,12 +176,12 @@
             </lg>
           </sp>
           <stage>(Nel tempo che si canta il coro, Adriano, e sciogliendosi quella connessione d'armi che serviva a sostenerlo, que' soldati, che la componevano, prendono ordinatamente sito fra gli altri.</stage>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l>Chiede il parto Farnaspe</l>
             <l part="I">Di presentarsi a te. <stage>(ad Adriano</stage></l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Venga e s'ascolti. <stage>(Aquilio parte; Adriano sale sul trono e parla in piedi</stage></l>
             <l>Valorosi compagni,</l>
@@ -174,7 +199,7 @@
             <l>Alla pubblica speme,</l>
             <l>Come fin or, noi serviremo insieme. <stage>(siede</stage></l>
           </sp>
-          <sp>
+          <sp who="#soldati">
             <speaker>CORO</speaker>
             <lg>
               <l>Vivi a noi, vivi all'impero,</l>
@@ -184,7 +209,7 @@
             </lg>
           </sp>
           <stage>(Nel tempo che si ripete il coro, passano il ponte Farnaspe ed Osroa sconosciuto, con tutto il séguito de' Parti. Sono preceduti da Aquilio, che li conduce</stage>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l>Nel dì che Roma adora</l>
             <l>Il suo Cesare in te, dal ciglio augusto,</l>
@@ -194,12 +219,12 @@
             <l>Ora al cesareo piede</l>
             <l>L'ire depone, e giura ossequio e fede.</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l>Tanta viltà, Farnaspe,</l>
             <l part="I">Necessaria non è. <stage>(piano a Farnaspe</stage></l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Madre comune</l>
             <l>D'ogni popolo è Roma, e nel suo grembo</l>
@@ -208,11 +233,11 @@
             <l>Perdona a' vinti, e con virtù sublime</l>
             <l>Gli oppressi esalta ed i superbi opprime.</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="I">(Che insoffribile orgoglio!)</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Un atto usato</l>
             <l>Della virtù romana</l>
@@ -220,46 +245,46 @@
             <l>Geme fra' vostri lacci</l>
             <l part="I">Prigioniera la figlia.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="M">E ben?</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Disciogli,</l>
             <l part="I">Signor, le sue catene.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="M">(Oh dèi!)</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Rasciuga</l>
             <l>Della sua patria il pianto: a me la rendi,</l>
             <l>E quanto io reco in guiderdon ti prendi.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>Prence, in Asia io guerreggio,</l>
             <l>Non cambio o merco; ed Adrian non vende,</l>
             <l>Su lo stil delle barbare nazioni,</l>
             <l part="I">La libertade altrui.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Dunque la doni.</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="I">(Che dirà?)</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Venga il padre:</l>
             <l part="I">La serbo a lui.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Dopo il fatal conflitto,</l>
             <l>In cui tutti per Roma</l>
@@ -267,41 +292,41 @@
             <l>Del nostro re la sorte. O in altre rive</l>
             <l>Va sconosciuto errando, o più non vive.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>Fin che d'Osroa palese</l>
             <l>Il destino non sia, cura di lei</l>
             <l part="I">Noi prenderem.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Giacché a tal segno è Augusto</l>
             <l>Dell'onor suo geloso,</l>
             <l>Questa cura di lei lasci al suo sposo.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="I">Come! E' sposa Emirena?</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Altro non manca</l>
             <l part="I">Che il sacro rito.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F"> (Oh Dio!)</l>
             <l part="I">Ma lo sposo dov'è?</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Signor, son io.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="I">Tu stesso! Ed ella t'ama?</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Ah, fummo amanti</l>
             <l>Pria di saperlo, ed apprendemmo insieme</l>
@@ -315,11 +340,11 @@
             <l>Esser doveva in dolce nido unita,</l>
             <l>Signor, che crudeltà! mi fu rapita.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="I">(Che barbaro tormento!)</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Ah, tu nel volto,</l>
             <l>Signor, turbato sei: forse t'offende</l>
@@ -330,7 +355,7 @@
             <l>Da me pretendi in vano:</l>
             <l>Cesare, io nacqui parto e non romano.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>(Oh rimprovero acerbo! Ah! si cominci</l>
             <l>Su' propri affetti a esercitar l'impero).</l>
@@ -356,7 +381,7 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>OSROA e FARNASPE</stage>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l>Comprendesti, o Farnaspe,</l>
             <l>D'Augusto i detti? Ei, d'Emirena amante,</l>
@@ -366,34 +391,34 @@
             <l>Innanzi alle tue ciglia</l>
             <l>Vorrei... No, non lo credo. Ella è mia figlia.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l>Mio re, che dici mai? Cesare è giusto;</l>
             <l>Ella è fedele. Ah, qual timor t'affanna!</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l>Chi dubita d'un mal, raro s'inganna.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="I">Io volo a lei.Vedrai...</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="F">Va pur, ma taci</l>
             <l part="I">Ch'io son fra' tuoi seguaci.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Anche alla figlia?</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l>Sì; saprai, quando torni,</l>
             <l>Tutti i disegni miei.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l>Sì, sì, mio re, ritornerò con lei.</l>
             <lg>
@@ -444,7 +469,7 @@
           <head>SCENA QUARTA</head>
           <stage>Appartamenti destinati ad Emirena nel palazzo imperiale.</stage>
           <stage>AQUILIO, poi EMIRENA</stage>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l>Ah! se con qualche inganno</l>
             <l>Non prevengo Emirena, io son perduto.</l>
@@ -456,11 +481,11 @@
             <l>Porto sempre nel cor. Numi, in qual parte</l>
             <l>Emirena s'asconde? Eccola. All'arte.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="I">Aquilio.</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l part="F">Ah! principessa; ah! se vedessi</l>
             <l>Da quai furie agitato</l>
@@ -473,7 +498,7 @@
             <l>Se in te non è la prima fiamma estinta,</l>
             <l>Ei vuol condurti al proprio carro avvinta.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l>Questo è l'eroe del vostro Tebro? Questo</l>
             <l>E' l'idolo di Roma? A me promise</l>
@@ -481,18 +506,18 @@
             <l>Esposta non sarei. Non è fra voi,</l>
             <l>Dunque il mancar di fé colpa agli eroi?</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l>Se un violento amore</l>
             <l>Agita i sensi e la ragione oscura,</l>
             <l>Emirena, gli eroi cangian natura.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l>In trionfo Emirena? In Asia ancora</l>
             <l part="I">Si sa morir.</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l part="F">Senza parlar di morte,</l>
             <l>V'è riparo miglior. Cesare viene</l>
@@ -506,37 +531,37 @@
             <l>Di tale indifferenza il tuo sembiante,</l>
             <l>Come se più di lui non fossi amante.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l>E il povero Farnaspe</l>
             <l>Di me che mai direbbe? Ah! tu non sai</l>
             <l>Di qual tempra è quel core. Io lo vedrei</l>
             <l>A tal colpo morir su gli occhi miei.</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l>Addio. Pensaci, e trova,</l>
             <l part="I">Se puoi, miglior consiglio.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">Odimi. Almeno</l>
             <l part="I">Corri, previeni il prence...</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l part="M">Eccolo.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">Oh Dio!</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l>Armati di fortezza. Io t'insegnai</l>
             <l>Ad evitare il tuo destin funesto. <stage>(parte</stage></l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l>Misera me, che duro passo è questo!</l>
           </sp>
@@ -544,101 +569,101 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>ADRIANO, FARNASPE ed EMIRENA</stage>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>Principe, quelle sono</l>
             <l part="I">Le sembianze che adori?</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Ah, sì, son quelle;</l>
             <l>E sempre agli occhi miei sembran più belle.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="I">(Mi trema il cor).</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Vaga Emirena, osserva</l>
             <l>Con chi ritorno a te. Più dell'usato</l>
             <l>So che  grato ti giungo: afferma il vero.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="I">Non so chi sia quello stranier.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F"><stage>(rimane stupido)</stage> Straniero!</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="I">Che! Nol conosci?</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="M">(Oh Dio!) No.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Quei sembianti</l>
             <l>Altrove hai pur veduti.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l>No. (Se parlo, io mi scopro, e siam perduti).</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>Prence, questa è colei che teco apprese</l>
             <l part="I">A vivere e ad amar?</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Io perdo il senno:</l>
             <l>Non so più dove son, né chi son io.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l>(Le angustie di quel cor risente il mio).</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>Se mai fosse timore il tuo ritegno,</l>
             <l>Senti, Emirena. Io degli affetti altrui</l>
             <l>Non son tiranno: ecco il tuo ben; lo rendo,</l>
             <l>Com'è ragione, al suo primiero affetto.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l>(Emirena, costanza!) Io non l'accetto.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l>Principessa, idol mio, che mai ti feci?</l>
             <l>Son reo di qualche fallo?</l>
             <l>Sei sdegnata con me? Dubiti forse</l>
             <l part="I">Della mia fedeltà?</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="M">Taci.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Io son quello...</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l>Ma taci per pietà; n'è degno assai</l>
             <l part="I">Lo stato in cui mi vedi.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Almen rammenta...</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l>Di nulla io mi rammento:</l>
             <l>Nulla io so dir. Del mio destino avverso</l>
@@ -646,7 +671,7 @@
             <l>Il tenor pertinace.</l>
             <l>Se oppressa non mi vuoi, lasciami in pace.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l>Lasciami in pace! Ubbidirò, crudele;</l>
             <l>Ma guardami una volta. In questa fronte</l>
@@ -670,23 +695,23 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>ADRIANO ed EMIRENA, che vuol partire.</stage>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="I">Dove, Emirena?</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">A pianger sola. Il pianto</l>
             <l>Libero almen mi resti,</l>
             <l part="I">Giacché tutto perdei.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Nulla perdesti.</l>
             <l>Io perdei la mia pace,</l>
             <l part="I">Cara, negli occhi tuoi.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F"><stage>(in aria maestosa</stage> Da te sperai</l>
             <l>Più rispetto, o signor. L'animo regio</l>
@@ -694,18 +719,18 @@
             <l>Ché, se il regno natio</l>
             <l>Era della fortuna, il core è mio.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>(Bella fierezza!) E in che t'offendo? Io posso</l>
             <l>Offerirti, se vuoi,</l>
             <l part="I">E l'impero e la man.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">No, tu nol puoi:</l>
             <l part="I">Son promessi a Sabina.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">E' ver, l'amai</l>
             <l>Quasi due lustri. Hanno a durare eterni</l>
@@ -721,59 +746,59 @@
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>AQUILIO frettoloso e detti.</stage>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l part="I">Signor...</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="M">Che fu?</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l part="F">Dalla città latina</l>
             <l part="I">Giunge...</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="M">Chi giunge mai?</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l part="F">Giunge Sabina.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="I">Sommi dèi!</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="M">(Qual soccorso!)</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">E che pretende?</l>
             <l>Per sì lungo cammin... Senza mio cenno...</l>
             <l part="I">Non t'ingannasti già?</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l part="F">Senti il tumulto</l>
             <l>Del popolo seguace,</l>
             <l part="I">Che la saluta Augusta.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Aquilio, oh Dio!</l>
             <l>Va, conducila altrove: in questo stato</l>
             <l>Non mi sorprenda. A ricompormi in volto</l>
             <l>Chiedo un momento. Ah, poni ogni arte in uso.</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l part="I">Signor, viene ella stessa.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Io son confuso.</l>
           </sp>
@@ -781,7 +806,7 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>SABINA con séguito di matrone e cavalieri romani, e detti.</stage>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l>Sposo, Augusto, signor, questo è il momento</l>
             <l>Che in van fin or bramai; giunse una volta:</l>
@@ -789,15 +814,15 @@
             <l>Di quel lauro io ti miri,</l>
             <l>Che costa all'amor mio tanti sospiri.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="I">(Che dirle?)</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="M">Non rispondi?</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Io non sperai...</l>
             <l>Potevi pure... (Oh Dio!) Chiede ristoro</l>
@@ -805,22 +830,22 @@
             <l>A' soggiorni migliori</l>
             <l>Passi Sabina, e al par di noi si onori.</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l>Che? tu mi lasci? Il mio riposo io venni</l>
             <l part="I">A ricercare in te.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Perdona: altrove</l>
             <l part="I">Grave cura or mi chiama.</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="F">Era una volta</l>
             <l part="I">Tua dolce cura ancor Sabina.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">E' vero;</l>
             <l>Ma la cura più grande oggi è l'impero. <stage>(parte</stage></l>
@@ -829,17 +854,17 @@
         <div type="scene">
           <head>SCENA NONA</head>
           <stage>SABINA, EMIRENA, AQUILIO</stage>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="I">Aquilio, io non l'intendo.</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l part="F">E pur l'arcano</l>
             <l>E' facile a spiegar. Cesare è amante:</l>
             <l part="I">Questa è la tua rival. <stage>(piano a Sabina</stage></l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">Pietosa Augusta,</l>
             <l>Se lungamente il Cielo</l>
@@ -847,16 +872,16 @@
             <l>Compatisci e soccorri. E regno e sposo,</l>
             <l>E patria e genitor, tutto perdei.</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="I">(Mi deride l'altera!)</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">Un bacio intanto</l>
             <l part="I">Sulla cesarea man...</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="F"><stage>(ritirandosi)</stage>Scostati. Ancora</l>
             <l>Non son moglie d'Augusto; e, quanto dici,</l>
@@ -867,15 +892,15 @@
             <l>La pietà che mi chiedi</l>
             <l part="I">Mendicherò da te.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">La mia catena...</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="I">Non più: lasciami sola.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">(Oh dèi, che pena!)</l>
             <lg>
@@ -895,16 +920,16 @@
         <div type="scene">
           <head>SCENA DECIMA</head>
           <stage>SABINA ed AQUILIO</stage>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l part="I">(Tentiam la nostra sorte).</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="F">Il caso mio</l>
             <l part="I">Non fa pietade, Aquilio?</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l part="F">E' grande in vero</l>
             <l>L'ingiustizia d'Augusto. Ei non prevede</l>
@@ -913,11 +938,11 @@
             <l>Non arderà per te? Su gli occhi suoi</l>
             <l part="I">Dovresti...</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="F">Che dovrei? <stage>(con serietà e sdegno</stage></l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l>Seguitarlo ad amar, mostrar costanza,</l>
             <l>E farlo vergognar d'esserti infido.</l>
@@ -954,7 +979,7 @@
           <head>SCENA DODICESIMA</head>
           <stage>Cortili del palazzo imperiale con veduta interrotta d'una parte del medesimo, che soggiace ad incendio, ed è poi diroccata da guastatori. Notte.</stage>
           <stage>OSROA dalla reggia con face nella destra e spada nuda nella sinistra. Séguito d'incendiari parti, e poi FARNASPE.</stage>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l>Feroci Parti, al nostro ardir felice</l>
             <l>Arrise il Ciel. Della nemica reggia</l>
@@ -968,43 +993,43 @@
             <l>Ch'or la partica fiamma abbatte e doma,</l>
             <l>Tutto il Senato, il Campidoglio e Roma!</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="I">Osroa, mio re!</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="F">Guarda, Farnaspe. E' quella</l>
             <l part="I">Opera di mia man. <stage>(accennando l'incendio</stage></l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Numi! E la figlia?</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l>Chi sa? Fra quelle fiamme,</l>
             <l>Col suo Cesare avvolta,</l>
             <l>Forse de' torti tuoi paga le pene.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="I">Ah, Emirena! ah, mio bene! <stage>(vuol partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="F">Ascolta. E dove?</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="I">A salvarla e morir. <stage>(come sopra</stage></l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="F">Come! Un'ingrata,</l>
             <l>Che ci manca di fé, pone in oblio...</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l>E' spergiura, lo so; ma è l'idol mio. <stage>(getta il manto, ed entra tra le fiamme e le ruine della reggia</stage></l>
           </sp>
@@ -1037,125 +1062,125 @@
         <div type="scene">
           <head>SCENA QUATTORDICESIMA</head>
           <stage>EMIRENA fuggendo, indi FARNASPE incatenato fra le guardie romane.</stage>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l>Misera! dove fuggo?</l>
             <l>Chi mi soccorre? Almen sapessi!... Oh dèi!</l>
             <l part="I">Farnaspe!</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Principessa!</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="I">Tu prigionier?</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="M">Tu salva?</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">Agl'infelici</l>
             <l>Difficile è il morir. Di quelle fiamme</l>
             <l part="I">Sei tu forse l'autor?</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">No, ma si crede.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="I">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Perché son parto,</l>
             <l>Perché son disperato, in quelle mura</l>
             <l part="I">Perché fui còlto.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="M">E a che venisti?</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Io venni</l>
             <l part="I">A salvarti e morir.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">Ma, se tu mori,</l>
             <l part="I">Credi salva Emirena?</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Ah, perché mai</l>
             <l>Mi schernisci così? Troppo è crudele</l>
             <l part="I">Questa finta pietà.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">Finta la chiami?</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l>Come crederla vera? Assai diversa</l>
             <l>Parlasti, o principessa.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l>Il parlar fu diverso; io fui l'istessa.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="I">Ma le fredde accoglienze?</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">Eran timore</l>
             <l>D'irritar d'Adriano il cor geloso.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l>E da lui che temevi?</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="I">D'un trionfo il rossor.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Se generoso</l>
             <l part="I">La mia destra t'offerse?</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">Arte inumana</l>
             <l part="I">Per leggermi nel cor.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Dunque son io?...</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="I">La mia speme, il mio cor.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Dunque tu sei?...</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="I">La tua sposa costante.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="M">E vivi?...</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">E vivo</l>
             <l>Fedele al mio Farnaspe. A lui fedele</l>
@@ -1164,7 +1189,7 @@
             <l>L'immagine scolpita,</l>
             <l>Se rimane agli estinti orma di vita.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l>Non più, cara, non più. Basta, ti credo.</l>
             <l>Detesto i miei sospetti:</l>
@@ -1177,21 +1202,21 @@
             <l>Il suo labbro mel dice:</l>
             <l>In faccia all'ire vostre io son felice. <stage>(partendo</stage></l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="I">Ah, non partir.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Conviene</l>
             <l part="I">Seguir la forza altrui.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">Farnaspe, oh Dio!</l>
             <l part="I">Che mai sarà di te?</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Nulla pavento.</l>
             <l>Sarà la morte istessa</l>
@@ -1204,7 +1229,7 @@
               <l>Fra' labbri io morirò.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <lg>
               <l>Se a me t'invola il fato,</l>
@@ -1213,34 +1238,34 @@
               <l>Fra' labbri io morirò.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <lg part="I">
               <l part="I">Addio, mia vita.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <lg part="F">
               <l part="F">Addio,</l>
               <l>Luce degli occhi miei.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <lg>
               <l>Quando fedel mi sei,</l>
               <l>Che più bramar dovrò?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <lg>
               <l>Quando il mio ben perdei,</l>
               <l>Che più sperar potrò?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <lg>
               <l>Un tenero contento,</l>
@@ -1248,7 +1273,7 @@
               <l>Numi, chi mai provò!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <lg>
               <l>Un barbaro tormento,</l>
@@ -1264,7 +1289,7 @@
           <head>SCENA PRIMA</head>
           <stage>Galleria negli appartamenti d'Adriano, corrispondente a diversi gabinetti.</stage>
           <stage>EMIRENA ed AQUILIO</stage>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l>Chi protegger Farnaspe</l>
             <l>Può mai meglio di te? Del cor d'Augusto</l>
@@ -1272,21 +1297,21 @@
             <l>Miglior uso farebbe</l>
             <l part="I">Dell'amor d'un monarca.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">A me non giova,</l>
             <l part="I">Perché non l'amo.</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l part="F">E' necessario amarlo,</l>
             <l part="I">Perch'ei lo creda?</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="M">E ho da mentir?</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l part="F">Né pure.</l>
             <l>E la menzogna ormai</l>
@@ -1303,12 +1328,12 @@
             <l>E tu, quando vorrai,</l>
             <l>Sempre gli potrai dir: Nol dissi mai.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l>Non so dove s'apprenda</l>
             <l part="I">Tal arte a porre in uso.</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l part="F">Eh, che pur troppo</l>
             <l>Voi nascete maestre. Aver sul ciglio</l>
@@ -1320,7 +1345,7 @@
             <l>Privilegi del sesso: in dono a voi</l>
             <l>Gli ha dati il Cielo, e costan tanto a noi.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l>Tu, che in corte invecchiasti,</l>
             <l>Non dovresti invidiarne. Io giurerei</l>
@@ -1339,7 +1364,7 @@
             <l>Sotto un zelo apparente un empio fine;</l>
             <l>Né fabbricar che su l'altrui ruine.</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l>Far volesti, Emirena,</l>
             <l>Le vendette del sesso. Io non credei</l>
@@ -1348,11 +1373,11 @@
             <l>Credo ch'io dissi, e tu dicesti il vero.</l>
             <l>Consigliarti pretesi.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l>Aiuto e non consiglio io ti richiesi.</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l>Ed io sempre ho creduto</l>
             <l>Che un salubre consiglio è grande aiuto.</l>
@@ -1363,15 +1388,15 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>SABINA ed EMIRENA</stage>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="I">(Stelle! E' qui la rival!)</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">(Numi! E' Sabina!)</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l>Veramente tu sei,</l>
             <l>Più di quel che credei,</l>
@@ -1379,7 +1404,7 @@
             <l>E' l'incendio notturno, e già ti trovo</l>
             <l part="I">Nelle stanze d'Augusto.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">Oh Dio, Sabina,</l>
             <l>Che ingiustizia è la tua! L'amor d'Augusto</l>
@@ -1390,25 +1415,25 @@
             <l>Farnaspe è l'idol mio. Gli diedi il core;</l>
             <l>E ha remoti principii il nostro amore.</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="I">Parli da senno, o fingi?</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">Io fingerei,</l>
             <l part="I">Se così non parlassi.</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="F">E non t'avvedi</l>
             <l>Che, parlando per lui, Cesare irrìti?</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="I">Ma non trovo altra via.</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="F">Quando tu voglia,</l>
             <l>Una miglior ve n'è. Da questa reggia</l>
@@ -1418,12 +1443,12 @@
             <l>Promettermi da lui d'un grato core</l>
             <l part="I">Anche prove più grandi.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">Ah, se potesse</l>
             <l part="I">Riuscire il pensier!</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="F">Vanne: è sicuro.</l>
             <l>A partir ti prepara. Al maggior fonte</l>
@@ -1431,16 +1456,16 @@
             <l>Col tuo sposo verrò. Colà m'attendi</l>
             <l>Prima che ascenda a mezzo corso il sole.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l>Ma verrai? Del destino</l>
             <l>Son tanto usata a tollerar lo sdegno...</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l>Ecco la destra mia: predila in pegno.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l>Ah! che a sì gran contento</l>
             <l>E' quest'anima augusta.</l>
@@ -1462,7 +1487,7 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>SABINA, poi ADRIANO, indi AQUILIO</stage>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l>Chi sa! Quando lontana</l>
             <l>Emirena sarà, forse ritorno</l>
@@ -1470,22 +1495,22 @@
             <l>Senz'esca il fuoco, e inaridisce il fiume,</l>
             <l>Separato dal fonte onde partissi.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>Emirena, mio ben... (Numi, che dissi!) <stage>(vuol partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l>Perché fuggi, Adriano? Un sol momento</l>
             <l>Non mi negar la tua presenza, e poi</l>
             <l part="I">Torna al tuo ben, se vuoi.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Come! Supponi...</l>
             <l part="I">Qual è dunque il mio bene?</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="F">Ah! non celarmi</l>
             <l>Quell'onesto rossor. Tu non sai quanto</l>
@@ -1493,11 +1518,11 @@
             <l>Chi non vede il suo fallo; e chi lo vede</l>
             <l part="I">E' vicino all'emenda.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="M">Oh Dio!</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="F">Sospiri?</l>
             <l>Lascia me sospirar. Numi del cielo,</l>
@@ -1507,7 +1532,7 @@
             <l>E' possibil? E' ver? Chi ti sedusse?</l>
             <l part="I">Parla, di', come fu?</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Che vuoi ch'io dica,</l>
             <l>Se tutto mi confonde? Ah, lascia queste</l>
@@ -1528,11 +1553,11 @@
             <l>Lo depongo in tua man. Saria felice</l>
             <l>Suddito a sì gran donna il mondo intero.</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l>Ah! domando il tuo core e non l'impero.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>Era tuo questo cor. S'io lo difesi,</l>
             <l>Se a te volli serbarlo,</l>
@@ -1543,11 +1568,11 @@
             <l>A paragon de' tuoi,</l>
             <l part="I">Lunga stagion credei che fosse.</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="F">E poi?</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>E poi... Non so. Di mia virtù sicuro,</l>
             <l>Trascurai le difese;</l>
@@ -1566,7 +1591,7 @@
             <l>Rimirata l'avesse a me vicina,</l>
             <l>Parrei degno di scusa anche a Sabina.</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l>Ah, questo è troppo. Abbandonar mi vuoi:</l>
             <l>Hai coraggio di dirlo: in faccia mia</l>
@@ -1580,11 +1605,11 @@
             <l>Che ho da te meritato?</l>
             <l>Barbaro! mancator! spergiuro! ingrato! <stage>(s'abbandona sopra una sedia</stage></l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l part="I">(Qui Sabina!) <stage>(in disparte</stage></l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">(Io non posso</l>
             <l>Più vederla penar. Troppo a quel pianto</l>
@@ -1592,90 +1617,90 @@
             <l>Bella Sabina. A' lacci tuoi felici</l>
             <l part="I">Tornerò: sarò tuo.</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l part="M">(Stelle!)</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="F"><stage>(guardandolo con tenerezza)</stage> Che dici?</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>Che alla pietà già cedo,</l>
             <l part="I">Messaggiera d'Amore.</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="F">Ah, non lo credo.</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l>(Qui bisogna un riparo).</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l>S'Emirena una volta</l>
             <l part="I">Torni a veder...</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="M">Non la vedrò.</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="F">Ma puoi</l>
             <l part="I">Di te fidarti?</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Ho risoluto, e tutto</l>
             <l part="I">Si può quando si vuole.</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l part="F"><stage>(ad Adriano</stage> A' piedi tuoi</l>
             <l>L'afflitta prigioniera</l>
             <l>Inchinarsi desia. Non ti ritrova,</l>
             <l part="I">E lung'ora ti cerca.</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="F">(Ecco la prova).</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>No, Aquilio: io più non deggio</l>
             <l>Emirena veder. Tempo una volta</l>
             <l>E' pur ch'io mi rammenti</l>
             <l part="I">La mia fida Sabina.</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="F">(Oh cari accenti!)</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l>E' giustizia, è dover. Ma che domanda</l>
             <l>La povera Emirena? A lei si niega</l>
             <l>Quel che a tutti è concesso? E' serva, è vero;</l>
             <l>Ma pur nacque regina.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>Veramente, Sabina,</l>
             <l part="I">Par cudeltà non ascoltarla.</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="F"><stage>(si turba)</stage>Oh Dio!</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>L'udirò te presente:</l>
             <l>Che potresti temer? Resta, e vedrai...</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l>Oh! questo no. Già m'ingannasti assai. <stage>(s'alza</stage></l>
             <lg>
@@ -1697,33 +1722,33 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>ADRIANO ed AQUILIO</stage>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l>La tua bella Emirena</l>
             <l part="I">Volo a cercar. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="M">No, ferma.</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l part="F">E a lei potresti</l>
             <l part="I">Tal giustizia negar?</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">No: ma per ora...</l>
             <l>Non udisti Sabina? Amor mi sprona;</l>
             <l>La ragion mi raffrena.</l>
             <l>Vorrei... Ma... Oh dèi, che pena!</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l>Spiegati al fin. Se non t'intendo, in vano</l>
             <l>M'affanno a consolar quel core oppresso.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>Spiegami! E come? Ah, non m'intendo io stesso. <stage>(parte</stage></l>
           </sp>
@@ -1758,7 +1783,7 @@
           <head>SCENA SESTA</head>
           <stage>Deliziosa, per cui si passa a' serragli di fiere.</stage>
           <stage>EMIRENA, e poi SABINA e FARNASPE</stage>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <lg>
               <l>Che fa il mio bene?</l>
@@ -1767,23 +1792,23 @@
               <l>Mi sembra un dì.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="I">Ecco la sposa tua. <stage>(a Farnaspe</stage></l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Bella Emirena!</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l>Sei pur tu, caro prence? Il credo a pena.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="I">Al fin, ben mio...</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="F">Di tenerezze adesso</l>
             <l>Tempo non è. Convien salvarsi. E' quella</l>
@@ -1797,16 +1822,16 @@
             <l>Sicuri a' vostri lidi:</l>
             <l>La Fortuna vi scorga, Amor vi guidi.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="I">Pietosa Augusta.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Eccelsa donna, e come</l>
             <l part="I">Render mercé...</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="F">Poco desio. Pensate</l>
             <l>Qualche volta a Sabina; e fra le vostre</l>
@@ -1830,50 +1855,50 @@
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>EMIRENA e FARNASPE</stage>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l>Ed è ver che sei mia? Ne temo, e quasi</l>
             <l part="I">Parmi ancor di sognar.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">Prence, fuggiamo,</l>
             <l>Se sognar non vogliamo. <stage>(s'incamminano verso la strada disegnata da Sabina</stage></l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="I">Ferma! <stage>(ad Emirena, arrestandola</stage></l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="M">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Non odi</l>
             <l part="I">Qualche strepito d'armi?</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">Odo, ma donde</l>
             <l part="I">Non saprei dir.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="I">Da quel cammino istesso</l>
             <l part="I">Che tener noi dobbiamo.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="M">Aimè!</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Non giova</l>
             <l>L'avvilirsi, ben mio. Celati, intanto</l>
             <l>Che l'armi io scopro e la cagion di quelle.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l>Che sarà mai! Non mi tradite, o stelle. <stage>(Emirena si nasconde molto indietro, vicino a' cancelli del serraglio</stage></l>
           </sp>
@@ -1881,27 +1906,27 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>OSROA in abito romano con ispada nuda insanguinata, che esce dalla strada disegnata da Sabina; FARNASPE, e in disparte EMIRENA</stage>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l>Fra l'ombre adesso a raccontar l'altero</l>
             <l part="I">Vada i trofei della sua Roma.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">E dove</l>
             <l part="I">Corri, signor, con queste spoglie?</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="F">Amico,</l>
             <l>Siam vendicati. Ecco il felice acciaro</l>
             <l part="I">Che Adriano svenò.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="M">Come!</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="F">Solea</l>
             <l>Di questa occulta via talor valersi</l>
@@ -1911,26 +1936,26 @@
             <l>Travestito in tal guisa, io l'aspettai,</l>
             <l>Fin che passò col servo, e lo svenai.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l>Ma, del nemico in vece,</l>
             <l>Potevi fra quell'ombre</l>
             <l part="I">L'altro ferir.</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="F">No: fu previsto il caso.</l>
             <l>Finse cader, quando mi fu vicino,</l>
             <l>Il servo reo. Con questo segno espresso</l>
             <l>Cesare espose, assicurò se stesso.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l>(Chi sarà quel roman? Stringe un acciaro,</l>
             <l>E sanguigno mi par. Potessi in volto</l>
             <l part="I">Mirarlo almeno!)</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Or che farem? Fuggendo</l>
             <l>Per la via che facesti, incontro andiamo</l>
@@ -1938,33 +1963,33 @@
             <l>Al tumulto saran. Su gli altri ingressi</l>
             <l part="I">Veglian servi e custodi.</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="F">E ben! col ferro</l>
             <l part="I">Ci apriremo la strada.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Al caso estremo</l>
             <l>Serbiam questo rimedio. io voglio prima</l>
             <l>Ricercar se vi fosse</l>
             <l part="I">Altra via di fuggir.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">(Parlan sommesso:</l>
             <l part="I">Intenderli non so).</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Fra quelle piante</l>
             <l>Nascoso attendi. Io tornerò di volo.</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l>Sollecito ritorna, o parto solo. <stage>(Osroa si nasconde molto innanzi fra le piante del boschetto</stage></l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l>Questo... No. Quel sentier... Ma s'io tentassi</l>
             <l>Il cammin che prescritto</l>
@@ -1977,28 +2002,28 @@
         <div type="scene">
           <head>SCENA NONA</head>
           <stage>FARNASPE, ADRIANO con ispada nuda e séguito di guardie dalla strada suddetta. OSROA ed EMIRENA in disparte.</stage>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="I">Fermati, traditor. <stage>(incontrandosi in Farnaspe</stage></l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F"><stage>(si ferma stupido)</stage> Numi, che veggo!</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>Impedite ogni passo</l>
             <l part="I">Alla fuga, o custodi. <stage>(alle guardie</stage></l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Io son di sasso.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="I">(Ah, siam scoperti!) <stage>(s'avanza ad ascoltare</stage></l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Istupidisci, ingrato,</l>
             <l>Perché vivo mi vedi? A me credesti</l>
@@ -2006,76 +2031,76 @@
             <l>Con voci ingiuriose</l>
             <l part="I">Nel ferir palesasti.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">(Ecco l'errore.</l>
             <l>Colui che si nasconde è il traditore).</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>Perfido! non rispondi? A che venisti?</l>
             <l>Qual disegno t'ha mosso?</l>
             <l part="I">Chi sciolse i lacci tuoi? Parla.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Non posso.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>Non puoi? Si tragga a forza</l>
             <l>Nel carcere più nero il delinquente.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l>Fermatevi: sentite; egli è innocente. <stage>(si scopre con impeto</stage></l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="I">Aimè!</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">Tra quelle fronde</l>
             <l part="I">Il traditor s'asconde. Eccolo... <stage>(s'incammina verso Osroa</stage></l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Oh Dio!</l>
             <l part="I">Ferma!</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="M"> Vedilo, Augusto. <stage>(accennando Osroa, che s'avanza</stage></l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="F">E' ver, son io.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="I">Ah, padre! <stage>(resta immobile</stage></l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Il re de' Parti</l>
             <l>In abito romano! E quanti siete,</l>
             <l part="I">Scellerati! a tradirmi?</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="F">Io solo, io solo</l>
             <l>Ho sete del tuo sangue. Il colpo errai;</l>
             <l>Ma, se mi lasci in vita,</l>
             <l part="I">Il fallo emenderò.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Così fra l'ombre</l>
             <l>Assalirmi, infedel? Coglier l'istante</l>
             <l part="I">Che inciampo e cado al suol?</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="F">Barbara sorte!</l>
             <l>Ecco l'inganno. Il tuo seguace ad arte</l>
@@ -2083,39 +2108,39 @@
             <l>Onde, confuso il segno,</l>
             <l part="I">L'un per l'altro svenai.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Questa mercede,</l>
             <l>Barbaro, tu mi rendi? Oppresso e vinto</l>
             <l>T'invito, t'offerisco</l>
             <l part="I">Di Roma l'amistà...</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="F">Sì, questo è il nome,</l>
             <l>Empi! con cui la tirannia chiamate;</l>
             <l>Ma poi servon gli amici, e voi regnate.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>Siam del giusto custodi. Al giusto serve</l>
             <l>Chi compagni ci vuol, non serve a noi:</l>
             <l>Ma la giustizia è tirannia per voi.</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l>E chi di lei vi fece</l>
             <l>Interpreti e custodi? Avete forse</l>
             <l>Ne' celesti congressi</l>
             <l>Parte co' numi? o siete i numi istessi?</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>Se non siam numi, almeno</l>
             <l>Procuriam d'imitarli; e il suo costume</l>
             <l>Chi co' numi conforma, agli altri è nume.</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l>Numi però voi siete</l>
             <l>Avidi dell'altrui: rapite i regni,</l>
@@ -2123,27 +2148,27 @@
             <l>Gl'innocenti rivali,</l>
             <l part="I">Tradite le consorti...</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Ah, troppo abusi</l>
             <l>Della mia sofferenza. Olà, ministri,</l>
             <l>In carcere distinto alla lor pena</l>
             <l part="I">Questi rei custodite.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Anche Emirena?</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="I">Sì, ancor l'ingrata.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Ah! che ingiustizia è questa?</l>
             <l>Qual delitto a punir ritrovi in lei?</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <lg>
               <l>Tutti nemici e rei,</l>
@@ -2164,37 +2189,37 @@
         <div type="scene">
           <head>SCENA DECIMA</head>
           <stage>OSROA, FARNASPE, EMIRENA e guardie.</stage>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l>Padre... Oh Dio! con qual fronte</l>
             <l>Posso padre chiamarti io che t'uccido?</l>
             <l>Deh! se per me t'avanza...</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l>Parti, non assalir la mia costanza.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l>Ah! mi scaccia a ragion. Perdono, o padre;</l>
             <l part="I">Eccomi a' piedi tuoi. <stage>(s'inginocchia</stage></l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="F">Lasciami, o figlia:</l>
             <l>No, sdegnato non sono;</l>
             <l>T'abbraccio, ti perdono.</l>
             <l>Addio, dell'alma mia parte più cara.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="I">Oh addio funesto!</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Oh divisione amara!</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <lg>
               <l>Quell'amplesso e quel perdono,</l>
@@ -2213,13 +2238,13 @@
         <div type="scene">
           <head>SCENA UNDICESIMA</head>
           <stage>OSROA e FARNASPE</stage>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l>Almen tutto il mio sangue</l>
             <l>A conservar bastasse</l>
             <l part="I">Il mio re, la mia sposa.</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="F">Amico, assai</l>
             <l>Debole io fui. Non congiurar tu ancora</l>
@@ -2271,13 +2296,13 @@
           <head>SCENA PRIMA</head>
           <stage>Sala terrena con sedie.</stage>
           <stage>SABINA ed AQUILIO</stage>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l>Come! ch'io parta? A questo segno è cieco?</l>
             <l>E' ingiusto a questo segno? E di qual fallo</l>
             <l part="I">Vuol punirmi Adriano?</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l part="F">Ei sa che fosti</l>
             <l>D'Emirena e Farnaspe</l>
@@ -2286,7 +2311,7 @@
             <l>Sa i tuoi falli ingrandir, che, a chi lo sente,</l>
             <l>Nel punirti così, sembra clemente.</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l>Serbando la sua gloria,</l>
             <l>Beneficando una rivale, io volli</l>
@@ -2294,60 +2319,60 @@
             <l>Mi consigliò, ma la pietà, l'amore;</l>
             <l>Onde error non commisi, o è lieve errore.</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l>Sabina, io lo conosco, e lo conosce</l>
             <l>Forse Adriano ancor; ma giova a lui</l>
             <l part="I">Un lodevol pretesto.</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="F">E ben, mi vegga</l>
             <l part="I">E n'arrossisca.</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l part="F">Il comparirgli innanzi</l>
             <l part="I">Di vietarti m'impose.</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="F">Oh dèi! Ma deggio</l>
             <l part="I">Partir senza vederlo?</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l part="M">Appunto.</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="F">E quando?</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l part="I">Già le navi son pronte.</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="F">Un tal comando</l>
             <l part="I">Ubbidir non si deve.</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l part="F">Ah no: ti perdi.</l>
             <l>Parti; fidati a me. Lo vincerai</l>
             <l>Non resistendo. Io cercherò l'istante</l>
             <l part="I">Di farlo ravveder.</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="F">Ma digli almeno...</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l>Va senz'altro parlar, t'intendo appieno.</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <lg>
               <l>Digli ch'è un infedele;</l>
@@ -2394,21 +2419,21 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>ADRIANO ed AQUILIO</stage>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>Aquilio, che ottenesti?</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l>Nulla, signore: è risoluta e vuole</l>
             <l part="I">Partir Sabina.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Ah! se sdegnata è meco</l>
             <l part="I">Ha gran ragion.</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l part="F">Ma moderate a segno</l>
             <l>Son le querele sue, che d'altro amante</l>
@@ -2416,12 +2441,12 @@
             <l>L'incostanza d'Augusto</l>
             <l part="I">Di pretesto alla sua.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">No, non mi piace</l>
             <l>Questa soverchia pace. Andiamo a lei.</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l>Ma, signor, ti scordasti</l>
             <l>Del re de' Parti. Il mio consiglio accetti;</l>
@@ -2429,7 +2454,7 @@
             <l>Ei vien, t'attende; e nel compir l'impresa</l>
             <l part="I">Ti confondi e vacilli?</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Ah! tu non sai</l>
             <l>Qual guerra di pensieri</l>
@@ -2444,7 +2469,7 @@
             <l>Il ben più non distinguo. Al fin mi veggio</l>
             <l>Stretto dal tempo, e mi risolvo al peggio.</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l>Eh finisci una volta</l>
             <l>Di tormentar te stesso. Hai quasi in braccio</l>
@@ -2453,15 +2478,15 @@
             <l>Di vederti soffrir. Vado de' Parti</l>
             <l part="I">Ad introdurre il re.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Senti. E se poi...</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l part="I">Non più dubbi, signor.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Fa quel che vuoi.</l>
           </sp>
@@ -2470,32 +2495,32 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>ADRIANO, poi OSROA ed AQUILIO</stage>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>Che dir può il mondo? Al fine</l>
             <l>Il conservar la vita</l>
             <l>E' ragion di natura: e in tanta pena</l>
             <l>Io viver non saprei senza Emirena.</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="I">Che si chiede da me?</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Che il re de' Parti</l>
             <l>Sieda e m'ascolti; e, se non pace, intanto</l>
             <l>Abbia tregua il suo sdegno. <stage>(siede</stage></l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l>A lunga sofferenza io non m'impegno. <stage>(siede</stage></l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l part="I">(Del mio destin si tratta).</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Osroa, nel mondo</l>
             <l>Tutto è soggetto a cambiamento, e strano</l>
@@ -2509,16 +2534,16 @@
             <l>Né che vincere a noi,</l>
             <l part="I">Nè che perdere a te.</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="F">Sì, conservai</l>
             <l>L'odio primiero; onde mi resta assai.</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l part="I">(Che barbara ferocia!)</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Ah, non vantarti</l>
             <l>D'un ben che posseduto</l>
@@ -2536,21 +2561,21 @@
             <l>A vantaggio d'entrambi. Io chiedo in dono</l>
             <l>Da te la figlia, e t'offerisco il trono.</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l part="I">(Tremo alla risposta).</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">E ben che dici?</l>
             <l part="I">Tu sorridi e non parli? <stage>(ad Osroa</stage></l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="F">E vuoi ch'io creda</l>
             <l part="I">Sì debole Adriano?</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Ah! che pur troppo,</l>
             <l>Osroa, io lo son. Dissimular che giova?</l>
@@ -2558,76 +2583,76 @@
             <l>Meco non vedo in dolce nodo unita,</l>
             <l>Non ho ben, non ho pace e non ho vita.</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l>Quando basti sì poco</l>
             <l>A renderti felice, io son contento:</l>
             <l part="I">Che si chiami la figlia.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Accetti dunque</l>
             <l part="I">Le offerte mie?</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="F">Chi ricusar potrebbe?</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>Ah! tu mi rendi, amico,</l>
             <l>Il perduto riposo. Aquilio, a noi</l>
             <l>La principessa invia.</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l>Ubbidito sarai. (Sabina è mia!) <stage>(parte</stage></l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>Ora a viver comincio. Olà, togliete <stage>(escono due guardie</stage></l>
             <l part="I">Quelle catene al re de' Parti.</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="F">Ancora</l>
             <l>Non è tempo, Adriano. Io goderei</l>
             <l>Prima de' doni tuoi che tu de' miei.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>Van riguardo. Eseguite <stage>(alle guardie</stage></l>
             <l part="I">Il cenno mio.</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="F">Non è dover. Partite. <stage>(partono le gurdie</stage></l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>Del peso ingiurioso io pur vorrei</l>
             <l part="I">Vederti alleggerir.</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="F">Son sì contento,</l>
             <l>Pensando all'avvenir, ch'io non lo sento.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="I">E pur non viene. <stage>(guardando per la scena</stage></l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="F"> Impaziente anch'io</l>
             <l part="I">Ne sono al par di te.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">La principessa</l>
             <l part="I">Io vado ad affrettar. <stage>(s'alza</stage></l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="F">No: già s'appressa. <stage>(s'alza, trattenendolo</stage></l>
           </sp>
@@ -2635,24 +2660,24 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>EMIRENA, ADRIANO ed OSROA</stage>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="I">Bellissima Emirena... <stage>(incontrandola</stage></l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="F"><stage>(ad Adriano)</stage> A lei primiero</l>
             <l part="I">Meglio sarà ch'io tutto spieghi.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">E' vero.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="I">(Perché son così lieti?)</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="F">E pure, o figlia,</l>
             <l>Frale miserie nostre abbiamo ancora</l>
@@ -2660,23 +2685,23 @@
             <l>Nella bellezza tua tutto il compenso</l>
             <l part="I">Delle perdite mie.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">Che dir mi vuoi!</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>Quella fiamma verace... <stage>(ad Emirana</stage></l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="I">Lasciami terminar.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Come a te piace.</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l>Tal virtù ne' tuoi lumi <stage>(ad Emirena</stage></l>
             <l>Raccolse amico il Ciel, che, fatto servo,</l>
@@ -2685,19 +2710,19 @@
             <l>S'abbassa alle preghiere; odia la vita</l>
             <l>Senza di te, che per suo nume adora.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="I">Tu dunque puoi... <stage>(ad Emirena</stage></l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="F">Non ho finito ancora.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="I">(Mi fa morir questa lentezza). <stage>(da sé</stage></l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="F">Io voglio...</l>
             <l>Senti, o figlia, e scolpisci</l>
@@ -2708,37 +2733,37 @@
             <l>Com'io l'odiai fin ora; e questa sia</l>
             <l part="I">L'eredità paterna.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Osroa, che dici!</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l>Né timor né speranza</l>
             <l>T'unisca a lui; ma forsennato, afflitto</l>
             <l>Vedilo a tutte l'ore</l>
             <l>Fremere di sdegno e delirar d'amore.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>Giusti dèi! son schernito.</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l>Parli Cesare adesso: Osroa ha finito.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>Sconsigliato! infelice! e non t'avvedi</l>
             <l>Che tu il fulmine accendi</l>
             <l part="I">Che opprimer ti dovrà?</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="F">Smania, o superbo:</l>
             <l part="I">Son le tue furie il mio trionfo.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Oh numi!</l>
             <l>Qual rabbia! qual veleno!</l>
@@ -2763,37 +2788,37 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>OSROA ed EMIRENA</stage>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l>Figlia, s'è ver che m'ami, ecco il momento</l>
             <l>Di farne prova. Un genitor soccorri,</l>
             <l part="I">Che ti chiede pietà.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">Se basta il sangue,</l>
             <l part="I">E' tuo: lo spargerò.</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="F">Toglimi all'ire</l>
             <l>Del tiranno roman. Senza catene</l>
             <l part="I">Ti veggo pur.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">Sì: ci conobbe Augusto</l>
             <l>D'ogn'insidia innocenti, e le disciolse</l>
             <l>A Farnaspe ed a me. Ma qual soccorso</l>
             <l part="I">Per ciò posso recarti?</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l part="F">Un ferro, un laccio,</l>
             <l>Un veleno, una morte,</l>
             <l part="I">Qualunque sia.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">Padre, che dici? Queste</l>
             <l>Sarian prove d'amor? La figlia istessa</l>
@@ -2803,7 +2828,7 @@
             <l>Fosse tanto inumano,</l>
             <l>Sapria nell'opra istupidir la mano.</l>
           </sp>
-          <sp>
+          <sp who="#osroa">
             <speaker>OSR.</speaker>
             <l>Va! ti credea più degna</l>
             <l>Dell'origine tua. Tremi di morte</l>
@@ -2826,64 +2851,64 @@
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>EMIRENA e poi FARNASPE</stage>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l>Misera, a qual consiglio</l>
             <l part="I">Appigliarmi dovrò?</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F"><stage>(con fretta)</stage> Corri, Emirena.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="I">Dove?</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="M">Ad Augusto.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="M">E perché mai?</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Procura</l>
             <l>Che il comando rivochi</l>
             <l>Contro il tuo genitore.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="I">Qual è?</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Vuol che, traendo</l>
             <l>Delle catene sue l'indegna soma,</l>
             <l part="I">Vada.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="M">A morte?</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="M">No: peggio.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="M">E dove?</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">A Roma</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="I">E che posso a suo pro?</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Va, prega, piangi,</l>
             <l>Offriti sposa ad Adriano: oblia</l>
@@ -2891,25 +2916,25 @@
             <l>Le speranze, l'amor. Tutto si perda,</l>
             <l part="I">E il re si salvi.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">Egli pur or m'impose</l>
             <l part="I">D'odiar Cesare sempre.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Ah! tu non devi</l>
             <l>Un comando eseguir dato nell'ira,</l>
             <l>Ch'è una breve follia. Dobbiamo, o cara,</l>
             <l part="I">Salvarlo suo malgrado.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">Ad altri in braccio</l>
             <l>Andar dunque degg'io? Tu lo consigli?</l>
             <l part="I">E con tanta costanza?</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Ah! principessa,</l>
             <l>Tu non vedi il mio cor. Non sai qual pena</l>
@@ -2933,13 +2958,13 @@
             <l>Nel mio dolor profondo:</l>
             <l>'Chi diè legge al mio cor, dà legge al mondo.'</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l>Ah! se vuoi ch'io consenta</l>
             <l>A perderti, ben mio, deh! non mostrarti</l>
             <l part="I">Così degna d'amor.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Bella mia speme,</l>
             <l>No, non mi perdi: infin ch'io resti in vita,</l>
@@ -2951,24 +2976,24 @@
             <l>Anche il tempo a dolerci. Osroa perisce,</l>
             <l part="I">Mentre pensiamo a conservarlo.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">Addio.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="I">Ascoltami.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="M">Che vuoi?</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Va... Ferma... Oh dèi!</l>
             <l>Vorrei che mi lasciassi e non vorrei.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <lg>
               <l>Oh Dio! mancar mi sento</l>
@@ -3010,100 +3035,100 @@
           <head>SCENA NONA</head>
           <stage>Luogo magnifico del palazzo imperiale; scale per cui si scende alle ripe dell'Oronte; veduta di campagna e giardini sull'opposta sponda.</stage>
           <stage>SABINA con séguito di matrone e cavalieri romani, AQUILIO, indi ADRIANO</stage>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l>Temerario! non più. Benché da lui</l>
             <l>Mi discacci Adriano, è a te delitto</l>
             <l>Del mio cor la richiesta.</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l>La prima volta è questa...</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l>E sia l'ultima volta</l>
             <l part="I">Che mi parli d'amor. <stage>(partendo per imbarcarsi</stage></l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Sabina, ascolta.</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l part="I">(Aimè).</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="M">(Numi!) Che chiedi? <stage>(tornando indietro</stage></l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">A questo segno</l>
             <l>Odioso io ti son, che partir vuoi</l>
             <l part="I">Senza vedermi?</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="F">Ah! Non schernirmi ancora</l>
             <l>Mi discacci, mi vieti</l>
             <l part="I">Di comparirti innanzi...</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Io? quando? Aquilio</l>
             <l>Non richiese Sabina</l>
             <l part="I">La libertà d'abbandonarmi?</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="F">Oh dèi!</l>
             <l>Non fu cenno d'Augusto <stage>(ad Aquilio</stage></l>
             <l>Ch'io dovessi partir senza mirarlo?</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l>(Se parlo, mi condanno, e se non parlo).</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="I">Perfido!</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="M">Non rispondi?</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="F">Or tutte intendo</l>
             <l part="I">Le trame tue. Sappi, Adriano...</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l part="F">E' vero,</l>
             <l>Signor, Sabina adoro, e, lei presente,</l>
             <l>Temei la tua virtù: perciò lontana...</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>Basta. Che tradimento! Anima rea!</l>
             <l>Tu rivale ad Augusto? Olà! costui</l>
             <l part="I">Sia custodito.</l>
           </sp>
-          <sp>
+          <sp who="#aquilio">
             <speaker>AQUI.</speaker>
             <l part="M">(Avverso Ciel!) <stage>(è disarmato</stage></l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F"> Né pensi</l>
             <l part="I">La mia sposa a partir.</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="M">Tua sposa!</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Io sento</l>
             <l>Che risano a gran passi. Il dover mio,</l>
@@ -3114,41 +3139,41 @@
         <div type="scene">
           <head>SCENA ULTIMA</head>
           <stage>EMIRENA, FARNASPE e detti.</stage>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="I">Ah, Cesare, pietà!</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Pietà, signore!</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l>Rendimi il padre mio.</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="I">Conservami il mio re.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">Rendilo; e poi</l>
             <l part="I">Eccomi tua, se vuoi.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="M">Che?</l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l part="F">Sì: ti cedo</l>
             <l part="I">L'impero di quel cor.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="M">Tu?</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="F">Sì: sarai</l>
             <l>Tu il nume mio. Per quel sereno, il giuro,</l>
@@ -3158,42 +3183,42 @@
             <l>Ch'è sostegno del mondo,</l>
             <l part="I">Ch'io bacio... <stage>(s'inginocchia</stage></l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F">Ah! sorgi: ah! taci. (E' donna o dea?</l>
             <l>Quando m'innamorò, così piangea).</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l>(Qual contrasto in quel petto</l>
             <l>Fan l'onore e l'affetto!)</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>(Se alla ragione io cedo,</l>
             <l>Perdo Emirena; e se all'amor mi fido,</l>
             <l>La mia Sabina uccido. Ah, qual cimento,</l>
             <l>Qual angustia crudele!)</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l>(E pur mi fa pietà, benché infedele).</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="I">Cesare, e non risolvi?</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="F">Augusto, al fine...</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>Ah! per pietà non tormentarmi. Io tutto</l>
             <l>Quanto dir mi potrai,</l>
             <l part="I">Tutto, Sabina, io so.</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="F">No, non lo sai:</l>
             <l>Odi. Troppo fatali</l>
@@ -3207,15 +3232,15 @@
             <l>Ti perdono ogni offesa;</l>
             <l>Ed io stessa sarò la tua difesa.</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="I">Come! <stage>(stupido</stage></l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l part="M">Cesare, addio. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F"><stage>(arrestandola)</stage> Fermati. Oh grande!</l>
             <l>Oh generosa! oh degna</l>
@@ -3237,20 +3262,20 @@
             <l>D'ogni fallo commesso;</l>
             <l>E a te, degno di te, rendo me stesso. <stage>(a Sabina</stage></l>
           </sp>
-          <sp>
+          <sp who="#farnaspe">
             <speaker>FARN.</speaker>
             <l>Oh contento improvviso!</l>
           </sp>
-          <sp>
+          <sp who="#sabina">
             <speaker>SAB.</speaker>
             <l>Ecco il vero Adriano: or lo ravviso.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l>Fin ch'io respiri, Augusto,</l>
             <l>Grata quest'alma a' benefizi tuoi...</l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l>Se grata esser mi vuoi, lasciami ormai</l>
             <l>La pace del mio cor. Poco è sicura,</l>
@@ -3260,11 +3285,11 @@
             <l>E tutti tre spargete</l>
             <l>Questi deliri miei d'eterno oblio.</l>
           </sp>
-          <sp>
+          <sp who="#emirena">
             <speaker>EMIR.</speaker>
             <l part="I">Almen, signor... <stage>(volendogli baciar la mano</stage></l>
           </sp>
-          <sp>
+          <sp who="#adriano">
             <speaker>ADRI.</speaker>
             <l part="F"><stage>(non soffrendolo)</stage> Basta, Emirena. Addio.</l>
           </sp>

--- a/tei/metastasio-alessandro-nell-indie.xml
+++ b/tei/metastasio-alessandro-nell-indie.xml
@@ -75,6 +75,31 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="poro">
+            <persName>Poro</persName>
+          </person>
+          <person xml:id="gandarte">
+            <persName>Gandarte</persName>
+          </person>
+          <person xml:id="timagene">
+            <persName>Timagene</persName>
+          </person>
+          <person xml:id="alessandro">
+            <persName>Alessandro</persName>
+          </person>
+          <person xml:id="erissena">
+            <persName>Erissena</persName>
+          </person>
+          <person xml:id="cleofide">
+            <persName>Cleofide</persName>
+          </person>
+          <personGrp xml:id="coro">
+            <name>Coro de' baccanti</name>
+          </personGrp>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Pavia</name>Digitalizzazione</change>
@@ -126,7 +151,7 @@
           <head>SCENA PRIMA</head>
           <stage>Campo di battaglia sulle rive dell'Idaspe. Tende, carri rovesciati, soldati dispersi, armi, insegne ed altri avanzi dell'esercito di Poro disfatto da Alessandro.</stage>
           <stage>Terminata la sinfonia, s'ode strepito d'armi e di stromenti militari. Nell'alzar della tenda veggonsi soldati che fuggono. PORO con ispada nuda, indi GANDARTE</stage>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l>Fermatevi, codardi! Ah! con la fuga</l>
             <l>Mal si compra una vita. A chi ragiono?</l>
@@ -141,7 +166,7 @@
             <l>L'acquisto di quel core</l>
             <l part="I">Sino all'ultimo dì.</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="F">Prendi, signore, <stage>(frettoloso e porgendo il proprio elmo a Poro</stage></l>
             <l>Prendi, e il real tuo serto</l>
@@ -149,23 +174,23 @@
             <l>La schiera ostil. Deh! non tardar. S'inganni</l>
             <l part="I">Il nemico così.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Ma il tuo periglio?</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l>E' periglio privato. In me non perde</l>
             <l>L'India il suo difensor. Porgi, t'affretta:</l>
             <l part="I">Non abbiam che un istante.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Ecco, o mio fido, <stage>(si leva il proprio cimiero e lo pone sul capo a Gandarte</stage></l>
             <l>Sul tuo crine il mio serto. Ah, sia presagio</l>
             <l>Di grandezze future.</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l>E vengano con lui le tue sventure. <stage>(parte</stage></l>
           </sp>
@@ -173,33 +198,33 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>PORO, poi TIMAGENE con ispada nuda e séguito de' Greci, indi ALESSANDRO</stage>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l>In vano, empia fortuna,</l>
             <l>Il mio coraggio indebolir tu credi. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l>Guerrier, t'arresta, e cedi</l>
             <l>Quell'inutile acciaro. E' più sicuro</l>
             <l>Col vincitor pietoso inerme il vinto.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l>Pria di vincermi, oh quanto</l>
             <l>E di periglio e di  sudor ti resta!</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l>Su, Macedoni, a forza</l>
             <l part="I">L'audace si disarmi.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F"><stage>(volendo difendersi, gli cade la spada)</stage>Ah stelle ingrate!</l>
             <l part="I">Il ferro m'abbandona.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Olà, fermate.</l>
             <l>Abbastanza fin ora</l>
@@ -208,19 +233,19 @@
             <l>Vincitor che ne abusa. <stage>(a Timagene)</stage> I miei seguaci</l>
             <l>Abbian virtude alla fortuna eguale.</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="I">Fia legge il tuo voler. <stage>(parte</stage></l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">(Questi è il rivale).</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="I">Guerrier, dimmi: chi sei?</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Nacqui sul Gange;</l>
             <l>Vissi fra l'armi; Asbite ho nome: ancora</l>
@@ -228,12 +253,12 @@
             <l>Amar la gloria è mio costume antico;</l>
             <l>Son di Poro seguace e tuo nemico.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>(Oh ardire! oh fedeltà!) Qual è di Poro</l>
             <l part="I">L'indole, il genio?</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">E' degno</l>
             <l>D'un guerriero e d'un re. La tua fortuna</l>
@@ -242,13 +267,13 @@
             <l>Colà su l'are istesse,</l>
             <l>Che il timor de' mortali offre al tuo nome.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>In India eroe sì grande</l>
             <l>E' germoglio straniero. In greca cuna</l>
             <l>D'esser nato il tuo re degno saria.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l>Credi dunque che sia</l>
             <l>Il ciel di Macedonia</l>
@@ -256,7 +281,7 @@
             <l>La gloria è cara e la virtù s'onora:</l>
             <l>Ha gli Alessandri suoi l'Idaspe ancora.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>Valoroso guerriero, al tuo signore</l>
             <l>Libero torna, e digli</l>
@@ -265,13 +290,13 @@
             <l>Poi torni a' regni sui:</l>
             <l>Altra ragion non mi riserbo in lui.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l>Vinto si chiami! E ambasciador mi vuoi</l>
             <l>Di simili proposte?</l>
             <l>Poco opportuno ambasciador scegliesti.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>Ma degno assai. <stage>(a' Greci)</stage> Si lasci</l>
             <l>Libero il varco al prigionier. Ma inerme</l>
@@ -280,7 +305,7 @@
             <l>Che la man d'Alessandro a te presenta;</l>
             <l>E, lei trattando, il donator rammenta. <stage>(Poro prende la spada da Alessandro, al quale una comparsa ne presenta subito un'altra</stage></l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <lg>
               <l>Vedrai con tuo periglio</l>
@@ -298,51 +323,51 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>ALESSANDRO, poi TIMAGENE con ERISSENA incatenata, due Indiani e séguito</stage>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>Oh ammirabile sempre,</l>
             <l>Anche in fronte a' nemici,</l>
             <l>Carattere d'onor! Quel core audace,</l>
             <l>Perché fido al suo re, minaccia e piace.</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l>Questa, che ad Alessandro</l>
             <l>Prigioniera donzella offre la sorte,</l>
             <l part="I">Germana è a Poro.</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="F">(Oh dèi!</l>
             <l part="I">D'Erissena che fia!)</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Chi di quei lacci</l>
             <l part="I">L'innocente aggravò?</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="F">Questi di Poro</l>
             <l>Sudditi per natura,</l>
             <l>Per genio a te. Fu lor disegno offrirti</l>
             <l part="I">Un mezzo alla vittoria.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Indegni! Il ciglio</l>
             <l>Rasciuga, o principessa. Ad Alessandro</l>
             <l>Persuade rispetto il tuo sembiante.</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="I">(Che dolce favellar!)</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="F">(Son quasi amante).</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>Agli empi, o Timagene,</l>
             <l>Si raddoppino i lacci</l>
@@ -350,17 +375,17 @@
             <l>Gl'infidi ed Erissena:</l>
             <l>Questa alla libertà, quelli alla pena. <stage>(due comparse sciolgono Erissena ed incatenano gl'Indiani</stage></l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="I">Generosa pietà!</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="F">Signor, perdona:</l>
             <l>Se Alessandro foss'io, direi che molto</l>
             <l>Giova se resta in servitù costei.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>S'io fossi Timagene anche il direi.</l>
             <lg>
@@ -379,20 +404,20 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>ERISSENA e TIMAGENE</stage>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l>(Oh rimprovero acerbo,</l>
             <l part="I">Che irrìta l'odio mio!)</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="F">Questo è Alessandro?</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="I">E' questo.</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="F">Io mi credea</l>
             <l>Che avessero i nemici</l>
@@ -400,69 +425,69 @@
             <l>Più fiero il cor. Ma sono</l>
             <l part="I">Tutti i Greci così?</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="F">(Semplice!) Appunto.</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l>Quanto invidio la sorte</l>
             <l>Delle greche donzelle! Almen fra loro</l>
             <l part="I">Fossi nata ancor io!</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="F">Che aver potresti</l>
             <l>Di più vago, nascendo in altra arena?</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l>Avrebbe un Alessandro anche Erissena.</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l>Se le greche sembianze</l>
             <l>Ti son grate così, l'affetto mio</l>
             <l>Posso offrirti, se vuoi: son greco anch'io.</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="I">Tu greco ancor?</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="F">Sotto un istesso cielo</l>
             <l>Spuntò la prima aurora</l>
             <l>A' giorni d'Alessandro, a' giorni miei.</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l>Non è greco Alessandro, o tu nol sei.</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l>Dimmi almen qual ragione</l>
             <l>Sì diverso da me lo renda mai.</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l>Ha in volto un non so che, che tu non hai.</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l>(Che pena!) Ah! già per lui</l>
             <l>Fra gli amorosi affanni</l>
             <l part="I">Dunque vive Erissena!</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="M">Io?</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="M">Sì.</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="F">T'inganni.</l>
             <lg>
@@ -513,7 +538,7 @@
           <head>SCENA SESTA</head>
           <stage>Recinto di palme e cipressi con picciolo tempio nel mezzo, dedicato a Bacco, nella reggia di Cleofide.</stage>
           <stage>CLEOFIDE con séguito, indi PORO</stage>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Perfidi! qual riparo, <stage>(alle comparse</stage></l>
             <l>Qual rimedio adoprar? Mancando ogni altro,</l>
@@ -529,32 +554,32 @@
             <l>Furie, che in sen sì facilmente aduna,</l>
             <l>Che il valor d'Alessandro e la fortuna.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l>(Ecco l'infida!) Io vengo,</l>
             <l>Regina, a te di fortunati eventi</l>
             <l part="I">Felice apportator.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F"><stage>(rasserenandosi)</stage> Numi! respiro.</l>
             <l part="I">Che rechi mai?</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F"><stage>(come sopra, con ironia)</stage> Per Alessandro al fine</l>
             <l>Si dichiarò la sorte. Esulta: avrai</l>
             <l>Dell'Oriente oppresso <stage>(Cleofide si turba</stage></l>
             <l>A momenti al tuo piè tutti i trofei.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Così m'insulti? Oh dèi! Dunque saranno</l>
             <l>Eterne le dubbiezze</l>
             <l>Del geloso tuo cor? Fidati, o caro,</l>
             <l part="I">Fidati pur di me.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Di te si fida</l>
             <l>Anche Alessandro. E chi può dir qul sia</l>
@@ -564,7 +589,7 @@
             <l>Hai le sue forze indebolite e dome.</l>
             <l>E creder deggio? e ho da fidarmi? e come?</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Ingrato, hai poche prove</l>
             <l>Della mia fedeltà? Comparve appena</l>
@@ -582,11 +607,11 @@
             <l>De' miei sudditi il sangue, il regno mio;</l>
             <l part="I">E non ti basta? e non mi credi?</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F"><stage>(commosso)</stage> (Oh Dio!)</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Tollerar non posso</l>
             <l>Così barbari oltraggi.</l>
@@ -597,49 +622,49 @@
             <l>Le tue furie una volta</l>
             <l part="I">Finiranno così.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Fermati; ascolta.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="I">Che dir mi puoi?</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Che a gran ragion t'offende</l>
             <l part="I">Il geloso amor mio.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F">Questo è un amore</l>
             <l part="I">Peggior dell'odio.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Io ti prometto, o cara,</l>
             <l>Che mai più di tua fede</l>
             <l part="I">Dubitar non saprò.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F">Queste promesse</l>
             <l>Mille volte facesti, e mille volte</l>
             <l part="I">Tornasti a vacillar.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Se mai di nuovo</l>
             <l>Io ti credo infedel, per mio tormento</l>
             <l>Altra fiamma t'accenda,</l>
             <l>E vera in te l'infedeltà si renda.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Ancor non m'assicuro:</l>
             <l part="I">Giuralo.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">A tutti i nostri dèi lo giuro.</l>
             <lg>
@@ -652,31 +677,31 @@
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>ERISSENA accompagnata da Macedoni, e detti.</stage>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Erissena! Che veggo!</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="I">Come! Tu nella reggia?</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="F">Un tradimento</l>
             <l>Mi portò fra' nemici, e un atto illustre</l>
             <l>Del vincitor pietoso a voi mi rende.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Che ti disse Alessandro? <stage>(Poro si turba</stage></l>
             <l part="I">Parlò di me?</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F"><stage>(si corregge)</stage> (Ma questa</l>
             <l part="I">E' innocente richiesta).</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="F">I detti suoi</l>
             <l>Ridirti non saprei: so che mi piacque;</l>
@@ -687,20 +712,20 @@
             <l>Serba la sua bellezza, e l'alma grande</l>
             <l>In ogni sguardo suo tutta si vede.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l>Cleofide da te questo non chiede. <stage>(con isdegno ad Erissena</stage></l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Ma giova questo ancora</l>
             <l>Forse a' disegni miei.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l>(Ah, non torniamo a dubitar di lei).</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Macedoni guerrieri,</l>
             <l>Tornate al vostro re: ditegli quanto</l>
@@ -709,42 +734,42 @@
             <l>Tra le falangi armate</l>
             <l part="I">Cleofide verrà.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Come! Fermate. <stage>(a' Macedoni con impeto</stage></l>
             <l part="I">Tu ad Alessandro? <stage>(a Cleofilde, turbato</stage></l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F">E che perciò? Non vedo</l>
             <l part="I">Ragion di meraviglia.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F"><stage>(come sopra)</stage> In questa guisa</l>
             <l>Il tuo decoro, il nome tuo si oscura.</l>
             <l part="I">L'India che mai dirà?</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F">Questa è mia cura.</l>
             <l part="I">Partite. <stage>(a' Macedoni che partono</stage></l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="M">(Io smanio).</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F">Ah, non vorrei che fosse</l>
             <l>Il tuo soverchio zelo</l>
             <l>Quel solito timor che t'avvelena.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l>Lo tolga il Cielo! <stage>(con tranquillità forzata</stage> (Oh giuramento! oh pena!)</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Siegui a fidarti: in questa guisa impegni</l>
             <l>A maggior fedeltà gli affetti miei.</l>
@@ -766,7 +791,7 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>PORO, ERISSENA, indi GANDARTE</stage>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l>Dèi, che tormento è questo!</l>
             <l>Va Cleofide al campo, ed io qui resto!</l>
@@ -774,15 +799,15 @@
             <l>Serva di qualche inciampo</l>
             <l part="I">La mia presenza. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="M">Ove, signore?</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Al campo.</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l>Ferma! non è ancor tempo. Io non in vano</l>
             <l>Tardai fin or. Questo real diadema</l>
@@ -791,32 +816,32 @@
             <l>Nemico d'Alessandro. Assai da lui</l>
             <l part="I">Noi possiamo sperare.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Or non è questa</l>
             <l>La mia cura maggiore. Al greco duce</l>
             <l part="I">Cleofide s'invia.</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="F">Ma che paventi?</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="I">Che figuri perciò?</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Mille figuro</l>
             <l>Immagini crudeli</l>
             <l>D'infedeltà, vezzi, lusinghe, sguardi.</l>
             <l part="I">Che posso dir?</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="M">Ma saran finti.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Addio.</l>
             <l>Fingendo s'incomincia. Ah, non sapete</l>
@@ -827,73 +852,73 @@
         <div type="scene">
           <head>SCENA NONA</head>
           <stage>ERISSENA e GANDARTE</stage>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l>Principessa adorata, allor che intesi</l>
             <l>Te prigioniera, il mio dolor fu estremo:</l>
             <l>Or che sciolta ti vedo,</l>
             <l part="I">Credimi, estremo è il mio piacer.</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="F">Lo credo.</l>
             <l>Dimmi: vedesti in su gli opposti lidi</l>
             <l part="I">Dell'Idaspe Alessandro?</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="F">Ancor nol vidi.</l>
             <l>E tu provasti mai</l>
             <l part="I">Alcun timor ne' miei perigli?</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="F">Assai.</l>
             <l>Se Alessandro una volta</l>
             <l part="I">Giungi a veder...</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="F">M'è noto. Ah, più di lui</l>
             <l>Or non parliam. Dimmi che m'ami: i pegni</l>
             <l>Rinnova di tua fé; dimmi che anela</l>
             <l>Il tuo bel core all'imeneo promesso.</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l>Eh! non è già l'istesso</l>
             <l>Il vedere Alessandro</l>
             <l>Che udirne ragionar. Qualunque vanto</l>
             <l part="I">Spiegar non può...</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="F">Ma tanto</l>
             <l>Parlar di lui che mai vuol dir? Pavento,</l>
             <l>Cara (sia con la tua pace),</l>
             <l part="I">Che Alessandro ti piaccia.</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="F">E' ver: mi piace.</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l>Dunque, così, tiranna,</l>
             <l part="I">Mi deridi, m'inganni?</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="F">E chi t'inganna?</l>
             <l part="I">San gli dèi ch'io non fingo.</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="F">Allor fingevi</l>
             <l>Dunque, o crudel, che del tuo core amante</l>
             <l>Mi giuravi il possesso.</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l>Allora io non fingea: non fingo adesso. <stage>(parte</stage></l>
           </sp>
@@ -933,18 +958,18 @@
           <head>SCENA UNDICESIMA</head>
           <stage>Gran padiglione d'Alessandro vicino all'Idaspe. Vista della reggia di Cleofide su l'altra sponda del fiume.</stage>
           <stage>ALESSANDRO e TIMAGENE, guardie dietro al padiglione.</stage>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>Pur troppo, amico, è vero: ama Alessandro;</l>
             <l>E nel suo cor trionfa</l>
             <l part="I">Cleofide già vinta.</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="F">Eccola: a lei</l>
             <l part="I">Offri e dimanda amore.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Amor! T'inganni:</l>
             <l>Alessandro sì presto</l>
@@ -956,7 +981,7 @@
           <head>SCENA DODICESIMA</head>
           <stage>Nel tempo d'una breve sinfonia si vedono venire diverse barche pel fiume, dalle quali scendono molti Indiani, portando diversi doni; e dalla principale sbarca CLEOFIDE, che viene incontrata da ALESSANDRO.</stage>
           <stage>CLEOFIDE e detti.</stage>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Ciò ch'io t'offro, Alessandro,</l>
             <l>E' quanto di più raro,</l>
@@ -968,7 +993,7 @@
             <l>All'amistà dovuto:</l>
             <l>Se suddita mi brami, ecco un tributo.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>Da' sudditi io non chiedo</l>
             <l>Altr'omaggio che fede, e dagli amici</l>
@@ -978,45 +1003,45 @@
             <l>Timagene, alle navi</l>
             <l>Tornino que' tesori. <stage>(Timagene si ritira, dando ordine agl'Indiani che tornino su le navi coi doni</stage></l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Ah! mel predisse il cor. Questo disprezzo</l>
             <l>Giustifica il mio pianto. <stage>(piange</stage></l>
             <l>L'esserti... odiosa... tanto...</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>Ma non è ver. Sappi... t'inganni... Oh Dio!</l>
             <l>(M'uscì quasi da' labbri idolo mio).</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Signor, rimanti in pace. A me non lice</l>
             <l>Miglior sorte sperar de' doni miei:</l>
             <l>Più di quelli importuna io ti sarei. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>T'arresta. <stage>(arrestandola)</stage> Ah! mal, regina,</l>
             <l>Interpreti il mio cor. Siedi e ragiona.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="I">Ubbidirò.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">(Che amabile sembianza!)</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="I">(Mie lusinghe, alla prova). <stage>(siedono</stage></l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">(Alma, costanza).</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>In faccia ad Alessandro</l>
             <l>Mi perdo, mi confondo; e non so come...</l>
@@ -1025,40 +1050,40 @@
         <div type="scene">
           <head>SCENA TREDICESIMA</head>
           <stage>TIMAGENE e detti.</stage>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l>Monarca, il duce Asbite</l>
             <l>Chiede a nome di Poro</l>
             <l part="I">Di presentarsi a te.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="M">(Numi!)</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Fra poco</l>
             <l part="I">Verrà: per or con la regina...</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="F">Appunto</l>
             <l>Inanzi a lei di ragionar desia.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="I">Venga. <stage>(Timagene parte</stage></l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F">(Poro l'invia!</l>
             <l part="I">Chi è mai costui!)</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">T'è noto il suo pensiero?</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Signor, l'ignoro, e non so dirti il vero.</l>
           </sp>
@@ -1066,15 +1091,15 @@
         <div type="scene">
           <head>SCENA QUATTORDICESIMA</head>
           <stage>PORO e detti.</stage>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="I">(Eccola: oh gelosia!)</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="M">(Poro!)</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Perdona,</l>
             <l>Cleofide, s'io vengo</l>
@@ -1082,99 +1107,99 @@
             <l>Più breve io figurai; ma d'Alessandro</l>
             <l>Piacevole è il soggiorno e di te degno.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>(Già di nuovo è geloso! Ardo di sdegno).</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>Parla, Asbite: che chiede</l>
             <l part="I">Poro da me?</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Le offerte tue ricusa,</l>
             <l part="I">Né vinto ancor si chiama.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">E ben, di nuovo</l>
             <l part="I">Tenti la sorte sua.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F">Signor, sospendi</l>
             <l>La tua credenza: Asbite</l>
             <l>Forse non ben comprese</l>
             <l part="I">Di Poro i detti.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="M">Anzi son questi.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F">Eh! taci.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="I">No: lo pretendi in van.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F">(Per suo castigo</l>
             <l>Abbia ragion d'ingelosirsi). Il passo,</l>
             <l>Amico o vincitor, qual più ti piace,</l>
             <l part="I">Volgi, signore, alla mia reggia.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">(Ah, infida!)</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Più dell'Idaspe il varco</l>
             <l>Non ti sarà conteso, e là saprai</l>
             <l>Meglio tutti di Poro i sensi e i miei.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l>Non fidarti a costei:</l>
             <l>E' avezza ad ingannar. Grato a' tuoi doni,</l>
             <l part="I">Io ti deggio avvertir.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="M">(Che soffro!)</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Asbite,</l>
             <l part="I">Sei troppo audace.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Io n'ho ragion: conosco</l>
             <l>Cleofide e il mio re. Da lei tradito...</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Non udirlo, o signor; nol merta: i primi</l>
             <l>Oltraggi non son questi,</l>
             <l part="I">Ch'io soffro da costui.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="M">(Perfida!)</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F">Accetti,</l>
             <l>Alessandro, l'invito?</l>
             <l>Qual risposta mi rendi?</l>
             <l part="I">Che ho da sperar? Verrai?</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Verrò: m'attendi.</l>
           </sp>
@@ -1182,72 +1207,72 @@
         <div type="scene">
           <head>SCENA QUINDICESIMA</head>
           <stage>PORO e CLEOFIDE.</stage>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l>Lode agli dèi! Son persuaso al fine</l>
             <l part="I">Della tua fedeltà. <stage>(con ironia</stage></l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F"><stage>(come sopra)</stage> Lode agli dèi!</l>
             <l>Poro di me si fida,</l>
             <l part="I">Più geloso non è.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Dov'è chi dice</l>
             <l>Che un femminil pensiero</l>
             <l part="I">Dell'aura è più leggiero?</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F">Ov'è chi dice</l>
             <l>Che più del mare un sospettoso amante</l>
             <l>E' torbido e incostante?</l>
             <l part="I">Io non lo credo.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Ed io</l>
             <l part="I">Nol posso dir.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F">Mi disinganna assai...</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l>Mi convince abbastanza...</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="I">La placidezza tua...</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">La tua costanza.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Ricordo il giuramento.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l>La promessa rammento.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="I">Si conosce...</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Si vede...</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="I">Che placido amator!</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Che bella fede!</l>
             <lg>
@@ -1256,7 +1281,7 @@
               <l>Pace mai non abbia il cor.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <lg part="M">
               <l>Se mai più sarò geloso,</l>
@@ -1264,13 +1289,13 @@
               <l>Che dell'India è domator.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <lg part="M">
               <l>Infedel! questo è l'amore?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <lg part="M">
               <l>Menzogner! questa è la fede?</l>
@@ -1283,14 +1308,14 @@
               <l>Che lo possa un dì provar!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <lg part="M">
               <l>Per chi perdo, o giusti dèi,</l>
               <l>Il riposo de' miei giorni!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <lg part="M">
               <l>A chi mai gli affetti miei,</l>
@@ -1312,12 +1337,12 @@
           <head>SCENA PRIMA</head>
           <stage>Gabinetti reali.</stage>
           <stage>PORO e GANDARTE</stage>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l>E passerà l'Idaspe</l>
             <l>L'aborrito rival senza contesa?</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l>No, mio re. Per tuo cenno</l>
             <l>Già radunai gran parte</l>
@@ -1329,7 +1354,7 @@
             <l>Dell'esercito greco il ponte angusto</l>
             <l part="I">Ritarderà.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Benché da lui diviso</l>
             <l>L'esercito rimanga, avrà difesa.</l>
@@ -1337,7 +1362,7 @@
             <l>Lo precedono sempre</l>
             <l part="I">Gli argiraspidi suoi.</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="F">Fra questi appunto</l>
             <l>Seminò Timagene</l>
@@ -1357,7 +1382,7 @@
             <l>Qua il duce resterà. Compìto questo,</l>
             <l>Al fato e al tuo valor si fidi il resto.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l>L'unico ben, ma grande,</l>
             <l>Che riman fra' disastri agl'infelici,</l>
@@ -1370,7 +1395,7 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>ERISSENA e detti.</stage>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l>Poro, Gandarte, arriva</l>
             <l>Alessandro a momenti. Un greco messo</l>
@@ -1381,26 +1406,26 @@
             <l>De' stranieri metalli; e fra le schiere</l>
             <l>Vidi all'aura ondeggiar mille bandiere.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l>E Cleofide intanto</l>
             <l part="I">Che fa?</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="M">Corre a incontrarlo.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Ingrata! Amico,</l>
             <l>Vanne, vola e m'attendi</l>
             <l part="I">Al destinato loco.</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="F">E tu non vieni?</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l>Sì; ma prima all'infida</l>
             <l>Voglio recar su gli occhi</l>
@@ -1408,17 +1433,17 @@
             <l>Un'altra volta almeno</l>
             <l>Voglio dirle infedele, e poi son pago.</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l>E tu pensi a costei? L'onor ti chiama</l>
             <l>A più degni cimenti.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l>Va, Gandarte; a momenti</l>
             <l>Raggiungo i passi tuoi.</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l>(Oh amor sempre tiranno, anche agli eroi!) <stage>(parte</stage></l>
           </sp>
@@ -1426,35 +1451,35 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>PORO ed ERISSENA</stage>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l>Germano, anch'io vorrei trovarmi in campo</l>
             <l part="I">D'Alessandro all'arrivo.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">In van lo brami.</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="I">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="M">Non più. Lasciami solo.</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="F">E quale</l>
             <l part="I">Ragione il vieta?</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">A una real donzella</l>
             <l>Andar così fra l'armi,</l>
             <l>Come lice a un guerrier, non è permesso.</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l>Misera servitù del nostro sesso! <stage>(parte</stage></l>
           </sp>
@@ -1490,7 +1515,7 @@
           <stage>Campagna sparsa di fabbriche antiche con tende ed alloggiamenti militari preparati da Cleofide per l'esercito greco Ponte sull'Idaspe. Campo numeroso d'Alessandro, disposto in ordinanza di là dal fiume, con elefanti, torri, carri coperti e macchine da guerra.</stage>
           <stage>Nell'apertura della scena s'ode sinfonia di stromenti militari, nel tempo della quale passa il ponte una parte de' soldati greci, ed appresso a loro ALESSANDRO con TIMAGENE: poi sopraggiunge CLEOFIDE ad incontrarlo.</stage>
           <stage>CLEOFIDE, ALESSANDRO, TIMAGENE; indi GANDARTE</stage>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Signor, l'India festiva</l>
             <l>Esulta al tuo passaggio, e lieta tanto</l>
@@ -1500,66 +1525,66 @@
             <l>Di pampini frondosi allegra plebe,</l>
             <l>Su le tigri di Nisa il dio di Tebe.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>Siano accenti cortesi, o sian veraci</l>
             <l>Sensi del cor, di tua gentil favella</l>
             <l>Mi compiaccio, o regina; e solo ho pena</l>
             <l>Che fu all'India funesto il brando mio.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Eh vadano in oblio</l>
             <l>Le passate vicende: ormai sicuro</l>
             <l part="I">Puoi riposar su le tue palme. <stage>(si sente di dentro rumore d'armi</stage></l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Ascolto</l>
             <l part="I">Strepito d'armi.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F">Oh stelle!</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="I">Timagene, che fu?</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="F">Poro si vede</l>
             <l>Fra non pochi seguaci</l>
             <l part="I">Apparir minaccioso.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F">(Ah, troppo veri</l>
             <l part="I">Voi foste, o miei timori!)</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">E ben, regina,</l>
             <l>Io posso ormai sicuro</l>
             <l part="I">Su le palme posar?</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F">Se colpa mia,</l>
             <l part="I">Signor...</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Di questa colpa</l>
             <l>Si pentirà chi, disperato e folle,</l>
             <l>Tante volte irritò gli sdegni miei. <stage>(Alessandro snuda la spada, e seco Timagene, e vanno verso il ponte</stage></l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>L'amato ben voi difendete, o dèi.</l>
           </sp>
           <stage>(Entrata Cleofide, si vedono uscir con impeto gl'Indiani da' lati della scena vicino al fiume. Questi assalgono i Macedoni. Poro assale Alessandro. Gandarte con pochi seguaci corre sul mezzo del ponte ad impedire il passo all'esercito greco. E intanto che segue la zuffa nel piano, alcuni guastatori vanno diroccando il suddetto ponte. Disviati i combattenti fra le scene, si vede vacillare e poi cadere parte del ponte. Quei Macedoni che combattevano su l'altra sponda si ritirano intimoriti dalla caduta; e Gandarte rimane con alcuni de' suoi compagni in cima alle ruine.</stage>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l>Seguitemi, o compagni: unico scampo</l>
             <l>E' quello ch'io v'addito. <stage>(getta la spada ed il cimiero nel fiume</stage> Ah secondate,</l>
@@ -1571,19 +1596,19 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>CLEOFIDE dalla destra, preceduta da PORO senza spada.</stage>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Ma per pietà, ben mio,</l>
             <l>Non più sospetti. Io t'amo;</l>
             <l>Non amo altro che te: penso a salvarti,</l>
             <l part="I">Quando soffro Alessandro.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Oh Dio! vorrei</l>
             <l part="I">Prestarti fé.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F"> Ma per prestarmi fede</l>
             <l>Quai pegni vuoi da me? T'adoro ingrato;</l>
@@ -1597,38 +1622,38 @@
             <l>Vindice e testimonio il Ciel ne sia.</l>
             <l>Poro, dammi la destra; ecco la mia.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l>Oh destra! oh sposa! oh me felice! Io fui</l>
             <l>Un ingiusto fin or: perdono, o cara. <stage>(inginocchiandosi</stage></l>
             <l>Qualunque fallo antico...</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Aimè! Sorgi, mia vita; ecco il nemico. <stage>(spaventata</stage></l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="I">Dove?</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="M">Colà.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Quest'altra via... Ma quindi</l>
             <l>Pur s'appressan guerrieri. Agl'infelici</l>
             <l>Son pur brevi i contenti!</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Sposo, ah, non v'è più scampo. A tergo il fiume;</l>
             <l>Alessandro ci arresta</l>
             <l>In quella parte, e Timagene in questa.</l>
             <l part="I">Eccoci prigioniri.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Oh dèi! Vedrassi</l>
             <l>La consorte di Poro</l>
@@ -1638,12 +1663,12 @@
             <l>Qual talamo novello... Ah, ch'io mi sento</l>
             <l part="I">Mille furie nel sen.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F">Poro, è perduta</l>
             <l>Per noi dunque ogni speme?</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l>No; ci resta una via: si mora insieme. <stage>(Poro snuda uno stile, ed alza il braccio in atto di ferirla</stage></l>
           </sp>
@@ -1651,35 +1676,35 @@
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>ALESSANDRO che, uscendo alle spalle di PORO, lo trattiene e lo disarma; soldati greci, e detti.</stage>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="I">Crudel, t'arresta.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="M">(Aita, o stelle!)</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F"><stage>(a Poro</stage> E donde</l>
             <l>Tanto ardimento e tanta</l>
             <l part="I">Temerità!</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F">Signor, la morte mia</l>
             <l part="I">Di Poro è cenno.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="M">Io sono...</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F">Egli è di Poro</l>
             <l>Fedele esecutor. (Taci, ben mio). <stage>(piano a Poro</stage></l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l>No, più tempo, o regina,</l>
             <l>Di ritegni or non è. Sappi, Alessandro,</l>
@@ -1690,33 +1715,33 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>TIMAGENE e detti.</stage>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="F">Le greche schiere,</l>
             <l>Signor, vieni a sedar. Chiede ciascuno</l>
             <l>Di Cleofide il sangue: ognun la crede</l>
             <l part="I">Rea dell'insidia.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Ella è innocente: ignota</l>
             <l>Le fu la trama. Il primo autor son io:</l>
             <l>Tutto l'onor del gran disegno è mio.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="I">(Aimè!)</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Barbaro, e credi</l>
             <l part="I">Pregio l'infedeltà?</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F">Signor, s'io mai...</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>Abbastanza palese</l>
             <l>Per l'insulto d'Asbite</l>
@@ -1734,32 +1759,32 @@
         <div type="scene">
           <head>SCENA NONA</head>
           <stage>CLEOFIDE, PORO e TIMAGENE con guardie.</stage>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l>Macedoni, alla reggia</l>
             <l>Cleofidi si scorga; e intanto Asbite</l>
             <l part="I">Meco rimanga.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F">(In libertà potessi,</l>
             <l>Senza scoprirlo, almen dargli un addio).</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l>(Potessi all'idol mio</l>
             <l part="I">Libero favellar).</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F">De' casi miei,</l>
             <l part="I">Timagene, hai pietà?</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="F">Più che non credi.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Ah! se Poro mai vedi,</l>
             <l>Digli dunque per me che non si scordi,</l>
@@ -1783,22 +1808,22 @@
         <div type="scene">
           <head>SCENA DECIMA</head>
           <stage>PORO e TIMAGENE</stage>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="I">(Tenerezze ingegnose!)</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="F">Amico Asbite,</l>
             <l part="I">Siam pur soli una volta.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">E con qual fronte</l>
             <l>Mi chiami amico? Al mio signor prometti</l>
             <l>Sedur parte de' Greci, e poi l'inganni!</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l>Non l'ingannai. Sedotti</l>
             <l>Gli argiraspidi avea: ma non so dirti</l>
@@ -1808,33 +1833,33 @@
             <l>Ultima quella schiera,</l>
             <l>Che doveva al passaggio esser primiera.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="I">Dubito di tua fè.</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="F">Qualunque prova</l>
             <l>Dimandane, e l'avrai. Va; la mia cura</l>
             <l>Prigionier non t'arresta.</l>
             <l>Libero sei: la prima prova è questa.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="I">Ma come ad Alessandro...</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="F">Ad Alessandro</l>
             <l>Creder farò che, disperato, a morte</l>
             <l part="I">Volontaria corresti.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">E di vendetta</l>
             <l part="I">Più speranza non v'è?</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="F">Sì: già inviai</l>
             <l>Un mio foglio al tuo re. Da quello istrutto,</l>
@@ -1843,36 +1868,36 @@
             <l>A svenar l'oppressore agio ed aita</l>
             <l part="I">Avrà da me.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Ma questo foglio a Poro</l>
             <l part="I">Non pervenne fin or.</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="F">No! Come il sai?</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l>Più non cercar; Poro non l'ebbe: io posso</l>
             <l part="I">Asserirlo per lui.</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="F">M'avesse mai</l>
             <l>Tradito il messaggier! Tremo. Ah, t'affretta,</l>
             <l>Asbite, a Poro: ah, s'ei non vien, ruina</l>
             <l>Tutto il disegno mio.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="I">Poro verrà: non dubitarne.</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="F">Addio. <stage>(parte</stage></l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l>Ricomincio a sperar. Da' lacci sciolto,</l>
             <l>L'impeto già de' miei furori ascolto.</l>
@@ -1896,7 +1921,7 @@
           <head>SCENA UNDICESIMA</head>
           <stage>Appartamenti nella reggia di Cleofide.</stage>
           <stage>CLEOFIDE e GANDARTE</stage>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>E' ver, tentò svenarmi,</l>
             <l>Ma per soverchio amor. Ma già che il Cielo</l>
@@ -1906,17 +1931,17 @@
             <l>Nessun rimane in libertà per noi.</l>
             <l part="I">Ei vien: parti.</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="F"> Non sia</l>
             <l part="I">Mai ver ch'io t'abbandoni.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F">Ah, dal suo ciglio</l>
             <l part="I">Celati per pietà.</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="F">Numi, consiglio. <stage>(si nasconde</stage></l>
           </sp>
@@ -1924,7 +1949,7 @@
         <div type="scene">
           <head>SCENA DODICESIMA</head>
           <stage>ALESSANDRO e detti.</stage>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>Per salvarti, o regina,</l>
             <l>Tentai frenar, ma in vano,</l>
@@ -1937,51 +1962,51 @@
             <l>Ogni schiera orgogliosa</l>
             <l>Una parte di me: sarai mia sposa.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Io sposa d'Alessandro? <stage>(sorpresa</stage></l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>E qual altro riparo,</l>
             <l>Quando un campo ribelle</l>
             <l part="I">Una vittima chiede?</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="M">Eccola. <stage>(si palesa</stage></l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F">(Oh stelle!)</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="I">Chi sei?</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="M">Poro son io.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Come fra questi</l>
             <l>Custoditi soggiorni</l>
             <l part="I">Giungesti a penetrar?</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="F">Per via nascosa,</l>
             <l>Che il passaggio assicura</l>
             <l>Dalle sponde del fiume a queste mura.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>E ben, che vuoi? Domandi</l>
             <l>Pietà, perdono? O ad insultar ritorni</l>
             <l part="I">L'infelice regina?</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="F">A che mi vai</l>
             <l>Rimproverando un disperato cenno,</l>
@@ -1998,19 +2023,19 @@
             <l>Le insidie, i tradimenti:</l>
             <l>Son Cleofide e Asbite ambo innocenti.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>(Oh coraggio! oh fortezza!)</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>(Oh fede che innamora!)</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l>(Il mio re si difenda, e poi si mora).</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>(E fia ver che mi vinca</l>
             <l>Un barbaro in virtù? No). Poro, ascolta:</l>
@@ -2019,11 +2044,11 @@
             <l>Che fra noi ti condusse,</l>
             <l>Allo sdegno de' Greci anche t'involi.</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l>E Cleofide intanto...</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>Cleofide è mia preda:</l>
             <l>Ritenerla potrei, potrei salvarla</l>
@@ -2033,15 +2058,15 @@
             <l>La tua grandezza e l'amor tuo comprendo;</l>
             <l>Onde a te (non so dirlo), a te la rendo.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="I">Oh clemenza!</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="M">Oh pietà!</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">D'Asbite io volo</l>
             <l>A disciogliere i lacci. Andate, amici;</l>
@@ -2067,69 +2092,69 @@
         <div type="scene">
           <head>SCENA TREDICESIMA</head>
           <stage>CLEOFIDE, GANDARTE; poi ERISSENA</stage>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Chi sperava, o Gandarte,</l>
             <l>Tanta felicità fra tanti affanni?</l>
             <l>Quanto dobbiamo a' tuoi pietosi inganni!</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l>Di vassallo e d'amico</l>
             <l>Ho compiuto il dover. Ma... Chi s'appressa?</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Sarà forse lo sposo.</l>
             <l part="I">Ah, no: giunge Erissena.</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="F">Oh, come asperso</l>
             <l part="I">Ha di lagrime il volto!</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F">Eh! Non è tempo</l>
             <l>Di pianto, o principessa. Andremo altrove</l>
             <l>A respirar con Poro aure felici.</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="I">Ah, che Poro morì.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="M">Come?</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="F">Che dici?</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="I">Mi ha tradita Alessandro!</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="F">Ei di se stesso</l>
             <l part="I">Fu l'uccisor.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F">Quando? Perché? Finisci</l>
             <l part="I">Di trafiggermi il cor. <stage>(con affanno e fretta</stage></l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="F">Sai che rimase,</l>
             <l>Creduto Asbite, a Timagene in cura...</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="I">E ben?</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="F">Cinto da' Greci,</l>
             <l>Lungo il fiume alle tende</l>
@@ -2139,25 +2164,25 @@
             <l>Fra lor la via s'aperse</l>
             <l>Si lanciò nell'Idaspe e si sommerse.</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l>Privo di te, servo de' Greci, in odio  <stage>(a Cleofide</stage></l>
             <l part="I">Ebbe Poro la vita.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F"><stage>(piangendo)</stage> I suoi furori</l>
             <l>Mi predicean qualche funesto eccesso.</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="I">Ma donde il sai?</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="F">Da Timagene istesso.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Che mi giovò su l'are</l>
             <l>Tante vittime offrirvi, ingiusti dèi?</l>
@@ -2167,7 +2192,7 @@
             <l>Tutti gli umani eventi, <stage>(con passione disperata</stage></l>
             <l>Vi usurpate il poter, numi impotenti!</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l>Ah, che dici, o regina! Un mal privato</l>
             <l>spesso è pubblico bene;</l>
@@ -2175,7 +2200,7 @@
             <l>Fuggi; torna in te stessa;</l>
             <l part="I">Pensa a salvarti.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F"><stage>(come sopra)</stage> A che fuggir? Qual danno</l>
             <l>Mi resta da temer? Lo sposo, il regno,</l>
@@ -2201,7 +2226,7 @@
         <div type="scene">
           <head>SCENA QUATTORDICESIMA</head>
           <stage>ERISSENA e GANDARTE</stage>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l>Adorata Erissena,</l>
             <l>Fra perdite sì grandi, ah, non si conti</l>
@@ -2209,7 +2234,7 @@
             <l>In più sicura parte:</l>
             <l>Tuo sposo e difensor sarà Gandarte.</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l>Vanne solo: io sarei</l>
             <l>D'impaccio al tuo fuggir. La mia salvezza</l>
@@ -2217,7 +2242,7 @@
             <l>Esser utile all'India. Anzi tu devi</l>
             <l>A favor degli oppressi usar la spada.</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l>E dove senza te speri ch'io vada?</l>
             <lg>
@@ -2263,7 +2288,7 @@
           <head>SCENA PRIMA</head>
           <stage>Portici de' giardini reali.</stage>
           <stage>CLEOFIDE ed ERISSENA</stage>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Ma lasciami, Erissena, <stage>(con noia</stage></l>
             <l>Respirar sola in pace. I passi miei</l>
@@ -2276,49 +2301,49 @@
             <l>Di vittima e di rogo or mi consola.</l>
             <l>Se altro non vuoi saper, lasciami sola.</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l>Che bella fedeltà! Ma con qual fronte</l>
             <l part="I">Al tempio andrai?</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F">V'andrò come conviene</l>
             <l part="I">A una sposa reale.</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="M">E Poro?</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F">E Poro</l>
             <l>Fin colà negli Elisi</l>
             <l part="I">Sarà pago di me.</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="F">Ma l'Asia tutta...</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="I">Tutta mia approverà.</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="F">Sì, veramente</l>
             <l part="I">Dell'Asia in te le spose avranno...</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F">Avranno</l>
             <l>Dell'Asia in me le spose esempio e guida.</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l>Arrossisco per te: spergiura! infida!</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Alle ingiurie, Erissena,</l>
             <l>Non trascorrer sì presto. Io ti vorrei</l>
@@ -2347,24 +2372,24 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>ERISSENA, poi TIMAGENE</stage>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l>E ostentar con tal fasto</l>
             <l part="I">Si può l'infedeltà!</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="F"><stage>(cercando per la scena, senza veder Erissena</stage> Poro non vedo.</l>
             <l part="I">Questa è pur l'ora, il loco è questo.</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="F"><stage>(senza veder Timagene</stage> E poi</l>
             <l>Ci lagneremo noi</l>
             <l>Se non credon gli amanti</l>
             <l>Alle nostre querele, a' nostri pianti!</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l>Se il mio foglio ei non ebbe,</l>
             <l>Asbite almen dovrebbe... <stage>(vede Erissena)</stage> Oh Ciel! chi mai</l>
@@ -2376,33 +2401,33 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>ALESSANDRO e detti.</stage>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F"><stage>(a Timagene)</stage> Ove t'affretti?</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="I">Signor... vado...: attendea...</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="M">Che mai?</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="F">L'istante</l>
             <l part="I">Di teco ragionar.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="M">Parla.</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="F">Vorrei...</l>
             <l part="I">(Stelle, ove son! Non trovo i detti).</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Intendo:</l>
             <l>Solo mi vuoi. Bella Erissena, e dove</l>
@@ -2412,7 +2437,7 @@
             <l>Ch'ella sarà mia sposa</l>
             <l>Prima che questo sol compisca il giro.</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l>Il so pur troppo; e il tuo bel core ammiro. <stage>(con dispetto, e parte</stage></l>
           </sp>
@@ -2420,12 +2445,12 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>ALESSANDRO e TIMAGENE</stage>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l>(Dèi: che m'avvenne mai! Gelar mi sento;</l>
             <l part="I">Mi trema il cor).</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F"><stage>(tutto senza sdegno)</stage> Siam soli:</l>
             <l>Ecco l'ora, ecco il loco, ecco Alessandro.</l>
@@ -2436,29 +2461,29 @@
             <l>All'onor di svenarmi</l>
             <l part="I">Non può sola aspirar?</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="F">Come! Io... svenarti?</l>
             <l>Ah! qual è quell'infame,</l>
             <l>Che ha questo in te nero sospetto impresso?</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="I">Vedilo. <stage>(gli dà il foglio da lui scritto a Poro</stage></l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="M">(Oh numi!) <stage>(abbattuto)</stage></l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">E' Timagene istesso.</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="I">Perfido messaggier!</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Come! Si lagna</l>
             <l>Della perfidia altrui</l>
@@ -2466,36 +2491,36 @@
             <l>D'esiger l'altrui fede</l>
             <l part="I">Qual diritto ha un traditore?</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="F">E pur, se vuoi</l>
             <l part="I">Ascoltar le mie scuse...</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Ah taci: aggravi</l>
             <l>Così la colpa tua. Reo, che convinto</l>
             <l>Va mendicando scusa,</l>
             <l>Sol del suo cor la pertinacia accusa.</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l>E' ver. Nel passo, a cui ridotto io sono, <stage>(disperato</stage></l>
             <l>Più difesa o perdono</l>
             <l>E' follia di sperar: tutto il tuo sdegno</l>
             <l>A vendicarti affretta.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>Alessandro vendetta! E sazio ancora</l>
             <l part="I">D'offendermi non sei?</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="F">Dovuto è questo</l>
             <l part="I">Mio sangue a te.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Ma che mi giova il sangue</l>
             <l>D'un traditore? Ah, se mi vuoi superbo</l>
@@ -2505,14 +2530,14 @@
             <l>Più pago di me stesso,</l>
             <l>Che Poro debellato e Dario oppresso.</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l>Oh delitto! oh perdono!</l>
             <l>Oh clemenza maggior de' falli miei! <stage>(inginocchiandosi con impeto e piangendo</stage></l>
             <l>Ma che resta agli dèi,</l>
             <l part="I">Se fa tanto un mortal?</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Sorgi! In quel pianto</l>
             <l>Già l'amico vegg'io. Sì bel rimorso</l>
@@ -2535,7 +2560,7 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>TIMAGENE indi PORO</stage>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l>Oh rimorso! oh rossore! E non m'ascondo,</l>
             <l>Misero! a' rai del dì? Con qual coraggio</l>
@@ -2543,51 +2568,51 @@
             <l>Se reo di questo eccesso,</l>
             <l>Orribile son io tanto a me stesso?</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l>(Qui Timagene, e solo!) Amico, il Cielo</l>
             <l part="I">Pur salvo a te mi guida.</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="F">Ah, fuggi, Asbite,</l>
             <l part="I">Fuggi da me.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Qui d'Alessandro il sangue</l>
             <l part="I">Non dobbiamo versar?</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="F">Prima si versi</l>
             <l part="I">Quello di Timagene.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">E la promessa?</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l>La promessa d'un fallo</l>
             <l part="I">Non obbliga a compirlo.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Infido! Ah dunque</l>
             <l>Tu più quel Timagene</l>
             <l part="I">Di poc'anzi non sei?</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="F">No, quello in seno</l>
             <l>Avea perfida l'alma, il cor rubello.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="I">Ed or...</l>
           </sp>
-          <sp>
+          <sp who="#timagene">
             <speaker>TIMAG.</speaker>
             <l part="F">Lode agli dèi, non è più quello.</l>
             <lg>
@@ -2606,7 +2631,7 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>PORO, poi GANDARTE, indi ERISSENA</stage>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l>Ecco spezzato il solo</l>
             <l>Debolissimo filo a cui s'attenne</l>
@@ -2615,32 +2640,32 @@
             <l>Di fortuna a soffrir gli scherni e l'ire?</l>
             <l>Ah! finisca una volta il mio martìre. <stage>(in atto di snudar la spada</stage></l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="I">Ferma! Sei tu, mio re? <stage>(trattenendolo)</stage></l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="F">Sei tu, germano?</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="I">Pur troppo io son.</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="F">La principessa estinto</l>
             <l>Ti dicea nell'Idaspe.</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l>L'asserì Timagene.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="I">E v'ingannò.</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="F">Ma quell'incerto sguardo,</l>
             <l>Quella pallida fronte,</l>
@@ -2648,23 +2673,23 @@
             <l>Che a un disperato affanno</l>
             <l>Il mio re s'abbandona, e non m'inganno.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l>E qual empio potrebbe</l>
             <l>Consigliarmi la vita in questo stato?</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l>Ah no, germano amato,</l>
             <l part="I">Non dir così; mi fai morir.</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="F">Non sia</l>
             <l>Di tua virtù maggiore</l>
             <l part="I">La tirannia degli astri.</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="F">Hai molti al fine</l>
             <l>Compagni al duol; né de' traditi amanti</l>
@@ -2672,95 +2697,95 @@
             <l>Cleofide è la prima,</l>
             <l part="I">Né l'ultima sarà.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="M"><stage>(sorpreso)</stage> Che?</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="F"> Non dolerti.</l>
             <l>Molto acquista chi perde</l>
             <l>Una donna infedel. Lascia che sposa</l>
             <l part="I">L'abbia pure Alessandro.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F"><stage>(sorpreso)</stage> Abbia Alessandro</l>
             <l part="I">Chi?</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="M">L'ignori? Cleofide.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">E obbligarla</l>
             <l part="I">Chi a tal nodo potrà?</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="F">Nessun. Di tutte</l>
             <l>Le sue lusinghe armata,</l>
             <l part="I">Ella stessa il richiese.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="M">Ella!</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="F">E l'ottenne;</l>
             <l>E i felici consorti andran contenti...</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="I">Dove? <stage>(impaziente</stage></l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="M">Al tempio maggior.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="M">Quando?</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="F">A momenti.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="I">Perfida! in van lo speri. <stage>(furioso in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="F"><stage>(trattenendolo</stage> Ove t'affretti?</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="I">Al tempio! <stage>(risoluto</stage></l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="M">Ah, no!</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="F">T'arresta!</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="I">Lasciatemi!<stage> (volendosi liberar da loro</stage></l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="F">Ti perdi!</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="I">Corri a morir!</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Lasciatemi, importuni! <stage>(si libera con impeto</stage></l>
             <l>Or non vedo perigli,</l>
@@ -2769,15 +2794,15 @@
             <l>Tutti i numi del ciel, tutto l'inferno</l>
             <l>Non basterebbe a trattenermi ormai.</l>
           </sp>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l part="I">E che tentar pretendi?</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="F">E che farai?</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <lg>
               <l>Trafiggerò quel core,</l>
@@ -2796,12 +2821,12 @@
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>ERISSENA e GANDARTE</stage>
-          <sp>
+          <sp who="#erissena">
             <speaker>ERISS.</speaker>
             <l>Seguilo almen, Gandarte;</l>
             <l part="I">Assistilo, se m'ami.</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="F">Addio, mia vita.</l>
             <l>Non mi porre in oblio,</l>
@@ -2847,29 +2872,29 @@
           <head>SCENA NONA</head>
           <stage>Parte interna del gran tempio di Bacco magnificamente illuminato e rivestito di ricchissimi tappeti, dietro de' quali al destro lato, vicinissimo all'orchestra, andranno a suo tempo a ricoverarsi Poro e Gandarte, in modo che rimangano celati a tutti i personaggi, ma scoperti a tutti gli spettatori. Vasto e ornato, ma basso rogo nel mezzo, che poi s'accende ad un cenno di Cleofide. Due grandissime porte in prospetto, che si spalancano all'arrivo d'Alessandro, e scoprono parte della reggia e della città illuminata in lontananza.</stage>
           <stage>PORO uscendo impetuoso, e GANDARTE seguitandolo da lontano.</stage>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l>Signor, fermati; ascolta!</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l>Tu qui! Chiusi del tempio e custoditi</l>
             <l part="I">Son pur gli ingressi. Onde venisti?</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="F">Io venni</l>
             <l>Su l'orme tue per la segreta via</l>
             <l part="I">Che conduce alla reggia.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">A secondarmi</l>
             <l>Giungi opportun. Presso alle chiuse porte,</l>
             <l>Che s'aprono attendiam: la coppia rea</l>
             <l part="I">Inaspettati assalirem.</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="F">T'accieca</l>
             <l>L'ira, o mio re. Di conseguir che speri?</l>
@@ -2878,22 +2903,22 @@
             <l>La tua morte assicuri:</l>
             <l part="I">Perdi la tua vendetta.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Ogni difesa</l>
             <l part="I">L'ira mia preverrà.</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="F">Signor, quest'ira,</l>
             <l>Deh per ora sospendi:</l>
             <l>Salvati, fuggi, e miglior tempo attendi.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="I">Non più. T'accheta: ho risoluto.</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="F"><stage>(inginocchiandosi)</stage> Oh Dio,</l>
             <l>Pietà di noi. Fuggi, mio re: conserva</l>
@@ -2901,11 +2926,11 @@
             <l>Del cor la miglior parte,</l>
             <l>All'India il difensor, tutto a Gandarte.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="I">Indarno...</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="F">Aimè! del tempio </l>
             <l>Si scuotono le porte. Odi il tumulto</l>
@@ -2913,27 +2938,27 @@
             <l>Per te mi trema in seno:</l>
             <l part="I">Fuggi.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="M">Non l'otterrai. <stage>(risoluto</stage></l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="F">Célati almeno.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l>A render certo il colpo,</l>
             <l part="I">Util saria; ma dove?</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="F">Offron que' marmi</l>
             <l>A te comodo asilo</l>
             <l>Fra la porpora e l'òr che li circonda.</l>
             <l>Vieni, e sicuro sei.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l>Reggete questa man, vindici dèi! <stage>(snuda la spada e va a nascondersi con Gandarte</stage></l>
           </sp>
@@ -2956,43 +2981,43 @@
               <l>Di sacro rossor.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Nell'odorata pira</l>
             <l>Si dèstino le fiamme. <stage>(i sacerdoti accendono il rogo</stage></l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="I">(Perfida!)</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">E' dolce sorte unire insieme</l>
             <l part="I">E la gloria e l'amor.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">(Più fren non soffre</l>
             <l part="I">Già 'l mio furor).</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Vieni, o regina. Un nodo</l>
             <l>Leghi le destre e i cori. <stage>(accostandosele, in atto di darle la mano</stage></l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Ferma: è tempo di morte e non d'amori.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="I">Numi!</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="M">(Che ascolto!) <stage>(Poro resta immobile nell'attitudine di scagliarsi</stage></l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F">Io fui</l>
             <l>Consorte a Poro: ei più non vive e deggio</l>
@@ -3002,28 +3027,28 @@
             <l>Temei la tua pietà. Questo è il momento,</l>
             <l>In cui si adempia il sacrifizio a pieno. <stage>(in atto di andare verso il rogo</stage></l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="I">Ah! nol deggio soffrir. <stage>(volendo arrestarla</stage></l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F"><stage>(impugnando uno stile</stage> Ferma, o mi sveno.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="I">(Oh amore!)</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="M">(Oh fedeltà!)</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Non esser tanto</l>
             <l>Di te stessa nemica.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Il nome d'impudica,</l>
             <l>Vivendo, acquisterei. Passa alle fiamme</l>
@@ -3032,48 +3057,48 @@
             <l>Dell'India tutta; ed ogni età lontana</l>
             <l part="I">Questa legge osservò.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Legge inumana,</l>
             <l>Che bisogno ha di freno,</l>
             <l part="I">Che distrugger saprò. <stage>(vuole appressarsi a Cleofide</stage></l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="F"><stage>(in atto di ferirsi)</stage> Ferma, o mi sveno.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>(Risolvermi non oso).</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l>Ombra del caro sposo,</l>
             <l>Ecco della mia fé le prove estreme. <stage>(volendo gettarsi nelle fiamme</stage></l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l>Aspettami, cor mio: morremo insieme. <stage>(scoprendosi</stage></l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l>(Aimè! Poro si perde).</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="I">Dèi! traveggo? Sei tu?</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">No, non travedi:</l>
             <l>Il tuo Poro son io.</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l>Chi usurpa il nome mio? <stage>(scoprendosi</stage></l>
             <l part="I">Non crederlo, Alessandro: io son...</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Tu sei</l>
             <l>Il mio caro Gandarte; e non è tempo</l>
@@ -3082,42 +3107,42 @@
             <l>Con la man d'Erissena,</l>
             <l>Con parte del mio regno, esserti grato.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="I">Son fuor di me. Come! Tu sei... <stage>(a Poro</stage></l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Son io</l>
             <l part="I">Il tuo nemico.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">E di venire ardisci?...</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="I">A morir con la sposa.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F"><stage>(a Cleofide</stage> E tu non vuoi?...</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="I">Viver senza di lui.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="M">Gandarte?...</l>
           </sp>
-          <sp>
+          <sp who="#gandarte">
             <speaker>GAND.</speaker>
             <l part="F">Espone</l>
             <l>Come è dover, la vita</l>
             <l part="I">Per quella del suo re.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Dunque germoglia</l>
             <l>Tanta virtù nell'India? Ed io dovrei</l>
@@ -3131,24 +3156,24 @@
             <l>Su la feconda parte,</l>
             <l>Ch'oltre il Gange io domai, regni Gandarte.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide #gandarte">
             <speaker>CLEOF. e GAND.</speaker>
             <l part="I">O Alessandro!</l>
           </sp>
-          <sp>
+          <sp who="#erissena #timagene">
             <speaker>ERISS. e TIMAG.</speaker>
             <l part="M">O signor!</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Tacete. Omaggi</l>
             <l>Altri non vuo' da voi che l'odio estinto.</l>
           </sp>
-          <sp>
+          <sp who="#cleofide">
             <speaker>CLEOF.</speaker>
             <l part="I">Or trionfi, Alessandro.</l>
           </sp>
-          <sp>
+          <sp who="#poro">
             <speaker>PORO</speaker>
             <l part="F">Or Poro è vinto.</l>
           </sp>

--- a/tei/metastasio-attilio-regolo.xml
+++ b/tei/metastasio-attilio-regolo.xml
@@ -85,6 +85,37 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="licinio">
+            <persName>Licinio</persName>
+          </person>
+          <person xml:id="attilia">
+            <persName>Attilia</persName>
+          </person>
+          <person xml:id="manlio">
+            <persName>Manlio</persName>
+          </person>
+          <person xml:id="barce">
+            <persName>Barce</persName>
+          </person>
+          <person xml:id="publio">
+            <persName>Publio</persName>
+          </person>
+          <person xml:id="amilcare">
+            <persName>Amilcare</persName>
+          </person>
+          <person xml:id="regolo">
+            <persName>Attilio Regolo</persName>
+          </person>
+          <personGrp xml:id="popolo">
+            <name>Popolo</name>
+          </personGrp>
+          <person xml:id="coro">
+            <persName>Coro di Romani</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -125,14 +156,14 @@
           <head>SCENA I</head>
           <stage>Atrio nel palazzo suburbano del console Manlio. Spaziosa scala che introduce a' suoi appartamenti.</stage>
           <stage>ATTILIA, LICINIO <emph>dalla scala, littori e popolo.</emph> </stage>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l>Sei tu, mia bella Attilia? Oh dei! confusa</l>
             <l>fra la plebe e i littori</l>
             <l>di Regolo la figlia</l>
             <l part="I">qui trovar non credei.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Su queste soglie</l>
             <l>ch'esca il console attendo. Io voglio almeno</l>
@@ -143,7 +174,7 @@
             <l>piango in Roma e rammento i casi sui.</l>
             <l>Se taccio anch'io, chi parlerà per lui?</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l>Non dir così; saresti ingiusta. E dove,</l>
             <l>dov'è chi non sospiri</l>
@@ -155,12 +186,12 @@
             <l>degno d'un cor romano</l>
             <l part="I">in me traluce, ei m'inspirò.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Fin ora</l>
             <l part="I">però non veggo...</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l part="F">E che potei privato</l>
             <l>fin or per lui? D'ambiziosa cura</l>
@@ -170,7 +201,7 @@
             <l>le istanze mie. Del popol tutto a nome</l>
             <l part="I">tribuno or chiederò...</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Serbisi questo</l>
             <l>violento rimedio al caso estremo.</l>
@@ -187,52 +218,52 @@
             <l>di Regolo il riscatto</l>
             <l part="I">il console potria.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l part="F">Manlio! Ah rammenta</l>
             <l>che del tuo genitore emulo antico</l>
             <l>fu da' prim'anni. In lui fidarsi è vano:</l>
             <l part="I">è Manlio un suo rival.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Manlio è un romano;</l>
             <l>né armar vorrà la nimistà privata</l>
             <l>col pubblico poter. Lascia ch'io parli;</l>
             <l part="I">udiam che dir saprà.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l part="F">Parlagli almeno,</l>
             <l>parlagli altrove; e non soffrir che mista</l>
             <l part="I">qui fra 'l volgo ti trovi.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Anzi vogl'io</l>
             <l>che appunto in questo stato</l>
             <l>mi vegga, si confonda;</l>
             <l>che in pubblico m'ascolti e mi risponda.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l part="I">Ei vien.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="M">Parti.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l part="F">Ah né pure</l>
             <l part="I">d'uno sguardo mi degni.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">In quest'istante</l>
             <l>io son figlia, o Licinio, e non amante.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l>Tu sei figlia, e lodo anch'io</l>
             <l>il pensier del genitore;</l>
@@ -250,27 +281,27 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>ATTILIA, MANLIO<emph>dalla scala, littori e popolo.</emph> </stage>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l>Manlio, per pochi istanti</l>
             <l part="I">t'arresta, e m'odi.</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="F">E questo loco, Attilia,</l>
             <l part="I">parti degno di te?</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Non fu sin tanto</l>
             <l>che un padre invitto in libertà vantai;</l>
             <l>per la figlia d'un servo è degno assai.</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="I">A che vieni?</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">A che vengo! Ah sino a quando</l>
             <l>con stupor della terra,</l>
@@ -304,7 +335,7 @@
             <l>che i pianti miei, ma senza prò versati?</l>
             <l>Oh padre! Oh Roma! Oh cittadini ingrati!</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l>Giusto, Attilia, è il tuo duol, ma non è giusta</l>
             <l>l'accusa tua. Di Regolo la sorte</l>
@@ -312,7 +343,7 @@
             <l>qual faccia empio governo</l>
             <l part="I">la barbara Cartago...</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Eh che Cartago</l>
             <l>la barbara non è. Cartago opprime</l>
@@ -324,17 +355,17 @@
             <l>perché d'allòr le circondò la chioma.</l>
             <l>La barbara or qual è? Cartago o Roma?</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="I">Ma che far si dovrebbe?</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Offra il Senato</l>
             <l>per lui cambio o riscatto</l>
             <l part="I">all'africano ambasciador.</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="F">Tu parli,</l>
             <l>Attilia, come figlia: a me conviene</l>
@@ -343,33 +374,33 @@
             <l>fa d'uopo esaminar. Chi alle catene</l>
             <l part="I">la destra accostumò...</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Donde apprendesti</l>
             <l part="I">così rigidi sensi?</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="F">Io n'ho su gli occhi</l>
             <l part="I">i domestici esempi.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Eh dì che al padre</l>
             <l part="I">sempre avverso tu fosti.</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="F">È colpa mia,</l>
             <l>se vincer si lasciò? Se fra' nemici</l>
             <l part="I">rimase prigionier?</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Pria d'esser vinto</l>
             <l part="I">ei v'insegnò più volte...</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="F">Attilia, ormai</l>
             <l>il Senato è raccolto: a me non lice</l>
@@ -393,7 +424,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>ATTILIA, <emph>poi</emph>  BARCE</stage>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l>Nulla dunque mi resta</l>
             <l>da' consoli a sperar. Questo è nemico;</l>
@@ -402,59 +433,59 @@
             <l>da che incerte vicende</l>
             <l>la libertà, la vita tua dipende!</l>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l part="I">Attilia, Attilia.</l>
             <stage>
               <emph>(con fretta)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="M">Onde l'affanno?</l>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l part="F">È giunto</l>
             <l part="I">l'africano orator.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Tanto trasporto</l>
             <l part="I">la novella non merta.</l>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l part="F">Altra ne reco</l>
             <l part="I">ben più grande.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="M">E qual è?</l>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l part="F">Regolo è seco.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="I">Il padre!</l>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l part="M">Il padre.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Ah, Barce,</l>
             <l part="I">t'ingannasti o m'inganni?</l>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l part="F">Io nol mirai,</l>
             <l part="I">ma ognun...</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="M">Publio...</l>
             <stage>
@@ -465,28 +496,28 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>PUBLIO <emph>e dette.</emph> </stage>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">Germana...</l>
             <l part="I">Son fuor di me... Regolo è in Roma.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Oh Dio!</l>
             <l>Che assalto di piacer! Guidami a lui.</l>
             <l part="I">Dov'è? Corriam...</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">Non è ancor tempo. Insieme</l>
             <l>con l'orator nemico attende adesso</l>
             <l part="I">che l'ammetta il Senato.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Ove il vedesti?</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l>Sai che questor degg'io</l>
             <l>gli stranieri oratori</l>
@@ -495,11 +526,11 @@
             <l>m'affretto al porto: un africano io credo</l>
             <l>vedermi in faccia, e il genitor mi vedo.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="I">Che disse? che dicesti?</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">Ei su la ripa</l>
             <l>era già, quand'io giunsi, e il Campidoglio,</l>
@@ -517,28 +548,28 @@
             <l>il console io volai. Dov'è? Non veggo</l>
             <l part="I">qui d'intorno i littori...</l>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l part="F">Ei di Bellona</l>
             <l part="I">al tempio s'inviò.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Servo ritorna</l>
             <l part="I">dunque Regolo a noi?</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">Sì; ma di pace</l>
             <l>so che reca proposte: e che da lui</l>
             <l part="I">dipende il suo destin.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Chi sa se Roma</l>
             <l part="I">quelle proposte accetterà.</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">Se vedi</l>
             <l>come Roma l'accoglie,</l>
@@ -550,7 +581,7 @@
             <l>molle osservai per tenerezza il ciglio!</l>
             <l>Che spettacolo, Attilia, al cor d'un figlio!</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l>Ah Licinio dov'è? Di lui si cerchi:</l>
             <l>imperfetta saria</l>
@@ -571,39 +602,39 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>PUBLIO <emph>e</emph>  BARCE</stage>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="I">Addio, Barce vezzosa.</l>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l part="F">Odi. Non sai</l>
             <l>dell'orator cartaginese il nome?</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="I">Sì; Amilcare si appella.</l>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l part="F">È forse il figlio</l>
             <l part="I">d'Annone?</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="M">Appunto.</l>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l part="M">(Ah l'idol mio!)</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">Tu cangi</l>
             <l>color! Perché? Fosse costui cagione</l>
             <l part="I">del tuo rigor con me?</l>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l part="F">Signor, trovai</l>
             <l>tal pietà di mia sorte</l>
@@ -612,7 +643,7 @@
             <l>sarei, se t'ingannassi: a te sincera</l>
             <l part="I">tutto il cor scoprirò. Sappi...</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">T'accheta:</l>
             <l>mi prevedo funesta</l>
@@ -635,7 +666,7 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>BARCE <emph>sola.</emph> </stage>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l>Dunque è ver che a momenti</l>
             <l>il mio ben rivedrò? L'unico, il primo,</l>
@@ -662,7 +693,7 @@
           <stage>
             <emph>Seguito d'Africani e popolo fuori del tempio.</emph>
           </stage>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l>Venga Regolo, e venga</l>
             <l>l'africano orator. Dunque i nemici</l>
@@ -671,7 +702,7 @@
               <emph>(a Publio)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">O de' cattivi almeno</l>
             <l>vogliono il cambio. A Regolo han commesso</l>
@@ -684,23 +715,23 @@
             <l>che a sì barbare pene</l>
             <l part="I">un tanto cittadin...</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="F">T'accheta: ei viene.</l>
             <stage>
               <emph>(Il console, Publio e tutti i senatori vanno a sedere, e rimane vuoto accanto al console il luogo altre volte occupato da Regolo. Passano Regolo ed Amilcare fra' littori, i quali lasciato ad essi aperto il varco tornano subito a chiudersi. Regolo entrato appena nel tempio s'arresta pensando).</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l>(Regolo, a che t'arresti? È forse nuovo</l>
             <l>per te questo soggiorno?)</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>(Penso qual ne partii, qual vi ritorno).</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l>Di Cartago il Senato,</l>
             <l>bramoso di depor l'armi temute,</l>
@@ -708,7 +739,7 @@
             <l>E, se Roma desia</l>
             <l>anche pace da lui, pace gl'invia.</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="I">Siedi ed esponi.</l>
             <stage>
@@ -720,59 +751,59 @@
             <l part="F">E tu l'antica sede,</l>
             <l part="I">Regolo, vieni ad occupar.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Ma questi</l>
             <l part="I">chi sono?</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="M">I padri.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="M">E tu chi sei?</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="F">Conosci</l>
             <l>il console sì poco?</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>E fra il console e i padri un servo ha loco?</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l>No; ma Roma si scorda</l>
             <l>il rigor di sue leggi</l>
             <l>per te, cui dee cento conquiste e cento.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>Se Roma se ne scorda, io gliel rammento.</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l>(Più rigida virtù chi vide mai?)</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="I">Né Publio sederà. .</l>
             <stage>
               <emph>(sorge)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Publio, che fai?</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l>Compisco il mio dover: sorger degg'io</l>
             <l part="I">dove il padre non siede.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Ah tanto in Roma</l>
             <l>son cambiati i costumi! Il rammentarsi</l>
@@ -780,42 +811,42 @@
             <l>d'un privato dover, pria che tragitto</l>
             <l>in Africa io facessi, era delitto.</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="I">Ma...</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Siedi, Publio; e ad occupar quel loco</l>
             <l part="I">più degnamente attendi.</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">Il mio rispetto</l>
             <l>innanzi al padre è naturale istinto.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>Il tuo padre morì, quando fu vinto.</l>
             <stage>
               <emph>(Publio siede)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="I">Parla, Amilcare, ormai. .</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l part="F">Cartago elesse</l>
             <l>Regolo a farvi noto il suo desio.</l>
             <l>Ciò ch'ei dirà, dice Cartago ed io.</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="I">Dunque Regolo parli.</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <stage>
               <emph>(piano a Regolo)</emph>
@@ -824,24 +855,24 @@
             <l>che, se nulla otterrai,</l>
             <l part="I">giurasti...</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Io compirò quanto giurai.</l>
             <stage>
               <emph>(pensa)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l>(Di lui si tratta: oh come</l>
             <l part="I">parlar saprà!)</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">(Numi di Roma, ah voi</l>
             <l>inspirate eloquenza a' labbri suoi!)</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>La nemica Cartago,</l>
             <l>a patto che sia suo quant'or possiede,</l>
@@ -851,49 +882,49 @@
             <l>termini un cambio il doloroso esiglio.</l>
             <l>Ricusar l'una e l'altro è il mio consiglio.</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l part="I">(Come!)</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="M">(Aimè!)</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="M">(Son di sasso).</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Io della pace</l>
             <l>i danni a dimostrar non m'affatico;</l>
             <l>se tanto la desia, teme il nemico.</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="I">Ma il cambio?</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Il cambio asconde</l>
             <l>frode per voi più perigliosa assai.</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l part="I">Regolo?</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Io compirò quanto giurai.</l>
             <stage>
               <emph>(ad Amilcare)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="I">(Numi! il padre si perde).</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Il cambio offerto</l>
             <l>mille danni ravvolge;</l>
@@ -909,13 +940,13 @@
             <l>del vincitor lo scherno</l>
             <l>soffrir si elesse? Oh vituperio eterno!</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l>Sia pur dannoso il cambio:</l>
             <l>a compensarne i danni</l>
             <l part="I">basta Regolo sol.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Manlio, t'inganni:</l>
             <l>Regolo è pur mortal. Sento ancor io</l>
@@ -930,25 +961,25 @@
             <l>che ne trionfa in vano,</l>
             <l>che di Regoli abbonda il suol romano.</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l>(Oh inudita costanza!)</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l>(Oh coraggio funesto!)</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l>(Che nuovo a me strano linguaggio è questo!)</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l>L'util non già dell'opre nostre oggetto,</l>
             <l>ma l'onesto esser dee; né onesto a Roma</l>
             <l>l'esser ingrata a un cittadin saria.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>Vuol Roma essermi grata? Ecco la via.</l>
             <l>Questi barbari, o padri,</l>
@@ -966,17 +997,17 @@
             <l>nell'osservar fra' miei respiri estremi</l>
             <l>come al nome di Roma Africa tremi.</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l>(La maraviglia agghiaccia</l>
             <l part="I">gli sdegni miei).</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">(Nessun risponde? Oh Dio!</l>
             <l part="I">mi trema il cor).</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="F">Domanda</l>
             <l>più maturo consiglio</l>
@@ -990,11 +1021,11 @@
               <emph>(s'alza e seco tutti)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">V'è dubbio ancora?</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l>Sì, Regolo: io non veggo</l>
             <l>se periglio maggiore</l>
@@ -1017,93 +1048,93 @@
         <div type="scene">
           <head>SCENA VIII</head>
           <stage>REGOLO, PUBLIO, AMILCARE; <emph>indi</emph>  ATTILIA, LICINIO <emph>e popolo.</emph> </stage>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l>In questa guisa adempie</l>
             <l part="I">Regolo le promesse?</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Io vi promisi</l>
             <l part="I">di ritornar; l'eseguirò.</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l part="M">Ma...</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <stage>
               <emph>(con impazienza)</emph>
             </stage>
             <l part="F">Padre!</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l part="I">Signor!</l>
             <stage>
               <emph>(come sopra)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#regolo #licinio">
             <speaker>ATTILIO, LICINIO</speaker>
             <l part="F">Su questa mano...</l>
             <stage>
               <emph>(voglion baciarli la mano)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>Scostatevi. Io non sono,</l>
             <l part="I">lode agli dei, libero ancora.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Il cambio</l>
             <l part="I">dunque si ricusò?</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Publio, ne guida</l>
             <l>al soggiorno prescritto</l>
             <l part="I">ad Amilcare e a me.</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">Né tu verrai</l>
             <l>a' patri lari, al tuo ricetto antico?</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>Non entra in Roma un messaggier nemico.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l>Questa troppo severa</l>
             <l part="I">legge non è per te.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Saria tiranna,</l>
             <l part="I">se non fosse per tutti.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Io voglio almeno</l>
             <l part="I">seguirti ovunque andrai.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">No; chiede il tempo,</l>
             <l>Attilia, altro pensier che molli affetti</l>
             <l part="I">di figlia e genitor.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Da quel che fosti,</l>
             <l>padre, ah perché così diverso adesso?</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>La mia sorte è diversa; io son l'istesso.</l>
             <l>Non perdo la calma</l>
@@ -1122,11 +1153,11 @@
         <div type="scene">
           <head>SCENA IX</head>
           <stage>ATTILIA<emph>sospesa</emph> , AMILCARE <emph>partendo</emph> , BARCE,<emph>che sopraggiunge.</emph> </stage>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l part="I">Amilcare!</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l part="F">Ah mia Barce!</l>
             <stage>
@@ -1135,21 +1166,21 @@
             <l>Ah di nuovo io ti perdo! Il cambio offerto</l>
             <l part="I">Regolo dissuade.</l>
           </sp>
-          <sp>
+          <sp who="#barce #regolo">
             <speaker>BARCE, ATTILIO</speaker>
             <l part="M">Oh stelle!</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l part="F">Addio:</l>
             <l>Publio seguir degg'io. Mia vita, oh quanto,</l>
             <l part="I">quanto ho da dirti!</l>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l part="F">E nulla dici intanto.</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l>Ah! se ancor mia tu sei,</l>
             <l>come trovar sì poco</l>
@@ -1167,12 +1198,12 @@
         <div type="scene">
           <head>SCENA X</head>
           <stage>ATTILIA <emph>e</emph>  BARCE</stage>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l>Chi creduto l'avrebbe! Il padre istesso</l>
             <l part="I">congiura a' danni suoi.</l>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l part="F">Già che il Senato</l>
             <l>non decise fin or, molto ti resta,</l>
@@ -1184,7 +1215,7 @@
             <l>or la fé degli amici, or de' Romani</l>
             <l>giova implorar l'aita in ogni loco.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l>Tutto farò; ma quel, ch'io spero, è poco.</l>
             <l>Mi parea del parto in seno</l>
@@ -1203,7 +1234,7 @@
         <div type="scene">
           <head>SCENA XI</head>
           <stage>BARCE <emph>sola.</emph> </stage>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l>Che barbaro destino</l>
             <l>sarebbe il mio, se Amilcare dovesse</l>
@@ -1231,41 +1262,41 @@
           <head>SCENA I </head>
           <stage>Logge a vista di Roma nel palazzo suburbano destinato agli ambasciatori cartaginesi. </stage>
           <stage>REGOLO <emph>e</emph>  PUBLIO</stage>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>Publio, tu qui! Si tratta</l>
             <l>della gloria di Roma,</l>
             <l>dell'onor mio, del pubblico riposo,</l>
             <l part="I">e in Senato non sei?</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">Raccolto ancora,</l>
             <l part="I">signor, non è.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Va, non tardar; sostieni</l>
             <l>fra i padri il voto mio: mostrati degno</l>
             <l part="I">dell'origine tua.</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">Come! e m'imponi</l>
             <l>che a fabbricar m'adopri</l>
             <l part="I">io stesso il danno tuo?</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Non è mio danno</l>
             <l part="I">quel che giova alla patria.</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">Ah di te stesso,</l>
             <l part="I">signore, abbi pietà.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Publio, tu stimi</l>
             <l>dunque un furore il mio? Credi ch'io solo,</l>
@@ -1281,11 +1312,11 @@
             <l>è della patria assicurar la sorte;</l>
             <l>ond'è mio ben la servitù, la morte.</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="I">Pur la patria non è...</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">La patria è un tutto,</l>
             <l>di cui siam parti. Al cittadino è fallo</l>
@@ -1312,20 +1343,20 @@
             <l>misere ghiande e d'un covil contento,</l>
             <l>viva libero e solo a suo talento.</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l>Adoro i detti tuoi. L'alma convinci,</l>
             <l>ma il cor non persuadi. Ad ubbidirti</l>
             <l>la natura repugna. Al fin son figlio,</l>
             <l part="I">non lo posso obbliar.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Scusa infelice</l>
             <l>per chi nacque romano. Erano padri</l>
             <l part="I">Bruto, Manlio, Virginio...</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">È ver; ma questa</l>
             <l>troppo eroica costanza</l>
@@ -1333,44 +1364,44 @@
             <l>Roma fin or, che a proccurar giungesse</l>
             <l>del genitor lo scempio.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>Dunque aspira all'onor del primo esempio.</l>
             <l part="I">Va.</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="M">Deh...</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Non più. Della mia sorte attendo</l>
             <l part="I">la notizia da te.</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">Troppo pretendi,</l>
             <l part="I">troppo, o signor.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Mi vuoi straniero, o padre?</l>
             <l>Se stranier, non posporre</l>
             <l>l'util di Roma al mio; se padre, il cenno</l>
             <l part="I">rispetta, e parti.</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">Ah se mirar potessi</l>
             <l>i moti del cor mio, rigido meno</l>
             <l part="I">forse con me saresti.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Or dal tuo core</l>
             <l>prove io vo' di costanza e non d'amore.</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l>Ah, se provar mi vuoi,</l>
             <l>chiedimi, o padre, il sangue;</l>
@@ -1388,34 +1419,34 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>REGOLO, <emph>poi</emph>  MANLIO</stage>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>Il gran punto s'appressa, ed io pavento</l>
             <l>che vacillino i padri. Ah voi di Roma</l>
             <l>deità protettrici, a lor più degni</l>
             <l part="I">sensi inspirate.</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="F">A custodir l'ingresso</l>
             <l>rimangano i littori; e alcun non osi</l>
             <l part="I">qui penetrar.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="M">(Manlio! A che viene?)</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="F">Ah lascia</l>
             <l part="I">che al sen ti stringa, invitto eroe.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Che tenti!</l>
             <l part="I">Un console...</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="F">Io nol sono</l>
             <l>Regolo, adesso: un uom son io che adora</l>
@@ -1425,7 +1456,7 @@
             <l>l'avverso genio antico,</l>
             <l>chiede l'onor di diventarti amico.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>Dell'alme generose</l>
             <l>solito stil. Più le abbattute piante</l>
@@ -1433,7 +1464,7 @@
             <l>così nobile acquisto</l>
             <l part="I">alla mia servitù.</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="F">Sì, questa appieno</l>
             <l>qual tu sei mi scoperse; e mai sì grande,</l>
@@ -1446,7 +1477,7 @@
             <l>un eroe, lo confesso,</l>
             <l>Regolo mi parea; ma un nume adesso.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>Basta, basta, signor: la più severa</l>
             <l>misurata virtù tentan le lodi</l>
@@ -1454,7 +1485,7 @@
             <l>che d'illustrar con l'amor tuo ti piaccia</l>
             <l part="I">gli ultimi giorni miei.</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="F">Gli ultimi giorni!</l>
             <l>Conservarti io pretendo</l>
@@ -1462,7 +1493,7 @@
             <l>in tuo favor l'offerto cambio ammesso,</l>
             <l part="I">tutto in uso porrò.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <stage>
               <emph>          (turbandosi)</emph>
@@ -1477,12 +1508,12 @@
 che accettar non si dee. Se non puoi darmi</l>
             <l>altri pegni d'amor, torna ad odiarmi.</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l>Ma il ricusato cambio</l>
             <l part="I">produrria la tua morte.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">E questo nome</l>
             <l>sì terribil risuona</l>
@@ -1496,13 +1527,13 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>viver più non potei,</l>
             <l>resi almen la mia morte utile a lei.</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l>Oh detti! Oh sensi! Oh fortunato suolo</l>
             <l>che tai figli produci! E chi potrebbe</l>
             <l part="I">non amarti, signor?</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Se amar mi vuoi,</l>
             <l>amami da romano. Eccoti i patti</l>
@@ -1516,41 +1547,41 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>sola di Manlio io l'amicizia accetto.</l>
             <l part="I">Che rispondi, signor?</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <stage>
               <emph>(pensa prima di rispondere)</emph>
             </stage>
             <l part="F">Sì, lo prometto.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>Or de' propizi numi</l>
             <l>in Manlio amico io riconosco un dono.</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l>Ah perché fra que' ceppi anch'io non sono!</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>Non perdiamo i momenti. Ormai raccolti</l>
             <l>forse saranno i padri. Alla tua fede</l>
             <l>della patria il decoro,</l>
             <l>la mia pace abbandono e l'onor mio.</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="I">Addio, gloria del Tebro.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Amico, addio.</l>
             <stage>
               <emph>(abbracciandosi)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l>Oh qual fiamma di gloria, d'onore</l>
             <l>scorrer sento per tutte le vene,</l>
@@ -1566,12 +1597,12 @@ che accettar non si dee. Se non puoi darmi</l>
         <div type="scene">
           <head>SCENA III</head>
           <stage>REGOLO <emph>e</emph> LICINIO</stage>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>A respirar comincio: i miei disegni</l>
             <l part="I">il fausto Ciel seconda.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <stage>
               <emph>(molto lieto)</emph>
@@ -1579,22 +1610,22 @@ che accettar non si dee. Se non puoi darmi</l>
             <l part="F">Al fin ritorno</l>
             <l part="I">con più contento a rivederti.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">E donde</l>
             <l part="I">tanta gioia, o Licinio?</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l part="F">Ho il cor ripieno</l>
             <l>di felici speranze. In fino ad ora</l>
             <l part="I">per te sudai.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="M">Per me!</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l part="F">Sì. Mi credesti</l>
             <l>forse ingrato così, ch'io mi scordassi</l>
@@ -1604,48 +1635,48 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>mossi, te condottiero,</l>
             <l>per le strade d'onor: tu mi rendesti...</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>Al fine, in mio favor, dì, che facesti?</l>
             <stage>
               <emph>(impaziente)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l>Difesi la tua vita</l>
             <l part="I">e la tua libertà.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <stage>
               <emph>(turbato)</emph>
             </stage>
             <l part="M">Come?</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l part="F">All'ingresso</l>
             <l>del tempio, ove il Senato or si raccoglie,</l>
             <l>attesi i padri, e ad uno ad un li trassi</l>
             <l part="I">nel desio di salvarti.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">(Oh dei, che sento!)</l>
             <l part="I">E tu...</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l part="F">Solo io non fui. Non si defraudi</l>
             <l>la lode al merto. Io feci assai, ma fece</l>
             <l part="I">Attilia più di me.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="M">Chi?</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l part="F">Attilia. In Roma</l>
             <l>figlia non v'è d'un genitor più amante.</l>
@@ -1654,11 +1685,11 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>il dolor col decoro! In quanti modi</l>
             <l>rimproveri mischiò, preghiere e lodi!</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="I">E i padri?</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l part="F">E chi resiste</l>
             <l>agli assalti d'Attilia? Eccola: osserva</l>
@@ -1669,12 +1700,12 @@ che accettar non si dee. Se non puoi darmi</l>
         <div type="scene">
           <head>SCENA IV</head>
           <stage>ATTILIA <emph>e detti.</emph> </stage>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Amato padre,</l>
             <l part="I">pure una volta...</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <stage>
               <emph>(serio e torbido)</emph>
@@ -1683,12 +1714,12 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>ancor venirmi innanzi? Ah non contai</l>
             <l part="I">te fin ad or fra' miei nemici.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Io, padre,</l>
             <l part="I">io tua nemica!</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <stage>
               <emph>( come sopra)</emph>
@@ -1696,12 +1727,12 @@ che accettar non si dee. Se non puoi darmi</l>
             <l part="F">E tal non è chi folle</l>
             <l part="I">s'oppone a' miei consigli?</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Ah di giovarti</l>
             <l>dunque il desio d'inimicizia è prova?</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>Che sai tu quel che nuoce o quel che giova?</l>
             <stage>
@@ -1711,12 +1742,12 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>chi a parte ti chiamò? Della mia sorte</l>
             <l part="I">chi ti fé protettrice? Onde...</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l part="F">Ah signore,</l>
             <l part="I">troppo...</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <stage>
               <emph>(come sopra)</emph>
@@ -1726,16 +1757,16 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>pentimento il silenzio. Eterni dei!</l>
             <l part="I">Una figlia!... un roman!</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Perché son figlia...</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l>Perché roman son io, credei che oppormi</l>
             <l>al tuo fato inumana...</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>Taci: non è romano</l>
             <stage>
@@ -1759,7 +1790,7 @@ che accettar non si dee. Se non puoi darmi</l>
         <div type="scene">
           <head>SCENA V</head>
           <stage>ATTILIA <emph>e</emph>  LICINIO</stage>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l>Ma dì; credi, o Licinio,</l>
             <l>che mai di me nascesse</l>
@@ -1768,7 +1799,7 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>di tenera pietade il cor trafitto</l>
             <l>saria merito ad altri; è a me delitto.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l>No; consolati, Attilia, e non pentirti</l>
             <l>dell'opera pietosa. Altro richiede</l>
@@ -1781,22 +1812,22 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>di crudel, d'inumano</l>
             <l>quella medica man, che lo risana.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l>Que' rimproveri acerbi</l>
             <l>mi trafiggono il cor: non ho costanza</l>
             <l part="I">per soffrir l'ire sue.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l part="F">Ma dì: vorresti</l>
             <l>pria d'un tal genitor vederti priva?</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l>Ah questo no: mi sia sdegnato, e viva.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l>Vivrà. Cessi quel pianto:</l>
             <l>tornatevi di nuovo,</l>
@@ -1820,7 +1851,7 @@ che accettar non si dee. Se non puoi darmi</l>
         <div type="scene">
           <head>SCENA VI</head>
           <stage>ATTILIA <emph>sola.</emph> </stage>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l>Ah che pur troppo è ver! non han misura</l>
             <l>della cieca fortuna</l>
@@ -1848,7 +1879,7 @@ che accettar non si dee. Se non puoi darmi</l>
           <head>SCENA VII</head>
           <stage>Galleria del palazzo medesimo. </stage>
           <stage>REGOLO <emph>solo.</emph> </stage>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>Tu palpiti, o mio cor! Qual nuovo è questo</l>
             <l>moto incognito a te? Sfidasti ardito</l>
@@ -1884,30 +1915,30 @@ che accettar non si dee. Se non puoi darmi</l>
         <div type="scene">
           <head>SCENA VIII</head>
           <stage>PUBLIO <emph>e detto.</emph> </stage>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">Signor... (Che pena</l>
             <l part="I">per un figlio è mai questa!)</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="M">E taci?</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">Oh dei!</l>
             <l part="I">Esser muto vorrei.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="M">Parla.</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">Ogni offerta</l>
             <l part="I">il Senato ricusa.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Ah dunque ha vinto</l>
             <l>il fortunato al fin genio romano!</l>
@@ -1916,44 +1947,44 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>che far su queste arene:</l>
             <l>la grand'opra compii, partir conviene.</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="I">Padre infelice!</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Ed infelice appelli</l>
             <l>chi poté, fin che visse,</l>
             <l part="I">alla patria giovar?</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">La patria adoro,</l>
             <l part="I">piango i tuoi lacci.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">È servitù la vita;</l>
             <l>ciascuno ha i lacci suoi. Chi pianger vuole,</l>
             <l>pianger, Publio, dovria</l>
             <l>la sorte di chi nasce, e non la mia.</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l>Di quei barbari, o padre,</l>
             <l>l'empio furor ti priverà di vita.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>E la mia servitù sarà finita.</l>
             <l part="I">Addio. Non mi seguir.</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">Da me ricusi</l>
             <l part="I">gli ultimi ancor pietosi uffizi?</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Io voglio</l>
             <l>altro da te. Mentre a partir m'affretto,</l>
@@ -1988,7 +2019,7 @@ che accettar non si dee. Se non puoi darmi</l>
         <div type="scene">
           <head>SCENA IX</head>
           <stage>PUBLIO, <emph>poi</emph>  ATTILIA <emph>e</emph>  BARCE; <emph>indi</emph>  LICINIO <emph>ed</emph>  AMILCARE, <emph>l'uno dopo l'altro e da diverse parti.</emph> </stage>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l>Ah sì, Publio, coraggio: il passo è forte,</l>
             <l>ma vincerti convien. Lo chiede il sangue,</l>
@@ -1997,189 +2028,189 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>impeti di natura; or meglio eleggi;</l>
             <l>il padre imìta, e l'error tuo correggi.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="I">Ed è vero, o german?</l>
             <stage>
               <emph>(con ispavento)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <stage>
               <emph>(con ispavento)</emph>
             </stage>
             <l part="F">Publio, ed è vero?</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l>Sì: decise il Senato;</l>
             <l part="I">Regolo partirà.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="M">Come!</l>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l part="F">Che dici!</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="I">Dunque ognun mi tradì?</l>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l part="M">Dunque...</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">Or non giova...</l>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l part="I">Amilcare, pietà.</l>
             <stage>
               <emph>(vedendolo da lontano)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <stage>
               <emph>(come sopra)</emph>
             </stage>
             <l part="F">Licinio, aiuto.</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l part="I">Più speranza non v'è.</l>
             <stage>
               <emph>(a Barce)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <stage>
               <emph>(ad Attilia)</emph>
             </stage>
             <l part="F">Tutto è perduto.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l>Dov'è Regolo? Io voglio</l>
             <l part="I">almen seco partir.</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">Ferma; l'eccesso</l>
             <l part="I">del tuo dolor l'offenderebbe.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">E speri</l>
             <l part="I">impedirmi così?</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">Spera che Attilia</l>
             <l>torni al fine in se stessa, e si rammenti</l>
             <l>che a lei non è permesso...</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l>Sol che son figlia io mi rammento adesso.</l>
             <l part="I">Lasciami.</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="M">Non sperarlo.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Ah parte intanto</l>
             <l part="I">il genitor!</l>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l part="F">Non dubitar ch'ei parta,</l>
             <l part="I">finché Amilcare è qui.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Chi mi consiglia?</l>
             <l part="I">chi mi soccorre? Amilcare?</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l part="F">Io mi perdo</l>
             <l part="I">fra l'ira e lo stupor.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="M">Licinio?</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l part="F">Ancora</l>
             <l>dal colpo inaspettato</l>
             <l part="I">respirar non poss'io.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="M">Publio?</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">Ah germana,</l>
             <l>più valor, più costanza. Il fato avverso</l>
             <l>come si soffra il genitor ci addìta.</l>
             <l>Non è degno di lui chi non l'imìta.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l>E tu parli così! tu, che dovresti</l>
             <l>i miei trasporti accompagnar gemendo!</l>
             <l part="I">Io non t'intendo, o Publio.</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l part="F">Ed io l'intendo.</l>
             <l>Barce è la fiamma sua: Barce non parte,</l>
             <l>se Regolo non resta; ecco la vera</l>
             <l>cagion del suo coraggio.</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l>(Questo pensar di me! Stelle, che oltraggio!)</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l>Forse, affinché il Senato</l>
             <l>non accettasse il cambio, ei pose in opra</l>
             <l>tutta l'arte e l'ingegno.</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l>Il dubbio in ver d'un africano è degno.</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l part="I">E pur...</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">Taci, e m'ascolta.</l>
             <l>Sai che l'arbitro io sono</l>
             <l part="I">della sorte di Barce?</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l part="F">Il so. L'ottenne</l>
             <l>già dal Senato in dono</l>
             <l>la madre tua: questa cedendo al fato,</l>
             <l part="I">signor di lei tu rimanesti.</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">Or odi</l>
             <l>qual uso io fo del mio dominio. Amai</l>
@@ -2190,15 +2221,15 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>ogni pretesto alla calunnia altrui.</l>
             <l>Barce, liberi sei; parti con lui.</l>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l part="I">Numi! Ed è ver?</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l part="F">D'una virtù sì rara...</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l>Come s'ama fra noi, barbaro, impara.</l>
             <stage>
@@ -2209,14 +2240,14 @@ che accettar non si dee. Se non puoi darmi</l>
         <div type="scene">
           <head>SCENA X</head>
           <stage>LICINIO, ATTILIA, BARCE, <emph>ed</emph>  AMILCARE </stage>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="I">Vedi il crudel come mi lascia!</l>
             <stage>
               <emph>(a Licinio, che non l'ode)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l part="F">Udisti,</l>
             <l part="I">come Publio parlò?</l>
@@ -2224,61 +2255,61 @@ che accettar non si dee. Se non puoi darmi</l>
               <emph>(ad Amilcare come sopra)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Tu non rispondi!</l>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l>Tu non m'odi, idol mio!</l>
             <stage>
               <emph>(ad Amilcare)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l part="I">Addio, Barce; m'attendi.</l>
             <stage>
               <emph>(risoluto incamminandosi per partire)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <stage>
               <emph>(come sopra)</emph>
             </stage>
             <l part="F">Attilia, addio.</l>
           </sp>
-          <sp>
+          <sp who="#regolo #barce">
             <speaker>ATTILIO, BARCE</speaker>
             <l part="I">Dove?</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <stage>
               <emph>(ad Attilia)</emph>
             </stage>
             <l part="F">A salvarti il padre.</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l part="I">Regolo a conservar.</l>
             <stage>
               <emph>(a Licinio)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Ma per qual via?</l>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l part="I">Ma come?</l>
             <stage>
               <emph>(ad Amilcare)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <stage>
               <emph>(ad Attilia)</emph>
@@ -2286,7 +2317,7 @@ che accettar non si dee. Se non puoi darmi</l>
             <l part="F">A' mali estremi</l>
             <l part="I">Diasi estremo rimedio.</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <stage>
               <emph>(a Barce)</emph>
@@ -2294,49 +2325,49 @@ che accettar non si dee. Se non puoi darmi</l>
             <l part="F">Abbia rivali</l>
             <l>nella virtù questo romano orgoglio.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="I">Esser teco vogl'io.</l>
             <stage>
               <emph>(a Licinio)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <stage>
               <emph>(ad Amilcare)</emph>
             </stage>
             <l part="F">Seguirti io voglio.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l>No; per te tremerei.</l>
             <stage>
               <emph>(ad Attilia)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l part="I">No; rimaner tu dèi.</l>
             <stage>
               <emph>(a Barce)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <stage>
               <emph>(ad Amilcare)</emph>
             </stage>
             <l part="F">Né vuoi spiegarti?</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="I">Né vuoi ch'io sappia almen...</l>
             <stage>
               <emph>(a Licinio)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <stage>
               <emph>(ad Attilia)</emph>
@@ -2344,14 +2375,14 @@ che accettar non si dee. Se non puoi darmi</l>
             <l part="F">Tutto fra poco</l>
             <l part="I">saprai.</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l part="M">Fidati a me.</l>
             <stage>
               <emph>(a Barce)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l part="F">Regolo in Roma</l>
             <l>si trattenga, o si mora.</l>
@@ -2359,7 +2390,7 @@ che accettar non si dee. Se non puoi darmi</l>
               <emph>(parte)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l>Faccia pompa d'eroi l'Africa ancora.</l>
             <stage>
@@ -2381,23 +2412,23 @@ che accettar non si dee. Se non puoi darmi</l>
         <div type="scene">
           <head>SCENA XI</head>
           <stage>ATTILIA <emph>e</emph>  BARCE</stage>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="I">Barce!</l>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l part="M">Attilia!</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Che dici?</l>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l part="I">Che possiamo sperar?</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Non so. Tumulti</l>
             <l>certo a destar corre Licinio; e questi</l>
@@ -2405,7 +2436,7 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>alla patria ed a lui, senza che il padre</l>
             <l part="I">perciò si salvi.</l>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l part="F">Amilcare sorpreso</l>
             <l>dal grand'atto di Publio e punto insieme</l>
@@ -2413,29 +2444,29 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>esser non vuol di lui. Chi sa che tenta</l>
             <l part="I">e a qual rischio s'espone?</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Il mio Licinio</l>
             <l part="I">deh ! secondate, o dei!</l>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l part="F">La sposo mio,</l>
             <l part="I">numi, assistete!</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Io non ho fibra in seno,</l>
             <l part="I">che non mi tremi.</l>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l part="F">Attilia,</l>
             <l>non dobbiamo avvilirci. Al fin più chiaro</l>
             <l>è adesso il ciel di quel che fu; si vede</l>
             <l>pur di speranza un raggio.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l>Ah Barce, è ver; ma non mi dà coraggio.</l>
             <l>Non è la mia speranza</l>
@@ -2454,7 +2485,7 @@ che accettar non si dee. Se non puoi darmi</l>
         <div type="scene">
           <head>SCENA XII</head>
           <stage>BARCE <emph>sola.</emph> </stage>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l>Rassicurar proccuro</l>
             <l>l'alma d'Attilia oppressa,</l>
@@ -2481,7 +2512,7 @@ che accettar non si dee. Se non puoi darmi</l>
           <head>SCENA I </head>
           <stage>Sala terrena corrispondente a' giardini. </stage>
           <stage>REGOLO, <emph>guardie africane, poi</emph>  MANLIO</stage>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>Ma che si fa? Non seppe</l>
             <l>forse ancor del Senato</l>
@@ -2498,35 +2529,35 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>per te conservo; a te si deve il frutto</l>
             <l part="I">della mia schiavitù.</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="F">Sì; ma tu parti;</l>
             <l part="I">sì; ma noi ti perdiam.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Mi perdereste,</l>
             <l part="I">s'io non partissi.</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="F">Ah perché mai sì tardi</l>
             <l>incomincio ad amarti! Altri fin ora,</l>
             <l>Regolo, non avesti</l>
             <l>pegni dell'amor mio, se non funesti.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>Pretenderne maggiori</l>
             <l>da un vero amico io non potei; ma pure</l>
             <l>se il generoso Manlio altri vuol darne,</l>
             <l part="I">altri ne chiederò.</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="M">Parla.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Compìto</l>
             <l>ogni dover di cittadino, al fine</l>
@@ -2544,7 +2575,7 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>debbano e a' tuoi consigli</l>
             <l>la gloria il padre, e l'assistenza i figli.</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l>Sì, tel prometto: i preziosi germi</l>
             <l>custodirò geloso. Avranno un padre,</l>
@@ -2555,7 +2586,7 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>di bel desio già per natura accese,</l>
             <l>l'istoria udir delle paterne imprese.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>Or sì più non mi resta...</l>
           </sp>
@@ -2563,54 +2594,54 @@ che accettar non si dee. Se non puoi darmi</l>
         <div type="scene">
           <head>SCENA II</head>
           <stage>PUBLIO <emph>e detti.</emph> </stage>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="I">Manlio! Padre!</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Che avvenne?</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l>Roma tutta è in tumulto: il popol freme;</l>
             <l part="I">non si vuol che tu parta.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">E sarà vero</l>
             <l>che un vergognoso cambio</l>
             <l part="I">possa Roma bramar?</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">No, cambio o pace</l>
             <l part="I">Roma non vuol; vuol che tu resti.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Io! Come?</l>
             <l part="I">E la promessa? e il giuramento?</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">Ognuno</l>
             <l>grida che fé non dessi</l>
             <l part="I">a perfidi serbar.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Dunque un delitto</l>
             <l>scusa è dell'altro. E chi sarà più reo,</l>
             <l part="I">se l'esempio è discolpa?</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">Or si raduna</l>
             <l>degli àuguri il collegio: ivi deciso</l>
             <l part="I">il gran dubbio esser deve.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Uopo di questo</l>
             <l>oracolo io non ho. So che promisi;</l>
@@ -2621,12 +2652,12 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>questo è privato affar. Non son qual fui;</l>
             <l>né Roma ha dritto alcun sui servi altrui.</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l>Degli àuguri il decreto</l>
             <l part="I">s'attenda almen.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">No; se l'attendo, approvo</l>
             <l>la loro autorità. Custodi, al porto.</l>
@@ -2638,30 +2669,30 @@ che accettar non si dee. Se non puoi darmi</l>
               <emph>(a Manlio partendo)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="F">No, Regolo; se vai</l>
             <l>fra la plebe commossa, a viva forza</l>
             <l>può trattenerti; e tu, se ciò succede,</l>
             <l>tutta Roma fai rea di poca fede.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="I">Dunque mancar degg'io?...</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="F">No; andrai; ma lascia</l>
             <l>che quest'impeto io vada</l>
             <l>prima a calmar. Ne sederà l'ardore</l>
             <l part="I">la consolare autorità.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Rimango,</l>
             <l part="I">Manlio, su la tua fé: ma...</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="F">Basta; intendo.</l>
             <l>La tua gloria desio,</l>
@@ -2682,7 +2713,7 @@ che accettar non si dee. Se non puoi darmi</l>
         <div type="scene">
           <head>SCENA III</head>
           <stage>REGOLO, PUBLIO</stage>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>E tanto or costa in Roma,</l>
             <l>tanta or si suda a conservar la fede!</l>
@@ -2693,17 +2724,17 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>di sì gran benefizio</l>
             <l part="I">debitore ad un figlio.</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">Ah padre amato,</l>
             <l part="I">ubbidirò; ma...</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Che? Sospiri! Un segno</l>
             <l>quel sospiro saria d'animo oppresso?</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l>Sì, lo confesso,</l>
             <l>morir mi sento;</l>
@@ -2725,18 +2756,18 @@ che accettar non si dee. Se non puoi darmi</l>
         <div type="scene">
           <head>SCENA IV</head>
           <stage>REGOLO <emph>e</emph> AMILCARE</stage>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l part="I">Regolo, al fin...</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Senza che parli, intendo</l>
             <l>già le querele tue. Non ti sgomenti</l>
             <l>il moto popolar: Regolo in Roma</l>
             <l part="I">vivo non resterà.</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l part="F">Non so di quali</l>
             <l>moti mi vai parlando. Io querelarmi</l>
@@ -2745,41 +2776,41 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>non nascono gli eroi,</l>
             <l>che vi sono alme grandi anche fra noi.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>Sia. Non è questo il tempo</l>
             <l>d'inutili contese. I tuoi raccogli,</l>
             <l>t'appresta alla partenza.</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l part="I">No. Pria m'odi, e rispondi.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">(Oh sofferenza!)</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l>È gloria l'esser grato?</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>L'esser grato è dover: ma già sì poco</l>
             <l>questo dover s'adempie,</l>
             <l part="I">ch'oggi è gloria il compirlo.</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l part="F">E se il compirlo</l>
             <l part="I">costasse un gran periglio?</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Ha il merto allora</l>
             <l part="I">d'un'illustre virtù.</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l part="F">Dunque non puoi</l>
             <l>questo merto negarmi. Odi. Mi rende,</l>
@@ -2789,19 +2820,19 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>vengo il padre a salvargli, e pur m'espongo</l>
             <l part="I">di Cartago al furor.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Tu vuoi salvarmi!</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l part="I">Io.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="M">Come?</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l part="F">A te lasciando</l>
             <l>agio a fuggir. Questi custodi ad arte</l>
@@ -2810,38 +2841,38 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>che senza te con simulato sdegno</l>
             <l>quindi l'ancore io sciolga.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="I">(Barbaro!)</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l part="F">E ben, che dici?</l>
             <l part="I">ti sorprende l'offerta.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="M">Assai.</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l part="F">L'avresti</l>
             <l part="I">aspettata da me?</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="M">No.</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l part="F">Pur la sorte</l>
             <l part="I">non ho d'esser roman.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="M">Si vede.</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l part="F">Andate,</l>
             <l part="I">custodi...</l>
@@ -2849,62 +2880,62 @@ che accettar non si dee. Se non puoi darmi</l>
               <emph>(agli Africani)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Alcun non parta.</l>
             <stage>
               <emph>(a' medesimi)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l part="I">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Grato io ti sono</l>
             <l part="I">del buon voler; ma verrò teco.</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l part="F">E sprezzi</l>
             <l part="I">la mia pietà?</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">No; ti compiango. Ignori</l>
             <l>che sia virtù. Mostrar virtù pretendi,</l>
             <l>e me, la patria tua, te stesso offendi.</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l part="I">Io!</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Sì. Come disponi</l>
             <l>della mia libertà? Servo son io</l>
             <l part="I">di Cartago, o di te?</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l part="F">Non è tuo peso</l>
             <l part="I">l'esaminar se il benefizio...</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">È grande</l>
             <l>il benefizio in ver! Rendermi reo,</l>
             <l part="I">profugo, mentitor...</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l part="F">Ma qui si tratta</l>
             <l>del viver tuo. Sai che supplizi atroci</l>
             <l>Cartago t'apprestò? Sai quale scempio</l>
             <l part="I">là si farà di te?</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Ma tu conosci,</l>
             <l>Amilcare, i Romani?</l>
@@ -2915,21 +2946,21 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>pur che gloria produca, ogni tormento;</l>
             <l>e la sola viltà qui fa spavento.</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l>Magnifiche parole,</l>
             <l>belle ad udir; ma inopportuno è meco</l>
             <l>quel fastoso linguaggio. Io so che a tutti</l>
             <l part="I">la vita è cara, e che tu stesso...</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Ah troppo</l>
             <l>di mia pazienza abusi. I legni appresta,</l>
             <l>raduna i tuoi seguaci,</l>
             <l>compisci il tuo dover, barbaro, e taci.</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l>Fa pur l'intrepido,</l>
             <l>m'insulta audace,</l>
@@ -2947,24 +2978,24 @@ che accettar non si dee. Se non puoi darmi</l>
         <div type="scene">
           <head>SCENA V</head>
           <stage>REGOLO <emph>e</emph>  ATTILIA</stage>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>E Publio non ritorna!</l>
             <l>e Manlio... Aimè! Che rechi mai sì lieta,</l>
             <l part="I">sì frettolosa, Attilia?</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Il nostro fato</l>
             <l>già dipende da te; già cambio o pace,</l>
             <l>fida a' consigli tuoi,</l>
             <l>Roma non vuol; ma rimaner tu puoi.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="I">Sì, col rossor...</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">No; su tal punto il sacro</l>
             <l>Senato pronunciò. L'arbitro sei</l>
@@ -2972,7 +3003,7 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>né obbligar può se stesso</l>
             <l part="I">chi libero non è».</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Libero è sempre</l>
             <l>chi sa morir. La sua viltà confessa</l>
@@ -2984,16 +3015,16 @@ che accettar non si dee. Se non puoi darmi</l>
         <div type="scene">
           <head>SCENA VI</head>
           <stage>PUBLIO <emph>e detti.</emph> </stage>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">Ma in vano,</l>
             <l part="I">signor, lo speri.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">E chi potrà vietarlo?</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l>Tutto il popolo, o padre: è affatto ormai</l>
             <l>incapace di fren. Per impedirti</l>
@@ -3001,11 +3032,11 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>precipitando al porto; e son di Roma</l>
             <l part="I">già l'altre vie deserte.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="M">E Manlio?</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">È il solo</l>
             <l>che ardisca opporsi ancora</l>
@@ -3018,18 +3049,18 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>in tumulto sì fiero</l>
             <l>esecutori il consolare impero.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="I">Attilia, addio: Publio, mi siegui.</l>
             <stage>
               <emph>(in atto di partire)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">E dove?</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>A soccorrer l'amico; il suo delitto</l>
             <l>a rinfacciare a Roma; a conservarmi</l>
@@ -3039,14 +3070,14 @@ che accettar non si dee. Se non puoi darmi</l>
               <emph>(partendo)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="I">Ah padre! ah no! Se tu mi lasci...</l>
             <stage>
               <emph>(piangendo)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <stage>
               <emph>(serio ma con sdegno)</emph>
@@ -3058,25 +3089,25 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>d'un gran trionfo il vanto</l>
             <l>non congiuri con Roma anche il tuo pianto.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="I">Ah tal pena è per me...</l>
             <stage>
               <emph>(piangendo)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Per te gran pena</l>
             <l>è il perdermi, lo so. Ma tanto costa</l>
             <l part="I">l'onor d'esser romana.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Ogni altri prova</l>
             <l part="I">son pronta...</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">E qual? Co' tuoi consigli andrai</l>
             <l>forse fra i padri a regolar di Roma</l>
@@ -3086,11 +3117,11 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>se a soffrir per la patria atta non sei</l>
             <l>senza viltà, dì, che farai per lei?</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l>È ver. Ma tal costanza...</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>È difficil virtù: ma Attilia al fine</l>
             <l part="I">è mia figlia, e l'avrà.</l>
@@ -3098,25 +3129,25 @@ che accettar non si dee. Se non puoi darmi</l>
               <emph>(partendo)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Sì, quanto io possa,</l>
             <l>gran genitor, t'imiterò. Ma... oh Dio!</l>
             <l>Tu mi lasci sdegnato:</l>
             <l part="I">io perdei l'amor tuo.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">No, figlia; io t'amo,</l>
             <l>io sdegnato non son. Prendine in pegno</l>
             <l>questo amplesso da me. Ma questo amplesso</l>
             <l>costanza, onor, non debolezza inspiri.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l>Ah sei padre, mi lasci, e non sospiri!</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>Io son padre, e nol sarei</l>
             <l>se lasciassi a' figli miei</l>
@@ -3132,7 +3163,7 @@ che accettar non si dee. Se non puoi darmi</l>
         <div type="scene">
           <head>SCENA VII</head>
           <stage>ATTILIA, <emph>poi</emph>  BARCE</stage>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l>Su, costanza, o mio cor. Deboli affetti,</l>
             <l>sgombrate da quest'alma; inaridite</l>
@@ -3143,26 +3174,26 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>ed Attilia non sia</l>
             <l>il ramo sol di sì gran pianta indegno.</l>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l>Attilia, è dunque ver? Dunque a dispetto</l>
             <l>del popol, del Senato,</l>
             <l>degli àuguri, di noi, del mondo intero</l>
             <l part="I">Regolo vuol partir?</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="M">Sì.</l>
             <stage>
               <emph>(con fermezza)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l part="F">Ma che insano</l>
             <l part="I">furor?</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <stage>
               <emph>(come sopra)</emph>
@@ -3170,23 +3201,23 @@ che accettar non si dee. Se non puoi darmi</l>
             <l part="F">Più di rispetto,</l>
             <l part="I">Barce, agli eroi.</l>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l part="F">Come! del padre approvi</l>
             <l part="I">l'ostinato pensier?</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Del padre adoro</l>
             <l part="I">la costante virtù.</l>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l part="F">Virtù che a' ceppi,</l>
             <l>che all'ire altrui, che a vergognosa morte</l>
             <l>certamente dovrà...</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <stage>
               <emph>(s'intenerisce di nuovo)</emph>
@@ -3195,33 +3226,33 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>quell'ire, quel morir del padre mio</l>
             <l part="I">saran trionfi.</l>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l part="M">E tu n'esulti?</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <stage>
               <emph>(piange)</emph>
             </stage>
             <l part="F">(Oh Dio!)</l>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l part="I">Capir non so...</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="F">Non può capir chi nacque</l>
             <l>in barbaro terren per sua sventura</l>
             <l>come al paterno vanto</l>
             <l part="I">goda una figlia.</l>
           </sp>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l part="F">E perché piangi intanto?</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l>Vuol tornar la calma in seno</l>
             <l>quando in lagrime si scioglie</l>
@@ -3237,7 +3268,7 @@ che accettar non si dee. Se non puoi darmi</l>
         <div type="scene">
           <head>SCENA VIII</head>
           <stage>BARCE <emph>sola.</emph> </stage>
-          <sp>
+          <sp who="#barce">
             <speaker>BARCE</speaker>
             <l>Che strane idee questa produce in Roma</l>
             <l>avidità di lode! Invidia i ceppi</l>
@@ -3263,41 +3294,41 @@ che accettar non si dee. Se non puoi darmi</l>
           <head>SCENA IX</head>
           <stage>Portici magnifici su le rive del Tevere. Navi pronte nel fiume per l'imbarco di Regolo. Ponte che conduce alla più vicina di quelle. Popolo numeroso, che impedisce il passaggio delle navi. Africani su le medesime. Littori col console.</stage>
           <stage>MANLIO <emph>e</emph>  LICINIO</stage>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l>No, che Regolo parta</l>
             <l part="I">Roma non vuole.</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="F">Ed il Senato ed io</l>
             <l part="I">non siam parte di Roma?</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l part="F">Il popol tutto</l>
             <l part="I">è la maggior.</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="M">Non la più sana.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l part="F">Almeno</l>
             <l>la men crudel. Noi conservar vogliamo</l>
             <l>pieni di gratitudine e d'amore</l>
             <l part="I">a Regolo la vita.</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="F">E noi l'onore.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l part="I">L'onor...</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="F">Basta; io non venni</l>
             <l>a garrir teco. Olà: libero il varco</l>
@@ -3306,32 +3337,32 @@ che accettar non si dee. Se non puoi darmi</l>
               <emph>(al popolo)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <stage>
               <emph>(al medesimo)</emph>
             </stage>
             <l part="F">Olà: nessun si parta.</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="I">Io l'impongo.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l part="M">Io lo vieto.</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="F">Osa Licinio</l>
             <l part="I">al console d'opporsi?</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l part="F">Osa al tribuno</l>
             <l part="I">d'opporsi Manlio?</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="F">Or si vedrà. Littori,</l>
             <l part="I">sgombrate il passo.</l>
@@ -3339,7 +3370,7 @@ che accettar non si dee. Se non puoi darmi</l>
               <emph>(i littori innalzando le scuri tentano avanzarsi)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l part="F">Il passo</l>
             <l part="I">difendete, o Romani.</l>
@@ -3347,23 +3378,23 @@ che accettar non si dee. Se non puoi darmi</l>
               <emph>(al popolo, che si mette in difesa)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="F">Oh dei! Con l'armi</l>
             <l>si resiste al mio cenno? In questa guisa</l>
             <l part="I">la maestà...</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l part="F">La maestade in Roma</l>
             <l>nel popolo risiede; e tu l'oltraggi</l>
             <l>contrastando con lui.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>POPOLO</speaker>
             <l part="I">Regolo resti.</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <stage>
               <emph>(al popolo)</emph>
@@ -3371,15 +3402,15 @@ che accettar non si dee. Se non puoi darmi</l>
             <l part="F">Udite:</l>
             <l>lasciate che l'inganno io manifesti.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>POPOLO</speaker>
             <l part="I">Resti Regolo.</l>
           </sp>
-          <sp>
+          <sp who="#manlio">
             <speaker>MANLIO</speaker>
             <l part="M">Ah voi...</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>POPOLO</speaker>
             <l part="F">Regolo resti.</l>
           </sp>
@@ -3387,7 +3418,7 @@ che accettar non si dee. Se non puoi darmi</l>
         <div type="scene">
           <head>SCENA ULTIMA</head>
           <stage>REGOLO <emph>e seco tutti.</emph> </stage>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>«Regolo resti!» Ed io l'ascolto! Ed io</l>
             <l>creder deggio a me stesso! Una perfidia</l>
@@ -3400,13 +3431,13 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>«Regolo resti!» Ah per qual colpa e quando</l>
             <l part="I">meritai l'odio vostro?</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l part="F">È il nostro amore,</l>
             <l>signor, quel che pretende</l>
             <l part="I">franger le tue catene.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">E senza queste</l>
             <l>Regolo che sarà? Queste mi fanno</l>
@@ -3416,24 +3447,24 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>se di queste mi privo,</l>
             <l>che uno schiavo spergiuro e fuggitivo.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l>A perfidi giurasti,</l>
             <l part="I">giurasti in ceppi; e gli àuguri...</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Eh lasciamo</l>
             <l>all'Arabo ed al Moro</l>
             <l>questi d'infedeltà pretesti indegni.</l>
             <l>Roma a' mortali a serbar fede insegni.</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l>Ma che sarà di Roma,</l>
             <l part="I">se perde il padre suo?</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Roma rammenti</l>
             <l>che il suo padre è mortal; che al fin vacilla</l>
@@ -3460,34 +3491,34 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>favor da voi domando;</l>
             <l>esorto, cittadin; padre, comando.</l>
           </sp>
-          <sp>
+          <sp who="#attilia">
             <speaker>ATTILIA</speaker>
             <l part="I">(Oh Dio! Ciascun già l'ubbidisce).</l>
           </sp>
-          <sp>
+          <sp who="#publio">
             <speaker>PUBLIO</speaker>
             <l part="F">(Oh Dio!</l>
             <l>ecco ogni destra inerme).</l>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker>LICINIO</speaker>
             <l part="I">Ecco sgombro il sentier.</l>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l part="F">Grazie vi rendo,</l>
             <l>propizi dei: libero è il passo. Ascendi,</l>
             <l>Amilcare, alle navi;</l>
             <l>io sieguo i passi tui.</l>
           </sp>
-          <sp>
+          <sp who="#amilcare">
             <speaker>AMILCARE</speaker>
             <l>(Al fin comincio ad invidiar costui).</l>
             <stage>
               <emph>(sale su la nave)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#regolo">
             <speaker>REGOLO</speaker>
             <l>Romani, addio. Siano i congedi estremi</l>
             <l>degni di noi. Lode agli dei, vi lascio,</l>
@@ -3509,7 +3540,7 @@ che accettar non si dee. Se non puoi darmi</l>
             <l>tutta l'ira del Ciel sul capo mio:</l>
             <l>ma Roma illesa... Ah qui si piange! Addio.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO DI ROMANI</speaker>
             <l>Onor di questa sponda,</l>
             <l>padre di Roma, addio.</l>

--- a/tei/metastasio-demetrio.xml
+++ b/tei/metastasio-demetrio.xml
@@ -85,6 +85,31 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="cleonice">
+            <persName>Cleonice</persName>
+          </person>
+          <person xml:id="olinto">
+            <persName>Olinto</persName>
+          </person>
+          <person xml:id="barsene">
+            <persName>Barsene</persName>
+          </person>
+          <person xml:id="mitrane">
+            <persName>Mitrane</persName>
+          </person>
+          <person xml:id="fenicio">
+            <persName>Fenicio</persName>
+          </person>
+          <person xml:id="coro">
+            <persName>Coro</persName>
+          </person>
+          <person xml:id="alceste">
+            <persName>Alceste</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -127,7 +152,7 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <emph>Gabinetto illuminato, con sedia e tavolino da un lato con sopra scettro e corona.</emph>
           </stage>
           <stage>CLEONICE,<emph>che siede appoggiata al tavolino, ed</emph> OLINTO</stage>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>Basta, Olinto, non più. Fra pochi istanti</l>
             <l>al destinato loco</l>
@@ -146,7 +171,7 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>servì lo Scita, ed in diverso lido</l>
             <l>Babilonia a Semira, Africa a Dido.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l>Perdonami, o regina;</l>
             <l>di noi ti lagni a torto. I pregi tuoi</l>
@@ -159,13 +184,13 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>già promesso da te per suo conforto;</l>
             <l>e ti lagni di noi? Ti lagni a torto.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>E ben, se tanto il regno</l>
             <l>confida a me, di pochi istanti ancora</l>
             <l part="I">non mi nieghi l'indugio.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">Oh Dio, regina,</l>
             <l>tante volte deluse</l>
@@ -184,11 +209,11 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>or che dagli occhi tuoi</l>
             <l>cadde improvviso e involontario il pianto.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="I">Fu giusto il mio timor.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">Dopo sì lievi</l>
             <l>mendicati pretesti, in questo giorno</l>
@@ -212,11 +237,11 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>a riveder la luce i preziosi</l>
             <l>dall'avaro timor tesori ascosi.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>Inutile sollievo a mia sventura.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l>Ma che prò tanta cura,</l>
             <l>tanto studio che prò? Se, attesa in vano</l>
@@ -229,7 +254,7 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>sembra ogn'indugio insufficiente e corto.</l>
             <l>E ti lagni di noi? Ti lagni a torto.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>Pur troppo è ver, pur troppo</l>
             <l>convien ch'io serva a questa</l>
@@ -237,53 +262,53 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>il mio venir. Sarà contento il regno;</l>
             <l part="I">lo sposo sceglierò.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">Pensa, rammenta</l>
             <l>che suddito fedele</l>
             <l>Olinto t'ammirò; che il sangue mio...</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>Lo so: d'illustri eroi</l>
             <l part="I">per le vene trascorse.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">Aggiungi a questo</l>
             <l part="I">i merti di Fenicio...</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">A me son noti.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="I">Sai de' consigli suoi...</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">De' suoi consigli</l>
             <l>io conosco il valor; distinguo il pregio</l>
             <l>della sua fedeltà. Tutto pensai,</l>
             <l part="I">tutto, Olinto, io già so.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">Tutto non sai.</l>
             <l>Già da lunga stagion tacito amante</l>
             <l>all'amorose faci</l>
             <l part="I">mi struggo de' tuoi lumi...</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Ah parti, e taci.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="I">Come tacere!</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">E ti par tempo, Olinto,</l>
             <l part="I">di parlarmi d'amor?</l>
@@ -291,16 +316,16 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
               <emph>(s'alza da sedere)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">Perché sdegnarti,</l>
             <l part="I">s'io chiedendo mercé...</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Ma taci, e parti.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l>Di quell'ingiusto sdegno</l>
             <l>io la cagion non vedo.</l>
@@ -318,7 +343,7 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
         <div type="scene">
           <head>SCENA II</head>
           <stage>CLEONICE <emph>e poi</emph> BARSENE</stage>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>Alceste, amato Alceste,</l>
             <l>dove sei? Non m'ascolti! In van ti chiamo;</l>
@@ -330,7 +355,7 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>mi rechi forse? Il mio diletto Alceste</l>
             <l part="I">forse tornò?</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l part="F">Volesse il Cielo. Io vengo,</l>
             <l>regina, ad affrettarti. Il popol tutto</l>
@@ -338,7 +363,7 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>Non puoi senza periglio</l>
             <l part="I">più differir.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Misera me! Si vada</l>
             <stage>
@@ -354,13 +379,13 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
               <emph>(si getta a sedere)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l part="F">Qual arte è questa</l>
             <l>di tormentar te stessa, ove non sono,</l>
             <l part="I">figurando sventure?</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">È figurato</l>
             <l>forse il dover, che mi costringe a farmi</l>
@@ -369,7 +394,7 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>con finto amor della mia destra il dono</l>
             <l>si duol che compra a caro prezzo il trono?</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l>È ver: ma il sacro nodo,</l>
             <l>i reciprochi pegni</l>
@@ -378,7 +403,7 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>il genio avverso a poco a poco in seno</l>
             <l>cangia in amore, o in amicizia almeno.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>E se tornando Alceste</l>
             <l>mi ritrovasse ad altro sposo in braccio,</l>
@@ -393,7 +418,7 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>ogni pensier sepolto,</l>
             <l>tutto il suo cor gli leggerei nel volto.</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l>Come sperar ch'ei torni? Omai trascorsa</l>
             <l>è un'intera stagion, da che trafitto</l>
@@ -403,12 +428,12 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>di lui s'intese. O di catene è cinto,</l>
             <l>o sommerso è fra l'onde, o in guerra estinto.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>No, mel predice il core, Alceste vive,</l>
             <l part="I">Alceste tornerà.</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l part="F">Quando ritorni,</l>
             <l>più infelice sarai. Se a lui ti doni,</l>
@@ -418,7 +443,7 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>t'esporrebbe al cimento</l>
             <l>d'esser crudele ad uno o ingiusta a cento.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>Ritorni, e a lui vicina</l>
             <l part="I">qualche via troverò...</l>
@@ -427,7 +452,7 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
         <div type="scene">
           <head>SCENA III</head>
           <stage>MITRANE <emph> e dette.</emph></stage>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l part="F">Che fai, regina?</l>
             <l>Il periglio s'avanza. A poco a poco</l>
@@ -435,7 +460,7 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>degenera in tumulto. Unico scampo</l>
             <l part="I">è la presenza tua.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Questo, Barsene,</l>
             <l>è il ritorno d'Alceste?... Andar conviene.</l>
@@ -443,28 +468,28 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
               <emph>(s'alza da sedere)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l part="I">E scegliesti?</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Non scelsi.</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l part="I">Ma che farai?</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="M">Non so.</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l part="F">Dunque t'esponi</l>
             <l part="I">irresoluta a sì gran passo?</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Io vado</l>
             <l>dove vuole il destin, dove la dura</l>
@@ -488,30 +513,30 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
         <div type="scene">
           <head>SCENA IV</head>
           <stage>BARSENE <emph>e</emph> MITRANE</stage>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l>Infelice regina,</l>
             <l part="I">quanto mi fa pietà!</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l part="F">Tanta per lei</l>
             <l>pietà sente Barsene,</l>
             <l part="I">e sì poca per me?</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l part="F">S'altro non chiedi</l>
             <l>che pietà, l'ottenesti. Amor se speri,</l>
             <l part="I">indarno ti lusinghi.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l part="F">E non son io</l>
             <l>già misero abbastanza?</l>
             <l>Perché toglier mi vuoi fin la speranza?</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l>Misero tu non sei:</l>
             <l>tu spieghi il tuo dolore,</l>
@@ -529,84 +554,84 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
         <div type="scene">
           <head>SCENA V</head>
           <stage>MITRANE, <emph>poi</emph> FENICIO</stage>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l part="I">Inutile pietà.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">Mitrane amico,</l>
             <l part="I">Cleonice dov'è?</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l part="F">Costretta al fine</l>
             <l part="I">s'incammina alla scelta.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">Ecco perdute</l>
             <l part="I">tutte le cure mie.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l part="M">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">Conviene</l>
             <l>ch'io sveli alla tua fede un grande arcano.</l>
             <l part="I">Tacilo e mi consiglia.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l part="F">A me ti fida:</l>
             <l part="I">impegno l'onor mio.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">Già ti sovviene</l>
             <l>che 'l barbaro Alessandro,</l>
             <l>di Cleonice genitor, dal trono</l>
             <l part="I">scacciò Demetrio il nostro re.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l part="F">Saranno</l>
             <l>omai sei lustri, e n'ho presente il caso.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l>Sai che Demetrio oppresso</l>
             <l>morì nel duro esilio; e inteso avrai</l>
             <l>che pargoletto in fasce</l>
             <l part="I">seco il figlio morì.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l part="F">Rammento ancora</l>
             <l part="I">che Demetrio ebbe nome.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">Or sappi, amico,</l>
             <l>che vive il real germe,</l>
             <l part="I">ed a te non ignoto.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l part="F">Il ver mi narri,</l>
             <l>o pur fole son queste?</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l>Anche più ti dirò. Vive in Alceste.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l part="I">Numi, che ascolto!</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">In queste braccia il padre</l>
             <l>lo depose fuggendo. Ei mi prescrisse</l>
@@ -616,13 +641,13 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>«Conserva il caro pegno</l>
             <l>al genitore, alla vendetta, al regno».</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l>Or la ragion comprendo</l>
             <l>del tuo zelo per lui. Ma per qual fine</l>
             <l part="I">celarlo tanto?</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">Avventurar non volli</l>
             <l>una vita sì cara. Io sparsi ad arte</l>
@@ -640,14 +665,14 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>non so s'ei viva; e Cleonice intanto</l>
             <l part="I">elegge un re.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l part="F">Ma Cleonice elegga:</l>
             <l>sempre, quando ritorni, e che 'l soccorso</l>
             <l>abbia di Creta, Alceste</l>
             <l part="I">vendicar si potrà.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">Questa non era,</l>
             <l>Mitrane, il mio pensier. Sperai che un giorno,</l>
@@ -665,7 +690,7 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>tu mi seconda; e, se coll'armi è d'uopo,</l>
             <l>tu coll'armi m'assisti.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l>Ecco tutto il mio sangue. In miglior uso</l>
             <l>mai versar nol potrò. Chiamasi acquisto</l>
@@ -673,7 +698,7 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>a favor del suo re. Sì bella morte</l>
             <l>invidiata saria.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l>Vieni al mio seno,</l>
             <l>generoso vassallo. Ai detti tuoi</l>
@@ -699,7 +724,7 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
         <div type="scene">
           <head>SCENA VI</head>
           <stage>MITRANE</stage>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l>Non poteva un Alceste</l>
             <l>nascer fra le capanne. Il suo sembiante</l>
@@ -725,33 +750,33 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <emph>Luogo magnifico con trono da un lato e sedili in faccia al suddetto trono per li grandi del regno. Vista in prospetto del gran porto di Seleucia con molo. Navi illuminate per solennizzare l'elezione del nuovo re.</emph>
           </stage>
           <stage>CLEONICE, <emph>preceduta dai grandi del regno, seguìta da </emph>FENICIO <emph>e da </emph>OLINTO; <emph>guardie e popolo.</emph></stage>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Ogni nume ed ogni diva</l>
             <l>sia presente al gran momento,</l>
             <l>che palesa il nostro re.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>PRIMO CORO</speaker>
             <l>Scenda Marte, Amor discenda,</l>
             <l>senza spada e senza benda.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>SECONDO CORO</speaker>
             <l>Coll'ulivo e colla face</l>
             <l>Imeneo venga e la Pace.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>PRIMO CORO</speaker>
             <l>Venga Giove ed abbia a lato</l>
             <l>gli altri dei, la Sorte e 'l Fato.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>SECONDO CORO</speaker>
             <l>Ma non abbia in questa riva</l>
             <l>i suoi fulmini con sé.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Ogni nume ed ogni diva</l>
             <l>sia presente al gran momento,</l>
@@ -760,25 +785,25 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
               <emph>(Nel tempo che si canta il suddetto coro, Cleonice servita da Fenicio, va in trono a sedere)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l>Dal tuo labbro, o regina, il suo monarca</l>
             <l>la Siria tutta impaziente attende.</l>
             <l>Risolvi. Ognuno il gran momento affretta</l>
             <l>con silenzio modesto.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>Sedete. (Oh dei, che gran momento è questo!)</l>
             <stage>
               <emph>(siedono Fenicio, Olinto e gli altri grandi)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="I">(Che mai farò?)</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Voi m'innalzaste al trono:</l>
             <l>son grata al vostro amor; ma troppo è il peso,</l>
@@ -790,16 +815,16 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>cangiamenti in un'ora.</l>
             <l>A sceglier vengo, e sono incerta ancora.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l>E ben, prendi, o regina,</l>
             <l part="I">maggior tempo a pensar.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="M">Come!</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">T'accheta.</l>
             <l>Teco tanto indiscreta.</l>
@@ -809,19 +834,19 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>non è la Siria; e ognun di noi conosce</l>
             <l part="I">quanto è grande il cimento.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">È dunque poco</l>
             <l>il giro di tre lune? In questa guisa,</l>
             <l>Cleonice, potrai</l>
             <l>prometter sempre e non risolver mai.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l>Audace, e chi ti rese</l>
             <l part="I">temerario a tal segno?</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">Il zelo, il giusto,</l>
             <l>il periglio di lei. Se ancor delusa</l>
@@ -829,7 +854,7 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>dove giunger potrebbe</l>
             <l part="I">l'intolleranza sua.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">Potrebbe forse</l>
             <l>pentirsi dell'ardir. Chi siede in trono</l>
@@ -839,7 +864,7 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>per la sua libertà</l>
             <l part="I">tutto si verserà...</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Fenicio, oh Dio!</l>
             <l>non risvegliar, ti prego,</l>
@@ -847,12 +872,12 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>Sempre incerta sarei.</l>
             <l part="I">Udite. Io sceglierò...</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">Sceglier non dèi.</l>
             <l part="I">(S'avventuri l'arcano).</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">A noi che porta</l>
             <l part="I">frettoloso Mitrane?</l>
@@ -864,31 +889,31 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
         <div type="scene">
           <head>SCENA VIII</head>
           <stage>MITRANE, <emph>poi</emph> ALCESTE <emph>dal porto, e detti.</emph></stage>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l part="F">In questo punto</l>
             <l>sopra picciolo legno Alceste è giunto.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="I">(Numi!)</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="M">(Respiro!)</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="M">Ove si trova?</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <stage>
               <emph>(accennando verso il porto)</emph>
             </stage>
             <l part="F">Ei viene.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <stage>
               <emph>(s'alza dal trono, e seco s'alzano tutti)</emph>
@@ -900,11 +925,11 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
               <emph>(torna a sedere. Fenicio e Mitrane vanno ad incontrare Alceste, che in picciola barca si vede approdare, e l'abbracciano)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="I">(Inopportuno arrivo!)</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">(Ecco il mio bene.</l>
             <stage>
@@ -913,7 +938,7 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>Tu palpiti, o cor mio,</l>
             <l>che riconosci, oh Dio! le tue catene).</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>Pur mi concede il fato</l>
             <l>il piacer sospirato</l>
@@ -925,47 +950,47 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>fra le cure del regno</l>
             <l>d'un regio sguardo il mio tributo è degno.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>E privata e sovrana</l>
             <l>l'istessa Cleonice in me ritrovi.</l>
             <l>Oh quanto, Alceste, oh quanto</l>
             <l>atteso giungi, e sospirato, e pianto!</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="I">(Torno a sperar).</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Ma qual disastro a noi</l>
             <l part="I">sì gran tempo ti tolse?</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">(Oh sofferenza!)</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>Sai che la mia partenza</l>
             <l part="I">col re tuo genitor...</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">Sappiamo, Alceste,</l>
             <l>la pugna, le tempeste,</l>
             <l part="I">di lui la morte e le vicende...</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Il resto</l>
             <l part="I">dunque giovi ascoltar. Siegui.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">(Che pena!)</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>Al cader d'Alessandro in noi l'ardire</l>
             <l>tutto mancò. Già le nemiche squadre</l>
@@ -982,11 +1007,11 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>da cento parti il sangue,</l>
             <l>perdei l'uso de' sensi e caddi esangue.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="I">(Mi fa pietà).</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">Quindi in balìa dell'onde</l>
             <l>quanto errai non so dirti. Aprendo il ciglio,</l>
@@ -997,11 +1022,11 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>eran di nasse e reti; e curvo e bianco</l>
             <l>pietoso pescator mi stava al fianco.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="I">Ma in qual terra giungesti?</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">In Creta: ed era</l>
             <l>cretense il pescator. Questi sul lido</l>
@@ -1012,16 +1037,16 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>dopo lungo soggiorno</l>
             <l>di quel picciolo legno il mio ritorno.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="I">Oh strani eventi!</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">Al fine</l>
             <l>l'istoria terminò. Tempo sarebbe...</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>T'intendo, Olinto; io sceglierò lo sposo.</l>
             <l part="I">Ciascun sieda e m'ascolti.</l>
@@ -1029,7 +1054,7 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
               <emph>(Fenicio, Olinto e gli altri grandi siedono)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">(Io ritornai</l>
             <l part="I">opportuno alla scelta).</l>
@@ -1037,75 +1062,75 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
               <emph>(Alceste, volendo sedere, è impedito da Olinto)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">Olà, che fai?</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="I">Servo al cenno real.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">Come! al mio fianco</l>
             <l>vedrà la Siria un vil pastore assiso?</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>La Siria ha già diviso</l>
             <l>Alceste dal pastor. Depose Alceste</l>
             <l>tutto l'esser primiero,</l>
             <l>allor che di pastor si fé guerriero.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l>Ma in quelle vene ancora</l>
             <l part="I">scorre l'ignobil sangue.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">In queste vene</l>
             <l>tutto si rinnovò: tutto il cangiai,</l>
             <l>quando in vostra difesa io lo versai.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l>Ma qual de' tuoi maggiori</l>
             <l>a tant'oltre aspirar t'aprì la strada?</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>Il mio cor, la mia destra e la mia spada.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="I">Dunque...</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="M">Eh taci una volta.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">Almen si sappia</l>
             <l>la chiarezza qual è degli avi sui.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l>Finisce in te, quando comincia in lui.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>Non più: nel mio comando</l>
             <l part="I">si nobilita Alceste.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">In questo loco</l>
             <l>solo ai gradi supremi</l>
             <l part="I">di sedere è permesso.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">E bene, Alceste</l>
             <l>sieda duce dell'armi,</l>
@@ -1115,26 +1140,26 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
               <emph>(Alceste siede, e Olinto si alza)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">Ah questo è troppo. A lui</l>
             <l>dona te stessa ancor. Conosce ognuno</l>
             <l part="I">dove giunger tu brami.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">In questa guisa,</l>
             <l>temerario, rispondi? Al braccio mio</l>
             <l>lascia il peso, o regina,</l>
             <l part="I">di punir quell'audace.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Ai merti suoi,</l>
             <l>all'inesperta età tutto perdono,</l>
             <l part="I">ma taccia in avvenir.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">Siedi, e raffrena</l>
             <l>tacendo almeno il violento ingegno.</l>
@@ -1143,14 +1168,14 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
               <emph>(ad Olinto)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">Ubbidirò. (Fremo di sdegno).</l>
             <stage>
               <emph> (torna a sedere)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>Scelsi già nel mio cor: ma, pria che faccia</l>
             <l>palese il mio pensiero, un'altra io bramo</l>
@@ -1159,36 +1184,36 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>sia di Siria o straniero,</l>
             <l>o sia di chiaro o sia di sangue oscuro.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="I">(Come tacer!)</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">Su la mia fé lo giuro.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="I">Siegui, Olinto.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">Non parli?</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="I">Lasciatemi tacer.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Forse ricusi?</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l>Io n'ho ragion. Né solo</l>
             <l>m'oppongo al giuramento. Altri vi sono...</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>E ben, su questo trono</l>
             <stage>
@@ -1197,13 +1222,13 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>regni chi vuole. Io d'un servile impero</l>
             <l part="I">non voglio il peso.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">Eh non curar di pochi</l>
             <l>il contrasto, o regina, in faccia a tanti</l>
             <l part="I">rispettosi vassalli.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">In faccia mia</l>
             <l>l'ardir di pochi io tollerar non deggio.</l>
@@ -1233,33 +1258,33 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
         <div type="scene">
           <head>SCENA IX</head>
           <stage>FENICIO, OLINTO <emph>ed</emph> ALCESTE</stage>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l>Così de' tuoi trasporti</l>
             <l>sempre arrossir degg'io? Né mai de' saggi</l>
             <l>il commercio, l'esempio</l>
             <l part="I">emendar ti farà?</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">Ma, padre, io soffro</l>
             <l>ingiustizia da te. Potresti al soglio</l>
             <l part="I">innalzarmi, e m'opprimi.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">Avrebbe in vero</l>
             <l>la Siria un degno re; torbido, audace,</l>
             <l part="I">violento, inquieto...</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">Il caro Alceste</l>
             <l>saria placido, umìle,</l>
             <l>generoso, prudente... Ah chi d'un padre</l>
             <l>gli affetti ad acquistar l'arte m'addìta!</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l>Vuoi gli affetti d'un padre? Alceste imìta.</l>
             <l>Se fecondo e vigoroso</l>
@@ -1278,7 +1303,7 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
         <div type="scene">
           <head>SCENA X</head>
           <stage>OLINTO <emph>ed</emph> ALCESTE</stage>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l>Nelle tue scuole il padre</l>
             <l>vuol ch'io virtude apprenda. E bene, Alceste,</l>
@@ -1286,19 +1311,19 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>così l'ingegno mio facile e destro,</l>
             <l>che non faccia arrossir sì gran maestro.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>Signor, quei detti amari</l>
             <l>soffro solo da te. Senza periglio</l>
             <l>tutto può dir chi di Fenicio è figlio.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l>Io poco saggio in vero</l>
             <l>ragionai col mio re. Signor, perdona</l>
             <l>se offendo in te la maestà del soglio.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>Olinto, addio. Più cimentar non voglio</l>
             <l>la sofferenza mia. Tu scherzi meco,</l>
@@ -1320,7 +1345,7 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
         <div type="scene">
           <head>SCENA XI</head>
           <stage>OLINTO</stage>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l>Chi di costui l'oscura</l>
             <l>origine ignorasse, ai detti alteri</l>
@@ -1345,20 +1370,20 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <emph>Giardino interno nel palazzo reale</emph>
           </stage>
           <stage>CLEONICE, BARSENE, <emph>poi</emph> FENICIO</stage>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>Dunque, perch'io l'adoro,</l>
             <l>tutto il mondo ad Alceste oggi è nemico?</l>
             <l>Questo contrasto appunto</l>
             <l part="I">più impegna l'amor mio.</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l part="F">Ma in questo istante</l>
             <l>forse il Consiglio a tuo favor decise.</l>
             <l part="I">Che giova innanzi tempo...</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Eh ch'io conosco</l>
             <l>dell'invidia il poter. Forse a quest'ora</l>
@@ -1366,11 +1391,11 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>misera mi farà l'altrui livore.</l>
             <l>È un gran regno per me d'Alceste il core.</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l part="I">(Oh gelosia!)</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Decise</l>
             <l part="I">il Consiglio, o Fenicio?</l>
@@ -1378,17 +1403,17 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
               <emph>(a Fenicio, che sopraggiunge)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="M">Appunto.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Il resto,</l>
             <l>senza che parli, intendo.</l>
             <l part="I">Il mio regno finì.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">Meglio, o regina,</l>
             <l>giudica della Siria. I tuoi vassalli</l>
@@ -1400,12 +1425,12 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>di chiara stirpe, o di progenie oscura,</l>
             <l>ciascuno adorerà, ciascuno il giura.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>Come! in sì brevi istanti</l>
             <l part="I">sì da prima diversi?</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">Ah, tu non sai</l>
             <l>quanta fede è ne' tuoi: nel gran consesso</l>
@@ -1416,11 +1441,11 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>impeto di piacer, regina, ah come</l>
             <l>udia sonar di Cleonice il nome!</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l part="I">(Infelice amor mio!)</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Vanne; al Consiglio</l>
             <l>riporta i sensi miei. Dì che 'l mio core</l>
@@ -1429,40 +1454,40 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>che non si penta il regno</l>
             <l>di sua fiducia in me; che grata io sono.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l>(Ecco in Alceste il vero erede al trono).</l>
             <stage>
               <emph>(parte)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l>Vedi come la sorte</l>
             <l>i tuoi voti seconda. Ecco appagato</l>
             <l>appieno il tuo desio,</l>
             <l part="I">ecco finito ogni tormento.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Oh Dio!</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l>Tu sospiri? Io non vedo</l>
             <l>ragion di sospirar. L'amato bene</l>
             <l>in questo punto acquisti, e ancor non sai</l>
             <l>le luci serenar torbide e meste?</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>Cara Barsene, ora ho perduto Alceste.</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l part="I">Come perduto!</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">E vuoi</l>
             <l>che siano i miei vassalli</l>
@@ -1476,11 +1501,11 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>l'invidia a superar; ma, quella oppressa,</l>
             <l>or mi consiglia a superar me stessa.</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l part="I">Alceste che dirà?</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Se m'ama Alceste,</l>
             <l>amerà la mia gloria: andrà superbo</l>
@@ -1488,12 +1513,12 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>si distingua così co' propri vanti</l>
             <l>dalla schiera volgar degli altri amanti.</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l>Non so se in faccia a lui</l>
             <l part="I">ragionerai così.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Questo cimento,</l>
             <l>amica, io fuggirò. Non so se avrei</l>
@@ -1505,37 +1530,37 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
         <div type="scene">
           <head>SCENA XIII</head>
           <stage>MITRANE <emph>e dette, poi</emph> ALCESTE</stage>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l part="I">Chiede Alceste l'ingresso.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Oh Dio, Barsene!</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l>Or tempo è di costanza.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="I">Va; non deggio per ora...</l>
             <stage>
               <emph>(a Mitrane)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l part="F">Egli s'avanza.</l>
             <stage>
               <emph>(parte)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="I">(Resisti, anima mia).</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">Senza riguardi</l>
             <l>la mia bella regina</l>
@@ -1546,11 +1571,11 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>sola de' pensier miei cura gradita,</l>
             <l>il mio ben, la mia gloria e la mia vita.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="I">Deh non parlar così.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">Come! uno sfogo</l>
             <l>dell'amor mio verace,</l>
@@ -1560,22 +1585,22 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>Son io quello, che tanto</l>
             <l>atteso giunge, e sospirato, e pianto?</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="I">(Che pena!)</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">Intendo, intendo,</l>
             <l>bastò la lontananza</l>
             <l>di poche lune a ricoprir di gelo</l>
             <l part="I">di due lustri l'amor.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Volesse il Cielo!</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>Volesse il Ciel! Qual colpa,</l>
             <l>qual demerito è in me? S'io mai t'offesi,</l>
@@ -1585,7 +1610,7 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>arbitri del mio cor, del viver mio.</l>
             <l part="I">Guardami, parla.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">(Ah non resisto!) Addio.</l>
             <stage>
@@ -1596,7 +1621,7 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
         <div type="scene">
           <head>SCENA XIV</head>
           <stage>ALCESTE<emph>e</emph> BARSENE</stage>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>Numi, che avvenne mai! Que' dubbi accenti,</l>
             <l>quel pallor, quei sospiri</l>
@@ -1606,13 +1631,13 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>È incostanza di lei?</l>
             <l>È ingiustizia degli astri? È colpa mia?</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l>Le smanie del tuo core</l>
             <l>mi fan pietà. Forse con altra amante</l>
             <l part="I">più felice saresti.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">Ah giunga prima</l>
             <l>l'ultimo de' miei giorni. Io voglio amarla</l>
@@ -1636,7 +1661,7 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
         <div type="scene">
           <head>SCENA XV</head>
           <stage>BARSENE</stage>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l>Infelice cor mio, qual altro attendi</l>
             <l>disinganno maggiore! Indarno aspiri</l>
@@ -1672,7 +1697,7 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <emph>Galleria.</emph>
           </stage>
           <stage>ALCESTE <emph>ed</emph> OLINTO</stage>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>E tu per qual ragione</l>
             <l>mi contendi l'ingresso? Al regio piede</l>
@@ -1681,17 +1706,17 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
               <emph>(in atto d'innoltrarsi)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">Andar non lice:</l>
             <l>la regina lo vieta, Olinto il dice.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>Attenderò fin tanto</l>
             <l>che fia permesso il presentarmi a lei.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l>Son pure i detti miei</l>
             <l>chiari abbastanza. A Cleonice innanzi</l>
@@ -1699,17 +1724,17 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>alla real dimora,</l>
             <l>né mai più vuol mirarti. Intendi ancora?</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>Più mirarmi non vuole? Oh dei! mi sento</l>
             <l part="I">stringere il cor.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">Questo comando, Alceste,</l>
             <l>t'agghiaccia, io me n'avvedo.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>No, perdonami, Olinto, io non ti credo.</l>
             <l>Non è la mia regina</l>
@@ -1717,18 +1742,18 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>che a sì gran pena un suo fedel condanni.</l>
             <l>O ingannar ti lasciasti, o tu m'inganni.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l>E ardisci dubitar de' detti miei?</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>Se troppo ardisco, io lo saprò da lei.</l>
             <stage>
               <emph>(in atto d'entrare s'incontra in Mitrane)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="I">Fermati.</l>
           </sp>
@@ -1736,28 +1761,28 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
         <div type="scene">
           <head>SCENA II</head>
           <stage>MITRANE <emph>e detti.</emph></stage>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l part="F">Alceste, e dove?</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>Non arrestarmi. A Cleonice io vado.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l>Amico, a te l'ingresso</l>
             <l>all'aspetto real non è permesso.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>Ed è vero il divieto?</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l part="I">Pur troppo è ver.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">Deh, per pietà, Mitrane,</l>
             <l>intercedi per me. Ritorna a lei:</l>
@@ -1766,21 +1791,21 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>che reo non sono; e che, se reo mi crede,</l>
             <l>io saprò discolparmi al regio piede.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l>Ubbidirti non posso. Ha la regina</l>
             <l>che di te non si parli a noi prescritto;</l>
             <l>e 'l nominarle Alceste anch'è delitto.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="I">Ma qual è la cagione?</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l part="F">A me la tace.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>Ah son tradito! Una calunnia infame</l>
             <l>mi fa reo nel suo core:</l>
@@ -1790,12 +1815,12 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>correrò disperato</l>
             <l part="I">a trafiggergli il sen.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">Queste minacce</l>
             <l part="I">sono inutili, Alceste.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">Amici, oh Dio!</l>
             <l>perdonate i trasporti</l>
@@ -1824,13 +1849,13 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
         <div type="scene">
           <head>SCENA III</head>
           <stage>OLINTO <emph>e</emph>MITRANE</stage>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l>La caduta d'Alceste al fin, Mitrane,</l>
             <l>m'assicura lo scettro. Io con la speme</l>
             <l part="I">ne prevengo il piacer.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l part="F">Fidarsi tanto</l>
             <l>non deve il saggio alle speranze. Un bene</l>
@@ -1848,12 +1873,12 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>ancor nel regio stato</l>
             <l>infelice sarai, come privato.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l>Felicità non credi</l>
             <l part="I">del comando il piacer?</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l part="F">L'uso d'un bene</l>
             <l>ne scema il senso. Ogni piacer sperato</l>
@@ -1861,18 +1886,18 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>di qual peso è il diadema, e quanto studio</l>
             <l part="I">costi l'arte del regno.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">Il regno istesso</l>
             <l part="I">a regnare ammaestra.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l part="F">È ver; ma sempre</l>
             <l>s'impara errando: ed ogni lieve errore</l>
             <l part="I">si fa grande in un re.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">Tanta dottrina</l>
             <l>non intendo, Mitrane. Il brando e l'asta</l>
@@ -1882,35 +1907,35 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>età più ferma, e frequentar conviene</l>
             <l>d'Egitto i tempii, o i portici d'Atene.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l>Ma d'Atene e d'Egitto</l>
             <l>il saper non bisogna</l>
             <l>per serbarsi fedel. Tu fino ad ora</l>
             <l part="I">non amasti Barsene?</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">E l'amo ancora.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l>E puoi, Barsene amando,</l>
             <l>compiacerti d'un trono,</l>
             <l part="I">per cui la perdi?</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">E comparar tu puoi</l>
             <l>la perdita d'un core</l>
             <l part="I">coll'acquisto d'un regno?</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l part="F">A queste prove</l>
             <l part="I">chi è fedel si distingue.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">Eh che in amore</l>
             <l>fedeltà non si trova. In ogni loco</l>
@@ -1931,7 +1956,7 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
         <div type="scene">
           <head>SCENA IV</head>
           <stage>MITRANE, <emph>poi</emph> CLEONICE <emph>e</emph> BARSENE</stage>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l>Un'aura di fortuna,</l>
             <l>che spira incerta, è a sollevar bastante</l>
@@ -1940,7 +1965,7 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>Quanto deboli sono</l>
             <l>fra i ciechi affetti lor le menti umane!</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="I">Olà; scriver vogl'io.</l>
             <stage>
@@ -1948,24 +1973,24 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             </stage>
             <l part="F">Parti, Mitrane.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l part="I">Ubbidisco al comando.</l>
             <stage>
               <emph>(in atto di partire)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Odimi. Alceste</l>
             <l part="I">più di me non ricerca?</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l part="F">Anzi, o regina,</l>
             <l>altra cura non ha; ma l'infelice...</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="I">Parti; basta così. Senti.</l>
             <stage>
@@ -1973,7 +1998,7 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             </stage>
             <l part="F">Che dice?</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l>Dice che t'è fedele:</l>
             <l>dice che alcun t'inganna;</l>
@@ -1991,12 +2016,12 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
         <div type="scene">
           <head>SCENA V</head>
           <stage>CLEONICE <emph>e</emph> BARSENE</stage>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l>Regina, è pronto il foglio. I sensi tuoi</l>
             <l part="I">spiega in quello ad Alceste.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Ah! che in tal guisa</l>
             <l>son troppo a lui, son troppo a me crudele.</l>
@@ -2014,7 +2039,7 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>d'un lungo amor le tenerezze estreme,</l>
             <l>e nell'ultimo addio piangere insieme.</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l>Questa è sollievo? Ah di vedere Alceste</l>
             <l>il desio ti seduce. A tal cimento</l>
@@ -2029,7 +2054,7 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>questo passo crudel, ch'ora t'affanna,</l>
             <l part="I">pende la gloria tua.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Gloria tiranna,</l>
             <l>dunque per te degg'io</l>
@@ -2040,61 +2065,61 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
               <emph>(va a scrivere al tavolino)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l>(Par che m'arrida il fato:</l>
             <l part="I">non dispero d'Alceste).</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <stage>
               <emph>(scrivendo)</emph>
             </stage>
             <l part="F">«Alceste amato».</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l>(Lusingarmi potrò d'esser felice,</l>
             <l>se la gloria resiste</l>
             <l>fra i moti di quel cor pochi momenti).</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>«E non vuole il destin farci contenti».</l>
             <stage>
               <emph>(scrivendo)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l>(Cresce la mia speranza. Oh dei! sospende</l>
             <l>la man tremante e si ricopre il volto.</l>
             <l>Ah che ritorna ai primi affetti in preda!)</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="I">Povero Alceste mio!</l>
             <stage>
               <emph>(parlando, poi torna a scrivere)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l part="F">(Temo che ceda.</l>
             <l>Io nel caso di lei</l>
             <l part="I">non so dir che farei).</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">«Vivi, mio bene,</l>
             <l>ma non per me». Già terminai, Barsene.</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l>(Eccomi in porto). Or giustamente al trono</l>
             <l>un'anima sì grande il Ciel destina.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="I">Prendi, e tua cura sia...</l>
             <stage>
@@ -2105,15 +2130,15 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
         <div type="scene">
           <head>SCENA VI</head>
           <stage>FENICIO<emph> e dette.</emph></stage>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">Pietà, regina.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="I">Ma per chi?</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">Per Alceste. Io l'incontrai</l>
             <l>pallido, semivivo, e per l'affanno</l>
@@ -2127,7 +2152,7 @@ teatro della cesarea corte alla presenza de' sovrani, il dì 4 novemnbre 1731, p
             <l>il tuo nome ripete ad ogni passo:</l>
             <l>farebbe il suo dolor pietade a un sasso.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>Ah, Fenicio crudel! Da te sperava
 la vacillante mia</l>
@@ -2136,7 +2161,7 @@ la vacillante mia</l>
             <l>barbaramente a ritentar la viva</l>
             <l part="I">ferita del mio cor?</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">Perdona al zelo</l>
             <l>del mio paterno amor questo trasporto.</l>
@@ -2149,11 +2174,11 @@ la vacillante mia</l>
             <l>del tuo regio favor; speme del regno,</l>
             <l>di mia cadente età speme e sostegno.</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l part="I">(Zelo importuno).</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">E inaridir vedrassi</l>
             <l>così bella speranza in un momento?</l>
@@ -2162,21 +2187,21 @@ la vacillante mia</l>
             <l>che possa a questo colpo</l>
             <l part="I">sopravvivere un dì.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Che far poss'io?</l>
             <l>Che vuole Alceste? E qual da me richiede</l>
             <l>conforto al suo martìre?</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l>Rivederti una volta, e poi morire.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="I">Oh Dio!</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">Bella regina,</l>
             <l>ti veggo intenerir. Pietà di lui,</l>
@@ -2184,18 +2209,18 @@ la vacillante mia</l>
             <l>la lunga servitù, l'intatta fede</l>
             <l>merita pur ch'io qualche premio ottenga.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>Eh resista chi può: digli che venga.</l>
             <stage>
               <emph>(lacera il foglio e si alza da sedere)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l>(Ecco di nuovo il mio sperare estinto).</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l>(Basta che vegga Alceste, e Alceste ha vinto).</l>
             <stage>
@@ -2206,28 +2231,28 @@ la vacillante mia</l>
         <div type="scene">
           <head>SCENA VII</head>
           <stage>OLINTO<emph> e detti.</emph></stage>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l>Padre, regina, Alceste</l>
             <l>più in Seleucia non è. Per opra mia</l>
             <l part="I">già ne partì.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="M">Come!</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="M">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">Voleva</l>
             <l>rivederti importuno ad ogni prezzo.</l>
             <l>Io gl'imposi in tuo nome</l>
             <l part="I">la legge di partir.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Ma quando avesti</l>
             <l>questa legge da me? Custodi, o dei!</l>
@@ -2240,11 +2265,11 @@ la vacillante mia</l>
               <emph>(partono le guardie)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="I">Misero me!</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Se la ricerca è vana,</l>
             <stage>
@@ -2253,13 +2278,13 @@ la vacillante mia</l>
             <l>trema per te. Mi pagherai la pena</l>
             <l part="I">del temerario ardir.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">Credei servirti,</l>
             <l>un periglioso inciampo</l>
             <l part="I">togliendo alla tua gloria.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">E chi ti rese</l>
             <l>sì geloso custode</l>
@@ -2283,7 +2308,7 @@ la vacillante mia</l>
         <div type="scene">
           <head>SCENA VIII</head>
           <stage>FENICIO, OLINTO <emph>e</emph> BARSENE</stage>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l>Signor, di Cleonice</l>
             <l>non vidi mai più stravagante ingegno.</l>
@@ -2291,20 +2316,20 @@ la vacillante mia</l>
             <l>or Alceste dimanda, or lo ricusa;</l>
             <l>e delle sue follie poi gli altri accusa.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l>Così la tua sovrana,</l>
             <l>temerario, rispetti? Impara almeno</l>
             <l>a tacere una volta. Ah ch'io dispero</l>
             <l part="I">di poterlo emendar!</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l part="F">Matura il senno</l>
             <l>al crescer dell'etade. Olinto ancora</l>
             <l part="I">degli anni è su l'april.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">Barsene, anch'io</l>
             <l>scorsi l'april degli anni; e folto e biondo</l>
@@ -2322,7 +2347,7 @@ la vacillante mia</l>
         <div type="scene">
           <head>SCENA IX</head>
           <stage>OLINTO <emph>e</emph> BARSENE</stage>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l>Per appagar la strana</l>
             <l>senile austerità dovremo noi</l>
@@ -2331,7 +2356,7 @@ la vacillante mia</l>
             <l>chiede la nostra età. Dimmi se Olinto</l>
             <l part="I">vive più nel tuo core.</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l part="F">Eh che tu vuoi</l>
             <l>deridermi, o signor. Le mie cangiasti</l>
@@ -2357,7 +2382,7 @@ la vacillante mia</l>
         <div type="scene">
           <head>SCENA X</head>
           <stage>OLINTO</stage>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l>Di Barsene i disprezzi,</l>
             <l>l'ire di Cleonice,</l>
@@ -2387,7 +2412,7 @@ la vacillante mia</l>
             <emph>Camera con sedie.</emph>
           </stage>
           <stage>CLEONICE <emph>e poi</emph> MITRANE</stage>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>Eccoti, Cleonice, al duro passo</l>
             <l>di rivedere Alceste,</l>
@@ -2397,18 +2422,18 @@ la vacillante mia</l>
             <l>che si scordi di te? Quant'era meglio</l>
             <l part="I">non impedir la sua partenza!</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l part="F">Alceste,</l>
             <l>regina, è qui, che, ritornato in vita</l>
             <l>dopo tante vicende,</l>
             <l>di rivederti impaziente attende.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="I">(Già mi palpita il cor).</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l part="F">Fenicio il vide;</l>
             <l>l'assicurò, gli disse</l>
@@ -2420,20 +2445,20 @@ la vacillante mia</l>
             <l>e al piacere improvviso</l>
             <l>l'allegrezza e l'amor gli ride in viso.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>(E perderlo dovrò?) Parti, Mitrane:</l>
             <l>digli che venga. In queste</l>
             <l part="I">stanze l'attendo.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l part="F">Oh fortunato Alceste!</l>
             <stage>
               <emph>(parte)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>Magnanimi pensieri</l>
             <l>e di gloria e di regno ah dove siete?</l>
@@ -2452,7 +2477,7 @@ la vacillante mia</l>
         <div type="scene">
           <head>SCENA XII</head>
           <stage>ALCESTE <emph>e detta</emph></stage>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>Adorata regina, io più non credo</l>
             <l>che di dolor si muora. È folle inganno</l>
@@ -2464,11 +2489,11 @@ la vacillante mia</l>
             <l>la pena, ch'io provai,</l>
             <l>in questo punto è compensata assai.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="I">(Tenerezze crudeli!)</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">Ah! se l'istessa</l>
             <l>per me tu sei, come per te son io;</l>
@@ -2477,36 +2502,36 @@ la vacillante mia</l>
             <l>per cui tanto rigore</l>
             <l>io da te meritai, dimmi una volta.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>Tutto, Alceste, saprai. Siedi, e m'ascolta.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>Servo al sovrano impero.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="I">(Io gelo e temo).</l>
             <stage>
               <emph>(siede)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">(Io mi consolo e spero).</l>
             <stage>
               <emph>(siede)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>Alceste, ami da vero</l>
             <l>la tua regina, o t'innamora in lei</l>
             <l>lo splendor della cuna,</l>
             <l>l'onor degli avi e la real fortuna?</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>Così bassi pensieri</l>
             <l>credi in Alceste? O con i dubbi tuoi</l>
@@ -2523,22 +2548,22 @@ la vacillante mia</l>
             <l>ed al serto real co' pregi sui</l>
             <l>luce maggior, che non ottien da lui.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>Da così degno amante</l>
             <l>un magnanimo sforzo</l>
             <l part="I">posso dunque sperar?</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">Qualunque legge</l>
             <l part="I">fedele eseguirò.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Molto prometti.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>E tutto adempirò. Non v'è periglio,</l>
             <l>che lieve non divenga</l>
@@ -2546,25 +2571,25 @@ la vacillante mia</l>
             <l>a sfidar le tempeste: inerme il petto</l>
             <l>esporrò, se lo chiedi, incontro all'armi.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>Chiedo molto di più. Convien lasciarmi.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>Lasciarti? Oh dei! Che dici?</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>E lasciarmi per sempre, e in altro cielo</l>
             <l part="I">viver senza di me.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">Ma chi prescrive</l>
             <l part="I">così barbara legge?</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Il mio decoro,</l>
             <l>il genio de' vassalli,</l>
@@ -2574,16 +2599,16 @@ la vacillante mia</l>
             <l>rende co' pregi sui</l>
             <l>luce maggior, che non ottien da lui.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>E con tanta costanza</l>
             <l part="I">chiedi ch'io t'abbandoni?</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Ah! tu non sai...</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>So che non m'ami, e lo conosco assai.</l>
             <stage>
@@ -2600,23 +2625,23 @@ la vacillante mia</l>
               <emph>(in atto di partire)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="I">Deh, non partire ancor.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">Del tuo decoro</l>
             <l>troppo son io geloso. Un vil pastore</l>
             <l>con più lunga dimora avvilirebbe</l>
             <l part="I">il tuo grado real.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Tu mi deridi</l>
             <l part="I">ingrato Alceste!</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">Io sono</l>
             <l>veramente l'ingrato: io t'abbandono:</l>
@@ -2625,7 +2650,7 @@ la vacillante mia</l>
             <l>le promesse, l'amor. Barbara, infida,</l>
             <l part="I">inumana, spergiura.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Io dal tuo labbro</l>
             <l>tutto voglio soffrir. S'altro ti resta,</l>
@@ -2633,17 +2658,17 @@ la vacillante mia</l>
             <l>sazio sei d'insultarmi, almen per poco</l>
             <l part="I">lascia ch'io parli.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">In tua difesa, ingrata,</l>
             <l>che dir potrai? D'infedeltà sì nera</l>
             <l>la colpa ricoprir forse tu credi?</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>Non condannarmi ancor. M'ascolta e siedi.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>(Oh dei, quanta si fida</l>
             <l part="I">nel suo poter!)</l>
@@ -2651,7 +2676,7 @@ la vacillante mia</l>
               <emph>(torna a sedere)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Se ti ricordi, Alceste,</l>
             <l>che per due lustri interi</l>
@@ -2666,12 +2691,12 @@ la vacillante mia</l>
             <l>tutti sacrificar gli affetti sui</l>
             <l>alla sua gloria ed alla pace altrui.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>Arbitra della scelta</l>
             <l part="I">non ti rese il Consiglio?</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">È ver, potrei</l>
             <l>dell'arbitrio abusar, condurti in trono;</l>
@@ -2695,11 +2720,11 @@ la vacillante mia</l>
             <l>di spezzar volontari i dolci nodi</l>
             <l>di così giusto e così lungo amore.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>Perché, barbari dei, farmi pastore!</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>Va: cediamo al destin. Da me lontano</l>
             <l>vivi felice; il tuo dolor consola.</l>
@@ -2710,7 +2735,7 @@ la vacillante mia</l>
             <l>fors'è l'ultimo pianto. Addio. Non dirmi</l>
             <l>mai più che infida e che spergiura io sono.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>Perdono, anima bella, oh Dio! perdono.</l>
             <l>Regna, vivi, conserva</l>
@@ -2722,23 +2747,23 @@ la vacillante mia</l>
             <l>se da un labbro sì caro</l>
             <l>tanta virtù, tanta costanza imparo.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>Sorgi, parti, s'è vero</l>
             <l part="I">ch'ami la mia virtù.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">Su quella mano,</l>
             <l>che più mia non sarà, permetti almeno</l>
             <l>che imprima il labbro mio</l>
             <l part="I">l'ultimo bacio, e poi ti lascio.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice #alceste">
             <speaker>CLEONICE <emph>e</emph> ALCESTE</speaker>
             <l part="F">Addio.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>Non so frenare il pianto,</l>
             <l>cara, nel dirti addio:</l>
@@ -2756,7 +2781,7 @@ la vacillante mia</l>
         <div type="scene">
           <head>SCENA XIII</head>
           <stage>CLEONICE <emph>e poi</emph> BARSENE, <emph>indi</emph> FENICIO</stage>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>Sarete alfin contenti,</l>
             <l>ambiziosi miei folli pensieri.</l>
@@ -2768,77 +2793,77 @@ la vacillante mia</l>
             <l>se costa un tal martìre,</l>
             <l>se per viver a lei convien morire?</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l>Regina, è dunque vero</l>
             <l>che trionfar sapesti</l>
             <l>su i propri affetti anche al tuo ben vicino?</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l>Dunque è vero, o regina,</l>
             <l>che avesti un cor sì fiero</l>
             <l part="I">contro te, contro Alceste?</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">È vero, è vero.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l>Non ti credea capace</l>
             <l part="I">di tanta crudeltà.</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l part="F">Minor costanza</l>
             <l part="I">non speravo da te.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">L'atto inumano</l>
             <l>detesterà chi vanta</l>
             <l part="I">massime di pietà.</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l part="F">L'atto sublime</l>
             <l>ammirerà chi sente</l>
             <l part="I">stimoli di virtù.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">Col tuo rigore</l>
             <l part="I">oh quanto perdi!</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l part="F">Oh quanta gloria acquisti!</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="I">Deh rivoca...</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l part="M">Ah resisti...</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Oh Dio! tacete.</l>
             <l>Perché affliggermi più? Che mai volete?</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l>Vorrei renderti chiaro</l>
             <l part="I">l'inganno tuo.</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l part="F">Di tua costanza il vanto</l>
             <l part="I">vorrei serbarti.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">E m'uccidete intanto.</l>
             <l>Egualmente il mio core</l>
@@ -2864,7 +2889,7 @@ la vacillante mia</l>
         <div type="scene">
           <head>SCENA XIV</head>
           <stage>FENICIO <emph>e</emph> BARSENE</stage>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l>Il tuo zelo eccessivo</l>
             <l>intendere io non so. La nobil cura</l>
@@ -2881,7 +2906,7 @@ la vacillante mia</l>
             <l>ingrata non sarai. La tua regina</l>
             <l>querelarsi a ragion di te potria.</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l>Ma se l'amo, o Fenicio, è colpa mia?</l>
             <l>Saria piacer, non pena</l>
@@ -2901,7 +2926,7 @@ la vacillante mia</l>
         <div type="scene">
           <head>SCENA XV</head>
           <stage>FENICIO</stage>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l>Fenicio, che farai? Tutto s'oppone</l>
             <l>al tuo nobil desio. Pietosi dei,</l>
@@ -2932,7 +2957,7 @@ la vacillante mia</l>
             <emph>Portico della reggia, corrispondente alle sponde del mare, con barca e marinari pronti per la partenza d'Alceste.</emph>
           </stage>
           <stage>OLINTO <emph>e poi</emph> ALCESTE <emph>e</emph> FENICIO</stage>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l>Sarò pure una volta</l>
             <l>senza rival. Da questo lido al fine</l>
@@ -2943,7 +2968,7 @@ la vacillante mia</l>
             <l>cagion gli estremi uffici</l>
             <l>forse saran degl'importuni amici.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>Signor, procuri indarno</l>
             <stage>
@@ -2951,13 +2976,13 @@ la vacillante mia</l>
             </stage>
             <l part="I">di trattenermi ancor.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">Son pronti, Alceste,</l>
             <l>i nocchieri e la nave: amico è il vento,</l>
             <l part="I">placido è il mar.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <stage>
               <emph>(ad Olinto)</emph>
@@ -2972,26 +2997,26 @@ la vacillante mia</l>
             <l>non avrai da pentirti. In fino ad ora</l>
             <l>sai pur che amico e genitor ti fui.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l>(Mancava il padre a trattener costui).</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>Ah! della mia sovrana al tuo consiglio</l>
             <l>il comando s'oppone.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l>Alceste, a quel ch'io sento, ha gran ragione.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l>E puoi lasciarmi? E vuoi partir? Né pensi</l>
             <l>come resta Fenicio? Io ti sperai</l>
             <l part="I">più grato a tanto amor.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">Deh caro padre,</l>
             <l>che tal possa chiamarti</l>
@@ -3015,14 +3040,14 @@ la vacillante mia</l>
             <l>l'ire della fortuna,</l>
             <l>e a' danni tuoi non ne rimanga alcuna.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l>Figlio, non dir così. Tu non conosci</l>
             <l>il prezzo di tua vita: e questa mia,</l>
             <l>se a te non giova, è un peso</l>
             <l part="I">inutile per me.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">Signor, tu piangi?</l>
             <l>Ah! non merita Alceste</l>
@@ -3032,11 +3057,11 @@ la vacillante mia</l>
               <emph>(in atto di partire)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="I">(Lode agli dei!)</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">Vi raccomando, amici,</l>
             <l>l'afflitta mia regina. Avrà bisogno</l>
@@ -3055,47 +3080,47 @@ la vacillante mia</l>
         <div type="scene">
           <head>SCENA II</head>
           <stage>CLEONICE <emph>e detti</emph>.</stage>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="I">Fermati, Alceste.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="M">Oh stelle!</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">(Un altro inciampo</l>
             <l part="I">ecco alla sua partenza).</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">A che ritorni,</l>
             <l>regina, a rinnovar la nostra pena?</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>Fenicio, Olinto, in libertà lasciate</l>
             <l part="I">me con Alceste.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">Il mio dover saria</l>
             <l part="I">coll'amico restar.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Tornar potrai</l>
             <l>per l'ultimo congedo.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l>Tornerò. (Ma ch'ei parta io non lo credo).</l>
             <stage>
               <emph>(parte)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l>Giungi a tempo, o regina. A caso il Cielo</l>
             <l>forse non prolungò la sua dimora:</l>
@@ -3116,7 +3141,7 @@ la vacillante mia</l>
         <div type="scene">
           <head>SCENA III</head>
           <stage>CLEONICE <emph>ed</emph> ALCESTE</stage>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>Alceste, assai diverso</l>
             <l>è 'l meditar dall'eseguir le imprese.</l>
@@ -3127,11 +3152,11 @@ la vacillante mia</l>
             <l>priva di te, s'indebolisce il core,</l>
             <l>e la mia gloria, oh Dio! cede all'amore.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="I">Che vuoi dirmi perciò?</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Che non poss'io</l>
             <l>viver senza di te. Se Alceste e il regno</l>
@@ -3139,18 +3164,18 @@ la vacillante mia</l>
             <l>il rigor delle stelle a me funeste,</l>
             <l>si lasci il regno, e non si perda Alceste.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="I">Come!</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Su queste arene</l>
             <l>rimaner non conviene. Aure più liete</l>
             <l>a respirare altrove</l>
             <l part="I">teco verrò.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">Meco verrai! Ma dove?</l>
             <l>Cara, se avessi anch'io,</l>
@@ -3161,7 +3186,7 @@ la vacillante mia</l>
             <l>che in retaggio mi diè sorte tiranna,</l>
             <l>son pochi armenti ed una vil capanna.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>Nel tuo povero albergo</l>
             <l>quella pace godrò, che in regio tetto</l>
@@ -3185,7 +3210,7 @@ la vacillante mia</l>
             <l>con te mi lascerà;</l>
             <l>con te mi troverà, quando ritorna.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>Cleonice adorata, in queste ancora</l>
             <l>felicità sognate,</l>
@@ -3195,13 +3220,13 @@ la vacillante mia</l>
             <l>Ma son vane lusinghe</l>
             <l part="I">d'un acceso desio...</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Lusinghe vane!</l>
             <l>Di ricusare un regno</l>
             <l part="I">capace non mi credi?</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">E tu capace</l>
             <l>mi credi di soffrirlo? Ah! bisognava</l>
@@ -3227,7 +3252,7 @@ la vacillante mia</l>
             <l>felicemente in fino all'ore estreme,</l>
             <l>vivranno almeno i nostri nomi insieme.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>Deh, perché qui raccolta</l>
             <l>tutta l'Asia non è? che l'Asia tutta</l>
@@ -3243,24 +3268,24 @@ la vacillante mia</l>
             <l>da me saprai. Dell'imeneo reale</l>
             <l part="I">ti voglio spettator.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">Troppa costanza</l>
             <l part="I">brami da me.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Ci sosterremo insieme,</l>
             <l part="I">emulandoci a gara.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">Oh Dio! non sai</l>
             <l>il barbaro martìr d'un vero amante,</l>
             <l>che di quel ben, che a lui sperar non lice,</l>
             <l>invidia in altri il possessor felice.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>Io so qual pena sia</l>
             <l>quella d'un cor geloso;</l>
@@ -3278,7 +3303,7 @@ la vacillante mia</l>
         <div type="scene">
           <head>SCENA IV</head>
           <stage>ALCESTE <emph>e poi</emph> OLINTO</stage>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>Di Cleonice i detti</l>
             <l>mi confondon la mente. Ella desia</l>
@@ -3289,52 +3314,52 @@ la vacillante mia</l>
             <l>per lei pronto a soffrire ogni cordoglio,</l>
             <l>e il suo comando esaminar non voglio.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l>Sei pur solo una volta. Or non avrai</l>
             <l>chi differisca il tuo partir. Permetti</l>
             <l>che in pegno d'amistà l'ultimo amplesso</l>
             <l part="I">ti porga Olinto.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">Un generoso eccesso</l>
             <l>del tuo bel cor la mia partenza onora:</l>
             <l>ma la partenza mia non è per ora.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l>Come! per qual ragione?</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="I">La regina l'impone.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">Ogni momento</l>
             <l>vai cangiando desio.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>Il comando cangiò, mi cangio anch'io.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l>Ma che vuol Cleonice? È suo pensiero</l>
             <l part="I">forse eleggerti re?</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">Tanto non spero.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l>Dunque ti vuol presente</l>
             <l>al novello imeneo. Barbaro cenno,</l>
             <l part="I">che non devi eseguir.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">T'inganni. Io voglio</l>
             <l>tutto soffrir. Sarà, qualunque sia,</l>
@@ -3355,7 +3380,7 @@ la vacillante mia</l>
         <div type="scene">
           <head>SCENA V</head>
           <stage>OLINTO</stage>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l>Io lo previdi. Una virtù fallace</l>
             <l>per sopire i tumulti</l>
@@ -3387,7 +3412,7 @@ la vacillante mia</l>
             <emph>Appartamenti terreni di fenicio dentro la reggia.</emph>
           </stage>
           <stage>FENICIO, <emph>poi</emph> MITRANE</stage>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l>In più dubbioso stato</l>
             <l>mai non mi vidi. Alle mie stanze impone</l>
@@ -3399,14 +3424,14 @@ la vacillante mia</l>
             <l>la regina mi tace? Ah ch'io pavento</l>
             <l>che sian le cure mie disperse al vento.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l>Consolati, o signor. Vicine al porto</l>
             <l>Son le cretensi squadre. Io rimirai</l>
             <l>dall'alto della reggia</l>
             <l>che sotto a mille prore il mar biancheggia.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l>Amico, ecco il soccorso</l>
             <l>sospirato da noi. Possiamo al fine</l>
@@ -3417,7 +3442,7 @@ la vacillante mia</l>
             <l>chiedo l'ultime prove</l>
             <l part="I">della tua fedeltà.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l part="F">Volo a momenti</l>
             <l part="I">quanto imponesti ad eseguir.</l>
@@ -3425,7 +3450,7 @@ la vacillante mia</l>
               <emph>(in atto di partire)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">Ma senti:</l>
             <l>cauto t'adopra, e cela</l>
@@ -3435,29 +3460,29 @@ la vacillante mia</l>
         <div type="scene">
           <head>SCENA VII</head>
           <stage>OLINTO <emph>e detti.</emph></stage>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l>Di gran novella, o padre,</l>
             <l part="I">apportator son io.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="M">Che rechi?</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">Ha scelto</l>
             <l part="I">Cleonice lo sposo.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">È forse Alceste?</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l>Ei lo sperò, ma in vano.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l>Che colpo è questo inaspettato e strano!</l>
           </sp>
@@ -3465,27 +3490,27 @@ la vacillante mia</l>
         <div type="scene">
           <head>SCENA VIII</head>
           <stage>ALCESTE <emph>con due comparse, che portano manto e corona; e detti</emph></stage>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="I">Permetti che al tuo piede...</l>
             <stage>
               <emph>(inginocchiandosi)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">Alceste, oh dei!</l>
             <l part="I">Che fai? che chiedi?</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">Il nostro re tu sei.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="I">Come! Sorgi.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">Signor, per me t'invia</l>
             <l>queste reali insegne</l>
@@ -3497,13 +3522,13 @@ la vacillante mia</l>
             <l>cari a Fenicio sono</l>
             <l>il messaggier, la donatrice e il dono.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l>Né pensò la regina</l>
             <l>quanto ineguale a lei</l>
             <l part="I">sia Fenicio d'età?</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">Pensò che in altri</l>
             <l>più senno e maggior fede</l>
@@ -3514,18 +3539,18 @@ la vacillante mia</l>
             <l>provvede al regno: il van desio delude</l>
             <l part="I">di tanti ambiziosi...</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l part="F">E calma in parte</l>
             <l>le gelose tempeste</l>
             <l>nel dubbio cor dell'affannato Alceste.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l>Ecco l'unico evento, a cui quest'alma</l>
             <l part="I">preparata non era.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">Ognun sospira</l>
             <l>di vedere il suo re. Consola, o padre,</l>
@@ -3533,21 +3558,21 @@ la vacillante mia</l>
             <l>il popolo fedel, Seleucia tutta,</l>
             <l part="I">che freme di piacer.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">Precedi, Olinto,</l>
             <l>al tempio i passi miei. Dì che fra poco</l>
             <l>vedranno il re. Meco Mitrane e Alceste</l>
             <l>rimangano un momento.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l>(Purché Alceste non goda, io son contento).</l>
             <stage>
               <emph>(parte)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l>Numi del ciel, pietosi numi, io tanto</l>
             <l>non bramava da voi. Cure felici!</l>
@@ -3560,27 +3585,27 @@ la vacillante mia</l>
               <emph>(l'abbraccia)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">E per qual fallo</l>
             <l>io tanto ben perdei?</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l>Son tuo vassallo, ed il mio re tu sei.</l>
             <stage>
               <emph>(s'inginocchia)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="I">Sorgi, che dici?</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l part="M">Oh generoso!</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">Al fine</l>
             <l>riconosci te stesso. In te respira</l>
@@ -3594,13 +3619,13 @@ la vacillante mia</l>
             <l>che m'inondan le gote,</l>
             <l part="I">lagrime di piacer.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">Ma fino ad ora,</l>
             <l>signor, perché celarmi</l>
             <l part="I">la sorte mia?</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">Tutto saprai. Concedi</l>
             <l>che un momento io respiri. Oppresso il core</l>
@@ -3622,11 +3647,11 @@ la vacillante mia</l>
         <div type="scene">
           <head>SCENA IX</head>
           <stage>ALCESTE <emph>e</emph> MITRANE</stage>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="I">Sogno? Son desto?</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l part="F">Il primo segno anch'io</l>
             <l part="I">di suddito fedel..</l>
@@ -3634,13 +3659,13 @@ la vacillante mia</l>
               <emph>(in atto d'inginocchiarsi)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">Mitrane amato,</l>
             <l>non parlarmi per ora</l>
             <l>Lasciami in libertà. Dubito ancora.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l>Più liete immagini</l>
             <l>nell'alma aduna;</l>
@@ -3660,7 +3685,7 @@ la vacillante mia</l>
         <div type="scene">
           <head>SCENA X</head>
           <stage>ALCESTE <emph>e poi</emph> BARSENE</stage>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>Io Demetrio! Io l'erede</l>
             <l>del trono di Seleucia; e tanto ignoto</l>
@@ -3672,27 +3697,27 @@ la vacillante mia</l>
             <l>che la Fortuna stolta</l>
             <l>non ti faccia pastore un'altra volta?</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l part="I">Fenicio è dunque il re?</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">Lo scelse al trono</l>
             <l part="I">l'illustre Cleonice.</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l part="F">Io ti compiango</l>
             <l>nelle perdite tue. Ma non potendo</l>
             <l>la regina ottener, più non dispero</l>
             <l>che tu volga a Barsene il tuo pensiero.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="I">A Barsene?</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l part="F">Io nascosi</l>
             <l>rispettosa fin or l'affetto mio.</l>
@@ -3704,7 +3729,7 @@ la vacillante mia</l>
             <l>più opportuni di questi</l>
             <l part="I">sceglier non posso.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">Oh quanto mal scegliesti!</l>
             <l>Se tutti i miei pensieri,</l>
@@ -3723,7 +3748,7 @@ la vacillante mia</l>
         <div type="scene">
           <head>SCENA XI</head>
           <stage>BARSENE <emph>sola</emph></stage>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l>Era meglio tacer. Speravo almeno</l>
             <l>che, parlando una volta,</l>
@@ -3750,19 +3775,19 @@ la vacillante mia</l>
             <emph>Gran tempio dedicato al Sole, con ara e simulacro del medesimo nel mezzo, e trono da un lato.</emph>
           </stage>
           <stage>CLEONICE <emph>con seguito, e</emph> FENICIO <emph>accompagnato da duecavalieri, che portano su de' bacili il manto reale, la corona e lo scettro.</emph></stage>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l>Credimi, io non t'inganno: Alceste è il vero</l>
             <l>successor della Siria. A lui dovute</l>
             <l part="I">son quelle regie insegne.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">In fronte a lui</l>
             <l>ben ravvisai gran parte</l>
             <l part="I">dell'anima real.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">So ch'è delitto</l>
             <l>la cura ch'io mostrai d'un tuo nemico;</l>
@@ -3770,13 +3795,13 @@ la vacillante mia</l>
             <l>ma il rifiuto d'un trono</l>
             <l>facciano la mia scusa e 'l mio perdono.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>Quanti portenti il fato</l>
             <l>in un giorno adunò! Di pace priva</l>
             <l part="I">quando credo restar...</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">Demetrio arriva.</l>
           </sp>
@@ -3785,7 +3810,7 @@ la vacillante mia</l>
           <head>SCENA XIII</head>
           <stage>ALCESTE, <emph>che viene incontrato da</emph> CLEONICE <emph>e
        da</emph> FENICIO: MITRANE <emph>e guardie.</emph></stage>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>La prima volta è questa,</l>
             <l>che mi presento a te senza il timore</l>
@@ -3794,7 +3819,7 @@ la vacillante mia</l>
             <l>che al destino real congiunti sono,</l>
             <l>questo è il maggior ch'io troverò sul trono.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>Signor, cangiammo sorte. Il re tu sei,</l>
             <l>la suddita son io;</l>
@@ -3806,17 +3831,17 @@ la vacillante mia</l>
             <l>così mi fu d'ogni contento avaro,</l>
             <l>che, sol quando lo perdo, egli mi è caro.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l part="I">Anime generose!</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">Andrò sul trono,</l>
             <l>ma la tua man mi guidi: e quella mano</l>
             <l part="I">sia premio alla mia fé.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">Sì grato cenno</l>
             <l>il merto d'ubbidir tutto mi toglie.</l>
@@ -3824,33 +3849,33 @@ la vacillante mia</l>
               <emph>(vanno vicino all'ara e si porgona la mano)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l>Oh qual piacer nell'alma mia s'accoglie!</l>
           </sp>
-          <sp>
+          <sp who="#alceste #cleonice">
             <speaker>ALCESTE <emph>e</emph> CLEONICE</speaker>
             <l>Deh risplendi, o chiaro nume,</l>
             <l>fausto sempre al nostro amor.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>Qual son io, tu fosti amante</l>
             <l>di Tessaglia in riva al fiume,</l>
             <l>e in sembiante di pastor.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l>Qual son io, tu sei costante,</l>
             <l>e conservi il bel costume</l>
             <l>d'esser fido ai lauri ancor.</l>
           </sp>
-          <sp>
+          <sp who="#alceste #cleonice">
             <speaker>ALCESTE e CLEONICE</speaker>
             <l>Deh risplendi, o chiaro nume,</l>
             <l>fausto sempre al nostro amor.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="I">Tuoni a sinistra il Ciel.</l>
           </sp>
@@ -3858,27 +3883,27 @@ la vacillante mia</l>
         <div type="scene">
           <head>SCENA XIV</head>
           <stage>BARSENE <emph>e detti.</emph></stage>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l part="F">Tutta in tumulto</l>
             <l>è Seleucia, o regina.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="I">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l part="F">Sai che poc'anzi</l>
             <l>giunse di Creta il messaggiero, e seco</l>
             <l part="I">cento legni seguaci...</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="F">E ben fra poco</l>
             <l part="I">l'ascolterò.</l>
           </sp>
-          <sp>
+          <sp who="#barsene">
             <speaker>BARSENE</speaker>
             <l part="F">Ma l'inquieto Olinto,</l>
             <l>non potendo soffrir che regni Alceste,</l>
@@ -3887,11 +3912,11 @@ la vacillante mia</l>
             <l>che sosterrà veraci i detti sui;</l>
             <l>e che 'l vero Demetrio è noto a lui.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="I">Aimè, Fenicio!</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">Eh non temer. Sul trono</l>
             <l>con sicurezza andate:</l>
@@ -3901,7 +3926,7 @@ la vacillante mia</l>
         <div type="scene">
           <head>SCENA ULTIMA</head>
           <stage>OLINTO, <emph>portando in mano un foglio sigillato, ambasciatore cretense; seguito de' Greci; popolo, e detti.</emph></stage>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">Olà, fermate.</l>
             <l>Il Ciel non soffre inganni. In questo foglio</l>
@@ -3917,18 +3942,18 @@ la vacillante mia</l>
             <l>tutte l'armi cretensi</l>
             <l>del regio sangue a sostener l'onore.</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="I">Oh dei!</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">Leggasi il foglio.</l>
             <stage>
               <emph>(ad Olinto)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l>Alceste finirà cotanto orgoglio.</l>
             <stage>
@@ -3941,11 +3966,11 @@ la vacillante mia</l>
             <l>Fenicio l'educò nel finto Alceste.</l>
             <l part="I">Demetrio».</l>
           </sp>
-          <sp>
+          <sp who="#cleonice">
             <speaker>CLEONICE</speaker>
             <l part="M">Io torno in vita.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <stage>
               <emph>(ad Olinto)</emph>
@@ -3953,15 +3978,15 @@ la vacillante mia</l>
             <l part="F">A questo passo</l>
             <l part="I">t'aspettava Fenicio.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <l part="F">(Io son di sasso).</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MITRANE</speaker>
             <l>Gelò l'audace.</l>
           </sp>
-          <sp>
+          <sp who="#olinto">
             <speaker>OLINTO</speaker>
             <stage>
               <emph>   (ad Alceste)</emph>
@@ -3969,23 +3994,23 @@ la vacillante mia</l>
             <l>In te, signor, conosco</l>
             <l>il mio monarca, e dell'ardir mi pento.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l>Che sei figlio a Fenicio io sol rammento.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l>Su quel trono una volta</l>
             <l>lasciate ch'io vi miri, ultimo segno</l>
             <l part="I">de' voti miei.</l>
           </sp>
-          <sp>
+          <sp who="#alceste">
             <speaker>ALCESTE</speaker>
             <l part="F">Quanto possiedo è dono</l>
             <l>della tua fedeltà. Dal labbro mio</l>
             <l part="I">tutto il mondo lo sappia.</l>
           </sp>
-          <sp>
+          <sp who="#fenicio">
             <speaker>FENICIO</speaker>
             <l part="F">E 'l mondo impari</l>
             <l>dalla vostra virtù come in un core</l>
@@ -3994,7 +4019,7 @@ la vacillante mia</l>
               <emph>(Alceste e Cleonice vanno sul trono)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Quando scende in nobil petto,</l>
             <l>è compagno un dolce affetto,</l>

--- a/tei/metastasio-demofoonte.xml
+++ b/tei/metastasio-demofoonte.xml
@@ -85,6 +85,34 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="dircea">
+            <persName>Dircea</persName>
+          </person>
+          <person xml:id="matusio">
+            <persName>Matusio</persName>
+          </person>
+          <person xml:id="timante">
+            <persName>Timante</persName>
+          </person>
+          <person xml:id="demofoonte">
+            <persName>Demofoonte</persName>
+          </person>
+          <person xml:id="adrasto">
+            <persName>Adrasto</persName>
+          </person>
+          <person xml:id="creusa">
+            <persName>Creusa</persName>
+          </person>
+          <person xml:id="cherinto">
+            <persName>Cherinto</persName>
+          </person>
+          <personGrp xml:id="coro">
+            <name>Coro</name>
+          </personGrp>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -132,7 +160,7 @@
           <head>SCENA I</head>
           <stage>Orti pensili corrispondenti a vari appartamenti della reggia di Demofoonte.</stage>
           <stage>DIRCEA<emph>e</emph>  MATUSIO</stage>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l>Credimi, o padre; il tuo soverchio affetto</l>
             <l>un mal dubbioso ancora</l>
@@ -141,7 +169,7 @@
             <l>l´urna fatale, altra ragion non hai</l>
             <l part="I">che il regio esempio.</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">E ti par poco? Io forse,</l>
             <l>ché suddito nacqui,</l>
@@ -166,34 +194,34 @@
             <l>ch´abbia a toccar sempre la parte a lui</l>
             <l>di spettator nelle miserie altrui.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l>Ma sai pur che a´ sovrani</l>
             <l>è suddita la legge.</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="I">Le umane sì, non le divine.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">E queste</l>
             <l part="I">a lor s´aspetta interpretar.</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">Non quando</l>
             <l part="I">parlan chiaro gli dei.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Mai chiari a segno...</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="I">Non più, Dircea: son risoluto.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Ah meglio</l>
             <l>pensaci, o genitor. L´ira ne´ grandi</l>
@@ -204,7 +232,7 @@
             <l>bieco ti guarda. Ah che sarà, se aggiunge</l>
             <l part="I">ire novelle all´odio antico?</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">In vano</l>
             <l>l´odio di lui tu mi rammenti e l´ira:</l>
@@ -225,34 +253,34 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>DIRCEA <emph>e poi</emph>  TIMANTE</stage>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l>Se il mio principe almeno</l>
             <l>quindi lungi non fosse... Oh Ciel, che miro!</l>
             <l part="I">Ei viene a me!</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="M">Dolce consorte...</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Ah taci!</l>
             <l>Potrebbe udirti alcun. Rammenta, o caro,</l>
             <l>che qui non resta in vita</l>
             <l>suddita sposa a regio figlio unita.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Non temer, mia speranza. Alcun non ode.</l>
             <l part="I">Io ti difendo.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">E quale amico nume</l>
             <l part="I">ti rende a me?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Del genitore un cenno</l>
             <l>mi richiama dal campo,</l>
@@ -260,12 +288,12 @@
             <l>m´ami ancor? ti ritrovo</l>
             <l part="I">qual ti lasciai? Pensasti a me?</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Ma come</l>
             <l part="I">chieder lo puoi? Puoi dubitarne?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Oh Dio!</l>
             <l>non dubito, ben mio; lo so che m´ami:</l>
@@ -277,7 +305,7 @@
             <l>che fa? Cresce in bellezza?</l>
             <l part="I">A qual di noi somiglia?</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Egli incomincia</l>
             <l>già col tenero piede</l>
@@ -289,12 +317,12 @@
             <l>credula troppo al dolce error del ciglio,</l>
             <l>mi strinsi al petto il genitor nel figlio!</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Ah dov´è? Sposa amata,</l>
             <l part="I">guidami a lui; fa ch´io lo vegga.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Affrena,</l>
             <l>signor, per ora il violento affetto.</l>
@@ -303,14 +331,14 @@
             <l>non è sempre sicuro. Oh quanta pena</l>
             <l part="I">costa il nostro segreto!</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Ormai son stanco</l>
             <l>di finger più, di tremar sempre: io voglio</l>
             <l>cercare oggi una via</l>
             <l part="I">d´uscir di tante angustie.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Oggi sovrasta</l>
             <l>altra angustia maggiore. Il giorno è questo</l>
@@ -319,44 +347,44 @@
             <l>si oppone il padre; e della lor contesa</l>
             <l part="I">temo più che del resto.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">È noto forse</l>
             <l part="I">al padre tuo che sei mia sposa?</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Il Cielo</l>
             <l part="I">nol voglia mai. Più non vivrei.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">M´ascolta.</l>
             <l>Proporrò che di nuovo</l>
             <l>si consulti l´oracolo. Acquistiamo</l>
             <l part="I">tempo a pensar.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="M">Questo è già fatto.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">E come</l>
             <l part="I">rispose?</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Oscuro e breve.</l>
             <l>«Con voi del Ciel si placherà lo sdegno,</l>
             <l>quando noto a se stesso</l>
             <l>fia l´innocente usurpator d´un regno».</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="I">Che tenebre son queste!</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">E se dall´urna</l>
             <l>esce il mio nome, io che farò? La morte</l>
@@ -367,18 +395,18 @@
             <l>colpevole mi rendo:</l>
             <l>il Ciel, se taccio, il re, se parlo, offendo.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Sposa, ne´ gran perigli</l>
             <l>gran coraggio bisogna. Al re conviene</l>
             <l part="I">scoprir l´arcano.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">E la funesta legge,</l>
             <l>che a morir mi condanna?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Un re la scrisse,</l>
             <l>può rivocarla un re. Benché severo,</l>
@@ -394,18 +422,18 @@
             <l>abbracciargli le piante,</l>
             <l part="I">domandargli pietà.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Dubito... Oh Dio!</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Non dubitar, Dircea. Lascia la cura</l>
             <l>a me del tuo destin. Va. Per tua pace</l>
             <l>ti stia nell´alma impresso</l>
             <l>che a te penso, cor mio, più che a me stesso.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l>In te spero, o sposo amato;</l>
             <l>fido a te la sorte mia;</l>
@@ -423,7 +451,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>TIMANTE <emph>e</emph>  DEMOFOONTE <emph>con seguito; indi</emph>  ADRASTO</stage>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Sei pur cieca, o Fortuna! Alla mia sposa</l>
             <l>generosa concedi</l>
@@ -434,27 +462,27 @@
             <l>il real genitor. Più non s´asconda</l>
             <l part="I">il mio segreto a lui.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Principe, figlio.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="I">Padre, signor.</l>
             <stage>
               <emph>(s´inginocchia e gli bacia la mano)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="M">Sorgi.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">I reali imperi</l>
             <l part="I">eccomi ad eseguir.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">So che non piace</l>
             <l>al tuo genio guerriero</l>
@@ -472,13 +500,13 @@
             <l>degnamente le sue compì fin ora,</l>
             <l>il padre, il re le sue compisca ancora.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>(Opportuno è il momento: ardir). Conosco</l>
             <l>tanto il bel cor del mio</l>
             <l part="I">tenero genitor, che...</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">No, non puoi</l>
             <l>conoscerlo abbastanza. Io penso, o figlio,</l>
@@ -488,12 +516,12 @@
             <l>vorresti ormai che ti vedesse il regno:</l>
             <l part="I">ver?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F"> (Certo ei scoperse il nodo,</l>
             <l part="I">che mi stringe a Dircea).</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Parlar non osi:</l>
             <l>e a compiacerti appunto</l>
@@ -506,62 +534,62 @@
             <l>il desio di vederti</l>
             <l part="I">felice, o prence.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F"> (Il dubitarne è vano).</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l>A paragon di questo</l>
             <l part="I">è lieve ogni riguardo.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Amato padre,</l>
             <l>nuova vita or mi dai. Volo alla sposa</l>
             <l part="I">per condurla al tuo piè.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Ferma. Cherinto,</l>
             <l>il tuo minor germano,</l>
             <l part="I">la condurrà.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Che inaspettata è questa</l>
             <l part="I">felicità!</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">V´è per mio cenno al porto</l>
             <l part="I">chi ne attende l´arrivo.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="M">Al porto!</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">E quando</l>
             <l>vegga apparir la sospirata nave,</l>
             <l part="I">avvertiti sarem.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="M">Qual nave?</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Quella</l>
             <l>che la real Creusa</l>
             <l part="I">conduce alle tue nozze.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="M"> (Oh dei!)</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Ti sembra</l>
             <l>strano, lo so. Gli ereditari sdegni</l>
@@ -570,22 +598,22 @@
             <l>ella ti porta un regno. Unica prole</l>
             <l part="I">è del cadente re.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Signor... Credei...</l>
             <l part="I"> (Oh error funesto!)</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Una consorte altrove,</l>
             <l>che suddita non sia, per te non trovo.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>O suddita o sovrana,</l>
             <l part="I">che importa, o padre?</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Ah no; troppo degli avi</l>
             <l>ne arrossirebbon l´ombre. È lor la legge,</l>
@@ -594,16 +622,16 @@
             <l>saronne il più severo</l>
             <l part="I">rigido esecutor.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Ma questa legge...</l>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <l>Signor, giungono in porto</l>
             <l part="I">le frigie navi.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Ad incontrar la sposa</l>
             <l part="I">vola, o Timante.</l>
@@ -611,31 +639,31 @@
               <emph>(Adrasto si ritira)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="I">Io?</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Sì. Con te verrei,</l>
             <l>ma un funesto dover mi chiama al tempio.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="I">Ferma, senti, signor.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Parla: che brami?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Confessarti... (Che fo?) Chiederti... (Oh Dio,</l>
             <l>che angustia è questa!) Il sacrifizio, o padre...</l>
             <l>La legge... La consorte...</l>
             <l>(Oh legge! Oh sposa! Oh sacrifizio! Oh sorte!)</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l>Prence, ormai non ci resta</l>
             <l>più luogo a pentimento. È stretto il nodo;</l>
@@ -656,7 +684,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>TIMANTE <emph>solo</emph> .</stage>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Ma che vi fece, o stelle,</l>
             <l>la povera Dircea, che tante unite</l>
@@ -683,7 +711,7 @@
           <head>SCENA V</head>
           <stage>Porto di mare adornato per l´arrivo della principessa di Frigia. Vista di molte navi, dalla più magnifica delle quali al suono di vari stromenti barbari, preceduti da numeroso corteggio, sbarcano a terra. </stage>
           <stage>CREUSA <emph>e</emph> CHERINTO</stage>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l>Ma che t´affanna, o prence?</l>
             <l>Perché mesto così? Pensi, sospiri,</l>
@@ -698,7 +726,7 @@
             <l>s´accompagnan fra voi? Per le mie nozze</l>
             <l>qual augurio è mai questo?</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l>Se nulla di funesto</l>
             <l>presagisce il mio duol, tutto si sfoghi,</l>
@@ -707,13 +735,13 @@
             <l>accresceran le stelle. Io de´ viventi</l>
             <l part="I">già sono il più infelice.</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="F">E questo arcano</l>
             <l>non può svelarsi a me? Vaglion sì poco</l>
             <l part="I">il mio soccorso, i miei consigli?</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="F">E vuoi</l>
             <l>ch´io parli? Ubbidirò. Dal primo istante...</l>
@@ -721,7 +749,7 @@
             <l>meglio è tacer: meriterei parlando</l>
             <l>forse lo sdegno tuo.</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="F">Lo merta assai</l>
             <l>già la tua diffidenza. È ver che al fine</l>
@@ -729,7 +757,7 @@
             <l>mal sicuro il segreto. Andiamo, andiamo.</l>
             <l part="I">Taci pur; n´hai ragion.</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="F">Fermati. Oh numi!</l>
             <l>Parlerò; non sdegnarti. Io non ho pace;</l>
@@ -737,42 +765,42 @@
             <l>so che l´adoro in vano;</l>
             <l>e mi sento morir. Questo è l´arcano.</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="I">Come? Che ardir!</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="F">Nol dissi</l>
             <l part="I">che sdegnar ti farei?</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="F">Sperai, Cherinto,</l>
             <l part="I">più rispetto da te.</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="F">Colpa d´amore...</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="I">Taci, taci: non più.</l>
             <stage>
               <emph>(volendo partire</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="F">Ma già che a forza</l>
             <l>tu volesti, o Creusa,</l>
             <l>il delitto ascoltar, senti la scusa.</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="I">Che dir potrai?</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="F">Che di pietà son degno,</l>
             <l>se ardo per te: che se l´amarti è colpa,</l>
@@ -791,12 +819,12 @@
             <l>a te spiegar credei</l>
             <l>gli affetti del german, spiegando i miei.</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l>(Ah me n´avvidi). Un tale ardir mi giunge</l>
             <l part="I">nuovo così, che istupidisco.</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="F">E pure</l>
             <l>talor mi lusingai che l´alme nostre</l>
@@ -806,24 +834,24 @@
             <l>spesso negli occhi tuoi, che mi parea</l>
             <l>molto più che amicizia.</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="F">Or su, Cherinto,</l>
             <l>della mia tolleranza</l>
             <l>cominci ad abusar. Mai più d´amore</l>
             <l part="I">guarda di non parlarmi.</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="F">Io non comprendo...</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l>Mi spiegherò. Se in avvenir più saggio</l>
             <l>non sei di quel che fosti infino ad ora</l>
             <l>non comparirmi innanzi. Intendi ancora?</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l>T´intendo, ingrata,</l>
             <l>vuoi ch´io mi uccida.</l>
@@ -837,11 +865,11 @@
               <emph>(vuol partire)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="I">Dove? Ferma.</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="F">No, no: troppo t´offende</l>
             <l part="I">la mia presenza.</l>
@@ -849,11 +877,11 @@
               <emph>(in atto di partire)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="M">Odi, Cherinto.</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="M">Eh troppo</l>
             <l>abuserei restando</l>
@@ -862,30 +890,30 @@
               <emph>(come sopra)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="F">E chi fin ora</l>
             <l part="I">t´impose di partir?</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="F">Comprendo assai</l>
             <l part="I">anche quel che non dici.</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="F">Ah prence, ah quanto</l>
             <l>mal mi conosci! Io da quel punto... (Oh numi!)</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l>Termina i detti tuoi.</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l>Da quel punto... (Ah che fo!) Parti, se vuoi.</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l>Barbara, partirò; ma forse... Oh stelle!</l>
             <l part="I">Ecco il german.</l>
@@ -894,41 +922,41 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>TIMANTE <emph>frettoloso, e detti</emph> .</stage>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Dimmi, Cherinto: è questa</l>
             <l part="I">la frigia principessa?</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="M">Appunto.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Io deggio</l>
             <l>seco parlar. Per un momento solo</l>
             <l part="I">da noi ti scosta.</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="F">Ubbidirò. (Che pena!)</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="I">Sposo, signor.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Donna real, noi siamo</l>
             <l>in gran periglio entrambi. Il tuo decoro,</l>
             <l>la vita mia tu sola</l>
             <l part="I">puoi difender, se vuoi.</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="M">Che avvenne?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">I nostri</l>
             <l>genitori fra noi strinsero un nodo,</l>
@@ -946,11 +974,11 @@
             <l>per questa via, che il mio dover t´addìta,</l>
             <l>l´onor tuo, la mia pace e la mia vita.</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="I">Come!</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Teco io non posso</l>
             <l>trattenermi di più. Prence, alla reggia</l>
@@ -959,11 +987,11 @@
               <emph>(a Cherinto partendo)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="F">Ah dimmi almeno...</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Dissi tutto il cor mio,</l>
             <l>né più dirti saprei: pensaci. Addio.</l>
@@ -975,18 +1003,18 @@
         <div type="scene">
           <head>SCENA VII</head>
           <stage>CREUSA <emph>e</emph>  CHERINTO</stage>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l>Numi, a Creusa, alla reale erede</l>
             <l>dello scettro di Frigia un tale oltraggio!</l>
             <l part="I">Cherinto, hai cor?</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="F">L´avrei,</l>
             <l part="I">se tu non mel toglievi.</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="F">Ah l´onor mio</l>
             <l>vendica tu, se m´ami. Il cor, la mano,</l>
@@ -994,40 +1022,40 @@
             <l>quanto possiedo, è tuo: limite alcuno</l>
             <l part="I">non pongo al premio.</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="M">E che vorresti?</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="F">Il sangue</l>
             <l>dell´audace Timante.</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="I">Del mio german!</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="F">Che! Impallidisci? Ah vile!</l>
             <l>Va: troverò chi voglia</l>
             <l part="I">meritar l´amor mio.</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="F">Ma principessa...</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l>Non più; lo so, siete d´accordo entrambi,</l>
             <l part="I">scellerati, a tradirmi.</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="F">Io! Come! E credi</l>
             <l>così dunque il mio amor poco sincero?</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l>Del tuo amor mi vergogno o falso o vero.</l>
             <l>Non curo l´affetto</l>
@@ -1046,7 +1074,7 @@
         <div type="scene">
           <head>SCENA VIII</head>
           <stage>CHERINTO <emph>solo</emph> .</stage>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l>Oh dei! perché tanto furor? Che mai</l>
             <l>le avrà detto il german? Voler ch´io stesso</l>
@@ -1073,11 +1101,11 @@
         <div type="scene">
           <head>SCENA IX</head>
           <stage>MATUSIO <emph>esce furioso con</emph>  DIRCEA <emph>per mano</emph> .</stage>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="I">Dove, dove, o signor?</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">Nel più deserto</l>
             <l>sen della Libia, alle foreste ircane,</l>
@@ -1085,48 +1113,48 @@
             <l>se alcuna il mar ne serra,</l>
             <l>separata dal mondo ultima terra.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="I"> (Aimè!)</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">Sudate, o padri,</l>
             <l>nella cura de´ figli. Ecco il rispetto</l>
             <l>che il dritto di natura,</l>
             <l>che prometter si può la vostra cura.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l>(Ah scoprì l´imeneo! Son morta). Oh Dio!</l>
             <l part="I">signor, pietà.</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">Non v´è pietà, né fede:</l>
             <l part="I">tutto è perduto.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="M">Ecco al tuo piè...</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">Che fai?</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l>Io voglio pianger tanto...</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l>Il tuo caso domanda altro che pianto.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="I">Sappi...</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">Attendimi. Un legno</l>
             <l>volo a cercar, che ne trasporti altrove.</l>
@@ -1138,19 +1166,19 @@
         <div type="scene">
           <head>SCENA X</head>
           <stage>DIRCEA, <emph>poi</emph>  TIMANTE</stage>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l>Dove, misera, ah dove</l>
             <l>vuol condurmi a morir? Figlio innocente,</l>
             <l>adorato consorte, oh dei, che pena</l>
             <l part="I">partir senza vedervi!</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Al fin ti trovo,</l>
             <l part="I">Dircea, mia vita.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Ah caro sposo, addio,</l>
             <l>e addio per sempre. Al tuo paterno amore</l>
@@ -1159,19 +1187,19 @@
             <l>narragli, quando sia</l>
             <l>capace di pietà, la sorte mia.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Sposa, che dici? Ah nelle vene il sangue</l>
             <l part="I">gelar mi fai!</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Certo scoperse il padre</l>
             <l>il nostro arcano. Ebbro è di sdegno; e vuole</l>
             <l>quindi lungi condurmi. Io lo conosco,</l>
             <l part="I">per me non v´è più speme.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Eh rassicura</l>
             <l>lo smarrito tuo cor, sposa diletta;</l>
@@ -1181,31 +1209,31 @@
         <div type="scene">
           <head>SCENA XI</head>
           <stage>MATUSIO <emph>torna frettoloso, e detti</emph> .</stage>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">Dircea, t´affretta.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="I">Dircea non partirà.</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">Chi l´impedisce?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="I">Io.</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="M">Come!</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="M">Aimè!</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">Difenderò col ferro</l>
             <l>la paterna ragion.</l>
@@ -1213,7 +1241,7 @@
               <emph>(snuda la spada)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <stage>
               <emph>(fa lo stesso)</emph>
@@ -1221,7 +1249,7 @@
             <l>Col ferro anch´io</l>
             <l part="I">la mia difenderò.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <stage>
               <emph>(si frappone) </emph>
@@ -1229,21 +1257,21 @@
             <l part="F">Prence, che fai?</l>
             <l part="I">Fermati, o genitore.</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">Empio! Impedirmi</l>
             <l>che al crudel sacrifizio una innocente</l>
             <l part="I">vergine io tolga?</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="M"> (Oh dei!)</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="M">Ma dunque...</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <stage>
               <emph>(piano a Timante, fingendo trattenerlo)</emph>
@@ -1251,48 +1279,48 @@
             <l part="F">(Ah taci.</l>
             <l part="I">Nulla sa; m´ingannai).</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">Volerla oppressa?</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l>(Io quasi per timor tradii me stessa).</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Signor, perdona: ecco l´error. Ti vidi</l>
             <l>verso lei, che piangea, correr sdegnato;</l>
             <l>tempo a pensar non ebbi; opra pietosa</l>
             <l>il salvarla credei dal tuo furore.</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l>Dunque la nostra fuga</l>
             <l>non impedir. La vittima, se resta,</l>
             <l part="I">oggi sarà Dircea.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="M">Stelle!</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Dall´urna</l>
             <l part="I">forse il suo nome uscì?</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">No; ma l´ingiusto</l>
             <l>tuo padre vuol quell´innocente uccisa</l>
             <l part="I">senza il voto del caso.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">E perché tanto</l>
             <l part="I">sdegno con lei?</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">Per punir me, che volli</l>
             <l>impedir che alla sorte</l>
@@ -1300,12 +1328,12 @@
             <l>l´esempio suo; perché l´amor paterno</l>
             <l part="I">mi fé scordar d´esser vassallo.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F"> (Oh Dio!</l>
             <l>ogni cosa congiura a danno mio).</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Matusio, non temer: barbaro tanto</l>
             <l>il re non è. Negl´impeti improvvisi</l>
@@ -1316,7 +1344,7 @@
         <div type="scene">
           <head>SCENA XII</head>
           <stage>ADRASTO <emph>con guardie, e detti</emph> .</stage>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <l part="F">Olà, ministri,</l>
             <l part="I">custodite Dircea.</l>
@@ -1324,24 +1352,24 @@
               <emph>(le guardie la circondano)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">Nol dissi, o prence?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="I">Come?</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="M">Misera me!</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Per qual cagione</l>
             <l part="I">è Dircea prigioniera?</l>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <l part="F">Il re l´impone.</l>
             <stage>
@@ -1349,33 +1377,33 @@
             </stage>
             <l part="I">Vieni.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="M">Ah dove?</l>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <l part="F">Fra poco,</l>
             <l part="I">sventurata, il saprai.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Principe, padre,</l>
             <l>soccorretemi voi;</l>
             <l part="I">movetevi a pietà.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">No, non fia vero...</l>
             <stage>
               <emph>(in atto d´assalire)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="I">Non soffrirò...</l>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <l part="F">Se v´appressate, in seno</l>
             <l part="I">questo ferro le immergo.</l>
@@ -1383,57 +1411,57 @@
               <emph>(impugnando uno stile)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="M">Empio!</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">Inumano!</l>
             <stage>
               <emph>(si fermano)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <l>Il comando sovrano</l>
             <l part="I">mi giustifica assai.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="M">Dunque...</l>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <l part="F">T´affretta:</l>
             <l>sono vane, o Dircea, le tue querele.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="I">Vengo.</l>
             <stage>
               <emph>(incamminandosi)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#timante #matusio">
             <speaker>TIMANTE, MATUSIO</speaker>
             <l part="M">Ah barbaro!</l>
             <stage>
               <emph>(in atto di assalire)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <l part="M">Olà.</l>
             <stage>
               <emph>(in atto di ferire)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#timante #matusio">
             <speaker>TIMANTE, MATUSIO</speaker>
             <l part="F">Ferma, crudele.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l>Padre, perdona... Oh pene!</l>
             <l>prence, rammenta... Oh Dio!</l>
@@ -1451,11 +1479,11 @@
         <div type="scene">
           <head>SCENA XIII</head>
           <stage>TIMANTE <emph>e</emph>  MATUSIO</stage>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="I">Consigliatemi, o dei.</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">Né s´apre il suolo!</l>
             <l>Né un fulmine punisce</l>
@@ -1463,31 +1491,31 @@
             <l>mi si dirà che Giove</l>
             <l part="I">abbia cura di noi.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Facciamo, amico,</l>
             <l>miglior uso del tempo. Appresso a lei</l>
             <l>tu vanne, e vedi ov´è condotta. Il padre</l>
             <l part="I">io volo intanto a raddolcir.</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">Non spero...</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Oh Dio! Va. Troverassi</l>
             <l>altra via di salvarla, ove non ceda</l>
             <l>del genitor lo sdegno.</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l>Oh di padre miglior figlio ben degno!</l>
             <stage>
               <emph>(l´abbracciae parte)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Se ardire e speranza</l>
             <l>dal Ciel non mi viene,</l>
@@ -1511,7 +1539,7 @@
           <head>SCENA I</head>
           <stage>Gabinetti.</stage>
           <stage>DEMOFOONTE <emph>e</emph>  CREUSA</stage>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l>Chiedi pure, o Creusa. In questo giorno</l>
             <l>tutto farò per te. Ma non parlarmi</l>
@@ -1523,18 +1551,18 @@
             <l>Paragonarsi a me? Regnar non voglio,</l>
             <l>se tal vergogna ho da soffrir nel soglio.</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l>Io non vengo per altri</l>
             <l>a pregarti, signor. Conosco assai</l>
             <l>quel che potrei sperar. Le mie preghiere</l>
             <l part="I">son per me stessa.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="M">E che vorresti?</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="F">In Frigia</l>
             <l>subito ritornar. Manca il tuo cenno</l>
@@ -1544,13 +1572,13 @@
             <l>venni a parte del trono,</l>
             <l>(non è strano il timor) schiava io non sono.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l>Che dici, o principessa! Ah quai sospetti!</l>
             <l>Che pungente parlar! Partir da noi!</l>
             <l part="I">E lo sposo? E le nozze?</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="F">Eh per Timante</l>
             <l>Creusa è poco. Una beltà mortale</l>
@@ -1558,45 +1586,45 @@
             <l>la mia cura non è. Partir vogl´io:</l>
             <l part="I">posso, o signor?</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Tu sei</l>
             <l>l´arbitra di te stessa. In Tracia a forza</l>
             <l>ritenerti io non vuo´. Ma non sperai</l>
             <l part="I">tale ingiuria da te.</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="F">Non so di noi</l>
             <l>chi ha ragion di lagnarsi: e il prence... Al fine</l>
             <l part="I">bramo partir.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="M">Ma lo vedesti?</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="F">Il vidi.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="I">Ti parlò?</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="M">Così meco</l>
             <l>parlato non avesse.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">E che ti disse?</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="I">Signor, basta così.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Creusa, intendo.</l>
             <l>Ruvido troppo alle parole, agli atti</l>
@@ -1617,21 +1645,21 @@
             <l>sotto la disciplina</l>
             <l>di sì dotti maestri ogni dottrina.</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l>Al rossor d´un rifiuto una mia pari</l>
             <l part="I">non s´espone però.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Rifiuto! E come</l>
             <l part="I">lo potresti temer?</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="M">Chi sa?</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">La mano,</l>
             <l>pur che tu non la sdegni, in questo giorno</l>
@@ -1640,18 +1668,18 @@
             <l>di repugnar, da mille furie invaso</l>
             <l>saprei... Ma no; troppo è lontano il caso.</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l>(Sì sì, Timante all´imeneo s´astringa,</l>
             <l>per poter rifiutarlo). E bene, accetto,</l>
             <l>signor, la tua promessa. Or fia tua cura</l>
             <l part="I">che poi...</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Basta così. Vivi sicura.</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l>Tu sai chi son; tu sai</l>
             <l>quel che al mio onor conviene:</l>
@@ -1669,7 +1697,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>DEMOFOONTE <emph>e poi</emph> TIMANTE</stage>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l>Che alterezza ha costei! Quasi... Ma tutto</l>
             <l>al grado, al sesso ed all´età si doni.</l>
@@ -1679,28 +1707,28 @@
             <l>le ripugnanze sue vinca in appresso.</l>
             <l>Timante a me... <stage><emph>(alle guardie)</emph></stage>Ma vien Timante istesso.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Mio re, mio genitor, grazia, perdono,</l>
             <l part="I">pietà.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="M">Per chi?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Per l´infelice figlia</l>
             <l part="I">dell´afflitto Matusio.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Ho già deciso</l>
             <l>del suo destin. Non si rivoca un cenno,</l>
             <l>che uscì da regio labbro. È d´un errore</l>
             <l>conseguenza il pentirsi: e il re non erra.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Se si adorano in terra, è perché sono</l>
             <l>placabili gli dei. D´ogni altro è il Fato</l>
@@ -1708,34 +1736,34 @@
             <l>un decreto giammai, non trovi esempio</l>
             <l>di chi voglia innalzargli un´ara, un tempio.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l>Tu non sai che del trono</l>
             <l part="I">è custode il timor.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Poco sicuro.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="I">Di lui figlio è il rispetto.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">E porta seco</l>
             <l part="I">tutti i dubbi del padre.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">A poco a poco</l>
             <l part="I">diventa amor.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="M">Ma simulato.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Il tempo</l>
             <l>t´insegnerà quel ch´or non sai. Per ora</l>
@@ -1743,29 +1771,29 @@
             <l>che mai facesti? In questo dì tua sposa</l>
             <l part="I">esser deve; e l´irrìti?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Ho tal per lei</l>
             <l>repugnanza nel cor, che non mi sento</l>
             <l part="I">valor di superarla.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">E pur conviene...</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Ne parleremo. Or per Dircea, signore,</l>
             <l>sono al tuo piè. Quell´innocente vita</l>
             <l part="I">dona a´ prieghi d´un figlio.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">E pur di lei</l>
             <l>torni a parlar. Se l´amor mio t´è caro,</l>
             <l part="I">questa impresa abbandona.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Ah padre amato,</l>
             <l>non ti posso ubbidir. Deh, se giammai</l>
@@ -1793,7 +1821,7 @@
             <l>onde viva Dircea, padre, non dai,</l>
             <l>io dal tuo piè non partirò giammai.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l>Principe (oh sommi dei), sorgi. E che deggio</l>
             <l>creder di te? Quel nominar con tanta</l>
@@ -1801,12 +1829,12 @@
             <l>violenti premure</l>
             <l part="I">che voglion dir? L´ami tu forse?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">In vano</l>
             <l part="I">farei studio a celarlo.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Ah questa è dunque</l>
             <l>delle freddezze tue verso Creusa</l>
@@ -1816,7 +1844,7 @@
             <l>che un imeneo nascosto... Ah, se potessi</l>
             <l part="I">immaginarmi sol...</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Qual dubbio mai</l>
             <l>ti cade in mente! A tutti i numi il giuro,</l>
@@ -1824,42 +1852,42 @@
             <l>che viva solo. E se pur vuoi che mora;</l>
             <l>morrà, non lusingarti, il figlio ancora.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l>(Per vincerlo si ceda). E ben, tu ´l vuoi,</l>
             <l>vivrà la tua diletta;</l>
             <l part="I">la dono a te.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="M">Mio caro padre...</l>
             <stage>
               <emph>(vuol baciargli la mano)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Aspetta.</l>
             <l>Merita la paterna</l>
             <l part="I">condescendenza una mercé?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">La vita,</l>
             <l part="I">il sangue mio...</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">No, caro figlio; io bramo</l>
             <l>meno da te. Nella real Creusa</l>
             <l>rispetta la mia scelta. A queste nozze</l>
             <l part="I">non ti mostrar sì avverso.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="M">Oh Dio!</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Lo veggo,</l>
             <l>ti costan pena: or questa pena accresca</l>
@@ -1873,85 +1901,85 @@
             <l>agl´invocati dei</l>
             <l>adempi, o figlio, i tuoi doveri, e i miei.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="I">Signor... non posso.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Io fin ad ora, o prence,</l>
             <l>da padre ti parlai: non obbligarmi</l>
             <l part="I">a parlarti da re.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Del re, del padre</l>
             <l>venerabili i cenni</l>
             <l>egualmente mi son; ma, tu lo sai,</l>
             <l part="I">amor forza non soffre.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Amor governa</l>
             <l>le nozze de´ privati. Hanno i tuoi pari</l>
             <l>nume maggior, che li congiunge: e questo</l>
             <l part="I">sempre è il pubblico ben.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Se il bene altrui</l>
             <l part="I">tal prezzo ha da costar...</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Prence, son stanco</l>
             <l>di garrir teco. Altra ragion non rendo:</l>
             <l part="I">io così voglio.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="M">Ed io non posso.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Audace!</l>
             <l part="I">Non sai...</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="M">Lo so: vorrai punirmi.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">E voglio</l>
             <l>che in Dircea s´incominci il tuo castigo.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="I">Ah no!</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="M">Parti.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="M">Ma senti.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Intesi assai.</l>
             <l>Dircea voglio che mora.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="I">E morendo Dircea...</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Né parti ancora?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Sì, partirò: ma poi</l>
             <stage>
@@ -1959,12 +1987,12 @@
             </stage>
             <l part="I">non ti lagnar...</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Che? Temerario! (Oh dei!)</l>
             <l part="I">Minacci!</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Io non distinguo</l>
             <l>se priego o se minaccio. A poco a poco</l>
@@ -1972,11 +2000,11 @@
             <l>non costringermi, o padre. Io mi protesto;</l>
             <l part="I">farei... Chi sa.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Dì; che faresti, ingrato?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Tutto quel che farebbe un disperato.</l>
             <l>Prudente mi chiedi?</l>
@@ -1997,7 +2025,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>DEMOFOONTE <emph>solo</emph> .</stage>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l>Dunque m´insulta ognun? L´ardita nuora,</l>
             <l>il suddito superbo, il figlio audace,</l>
@@ -2030,11 +2058,11 @@
           <head>SCENA IV</head>
           <stage>Portici. </stage>
           <stage>MATUSIO <emph>e</emph> TIMANTE</stage>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l>È l´unica speranza...</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Sì, caro amico, è nella fuga. In vece</l>
             <l>di placarsi a´ miei prieghi,</l>
@@ -2047,17 +2075,17 @@
             <l>m´attendi ascoso: io con Dircea fra poco</l>
             <l part="I">a te verrò.</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">Ma de´ custodi suoi...</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Deluderò la cura. Ignota via</l>
             <l>v´è chi m´apre all´albergo ov´ella è chiusa.</l>
             <l>Va, che il tempo è infedele a chi ne abusa.</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l>È soccorso d´incognita mano</l>
             <l>quella brama, che l´alma t´accende:</l>
@@ -2072,7 +2100,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>TIMANTE <emph>e poi</emph>  DIRCEA <emph>in bianca veste e  coronata di fiori tra le guardie ed i ministri del tempio</emph> .</stage>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Gran passo è la mia fuga. Ella mi rende</l>
             <l>e povero e privato. Il regno e tutte</l>
@@ -2093,31 +2121,31 @@
             <l>fra lor... Misero me! La sposa! Oh Dio!</l>
             <l part="I">Fermatevi. Dircea, che avvenne?</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Al fine</l>
             <l>ecco l´ora fatale; ecco l´estremo</l>
             <l>istante ch´io ti veggo. Ah prence, ah questo</l>
             <l part="I">è pur l´amaro passo!</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">E come! Il padre...</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="I">Mi vuol morta a momenti.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Infin ch´io vivo.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l>Signor, che fai? Sol, contro tanti, in vano</l>
             <l part="I">difendi me; perdi te stesso.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">È vero.</l>
             <l part="I">Miglior via prenderò.</l>
@@ -2125,11 +2153,11 @@
               <emph>(volendo partire)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="M">Dove?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">A raccorre</l>
             <l>quanti amici potrò. Va pure: al tempio</l>
@@ -2138,11 +2166,11 @@
               <emph>(come sopra)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">No. Pensa... Oh Dio!</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Non v´è più che pensar. La mia pietade</l>
             <l>già diventa furor. Tremi qualunque</l>
@@ -2158,7 +2186,7 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>DIRCEA, <emph>poi</emph>  CREUSA</stage>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l>Fermati. Ah non m´ascolta. Eterni dei,</l>
             <l>custoditelo voi. S´ei pur si perde,</l>
@@ -2170,11 +2198,11 @@
             <l>la chiede al tuo bel core</l>
             <l>nell´ultime miserie una che muore.</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="I">Chi sei? Che brami?</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Il caso mio già noto</l>
             <l>pur troppo ti sarà: Dircea son io;</l>
@@ -2185,12 +2213,12 @@
             <l>se i prieghi di chi muor vani non sono,</l>
             <l>disperato assistenza, e reo perdono.</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l>E tu a morir vicina</l>
             <l>come puoi pensar tanto al suo riposo?</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l>Oh Dio! Più non cercar. Sarà tuo sposo.</l>
             <l>Se tutti i mali miei</l>
@@ -2209,7 +2237,7 @@
         <div type="scene">
           <head>SCENA VII</head>
           <stage>CREUSA <emph>e poi</emph> CHERINTO</stage>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l>Che incanto è la beltà! Se tale effetto</l>
             <l>fa costei nel mio cor, degno di scusa</l>
@@ -2220,12 +2248,12 @@
             <l>qualche via d´evitarla. Appunto ho d´uopo</l>
             <l part="I">di te, Cherinto.</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="F">Il mio germano esangue</l>
             <l part="I">domandar mi vorrai.</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="F">No; quella brama</l>
             <l>con l´ira nacque e s´ammorzò con l´ira:</l>
@@ -2235,21 +2263,21 @@
             <l>tu corri a regolar; grazia per lei</l>
             <l part="I">ad implorare io vado.</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="F">Oh degna cura</l>
             <l>d´un´anima reale! E chi potrebbe</l>
             <l>non amarti, o Creusa? Ah, se non fossi</l>
             <l part="I">sì tiranna con me...</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="F">Ma donde il sai</l>
             <l>ch´io son tiranna? E questo cor diverso</l>
             <l>da quel che tu credesti.</l>
             <l>Anch´io... Ma va. Troppo saper vorresti.</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l>No, non chiedo, amate stelle,</l>
             <l>se nemiche ancor mi siete:</l>
@@ -2267,7 +2295,7 @@
         <div type="scene">
           <head>SCENA VIII</head>
           <stage>CREUSA <emph>sola</emph> .</stage>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l>Se immaginar potessi,</l>
             <l>Cherinto idolo mio, quanto mi costa</l>
@@ -2297,13 +2325,13 @@
           <head>SCENA IX</head>
           <stage>Atrio del tempio d´Apollo. Magnifica, ma breve scala, per cui si ascende al tempio medesimo, la parte interna del quale è tutta scoperta agli spettatori, se non quanto ne interrompono la vista le colonne che sostengono la gran tribuna. Veggonsi l´are cadute, il fuoco estinto, i sacri vasi rovesciati, i fiori, le bende, le scuri e gli altri stromenti del sagrifizio sparsi per le scale e sul piano; i sacerdoti in fuga, i custodi reali inseguiti dagli amici di Timante; e per tutto confusione e tumulto. </stage>
           <stage>TIMANTE <emph>che, incalzando disperatamente per la scala alcune guardie, si perde fra le scene</emph> . DIRCEA <emph>che, dalla cima della scala medesima, spaventata lo richiama. Siegue breve mischia col vantaggio degli amici di</emph> TIMANTE: <emph>e, dileguati i combattenti</emph>  , DIRCEA, <emph>che rivede</emph> TIMANTE, <emph>corre a trattenerlo, scendendo dal tempio</emph> .</stage>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l>Santi numi del Cielo,</l>
             <l>difendetelo voi! Timante, ascolta;</l>
             <l part="I">Timante, ah per pietà...</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <stage>
               <emph>(tornando affannato con ispada alla mano)</emph>
@@ -2311,33 +2339,33 @@
             <l part="F">Vieni, mia vita,</l>
             <l part="I">vieni: sei salva.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="M">Ah che facesti!</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Io feci</l>
             <l part="I">quel che dovea.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Misera me! Consorte,</l>
             <l>oh Dio, tu sei ferito! Oh Dio, tu sei</l>
             <l part="I">tutto asperso di sangue!</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Eh no, Dircea,</l>
             <l>non ti smarrir: dalle mie vene uscito</l>
             <l>questo sangue non è. Dal seno altrui</l>
             <l part="I">lo trasse il mio furor!</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="M">Ma guarda...</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Ah sposa,</l>
             <l part="I">non più dubbi: fuggiamo.</l>
@@ -2345,13 +2373,13 @@
               <emph>(la prende per mano)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">E Olinto? E il figlio?</l>
             <l>Dove resta? Senz´esso</l>
             <l part="I">vogliam partir?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Ritornerò per lui</l>
             <l part="I">quando in salvo sarai.</l>
@@ -2359,13 +2387,13 @@
               <emph>(partendo alla sinistra)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Fermati. Io veggo</l>
             <l>tornar per questa parte</l>
             <l part="I">i custodi reali.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">È ver: fuggiamo</l>
             <stage>
@@ -2374,11 +2402,11 @@
             <l>dunque per l´altra via. Ma quindi ancora</l>
             <l part="I">stuol d´armati s´avanza.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="M">Aimè!</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <stage>
               <emph>(guardando intorno)</emph>
@@ -2386,12 +2414,12 @@
             <l part="F">Gli amici</l>
             <l part="I">tutti m´abbandonar.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Miseri noi!</l>
             <l part="I">Or che farem?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Col ferro</l>
             <l part="I">una via t´aprirò. Sieguimi.</l>
@@ -2403,21 +2431,21 @@
         <div type="scene">
           <head>SCENA X</head>
           <stage>DEMOFOONTE <emph>dal destro lato con ispada alla mano. Guardie per tutte le parti; e detti</emph> .</stage>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Indegno,</l>
             <l part="I">non fuggirmi; t´arresta.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Ah padre, ah dove</l>
             <l part="I">vieni ancor tu!</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="M">Perfido figlio!</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <stage>
               <emph>(vede crescere il numero della guardie, e si pone innanzi alla sposa)</emph>
@@ -2425,12 +2453,12 @@
             <l part="F">Alcuno</l>
             <l part="I">non s´appressi a Dircea.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Principe, ah cedi.</l>
             <l part="I">Pensa a te.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">No, custodi,</l>
             <l>non si stringe il ribelle: al suo furore</l>
@@ -2441,11 +2469,11 @@
             <l>nel trafiggere un padre</l>
             <l>chi fin dentro a´ lor tempii insulta i numi.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="I">Oh Dio!</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Chi ti trattien? Forse il vedermi</l>
             <l>la destra armata? Ecco l´acciaro a terra.</l>
@@ -2459,7 +2487,7 @@
             <l>fumante ancor, la scellerata mano</l>
             <l part="I">porgere alla tua bella.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Ah basta; ah padre,</l>
             <l>taci; non più. Con quei crudeli accenti</l>
@@ -2471,11 +2499,11 @@
             <l>che ardir non ho per domandar mercede:</l>
             <l>ma un tal castigo ogni delitto eccede.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="I"> (In che stato è per me!)</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F"> (S´io non avessi</l>
             <l>della perfidia sua prove sì grandi,</l>
@@ -2483,7 +2511,7 @@
             <l>quella destra ribelle</l>
             <l part="I">porgi, o fellon.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Custodi,</l>
             <stage>
@@ -2493,42 +2521,42 @@
             <l>Ecco la man: non le ricusa il figlio</l>
             <l>del giusto padre al venerato impero.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l>(Pur troppo il mio timor predisse il vero!)</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l>All´oltraggiato nume</l>
             <l>la vittima si renda; e me presente</l>
             <l part="I">si sveni, o sacerdoti.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Ah ch´io non posso</l>
             <l>difenderti, ben mio!</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l>Quante volte in un dì morir degg´io!</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="I">Mio re, mio genitor...</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Lasciami in pace.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="I">Pietà!</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="M">La chiedi in van.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Ma ch´io mi vegga</l>
             <l>svenar Dircea su gli occhi,</l>
@@ -2538,33 +2566,33 @@
             <l>la vittima richiesta. Il sacrifizio</l>
             <l part="I">sacrilego saria.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Per qual ragione?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Dì: che domanda il nume?</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="I">D´una vergine il sangue.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">E ben Dircea</l>
             <l>non può condursi a morte:</l>
             <l>ella è moglie, ella è madre e mia consorte.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="I">Come!</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="M"> (Io tremo per lui).</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Numi possenti,</l>
             <l>che ascolto mai! L´incominciato rito</l>
@@ -2576,7 +2604,7 @@
             <l>guisa tu sei della vecchiezza mia</l>
             <l part="I">il felice sostegno? Ah..</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Non sdegnarti,</l>
             <l>signor, con lui: son io la rea; son queste</l>
@@ -2586,7 +2614,7 @@
             <l>al vietato imeneo con le frequenti</l>
             <l part="I">lagrime insidiose.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Ah, non è vero;</l>
             <l>non crederle, signor. Diversa affatto</l>
@@ -2600,11 +2628,11 @@
             <l>questa man disperata il ferro strinse;</l>
             <l>volli ferirmi, e la pietà la vinse.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="I">E pur...</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Tacete. (Un non so che mi serpe</l>
             <l>di tenero nel cor, che in mezzo all´ira</l>
@@ -2615,15 +2643,15 @@
             <l>in carcere distinto</l>
             <l part="I">si serbino al castigo.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Almen congiunti...</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l>Congiunti almen nelle sventure estreme...</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l>Sarete, anime ree, sarete insieme.</l>
             <l>Perfidi, già che in vita</l>
@@ -2642,32 +2670,32 @@
         <div type="scene">
           <head>SCENA XI</head>
           <stage>DIRCEA <emph>e</emph>  TIMANTE</stage>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="I">Sposo.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="M">Consorte.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">E tu per me ti perdi?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="I">E tu mori per me?</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Chi avrà più cura</l>
             <l part="I">del nostro Olinto?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="M">Ah qual momento!</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Ah quale...</l>
             <l>Ma che? Vogliamo, o prence,</l>
@@ -2676,110 +2704,110 @@
             <l>questo nodo crudel divida e franga.</l>
             <l>Separiamci da forti; e non si pianga.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Sì, generosa; approvo</l>
             <l>l´intrepido pensier. Più non si sparga</l>
             <l part="I">un sospiro fra noi.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Disposta io sono.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Risoluto son io.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="I">Coraggio.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="M">Addio, Dircea.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Principe, addio.</l>
             <stage>
               <emph>(si dividono con intrepidezza; ma, giunti alla scena, tornano a riguardarsi)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="I">Sposa.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="M">Timante.</l>
           </sp>
-          <sp>
+          <sp who="#timante #dircea">
             <speaker>TIMANTE, DIRCEA</speaker>
             <l part="M">Oh dei!</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Perché non parti?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="I">Perché torni a mirarmi?</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Io volli solo</l>
             <l>veder come resisti a´ tuoi martìri.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="I">Ma tu piangi frattanto!</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">E tu sospiri!</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Oh Dio, quanto è diverso</l>
             <l part="I">l´immaginar dall´eseguire!</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Oh quanto</l>
             <l>più forte mi credei! S´asconda almeno</l>
             <l>questa mia debolezza agli occhi tuoi.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="I">Ah fermati, ben mio. Senti.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Che vuoi?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>La destra ti chiedo,</l>
             <l>mio dolce sostegno,</l>
             <l>per ultimo pegno</l>
             <l>d´amore e di fé.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l>Ah! questo fu il segno</l>
             <l>del nostro contento:</l>
             <l>ma sento che adesSo</l>
             <l>l´istesso non è.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Mia vita, ben mio.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l>Addio, sposo amato.</l>
           </sp>
-          <sp>
+          <sp who="#timante #dircea">
             <speaker>TIMANTE, DIRCEA</speaker>
             <l>Che barbaro addio!</l>
             <l>Che fato crudel!</l>
@@ -2799,52 +2827,52 @@
           <head>SCENA I</head>
           <stage>Cortile interno del carcere, in cui è custodito Timante. </stage>
           <stage>TIMANTE <emph>e</emph>  ADRASTO</stage>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Taci. E speri ch´io voglia,</l>
             <l>quando muore Dircea, serbarmi in vita,</l>
             <l>stringendo un´altra sposa? E con qual fronte</l>
             <l part="I">sì vil consiglio osi propor?</l>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <l part="F">L´istessa</l>
             <l>tua Dircea lo propone. Ella ti parla</l>
             <l>così per bocca mia. Dice che è questo</l>
             <l part="I">l´ultimo don che ti domanda.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Appunto</l>
             <l part="I">perch´ella il vuol, non deggio farlo.</l>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <l part="F">E pure...</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="I">Basta così.</l>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <l part="M">Pensa, signor...</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Non voglio,</l>
             <l part="I">Adrasto, altri consigli.</l>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <l part="F">Io per salvarti</l>
             <l>pietoso m´affatico...</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Chi di viver mi parla, è mio nemico.</l>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <l>Non odi consiglio?</l>
             <l>Soccorso non vuoi?</l>
@@ -2862,7 +2890,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>TIMANTE <emph>e poi</emph> CHERINTO </stage>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Perché bramar la vita? E quale in lei</l>
             <l>piacer si trova? Ogni fortuna è pena;</l>
@@ -2879,7 +2907,7 @@
             <l>a scoprir s´incomincia, allor si muore.</l>
             <l part="I">Ah si mora una volta...</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="F">Amato prence,</l>
             <l part="I">vieni al mio sen.</l>
@@ -2887,14 +2915,14 @@
               <emph>(l´abbraccia)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Così sereno in volto</l>
             <l>mi dai gli estremi amplessi? E queste sono</l>
             <l>le lagrime fraterne</l>
             <l part="I">dovute al mio morir?</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="F">Che amplessi estremi,</l>
             <l>che lagrime, che morte? Il più felice</l>
@@ -2903,24 +2931,24 @@
             <l>la tenerezza sua, la sposa, il figlio,</l>
             <l part="I">la libertà, la vita.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">A poco a poco,</l>
             <l>Cherinto, per pietà. Troppe son queste,</l>
             <l>troppe gioie in un punto. Io verrei meno</l>
             <l>già di piacer, se ti credessi a pieno.</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="I">Non dubitar, Timante.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">E come il padre</l>
             <l>cambiò pensier? Quando partì dal tempio,</l>
             <l part="I">me con Dircea voleva estinto.</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="F">Il disse</l>
             <l>e l´eseguia; che inutilmente ognuno</l>
@@ -2928,12 +2956,12 @@
             <l>principe, a disperar, quando comparve</l>
             <l part="I">Creusa in tuo soccorso.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">In mio soccorso</l>
             <l part="I">Creusa, che oltraggiai?</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="F">Creusa. Ah tutti</l>
             <l>di quell´anima bella</l>
@@ -2961,19 +2989,19 @@
             <l>l´innocente bambin; gli sdegni suoi</l>
             <l>calmò; s´intenerì, pianse con noi.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Oh mio dolce germano!</l>
             <l>oh caro padre mio! Cherinto, andiamo,</l>
             <l part="I">andiamo a lui.</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="F">No: il fortunato avviso</l>
             <l>recarti ei vuol. Si sdegnerà se vede</l>
             <l part="I">ch´io lo prevenni.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">E tanto amore, e tanta</l>
             <l>tenerezza ha per me, che fino ad ora</l>
@@ -2987,52 +3015,52 @@
             <l>da una pena infinita</l>
             <l>gli ultimi dì della paterna vita.</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l>Che mi proponi, o prence! Ah per Creusa,</l>
             <l>sappilo al fin, non ho riposo: io l´amo</l>
             <l part="I">quanto amar si può mai. Ma...</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="M">Che?</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="F">Non spero</l>
             <l>ch´ella m´accetti. Al successor reale</l>
             <l>sai che fu destinata: io non son tale.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="I">Altro inciampo non v´è?</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="F">Grande abbastanza</l>
             <l part="I">questo mi par.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Va; la paterna fede</l>
             <l>disimpegna, o german: tu sei l´erede.</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="I">Io?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Sì. Già lo saresti,</l>
             <l>s´io non vivea per te. Ti rendo, o prence,</l>
             <l>parte sol del tuo dono,</l>
             <l>quando ti cedo ogni ragione al trono.</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="I">E il genitore...</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">E il genitore almeno</l>
             <l>non vedremo arrossir. Povero padre!</l>
@@ -3040,16 +3068,16 @@
             <l>a paragon di tanti</l>
             <l>beni, ch´egli mi rende?</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="I">Ah perde assai</l>
             <l>chi lascia una corona.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Sempre è più quel che resta a chi la dona.</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l>Nel tuo dono io veggo assai</l>
             <l>che del don maggior tu sei:</l>
@@ -3067,7 +3095,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>TIMANTE <emph>e poi</emph> MATUSIO <emph>con un foglio in mano</emph> .</stage>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Oh figlio, oh sposa, oh care</l>
             <l>parti dell´alma mia! Dunque fra poco</l>
@@ -3077,71 +3105,71 @@
             <l>Numi, che gioia è questa! A prova io sento</l>
             <l>che ha più forza un piacer d´ogni tormento.</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="I">Prence, signor.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Sei tu, Matusio? Ah scusa</l>
             <l part="I">se in vano al mar tu m´attendesti.</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">Assai</l>
             <l part="I">ti scusa il luogo in cui ti trovo.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">E come</l>
             <l part="I">potesti mai qui penetrar?</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">Cherinto</l>
             <l part="I">m´agevolò l´ingresso.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Ei t´avrà dette</l>
             <l part="I">le mie felicità.</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">No: frettoloso</l>
             <l part="I">non so dove correa.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Gran cose, amico,</l>
             <l part="I">gran cose ti dirò.</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">Forse più grandi</l>
             <l part="I">da me ne ascolterai.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Sappi che in terra</l>
             <l part="I">il più lieto or son io.</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">Sappi che or ora</l>
             <l part="I">scopersi un gran segreto.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="M">E quale?</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">Ascolta</l>
             <l>se la novella è strana.</l>
             <l>Dircea non è mia figlia, è tua germana.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Mia germana Dircea!</l>
             <stage>
@@ -3149,23 +3177,23 @@
             </stage>
             <l part="I">Eh tu scherzi con me.</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">Non scherzo, o prence.</l>
             <l>La cuna, il sangue, il genitor, la madre</l>
             <l part="I">hai comuni con lei.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Taci: che dici?</l>
             <l part="I"> (Ah nol permetta il Ciel!)</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">Fede sicura</l>
             <l part="I">questo foglio ne fa.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <stage>
               <emph>(con impazienza)</emph>
@@ -3173,7 +3201,7 @@
             <l part="F">Che foglio è quello?</l>
             <l part="I">Porgilo a me.</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">Sentimi pria. Morendo</l>
             <l>chiuso mel diè la mia consorte; e volle</l>
@@ -3181,82 +3209,82 @@
             <l>che a Dircea sovrastasse alcun periglio,</l>
             <l part="I">aperto non l´avrei.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Quand´ella adunque</l>
             <l>oggi dal re fu destinata a morte,</l>
             <l part="I">perché non lo facesti?</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">Eran tant´anni</l>
             <l part="I">scorsi di già, ch´io l´obbliai.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Ma come</l>
             <l part="I">or ti sovvien?</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">Quando a fuggir m´accinsi,</l>
             <l>fra le cose più care</l>
             <l>il ritrovai, che trassi meco al mare.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="I">Lascia al fin ch´io lo vegga.</l>
             <stage>
               <emph>(con impazienza)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="M">Aspetta.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Oh stelle!</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l>Rammenti già che alla real tua madre</l>
             <l>fu amica sì fedel la mia consorte,</l>
             <l>che in vita l´adorò, seguilla in morte?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="I">Lo so.</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">Questo ravvisi</l>
             <l part="I">reale impronto?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="M">Sì.</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">Vedi ch´è il foglio</l>
             <l>di propria man della regina impresso?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="I">Sì; non straziarmi più.</l>
             <stage>
               <emph>(con impazienza)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <stage>
               <emph>(gli porge il foglio)</emph>
             </stage>
             <l part="F">Leggilo adesso.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>(Mi trema il cor).<stage><emph>(legge)</emph></stage> «Non di Matusio è figlia,</l>
             <l>ma del tronco reale</l>
@@ -3269,38 +3297,38 @@
             <l>eccone intanto: una regina il giura.</l>
             <l part="I">Argìa».</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">Tu tremi, o prence!</l>
             <l>Questo è più che stupor. Perché ti copri</l>
             <l>di pallor sì funesto?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>(Onnipotenti dei, che colpo è questo!)</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l>Narrami adesso almeno</l>
             <l part="I">le tue felicità.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Matusio, ah parti.</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l>Ma che t´affligge! Una germana acquisti,</l>
             <l>ed è questa per te cagion di duolo?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Lasciami, per pietà, lasciami solo.</l>
             <stage>
               <emph>(si getta a sedere)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l>Quanto le menti umane</l>
             <l>son mai varie fra lor! Lo stesso evento</l>
@@ -3321,7 +3349,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>TIMANTE <emph>solo</emph> .</stage>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Misero me! Qual gelido torrente</l>
             <l>mi ruina sul cor! Qual nero aspetto</l>
@@ -3356,161 +3384,161 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>CREUSA, DEMOFONTE, ADRASTO, <emph>con</emph> OLINTO <emph>per mano, e</emph>  DIRCEA, <emph>l´un dopo l´altro da parti opposte; e detto</emph> .</stage>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="I">Timante.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Ah principessa; ah perché mai</l>
             <l part="I">morir non mi lasciasti?</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Amato figlio.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Ah no, con questo nome</l>
             <l part="I">non chiamarmi mai più.</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="F">Forse non sai...</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="I">Troppo, troppo ho saputo.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Un caro amplesso,</l>
             <l>pegno del mio perdon... Come! T´involi</l>
             <l>dalle paterne braccia?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Ardir non ho di rimirarti in faccia.</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="I">Ma perché?</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="M">Ma che avvenne?</l>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <l part="F">Ecco il tuo figlio;</l>
             <l part="I">consolati, signor.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Dagli occhi, Adrasto,</l>
             <l part="I">toglimi quel bambin.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Sposo adorato.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="I">Parti, parti, Dircea.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Da te mi scacci</l>
             <l>in dì così giocondo?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Dove, misero me, dove m´ascondo!</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="I">Ferma.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="M">Senti.</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="M">T´arresta.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Ah voi credete</l>
             <l>consolarmi, crudeli, e m´uccidete.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="I">Ma da chi fuggi?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Io fuggo</l>
             <l>dagli uomini, dai numi,</l>
             <l part="I">da voi tutti e da me.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Ma dove andrai?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Ove non splenda il sole,</l>
             <l>ove non sian viventi, ove sepolta</l>
             <l>la memoria di me sempre rimanga.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="I">E il padre?</l>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <l part="M">E il figlio?</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="M">E la tua sposa?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Oh Dio!</l>
             <l>Non parlate così. Padre, consorte,</l>
             <l>figlio, german son dolci nomi agli altri;</l>
             <l part="I">ma per me sono orrori.</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="F">E la cagione?</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Non curate saperla;</l>
             <l part="I">scordatevi di me.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Deh per quei primi</l>
             <l>fortunati momenti in cui ti piacqui...</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="I">Taci, Dircea.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Per que´ soavi nodi...</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Ma taci per pietà. Tu mi trafiggi</l>
             <l part="I">l´anima, e non lo sai.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Già che si poco</l>
             <l>curi la sposa, almen ti muova il figlio.</l>
@@ -3518,11 +3546,11 @@
             <l>che altre volte ti mosse:</l>
             <l part="I">guardalo; è sangue tuo.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Così nol fosse.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l>Ma in che peccò? Perché lo sdegni? A lui</l>
             <l>perché nieghi uno sguardo? Osserva, osserva</l>
@@ -3530,7 +3558,7 @@
             <l>come solleva a te; quanto vuol dirti</l>
             <l part="I">con quel riso innocente.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Ah! se sapessi,</l>
             <l>infelice bambin, quel che saprai</l>
@@ -3552,7 +3580,7 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>DEMOFOONTE, DIRCEA, CREUSA, ADRASTO, <emph>e</emph>  OLINTO</stage>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l>Sieguilo, Adrasto. Ah chi di voi mi spiega</l>
             <l>se il mio Timante è disperato o stolto!</l>
@@ -3578,7 +3606,7 @@
         <div type="scene">
           <head>SCENA VII</head>
           <stage>DIRCEA <emph>e</emph>  CREUSA</stage>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l>E tu, Dircea, che fai? Di te si tratta,</l>
             <l>si tratta del tuo sposo. Appresso a lui</l>
@@ -3590,7 +3618,7 @@
             <l>sfoga il duol che nascondi;</l>
             <l>piangi, lagnati almen, parla, rispondi.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l>Che mai risponderti,</l>
             <l>che dir potrei?</l>
@@ -3612,7 +3640,7 @@
         <div type="scene">
           <head>SCENA VIII</head>
           <stage>CREUSA <emph>sola</emph> .</stage>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l>Qual terra è questa! Io perché venni a parte</l>
             <l>delle miserie altrui? Quante in un giorno,</l>
@@ -3642,13 +3670,13 @@
           <head>SCENA IX</head>
           <stage>Luogo magnifico nella reggia festivamente adornato per le nozze di Creusa.</stage>
           <stage>TIMANTE <emph>e</emph> CHERINTO</stage>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Dove, crudel, dove mi guidi? Ah! queste</l>
             <l>liete pompe festive</l>
             <l part="I">son pene a un disperato.</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="F">Io non conosco</l>
             <l>più il mio german. Che debolezza è questa</l>
@@ -3657,7 +3685,7 @@
             <l>ma non sei reo. Qualunque male è lieve,</l>
             <l part="I">dove colpa non è.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Dall´opre il mondo</l>
             <l>regola i suoi giudizi; e la ragione,</l>
@@ -3679,7 +3707,7 @@
         <div type="scene">
           <head>SCENA X</head>
           <stage>ADRASTO <emph>e poi</emph>  MATUSIO, <emph>indi</emph>   DIRCEA <emph>con</emph> OLINTO; <emph>e detti</emph> .</stage>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADRASTO</speaker>
             <l part="F">Il re per tutto</l>
             <l>ti ricerca, o Timante. Or con Matusio</l>
@@ -3687,39 +3715,39 @@
             <l>Ambo son lieti in volto,</l>
             <l part="I">né chiedon che di te.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Fuggasi: io temo</l>
             <l>troppo l´incontro del paterno ciglio.</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="I">Figlio mio, caro figlio.</l>
             <stage>
               <emph>(abbracciandolo)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">A me tal nome!</l>
             <l part="I">Come? Perché?</l>
           </sp>
-          <sp>
+          <sp who="#matusio">
             <speaker>MATUSIO</speaker>
             <l part="F">Perché mio figlio sei,</l>
             <l part="I">perché son padre tuo.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Tu sogni... Oh stelle,</l>
             <l part="I">torna Dircea!</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">No, non fuggirmi, o sposo;</l>
             <l part="I">tua germana io non son.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Voi m´ingannate</l>
             <l>per rimettere in calma il mio pensiero.</l>
@@ -3728,16 +3756,16 @@
         <div type="scene">
           <head>SCENA XI</head>
           <stage>DEMOFOONTE <emph>con seguito, e detti</emph> .</stage>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l>Non t´ingannan, Timante: è vero, è vero.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Se mi tradiste adesso,</l>
             <l part="I">sarebbe crudeltà.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Ti rassicura:</l>
             <l>no, mio figlio non sei. Tu con Dircea</l>
@@ -3754,12 +3782,12 @@
             <l>Matusio ti mostrò: l´altro nascose,</l>
             <l part="I">ed è questo che vedi.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">E perché tutto</l>
             <l part="I">nel primo non spiegò?</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Solo a Dircea</l>
             <l>lasciò in quello una prova</l>
@@ -3772,18 +3800,18 @@
             <l>celò quest´altro foglio in parte solo</l>
             <l part="I">accessibile a me.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Sì strani eventi</l>
             <l part="I">mi fanno dubitar.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Troppo son certe</l>
             <l>le prove, i segni. Eccoti il foglio, in cui</l>
             <l>di quanto ti narrai la serie è accolta.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Non deludermi, o sorte, un´altra volta.</l>
             <stage>
@@ -3794,44 +3822,44 @@
         <div type="scene">
           <head>SCENA XII</head>
           <stage>CREUSA <emph>e detti</emph> .</stage>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l>Signor, veraci sono</l>
             <l>le felici novelle, onde la reggia</l>
             <l part="I">tutta si riempì?</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Sì, principessa.</l>
             <l>Ecco lo sposo tuo. L´erede, il figlio</l>
             <l>io ti promisi; ed in Cherinto io t´offro</l>
             <l part="I">ed il figlio e l´erede.</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l part="F">Il cambio forse</l>
             <l part="I">spiace a Creusa.</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="F">A quel, che il Ciel destina,</l>
             <l>in van farei riparo.</l>
           </sp>
-          <sp>
+          <sp who="#cherinto">
             <speaker>CHERINTO</speaker>
             <l>Ancora non vuoi dir ch´io ti son caro?</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="I">L´opra stessa il dirà.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l part="F">Dunque son io</l>
             <l>quell´innocente usurpator, di cui</l>
             <l part="I">l´oracolo parlò?</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Sì. Vedi come</l>
             <l>ogni nube sparì. Libero è il regno</l>
@@ -3844,7 +3872,7 @@
             <l>una cagion di duolo;</l>
             <l>e scioglie tanti nodi un foglio solo.</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <l>Oh caro foglio! Oh me felice! Oh numi!</l>
             <l>Da qual orrido peso</l>
@@ -3852,15 +3880,15 @@
             <l>tornate a questo sen: posso abbracciarvi</l>
             <l part="I">senza tremar.</l>
           </sp>
-          <sp>
+          <sp who="#dircea">
             <speaker>DIRCEA</speaker>
             <l part="F">Che fortunato istante!</l>
           </sp>
-          <sp>
+          <sp who="#creusa">
             <speaker>CREUSA</speaker>
             <l part="I">Che teneri trasporti!</l>
           </sp>
-          <sp>
+          <sp who="#timante">
             <speaker>TIMANTE</speaker>
             <stage>
               <emph>(s´inginocchia)</emph>
@@ -3872,7 +3900,7 @@
             <l>sarò miglior vassallo</l>
             <l part="I">che figlio non ti fui.</l>
           </sp>
-          <sp>
+          <sp who="#demofoonte">
             <speaker>DEMOFOONTE</speaker>
             <l part="F">Sorgi. Tu sei</l>
             <l>mio figlio ancor. Chiamami padre: io voglio</l>
@@ -3881,7 +3909,7 @@
             <l>elezion sarà: nodo più forte</l>
             <l>fabbricato da noi, non dalla sorte.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Par maggiore ogni diletto,</l>
             <l>se in un´anima si spande,</l>

--- a/tei/metastasio-didone-abbandonata.xml
+++ b/tei/metastasio-didone-abbandonata.xml
@@ -85,6 +85,31 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="enea">
+            <persName>Enea</persName>
+          </person>
+          <person xml:id="selene">
+            <persName>Selene</persName>
+          </person>
+          <person xml:id="osmida">
+            <persName>Osmida</persName>
+          </person>
+          <person xml:id="didone">
+            <persName>Didone</persName>
+          </person>
+          <person xml:id="araspe">
+            <persName>Araspe</persName>
+          </person>
+          <person xml:id="iarba">
+            <persName>Iarba</persName>
+          </person>
+          <person xml:id="nettuno">
+            <persName>Nettuno</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -128,7 +153,7 @@
           <stage>Luogo magnifico per le pubbliche udienze, con trono da un lato.</stage>
           <stage>Veduta in prospetto della città di Cartagine, che sta edificandosi.</stage>
           <stage>ENEA, SELENE, OSMIDA</stage>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>No, principessa, amico,</l>
             <l>sdegno non è, non è timor che move</l>
@@ -143,26 +168,26 @@
             <l>e son sì sventurato,</l>
             <l>che sembra colpa mia quella del fato.</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>Se cerchi al lungo error riposo e nido,</l>
             <l>te l'offre in questo lido</l>
             <l>la germana, il tuo merto e il nostro zelo.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Riposo ancor non mi concede il Cielo.</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l part="I">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l part="F">Con qual favella</l>
             <l>il lor voler ti palesaro i numi?</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Osmida, a questi lumi</l>
             <l>non porta il sonno mai suo dolce obblio,</l>
@@ -185,37 +210,37 @@
             <l>tronca il canape reo, sciogli le sarte».</l>
             <l>Mi guarda poi con torvo ciglio, e parte.</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l part="I">Gelo d'orror.</l>
             <stage>
               <emph>(dal fondo della scena comparisce Didone con seguito)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l part="F">(Quasi felice io sono.</l>
             <l>Se parte Enea, manca un rivale al trono).</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>Se abbandoni il tuo bene,</l>
             <l>morrà Didone (e non vivrà Selene).</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l>La regina s'appressa.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="I">(Che mai dirò?)</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l part="F">(Non posso</l>
             <l>scoprire il mio tormento).</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>(Difenditi, mio core, ecco il cimento).</l>
           </sp>
@@ -223,7 +248,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>DIDONE <emph>con seguito, e detti.</emph> </stage>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Enea, d'Asia splendore,</l>
             <l>di Citerea soave cura e mia,</l>
@@ -239,7 +264,7 @@
             <l>Forse già dal tuo core</l>
             <l>di me l'immago ha cancellata Amore?</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Didone alla mia mente,</l>
             <l>giuro a tutti gli dei, sempre è presente:</l>
@@ -247,63 +272,63 @@
             <l>potrà sparger d'obblio,</l>
             <l>questo ancor giuro ai numi, il foco mio.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Che proteste! Io non chiedo</l>
             <l>giuramenti da te: perch'io ti creda,</l>
             <l>un tuo sguardo mi basta, un tuo sospiro.</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l part="I">(Troppo s'inoltra).</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l part="F">(Ed io parlar non oso).</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Se brami il tuo riposo,</l>
             <l>pensa alla tua grandezza,</l>
             <l part="I">a me più non pensar.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="F">Che a te non pensi?</l>
             <l>Io, che per te sol vivo? Io, che non godo</l>
             <l>i miei giorni felici,</l>
             <l part="I">se un momento mi lasci?</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="F">Oh Dio, che dici!</l>
             <l>E qual tempo scegliesti! Ah troppo, troppo</l>
             <l>generosa tu sei per un ingrato.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Ingrato Enea! Perché? Dunque noiosa</l>
             <l part="I">ti sarà la mia fiamma.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="F">Anzi giammai</l>
             <l>con maggior tenerezza io non t'amai.</l>
             <l part="I">Ma...</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="M">Che?</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="F">La patria, il Cielo...</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Parla.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="F">Dovrei... ma no...</l>
             <l>L'amore... Oh Dio! la fé...</l>
@@ -320,33 +345,33 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>DIDONE, SELENE <emph>e</emph>  OSMIDA</stage>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Parte così, così mi lascia Enea!</l>
             <l>Che vuol dir quel silenzio? In che son rea?</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>Ei pensa abbandonarti.</l>
             <l>Contrastano in quel core,</l>
             <l>né so chi vincerà, gloria ed amore.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>È gloria abbandonarmi?</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l>(Si deluda). Regina,</l>
             <l>il cor d'Enea non penetrò Selene.</l>
             <l>Dalla reggia de' Mori</l>
             <l>qui giunger dee l'ambasciatore Arbace...</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="I">Che perciò?</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l part="F">Le tue nozze</l>
             <l>chiederà il re superbo; e teme Enea</l>
@@ -354,14 +379,14 @@
             <l>Perciò, così partendo,</l>
             <l part="I">fugge il dolor di rimirarti...</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="F">Intendo.</l>
             <l>Vanne, amata germana,</l>
             <l>dal cor d'Enea sgombra i sospetti, e digli</l>
             <l>che a lui non mi torrà se non la morte.</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>(A questo ancor tu mi condanni, o Sorte!)</l>
             <l>Dirò che fida sei;</l>
@@ -380,7 +405,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>DIDONE <emph>e</emph>  OSMIDA</stage>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Venga Arbace qual vuole,</l>
             <l>supplice, o minaccioso; ci viene in vano.</l>
@@ -389,7 +414,7 @@
             <l>Solo quel cor mi piace:</l>
             <l part="I">sappialo Iarba.</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l part="F">Ecco s'appressa Arbace.</l>
           </sp>
@@ -398,11 +423,11 @@
           <head>SCENA V</head>
           <stage>IARBA <emph>sotto nome d'Arbace</emph> , ARASPE <emph>e detti</emph> .</stage>
           <stage><emph>Mentre al suono di barbari si vedono venire da lontano</emph>  IARBA <emph>ed</emph>  ARASPE <emph>con seguito di Mori e comparse, che conducono tigri, leoni, e recano altri doni da presentare alla regina,</emph>  DIDONE, <emph>servita da</emph>  OSMIDA, <emph>va sul trono, alla destra del quale rimane</emph>  OSMIDA.<emph>Due cartaginesi portano fuori i cuscini per l'ambasciatore africano, e li situano lontano, ma in faccia al trono.</emph>  IARBA <emph>ed</emph>  ARASPE, <emph>fermandosi su l'ingresso, non intesi dicono:</emph> </stage>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l part="I">(Vedi, mio re...</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="F">T'accheta.</l>
             <l>Finché dura l'inganno,</l>
@@ -419,7 +444,7 @@
             <l>pegni di sua grandezza in don t'invia.</l>
             <l>Nel dono impara il donator qual sia.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Mentre io ne accetto il dono</l>
             <l>larga mercede il tuo signor riceve.</l>
@@ -427,14 +452,14 @@
             <l>quel, ch'ora è don, può divenire omaggio.</l>
             <l>(Come altiero è costui!) Siedi e favella.</l>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l part="I">(Qual ti sembra, o signor?)</l>
             <stage>
               <emph>(piano a Iarba)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <stage>
               <emph>(piano a Araspe)</emph>
@@ -450,30 +475,30 @@
             <l>la superba Cartago, ampio terreno,</l>
             <l part="I">dono del mio signore, e fu...</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="F">Col dono</l>
             <l>la vendita confondi...</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Lascia pria ch'io favelli, e poi rispondi.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="I">(Che ardir!)</l>
             <stage>
               <emph>(piano ad Osmida)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l part="M">(Soffri).</l>
             <stage>
               <emph>(piano a Didone)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="F">Cortese</l>
             <l>Iarba il mio re le nozze tue richiese:</l>
@@ -487,12 +512,12 @@
             <l>a contrastar gli amori</l>
             <l>un avanzo di Troia al re de' Mori.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>E gli amori e gli sdegni</l>
             <l>fian del pari infecondi.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Lascia pria ch'io finisca, e poi rispondi.</l>
             <l>Generoso il mio re di guerra in vece,</l>
@@ -501,15 +526,15 @@
             <l>brama gli affetti tuoi, chiede il tuo letto,</l>
             <l part="I">vuol la testa d'Enea.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="M">Dicesti?</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="F">Ho detto.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Dalla reggia di Tiro</l>
             <l>io venni a queste arene</l>
@@ -521,11 +546,11 @@
             <l>d'esser fida allo sposo allor pensai.</l>
             <l part="I">Or più quella non son...</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="F">Se non sei quella...</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Lascia pria ch'io risponda, e poi favella.</l>
             <l>Or più quella non son. Variano i saggi</l>
@@ -533,44 +558,44 @@
             <l>Enea piace al mio cor, giova al mio trono,</l>
             <l part="I">e mio sposo sarà.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="F">Ma la sua testa...</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Non è facil trionfo; anzi potrebbe</l>
             <l>costar molti sudori</l>
             <l>questo avanzo di Troia al re de' Mori.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Se il mio signore irrìti,</l>
             <l>verranno a farti guerra</l>
             <l>quanti Getuli e quanti</l>
             <l>Numidi e Garamanti Africa serra.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Purché sia meco Enea, non mi confondo.</l>
             <l>Vengano a questi lidi</l>
             <l>Garamanti, Numidi, Africa e il mondo.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="I">Dunque dirò...</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="F">Dirai</l>
             <l>che amoroso nol curo,</l>
             <l>che nol temo sdegnato.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="I">Pensa meglio, o Didone.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="F">Ho già pensato.</l>
             <stage>
@@ -590,35 +615,35 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>IARBA, OSMIDA <emph>e</emph>  ARASPE</stage>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Araspe, alla vendetta.</l>
             <stage>
               <emph>(in atto di partire)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l part="I">Mi son scorta i tuoi passi.</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l part="F">Arbace, aspetta.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="I">(Da me che bramerà?)</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l part="F">Posso a mia voglia</l>
             <l part="I">libero favellar?</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="M">Parla.</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l part="F">Se vuoi,</l>
             <l>m'offro agli sdegni tuoi compagno e guida.</l>
@@ -627,52 +652,52 @@
             <l>tutte dal cenno mio. Molto potrei</l>
             <l>a' tuoi disegni agevolar la strada.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="I">Ma tu chi sei?</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l part="F">Seguace</l>
             <l>della tiria regina, Osmida io sono.</l>
             <l>In Cipro ebbi la cuna,</l>
             <l>e il mio core è maggior di mia fortuna.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>L'offerta accetto, e, se fedel sarai,</l>
             <l>tutto in mercé ciò, che domandi, avrai.</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l>Sia del tuo re Didone, a me si ceda</l>
             <l part="I">di Cartago l'impero.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="F">Io tel prometto.</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l>Ma chi sa se consente</l>
             <l>il tuo signore alla richiesta audace?</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Promette il re, quando promette Arbace.</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l part="I">Dunque...</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="F">Ogni atto innocente</l>
             <l>qui sospetto esser può: serba i consigli</l>
             <l>a più sicuro loco e più nascoso.</l>
             <l>Fidati; Osmida è re, se Iarba è sposo.</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l>Tu mi scorgi al gran disegno:</l>
             <l>al tuo sdegno, al tuo desio</l>
@@ -689,16 +714,16 @@
         <div type="scene">
           <head>SCENA VII</head>
           <stage>IARBA <emph>ed</emph>  ARASPE</stage>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Quanto è stolto, se crede</l>
             <l>ch'io gli abbia a serbar fede.</l>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l>Il promettesti a lui.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Non merta fé chi non la serba altrui.</l>
             <l>Ma vanne, amato Araspe,</l>
@@ -706,20 +731,20 @@
             <l>vanne: le mie vendette</l>
             <l>un tuo colpo assicuri. Enea s'uccida.</l>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l>Vado: e sarà fra poco</l>
             <l>del suo, del mio valore</l>
             <l>in aperta tenzone arbitro il fato.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>No, t'arresta: io non voglio</l>
             <l>che al caso si commetta</l>
             <l>l'onor tuo, l'odio mio, la mia vendetta.</l>
             <l>Improvviso l'assali, usa la frode.</l>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l>Da me frode! Signor, suddito io nacqui,</l>
             <l>ma non già traditor. Dimmi ch'io vada</l>
@@ -729,17 +754,17 @@
             <l>non ricuso cimento,</l>
             <l>ma da me non si chieda un tradimento.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Sensi d'alma volgare. A me non manca</l>
             <l part="I">braccio del tuo più fido.</l>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l part="F">E come, oh dei!</l>
             <l part="I">La tua virtude...</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="F">Eh che virtù? Nel mondo</l>
             <l>o virtù non si trova,</l>
@@ -760,7 +785,7 @@
         <div type="scene">
           <head>SCENA VIII</head>
           <stage>ARASPE <emph>solo</emph> </stage>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l>Empio! L'orror, che porta</l>
             <l>il rimorso d'un fallo anche felice,</l>
@@ -784,7 +809,7 @@
           <head>SCENA IX</head>
           <stage>Cortile</stage>
           <stage>SELENE <emph>ed</emph>  ENEA</stage>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Già tel dissi, o Selene,</l>
             <l>male interpreta Osmida i sensi miei.</l>
@@ -794,7 +819,7 @@
             <l>Ma saper che m'adora,</l>
             <l>e doverla lasciar, questo è il tormento.</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>Sia qual vuoi la cagione,</l>
             <l>che ti sforza a partir, per pochi istanti</l>
@@ -802,58 +827,58 @@
             <l>vanne: la mia germana</l>
             <l>vuol colà favellarti.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="I">Sarà pena l'indugio.</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l part="F">Odila e parti.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Ed a colei, che adoro,</l>
             <l part="I">darò l'ultimo addio?</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l part="F">(Taccio, e non moro!)</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="I">Piange Selene!</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l part="F">E come,</l>
             <l>quando parli così, non vuoi ch'io pianga?</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Lascia di sospirar. Sola Didone</l>
             <l>ha ragion di lagnarsi al partir mio.</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>Abbiam l'istesso cor Didone ed io.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Tanto per lei t'affliggi?</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>Ella in me così vive,</l>
             <l>io così vivo in lei,</l>
             <l>che tutti i mali suoi son mali miei.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Generosa Selene, i tuoi sospiri</l>
             <l>tanta pietà mi fanno,</l>
             <l>che scordo quasi il mio nel vostro affanno.</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>(Se mi vedessi il core,</l>
             <l>forse la tua pietà saria maggiore).</l>
@@ -862,16 +887,16 @@
         <div type="scene">
           <head>SCENA X</head>
           <stage>IARBA, ARASPE <emph>e detti</emph> </stage>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Tutta ho scorsa la reggia</l>
             <l>cercando Enea, né ancor m'incontro in lui.</l>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l part="I">Forse quindi partì.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <stage>
               <emph>(vedendo Enea)</emph>
@@ -883,65 +908,65 @@
               <emph>(ad Enea)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l>(Quanto piace quel volto agli occhi miei!)</l>
             <stage>
               <emph>(vedendo Selene)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="I">Troppo, bella Selene...</l>
             <stage>
               <emph>(dopo aver guardato Iarba)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <stage>
               <emph>(ad Enea)</emph>
             </stage>
             <l part="F">Olà non odi?</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Troppo ad altri pietosa...</l>
             <stage>
               <emph>(come sopra)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l part="I">Che superbo parlar!</l>
             <stage>
               <emph>(guardando Iarba)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <stage>
               <emph>(guardando Selene)</emph>
             </stage>
             <l part="F">(Quanto è vezzosa!)</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="I">O palesa il tuo nome, o ch'io...</l>
             <stage>
               <emph>(ad Enea)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="F">Qual dritto</l>
             <l>hai tu di domandarne? A te che giova?</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="I">Ragione è il piacer mio.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="F">Fra noi non s'usa</l>
             <l part="I">di rispondere a stolti.</l>
@@ -949,57 +974,57 @@
               <emph>(vuol partire)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="F">A questo acciaro...</l>
             <stage>
               <emph>(volendo cavar la spada, Selene lo ferma)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>Su gli occhi di Selene,</l>
             <l>nella reggia di Dido, un tanto ardire?</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Di Iarba al messaggiero</l>
             <l part="I">sì poco di rispetto?</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l part="F">Il folle orgoglio</l>
             <l part="I">la regina saprà.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="F">Sappialo. Intanto</l>
             <l>mi vegga ad onta sua troncar quel capo,</l>
             <l>e a quel d'Enea congiunto,</l>
             <l>dell'offeso mio re portarlo a' piedi.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Difficile sarà più che non credi.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Tu potrai contrastarlo? o quell'Enea,</l>
             <l>che per glorie racconta</l>
             <l part="I">tante perdite sue?</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="F">Cedono assai</l>
             <l>in confronto di glorie</l>
             <l>alle perdite sue le tue vittorie.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Ma tu chi sei, che tanto</l>
             <l>meco per lui contrasti?</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Son un che non ti teme, e ciò ti basti.</l>
             <l>Quando saprai chi sono</l>
@@ -1015,53 +1040,53 @@
         <div type="scene">
           <head>SCENA XI</head>
           <stage>SELENE, IARBA <emph>ed</emph>  ARASPE</stage>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="I">Non partirà, se pria...</l>
             <stage>
               <emph>(volendo seguirlo)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <stage>
               <emph>(arrestandolo)</emph>
             </stage>
             <l part="F">Da lui che brami?</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="I">Il suo nome.</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l part="F">Il suo nome</l>
             <l>senza tanto furor da me saprai.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>A questa legge io resto.</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>Quell'Enea, che tu cerchi, appunto è questo.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Ah! m'involasti un colpo,</l>
             <l>che al mio braccio offeriva il Ciel cortese.</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>Ma perché tanto sdegno? In che t'offese?</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Gli affetti di Didone</l>
             <l>al mio signor contende;</l>
             <l>t'è noto, e mi domandi in che m'offende?</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>Dunque supponi, Arbace,</l>
             <l>che scelga a suo talento il caro oggetto</l>
@@ -1075,17 +1100,17 @@
         <div type="scene">
           <head>SCENA XII</head>
           <stage>IARBA, ARASPE, <emph>poi</emph>  OSMIDA</stage>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Non è più tempo, Araspe,</l>
             <l>di celarmi così. Troppa finora</l>
             <l part="I">sofferenza mi costa.</l>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l part="F">E che farai?</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>I miei guerrier, che nella selva ascosi</l>
             <l>quindi non lungi al mio venir lasciai,</l>
@@ -1093,7 +1118,7 @@
             <l>distruggerò Cartago, e l'empio core</l>
             <l part="I">all'indegno rival trarrò...</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <stage>
               <emph>(con fretta)</emph>
@@ -1104,20 +1129,20 @@
             <l>al superbo troiano,</l>
             <l>se tardi a riparar, porge la mano.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="I">Tanto ardir!</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l part="F">Non è tempo</l>
             <l part="I">d'inutili querele.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="F">E qual consiglio?</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l>Il più pronto è il migliore. Io ti precedo:</l>
             <l>ardisci. Ad ogni impresa</l>
@@ -1130,30 +1155,30 @@
         <div type="scene">
           <head>SCENA XIII</head>
           <stage>IARBA <emph>ed</emph>  ARASPE</stage>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l>Dove corri, o signore?</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="I">Il rivale a svenar.</l>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l part="F">Come lo speri?</l>
             <l>Ancora i tuoi guerrieri</l>
             <l>il tuo voler non sanno.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Dove forza non val, giunga l'inganno.</l>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l>E vuoi la tua vendetta</l>
             <l>con la taccia comprar di traditore?</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Araspe, il mio favore</l>
             <l>troppo ardito ti fé. Più franco all'opre</l>
@@ -1175,36 +1200,36 @@
           <head>SCENA XIV</head>
           <stage>Tempio di Nettuno con simulacro del medesimo</stage>
           <stage>ENEA <emph>ed</emph>  OSMIDA</stage>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l>Come! Da' labbri tuoi</l>
             <l>Dido saprà che abbandonar la vuoi?</l>
             <l>Ah! taci per pietà,</l>
             <l>e risparmia al suo cor questo tormento.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Il dirlo è crudeltà,</l>
             <l>ma sarebbe il tacerlo un tradimento.</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l>Benché costante, io spero</l>
             <l>che al pianto suo tu cangerai pensiero.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Può togliermi di vita,</l>
             <l>ma non può il mio dolore</l>
             <l>far ch'io manchi alla patria e al genitore.</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l>Oh generosi detti!</l>
             <l>Vincere i propri affetti</l>
             <l>avanza ogni altra gloria.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Quanto costa però questa vittoria!</l>
           </sp>
@@ -1212,7 +1237,7 @@
         <div type="scene">
           <head>SCENA XV</head>
           <stage>IARBA, ARASPE <emph>e detti.</emph> </stage>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Ecco il rival; né seco</l>
             <l>è alcun de' suoi seguaci...</l>
@@ -1220,14 +1245,14 @@
               <emph>(piano ad Araspe)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l part="I">Ah pensa che tu sei...</l>
             <stage>
               <emph>(piano a Iarba)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <stage>
               <emph>(Come sopra)</emph>
@@ -1238,14 +1263,14 @@
               <emph>(nel voler ferire Enea, trattenuto da Araspe, gli cade il pugnale, ed Araspe lo raccoglie)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <stage>
               <emph>(ad Iarba)</emph>
             </stage>
             <l part="M">Fermati.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <stage>
               <emph>(ad Araspe)</emph>
@@ -1253,14 +1278,14 @@
             <l part="F">Indegno,</l>
             <l>al nemico in aiuto?</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="I">Che tenti, anima rea?</l>
             <stage>
               <emph>(ad Araspe, vedendogli il pugnale)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l part="F">(Tutto è perduto).</l>
           </sp>
@@ -1268,7 +1293,7 @@
         <div type="scene">
           <head>SCENA XVI</head>
           <stage>DIDONE <emph>con guardie, e detti</emph> .</stage>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l>Siam traditi, o regina.</l>
             <stage>
@@ -1278,47 +1303,47 @@
             <l>il valoroso Enea</l>
             <l>sotto colpo inumano oggi cadea.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Il traditor qual è, dove dimora?</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l>Miralo: nella destra ha il ferro ancora.</l>
             <stage>
               <emph>(accenna Araspe)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Chi ti destò nel seno</l>
             <l>sì barbaro desio?</l>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l>Del mio signor la gloria e il dover mio.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Come! L'istesso Arbace</l>
             <l part="I">disapprova...</l>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l part="F">Lo so ch'ei mi condanna:</l>
             <l>il suo sdegno pavento;</l>
             <l>ma il mio non fu delitto, e non mi pento.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>E né meno hai rossore</l>
             <l>del sacrilego eccesso?</l>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l>Tornerei mille volte a far l'istesso.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Ti preverrò. Ministri,</l>
             <l>custodite costui.</l>
@@ -1326,7 +1351,7 @@
               <emph>(Araspe parte tra le guardie)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Generoso nemico,</l>
             <stage>
@@ -1335,27 +1360,27 @@
             <l>in te tanta virtude io non credea.</l>
             <l part="I">Lascia che a questo sen...</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="F">Scostati, Enea.</l>
             <l>Sappi che il viver tuo d'Araspe è dono:</l>
             <l>che il tuo sangue vogl'io: che Iarba io sono.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="I">Tu Iarba!</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="F">Il re de' Mori!</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Un re sensi sì rei</l>
             <l>non chiude in seno: un mentitor tu sei.</l>
             <l part="I">Si disarmi.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="F">Nessuno</l>
             <stage>
@@ -1363,7 +1388,7 @@
             </stage>
             <l>avvicinarsi ardisca, o ch'io lo sveno.</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l>Cedi per poco almeno,</l>
             <l>fin ch'io genti raccolga: a me ti fida.</l>
@@ -1371,39 +1396,39 @@
               <emph>(piano a Iarba)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="I">E così vil sarò?</l>
             <stage>
               <emph>(piano ad Osmida)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="F">Fermate, amici;</l>
             <l part="I">a me tocca il punirlo.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="F">Il tuo valore</l>
             <l>serba ad uopo miglior. Che più s'aspetta?</l>
             <l>O si renda, o svenato al piè mi cada.</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l part="I">Serbati alla vendetta.</l>
             <stage>
               <emph>(piano a Iarba)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="F">Ecco la spada.</l>
             <stage>
               <emph>(getta la spada, che viene raccolta dalle guardie, e parte fra quelle)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Frenar l'alma orgogliosa</l>
             <l part="I">tua cura sia.</l>
@@ -1411,7 +1436,7 @@
               <emph>(ad Osmida)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l part="F">Su la mia fé riposa.</l>
             <stage>
@@ -1422,39 +1447,39 @@
         <div type="scene">
           <head>SCENA XVII</head>
           <stage>DIDONE <emph>ed</emph> ENEA</stage>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Enea, salvo già sei</l>
             <l>dalla crudel ferita.</l>
             <l>Per me serban gli dei sì bella vita.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="I">Oh Dio, regina!</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="F">Ancora</l>
             <l>forse della mia fede incerto stai?</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>No: più funeste assai</l>
             <l>son le sventure mie. Vuole il destino...</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Chiari i tuoi sensi esponi.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Vuol... (mi sento morir) ch'io t'abbandoni.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="I">M'abbandoni! Perché?</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="F">Di Giove il cenno,</l>
             <l>l'ombra del genitor, la patria, il Cielo,</l>
@@ -1463,16 +1488,16 @@
             <l>La mia lunga dimora</l>
             <l>pur troppo degli dei mosse lo sdegno.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>E così fin ad ora,</l>
             <l>perfido, mi celasti il tuo disegno?</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="I">Fu pietà.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="F">Che pietà? Mendace il labbro</l>
             <l>fedeltà mi giurava,</l>
@@ -1489,7 +1514,7 @@
             <l>ecco poi la mercede.</l>
             <l>A chi, misera me! darò più fede?</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Fin ch'io viva, o Didone,</l>
             <l>dolce memoria al mio pensier sarai:</l>
@@ -1498,17 +1523,17 @@
             <l>consacrare il mio affanno</l>
             <l>all'impero latino.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Veramente non hanno</l>
             <l>altra cura gli dei che il tuo destino.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Io resterò, se vuoi</l>
             <l>che si renda spergiuro un infelice.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>No: Sarei debitrice</l>
             <l>dell'impero del mondo a' figli tuoi.</l>
@@ -1521,30 +1546,30 @@
             <l>d'aver creduto all'elemento insano,</l>
             <l>richiamerai la tua Didone in vano.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Se mi vedessi il core...</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Lasciami, traditore!</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Almen dal labbro mio</l>
             <l>con volto meno irato</l>
             <l part="I">prendi l'ultimo addio.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="F">Lasciami, ingrato.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>E pur con tanto sdegno</l>
             <l part="I">non hai ragion di condannarmi.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="F">Indegno!</l>
             <l>Non ha ragione, ingrato,</l>
@@ -1564,7 +1589,7 @@
         <div type="scene">
           <head>SCENA XVIII</head>
           <stage>ENEA <emph>solo</emph> </stage>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>E soffrirò che sia</l>
             <l>sì barbara mercede</l>
@@ -1607,12 +1632,12 @@
           <head>SCENA I</head>
           <stage>Appartamenti reali con tavolino e sedia.</stage>
           <stage>SELENE <emph>ed</emph>  ARASPE</stage>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>Chi fu che all'inumano</l>
             <l>disciolse le catene?</l>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l>A me, bella Selene, il chiedi in vano.</l>
             <l>Io prigioniero e reo,</l>
@@ -1621,12 +1646,12 @@
             <l>fra' lacci il mio signor: il passo muovo</l>
             <l>a suo prò nella reggia, e vel ritrovo.</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>Ah contro Enea v'è qualche frode ordita.</l>
             <l part="I">Difendi la sua vita.</l>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l part="F">È mio nemico:</l>
             <l>pur se brami che Araspe</l>
@@ -1635,38 +1660,38 @@
             <l>l'onor mio nol contrasta:</l>
             <l part="I">ma ti basti così.</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l part="F">Così mi basta.</l>
             <stage>
               <emph>(in atto di partire)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l>Ah non toglier sì tosto</l>
             <l>il piacer di mirarti agli occhi miei.</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l part="I">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l part="F">Tacer dovrei ch'io sono amante:</l>
             <l>ma reo del mio delitto è il tuo sembiante.</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>Araspe, il tuo valore,</l>
             <l>il volto tuo, la tua virtù mi piace;</l>
             <l>ma già pena il mio cor per altra face.</l>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l part="I">Quanto son sventurato!</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l part="F">È più Selene.</l>
             <l>Se t'accende il mio volto,</l>
@@ -1674,22 +1699,22 @@
             <l>Io l'incendio nascoso</l>
             <l>tacer non posso, e palesar non oso.</l>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l>Soffri almen la mia fede.</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>Sì, ma da me non aspettar mercede.</l>
             <l>Se può la tua virtude</l>
             <l>amarmi a questa legge, io tel concedo:</l>
             <l part="I">ma non chieder di più.</l>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l part="F">Di più non chiedo.</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>Ardi per me fedele,</l>
             <l>serba nel cor lo strale,</l>
@@ -1707,7 +1732,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>ARASPE<emph>solo</emph> .</stage>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l>Tu dici ch'io non speri,</l>
             <l>ma nol dici abbastanza;</l>
@@ -1720,7 +1745,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>DIDONE <emph>con foglio in mano</emph> , OSMIDA, <emph>e poi</emph>  SELENE</stage>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Già so che si nasconde</l>
             <l>de' Mori il re sotto il mentito Arbace.</l>
@@ -1728,22 +1753,22 @@
             <l>e senz'altra dimora,</l>
             <l>o suddito o sovrano, io vuo' che mora.</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l>Sempre in me de' tuoi cenni</l>
             <l>il più fedele esecutor vedrai.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Premio avrà la tua fede.</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l>E qual premio, o regina? Adopro in vano</l>
             <l>per te fede e valore:</l>
             <l>occupa solo Enea tutto il tuo core.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Taci, non rammentar quel nome odiato.</l>
             <l>È un perfido, è un ingrato,</l>
@@ -1751,30 +1776,30 @@
             <l>Contro me stessa ho sdegno,</l>
             <l>perché finor l'amai.</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l>Se lo torni a mirar, ti placherai.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Ritornarlo a mirar! Per fin ch'io viva</l>
             <l>mai più non mi vedrà quell'alma rea.</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>Teco vorrebbe Enea</l>
             <l>parlar, se gliel concedi.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="I">Enea! Dov'è?</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l part="F">Qui presso</l>
             <l>che sospira il piacer di rimirarti.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="I">Temerario! Che venga.</l>
             <stage>
@@ -1782,12 +1807,12 @@
             </stage>
             <l part="F">Osmida, parti.</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l>Io non tel dissi? Enea</l>
             <l>tutta del cor la libertà t'invola.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Non tormentarmi più; lasciami sola.</l>
             <stage>
@@ -1798,7 +1823,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>DIDONE <emph>ed</emph>  ENEA</stage>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Come! Ancor non partisti? Adorna ancora</l>
             <l>questi barbari lidi il grande Enea?</l>
@@ -1807,7 +1832,7 @@
             <l>in trionfo traessi</l>
             <l>popoli debellati e regi oppressi.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Quest'amara favella</l>
             <l>mal conviene al tuo cor, bella regina.</l>
@@ -1816,17 +1841,17 @@
             <l>del moro il fiero orgoglio</l>
             <l part="I">con la morte punir.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="F">E questo è il foglio.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>La gloria non consente</l>
             <l>ch'io vendichi in tal guisa i torti miei:</l>
             <l>se per me lo condanni...</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Condannarlo per te! Troppo t'inganni.</l>
             <l>Passò quel tempo, Enea,</l>
@@ -1834,21 +1859,21 @@
             <l>è sciolta la catena,</l>
             <l>e del tuo nome or mi rammento appena.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Pensa che il re de' Mori</l>
             <l>è l'orator fallace.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Io non so qual ei sia, lo credo Arbace.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Oh Dio! Con la sua morte</l>
             <l>tutta contro di te l'Africa irrìti.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Consigli or non desio:</l>
             <l>tu provvedi a' tuoi regni, io penso al mio.</l>
@@ -1857,12 +1882,12 @@
             <l>Felice me, se mai</l>
             <l>tu non giungevi, ingrato, a questi lidi!</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Se sprezzi il tuo periglio,</l>
             <l>donalo a me: grazia per lui ti chieggio.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Sì, veramente io deggio</l>
             <l>il mio regno e me stessa al tuo gran merto.</l>
@@ -1887,7 +1912,7 @@
               <emph>(soscrive)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Idol mio, che pur sei</l>
             <l>ad onta del destin l'idolo mio,</l>
@@ -1902,7 +1927,7 @@
             <l>più della vita tua, più del tuo soglio;</l>
             <l part="I">quello...</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="F">Basta; vincesti: eccoti il foglio.</l>
             <l>Vedi quanto t'adora ancora, ingrato!</l>
@@ -1925,46 +1950,46 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>ENEA, <emph>poi</emph>  IARBA</stage>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Io sento vacillar la mia costanza</l>
             <l>a tanto amore appresso;</l>
             <l>e mentre salvo altrui, perdo me stesso.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Che fa l'invitto Enea? Gli veggo ancora</l>
             <l>del passato timore i segni in volto.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Iarba da' lacci è sciolto!</l>
             <l part="I">Chi ti diè libertà?</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="F">Permette Osmida</l>
             <l>che per entro la reggia io mi raggiri:</l>
             <l>ma vuol ch'io vada errando</l>
             <l>per sicurezza tua senza il mio brando.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Così tradisce Osmida</l>
             <l part="I">il comando real?</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="F">Dimmi, che temi?</l>
             <l>Ch'io fuggendo m'involi a queste mura?</l>
             <l>Troppo vi resterò per tua sventura.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>La tua sorte presente</l>
             <l>fa pietà, non timore.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Risparmia al tuo gran core</l>
             <l>questa pietà. D'una regina amante</l>
@@ -1973,7 +1998,7 @@
             <l>Con altr'armi non sanno</l>
             <l>le offese vendicar gli eroi troiani.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Leggi. La regal donna in questo foglio</l>
             <l>la tua morte segnò di propria mano.</l>
@@ -1989,7 +2014,7 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>IARBA <emph>solo</emph> .</stage>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Così strane venture io non intendo.</l>
             <l>Pietà nel mio nemico,</l>
@@ -2016,7 +2041,7 @@
           <head>SCENA VII</head>
           <stage>Atrio.</stage>
           <stage>ENEA, <emph>poi</emph>  ARASPE</stage>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Fra il dovere e l'affetto</l>
             <l>ancor dubbioso in petto ondeggia il core.</l>
@@ -2024,29 +2049,29 @@
             <l>all'impero servì d'un bel sembiante.</l>
             <l>Ah una volta l'eroe vinca l'amante.</l>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l>Di te finora in traccia</l>
             <l part="I">scorsi la reggia.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="F">Amico,</l>
             <l>vieni fra queste braccia.</l>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l>Allontanati, Enea; son tuo nemico.</l>
             <l>Snuda, snuda quel ferro:</l>
             <l>guerra con te, non amicizia io voglio.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Tu di Iarba all'orgoglio</l>
             <l>prima m'involi, e poi</l>
             <l>guerra mi chiedi, ed amistà non vuoi?</l>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l>T'inganni. Allor difesi</l>
             <l>la gloria del mio re, non la tua vita.</l>
@@ -2054,28 +2079,28 @@
             <l>rendergli a me s'aspetta</l>
             <l>quella, che tolsi a lui, giusta vendetta.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Enea stringer l'acciaro</l>
             <l part="I">contro il suo difensore!</l>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l part="F">Olà! che tardi?</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>La mia vita è tuo dono,</l>
             <l>prendila pur se vuoi; contento io sono.</l>
             <l>Ma ch'io debba a tuo danno armar la mano,</l>
             <l>generoso guerrier, lo speri in vano.</l>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l>Se non impugni il brando</l>
             <l>a ragion ti dirò codardo e vile.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Questa ad un cor virile</l>
             <l>vergognosa minaccia Enea non soffre.</l>
@@ -2096,33 +2121,33 @@
         <div type="scene">
           <head>SCENA VIII</head>
           <stage>SELENE<emph>e detti</emph> .</stage>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>Tanto ardir nella reggia? Olà, fermate.</l>
             <l>Così mi serbi fé? Così difendi,</l>
             <l>Araspe traditor, d'Enea la vita?</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>No, principessa, Araspe</l>
             <l>non ha di tradimenti il cor capace.</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>Chi di Iarba è seguace,</l>
             <l part="I">esser fido non può.</l>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l part="F">Bella Selene,</l>
             <l>puoi tu sola avanzarti</l>
             <l part="I">a tacciarmi così.</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l part="F">T'accheta, e parti.</l>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l>Tacerò, se tu lo brami;</l>
             <l>ma fai torto alla mia fede,</l>
@@ -2138,7 +2163,7 @@
         <div type="scene">
           <head>SCENA IX</head>
           <stage>SELENE <emph>ed</emph>  ENEA</stage>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Allorché Araspe a provocar mi venne,</l>
             <l>del suo signor sostenne</l>
@@ -2146,13 +2171,13 @@
             <l>se condannar pretendi,</l>
             <l>troppo quel core ingiustamente offendi.</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>Sia qual ei vuole Araspe, or non è tempo</l>
             <l>di favellar di lui. Brama Didone</l>
             <l part="I">teco parlar.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="F">Poc'anzi</l>
             <l>dal suo real soggiorno io trassi il piede.</l>
@@ -2160,20 +2185,20 @@
             <l>ch'io resti in questa arena,</l>
             <l>in van s'accrescerà la nostra pena.</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>Come fra tanti affanni,</l>
             <l>cor mio, chi t'ama abbandonar potrai?</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Selene, a me «cor mio»?</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>È Didone che parla, e non son io.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Se per la tua germana</l>
             <l>così pietosa sei,</l>
@@ -2181,21 +2206,21 @@
             <l>Dille che si consoli,</l>
             <l>che ceda al fato e rassereni il ciglio.</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>Ah no! Cangia, mio ben, cangia consiglio.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Tu mi chiami tuo bene?</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>È Didone che parla, e non Selene.</l>
             <l>Vieni e l'ascolta. È l'unica conforto,</l>
             <l part="I">ch'ella implora da te.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="F">D'un core amante</l>
             <l>quest'è il solito inganno:</l>
@@ -2216,7 +2241,7 @@
         <div type="scene">
           <head>SCENA X</head>
           <stage>SELENE <emph>sola</emph> .</stage>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>Stolta! per chi sospiro? Io senza speme</l>
             <l>perdo la pace mia. Ma chi mi sforza</l>
@@ -2246,7 +2271,7 @@
           <head>SCENA XI</head>
           <stage>Gabinetto con sedie.</stage>
           <stage>DIDONE, <emph>poi</emph>  ENEA</stage>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Incerta del mio fato</l>
             <l>io più viver non voglio. È tempo ormai</l>
@@ -2255,7 +2280,7 @@
             <l>se la pietà non giova,</l>
             <l>faccia la gelosia l'ultima prova.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Ad ascoltar di nuovo</l>
             <l>i rimproveri tuoi vengo, o regina.</l>
@@ -2263,7 +2288,7 @@
             <l>perfido, mancator, spergiuro, indegno:</l>
             <l>chiamami come vuoi: sfoga il tua sdegno.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>No, sdegnata io non sono. Infido, ingrato,</l>
             <l>perfido, mancator più non ti chiamo;</l>
@@ -2274,11 +2299,11 @@
               <emph>(siedono)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="M">(Che mai dirà?)</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="F">Già vedi, Enea,</l>
             <l>che fra nemici è il mio nascente impero.</l>
@@ -2296,21 +2321,21 @@
             <l>e non è meraviglia</l>
             <l>s'io risolver non so: tu mi consiglia.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Dunque fuor che la morte,</l>
             <l>o il funesto imeneo,</l>
             <l>trovar non si potria scampo migliore?</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="I">V'era pur troppo.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="F">E quale?</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Se non sdegnava Enea d'esser mio sposo,</l>
             <l>l'Africa avrei veduta</l>
@@ -2322,14 +2347,14 @@
             <l>Dimmi, che far degg'io? Con alma forte</l>
             <l>come vuoi, sceglierò Iarba, o la morte.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Iarba, o la morte! E consigliarti io deggio?</l>
             <l>Colei, che tanto adoro,</l>
             <l>all'odiato rival vedere in braccio!</l>
             <l part="I">Colei...</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="F">Se tanta pena</l>
             <l>trovi nelle mie nozze, io le ricuso:</l>
@@ -2338,37 +2363,37 @@
             <l>svena la tua fedele:</l>
             <l>è pietà con Didone esser crudele.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Ch'io ti sveni? Ah! più tosto</l>
             <l>cada sopra di me del Ciel lo sdegno:</l>
             <l>prima scemin gli dei,</l>
             <l>per accrescer tuoi giorni, i giorni miei.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="I">Dunque a Iarba mi dono. Olà.</l>
             <stage>
               <emph>(esce un paggio)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="F">Deh ferma.</l>
             <l>Troppo, oh Dio! per mia pena</l>
             <l part="I">sollecita tu sei.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="F">Dunque mi svena.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>No, si ceda al destino: a Iarba stendi</l>
             <l>la tua destra real. Di pace priva</l>
             <l>resti l'alma d'Enea, purché tu viva.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Giacché d'altri mi brami,</l>
             <l>appagarti saprò. Iarba si chiami.</l>
@@ -2378,21 +2403,21 @@
             <l>Vedi quanto son io</l>
             <l part="I">ubbidiente a te.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="F">Regina, addio.</l>
             <stage>
               <emph>(s'alzano)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Dove, dove? T'arresta.</l>
             <l>Del felice imeneo</l>
             <l>ti voglio spettatore.</l>
             <l part="I">(Resister non potrà).</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="F">(Costanza, o core).</l>
           </sp>
@@ -2400,18 +2425,18 @@
         <div type="scene">
           <head>SCENA XII</head>
           <stage>IARBA <emph>e detti</emph> .</stage>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Didone, a che mi chiedi?</l>
             <l>Sei folle, se mi credi</l>
             <l>dall'ira tua, da tue minacce oppresso.</l>
             <l>Non si cangia il mio cor; sempre è l'istesso.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="I">(Che arroganza!)</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="F">Deh placa</l>
             <l>il tua sdegno, o signor. Tu, col tacermi</l>
@@ -2421,40 +2446,40 @@
             <l>e con placido volto</l>
             <l part="I">ascolta i sensi miei.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="F">Parla, t'ascolto.</l>
             <stage>
               <emph>(siedono Iarba e Didone)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="I">Permettimi che ormai...</l>
             <stage>
               <emph>(in atto di partire)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="F">Fermati e siedi.</l>
             <l>Troppo lunghe non fian le tue dimore.</l>
             <l part="I">(Resister non potrà).</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="F">(Costanza, o core).</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Eh vada. Allor che teco</l>
             <l>Iarba soggiorna, ha da partir costui.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="I">(Ed io lo soffro?)</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="F">In lui</l>
             <l>in vece d'un rival trovi un amico.</l>
@@ -2466,16 +2491,16 @@
               <emph>(ad Enea)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="F">È vero.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Dunque nel re de' Mori</l>
             <l>altro merto non v'è che un suo consiglio?</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>No, Iarba; in te mi piace</l>
             <l>quel regio ardir, che ti conosco in volto:</l>
@@ -2484,42 +2509,42 @@
             <l>E se il Ciel mi destina</l>
             <l part="I">tua compagna e tua sposa...</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="F">Addio, regina.</l>
             <l>Basta che fin ad ora</l>
             <l part="I">t'abbia ubbidito Enea.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="F">Non basta ancora.</l>
             <l>Siedi per un momento.</l>
             <l part="I">(Comincia a vacillar).</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <stage>
               <emph>(torna a sedere)</emph>
             </stage>
             <l part="F">(Questo è tormento!)</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Troppo tardi, o Didone,</l>
             <l>conosci il tuo dover. Ma pure io voglio</l>
             <l>donar gli oltraggi miei</l>
             <l part="I">tutti alla tua beltà.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="F">(Che pena, o dei!)</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>In pegno di tua fede</l>
             <l part="I">dammi dunque la destra.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="F">Io son contenta.</l>
             <stage>
@@ -2528,27 +2553,27 @@
             <l>A più gradito laccio Amor pietoso</l>
             <l>stringer non mi potea.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="I">Più soffrir non si può.</l>
             <stage>
               <emph>(s'alza agitato)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="F">Qual ira, Enea?</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>E che vuoi? Non ti basta</l>
             <l>quanto fin or soffrì la mia costanza?</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="I">Eh taci.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="F">Che tacer? Tacqui abbastanza.</l>
             <l>Vuoi darti al mio rivale,</l>
@@ -2557,7 +2582,7 @@
             <l>Ch'io ti vedessi ancor fra le sue braccia?</l>
             <l>Dimmi che mi vuoi morto, e non ch'io taccia.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Odi. A torto ti sdegni.</l>
             <stage>
@@ -2565,7 +2590,7 @@
             </stage>
             <l part="I">Sai che per ubbidirti...</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="F">Intendo, intendo;</l>
             <l>io sono il traditor, son io l'ingrato;</l>
@@ -2580,63 +2605,63 @@
         <div type="scene">
           <head>SCENA XIII</head>
           <stage>DIDONE <emph>e</emph>  IARBA</stage>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="I">Senti.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="M">Lascia che parta.</l>
             <stage>
               <emph>(s'alza)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="F">I suoi trasporti</l>
             <l part="I">a me giova calmar.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="F">Di che paventi?</l>
             <l>Dammi la destra, e mia</l>
             <l>di vendicarti poi la cura sia.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>D'imenei non è tempo.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="I">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="M">Più non cercar.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="F">Saperlo io bramo.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Giacché vuoi, tel dirò: perché non t'amo:</l>
             <l>perché mai non piacesti agli occhi miei;</l>
             <l>perché odioso mi sei; perché mi piace,</l>
             <l>più che Iarba fedele, Enea fallace.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Dunque, perfida, io sono</l>
             <l>un oggetto di riso agli occhi tuoi!</l>
             <l>Ma sai chi Iarba sia?</l>
             <l>Sai con chi ti cimenti?</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>So che un barbaro sei, né mi spaventi.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Chiamami pur così.</l>
             <l>Forse pentita un dì</l>
@@ -2654,7 +2679,7 @@
         <div type="scene">
           <head>SCENA XIV</head>
           <stage>DIDONE <emph>sola</emph> .</stage>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>E pure in mezzo all'ire</l>
             <l>trova pace il mio cor. Iarba non temo;</l>
@@ -2686,7 +2711,7 @@
           <head>SCENA I</head>
           <stage>Porto di mare, con navi per l'imbarco d'Enea.</stage>
           <stage>ENEA <emph>con seguito di Troiani</emph> .</stage>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Compagni invitti, a tollerare avvezzi</l>
             <l>e del cielo e del mar gl'insulti e l'ire,</l>
@@ -2703,24 +2728,24 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>IARBA <emph>con seguito di Mori, e detti</emph> </stage>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Dove rivolge, dove</l>
             <l>quest'eroe fuggitivo i legni e l'armi?</l>
             <l>Vuol portar guerra altrove?</l>
             <l>O da me col fuggir cerca lo scampo?</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Ecco un novello inciampo.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Per un momento il legno</l>
             <l>può rimaner sul lido.</l>
             <l>Vieni, se hai cor; meco a pugnar ti sfido.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Vengo. Restate, amici,</l>
             <stage>
@@ -2730,32 +2755,32 @@
             <l>altri che il mio valor meco non voglio.</l>
             <l>Eccomi a te. Che pensi?</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Penso che all'ira mia</l>
             <l>la tua morte sarà poca vendetta.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Per ora a contrastarmi</l>
             <l part="I">non fai poco se pensi. All'armi.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="F">All'armi.</l>
             <stage>
               <emph>(mentre si battono, e Iarba va cedendo, i suoi Mori vengono in aiuto di lui ed assalgono Enea)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Venga tutto il tuo regno.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="I">Difenditi, se puoi.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="F">Non temo, indegno.</l>
             <stage>
@@ -2764,20 +2789,20 @@
             <l>Già cadesti e sei vinto. O tu mi cedi,</l>
             <l part="I">o trafiggo quel core.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="F">In van lo chiedi.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Se al vincitor sdegnato</l>
             <l part="I">non domandi pietà...</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="F">Siegui il tuo fato.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Sì, mori... Ma che fo? No, vivi. In vano</l>
             <l>tenti il mio cor con quell'insano orgoglio.</l>
@@ -2786,7 +2811,7 @@
               <emph>(parte)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Son vinto sì, ma non oppresso. Almeno</l>
             <l>oggetto all'ire tue, sorte incostante,</l>
@@ -2802,7 +2827,7 @@
           <head>SCENA III</head>
           <stage>Arborata tra la città e il porto.</stage>
           <stage>OSMIDA <emph>solo</emph> .</stage>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l>Già di Iarba in difesa</l>
             <l>lo stuol de' Mori a queste mura è giunto.</l>
@@ -2817,7 +2842,7 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>IARBA<emph>frettoloso, con seguito, e detto</emph> .</stage>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Seguitemi, o compagni:</l>
             <l part="I">alla reggia, alla reggia.</l>
@@ -2825,13 +2850,13 @@
               <emph>(passa davanti Osmida senza vederlo)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l part="F">Odi, signore:</l>
             <l>le tue schiere son pronte: è tempo al fine</l>
             <l part="I">che vendichi i tuoi torti.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="F">Amici, andiamo;</l>
             <stage>
@@ -2842,33 +2867,33 @@
               <emph>(in atto di partire)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l part="F">T'arresta.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="I">Che vuoi?</l>
             <stage>
               <emph>(con isdegno)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l part="F">Deh non scordarti</l>
             <l>che deve alla mia fede</l>
             <l>l'amor tuo vendicato una mercede.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>È giusto: anzi preceda</l>
             <l>la tua mercede alla vendetta mia.</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l part="I">Generoso monarca...</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="F">Olà, costui</l>
             <l>si disarmi, s'annodi, e poi s'uccida.</l>
@@ -2876,12 +2901,12 @@
               <emph>(in atto di partire)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l>Come! Questo ad Osmida?</l>
             <l>Qual ingiusto furore...</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Quest'è il premio dovuto a un traditore.</l>
             <stage>
@@ -2895,7 +2920,7 @@
           <stage>
             <emph>(uscendo Enea fuggono i Mori e lasciano legato ad un albero Osmida)</emph>
           </stage>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Siam tutti al fin raccolti. Alcun non manca</l>
             <l>de' dispersi compagni. E ben si tronchi</l>
@@ -2903,20 +2928,20 @@
             <l>l'aure e l'onde son chiare:</l>
             <l>alle navi, alle navi: al mare, al mare.</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l part="I">Invitto eroe.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="M">Che avvenne?</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l part="F">In questo stato</l>
             <l part="I">Iarba, il barbaro re...</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="F">Comprendo. Amici,</l>
             <l part="I">&gt;si ponga Osmida in libertà.</l>
@@ -2927,7 +2952,7 @@
             <l>da chi men può sperarlo abbia soccorso,</l>
             <l>ed apprenda virtù dal suo rimorso).</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l>Ah lascia, eroe pietoso,</l>
             <stage>
@@ -2935,21 +2960,21 @@
             </stage>
             <l part="I">che grato a sì gran don...</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="F">Sorgi, ed altrove</l>
             <l part="I">rivolgi i passi tuoi.</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l part="F">Grato a virtù sì rara...</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Se grato esser mi vuoi,</l>
             <l>ad esser fido un'altra volta impara.</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l>Quando l'onda, che nasce dal monte,</l>
             <l>al suo fonte ritorni dal prato,</l>
@@ -2965,24 +2990,24 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>ENEA <emph>e</emph>  SELENE <emph>frettolosa</emph> .</stage>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="I">Principessa, ove corri?</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l part="F">A te. M'ascolta.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l>Se brami un'altra volta</l>
             <l>rammentarmi l'amor, t'adopri in vano.</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l part="I">Ma che farà Didone?</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="F">Al partir mio</l>
             <l>manca ogni suo periglio.</l>
@@ -2993,16 +3018,16 @@
               <emph>(in atto di partire)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>Senti: se a noi t'involi,</l>
             <l>non sol Didone, ancor Selene uccidi.</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="I">Come?</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l part="F">Dal dì ch'io vidi il tuo sembiante,</l>
             <l>celai timida amante</l>
@@ -3011,7 +3036,7 @@
             <l>mercé, se non d'amore,</l>
             <l part="I">almeno di pietà; mercé...</l>
           </sp>
-          <sp>
+          <sp who="#enea">
             <speaker>ENEA</speaker>
             <l part="F">Selene,</l>
             <l>ormai più del tuo foco</l>
@@ -3035,7 +3060,7 @@
         <div type="scene">
           <head>SCENA VII</head>
           <stage>SELENE<emph>sola</emph> .</stage>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>Sprezzar la fiamma mia,</l>
             <l>togliere alla mia fede ogni speranza,</l>
@@ -3060,7 +3085,7 @@
           <head>SCENA VIII</head>
           <stage>Reggia con veduta della città di Cartagine in prospetto, che poi s'incendia.</stage>
           <stage>DIDONE <emph>e poi</emph>  OSMIDA</stage>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Va crescendo</l>
             <l>il mio tormento;</l>
@@ -3068,25 +3093,25 @@
             <l>e non l'intendo:</l>
             <l>giusti dei, che mai sarà!</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l part="I">Deh regina, pietà!</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="F">Che rechi, amico?</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l>Ah no, così bel nome</l>
             <l>non merta un traditore,</l>
             <l>d'Enea, di te nemico e del tuo amore.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="I">Come!</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l part="F">Con la speranza</l>
             <l>di posseder Cartago,</l>
@@ -3094,19 +3119,19 @@
             <l>fin or di me: poi per mercé volea</l>
             <l>l'empio svenarmi; e mi difese Enea.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Reo di tanto delitto hai fronte ancora</l>
             <l part="I">di presentarti a me?</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l part="F">Sì, mia regina.</l>
             <l>Tu vedi un infelice,</l>
             <l>che non spera il perdono e nol desia:</l>
             <l>chiedo a te per pietà la pena mia.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Sorgi. Quante sventure!</l>
             <l>Misera me, sotto qual astro io nacqui!</l>
@@ -3116,16 +3141,16 @@
         <div type="scene">
           <head>SCENA IX</head>
           <stage>SELENE <emph>e detti</emph> .</stage>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l part="F">Oh Dio, germana!</l>
             <l part="I">Al fine Enea...</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="M">Partì?</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l part="F">No, ma fra poco</l>
             <l>le vele scioglierà da' nostri lidi.</l>
@@ -3133,7 +3158,7 @@
             <l>verso i legni fugaci</l>
             <l>sollecito condurre i suoi seguaci.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Che infedeltà! Che sconoscenza! Oh dei!</l>
             <l>Un esule infelice</l>
@@ -3142,17 +3167,17 @@
             <l>E tu, cruda Selene,</l>
             <l>partir lo vedi, ed arrestar nol sai?</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>Fu vana ogni mia cura.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Vanne, Osmida; e procura</l>
             <l>che resti Enea per un momento solo.</l>
             <l part="I">M'ascolti; e parta.</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l part="F">Ad ubbidirti io volo.</l>
             <stage>
@@ -3163,25 +3188,25 @@
         <div type="scene">
           <head>SCENA X</head>
           <stage>DIDONE <emph>e</emph>  SELENE</stage>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>Ah non fidarti: Osmida</l>
             <l part="I">tu non conosci ancor.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="F">Lo so pur troppo.</l>
             <l>A questo eccesso è giunta</l>
             <l>la mia sorte tiranna:</l>
             <l>deggio chiedere aita a chi m'inganna.</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>Non hai, fuor che in te stessa, altra speranza.</l>
             <l>Vanne a lui, prega e piangi;</l>
             <l>chi sa, forse potrai vincer quel core.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Alle preghiere, ai pianti</l>
             <l>Dido scender dovrà! Dido, che seppe</l>
@@ -3194,7 +3219,7 @@
             <l>fra le insidie, fra l'armi e fra i perigli;</l>
             <l>ed a tanta viltà tu mi consigli?</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>O scordati il tuo grado,</l>
             <l>o abbandona ogni speme.</l>
@@ -3204,14 +3229,14 @@
         <div type="scene">
           <head>SCENA XI</head>
           <stage>ARASPE <emph>e dette</emph> .</stage>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="I">Araspe in queste soglie!</l>
             <stage>
               <emph>(si cominciano a veder fiamme in lontananza su gli edifizi di Cartagine)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l part="F">A te ne vengo</l>
             <l>pietoso del tuo rischio. Il re sdegnato</l>
@@ -3222,12 +3247,12 @@
             <l>a placare il suo sdegno,</l>
             <l>un sol giorno ti toglie e vita e regno.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Restano più disastri</l>
             <l part="I">per rendermi infelice?</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l part="F">Infausto giorno!</l>
           </sp>
@@ -3235,26 +3260,26 @@
         <div type="scene">
           <head>SCENA XII</head>
           <stage>OSMIDA <emph>e detti</emph> .</stage>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="I">Osmida.</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l part="F">Arde d'intorno...</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Lo so: d'Enea ti chiedo.</l>
             <l part="I">Che ottenesti da Enea?</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l part="F">Partì. Lontano</l>
             <l>è già da queste sponde. Io giunsi appena</l>
             <l>a ravvisar le fuggitive antenne.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Ah stolta! io stessa, io sono</l>
             <l>complice di sua fuga. Al primo istante</l>
@@ -3267,19 +3292,19 @@
             <l>quel traditore avvinto;</l>
             <l>e, se vivo non puoi, portalo estinto.</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l>Tu pensi a vendicarti, e cresce intanto</l>
             <l part="I">la sollecita fiamma.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="F">È ver, corriamo.</l>
             <l>Io voglio... Ah no... Restate...</l>
             <l>Ma la vostra dimora...</l>
             <l>Io mi confondo... E non partisti ancora?</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l part="I">Eseguisco i tuoi cenni.</l>
             <stage>
@@ -3290,24 +3315,24 @@
         <div type="scene">
           <head>SCENA XIII</head>
           <stage>DIDONE, SELENE, ARASPE</stage>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l part="F">Al tuo periglio</l>
             <l part="I">pensa, o Didone.</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l part="F">E pensa</l>
             <l>a ripararne il danno.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Non fo poco s'io vivo in tanto affanno.</l>
             <l>Va tu, cara Selene;</l>
             <l>provvedi, ordina, assisti in vece mia.</l>
             <l>Non lasciarmi, se m'ami, in abbandono.</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>Ah che di te più sconsolata io sono!</l>
             <stage>
@@ -3318,24 +3343,24 @@
         <div type="scene">
           <head>SCENA XIV</head>
           <stage>DIDONE <emph>ed</emph>  ARASPE</stage>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l>E tu qui resti ancor? Né ti spaventa</l>
             <l>l'incendio, che s'avanza?</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Perduta ogni speranza,</l>
             <l>non conosco timor. Ne' petti umani</l>
             <l>il timore e la speme</l>
             <l>nascono in compagnia, muoiono insieme.</l>
           </sp>
-          <sp>
+          <sp who="#araspe">
             <speaker>ARASPE</speaker>
             <l>Il tuo scampo desio. Vederti esposta</l>
             <l>a tal rischio mi spiace.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Araspe, per pietà lasciami in pace.</l>
             <stage>
@@ -3346,7 +3371,7 @@
         <div type="scene">
           <head>SCENA XV</head>
           <stage>DIDONE, <emph>poi</emph>  OSMIDA</stage>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>I miei casi infelici</l>
             <l>favolose memorie un dì saranno:</l>
@@ -3354,15 +3379,15 @@
             <l>soggetti miserabili e dolenti</l>
             <l>alle tragiche scene i miei tormenti.</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l>È perduta ogni speme.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="I">Così presto ritorni?</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l part="F">In vano, oh Dio!</l>
             <l>tentai passar dal tuo soggiorno al lido:</l>
@@ -3374,7 +3399,7 @@
             <l>né più desta pietade</l>
             <l>o l'immatura o la cadente etade.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Dunque alla mia ruina</l>
             <l part="I">più riparo non v'è?</l>
@@ -3386,7 +3411,7 @@
         <div type="scene">
           <head>SCENA XVI</head>
           <stage>SELENE <emph>e detti</emph> .</stage>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l part="F">Fuggi, o regina.</l>
             <l>Son vinti i tuoi custodi;</l>
@@ -3395,20 +3420,20 @@
             <l>passan le fiamme alla tua reggia in seno,</l>
             <l>e di fumo e faville è il ciel ripieno.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Andiam. Si cerchi altrove</l>
             <l part="I">per noi qualche soccorso.</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l part="M">E come?</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l part="F">E dove?</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Venite, anime imbelli;</l>
             <l>se vi manca valore,</l>
@@ -3418,15 +3443,15 @@
         <div type="scene">
           <head>SCENA XVII</head>
           <stage>IARBA <emph>con guardie, e detti</emph> .</stage>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="I">Fermati.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="M">Oh dei!</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l part="F">Dove così smarrita?</l>
             <l>Forse al fedel troiano</l>
@@ -3434,17 +3459,17 @@
             <l>Va pure, affretta il piede,</l>
             <l>che al talamo reale ardon le tede.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Lo so, questo è il momento</l>
             <l>delle vendette tue; sfoga il tuo sdegno</l>
             <l>or che ogni altro sostegno il Ciel mi fura.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Già ti difende Enea; tu sei sicura.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>E ben sarai contento.</l>
             <l>Mi volesti infelice? Eccomi sola,</l>
@@ -3456,19 +3481,19 @@
             <l>chiedo a Iarba ristoro:</l>
             <l>da Iarba per pietà la morte imploro.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>(Cedon gli sdegni miei).</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l part="I">(Giusti numi, pietà!)</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l part="F">(Soccorso, o dei!)</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>E pur, Didone, e pure</l>
             <l>sì barbaro non son, qual tu mi credi.</l>
@@ -3476,7 +3501,7 @@
             <l>L'offese io ti perdono,</l>
             <l>e mia sposa ti guido al letto e al trono.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Io sposa d'un tiranno,</l>
             <l>d'un empio, d'un crudel, d'un traditore,</l>
@@ -3486,7 +3511,7 @@
             <l>saria giusto il mio pianto.</l>
             <l>No, la disgrazia mia non giunse a tanto.</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>In sì misero stato insulti ancora!</l>
             <l>Olà, miei fidi, andate:</l>
@@ -3497,11 +3522,11 @@
               <emph>(partono due guardie)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>Pietà del nostro affanno!</l>
           </sp>
-          <sp>
+          <sp who="#iarba">
             <speaker>IARBA</speaker>
             <l>Or potrai con ragion dirmi tiranno.</l>
             <l>Cadrà fra poco in cenere</l>
@@ -3520,15 +3545,15 @@
         <div type="scene">
           <head>SCENA XVIII</head>
           <stage>DIDONE, SELENE <emph>ed</emph>  OSMIDA</stage>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l>Cedi a Iarba, o Didone.</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>Conserva con la tua la nostra vita.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Solo per vendicarmi</l>
             <l>del traditore Enea,</l>
@@ -3543,36 +3568,36 @@
             <l>così barbara sia,</l>
             <l>che si riduca ad invidiar la mia.</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>Deh modera il tuo sdegno. Anch'io l'adoro,</l>
             <l part="I">e soffro il mio tormento.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="F">Adori Enea!</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l part="I">Sì, ma per tua cagione...</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="F">Ah disleale!</l>
             <l part="I">Tu rivale al mio amor?</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l part="F">Se fui rivale,</l>
             <l part="I">ragion non hai...</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l part="F">Dagli occhi miei t'invola;</l>
             <l>non accrescer più pene</l>
             <l>ad un cor disperato.</l>
           </sp>
-          <sp>
+          <sp who="#selene">
             <speaker>SELENE</speaker>
             <l>(Misera donna, ove la guida il fato!)</l>
             <stage>
@@ -3583,11 +3608,11 @@
         <div type="scene">
           <head>SCENA XIX</head>
           <stage>DIDONE <emph>ed</emph> OSMIDA</stage>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l>Crescon le fiamme, e tu fuggir non curi?</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Mancano più nemici? Enea mi lascia,</l>
             <l>trovo Selene infida,</l>
@@ -3599,16 +3624,16 @@
             <l>Dunque perché congiura</l>
             <l>tutto il Ciel contro me, tutto l'inferno?</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l>Ah pensa a te; non irritar gli dei.</l>
           </sp>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Che dei? Son nomi vani,</l>
             <l>son chimere sognate, o ingiusti sono.</l>
           </sp>
-          <sp>
+          <sp who="#osmida">
             <speaker>OSMIDA</speaker>
             <l>(Gelo a tanta empietade, e l'abbandono).</l>
             <stage>
@@ -3619,7 +3644,7 @@
         <div type="scene">
           <head>SCENA ultima</head>
           <stage>DIDONE <emph>sola</emph> .</stage>
-          <sp>
+          <sp who="#didone">
             <speaker>DIDONE</speaker>
             <l>Ah che dissi, infelice! A qual eccesso</l>
             <l>mi trasse il mio furore?</l>
@@ -3650,7 +3675,7 @@
       </div>
       <div type="poesia">
         <head>LICENZA</head>
-        <sp>
+        <sp who="#nettuno">
           <speaker>NETTUNO</speaker>
           <l>Se alla discordia antica</l>
           <l>ritornar gli elementi, astri benigni</l>

--- a/tei/metastasio-ezio.xml
+++ b/tei/metastasio-ezio.xml
@@ -76,6 +76,31 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="massimo">
+            <persName>Massimo</persName>
+          </person>
+          <person xml:id="valentiniano">
+            <persName>Valentiniano III</persName>
+          </person>
+          <person xml:id="varo">
+            <persName>Varo</persName>
+          </person>
+          <person xml:id="ezio">
+            <persName>Ezio</persName>
+          </person>
+          <person xml:id="fulvia">
+            <persName>Fulvia</persName>
+          </person>
+          <person xml:id="Onoria">
+            <persName>Onoria</persName>
+          </person>
+          <person xml:id="coro">
+            <persName>Coro</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT-Pavia</name>Digitalizzazione</change>
@@ -129,7 +154,7 @@
           <head>SCENA PRIMA</head>
           <stage>Parte del Foro romano con trono imperiale da un lato. Vista di Roma illuminata in un tempo di notte, con archi trionfali ed altri apparati festivi, apprestati per celebrare le feste decennali e per onorare il ritorno d'Ezio, vincitore d'Attila.</stage>
           <stage>VALENTINIANO, MASSIMO, VARO, con pretoriani e popolo.</stage>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>Signor, mai con più fasto</l>
             <l>La prole di Quirino</l>
@@ -140,7 +165,7 @@
             <l>Al secolo vetusto</l>
             <l>Più non invidia il suo felice Augusto.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Godo ascoltando i voti</l>
             <l>Che a mio favor sino alle stelle invia</l>
@@ -150,7 +175,7 @@
             <l>Ch'io possa offrir con la mia destra in dono</l>
             <l>Ricco di palme alla tua figlia il trono.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>Dall'umiltà del padre</l>
             <l>Apprese Fulvia a non bramare il soglio,</l>
@@ -158,30 +183,30 @@
             <l>Dall'istessa umiltà. Cesare imponga:</l>
             <l part="I">La figlia eseguirà.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Fulvia io vorrei</l>
             <l part="I">Amante più, men rispettosa.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">E' vano</l>
             <l>Temer ch'ella non ami</l>
             <l>Que' pregi in te che l'universo ammira.</l>
             <l>(Il mio rispetto alla vendetta aspira).</l>
           </sp>
-          <sp>
+          <sp who="#varo">
             <speaker>VARO</speaker>
             <l>Ezio s'avanza. Io già le prime insegne</l>
             <l part="I">Veggo appressarsi.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Il vincitor s'ascolti:</l>
             <l>E sia Massimo a parte</l>
             <l>De' doni che mi fa la sorte amica. <stage>(Valentiniano va sul trono, servito da Varo</stage></l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>(Io però non oblio l'ingiuria antica).</l>
           </sp>
@@ -189,7 +214,7 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>EZIO, preceduto da istromenti bellici, schiavi ed insegne de' vinti, seguito da' soldati vincitori e popolo, e detti.</stage>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>Signor, vincemmo. Ai gelidi trioni</l>
             <l>Il terror de' mortali</l>
@@ -211,7 +236,7 @@
             <l>Se una prova ne vuoi, mira le vinte schiere:</l>
             <l>Ecco l'armi, le insegne e le bandiere.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Ezio, tu non trionfi</l>
             <l>D'Attila sol: nel debellarlo, ancora</l>
@@ -222,7 +247,7 @@
             <l>Alla tua mente, alla tua destra audace</l>
             <l>L'Italia tutta e libertade e pace.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>L'Italia i suoi riposi</l>
             <l>Tutta non deve a me; v'è chi li deve</l>
@@ -239,7 +264,7 @@
             <l>Di marmi adorne e gravi,</l>
             <l>Sorger le mura ove ondeggiàr le navi.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Chi mai non sa qual sia</l>
             <l>D'Antenore la prole? E' noto a noi</l>
@@ -253,7 +278,7 @@
             <l>Qual può sperarsi adulta,</l>
             <l part="I">Se nascente è così.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">Cesare, io veggo</l>
             <l>I semi in lei delle future imprese:</l>
@@ -263,7 +288,7 @@
             <l>Con mille vele e mille aperte al vento,</l>
             <l>Ai tiranni dell'Asia alto spavento.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Gli augùri fortunati</l>
             <l>Secondi il Ciel. Fra queste braccia intanto <stage>(scende dal trono</stage></l>
@@ -291,14 +316,14 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>EZIO, MASSIMO e poi FULVIA con paggi ed alcuni schiavi.</stage>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>Ezio, donasti assai</l>
             <l>Alla gloria e al dover: qualche momento</l>
             <l>Concedi all'amistà: lascia ch'io stringa</l>
             <l part="I">Quella man vincitrice. <stage>(Massimo prende per mano Ezio</stage></l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">Io godo amico,</l>
             <l>Nel rivederti, e caro</l>
@@ -308,11 +333,11 @@
             <l>Su le mie pompe ad appagar le ciglia,</l>
             <l part="I">La tua figlia non viene?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">Ecco la figlia.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>Cara, di te più degno <stage>(a Fulvia nell'uscire</stage></l>
             <l>Torna il tuo sposo, e al volto tuo gran parte</l>
@@ -327,28 +352,28 @@
             <l>Lontananza crudel, così m'accogli?</l>
             <l part="I">Mi consoli così?</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">(Che pena!) Io vengo...</l>
             <l part="I">Signor...</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">Tanto rispetto,</l>
             <l>Fulvia, con me? Perché non dir mio fido?</l>
             <l>Perché sposo non dirmi? Ah! Tu non sei</l>
             <l part="I">Per me quella che fosti.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">Oh Dio! son quella;</l>
             <l>Ma senti... Ah! genitor, per me favella.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="I">Massimo, non tacer.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">Tacqui fin ora,</l>
             <l>Perché co' nostri mali a te non volli</l>
@@ -362,26 +387,26 @@
             <l>I popoli dovranno</l>
             <l>Più superbo soffrirlo e più tiranno.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>Io tal nol credo. Almeno</l>
             <l>La tirannide sua mi fu nascosa.</l>
             <l part="I">Che pretende? Che vuol?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">Vuol la tua sposa.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>La sposa mia? Massimo, Fulvia, e voi</l>
             <l part="I">Consentite a tradirmi?</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="M">Aimè!</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">Qual arte,</l>
             <l>Qual consiglio adoprar? Vuoi che l'esponga,</l>
@@ -400,7 +425,7 @@
             <l>Vittima più gradita</l>
             <l part="I">D'un empio re.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">Che dici mai! L'affanno</l>
             <l>Vince la tua virtù. Giudice ingiusto</l>
@@ -409,7 +434,7 @@
             <l>Di loro è il Cielo. Ogni altra via si tenti,</l>
             <l part="I">Ma non l'infedeltade.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F"><stage>(abbraccia Ezio)</stage> Anima grande,</l>
             <l>Al par del tuo valore</l>
@@ -417,33 +442,33 @@
             <l>Nelle offese diviene.</l>
             <l>(Cangiar favella e simular conviene).</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l>Ezio così tranquillo</l>
             <l>La sua Fulvia abbandona ad altri in braccio?</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>Tu sei pur d'ogni laccio</l>
             <l>Disciolta ancora. Io parlerò. Vedrai</l>
             <l part="I">Tutto cangiar d'aspetto.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">Oh Dio! se parli,</l>
             <l part="I">Temo per te.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">L'imperator fin ora</l>
             <l part="I">Dunque non sa ch'io t'amo?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">Il vostro amore</l>
             <l part="I">Per tema io celai.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">Questo è l'errore.</l>
             <l>Cesare non ha colpa. Al nome mio</l>
@@ -451,7 +476,7 @@
             <l>Quanto mi deve e sa ch'opra da saggio</l>
             <l part="I">L'irritarmi non è.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">Tanto ti fidi?</l>
             <l>Ezio, mille timori</l>
@@ -462,7 +487,7 @@
             <l>E sperar non mi lice</l>
             <l>Che la sorte per me giammai si cangi.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>Son vincitor, sai che t'adoro, e piangi?</l>
             <lg>
@@ -483,7 +508,7 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>MASSIMO e FULVIA </stage>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l>E' tempo, o genitore,</l>
             <l>Che uno sfogo conceda al mio rispetto.</l>
@@ -496,14 +521,14 @@
             <l>D'Ezio stringer la mano,</l>
             <l>Ti sento dir che lo sperarlo è vano.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>Io d'ingannarti, o figlia,</l>
             <l>Mai non ebbi il pensier. T'accheta. Al fine,</l>
             <l>Non è il peggior de' mali</l>
             <l part="I">Il talamo d'Augusto.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">E soffrirai</l>
             <l>Ch'abbia sposa la figlia</l>
@@ -512,7 +537,7 @@
             <l>Le offese dell'onor? Cosìt'abbagli</l>
             <l part="I">Del trono allo splendor?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">Vieni al mio seno,</l>
             <l>Degna parte di me. Quell'odio illustre</l>
@@ -525,7 +550,7 @@
             <l>Tu puoi svenarlo: o almeno</l>
             <l>Agio puoi darmi a trapassargli il seno.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l>Che sento! E con qual fronte</l>
             <l>Posso a Cesare offrirmi</l>
@@ -538,31 +563,31 @@
             <l>Vindice di sua morte</l>
             <l part="I">Il popolo saria.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">L'odia ciascuno:</l>
             <l part="I">Vano è il timor.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">T'inganni: il volgo insano</l>
             <l>Quel tiranno talora,</l>
             <l>Che vivente aborrisce, estinto adora.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>Tu l'odio mi rammenti, e poi dimostri</l>
             <l>Quell'istessa freddezza</l>
             <l part="I">Che disapprovi in me!</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">Signor, perdona</l>
             <l>Se libera ti parlo. Un tradimento</l>
             <l>Io non consiglio, allora</l>
             <l part="I">Che una viltà condanno.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">Io ti credea,</l>
             <l>Fulvia, più saggia e men soggetta a questi</l>
@@ -570,21 +595,21 @@
             <l>Utili all'alme vili,</l>
             <l part="I">&gt;Inutili alle grandi.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">Ah! non son questi</l>
             <l>Que' semi di virtù, che in me versasti</l>
             <l>Da' miei primi vagiti infino ad ora.</l>
             <l>M'inganni adesso o m'ingannasti allora?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>Ogni diversa etade</l>
             <l>Vuol massime diverse. Altro a' fanciulli,</l>
             <l>Altro agli adulti è d'insegnar permesso.</l>
             <l part="I">Allora io t'ingannai.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">M'inganni adesso.</l>
             <l>Che l'odio della colpa,</l>
@@ -598,14 +623,14 @@
             <l>Ah! se cara io ti sono,</l>
             <l>pensa alla gloria tua, pensa che vai...</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>Taci, importuna. Io t'ho sofferta assai.</l>
             <l>Non dar consigli, o, consigliar se brami,</l>
             <l>Le tue pari consiglia.</l>
             <l>Rammenta ch'io son padre e tu sei figlia.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <lg>
               <l>Caro padre, a me non déi</l>
@@ -624,7 +649,7 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>MASSIMO solo.</stage>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>Che sventura è la mia! Così ripiena</l>
             <l>Di malvagi è la terra; e, quando poi</l>
@@ -666,7 +691,7 @@
           <head>SCENA SESTA</head>
           <stage>Camere imperiali istoriate di pitture</stage>
           <stage>ONORIA e VARO</stage>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l>Del vincitor ti chiedo,</l>
             <l>Non delle sue vittorie: esse abbastanza</l>
@@ -676,7 +701,7 @@
             <l>Gli accrebbe fasto, o mansueto il rese?</l>
             <l>Questo narrami, o Varo, e non le imprese.</l>
           </sp>
-          <sp>
+          <sp who="#varo">
             <speaker>VARO</speaker>
             <l>Onoria, a me perdona</l>
             <l>Se degli acquisti suoi, più che di lui,</l>
@@ -685,7 +710,7 @@
             <l>Sì minute richieste</l>
             <l part="I">D'amante più che di sovrana.</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l part="F">E' troppa</l>
             <l>Questa del nostro sesso</l>
@@ -698,12 +723,12 @@
             <l>Nel soggiorno è rimasta,</l>
             <l>Non v'accorse, nol vide; e pur non basta.</l>
           </sp>
-          <sp>
+          <sp who="#varo">
             <speaker>VARO</speaker>
             <l>Un soverchio ritegno</l>
             <l part="I">Anche d'amor è segno.</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l part="F">Alla tua fede,</l>
             <l>Al tuo lungo servir tollero, o Varo,</l>
@@ -711,7 +736,7 @@
             <l>Ch'è dal suo grado al mi, teco dovrebbe</l>
             <l part="I">Difendermi abbastanza.</l>
           </sp>
-          <sp>
+          <sp who="#varo">
             <speaker>VARO</speaker>
             <l part="F">Ognuno ammira</l>
             <l>D'Ezio il valor: Roma l'adora: il mondo</l>
@@ -719,7 +744,7 @@
             <l>Ne parlan con rispetto:</l>
             <l>Ingiustizia saria negargli affetto.</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l>Giacché tanto ti mostri</l>
             <l>Ad Ezio amico, il suo poter non devi</l>
@@ -729,7 +754,7 @@
             <l>All'amico non rendi.</l>
             <l>Chi sa? Potrebbe un dì... Varo, m'intendi.</l>
           </sp>
-          <sp>
+          <sp who="#varo">
             <speaker>VARO</speaker>
             <l>Io, che son d'Ezio amico,</l>
             <l>Più cauto parlerò; ma tu, se l'ami,</l>
@@ -756,7 +781,7 @@
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>ONORIA sola.</stage>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l>Importuna grandezza,</l>
             <l>Tiranna degli affetti, e perché mai</l>
@@ -780,7 +805,7 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>VALENTINIANO e MASSIMO</stage>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Ezio sappia ch'io bramo</l>
             <l>Seco parlar; che qui l'attendo.  <stage>(ad una comparsa che, ricevuto l'ordine, parte)</stage> Amico,</l>
@@ -793,7 +818,7 @@
             <l>Al talamo innalzarlo, acciò che sia</l>
             <l>Suo premio il nodo e sicurezza mia.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>Veramente per lui giunge all'eccesso</l>
             <l>L'idolatria del volgo. Omai si scorda</l>
@@ -805,32 +830,32 @@
             <l>Mal sicuro riparo</l>
             <l part="I">Tanto innalzarlo.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Un sì gran dono ammorza</l>
             <l part="I">&gt;L'ambizion d'un'alma.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">Anzi l'accende.</l>
             <l>Quando è vasto l'incendio, è l'onda istessa</l>
             <l part="I">Alimento alla fiamma.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">E come io spero</l>
             <l>Sicurezza miglior? Vuoi ch'io m'impegni</l>
             <l>Su l'orme de' tiranni, e ch'io divenga</l>
             <l>All'odio universale oggetto e segno?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>La prima arte del regno</l>
             <l>E' il soffrir l'odio altrui. Giova al regnante</l>
             <l>Più l'odio che l'amor. Con chi l'offende</l>
             <l>Ha più ragion d'esercitar l'impero.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Massimo, non è vero.</l>
             <l>Chi fa troppi temersi</l>
@@ -839,7 +864,7 @@
             <l>Il volgo contumace</l>
             <l>Per soverchio timor rendersi audace.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>Signor, meglio d'ogni altro</l>
             <l>Sai l'arte di regnare. Hanno i monarchi</l>
@@ -865,18 +890,18 @@
         <div type="scene">
           <head>SCENA NONA</head>
           <stage>VALENTINIANO, poi EZIO</stage>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Del Ciel felice dono</l>
             <l>Sembra il regno a chi sta lunge dal trono;</l>
             <l>Ma sembra il trono istesso</l>
             <l>Dono infelice a chi gli sta d'appresso.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="I">Eccomi al cenno tuo.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Duce, un momento</l>
             <l>Non posso tollerar d'esserti ingrato.</l>
@@ -889,7 +914,7 @@
             <l>Ricompensare un vincitore amico</l>
             <l>Trovo (chi 'l crederia?) ch'io son mendico.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>Signor, quando fra l'armi</l>
             <l>A pro di Roma, a pro di te sudai,</l>
@@ -898,7 +923,7 @@
             <l>Quando ottener poss'io,</l>
             <l part="I">Basta questo al mio cor.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Non basta al mio.</l>
             <l>Vuo' che il mondo conosca</l>
@@ -909,29 +934,29 @@
             <l>Darti pegno maggior non posso mai.</l>
             <l>Sposo d'Onoria al nuovo dì sarai.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="I">(Che ascolto!)</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="M">Non rispondi?</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">Onor sì grande</l>
             <l>Mi sorprende a ragion. D'Onoria il grado</l>
             <l>Chiede un re, chiede un trono;</l>
             <l>Ed io regni non ho, suddito io sono.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Ma un sudditto tuo pari</l>
             <l>E' maggior d'ogni re. Se non possiedi,</l>
             <l>Tu doni i regni; e il possederli è caso,</l>
             <l part="I">Il donarli è virtù.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">La tua germana,</l>
             <l>Signor, deve alla terra</l>
@@ -940,7 +965,7 @@
             <l>Ineguali imenei</l>
             <l>Ella a me scende, io non m'innalzo a lei.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Il mondo e la germana</l>
             <l>Nell'illustre imeneo punto non erde:</l>
@@ -948,13 +973,13 @@
             <l>D'un eroe corrispondo,</l>
             <l>Non può lagnarsi e la germana e il mondo.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>No, consentir non deggio</l>
             <l>Che comparisca Augusto,</l>
             <l>Per esser grato ad uno, a tanti ingiusto.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Duce, fra noi si parli</l>
             <l>Con franchezza una volta. Il tuo rispetto</l>
@@ -964,23 +989,23 @@
             <l>Di chi troppo richiede</l>
             <l>E' colui che ricusa ogni mercede.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>E ben, la tua franchezza</l>
             <l>Sia d'esempio alla mia. Signor, tu credi</l>
             <l part="I">Premiarmi, e mi punisci.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Io non sapea</l>
             <l>Che a te fosse castigo</l>
             <l>Una sposa germana al tuo regnante.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>Non è gran premio a chi d'un'altra è amante.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Dov'è questa beltà che tanto indietro</l>
             <l>Lascia il merto d'Onoria? E' a me soggetta?</l>
@@ -988,75 +1013,75 @@
             <l>Queste illustri catene.</l>
             <l part="I">Spiegami il nome suo.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">Fulvia è il mio bene.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="I">Fulvia!</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="M">Appunto. (Si turba).</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">(Che sorte!) Ed ella</l>
             <l part="I">Sa l'amor tuo?</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">Nol credo.</l>
             <l part="I">(Contro lei non s'irrìti).</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Il suo consenso</l>
             <l>Prima ottener procura:</l>
             <l>Vedi se tel contrasta.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>Quello sarà mia cura: il tuo mi basta.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Ma potrebbe altro amante</l>
             <l>Ragione aver sopra gli affetti suoi.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>Dubitarne non puoi. Dov'è chi ardisca</l>
             <l>Involar temerario una mercede</l>
             <l>Alla man che di Roma il giogo scosse?</l>
             <l part="I">Costui non veggo.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">E se costui vi fosse?</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>Vedria ch'Ezio difende</l>
             <l>Gli affetti suoi, come gl'imperi altrui:</l>
             <l part="I">Temer dovrebbe...</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">E se foss'io costui?</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>Saria più grande il dono,</l>
             <l>Se costasse uno sforzo al cor d'Augusto.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Ma non chiede un vassallo al suo sovrano</l>
             <l>Uno sforzo in mercede.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>Ma Cesare è il sovrano: Ezio lo chiede.</l>
             <l>Ezio che fin ad ora</l>
@@ -1068,18 +1093,18 @@
             <l>Non prova fortunato</l>
             <l>Per tema sol di comparirmi ingrato.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>(Temerario!) Credea,</l>
             <l>Nel rammentare io stesso i merti tuoi,</l>
             <l part="I">Di scemartene il peso.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">Io li rammento,</l>
             <l>Quando in premio pretendo...</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Non più: dicesti assai; tutto comprendo.</l>
             <lg>
@@ -1101,39 +1126,39 @@
         <div type="scene">
           <head>SCENA DECIMA</head>
           <stage>EZIO e poi FULVIA</stage>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>Vedrem se ardisce ancora</l>
             <l part="I">D'opporsi all'amor mio.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">Ti leggo in volto,</l>
             <l>Ezio, l'ire del cor. Forse ad Augusto</l>
             <l part="I">Ragionasti di me?</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">Sì, ma celai</l>
             <l>A lui che m'ami; onde temer non déi.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l>Che disse alla richiesta e che rispose?</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>Non cedé, non s'oppose:</l>
             <l>Si turbò; me n'avvidi a qualche segno;</l>
             <l>Ma non osò di palesar lo sdegno.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l>Questo è il peggior presagio. A vendicarsi</l>
             <l>Cauto le vie disegna</l>
             <l>Chi ha ragion di sdegnarsi e non si sdegna.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>Troppo timida sei.</l>
           </sp>
@@ -1141,7 +1166,7 @@
         <div type="scene">
           <head>SCENA UNDICESIMA</head>
           <stage>ONORIA e detti.</stage>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l>Ezio, gli obblighi miei</l>
             <l>Sono immensi con te. Volle il germano</l>
@@ -1149,14 +1174,14 @@
             <l>Sino alla tua; ma tu però, più giusto,</l>
             <l>D'esserne indegno hai persuaso Augusto.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>No, l'obbligo d'Onoria</l>
             <l>Questo non è. L'obbligo grande è quello</l>
             <l>Ch'io fui cagion, nel conservarle il soglio,</l>
             <l>Ch'or mi possa parlar con quell'orgoglio.</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l>E' ver, ti deggio assai; perciò mi spiace</l>
             <l>Che ad onta mia mi rendano le stelle</l>
@@ -1165,22 +1190,22 @@
             <l>Fulvia, ti vuol sua sposa <stage>(a Fulvia</stage></l>
             <l part="I">Cesare al nuovo dì.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="M">Come!</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">Che sento!</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l>Di recartene il cenno</l>
             <l>Egli stesso or m'impose. Ezio, dovresti</l>
             <l>Consolartene al fin: veder soggetto</l>
             <l>Tutto il mondo al tuo ben è pur diletto.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>Ah, questo è troppo! A troppo gran cimento</l>
             <l>D'Ezio la fedeltà Cesare espone.</l>
@@ -1191,11 +1216,11 @@
             <l>Vuol che Roma si faccia</l>
             <l>Di tragedie per lui scena funesta?</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l>Ezio minaccia; e la sua fede è questa?</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <lg>
               <l>Se fedel mi brama il regnante,</l>
@@ -1212,28 +1237,28 @@
         <div type="scene">
           <head>SCENA DODICESIMA</head>
           <stage>ONORIA e FULVIA</stage>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l>A Cesare nascondi,</l>
             <l>Onoria, i tuoi trasporti. Ezio è fedele:</l>
             <l>Parla così da disperato amante.</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l>Mostri, Fulvia, al sembiante</l>
             <l>Troppa pietà per lui, troppo timore.</l>
             <l>Fosse mai la pietà segno d'amore?</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l>Principessa, m'offendi. Assai conosco</l>
             <l>A chi deggio l'affetto.</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l>Non ti sdegnar così: questo è un sospetto.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l>Se prestar si dovesse</l>
             <l>Tanta fede ai sospetti, Onoria ancora</l>
@@ -1241,7 +1266,7 @@
             <l>Come soffri un rifiuto, anch'io m'avvedo:</l>
             <l>Dovrei crederti amante, e pur nol credo.</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l>Anch'io, quando m'oltraggi</l>
             <l>Con un sospetto al fasto mio nemico,</l>
@@ -1263,7 +1288,7 @@
         <div type="scene">
           <head>SCENA DODICESIMA</head>
           <stage>FULVIA sola.</stage>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l>Via, per mio danno aduna,</l>
             <l>O barbara Fortuna,</l>
@@ -1293,7 +1318,7 @@
         <div type="scene">
           <head>SCENA PRIMA</head>
           <stage>Orti palatine, corrispondenti agli appartamenti imperiali, con viali, spalliere di fiori e fontane continuate. Nel fondo caduta d'acque, e innanzi grotteschi e statue.</stage>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>Qual silenzio è mai questo! E' tutto in pace</l>
             <l>L'imperiale albergo. In oriente</l>
@@ -1305,23 +1330,23 @@
             <l>Nel tiranno punir tutti i miei torti,</l>
             <l part="I">E pigro...</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="M">Ah, genitor!</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">Figlia, che porti?</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="I">Che mi facesti?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="M">Io nulla feci.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">Oh, Dio!</l>
             <l>Fu Cesare assalito. Io già comprendo</l>
@@ -1329,26 +1354,26 @@
             <l>Che spingi a vendicarti</l>
             <l>La man che l'assalì.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="I">Ma Cesare mori?</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">Pensa a salvarti.</l>
             <l>Già di guerra e d'armi</l>
             <l>Tutto il soggiorno è cinto.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>Dimmi se vive o se rimane estinto.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l>Non so. Nulla di certo</l>
             <l part="I">Compresi nel timor.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">Sei pur codarda.</l>
             <l>Vado a chiederlo io stesso. <stage>(in atto di partire, s'incontra in Valentiniano</stage></l>
@@ -1357,54 +1382,54 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>VALENTINIANO senza manto e senza lauro, con ispada nuda e séguito di pretoriani, e detti.</stage>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Ogni via custodite ed ogni ingresso. <stage>(parlando ad alcuni soldati, che partono</stage></l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="I">(Egi vive! Oh destin!)</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Massimo, Fulvia,</l>
             <l part="I">Chi creduto l'avria?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">Signor, che avvenne?</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Ah! maggior fellonia mai non s'intese.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="I">(Misero genitor!)</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">(Tutto comprese).</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Di chi deggio fidarmi? I miei più cari</l>
             <l>M'insidiano la vita.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>(Ardir). Come! E potrebbe</l>
             <l>Un'anima sì rea trovarsi mai?</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Massimo, e pur si trova; e tu lo sai.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="I">Io!</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Sì; ma il Ciel difende</l>
             <l>Le vite de' monarchi. Emilio in vano</l>
@@ -1420,75 +1445,75 @@
             <l>Mi veggo, al lume inaspettato e nuovo,</l>
             <l>Sanguigno il ferro: il traditor non trovo.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="I">Forse Emilio non fu.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">La nota voce</l>
             <l>Ben riconobbi al grido, onde si dolse</l>
             <l part="I">Allor che lo piagai.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">Ma per qual fine</l>
             <l>Un tuo servo arrischiarsi al colpo indegno?</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Il servo lo tentò: d'altri è il disegno.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="I">(Oh Dio!)</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">Lascia ch'io vada</l>
             <l part="I">In traccia del fellon. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Cura è di Varo:</l>
             <l part="I">Tu non partire.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">(Ah, son perduto!) Io forse</l>
             <l part="I">Meglio di lui potrò...</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Massimo, amico,</l>
             <l>Non lasciarmi così: se tu mi lasci,</l>
             <l>Donde spero consiglio e donde aita?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="I">T'ubbidisco. (Io respiro).</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">(Io torno in vita).</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>Ma chi del tradimento</l>
             <l part="I">Tu credi autor?</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Puoi dubitarne? In esso</l>
             <l>Ezio non riconosci? Ah! se mai posso</l>
             <l>Convincerlo abbastanza, i giorni suoi</l>
             <l>L'error mi pagheranno.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l>(Mancava all'alma mia quest'altro affanno).</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>Io non so figurarmi</l>
             <l>In Ezio un traditor. D'esserlo almeno</l>
@@ -1502,23 +1527,23 @@
             <l>Arbitro è delle schiere...</l>
             <l>Eh potrebbe scordarsi il suo dovere.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l>Tu lo conosci, ed in tal guisa, o padre,</l>
             <l part="I">Parli di lui?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">Son d'Ezio amico, è vero,</l>
             <l part="I">Ma suddito d'Augusto.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">E Fulvia tanto</l>
             <l>Difende un traditor? Ah, che il sospetto</l>
             <l>Del geloso mio cor vero diviene.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>Credi Fulvia capace</l>
             <l>D'altro amor che del tuo? T'inganni. In lei</l>
@@ -1532,27 +1557,27 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>VARO e detti.</stage>
-          <sp>
+          <sp who="#varo">
             <speaker>VARO</speaker>
             <l>Cesare, in vano il traditor cercai.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="I">Ma dove si celò?</l>
           </sp>
-          <sp>
+          <sp who="#varo">
             <speaker>VARO</speaker>
             <l part="F">La nostra cura</l>
             <l part="I">Non poté rinvenirlo.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">E deggio in questa</l>
             <l>Incertezza restar? Di chi fidarmi?</l>
             <l>Di chi temer? Stato peggio del mio</l>
             <l part="I">Vedeste mai?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">Ti rassicura. Un colpo,</l>
             <l>Che a vuoto andò, del traditor scompone</l>
@@ -1561,7 +1586,7 @@
             <l>L'insidiator non è. Per tua salvezza</l>
             <l>D'alcuno intanto assicurar ti puoi.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Deh, m'assistete: io mi riposo in voi.</l>
             <lg>
@@ -1581,12 +1606,12 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>MASSIMO e FULVIA</stage>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l>E puoi d'un tuo delitto</l>
             <l>Ezio incolpar! Chi ti consiglia, o padre?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>Folle! la sua ruina</l>
             <l>E' riparo alla mia: della vendetta</l>
@@ -1598,25 +1623,25 @@
             <l>A chi di te più visse,</l>
             <l part="I">E più saggio è di te.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">Dunque ti renda</l>
             <l part="I">L'età più giusto ed il saper.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">Se tento</l>
             <l>L'onor mio vendicar, non sono ingiusto:</l>
             <l>E se lo fossi ancor, presa è la via,</l>
             <l>Ed a ritrarne il piè tardi saria.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l>Non è mai troppo tardi, onde si rieda</l>
             <l>Per le vie di virtù. Torna innocente</l>
             <l part="I">Chi detesta l'error.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">Posso una volta</l>
             <l>Ottener che non parli? Al fin che brami?</l>
@@ -1626,7 +1651,7 @@
             <l>I tuoi labbri loquaci,</l>
             <l>E in avvenir non irritarmi e taci.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l>Ch'io taccia e non t'irrìti, allor che veggio</l>
             <l>Il monarca assalito,</l>
@@ -1635,7 +1660,7 @@
             <l>O mi disciogli, o, quando</l>
             <l>Rispettosa mi vuoi, cangia il comando.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>Ah, perfida! Conosco</l>
             <l>Che vuoi sacrificarmi al tuo desio.</l>
@@ -1659,7 +1684,7 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>FULVIA, poi EZIO</stage>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l>Che fo? Dove mi volgo? Egual delitto</l>
             <l>E' il parlare e il tacer. Se parlo, oh Dio!</l>
@@ -1670,17 +1695,17 @@
             <l>Ah, qual consiglio mai...</l>
             <l>Ezio, dove t'inoltri? ove ten vai?</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="I">In difesa d'Augusto. Intesi...</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">Ah, fuggi!</l>
             <l>In te del tradimento</l>
             <l part="I">Cade il sospetto.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">In me! Fulvia, t'inganni.</l>
             <l>Ha troppe prove il Tebro</l>
@@ -1688,12 +1713,12 @@
             <l>Superar con l'imprese,</l>
             <l>Maggior d'ogni calunnia anche si rese.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l>Ma, se Cesare istesso il reo ti chiama,</l>
             <l part="I">S'io stessa l'ascoltai!</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">Può dirlo Augusto,</l>
             <l>Ma crederlo non può. S'anche un momento</l>
@@ -1702,7 +1727,7 @@
             <l>La sua grandezza, il conservato impero</l>
             <l>Rinfacciar gli saprà che non è vero.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l>So che la tua ruina</l>
             <l>Vendicata saria; ma chi m'accerta</l>
@@ -1711,12 +1736,12 @@
             <l>Della perdita tua non mi consola.</l>
             <l part="I">Fuggi, se m'ami; al tuo timor t'invola.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">Tu, per soverchio affetto, ove non sono</l>
             <l part="I">Ti figuri i perigli.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">E dove fondi</l>
             <l>Questa tua sicurezza?</l>
@@ -1726,7 +1751,7 @@
             <l>Sventure io ti predìco:</l>
             <l>Il merto appunto è il tuo maggior nemico.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>La sicurezza mia, Fulvia, è riposta</l>
             <l>Nel cor candido e puro,</l>
@@ -1742,43 +1767,43 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>VARO con pretoriani, e detti.</stage>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="I">Varo, che rechi?</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">E' salva</l>
             <l>Di Cesare la vita? Al suo riparo</l>
             <l>Può giovar l'opra mia?</l>
             <l part="I">Che fa?</l>
           </sp>
-          <sp>
+          <sp who="#varo">
             <speaker>VARO</speaker>
             <l part="F">Cesare appunto a te m'invia.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>A lui dunque si vada.</l>
           </sp>
-          <sp>
+          <sp who="#varo">
             <speaker>VARO</speaker>
             <l>Non vuol questo da te; vuol la tuia spada.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="I">Come!</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="M">Il previdi!</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">E qual follia lo mosse?</l>
             <l part="I">E possibil sarà?</l>
           </sp>
-          <sp>
+          <sp who="#varo">
             <speaker>VARO</speaker>
             <l part="F">Così non fosse.</l>
             <l>La tua compiango, amico,</l>
@@ -1786,7 +1811,7 @@
             <l>Un uffizio a compir contrario tanto</l>
             <l>Alla nostra amicizia, al genio antico.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>Prendi: Augusto compiangi e non l'amico. <stage>(gli dà la spada</stage></l>
             <lg>
@@ -1806,13 +1831,13 @@
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>FULVIA e  VARO</stage>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l>Varo, se amasti mai, de' nostri affetti</l>
             <l>Pietà dimostra, e d'un oppresso amico</l>
             <l part="I">Difendo l'innocenza.</l>
           </sp>
-          <sp>
+          <sp who="#varo">
             <speaker>VARO</speaker>
             <l part="F">Or che m'è noto</l>
             <l>Il vostro amor, la pena mia s'accresce,</l>
@@ -1820,7 +1845,7 @@
             <l>Ezio è di sé nemico: ei parla in guisa</l>
             <l part="I">Che irrìta Augusto.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">Il suo costume altero</l>
             <l>E' palese a ciascuno. Omai dovrebbe</l>
@@ -1828,7 +1853,7 @@
             <l>Che, se de' merti suoi così favella,</l>
             <l>Ei non è menzognero.</l>
           </sp>
-          <sp>
+          <sp who="#varo">
             <speaker>VARO</speaker>
             <l>Qualche volta è virtù tacere il vero.</l>
             <l>Se non lodo il suo fasto,</l>
@@ -1836,43 +1861,43 @@
             <l>Impiegar l'opra mia:</l>
             <l>Ma voglia il Ciel che inutile non sia.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l>Non dir così. Niega agli afflitti aita</l>
             <l part="I">Chi dubbiosa la porge.</l>
           </sp>
-          <sp>
+          <sp who="#varo">
             <speaker>VARO</speaker>
             <l part="F">Egli è sicuro,</l>
             <l>Sol che tu voglia. A Cesare ti dona,</l>
             <l>E, consorte di lui, tutto potrai.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l>Che ad altri io voglia mai,</l>
             <l>Fuor che ad Ezio, donarmi? Ah, non fia vero.</l>
           </sp>
-          <sp>
+          <sp who="#varo">
             <speaker>VARO</speaker>
             <l>Ma, Fulvia, per salvarlo, in qualche parte</l>
             <l>Ceder convien. Tu puoi l'ira d'Augusto</l>
             <l>Sola placar. Non differirlo; e in seno</l>
             <l>Se amor non hai per lui, fingilo almeno.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l>Seguirò il tuo consiglio,</l>
             <l>Ma chi sa con qual sorte! E' sempre un fallo</l>
             <l>Il simulare. Io sento</l>
             <l part="I">Che vi ripugna il core.</l>
           </sp>
-          <sp>
+          <sp who="#varo">
             <speaker>VARO</speaker>
             <l part="F">In simil caso</l>
             <l>Il fingere è permesso;</l>
             <l>E poi non è gran pena al vostro sesso.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <lg>
               <l>Quel fingere affetto,</l>
@@ -1895,7 +1920,7 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>VARO</stage>
-          <sp>
+          <sp who="#varo">
             <speaker>VARO</speaker>
             <l>Folle è colui che al tuo favor si fida,</l>
             <l>Instabile Fortuna. Ezio, felice,</l>
@@ -1924,7 +1949,7 @@
           <head>SCENA NONA</head>
           <stage>Galleria di statue e specchi, con sedili intorno, fra' quali uno innanzi a mano destra, capace di due persone. Gran balcone aperto in prospetto, dal quale vista di Roma.</stage>
           <stage>ONORIA e MASSIMO</stage>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l>Massimo, anch'io lo veggo; ogni ragione</l>
             <l>Ezio condanna. Egli è rival d'Augusto:</l>
@@ -1935,7 +1960,7 @@
             <l>Incredulo, il mio core</l>
             <l>Reo non sa figurarlo e traditore.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>Oh virtù senza pari! E' questo in vero</l>
             <l>Eccesso di clemenza. E chi dovrebbe</l>
@@ -1943,7 +1968,7 @@
             <l>Ricusa quella mano</l>
             <l>Contesa dai monarchi. Ogni altra avria...</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l>Ah, dell'ingiuria mia</l>
             <l>Non ragionarmi più. Quella mi punse</l>
@@ -1955,7 +1980,7 @@
             <l>La gloria... l'onor mio...</l>
             <l part="I">Son le cagioni...</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">Eh, lo conosco anch'io;</l>
             <l>Ma nol conosce ognun. Sai che si crede</l>
@@ -1966,7 +1991,7 @@
             <l>Una giusta vendetta:</l>
             <l>Tanta clemenza a nuovi oltraggi alletta.</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l>Le mie private offese ora non sono</l>
             <l>La maggior cura. Esaminar conviene</l>
@@ -1974,13 +1999,13 @@
             <l>Si trovi il reo. Potrebbe</l>
             <l part="I">Esser egli innocente.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">E' vero; e poi</l>
             <l>Potrebbe anche pentirsi;</l>
             <l part="I">La tua destra accettar...</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l part="F">La destra mia!</l>
             <l>Eh non tanto se stessa Onoria oblia.</l>
@@ -1988,7 +2013,7 @@
             <l>Anche signor dell'universo intero,</l>
             <l>Non mi speri ottener; ma non fia vero.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>Or ve' com'è ciascuno</l>
             <l>Facile a lusingarsi! E pure ei dice</l>
@@ -1997,7 +2022,7 @@
             <l>D'Onoria innamorata;</l>
             <l>Che, s'ei vuol, basta un guardo, e sei placata.</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l>Temerario! Ah! non voglio</l>
             <l>Che lungamente il creda. Al primo sposo,</l>
@@ -2010,7 +2035,7 @@
         <div type="scene">
           <head>SCENA DECIMA</head>
           <stage>VALENTINIANO e detti.</stage>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Onoria, non partir. Per mio riposo</l>
             <l>Tu devi ad uno sposo,</l>
@@ -2020,12 +2045,12 @@
             <l>E al pacifico invito</l>
             <l part="I">Acconsentir conviene.</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l part="F">(Ezio è pentito).</l>
             <l part="I">M'è noto il nome suo?</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Pur troppo. Ho pena,</l>
             <l>Germana, in profferirlo. Io dal tuo labbro</l>
@@ -2036,31 +2061,31 @@
             <l>Rammentando i perigli,</l>
             <l>E' forza che a tal nodo io ti consigli.</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l>(Rifiutarlo or dovrei; ma...) Senti. Al fine,</l>
             <l>Se giova alla tua pace,</l>
             <l>Disponi del mio cor come a te piace.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>Signore, il tuo disegno</l>
             <l>Io non intendo. Ezio t'insidia, e pensi</l>
             <l>Solamente a premiarlo?</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Ad Ezio io non pensai: d'Attila io parlo.</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l part="I">(Oh inganno!) Attila!</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">E come?</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Un messaggier di lui</l>
             <l>Me ne recò pur ora</l>
@@ -2072,16 +2097,16 @@
             <l>Dal tuo nobile amore,</l>
             <l>La barbarie cangiar tutta in valore.</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l part="I">Ezio sa la richiesta?</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">E che! Degg'io</l>
             <l>Consigliarmi con lui? Questo a che giova?</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l>Giova per evvilirlo e perché meno</l>
             <l>Necessario si creda:</l>
@@ -2089,13 +2114,13 @@
             <l>Che al popolo romano</l>
             <l>Utile più d'ogni altra è questa mano.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Egli il saprà; ma intanto</l>
             <l>Posso del tuo consenso</l>
             <l part="I">Attila assicurar?</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l part="F">No. prima io voglio</l>
             <l>Vederti salvo. Il traditor si cerchi,</l>
@@ -2118,14 +2143,14 @@
         <div type="scene">
           <head>SCENA UNDICESIMA</head>
           <stage>VALENTINIANO e MASSIMO</stage>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Olà qui si conduca</l>
             <l>Il prigionier. <stage>(esce una comparsa, la quale, ricevuto l'ordine, parte</stage> Ne' miei timori io cerco</l>
             <l>Da te consiglio. Assicurarmi in parte</l>
             <l part="I">Potrà Attila il nodo?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">Anzi ti espone</l>
             <l>A periglio maggior. Cerca il nemico</l>
@@ -2138,7 +2163,7 @@
             <l>Condurlo prigioniero;</l>
             <l part="I">Ma non volle, e potea.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Pur troppo è vero.</l>
           </sp>
@@ -2146,29 +2171,29 @@
         <div type="scene">
           <head>SCENA DODICESIMA</head>
           <stage>FULVIA e detti.</stage>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l>Augusto, ah, rassicura</l>
             <l>I miei timori! E' il traditor palese?</l>
             <l part="I">E' in salvo la tua vita?</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">E Fulvia ha tanta</l>
             <l part="I">Cura di me?</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">Puoi dubitrne? Adoro</l>
             <l>In Cesare un amante, a cui fra poco</l>
             <l>Con soave catena</l>
             <l>Annodarmi dovrò. (So dirlo appena).</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="I">(Simula, o dice il ver?)</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F"> Se il mio periglio</l>
             <l>Amorosa pietà ti desta in seno,</l>
@@ -2176,24 +2201,24 @@
             <l>Ma potrà lusingarmi</l>
             <l part="I">Della tua fedeltà?</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">Perfin ch'io viva,</l>
             <l>De' miei teneri affetti avrai l'impero.</l>
             <l part="I">(Ezio, perdona).</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">(Io non comprendo il vero).</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Ah! se d'Ezio non era</l>
             <l>La fellonia, saresti già mia sposa.</l>
             <l>Ma cara alla sua vita</l>
             <l part="I">Costerà la tardanza.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">Il gran delitto</l>
             <l>Dovresti vendicar. Ma chi dall'ira</l>
@@ -2201,77 +2226,77 @@
             <l>Assicurar ci può? Pensaci, Augusto.</l>
             <l>Per te dubbia mi rendo.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="I">Questo sol mi trattiene.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">(Or Fulvia intendo).</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l>E se fosse innocente? Eccoti privo</l>
             <l>D'un gran sostegno; eccoti esposto ai colpi</l>
             <l>D'ignoto traditore;</l>
             <l>Eccoti in odio... Ah, mi si agghiaccia il core!</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Volesse il Ciel che reo non fosse! Ei viene</l>
             <l part="I">Qui per mio cenno.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="M">(Ah! che farò?)</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Vedrai</l>
             <l part="I">Ne' suoi detti qual è.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">Lascia ch'io parta.</l>
             <l>Col suo giudice solo</l>
             <l part="I">Meglio il reo parlerà.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="M">No, resta.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F"><stage>(vedendo venire Ezio)</stage> Augusto,</l>
             <l part="I">Ezio qui giunge.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">(Oh Dio!)</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>T'assidi al fianco mio. <stage>(a Fulvia</stage></l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l>Come! Suddita io sono, e tu vorrai...</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Suddita non è mai</l>
             <l part="I">Chi ha vassallo il monarca.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">Ah! non conviene...</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Non più: comincia ad avvezzarti al trono.</l>
             <l part="I">Siedi.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">Ubbidisco. (In qual cimento io sono!)<stage>(siede alla destra di Valentiniano</stage></l>
           </sp>
@@ -2279,39 +2304,39 @@
         <div type="scene">
           <head>SCENA TREDICESIMA</head>
           <stage>EZIO disarmato e detti.</stage>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l><stage>(nell'uscire, vedendo Fulvia, si ferma</stage> (Stelle, che miro! In Fulvia</l>
             <l>Come tanta incostanza!)</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="I">(Resisti, anima mia).</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Duce, t'avanza.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>Il giudice qual è? Pende il mio fato</l>
             <l part="I">Da Cesare o da Fulvia?</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">E Fulvia ed io</l>
             <l>Siamo un giudice solo. Ella è sovrana,</l>
             <l>Or che in lacci di sposo a lei mi stringo.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="I">(Donna infedel!)</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">(Potessi dir che fingo!)</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Ezio, m'ascolta, e a moderare impara,</l>
             <l>Per poco almeno, il naturale orgoglio,</l>
@@ -2325,11 +2350,11 @@
             <l>Di cui tu sai che testimonio io sono.</l>
             <l>Pensa a scolparti o a meritar perdono.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="I">(Sorte, non mi tradir!)</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">Cesare, in vero</l>
             <l>Ingegnoso è il pretesto. Ove s'asconde</l>
@@ -2338,15 +2363,15 @@
             <l>Del figurato eccesso,</l>
             <l>Giudice e testimonio a un tempo istesso.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="I">(Oh Dio! si perde).</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">(E soffrirò l'altero?)</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>Ma il delitto sia vero:</l>
             <l>Perché si appone a me? Perché d'Onoria</l>
@@ -2364,27 +2389,27 @@
             <l>Qual io mi sia, perché di me ragiono.</l>
             <l>L'alme vili a se stesse ignote sono.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="I">(Partir potessi).</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Un nuovo fallo è questa</l>
             <l>Temeraria difesa. Altro t'avanza</l>
             <l part="I">Per tua discolpa ancor?</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">Dissi abbastanza.</l>
             <l>Cesare, non curarti</l>
             <l>Tutto il resto ascoltar, ch'io dir potrei.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="I">Che diresti?</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">Direi</l>
             <l>Che produce un tiranno</l>
@@ -2396,44 +2421,44 @@
             <l>Che sai di meritar, quando mi privi</l>
             <l part="I">D'un cor...</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Superbo, a questo eccesso arrivi?</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="I">(Aimè!)</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="M">Punir saprò...</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">Soffri, se m'ami,</l>
             <l>Che Fulvia parta. I vostri sdegni irrìta</l>
             <l part="I">L'aspetto mio. <stage>(s'alza</stage></l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">No, non partir. Tu scorgi</l>
             <l>Che mi sdegno a ragion. Siedi, e vedrai</l>
             <l>Come un reo pertinace</l>
             <l>A convincer m'accingo.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="I">(Donna infedel!)</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F"><stage>(torna a sedere)</stage> (Potessi dir che fingo!)</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="I">(Tutto fin or mi giova).</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Ezio, tu sei</l>
             <l>D'ogni colpa innocente. Invidio Augusto</l>
@@ -2443,110 +2468,110 @@
             <l>Contrastando la sposa,</l>
             <l part="I">Il suddito è ribelle?</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">E al suo vassallo,</l>
             <l>Che il prevenne in amor, quando la tolga,</l>
             <l part="I">Il sovrano è tiranno?</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">A quel che dici,</l>
             <l part="I">Dunque Fulvia t'amò?</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="M">(Che pena!)</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">A lui</l>
             <l>Togli, o cara, un inganno, e di' s'io fui</l>
             <l>Il tuo foco primiero</l>
             <l part="I">Se l'ultimo sarò: spiegalo.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F"><stage>(a Valentiniano)</stage> E' vero.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>Ah perfida, ah spergiura! A questo colpo</l>
             <l>Manca la mia costanza.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Vedi se t'ingannò la tua speranza. <stage>(ad Ezio</stage></l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>Non trionfar di me. Troppo ti fidi</l>
             <l>D'una donna incostante. A lei la cura</l>
             <l>Lascio di vendicarmi. Io mi lusingo</l>
             <l part="I">Che 'l proverai.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">(Né posso dir che fingo!)</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="I">(E Fulvia non si perde!)</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">In questo stato</l>
             <l>Non conosco me stesso. In faccia a lei</l>
             <l>Mi si divide il cor. Pena maggiore,</l>
             <l>Massimo, da che nacqui, io non provai.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l>(Io mi sento morir). <stage>(s'alza piangendo e vuol partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Fulvia, che fai?</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l>Voglio partir, ché a tanti ingiusti oltraggi</l>
             <l part="I">Più non resisto.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Anzi t'arresta, e siegui</l>
             <l part="I">A punirlo così.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">No, te ne priego:</l>
             <l part="I">ascia ch'io vada.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Io nol consento. Afferma</l>
             <l>Per mio piacer di nuovo</l>
             <l>Che sospiri per me, ch'io ti son caro,</l>
             <l>Che godi alle sue pene...</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l>Ma se vero non è; s'egli è il mio bene!</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="I">Che dici?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="M">(Aimè!)</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="M">Respiro.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">E sino a quando</l>
             <l>Dissimular dovrò? Finsi fin ora,</l>
@@ -2557,27 +2582,27 @@
             <l>Ch'io t'amo a te diranno,</l>
             <l>Non mi credere, Augusto; allor t'inganno.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="I">Oh cari accenti!</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Ove son io! Che ascolto!</l>
             <l>Qual ardir, qual baldanza!</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>Vedi se t'ingannò la tua speranza. <stage>(a Valentiano</stage></l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Ah temerario! ah ingrata! Olà, custodi,</l>
             <l>Toglietemi d'avanti</l>
             <l>Quel traditor. Nel carcere più orrendo</l>
             <l>Serbatelo al mio sdegno.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>Il tuo furor del mio trionfo è segno.</l>
             <l>Chi più di me felice? Io cederei</l>
@@ -2603,47 +2628,47 @@
         <div type="scene">
           <head>SCENA QUATTORDICESIMA</head>
           <stage>VALENTINIANO, MASSIMO e FULVIA</stage>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Ingratissima donna, e quando mai</l>
             <l>Io da te meritai questa mercede?</l>
             <l>Vedi, amico, qual fede</l>
             <l part="I">La tua figlia mi serba?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">Indegna! e dove</l>
             <l>Imparasti a tradir? Così del padre</l>
             <l>La fedeltade imìti? E quando avesti</l>
             <l part="I">Questi esempi da me?</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">Lasciami in pace,</l>
             <l>Padre; non irritarmi: è sciolto il freno.</l>
             <l part="I">Se m'insulti dirò...</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">Taci, o il tuo sangue...</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Massimo, ferma. Io meglio</l>
             <l>Vendicarmi saprò. Giacché m'aborre,</l>
             <l>Giacché le sono odioso,</l>
             <l>Voglio per tomentarla esserle sposo.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="I">Non lo sperar.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">Ch'io non lo speri? Infida,</l>
             <l part="I">Non sai quanto potrò...</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">Potrai svenarmi;</l>
             <l>Ma per farmi temer debole or sei.</l>
@@ -2665,30 +2690,30 @@
         <div type="scene">
           <head>SCENA QUINDICESIMA</head>
           <stage>VALENTINIANO e MASSIMO</stage>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>(Or giova il simular). No, non sia vero</l>
             <l>Che per vergogna mia viva costei.</l>
             <l>Cesare, io corro a lei:</l>
             <l part="I">Voglio passarle il cor.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">T'arresta, amico.</l>
             <l>S'ella muore, io non vivo. Ancor potrebbe</l>
             <l part="I">Quell'ingrata pentirsi.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">Al tuo comando</l>
             <l>Con pena ubbidirò. Troppo a punirla</l>
             <l>Il dover mi consiglia.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Perché simile a te non è la figlia?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <lg>
               <l>Col volto ripieno</l>
@@ -2707,7 +2732,7 @@
         <div type="scene">
           <head>SCENA SEDICESIMA</head>
           <stage>VALENTINIANO</stage>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Sdegno, amor, gelosia, cure d'impero</l>
             <l>Che volete da me? Nemico e amante,</l>
@@ -2740,7 +2765,7 @@
           <head>SCENA PRIMA</head>
           <stage>Atrio delle carceri con cancelli di ferro in prospetto, che conducono a diverse prigioni. Guardie a vista su la porta de' detti cancelli.</stage>
           <stage>ONORIA, indi EZIO con catene.</stage>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l>Ezio qui venga. E' questa gemma il segno <stage>(alle guardie</stage></l>
             <l>Del cesareo voler. Il suo periglio</l>
@@ -2754,7 +2779,7 @@
             <l>O quell'alma è innocente, o non è vero</l>
             <l>Che immagine dell'alma è la sembianza. <stage>(esce Ezio da uno de' cancelli, presso de' quali restano le guardie</stage></l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>Questi del tuo germano <stage>(mostrando le catene</stage></l>
             <l>Son, principessa, i doni. Avresti mai</l>
@@ -2764,7 +2789,7 @@
             <l>E poi co' lacci intorno</l>
             <l>Tu mi rivedi all'apparir del giorno.</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l>Ezio, qualunque nasce alle vicende</l>
             <l>Della sorte è soggetto. Il primo esempio</l>
@@ -2774,11 +2799,11 @@
             <l>Cesare l'ira sua tutta abbandona:</l>
             <l>T'ama, ti vuole amico, e ti perdona.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="I">E il crederò?</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l part="F">Sì. Né domanda Augusto</l>
             <l>Altra emenda da te che il suo riposo.</l>
@@ -2786,7 +2811,7 @@
             <l>Scopri la trama, e appieno</l>
             <l>Libero sei. Può domandar di meno?</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>Non è poca richiesta. Ei vuol ch'io stesso</l>
             <l>M'accusi per timore. Ei vuole a prezzo</l>
@@ -2795,7 +2820,7 @@
             <l>Prova rossor nell'oltraggiarmi a torto;</l>
             <l>Perciò mi vuole o delinquente o morto.</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l>Dunque con tanto fasto</l>
             <l>Lo sdegno tuo giustificar non déi;</l>
@@ -2804,28 +2829,28 @@
             <l>Che non possa incolparti,</l>
             <l>Che non abbia coraggio a condannarti.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>Onoria, per salvarmi</l>
             <l>Ad esser vile io non appresi ancora.</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l part="I">Ma sai che corri a morte?</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">E ben, si mora!</l>
             <l>Non è il peggior de' mali</l>
             <l>Al fin questo morir; ci toglie almeno</l>
             <l part="I">Dal commercio de' rei.</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l part="F">Pensar dovresti</l>
             <l>Che per la patria tua poco vivesti.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>Il viver si misura</l>
             <l>Dall'opre e non dai giorni. Onoria, i vili,</l>
@@ -2836,16 +2861,16 @@
             <l>Per l'orme ch'io segnai,</l>
             <l>Vivendo pochi dì, vissero assai.</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l>Se di te non hai cura,</l>
             <l part="I">Abbila almen di me.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="M">Che dici?</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l part="F">Io t'amo:</l>
             <l>Più tacerlo nol so. Quando mi veggo</l>
@@ -2853,7 +2878,7 @@
             <l>Ed è poca difesa</l>
             <l>Alla mia debolezza il fasto mio.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>Onoria, e tu sei quella</l>
             <l>Che umiltà mi consigli? In questa guisa</l>
@@ -2862,7 +2887,7 @@
             <l>Deh, consenti ch'io mora. Ezio piagato</l>
             <l>Per altro stral ti viverebbe ingrato.</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l>Viva ingrato, mi renda</l>
             <l>D'ogni speranza priva,</l>
@@ -2874,7 +2899,7 @@
             <l>Mori vincendo; onde t'invìdi il mondo,</l>
             <l part="I">Non ti compianga.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">O in carcere o fra l'armi,</l>
             <l>Ad altri insegnerò come si mora.</l>
@@ -2896,56 +2921,56 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>ONORIA, poi VALENTINIANO</stage>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l>Oh Dio, chi 'l crederebbe! Al fato estremo</l>
             <l>Egli lieto s'appressa; io gelo e tremo.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>E ben, da quel superbo</l>
             <l part="I">Che ottenesti, o germana?</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l part="F">Io nulla ottenni</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Già lo predissi. Eh si punisca. Omai</l>
             <l part="I">E' viltade il riguardo.</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l part="F">E pur non posso</l>
             <l>Crederlo reo. D'alma innocente è segno</l>
             <l part="I">Quella sua sicurezza.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Anzi è una prova</l>
             <l>Del suo delitto. Il traditor si fida</l>
             <l>Nell'aura popolar. Vuo' che s'uccida.</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l>Meglio ci pensa. Ezio è peggior nemico</l>
             <l part="I">Forse estinto che vivo.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">E che far deggio?</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l>Cerca vie di placarlo: il suo segreto</l>
             <l>Sveller da lui senza rigor procura.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="I">E qual via non tentai?</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l part="F">La più sicura.</l>
             <l>Ezio, per quel ch'io vedo,</l>
@@ -2953,55 +2978,55 @@
             <l>Assalirlo conviene. Ei Fulvia adora:</l>
             <l>Offrila all'amor suo; cedila ancora.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Quanto è facile, Onoria,</l>
             <l>A consigliare altrui fuor del periglio!</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l>Signor, nel mio consiglio io ti propongo</l>
             <l>Un esempio a seguir. Sappi che amante</l>
             <l>Io sono al par di te, né perdo meno:</l>
             <l>Fulvia è la fiamma tua; per Ezio io peno.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="I">E l'ami?</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l part="F">Sì. Nel consigliarti or vedi</l>
             <l>Se facile son io, come tu credi.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Ma troppo ad eseguir duro consiglio</l>
             <l part="I">Mi proponi, o germana.</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l part="F">Il tuo coraggio,</l>
             <l>La tua  virtù faccia arrossir la sorte.</l>
             <l>Una donna t'insegna ad esser forte.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="I">Oh Dio!</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l part="F">Vinci te stesso. I tuoi vassalli</l>
             <l>Apprendano qual sia</l>
             <l part="I">D'Augusto il cor...</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Non più: Fulvia m'invia:</l>
             <l>Facciasi questo ancor. Se tu sapessi</l>
             <l>Che sforzo è il mio, quanto il cimento è duro...</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l>Dalla mia pena il tuo dolor misuro:</l>
             <l>Ma soffrilo. Nel duolo</l>
@@ -3023,18 +3048,18 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>VALENTINIANO, indi VARO</stage>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Olà! Varo si chiami. <stage>(una comparsa esce, e parte per eseguire il comando)</stage> A questo eccesso</l>
             <l>Della clemenza mia se il reo non cede,</l>
             <l>Un momento di vita</l>
             <l part="I">Più lasciargli non vuo'.</l>
           </sp>
-          <sp>
+          <sp who="#varo">
             <speaker>VARO</speaker>
             <l part="M">Cesare.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Ascolta.</l>
             <l>Disponi i tuoi più fidi</l>
@@ -3043,31 +3068,31 @@
             <l>Ezio non è, s'io non gli son di guida,</l>
             <l>Quando uscir lo vedrai, fa che s'uccida.</l>
           </sp>
-          <sp>
+          <sp who="#varo">
             <speaker>VARO</speaker>
             <l>Ubbidirò. ma sai</l>
             <l>Qual tumulto destò d'Ezio l'arresto?</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Tutto m'è noto. A questo</l>
             <l part="I">Già Massimo provvede.</l>
           </sp>
-          <sp>
+          <sp who="#varo">
             <speaker>VARO</speaker>
             <l part="F">E' ver, ma temo...</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Eh! taci: adempi il cenno, e fa che il colpo</l>
             <l>Cautamente succeda.</l>
             <l part="I">Udisti?</l>
           </sp>
-          <sp>
+          <sp who="#varo">
             <speaker>VARO</speaker>
             <l part="M">Intesi. <stage>(parte</stage></l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Il prigionier qui rieda. <stage>(alle guardie de' cancelli</stage></l>
             <l>Tacete, o sdegni miei: l'odio sepolto</l>
@@ -3090,24 +3115,24 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>MASSIMO e detto.</stage>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>Signor, tutto sedai. D'Ezio la morte</l>
             <l>A tuo piacer affretta:</l>
             <l>Roma t'applaude; ogni fedel l'aspetta.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Ma che vuoi? Mi si dice</l>
             <l>Che un barbaro, che un empio,</l>
             <l>Che un incautto son io. Gli esempi altrui</l>
             <l>Seguitar mi conviene.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="I">Come! Perché?</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">T'accheta: Ezio già viene.</l>
           </sp>
@@ -3115,43 +3140,43 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>EZIO incatenato esce dai cancelli, e detti.</stage>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="I">(Chi mai lo consigliò!)</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">Dal carcer mio</l>
             <l>Richiamato, io credei</l>
             <l>D'incamminarmi ad un supplizio ingiusto:</l>
             <l>Ma ne incontro uno peggior; rivedo Augusto.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>(Che audace!) Ezio, fra noi</l>
             <l>Più d'odio non si parli. Io vengo amico:</l>
             <l>Il mio rigor detesto;</l>
             <l part="I">E voglio...</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">Io so che vuoi: m'è noto il resto.</l>
             <l>Onoria ti prevenne; il tutto intesi.</l>
             <l>S'altro a dirmi non hai,</l>
             <l>Torno alla mia prigion; seco parlai.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Non potea dirti Onoria</l>
             <l part="I">Quanto offrirti vogl'io.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">Lo so; mel disse:</l>
             <l>Che la mia libertà, che il primo affetto,</l>
             <l>Che l'amistà d'Augusto i doni sono.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="I">Ma non disse il maggior.</l>
           </sp>
@@ -3159,35 +3184,35 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>FULVIA, e detti.</stage>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F"><stage>(accennando Fulvia)</stage> Vedi qual dono.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="I">Fulvia!</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">(Che mai sarà! L'alma s'agghiaccia).</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="I">Da Fulvia che si vuol?</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Che ascolti e taccia.</l>
             <l><stage>(ad Ezio)</stage>Ti sorprende l'offerta. Ella è sì grande,</l>
             <l>Che crederla non sai, ma temi in vano:</l>
             <l>La promisi: l'affermo; ecco la mano.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>A qual prezzo però mi si concede</l>
             <l part="I">D'esserne possessor?</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Poco si chiede.</l>
             <l>Tu sei reo per amor: chi visse amante</l>
@@ -3196,65 +3221,65 @@
             <l>Svelami, te ne priego, acciò non viva</l>
             <l>Cesare più co' suoi timori intorno.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>Addio, mia vita: alla prigione io torno. <stage>(a Fulvia</stage></l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="I">(E il soffro?)</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="M">(Aimè!)</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F"><stage>(ad Ezio)</stage> Senti. E lasciar tu vuoi,</l>
             <l>Ostinato a tacer, Fulvia, che tanto</l>
             <l>Fedel ti corrisponde?</l>
             <l>Parla. (Né meno il traditor risponde).</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="I">(Quanti perigli!)</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Ezio, m'ascolti? Intendi</l>
             <l>Che parlo a te? Son tali i detti miei,</l>
             <l>Che un reo, come tu sei, debba sprezzarli?</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l>Quando parli così, meco non parli.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="I">(Eh! si risolva). Olà, custodi!</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">Ah! prima</l>
             <l>Lo sdegno tuo contro di me si volga. <stage>(a Valentiniano</stage></l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>Né puoi tacere? <stage>(a Fulvia)</stage> Il prigionier si sciolga. <stage>(si tolgono le catene ad Ezio</stage></l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="I">Come!</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="M">(Che veggio!)</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="M">(Oh stelle!)</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Al fin conosco</l>
             <l>Che innocente tu sei. Tanta costanza</l>
@@ -3264,11 +3289,11 @@
             <l>Le ingiuste offese de' sospetti miei.</l>
             <l>Vanne; Fulvia è già tua; libero sei.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="I">(Feliceme!)</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">La prima volta è questa</l>
             <l>Ch'io mi confondo, e con ragion. Chi mai</l>
@@ -3276,7 +3301,7 @@
             <l>Generoso sperò! La tua diletta</l>
             <l part="I">Mi cedi, e non rammenti!...</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Omai t'affretta.</l>
             <l>Impaziente attende</l>
@@ -3285,16 +3310,16 @@
             <l>A' reciprochi segni</l>
             <l part="I">D'affetto, d'amistà.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">Del fasto mio</l>
             <l>Or, Cesare, arrossisco; e tanto dono...</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Ezio, va pur: conoscerai qual sono.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <lg>
               <l>Se la mia vita</l>
@@ -3317,15 +3342,15 @@
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>VALENTINIANO, FULVIA e MASSIMO</stage>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="I">(Va pur, te n'avvedrai).</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">(Perdo ogni speme).</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l>Generoso monarca, il Ciel ti renda</l>
             <l>Quella felicità che rendi a noi.</l>
@@ -3333,26 +3358,26 @@
             <l>Sempre rammenterò. Lascia che intanto</l>
             <l>Su quell'augusta mano un bacio imprima.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>No, Fulvia: attendi prima</l>
             <l>Che sia compìto il dono: ancor non sai</l>
             <l>Quanto ogni voto avanza,</l>
             <l>Quanto il dono è maggior di tua speranza.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>Cesare, che facesti? Ah, questa volta</l>
             <l part="I">T'ingannò la pietade.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">E pur vedrai</l>
             <l>Che giova la pietà, ch'io non errai.</l>
             <l>Ogni cura, ogni tema</l>
             <l part="I">Terminata sarà.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">Qual pace acquisti,</l>
             <l part="I">Se torna in libertà?</l>
@@ -3361,55 +3386,55 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>VARO e detti.</stage>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Varo, eseguisti?</l>
           </sp>
-          <sp>
+          <sp who="#varo">
             <speaker>VARO</speaker>
             <l>Eseguito è il tuo cenno:</l>
             <l part="I">Ezio morì.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="M">Come! che dici?</l>
           </sp>
-          <sp>
+          <sp who="#varo">
             <speaker>VARO</speaker>
             <l part="F"><stage>(a Valentiniano)</stage> Al varco</l>
             <l>L'attesero i miei fidi: ei venne; e prima</l>
             <l>Che potesse temerne, il sen trafitto</l>
             <l>Si vide; sospirò, cadde fra loro.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="I">(Oh sorte inaspettata!)</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">Oh Dio! mi moro. <stage>(si appoggia ad una scena, coprendosi il volto</stage></l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Corri; l'esangue spoglia</l>
             <l>Nascondi ad ogni sguardo: ignota resti</l>
             <l>D'Ezio la morte ad ogni suo seguace.</l>
           </sp>
-          <sp>
+          <sp who="#varo">
             <speaker>VARO</speaker>
             <l part="I">Sarà legge il tuo cenno. <stage>(parte</stage></l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">E Fulvia tace?</l>
             <l>Or è tempo che parli. E perché mai</l>
             <l>Generoso monarca or non mi dice?</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l>Ah, tiranno! Io vorrei... Sposo infelice! <stage>(come sopra</stage></l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>Un primo sfogo al tuo dolore ingiusto</l>
             <l part="I">Lascia, o signor.</l>
@@ -3418,76 +3443,76 @@
         <div type="scene">
           <head>SCENA NONA</head>
           <stage>ONORIA e detti.</stage>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l part="F">Liete novelle, Augusto.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Che reca Onoria? Il volto suo ridente</l>
             <l part="I">Felicità promette.</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l part="F">Ezio è innocente.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="I">Come?</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l part="F">Emilio parlò. L'empio ministro</l>
             <l>Nelle mie stanze io ritrovai celato,</l>
             <l part="I">Già vicino a morir.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">(Son disperato).</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="I">Nelle tue stanze?</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l part="F">Sì. Da te ferito,</l>
             <l>La scorsa notte ivi s'ascose. Intesi</l>
             <l>Dal labbro suo ch'Ezio è innocente. Augusto,</l>
             <l part="I">Non mentisce chi more.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">E l'alma rea,</l>
             <l>Che gli commise il colpo,</l>
             <l part="I">Almen ti palesò?</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l part="F">Mi disse: E' quella</l>
             <l>Che a Cesare è più cara, e che da lui</l>
             <l part="I">Fu oltraggiata in amor.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="M">Ma il nome?</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l part="F">Emilio</l>
             <l>A dirlo si accingea, tutta su i labbri</l>
             <l>L'anima fuggitiva egli raccolse;</l>
             <l>Ma l'estremo sospiro il nome involse.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="I">Oh sventura!</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="M">(Oh periglio!)</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F"><stage>(a Valentiniano)</stage> Or di', tiranno,</l>
             <l>S'era infido il mio sposo,</l>
@@ -3495,12 +3520,12 @@
             <l>Che tu il pianga innocente? Or chi la vita,</l>
             <l part="I">Empio! gli renderà?</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l part="F">Fulvia, che dici?</l>
             <l part="I">Ezio morì?</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">Sì principessa. Ah! fuggi</l>
             <l>Dal barbaro germano: egli è una fiera</l>
@@ -3510,11 +3535,11 @@
             <l>Della sua crudeltà, gloria non cura:</l>
             <l>Pur la tua vita, Onoria, è mal sicura.</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l part="I">Ah, inumano! E potesti...</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Onoria, oh Dio!</l>
             <l>Non insultarmi: io lo conosco, errai;</l>
@@ -3523,39 +3548,39 @@
             <l>Son questi i miei più cari: in qual di loro</l>
             <l>Cercherò il traditor, s'io non gli offesi?</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l>Chi mai non offendesti? Il tuo pensiero</l>
             <l>Il passato raccolga, e non si scordi</l>
             <l>Di Massimo la sposa, i folli amori,</l>
             <l part="I">L'insidiata onestà.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">(Come salvarmi!)</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>E dovrò figurarmi</l>
             <l>Che i benefìci miei meno ei rammenti</l>
             <l part="I">Che un giovanil trasporto?</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l part="F">E ancor non sai</l>
             <l>Che l'offensore oblia,</l>
             <l>Ma non l'offeso, i ricevuti oltraggi?</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="I">(Ecco il padre in periglio.)</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Ah! che pur troppo</l>
             <l part="I">Tu taci il ver; ma che farò?</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l part="F">Consigli</l>
             <l>Or pretendi da me? Se fosti solo</l>
@@ -3566,12 +3591,12 @@
         <div type="scene">
           <head>SCENA DECIMA</head>
           <stage>VALENTINIANO, MASSIMO e FULVIA</stage>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>Cesare, alla mia fede</l>
             <l>Troppo ingrato tu sei, se ne sospetti.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Ah! che d'Onoria ai detti</l>
             <l>Dal mio sonno io mi desto:</l>
@@ -3579,17 +3604,17 @@
             <l>Fin che il reo non si trova,</l>
             <l part="I">Il reo ti crederò.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">Perché? Qual fallo?</l>
             <l>Sol perché Onoria il dice?</l>
             <l part="I">Che ingiustizia è la tua!</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">(Padre infelice!)</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Giusto è il timor. Disse morendo Emilio</l>
             <l>Che il traditor m'è caro,</l>
@@ -3598,17 +3623,17 @@
             <l>Pensa a provarlo: assicurarmi intanto</l>
             <l part="I">Di te vogl'io.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="M">(M'assista il Ciel!)</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Qual altro</l>
             <l>Insidiar mi potea?</l>
             <l part="I">Olà!</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">Barbaro, ascolta: io son la rea.</l>
             <l>Io commisi ad Emilio</l>
@@ -3624,34 +3649,34 @@
             <l>Da un cor tiranno e da una destra imbelle.</l>
             <l>Oh sognate speranze! oh avverse stelle!</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="I">(Ingegnosa pietade!)</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">Io mi confondo.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l>(Il genitor si salvi, e pèra il mondo).</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Tradimento sì reo pensar potesti?</l>
             <l part="I">Eseguirlo, vantarlo?</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">Ezio innocente</l>
             <l>Morì per colpa mia: non vuo' che mora</l>
             <l>Innocente, per Fulvia, il padre ancora.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="I">Massimo è fido almeno.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">Adesso, Augusto,</l>
             <l>Colpevole son io. Se quell'indegna</l>
@@ -3663,7 +3688,7 @@
             <l>Che per la prole in ogni petto eccede,</l>
             <l>Del padre un dì contaminar la fede.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>A suo piacer la sorte</l>
             <l>Di me disponga: io m'abbandono a lei.</l>
@@ -3691,7 +3716,7 @@
         <div type="scene">
           <head>SCENA UNDICESIMA</head>
           <stage>MASSIMO e FULVIA</stage>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>Partì una volta. Io per te vivo, o figlia,</l>
             <l>Io respiro per te. Con quanta forza</l>
@@ -3699,15 +3724,15 @@
             <l>Mia speme, mio sostegno,</l>
             <l>Cara difesa mia, che al fin t'abbracci. <stage>(vuole abbracciar Fulvia</stage></l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="I">Vanne, padre crudel</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">Perché mi scacci?</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l>Tutte le mie sventure</l>
             <l>Io riconosco in te. Basta ch'io seppi,</l>
@@ -3716,14 +3741,14 @@
             <l>Quanto per te perdei,</l>
             <l>Qual son io per tua colpa, e qual tu sei.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>E contrastar pretendi</l>
             <l>Al grato genitor questo d'affetto</l>
             <l>Testimonio verace?</l>
             <l part="I">Vieni... <stage>(vuole abbracciarla</stage></l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">Ma per pietà lasciami in pace.</l>
             <l>Se grato esser mi vuoi, stringi quel ferro:</l>
@@ -3731,7 +3756,7 @@
             <l>Col pianto in su le ciglia</l>
             <l>Al padre, che salvò, chiede una figlia.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <lg>
               <l>Tergi le ingiuste lagrime,</l>
@@ -3787,7 +3812,7 @@
           <head>SCENA TREDICESIMA</head>
           <stage>Campidoglio antico, con popolo.</stage>
           <stage>MASSIMO senza manto, con séguito; poi VARO</stage>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>Inorridisci, o Roma:</l>
             <l>D'Attila lo spavento, il duce invitto,</l>
@@ -3802,19 +3827,19 @@
             <l>Dai vicini perigli</l>
             <l>L'onor, la vita, le consorti e i figli. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#varo">
             <speaker>VARO</speaker>
             <l>Massimo, ferma: e qual desio ribelle,</l>
             <l>Qual furor ti consiglia?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l>Varo, t'accheta, o al mio pensier t'appiglia.</l>
             <l>Chi vuol salva la patria</l>
             <l>Stringa il ferro e mi segua. <stage>(tutti snudan la spada</stage> <stage>(accennando il Campidoglio)</stage> Ecco il sentiero,</l>
             <l>Onde avrà libertà Roma e l'impero. <stage>(parte, seguìto da tutti, verso il Campidoglio</stage></l>
           </sp>
-          <sp>
+          <sp who="#varo">
             <speaker>VARO</speaker>
             <l>Che indegno! Egli la morte</l>
             <l>D'un innocente affretta,</l>
@@ -3840,46 +3865,46 @@
         <div type="scene">
           <head>SCENA QUATTORDICESIMA</head>
           <stage>Si vedono scendere dal Campidoglio, combattendo, le guardie imperiali coi sollevati. Siegue zuffa, la quale terminata, esce VALENTINIANO senza manto, con ispada rotta, difendendosi da due congiurati; e poi MASSIMO colla spada alla mano, indi FULVIA</stage>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Ah, traditori! Amico, <stage>(a Massimo</stage></l>
             <l part="I">Soccorri il tuo signor.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">Fermate! Io voglio</l>
             <l part="I">Il tiranno svenar.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F"><stage>(si frappone)</stage> Padre, che fai?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="I">Punisco un empio.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="F">E' questa</l>
             <l part="I">Di Massimo la fede?</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="F">Assai fin ora</l>
             <l>Finsi con te. Se il mio comando Emilio</l>
             <l>Mal eseguì, per questa man cadrai.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="I">Ah, iniquo!</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="F">Al sen d'Augusto</l>
             <l>Non passerà quel ferro,</l>
             <l>Se me di vita il genitor non priva.</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="I">Cesare morirà.</l>
           </sp>
@@ -3887,55 +3912,55 @@
         <div type="scene">
           <head>SCENA ULTIMA</head>
           <stage>EZIO e VARO con ispade nude, popolo e soldati; indi ONORIA e detti.</stage>
-          <sp>
+          <sp who="#ezio #varo">
             <speaker>EZIO e VARO</speaker>
             <l part="F">Cesare viva.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="I">Ezio!</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="M">Che veggo!</l>
           </sp>
-          <sp>
+          <sp who="#massimo">
             <speaker>MASS.</speaker>
             <l part="M">Oh sorte! <stage>(getta la spada</stage></l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l part="F">E' salvo Augusto?</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="I">Vedi chi mi salvò! <stage>(accenna Ezio</stage></l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l part="F"><stage>(ad Ezio)</stage> Duce, qual nume</l>
             <l part="I">Ebbe cura di te?</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">Di Varo amico</l>
             <l part="I">Il zelo e la pietà.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l part="M">Come?</l>
           </sp>
-          <sp>
+          <sp who="#varo">
             <speaker>VARO</speaker>
             <l part="F">Eseguita</l>
             <l>Finsi di lui la morte: io t'ingannai;</l>
             <l>Ma in Ezio il tuo liberator serbai.</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="I">Provvida infedeltà!</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">Permette il Cielo</l>
             <l>Che tu debba i tuoi giorni,</l>
@@ -3945,7 +3970,7 @@
             <l>Per me qualche dubbiezza in mente accolta,</l>
             <l>Eccomi prigioniero un'altra volta.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>Anima grande, eguale</l>
             <l>Solamente a te stessa! In questo seno</l>
@@ -3955,29 +3980,29 @@
             <l>D'Attila si prepari: io so che lieta</l>
             <l>La tua man generosa a Fulvia cede.</l>
           </sp>
-          <sp>
+          <sp who="#Onoria">
             <speaker>ONOR.</speaker>
             <l>E' poco il sacrificio a tanta fede.</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="I">Oh contento!</l>
           </sp>
-          <sp>
+          <sp who="#fulvia">
             <speaker>FUL.</speaker>
             <l part="M">Oh piacer!</l>
           </sp>
-          <sp>
+          <sp who="#ezio">
             <speaker>EZIO</speaker>
             <l part="F">Concedi, Augusto,</l>
             <l>La salvezza di Varo</l>
             <l>Di Massimo la vita ai nostri prieghi.</l>
           </sp>
-          <sp>
+          <sp who="#valentiniano">
             <speaker>VAL.</speaker>
             <l>A tanto intercessor nulla si nieghi.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Della vita nel dbbio cammino</l>

--- a/tei/metastasio-il-re-pastore.xml
+++ b/tei/metastasio-il-re-pastore.xml
@@ -76,6 +76,28 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="aminta">
+            <persName>Aminta</persName>
+          </person>
+          <person xml:id="elisa">
+            <persName>Elisa</persName>
+          </person>
+          <person xml:id="agenore">
+            <persName>Agenore</persName>
+          </person>
+          <person xml:id="alessandro">
+            <persName>Alessandro</persName>
+          </person>
+          <person xml:id="tamiri">
+            <persName>Tamiri</persName>
+          </person>
+          <person xml:id="coro">
+            <persName>Coro</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Pavia</name>Digitalizzazione</change>
@@ -136,7 +158,7 @@
             Largo, ma rustico ponte sul fiume. Innanzi, tuguri pastorali. Veduta della
             città di Sidone in lontano.</stage>
           <stage>AMINTA, assiso sopra un sasso, cantando al suono delle avene pastorali; indi ELISA</stage>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <lg>
               <l>Intendo, amico rio,</l>
@@ -149,11 +171,11 @@
             <l>Bella Elisa, idol mio,</l>
             <l part="I">Dove?</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="M">A te, caro Aminta. <stage>(lieta e frettolosa</stage></l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">Oh dèi! non sai</l>
             <l>Che il campo d'Alessandro</l>
@@ -161,38 +183,38 @@
             <l>Quste amene contrade</l>
             <l part="I">Il Macedone armato?</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="M">Il so.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">Ma dunque</l>
             <l>Perché sola t'esponi all'insolente</l>
             <l part="I">Licenza militar?</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">Rischio non teme,</l>
             <l>Non ode amor consiglio.</l>
             <l>Il non vederti è il mio maggior periglio.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="I">E per me...</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">Deh! m'ascolta. Ho colmo il core</l>
             <l>Di felici speranze, e non ho pace</l>
             <l part="I">Fin che con te non le divido.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">Altrove</l>
             <l part="I">Più sicura potrai...</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">Ma d'Alessandro</l>
             <l>Fai torto alla virtù. Son della nostra</l>
@@ -202,21 +224,21 @@
             <l>Che sia vendita il dono:</l>
             <l>Ne franse il giogo, e ne ricusa il trono.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="I">Chi sarà dunque il nostro re?</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">Si crede</l>
             <l>Che, ignoto anche a se stesso, occulto viva</l>
             <l part="I">Il legittimo erede.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="M">E dove...</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">Ah! lascia</l>
             <l>Che Alessandro ne cerchi. Odi. La mia</l>
@@ -226,16 +248,16 @@
             <l>Va l'assenso a implorar dal genitore,</l>
             <l>E l'otterrà: me lo predice il core.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="I">Ah!</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">Tu sospiri, Aminta?</l>
             <l>Che vuol dir quel sospiro?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l>Contro il destin m'adiro,</l>
             <l>Che sì poco mi fece</l>
@@ -246,7 +268,7 @@
             <l>Io non potrò, nella mia sorte umìle,</l>
             <l>Che una povera reggia, un rozzo ovile.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l>Non lagnarti del Ciel: prodigo assai</l>
             <l>Ti fu de' doni suoi. Se l'ostro e l'oro</l>
@@ -260,12 +282,12 @@
             <l>E mi restò nel core</l>
             <l>Quell'ovil, quella greggia e quel pastore.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l>Oh mia sola, oh mia vera</l>
             <l part="I">Felicità! quei cari detti...</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">Addio.</l>
             <l>Corro alla madre e vengo a te. Fra poco</l>
@@ -289,171 +311,171 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>AMINTA, poi ALESSANDRO ed AGENORE con picciol séguito.</stage>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l>Perdono, amici dèi: fui troppo ingiusto,</l>
             <l>Lagnandomi di voi. Non splende in cielo</l>
             <l>Dell'astro, che mi guida, astro più bello.</l>
             <l>Se la terra ha un felice, Aminta è quello.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="I">(Ecco il pastor). <stage>(piano ad Alessandro</stage></l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">Ma fra' contenti oblio</l>
             <l part="I">La mia povera greggia. <stage>(da sé, in atto di
             partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F"><stage>(ad Aminta)</stage> Amico, ascolta.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l>(Un guerrier!) Che domandi?</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="I">Sol con te ragionar.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">Signor, perdona,</l>
             <l>Qualunque sei: d'abbeverar la greggia</l>
             <l part="I">L'ora già passa.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Andrai, ma un breve istante</l>
             <l>Donami sol. (Che signoril sembiante!) <stage>(piano ad Agenore</stage></l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="I">(Da me che mai vorrà?)</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Come t'appelli?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="I">Aminta.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="M">E il padre?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="M">Alceo.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="M">Vive?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">No; scorse</l>
             <l part="I">Un lustro già ch'io lo perdei.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Che avesti</l>
             <l part="I">Dal paterno retaggio?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">Un orto angusto</l>
             <l>Ond'io traggo alimento,</l>
             <l>Poche agnelle, un tugurio e il cor contento.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="I">Vivi in povera sorte.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">Assai benigna</l>
             <l>Sembra a me la mia stella:</l>
             <l>Non bramo della mia sorte più bella.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="I">Ma in sì scarsa fortuna...</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">Assai più scarse</l>
             <l part="I">Son le mie voglie.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Aspro sudor t'appresta</l>
             <l part="I">Cibo volgar.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="M">Ma lo condisce.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Ignori</l>
             <l>Le grandezze, gli onori.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l>E rivali non temo,</l>
             <l part="I">E rimorsi non ho.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">T'offre un ovile</l>
             <l>Sonni incomodi e duri.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="I">Ma tranquilli e sicuri.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">E chi fra queste,</l>
             <l>Che ti fremono intorno, armate squadre,</l>
             <l part="I">Chi assicurar ti può?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">Questa, che tanto</l>
             <l>Io lodo, tu disprezzi, e il Ciel protegge,</l>
             <l part="I">Povera, oscura sorte.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F"><stage>(piano ad Alessandro)</stage> Hai dubbi ancora?</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>(Quel parlar mi sorprende e m'innamora).</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="I">Se altro non brami, addio.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Senti. I tuoi passi</l>
             <l>Ad Alessandro io guiderò, se vuoi.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="I">No.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="M">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">Sedurrebbe</l>
             <l>Ei me dalle mie cure: io qualche istante</l>
@@ -466,12 +488,12 @@
             <l>Ei duce è di guerrieri:</l>
             <l>Picciol campo io coltivo, ei fonda imperi.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>Ma può il Ciel di tua sorte</l>
             <l>In un punto cangiar tutto il tenore.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l>Sì; ma il Cielo fin or mi vuol pastore.</l>
             <lg>
@@ -491,11 +513,11 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>ALESSANDRO ed AGENORE</stage>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="I">Or che dici, Alessandro?</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Ah! certo asconde</l>
             <l>Quel pastorel lo sconosciuto erede</l>
@@ -530,11 +552,11 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>TAMIRI in abito pastorale ed AGENORE</stage>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="I">Agenore! T'arresta: odi...</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Perdona,</l>
             <l>Leggiadra pastorella: io d'Alessandro</l>
@@ -542,102 +564,102 @@
             <l>O m'inganna il desio?)</l>
             <l part="I">Principessa!</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="M">Ah, mio ben!</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="M">Sei tu!</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="F">Son io.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="I">Tu qui? tu in questa spoglia?</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="F">Io deggio a questa</l>
             <l>Il sol ben che mi resta.</l>
             <l>Ch'è la mia libertà, giacché Alessandro</l>
             <l part="I">Padre e regno m'ha tolto.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Oh, quanto mai</l>
             <l>Ti piansi e ti cercai! Ma dove ascosa</l>
             <l part="I">Ti celasti fin or?</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="F">La bella Elisa</l>
             <l part="I">Fuggitiva m'accolse.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">E qual disegno...</l>
             <l> Ah! m'attende Alessandro.</l>
             <l part="I">Addio: ritornerò.</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="F">Senti. Alla fuga</l>
             <l>Tu d'aprirmi un cammin, ben mio, procura:</l>
             <l>Altrove almeno io piangerò sicura.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l>Vuoi seguir, principessa</l>
             <l>Un consiglio più saggio? ad Alessandro</l>
             <l part="I">Meco ne vieni.</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="F">All'uccisor del padre!</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l>Straton se stesso uccise: ei la clemenza</l>
             <l part="I">Del vincitor prevenne.</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="F">Io stessa ai lacci</l>
             <l>Offrir la destra! Io delle greche spose</l>
             <l part="I">Andrò gl'insulti a tollerar!</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">T'inganni:</l>
             <l>Non conosci Alessandro; ed io non posso</l>
             <l>Per or disingannarti. Addio. Fra poco</l>
             <l part="I">A te verrò. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="F">Guarda: di Elisa i tetti</l>
             <l part="I">Colà...</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="M">Già mi son noti. <stage>(come sopra</stage></l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="M">Odi.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Che brami?</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="I">Come sto nel tuo core?</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Ah! non lo vedi?</l>
             <l>A' tuoi begli occhi, o principessa, il chiedi.</l>
@@ -681,7 +703,7 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>ELISA sommamente allegra e frettolosa, poi AMINTA</stage>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l>Oh lieto giorno! oh me felice! oh caro</l>
             <l>Mio genitor! Ma... Dove andò? Pur dianzi</l>
@@ -699,27 +721,27 @@
             <l>Tranquilla in questa guisa</l>
             <l part="I">Più rimaner. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">Dove t'affretti, Elisa?</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="I">Ah, tornasti una volta! Andiamo.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">E dove?</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="I">Al genitor.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="M">Dunque ei consente...</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">Il core</l>
             <l>Non m'ingannò: sarai mio sposo, e prima</l>
@@ -728,7 +750,7 @@
             <l>Superbo, e lieto... Ei tel dirà. Vedrai</l>
             <l part="I">Dall'accoglienze sue... Vieni.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">Ah! ben mio,</l>
             <l>Lasciami respirar. Pietà d'un core</l>
@@ -740,58 +762,58 @@
           <head>SCENA SETTIMA</head>
           <stage>AGENORE, seguìto da guardie reali e nobili di Sidone, che portano sopra
             bacili d'oro le regie insegne, e detti.</stage>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l>Dal più fedel vassallo</l>
             <l>Il primo omaggio, eccelso re, ricevi.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="I">Che dice? <stage>(ad Aminta</stage></l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">A chi favelli? <stage>(ad Agenore</stage></l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="I">A te, signor.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F"><stage>(con viso sdegnoso)</stage> Lasciami in pace e prendi</l>
             <l>Alcun altro a schernir. Libero io nacqui,</l>
             <l>Se re non sono; e, se non merto omaggi, <stage>(crescendo il risentimento</stage></l>
             <l>Ho un core almen, che non sopporta oltraggi.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l>Quel generoso sdegno</l>
             <l>Te scopre e me difende. Odimi e soffri</l>
             <l>Che ti sveli a te stesso il zelo mio.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="I">Come! Aminta ei non è? <stage> (ad Agenore</stage></l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="M">No.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">E chi son io?</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l>Tu Abdolonimo sei, l'unico erede</l>
             <l part="I">Del soglio di Sidone.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="M">Io!</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Sì. Scacciato</l>
             <l> Dal reo Stratone, il padre tuo bambino</l>
@@ -799,19 +821,19 @@
             <l>Alla mia fé commise</l>
             <l part="I">Te, il segreto e le prove.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">E il vecchio Alceo...</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="I">L'educò sconosciuto.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">E tu fin ora...</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l>Ed io, fin or tacendo, alla paterna</l>
             <l>Legge ubbidii. M'era il parlar vietato,</l>
@@ -819,16 +841,16 @@
             <l>L'assistenza de' numi. Io la cercai</l>
             <l>Nel gran cor d'Alessandro, e la trovai.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l>Oh giubilo! oh contento!</l>
             <l part="I">Il mio bene è il mio re.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F"><stage>(ad Agenore)</stage> Dunque Alessandro...</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l>T'attende, e di sua mano</l>
             <l>Vuol coronarti il crin. Le regie spoglie</l>
@@ -840,48 +862,48 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>ELISA allegra, AMINTA attonito.</stage>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="I">Elisa?</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="M">Aminta?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="M">E' sogno?</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="M">Ah! no.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">Tu credi</l>
             <l part="I">Dunque...</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">Sì; ma è strano</l>
             <l>Questo colpo per me, benché improvviso:</l>
             <l>Un cor di re sempre io ti vidi in viso.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l>Sarà. Vadasi intanto</l>
             <l part="I">Al padre tuo. <stage>(s'incammina</stage></l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F"><stage>(l'arresta)</stage> No; maggior cura i numi</l>
             <l>Ora esigon da te. Va, regna, e poi...</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="I">Che! m'affretti a lasciarti?</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">Ah, se vedessi</l>
             <l>Come sta questo cor! Di gioia esulta;</l>
@@ -890,13 +912,13 @@
             <l>Se non che Aminta è re. Deh! va: potrebbe</l>
             <l part="I">Alessandro sdegnarsi.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">Amici dèi,</l>
             <l>Son grato al vostro dono;</l>
             <l>Ma troppo è caro a questo prezzo un trono</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <lg>
               <l>Vanne a regnar, ben mio;</l>
@@ -904,7 +926,7 @@
               <l>Serba, se puoi, quel cor.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <lg>
               <l>Se ho da regnar, ben mio,</l>
@@ -912,19 +934,19 @@
               <l>Il fido tuo pastor.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <lg part="I">
               <l>Ah, che il mio re tu sei!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <lg part="F">
               <l>Ah, che crudel timor!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aminta #elisa">
             <speaker>A DUE</speaker>
             <lg>
               <l>Voi proteggete, o dèi,</l>
@@ -940,50 +962,50 @@
           <stage>Grande e ricco padiglione d'Alessandro da un lato; ruine inselvatichite di antichi
             edifici dall'altro. Campo de' Greci in lontano. Guardie del medesimo in vari luoghi.</stage>
           <stage>TAMIRI in atto di timore, ELISA conducendola per mano.</stage>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="I"> Seguimi. A che t'arresti?</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="F">Amica, oh Dio!</l>
             <l>Tremo da capo a piè. Torniam, se m'ami,</l>
             <l part="I">Torniamo al tuo soggiorno.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">Io non t'intendo:</l>
             <l>T'affretti impaziente</l>
             <l>Pria d'Agenore in traccia; ed or nol curi,</l>
             <l part="I">Già vicina a trovarlo?</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="F">Amor m'ascose</l>
             <l>Da lungi il rischio: or che vi son, comprendo</l>
             <l part="I">La mia temerità.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="M">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="F">La figlia</l>
             <l part="I">Non son io di Stratone?</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="M">E ben?</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="F">Le tende</l>
             <l>Non son quelle de' Greci? E se di loro</l>
             <l>Mi scopre alcuno? Ah! per pietà, fuggiamo,</l>
             <l part="I">Cara Elisa.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">E' follia. Chi vuoi che possa</l>
             <l>Scoprirti in queste vesti? E, se potesse</l>
@@ -993,38 +1015,38 @@
             <l>E la sposa e la madre</l>
             <l part="I">Non sai...</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="F">Lo so; ma la sventura mia</l>
             <l>Forse è maggior di sua virtù. Non oso</l>
             <l part="I">Di metterla a cimento. Andiam.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">Perdona;</l>
             <l>Puoi tornar sola. Io nulla temo, e voglio</l>
             <l part="I">Cercare Aminta. <stage>(incamminandosi verso il padigilione</stage></l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="F">Aspetta: il tuo coraggio</l>
             <l part="I">M'inspira ardir. <stage>(risoluta</stage></l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="M">Dunque mi segui. <stage>(incamminandosi come sopra</stage></l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="F"><stage>(fa qualche passo e poi s'arresta)</stage> Oh Dio!</l>
             <l>Mille rischi ho presenti.</l>
             <l part="I">No, non ho cor.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="M">Dunque mi lasci? <stage>(le fugge di mano</stage></l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="F">Ah! senti.</l>
             <lg>
@@ -1044,101 +1066,101 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>ELISA, poi AGENORE</stage>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l>Questa del campo greco</l>
             <l>E' la tenda maggior: qui l'idol mio</l>
             <l part="I">Certo ritroverò.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Dove l'affretti,</l>
             <l part="I">Leggiadra ninfa? <stage>(arrestandola</stage></l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="M">Io vado al re. <stage>(vuol passare</stage></l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F"><stage>(la ferma)</stage> Perdona:</l>
             <l part="I">Veder nol puoi.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="M">Per qual cagione?</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Or siede</l>
             <l>Co' suoi Greci a consiglio.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="I">Co' Greci suoi?</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="M">Sì.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">Dunque andar poss'io:</l>
             <l part="I">Non è quello il mio re. <stage>(incamminandosi</stage></l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F"><stage>(arrestandola)</stage> Ferma: né pure</l>
             <l part="I">Al tuo re lice andar.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="M">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Che attenda</l>
             <l part="I">Alessandro or convien.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">L'attenda. Io bramo</l>
             <l part="I">Vederlo sol. <stage>(come sopra</stage></l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">No; d'inoltrarti tanto</l>
             <l part="I">Non è permesso a te.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">Dunque l'avverti:</l>
             <l part="I">Egli a me venga.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">E questo</l>
             <l part="I">Non è permesso a lui.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">Permesso almeno</l>
             <l part="I">Mi sarà d'aspettarlo. <stage>(siede</stage></l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Amica Elisa,</l>
             <l>Va, credi a me: per ora</l>
             <l>Deh! non turbarci. Io col tuo re fra poco</l>
             <l part="I">Più tosto a te verrò.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">No, non mi fido:</l>
             <l>Tu non pensi a Tamiri</l>
             <l part="I">Ed a me penserai?</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">T'inganni. Appunto</l>
             <l>Io voglio ad Alessandro</l>
@@ -1147,53 +1169,53 @@
             <l>Gli opportuni momenti</l>
             <l part="I">Rubar mi puoi.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">T'appagherò. <stage>(s'alza, sincammina, poi si volge)</stage>
               Frattanto</l>
             <l>Non celare ad Aminta</l>
             <l part="I">Le smanie mie.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="M">No.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F"><stage>(come sopra)</stage> Digli</l>
             <l>Che le sue mi figuro.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="I">Sì.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">Da me lungi, oh quanto</l>
             <l>Penerà l'infelice! <stage>(ad Agenore, ma da lontano</stage></l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="I">Molto.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="M">E parla di me? <stage>(da lontano</stage></l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="M">Sempre.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F"><stage>(torna ad Agenore)</stage> E che dice?</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l>Ma tu partir non vuoi. Se tutte io deggio</l>
             <l>Ridir le sue querele... <stage>(con impeto</stage></l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l>Vado: non ti sdegnar. Sei pur crudele!</l>
             <lg>
@@ -1213,7 +1235,7 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>AGENORE ed AMINTA</stage>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l>Nel gran cor d'Alessandro, o dèi clementi,</l>
             <l>Secondate i miei detti</l>
@@ -1221,50 +1243,50 @@
             <l>La sua virtù, la sua beltà... Ma dove,</l>
             <l part="I">Dove corri, mio re?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">La bella Elisa</l>
             <l>Pur da lungi or mirai: perché s'asconde?</l>
             <l part="I">Dov'è?</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="M">Partì.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">Senza vedermi? Ingrata!</l>
             <l>Ah! raggiungerla io voglio. <stage>(s'incammina</stage></l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="I">Ferma, signor. <stage>(l'arresta</stage></l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="M">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="M">Non puoi.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">Non posso?</l>
             <l part="I">Chi dà legge ad un re?</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">La sua grandezza,</l>
             <l>La giustizia, il decoro, il bene altrui,</l>
             <l part="I">La ragione, il dover.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">Dunque pastore</l>
             <l>Io fui men servo? e che mi giova il regno?</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l>Se il regno a te non giova,</l>
             <l>Tu giovar devi a lui. Te dona al regno</l>
@@ -1277,19 +1299,19 @@
             <l>Che Aminta è il re, che un suo vassallo io sono.</l>
             <l>Errai per troppo zel: signor, perdono. <stage>(vuole inginocchiarsi</stage></l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l>Che fai? Sorgi. <stage>(lo solleva)</stage> Ah! se m'ami,</l>
             <l>Parlami ognor così. Mi par sì bella,</l>
             <l>Che di sé m'innamora,</l>
             <l>La verità, quando mi sferza ancora.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l>Ah! te destina il fato</l>
             <l part="I">Veramente a regnar.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">Ma dimmi, amico:</l>
             <l>Non deggio amar chi m'ama? E' poco Elisa</l>
@@ -1300,44 +1322,44 @@
             <l>Fra gli uomini, fra i numi, in terra, in cielo</l>
             <l part="I">La tenerezza mia?</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Nessuno: è giusta;</l>
             <l part="I">Ma pria di tutto...</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">Ah! pria di tutto andiamo,</l>
             <l part="I">Amico, a consolarla, e poi...</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">T'arresta.</l>
             <l>Sciolto è il consiglio; escono i duci; a noi</l>
             <l part="I">Viene Alessandro.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="M">Ov'è?</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Non riconosci</l>
             <l>I suoi custodi alla real divisa?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="I">Dunque...</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="M">Attender convien.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">Povera Elisa!</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <lg>
               <l>Ogni altro affetto ormai</l>
@@ -1356,15 +1378,15 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>ALESSANDRO e detti.</stage>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="I">Agenore. <stage>(ad Agenore, che parte</stage></l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="M">Signor.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Fermati: io deggio</l>
             <l>Poi teco favellar. <stage>(Agenore si ferma</stage>
@@ -1372,7 +1394,7 @@
             <l>Resta il re di Sidone</l>
             <l>Ravvolto ancor fra quelle lane istesse?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l>Perché ancor non impresse</l>
             <l>Su quella man, che lo solleva al regno,</l>
@@ -1380,7 +1402,7 @@
             <l>Soffri che prima al piede</l>
             <l part="I">Del mio benefattor... <stage>(vuole inginocchiarsi</stage></l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">No; dell'amico</l>
             <l>Viene alle braccia, e, di rispetto in vece,</l>
@@ -1390,13 +1412,13 @@
             <l>Sol mi sei debitor. Per mia mercede</l>
             <l part="I">Chiedo la gloria tua.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">Qual gloria, oh dèi!</l>
             <l>Io saprò meritar, se fino ad ora</l>
             <l>Una greggia a guidar solo imparai?</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>Sarai buon re, se buon pastor sarai.</l>
             <l>Ama la nuova greggia,</l>
@@ -1418,14 +1440,14 @@
             <l>Come avesti fra' boschi, in trono avrai.</l>
             <l>Sarai buon re, se buon pastor sarai.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l>Sì. Ma in un mar mi veggo</l>
             <l>Ignoto e procelloso. Or, se tu parti,</l>
             <l>Chi sarà l'astro mio? da chi consigli</l>
             <l part="I">Prender dovrò?</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Già questo dubbio solo</l>
             <l>Mi promette un gran re. Del mar che varchi</l>
@@ -1444,12 +1466,12 @@
             <l>La verità tra le menzogne oppressa,</l>
             <l>E' la grande al re solo opra commessa.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l>Ma donde un sì gran lume</l>
             <l part="I">Può sperare un pastor?</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Dal Ciel, che illustra</l>
             <l>Quei che sceglie a regnar. Nebbie d'affetti</l>
@@ -1457,18 +1479,18 @@
             <l>A turbarti il seren, tutto vedrai.</l>
             <l>Sarai buon re, se buon pastor sarai.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="I">Tanto ardir da quei detti...</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Or va... deponi</l>
             <l>Quelle rustiche vesti, altre ne prendi,</l>
             <l>E torna a me. Già di mostrarti è tempo</l>
             <l part="I">A' tuoi fidi vassalli.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">Ah! fate, o numi,</l>
             <l>Fate che Aminta in trono</l>
@@ -1490,12 +1512,12 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>ALESSANDRO ed AGENORE</stage>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l>(Or per la mia Tamiri</l>
             <l part="I">E' tempo di parlar).</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">La gloria mia</l>
             <l>Me fra lunghi riposi,</l>
@@ -1514,76 +1536,76 @@
             <l>Di me che si dirà? che un'empio io sono,</l>
             <l part="I">Un barbaro, un crudel.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Degna è di scusa,</l>
             <l>Se, figlia d'un tiranno, ella temea...</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>Questo è il suo fallo: e che temer dovea?</l>
             <l>Se Alessandro punisce</l>
             <l>Le colpe altrui, le altrui virtudi onora.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l>L'Asia non vide altri Alessandri ancora.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>Quanta gloria m'usurpa! Io lascerei</l>
             <l>Tutti felici. Ah! per lei sola or questa</l>
             <l>Riman del mio valore orma funesta.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="I">(Coraggio!)</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Avrei potuto</l>
             <l>Altrui mostrar, se non fuggia Tamiri,</l>
             <l>Ch'io distinguer dal reo so l'innocente.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="I">Non lagnarti. Il potrai.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="M">Come!</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">E' presente.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="I">Chi?</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="M">Tamiri.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="M">E mel taci?</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Il seppi appena</l>
             <l part="I">Che a te venne; e or volea...</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Corri! t'affretta!</l>
             <l part="I">Guidala a me.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="M">Vado e ritorno. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Aspetta. <stage>(pensa</stage></l>
             <l>(Ah! sì: mai più bel nodo <stage>(risoluto da
@@ -1593,11 +1615,11 @@
             <l>Ch'oggi al nuovo sovrano</l>
             <l>Io darò la corona, ella la mano.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="I">La man!</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Sì, amico. Ah! con un sol diadema</l>
             <l>Di due bell'alme io la virtù corono.</l>
@@ -1607,37 +1629,37 @@
             <l>La gloria al nome mio</l>
             <l part="I">Rendo così: tutto assicuro.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">(Oh Dio!)</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>Tu impallidisci e taci!</l>
             <l>Disapprovi il consiglio? E' pur Tamiri...</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="I">Degnissima del trono.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">E' un tal pensiero...</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="I">Degnissimo di te.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Di quale affetto</l>
             <l>Quel tacer dunque è segno e quel pallore?</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l>Di piacer, di rispetto e di stupore.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <lg>
               <l>Se vincendo vi rendo felici,</l>
@@ -1674,7 +1696,7 @@
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>AMINTA in abito reale, e detto.</stage>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l>Eccomi a te di nuovo; ecco deposte</l>
             <l>Le care spoglie antiche. Avvolto in questi</l>
@@ -1682,32 +1704,32 @@
             <l>Mal noto forse io giungerò. Potessi</l>
             <l part="I">Almeno a lei mostrarmi!</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Ah! d'altre cure,</l>
             <l>Signore, è tempo. Or che sei re, conviene</l>
             <l>Che a pensar tu incominci in nuova guisa.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="I">Come! E che far dovrei?</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Scordati Elisa.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="I">Elisa! E chi l'impone?</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Un cenno Augusto</l>
             <l>Di chi può ciò che vuole, e vuole il giusto:</l>
             <l>L'impone il ben d'un regno,</l>
             <l part="I">L'onor d'un trono...</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">Ah! vadan pria del mondo</l>
             <l>Tutti i troni sossopra. Elisa è stato,</l>
@@ -1717,48 +1739,48 @@
             <l>Ma sai come io l'adoro?</l>
             <l part="I">Sai che fece per me? sai come...</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Ah! calma</l>
             <l part="I">Quegl'impeti, o mio re.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">Scordarmi Elisa!</l>
             <l part="I">Se lo tentassi, io ne morrei.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">T'inganni:</l>
             <l>Di tua virtù non ben conosci ancora</l>
             <l>Tutto il valor. Sentimi solo; e poi...</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="I">Che mai, che dir mi puoi?</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Che, quando al trono</l>
             <l>Sceglie il Cielo un regnante... <stage>(vede Elisa alla destra)</stage> Ah! viene
               Elisa.</l>
             <l part="I">Fuggiam.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="M">Non lo sperar.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Pietà, signore,</l>
             <l>Di te, di lei. L'ucciderai, se parli</l>
             <l part="I">Pria di saper...</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">Non parlerò, tel giuro.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l>No: déi fuggirla. Andiam: soffri un eccesso</l>
             <l>Dell'ardita mia fé sol questa volta. <stage>(lo prende per mano e il trae
@@ -1768,173 +1790,173 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>TAMIRI dalla sinistra, ELISA dalla destra, e detti.</stage>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="I">Dove, Agenore?</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="M">Oh stelle!</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">Aminta, ascolta.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="I">Ah, principessa!</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="M">Ah! mio tesoro!</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="F"><stage>(ad Agenore )</stage> E tanto</l>
             <l part="I">Attenderti convien?</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F"><stage>(ad Aminta)</stage> Tanto bisogna</l>
             <l part="I">Sospirar per vederti?</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="F"><stage>(ad Agenore )</stage> A me pensasti?</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="I">Pensasti a me? <stage>(ad Aminta</stage></l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="F"><stage>(ad Agenore )</stage> Posso saper qual sia</l>
             <l part="I">Al fin la sorte mia?</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">Ritrovo ancora</l>
             <l part="I">Il mio pastor nel re? <stage>(ad Aminta</stage></l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="F"><stage>(ad Agenore )</stage> Ma tu sospiri?</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l>Ma tu non mi rispondi? <stage>(ad Aminta</stage></l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="I">Parla. <stage>(ad Agenore</stage>
             </l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Dovrei... Non posso.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="I">Parla. <stage>(ad Aminta</stage></l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="M">Vorrei... Non so.</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="M">Come!</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">Che avvenne?</l>
           </sp>
-          <sp>
+          <sp who="#tamiri #elisa">
             <speaker>TAM. ELI.</speaker>
             <l part="I">Ma parlate una volta.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Ah! che pur troppo</l>
             <l>Si parlerà. Lasciateci un momento</l>
             <l part="I">Respirar soli in pace.</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="F">Udisti, Elisa?</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l>Oh dèi, scacciarne! E tu che dici, Aminta?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="I">Ch'io mi sento morire.</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="M">Intendo.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">Intendo.</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l>T'avvilì la mia sorte.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l>Han quelle spoglie anche il tuo cor cangiato.</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="I">Agenore incostante!</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">Aminta ingrato!</l>
             <lg part="I">
               <l>Ah, tu non sei più mio!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <lg part="F">
               <l>Ah, l'amor tuo finì!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <lg part="I">
               <l>Come non dirmi, oh Dio!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <lg part="F">
               <l>Non dirmi, oh Dio! così.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <lg part="I">
               <l>Dov'è quel mio pastore?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <lg part="F">
               <l>Quel mio fedel dov'è?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#aminta #agenore">
             <speaker>AMIN.ed AGEN.</speaker>
             <lg part="I">
               <l>Ah, mi si agghiaccia il core!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#elisa #tamiri #aminta #agenore">
             <speaker>A QUATTRO.</speaker>
             <lg part="F">
               <l>Ah, che sarà di me!</l>
@@ -1982,60 +2004,60 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>AGENORE e detto.</stage>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">E irresoluto ancora</l>
             <l part="I">Ti ritrovo, o mio re?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="M">No.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Decidesti?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="I">Sì.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="M">Come?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">Il dover mio</l>
             <l part="I">A compir son disposto.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Ad Alessandro</l>
             <l part="I">Dunque d'andar più non ricusi?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">A lui</l>
             <l part="I">Anzi già m'incammino.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Elisa e trono</l>
             <l part="I">Vedi che andar non ponno insieme.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">E' vero.</l>
             <l>Né d'un eroe benefico al disegno</l>
             <l>Oppor si dee chi ne riceve un regno.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l>Oh fortunato Aminta! oh qual compagna</l>
             <l>Ti destinan le stelle! Amala: è degna</l>
             <l part="I">Degli affetti d'un re.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">Comprendo, amico,</l>
             <l>Tutta la mia felicità. Non dirmi</l>
@@ -2067,7 +2089,7 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>ELISA e detto.</stage>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">Ma senti,</l>
             <l>Agenore: quai fole</l>
@@ -2081,88 +2103,88 @@
             <l>Che ha dell'affanno altrui</l>
             <l part="I">Sì maligno piacer?</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Mia cara Elisa,</l>
             <l part="I">Esci d'error: nessun t'inganna.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">E sei</l>
             <l>Tu sì credulo ancor? tu ancor faresti</l>
             <l part="I">Sì gran torto ad Aminta?</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Io non saprei</l>
             <l part="I">Per qual via dubitarne.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">E mi abbandona</l>
             <l>Dunque Aminta così... No, non è vero:</l>
             <l>Ti lasciasti ingannar. Donde apprendesti</l>
             <l part="I">Novella sì gentil?</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="M">Da lui.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">Da lui!</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l>Sì, dall'istesso Aminta.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="I">Dove?</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="M">Qui.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="M">Quando?</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="M">Or ora.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="M">E disse?</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">E disse</l>
             <l>Che al voler d'Alessandro</l>
             <l>Non dessi oppor chi ne riceve un regno.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l>Santi numi del ciel! Come! a Tamiri</l>
             <l part="I">Darà la man?</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="M">La mano e il cor.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">Che possa</l>
             <l part="I">Così tradirmi Aminta!</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Ah! cangia, Elisa,</l>
             <l>Cangia ancor tu pensiero,</l>
             <l part="I">Cedi al destin.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F"><stage>(con impeto ma piangendo)</stage> No, non sarà mai vero:</l>
             <l>Non lo speri Alessandro,</l>
@@ -2170,35 +2192,35 @@
             <l>La sua sposa son io:</l>
             <l>Io l'amai da che nacqui; Aminta è mio.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l>E' giusto, o bella ninfa,</l>
             <l>Ma inutile il tuo duol. Se saggia sei,</l>
             <l part="I">Credimi, ti consola.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">Io consolarmi?</l>
             <l>Ingegnoso consiglio</l>
             <l part="I">Facile ad eseguir!</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">L'eseguirai,</l>
             <l>Se imitar mi vorrai. Puoi consolarti,</l>
             <l>E ne déi dall'esempio esser convinta.</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l>Io non voglio imitarti;</l>
             <l>Consolarmi io non voglio: io voglio Aminta.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l>Ma s'ei più tuo non è, con quei trasporti</l>
             <l part="I">Che puoi far?</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">Che posso far? Ad Alessandro,</l>
             <l>Agli uomini, agli dèi pietà, mercede,</l>
@@ -2226,7 +2248,7 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>AGENORE, poi TAMIRI</stage>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l>Povera ninfa! io ti compiango, e intendo</l>
             <l>Nella mia la tua pena. E pure Elisa</l>
@@ -2236,140 +2258,140 @@
             <l>Convien che fugga; e ritrovar non spero</l>
             <l>Alla mia debolezza altro ricorso. <stage>(in atto di partire)</stage></l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="I">Agenore, t'arresta.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">(O dèi, soccorso!)</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l>D'un regno debitrice <stage>(con ironia</stage></l>
             <l>Ad amator sì degno</l>
             <l part="I">Dunque è Tamiri?</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Il debitore è il regno.</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l>Perché sì gran novella <stage>(con ironia)</stage></l>
             <l>Non recarmi tu stesso? Io dal tuo labbro</l>
             <l>Più che da un foglio tuo l'avrei gradita.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l>Troppo mi parve ardita</l>
             <l part="I">Quest'impresa, o regina.</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="F"><stage>(con risentimento)</stage> Era men grande</l>
             <l part="I">Che il cedermi ad Aminta.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">E' ver; ma forse</l>
             <l>L'idea del dover mio</l>
             <l>In faccia a te... Bella regina, addio.</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="I">Sentimi. Dove corri?</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">A ricordarmi</l>
             <l>Che sei la mia sovrana.</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="I">Sol tua mercé. <stage>(con ironia</stage></l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Ch'io d'esser teco evìti</l>
             <l part="I">Chiede il rispetto mio.</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="F"><stage>(con isdegno)</stage> Tanto rispetto</l>
             <l>E' immaturo fin or: sarà più giusto</l>
             <l>Quando al tuo re la mano</l>
             <l>Porger m'avrai veduto.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="I">Io nol vedrò.</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="F"><stage>(con impeto)</stage> Che! nol vedrai! Ti voglio</l>
             <l part="I">Presente alle mie nozze.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Ah! no, perdona:</l>
             <l part="I">Questo è l'ultimo addio.</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="F">Senti. Ove vai?</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l>Ove il Ciel mi destina.</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l>E ubbidisci così la tua regina? <stage>(con impeto</stage></l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="I">Già senza me...</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="F">No, senza te sarebbe</l>
             <l part="I">La mia sorte men bella.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">E che pretendi?</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l>Che mi vegga felice <stage>(con ironia</stage></l>
             <l>Il mio benefattore, e si compiaccia</l>
             <l part="I">Dell'opra sua.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">(Che tirannia!) Deh! cangia,</l>
             <l part="I">Tamiri, per pietà...</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="F"><stage>(con impeto)</stage> Prieghi non odo,</l>
             <l>Né scuse accetto: ubbidienza io voglio</l>
             <l>Da un suddito fedele.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l>(Oh Dio!)</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="I">M'udisti? <stage>(come sopra</stage></l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Ubbidirò, crudele.</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <lg>
               <l>Se tu di me fai dono,</l>
@@ -2411,7 +2433,7 @@
           <stage>Parte dello spazio circondato dal gran portico del celebre tempio di Ercole tirio.</stage>
           <stage>Fra l'armonia strepitosa de' militari stromenti esce ALESSANDRO, preceduto da'
             capitani greci e seguìto da' nobili di Sidone; poi TAMIRI, indi AGENORE</stage>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <lg>
               <l>Voi, che fausti ognor donate</l>
@@ -2429,23 +2451,23 @@
             <l>Perché il re non si vede?</l>
             <l part="I">Dov'è Tamiri?</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="F">E' d'Alessandro al piede.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>Sei tu la principessa?</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="I">Son io.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Signor, non dubitarne: è dessa.</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l>Perdonare a' nemici</l>
             <l>Sanno gli eroi; ma sollevarli al trono</l>
@@ -2453,21 +2475,21 @@
             <l>Signor, non so, che per te sento in petto.</l>
             <l>Vincitor ti rispetto, eroe t'onoro.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>E' gran premio dell'opra</l>
             <l>Render superbo un trono</l>
             <l part="I">Di sì amabil regina.</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="F">Ancor nol sono.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>Ma sol manca un istante.</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l>Odi. Agenore, amante,</l>
             <l>La mia grandezza all'amor suo prepone.</l>
@@ -2477,39 +2499,39 @@
             <l>Quel, che nel caso mio</l>
             <l>Alessandro faria, far voglio anch'io.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="I">E tu sapesti, amando... <stage>(ad Agenore</stage></l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Odila; e vedi</l>
             <l>Se usurpar dessi al trono</l>
             <l part="I">Un'anima sì bella.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F"><stage>(a Tamiri)</stage> E tu sì grata</l>
             <l part="I">Dunque ti senti a lui...</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l part="F">L'ascolta; e dimmi</l>
             <l>Se merita un castigo</l>
             <l part="I">Tanta virtù.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="F">Ma, principessa, or ora</l>
             <l>Lieta pur mi paresti</l>
             <l>Del nuziale invito.</l>
           </sp>
-          <sp>
+          <sp who="#tamiri">
             <speaker>TAM.</speaker>
             <l>No; ma tu mi credesti</l>
             <l>Più ambiziosa che amante: io t'ho punito.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>Dèi, qual virtù! qual fede!</l>
           </sp>
@@ -2517,45 +2539,45 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>ELISA e detti.</stage>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l>Ah! giustizia, signor, pietà, mercede!</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="I">Chi sei? che brami?</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">Io sono Elisa. Imploro</l>
             <l>D'Alessandro il soccorso</l>
             <l>A pro d'un core ingiustamente oppresso.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="I">Contro chi mai?</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">Contro Alessandro istesso.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="I">Che ti fece Alessandro?</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">Egli m'invola</l>
             <l>Ogni mia pace, ogni mio ben; d'affanno</l>
             <l>Ei vuol vedermi estinta.</l>
             <l>D'Aminta io vivo: ei mi rapisce Aminta.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>Aminta? E qual ragione</l>
             <l part="I">Hai tu sopra di lui?</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l part="F">Qual! Da bambina</l>
             <l>Ebbi il suo core in dono, e sino ad ora</l>
@@ -2564,7 +2586,7 @@
             <l>Chi ne dispon, s'io non lo cedo; ed io</l>
             <l>La vita cederò, non l'idol mio.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>Colui che il cor ti diè, ninfa gentile,</l>
             <l>Era Aminta il pastore: a te giammai</l>
@@ -2575,26 +2597,26 @@
           <head>SCENA ULTIMA</head>
           <stage>AMINTA in abito pastorale, seguìto da pastorelli, che portano sopra due
             bacili le vesti reali, e detti.</stage>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l>Signor, io sono Aminta e son pastore.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="I">Come!</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">Le regie spoglie</l>
             <l>Ecco al tuo piè. <stage>(si depongono i bacili a' piedi di
               Alessandro)</stage> Con le mie lane intorno,</l>
             <l>Alla mia greggia, alla mia pace io torno.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="I">E Tamiri non è...</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">Tamiri è degna</l>
             <l>Del cor d'un re; ma non è degna Elisa</l>
@@ -2607,19 +2629,19 @@
             <l>Signor, sia con tua pace,</l>
             <l>Più che un re senza fede, esser mi piace.</l>
           </sp>
-          <sp>
+          <sp who="#agenore">
             <speaker>AGEN.</speaker>
             <l part="I">Che ascolto!</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Ove son io!</l>
           </sp>
-          <sp>
+          <sp who="#elisa">
             <speaker>ELI.</speaker>
             <l>Agenore, io tel dissi: Aminta è mio.</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>Oh dèi! Quando felici</l>
             <l>Tutti io render pretendo,</l>
@@ -2633,24 +2655,24 @@
             <l>La mia fortuna impegno;</l>
             <l>Ed a tanta virtù non manca un regno.</l>
           </sp>
-          <sp>
+          <sp who="#tamiri #agenore">
             <speaker>TAM. AGEN.</speaker>
             <l part="I">Oh grande!</l>
           </sp>
-          <sp>
+          <sp who="#aminta #elisa">
             <speaker>AMIN. ELI.</speaker>
             <l part="M">Oh giusto!</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l part="F">Ah! vegga al fin Sidone</l>
             <l part="I">Coronato il suo re.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMIN.</speaker>
             <l part="F">Ma in queste spoglie...</l>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESS.</speaker>
             <l>In queste spoglie a caso</l>
             <l>Qui non ti guida il Cielo. Il Ciel predice</l>
@@ -2658,7 +2680,7 @@
             <l>Tutto, per questa via, forse il tenore:</l>
             <l>Bella sorte d'un regno è il re pastore.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Dalla selva e dall'ovile</l>

--- a/tei/metastasio-ipermestra.xml
+++ b/tei/metastasio-ipermestra.xml
@@ -75,6 +75,34 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="elpinice">
+            <persName>Elpinice</persName>
+          </person>
+          <person xml:id="ipermestra">
+            <persName>Ipermestra</persName>
+          </person>
+          <person xml:id="danao">
+            <persName>Danao</persName>
+          </person>
+          <person xml:id="linceo">
+            <persName>Linceo</persName>
+          </person>
+          <person xml:id="plistene">
+            <persName>Plistene</persName>
+          </person>
+          <person xml:id="adrasto">
+            <persName>Adrasto</persName>
+          </person>
+          <personGrp xml:id="popolo">
+            <name>Popolo</name>
+          </personGrp>
+          <personGrp xml:id="coro">
+            <name>Coro</name>
+          </personGrp>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Pavia</name>Digitalizzazione</change>
@@ -127,7 +155,7 @@
           <head>SCENA PRIMA</head>
           <stage>Fuga di camere festivamente ornate per le reali nozze d'Ipermestra.</stage>
           <stage>IPERMESTRA, ELPINICE e cavalieri.</stage>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l>I teneri tuoi voti al fin seconda</l>
             <l>Propizio il padre, o principessa; al fine</l>
@@ -139,7 +167,7 @@
             <l>Eccelsa coppia eletta,</l>
             <l>Quanti dì fortunati il mondo aspetta!</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l>No, mia cara Elpinice,</l>
             <l>Al par di me felice</l>
@@ -151,37 +179,37 @@
             <l>Che a vincere il mio core</l>
             <l>Dell'armi di ragion si valse Amore.</l>
           </sp>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l>Ah, così potess'io</l>
             <l>Al principe Plistene in questo giorno</l>
             <l part="I">Unir la sorte mia! Tu sai...</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Ne lascia</l>
             <l>La cura a me. Dal real padre io spero</l>
             <l>Ottener l'assenso: in dì sì grande</l>
             <l part="I">Nulla mi negherà.</l>
           </sp>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l part="F">Qual mai poss'io,</l>
             <l part="I">Generosa Ipermestra...</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Ah! tu non sai</l>
             <l>Che gran felicità per l'alma mia</l>
             <l part="I">E' il fare altri felici.</l>
           </sp>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l part="F">I fausti numi</l>
             <l>Chi tanto a lor somiglia</l>
             <l part="I">Custodiscan gelosi.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Ancor Linceo</l>
             <l>Non veggo comparir. Che fa? Dovrebbe</l>
@@ -190,7 +218,7 @@
             <l>La sua congiunga. Ormai</l>
             <l>Tempo sarebbe: abbiam penato assai.</l>
           </sp>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <lg>
               <l>Abbiam penato, è ver;</l>
@@ -209,7 +237,7 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>IPERMESTRA, poi DANAO con séguito.</stage>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l>Vadasi al genitor: dal labbro mio</l>
             <l>Sappia quanto io son grata, e sappia... Ei viene</l>
@@ -218,59 +246,59 @@
             <l>Rende quel della vita. Oggi conosco</l>
             <l part="I">Tutto il prezzo di questa: oggi...</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">Da noi</l>
             <l part="I">S'allontani ciascun. <stage>(al séguito, che si ritira</stage></l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Perché? M'ascolti</l>
             <l>Ttto il mondo, signor. Non arrossisco</l>
             <l>Di que' dolci trasporti,</l>
             <l>Che il padre approva; e a così pure faci...</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l>Voglio teco esser solo. Odimi e taci.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="I">M'è legge il cenno.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">Assicurar tu déi</l>
             <l>Il trono, i giorni miei,</l>
             <l>La mia tranquillità. Posso di tanto</l>
             <l part="I">Fidarmi a te?</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="M">M'offende il dubbio.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">Avrai</l>
             <l part="I">Costanza e fedeltà?</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Quanta ne deve</l>
             <l part="I">Ad un padre una figlia.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F"><stage>(le dà un pugnale)</stage> Or questo acciaro</l>
             <l>Prendi; cauta il nascondi; e, quando oppresso</l>
             <l>Già fra 'l notturno orrore</l>
             <l>Fia dal sonno Linceo, passagli il core.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="I">Santi numi! e perché?</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">Minaccia il fato</l>
             <l>Il mio scettro, i miei dì per man d'un figlio</l>
@@ -279,23 +307,23 @@
             <l>Che poc'anzi ascoltai: né v'è chi possa,</l>
             <l part="I">Più di Linceo, farmi temer.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Ma pensa...</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l>Molto, tutto pensai. Qualunque via</l>
             <l>Men facile è di questa,</l>
             <l>Ed ha rischio maggior. L'aman le squadre,</l>
             <l part="I">Argo l'adora.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">(Io non ho fibra in seno</l>
             <l part="I">Che tremar non mi senta).</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">Il gran segreto</l>
             <l>Guarda di non tradir. Componi il volto,</l>
@@ -320,7 +348,7 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>IPERMESTRA sola, indi LINCEO</stage>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l>Misera, che ascoltai! Son io? son desta?</l>
             <l>Sogno forse o vaneggio? Io nelle vene</l>
@@ -338,38 +366,38 @@
             <l>In solitaria parte</l>
             <l>Si nasconda il dolor che mi trasporta. <stage>(vuol partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="I">Principessa, mio nume!</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">(Aimè! son morta).</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l>Giunse pur quel momento</l>
             <l>Che tanto sospirai! Chiamarti mia</l>
             <l>Posso pure una volta! Or sì che l'ire</l>
             <l>Tutte io sfido degli astri, o mio bel sole.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l>(Oh Dio! non so partire,</l>
             <l>Non so restar, non so formar parole).</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l>Ma perché, principessa, in te non trovo</l>
             <l>Quel contento ch'io provo? Altrove i lumi</l>
             <l>Tu rivolgi inquieta e sfuggi i miei?</l>
             <l part="I">Che avvenne? Non tacer.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">(Consiglio, o dèi!)</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l>Questa felice aurora</l>
             <l>Bramasti tanto, e tanti voti a tanti</l>
@@ -377,7 +405,7 @@
             <l>E sì mesta ne sei? Cangiasti affetto?</l>
             <l>Dell'amor di Linceo stanco è il tuo core?</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <lg>
               <l>Ah, non parlar d'amore,</l>
@@ -396,7 +424,7 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>LINCEO solo, poi ELPINICE e PLISTENE, l'un dopo l'altro.</stage>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l>Questi son gl'imenei! son d'una sposa</l>
             <l>Questi i dolci trasporti! in questa guisa</l>
@@ -410,47 +438,47 @@
             <l>Che l'alma mi divide;</l>
             <l>Ma non so chi m''insidia o chi m'uccide.</l>
           </sp>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l>Fortunato Linceo, contenta a segno</l>
             <l part="I">Son io de' tuoi contenti...</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">Ah! principessa,</l>
             <l>L'anima mi trafiggi. Io de' mortali,</l>
             <l>Io sono il più infelice.</l>
           </sp>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l part="I">Tu! come?</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="F">In questo amplesso</l>
             <l>Un testimon ricevi</l>
             <l>Del giubilo sincero,</l>
             <l>Onde esulto per te. Tu godi, e parmi...</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l>Amico, ah! per pietà, non tormentarmi.</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="I">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="M">Son disperato.</l>
           </sp>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l part="F">Or che alla bella</l>
             <l>Ipermestra t'accoppia un caro laccio,</l>
             <l part="I">Disperato tu sei?</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">Mi scaccia, oh Dio!</l>
             <l>Ipermestra da sé; vieta Ipermestra</l>
@@ -458,44 +486,44 @@
             <l>Ipermestra m'appella:</l>
             <l>Ipermstra cangiò, non è più quella.</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="I">Che dici?</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">Ah! se v'è noto</l>
             <l>Chi quel cor m'ha sedotto,</l>
             <l part="I">Non mel tacete, amici. Io vuo'...</l>
           </sp>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l part="F">T'inganni:</l>
             <l>Ipermestra non ama</l>
             <l part="I">Che il suo Linceo; lui solo attende...</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">E dunque</l>
             <l>Perché da sé mi scaccia?</l>
             <l>Perché fugge da me? così turbata</l>
             <l part="I">Perché m'accoglie?</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="M">E la vedesti?</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">Or parte</l>
             <l part="I">Da questo loco.</l>
           </sp>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l part="F">Ed Ipermestra istessa</l>
             <l>Sì turbata ti parla?</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l>Così morto foss'io pria d'ascoltarla!</l>
             <lg>
@@ -514,17 +542,17 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>ELPINICE e PLISTENE</stage>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l>Plistene, ah! che sarà? Come in un punto</l>
             <l part="I">Ipermestra cangiossi?</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="F">Io nulla intendo:</l>
             <l part="I">Non so che immaginar.</l>
           </sp>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l part="F">Questo mancava</l>
             <l>Novello inciampo al nostro amor. Turbati</l>
@@ -534,7 +562,7 @@
             <l>Astro nemico io nacqui? Anche nel porto</l>
             <l part="I">Per me vi son tempeste.</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="F">In queste care</l>
             <l>Intolleranze tue, bella Elpinice,</l>
@@ -543,24 +571,24 @@
             <l>Mi priva della man qualche momento;</l>
             <l>Ma del cor m'assicura, e son contento.</l>
           </sp>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l>Sì dolorose prove</l>
             <l>Dar non vorrei dell'amor mio. Di queste</l>
             <l part="I">Tu ancor ti stancherai.</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="F">No, non si trova</l>
             <l>Pena che all'alma mia</l>
             <l>Per sì degna cagion dolce non sia.</l>
           </sp>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l>So che fido sei tu, ma so che troppo</l>
             <l part="I">Sventurata son io.</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="F">Deh! non conviene</l>
             <l>Disperar così presto. Esser potrebbe</l>
@@ -571,7 +599,7 @@
             <l>La cagion che ci affligge, ed avrem poi</l>
             <l part="I">Assai tempo a dolerci.</l>
           </sp>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l part="F">E' ver. L'amico</l>
             <l>A raggiunger tu corri: io d'Ipermestra</l>
@@ -623,26 +651,26 @@
           <head>SCENA SETTIMA</head>
           <stage>Logge interne nella reggia d'Argo. Veduta da un lato di vastissima campagna, irrigata dal fiume Inaco; e dall'altro di maestose ruine d'antiche fabbriche.</stage>
           <stage>DANAO e ADRASTO da diverse parti.</stage>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADR.</speaker>
             <l>Ah! signor, siam perduti. Il tuo segreto</l>
             <l part="I">Forse è noto a Linceo.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">Stelle! Ipermestra</l>
             <l>M'avrebbe mai tradito! Onde in te nasce</l>
             <l part="I">Questo timor? Vedesti il prence?</l>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADR.</speaker>
             <l part="F">Il vidi.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="I">Ti parlò?</l>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADR.</speaker>
             <l part="F">Lo volea: molto propose,</l>
             <l>Più volte incominciò; ma un senso intero</l>
@@ -655,32 +683,32 @@
             <l>L'idea di quell'aspetto,</l>
             <l>Di pietà, di spavento e di sospetto.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l>Ah! non tel dissi, Adrasto? Era Elpinice</l>
             <l>Migliore esecutrice</l>
             <l part="I">De' cenni miei.</l>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADR.</speaker>
             <l part="F">Di fedeltà mi parve</l>
             <l>Che assai ceder dovesse</l>
             <l part="I">La nipote alla figlia.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">A figlia amante</l>
             <l>Troppo fidai. Ma, se tradì l'ingrata</l>
             <l part="I">L'arcano mio, mi pagherà...</l>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADR.</speaker>
             <l part="F">Per ora</l>
             <l>L'ire sospendi, e pensa</l>
             <l>Alla tua sicurezza. E' delle squadre</l>
             <l part="I">Linceo l'amor: tutto ei potrebbe.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">Ah! corri,</l>
             <l>Va; di lui t'assicura, e fa... Ma temo</l>
@@ -688,7 +716,7 @@
             <l>Il colpo ha di periglio. Io mi confondo.</l>
             <l part="I">Deh! consigliami, Adrasto.</l>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADR.</speaker>
             <l part="F">Or nella reggia</l>
             <l>Farò che de' custodi</l>
@@ -701,13 +729,13 @@
             <l>L'immaturo riparo</l>
             <l part="I">Sollecita un periglio.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F"><stage>(l'abbraccia)</stage> Oh saggio, oh vero</l>
             <l>Sostegno del mio trono!</l>
             <l>Va: tutto alla tua fede io m'abbandono.</l>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADR.</speaker>
             <lg>
               <l>Più temer non posso ormai</l>
@@ -726,7 +754,7 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>DANAO, poi IPERMESTRA</stage>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l>Giunse Linceo dal campo, e a me fin ora</l>
             <l>Non comparisce innanzi! Ah! troppo è chiaro</l>
@@ -734,29 +762,29 @@
             <l>Placido mi ritrovi; e lo spavento</l>
             <l part="I">Non le insegni a tacer.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Posso, o signore,</l>
             <l>Sperar che i prieghi miei</l>
             <l>M'ottengano da te che pochi istanti</l>
             <l part="I">Senza sdegno m'ascolti?</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">E quando mai</l>
             <l>D'ascoltarti negai? Teco io non uso</l>
             <l>Sì rigidi costumi:</l>
             <l part="I">Parla a tua voglia.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">(Or m'assistete, o numi).</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l>(Mi scoprì: vuol perdono).</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l>Ebbi la vita in dono,</l>
             <l>Padre, da te: me ne rammento. E questo</l>
@@ -765,22 +793,22 @@
             <l>Che, per non farsi reo,</l>
             <l part="I">E' capace...</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">T'accheta: ecco Linceo.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l>Deh! permetti ch'io fugga</l>
             <l part="I">L'incontro suo.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">No; già ti vide, e troppo</l>
             <l>Il fuggirlo è sospetto: il passo arresta,</l>
             <l part="I">Seconda i detti miei.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">(Che angustia è questa!)</l>
           </sp>
@@ -788,14 +816,14 @@
         <div type="scene">
           <head>SCENA NONA</head>
           <stage>LINCEO e detti.</stage>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l>Ad un sì dolce invito</l>
             <l>Vien sì pigro Linceo? Tanto s'affretta</l>
             <l>A meritar mercede,</l>
             <l part="I">Sì poco a conseguirla?</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">I miei sudori,</l>
             <l>Le mie cure, la servitù costante,</l>
@@ -804,75 +832,75 @@
             <l>Signor, ch'oggi mi dài, degni non sono:</l>
             <l>Sol corrisponde al donatore il dono.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="I">(Doppio parlar!)</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">(Par che mirarmi, oh Dio!</l>
             <l part="I">Sdegni Ipermestra).</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">(Ah, che tormento è il mio!)</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l>Io sperai di vederti</l>
             <l part="I">Oggi più lieto, o prence.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">Anch'io sperai...</l>
             <l part="I">Ma... poi...</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">Perché sospiri?</l>
             <l>Qual disastro t'affligge?</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="I">Nol so.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="M">Come! nol sai?</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="M"> Signor...</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">Palesa</l>
             <l>L'affanno tuo: voglio saper qual sia.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l>Ipermestra può dirlo in vece mia.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l>Ma concedi ch'io parta. <stage>(a Danao</stage></l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l>No, tempo è di parlar. Dirmi tu déi</l>
             <l part="I">Quel che tace Linceo.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="M"><stage>(impaziente)</stage> Ma... padre...</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">Ah! veggo</l>
             <l>Quanto poco degg'io</l>
             <l>Da una figlia sperar. Conosco, ingrata...</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l>Ah! non sdegnarti seco,</l>
             <l>Signor, per me: non merita Linceo</l>
@@ -882,67 +910,67 @@
             <l>Tutto voglio soffrir; ma non mi sento</l>
             <l>Per vederla oltraggiar forze bastanti.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l>(Che fido amor! che fortunati amanti!)</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l>Il dubitar che possa</l>
             <l>Ipermestra sdegnar gli affetti tuoi,</l>
             <l>Prence, è folle pensiero:</l>
             <l part="I">Non crederlo.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">Ah, mio re, pur troppo è vero!</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l>Non so veder per qual ragion dovrebbe</l>
             <l part="I">Cangiar così.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="M">Pur si cangiò.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">Ne sai</l>
             <l part="I">Tu la cagion?</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">Volesse il Ciel! Mi scaccia</l>
             <l>Senza dirmi perché: questo è l'affanno</l>
             <l>Ond'io gemo, ond'io smanio, ond'io deliro.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="I">(Mi fa pietà).</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">(Nulla ei scoprì: respiro).</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l>Deh! principessa amata,</l>
             <l>Se veder non mi vuoi</l>
             <l>Disperato morir, dimmi qual sia</l>
             <l part="I">Almen la colpa mia.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">(Potessi in parte</l>
             <l part="I">Consolar l'infelice!)</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">(In lei pavento</l>
             <l part="I">Il troppo amor).</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">Bella mia fiamma, ascolta.</l>
             <l>Giuro a tutti gli dèi,</l>
@@ -953,38 +981,38 @@
             <l>Con questo stesso acciar, con questa destra</l>
             <l part="I">Voglio passarmi il cor.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="M"><stage>(a Linceo)</stage> Prence...</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F"><stage>(temendo che parli)</stage> Ipermestra!</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="I">Oh Dio!</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="M">Parla.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">Rammenta</l>
             <l part="I">Il tuo dover.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">(Che crudeltà! Non posso</l>
             <l part="I">Né parlar né tacer).</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">Né m'è concesso</l>
             <l>Di saper, mia speranza...</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l>Ma qual è la costanza, <stage>(con impeto</stage></l>
             <l>Che durar possa a questi assalti? Al fine</l>
@@ -997,15 +1025,15 @@
             <l>La virtù de' mortali. Astri tiranni,</l>
             <l>O datemi più forza, o meno affanni!</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l>Che smania intempestiva!</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l>Qual ignoto dolor, bella mia face?...</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l>Ah! lasciatemi in pace;</l>
             <l>Ah! da me che volete?</l>
@@ -1027,30 +1055,30 @@
         <div type="scene">
           <head>SCENA DECIMA</head>
           <stage>LINCEO e DANAO</stage>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l>Io mi perdo, o mio re. Quei detti oscuri</l>
             <l part="I">Quel pianto, quel dolor...</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">Non ti sgomenti</l>
             <l>D'una donzella il pianto. Esse son meste</l>
             <l>Spesso senza cagion; ma tornan spesso</l>
             <l part="I">Senza cagione a serenarsi.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">Ah! parmi</l>
             <l>Ch'abbia salde radici</l>
             <l>D'Ipermestra il dolor; né facilmente</l>
             <l>Si sana il duol d'una ferita ascosa.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l>Io ne prendo la cura: in me riposa. <stage>(parte</stage></l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l>Non che torni sì presto</l>
             <l>A serenarsi il ciel l'alma non spera:</l>
@@ -1076,12 +1104,12 @@
           <head>SCENA PRIMA</head>
           <stage>Galleria di statue e di pitture.</stage>
           <stage>DANAO e ADRASTO</stage>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l>Come! di me già cominciò Linceo</l>
             <l part="I">A sospettar?</l>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADR.</speaker>
             <l part="F">Qual maraviglia? E' forza</l>
             <l>Ch'ei cerchi la cagione onde Ipermestra</l>
@@ -1089,7 +1117,7 @@
             <l>Teme il nemico; e da' sospetti suoi</l>
             <l part="I">Danao esente non è.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">Mi gela, Adrasto,</l>
             <l>Quel dubbio, ancorché lieve e passeggiero.</l>
@@ -1098,7 +1126,7 @@
             <l>Un accento, uno sguardo... Ah! s'ei giungesse</l>
             <l part="I">Una volta a scoprir...</l>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADR.</speaker>
             <l part="F">Questo periglio</l>
             <l>Vidi, prevenni, e de' sospetti suoi</l>
@@ -1106,11 +1134,11 @@
             <l>Per opra mia, nel suo più caro amico</l>
             <l>Il rival corrisposto.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="I">In Plistene?</l>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADR.</speaker>
             <l part="F">In Plistene. Un de' miei fidi</l>
             <l>Cominciò l'opra; io la compii. Dubbioso</l>
@@ -1121,12 +1149,12 @@
             <l>Mendicate difese</l>
             <l part="I">I sospetti irritai.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">Ma qual profitto</l>
             <l part="I">Speri da ciò?</l>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADR.</speaker>
             <l part="F">Mille, signor. Disvio</l>
             <l>Ogni indizio da te; scemo la fede</l>
@@ -1134,12 +1162,12 @@
             <l>Se mai parlasse; e l'union disciolgo</l>
             <l part="I">Di due potenti amici.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">E' d'Ipermestra</l>
             <l part="I">Linceo troppo sicuro.</l>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADR.</speaker>
             <l part="F">Io l'ho veduto</l>
             <l>Già impallidir. La gelosia non trova</l>
@@ -1147,7 +1175,7 @@
             <l>Questa pianta funesta,</l>
             <l>Che per tutto germoglia ove s'innesta.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l>E' vero. E, se la figlia</l>
             <l>Ricusa d'ubbidir, possono appunto</l>
@@ -1155,13 +1183,13 @@
             <l>Alprimo mio pensiero; ed Elpinice</l>
             <l part="I">Il colpo eseguirà.</l>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADR.</speaker>
             <l part="F">Senza bisogno</l>
             <l>Non s'accrescano i rischi. Il buon si perde</l>
             <l part="I">Talor, cercando il meglio.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">Io non pretendo</l>
             <l>Far noto ad Elpinice il mio segreto</l>
@@ -1175,11 +1203,11 @@
             <l>Rendila ambiziosa; e a me del resto</l>
             <l part="I">Lascia il pensiero.</l>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADR.</speaker>
             <l part="M">Ubbidirò. Ma...</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">Veggo</l>
             <l>Ipermestra da lungi. Ad Elpinice</l>
@@ -1187,7 +1215,7 @@
             <l>Già di speranze accesa</l>
             <l>Tu la vedrai, di' che a me venga allora.</l>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADR.</speaker>
             <l>Signor, pria di parlar pensaci ancora.</l>
             <lg>
@@ -1207,19 +1235,19 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>DANAO, IPERMESTRA</stage>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l>Potrò pure una volta</l>
             <l part="I">Al mio padre, al mio re...</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">Vieni: io mi deggio</l>
             <l>Molto applaudir di tua costanza. In vero</l>
             <l>Ne dimostrasti assai</l>
             <l part="I">Nell'accoglier Linceo.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Signor, se giova</l>
             <l>Che tutto il sangue mio per te si versi;</l>
@@ -1230,12 +1258,12 @@
             <l>Impallidir sino al momento estremo.</l>
             <l>Ma, se chiedi un delitto, è vero, io tremo.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l>Eh! di' che più del padre</l>
             <l part="I">Linceo ti sta nel cor.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Nol niego, io l'amo:</l>
             <l>L'approvasti, lo sai. Ma il tuo comando</l>
@@ -1263,19 +1291,19 @@
             <l>Lagrime che a tuo pro verso dal ciglio,</l>
             <l>Amato genitor, cangia consiglio.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l>(Qual contrasto a que' detti</l>
             <l>Sento nel cor! Temo Linceo: vorrei</l>
             <l part="I">Conservarmi innocente).</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">(Ei pensa: ah! forse</l>
             <l>La sua virtù destai. Numi clementi,</l>
             <l part="I">Secondate quei moti).</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">(E' tardi: io sono</l>
             <l>Già reo nel mio pensiero). Odi, Ipermestra:</l>
@@ -1284,84 +1312,84 @@
             <l>Il carnefice mio. S'egli non muore,</l>
             <l part="I">Pace io non ho.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="M">Vano timor.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">Da questo</l>
             <l>Vano timor tu liberar mi déi.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="I">Né rifletti...</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">Io rifletto</l>
             <l>Che ormai troppo resisti e ch'io son stanco</l>
             <l>Di sì lungo garrir. Compisci l'opra:</l>
             <l part="I">Io lo chiedo, io lo voglio.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Ed io non posso</l>
             <l part="I">Volerlo, o genitor.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">Nol puoi? D'un padre</l>
             <l part="I">Così rispetti il cenno?</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Io ne rispetto</l>
             <l part="I">La gloria, la virtù.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">Temi sì poco</l>
             <l part="I">Lo sdegno del tuo re?</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Più del suo sdegno</l>
             <l part="I">Un fallo suo mi fa tremar.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">Tue cure</l>
             <l>Esser queste non denno.</l>
             <l part="I">Ubbidisci.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Perdona io sentirei</l>
             <l>Nell'impiego inumano</l>
             <l>Mancarmi il core, irrigidir la mano.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l>Dunque al maggior bisogno</l>
             <l part="I">M'abbandoni in tal guisa?</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Ogni altra prova...</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l>No, no, già n'ebbi assai. Veggo di quanto</l>
             <l>Son posposto a Linceo. Chi m'ha potuto</l>
             <l>Disubbidir per lui, per lui tradirmi</l>
             <l part="I">Ancor potrebbe.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="M">Io!</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">Sì: perciò ti vieto</l>
             <l>Di vederlo mai più. Pensaci. Ogni atto,</l>
@@ -1369,11 +1397,11 @@
             <l>Pensieri istessi a me saran palesi:</l>
             <l part="I">Ei morrà, se l'ascolti. Udisti?</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Intesi.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <lg>
               <l>Non hai cor per un'impresa</l>
@@ -1392,26 +1420,26 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>IPERMESTRA, poi PLISTENE</stage>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l>Nuova angustia per me. Come poss'io</l>
             <l part="I">Evitar che lo sposo...</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="F">Ah! principessa,</l>
             <l>Pietà del tuo Linceo. Confuso, oppresso,</l>
             <l>Come or lo veggo, io non l'ho mai veduto.</l>
             <l>Se tarda il tuo soccorso, egli è perduto.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l>Ma che dice, o Plistene?</l>
             <l>Che fa? che pensa? il mio ritegno accusa?</l>
             <l>M'odia? m'ama? mi crede</l>
             <l part="I">Sventurata o infedel?</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="F">Tanto io non posso</l>
             <l>Dirti, Ipermestra. Or più Linceo, qual era,</l>
@@ -1420,48 +1448,48 @@
             <l>Forse sol n'è cagion. Deh! lo consola</l>
             <l part="I">Or che a te vien.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="M"><stage>(con timore)</stage> Dov'è?</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="F">Nelle tue stanze</l>
             <l>Ti cerca in van; ma lo vedrai fra poco</l>
             <l part="I">Qui comparir.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">(Misera me!) Plistene,</l>
             <l>Soccorrimi, ti prego; abbi pietade</l>
             <l>Dell'amico e di me. Fa ch'ei non venga</l>
             <l part="I">Dove son io; mi fido a te.</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="F">Ma come</l>
             <l part="I">Posso impedir?</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Di conservar si tratta</l>
             <l>La vita sua. Più non cercar; né questo,</l>
             <l part="I">Ch'io fido a te, sappia Linceo.</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="F">Ma l'ami?</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="I">Più di me stessa.</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="F">Io nulla intendo. E puoi</l>
             <l>Lasciarlo a tanti affanni in abbandono?</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l>Ah, tu non sai quanto infelice io sono!</l>
             <lg>
@@ -1481,89 +1509,89 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>PLISTENE, poi LINCEO</stage>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l>Di qual nemico ignoto</l>
             <l>Ha da temer linceo? Perché non deggio</l>
             <l>Del suo rischio avvertirlo? E con qual arte</l>
             <l>Impedir potrò mai...</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="I">Ipermestra dov'è?</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="M"><stage>(confuso)</stage> Nol so.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F"><stage>(turbato)</stage> Nol sai?</l>
             <l part="I">Era teco pur or.</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="F">Sì... Ma... Non vidi</l>
             <l>Dove rivolse i passi, e non osai</l>
             <l part="I">Spiarne l'orme.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F"><stage>(con ironia)</stage> Il tuo rispetto ammiro.</l>
             <l part="I">Rinvenirla io saprò. <stage>(vuol partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="M"><stage>(agitato)</stage> Senti.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">Che brami?</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="I">Molto ho da dirti.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="M">Or non è tempo. <stage>(vuol partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="F">Amico,</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="I">Fermati; non partir.</l>
             <l part="F">Tanto t'affanni</l>
             <l part="I">Perch'io non vada ad Ipermestra?</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="F">Andrai:</l>
             <l part="I">Per or lasciala in pace.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">In pace? Io turbo</l>
             <l>Dunque la pace sua? Dunque tu sai</l>
             <l part="I">Che in odio le son io.</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="M">No.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">Che ad alcuno</l>
             <l part="I">Dispiaccia il nostro amor?</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="F">Nulla so dirti;</l>
             <l part="I">Tutto si può temer.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">Senti, Plistene:</l>
             <l>Se temerario a segno</l>
@@ -1579,7 +1607,7 @@
             <l>Se non potessi altrove,</l>
             <l>Sul tripode d'Apollo, in grembo a Giove.</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="I">(Son fuor di me).</l>
           </sp>
@@ -1587,30 +1615,30 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>ELPINICE e detti.</stage>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l part="F">Così turbato in volto</l>
             <l>Perché trovo Linceo? Con chi ti sdegni?</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l>Dimandane a Plistene: ei potrà dirlo</l>
             <l part="I">Meglio di me. Seco ti lascio. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="F"><stage>(trattenendolo)</stage> Ascolta.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="I">Abbastanza ascoltai. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="F">Linceo, perdona:</l>
             <l part="I">Trattenerti degg'io.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">Ma sai che troppo</l>
             <l>Ormai, prence, m'insulti e mi deridi?</l>
@@ -1619,12 +1647,12 @@
             <l>Io ne so, li rispetto, e tu ben vedi</l>
             <l part="I">Se gran prove io ne do. Ma... poi...</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="F">Se m'odi,</l>
             <l part="I">Un consiglio fedel...</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">Miglior consiglio</l>
             <l>Io ti darò. Le tue speranze audaci</l>
@@ -1646,24 +1674,24 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>ELPINICE e PLISTENE</stage>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="I">Addio, cara Elpinice. <stage>(partendo</stage></l>
           </sp>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l part="F">Ove t'affretti?</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="I">Su l'orme di Linceo. <stage>(come sopra</stage></l>
           </sp>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l part="F">Gran cose io vengo</l>
             <l part="I">A dirti...</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="F">Tornerò. Perdon ti chieggio:</l>
             <l>Per or l'amico abbandonar non deggio. <stage>(parte</stage></l>
@@ -1704,18 +1732,18 @@
           <head>SCENA OTTAVA</head>
           <stage>Innanzi, amenissimo sito ne' giardini reali, adombrato da ordinate altissime piante, che lo circondano: indietro, lunghi e spaziosi viali, formati da spalliere di fiori e di verdure; de' quali altri son terminati dal prospetto di deliziosi edifizi, altri dalla vista di copiosissime acque in varie guise artificiosamente cadenti.</stage>
           <stage>DANAO, ADRASTO e guardie.</stage>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="I">Tanto ardisce Linceo!</l>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADR.</speaker>
             <l part="F">Non v'è chi possa</l>
             <l>Ormai più trattenerlo. Ei nulla ascolta,</l>
             <l>Veder vuole Ipermestra; e, se la vede,</l>
             <l part="I">Tutto saprà.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">Vanne, ed un colpo al fine</l>
             <l>Termini... Ah! no: troppo avventuro. Un'altra</l>
@@ -1725,16 +1753,16 @@
             <l>Io possa prevenir: venga egli poi,</l>
             <l part="I">La vegga pur.</l>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADR.</speaker>
             <l part="F">Ma se la figlia amante...</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l>Vanne, non parlerà. Compisci solo</l>
             <l part="I">Tu quanto imposi.</l>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADR.</speaker>
             <l part="F">Ad ubbidirti io volo. <stage>(parte</stage></l>
           </sp>
@@ -1742,41 +1770,41 @@
         <div type="scene">
           <head>SCENA NONA</head>
           <stage>DANAO, IPERMESTRA e custodi.</stage>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="I">Ecco al paterno impero...</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">Olà! custodi,</l>
             <l>Celatevi d'intorno, e a un cenno mio</l>
             <l part="I">Siate pronti a ferir. <stage>(le guardie si nascondono</stage></l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="M">(Che fia?)</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F"><stage>(ad Ipermestra</stage> Linceo</l>
             <l part="I">Ora a te vien.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="M">L'eviterò.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">No: crede</l>
             <l>Che tu per altri arda d'amor; mi giova</l>
             <l>Molto il sospetto suo: se vivo il vuoi,</l>
             <l part="I">Disingannar nol déi.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Ma tu vietasti...</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l>Ed or che il vegga io ti comando. Ascoso</l>
             <l>Qui resto ad osservar. Se con un cenno</l>
@@ -1799,13 +1827,13 @@
         <div type="scene">
           <head>SCENA DECIMA</head>
           <stage>IPERMESTRA, DANAO celato,  poi Linceo</stage>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l>V'è qualche nume in cielo,</l>
             <l>Che si muova a pietà? che da me lunge</l>
             <l>Guidando il prence... Ah, son perduta! ei giunge.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l>Al fin, lode agli dèi, tutto è palese</l>
             <l>Il mistero, Ipermestra. Intendo al fine</l>
@@ -1813,14 +1841,14 @@
             <l>Tutta la storia io so. Sperasti in vano</l>
             <l part="I">Di celarti da me.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">No: teco mai</l>
             <l>Celarmi io non pensai. So che t'è noto</l>
             <l>Troppo il mio cor, che mi conosci appieno,</l>
             <l>Che ingannar non ti puoi. (Capisse almeno!)</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l>Pur troppo m'ingannai. Prima sconvolti</l>
             <l>Gli ordin di natura avrei temuti,</l>
@@ -1832,11 +1860,11 @@
             <l>Pensando al mio martìre,</l>
             <l>Cangiarti, abbandonarmi e non morire?</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="I">(Numi, assistenza! io non resisto).</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">Ingrata!</l>
             <l>Bel cambio in ver per tanto amor mi rendi,</l>
@@ -1854,42 +1882,42 @@
             <l>T'accendi a nuove faci!</l>
             <l part="I">Sai ch'io morrò di pena, e pure...</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F"><stage>(si trasporta</stage> Ah! taci,</l>
             <l>Prence, non più. Se d'un pensiero infido</l>
             <l part="I">Son rea... <stage>(s'arresta, vedendo il padre</stage></l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="M">Perché t'arresti?</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">(Oh Dio! l'uccido).</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="I">Siegui, termina almen.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F"><stage>(si ricompone)</stage> Se rea son io</l>
             <l>D'un infido pensier, da te non voglio</l>
             <l>Tollerarne l'accusa. Assai dicesti:</l>
             <l part="I">Basta così; parti, Linceo.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">T'affanna</l>
             <l>Tanto la mia presenza?</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l>Più di quel che non credi, e d'un affanno</l>
             <l part="I">Che spiegarti non posso.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">A questo segno</l>
             <l>Dunque son io?... Che tirannia! Mi lasci,</l>
@@ -1897,29 +1925,29 @@
             <l>L'aspetto mio, non vuoi che a te m'appressi,</l>
             <l>Giungi sino ad odiarmi, e mel confessi?</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="I">(Che morte!)</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">Addio per sempre. Io non so come</l>
             <l>Non mi tragga di senno il mio martìre.</l>
             <l part="I">Addio. <stage>(partendo</stage></l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="M">Dove, Linceo?</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">Dove? A morire.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="I">Ferma. (Aimè!)</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">Che vuoi dirmi?</l>
             <l>Che ho perduto il tuo cor? ch'io son l'oggetto</l>
@@ -1927,85 +1955,85 @@
             <l>Lo conosco, lo so. Voglio appagarti:</l>
             <l part="I">Perciò parto da te. <stage>(come sopra</stage></l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Senti, e poi parti.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="I">E ben, che brami?</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Io non pretendo... (Oh Dio!</l>
             <l>Mi mancano i respiri). Io la tua morte</l>
             <l>Non pretendo, non chiedo: anzi t'impongo</l>
             <l part="I">Che tu viva, Linceo.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">Tu vuoi ch'io viva?</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="I">&gt;Sì.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="M">Ma perché?</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Perché, se mori... Ah! parti,</l>
             <l part="I">Non tormentarmi più.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">Che vuol dir mai</l>
             <l>Cotesta smania tua? Direbbe forse</l>
             <l>Che il mio stato infelice...</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l>Dice sol che tu viva; altro non dice.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l>Ma, giusti dèi! tu vuoi che viva, e vuoi</l>
             <l>Dal cor, dagli occhi tuoi ch'io vada in bando?</l>
             <l part="I">E che deggio pensar?</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Ch'io tel comando.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <lg part="I">
               <l>Ah! se di te mi privi,</l>
               <l>Ah! per chi mai vivrò?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <lg part="F">
               <l>Lasciami in pace e vivi,</l>
               <l>Altro da te non vuo'.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <lg part="I">
               <l>Ma qual destin tiranno?...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <lg part="M">
               <l>Parti: nol posso dir.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#linceo #ipermestra">
             <speaker>A DUE</speaker>
             <lg part="F">
               <l>Questo è morir d'affanno</l>
@@ -2024,31 +2052,31 @@
           <head>SCENA PRIMA</head>
           <stage>Gabinetti.</stage>
           <stage>IPERMESTRA ed ELPINICE</stage>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l>Pure è così: vuol che il mio braccio adempia</l>
             <l part="I">Ciò che il tuo ricusò.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Ma come indurre</l>
             <l>Te ad un atto sì rei? d'un'altra sposa</l>
             <l>Rendere il prence amante,</l>
             <l part="I">Come Danao sperò?</l>
           </sp>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l part="F">Ciò che si brama</l>
             <l>Mai difficil non sembra. Egli ha creduto</l>
             <l>Linceo sedur con un geloso sdegno,</l>
             <l part="I">Me con l'esca d'un trono.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">E che dicesti</l>
             <l part="I">A sì fiera proposta?</l>
           </sp>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l part="F">Al primo istante</l>
             <l>L'orror m'istupidì; poi mi conobbi</l>
@@ -2060,16 +2088,16 @@
             <l>Un altro esecutor. Fuggir poss'io;</l>
             <l part="I">Posso avvertir Linceo.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F"><stage>(con timore</stage> Parlasti a lui?</l>
           </sp>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l>No; ma il dissi a Plistene: ei dell'amico</l>
             <l part="I">Corse subito in traccia.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Ah, che facesti,</l>
             <l>Sconsigliata Elpinice! a qual periglio</l>
@@ -2078,58 +2106,58 @@
             <l>Sospiri a' labbri miei, pianti alle ciglia;</l>
             <l part="I">E tu...</l>
           </sp>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l part="F">Ma, principessa, io non son figlia.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l>Va, per pietà, trova Plistene... E' meglio</l>
             <l>Che al padre io corra e lo prevenga... Oh Dio!</l>
             <l>Il colpo affretterò... Vedi a che stato</l>
             <l part="I">M'hai ridotta, Elpinice!</l>
           </sp>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l part="F">E pur credei...</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l>Parlisi con Linceo. Corri, t'affretta;</l>
             <l part="I">Ch'ei venga a me.</l>
           </sp>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l part="M">Volo a servirti. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Aspetta.</l>
             <l>Troppo arrischia, s'ei vien. De' sensi miei</l>
             <l>L'informi un foglio. Attendimi: a momenti</l>
             <l part="I">Tornerò. <stage>(come sopra</stage></l>
           </sp>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l part="F">Principessa,</l>
             <l part="I">Odi.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="M">Non m'arrestar. <stage>(come sopra</stage></l>
           </sp>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l part="F"> Linceo s'appressa.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l>Aimè! se 'l vede alcun... Ma fra due rischi</l>
             <l>Scelgo il minor. Corri a Plistene intanto;</l>
             <l>Di' che l'arcan funesto</l>
             <l part="I">Taccia, se non parlò.</l>
           </sp>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l part="F">Che giorno è questo! <stage>(parte</stage></l>
           </sp>
@@ -2137,29 +2165,29 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>IPERMESTRA e LINCEO</stage>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="I">Non creder già ch'io torni a te...</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F"><stage>(con fretta e premura)</stage> Vedesti</l>
             <l part="I">Plistene?</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="M">Il vidi, e l'evitai.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">(Respiro).</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l>E se qui ritrovarlo</l>
             <l part="I">Fra' labbri tuoi creduto avessi...</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Il tempo</l>
             <l>Alle nostre querele</l>
@@ -2167,12 +2195,12 @@
             <l>Ben più ragion di te. Fu menzognero</l>
             <l>Il tuo sospetto, ed il mio torto è vero.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l>Che! potrei lusingarmi</l>
             <l part="I">Della fé d'Ipermestra?</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Il chiedi? Ingrato!</l>
             <l>Sì poca intelligenza</l>
@@ -2182,12 +2210,12 @@
             <l>Più non mi leggi in volto? i merti tuoi,</l>
             <l part="I">La fede mia più non conosci?</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">Ah! dunque,</l>
             <l part="I">Cara, tu m'ami ancor?</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">S'io lo volessi,</l>
             <l>Non potrei non amarti. Ad altra face</l>
@@ -2196,80 +2224,80 @@
             <l>Del puro ardor che nel mio sen s'annida:</l>
             <l>Vorrei prima morir ch'esserti infida.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="I">Oh cari accenti! oh mio bel nume!</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">E pure</l>
             <l part="I">Solo un'ombra bastò...</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">Lo veggo, è vero:</l>
             <l part="I">Non merito perdon; ma...</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Di scusarti</l>
             <l>Lascia il peso al mio cor. Sarà sua cura</l>
             <l>Di trovarti innocente. Or da te bramo</l>
             <l part="I">Una prova d'amor.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">Tutto, mia speme,</l>
             <l part="I">Tutto farò.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="M">Me lo prometti?</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">Il giuro</l>
             <l part="I">Ai numi, a te.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Senza frappor dimore,</l>
             <l part="I">Fuggi d'Argo, se m'ami.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">E qual cagione...</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l>Questo cercar non déi. Questa è la prova</l>
             <l part="I">Ch'io domando a Linceo.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">Che dura legge!</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l>Barbara, è ver, ma necessaria. Addio:</l>
             <l part="I">Va.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="M">Senti.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Ah! prence amato,</l>
             <l>Troppo già mi sedusse</l>
             <l>Il piacer d'esser teco. Io perdo il frutto</l>
             <l part="I">Del mio dolor, se più rimango.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">E come?</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l>Non cercar come io sto. Se tu vedessi</l>
             <l>In che misero stato ora è il cor mio;</l>
@@ -2291,50 +2319,50 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>LINCEO poi PLISTENE</stage>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l>Qual sarà, giusti numi,</l>
             <l>Mai la cagion... Ma ciecamente io deggio</l>
             <l part="I">Il comando eseguir.</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="F"><stage>(affannato)</stage> Pur ti ritrovo,</l>
             <l part="I">Principe, al fin: sieguimi, andiamo.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">E dove?</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l>A punire un tiranno, a vendicarci</l>
             <l>De' nostri torti. I tuoi seguaci, i miei</l>
             <l part="I">Corriamo a radunar.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">Ma quale offesa...</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l>Danao ti vuole estinto: indir la figlia</l>
             <l>A svenarti non seppe: ad Elpinice</l>
             <l>Sperò di persuaderlo: essa la mano</l>
             <l>Promise al colpo, e mi svelò l'arcano.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l>Barbaro! Intendo adesso</l>
             <l>Le angustie d'Ipermestra. In questa guisa</l>
             <l part="I">Premia de' miei sudori...</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="F">Or di vendette,</l>
             <l part="I">Non di querele, è tempo. Andiam.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">Non posso,</l>
             <l>Caro Plistene. All'idol mio promisi</l>
@@ -2344,16 +2372,16 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>ELPINICE e detti.</stage>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l part="F">Udite.</l>
             <l part="I">Io gelo di timor.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="M">Che fu?</l>
           </sp>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l part="F">S'invia</l>
             <l>Alle stanze del re, condotta a forza</l>
@@ -2361,12 +2389,12 @@
             <l>Danao che teco ella parlò; né mai</l>
             <l part="I">Sì terribil ei fu.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">Contro una figlia</l>
             <l part="I">Che potrebbe tentar?</l>
           </sp>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l part="F">Tutto, o Linceo.</l>
             <l>Ei si conosce reo;</l>
@@ -2374,24 +2402,24 @@
             <l>Che il timor de' tiranni</l>
             <l part="I">Coi deboli è furor.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F"><stage>(risoluto)</stage> Plistene, accetto</l>
             <l>Le offerte tue: le mie promesse assolve</l>
             <l part="I">Il rischio d'Ipermestra.</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="F">Eccomi teco</l>
             <l part="I">A vincere o a morir. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l part="F">Dove correte</l>
             <l>Così senza consiglio? Ah! pria pensate</l>
             <l>Ciò che pensar conviensi.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l>Ipermestra è in periglio, e vuoi ch'io pensi?</l>
             <lg>
@@ -2411,13 +2439,13 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>ELPINICE e PLISTENE</stage>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l>Prence, e sai che avventuri</l>
             <l>I miei ne' giorni tuoi?</l>
             <l>Sai come io resto, e abbandonar mi puoi?</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <lg>
               <l>Vuoi ch'io lasci, o mio tesoro,</l>
@@ -2459,16 +2487,16 @@
           <head>SCENA SETTIMA</head>
           <stage>Luogo magnifico corrispondente a' portici ed appartamenti reali, tutto pomposamente adorno ed illuminato in tempo di notte.</stage>
           <stage>DANAO ed ADRASTO</stage>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADR.</speaker>
             <l part="I">Dove corri, o mio re?</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">Fuor della reggia</l>
             <l part="I">Un asilo a cercar.</l>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADR.</speaker>
             <l part="F">Chi ti difende</l>
             <l>Fra 'l popolo commosso? Ogni momento</l>
@@ -2479,13 +2507,13 @@
             <l>De' reali soggiorni,</l>
             <l>Fin ch'io gente raccolga e a te ritorni.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l>Ma quindi uscir potrai?</l>
             <l>Potrai tornar con la raccolta schiera?</l>
             <l part="I">Pensa...</l>
           </sp>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADR.</speaker>
             <l part="F">A tutto pensai: fidati e spera. <stage>(parte</stage></l>
           </sp>
@@ -2493,7 +2521,7 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>DANAO ed IPERMESTRA, fra' custodi.</stage>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l>Sei contenta, Ipermestra? Al caro amante</l>
             <l>Sagrificasti il genitor: trionfa</l>
@@ -2505,30 +2533,30 @@
             <l>Al tuo nome assicuri</l>
             <l>Fra le spose fedeli ai dì futuri.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="I">Padre, t'inganni: io non parlai.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">Pretendi</l>
             <l>Di deludermi ancor? Non vidi io stesso</l>
             <l part="I">Te con Linceo?</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="M">Ma non perciò...</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">T'accheta,</l>
             <l part="I">Figlia inumana, ingrata figlia!</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">E credi?...</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l>Credo ch'io son l'oggetto</l>
             <l>Dell'odio tuo; che di veder sospiri</l>
@@ -2536,7 +2564,7 @@
             <l>Del sangue mio; che tollerar non puoi</l>
             <l>Ch'io goda i rai del dì...</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <lg>
               <l>Ah! non mi dir così:</l>
@@ -2549,15 +2577,15 @@
               <l part="I">Un fulmine del Ciel...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>POPOLO</speaker>
             <l part="F"><stage>(di dentro)</stage> Mora il tiranno!</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="I">Ah, qual tumulto!</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="F">Ogni soccorso è lungi:</l>
             <l>Cader degg'io. Le mie ruine almeno</l>
@@ -2567,160 +2595,160 @@
         <div type="scene">
           <head>SCENA NONA</head>
           <stage>LINCEO, PLISTENE e seguaci, tutti con ispade nude alla mano, e detti.</stage>
-          <sp>
+          <sp who="#linceo #plistene">
             <speaker>LIN. e PLIST.</speaker>
             <l part="I">Mora, mora il tiranno!</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F"><stage>(opponendosi)</stage> Empi, fermate!</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="I">Lascia che un colpo al fin...</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">(si pone innanzi a Danao) Sì; ma comincia</l>
             <l>Da questo sen: per altra strada un ferro</l>
             <l part="I">Al suo non passerà.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="M">(Che ascolto!)</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="F">E' giusta</l>
             <l part="I">La pena d'un crudele.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">E voi chi fece</l>
             <l part="I">Giudici de' monarchi?</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">Il tuo periglio...</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="I">Questa è mia cura.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="M">E' un barbaro.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">E' mio padre.</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="I">E' un tiranno.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="M">E' il tuo re.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">T'odia, e il difendi?</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l>Il mio dover lo chiede.</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="I">Può toglierti la vita.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Ei me la diede.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="I">(Oh figlia!)</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="M">E vuoi, ben mio...</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Taci: tuo bene,</l>
             <l>Con quell'acciaro in pugno,</l>
             <l part="I">Non osar di chiamarmi.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="M">Amor...</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Se amore</l>
             <l>Persuade i delitti,</l>
             <l>Sento rossor della mia fiamma antica.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="I">Ma, sposa...</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Non è ver: son tua nemica.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l part="I">(Chi vide mai maggior virtù!)</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l part="F">Linceo,</l>
             <l>Troppo tempo tu perdi. Ecco da lungi</l>
             <l part="I">Mille spade appressar.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F"><stage>(con fretta)</stage> Vieni, Ipermestra;</l>
             <l part="I">Sieguimi almen.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">Non lo sperar: dal fianco</l>
             <l part="I">Del padre mio non partirò.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">T'esponi</l>
             <l part="I">Al suo sdegno, se resti.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l part="F">E, se ti sieguo,</l>
             <l>M'espongo del tuo fallo</l>
             <l part="I">Complice a comparir.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l part="F">Ma la tua vita...</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l>Ne disponga il destin. Meglio una figlia</l>
             <l>Spirar non può che al genitore accanto.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l>(Un sasso io son, se non mi sciolgo in pianto).</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l>Prence, ognun ci abbandona; Adrasto arriva.</l>
             <l>Fuggi, o perduto sei.</l>
           </sp>
-          <sp>
+          <sp who="#linceo">
             <speaker>LIN.</speaker>
             <l>Salvati, amico: io vuo' morir con lei. <stage>(getta la spada</stage></l>
           </sp>
@@ -2728,22 +2756,22 @@
         <div type="scene">
           <head>SCENA ULTIMA</head>
           <stage>ADRASTO con numeroso séguito, ELPINICE e detti.</stage>
-          <sp>
+          <sp who="#adrasto">
             <speaker>ADR.</speaker>
             <l>Occupate, o miei fidi, <stage>(alle guardie</stage></l>
             <l>Dell'albergo real tutte le parti.</l>
           </sp>
-          <sp>
+          <sp who="#plistene">
             <speaker>PLIST.</speaker>
             <l>Danao, non ingannarti</l>
             <l>Nell'inchiesta del reo: da me sedotto</l>
             <l>Fu il prence a prender l'armi; ei non volea.</l>
           </sp>
-          <sp>
+          <sp who="#elpinice">
             <speaker>ELP.</speaker>
             <l>Io, che svelai l'arcano, io son la rea.</l>
           </sp>
-          <sp>
+          <sp who="#ipermestra">
             <speaker>IPER.</speaker>
             <l>Padre, udisti fin ora</l>
             <l>Una figlia pietosa:</l>
@@ -2765,7 +2793,7 @@
             <l>La vita or mi saria; finisca ormai.</l>
             <l>A salvarti bastò: fu lunga assai.</l>
           </sp>
-          <sp>
+          <sp who="#danao">
             <speaker>DAN.</speaker>
             <l>Non più, figlia, non più: tu mi facesti</l>
             <l>Abbastanza arrossir. Come potrei</l>
@@ -2780,7 +2808,7 @@
             <l>Ceder dell'universo a te l'impero:</l>
             <l>Renderei fortunato il mondo intero.</l>
           </sp>
-          <sp>
+          <sp who="#adrasto #elpinice #ipermestra #danao #plistene #linceo">
             <speaker>TUTTI</speaker>
             <lg>
               <l>Alma eccelsa, ascendi in trono:</l>
@@ -2824,7 +2852,7 @@
           <l>Tutti i moti del cor limpidi e vivi;</l>
           <l>E facondia non v'è che a tanto arrivi.</l>
         </lg>
-        <sp>
+        <sp who="#coro">
           <speaker>CORO</speaker>
           <lg>
             <l>Per voi s'avvezzi Amore,</l>

--- a/tei/metastasio-issipile.xml
+++ b/tei/metastasio-issipile.xml
@@ -76,6 +76,31 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="issipile">
+            <persName>Issipile</persName>
+          </person>
+          <person xml:id="rodope">
+            <persName>Rodope</persName>
+          </person>
+          <person xml:id="eurinome">
+            <persName>Eurinome</persName>
+          </person>
+          <person xml:id="toante">
+            <persName>Toante</persName>
+          </person>
+          <person xml:id="learco">
+            <persName>Learco</persName>
+          </person>
+          <person xml:id="giasone">
+            <persName>Giasone</persName>
+          </person>
+          <person xml:id="coro">
+            <persName>Coro</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT-Pavia</name>Digitalizzazione</change>
@@ -133,7 +158,7 @@
           <stage>
             <p>ISSIPILE e RODOPE, coronate di pampini ed armate di tirso. Schiera di baccanti in lontano.</p>
           </stage>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l>Ah! per pietà del mio</l>
             <l>Giustissimo dolor, Rodope amica,</l>
@@ -143,14 +168,14 @@
             <l>Le congiure, i tumulti,</l>
             <l part="I">Le furie femminili.</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="F">E tu poc'anzi</l>
             <l>Non giurasti svenarlo? Io pur ti vidi</l>
             <l>Con intrepido volto</l>
             <l part="I">Su l'are atroci...</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Io secondai fingendo</l>
             <l>D'Eurinome il furor. Vedesti come</l>
@@ -164,23 +189,23 @@
             <l>Tutti gli dèi sollecitava il core;</l>
             <l>E l'ardir del mio volto era timore.</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="I">Anch'io...</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Se tardi, amica,</l>
             <l>Vana è la cura. Ah! che vicine al porto</l>
             <l>Son già le navi, e se non corri... Oh Dio!</l>
             <l part="I">Giunge Eurinome.</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="F">E come</l>
             <l>a pieno d'ira e di vendetta il ciglio!</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l>Suggeritemi, o dèi, qualche consiglio.</l>
           </sp>
@@ -190,7 +215,7 @@
           <stage>
             <p>EURINOME con séguito di donne vestite a guisa di baccanti, e dette.</p>
           </stage>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l>Rodope, principessa,</l>
             <l>Valorose compagne, a queste arene</l>
@@ -220,53 +245,53 @@
             <l>De' femminili sdegni</l>
             <l>Al sesso ingrato a serbar fede insegni.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l>Sì, sì, di morte è rea</l>
             <l>Chi pietosa si mostra.</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="I">(Come finge furor!)</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Rodope, corri:</l>
             <l>Già sai... Quando sul lido</l>
             <l>Saran discesi, ad avvertir ritorna.</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l>Inutil cura. Io stessa</l>
             <l>Fuor de' legni balzar vidi le squadre.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="I">Tu stessa?</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="M">Io stessa.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F"><stage>(vuol partire)</stage> (Ah! si prevenga il padre).</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="I">Dove corri?</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Alle navi. Il re vogl'io</l>
             <l>Rassicurar, celando</l>
             <l>Lo sdegno mio con accoglienza accorta.</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="I">E' tardi: ecco Toante.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">(Oh dèi! son morta).</l>
           </sp>
@@ -274,7 +299,7 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>Toante con sèguito di cavalieri e soldati lenni, e dette.</stage>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l>Vieni, o dolce mia cura,</l>
             <l>Vieni al paterno sen. Da te lontano,</l>
@@ -283,68 +308,68 @@
             <l>Or che appresso mi sei, <stage>(l'abbraccia</stage></l>
             <l>Il peso alleggerir degli anni miei.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="I">(Mi si divide il cor!)</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="F">Perché ritrovo</l>
             <l>Issipile sì mesta?</l>
             <l>Qual mai freddezza è questa</l>
             <l part="I">All'arrivo d'un padre?</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Ah! tu non sai...</l>
             <l part="I">Signor...</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="M">Taci! <stage>(piano ad Issipile</stage></l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="M">(Che pena!)</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="F">(Ah! mi tradisce</l>
             <l part="I">La debolezza sua).</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="F">La mia presenza</l>
             <l part="I">Ti funesta così?</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Non vedi il core:</l>
             <l part="I">Perciò... <stage>(Eurinome minaccia Issipile acciò non parli</stage></l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="M">Spiegati.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="M">
               <stage>Oh Dio! (Eurinome, come sopra</stage>
             </l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="F">Spiegati, o figlia:</l>
             <l>Se l'imeneo ti spiace</l>
             <l>Del prence di Tessaglia,</l>
             <l part="I">Che a momenti verrà...</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Dal primo istante</l>
             <l part="I">Che il vidi, l'adorai.</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="F">Forse, in mia vece</l>
             <l>Avvezzata a regnar, temi che sia</l>
@@ -355,20 +380,20 @@
             <l>Issipile adorata,</l>
             <l>Che viver teco e che morirti accanto. <stage>(l'abbraccia</stage></l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="I">Padre, non più. <stage>(bacia la destra a Toante e piange</stage></l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="F">Ma che vuol dir quel pianto?</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l>E' necessario effetto</l>
             <l>D'un piacer che improvviso inonda il petto.</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <lg>
               <l>So che riduce a piangere</l>
@@ -386,33 +411,33 @@
         </div>
         <div type="scene">
           <head>SCENA QUARTA</head>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="I">Issipile. <stage>(ad Issipile, che s'incammina appresso al padre</stage></l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="M">Che chiedi?</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="F">Ah! se non hai</l>
             <l>A trafigger Toante ardir che basti,</l>
             <l part="I">Lasciane il peso a noi.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Perché mi vuoi</l>
             <l>Involar questo vanto?</l>
             <l part="I">Fidati pur di me.</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="F">Prometti assai;</l>
             <l>Vuoi che di te mi fidi:</l>
             <l>Ma in faccia al padre impallidir ti vidi.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <lg>
               <l>Impallidisce in campo</l>
@@ -431,20 +456,20 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>EURINOME e RODOPE</stage>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l>Rodope, il giorno manca, e non conviene</l>
             <l>Più differire. Il concertato segno</l>
             <l>A momenti darò. Ma tu nel volto</l>
             <l part="I">Sembri confusa ancor.</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="F">L'età canuta</l>
             <l>Compatisco in Toante; il regio in lui</l>
             <l part="I">Carattere rispetto.</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="F">Eh! che il peggiore</l>
             <l>E' de' nostri nemici. In duro esiglio</l>
@@ -452,24 +477,24 @@
             <l>Ricordartene meglio. Il figlio in lui</l>
             <l part="I">Io perdei, tu l'amante.</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="F">Il suo delitto</l>
             <l>Tal pena meritò. Fingea d'amarmi,</l>
             <l>E tentava frattanto</l>
             <l part="I">Issipile rapir.</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="F">Rodope, io veggo</l>
             <l>Che alla tua debolezza</l>
             <l part="I">Scuse cercando vai.</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="F">Son donna al fine.</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l>E perché donna sei,</l>
             <l>Scuotere il giogo e vendicar ti déi.</l>
@@ -490,7 +515,7 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>RODOPE e poi LEARCO</stage>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l>Ma i numi in ciel che fanno? Un sol fra loro</l>
             <l>Non ve n'ha che protegga</l>
@@ -498,33 +523,33 @@
             <l>Oh terror!... Ma... traveggo?</l>
             <l part="I">Learco?</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Ah! non scoprirmi:</l>
             <l part="I">Taci, Rodope.</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="F">Oh dèi! tu vivi? Ognuno</l>
             <l part="I">Ti pianse estinto.</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Ad ingannar Toante</l>
             <l part="I">Tal menzogna inventai. </l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="F">Chi mai ti guida,</l>
             <l part="I">Sconsigliato! a perir? Fuggi.</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Un momento</l>
             <l>Mi sia permesso almeno</l>
             <l part="I">Di vagheggiarti.</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="F">Eh! d'ingannarmi adesso</l>
             <l>Non è tempo, Learco. E' il tuo ritorno</l>
@@ -533,11 +558,11 @@
             <l>Issipile si stringe, e qualche nera</l>
             <l part="I">Macchina ordisci.</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Ah! così reo non sono.</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l>Non più. Salvati, fuggi! Il nuovo giorno</l>
             <l>Tutti gli uomini estinti</l>
@@ -546,19 +571,19 @@
             <l>Barbare abitatrici. E questa è l'ora</l>
             <l part="I">Congiurata alla strage.</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">E tu mi credi</l>
             <l>Semplice tanto? Ad atterrirmi inventa</l>
             <l part="I">Argomento miglior.</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="F">Credimi, fuggi.</l>
             <l>Ti perdi, se disprezzi</l>
             <l part="I">La mia pietà.</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">La tua pietade ancora,</l>
             <l>Perdonami, è sospetta. Esser tradita</l>
@@ -566,7 +591,7 @@
             <l>T'interessi a tal segno? Ah! mal si crede</l>
             <l>Una virtù che l'ordinario eccede.</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <lg>
               <l>Perché l'altrui misura</l>
@@ -617,65 +642,65 @@
           <head>SCENA OTTAVA</head>
           <stage>Parte del giardino reale, con fontane rutiche da' lati e boschetto sacro a Diana in prospetto. Notte.</stage>
           <stage>ISSIPILE, TOANTE e poi di nuovo LEARCO in disparte.</stage>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l>Eccoci in salvo, o padre. E' questo il bosco</l>
             <l>Sacro a Diana. Il mio ritorno attendi</l>
             <l part="I">Fra quell'ombre celato.</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="F">E' questo, o figlia,</l>
             <l>L'imeneo di Giasone? E queste sono</l>
             <l part="I">Le tenere accoglienze?</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Ah! di querele</l>
             <l part="I">Non è tempo, signor. Celati.</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="F">Oh Dio!</l>
             <l>Tu ritorni ad esporti</l>
             <l part="I">All'ire femminili. <stage>(Learco s'avanza, e non veduto ascolta in disparte</stage></l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Il nostro scampo</l>
             <l>Assicuro così. Perché ti stimi</l>
             <l>Ciascuna estinto, accreditar l'inganno</l>
             <l part="I">Dee la presenza mia.</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="F">Ma come speri</l>
             <l part="I">Eurinome ingannar?</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">De' Lenni uccisi</l>
             <l>Uno si sceglierà, che, avvolto ad arte</l>
             <l>Nelle tue regie spoglie, il pianto mio</l>
             <l part="I">Esiga in vece tua.</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="F">Poco sicura</l>
             <l part="I">E' la frode pietosa.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Al fine in cielo</l>
             <l>V'è chi protegge i re, v'è chi seconda</l>
             <l part="I">Gl'innocenti disegni.</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="F">Ah! che per noi</l>
             <l part="I">Fausto nume non v'è.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Se poi congiura</l>
             <l>Tutto a mio danno, e, del tuo sangue in vece,</l>
@@ -687,7 +712,7 @@
             <l>Il cammin di virtù non ho smarrito;</l>
             <l>E il dover d'una figlia avrò compito. <stage>(parte</stage></l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l>Oh coraggio! oh virtù! Pensando solo</l>
             <l>Che a tal figlia io son padre,</l>
@@ -713,7 +738,7 @@
         <div type="scene">
           <head>SCENA NONA</head>
           <stage>LEARCO e poi TOANTE</stage>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l>Che ascoltai! Dunque il vero</l>
             <l>Rodope mi narrò. Che bell'inganno,</l>
@@ -724,32 +749,32 @@
             <l>Amor mi suggerisce. Ardir! Toante,</l>
             <l part="I">Toante. Ove si cela? <stage>(avvicinadosi al bosco</stage></l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="F">(Ignota voce</l>
             <l>Ripete il nome mio:</l>
             <l part="I">Che fia?)</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Misera figlia! Il padre istesso,</l>
             <l part="I">Non volendo, l'uccide. <stage>(affettando compassione</stage></l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="F">Olà! che dici?</l>
             <l part="I">Chi compiangi? Chi sei?</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F"><stage>(finge non udirlo)</stage> Se il re non trovo</l>
             <l>Issipile si perde.</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="I">Perché? Parla: son io.</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Lode agli dèi!</l>
             <l>Fuggi, fuggi da questa</l>
@@ -759,29 +784,29 @@
             <l>Se il sospetto s'avvera,</l>
             <l part="I">La pietà della figlia.</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="F">Io voglio almeno</l>
             <l part="I">Morire in sua difesa.</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Ah! se tu l'ami,</l>
             <l>Affrettati a fuggir. Non v'è di questa</l>
             <l>Difesa più sicura.</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l>E a chi di tanta cura</l>
             <l part="I">Son debitor?</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Non mi conosci? Io... sono...</l>
             <l>Deh! parti. Fra que' rami</l>
             <l>Veggo già lampeggiar l'armi rubelle.</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l>Vi placherete mai, barbare stelle? <stage>(parte frettoloso</stage></l>
           </sp>
@@ -815,11 +840,11 @@
           <head>SCENA UNDICESIMA</head>
           <stage>Sala d'armi illuminata, con simulacro della Vendetta nel mezzo.</stage>
           <stage>ISSIPILE e RODOPE</stage>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="I">Sentimi. Non fuggirmi. <stage>trattenendo Rodope</stage></l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="F">Ho troppo orrore</l>
             <l>Della tua crudeltà. Soffrir non posso</l>
@@ -828,18 +853,18 @@
             <l>Nelle vene d'un padre.</l>
             <l part="I">Lasciami.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="M">Se t'inganni!</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="F">Agli occhi miei</l>
             <l>Dunque non crederò? Nel regio albergo</l>
             <l>Io vidi il re trafitto, e tremo ancora</l>
             <l part="I">Di spavento e d'orror.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Vedesti, amica,</l>
             <l>In vece di Toante... Alcun s'appressa.</l>
@@ -851,62 +876,62 @@
         <div type="scene">
           <head>SCENA DODICESIMA</head>
           <stage>EURINOME e dette.</stage>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="F">Tra noi qualcuna</l>
             <l part="I">Mancò di fede.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="M">Onde il timor?</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="F">Respira</l>
             <l>Un de' nostri tiranni. Ei fu sorpreso</l>
             <l>In questo, che dal porto</l>
             <l>Introduce alla reggia, angusto varco.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="I">(Ah! forse è il padre mio).</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="F">(Forse è Learco!)</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l>Ravvisar lo potesti? <stage>(ad Eurinome</stage></l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="I">E' noto il nome suo? <stage>(ad Eurinome</stage></l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="F">Fra l'ombre avvolto,</l>
             <l>Distinguer non si può. Ma d'armi è cinto,</l>
             <l part="I">Ed ostenta coraggio.</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="M">E' preso? <stage>(ad Eurinome</stage></l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F"><stage>(ad Eurinome</stage> E' vinto?</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l>No, ma fra pochi istanti</l>
             <l>L'opprimeran le femminili squadre.</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="I">(Sconsigliato Learco!)</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">(Incauto padre!)</l>
           </sp>
@@ -914,45 +939,45 @@
         <div type="scene">
           <head>SCENA TREDICESIMA</head>
           <stage>GIASONE con ispada nuda, seguitando alcune amazzoni, e dette.</stage>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l>In vano all'ira mia <stage>(di dentro</stage></l>
             <l part="I">D'involarvi sperate. <stage>(esce)</stage> Eccovi... <stage>(nell'atto d'assalire Issipile, la conosce</stage></l>
           </sp>
-          <sp>
+          <sp who="#eurinome #rodope">
             <speaker>EUR. e ROD.</speaker>
             <l part="F">Oh numi!</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="I">Sposa!</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="M">Principe!</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">E' questa</l>
             <l>Pur la reggia di Lenno, o son le sponde</l>
             <l part="I">Dell'inospita Libia?</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Amato prence,</l>
             <l part="I">Qual nume ti salvò?</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">Vengo alle nozze,</l>
             <l part="I">E mi trovo fra l'armi!</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Almen dovevi</l>
             <l part="I">Avvertir che giungesti.</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">Anzi sperai</l>
             <l>D'un improvviso arrivo</l>
@@ -965,29 +990,29 @@
             <l>La schiera insidiosa</l>
             <l>Raggiungere, punir, trovo la sposa.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l>Rodope, va: prescrivi</l>
             <l>Che del tessalo prence</l>
             <l>Si rispetti la vita. Il nostro voto</l>
             <l>Solo i Lenni comprende. <stage>(parte Rodope</stage></l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="I">Di qual voto si parla?</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="F">Il sesso ingrato</l>
             <l>Fu punito da noi. Non vive un solo</l>
             <l part="I">Fra gli uomini di Lenno.</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">Oh stelle! E come</l>
             <l>Eseguir si poté sì reo disegno?</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l>Agevolò l'impresa</l>
             <l>La stanchezza e la notte. Altri l'acciaro,</l>
@@ -997,17 +1022,17 @@
             <l>Spirò trafitto; in cento guise e cento</l>
             <l>Si vestì d'amicizia il tradimento.</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="I">Io gelo! E 'l padre?</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Anch'ei spirò, confuso</l>
             <l>Nella strage comun. (Se scopro il vero,</l>
             <l part="I">Espongo il genitor).</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">Dunque i soggiorni</l>
             <l>Delle Furie son questi. Ah! vieni altrove</l>
@@ -1018,21 +1043,21 @@
             <l>Non resterà. Ne giuro</l>
             <l>Memorabil vendetta a tutti i numi.</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l>Il nome della rea</l>
             <l>Basterà per placarti.</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="I">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="F">Cara è a Giasone: avrà da lui</l>
             <l part="I">E perdono e pietà.</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">Sarò crudele</l>
             <l>Contro qualunque sia. Così mi serbi</l>
@@ -1040,63 +1065,63 @@
             <l>Di questa, a cui commise</l>
             <l part="I">Il fren de' miei pensieri.</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="F">Ella l'uccise.</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="I">Chi?</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="M">La tua sposa.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="M">(Oh Dio!)</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">Parla, difendi,</l>
             <l>Idol mio, la tua gloria.</l>
             <l>Un delitto sì nero</l>
             <l part="I">E' vero o no?</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">(Che duro passo!) E' vero. <stage>(prima di rispondere, guarda Eurinome</stage></l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="I">Come! <stage>(abbandona la mano d'Issipile, e resta immobile</stage></l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="M">(E' forza soffrir).</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">Sogno o deliro?</l>
             <l>Qual voce il cor m'offese?</l>
             <l>Issipile parlò? Giasone intese?</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l>Or s'adempia il tuo voto. Il re tradito</l>
             <l part="I">Vendica pur, se vuoi.</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">Vi sono in terra</l>
             <l part="I">Alme sì ree!</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Non condannar per ora,</l>
             <l part="I">Mio ben, la sposa tua.</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">Scostati, fuggi!</l>
             <l>Tu mia sposa? Io tuo bene? E chi potrebbe</l>
@@ -1106,11 +1131,11 @@
             <l>Se l'aure che respiri anch'io respiro;</l>
             <l>E mi sento gelar quando ti miro.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="I">(Quanto mi costi, o padre!)</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">Ov'è chi dice</l>
             <l>Che palesa il sembiante</l>
@@ -1119,11 +1144,11 @@
             <l>Di que' sguardi fallaci</l>
             <l part="I">Venga a mirar. <stage>(nel partire, si ferma vicino alla scena e guarda con meraviglia Issipile</stage></l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Perché mi guardi e taci?</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <lg>
               <l>Ti vo cercando in volto</l>
@@ -1140,17 +1165,17 @@
         <div type="scene">
           <head>SCENA QUATTORDICESIMA</head>
           <stage>ISSIPILE ed EURINOME</stage>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="I">Udisti? Oh Dio!</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="F">Non sospirar, ché perdi</l>
             <l>Tutto il merto dell'opra; e fanno oltraggio</l>
             <l>Quei segni di rimorso al tuo coraggio. <stage>(parte</stage></l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l>Dal cor dell'idol mio</l>
             <l>Un error che m'offende</l>
@@ -1178,7 +1203,7 @@
           <head>SCENA PRIMA</head>
           <stage>Di nuovo parte del giardino reale, con fontane rustiche da' lati e boschetto sacro a Diana nel mezzo. Notte.</stage>
           <stage>EURINOME e LEARCO in disparte.</stage>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l>Ah! che per tutto io veggo</l>
             <l>Qualche oggetto funesto,</l>
@@ -1191,28 +1216,28 @@
             <l>Non sospira il tragitto,</l>
             <l>E che val la sua pace il mio delitto.</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="I">(Ecco Issipile. Ardire!) <stage>(esce dal bosco</stage></l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="F">Alcun s'appressa.</l>
             <l>Numi! chi giunge mai?</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="I">Cara! <stage>(prende per la mano Eurinome, credendola Issipile</stage></l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="M">Chi sei? Qual voce! <stage>(scostandosi da Learco, spaventata</stage></l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">(Ah! m'ingannai). <stage>(torna nel bosco</stage></l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l>Misera me! Qual gelo</l>
             <l>Per le vene mi scorre! E' di Learco</l>
@@ -1237,7 +1262,7 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>ISSIPILE, frettolosa, e detta.</stage>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l>Qui pria di me dovrebbe</l>
             <l part="I">Esser Rodope giunta. Eccola. <stage>(s'incontra in Eurinome, e la crede Rodope</stage></l>
@@ -1249,7 +1274,7 @@
             <l>All'incontro venire, e 'l nostro scampo</l>
             <l part="I">Assicurar così. <stage>(va verso il bosco</stage></l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="F">Qual trama ignota</l>
             <l>La fortuna mi scopre! Intendo, o figlio,</l>
@@ -1262,7 +1287,7 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>ISSIPILE e LEARCO</stage>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l>Ecco le sacre piante, ove si cela</l>
             <l>L'amato genitore. Al primo arrivo,</l>
@@ -1270,51 +1295,51 @@
             <l>I miei passi confuse. Or non m'inganno.</l>
             <l part="I">Padre, signor, t'affretta.</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F"><stage>(uscendo dal bosco)</stage> (E' pur la voce</l>
             <l>Questa dell'idol mio. Coraggio! Oh dèi!</l>
             <l>Palpita il cor mentre m'appresso a lei).</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l>Vieni. Dove t'aggiri? I passi ascolto,</l>
             <l>E trovarti non so. Fra questo orrore</l>
             <l part="I">Forse... Pur t'incontrai. <stage>(incontra Learco, e la prende per mano</stage></l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">(M'assisti, Amore!)</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l>Tu tremi, o padre? Ah! non temer. Giasone</l>
             <l>Ci assicura la fuga. Ei, non ha molto,</l>
             <l part="I">Giunse al porto di Lenno.</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">(Aimè, che ascolto!)</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l>Già da lungi rimiro</l>
             <l part="I">Lo splendor delle faci...</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">(Io son perduto).</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l>E d'ascoltar già parmi</l>
             <l part="I">Le voci del mio ben.</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">(Torno a celarmi). <stage>(torna al bosco</stage></l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l>Dove vai? Perché fuggi? Oh, come mai</l>
             <l>Gli animi più virili</l>
@@ -1324,34 +1349,34 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>EURINOME, e seco baccanti ed amazzoni con faci accese ed armi, e detti.</stage>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="F">Olà! cingete,</l>
             <l>Compagne, il bosco intorno, ed ogni uscita</l>
             <l part="I">Del giardino reale.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">(Ah! fu presago</l>
             <l part="I">Di Toante il timor).</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="F">Scoperta sei.</l>
             <l part="I">Palesa il padre</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">(Ah, m'assistete, oh dèi!)</l>
             <l part="I">Mi si chiede un estinto?</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="F">Eh! di menzogne</l>
             <l>Or più tempo non è. V'è chi t'intese</l>
             <l>Chiamarlo a nome e ragionar con lui.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l>Pur troppo è ver. L'immagine funesta</l>
             <l>Sempre mi sta su gli occhi; in ogni loco</l>
@@ -1359,19 +1384,19 @@
             <l>Mi sgrida, mi rinfaccia</l>
             <l>Che vide per colpa mia il giorno estremo.</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="I">(Io gelo, e so che finge).</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">(Io fingo e tremo).</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="I">Eh! gl'inganni son vani.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Oh Dio! Nol vedi,</l>
             <l>Eurinome, tu stessa? Osserva il ciglio</l>
@@ -1385,69 +1410,69 @@
             <l>La face, oh Dio! caliginosa e nera,</l>
             <l>E i flagelli d'Aletto e di Megera.</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l>Misera principessa! Io sento in seno</l>
             <l part="I">Pietà per te.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">(Si commovesse almeno!)</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l>L'orror di queste piante</l>
             <l>E' di larve importune infausto nido:</l>
             <l>Ardetele, o compagne. In un istante</l>
             <l part="I">Vada in cenere il bosco.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Ah, no! fermate.</l>
             <l>Alla dea delle selve</l>
             <l part="I">Sacre son quelle piante.</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="F">Eh! non si ascolti.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l>Dunque neppur gli dèi dal tuo furore,</l>
             <l>Empia! saran sicuri? Il reo comando</l>
             <l part="I">Vi sarà chi eseguisca?</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="F">Incauta, oh come</l>
             <l>Tradisci il tuo segreto! Ecco la selva</l>
             <l>Dove ascoso è Toante. Andate, amiche:</l>
             <l part="I">Traetelo al supplizio. <stage>(entrano le mazzoni nel bosco di Diana</stage></l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Aimè! Sentite.</l>
             <l>Misera! che farò? Numi del cielo,</l>
             <l part="I">Eurinome, pietà!</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="F">Del figlio mio</l>
             <l part="I">Non l'ebbe il padre tuo.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Se tanto sei</l>
             <l>Avida di vendetta, aprimi il seno;</l>
             <l>Feriscimi per lui. Supplice, umìle</l>
             <l part="I">Eccomi a' piedi tuoi. <stage>(s'inginocchia</stage></l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="F">(Sento quel pianto</l>
             <l>Lo sdegno intiepidir).</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l>Placati, o cambia</l>
             <l>Oggetto al tuo furor. Per quanto accoglie</l>
@@ -1455,7 +1480,7 @@
             <l>Per le ceneri istesse</l>
             <l part="I">Del tuo caro Learco...</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="F">Ah! questo nome</l>
             <l>Rinnova il mio furor. Mora il tiranno, <stage>(snuda la spada</stage></l>
@@ -1463,15 +1488,15 @@
             <l>Fin che del sangue suo fatto vermiglio</l>
             <l part="I">Quest'acciaro non veggo. <stage>(crede incontrar Toante; ma, nell'atto di rivoltarsi, incontrandosi in Learco, che vien condotto dalle amazzoni fuori del bosco, resta immobile e le cade la spada di mano</stage></l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="M">Ah, madre!</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="F">Ah, figlio!</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l>Che avvenne! Io son di sasso. <stage>(s'alza</stage></l>
           </sp>
@@ -1479,21 +1504,21 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>RODOPE e detti.</stage>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l>(Dèi! Learco in catene!</l>
             <l>Come salvarlo mai? Finger conviene).</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="I">Sei pur tu? Son pur io?</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Così nol fossi,</l>
             <l>Per soverchia pietà madre crudele!</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l>Misera me! T'uccido</l>
             <l>Dunque per vendicarti? Ah! torni in vita</l>
@@ -1502,49 +1527,49 @@
             <l>Di questi amari amplessi</l>
             <l part="I">L'inumano piacer!</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="F">Compagne, il reo</l>
             <l>Ad un tronco s'annodi, e segno sia</l>
             <l part="I">Alle nostre saette. <stage>(le amazzoni legano Learco ad un tronco</stage></l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="F">Ah, no! crudeli...</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l>Eurinome si tragga</l>
             <l>A forza altrove, onde non turbi l'opra</l>
             <l part="I">Il materno dolor.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Misera madre!</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="I">Pietà, Rodope!</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="F">E vuoi</l>
             <l>L'istesse leggi tue porre in oblio?</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="I">Issipile, pietà!</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Che far poss'io?</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l>S'affretti la sua morte,</l>
             <l>Se il partir differisce anche un momento.</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l>Oh tormento maggior d'ogni tormento!</l>
             <lg>
@@ -1564,24 +1589,24 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>ISSIPILE, RODOPE, LEARCO</stage>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l>Vedi nella mia sorte</l>
             <l>I funesti trofei di tua bellezza,</l>
             <l>Issipile crudele. Al duro passo</l>
             <l part="I">Giungo per troppo amarti.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Il fabbro sei</l>
             <l part="I">Tu della tua sventura.</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Era già scritta</l>
             <l>Ne' volumi del fato allor ch'io nacqui.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l>Infelice momento in cui ti piacqui!</l>
             <lg>
@@ -1599,7 +1624,7 @@
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>RODOPE e LEARCO</stage>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l>Compagne, in questo loco</l>
             <l>A Nemesi men grata</l>
@@ -1610,46 +1635,46 @@
             <l>La schiera vincitrice. Io resto intanto</l>
             <l part="I">In custodia del reo. <stage>(partono le baccanti e le amazzoni</stage></l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Così tiranna</l>
             <l part="I">Rodope non credei.</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="F">Conosci, ingrato,</l>
             <l>Meglio la mia pietà. Finsi rigore,</l>
             <l>Per deluder l'insano</l>
             <l part="I">Femminile furore.</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Se dici il vero,</l>
             <l part="I">Disponi del cor mio.</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="F">Da te non bramo</l>
             <l part="I">Un pattuito amor.</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Forse non credi</l>
             <l>I miei detti veraci?</l>
             <l part="I">Giuro agli dèi...</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="F">Taci, Learco, taci.</l>
             <l>Non voglio che 'l mio dono</l>
             <l>Ti costi uno spergiuro. Ecco: ti rendo</l>
             <l>E libertade e vita. <stage>(lo scioglie</stage></l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l>Ma della tua pietà qual premio avrai?</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l>Già premiata son io, ma tu nol sai.</l>
             <lg>
@@ -1731,7 +1756,7 @@
         <div type="scene">
           <head>SCENA DECIMA</head>
           <stage>GIASONE che dorme, e poi LEARCO</stage>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l>Abbastanza sin ora</l>
             <l>Malvagio io fui. Di variar costume,</l>
@@ -1757,13 +1782,13 @@
         <div type="scene">
           <head>SCENA UNDICESIMA</head>
           <stage>ISSIPILE, LEARCO, GIASONE che dorme </stage>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Il genitore</l>
             <l>Dove mai troverò? Forse... Learco!</l>
             <l part="I">Perché stringi quel ferro?</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F"><stage>(fra sé)</stage> Ignota al mondo</l>
             <l>Sarà questa virtù. S'io non l'uccido,</l>
@@ -1773,53 +1798,53 @@
             <l>Questa pietà, che inopportuna usai.</l>
             <l part="I">Si vibri il colpo! <stage>(s'incammina in atto di ferire</stage></l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Ah, traditor, che fai! <stage>(trattenendogli il braccio</stage></l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="I">Lasciami.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="M">Non sperarlo.</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Il ferro io cedo,</l>
             <l part="I">Se meco vieni.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Un fulmine di Giove</l>
             <l part="I">M'incenerisca pria.</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Dunque per lui</l>
             <l part="I">Non aspettar pietà. <stage>(tenta liberare il braccio</stage></l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Vedi ch'io desto</l>
             <l part="I">Lo sposo, e sei perduto.</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Ah, taci! Io parto.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l>No. La man disarmata</l>
             <l part="I">M'abbandoni l'acciaro.</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Eccolo, ingrata! <stage>(Learco pensa un momento; e poi lascia lo stile in mano d'Issipile</stage></l>
             <l>Prence, tradito sei! <stage>(scuote Giasone e fugge</stage></l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="I">Ferma! <stage>(Giasone si sveglia; s'alza con impeto; e, nell'atto di volere snudare la spada, s'avvede d'Issipile, che tiene impugnato lo stile, e resta sorpreso</stage></l>
           </sp>
@@ -1827,15 +1852,15 @@
         <div type="scene">
           <head>SCENA DODICESIMA</head>
           <stage> GIASONE  ED ISSIPILE</stage>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">Chi mi tradisce? Eterni dèi!</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="I">Sposo!</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">Ah! barbara donna,</l>
             <l>Io che ti feci mai? Di qual delitto</l>
@@ -1845,62 +1870,62 @@
             <l>Empia! spogliar vorresti,</l>
             <l>Perché al tuo fallo un testimon non resti.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l>Può radunar la sorte</l>
             <l>Più sventure per me! Signor, t'inganni:</l>
             <l part="I">Io non venni a svenarti.</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">E quell'acciaro,</l>
             <l>E quel volto smarrito, e quella voce,</l>
             <l>Che tua non fu, che mi destò dal sonno,</l>
             <l>Non ti convince assai?</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l>Altri tentò svenarti: io ti salvai.</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l>Sì, veramente ho grandi</l>
             <l>Prove di tua pietà. Chi uccise un padre,</l>
             <l part="I">Custodirà lo sposo.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Io non l'uccisi.</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="I">Ma se 'l tuo labbro...</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Il labbro</l>
             <l part="I">Fu forzato a mentir.</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">Se il re trafitto</l>
             <l part="I">Nella reggia vid'io!</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Veder ti parve,</l>
             <l part="I">Ma non vedesti il re.</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">Dunque Toante</l>
             <l part="I">Additami dov'è.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Ne cerco in vano.</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l>Perfida! e crederesti</l>
             <l>Così stolto Giasone? Anche il disprezzo</l>
@@ -1914,57 +1939,57 @@
             <l>Tessaglia non produce</l>
             <l>Gli abitatori suoi semplici tanto.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="I">Vedrai...</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">Vidi abbastanza.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="I">Né vuoi...</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="M">Né voglio udirti.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="M">E credi...</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">E credo</l>
             <l>Che son reo, se t'ascolto.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="I">Dunque...</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="M">Parti.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">E l'amore?</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="I">Con rossor lo rammento.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="M">E sono?...</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">E sei</l>
             <l>Oggetto di spavento agli occhi miei.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l>Ah! Furie abitatrici</l>
             <l>Di quest'orride sponde, intendo, intendo:</l>
@@ -1972,60 +1997,60 @@
             <l>Di cui miro vermiglio il suol natio:</l>
             <l>Saziatevi una volta; eccovi il mio. <stage>(vuol ferirsi</stage></l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="I">Fermati. <stage>(la trattiene</stage></l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Che pretendi?</l>
             <l>Chi la mia morte a trattener ti muove?</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l>Mori, se vuoi morir; ma mori altrove. <stage>(le toglie e getta lo stile</stage></l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="I">Almen...</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">Lasciami in pace.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="I">Ascoltami.</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">Non voglio.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="I">Uccidimi.</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="M">Non posso.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Un sguardo solo.</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l>E' delitto il mirarti.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="I">Idol mio, caro sposo.</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">O parto, o parti.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <lg>
               <l>Parto, se vuoi così;</l>
@@ -2044,7 +2069,7 @@
         <div type="scene">
           <head>SCENA TREDICESIMA</head>
           <stage>GIASONE, poi TOANTE</stage>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l>Partì: lode agli dèi.</l>
             <l>Vi seducea quel pianto</l>
@@ -2053,26 +2078,26 @@
             <l>Vadasi omai. La lontananza estingua</l>
             <l part="I">Un vergognoso amor.</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="F">Principe! amico!</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l>Signor! M'inganno, o sei</l>
             <l part="I">Tu di Lenno il regnante?</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="F">Almen lo fui.</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l>Son fuor di me. Come risorgi? Estinto</l>
             <l>Nell'albergo real ti vidi io stesso:</l>
             <l>O sognava in quel punto, o sogno adesso.</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l>Vedesti un infelice</l>
             <l>Avvolto in regie spoglie; e quel sembiante,</l>
@@ -2080,23 +2105,23 @@
             <l>Altri ingannò. Questa pietosa frode</l>
             <l>Issipile inventò per mia difesa.</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l>Ah, di tutto innocente</l>
             <l>Dunque è la sposa mia! Toante, or ora</l>
             <l part="I">Ritorno a te. <stage>(in atto di partire con fretta</stage></l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="M">Perché mi lasci?</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">Io voglio</l>
             <l>Raggiungere il mio ben. Saprai, saprai</l>
             <l part="I">Quanto, ingiusto, l'offesi. <stage>(come sopra</stage></l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="F">Odi: che fai?</l>
             <l>Le femminili schiere,</l>
@@ -2106,18 +2131,18 @@
             <l>Né il tuo sangue risparmi,</l>
             <l part="I">Né difendi la sposa.</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F"><stage>(verso le tende</stage> All'armi! all'armi!</l>
             <l>Destatevi, sorgete,</l>
             <l part="I">Seguitemi, o compagni!</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="F">A' vostri passi</l>
             <l part="I">Io servirò di scorta.</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">Ah, no! Saresti</l>
             <l>Impaccio e non difesa. In mezzo all'ire,</l>
@@ -2168,7 +2193,7 @@
           <head>SCENA PRIMA</head>
           <stage>Luogo rimoto fra la città e la marina, adorno di cipressi e di monumenti degli antichi re di Lenno.</stage>
           <stage>LEARCO con due pirati suoi seguaci, e poi TOANTE</stage>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l>Ogni nostra speranza</l>
             <l>Fu vana, amici. Alle più belle imprese</l>
@@ -2178,17 +2203,17 @@
             <l>Per queste vie romite.</l>
             <l>Facciam l'ultima prova. Amici, udite. <stage>(tornano i pirati, a' quali, tratti in disparte, Learco parla in voce sommessa</stage></l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l>Nelle tessale tende</l>
             <l>Restar dovrei, ma voi non tollerate,</l>
             <l part="I">Affetti impazienti.</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Udiste? Andate. <stage>(a' pirate, che partono</stage></l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l>Sollecito, dubbioso,</l>
             <l>Palpito, non ho pace. Ogni momento</l>
@@ -2197,45 +2222,45 @@
             <l>Più solitaria parte</l>
             <l part="I">Alla reggia n'andrò. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">(Learco, all'arte!)</l>
             <l>Signor, soffri al tuo piede <stage>(se gl'inginocchia innanzi</stage></l>
             <l part="I">Il vassallo più reo...</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="F">Tu vivi! Oh numi!</l>
             <l part="I">Sei Learco o nol sei?</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Learco io sono.</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="I">Che pretendi da me?</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Morte o perdono.</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l>Traditor! non offrirti</l>
             <l part="I">Al mio sguardo mai più. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Sentimi, e poi <stage>(s'alza e lo siegue</stage></l>
             <l part="I">Discacciami, se vuoi.</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="F">Non sai qual pena,</l>
             <l>Perfido! a te si serba in questo lido?</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l>La morte io meritai,</l>
             <l>Signor, quando tentai</l>
@@ -2257,42 +2282,42 @@
             <l>Lo spirto mi divide,</l>
             <l>E' pietoso con me quando m'uccide.</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l>(Quel disperato affanno</l>
             <l>Scema l'orror della sua colpa antica).</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l>(Quanto tarda a venir la schiera amica!) <stage>(impaziente verso la scena</stage></l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l>Da' tuoi disastri impara</l>
             <l>A rispettar, Learco,</l>
             <l>In avvenir la maestà del trono.</l>
             <l>Riconsolati e vivi. Io ti perdono. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l>Ah! signor, tu mi lasci</l>
             <l>Dubbioso ancor, se un più sicuro pegno</l>
             <l part="I">Non ho di tua pietà.</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="F">Dopo il perdono</l>
             <l>Che di più posso darti?</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="I">La tua destra real.</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="F">Prendila, e parti.</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l>O de' numi clementi <stage>(va allungando queste parole, per dar tempo che giungano i compagni</stage></l>
             <l>Pietoso imitator, questo momento</l>
@@ -2301,37 +2326,37 @@
             <l>E dubbioso e tremante</l>
             <l>Eccomi alle tue piante... E in umil atto... <stage>(mentre vuole inginocchiarsi e prender la mano al re, escono i corsari armati, che circondano Toante</stage></l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="I">Qual gente ne circonda?</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Il colpo è fatto! <stage>(lascia la mano di Toante, sorge, ed abbandona l'affettata umiltà, da lui finta sin ora</stage></l>
             <l part="I">Cedimi quella spada. <stage>(a Toante</stage></l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="F">A chi ragioni?</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="I">Parlo con te.</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="F">Meco favelli? Oh dèi!</l>
             <l part="I">Come...</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Non più: mio prigionier tu sei.</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="I">Qual nera frode!</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Al fine</l>
             <l>Cadesti ne' miei lacci. Arbitro io sono</l>
@@ -2340,11 +2365,11 @@
             <l>All'evento felice il reo succede.</l>
             <l>Or tocca a te di domandar mercede.</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="I">Scellerato!</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Toante,</l>
             <l>Cambia linguaggio. Un grande esempio avesti</l>
@@ -2353,7 +2378,7 @@
             <l>Necessaria virtù. Pendon quell'armi</l>
             <l part="I">Dal mio cenno; e poss'io...</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="F">Che puoi tu farmi?</l>
             <l>Puoi togliermi l'avanzo</l>
@@ -2361,16 +2386,16 @@
             <l>Che mi rese molesta</l>
             <l>Degli anni il peso e degli affanni miei.</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l>Anch'io dissi così, ma nol credei.</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l>V'è però gran distanza</l>
             <l part="I">Dal mio core al tuo cor.</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Fole son queste.</l>
             <l>Ogni animal, che vive,</l>
@@ -2379,7 +2404,7 @@
             <l>Che affettano gli eroi ne' casi estremi.</l>
             <l>Io ti leggo nell'alma, e so che tremi.</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l>Tremerei, se credessi</l>
             <l>D'esser simile a te; ché avrei su gli occhi</l>
@@ -2388,13 +2413,13 @@
             <l>Il fulmine di Giove,</l>
             <l part="I">Punitor de' malvagi.</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">A questo segno</l>
             <l>Non è l'ira celeste</l>
             <l part="I">Terribile per me.</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="F">Fole son queste.</l>
             <l>Tranquillo esser non puoi.</l>
@@ -2409,24 +2434,24 @@
             <l>L'idea del giusto e dell'onesto i semi.</l>
             <l>Io ti leggo nell'alma, e so che tremi.</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l>Questo de' cori umani</l>
             <l>Saggio conoscitor traete, amici,</l>
             <l>Prigioniero alle navi. E tu deponi</l>
             <l>Quell'inutile acciaro. <stage>(a Toante</stage></l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="I">Prendilo, traditor! <stage>(getta la spada</stage></l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Dovresti ormai</l>
             <l>Quell'orgoglio real porre in oblio.</l>
             <l>Toante è il vinto: il vincitor son io.</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <lg>
               <l>Guardami prima in volto,</l>
@@ -2445,23 +2470,23 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>LEARCO e poi RODOPE</stage>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l>E pur quel regio aspetto</l>
             <l>Quel parlar generoso... Eh! non si pensi</l>
             <l>Che al piacer d'un acquisto</l>
             <l part="I">Che può farmi felice.</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="F"><stage>(spaventata)</stage> Oh Dio! Learco!</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l>Qual è del tuo spavento,</l>
             <l part="I">Rodope la cagion?</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="F">Quindi non lunge,</l>
             <l>Stuol di gente straniera al mar conduce</l>
@@ -2472,11 +2497,11 @@
             <l>Puoi cancellar, se vuoi. Poi del nome tuo</l>
             <l part="I">La memoria eternar.</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Gran sorte! E come?</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l>Va, combatti, procura</l>
             <l>Di liberar Toante. Offri la vita</l>
@@ -2485,7 +2510,7 @@
             <l>Ogni fallo passato,</l>
             <l>E mi tolga il rossor d'averti amato.</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l>Generoso è il consiglio, e per mercede</l>
             <l>Merita un disinganno. E' mio comando</l>
@@ -2513,14 +2538,14 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>RODOPE poi ISSIPILE</stage>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l>E tanta si ritrova</l>
             <l>Malvagità fra noi? Misera figlia!</l>
             <l>Principessa infelice! A tal novella</l>
             <l part="I">Qual diverrai!</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Son terminati, amica,</l>
             <l>Tutti gli affanni nostri. E' stanco il Cielo</l>
@@ -2531,55 +2556,55 @@
             <l>Noi vincitrici, ogni discordia tace:</l>
             <l>Tutto è amor, tutto è fede e tutto è pace.</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="I">Ma Toante però...</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Toante aspetta</l>
             <l>Nelle tessale tende</l>
             <l part="I">Di Giasone il ritorno.</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="F">Ah, fosse vero!</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="I">Perché? Parla!</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="F">Toante è prigioniero.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="I">E di chi?</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="M">Di Learco.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Onde il sapesti?</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l>Fra' seguaci dell'empio</l>
             <l part="I">Avvinto l'incontrai.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Ma quali sono</l>
             <l>Di Learco i seguaci?</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="I">Gente simile a lui.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Numi del cielo!</l>
             <l>A che mai di funesto</l>
@@ -2589,39 +2614,39 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>GIASONE con Argonauti, e dette.</stage>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l>Issipile, mio ben, qual nuovo affanno</l>
             <l part="I">Oscura i lumi tuoi?</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Sposo adorato,</l>
             <l>Opportuno giungesti. Ah! puoi tu solo</l>
             <l>Consolarmi, se vuoi. Corri... Difendi...</l>
             <l part="I">Abbi pietà di me!</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">Spiegati. Ancora</l>
             <l part="I">Intenderti non so.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Toante... Il padre...</l>
             <l part="I">Learco... Ah, mi confondo!</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="F">Al mar conduce</l>
             <l>Il traditor Learco</l>
             <l part="I">Incatenato il re.</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">L'istesso è forse...</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l>Sì, quel Learco istesso,</l>
             <l>Che te dal sonno oppresso</l>
@@ -2629,18 +2654,18 @@
             <l>Funestar co' sospetti</l>
             <l part="I">Volle la nostra pace.</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">Anima rea!</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l>Principe generoso, ecco un'impresa</l>
             <l>Degna di te. Perdi la sposa,</l>
             <l>Se lui non salvi. E' ad un sol filo unita</l>
             <l>La vita di Toante e la mia vita.</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l>Lasciami il peso, o cara,</l>
             <l>Di punire il fellon. Ma tu rasciuga</l>
@@ -2664,14 +2689,14 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>RODOPE ed ISSIPILE</stage>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l>Ma troppo, o principessa,</l>
             <l>T'abbandoni al dolor. Sempre la sorte</l>
             <l>Non ti sarà severa.</l>
             <l>Di Giasone al valor fidati e spera.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <lg>
               <l>Ch'io speri? Ma come?</l>
@@ -2692,48 +2717,48 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>RODOPE ed EURINOME</stage>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l>Io mi perdo in sì grande</l>
             <l part="I">Numero di sventure.</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="F">Il figlio mio,</l>
             <l part="I">Rodope, dove andò?</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="F">Pensa, inumana!</l>
             <l>Pensa a te stessa. Al vincitor t'ascondi,</l>
             <l part="I">Se t'è cara la vita.</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="F">Io non la curo,</l>
             <l part="I">Se non trovo Learco.</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="F">Un nome oblia,</l>
             <l>Ch'odio è del mondo, e tua vergogna e mia.</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l>Tanto sdegno perché? Tu lo salvasti...</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="I">E ne sento dolor.</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="F">Spero che sia</l>
             <l>Simulata quest'ira. Un'altra volta</l>
             <l>Dicesti ancor che lo bramavi oppresso,</l>
             <l part="I">E l'adoravi allor.</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="F">Ma l'odio adesso.</l>
             <lg>
@@ -2779,7 +2804,7 @@
           <head>SCENA OTTAVA</head>
           <stage>Lido del mare, con navi di Learco e ponte per cui si ascende ad una di esse. Da un lato, rovine del tempio di Venere; dall'altr, avanzi d'un antico porto di Lenno.</stage>
           <stage>GIASONE, ISSIPILE, RODOPE, con séguito d'Argonauti. LEARCO e TOANTE in una delle navi.</stage>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l>Issipile, respira:</l>
             <l>Giungemmo il traditor. Compagni, in quelli</l>
@@ -2792,28 +2817,28 @@
             <l>Di quel perfido sangue il mar vermiglio.</l>
           </sp>
           <stage>(Learco comparisce su la poppa della nave, tenendo con la sinistra per un braccio l'incatenato Toante ed impugnando uno stile nella destra sollevata in atto di ferirlo</stage>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l>Sì, ma quel di Toante</l>
             <l part="I">Si cominci a versar.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="M">Fermati!</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="F">Indegno!</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l>Qual furor ti trasporta?</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l>Padre... Sposo... Learco... Oh dèi! son morta.</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l>Issipile, che giova</l>
             <l>L'affliggersi così? Della sua vita</l>
@@ -2821,40 +2846,40 @@
             <l>Sposa a Learco. Il mio costante amore</l>
             <l>Premii la figlia; e 'l genitor non muore.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="I">Che ascolto, o sposo!</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">E profferire ardisci</l>
             <l>Il patto scellerato, anima rea?</l>
             <l>Ah! raffrenar non posso</l>
             <l part="I">Il mio giusto furor. <stage>(in atto di snudar la spada</stage></l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Pietà, Giasone! <stage>(trattenendolo</stage></l>
             <l>L'empio trafigge il padre,</l>
             <l part="I">Se tenti d'assalirlo.</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">Ah! ch'io mi sento</l>
             <l part="I">Tutte le furie in sen.</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Vedi, o Toante,</l>
             <l>Quella tenera figlia</l>
             <l>Come corre a salvarti. I suoi disprezzi</l>
             <l>Paghi il tuo sangue: ho tollerato assai. <stage>(in atto di ferire</stage></l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="I">Eccomi! non ferir. <stage>(s'affretta verso la nave</stage></l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="F">Figlia, che fai?</l>
             <l>Potesti a questo segno <stage>(Issipile si ferma</stage></l>
@@ -2866,12 +2891,12 @@
             <l>E divenir tu vuoi</l>
             <l>Madre di scellerati e non d'eroi?</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l>Dunque un'altra m'addita</l>
             <l part="I">Miglior via di salvarti.</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="F">Eccola. Intatto</l>
             <l>Custodisci l'onor del sangue mio.</l>
@@ -2883,32 +2908,32 @@
             <l>La vita che m'avanza,</l>
             <l>Abbastanza regnai, vissi abbastanza.</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="I">Oh forte!</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="M">Oh generoso!</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">E non ti muove</l>
             <l part="I">Tanta virtù, Learco?</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Anzi m'irrìta.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="I">Dunque?</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="M">Vieni, o l'uccido.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Ah! questo pianto</l>
             <l>Ti faccia impietosir. Del mio rifiuto</l>
@@ -2918,11 +2943,11 @@
             <l>Miserabile oggetto in questo lido?</l>
             <l part="I">Eccomi a' piedi tuoi. <stage>(s'inginocchia</stage></l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Vieni, o l'uccido.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l>Sì, verrò, traditor: verrò; ma quanto</l>
             <l>D'orribile ha l'inferno <stage>(s'alza furiosa</stage></l>
@@ -2934,11 +2959,11 @@
             <l>Mostro di crudeltà, quel core infido.</l>
             <l part="I">Scellerato! verrò.</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Vieni, o l'uccido. <stage>(con isdegno, in atto di ferire</stage></l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <lg>
               <l>Eccomi, non ferir. <stage>(a Learco</stage></l>
@@ -2954,7 +2979,7 @@
             </lg>
           </sp>
           <stage>(Issipile, piangendo, s'incammina lentamente alla nave, e va rivolgendosi a riguardar con tenerezza Giasone</stage>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l>Sposa, così mi lasci? Empio! Vorrei...</l>
             <l>Fremo... Non ho consiglio.</l>
@@ -2964,15 +2989,15 @@
         <div type="scene">
           <head>SCENA NONA</head>
           <stage>EURINOME e detti.</stage>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="F">Pur ti ritrovo, o figlio.</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="I">Salvati, o madre.</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">Ah, scellerata! A caso <stage>(trattiene Eurinome</stage></l>
             <l>Qui non giungesti. Issipile, t'arresta.</l>
@@ -2980,25 +3005,25 @@
             <l>Rendi Toante, o la tua madre io sveno.</l>
           </sp>
           <stage>(Issipile si ferma a mezzo il ponte, e Giasone, impugnando uno stile, minaccia di ferire Eurinome</stage>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="I">Come!</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="M">Che fu?</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="M">Qual cangiamento!</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">In lei</l>
             <l>Non punire i miei falli. Il tuo nemico</l>
             <l part="I">Son io, Giasone.</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">Il mio furor non lascia</l>
             <l>Luogo a consiglio. E' mio nemico ognuno</l>
@@ -3008,65 +3033,65 @@
             <l>D'averle ingiustamente il sen trafitto.</l>
             <l>L'esser madre a Learco è un gran delitto.</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="I">Confuso è l'empio.</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Eterni dèi, prestate</l>
             <l>Adesso il vostro aiuto!</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="I">Barbaro! non risolvi?</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Ho risoluto.</l>
             <l>Svenala pur: ma venga,</l>
             <l>E la legge primiera</l>
             <l part="I">Issipile compisca.</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="M">Oh mostro!</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Oh fiera!</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l>A voi dunque, o d'Averno</l>
             <l>Arbitre deità, questo offerisco</l>
             <l part="I">Orrido sacrifizio.</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="M">(Io tremo!)</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">A voi</l>
             <l>Di vendicar nel figlio</l>
             <l>Della madre lo scempio il peso resti.</l>
             <l part="I">Mori, infelice! <stage>(mostra di ferirla</stage></l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Ah! non ferir: vincesti.</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="I">E pur s'intenerì.</l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="F">Deggio la vita,</l>
             <l part="I">Caro Learco, a te.</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Poco il tuo figlio,</l>
             <l>Eurinome, conosci... E' debolezza</l>
@@ -3081,75 +3106,75 @@
             <l>Dubbiezza tua la mia ruina affretta.</l>
             <l>Incominci da te la mia vendetta. <stage>(si ferisce</stage></l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="I">Ferma! che fai?</l>
           </sp>
-          <sp>
+          <sp who="#learco">
             <speaker>LEAR.</speaker>
             <l part="F">Non spero</l>
             <l>E non voglio perdono. Il morir mio</l>
             <l part="I">Sia simile alla vita. <stage>(si getta in mare</stage></l>
           </sp>
-          <sp>
+          <sp who="#eurinome">
             <speaker>EUR.</speaker>
             <l part="F">Io manco. Oh Dio! <stage>(sviene ed è condotta dentro</stage></l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="I">Oh giustissimo Ciel!</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="F">Correte, amici,</l>
             <l part="I">A disciogliere il re. <stage>(gli Argonauti corrono su la nave</stage></l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Sposo, io non posso</l>
             <l part="I">Rassicurarmi ancor.</l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="F">Quante vicende</l>
             <l part="I">Un sol giorno adunò!</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="F">Principe! figlia! <stage>scendendo dalla nave</stage></l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="I">Padre!</l>
           </sp>
-          <sp>
+          <sp who="#giasone">
             <speaker>GIAS.</speaker>
             <l part="M">Signor!</l>
           </sp>
-          <sp>
+          <sp who="#issipile">
             <speaker>ISS.</speaker>
             <l part="F">Questa paterna mano</l>
             <l part="I">Torno pure a baciar! <stage>(bacia la mano a Toante</stage></l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="F">Posso al mio seno</l>
             <l part="I">Stringervi ancora! <stage>(gli abbraccia</stage></l>
           </sp>
-          <sp>
+          <sp who="#rodope">
             <speaker>ROD.</speaker>
             <l part="F">I tollerati affanni</l>
             <l>L'allegrezza compensi</l>
             <l part="I">D'un felice imeneo.</l>
           </sp>
-          <sp>
+          <sp who="#toante">
             <speaker>TOAN.</speaker>
             <l part="F">Ma pria nel tempio</l>
             <l>Rendiam grazie agli dèi; ché troppo, o figli,</l>
             <l>E' perigliosa e vana,</l>
             <l>Se da lor non comincia, ogni opra umana.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>E' follia d'un'alma stolta</l>

--- a/tei/metastasio-l-eroe-cinese.xml
+++ b/tei/metastasio-l-eroe-cinese.xml
@@ -76,6 +76,28 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="lisinga">
+            <persName>Lisinga</persName>
+          </person>
+          <person xml:id="ulania">
+            <persName>Ulania</persName>
+          </person>
+          <person xml:id="siveno">
+            <persName>Siveno</persName>
+          </person>
+          <person xml:id="minteo">
+            <persName>Mintéo</persName>
+          </person>
+          <person xml:id="leango">
+            <persName>Leango</persName>
+          </person>
+          <person xml:id="coro">
+            <persName>Coro</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Pavia</name>Digitalizzazione</change>
@@ -126,7 +148,7 @@
           <head>SCENA PRIMA</head>
           <stage>Appartamenti nel palazzo imperiale destinati alle tartare prigioniere, distinti di strane pitture, di vasi trasparenti, di ricchi panni, di vivaci tappeti e di tutto ciò che serve al lusso ed alla delizia cinese. Tavolino e sedia da un lato.</stage>
           <stage>LISINGA ed ULANIA; nobili tartari, de' quali uno inginocchiato innanzi a LISINGA in atto di presentarle una lettera.</stage>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l>Del real genitore <stage>(prende la lettera</stage></l>
             <l>I caratteri adoro:</l>
@@ -135,12 +157,12 @@
             <stage>(partono i Tartari dopo gli atti di rispetto di lor nazione. Lisinga depone la lettera sul tavolino</stage>
             <l part="I">Oh Dio!</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Leggi, o germana,</l>
             <l part="I">Del padre i sensi.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">Ah, cara Ulania, ah, troppo</l>
             <l>Senza legger gl'intendo! Ecco l'istante</l>
@@ -150,7 +172,7 @@
             <l>Le novelle di pace</l>
             <l part="I">Mi facevan tremar.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Termina al fine</l>
             <l>La nostra schiavitù; la patria, il padre</l>
@@ -159,17 +181,17 @@
             <l>Di tanti regni al fin ti rendi: al fine</l>
             <l>Torni agli onori, alle grandezze in seno.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l>Sì, tutto è ver; ma lascerò Siveno.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l>Ma la real tua mano</l>
             <l>Sai che non è per lui, sai che nemico,</l>
             <l part="I">Sai che suddito ei nacque.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">Io so che l'amo;</l>
             <l> So che n'è degno assai; che il primo è stato,</l>
@@ -178,7 +200,7 @@
             <l>Barbaro mi divide,</l>
             <l>Senza saperlo il genitor m'uccide. <stage>(siede</stage></l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l>Odi, o Lisinga, e impara</l>
             <l>Da me fortezza. Io per Mintéo sospiro,</l>
@@ -186,7 +208,7 @@
             <l>Or da lui mi scompagno;</l>
             <l>Me ne sento morir, ma non mi lagno.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l>Felice te, che puoi</l>
             <l>Amar così. Del mio Siveno anch'io</l>
@@ -196,12 +218,12 @@
             <l>Il viver senza amarlo,</l>
             <l part="I">Che l'amarlo e morir.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Pria d'affannarti</l>
             <l part="I">Leggi quel foglio almen. Chi sa!</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">Tu vuoi</l>
             <l>Ch'io perda anche il conforto</l>
@@ -211,12 +233,12 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>SIVENO e dette.</stage>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">Ah, dimmi, è vero</l>
             <l part="I">Ch'io ti perdo, o mia vita?</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">Ha questo foglio</l>
             <l>Del padre i cenni. Assicurarmi ancora</l>
@@ -225,7 +247,7 @@
             <l>Mi sembrerà men dura</l>
             <l>Sempre fra' labbri tuoi la mia sventura.</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l><stage>(legge)</stage> Figlia, è già tutto in pace;</l>
             <l>Non abbiam più nemici. Alla tua mano</l>
@@ -237,21 +259,21 @@
             <l>Noto a Leango; ei scopriratti il vero.</l>
             <l part="I">Zeilan. Giusto Ciel!</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="M">Che fia?</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">Quel foglio</l>
             <l part="I">Forse mal comprendesti.</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">Ah, no! Tu stessa</l>
             <l part="I">Leggilo, o principessa. <stage>(le porge il foglio</stage></l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F"><stage>(legge)</stage> A te l'erede</l>
             <l>Del cinese diadema</l>
@@ -259,54 +281,54 @@
             <l>Dunque, o Siveno, è la tragedia antica?</l>
             <l part="I">Ah, parla, ah, di'.</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">Che vuoi, mio ben, ch'io dica?</l>
             <l>Mancava a' miei timori</l>
             <l part="I">Un ignoto rival!</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Fu pur dal soglio</l>
             <l>Da' popoli ribelli</l>
             <l part="I">Discacciato Livanio.</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">E il quarto lustro</l>
             <l part="I">Siam vicini a compir.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">Pur nell'esiglio</l>
             <l part="I">I suoi dì terminò.</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">Sin da quel giorno</l>
             <l>Che tu dell'armi nostre, io prigioniero</l>
             <l part="I">Restai di tua beltà.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Del regio sangue...</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l>Nessun restò. Fu tra le fasce ucciso</l>
             <l>Fin l'ultimo rampollo</l>
             <l part="I">Della stirpe real.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">Ma questo erede</l>
             <l part="I">Chi mai sarà?</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="M">Qualche impostor.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">Leango,</l>
             <l>Il padre di Siveno,</l>
@@ -314,7 +336,7 @@
             <l>Vola al tuo genitor; chiedi, rischiara</l>
             <l>I miei dubbi, o Siveno, i dubbi tuoi.</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l>Ah principessa, ah che sarà di noi!</l>
             <lg>
@@ -334,29 +356,29 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>LISINGA ed ULANIA</stage>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l>Tutti dunque i miei dì saran, germana</l>
             <l part="I">Neri così?</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Non li sperar sereni.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="I">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Perché avveleni</l>
             <l>Sempre col mal che temi, il ben che godi?</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="I">Or qual ombra ho di ben?</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Qual? Tu non parti;</l>
             <l>Siveno è qui; questo temuto erede</l>
@@ -365,11 +387,11 @@
             <l>Qualche felicità; spera in Siveno</l>
             <l part="I">Cotesto erede.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="M">Ah sarei folle!</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">E' vuoto</l>
             <l>Pur questo soglio; estinta</l>
@@ -380,48 +402,48 @@
             <l>Fin or di questi regni, oggi il monarca</l>
             <l part="I">Farsene ben potria.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">Perché nol fece</l>
             <l part="I">Dunque fin or? Sempre ha potuto.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Il trono</l>
             <l> Vuoto serbò, come dovea, Leango</l>
             <l>All'esule suo re; ma, quello estinto,</l>
             <l part="I">A chi più dee serbarlo?</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">Ah che pur troppo</l>
             <l>Quest'incognito erede,</l>
             <l part="I">Pur troppo vi sarà!</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Dunque ad amarlo</l>
             <l part="I">L'alma disponi.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="M">Io?</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Sì. Fingi che sia</l>
             <l part="I">Amabile, gentil...</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="M">Taci.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Cancelli</l>
             <l>L'idea d'un nuovo amore...</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l>Taci, crudel; tu mi trafiggi il core.</l>
             <lg>
@@ -441,99 +463,99 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>ULANIA, poi MINTÉO</stage>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l>Ecco Mintéo; si evìti. Ah, s'ei sapesse</l>
             <l part="I">Quanto mi costa il mio rigor! <stage>(in atto d'incamminarsi</stage></l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">Tu fuggi,</l>
             <l>Bella Ulania, da me? Ferma; se il volto</l>
             <l>Del povero Mintéo tanto ti spiace,</l>
             <l>Tocca a lui di partir; rimanti in pace. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l>Senti. <stage>(Minto si rivolge e resta lontano)</stage> (Che dolce aspetto,</l>
             <l>Che modesto parlar!) T'appressa. <stage>(Mintéo s'avvicina rispettosamente)</stage> Imposi</l>
             <l part="I">Pure a te d'evitarmi? <stage>(con serietà</stage></l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="M"><stage>(con rispetto)</stage> E' ver.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Ma dunque</l>
             <l part="I">A chi vieni?</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">Perdona: io vengo in traccia</l>
             <l>Del mio caro Siveno. Un folto stuolo</l>
             <l>Di Manderini impaziente il chiede.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="I">Me non cercasti?</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="M">No.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Di non amarmi</l>
             <l part="I">La legge ti sovvien?</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="M">Sì.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F"><stage>(con risentimento)</stage> Di Siveno</l>
             <l part="I">Siegui dunque l'inchiesta.</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">Oh Dio! sì presto</l>
             <l part="I">Non scacciarmi, crudel.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Se più non m'ami,</l>
             <l part="I">Di che lagnar ti puoi?</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">Se più non t'amo,</l>
             <l>T'adoro e non t'offendo. In cielo ancora</l>
             <l>V'è un nume, non si sdegna, e ognun l'adora.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="I">(Che fido cor!) <stage>(con tenerezza</stage></l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F"><stage>(con risentimento)</stage> Ma se gli omaggi miei</l>
             <l>T'offendono così, l'ultima volta</l>
             <l part="I">Questa sarà che tu mi vedi. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">(Oh Dio!)</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l>Da te lungi, idol mio,</l>
             <l>Disperato vivrò; ma il bel sereno</l>
             <l>Non turberò di quei vezzosi rai.</l>
             <l>Forse io morrò d'amor, tu nol saprai. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l>Mintéo, m'ascolta. Io non son tanto ingiusta</l>
             <l>Quanto mi credi. Io te non odio: ammiro</l>
@@ -541,31 +563,31 @@
             <l>Quel modesto contegno,</l>
             <l part="I">Quell'aspetto gentil: ma...</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="M">Che?</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F"><stage>(con dolcezza)</stage> Ma il fato</l>
             <l>Troppo il tuo dal mio stato</l>
             <l part="I">Allontanò. Tanta distanza...</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F"><stage>(con allegrezza)</stage> Ah! dunque</l>
             <l>In Mintéo non ti spiace...</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="I">Che gli oscuri natali. <stage>(con lieta tenerezza</stage></l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">E se foss'io</l>
             <l part="I">Di te più degno...</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Ah! se tu fossi... Addio. <stage>(con serietà</stage></l>
             <lg>
@@ -585,28 +607,28 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>MINTÉO, poi LEANGO</stage>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l>Non mi lusingo in vano;</l>
             <l>Il cor d'Ulania è mio: ne intendo i moti</l>
             <l>Che asconde il labbro, e che palesa il ciglio.</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l>Mintéo, dovìè mio figlio?</l>
             <l part="I">Come tu qui senza di lui?</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">Ne vado</l>
             <l part="I">Signore, in traccia.</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">Ascoltami, rispondi,</l>
             <l>E parlami sincero. Ami Siveno? <stage>(con gravità</stage></l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l>Ami Siveno! Ah, qual richiesta! <stage>(con istupore)</stage> Io l'amo</l>
             <l>Eroe, compagno, amico;</l>
@@ -614,20 +636,20 @@
             <l>Difensor fra le schiere,</l>
             <l>Per genio, per costume e per dovere.</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l>Ti rammenti chi fosti? <stage>(con gravità</stage></l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l>Un mendico fanciullo, in man straniera,</l>
             <l part="I">De' suoi natali ignaro.</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">Ed or chi sei?</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l><stage>(turbato)</stage> Ed or mercé l'amica</l>
             <l> Tua benefica man, fra' sommi duci</l>
@@ -635,12 +657,12 @@
             <l>Delle forze cinesi una gran parte</l>
             <l part="I">Pender dal cenno mio.</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F"><stage>(grave e serio)</stage> Sai qual tu debba</l>
             <l part="I">Gratitudine e fé...</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F"><stage>(con trasporto di passione)</stage> Perché, signore,</l>
             <l>Mi trafiggi così? Qual mio delitto</l>
@@ -650,32 +672,32 @@
             <l>Non parlerò; ma questo dubbio, oh Dio!</l>
             <l part="I">Non posso tollerar.</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F"><stage>(sereno)</stage> Vieni al mio seno,</l>
             <l>Caro Mintéo. La tua virtù conosco,</l>
             <l>La sprono e non l'accuso. Avrò bisogno</l>
             <l part="I">Oggi forse di te.</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">Spiegati, imponi.</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="I">Va; non è tempo ancor.</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">Fin ch'io non possa</l>
             <l>Darti un'illustre prova</l>
             <l>Della mia fé, non avrò pace mai.</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l>Va: Mintéo, ti consola, oggi il potrai. <stage>(misterioso</stage></l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <lg>
               <l>Il padre mio tu sei,</l>
@@ -719,38 +741,38 @@
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>LEANGO, e SIVENO con Manderini</stage>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">Onde sì lieto? e dove</l>
             <l part="I">T'affretti, o figlio?</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="M">A' piedi tuoi. <stage>(s'inginocchia, e seco alcuni de' seguaci</stage></l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">Che fai?</l>
             <l part="I">Sorgi. E voi, che chiedete? <stage>(agli altri</stage></l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">Il nostro, o padre,</l>
             <l part="I">Monarca in te.</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="M">Figlio, ah che dici!</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">Al fine...</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="I">Sorgete, o non v'ascolto. <stage>(si levano</stage></l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">Al fin corona</l>
             <l>I tuoi meriti il Ciel. Di tanti regni,</l>
@@ -758,11 +780,11 @@
             <l>Pieni de' tuoi trofei,</l>
             <l>Se fosti padre, imperadore or sei.</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="I">Come!</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">I duci, il Senato,</l>
             <l>I ministri del Ciel, gli Ordini tutti</l>
@@ -771,18 +793,18 @@
             <l>Lo dimanda il periglio;</l>
             <l>Ed a nome d'ognun l'implora un figlio.</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l>(Tu vorresti, o fortuna,</l>
             <l>Di mia fé trionfar: no, la mia fede</l>
             <l>Al tuo non cede insidioso dono,</l>
             <l>E a farla vacillar non basta un trono).</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="I">Tu pensi, o padre!</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">E ne stupisci? Ah! sai</l>
             <l>Di che peso è un diadema, e quanto sia</l>
@@ -797,21 +819,21 @@
             <l>La lusinga e la frode,</l>
             <l>Che ogni fallo d'un re trasforma in lode?</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l>Il so. Tu mi spiegasti</l>
             <l>Di questo mare immenso</l>
             <l part="I">Tutti i perigli.</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">Ed hai stupor s'io penso?</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="I">Quando esperto è il nocchiero...</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">Andate, amici.</l>
             <stage>(a' Manderini che, ricevuto l'ordine, partono</stage>
@@ -836,40 +858,40 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>SIVENO e LUSINGA</stage>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="I">Siveno, ascolta. <stage>(allegri sommamente</stage></l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="M">Ah, mia speranza!</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">E' vero</l>
             <l part="I">Che il padre tuo...</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="M">Sì, tutto è ver.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">L'erede</l>
             <l part="I">Dunque or tu sei di questo trono?</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">Addio.</l>
             <l>Di te degno a momenti,</l>
             <l part="I">Cara, ritornerò.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">Senti. Ma donde</l>
             <l>Così strane vicende...</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l>Sappi... Ah non posso: il genitor m'attende. <stage>(parte</stage></l>
           </sp>
@@ -903,18 +925,18 @@
           <head>SCENA PRIMA</head>
           <stage>Logge terrene, dalle quali si scopre gran parte della real città di Singana e del fiume che la bagna. Le torri, i tetti, le pagode, le navi, gli alberi stessi, e tutto ciò che si vede, ostenta la diversità con la quale producono in clima così diverso non men la natura che l'arte.</stage>
           <stage>SIVENO e MINTÉO</stage>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l>Lasciami, caro amico; <stage>(disperato</stage></l>
             <l>Lasciami in pace; il mio dolor non soffre</l>
             <l part="I">Compagnia, né consigli.</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">Ah no, sì presto</l>
             <l part="I">Non disperar.</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">Tu mi trafiggi. Il padre</l>
             <l>Non ricusò l'impero? Il vero erede</l>
@@ -922,13 +944,13 @@
             <l>Dunque ch'io speri più? Qual più m'avanza</l>
             <l part="I">Conforto a' mali miei?</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">La tua costanza.</l>
             <l>Mostrati, allor che il perdi,</l>
             <l part="I">Ch'eri degno de trono.</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">E creder puoi</l>
             <l>Che il trono io pianga? Il meritarlo è stato,</l>
@@ -940,20 +962,20 @@
             <l>Il bell'idol mio, la mia speranza,</l>
             <l>Tu, come hai cor di consigliar costanza?</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l>Sei degno, lo confesso,</l>
             <l part="I">Sei degno di pietà; ma pure...</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">Addio.</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="I">Dove?</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">Quindi lontan. No, non potrei</l>
             <l>Pace qui più sperar. Di mie passate</l>
@@ -969,7 +991,7 @@
             <l>D'un felice rival su gli occhi miei...</l>
             <l part="I">Ah! lasciami...</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="M">Ove vai? <stage>(trattenendolo</stage></l>
           </sp>
@@ -977,7 +999,7 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>ULANIA e detti.</stage>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">Da queste sponde</l>
             <l>Ah! lasciami fuggir. M'eran sì care; <stage>(vuol fuggir di mano a Mintéo</stage></l>
@@ -988,33 +1010,33 @@
             <l>Seppe il caso infelice?</l>
             <l part="I">Come sta? Che ne dice?</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Al colpo acerbo</l>
             <l part="I">Istupidì.</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">Tutto è finito. Un sogno</l>
             <l>Fur le speranze mie. Quel cor, quel volto,</l>
             <l> Quella man che mi diede,</l>
             <l part="I">Oh Dio! d'altri sarà.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="M">Nol credo.</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">E come?</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l>A costo d'un impero ella è capace</l>
             <l>D'esser fedel. So come t'ama; ed io</l>
             <l part="I">&gt;Ben conosco il suo cor.</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">Ma ignori il mio.</l>
             <l>Soffrir che, nata al soglio, ella discenda</l>
@@ -1024,43 +1046,43 @@
             <l>Io non sono a tal segno</l>
             <l>E vile amante e cittadino indegno.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l>E qual altro riparo?</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="I">Fuggir.</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="M">Ma dove?</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="M">E a che?</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">Dove non abbia</l>
             <l>Ritegni il mio martìre;</l>
             <l>A lagnarmi, a languire,</l>
             <l part="I">A piangere, a morir.</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">Senti. E Lisinga</l>
             <l part="I"> Lasci così?</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Pria di partir l'ascolta.</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="I">Vedila almeno.</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">Ah, che mi dite! Ah, troppo,</l>
             <l>Troppo il suo affanno accrescerebbe il mio!</l>
@@ -1082,7 +1104,7 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>ULANIA e MINTÉO</stage>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l>Ulania, ah! tu del volto</l>
             <l>So che non hai men bello il cor; t'incresca</l>
@@ -1092,41 +1114,41 @@
             <l>Trasportar lo potrebbe</l>
             <l part="I">L'eccessivo dolore.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">E tu frattanto</l>
             <l part="I">Perché nol siegui?</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">Oh Dio! non posso. Io volo</l>
             <l>Fuor della reggia; un popolar tumulto</l>
             <l part="I">Colà mi chiama.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="M">E chi lo desta?</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">Ignoro</l>
             <l part="I">La cagione e l'autor.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Dunque ad esporti</l>
             <l part="I">Perché corri così?</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">M'obbliga un cenno</l>
             <l part="I">Del vecchio Alsingo.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="M">E chi è costui?</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">L'istesso</l>
             <l>Che infante abbandonato</l>
@@ -1136,33 +1158,33 @@
             <l>Di sua pietà, se non son io suo figlio:</l>
             <l>E' dovuto il mio sangue al suo periglio.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l>(Che grato, che sincero,</l>
             <l part="I">Che nobil cor!)</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="M">Rimanti in pace.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Ascolta.</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="I">Che imponi?</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">E' ver ch'io posso</l>
             <l part="I">Dispor di te?</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="M">Pommi al cimento.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Io fido</l>
             <l> Te stesso a te. Ricordati che déi</l>
@@ -1170,27 +1192,27 @@
             <l>Non arrischiarti: una sì bella vita</l>
             <l part="I">Merta che si risparmi.</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">Ah mio tesoro!</l>
             <l part="I">Ah bell'idol mio! tu m'ami.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Io! Quando</l>
             <l part="I">Dissi d'amarti?</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">Il tuo timor, le care</l>
             <l>Premure tue, quel rimirar pietoso,</l>
             <l>Quel modesto arrossir mel dice assai.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l>Ah, Mintéo, che ti giova or che lo sai?</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <lg>
               <l>Oh quanto mai son belle</l>
@@ -1209,7 +1231,7 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>ULANIA, poi LISINGA</stage>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l>Debole Ulania! i tuoi ritegni ha vinto</l>
             <l>Al fine amor. Ma sì gran colpa è dunque</l>
@@ -1218,7 +1240,7 @@
             <l>L'arte dov'è? Fra i più felici ingegni,</l>
             <l>Se alcun l'ha ritrovata, ah, me l'insegni!</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l>Ulania, e in questo stato<stage>(affannata</stage></l>
             <l>La germana abbandoni? Io mai non ebbi</l>
@@ -1226,11 +1248,11 @@
             <l>Maggior bisogno. Ah tu non ami! Avresti</l>
             <l>Maggior pietà quando languir mi vedi.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l>Mi fai torto; ho pietà più che non credi.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l>Dunque m'assisti: io non son più capace</l>
             <l> Di consigliar me stessa. In un istante</l>
@@ -1239,7 +1261,7 @@
             <l>Dubbi così m'involvo,</l>
             <l>Mi confondo, mi stanco e non risolvo.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l>Odimi. Io nel tuo caso</l>
             <l>Tutto in un foglio al padre</l>
@@ -1248,31 +1270,31 @@
             <l>Temer che de' tuoi giorni il corso intiero</l>
             <l part="I">Voglia render funesto.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">E' vero, è vero. <stage>(pensa e poi risoluta</stage></l>
             <l>Sì, tu fa che a me venga</l>
             <l>Il tartaro messaggio; ed io frattanto</l>
             <l part="I">Volo il foglio a vergar. <stage>(s'incammina</stage></l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="M"><stage>(fa lo stesso)</stage> Vado.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F"><stage>(si ferma irresoluta)</stage> Ah! t'arresta!</l>
             <l>Pria che torni il messaggio</l>
             <l>Chi mi difenderà? Vorrà Leango</l>
             <l part="I">Obbligarmi a compir...</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Va dunque a lui;</l>
             <l>Parlagli: a tua richiesta</l>
             <l part="I">Gl'imenei differisca.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">Andiamo... E quale<stage>(va e s'arresta irresoluta</stage></l>
             <l>Della richiesta mia</l>
@@ -1281,46 +1303,46 @@
             <l>Ma dove è mai Siveno? <stage>(impaziente</stage></l>
             <l part="I">&gt;Perché non vien?</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Di comparirti innanzi</l>
             <l part="I">Non ha più cor.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="M">Dunque il vedesti?</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Il vidi.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l>Che ti disse? Che pensa?</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="I">Pensa a partir.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="M">Stelle! E perché?</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Paventa</l>
             <l> Il suo dolore e il tuo; né vuol più mai</l>
             <l part="I">Esporsi...</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="M">E già partì? <stage>(con ansietà</stage></l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="M">Nol so.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F"><stage>(con sdegno)</stage> Nol sai?</l>
             <l>E questo... Olà! Che tradimento! e questo,</l>
@@ -1328,21 +1350,21 @@
             <l>Si cerchi, si raggiunga,</l>
             <l part="I">Si riconduca a me. <stage>(partono i Tartari</stage></l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Deh! ti consola;</l>
             <l part="I">Forse...</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">Lasciami sola: <stage>(con sdegno</stage></l>
             <l part="I">Involati al mio sguardo.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Oh Dio! Germana...</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l>Germana! Ah! questo nome</l>
             <l>Non profanar: nemica mia tu sei</l>
@@ -1350,7 +1372,7 @@
             <l>La natura non diede</l>
             <l>Senso d'amor, d'umanità, di fede.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l>M'insulti a torto. In tante angustie anch'io</l>
             <l>Mi perdo, mi confondo, e rea non sono,</l>
@@ -1359,7 +1381,7 @@
             <l>La mercé che mi dona!</l>
             <l part="I">Resta, resta pur sola. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">Ah! no; perdona,</l>
             <l>Perdona, Ulania amata;</l>
@@ -1368,7 +1390,7 @@
             <l>Che non parta Siveno. Ah! va; ti muova</l>
             <l>Il mio stato, il mio pianto.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l>Vado; ma tu non avvilirti intanto.</l>
             <lg>
@@ -1388,12 +1410,12 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>LEANGO e LISINGA</stage>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l>Se perdo il mio Siveno,</l>
             <l>Numi, che fia di me! Grave a me stessa...</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l>Al fine, o principessa,</l>
             <l>Posso offrirti palesi</l>
@@ -1403,7 +1425,7 @@
             <l>La più lucida stella: oggi raccolta</l>
             <l part="I">Nel talamo real...</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">Leango, ascolta.</l>
             <l>Se dispor degl'imperi</l>
@@ -1429,66 +1451,66 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>LEANGO, poi SIVENO</stage>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l>Disingannarla io pur vorrei. No, prima</l>
             <l>Che i Tartari sian giunti,</l>
             <l>E' rischio avventurar. Che rechi? Un foglio? <stage>(a un paggio che giunge</stage></l>
             <l part="I">Porgilo e parti. <stage>(il paggio dà la lettera e parte</stage></l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">A lei vuol ch'io ritorni<stage>(dubbioso senza veder Leango</stage></l>
             <l>La mia bella Lisinga: io sudo, io tremo</l>
             <l>Nell'appressarmi a lei. No... Ma poss'io</l>
             <l part="I">Trasgredire un suo cenno?</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">Astri benigni,</l>
             <l>Eccomi in porto: il tartaro soccorso</l>
             <l part="I">Pur giunto è al fin. <stage>(rilegge</stage></l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">Lisinga il vuol, si vada...</l>
             <l>(Il genitor! No, sì confuso almeno</l>
             <l part="I">Non vogl'io ch'ei mi vegga). <stage>(vuol partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">Odi, Siveno,</l>
             <l part="I">Fermati. (Il Ciel l'invia). <stage>(Siveno s'arresta</stage></l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">(Che dirgli mai!</l>
             <l part="I">Quali scuse...) <stage>(s'arresta da lontano</stage></l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="M">Ah signor! <stage>(vuole inginocchiarsi</stage></l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F"><stage>(sollevandolo</stage> Padre! che fai?</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="I">Non son più padre tuo.</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">Perché? Tu piangi!</l>
             <l>Misero me! Dell'improvviso pianto</l>
             <l>Che tu versi dal ciglio,</l>
             <l part="I">Ah, forse il figlio è reo?</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">Non ho più figlio.</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l>Intendo, intendo; un temerario amore</l>
             <l>Tu disapprovi in me. Perdona, è vero:</l>
@@ -1496,12 +1518,12 @@
             <l>Ma la scusa è maggior. Dov'è chi possa</l>
             <l part="I">Vederla e non amarla?</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">Amala; è giusto</l>
             <l part="I">Che la tua sposa adori.</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">Ah padre, ah questo</l>
             <l>Scherzo crudel troppo il mio fallo eccede!</l>
@@ -1509,15 +1531,15 @@
             <l>Hai destinato a lei</l>
             <l part="I">Lo sconosciuto erede.</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">E quel tu sei.</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="I">Che!</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">Tu sei quello. Io ti serbai bambino</l>
             <l> Fra la strage de' tuoi; ressi fin ora</l>
@@ -1526,55 +1548,55 @@
             <l>Te potessi al tuo soglio, io sospirai;</l>
             <l>Quel giorno è giunto; ora ho vissuto assai.</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="I">Io... Non m'inganni?</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">No; tu sei Svenvango,</l>
             <l part="I">Del gran Livanio ultimo figlio.</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">E il trono...</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l>E il trono è tuo retaggio.</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="I">E Lisinga...</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="M">E' tua sposa.</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">Oh sposa! oh giorno!</l>
             <l>Oh me felice! Ah, sappia</l>
             <l part="I">L'idol mio!... <stage>(vuol partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="M">Dove t'affretti?</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">A lei.</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l>Ferma; e, se m'ami, in questo stato altrui</l>
             <l>Non ti mostrar. Ti ricomponi, e pensa...</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l>Oh Dio, piange Lisinga!</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l>A consolarla io stesso</l>
             <l>Con tal novella andrò. Nel maggior tempio</l>
@@ -1597,18 +1619,18 @@
             <l>San le sue veci a benefizio altrui,</l>
             <l> Preme così chi non somiglia a lui.</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l>Sì, caro padre mio, sarò... Vedrai...</l>
             <l>Ah troppo vorrei dir! Lisinga... Il trono...</l>
             <l part="I">I benefizi tuoi...</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">Non affannarti;</l>
             <l part="I">Tutto intendo, o signor.</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">Signor mi chiami!</l>
             <l>Ah no, chiamami figlio. Ah, questo nome</l>
@@ -1619,7 +1641,7 @@
             <l>La mia riconoscenza, il mio rispetto,</l>
             <l>L'amor mio, la mia fede...</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l>Figlio, ah! non più: la tenerezza eccede. <stage>(lo abbraccia con tenerezza, poi si ritira con rispetto</stage></l>
             <lg>
@@ -1639,69 +1661,69 @@
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>SIVENO, poi MINTÉO in fretta.</stage>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l>Oh sorpresa! oh contento! Ah, quando il sappia,</l>
             <l part="I">Ah, che dirà la mia Lisanga!</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F"><stage>(affannato</stage> Amico,</l>
             <l part="I">E' teco alcun?</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="M">Son solo.</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">Oh ignote, oh strane</l>
             <l part="I">Vie del destin!</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="M">Che mai t'avvenne?</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">Al fine</l>
             <l>Dell'impero cinese</l>
             <l part="I">E' il successor palese.</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">Onde sì presto</l>
             <l part="I">Giunse a te la novella?</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">E a te chi mai</l>
             <l part="I">Sì presto la recò?</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="M">Leango.</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">Avresti</l>
             <l>Potuto immaginar che il tuo Mintéo</l>
             <l part="I">Fosse un monarca?</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="M">Che!</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">Che fossi il figlio</l>
             <l part="I">Io di Livanio?</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="M">Tu!</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">Sì. D'un evento</l>
             <l>Strano così per informarti io corsi,</l>
@@ -1709,43 +1731,43 @@
             <l>Non trattenermi: è necessaria altrove</l>
             <l part="I">La mia presenza.</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">Odimi. (Oh Ciel!) Chi disse</l>
             <l part="I">A te che sei Svenvango?</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">Il vecchio Alsingo.</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="I">Quei che ignoto bambin...</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">Bambino ignoto</l>
             <l>Per salvarmi mi finse. I miei natali,</l>
             <l>Le indubutate prove, il nome mio</l>
             <l>Poc'anzi sol mi fe' palese. Addio.</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l>Sentimi. (Dove son!) Ma come Alsingo</l>
             <l part="I">Tacque fin or?</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">Fin or fu vuoto il trono,</l>
             <l>Ed Alsingo attendea</l>
             <l part="I">Tempo a parlar senza mio rischio.</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">Ed oggi</l>
             <l part="I">Perché parlò?</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">Perché fu il trono offerto</l>
             <l>Oggi a Leango. Oh, se vedessi come</l>
@@ -1755,11 +1777,11 @@
             <l>Vieni al mio seno, ed in qualunque stato</l>
             <l> Sappi ch'io serbo a te l'affetto antico.</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="I">Ferma un istante ancor.</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">Non posso, amico. <stage>(parte in fretta</stage></l>
           </sp>
@@ -1767,82 +1789,82 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>SIVENO, poi LISINGA</stage>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l>Giusto Ciel, che m'avvenne!</l>
             <l>Son Svenvango o Siveno?</l>
             <l>Dove son? Chi son io? M'inganna il padre?</l>
             <l part="I">Mi tradisce l'amico?</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F"><stage>(allegrissima</stage> Ah, mio tesoro!</l>
             <l>Ah, mio sposo! ah, mio re! posso una volta</l>
             <l part="I">Chiamarti mio?</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">(Misero me! che dirle?</l>
             <l part="I">La trafiggo, se parlo). <stage>(confuso</stage></l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">Oggi co' numi</l>
             <l>La mia felicità non cambierei.</l>
             <l>Oggi... Ma tu non sei</l>
             <l part="I">Lieto, ben mio?</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="M">(Questo è martìr!)</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">Che avvenne?</l>
             <l part="I">Forse non m'ami più?</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">T'amo, t'adoro,</l>
             <l part="I">Sei tu l'anima mia. <stage>(come sopra</stage></l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">Parlasti al padre?</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="I">Gli parlai.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">Non ti disse</l>
             <l part="I">Che Svenvango tu sei?</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="M">Mel disse.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">E ch'io</l>
             <l part="I">Son la tua sposa?</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="M">Il disse ancor.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">Ma dunque</l>
             <l>Di che t'affliggi in sì felice stato?</l>
             <l part="I">Parla.</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">Ah, mia vita, a sospirar son nato!</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <lg>
               <l>Perché, se re tu sei,</l>
@@ -1851,7 +1873,7 @@
               <l>Sei nato a sospirar?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <lg>
               <l>Non so se mia tu sei:</l>
@@ -1860,25 +1882,25 @@
               <l>Parmi di delirar.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <lg part="I">
               <l part="I">Spiegati.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <lg part="M">
               <l part="F">Io... sappi... addio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <lg part="M">
               <l>Così mi lasci, ingrato?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#lisinga #siveno">
             <speaker>A DUE</speaker>
             <lg part="F">
               <l>Ah non è stanco il fato</l>
@@ -1893,7 +1915,7 @@
           <head>SCENA PRIMA</head>
           <stage>Luogo solitario ed ombroso ne' giardini imperiali.</stage>
           <stage>LISINGA, poi SIVENO con guardie cinesi.</stage>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <lg>
               <l>Fra quante vicende</l>
@@ -1906,16 +1928,16 @@
               <l>Minaccia di nuovo...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l>Lisinga? Ah! lode al Ciel, pur ti ritrovo.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l>Qual fretta? Onde l'affanno?</l>
             <l part="I">Perché tant'armi?</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F"><stage>(alle guardie)</stage> Al valor vostro, amici,</l>
             <l>Ed alla vostra fé questo io consegno</l>
@@ -1926,39 +1948,39 @@
             <l>Siegui, Lisinga. In sì munito loco</l>
             <l>Sicura attendi; io tornerò fra poco.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l>Siveno, o dèi, qual nuovo</l>
             <l> Periglio or mi sovrasta?</l>
             <l part="I">Tu dove corri?</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">Il popolo in tumulto</l>
             <l>Tutto inonda le vie: vuol nella reggia</l>
             <l>Introdurre un suo re; gl'impeti insani</l>
             <l part="I">Io corro a raffrenar.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">Senti. O t'arresta,</l>
             <l>O con te mi conduci; io voglio almeno</l>
             <l part="I">Perirti accanto.</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">Ah, che il tuo rischio, o cara,</l>
             <l>Farebbe il mio! Mi tremerebbe il core</l>
             <l>Al lampo d'ogni acciar. Resta tranquilla:</l>
             <l part="I">Torno a momenti.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">O dèi, tranquilla! E intanto</l>
             <l>Tu d'un popolo armato</l>
             <l part="I">Vai l'ire ad affrontar?</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">No. Della reggia</l>
             <l>Verso il maggiore ingresso il volgo insano</l>
@@ -1968,12 +1990,12 @@
             <l>Di pochi istanti opra sarà... Che? Piangi!</l>
             <l part="I">Ah, non temer, mia vita!</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">E a ciglio asciutto</l>
             <l>Vuoi ch'io ti vegga a tale impresa accinto?</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l>Amati rai, se non piangete, ho vinto.</l>
             <lg>
@@ -1993,76 +2015,76 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>LISINGA, poi LEANGO con guardie.</stage>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="I">Assistetelo, o dèi. <stage>(volendo partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">Dove, o Lisinga,</l>
             <l part="I">Così turbata?</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">E tu, signor, che fai</l>
             <l>Così tranquillo? E' la città sossopra:</l>
             <l>Minacciata è la reggia;</l>
             <l part="I">Un altro re...</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">Ti rassicura; a tutto,</l>
             <l part="I">Bella Lisinga, io già provvidi.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">E come?</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l>A mia richiesta un numeroso stuolo</l>
             <l>Di tartari guerrieri il tuo gran padre</l>
             <l>Sai che inviò. Giunse poc'anzi, e verso</l>
             <l part="I">&gt;La cità già s'avanza.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">E se frattanto</l>
             <l>Il volgo contumace</l>
             <l>La reggia inonda? Avrem dal tardo aiuto</l>
             <l part="I">Vendetta, e non difesa.</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">Elette schiere</l>
             <l>Custodiscon la reggia;</l>
             <l>Mintéo n'è il duce; e riposar possiamo</l>
             <l part="I">Di Mintéo su la fé.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">Dunque ad esporsi</l>
             <l part="I">Perché corre Siveno?</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">Esporsi! E come?</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l>Ei per la via del fiume</l>
             <l part="I">Va i sollevati ad assalir.</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F"><stage>(a' custodi, senza spavento)</stage> Correte,</l>
             <l part="I">Custodi, a trattenerlo.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="M">Ah, sì. <stage>(a' medesimi</stage></l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">Che pena</l>
             <l>E' il moderar quei giovanili in lui</l>
@@ -2071,19 +2093,19 @@
             <l>Che un'amabile sposa</l>
             <l part="I">Sarà di me miglior maestra.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">Ah, voglia</l>
             <l part="I">Il Cielo al fin!...</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">Mai più sereno il cielo</l>
             <l>Non si mostrò per noi. D'ogni procella</l>
             <l>La minaccia è svanita</l>
             <l part="I">Siam tutti in porto.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">Ah tu mi torni in vita!</l>
             <lg>
@@ -2103,77 +2125,77 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>LEANGO, poi ULANIA</stage>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l>Olà, se ancor nel tempio</l>
             <l>Son tutti uniti, alcun m'avverta. Or parmi</l>
             <l part="I">Un secolo ogn'istante...</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F"><stage>(spaventata)</stage> Ove... Ah, Leango!...</l>
             <l>Ov'è la mia germana? Ah! me l'addita;</l>
             <l part="I">Difendici... Fuggiam.</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">Non hai rossore</l>
             <l>Di questo, o principessa,</l>
             <l part="I">Spavento femminil?</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Sì, la tua pace</l>
             <l>Degna in vero è di lode, or che agl'insulti</l>
             <l part="I">D'un popol reo...</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">Ma nella chiusa reggia</l>
             <l part="I">Che mai, che puoi temer?</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Chiusa la reggia!</l>
             <l>Dèi, qual letargo! Io n'ho veduto, io stessa,</l>
             <l part="I">L'ingresso aperto.</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="M">Ed i custodi? <stage>(comincia a turbarsi</stage></l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Un solo</l>
             <l> Non s'oppon, non resiste; un brando, un'asta</l>
             <l part="I">Non si muove per noi.</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">Stelle! ma intanto</l>
             <l part="I">Che fa, dov'è Mintéo?</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Mintéo fra poco</l>
             <l part="I">Il trono usurperà.</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">Mintéo? Che dici?</l>
             <l part="I">&gt;Il mio fido Mintéo?</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Come? e non sai</l>
             <l>Ch'ei del popol ribelle</l>
             <l part="I">E' capo e condottier?</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="M">Che ascolto!</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Or credi</l>
             <l>A quel dolce sembiante,</l>
@@ -2185,24 +2207,24 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>MINTÉO e detti.</stage>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">Ah, traditore! <stage>(snudando la spada e andandogli incontro</stage></l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l>Perché quel nudo acciaro? <stage>(con modestia</stage></l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l>Empio! ribelle!</l>
             <l part="I">&gt;Perfido! ingrato!</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="M"><stage>(come sopra)</stage> A me, signor!</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">Son questi</l>
             <l>Delle mie cure i frutti? A' doni miei</l>
@@ -2215,79 +2237,79 @@
             <l>Saran queste mie ciglia aperte a' rai,</l>
             <l>Io lo difenderò, tu non l'avrai.</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="I">Ma per pietà m'ascolta.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F"><stage>(con compassione)</stage> Ah, si permetta</l>
             <l part="I">Ch'ei parli almeno!</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="M">E che può dir?</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">Si vuole,</l>
             <l>Signor, ch'io sia Svenvango: il volgo il crede;</l>
             <l part="I">Ed io se a quei tumulti...</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">E tu, spergiuro,</l>
             <l part="I">Suo condottier ti fai?</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Ma se non lasci</l>
             <l part="I">Ch'ei possa dir. <stage>(come sopra, ma con impeto</stage></l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">Se a quei tumulti io debba</l>
             <l>Oppormi o secondarli, a chieder vengo</l>
             <l part="I">L'oracolo da te.</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">Sì, ma conduci</l>
             <l>Tutto un popolo armato; apri una reggia</l>
             <l part="I">Commessa alla tua fé.</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">La reggia è chiusa,</l>
             <l>Signor; nessun mi siegue; io vengo solo</l>
             <l part="I">A presentarmi a te.</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="M">Ma Ulania...</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Io vidi</l>
             <l>Su le porte i ribelli,</l>
             <l>Le vidi aprir, vidi Mintéo fra loro:</l>
             <l part="I">Che più attender dovea?</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="M"><stage>(sorpreso)</stage> Dunque...</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">Tu sei</l>
             <l>Della mia sorte e del cinese impero</l>
             <l part="I">L'arbitro ognor.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="M">(Né deggio amarlo?)</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">Ascolta.</l>
             <l>Esamina, disponi</l>
@@ -2296,23 +2318,23 @@
             <l>L'imperial retaggio,</l>
             <l>Del pubblico riposo eccomi ostaggio. <stage>(depone la spada</stage></l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="I">(Che adorabile eroe!)</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">Figlio, a gran torto</l>
             <l> Io t'insultai; ma l'inudito eccesso</l>
             <l>Di tua virtù mi scusa: è grande a segno</l>
             <l part="I">Che superò le mie speranze. <stage>(rimette la spada</stage></l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Or dimmi</l>
             <l part="I">Ch'ei re non sia.</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">No, principessa. Al tempio,</l>
             <l>Caro Mintéo, mi siegui; in faccia al nume</l>
@@ -2333,12 +2355,12 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>ULANIA e MINTÉO</stage>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l>Mi lusingai che mi rendesse un trono</l>
             <l part="I">Degno di te, ma...</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Senza il trono, è degno</l>
             <l>Ch'io l'adori Mintéo. Non ha bisogno</l>
@@ -2346,24 +2368,24 @@
             <l>Chi tanto ha in sé. Con quel del mondo intero</l>
             <l>Io del tuo cor non cangerei l'impero.</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l>Chi provò fra' mortali</l>
             <l>Maggior felicità? Mio ben, mio nume,</l>
             <l part="I">Amor mio, mia speranza...</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Andiamo al tempio;</l>
             <l part="I">Leango attenderà.</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">Sì, mi precedi:</l>
             <l>Con Siveno a momenti</l>
             <l part="I">Io ti raggiungerò. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Ferma; Siveno</l>
             <l>Or non è nella reggia. Il Ciel sa quando</l>
@@ -2371,7 +2393,7 @@
             <l>Ne uscì poc'anzi armato</l>
             <l part="I">Per opporsi a' ribelli.</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">Ah, sconsigliato!</l>
             <l>Io con tanto sudor del volgo insano</l>
@@ -2380,21 +2402,21 @@
             <l>Ad irritarlo, ad arrischiarsi! Ah, soffri</l>
             <l part="I">Che a soccorrerlo io vada.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">E per Siveno</l>
             <l>Così lasciar mi déi?</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l>Egli è in rischio, mia vita, e tu nol sei.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l>Ah, Mintéo, non è questa</l>
             <l part="I">Prova di poco amore?</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">Anzi è gran prova</l>
             <l>Dell'amor mio costante:</l>
@@ -2437,41 +2459,41 @@
           <head>SCENA SETTIMA</head>
           <stage>Parte interna ed illuminata della maggiore imperial Pagoda. Così la struttura come gli ornamenti del magnifico edifizio esprimono il genio ed il culto della nazione.</stage>
           <stage>Bonzi, Manderini d'armi e di lettere, grandi e custodi. All'aprirsi della scena si vede LEANGO in atto di ascoltar con isdegno alcune delle guardie. Poi giunge LISINGA.</stage>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l>E voi, stupidi, e voi del suo periglio</l>
             <l>Venite adesso ad avvertirmi? Andiamo;</l>
             <l>Seguitemi, codardi, <stage>(incamminandosi</stage></l>
             <l part="I">A difender Siveno.</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F"><stage>(piangendo)</stage> E' tardi, è tardi.</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="I">Che?</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="M">Più non vive.</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">Ah! no? Chi l'assicura?</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l>Questi occhi... oh Dio! questi occhi. Io dalla cima</l>
             <l>Della torre maggiore... aimè... lo vidi</l>
             <l>Affrettarsi... assalir... Sperò... volea...</l>
             <l part="I">Ah, non posso parlar!</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="M">Gelo!</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">Ei nel fianco</l>
             <l>Del popol folto urtò co' suoi. Lo assalse</l>
@@ -2483,7 +2505,7 @@
             <l>Ripercosso, trafitto, urtato e spinto</l>
             <l>Pende sul fiume, e vi trabocca estinto.</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l>A sì barbaro colpo</l>
             <l>Cede la mia costanza. Abbiam perduto,</l>
@@ -2513,63 +2535,63 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>ULANIA e detti.</stage>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">Leango, ah quale,</l>
             <l>Qual novella io ti porto!</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l>Troppo, ah! troppo lo so: Siveno è morto.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="I">Vive, vive Siveno.</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="M">Oh Ciel!</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">Qual nume</l>
             <l part="I">Potea salvarlo?</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="M">Il suo Mintéo.</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">Che dici?</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="I">E' vero?</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">E' vero. Ei giunse</l>
             <l>Opportuno a sottrarlo e all'onde e all'ire</l>
             <l part="I">Del popol folle.</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">A rintuzzarlo, amici,</l>
             <l part="I">Corrasi.</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="F">E' vano. Ha i Tartari alle spalle,</l>
             <l>La reggia a fronte; e, da Mintéo sedato,</l>
             <l>Non è più quel di pria:</l>
             <l>Sol dimanda il suo re, qualunque ei sia.</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="I">Ma Siveno dov'è?</l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="M">Vedilo.</l>
           </sp>
@@ -2577,14 +2599,14 @@
         <div type="scene">
           <head>SCENA ULTIMA</head>
           <stage>SIVENO, MINTÉO, séguito di Cinesi, due de' quali portano sopra bacili le fanciullesche vesti reali, e detti.</stage>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">Ah, vieni</l>
             <l> Dell'età mia cadente</l>
             <l>Delizia, onor, sostegno,</l>
             <l part="I">Vieni, mio re!</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">Sono il tuo figlio. Il trono,</l>
             <l>Signor, non dessi a me: l'usurperei</l>
@@ -2592,23 +2614,23 @@
             <l>Ecco in Mintéo; son troppo</l>
             <l>Grandi le prove sue: dubbio non resta.</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l>Leggi; e di' se v'è prova eguale a questa. <stage>(gli dà un foglio</stage></l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l>Chi vergò questo foglio?</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="I">&gt;Livanio, il tuo gran padre.</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">(Or chi son io?)</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l><stage>(legge)</stage> Popoli, il figlio mio</l>
             <l>Vive in Siveno. Io dell'eroica fede</l>
@@ -2616,64 +2638,64 @@
             <l>E' Leango l'eroe: credete a lui.</l>
             <l part="I">Livanio.</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="M">E ben?</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">Son fuor di me. Ma dimmi...</l>
             <l>(Appressatevi a noi). <stage>(a' Cinesi che portano i bacili, e che s'appressano)</stage> Dimmi: ravvisi</l>
             <l>Queste, tinte di sangue,</l>
             <l part="I">Regie spoglie infantili?</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F"><stage>(inorridisce)</stage> Aimè, che miro!</l>
             <l part="I">Donde in tua man?</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">Tutto saprai. Non era</l>
             <l>Svenvango in queste avvolto, allorché il ferro</l>
             <l part="I">De' ribelli il trafisse?</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">Oh Dio! non v'era. <stage>(con impeto di passione</stage></l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="I">Come!</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="M">V'era il mio figlio.</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="F">Il tuo! Chi mai,</l>
             <l part="I">Chi vel ravvolse?</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">Io stesso; ed io lo vidi</l>
             <l>In tua vece spirar. Questo è l'inganno</l>
             <l>Che ha serbato all'impero il vero erede.</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="I">Oh, virtù senza esempio!</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">Oh, eroica fede!</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l part="I">E ti costa...</l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="F">Ah, non più! Perché con queste</l>
             <l>Rimembranze funeste un dì sì lieto</l>
@@ -2687,15 +2709,15 @@
             <l>Nella tenera gola</l>
             <l>Rivedo, oh Dio! cader; tutte ho sul ciglio...</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l>Padre mio, caro padre, ecco il tuo figlio. <stage>(gli bacia la mano con impeto di gioia e di tenerezza</stage></l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="I">Che!<stage>(sorpreso</stage></l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">Tuo figlio son io. L'antico Alsingo</l>
             <l>Mi salvò moribondo, e in queste spoglie</l>
@@ -2703,33 +2725,33 @@
             <l>Cicatrici abbastanza. Osserva. Il caro</l>
             <l>Mio genitor tu sei. <stage>(mostrando le cicatrici della mano e della gola</stage></l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l part="I">Sostenetemi... Io manco... <stage>(le guarda, s'appoggia, ma non isviene</stage></l>
           </sp>
-          <sp>
+          <sp who="#ulania">
             <speaker>ULA.</speaker>
             <l part="M">Oh stelle!</l>
           </sp>
-          <sp>
+          <sp who="#lisinga">
             <speaker>LIS.</speaker>
             <l part="F">Oh dèi!</l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l>Ah, tu m'involi, amico, <stage>a Mintéo</stage></l>
             <l part="I">Il caro padre mio!</l>
           </sp>
-          <sp>
+          <sp who="#minteo">
             <speaker>MIN.</speaker>
             <l part="F">Ma rendo al trono</l>
             <l>Un monarca sì degno. <stage>(accennando a Siveno</stage></l>
           </sp>
-          <sp>
+          <sp who="#siveno">
             <speaker>SIV.</speaker>
             <l>Lascia, ah, lasciami il padre e prendi il regno! <stage>(stringendosi al petto la mano di Leango</stage></l>
           </sp>
-          <sp>
+          <sp who="#leango">
             <speaker>LEAN.</speaker>
             <l>Figli miei, cari figli, <stage>(abbracciando or l'uno or l'altro</stage></l>
             <l> Tacete per pietà. Non ho vigore</l>
@@ -2738,7 +2760,7 @@
             <l>Difesi il mio sovrano;</l>
             <l>Posso or morir: non ho vissuto in vano.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Sarà nota al mondo intero,</l>

--- a/tei/metastasio-l-impresario-delle-canarie.xml
+++ b/tei/metastasio-l-impresario-delle-canarie.xml
@@ -76,6 +76,16 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="dorina">
+            <persName>Dorina</persName>
+          </person>
+          <person xml:id="nibbio">
+            <persName>Nibbio</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -92,7 +102,7 @@
           <p>Dopo l'atto primo.</p>
         </argument>
         <stage><hi rend="normal">Dorina</hi>, poi <hi rend="normal">Nibbio</hi></stage>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Via sbrigatevi in fretta,</l>
           <l>Portate la spinetta, e da sedere.</l>
@@ -115,59 +125,59 @@
           <stage>(vedendo venire una delle due donne, che poi se n'entra)</stage>
           <l>Sarà ben ch'io lo vada ad incontrare.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Mia signora Dorina, al suo gran merito</l>
           <l>Profondissimamente io mi rassegno.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Son sua serva umilissima,</l>
           <l>E a maggior complimento io non m'impegno.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Forse di tanto ardire</l>
           <l>Si meraviglierà?</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Mi fa favore.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Anz'io mi do l'onore</l>
           <l>Di farle di me stesso, o bene o male</l>
           <l>Una dedicatoria universale.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Star incomodo più non è dovere:</l>
           <l>Sieda Vossignoria.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Con la sua compagnia</l>
           <l>Incomodo si resta in ogni loco:</l>
           <l>Si sta vicino a lei sempre sul foco.</l>
         </sp>
         <stage>(siedono)</stage>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>(Che strano complimento!) Almeno io bramo</l>
           <l>Il suo nome saper.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Nibbio mi chiamo</l>
           <l>Canario di nazione,</l>
           <l>E suo buon servitor di professione.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Ella è molto obbligante.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Io faccio il mio dovere.</l>
           <l>Deve dunque sapere</l>
@@ -179,35 +189,35 @@
           <l>Ci dovrà favorir, quando non sdegni</l>
           <l>La nostra offerta.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Ho quattro o cinque impegni;</l>
           <l>Ma Vedrò di servirla, ove m'accordi</l>
           <l>Un onorario comodo e decente.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Io sono differente</l>
           <l>Da tutti gl'impresari,</l>
           <l>E precipito a sacchi i miei denari.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Dunque il nostro contratto</l>
           <l>conchiuder si potrà.</l>
           <l>Una difficoltà però mi resta.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Qual è, signora?</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>È questa:</l>
           <l>Io la lingua non so di quel paese,</l>
           <l>E non m'intenderanno.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Eh! non si prenda affanno.</l>
           <l>il libretto non deve esser capito:</l>
@@ -215,32 +225,32 @@
           <l>E non si bada a questo:</l>
           <l>Si canti bene, e non importi il resto.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Nell'arie io son con lei,</l>
           <l>Ma ne' recitativi è un'altra cosa.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Anzi in questi potrà</l>
           <l>Cantar con quella lingua che le pare,</l>
           <l>Ché allor, com'Ella sa,</l>
           <l>Per solito l'udienza ha da ciarlare.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Com'è così, va bene.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Or le sue pretensioni</l>
           <l>Liberamente palesar mi può.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Voglio pensarci e poi risolverò.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Risolva, e le prometto</l>
           <l>Che avrà per onorario</l>
@@ -257,126 +267,126 @@
           <l>Se vien colà, mi creda,</l>
           <l>Gran preda ne farà.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Ell'ha troppa bontà.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Ma vuol ch'io parta</l>
           <l>Senza farmi sentire una cantata?</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Son tanto raffreddata</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Eh! non importa:</l>
           <l>Per dir un'aria sola</l>
           <l>Non bisogna gran fiato</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Il cembalo è scordato.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Questo non le farà gran pregiudizio</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Non sono in esercizio.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Qui canta per suo spasso.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Non v'è chi suoni il basso.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Da sé non vuol sonare</l>
           <l>Per non farmi goder la sua virtù.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Ella mi vuol burlare.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Eh! favorisca. (Io non ne posso più).</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Sonerò per servirla;</l>
           <stage>(va alla spinetta)</stage>
           <l>Ma resti in confidenza.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Non dubiti, signora. (Oh che pazienza!)</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>«Amor prepara»...</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Oh cara!</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>«Le mie catene»...</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Oh bene !</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>«Ch'io voglio perdere</l>
           <l>La libertà»...</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Bel trillo in verità!</l>
           <l>Che dolce appoggiatura!</l>
           <l>È un miracolo, è un mostro di natura.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>«Tu m'imprigiona.»...</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Oh buona!</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>«Di lacci priva»...</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Evviva!</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>«No, che più vivere</l>
           <l>L'alma non sa.»</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Da capo, in verità.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Signor Nibbio, perdoni</l>
           <l>La debolezza mia.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Burla Vossignoria:</l>
           <l>Ha una voce pastosa</l>
@@ -384,54 +394,54 @@
           <l>Ed è miracolosa</l>
           <l>Nel divorar biscrome a cento a cento.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Dal suo parlar comprendo</l>
           <l>Che di musica è intesa.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Io me ne intendo,</l>
           <l>Però quanto è bastante</l>
           <l>Per picciol ornamento a un dilettante.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Dunque non è dovere</l>
           <l>Ch'io' non abbia a godere il gran vantaggio</l>
           <l>Di sentirla cantare.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Io l'ubbidisco e non mi fo pregare.</l>
         </sp>
         <stage>(cava da saccoccia una cantata)</stage>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Sarà la sua cantata</l>
           <l>Di qualche illustre autore?</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Son d'un suo servitore</l>
           <l>E musica e parole.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>È ancor poeta?</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Anzi questo è il mio forte.</l>
           <l>Ho una vena terribile.</l>
           <l>Tanto che al mio paese</l>
           <l>Feci quindici drammi in men d'un mese.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Bella felicità! Via! favorisca.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Non è mia professione, e compatisca.</l>
           <stage>(va alla spinetta a cantare)</stage>
@@ -440,12 +450,12 @@
           <l>All' Etna de' tuoi lumi arder vorrei»...</l>
           <l>Noti, questa è per lei.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Grazie le rendo.</l>
           <l>(Che testa originale! Io non l'intendo).</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>«Fingi meco rigore</l>
           <l>Sol per prenderti spasso ;</l>
@@ -453,132 +463,132 @@
           <l>Bell'ostreca d'amore, e sembri un sasso.»</l>
           <l>Che ne dice?</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>È un portento.</l>
           <l>La sua musa canaria</l>
           <l>Mi sorprende, o signor.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Senta quest'aria.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Non la voglio stancare.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Se avessi da crepare</l>
           <l>Io la deggio servir.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Grazie! (Che tedio!</l>
           <l>Adesso ci rimedio).</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>«Perché, Lilla, perché</l>
           <l>Così crudel con me»...</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Che vuoi, Lisetta ?</l>
         </sp>
         <stage>(finge di esser chiamata, e va alla scena a parlare)</stage>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Disgrazia maledetta!</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Signor Nibbio, mi scusi,</l>
           <l>Deggio andare a un convito:</l>
           <l>Non s'aspetta che me; tutti vi sono.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Giusto veniva il buono.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Pazienza! Un'altra volta</l>
           <l>potrà farmi favore.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Ella perde il migliore.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Sarà disgrazia mia.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Senta, per cortesia, questa passata</l>
           <l>Piena di semituoni.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Ma se non posso!</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Eh! via</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>No, mi perdoni:</l>
           <l>Scusi la confidenza.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Pazienza!</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Già so che mi perdona.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Padrona.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Si lasci ccompagnare.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Le pare?</l>
           <l>S'Ella non entra in camera,</l>
           <l>Di qui non partirò.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Per non tenerla incomoda,</l>
           <l>Dunque così farò.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Io vado un poco a spasso,</l>
           <l>Ma torno adesso adesso.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Se non la servo abbasso,</l>
           <l>è per ragion del sesso.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Son servitor di casa.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Rimanga persuasa</l>
           <l>Ch'io non ho tale idea.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Ma questa è sua livrea,</l>
           <l>O che la voglia o no.</l>
@@ -590,7 +600,7 @@
           <p>Dopo il secondo atto.</p>
         </argument>
         <stage><hi rend="normal">Dorina</hi> vestita da teatro con sartori e cameriere, e poi <hi rend="normal">Nibbio</hi>.</stage>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Quest'abito vi dico che sta male:</l>
           <l>Da regina non è, non è alla moda:</l>
@@ -598,70 +608,70 @@
           <l>Deve aver dieci palmi e più di coda.</l>
         </sp>
         <stage>(in collera coi sartori)</stage>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Mi confermo qual fui:</l>
           <l>Son qui con la cantata.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>(Ci mancava costui!) Serva obbligata.</l>
           <l>Più corta questa parte;</l>
           <l>Tantin più, per favore.</l>
         </sp>
         <stage>(alli suddetti, non guardando Nibbio)</stage>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Recita questa sera?</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Sì signore.</l>
           <l>Presto! presto! Che fate?</l>
           <l>Un altro punto qui.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Farà la prima donna?</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Signor sì.</l>
           <l>Che manica storpiata!</l>
           <l>Qui la voglio allargata:</l>
           <l>In tutto ci si vede la miseria.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Credo che avrà materia</l>
           <l>Da poter farsi onore.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>(Che noia!) Sì signore.</l>
           <l>Pare che lo facciate per dispetto.</l>
           <l>Larga, larga, vi ho detto.</l>
           <l>Che razza di sartore!</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>L'opera quanto dura?</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Sì signore.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>(Che risposta!)</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Partite,</l>
           <l>Levatevi di qui.</l>
           <l>Lo porterò così per questa sera.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Ma certo, che maniera</l>
           <l>È questa di servire una signora?</l>
@@ -669,13 +679,13 @@
           <stage>(alli sartori, li quali partono scacciati)</stage>
           <l>(Così la finirà).</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Mi creda, in verità,</l>
           <l>Che non si può durare:</l>
           <l>Tutto da sé bisognerebbe fare.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Non gliel niego; ma poi</l>
           <l>Scorderà questa pena,</l>
@@ -683,7 +693,7 @@
           <l>Sentirà da' vicini e da' lontani</l>
           <l>Le sbattute de' piedi e delle mani.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Anzi appunto in teatro</l>
           <l>Son le pene maggiori.</l>
@@ -709,12 +719,12 @@
           <l>Io qui spendo il mio denaro;</l>
           <l>Voglio dir quel che mi par.”</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Signora, il suo gran rnerito</l>
           <l>Non sta soggetto a critica.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Quello che più mi turba è che nell'opera</l>
           <l>Ho una scena agitata,</l>
@@ -722,31 +732,31 @@
           <l>E temo che la collera</l>
           <l>M'abbia pregiudicata nella voce.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Ed io, per mia disgrazia,</l>
           <l>Questa sera ho un impegno,</l>
           <l>Che mi toglie il piacere</l>
           <l>Di poterla vedere.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Oh! mi dispiace:</l>
           <l>L'approvazion di lei</l>
           <l>Gradita mi saria.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Potrebbe in grazia mia</l>
           <l>Farmi godere una scenetta a solo?</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Lo farei volentieri ma, senza i lumi,</l>
           <l>Senza scene, istrumenti, e a pian terreno,</l>
           <l>Manca l'azione e cornparisce meno.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Questo non dà fastidio: si figuri</l>
           <l>Che qui l'orchestra suoni</l>
@@ -757,19 +767,19 @@
           <l>Porti seco la perla e l'antimonio:</l>
           <l>Io son qui, se bisogna, un Marc'Antonio.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Non occorre, ché il fatto non è quello:</l>
           <l>È una lite che avea con suo fratello.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Sarà per me bastante</l>
           <l>La parte d'ascoltante.</l>
           <l>Questo il cerino sia, questo il libretto:</l>
           <l>Faccia conto ch'io stia dentro un palchetto.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>«Ceppi, barbari ceppi, ombre funeste,</l>
           <l>Empie mura insensate,</l>
@@ -777,11 +787,11 @@
           <l>Mentre da queste ciglia</l>
           <l>Sgorga di pianto un mar?»...</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Povera figlia!</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>«Non vien da strano lido</l>
           <l>Barbaro usurpatore a tormi il regno:</l>
@@ -789,52 +799,52 @@
           <l>germano è l'ingrato</l>
           <l>Che mi scaccia dal soglio»......</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Oh che peccato!</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>«Delle catene al peso, al mio tormento</l>
           <l>Più non resisto, e già languir mi sento»....</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Fa da vero, sicuro.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>«Ah, Tolomeo spergiuro,</l>
           <l>Godi del mio martoro:</l>
           <l>Prendi il trono che brami; io manco, io moro.»</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Acqua, poter del mondo!</l>
           <l>Comparisse qualcuno!</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Oh, questa è bella! Io non ho mal nessuno.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>La fa sì naturale,</l>
           <l>Che ingannato mi son: veniamo all'aria.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Finisce qui.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Senz'altro?</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Sì signore.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Ma questo è un grand'errore</l>
           <l>Il poeta mi scusi. E dove mai</l>
@@ -842,34 +852,34 @@
           <l>Da mettere un arietta</l>
           <l>Cori qualche «farfalletta» o «navicella»?</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Dopo una scena tragica</l>
           <l>Vogliono certe stitiche persone</l>
           <l>Che stia male una tal cornparazione.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>No, no, comparazione: in questo sito</l>
           <l>Una similitudine bastava;</l>
           <l>E sa quanto l'udienza rallegrava?</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>(Che sciocco!)</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>In un mio dramma io mi ricordo,</l>
           <l>Dopo una scena simile</l>
           <l>Che un'aria mia fu così ben accolta,</l>
           <l>Che la gente gridava: “Un'altra volta !”</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Me la faccia sentire.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Sì, sì: per lei forse potrà servire.</l>
           <l>«La farfalla, che allo scuro</l>
@@ -883,30 +893,30 @@
           <l>Va sbalzando, va sparando</l>
           <l>Cannonate in quantità.»</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>(Che poesia curiosa!)</l>
           <l>Ella è particolare in ogni cosa.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Più d'uno me l'ha detto, e dice il vero.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Ma del nostro contratto</l>
           <l>Niente fin or si è fatto.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Anzi è concluso.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Come! Se il mio pensiero</l>
           <l>Non palesai peranco?</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Eccole un foglio in bianco</l>
           <l>Colla mia firma: in esso</l>
@@ -914,35 +924,35 @@
           <l>Di patti e condizioni:</l>
           <l>Purché venga con me, tutti son buoni.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Troppo si fida; esperienza alcuna</l>
           <l>Di me non ha Vossignoria fin ora.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Non importa, signora.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Ci porrò ch'io non recito</l>
           <l>Se non da prima donna, e che non voglio</l>
           <l>Che la parte sia corta.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Signora, non importa.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Che l'autor de' libretti</l>
           <l>Sia sempre amico mio, vi voglio ancora.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Non importa, signora.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>E che, oltre l'onorario, Ella mi debba</l>
           <l>Dar sorbetti e caffè,</l>
@@ -952,60 +962,60 @@
           <l>Di Brasile e d'Avana,</l>
           <l>E due regali almen la settimana.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Non m'importa: mi basta che un poco</l>
           <l>Si ricordi d'un suo servitore.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Speri, speri, ché forse il mio core</l>
           <l>Il suo merto distinguer saprà</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Ah! signora, la sola speranza</l>
           <l>Non mi serva, non giova per me.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Eh! signore; ma troppo s'avanza:</l>
           <l>Si contenti per ora così.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Ih! ma questa mi par scortesia:</l>
           <l>Tanta flemma soffrir non si può.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Oh! che fretta! Bastar gli potria</l>
           <l>Di parlarne vicino al Perù.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Uh! Ma tanto tenermi nel foco,</l>
           <l>Con sua pace, mi par crudeltà.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Con sua pace, non è crudeltà.</l>
           <l>Ma si spieghi: qual è il suo pensiero?</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Un affetto modesto e sincero.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Me ne parli, ma quando sto in ozio.</l>
         </sp>
-        <sp>
+        <sp who="#nibbio">
           <speaker>NIB.</speaker>
           <l>Ho paura che il nostro negozio</l>
           <l>Mai concluso fra noi non sarà.</l>
         </sp>
-        <sp>
+        <sp who="#dorina">
           <speaker>DOR.</speaker>
           <l>Non disperi: vedrerno. Chi sa?</l>
         </sp>

--- a/tei/metastasio-l-olimpiade.xml
+++ b/tei/metastasio-l-olimpiade.xml
@@ -85,6 +85,40 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="licida">
+            <persName>Licida</persName>
+          </person>
+          <person xml:id="aminta">
+            <persName>Aminta</persName>
+          </person>
+          <person xml:id="megacle">
+            <persName>Megacle</persName>
+          </person>
+          <person xml:id="coro">
+            <persName>Coro</persName>
+          </person>
+          <person xml:id="argene">
+            <persName>Argene</persName>
+          </person>
+          <person xml:id="aristea">
+            <persName>Aristea</persName>
+          </person>
+          <person xml:id="clistene">
+            <persName>Clistene</persName>
+          </person>
+          <person xml:id="alcandro">
+            <persName>Alcandro</persName>
+          </person>
+          <personGrp xml:id="sacerdoti">
+            <name>Coro di sacerdoto</name>
+          </personGrp>
+          <personGrp xml:id="popolo">
+            <name>Popolo</name>
+          </personGrp>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -123,19 +157,19 @@
             <emph>Fondo selvoso di cupa ed angusta valle, adombrata dall'alto da grandi alberi, che giungono ad intreciare i rami dall'uno all'altro colle, fra' quali è chiusa.</emph>
           </stage>
           <stage>LICIDA <emph>ed</emph> AMINTA</stage>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l>Ho risoluto, Aminta;</l>
             <l part="I">più consiglio non vuo'.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Licida, ascolta.</l>
             <l>Deh modera una volta</l>
             <l>questo tuo violento</l>
             <l part="I">spirito intollerante.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">E in chi poss'io</l>
             <l>fuor che in me più sperar? Megacle istesso,</l>
@@ -143,7 +177,7 @@
             <l>nel bisogno maggiore. Or va, riposa</l>
             <l part="I">su la fé d'un amico.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Ancor non dèi</l>
             <l>condannarlo però. Breve cammino</l>
@@ -157,7 +191,7 @@
             <l>agli olimpici giuochi</l>
             <l>oltre il meriggio, ed or non è l'aurora.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l>Sai pur che ognun, che aspiri</l>
             <l>all'olimpica palma, or sul mattino</l>
@@ -166,11 +200,11 @@
             <l>giurar di non valersi</l>
             <l part="I">di frode nel cimento.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="M">Il so.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">T'è noto</l>
             <l>ch'escluso è dalla pugna</l>
@@ -180,35 +214,35 @@
             <l>tumulto pastoral? Dunque che deggio</l>
             <l part="I">attender più, che più sperar?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Ma quale</l>
             <l part="I">sarebbe il tuo disegno?</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">All'ara innanzi</l>
             <l part="I">presentarmi con gli altri.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="M">E poi?</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Con gli altri</l>
             <l part="I">a suo tempo pugnar.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="M">Tu!</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Sì. Non credi</l>
             <l part="I">in me valor che basti?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Eh qui non giova,</l>
             <l>prence, il saper come si tratti il brando.</l>
@@ -220,7 +254,7 @@
             <l>del giovanile ardire</l>
             <l part="I">ti potresti pentir.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Se fosse a tempo</l>
             <l>Megacle giunto a tai contese esperto,</l>
@@ -233,57 +267,57 @@
             <l>delle greche sembianze; unica e bella</l>
             <l>fiamma di questo cor, benché novella.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="I">Ed Argene?</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Ed Argene</l>
             <l>più riveder non spero. Amor non vive,</l>
             <l part="I">quando muor la speranza.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">E pur giurasti</l>
             <l part="I">tante volte...</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">T'intendo. In queste fole,</l>
             <l>finché l'ora trascorra,</l>
             <l part="I">trattener mi vorresti. Addio.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Ma senti.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="I">No no.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Vedi che giunge...</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="I">Chi?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="M">Megacle.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="M">Dov'è?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Fra quelle piante</l>
             <l part="I">parmi... No... non è desso.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Ah mi deridi,</l>
             <l>e lo merito, Aminta. Io fui sì cieco,</l>
@@ -296,60 +330,60 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>MEGACLE <emph>e detti</emph>.</stage>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">Megacle è teco.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="I">Giusti dei!</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="M">Prence.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Amico.</l>
             <l>Vieni, vieni al mio seno. Ecco risorta</l>
             <l part="I">la mia speme cadente.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">E sarà vero</l>
             <l>che il Ciel m'offra una volta</l>
             <l part="I">la via d'esserti grato?</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">E pace e vita</l>
             <l part="I">tu puoi darmi, se vuoi.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="M">Come?</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Pugnando</l>
             <l>nell'olimpico agone</l>
             <l part="I">per me, col nome mio.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">Ma tu non sei</l>
             <l part="I">noto in Elide ancor?</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="M">No.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">Quale oggetto</l>
             <l part="I">ha questa trama?</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Il mio riposo. Oh Dio!</l>
             <l>non perdiamo i momenti. Appunto è l'ora</l>
@@ -359,7 +393,7 @@
             <l>inutile sarà, se più soggiorni.</l>
             <l>Vanne. Tutto saprai quando ritorni.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l>Superbo di me stesso</l>
             <l>andrò portando in fronte</l>
@@ -377,17 +411,17 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>LICIDA <emph>ed</emph> AMINTA</stage>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l>Oh generoso amico!</l>
             <l part="I">Oh Megacle fedel!</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Così di lui</l>
             <l part="I">non parlavi poc'anzi.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Eccomi al fine</l>
             <l>possessor d'Aristea. Vanne, disponi</l>
@@ -395,7 +429,7 @@
             <l>prima che il sol tramonti,</l>
             <l part="I">voglio quindi partir.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Più lento, o prence,</l>
             <l>nel fingerti felice. Ancor vi resta</l>
@@ -406,7 +440,7 @@
             <l>so che talor confonde il vile e 'l forte;</l>
             <l>né sempre ha la virtù l'istessa sorte.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l>Oh sei pure importuno</l>
             <l>con questo tuo noioso</l>
@@ -436,48 +470,48 @@
        tessendo ghirlande.</emph>CORO <emph>di</emph> NINFE
       <emph>e</emph> PASTORI <emph>tutti occupati in lavori
        pastorali. Poi</emph> ARISTEA <emph>con seguito.</emph> </stage>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Oh care selve, oh cara</l>
             <l>felice libertà!</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l>Qui se un piacer si gode,</l>
             <l>parte non v'ha la frode</l>
             <l>ma lo condisce a gara</l>
             <l>amore e fedeltà.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Oh care selve, oh cara</l>
             <l>felice libertà!</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l>Qui poco ognun possiede,</l>
             <l>e ricco ognun si crede:</l>
             <l>né, più bramando, impara</l>
             <l>che cosa è povertà.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Oh care selve, oh cara</l>
             <l>felice libertà!</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l>Senza custodi o mura</l>
             <l>la pace è qui sicura,</l>
             <l>che l'altrui voglia avara</l>
             <l>onde allettar non ha.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Oh care selve, oh cara</l>
             <l>felice libertà!</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l>Qui gl'innocenti amori</l>
             <l part="I">di ninfe...</l>
@@ -486,23 +520,23 @@
             </stage>
             <l part="M">Ecco Aristea.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Siegui, o Licori.</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l>Già il rozzo mio soggiorno</l>
             <l>torni a render felice, o principessa?</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l>Ah fuggir da me stessa</l>
             <l>potessi ancor, come dagli altri! Amica</l>
             <l>tu non sai qual funesto</l>
             <l part="I">giorno per me sia questo.</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">È questo un giorno</l>
             <l>glorioso per te. Di tua bellezza</l>
@@ -511,7 +545,7 @@
             <l>nell'olimpico agone</l>
             <l>tutto il fior della Grecia oggi s'espone.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l>Ma chi bramo non v'è. Deh si proponga</l>
             <l>men funesta materia</l>
@@ -523,7 +557,7 @@
             <l>raddolcisci, se puoi,</l>
             <l>i miei tormenti in rammentando i tuoi.</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l>Se avran tanta virtù, senza mercede</l>
             <l>non va la mia costanza. <stage><emph>(siede)</emph></stage> A te già dissi</l>
@@ -531,11 +565,11 @@
             <l>d'illustre sangue, e che gli affetti miei</l>
             <l>fur più nobili ancor de' miei natali.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="I">So fin qui.</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">De' miei mali</l>
             <l>ecco il principio. Del cretense soglio</l>
@@ -573,42 +607,42 @@
             <l>ma serbo al caro bene</l>
             <l>fido in sen di Licori il cor d'Argene.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l>In ver mi fai pietà. Ma la tua fuga</l>
             <l>non approvo però. Donzella e sola</l>
             <l>cercar contrade ignote,</l>
             <l part="I">abbandonar...</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">Dunque dovea la mano</l>
             <l part="I">a Megacle donar?</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Megacle? (Oh nome!)</l>
             <l part="I">Di qual Megacle parli?</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">Era lo sposo</l>
             <l>questi, che il re mi destinò. Dovea</l>
             <l part="I">dunque obbliar...</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="M">Ne sai la patria?</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">Atene.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="I">Come in Creta pervenne?</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">Amor vel trasse,</l>
             <l>com'ei stesso dicea, ramingo, afflitto.</l>
@@ -620,12 +654,12 @@
             <l>fu noto al padre; e dal reale impero</l>
             <l>destinato mi fu, perché straniero.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l>Ma ti ricordi ancora</l>
             <l part="I">le sue sembianze?</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">Io l'ho presente. Avea</l>
             <l>bionde le chiome, oscuro il ciglio, i labbri</l>
@@ -635,16 +669,16 @@
             <l>un soave parlar... Ma... principessa,</l>
             <l part="I">tu cambi di color! Che avvenne?</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Oh Dio!</l>
             <l>Quel Megacle, che pingi, è l'idol mio.</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="I">Che dici!</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Il vero. A lui,</l>
             <l>lunga stagion già mio segreto amante,</l>
@@ -655,42 +689,42 @@
             <l>da me partì; più nol rividi: e in questo</l>
             <l>punto da te so de' suoi casi il resto.</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l>In ver sembrano i nostri</l>
             <l part="I">favolosi accidenti.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Ah s'ei sapesse</l>
             <l part="I">ch'oggi per me qui si combatte!</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">In Creta</l>
             <l>a lui voli un tuo servo; e tu procura</l>
             <l part="I">la pugna differir.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="M">Come?</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">Clistene</l>
             <l>è pur tuo padre: ei qui presiede eletto</l>
             <l>arbitro delle cose; ei può, se vuole...</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="I">Ma non vorrà.</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="M">Che nuoce,</l>
             <l part="I">principessa, il tentarlo?</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">E ben, Clistene</l>
             <l part="I">vadasi a ritrovar.</l>
@@ -698,7 +732,7 @@
               <emph>(s'alzano)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">Fermati: ei viene.</l>
           </sp>
@@ -706,7 +740,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>CLISTENE <emph>con seguito, e dette</emph> .</stage>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l>Figlia, tutto è compìto. I nomi accolti,</l>
             <l>le vittime svenate, al gran cimento</l>
@@ -715,11 +749,11 @@
             <l>della pubblica fé, dell'onor mio,</l>
             <l part="I">differir non si può.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">(Speranze, addio).</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l>Ragion d'esser superba</l>
             <l>io ti darei, se ti dicessi tutti</l>
@@ -729,44 +763,44 @@
             <l>Erilo di Corinto, e fin di Creta</l>
             <l part="I">Licida venne.</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="M">Chi?</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="F">Licida, il figlio</l>
             <l part="I">del re cretense.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="M">Ei pur mi brama?</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="F">Ei viene</l>
             <l part="I">con gli altri a prova.</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">(Ah si scordò d'Argene!)</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="I">Sieguimi, figlia.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Ah questa pugna, o padre,</l>
             <l part="I">si differisca.</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="F">Un impossibil chiedi:</l>
             <l>dissi perché. Ma la cagion non trovo</l>
             <l part="I">di tal richiesta.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">A divenir soggette</l>
             <l>sempre v'è tempo. È d'Imeneo per noi</l>
@@ -774,7 +808,7 @@
             <l>che soffrire abbastanza</l>
             <l>nella nostra servil sorte infelice.</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l>Dice ognuna così, ma il ver non dice.</l>
             <l>Del destin non vi lagnate</l>
@@ -793,11 +827,11 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>ARISTEA <emph>ed</emph>  ARGENE</stage>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="I">Udisti, o principessa?</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Amica, addio:</l>
             <l>convien ch'io siegua il padre. Ah tu, che puoi,</l>
@@ -820,7 +854,7 @@
         <div type="scene">
           <head>SCENA VII</head>
           <stage>ARGENE <emph>sola</emph> .</stage>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l>Dunque Licida ingrato</l>
             <l>già di me si scordò! Povera Argene,</l>
@@ -855,23 +889,23 @@
         <div type="scene">
           <head>SCENA VIII</head>
           <stage>LICIDA <emph>e</emph>  MEGACLE <emph>da diverse parti</emph> .</stage>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="I">Licida.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="M">Amico.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="M">Eccomi a te.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Compisti...</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l>Tutto, o signor. Già col tuo nome al tempio</l>
             <l>per te mi presentai. Per te fra poco</l>
@@ -879,17 +913,17 @@
             <l>della pugna si dia, spiegar mi puoi</l>
             <l part="I">la cagion della trama.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Oh, se tu vinci,</l>
             <l>non ha di me più fortunato amante</l>
             <l part="I">tutto il regno d'Amor.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="M">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Promessa</l>
             <l>in premio al vincitore</l>
@@ -897,19 +931,19 @@
             <l>che n'arsi e la bramai. Ma poco esperto</l>
             <l part="I">negli atletici studi...</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">Intendo. Io deggio</l>
             <l part="I">conquistarla per te.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Sì. Chiedi poi</l>
             <l>la mia vita, il mio sangue, il regno mio;</l>
             <l>tutto, o Megacle amato, io t'offro, e tutto</l>
             <l part="I">scarso premio sarà.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">Di tanti, o prence,</l>
             <l>stimoli non fa d'uopo</l>
@@ -929,120 +963,120 @@
             <l>dell'olimpica polve il crine, il volto,</l>
             <l>del volgo spettator gli applausi ascolto.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l>Oh dolce amico! Oh cara</l>
             <l part="I">sospirata Aristea!</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="M">Che!</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Chiamo a nome</l>
             <l part="I">il mio tesoro.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">Ed Aristea si chiama?</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="I">Appunto.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="M">Altro ne sai?</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Presso a Corinto</l>
             <l>nacque in riva all'Asopo, al re Clistene</l>
             <l part="I">unica prole.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">(Aimè! Questa è il mio bene).</l>
             <l>E per lei si combatte?</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="I">Per lei.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">Questa degg'io</l>
             <l>conquistarti pugnando?</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="I">Questa.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">Ed è tua speranza e tuo conforto</l>
             <l part="I">sola Aristea?</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="M">Sola Aristea.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">(Son morto).</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l>Non ti stupir. Quando vedrai quel volto,</l>
             <l>forse mi scuserai. D'esserne amanti</l>
             <l>non avrebbon rossore i numi istessi.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="I">(Ah così nol sapessi!)</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Oh, se tu vinci,</l>
             <l>chi più lieto di me! Megacle istesso</l>
             <l>quanto mai ne godrà! Dì; non avrai</l>
             <l part="I">piacer del piacer mio?</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="M">Grande.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Il momento,</l>
             <l>che ad Aristea m'annodi,</l>
             <l>Megacle, dì, non ti parrà felice?</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="I">Felicissimo. (Oh dei!)</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Tu non vorrai</l>
             <l>pronubo accompagnarmi</l>
             <l part="I">al talamo nuzial?</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="M">(Che pena!)</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Parla.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l>Sì; come vuoi. (Qual nuova specie è questa</l>
             <l part="I">di martirio e d'inferno!)</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Oh quanto il giorno</l>
             <l>lungo è per me! Che l'aspettare uccida</l>
@@ -1050,21 +1084,21 @@
             <l>tu non credi, o non sai.</l>
             <l part="I">Lo so, lo credo.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Senti, amico. Io mi fingo</l>
             <l>già l'avvenir: già col desio possiedo</l>
             <l part="I">la dolce sposa.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="M">(Ah questo è troppo!)</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">E parmi...</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l>Ma taci: assai dicesti. Amico io sono;</l>
             <stage>
@@ -1073,64 +1107,64 @@
             <l>il mio dover comprendo;</l>
             <l part="I">ma poi...</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Perché ti sdegni? In che t'offendo?</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l>(Imprudente, che feci!) <stage><emph>(si ricompone)</emph></stage> Il mio trasporto</l>
             <l>è desio di servirti. Io stanco arrivo</l>
             <l>da cammin lungo: ho da pugnar: mi resta</l>
             <l>picciol tempo al riposo, e tu mel togli.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l>E chi mai ti ritenne</l>
             <l part="I">di spiegarti fin ora?</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">Il mio rispetto.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="I">Vuoi dunque riposar?</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="M">Sì.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Brami altrove</l>
             <l part="I">meco venir?</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="M">No.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Rimaner ti piace</l>
             <l part="I">qui fra quest'ombre?</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="M">Sì.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Restar degg'io?</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="I">No.</l>
             <stage>
               <emph>(con impazienza; e si getta a sedere)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">(Strana voglia!) E ben, riposa: addio.</l>
             <l>Mentre dormi, Amor fomenti</l>
@@ -1147,7 +1181,7 @@
         <div type="scene">
           <head>SCENA IX</head>
           <stage>MEGACLE <emph>solo</emph> .</stage>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l>Che intesi, eterni dei! Quale improvviso</l>
             <l>fulmine mi colpì! L'anima mia</l>
@@ -1179,29 +1213,29 @@
         <div type="scene">
           <head>SCENA X</head>
           <stage>ARISTEA <emph>e detto; poi</emph>  ALCANDRO</stage>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="I">Stranier.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="M">Chi mi sorprende?</l>
             <stage>
               <emph>(rivoltandosi)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="M">(Oh stelle!)</l>
             <stage>
               <emph>(riconoscendosi reciprocamente)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">(Oh dei!)</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l>Megacle! mia speranza!</l>
             <l>Ah sei pur tu? Pur ti riveggo? Oh Dio!</l>
@@ -1214,11 +1248,11 @@
             <l>Oh felici martìri!</l>
             <l>Oh ben sparsi fin or pianti e sospiri!</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="I">(Che fiero caso è il mio!)</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Megacle amato,</l>
             <l>e tu nulla rispondi?</l>
@@ -1228,40 +1262,40 @@
             <l>lagrime trattenute? Ah! più non sono</l>
             <l part="I">forse la fiamma tua? Forse...</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">Che dici!</l>
             <l>Sempre... Sappi... Son io...</l>
             <l>Parlar non so. (Che fiero caso è il mio!)</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l>Ma tu mi fai gelar. Dimmi: non sai</l>
             <l part="I">che per me qui si pugna?</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="M">Il so.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Non vieni</l>
             <l part="I">ad esporti per me?</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="M">Sì.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Perché mai</l>
             <l>dunque sei così mesto?</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l>Perché... (Barbari dei, che inferno è questo!)</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l>Intendo: alcun ti fece</l>
             <l>dubitar di mia fé. Se ciò t'affanna,</l>
@@ -1272,30 +1306,30 @@
             <l>il tuo volto nel cor. Mai d'altri accesa</l>
             <l>non fui, non sono, e non sarò. Vorrei...</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="I">
 Basta: lo so.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Vorrei morir più tosto</l>
             <l>che mancarti di fede un sol momento.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l>(Oh tormento maggior d'ogni tormento!)</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l>Ma guardami, ma parla,</l>
             <l part="I">ma dì...</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="M">Che posso dir?</l>
           </sp>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <stage>
               <emph>(uscendo frettoloso)</emph>
@@ -1307,16 +1341,16 @@ Basta: lo so.</l>
               <emph>(parte)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l>Assistetemi, o numi. Addio, mia vita.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l>E mi lasci così? Va; ti perdono,</l>
             <l part="I">pur che torni mio sposo.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">Ah sì gran sorte</l>
             <l part="I">non è per me!</l>
@@ -1324,94 +1358,94 @@ Basta: lo so.</l>
               <emph>(in atto di partire)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Senti. Tu m'ami ancora?</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="I">Quanto l'anima mia.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Fedel mi credi?</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="I">Sì, come bella.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">A conquistar mi vai?</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="I">Lo bramo almeno.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Il tuo valor primiero</l>
             <l part="I">hai pur?</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="M">Lo credo.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="M">E vincerai?</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">Lo spero.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l>Dunque allor non son io,</l>
             <l part="I">caro, la sposa tua?</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">Mia vita... Addio.</l>
             <l>Ne' giorni tuoi felici</l>
             <l>ricordati di me.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l>Perché così mi dici,</l>
             <l>anima mia, perché?</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l>Taci, bell'idol mio.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l>Parla, mio dolce amor.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l>Ah che parlando oh Dio!</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l>Ah che tacendo oh Dio!</l>
           </sp>
-          <sp>
+          <sp who="#aristea #megacle">
             <speaker>ARISTEA, MEGACLE</speaker>
             <l>tu mi trafiggi il cor.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l>(Veggio languir chi adoro,</l>
             <l>né intendo il suo languir).</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l>(Di gelosia mi moro,</l>
             <l>e non lo posso dir).</l>
           </sp>
-          <sp>
+          <sp who="#aristea #megacle">
             <speaker>ARISTEA, MEGACLE</speaker>
             <l>Chi mai provò di questo</l>
             <l>affanno più funesto,</l>
@@ -1425,25 +1459,25 @@ Basta: lo so.</l>
         <div type="scene">
           <head>SCENA I</head>
           <stage>ARISTEA <emph>ed</emph>  ARGENE</stage>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l>Ed ancor della pugna</l>
             <l part="I">l'esito non si sa?</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">No, bella Argene.</l>
             <l>È pur dura la legge, onde n'è tolto</l>
             <l part="I">d'esserne spettatrici!</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">Ah! che sarebbe</l>
             <l>forse pena maggior veder chi s'ama</l>
             <l>in cimento sì grande, e non potergli</l>
             <l part="I">porger soccorso: esser presente...</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Io sono</l>
             <l>presente ancor lontana: anzi mi fingo</l>
@@ -1460,7 +1494,7 @@ Basta: lo so.</l>
             <l>solo il ver temerei; ma il mio pensiero</l>
             <l>fa ch'io tema lontana il falso e il vero.</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="I">
 Né ancor si vede alcun.</l>
@@ -1468,32 +1502,32 @@ Né ancor si vede alcun.</l>
               <emph>(guardando per la scena)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <stage>
               <emph>(turbata)</emph>
             </stage>
             <l part="F">Né alcuno... Oh Dio!</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="I">Che avvenne?</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Oh come io tremo,</l>
             <l part="I">come palpito adesso!</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">E la cagione?</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l>È deciso il mio fato:</l>
             <l part="I">vedi Alcandro, che arriva.</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">Alcandro, ah corri:</l>
             <stage>
@@ -1505,34 +1539,34 @@ Né ancor si vede alcun.</l>
         <div type="scene">
           <head>SCENA II</head>
           <stage>ALCANDRO <emph>e dette</emph> .</stage>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l>Fortunate novelle. Il re m'invia</l>
             <l>nunzio felice, o principessa. Ed io...</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="I">
 La pugna terminò?</l>
           </sp>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l part="F">Sì; ascolta. Intorno</l>
             <l part="I">già impazienti...</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <stage>
               <emph>(ad Alcandro)</emph>
             </stage>
             <l part="F">Il vincitor si chiede.</l>
           </sp>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l>Tutto dirò. Già impazienti intorno</l>
             <l part="I">le turbe spettatrici...</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <stage>
               <emph>(con impazienza)</emph>
@@ -1540,48 +1574,48 @@ La pugna terminò?</l>
             <l part="F">Eh ch'io non cerco</l>
             <l part="I">questo da te.</l>
           </sp>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l part="F">Ma in ordine distinto...</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="I">Chi vinse dimmi sol.</l>
             <stage>
               <emph>(con isdegno)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l part="F">Licida ha vinto.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="I">
 Licida!</l>
           </sp>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l part="M">Appunto.</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">Il principe di Creta!</l>
           </sp>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l>Sì, che giunse poc'anzi a queste arene.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="I">
 (Sventurata Aristea!)</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">(Povera Argene!)</l>
           </sp>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l>Oh te felice! Oh quale</l>
             <stage>
@@ -1589,31 +1623,31 @@ Licida!</l>
             </stage>
             <l part="I">sposo ti diè la sorte!</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Alcandro, parti.</l>
           </sp>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l part="I">T'attende il re.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="M">Parti, verrò.</l>
           </sp>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l part="F">T'attende</l>
             <l>nel gran tempio adunata...</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="I">Né parti ancor?</l>
             <stage>
               <emph>(con isdegno)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l part="F">(Che ricompensa ingrata!)</l>
             <stage>
@@ -1624,24 +1658,24 @@ Licida!</l>
         <div type="scene">
           <head>SCENA III</head>
           <stage>ARISTEA <emph>ed</emph>   ARGENE</stage>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l>Ah dimmi, o principessa,</l>
             <l>v'è sotto il ciel chi possa dirsi, oh Dio!</l>
             <l part="I">più misera di me?</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Sì, vi son io.</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l>Ah non ti faccia amore</l>
             <l>provar mai le mie pene! Ah tu non sai</l>
             <l>qual perdita è la mia! Quanto mi costa</l>
             <l part="I">quel cor che tu m'involi!</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">E tu non senti,</l>
             <l>non comprendi abbastanza i miei tormenti.</l>
@@ -1661,12 +1695,12 @@ Licida!</l>
         <div type="scene">
           <head>SCENA IV</head>
           <stage>ARGENE <emph>e poi</emph>   AMINTA</stage>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l>E trovar non poss'io</l>
             <l part="I">né pietà né soccorso?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <stage>
               <emph>(a parte nell'uscire)</emph>
@@ -1674,7 +1708,7 @@ Licida!</l>
             <l part="F">Eterni dei!</l>
             <l part="I">parmi Argene colei.</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">Vendetta almeno,</l>
             <l part="I">vendetta si procuri.</l>
@@ -1682,13 +1716,13 @@ Licida!</l>
               <emph>(vuol partire)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Argene, e come</l>
             <l>tu in Elide! Tu sola!</l>
             <l part="I">Tu in sì ruvide spoglie!</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">I neri inganni</l>
             <l>a secondar del prence</l>
@@ -1699,11 +1733,11 @@ Licida!</l>
             <l>d'andarne altier. Chi vuol sapere appieno</l>
             <l>se fu attento il cultor, guardi il terreno.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>(Tutto già sa). Non da' consigli miei...</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l>Basta... Chi sa: nel Cielo</l>
             <l>v'è giustizia per tutti; e si ritrova</l>
@@ -1716,7 +1750,7 @@ Licida!</l>
             <l>l'abborrisca, l'evìti,</l>
             <l>e con orrore, a chi nol sa, l'addìti.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Non son questi pensieri</l>
             <l>degni d'Argene. Un consigliero infido,</l>
@@ -1727,19 +1761,19 @@ Licida!</l>
             <l>il racquistarlo amante</l>
             <l part="I">che opprimerlo nemico.</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">E credi, Aminta,</l>
             <l part="I">ch'ei tornerebbe a me?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Lo spero. Al fine</l>
             <l>fosti l'idolo suo. Per te languiva,</l>
             <l>delirava per te. Non ti sovviene</l>
             <l>che cento volte e cento...</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l>Tutto, per pena mia, tutto rammento.</l>
             <l>Che non mi disse un dì!</l>
@@ -1760,7 +1794,7 @@ Licida!</l>
         <div type="scene">
           <head>SCENA V</head>
           <stage>AMINTA <emph>solo</emph>  .</stage>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Insana gioventù! Qualora esposta</l>
             <l>ti veggo tanto agl'impeti d'amore,</l>
@@ -1790,35 +1824,35 @@ Licida!</l>
         <div type="scene">
           <head>SCENA VI</head>
           <stage>CLISTENE, <emph>preceduto da</emph>   LICIDA: ALCANDRO, MEGACLE, <emph>coronato d'ulivo;</emph>   CORO <emph>d'</emph>   ATLETI, <emph>guardie e popolo.</emph>  </stage>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Del forte Licida</l>
             <l>nome maggiore</l>
             <l>d'Alfeo sul margine</l>
             <l>mai non sonò.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>PARTE DEL CORO</speaker>
             <l>Sudor più nobile</l>
             <l>del suo sudore</l>
             <l>l'arena olimpica</l>
             <l>mai non bagnò.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>ALTRA PARTE</speaker>
             <l>L'arti ha di Pallade,</l>
             <l>l'ali ha d'Amore:</l>
             <l>d'Apollo e d'Ercole</l>
             <l>l'ardir mostrò.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>No, tanto merito,</l>
             <l>tanto valore</l>
             <l>l'ombra de' secoli</l>
             <l>coprir non può.</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l>Giovane valoroso,</l>
             <l>che in mezzo a tanta gloria umìl ti stai,</l>
@@ -1830,21 +1864,21 @@ Licida!</l>
             <l>chi sa, sarebbe tal. <stage><emph>(ad Alcandro)</emph></stage> Rammenti, Alcandro,</l>
             <l>con qual dolor tel consegnai? Ma pure...</l>
           </sp>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l>Tempo or non è di rammentar sventure.</l>
             <stage>
               <emph>(a Clistene)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l>(È ver). <stage><emph>(a Megacle)</emph></stage> Premio Aristea</l>
             <l>sarà del tuo valor. S'altro donarti</l>
             <l>Clistene può, chiedilo pur, che mai</l>
             <l>quanto dar ti vorrei non chiederai.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l>(Coraggio, o mia virtù). Signor, son figlio,</l>
             <l>e di tenero padre. Ogni contento,</l>
@@ -1855,11 +1889,11 @@ Licida!</l>
             <l>per queste nozze; e, lui presente, in Creta</l>
             <l part="I">legarmi ad Aristea.</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="F">Giusta è la brama.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l>Partirò, se il concedi,</l>
             <l>senz'altro indugio. In vece mia rimanga</l>
@@ -1869,14 +1903,14 @@ Licida!</l>
             </stage>
             <l part="I">servo, compagno e condottier.</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="F">(Che volto</l>
             <l>è questo mai! Nel rimirarlo il sangue</l>
             <l>mi si riscuote in ogni vena). E questi</l>
             <l part="I">chi è? Come s'appella?</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">Egisto ha nome,</l>
             <l>Creta è sua patria. Egli deriva ancora</l>
@@ -1886,29 +1920,29 @@ Licida!</l>
             <l>comuni a segno e l'allegrezza e 'l duolo,</l>
             <l>che Licida ed Egisto è un nome solo.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="I">(Ingegnosa amicizia!)</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="F">E ben, la cura</l>
             <l>di condurti la sposa</l>
             <l>Egisto avrà. Ma Licida non debbe</l>
             <l part="I">partir senza vederla.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">Ah no, sarebbe</l>
             <l>pena maggior. Mi sentirei morire</l>
             <l>nell'atto di lasciarla. Ancor da lunge</l>
             <l part="I">tanta pena io ne provo...</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="F">Ecco che giunge.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l>(Oh me infelice!)</l>
           </sp>
@@ -1916,7 +1950,7 @@ Licida!</l>
         <div type="scene">
           <head>SCENA VII</head>
           <stage>ARISTEA <emph>e detti</emph>  .</stage>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <stage>
               <emph>(non vedendo Megacle)</emph>
@@ -1924,43 +1958,43 @@ Licida!</l>
             <l>(All'odiose nozze</l>
             <l>come vittima io vengo all'ara avanti).</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l>(Sarà mio quel bel volto in pochi istanti).</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l>Avvicinati, o figlia; ecco il tuo sposo.</l>
             <stage>
               <emph>(tenendo Megacle per mano)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="I">(Ah! non è ver).</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="M">Lo sposo mio!</l>
             <stage>
               <emph>(stupisce vedendo Megacle)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="F">Sì. Vedi</l>
             <l>se giammai più bel nodo in Ciel si strinse.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l>(Ma se Licida vinse,</l>
             <l>come il mio bene?... Il genitor m'inganna?)</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l>(Crede Megacle sposo e se ne affanna).</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="I">
 E questi, o padre, è il vincitor?</l>
@@ -1968,7 +2002,7 @@ E questi, o padre, è il vincitor?</l>
               <emph>(additando Megacle)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="F">Mel chiedi?</l>
             <l>Non lo ravvisi al volto</l>
@@ -1977,33 +2011,33 @@ E questi, o padre, è il vincitor?</l>
             <l>che son di chi trionfa</l>
             <l>l'ornamento primiero?</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="I">Ma che dicesti, Alcandro?</l>
           </sp>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l part="F">Io dissi il vero.</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l>Non più dubbiezze. Ecco il consorte, a cui</l>
             <l>il Ciel t'accoppia: e nol potea più degno</l>
             <l>ottener dagli dei l'amor paterno.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="I">(Che gioia!)</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="M">(Che martìr!)</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">(Che giorno eterno!)</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="I">
 E voi tacete? Onde il silenzio?</l>
@@ -2011,17 +2045,17 @@ E voi tacete? Onde il silenzio?</l>
               <emph>(a Megacle ed Aristea)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">(Oh Dio!</l>
             <l part="I">come comincierò?)</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Parlar vorrei,</l>
             <l part="I">ma...</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="F">Intendo. Intempestiva</l>
             <l>è la presenza mia. Severo ciglio,</l>
@@ -2031,11 +2065,11 @@ E voi tacete? Onde il silenzio?</l>
             <l>quanto increbbero a me. Restate. Io lodo</l>
             <l>quel modesto rossor, che vi trattiene.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l>(Sempre lo stato mio peggior diviene).</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l>So ch'è fanciullo Amore,</l>
             <l>né conversar gli piace</l>
@@ -2052,12 +2086,12 @@ E voi tacete? Onde il silenzio?</l>
         <div type="scene">
           <head>SCENA VIII</head>
           <stage>ARISTEA, MEGACLE <emph>e</emph>   LICIDA</stage>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l>(Fra l'amico e l'amante,</l>
             <l part="I">che farò sventurato!)</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">All'idol mio</l>
             <l part="I">è tempo ch'io mi scopra.</l>
@@ -2065,20 +2099,20 @@ E voi tacete? Onde il silenzio?</l>
               <emph>(piano a Megacle)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">(Aspetta). Oh Dio!</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l>Sposo, alla tua consorte</l>
             <l part="I">non celar che t'affligge.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">(Oh pena! Oh morte!)</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l>L'amor mio, caro amico,</l>
             <stage>
@@ -2086,12 +2120,12 @@ E voi tacete? Onde il silenzio?</l>
             </stage>
             <l part="I">non soffre indugio.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Il tuo silenzio, o caro,</l>
             <l part="I">mi cruccia, mi dispera.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">(Ardir mio core:</l>
             <l>finiamo di morir). Per pochi istanti</l>
@@ -2100,11 +2134,11 @@ E voi tacete? Onde il silenzio?</l>
               <emph>(a parte a Licida)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">E qual ragione?...</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l>Va: fidati di me. Tutto conviene</l>
             <l part="I">ch'io spieghi ad Aristea.</l>
@@ -2112,12 +2146,12 @@ E voi tacete? Onde il silenzio?</l>
               <emph>(a parte a Licida)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Ma non poss'io</l>
             <l part="I">esser presente?</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">No: più che non credi</l>
             <l part="I">delicato è l'impegno.</l>
@@ -2125,7 +2159,7 @@ E voi tacete? Onde il silenzio?</l>
               <emph>(come sopra)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">E ben, tu 'l vuoi,</l>
             <l>io lo farò. Poco mi scosto: un cenno</l>
@@ -2142,12 +2176,12 @@ E voi tacete? Onde il silenzio?</l>
         <div type="scene">
           <head>SCENA IX</head>
           <stage>MEGACLE <emph>ed</emph>   ARISTEA</stage>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="I">
 (Oh ricordi crudeli!)</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Al fin siam soli:</l>
             <l>potrò senza ritegni</l>
@@ -2155,48 +2189,48 @@ E voi tacete? Onde il silenzio?</l>
             <l>mia speme, mio diletto,</l>
             <l part="I">luce degli occhi miei...</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">No, principessa,</l>
             <l>questi soavi nomi</l>
             <l>non son per me. Serbali pure ad altro</l>
             <l part="I">più fortunato amante.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">E il tempo è questo</l>
             <l>di parlarmi così? Giunto è quel giorno...</l>
             <l>Ma semplice ch'io son: tu scherzi, o caro,</l>
             <l part="I">ed io stolta m'affanno.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">Ah! non t'affanni</l>
             <l part="I">senza ragion.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Spiegati dunque. Ascolta:</l>
             <l>ma coraggio, Aristea. L'alma prepara</l>
             <l>a dar di tua virtù la prova estrema.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l>Parla. Aimè! che vuoi dirmi? Il cor mi trema.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l>Odi. In me non dicesti</l>
             <l>mille volte d'amar, più che 'l sembiante,</l>
             <l>il grato cor, l'alma sincera, e quella,</l>
             <l>che m'ardea nel pensier, fiamma d'onore?</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l>Lo dissi, è ver. Tal mi sembrasti, e tale</l>
             <l part="I">ti conosco, t'adoro.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">E se diverso</l>
             <l>fosse Megacle un dì da quel che dici;</l>
@@ -2207,23 +2241,23 @@ E voi tacete? Onde il silenzio?</l>
             <l>amor per lui? Lo soffriresti amante?</l>
             <l part="I">L'accetteresti sposo?</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">E come vuoi</l>
             <l>ch'io figurar mi possa</l>
             <l part="I">Megacle mio sì scellerato?</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">Or sappi</l>
             <l>che per legge fatale,</l>
             <l>se tuo sposo divien, Megacle è tale.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="I">Come!</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">Tutto l'arcano</l>
             <l>ecco ti svelo. Il principe di Creta</l>
@@ -2231,28 +2265,28 @@ E voi tacete? Onde il silenzio?</l>
             <l>e la vita mi diede. Ah principessa,</l>
             <l>se negarla poss'io, dillo tu stessa.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="I">E pugnasti...</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="M">Per lui.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Perder mi vuoi...</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l>Sì, per serbarmi sempre</l>
             <l part="I">degno di te.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="M">Dunque io dovrò...</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">Tu dèi</l>
             <l>coronar l'opra mia. Sì, generosa,</l>
@@ -2263,14 +2297,14 @@ E voi tacete? Onde il silenzio?</l>
             <l>vivo di lui nel seno;</l>
             <l>e s'ei t'acquista, io non ti perdo appieno.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l>Ah qual passaggio è questo! Io dalle stelle</l>
             <l>precipito agli abissi. Eh no: si cerchi</l>
             <l>miglior compenso. Ah! senza te la vita</l>
             <l part="I">per me vita non è.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">Bella Aristea,</l>
             <l>non congiurar tu ancora</l>
@@ -2279,24 +2313,24 @@ E voi tacete? Onde il silenzio?</l>
             <l>di quei teneri sensi</l>
             <l part="I">quant'opera distrugge!</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">E di lasciarmi...</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="I">Ho risoluto.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Hai risoluto? E quando?</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l>Questo (morir mi sento)</l>
             <l part="I">questo è l'ultimo addio.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">L'ultimo! Ingrato...</l>
             <l>Soccorretemi, o numi! Il piè vacilla:</l>
@@ -2306,28 +2340,28 @@ E voi tacete? Onde il silenzio?</l>
               <emph>(s'appoggia ad un tronco)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l>Sento che il mio valore</l>
             <l>mancando va. Più che a partir dimoro,</l>
             <l>meno ne son capace.</l>
             <l>Ardir. Vado, Aristea: rimanti in pace.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="I">
 Come! Già m'abbandoni?</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">È forza, o cara,</l>
             <l part="I">separarsi una volta.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="M">E parti...</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">E parto</l>
             <l>per non tornar più mai.</l>
@@ -2335,11 +2369,11 @@ Come! Già m'abbandoni?</l>
               <emph>(in atto di partire)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l>Senti. Ah no... Dove vai?</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l>A spirar, mio tesoro,</l>
             <l part="I">lungi dagli occhi tuoi.</l>
@@ -2347,14 +2381,14 @@ Come! Già m'abbandoni?</l>
               <emph>(Megacle parte risoluto, poi si ferma)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Soccorso... Io... moro.</l>
             <stage>
               <emph>(sviene sopra un sasso)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l>Misero me, che veggo!</l>
             <stage>
@@ -2390,13 +2424,13 @@ Come! Già m'abbandoni?</l>
         <div type="scene">
           <head>SCENA X</head>
           <stage>LICIDA <emph>e detti</emph>  .</stage>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">
 Intese</l>
             <l part="I">tutto Aristea?</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">Tutto. T'affretta, o prence;</l>
             <l part="I">soccorri la tua sposa.</l>
@@ -2404,7 +2438,7 @@ Intese</l>
               <emph>(in atto di partire)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Aimè, che miro!</l>
             <l part="I">Che fu?</l>
@@ -2412,7 +2446,7 @@ Intese</l>
               <emph>(a Megacle)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">Doglia improvvisa</l>
             <l part="I">le oppresse i sensi.</l>
@@ -2420,11 +2454,11 @@ Intese</l>
               <emph>(partendo, come sopra)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="M">E tu mi lasci?</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">Io vado...</l>
             <stage>
@@ -2453,26 +2487,26 @@ Intese</l>
         <div type="scene">
           <head>SCENA XI</head>
           <stage>LICIDA <emph>ed</emph>   ARISTEA</stage>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l>Che laberinto è questo! Io non l'intendo.</l>
             <l>Semiviva Aristea... Megacle afflitto...</l>
             <l part="I">Oh Dio!</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Ma già quell'alma</l>
             <l>torna agli usati uffizi. Apri i bei lumi,</l>
             <l part="I">principessa, ben mio.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <stage>
               <emph>(senza vederlo)</emph>
             </stage>
             <l part="F">Sposo infedele!</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l>Ah! non dirmi così. Di mia costanza</l>
             <l part="I">ecco in pegno la destra.</l>
@@ -2480,7 +2514,7 @@ Intese</l>
               <emph>(la prende per mano)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Almeno... Oh stelle!</l>
             <stage>
@@ -2488,20 +2522,20 @@ Intese</l>
             </stage>
             <l part="I">Megacle ov'è?</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="M">Partì.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Partì l'ingrato?</l>
             <l>Ebbe cor di lasciarmi in questo stato?</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l>Il tuo sposo restò.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <stage>
               <emph>(s'alza con impeto)</emph>
@@ -2512,24 +2546,24 @@ Intese</l>
             <l>incenerir non sanno,</l>
             <l>numi, i fulmini vostri in ciel che fanno?</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l>Son fuor di me. Dì, che t'offese, o cara?</l>
             <l>Parla; brami vendetta? Ecco il tuo sposo,</l>
             <l part="I">ecco Licida...</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Oh dei!</l>
             <l>Tu quel Licida sei! Fuggi, t'invola,</l>
             <l>nasconditi da me. Per tua cagione,</l>
             <l>perfido, mi ritrovo a questo passo.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l>E qual colpa ho commessa? Io son di sasso.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l>Tu me da me dividi;</l>
             <l>barbaro, tu m'uccidi:</l>
@@ -2547,22 +2581,22 @@ Intese</l>
         <div type="scene">
           <head>SCENA XII</head>
           <stage>LICIDA <emph>e poi</emph>   ARGENE</stage>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l>A me «barbaro»! Oh numi!</l>
             <l>«Perfido» a me! Voglio seguirla; e voglio</l>
             <l>sapere almen che strano enigma è questo.</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="I">
 Fermati, traditor.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Sogno o son desto!</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l>Non sogni no: son io</l>
             <l>l'abbandonata Argene. Anima ingrata,</l>
@@ -2571,7 +2605,7 @@ Fermati, traditor.</l>
             <l>in sorte sì funesta</l>
             <l>delle antiche sembianze orma vi resta.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l>(Donde viene; in qual punto</l>
             <l>mi sorprende costei! Se più mi fermo,</l>
@@ -2582,19 +2616,19 @@ Fermati, traditor.</l>
               <emph>(vuol partire)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <stage>
               <emph>(trattenendola)</emph>
             </stage>
             <l part="F">Indegno, ascolta.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="I">
 (Misero me!)</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">Tu non m'intendi? Intendo</l>
             <l>ben io la tua perfidia. I nuovi amori,</l>
@@ -2602,7 +2636,7 @@ Fermati, traditor.</l>
             <l>saprà da me Clistene</l>
             <l part="I">per tua vergogna.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Ah no! Sentimi, Argene.</l>
             <l>Non sdegnarti: perdona,</l>
@@ -2610,7 +2644,7 @@ Fermati, traditor.</l>
             <l>gli antichi affetti; e, se tacer saprai,</l>
             <l part="I">forse... chi sa.</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">Si può soffrir di questa</l>
             <l>ingiuria più crudel! «Chi sa», mi dici?</l>
@@ -2618,23 +2652,23 @@ Fermati, traditor.</l>
             <l>di tua bontà non sono</l>
             <l>le vie che m'offri a meritar perdono.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="I">Ascolta. Io volli dir...</l>
             <stage>
               <emph>(vuol prenderla per mano)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">Lasciami, ingrato:</l>
             <l part="I">non ti voglio ascoltar.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">(Son disperato).</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l>No, la speranza</l>
             <l>più non m'alletta:</l>
@@ -2652,7 +2686,7 @@ Fermati, traditor.</l>
         <div type="scene">
           <head>SCENA XIII</head>
           <stage>LICIDA <emph>e poi</emph>   AMINTA</stage>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l>In angustia più fiera</l>
             <l>io non mi vidi mai. Tutto è in ruina,</l>
@@ -2666,35 +2700,35 @@ Fermati, traditor.</l>
               <emph>(vuol partire)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Megacle è morto!</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="I">
 Che dici, Aminta!</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Io dico</l>
             <l part="I">pur troppo il ver.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Come! Perché? Qual empio</l>
             <l>sì bei giorni troncò? Trovisi: io voglio</l>
             <l>ch'esempio di vendetta altrui ne resti.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Principe, nol cercar: tu l'uccidesti.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="I">Io! Deliri?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Volesse</l>
             <l>il Ciel ch'io delirassi. Odimi. In traccia</l>
@@ -2718,11 +2752,11 @@ Che dici, Aminta!</l>
             <l>m'uccide, e non lo sa; ma non m'offende:</l>
             <l>suo dono è questa vita; ei la riprende».</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="I">Oh amico! E poi?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Fugge da me, ciò detto,</l>
             <l>come partico stral. Vedi quel sasso,</l>
@@ -2734,7 +2768,7 @@ Che dici, Aminta!</l>
             <l>si riunì; l'ascose. Il colpo, i gridi</l>
             <l>replicaron le sponde; e più nol vidi.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l>Ah qual orrida scena</l>
             <l part="I">or si scopre al mio sguardo!</l>
@@ -2742,7 +2776,7 @@ Che dici, Aminta!</l>
               <emph>(rimane stupido)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Almen la spoglia,</l>
             <l>che albergò sì bell'alma,</l>
@@ -2756,7 +2790,7 @@ Che dici, Aminta!</l>
         <div type="scene">
           <head>SCENA XIV</head>
           <stage>LICIDA <emph>e poi</emph>   ALCANDRO</stage>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l>Dove son! Che m'avvenne! Ah dunque il Cielo</l>
             <l>tutte sopra il mio capo</l>
@@ -2771,59 +2805,59 @@ Che dici, Aminta!</l>
             <l>a ricalcar su l'orme</l>
             <l>d'Ercole e di Tesèo le vie di morte.</l>
           </sp>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l part="I">Olà!</l>
             <stage>
               <emph>(Licida non l'ode)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="M">Del guado estremo...</l>
           </sp>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l part="M">Olà!</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Chi sei</l>
             <l>tu, che audace interrompi</l>
             <l part="I">le smanie mie?</l>
           </sp>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l part="F">Regio ministro io sono.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="I">
 Che vuole il re?</l>
           </sp>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l part="F">Che in vergognoso esiglio</l>
             <l>quindi lungi tu vada. Il sol cadente</l>
             <l>se in Elide ti lascia,</l>
             <l part="I">sei reo di morte.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="M">A me tal cenno?</l>
           </sp>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l part="F">Impara</l>
             <l>a mentir nome, a violar la fede,</l>
             <l part="I">a deludere i re.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Come! Ed ardisci,</l>
             <l part="I">temerario...</l>
           </sp>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l part="F">Non più. Principe, è questo</l>
             <l>mio dover; l'ho adempito: adempi il resto.</l>
@@ -2835,7 +2869,7 @@ Che vuole il re?</l>
         <div type="scene">
           <head>SCENA XV</head>
           <stage>LICIDA <emph>solo</emph>  .</stage>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l>Con questo ferro, indegno,</l>
             <l>il sen ti passerò... Folle, che dico?</l>
@@ -2880,12 +2914,12 @@ Che vuole il re?</l>
             <emph>Bipartita che si forma dalle rovine di un antico ippodromo, già ricoperte in gran parte d'edera, di spini e d'altre piante selvagge.</emph>
           </stage>
           <stage>MEGACLE, <emph>trattenuto da</emph>  AMINTA <emph>per una parte, e dopo</emph>  ARISTEA, <emph>trattenuta da</emph>  ARGENE <emph>per l'altra: ma quelli non veggono queste</emph>  .</stage>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="I">
 Lasciami. In van t'opponi.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Ah torna, amico,</l>
             <l>una volta in te stesso. In tuo soccorso</l>
@@ -2894,135 +2928,135 @@ Lasciami. In van t'opponi.</l>
             <l>credimi, non avrai. Si stanca il Cielo</l>
             <l part="I">d'assister chi l'insulta.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">Empio soccorso,</l>
             <l>inumana pietà! negar la morte</l>
             <l>a chi vive morendo. Aminta, oh Dio!</l>
             <l part="I">lasciami.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="M">Non fia ver.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Lasciami, Argene.</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="I">
 Non lo sperar.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">Senz'Aristea non posso,</l>
             <l part="I">non deggio viver più.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Morir vogl'io</l>
             <l part="I">dove Megacle è morto.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <stage>
               <emph>(a Megacle)</emph>
             </stage>
             <l part="M">Attendi.</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <stage>
               <emph>(ad Aristea)</emph>
             </stage>
             <l part="F">Ascolta.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="I">Che attender?</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="M">Che ascoltar?</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">Non si ritrova</l>
             <l part="I">più conforto per me.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Per me nel mondo</l>
             <l part="I">non v'è più che sperar.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">Serbarmi in vita...</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l>Impedirmi la morte...</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="I">Indarno tu pretendi.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">In van presumi.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="I">Ferma.</l>
             <stage>
               <emph>(volendo trattener Megacle, che gli fugge)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="M">Senti, infelice.</l>
             <stage>
               <emph>(volendo trattenere Aristea, come sopra)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <stage>
               <emph>(incontrandosi in Megacle)</emph>
             </stage>
             <l part="M">Oh stelle!</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <stage>
               <emph>(incontrando Aristea)</emph>
             </stage>
             <l part="F">Oh numi!</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="I">Megacle!</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="M">Principessa!</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Ingrato! E tanto</l>
             <l>m'odii dunque e mi fuggi,</l>
             <l>che, per esserti unita</l>
             <l>s'io m'affretto a morir, tu torni in vita?</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l>Vedi a qual segno è giunta,</l>
             <l>adorata Aristea, la mia sventura;</l>
             <l>io non posso morir: trovo impedite</l>
             <l>tutte le vie, per cui si passa a Dite.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l>Ma qual pietosa mano...</l>
           </sp>
@@ -3030,37 +3064,37 @@ Non lo sperar.</l>
         <div type="scene">
           <head>SCENA II</head>
           <stage>ALCANDRO <emph>e detti</emph>  .</stage>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l>Oh sacrilego! Oh insano!</l>
             <l part="I">Oh scellerato ardir!</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Vi sono ancora</l>
             <l part="I">nuovi disastri, Alcandro?</l>
           </sp>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l part="F">In questo istante</l>
             <l part="I">rinasce il padre tuo.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="M">Come!</l>
           </sp>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l part="F">Che orrore,</l>
             <l>che ruina, che lutto,</l>
             <l>se 'l Ciel non difendea, n'avrebbe involti!</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="I">
 Perché?</l>
           </sp>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l part="F">Già sai che per costume antico</l>
             <l>questo festivo dì con un solenne</l>
@@ -3080,11 +3114,11 @@ Perché?</l>
             <l>«Mori», grida fremendo, e gli alza in fronte</l>
             <l part="I">il sacrilego ferro.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="M">Oh Dio!</l>
           </sp>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l part="F">Non cangia</l>
             <l>il re sito o color. Severo il guardo</l>
@@ -3098,30 +3132,30 @@ Perché?</l>
             <l>e dal ciglio, che tanto</l>
             <l>minaccioso parea, prorompe il pianto.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="I">
 Respiro.</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="M">Oh folle!</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="M">Oh sconsigliato!</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Ed ora</l>
             <l part="I">il genitor che fa?</l>
           </sp>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l part="F">Di lacci avvolto</l>
             <l part="I">ha il colpevole innanzi.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">(Ah! si procuri</l>
             <l>di salvar l'infelice).</l>
@@ -3129,12 +3163,12 @@ Respiro.</l>
               <emph>(parte)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="I">
 E Licida che dice?</l>
           </sp>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l part="F">Alle richieste</l>
             <l>nulla risponde. È reo di morte, e pare</l>
@@ -3143,12 +3177,12 @@ E Licida che dice?</l>
             <l>lo vuol da tutti; e fra' suoi labbri, come</l>
             <l>altro non sappia dir, sempre ha quel nome.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l>Più resister non posso. Al caro amico</l>
             <l part="I">per pietà chi mi guida?</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Incauto! E quale</l>
             <l>sarebbe il tuo disegno? Il genitore</l>
@@ -3156,7 +3190,7 @@ E Licida che dice?</l>
             <l>sa che Megacle sei; perdi te stesso</l>
             <l>presentandoti al re; non salvi altrui.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l>Col mio principe insieme</l>
             <l part="I">almen mi perderò.</l>
@@ -3164,23 +3198,23 @@ E Licida che dice?</l>
               <emph>(vuol partire)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Senti. E non stimi</l>
             <l>consiglio assai miglior, che il padre offeso</l>
             <l part="I">vada a placare io stessa?</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">Ah! che di tanto</l>
             <l part="I">lusingarmi non so.</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Sì, questo ancora</l>
             <l part="I">per te si faccia.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">Oh generosa, oh grande,</l>
             <l>oh pietosa Aristea! Facciano i numi</l>
@@ -3189,7 +3223,7 @@ E Licida che dice?</l>
             <l>quando pria ti mirai, che tu non eri</l>
             <l part="I">cosa mortal. Va, mio conforto...</l>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="F">Ah basta;</l>
             <l>non fa d'uopo di tanto.</l>
@@ -3211,7 +3245,7 @@ E Licida che dice?</l>
         <div type="scene">
           <head>SCENA III</head>
           <stage>MEGACLE <emph>ed</emph>   ARGENE</stage>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l>Deh secondate, o numi,</l>
             <l>la pietà d'Aristea. Chi sa se il padre</l>
@@ -3222,14 +3256,14 @@ E Licida che dice?</l>
             <l>veder come l'ascolta. Argene, io voglio</l>
             <l part="I">seguitarla da lungi.</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">Ah tanta cura</l>
             <l>non prender di costui. Vedi che 'l Cielo</l>
             <l>è stanco di soffrirlo. Al suo destino</l>
             <l>lascialo in abbandono.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l>Lasciar l'amico! Ah così vil non sono.</l>
             <l>Lo seguitai felice</l>
@@ -3248,7 +3282,7 @@ E Licida che dice?</l>
         <div type="scene">
           <head>SCENA IV</head>
           <stage>ARGENE, <emph>poi</emph>   AMINTA</stage>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l>E pure a mio dispetto</l>
             <l>sento pietade anch'io. Tento sdegnarmi,</l>
@@ -3263,27 +3297,27 @@ E Licida che dice?</l>
             <l>se mi cadesse accanto,</l>
             <l>non verserei per lui stilla di pianto.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Misero dove fuggo? Oh dì funesto!</l>
             <l part="I">Oh Licida infelice!</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">È forse estinto</l>
             <l part="I">quel traditor?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">No, ma il sarà fra poco.</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l>Non lo credere, Aminta. Hanno i malvagi</l>
             <l>molti compagni; onde giammai non sono</l>
             <l part="I">poveri di soccorso.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Or ti lusinghi:</l>
             <l>non v'è più che sperar. Contro di lui</l>
@@ -3297,12 +3331,12 @@ E Licida che dice?</l>
             <l>l'offeso re presente; e al sacerdote</l>
             <l part="I">porgere il sacro acciaro.</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">E non potrebbe</l>
             <l part="I">rivocarsi il decreto?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">E come? Il reo</l>
             <l>già in bianche spoglie è avvolto. Il crin di fiori</l>
@@ -3311,31 +3345,31 @@ E Licida che dice?</l>
             <l>ah! forse adesso, Argene,</l>
             <l>la bipenne fatal gli apre le vene.</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l>Ah no, povero prence!</l>
             <stage>
               <emph>(piange)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="I">Che giova il pianto?</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">Ed Aristea non giunse?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Giunse; ma nulla ottenne. Il re non vuole,</l>
             <l>o non può compiacerla.</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="I">E Megacle?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Il meschino</l>
             <l>ne' custodi s'avvenne,</l>
@@ -3346,7 +3380,7 @@ E Licida che dice?</l>
             <l>ottenuto l'avria. Ma un reo per l'altro</l>
             <l part="I">morir non può.</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">L'ha procurato almeno.</l>
             <l>Oh forte! Oh generoso! Ed io l'ascolto</l>
@@ -3372,7 +3406,7 @@ E Licida che dice?</l>
         <div type="scene">
           <head>SCENA V</head>
           <stage>AMINTA <emph>solo</emph>  .</stage>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Fuggi, salvati, Aminta. In queste sponde</l>
             <l>tutto è orror, tutto è morte. E dove, oh Dio!</l>
@@ -3404,37 +3438,37 @@ E Licida che dice?</l>
             <emph>Aspetto esteriore del gran tempio di Giove Olimpico, dal quale si scende per lunga e magnifica scala divisa in vari piani. Piazza innanzi al medesimo con ara ardente nel mezzo. Bosco all'intorno de' sacri ulivi silvestri, donde formavansi le corone per gli atleti vincitori.</emph>
           </stage>
           <stage>CLISTENE, <emph>che scende dal tempio, preceduto da numeroso popolo, de' suoi custodi, da</emph>  LICIDA <emph>in bianca veste, coronato di fiori, da</emph>  ALCANDRO <emph>e dal coro de' sacerdoti, de' quali alcuni portano sopra bacili d'oro gli stromenti del sagrifizio</emph>  .</stage>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>I tuoi strali terror de' mortali</l>
             <l>ah! sospendi, gran padre de' numi,</l>
             <l>ah! deponi, gran nume de' re.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>PARTE DEL CORO</speaker>
             <l>Fumi il tempio del sangue d'un empio,</l>
             <l>che oltraggiò con insano furore,</l>
             <l>sommo Giove, un'immago di te.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>I tuoi strali terror de' mortali</l>
             <l>ah! sospendi, gran padre de' numi,</l>
             <l>ah! deponi, gran nume de' re.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>PARTE DEL CORO</speaker>
             <l>L'onde chete del pallido Lete</l>
             <l>l'empio varchi; ma il nostro timore</l>
             <l>ma il suo fallo portando con sé.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>I tuoi strali terror de' mortali</l>
             <l>ah! sospendi, gran padre de' numi,</l>
             <l>ah! deponi, gran nume de' re.</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l>Giovane sventurato, ecco vicino</l>
             <l>de' tuoi miseri dì l'ultimo istante.</l>
@@ -3456,7 +3490,7 @@ E Licida che dice?</l>
             <l>fedele esecutor. Quanto ti piace,</l>
             <l>figlio, prescrivi; e chiudi i lumi in pace.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l>Padre, che ben di padre,</l>
             <l>non di giudice e re, que' detti sono,</l>
@@ -3471,7 +3505,7 @@ E Licida che dice?</l>
             <l>l'ultima grazia imploro</l>
             <l>d'abbracciarlo Una volta, e lieto io moro.</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l>T'appagherò. Custodi,</l>
             <stage>
@@ -3479,12 +3513,12 @@ E Licida che dice?</l>
             </stage>
             <l part="I">Megacle a me.</l>
           </sp>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l part="F">Signor, tu piangi! E quale</l>
             <l>eccessiva pietà l'alma t'ingombra?</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l>Alcandro, lo confesso,</l>
             <l>stupisco di me stesso. Il volto, il ciglio,</l>
@@ -3509,23 +3543,23 @@ E Licida che dice?</l>
         <div type="scene">
           <head>SCENA VII</head>
           <stage>MEGACLE <emph>fra le guardie, e detti</emph>  .</stage>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l>Ah! vieni, illustre esempio</l>
             <l>di verace amistà: Megacle amato,</l>
             <l part="I">caro Megacle, vieni.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">Ah qual ti trovo,</l>
             <l part="I">povero prence!</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Il rivederti in vita</l>
             <l part="I">mi fa dolce la morte.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">E che mi giova</l>
             <l>una vita, che in vano</l>
@@ -3533,7 +3567,7 @@ E Licida che dice?</l>
             <l>Licida, non andrai. Noi passeremo</l>
             <l>ombre amiche indivise il guado estremo.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l>O delle gioie mie, de' miei martiri,</l>
             <l>finché piacque al destin, dolce compagno,</l>
@@ -3553,11 +3587,11 @@ E Licida che dice?</l>
             <l>tu gli asciuga sul ciglio;</l>
             <l>e in te, se un figlio vuol, rendigli un figlio.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="I">Taci: mi fai morir.</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="F">Non posso, Alcandro,</l>
             <l>resister più. Guarda que' volti: osserva</l>
@@ -3566,12 +3600,12 @@ E Licida che dice?</l>
             <l>fra le lagrime alterne ultimi baci.</l>
             <l part="I">Povera umanità!</l>
           </sp>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l part="F">Signor, trascorre</l>
             <l part="I">l'ora permessa al sacrifizio.</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="F">È vero.</l>
             <l>Olà, sacri ministri,</l>
@@ -3582,35 +3616,35 @@ E Licida che dice?</l>
               <emph>(son divisi da' sacerdoti e da' custodi)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">Barbari! Ah voi</l>
             <l>avete dal mio sen svelto il cor mio!</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="I">
 Ah dolce amico!</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="M">Ah caro prence!</l>
           </sp>
-          <sp>
+          <sp who="#licida #megacle">
             <speaker>LICIDA, MEGACLE</speaker>
             <stage>
               <emph>(guardandosi da lontano)</emph>
             </stage>
             <l part="F">Addio!</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>I tuoi strali terror de' mortali</l>
             <l>ah! sospendi, gran padre de' numi</l>
             <l>ah! deponi, gran nume de' re.</l>
             <stage><emph>(Nel tempo che si canta il coro, Licida va ad inginocchiarsi apiè dell'ara appresso al sacerdote. Il re prende la sacra scure, che gli vien presentata sopra un bacile da un de' ministri del tempio; e, nel porgerla al sacerdote canta i seguenti versi, accompagnati da grave sinfonia)</emph>  .</stage>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l>O degli uomini padre e degli dei,</l>
             <l>onnipotente Giove,</l>
@@ -3630,17 +3664,17 @@ Ah dolce amico!</l>
         <div type="scene">
           <head>SCENA VIII</head>
           <stage>ARGENE <emph>e detti</emph>  .</stage>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l>Fermati, o re. Fermate,</l>
             <l part="I">sacri ministri.</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="F">Oh insano ardir! Non sai,</l>
             <l part="I">ninfa, qual opra turbi?</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">Anzi più grata</l>
             <l>vengo a renderla a Giove. Una io vi reco</l>
@@ -3648,29 +3682,29 @@ Ah dolce amico!</l>
             <l>che ha valor, che ha desio</l>
             <l part="I">di morir per quel reo.</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="M">Qual è?</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">Son io.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="I">(Oh bella fede!)</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="M">(Oh mio rossor!)</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="F">Dovresti</l>
             <l>saper che al debil sesso</l>
             <l>pel più forte morir non è permesso.</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l>Ma il morir non si vieta</l>
             <l>per lo sposo a una sposa. In questa guisa</l>
@@ -3678,40 +3712,40 @@ Ah dolce amico!</l>
             <l>serbò la vita Alceste; e so che poi</l>
             <l>l'esempio suo divenne legge a noi.</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l>Che perciò? Sei tu forse</l>
             <l part="I">di Licida consorte?</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">Ei me ne diede</l>
             <l>in pegno la sua destra e la sua fede.</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l>Licori, io, che t'ascolto,</l>
             <l>son più folle di te. D'un regio erede</l>
             <l>una vil pastorella</l>
             <l part="I">dunque...</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">Né vil son io,</l>
             <l>né son Licori. Argene ho nome: in Creta</l>
             <l>chiara è del sangue mio la gloria antica:</l>
             <l>e, se giurommi fé, Licida il dica.</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="I">Licida, parla.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">(È l'esser menzognero</l>
             <l>questa volta pietà). No, non è vero.</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l>Come! E negar lo puoi? Volgiti, ingrato;</l>
             <l>riconosci i tuoi doni,</l>
@@ -3721,16 +3755,16 @@ Ah dolce amico!</l>
             <l>ebbi da te. Ti risovvenga almeno</l>
             <l>che di tua man me ne adornasti il seno.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="I">
 (Pur troppo è ver).</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="M">Guardalo, o re.</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="F">Dinanzi</l>
             <stage>
@@ -3738,7 +3772,7 @@ Ah dolce amico!</l>
             </stage>
             <l part="I">mi si tolga costei.</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">Popoli, amici,</l>
             <l>sacri ministri, eterni dei, se pure</l>
@@ -3753,12 +3787,12 @@ Ah dolce amico!</l>
         <div type="scene">
           <head>SCENA IX</head>
           <stage>ARISTEA <emph>e detti</emph>  .</stage>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l>Credimi, o padre,</l>
             <l part="I">è degna di pietà.</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="F">Dunque volete</l>
             <l>ch'io mi riduca a delirar con voi?</l>
@@ -3767,7 +3801,7 @@ Ah dolce amico!</l>
               <emph>(ad Argene)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l>Parlino queste gemme,</l>
             <stage>
@@ -3776,7 +3810,7 @@ Ah dolce amico!</l>
             <l>io tacerò. Van di tai fregi adorne</l>
             <l part="I">in Elide le ninfe?</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <stage>
               <emph>(lo guarda e si turba)</emph>
@@ -3785,69 +3819,69 @@ Ah dolce amico!</l>
             <l>Alcandro riconosci</l>
             <l part="I">questo monil?</l>
           </sp>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l part="F">Se il riconosco? È quello</l>
             <l>che al collo avea, quando l'esposi all'onde,</l>
             <l part="I">il tuo figlio bambin.</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="F">Licida (oh Dio!</l>
             <l>tremo da capo a piè). Licida, sorgi,</l>
             <l>guarda: è ver che costei</l>
             <l part="I">l'ebbe in dono da te?</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Però non debbe</l>
             <l>morir per me. Fu la promessa occulta,</l>
             <l>non ebbe effetto; e col solenne rito</l>
             <l part="I">l'imeneo non si strinse.</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="F">Io chiedo solo</l>
             <l part="I">se il dono è tuo.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="M">Sì.</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="F">Da qual man ti venne?</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="I">
 A me donollo Aminta.</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="F">E questo Aminta</l>
             <l part="I">chi è?</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Quello a cui diede</l>
             <l>il genitor degli anni miei la cura.</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="I">
 Dove sta?</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Meco venne;</l>
             <l>meco in Elide è giunto.</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="I">Questo Aminta si cerchi.</l>
           </sp>
-          <sp>
+          <sp who="#argene">
             <speaker>ARGENE</speaker>
             <l part="F">Eccolo appunto.</l>
           </sp>
@@ -3855,36 +3889,36 @@ Dove sta?</l>
         <div type="scene">
           <head>SCENA X</head>
           <stage>AMINTA <emph>e detti</emph>  .</stage>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="I">Ah, Licida...</l>
             <stage>
               <emph>(vuole abbracciarlo)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="F">T'accheta.</l>
             <l>Rispondi, e non mentir. Questo monile</l>
             <l part="I">donde avesti?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Signor, da mano ignota,</l>
             <l>già scorse il quinto lustro</l>
             <l part="I">ch'io l'ebbi in don.</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="M">Dov'eri allor?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Là, dove</l>
             <l>in mar presso a Corinto</l>
             <l part="I">sbocca il torbido Asopo.</l>
           </sp>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l part="F">(Ah! ch'io rinvengo</l>
             <stage>
@@ -3899,11 +3933,11 @@ Dove sta?</l>
             <l>mio re, son reo. Deh mel perdona: io tutto</l>
             <l part="I">fedelmente dirò.</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="F">Sorgi, favella.</l>
           </sp>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l>Al mar, come imponesti,</l>
             <l>non esposi il bambin: pietà mi vinse.</l>
@@ -3912,32 +3946,32 @@ Dove sta?</l>
             <l>che in rimote contrade</l>
             <l part="I">tratto l'avrebbe.</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="F">E quel fanciullo, Aminta,</l>
             <l part="I">dov'è? Che ne facesti?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Io... (Quale arcano</l>
             <l part="I">ho da scoprir!)</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="F">Tu impallidisci! Parla,</l>
             <l>empio; dì, che ne fu? Tacendo aggiungi</l>
             <l>all'antico delitto error novello.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>L'hai presente, o signor: Licida è quello.</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l>Come! non è di Creta</l>
             <l part="I">Licida il prence?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Il vero prence in fasce</l>
             <l>finì la vita. Io, ritornato appunto</l>
@@ -3945,61 +3979,61 @@ Dove sta?</l>
             <l>l'offersi in dono: ei dell'estinto in vece</l>
             <l>al trono l'educò per mio consiglio.</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l>Oh numi! ecco Filinto, ecco il mio figlio.</l>
             <stage>
               <emph>(abbracciandolo)</emph>
             </stage>
           </sp>
-          <sp>
+          <sp who="#aristea">
             <speaker>ARISTEA</speaker>
             <l part="I">Stelle!</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="M">Io tuo figlio?</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="F">Sì. Tu mi nascesti</l>
             <l>gemello ad Aristea. Delfo m'impose</l>
             <l>d'esporti al mar bambino, un parricida</l>
             <l part="I">minacciandomi in te.</l>
           </sp>
-          <sp>
+          <sp who="#licida">
             <speaker>LICIDA</speaker>
             <l part="F">Comprendo adesso</l>
             <l>l'orror che mi gelò, quando la mano</l>
             <l part="I">sollevai per ferirti.</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="F">Adesso intendo</l>
             <l>l'eccessiva pietà, che nel mirarti</l>
             <l part="I">mi sentivo nel cor.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Felice padre!</l>
           </sp>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l>Oggi molti in un punto</l>
             <l part="I">puoi render lieti.</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="F">E lo desio. D'Argene</l>
             <l>Filinto il figlio mio,</l>
             <l>Megacle d'Aristea vorrei consorte;</l>
             <l>ma Filinto, il mio figlio, è reo di morte.</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="I">Non è più reo, quando è tuo figlio.</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="F">È forse</l>
             <l>la libertà de' falli</l>
@@ -4010,15 +4044,15 @@ Dove sta?</l>
             <l>risvegliate su l'ara il sacro fuoco.</l>
             <l>Va, figlio, e mori. Anch'io morrò fra poco.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Che giustizia inumana!</l>
           </sp>
-          <sp>
+          <sp who="#alcandro">
             <speaker>ALCANDRO</speaker>
             <l part="I">Che barbara virtù!</l>
           </sp>
-          <sp>
+          <sp who="#megacle">
             <speaker>MEGACLE</speaker>
             <l part="F">Signor, t'arresta.</l>
             <l>Tu non puoi condannarlo. In Sicione</l>
@@ -4026,13 +4060,13 @@ Dove sta?</l>
             <l>a cui tu presiedesti. Il reo dipende</l>
             <l part="I">dal pubblico giudizio.</l>
           </sp>
-          <sp>
+          <sp who="#clistene">
             <speaker>CLISTENE</speaker>
             <l part="F">E ben s'ascolti</l>
             <l>dunque il pubblico voto. A prò del reo</l>
             <l>non prego, non comando, e non consiglio.</l>
           </sp>
-          <sp>
+          <sp who="#sacerdoti #popolo">
             <speaker>CORO DI SACERDOTI E POPOLO</speaker>
             <l>Vivà il figlio delinquente,</l>
             <l>perché in lui non sia punito</l>

--- a/tei/metastasio-nitteti.xml
+++ b/tei/metastasio-nitteti.xml
@@ -75,6 +75,31 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="amenofi">
+            <persName>Amenofi</persName>
+          </person>
+          <person xml:id="sammete">
+            <persName>Sammete</persName>
+          </person>
+          <person xml:id="nitteti">
+            <persName>Nitteti</persName>
+          </person>
+          <person xml:id="beroe">
+            <persName>Beroe</persName>
+          </person>
+          <person xml:id="bubaste">
+            <persName>Bubaste</persName>
+          </person>
+          <personGrp xml:id="coro">
+            <name>Coro</name>
+          </personGrp>
+          <person xml:id="amasi">
+            <persName>Amasi</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Pavia</name>Digitalizzazione</change>
@@ -129,7 +154,7 @@
           <head>SCENA PRIMA</head>
           <stage>Parte ombrosa e raccolta degl'interni giardini della reggia di Canopo alle sponde del Nilo, corrispondenti a diversi appartamenti. Sole mascente su l'orizzonte.</stage>
           <stage>AMENOFI impaziente, poi SAMMETE in abito pastorale che approda sopra picciolo battello.</stage>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l>E Sammete non torna!</l>
             <l>Oimè! già spunta il sol. Sa pur che il padre</l>
@@ -153,32 +178,32 @@
             <l>Tutto in moto è Canopo: ho palpitato</l>
             <l part="I">Assai fin or per te.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">Son disperato.</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="I">Perché, Sammete? Onde l'affanno?</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">Oh Dio!</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l>Parla. Forse rifiuta</l>
             <l part="I">Beroe gli affetti tuoi?</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">Beroe è perduta.</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="I">Perduta! Oimè! Come? Che dici?</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">In vano</l>
             <l>Fin or di là dal fiume</l>
@@ -187,13 +212,13 @@
             <l>Or sul monte, or sul piano</l>
             <l>Replicai mille volte, e sempre in vano.</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l>Che tu non sei Dalmiro,</l>
             <l>Che un pastor tu non sei</l>
             <l>Forse Beroe ha scoperto, e a te s'invola.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l>No, caro amico; il caso</l>
             <l>E' più funesto assai. Da un fuggitivo</l>
@@ -202,24 +227,24 @@
             <l>Altra ninfa unita</l>
             <l>Fu da gente crudel Beroe rapita.</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l>Forse da qualche stuolo</l>
             <l>D'arabi masnadieri?</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l>No, d'egizi guerrieri:</l>
             <l part="I">Ei l'asserì.</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="F">Non so pensar... Ma fugge,</l>
             <l>Sammete, il tempo. Ah, le tue spoglie usate</l>
             <l>Vanne a vestir! Questo real soggiorno</l>
             <l part="I">Per Dalmiro non è.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">Vado e ritorno.</l>
             <l>Ma non partir: sovvienti</l>
@@ -242,7 +267,7 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>AMENOFI, poi NITTETI e BEROE, entrambi in abito pastorale, fra guardie.</stage>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l>Oh come, amor tiranno,</l>
             <l>Confondi i sensi e la ragion disarmi!</l>
@@ -251,49 +276,49 @@
             <l>Donna real? Che fu? Perché d'armati</l>
             <l part="I">Cinta così?</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F">Nol so. Vittima io vengo</l>
             <l>Forse del nuovo re. Dal bosco, in cui</l>
             <l>Io m'ascondea da lui, qui tratta a forza</l>
             <l part="I">Son con l'ospite mia.</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="F">No; t'assicura:</l>
             <l>Amasi non trascorre a questi eccessi.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l>(Dalmiro almen potessi</l>
             <l part="I">Del mio caso avvertir).</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="F">Di questa schiera</l>
             <l part="I">Qual è il duce, e dov'è?</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F">Bubaste ha nome;</l>
             <l part="I">Va incontro al re.</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="F">Raggiungerollo. Or ora</l>
             <l>In libertà sarai; ne son sicuro.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l>(Le smanie di Dalmiro io mi figuro).</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l>Prence, la prima prova</l>
             <l>Del tuo bel cor questa non è. Son grata,</l>
             <l part="I">Conosco...</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="F">Ah no, non mi conosci: io sempre...</l>
             <l>Sappi... Tu sei... Sperai... (Barbaro amore!</l>
@@ -315,7 +340,7 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>NITTETI e BEROE, in fine BUBASTE.</stage>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l>Nitteti, ah per pietà, fedel compagna</l>
             <l>Se m'avesti fin or, s'è ver che m'ami,</l>
@@ -326,24 +351,24 @@
             <l>Tutto temer poss'io;</l>
             <l>Troppo fido è quel core, e troppo è mio.</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l>Non tante smanie, amata Beroe: andrai;</l>
             <l>Farò tutto per te. Ma della sorte</l>
             <l>Vedi pur ch'io lo sdegno</l>
             <l>Con più costanza a tollerar t'insegno.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l>Nel caso in cui tu sei,</l>
             <l>Maestra di costanza anch'io sarei.</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l>Perché? Forse i miei mali</l>
             <l part="I">Non eguagliano i tuoi?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">V'è gran distanza.</l>
             <l>Siam prigioniere entrambe;</l>
@@ -351,7 +376,7 @@
             <l>Tu sospiri, io sospiro;</l>
             <l>Ma in Canopo è Sammete, e non Dalmiro.</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l>E' ver; confesso, amica,</l>
             <l>La debolezza mia; Sammete adoro;</l>
@@ -360,39 +385,39 @@
             <l>Quel caro volto ond'è il mio core acceso,</l>
             <l>Di mie catene alleggerisce il peso.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l>Basta un ben che tu speri</l>
             <l>Per consolarti, e vuoi che un ben ch'io perdo</l>
             <l part="I">Affliggermi non debba?</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F">Ah, se vedessi</l>
             <l>Il mio Sammete, approveresti assai</l>
             <l part="I">La mia tranquillità!</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Se fosse noto</l>
             <l>Dalmiro a te, condanneresti meno</l>
             <l part="I">L'intolleranza mia.</l>
           </sp>
-          <sp>
+          <sp who="#bubaste">
             <speaker>BUB.</speaker>
             <l part="F">Nitteti, arriva</l>
             <l>Amasi; io là m'invio:</l>
             <l part="I">Scorgetela, o custodi. <stage>(espone e parte</stage></l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F">Amica, addio.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="I">Così mi lasci! Io che farò?</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F">T'accheta,</l>
             <l>Amata Beroe; a me ti fida, e credi</l>
@@ -415,65 +440,65 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>BEROE, SAMMETE nel proprio suo abito; poi AMENOFI</stage>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l>Questi reali alberghi <stage>(guardando curiosa intorno</stage></l>
             <l>Son pur nuovi per me! Dovunque io miro...</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="I">Ecco deposte al fin... Beroe! <stage>(si veggono, e si guardano fissamente alcuni istanti senza parlare</stage></l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Dalmiro!</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="I">Tu qui?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Tu in quelle spoglie!</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="I">A che vieni? ove vai?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Che strano evento</l>
             <l>Ti trasforma in tal guisa agli occhi miei?</l>
             <l>Parla: che fu? Dov'è il pastor? Chi sei?</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="I">Tutto, ben mio, dirò...</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="F">Prence, Sammete,</l>
             <l part="I">Giunge il real tuo genitor. <stage>(Sammete confuso</stage></l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F"><stage>(colpita dalla sorpresa del nome)</stage> (Sammete!</l>
             <l part="I">Misera me!)</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="M">Verrò. <stage>(confuso</stage></l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="F">Corri; potria</l>
             <l part="I">Prima giungere il re.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">Verrò; t'invia. <stage>(con impazienza ad Amenofi, che parte</stage></l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l>Crudel, tu sei Sammete?</l>
             <l>Tu sei prole d'un re? Dunque fin ora</l>
@@ -485,7 +510,7 @@
             <l>D'un cor che offerto interamente in dono...</l>
             <l part="I">Barbaro!... Ingrato!...</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">Anima mia, perdono.</l>
             <l>Fu giovanil vaghezza,</l>
@@ -501,55 +526,55 @@
             <l>Or non t'inganna; ha su le labbra il core:</l>
             <l>Accettami, qual vuoi, prence o pastore.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l>Ah, Sammete! ah, non più! Sorgi; io trascorsi</l>
             <l>Troppo con te. Dal mio dolor sorpresa,</l>
             <l>Il mio prence insultai: perdona il fallo</l>
             <l>All'eccesso, o signor, d'un lungo affetto.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l>Per pietà, mio tesoro, ah, men rispetto!</l>
             <l>Eccede un tal castigo <stage>(con enfasi affettuosa</stage></l>
             <l>Tutte le colpe mie: morir mi fai</l>
             <l part="I">Parlandomi in tal guisa.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Ah! che or tu sei...</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="I">Il tuo fedele.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="M">Ah! che or son io...</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">La mia</l>
             <l part="I">Unica speme.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="M">Oh Dio! <stage>(piange</stage></l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">Tanto ti spiace</l>
             <l>Che in real prence il tuo pastor si cangi?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="I">No; lo merti, cor mio.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">Dunque a che piangi?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l>Queste lagrime, o caro,</l>
             <l>Se sian doglia o piacer, dir non saprei.</l>
@@ -560,7 +585,7 @@
             <l>Or non son più di te, col Ciel m'adiro,</l>
             <l>Piango d'affanno, e ti vorrei Dalmiro.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l>Ah, se alcun disapprova</l>
             <l>L'eccesso in me degli amorosi affanni,</l>
@@ -573,47 +598,47 @@
             <l>O Dalmiro o Sammete,</l>
             <l>O principe o pastor sarò... sarai...</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l>Deh, sovvienti che ormai</l>
             <l part="I">Amasi sarà giunto.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">E' vero. Addio.</l>
             <l part="I">Ma... siamo in pace?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="M">Sì.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">Del tuo perdono</l>
             <l part="I">Mi posso assicurar?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="M">Sì, caro.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">Ottengo</l>
             <l>I primi affetti tuoi?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="I">Tutti. Ah! parti.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="M">E tu sei...</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Son quel che vuoi.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <lg>
               <l>Se d'amor, se di contento</l>
@@ -669,42 +694,42 @@
             <p>Si vedrà avanzar lentamente e passar indi sotto l'arco preparato il nuovo re vincitore, assiso in maestà sopra un bianco e pomposamente guarnito elefante; preceduto dagli oratori delle suddite provincie coi loro respettivi tributi; circondato da folta schiera di nobili egizi, di schiavi etiopi e di paggi che gli sostengono sul capo il reale ombrello, e vaghi e grandi ventagli di colorate penne all'intorno; e seguìto finalmente dalle guardie reali e dalla folla de' carri e de' cammelli carichi delle spoglie nemiche.</p>
           </stage>
           <stage>Mentre fra lo strepito armonioso di timpani, di sistri e d'altri stromenti barbari s'avanza AMASI, scende assistito da SAMMETE ed AMENOFI, e va sul trono, si canta il seguente</stage>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Si scordi i suoi tiranni,</l>
             <l>Sollevi il ciglio afflitto,</l>
             <l>Ponga in oblio l'Egitto</l>
             <l>Gli affanni che provò.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>PARTE DEL CORO</speaker>
             <l>Se il cielo è più sereno,</l>
             <l>Se fausti raggi or spande,</l>
             <l>Amasi il giusto, il grande,</l>
             <l>E' l'astro che spuntò.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Si scordi i suoi tiranni,</l>
             <l>Sollevi il ciglio afflitto,</l>
             <l>Ponga in oblio l'Egitto</l>
             <l>Gli affanni che provò.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>PARTE DEL CORO</speaker>
             <l>In dì così ridente</l>
             <l>Esulti il Nilo, e scopra</l>
             <l>L'oscura sua sorgente</l>
             <l>Che fino ad or celò.</l>
           </sp>
-          <sp>
+          <sp who="#amasi #amenofi #beroe #sammete #bubaste #nitteti">
             <speaker>TUTTI</speaker>
             <l>Si scordi i suoi tiranni,</l>
             <l>Sollevi il ciglio afflitto,</l>
             <l>Ponga in oblio l'Egitto</l>
             <l>Gli affanni che provò.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l>Non rendono superbi, <stage>(dal trono in piedi</stage></l>
             <l>Popoli al Ciel diletti, i miei sudori</l>
@@ -721,7 +746,7 @@
             <l>Figli, implorate a chi donaste il trono</l>
             <l>Vigor, virtù che corrisponda al dono! <stage>(siede</stage></l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Si scordi i suoi tiranni,</l>
             <l>Sollevi il ciglio afflitto,</l>
@@ -732,7 +757,7 @@
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>BUBASTE, NITTETI e detti.</stage>
-          <sp>
+          <sp who="#bubaste">
             <speaker>BUB.</speaker>
             <l>Signor, t'arride il Ciel. L'unica prole</l>
             <l>Dell'oppresso tiranno,</l>
@@ -740,18 +765,18 @@
             <l>Da noi scoperta in su l'opposta riva,</l>
             <l>Ecco al tuo piede e prigioniera e viva. <stage>(additando Nitteti</stage></l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l>Come! Nitteti! In così vili spoglie</l>
             <l part="I">L'egizia principessa! <stage>(s'alza e scende</stage></l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F">Illustri assai</l>
             <l>Eran per me, de dalle tue catene</l>
             <l part="I">M'avessero difeso.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">Ah, quai catene?</l>
             <l>Da chi? perché? non sai</l>
@@ -762,33 +787,33 @@
             <l>Ingiustizia maggiore,</l>
             <l>Insulto più crudel del tuo timore.</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="I">Oh magnanimo!</l>
           </sp>
-          <sp>
+          <sp who="#bubaste">
             <speaker>BUB.</speaker>
             <l part="M">Oh grande!</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F">Amasi, il sai,</l>
             <l>Fu real la mia cuna; e se pretendo</l>
             <l>Evitar d'esser serva, io non t'offendo.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l>Tu serva! Olà, Sammete,</l>
             <l>Ai soggiorni più degni</l>
             <l>Dell'albergo reale in vece mia</l>
             <l part="I">Scorgi Nitteti.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">Ubbidirò. (Che pena!</l>
             <l part="I">Beroe mi attenderà).</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">Bubaste, amici,</l>
             <l>Seguitela fin tanto</l>
@@ -797,18 +822,18 @@
             <l>Si rispetti, si onori, e i cenni suoi,</l>
             <l>Come a me lo saran, sian legge a voi.</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="I">Signor, non più; questa è vendetta.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">E' vero.</l>
             <l>M'oltraggiasti; son punto; e a vendicarmi</l>
             <l>Appena incominciai. Maggior vendetta</l>
             <l>Dall'offeso mio cor, Nitteti, aspetta.</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <lg>
               <l>Già vendicato sei;</l>
@@ -827,25 +852,25 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>AMASI, AMENOFI e séguito.</stage>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="I">Amenofi, ove vai? <stage>(ad Amenofi, che volea seguitar Nitteti</stage></l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="F">Come imponesti,</l>
             <l part="I">Sieguo Nitteti.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">No: ferma; vogl'io</l>
             <l part="I">Parlarti, o prence.</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="F">Adoro il cenno. (Oh Dio!) <stage>(guardando con tenerezza presso Nitteti</stage></l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l>Di gran fede ho bisogno, e tanta altrove,</l>
             <l>Come in te, non ne spero. Io l'ammirai</l>
@@ -861,31 +886,31 @@
             <l>Amenofi, misura ogni tua brama:</l>
             <l>Amasi regna, e ti conosce, e t'ama.</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="I">Troppo, signor...</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">Taci, m'ascolta, e giura</l>
             <l part="I">Silenzio e fedeltà</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="F">Tutti ne impegno</l>
             <l part="I">Vindici i numi.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">Or di'. D'Aprio nemico</l>
             <l part="I">Tu mi credesti?</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="F">Il crede</l>
             <l part="I">Tutto, signor, con me l'Egitto.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">E tutto</l>
             <l>Con te s'inganna. Ebbe l'inganno, è vero,</l>
@@ -898,11 +923,11 @@
             <l>Fosse il tuo regno; e nella mia lo rese</l>
             <l part="I">Deposito sicuro.</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="M">Oh stelle!</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">Il Cielo</l>
             <l>Secondava il mio zel; quando sorpreso</l>
@@ -917,11 +942,11 @@
             <l>Ei di più dir volea, ma freddo intanto</l>
             <l>Mi cadde in braccio, e mi lasciò nel pianto.</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="I">(Che ascolto!)</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">Il giuramento</l>
             <l>Deggio e voglio adempir; ma temo avversa</l>
@@ -939,11 +964,11 @@
             <l>Per tuo consiglio all'amorosa face,</l>
             <l>Io, caro prence, io ti dovrò la pace.</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="I">Dunque...</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">Più non tardiam: non v'è riposo</l>
             <l>Per me, se il giuramento io non adempio.</l>
@@ -965,75 +990,75 @@
         <div type="scene">
           <head>SCENA NONA</head>
           <stage>AMENOFI, poi BEROE.</stage>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l>Lasciatemi una volta,</l>
             <l>Folli speranze, in pace. Al fin vedete...</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l>Ov'è, signor... perdona... ov'è Sammete?</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l>Beroe sei tu, delle vicine selve</l>
             <l>La bella abitatrice?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="I">Quella Beroe son io.</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="F">Beore infelice!</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="I">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="F">Credimi, accetta</l>
             <l>Un consiglio fedel. Fuggi la reggia,</l>
             <l part="I">Ritorna a' boschi tuoi.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Ma tu chi sei?</l>
             <l part="I">Perché fuggir degg'io?</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="F">Del tuo Dalmiro</l>
             <l>L'amico io son; tu déi fuggir se in braccio</l>
             <l>D'altra veder nol vuoi. Sposo a Nitteti</l>
             <l part="I">L'ha destinato il padre.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Oimè! Consente</l>
             <l part="I">Sammete al nodo?</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="F">E come opporsi il figlio</l>
             <l part="I">Ad un re genitor?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="M">Dunque...</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="F">E' vicino</l>
             <l>Il barbaro momento</l>
             <l part="I">Del fatale imeneo.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Morir mi sento. <stage>(piange</stage></l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l>Tu piangi, e n'hai ragion. Dal caso mio,</l>
             <l>Bella ninfa, io misuro... Ah! sappi... Addio... <stage>(parte</stage></l>
@@ -1042,37 +1067,37 @@
         <div type="scene">
           <head>SCENA DECIMA</head>
           <stage>BEROE, poi SAMMETE.</stage>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l>Misera, ah, qual novella! Ah, qual mi stringe</l>
             <l>Gelida mano il cor! No; più funeste</l>
             <l>L'ore a morir vicine...</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l>Beroe, idol mio: pur ti raggiungo al fine. <stage>(allegro molto</stage></l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="I">(Che giubilo crudel!)</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">Di mia tardanza</l>
             <l>Colpa non ho. Presso a Nitteti il padre</l>
             <l part="I">Fin or mi volle.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">(Ah questo è troppo! Ostenta</l>
             <l part="I">In faccia mia l'infedeltà).</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">Tu piangi!</l>
             <l part="I">Perché? Che avvenne, anima mia?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Ma basta:</l>
             <l>Prence, signor, non insultarmi. Assai</l>
@@ -1083,75 +1108,75 @@
             <l>Nell'albergo natio</l>
             <l>Lungi dagli occhi tuoi morir vogl'io.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l>Come? Partir! Lasciarmi!</l>
             <l>Bramar la morte! Io che ti feci? Ah parla,</l>
             <l>Non m'uccider così, Beroe vezzosa!</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l>Dalla novella sposa</l>
             <l>Con quel volto sereno</l>
             <l>Mi torni innanzi, e l'idol tuo mi chiami?</l>
             <l>E pretendi... e non vuoi...</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l>Se intendo i detti tuoi, m'atterri, o cara,</l>
             <l part="I">Un fulmine del Ciel.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Che! non dicesti</l>
             <l>Tu stesso or or che per voler del padre</l>
             <l part="I">A Nitteti...</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">A Nitteti</l>
             <l>Mi vuol servo e non sposo</l>
             <l>Il padre mio. Qual mentitor ti venne</l>
             <l part="I">A recar tai novelle?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Un che si vanta</l>
             <l>Tuo vero amico; e di Dalmiro il nome</l>
             <l part="I">Meco ti diè.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F"><stage>(si turba)</stage> Stelle! Amenofi? Ah, dunque</l>
             <l>Fola non è! Ma si spiegò? Ti disse</l>
             <l part="I">Onde il sapea?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">No; ma parlò sicuro.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l>Nulla, ben mio, lo giuro</l>
             <l>Ai numi, a te, del minacciato nodo,</l>
             <l>Nulla seppi fin ora; e ingiusta sei,</l>
             <l>Se mi temi incostante.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l>Vuoi che non tema, e mi conosci amante?</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l>No, temer tu non déi. Tuo mi promisi</l>
             <l part="I">E tuo, Beroe, io sarò.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Ma come al cenno</l>
             <l part="I">D'un padre opporti?</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">Io so per me qual sia</l>
             <l>Del genitor la tenerezza. Ah, lascia,</l>
@@ -1159,7 +1184,7 @@
             <l>Di', se in fronte una volta il cor mi vedi,</l>
             <l>Se sei tranquilla e se fedel mi credi!</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <lg>
               <l>Sì, ti credo, amato bene;</l>
@@ -1167,7 +1192,7 @@
               <l>Veggo espresso il tuo bel cor.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <lg>
               <l>Se mi credi, amato bene,</l>
@@ -1175,19 +1200,19 @@
               <l>Né tremar mi sento il cor.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <lg part="I">
               <l>Non lasciarmi, o mio tesoro.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <lg part="M">
               <l>Tutta in pegno hai la mia fé.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sammete #beroe">
             <speaker>A DUE</speaker>
             <lg part="F">
               <l>Ah! sovvengati ch'io moro,</l>
@@ -1238,106 +1263,106 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>NITTETI turbata, in abito da principessa, e detta.</stage>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l>Ah, cara, ah, fida amica,</l>
             <l part="I">Son fuor di me.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="M">Che avvenne?</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F">Ogni mia speme</l>
             <l>E' svanita, è delusa.</l>
             <l>M'offre il padre a Sammete, ei mi ricusa.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="I">(Oh fedeltà!)</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F">L'avresti</l>
             <l>Potuto immaginar? Come io mi sento,</l>
             <l>Dirti, amica, non so. L'amore offeso,</l>
             <l>La vergogna, il disprezzo... Audace! ingrato!</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="I">(Mi fa pietà).</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F">Qualche segreto affetto,</l>
             <l part="I">Credimi, mi prevenne.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">(E' un tradimento</l>
             <l part="I">Il mio silenzio).</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F">Ah, conoscessi almeno</l>
             <l part="I">La felice rivale! Almen...</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Perdona,</l>
             <l>Amata principessa, il fallo mio.</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="I">Perdon! di che?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">La tua rival son io.</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="I">Come!</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Rival ti sono;</l>
             <l part="I">Ma...</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="M">Che? t'ama Sammete?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="M">Il credo.</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F">E l'ami?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="I">Più di me stessa.</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="M">E il tuo Dalmiro?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">E' un solo</l>
             <l part="I">E Dalmiro e Sammete.</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F">E tu, superba,</l>
             <l>E tu, fallace amica,</l>
             <l>Senza pensar chi sei,</l>
             <l part="I">Vai degli affetti miei...</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Sempre un pastore</l>
             <l part="I">L'ho creduto fin or. Sempre...</l>
@@ -1346,23 +1371,23 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>AMASI e dette.</stage>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">Ah, Nitteti,</l>
             <l>Del mio figlio il rifiuto</l>
             <l>Mi copre di rossor! Ma re, ma padre</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l>Non son, se a vendicarti... Eh! del tuo sdegno,</l>
             <l>Amasi, il corso arresta:</l>
             <l>Gran scusa ha il reo; la mia rivale è questa. <stage>(con ironia amara</stage></l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="I">Stelle! che dici!</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F"><stage>(come sopra)</stage> Ammira</l>
             <l>Gl'incanti di quel ciglio,</l>
@@ -1372,51 +1397,51 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>AMASI e BEROE</stage>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="I">(Tremo da capo a piè). <stage>(timida e confusa</stage></l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="M">T'appressa. <stage>(esaminandola fissamente, ma senza sdegno</stage></l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F"> (Oh Dio!)</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="I">Parla. Chi sei?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Qual vedi,</l>
             <l>Un'umil pastorella.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="I">Il nome?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="M">E' Beroe.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="M">Ove nascesti?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Io nacqui</l>
             <l>Colà fra quelle selve,</l>
             <l>Che adombrano del Nil l'opposta sponda.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l>Qual ventura a Sammete</l>
             <l part="I">Nota ti rese?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">In rozze lane avvolto,</l>
             <l>Fra le nostre festive</l>
@@ -1427,42 +1452,42 @@
             <l>Mi piacque, l'ascoltai;</l>
             <l>Dimandò la mia fede; io la giurai.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l>Stelle, la fede tua! Sposa tu sei? <stage>(con premura</stage></l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l>No, mio re; ma promisi</l>
             <l part="I">D'esserla un dì.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">(Respiro).</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l>Sol Sammete in Dalmiro</l>
             <l>Oggi, che in ricche spoglie</l>
             <l>Nella reggia ei s'offerse agli occhi miei,</l>
             <l>Al fin conobbi, e di morir credei.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="I">Come tu nella reggia?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">I tuoi guerrieri</l>
             <l part="I">Mi trasser con Nitteti.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F"><stage>(con umanità)</stage> Or odi. Io scuso,</l>
             <l>Beroe, la tua semplicità; ma pensa</l>
             <l part="I">Ch'or tuo dovere...</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Il mio dover, signore,</l>
             <l>Pur troppo il so. Non me ne scemi il merto</l>
@@ -1479,7 +1504,7 @@
             <l>Abbian Nitteti, il regno,</l>
             <l>Figlio sì caro e genitor sì degno.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l>Giusti dèi, qual favella! <stage>(sorpreso</stage></l>
             <l>Ma sei tu pastorella? Ove apprendesti</l>
@@ -1489,22 +1514,22 @@
             <l>Mirabilmente in te. Deh! non celarti:</l>
             <l part="I">Chi sei? chi t'educò?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Qualunque io sono,</l>
             <l>D'Inaro il padre mio deggio alla cura.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="I">E ha saputo un pastor...</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Sempre ei pastore,</l>
             <l>Signor, non fu. Visse già d'Aprio in corte,</l>
             <l>Ed è lo stato suo scelta e non sorte.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l>Ah, perché mai non sono</l>
             <l>Arbitro ancor del mio voler! Qual altra</l>
@@ -1516,29 +1541,29 @@
             <l>Fra' miei più cari e più sublimi amici</l>
             <l part="I">Scegli a tua voglia...</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Ah, giusto re, che dici?</l>
             <l>Io promettermi ad altri! Ogni promessa</l>
             <l>Sarebbe un tradimento.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l>Ma se resta a Sammete</l>
             <l part="I">Speranza ancor...</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Non resterà. Ti puoi</l>
             <l>Di me fidar: né troppo,</l>
             <l>Signor, Beroe presume;</l>
             <l>Darà di sé mallevadore un nume.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="I">Come?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Ad Iside offrirmi, e fra le sacre</l>
             <l>Vergini sue ministre il resto io voglio</l>
@@ -1550,7 +1575,7 @@
             <l>Un eroe, qual tu sei,</l>
             <l>Stancherò co' miei voti almen gli dèi.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l>Ah, Beroe! ah, figlia! io fuor di me mi sento <stage>(con trasporto di tenerezza</stage></l>
             <l>Di stupor, di contento,</l>
@@ -1563,7 +1588,7 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>SAMMETE e detti.</stage>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l>Vieni. Non arrossirti: esser superbo</l>
             <l>Puoi del tuo amor. T'appressa pur: ti lascio,</l>
@@ -1587,17 +1612,17 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>BEROE e SAMMETE e detti.</stage>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l>Chi al genitor mai rese <stage>(con curiosità ed allegrezza</stage></l>
             <l part="I">Il nostro amor palese?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Ei da Nitteti,</l>
             <l part="I">Ella il seppe da me.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">Più amabil padre</l>
             <l>Trovar si può? Non tel diss'io? Conose</l>
@@ -1607,15 +1632,15 @@
             <l>Prenda consiglio in questo dì mi dice.</l>
             <l>Oh padre! oh caro padre! oh me felice!</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="I">(Beroe, costanza).</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="M">E tu non parli?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Ammiro</l>
             <l>Principe, il tuo bel cor. Per un tal padre</l>
@@ -1624,68 +1649,68 @@
             <l>Un sì buon genitor da un grato figlio</l>
             <l part="I">Ogni prova d'amor?</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">Se il Ciel m'intende</l>
             <l>Qualche via m'aprirà, cara, ond'io po</l>
             <l>Farmi una volta al genitor palese.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l>Consolati, Sammete; il Ciel t'intese.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="I">Come?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Da te dipende</l>
             <l>La pace dell'Egitto e la paterna</l>
             <l part="I">Tranquillità.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="M">Da me?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="M">Sì.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">Parla; a tutto</l>
             <l>Pronto son io. Qual per sì grande oggetto,</l>
             <l>Qual impresa, ben mio, compir dovrei?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l>L'impresa è dura; abbandonar mi déi.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="I">Che? <stage>(attonito</stage></l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="M">Abbandonarmi.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">Abbandonarti! Ah, forse</l>
             <l part="I">Il padre mi deluse?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Il padre è giusto;</l>
             <l part="I">T'ama, non t'ingannò.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">Chi dunque chiese</l>
             <l part="I">Sì crudel sacrifizio?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Il Ciel, la terra;</l>
             <l>Tu stesso, se vorrai,</l>
@@ -1700,25 +1725,25 @@
             <l>De' dolci affetti tuoi</l>
             <l>All'odio, al riso ed agl'insulti altrui.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l>A parlarmi così valor ti senti?</l>
             <l>Ah! la virtù che ostenti,</l>
             <l>Beroe crudel, di poco amor t'accusa.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l>Di poco amore? Oh Dio!</l>
             <l>Se vedessi, ben mio,</l>
             <l>Come sta questo cor, com'io mi sento,</l>
             <l part="I">No, così non diresti.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">A non amarmi</l>
             <l part="I">Pur disposta già sei.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">T'inganni. Io posso</l>
             <l>E voglio amarti sempre. Io di monarchi</l>
@@ -1730,7 +1755,7 @@
             <l>Che soffre la virtù, serbar vogl'io.</l>
             <l>Ti rendo il tuo; ma non dimando il mio.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l>Ah, se vuoi ch'io non t'ami, ah non mostrarti</l>
             <l>Così degna d'amore, anima mia!</l>
@@ -1739,7 +1764,7 @@
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>BUBASTE con guardie, e detti.</stage>
-          <sp>
+          <sp who="#bubaste">
             <speaker>BUB.</speaker>
             <l>Amasi a te m'invia,</l>
             <l>Pastorella gentil. E' suo volere</l>
@@ -1747,36 +1772,36 @@
             <l>Esecutor son io</l>
             <l part="I">Qui de' tuoi cenni.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Amato prence, addio.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="I">Che! già mi lasci! Ah, dove vai?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Fra poco</l>
             <l part="I">Saprà tutto Sammete.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">I passi tuoi</l>
             <l part="I">Seguir vogl'io.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">No; s'è pur ver che m'ami</l>
             <l>Resta, ben mio. Quest'ultimo io ti chiedo</l>
             <l part="I">Pegno d'amor.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">Che tiranna! Ch'io resti</l>
             <l part="I">Così senza saper...</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Fidati, o caro:</l>
             <l>Da te lungi io non vo; caro, tel giuro,</l>
@@ -1800,7 +1825,7 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>SAMMETE, poi NITTETI, indi AMENOFI</stage>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l>Assistetemi, o numi;</l>
             <l>Son fuor di me. Che avvenne?</l>
@@ -1810,52 +1835,52 @@
             <l>E ignorar chi m'uccide? E' il mio tesoro,</l>
             <l part="I">E' il genitor che mi tradisce? <stage>(resta immobile e pensoso, e non ode che le ultime parole di Nitteti</stage></l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F">Ah, prence,</l>
             <l>Son rea; perdona. Un improvviso assalto</l>
             <l>Di cieco sdegno al genitor mi fece</l>
             <l part="I">La tua Beroe tradir.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F"><stage>(con vivacità)</stage> No; principessa,</l>
             <l>Possibile non è. Beroe incapace</l>
             <l>E' di tradirmi. Ha troppo bello il core,</l>
             <l part="I">Troppo candida ha l'alma.</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F">O non m'intendi,</l>
             <l part="I">O non t'intendo.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">(da sé) (In questa angustia, in questa</l>
             <l>Oscurità come restar? No; voglio</l>
             <l>Raggiungere il mio ben... Ma, oh Dio! m'impose</l>
             <l part="I">Di non seguirla). <stage>(pensoso come sopra, e non intendendo che le ultime parole di Amenofi</stage></l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="F">Al genitor, Sammete,</l>
             <l part="I">Il passo affretta. Egli m'impose...</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">Ed io</l>
             <l>Ubbidirla non posso:</l>
             <l>Nulla ho promesso a lei. Quand'io la siegua,</l>
             <l part="I">Non dee Beroe sdegnarsi. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="F">Odi; t'arresta.</l>
             <l>Qual favella è mai questa? Io non ritrovo</l>
             <l>Senso ne' detti tuoi. Non sembra intero,</l>
             <l part="I">Caro prence, il tuo senno.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">E' vero, è vero;</l>
             <l>Son fuor di me; perdona:</l>
@@ -1879,14 +1904,14 @@
         <div type="scene">
           <head>SCENA NONA</head>
           <stage> NITTETI ed AMENOFI</stage>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l>Povero prence! A quale</l>
             <l>Estremità per mia cagion tu sei!</l>
             <l>De' folli sdegni miei quanto, Amenofi,</l>
             <l part="I">Quanto or mi pento!</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="F">E' degna</l>
             <l>Dell'eccelsa Nitteti</l>
@@ -1895,17 +1920,17 @@
             <l>Così mi fosse dato,</l>
             <l>Conterei per favor l'ire del fato.</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l>Ah dal caso funesto</l>
             <l>D'esigerla così, prence cortese,</l>
             <l>Ti preservin gli dèi!</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l>Essi intendono meglio i voti miei.</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l>Sammete ama da vero; è amato, e teme</l>
             <l>Di perdere il suo bene: ad ogni eccesso</l>
@@ -1914,7 +1939,7 @@
             <l>D'un fido amico. Io ti dovrò la cura</l>
             <l part="I">Che avrai di lui.</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="F">Sì venerato cenno</l>
             <l>All'amistà s'accorda. Io vo; ma intanto</l>
@@ -1939,7 +1964,7 @@
         <div type="scene">
           <head>SCENA DECIMA</head>
           <stage> NITTETI ed BUBASTE</stage>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l>Se lasciasse Sammete</l>
             <l>Un solo in libertà de' miei pensieri,</l>
@@ -1948,33 +1973,33 @@
             <l>Con cui celando in petto</l>
             <l>Le sue fiamme segrete...</l>
           </sp>
-          <sp>
+          <sp who="#bubaste">
             <speaker>BUB.</speaker>
             <l part="I">Amenofi dov'è? <stage>(con gran fretta</stage></l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F">Cerca Sammete.</l>
           </sp>
-          <sp>
+          <sp who="#bubaste">
             <speaker>BUB.</speaker>
             <l part="I">Dunque ad Amasi io volo.</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F">Odi. Che rechi?</l>
             <l part="I">Donde vieni? che fu?</l>
           </sp>
-          <sp>
+          <sp who="#bubaste">
             <speaker>BUB.</speaker>
             <l part="F">Temo, o Nitteti,</l>
             <l part="I">Qualche fiero disastro.</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F">Onde la tema?</l>
           </sp>
-          <sp>
+          <sp who="#bubaste">
             <speaker>BUB.</speaker>
             <l>Volle Beroe da me d'Iside a' sacri</l>
             <l>Recinti esser condotta:</l>
@@ -1988,16 +2013,16 @@
             <l>Vibrar folgori ardenti;</l>
             <l>Fremea piangendo, e confondea gli accenti.</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l>E scelto ha Beroe istessa...</l>
           </sp>
-          <sp>
+          <sp who="#bubaste">
             <speaker>BUB.</speaker>
             <l>Perdona, o principessa; erro, s'io resto:</l>
             <l>Può troppo un breve indugio esser funesto. <stage>(parte in fretta</stage></l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l>Misera! quai ruine un mio geloso</l>
             <l>Sconsigliato trasporto</l>
@@ -2021,20 +2046,20 @@
           <head>SCENA UNDICESIMA</head>
           <stage>Gran porto di Canopo ripieno di navi e di nocchieri.</stage>
           <stage>SAMMETE dalla destra traendo per mano BEROE, e séguito di compagni armati.</stage>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l>Ma dove, oh Dio! mi guidi?</l>
             <l>Qual furor ti consiglia! Ah, che facesti? <stage>(comincia ad oscurarsi il cielo</stage></l>
             <l>La tua ragion si desti:</l>
             <l part="I">Pensa ad Iside, al padre, a te.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">Non posso</l>
             <l>Pensar che a Beroe. E' sola <stage>(lampi</stage></l>
             <l part="I">Beroe la mia ragion.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Rendimi al tempio, <stage>(tuoni</stage></l>
             <l>Idol mio, per pietà. Condanna il Cielo</l>
@@ -2045,13 +2070,13 @@
             <l>L'orrido de' mortali ultimo scempio!</l>
             <l>Idol mio, per pietà, rendimi al tempio.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l>Eh! non turbarti; è questa</l>
             <l>Passeggiera tempesta. Andiamo: aperto</l>
             <l part="I">Il mar ci offre lo scampo.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Il mar! Non vedi</l>
             <l>Che ogni cammin ti serra</l>
@@ -2062,41 +2087,41 @@
             <l>Dell'ira degli dèi misero esempio!</l>
             <l>Rendimi, per pietà, rendimi al tempio.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l>Ma vi sono, empie stelle, <stage>(con intolleranza impetuosa</stage></l>
             <l>Più disastri per me? Stanche non siete</l>
             <l part="I">Di tormentarmi ancor?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Fuggi, Sammete.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="I">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Giungono armati. Oimè! la fuga</l>
             <l>Impossibil già parmi.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l>E ben, tutto si perda. Amici, all'armi. <stage>(lascia Beroe, snuda la spada, e seco i suoi seguaci</stage></l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l>Ah no, che fai? Cedi più tosto il brando;</l>
             <l part="I">Abbandonati al padre.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">Al mondo intero</l>
             <l>M'opporrò per serbarti, o mio tesoro.</l>
             <l part="I">All'armi, all'armi. <stage>(ai seguaci</stage></l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Oh Dio! t'arresta... Io moro. <stage>(sviene sopra un sasso alla destra. Sammete assale furioso le guardie reali, e si disvia inseguendone alcune alla sinistra. Intanto fra il balenar de' frequenti lampi, fra il rimbombo de' tuoni e fra il muggito marino, a vista delle navi e de' nocchieri, che balzati dalle onde e sospinti dal vento si urtano fra di loro, si frangono e si sommergono in parte; siegue, con lo strepito di tumultuosa sinfonia, nella spiaggia e nel porto, ostinato combattimento fra i seguaci di Sammete e le guardie reali, che vincitrici alfine rincalzando gli altri, lasciano vuota la scena. Verso il fine del combattimento cessa a grado a grado il furore della tempesta, si va rasserenando il cielo, e l'iride comparisce</stage></l>
           </sp>
@@ -2104,7 +2129,7 @@
         <div type="scene">
           <head>SCENA DODICESIMA</head>
           <stage>BEROE cominciando a rinvenire, poi SAMMETE dalla sinistra difendendosi da due de' custodi reali; finalmente AMASI con numeroso séguito d'armati alla destra.</stage>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l><stage>(senza aprire gli occhi</stage> Oimè! Deh, per pietà rendimi... Oh dèi, <stage>(guardando sorpreso intorno</stage></l>
             <l>Sola restai! Prence? <stage>(s'alza)</stage> Sammete? Ah, dove,</l>
@@ -2112,31 +2137,31 @@
             <l>Forse... Ma sento ancora</l>
             <l part="I">Colà strepito d'armi.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F"><stage>(di dentro alla sinistra</stage> In van ch'io ceda,</l>
             <l part="I">Temerari, sperate. <stage>(esce</stage></l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Ah! basta, o prence;</l>
             <l part="I">Più non opporti agli astri.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">Olà, deponi,</l>
             <l>Forsennato, quel brando, e prigioniero</l>
             <l>Renditi a queste squadre.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="I">Principe, non opporti.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F"><stage>(si lascia disarmare)</stage> Ah, Beroe! ah, padre!</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l>Ingrato! ecco i bei frutti <stage>(con ironia lenta ed ama</stage></l>
             <l>De' paterni sudori; ecco la bella</l>
@@ -2150,7 +2175,7 @@
             <l>Freni bastanti al tuo furor non sono.</l>
             <l part="I">Ingrato...</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Ah! basta. Al prence</l>
             <l>Tutto non dessi il tuo rigor. La rea</l>
@@ -2159,12 +2184,12 @@
             <l>Io lo sedussi; io gli turbai la mente.</l>
             <l>Se mai non mi vedeva, era innocente.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l>D'un figlio contumace</l>
             <l part="I">In van la tua pietà...</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">No, contumace,</l>
             <l>Mio re, non è. Conosco</l>
@@ -2172,7 +2197,7 @@
             <l>Non son gli eccessi suoi che ultimi sforzi</l>
             <l part="I">D'un moribondo amor.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">M'onora e m'ama</l>
             <l>Ei, che ad esser mi astringe</l>
@@ -2186,7 +2211,7 @@
             <l>Quest'è l'odio più nero,</l>
             <l part="I">Questo...</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">No, padre mio; no, non è vero.</l>
             <l>Di rispetto, d'amore,</l>
@@ -2199,90 +2224,90 @@
             <l>Io non amai che lei:</l>
             <l>Ella è tutto per me. Se lei mi togli...</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l>Custodi, olà; traete</l>
             <l>Al suo carcere il reo. <stage>(Sammete è incatenato</stage></l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="I">Pietà, signor!</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">Su la paterna mano...</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="I">Parti. <stage>(l'evita senza sdegno</stage></l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">Ah! concedi al mio dolor verace</l>
             <l part="I">Che questo pegno almen...</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">Lasciami in pace.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <lg part="I">
               <l>Guardami, padre amato.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <lg part="M">
               <l>Lasciami, figlio ingrato.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <lg part="M">
               <l>Amor ti dia consiglio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <lg part="M">
               <l>E' troppo ingrato il figlio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <lg part="M">
               <l>Ingrato, ah! non son io.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <lg part="F">
               <l>Eccede il tuo rigor.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amasi #beroe #sammete">
             <speaker>A TRE</speaker>
             <lg part="I">
               <l>In quante parti, oh Dio,</l>
               <l>Mi si divide il cor!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <lg part="M">
               <l>Signor, de' falli miei</l>
               <l>Sai la cagion qual è.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <lg part="F">
               <l>Non ti scordar che sei</l>
               <l>Pria genitor che re.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <lg>
               <l>(In tal cimento, oh dèi,</l>
@@ -2297,19 +2322,19 @@
           <head>SCENA PRIMA</head>
           <stage>Logge adombre di statue, con magnifiche scale che conducono a' giardini reali.</stage>
           <stage>AMASI e NITTETI, poi BUBASTE.</stage>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l>E fia ver, o mio re? Varran sì poco</l>
             <l>Dunque nel cor d'un padre</l>
             <l part="I">I dritti di natura? Un figlio...</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">Un figlio,</l>
             <l>Che pria di me se gli scordò, non merta</l>
             <l part="I">Ch'io li rammenti. E' reo di morte...</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F">E' reo;</l>
             <l>Ma non l'istessa han sempre i falli istessi</l>
@@ -2323,7 +2348,7 @@
             <l>Qual virtù, qual bellezza il figlio accese.</l>
             <l>Ah! son grandi, o signor, le sue difese.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l>Beroe m'è nota; e, più di quel che credi,</l>
             <l>Padre son io; ma di giustizia io deggio,</l>
@@ -2331,7 +2356,7 @@
             <l>Oggi prove all'Egitto. Oggi conversi</l>
             <l>Tutti son gli occhi in me. Da me ciascuno...</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l>Ciascun da te dimanda</l>
             <l>Clemenza, e non rigor. Mostrati, e udrai</l>
@@ -2343,44 +2368,44 @@
             <l>Ad implorar mi credo,</l>
             <l>Signor, grazie da te: questa io ti chiedo.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l>Olà. D'Aprio una figlia</l>
             <l>Dà legge, allor che implora. Olà, Bubaste,</l>
             <l>All'oscuro recinto</l>
             <l part="I">Ov'è Sammete, affretta il passo.</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F">(Ho vinto).</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l>Digli che salvo il vuole</l>
             <l>Nitteti offesa, e ch'io consento, a patto</l>
             <l>Che grato ei sia. Purché ad offrirle in dono</l>
             <l>Venga il cor con la destra, io gli perdono.</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="I">(Oimè!)</l>
           </sp>
-          <sp>
+          <sp who="#bubaste">
             <speaker>BUB.</speaker>
             <l part="M">Volo. <stage>(volendo partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F">Che fai? Questo è castigo,</l>
             <l>Amasi, e non perdono. Io mai non chiesi</l>
             <l part="I">Prezzo dell'opra mia.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">Ma l'opra istessa</l>
             <l part="I">Il chiede assai.</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F">Dunque m'ascolta. (Ah, tutto</l>
             <l>Per salvarlo i tenti!) In van tu fai</l>
@@ -2389,16 +2414,16 @@
             <l>Bench'ei cedesse, il tuo pensier deluso:</l>
             <l>Io (soffritelo, affetti), io lo ricuso.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l>Ricusalo, se vuoi; ma venga, ed offra</l>
             <l part="I">Materia al tuo rifiuto.</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F">Inutil cura.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l>Ah, generosa! in vano</l>
             <l>La tua celar pretendi</l>
@@ -2409,25 +2434,25 @@
             <l>Bubaste, udisti. A lui li reca, e torna</l>
             <l part="I">A me co' suoi. <stage>(parte Bubaste</stage></l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="M">Dunque?...</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">Ho deciso. O ceda</l>
             <l part="I">O aspetti il suo castigo.</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F">(Ah, di salvarlo</l>
             <l>Facciam l'ultime prove!) <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="I">Dove, Nitteti?</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F">Ad arrossirmi altrove. <stage>(parte</stage></l>
           </sp>
@@ -2435,7 +2460,7 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>AMASI, indi AMENOFI</stage>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l>Ah! de' falli del figlio in parte è reo</l>
             <l>Il mio soverchio amor. Poco, or m'avveggo,</l>
@@ -2447,36 +2472,36 @@
             <l>Con la costanza istessa</l>
             <l>Il momento fatal, quando s'appressa.</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l>Con sollecita istanza</l>
             <l>D'Iside il sacerdote</l>
             <l part="I">Chiede, signor, che tu l'ascolti.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">Intendo.</l>
             <l>Del tempio profanato</l>
             <l part="I">Vorrà vendetta.</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="F">A me nol disse. Ei reca</l>
             <l>Un chiuso foglio; ed uom canuto ha seco,</l>
             <l>Che alla spoglia mi parve,</l>
             <l part="I">Non ai detti, un pastor.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F"><stage>(in atto di partire)</stage> Che fia! S'ascolti.</l>
             <l>Tu qui Bubaste attendi, e, quando ei giunga</l>
             <l part="I">Sollecito m'avverti.</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="M">Eccolo.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F"><stage>(dopo essersi rivoltato e aver guardato attentamente Bubaste dentro la scena)</stage> Oh dèi!</l>
             <l>In quella fronte oscura</l>
@@ -2486,61 +2511,61 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>BUBASTE e detti, indi BEROE</stage>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="M">E ben? <stage>(con premura a Bubaste</stage></l>
           </sp>
-          <sp>
+          <sp who="#bubaste">
             <speaker>BUB.</speaker>
             <l part="F">Signore... <stage>(con timore, tradando in rispondere</stage></l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l>Dunque, ad onta di tante</l>
             <l part="I">Grazie, Sammete è ancor ribelle?</l>
           </sp>
-          <sp>
+          <sp who="#bubaste">
             <speaker>BUB.</speaker>
             <l part="F"><stage>(in atto di scusa)</stage> E' amante.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l>Dunque non han più loco</l>
             <l>Né ragione in quel core,</l>
             <l part="I">Né timor, né pietà?</l>
           </sp>
-          <sp>
+          <sp who="#bubaste">
             <speaker>BUB.</speaker>
             <l part="F"><stage>(come sopra)</stage> L'occupa amore.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l>L'occuperà per poco. <stage>(esce Beroe e resta indietro</stage> Un sangue reo</l>
             <l part="I">Si versi, ancorché mio. <stage>(con molto sdegno in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="M">Misera!</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="F">Ah! pensa...</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l>Tacete. Alcun di lui <stage>(con molto sdegno</stage></l>
             <l>Più non osi parlarmi. E' chi il difende</l>
             <l>Reo dell'istessa pena. <stage>(partendo</stage></l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l>Ah! signor, per pietà m'odi, e mi svena. <stage>(Amasi si rivolge, Beroe si getta a' suoi piedi</stage></l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="I">Beroe, sorgi; che vuoi?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">L'onor del figlio,</l>
             <l>La pace del tuo regno,</l>
@@ -2550,54 +2575,54 @@
             <l>Pentito, ubbidiente,</l>
             <l part="I">Sposo a Nitteti, e in questo dì.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">Ch'io speri</l>
             <l>D'un figlio reo l'emenda</l>
             <l part="I">Dalla cagion che l'ha sedotto?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Il ferro</l>
             <l>Atto a ferir può risanar. Ti fida,</l>
             <l part="I">Credimi...</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="F">Ah! sì. Rammenta</l>
             <l>Aprio e il tuo giuramento. E' d'altri il figlio:</l>
             <l part="I">Sai che il devi a Nitteti.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">Ei la ricusa.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="I">L'accetterà: lascia ch'io parli.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">A lui</l>
             <l>Va, se vuoi; non tel vieto;</l>
             <l part="I">Ma ritorna a momenti.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">I suoi custodi</l>
             <l part="I">Mel vieteran.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">Del regio assenso il segno</l>
             <l>Questa gemma sarà. <stage>(le dà l'anello)</stage> Va; ma vedrai</l>
             <l>Ch'oltre a ragion del tuo poter presumi.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l>(Or la vostra assistenza imploro, o numi). <stage>(parte in fretta</stage></l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <lg>
               <l>Se un tenero disprezza</l>
@@ -2616,45 +2641,45 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>AMENOFI e BUBASTE</stage>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="I">Dove, Bubaste?</l>
           </sp>
-          <sp>
+          <sp who="#bubaste">
             <speaker>BUB.</speaker>
             <l part="M">Appresso al re.</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="F">Non puoi.</l>
           </sp>
-          <sp>
+          <sp who="#bubaste">
             <speaker>BUB.</speaker>
             <l part="I">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="F">D'Iside è seco</l>
             <l part="I">Il sacerdote.</l>
           </sp>
-          <sp>
+          <sp who="#bubaste">
             <speaker>BUB.</speaker>
             <l part="F">Il sacerdote! Ei mai</l>
             <l>Non lascia il sacro albergo</l>
             <l part="I">Senza grave cagion. T'è nota?</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="F">Un foglio</l>
             <l>In man gli vidi, ed un pastore al fianco:</l>
             <l part="I">Altro non so.</l>
           </sp>
-          <sp>
+          <sp who="#bubaste">
             <speaker>BUB.</speaker>
             <l part="F">Contro Sammete il padre</l>
             <l part="I">Forse irritar vorrà.</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="F">Deh! tu, che sei</l>
             <l>Sempre d'Amasi a lato, i moti osserva</l>
@@ -2664,7 +2689,7 @@
             <l>Sospendilo: m'avverti. Il caro amico</l>
             <l part="I">Merta pietà.</l>
           </sp>
-          <sp>
+          <sp who="#bubaste">
             <speaker>BUB.</speaker>
             <l part="F">Nel portico vicino</l>
             <l>Amasi attenderò: tutto saprai;</l>
@@ -2722,12 +2747,12 @@
           <head>SCENA SESTA</head>
           <stage>Fondo oscuro di antica torre, chiuso in varie parti da rugginosi cancelli, che lasciano vedere in lontano le rovinose scale, per cui vi si scende.</stage>
           <stage>BEROE e SAMMETE disarmato.</stage>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l>Come! sposo a Nitteti <stage>(turbato</stage></l>
             <l part="I">Beroe mi vuol?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Sì, caro prence, e prima <stage>(sollecita e affannata</stage></l>
             <l>Che il sol giunga all'occaso. Or non si tratta</l>
@@ -2739,57 +2764,57 @@
             <l>D'esaminar: salvati, vivi; io prego,</l>
             <l part="I">Io consiglio, io comando.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">E ad altra sposa <stage>(con ironia lenta ed amara</stage></l>
             <l part="I">Tranquillamente in braccio...</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F"><stage>(con tenerezza</stage> Ah, tu non déi</l>
             <l>Saper com'io mi senta</l>
             <l part="I">In questo punto il cor!</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">La tua costanza</l>
             <l part="I">Lo palesa abbastanza.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">E ben, se vuoi, <stage>(con rassegnazione affettata</stage></l>
             <l>Credi pur ch'io non t'amo. Al nuovo laccio</l>
             <l>Per punirmi t'affretta;</l>
             <l>Conserva la tua vita, e sia vendetta.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l>Non è facile impresa</l>
             <l part="I">L'imitarti, o crudel.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Sarei pietosa</l>
             <l>Se spirar ti vedessi? Ah, prence amato, <stage>(con passione</stage></l>
             <l>Volan gl'istanti; il re m'attende. Ah, cedi</l>
             <l part="I">Al padre, al fato, al mio dolor!</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F"><stage>(con ammirazione)</stage> Ch'io stringa</l>
             <l part="I">Sposo altra man...</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Sì, la tua Beroe il vuole. <stage>(con dolcezza ed affetto</stage></l>
             <l>L'arbitra, mel dicesti,</l>
             <l part="I">Son pur io del tuo cor.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="M"><stage>(dubbioso)</stage> Che pena!</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Io tremo,</l>
             <l>Io palpito, io mi sento</l>
@@ -2800,115 +2825,115 @@
             <l>Hanno nei primi istanti</l>
             <l>Le nostre incominciato anime amanti.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="I">Aimè!</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Sì, lo conosco, <stage>(con ilarità e fretta</stage></l>
             <l>Sei già disposto a consolarmi. Al padre</l>
             <l>Del lieto avviso apportatrice io volo. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="I">Ferma, Beroe. <stage>(con premura ansiosa</stage></l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="M">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">(risoluto) Troppo pretendi.</l>
             <l>Io non posso, io non voglio; io di Nitteti,</l>
             <l>Rovini il ciel, non sarò mai consorte.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l>Dunque della tua morte <stage>(grave, torbida e lenta</stage></l>
             <l>Spettatrice mi vuoi? No; questa pena <stage>(si slontana</stage></l>
             <l>Per un'anima fida è troppo amara.</l>
             <l>Guarda, se non lo sai, guardami, e impara. <stage>(snuda uno stile</stage></l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="I">Fermati! <stage>(movendosi per avvicinarsi e trattenerla</stage></l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Affretti il colpo,</l>
             <l part="I">Se d'un passo t'appressi. <stage>(solleva il braccio in atto di ferirsi</stage></l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F"><stage>(arrestandosi)</stage> Ah, Beroe, ah, cara</l>
             <l>Parte dell'alma mia,</l>
             <l part="I">Pietà!</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Quella che ottenni</l>
             <l part="I">Ti rendo, ingrato. <stage>(in atto di ferirsi</stage></l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F"><stage>(slontanandosi</stage> Ah! no: prescrivi, imponi,</l>
             <l part="I">Di' qual mi brami.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F"><stage>(con autorità</stage> Ubbidiente al padre,</l>
             <l>Fido sposo a Nitteti, e de' tuoi giorni</l>
             <l part="I">Rispettoso custode.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F"><stage>(con sommissione</stage> E ben, deponi</l>
             <l>Dunque, o cara, l'acciar. Pronto io sono</l>
             <l part="I">Tutto, tutto a compir.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="M"><stage>(autorevole)</stage> Giuralo.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F"><stage>(in atto supplichevole)</stage> Oh Dio!</l>
             <l part="I">Che tirannia! Beroe, mia vita...</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F"><stage>(grave, torbida e minacciosa)</stage> Ingrato!</l>
             <l>Dunque delusa io sono</l>
             <l>Se di te m'assicuro?</l>
             <l part="I">Ah, vedimi morir. <stage>(risoluta in atto di ferirsi</stage></l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">Fermati: io giuro.</l>
             <l>Getta quel ferro: esecutor fedele</l>
             <l>Sarò de' cenni tuoi; lo giuro a' numi;</l>
             <l>Lo giuro a te, cor mio.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l>(Oh vittoria crudel!) <stage>(getta lo stile e s'abbandona come stanca)</stage> Sammete, addio. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="I">Dove sì presto?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="M">Al re.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">Sentimi almeno,</l>
             <l>Pria che a lui t'incammini.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l>No, prence. I suoi confini</l>
             <l>Ha la nostra virtù. Ne arrischia il frutto</l>
@@ -2931,7 +2956,7 @@
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>SAMMETE solo, indi NITTETI con seguaci armati.</stage>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l>Misero, che giurai! Come da quella</l>
             <l>Dividermi per sempre, onde diviso</l>
@@ -2945,7 +2970,7 @@
             <l>Fra quest'orride forse ombre segrete</l>
             <l part="I">A nasconder verrà.</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F">Fuggi, Sammete:</l>
             <l>Chi fece il tuo periglio,</l>
@@ -2954,33 +2979,33 @@
             <l>Questo l'oro m'aprì. <stage>(accennando la porta per la quale è venuta)</stage> Gli altri riguardi</l>
             <l part="I">Il mio dover tutti ha posposti.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">E' tardi.</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l>Tardi sarà, se non risolvi. Un solo</l>
             <l>De' reali custodi</l>
             <l>Che ascolti, che s'avvegga... Ah prence, ah fuggi,</l>
             <l part="I">Non t'arrestar!</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="M">Non è più tempo.</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F">Ingrato!</l>
             <l>Dalla mia man ti spiace</l>
             <l>La vita ancor! Va; non temer, non chiedo</l>
             <l part="I">Mercé dell'opra.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="M">Oh Dio, Nitteti! <stage>(con impazienza</stage></l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F">Intendo:</l>
             <l>Perder Beroe paventi</l>
@@ -2988,7 +3013,7 @@
             <l>Io ne sarò custode;</l>
             <l part="I">A te si serberà.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">Qual nuovo è questo</l>
             <l>Eccesso di virtù! Dopo un rifiuto...</l>
@@ -2997,54 +3022,54 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>BUBASTE e detti.</stage>
-          <sp>
+          <sp who="#bubaste">
             <speaker>BUB.</speaker>
             <l part="I">Prence, ti chiede il re.</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F">(Tutto è perduto).</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="I">Giunse già Beroe al re?</l>
           </sp>
-          <sp>
+          <sp who="#bubaste">
             <speaker>BUB.</speaker>
             <l part="F">No; ma desia</l>
             <l>Amasi di vederla. Io per cammino</l>
             <l part="I">In lei m'invenni, e l'affrettai.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">Che vuole</l>
             <l part="I">Il genitor da me?</l>
           </sp>
-          <sp>
+          <sp who="#bubaste">
             <speaker>BUB.</speaker>
             <l part="F">Nol so. Lasciai</l>
             <l>D'Iside seco il sacerdote; e solo</l>
             <l>Te condurgli m'impose. Andiam; ci attende:</l>
             <l part="I">Non l'irritiam.</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F"><stage>(a Sammete)</stage> Deh, non esporti! Amico, <stage>(a Bubaste</stage></l>
             <l>Salviam Sammete. Io quel cammin gli apersi;</l>
             <l part="I">Ei può, se non t'opponi...</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">Ah, d'agitarti</l>
             <l>Per me cessa, o Nitteti. Al padre è forza</l>
             <l part="I">Ch'io mi presenti.</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F">Ed incontrar non temi</l>
             <l>I paterni rigori?</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l>Son finiti (ah, pur troppo!) i miei timori.</l>
             <lg>
@@ -3086,99 +3111,99 @@
           <head>SCENA ULTIMA</head>
           <stage>Reggia di Canopo riccamente adorna ed illuminata in tempo di notte per festeggiar l'arrivo del nuovo re.</stage>
           <stage>AMASI con foglio in mano ed AMENOFI. Grandi d'Egitto, nobili, Etiopi, oratori delle provincie, paggi, guardie reali e numeroso séguito di altre nazioni; indi BEROE,  poi SAMMETE con BUBASTE, e finalmente NITTETI.</stage>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l>Ma qual gioia improvvisa, <stage>(alla destra d'Amasi</stage></l>
             <l>Signor, ti ride in volto? Ah, la mia fede</l>
             <l part="I">Merita pur ch'io n'entri a parte!</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">Amico,</l>
             <l>Tu vedi de' mortali</l>
             <l part="I">Oggi il più lieto in me. Sappi...</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F"><stage>(alla destra d'Amasi)</stage> E' compìto,</l>
             <l part="I">Amasi, il mio dover; Sammete...</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">Ah, dove,</l>
             <l>Dov'è? Tanto al mio ciglio</l>
             <l part="I">Perché tarda ad offrirsi?</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="M">Ah, padre! <stage>(gettandosi in ginocchioni alla sinistra del padre</stage></l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">Ah, figlio!</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l>Pentito, ubbidiente</l>
             <l>Eccomi a' piedi tuoi. Del fallo mio</l>
             <l>Il castigo a soffrir pronto son io.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l>Sorgi. Il tuo pentimento</l>
             <l>Chiede premio, e l'avrà. D'Aprio la figlia</l>
             <l>Ti renderà felice; e Beroe istessa</l>
             <l>Non ne sarà gelosa.</l>
           </sp>
-          <sp>
+          <sp who="#sammete #beroe">
             <speaker>SAMM. e BER.</speaker>
             <l part="I">(Oh Dio!)</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">Questa è Nitteti, ed è tua sposa. <stage>(prende senza fretta Beroe per mano, e la conduce a Sammete</stage></l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="I">Che mai dici?</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Io Nitteti! <stage>(esce Nitteti e l'ascolta</stage></l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="I">Come esser può?</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">Non dubitar del  dono:</l>
             <l part="I">La tua Beroe è Nitteti.</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F">Ed io chi sono?</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l>Ah! vieni, amata figlia, <stage>(le va incontro, l'abbraccia e le resta alla destra</stage></l>
             <l part="I">Vieni al mio seno.</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="M">Io figlia tua?</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">Sì, quella</l>
             <l>Amestri che bambina</l>
             <l part="I">Già piansi estinta.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="M"><stage>(ad Amasi)</stage> Io nulla intendo.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">Ascolta.</l>
             <l>La real madre tua perdé la vita</l>
@@ -3196,23 +3221,23 @@
             <l>A far credere attese;</l>
             <l>La pubblicò Nitteti, e al re la rese.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="I">Tutto ciò donde sai?</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">Da questo foglio</l>
             <l>Che, impresso di sua man, la mia consorte</l>
             <l>D'Iside al sacerdote</l>
             <l part="I">Morendo consegnò.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Dunque celato</l>
             <l part="I">Perché fu sin ad or?</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">Temea la sposa</l>
             <l>Ch'Aprio si vendicasse e dell'inganno</l>
@@ -3220,23 +3245,23 @@
             <l>In Sammete ed in me. Quindi prescrisse</l>
             <l part="I">Si tacesse l'arcano.</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="F">Anche al consorte?</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l>Sì. L'esatta mia fé, la mia paterna</l>
             <l>Tenerezza sapeva; e mi suppose</l>
             <l part="I">Complice mal sicuro.</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="F">E chi ne accerta,</l>
             <l>Soffri il mio zel, che questa Beroe è quella?</l>
             <l part="I">Non può supporne altra il pastor?</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">No: quando</l>
             <l>A lui la consegnò, cauta la sposa</l>
@@ -3244,21 +3269,21 @@
             <l>Il destro alla bambina</l>
             <l>Tenero braccio, ove alla man confina.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="I">E' vero: eccole; osserva.</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">Il so. Poc'anzi</l>
             <l part="I">Inaro già mel disse.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Inaro! Ah, dove</l>
             <l part="I">E' il padre mio?</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">Seco il conduce al tempio</l>
             <l>D'Iside il sacerdote,</l>
@@ -3267,26 +3292,26 @@
             <l>Voglio sposo Amenofi; ed alla vera</l>
             <l part="I">Nitteti il mio Sammete.</l>
           </sp>
-          <sp>
+          <sp who="#amenofi">
             <speaker>AMEN.</speaker>
             <l part="F">E al cor d'Amestri</l>
             <l part="I">Posso aspirar?</l>
           </sp>
-          <sp>
+          <sp who="#nitteti">
             <speaker>NITT.</speaker>
             <l part="M">T'è ben dovuto.</l>
           </sp>
-          <sp>
+          <sp who="#beroe">
             <speaker>BER.</speaker>
             <l part="F">Io temo,</l>
             <l part="I">Sammete, di sognar.</l>
           </sp>
-          <sp>
+          <sp who="#sammete">
             <speaker>SAMM.</speaker>
             <l part="F">Mia Beroe, io sento</l>
             <l part="I">Che angusto il core a tanta gioia...</l>
           </sp>
-          <sp>
+          <sp who="#amasi">
             <speaker>AMA.</speaker>
             <l part="F">Ancora</l>
             <l>Tempo, o figli, non è di sciorre il freno</l>
@@ -3294,11 +3319,11 @@
             <l>Diè per voi di clemenza un raro esempio:</l>
             <l part="I">Prima al tempio si vada.</l>
           </sp>
-          <sp>
+          <sp who="#amasi #amenofi #beroe #sammete #bubaste #nitteti">
             <speaker>TUTTI</speaker>
             <l part="F">Al tempio, al tempio.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Temerario è ben chi vuole</l>

--- a/tei/metastasio-romolo-ed-ersilia.xml
+++ b/tei/metastasio-romolo-ed-ersilia.xml
@@ -76,6 +76,31 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <personGrp xml:id="coro">
+            <name>Coro</name>
+          </personGrp>
+          <person xml:id="romolo">
+            <persName>Romolo</persName>
+          </person>
+          <person xml:id="ersilia">
+            <persName>Ersilia</persName>
+          </person>
+          <person xml:id="ostilio">
+            <persName>Ostilio</persName>
+          </person>
+          <person xml:id="valeria">
+            <persName>Valeria</persName>
+          </person>
+          <person xml:id="acronte">
+            <persName>Acronte</persName>
+          </person>
+          <person xml:id="curzio">
+            <persName>Curzio</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT-Pavia</name>Digitalizzazione</change>
@@ -135,7 +160,7 @@
           <head>SCENA PRIMA</head>
           <stage>Gran piazza di Roma, circondata di pubbliche e private fabbriche in parte non ancor terminate, ed in parte adombrate ancora di qualche albero frapposto. Campidoglio in faccia, selvaggio pur anche ed incolto, con ara ardente innanzi alla celebre annosa quercia consacrata a Giove su la cima del medesimo, donde per doppia spaziosa strada si discende sul piano. L'ara, la quercia, il monte, gli alberi e gli edifici tutti della gran piazza suddetta sono vagamente guarniti di festoni di fiori capricciosamente disposti per solennizzar le nozze de' giovani romani e delle donzelle sabine.</stage>
           <stage>Il basso della scena è tutto ingombrato di guerrieri, di littori e di popolo spettatore; e mentre allo strepito de' festivi stromenti, che accompagnano il seguente coro, vanno scendendo gli sposi per le varie strade del colle, ed intrecciando poi allegra danza sul piano, ROMOLO con ERSILIA per una via, OSTILIO con VALERIA per l'altra, vengono seguitando lentamente la pompa; e non rimane su l'alto che il numeroso stuolo de'sacerdoti intorno all'ara di Giove.</stage>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Sul Tarpeo propizie e liete</l>
@@ -144,7 +169,7 @@
               <l>Protettrice deità.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>PARTE DEL CORO</speaker>
             <lg>
               <l>Tu propaga, o dio dell'armi,</l>
@@ -153,14 +178,14 @@
               <l>Nella prole che verrà.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>TUTTO IL CORO</speaker>
             <lg>
               <l>Dall'Olimpo oggi scendete,</l>
               <l>Protettrici deità.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>PARTE DEL CORO</speaker>
             <lg>
               <l>Dea, che provvida e feconda</l>
@@ -169,14 +194,14 @@
               <l>D'amorosa fedeltà.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>TUTTO IL CORO</speaker>
             <lg>
               <l>Dall'Olimpo oggi scendete</l>
               <l>Protettrici deità.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>PARTE DEL CORO</speaker>
             <lg>
               <l>Piante eccelse innesti Amore,</l>
@@ -185,7 +210,7 @@
               <l>La comun felicità.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>TUTTO IL CORO</speaker>
             <lg>
               <l>Sul Tarpeo propizie e liete</l>
@@ -194,7 +219,7 @@
               <l>Protettrici deità.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l>Eccovi al fine, o belle</l>
             <l>De' vostri vincitori</l>
@@ -227,7 +252,7 @@
             <l>Secondate amorose i grandi augùri.</l>
           </sp>
           <stage>(nel tempo della seguente replica del coro partono danzando gli sposi</stage>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Sul Tarpeo propizie e liete</l>
@@ -240,31 +265,31 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>ROMOLO, ERSILIA, VALERIA ed OSTILIO</stage>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l>E fra tanti felici, <stage>(ad Ersilia</stage></l>
             <l>Adorabile Ersilia, esser degg'io</l>
             <l part="I">Incerto ancor della mia sorte?</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">(Oh Dio!)</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l>Né muover può l'esempio <stage>(a Valeria</stage></l>
             <l>Del sabino pur or vinto rigore</l>
             <l part="I">Il cor per me d'una romana?</l>
           </sp>
-          <sp>
+          <sp who="#valeria">
             <speaker>VAL.</speaker>
             <l part="F">(Oh amore!)</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="I">Parla almen, principessa.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Al sacro rito</l>
             <l>Spettatrice, e non sposa</l>
@@ -273,7 +298,7 @@
             <l>Qual dover mi consiglia;</l>
             <l>Tu sai ch'io son sabina e ch'io son figlia.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l>So che pretendo in vano</l>
             <l>D'ottener la tua mano, ove dal grande</l>
@@ -288,25 +313,25 @@
             <l>Se gli affetti veraci</l>
             <l part="I">D'un amante fedel...</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Romolo, ah! taci,</l>
             <l>E non perder di tanti</l>
             <l>Generosi riguardi</l>
             <l part="I">Il merito così.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="F">Qual fallo è il mio?</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l>Così liberi accenti</l>
             <l>Le donzelle sabine</l>
             <l>A soffrir non son use, e non s'impara</l>
             <l>Tal linguaggio fra noi che presso all'ara.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l>Che incanto è la bellezza</l>
             <l>Ornata di virtù! Seconda, amico,</l>
@@ -315,7 +340,7 @@
             <l>Il sospirato messaggier. Gl'istanti</l>
             <l part="I">Son secoli per me.</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l part="F">Di te non meno</l>
             <l>Mal sopporta l'indugio</l>
@@ -324,7 +349,7 @@
             <l>Pretenderia che tu volgessi ad altro</l>
             <l>Men difficile oggetto i tuoi pensieri.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l>Altro oggetto ch'Ersilia!... ah, non lo speri!</l>
             <lg>
@@ -344,7 +369,7 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>ERSILIA e VALERIA</stage>
-          <sp>
+          <sp who="#valeria">
             <speaker>VAL.</speaker>
             <l>Né ti par degno, Ersilia,</l>
             <l>D'amore il nostro eroe?</l>
@@ -352,25 +377,25 @@
             <l>L'attentato impedir, tu vedi come</l>
             <l part="I">Ei lo corregge.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="M">Il veggo.</l>
           </sp>
-          <sp>
+          <sp who="#valeria">
             <speaker>VAL.</speaker>
             <l part="F">E nulla intanto</l>
             <l part="I">Per lui ti dice il cor?</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="M">L'ammiro.</l>
           </sp>
-          <sp>
+          <sp who="#valeria">
             <speaker>VAL.</speaker>
             <l part="F">Io chiedo</l>
             <l part="I">Se l'odia o l'ama.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Amica,</l>
             <l>Me stessa io non intendo. Ho mille in seno</l>
@@ -401,7 +426,7 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>VALERIA, poi ACRONTE in abito romano.</stage>
-          <sp>
+          <sp who="#valeria">
             <speaker>VAL.</speaker>
             <l>Arde, e nol sa, ma in nobil fuoco almeno,</l>
             <l>La saggia Ersilia. Io sventurata adoro</l>
@@ -409,11 +434,11 @@
             <l>So che m'inganna Acronte, e pure... Oh stelle!</l>
             <l part="I">Traveggo? Ei viene.</l>
           </sp>
-          <sp>
+          <sp who="#acronte">
             <speaker>ACR.</speaker>
             <l part="M">(Infausto incontro!)</l>
           </sp>
-          <sp>
+          <sp who="#valeria">
             <speaker>VAL.</speaker>
             <l part="F">E dove,</l>
             <l>Folle, t'inoltri mai? Mentre congiura</l>
@@ -422,33 +447,33 @@
             <l>Qui con mentite spoglie</l>
             <l part="I">Arrischiarti così?</l>
           </sp>
-          <sp>
+          <sp who="#acronte">
             <speaker>ACR.</speaker>
             <l part="F">Rischio non temo,</l>
             <l>Cara, per rivederti.</l>
           </sp>
-          <sp>
+          <sp who="#valeria">
             <speaker>VAL.</speaker>
             <l>Ah mentitor! so che la fé di sposo</l>
             <l>Donata a me non curi più; che solo</l>
             <l part="I">D'Ersilia or ardi.</l>
           </sp>
-          <sp>
+          <sp who="#acronte">
             <speaker>ACR.</speaker>
             <l part="M">Io!</l>
           </sp>
-          <sp>
+          <sp who="#valeria">
             <speaker>VAL.</speaker>
             <l part="F">Sì. Credi che ignori</l>
             <l>Le tue vane richieste,</l>
             <l>I rifiuti del padre, i tuoi furori?</l>
           </sp>
-          <sp>
+          <sp who="#acronte">
             <speaker>ACR.</speaker>
             <l>Ingiusta sei. Ne chiamo</l>
             <l part="I">Tutti del cielo in testimonio...</l>
           </sp>
-          <sp>
+          <sp who="#valeria">
             <speaker>VAL.</speaker>
             <l part="F">Ah! taci;</l>
             <l>Io non voglio arrossir de' tuoi spergiuri.</l>
@@ -457,12 +482,12 @@
             <l>Gradisci il mio consiglio,</l>
             <l>E non farmi tremar nel tuo periglio.</l>
           </sp>
-          <sp>
+          <sp who="#acronte">
             <speaker>ACR.</speaker>
             <l>Perché in rischio mi vedi,</l>
             <l>Palpiti tanto, e un traditor mi credi?</l>
           </sp>
-          <sp>
+          <sp who="#valeria">
             <speaker>VAL.</speaker>
             <lg>
               <l>Sì, m'inganni, e pure, oh Dio!</l>
@@ -481,7 +506,7 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>ACRONTE, indi CURZIO in abito parimente romano.</stage>
-          <sp>
+          <sp who="#acronte">
             <speaker>ACR.</speaker>
             <l>Già un sinistro all'impresa</l>
             <l>Augurio è quest'incontro. Eh, non si scemi</l>
@@ -495,28 +520,28 @@
             <l>Scortar mi dee; ma nol rinvengo. Altrove</l>
             <l part="I">Cerchisi... <stage>(s'incontrano Curzio ed Acronte, e restano qualche istante immobili a guardarsi</stage> Curzio!</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l part="F">Acronte!</l>
           </sp>
-          <sp>
+          <sp who="#acronte">
             <speaker>ACR.</speaker>
             <l part="I">Sei pur tu?</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l part="F">Non m'inganno?</l>
           </sp>
-          <sp>
+          <sp who="#acronte">
             <speaker>ACR.</speaker>
             <l part="I">Degli Antemnati il prence in Roma?</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l part="F">In Roma</l>
             <l part="I">De' Ceninesi il prence?</l>
           </sp>
-          <sp>
+          <sp who="#acronte">
             <speaker>ACR.</speaker>
             <l part="F">Io, stanco al fine</l>
             <l>Delle pigre ire vostre,</l>
@@ -537,7 +562,7 @@
             <l>Dell'offesa comun non sia palese,</l>
             <l>Taccia il rancor delle private offese.</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l>Ma sai qual ne sovrasta</l>
             <l>Oggi ingiuria novella? Oggi si denno</l>
@@ -552,20 +577,20 @@
             <l>A liberar da questi</l>
             <l part="I">Imenei m'affrettai. </l>
           </sp>
-          <sp>
+          <sp who="#acronte">
             <speaker>ACR.</speaker>
             <l part="F">Tardi giungesti.</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l part="I">Come?</l>
           </sp>
-          <sp>
+          <sp who="#acronte">
             <speaker>ACR.</speaker>
             <l part="F">Il solenne rito</l>
             <l part="I">Principe, è già compiuto.</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l part="F">Oimè! sarebbe</l>
             <l>Ersilia ancor... No; la conosco: è troppo</l>
@@ -573,46 +598,46 @@
             <l>Tenace, rispettosa,</l>
             <l part="I">Rigida osservatrice.</l>
           </sp>
-          <sp>
+          <sp who="#acronte">
             <speaker>ACR.</speaker>
             <l part="F">E pure è sposa.</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l>Chi l'afferma? Onde il sai?</l>
           </sp>
-          <sp>
+          <sp who="#acronte">
             <speaker>ACR.</speaker>
             <l>Tutta io pur or mirai,</l>
             <l>Qui fra il volgo confuso in queste spoglie,</l>
             <l part="I">La pompa nuziale.</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l part="F">Ed era Ersilia...</l>
           </sp>
-          <sp>
+          <sp who="#acronte">
             <speaker>ACR.</speaker>
             <l>Ed era Ersilia anch'essa</l>
             <l>Della romana gioventù feroce</l>
             <l part="I">Fra le spose festive.</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l part="F">Oh colpo atroce! <stage>(si getta a sedere fiero e pensoso</stage></l>
           </sp>
-          <sp>
+          <sp who="#acronte">
             <speaker>ACR.</speaker>
             <l>Arrestarsi or perché? Tardo è il riparo;</l>
             <l>Pronta sia la vendetta. I tuoi guerrieri</l>
             <l>Corri, vola ad unir. Con me congiura</l>
             <l>Di Roma alla ruina.</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l>(Ersilia! mia figlia! una sabina!)</l>
           </sp>
-          <sp>
+          <sp who="#acronte">
             <speaker>ACR.</speaker>
             <l>(Né pur m'ascolta. Ah! quello sdegno insano</l>
             <l>Può tumulti destar, può alla rapina,</l>
@@ -621,11 +646,11 @@
             <l>Prevenirne gli effetti). E ben, poss'io,</l>
             <l part="I">Curzio, saper da te...</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l part="F">Lasciami solo.</l>
           </sp>
-          <sp>
+          <sp who="#acronte">
             <speaker>ACR.</speaker>
             <l>Tu il vuoi? ti lascio. (E al mio disegno io volo). <stage>(parte</stage></l>
           </sp>
@@ -655,46 +680,46 @@
           <head>SCENA SETTIMA</head>
           <stage>Appartamenti destinati nella reggia ad Ersilia sul colle Palatino.</stage>
           <stage>ERSILIA ed OSTILIO</stage>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l>Ma di Romolo, o Ersilia,</l>
             <l>Tutto il merto conosci?</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="I">Tutto.</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l part="M">E non l'ami?</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">No. Fra noi l'amore</l>
             <l part="I">E' figlio del dovere.</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l part="F">Altra speranza</l>
             <l>Dunque a noi non rimane,</l>
             <l part="I">Che un comando paterno?</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">E questa è vana;</l>
             <l part="I">Conosco il genitor.</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l part="F">Se avverso è il padre,</l>
             <l>Se insensibil tu sei, procura almeno</l>
             <l part="I">La nostra pace.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="M">Io! Come?</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l part="F">Il popol brama</l>
             <l>I reali imenei. Quasi in tumulto</l>
@@ -702,85 +727,85 @@
             <l>Te nega a noi, dal tuo consiglio accetti</l>
             <l>Romolo un'altra sposa.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="I">Dal mio consiglio!</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l part="M">Ah sì!</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Qual dritto ho mai...</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l>Quel che su l'alma sua ti dona amore.</l>
             <l>Chi dispor di quel core</l>
             <l>Ardirebbe sperar, se a te non lice?</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l>Io farmi debitrice</l>
             <l>Della sorte di Roma! Una regina</l>
             <l part="I">Io straniera cercar!</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l part="F">L'hai pur vicina.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="I">Chi?</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l part="M">Valeria.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="M">Valeria!</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l part="F">Oltraggio il trono</l>
             <l>Dall'illustre Valeria</l>
             <l>Almen non soffrirà, quando non possa</l>
             <l part="I">Adornarsi d'Ersilia.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">E ben, se credi</l>
             <l>Che giovi il voto mio... Ma queste, Ostilio,</l>
             <l>Son stravaganti idee... Valeria è amante.</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l>Lo so. Per sua sventura</l>
             <l>D'Acronte è accesa; e sarebbe opra appunto</l>
             <l>Di sincera amistà franger quel laccio</l>
             <l>Tanto indegno di lei.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="I">Sì... ma...</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l part="F">Viene a momenti</l>
             <l part="I">Romolo a te.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="M">Romolo!</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l part="F">Sì; proteggi,</l>
             <l part="I">Ersilia, il mio pensier; cerca...</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Tu vuoi</l>
             <l>Ch'io deliri con te. Chi mai t'intende?</l>
@@ -789,7 +814,7 @@
             <l>Che sposa io l'offra. O m'ingannasti prima</l>
             <l part="I">O al presente m'inganni!</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l part="F">Ah non t'inganno,</l>
             <l>Né fin or t'ingannai.</l>
@@ -813,7 +838,7 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>ERSILIA, indi CURZIO</stage>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l>D'un generoso amante</l>
             <l>Secondar io dovrei... Ma pur di qualche</l>
@@ -824,79 +849,79 @@
             <l>Ond'è che un tal mi regna</l>
             <l part="I">Tumulto in sen?</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l part="F">Pur ti raggiungo, indegna.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="I">Qual voce, oh Dio! Padre, signor...</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l part="F">T'accheta;</l>
             <l part="I">Non profanar quel nome.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="M">Ah padre!</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l part="F">Abbassa</l>
             <l>Le temerarie ciglia:</l>
             <l>La sposa d'un roman non è mia figlia.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="I">Sposa! Io signor?</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l part="F">Non aggravar, spergiura,</l>
             <l>Con la menzogna il fallo. Or or con l'altre</l>
             <l>Tue ribelli compagne</l>
             <l part="I">Sposa non fosti all'ara?</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Io spettatrice</l>
             <l part="I">Vi fui, non sposa.</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l part="M">E la tua man...</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">La mano</l>
             <l>D'Ersilia non si dona</l>
             <l part="I">Senza il cenno paterno.</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l part="M">E sei...</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Son io</l>
             <l part="I">Sabina ancor.</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l part="M">Né un trono offerto...</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Un trono</l>
             <l part="I">Vile è per me, se a te nol deggio.</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l part="F">E l'ire</l>
             <l part="I">E le minacce...</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Altra minaccia, o padre,</l>
             <l>Non può farmi tremar, che quella sola</l>
@@ -904,14 +929,14 @@
             <l>A me la morte istessa,</l>
             <l>Amato genitor, sarebbe amara.</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l>Ah, dell'anima mia parte più cara,</l>
             <l>Vieni al mio sen. Detesto</l>
             <l>I miei trasporti. Ah, più felice giorno</l>
             <l part="I">Per me fin or... Tu tremi, Ersilia?</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Io tremo,</l>
             <l>Padre, per te. Qui Romolo a momenti</l>
@@ -920,28 +945,28 @@
             <l>Chi sa... Partiam, signore; ovunque vuoi,</l>
             <l part="I">Io sieguo i passi tuoi.</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l part="F">No, figlia; il colpo</l>
             <l>S'avventura in tal guisa. E' della notte</l>
             <l part="I">Necessario il favor.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Ma intanto... Oh Dio!</l>
             <l part="I">Eccolo.</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l part="F">Io parto. Avverti</l>
             <l part="I">Che il tuo timor non mi tradisca.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Ah, dove,</l>
             <l part="I">Tu sicuro potrai...</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l part="F">V'è chi seconda</l>
             <l>Fido il disegno mio.</l>
@@ -951,7 +976,7 @@
         <div type="scene">
           <head>SCENA NONA</head>
           <stage>ERSILIA, poi ROMOLO</stage>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l>Misera me! mancava</l>
             <l>Solo alle angustie mie la più crudele,</l>
@@ -959,15 +984,15 @@
             <l>Come a Romolo offrirmi?... Ah, vien! S'evìti</l>
             <l>Per or la sua presenza.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="I">Fuggi, Ersilia, da me?</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">(Numi, assistenza!)</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l>Non temer, principessa,</l>
             <l>Ch'io ti parli d'amore: i tuoi rispetto,</l>
@@ -976,11 +1001,11 @@
             <l>Lo confesso, per me; ma il dispiacerti</l>
             <l part="I">Saria maggiore.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="M">(Oh generoso!)</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="F">Io credo</l>
             <l>Però che non si chiami</l>
@@ -990,32 +1015,32 @@
             <l>Possessor mi faranno, il più felice</l>
             <l part="I">Io sarò de' viventi.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="M">(Oimè!)</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="F">Che al trono</l>
             <l>Tu aggiungerai splendor; che tu di Roma</l>
             <l>La deità sarai; che arbitra sola</l>
             <l part="I">Sempre tu del cor mio...</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Signor, permetti</l>
             <l part="I">Ch'io volga i passi altrove.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="F">Ah, dunque io sono</l>
             <l part="I">L'aborrimento tuo?</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="M">(Che pena!)</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="F">Un fallo</l>
             <l> Se l'amore è per voi, per voi non credo</l>
@@ -1025,7 +1050,7 @@
             <l>Se dal Ciel m'è negata,</l>
             <l>Può ben essermi Ersilia amica e grata.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l>(Non so più dove io sia. Non so s'io debba</l>
             <l>O partire o restar. Vorrei scusarmi;</l>
@@ -1033,17 +1058,17 @@
             <l>Che proferir vorrei,</l>
             <l>Si trasforma in sospir fra' labbri miei).</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l>E tace Ersilia, e un guardo</l>
             <l>Non volge a me! Ma quando</l>
             <l>T'offesi mai? Ma di che reo son io?</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="I">Signor... se credi... (Oh Dio!)</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="F">Né siegui! Ah, qualche</l>
             <l>Nuovo affanno t'opprime. A questo segno</l>
@@ -1053,55 +1078,55 @@
             <l>Degl'interni tumulti il cor commosso!</l>
             <l part="I">Spiegati, per pietà.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Signor... non posso. <stage>(piange</stage></l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <lg>
               <l>Ah, che vuol dir quel pianto?</l>
               <l>L'affanno tuo qual è?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <lg>
               <l>Sento morirmi, e intanto</l>
               <l>Non saprei dir perché.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <lg part="I">
               <l>Reo del tuo duol son io?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <lg part="F">
               <l>Tu... s'io sapessi... Addio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <lg part="I">
               <l part="I">Non mi lasciar.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <lg part="M">
               <l part="F">Che giova?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <lg part="F">
               <l>Non mi lasciar così.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#ersilia #romolo">
             <speaker>A DUE</speaker>
             <lg>
               <l>Angustia così nuova</l>
@@ -1143,17 +1168,17 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>CURZIO e detta.</stage>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l part="I">Figlia, Ersilia.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Ah, signor, possiam la nostra</l>
             <l>Partenza anticipar? Teco son io,</l>
             <l part="I">Se vieni ad affrettarmi.</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l part="F">Ad avvertirti</l>
             <l>D'un nuovo tuo periglio</l>
@@ -1168,18 +1193,18 @@
             <l>Le temerarie imprese</l>
             <l part="I">Belle sembrano a lui: guardati.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Ah, dunque</l>
             <l part="I">A che più rimaner? Partasi.</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l part="F">Il tempo</l>
             <l>Ancor non è. Pochi momenti ancora</l>
             <l part="I">Tollera in pace.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">In Roma</l>
             <l>Non v'è pace per me: questo soggiorno</l>
@@ -1188,7 +1213,7 @@
             <l>Fa ch'io m'involi, e fa ch'io possa al fine</l>
             <l>Respirar le tranquille aure sabine.</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l>Oh come, amata figlia,</l>
             <l>Codesta m'innamora</l>
@@ -1254,34 +1279,34 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>ERSILIA, OSTILIO, indi VALERIA</stage>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l part="F">Or dal Senato</l>
             <l part="I">Torna a' soggiorni suoi.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Sarà permesso</l>
             <l part="I">A me vederlo?</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l part="F">A te! Perdona; è ingrata</l>
             <l part="I">La tua dubbiezza.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Io voglio</l>
             <l part="I">Seco parlar.</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l part="F">Potrebbe</l>
             <l>Forse Roma sperarti</l>
             <l>Fausta a' suoi voti, e grata</l>
             <l part="I">Romolo all'amor suo?</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Non nacque Ersilia</l>
             <l>Per Roma, né per lui. Ma se pur vero,</l>
@@ -1289,21 +1314,21 @@
             <l>Di Romolo il volere, oggi regina</l>
             <l part="I">Sarà la tua Valeria.</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l part="M">Ah! dunque...</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F"><stage>(a Valeria che esce)</stage> Amica,</l>
             <l>Se mi secondan gli astri, un regio serto</l>
             <l part="I">Ad apprestarti io vado.</l>
           </sp>
-          <sp>
+          <sp who="#valeria">
             <speaker>VAL.</speaker>
             <l part="M">A me?</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Sì. Mia</l>
             <l>Di così bel pensiero</l>
@@ -1313,7 +1338,7 @@
             <l>In te propone; io con ragion l'ammiro,</l>
             <l>E ad emularlo ambiziosa aspiro.</l>
           </sp>
-          <sp>
+          <sp who="#valeria">
             <speaker>VAL.</speaker>
             <l>Grata io vi son; ma voi</l>
             <l>Disponete di me, quando non posso</l>
@@ -1321,7 +1346,7 @@
             <l>Uno sposo infedele; e in me divenne</l>
             <l part="I">L'amor necessità.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Comun pretesto</l>
             <l>Dell'altrui debolezza. Eh! miglior uso</l>
@@ -1343,7 +1368,7 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>OSTILIO e VALERIA</stage>
-          <sp>
+          <sp who="#valeria">
             <speaker>VAL.</speaker>
             <l>Io nulla intendo, Ostilio: Ersilia amante</l>
             <l>Di Romolo credei: convinta a prova</l>
@@ -1353,19 +1378,19 @@
             <l>M'adulasti fin ora  amor fingendo:</l>
             <l>Ostilio, lo confesso, io nulla intendo.</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l>Credendo Ersilia amante, io non saprei</l>
             <l>Se t'apponesti al ver. So ben ch'io t'amo</l>
             <l>Quanto amar mai si possa, e so che amarti</l>
             <l part="I">Sempre così vogl'io.</l>
           </sp>
-          <sp>
+          <sp who="#valeria">
             <speaker>VAL.</speaker>
             <l part="F">Ma tua regina</l>
             <l part="I">Come dunque mi brami?</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l part="F">In che s'oppone</l>
             <l>Il trono all'amor mio? L'amor ch'io sento,</l>
@@ -1376,7 +1401,7 @@
             <l>Del tuo real decoro,</l>
             <l>Sempre t'adorerò, come or t'adoro.</l>
           </sp>
-          <sp>
+          <sp who="#valeria">
             <speaker>VAL.</speaker>
             <l>Taci, Ostilio, e risparmia</l>
             <l>I rimorsi del mio cor d'esserti ingrata.</l>
@@ -1427,7 +1452,7 @@
           <head>SCENA SETTIMA</head>
           <stage>Gabinetti, viali coperti, ed altri edifici di verdure, tutti imitanti architettura, su la falda del Palatino.</stage>
           <stage>ROMOLO, poi ACRONTE</stage>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l>No, d'Ersilia l'affanno</l>
             <l>Non è tutto rigor. Vidi in quel volto,</l>
@@ -1447,60 +1472,60 @@
             <l>Il voto popolar... Ma quale ascolto</l>
             <l part="I">Strepito d'armi! Olà. <stage>(verso la scena</stage></l>
           </sp>
-          <sp>
+          <sp who="#acronte">
             <speaker>ACR.</speaker>
             <l part="F">No, questo acciaro</l>
             <l part="I">Non è facil trofeo. <stage>(dentro</stage></l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="F">Contro un romano</l>
             <l part="I">I miei custodi!</l>
           </sp>
-          <sp>
+          <sp who="#acronte">
             <speaker>ACR.</speaker>
             <l part="M">Avversi dèi! <stage>(nell'uscir difendendosi gli cade la spada</stage></l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="F">Fermate,</l>
             <l>Miei fidi. Ah, non si opprima,</l>
             <l>Chi difesa non ha. Stelle! M'inganno?</l>
             <l part="I">Acronte tu non sei?</l>
           </sp>
-          <sp>
+          <sp who="#acronte">
             <speaker>ACR.</speaker>
             <l part="M"><stage>(con alterigia</stage> Lo sono.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="F">In Roma!</l>
             <l>Ne' miei soggiorni! in finte spoglie! E quale</l>
             <l part="I">E' il tuo disegno?</l>
           </sp>
-          <sp>
+          <sp who="#acronte">
             <speaker>ACR.</speaker>
             <l part="F">A te ragion non rendo</l>
             <l part="I">Dell'opre mie. <stage>(come sopra</stage></l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="F">Fuor di stagione, Acronte,</l>
             <l part="I">Ostenti ardir. Pensa ove sei.</l>
           </sp>
-          <sp>
+          <sp who="#acronte">
             <speaker>ACR.</speaker>
             <l part="F">Son meco</l>
             <l>Sempre, dovunque io sia.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l>Ma il valore è follia,</l>
             <l>Prence, nel caso tuo. Parla. Fu il vano</l>
             <l>Amor che hai per Ersilia, o fu l'antico</l>
             <l part="I">Odio per me, che t'acciecò?</l>
           </sp>
-          <sp>
+          <sp who="#acronte">
             <speaker>ACR.</speaker>
             <l part="F">Risparmia</l>
             <l>Romolo, le richieste: io qui non venni</l>
@@ -1512,7 +1537,7 @@
             <l>Dagli avversi al valor fati inclementi,</l>
             <l part="I">E argomento la mia.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="F">Male argomenti.</l>
             <l>Littori, olà; de' Ceninesi al prence</l>
@@ -1520,16 +1545,16 @@
             <l>Delle romane mura oltre il recinto</l>
             <l part="I">Conducetelo illeso.</l>
           </sp>
-          <sp>
+          <sp who="#acronte">
             <speaker>ACR.</speaker>
             <l part="F">A me la spada!</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l>Sì, prendila; e, se puoi, racquista in campo</l>
             <l part="I">Ciò che in Roma perdesti.</l>
           </sp>
-          <sp>
+          <sp who="#acronte">
             <speaker>ACR.</speaker>
             <l part="F">Assai costarti</l>
             <l>L'imprudenza potrebbe. Una vendetta</l>
@@ -1537,14 +1562,14 @@
             <l>Romolo, t'avvedrai</l>
             <l>Che da saggio non è.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l>Io vendetta! E di che? Folle, ti scuso;</l>
             <l>Amante, ti compiango;</l>
             <l>Nemico, non ti curo; e a frodi avvezzo</l>
             <l>Se insidiator venisti, io ti disprezzo.</l>
           </sp>
-          <sp>
+          <sp who="#acronte">
             <speaker>ACR.</speaker>
             <lg>
               <l>Sprezzami pur per ora,</l>
@@ -1563,29 +1588,29 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>ROMOLO ed ERSILIA</stage>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l>(Eccolo. La vittoria</l>
             <l part="I">E' tempo di compir). <stage>(s'incammina e s'arresta</stage></l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="F">(Strano portento</l>
             <l part="I">Quel coraggio è per me).</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">(Numi, qual sorte</l>
             <l>D'incantamento è questo! Appresso a lui di nuovo</l>
             <l part="I">Comincio a palpitar).</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="F">(Come può mai</l>
             <l>In un'alma albergar tanto valore</l>
             <l part="I">Con sì poca virtù!)</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">(No, non t'arresti</l>
             <l>Questo palpito, Ersilia. In ogni assalto</l>
@@ -1595,48 +1620,48 @@
             <l>Signor, per brevi istanti</l>
             <l part="I">Chiedo che tu m'ascolti.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="F">E' ver? Non sogno?</l>
             <l>La dolce cura mia,</l>
             <l>L'unico mio pensier, la bella Ersilia</l>
             <l part="I">Viene in traccia di me!</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F"><stage>(seria)</stage> Dunque ascoltarmi,</l>
             <l part="I">Romolo, tu non vuoi?</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="M">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F"><stage>(come sopra)</stage> Lo sai,</l>
             <l part="I">Quel linguaggio m'offende.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="F">A mio dispetto</l>
             <l part="I">Vien su le labbra il cor.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Se vuoi ch'io resti,</l>
             <l>Non far uso di questi</l>
             <l>Teneri accenti, e non dir mai che m'ami.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l>(E pur non m'odia). Ubbidirò. Che brami?</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l>Ad implorare io vengo</l>
             <l part="I">Grazie da te.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="F">Tu da me grazie! Ah! dunque</l>
             <l>Ignori ancor che dal felice istante</l>
@@ -1644,39 +1669,39 @@
             <l>Del mio cor, del mio soglio,</l>
             <l>Di tutti... Ah! no; disubbidir non voglio.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l>(Costanza, Ersilia. A lui</l>
             <l part="I">Si proponga Valeria).</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="F">E ben, che chiedi?</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l>Che di mia mano accetti,</l>
             <l part="I">Romolo, un'altra sposa.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="M"><stage>(con sorpresa)</stage> Io!</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Sì. L'amica</l>
             <l part="I">Valeria io t'offro.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="M">A me? <stage>(turbato</stage></l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Valeria è degna</l>
             <l>Il sai, d'essere amata.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l>E a questo segno, ingrata, <stage>(con passione di sdegno e di tenerezza</stage></l>
             <l>Insulti all'amor mio! Questa mercede</l>
@@ -1686,11 +1711,11 @@
             <l>Dove impressa tu sei, dove tu sempre,</l>
             <l>Così barbara ancor, sarai regina?</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l>(Ah, non lasciarmi, austerità sabina!)</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l>Offrirmi un'altra sposa! E non bastava</l>
             <l>Per opprimermi, oh dèi! la tua freddezza,</l>
@@ -1699,11 +1724,11 @@
             <l>Eccesso di tormento</l>
             <l part="I">Chi non vive che in te!</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">(Morir mi sento).</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l>Semplice! ed io pur dianzi</l>
             <l>Dell'amor tuo mi lusingai. Quei detti</l>
@@ -1712,33 +1737,33 @@
             <l>Tutto mi parve un amoroso affanno.</l>
             <l part="I">Che inganno, Ersilia! <stage>(con tenerezza</stage></l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F"><stage>(come sopra)</stage> Ah, non è stato inganno!</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l>Come! non m'ingannai? <stage>(con sorpresa di piacere</stage></l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="I">(Numi, che dissi mai!)</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="F"><stage>(con impeto d'affetto)</stage> Bella mia fiamma,</l>
             <l>Dunque è ver, dunque m'ami?</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="I">Taci; non trionfar.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="F">Ma come, amante,</l>
             <l part="I">Potesti offrirmi un'altra sposa?</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Oh Dio,</l>
             <l>Non trafiggermi più. Se tu vedermi</l>
@@ -1753,7 +1778,7 @@
             <l>Romolo, io ti farei</l>
             <l part="I">Meraviglia e pietà.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="F">Dimmi piuttosto</l>
             <l>Tenerezza ed amor. Chi fra' mortali</l>
@@ -1762,17 +1787,17 @@
             <l>Astro del nuovo impero;</l>
             <l part="I">Ecco Roma felice.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Ah, non è vero!</l>
             <l>E' speranza infedel; mal ti consiglia;</l>
             <l part="I">Tua non sarò.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="M">Ma perché mai?</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Son figlia.</l>
             <lg>
@@ -1792,7 +1817,7 @@
         <div type="scene">
           <head>SCENA NONA</head>
           <stage>ROMOLO, indi OSTILIO</stage>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l>Ah! non è dubbio il mio trionfo; ho vinto</l>
             <l>L'austero cor d'Ersilia. Il genitore,</l>
@@ -1801,25 +1826,25 @@
             <l>Nulla fia ch'io risparmi</l>
             <l part="I">Per ottener da lui...</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l part="F"><stage>(con premura)</stage> Romolo, all'armi.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="I">Che fu?</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l part="F">Roma è in periglio. Ingrato Acronte</l>
             <l>A' benefici tuoi, libero a pena,</l>
             <l part="I">D'assalirla minaccia.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="F">E con quai schiere?</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l>Co' Ceninesi suoi. Già in vari agguati</l>
             <l>Pronti gli avea; che ad un suo cenno io vidi</l>
@@ -1828,17 +1853,17 @@
             <l>Balenar mille acciari, e cento e cento</l>
             <l>Improvvise bandiere aprirsi al vento.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l>Mal preparati il folle</l>
             <l>Sorprenderne sperò. Lo disinganni</l>
             <l part="I">Il suo castigo. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l part="M">Al fianco tuo... <stage>(volendolo seguire</stage></l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="F">No, resta.</l>
             <l>Roma io confido a te. Veglia in difesa</l>
@@ -1847,11 +1872,11 @@
             <l>Non ancora eseguita insidia ascosa.</l>
             <l part="I">Va, non tardar.</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l part="F">Su la mia fé riposa. <stage>(parte</stage></l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l>Grazie, o nume dell'armi,</l>
             <l>Grazie, o madre d'Amor, del sangue mio</l>
@@ -1881,7 +1906,7 @@
           <head>SCENA PRIMA</head>
           <stage>Sito angusto ed incolto negli orti palatini, ristretto fra scoscesi ed elevati sassi, bagnato da un'acqua cadente, e soltanto illuminato dall'alto, quanto permettono le frondose piante che gli sovrastano.</stage>
           <stage>CURZIO frettoloso, poi ERSILIA</stage>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l>Dove mai rinvenirla? Il destro istante</l>
             <l>Trascurar non vorrei. M'offre la sorte...</l>
@@ -1889,7 +1914,7 @@
             <l>Rendi grazie agli dèi; partir possiamo:</l>
             <l part="I">Giunse il tempo opportuno.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Ah! tu non sai,</l>
             <l>Che accesa è già del Palatino a tergo</l>
@@ -1899,11 +1924,11 @@
             <l>Tutti d'armi e d'armati; e di Sabina</l>
             <l part="I">Interrotta è ogni via.</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l part="M">Non tutte.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Io stessa,</l>
             <l>Non dubitarne, o genitor, dall'alto</l>
@@ -1911,7 +1936,7 @@
             <l>Già veduto assalirsi; e dal funesto</l>
             <l part="I">Spettacolo fuggendo...</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l part="F">Appunto all'opra</l>
             <l> Questo, che credi inciampo,</l>
@@ -1925,12 +1950,12 @@
             <l>Siam nell'Etruria amica: e quindi è franco</l>
             <l part="I">Alla patria il ritorno.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Eccomi dunque</l>
             <l part="I">Pronta a seguirti.</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l part="F">No: questa ti lascio</l>
             <l>Scorta fedel; seco t'invia. Raccolti</l>
@@ -1942,11 +1967,11 @@
             <l>Ne attende poi là dove bagna il fiume</l>
             <l part="I">La porta Carmental.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">(Crudel partenza!)</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l>Palpiti ancora? Eh, non temer; ti fida,</l>
             <l>Ersilia, a me: tutto io pensai; son tutti</l>
@@ -1970,7 +1995,7 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>ERSILIA, poi VALERIA</stage>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l>Oh Tebro, oh Roma, oh care sponde, a cui</l>
             <l>I miei primi ho fidati</l>
@@ -1991,41 +2016,41 @@
             <l>Se pur sai le vicende,</l>
             <l>Non lasciar ch'io le ignori.</l>
           </sp>
-          <sp>
+          <sp who="#valeria">
             <speaker>VAL.</speaker>
             <l part="I">Il conflitto finì.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="M">Chi vinse?</l>
           </sp>
-          <sp>
+          <sp who="#valeria">
             <speaker>VAL.</speaker>
             <l part="F">Avea</l>
             <l part="I">Romolo già la palma.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="M">Ed ora?</l>
           </sp>
-          <sp>
+          <sp who="#valeria">
             <speaker>VAL.</speaker>
             <l part="F">Ed ora</l>
             <l>Non si sa chi otterrà l'ultime lodi.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="I">Io nulla intendo.</l>
           </sp>
-          <sp>
+          <sp who="#valeria">
             <speaker>VAL.</speaker>
             <l part="F">Intenderai, se m'odi.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="I">Parla.</l>
           </sp>
-          <sp>
+          <sp who="#valeria">
             <speaker>VAL.</speaker>
             <l part="F">Già della pugna</l>
             <l>Deciso era il destin; già in ogni lato</l>
@@ -2044,11 +2069,11 @@
             <l>Con insano ardimento</l>
             <l>Il vincitore a singolar cimento.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="I">Oh temerario!</l>
           </sp>
-          <sp>
+          <sp who="#valeria">
             <speaker>VAL.</speaker>
             <l part="F">Il nostro eroe, sdegnando</l>
             <l>Ogni vantaggio, ad un girar di ciglio</l>
@@ -2057,11 +2082,11 @@
             <l>Cambiar di volto, al Ceninese ardito</l>
             <l>Si fece incontro ed accettò l'invito.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="I">Ma poi?</l>
           </sp>
-          <sp>
+          <sp who="#valeria">
             <speaker>VAL.</speaker>
             <l part="F">Non so: quando partì dal campo</l>
             <l>Chi mi narrò ciò ch'io t'esposi, ancora</l>
@@ -2071,27 +2096,27 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>OSTILIO e detti.</stage>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l>Più indistinto non è: Romolo ha vinto.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="I">Ed è vero?</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l part="F">Il vedrai</l>
             <l>Tu stessa or ora al re de' numi in voto</l>
             <l>Le prime spoglie opime</l>
             <l part="I">Trionfante portar.</l>
           </sp>
-          <sp>
+          <sp who="#valeria">
             <speaker>VAL.</speaker>
             <l part="F">Le spoglie! Ah! dunque</l>
             <l part="I">Acronte...</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l part="F">Acronte a prova</l>
             <l>Mostrò di quanto alla virtude e all'arte</l>
@@ -2108,11 +2133,11 @@
             <l>Corre a lui, lo solleva,</l>
             <l part="I">Gli rende il ferro.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="M">Oh grande!</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l part="F">E già volea</l>
             <l>Stringerlo amico al sen, quando s'avvide</l>
@@ -2123,11 +2148,11 @@
             <l>Di quell'ingrato sangue ancor non tinto,</l>
             <l>Gli passa il petto e lo rovescia estinto.</l>
           </sp>
-          <sp>
+          <sp who="#valeria">
             <speaker>VAL.</speaker>
             <l part="I">Chi mi soccorre! Io moro. <stage>(s'abbandona sopra un sasso</stage></l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Or di costanza,</l>
             <l>Valeria, è tempo. Un tale affanno... (Oh Dio,</l>
@@ -2152,21 +2177,21 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>VALERIA ed OSTILIO</stage>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l>Adorata Valeria,</l>
             <l>Soffri ch'io lo confessi, invidio il fato</l>
             <l>Di chi l'omaggio ottiene</l>
             <l part="I">Di lagrime si' belle.</l>
           </sp>
-          <sp>
+          <sp who="#valeria">
             <speaker>VAL.</speaker>
             <l part="F">Ostilio, ah parti!</l>
             <l>Un di mia debolezza</l>
             <l>Spettator, qual tu sei,</l>
             <l part="I">Mi fa troppo arrossir.</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l part="F">Sono i tuoi cenni</l>
             <l>Leggi per me. Ma sappi</l>
@@ -2216,7 +2241,7 @@
           <stage>Luogo spazioso alle radici del colle Palatino già ornato per festeggiare le seguìte nozze con le donzelle sabine; donde per magnifica scala si ascende alla reggia di Romolo situata sul colle suddetto.</stage>
           <stage>La scena è tutta ingombrata di numeroso popolo accorso al ritorno del vincitore. Fra lo strepito de' pubblici applausi si avanza ROMOLO coronato d'alloro, preceduto da' littori, da' prigionieri sabini, dalle spoglie opime del vinto ACRONTE, e seguìto dal trionfante esercito vittorioso.</stage>
           <stage>ROMOLO, indi VALERIA frettolosa.</stage>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Serbate, o numi,</l>
@@ -2231,7 +2256,7 @@
               <l>La terra e il mar.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <lg>
               <l>Il tenor de' fati intendi,</l>
@@ -2252,7 +2277,7 @@
               <l>I superbi a debellar.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Serbate, o numi,</l>
@@ -2261,38 +2286,38 @@
               <l>Di trionfar.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <lg>
               <l>Il tenor de' fati intendi,</l>
               <l>E vincendo, o Roma, apprendi...</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#valeria">
             <speaker>VAL.</speaker>
             <l>Al riparo, signor. La tua presenza</l>
             <l>E' necessaria: abbiam nemici in Roma.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="I">Nemici in Roma!</l>
           </sp>
-          <sp>
+          <sp who="#valeria">
             <speaker>VAL.</speaker>
             <l part="M">Sì.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="M">Dove?</l>
           </sp>
-          <sp>
+          <sp who="#valeria">
             <speaker>VAL.</speaker>
             <l part="F">Là, verso</l>
             <l>La porta Carmental, già tutto è in armi.</l>
             <l>Altri accorre, altri fugge, e si dilata</l>
             <l>A momenti il tumulto.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="I">Seguitemi, o Romani.</l>
           </sp>
@@ -2300,28 +2325,28 @@
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>OSTILIO e detti.</stage>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l part="F">E' tutto in calma:</l>
             <l>Risparmia a maggior uopo,</l>
             <l part="I">Romolo, il tuo valor.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="F">Ma qual cagione...</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l>Il crederesti? Ersilia</l>
             <l part="I">V'è chi tentò rapir.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="F">Come dal chiuso</l>
             <l>Recinto cittadin sperar potea</l>
             <l part="I">D'uscir sicuro il rapitor?</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l part="F">Già innanzi</l>
             <l>Delle porte custodi</l>
@@ -2334,15 +2359,15 @@
             <l>Seguace stuol, benché ostinato e fiero,</l>
             <l>Tutto estinto rimase, ei prigioniero.</l>
           </sp>
-          <sp>
+          <sp who="#valeria">
             <speaker>VAL.</speaker>
             <l part="I">Oh ardire!</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="M">E intanto Ersilia?</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l part="F">Ersilia intanto</l>
             <l>Palpitante e smarrita...</l>
@@ -2351,60 +2376,60 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>ERSILIA e detti.</stage>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l>Ah Romolo, pietà, clemenza, aita! <stage>(vuole inginocchiarsi</stage></l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l>Principessa, ah, che fai? Sorgi: che temi?</l>
             <l part="I">Qui sicura già sei. <stage>(l'impedisce</stage></l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Salvami il padre</l>
             <l>Da' militari insulti,</l>
             <l part="I">Dall'ira popolare.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="M">Il padre!</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l part="F">Ah! quello</l>
             <l>Forse che te per man traeva, e ch'io</l>
             <l part="I">Ammirai nella pugna...</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">E' il padre mio.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="I">Di lui che avvenne?</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l part="F">E' prigionier, ma salvo.</l>
             <l>Serbarti alcuno, onde ritrarre il vero,</l>
             <l>Credei prudente; ed esigea rispetto</l>
             <l part="I">La sua presenza, il suo valor.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="F">Ma dove</l>
             <l>Il prence or si trattiene?</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l part="I">Fra i custodi il lasciai.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="M">Deh, venga!</l>
           </sp>
-          <sp>
+          <sp who="#ostilio">
             <speaker>OST.</speaker>
             <l part="F">Ei viene.</l>
           </sp>
@@ -2412,7 +2437,7 @@
         <div type="scene">
           <head>SCENA ULTIMA</head>
           <stage>CURZIO fra le guardie, e detti.</stage>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l>Principe valoroso, e non avranno</l>
             <l>Mai fin gli sdegni nostri? I nostri ognora</l>
@@ -2423,19 +2448,19 @@
             <l>Torni l'invitto acciar. Libero sei.</l>
             <l>Niuna sopra di te ragion mi resta.</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l>(Qual mai favella inaspettata è questa!)</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l>Non mi rispondi, o prence?</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="I">(Implacabile è il padre).</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="F">Ah, già che puoi</l>
             <l>Render altri felice,</l>
@@ -2447,26 +2472,26 @@
             <l>Della nostra amistà. Curzio prescriva,</l>
             <l>Curzio l'arbitro sia del mio destino.</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l>(Perché Romolo, o dèi, non è sabino!)</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="I">(Ah, tace ognor!)</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="M">Tu parla, Ersilia.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Oh Dio!</l>
             <l>Che posso dir? Son figlia;</l>
             <l>Intendo il padre; e l'ubbidir, lo sai,</l>
             <l part="I">E' il mio primo dover.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="F">Dunque decisa</l>
             <l>E' la mia sorte. Il suo tacer si spiega</l>
@@ -2476,27 +2501,27 @@
             <l>Me stesso io vincerò. Va; la tua figlia</l>
             <l>Libero riconduci al suol natio.</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l part="I">A me tu rendi Ersilia!</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="M">A te.</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l part="F">Che intendo!</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l>E amante e amato e vincitor la rendo.</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l part="I">(Oh, virtù più che umana!)</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="F">Addio, mia sola,</l>
             <l>Addio, bella mia fiamma. Il Ciel ti serbi</l>
@@ -2504,34 +2529,34 @@
             <l>Del tuo sesso all'onore,</l>
             <l>Al mio rispetto ed all'esempio altrui.</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="I">(Morir mi sento).</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l part="F">(E come odiar costui?)</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l>Parla, guardami, o prence,</l>
             <l>Almen pria di partir. Deh, parti amico</l>
             <l>Già che padre non vuoi! L'antico almeno</l>
             <l>Natio rancore in qualche parte estinto...</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l>Ah! figlio, ah! basta: eccoti Ersilia: hai vinto.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="I">E' sogno!</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="M">E' ver!</l>
           </sp>
-          <sp>
+          <sp who="#curzio">
             <speaker>CUR.</speaker>
             <l part="F">Non ho di sasso al fine</l>
             <l>In petto il cor. V'è chi conoscer possa</l>
@@ -2539,15 +2564,15 @@
             <l>Anch'io l'amo, l'adoro, e al Ciel son grato,</l>
             <l>Che a sì bel dì mi conservò pietoso.</l>
           </sp>
-          <sp>
+          <sp who="#romolo">
             <speaker>ROM.</speaker>
             <l part="I">Oh Roma fortunata!</l>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERS.</speaker>
             <l part="F">Oh padre! oh sposo!</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Numi, che intenti siete</l>

--- a/tei/metastasio-ruggero-ovvero-l-eroica-gratitudine.xml
+++ b/tei/metastasio-ruggero-ovvero-l-eroica-gratitudine.xml
@@ -76,6 +76,31 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="bradamante">
+            <persName>Bradamante</persName>
+          </person>
+          <person xml:id="clotilde">
+            <persName>Clotilde</persName>
+          </person>
+          <person xml:id="ottone">
+            <persName>Ottone</persName>
+          </person>
+          <person xml:id="ruggiero">
+            <persName>Ruggiero</persName>
+          </person>
+          <person xml:id="leone">
+            <persName>Leone</persName>
+          </person>
+          <person xml:id="carlo_magno">
+            <persName>Carlo Magno</persName>
+          </person>
+          <personGrp xml:id="coro">
+            <name>Coro</name>
+          </personGrp>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT-Pavia</name>Digitalizzazione</change>
@@ -140,17 +165,17 @@
           <head>SCENA PRIMA</head>
           <stage>Logge terrene negli appartamenti destinati a Clotilde.</stage>
           <stage>BRADAMANTE in abito guerriero, ma senza scudo, e CLOTILDE</stage>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l>Sì, Clotilde, ho deciso; e il mio disegno</l>
             <l>Fido a te sola: all'oscurar del giorno</l>
             <l part="I">Voglio quindi partir.</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="M">Che dici!</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Ah! scorse</l>
             <l>Son già tre lune, ed io sospiro in vano</l>
@@ -161,12 +186,12 @@
             <l>Barbaro oblio. Chi sa dov'è? fra quali</l>
             <l part="I">Angustie, oh Dio, languisce?</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">E il suo valore</l>
             <l part="I">Non ti rende tranquilla?</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Ah! principessa,</l>
             <l>Son uomini gli eroi. Chi gli assicura</l>
@@ -178,12 +203,12 @@
             <l>Trovar così? No; rinvenirlo io voglio</l>
             <l part="I">O perdermi con lui.</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">Ma dove speri</l>
             <l part="I">Ritrovarne la traccia?</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Ei contro il greco</l>
             <l>Furor (lo sai) de' Bulgari sostenne</l>
@@ -192,7 +217,7 @@
             <l>Passi io là volgerò: d'indi a cercarlo</l>
             <l>Le imprese sue mi serviran di scorta.</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l>E vorrai, Bradamante,</l>
             <l>Così l'afflitto padre e la dolente</l>
@@ -200,7 +225,7 @@
             <l>Di nuovo abbandonar? Né ti ritiene</l>
             <l part="I">Il lor tenero amore?</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Ah! questo, amica,</l>
             <l>Questo amor sconsigliato è la sorgente</l>
@@ -210,39 +235,39 @@
             <l>Cerca errante il rivale; io qui per loro</l>
             <l part="I">Palpito abbandonata.</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">Il trono eccelso,</l>
             <l>Che la paterna cura</l>
             <l>Provvida a te procura, è gran compenso</l>
             <l part="I">Delle perdite tue.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">No, non è vero:</l>
             <l>Mille troni ha la terra, e un solo Ruggiero.</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l>Ah, Leon non conosci. Allor che quindi</l>
             <l>Pellegrino ei passò, guerrieri allori</l>
             <l>Tu raccoglievi altrove. Ah, se un istante</l>
             <l part="I">Il giungessi a mirar!...</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">So che a te piacque:</l>
             <l>Ma non ben si misura</l>
             <l part="I">L'altrui dal proprio cor.</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">Scuoterti almeno</l>
             <l>Un tanto amor dovrebbe,</l>
             <l>Che sol la tua d'Asia e d'Europa a tutte</l>
             <l part="I">Le bellezze antepone.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Amor tu chiami,</l>
             <l>Clotilde, una leggiera</l>
@@ -253,17 +278,17 @@
             <l>Nuovo è per lui strano portento, e ambisce</l>
             <l part="I">Farsene possessor.</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">Deh! meno ingrata...</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l>Ah, non più, principessa; o taci, o solo</l>
             <l> Parlami di Ruggiero, e meco affretta</l>
             <l part="I">Co' tuoi voti la notte.</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">Almen sospendi</l>
             <l>Il tuo partir fin che l'atteso giunga</l>
@@ -271,7 +296,7 @@
             <l>Del tuo Ruggier forse contezza, e a caso</l>
             <l part="I">Errando non andrai.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">L'arrivo appunto</l>
             <l>Io fuggo di costui. L'unico erede</l>
@@ -284,7 +309,7 @@
             <l>Con la paterna autorità? Di quanto</l>
             <l part="I">Peggior sarebbe il caso mio!</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">S'affretta</l>
             <l part="I">Ottone a questa volta.</l>
@@ -293,58 +318,58 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>OTTONE e dette.</stage>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Otton, che rechi?</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="I">Giunse il greco orator.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="M">Giunse?</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="F">E più grande</l>
             <l>Sarà, se m'odi, il tuo stupor. L'istesso</l>
             <l part="I">Leone è l'orator.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="M">Leon!</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">Vedesti</l>
             <l part="I">Tu il prence?</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="F">Io no; ma un mio</l>
             <l part="I">Fedel, cui molto è noto.</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">E dove a lui</l>
             <l part="I">Destinato è l'albergo?</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="F">In questo ameno</l>
             <l part="I">Recinto ove noi siam.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F"><stage>(altiera e sdegnata)</stage> Che vuol? che spera?</l>
             <l part="I">Che pretende? a che vien?</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="M">Tu il chiedi!</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">E' folle</l>
             <l>Se conseguire a forza</l>
@@ -352,53 +377,53 @@
             <l>Violenze non soffre: i propri affetti</l>
             <l>Difender sa come gl'imperi altrui.</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="I">Calmati amica.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F"><stage>(ad Ottone)</stage> Ah questo è troppo! Augusto</l>
             <l part="I">Il vide ancor?</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="F">No; qualche spazio a lui</l>
             <l>Di riposo concede:</l>
             <l part="I">E poi l'ascolterà.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Ma sa che il prence</l>
             <l part="I">E' l'orator?</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="F">Né pure. Io ben l'avviso</l>
             <l>Corsi a recar; ma Cesare è raccolto</l>
             <l>In solitaria stanza, onde permesso</l>
             <l part="I">Per or non è l'ingresso.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Ah, questo audace</l>
             <l>Giovane mal accorto</l>
             <l part="I">Farò pentir! <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="M">Dove t'affretti?</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Dove</l>
             <l>L'amor, lo sdegno e il mio valor mi guida.</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="I">Odi: pensiamo...</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Or non è tempo: avezza</l>
             <l>Non sono a tollerar. Me stessa oltraggio,</l>
@@ -422,19 +447,19 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>CLOTILDE ed OTTONE</stage>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l>Seguila, principessa, e quei t'adopra</l>
             <l>Suoi primi ardori a moderar. Fra' Greci</l>
             <l>Io di Ruggier novelle</l>
             <l part="I">A rintracciar men vo.</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">Del caso mio</l>
             <l part="I">Che dici, Otton? Di me t'incresce?</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="F">Il caso</l>
             <l>Comprendo, e ti compiango. Una rivale</l>
@@ -443,24 +468,24 @@
             <l>Pompa d'infedeltà; d'un giusto sdegno,</l>
             <l part="I">Lo so, deve infiammarti.</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">Ah, non procede</l>
             <l>Quindi lo sdegno mio! Se merta amore,</l>
             <l>Qual colpa ha Bradamante? E qual se cede</l>
             <l>Leone a sì gran merto?</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l>Con chi dunque t'adiri?</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l>Con me, che un caro oggetto,</l>
             <l>Che il Cielo a me non destinò, dovrei</l>
             <l part="I">E non posso obliar.</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="F">Clotilde, addio:</l>
             <l>Presto il potrai. Fin che delira amore,</l>
@@ -499,41 +524,41 @@
           <head>SCENA QUINTA</head>
           <stage>Galleria negli appartamenti di Leone</stage>
           <stage>RUGGIERO ed OTTONE</stage>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l>Oh qual di Bradamante in rivederti</l>
             <l part="I">Sarà la gioia!</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Ah! Bradamante, amico,</l>
             <l part="I">E' perduta per me.</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="F">Perduta! Oh stelle!</l>
             <l part="I">Che mai dici, o Ruggier?</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Taci. Fra' Greci</l>
             <l part="I">Erminio è il nome mio.</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="F">Nulla io comprendo.</l>
             <l>Credi il tuo ben perduto!</l>
             <l>Ritorni a noi del tuo rival compagno!</l>
             <l part="I">Ma che fu? ma che avvenne?</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Ascolta, e dimmi</l>
             <l>Se ha più di me la terra</l>
             <l>Infelice mortale. Io sconosciuto</l>
             <l part="I">Sai che quindi partendo...</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="F">Io so che andasti</l>
             <l>De' Bulgari in difesa</l>
@@ -543,7 +568,7 @@
             <l>Aspirar a rapirti il tuo tesoro;</l>
             <l>Poi mancaro i tuoi fogli, e il resto ignoro.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l>Odilo. Il gran conflitto, in cui decise</l>
             <l>Contro i Greci la sorte,</l>
@@ -560,11 +585,11 @@
             <l>Se fur lunghi non so; so che riscosso</l>
             <l part="I">Fra catene io mi vidi.</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="M">Oimè!</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Ne chiedo</l>
             <l>Ragione a chi m'annoda;</l>
@@ -574,11 +599,11 @@
             <l>Del carcere funesto</l>
             <l>Sento l'uscio ferrato, e solo io resto.</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="I">E chi tal frode ordì?</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">La mia sventura.</l>
             <l>Madre d'un, che pugnando uccisi in campo</l>
@@ -586,11 +611,11 @@
             <l>Del greco imperador, di quell'istesso</l>
             <l>Tetto signora, ov'io smarrito entrai.</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="I">Oh errore!</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Ognun sapea</l>
             <l>Che il cavalier straniero</l>
@@ -617,88 +642,88 @@
             <l>A meritarti amico. Altra mercede</l>
             <l>Il tuo da te liberator non chiede.</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l>Oh magnanimo! E questo</l>
             <l>Chi fu, che generoso</l>
             <l part="I">La vita a te donò?</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Fu quell'istesso</l>
             <l>A cui dar morte in singolar tenzone</l>
             <l part="I">Io geloso volea.</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="M">Leon?</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Leone.</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l>Che ascolto! Ed a salvarti</l>
             <l part="I">Qual cagion lo spronò?</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">M'avea più volte</l>
             <l>Pugnar veduto in campo: il mio coraggio</l>
             <l>Stimò degno d'amore, e non sofferse</l>
             <l part="I">Di vedermi perir.</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="F">Dovresti a lui</l>
             <l>Scoprirti al fin; già ch'egli ha il cor sì grande...</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l>Ah, perché grande ha il core</l>
             <l>Deggio abusarne? ed obbligarlo a un duro</l>
             <l part="I">Sagrificio per me?</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="F">Dunque a che vieni?</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l>Leon l'esige: egli non vuol soffrirmi</l>
             <l>Da lui diviso; ed io pavento e bramo</l>
             <l part="I">Di veder Bradamante.</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="F">A lei frattanto</l>
             <l part="I"> Se vuoi...</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Lasciami: io veggo</l>
             <l part="I">Da lungi il prence.</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="M">A lei dirò...</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">No, taci.</l>
             <l>Fin che si può, lo sventurato ignori</l>
             <l>Nostro destin severo.</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="I">Ma pur...</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="M">Parti: ecco il prence.</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="F"><stage>(da sé partendo)</stage> Il caso è fiero.</l>
           </sp>
@@ -706,12 +731,12 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>RUGGIERO, poi LEONE</stage>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l>No; fra tutti i viventi alcun non vive</l>
             <l>Di me spiù sfortunato.</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l>Ma quando, Erminio amato,</l>
             <l>Quando una volta io giungerò la bella</l>
@@ -719,81 +744,81 @@
             <l>Che Augusto a me cooncede,</l>
             <l part="I">E' tormento per me.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Ma come, o prence,</l>
             <l>Per un sembiante ignoto</l>
             <l part="I">Tanto accender ti puoi?</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F">La fama istessa,</l>
             <l>Che il gran valor di Bradamante esalta,</l>
             <l>N'esalta la beltà. Forse è mendace?</l>
             <l part="I">Dirlo tu puoi. Tu la conosci?</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Assai.</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="I">Parlasti a lei?</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="M">Più volte.</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F">E qual ti parve?</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="I">Degna della sua fama.</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F">E' dolce? è altiera</l>
             <l>Agli atti, alla favella?</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l>O lusinghi o minacci è sempre bella.</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l>Ah! non ho ben se mia non è. Si voli</l>
             <l>A chiederla ad Augusto. Ai voti miei</l>
             <l part="I"> Fausto lo speri?</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Il tuo gran padre onora,</l>
             <l>Bradamante gli è cara: e a sì gran sorte</l>
             <l part="I">Lieto sarà di sollevarla.</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F">Ed ella</l>
             <l part="I">Credi che ubbidirà?</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">So che rispetta,</l>
             <l part="I">Quanto è ragione, il suo sovran.</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F">Ma il mondo</l>
             <l>Del famoso Ruggier la crede amante:</l>
             <l part="I">L'udisti tu?</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="M">L'intesi.</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F">Ah, saria questo</l>
             <l>Un terribil rivale! Afferma ognuno</l>
@@ -802,12 +827,12 @@
             <l>Ei vorrà forse in campo</l>
             <l>Contendermi la sposa.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l>No, nol vorrà. Rispetterà Ruggiero</l>
             <l part="I">D'Erminio in te l'amico.</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F">Oh fido, oh caro</l>
             <l>Sostegno mio! No, con Erminio accanto,</l>
@@ -860,7 +885,7 @@
           <head>SCENA OTTAVA</head>
           <stage>Appartamenti imperiali</stage>
           <stage>CARLO MAGNO con séguito, poi BRADAMANTE</stage>
-          <sp>
+          <sp who="#carlo_magno">
             <speaker>CAR.</speaker>
             <l>E ben, dunque ascoltiam l'impaziente</l>
             <l>Orientale ambasciadore. Andate</l>
@@ -878,41 +903,41 @@
             <l>Qual mai per me fausta cagione a queste</l>
             <l part="I"> Soglie guida il tuo piè?</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Cesare, io vengo</l>
             <l part="I">Grazie a implorar da te.</l>
           </sp>
-          <sp>
+          <sp who="#carlo_magno">
             <speaker>CAR.</speaker>
             <l part="F">Grazie! Ah, di tanto</l>
             <l>Debitor mi rendesti,</l>
             <l>Che quanto or chieder puoi</l>
             <l>Sarà scarsa mercede a' merti tuoi.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l>Già che al grado di merto</l>
             <l>Solleva Augusto il mio dover, poss'io</l>
             <l>Della grazia che imploro</l>
             <l part="I">Certa esser già.</l>
           </sp>
-          <sp>
+          <sp who="#carlo_magno">
             <speaker>CAR.</speaker>
             <l part="F">Sì, la prometto: e nulla</l>
             <l part="I">So che teco avventuro.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Ah m'assicuri,</l>
             <l>Se il mio pregar n'è degno,</l>
             <l part="I">La tua destra real.</l>
           </sp>
-          <sp>
+          <sp who="#carlo_magno">
             <speaker>CAR.</speaker>
             <l part="F">Prendila in pegno.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l>Signor, gli studi feminili e gli usi</l>
             <l>Sai che sprezzai fanciulla; e che, ammirando</l>
@@ -920,11 +945,11 @@
             <l>L'ardir guerriero, i gloriosi gesti,</l>
             <l part="I">Procurai d'imitarle.</l>
           </sp>
-          <sp>
+          <sp who="#carlo_magno">
             <speaker>CAR.</speaker>
             <l part="F">E le vincesti.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l>Il nome mio, più che il mio volto, or sento</l>
             <l>Che a chiedermi in consorte</l>
@@ -937,11 +962,11 @@
             <l>Da un tal timor m'assolva</l>
             <l part="I">L'imperiale autorità.</l>
           </sp>
-          <sp>
+          <sp who="#carlo_magno">
             <speaker>CAR.</speaker>
             <l part="F">Ma come?</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l>Questa legge a tuo nome</l>
             <l>Sia palese a ciascun: che la mia mano</l>
@@ -953,48 +978,48 @@
             <l>Mal risponde alle prove</l>
             <l>Che intraprendere osò, la cerchi altrove.</l>
           </sp>
-          <sp>
+          <sp who="#carlo_magno">
             <speaker>CAR.</speaker>
             <l>I lacci d'Imeneo</l>
             <l part="I">Dunque aborrisci?</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Sì, se de' miei lacci</l>
             <l part="I">Deggio arrossir.</l>
           </sp>
-          <sp>
+          <sp who="#carlo_magno">
             <speaker>CAR.</speaker>
             <l part="F">Se men difficil prezzo</l>
             <l>Non proponi all'acquisto</l>
             <l part="I">Del tuo bel cor, chi l'otterrà?</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Chi degno</l>
             <l part="I">Sarà di me.</l>
           </sp>
-          <sp>
+          <sp who="#carlo_magno">
             <speaker>CAR.</speaker>
             <l part="F">Forse qual sia non sai</l>
             <l part="I">Che aspira al don della tua destra.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">In campo</l>
             <l part="I">L'apprenderò.</l>
           </sp>
-          <sp>
+          <sp who="#carlo_magno">
             <speaker>CAR.</speaker>
             <l part="M">Deh, men severa!...</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Augusto,</l>
             <l>Ah! la grazia che ottenni,</l>
             <l part="I">Render dubbia or mi vuoi?</l>
           </sp>
-          <sp>
+          <sp who="#carlo_magno">
             <speaker>CAR.</speaker>
             <l part="F">No: ripigliarmi</l>
             <l>Quel che donai non posso. In questo istante,</l>
@@ -1057,24 +1082,24 @@
           <head>SCENA PRIMA</head>
           <stage>Deliziosa parte de' giardini reali.</stage>
           <stage>CARLO MAGNO ed  OTTONE</stage>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l>Nol crederlo, signor: dall'ardua impresa</l>
             <l>Non v'è ragion che vaglia</l>
             <l part="I">Il greco prence a frastornar.</l>
           </sp>
-          <sp>
+          <sp who="#carlo_magno">
             <speaker>CAR.</speaker>
             <l part="F">Vogl'io</l>
             <l> Tentarlo almen. Dicesti a lui che bramo</l>
             <l part="I">Seco parlar di nuovo?</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="F">Il dissi; ei viene,</l>
             <l part="I">Ma sol la pugna ad affrettar.</l>
           </sp>
-          <sp>
+          <sp who="#carlo_magno">
             <speaker>CAR.</speaker>
             <l part="F">Va: prendi</l>
             <l>Del guerriero apparato</l>
@@ -1082,7 +1107,7 @@
             <l>Attenderò. Chi sa? Forse a mio senno</l>
             <l>Svolger potrò quel giovanil pensiero.</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l>Cesare, il bramo anch'io, ma non lo spero.</l>
             <lg>
@@ -1101,7 +1126,7 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>CARLO MAGNO, poi LEONE</stage>
-          <sp>
+          <sp who="#carlo_magno">
             <speaker>CAR.</speaker>
             <l>Del giovane reale io pur vorrei</l>
             <l>Il periglio evitar. S'ei qui perisse,</l>
@@ -1111,24 +1136,24 @@
             <l>Tu già pugnar vorresti: io tutto in volto</l>
             <l part="I">Ti leggo il cor.</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F">Sì, lo confesso, io vengo</l>
             <l>Ad affrettarne il sospirato istante.</l>
           </sp>
-          <sp>
+          <sp who="#carlo_magno">
             <speaker>CAR.</speaker>
             <l>Ma sai di Bradamante</l>
             <l>Qual sia l'arte guerriera,</l>
             <l part="I">Quanto il poter?</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F">Sì; ma compagno in campo</l>
             <l>So che avrò meco Amore; e i fidi suoi</l>
             <l>So che Amor, quando vuol, cangia in eroi.</l>
           </sp>
-          <sp>
+          <sp who="#carlo_magno">
             <speaker>CAR.</speaker>
             <l>E' bello anche l'eccesso</l>
             <l>D'un giovanile ardir. Quel che sarai</l>
@@ -1138,7 +1163,7 @@
             <l>Gran speranze recidi,</l>
             <l>Se innanzi tempo al tuo gran cor ti fidi.</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l>Se quella ch'or m'alletta</l>
             <l>Dolce speme, o signor, perdo o trascuro,</l>
@@ -1146,12 +1171,12 @@
             <l>Deh, secondar ti piaccia</l>
             <l part="I">Le impazienze mie.</l>
           </sp>
-          <sp>
+          <sp who="#carlo_magno">
             <speaker>CAR.</speaker>
             <l part="F">Ma prendi almeno</l>
             <l part="I">Qualche tempo a pensar.</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F">No; di mia sorte</l>
             <l>La penosa incertezza</l>
@@ -1160,7 +1185,7 @@
             <l>Senz'altro indugio. Il sol favor che imploro</l>
             <l part="I">Da te, Cesare, è questo.</l>
           </sp>
-          <sp>
+          <sp who="#carlo_magno">
             <speaker>CAR.</speaker>
             <l part="F">Il vuoi? S'adempia</l>
             <l>Il tuo voler. Quel marzial recinto</l>
@@ -1189,7 +1214,7 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>LEONE, poi BRADAMANTE</stage>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l>Ah, se d'un tal portento</l>
             <l>Di valor, di beltà potrò vantarmi</l>
@@ -1199,27 +1224,27 @@
             <l>Felice al par di me?... Ma Bradamante</l>
             <l part="I">Quella non è? Sì, non m'inganno.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Oh stelle!</l>
             <l>Ecco il Greco importuno.</l>
             <l part="I">Se n'eviti l'incontro. <stage>(in atto di ritirarsi</stage></l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F">Ah! soffri almeno,</l>
             <l>Bella nemica mia, soffri ch'io possa,</l>
             <l>Pria che al tuo ferro il petto,</l>
             <l>Offrire a te d'un fido cor l'omaggio.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l>Prence, questo è linguaggio</l>
             <l>Da vincitor; prima d'usarlo è d'uopo</l>
             <l>Nell'arringo prescritto</l>
             <l>Di sé far prova ed acquistarne il dritto.</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l>Se a chi non è capace</l>
             <l>Di resisterti in campo è sì gran fallo,</l>
@@ -1228,13 +1253,13 @@
             <l>Sol chi ascolta il tuo nome; e a chi ti mira</l>
             <l part="I">Divien l'amor necessità.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Se forte</l>
             <l>Sei tu quanto cortese,</l>
             <l part="I">Io comincio a tremar.</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F">Ah! so pur troppo</l>
             <l>Che a Bradamante in petto</l>
@@ -1242,48 +1267,48 @@
             <l>Ma so che un'alma grande</l>
             <l part="I">Ingrata esser non può.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Nol sono; e pronta</l>
             <l>Eccomi a darne prova, ove tu vogli</l>
             <l part="I">Secondar le mie brame.</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F">Arbitra sei</l>
             <l part="I"> Del mio voler: tutto farò.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">L'impresa</l>
             <l part="I">Dunque abbandona, o prence.</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="M">Io?</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="M">Sì.</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F">Crudele!</l>
             <l part="I">Così grata mi sei?</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Grata non sono</l>
             <l>Se contro te mi spiace</l>
             <l>Trattar l'armi omicide, e se procuro</l>
             <l part="I">I tuoi rischi evitar?</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F">Fra i rischi miei</l>
             <l part="I">Il perderti è il maggior.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F"><stage>(con dolcezza)</stage> Deh, s'egli è vero</l>
             <l>Che in tal pregio io ti sono, e che disporre</l>
@@ -1292,19 +1317,19 @@
             <l>A te d'Asia e d'Europa offre ogni trono</l>
             <l part="I">Spose di te ben degne.</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F">Ah no; perdono:</l>
             <l>Il sol tuo cenno è questo</l>
             <l part="I">Ch'io non posso eseguir.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F"><stage>(con sdegno)</stage> No? Forse in campo</l>
             <l>Meglio saprò persuaderti armata.</l>
             <l>Vieni al cimento: e non chiamarmi ingrata.</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <lg>
               <l>Quell'ira istessa che in te favella</l>
@@ -1320,70 +1345,70 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>BRADAMANTE, poi CLOTILDE</stage>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l>Lo strano ardir di questo</l>
             <l>Sconsigliato garzon mi fa dispetto,</l>
             <l>Meraviglia e pietà. L'ire a fatica</l>
             <l part="I"> Io tenni a fren.</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">Liete novelle, amica. <stage>(allegra e frettolosa</stage></l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="I">Liete? Ah, son di Ruggier?</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="M">Sì.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="M">Vive?</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">E' giunto.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="I">Dove?</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="M">Qui.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="M">Non t'inganni?</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">Io stessa il vidi:</l>
             <l part="I">Otton seco parlò.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">L'editto intese;</l>
             <l>A conquistarmi ei corre. Oh Dio, che assalto</l>
             <l part="I">D'improvviso piacere!</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">Ecco finiti</l>
             <l>I palpiti, gli affanni; eccoti sposa</l>
             <l part="I">Del tuo fido Ruggiero.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Ah, principessa,</l>
             <l>Lasciami respirar! pur troppo è angusto</l>
             <l>A tanta gloria il cor... Ma dove è mai?</l>
             <l part="I">Perché di me non cerca? Andiam...</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">Non vedi</l>
             <l part="I">Che a noi di là rivolge i passi?</l>
@@ -1392,7 +1417,7 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>RUGGIERO e dette</stage>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Ah vieni,</l>
             <l>Mia dolce unica speme,</l>
@@ -1400,22 +1425,22 @@
             <l>A te pervenne il grido</l>
             <l>Del proposto cimento?</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="I">Sì.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Dunque va: le usate</l>
             <l>Illustri armi ti cingi, e a vincer vieni,</l>
             <l part="I">Non a pugnar.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Mia Bradamante, ascolta:</l>
             <l part="I">Molto ho da dir.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Ne stringe</l>
             <l> Troppo il tempo, o Ruggier. Chiederti anch'io</l>
@@ -1428,26 +1453,26 @@
             <l>Forse per lui fatale,</l>
             <l part="I">Un rival temerario.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Ah, qual rivale!</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="I">Leon!</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Sì, Bradamante,</l>
             <l>E' il mio benefattor; per lui respiro:</l>
             <l>Il ben di rivederti</l>
             <l part="I">Solo è dono di lui.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="M">Come?</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Sorpreso,</l>
             <l>In un carcere orrendo</l>
@@ -1455,32 +1480,32 @@
             <l>Venne a serbarmi in vita,</l>
             <l part="I">E a rischio della sua.</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="M">Che ascolto!</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Ah, degno</l>
             <l>E' ben d'alma reale atto sì grande!</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="I">Non deggio essergli grato?</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Anzi ho ragione</l>
             <l>D'esserla anch'io: son miei</l>
             <l part="I">Tutti gli obblighi tuoi.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Ma vai, ben mio,</l>
             <l>Ad assalirlo armata! Egli inesperto..</l>
             <l part="I">Tu terror de' più forti...</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">E ben, se vuoi,</l>
             <l>Non l'esponiamo. In campo</l>
@@ -1488,14 +1513,14 @@
             <l>Sia l'arringo primier: luogo al  secondo</l>
             <l part="I">Non resterà.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Ma con qual fronte io posso</l>
             <l>A tutto il mondo in faccia</l>
             <l> Dichiararmi rival del mio pietoso</l>
             <l part="I">Liberator?</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Dunque la sorte in campo</l>
             <l>Tenti prima Leone. Egli al cimento</l>
@@ -1504,41 +1529,41 @@
             <l>Da lui perduto ad acquistar tu vieni,</l>
             <l part="I">Non sei più suo rivale.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Ah, s'io felice</l>
             <l>Al suo disastro insulto,</l>
             <l part="I">Sono ingrato e crudel.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Ma che per lui,</l>
             <l>Che di più far potrei?</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l>Deh! se gli obblighi miei</l>
             <l>E' pur ver che sian tuoi...</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l>Segui, parla, che vuoi?</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="I">Premialo tu per me.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="M">Ma come?</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Il fato</l>
             <l>Nega a me la tua mano; abbiala almeno</l>
             <l part="I">Chi mi salvò.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Che? sposa</l>
             <l>Io di Leone! Ad altro amante in braccio</l>
@@ -1546,12 +1571,12 @@
             <l>E il propone Ruggier! Clotilde, udisti?</l>
             <l part="I">Che ti par del consiglio?</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">Oppressa io sono</l>
             <l part="I">Dallo stupor.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Da sì remote sponde</l>
             <l>Così la tua fedele</l>
@@ -1562,13 +1587,13 @@
             <l>Sparsi per te! Costa al tuo cor ben poco</l>
             <l part="I">Il perdermi, o crudel.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Quel che mi costa</l>
             <l>Non curar di saper: troppo è funesto</l>
             <l>Lo stato, oh Dio! di chi crudel tu chiami.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l>No, tu mai non m'amasti, o più non m'ami.</l>
             <l>Questo è un pretesto all'incostanza. I suoi</l>
@@ -1582,33 +1607,33 @@
             <l>L'idea del tuo martìre,</l>
             <l>A trafiggerti il core, e non morire.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="I">Ah! s'io non moro ancora...</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Ad altro amante</l>
             <l>Ch'io porga la mia man? Che atroce insulto!</l>
             <l>Che disprezzo inumano!</l>
             <l part="I">Che nera infedeltà!</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Se meno irata,</l>
             <l part="I">Mia vita, udir mi vuoi...</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Né voglio udirti,</l>
             <l part="I">Né mirarti mai più. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Senti, ben mio:</l>
             <l part="I">Non partir: dove vai?</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F"><stage>(con pianto ed ira</stage> Vo d'un infido</l>
             <l>A svellermi, se posso,</l>
@@ -1618,12 +1643,12 @@
             <l>Di vivere o d'amarti</l>
             <l part="I">Vo, barbaro, a finir. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Deh, in questo stato,</l>
             <l part="I">Deh, non mi abbandonar! <stage>(trattenendola</stage></l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F"><stage>(staccandosi da lui)</stage> Lasciami, ingrato.</l>
             <lg>
@@ -1643,13 +1668,13 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>RUGGIERO e CLOTILDE</stage>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l>In odio al mio bel nume</l>
             <l>No, viver non poss'io. Seguirla io voglio:</l>
             <l part="I">Voglio almeno al suo piè...</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">Gl'impeti primi</l>
             <l>D'un irritato amore</l>
@@ -1657,19 +1682,19 @@
             <l>Indebolisce il fiume, il suo furore</l>
             <l part="I">Se sfoga in libertà.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Ma intanto, oh Dio!</l>
             <l>Ella freme, s'affanna,</l>
             <l part="I">E mi crede infedele.</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">Io le tempeste</l>
             <l>Di quell'alma agitata</l>
             <l part="I">Tenterò di calmar.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Sì, principessa,</l>
             <l>Pietà di lei, pietà di me. Procura</l>
@@ -1680,18 +1705,18 @@
             <l>Lagrimevole stato in cui mi vedi:</l>
             <l part="I">Dille...</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">Non più: tutto dirò; t'accheta;</l>
             <l part="I">Fidati a me.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Del tuo bel cor mi fido,</l>
             <l>Ma poco è quel ch'io spero:</l>
             <l part="I">Quello sdegno è sì fiero...</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">Ah, quello sdegno,</l>
             <l>Ben più che di pietà, d'invidia è degno!</l>
@@ -1736,47 +1761,47 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>LEONE frettoloso, e detto.</stage>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F">Pur ti ritrovo al fine.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="I">Prence!</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F">Ah, mio fido, ecco il momento in cui</l>
             <l>Rendere un generoso all'amor mio</l>
             <l part="I">Contraccambio potrai.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Che mai, signore,</l>
             <l part="I">Che sperar puoi da me?</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F">L'onor, la vita,</l>
             <l part="I"> La mia felicità.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="M">Spiegati.</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F">Udisti</l>
             <l part="I">Che Bradamante a conquistar...</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Con lei</l>
             <l>So che pugnar si dee; so che tu vuoi</l>
             <l>Esporti al gran cimento; e gelo al rischio</l>
             <l part="I">Del mio liberator.</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F">Calmati: appieno</l>
             <l>Della bella eroina</l>
@@ -1785,12 +1810,12 @@
             <l>A me non son, che lusingarmi ardisca</l>
             <l part="I">Di resistere a lei.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Con qual coraggio</l>
             <l part="I">Dunque...</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F">Il coraggio mio,</l>
             <l>Caro amico, sei tu. Quel che tu puoi</l>
@@ -1802,28 +1827,28 @@
             <l>Ad un altro me stesso</l>
             <l part="I">Prudente a confidar.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="M">Come?</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F">Tu déi</l>
             <l part="I">Pugnar per me.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="M"><stage>(attonito)</stage> Con Bradamante!</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F">Appunto.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="I">Io!</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F">Sì, tu. Ma ciascuno</l>
             <l>Leon ti crederà. Le mie d'intorno</l>
@@ -1839,13 +1864,13 @@
             <l>A difenderti solo. Andiam: vogl'io</l>
             <l part="I">Di propria man cingerti l'armi.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Ah! pensa</l>
             <l>Meglio, Leone. Ardua è l'impresa: io tremo</l>
             <l part="I">Alla proposta sol.</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F">Di che! L'arcano</l>
             <l>(Fidati) alcun non scoprirà. Gl'istessi</l>
@@ -1860,13 +1885,13 @@
         <div type="scene">
           <head>SCENA NONA</head>
           <stage>RUGGIERO, indi OTTONE, poi LEONE</stage>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Oh stelle!</l>
             <l>Che m'avvien! Che ascoltai!</l>
             <l part="I">Sogno? vivo? son io?</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="F">Ruggier, che fai?</l>
             <l>Della tromba guerriera i primi inviti</l>
@@ -1877,61 +1902,61 @@
             <l>Tradita esser si crede, e piange e freme</l>
             <l part="I">D'ira e d'amor.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="M">Misero me!</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="F">Potresti</l>
             <l>Trascurar d'acquistarla allor che l'offre</l>
             <l>Sì destra a te la sorte? Ah no: l'eccesso</l>
             <l>Ti muova almen del giusto suo dolore.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l>Sento spezzarmi in cento parti il core.</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="I">Su: risolvi, o Ruggier.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F"><stage>(fra sé)</stage> (S'uno abbandono...</l>
             <l>Se così l'altra oblio... se vo, se resto...)</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l>Erminio? Amico? Ah, quale indugio è questo! <stage>(da un lato indietro</stage></l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="I">Eccomi a te. <stage>(movendosi verso Leone</stage></l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="M">Vieni, t'affretta. <stage>(parte e Ruggiero vuol seguirlo</stage></l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="F">E senza</l>
             <l>Rispondermi tu parti?</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="I">Ah, per pietà, non tormentarmi!</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="F">Almeno</l>
             <l>Dimmi se vinto il tuo rivale audace...</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l>Nulla dirti poss'io: lasciami in pace. <stage>(con impeto</stage></l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="I">Povera Bradamante!</l>
           </sp>
@@ -1970,7 +1995,7 @@
           <head>SCENA PRIMA</head>
           <stage>Gabinetti negli appartamenti di Bradamante con balconi a vista de' giardini, e sedili all'intorno.</stage>
           <stage>CLOTILDE sbigottita, poi OTTONE</stage>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l>No, della pugna atroce</l>
             <l>Il vicino a mirar tragico fine,</l>
@@ -1981,23 +2006,23 @@
             <l>Io di Leon lo scempio</l>
             <l>Mirar non volli ed ascoltar non oso.</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l>Lo scempio di Leon! Leone è sposo.</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="I">Che?</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="M">Sì, Leone è il vincitor.</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">Ma come?</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l>Odimi sol. Ne' primi assalti il noto</l>
             <l>Moderò Bradamante</l>
@@ -2014,12 +2039,12 @@
             <l>La feroce guerriera</l>
             <l part="I">Contro lui si scagliò...</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">Pur troppo il vidi:</l>
             <l part="I">Nol sostenni e fuggii.</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="F">L'incalza, il preme;</l>
             <l>Al volto, al fianco, al petto</l>
@@ -2033,11 +2058,11 @@
             <l>Lampi di sdegno, e lucide scintille</l>
             <l>Da' brandi ripercossi a mille a mille</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="I">E il povero Leon?</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="F">Leon gli esempi</l>
             <l>Di qualunque valor vinse d'assai.</l>
@@ -2053,11 +2078,11 @@
             <l>Del furor che l'invase</l>
             <l>Cessar convenne: ei vincitor rimase.</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="I">Crederlo io posso a pena.</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="F">Agli occhi tuoi</l>
             <l>Creder lo déi. Vedi colà che torna</l>
@@ -2065,7 +2090,7 @@
             <l>Che i suoi Greci ha d'intorno e che il festivo</l>
             <l part="I">Popolo l'accompagna?</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">E' ver. Per sempre</l>
             <l>Ecco dunque divisi</l>
@@ -2078,7 +2103,7 @@
             <l>L'assister gl'infelici</l>
             <l>In caso sì funesto.</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l>Anzi d'ognun sacro dovere è questo.</l>
             <lg>
@@ -2098,7 +2123,7 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>CLOTILDE, poi BRADAMANTE</stage>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l>Di Bradamante io bramo</l>
             <l>Quanto temo il ritorno. Il suo conosco</l>
@@ -2107,7 +2132,7 @@
             <l>Cambia il furor le sue sembianze usate!</l>
           </sp>
           <stage>(Bradamante senza manto, con spada nuda e scudo imbracciato esce furibonda, gettando successivamente a terra e lo scudo e la spada, senza veder Clotilde</stage>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l>Andate a terra, andate</l>
             <l>Da me lungi per sempre, armi infelici,</l>
@@ -2119,39 +2144,39 @@
             <l>Le antiche palme. Ah, t'involò la gloria</l>
             <l>Questa perdita sol d'ogni vittoria!</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l>Calmati, amica: alla fortuna avversa</l>
             <l>Magnanima resisti, e ti consola.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l>Tu qui? Lasciami sola,</l>
             <l>Se m'ami, o principessa.</l>
             <l>Or soffrir di me stessa</l>
             <l part="I">La compagnia non so.</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">Ch'io t'abbandoni</l>
             <l part="I">In tanto affanno? Ah non sia ver!</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">L'accresce</l>
             <l part="I">La presenza d'ognun: va.</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">No perdona:</l>
             <l>Questa volta appagarti</l>
             <l part="I">E non posso e non deggio.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F"><stage>(risoluta)</stage> O parto, o parti.</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="I">L'assisti, o Ciel pietoso! <stage>(parte</stage></l>
           </sp>
@@ -2159,118 +2184,118 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>BRADAMANTE, poi RUGGIERO</stage>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Io vinta! Io sposa</l>
             <l>Di chi non amo! Io da colui divisa</l>
             <l>Per cui solo io vivea! Sprezzata, oh stelle, <stage>(esce Ruggiero non veduto da Bradamante</stage></l>
             <l>Io da Ruggiero ho da vedermi ancora!</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l>Non è vero, idol mio: Ruggier t'adora. <stage>(si scopre</stage></l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l>Ah ingrato! or vieni? E a chi sì tardi innanzi</l>
             <l>Hai di tornarmi ardire?</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l>A placarti, mia vita, e poi morire.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l>Placarmi! E del mio sdegno</l>
             <l>Qual cura hai tu, che fin ad or sì poca</l>
             <l>Dell'amor mio ne avesti?</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l>Ah, così non diresti</l>
             <l part="I">Se mi vedessi il cor.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Per me son chiuse</l>
             <l>Or di quel cor le vie: lo so, ma intendo</l>
             <l part="I">Qual è da quel che fai.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="M">T'inganni.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Allora,</l>
             <l>Menzogner, m'ingannai</l>
             <l part="I">Che ti credei fedel.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="M">Sappi...</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Pur troppo</l>
             <l part="I">So che acquistar non mi volesti.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Ah! pensa...</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l>Penso che ad altri in braccio,</l>
             <l part="I">Barbaro, m'abbandoni.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="M">E credi...</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">E credo</l>
             <l> Che altra fiamma t'accende,</l>
             <l>Che di me più non curi,</l>
             <l part="I">Ch'io son tradita.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="M">Odimi sol...</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Non voglio.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l>Odi: e meglio conosci</l>
             <l part="I">Il tuo Ruggier.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Già lo conobbi appieno. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l>Ah, se udir non mi vuoi, guardami almeno! <stage>(snudando la spada</stage></l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="I">Che fai? <stage>(rivolgendosi</stage></l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">L'ultima prova il sangue mio</l>
             <l part="I">Ti darà di mia fé. <stage>(in atto di ferirsi</stage></l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F"><stage>(trattenendola)</stage> Fermati. (Oh Dio!)</l>
             <l part="I">Sazio non sei di tormentarmi?</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">E come</l>
             <l>Viver poss'io, se un mancator di fede,</l>
@@ -2284,13 +2309,13 @@
             <l>Su per le vie d'onore</l>
             <l>Indefesso anelar tu mi vedesti.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l>Tanto per me facesti</l>
             <l>Per poi donarmi ad altri: e questa è fede?</l>
             <l part="I">E che m'ami puoi dir?</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Sì, mia speranza,</l>
             <l>T'amo più di me stesso: e tanto mai,</l>
@@ -2311,11 +2336,11 @@
             <l>Dimmi, idol mio, non ti farebbe orrore</l>
             <l part="I">Il tuo Ruggier?</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Che sfortunato amore!</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l>Deh, pietà, mio tesoro: ah, con la sorte</l>
             <l>Non congiurar! Senza il tuo sdegno io sono</l>
@@ -2326,7 +2351,7 @@
             <l>D'infedeltà mi credi, e mi trafiggi</l>
             <l part="I">L'alma così...</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Basta, non più. Pur troppo</l>
             <l>Ravviso il mio Ruggier ne' detti tuoi.</l>
@@ -2335,7 +2360,7 @@
             <l>Se da te mi divido,</l>
             <l>Perdo assai men quando ti perdo infido.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l>Grazie, bella mia speme. Il più funesto</l>
             <l>Manca alla mia sventura,</l>
@@ -2347,38 +2372,38 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>CLOTILDE e detti.</stage>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">Bradamante,</l>
             <l part="I">Cesare a sé ti chiama.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Oimè! che chiede?</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l>Che a liberar tua fede</l>
             <l part="I">Venga col don della tua destra.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">E tanto</l>
             <l> Perché s'affretta il mio suplicio? A' rei</l>
             <l>Spazio pur si concede</l>
             <l part="I">Di respirar.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Ma il differir che giova</l>
             <l>Ciò ch'evitar non puossi? In che più speri?</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l>Nel mio dolor, che intanto</l>
             <l part="I">Forse m'ucciderà.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">No, Bradamante,</l>
             <l>Così deboli affetti</l>
@@ -2387,25 +2412,25 @@
             <l>Nel tempo stesso il tuo dovere e il mio:</l>
             <l part="I">Addio, mia vita.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Oh doloroso addio! <stage>(s'incammina piangendo e s'arresta</stage></l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="I">(Quanta pietà mi fanno!)</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Or perché mai</l>
             <l>S'arresta il piè già mosso?</l>
             <l part="I">Perché non parti?</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Oh Dio, Ruggier! non posso. <stage>(si getta a sedere</stage></l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l>Ah sì, vinci te stessa: a' piedi tuoi <stage>(s'inginocchia</stage></l>
             <l>L'implora il tuo Ruggier. Questo l'ottenga</l>
@@ -2413,12 +2438,12 @@
             <l>Che imprime il labbro mio </l>
             <l part="I">Su la tua man. <stage>(le bacia la mano</stage></l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Ma come mai, ma come</l>
             <l part="I">Esser può questo il tuo voler?</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Sì, questo</l>
             <l>E' debito, è ragione,</l>
@@ -2427,7 +2452,7 @@
             <l>Che un dì sul tuo bel core ottenni amando,</l>
             <l>Luce degli occhi miei, questo è comando.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <lg>
               <l>T'ubbidirò, ben mio, <stage>(s'alzano</stage></l>
@@ -2446,13 +2471,13 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>CLOTILDE e RUGGIERO</stage>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l>Oh degno, oh grande eroe! Chi mai capace</l>
             <l>D'imitarti sarà? Virtù sì bella</l>
             <l>Mi sforza ad ammirarti in mezzo al pianto.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l>Non ammirarmi tanto,</l>
             <l>Generosa Clotilde: or non son degno</l>
@@ -2463,25 +2488,25 @@
             <l>Ultimi sforzi ogni vigor restrinse,</l>
             <l>Per l'altrui ravvivar, se stessa estinse.</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l>No, non è ver: tanto da te diverso</l>
             <l part="I">Divenir tu non puoi.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Del mio destino</l>
             <l>Tutto or veggo l'orror: forza non trovo</l>
             <l>In me per sostenerlo; e fra' viventi</l>
             <l part="I">Più soffrirmi non so.</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">Che dici! Ah, scaccia</l>
             <l>Sì nere idee. Lunga stagione è giusto</l>
             <l>Che tal vita si serbi e si risparmi.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l>Serbarmi in vita! E a chi degg'io serbarmi?</l>
             <lg>
@@ -2501,81 +2526,81 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>CLOTILDE, poi LEONE</stage>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l>Così confusa io sono</l>
             <l>Fra lo stupore e la pietà, che a pena</l>
             <l>Mi ricordo di me. Chi tanto amore,</l>
             <l part="I">Chi vide mai tanta virtù?</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F">La mia</l>
             <l part="I">Bradamante dov'è?</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">D'Augusto appresso</l>
             <l>Lo sposo attende; e strano assai mi sembra</l>
             <l part="I">Che prevenir Leon si lasci.</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F">A lei</l>
             <l>Di volo andrò; ma prima io voglio il caro</l>
             <l>Erminio rinvenir: de' miei contenti</l>
             <l part="I">Essere ei deve a parte.</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">Ah, prence, in pace</l>
             <l>Lascia il povero Erminio; assai fin ora</l>
             <l part="I">Lacerasti quell'alma.</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="M">Io!</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">Sì: ti basti</l>
             <l part="I">Quanto per te soffrì.</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F">Per me! Non sai</l>
             <l>Dunque a qual segno io l'amo. A conservarlo</l>
             <l part="I">Me stesso esposi.</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">Il conservasti Erminio,</l>
             <l part="I">E l'uccidi Ruggier.</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="M">Come?</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">E' Ruggiero</l>
             <l part="I">Quel ch'Erminio tu chimi.</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="M">Eh, sogni!</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">Io veglio,</l>
             <l part="I">Leon, pur troppo.</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F">Il mio diletto Erminio</l>
             <l part="I">E' il famoso Ruggier?</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">Sì, quell'istesso</l>
             <l>Che, noto al mondo intero,</l>
@@ -2601,7 +2626,7 @@
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>LEONE solo.</stage>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l>Oh, d'un'anima grata</l>
             <l>Portentosa virtù! Può dunque a tanto</l>
@@ -2638,52 +2663,52 @@
           <head>SCENA OTTAVA</head>
           <stage>Reggia illuminata</stage>
           <stage>CLOTILDE ed OTTONE</stage>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l>Qui Ottone! E chi difende</l>
             <l>Ruggiero da Ruggier? Ne' suoi trasporti</l>
             <l part="I">Tu l'abbandoni?</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="F">Il principe de' Greci</l>
             <l>Vidi con lui, né d'appressarmi osai.</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l>Sventurato! Ah qual mai</l>
             <l part="I">Pietà ne sento!</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="F">E tu di lui men degna,</l>
             <l part="I">Clotilde, non ne sei.</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">Deh cessa, Ottone,</l>
             <l part="I">D'esacerbar le mie ferite!</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="F">Io prendo</l>
             <l>Parte ne' torti tuoi. Leon detesto,</l>
             <l>Né posso immaginar... Ma che mai dice?</l>
             <l>Qual è mai la sua scusa?</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l>Il silenzio. Ei non seppe</l>
             <l part="I">Rinvenirne migliore.</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="F">Ah, tu dovevi</l>
             <l>La rotta fé rimproverargli! In lui,</l>
             <l>Chi sa! detestato avresti</l>
             <l part="I">Forse l'antico ardor.</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">No: reso avrei</l>
             <l>Il mio caso peggior. Quando in un core</l>
@@ -2692,11 +2717,11 @@
             <l>La ragion non dà legge,</l>
             <l>Il rimprovero irrìta e non corregge.</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="I">Ma tu...</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">Taci: ecco Augusto, e la dolente</l>
             <l part="I">Vittima è seco.</l>
@@ -2705,7 +2730,7 @@
         <div type="scene">
           <head>SCENA NONA</head>
           <stage>CARLO MAGNO, BRADAMANTE e detti.</stage>
-          <sp>
+          <sp who="#carlo_magno">
             <speaker>CAR.</speaker>
             <l part="F">Assai difficil prova,</l>
             <l>Ma ben degna di lui, donò Ruggiero</l>
@@ -2715,17 +2740,17 @@
             <l>Di ragione e d'amor duro conflitto,</l>
             <l>Che non hai men del braccio il core invitto.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l>Ah, Cesare, il vorrei,</l>
             <l part="I">Ma non basta il volerlo.</l>
           </sp>
-          <sp>
+          <sp who="#ottone">
             <speaker>OTT.</speaker>
             <l part="F">Ecco lo sposo,</l>
             <l part="I">E Ruggier l'accompagna.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">E farsi, oh Dio,</l>
             <l>Del sagrificio mio</l>
@@ -2735,24 +2760,24 @@
         <div type="scene">
           <head>SCENA ULTIMA</head>
           <stage>LEONE, RUGGIERO e detti.</stage>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Dove mi guidi, o prence? <stage>(a Leone, uscendo dal fondo della scena</stage></l>
             <l>Soffri ch'io parta. In nulla qui poss'io</l>
             <l part="I">Esser utile a te.</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F"><stage>(a Ruggiero</stage> Mai non mi fosti</l>
             <l part="I">Sì necessario, amato Erminio.</l>
           </sp>
-          <sp>
+          <sp who="#carlo_magno">
             <speaker>CAR.</speaker>
             <l part="F">Ah venga,</l>
             <l>Di sua vittoria i frutti</l>
             <l part="I">Venga a raccorre il vincitor!</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F">E' giusto.</l>
             <l>Adempia Bradamante</l>
@@ -2761,20 +2786,20 @@
             <l>Chi a resisterti in campo</l>
             <l part="I">Ebbe valor?</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">Vorrei negarlo in vano.</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l>Dunque al fido Ruggier porgi la mano.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l>Come? se meco armato</l>
             <l part="I">Tu pur or...</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F">T'ingannasti:</l>
             <l>L'armi eran mie, non il valor; le cinse</l>
@@ -2783,15 +2808,15 @@
             <l>Nel recinto guerriero;</l>
             <l part="I">Ruggier teco pugnò.</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="M">Ruggier!</l>
           </sp>
-          <sp>
+          <sp who="#clotilde #ottone #bradamante #carlo_magno #leone #ruggiero">
             <speaker>TUTTI</speaker>
             <l part="F">Ruggiero!</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l><stage>(a Bradamante</stage> Sì, quest'anima grande,</l>
             <l>Che in te solo vivea, tant'oltre spinse</l>
@@ -2806,18 +2831,18 @@
             <l>Vantai nel fido Erminio, oggi il maestro</l>
             <l part="I">Posso vantar nel gran Ruggiero.</l>
           </sp>
-          <sp>
+          <sp who="#ruggiero">
             <speaker>RUGG.</speaker>
             <l part="F">Ah prence,</l>
             <l>Di quante vite io deggio</l>
             <l part="I">Esserti debitore?</l>
           </sp>
-          <sp>
+          <sp who="#bradamante">
             <speaker>BRAD.</speaker>
             <l part="F">(Ora è portento</l>
             <l part="I">Se di gioia io non moro).</l>
           </sp>
-          <sp>
+          <sp who="#carlo_magno">
             <speaker>CAR.</speaker>
             <l part="F">Io sento il ciglio</l>
             <l>A così nobil gara</l>
@@ -2825,17 +2850,17 @@
             <l>Vieni al mio sen. Vieni al mio seno, o prence,</l>
             <l part="I">Gloria del suol natio. <stage>(vuol abbracciar Leone</stage></l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l part="F"><stage>(si ritira con rispetto)</stage> Perdona, Augusto,</l>
             <l>Non ne son degno ancora: ancor non sono</l>
             <l part="I">Tutti corretti i falli miei.</l>
           </sp>
-          <sp>
+          <sp who="#carlo_magno">
             <speaker>CAR.</speaker>
             <l part="F">Quai falli?</l>
           </sp>
-          <sp>
+          <sp who="#leone">
             <speaker>LEO.</speaker>
             <l>Della real Clotilde un dì m'accese</l>
             <l>Il merto e la beltà. Le offersi il core,</l>
@@ -2852,18 +2877,18 @@
             <l>Se il mio cor, se il mio trono</l>
             <l>Non son bastati a meritar perdono.</l>
           </sp>
-          <sp>
+          <sp who="#carlo_magno">
             <speaker>CAR.</speaker>
             <l>Che risponde Clotilde</l>
             <l part="I">Ad un reo sì gentil?</l>
           </sp>
-          <sp>
+          <sp who="#clotilde">
             <speaker>CLOT.</speaker>
             <l part="F">Signor... Son io...</l>
             <l>E' il prence... Ah, mi confondo:</l>
             <l part="I">Deh, rispondi per me!</l>
           </sp>
-          <sp>
+          <sp who="#carlo_magno">
             <speaker>CAR.</speaker>
             <l part="F">Sì, tu la mano</l>
             <l>Porgi sposa a Leon. Ruggiero ottenga</l>
@@ -2875,7 +2900,7 @@
             <l>Ogni virtude apprenda;</l>
             <l>E più chiari i suoi dì la terra attenda.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Portator di lieti eventi,</l>
@@ -2921,7 +2946,7 @@
           <l>Serbato a questo dì laccio sì degno.</l>
           <l>Posteri, è il Ciel per noi: ne abbiamo il pegno.</l>
         </lg>
-        <sp>
+        <sp who="#coro">
           <speaker>CORO</speaker>
           <lg>
             <l>Portator di lieti eventi,</l>

--- a/tei/metastasio-siroe.xml
+++ b/tei/metastasio-siroe.xml
@@ -76,6 +76,31 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="cosroe">
+            <persName>Cosroe</persName>
+          </person>
+          <person xml:id="medarse">
+            <persName>Medarse</persName>
+          </person>
+          <person xml:id="siroe">
+            <persName>Siroe</persName>
+          </person>
+          <person xml:id="emira">
+            <persName>Emira</persName>
+          </person>
+          <person xml:id="laodice">
+            <persName>Laodice</persName>
+          </person>
+          <person xml:id="arasse">
+            <persName>Arasse</persName>
+          </person>
+          <personGrp xml:id="coro">
+            <name>Coro</name>
+          </personGrp>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Pavia</name>Digitalizzazione</change>
@@ -129,7 +154,7 @@
           <head>SCENA PRIMA</head>
           <stage>Gran tempio dedicato al Sole, con ara e simulacro del medesimo.</stage>
           <stage>COSROE, SIROE e MEDARSE</stage>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Figli, io non son del regno</l>
             <l>Men padre che di voi. Se a voi degg'io</l>
@@ -146,17 +171,17 @@
             <l>Che, in pace o fra le squadre,</l>
             <l>Giunga la gloria ad oscurar del padre.</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l>Tutta dal tuo volere</l>
             <l part="I">La mia sorte dipende.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">E in qual di noi</l>
             <l part="I">Il più degno ritrovi?</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Eguale è il merto.</l>
             <l>Amo in Siroe il valore,</l>
@@ -172,12 +197,12 @@
             <l>E giuri al nuovo erede</l>
             <l>Serbar, senza lagnarsi, ossequio e fede.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>(Che giuri il labbro mio?</l>
             <l part="I">Ah no!)</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">Pronto ubbidisco. (Il re son io).</l>
             <l>A te, nume fecondo,</l>
@@ -188,23 +213,23 @@
             <l>S'io non adempio il giuramento intero,</l>
             <l>Splenda sempre per me torbido e nero.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Amato figlio! Al nume,</l>
             <l>Siroe, t'accosta, e dal minor germano</l>
             <l part="I">Ubbidienza impara.</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">Ei pensa e tace.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Deh, perché la mia pace</l>
             <l>Ancor non assicuri?</l>
             <l part="I">Perché tardi? Che pensi?</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">E vuoi ch'io giuri?</l>
             <l>Questa ingiusta dubbiezza</l>
@@ -226,7 +251,7 @@
             <l>Fra gli amplessi paterni i giorni oscuri.</l>
             <l>Padre, sai tutto questo, e vuoi ch'io giuri?</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>So ancor di più. Fin del nemico Asbite</l>
             <l>So ch'Emira la figlia</l>
@@ -237,7 +262,7 @@
             <l>E, se Emira vivesse,</l>
             <l>Chi sa fin dove il tuo furor giungesse.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Appaga pure, appaga</l>
             <l>Quel cieco amor che a me ti rende ingiusto.</l>
@@ -252,18 +277,18 @@
             <l>In aiuto agli oppressi. Egli è secondo</l>
             <l>D'anni e di merti, e ci conosce il mondo.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Infino alle minacce,</l>
             <l part="I">Temerario, t'inoltri? Io voglio...</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">Ah, padre!</l>
             <l>Non ti sdegnare. A lui concedi il trono:</l>
             <l part="I">Basta a me l'amor tuo.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">No, per sua pena</l>
             <l>Voglio che in questo dì suo re t'adori:</l>
@@ -286,19 +311,19 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>SIROE e MEDARSE</stage>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>E puoi senza arrossirti</l>
             <l>Fissar, Medarse, in sul mio volto i lumi?</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l>Olà, così favella</l>
             <l>Siroe al suo re? Sai che de' giorni tuoi</l>
             <l>Oggi l'arbitro io sono?</l>
             <l>Cerca di meritar la vita in dono.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Troppo presto t'avanzi</l>
             <l>A parlar da monarca. In su la fronte</l>
@@ -310,7 +335,7 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>EMIRA in abito d'uomo, col nome d'Idaspe, e detti.</stage>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Perché di tanto sdegno,</l>
             <l>Principi, vi accendete?</l>
@@ -319,53 +344,53 @@
             <l>D'amor, di genio eguali</l>
             <l>Seleucia vi rivegga e non rivali.</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l>A placar m'affatico</l>
             <l>Gli sdegni del germano:</l>
             <l>Tutto sopporto e m'affatico invano.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="I">Come finge modestia!</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">E' a me palese</l>
             <l part="I">L'umiltà di Medarse</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">Ah! caro Idaspe,</l>
             <l>E' suo costume antico</l>
             <l part="I">D'insultar simulando.</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F"><stage>(ad Emira)</stage> Il senti, amico?</l>
             <l>Quant'odio in seno accolga,</l>
             <l>Vedilo al volto acceso, al guardo bieco.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Parti; non l'irritar; lasciami seco. <stage>(a Medarse)</stage></l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="I">Perfido!</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">Oh Dio! m'oltraggi</l>
             <l>Senza ragion. Deh, tu lo placa, Idaspe:</l>
             <l>Digli che adoro in lui</l>
             <l>Della Persia il sostegno e il mio sovrano.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="I">Vanne. <stage>(a Medarse)</stage></l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">(Il trionfo mio non è lontano). <stage>(parte</stage></l>
           </sp>
@@ -373,22 +398,22 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>EMIRA e SIROE</stage>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Bella Emira adorata.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Taci, non mi scoprir: chiamami Idaspe.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Nessun ci ascolta, e solo</l>
             <l>A me nota qui sei.</l>
             <l>Senti qual torto io soffro</l>
             <l part="I">Dal padre ingiusto.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Io già l'intesi; e intanto</l>
             <l>Siroe che fa? Riposa</l>
@@ -398,11 +423,11 @@
             <l>Onde contrasti al suo destin crudele,</l>
             <l>Che infecondi sospiri e che querele?</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="I">Che posso far?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Ch puoi?</l>
             <l>Tutto potresti. A tuo favor di sdegno</l>
@@ -410,21 +435,21 @@
             <l>Il tuo trionfo affretta,</l>
             <l>Ed unisce alla tua la mia vendetta.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="I">Che mi chiedi, mia vita?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Un colpo io chiedo</l>
             <l>Necessario per noi. Sai qual io sia?</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Lo so: l'idolo mio,</l>
             <l>L'indica principessa, Emira sei.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Ma quella io sono, a cui da Cosroe istesso</l>
             <l>Asbite, il genitor, fu già avenato;</l>
@@ -433,7 +458,7 @@
             <l>Erro lontan dalle paterne soglie,</l>
             <l>Per desio di vendetta, in queste spoglie.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Oh Dio! per opra mia</l>
             <l>Nella reggia t'avanzi, e giungi a tanto</l>
@@ -441,20 +466,20 @@
             <l>E, ingrata a tanti doni,</l>
             <l>Puoi rammentarti la vendetta e l'ira?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Ama Idaspe il tiranno, e non Emira.</l>
             <l>Pensa, se tua mi brami,</l>
             <l part="I">Ch'io voglio la sua morte.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">Ed io potrei</l>
             <l>Da Emira essere accolto</l>
             <l>Immondo di quel sangue,</l>
             <l>E con l'orror d'un parricidio in volto?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Ed io potrei, spergiura,</l>
             <l>Veder del padre mio l'ombra negletta,</l>
@@ -463,21 +488,21 @@
             <l>E fra le piume intanto</l>
             <l>Posar dell'uccisore al figlio accanto?</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="I">Dunque...</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Dunque, se vuoi</l>
             <l>Stringer la mia destra, Siroe, già sai</l>
             <l part="I">Che devi oprar.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">Non lo sperar giammai.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Senti: se il tuo mi nieghi,</l>
             <l>E' già pronto altro braccio. In questo giorno</l>
@@ -486,40 +511,40 @@
             <l>Se la tua destra prevenir non osa,</l>
             <l>Non salvi il padre e perderai la sposa.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Ah, non son questi, o cara,</l>
             <l>Que' sensi onde addolcivi il mio dolore.</l>
             <l>Qui l'odio ti conduce,</l>
             <l>E fingi a me che ti conduca amore.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Io ti celai lo sdegno,</l>
             <l>Fin che Cosroe fu padre; or ch'è tiranno,</l>
             <l>Vendicar teco volli i torti miei,</l>
             <l>Né il figlio in te più ritrovar credei.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Parricida mi brami! E sì gran pena</l>
             <l part="I">Merta l'ardir d'averti amata?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Assai</l>
             <l>M'è palese il tuo cor; no, che non m'ami.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="I">Non t'amo?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Ecco Laodice: ella, che gode</l>
             <l part="I">L'amor tuo, dirà.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">Soffro costei</l>
             <l>Sol per Cosroe, che l'ama: in lei lusingo</l>
@@ -529,55 +554,55 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>LAODICE e detti.</stage>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Al fin giungesti</l>
             <l>A consolar, Laodice, un fido amante.</l>
             <l>Oh quante volte, oh quante</l>
             <l part="I">Ei sospirò per te!</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="F">L'afferma Idaspe:</l>
             <l part="I">Il crederò.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Ti dirà Siroe il resto.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>(Che nuovo stil di tormentarmi è questo!)</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l>E potrei lusingarmi</l>
             <l>Che s'abbassi ad amarmi,</l>
             <l part="I">Prence illustre, il tuo cor?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Per te sicuro</l>
             <l part="I">E' l'amor suo.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="M"><stage>(piano ad Emira)</stage> Per lei!</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F"><stage>(piano a Siroe)</stage> Taci, spergiuro.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l>E rende amor sì poco</l>
             <l>Il suo labbro loquace?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Sai che un fido amatore avvampa e tace.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l>Ma il silenzio del labbro</l>
             <l>Trdiscon le pupille; ed ei né meno</l>
@@ -585,48 +610,48 @@
             <l>Stupidi fissa in terra i lumi suoi.</l>
             <l>Direi che disapprova i detti tuoi.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Eh! Laodice, t'inganni.</l>
             <l>Siroe tu non conosci: io lo conosco.</l>
             <l>D'Idaspe egli ha rossore.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="I">Non è vero, idol mio! <stage>(piano ad Emira</stage></l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F"><stage>(piano a Siroe)</stage> Sì, traditore!</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l>Siroe rossor! Sin ora</l>
             <l>Taccia non ha; ma, se v'è taccia in lui,</l>
             <l part="I">Sai ch'è l'ardir, non la modestia.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Amore</l>
             <l>Cangia affatto i costumi:</l>
             <l>Rende il timido audace;</l>
             <l>Fa l'audace modesto.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>(Che nuovo stil di tormentarmi è questo!)</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Meglio è lasciarvi in pace. A' fidi amanti</l>
             <l>Ogni altra compagnia troppo è molesta.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l>Idaspe, e pur mi resta</l>
             <l part="I">Un gran timor ch'ei non m'inganni.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Affatto</l>
             <l>Condannar non ardisco il tuo sospetto.</l>
@@ -652,81 +677,81 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>SIROE e LAODICE</stage>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l>Siroe, non parli? Or di che temi? Idaspe</l>
             <l>Più presente non è: spiega il tuo foco.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>(Che importuna!) Ah, Laodice,</l>
             <l>Scorda un amor che è tuo periglio e mio.</l>
             <l>Se Cosroe, che t'adora,</l>
             <l part="I">Giunge a scoprir...</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="F">Non paventar di lui:</l>
             <l part="I">Nulla saprà.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="M">Ma Idaspe...</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="F">Idaspe è fido,</l>
             <l>E approva il nostro amore.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Non è sempre d'accordo il labbro e il core.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l>Ci tormentiamo in vano,</l>
             <l>S'altra ragion non v'è per cui si ponga</l>
             <l>Tanto affetto in oblio.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Altre ancor ve ne son. Laodice, addio.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="I">Senti: perché tacerle?</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">Oh Dio! risparmia</l>
             <l>La noia a te d'udirle,</l>
             <l part="I">A me il rossor di palesarle.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="F">E vuoi</l>
             <l>Sì dubbiosa lasciarmi? Eh dille, o caro.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>(Che pena!) Io le dirò... No, no, perdona:</l>
             <l part="I">Deggio partir.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="F">Nol soffrirò, se pria</l>
             <l part="I">L'arcano non mi sveli.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">Un'altra volta</l>
             <l part="I">Tutto saprai.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="M">No, no.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">Dunque, m'ascolta.</l>
             <l>Ardo per altra fiamma, e son fedele</l>
@@ -769,27 +794,27 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>ARASSE e detta.</stage>
-          <sp>
+          <sp who="#arasse">
             <speaker>ARA.</speaker>
             <l>Di te, germana, in traccia</l>
             <l part="I">Sollecito ne vengo.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="F">Ed opportuno</l>
             <l part="I">Giungi per me.</l>
           </sp>
-          <sp>
+          <sp who="#arasse">
             <speaker>ARA.</speaker>
             <l part="F">Più necessaria mai</l>
             <l part="I">L'opra tua non mi fu.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="F">Né mai più ardente</l>
             <l part="I">Bramai di favellarti. Or sappi...</l>
           </sp>
-          <sp>
+          <sp who="#arasse">
             <speaker>ARA.</speaker>
             <l part="F">Ascolta.</l>
             <l>Cosroe, di sdegno acceso,</l>
@@ -800,7 +825,7 @@
             <l>Svolgi, se puoi, lo sdegno,</l>
             <l>Ed in Siroe un eroe conserva al regno.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l>Siroe un eroe? T'inganni: h un'alma in seno</l>
             <l>Stoltamente feroce, un cor superbo,</l>
@@ -809,32 +834,32 @@
             <l>E che tutto in tributo</l>
             <l>Il mondo al suo valor crede dovuto.</l>
           </sp>
-          <sp>
+          <sp who="#arasse">
             <speaker>ARA.</speaker>
             <l part="I">Che insolita favella! E credi...</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="F">E credo</l>
             <l>Necessaria per noi la sua ruina.</l>
             <l>La caduta è vicina:</l>
             <l part="I">Non t'opporre alla sorte.</l>
           </sp>
-          <sp>
+          <sp who="#arasse">
             <speaker>ARA.</speaker>
             <l part="F">E chi mai fece</l>
             <l>Così cangiar Laodice?</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l>Penetrar quest'arcano a te non lice.</l>
           </sp>
-          <sp>
+          <sp who="#arasse">
             <speaker>ARA.</speaker>
             <l>Condannerà ciasuno</l>
             <l>Il tuo genio volubile e leggiero.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l>Costanza è spesso il variar pensiero.</l>
             <lg>
@@ -907,61 +932,61 @@
         <div type="scene">
           <head>SCENA UNDICESIMA</head>
           <stage>COSROE, SIROE in disparte, poi LAODICE</stage>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Che da un superbo figlio</l>
             <l>Prenda leggi il mio cor, troppo sarei</l>
             <l>Stupido in tollerarlo. E quale, o cara, <stage>(vedendo Laodice</stage></l>
             <l>Insolita ventura a me ti guida?</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l>Vengo a chieder difesa. In questa reggia</l>
             <l>Non basta il tuo favor perch'io non tema.</l>
             <l part="I">V'è chi m'oltraggia e chi m'insulta.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">A tanto</l>
             <l part="I">Chi potrebbe avanzarsi?</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="F">E il mio delitto</l>
             <l part="I">E' l'esser fida a te.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Scopri l'indegno,</l>
             <l>E lascia di punirlo a me la cura.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l>Un tuo figlio procura</l>
             <l>Di sedurre il mio amor: perch'io ricuso</l>
             <l>Di renderlo contento,</l>
             <l part="I">Minaccia il viver mio.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">(Numi, che sento!)</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Dell'amato Meddarse</l>
             <l>Esser colpa non può. Siroe è l'audace.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l>Pur troppo è ver. Tu vedi</l>
             <l>Qual uopo ho di soccorso. Imbelle e sola,</l>
             <l>Contro un figlio real che far poss'io?</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>(Tutto il mondo congiura a danno mio).</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Anche in amor costui</l>
             <l>Rivale ho da soffrir! Tergi i bei lumi,</l>
@@ -969,32 +994,32 @@
             <l>Ancor questo da te! Cosroe non sono,</l>
             <l part="I">S'io non farò... Basta... vedrai...</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">(Che pena!)</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l>(Fu mio saggio consiglio</l>
             <l part="I">Il prevenir l'accusa).</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Indegno figlio! <stage>(siede e s'avvede del foglio: lo prende e legge da sé</stage></l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l>S'io preveder potea</l>
             <l>Nel tuo cor tanto affanno, avrei... (Qual foglio</l>
             <l part="I">Stupido ei legge e impallidisce?)</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Oh numi!</l>
             <l>E che di più funesto</l>
             <l>Può minacciarmi il Ciel! Che giorno è questo! <stage>(s'alza</stage></l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="I">Che ti affligge, o signor?</l>
           </sp>
@@ -1002,25 +1027,25 @@
         <div type="scene">
           <head>SCENA DODICESIMA</head>
           <stage>MEDARSE e detti.</stage>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">Padre, io ti miro</l>
             <l part="I">Cangiato in volto.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Ah! senti,</l>
             <l part="I">Caro Medarse, e inorridisci.</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">(Un foglio!)</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="I">(Che mai sarà?)</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F"><stage>(legge)</stage> Cosroe, chi credi amico</l>
             <l>Insidia la tua vita. In questo giorno</l>
@@ -1029,11 +1054,11 @@
             <l>Della presenza tua tutti non privi.</l>
             <l>Chi t'avvisa è fedel; credilo, e vivi.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="I">Gelo d'orrore.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">E qual pietà crudele</l>
             <l>E' il salvarmi così? Da mano ignota</l>
@@ -1044,41 +1069,41 @@
             <l>La minaccia crudel vedrò scolpita?</l>
             <l>E questo è farmi salvo? E questa è vita?</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="I">(Misero genitor!)</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">(Non si trascuri</l>
             <l part="I">Sì opportuna occasion).</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Mesarse tace?</l>
             <l part="I">Laodice non favella?</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="F">Io son confusa.</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l>S'io non parlai fin or, volli al tuo sdegno</l>
             <l>Un reo celar che ad ambi è caro. Al fine,</l>
             <l>Quando giunge all'estremo il tuo cordoglio,</l>
             <l>Non ho cor di tacerlo. E' mio quel foglio.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="I">(Ah, mentitor!)</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">L'empio conosci, e ancora</l>
             <l part="I">L'ascondi all'ira mia?</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F"><stage>(s'inginocchia</stage> Padre adorato,</l>
             <l>Perdona al traditor: basti che salvi</l>
@@ -1086,52 +1111,52 @@
             <l>Di questo reo contaminar la mano.</l>
             <l>Chi t'insidia è tuo figlio, è mio germano.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="I">(Che tormento è tacer!)</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Sorgi. A Medarse</l>
             <l part="I">Chi l'arcano scoprì?</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">Fu Siroe istesso.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="I">Chi 'l crederebbe?</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">Ei mi volea compagno</l>
             <l>A crudel parricidio. In van m'opposi;</l>
             <l>La tua morte giurò: perciò Medarse</l>
             <l>In quel foglio scoprì l'empio desio.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Medarse è un traditor. Quel foglio è mio. <stage>(si scopre</stage></l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="I">(Oh Ciel!)</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="M">(Che veggio mai!)</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Siroe nascoso</l>
             <l part="I">Nelle mie stanze!</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">Il suo delitto è certo.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Ei mente. A te mi trasse</l>
             <l>Il desio di salvarti. Un core ardito</l>
@@ -1141,48 +1166,48 @@
         <div type="scene">
           <head>SCENA TREDICESIMA</head>
           <stage>EMIRA sotto nome d'Idaspe, e detti.</stage>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Chi tradisce il mio re? Per sua difesa</l>
             <l>Ecco il braccio, ecco l'armi.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Solo Idaspe mancava a tormentarmi!</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Vedi, amico, a qual pena</l>
             <l part="I">Mi serba il Ciel. <stage>(dà il foglio ad Emira, la quale lo legge da sé</stage></l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="F">(Che inaspettati eventi!)</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="I">Donde l'avviso? E' noto il reo? <stage>(rende il foglio a Cosroe</stage></l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">Medarse</l>
             <l part="I">Tutto svelò.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">Il germano</l>
             <l>T'inganna, Idaspe; io palesai l'arcano.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Dunque, perché non scopri</l>
             <l part="I">L'insidiator?</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">Dirti di più non deggio.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Perfido! e in questa guisa</l>
             <l>Di mentita virtù copri il tuo fallo?</l>
@@ -1197,11 +1222,11 @@
             <l>Io non rispetto il figlio:</l>
             <l>E' mio proprio interesse il tuo periglio.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="I">(Che ardir!)</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Quanto ti deggio, amato Idaspe!</l>
             <l><stage>(a Siroe)</stage> Impara, ingrato, impara. Egli è straniero,</l>
@@ -1209,15 +1234,15 @@
             <l>A te donai la vita; e pure, ingrato,</l>
             <l>Ei mi difende, e tu m'insidi il trono.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Difendermi non posso, e reo non sono.</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l>L'innocente non tace: io già parlai.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Via! Che pensi? Che fai? Chi giunse a tanto</l>
             <l>Può ben l'opra compir. Tu non rispondi?</l>
@@ -1227,85 +1252,85 @@
             <l>Perciò taci e arrossisci,</l>
             <l>Perciò né meno in volto osi mirarmi.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Solo Idaspe mancava a tormentarmi!</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Medarse, quel silenzio</l>
             <l part="I">Giustifica l'accusa.</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">Io non mentisco.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Se un mentitor si cerca,</l>
             <l part="I">Siroe sarà.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">Ma questo è troppo, Idaspe.</l>
             <l part="I">Non ti basta? Che vuoi?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Vuo' che tu assolva</l>
             <l part="I">Da' sospetti il mio re.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">Che dir poss'io?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Di' che il tuo fallo è mio. Di' pur ch'io sono</l>
             <l>Complice del delitto; anzi che tutta</l>
             <l>E' tua la fedeltà, la colpa è mia.</l>
             <l><stage>(a Cosroe)</stage> Capace ancor di questo egli saria.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Ma lo sarebbe in van. Felice impresa</l>
             <l>L'ingannarmi non è. So la tua fede.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Così fosse per te di Siroe il core.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Lo so ch'è un traditore. Ei non procura</l>
             <l>Difesa né perdono.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Difendermi non posso, e reo non sono.</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l>E non è reo chi niega</l>
             <l>Al padre un giuramento?</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l>Non è reo l'ardimento</l>
             <l>Del tuo foco amoroso?</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Non è reo chi nascoso</l>
             <l>Io stesso ho qui veduto?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Non è reo chi ha potuto</l>
             <l>Recar quel foglio, e si sgomenta e tace</l>
             <l>Quando seco io ragiono?</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Tutti reo mi volete, e reo non sono.</l>
             <lg>
@@ -1327,33 +1352,33 @@
         <div type="scene">
           <head>SCENA QUATTORDICESIMA</head>
           <stage>COSROE, EMIRA, MEDARSE e LAODICE</stage>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="I">Olà! s'osservi il prence. <stage>(alle guardie verso la scena</stage></l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Alla tua cura</l>
             <l part="I">Io veglierò.</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">Quand'hai tant'alme fide,</l>
             <l part="I">Paventi un traditor?</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="F">Troppo t'affanni.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Chi sa qual sia fedele, e qual m'inganni?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="I">E puoi temer di me?</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">No, caro Idaspe.</l>
             <l>Anzi tutta confido</l>
@@ -1361,7 +1386,7 @@
             <l>Scopri l'indegna trama,</l>
             <l>Ed in Corsoe difendi un re che t'ama.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Ad anima più fida</l>
             <l>Commetter non potevi il tuo riposo.</l>
@@ -1369,7 +1394,7 @@
             <l>Io verserò, signor, quando non basti</l>
             <l>Tutta l'opra e il consiglio.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Trovo un amico allor che perdo un figlio.</l>
             <lg>
@@ -1389,17 +1414,17 @@
         <div type="scene">
           <head>SCENA QUINDICESIMA</head>
           <stage>EMIRA, MEDARSE e LAODICE</stage>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l>Avresti mai creduto</l>
             <l part="I">In Siroe un traditor?</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="F">Tanto infedele</l>
             <l>Lo prevedesti, e temerario tanto?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>E qual viltade è questa</l>
             <l>D'insultar chi non v'ode? Al fin dovrebbe</l>
@@ -1407,47 +1432,47 @@
             <l>A un principe Laodice:</l>
             <l>Non sempre delinquente è un infelice.</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="I">Che pietà!</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="M">Che difesa!</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">E tu fin ora</l>
             <l part="I">Non l'insultasti?</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="F">Or qual cagion ti muove</l>
             <l>A sdegnarti con noi?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>A me lice insultarlo, e non a voi.</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l>Così presto ti cangi? Or lo difendi,</l>
             <l>Or lo vorresti oppresso.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>A voi par ch'io mi cangi, e son l'istesso.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="I">L'istesso! Io non t'intendo.</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">h! non produce</l>
             <l>Sì diversa favella un sol pensiero.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>So che strano vi sembra, e pure è vero.</l>
             <lg>
@@ -1471,11 +1496,11 @@
         <div type="scene">
           <head>SCENA SEDICESIMA</head>
           <stage>LAODICE e MEDARSE</stage>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l>Gran mistero in que' detti Idaspe asconde.</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l>Semplice, e tu lo credi? A te dovrebbe</l>
             <l>Esser nota la corte. E' di chi gode</l>
@@ -1487,7 +1512,7 @@
             <l>Quel che teme o desia, ma sempre in vano:</l>
             <l>Ché v'è spesso l'enigma, e non l'arcano.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l>Non credo che sian tali</l>
             <l>D'Idaspe i sensi. E' ver ch'io non gl'intendo,</l>
@@ -1537,7 +1562,7 @@
           <head>SCENA PRIMA</head>
           <stage>Parco reale.</stage>
           <stage>LAODICE, poi SIROE</stage>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l>Che funesto piacere</l>
             <l>E' mai quel di vendetta!</l>
@@ -1547,24 +1572,24 @@
             <l>Del periglio di Siroe in mezzo al core</l>
             <l part="I">Il rimorso e l'orrore.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">La fin, Laodice,</l>
             <l>Sei vendicata: a me soffrir conviene</l>
             <l part="I">La pena del tuo fallo.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="F">Amato prence,</l>
             <l>Così confusa io sono,</l>
             <l part="I">Che non ho cor di favellarti.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">Avesti</l>
             <l part="I">Però cor d'accusarmi.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="F">Un cieco sdegno,</l>
             <l>Figlio del tuo disprezzo,</l>
@@ -1575,7 +1600,7 @@
             <l>Io scoprirò l'inganno.</l>
             <l part="I">Saprà Corsoe ch'io fui...</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">La tua ruina</l>
             <l>Non fa la mia salvezza. Anche innocente</l>
@@ -1585,7 +1610,7 @@
             <l>D'amorosa fra noi</l>
             <l part="I">Segreta intelligenza.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="F">E qual emenda</l>
             <l>Può farmi meritare il tuo perdono?</l>
@@ -1593,22 +1618,22 @@
             <l>Prescriver mi vorrai pronta son io:</l>
             <l>Ma poi scordati, o caro, il fallo mio.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Più nol rammento; e, se ti par che sia</l>
             <l>La sofferenza mia di premio degna,</l>
             <l part="I">Più non amarmi.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="F">Oh Dio! come potrei</l>
             <l>Lasciar sì dolci affetti in abbandono?</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Questo da te domando unico dono.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <lg>
               <l>Mi lagnerò tacendo</l>
@@ -1627,66 +1652,66 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>SIROE, poi EMIRA sotto nome d'Idaspe.</stage>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Come quel di Laodice,</l>
             <l>Potessi almen lo sdegno</l>
             <l part="I">Placar dell'idol mio.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Fermati, indegno!</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Ancor non sei contenta?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="I">Ancor pago non sei?</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">Forse ritorni</l>
             <l>Ad insultare un misero innocente?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Vai forse al genitore</l>
             <l>A palesar quel che taceva il foglio?</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Quel foglio in che t'offese? Io son creduto</l>
             <l>Reo del delitto, e mel sopporto e taccio.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Ed io, crudel, che faccio,</l>
             <l>Qualor t'insulto? Assicurar procuro</l>
             <l>Cosroe della mia fé, più per tuo scampo</l>
             <l part="I">Che per la mia vendetta.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">Ah! dunque, o cara,</l>
             <l>Fai più per me. Perdona al padre, o almeno,</l>
             <l>Se brami una vendetta, aprimi il seno.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Io confonder non so Cosroe col figlio.</l>
             <l>Odio quello, amo te; vendico estinto</l>
             <l part="I">Il proprio genitore.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">E il mio, che vive,</l>
             <l>Per legge di natura anch'io difendo.</l>
             <l>Sempre della vendetta</l>
             <l>Più giusta è la difesa.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>La generosa impresa</l>
             <l>Dunque tu siegui; io seguirò la mia.</l>
@@ -1701,11 +1726,11 @@
             <l>Aborrir d'un tiranno il figlio indegno.</l>
             <l>Cominci in questo punto il nostro sdegno. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="I">Mio ben, t'arresta.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Ardisci</l>
             <l>Di chiamarmi il tuo bene? Unir pretendi</l>
@@ -1713,26 +1738,26 @@
             <l>E ti mostri a un istante</l>
             <l>Debol nemico ed infedele amante.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="I">A torto l'amor mio...</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Taci: l'amore</l>
             <l>E' nell'odio sepolto.</l>
             <l>Parlami di furore,</l>
             <l>Parlami di vendetta, ed io t'ascolto.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Dunque così degg'io...</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="I">Sì, scordati d'Emira.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">Emira, addio.</l>
             <l>Mi vuoi reo, mi vuoi morto:</l>
@@ -1740,21 +1765,21 @@
             <l>Vado a scoprirmi autor: la tua fierezza</l>
             <l>Così sarà contenta. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="I">Sentimi: non partir.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">Che vuoi ch'io senta?</l>
             <l part="I">Lasciami alla mia sorte.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Odi: non giova</l>
             <l part="I">Né a me né a Cosroe il farti reo.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">Ma basta</l>
             <l>Per morire innocente. Ascolta. Al fine</l>
@@ -1763,14 +1788,14 @@
             <l>Al genitor farò, quando non possa</l>
             <l>Toglierlo in altra guisa al tuo furore.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Va pur, va, traditore!</l>
             <l>Accusami, o t'accusa: a tuo dispetto</l>
             <l>Il contrario io farò. Vedrem di noi</l>
             <l>Chi troverà più fede.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Il mio sangue si chiede:</l>
             <l>Barbara, il verserò. L'animo acerbo</l>
@@ -1780,22 +1805,22 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>COSROE senza guardie, e detti.</stage>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Che fai, superbo?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="I">(Oh dèi!)</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Contro un mio fido</l>
             <l>Stringi il brando, o fellon? Niega, se puoi:</l>
             <l>Or non v'è chi t'accusi. Il guardo mio</l>
             <l>Non s'ingannò. Di' che mentisco anch'io.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Tutto è vero. Io son reo: tradisco il padre,</l>
             <l>Son nemico al germano, insulto Idaspe:</l>
@@ -1804,45 +1829,45 @@
             <l>Non curo uomini e dèi:</l>
             <l>Odio il giorno, odio tutti, odio me stesso.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>(Difendetelo, o numi!)</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="I">Olà! costui s'arresti. <stage>(escono alcune guardie</stage></l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Ei non volea</l>
             <l>Offendermi, o signor. Cieco di sdegno,</l>
             <l>Forse contro di sé volgea l'acciaro.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>In van cerchi riparo</l>
             <l>Con pietosa menzogna al suo delitto.</l>
             <l part="I">Perché fuggir?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">La fuga</l>
             <l part="I">Tema non era in me.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">Taci una volta,</l>
             <l>Idaspe, taci: il mio maggior nemico</l>
             <l>E' chi più mi soccorre. Il mio tormento</l>
             <l part="I">Termini col morir.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Sarai contento.</l>
             <l>Pochi istanti di vita</l>
             <l part="I">Ti restano, infedel.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Mio re, che dici?</l>
             <l>Necessaria a' tuoi giorni</l>
@@ -1850,31 +1875,31 @@
             <l>I complici scoprì: morrebbe seco</l>
             <l part="I">Il temuto segreto.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">E' vero. Oh quanto</l>
             <l>Deggio al tuo amor! Vegliami sempre a lato.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Forse incontro al tuo fato</l>
             <l>Corri così. Non puoi tradirti Idaspe?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="I">Io tradirlo?</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">In ciascuno</l>
             <l>Può celarsi il nemico. Ah! non fidarti:</l>
             <l part="I">Chi sa l'empio qual è?</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Chètati e parti.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <lg>
               <l>Mi credi infedele:</l>
@@ -1894,37 +1919,37 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>COSROE ed EMIRA</stage>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="I">(Pensoso è il re).</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">(Per tante prove e tante</l>
             <l>So che il figlio è infedel; ma pur que' detti...)</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>(Forse crede a' sospetti</l>
             <l part="I">Che Siroe suggerì).</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">(Tradirmi Idaspe!</l>
             <l part="I">Per qual ragion?)</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">(S'ei di mia fé paventa,</l>
             <l>Perdo i mezzi al disegno. Or non m'osserva:</l>
             <l part="I">Siam soli: il tempo è questo).</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">(Un reo l'accusa,</l>
             <l>Per render forse il fallo suo minore).</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>(La vittima si sveni al genitore). <stage>(snuda la spada per ferir Cosroe</stage></l>
           </sp>
@@ -1932,19 +1957,19 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>MEDARSE e detti.</stage>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="I">Signore...</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="M">(Oh dèi!)</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">Perché quel ferro, Idaspe?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Per deporlo al suo piè. V'è chi ha potuto</l>
             <l>Farlo temer di me. Troppo geloso</l>
@@ -1954,21 +1979,21 @@
             <l>Fin che si scopra il vero,</l>
             <l>Eccomi disarmato e prigioniero.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="I">Che fedeltà!</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">Forse il german procura</l>
             <l part="I">Divider la sua colpa.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Idaspe, torni</l>
             <l>Per ia difesa al fianco tuo la spada.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Perdonami, o signor; quando è in periglio</l>
             <l>D'un sovrano la vita, ha corpo ogno ombra.</l>
@@ -1977,46 +2002,46 @@
             <l>Poscia per tuo riparo</l>
             <l>Senza taccia d'error torni l'acciaro.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>No, no: ripiglia il brando.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="I">Ubbidirti non deggio.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Io tel comando.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Così vuoi: non m'oppongo. Almen permetti</l>
             <l>Ch'io la reggia abbandoni, acciò non dia</l>
             <l>Di novelli sospetti</l>
             <l>Colpa l'invidia all'innocenza mia.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Anzi voglio che Idaspe</l>
             <l>Sempre de' giorni miei vegli alla cura.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="I">Io?</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="M">Sì.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Chi m'assicura</l>
             <l>Della fede di tanti, a cui commessa</l>
             <l>E' la tua vita? Io debitor sarei</l>
             <l>Della colpa d'ognun. S'io fossi solo...</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>E solo esser tu déi.</l>
             <l>Fra le reali guardie</l>
@@ -2024,7 +2049,7 @@
             <l>Le cambia e le disponi; e sia tuo peso</l>
             <l part="I">Di scoprir chi m'insidia.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Al regio cenno</l>
             <l>Ubbidirò; né dal mio sguardo accorto</l>
@@ -2050,21 +2075,21 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>COSROE e MEDARSE</stage>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l>Non è piccola sorte</l>
             <l>Che uno stranier così fedel ti sia.</l>
             <l>Ma non basta, o mio re: maggior riparo</l>
             <l part="I">Chiede il nostro destin.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Sarai nel giro</l>
             <l>Di questo dì tu mio compagno al soglio:</l>
             <l>E opporsi a due regnanti</l>
             <l>Non potrà facilmente un folle orgoglio.</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l>Anzi il tuo amor l'irrìta. Ha già sedotta</l>
             <l>Del popol fedel Siroe gran parte.</l>
@@ -2076,11 +2101,11 @@
             <l>Perde tutto il vigore</l>
             <l part="I">L'audacia popolare.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Ah! non ho core.</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l>Anch'io gelo in pensarlo. Altro non resta</l>
             <l>Dunque per tua salvezza</l>
@@ -2093,14 +2118,14 @@
             <l>Se può la mia ferita</l>
             <l>Render la pace a chi mi dié la vita.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Sento per tenerezza</l>
             <l>Il ciglio inumidir. Caro Medarse,</l>
             <l>Vieni al mio sen. Perché due figli eguali</l>
             <l part="I">Non diemmi il Ciel?</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">Se ricusar potessi</l>
             <l>Di scemar, per salvarti, i giorni miei,</l>
@@ -2147,7 +2172,7 @@
           <head>SCENA OTTAVA</head>
           <stage>Appartamenti terreni corrispondenti a' giardini</stage>
           <stage>SIROE senza spada, ed ARASSE</stage>
-          <sp>
+          <sp who="#arasse">
             <speaker>ARA.</speaker>
             <l>Chi ricusa un'aita,</l>
             <l>Giustifica il rigor della sua sorte.</l>
@@ -2156,35 +2181,35 @@
             <l>Un zelo, che fomenta</l>
             <l>Del popolo il favor per tuo riparo.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>L'ira del fato avaro</l>
             <l part="I">Tollerando si vince.</l>
           </sp>
-          <sp>
+          <sp who="#arasse">
             <speaker>ARA.</speaker>
             <l part="F">Al merto amica</l>
             <l>Rade volte è Fortuna; e prende a sdegno</l>
             <l>Chi meno a lei che alla virtù si affida.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>L'alma, che in me s'annida,</l>
             <l>Più che felice e rea</l>
             <l>Misera ed innocente esser desia.</l>
           </sp>
-          <sp>
+          <sp who="#arasse">
             <speaker>ARA.</speaker>
             <l>Un'innocenza oblia,</l>
             <l>Che avria nome di colpa. Il volgo suole</l>
             <l>Giudicar dagli eventi, e sempre crede</l>
             <l>Colpevole colui che resta oppresso.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Mi basta di morir noto a me stesso.</l>
           </sp>
-          <sp>
+          <sp who="#arasse">
             <speaker>ARA.</speaker>
             <l>Ad onta ancor di questa</l>
             <l>Rigorosa virtù, sarà mia cura</l>
@@ -2192,11 +2217,11 @@
             <l>Il popolo e le squadre</l>
             <l>Solleverò per così giusta impresa.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Ma questo è tradimento, e non difesa.</l>
           </sp>
-          <sp>
+          <sp who="#arasse">
             <speaker>ARA.</speaker>
             <lg>
               <l>Se pugnar non sai col fato,</l>
@@ -2213,29 +2238,29 @@
         <div type="scene">
           <head>SCENA NONA</head>
           <stage>MEDARSE e detto.</stage>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="I">Come! Nessuno è teco?</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">Ho sempre a lato</l>
             <l>La crudel compagnia di mie sventure.</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l>Son già quasi sicure</l>
             <l>Le tue felicità. Deve a momenti</l>
             <l>Qui venir Cosroe, e forse</l>
             <l part="I">A consolarti ei viene.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">Or vedi, quanto</l>
             <l>Sventurato son io: del padre in vece</l>
             <l part="I">Giunse Medarse.</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">Il tuo piacer saria</l>
             <l>Poter senza compagno</l>
@@ -2244,7 +2269,7 @@
             <l>Sapresti il mal talento.</l>
             <l>Semplice, se lo speri! Io nol consento.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>T'inganni. A me non spiace</l>
             <l>Favellar te presente:</l>
@@ -2252,7 +2277,7 @@
             <l>Pena in vederti è il sovvenirmi solo</l>
             <l>Ch'abbia fonte comune il sangue nostro.</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l>Sarà mio merto e la corona e l'ostro.</l>
           </sp>
@@ -2260,57 +2285,57 @@
         <div type="scene">
           <head>SCENA DECIMA</head>
           <stage>COSROE, EMIRA col nome d'Idaspe, e detti.</stage>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Veglia, Idaspe, all'ingresso; e il cenno mio</l>
             <l>Nelle vicine stanze</l>
             <l part="I">Laodice attenda.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="M">Ubbidirò. <stage>(si ritira in disparte</stage></l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Medarse,</l>
             <l part="I">Parti.</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">Ch'io parta! E chi difende intanto,</l>
             <l part="I">Signor, le mie ragioni?</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Io le difendo.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="I">Resti, se vuol.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">No, teco</l>
             <l part="I">Solo esser voglio.</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">E puoi fidarti a lui?</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="I">Più oltre non cercar. Vanne.</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">Ubbidisco.</l>
             <l part="I">Ma poi...</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Taci, Medarse, e t'allontana.</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l>(Mi cominci a tradir, sorte inumana). <stage>(parte</stage></l>
           </sp>
@@ -2318,7 +2343,7 @@
         <div type="scene">
           <head>SCENA UNDICESIMA</head>
           <stage>COSROE, SIROE ed EMIRA indisparte.</stage>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Siedi, Siroe e m'ascolta. <stage>(Cosroe siede</stage></l>
             <l>Io vengo qual mi vuoi, giudice o padre.</l>
@@ -2327,25 +2352,25 @@
             <l>Giudice vuoi ch'io sia?</l>
             <l>Sosterrò teco il mio real decoro.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Il giudice non temo: il padre adoro. <stage>(siede</stage></l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Posso sperar dal figlio</l>
             <l>Ubbidito un mio cenno? Infin ch'io parlo,</l>
             <l>Taci, e mostrami in questo il tuo rispetto.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Fn che vuoi tacerò; così prometto.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="I">(Che dir vorrà?)</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Di mille colpe reo,</l>
             <l>Siroe, tu sei. Per questa volta soffri</l>
@@ -2360,19 +2385,19 @@
             <l>Che più? Medarse istesso</l>
             <l part="I">Scopre i tuoi falli...</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">e creder puoi veraci...</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Serbami la promessa: ascolta e taci.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="I">(Misero prence!)</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Ognun di te si lagna.</l>
             <l>Hai sconvolto la reggia; al sicuro</l>
@@ -2382,11 +2407,11 @@
             <l>Né ti basta. I tumulti a danno mio</l>
             <l part="I">Ne' popoli risvegli...</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">Ah! son fallaci...</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Serbami la promessa: ascolta e taci.</l>
             <l>Vedi da quanti oltraggi</l>
@@ -2397,16 +2422,16 @@
             <l>Altra emenda non chiede</l>
             <l>Dall'offensor che pentimento e fede.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>(Veggio Siroe commosso.</l>
             <l part="I">Ah, mi scoprisse mai!</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">Parlar non posso.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Odi, Siroe. Se temi</l>
             <l>Per la vita del reo, paventi in vano.</l>
@@ -2416,57 +2441,57 @@
             <l>Pur che noto misia, salvo l'indegno.</l>
             <l>Ecco, se vuoi, la real destra in pegno.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="I">(Aimè!)</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">Quando sicuri</l>
             <l>Siano dal tuo castigo i tradimenti,</l>
             <l part="I">Dirò... </l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Non ti rammenti</l>
             <l>Che il tuo cenno, signor, Laodice attende?</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="I">(Oh dèi!)</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="M">Lo so: parti.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Dirò frattanto...</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="I">Di' ciò che vuoi.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">T'ubbidirò fedele.</l>
             <l part="I">(Perfido, non parlar). <stage>(a Siroe</stage></l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">(Quanto è crudele!)</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Spiegati e ricomponi</l>
             <l>I miei sconvolti affetti. Or perché taci?</l>
             <l part="I">Perché quel turbamento?</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="M">Oh Dio!</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">T'intendo:</l>
             <l>Al nome di Laodice</l>
@@ -2477,46 +2502,46 @@
             <l>Cederla a te. Sol dalla trama ascosa</l>
             <l>Assicurami, o figlio, e sia tua sposa.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="I">Forse non crederai...</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Chiedea Laodice</l>
             <l>Importuna l'ingresso: acciò non fosse</l>
             <l>A te molesta, allontanar la feci.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="I">E partì?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="M">Sì, mio re.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Vanne, e l'arresta.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="I">Vado. (Mi vuoi tradir?) <stage>(a Siroe</stage></l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">(Che pena è questa!)</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Parla. Laodice è tua. Di più che brami?</l>
             <l>Dubbioso ancor ti veggio?</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Sdegno Laodice, e favellar non deggio.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Perfido! Al fin tu vuoi <stage>(s'alza</stage></l>
             <l>Morir da traditor, come vivesti.</l>
@@ -2531,23 +2556,23 @@
             <l>Già teco io son: via, ti soddisfa appieno.</l>
             <l>Disarmami, inumano, e m'apri il seno.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>E chi tant'ira accende?</l>
             <l>Così senza difesa</l>
             <l>In periglio lasciarti a me non lice;</l>
             <l part="I">Eccomi al fianco tuo.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Venga Laodice.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Signor, se amai Laodice,</l>
             <l part="I">Punisca il Ciel..</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Non irritar gli dèi.</l>
             <l>Con novelli spergiuri.</l>
@@ -2556,11 +2581,11 @@
         <div type="scene">
           <head>SCENA DODICESIMA</head>
           <stage>LAODICE e detti.</stage>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="I">Eccomi a' cenni tuoi.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Siroe, m'ascolta.</l>
             <l>Questa è l'ultima volta</l>
@@ -2589,11 +2614,11 @@
         <div type="scene">
           <head>SCENA TREDICESIMA</head>
           <stage>SIROE, EMIRA e LAODICE</stage>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="I">(Che risolver degg'io?)</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Felici amanti,</l>
             <l>Delle vostre fortune oh quanto io godo!</l>
@@ -2602,48 +2627,48 @@
             <l>I figli prenderan forme leggiadre,</l>
             <l>E se avran fedeltà simile al padre!</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="I">(E mi deride ancor!)</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="F">Secondi il Cielo</l>
             <l>Il lieto augurio. Ei però tace, e parmi</l>
             <l part="I">Irresoluto ancor.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F"><stage>(a Siroe)</stage> Parla. Saria</l>
             <l part="I">Stupidità se più tacessi.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">Oh dèi!</l>
             <l part="I">Lasciami in pace.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Il re sai che t'impose</l>
             <l>Di sceglier, me presente,</l>
             <l part="I">Il carcere o Laodice.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="F">Or che risolvi?</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Per me risolva Idaspe: il suo volere</l>
             <l>Sarà legge del mio. Frattanto io parto,</l>
             <l>E vo fra le ritorte</l>
             <l>L'esito ad aspettar della mia sorte.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="I">Ma, prence, io non saprei...</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">Sapesti assai</l>
             <l>Tormentarmi fin ora.</l>
@@ -2665,68 +2690,68 @@
         <div type="scene">
           <head>SCENA QUATTORDICESIMA</head>
           <stage>EMIRA e LAODICE</stage>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="I">(A costei che dirò?)</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="F">Da' labbri tuoi</l>
             <l>Ora dipende, Idaspe,</l>
             <l>Il riposo d'un regno e il mio contento.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Di Siroe, a quel ch'io sento,</l>
             <l>Senza noia Laodice</l>
             <l part="I">Le nozze accetteria.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="F">Sarei felice.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="I">Dunque l'ami?</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="F">L'adoro.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>E speri la sua mano?...</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="I">Stringer per opra tua.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Lo speri in vano.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="I">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Posso svelarti un mio segreto?</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="I">Parla.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Del tuo sembiante</l>
             <l>Perdonami l'ardire, io vivo amante.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="I">Di me!</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Sì. Chi mai puote</l>
             <l>Mirar, senz'avvampar, quell'aureo crine,</l>
@@ -2737,62 +2762,62 @@
             <l>Qual fuoco ho in petto accolto,</l>
             <l>Guarda, e vedrai che mi rosseggia in volto.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="I">E tacesti?...</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Il rispetto</l>
             <l part="I">Muto fin or mi rese.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="F">Ascolta, Idaspe:</l>
             <l>Amarti non poss'io.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="I">Così crudele! oh Dio!</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="F">Se è ver che m'ami,</l>
             <l>Servi agli affetti miei. L'amato prence,</l>
             <l>Con virtù di te degna, a me concedi.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Oh! questo no: troppa virtù mi chiedi.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="I">Siroe si perde.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Il Cielo</l>
             <l part="I">Gl'innocenti difende.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="F">E se la speme</l>
             <l>Me pietosa ti finge, ella t'inganna.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Tanto meco potresti esser tiranna?</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l>T'odierò fin ch'io viva; e non potrai</l>
             <l>Riderti de' miei danni.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Saranno almen comuni i nostri affanni.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <lg>
               <l>Amico il Fato</l>
@@ -2845,20 +2870,20 @@
           <head>SCENA PRIMA</head>
           <stage>Cortile.</stage>
           <stage>COSROE ed ARASSE</stage>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>No, no; voglio che mora.</l>
             <l>Abbastanza fin ora</l>
             <l>Pietosa a me per lui parlò natura.</l>
           </sp>
-          <sp>
+          <sp who="#arasse">
             <speaker>ARA.</speaker>
             <l>Signor, chi t'assicura</l>
             <l>Che, Siroe ucciso, il popolo ribelle</l>
             <l>Non voglia vendicarlo; e, quando speri</l>
             <l>I tumulti sedar, non sian più fieri?</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Sollecito e nascosto</l>
             <l>Previeni i sediziosi. A lor si mostri,</l>
@@ -2866,24 +2891,24 @@
             <l>Vedrai gelar lo sdegno,</l>
             <l part="I">Quando manchi il fomento.</l>
           </sp>
-          <sp>
+          <sp who="#arasse">
             <speaker>ARA.</speaker>
             <l part="F">Innanzi a questo</l>
             <l>Violento rimedio, altro possiamo</l>
             <l part="I">Men funesto tentarne.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">E quale? Ho tutto</l>
             <l>Posto in uso fin ora. Idaspe ed io</l>
             <l>Sudammo in vano. Il figlio contumace</l>
             <l>Morto mi vuol, ricusa i doni e tace.</l>
           </sp>
-          <sp>
+          <sp who="#arasse">
             <speaker>ARA.</speaker>
             <l part="I">Dunque degg'io...</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Sì, vanne: è la sua morte</l>
             <l>Necessaria per me. Pronuncio, Arasse,</l>
@@ -2891,7 +2916,7 @@
             <l>Gelarsi il core, inumidirsi il ciglio:</l>
             <l>Parte del sangue mio verso nel figlio.</l>
           </sp>
-          <sp>
+          <sp who="#arasse">
             <speaker>ARA.</speaker>
             <l>Ubbidirò con pena;</l>
             <l>Ma pur ubbidirò. Di Siroe amico</l>
@@ -2909,7 +2934,7 @@
               <l>E delitto è la pietà. <stage>(parte</stage></l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Fin che del Ciel nemico</l>
             <l>Io non provai lo sdegno,</l>
@@ -2922,62 +2947,62 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>LAODICE e detto.</stage>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l>Mio re, che fai? Freme alla reggia intorno</l>
             <l>Un sedizioso stuol, che Siroe chiede.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>L'avrà, l'avrà. Già d'un mio fido al braccio</l>
             <l>La sua morte è commessa, e forse adesso</l>
             <l>Per le aperte ferite</l>
             <l>Fugge l'anima rea. Così gliel rendo.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l>Misera me, che intendo!</l>
             <l>E che facesti mai!</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Che feci? Io vendicai</l>
             <l>L'offesa maestà, l'amore offeso,</l>
             <l>I tuoi torti ed i miei.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l>Ah, che ingannato sei! Sospendi il cenno.</l>
             <l>Nell'amor tuo giammai</l>
             <l>Il prence non t'offese; io t'ingannai.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="I">Che dici!</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="F">Amore in vano</l>
             <l>Chiesi da Siroe, e il suo disprezzo volli</l>
             <l part="I">Con l'accusa punir.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Tu ancor tradirmi?</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l>Sì, Cosroe, ecco la rea:</l>
             <l>Questa s'uccida, e l'innocente viva.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Innocente chi vuol la morte mia?</l>
             <l>Viva chi t'innamora?</l>
             <l>E' reo di fellonia;</l>
             <l>E' reo perché ti piace, e vuo' che mora.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l>La vita d'un tuo figlio è sì gran dono</l>
             <l>Ch'io temeraria sono,</l>
@@ -2986,7 +3011,7 @@
             <l>Se placarti non sanno,</l>
             <l>Mai non m'amasti, e fu l'amore inganno.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Pur troppo, anima ingrata, io t'adorai.</l>
             <l>Fin della Persia al trono</l>
@@ -2996,20 +3021,20 @@
             <l>E pur, chi 'l crederia? nell'alma io sento</l>
             <l>Che sei gran parte ancor del mio tormento.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l>Dunque alle mie preghiere</l>
             <l>Cedi, o Signor. Sia salvo il prence, e poi</l>
             <l>Ucidimi se vuoi. Sarò felice</l>
             <l part="I">Se il mio sangue potrà...</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Parti, Laodice.</l>
             <l>Chiedendo la sua vita,</l>
             <l>Colpa gli accresci, e il tuo pregar m'irrìta.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <lg>
               <l>Se il caro figlio</l>
@@ -3032,13 +3057,13 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>COSROE e poi EMIRA</stage>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Vediam fin dove giunge</l>
             <l>Del mio destino il barbbaro rigore:</l>
             <l part="I">Tutto soffrir saprò...</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Rendi, o Signore,</l>
             <l>Libero il prence al popolo sdegnato.</l>
@@ -3047,11 +3072,11 @@
             <l>La plebe insana; e s'ode in un momento</l>
             <l>Di Siroe il nome in cento bocche e cento.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="I">Tanto crebbe il tumulto?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Ogni alma vile</l>
             <l>Divien superba. In mille destre e mille</l>
@@ -3060,33 +3085,33 @@
             <l>Fatti arditi e veloci,</l>
             <l>Somministrano l'armi ai più feroci.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Se ancor pochi momenti</l>
             <l>L'impeto si sospende, io più nol temo.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="I">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Già il fido Arasse</l>
             <l>Corse a svenar per mio comando il figlio.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>E potesti così... Revoca, oh Dio!</l>
             <l>La sentenza funesta:</l>
             <l>Nunzio n'andrò di tua pietade io stesso...</l>
             <l part="I">Porgimi il regio impronto.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">In van lo chiedi:</l>
             <l part="I">La sua morte mi giova.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Ah Cosroe, e come</l>
             <l>Così da te diverso? E dove or sono</l>
@@ -3104,11 +3129,11 @@
             <l>Un fatto sol tutti i tuoi pregi oscura.</l>
             <l>Deh con miglior consiglio...</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="I">Ma Siroe è un traditor.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Ma Siroe è figlio;</l>
             <l>Figlio che, di te degno,</l>
@@ -3124,31 +3149,31 @@
             <l>Né il sanguinoso lume</l>
             <l>Temea dell'elmo o le tremanti piume.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="I">Che mi rammenti!</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Ed or quel figlio istesso,</l>
             <l>Quello s'uccide: e chi l'uccide? Il padre.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="I">Oh Dio! più non resisto.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Ah se alcun premio</l>
             <l>Merita la mia fé, Siroe non mora.</l>
             <l>Vado? Risolvi. Or ora</l>
             <l>Trattener non potrai la sua ferita.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="I">Prendi, vola a salvarlo. <stage>(gli dà l'impronto regio</stage></l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">(Io torno in vita).</l>
           </sp>
@@ -3156,42 +3181,42 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>ARASSE e detti.</stage>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="I">Arasse! Oh Cieli!</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Ah, che turbato ha il ciglio!</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="I">Vive il prence?</l>
           </sp>
-          <sp>
+          <sp who="#arasse">
             <speaker>ARA.</speaker>
             <l part="M">Non vive.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="M">Ah, Siroe!</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Oh, figlio!</l>
           </sp>
-          <sp>
+          <sp who="#arasse">
             <speaker>ARA.</speaker>
             <l>Ei cadde al primo colpo; e l'alma grande</l>
             <l>Sul moribondo labbro</l>
             <l>Sol tanto s'arrestò, fin che mi disse:</l>
             <l>Difendi il padre; e poi fuggì dal seno.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Deh! soccorrimi, Idaspe, io vengo meno.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Tu, barbaro, tu piangi! E chi l'uccise?</l>
             <l>Scellerato, chi fu? Di chi ti lagni?</l>
@@ -3202,40 +3227,40 @@
             <l>Mostro di crudeltà, furia d'averno,</l>
             <l>Vergogna della Persia, odio del mondo.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Così mi parla Idaspe! E' stolto o finge?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Finsi fin or, ma solo</l>
             <l part="I">Per trafiggerti il cor.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Che mai ti feci?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Empio, che mi facesti?</l>
             <l>Lo sposo m'uccidesti;</l>
             <l>Per te padre non ho, non ho più trono.</l>
             <l>Io son la tua nemica, Emira io sono.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="I">Che sento!</l>
           </sp>
-          <sp>
+          <sp who="#arasse">
             <speaker>ARA.</speaker>
             <l part="M">Oh meraviglia!</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Adesso intendo</l>
             <l part="I">Chi mi sedusse il figlio.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">E' ver, ma in vano</l>
             <l>Di sedurlo tentai. Per mia vendetta</l>
@@ -3246,29 +3271,29 @@
             <l>Ch'ogni accusa è fallace.</l>
             <l>Va, pensaci; e, se puoi, riposa in pace.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Serba, Arasse, al mio sdegno,</l>
             <l part="I">Ma fra' ceppi costei.</l>
           </sp>
-          <sp>
+          <sp who="#arasse">
             <speaker>ARA.</speaker>
             <l part="F">Pronto ubbidisco.</l>
             <l part="I">Olà, deponi...</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Io stessa</l>
             <l>Disarmo il fianco mio. Prendi! <stage>(dà la spada ad Arasse, il quale, presala, entra e poi esce con guardie</stage> <stage>(a Cosroe)</stage> T'inganni</l>
             <l part="I">Se credi spaventarmi.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Ah! parti, ingrata:</l>
             <l>D'un'alma disperata</l>
             <l>L'odiosa compagnia troppo m'affligge.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Perché tu resti afflitto,</l>
             <l>basta la compagnia del tuo delitto. <stage>(parte con guardie</stage></l>
@@ -3277,17 +3302,17 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>COSROE ed ARASSE</stage>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Ove son? Che m'avvenne? E vivo ancora?</l>
           </sp>
-          <sp>
+          <sp who="#arasse">
             <speaker>ARA.</speaker>
             <l>Consolati, signor. Pensa per ora</l>
             <l>A conservarti il vacillante impero;</l>
             <l part="I">Pensa alla pace tua.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Pace non spero.</l>
             <l>Ho nemici i vassalli,</l>
@@ -3311,37 +3336,37 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>ARASSE, poi EMIRA con guardie e senza spada.</stage>
-          <sp>
+          <sp who="#arasse">
             <speaker>ARA.</speaker>
             <l>Ritorni il prigioniero. I miei disegni</l>
             <l>Secondino le stelle. Olà, partite. <stage>(al comando d'Arasse le guardie conducono fuori Emira, indi partono</stage></l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Che vuoi, d'un empio re più reo ministro?</l>
             <l part="I">Forse svenarmi?</l>
           </sp>
-          <sp>
+          <sp who="#arasse">
             <speaker>ARA.</speaker>
             <l part="F">No; vivi e ti serba,</l>
             <l>Illustre principessa, al tuo gran sposo.</l>
             <l part="I">Siroe respira ancor.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="M">Come!</l>
           </sp>
-          <sp>
+          <sp who="#arasse">
             <speaker>ARA.</speaker>
             <l part="F">La cura</l>
             <l>D'ucciderlo accettai, ma per salvalo.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Parché tacerlo al padre</l>
             <l part="I">Pentito dell'error?</l>
           </sp>
-          <sp>
+          <sp who="#arasse">
             <speaker>ARA.</speaker>
             <l part="F">Parve pietoso,</l>
             <l>Perché più nol temea: se vivo il crede,</l>
@@ -3351,20 +3376,20 @@
             <l>Quella dal nostro, e questa</l>
             <l>Solo dall'altrui danno in noi si desta.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="I">Siroe dov'è?</l>
           </sp>
-          <sp>
+          <sp who="#arasse">
             <speaker>ARA.</speaker>
             <l part="F">Fra' lacci</l>
             <l>Attende la sua morte.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="I">E nol salvasti ancor?</l>
           </sp>
-          <sp>
+          <sp who="#arasse">
             <speaker>ARA.</speaker>
             <l part="F">Prima degg'io</l>
             <l>I miei fidi raccorre,</l>
@@ -3373,17 +3398,17 @@
             <l>Si crede estinto, avremo</l>
             <l>Agio bastante a maturar l'impresa.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Andiamo. Ah vien Medarse.</l>
           </sp>
-          <sp>
+          <sp who="#arasse">
             <speaker>ARA.</speaker>
             <l>Non sbigottirti: io partirò; tu resta</l>
             <l>I disegni a scoprir dl prence infido.</l>
             <l part="I">Fìdati, non temer.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Di te mi fido. <stage>(parte Arasse</stage></l>
           </sp>
@@ -3391,64 +3416,64 @@
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>EMIRA e MEDARSE</stage>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="I">Che ti turba, o signor?</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">Tutto è in tumulto,</l>
             <l>E mi vuoi lieto, Idaspe?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>(Ignota ancor gli son). Dunque n'andiamo</l>
             <l part="I">Ad opporci a' ribelli.</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">Altro soccorso</l>
             <l>Chiede il nostro periglio. A Siroe io vado.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>E liberar vorresti</l>
             <l part="I">L'indegno autor de' nostri mali?</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">Eh tanto</l>
             <l part="I">Stolto non son; corro a svenarlo.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Intesi</l>
             <l part="I">Che già Siroe morì.</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">Ma per qual mano?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Non so. Dubbia e confusa</l>
             <l>Giunse a me la novella. E tu nol sai?</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="I">Nulla seppi.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Saranno</l>
             <l part="I">Popolari menzogne.</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">Estinto o vivo,</l>
             <l part="I">Siroe trovar mi giova.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Io ti precedo.</l>
             <l>De' tuoi disegni avrai</l>
@@ -3480,7 +3505,7 @@
           <head>SCENA NONA</head>
           <stage>Luogo angusto e racchiuso nel castello destinato a Siroe per carcere.</stage>
           <stage>SIROE, poi EMIRA</stage>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Son stanco, ingiusti numi,</l>
             <l>Di soffrir l'ira vostra. A che mi giova</l>
@@ -3489,35 +3514,35 @@
             <l>Così bilancia Astrea,</l>
             <l>O regge il caso, o l'innocenza è rea.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>(Arasse non mentì: vive il mio bene).</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Ed Emira fra tanti</l>
             <l>Rigorosi custodi a me si porta?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Questo impronto real fu la mia scorta.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="I">Come in tua man?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">L'ebbi da Cosroe istesso.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Se del mio fato estremo</l>
             <l>Scelse per te ministra il genitor,</l>
             <l>Per così bella morte</l>
             <l>Io perdono alla sorte il suo rigore.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Senti Emira qual sia...</l>
           </sp>
@@ -3525,36 +3550,36 @@
         <div type="scene">
           <head>SCENA DECIMA</head>
           <stage>MEDARSE e detti.</stage>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l>Non temete, o custodi: il re m'invia.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="I">(Oh numi!)</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">Idaspe è qui! Senza il tuo brando</l>
             <l part="I">Ti porti in mia difesa?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">In su l'ingresso</l>
             <l>Mel tolsero i custodi.</l>
             <l part="I">(Giungesse Arasse!) <stage>(guardando per la scena</stage></l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">Ad insultarmi ancora</l>
             <l>Qui vien Medarse! E in qual remoto lido</l>
             <l part="I">Posso celarmi a te?</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">Taci o t'uccido. <stage>(snuda la spada</stage></l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>E' lieve pena a un reo</l>
             <l>La sollecita morte. Ancor sospendi</l>
@@ -3565,95 +3590,95 @@
             <l>Contro di me fin nella reggia il ferro,</l>
             <l>Quasi a morte mi trasse.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>E tanto ho da soffrir?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l><stage>(guardando per la scena)</stage> (Giungesse Arasse!)</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>E Idaspe è così infido,</l>
             <l part="I">Che, unito a un traditor...</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">Taci, o t'uccido.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Uccidimi, crudel. Tolga la morte</l>
             <l>Tanti oggetti penosi agli occhi miei.</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="I">Mori... (Mi trema il cor).</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">(Soccorso, o dèi!)</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l>(Sento, né so che sia,</l>
             <l>Un incognito orror che mi trattiene).</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="I">Barbaro, a che t'arresti?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F"><stage>(come sopra)</stage> (E ancor non viene!)</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="I">(Chi mi rende sì vile?)</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Impallidisci!</l>
             <l>Dammi quel ferro: io svenerò l'indegno;</l>
             <l>Io svellerò quel core. Io solo, io solo</l>
             <l>Basto di tanti a vendicar gli oltraggi.</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="I">Prendi; 'usa in mia vece. <stage>(dà la spada ad Emira)</stage></l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">A questo segno</l>
             <l part="I">Ti sono odioso?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Or lo vedrai, superbo:</l>
             <l>Se speri alcun riparo...</l>
             <l>Difenditi, mia vita; ecco l'acciaro! <stage>(dà la spada a Siroe)</stage></l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l>Che fai, che dici, Idaspe? E mi tradisci,</l>
             <l>Quando a te m'abbandono?</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>No, più non sono Idaspe; Emira io sono.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="I">(Che sarà?)</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">Traditori!</l>
             <l>Verranno ad un mio grido</l>
             <l part="I">I custodi a punir.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">Taci, o t'uccido.</l>
           </sp>
@@ -3661,24 +3686,24 @@
         <div type="scene">
           <head>SCENA UNDICESIMA</head>
           <stage>ARASSE con guardie, e detti.</stage>
-          <sp>
+          <sp who="#arasse">
             <speaker>ARA.</speaker>
             <l part="I">Vieni, Siroe.</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">Ah, difendi,</l>
             <l part="I">Arasse, il tuo signor.</l>
           </sp>
-          <sp>
+          <sp who="#arasse">
             <speaker>ARA.</speaker>
             <l part="F">Siroe difendo.</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="I">Ah, perfido!</l>
           </sp>
-          <sp>
+          <sp who="#arasse">
             <speaker>ARA.</speaker>
             <l part="F"><stage>(a Siroe)</stage> Dipende</l>
             <l>La città dal tuo cenno. Andiam: consola</l>
@@ -3691,35 +3716,35 @@
         <div type="scene">
           <head>SCENA DODICESIMA</head>
           <stage>SIROE, EMIRA e MEDARSE</stage>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="I">Numi! ognun m'abbandona.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">Andiamo, o caro.</l>
             <l>Dell'amica fortuna</l>
             <l>Non si trascuri il dono.</l>
             <l>Siegui i miei passi; ecco la via del trono.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>E' pur vero, idol mio,</l>
             <l>Che non mi sei nemica? Oh Dio! che pena</l>
             <l part="I">Il crederti infedele!</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="F">E tu potesti</l>
             <l part="I">Dubitar di mia fé?</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l part="F">Perdona, o cara:</l>
             <l>Tanto in odio alle stelle oggi mi vedo,</l>
             <l>Che per mio danno ogn'impossibil credo.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <lg>
               <l>Ch'io mai vi possa</l>
@@ -3742,14 +3767,14 @@
         <div type="scene">
           <head>SCENA TREDICESIMA</head>
           <stage>SIROE e MEDARSE</stage>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l>Siroe, già so qual sorte</l>
             <l>Sovrasti a un traditor. Più della pena</l>
             <l>Mi sgomenta il delitto. Al soglio ascendi:</l>
             <l>Svenami pur; senza difesa or sono.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Prendi, vivi, t'abbraccio e ti perdono. <stage>(gli dà la spada</stage></l>
             <lg>
@@ -3800,38 +3825,38 @@
           <stage>Gran piazza di Seleucia con veduta del palazzo reale e con apparato magnifico, ordinato per la coronazione di Medarse, che poi serve per quella di Siroe. Nell'aprir della scena si vede una mischia tra i ribelli e le guardie reali, le quali sono rincalzate e fuggono.</stage>
           <stage>COSROE, EMIRA e SIROE, l'uno dopo l'altro con ispada nuda; indi ARASSE con tutto il popolo.</stage>
           <stage>COSROE, difendendosi da alcuni congiurati, cade.</stage>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Vinto ancor non son io.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Arrestatevi, amici; il colpo è mio.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Ferma, Emira, che fai? Padre, io son teco:</l>
             <l part="I">Non temer.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l part="M">Empio Ciel!</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Figlio, tu vivi!</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Io vivo, e posso ancora</l>
             <l part="I">Morir per tua difesa.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">E chi fu mai</l>
             <l part="I">Che serbò la tua vita?</l>
           </sp>
-          <sp>
+          <sp who="#arasse">
             <speaker>ARA.</speaker>
             <l part="F">Io la serbai.</l>
             <l>Libero il prence io volli,</l>
@@ -3840,7 +3865,7 @@
             <l>Non fa la mia discolpa,</l>
             <l part="I">Puoi la colpa punir.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l part="F">Che bella colpa!</l>
           </sp>
@@ -3848,52 +3873,52 @@
         <div type="scene">
           <head>SCENA ULTIMA</head>
           <stage>MEDARSE, LAODICE e detti.</stage>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="I">Padre!</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="M">Signor!</l>
           </sp>
-          <sp>
+          <sp who="#medarse">
             <speaker>MED.</speaker>
             <l part="F">Del mio fallir ti chiedo</l>
             <l part="I">Il perdono o la pena.</l>
           </sp>
-          <sp>
+          <sp who="#laodice">
             <speaker>LAOD.</speaker>
             <l part="F">Anch'io son rea;</l>
             <l>Vengo al giudice mio: l'incendio acceso</l>
             <l part="I">In gran parte io destai.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Siroe è l'offeso.</l>
           </sp>
-          <sp>
+          <sp who="#siroe">
             <speaker>SIR.</speaker>
             <l>Nulla Siroe rammenta. E tu, mio bene, <stage>(ad Emira</stage></l>
             <l>Deponi al fin lo sdegno. Ah, mal s'unisce</l>
             <l>Con la nemica mia la mia diletta:</l>
             <l>O scordati l'amore o la vendetta.</l>
           </sp>
-          <sp>
+          <sp who="#emira">
             <speaker>EMI.</speaker>
             <l>Più resister non posso. Io, con l'esempio</l>
             <l>Di sì bella virtù, l'odio abbandono.</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>E, perché quindi il trono</l>
             <l>Sia per voi di piacer sempre soggiorno,</l>
             <l part="I">Siroe sarà tuo sposo.</l>
           </sp>
-          <sp>
+          <sp who="#emira #siroe">
             <speaker>EMI. e SIR.</speaker>
             <l part="F">Oh lieto giorno!</l>
           </sp>
-          <sp>
+          <sp who="#cosroe">
             <speaker>COS.</speaker>
             <l>Ecco, Persia, il tuo re. Passi dal mio</l>
             <l>Su quel crin la corona: io stanco al fine</l>
@@ -3901,7 +3926,7 @@
             <l>Fu da' prim'anni inteso,</l>
             <l>Saprà con più vigor soffrirne il peso. <stage>(siegue l'incoronazione di Siroe</stage></l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>I suoi nemici affetti</l>

--- a/tei/metastasio-temistocle.xml
+++ b/tei/metastasio-temistocle.xml
@@ -76,6 +76,34 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="temistocle">
+            <persName>Temistocle</persName>
+          </person>
+          <person xml:id="neocle">
+            <persName>Neocle</persName>
+          </person>
+          <person xml:id="aspasia">
+            <persName>Aspasia</persName>
+          </person>
+          <person xml:id="sebaste">
+            <persName>Sebaste</persName>
+          </person>
+          <person xml:id="rossane">
+            <persName>Rossane</persName>
+          </person>
+          <person xml:id="serse">
+            <persName>Serse</persName>
+          </person>
+          <person xml:id="lisimaco">
+            <persName>Lisimaco</persName>
+          </person>
+          <personGrp xml:id="coro">
+            <name>Coro</name>
+          </personGrp>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT-Pavia</name>Digitalizzazione</change>
@@ -128,18 +156,18 @@
           <head>SCENA PRIMA</head>
           <stage>Deliziosa nel palazzo di Serse</stage>
           <stage>TEMISTOCLE e NEOCLE</stage>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="I">Che fai?</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="F">Lascia ch'io vada</l>
             <l>Quel superbo a punir. Vedesti, o padre,</l>
             <l>Come ascoltò le tue richieste? E quanti</l>
             <l part="I">Insulti mai dobbiam soffrir?</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Raffrena</l>
             <l>Gli ardori intempestivi. Ancor supponi</l>
@@ -155,7 +183,7 @@
             <l>Ogni cosa perdei: solo m'avanza,</l>
             <l>E il miglior mi restò, la mia costanza.</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l>Ormai, scusa, o signor, quasi m'irrìta</l>
             <l>Questa costanza tua. Ti vedi escluso</l>
@@ -171,7 +199,7 @@
             <l>Soffrir con questa pace</l>
             <l part="I">Perversità sì mostruosa?</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Ah! figlio,</l>
             <l> Nel cammin della vita</l>
@@ -188,32 +216,32 @@
             <l>Perciò diversi siamo:</l>
             <l>Quindi m'odia la patria, e quindi io l'amo.</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l>Se solo ingiusti, o padre,</l>
             <l>Fosser gli uomini teco, il doffrirei;</l>
             <l>Ma con te sono ingiusti ancor gli dèi.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="I">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="F">Di tua virtù premio si chiama</l>
             <l part="I">Questa misera sorte?</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">E, fra la sorte</l>
             <l>O misera o serena,</l>
             <l>Sai tu ben quale è premio e quale è pena?</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="I">Come?</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Se stessa affina</l>
             <l>La virtù ne' travagli, e si corrompe</l>
@@ -222,18 +250,18 @@
             <l>Brando, che inutil giace,</l>
             <l>Splendeva in guerra, è rugginoso in pace.</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l>Ma il passar da' trionfi</l>
             <l part="I">A sventure sì grandi...</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Invidieranno</l>
             <l>Forse l'età future,</l>
             <l>Più che i trionfi miei, le mie sventure.</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l>Sia tutto ver. Ma qual cagion ti guida</l>
             <l>A cercar nuovi rischi in questo loco?</l>
@@ -251,42 +279,42 @@
             <l>Deh! per pietà, signore,</l>
             <l part="I">Fuggiam...</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Taci: da lungi</l>
             <l>Veggo alcun appressar. Lasciami solo;</l>
             <l part="I">Attendimi in disparte.</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="F">E non poss'io</l>
             <l part="I">Teco, o padre, restar?</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">No: non mi fido</l>
             <l>Della tua tolleranza; e il nostro stato</l>
             <l part="I">Molta ne chiede.</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="M">Ora...</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="M">Ubbidisci.</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="F">Almeno</l>
             <l>In tempesta sì fiera</l>
             <l part="I">Abbi cura di te.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Va; taci e spera.</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <lg>
               <l>Ch'io speri! Ah! padre amato,</l>
@@ -305,59 +333,59 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>ASPASIA, SEBASTE, e TEMISTOCLE in disparte.</stage>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l>(Uom d'alto affare, al portamento, al volto</l>
             <l>Quegli mi par: sarà men rozzo. A lui</l>
             <l>Chieder potrò... Ma una donzella è seco,</l>
             <l part="I"> E par greca alle vesti).</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="M"><stage>(a Sebaste)</stage> Odi.</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="F"><stage>(in atto di partire)</stage>Non posso,</l>
             <l>Bella Aspasia, arrestarmi:</l>
             <l part="I">M'attende il re.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Solo un momento. E' vero</l>
             <l part="I">Questo barbaro editto?</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="F">E' ver. Chi a Serse</l>
             <l>Temistocle conduce estinto o vivo,</l>
             <l part="I">Grandi premi otterrà. <stage>(incamminato per partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">(Padre infelice!)</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l>Signor, dimmi, se lice <stage>(incontrando Sebaste</stage></l>
             <l>Tanto saper: può del gran Serse al piede</l>
             <l>Ciascuno andar? Quando è permesso, e dove?</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="I">(Come il padre avvertir?)</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="F"><stage>(a Temistocle con disprezzo)</stage> Chiedilo altrove.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l>Se forse errai, cortese</l>
             <l>M'avverti dell'error. Stranier son io</l>
             <l part="I">E de' costumi ignaro.</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="F">Aspasia, addio. <stage>(dopo aver guardato Temistocle come sopra, parte</stage></l>
           </sp>
@@ -365,56 +393,56 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>TEMISTOCLE ed ASPASIA.</stage>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="I">(Che fasto insano!)</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">(A queste sponde, o numi,</l>
             <l part="I">Deh! non guidate il genitor).</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">(Si cerchi</l>
             <l>Da questa greca intanto</l>
             <l>Qualche lume miglior). Gentil donzella,</l>
             <l part="I">Se il Ciel... (Stelle, che volto!)</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">(Eterni dèi!</l>
             <l>E' il genitore, o al genitor somiglia).</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="I">Di'...</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="M">Temistocle!</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="M">Aspasia!</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="M">Ah, padre!</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F"><stage>(s'abbracciano)</stage> Ah, figlia!</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="I">Fuggi.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="M">E tu vivi?</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Ah! fuggi,</l>
             <l>Caro mio genitor. Qual ti condusse</l>
@@ -423,7 +451,7 @@
             <l>Premi ha proposti... Ah! non tardar: potrebbe</l>
             <l part="I">Scoprirti alcun.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Mi scoprirai con questo</l>
             <l>Eccessivo timor. Di': quando in Argo</l>
@@ -431,29 +459,29 @@
             <l>A' tumulti guerrieri, il tuo naviglio</l>
             <l part="I">Non si perdé?</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Sì, naufragò, né alcuno</l>
             <l>Campò dal mare. Io, sventurata, io sola</l>
             <l>Alla morte rapita,</l>
             <l>Con la mia libertà comprai la vita.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="I">Come?</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Un legno nemico all'onde... oh Dio!</l>
             <l>Lo spavento m'agghiaccia... all'onde insane</l>
             <l>M'involò semiviva;</l>
             <l>Prigioniera mi trasse a questa riva.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="I">E' noto il tuo natal?</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">No: Serse in dono</l>
             <l>Alla real Rossane</l>
@@ -462,7 +490,7 @@
             <l>Stancai per rivederti! Ah, non temei</l>
             <l>Sì funesti adempiti i voti miei!</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l>Rasserenati, o figlia: assai vicini</l>
             <l>Han fra loro i confini</l>
@@ -471,7 +499,7 @@
             <l>Prender la nostra sorte un ordin nuovo:</l>
             <l>Già son meno infelice or che ti trovo.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l>Ma qual mi trovi! in servitù. Qual vieni!</l>
             <l>Solo, proscritto e fuggitivo. Ah! dove,</l>
@@ -482,7 +510,7 @@
             <l>E il terren ti sostiene! e oziosi ancora</l>
             <l part="I">I fulmini di Giove...</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Olà, più saggia</l>
             <l>Regola, Aspasia, il tuo dolor. Mia figlia</l>
@@ -490,25 +518,25 @@
             <l>Della patria bramar; né un solo istante</l>
             <l>Tollero in te sì scellerata idea.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l>Quando tu la difendi, ella è pur rea.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="I">Mai più...</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Parti una volta,</l>
             <l part="I">Fuggi da questo ciel.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Di che paventi,</l>
             <l part="I">Se ignoto a tutti...?</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Ignoto a tutti! E dove</l>
             <l>E' Temistocle ignoto? Il luminoso</l>
@@ -518,34 +546,34 @@
             <l>In Susa è giunto. A' suoi seguaci, a lui</l>
             <l part="I">Chi potrebbe celar...</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Dimmi: sapresti</l>
             <l part="I">A che venga e chi sia?</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">No, ma fra poco</l>
             <l>Il re l'ascolterà. Puoi quindi ancora</l>
             <l>Il popolo veder, che già s'affretta</l>
             <l part="I">Al destinato loco.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Ognun che il brami</l>
             <l part="I">Andar vi può?</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="M">Sì.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Dunque resta: io volo</l>
             <l>A render pago il desiderio antico,</l>
             <l>Che ho di mirar d'appresso il mio nemico.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l>Ferma! misera me! che tenti? Ah! vuoi</l>
             <l>Ch'io muoia di timor? Cambia, se m'ami,</l>
@@ -555,7 +583,7 @@
             <l> Che non soffri oltraggiata,</l>
             <l>Che ami nemica e che difendi ingrata...</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l>Vieni al mio sen, diletta Aspasia. In questi</l>
             <l>Palpiti tuoi d'un'amorosa figlia</l>
@@ -580,51 +608,51 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>ASPASIA e poi ROSSANE</stage>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l>Ah! non ho fibra in seno</l>
             <l part="I">Che tremar non mi senta.</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="F">Aspasia, io deggio</l>
             <l>Di te lagnarmi. I tuoi felici eventi</l>
             <l>Perché celar? Se non amica, almeno</l>
             <l part="I">Ti sperai più sincera.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">(Ah! tutto intese.</l>
             <l part="I">Temistocle è scoperto).</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="F">Impallidisci!</l>
             <l>Non parli! E' dunque ver? Sì gran nemica</l>
             <l part="I">Ho dunque al fianco mio?</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Deh! principessa...</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l>Taci, ingrata! Io ti scopro</l>
             <l>Tutta l'anima mia, di te mi fido;</l>
             <l>E tu m'insidii intanto</l>
             <l part="I">Di Serse il cor!</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="M">(D'altro ragiona).</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="F">E' questa</l>
             <l> De' benefizi miei</l>
             <l part="I">La dovuta mercé?</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Rossane, a torto</l>
             <l>E m'insulti e ti sdegni. Il cor di Serse</l>
@@ -632,7 +660,7 @@
             <l>Ignota a me non sono,</l>
             <l>Né van le mie speranze insino al trono.</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l>Non simular. Mille argomenti ormai</l>
             <l>Ho di temer. Da che ti vede, io trovo</l>
@@ -643,38 +671,38 @@
             <l>Al suo fallo una scusa,</l>
             <l>Della sua tiepidezza il regno accusa.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l>Pietoso e non amante</l>
             <l part="I">Forse è con me.</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="F">Ciò, che pietà rassembra,</l>
             <l part="I">Non è sempre pietà.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Troppa distanza</l>
             <l part="I">V'è fra Serse ed Aspasia.</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="F">Assai maggiori</l>
             <l part="I">Ne agguaglia Amor.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="M">Ma una straniera...</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="F">Appunto</l>
             <l>Questo è il pregio ch'io temo. Han picciol vanto</l>
             <l>Le gemme là dove n'abbonda il mare:</l>
             <l>Son tesori fra noi, perché son rare.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l>Rossane, per pietà, non esser tanto</l>
             <l>Ingegnosa a tuo danno. A te fai torto,</l>
@@ -685,7 +713,7 @@
             <l>Porto nel core impresso; e Aspasia ha un core</l>
             <l>Che ignora ancor come si cambi amore.</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="I">Tu dunque...</l>
           </sp>
@@ -693,54 +721,54 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>SEBASTE e dette.</stage>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="F">Principessa,</l>
             <l> Se vuoi mirarlo, or l'orator d'Atene</l>
             <l part="I">Al re s'invia.</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="M">Verrò fra poco.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F"><stage>(a Sebaste)</stage> Ascolta.</l>
             <l>E' ancor noto il suo nome?</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="I">Lisimaco d'Egisto.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">(Eterni dèi!</l>
             <l part="I">Questi è il mio ben). Ma perché venne?</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="F">Intesi</l>
             <l part="I">Che Temistocle cerchi.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">(Ancor l'amante</l>
             <l>Nemico al padre mio! Dunque fa guerra</l>
             <l>Contro un misero sol tutta la terra).</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l>Precedimi, Sebaste. <stage>(parte Sebaste)</stage> Aspasia, addio.</l>
             <l part="I">Deh! non tradirmi.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Ah! scaccia</l>
             <l>Questa dal cor gelosa cura. E come</l>
             <l>Può mai trovar ricetto</l>
             <l>In un'alma gentil sì basso affetto?</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <lg>
               <l>Basta dir ch'io sono amante,</l>
@@ -784,31 +812,31 @@
           <head>SCENA SETTIMA</head>
           <stage>Luogo magnifico destinato alle pubbliche udienze. Trono sublime da un lato. Veduta della città in lontano.</stage>
           <stage>TEMISTOCLE e NEOCLE: indi SERSE e SEBASTE con numeroso séguito.</stage>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l>Padre, dove t'inoltri? Io non intendo</l>
             <l>Il tuo pensier. Temo ogni sguardo, e parmi</l>
             <l>Che ognun te sol rimiri. Ecco i custodi</l>
             <l part="I">E il re: partiam.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Fra il popolo confusi</l>
             <l part="I">Resteremo in disparte.</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="F">E' il rischio estremo.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="I">Più non cercar: taci una volta.</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="F">(Io tremo). <stage>(si ritirano da un lato</stage></l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l>Olà! venga e s'ascolti</l>
             <l>Il greco ambasciador. <stage>(parte una guardia</stage> Sebaste, e ancora</l>
@@ -816,13 +844,13 @@
             <l>Allettano sì poco</l>
             <l part="I">Il mio favor, le mie promesse?</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="F">Ascoso</l>
             <l>Lungamente non fia: son troppi i lacci</l>
             <l part="I">Tesi a suo danno.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Io non avrò mai pace</l>
             <l> Fin che costui respiri. Egli ha veduto</l>
@@ -837,19 +865,19 @@
             <l>Si può vantar? No, non fia vero: avrei</l>
             <l>Questa sempre nel cor smania inquieta. <stage>(va sul trono</stage></l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="I">(Udisti?)</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="M">(Udii).</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="M">(Dunque fuggiam).</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">(T'accheta).</l>
           </sp>
@@ -857,7 +885,7 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>LISIMACO con séguito di Greci, e detti.</stage>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l>Monarca eccelso, in te, nemico ancora,</l>
             <l>Non solo Atene onora</l>
@@ -865,28 +893,28 @@
             <l>Grande al par dell'impero, un dono attende</l>
             <l>Maggior di tutti i doni.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l>Pur che pace non sia, siedi ed esponi. <stage>(Lisimaco siede</stage></l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="I">(E' Lisimaco?) <stage>(a Temistocle</stage></l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="M">(Sì). <stage>(a Neocle</stage></l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="F">(Potria giovarti</l>
             <l part="I">Un amico sì caro).</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">(O taci o parti).</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l>L'opprimer chi disturbi</l>
             <l>Il pubblico riposo, è de' regnanti</l>
@@ -899,16 +927,16 @@
             <l>Che cerca Atene. In questa reggia il crede;</l>
             <l>Pretenderlo potrebbe; in dono il chiede.</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l>(Oh domanda crudele!</l>
             <l part="I">Oh falso amico!)</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">(Oh cittadin fedele!)</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l>Esaminar per ora,</l>
             <l>Messagger, non vogl'io qual sia la vera</l>
@@ -927,48 +955,48 @@
             <l>La greca sorte incerta;</l>
             <l>E' ancor la via d'Atene a Serse aperta.</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l>Ma di qual uso a voi</l>
             <l part="I">Temistocle esser può?</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Vi sarà noto,</l>
             <l part="I">Quando si trovi in mio poter.</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l part="F">Fin ora</l>
             <l part="I">Dunque non v'è?</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Né, se vi fosse, a voi</l>
             <l part="I">Ragion non renderei.</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l part="F">Troppo t'accieca</l>
             <l>L'odio, o signor, del greco nome; e pure</l>
             <l part="I">Se in pacifico nodo...</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Olà! di pace</l>
             <l part="I">Ti vietai di parlarmi.</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l part="M">E' ver, ma...</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Basta!</l>
             <l>Intesi i sensi tuoi;</l>
             <l>La mia mente spiegai: partir già puoi.</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <lg>
               <l>Io partirò; ma, tanto</l>
@@ -987,7 +1015,7 @@
         <div type="scene">
           <head>SCENA NONA</head>
           <stage>SERSE, SEBASTE, TEMISTOCLE e NEOCLE</stage>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l>Temistocle fra' Persi</l>
             <l>Credon, Sebaste, i Greci? Ah! cerca e spia</l>
@@ -996,112 +1024,112 @@
             <l>l'odio, che il cor mi strugge,</l>
             <l part="I">Calmar potrebbe.</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="F">(E il genitor non fugge!)</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="I">(Ecco il punto: all'impresa!) <stage>(si fa strada fra le guardie</stage></l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="F">(Ah, padre! ah, senti!)</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="I">Potentissimo re. <stage>(presentandosi dinanzi al trono</stage></l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="F">Che ardir! <stage>(alle guardie)</stage> Quel folle</l>
             <l>Dal trono s'allontani.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l>Non oltragggiano i numi i voti umani.</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="I">Parti.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">No, no: s'ascolti.</l>
             <l part="I">Parla, stranier: che vuoi?</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Contro la sorte,</l>
             <l>Cerco un asilo, e non lo spero altrove:</l>
             <l>Difendermi non può che Serse o Giove.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="I">Chi sei?</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="M">Nacqui in Atene.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">E greco ardisci</l>
             <l part="I">Di presentarti a me?</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Sì. Questo nome</l>
             <l>Qui è colpa, il so; ma questa colpa è vinta</l>
             <l>Da un gran merito in me. Serse, tu vai</l>
             <l>Temistocle cercando: io tel recai.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="I">Temistocle! Ed è vero?</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">A' regi innanzi</l>
             <l part="I">Non si mentisce.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Un merito sì grande</l>
             <l>Premio non v'è che ricompensa. Ah! dove,</l>
             <l>Quest'oggetto dov'è dell'odio mio?</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="I">Già su gli occhi ti sta.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="M">Qual è?</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Son io.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="I">Tu!</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="M">Sì.</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="M">(Dove m'ascondo?) <stage>(parte</stage></l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">E così poco</l>
             <l>Temi dunque i miei sdegni?</l>
             <l part="I">Dunque...</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Ascolta e risolvi. Eccoti innanzi</l>
             <l>De' giuochi della sorte</l>
@@ -1127,7 +1155,7 @@
             <l>Vittima volontaria a questi lidi.</l>
             <l>Pensaci, e poi del mio destin decidi.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l>(Giusti dèi! chi mai vide</l>
             <l>Anima più sicura?</l>
@@ -1143,7 +1171,7 @@
             <l>S'armeranno i miei regni; e quindi appresso</l>
             <l>Fia Temistiocle e Serse un nome istesso.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l>Ah! signor, fin ad ora</l>
             <l>Un eccesso parea la mia speranza,</l>
@@ -1153,7 +1181,7 @@
             <l>Sempre saran minori</l>
             <l>La mia vita, il mio sangue, i miei suddori.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l>Sia Temistocle amico</l>
             <l>La mia sola mercé. Le nostre gare</l>
@@ -1196,7 +1224,7 @@
         <div type="scene">
           <head>SCENA UNDICESIMA</head>
           <stage>ASPASIA e poi ROSSANE.</stage>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l>Dove mai? Chi m'addita,</l>
             <l>Misera! il genitor? Nol veggo, e pure</l>
@@ -1205,40 +1233,40 @@
             <l>Pietà, soccorso! Il padre mio difendi</l>
             <l part="I">Dagli sdegni di Serse.</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="M">Il padre!</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Oh Dio!</l>
             <l>Io son dell'infelice</l>
             <l>Temistocle la figlia.</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="I">Tu! come?</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Or più non giova</l>
             <l>Nasconder la mia sorte.</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l>(Aimè! la mia rival si fa più forte).</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l>Deh! generosa implora</l>
             <l part="I">Grazia per lui.</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="F">Grazia per lui! Tu dunque</l>
             <l part="I">Tutto non sai.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">So che all'irato Serse</l>
             <l>Il padre si scoperse: il mio germano,</l>
@@ -1246,7 +1274,7 @@
             <l>E il racconto funesto</l>
             <l part="I">Ascoltai dal suo labbro.</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="F">Or odi il resto.</l>
             <l part="I">Sappi...</l>
@@ -1255,39 +1283,39 @@
         <div type="scene">
           <head>SCENA DODICESIMA</head>
           <stage>SEBASTE e dette.</stage>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="F">Aspasia, t'affretta:</l>
             <l>Serse ti chiama a sé. Che sei sua figlia</l>
             <l>Temistocle or gli disse; e mai più lieta</l>
             <l part="I">Novella il re non ascoltò.</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="F">(Che affanno!)</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l>Forse l'odio di Serse</l>
             <l part="I">Più moderato almen.</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="F">L'odio! Di lui</l>
             <l part="I">Temistocle è l'amor.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Come! Poc'anzi</l>
             <l part="I">Il volea morto.</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="F">Ed or l'abbraccia, il chiama</l>
             <l>La sua felicità, l'addita a tutti,</l>
             <l part="I">Non parla che di lui.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Rossane, addio:</l>
             <l>Non so, per troppa gioia, ove son io.</l>
@@ -1308,27 +1336,27 @@
         <div type="scene">
           <head>SCENA TREDICESIMA</head>
           <stage>ROSSANE e SEBASTE</stage>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l>(Già Rossane è gelosa:</l>
             <l part="I">Spera, o mio cor).</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="F">Che mai vuol dir, Sebaste,</l>
             <l>Questa di Serse impaziente cura</l>
             <l part="I">Di parlar con Aspasia?</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="F">Io non ardisco</l>
             <l part="I">Dirti i sospetti miei.</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="M">Ma pur?</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="F">Mi sembra</l>
             <l>Che Serse l'ami. Allor che d'essa intese</l>
@@ -1336,28 +1364,28 @@
             <l>Gioia gli scintillò, che del suo core</l>
             <l part="I">Il segreto tradì.</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="F">Va, non è vero</l>
             <l part="I">Son sogni tuoi.</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="F">Lo voglia il Ciel; ma giova</l>
             <l part="I">Sempre il peggio temer.</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="F">Numi! e in tal caso</l>
             <l part="I">Che far degg'io?</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="F">Che? Vendicarti. A tanta</l>
             <l>Beltà facil sarebbe. E' un gran diletto</l>
             <l>D'un fido amator punir l'inganno.</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l>Consola, è ver, ma non compensa il danno.</l>
             <lg>
@@ -1409,7 +1437,7 @@
           <head>SCENA PRIMA</head>
           <stage>Ricchissimi appartamenti destinati da Serse a Temistocle. Vasi all'intorno ricolmi d'oro e di gemme</stage>
           <stage>TEMISTOCLE, poi  NEOCLE</stage>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l>Eccoti in altra sorte; ecco cambiato,</l>
             <l>Temistocle, il tuo stato. Or or, di tutto</l>
@@ -1425,7 +1453,7 @@
             <l>Che favola è la vita;</l>
             <l>E la favola mia non è compita.</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l>Splendon pure una volta,</l>
             <l>Amato genitor, fauste le stelle</l>
@@ -1441,7 +1469,7 @@
             <l>Passar d'Alcide i segni,</l>
             <l>I regi debellar, dar legge a' regni.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l>Non tanta ancor, non tanta</l>
             <l>Fiducia, o Neocle. Or nell'ardire ecced,</l>
@@ -1456,11 +1484,11 @@
             <l>Prima ti tenne oppresso,</l>
             <l>Fu vizio allor, saria virtude adesso.</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l>Ma che temer dobbiamo?</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l>Ma in che dobbiam fidarci? In quei tesori?</l>
             <l>D'un istante son dono:</l>
@@ -1468,48 +1496,48 @@
             <l>Che acquistar già mi vedi? Eh! non son miei:</l>
             <l>Vengon con la fortuna, e van con lei.</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l>Del magnanimo Serse</l>
             <l part="I">Basta il favore a sostenerci.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">E basta</l>
             <l part="I">L'ira di Serse a riunarne.</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="F">E' troppo</l>
             <l part="I">Giusto e prudente il re.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Ma un re sì grande</l>
             <l>Tutto veder non può. Talor s'inganna,</l>
             <l>Se un malvagio il circonda;</l>
             <l>E di malvagi ogni terreno abbonda.</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l>Superior d'ogni calunnia ormai</l>
             <l part="I">La tua virtù ti rese.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Anzi là, dove</l>
             <l>Il suo merto ostentar ciascun procura,</l>
             <l>La virtù, che più splende, è men sicura.</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="I">Ah qual!...</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="M">Parti: il re vien.</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="F">Qual ne' tuoi detti</l>
             <l>Magia s'asconde! Io mi credea felice;</l>
@@ -1532,15 +1560,15 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>SERSE e TEMISTOCLE</stage>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="I">Temistocle.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="M">Gran re.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Di molto ancora</l>
             <l>Debitor ti son io. Mercé promisi</l>
@@ -1548,22 +1576,22 @@
             <l>L'ottenni: or le promesse</l>
             <l part="I">Vengo a compir.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Né tanti doni e tanti</l>
             <l part="I"> Bastano ancor?</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">No; di sì grande acquisto</l>
             <l>Onde superbo io sono,</l>
             <l>Parmi scarsa mercé qualunque dono.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="I">E vuoi...</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Vuo' della sorte</l>
             <l>Corregger l'ingiustizia e sollevarti</l>
@@ -1573,7 +1601,7 @@
             <l>Del giusto amore, onde il tuo merto onora,</l>
             <l>Prove darà più luminose ancora.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l>Deh! sia più moderato</l>
             <l>L'uso, o signor, del tuo trionfo; e tanto</l>
@@ -1581,7 +1609,7 @@
             <l>Temistocle arrossir. Per te fin ora</l>
             <l part="I">Che feci?</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Che facesti! E ti par poco</l>
             <l>Credermi generoso?</l>
@@ -1590,26 +1618,26 @@
             <l>Rendere a' regni miei</l>
             <l>In Temistocle sol quanto perdei?</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l>Ma le ruine, il sangue,</l>
             <l part="I">Le stragi, onde son reo...</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Tutto compensa</l>
             <l>La gloria di poter nel mio nemico</l>
             <l>Onorar la virtù. L'onta di pria</l>
             <l>Fu della sorte; e questa gloria è mia.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l>Oh magnanimi sensi,</l>
             <l>Degni d'un'alma a sostener di Giove</l>
             <l>Le veci eletta! oh fortunati regni</l>
             <l part="I">A tal re sottoposti!</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Odimi. Io voglio</l>
             <l>Della proposta gara</l>
@@ -1624,18 +1652,18 @@
             <l>Poi tenterem. Di soggiogare io spero,</l>
             <l>Con Temistocle al fianco, il mondo intero.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l>E a questo segno arriva,</l>
             <l part="I">Generoso mio re...</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Va, ti prepara</l>
             <l>A novelli trofei. Diran poi l'opre</l>
             <l part="I">Ciò che dirmmi or vorresti.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Amici dèi,</l>
             <l>Chi tanto a voi somiglia</l>
@@ -1659,7 +1687,7 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>SERSE, poi ROSSANE, indi SEBASTE</stage>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l>E' ver che opprime il peso</l>
             <l>D'un diadema real, che mille affanni</l>
@@ -1686,27 +1714,27 @@
             <l>Tornar nol veggo. Eccolo forse... Oh stelle!</l>
             <l part="I">E' Rossane. Si evìti. <stage>(partendo</stage></l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="F">Ove t'affretti,</l>
             <l part="I">Signor? fuggi da me?</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">No; in altra parte</l>
             <l part="I">Grave cura mi chiama.</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="F">E pur fra queste</l>
             <l>Tue gravi cure avea Rossane ancora</l>
             <l part="I">Luogo una volta.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="M">Or son più grandi.</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="F">E' vero;</l>
             <l>Lo comprendo ancor io: veggo di quanto</l>
@@ -1717,69 +1745,69 @@
             <l>Né mi fa meraviglia,</l>
             <l part="I">Fra' meriti del padre, e...</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Principessa,</l>
             <l part="I">Addio.</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="M">Senti. Ah! crudel!</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">(Si disinganni</l>
             <l>La sua speranza). Odi, Rossane: è tempo</l>
             <l>Ch'io ti spieghi una volta i miei pensieri.</l>
             <l part="I">Sappi...</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="F">Signor, di nuovo</l>
             <l>Chiede il greco orator che tu l'ascolti.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="I">Che! non partì?</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="F">No. Seppe</l>
             <l>Che Temistocle è in Susa, e grandi offerte</l>
             <l part="I">Farà per ottenerlo.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Or troppo abusa</l>
             <l>Della mia tolleranza: udir nol voglio:</l>
             <l part="I">Parta, ubbidisca. <stage>(Sebaste s'incammina</stage></l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="M">(E' amor quell'ira).</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F"><stage>(a Sebaste)</stage> Ascolta:</l>
             <l>Meglio pensai. Va, l'introduci. Io voglio</l>
             <l part="I">Punirlo in altra guisa. <stage>(parte Sebaste</stage></l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="F">I tuoi pensieri</l>
             <l part="I">Spiegami al fin.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="M">Tempo or non v'è. <stage>(volendo partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="F">Prometti</l>
             <l>Pria con me di spiegarti,</l>
             <l>E poi, crudel, non mi rispondi e parti!</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <lg>
               <l>Quando parto e non rispondo,</l>
@@ -1796,29 +1824,29 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>ROSSANE e poi ASPASIA</stage>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l>Non giova lusingarsi;</l>
             <l>Trionfa Aspasia. Ecco l'altera. E quale</l>
             <l>E' il gran pregio che adora</l>
             <l part="I">Serse in costei? <stage>(considerando Aspasia</stage></l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Sono i tuoi dubbi al fine</l>
             <l part="I">Terminati, o Rossane?</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="F"><stage>(come sopra)</stage> (Io non ritrovo</l>
             <l>Di nodi sì tenaci</l>
             <l part="I">Tanta ragion).</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Che fai? Mi guardi e taci!</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <lg>
               <l>Ammiro quel volto,</l>
@@ -1837,19 +1865,19 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>ASPASIA, poi LISIMACO</stage>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l>Che amari detti! O gelosia tiranna,</l>
             <l>Come tormenti un cor! Ti provo, oh Dio!</l>
             <l part="I">Per Lisimaco anch'io.</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l part="F">(Solo un istante</l>
             <l>Bramerei rivederla, e poi... M'inganno?</l>
             <l part="I">Ecco il mio ben).</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Non può ignorar ch'io viva:</l>
             <l>Troppo pubblico è il caso. Ah! d'altra fiamma</l>
@@ -1857,47 +1885,47 @@
             <l>Ancor di lui scordarmi? Ah! sì, disciolta</l>
             <l part="I">Da questi lacci ormai... <stage>(volendo partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l part="F">Mia vita, ascolta.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="I">Chi sua vita mi chiama?... Oh stelle!</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l part="F">Il tuo</l>
             <l>Lisimaco fedele. A rivederti</l>
             <l>Pur, bella Aspasia, il mio destin mi porta.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l>Aspasia! Io non son quella: Aspasia è morta.</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l>So che la fama il disse;</l>
             <l>So che mentì; so per quai mezzi il Cielo</l>
             <l part="I">Te conservò.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Già che tant'oltre sai,</l>
             <l>Che per te più non vivo ancor saprai.</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l>Deh! perché mi trafiggi</l>
             <l part="I">Sì crudelmente il cor?</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Merita in vero</l>
             <l>Più di riguardo un sì fedele amico,</l>
             <l>Un sì tenero amante. Ingrato! e ardisci,</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l>Nemico al genitore,</l>
             <l>Venirmi innanzi e ragionar d'amore?</l>
@@ -1906,54 +1934,54 @@
             <l>La patria ad ubbidir; ma in ogni istante</l>
             <l>Contrasta in me col cittadin l'amante.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="I">Scordati l'uno e l'altro.</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l part="F">Uno non deggio,</l>
             <l>L'altro non posso; e, senza aver mai pace,</l>
             <l>Procuro ognor quel che ottener mi spiace.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="I">Va, lode al Ciel, nulla ottenesti.</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l part="F">Oh Dio!</l>
             <l>Pur troppo, Aspasia, ottenni. Ah! perdonate,</l>
             <l>Se al dolor del mio bene</l>
             <l>Donai questo sospiro, o dèi d'Atene.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="I">(Io tremo!) E che ottenesti?</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l part="F">Il re concede</l>
             <l part="I">Temistocle alla Grecia.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="M">Aimè!</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l part="F">Pur ora</l>
             <l>Rimandarlo promise, e la promessa</l>
             <l part="I">Giurò di mantener.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Misera! (Ah! Serse</l>
             <l>Punisce il mio rifiuto).</l>
             <l>Lisimaco, pietà. Tu sol, tu puoi</l>
             <l part="I">Salvarmi il padre.</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l part="F">E per qual via? M'attende</l>
             <l>Già forse il re dove adunati sono</l>
@@ -1961,71 +1989,71 @@
             <l>Consegnarlo vorrà. Pensa qual resti</l>
             <l part="I">Arbitrio a me.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Tutto, se vuoi. Concedi</l>
             <l part="I">Che una fuga segreta...</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l part="F">Ah! che mi chiedi?</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l>Chiedo da un vero amante</l>
             <l>Una prova d'amor. Non puoi scusarti.</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l>Oh Dio! fui cittadin prima d'amarti.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l>Ed obbliga tal nome</l>
             <l>D'un innocente a procurar lo scempio?</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l>Io non lo bramo: il mio dovere adempio.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l>E ben, facciamo entrambi</l>
             <l>Dunque il nostro dovere: anch'io lo faccio.</l>
             <l part="I">Addio.</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l part="M">Dove t'affretti?</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">A Serse in braccio.</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l part="I">Come!</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Egli m'ama, e ch'io soccorra un padre</l>
             <l>Ogni ragion consiglia.</l>
             <l>Anch'io prima d'amarti ero già figlia.</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l>Senti. Ah! non dare al mondo</l>
             <l>Questo d'infedeltà barbaro esempio.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l>Sieguo il tuo stile: il mio dovere adempio.</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l>Ma sì poco ti costa...</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l>Mi costa poco? Ah, sconoscente! Or sappi</l>
             <l>Per tuo rossor che, se consegna il padre,</l>
@@ -2034,11 +2062,11 @@
             <l>Nulla costa il lasciarti in abbandono,</l>
             <l>Per non lasciarti ha ricusato il trono.</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l part="I">Che dici, anima mia!</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Tutto non dissi:</l>
             <l>Senti, crudel. Mille ragioni, il sai,</l>
@@ -2049,26 +2077,26 @@
             <l>Vorrei, ma non ho tanto</l>
             <l>Valor che basti a trattenere il pianto.</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l>Deh! non pianger così: tutto vogl'io,</l>
             <l>Tutto... (Ah, che dico!) Addio, mia vita, addio.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="I">Dove?</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l part="F">Fuggo un assalto</l>
             <l part="I">Maggior di mia virtù.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Se di pietade</l>
             <l>Ancor qualche scintilla...</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l>Addio, non più: già il mio dover vacilla.</l>
             <lg>
@@ -2108,12 +2136,12 @@
           <head>SCENA SETTIMA</head>
           <stage>Grande e ricco padiglione aperto da tutti i lati, sotto di cui trono alla destra, ornato d'insegne militari. Veduta di vasta pianura, occupata dall'esercito persiano disposto in ordinanza.</stage>
           <stage>SERSE e SEBASTE con séguito di satrapi, guardie e popolo; poi TEMISTOCLE, indi LISIMACO con Greci.</stage>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l>Sebaste, ed è pur vero! Aspasia dunque</l>
             <l part="I">Ricusa le mie nozze?</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="F">E', al primo invito,</l>
             <l>Ritrosa ogni beltà. Forse in segreto</l>
@@ -2121,35 +2149,35 @@
             <l>Si reca ad onta, ed a spiegarsi un cenno</l>
             <l part="I">Brama del genitor.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="M">L'avrà.</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="F">Già viene</l>
             <l>L'esule illustre e l'orator d'Atene.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l>Il segno a me del militare impero</l>
             <l part="I">Fa che si rechi.</l>
           </sp>
           <stage>(Serse va in trono, servito da Sebaste. Uno de' satrapi porta sopra bacile d'oro il bastone del comando, e lo sostiene vicino a lui. Intanto nello approssimarsi, non udito da Serse, dice Lisimaco a Temistocle quanto siegue</stage>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l part="F">(A qual funesto impiego,</l>
             <l>Amico, il Ciel mi destinò! Con quanto</l>
             <l part="I">Rossor...)</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">(Di che arrossisci? Io non confondo</l>
             <l>L'amico e il cittadin. La patria è un nume,</l>
             <l>A cui sacrificar tutto è permesso:</l>
             <l>Anch'io, nel caso tuo, farei l'istesso).</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l>Temistocle, t'appressa. In un raccolta</l>
             <l>Ecco de' miei guerrieri</l>
@@ -2161,12 +2189,12 @@
             <l>Premia, pugna, trionfa. E' a te fidato</l>
             <l>L'onor di Serse e della Persia il fato.</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l>(Dunque il re mi deluse,</l>
             <l part="I">O Aspasia lo placò).</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Del grado illustre,</l>
             <l>Monarca eccelso, a cui mi veggo eletto,</l>
@@ -2183,7 +2211,7 @@
             <l>In questa guisa, o Serse,</l>
             <l part="I"> Temistocle consegni?</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Io sol giurai</l>
             <l>Di rimandarlo in Grecia. Odi se adempio</l>
@@ -2196,21 +2224,21 @@
             <l>Delle nostre catene</l>
             <l>Tebe, Sparta, Corinto, Argo ed Atene.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="I">(Or son perduto!)</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l part="F">E ad ascoltar m'inviti...</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l>Non più: vanne e riporta</l>
             <l>Sì gran novella a' tuoi. Di' lor qual torna</l>
             <l>L'esule in Grecia e quai compagni ei guida.</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l>(Oh patria sventurata! oh Aspasia infida!) <stage>(parte co' Greci</stage></l>
           </sp>
@@ -2218,81 +2246,81 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>TEMISTOCLE, SERSE e SEBASTE</stage>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="I">(Io traditor!)</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="M">Duce, che pensi?</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Ah! cambia</l>
             <l>Cenno, mio re. V'è tanto mondo ancora</l>
             <l part="I">Da soggiogar.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Se della Grecia avversa</l>
             <l>Pria l'ardir non confondo,</l>
             <l>Nulla mi cal d'aver soggetto il mondo.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="I">Rifletti...</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">E' stabilita</l>
             <l>Di già l'impresa; e chi si oppon, m'irrìta.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l>Dunque eleggi altro duce.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="I">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Dell'armi perse</l>
             <l>Io depongo l'impero al piè di Serse. <stage>(depone il bastone a piè del trono</stage></l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="I">Come!</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">E vuoi ch'io divenga</l>
             <l>Il distruttor delle paterne mura?</l>
             <l>No, tanto non potrà la mia sventura.</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="I">(Che ardir!)</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Non è più Atene, è questa reggia</l>
             <l>La patria tua: quella t'insidia, e questa</l>
             <l>T'accoglie, ti difende e ti sostiene.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l>Mi difenda chi vuol: nacqui in Atene.</l>
             <l>E' istinto di natura</l>
             <l>L'amor del patrio nido. Amano anch'esse</l>
             <l>Le spelonche natie le fiere istesse.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l>(Ah! d'ira avvampo). Ah! dunque Atene ancora</l>
             <l>Ti sta nel cor? Ma che tanto ami in lei?</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l>Tutto, signor: le ceneri degli avi,</l>
             <l>Le sacre leggi, i tutelari numi,</l>
@@ -2301,23 +2329,23 @@
             <l>Lo splendor che ne trassi,</l>
             <l>L'aria, i tronchi, il terren, le mura, i sassi.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l>Ingrato! e in faccia mia <stage>(scende dal trono</stage></l>
             <l>Vanti con tanto fasto</l>
             <l part="I">Un'amor che m'oltraggia?</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="M">Io son...</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Tu sei</l>
             <l>Dunque ancor mio nemico. In van tentai</l>
             <l part="I">Co' benefizi miei...</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Questi mi stanno,</l>
             <l>E a caratteri eterni,</l>
@@ -2328,68 +2356,68 @@
             <l>Se pretendi obbligar gli sdegni miei,</l>
             <l>Serse, t'inganni: io morirò per lei.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l>Non più: pensa e risolvi. Esser non lice</l>
             <l>Di Serse amico e difensor d'Atene:</l>
             <l part="I">Scegli qual vuoi.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="M">Sai la mia scelta.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Avverti</l>
             <l>Del tuo destin decide</l>
             <l part="I">Questo momento.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="M">Il so pur troppo.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Irrìti</l>
             <l>Chi può farti infelice.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="I">Ma non ribelle.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Il viver tuo mi devi.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="I">Non l'onor mio.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="M">T'odia la Grecia.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Io l'amo.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l>(Che insulto, oh dèi!) Questa mercede ottiene</l>
             <l part="I">Dunque Serse da te?</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Nacqui in Atene.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l>(Più frenarmi non posso). Ah! quell'ingrato</l>
             <l>Toglietemi d'innanzi:</l>
             <l>Serbatelo al castigo. E pur vedremo</l>
             <l>Forse tremar questo coraggio invitto.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l>Non è timor dove non è delitto.</l>
             <lg>
@@ -2410,11 +2438,11 @@
         <div type="scene">
           <head>SCENA NONA</head>
           <stage>SERSE, SEBASTE, ROSSANE e poi ASPASIA</stage>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="I">Serse, io lo credo appena...</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Ah! principessa,</l>
             <l>Chi crederlo potea? Nella mia reggia,</l>
@@ -2423,90 +2451,90 @@
             <l>Se ne vanta, e per lei</l>
             <l>L'amor mio vilipende e i doni miei.</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l>(Torno a sperar). Chi sa? Potrà la figlia</l>
             <l part="I">Svolgerlo forse.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Eh! che la figlia e il padre</l>
             <l>Son miei nemici. E' naturale istinto</l>
             <l>L'odio per Serse ad ogni greco. Io voglio vendicarmi</l>
             <l>D'entrambi.</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l>(Felice me!) Della fedel Rossane</l>
             <l part="I">Tutti non hanno il cor.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Lo veggo, e quasi</l>
             <l part="I">Del passato arrossisco.</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="F">E pure io temo</l>
             <l part="I">Che, se Aspasia a te viene...</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Aspasia! Ah! tanto</l>
             <l part="I">Non ardirà.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="M">Pietà, signor!</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="F"><stage>(piano a Serse)</stage> (Lo vedi</l>
             <l part="I">Se tanto ardì? Non ascoltarla).</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F"><stage>(piano a Rossane)</stage> Udiamo</l>
             <l part="I">Che mai dirmi saprà).</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Salvami, o Serse,</l>
             <l>Salvami il genitor. Donal, oh Dio!</l>
             <l>Al tuo cor generoso, al pianto mio.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="I">(Che bel dolor!)</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="M">(Temo l'assalto).</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">E vieni</l>
             <l>Tu grazie ad implorar? tu che d'ogni altro</l>
             <l part="I">Forse più mi disprezzi?</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Ah no, t'inganni:</l>
             <l>Fu rossor quel rifiuto. Il mio rossore</l>
             <l>Un velo avrà, se il genitor non rendi:</l>
             <l part="I">Sarà tuo questo cor.</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="M">(Fremo).</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">E degg'io</l>
             <l>Un ingrato soffrir, che i miei nemici</l>
             <l part="I">Ama così?</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">No, chiedo men. Sospendi</l>
             <l>Sol per poco i tuoi sdegni: ad ubbidirti</l>
@@ -2522,15 +2550,15 @@
             <l>I suoi moti pietosi e la mia speme,</l>
             <l>O me spirar vedrai col padre insieme.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="I">Sorgi. (Che incanto!)</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="F">(Ecco, delusa io sono).</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l>Fa che il padre ubbidisca, e gli perdono.</l>
             <lg>
@@ -2551,16 +2579,16 @@
         <div type="scene">
           <head>SCENA DECIMA</head>
           <stage>ASPASIA, ROSSANE e SEBASTE</stage>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="I">(Io mi sento morir).</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Scusa, Rossane,</l>
             <l part="I">Un dover che m'astrinse...</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="F">Agli occhi miei</l>
             <l>Involati, superba! Hai vinto, il vedo;</l>
@@ -2568,7 +2596,7 @@
             <l>Brami ancor più? Vuoi trionfarne? Ormai</l>
             <l>Troppo m'insulti: ho tollerato assai.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <lg>
               <l>L'ire tue sopporto in pace,</l>
@@ -2587,27 +2615,27 @@
         <div type="scene">
           <head>SCENA UNDICESIMA</head>
           <stage>ROSSANE e SEBASTE</stage>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l>(Profittiam di quell'ira).</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l>Ah, Sebaste, ah, potessi</l>
             <l>Vendicarmi di Serse!</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l>Pronta è la via. Se a' miei fedeli aggiungi</l>
             <l>Gli amici tuoi, sei vendicata, e siamo</l>
             <l part="I">Arbitri dello scettro.</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="F">E quali amici</l>
             <l part="I">Offrir mi puoi?</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="F">Le numerose schiere</l>
             <l>Sollevate in Egitto</l>
@@ -2615,23 +2643,23 @@
             <l>Per cenno mio, col suo consiglio. Osserva:</l>
             <l part="I">Questo è un suo foglio. <stage>(le porge un foglio ed ella il prende</stage></l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="F">Alle mie stanze, amico,</l>
             <l>Vanne, m'attendi: or sarò teco. E' rischio</l>
             <l part="I">Qui ragionar di tale impresa.</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="F">E poi</l>
             <l part="I">Sperar poss'io...</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="F">Va: sarò grata. Io veggo</l>
             <l>Quanto ti deggio, e ti conosco amante.</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l>(Pur colsi al fine un fortunato istante). <stage>(parte</stage></l>
           </sp>
@@ -2639,7 +2667,7 @@
         <div type="scene">
           <head>SCENA DODICESIMA</head>
           <stage>ROSSANE sola</stage>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l>Rossane, avrai costanza</l>
             <l>D'opprimer chi adorasti? Ah! sì; l'infido</l>
@@ -2669,7 +2697,7 @@
           <head>SCENA PRIMA</head>
           <stage>Camere in cui Temistocle è ristretto.</stage>
           <stage>TEMISTOCLE e poi SEBASTE</stage>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l>Oh patria, oh Atene, oh tenerezza, oh nome</l>
             <l>Per me fatal! Dolce fin or mi parve</l>
@@ -2687,7 +2715,7 @@
             <l>Sempre sarai, come fin or lo fosti;</l>
             <l>Ma comincio a sentir quanto mi costi.</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l>A te Serse m'invia: come scegliesti,</l>
             <l>Senz'altro indugio, ei vuol saper. Ti brama</l>
@@ -2695,34 +2723,34 @@
             <l>Che non può figurarsi a questo segno</l>
             <l>Un Temistocle ingrato.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l>Ah! no, tal non son io; lo sanno i numi,</l>
             <l>Che mi veggono il cor: così potesse</l>
             <l>Vederlo anche il mio re. Guidami, amico,</l>
             <l part="I">Guidami a lui...</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="F">Non è permesso. O vieni</l>
             <l>Pronto a giurar su l'ara</l>
             <l>Odio eterno alla Grecia, o a Serse innanzi</l>
             <l part="I">Non sperar più di comparir.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Né ad altro</l>
             <l>Prezzo ottener si può che mi rivegga</l>
             <l part="I">Il mio benefattor?</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="F">No. Giura, e sei</l>
             <l>Del re l'amor. Ma, se ricusi, io tremo</l>
             <l>Pensando alla tua sorte. In questo, il sai,</l>
             <l part="I">Implacabile è Serse.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">(Ah, dunque io deggio</l>
             <l>Farmi ribelle, o tollerar l'infame</l>
@@ -2730,11 +2758,11 @@
             <l>In faccia al mondo, o confessar morendo</l>
             <l part="I">Gli obblighi miei!) <stage>(pensa</stage></l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="M">Risolvi.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F"><stage>(risoluto)</stage> (Eh! usciam da questo</l>
             <l>Laberinto funesto, e degno il modo</l>
@@ -2743,27 +2771,27 @@
             <l>E' necessario al giuramento. Ho scelto:</l>
             <l part="I">Verrò.</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="M">Contento io volo a Serse.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Ascolta:</l>
             <l part="I">Lisimaco partì?</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="F">Scioglie or dal porto</l>
             <l part="I">L'ancore appunto.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Ah! si trattenga: il bramo</l>
             <l>Presente a sì grand'atto. Al re ne porta,</l>
             <l>Sebaste, i prieghi miei.</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l>Vi sarà: tu di Serse arbitro or sei. <stage>(parte</stage></l>
           </sp>
@@ -2771,7 +2799,7 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>TEMISTOCLE solo.</stage>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l>Sia luminoso il fine</l>
             <l>Del viver mio: qual moribonda face,</l>
@@ -2794,69 +2822,69 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>NEOCLE, ASPASIA e detto.</stage>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="I">O caro padre!</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">O amato</l>
             <l part="I">Mio genitore!</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="F">E' dunque ver che a Serse</l>
             <l part="I">Viver grato eleggesti?</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">E' dunque vero</l>
             <l>Che sentisti una volta</l>
             <l part="I">Pietà di noi, pietà di te?</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Tacete,</l>
             <l>E ascoltatemi entrambi. E' noto a voi</l>
             <l>A qual esatta ubbidienza impegni</l>
             <l part="I">Un comando paterno?</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="F">E' sacro nodo.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="I">E' inviolabil legge.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">E ben, v'impongo</l>
             <l>Celar quanto dirò, fin che l'impresa</l>
             <l>Risoluta da me non sia matura.</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="I">Pronto Neocle il promette.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Aspasia il giura.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l>Dunque sedete, e di coraggio estremo</l>
             <l part="I">Date prova in udirmi. <stage>(siede</stage></l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="M">(Io gelo).</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">(Io tremo). <stage>(siedono Neocle ed Aspasia</stage></l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l>L'ultima volta è questa,</l>
             <l>Figli miei, ch'io vi parlo. Infin ad ora</l>
@@ -2864,15 +2892,15 @@
             <l>Forse di tante pene</l>
             <l>Il frutto perderei: morir conviene.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="I">Ah, che dici!</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="M">Ah, che pensi!</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">E' Serse il mio</l>
             <l>Benefattor; patria la Grecia. A quello</l>
@@ -2885,22 +2913,22 @@
             <l>Fuggir, morendo. Un violento ho meco</l>
             <l part="I">Opportuno velen...</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Come! ed a Serse</l>
             <l part="I">Andar non promettesti?</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">E in faccia a lui</l>
             <l part="I">L'opra compir si vuol.</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="F">Sebaste afferma</l>
             <l part="I">Che a giurar tu verrai...</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">So ch'ei lo crede,</l>
             <l>E mi giova l'error. Con questa speme</l>
@@ -2909,15 +2937,15 @@
             <l>Che per Serse ed Atene in petto ascondo,</l>
             <l>Giudice io voglio e testimonio il mondo.</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="I">(Oh noi perduti!)</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="M">(Oh me dolente!) <stage>(piangono</stage></l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Ah, figli,</l>
             <l>Che debolezza è questa! A me celate</l>
@@ -2925,27 +2953,27 @@
             <l>Non mi fate arrossir. Pianger dovreste</l>
             <l part="I">S'io morir non sapessi.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Ah! se tu mori,</l>
             <l part="I"> Noi che farem?</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="M">Chi resta a noi?</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Vi resta</l>
             <l>Della virtù l'amore,</l>
             <l>Della gloria il desio,</l>
             <l>L'assistenza del Ciel, l'esempio mio.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="I">Ah! padre...</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Udite. Abbandonarvi io deggio</l>
             <l>Soli, in mezzo a' nemici,</l>
@@ -2973,16 +3001,16 @@
             <l>Vi trovaste dal fato a un'atto indegno,</l>
             <l>V'è il cammin d'evitarlo: io ve l'insegno. <stage>(s'alza e s'alzano Neocle e Aspasia</stage></l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="I">Deh! non lasciarne ancora.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Ah! padre amato</l>
             <l part="I">Dunque mai più ti vedrò?</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Tronchiamo</l>
             <l>Questi congedi estremi. E' troppo, o figli,</l>
@@ -3006,29 +3034,29 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage> ASPASIA e NEOCLE</stage>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="I">Neocle!</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="M">Aspasia!</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="M">Ove siam?</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="F">Quale improvviso</l>
             <l part="I">Fulmine ci colpì!</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Miseri! e noi</l>
             <l part="I">Or che far dobbiam?</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="F">Mostrarci degni</l>
             <l>Di sì gran genitore. <stage>(risoluto)</stage> Andiam, germana,</l>
@@ -3036,22 +3064,22 @@
             <l>Trionfar di se stesso. Il nostro ardire</l>
             <l part="I">Gli addolcirà la morte.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Andiam: ti sieguo...</l>
             <l part="I">Oh Dio! non posso: il piè mi trema. <stage>(siede</stage></l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="F">E vuoi</l>
             <l part="I">Tanto dunque avvilirti?</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">E han tanto ancora</l>
             <l>Valor gli affetti tui?</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l>Se manca a me, l'apprenderò da lui.</l>
             <lg>
@@ -3104,33 +3132,33 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage> SERSE, poi ROSSANE con un foglio.</stage>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l>Dove il mio duce, il mio</l>
             <l>Temistocle dov'è? D'un re che l'ama</l>
             <l part="I">Non si nieghi agli amplessi.</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="F">Io vengo, o Serse,</l>
             <l part="I">Su l'orme tue.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="M">(Che incontro!)</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="F">Odimi; e questa</l>
             <l>Sia pur l'ultima volta.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l>Io so, Rossane,</l>
             <l>So che hai sdegno di me; so che vendetta</l>
             <l part="I">Minacciarmii vorrai...</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="F">Sì, vendicarmi</l>
             <l>Io voglio, è ver: son troppo offesa. Ascolta</l>
@@ -3139,12 +3167,12 @@
             <l>Un disegno sì rio</l>
             <l>Leggi, previeni, e ti conserva. Addio. <stage>(gli dà il foglio, e vuol partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l>Sentimi, principessa:</l>
             <l>Lascia che almen del generoso dono...</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l>Basta così: già vendicata io sono.</l>
             <lg>
@@ -3164,7 +3192,7 @@
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>SERSE, poi SEBASTE</stage>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l>Viene il foglio a Sebaste;</l>
             <l>Oronte lo vergò: leggasi... Oh stelle,</l>
@@ -3174,19 +3202,19 @@
             <l>Sì gran zelo fingendo... Eccolo. E come</l>
             <l part="I">Osa il fellon venirmi innanzi!</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="F">Io vengo</l>
             <l> Della mia fé, dei miei sudori, o Serse,</l>
             <l part="I">Un premio al fine ad implorar.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Son grandi,</l>
             <l>Sebaste, i merti tuoi,</l>
             <l>E puoi tutto sperar. Parla: che vuoi?</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l>Va l'impresa d'Atene</l>
             <l>Temistocle a compir; l'altra d'Egitto</l>
@@ -3194,59 +3222,59 @@
             <l>Che all'ultima destini,</l>
             <l part="I">Chiedo il comando.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="M">Altro non vuoi?</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="F">Mi basta</l>
             <l>Poter del mio zelo</l>
             <l part="I">Darti prove, o signor.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Ne ho molte, e questa</l>
             <l>E' ben degna di te. Ma tu d'Egitto</l>
             <l part="I">Hai contezza bastate?</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="F">I monti, i fiumi,</l>
             <l>Le foreste, le vie, quasi potrei</l>
             <l part="I">I sassi annoverar.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Non basta: è d'uopo</l>
             <l>Conoscer del tumulto</l>
             <l part="I">Tutti gli autori.</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="M">Oronte è il solo.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Io credo</l>
             <l>Ch'altri ve n'abbia. Ha questo foglio i nomi:</l>
             <l part="I">Vedi se a te son noti. <stage>(gli dà il foglio</stage></l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="F"><stage>(lo prende)</stage> E donde avesti...</l>
             <l part="I">(Misero me!) <stage>(lo riconosce</stage></l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Che fu? Ti sei smarrito!</l>
             <l part="I">Ti scolori! ammutisci!</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="F">(Ah, son tradito!)</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <lg>
               <l>Non tremar, vassallo indegno;</l>
@@ -3294,7 +3322,7 @@
           <head>SCENA NONA</head>
           <stage>Reggia, ara accesa nel mezzo, e sopra essa la tazza preparata pel giuramento.</stage>
           <stage>SERSE, ASPASIA e NEOCLE, satrapi, guardie e popolo.</stage>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l>Neocle, perché sì mesto? Onde deriva,</l>
             <l>Bella Aspasia, quel pianto? Allor che il padre</l>
@@ -3302,7 +3330,7 @@
             <l>L'amistà, l'amor mio</l>
             <l part="I">Un disastro per voi? Parlate.</l>
           </sp>
-          <sp>
+          <sp who="#neocle #aspasia">
             <speaker>NEOC. ed ASP.</speaker>
             <l part="F">Oh Dio!</l>
           </sp>
@@ -3310,84 +3338,84 @@
         <div type="scene">
           <head>SCENA DECIMA</head>
           <stage>ROSSANE, LISIMACO con séguito di Greci, e detti.</stage>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l>A che, signor, mi chiedi?</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l part="I">Serse, da me che vuoi?</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Voglio presenti</l>
             <l part="I">Lisimaco e Rossane...</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l part="F">I nuovi oltraggi</l>
             <l part="I">Ad ascoltar d'Atene?</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="F">I torti miei</l>
             <l part="I">Di nuovo a tollerar?</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l part="F">D'Aspasia infida</l>
             <l part="I">A veder l'incostanza?</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Ah! non è vero;</l>
             <l>Non affliggermi a torto,</l>
             <l>Lisimaco crudele: io son l'istessa.</l>
             <l>Perché opprimer tu ancora un'alma oppressa?</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="I">Come! voi siete amanti!</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Ormai sarebbe</l>
             <l part="I">Vano il negar: troppo già dissi.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F"><stage>(ad Aspasia)</stage> E m'offri</l>
             <l part="I">Tu la tua man?</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">D'un genitor la vita</l>
             <l part="I">Chiedea quel sacrifizio.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F"><stage>(a Lisimaco)</stage> E del tuo bene</l>
             <l part="I">Tu perseguiti il padre?</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l part="F">Il volle Atene.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="I">(Oh virtù che innamora!)</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="F">Il greco duce</l>
             <l part="I">Ecco s'appressa.</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="F"><stage>(guardando il padre)</stage> (Aver potessi anch'io</l>
             <l>Quell'intrepido aspetto!) </l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l>(Ah, imbelle cor, come mi tremi in petto!)</l>
           </sp>
@@ -3395,27 +3423,27 @@
         <div type="scene">
           <head>SCENA ULTIMA</head>
           <stage>TEMISTOCLE e detti, poi SEBASTE in fine.</stage>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l>Pur, Temistocle, al fine</l>
             <l>Risolvesti esser mio. Torna agli amplessi</l>
             <l>D'un re, che tanto onora... <stage>(volendo abbracciarlo</stage></l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="I">Ferma. <stage>(ritirandosi con rispetto</stage></l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="M">E perché?</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Non ne son degno ancora.</l>
             <l>Degno pria me ne renda</l>
             <l part="I">Il grand'atto a cui vengo.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">E' già su l'ara</l>
             <l>La necessaria al rito</l>
@@ -3423,17 +3451,17 @@
             <l>Giuramento solenne; e in lui cominci</l>
             <l part="I">Della Grecia il castigo.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Esci, o signore,</l>
             <l>Esci d'inganno. Io di venir promisi,</l>
             <l part="I">Non di giurar.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="M">Ma tu...</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Sentimi, o Serse;</l>
             <l>Lisimaco, m'ascolta; udite, o voi</l>
@@ -3448,15 +3476,15 @@
             <l>Senza delitto altro cammin non veggo</l>
             <l>Che il cammin della tomba, e quello eleggo.</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l part="I">(Che ascolto!)</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="M">(Eterni dèi!)</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F"><stage>(trae dal petto il veleno</stage> Questo, che meco</l>
             <l>Trassi compagno al doloroso esiglio,</l>
@@ -3467,15 +3495,15 @@
             <l>Di fé, di gratitudine e d'onore,</l>
             <l part="I">Tutti assistan gli dèi.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">(Morir mi sento).</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="I">(M'occupa lo stupor).</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F"><stage>(a Lisimaco)</stage> Della mia fede</l>
             <l>Tu, Lisimaco, amico,</l>
@@ -3498,36 +3526,36 @@
             <l>Il tuo sdegno in un punto e il viver mio.</l>
             <l>Figli, amico, signor, popoli, addio! <stage>(prende la tazza</stage></l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l>Ferma! che fai? Non appressar le labbra</l>
             <l part="I">Alla tazza letal.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="M">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Soffrirlo</l>
             <l part="I">Serse non debbe.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="M">E la cagion?</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Son tante</l>
             <l part="I">Che spiegarle non so. <stage>(gli leva la tazza</stage></l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Serse, la morte</l>
             <l>Tormi non puoi: l'unico arbitrio è questo</l>
             <l part="I">Non concesso a' monarchi.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F"><stage>(getta la tazza)</stage> Ah! vivi, o grande</l>
             <l> Onor del secol nostro. Ama, il consento,</l>
@@ -3536,12 +3564,12 @@
             <l>Odiar la produttrice</l>
             <l>D'un eroe, qual tu sei, terra felice?</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l>Numi! ed è ver? tant'oltre</l>
             <l part="I">Può andar la mia speranza?</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Odi, ed ammira</l>
             <l>Gl'inaspettati effetti</l>
@@ -3552,22 +3580,22 @@
             <l>Esule generoso,</l>
             <l>A sì gran cittadino il suo riposo.</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l>O magnanimo re, qual nuova è questa</l>
             <l>Arte di trionfar! D'esser sì grandi</l>
             <l>E' permesso a' mortali? Oh Grecia! oh Atene!</l>
             <l part="I">Oh esiglio avventuroso!</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="F">Oh dolce istante!</l>
           </sp>
-          <sp>
+          <sp who="#neocle">
             <speaker>NEOC.</speaker>
             <l part="I">Oh lieto dì!</l>
           </sp>
-          <sp>
+          <sp who="#lisimaco">
             <speaker>LIS.</speaker>
             <l part="F">Le vostre gare illustri,</l>
             <l>Anime eccelse, a pubblicar lasciate</l>
@@ -3575,13 +3603,13 @@
             <l>A  donator sì grande,</l>
             <l part="I">A tanto intercessor.</l>
           </sp>
-          <sp>
+          <sp who="#sebaste">
             <speaker>SEB.</speaker>
             <l part="F">De' falli miei,</l>
             <l>Signor, chiedo il castigo. Odio una vita,</l>
             <l part="I">Che a te... <stage>(inginocchindosi</stage></l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Sorgi, Sebaste: oggi non voglio</l>
             <l>Respirar che contenti. A te perdono;</l>
@@ -3589,21 +3617,21 @@
             <l>Lascio d'Aspasia; e la real mia fede</l>
             <l>Di Rossane all'amor dono in mercede.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASP.</speaker>
             <l part="I">Ah, Lisimaco!</l>
           </sp>
-          <sp>
+          <sp who="#rossane">
             <speaker>ROSS.</speaker>
             <l part="M">Ah, Serse!</l>
           </sp>
-          <sp>
+          <sp who="#temistocle">
             <speaker>TEMIS.</speaker>
             <l part="F">Amici numi,</l>
             <l>Deh! fate voi ch'io possa</l>
             <l part="I">Esser grato al mio re.</l>
           </sp>
-          <sp>
+          <sp who="#serse">
             <speaker>SER.</speaker>
             <l part="F">Da' numi implora</l>
             <l>Che ti serbino in vita,</l>
@@ -3611,7 +3639,7 @@
             <l>Di tua virtù la mia virtude accendi,</l>
             <l>Più di quel ch'io ti do, sempre mi rendi.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Quando un'emula l'invita,</l>

--- a/tei/metastasio-zenobia.xml
+++ b/tei/metastasio-zenobia.xml
@@ -76,6 +76,31 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="zopiro">
+            <persName>Zopiro</persName>
+          </person>
+          <person xml:id="radamisto">
+            <persName>Radamisto</persName>
+          </person>
+          <person xml:id="zenobia">
+            <persName>Zenobia</persName>
+          </person>
+          <person xml:id="egle">
+            <persName>Egle</persName>
+          </person>
+          <person xml:id="tiridate">
+            <persName>Tiridate</persName>
+          </person>
+          <person xml:id="mitrane">
+            <persName>Mitrane</persName>
+          </person>
+          <personGrp xml:id="coro">
+            <name>Coro</name>
+          </personGrp>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT-Pavia</name>Digitalizzazione</change>
@@ -128,7 +153,7 @@
           <head>SCENA PRIMA</head>
           <stage>Fondo sassoso di cupa ed oscura valle, orrida per le scoscese rupi che la circondano e per le foltissime piante che la sovrastano.</stage>
           <stage>RADAMISTO, dormendo sopra un sasso, e ZOPIRO che attentamente l'osserva.</stage>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l>No, non m'inganno, è Radamisto. Oh, come</l>
             <l>Secondano le stelle</l>
@@ -140,36 +165,36 @@
             <l>Ei l'odia, io nell'amor. Servo in un punto</l>
             <l part="I">Al mio sdegno e al mio re. <stage>(in atto di snudar la spada</stage></l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F"><stage>(sognando)</stage> Lasciami in pace.</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l>Si desta. Ah, sorte ingrata!</l>
             <l part="I">Fingiam.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">Lasciami in pace, ombra onorata.</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="I">Numi! <stage>(fingendo non averlo veduto</stage></l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">Stelle, che miro!</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="I">Radamisto!</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="M">Zopiro! <stage>(si leva</stage></l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">O prence invitto,</l>
             <l>Gloria del suol natio,</l>
@@ -178,44 +203,44 @@
             <l>Che mille volte io baci</l>
             <l part="I">Questa destra real!</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">Qual tua sventura</l>
             <l>Fra questi orridi sassi,</l>
             <l>Quasi incogniti al sol, guida i tuoi passi?</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l>Dell'empio Farasmane</l>
             <l part="I">Fuggo il furor.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">Non l'oltraggiar: rammenta</l>
             <l> Ch'è tuo re, ch'è mio padre. E di qual fallo</l>
             <l part="I">Ti vuol punir?</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="M">D'esserti amico.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">E' giusto.</l>
             <l>Tutti aborrir mi denno. Io, lo confesso,</l>
             <l>Son l'orror de' viventi e di me stesso.</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l>Sventurato e non reo, signor, tu sei.</l>
             <l part="I">Mi son noti i tuoi casi.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">Oh, quanto ignori</l>
             <l part="I">Della storia funesta!</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">Io so che tutta</l>
             <l>Sollevata è l'Armenia e che ti crede</l>
@@ -224,45 +249,45 @@
             <l>Dal padre tuo; ch'ei rovesciò l'accusa</l>
             <l part="I">Sopra di te; che di Zenobia...</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">Ah! taci.</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="I">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">Con questo nome</l>
             <l part="I">L'anima mi trafiggi.</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">Era altre volte</l>
             <l>Pur la delizia tua. So che in isposa</l>
             <l part="I">La bramasti.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">E l'ottenni. Ah! fui di tanto</l>
             <l part="I">Tesoro possessor. Ma... oh Dio!</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">Tu piangi!</l>
             <l>La perdesti? dov'è? Parla: qual fato</l>
             <l>Sì bei nodi ha divisi?</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l>Ah, Zopiro, ella è morta, ed io l'uccisi!</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="I">Giusti numi! e perché?</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">Perché giammai</l>
             <l>Mostro il suol non produsse</l>
@@ -270,11 +295,11 @@
             <l>Del geloso furor gl'impeti insani</l>
             <l part="I">Mai raffrenar.</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="M">Nulla io comprendo.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">Ascolta.</l>
             <l>Da' sollevati Armeni</l>
@@ -307,22 +332,22 @@
             <l>Più di formar parole;</l>
             <l>Fosca l'aria mi parve e doppio il sole.</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="I">E che facesti?</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">Impetuoso, insano,</l>
             <l>Strinsi l'acciar: della consorte in petto</l>
             <l>L'immersi, indi nel mio. Di vita priva</l>
             <l>Nell'Arasse ella cadde, io su la riva.</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="I">Principessa infelice!</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">Io per mia pena</l>
             <l>Al colpo sopravvissi. A' miei nemici</l>
@@ -336,12 +361,12 @@
             <l>Per castigo a me stesso, al mio crudele</l>
             <l part="I">Tardo rimorso.</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">(A trucidar quest'empio</l>
             <l part="I">Non basto sol).</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">So che aprir deggio il varco</l>
             <l>A quest'anima rea; ma pria vorrei</l>
@@ -351,7 +376,7 @@
             <l>Sempre su gli occhi: io non ho pace. Andiamo,</l>
             <l part="I">Andiamo a ricercar... <stage>(incamminandosi</stage></l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F"><stage>(arrestandolo)</stage> Ferma! che dici?</l>
             <l>Circondano i nemici</l>
@@ -360,18 +385,18 @@
             <l>Resta e m'attendi: alla pietosa inchiesta</l>
             <l part="I">Io volerò.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">Sì, caro amico; e poi...</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l>Non più: fidati di me. Da questo loco</l>
             <l>Non dilungarti: io tornerò. Frattanto</l>
             <l>Modera il tuo dolor, pensa a te stesso,</l>
             <l>Quel volto oblia, non rammentar quel nome.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l>Oh Dio! Zopiro, il vorrei far, ma come?</l>
             <lg>
@@ -414,7 +439,7 @@
           <head>SCENA TERZA</head>
           <stage>Vastissima campagna irrigata dal fiume Arasse, sparsa da un lato di capanne pastorali, e terminata dall'altro dalle falde d'amenissime montagne. A piè della più vicina di queste comparisce l'ingresso di rustica grotta, tutto d'edera e di spini ingombrato. Vedesi in lontano, di là dal fiume, la real città di Artassata, con magnifico ponte che vi conduce, e su le rive opposte l'esercito parto attendato.</stage>
           <stage>ZENOBIA ed EGLE da una capanna.</stage>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l>Non tentar di seguirmi:</l>
             <l>Soffrir nol deggio, Egle amorosa. Io vado</l>
@@ -435,12 +460,12 @@
             <l>Me del perduto sposo affretta il mio.</l>
             <l>Facciamo entrambe il dover nostro. Addio.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l>Ma sola e senza guida</l>
             <l>Per queste selve... Il tuo coraggio ammiro.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l>Non è nuovo per me. Fanciulla appresi</l>
             <l>Le sventure a soffrir. Tre lustri or sono</l>
@@ -450,33 +475,33 @@
             <l>Che morì nel tumulto o fu rapita!</l>
             <l>Io per sempre penar rimasi in vita.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l>E vuoi con tanto rischio andare in traccia</l>
             <l part="I">D'un barbaro consorte?</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Ah! più rispetto</l>
             <l>Per un eroe ripieno</l>
             <l part="I">D'ogni real virtù.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F">Virtù reale</l>
             <l part="I">E' il geloso furor?</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Chi può vantarsi</l>
             <l>Senza difetti? Esaminando i sui,</l>
             <l>Ciascuno impari a perdonar gli altrui.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="I">Ma una sposa svenar...</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Reo non si chiama</l>
             <l>Chi pecca involontario. In quello stato,</l>
@@ -485,22 +510,22 @@
             <l>Strinse l'armi omicide,</l>
             <l>M'assalì, mi trafisse e non mi vide.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l>Oh generosa! E ben, di lui novella</l>
             <l part="I">Io cercherò: tu puoi restar.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">No, cara</l>
             <l>Egle, non deggio: a troppo rischio espongo</l>
             <l part="I">La gloria mia, la mia virtù.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F">Che dici?</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l>Io lo so, non m'intendi. Or odi e dimmi</l>
             <l>Se temo a torto. Il giovanetto duce</l>
@@ -537,12 +562,12 @@
             <l>La mia virtù; sacrificai costante</l>
             <l>Di consorte al dover quello d'amante.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l>Né mai più Tiridate</l>
             <l>Rivedesti fin ora?</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l>Ah, nol permetta il Ciel! Questo è il timore</l>
             <l>Che affretta il partir mio. Non ch'io diffidi,</l>
@@ -555,18 +580,18 @@
             <l>E' geloso cristallo, è debil canna,</l>
             <l>Ch'ogni aura inchina, ogni respiro appanna.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l>Misero prence! E alla novella amara</l>
             <l part="I">Che detto avrà?</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">L'ignora ancor: mi strinse</l>
             <l>Segreto laccio a Radamisto. Ei torna</l>
             <l part="I">Agl'imenei promessi.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F">Oh numi! e trova</l>
             <l>Sollevata l'Armenia,</l>
@@ -574,15 +599,15 @@
             <l>Tutti i disegni sui;</l>
             <l part="I">E Zenobia...</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">E Zenobia in braccio altrui.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="I">Che barbaro destin!</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Or di': poss'io</l>
             <l>Espormi a rimirar l'acerbo affanno</l>
@@ -590,21 +615,21 @@
             <l>Che tanto meritò? che forse al solo</l>
             <l part="I">Udir che d'altri io sono... Addio.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F">Mi lasci?</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l>Sì, cara; io fuggo: è periglioso il loco,</l>
             <l part="I">Le memorie, i pensieri.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F">A chi fa oltraggio</l>
             <l part="I">L'innocente pietà...</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Temer conviene</l>
             <l>L'insidie ancor d'una pietà fallace.</l>
@@ -688,7 +713,7 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>TIRIDATE, poi MITRANE, e detta in disparte.</stage>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l>Né ritorna Mitrane! Ah! mi spaventa</l>
             <l>La sua tardanza. Eccolo. Aimè! Che mesto,</l>
@@ -697,56 +722,56 @@
             <l>Dov'è? ne rintracciasti</l>
             <l part="I">Qualche novella?</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="M">Ah, Tiridate!</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">Oh Dio,</l>
             <l>Che silenzio crudel! Parla. E' un arcano</l>
             <l>La sorte di Zenobia? Ognuno ignora</l>
             <l>Che fu di lei, dove il destin la porta?</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="I">Ah! pur troppo si sa.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="M">Che avvenne?</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="F">E' morta.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="I">Santi numi del ciel!</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="F">Quell'empio istesso</l>
             <l>Che il genitor trafisse,</l>
             <l part="I">La figlia anche svenò.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="M">Chi?</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="F">Radamisto</l>
             <l part="I"> Fu l'inumano.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">Ah, scellerato! E tanto...</l>
             <l>No, possibil non è. Qual cor non placa</l>
             <l>Tanta bellezza? Ei ne languia d'amore.</l>
             <l part="I">Non crederlo, Mitrane.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="F">Il Ciel volesse</l>
             <l>Che fosse dubbio il caso. Ei dell'Arasse</l>
@@ -759,44 +784,44 @@
             <l>Esser non ponno infidi:</l>
             <l>La spoglia è di Zenobia, ed io la vidi.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="I">Soccorrimi.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="M">(Oh cimento!)</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F"><stage>(si appoggia ad un tronco)</stage> Agli occhi miei</l>
             <l part="I">Manca il lume del dì.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">(Consiglio, o dèi!)</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l>Principe, ardir!</l>
             <l>Con questi colpi i numi</l>
             <l part="I">Fan prova degli eroi.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="M">Lasciami.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="F">In questo</l>
             <l>Stato degg'io lasciarti!</l>
             <l part="I">Di me, signor, che si direbbe?</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">Ah! parti.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <lg>
               <l>Ch'io parta? M'accheto,</l>
@@ -815,7 +840,7 @@
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>TIRIDATE, e ZENOBIA in disparte.</stage>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l>Dunque è morta Zenobia? E tu respiri,</l>
             <l>Sventurato cor mio! Per chi? che speri?</l>
@@ -829,78 +854,78 @@
             <l>Ne' regni dell'oblio</l>
             <l>M'unirà questo ferro all'idol mio. <stage>(snuda la spada</stage></l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="I">(Aimè!) <stage>(uscendo</stage></l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">L'onda fatale</l>
             <l>Deh! non varcar, dolce mia fiamma: aspetta</l>
             <l>Che Tiridate arrivi;</l>
             <l part="I">Ecco... <stage>(vuol ferirsi</stage></l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="M">Fermati! <stage>(trattenendolo</stage></l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="M"><stage>(rivolgendosi)</stage> Oh dèi!</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Fermati e vivi! <stage>(gli toglie la spada, e s'incammina per partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l>Zenobia, anima bella! <stage>(vuol seguirla</stage></l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l>Guardati di seguirmi: io non son quella. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="I">Come! e vuoi... <stage>(in atto di seguirla</stage></l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Non seguirmi,</l>
             <l>Principe, te ne priego; e non potrebbe</l>
             <l>Chi la vita ti diè chiederti meno.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l>Ma possibil non è... <stage>(seguendola</stage></l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l><stage>(risoluta in atto di ferirsi)</stage> Resta o mi sveno.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="I">Eterni dèi! Deh!... <stage>(arrestandosi</stage></l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F"><stage>(in atto di ferirsi)</stage> Se t'inoltri d'un passo,</l>
             <l part="I">Su questo ferro io m'abbandono.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">Ah, ferma!</l>
             <l>M'allontano, ubbidisco. Odi: ove vai?</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l>Dove il destin mi porta. <stage>(partendo</stage></l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="I">Ah, Zenobia crudel!</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Zenobia è morta. <stage>(parte</stage></l>
           </sp>
@@ -908,60 +933,60 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>TIRIDATE e poi MITRANE</stage>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l>Principessa, idol mio, sentimi... Oh stelle!</l>
             <l>Che far degg'io? Né seguitarla ardisco</l>
             <l>Né trattener mi so. Questo è un tormento,</l>
             <l part="I">Questo...</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="F">Signor, gli ambasciadori armeni</l>
             <l part="I">Giunsero d'Artassata.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F"><stage>(con affanno)</stage> Ah, mio fedele,</l>
             <l>Corri, vola, t'affretta.</l>
             <l part="I">Sieguila tu per me.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="M">Chi?</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">Vive ancora;</l>
             <l>Ancor del chiaro dì l'aure respira.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="I">Ma chi, prence?</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="M">Zenobia.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="F">(Aimè! delira).</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l>Oh Dio! perché t'arresti? Ecco il sentiero;</l>
             <l part="I">Quelle son l'orme sue.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="M">Ma...</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F"><stage>(con impazienza)</stage> S'allontana,</l>
             <l>Mentre domandi e pensi.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l>Vado. (Oh, come il dolor confonde i sensi!) <stage>parte</stage></l>
           </sp>
@@ -1007,7 +1032,7 @@
         <div type="scene">
           <head>SCENA PRIMA</head>
           <stage>TIRIDATE e MITRANE</stage>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l>Ma s'io stesso la vidi,</l>
             <l>S'io stesso l'ascoltai! Ne ho viva ancora</l>
@@ -1015,7 +1040,7 @@
             <l>Mi risuona sul cor. Zenobia è in vita:</l>
             <l part="I">Mitrane, io non sognai.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="F">Signor, gli amanti</l>
             <l>Sognano ad occhi aperti. Anche il dolore</l>
@@ -1025,13 +1050,13 @@
             <l>L'idea che la diletta a sé dipinge;</l>
             <l>E ognun quel che desia facil si finge.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l>Ah! seguìta io l'avrei: ma quel vederla</l>
             <l>Già risoluta a trapassarsi il petto</l>
             <l part="I">Gelar mi fé.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="F">Pensa alla tua grandezza,</l>
             <l>O mio prence, per or. T'offron gli Armeni</l>
@@ -1040,7 +1065,7 @@
             <l>Or che destra è Fortuna: i suoi favori</l>
             <l part="I">Sai che durano istanti.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">In ogni loco</l>
             <l>Radamisto si cerchi: il traditore</l>
@@ -1048,11 +1073,11 @@
             <l>Già la mercé; bramo a Zenobia offesa</l>
             <l part="I">Offrire il reo.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="M">Dunque ancor speri?</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">Ad una</l>
             <l>Leggiadra pastorella</l>
@@ -1060,75 +1085,75 @@
             <l>Questa è la sua capanna. Avrem da lei</l>
             <l part="I">Qualche lume miglior.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="F">Ma che ti disse?</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="I">Nulla.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="M">E tu speri?</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">Sì. Mi parve assai</l>
             <l>Confusa alle richieste:</l>
             <l>Mi guardava, arrossia, parlar volea,</l>
             <l>Cominciava a spiegarsi, e poi tacea.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l>O amanti, oh quanto poco</l>
             <l part="I">Basta a farvi sperar!</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">Con Egle io voglio</l>
             <l part="I">Parlar di nuovo: a me l'appella.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="F">Il cenno</l>
             <l part="I">Pronto eseguisco. <stage>(entra nella capanna</stage></l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">Oh che crudel contrasto</l>
             <l>Di speranze e timori,</l>
             <l>Giusti numi, ho nel sen! Non v'è del mio</l>
             <l part="I">Stato peggior.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="F"><stage>(tornando)</stage> La pastorella è altrove:</l>
             <l part="I">Solitario è l'albergo.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">Infin che torni,</l>
             <l part="I">L'attenderò. Vanne alle tende.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="F">E' vana</l>
             <l> La cura tua. Quella sanguigna spoglia,</l>
             <l part="I">Ch'io stesso rimirai...</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">Crudel Mitrane,</l>
             <l>Io che ti feci mai? Deh! la speranza</l>
             <l part="I">Non mi togliere almen.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="F">Spesso la speme,</l>
             <l>Principe, il sai, va con l'inganno insieme. <stage>(parte</stage></l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <lg>
               <l>Non so se la speranza</l>
@@ -1147,7 +1172,7 @@
         <div type="scene">
           <head>SCENA SECONDA</head>
           <stage>ZENOBIA ed EGLE</stage>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l>Vanne, cercalo, amica,</l>
             <l>Guidalo a me: conoscerai lo sposo</l>
@@ -1158,33 +1183,33 @@
             <l>Con Tiridate. Il primo assalto insegna</l>
             <l part="I">Il secondo a fuggir.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F">Degna di scusa</l>
             <l>Veramente è chi l'ama: io mai non vidi</l>
             <l part="I">Più amabili sembianze.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Ove il vedesti?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l>Poc'anzi in lui m'avvenni. Ei, che a ciascuno</l>
             <l>Di te chiede novelle,</l>
             <l part="I">A me pur ne richiese.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="M">E tu?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F">Rimasi</l>
             <l>Stupida ad ammirarlo. I dolci sguardi,</l>
             <l part="I"> La favella gentil...</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Questo io non chiedo,</l>
             <l>Egle, sa te: non risvegliar con tante</l>
@@ -1192,19 +1217,19 @@
             <l>La guerra nel mio cor. Dimmi se a lui</l>
             <l part="I">Scopristi la mia sorte.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F">Il tuo divieto</l>
             <l part="I">Mi rammentai: nulla gli dissi.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Or vanne,</l>
             <l>Torna a me col mio sposo; e cauta osserva,</l>
             <l>Se Tiridate incontri,</l>
             <l part="I">La legge di tacer.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F">Volendo ancora,</l>
             <l>Tradirti non potrei:</l>
@@ -1226,7 +1251,7 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>ZENOBIA, e TIRIDATE nella capanna.</stage>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l>Povero cor, t'intendo: or che siam soli,</l>
             <l>La libertà vorresti</l>
@@ -1248,24 +1273,24 @@
             <l>Veggo?... o il timor che ho nella mente impresso</l>
             <l>Mi finge... Oh stelle! è Tiridate istesso.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l>Senti. Or mi fuggi in van: dovunque andrai,</l>
             <l part="I">Al tuo fianco sarò. <stage>(uscendo dalla capanna ed inseguendo Zenobia</stage></l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Ferma! Ti sento.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="I">Ah, Zenobia, Zenobia!</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">(Ecco il cimento).</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l>Sei tu? Son io? Così mi accogli? E' questo,</l>
             <l>Principessa adorata, il dolce istante</l>
@@ -1279,26 +1304,26 @@
             <l>Il tuo bel cor qual sia;</l>
             <l>Conosco, anima mia...</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l>Signor, già che m'astringi</l>
             <l>Teco a restar questi momenti, almeno</l>
             <l part="I">Non si spendano in van.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">Dunque ti spiace...</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l>Sì, mi spiace esser teco. Odimi, e dammi</l>
             <l part="I">Prove di tua virtù.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="M">(Tremo!)</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">I legami</l>
             <l>De' reali imenei per man del fato</l>
@@ -1316,21 +1341,21 @@
             <l>Alla nostra virtù, prence, si tolga.</l>
             <l>Questa già ci legò; questa ci sciolga.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l>Assistetemi, o dèi! Dunque io non deggio</l>
             <l part="I">Mai più sperar...</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Che più sperar non hai.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l>Ma perché? Ma chi mai</l>
             <l part="I">T'invola a me? Qual fallo mio...</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Non giova</l>
             <l>Questo esame penoso</l>
@@ -1340,7 +1365,7 @@
             <l>La cagion che ne parte, o colpa mia:</l>
             <l>Questo ti basti, e non cercar qual sia.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l>Barbara! e puoi con tanta</l>
             <l>Tranquillità parlar così? Non sai</l>
@@ -1349,32 +1374,32 @@
             <l>Tutto manca per me? che non ebb'io</l>
             <l part="I">Altro oggetto fin or...</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F"><stage>(vuol partire)</stage> Principe, addio.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="I">Ma spiegami...</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Non posso.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="I">Ascoltami...</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="M">Non deggio.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">Odiarmi tanto!</l>
             <l>Fuggir dagli occhi miei!</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l>Ah! signor, se t'odiassi, io resterei.</l>
             <l>Temo la tua presenza: ella è nemica</l>
@@ -1392,21 +1417,21 @@
             <l>Che mi sforzi a versar: lasciami, fuggi,</l>
             <l part="I">Evitami, signore.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">E non degg'io</l>
             <l part="I">Rivederti mai più?</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">No, se la pace,</l>
             <l>No, se la gloria mia, prence, t'è cara.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l>Oh barbara sentenza! oh legge amara!</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <lg>
               <l>Va, ti consola, addio;</l>
@@ -1414,7 +1439,7 @@
               <l>Vivi più lieti dì.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <lg>
               <l>Come! tiranna! Oh Dio!</l>
@@ -1422,19 +1447,19 @@
               <l>Ma non mi dir così.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <lg part="I">
               <l>L'alma gelar mi sento.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <lg part="M">
               <l>Sento mancarmi il cor.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#zenobia #tiridate">
             <speaker>A DUE</speaker>
             <lg part="F">
               <l>Oh che fatal momento!</l>
@@ -1495,21 +1520,21 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>RADAMISTO, EGLE, e ZOPIRO in disparte.</stage>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">Non ingannarmi,</l>
             <l>Cortese pastorella. Il farsi giuoco</l>
             <l>Degl'infelici è un barbaro diletto,</l>
             <l part="I">Troppo indegno di te.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F">No, non t'inganno:</l>
             <l>Vive la sposa tua. Trafitta il seno,</l>
             <l>Io dall'onde la trassi, e con periglio</l>
             <l part="I">Di perir seco.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">Oh amabil ninfa! oh mio</l>
             <l>Nume liberator! Dunque si trova</l>
@@ -1517,40 +1542,40 @@
             <l>Virtù qui alberga; il cittadino stuolo</l>
             <l>Sol la spoglia ha di quella, o il nome solo.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l>Attendimi: siam giunti.</l>
             <l part="I">Vado Zenobia ad avvertir. <stage>(entra nella capanna</stage></l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">M'affretto</l>
             <l>Impaziente a rivederla, e tremo</l>
             <l>Di presentarmi a lei. M'accende amore;</l>
             <l part="I">Il rimorso m'agghiaccia.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F"><stage>(tornando)</stage> In altra parte</l>
             <l part="I">Zenobia andò: non la ritrovo.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">Oh dèi!</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l>Non ti smarrir, ritornerà: va in traccia</l>
             <l part="I">Forse di noi.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">No; m'aborrisce, evìta</l>
             <l>D'incontrarsi con me. Non la condanno;</l>
             <l>E' giusto l'odio suo; minor castigo,</l>
             <l part="I">Egle, non meritai.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F">Zenobia odiarti!</l>
             <l>Aborrirti Zenobia! Ah! mal conosci</l>
@@ -1563,25 +1588,25 @@
             <l>Condannarti non osa:</l>
             <l>La man, che la ferì, chiama pietosa.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l>Deh! corriamo a cercarla. A' piedi suoi</l>
             <l>Voglio morir d'amore,</l>
             <l part="I">Di pentimento e di rossor.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F">La perdi</l>
             <l part="I"> Forse, se t'allontani.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">Intanto almeno</l>
             <l>Va tu per me: deh! non tardar. Perdona</l>
             <l>L'intolleranza mia: sospiro un bene</l>
             <l>Ch'io so quanti mi costi e pianti e pene.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <lg>
               <l>Oh che felici pianti!</l>
@@ -1600,7 +1625,7 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>RADAMISTO e poi ZOPIRO</stage>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l>Oh generosa, oh degna</l>
             <l>Di men barbaro sposo,</l>
@@ -1610,66 +1635,66 @@
             <l>La gloria femminil, ditemi voi</l>
             <l>Se han virtù più sublime i nostri eroi.</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l>Dove, principe, dove</l>
             <l part="I">T'aggiri mai? Così m'attendi?</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">Ah! vieni,</l>
             <l>De' miei prosperi eventi</l>
             <l part="I">Vieni a goder. La mia Zenobia...</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">E' in vita,</l>
             <l part="I">Lo so.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="M">Lo sai?</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">Così mi fosse ignoto!</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="I">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">Perché... Non lo cercar. Di lei</l>
             <l>Scordati, Radamisto: è poco degna</l>
             <l part="I">Dell'amor tuo.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="M">Ma la cagion?</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">Che giova</l>
             <l part="I">Affliggerti, o signor?</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">Parla: m'affliggi</l>
             <l part="I">Più col tacer.</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">Dunque ubbidisco. Io vidi</l>
             <l>La tua sposa infedel... Ma già cominci,</l>
             <l>Principe, a impallidir! Perdona: è meglio</l>
             <l part="I">Ch'io taccia.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="M">Ah! se non parli... <stage>(minacciandolo</stage></l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">E ben, tu il vuoi:</l>
             <l>Non lagnarti di me. Poc'anzi io vidi</l>
@@ -1680,13 +1705,13 @@
             <l>Che l'antica nel sen fiamma segreta</l>
             <l part="I">Ognor più viva...</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">Ah! mentitor, t'accheta.</l>
             <l>Io conosco Zenobia: ella è incapace</l>
             <l part="I">Di tal malvagità.</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">Tutto degg'io</l>
             <l>Da te soffrir; ma la mia pena, o prence,</l>
@@ -1694,12 +1719,12 @@
             <l>Non meritò questa mercé. Tu stesso</l>
             <l part="I">A parlar mi costringi, e poscia...</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">Oh Dio!</l>
             <l part="I">Non vorrei dubitar.</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">Senza ch'io parli,</l>
             <l>Non conosci abbastanza</l>
@@ -1708,15 +1733,15 @@
             <l>Più di se stessa, e che un amor primiero</l>
             <l part="I">Mai non s'estingue?</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">Ah, che pur troppo è vero!</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="I">(Già si spande il velen).</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">Numi! e a tal segno</l>
             <l>Son le donne incostanti? Oh fortunati</l>
@@ -1724,45 +1749,45 @@
             <l> Dell'arcadi foreste,</l>
             <l>S'è pur ver che da' tronchi al dì nasceste!</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l>Pria di te Tiridate</l>
             <l>Ebbe il cor di Zenobia; e fin ch'ei iva,</l>
             <l part="I">Signor, l'avrà.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">L'avrà per poco: io volo</l>
             <l part="I">A trafiggergli il sen.</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">Ferma: che speri?</l>
             <l>In mezzo a' suoi guerrieri</l>
             <l>T'esponi in van. Se in solitaria parte</l>
             <l part="I">Lungi da' suoi trar si potesse...</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">E come?</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l>Chi sa? Pensiam. Bisogna</l>
             <l part="I">Il colpo assicurar.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">Ma il furor mio</l>
             <l part="I">Non soffre indugi.</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">Ascolta. Un finto messo</l>
             <l>A nome di Zenobia in loco ascoso</l>
             <l part="I">Farò che il tragga.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">E s'ei diffida? Almeno</l>
             <l>D'uopo sarebbe accreditar l'invito</l>
@@ -1776,22 +1801,22 @@
             <l>Se fummi allor, fido stromento ad esso</l>
             <l part="I">Sia di vendetta.</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">(Oh sorte amica!) Attendi</l>
             <l>Alla nascosta valle,</l>
             <l part="I">Dove pria t'incontrai.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="M">Ma...</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">Della trama</l>
             <l>A me lascia il governo.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l>Ricordati che ho in sen tutto l'inferno.</l>
             <lg>
@@ -1809,7 +1834,7 @@
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>ZOPIRO con seguaci, indi ZENOBIA</stage>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l>Oh che illustre vittoria! I miei nemici</l>
             <l>Per me combatteranno, ed io tranquillo</l>
@@ -1838,43 +1863,43 @@
             <l>Che l'istessa Zenobia a dirmi il vero</l>
             <l part="I">Costringerà.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Che veggo!</l>
             <l part="I">Tu in Armenia, o Zopiro!</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">Ah! principessa,</l>
             <l>Giungi opportuna: un tuo consiglio io bramo,</l>
             <l>Anzi un comando tuo. D'affar si tratta,</l>
             <l part="I">Che interessa il tuo cor.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Del mio consorte</l>
             <l part="I">Or vado in traccia.</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">Il perderlo dipende</l>
             <l part="I">O il trovarlo da te.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="M">Che!</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">Senti. Io deggio</l>
             <l>Inevitabilmente o a Radamisto</l>
             <l part="I">Dar morte o a Tiridate.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="M">Ah!...</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">Taci. Il primo</l>
             <l>Già da' miei fidi è custodito; e l'altro</l>
@@ -1882,11 +1907,11 @@
             <l>Gemma per segno, ove l'insidia è tesa,</l>
             <l part="I">Tratto sarà.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="M">Donde in tua man...</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">Finisci</l>
             <l>Pria d'ascoltar. Qual di lor voglio, io posso</l>
@@ -1895,55 +1920,55 @@
             <l>Sei sposa all'altro. In vece mia risolvi:</l>
             <l>Qual vuoi condanna, e qual ti piace assolvi.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l>Dunque... Misera me! Qual empio cenno!</l>
             <l part="I">Per qual ragion? Chi ti costringe...</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">E' troppo</l>
             <l>Lungo il racconto e scarso il tempo: assai</l>
             <l>Ne perdei, te cercando. Apri il tuo core,</l>
             <l part="I">E lasciami partir.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Numi! e tu prendi</l>
             <l>Sì scellerato impegno ed inumano?</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l>Il comando è sovrano, e a me la vita</l>
             <l part="I">Costeria trasgredito.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">E qual castigo,</l>
             <l>Qual premio o quale autorità può mai</l>
             <l part="I">Render giusta una colpa?</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">Addio. Non venni</l>
             <l> Teco a garrir. Nella proposta scelta</l>
             <l>Vedesti il mio rispetto. A mio talento</l>
             <l part="I">Risolverò. <stage>(finge voler partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="M">Ferma!</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="M">Che brami?</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Io... Pensa...</l>
             <l part="I">(Assistetemi, o dèi!)</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">T'intendo: io deggio</l>
             <l>Prevenir le tue brame</l>
@@ -1954,20 +1979,20 @@
             <l>Note mi son. Basta così. Fra poco</l>
             <l part="I">Vendicata sarai. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Perfido! e credi</l>
             <l>Sì malvagia Zenobia? un sì perverso</l>
             <l part="I">Disegno in me?...</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">Non ti sdegnar: l'errore</l>
             <l>Nacque dal tuo silenzio. <stage>(ai seguaci)</stage> Olà! guidate</l>
             <l>La principessa al suo consorte... Io volo</l>
             <l part="I">Tiridate a svenar. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Sentimi. (O numi,</l>
             <l>La mia virtù voi riducete a prove</l>
@@ -1975,57 +2000,57 @@
             <l>Condannar Tiridate! E che mi fece</l>
             <l>Quell'anima fedel? come poss'io...)</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="I">Dubiti ancor?</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">No, non è dubbio il mio:</l>
             <l>So chi deggio salvar; ma di sua vita</l>
             <l part="I">M'inorridisce il prezzo.</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">A me non lice</l>
             <l part="I">Più rimaner: decidi o parto.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Aspetta</l>
             <l part="I">Solo un istante. Ah! tu potresti...</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">Il tempo</l>
             <l>Perdiamo inutilmente. O l'uno o l'altro</l>
             <l part="I">Deve perir.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Dunque perisca... (oh Dio!)</l>
             <l part="I">Dunque salvami...</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="M">Chi?</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Salvami entrambi,</l>
             <l>Se pur vuoi ch'io ti debba il mio riposo;</l>
             <l>E, se entrambi non puoi, salva il mio sposo.</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l>(Ah! Radamisto adora). E vuoi la morte</l>
             <l>D'un sì fido amatore?</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l>Salva il mio sposo, e non mi dir chi muore.</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <lg>
               <l>Salvo tu vuoi lo sposo?</l>
@@ -2084,123 +2109,123 @@
           <head>SCENA PRIMA</head>
           <stage>Bosco.</stage>
           <stage>RADAMISTO ed EGLE</stage>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="I">Chi ti diè quella gemma?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F">Uno straniero</l>
             <l part="I">Ch'io non conosco.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="M">Ed a qual fin?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F">M'impose,</l>
             <l>Con questo segno, e di Zenobia a nome,</l>
             <l>Alla valle de' mirti</l>
             <l part="I">D'invitar Tiridate.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">Andasti a lui?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="I">No.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="M">Perché?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F">Perché questa</l>
             <l part="I">Certamente è una frode.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">(Ah! di costei</l>
             <l>Non potea far Zopiro</l>
             <l>Scelta peggior). Ma del messaggio il peso</l>
             <l part="I">A che dunque accettasti?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F">Affin che un'altra</l>
             <l part="I">Non l'eseguisse.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">(Or la cagion comprendo,</l>
             <l>Per cui fin or nel destinato loco</l>
             <l part="I">Atteso in vano ho Tiridate).</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F">Io vado</l>
             <l> Di sì nera menzogna</l>
             <l part="I">Zenobia ad avvertir. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">No. Senti: a lei</l>
             <l part="I">Narrar non giova...</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F">Anzi ignorar non deve</l>
             <l>Che le insidia un indegno</l>
             <l part="I">La gloria di fedele.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">E tu che sai</l>
             <l>A qual di lor convenga</l>
             <l part="I">D'indegno il nome o di fedel?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F">Che! dunque</l>
             <l part="I">Puoi dubitar...</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="M">Non è più dubbio...</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F">Ah! taci:</l>
             <l part="I">Orror mi fai.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="M">Sappi...</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F">Lo so: non merti</l>
             <l part="I">Tanto amor, tanta fede.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="M">Io son...</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F">Tu sei</l>
             <l>Un ingiusto, un ingrato,</l>
             <l part="I">Un barbaro, un crudel. <stage>(in atto di partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F"><stage>(seguendola)</stage> Se puoi, dilegua</l>
             <l part="I">Dunque il sospetto mio.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F">No; quel sospetto</l>
             <l>Sempre, per pena tua, ti resti in petto. <stage>parte</stage></l>
@@ -2232,11 +2257,11 @@
             </lg>
           </sp>
           <stage>(Mentre Radamisto è per partire, sente la voce di Zenobia, s'arresta e si rivolge</stage>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="I">Ma dove andiam?</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">Qual voce udii! La sposa</l>
             <l>Giurerei che parlò. Vien quindi il suono:</l>
@@ -2247,30 +2272,30 @@
         <div type="scene">
           <head>SCENA TERZA</head>
           <stage>ZENOBIA e ZOPIRO, poi RADAMISTO di nuovo.</stage>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l>E non posso saper dove mi guidi?</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="I">Sieguimi: non temer.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F"><stage>(arrestandosi sospettosa)</stage> (Qualche sventura</l>
             <l part="I">Il cor mi presagisce).</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">(Eccola. E' seco</l>
             <l part="I">Zopiro: udiam s'egli è fedel). <stage>(resta in disparte</stage></l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">Che fai?</l>
             <l part="I">Vieni: al tuo sposo io ti conduco.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">E quando</l>
             <l>Il troverem? Da noi</l>
@@ -2278,149 +2303,149 @@
             <l>Già lung'ora m'aggiro</l>
             <l>Per sì strani sentieri, e ancor nol miro.</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="I">Pur l'hai presente.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Io l'ho presente? Oh Dio!</l>
             <l part="I">Come? Dov'è?</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">Lo sposo tuo son io.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="I">Numi! <stage>(sorpresa</stage></l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">(Ah, mora il fellon!... <stage>(vuol snudar la spada e si pente)</stage> No; pria bisogna</l>
             <l>Tutta scoprir la frode).</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l>E tu di Radamisto alla consorte</l>
             <l part="I">Osi parlar così?</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">Di Radamisto</l>
             <l part="I">Alla vedova io parlo.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Aimè! non vive</l>
             <l part="I">Dunque il mio sposo?</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">Ad incontrar la morte</l>
             <l part="I">Già l'inviai.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="M">(Fremo!)</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Ah, spergiuro! Adempi</l>
             <l part="I">Così le tue promesse?</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">E in che mancai?</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l>In che! Non mi dicesti</l>
             <l>Che per legge sovrana o Radamisto</l>
             <l part="I">Perir dovea o Tiridate?</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">Il dissi.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l>Che un sol di loro a scelta mia potevi,</l>
             <l part="I">E m'offrivi salvar?</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="M">Sì.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Non ti chiesi</l>
             <l part="I">Del consorte la vita?</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">E' vero; ed io</l>
             <l>D'ubbidirti giurai,</l>
             <l>E uno sposo in Zopiro a te serbai.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="I">(Più non so trattenermi).</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Oh sventurato!</l>
             <l part="I">Oh tradito mio sposo!</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">In van lo chiami;</l>
             <l>Fra gli estinti ei dimora.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l>Menti! per tuo castigo ei vive ancora. <stage>(palesandosi</stage></l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="I">Son tradito!</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="M">Ah, consorte!</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">Indegno! infido!</l>
             <l part="I">Così... <stage>(snuda la spada, e vuole assalir Zopiro</stage></l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">T'arresta, o che Zenobia uccido. <stage>(impugnando con la destra uno stile in atto di ferir Zenobia e tenendola afferrata con la sinistra</stage></l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="I">Che fai? <stage>(fermandosi</stage></l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="M">Misera me!</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">Non so frenarmi:</l>
             <l>Il furor mi trasporta.</l>
             <l part="I">Empio...!</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">Se muovi il piè, Zenobia è morta.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="I">Che angustia!</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Amato sposo,</l>
             <l>Già che il Ciel mi ti rende,</l>
@@ -2431,7 +2456,7 @@
             <l>Dal carcere mortal, purché si scioglia</l>
             <l>Senza il rossor della macchiata spoglia.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l>O parte del mio core, o vivo esempio</l>
             <l>D'onor, di fedeltà, dove, in qual rischio,</l>
@@ -2442,30 +2467,30 @@
             <l>Vendicarmi non voglio: io ti perdono</l>
             <l part="I">Tutti gli eccessi tuoi.</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">No, non mi fido.</l>
             <l part="I">Parti.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="M">Il giuro agli dèi...</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">Parti, o l'uccido.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l>Ah, fiera! ah, mostro! ah! delle Furie istesse</l>
             <l>Furia peggior! Da quell'infame petto</l>
             <l part="I">Voglio svellerti... <stage>(avanzandosi</stage></l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="M">Osserva. <stage>(in atto di ferir Zenobia</stage></l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F"><stage>(ritirandosi)</stage> Ah, no! Ma dove,</l>
             <l>Dove son io? Chi mi consiglia? Ah, sposa!...</l>
@@ -2473,35 +2498,35 @@
             <l>Freme l'alma e sospira.</l>
             <l>Mi straccia il cor la tenerezza e l'ira.</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l>Tu, Zenobia, vien meco; <stage>(a Zenobia</stage> <stage>(a Radamisto)</stage> E tu, se estinta</l>
             <l> Rimirarla non vuoi,</l>
             <l part="I">Guardati di seguirci.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">Al mio furore</l>
             <l part="I">Cede già la pietà.</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="M">Vieni. <stage>(a Zenobia</stage></l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">E lo sposo</l>
             <l part="I">M'abbandona così?</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">No. Cadi ormai!... <stage>(volendo assalir Zopiro</stage></l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="I">E tu mori!... <stage>(in atto di ferir Zenobia</stage></l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">Odi, aspetta.</l>
           </sp>
@@ -2509,23 +2534,23 @@
         <div type="scene">
           <head>SCENA QUARTA</head>
           <stage>TIRIDATE e detti.</stage>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F"><stage>(trattenendo Zopiro)</stage> Empio, che fai?</l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="I">Oimè!</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="M">Cedimi il ferro. <stage>(procura levargli lo stile</stage></l>
           </sp>
-          <sp>
+          <sp who="#zopiro">
             <speaker>ZOP.</speaker>
             <l part="F">Ah, son perduto! <stage>(lascia lo stile, e fugge</stage></l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="I">Perfido! in van mi fuggi. <stage>(seguendolo furioso</stage></l>
           </sp>
@@ -2533,57 +2558,57 @@
         <div type="scene">
           <head>SCENA QUINTA</head>
           <stage>ZENOBIA e TIRIDATE</stage>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Ove t'affretti,</l>
             <l part="I">Signor? Fermati. <stage>(a Radamisto, seguendolo</stage></l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">Ingrata!</l>
             <l part="I">Già t'involi da me?</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Principe... Oh Dio!</l>
             <l part="I">Ti pregai d'evitarmi.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">Ah! quale arcano</l>
             <l>Mi si nasconde? Ubbidirò; ma dimmi</l>
             <l part="I">Perché mi fuggi almen.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Tutto saprai</l>
             <l part="I">Pria di quel che vorresti. Addio.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">Perdona,</l>
             <l part="I">Deggio seguirti.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="M">Ah! no.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">Pur or ti vidi</l>
             <l> In troppo gran periglio. Io non conosco</l>
             <l>Chi t'assalì, chi ti difese, e sola</l>
             <l>Lasciarti in rischio a gran rossor mi reco.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l>Il mio rischio più grande è l'esser teco. <stage>(partendo</stage></l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="I">Ma ch'io non possa almen... <stage>(volendo seguirla</stage></l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Lasciami in pace;</l>
             <l>Per pietà lo domando. E' questa vita</l>
@@ -2606,7 +2631,7 @@
         <div type="scene">
           <head>SCENA SESTA</head>
           <stage>TIRIDATE e poi MITRANE</stage>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l>Non intendo Zenobia, e non intendo</l>
             <l>Ormai quasi me stesso. Ella mi scaccia,</l>
@@ -2616,25 +2641,25 @@
             <l>In quelle ciglia un non so che risplende,</l>
             <l>Che rigetta ogni accusa e lei difende.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l>Signor, liete novelle: è Radamisto</l>
             <l part="I">Tuo prigionier.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="M">Dove il giungesti?</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="F">Ei venne</l>
             <l part="I">Per se stesso a' tuoi lacci.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="M">E come?</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="F">Appresso</l>
             <l>A un guerrier fuggitivo entrò l'audace</l>
@@ -2643,11 +2668,11 @@
             <l>Dell'orrenda ira sua cercò l'oggetto:</l>
             <l>Lo vide, il giunse e gli trafisse il petto.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="I">Che ardir!</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="F">Tutto non dissi. Uscir dal vallo</l>
             <l>Sperò di nuovo, e l'intraprese, e forse</l>
@@ -2657,7 +2682,7 @@
             <l>Cresca contro di lui l'infesta piena,</l>
             <l>Egli è solo ed inerme, e cede appena.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l>Un di que' due, che or ora</l>
             <l part="I">Qui rimirai, l'empio sarà.</l>
@@ -2666,74 +2691,74 @@
         <div type="scene">
           <head>SCENA SETTIMA</head>
           <stage>EGLE, da prima non veduta, e detti.</stage>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="F">La vita</l>
             <l part="I">Di Radamisto ecco in tua man. <stage>(a Tiridate</stage></l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F">(Che sento!)</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="I">Punisci il traditor.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="M">Sì, andiam. <stage>(vuol partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F">T'arresta,</l>
             <l>Prence: ove corri? incrudelir non déi</l>
             <l part="I">Contro quell'infelice.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">E te chi muove</l>
             <l part="I">D'un perfido in difesa?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F">Io non lo credo,</l>
             <l part="I">Signor, sì reo.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">Ma di Zenobia il padre</l>
             <l part="I">A tradimento oppresse.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="F">E poi la figlia</l>
             <l>Tentò svenar. Non m'ingannò chi vide</l>
             <l part="I">L'atto crudel.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F">Pensaci meglio. A tutto</l>
             <l>Prestar fé non bisogna; e co' nemici</l>
             <l part="I">Più bella è la pietà.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">Le proprie offese</l>
             <l> Posso obliar; ma di Zenobia i torti</l>
             <l>Perdonargli io non posso. A lei quel sangue</l>
             <l part="I">Si deve in sacrifizio.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F">Io t'assicuro</l>
             <l part="I">Ch'ella nol chiede.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">E non richiesto appunto</l>
             <l part="I">Ha merito il servir. <stage>(vuol partire</stage></l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F">Fermati, oh dèi!</l>
             <l>Credi: non parlo in van: Se ami Zenobia,</l>
@@ -2741,16 +2766,16 @@
             <l>T'espone a un grande errore;</l>
             <l>Tu vuoi servirla, e le trafiggi il core.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="I">Ma perché? L'ama forse?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F">Ella?... Se brami...</l>
             <l part="I">Io dovrei... (Troppo dico).</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">Ah! ti confondi.</l>
             <l>Mitrane, io son di gel Fu Radamisto</l>
@@ -2760,11 +2785,11 @@
             <l>Egle m'avverte... Ah! per pietà palesa,</l>
             <l>Pastorella gentil, ciò che ne sai.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l>Altro dir non poss'io: già dissi assai.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l>Aimè! Qual fredda mano</l>
             <l>Mi si aggrava sul cor! che tormentoso</l>
@@ -2786,7 +2811,7 @@
         <div type="scene">
           <head>SCENA OTTAVA</head>
           <stage>EGLE e MITRANE</stage>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l>Povero prence! Oh quanta</l>
             <l>Pietà sento di lui! qual pena io provo</l>
@@ -2797,7 +2822,7 @@
             <l>Merita miglior sorte. Oh, s'io potessi</l>
             <l part="I">Renderlo più felice!</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="F">Assai pietosa,</l>
             <l>Egle, mi sembri. Ei di pietade è degno;</l>
@@ -2847,7 +2872,7 @@
           <head>SCENA DECIMA</head>
           <stage>Deliziosa dei re d'Armenia, abitata da Tiridate.</stage>
           <stage>TIRIDATE e MITRANE</stage>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l>Pur troppo è ver; pur troppo</l>
             <l>D'Egle i detti intendesti: è Radamisto</l>
@@ -2856,23 +2881,23 @@
             <l>Frettolosa alle tende, a lui l'ingresso</l>
             <l>Ardì cercar; ma non le fu permesso.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l>E pur, Mitrane, e pure</l>
             <l part="I">Non so crederlo ancora.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="F">A lei fra poco</l>
             <l>Lo crederai: del prigionier la vita</l>
             <l part="I">A dimandarti ella verrà.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">Che ardisca</l>
             <l part="I">D'insultarmi a tal segno?</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="F">A te dinanzi</l>
             <l>Giunta di già saria; ma due guerrieri,</l>
@@ -2880,17 +2905,17 @@
             <l>A lei recano un foglio, a gran fatica</l>
             <l part="I">La ritengon per via.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">No, no, l'ingrata</l>
             <l>Non mi venga su gli occhi: io non potrei</l>
             <l part="I">Più soffrirne l'aspetto.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="M">Eccola.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">Oh dèi!</l>
           </sp>
@@ -2898,11 +2923,11 @@
         <div type="scene">
           <head>SCENA UNDICESIMA</head>
           <stage>ZENOBIA e detti.</stage>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="I">Principe...</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">Il grande arcano,</l>
             <l>Lode al Ciel, si scoperse. Al fin palese</l>
@@ -2913,11 +2938,11 @@
             <l>Lo brami sposo? ho da apprestar le tede</l>
             <l part="I">Al felice imeneo?</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="M">Signor...</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">Tiranna!</l>
             <l>Barbara! menzognera! il premio è questo</l>
@@ -2925,39 +2950,39 @@
             <l>E per chi, giusti dèi! per chi d'un padre</l>
             <l part="I">Ti privò fraudolento, e poi...</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">T'inganni;</l>
             <l part="I">Mentì la fama.</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="F"><stage>(a Tiridate)</stage> E' ver: da Farasmane</l>
             <l>Il colpo venne. Il perfido Zopiro</l>
             <l part="I">Lo palesò morendo.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">E tu dài fede</l>
             <l part="I">A un traditor?</l>
           </sp>
-          <sp>
+          <sp who="#mitrane">
             <speaker>MIT.</speaker>
             <l part="F">Sì: lo conferma un foglio</l>
             <l>Ch'ei seco avea. Del tradimento in esso</l>
             <l>Son gli ordini prescritti, e Farasmane</l>
             <l part="I">Di sua mano il vergò.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Vedi se a torto...</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l>Taci: il tuo amor per Radamisto accusi,</l>
             <l part="I">Mentre tanto il difendi.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">E' vero, io l'amo,</l>
             <l>Non pretendo celarlo. Il suo periglio</l>
@@ -2971,36 +2996,36 @@
             <l>Secondo il lor disegno:</l>
             <l>Rendimi Radamisto; abbiti il regno.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l>Per un novello amante</l>
             <l>In vero il sacrifizio è generoso.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l>Ma eccessivo non è per uno sposo.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="I">Sposo!</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="M">Appunto.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">Ed è vero? e un tal segreto</l>
             <l part="I">Mi si cela fin or?</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Contro il consorte</l>
             <l>Dubitai d'irritarti; il tuo temei</l>
             <l>Giusto dolor; non mi sentia capace</l>
             <l>D'esserne spettatrice; e almen da lungi...</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l>Oh instabile! oh crudele!</l>
             <l>Oh ingratissima donna! A chi fidarsi,</l>
@@ -3008,7 +3033,7 @@
             <l>Quanto s'ascolta e vede:</l>
             <l>Zenobia mi tradì; non v'è più fede.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l>Non son io, Tiridate,</l>
             <l>Quella che ti tradì; fu il Ciel nemico,</l>
@@ -3017,30 +3042,30 @@
             <l>Cambiar lo fe': so che partisti, e ad altro</l>
             <l part="I">Sposo mi destinò.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">Né tu potevi...</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l>Che potevo? infelice! 'E regno e vita</l>
             <l>E onor' mi disse 'a conservarmi, o figlia,</l>
             <l>Ecco l'unica strada.' Or di': che avresti</l>
             <l part="I">Saputo far tu nel mio caso?</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">Avrei</l>
             <l>Saputo rimaner di vita privo.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l>Io feci più: t'ho abbandonato, e vivo.</l>
             <l>Non giovava la morte</l>
             <l>Che a far breve il mio duol: te ucciso avrei,</l>
             <l part="I">Disubbidito il padre.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">I nuovi lacci</l>
             <l> Però non ti son gravi: assai t'affanni</l>
@@ -3048,26 +3073,26 @@
             <l>Lusingare il tuo cor. Fu falso, il vedo,</l>
             <l part="I">Che svenarti ei tentò.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Fu ver; ma questo</l>
             <l>Non basta a render gravi i miei legami.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="I">Non basta?</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="M">No.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">Tentò svenarti, e l'ami?</l>
             <l>E l'ami a questo segno,</l>
             <l>Che m'offrì per salvarlo in prezzo un regno?</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l>Sì, Tiridate; e, s'io facessi meno,</l>
             <l>Tradirei la mia gloria,</l>
@@ -3079,11 +3104,11 @@
             <l>Quel puro cor che in me ti piacque? Indegna,</l>
             <l>Dimmi, allor non sarei d'averti amato?</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l>Quanta, ahi quanta virtù m'invola il fato!</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l>Deh! s'è pur ver che nasca</l>
             <l>Da somiglianza amor, perché combatti</l>
@@ -3097,7 +3122,7 @@
             <l>Che, nato in nobil core,</l>
             <l>Frutti sol di virtù produce amore.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l>Corri, vola, Mitrane: a noi conduci</l>
             <l>Libero Radamisto. <stage>(Mitrane parte</stage> Oh, come volgi,</l>
@@ -3113,14 +3138,14 @@
             <l>Imitator de' puri tuoi costumi,</l>
             <l>T'amo come i mortali amano i numi.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l>Grazie, o dèi protettori! Or più nemici</l>
             <l>Non ha la mia virtù: vinsi il più forte,</l>
             <l>Ch'era il pensier del tuo dolor. Va, regna,</l>
             <l part="I">Prence, per me; ne sei ben degno.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">Ah! taci:</l>
             <l>Non m'offender così. Prezzo io non chiedo,</l>
@@ -3131,36 +3156,36 @@
         <div type="scene">
           <head>SCENA ULTIMA</head>
           <stage>EGLE, poi RADAMISTO con MITANE, e detti.</stage>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l>Lascia, amata germana,</l>
             <l part="I">Lascia che a questo seno...</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Egle, che dici?</l>
             <l part="I">Quai sogni?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F">Egle non più: la tua perduta</l>
             <l>Arsinoe io son. Questa vermglia osserva</l>
             <l>Nota, che porta al manco braccio impressa</l>
             <l part="I">Ciascun di nostra stirpe.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="M">E' vero!</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">Oh stelle!</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l>Quante gioie in un punto! E donde il sai?</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l>Da quel pastor, che padre</l>
             <l>Credei fin ora. Ei da' ribelli Armeni,</l>
@@ -3175,45 +3200,45 @@
             <l>Tutta la sorte mia</l>
             <l>Lagrimando mi svela, e a te m'invia.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l>Ben ti conobbi in volto</l>
             <l part="I">L'alma real.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="M">Deh! Tiridate...</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l part="F">Ah! vieni,</l>
             <l>Vieni, o signore. Ecco, Zenobia, il tanto</l>
             <l>Tuo cercato consorte: io te lo rendo.</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="I">Perdono, o sposa.</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="M">E di quel fallo?</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="F">Oh Dio!</l>
             <l part="I">Il mio furor geloso...</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Il tuo furore</l>
             <l>Per eccesso d'amor ti nacque in petto:</l>
             <l>La cagion mi ricordo e non l'effetto.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l>Oh virtù sovrumana!</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l>Principe, una germana il Ciel mi rende, <stage>(a Tiridate</stage></l>
             <l>A cui deggio la vita: esserle grata</l>
@@ -3221,24 +3246,24 @@
             <l>Che doveva essere mia,</l>
             <l>Diasi a mia voglia almen; d'Arsinoe or sia.</l>
           </sp>
-          <sp>
+          <sp who="#tiridate">
             <speaker>TIR.</speaker>
             <l>Prendila, principessa. Ogni tuo cenno,</l>
             <l part="I">Zenobia, adoro.</l>
           </sp>
-          <sp>
+          <sp who="#egle">
             <speaker>EGLE</speaker>
             <l part="F">Oh fortunato istante!</l>
           </sp>
-          <sp>
+          <sp who="#radamisto">
             <speaker>RAD.</speaker>
             <l part="I">Oh fida sposa!</l>
           </sp>
-          <sp>
+          <sp who="#zenobia">
             <speaker>ZEN.</speaker>
             <l part="F">Oh generoso amante!</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>E' menzogna il dir che Amore</l>
             <l>Tutto vinca, e sia tiranno</l>

--- a/tei/monti-caio-gracco.xml
+++ b/tei/monti-caio-gracco.xml
@@ -82,6 +82,52 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="caio">
+            <persName>Caio Gracco</persName>
+          </person>
+          <person xml:id="fulvio">
+            <persName>M. Fulvio</persName>
+          </person>
+          <person xml:id="cornelia">
+            <persName>Cornelia</persName>
+          </person>
+          <person xml:id="licinia">
+            <persName>Licinia</persName>
+          </person>
+          <person xml:id="druso">
+            <persName>Livio Druso</persName>
+          </person>
+          <person xml:id="opimio">
+            <persName>L. Opimio</persName>
+          </person>
+          <personGrp xml:id="popolo">
+            <name>Popolo</name>
+          </personGrp>
+          <person xml:id="uno_del_popolo">
+            <persName>Uno del popolo</persName>
+          </person>
+          <person xml:id="cittadino_1">
+            <persName>Primo cittadino</persName>
+          </person>
+          <person xml:id="cittadino_2">
+            <persName>Secondo cittadino</persName>
+          </person>
+          <person xml:id="cittadino_3">
+            <persName>Terzo cittadino</persName>
+          </person>
+          <person xml:id="cittadino_4">
+            <persName>[Un cittadino (atto terzo, scena II)]</persName>
+          </person>
+          <person xml:id="vecchio">
+            <persName>Un vecchio del popolo</persName>
+          </person>
+          <personGrp xml:id="senatori">
+            <name>Senatori</name>
+          </personGrp>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -134,7 +180,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>CAIO solo.</stage>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l>Eccoti, Caio, in Roma. Io qui non visto</l>
             <l>entrai protetto dalla notte amica.</l>
@@ -165,7 +211,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>FULVIO con uno schiavo, e DETTO.</stage>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="F">Sgombra,</l>
             <l>servo fedele, ogni timor. Compiemmo</l>
@@ -183,33 +229,33 @@
             <l>tenebroso spiando i passi altrui?</l>
             <l part="I">Non t'avanzar: chi sei? parla.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">La voce</l>
             <l part="I">non è questa di Fulvio?</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="F">Che pretendi</l>
             <l>tu da Fulvio? Che ardir s'è questo tuo</l>
             <l>d'interrogar fra l'ombre un cittadino</l>
             <l part="I">che non ti cerca?</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Ah! tu sei desso. Oh Fulvio!</l>
             <l part="I">Abbracciami. Son Caio.</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="F"> Oh ciel! Tu Caio?</l>
             <l part="I">Tu?. . .</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="M">Sì, taci; son io.</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="F">Oh me felice!</l>
             <l>Oh sospirato amico! E qual propizio</l>
@@ -217,7 +263,7 @@
             <l>sul lido ti credea. Come ne vieni?</l>
             <l part="I">Come dunque ritorni?</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Io là spedito</l>
             <l>fui di Cartago a rialzar le mura.</l>
@@ -238,7 +284,7 @@
             <l>qual folgore qui giungo. Or, quale abbiamo</l>
             <l part="I">stato di cose?</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="F">Periglioso e tristo.</l>
             <l>L'altero Opimio, il tuo crudel nemico,</l>
@@ -252,21 +298,21 @@
             <l>tribunato le leggi; e il dì che viene,</l>
             <l>a quest'opra d'infamia è già prefisso.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="I">Ma i tribuni che fan?</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="F">Fanno mercato</l>
             <l>de' lor sacri doveri. A prezzo han messa</l>
             <l>lor potestade, e i senator l'han compra.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="I">Oh infami!</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="F">E Druso, il capo della mandra</l>
             <l>tribunizia, il codardo e molle Druso,</l>
@@ -279,7 +325,7 @@
             <l>e forse pur della tua vita, il nero</l>
             <l part="I">orribile contratto.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Alto contratto,</l>
             <l>degno di tali mercatanti! Oh Roma!</l>
@@ -291,20 +337,20 @@
             <l>ch'altro adesso se' tu che una temuta</l>
             <l>illustre tana di ladroni? Io fremo.</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l>Freme ogni vero cittadin. Ma questo</l>
             <l>di dolor non è tempo e di sospiri;</l>
             <l part="I">tempo è di fatti.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F"> E li farem. Ma pria</l>
             <l>le nostre forze esaminiam. Rispondi:</l>
             <l>quanti amici, se amici ha la sventura,</l>
             <l part="I">nella fede restâr?</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="F">Pochi, ma forti.</l>
             <l>L'intrepido Carbon, già tuo collega</l>
@@ -334,7 +380,7 @@
             <l>questo nume terreno, e dagli altari</l>
             <l part="I">gittato nella polve.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">E che per questo?</l>
             <l>Nell'ire sue l'avversa sorte a Gracco</l>
@@ -346,7 +392,7 @@
             <l>un dio ne fece. Ma perché tra' nostri</l>
             <l part="I">Fannio non conti?</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="F">Fannio? Il vile è fatto</l>
             <l>tuo nemico mortal. Pose in obblio</l>
@@ -356,7 +402,7 @@
             <l>E tel predissi allor che tu nel core</l>
             <l>d'un ingrato locavi il benefizio.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l>Sì, nel cor d'un patrizio. Ah! ch'io non sempre</l>
             <l>fui nella scelta degli amici uom saggio.</l>
@@ -368,7 +414,7 @@
             <l>parlami vero, è tutta in lei già morta</l>
             <l part="I">la memoria di Caio?</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="F">Aura che passa,</l>
             <l>ed or da questo or da quel lato spira,</l>
@@ -391,7 +437,7 @@
             <l>langue ogni spirto; trepida, abbattuta</l>
             <l>geme la plebe; ti desìa, ma tace.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l>Io parlar la farò. Lion che dorme</l>
             <l>è la plebe romana, e la mia voce</l>
@@ -417,37 +463,37 @@
             <l>patria, e l'immago d'un fratel che grida,</l>
             <l>son dieci anni, vendetta, e ancor non l'ebbe.</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="I">Già l'ebbe.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="M">E quale?</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="M">Lo saprai.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Ti spiega.</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="I">Senti. . . (Incauto, che fo?)</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Perché t'arresti?</l>
             <l part="I">perché non parli?</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="F">Scusa. Ha qualche volta</l>
             <l part="I">i suoi segreti l'amistà.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">No, mai</l>
             <l>la verace amistà. Ma, sia qualunque,</l>
@@ -456,38 +502,38 @@
             <l>quale osserva contegno in tanto affare</l>
             <l>il mio congiunto Emilian? Che dice?</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l>Emilian?. . . Perdona, ogni tuo detto</l>
             <l>è una domanda; e della madre ancora,</l>
             <l>e della sposa, o Caio, e del tuo figlio</l>
             <l part="I">nulla inchiedesti?</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">I pensier primi a Roma:</l>
             <l>darò i secondi a mia famiglia. Or dunque,</l>
             <l>d'Emiliano che sperar? Marito</l>
             <l part="I">di mia sorella. . .</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="F">Nol chiamar marito,</l>
             <l part="I">ma tiranno.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Lo so che la meschina</l>
             <l part="I">di tal consorte non è lieta.</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="F">E il puote</l>
             <l>esser mai donna che plebea si stringe</l>
             <l>a marito patrizio? Egli l'abborre,</l>
             <l part="I">e te del pari abborre.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Ed io. . . non l'amo.</l>
             <l>Ma non t'ascondo il ver: l'alta sua fama,</l>
@@ -498,16 +544,16 @@
             <l>tutto in lui mi conturba; e duro intoppo,</l>
             <l>s'egli n'è contra, alla vittoria avremo.</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l>E noi vittoria avrem, s'altro non temi:</l>
             <l part="I">ti rassicura.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="M">. . . Io non t'intendo.</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="F">In breve</l>
             <l>m'intenderai. Ma noi spendiam qui indarno</l>
@@ -516,29 +562,29 @@
             <l>di tua venuta. A confortarli io corro</l>
             <l part="I">di tanto annunzio.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="M">Férmati.</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="F">A qual fine?</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="I">A farmi chiaro il tuo parlar.</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="F">T'accheta.</l>
             <l>Romor di passi ascolto, e venir sembra</l>
             <l part="I">dalle tue soglie.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="M">Oh ciel! che fia?</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="F">T'accheta.</l>
           </sp>
@@ -546,78 +592,78 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>CORNELIA, LICINIA col figlio per mano, il liberto FILOCRATE, e DETTI</stage>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l>Frena il pianto, Licinia, e non tradire</l>
             <l>co' tuoi lamenti i nostri passi. Andiamo</l>
             <l>tacitamente, o figlia. - E tu ci scorta,</l>
             <l part="I">Filocrate.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Qual voce! Udisti? Ah! questa,</l>
             <l part="I">questa è mia madre.</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="M">Avviciniamci.</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">Gente</l>
             <l>s'appressa. - State: io vado innanzi, io sola</l>
             <l part="I">esploratrice.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="M">Il cor mi balza.</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">Olà,</l>
             <l part="I">cittadini, chi siete?</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Oh madre mia!</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="I">Di chi madre?</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Di Gracco. Sì, son io;</l>
             <l>non sospettar, son Caio; riconosci</l>
             <l part="I">del tuo figlio la voce.</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">Ah tu sei desso!</l>
             <l>Il cor ti vede. Oh caro figlio! E come?. . .</l>
             <l part="I">Quando?. . .</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Tutto saprai. Ma la consorte,</l>
             <l>Licinia mia, dov'è? Tu la nomavi</l>
             <l part="I">pur or: dov'è?</l>
           </sp>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <l part="F">Fra le tue braccia. Il suono</l>
             <l>di tua voce su l'anima mi corse,</l>
             <l part="I">e il cor sentì la tua presenza.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Oh gioia!</l>
           </sp>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <l part="I">E questo il vedi? Lo ravvisi?</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Il figlio?</l>
             <l>Possenti numi! il figlio mio? Nell'ora</l>
@@ -629,18 +675,18 @@
             <l>per quest'ombre a vagar? Chi vi persegue?</l>
             <l part="I">Chi vi caccia?</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">. . . Filocrate, rientra,</l>
             <l>e teco adduci quel fanciul. - Chi è questi</l>
             <l part="I">che t'accompagna? <stage>(Piano a CAIO.)</stage></l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Un mio fidato amico,</l>
             <l part="I">e udir può tutto.</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">Dirò dunque aperto</l>
             <l>di tua famiglia il duro stato, e quali</l>
@@ -674,14 +720,14 @@
             <l>tu sei, cangiato è il mio consiglio, e l'alma</l>
             <l part="I">più non mi trema.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">E di tremar ti vieto.</l>
             <l>Fra poco il sole ed il tuo figlio in Roma</l>
             <l>mostreranno la fronte, e cangerassi</l>
             <l>degli uomini la faccia e delle cose.</l>
           </sp>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <l>Lo spero io ben; ma se lontan mi fosti</l>
             <l>di lagrime cagion, presente adesso</l>
@@ -695,7 +741,7 @@
             <l>deh! custodisci per pietà la vita</l>
             <l part="I">del tuo figlio e la mia.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Ti riconforta,</l>
             <l>consorte amata; e sulla certa speme</l>
@@ -705,20 +751,20 @@
             <l>di mia famiglia protettor pietoso?</l>
             <l part="I">questo patrizio non perverso?</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">Il figlio</l>
             <l part="I">d'Emilio, il tuo cognato.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Un mio nemico?</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l>Non è tal chi comparte un beneficio.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l>Ei m'è nemico; e atroce offesa io stimo</l>
             <l>il beneficio di nemica mano.</l>
@@ -727,28 +773,28 @@
             <l>egli è l'idol de' grandi, il più superbo</l>
             <l>dispregiatore della plebe, e basta.</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="I">Tu oltraggi la virtù.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Non è virtude,</l>
             <l>ov'anco amor del popolo non sia.</l>
             <l part="I">Cessa: m'irrita il tuo parlar.</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">La prima</l>
             <l>volta s'è questa che al mio figlio è grave</l>
             <l>la mia favella. Al tuo dolor perdono</l>
             <l part="I">l'irriverente tua risposta.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Oh madre!</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l>Più tacermi non so. - Donna, tu prendi</l>
             <l>sconsigliata difesa, e sul tuo labbro</l>
@@ -762,17 +808,17 @@
             <l>Oh Cornelia! tu sei famoso seme</l>
             <l>di questa schiatta, e tu la plebe adori?</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="I">Caio, chi è questo temerario?</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="F">Appella</l>
             <l>qual più ti piace il ragionar mio franco;</l>
             <l part="I">Marco Fulvio son io.</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">Sei Fulvio, ed osi</l>
             <l>voce alzar me presente? E ancor non sai</l>
@@ -787,32 +833,32 @@
             <l>Che di comune hai tu con un siffatto</l>
             <l part="I">malvagio? Un Gracco con un Fulvio!</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="F">Oh rabbia!</l>
             <l part="I">Quale oltraggio?</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="M">Qual merti.</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="F">E chi ti diede</l>
             <l part="I">su me tal dritto?</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">I tuoi costumi, e forse</l>
             <l part="I">i tuoi misfatti.</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="F">I miei misfatti, o donna,</l>
             <l>son due: l'odio a' superbi, e immenso, ardente</l>
             <l part="I">amor di libertà.</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">Di libertade</l>
             <l>che parli tu, e con chi? Non hai pudore,</l>
@@ -838,13 +884,13 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>CAIO e FULVIO</stage>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="F">Udisti? E mi degg'io</l>
             <l>soffrir sì atroce favellar? Daresti</l>
             <l part="I">tu fede al detto di costei?</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Rispetta</l>
             <l>mia madre, e pensa a ben scolparti; intendi?</l>
@@ -867,7 +913,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>OPIMIO e DRUSO</stage>
-          <sp>
+          <sp who="#druso">
             <speaker>DRUSO</speaker>
             <l>Il primo raggio appena al Palatino</l>
             <l>illumina le cime, e già pel Foro</l>
@@ -882,46 +928,46 @@
             <l>inoperoso? e il dirò pur, se lice,</l>
             <l>dimentico d'altrui e di sé stesso?</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="I">Tribuno, hai pronti i tuoi colleghi?</l>
           </sp>
-          <sp>
+          <sp who="#druso">
             <speaker>DRUSO</speaker>
             <l part="F">Tutti</l>
             <l part="I">da te pendiamo.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Riposar poss'io</l>
             <l part="I">su la lor fede?</l>
           </sp>
-          <sp>
+          <sp who="#druso">
             <speaker>DRUSO</speaker>
             <l part="M">Ella t'è sacra.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">I capi</l>
             <l part="I">del popolo son nostri?</l>
           </sp>
-          <sp>
+          <sp who="#druso">
             <speaker>DRUSO</speaker>
             <l part="F">Il ricevuto</l>
             <l>oro, e la speme di maggior mercede</l>
             <l part="I">te n'assicura.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">E le tribù son tutte</l>
             <l>alla calma disposte ed al rispetto?</l>
           </sp>
-          <sp>
+          <sp who="#druso">
             <speaker>DRUSO</speaker>
             <l>Tutte. La plebe non fu mai, mel credi,</l>
             <l>più docile, più saggia e mansueta.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l>È la plebe romana una tal belva,</l>
             <l>che, come manco il pensi, apre gli artigli,</l>
@@ -931,12 +977,12 @@
             <l>per tornar poscia ad adorarti estinto. -</l>
             <l part="I">Di me che pensa questa belva?</l>
           </sp>
-          <sp>
+          <sp who="#druso">
             <speaker>DRUSO</speaker>
             <l part="F">Muta</l>
             <l part="I">t'osserva, e trema.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Il suo tremar m'è caro</l>
             <l>più d'assai che l'amarmi. Ma, di plebe</l>
@@ -948,20 +994,20 @@
             <l>E non invoca, non rimembra intanto</l>
             <l part="I">il suo Gracco ella più?</l>
           </sp>
-          <sp>
+          <sp who="#druso">
             <speaker>DRUSO</speaker>
             <l part="F">Ben lo rimembra;</l>
             <l>ma come sogno lusinghier fuggito.</l>
             <l>Rotto è il fascino al fine, in che l'avvolse</l>
             <l part="I">quel periglioso forsennato.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">E credi</l>
             <l>che indifferente ne vedrà soppressi</l>
             <l part="I">i plebisciti?</l>
           </sp>
-          <sp>
+          <sp who="#druso">
             <speaker>DRUSO</speaker>
             <l part="F">Il lor funesto effetto,</l>
             <l>le discordie vo' dir, che amare e tante</l>
@@ -974,47 +1020,47 @@
             <l>e tutte cancellarle opra ti fia</l>
             <l>agevole del par che gloriosa.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="I">Più dura, amico, che non pensi.</l>
           </sp>
-          <sp>
+          <sp who="#druso">
             <speaker>DRUSO</speaker>
             <l part="F">E quali</l>
             <l>ostacoli figuri? Onnipossente</l>
             <l>è il tuo partito, disperato e nullo</l>
             <l>quello di Gracco: egli è lontano, e temi?</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l>Io mai non temo. - Ma senti e stupisci:</l>
             <l part="I">Gracco è in Roma.</l>
           </sp>
-          <sp>
+          <sp who="#druso">
             <speaker>DRUSO</speaker>
             <l part="F">Oh! che dici? In Roma Gracco?</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="I">In Roma.</l>
           </sp>
-          <sp>
+          <sp who="#druso">
             <speaker>DRUSO</speaker>
             <l part="M">E come, se in Cartago?. . .</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">In Roma,</l>
             <l>ti dico; e Fulvio già ne porse avviso</l>
             <l>a Pomponio, a Licinio, e a quanti v'hanno</l>
             <l part="I">suoi parteggianti.</l>
           </sp>
-          <sp>
+          <sp who="#druso">
             <speaker>DRUSO</speaker>
             <l part="F">E non potrìa qualcuno</l>
             <l part="I">ingannarti?</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Ingannar me non ardisce</l>
             <l>nessun. Per tutto orecchie ed occhi e mani</l>
@@ -1028,13 +1074,13 @@
             <l>vittime a questa rediviva e cara</l>
             <l part="I">popolar deità.</l>
           </sp>
-          <sp>
+          <sp who="#druso">
             <speaker>DRUSO</speaker>
             <l part="F">La maraviglia</l>
             <l>il pensier mi confonde e le parole.</l>
             <l part="I">Qual dio nemico lo condusse?</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Un dio</l>
             <l>che lo persegue; il dio che spinse a morte</l>
@@ -1045,12 +1091,12 @@
             <l>Vedrai. . . Ma prima vo' parlargli. Io venni</l>
             <l>espressamente a questo, e qui l'attendo.</l>
           </sp>
-          <sp>
+          <sp who="#druso">
             <speaker>DRUSO</speaker>
             <l>Console, bada: temerario e fiero</l>
             <l part="I">e bollente è quel cor.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Ma generoso,</l>
             <l>ma leal. Sua virtù mi fa sicuro</l>
@@ -1062,14 +1108,14 @@
             <l>di starsi in calma, e nulla osar. Non chieggo</l>
             <l part="I">da voi, tribuni, che prudenza.</l>
           </sp>
-          <sp>
+          <sp who="#druso">
             <speaker>DRUSO</speaker>
             <l part="F">Io volo.</l>
           </sp>
         </div>
         <div type="scene">
           <head>SCENA II</head>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <stage>solo.</stage>
             <l>Io mi dolea che lungi ei fosse; ed ecco</l>
@@ -1089,12 +1135,12 @@
             <l>fervid'onda di plebe, ed orgoglioso</l>
             <l>fra gli applausi avanzarsi il mio nemico.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>POPOLO</speaker>
             <stage>dentro la scena.</stage>
             <l part="I">Viva Gracco.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Tripudia, esulta, sfógati,</l>
             <l>stolida plebe, generata in seno</l>
@@ -1108,11 +1154,11 @@
           <sp>
             <l part="F">Viva Gracco. Onore a Gracco.</l>
           </sp>
-          <sp>
+          <sp who="#uno_del_popolo">
             <speaker>UNO DEL POPOLO</speaker>
             <l part="I">Morte ai patrizi.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">A nessun morte, amati</l>
             <l>miei fratelli; a nessuno. Io qui non miro</l>
@@ -1129,16 +1175,16 @@
             <l>Fia quello il tempo di spiegar la vostra</l>
             <l part="I">alta, tremenda maestà.</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_1">
             <speaker>PRIMO CITTADINO</speaker>
             <l part="F">Ben parla:</l>
             <l part="I">Gracco è un nobile cor.</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_2">
             <speaker>SECONDO CITTADINO</speaker>
             <l part="F">Del giusto amico.</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_3">
             <speaker>TERZO CITTADINO</speaker>
             <l>Vero sangue plebeo. Gracco, disponi</l>
             <l part="I">di nostre vite. <stage>(Il popolo si ritira.)</stage></l>
@@ -1147,42 +1193,42 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>OPIMIO e GRACCO</stage>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">A che mi guardi, e in atto</l>
             <l>di stupor ti soffermi? Non ravvisi</l>
             <l part="I">Lucio Opimio?</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Son tali i tuoi sembianti,</l>
             <l>che si fan tosto ravvisar. Ma, dove</l>
             <l>nol potesse lo sguardo, il cor che freme</l>
             <l>alla tua vista, mi dirìa chi sei.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l>Ti dirà dunque ch'io son tuo nemico,</l>
             <l>e securo abbastanza il cor mi sento</l>
             <l>per affermarlo, e non temerti. - Or dunque</l>
             <l>che tutto mi conosci, odi e rispondi.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="I">Vuoi tu tradirmi innanzi tempo?</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Il forte</l>
             <l part="I">non sa tradire; ed io son forte.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">E iniquo:</l>
             <l>e tal tu sendo, ascoltator ti cerca</l>
             <l part="I">più rispettoso.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Se consiglio prendi</l>
             <l>dall'odio, va; se tuttavolta caro,</l>
@@ -1190,28 +1236,28 @@
             <l>l'alto interesse, férmati. Qui trassi</l>
             <l part="I">a parlarti di lei.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Dell'interesse</l>
             <l part="I">sol della patria?</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="M">Di ciò sol.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">T'ascolto.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="I">Giurami calma, attenzion.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">La giuro.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l>Tra noi tu vedi in due Roma divisa:</l>
             <l>tu libera la brami, ed io la bramo.</l>
@@ -1253,13 +1299,13 @@
             <l>alme tutte di fango, e vitupéro</l>
             <l part="I">del gran nome romano.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">E Opimio ardisce</l>
             <l>con questi vili pareggiar me Gracco?</l>
             <l part="I">Me?. . .</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Tu manchi d'onor, se manchi a' tuoi</l>
             <l>giuramenti. Tu devi, e lo pretendo,</l>
@@ -1283,11 +1329,11 @@
             <l>tu che tutto sconvolgi, e che fors'anco</l>
             <l>terribile saresti, ov'io non fossi?</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="I">Hai tu finito?</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Non ancor, sta cheto;</l>
             <l>non rompere i miei detti. Ad isfogarti</l>
@@ -1321,12 +1367,12 @@
             <l>E che dico di questi? Il tuo fratello</l>
             <l part="I">perché giacque?</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Perché de' giusti è fatto</l>
             <l part="I">carnefice il senato.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Punitore</l>
             <l>delle colpe è il senato. E nondimeno</l>
@@ -1354,7 +1400,7 @@
             <l>Or che aperto conosci il mio pensiero,</l>
             <l>fa ch'io del pari il tuo conosca; e parla.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l>Orator del senato, e de' superbi</l>
             <l>ricchi malvagi, che si noman grandi,</l>
@@ -1383,57 +1429,57 @@
             <l>la tirannìa ne freme; e ciò m'avvisa</l>
             <l>che giuste fûro e necessarie e sante.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="I">Altra risposta non mi dai?</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">La sola</l>
             <l part="I">di te degna.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">E non curi il mio consiglio?</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l>Consiglio di nemico è tradimento.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l>Or ben, se sprezzi le parole, avrai</l>
             <l part="I">fatti.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Sì, quelli del crudel Nasica,</l>
             <l>dell'assassino del fratello mio.</l>
             <l part="I">Ben tu se' degno d'imitarlo.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Io taccio.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="I">E tacendo parlasti.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Innanzi a Roma</l>
             <l part="I">più chiaro in breve parlerò.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">E più chiare</l>
             <l part="I">n'avrai risposte.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="M">Le udirem.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Lo spero.</l>
           </sp>
@@ -1441,7 +1487,7 @@
         <div type="scene">
           <head>SCENA V</head>
           <stage>DRUSO e DETTI</stage>
-          <sp>
+          <sp who="#druso">
             <speaker>DRUSO</speaker>
             <l>Console, . . . io vengo apportator di nuova</l>
             <l>che porrà tutto in pianto. . . Al rio racconto</l>
@@ -1449,11 +1495,11 @@
             <l>un illustre congiunto, e Roma il primo</l>
             <l>de' cittadini. Emiliano è spento.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="I">Oimè! che narri?</l>
           </sp>
-          <sp>
+          <sp who="#druso">
             <speaker>DRUSO</speaker>
             <l part="F">Verità funesta.</l>
             <l>Osserva che frequente d'ogni parte</l>
@@ -1465,15 +1511,15 @@
             <l>per tutto dirti, chi bisbiglia voce</l>
             <l part="I">di violenta morte.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Oh ciel! che ascolto?</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="I">Quale orrendo sospetto? <stage>(Tra sé.)</stage></l>
           </sp>
-          <sp>
+          <sp who="#druso">
             <speaker>DRUSO</speaker>
             <l part="F">Ecco Cornelia.</l>
             <l>Il turbato suo volto assai ne dice</l>
@@ -1483,40 +1529,40 @@
         <div type="scene">
           <head>SCENA VI</head>
           <stage>CORNELIA e DETTI</stage>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">Figlio,</l>
             <l>un doloroso annunzio. Il tuo cognato</l>
             <l part="I">più non respira.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="M">Oh madre!. . .</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">A che mi traggi</l>
             <l>in disparte? Che hai, figlio? tu tremi?</l>
             <l part="I">che t'avvenne? che hai?</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Druso racconta</l>
             <l>cosa che fammi inorridir. Va, corri,</l>
             <l>vedi, osserva, t'informa. Il cor mi strazia</l>
             <l part="I">un sospetto crudel.</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">Parla, ti spiega. . .</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l>Qui nol posso. Deh! vola, e dall'estinto</l>
             <l>non ti partir fin ch'io non giungo. E tosto</l>
             <l part="I">ti seguirò.</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="M">Mi trema il cor.</l>
           </sp>
@@ -1524,23 +1570,23 @@
         <div type="scene">
           <head>SCENA VII</head>
           <stage>OPIMIO, DRUSO e CAIO</stage>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Notasti?</l>
           </sp>
-          <sp>
+          <sp who="#druso">
             <speaker>DRUSO</speaker>
             <l part="I">Notai.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="M">Vedesti quel pallor?</l>
           </sp>
-          <sp>
+          <sp who="#druso">
             <speaker>DRUSO</speaker>
             <l part="F">Lo vidi.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l>Quel pallor, quella smania, quel sommesso</l>
             <l>favellarsi in disparte, m'assicura</l>
@@ -1550,7 +1596,7 @@
         <div type="scene">
           <head>SCENA VIII</head>
           <stage>CAIO, poi FULVIO</stage>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l>Ho l'inferno nel cor. Di Fulvio i detti</l>
             <l>mi ricorrono tutti alla memoria,</l>
@@ -1559,18 +1605,18 @@
             <l>giace in braccio di morte assassinato:</l>
             <l part="I">chi l'uccise?</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="M">A me il chiedi?</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">A te, che in guisa</l>
             <l>ragionavi di lui da farmi or certo</l>
             <l>che tu medesmo l'assassin ne sei.</l>
             <l part="I">Parla dunque, fellon; parla.</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="F">Se tanto</l>
             <l>al cor t'è grave la costui caduta,</l>
@@ -1579,11 +1625,11 @@
             <l>al generoso ardir che un oppressore</l>
             <l>tolse alla patria, un avversario a lui.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="I">Dunque tu l'uccidesti.</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="F">A che mi tenti,</l>
             <l>ingrato amico? L'onor tuo periglia;</l>
@@ -1598,12 +1644,12 @@
             <l>e mi chiami assassin? Va, tel ripeto,</l>
             <l>o tu non sei più Gracco, o tu deliri.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l>Or ti conosco, barbaro! E tu servi</l>
             <l part="I">alla mia causa co' delitti?</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="F">E quelli</l>
             <l>del superbo ch'io spensi e tu compiangi,</l>
@@ -1649,7 +1695,7 @@
             <l>tuo pur anco il delitto. Amico, e cieco,</l>
             <l part="I">io non fei che obbedirti.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Amico mio</l>
             <l>tu, scellerato? Di ribaldi io mai</l>
@@ -1664,79 +1710,79 @@
             <l>che il tuo vil capo troncherà. Tu festi</l>
             <l>orribil onta al mio nome, e tu trema.</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l>Caio, fine agli oltraggi; io tel consiglio:</l>
             <l>fine agli oltraggi. Iniquo o giusto sia,</l>
             <l>raccogli il frutto del mio colpo, e taci,</l>
             <l part="I">non sforzarmi a dir oltre.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">E che diresti?</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="I">Quel che taccio.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Che? Forse altri delitti?</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="I">Nol so.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Nol sai? Gelo d'orror, ned oso</l>
             <l part="I">più interrogarti.</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="M">E n'hai ragion.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Che dici?</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="I">Nulla.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Quel detto il cor mi serra. Oh quale</l>
             <l>nel pensier mi balena orrido lampo!</l>
             <l part="I">Hai tu complici?</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="M">Sì.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="M">Quali?</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="F">Insensato,</l>
             <l part="I">non dimandarlo.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="M">Vo' saperlo.</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="F">Bada,</l>
             <l part="I">ti pentirai.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="M">Non più: lo voglio.</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="F">Il vuoi?</l>
             <l part="I">Chiedilo. . . a tua sorella.</l>
@@ -1767,7 +1813,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>CORNELIA, LICINIA e CAIO</stage>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l>Figlio, calma il furor; torna in te stesso,</l>
             <l>mio caro figlio, per pietà. Rispetta</l>
@@ -1777,17 +1823,17 @@
             <l>da queste braccia; guardami, crudele;</l>
             <l part="I">io son che prego.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="M">Ah madre!. . .</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">Deh! sì fiero</l>
             <l>non rispondere, o figlio; supplicarti</l>
             <l>io no, non voglio per la rea sorella. . .</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l>Non mi nomar quel mostro. Una tal furia</l>
             <l>non m'è sorella. Perché m'hai di pugno</l>
@@ -1795,7 +1841,7 @@
             <l>nelle perfide vene? Oh! tu lo caccia</l>
             <l>per pietà nelle mie, e qui m'uccidi.</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l>Deh! considera meglio. Il suo delitto</l>
             <l>non è palese: il suo pentir, l'orrore</l>
@@ -1827,17 +1873,17 @@
             <l>il tuo destin, non ismentir te stesso,</l>
             <l part="I">né me tua madre.</l>
           </sp>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <l part="M">Oh me infelice!</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">Intendo</l>
             <l>il tuo gemito, o figlia; ma disdice</l>
             <l>alla moglie di Gracco, a una Romana.</l>
           </sp>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <l>Se romana virtù pianto non soffre,</l>
             <l>se mi comanda soffocar natura,</l>
@@ -1849,12 +1895,12 @@
             <l>questo dell'alma mia parte più cara;</l>
             <l>poss'io vederlo e non disfarmi in pianto?</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l>Vuoi che Cornelia una viltà consigli?</l>
             <l part="I">Vuoi tu ch'ella?. . .</l>
           </sp>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <l part="F">Sia madre: altro non chieggo.</l>
             <l>Qual più sublime, qual più santo nome</l>
@@ -1886,7 +1932,7 @@
             <l>di rendermi pietose il divorato</l>
             <l part="I">tuo cadavere!</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Oh tu! su le cui labbra</l>
             <l>colsi il primo d'amor bacio divino,</l>
@@ -1900,11 +1946,11 @@
             <l>dal dolor. . . Ma che pro? Sul nome mio</l>
             <l>piombò l'infamia, ed io la vita abborro.</l>
           </sp>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <l part="I">Me misera!</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Fa cor, Licinia, e prendi</l>
             <l>convenienti al tempo alma e pensieri.</l>
@@ -1930,7 +1976,7 @@
             <l>entrar delitti, orribili delitti. . .</l>
             <l part="I">e invendicati.</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">Oh figlio! e perché tenti</l>
             <l>con memorie sì crude il mio coraggio?</l>
@@ -1954,60 +2000,60 @@
             <l>Gracco, un decreto del senato; il vedi?</l>
             <l part="I">T'accosta e leggi.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <stage>(s'accosta e legge)</stage>
             <l part="F">«Il console provvegga</l>
             <l>che non riceva detrimento alcuno</l>
             <l part="I">la repubblica.«</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_4">
             <speaker>LO STESSO CITTADINO</speaker>
             <l part="F">Guàrdati, infelice:</l>
             <l>quel decreto è fatale alla tua vita.</l>
           </sp>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <l part="I">Ahi che sento!</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Lo veggo, e ti ringrazio,</l>
             <l>cortese cittadin. Tu, se non erro,</l>
             <l part="I">tu sei Quintilio.</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_4">
             <speaker>Il CITTADINO</speaker>
             <stage>(stringendogli la mano)</stage>
             <l part="F">E amico tuo: coraggio. <stage>(Si ritira.)</stage></l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l>Volgiti, figlio: al popol tutto in mezzo</l>
             <l>fiero s'avanza a questa volta Opimio.</l>
             <l>Svégliati: il tempo d'aver core è giunto.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="I">Va: non temer.</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="M">La man mi porgi.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Prendi;</l>
             <l part="I">senti se trema.</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">No, non trema: è quella</l>
             <l>del mio figlio; e mi dice che tu sai,</l>
             <l>pria che tradirne l'onor tuo, morire.</l>
             <l part="I">Son tranquilla.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Licinia. . . addio. . . m'abbraccia.</l>
             <l>Se questo amplesso. . . se il destin. . . Soccorri</l>
@@ -2025,17 +2071,17 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>OPIMIO preceduto dai littori, e seguìto dai senatori; DRUSO, e gli altri tribuni; FULVIO confuso tra il popolo che accorre da tutte le parti, e CAIO</stage>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Romani,</l>
             <l>la salute del popolo è in periglio.</l>
             <l part="I">Chieggo parlarvi.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>POPOLO</speaker>
             <l part="M">Parla.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <stage>(sulla tribuna)</stage>
             <l part="F">Le divine</l>
@@ -2062,16 +2108,16 @@
             <l>o degli empi la man troncò uno stame</l>
             <l part="I">sì prezioso.</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="F">Console, tu lungi</l>
             <l>vai dal proposto tuo: torna al suggetto.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>POPOLO</speaker>
             <l part="I">Al suggetto, al suggetto.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Io ben mi veggo</l>
             <l>che il sol ricordo dell'estinto eroe</l>
@@ -2096,31 +2142,31 @@
             <l>tiranno de' suffragi, indi assoluto</l>
             <l part="I">della patria tiranno!</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <stage>(lanciandosi alla tribuna)</stage>
             <l part="F">A me tiranno!</l>
             <l>Mentitor, scendi, ch'io risponda, scendi.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l>È mia, Romani, la tribuna; io chieggo</l>
             <l part="I">libertà di parole.</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_1">
             <speaker>PRIMO CITTADINO</speaker>
             <l part="F">Il giusto ci chiede:</l>
             <l part="I">libertà di parole.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Egli mentisce. . .</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>POPOLO</speaker>
             <l part="I">Libertà di parole.</l>
           </sp>
-          <sp>
+          <sp who="#druso">
             <speaker>DRUSO</speaker>
             <l part="F">Ti slontana,</l>
             <l>forsennato, obbedisci. Il popol solo</l>
@@ -2128,18 +2174,18 @@
             <l>liberissime. Taci: nel suo nome</l>
             <l part="I">io tel comando.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="M">Oh rabbia!</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_3">
             <speaker>TERZO CITTADINO</speaker>
             <stage>piano a CAIO</stage>
             <l part="F">Incauto, affrena</l>
             <l>l'intempestivo tuo furor. Ti perdi</l>
             <l part="I">se interrompi: nol vedi?</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">A te di nuovo</l>
             <l>mi volgo, o Gracco. - Seduttor te chiamo</l>
@@ -2189,11 +2235,11 @@
             <l>Chi?. . . Non vo' dirlo. Il vostro cor fremente</l>
             <l>per cotanti delitti assai vel dice.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="I">Non più, Romani; vo' parlare.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Io tutto</l>
             <l>ancor non dissi, e qui ditollo, e Roma</l>
@@ -2242,37 +2288,37 @@
             <l>il popolo seduce, e fin dai lidi</l>
             <l>d'Africa viene a lacerarti il petto. . .</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l>Assai dicesti: or me, Romani, udite.</l>
           </sp>
-          <sp>
+          <sp who="#druso">
             <speaker>DRUSO</speaker>
             <l>Popolo, non udirlo: egli è provato</l>
             <l part="I">seduttor; non l'udir.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>PARTE DEL POPOLO</speaker>
             <l part="F">Gracco s'ascolti.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>ALTRA PARTE DEL POPOLO</speaker>
             <l part="I">No; Gracco è seduttor.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>I PRIMI</speaker>
             <l part="F">Gracco s'ascolti.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>I SECONDI</speaker>
             <l part="I">Gracco al Tarpeo.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Deh! per gli Dei, m'udite,</l>
             <l part="I">poi m'uccidete.</l>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>UN VECCHIO DEL POPOLO</speaker>
             <l part="F">Udiam, fratelli, udiamo.</l>
             <l>Quetatevi, sentite. Opra sarìa</l>
@@ -2280,7 +2326,7 @@
             <l>pria d'ascoltarlo. Alfin gli è Gracco, il nostro</l>
             <l part="I">benefattor.</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_1">
             <speaker>PRIMO CITTADINO</speaker>
             <l part="F">E fosse anco nemico,</l>
             <l>udirsi ei debbe, ed ammutir chiunque</l>
@@ -2289,7 +2335,7 @@
             <l>io non venduto a qualsisia partito.</l>
             <l part="I">Monta securo, e ti difendi.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <stage>(su la tribuna)</stage>
             <l part="F">È questa</l>
@@ -2328,14 +2374,14 @@
             <l>tormento eterno, anch'io tiranno. - Oh plebe,</l>
             <l part="I">qual ria mercede a chi ti serve!</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_3">
             <speaker>TERZO CITTADINO</speaker>
             <l part="F">Gracco,</l>
             <l>fa cor: la plebe non è ingrata, il giuro.</l>
             <l>Niun t'estima tiranno: arditamente</l>
             <l part="I">di' tua ragione, e non tremar.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Tremare</l>
             <l>soli qui denno gli oppressor. Son io</l>
@@ -2349,21 +2395,21 @@
             <l>il popol feci. Fu delitto ei questo?</l>
             <l>Plebe, rispondi: è questo un mio delitto?</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_3">
             <speaker>TERZO CITTADINO</speaker>
             <l part="I">No; qui tutti siam re.</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_2">
             <speaker>SECONDO CITTADINO</speaker>
             <l part="F">Nel popol tutta</l>
             <l part="I">sta la possanza.</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_1">
             <speaker>PRIMO CITTADINO</speaker>
             <l part="F">Esecutor di nostra</l>
             <l part="I">mente il senato, e nulla più.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Nemico</l>
             <l>è dunque vostro chi di vostra intera</l>
@@ -2387,14 +2433,14 @@
             <l>dell'alma Roma e de' suoi santi numi,</l>
             <l>nome acquisti di colpa e sei punita?</l>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>IL VECCHIO</speaker>
             <stage>(sotto voce al più vicino.)</stage>
             <l>Vero è, pur troppo, il suo parlar. Mostrarsi</l>
             <l>di virtù caldo è gran periglio. Un dio</l>
             <l part="I">sul suo labbro ragiona.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Io per supremo</l>
             <l>degli Dei beneficio in grembo nato</l>
@@ -2406,23 +2452,23 @@
             <l>di questa madre, nomerete or voi</l>
             <l>l'italiana libertà delitto?</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_1">
             <speaker>PRIMO CITTADINO</speaker>
             <l>No, Itali siam tutti, un popol solo,</l>
             <l part="I">una sola famiglia.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>POPOLO</speaker>
             <l part="F">Italiani</l>
             <l part="I">tutti, e fratelli.</l>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>IL VECCHIO</speaker>
             <l part="F">Oh dolci grida! oh sensi</l>
             <l>altissimi, divini! Per la gioia</l>
             <l part="I">mi sgorga il pianto.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Alfine odo sublimi</l>
             <l>romane voci, e lagrime vegg'io</l>
@@ -2492,13 +2538,13 @@
             <l>chi possiede di voi un foco, un'ara,</l>
             <l part="I">una vil pietra sepolcral?</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>POPOLO</speaker>
             <stage>con altissimo grido.</stage>
             <l part="F">Nessuno,</l>
             <l part="I">nessuno.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">E per chi dunque andate a morte?</l>
             <l>Per chi son quelle larghe cicatrici</l>
@@ -2508,31 +2554,31 @@
             <l>m'intenerisce, e ad un medesmo tempo</l>
             <l>a fremer d'ira e a lagrimar mi sforza.</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_2">
             <speaker>SECONDO CITTADINO</speaker>
             <l>Misero Caio! Ei piange, e per noi piange.</l>
             <l part="I">Oh magnanimo cor!</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_3">
             <speaker>TERZO CITTADINO</speaker>
             <l part="F">Costerà caro</l>
             <l part="I">ai patrizi quel pianto.</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="F">E caro ei costi.</l>
             <l>Che si tarda, compagni? Ecco il momento. . .</l>
             <l part="I">Mano al pugnal; seguitemi.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Romani. . .</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_1">
             <speaker>PRIMO CITTADINO</speaker>
             <l>Silenzio; ei torna a ragionar; silenzio.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l>Fratelli, udiste i miei delitti. Or voi</l>
             <l>puniteli, ferite. Io v'abbandono</l>
@@ -2548,37 +2594,37 @@
             <l>cercar la spoglia lacerata. Oh patria!</l>
             <l part="I">Felice me, se il mio morir. . .</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_3">
             <speaker>TERZO CITTADINO</speaker>
             <l part="F">No; vivi:</l>
             <l part="I">muora Opimio. <stage>(I congiurati ripetono con furore le ultime parole.)</stage></l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Littori, alto levate</l>
             <l>le mannaie, e, chiunque osa, ferite.</l>
           </sp>
           <stage>Il capo de' littori ANTILIO con la scure in alto, e gridando: «Addietro», si avanza contro il popolo alla testa de' suoi compagni.</stage>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l>Vile ministro di più vil tiranno,</l>
             <l part="I">muori dunque tu primo. <stage>(ANTILIO cade trafitto da molti pugnali)</stage></l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <stage>(precipitandosi dalla tribuna)</stage>
             <l part="F">Ahi! che faceste?</l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <stage>(ai congiurati)</stage>
             <l>Coraggiosi avanzate: Opimio muora.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>POPOLO</speaker>
             <l part="I">Muora Opimio.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <stage>(frapponendosi)</stage>
             <l part="F">Fermate, o me con esso</l>
@@ -2592,11 +2638,11 @@
             <l>del furor che v'acceca, e gli assassini</l>
             <l>del mio fratello ad imitar vi mena.</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_3">
             <speaker>TERZO CITTADINO</speaker>
             <l part="I">Vogliam vendetta.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">E noi l'avrem. - M'ascolta,</l>
             <l>console, ed alza l'atterrito viso.</l>
@@ -2616,7 +2662,7 @@
             <l>queti, e lasciate a' suoi rimorsi in preda</l>
             <l part="I">questo superbo. <stage>(Parte, e il popolo si ritira modestamente)</stage></l>
           </sp>
-          <sp>
+          <sp who="#fulvio">
             <speaker>FULVIO</speaker>
             <l part="F">Oh vil clemenza! oh stolta</l>
             <l>virtù! Per Gracco Opimio vivo!. . . Io sento</l>
@@ -2627,31 +2673,31 @@
         <div type="scene">
           <head>SCENA IV</head>
           <stage>OPIMIO, DRUSO, SENATORI e LITTORI</stage>
-          <sp>
+          <sp who="#druso">
             <speaker>DRUSO</speaker>
             <l>A che pur taci, e torvo guardi e fremi?</l>
             <l>Tu meditavi la sua morte, ed egli</l>
             <l>ti fa don della vita. Dopo tanto</l>
             <l part="I">benefizio a che pensi?</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Alla vendetta.</l>
           </sp>
-          <sp>
+          <sp who="#druso">
             <speaker>DRUSO</speaker>
             <l part="I">E vuoi che Gracco?. . .</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Muoia. - Odi, Rabirio.</l>
           </sp>
-          <sp>
+          <sp who="#druso">
             <speaker>DRUSO</speaker>
             <l>Quale e quanto è nel cor, comincio or tutto</l>
             <l part="I">a conoscere Opimio.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <stage>(a Rabirio, che subito parte)</stage>
             <l part="F">Il mio comando</l>
@@ -2667,7 +2713,7 @@
         <div type="scene">
           <head>SCENA I</head>
           <stage>CORNELIA e CAIO</stage>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l>Faccian gli Dei che non ti penta, o figlio,</l>
             <l>di tua troppa virtù. Se generosi</l>
@@ -2678,7 +2724,7 @@
             <l>mai perdonarti non saprà lo scorno</l>
             <l part="I">di doverti la vita.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">E nol perdoni;</l>
             <l>non pentirommi del mio don per questo.</l>
@@ -2688,7 +2734,7 @@
             <l>altro ve n'era, e tu lo sai, più degno</l>
             <l part="I">d'esser versato.</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">Tu, crudel, rinnovi</l>
             <l>memoria d'ira e di dolor che tutto</l>
@@ -2704,12 +2750,12 @@
             <l>colpo si tenta. Se costui. . . Che veggio?</l>
             <l part="I">Cinto il Foro d'armati?</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Anzi di sgherri.</l>
             <l part="I">La schiera è questa de' Cretensi.</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">Oh cielo!</l>
             <l>De' Cretensi la schiera! Ed a qual fine?</l>
@@ -2717,12 +2763,12 @@
             <l>senza sangue e terror. Figlio, in tuo danno</l>
             <l part="I">son quelle lance; il cor mel dice.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">E a tanto</l>
             <l part="I">spinge quel vile la perfidia?</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">Ed altro</l>
             <l>speri tu da un tiranno?. . . Ma che vale</l>
@@ -2739,7 +2785,7 @@
             <l>di tua clemenza, e vendicato torna,</l>
             <l part="I">o non tornar più mai.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Madre, lo veggo;</l>
             <l>il tradimento mi circonda, usate</l>
@@ -2748,20 +2794,20 @@
             <l>senza sangue civile; ed io di sangue</l>
             <l part="I">non ho sete; e lo sai.</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">Di guasto sangue</l>
             <l>Roma ha colme le vene, e sta nel trarlo</l>
             <l part="I">la sua salute.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Traggalo la scure,</l>
             <l>non la man del tuo figlio. Anche de' rei</l>
             <l>il sangue è sacro, né versarlo debbe</l>
             <l part="I">che il ferro della legge.</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">E che ragioni</l>
             <l>tu di leggi, infelice, ove la sola</l>
@@ -2778,14 +2824,14 @@
             <l>il debole percuote, e col potente</l>
             <l part="I">patteggia.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Madre, se mi sproni ad opra</l>
             <l>di sangue, tu m'oltraggi. Io non son nato</l>
             <l>ai delitti, né queste eran le imprese</l>
             <l part="I">a che tu m'educavi.</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">E chi ti chiede</l>
             <l>delitti? Armarsi, cospirar, dar morte</l>
@@ -2794,11 +2840,11 @@
             <l>e trepidanti lor mannaie? Hai forse</l>
             <l part="I">temenza di morir?</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="M">Donna. . .</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">Che dissi?</l>
             <l>Io t'offesi; perdona. Amor materno,</l>
@@ -2812,40 +2858,40 @@
             <l>non mi dir per che mezzo, ma provvedi</l>
             <l part="I">al tuo periglio, all'onor tuo.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Su questo</l>
             <l>statti sicura. . . So che far. . . Tra poco</l>
             <l>o vivo o spento intenderai ch'io sono</l>
             <l part="I">di te degno.</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">Ed inerme ad espor corri</l>
             <l part="I">tra' nemici la vita?</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Ho l'arme al petto</l>
             <l part="I">dell'innocenza; e basta.</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">Tra' pugnali</l>
             <l>vai de' vili ottimati, e bastar credi</l>
             <l part="I">d'innocenza lo scudo?</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Io tel ridico;</l>
             <l part="I">io non vo' sangue cittadin.</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">Tu vuoi</l>
             <l part="I">dunque tua morte?</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Intatta fama io voglio.</l>
             <l>O fera o mite che mi sia fortuna,</l>
@@ -2868,7 +2914,7 @@
         <div type="scene">
           <head>SCENA II</head>
           <stage>LICINIA e DETTI</stage>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <l>Morir? crudele! Ed in obblio ponesti</l>
             <l>ch'altri pure in te vive? E questa vita,</l>
@@ -2877,12 +2923,12 @@
             <l>che sui tuoi giorni han dritto, e moriranno</l>
             <l part="I">se tu muori?</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Licinia, e tu pur vieni</l>
             <l part="I">a lacerarmi?</l>
           </sp>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <l part="F">A ricordarti io vengo</l>
             <l>che tu sei padre, che tu sei marito,</l>
@@ -2909,12 +2955,12 @@
             <l>d'odio patrizio. In cotanta ruina</l>
             <l part="I">che ti resta, infelice?</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Il mio coraggio,</l>
             <l part="I">la mia ragion, la plebe.</l>
           </sp>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <l part="F">E in chi t'affidi,</l>
             <l>sconsigliato, in chi speri? Infausti e brevi</l>
@@ -2931,7 +2977,7 @@
             <l>pietà della cadente tua famiglia,</l>
             <l>e al cor ti scenda di natura il grido.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l>Deh! Licinia, t'accheta; e di mia fama</l>
             <l>non voler che tramonti oggi la luce,</l>
@@ -2948,34 +2994,34 @@
             <l>che in tua pace mi parta, e alla chiamata</l>
             <l part="I">della patria obbedisca. - Addio.</l>
           </sp>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <l part="F">No, resta.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="I">Lasciami.</l>
           </sp>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <l part="M">No, crudel!</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="M">Lasciami.</l>
           </sp>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <l part="F">O resta,</l>
             <l>cuor di tigre, o m'uccidi: oltre non passi,</l>
             <l>no, se prima non calchi questo corpo</l>
             <l part="I">atterrato a' tuoi piedi.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="M">Oh padre!. . .</l>
           </sp>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <l part="F">Io vinsi,</l>
             <l>numi pietosi! Intenerito e fiso</l>
@@ -2988,7 +3034,7 @@
         <div type="scene">
           <head>SCENA III</head>
           <stage>PRIMO CITTADINO e DETTI</stage>
-          <sp>
+          <sp who="#cittadino_1">
             <speaker>PRIMO CITTADINO</speaker>
             <l part="F">Caio, sul capo</l>
             <l>gran disastro ti pende. L'Aventino</l>
@@ -3002,45 +3048,45 @@
             <l>Il popolo bisbiglia, e l'uno all'altro</l>
             <l>la susurra all'orecchio, e già la crede.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="I">E già la crede?. . .</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_1">
             <speaker>PRIMO CITTADINO</speaker>
             <l part="F">Né ciò sol, ma giura</l>
             <l>dell'ucciso vendetta. Io che pur anco</l>
             <l part="I">innocente ti reputo. . .</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">La plebe</l>
             <l part="I">già mi crede assassino?. . . <stage>(Parte rapidamente
 come fuori di sé.)</stage></l>
           </sp>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <l part="F">Ah! ferma, ah! senti,</l>
             <l part="I">barbaro; ferma. . .</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">Dove corri, o figlia?. . .</l>
           </sp>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <l part="I">Lasciami, madre.</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">No, lo tenti invano.</l>
           </sp>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <l>Madre crudel!. . . Me misera!. . . Più mai</l>
             <l part="I">nol rivedrò, mai più!</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_1">
             <speaker>PRIMO CITTADINO</speaker>
             <l part="F">. . . Gracco è innocente.</l>
             <l part="I">Ben feci.</l>
@@ -3049,7 +3095,7 @@ come fuori di sé.)</stage></l>
         <div type="scene">
           <head>SCENA IV</head>
           <stage>CORNELIA e LICINIA</stage>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">Ah! riedi nel tuo senno, o figlia;</l>
             <l>e per soverchia doglia, ove non sono,</l>
@@ -3057,35 +3103,35 @@ come fuori di sé.)</stage></l>
             <l>più ch'io non l'amo, il figlio mio? Tranquilla</l>
             <l>nondimen tu mi vedi, ed io son madre.</l>
           </sp>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <l part="I"> . . Nol rivedrò più mai!</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">Più saldo petto,</l>
             <l>e più romano pianto m'aspettava</l>
             <l part="I">io dalla nuora di Cornelia.</l>
           </sp>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <l part="F">Ei corre</l>
             <l>a certa morte, e tu mi fai delitto</l>
             <l part="I">del piangere?</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">Egli corre ove l'appella</l>
             <l part="I">voce sacra d'onor.</l>
           </sp>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <l part="F">Ma quando innanzi</l>
             <l>brutto di sangue, piagato, sbranato</l>
             <l>tel vedrai tratto nella polve, allora</l>
             <l part="I">che farai?</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">Ciò che feci il dì che cadde</l>
             <l>il suo fratello. Adotterò contenta</l>
@@ -3094,7 +3140,7 @@ come fuori di sé.)</stage></l>
             <l>della fedel posterità. Tu imita</l>
             <l part="I">la mia costanza, e datti pace.</l>
           </sp>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <l part="F">Io pace?</l>
             <l>Più non l'attendo che da morte. Il rogo</l>
@@ -3135,7 +3181,7 @@ come fuori di sé.)</stage></l>
         <div type="scene">
           <head>SCENA VI</head>
           <stage>OPIMIO, SENATORI che portano il feretro d'Emiliano, LITTORI e POPOLO</stage>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Qui posate</l>
             <l>quell'incarco feral. - Popolo, amici,</l>
@@ -3190,47 +3236,47 @@ come fuori di sé.)</stage></l>
             <l>non sappiate, no, mai che vi fe' privi</l>
             <l part="I">del vostro padre un assassinio.</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_1">
             <speaker>PRIMO CITTADINO</speaker>
             <l part="F">Parla:</l>
             <l part="I">vogliam saperlo.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">No, Romani: io deggio</l>
             <l>tacer: vi prego, non forzate il labbro</l>
             <l part="I">a nomar gli uccisori.</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_1">
             <speaker>CITTADINO</speaker>
             <l part="F">Il nome, il nome</l>
             <l part="I">degli assassini.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Deh! calmate il vostro</l>
             <l>sdegno, fratelli. A che nomarvi i rei,</l>
             <l>se di tanto misfatto ancor le prove</l>
             <l part="I">non conoscete?</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_2">
             <speaker>SECONDO CITTADINO</speaker>
             <l part="F">Ebben, le prove: udiamo,</l>
             <l part="I">vediam le prove.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Le volete? Io dunque</l>
             <l>alzerò la gramaglia che nasconde</l>
             <l>quella fronte onorata. Avvicinatevi,</l>
             <l part="I">fatemi cerchio e contemplate.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>POPOLO</speaker>
             <l part="F">Oh rio</l>
             <l part="I">spettacolo! <stage>(Retrocedendo inorridito.)</stage></l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Mirate per l'asceso</l>
             <l>sangue alla faccia tutte della fronte</l>
@@ -3272,28 +3318,28 @@ come fuori di sé.)</stage></l>
             <l>Oh Romani! oh non possa il vostro sguardo,</l>
             <l>siccome il mio, veder chiaro il delitto!</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_1">
             <speaker>PRIMO CITTADINO</speaker>
             <l>Egli è chiaro, evidente, e ne vogliamo</l>
             <l part="I">tutti vendetta.</l>
           </sp>
-          <sp>
+          <sp who="#popolo">
             <speaker>POPOLO</speaker>
             <l part="M">Sì, vendetta.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">E voi,</l>
             <l>la vorrete voi, quando vi fia noto</l>
             <l>chi commise il misfatto? Io non vi dissi</l>
             <l part="I">de' rei pur anco il nome.</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_3">
             <speaker>TERZO CITTADINO</speaker>
             <l part="F">E tu li noma;</l>
             <l part="I">di' chi sono, e vedrai.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">E non vel dice</l>
             <l>chiaro abbastanza la lor colpa istessa?</l>
@@ -3304,22 +3350,22 @@ come fuori di sé.)</stage></l>
             <l>Da domestica man dunque partito</l>
             <l part="I">mi sembra il colpo.</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_2">
             <speaker>SECONDO CITTADINO</speaker>
             <l part="M">Ei dice il vero.</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_3">
             <speaker>TERZO CITTADINO</speaker>
             <l part="F">Opimio</l>
             <l>ben parla: il colpo non potea partire</l>
             <l part="I">che da mano domestica.</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_1">
             <speaker>PRIMO CITTADINO</speaker>
             <l part="F">Tacete,</l>
             <l part="I">ascoltiam.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Fra' suoi cari è forza dunque</l>
             <l>il reo cercar. Ma su qual capo? Egli era</l>
@@ -3328,11 +3374,11 @@ come fuori di sé.)</stage></l>
             <l>col proprio sangue il suo signor. Chi dunque,</l>
             <l part="I">chi l'abborrìa?</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_1">
             <speaker>PRIMO CITTADINO</speaker>
             <l part="M">La moglie.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">A questo nome</l>
             <l>veggo, o Quiriti, le sembianze vostre</l>
@@ -3348,7 +3394,7 @@ come fuori di sé.)</stage></l>
             <l>muto è fatto ogni labbro. - Io non ardisco</l>
             <l part="I">dunque dir oltre, e taccio anch'io.</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_1">
             <speaker>PRIMO CITTADINO</speaker>
             <l part="F">No, parla;</l>
             <l>libero parla, non ne far l'oltraggio</l>
@@ -3360,7 +3406,7 @@ come fuori di sé.)</stage></l>
             <l part="F">Sì, tutti:</l>
             <l part="I">la verità, la verità.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Ditolla.</l>
             <l>Ma consentite una dimanda sola:</l>
@@ -3368,24 +3414,24 @@ come fuori di sé.)</stage></l>
             <l>de' cittadini, che opinate voi</l>
             <l part="I">dei costumi di Fulvio?</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_2">
             <speaker>SECONDO CITTADINO</speaker>
             <l part="F">Egli è un infame.</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_3">
             <speaker>TERZO CITTADINO</speaker>
             <l>E nimico di Scipio, ed io l'intesi</l>
             <l>io qui ier l'altro con atroci detti</l>
             <l part="I">minacciarne la vita.</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_1">
             <speaker>PRIMO CITTADINO</speaker>
             <l part="F">E tutto questo</l>
             <l>anch'io l'affermo, ché presente io v'era;</l>
             <l>e quanto affermo, sosterrollo a fronte</l>
             <l part="I">di quel vile, e di tutti.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Or dunque udite.</l>
             <l>Questo indegno Romano (io parlo cose</l>
@@ -3399,12 +3445,12 @@ come fuori di sé.)</stage></l>
             <l>E oimè! che Fulvio a minacciar sì cara</l>
             <l part="I">e nobil vita non fu sol.</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_1">
             <speaker>PRIMO CITTADINO</speaker>
             <l part="F">Chi altri?</l>
             <l>Tutto rivela: io qui per tutti il chieggo.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l>Voi lo chiedete, e a me il chiedete? E quelli</l>
             <l>non siete voi che un giorno in questo Foro</l>
@@ -3430,46 +3476,46 @@ come fuori di sé.)</stage></l>
             <l>poss'io non dire?. . . Ma che dir, se caro,</l>
             <l>se protetto, adorato è l'assassino?</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_2">
             <speaker>SECONDO CITTADINO</speaker>
             <l>Postumio, udisti? Non ti par che dritto</l>
             <l part="I">il console ragioni?</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_1">
             <speaker>PRIMO CITTADINO</speaker>
             <l part="F">Oh! Gracco è reo;</l>
             <l part="I">più non v'ha dubbio.</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_2">
             <speaker>SECONDO CITTADINO</speaker>
             <l part="F">Non v'ha dubbio, è reo.</l>
             <l part="I">Che far dobbiam?</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_3">
             <speaker>TERZO CITTADINO</speaker>
             <l part="F">Di Fulvio arder le case,</l>
             <l>e nel mezzo gittarlo delle fiamme</l>
             <l part="I">scannato.</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_2">
             <speaker>SECONDO CITTADINO</speaker>
             <l part="M">E Gracco?</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_1">
             <speaker>PRIMO CITTADINO</speaker>
             <l part="M">Abbandonarlo.</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_2">
             <speaker>SECONDO CITTADINO</speaker>
             <l part="F">E vuoi</l>
             <l part="I">che il misero perisca?</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_1">
             <speaker>PRIMO CITTADINO</speaker>
             <l part="F">E ben, perisca.</l>
             <l part="I">Vegga il senato che siam giusti.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Osserva,</l>
             <l>Fabio, quei volti. Il mio parlar gli ha tutti</l>
@@ -3480,7 +3526,7 @@ come fuori di sé.)</stage></l>
         <div type="scene">
           <head>SCENA VII</head>
           <stage>DRUSO e DETTI</stage>
-          <sp>
+          <sp who="#druso">
             <speaker>DRUSO</speaker>
             <l>Console, accorri: orribil zuffa è sorta</l>
             <l>fra soldati e plebei sull'Aventino.</l>
@@ -3523,7 +3569,7 @@ come fuori di sé.)</stage></l>
             <l>strascinarsi spirante e sanguinoso</l>
             <l part="I">da man pietose sostenuto.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Oh vista</l>
             <l>che dalle fiere ancor trarrebbe il pianto!</l>
@@ -3548,12 +3594,12 @@ come fuori di sé.)</stage></l>
             <l>tutti la man su quest'esangue, e tutti</l>
             <l part="I">giuriam di vendicarlo.</l>
           </sp>
-          <sp>
+          <sp who="#senatori">
             <speaker>I SENATORI</speaker>
             <stage>(stendendo la mano sul cadavere.)</stage>
             <l part="M">Il giuro.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Or parte</l>
             <l>di voi prenda la via speditamente</l>
@@ -3592,7 +3638,7 @@ come fuori di sé.)</stage></l>
         <div type="scene">
           <head>SCENA II</head>
           <stage>LICINIA e il VECCHIO dell'atto terzo, riconducente il giovinetto suo figlio dal tumulto dell'Aventino.</stage>
-          <sp>
+          <sp who="#vecchio">
             <speaker>IL VECCHIO</speaker>
             <l part="F">Ah figlio, amato figlio!</l>
             <l>Non resistere, vieni. Alle tremanti</l>
@@ -3606,14 +3652,14 @@ come fuori di sé.)</stage></l>
             <l>non può di Gracco la virtù suprema;</l>
             <l part="I">e tu, insensato, lo pretendi?</l>
           </sp>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <l part="F">. . . Io tremo</l>
             <l>tutta. . . dal capo alle piante. . . Vorrei</l>
             <l>interrogarli, . . . e la voce mi spira</l>
             <l part="I">su le labbra.</l>
           </sp>
-          <sp>
+          <sp who="#vecchio">
             <speaker>IL VECCHIO</speaker>
             <l part="F">Non più, vieni, sostegno</l>
             <l>unico e caro di mia stanca vita;</l>
@@ -3641,11 +3687,11 @@ come fuori di sé.)</stage></l>
         <div type="scene">
           <head>SCENA IV</head>
           <stage>CORNELIA e DETTA</stage>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <l>Ah! madre, dov'è Caio? È salvo? è vivo?</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <stage>traversa la scena senza rispondere.</stage>
             <l>Non mi risponde. L'affrettato passo,</l>
@@ -3658,7 +3704,7 @@ come fuori di sé.)</stage></l>
         <div type="scene">
           <head>SCENA V</head>
           <stage>LICINIA e CORNELIA che rientra col pargoletto di Caio in braccio, seguìta dal liberto FILOCRATE</stage>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">Andiam, mi segui,</l>
             <l>servo fedel. . . Che miro? Il duolo oppresse</l>
@@ -3669,12 +3715,12 @@ come fuori di sé.)</stage></l>
             <l>all'amor tuo l'affido. - Alzati, figlia;</l>
             <l>apri alla speme il cor: Caio ancor vive.</l>
           </sp>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <l>Vive Caio? e dov'è? perché nol veggo?</l>
             <l part="I">perché teco non è? deh! parla.</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">. . .Oh! figlia,</l>
             <l>che dir poss'io che ti conforti e insieme</l>
@@ -3690,12 +3736,12 @@ come fuori di sé.)</stage></l>
             <l>e scorrendo van Roma, e percotendo</l>
             <l part="I">le più libere fronti.</l>
           </sp>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <l part="F">E che vuoi dire?</l>
             <l part="I">Dunque Caio?. . .</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">M'ascolta, e coraggiosa</l>
             <l>all' avversa fortuna il cor prepara. -</l>
@@ -3731,13 +3777,13 @@ come fuori di sé.)</stage></l>
             <l>in lontananza vidi. . . oh Dio! che vidi!. . .</l>
             <l part="I">e che racconto io mai?</l>
           </sp>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <l part="F">Madre, finisci</l>
             <l>di straziarmi; prosegui. E che vedesti,</l>
             <l part="I">di', che vedesti?</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">Oh figlia!. . . aste, bipenni,</l>
             <l>e snudati pugnali, e senatori</l>
@@ -3749,7 +3795,7 @@ come fuori di sé.)</stage></l>
             <l>del tuo consorte, ma più alto, credi,</l>
             <l>il suo coraggio; e vi son numi in cielo.</l>
           </sp>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <l>Sì, ma non giusti. Ed in quai numi, o madre,</l>
             <l>aver più speme? In quelli al cui cospetto</l>
@@ -3779,7 +3825,7 @@ come fuori di sé.)</stage></l>
             <l>di tiranni e d'ingrati, e me sovr'essi,</l>
             <l>me seppellite nelle sue ruine.</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="I">Mi sbrana il cor.</l>
           </sp>
@@ -3787,17 +3833,17 @@ come fuori di sé.)</stage></l>
         <div type="scene">
           <head>SCENA VI</head>
           <stage>PRIMO CITTADINO che accorre spaventato, e DETTE</stage>
-          <sp>
+          <sp who="#cittadino_1">
             <speaker>PRIMO CITTADINO</speaker>
             <l part="F">Donna, che fai? La morte</l>
             <l>sul tuo figlio già pende: a prezzo è messa</l>
             <l part="I">la sua testa; nol sai? <stage>(Via subito.)</stage></l>
           </sp>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <l part="F">Cielo, che intesi!</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l>Che disse? Il capo del mio figlio a prezzo</l>
             <l>qual d'infame ladron? Roma crudele,</l>
@@ -3811,22 +3857,22 @@ come fuori di sé.)</stage></l>
         <div type="scene">
           <head>SCENA VII</head>
           <stage>SECONDO CITTADINO fuggendo egli pure atterrito, e DETTE</stage>
-          <sp>
+          <sp who="#cittadino_2">
             <speaker>SECONDO CITTADINO</speaker>
             <l part="F">Il piè fermate, o donne,</l>
             <l>non innoltrate; ché per tutto è strage</l>
             <l part="I">e morte inevitabile.</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">E il mio figlio?</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_2">
             <speaker>SECONDO CITTADINO</speaker>
             <l>Misera madre! tu non hai più figlio. <stage>(Via subito.)</stage></l>
           </sp>
           <stage>LICINIA rimane stupida per dolore.</stage>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l>Perché torno a tremar? Perché le chiome</l>
             <l>sento agitarsi sulla fronte, . . . e freddo</l>
@@ -3837,28 +3883,28 @@ come fuori di sé.)</stage></l>
         <div type="scene">
           <head>SCENA VIII</head>
           <stage>TERZO CITTADINO e DETTE</stage>
-          <sp>
+          <sp who="#cittadino_3">
             <speaker>TERZO CITTADINO</speaker>
             <l part="F">Ti conforta,</l>
             <l part="I">eccelsa donna; è salvo il figlio. . .</l>
           </sp>
-          <sp>
+          <sp who="#licinia #cornelia">
             <speaker>LICINIA e CORNELIA</speaker>
             <l part="F">Oh gioia!. . .</l>
           </sp>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <l part="I">Salvo il mio sposo?. . .</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">Il figlio mio! deh, narra. . .</l>
           </sp>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <l>Narra: il cor torna, per udirti, in vita.</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_3">
             <speaker>TERZO CITTADINO</speaker>
             <l>Da' Cretensi inseguìto, e dimandando</l>
             <l>a tutti un ferro per morir da forte,</l>
@@ -3877,24 +3923,24 @@ come fuori di sé.)</stage></l>
             <l>torse le piante, e ricovrossi al bosco</l>
             <l part="I">consecrato alle Furie.</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">. . .E che racconti</l>
             <l>tu de' Gracchi alla madre? Una vil fuga</l>
             <l part="I">posto ha in salvo il mio figlio?</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_3">
             <speaker>TERZO CITTADINO</speaker>
             <l part="F">A sgherri infami</l>
             <l>dovea dar egli con più vil partito</l>
             <l part="I">così nobile vita?</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">E non avevi</l>
             <l part="I">tu dunque un ferro?</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_3">
             <speaker>TERZO CITTADINO</speaker>
             <l part="F">Pe' nemici il ferro;</l>
             <l>per gli amici il mio sangue: e questo, o donna,</l>
@@ -3908,13 +3954,13 @@ come fuori di sé.)</stage></l>
             <l>resiston soli i generosi petti</l>
             <l part="I">di Pomponio e Licinio.</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">E vile il resto,</l>
             <l>sempre vile la plebe, e sempre ingrata</l>
             <l part="I">abbandona il mio figlio?</l>
           </sp>
-          <sp>
+          <sp who="#cittadino_3">
             <speaker>TERZO CITTADINO</speaker>
             <l part="F">I numi, o donna,</l>
             <l>lo tradîr, non la plebe; e ne fan prova</l>
@@ -3928,7 +3974,7 @@ come fuori di sé.)</stage></l>
             <l>il popolo atterrito. Ah! certo arriva</l>
             <l part="I">il console crudel: fuggi.</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">Io fuggire?</l>
             <l part="I">Ad incontrarlo io corro.</l>
@@ -3937,18 +3983,18 @@ come fuori di sé.)</stage></l>
         <div type="scene">
           <head>SCENA IX</head>
           <stage>CAIO, accorrendo precipitoso, e DETTI</stage>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Un ferro, o madre,</l>
             <l>un ferro per pietà. Non abbia il vanto</l>
             <l part="I">di mia morte quel vile.</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <l part="F">A quel tiranno,</l>
             <l part="I">questo vanto? - No, mai.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">Deh! madre, un ferro:</l>
             <l>tu l'hai, porgilo: all'onta mi sottraggi</l>
@@ -3958,42 +4004,42 @@ come fuori di sé.)</stage></l>
         <div type="scene">
           <head>SCENA ULTIMA</head>
           <stage>OPIMIO con seguito di Patrizi, d'armati, e DETTI</stage>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Eccolo: in lui</l>
             <l part="I">abbassate quell'armi.</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <stage>(lanciandosi tra CAIO e i soldati)</stage>
             <l part="F">I vostri colpi,</l>
             <l>pria che al suo petto passeran per questo.</l>
           </sp>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <stage>(facendo lo stesso)</stage>
             <l part="I">E per questo, crudeli.</l>
           </sp>
-          <sp>
+          <sp who="#opimio">
             <speaker>OPIMIO</speaker>
             <l part="F">Allontanate,</l>
             <l>soldati, a forza quelle donne; il reo</l>
             <l>percotete. Il suo capo alla salute</l>
             <l part="I">pubblica è caro. Percotete.</l>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <stage>(con una mano avvolgendosi il capo nel manto e con l'altra porgendo rapidamente al figlio il pugnale)</stage>
             <l part="F">Ah figlio,</l>
             <l part="I">prendi, e muori onorato.</l>
           </sp>
-          <sp>
+          <sp who="#caio">
             <speaker>CAIO</speaker>
             <l part="F">In questo dono</l>
             <l>ti riconosco, o madre. In questo colpo</l>
             <l part="I">riconosci tu il figlio. <stage>(Si uccide.)</stage></l>
           </sp>
-          <sp>
+          <sp who="#licinia">
             <speaker>LICINIA</speaker>
             <stage>(gettando un grido acutissimo e cadendo tramortita)</stage>
             <l part="F">Oh dio!. . . mi moro.</l>

--- a/tei/muzi-la-rappresentazione-del-vitello-sagginato.xml
+++ b/tei/muzi-la-rappresentazione-del-vitello-sagginato.xml
@@ -81,6 +81,40 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="angelo">
+            <persName>L'Angelo</persName>
+          </person>
+          <person xml:id="figliuolo_minore">
+            <persName>Il Figliuolo Minore</persName>
+          </person>
+          <person xml:id="padre">
+            <persName>Il Padre</persName>
+          </person>
+          <person xml:id="libero_albitro">
+            <persName>Libero Albìtro</persName>
+          </person>
+          <personGrp xml:id="peccati">
+            <name>Sette Peccati Mortali</name>
+          </personGrp>
+          <person xml:id="superbia">
+            <persName>Superbia</persName>
+          </person>
+          <person xml:id="figliuolo_maggiore">
+            <persName>Il Figliuolo Maggiore</persName>
+          </person>
+          <personGrp xml:id="invitati">
+            <name>Gli Invitati alla festa</name>
+          </personGrp>
+          <person xml:id="allegrezza">
+            <persName>Allegrezza</persName>
+          </person>
+          <person xml:id="servo">
+            <persName>Un servo</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -95,19 +129,21 @@
         <head>Personaggi</head>
         <castItem>
           <role>L'Angelo</role>
-          <roleDesc><hi rend="italic">che annuncia</hi></roleDesc>
+          <roleDesc>
+            <hi rend="italic">che annuncia</hi>
+          </roleDesc>
         </castItem>
         <castItem>
           <role>Il Figliuolo Minore</role>
-          <roleDesc><hi rend="italic">che fu quello che si parti dal Padre</hi></roleDesc>
+          <roleDesc>
+            <hi rend="italic">che fu quello che si parti dal Padre</hi>
+          </roleDesc>
         </castItem>
         <castItem>
           <role>Il Padre</role>
         </castItem>
-        <castItem>
-          <role>Libero Albìtro</role>,
-          <roleDesc><hi rend="italic">cassiere</hi></roleDesc>
-        </castItem>
+        <castItem><role>Libero Albìtro</role>,
+          <roleDesc><hi rend="italic">cassiere</hi></roleDesc></castItem>
         <castItem>
           <role>I Sette Peccati Mortali</role>
         </castItem>
@@ -116,15 +152,21 @@
         </castItem>
         <castItem>
           <role>Un Garzone</role>
-          <roleDesc><hi rend="italic">che non parla</hi></roleDesc>
+          <roleDesc>
+            <hi rend="italic">che non parla</hi>
+          </roleDesc>
         </castItem>
         <castItem>
           <role>Speranza</role>
-          <roleDesc><hi rend="italic">Virtù in servizio del Padre</hi></roleDesc>
+          <roleDesc>
+            <hi rend="italic">Virtù in servizio del Padre</hi>
+          </roleDesc>
         </castItem>
         <castItem>
           <role>Provedenza</role>
-          <roleDesc><hi rend="italic">Virtù in servizio del Padre</hi></roleDesc>
+          <roleDesc>
+            <hi rend="italic">Virtù in servizio del Padre</hi>
+          </roleDesc>
         </castItem>
         <castItem>
           <role>Allegrezza</role>
@@ -153,7 +195,7 @@ PIERO DI MARIANO BORSAIO FIORENTINO</p>
           <p><hi rend="italic">Incomincia l'annu<add resp="#ed">n</add>ziazione della festa e comincia
 per uno Angelo vestito de bianco. Parla in questa forma</hi>:</p>
         </stage>
-        <sp>
+        <sp who="#angelo">
           <speaker>ANGELO</speaker>
           <lg>
             <l>A laude sia del Padre onnipotente</l>
@@ -240,7 +282,7 @@ piacciavi di stare con divozione a udire e 'ntendere questa rappresentazione acc
 qualche utile all'anime nostre. E così piaccia a Dio che sia, acciò che noi riceviamo quel bene che
 non viene mai meno. <foreign xml:lang="lat">Per infinita Secula seculorum. Amen</foreign>. El
 Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice così</hi>:</stage>
-        <sp>
+        <sp who="#figliuolo_minore">
           <speaker>FIGLIUOLO MINORE</speaker>
           <lg>
             <l>O padre mio, ascoltatemi un poco</l>
@@ -254,7 +296,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Il Padre risponde</hi>:</stage>
-        <sp>
+        <sp who="#padre">
           <speaker>PADRE</speaker>
           <lg>
             <l>O figliuol mio, ch'è questo che m'hai detto?</l>
@@ -268,7 +310,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Il Figliuolo risponde</hi>:</stage>
-        <sp>
+        <sp who="#figliuolo_minore">
           <speaker>FIGLIUOLO MINORE</speaker>
           <lg>
             <l>Padre, detto io v'ho il mio pensiero:</l>
@@ -282,7 +324,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Il Padre al Figliuolo</hi>:</stage>
-        <sp>
+        <sp who="#padre">
           <speaker>PADRE</speaker>
           <lg>
             <l>Figliuolo mio, non mi dar tal risposta!</l>
@@ -296,7 +338,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Il Figliuolo parla al Padre</hi>:</stage>
-        <sp>
+        <sp who="#figliuolo_minore">
           <speaker>FIGLIUOLO MINORE</speaker>
           <lg>
             <l>Voi potrete ben dire, o padre mio:</l>
@@ -310,7 +352,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Il Padre risponde al Figliuolo</hi>:</stage>
-        <sp>
+        <sp who="#padre">
           <speaker>PADRE</speaker>
           <lg>
             <l>O figliuol mio, tu sai cline pel passato</l>
@@ -324,7 +366,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Il Figliuolo risponde al Padre e getta la borsa</hi>:</stage>
-        <sp>
+        <sp who="#figliuolo_minore">
           <speaker>FIGLIUOLO MINORE</speaker>
           <lg>
             <l>O padre mio, egli è pure usanza</l>
@@ -338,7 +380,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">El Padre si rizza e va contro al Figliuolo adiratamente e diceli così</hi>:</stage>
-        <sp>
+        <sp who="#padre">
           <speaker>PADRE</speaker>
           <lg>
             <l>Or veggio bene che se' ostinato</l>
@@ -352,7 +394,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Il Figliuolo risponde al Padre</hi>:</stage>
-        <sp>
+        <sp who="#figliuolo_minore">
           <speaker>FIGLIUOLO MINORE</speaker>
           <lg>
             <l>El parlar vostro niente stimo o curo.</l>
@@ -366,7 +408,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Il Padre dice al Figliuolo</hi>:</stage>
-        <sp>
+        <sp who="#padre">
           <speaker>PADRE</speaker>
           <lg>
             <l>Figliuol mio, tu se' in libertade</l>
@@ -378,7 +420,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Volgesi il Padre al Cassiere e dice</hi>:</stage>
-        <sp>
+        <sp who="#padre">
           <speaker>PADRE</speaker>
           <lg>
             <l>Libero Albìtro, cassier mio leale,</l>
@@ -386,7 +428,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Libero Albìtro dà i danari, e 'l Figliuolo non li lascia contare, anzi to' le mon<add resp="#ed">e</add>te, non son conte, e fa vista di darli coll'arme. Libero Albìtro dice così quando ha dati e danari</hi>:</stage>
-        <sp>
+        <sp who="#libero_albitro">
           <speaker>LIBERO ALBÌTRO</speaker>
           <lg>
             <l>Diecimila fiorini ch'io li ho dato</l>
@@ -400,7 +442,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Il Figliuolo risponde a Libero Albìtro e dice così</hi>:</stage>
-        <sp>
+        <sp who="#figliuolo_minore">
           <speaker>FIGLIUOLO MINORE</speaker>
           <lg>
             <l>Al tuo mal dire io non vo' guardare,</l>
@@ -414,7 +456,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde Libero Albìtro</hi>:</stage>
-        <sp>
+        <sp who="#libero_albitro">
           <speaker>LIBERO ALBÌTRO</speaker>
           <lg>
             <l>Libero Albìtro son, cassier leale,</l>
@@ -428,7 +470,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Dice il Padre al Figliuolo</hi>:</stage>
-        <sp>
+        <sp who="#padre">
           <speaker>PADRE</speaker>
           <lg>
             <l>Tu sì vorresti in questa tua partenza</l>
@@ -452,7 +494,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Il Figliuolo parla al Padre</hi>:</stage>
-        <sp>
+        <sp who="#figliuolo_minore">
           <speaker>FIGLIUOLO MINORE</speaker>
           <lg>
             <l>Io me ne vo, padre, allegramente.</l>
@@ -466,7 +508,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Il Figliuolo si parte dal Padre e dice così</hi>:</stage>
-        <sp>
+        <sp who="#figliuolo_minore">
           <speaker>FIGLIUOLO MINORE</speaker>
           <lg>
             <l>Io ho una borsa piena di fiorini:</l>
@@ -480,7 +522,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Rispondono al Figliuolo e Sette Peccati Mortali in questa forma</hi>:</stage>
-        <sp>
+        <sp who="#peccati">
           <speaker>SETTE PECCATI MORTALI</speaker>
           <lg>
             <l>Siàn sette compagnon che veren teco:</l>
@@ -494,7 +536,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Il Figliuolo domanda chi ellino sieno</hi>:</stage>
-        <sp>
+        <sp who="#figliuolo_minore">
           <speaker>FIGLIUOLO MINORE</speaker>
           <lg>
             <l>Caro arei di sapere chi voi siate</l>
@@ -508,7 +550,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde la Superbia per tutti e Peccati e a uno a uno li nomina e tirali a sé</hi>:</stage>
-        <sp>
+        <sp who="#superbia">
           <speaker>SUPERBIA</speaker>
           <lg>
             <l>Io sono el capitan della brigata:</l>
@@ -522,7 +564,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde il Figliuolo e dice</hi>:</stage>
-        <sp>
+        <sp who="#figliuolo_minore">
           <speaker>FIGLIUOLO MINORE</speaker>
           <lg>
             <l>Io sì v'accetto, cari compagnoni,</l>
@@ -536,7 +578,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Il Figliuolo si parte. El Padre della famiglia dice in questa forma al suo Maggiore Figliuolo. Dice così</hi>:</stage>
-        <sp>
+        <sp who="#padre">
           <speaker>PADRE</speaker>
           <lg>
             <l>Tu hai veduto el tuo minor fratello:</l>
@@ -550,7 +592,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Il Figliuolo <add resp="#ed">Maggiore</add> risponde al Padre</hi>:</stage>
-        <sp>
+        <sp who="#figliuolo_maggiore">
           <speaker>FIGLIUOLO MAGGIORE</speaker>
           <lg>
             <l>padre mio, di voi m'incresce assai</l>
@@ -564,7 +606,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Il Padre dice al Figliuolo <add resp="#ed">Maggiore</add></hi>:</stage>
-        <sp>
+        <sp who="#padre">
           <speaker>PADRE</speaker>
           <lg>
             <l>Tu sai ch'abbiam dimolte possessioni</l>
@@ -578,7 +620,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Il Figliuolo <add resp="#ed">Maggiore</add> risponde al Padre</hi>:</stage>
-        <sp>
+        <sp who="#figliuolo_maggiore">
           <speaker>FIGLIUOLO MAGGIORE</speaker>
           <lg>
             <l>Ubbidir voglio il tuo comandamento</l>
@@ -602,7 +644,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">El Padre parla a Libero Albìtro</hi>:</stage>
-        <sp>
+        <sp who="#padre">
           <speaker>PADRE</speaker>
           <lg>
             <l>Libero Albìtro, dàgli el libro nero</l>
@@ -616,7 +658,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Libero Albìtro gli dà el libro e 'l garzone, e poi el Figliuolo chiede licenza al Padre ed elli liela dà, e va in villa e sta un tempo. E 'n questo mezzo il Figliuolo Minore torna e chiede misericordia al Padre e così dice. Ritorna a lui tutti e panni stracciati, vestito di taccolino e tutto piloso</hi>:</stage>
-        <sp>
+        <sp who="#figliuolo_minore">
           <speaker>FIGLIUOLO MINORE</speaker>
           <lg>
             <l>Ritorno a te, o dolce padre mio,</l>
@@ -630,7 +672,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Il Padre risponde al Figliuolo e vagli incontro e abbraccialo e dice così</hi>:</stage>
-        <sp>
+        <sp who="#padre">
           <speaker>PADRE</speaker>
           <lg>
             <l>O figliuol mio, tu sia el ben venuto!</l>
@@ -644,7 +686,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Il Padre chiama una Virtù e dice</hi>:</stage>
-        <sp>
+        <sp who="#padre">
           <speaker>PADRE</speaker>
           <lg>
             <l>Vien qua, Speranza, se' mio servidore.</l>
@@ -658,7 +700,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Il Padre si rivolge al Figliuolo e dice</hi>:</stage>
-        <sp>
+        <sp who="#padre">
           <speaker>PADRE</speaker>
           <lg>
             <l>Vien qua, figliuolo mio, ch'i' ti perdono</l>
@@ -682,7 +724,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">El Figliuolo parla al Padre e diceli tutti i suoi casi e comincia così</hi>:</stage>
-        <sp>
+        <sp who="#figliuolo_minore">
           <speaker>FIGLIUOLO MINORE</speaker>
           <lg>
             <l>O padre mio, era di mio pensiero</l>
@@ -756,7 +798,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Il Padre chiama una Virtù e così le comanda</hi>:</stage>
-        <sp>
+        <sp who="#padre">
           <speaker>PADRE</speaker>
           <lg>
             <l>Vien qua, Provedenza, ch'io vo' far festa</l>
@@ -770,7 +812,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">La Providenza va e 'nvita tutti quelli che le fu imposto ed elli vengono alla festa. El Padre fa loro buon viso e dice così</hi>:</stage>
-        <sp>
+        <sp who="#padre">
           <speaker>PADRE</speaker>
           <lg>
             <l>Voi siat'e ben venuti tutti quanti</l>
@@ -784,7 +826,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Rispondono li 'nvitati e uno per tutti <add resp="#ed">dice</add></hi>:</stage>
-        <sp>
+        <sp who="#invitati">
           <speaker>INVITATI</speaker>
           <lg>
             <l>Quando sentimo la vostra imbasciata,</l>
@@ -798,7 +840,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">El Padre chiama una Virtù chiamata Allegrezza e impolle questa ambasciata</hi>:</stage>
-        <sp>
+        <sp who="#padre">
           <speaker>PADRE</speaker>
           <lg>
             <l>Vien qua, Allegrezza, va pe' sonatori</l>
@@ -812,7 +854,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Allegrezza va e truova i Sonatori, e poi dice così quando li ha menati</hi>:</stage>
-        <sp>
+        <sp who="#allegrezza">
           <speaker>ALLEGREZZA</speaker>
           <lg>
             <l>Io ho fatto quello che mi dicesti</l>
@@ -826,7 +868,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">E Sonatori suonano e fanno festa. In questo tempo el Figliuolo Maggiore torna di villa e vada fuori uno de' Servi del Padre e in questo modo <add resp="#ed">el Figliuolo Maggiore</add> li dice</hi>:</stage>
-        <sp>
+        <sp who="#figliuolo_maggiore">
           <speaker>FIGLIUOLO MAGGIORE</speaker>
           <lg>
             <l>Deh dimmi, servo, che vuoi dir tal cosa</l>
@@ -840,7 +882,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">El Servo dice così al Maggior Figliuolo</hi>:</stage>
-        <sp>
+        <sp who="#servo">
           <speaker>SERVO</speaker>
           <lg>
             <l>È ch'è tornato il tuo minor fratello,</l>
@@ -854,7 +896,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde il Maggior Figliuolo adirato al Servo</hi>:</stage>
-        <sp>
+        <sp who="#figliuolo_maggiore">
           <speaker>FIGLIUOLO MAGGIORE</speaker>
           <lg>
             <l>Sicché e' fa festa ch'elli è ritornato?</l>
@@ -868,7 +910,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Il Servo dice al Padre così</hi>:</stage>
-        <sp>
+        <sp who="#servo">
           <speaker>SERVO</speaker>
           <lg>
             <l>Un'ambasciata v'ho a fare, Sire,</l>
@@ -882,7 +924,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Il Padre, sentendo l'ambasciata del Servo suo, esce fuori di casa e fassi incontro al Figliuolo e così li dice</hi>:</stage>
-        <sp>
+        <sp who="#padre">
           <speaker>PADRE</speaker>
           <lg>
             <l>Che imbasciata m'hai mandato a dire,</l>
@@ -896,7 +938,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde al Padre il Figliuolo</hi>:</stage>
-        <sp>
+        <sp who="#figliuolo_maggiore">
           <speaker>FIGLIUOLO MAGGIORE</speaker>
           <lg>
             <l>In questa casa io non voglio entrare</l>
@@ -910,7 +952,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Il Padre risponde al Figliuolo</hi>:</stage>
-        <sp>
+        <sp who="#padre">
           <speaker>PADRE</speaker>
           <lg>
             <l>Tu mi se' stato sempre reverente</l>
@@ -924,7 +966,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Il Figliuolo risponde al Padre</hi>:</stage>
-        <sp>
+        <sp who="#figliuolo_maggiore">
           <speaker>FIGLIUOLO MAGGIORE</speaker>
           <lg>
             <l>Padre, far voglio ciò che voi volete,</l>
@@ -938,7 +980,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Il Padre lo mena seco in casa e dice così</hi>:</stage>
-        <sp>
+        <sp who="#padre">
           <speaker>PADRE</speaker>
           <lg>
             <l>Or viene in casa meco in buona ora</l>
@@ -952,7 +994,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">El Maggior Fratello poi c'ha sentita la volontà del Padre, fa festa al suo Minor Fratello e poi dice così</hi>:</stage>
-        <sp>
+        <sp who="#figliuolo_maggiore">
           <speaker>FIGLIUOLO MAGGIORE</speaker>
           <lg>
             <l>O fratel mio, tu sia il ben tornato!</l>
@@ -966,7 +1008,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Risponde el Fratello Minore al Maggiore</hi>:</stage>
-        <sp>
+        <sp who="#figliuolo_minore">
           <speaker>FIGLIUOLO MINORE</speaker>
           <lg>
             <l>Io mi son rallegrato di buon core</l>
@@ -980,7 +1022,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Rivoltasi il Padre e dice così a' figliuoli e a li altri che stanno a vedere la festa</hi>:</stage>
-        <sp>
+        <sp who="#padre">
           <speaker>PADRE</speaker>
           <lg>
             <l>Parar si vuol, figliuol mie', dal Signore,</l>
@@ -995,7 +1037,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
         </sp>
         <stage><hi rend="italic">Finita la nu<add resp="#ed">n</add>ziazione della festa</hi>.</stage>
         <stage><hi rend="italic">Questa stanza si è del ringraziamento, che apparisce l'Angelo che ha annunziata la festa e dà licenza a tutti e dice così</hi>:</stage>
-        <sp>
+        <sp who="#angelo">
           <speaker>ANGELO</speaker>
           <lg>
             <l>Padre e fratelli che avete qui stanza,</l>
@@ -1009,7 +1051,7 @@ Figliuolo Minore si leva ritto dal lato del Padre e domanda la parte, e dice cos
           </lg>
         </sp>
         <stage><hi rend="italic">Dipoi detto questo, ognuno si rizza e fanno un ballo e cantano una lauda che dice così</hi>:</stage>
-        <sp>
+        <sp who="#tutti i personaggi">
           <speaker>TUTTI I PERSONAGGI</speaker>
           <lg>
             <l rend="italic">Deh sappiatevi guardare</l>

--- a/tei/pagano-gli-esuli-tebani.xml
+++ b/tei/pagano-gli-esuli-tebani.xml
@@ -77,6 +77,43 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="emonte">
+            <persName>Emonte</persName>
+          </person>
+          <person xml:id="carone">
+            <persName>Carone</persName>
+          </person>
+          <person xml:id="pelopida">
+            <persName>Pelopida</persName>
+          </person>
+          <person xml:id="aspasia">
+            <persName>Aspasia</persName>
+          </person>
+          <person xml:id="ismene">
+            <persName>Ismene</persName>
+          </person>
+          <person xml:id="servo">
+            <persName>Servo di Carone</persName>
+          </person>
+          <person xml:id="leontida">
+            <persName>Leontida</persName>
+          </person>
+          <person xml:id="congiurati">
+            <persName>Congiurati</persName>
+          </person>
+          <person xml:id="telefo">
+            <persName>Telefo</persName>
+          </person>
+          <person xml:id="polifonte">
+            <persName>Polifonte</persName>
+          </person>
+          <person xml:id="polinice">
+            <persName>Polinice</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT-Salerno</name>Digitalizzazione</change>
@@ -224,7 +261,7 @@ per sempre</hi>
             <hi rend="Italic">SCENA PRIMA</hi>
           </head>
           <stage>EMONTE, CARONE</stage>
-          <sp>
+          <sp who="#emonte">
             <speaker>EMONTE</speaker>
             <l>Perché mai sì pensoso e sì turbato</l>
             <l>Tu sei, Carone? in qual tumulto e in quale</l>
@@ -237,7 +274,7 @@ per sempre</hi>
             <l>Fa che a parte ancor sia dell"alta cura</l>
             <l part="I">Che t"affanna cotanto.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l part="F">O sovr" ogni altro</l>
             <l>A me caro e diletto, i rari sensi</l>
@@ -257,7 +294,7 @@ per sempre</hi>
             <l>E della sempre invitta e sacra Tebe</l>
             <l>Strinsero a lor talento il duro freno.</l>
           </sp>
-          <sp>
+          <sp who="#emonte">
             <speaker>EMONTE</speaker>
             <l>E a che ripeti il nostro antico affanno</l>
             <l>E cose a me ben note?</l>
@@ -271,7 +308,7 @@ per sempre</hi>
             <l>Afflitti e bisognosi</l>
             <l>Lungi dal patrio suol n"andaro in bando.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Or ho pi?te alla tua fé commesso</l>
             <l>Che, stanchi alfin gli Dei che han Tebe in cura</l>
@@ -295,7 +332,7 @@ per sempre</hi>
             <l>E all"impresa magnanima il tuo petto</l>
             <l>Disponi e il braccio porgi al gran disegno.</l>
           </sp>
-          <sp>
+          <sp who="#emonte">
             <speaker>EMONTE</speaker>
             <l>Ah! che grato mi sia per sì  bell"opra</l>
             <l>Spargere il sangue mio.</l>
@@ -307,7 +344,7 @@ per sempre</hi>
             <l>Mi legherà, se mai destin crudele</l>
             <l>Non turbi invidioso il mio contento.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Su la mia fé  riposa. Or la tua patria</l>
             <l>Servi con zelo e Ismene in premio attendi.</l>
@@ -319,7 +356,7 @@ per sempre</hi>
           </head>
           <stage>PELOPIDA, CARONE, <hi rend="Italic">gli</hi> ESULI <hi rend="Italic">da cacciatori</hi>
 					</stage>
-          <sp>
+          <sp who="#pelopida">
             <speaker>PELOPIDA</speaker>
             <l>Amici, ormai siam giunti. O patri Numi!</l>
             <l>O lari, o tombe antiche,</l>
@@ -341,7 +378,7 @@ per sempre</hi>
             <l>Ma vien Carone. O mio diletto amico,</l>
             <l>Gloria di Tebe, alle mie braccia vieni.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Metà dell"alma mia!</l>
             <l>O Pelopida invitto! Alfin al Cielo</l>
@@ -357,7 +394,7 @@ per sempre</hi>
             <l>Ma quanti son gli amici</l>
             <l>Venuti della patria al pio soccorso?</l>
           </sp>
-          <sp>
+          <sp who="#pelopida">
             <speaker>PELOPIDA</speaker>
             <l>Cento nel borgo sono all"armi pronti</l>
             <l>Oltre costor che vedi or qui, bramosi</l>
@@ -370,7 +407,7 @@ per sempre</hi>
             <l>Hai raccolti, e son pronti alla grand"opra?</l>
             <l>Fillia che fa? serbò le sue promesse?</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Son tutti accinti e avvampano di zelo</l>
             <l>Di liberar la patria o di morire.</l>
@@ -400,13 +437,13 @@ per sempre</hi>
             <l>Ma la morte fra tazze e suoni ascosa</l>
             <l>Lancerà loro irreparabil telo.</l>
           </sp>
-          <sp>
+          <sp who="#pelopida">
             <speaker>PELOPIDA</speaker>
             <l>Fortuna sia propizia al bel pensiero,</l>
             <l>Ma fa mestier che ben si pesi, pria </l>
             <l>Che ad effetto si ponga un gran disegno.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Egli è pur vero, amico.</l>
             <l>E se ogni impresa di maturo esame</l>
@@ -426,7 +463,7 @@ per sempre</hi>
             <hi rend="Italic">SCENA TERZA</hi>
           </head>
           <stage>ASPASIA,<hi rend="Italic">poi</hi>CARONE</stage>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l>Quai nuove cose, oh Dei! son queste e quai</l>
             <l>Tetri presagi immagina la mente?</l>
@@ -442,13 +479,13 @@ per sempre</hi>
             <l>Si chieda la cagion. O mio consorte,</l>
             <l>A tempo giungi, ché parlar ti deggio.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Perché affannata ti dimostri, Aspasia?</l>
             <l>Qual grave affare a favellar ti spinge</l>
             <l>Con tal premura or meco?</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l>Un torbido pensier alla mia mente</l>
             <l>Sospetti orrendi e reo timor dipinge.</l>
@@ -459,7 +496,7 @@ per sempre</hi>
             <l>E perché in tua magion li accogli e celi?</l>
             <l>Deh! qual tetro mistero a me si asconde?</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Qual meraviglia, Aspasia, se agli amici</l>
             <l>Noi diam ricetto e agl"infelici asilo?</l>
@@ -478,7 +515,7 @@ per sempre</hi>
           </head>
           <stage>ASPASIA,<hi rend="Italic">sola</hi>
 					</stage>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l>Qual nube (oimè) d"orrore il sen m"ingombra?</l>
             <l>Qual notte e qual caligine profonda</l>
@@ -498,7 +535,7 @@ per sempre</hi>
             <hi rend="Italic">SCENA QUINTA</hi>
           </head>
           <stage>ASPASIA, ISMENE</stage>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l>Più che sorella a me diletta, Ismene,</l>
             <l>Deh vieni e calma tu questo mio core</l>
@@ -507,7 +544,7 @@ per sempre</hi>
             <l>Quegl"infelici che a turbar la pace</l>
             <l part="I">Nostra venuti or sono.</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l part="F"> O mia sorella,</l>
             <l>Ne’ penetrali, ove Caron li ascose,</l>
@@ -530,11 +567,11 @@ per sempre</hi>
             <l>Il fodero nel petto spinge come</l>
             <l>Farìa col ferro al più crudel nemico.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l part="I">Ah! funesti princìpi!</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l part="F">Se vedessi</l>
             <l>Come torvo Pelopida all"intorno</l>
@@ -543,19 +580,19 @@ per sempre</hi>
             <l>Sitibondo di sangue irato scende</l>
             <l>Non credo avrà così feroce aspetto.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l>Ahimè, ché già m"immagino la cosa.</l>
             <l>Terribil notte, e qual orror n"arrechi?</l>
             <l>Che fere stragi e che ruine, o casa</l>
             <l>Di Carone perduta! o figlio mio!</l>
           </sp>
-          <sp>
+          <sp who="#servo">
             <speaker>SERVO</speaker>
             <l>Signora, or giunge in casa il fier tiranno</l>
             <l>Leontida. Al padron porto l"avviso.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l>O nuovo affanno, ecco scoverto il tutto.</l>
             <l>Siamo perduti affatto, o Tebe, o Tebe,</l>
@@ -570,7 +607,7 @@ per sempre</hi>
             <hi rend="Italic">SCENA SESTA</hi>
           </head>
           <stage>LEONTIDA, CARONE</stage>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Un tradimento io temo. Avrà scoverto</l>
             <l>La venuta degli esuli il tiranno.</l>
@@ -583,7 +620,7 @@ per sempre</hi>
             <l>Dell"agitato sangue, ché altre volte</l>
             <l>In perigli maggiori ti sei trovato.</l>
           </sp>
-          <sp>
+          <sp who="#leontida">
             <speaker>LEONTIDA</speaker>
             <l>Grave affare, Carone, a te mi guida.</l>
             <l>Ciò che giova ad entrambi</l>
@@ -592,20 +629,20 @@ per sempre</hi>
             <l>La tua felicità dal mio potere.</l>
             <l>Caron, nol crederai, mi vinse amore.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l part="I">Amor nel petto tuo? Che sento!</l>
           </sp>
-          <sp>
+          <sp who="#leontida">
             <speaker>LEONTIDA</speaker>
             <l part="F">Amico,</l>
             <l>Ardo ed avvampo per la bella Ismene.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Ismene, mia sorella!</l>
           </sp>
-          <sp>
+          <sp who="#leontida">
             <speaker>LEONTIDA</speaker>
             <l>Sì. De’  sospiri miei questa è l"oggetto.</l>
             <l>Amico, stringi tu l"amato nodo</l>
@@ -614,13 +651,13 @@ per sempre</hi>
             <l>Risplenderà su la tua fronte ancora</l>
             <l>Del mio poter un raggio.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Leontida, mi spiace che ‘l servirti</l>
             <l>In possa mia non è. Di già d"Emonte</l>
             <l>Ismene è sposa e s" han la fé promessa.</l>
           </sp>
-          <sp>
+          <sp who="#leontida">
             <speaker>LEONTIDA</speaker>
             <l>Ah,  s"altro non si oppon, poco mi cale</l>
             <l>Di promesse, di fede e giuramenti.</l>
@@ -629,34 +666,34 @@ per sempre</hi>
             <l>È divenir di morte</l>
             <l>Colpevole. Al padron non si contrasta.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Ma la legge di Tebe e delle genti…</l>
           </sp>
-          <sp>
+          <sp who="#leontida">
             <speaker>LEONTIDA</speaker>
             <l>Su i prìncipi poter non han le leggi,</l>
             <l>Ché, se di quelle sono essi gli autori,</l>
             <l>All"opre lor non denno esser soggetti.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Pur son soggetti a quell"eterna legge</l>
             <l>Che scrisse di sua man l"alma natura.</l>
           </sp>
-          <sp>
+          <sp who="#leontida">
             <speaker>LEONTIDA</speaker>
             <l>E questa sol comanda che al più forte</l>
             <l>L"infermo e debil serva.</l>
             <l>L"aquila forte e lo sparvier rapace</l>
             <l>Su gli uccelli minor hanno l"impero.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Ma son gli Dei mallevadori e vindici</l>
             <l>De’ sacri patti e della fé giurata.</l>
           </sp>
-          <sp>
+          <sp who="#leontida">
             <speaker>LEONTIDA</speaker>
             <l>Io ti credea più saggio</l>
             <l>E sprezzator della volgar credenza.</l>
@@ -689,7 +726,7 @@ per sempre</hi>
           </head>
           <stage>CARONE,<hi rend="Italic">solo</hi>
 					</stage>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Io tradirò la patria? io tuo compagno,</l>
             <l>Stolto tiranno! e pegno Ismene sia</l>
@@ -708,7 +745,7 @@ per sempre</hi>
             <hi rend="Italic">SCENA PRIMA</hi>
           </head>
           <stage>ISMENE, CARONE</stage>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>Diletto mio german, giammai non fia</l>
             <l>Ch"io stringa l"empia man del reo tiranno,</l>
@@ -730,7 +767,7 @@ per sempre</hi>
             <l>Del tiranno crudel altro che morte,</l>
             <l>Ho ben valore da squarciarmi il petto.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>O sensi di te degni</l>
             <l>E di quel sangue donde nata sei.</l>
@@ -745,12 +782,12 @@ per sempre</hi>
             <l>L"animo acerbo del crudel nemico</l>
             <l>E differir il mal quanto si puote.</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>Che pro? saremo, alfine, nell"istesso</l>
             <l>Duro cimento. Il differir che giova?</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Il tempo d"ogni Nume è il più potente.</l>
             <l>Ei tutto al mondo cangia e nuovo aspetto</l>
@@ -766,7 +803,7 @@ per sempre</hi>
             <hi rend="Italic">SCENA SECONDA</hi>
           </head>
           <stage>LEONTIDA, CARONE</stage>
-          <sp>
+          <sp who="#leontida">
             <speaker>LEONTIDA</speaker>
             <l>Irrequieto a te presto ritorno,</l>
             <l>Ché più soffrir non può quest" affannato</l>
@@ -774,21 +811,21 @@ per sempre</hi>
             <l>Alla mie nozze impedimento omai</l>
             <l>Non resta. Emonte non si oppone e cede.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Al tuo poter avrà ceduto ei solo</l>
             <l>Ed alla forza che ragion opprime.</l>
           </sp>
-          <sp>
+          <sp who="#leontida">
             <speaker>LEONTIDA</speaker>
             <l>Se adempio il mio voler, non curo il modo.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Non è il proprio voler norma dell"uomo,</l>
             <l>Ma la ragione e il giusto.</l>
           </sp>
-          <sp>
+          <sp who="#leontida">
             <speaker>LEONTIDA</speaker>
             <l>Dell"amistà, che t"offro, omai ti abusi,</l>
             <l>Carone; eh poni termine a coteste</l>
@@ -804,7 +841,7 @@ per sempre</hi>
             <l>Tronchiam le ciarle. A me conduci Ismene </l>
             <l>E in questo punto diverrà mia sposa.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Senza usate pompe ed il solenne</l>
             <l>Rito e presenza de’ parenti e amici</l>
@@ -812,7 +849,7 @@ per sempre</hi>
             <l>Né a te, né a Ismene. Almen si aspetti il nuovo</l>
             <l>Giorno e pomposa allor farem la festa.</l>
           </sp>
-          <sp>
+          <sp who="#leontida">
             <speaker>LEONTIDA</speaker>
             <l>Pascon le pompe e fregi esterni solo</l>
             <l>L"alme volgari, ma le sprezza il saggio.</l>
@@ -820,7 +857,7 @@ per sempre</hi>
             <l>Non vo’ tardar l"acquisto: ben perduto</l>
             <l>Giammai non si ristora.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>La mente femminil di pompe è vaga</l>
             <l>E la più saggia donna ancor si alletta</l>
@@ -828,7 +865,7 @@ per sempre</hi>
             <l>Questo piacer, che vada a nozze come</l>
             <l>A tanto sposo e al grado suo conviene.</l>
           </sp>
-          <sp>
+          <sp who="#leontida">
             <speaker>LEONTIDA</speaker>
             <l>Ismene, che la sorte omai solleva</l>
             <l>Sullo stato volgar, deve pensare</l>
@@ -843,7 +880,7 @@ per sempre</hi>
           </head>
           <stage>LEONTIDA<hi rend="Italic">solo</hi>
 					</stage>
-          <sp>
+          <sp who="#leontida">
             <speaker>LEONTIDA</speaker>
             <l>Ah! quanto più sugli altri il mio comando</l>
             <l>Distendo, tanto sovra me gli affetti</l>
@@ -876,13 +913,13 @@ per sempre</hi>
             <hi rend="Italic">SCENA QUARTA</hi>
           </head>
           <stage>ISMENE, CARONE</stage>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Ove n"andò Leontida? nol veggio.</l>
             <l>O Dio! che dentro il piede audace ei porta.</l>
             <l>S"occorra… aspetta, Ismene, qui frattanto.</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>Ahimè! già scovre gli esuli celati!</l>
             <l>O Ciel! e quanti affanni ci prepari!</l>
@@ -895,69 +932,69 @@ per sempre</hi>
             <hi rend="Italic">SCENA QUINTA</hi>
           </head>
           <stage>LEONTIDA, ISMENE</stage>
-          <sp>
+          <sp who="#leontida">
             <speaker>LEONTIDA</speaker>
             <l>Ismene, idolo mio, che solo adoro,</l>
             <l>Perché fuggi l"amante e ‘l fido sposo?</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>Sì dolci nomi ancor tempo di usare,</l>
             <l>Leontida, non è; mentre che sono</l>
             <l>Promessa altrui, come sarò tua sposa?</l>
           </sp>
-          <sp>
+          <sp who="#leontida">
             <speaker>LEONTIDA</speaker>
             <l>D"ogni legame ti ha disciolto Emonte.</l>
             <l>Libera alfin tu sei, di te disponi.</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>E tanto amor poter scordar sì presto?</l>
           </sp>
-          <sp>
+          <sp who="#leontida">
             <speaker>LEONTIDA</speaker>
             <l>Sii certa pure che colui d"Ismene</l>
             <l>Or più non prende cura.</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>E’ l crederò di tal viltà capace?</l>
           </sp>
-          <sp>
+          <sp who="#leontida">
             <speaker>LEONTIDA</speaker>
             <l>Presso di te sì poca fede io trovo?</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>Dunque a tal segno, Emonte,</l>
             <l>Volubile, incostante, meco fosti!</l>
           </sp>
-          <sp>
+          <sp who="#leontida">
             <speaker>LEONTIDA</speaker>
             <l>Ma tu ancor sei irresoluta e incerta? </l>
             <l>Lascia di quello ormai ogni pensiero;</l>
             <l>Mentre,  se aspiri alle sue nozze ancora,</l>
             <l>Un impossibil chiedi.</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>Come impossibil fia?</l>
             <l>Da Tebe forse discacciato l"hai?</l>
             <l>Ah dimmi il ver, rispondi.</l>
           </sp>
-          <sp>
+          <sp who="#leontida">
             <speaker>LEONTIDA</speaker>
             <l>Troppo lontan da Tebe si ritrova.</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>Troppo lontan da Tebe! qual mistero!</l>
             <l>Rischiara la mia mente: in quale parte</l>
             <l>L"hai tu sospinto? tra feroci Sciti?</l>
             <l>O nella Libia infame? in qual contrada?</l>
           </sp>
-          <sp>
+          <sp who="#leontida">
             <speaker>LEONTIDA</speaker>
             <l>In più rimota parte,</l>
             <l>Onde il ritorno non sarà concesso.</l>
@@ -966,28 +1003,28 @@ per sempre</hi>
             <l>Che per mio scorno e mia vergogna eterna</l>
             <l>Del tuo core contrasta a me l"impero.</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>O Dio di Tebe, invitto Alcide! ahi misera!</l>
             <l>Qual freddo gel mi agghiaccia. Io tremo; dimmi,</l>
             <l>Perché il ritorno vien a lui negato?</l>
           </sp>
-          <sp>
+          <sp who="#leontida">
             <speaker>LEONTIDA</speaker>
             <l>Questa è la legge che mutar non ponno</l>
             <l>Gli Dei medesimi, se v"ha Dio nel Cielo.</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>Qual legge e qual decreto empio rammenti?</l>
           </sp>
-          <sp>
+          <sp who="#leontida">
             <speaker>LEONTIDA</speaker>
             <l>La legge di natura e del destino.</l>
             <l>Da tenebrosi, oscuri regni mai</l>
             <l>Non si ritorna qui. M"intendi alfine?</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>Sì, barbaro, t"intendo. Ah più non vive</l>
             <l>Emonte. O Dei… io moro.</l>
@@ -997,7 +1034,7 @@ per sempre</hi>
               <hi>Sviene.</hi>
             </p>
           </stage>
-          <sp>
+          <sp who="#leontida">
             <speaker>LEONTIDA</speaker>
             <l>Carone, occorri; a tua sorella porgi</l>
             <l>Aita, ché il dolor suoi sensi offusca.</l>
@@ -1008,20 +1045,20 @@ per sempre</hi>
             <hi rend="Italic">SCENA SESTA</hi>
           </head>
           <stage>CARONE, LEONTIDA, ISMENE</stage>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Oimè, sorella! qual pallor di morte</l>
             <l>Scolora il viso? gelo son le membra!</l>
             <l>Leontida,  che avvenne?</l>
           </sp>
-          <sp>
+          <sp who="#leontida">
             <speaker>LEONTIDA</speaker>
             <l>Emonte, il mio rivale,  a un cenno mio</l>
             <l>Cadde trafitto: riportò la pena</l>
             <l>Di un temerario ardir. Ismene il seppe</l>
             <l>Ed improvvisa doglia il cor le oppresse.</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>Emonte più non vive…</l>
             <l>Ove son io? deh lasciami, crudele,</l>
@@ -1033,11 +1070,11 @@ per sempre</hi>
             <l>O mio fratello, io giaccio…</l>
             <l part="I">Nelle tue braccia!</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l part="F">Ismene, o Dei! coraggio.</l>
           </sp>
-          <sp>
+          <sp who="#leontida">
             <speaker>LEONTIDA</speaker>
             <l>Ella rinviene  ed io mi appresto or ora</l>
             <l>Ad ascoltar le sue querele e’ gridi.</l>
@@ -1051,7 +1088,7 @@ per sempre</hi>
             <l>Il turbin cessa e segue pace e calma</l>
             <l>E grand"oblio di quel passato affanno.</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>Io vivo ancor! l"aura vitale io spiro!</l>
             <l>E sovra il capo mio si arresta solo,</l>
@@ -1066,7 +1103,7 @@ per sempre</hi>
             <l>Stige non ha così tremenda imago </l>
             <l>Che te paregi o te somigli in parte.</l>
           </sp>
-          <sp>
+          <sp who="#leontida">
             <speaker>LEONTIDA</speaker>
             <l>Ismene, al tuo trasporto, al tuo dolore</l>
             <l>Ed al tuo sesso ancor perdono questi</l>
@@ -1077,7 +1114,7 @@ per sempre</hi>
             <l>Loco, più saggia al tuo vantaggio allora</l>
             <l>Abbi pensiero. Addio.</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>O Furie, Erinni orribili, voi tutte</l>
             <l>A me d"intorno stagee. Io veggio, o Dive,</l>
@@ -1085,20 +1122,20 @@ per sempre</hi>
             <l>Delle ceraste. Abisso, apriti pure,</l>
             <l>E me sottraggi al mio dolor estremo.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Ahi! sventurato amico! qual dolente</l>
             <l>Ed infelice fin a tuoi begli anni</l>
             <l>Il fato diè! qual frutto amaro cogli</l>
             <l>Da tanto amore e da sì bella fede.</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>Ferma, mio sposo, d"Acheronte in riva</l>
             <l>Ecco ti giungo, la fatale sponda</l>
             <l>Debbe teco varcar la tua consorte.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>La doglia di ragion l"ha priva. Ismene,</l>
             <l>Seguimi dentro e calma il tuo trasporto.</l>
@@ -1112,7 +1149,7 @@ per sempre</hi>
             <hi rend="Italic">SCENA PRIMA</hi>
           </head>
           <stage>PELOPIDA, CARONE, CONGIURATI</stage>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Sono i nimici nella rete ordita</l>
             <l>Caduti ormai: già tutti</l>
@@ -1123,18 +1160,18 @@ per sempre</hi>
             <l>L"amico estinto nuovo ardore aggiunge</l>
             <l>Alla vostra virtù. Che più si aspetta?</l>
           </sp>
-          <sp>
+          <sp who="#congiurati">
             <speaker>CONGIURATI</speaker>
             <l>Ecco le destre ed ecco i petti pronti</l>
             <l>Ad affrontar la morte.</l>
             <l>O morte o libertà tutti cerchiamo.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Pelopida, ti affretta, il tempo vola.</l>
             <l>I tuoi conforta e alla grand"opra accendi.</l>
           </sp>
-          <sp>
+          <sp who="#pelopida">
             <speaker>PELOPIDA</speaker>
             <l>Valorosi compagni, se pensato</l>
             <l>Avessi che mestier era di sprone</l>
@@ -1175,13 +1212,13 @@ per sempre</hi>
             <l>Di morte ne verranno in questa notte</l>
             <l>Le pallid"ombre de’ tiranni esangui.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Su, compagni, si adempia il sacro rito,</l>
             <l>E poi si parta. Il Ciel principio sia</l>
             <l>D"opra sì giusta e a’ Numi eterni accetta.</l>
           </sp>
-          <sp>
+          <sp who="#pelopida">
             <speaker>PELOPIDA</speaker>
             <l>La vittima si rechi all"ara e voi</l>
             <l>Assistete, o compagni.</l>
@@ -1204,7 +1241,7 @@ per sempre</hi>
             <l>Da questa tazza ognuno</l>
             <l>Della vittima assaggi il sangue e giuri.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Io giurerò primiero.</l>
             <l>Gran Dei del Cielo, o santa Temi, o Giove,</l>
@@ -1216,7 +1253,7 @@ per sempre</hi>
             <l>A te, mia patria, o mio gran Nume, il sangue</l>
             <l>E ‘l viver mio consagro.</l>
           </sp>
-          <sp>
+          <sp who="#congiurati">
             <speaker>CONGIURATI</speaker>
             <l>Di noi ciascun al giuramento è pronto.</l>
           </sp>
@@ -1231,67 +1268,67 @@ per sempre</hi>
             <hi rend="Italic">SCENA SECONDA</hi>
           </head>
           <stage>SERVO, TELEFO <hi rend="Italic">e</hi> DETTI</stage>
-          <sp>
+          <sp who="#servo">
             <speaker>SERVO</speaker>
             <l>Signor, di Fillia un messo a te richiede</l>
             <l>Parlar di grave e premuroso affare.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Deh fa che venga. E qual novella mai</l>
             <l>Potrà recar di nuovo?</l>
           </sp>
-          <sp>
+          <sp who="#telefo">
             <speaker>TELEFO</speaker>
             <l>È già palese… qual ruina, o Dei!</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Che mai tu rechi? che vuol dir l"affanno?</l>
             <l>L"interrotto parlar? dì, su, favella.</l>
           </sp>
-          <sp>
+          <sp who="#telefo">
             <speaker>TELEFO</speaker>
             <l>La congiura è scoverta.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>La congiura è scoverta? o grande Alcide!</l>
             <l>Come? chi fu? chi ne tradì? rispondi.</l>
           </sp>
-          <sp>
+          <sp who="#telefo">
             <speaker>TELEFO</speaker>
             <l>A’ tiranni la spia</l>
             <l>La novella recò che dentro Tebe</l>
             <l>La voce è sparsa, che venuti sono</l>
             <l>Al tramontar del sol gli esuli armati.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>E sepper che in mia casa hanno ricetto?</l>
           </sp>
-          <sp>
+          <sp who="#telefo">
             <speaker>TELEFO</speaker>
             <l>Nulla sepper di ciò.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Ed han sospetto alcun della mia fede?</l>
           </sp>
-          <sp>
+          <sp who="#telefo">
             <speaker>TELEFO</speaker>
             <l>D"essa, nissun sospetto.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Grazie agli Dei,  respiro. Il male è grande,</l>
             <l>Ma non sì grave qual recato avevi.</l>
           </sp>
-          <sp>
+          <sp who="#pelopida">
             <speaker>PELOPIDA</speaker>
             <l>Or qual partito prenderemo intanto?</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Ritorni in calma il core.</l>
             <l>Non mancherà dal Ciel qualche consiglio.</l>
@@ -1302,20 +1339,20 @@ per sempre</hi>
             <hi rend="Italic">SCENA TERZA</hi>
           </head>
           <stage>SERVO <hi rend="Italic">e</hi> DETTI</stage>
-          <sp>
+          <sp who="#servo">
             <speaker>SERVO</speaker>
             <l>Signor, batte la porta Polifonte,</l>
             <l>Il capitan superbo della guardia</l>
             <l part="I">De’ tiranni di Tebe!</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l part="F">Polifonte?</l>
             <l>O misera mia patria!</l>
             <l>Già siam d"armati cinti.</l>
             <l>Pelopida, a perir tu sei venuto.</l>
           </sp>
-          <sp>
+          <sp who="#pelopida">
             <speaker>PELOPIDA</speaker>
             <l>Morrò, se pure il Ciel così prescrive;</l>
             <l>Ma invendicato e solo</l>
@@ -1323,7 +1360,7 @@ per sempre</hi>
             <l>A Polifonte acuto ferro in petto</l>
             <l>Or ora immergerò.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Frena il furor che t"agita la mente</l>
             <l>E ‘l disperato ardir serba all"estremo.</l>
@@ -1337,7 +1374,7 @@ per sempre</hi>
             <hi rend="Italic">SCENA QUARTA</hi>
           </head>
           <stage>POLIFONTE, CARONE</stage>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <l>Leontida comanda</l>
             <l>Che senza indugio alcun ora ti porti</l>
@@ -1345,22 +1382,22 @@ per sempre</hi>
             <l>La signoria di Tebe. Un grave affare</l>
             <l>Si tratta; né tardar un sol momento.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Ti è nota, o Polifonte, la cagione</l>
             <l>Di tal grave premura?</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <l>La comune salute</l>
             <l>In gran periglio è posta.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Forse i nemici alle tebane porte</l>
             <l>Or sono e dàn l"assalto?</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <l>Anzi i nemici son dentro la terra.</l>
             <l>In Tebe si congiura: è certo omai</l>
@@ -1376,7 +1413,7 @@ per sempre</hi>
           </head>
           <stage>CARONE <hi rend="Italic">solo</hi>
 					</stage>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Che dubitar di più? La cosa è certa.</l>
             <l>Sanno che in Tebe gli esuli già sono,</l>
@@ -1418,45 +1455,45 @@ per sempre</hi>
             <hi rend="Italic">SCENA SESTA</hi>
           </head>
           <stage>ASPASIA, POLINICE</stage>
-          <sp>
+          <sp who="#polinice">
             <speaker>POLINICE</speaker>
             <l>Madre, perché tu piangi? e qual dolore</l>
             <l>A sospirar ti muove?</l>
             <l>Ma tu mi guardi e taci.</l>
             <l>Deh parla, o Dei! m"affanni con quel pianto.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l>Figlio, degli occhi miei più caro assai,</l>
             <l>Lasciami in preda al mio tormento fiero.</l>
             <l>Ah! tu mi uccidi, o figlio, e pur nol vedi.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>POLINICE</speaker>
             <l>In che ti offesi mai, diletta madre,</l>
             <l>Qual cenno tuo posi in oblio? che feci?</l>
             <l>Se mai ti spiacqui, involontario errore</l>
             <l>Credilo, o genitrice.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l>Taci, mio figlio, taci, io più non posso.</l>
             <l>Tu mi laceri il core.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>POLINICE</speaker>
             <l>Perché dolente sei?</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l>Ah forse lo saprai con tuo gran danno.</l>
             <l>Intanto parti e lasciami qui sola.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>POLINICE</speaker>
             <l>Ogni tuo cenno è mia sovrana legge.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l>O sommi Dei! perché donaste voi</l>
             <l>A me così leggiadro e nobil figlio,</l>
@@ -1470,7 +1507,7 @@ per sempre</hi>
             <hi rend="Italic">SCENA SETTIMA</hi>
           </head>
           <stage>CARONE, PELOPIDA</stage>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Pelopida, tardar senza sospetto</l>
             <l>Io più non posso; partirò, ma voi,</l>
@@ -1484,7 +1521,7 @@ per sempre</hi>
             <l>Ed a tal prezzo la mia patria acquisti</l>
             <l>La libertà perduta.</l>
           </sp>
-          <sp>
+          <sp who="#pelopida">
             <speaker>PELOPIDA</speaker>
             <l>O grand"eccelso eroe, in te d"Alcide</l>
             <l>Il sangue scorre e ben palesi all"opre</l>
@@ -1493,7 +1530,7 @@ per sempre</hi>
             <l>Teco morremo e col nemico sangue</l>
             <l>Vendicherò la tua grand"ombra e Tebe.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Che! Pelopida, tu non ti rammenti</l>
             <l>Il giuramento e il sacro, orrendo patto?</l>
@@ -1504,13 +1541,13 @@ per sempre</hi>
             <l>Ché,  se tu manchi, chi sarà per lei?</l>
             <l>Tebe è caduta e la sua speme è morta.</l>
           </sp>
-          <sp>
+          <sp who="#pelopida">
             <speaker>PELOPIDA</speaker>
             <l>Dovrò dunque sicuro il tuo periglio</l>
             <l>Mirare e comprerò la vita mia</l>
             <l>Col prezzo del tuo sangue?</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Chiama gli amici fuora. E tutti uniti</l>
             <l>Ascolterete mie parole estreme.</l>
@@ -1521,17 +1558,17 @@ per sempre</hi>
             <hi rend="Italic">SCENA OTTAVA</hi>
           </head>
           <stage>CARONE, ASPASIA, POLINICE</stage>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>In tempo giungi; l"ultimo congedo</l>
             <l>Prendi, consorte amata.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l>O Dei! che ascolto! che ferali accenti!</l>
             <l>Qual voce orribil sul mio cuor rimbomba!</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Ora convien che in chiare,  aperte note,</l>
             <l>Aspasia, a te favelli.</l>
@@ -1546,7 +1583,7 @@ per sempre</hi>
             <l>Polifonte a chiamar mi venne a nome</l>
             <l>Del tiranno maggior nostro nemico.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l>Oimè finito hai di tremar,  mio core.</l>
             <l>Or più non temi. Il male è certo. O Dei,</l>
@@ -1555,12 +1592,12 @@ per sempre</hi>
             <l>Con ferro acuto chi mi passa il petto?</l>
             <l>È pietà meco esser crudele e fiero.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Che giova darsi al duol in preda? Il male</l>
             <l>Acquista forza dall"altrui viltade.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l>Ah! più ragion non ho. L"aspro martire</l>
             <l>Ha tolto alla mia mente ogni vigore.</l>
@@ -1578,7 +1615,7 @@ per sempre</hi>
             <hi rend="Italic">SCENA NONA</hi>
           </head>
           <stage>PELOPIDA, CONGIURATI, DETTI</stage>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Della patria il destin e ‘l vostro ancora,</l>
             <l>O del popol di Cadmo invitti eroi,</l>
@@ -1597,7 +1634,7 @@ per sempre</hi>
             <l>Sarò, versate in lui del sangue mio</l>
             <l>La parte la più pura e la più cara.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Ah, Carone, t"arresta. Con tuoi detti</l>
             <l>Dal seno il cor ne svelli e grave offesa</l>
@@ -1605,7 +1642,7 @@ per sempre</hi>
             <l>La tua virtù d"ogni sospetto è sgombra.</l>
             <l>Con la sua madre il figlio tuo rimanga.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>No, venga pur con voi,</l>
             <l>Almen perché valor e patrio zelo</l>
@@ -1617,13 +1654,13 @@ per sempre</hi>
             <l>La cadente città con sue rovine</l>
             <l>Il figlio e tutta la mia gente copra.</l>
           </sp>
-          <sp>
+          <sp who="#pelopida">
             <speaker>PELOPIDA</speaker>
             <l>Se così brami, il tuo voler s"adempia;</l>
             <l>Ma il ferro ostil non ferirà sue membra,</l>
             <l>Se pria nel petto mio non si fa strada.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l>Ahimè! son di me fuora. Adunque il figlio</l>
             <l>E il padre insieme io perdo e senza figlio</l>
@@ -1632,12 +1669,12 @@ per sempre</hi>
             <l>Pietà del mio dolor, che l"ostinato</l>
             <l>Suo core a prieghi tuoi faccia cortese.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>POLINICE</speaker>
             <l>Deh,  madre mia, non t"affannar di questo,</l>
             <l>Lascia ch"io vada della gloria in traccia.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>O figlio mio, sangue de’ Dei, d"Alcide</l>
             <l>Nostro progenitor degno germoglio,</l>
@@ -1648,7 +1685,7 @@ per sempre</hi>
             <l>Ma l"indugio si tronchi. Su partite,</l>
             <l>Ché ad incontrar il mio destin mi affretto.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l>Dove, crudel, ne vai? Tu me qui sola</l>
             <l>Pensi lasciare? E dove il figlio mio</l>
@@ -1666,12 +1703,12 @@ per sempre</hi>
             <l>Ah! spietato consorte,  a qual mi serbi</l>
             <l>Barbaro strazio, a qual crudel tormento?</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>POLINICE</speaker>
             <l>Madre non pianger più. Di me gli Dei</l>
             <l>Avran pietade e cura.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Pelopida,  tronchiam l"inutil pianto,</l>
             <l>Ché l"affetto materno non ha fine.</l>
@@ -1679,20 +1716,20 @@ per sempre</hi>
             <l>Partite: o Polinice,  vanne. E resta,</l>
             <l>Aspasia, e l"aspro duol saggia raffrena</l>
           </sp>
-          <sp>
+          <sp who="#pelopida">
             <speaker>PELOPIDA</speaker>
             <l>Addio,  Carone, al fianco ognor ti vegli</l>
             <l>Un Dio che Tebe e i giorni tuoi difenda.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l part="I">Fermati, figlio, ferma.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>POLINICE</speaker>
             <l part="F"> O madre, addio.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l>Non trattenermi… O Ciel… mio figlio… I lumi</l>
             <stage>
@@ -1705,7 +1742,7 @@ per sempre</hi>
               <hi>Sviene.</hi>
             </stage>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Olà,  guidate dentro</l>
             <l>La padrona e porgete a lei soccorso.</l>
@@ -1721,7 +1758,7 @@ per sempre</hi>
             <hi rend="Italic">SCENA PRIMA</hi>
           </head>
           <stage>ASPASIA <hi>poi</hi> TELEFO</stage>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l>Ah fermate, crudeli, non ferite,</l>
             <l>Arrestate la mano, o il crudo ferro</l>
@@ -1745,7 +1782,7 @@ per sempre</hi>
             <l>Fronte non ha. Su presto, o Nuncio infausto,</l>
             <l>Morto è Carone, e Polinice mio?</l>
           </sp>
-          <sp>
+          <sp who="#telefo">
             <speaker>TELEFO</speaker>
             <l>Salvo è il consorte, e il figlio.</l>
             <l>Giunse Carone,  da’ tiranni atteso,</l>
@@ -1771,24 +1808,24 @@ per sempre</hi>
             <l>E Fillia aggiunse fede</l>
             <l>Col suo parlar a’ detti di Carone.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l>O lieto Nuncio, inaspettata tregua</l>
             <l>Tu rechi al cor, in gran procella assorto.</l>
             <l>Ma come di leggier gli hanno creduto</l>
             <l>In tanto grave affare?</l>
           </sp>
-          <sp>
+          <sp who="#telefo">
             <speaker>TELEFO</speaker>
             <l>Quando nell"onde del piacer sommersa</l>
             <l>È la mente dell"uom, il tutto crede;</l>
             <l>Ma periglio novello ne sovrasta.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l>Ahimè che più mi apporti di funesto?</l>
           </sp>
-          <sp>
+          <sp who="#telefo">
             <speaker>TELEFO</speaker>
             <l>Le lettere da Atene son recate</l>
             <l>In mano di Leontida;</l>
@@ -1797,11 +1834,11 @@ per sempre</hi>
             <l>Hanno i tiranni spie per ogni parte</l>
             <l>Ed in Atene molto più che altrove.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l>Il tiranno le lesse?</l>
           </sp>
-          <sp>
+          <sp who="#telefo">
             <speaker>TELEFO</speaker>
             <l>Non già. Le pose in tasca, e al dì venturo,</l>
             <l>Disse, rimetto i seri e gravi affari;</l>
@@ -1810,20 +1847,20 @@ per sempre</hi>
             <l>Come prescrisse l"ospite d"Atene</l>
             <l>Che gli mandò l"avviso.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l>Ah! mi ritorni nell"antico affanno.</l>
             <l>Temo ch"ognor e’ legga</l>
             <l>Il mio fatal arresto.</l>
           </sp>
-          <sp>
+          <sp who="#telefo">
             <speaker>TELEFO</speaker>
             <l>Perché nell"avvenir tu scerner vuoi</l>
             <l>Sempre i tuoi mali? spera il bene ancora.</l>
             <l>Chi sempre teme il male, o sempre spera</l>
             <l>Il ben, del par s"inganna.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l>Agl"infelici di sperar non resta.</l>
           </sp>
@@ -1833,17 +1870,17 @@ per sempre</hi>
             <hi rend="Italic">SCENA SECONDA</hi>
           </head>
           <stage>POLIFONTE, TELEFO</stage>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <l>O Telefo, la sorte a me ti guida</l>
             <l>Incontro ed opportuno qui ti trovo.</l>
             <l>Tu puoi coll"opre agevolar l"affare.</l>
           </sp>
-          <sp>
+          <sp who="#telefo">
             <speaker>TELEFO</speaker>
             <l>In che poss"io giovarti?</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <l>Già sai che il mio signor arde e delira</l>
             <l>Per Ismene, né aver potrà mai pace,</l>
@@ -1854,14 +1891,14 @@ per sempre</hi>
             <l>Amico, l"ostinato</l>
             <l>Suo cor alla ragion sommetti e piega.</l>
           </sp>
-          <sp>
+          <sp who="#telefo">
             <speaker>TELEFO</speaker>
             <l>Ma se quella l"aborre, perché mai</l>
             <l>Tu nol consigli a discacciar dal petto</l>
             <l>L"insano ardor? Che stolto è l"uom che brama</l>
             <l>A donna unirsi, che il disprezza ed odia.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <l>Al mio signor di giovamento sono</l>
             <l>Tai nozze. Può l"affinità novella</l>
@@ -1872,37 +1909,37 @@ per sempre</hi>
             <l>Ond"io nutrisco quell"ardor che serve</l>
             <l>Al suo poter, che me fa grande ancora.</l>
           </sp>
-          <sp>
+          <sp who="#telefo">
             <speaker>TELEFO</speaker>
             <l>Fabro dunque tu sei delle catene,</l>
             <l>Onde la patria ingrato figlio stringe.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <l>Il suo vantaggio io bramo. Un sol padrone</l>
             <l>È meglio aver che mille.</l>
           </sp>
-          <sp>
+          <sp who="#telefo">
             <speaker>TELEFO</speaker>
             <l>In libera città solo la legge</l>
             <l>Sovrana impera e tutti son soggetti,</l>
             <l>Né quivi serve, né comanda alcuno.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <l>Dura è la legge e nulla scerne ed ode,</l>
             <l>Né per pregar dal suo voler si torce;</l>
             <l>Ma presso del signor grazia e favore</l>
             <l>Può ritrovar chi "l chiede.</l>
           </sp>
-          <sp>
+          <sp who="#telefo">
             <speaker>TELEFO</speaker>
             <l>Altrui chi dà favor, cogli altri è ingiusto,</l>
             <l>Né dritti uguali a ciaschedun dispensa;</l>
             <l>Onde n"avviene ch"altri abbondi ed altri</l>
             <l>Ingiuria soffra e in povertà ne gema.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <l>Sono a’ mortali varie sorti fisse</l>
             <l>Al nascer di ciascun, come la Parca</l>
@@ -1914,7 +1951,7 @@ per sempre</hi>
             <l>Brami, d"Ismene al cor gelato ispira</l>
             <l part="I">Fiamma pel tuo signor.</l>
           </sp>
-          <sp>
+          <sp who="#telefo">
             <speaker>TELEFO</speaker>
             <l part="F"> Al mio dovere</l>
             <l>A tempo adempirò. Ma qui ne viene</l>
@@ -1927,7 +1964,7 @@ per sempre</hi>
             <hi rend="Italic">SCENA TERZA</hi>
           </head>
           <stage>ISMENE, POLIFONTE</stage>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>Qual oggetto funesto? del tiranno</l>
             <l>E della morte il fier ministro io veggio</l>
@@ -1940,7 +1977,7 @@ per sempre</hi>
             <l>E non si pasce ognor del pianto amaro</l>
             <l>Degl"infelici oppressi.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <l>Ismene, e quando al tuo dolor dài freno?</l>
             <l>Infido consigliero è fero sdegno.</l>
@@ -1956,7 +1993,7 @@ per sempre</hi>
             <l>Il piè lontano porterà, se tardi</l>
             <l>A stringer il suo dono.</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>Il mio dolor e l"aspra pena mia</l>
             <l>Non avrà fine e l"odio del tiranno</l>
@@ -1970,7 +2007,7 @@ per sempre</hi>
             <l>Sposo diletto, vittim"innocente</l>
             <l>Del barbaro furor d"un mostro infame!</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <l>Tergi le belle lagrime e sereno</l>
             <l>Torni col ciglio il cor. L"umane cose</l>
@@ -1982,7 +2019,7 @@ per sempre</hi>
             <l>Estima l"infinito amor, che nutre</l>
             <l>Per te quel fido amante.</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>Amor d"ogni odio assai peggior! Deh pera</l>
             <l>Il dì che piacqui agli occhi suoi. Deh fossi</l>
@@ -1991,7 +2028,7 @@ per sempre</hi>
             <l>Omicide crudeli, oh ree sembianze,</l>
             <l>Se voi piaceste al perfido tiranno.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <l>Non vidi mai al par di te nell"odio</l>
             <l>Donna ostinata. Tigre, cui rapita</l>
@@ -1999,7 +2036,7 @@ per sempre</hi>
             <l>Tranquill"ancor diviene e la natìa</l>
             <l>Ferocia ha tregua e posa.</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>Deh Polifonte, alfin lascia l"impegno</l>
             <l>Di mitigar l"acerbo mio pensiero.</l>
@@ -2007,26 +2044,26 @@ per sempre</hi>
             <l>Eterni in me. Lor esca eterna e cibo</l>
             <l>Sarà questo mio petto.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <l>Né ti lusinga lo splendor e ‘l fasto</l>
             <l>Della sorte superba, a che t"invita?</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>Anzi m" irrita più, più faci aggiunge</l>
             <l>All"odio mio, al mio mortal cordoglio.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <l>Né l"ire tu del tuo signor paventi?</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>E che deggio temer? Chi si dispone</l>
             <l>Morte a sprezzar, più nulla al mondo teme.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <l>Deh superba, ti vanta a tuo talento</l>
             <l>Di questa tua ferocia. Ben favella</l>
@@ -2038,37 +2075,37 @@ per sempre</hi>
             <l>E nel sangue del padre il figlio ucciso</l>
             <l>Nuotar bagnato e immerso.</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>Come! Carone! che peccò? che fece?</l>
             <l>Ei fia punito dell"altrui demerto?</l>
             <l>Non è del tuo signor il crudo ferro</l>
             <l>Sazio di stragi ancor? senti, t"arresta.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <l>I sensi tuoi al mio signor riporto.</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>Polifonte, pietà di un"infelice,</l>
             <l>Se del mio sposo mi privò la sorte,</l>
             <l>Del mio germano non mi privi ancora.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <l>Ma tu cangia pensier, deponi il folle</l>
             <l>Orgoglio e quei feroci alteri spirti,</l>
             <l>E il tuo Carone alla tebana gente</l>
             <l>Signoreggiar vedrai.</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>Dona al dolor un giusto tempo almeno.</l>
             <l>Poch"ore al pianto ho date. Il tempo porge</l>
             <l>Maggior conforto che de’ saggi i detti.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <l>Deh leggi questo foglio, egli ti appresta</l>
             <l>Un conforto miglior che il tempo istesso.</l>
@@ -2076,15 +2113,15 @@ per sempre</hi>
           <stage>
             <hi>Ismene legge il foglio.</hi>
           </stage>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>Oh qual ardir! che pensoexcl che rispondo!</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <l>E ben risolvi… Ismene.</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>Leontida contento</l>
             <l>Sarà: ne venga. Io spero che conceda</l>
@@ -2098,7 +2135,7 @@ per sempre</hi>
           </head>
           <stage>POLIFONTE <hi>solo</hi>
 					</stage>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <l>O delle donne instabil mente e inferma!</l>
             <l>Di orgoglio e vanità quanto ricolma</l>
@@ -2127,7 +2164,7 @@ per sempre</hi>
           </head>
           <stage>ISMENE <hi rend="Italic">sola</hi>
 					</stage>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>Ombra diletta dell"amato Emonte,</l>
             <l>Ombra onorata e cara,</l>
@@ -2174,7 +2211,7 @@ per sempre</hi>
             <hi rend="Italic">SCENA SESTA</hi>
           </head>
           <stage>EMONTE <hi rend="Italic">indi</hi> ISMENE</stage>
-          <sp>
+          <sp who="#emonte">
             <speaker>EMONTE</speaker>
             <l>O tenebrosa notte! o tetro buio!</l>
             <l>Qual profondo silenzio</l>
@@ -2204,7 +2241,7 @@ per sempre</hi>
           <stage>
             <hi rend="Italic">Si pone nella parte più rimota dal proscenio.</hi>
           </stage>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>Ecco il tiranno, capitò nel laccio.</l>
             <stage>
@@ -2229,12 +2266,12 @@ per sempre</hi>
             <l>Tema che adombra il cor. Ah no, si vada</l>
             <l>E beva il ferro del crudel il sangue.</l>
           </sp>
-          <sp>
+          <sp who="#emonte">
             <speaker>EMONTE</speaker>
             <l>Qual cheta voce ascolto</l>
             <l>E tacito sussurro?</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>Ei vien incontra… O caro…</l>
             <l part="I">Muori malvagio…</l>
@@ -2242,14 +2279,14 @@ per sempre</hi>
           <stage>
             <hi rend="Italic">Alza per ferir la mano.</hi>
           </stage>
-          <sp>
+          <sp who="#emonte">
             <speaker>EMONTE</speaker>
             <l part="F">Ismene?</l>
           </sp>
           <stage>
             <hi>Si arresta in quell"atto, sentendo la voce d"Emonte.</hi>
           </stage>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>Emonte? eterni Dei!</l>
           </sp>
@@ -2259,42 +2296,42 @@ per sempre</hi>
             <hi rend="Italic">SCENA SETTIMA</hi>
           </head>
           <stage>CARONE, SERVO <hi rend="Italic">con lume e</hi> DETTI</stage>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Che veggio, Emonte vivo!</l>
             <l>Ismene in atto di passargli il core!</l>
             <l>Che strani avvenimenti il Ciel destina!</l>
           </sp>
-          <sp>
+          <sp who="#emonte">
             <speaker>EMONTE</speaker>
             <l>Qual fallo mio meritò tant"ira?</l>
             <l>Che mai ti feci, Ismene?</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>Ah,  caro Emonte mio, perdona questo</l>
             <l>Involontario error. Tu vivi ancora?</l>
             <l>Né ti fece svenar l"empio tiranno?</l>
           </sp>
-          <sp>
+          <sp who="#emonte">
             <speaker>EMONTE</speaker>
             <l>A Fillia diè la cura che di vita</l>
             <l>Mi facesse privar; l"amico finse</l>
             <l>Eseguito il comando e ‘l fier tiranno</l>
             <l>Sicuro è di mia morte.</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>O Ciel! a qual eccesso il braccio mio</l>
             <l>Ora portavi? vendicar lo sposo</l>
             <l>Volendo, io stessa gli squarciava il petto.</l>
             <l>Ah qual orrore nel pensarci io sento!</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>E qual d"un tanto error fu la cagione?</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>Leontida,  di vino e d"impudico</l>
             <l>Amor ardente, mi cercò secreto</l>
@@ -2305,7 +2342,7 @@ per sempre</hi>
             <l>Le chiome tutte) di passar il core</l>
             <l>Al mio diletto sposo.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Oimè! quest"accidente può turbare</l>
             <l>La nostra impresa. D"affrettar fa d"uopo</l>
@@ -2317,7 +2354,7 @@ per sempre</hi>
             <hi rend="Italic">SCENA OTTAVA</hi>
           </head>
           <stage>EMONTE, ISMENE</stage>
-          <sp>
+          <sp who="#emonte">
             <speaker>EMONTE</speaker>
             <l>Ismene,  addio, qui restar non posso.</l>
             <l>Al gran cimento l"amistà, l"onore</l>
@@ -2338,7 +2375,7 @@ per sempre</hi>
             <l>Ma tu piangi, mia vita, e coi sospiri</l>
             <l>E con singulti mi rispondi solo?</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>Ah! caro Emonte… oh Dio!</l>
             <l>Ahi! tosto che la sorte mi ti rende,</l>
@@ -2346,7 +2383,7 @@ per sempre</hi>
             <l>Il Ciel forse per sempre ne divide;</l>
             <l>Né ti vedran mai più questi occhi miei.</l>
           </sp>
-          <sp>
+          <sp who="#emonte">
             <speaker>EMONTE</speaker>
             <l>Ahi! qual assalto fiero, Ismene, or movi</l>
             <l>A mia virtù, ch"amor si vede a fronte.</l>
@@ -2355,12 +2392,12 @@ per sempre</hi>
             <l>Alla mia gloria e al mio dover geloso.</l>
             <l>Io parto. Ismene, addio.</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>Ah no, ti arresta, o sposo. Incontro a morte</l>
             <l>Tu porti il piè. Ti ferma.</l>
           </sp>
-          <sp>
+          <sp who="#emonte">
             <speaker>EMONTE</speaker>
             <l>Se fosse mai nella fatal bilancia,</l>
             <l>U‘ son le sorti del mortal librate,</l>
@@ -2384,7 +2421,7 @@ per sempre</hi>
             <l>Se nel volume del destino è scritto</l>
             <l>Che alla mia patria io renda il proprio dono.</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>Qual Dio parlò col labro tuo? qual Nume</l>
             <l>Tutelare di Tebe ne’ tuoi detti</l>
@@ -2407,7 +2444,7 @@ per sempre</hi>
             <l>Ché ‘l petto mio sarà campo di guerra,</l>
             <l>Ove sarà più cruda aspra tenzone.</l>
           </sp>
-          <sp>
+          <sp who="#emonte">
             <speaker>EMONTE</speaker>
             <l>Son queste voci di tebana donna,</l>
             <l>Sorella di Carone e sposa mia.</l>
@@ -2426,7 +2463,7 @@ per sempre</hi>
           </head>
           <stage>CARONE <hi rend="Italic">all'altare</hi>
 					</stage>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Onnipotenti  Dei, che proteggete</l>
             <l>Il popolo di Cadmo, o de’ tiranni</l>
@@ -2446,7 +2483,7 @@ per sempre</hi>
             <hi rend="Italic">SCENA SECONDA</hi>
           </head>
           <stage>ASPASIA, CARONE</stage>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l>Chi m"arreca o la vita o la mia morte?</l>
             <l>Né alcun ancor qui viene?</l>
@@ -2455,11 +2492,11 @@ per sempre</hi>
             <l>Forse il timor del male</l>
             <l>È più penoso dell"istesso male.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Spera nel Cielo e nel favor de’ Dei.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l>Le speranze nel Ciel e i caldi prieghi</l>
             <l>Spesso coll"uom restar nell"onde immersi.</l>
@@ -2484,7 +2521,7 @@ per sempre</hi>
             <l>Ombra del figlio mio,</l>
             <l>Nell"eterna magion fra pochi istanti.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Ah! che ‘l timor nell"animo ti pinge</l>
             <l>Immagini fallaci di spavento.</l>
@@ -2499,7 +2536,7 @@ per sempre</hi>
             <l>Così,  se accade, è dimezzato il male,</l>
             <l>Siccome è doppio il bene.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l>Vani pensieri! inutili conforti!</l>
             <l>Ma vien qualcuno… o pur m"inganno? è vero.</l>
@@ -2511,29 +2548,29 @@ per sempre</hi>
             <hi rend="Italic">SCENA TERZA</hi>
           </head>
           <stage>POLINICE, ISMENE <hi rend="Italic">e</hi> DETTI</stage>
-          <sp>
+          <sp who="#polinice">
             <speaker>POLINICE</speaker>
             <l>Liete novelle, o padre mio, ti arreco:</l>
             <l>Archia è già caduto e i suoi compagni</l>
             <l>Sono in un mar del proprio sangue immersi.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Grazie vi rendo, o Dei!</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l>O Polinice, che mai fu d"Emonte?</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>POLINICE</speaker>
             <l>È salvo il prode Emonte.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Narra per ordin tutto, o caro figlio.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>POLINICE</speaker>
             <l>Nelle casa di Fillia ogni uscio aperto</l>
             <l>Trovammo e senza servo alcun di guardia,</l>
@@ -2585,22 +2622,22 @@ per sempre</hi>
             <l>Un rovescio tirò sul nudo capo</l>
             <l part="I">D"Emonte…</l>
           </sp>
-          <sp>
+          <sp who="#ismene">
             <speaker>ISMENE</speaker>
             <l part="M">E l"ha ferito?</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>POLINICE</speaker>
             <l part="F">Ismene, no,</l>
             <l>Ché nel mirar l"amico in tal periglio</l>
             <l>Mi sospinsi da lato a quel crudele</l>
             <l>E con ambe le mani il braccio tenni.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l>O caro figlio, palpito di affanno.</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>POLINICE</speaker>
             <l>Di sprigionar tentò l"avvinto braccio,</l>
             <l>Ma invan tentò, ché l"amistade infuse</l>
@@ -2625,16 +2662,16 @@ per sempre</hi>
             <l>Estinto e questo fin ebbe ciascuno</l>
             <l>Ch"empio la patria sua serva si rese.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Ma del crudel Leontida novella</l>
             <l>Tu non mi rechi, o figlio?</l>
           </sp>
-          <sp>
+          <sp who="#polinice">
             <speaker>POLINICE</speaker>
             <l>Poc"anzi egli di là si era partito.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Il maggiore nemico oimè! ne resta.</l>
             <l>Se fia salvo Leontida, ogni nostra</l>
@@ -2647,7 +2684,7 @@ per sempre</hi>
           </head>
           <stage>LEONTIDA <hi rend="Italic">e</hi> DETTI “<hi rend="Italic">poi</hi>  POLIFONTE <hi rend="Italic">e</hi>
 	PELOPIDA“</stage>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Ecco il tiranno, su, mio cor,  valore.</l>
             <l part="I">Cedi sei morto…</l>
@@ -2655,7 +2692,7 @@ per sempre</hi>
               <hi rend="Italic">Carone tira il ferro e va sopra Leontida.</hi>
             </stage>
           </sp>
-          <sp>
+          <sp who="#leontida">
             <speaker>LEONTIDA</speaker>
             <l part="F">Traditor, ti resta </l>
             <l>Molto da far per superarmi ancora…</l>
@@ -2663,11 +2700,11 @@ per sempre</hi>
               <hi rend="Italic">Leontida si disbriga da Carone e si pone in difesa e battonsi.</hi>
             </stage>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l>O Dei! soccorso… aita…</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Lascia l"inutil ferro… mori, e tardi</l>
             <l>Impara de‘ tiranni il fin prefisso.</l>
@@ -2675,17 +2712,17 @@ per sempre</hi>
               <hi>Carone vince il ferro a Leontida.</hi>
             </stage>
           </sp>
-          <sp>
+          <sp who="#leontida">
             <speaker>LEONTIDA</speaker>
             <l>I miei compagni ne faran vendetta.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>I tuoi compagni preceder tuoi passi.</l>
             <l>Ombre gementi attendon il lor duce</l>
             <l>Nella torbida sponda d"Acheronte.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <l>Ma vi son io. Ti arresta; o Polinice</l>
             <l>Sugli occhi tuoi  ti sveno.</l>
@@ -2694,43 +2731,43 @@ per sempre</hi>
 	lo tiene stretto.</hi>
             </stage>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>O Fato, avverso ognora!</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l>Ah Polifonte, ferma.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <stage>
               <hi rend="Italic">Aspasia si muove verso Polifonte.</hi>
             </stage>
             <l>Se t"accosti, ferisco.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l>Figlio, misero figlio!</l>
             <stage>
               <hi>Aspasia si arresta.</hi>
             </stage>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <l>Caron, sciogli Leontida</l>
             <l>O vibro al seno il ferro.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Servo malvagio di un tiranno iniquo,</l>
             <l>Contra la patria l"armi empio tu movi.</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <l>Il tempo vola. Ferirò, se tardi.</l>
           </sp>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l>Ah, Carone, pietà del figlio tuo.</l>
             <l>Figlio, misero figlio…</l>
@@ -2740,24 +2777,24 @@ per sempre</hi>
           <stage>
             <hi>Aspasia s"incamina di nuovo verso il figlio e poi si arresta.</hi>
           </stage>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <l>Ferma. O l"uccido. E tu, Caron, risolvi.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Ah figlio! o Polinice!</l>
             <l>O patria! o sacra fede!</l>
             <l>Provvidenza del Ciel, o vano nome!</l>
           </sp>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <l part="I">Ecco,  ferisco.</l>
           </sp>
           <stage>
             <hi rend="Italic">Accenna di ferire.</hi>
           </stage>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l part="F"> No, t"arresta, o Dio!</l>
             <l>Ah barbaro, crudel, sposo inumano,</l>
@@ -2766,12 +2803,12 @@ per sempre</hi>
             <l>Sugli occhi della madre?</l>
             <l>Numi, Caron, pietà… Misera madre!</l>
           </sp>
-          <sp>
+          <sp who="#leontida">
             <speaker>LEONTIDA</speaker>
             <l>Polifonte, ferisci. Io moro lieto,</l>
             <l>Facendo anco tremar l"eroe di Tebe.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Viva la patria. Tu ferisci, e mori,</l>
             <l part="I">Empio tiranno.</l>
@@ -2779,7 +2816,7 @@ per sempre</hi>
           <stage>
             <hi rend="Italic">Carone ferisce Leontida e costui cade.</hi>
           </stage>
-          <sp>
+          <sp who="#aspasia">
             <speaker>ASPASIA</speaker>
             <l part="M">O Ciel! soccorso</l>
           </sp>
@@ -2787,26 +2824,26 @@ per sempre</hi>
             <hi>Giunge Pelopida,  trattiene colla sinistra il braccio di Polifonte e colla
 	dritta lo ferisce</hi>
           </stage>
-          <sp>
+          <sp who="#pelopida">
             <speaker>PELOPIDA</speaker>
             <l part="F">Mori.</l>
           </sp>
           <stage>
             <hi>e questi cade.</hi>
           </stage>
-          <sp>
+          <sp who="#polifonte">
             <speaker>POLIFONTE</speaker>
             <l part="I">Io manco.</l>
           </sp>
-          <sp>
+          <sp who="#leontida">
             <speaker>LEONTIDA</speaker>
             <l part="F">Invendicato io moro… empio destino.</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>O Dei pietosi! O figlio mio! Carone!</l>
           </sp>
-          <sp>
+          <sp who="#carone">
             <speaker>CARONE</speaker>
             <l>Stolti mortali! La celeste mano</l>
             <l>È più vicina, allorché men si vede.</l>

--- a/tei/poliziano-orfeo.xml
+++ b/tei/poliziano-orfeo.xml
@@ -81,6 +81,40 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="mopso">
+            <persName>Mopso</persName>
+          </person>
+          <person xml:id="aristeo">
+            <persName>Aristeo</persName>
+          </person>
+          <person xml:id="canzona">
+            <persName>Canzona</persName>
+          </person>
+          <person xml:id="tyrsi">
+            <persName>Tyrsi</persName>
+          </person>
+          <person xml:id="orpheo">
+            <persName>Orpheo</persName>
+          </person>
+          <person xml:id="pluto">
+            <persName>Pluto</persName>
+          </person>
+          <person xml:id="proserpina">
+            <persName>Proserpina</persName>
+          </person>
+          <person xml:id="una_furia">
+            <persName>Una Furia</persName>
+          </person>
+          <person xml:id="una_baccante">
+            <persName>Una Baccante</persName>
+          </person>
+          <person xml:id="el_coro_delle_baccante">
+            <persName>El Coro Delle Baccante</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -129,7 +163,7 @@
           <l>State tenta, bragata! Bono argurio,</l>
           <l>ché di cievol in terra vien Marcurio.</l>
         </lg>
-        <sp>
+        <sp who="#mopso">
           <speaker>Mopso</speaker>
           <stage>pastor vecchio:</stage>
           <lg>
@@ -164,7 +198,7 @@
           <l>ma sempre piango, e 'l cibo non mi piace,</l>
           <l>e senza mai dormir son stato in letto.</l>
         </lg>
-        <sp>
+        <sp who="#mopso">
           <speaker>Mopso:</speaker>
           <lg>
             <l>Aristeo mio, questa amorosa face</l>
@@ -182,7 +216,7 @@
             <l>e vite e biade e paschi e mandre e gregge.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#aristeo">
           <speaker>Aristeo:</speaker>
           <lg>
             <l>Mopso, tu parli queste cose a' morti:</l>
@@ -203,7 +237,7 @@
             <l>ch'i' so che la mia nympha el canto agogna.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#canzona">
           <speaker>Canzona.</speaker>
           <lg>
             <l>Udite, selve, mie dolce parole,</l>
@@ -258,7 +292,7 @@
             <l>poi che la nympha mia udir non vuole.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mopso">
           <speaker>Mopso:</speaker>
           <lg>
             <l>El non è tanto el mormorio piacevole</l>
@@ -274,7 +308,7 @@
             <l>Ch'è del vitello? ha'lo tu ritrovato?</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#tyrsi">
           <speaker>Tyrsi:</speaker>
           <lg>
             <l>Sì, così gli avessi el collo mozzo!</l>
@@ -296,21 +330,21 @@
             <l>tutta soletta e sotto bianca vesta.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#aristeo">
           <speaker>Aristeo:</speaker>
           <lg>
             <l>Rimanti, Mopso, ch'i' la vo' seguire,</l>
             <l>perché l'è quella di chi io t'ho parlato.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mopso">
           <speaker>Mopso:</speaker>
           <lg>
             <l>Guarda, Aristeo, che 'l troppo grande ardire</l>
             <l>non ti conduca in qualche tristo lato.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#aristeo">
           <speaker>Aristeo:</speaker>
           <lg>
             <l>O mi convien questo giorno morire,</l>
@@ -319,7 +353,7 @@
             <l>ch'i' vogl'ire a trovalla sopra 'l monte.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mopso">
           <speaker>Mopso:</speaker>
           <lg>
             <l>O Tyrsi, che ti par del tuo car sire?</l>
@@ -328,7 +362,7 @@
             <l>quanta vergogna gli fa questo amore.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#tyrsi">
           <speaker>Tyrsi:</speaker>
           <lg>
             <l>O Mopso, al servo sta bene ubidire,</l>
@@ -371,7 +405,7 @@
           <l>e fu tanto possente e crudo el morso</l>
           <l>ch'ad un tratto finì la vita e 'l corso.</l>
         </lg>
-        <sp>
+        <sp who="#orpheo">
           <speaker>Orpheo:</speaker>
           <lg>
             <l>Dunque piangiamo, o sconsolata lira,</l>
@@ -414,7 +448,7 @@
             <l>dunque gli aprite le ferrate porte.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#pluto">
           <speaker>Pluto:</speaker>
           <lg>
             <l>Chi è costui che con suo dolce nota</l>
@@ -427,7 +461,7 @@
             <l>e le Furie aquietate al pio lamento.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#orpheo">
           <speaker>Orpheo:</speaker>
           <lg>
             <l>O regnator di tutte quelle genti</l>
@@ -480,7 +514,7 @@
             <l>io non vo' su tornar, ma chieggio morte.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#proserpina">
           <speaker>Proserpina:</speaker>
           <lg>
             <l>Io non credetti, o dolce mie consorte,</l>
@@ -493,7 +527,7 @@
             <l>pel canto, pell'amor, pe' giusti prieghi.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#pluto">
           <speaker>Pluto:</speaker>
           <lg>
             <l>Io te la rendo, ma con queste leggi:</l>
@@ -515,7 +549,7 @@
           <l>Ben tendo a te le braccia, ma non vale,</l>
           <l>ché 'ndrieto son tirata. Orpheo mie, vale!</l>
         </lg>
-        <sp>
+        <sp who="#orpheo">
           <speaker>Orpheo:</speaker>
           <lg>
             <l>Oimè, se' mi tu tolta,</l>
@@ -526,7 +560,7 @@
             <l>convien ch'i' torni alla plutonia corte.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#una_furia">
           <speaker>Una furia:</speaker>
           <lg>
             <l>Più non venire avanti, anzi 'l piè ferma</l>
@@ -535,7 +569,7 @@
             <l>vano el pianto e 'l dolor. Tuo legge è ferma.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#orpheo">
           <speaker>Orpheo:</speaker>
           <lg>
             <l>Qual sarà mai sì miserabil canto</l>
@@ -578,7 +612,7 @@
             <l>e ciascun fugga el feminil consorzio.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#una_baccante">
           <speaker>Una Baccante:</speaker>
           <lg>
             <l>Ecco quel che l'amor nostro disprezza!</l>
@@ -602,7 +636,7 @@
           <l>Or vadi e biasimi la teda legittima!</l>
           <l>Euoè Bacco! accepta questa vittima!</l>
         </lg>
-        <sp>
+        <sp who="#el_coro_delle_baccante">
           <speaker>El coro delle Baccante</speaker>
           <lg>
             <l>Ognun segua, Bacco, te!</l>

--- a/tei/rucellai-rosmunda.xml
+++ b/tei/rucellai-rosmunda.xml
@@ -81,6 +81,37 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="rosmunda">
+            <persName>Rosmunda</persName>
+          </person>
+          <person xml:id="nutrice">
+            <persName>Nutrice</persName>
+          </person>
+          <person xml:id="coro">
+            <persName>Coro</persName>
+          </person>
+          <person xml:id="falisco">
+            <persName>Falisco</persName>
+          </person>
+          <person xml:id="nunzio">
+            <persName>Nunzio</persName>
+          </person>
+          <person xml:id="alboino">
+            <persName>Alboino</persName>
+          </person>
+          <person xml:id="messo">
+            <persName>Messo</persName>
+          </person>
+          <person xml:id="almachilde">
+            <persName>Almachilde</persName>
+          </person>
+          <person xml:id="serva">
+            <persName>Serva</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -131,7 +162,7 @@
       <div>
         <head>1</head>
         <stage>ROSMUNDA e NUTRICE</stage>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Tempo è ormai, or che 'l profondo sonno,</l>
           <l>Vestitosi el sembiante de la morte,</l>
@@ -149,7 +180,7 @@
           <l>E non t'incresca, benché infirma e vecchia,</l>
           <l>Breve camino in questo officio extremo.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l>Regina, unica speme al nostro regno,</l>
           <l>Non mi grava el camin nocturno e ceco,</l>
@@ -184,51 +215,51 @@
           <l>De la inimica gente e di Alboino,</l>
           <l>Che più caro gli fia che van sepulcro.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Dunque tu vuoi che le paterne membra,</l>
           <l>A le fere, a li ucei restando in preda,</l>
           <l>Sien sepellite poi nel ventre loro?</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l>Voglio che pensi al mantenerti in vita.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>La indegna vita è assai peggior che morte.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l>E l'uno e l'altro ti potria seguire.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Che posso peggiorar da quel ch'io sono?</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l>L'onor, la libertà perder tu puoi.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Questo non perderò senza la vita.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l>Tu non sai bene ancor che cosa è morte.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>La morte è fin de le miserie umane.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l>Io comendo el morir quando resulta</l>
           <l>Utile ad altri, a sé gloria et onore,</l>
           <l>Non quando a sé vergogna, ad altri danno.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Bench'io non giunga al sexto decimo anno,</l>
           <l>Pel che dovrei seguire el tuo consiglio,</l>
@@ -281,14 +312,14 @@
           <l>Ma pur ch'io faccia le pietose exequie,</l>
           <l>Venga che può ch'io non mi disconforto.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l>Figliola mia, poi che da tanto sogno</l>
           <l>Admonita ne vai, più non ti tegno,</l>
           <l>Ma teco vengo a la mostrata fonte;</l>
           <l>Poi prenderén la via per questo monte.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CORO</speaker>
           <l>Fra le cose mortali</l>
           <l>Non nacque al mondo peggio</l>
@@ -334,7 +365,7 @@
       <div>
         <head>2</head>
         <stage>NUTRICE. ROSMUNDA. CORO. FALISCO Prefecto et el NUNZIO</stage>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l>Tu se' sì longamente dimorata,</l>
           <l>Mentre lavi le piaghe a una a una</l>
@@ -345,14 +376,14 @@
           <l>E mena seco l'inimica luce,</l>
           <l>Che ci potrebbe far vergogna e danno.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Non temer, madre mia, perché dal cielo</l>
           <l>Vien spesso aiuto a l'opere pietose.</l>
           <l>Ma che esser pò che tutte paventose</l>
           <l>Veggo venir vèr noi le donne nostre?</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CO.</speaker>
           <l>Regina, tu sei presa</l>
           <l>E noi siàn prese teco,</l>
@@ -368,13 +399,13 @@
           <l>Acciò possa fuggire</l>
           <l>Avanti el suo venire.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l>Eccoli qui, figliola,</l>
           <l>Ecco che son venuti.</l>
           <l>Fuggiamo, oimè, fuggiam subitamente.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Ma chi fia che ci aiuti</l>
           <l>Si non la morte sola?</l>
@@ -385,66 +416,66 @@
           <l>Che generosa morte</l>
           <l>Ha el primo loco infra le cose belle.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CO.</speaker>
           <l>O voce alta e divina,</l>
           <l>Degna di tal Regina!</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>Qual di voi, donne, è stata tanto ardita</l>
           <l>Che ha dato sepoltura a corpo alcuno</l>
           <l>Contro el mandato di sì gran Signore?</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Dunque il Re vostro fa la guerra ai morti ?</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>El Re nostro la guerra ha co' nimici</l>
           <l>E cerca di privar di sepoltura</l>
           <l>Quei che han cercato lui privar di vita</l>
         </sp>
-        <sp>
+        <sp who="#nunzio">
           <speaker>NUNZ.</speaker>
           <l>Questa è colei di ch'io ti dissi dianzi</l>
           <l>Che sepelliva un corpo appresso el fonte.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Sì ch'io son quella, e non ti niego el vero,</l>
           <l>C'ho dato sepoltura al padre mio.</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>Rosmunda, inanzi al Re verrai con meco</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Al Re ne verrò io, poi che al ciel piace.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CO.</speaker>
           <l>O misera Regina, ove sei giunta?</l>
           <l>Ove siàn noi condotte?</l>
           <l>Ma in vita fia coniuncta</l>
           <l>Nostra fortuna o in sempiterna nocte.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Donne, non dubitate:</l>
           <l>Ch'io non posso patir cosa più dura</l>
           <l>Del veder lacerate</l>
           <l>L'ossa paterne e senza sepoltura.</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>Ite a desepellir presto Comundo;</l>
           <l>Tagliateli la testa</l>
           <l>E portatela al Re dentro a quel vaso.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CO.</speaker>
           <l>Oimè, Regina, oimè, che gran dolore</l>
           <l>Ti dan queste parole!</l>
@@ -456,7 +487,7 @@
           <l>A provar non ti resta.</l>
           <l>Oimè, Regina, oimè, che duro caso!</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Quante fatiche invano</l>
           <l>Pigliate son in questa breve vita</l>
@@ -469,26 +500,26 @@
           <l>Questa nostra pietate al ciel gradita,</l>
           <l>Che non mi curerei de li altri mali.</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>O voglia o non, bisogna che ciascuno</l>
           <l>Sopporti quel che ha terminato el cielo,</l>
           <l>Contro del qual non val difesa umana.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Deh non voler, Falisco, esser ministro</l>
           <l>Di tanta crudeltà; di me t'incresca,</l>
           <l>Di me fanciulla che in un punto ho perso</l>
           <l>La cara libertà, mio padre e el regno.</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>Madonna, assai di voi me incresce e duole,</l>
           <l>Ma molto più di me m'increscerebbe</l>
           <l>Quando disubidisse al mio Signore.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Tu sai che avanti a questa orribil guerra</l>
           <l>El tuo Signore e 'l mio padre Comundo</l>
@@ -517,7 +548,7 @@
           <l>Impetrino el sepulcro di colui</l>
           <l>Che, pregato da me, ti diè la vita.</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>Regina, io non potrei né vo' negarti,</l>
           <l>Per li tuoi benefizii e di tuo padre,</l>
@@ -535,7 +566,7 @@
           <l>Ch'io ti possa ancor dar qualche soccorso:</l>
           <l>Però raffrena el doloroso pianto.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Falisco, poi che sei disposto al tutto</l>
           <l>Portarne al Re quella onorata testa,</l>
@@ -550,7 +581,7 @@
           <l>In brevissimo tempo nascer ponno</l>
           <l>Molti vendicator del sangue nostro.</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>Io non posso altro far si non pregarti</l>
           <l>Che tu stia paziente a quella legge</l>
@@ -558,16 +589,16 @@
           <l>Io per li merti tuoi vèr me ti giuro</l>
           <l>Pregare el mio Signor per la tua vita.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Prega più tosto lui per la mia morte,</l>
           <l>Più grata a me di questa vita amara.</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>Andiàn, che farai forse altro pensiero.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CORO</speaker>
           <l>Giorno infelice, al mio mal sì fecondo,</l>
           <l>Poi che la libertate</l>
@@ -607,7 +638,7 @@
       <div>
         <head>3</head>
         <stage>[ALBOINO Re. MESSO. ROSMUNDA. CORO. FALISCO. NUTRICE]</stage>
-        <sp>
+        <sp who="#alboino">
           <speaker>ALB.</speaker>
           <l>Maravigliomi assai come Falisco,</l>
           <l>Nostro prefecto de le turme equestre,</l>
@@ -626,13 +657,13 @@
           <l>Ma ecco un messagier che viene in fretta:</l>
           <l>Forse dirà qualcosa di Falisco.</l>
         </sp>
-        <sp>
+        <sp who="#messo">
           <speaker>MES.</speaker>
           <l>Eccoti, invicto Re l'odioso teschio</l>
           <l>Che ti manda Falisco, tuo prefecto,</l>
           <l>Qual sarà presto nella tua presenzia.</l>
         </sp>
-        <sp>
+        <sp who="#alboino">
           <speaker>ALB.</speaker>
           <l>Io lodo assai la vostra diligenzia.</l>
           <l>Segate el cranio e fatelo ben netto</l>
@@ -644,35 +675,35 @@
           <l>E come gli era di ferite carco,</l>
           <l>E dove: nelle spalle o ne la fronte?</l>
         </sp>
-        <sp>
+        <sp who="#messo">
           <speaker>MES.</speaker>
           <l>Noi il trovamo sepolto a piè d'un fonte.</l>
         </sp>
-        <sp>
+        <sp who="#alboino">
           <speaker>ALB.</speaker>
           <l>Come, sepulto? E chi fu tanto audace</l>
           <l>Che presumesse contra el mio decreto</l>
           <l>Di voler dar sepulcro a corpo alcuno?</l>
         </sp>
-        <sp>
+        <sp who="#messo">
           <speaker>MES.</speaker>
           <l>Rosmunda fu, con le sue proprie mani.</l>
         </sp>
-        <sp>
+        <sp who="#alboino">
           <speaker>ALB.</speaker>
           <l>Rosmunda ove è? Sarebbe mai fuggita?</l>
           <l>O pure è stata da Falisco presa?</l>
         </sp>
-        <sp>
+        <sp who="#messo">
           <speaker>MES.</speaker>
           <l>È stata presa et è qui poco adietro.</l>
         </sp>
-        <sp>
+        <sp who="#alboino">
           <speaker>ALB.</speaker>
           <l>Oh quanto è il ciel benigno alle mie voglie!</l>
           <l>Narrami apunto come andò la cosa.</l>
         </sp>
-        <sp>
+        <sp who="#messo">
           <speaker>MES.</speaker>
           <l>Noi cercavàn di lei pel folto bosco</l>
           <l>Et un de' nostri, ch'era forse andato</l>
@@ -690,17 +721,17 @@
           <l>Giacer involto, che si avea Rosmunda</l>
           <l>Spogliata a sé per onorare el patre.</l>
         </sp>
-        <sp>
+        <sp who="#alboino">
           <speaker>ALB.</speaker>
           <l>Ma tu non mi hai narrato quante e quali</l>
           <l>Ferite avesse el mio nimico morto.</l>
         </sp>
-        <sp>
+        <sp who="#messo">
           <speaker>MES.</speaker>
           <l>Le piaghe erano molte, aspre e profonde,</l>
           <l>Nel pecto, nella faccia e ne la gola.</l>
         </sp>
-        <sp>
+        <sp who="#alboino">
           <speaker>ALB.</speaker>
           <l>Questo credo io, perché con questa spada</l>
           <l>Li detti colpi assai ch'eran mortali:</l>
@@ -710,24 +741,24 @@
           <l>Rosmunda, guarda a non negarmi el vero:</l>
           <l>Sei tu colei che seppellio Comundo?</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Perché degio io negarlo? Io son quella epsa.</l>
         </sp>
-        <sp>
+        <sp who="#alboino">
           <speaker>ALB.</speaker>
           <l>Erati noto el mio comandamento?</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Come non, sendo a tutti manifesto?</l>
         </sp>
-        <sp>
+        <sp who="#alboino">
           <speaker>ALB.</speaker>
           <l>Adonque tu sei stata tanto ardita</l>
           <l>Che hai dispregiato e rotto la mia legge?</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Più tosto a li divini, alti precepti</l>
           <l>Di quel Signor che regge l'universo</l>
@@ -756,7 +787,7 @@
           <l>Lo invictissimo sangue onde sei nata,</l>
           <l>Che non può sottoporsi a' casi adversi.</l>
         </sp>
-        <sp>
+        <sp who="#alboino">
           <speaker>ALB.</speaker>
           <l>La superchia altereza alfin ruina.</l>
           <l>Più volte ho visto un gran corsier feroce</l>
@@ -773,7 +804,7 @@
           <l>Ma si di questo non riporti pena,</l>
           <l>Non possi io mai portar corona in testa.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Più tosto volsi satisfar coloro</l>
           <l>Che mi fur cari e che mi fecer bene,</l>
@@ -781,7 +812,7 @@
           <l>E con cui deggio dimorar mai sempre,</l>
           <l>Che a te da cui non ebbi altro che male.</l>
         </sp>
-        <sp>
+        <sp who="#alboino">
           <speaker>ALB.</speaker>
           <l>Orsù, lasciamo andar tante parole:</l>
           <l>Menate queste donne a quella tenda.</l>
@@ -793,7 +824,7 @@
           <l>Vero è che ancor non ho deliberato</l>
           <l>Quale è il suplizio ch'io gli voglia dare.</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>Inclito Re, non è si grave pena</l>
           <l>Che non sia lieve per punir colui</l>
@@ -801,19 +832,19 @@
           <l>Ma le donne son donne e non si acquista</l>
           <l>Nesuna laude per la morte loro.</l>
         </sp>
-        <sp>
+        <sp who="#alboino">
           <speaker>ALB.</speaker>
           <l>Ma non debbio io punir quel che m'offende?</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>Poss'io teco parlar liberamente?</l>
         </sp>
-        <sp>
+        <sp who="#alboino">
           <speaker>ALB.</speaker>
           <l>Liberamente di' ciò che ti piace.</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>Io non niego che 'l premio e che la pena</l>
           <l>Sien dui ferme colonne in cui si appogia</l>
@@ -839,7 +870,7 @@
           <l>E la misera sua noiosa vita</l>
           <l>Li saranno cagion di extrema doglia.</l>
         </sp>
-        <sp>
+        <sp who="#alboino">
           <speaker>ALB.</speaker>
           <l>Non mi dispiace questo tuo consiglio</l>
           <l>E già per me non era pria disposto</l>
@@ -847,20 +878,20 @@
           <l>Ma si avea tirato dietro el male</l>
           <l>Come trae Cecia vento a sé le nube.</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>El grave suo dolor che la trasporta</l>
           <l>Li fe' forse parlar quel che ti spiacque;</l>
           <l>Ma mi dai tu licenza ancor ch'io dica</l>
           <l>Liberamente a te qualche parole ?</l>
         </sp>
-        <sp>
+        <sp who="#alboino">
           <speaker>ALB.</speaker>
           <l>Dovresti ormai saper quanto ch'io t'ami</l>
           <l>E come spesso mi consiglio teco:</l>
           <l>Di' senza dubitar quel che tu vuoi.</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAR.</speaker>
           <l>Come tu sai, con li ampli regni tuoi</l>
           <l>El gran regno de' Geppidi confina,</l>
@@ -875,12 +906,12 @@
           <l>Per ciò che a lei la signoria conviensi:</l>
           <l>Così l'arai senza contrasto alcuno.</l>
         </sp>
-        <sp>
+        <sp who="#alboino">
           <speaker>ALB.</speaker>
           <l>Come per moglie mia, sendo figliola</l>
           <l>Del Re Comundo, mio mortal nimico?</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>Non si diè risguardare ira né sdegno</l>
           <l>Dov'è l'util del regno o di chi regge.</l>
@@ -900,37 +931,37 @@
           <l>Sì che non ti lasciar uscir di mano</l>
           <l>Tanta ventura che ti manda el cielo.</l>
         </sp>
-        <sp>
+        <sp who="#alboino">
           <speaker>ALB.</speaker>
           <l>Questo non mi era ancor venuto in mente.</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>A questo non bisogna altro pensiero</l>
           <l>Che darli effecto e preparar le noze.</l>
         </sp>
-        <sp>
+        <sp who="#alboino">
           <speaker>ALB.</speaker>
           <l>Tu mi consigli adonque ch'io la prenda?</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>Io ti consiglio a quel ch'io veggio expresso</l>
           <l>Recarti utilità, quiete e gloria.</l>
         </sp>
-        <sp>
+        <sp who="#alboino">
           <speaker>ALB.</speaker>
           <l>Son contento exequire el tuo consiglio:</l>
           <l>Però, Falisco, prenderai la cura</l>
           <l>Di parlar seco e far quel che bisogna.</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>Donne, chiamate la Regina vostra</l>
           <l>A cui parlar vorrei</l>
           <l>Presto, per ciò che 'l Re mi manda a lei.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CO.</speaker>
           <l>Signor che reggi el cielo,</l>
           <l>E tu, pietosa Madre,</l>
@@ -942,34 +973,34 @@
           <l>Falisco e temo, omei,</l>
           <l>Non rechi eterno pianto agli occhi miei.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>S'el vien per quel ch'io credo,</l>
           <l>Io vegno volontieri,</l>
           <l>Che aràn pur fine e duri mei pensieri.</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>Più volentier verresti</l>
           <l>Si tu sapesse ben quel ch'io ti reco.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Da tal tu ti movesti,</l>
           <l>Che so ch'altro che mal non porti teco.</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>Forse che quel ch'è meco</l>
           <l>È miglior che non speri</l>
           <l>E potrà farti ritornar come eri.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Narrami adonque questo nuovo bene</l>
           <l>Che tu mi porti, come che nol creda.</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>Non creder che mi sien di mente usciti</l>
           <l>Li benifizii che ebbi da tuo padre</l>
@@ -990,71 +1021,71 @@
           <l>E questo e c'ho impetrato co' miei preghi,</l>
           <l>Dallo adirato Re, che non ti occida.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Apunto impetrato hai dal tuo Signore</l>
           <l>El contrario di quel ch'io desiava.</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>Come 'l contrario? Quale è el tuo disio?</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Uscirmi presto fuor di questa vita.</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>Ah, non dar tanto loco a la tua doglia!</l>
           <l>ROS. Nissuna altra speranza m'è rimasa.</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>Non dir così, Regina, ch'è la morte</l>
           <l>L'ultima cosa de le cose orrende.</l>
           <l>ROS. Anzi è riposo e fine a li altri mali.</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>A color che non han remedio alcuno.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Et io son un di quei senza rimedio.</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>Forse che non: non sai che volga el cielo.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Volger per me non può si non martiri.</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>Doppo la pioggia el sol talora appare.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Io non spero già mai vedere el sole.</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>Quando tu arai le mie parole intese,</l>
           <l>Forse el vedrai per questa obscura nebbia.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Dio el voglia. Or fammi tuo parole conte.</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>Regina, io non ti porto solamente</l>
           <l>La tua salute, ma la patria e 'l regno,</l>
           <l>Con amplissime noze. E queste sono</l>
           <l>Che 'l mio Signor ti vol pigliar per moglie.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Deh non pigliar dilecto in l'altrui doglie,</l>
           <l>Che non è cosa digna al vincitore</l>
@@ -1064,7 +1095,7 @@
           <l>Per moglie et io men lui per mio marito:</l>
           <l>Sì che fa' quando vòi quel che t'ha imposto.</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>Non dir così, Rosmunda, ch'io non sono</l>
           <l>Uom che si rida de li altrui dolori.</l>
@@ -1073,14 +1104,14 @@
           <l>E mi credea che di sì bella grazia</l>
           <l>Tu dovessi levar le mani al cielo.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Io non reputo grazia, anzi disgrazia</l>
           <l>Il dover esser moglie di colui</l>
           <l>Che ne ha destructi et ha le mani ancora</l>
           <l>Calde e stillante del paterno sangue.</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>L'animo grande sempre è da lodare,</l>
           <l>Ma non quel che sé stesso non conosce;</l>
@@ -1110,7 +1141,7 @@
           <l>Sì che apri gli occhi e ricognosci bene</l>
           <l>L'alta ventura che ti appar davanti.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Ben cognosco, Falisco, che procede</l>
           <l>Ciò che tu parli da perfecta mente,</l>
@@ -1130,7 +1161,7 @@
           <l>Sì che non prender più fatiche invano,</l>
           <l>Che tal noze non voglio in modo alcuno.</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>Io non accepto questa per risposta,</l>
           <l>Ma voglio andar qui presso per vedere</l>
@@ -1138,47 +1169,47 @@
           <l>Che andò di là al Mincio in su la riva</l>
           <l>Di Benaco a predar tutto el paese.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Almechilde è tornato? O Almechilde,</l>
           <l>A che tempo vien tu per darmi aiuto!</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>In questo mezo tu potrai pensare</l>
           <l>E consigliarti ben con la ragione,</l>
           <l>E tornerò per la risposta certa.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l>A me non piacque questa tua risposta.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>A me non piacque ancor la sua proposta.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l>Ma che cosa miglior potea proporre?</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Ogni altra cosa era miglior di questa.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l>Come ogni cosa? Tu non pensi el tutto,</l>
           <l>Né puoi pensarlo ben, per ciò che hai posto</l>
           <l>El fren de la ragione in man de l'ira.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Vero è c'ho gionto l'ira alla ragione,</l>
           <l>Ma in man de la ragion posto ho il governo,</l>
           <l>E poscia a quella subministra l'ira</l>
           <l>Incitamento e spron de la forteza.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l>L'ira è una bestia indomita e superba,</l>
           <l>Inimica di pace e di consiglio,</l>
@@ -1187,16 +1218,16 @@
           <l>Sì che disiungi lor, però che insieme</l>
           <l>Stanno così come con aqua foco.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Tu mi consigli adonque ch'io divenga</l>
           <l>Moglie di quel che mi dicea Falisco.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l>Questo mi pare el meglio in tal fortuna.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>O Dio del cielo, o stelle, o sole, o luna,</l>
           <l>Volete voi ch'io prenda per marito</l>
@@ -1205,7 +1236,7 @@
           <l>Prima la terra si apra e mi divori</l>
           <l>Ch'io mi ritrovi mai congiunta a lui.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l>Figliola, si tu fusse in libertade</l>
           <l>O potesse esser moglie di qualcuno</l>
@@ -1213,11 +1244,11 @@
           <l>Non ti consigliarei tòrre Alboino:</l>
           <l>Ma che puoi tu fare altro in questo caso?</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>E' non giacerà mai nel lecto mio.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l>Non dir così, per ciò che far nol pòi.</l>
           <l>S'egli vorrà giacer sopra el tuo lecto,</l>
@@ -1265,16 +1296,16 @@
           <l>Desiderosa che si faccia questo,</l>
           <l>Con lacrime e sospir tacendo prega.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Non credo mai poter toccar costui.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l>Ciascun fa di sé stesso ciò che vuole,</l>
           <l>Pur che l'animo fermo sel dispona.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Ben cognosco io che tu m ' hai dicto el vero.</l>
           <l>Come che duro sia posserlo fare,</l>
@@ -1284,42 +1315,42 @@
           <l>Però, prendendo el tuo voler per guida,</l>
           <l>Seguirò le vestigie del tuo senno.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CO.</speaker>
           <l>Quanto vale un consiglio che sia bono!</l>
           <l>E veramente quel si può dir buono</l>
           <l>Che reca al suo Signore utile e gloria,</l>
           <l>A li populi poi salute e pace.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l>Ecco, questo è Falisco che ritorna</l>
           <l>Per riportarne al Re la tua risposta.</l>
           <l>Ora accompagna el volto a le parole</l>
           <l>Acciò che scontenteza non dimostri.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Questo molto repugna a' miei costumi,</l>
           <l>Avezi a dire el ver dal dì ch'io nacqui:</l>
           <l>Sì che respondi tu ciò che ti piace.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l>Ben responder poss'io, ma questo è nulla,</l>
           <l>Si non confermi tu ciò ch'io rispondo.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Di', ch'io confirmerò ciò che dirai.</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>Io son tornato a te, come io ti dixi,</l>
           <l>Per saper chiaramente el tuo volere</l>
           <l>E referirne al Re ciò che ti piace.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l>Falisco, poi che la passion da parte</l>
           <l>Pose Rosmunda, ricognobbe e vidde</l>
@@ -1327,39 +1358,39 @@
           <l>Però grazia ti rende et è disposta</l>
           <l>E prompta al tutto di voler seguirlo.</l>
         </sp>
-        <sp>
+        <sp who="#falisco">
           <speaker>FAL.</speaker>
           <l>Quanto prudentemente avete electo!</l>
           <l>Quanto piacer ne arò, tu quanto bene!</l>
           <l>Andiamo adonque al Re, perché le noze</l>
           <l>Si possin celebrare in questa sera.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Oimè, come stasera?</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CO.</speaker>
           <l>Quelle cose che son salubre e buone</l>
           <l>Mai non si posson far troppo per tempo.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l>Rosmunda, non disdire a quel che vuole,</l>
           <l>Che quanto prima tu sarai Regina</l>
           <l>E fuor di servitù, tanto fie meglio</l>
           <l>Per te, né peggio ancor sarà per noi.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Fa' pur come tu vuoi.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l>Andiamo adonque. Or va', Falisco, avante,</l>
           <l>E noi ti verrén dietro tutte quante.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CORO</speaker>
           <l>Ciascun che regge prenda</l>
           <l>Exemplo da Rosmunda,</l>
@@ -1427,7 +1458,7 @@
       <div>
         <head>4</head>
         <stage>[ALMACHILDE. CORO. SERVA. ROSMUNDA. NUTRICE] </stage>
-        <sp>
+        <sp who="#almachilde">
           <speaker>ALM.</speaker>
           <l>Lasso, quanto m'incresce</l>
           <l>D'essermi in altra parte ritrovato,</l>
@@ -1444,11 +1475,11 @@
           <l>Donne, che fate voi? dove è Rosmunda</l>
           <l>Che fu vostra Regina?</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CO.</speaker>
           <l>O Almachilde, ella è ben qui vicina.</l>
         </sp>
-        <sp>
+        <sp who="#almachilde">
           <speaker>ALM.</speaker>
           <l>Ite donque a trovarla e per mia parte</l>
           <l>Ditegli ch'io son qui fermo e disposto</l>
@@ -1460,45 +1491,45 @@
           <l>Acciò che medicina</l>
           <l>Gli sien queste parole, e non ruina.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CO.</speaker>
           <l>Oimè, Almachilde, el tuo soccorso è tardo</l>
           <l>Per ciò che a lei fu forza</l>
           <l>Trovare altro soccorso a la sua vita.</l>
         </sp>
-        <sp>
+        <sp who="#almachilde">
           <speaker>ALM.</speaker>
           <l>Di tal tardeza anch'io mi struggo et ardo,</l>
           <l>Ma el ciel che tutto sforza</l>
           <l>Ne fu cagion: or chi gli ha dato aita?</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CO.</speaker>
           <l>Dura necessità, che sempre ardita</l>
           <l>Rende la gente ne' perigli extremi.</l>
           <l>Questa da' primi bei pensier supremi</l>
           <l>La svolse e diè per moglie ad Alboino.</l>
         </sp>
-        <sp>
+        <sp who="#almachilde">
           <speaker>ALM.</speaker>
           <l>Oh mio crudel destino!</l>
           <l>È ver quel che voi dite?</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CO.</speaker>
           <l>A che dicto l'arei, non sendo el vero?</l>
         </sp>
-        <sp>
+        <sp who="#almachilde">
           <speaker>ALM.</speaker>
           <l>Dite Alboin, quel fero</l>
           <l>Che di crudel ferite</l>
           <l>Gli uccise el padre e fegli ogni dispecto?</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CO.</speaker>
           <l>Questo è proprio colui: non te l'ho dicto?</l>
         </sp>
-        <sp>
+        <sp who="#almachilde">
           <speaker>ALM.</speaker>
           <l>O dura mia fortuna! Ove mi scorse</l>
           <l>Nel mio maggior bisogno!</l>
@@ -1508,26 +1539,26 @@
           <l>Né spero più già mai di aver conforto.</l>
           <l>Ma che condusse, lasso, a farmi torto?</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CO.</speaker>
           <l>La servitù, la tema de lo onore,</l>
           <l>Le minaccie del Re, l'ardente amore</l>
           <l>Di noi; e mezo el buon Falisco è stato.</l>
         </sp>
-        <sp>
+        <sp who="#almachilde">
           <speaker>ALM.</speaker>
           <l>Anzi pur scelerato.</l>
           <l>Non sapeva ella poi</l>
           <l>Ch'ero qui presso e che tanto l'amava?</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CO.</speaker>
           <l>Spesso ti ricordava:</l>
           <l>Ma tutti e dolor suoi</l>
           <l>Eran presenti e certi, e tu lontano</l>
           <l>Eri col tuo soccorso, e forse in vano.</l>
         </sp>
-        <sp>
+        <sp who="#almachilde">
           <speaker>ALM.</speaker>
           <l>O misero Almachilde, ora è ben vòlto</l>
           <l>Ogni tuo riso in pianto!</l>
@@ -1547,38 +1578,38 @@
           <l>Che si ogni aiuto è scarso a li miei danni,</l>
           <l>Questa mia dextra mi trarrà di affanni.</l>
         </sp>
-        <sp>
+        <sp who="#serva">
           <speaker>SER.</speaker>
           <l>O Dio, si se' nel ciel come si crede</l>
           <l>Et hai la cura de le umane genti,</l>
           <l>Come comporti queste cose orrende?</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CO.</speaker>
           <l>Che cosa ti fa dir sì gran parole?</l>
         </sp>
-        <sp>
+        <sp who="#serva">
           <speaker>SER.</speaker>
           <l>Care sorelle mie, che aggio veduto!</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CO.</speaker>
           <l>Lasso, dolente a me, c'hai tu veduto?</l>
         </sp>
-        <sp>
+        <sp who="#serva">
           <speaker>SER.</speaker>
           <l>Veduto ho cose da scurare el sole.</l>
         </sp>
-        <sp>
+        <sp who="#almachilde">
           <speaker>ALM.</speaker>
           <l>O me, ch'io tremo tutto di paura</l>
           <l>Che Rosmunda non abia qualche male!</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CO.</speaker>
           <l>Deh per tua fé, non ci tener sospese.</l>
         </sp>
-        <sp>
+        <sp who="#serva">
           <speaker>SER.</speaker>
           <l>Io vel dirò, benché m'induca orrore</l>
           <l>Solamente el pensier, non che 'l narrarlo.</l>
@@ -1627,19 +1658,19 @@
           <l>Et ecco . . . oimè mi trema el cor nel pecto</l>
           <l>E la voce mi manca a referirlo . . .</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CO.</speaker>
           <l>Ma che esser pò, che tanto ti commove?</l>
         </sp>
-        <sp>
+        <sp who="#serva">
           <speaker>SER.</speaker>
           <l>La taza era del teschio d'uno uom morto.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CO.</speaker>
           <l>Ohimè, tu narri una cosa da fere!</l>
         </sp>
-        <sp>
+        <sp who="#serva">
           <speaker>SER.</speaker>
           <l>Alboin, preso questo orrendo vaso,</l>
           <l>L'empié di vino e sorridendo dixe:</l>
@@ -1665,40 +1696,40 @@
           <l>Di lei la pose; onde sforzata e vinta,</l>
           <l>D'indi beveo più lagrime che vino.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CO.</speaker>
           <l>O miserabil noze, o duro caso!</l>
           <l>Ma così adviene a chi de' sua inimici</l>
           <l>Si fida e ponsi ne le forze loro.</l>
         </sp>
-        <sp>
+        <sp who="#almachilde">
           <speaker>ALM.</speaker>
           <l>Ma che seguì dapoi de la Regina?</l>
         </sp>
-        <sp>
+        <sp who="#serva">
           <speaker>SER.</speaker>
           <l>Altro non so, che come fur levati,</l>
           <l>Io me ne venni qui, lassando lei</l>
           <l>Che insieme con el Re ne andava a letto.</l>
         </sp>
-        <sp>
+        <sp who="#almachilde">
           <speaker>ALM.</speaker>
           <l>Ma veggio io là Rosmunda e la Nutrice</l>
           <l>Che escon fora. O Dio, che esser può questo?</l>
           <l>Io mi voglio appressare in verso loro.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Per seguir le vestigie del tuo senno,</l>
           <l>Come conviensi a giovenile etade,</l>
           <l>Bevuto ho dentro al teschio di mio padre.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l>Chi are' mai pensato che costui</l>
           <l>Fusse sì cruda e inexorabil fera?</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>O misera Rosmunda, or che far deggio?</l>
           <l>È questo el capo sopra ogni altro degno</l>
@@ -1732,7 +1763,7 @@
           <l>Tra li Geppidi miei dilecti e cari,</l>
           <l>Acciò che in libertà stia viva e morta.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l>Oimè, donne, oimè, presto, soccorso!</l>
           <l>Su, aiutate la vostra Regina</l>
@@ -1740,7 +1771,7 @@
           <l>Già el sangue per le vene si fa ghiaccio</l>
           <l>Si non porgete aiuto a la sua vita.</l>
         </sp>
-        <sp>
+        <sp who="#almachilde">
           <speaker>ALM.</speaker>
           <l>Oimè, Nutrice, oimè,</l>
           <l>Che crudo caso è questo?</l>
@@ -1753,53 +1784,53 @@
           <l>L'ira del vendicare</l>
           <l>Vinca el grave dolore.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l>O giovane, Rosmunda è tramortita:</l>
           <l>Non correr a furor perché sarai</l>
           <l>Dalla guardia del Re tagliato in pezi.</l>
         </sp>
-        <sp>
+        <sp who="#almachilde">
           <speaker>ALM.</speaker>
           <l>E di che può temer chi morir vole?</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l>Si sei disposto al vendicar costei,</l>
           <l>Non niego che lo ardir tuo possa assai,</l>
           <l>Come è noto a ogniun: ma gli bisogna</l>
           <l>Aver qualche altro aiuto oltre a la forza.</l>
         </sp>
-        <sp>
+        <sp who="#almachilde">
           <speaker>ALM.</speaker>
           <l>Qui basta sol l'ardir, perché la sorte</l>
           <l>Aiuta i forti e i timidi discaccia.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l>A quel che giogne colle forze el senno</l>
           <l>Ogni impresa felice gli succede:</l>
           <l>Vecchi consigli in giovenil forteza.</l>
         </sp>
-        <sp>
+        <sp who="#almachilde">
           <speaker>ALM.</speaker>
           <l>Disposto son di far come vorrai,</l>
           <l>Pur che uccida Alboino e faciàn tosto:</l>
           <l>Morto che è lui, non curo la mia vita.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l>Tu puoi far presto e ben queste due cose:</l>
           <l>Uccider lui e poi salvar te stesso</l>
           <l>Con costei qui e tutte quante noi.</l>
         </sp>
-        <sp>
+        <sp who="#almachilde">
           <speaker>ALM.</speaker>
           <l>E' non si desiò mai cosa alcuna</l>
           <l>Quanto io desio la morte di costui.</l>
           <l>Orsù, datemi tosto questo modo.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l>Entriàn qua dentro a queste prime tende,</l>
           <l>Perché siàn qui negli ochi di ciascuno.</l>
@@ -1821,7 +1852,7 @@
           <l>E non restate di pregare Dio</l>
           <l>Che porga aiuto all'opere piatose.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CORO</speaker>
           <l>Non ha quando è sereno el ciel più stelle,</l>
           <l>Né per tempesta el gran furiar del vento</l>
@@ -1867,7 +1898,7 @@
       <div>
         <head>5</head>
         <stage>[SERVA. ROSMUNDA]</stage>
-        <sp>
+        <sp who="#serva">
           <speaker>SER.</speaker>
           <l>Levati su, Regina,</l>
           <l>Che Dio ha posto fine</l>
@@ -1877,7 +1908,7 @@
           <l>Al Re ingiusto e crudele,</l>
           <l>La qual reporta seco.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Come? O Signor del cielo,</l>
           <l>Questo creder non posso!</l>
@@ -1888,13 +1919,13 @@
           <l>Narrarci prestamente</l>
           <l>Quando e in che modo è morto.</l>
         </sp>
-        <sp>
+        <sp who="#serva">
           <speaker>SER.</speaker>
           <l>Almachilde è stato epso,</l>
           <l>Tuo fido e caro amante,</l>
           <l>Quel che ha morto Alboino.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Come potrò io mai</l>
           <l>Remunerar costui ?</l>
@@ -1939,13 +1970,13 @@
           <l>E dentro a certo panno la rinvolse</l>
           <l>Sol per portarla ne la tua presenzia.</l>
         </sp>
-        <sp>
+        <sp who="#rosmunda">
           <speaker>ROS.</speaker>
           <l>Tu se' pure Dio in ciel come ogniun crede,</l>
           <l>Et hai la cura de le cose umane</l>
           <l>E porgi aiuto a l'opere piatose!</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CORO</speaker>
           <l>Ciascun che regge, impari</l>
           <l>Dal dispietato Re che morto iace</l>

--- a/tei/salfi-pausania.xml
+++ b/tei/salfi-pausania.xml
@@ -78,6 +78,28 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="eudamida">
+            <persName>Eudamida</persName>
+          </person>
+          <person xml:id="archidamo">
+            <persName>Archidamo</persName>
+          </person>
+          <person xml:id="teane">
+            <persName>Teane</persName>
+          </person>
+          <person xml:id="euristia">
+            <persName>Euristia</persName>
+          </person>
+          <person xml:id="pausania">
+            <persName>Pausania</persName>
+          </person>
+          <person xml:id="argilio">
+            <persName>Argilio</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT-Salerno</name>Digitalizzazione</change>
@@ -180,7 +202,7 @@ in Sparta.</hi>
           </head>
           <stage>ARCHIDAMO, EUDAMIDA</stage>
           <stage>Foro di Sparta</stage>
-          <sp>
+          <sp who="#emonte">
             <speaker>EMONTE</speaker>
             <l>Giugni, Eudamida, in tempo. In questo punto</l>
             <l>Dalla Troade a noi torna il messaggio,</l>
@@ -189,14 +211,14 @@ in Sparta.</hi>
             <l>Di Sparta gli recò, di appresentarsi</l>
             <l part="I">Immantinente agli efori.</l>
           </sp>
-          <sp>
+          <sp who="#eudamida">
             <speaker>EUDAMIDA</speaker>
             <l part="F">Ned altro</l>
             <l>Ei veder seppe, Archidamo, che valga</l>
             <l>A raffermare o dileguar cotesti</l>
             <l part="I">Rinascenti sospetti?</l>
           </sp>
-          <sp>
+          <sp who="#archidamo">
             <speaker>ARCHIDAMO</speaker>
             <l part="F">Ei troppo vide</l>
             <l>Che non mentì finor la fama: che aspro</l>
@@ -221,20 +243,20 @@ in Sparta.</hi>
             <l>Ed or, poiché da Atene era proscritto,</l>
             <l part="I">Di Grecia tutta aspro nemico.</l>
           </sp>
-          <sp>
+          <sp who="#eudamida">
             <speaker>EUDAMIDA</speaker>
             <l part="F">Io quasi</l>
             <l>Son fuor di me! Che intesi? – E qual mai  stolto</l>
             <l part="I">Disegno ei nutrir può?</l>
           </sp>
-          <sp>
+          <sp who="#archidamo">
             <speaker>ARCHIDAMO</speaker>
             <l part="F">Quel che ognor meco</l>
             <l>Temono i buoni: ch'egli Sparta abborra,</l>
             <l>Che le leggi ne sprezzi e che turbarne</l>
             <l part="I">Mediti in cor la libertà….</l>
           </sp>
-          <sp>
+          <sp who="#eudamida">
             <speaker>EUDAMIDA</speaker>
             <l part="F">Che dici?</l>
             <l>Nel tuo strano timor tu sempre eccedi!</l>
@@ -247,7 +269,7 @@ in Sparta.</hi>
             <l>La greca libertà sarebbe spenta,</l>
             <l part="I">Se Pausania non era?</l>
           </sp>
-          <sp>
+          <sp who="#archidamo">
             <speaker>ARCHIDAMO</speaker>
             <l part="F">Io ne rammento,</l>
             <l>Più che nol pensi tu, le imprese prime</l>
@@ -269,7 +291,7 @@ in Sparta.</hi>
             <l>Godea sul mar, la Grecia tutta, in tempo</l>
             <l part="I">Ammutinata, a torle giunse.</l>
           </sp>
-          <sp>
+          <sp who="#eudamida">
             <speaker>EUDAMIDA</speaker>
             <l part="F">Oh! taci</l>
             <l>L'infausto caso; e,  più che altrui, ne incolpa</l>
@@ -284,42 +306,42 @@ in Sparta.</hi>
             <l>In volontario esiglio, or di’: non soffre</l>
             <l part="I">De’ suoi trascorsi ammenda grave?</l>
           </sp>
-          <sp>
+          <sp who="#archidamo">
             <speaker>ARCHIDAMO</speaker>
             <l part="F">Ei nuovo</l>
             <l>Desio può trarne di vendetta; e forse</l>
             <l part="I">Di tal brama or si pasce!</l>
           </sp>
-          <sp>
+          <sp who="#eudamida">
             <speaker>EUDAMIDA</speaker>
             <l part="F">E quai potrebbe</l>
             <l part="I">Mezzi tentar?</l>
           </sp>
-          <sp>
+          <sp who="#archidamo">
             <speaker>ARCHIDAMO</speaker>
             <l part="F">Tranne il consiglio, tutti</l>
             <l>Può Serse offrirgli; né il consiglio manca,</l>
             <l part="I">Se Pausania a lui serve.</l>
           </sp>
-          <sp>
+          <sp who="#eudamida">
             <speaker>EUDAMIDA</speaker>
             <l part="F">Or odi accusa</l>
             <l>Prodotta sempre e non provata mai!</l>
           </sp>
-          <sp>
+          <sp who="#archidamo">
             <speaker>ARCHIDAMO</speaker>
             <l>Perché, a rischio di Sparta, in lui si volle,</l>
             <l>Piucché punirne i nuovi errori, i prischi</l>
             <l part="I">Suoi merti riconoscere.</l>
           </sp>
-          <sp>
+          <sp who="#eudamida">
             <speaker>EUDAMIDA</speaker>
             <l part="F">Più giusto</l>
             <l>Di’ che finor n'eran le glorie certe,</l>
             <l>Dubbia l'accusa; ed a punirlo quindi</l>
             <l part="I">Troppo lievi gl'indizi.</l>
           </sp>
-          <sp>
+          <sp who="#archidamo">
             <speaker>ARCHIDAMO</speaker>
             <l part="F">E son mai lievi,</l>
             <l>Ove la patria è minacciata e teme?</l>
@@ -333,7 +355,7 @@ in Sparta.</hi>
             <l>Credi nel giudicar, dove ci tragga,</l>
             <l part="I">Eudamida, nol vedi?</l>
           </sp>
-          <sp>
+          <sp who="#eudamida">
             <speaker>EUDAMIDA</speaker>
             <l part="F">Io veggio or dove</l>
             <l>Lo zelo tuo trarci potria! – Tu temi</l>
@@ -360,7 +382,7 @@ in Sparta.</hi>
             <l>L'accusato convincerne, vedrai</l>
             <l part="I">Se io primo allor saprò dannarlo.</l>
           </sp>
-          <sp>
+          <sp who="#archidamo">
             <speaker>ARCHIDAMO</speaker>
             <l part="F">E certe,</l>
             <l>Più che nol brami, oggi ne avrai tu prove.</l>
@@ -378,7 +400,7 @@ in Sparta.</hi>
             <emph>SCENA SECONDA</emph>
           </head>
           <stage>EUDAMIDA</stage>
-          <sp>
+          <sp who="#eudamida">
             <speaker>EUDAMIDA</speaker>
             <l part="F">Fervido troppo</l>
             <l>Di libertà, troppo oltr'ei teme. – Sparta</l>
@@ -395,7 +417,7 @@ in Sparta.</hi>
             <emph>SCENA TERZA</emph>
           </head>
           <stage>EUDAMIDA, TEANE</stage>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">Un solo istante,</l>
             <l>Eudamida, deh! soffri che alle tue</l>
@@ -419,7 +441,7 @@ in Sparta.</hi>
             <l>Pausania qui? Sparta lo chiama? giusti</l>
             <l part="I">Son pur gli altrui sospetti?…</l>
           </sp>
-          <sp>
+          <sp who="#eudamida">
             <speaker>EUDAMIDA</speaker>
             <l part="F">Oh Ciel! che chiedi? –</l>
             <l>Men tristo annunzio, e di te degno, io darti,</l>
@@ -427,19 +449,19 @@ in Sparta.</hi>
             <l>Virtù spartane appien risponda il figlio;</l>
             <l part="I">Ma contra il ver che dir poss'io?…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">T'intesi!</l>
             <l part="I">Dunque mio figlio è reo?</l>
           </sp>
-          <sp>
+          <sp who="#eudamida">
             <speaker>EUDAMIDA</speaker>
             <l part="F">Tal, io nol credo;</l>
             <l>E forse ei tal non è. Ma di lui tanti</l>
             <l>Sorgon sospetti, ch'è mestier ch'ei stesso</l>
             <l part="I">Venga in Sparta a smentirli.</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">E qual può nuova</l>
             <l>Rea cagion riprodurli? Erano un tempo,</l>
@@ -459,23 +481,23 @@ in Sparta.</hi>
             <l>Sospetti altrui, qual gli si puote ancora</l>
             <l part="I">Nuovo disegno apporre?</l>
           </sp>
-          <sp>
+          <sp who="#eudamida">
             <speaker>EUDAMIDA</speaker>
             <l part="F">Esser potrebbe</l>
             <l>Vano il sospetto ancor; pur v'ha chi teme</l>
             <l>Ch'ei, più che a Sparta, a’ suoi nemici or serva.</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="I">Misero!… – Ed onde ciò?</l>
           </sp>
-          <sp>
+          <sp who="#eudamida">
             <speaker>EUDAMIDA</speaker>
             <l part="F">D’ modi strani,</l>
             <l>Che per legge non men che per costume</l>
             <l part="I">Sparta detesta, e ch'egli ostenta.</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">E a tale</l>
             <l>Dimenticar potria d'esser mio figlio</l>
@@ -494,7 +516,7 @@ in Sparta.</hi>
             <l>Pietà, tu mi assecura; e mi consiglia,</l>
             <l>Se Sparta o il figlio mio difender deggia.</l>
           </sp>
-          <sp>
+          <sp who="#eudamida">
             <speaker>EUDAMIDA</speaker>
             <l>Modera il tuo timor. Le nostre leggi</l>
             <l>Difenderan Sparta non men che il figlio.</l>
@@ -516,7 +538,7 @@ in Sparta.</hi>
             <emph>SCENA QUARTA</emph>
           </head>
           <stage>TEANE</stage>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">Potessi</l>
             <l>Calmare in parte il mio timore! Ei cresce,</l>
@@ -537,7 +559,7 @@ in Sparta.</hi>
             <emph>SCENA QUINTA</emph>
           </head>
           <stage>TEANE, EURISTIA</stage>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">Ah corri, o donna… In punto</l>
             <l>Pausania arriva… Io n'ebbi avviso appena</l>
@@ -546,20 +568,20 @@ in Sparta.</hi>
             <l>Compagna: unite ad abbracciar corriamo,</l>
             <l part="I">Io lo sposo e tu il figlio.</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">E tu di gioia</l>
             <l>Mi parli, Euristia, in questo dì! né sai</l>
             <l>Quanto per noi riuscir potria  funesto?</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l>Io so che meco ognor tu sospiravi</l>
             <l>Sull'assenza del figlio; e che agli Dei</l>
             <l>Preghi finor porgevi, ond'egli a Sparta</l>
             <l part="I">E a’ lari suoi tornasse alfin.</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">Ma preghi</l>
             <l>Non porsi io mai, perch'ei tornasse quale</l>
@@ -586,13 +608,13 @@ in Sparta.</hi>
             <l>E, quel che più d'alto terror mi stringe!</l>
             <l part="I">E chi sa, se innocente…</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">Ohimè! che dici?</l>
             <l>Del figlio tuo tu ancor diffidi? e il danni,</l>
             <l part="I">Pria che pronunzin gli efori?</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">Se in core</l>
             <l>Tu mi leggessi, appien vedresti, o donna,</l>
@@ -615,25 +637,25 @@ in Sparta.</hi>
             <l>Dell'innocenza sua. – Ma se mai vero</l>
             <l part="I">Fosse il delitto!…</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">Ah! nol sarà. Più volte</l>
             <l>Ei trionfò della calunnia iniqua;</l>
             <l part="I">Trionferà pur questa volta.</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">Ed io,</l>
             <l>Al par di te, lo spero e il bramo; e il Cielo</l>
             <l>Ne prego; e sol di questa speme or vivo!</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l>Dunque si vada ad incontrarlo. Almeno,</l>
             <l>Da tutti omai negletto, a’ fianchi suoi</l>
             <l part="I">La sposa ei veggia e la sua madre.</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">E Sparta</l>
             <l>Che direbbe di noi? La sua innocenza</l>
@@ -648,13 +670,13 @@ in Sparta.</hi>
             <l>Chi sa?… malgrado mio, lieto un presagio</l>
             <l part="I">Mi parla in cor!… Deh! vieni.</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">Ad obbedirti</l>
             <l>Son presta. – Eppur, me misera! mi uccide</l>
             <l part="I">Lo starmi ancor da lui divisa!</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">I Numi</l>
             <l>Odan pria per la patria i nostri voti;</l>
@@ -663,7 +685,7 @@ in Sparta.</hi>
             <l>Più che altri, ne farei, di Sparta a vista,</l>
             <l part="I">Piena difesa.</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">Il Ciel tuoi voti accolga!</l>
           </sp>
@@ -676,21 +698,21 @@ in Sparta.</hi>
             <emph>SCENA PRIMA</emph>
           </head>
           <stage>PAUSANIA, EURISTIA, ARGILIO</stage>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l>Euristia, va; non mi seguir… – Già siamo</l>
             <l>Al tribunal degli efori. Io qui deggio</l>
             <l>Udire il mio destino. A che vuoi meco</l>
             <l part="I">Divider l'onta, a cui mi espongo?</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">Sparta</l>
             <l>Sa già che sposo a me tu sei, ch'io ti amo;</l>
             <l>Sappia quindi ch'io voglio il tuo qualsia</l>
             <l part="I">Fero destin divider teco.</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F"> Ad altri</l>
             <l>Tempi, deh! serba le tue cure. Il mio</l>
@@ -698,7 +720,7 @@ in Sparta.</hi>
             <l>Gli efori qui mi appellano; pria che altri</l>
             <l part="I">Udir lor voglio; e il deggio.</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Un qualche istante</l>
             <l>Pur riveder potevi i lari tuoi</l>
@@ -706,13 +728,13 @@ in Sparta.</hi>
             <l>E la tua madre consolar, che palpita</l>
             <l part="I">Sul tuo destino!</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Il vedi. In tale stato</l>
             <l>Io non godrei del figlio; e della madre</l>
             <l part="I">Accrescerei l'affanno.</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">Oh! se veduti</l>
             <l>Gli avessi tu! Pargoleggiando l'uno</l>
@@ -737,7 +759,7 @@ in Sparta.</hi>
             <l>Stavan supplici madri; e il suo materno</l>
             <l>Pianto pur tutte a lagrimar movea!</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l>Meglio, o donna, a’ suoi voti unisci i tuoi.</l>
             <l>Che giova lo star qui? La mia giust'ira</l>
@@ -749,17 +771,17 @@ in Sparta.</hi>
             <l>Io vi avea di più caro; e, se il potessi,</l>
             <l part="I">Ad abborrirla quasi…</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">Ohimè! quali odo</l>
             <l part="I">Strani sensi da te?</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Né strani estimi</l>
             <l part="I">Tu gli oltraggi ch'io soffro?</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">È ver; ma denno</l>
             <l>Gli efori, il sai, di Sparta adempier l'alte,</l>
@@ -779,13 +801,13 @@ in Sparta.</hi>
             <l>Se non suo re, suo cittadin chiamarti;</l>
             <l part="I">E forse ancor…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Che speri mai? Più volte</l>
             <l>Finora assolto io fui. – Ma di’: sul trono</l>
             <l part="I">Mi vedi or tu?</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F"> Che parli? E avrebbe il trono</l>
             <l>Rassicurata più la tua innocenza?</l>
@@ -794,29 +816,29 @@ in Sparta.</hi>
             <l>Dal popolo temuto! or tu saresti</l>
             <l>Forse men grande e più stimato al certo!</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l>Cessa; non più. Qual sia il periglio, lascia</l>
             <l>A me la mia difesa. – Oggi salvarmi,</l>
             <l>Ad onta ancor de’ miei nemici, io spero; –</l>
             <l>Ma dagli efori no, da me lo spero.</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="I">Misera me!… tu fai tremarmi!</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">E sei</l>
             <l part="I">Spartana tu?</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">Pur troppo, io sento, ahi lassa!</l>
             <l>Che moglie io sono! L'ira tua soverchia</l>
             <l part="I">Tremar mi fa!</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Dunque il cimento evita.</l>
             <l>Va’; conforta la madre; al figlio assisti. –</l>
@@ -825,7 +847,7 @@ in Sparta.</hi>
             <l>Maggior de’ miei nemici ancor mi sento!</l>
             <l>Va’; più non ti odo; lasciami; l'impongo.</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l>Oh momento terribile!… Pietosi</l>
             <l>Numi, se io più nol posso, ah, voi sovr'esso</l>
@@ -838,7 +860,7 @@ in Sparta.</hi>
             <hi rend="Italic">SCENA SECONDA</hi>
           </head>
           <stage>PAUSANIA, ARGILIO</stage>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l>Tu mi compiangi, Argilio? Ah! vieni; abbraccia,</l>
             <l>Se non il re, l'amico tuo. Se fidi,</l>
@@ -848,7 +870,7 @@ in Sparta.</hi>
             <l>Che più sperano i miei? Del tutto han forse</l>
             <l part="I">Obliato il mio nome?</l>
           </sp>
-          <sp>
+          <sp who="#argilio">
             <speaker>ARGILIO</speaker>
             <l part="F">Il popol, fero</l>
             <l>Della sua piena libertà, sovente</l>
@@ -870,7 +892,7 @@ in Sparta.</hi>
             <l>Sdegnano or quasi di servir più Sparta</l>
             <l>Per non esserne alfin, qual tu, puniti.</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l>Se de’ migliori io regno in cor, del volgo</l>
             <l>I sospetti non men che il rigor sprezzo</l>
@@ -878,7 +900,7 @@ in Sparta.</hi>
             <l>Anco i pensieri di chi regna; e forse</l>
             <l>Gli efori qui regnar non potran sempre.</l>
           </sp>
-          <sp>
+          <sp who="#argilio">
             <speaker>ARGILIO</speaker>
             <l>E chi attentar potria la lor suprema</l>
             <l>Autorità? Dopo i suoi Numi, Sparta</l>
@@ -887,7 +909,7 @@ in Sparta.</hi>
             <l>Che degli efori schiavi; or tutta, insomma,</l>
             <l part="I">Sta negli efori Sparta!</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">E alcun non freme</l>
             <l>Contra questo degli efori usurpato</l>
@@ -905,7 +927,7 @@ in Sparta.</hi>
             <l>Soffrirlo ancor dovrei? dovrei vedermi</l>
             <l>Di re, qual era, or vil così?… Non mai.</l>
           </sp>
-          <sp>
+          <sp who="#argilio">
             <speaker>ARGILIO</speaker>
             <l>Frena il trasporto. Ove tu stai, non vedi?</l>
             <l>Sparta in te sol volto ha lo sguardo; e gli atti,</l>
@@ -915,19 +937,19 @@ in Sparta.</hi>
             <l>Deh! più tu non accrescere. La tua</l>
             <l>Sola innocenza appien l'odio altrui spenga.</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l>La mia innocenza e il mio soffrir non fece</l>
             <l>Che render Sparta ognor più ingrata e questi</l>
             <l part="I">Efori iniqui più…</l>
           </sp>
-          <sp>
+          <sp who="#argilio">
             <speaker>ARGILIO</speaker>
             <l part="F">Gli efori io veggio</l>
             <l>Venir!… lor segue taciturno e fero</l>
             <l part="I">Lungo stuolo di popolo!…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Qual onta?… –</l>
             <l>Va’; cerca, Argilio, i fidi miei; ritenta</l>
@@ -949,7 +971,7 @@ in Sparta.</hi>
 	</hi>
 						</p>
           </stage>
-          <sp>
+          <sp who="#archidamo">
             <speaker>ARCHIDAMO</speaker>
             <l>Popolo, e voi quanti qui state, udite. –</l>
             <l>Pausania è questi ch'io vi addito, un tempo</l>
@@ -982,7 +1004,7 @@ in Sparta.</hi>
             <l>Che il tuo destin pronunzi, ella udir vuole,</l>
             <l>Qual dee, le tue discolpe; e a sè ti chiama.</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l>Il messaggio degli efori io conobbi;</l>
             <l>Ed agli efori io venni. Udrò coteste</l>
@@ -991,7 +1013,7 @@ in Sparta.</hi>
             <l>Vederli ancor puniti! – Eppur, lo spero;</l>
             <l>Se qui, più che altri, omai regnan le leggi.</l>
           </sp>
-          <sp>
+          <sp who="#archidamo">
             <speaker>ARCHIDAMO</speaker>
             <l>Dove or se’ tu, più non rammenti? o torni</l>
             <l>Cangiato sì che più non sai che Sparta</l>
@@ -999,15 +1021,15 @@ in Sparta.</hi>
             <l>Or sappi tu che delle leggi in nome</l>
             <l part="I">Per gli efori ti parla.</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F"> Ed io gli ascolto.</l>
           </sp>
-          <sp>
+          <sp who="#archidamo">
             <speaker> ARCHIDAMO</speaker>
             <l part="I">– Narra: perché Sparta lasciasti?</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Io volli</l>
             <l>Torle un oggetto di livor, di sprezzo.</l>
@@ -1015,26 +1037,26 @@ in Sparta.</hi>
             <l>Spontaneo elessi, pria che oziar fra’ lari</l>
             <l part="I">Inutile e negletto.</l>
           </sp>
-          <sp>
+          <sp who="#archidamo">
             <speaker>ARCHIDAMO</speaker>
             <l part="F">Alcun nemico</l>
             <l part="I">Hai tu di Sparta conosciuto?</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Molti</l>
             <l>A Platea ne conobbi, allor ch'io Sparta</l>
             <l part="I">E la Grecia salvai.</l>
           </sp>
-          <sp>
+          <sp who="#archidamo">
             <speaker>ARCHIDAMO</speaker>
             <l part="F">Né mai vedesti</l>
           </sp>
-          <sp>
+          <sp who="#archidamo">
             <speaker>ARCHIDAMO</speaker>
             <l part="I">Temistocle?</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Lo vidi allor che vinse</l>
             <l>La persa armata a Salamina; il vidi</l>
@@ -1045,36 +1067,36 @@ in Sparta.</hi>
             <l>E apprender quindi qual si possa all'uopo</l>
             <l>La ingiustizia de’ suoi soffrir tranquillo.</l>
           </sp>
-          <sp>
+          <sp who="#archidamo">
             <speaker>ARCHIDAMO</speaker>
             <l>Né ad altro fin Temistocle, ned altri</l>
             <l part="I">Tu frequentasti mai?</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Se il sai, lo svela</l>
             <l part="I">Tu, che mi accusi.</l>
           </sp>
-          <sp>
+          <sp who="#archidamo">
             <speaker>ARCHIDAMO</speaker>
             <l part="F">E perché tu scegliesti</l>
             <l>Quasi nel sen dell'Asia a tuo soggiorno</l>
             <l part="I">La remota Golona?</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Ivi lontano</l>
             <l>Da Sparta io più, da’ suoi sospetti eterni</l>
             <l part="I">Vie più securo io mi credea.</l>
           </sp>
-          <sp>
+          <sp who="#archidamo">
             <speaker>ARCHIDAMO</speaker>
             <l part="F">Speravi</l>
             <l>Che di Sparta vegliante ivi lo sguardo</l>
             <l>Non ti giugnesse? e che potesse quindi</l>
             <l>Conspirar teco ognor più cauto il Perso?</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l>Il Perso, è ver, me frequentò; ma nota</l>
             <l>La cagion n'era. – Omai favola al mondo</l>
@@ -1087,7 +1109,7 @@ in Sparta.</hi>
             <l>Un fero esemplo contemplar dell'alta</l>
             <l part="I">Spartana ingratitudine!</l>
           </sp>
-          <sp>
+          <sp who="#archidamo">
             <speaker>ARCHIDAMO</speaker>
             <l part="F">Spartano</l>
             <l>S'eri tu ancor, tu stesso in te gli effetti</l>
@@ -1104,7 +1126,7 @@ in Sparta.</hi>
             <l>La mensa e il fasto; e per dir tutto in una,</l>
             <l>Satellite di corte eri tu vile!</l>
           </sp>
-          <sp>
+          <sp who="#archidamo">
             <speaker>ARCHIDAMO</speaker>
             <l>A’ rimproveri tuoi breve io rispondo. –</l>
             <l>Della Persia e de’ barbari i costumi</l>
@@ -1119,18 +1141,18 @@ in Sparta.</hi>
             <l>E, perch'io trassi già l'abito medo,</l>
             <l part="I">Meno Spartan son io?</l>
           </sp>
-          <sp>
+          <sp who="#archidamo">
             <speaker>ARCHIDAMO</speaker>
             <l part="F">Così rammenti</l>
             <l part="I">Di Licurgo le leggi?</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Io ne rammento</l>
             <l>Che opra sua non son gli efori; ch'ei tutta</l>
             <l>Pose ne’  re la maestà di Sparta.</l>
           </sp>
-          <sp>
+          <sp who="#archidamo">
             <speaker>ARCHIDAMO</speaker>
             <l>E perché i re del gran Licurgo l'opra</l>
             <l>Non attentasser mai, Sparta la pose</l>
@@ -1138,7 +1160,7 @@ in Sparta.</hi>
             <l>Ti avrian di re la dignità mai tolta,</l>
             <l>Se violata pria tu non l'avessi.</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l>Io violata l'ebbi allor ch'io solo</l>
             <l>Salvai la Grecia intera e a Sparta diedi</l>
@@ -1152,7 +1174,7 @@ in Sparta.</hi>
             <l>Mi si lasciò, perché più sempre io soffra</l>
             <l part="I">Nuovi oltraggi e più gravi.</l>
           </sp>
-          <sp>
+          <sp who="#archidamo">
             <speaker>ARCHIDAMO</speaker>
             <l part="F">Or ti credevi</l>
             <l>Che, perché tu la Grecia un dì salvasti,</l>
@@ -1166,7 +1188,7 @@ in Sparta.</hi>
             <l>E, fremendo, in suon d'ira il tuo destino</l>
             <l part="I">Pronunzia quasi…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">E ben; che tarda? Immoli</l>
             <l>Questa vittima sacra all'odio vostro,</l>
@@ -1179,7 +1201,7 @@ in Sparta.</hi>
             <l>Mi avanza or più che una spregevol vita;</l>
             <l>Ed il tormela or fia la minor pena.</l>
           </sp>
-          <sp>
+          <sp who="#archidamo">
             <speaker>ARCHIDAMO</speaker>
             <l>Pena, l'avrai, non pur da noi, da quanti </l>
             <l>Amin la Grecia e le sue leggi; eterno </l>
@@ -1196,36 +1218,36 @@ in Sparta.</hi>
           </head>
           <stage>PAUSANIA, EUDAMIDA, ARCHIDAMO, TEANE, EFORI, POPOLO <hi rend="Italic">e</hi>
 	GUARDIE</stage>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">Ah! no; – pria che si danni il figlio,</l>
             <l>Efori, deh! vi piaccia ancor per poco</l>
             <l part="I">Udir la madre.</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="M">Oh! qual incontro?…</l>
           </sp>
-          <sp>
+          <sp who="#archidamo">
             <speaker>ARCHIDAMO</speaker>
             <l part="F">Loco</l>
             <l>A femminil lamento, il sai, non dassi</l>
             <l part="I">Unque fra noi.</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">Né femminil lamento</l>
             <l>A voi qui reco. Assai di Sparta gli usi</l>
             <l part="I">E le leggi io rispetto.</l>
           </sp>
-          <sp>
+          <sp who="#eudamida">
             <speaker>EUDAMIDA</speaker>
             <l part="F">E Sparta anch'essa</l>
             <l>Le tue virtù, donna, rispetta. – Frena,</l>
             <l>Archidamo, il tuo zelo. Ella capace</l>
             <l>Di sedurci non è. – Donna, che chiedi?</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l>Ch'io stessa il figlio mio difender possa. –</l>
             <l>Spartani, ah! no, della materna inchiesta</l>
@@ -1257,24 +1279,24 @@ in Sparta.</hi>
             <l>Non resti in me di avere un dì negletto</l>
             <l>Quest'ufficio qualsia del figlio a scampo.</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l>Ancorché forse invan, di me già diedi,</l>
             <l part="I">Donna, ragion; che speri più?</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">Dar questo</l>
             <l>Sfogo al mio core; e abbandonarti poscia</l>
             <l>Alle leggi di Sparta e degli Dei.</l>
           </sp>
-          <sp>
+          <sp who="#eudamida">
             <speaker>EUDAMIDA</speaker>
             <l>Gli efori omai ti ascoltano. Difendi,</l>
             <l>Tu madre, il figlio; efori noi, le leggi</l>
             <l part="I">Difenderem.</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">Spartani, io non difendo</l>
             <l>Gli strani modi suoi, né quanto in esso</l>
@@ -1326,7 +1348,7 @@ in Sparta.</hi>
             <l>Giudizio, qual ch'ei sia, saprò spartana</l>
             <l>L'alto consiglio rispettar di Sparta.</l>
           </sp>
-          <sp>
+          <sp who="#eudamida">
             <speaker>EUDAMIDA</speaker>
             <l>Donna, al tuo dir di alto stupor compresi,</l>
             <l>Quanti qui stanno, io veggio! Ancor che madre,</l>
@@ -1354,12 +1376,12 @@ in Sparta.</hi>
             <l>Al suo cospetto, di Pausania ad una</l>
             <l>L'innocenza proclami od il castigo.</l>
           </sp>
-          <sp>
+          <sp who="#archidamo">
             <speaker>ARCHIDAMO</speaker>
             <l>Oh! qual mezzo proponi? Esser funesto</l>
             <l part="I">Potria cotesto indugio!</l>
           </sp>
-          <sp>
+          <sp who="#eudamida">
             <speaker>EUDAMIDA</speaker>
             <l part="F">Un solo istante</l>
             <l>Sparta perder non puote; e l'innocenza</l>
@@ -1367,7 +1389,7 @@ in Sparta.</hi>
             <l>Il voto mio; se v'ha cui spiaccia, schietto</l>
             <l part="I">Favelli. – Il vedi? ognun l'approva.</l>
           </sp>
-          <sp>
+          <sp who="#archidamo">
             <speaker>ARCHIDAMO</speaker>
             <l part="F">Dunque</l>
             <l>Pausania qui da noi si chiama, ond'abbia,</l>
@@ -1375,7 +1397,7 @@ in Sparta.</hi>
             <l>E il senato consulti? ed ei conspiri</l>
             <l part="I">Qui securo fra noi?</l>
           </sp>
-          <sp>
+          <sp who="#eudamida">
             <speaker>EUDAMIDA</speaker>
             <l part="F">Sparta l'osserva.</l>
             <l>Che puoi temer? Se il suo disegno è vero,</l>
@@ -1384,13 +1406,13 @@ in Sparta.</hi>
             <l>Pausania, dal senato il tuo destino</l>
             <l part="I">Attendi or tu.</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Qual ch'egli sia, pur sempre</l>
             <l>Pari opporgli saprò la mia costanza.</l>
             <l>Tutto da Sparta a tollerare appresi.</l>
           </sp>
-          <sp>
+          <sp who="#eudamida">
             <speaker>EUDAMIDA</speaker>
             <l>E Sparta ancor magnanima rispetta</l>
             <l>Le glorie tue, che tu disprezzi or forse.</l>
@@ -1400,7 +1422,7 @@ in Sparta.</hi>
             <l>Che il tuo più lieve error potrebbe a danno</l>
             <l part="I">Della patria tornare!</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">Ah! peran pria</l>
             <l>La madre e il figlio in un, che il minor danno</l>
@@ -1410,27 +1432,27 @@ in Sparta.</hi>
             <l> Non pur co’ detti suoi, saprà coll'opre</l>
             <l part="I">Smentirlo appieno.</l>
           </sp>
-          <sp>
+          <sp who="#eudamida">
             <speaker>EUDAMIDA</speaker>
             <l part="F">Ed io l'augurio accetto.</l>
           </sp>
-          <sp>
+          <sp who="#archidamo">
             <speaker>ARCHIDAMO</speaker>
             <l part="I">Or via; si tronchi ogni altro indugio.</l>
           </sp>
-          <sp>
+          <sp who="#eudamida">
             <speaker>EUDAMIDA</speaker>
             <l part="F">Tosto</l>
             <l>Si raduni il senato; e il popol tutto</l>
             <l part="I">Si appelli al gran consesso.</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">Oh giorno!… Io spero;</l>
             <l>Eppur non cesso di tremare!… – Oh figlio!…</l>
             <l>Abbracciarlo io vorrei; nè l'oso ancora!…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l>Ognun me sdegna! e a nuovi affronti espormi</l>
             <l>Io deggio ancora? – eppur soffrirlo io deggio!</l>
@@ -1447,21 +1469,21 @@ in Sparta.</hi>
           <stage>
             <hi>Casa di Pausania</hi>
           </stage>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l>Oh! vieni, Argilio. Alfin siam soli. Io deggio</l>
             <l>Un gran mistero confidarti… – Or dimmi:</l>
             <l>Poss' io dell'amistà, della tua fede</l>
             <l part="I">Una prova tentar?</l>
           </sp>
-          <sp>
+          <sp who="#argilio">
             <speaker>ARGILIO</speaker>
             <l part="F">Che di’? Se basta</l>
             <l>A tuo scampo il mio sangue, appien ti spiega.</l>
             <l>Dopo i tuoi tanti benefizi, il sai,</l>
             <l part="I">Sacra è a te la mia vita.</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Omai tu vedi</l>
             <l>Tutto il mio stato orribile! Ridotto</l>
@@ -1475,11 +1497,11 @@ in Sparta.</hi>
             <l>Altro mezzo io non trovo che sperarla</l>
             <l part="I">Da miei nemici…</l>
           </sp>
-          <sp>
+          <sp who="#argilio">
             <speaker>ARGILIO</speaker>
             <l part="M">Oh Ciel!…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Tu ti conturbi?</l>
             <l>E n'hai ragion; non men turbato io sono! –</l>
@@ -1489,12 +1511,12 @@ in Sparta.</hi>
             <l>Che al nome mio, più che di Grecia al nome,</l>
             <l part="I">Tremava un dì!</l>
           </sp>
-          <sp>
+          <sp who="#argilio">
             <speaker>ARGILIO</speaker>
             <l part="F">Che intesi? – Erano dunque</l>
             <l part="I">Giusti i sospetti?</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Un dì non eran tali,</l>
             <l>Priaché di Sparta ingrata il rigor troppo</l>
@@ -1507,12 +1529,12 @@ in Sparta.</hi>
             <l>Al sommo duce, ad Artabazo tosto</l>
             <l>Recarlo debbi; ei non ignora il resto.</l>
           </sp>
-          <sp>
+          <sp who="#argilio">
             <speaker>ARGILIO</speaker>
             <l>Deh! se ti affidi in me, tutto mi svela:</l>
             <l part="I">Qual mai disegno è il tuo?…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Di vendicarmi;</l>
             <l>Di me salvare e quanti esser pon meco</l>
@@ -1526,7 +1548,7 @@ in Sparta.</hi>
             <l>Di libertà delirio strano! è forza,</l>
             <l>Qual che il mezzo ne sia, porvi un riparo.</l>
           </sp>
-          <sp>
+          <sp who="#argilio">
             <speaker>ARGILIO</speaker>
             <l>E speri tu  che un tanto ben si lasci</l>
             <l>Rapir la Grecia? Sia ragion, sia inganno,</l>
@@ -1536,7 +1558,7 @@ in Sparta.</hi>
             <l>Qual di Dario o di Serse immensa forza</l>
             <l part="I">Potè mai soggiogarli?</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">È ver; ma stanchi</l>
             <l>Son molti alfin di più pugnar per essa;</l>
@@ -1567,7 +1589,7 @@ in Sparta.</hi>
             <l>I Messeni me seguono e gl'Iloti,</l>
             <l part="I">Di più servire impazienti.</l>
           </sp>
-          <sp>
+          <sp who="#argilio">
             <speaker>ARGILIO</speaker>
             <l part="F">Nato</l>
             <l>Fra questi anch'io, sebben di Sparta l'aspro</l>
@@ -1577,7 +1599,7 @@ in Sparta.</hi>
             <l>Dagli efori accusato, giudicarti</l>
             <l part="I">Debbe or’ ora il senato!…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Io del senato</l>
             <l>Con l'oro della Persia ho già gran parte</l>
@@ -1597,31 +1619,31 @@ in Sparta.</hi>
             <l>Il segno io darne deggio; e il segno è questo. –</l>
             <l>Va’; vola; occulto ad Artabazo il reca.</l>
           </sp>
-          <sp>
+          <sp who="#argilio">
             <speaker>ARGILIO</speaker>
             <l part="I">Deh! più cauto, se il puoi…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Non è più tempo.</l>
             <l>Ogni consiglio è inutile o dannoso;</l>
             <l>Un punto che si perda, io son perduto!</l>
           </sp>
-          <sp>
+          <sp who="#argilio">
             <speaker>ARGILIO</speaker>
             <l>Il tuo periglio or mi spaventa!… Io tremo</l>
             <l part="I">Solo per te!</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Tu perdermi o salvarmi</l>
             <l part="I">Puoi solo…</l>
           </sp>
-          <sp>
+          <sp who="#argilio">
             <speaker>ARGILIO</speaker>
             <l part="M">E che far deggio?…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Obbedir ratto. –</l>
             <l>Se mi ami ancor, se vuoi salvarmi, parti;</l>
@@ -1634,7 +1656,7 @@ in Sparta.</hi>
             <hi rend="Italic">SCENA SECONDA</hi>
           </head>
           <stage>PAUSANIA</stage>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l>Ei per me trema! ed io di lui non meno,</l>
             <l>Ma per più forte, alta cagion pur tremo!</l>
@@ -1666,7 +1688,7 @@ in Sparta.</hi>
             <hi rend="Italic">SCENA TERZA</hi>
           </head>
           <stage>PAUSANIA, EURISTIA</stage>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">Invan finor te cerco,</l>
             <l>Pausania. Un solo istante ancor concesso</l>
@@ -1675,7 +1697,7 @@ in Sparta.</hi>
             <l>Né ancor riabbracci i tuoi? né della sposa,</l>
             <l part="I">Né del figlio più chiedi?</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Invan finor te cerco,</l>
             <l>È ver… lo veggio…</l>
@@ -1690,7 +1712,7 @@ in Sparta.</hi>
             <l>Sta; nel senato a mi oltraggiar di nuovo</l>
             <l part="I">Omai si pensa; e chi sa forse?…</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">Ah! cessi</l>
             <l>L’infausto augurio! Ad or ad or più veggio</l>
@@ -1701,14 +1723,14 @@ in Sparta.</hi>
             <l>Non osan giudicarti, ed al senato</l>
             <l>Han dell’incerta lite il fin commesso.</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l>E forse, onde men torni onta più grave. –</l>
             <l>Chi sa qual trama or mi si ordisce? Or forse</l>
             <l>Nuove insidie si tentano al mio nome!…</l>
             <l part="I">E speri tu ne’ miei nemici?</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">Io spero</l>
             <l>Nelle leggi di Sparta e nella somma</l>
@@ -1717,15 +1739,15 @@ in Sparta.</hi>
             <l>Un profondo pensier ti appar sul ciglio,</l>
             <l part="I">Che fa tremarmi!… Ohimè! che pensi?…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Nulla</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="I">Deh! ti spiega alla moglie.</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">E che dir posso</l>
             <l>Che a te pur non sia noto? Or di’: potrei</l>
@@ -1741,7 +1763,7 @@ in Sparta.</hi>
             <l>Innanzi a me; ned io soffria lo sguardo</l>
             <l part="I">Insultatore…</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">E qui tranquillo in vece</l>
             <l>Viver non puoi di tua famiglia in seno?</l>
@@ -1755,21 +1777,21 @@ in Sparta.</hi>
             <l>Chi della sposa più temperar puote</l>
             <l part="I">Del tuo cor l’amarezza?</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Un altro istante</l>
             <l>Scegli perciò. Da troppo gravi cure</l>
             <l>Oppresso, or più vi attristerei presente. –</l>
             <l>Perché turbar vuoi la tua pace, e indarno?</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l>E pace aver poss’io, se non l’ho teco?</l>
             <l>Io piango e spero e prego il Ciel che mostri</l>
             <l>La tua innocenza; e in te Sparta rivegga</l>
             <l part="I">Un cittadino, un figlio…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">In me non puote</l>
             <l>Sparta or veder che un re sprezzato e inulto. –</l>
@@ -1784,7 +1806,7 @@ in Sparta.</hi>
             <hi rend="Italic">SCENA QUARTA</hi>
           </head>
           <stage>EURISTIA</stage>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l>Misera me!… Qual preme in sen profondo</l>
             <l>Rancore? Ei parla; e par che ad altro intenda!</l>
@@ -1802,40 +1824,40 @@ in Sparta.</hi>
             <hi rend="Italic">SCENA QUINTA</hi>
           </head>
           <stage>EURISTIA, ARGILIO</stage>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">Argilio! … Ohimè!…turbato</l>
             <l part="I">A che vieni?… che cerchi?…</l>
           </sp>
-          <sp>
+          <sp who="#argilio">
             <speaker>ARGILIO</speaker>
             <l part="F">Accorri;… ah! salva</l>
             <l part="I">Pausania or tu…</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">Che avvenne mai?… Dannollo</l>
             <l part="I">Il senato?…</l>
           </sp>
-          <sp>
+          <sp who="#argilio">
             <speaker>ARGILIO</speaker>
             <l part="F">Non già; ma, se tu all’uopo</l>
             <l part="I">Pur non ti adopri, egli è perduto…</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">E come?…</l>
           </sp>
-          <sp>
+          <sp who="#argilio">
             <speaker>ARGILIO</speaker>
             <l>Certo è il delitto: contra Sparta ei stesso</l>
             <l part="I">Conspira…</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="M">Oh! che di’ tu?…</l>
           </sp>
-          <sp>
+          <sp who="#argilio">
             <speaker>ARGILIO</speaker>
             <l part="F">Dal suo periglio</l>
             <l>Invan tentai dianzi ritrarlo. Fermo</l>
@@ -1857,11 +1879,11 @@ in Sparta.</hi>
             <l>E te qui cerco, ond’io l’orror ti mostri</l>
             <l>Del suo periglio; e tu, se il puoi, lo salvi.</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l>Che intesi?… E creder deggio?… e fia mai vero?…</l>
           </sp>
-          <sp>
+          <sp who="#argilio">
             <speaker>ARGILIO</speaker>
             <l>Così nol fosse! – Ma, se a me nol credi,</l>
             <l>Credilo al foglio, ch’io recar doveva</l>
@@ -1870,7 +1892,7 @@ in Sparta.</hi>
             <l>Contento io son del mio destin, se io posso</l>
             <l part="I">Per opra tua salvarlo almeno.</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">Io tremo</l>
             <l>Sol nell’aprirlo! or che sarà, se il leggo? –</l>
@@ -1899,12 +1921,12 @@ in Sparta.</hi>
             <l>Mi ripudia, mi oblia!… Ma, che non puote,</l>
             <l>Chi di tradir la patria sua non teme?</l>
           </sp>
-          <sp>
+          <sp who="#argilio">
             <speaker>ARGILIO</speaker>
             <l>Numi! che feci? – Deh! più saggia or, donna,</l>
             <l part="I">Previeni il suo periglio.</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">E che? vorresti</l>
             <l>Ch’io difendessi un perfido, che immola</l>
@@ -1924,12 +1946,12 @@ in Sparta.</hi>
             <l>Nel tumulto de’ sensi, io sento appieno</l>
             <l>Che maggior de’ miei torti amor mi arresta!…</l>
           </sp>
-          <sp>
+          <sp who="#argilio">
             <speaker>ARGILIO</speaker>
             <l>Ed arrestare anch’esso amor non puote</l>
             <l part="I">E ritenerlo dal delitto?…</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">– E credi</l>
             <l>Ch’ei riconosca ancor dell’amor mio</l>
@@ -1940,7 +1962,7 @@ in Sparta.</hi>
             <l>Se non di me, si risovvenne almeno</l>
             <l part="I">Del figlio suo?… Tutto mi narra.</l>
           </sp>
-          <sp>
+          <sp who="#argilio">
             <speaker>ARGILIO</speaker>
             <l part="F">Tranne</l>
             <l>Il suo disegno, a me tutt’altro ei tacque.</l>
@@ -1959,7 +1981,7 @@ in Sparta.</hi>
             <hi rend="Italic">SCENA SESTA</hi>
           </head>
           <stage>EURISTIA</stage>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l>Salvarlo!… e bastar ponno i preghi e il pianto</l>
             <l>Di una moglie tradita? E qual mi resta</l>
@@ -1977,11 +1999,11 @@ in Sparta.</hi>
             <hi rend="Italic">SCENA stageTIMA</hi>
           </head>
           <stage>EURISTIA, TEANE</stage>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">Oh madre!…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l>Figlia, deh! meco appien ti allegra!… Assolto</l>
             <l>Fu Pausania in senato… – Ohimè!… l’eccesso</l>
@@ -2001,66 +2023,66 @@ in Sparta.</hi>
             <l>Ma, tu sospiri?… ohimè! qual importuno</l>
             <l part="I">Turbamento t’invade?…</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="M">Oh madre!…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">Parla:</l>
             <l part="I">Che vuoi tu dir?…</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">Che siam tradite entrambe!…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="I">Da chi?… segui…</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">– Non posso!… Oh Ciel!… – Tu stessa</l>
             <l part="I">Leggi ed apprendi il resto.</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">E qual mistero?… –</l>
             <l>“Pausania ad Artabazo”… – Oh! qual mi assale</l>
             <l>Orror di morte?… Oh sventurata madre!… –</l>
             <l part="I">Chi ti diè questo foglio?</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="M">Argilio…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">Quando?…</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="I">Or dianzi…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="M" n="1">Dove?…</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="M" n="2">In questo loco…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">E quale</l>
             <l part="I">Ragion lo mosse?…</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">Amor, pietà, rispetto</l>
             <l part="I">Di Pausania e di Sparta…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">In un Ilota</l>
             <l>Tanta virtù! Chi ‘l crederebbe?… Oh Sparta!</l>
@@ -2079,12 +2101,12 @@ in Sparta.</hi>
             <l>Non foss’io mai, poiché da me dovea</l>
             <l>Nascer di Grecia il traditor più vile!</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l>Lassa! a’ tuoi detti io tremo or più! Consiglio</l>
             <l>Da te sperava e tu il mio orror più accresci!</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l>Di’: l’avresti creduto ch’io nel figlio,</l>
             <l>Ch’era un dì la mia speme, il mio sostegno,</l>
@@ -2097,13 +2119,13 @@ in Sparta.</hi>
             <l>Vita mi concedeste? Or non avrei</l>
             <l>Veduto almen la mia vergogna eterna.</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l>Or qual si puote al mio dolore e al tuo,</l>
             <l>Al periglio comun pronto riparo</l>
             <l part="I">Implorar dagli Dei?…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">Quel che tu meco,</l>
             <l>Che ogni Spartano implorar dee, che il figlio,</l>
@@ -2111,11 +2133,11 @@ in Sparta.</hi>
             <l>Lo scempio de’ nemici, la vendetta</l>
             <l part="I">Di Sparta…</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="M">Oh! che di’ mai?…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">Che tutto io sento</l>
             <l>L'orror di questo dì! che madre io sono,</l>
@@ -2125,27 +2147,27 @@ in Sparta.</hi>
             <l>Sacrificio terribile a me chiedi!… –</l>
             <l part="I">Ma, il tempo preme!… Andiam…</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="M">E dove?…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">Il solo</l>
             <l>Mezzo a tentar che or resta; e ch’il Ciel forse</l>
             <l part="I">M’inspira in questo punto!</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">E qual?… ti spiega…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l>Vieni e me imita; un punto sol potrebbe</l>
             <l>Nuocere a Sparta… – Avrem poi il tempo entrambe,</l>
             <l>Io di piangere il figlio e tu lo sposo…</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l>Oh! quai mi annuncia il cor nuove sventure!</l>
           </sp>
@@ -2159,7 +2181,7 @@ in Sparta.</hi>
           </head>
           <stage>PAUSANIA</stage>
           <stage>[<hi>Vestibulo del tempio di Minerva Calcieca</hi>]</stage>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l>In questo tempio Argilio entrar fu visto. –</l>
             <l>Qual presagio mi turba? E qual può fargli</l>
@@ -2172,17 +2194,17 @@ in Sparta.</hi>
             <hi rend="Italic">SCENA SECONDA</hi>
           </head>
           <stage>PAUSANIA, TEANE, EURISTIA</stage>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">T’arresta,</l>
             <l>Pausania; ansante io te qui cerco; grata</l>
             <l part="I">Per me novella udir tu debbi.</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">E quale?…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l>Qual forse tu non ti aspettavi. – Assolto</l>
             <l>Già fosti dal senato. I suoi sospetti</l>
@@ -2190,12 +2212,12 @@ in Sparta.</hi>
             <l>Nonché spartan, qual eri un dì, ma degno</l>
             <l>Di risalir sul trono onde scendesti.</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l>Io so che Sparta ognor mi accusa e assolve,</l>
             <l part="I">Per dannarmi di nuovo.</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">E sai ch’io forse,</l>
             <l>Più che altri, a favor tuo l’ancor sospesa</l>
@@ -2204,23 +2226,23 @@ in Sparta.</hi>
             <l>La tua innocenza proclamata ad una</l>
             <l part="I">Voce si udì?</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Lode agli Dei! La mia</l>
             <l>Salvezza, più che agli efori e al senato,</l>
             <l part="I">Deggio a te, madre.</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">– Or dimmi: dal senato,</l>
             <l>Dagli efori, da me questo mertavi</l>
             <l part="I">Strano favor?…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Che sento?… E che dir vuoi?…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l>Che finor m’ingannasti; che tu Sparta</l>
             <l>Tradisci allor che ti perdona; e ch’io</l>
@@ -2228,19 +2250,19 @@ in Sparta.</hi>
             <l>Del tradimento tuo, quando punirti</l>
             <l>Sparta doveva ed accusarti io prima.</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="I">Chi mi tradì?…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">Tu stesso. – Il riconosci?…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="I">Oh Ciel!…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">Tu fremi al tuo delitto!… ed hai</l>
             <l>Potuto concepirlo? E chi fu l’empio,</l>
@@ -2282,7 +2304,7 @@ in Sparta.</hi>
             <l>Poiché là fra gli estinti io sarò teco,</l>
             <l>Il rossor di fuggirti ombra nemica.</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l>Pausania, ah! sì; di madre a’ preghi il pianto</l>
             <l>Unisce ancor la moglie tua, che sprezzi</l>
@@ -2311,27 +2333,27 @@ in Sparta.</hi>
             <l>Di cui nel cor l’atrocità pur tutta</l>
             <l>Sento, in nome di Sparta, io ti perdono.</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l>Infelice! tu taci? E non ti scuote</l>
             <l>Il pianto della moglie, il mio consiglio</l>
             <l>E più, la patria tua, che ancor ti chiama,</l>
             <l>E contra te da te difesa attende?</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l>Qual terribile assalto?… E che far deggio?…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l>La trama rea, che ordisti tu, tu stesso</l>
             <l part="I">Tosto annientare e i rei punirne…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">E come?…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l>Ecco l’unico mezzo; io tel’addito.</l>
             <l>Vien meco avanti agli efori; tu stesso,</l>
@@ -2339,7 +2361,7 @@ in Sparta.</hi>
             <l>E contra i rei, contra te stesso implora</l>
             <l part="I">Delle leggi il poter…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Che di’ tu mai?</l>
             <l>Ch’io mi offra volontario a’ miei più feri</l>
@@ -2348,7 +2370,7 @@ in Sparta.</hi>
             <l>Sparta tradire e non sperar difesa</l>
             <l part="I">Che da’ nemici suoi!…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">Perfido! e quale</l>
             <l>Sia pur forte cagion, potea sì vile</l>
@@ -2356,14 +2378,14 @@ in Sparta.</hi>
             <l>E pace e fama ed innocenza, tutto</l>
             <l part="I">Alla patria non debbi?</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">E patria è questa,</l>
             <l>Da che regnan qui gli efori? Non servi</l>
             <l>Tu stessa qui? Non torna a te pur l’onta</l>
             <l part="I">Degli oltraggi ch’io soffro?…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">Oh Ciel! tu tenti</l>
             <l>Ancor la mia virtù? Servo tu nomi</l>
@@ -2372,7 +2394,7 @@ in Sparta.</hi>
             <l>Che avidità di regno, odio di leggi,</l>
             <l part="I">Favor di servitù!…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Più che nol pensi,</l>
             <l>Odio il servaggio; e perciò tento i torti</l>
@@ -2387,7 +2409,7 @@ in Sparta.</hi>
             <l>Invan più arresterei l’alta congiura,</l>
             <l part="I">Già vicina a scoppiar…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">Che sento? E speri</l>
             <l>Che si possa compir la perfida opra? –</l>
@@ -2410,30 +2432,30 @@ in Sparta.</hi>
             <l>De’  tuoi, del trono; infin, tiranno intero… –</l>
             <l>Ecco un ferro; ecco il petto… E che? ti arresti?</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l>Qual nel suo sguardo, oh Ciel! virtù sfavilla,</l>
             <l>Che ad ammirarla ed a tremar mi sforza?</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="I">Oh momento terribile!…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">L’estremo</l>
             <l>Esser dee questo ad ambo. Io tel ripeto:…</l>
             <l>Sacrifica tua madre o sei perduto.</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="I">Che mi proponi tu?…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">Dissi. Risolvi.</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l>E che poss’io risolvere? Nol vedi</l>
             <l>Che il delitto mi tragge a suo talento;</l>
@@ -2441,63 +2463,63 @@ in Sparta.</hi>
             <l>Di me maggior, m’invade, a Sparta avverso;</l>
             <l part="I">Ch’io più non sono in me?…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">Dunque hai deciso?</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="I">Necessario è il delitto…</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="M">Ahi lassa!…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">E speri</l>
             <l part="I">Eseguirlo?…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="M" n="1">O perire…</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="M" n="2">Ah! cessa…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">– Oh figlio!…</l>
             <l part="I">A qual passo mi sforzi?…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Ad abborrirmi…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l>Oh patria! oh Sparta! oh mio dover!… – Si vada…</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="I">Dove così smarrita?…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">Ove gli Dei,</l>
             <l part="I">Ove Sparta mi appella…</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">Ohimè! che pensi?…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l>Dare un esempio alle spartane madri:</l>
             <l>Sparta salvare e poi morir di duolo!</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l>Ove il dolor ti tragge?… oh Ciel! ti arresta…</l>
           </sp>
@@ -2525,21 +2547,21 @@ in Sparta.</hi>
             <hi rend="Italic">SCENA QUARTA</hi>
           </head>
           <stage>PAUSANIA, ARGILIO</stage>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Omai</l>
             <l>Ti vendica, Pausania. Ecco, l’asilo</l>
             <l>Abbandono, se il vuoi. – Del tuo periglio</l>
             <l>è ver, son reo; ma per salvarti il sono.</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l>Che mai festi, infelice? Allor che tutta</l>
             <l>Era riposta in te la mia salvezza,</l>
             <l>Tu mi tradisci? tu?… né l’ira mia</l>
             <l part="I">Temesti almen?…</l>
           </sp>
-          <sp>
+          <sp who="#argilio">
             <speaker>ARGILIO</speaker>
             <l part="F">Io sol temetti l’ira</l>
             <l>Del Ciel, di Sparta; e più per te, lo giuro,</l>
@@ -2551,18 +2573,18 @@ in Sparta.</hi>
             <l>Trarti dal tuo disegno e in un dal tuo</l>
             <l part="I">Periglio aperto.</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">E tu maggior lo rendi!</l>
             <l>Tutto or noto è alla madre; ed io più temo</l>
             <l part="I">La sua virtù che l’odio altrui.</l>
           </sp>
-          <sp>
+          <sp who="#argilio">
             <speaker>ARGILIO</speaker>
             <l part="F">Che dici?</l>
             <l part="I">E che temerne dei?</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Ciò che inspirarle</l>
             <l>Potria furor di libertà, feroce</l>
@@ -2576,16 +2598,16 @@ in Sparta.</hi>
             <hi rend="Italic">SCENA QUINTA</hi>
           </head>
           <stage>PAUSANIA, ARGILIO, EURISTIA</stage>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">Io torno!…</l>
             <l part="I">Pausania!… ohimè!…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="M">Che avvenne mai?…</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">Ti salva;…</l>
             <l>Teane… oh Ciel!… la madre tua;… tremante</l>
@@ -2599,17 +2621,17 @@ in Sparta.</hi>
             <l>Quindi a te corro… Or, deh! qual puoi tu scampo</l>
             <l part="I">Al tuo periglio opporre?</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Io veggio alfine</l>
             <l>Ch’è sol mio scampo il non sperarne alcuno.</l>
             <l>Col mio periglio il mio furor più cresce!</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="I">Lassa! che dici mai?…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Che ancor di nuovi</l>
             <l>Eccessi ho d’uopo; che, a smentir l’accusa,</l>
@@ -2617,16 +2639,16 @@ in Sparta.</hi>
             <l>Che affermarla potria; che pera, in somma,</l>
             <l part="I">L’autor del danno mio…</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="M">Che fai?…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Cominci</l>
             <l part="I">Da te la mia vendetta…</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="M">Ah! no…</l>
           </sp>
@@ -2637,45 +2659,45 @@ in Sparta.</hi>
           </head>
           <stage>PAUSANIA, ARGILIO, EURISTIA,TEANE, EUDAMIDA, <hi rend="Italic">altri</hi> EFORI
 <hi rend="Italic">e</hi> GUARDIE</stage>
-          <sp>
+          <sp who="#eudamida">
             <speaker>EUDAMIDA</speaker>
             <l part="F">Ti arresta…</l>
             <l>Gli efori omai ti osservano. – Deponi</l>
             <l part="I">Quel ferro or tu; Sparta l’impone.</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">E a Sparta</l>
             <l part="I">Io sol lo rendo.</l>
           </sp>
-          <sp>
+          <sp who="#eudamida">
             <speaker>EUDAMIDA</speaker>
             <l part="F">E che tentavi, o stolto?…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l>Un perfido punir, che al rio disegno</l>
             <l>Serve de’ miei nemici; che conspira</l>
             <l>Contra il mio nome; che gli altrui sospetti</l>
             <l part="I">Cerca destar…</l>
           </sp>
-          <sp>
+          <sp who="#eudamida">
             <speaker>EUDAMIDA</speaker>
             <l part="F">Pausania, e che? di nuovo</l>
             <l>Speri ingannarci tu? Certo è il delitto;</l>
             <l part="I">Manifeste le prove…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">E chi l’afferma?</l>
           </sp>
-          <sp>
+          <sp who="#eudamida">
             <speaker>EUDAMIDA</speaker>
             <l>Argilio, il foglio, i tuoi più cari, quanto</l>
             <l>Dintorno ti rimprovera, e più, il tuo</l>
             <l part="I">Disperato furore…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">E prestar fede</l>
             <l>A un Ilota puoi tu? Da’ servi dunque</l>
@@ -2690,7 +2712,7 @@ in Sparta.</hi>
             <l>Non può, né dee convincermi, chi fia</l>
             <l part="I">Che osi accusarmi innanzi a voi?</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F"> Tua madre.</l>
             <l>Io, che finor ti amai, che ti credea</l>
@@ -2705,11 +2727,11 @@ in Sparta.</hi>
             <l>I suoi tardi rimorsi… – Efori, alfine</l>
             <l part="I">Egli è convinto.</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">Misera! che festi?…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l>Il mio dover. – Compiete, efori, il vostro.</l>
             <l>Io più figlio non ho; solo a voi Sparta</l>
@@ -2719,12 +2741,12 @@ in Sparta.</hi>
             <l>Deh! tu mi assisti;… io piango e ne arrossisco!…</l>
             <l part="I">Il pianto almen si celi altrove…</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">E il pianto</l>
             <l>Può in noi sfogare l’immenso dolore?</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="I">La sua virtù mi abbatte or sol!</l>
           </sp>
@@ -2735,7 +2757,7 @@ in Sparta.</hi>
           </head>
           <stage>PAUSANIA, EUDAMIDA, ARGILIO <hi rend="Italic">altri</hi> EFORI <hi rend="Italic">e</hi>
 GUARDIE</stage>
-          <sp>
+          <sp who="#eudamida">
             <speaker>EUDAMIDA</speaker>
             <l part="F">Oh eccelsa!</l>
             <l>Oh magnanima donna! – E tu da’ suoi</l>
@@ -2743,14 +2765,14 @@ GUARDIE</stage>
             <l>Qual mai potè sedurti a tanto eccesso</l>
             <l part="I">Fera cagion?…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F"> La maestà suprema</l>
             <l>Di re, per voi sol vilipesa; i dritti</l>
             <l>Del mio sangue usurpati; infin, l’iniqua</l>
             <l>Mercè che all’opre mie per voi raccolsi.</l>
           </sp>
-          <sp>
+          <sp who="#eudamida">
             <speaker>EUDAMIDA</speaker>
             <l>Di questo tempio esci tu dunque. Innanzi</l>
             <l>Al popol tutto a reclamar non meno</l>
@@ -2768,7 +2790,7 @@ GUARDIE</stage>
             <hi rend="Italic">SCENA OTTAVA</hi>
           </head>
           <stage>PAUSANIA</stage>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">A qual estremo, avverso</l>
             <l>Fato, mi spingi e mi abbandoni? – Omai</l>
@@ -2788,7 +2810,7 @@ GUARDIE</stage>
           <stage>
             <hi>Interno del tempio di Minerva Calcieca</hi>
           </stage>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l>Dove mi ascondo?… Misero! io non veggio</l>
             <l>Che l’orror del delitto a me dintorno! –</l>
@@ -2810,11 +2832,11 @@ GUARDIE</stage>
             <hi rend="Italic">SCENA SECONDA</hi>
           </head>
           <stage>PAUSANIA, EURISTIA</stage>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="I">Oh! chi si avanza?… Oh Ciel!… tu qui?..</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">Deh! vieni.</l>
             <l>Se finor me fuggisti, or, deh! mi segui,</l>
@@ -2833,19 +2855,19 @@ GUARDIE</stage>
             <l>Dall’ira sua ti salvi ella, che il puote.</l>
             <l part="I">Salvati ovunque ed io son paga.</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Oh nuovo</l>
             <l>Rimprovero mortale!… E il grave oltraggio</l>
             <l part="I">Vendichi or tu così?</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">Finor pur troppo</l>
             <l>Il mio trasporto m’ingannò! La prima</l>
             <l part="I">Io t’accusai!…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Sparta servisti. Io suo</l>
             <l>Era non men che tuo nemico. – Or sappi</l>
@@ -2854,7 +2876,7 @@ GUARDIE</stage>
             <l>L’amicizia di Serse e n’eran pegno</l>
             <l part="I">Di sua figlia le nozze…</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">Or non è tempo</l>
             <l>Di rammentare i torti miei. Ti salva,</l>
@@ -2872,7 +2894,7 @@ GUARDIE</stage>
             <l>Io sarò schermo all’ire altrui… Deh! cerca</l>
             <l part="I">La tua salvezza altrove.</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">E come? e dove?</l>
             <l>Che non m’insegua il mio delitto sempre? –</l>
@@ -2883,22 +2905,22 @@ GUARDIE</stage>
             <l>Obbrobriosa, vile. Omai ti basti</l>
             <l>Che spartano io morrò, se tal non vissi.</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="I">Che di’?…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Non più; la tua virtù richiama:</l>
             <l>Mira in me, non lo sposo; il tuo nemico,</l>
             <l part="I">Il nemico di Sparta.</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">Ah! tal non sei,</l>
             <l part="I">Poiché il tuo fallo appien conosci.</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">E vuoi</l>
             <l>Che il castigo io ne fugga? io che finora</l>
@@ -2911,45 +2933,45 @@ GUARDIE</stage>
             <l>L’infamia immensa. E tu, che mi perdoni,</l>
             <l>La morte no, la mia vergogna or piangi!</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l>Con questi sensi, sol di Sparta degni,</l>
             <l part="I">Come tradirla tu potesti?</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Intera</l>
             <l>Mal si conserva la virtù sul trono!</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="I">Oh! qual tumulto?…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">“Al traditor” si grida.</l>
             <l>Odi voce del popolo, che il mio</l>
             <l part="I">Destino affretta!</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="M" n="1">Ah! no…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="M" n="2">Che fai?…</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">Perdono…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l>E speri tu spartana! il mio perdono?</l>
             <l>E chi fra noi tant’osa, che non sia</l>
             <l part="I">Delle leggi nemico?</l>
           </sp>
-          <sp>
+          <sp who="#euristia">
             <speaker>EURISTIA</speaker>
             <l part="F">Io più non veggio</l>
             <l>Che il tuo periglio! Il Ciel sa ben se io Sparta</l>
@@ -2962,7 +2984,7 @@ GUARDIE</stage>
             <hi rend="Italic">SCENA TERZA</hi>
           </head>
           <stage>PAUSANIA</stage>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Oh fero!…</l>
             <l>Oh terribile istante!… Omai si affretti</l>
@@ -2977,21 +2999,21 @@ GUARDIE</stage>
             <hi rend="Italic">SCENA QUARTA</hi>
           </head>
           <stage>PAUSANIA, TEANE</stage>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="I">Che veggio?… Oh madre!…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">E son più madre?… Ah! taci</l>
             <l>Quel fatal nome, ch’è l’onta mia eterna!</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l>Dunque vendica te, la patria, i Numi,</l>
             <l part="I">Quanti oltraggiai.</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">Sparta lo dee. – Fuggirti</l>
             <l>Io sol dovrei; ma una secreta forza,</l>
@@ -3012,7 +3034,7 @@ GUARDIE</stage>
             <l>Quella pietà che non avesti, ingrato,</l>
             <l>Di me tu mai, nè più da alcun tu merti?</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l>E qual poss’io danno temer, che agguagli</l>
             <l>Della mia vita odiosa un solo istante?</l>
@@ -3022,14 +3044,14 @@ GUARDIE</stage>
             <l>Al disperato strazio mio conforto,</l>
             <l part="I">Il sospeso castigo.</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">E in questo punto</l>
             <l>L’implorano pur teco le spartane</l>
             <l>Madri, che meco un dì la tua salvezza</l>
             <l part="I">Sovente ne imploravano.</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Esaudite</l>
             <l>Tutte già sono. Più che tu non pensi,</l>
@@ -3042,7 +3064,7 @@ GUARDIE</stage>
             <l>Maggior del mio delitto è il mio rimorso,</l>
             <l>Deh! riconosci il figlio e lo compiangi…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l>Misero!… In te non veggio più che l’onta</l>
             <l>Di Sparta e mia! Mio figlio eri tu allora</l>
@@ -3064,21 +3086,21 @@ GUARDIE</stage>
             <l part="F">Or di’conosci</l>
             <l part="I">Tu questo brando?…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="M">Egli era mio.</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">– Rappreso</l>
             <l>Ancor v’è il sangue che in Platea spargesti!…</l>
             <l part="I">Lo vedi?…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="M">Oh vista!…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">E ti rammenti il giorno</l>
             <l>Che a questo Nume tu il sacravi? Io stessa</l>
@@ -3086,24 +3108,24 @@ GUARDIE</stage>
             <l>Dintorno ti applaudia, non che di Sparta,</l>
             <l>Di Grecia eroe, liberator, sostegno!…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="I">In qual punto il rammenti?…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">E tu giuravi…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l>Di oprarlo a pro di Sparta e a danno sempre</l>
             <l part="I">De’ suoi nemici…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="F">E il giuramento hai pieno?…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="I">Adempierlo ancor posso.</l>
             <stage>
@@ -3114,18 +3136,18 @@ GUARDIE</stage>
             <l part="F">– Ecco nel figlio</l>
             <l>Il nemico di Sparta omai punito!…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l part="I">Oh figlio!…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l part="F">Oh madre!… Di pietade un lampo</l>
             <l>In te pur vidi! …io son contento. – Or solo,</l>
             <l>Se alfin mertai la tua pietà, deh! narra</l>
             <l>Il pentimento mio; salva il mio nome…</l>
           </sp>
-          <sp>
+          <sp who="#teane">
             <speaker>TEANE</speaker>
             <l>Più non resisto!… Il mio dover compiei…</l>
             <l>Sparta, perdona omai queste, ch’io verso,</l>
@@ -3140,15 +3162,15 @@ GUARDIE</stage>
             <hi rend="Italic">SCENA QUINTA</hi>
           </head>
           <stage>PAUSANIA, TEANE, EUDAMIDA, ARCHIDAMO, EFORI <hi rend="Italic">e</hi> GUARDIE</stage>
-          <sp>
+          <sp who="#archidamo">
             <speaker>ARCHIDAMO</speaker>
             <l part="I">Odi la tua condanna…</l>
           </sp>
-          <sp>
+          <sp who="#eudamida">
             <speaker>EUDAMIDA</speaker>
             <l part="F">Oh Ciel!… che veggio?…</l>
           </sp>
-          <sp>
+          <sp who="#pausania">
             <speaker>PAUSANIA</speaker>
             <l>Vendicata la patria;… e il suo nemico</l>
             <l>Di mia man trucidato. – Or sappia Sparta</l>
@@ -3163,7 +3185,7 @@ GUARDIE</stage>
             <l>Ne’ potenti e ne’ re…. Madre!… la sposa…</l>
             <l>Ti affido… e il figlio… Or salva è Sparta… Io moro!</l>
           </sp>
-          <sp>
+          <sp who="#eudamida">
             <speaker>EUDAMIDA</speaker>
             <l>– Si muri il tempio profanato. Al volgo</l>
             <l>Tutto si taccia; e qui sepolto resti</l>

--- a/tei/scala-il-finto-marito.xml
+++ b/tei/scala-il-finto-marito.xml
@@ -80,6 +80,46 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="comico">
+            <persName>Comico</persName>
+          </person>
+          <person xml:id="forestiero">
+            <persName>Forestiero</persName>
+          </person>
+          <person xml:id="lepido">
+            <persName>Lepido</persName>
+          </person>
+          <person xml:id="flavio">
+            <persName>Flavio</persName>
+          </person>
+          <person xml:id="scaramuccia">
+            <persName>Scaramuccia</persName>
+          </person>
+          <person xml:id="demetrio">
+            <persName>Demetrio Aliprandi</persName>
+          </person>
+          <person xml:id="gervasio">
+            <persName>Gervasio Grifone</persName>
+          </person>
+          <person xml:id="ruchetta">
+            <persName>Ruchetta</persName>
+          </person>
+          <person xml:id="giulia">
+            <persName>Giulia</persName>
+          </person>
+          <person xml:id="licinio">
+            <persName>Licinio</persName>
+          </person>
+          <person xml:id="porzia">
+            <persName>Porzia</persName>
+          </person>
+          <person xml:id="trapola">
+            <persName>Trapola</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Siena</name>Digitalizzazione</change>
@@ -142,180 +182,180 @@
           <hi rend="italic">e</hi>
           <hi rend="sc">forestiero</hi>
         </stage>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>O là, o là signore, dove andate? Non si va di costà.</p>
         </sp>
-        <sp>
+        <sp who="#forestiero">
           <speaker><emph rend="sc">forestiero</emph>.</speaker>
           <p>O donde?</p>
         </sp>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>Di qua, in mal'ora!</p>
         </sp>
-        <sp>
+        <sp who="#forestiero">
           <speaker><emph rend="sc">forestiero</emph>.</speaker>
           <p>Oh piano! Non è questo l'apparato, la scena, e il luogo dove si ha da rappresentare la commedia?</p>
         </sp>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>E quello è il luogo dove hanno a stare gli ascoltanti e non questo; né di qui si passa.</p>
         </sp>
-        <sp>
+        <sp who="#forestiero">
           <speaker><emph rend="sc">forestiero</emph>.</speaker>
           <p>Orsù, andrem d'altrove. Ma che Zannata è questa che si deve recitare?</p>
         </sp>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>O costui è fastidioso!</p>
           <p>É il <title>Finto Marito</title> di Flaminio Scala.</p>
         </sp>
-        <sp>
+        <sp who="#forestiero">
           <speaker><emph rend="sc">forestiero</emph>.</speaker>
           <p>Di chi?</p>
         </sp>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>Dello Scala sì, che a' suoi dì ha fatto mille suggetti Voi torcete il naso? che ve ne maravigliate?</p>
         </sp>
-        <sp>
+        <sp who="#forestiero">
           <speaker><emph rend="sc">forestiero</emph>.</speaker>
           <p>Sì, ch'io me ne maraviglio, perché altro è impiastrare un suggetto perché sia rappresentato all'improviso. E altro è distendere una commedia affettuosa e sentire un bel disteso co' suoi graziosi e ben formati periodi, che udir dire «dagli lo scaldaletto», «i lazzi», «in questo», «restia», «e<pb n="228"/> via», «e via», all'usanza de' comedianti. Che, per mia fé, ch'io non voglio tanti urtoni, come veggo che si tocca laggiù a star tra il popolo! Andiamoci con Dio, ché in ogni modo la sarà, com'io dissi, una Zannata.</p>
         </sp>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>Oh piano un poco, ché lo Scala ha avuto sempre felicità nell'inventare, che alla fine poi è l'anima e il tutto nelle commedie.</p>
         </sp>
-        <sp>
+        <sp who="#forestiero">
           <speaker><emph rend="sc">forestiero</emph>.</speaker>
           <p>Io ne ho pur sentite delle sue che non mi hanno fatto maravigliare.</p>
         </sp>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>Troppo ci vuole a far maravigliare un par vostro, ch'al sentire tanto sa, o per lo meno se lo crede, stimandovi forse avere in voi l'Idea de' componimenti scenici, che però biasimate voi solo chi fin'ora nelle stampe vien universalmente assai lodato. Ma non mi negherete già che dove lo Scala ha portati i suoi suggetti sempre hanno dato gusto e son piacciuti.</p>
         </sp>
-        <sp>
+        <sp who="#forestiero">
           <speaker><emph rend="sc">forestiero</emph>.</speaker>
           <p>É vero, ma perché? Perché egli ha cercato fargli apparire con le azioni, e le buone compagnie de' comici son quelle che, ben recitando, nobilitano i suggetti. Ma quella composizione poi ch'è solamente scritta sopra un foglio, s'ella non ha in sé l'arte del bene scrivere che l'accompagni, resta fredda e cade.</p>
         </sp>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>Dunque, questa ora recitata piacerà, perché hanno fatto scelta de' personaggi.</p>
         </sp>
-        <sp>
+        <sp who="#forestiero">
           <speaker><emph rend="sc">forestiero</emph>.</speaker>
           <p>Sta bene, ma essendo imparata a mente, se il disteso non è vago proprio, e di buona lingua, non daranno in nulla.<pb n="230"/></p>
         </sp>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>Cotesto è vero, quando con un bello e nobile encomio si vuol celebrare chi che sia, o pure narrare un fatto seguìto; ma nella commedia basta che vi sia buona imitazione e il verisimile, e che la locuzione non sia scabrosa o barbara, anzi che la familiare, e senza tanta arte, è la più propria, perché la commedia rappresenta azioni comuni, e non di uomini di alta qualità, onde l'esquisitezza gli è impropria.</p>
         </sp>
-        <sp>
+        <sp who="#forestiero">
           <speaker><emph rend="sc">forestiero</emph>.</speaker>
           <p>Ben dite nel troppo; ma per imitare più parti e introdurre ciascuna a parlar propriamente, bisogna saperne assai, perché non si può dilettare con la variazione o del bergamasco o del veneziano o del bolognese; ma bisogna con la proprietà delle parole, ancor che non si muti linguaggio, ben imitare, e a questo ci vuol del buono, sì che torno a ridire che non spero molto di questa, perché ogn'uno val nell'arte sua.</p>
         </sp>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>L'arte vera del ben far le commedie, credo io che sia di chi ben le rappresenta, perché, se l'esperienza è maestra delle cose, ella può insegnare, a chi ha spirito di ben formare e meglio rappresentare i suggetti recitabili, il ben distenderli ancora; quando però quel tale non sia nato in Voltolina o dove si lascia l'io per il mi. Ma in che consiste, di grazia, cotant'arte?</p>
         </sp>
-        <sp>
+        <sp who="#forestiero">
           <speaker><emph rend="sc">forestiero</emph>.</speaker>
           <p>Nel servare i precetti e nell'imitare il più che sia possibile.</p>
         </sp>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>Chi può sapere meglio i precetti dell'arte che i comici stessi, che ogni giorno gli mettono in pratica esercitandola? E però gl'imparano dall'uso. E chi ha più la vera arte dello imitare di loro, che non solo imitano nelli affetti e proprietà delle azioni, ma ancora, con l'introdur varie lingue, sono necessitati a procurare di sapere ottimamente imitare, non solo con la propria favella, ma anco con l'altre, perché se il veneziano parlasse fiorentino e il fiorentino bergamasco, si darebbe loro il premio con le meluzze.<pb n="231"/></p>
         </sp>
-        <sp>
+        <sp who="#forestiero">
           <speaker><emph rend="sc">forestiero</emph>.</speaker>
           <p>I precetti bisogna cavarli da' buoni autori che hanno scritto le poetiche, perché l'imitazione del linguaggio poco vale, se non v'è, nel modo del dire e nelle parole, l'espressione dell'allegrezza o del dolore, del timore o dell'ardire, ché di questo l'oratore e il filosofo ne insegnano il modo, e non il comico.</p>
         </sp>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>Tutti i precetti veramente son buoni, ma il ridurre le cose all'operazione, quello è la essenza di ogni arte o scienza.</p>
         </sp>
-        <sp>
+        <sp who="#forestiero">
           <speaker><emph rend="sc">forestiero</emph>.</speaker>
           <p>Ben dicesti, ma all'operazione bisogna che preceda la regola, o vogliamo dir l'ordine, che da' precetti solamente si cava.</p>
         </sp>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>L'esperienza fa l'arte, perché molti atti reiterati fanno la regola, e se i precetti da essa si cavano, adunque da tali azioni si viene a pigliar la vera norma, sì che il comico può dar regola a' compositori di commedie, ma non già quegli a questi.</p>
         </sp>
-        <sp>
+        <sp who="#forestiero">
           <speaker><emph rend="sc">forestiero</emph>.</speaker>
           <p>Da quanto in qua avete voi preso la forma de sillogizzare?</p>
         </sp>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>La mia è logica naturale, fondata sopra la sola ragione.</p>
         </sp>
-        <sp>
+        <sp who="#forestiero">
           <speaker><emph rend="sc">forestiero</emph>.</speaker>
           <p>Con questa adunque vi voglio combattere. L'artefice non può perfezionare l'arte sua, senza la materia e gli strumenti, e se non ha fine al quale egli si indirizzi.</p>
         </sp>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>Ve lo concedo.</p>
         </sp>
-        <sp>
+        <sp who="#forestiero">
           <speaker><emph rend="sc">forestiero</emph>.</speaker>
           <p>La materia ora della nostra arte è l'orazione, o vogliamo dire locuzione, gli strumenti sono i concetti e invenzioni, e il fine è l'imitare e dilettare, dal quale ne segua il frutto dell'utilità.</p>
         </sp>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>Bene sta.</p>
         </sp>
-        <sp>
+        <sp who="#forestiero">
           <speaker><emph rend="sc">forestiero</emph>.</speaker>
           <p>Adunque, per ottenere il fine d'imitare e dilettare con giovamento si ricercano, oltr'all'invenzioni, concetti proprii, espressivi e significanti quello che si vuole imitare, e orazione o locuzione bene ordinata, rappresentativa ed <pb n="232"/>espressiva, atta a mettere innanzi a gl'occhi quello che imitar si vuole, accioché da questo ne segua il diletto e l'utile.</p>
         </sp>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>Chi dubita di questo?</p>
         </sp>
-        <sp>
+        <sp who="#forestiero">
           <speaker><emph rend="sc">forestiero</emph>.</speaker>
           <p>Resta perciò provato che i veri precetti, cavati da chi gli sa dare, ne fanno conoscere i buoni concetti, che propriamente esprimano e significano quello che imitare si vuole. E anco somministrano l'invenzioni, perché con la distinzione che ci porge il precetto che seguir si dee, differente da quello che si deve sfuggire, ci vien fatto scorgere il non buono dal buono, e l'orazione rappresentativa, e le parole proprie espressive, poi ben concatenate e atte a mettere innanzi a gl'occhi, per ottenere il fine d'imitare, senza le regole e senza i precetti, né imparare né usare si possano, ma né anco s'arriva a conoscerle senza i proprii documenti, i quali sono il vero fondamento.</p>
         </sp>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>Il vostro argumentare scolastico, se bene è con ingegno, credo che essendo sofistico resterà gettato a terra dalla mia naturalezza.</p>
         </sp>
-        <sp>
+        <sp who="#forestiero">
           <speaker><emph rend="sc">forestiero</emph>.</speaker>
           <p>Alle mani.</p>
         </sp>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>Sarebbe vera la vostra proposta, se noi avessimo da gli scrittori veri precetti intorno all'orazione e locuzione e modo di dire comico, come ancora de' concetti e dell'invenzioni, che in quel modo di poetare usar si dee. Ma ricordatevi voi, che dovete averlo letto, che io posso aver sentito dire, che il vostro Aristotele dà i precetti della tragedia solamente, né mai dello stile comico discende a' particulari, e da Orazio non se ne ritrae cosa di sustanzia. Onde, della commedia non ce ne è altra regola, né altri precetti, che il buon uso e i buoni autori, da' quali si son cavate le forme che oggidì si costumano, essendo verissimo che le regole furon sempre <pb n="233"/>cavate dall'uso e non l'uso da quelle. E da questo avviene che molti gran litterati, e de' migliori, per non aver pratica della scena, distendano commedie con bello stile, buoni concetti, e graziosi discorsi e nobili invenzioni, ma queste poi messe su la scena restan fredde, perché mancando dell'imitazione del proprio, con una insipidezza e languidezza mirabile, e talora con l'inverisimile per non dir coll'impossibile, fanno stomacare altrui, né conseguiscono perciò il fine di dilettare e meno del giovare, e non si gli porgendo però attenzione, si perde la memoria non che il frutto degl'auditori. Onde, i buoni concetti si conoscano dalli effetti e non da' precetti, perché chi nega il senso (dicono quelli che sanno) ha bisogno di sentir l'effetto delle cose sensibili, e si fanno però ridire que' tali col bastone. Per tal cagione adunque l'orazione e locuzione ancora, e le parole sole, poca parte aranno in questo dell'imitazione, perché ogni minimo gesto a tempo e affettuoso, farà più effetto che tutta la filosofia d'Aristotile o quanta retorica seppone Demostene e Cicerone. E che sia il vero che gl'affetti si muovono più agevolmente da' gesti che dalle parole, ciascuno che ha intelletto, e anco gli animali bruti, sempre faran più caso e moverannosi più a chi alza il bastone, che a chi alza la voce, perché, dice il bergamasco, <emph>dal dech al fach al gh'è un gran trach</emph>. E ciò avviene ancora in ogni altra cosa al senso sottoposta, però sovvengavi che la virtù de' sassi fece scendere quel galant'uomo dal fico e non le parole, perché in effetto alle azioni son più simili l'azioni che le narrazioni, e in sustanzia, e nelle narrazioni per accidente. Chi adunque vorrà azioni imitare, con le azioni più se gli appresserà che con le parole, nel genere</p>
         </sp>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>E considerisi ciò ne gl'amanti, che più da una lacrimuzza, da uno sguardo, da un bacio, per non dir più, e da simili coserelle vengano dal subietto amato tirati e mossi, <pb n="234"/>che dalla persuasiva di qual si voglia gran filosofo morale, che con ben ordinata scrittura, perfetti concetti, ottima locuzione ed esquisite parole e migliori ragioni, esorti alla virtù, persuadendo a lasciar da canto la sensualità, perché i sensi da' sensi più agevolmente vengon mossi, che dalle cose che sono in astratto, accostandosi sempre il simile volentieri al suo simile.</p>
         </sp>
-        <sp>
+        <sp who="#forestiero">
           <speaker><emph rend="sc">forestiero</emph>.</speaker>
           <p>Veramente voi vi portate bene, e quasi quasi ch'io mi lascio andare, e se bene averei qual cosa da rispondere, mi contento per ora far buono il vostro detto, perché l'azione e l'armonia di queste musiche e il vago lavoro in atto di questa scena così ben fatta, e molto più la presenza di sì belle dame facendomi sollevare la fantasia al fare, cagionano che ella mi tira in modo che mi si muove il desiderio e si drizza l'appetito in guisa che mi lascio portare ancor io dal senso, e però bramo vederne il compimento, quando bene la ragione mi persuadesse il contrario. Ma vo dubitando che questa nobil brigata stia per cagion di noi troppo a disagio, perché dovendo voi per mio credere fare il prologo, io vi trattengo con lungo chiacchierare, e però mi risolvo di finire le parole e venire a' fatti per chiarirmi se le vostre ragioni sono con l'effetto tanto sustanziali come accennano col discorso. Sentirò adunque ancor io la commedia, e poi mi risolverò a darne il giudizio.</p>
         </sp>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>Credo che arete consolazione, però già che voi siate qui, andate di costì a seder tra gl'ascoltanti, e patitevi quattro pinte di più per aver voluto al principio poco credermi.</p>
         </sp>
-        <sp>
+        <sp who="#forestiero">
           <speaker><emph rend="sc">forestiero</emph>.</speaker>
           <p>Non mi basta l'animo per di qui entrare tra tanta calca, s'io non saltassi addosso a queste donne.</p>
         </sp>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>Forse che non l'arebbono anco a male, ma più tempo bisogna a tanta lite, e la concordia, ch'è sì rara al mondo. Però, andatevene per di là dalla scena, e voi, cortesi signori, acciò questo galant'uomo resti chiarito, di grazia, fatele di dietro un poco di luogo.<pb n="235"/></p>
         </sp>
-        <sp>
+        <sp who="#forestiero">
           <speaker><emph rend="sc">forestiero</emph>.</speaker>
           <p>Deh, sì, cari signori, ché lo star dietro a bella brigata per buona creanza non mi fu mai noioso e la persuasione di questo galant'uomo mi ha fatto di nuovo desiderarlo. Io ne vengo.</p>
         </sp>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>Signori, io dovevo farvelo, io dico il prologo, ma questo bello umore, che non vuol credere se non al tasto, mi ha fatto perder tanto tempo, che ormai sentendo che i compagni sono all'ordine, lascierò che ve lo faccin loro per me, e io lascierò stare per non correr risico di rompervi la fantasia col mio grosso modo di dire. Però vi avvertirò solamente che l'autore non vi dà la commedia per nuova, perché tutte le scene l'hanno avuta, ma ve la dà bene come cosa sua, perché sua è stata sempre ed è, ma essendogli stata messa già in grazia dal favor d'un gran principe, degno d'eterna memoria, che con troppo illustre iperbole la chiamava la regina delle comedie, e avendola solamente per questo stimata sempre qualche poco, s'è però arrisicato adesso a distenderla in carta per farla ragguardevole con la protezione di virtuosissimo, non che illustrissimo, personaggio, perché la possa in tal guisa arditamente comparirvi innanzi. Ma l'ha distesa alla buona, sapete, e alla diritta, ancorché non sia il far ciò la sua professione ordinaria, né d'oratore né di filosofo, professando solamente non aver altro talento che di poter farvi sentire una gustosa e ridicolosa commedia. Il suggetto lo sentirete da' recitanti, ché però me ne vo io. A Dio.</p>
         </sp>
@@ -328,88 +368,88 @@
           <hi rend="italic">e</hi>
           <hi rend="sc">forestiero</hi>
         </stage>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>Corpo ch'io non vo' dir del male, passate di qua, che poco termine è il vostro?</p>
         </sp>
-        <sp>
+        <sp who="#forestiero">
           <speaker><emph rend="sc">forestiero</emph>.</speaker>
           <p>Al sangue, ch'io non vo' bestemmiare, che la vostra è una bella impertinenza! Non si può egli passar di qui?</p>
         </sp>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>Signor no, ché questa è la scena per la commedia.</p>
         </sp>
-        <sp>
+        <sp who="#forestiero">
           <speaker><emph rend="sc">forestiero</emph>.</speaker>
           <p>Per la commedia? Doh, ve' dove io mi son condotto! Non più, non più, ché mi par mille anni di esser fuor di qui. Insegnatemi l'uscio.</p>
         </sp>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>Ohimè, a tanta fretta e calca che avete fatto per entrare, questa e una gran mutazione.</p>
         </sp>
-        <sp>
+        <sp who="#forestiero">
           <speaker><emph rend="sc">forestiero</emph>.</speaker>
           <p>Se io avessi pensato che qui si facesse commedia, non sol non facevo calca, ma mi fuggivo più che il can dalle mazzate.</p>
         </sp>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>Domine intendilo tu! E perché questo?</p>
         </sp>
-        <sp>
+        <sp who="#forestiero">
           <speaker><emph rend="sc">forestiero</emph>.</speaker>
           <p>Perché io non mi diletto di coteste vostre cenciaie.</p>
         </sp>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>Cenciaie? Così chiamate lo specchio della vita umana, eh?</p>
         </sp>
-        <sp>
+        <sp who="#forestiero">
           <speaker><emph rend="sc">forestiero</emph>.</speaker>
           <p>Così chiamo un'azione la quale insegna alle giovani oneste il modo di divenir vagabonde, sollieva i giovani a ingannare i padri con l'esempio per scapestrarsi e <pb n="237"/> scapigliarsi, e avvezza i servitori a mettere in mezzo i padroni e le serve a far la ruffiana. Ma deh, lasciatemene andare.</p>
         </sp>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>Piano un poco, di grazia, ché se prima mi davi noia con la persona, con lo stare, ora mi offendete con le parole, con lo andarvene. É egli però la comedia sì mala cosa?</p>
         </sp>
-        <sp>
+        <sp who="#forestiero">
           <speaker><emph rend="sc">forestiero</emph>.</speaker>
           <p>Ella non è lodevole in chi la fa, più biasimevole in chi in lei si occupa e manco onorevole in chi la recita; ma in chi l'ascolta è ella poi detestabile, perché il sentire con piacere cosa che corrompe i costumi è vizio, e spezie di mancamento. E il tempo mal impiegato non ritornando, rende biasimevole chi lo consuma mal a proposito, e però fino nell'antichità non mancarono delle republiche lodatissime, che non permettevano tra loro recitanti, e per tutto l'arte era reputata tale che chi la esercitava non era ammesso a gl'onori. Sì che lasciatemene andare in buon'ora.</p>
         </sp>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>Fermatevi un poco, che ancor io voglio dire le mie sillabe per me e anco per i miei compagni, perché chi ci sente, sentendomi tacere, non credessi che voi avessi ragione. Io so pure che Silla, uom savio e lodato, amò talmente Roscio istrione, che lo messe al pari di Cicerone, che però il medesimo Roscio fece un trattato col quale agguagliò l'arte <pb n="238"/>istrionica alla retorica. Ma se le vostre ragioni valessero, ancor la medicina, che insegna a comporre i veleni per guardarsene e trovarvi rimedio,sarebbe da esser fuggita, e le spade, le lancie, e gl'archibusi che ammazzano gl'uomini, si avrebbon tutte a gettar in un pozzo, e pure la fortezza e la prudenza, che son le maggior delle virtù, con detti strumenti difendendosi, resistendo e conquistando, si mettano in opera. Dunque, secondo voi, la milizia, che pur dà occasione a gl'uomini di trionfare e farsi immortali, si deve vilipendere, perché ella può essere, anzi al sicuro è, cagione de gli omicidii? I medici ancora furono cacciati dalla republica romana, poi richiamati con grande onore per la necessità, e poi un fior non fa primavera, per pregiabile che sia, però né un sol caso forma una legge. Se la republica marsiliese non volle commedia e Roma con tutto il resto d'Italia e della Grecia sempre la tenne, e i comici sempre vi furon ricevuti per ragione di buon governo, e gli sarebbe parso anco mill'anni riaverli, per la necessità di trattenere e instruire quei popoli, se pure cacciati gl'avessero.</p>
           <p>No no, signor mio, quest'arte è cosa media, come sono tutte le cose umane sottoposte a gl'oppositi e a' contrarii, e non è biasimevole né lodevole per sé stessa, ma sì bene per le azioni che in altri conseguentemente ne seguono dopo di lei però in chi l'adopera, o con abuso o pur convenientemente, merita esser o lodata o biasimata; onde avendo ella per sé il fine di giovare con l'esempio, il difetto non può mai esser suo, ma sì bene di chi mal se ne serve.<pb n="239"/></p>
         </sp>
-        <sp>
+        <sp who="#forestiero">
           <speaker><emph rend="sc">forestiero</emph>.</speaker>
           <p>Bene sta, ma ella sollieva però gl'animi, ed essendo l'uomo per natura inclinato al male più che al bene, più tosto elegge quello che questo.</p>
         </sp>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>Buono, per mia fé, voi biasimate adunque la natura dell'uomo e non la commedia.</p>
         </sp>
-        <sp>
+        <sp who="#forestiero">
           <speaker><emph rend="sc">forestiero</emph>.</speaker>
           <p>Sì, ma come mezzo che solamente inclina a quel fine, ove poi quella lo conduca.</p>
         </sp>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>No no, dite pure ch'avendo il fine come aver si deve, l'uomo ben composto cava i veri precetti del ben vivere, dal veder chi mal vive, e non da esso mal vivere i cattivi costumi per sé; e la commedia n'è la mezana.</p>
         </sp>
-        <sp>
+        <sp who="#forestiero">
           <speaker><emph rend="sc">forestiero</emph>.</speaker>
           <p>Orsù, concedianvi questo. Ma che onore può avere chi esercita cosa dichiarata etiam dalle leggi poco onorevole?</p>
         </sp>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>Quello istesso che conseguisce chi si contenta tirar addosso a sé il mal d'altri, per giovare all'amico, non altrimen ti che il servitore che per spazzolare il padrone si tira addosso la polvere, e con la torcia fa a sé ombra, perché il suo signore vegga la strada e non inciampi. Ma concessovi ancora che l'arte non sia onorevole, voi non mi negherete ch'ella acquista assai onore in chi l'esercita, mentre che per giovare comunemente (come concesso m'avete che fa la comedia) i comici si contentano di sottoporsi al giudizio che possi fare ciascuno della loro azione col tenerla o per poco onorevole e per biasimevole; e pur che giovino, o faccino cosa atta a giovare, non curano il biasimo o danno che avvenir gliene possa, etiam nell'onore.</p>
         </sp>
-        <sp>
+        <sp who="#forestiero">
           <speaker><emph rend="sc">forestiero</emph>.</speaker>
           <p>Per vita mia, che voi siate a bottega, io non voglio adunque parer di quelli che, per aver in me del vizioso, faccia apparire di voler convertire in tal uso una cosa media, come vi accordo essere la commedia, e per questo voglio (se così vi piace) gettarmi al buono, e pazientemente ascoltarla per veder di cavarne qualche frutto.</p>
         </sp>
-        <sp>
+        <sp who="#comico">
           <speaker><emph rend="sc">comico</emph>.</speaker>
           <p>Così fate adunque, ché farete bene con utilità e buon esempio e accomodatevi costì da banda, ch'io che dovevo fare il prologo, poiché veggo i compagni in ordine, con una <pb n="240"/>breve scusa mi licenzierò da questi signori per non cagionarli tedio.</p>
           <p>Signori, più capricciosa vi riuscirà la commedia senza il prologo, perché vi terrà gl'animi più sospesi, essendo solito il narrarsi con quelli l'argumento delle commedie, però accettate questo passaggio accidentale in vece di esso, che io col dirvi che si rappresenterà <title>Il finto marito</title> di Flaminio Scala, commedia tutta sua, se ben non nuova, farò qui fine, lasciando che il resto lo sentiate da' miei compagni. A Dio.</p>
@@ -441,107 +481,107 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">lepido</hi>
           </stage>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Lepido son per servirvi, signor Flavio, e il medesimo Lepido vostro.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Io non so qual sia maggiore in me, o 'l piacere ch'io sento del vostro ritorno, o il desiderio di sapere perché così celatamente sète venuto. E quanto più la cagione sarà potente, tanto più mi terrò favorito da voi. Ora, se non vi apporta noia il palesarmela, vi prego, per quella stretta amicizia ch'è tra di noi, che sì come mi rallegrate con la presenza, così vogliate ancora rallegrarmi con lo scoprirmi questo vostro segreto.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Essendomi voi caro e leale amico, è dovere che d'ogni vostro volere io mi faccia legge; e però volentieri vi racconterò il male. E crediate, signor Flavio, che non fu giamai nave da procellosa tempesta di rabbiosi venti così agitata e percossa, come di presente è l'anima mia nel tempestoso mare de' miei tormenti.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Il nodo, che congiunge gli amici, d'ogni sinistro avvenimento li rende partecipi; però potete assicurarvi, ch'essend'io a parte d'ogni vostro disturbo, ne desideri lo alleggerimento. Narratemi adunque pur liberamente quello che conturba l'animo vostro, sì perché parlando facciate minore la doglia, come molto più perché mi diate campo di poter trovare qualche rimedio al vostro male, che affligge me ancora.<pb n="245"/></p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Perché voi possiate signor mio, dopo la mia vicina morte, palesare al mondo la cagione di essa, vi narrerò il tutto; ma non già con speranza di trovar rimedio alle mie pene.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Voi m'offendete, con queste vostre parole tanto dolenti, e tanto più quanto andate con esse a voi prolongando il dolore, e a me il desiderio di sapere questo vostro travaglio per potervi rimediare.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Or udite. So che vi dovete ricordare come già son quattro anni, ch'io partii dalla patria, e per comandamento di mio padre me ne andai a Lion di Francia.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Me ne ricordo, e mi ricordo ancora quanto di mala voglia v'andaste.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Avete voi in mente la cagione?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Signor sì, per ritrovarvi innamorato della signora Porzia.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Adunque voi stesso, a voi medesimo, avete cominciato a far palese la cagione del mio tormento. So bene che vi dovete ricordare ancora che mio padre, non perch'io andassi a riconoscere il mio, mi mandò a Lione, come diceva, ma per dubbio, ch'egli aveva, ch'io non sposassi la detta signora Porzia, solo per non esser ella, come ci diceva, eguale a me ne i beni di fortuna.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Me ne ricordo, e comprendo bene che tutto questo vostro travaglio è cagionato dall'amore che voi portate alla signora Porzia; ma ditemi di grazia, avete voi inteso altro di lei? e s'ella si sia poi maritata?</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Così foss'io caduto morto, quando la nuova mi giunse delle sue nozze, ch'ora non sarei nel travaglio, ch'io sono.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Ohimè, ch'è quello ch'io intendo?</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Io, come ho detto, per compiacer al padre fui sforzato a partire, ancor che noto mi fosse il perverso animo suo. E innanzi, col mezo di Brigida, mia antica serva di casa, già moglie di Scaramuccia, mio fedelissimo servo, parlai con Porzia più volte, la quale, per lo nostro reciproco amore, sentendo mediante la mia partita quel dolore, che suole sentire chi è condannato alla morte, fu quasi per soverchia doglia a rimanere del tutto priva di vita. Quello che sentisse allora l'affannato mio cuore, vedendo così tribulare l'amato<pb n="246"/> oggetto de gli occhi miei, voi come amico e amante considerar lo potete. Tuttavia, consolati ambedue dalla fedelissima serva, e ritenute le lagrime, prendemmo alquanto di conforto, e, ripigliato lo smarrito spirito, pregai Porzia mia di volermi conceder grazia di tollerare con pazienza la mia partita, la lontananza e l'assenza mia per tre anni soli, se era vero che come diceva cotanto mi amasse, e in quel tempo facesse resistenza al padre e a gli altri parenti se la volessero maritare; promettendole alla presenza di Brigida assolutamente di pigliarla subito al mio ritorno per moglie. E glielo affermai con giuramento, e imposi alla mia serva ch'ogni giorno dovesse essere da lei; così, pigliato da essa congedo, li diedi la fede e li ultimi abbracciamenti per allora, con più copia di lagrime che di parole, e me n'andai.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Amara dipartenza! Così, ve ne andaste in Francia, e colà dovevate menar una infelicissima vita.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Amore per me ve lo dica. Io in quel tempo feci qual si voglia diligenza per ritornar alla patria, per adempire la promessa fatta. Ma il crudelissimo padre e la nemica fortuna, attraversandosi sempre ad ogni mio desiderio, non me lo permetterno giamai, anzi la malvagia mia sorte, per mostrarmisi più crudele, fece sì che repentina morte privò di vita la mia Brigida, nella quale (ahi lasso) era riposta ogni mia speranza. In oltre, non contenta e sazia di questo, per ultimo mio precipizio fece che, non potend'io arrivare al tempo promesso, mi venisse all'orecchie Porzia mia essersi maritata. Ora giudicate voi, se quella fu per me cruda e dispietata nuova. Ben sallo il mio cuore, il quale per virtù divina muore e rinasce mille volte l'ora nel mio petto; il morir suo qual ei si sia, vedendosi privo d'ogni amorosa speranza. E se pur di nuovo torna a ravvivarsi è solo per discolparsi con Porzia del suo tardare e della macchiata fede.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Tutta la colpa si debbe dare a vostro padre, il quale, come pur dianzi diceste, non per altro vi mandò in Francia, se non per vietar le vostre nozze con Porzia, e dovette per aventura ordinare ancora a i vostri parenti di Lione che non vi lasciassero partire sin tanto che Porzia non fosse maritata. Onde non dovreste affliggervi tanto, poi che la colpa non è vostra.<pb n="247"/></p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Ch'io non m'affligga? ch'io non mi doglia e ch'io non mi lamenti? Ah signor Flavio mio, credete voi ch'io tenga sì poco conto della mia fede, di quella fede che data una volta più non si può ritôrre? Acconsento alle cagioni, ma l'effetto del mancamento nasce poi da me.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Le passioni ne gli animi nostri debbono esser temperate dalla prudenza; voglio che vi lamentiate sì, ma che pensiate ancora a quello che dovete fare per sincerarvi appresso di lei, con farle constare le vere ragioni.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Per questo solo son qui segretamente. E, arrivato, ritraggo che Licinio, marito di Porzia, è uomo che tiene grandissima cura dell'onor suo, e per sua natura fantastico e bizzarro; e che da quel giorno in qua, ch'egli l'ha presa per moglie, ella non s'è mai veduta fuora di casa, né meno alla fenestra, onde maggiormente m'affliggo, disperando quasi de' rimedii.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Vigilanza e assidua accortezza penetrano per tutto.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Credo quanto mi dite. E però io mi risolvo di cercar di parlare con Porzia. Quello poi ch'io bramo e desidero da voi, è che tenghiate segreta per ciò la mia venuta, e che mi concediate albergo per poco spazio di tempo, e credete fermamente che nel parlare a Porzia sta la mia vita e la mia morte.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Non so altro che dirvi, se non che quello ch'è vostro non dovete chiederlo ad altrui. Desidero bene che vi governiate con prudenza e che in quello che mi conoscete buono, in questo vostro negozio come in ogn'altro, vogliate mettermi liberamente in opera.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Per ora non m'occorre altro che segretezza. E se nell'andare a' vostri negozi voi incontraste Scaramuccia, menatelo a casa vostra, ch'io in questo mentre m'anderò aggirando qua d'intorno, per veder s'io l'incontrassi, per far l'istesso, poi c'ho necessità dell'opera sua in questo fatto.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Tanto farò, con la diligenza che mi conviene. Servitore.</p>
           </sp>
@@ -555,97 +595,97 @@
             <hi rend="sc">scaramuccia</hi>
             <hi rend="italic">servo</hi>
           </stage>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Deh, dolcissimo e pietosissimo Amore, che tale mi ti dimostrasti nelle bellissime luci della mia vaga Porzia, sarà dunque vero che io, tuo fedelissimo servo, abbia da te sì strana ricompensa? e che da te sia così miseramente abbandonato? Tu, bellissimo figliuolo di Citerea, mi promettesti felicissimo fine e gloriosa vittoria dell'amor mio. Tu, glorioso fanciullo, promettesti felicissimo porto alla mia errante navicella, e, come nume divino e verace, sei tenuto ad osservar le tue promesse. Vorrai tu dunque, non più dolce, non più pietoso, ma colmo d'assenzio e di fèle dimostrarmiti? vorrai tu essere capitano mancatore? ingiusto rimuneratore dell'altrui fatiche? crudelissimo giudice che brami l'altrui morte? e superbo aquilone che sommerga questo mio stanco e travagliato legno? Deh no, deh no, potentissimo arciero, abbi pietà del tuo fidato servo!</p>
             <p>Ma chi è colui ch'esce di casa mio padre mezo spogliato e mezo vestito? Egli è Scaramuccia al certo. O mia buona fortuna.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Colui che disse che i sogni nascono in noi per la superfluità de' cibi, mi pare che non abbia punto di ragione, poi che in me stesso lo provo e sentolo il più delle volte. Ierisera me ne andai a letto a corpo vòto, per colpa dell'avarizia del vecchio mio padrone, e pur tutta notte non ho mai fatt'altro che sognare; a tale, che la regola camina per li suoi contrarii. É ben vero che stamane nello spuntar dell'alba mi venne in mente il mio giovane padrone e mi pareva ch'egli fosse ritornato di Francia tutto mesto, e addolorato, per aver trovata la sua Porzia maritata; e ch'io li diceva: «Lepido, Lepido mio, ecco Scaramuccia, il quale ti è stato<pb n="249"/> tanto aspettando». Ma, risvegliatomi, poi, trovai il sol levato e son sbalzato fuora, perché il vecchio non mi trovi a letto.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Scaramuccia mi va nominando, chiaro segno che tiene memoria di me. Voglio scoprirmi a un tratto, perché posso farlo, essendo da lui sommamente amato.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Queste scarpe mi sono state sempre strette, a tale che mi bisognerà fare quello che dice la canzone: «La mi fa male in punta / di dietro la vo' tagliare». Ma chi è colui che se ne sta colà su quel cantone incamuffato?</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Che fai, o galantuomo?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Costui non parla meco.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Olà, olà, o Scaramuccia.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Alla fé, ch'ei dice a me. Che dite voi, quell'uomo? ch'avete voi da fare con Scaramuccia?</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Molto più di quello che forse ti credi. Odi.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Chi diavol sarà così per tempo? Non ho debiti, ch'io sappia, né costui ha cera di sbirro, se bene quel cappello tanto tirato su gli occhi non mi dà troppo buono indizio. Voglio far buon animo.</p>
             <p>Quell'uomo, di grazia, levatevi quel mantello dal viso, se volete parlar meco.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Scaramuccia mio, non mi maraviglio che tu non mi riconosca, poi ch'io non son più quel Lepido ch'esser soleva.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Ohimè, che sento? ohimè, che vedo? Signor Lepido, sète voi? sète voi il mio padrone?</p>
             <p>Son io Scaramuccia? sogno, dormo o son desto? Scaramuccia, torna in te stesso, apri gli occhi, ché questo è il tuo padrone! Questo è Lepido, sì ch'egli è desso!</p>
             <p>O signor Lepido mio, e che buon vento vi mena in questa città?</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Zitto, sta' cheto, o parla piano! Sì, ch'io son Lepido ma non più tuo, colpa d'Amore e di Fortuna, che m'hanno fatto bersaglio e olocausto di morte.<pb n="250"/></p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Caro padrone, non turbate il contento c'ho di vedervi, con sì dolenti parole, e ditemi perché volete ch'io parli piano e perché andate così sconosciuto. Ditemi, padrone, qualche cosa di nuovo. Volete voi ch'io chiami vostro padre?</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Tu volevi dire il mio mortalissimo nemico! No, ch'io non voglio che tu lo chiami, né meno voglio ch'egli sappia l'arrivo mio, se non con la mia morte.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Con la vostra morte? e perché questo? che parole son queste? è dunque questo il contento che ne debbe apportare il vostro ritorno?</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Ben m'avveggo, o Scaramuccia, come tu non ti sei affatto dimenticato di me; ma ti sei però scordato di quelle cose delle quali io desiderava che tu tenessi eternamente cura. Come tu ti maraviglia delle parole mie? e ti rallegri della mia tornata? e non ti sovviene come e quale mi partii? quale io ritorno? quale ti lasciai? e quale io ti ritrovo?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Or mi sovvien del sogno. Signor Lepido mio, benissimo intendo il senso delle vostre parole, ma credeva che la lunghezza del tempo e la lontananza v'avesse liberato d'ogni amoroso pensiero.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Né tempo, né lontananza saranno mai bastanti (sì come non sono stati) a levarmi dell'animo Porzia mia! Sarà ben bastante il dolore a levarmi in breve la vita. Ma prima che ciò segua, voglio parlar seco, se possibil sia, e disingannarla di quella falsa opinione, che debbe tener di me per la mia lunga dimora, e questa è la cagione principale che m'ha fatto venire così incognito alla patria. E perché so che tu m'ami di quel perfetto amore, col quale già m'amava la buon'anima di tua moglie, per questo, dico, spero che mi sarai buon mezano, e, assottigliando l'ingegno, farai sì ch'io possa venire al fine di questo mio giusto volere. Tu non rispondi? che cos'hai? Levati quelle mani dal viso, che vuol dir questo?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Padrone mio, le vostre parole m'affliggono, sì per la rimembranza di Brigida, mia carissima moglie, come ancora perché voi cercate cose impossibili. In che cosa vi confidate voi? forse nell'amore che già Porzia vi portava? In quel tempo ella era padrona di sé stessa, ma ora è sottoposta <pb n="251"/>ad altri, né può disporre di sé medesima, e quello che già vi promesse, non può più attendervelo, avendov'ella aspettato sin al termine dovuto, e d'avvantaggio ancora, come ve ne potrebbe far fede la buona anima di mia moglie se fusse viva.</p>
             <p>Di più, essend'ella savia, e conoscendo la fragilità della carne, e rammentandosi delli onesti contenti tra di voi passati, non vorrà porre in pericolo l'onor suo, poi che ben potrà conoscere che di questo vostro amore sia spenta la fiamma, ma non già estinto il fuoco.</p>
             <p>Ma che occorre narrare tante e sì potenti ragioni, poi che a nulla servono? In somma, vi dico che, quando ben ella volesse, sarebbe cosa difficilissima e quasi impossibile il venirne a fine, rispetto alla severissima cura che di lei tiene il marito; il quale, per quello che s'intende, è uno de' più gelosi uomini del mondo, ed ella non si vede mai.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Orsù taci, né ti pensar, con l'addurmi queste tue ragioni, di levarmi dall'animo lo stabilito mio proponimento. Se tu amerai la mia salute, io lo vedrò. Intanto leviamoci di qui, acciò che non venisse mio padre, o altra persona, che mi potesse conoscere, e per la strada discorreremo sopra di ciò, andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Voi dite bene, andianne.</p>
           </sp>
@@ -658,104 +698,104 @@
             <hi rend="sc">gervasio,</hi>
             <hi rend="italic">vecchi</hi>
           </stage>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Scaramuccia, Scaramuccia.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Trapola, Trapola.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Dove diavolo sarà andato questa bestia, questa sua tanta sollecitudine non mi piace.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Non ti levar manigoldo no, sta' pure in letto, ché ancora non è levato il sole!</p>
             <p>Io per me non credo che la natura potesse creare il maggior infingardo di costui.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Il più sollecito servo non è in questa città di Scaramuccia, ma io non so se debbo di ciò lodarlo, sapendo ogni estremo esser vizioso.<pb n="252"/></p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Subito levato, intendi, vienne in banchi, ch'io t'aspetto; e guarda che tu non tornassi a dormire, animalaccio, sai?</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Oh, ecco il mio vicino Gervasio. Buon dì, messer Gervasio, con chi l'avete voi, che sète così turbato stamane per tempo?</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>O buondì e buon anno, messer Demetrio. Io stava gridando con un mio servitore, il quale è il maggior infingardo, il maggior sudicio e il maggior ghiotto, che si trovi al mondo, e s'io la mattina non levassi di letto, vi sarebbe sin alla notte.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>E io, per lo contrario, ho un servo tanto sollecito, che per levarmi a buon'ora ch'io mi faccia, sempre lo trovo più sollecito di me. Ma lasciando questo, che buone faccende questa mattina vi cavano di casa?</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Ho da fare alcuni negozii per mio genero, per dare impiego a' suoi denari e veder s'io trovo, qui vicino, casa a proposito, perch'egli ha pensiero di ritirarsi da sé; il che, se bene m'è scomodo assai, mi bisogna nondimeno contentarlo.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Io mi rallegro in vero, messer Gervasio, assai della parentela che avete fatta di vostra figliuola con quel gentiluomo fiorentino. E avete fatto molto bene a levarvi quella fanciulla d'addosso, poi che ormai era tempo di maritarla, tanto più ch'intendo ch'è molto facultoso, e ben sapete ancora non esser in una casa mercanzia più pericolosa di questa.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Voi dite il vero, messer Demetrio. E credetemi, che in quanto a me, se mia figliuola avesse fatto a mio modo, l'averei maritata già tre anni sono; ma ella, per un certo suo voto ch'aveva fatto, non ha mai voluto acconsentire al mio volere. Pure del tutto io ne ringrazio il Cielo, poi che con questo maritaggio ho dato in persona di qualità facultosa, ed è di qualche merito. Solo una cosa in lui mi dispiace assai, che è la sua troppa gelosia, la quale non vorrei ormai che fosse tanto conosciuta, ch'egli acquistasse cattivo nome per la città e diventasse poi favola del popolaccio.<pb n="253"/></p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>In vero è da dispiacerne; ma non vi maravigliate di questo, perché gli è solito de' gioveni così ne' prìncipii dar in questi estremi, ma poi tornano a segno. Volesse pur la fortuna, che mi capitasse un partito simile per la mia Giulia, ché mi terrei felice.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Qual vostra Giulia?</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>La figliuola di messer Lampridio mio compare, la quale egli mi lasciò poco innanzi la sua morte, con quel poco che si trovava, acciò ch'io la maritassi.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Sì sì, ora v'intendo, messer Demetrio. Ma, a dirvela, io mi credeva che questa giovane voi la serbassi per darla a vostro figliuolo.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Appunto, messer no; anzi, perch'io so ch'egli ha da tornare presto, vorrei levarmela di casa innanzi che giungesse, e l'openione mia sarebbe di darla a qualche persona riposata, ch'abbia, per dirvela, di già passato il furore della sua gioventù, essend'anch'ella, per dir così, più tosto donna che fanciulla, dico quanto a gl'anni. E, per venire alla liberaa, io ho più volte pensato in voi, da ch'io seppi che, come Porzia v'esce di casa, voi desideravi compagnia per vostro governo, e sapend'io quanto la giovane sia savia, l'ho giudicata cosa per voi. Che ne dite, messer Gervasio?</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Messer Demetrio, io dubito che voi non vi burliate di me, perché, come non molto facultoso, non mi pare di meritar sì buon ricapito, e come d'età, non son forse capace di così bella giovane. Ma crediate che, quando la mia povertà non vi ritenesse in dietro, ch'ella non potrebbe stare se non presso che bene, perch'io benissimo conosco la natura mia e il genio ch'io ho con la giovanezza. E credetemi, che così non si rinverdiscono le piante al tempo della primavera, come si ringioveniscono gli spiriti miei alla presenza di giovanetta donna.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Io le credo d'avanzo, e perché voi conosciate ch'io ho riguardo alla qualità e non alle facultà, e vi assecuriate ch'io dica il vero, e che tale in effetto è il desiderio mio, veniamo alle strette. Chi fusse il padre della giovane, voi lo sapete, ed<pb n="254"/> ella è allevata in casa mia come figliuola; la dote è conveniente, e, tra mobili e stabili, arriva a due mila ducati; e io poi, per amore del mio messer Gervasio, le farò ancora presente tale, ch'ella conoscerà quanto io l'ami e voi ne sentirete il frutto.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Di ciò son io molto ben sicuro prima che ora, e ve ne ringrazio. Il padre della giovane è stato da me benissimo conosciuto, anzi amico mio, e in quanto alla dote sia rimessa nella vostra coscienza, sapend'io molto bene che voi non avete bisogno del suo, anzi, il modo da darli del vostro. Però quanto a me son contentissimo. Ma quando vogliamo noi tirare innanzi il negozio, messer Demetrio? Perché, a dirvela chiaramente, io me ne vo tutto in succhio, da che voi mi fate tale offerta, e di già parmi essere mezo guasto del fatto suo, perché veramente ella è giovane che merita.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Lo credo; e tutto forse è per voler del Cielo, ove si stabiliscono i parentadi. Orsù, mi risolvo,adunque,che noi venghiamo (come voi desiderate) quanto prima a fine di questo negozio. Ma non mi par già se non bene (ancor che la giovane mi sia stata sempre obbidientissima) di ragionarne prima seco e farla avisata del tutto, come quella c'ha da essere la principale nel fatto e la robba è la sua. Però voi fra un'ora potrete mandare il vostro servitore da me per la risposta, ché io in tanto farò quanto bisognerà. Che ne dite? parvi che sia ben fatto, così?</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Messersì, voi dite benissimo, ch'io similmente non vorrei che fusse fatto nulla, senza il buon voler della giovane, perché diventa troppo gran fiera in una casa una donna maritata contra sua voglia, e se ne vedono infiniti esempi.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Voi dite benissimo. Andate dunque alle vostre faccende e io farò quanto v'ho detto.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Orsù, son vostro, messer Demetrio.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Andate felice.</p>
             <p>Miglior bonaccia di questa non bramava la mia barca; o come mi riesce ora ogni disegno! La scioccaggine e povertà <pb n="255"/>di costui è appunto a proposito mio. Si dice che l'uomo vive dell'uomo; ond'io per mezo di costui spero d'esser felice nell'amor mio.</p>
@@ -766,282 +806,282 @@
         <div type="scene">
           <head rend="italic">SCENA QUARTA</head>
           <stage><hi rend="sc">ruchetta</hi><hi rend="italic">serva</hi>, <hi rend="sc">demetrio</hi><hi rend="italic">e</hi><hi rend="sc">giulia</hi></stage>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Chi è? Uh, che romore è questo? O sète voi, padrone, che domine avete? vi debbe scappare, eh? volete ch'io cominci a sfibbiarvi le brache?</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Voglio il cànchero e 'l malanno, bestiola! Chiama Giulia...</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Che venga a voi. Ora la chiamo. Écci qual cosa di nuovo, padrone?<pb n="256"/></p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Assai di nuovo, e d'importanza; però chiamala qui, dico.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Giulia, Giulia, venite giù, ché messere vi chiama! Ma che nuova è questa? Deh, ditemelo, caro padrone.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Se tu avrai orecchie e pazienza lo saprai. Chiamala, dico, bestia!</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Voi! Avete una gran fretta. Giulia, Giulia!</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Che vuoi tu, Ruchetta, dove sei?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Sono sulla via e messere vi vuole. Tanto, padrone, che non me lo volete dire, eh! Me lo vorrete forse poi dire che non vi vorrò sentire, sapete.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Dì grazia, quella giovane, non entrate in collera! S'io piglio un bastone...</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Per voi! Non farei io già così, anch'io farò la sorda poi, sapete, quando mi chiamate la notte, come è vostro solito. Oh ecco la padrona.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Che mi comandate messere? che novità son queste di chiamarmi qui fuora sulla via?</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Giulia mia, io t'ho da dare una nuova di tanta importanza, e così buona per te, che non ho avuto pazienza di venire a dirtela in casa, perché ho bisogno d'andar altrove; sì che odi, figliuola mia cara.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Padrona, non mi detta punto l'animo che l'abbia da esser buona questa nuova.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Perché, madonna linguacciuta?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Perché voi altri vecchi mal potete giudicare il gusto delle giovani e poco contento potete dar alle donne.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Eh, civetta, sempre tu parli senza giudizio.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>E bene, quando io sarò civetta, o civettone messere, parlerò con giudizio.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Orsù sta' cheta ormai. Messere, seguitate, se vi piace, e lasciate dir costei.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Ruchetta, con questo tuo cicalare, una volta ti romperò il capo, ve'.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Vo' che mi rompiate... quasi che me lo avete fatto dire!</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Deh messere, lasciatela cicalare, non sapete voi ormai che natura sia la sua?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Così non lo sapesse, il vecchio cattivo!<pb n="257"/></p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Giulia, tu sai che doppo la morte di tuo padre t'ho sempre tenuta in casa mia come mia propria figliuola, e s'ho tardato sin ora a darti marito, è stato per non m'esser venuto per le mani partito a mio modo, e degno di te. Ora, come è piaciuto alla fortuna, m'è capitata (secondo il mio giudizio) persona tale, che a me darà gusto grande, e a te grandissimo contento e sodisfazione.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Come sarà secondo il vostro gusto, malamente potrà dar contento alla padrona.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Taci tu, ch'io non parlo teco, in malora!</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Né io con voi.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Ruchetta, s'egli è possibile, chètati, una volta! Dunque, messere, voi m'avete dato marito?</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Sì Giulia mia, ed è persona molto ben conosciuta da te.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Deh, caro messere, ditemi chi ell'è, poi che dite ch'io lo conosco.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Qualche barbogio come lui sarà senz'altro, che credete?</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Sai tu chi è messer Gervasio nostro vicino, il padre di Porzia?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Alla fé ch'io l'indovinai! Che ti dissi? O povera giovane!</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Tu non mi rispondi? Leva gli occhi da terra, guardami in faccia, non sei tu forse contenta?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Tanto possi esser tu, vecchio moccicone.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>A chi dich'io? O Giulia, t'è forse venuto male?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Sì, quel della madre, perché non li piace quel padre.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Rispondimi, ti dico.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Che volete voi ch'io vi risponda, messere, s'io veggo che non di marito, ma di padre mi andate provedendo! Fate voi forse questo per la doglia grande ch'io sentii per la perdita del primo, poi che ora volete darmi il secondo? La fortuna mi providde di voi, che come figliuola mi avete sempre tenuta e allevata, e però dovrebbe bastare a questa pazza, d'avermi pur troppo travagliata, senza volermi dare ora in poter di Gervasio, che più mi si conviene per padre, che per marito.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Come per padre? Dunque sì vecchio ti par Gervasio? Non vedi tu che quella barba così folta e così grande, ch'egli<pb n="258"/> porta al mento, non è ancora canuta, ma ch'egli la porta così per ornamento del viso? e per parere uomo grave e venerando nell'aspetto? Egli non arriva ancora a quarantotto anni, e non è ancora canuto.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>E a lei toccherà farlo cornuto, s'ella lo piglia.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Messer Demetrio mio, voi sapete benissimo come sin ora vi sono stata obbediente come figliuola propria, e che mai non vi ho dato disgusto in cosa che mi abbiate comandato.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Non lo nego, è vero. E ho speranza che manco me lo darai in questo.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Stessi tu tanto a mangiare, vecchio bavoso!</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Ora, per quell'amore che so che voi mi portate, e per quell'amicizia la quale era tra mio padre e voi, io vi prego affettuosamente a concedermi una grazia, e so che non me la negherete.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Come, Giulia, domanda pur quello che tu vuoi liberamente!</p>
             <p>O s'ella sapesse l'imperio ch'ella ha sopra di me!</p>
             <p>Di' sù, allegramente.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>La grazia è questa: che voi mi diate un poco di tempo a pensare sopra la proposta fattami, e sarà ancora più breve di quello che forse non credete.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Come? Mi contento, questo è ragionevolissimo. Ma vorrei bene, come tu dici, che fusse breve, rispetto alla promessa c'ho di già fatta a Gervasio.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Messere, lasciate pur fare a me, e lasciamo andar le baie, ché ora ch'io conosco il buon animo vostro verso Giulia, farò sì con essa lei che la si contenterà.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Ruchetta, se tu t'adopri in questo negozio in modo che tu lo riduca secondo il desiderio mio, buon per te; e il manco che tu avrai sarà il farti qualche cosa di nuovo intorno.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Come io non ho voi, ogni cosa m'è nuova! Non dubitate e lasciate fare a me.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Orsù, Giulia, éntratene in casa, e risolviti quanto prima. Ruchetta, tu m'hai inteso.Addio.<pb n="259"/></p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Va' col trentapara, che ti faccia rompere il collo, o possi tornare a casa come Pasquino! Oh povera padrona, e quasi dissi non fossi voi mai nata.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Eh, Ruchetta, quanto sarebbe stato meglio quel che tu di', poi che al nascer mio tutte le maligne stelle erano congionte insieme, e ogni maligno accidente prese albergo nella persona mia. E posso veramente dire che da quel giorno in qua ch'io ebbi cognizione delle cose del mondo, diventai bersaglio de' colpi di mala fortuna, la quale, non sazia de' miei lunghi travagli, aggiunse al suo potere la forza e potenza d'Amore, facendomi a esso soggetta e facendomi amar uno il quale non tanto si mostrò pietoso nel ferirmi, quant'ora si dimostra crudele nel sanarmi; né per abbondantissime lagrime, ch'egli veda scaturir da quest'occhi, né per ardenti sospiri, che da questa mia bocca esalino, non si muove a pietà di me. E se pur alcun segno ne dimostra, lo fa solo per accender maggior fuoco in questo mio già arso e incenerito petto. Credimi, Ruchetta mia, che mai nube fu così agitata e combattuta da impetuosi e contrarii venti quanto ora è travagliata l'anima mia dalla moltitudine delle punture che la trafiggono.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Fortuna e Amore vi saranno favorevoli se vorrete governarvi da persona savia. Ben sapete, padrona, come io so ogni vostro segreto, e se ben dianzi dissi non fussi voi mai nata, lo dissi, e perdonatemi, per conoscervi quasi dappoca in questo vostro amore. E se voi istessa vi cagionate il vostro male, vostro danno. Non è egli una vergogna, che una donna grande e grossa come siete voi, abbia indugiato tanto e sin a quest'ora a sapere quali siano le dolcezze d'amore? E <pb n="260"/>che credete, voi, d'aver a campar cento anni in questa vostra fiorita etade? Voi v'ingannate: non è cosa che più presto passi della gioventù. Sia pur benedetta l'anima di mia madre, che quando vidde ch'io sapeva masticar la carne, mi diede a conoscer il nerbo e licenza di procacciarmene piacendomi! Voi vi lamentate della fortuna e non avete ragione, perché la buona e cattiva fortuna ce la facciamo con la prudenza noi istessi. Non v'ha ella posto innanzi un giovene nobile, ricco, virtuoso, bello e gentile, e che v'ama al pari della vita sua, che è Flavio? Ora a che tanto dolersi e lamentarsi di lei? Lamentatevi di voi istessa e della vostra ostinazione! Perché dire: non lo voglio contentare, se prima non mi publica per sua moglie e se messer Demetrio non è consapevole? E ogni volta che il povero giovene vi viene innanzi, vi ponete a piangere, a sospirare e a dolervi di lui. Perdonatemi, a dirvela, queste son cose da far passar l'amore ad un cane, il quale, per bastonate che se li diano, non lascia mai di seguitar la cagna.</p>
             <p>Bisogna credere che, essendo Flavio gentiluomo, debba parimente con voi proceder secondo la sua gentilezza e il merito vostro. Ah, ah, voi sospirate perché vi dico il vero, eh?</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Io non sospiro perché tu mi dica il vero, ma perché tu m'accusi di quello che tu dovresti scusarmi e accusar Flavio, se pur è vero ch'egli mi ami come tu vai dicendo, della sua tarda risoluzione. Perché quel dire: «Giulia mia, io moro per voi, io spasimo, non son mai per amar altra donna che voi, voi siete sola, signora di questo cuore», non fa sì ch'io resti contenta e appagata di lui. Ruchetta mia, si dice che da i segni esteriori si conoscono i riposti segreti del core; non nego che quelle dolci parole non mi apportino contento, perché in quello istante non sarebbe cosa ch'io non credessi del mio Flavio. Ma allontanandosi egli da me con la persona, e io ripensandovi sopra, trovo che le parole sono molto lontane dal vero, perché, s'egli sentisse e patisse quello ch'egli dice per me, me ne avrebbe già dato segno e soddisfazione col parlarne con messer Demetrio; col mezo del quale, sarebbe venuto a fine sì dell'obligo suo, come ancora de' nostri bramati contenti, e non sarei per lui nel travaglio ch'io sono.<pb n="261"/></p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Padrona, voi volete tutte le ragioni a modo vostro. Ma che sapete voi qual sia il rispetto c'ha tenuto Flavio a non discoprire a messer Demetrio il desiderio suo? Ricordatevi ch'egli è giovene savio e discreto.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Non dico il contrario, poi che l'ha dimostrato (come lui dice) nel far elezione di donna che tanto merita, che tanto l'ama e che per lui sosterrebbe mille morti l'ora. Ma io per me, non so già qual sia questo rispetto che l'ha ritenuto. Ruchetta mia, i gioveni d'oggidì godono del godere, ma molto più del dire, e hanno per gloria che si dica: la tale fu goduta dal tale e la tale si strugge e si consuma per quel tale. Con tutto ciò, non dico che Flavio mio sia uno di questi; tutta via, la volubilità de' giovani e l'instabilità loro non mi fa se non temere. In somma, nessuno rispetto doveva tener Flavio che non mi chiedesse a messer Demetrio, se diceva da vero.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Padrona, ben m'avveggo che il dolore vi fa vacillare! Ora, per concluderla, sapend'io qual sia la forza di questo imperioso amore, sono sforzata (oltre l'obligo che vi debbo) d'aiutarvi. Non vi date fastidio, ché questo vecchio, a tutto mio potere, non sarà al certo vostro marito. E voi, dall'altra parte, mostratevi un poco più piacevole a Flavio, e parlandoli cercate di concluder la cosa tra di voi, in qual si voglia modo; ricordandovi sempre ch'egli è gentiluomo e che non procederà se non da par suo.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Ruchetta, tu parli bene e mi getto nelle tue braccia, ti sia raccomandato l'onore e la vita mia! Va' dunque or ora, e trova Flavio, raccomandami a lui, dilli il tutto e fa' che subito, se possibil sia, venga da me.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Lasciatene la cura a me, entrate pur in casa, e mettetevi all'ordine per quando egli venga.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>All'ordine di che?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Di rinchiudere il cardellino nella gabbia, s'io ve lo conduco.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>In che gabbia?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Nella naturale, fatta da vostra madre.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>E dov'è?<pb n="262"/></p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Cercàtela e la trovarete alla prima.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Io per me non t'intendo. Vanne e torna presto, e di nuovo ti raccomando l'onor mio.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Sia maladetto quest'onore, e quasi dissi chi lo trovò! É possibile che questo abuso vada tanto innanzi e che da tutti sia osservato per legge? E che la maggior parte delle donne temino tanto di perder questo non conosciuto onore? Io per me non ebbi mai il maggior contento, se non la prima volta ch'io lo perdei, perché fui fuora d'impaccio, ora più non mi curo di ritrovarlo per manco briga! Ma chi è costui che viene? In buona fé, ch'egli è Flavio, che ragionando da sé, come gli innamorati fanno, in qua se ne viene. Mi voglio ritirar da parte e udir ciò che dice.</p>
           </sp>
@@ -1053,251 +1093,251 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">ruchetta</hi>
           </stage>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>In effetto, non è cosa alcuna, approvata da gli antichi, che non sia più che vera. Vogliono molti che amore altro non sia che uno influsso che vien di fuora, entra per gli occhi, se ne passa al cuore, priva l'uomo di sé stesso e lo fa proprio della cosa amata. E che ciò sia vero, non solo lo conosco in me stesso, quant'anco in Lepido, mio cordialissimo amico, il quale si trova talmente privo di sé, che non avendo riguardo all'obbedienza paterna, al suo proprio onore, all'istessa vita, tenta di far possibile l'impossibile, con evidente suo biasmo e con la perdita di sé stesso. O Amore, queste tue dolcezze, che da principio gustare ne lasci, di quanti amari sono condite? Ben lo so io, ben or lo provo, poi che già mi ti dimostrasti lascivo fanciullo e ora mi sei severissimo vecchio! Ben mi credei, adescato da te, côrre i dolci frutti mostratimi in fiori, ma turbine di rabbioso vento il tutto svelse; ond'io (misero) novella primavera attendendo, <pb n="263"/>posso ben dire: o amarezze dolcissime d'Amore, per girar di pianeta, o volger d'anni, primavera per me pur non è mai.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Egli ragiona da sé e ragiona d'amore al suo solito; e, se bene ho inteso, ha nominato Lepido.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Potrei ancor dire che, per accrescer dolcezza al mio contento, tu, in persona della mia Giulia, mi ti fussi mostrato per lo passato alquanto crudele.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Egli seguita pure a ragionare, ma non intendo più nominar Lepido.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>E di già parmi udire dalla tua dolcissima bocca: «Incauto amante, non sai tu che par più dolce il bene con maggior fatica acquistato?». Ma chi è quella ch'io veggo colà su quel canto appoggiata? Ella mi par Ruchetta, ella è dessa senz'altro.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>La lepre è scoperta e il bracco viene alla volta mia.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Ben trovata Ruchetta, che facevi tu colà appoggiata?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Vi stava aspettando per darvi una buona nuova.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>E che buona nuova è questa?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Io stavo, dico, pensando s'io dovevo dirvi quello che v'ho da dire o no.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Se tu me lo avevi a dire, a che pensarvi sopra?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Stavo considerando, perché alle volte egli è buono il mutar proposito e massime quando si puo nuocere e giovar altrui.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Io non intendo questo tuo parlare. Tu mi vai mettendo in sospetto, dimmi di grazia quello che tu m'hai da dire e spedisciti.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Eh, signor Flavio, sappiate...</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Sappiate che?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>La signora Giulia si è...</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Si è, che? Di grazia, di' via! O Cielo, aiutami tu in questo punto.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Maritata! Lo dirò pure, in tanta buon'ora!</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Maritata chi?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Giulia.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Giulia mia è maritata? il mio bene? l'anima mia?<pb n="264"/></p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Giulia vostra? Eh, voi ne accorgerete se la sarà vostra.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Me ne accorgerò? E chi sarà quel scelerato, quel tanto arrogante, ch'abbia ardire di levarmi quello ch'è giustamente mio?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Chi sarà? Sarà messer Gervasio Grifoni.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Messer Gervasio padre di Porzia?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Signor sì, cotesto è desso.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Ohimè, ch'io mi consumo! Intendiamoci, di grazia: questo parentado come s'è fatto così in un subito? Giulia se ne contenta? messer Demetrio è informato del fatto? come va questa cosa? Dimmela, ti prego Ruchetta mia, dimmela tosto.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Come, se messer Demetrio lo sa? e s'egli è informato del tutto? Signor sì e poco dianzi chiamò fuora di casa egli stesso Giulia e me, e gli impose che si dovesse metter all'ordine, volendo senz'altro indugio fare stasera le nozze.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Questa sera le nozze? e lei che ha risposto?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Che volete ch'ella abbia risposto? La povera giovane (io li vo' dare un poco di corda) come figliuola obbediente, non conoscendo altro padre che lui, ha risposto che farà quello ch'è di sua volontà e di piacer suo.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Quello ch'è di suo piacere e di sua volontà? e non si ricorda di me? delle promesse fattemi? di quanto è occorso tra noi? di quello che tu hai udito e veduto? e tu non l'hai ripresa? Ahi, Cielo ingrato, Amor crudele, Fortuna malvagia, Giulia infedele, che torti sono questi? che tradimenti mi sono fatti? Tu me tralasci, Giulia, per Gervasio? per Gervasio abbandoni il tuo Flavio? quello per cui dicevi di viver al mondo? da cui dicevi dipendere ogni tua felicità? Deh, perché sì come ora conosco false le parole, non conobbi allora esser falso il cuore? Ma ciò non mi permesse Amore, perché non li parve allora assai potente la cagione per condurmi a morte! Ma volle tardare, il crudele, acciò ch'io dovessi con l'udire, co'l vedere, e co'l toccar con mano l'error mio e il tradimento altrui, apportar maggior dolore al cuore; accioché, vinto da giusto sdegno (per esser stato troppo creduto amante) con le mie proprie mani mi dessi la morte!<pb n="265"/></p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>La piaga s'infistolisce troppo! Olà, olà signor Flavio, che pensiero è il vostro?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Pensiero di voler morire, solo per non dar contento a quella crudele, la quale so che ogni volta che mi vedesse avrebbe contento, ricordandosi d'avermi burlato! Tu dunque a lei darai relazione della mia morte e al mondo della sua crudeltade.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>A lei, sarò io relatrice della poca fede che gli avete e al mondo della vostra pazzia! Eh, uomo da poco, (perdonatemi) senza ingegno, e senza giudizio, che parole vi lasciate voi uscir di bocca? E vi tenete di così poco merito?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Che parli tu di fede? che di' tu di pazzia? come di poco merito? Ruchetta, tu hai torto ad ingiuriarmi di questa maniera.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Non solo sète degno d'ingiuria, ma d'ogni altro gastigo maggiore, ma io mi riserbo a farvelo dare a Giulia.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Io né maggior gastigo, né maggior pena, posso avere di quella ch'or provo e sento. Ma quando tu dicesti ch'io mi teneva di poco merito, che volevi tu dir per questo?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Non dico forse il vero? non vi tenete voi di poco merito, credendo che Giulia vi lasci per quel lercio moccicone di Gervasio?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Non perch'io non conosca di meritar più di lui l'ho detto, ma perché m'è venuto in mente la natura di voi altre donne, la quale è d'appigliarsi sempre al peggio. E quello, poi, che maggiormente m'ha fatto ciò credere, è l'essermi detto e affermato da te.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>É vero che l'ho detto e affermato, ma a che fine? Per vedere dove io vi trovava, per dirvela. E ricordatevi che non solo avete offesa Giulia, ma me ancora col vostro parlare, e del tutto ho speranza ch'ella ne farà la vendetta. E vi prometto che se non fosse per amor suo, che di questo negozio non me ne vorrei più intrigar punto. Che le donne s'appigliano sempre al loro peggio, eh? Alla fé, che Giulia si sarà appigliata ad una buona cosa, per questa volta, e sto per questa parola per mandar ogni cosa in conquasso!<pb n="266"/></p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Ruchetta mia, io ti prego, come ho detto, a non accrescer afflizione alla miseria mia. Se io ho offesa Giulia, se ho offesa te, ecco che, con le ginocchia a terra, domando all'una e all'altra umilmente perdono e gastigo insieme. Non vedi, Ruchetta, che il soverchio dolore mi leva l'intelletto? né so quello che si vada articolando la lingua? Deh, se tu vuoi ch'io viva, narrami il tutto, dimmi la cosa come passa e rallegra l'anima mia, altrimente qui inginocchioni innanzi a te con questo ferro io mi darò la morte.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Levatevi, signor Flavio, levatevi, ché non solo voi plachereste la mia natura adirata, ma quella di qual si voglia altra donna a ch'ella fumasse! Ch'io vi perdono e so che vi perdonerà ancora Giulia vostra. Io son pur tenera di cuore e questi giovanotti hanno pur la gran dolcezza nella lingua! Venite qua, signor Flavio, state allegro, ché Giulia vuol esser la vostra, al dispetto di messer Gervasio e di tutto il mondo, e io ora venivo a posta a trovarvi per avvisarvi del tutto.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Ohimè, chi mi ritorna il cuore? chi mi rende gli spiriti? chi mi disgela il sangue? chi mi rende la vita? Ruchetta mia, il soccorso tuo amorevole, colmo di pietade e gentilezza!</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Voi altri giovani sète i ladri de' cuori di noi povere donne! Almeno questa vita ch'io vi do l'adoperassi voi alcuna volta per me ancora, perché tal volta è caro anco il fuoco di cucina, quando fa freddo, ah, ah, ah!</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Séguita, Ruchetta mia, e poi comanda a Flavio tuo.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Dico dunque che messer Demetrio voleva in tutti i modi che Giulia poco fa desse il sì, di contentarsi di pigliar messer Gervasio, e gli era attorno con le male parole. Alla fine la povera giovane le chiese per grazia un poco di tempo da pensarvi sopra, dando pur tuttavia buona speranza al vecchio, il quale pure contentossi, ma mezo borbottando e brontolando da lei si partì. Allora quella poverina di Giulia, con le lagrime a gli occhi, cominciò a raccomandarmisi e in un istesso tempo cominciò a dolersi di voi. E veramente, n'ha gran ragione, signor Flavio mio, poi che avendo avuto tanto tempo, non vi siate mai una volta risolto di parlarne a messer Demetrio. Io vi ho sempre scusato, e sallo il Cielo se più volte avrei voluto esser Giulia, per contentarvi alla pri<pb n="267"/>ma! Onde, vedendola io piangere e sospirare di quella maniera gli promessi di venirvi a trovare e far sì con voi che il parentado tra Gervasio e lei non vada innanzi, e il vostro, come più volte promesso avete, si stringa omai senz'altri rispetti; e del tutto la ho assicurata, confidata solo sulla vostra parola. Ora, che dite, vi ama Giulia, o no?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Che poss'io dire, Ruchetta, se non che l'amante tormentato da i pensieri, saettato dalla gelosia, alterato dalla passione, e vinto da improviso sdegno (cagionatoli dal sospetto) non opera come uomo, ma come animale senza ragione? Io dunque, per le dette cose operando come fuora del senno, sono degno di qualche scusa, poi che dove non è la cognizione dell'operare, non vi può esser la punizione della colpa; onde non credo meritar punizione alcuna dell'errore commesso, né da te, né dalla mia bellissima e graziosissima Giulia, ma sì bene cortesissimo perdono.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Non parliamo più di perdono, essendo legge d'amore che l'offeso sia quello che chieda il perdono all'offensore. Ma avete voi ancora pensato il modo come possiate condurre il negozio a fine?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Amore in un subito m'ha insegnato il modo. Or odi e apri ben l'orecchia a quello ch'io son per dirti, e sopra tutto usa il silenzio.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Per darvi gusto, aprirei altro che l'orecchia! Dite pure; ma in quanto al silenzio, vedo la cosa un poco difficiletta, per esser io donna, tutta via farò forza alla mia natura.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Farai bene. Ora sappi che gli è ritornato Lepido vostro.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Lepido figliuolo di messer Demetrio?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Lepido, sì, parla piano, perché tu non sia udita.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>E come non è venuto a casa da noi? suo padre non sa già nulla?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>No, e la cagione è questa: sappi che, quando egli partì, egli amava Porzia, figliuola di messer Gervasio, e ora è non meno innamorato di lei di quello ch'egli si fusse già quattro anni sono.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Lo so. Ma se ora ella è maritata, che animo è il suo?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>L'intenderai. E, credendosi che costei non abbia punto diminuito l'amore che ella gli portava, ma che, sforzata dal padre, abbia preso marito, ha fatto pensiero di non di<pb n="268"/>scoprirsi a suo padre, sin tanto che non si sia discoperto a lei. E questo per discolparsi di non so che promissione che già le fece avanti la partenza. E del tutto s'è confidato meco. Ora io, che altro non desidero che di far cosa grata a Lepido, mi sono immaginato una cosa, sì per sua come per mia salute, ed è questa: che Giulia mostri di contentarsi di pigliar Gervasio, ma che mandi un poco la cosa alla lunga, e in questo mentre, ella ne vadi talvolta in casa loro, e tu con essa, e parlando ella con Porzia, cerchi solamente d'intendere dalla larga qual sia l'animo suo verso di Lepido, perché più agevolmente lo confiderà a lei che a te. E, trovando la materia disposta, tu allora da te sola le scopra come Lepido è tornato, e da questo poi pigli occasione di scoprirle ancora tutto quello che ha stabilito di fare, e cerchi d'adoperarti tu in modo che, se sia possibile, Lepido per tuo mezo abbia il suo contento, dal quale verrà ancora a dipendere il mio. Perché, a dirtela, io ho sempre avuto sospetto Demetrio non tardassi per altro a maritar Giulia, se non per darla a Lepido al suo ritorno. E come intenderemo ch'egli abbia sodisfazione da Porzia, potremo poi liberamente credere che ogni disegno del vecchio sia vano. Ed essendo assicurato che Lepido sia contento, voglio poi discoprirli il tutto, sì dell'amore che è tra me e Giulia, com'ancora di quello ti ho imposto che si faccia per suo servizio. Che ne di', Ruchetta? piaceti questo mio pensiero? pènetrati questo natural discorso?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Benissimo! E ve ne fusse! Signor Flavio, mi dite gran cose, né mai mi sarei creduta tanto. Ora, che non può questo maledetto amore! In quanto al vostro pensiero, mi pare che sia assai bene; e però da mandarlo quanto prima in esecuzione. Ma ditemì, di grazia, quel sospetto che voi avevi che Lepido avessi a pigliar Giulia, è egli cagione che voi non vi siate mai risolto di chiederla a messer Demetrio?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Sì, certo.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Se voi lo scoprivi a me, io vi levava ben presto di sospetto, perché il vecchio non si degnerebbe a così poca dote; ma lasciamo questo. Io sarei ora di parere che voi parlassi prima con Giulia, per consolar la meschina, che si strugge e si consuma.<pb n="269"/></p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Tu di' bene, vedi adunque s'ella vuol venir fuori.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Come s'ella verrà! Tiratevi da parte. Tich, tich, toch.</p>
           </sp>
@@ -1309,147 +1349,147 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">flavio</hi>
           </stage>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Chi picchia?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Son io padrona.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Ché non vieni tu in casa? sei tu sola?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Signora no.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Chi è teco?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Lo sposo, che viene a toccarvi la mano.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Il malanno, quasi che tu me l'hai fatto dire! Vieni in casa, in malora, non star più costì.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Venite fuora voi, dico, ché messere vi chiama.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Il messere?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Signora sì.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Ora vengo. Oh infelice Giulia!</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Alla fé, che questa volta ti do il brusco dinanzi e il dolce di dietro.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Eccomi. Dov'è il messere? Eh, Ruchetta, tu cerchi di tribolarmi (pazienza), la mia fortuna vuol così. Ben, hai tu trovato quell'ingrato di Flavio? quello ch'è cagione ch'io arda e mi consumi senza speranza?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>O anima mia, se tu ti consumi, e io sarei già ridutto in cenere! Ma sola la speranza di goderti mi mantiene.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Signora, io l'ho trovato e non l'ho trovato. Eccolo qui, mezo vivo e mezo morto; ravvivatelo ora voi.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Ah traditore, quest'è dunque l'amore, che voi dicevi di portarmi? questo è dunque il premio della mia fede? Ahi misera, ben m'avvedo ch'altra fiamma vi scalda il petto, e che nuovo incendio vi consuma il cuore! Misera me, or dove, or dove debbo trovar più fede, se di già la vedo morta nel petto di colui che diceva esserne il vero tempio?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Giulia mia, eccovi Flavio vostro, eccovi quel core che lungo tempo è stato ed è il vero tempio della fede, come il vostro viso è il tempio della vera bellezza.<pb n="270"/></p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Ohimè, Flavio mio, anima mia, che tradimenti son questi? Perdonate, vi prego, a questa meschina, se spinta dal dolore avesse detto cosa che vi apportassi noia! Ah, Ruchetta, questo a me, eh? Basta.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Non vi dolete, ben mio, di Ruchetta, né vi affaticate a far ch'io vi perdoni, poi che non puole apportare noia quella dolcissima bocca, nella quale io vorrei, a guisa d'ape industriosa, andar suggendo l'amoroso nettare.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Deh, unico mio bene, avendo voi fatto, a guisa di rapace augello, preda di questo cuore, ben potete ancora volendo pigliar da queste labra, quali elle si siano, quel contento che desiderate.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Sotto, che aspettate? Accettate l'invito, servitevi dell'occasione!</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>O ben felice e avventurato Flavio, e che parole son queste, che mi vengono dalla cagione d'ogni mio bene? E quando e con che pagherò io giamai, signora Giulia, un tanto dono, che ora ricevo da voi?</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Quando, signor mio? Quando m'osserverete quello che più volte promesso m'avete con l'esser mio marito; e a questo non ci vuol molto indugio, se però bramate ch'io sia vostra, perché forse non sapete quello che la fortuna ne minaccia.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Del tutto appieno m'ha informato Ruchetta, e di già abbiamo stabilito il rimedio e sarete da lei informata del tutto, né altro bisogna, se non che voi vi governiate secondo quello che Ruchetta vi dirà. E quanto al divenirvi marito, ben sapete che prima ch'ora vi è stato promesso da me, e però qui alla presenza di Ruchetta, nostra fida segretaria, vi do per pegno la mia fede, chiamando di più per testimonio non solo Amore, ma tutte le deità che de' matrimonii hanno cura. E se mai Flavio manca di quanto alla sua bellissima e cara consorte promette, non solo perda com'infame la vita, ma l'anima sua sia continuamente tormentata dalle pessime furie infernali.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Che dite mo, madonna stitica? Così vogliono esser gli uomini. Sì, sì, stringetele ben la mano, diventiamo un po' rossa e non sappiamo quello che rispondere per dolcezza. E che aspettate, uh, che non la baciate?<pb n="271"/></p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Reggetemi, amor mio, ohimè, ch'io dubito che il contento avrà forza di far quello che non ha avuto il dolore, Flavio mio.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Anima mia, e che dolcezza che sente il cuor mio? Stringetemi, mia vita, e stringetemi forte.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>O canagliola, ricordatevi che sète nella strada! Oh là, sù, pazzarella, andiamo al manco in casa.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Ohimè no, Ruchetta mia! Orsù, mio signore, io me n'entrerò tutta lieta.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>E io me ne anderò interamente felice.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Io son pur contenta, mio bene.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>E io gioisco, cuor mio.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Fagioli! A quel ch'io veggo, voi avete animo di far altro che parole! Sù, sù, finiamola, entratevene in casa, Giulia, che non venissi il messere o Scaramuccia, e guastassi il tutto.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Addio, signor Flavio, governate il cuor mio.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>E voi, signora Giulia, l'anima mia! Ruchetta, ricordati subito d'informar Giulia di quello che tu sai, son tuo sorella.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Toccherebbe a voi d'informarla con un buon bussetto, come fanno i valenti calzolai.</p>
             <pb n="272"/>
@@ -1465,244 +1505,244 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">porzia</hi>
           </stage>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Vorrei più tosto tener a freno una dozzina di stalloni in mezo una mandra di cavalle, che reggere e frenare un giovene innamorato, overo indomito, per meglio dire. Io ho predicato tre ore nell'orecchie a Lepido e non ci è ordine. Io credo certo, come ho detto, che , sia indemoniato, perché un uomo di giudizio si pagherebbe di ragione, ma costui, tanto conosce ragione, quanto conosco io il digiuno, e dice di esser risoluto di voler parlar a Porzia o di morire. Con una giovane maritata che non è sei mesi, e poi a chi? ad uno, che è il maggior geloso, secondo dicano, che sia in questa città! Un cervellino e delle mani, come il diavolo, e che gli sta sempre intorno. Oh poveretto me, in che intrigo mi ritrov'io! Lepido si fonda sul dire: la m'ha voluto bene. Quel m'ha voluto bene è tempo passato, bisogna vedere al presente come si trova disposta la sua natura! Nel tempo ch'ella ti voleva bene, non aveva provato quello c'ha provato e prova ora. Tu gli apportavi contento alla vista, all'orecchie e alla bocca su, ma a quell'altra poi, che ingrossa senza masticare? Oh ci sono de' fastidii e de' fastidii da vero! A sua posta io ho promesso d'aiutarlo, e s'io credessi di perder la vita, voglio far il debito mio! Orsù alle mani, Scaramuccia, in cervello, bisogna far animo! Gervasio non è in casa, che farò? A sua posta, voglio battere. Alla voce conoscerò chi mi risponderà. Tich, tich, tich, toch.<pb n="273"/></p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Ch'è là giù, chi batte?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Cattivo principio! Questa è la voce del marito, voglio tornar a battere, qualche cosa sarà. Tich, tich, tich, toch.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Che ti si secchino le mani e la lingua, non puoi batter più piano e rispondere alla prima? Chi batte, dico?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>E a te si secchi il sangue nelle vene! Alla fé, che la porta s'apre e Licinio vien fuora; mi voglio ritirar da banda in questo cantone, perché costui non fa per me.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Olà, chi è? chi ha picchiato a questa porta? Non si vede alcuno. Porzia, vieni a basso.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Vengo, signore.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Dubito certo di non aver a far male i fatti miei in questa città; non so che insolenzie siano queste che si fanno alle case de i gentiluomini. Certo che non può esser stato se non qualche furfante ruffiano.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Costui ha un buon giudizio, e hammi conosciuto al picchiare.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Son qui, signore, che mi comandate?</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Hai tu sentito picchiar alla porta?</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Signor no, e quando?</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Or ora, e dove ti eri tu cacciata, in cantina? (Non vi maravigliate del mio parlare, perché siamo veduti e sentiti) Dove diavolo ti eri tu cacciata, dico?</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Ero sulla loggia, che stendevo i vostri collari.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Non t'ho io detto che tu non vada su quella loggia, dalla quale tu sei veduta e scoperta sino in piazza? Porzia, Porzia, questo voler far a tuo modo, questo non voler dar mente a quello ch'io ti dico, farà sì una volta che mai avrai contento meco! Tu non avrai un marito, ma averai un gran diavolo, che ti tribolerà continuamente.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Se tu sei il diavolo, torna all'inferno, che tu non la puoi vincere con la moglie, se la novella dice il vero.<pb n="274"/></p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Marito mio caro, perdonatemi; sempre voi vi lamentate a torto di me.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Sempre mi lamenterò a ragione, quando non farai a mio modo, e di nuovo ti dico che, quando io non sono in casa, tu non abbia mai tanto ardire di venire su questa porta a rispondere a persona che viva.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>E lei anderà alla fenestra.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Né t'affacciar mai alla fenestra.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Anderà sul verone che guarda nel giardino.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>E guardati che il trentapara non ti facesse andare sul verone che risponde nel giardino, ve'?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>E che sì, ch'egli dirà di suggellare il necessario?</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>E, se bisognerà ancora, farò fare una chiave all'usciolino del necessario.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Alla fé, ch'io l'indovinai! O che ti sia tagliato quello che si circoncide a gli Ebrei!</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>(Si getterebbe via poco del mio!) Èntratene in quella casa, ch'io voglio andare sino in banchi; e come viene il messere, dilli ch'io voglio desinare a buon'ora.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Così farò. Volete altro?</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Non voglio altro, fa' quanto t'ho detto, va' in casa, ch'io me ne voglio andar di qua.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Va' come andò mio padre, che non tornò mai più.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Oh Cielo, io ti ringrazio pure, poi che m'hai dato un marito che si vede che perfettamente mi ama, e tien conto dell'onor mio. E ben sarei meritevole di qual si voglia gran gastigo, quando mi nascesse un minimo pensiero di volerli far torto. O marito mio caro, se tu sapessi quanto è l'amor ch'io ti porto, tu non saresti così geloso di me.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Alla fé, che mi pare di già d'aver avuta la sentenza contra, senza litigare! Or va' Lepido, e fòndati sul dire: ella m'ha voluto bene! Almeno avesti tu sentite queste quattro parole! Eh, a sua posta, io gli voglio parlare e far faccia alla fortuna; e faccia ella poi quel che la vuole.</p>
             <p>Ben trovata, signora Porzia.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>O ben venga, Scaramuccia. E che miracolo è questo, ch'io ti vegga una volta? che vai tu facendo?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Signora mia, molte sono le cagioni che mi ritengono ch'io non venga a far il debito mio con vostra signorìa.<pb n="275"/></p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>E quali sono?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>L'una si è il veder vostro marito tanto geloso, e l'esser io un poltrone; l'altra, che ancora m'accora, si è che, quando vi veggo, tutto il sangue mi si commove, pensando al grand'amore che vi voleva la poverina di Brigida mia moglie, che non so s'ella vi avesse portata nove mesi in corpo, se vi avesse potuto voler meglio di quello che vi voleva! Deh, moglie mia cara, come sì presto mi ti tolse il Cielo, uh, uh, uh.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Di che piangi, Scaramuccia? piangi tu forse perché sia morta Brigida? Se questo è, tu sei differente assai dalla maggior parte de i mariti, i quali, per lo più, si sogliono rallegrare quando loro muoiano le mogli.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Sì, quelle che non s'amano, signora Porzia; ma a Brigida mia io gli ho voluto bene in vita e così ancora morta l'amo e onoro.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Tu di' bene, Scaramuccia! Perché si suol dire che a chi si volle bene una volta, non si vorrà mai male, e che il vero e perfetto amore non si scorda mai.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Questo detto è a proposito mio. Credete voi in effetto che sia così, signora Porzia?</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Io lo credo, e tengolo per certissimo. Ma perché mi replichi tu questo?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Vi contentate voi ch'io ve lo dica?</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Perché non vuoi tu ch'io me ne contenti?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Ditemi, di grazia, qual maggior amore s'è mai trovato al mondo di quello che voi avete portato a Lepido? E ora non ve ne ricordate più punto. Eh, signora, se voi sapeste qual è al presente la vita di Lepido...</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Né manco mi curo di saperlo! Ma egli è ben vero che, se io mi sono scordata di lui, egli prima si scordò di me, e me ne mostrò chiaro segno col mancarmi di quello che promesso m'aveva. E pur non aveva ragione d'abbandonarmi! Ma io ho ben avuta cagione e ragione d'abbandonar lui, poi che ben si sa che per lo marito s'abbandona padre e madre; e facilmente, però, si può abbandonare ancora uno che ti manchi di fede e ti tradisca.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Dite bene. Ma a Lepido non si può dar nome di mancatole di fede, né di traditore.<pb n="276"/></p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>No? perché? Non sai tu quello che passò nel partirsi tra me e lui. Ben lo sapeva la buon'anima di tua moglie.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Signora Porzia, so anch'io qualche cosa. Non vorrei altro se non che voi vedeste in che termine si trova Lepido al presente.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Non si può trovar così male che non meriti peggio! Ti par poco aver offeso non solo me, ma gli alti e supremi dèi per li quali mi giurò di prendermi per sua moglie? Ma che male è il suo? è forse venuta alcuna nuova de' fatti suoi?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Signora, secondo l'animo suo v'ha mantenuto e sarebbe per mantenervi quanto già vi promesse. Ma alla mala fortuna, malamente si può contrastare. Basta, se voi vorrete, potrete toccar con mano e con l'orecchie udire la sua modestia e il vostro errore. Ma voi mi domandate se abbiamo alcuna nuova di lui? Eh, signora, è possibile che quella parte, la quale è in voi, che partecipa del divino, non abbia notificato al vostro cuore la venuta qui di Lepido vostro?</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Lepido è tornato?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Signora sì, è tornato. Ed è tornato per voi e non per altri. E che ciò sia vero, non s'è palesato ad uomo del mondo, se non a me, acciò che io lo palesi solo a voi.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Che tu lo palesi a me, e questo perché? Eh, Scaramuccia, egli è passato il tempo, per non dire il termine, che mi sarebbe stata grata tal nova, e che forse il cuor mio (come dicesti) sarebbe stato presago del suo ritorno! Ma ora non è meno lunge del mio pensiero, ch'io sia dal suo, per poco amore e poca lealtà di fede.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Signora Porzia, perdonatemi, voi avete il torto; ma vi farò conoscere, e vi farò buono, che voi siate state lunge dal pensiero di Lepido. É ben vero che la fortuna, invidiosa de' vostri contenti, ha cercato di far ch'egli non abbia potuto effettuare mai quello ch'egli aveva nell'animo suo e a voi promesso; sì come, piacendovi di darle audienza, potrete da lui medesimo meglio intendere, il quale non ad altro effetto (poi che gli è stato concesso il partir di Lione) è tornato nella patria così incognito, se non per discolparsi appresso di voi, e se non saranno da voi accettate le sue giuste e vere ragioni, publicarsi al mondo per vero vostro marito innanzi di Licinio, e ciò fatto, per lasciar voi libera<pb n="277"/> nella vostra felicità, darsi poi la morte con le sue proprie mani.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Scaramuccia, le tue parole mi muovono a riso; e accorta del mio errore, non posso più dimorar teco, né rispondere a quanto tu hai detto. Or vanne con la buona ventura, ch'io me ne voglio entrar in casa, acciò che mio marito non mi trovi qui teco a ragionare. Il tuo padrone si potrà consolare con la memoria di qualche nova amata, che debbe facilmente aver lasciata a Lione, ché per questo sarà venuto incognito, per poter poi più liberamente ritornar a lei. Ben so che la conscienza lo deve rimordere, e con ragione; e che per questo vorrebbe far meco questa poca di scusa. E con questo, Scaramuccia, addio.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Signora, per quanto amore voi portate a Lepido, ascoltatemi ancora due altre parole.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Sì come nell'animo è annullato l'amore, così nell'orecchie è ingrossato l'udire; tale scongiuro, Scaramuccia mio, non ha forza in me. Addio, son tua.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Se siate mia, udite una parola, e per l'amor che portate al vostro marito, sù, uditene poi due.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>É troppo grande l'amor ch'io porto a mio marito! Orsù, di' ch'io t'ascolto.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Oh ventura, ecco appunto Lepido.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Or parla, che guardi? Spediscila, dico, che vai tu accen nando?</p>
           </sp>
@@ -1714,53 +1754,53 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">scaramuccia</hi>
           </stage>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Dalla lunga ho veduto Scaramuccia, e par che m'accenni non so che. Ohimè, che vedo? non è quella Porzia mia, quella che seco parla? Sì, ch'ella è dessa! O Amore, favoriscimi, ti prego, in questo punto!</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Scaramuccia, tu mi pari spiritato. Orsù, poi che tu non vuoi parlare, addio di nuovo.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Dove andate? Udite, signora Porzia, udite...</p>
             <p>Lepido fatti innanzi, fatti innanzi, dico, in malora, che aspetti disgraziato?<pb n="278"/></p>
             <p>Signora, udite di grazia questo gentiluomo, che vi vuol parlare per me.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Qual gentiluomo? Ah traditore, tu mi vuoi morta, eh?</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Anzi, con la mia morte s'accresce la vita a voi, signora Porzia mia.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Io Porzia vostra! Ohimè! Partitevi, Lepido, e non vogliate con questa vostra audacia macchiar l'onor mio! Ahi misera, ch'io sento lo spirito allontanarsi da questo petto! Scaramuccia, aiutami! Chi mi rapisce il lume? Deh, mi dia aìta quella mano che già mi passò il cuore! Reggimi, ch'io son morta.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Signora, fate buon animo. Olà? che vuol dir questo? Lepido, a che gioco giochiamo? Signora Porzia? Ohimè, che cosa grave è questa? ella è così fredda? Ohimè!</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Signora Porzia mia, che dolore è il vostro? dunque la mia presenza a tal termine vi conduce? voi non mi rispondete? Rispondete, anima mia! Ah Cielo, perché mi desti tanto spirito che qui ora giungessi? forse perch'io dovessi divenir omicida di me stesso? Ah, che pur sarà vero che se maligno accidente fa sì che lo spirto non ritorni nel bellissimo corpo di Porzia mia, io, io stesso con le mie mani, darò luogo a questa dolente anima mia, acciò che se ne vada a ritrovar quella della quale s'accese, nell'idea del Sommo Motore, e così, malgrado del padre mio, s'uniranno insieme, se non potranno i corpi, almeno l'anime!</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Padrone, io lascierò andar la carità in terra, io non posso più regger questo peso.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Ed ecco pure, Porzia mia, che pur ora ti tocca con pietoso affetto quella mano che non sarà men ladra a Lepido ch'ella sia stata a Porzia; poi che a te, come dicesti, rapì il cuore, e a me rapirà l'anima. Ed ecco, misero me, pur pallide e fredde quelle guancie che un tempo mi si mostrarono a guisa di falda di neve che faceva letto alle purpuree rose del tuo bel viso.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Non posso più, dico! E qui corriamo qualche pericolo.<pb n="279"/></p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Deh Porzia, anima mia, questi son quei begli occhi amorosi di donde uscì la saetta che, per gli occhi miei penetrando al cuore, vi fece sì profonda piaga! Voi ora chiusi, occhi graziosi e belli, non meno grazia avete che aperti! Sia maladetto il destino e il punto, che a mirar voi mi condusse! Sia maladetto Amore, che tanta vaghezza in voi racchiuse! Siano maladette le quadrella, onde ferito fui! E maladette siano, finalmente, tutte le grazie che sono in te, tiranno Amore, poi che avevano a cagionare, per mezo di quelle, la sua e la mia morte.</p>
           </sp>
@@ -1772,80 +1812,80 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">porzia</hi>
           </stage>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>O padrona, dove siete voi fitta ora?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Lepido, levatevi di qua, ch'io sento persona; mi par la voce di Trapola, il Cielo ci aiuti in questo giorno!</p>
             <p>Tiratevi in là, ché la porta s'apre.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Ohimè, Scaramuccia, reggila, non la lasciar andar in terra.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Lasciate far a me, non dubitate. Andatevi con Dio, dico.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Egli è una gran fatica a tenere serrate in casa donne, che bramano sempre d'esser vedute! Deh, povero Licinio, se la tua gelosia non ti fa diventar un cervo, diventar poss'io un castrone! Dove domine sarà andata costei? Non è già solito suo.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Olà, o vicini, o gente, o buon compagno, o Trapola, o bestiaccia, oh!</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Chi è quello che mi chiama?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>O povera giovane, che vuol dir questo? Olà, a chi dich'io? non sei tu il suo servitore? O mangia pane, viemmi aiuta, cànchero ti mangi, non vedi ch'ella è la tua padrona?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Ohimè, che vedo? non è questa la mia padrona? Ah traditore, tu l'hai ammazzata, tu! Alla giustizia, alla<pb n="280"/> giustizia! O povera padroncina, e chi farà più le buone minestrine, chi cucinerà le buone torte, in casa nostra? O povero Trapola! Con che l'hai tu fatta morire, traditore? Mostrami l'arme.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Vo' mostrarti la fune che t'impicchi, pecoraccia! Non vedi tu che gli è venuto uno svenimento, che se a sorte io non arrivavo qui per reggerla, ella cadeva in terra e s'ammazzava.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>O buono Scaramuccia! Deh, vita mia, ritornate in voi.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Di che luogo viene questo svenimento? dunque non è ella morta? Mi par pur morta ne gli occhi e nella bocca, ma il nascimento dov'è?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Eh, babbione, pigliala, abbracciala e portiamola in casa.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Ch'io l'abbraccia? Qualche cocomero! E che direbbe messer Licinio?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Non ci è pericolo che Licinio lo sappia; portiamola in casa, dico.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Orsù, portiamola. Pigliala tu di sotto, ch'io la piglierò di sopra. O povera padrona!</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Non la baciare, traditore.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Tuo danno, mi sa buono a me, entriamo.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>O giorno per me più d'ogn'altro infelice, o Fortuna iniqua tiranna, di te sola debbo dolermi, da te sola dipende il mio male! Tu, empia, tentasti in varii modi di spegner l'amorose mie fiamme, ma fu vano, poi che tu ne gli animi nostri non hai poter alcuno. Misero me, ora chiaramente conosco come ch'io nacqui sotto cattivo pianeta e sotto maligno ascendente, poi che vedo la donna mia in forza altrui e quasi come morta innanzi a gli occhi miei. Ora, che farete voi, occhi dolenti, senza il vostro amato oggetto? Altro non potrete fare che versar di continuo copiose lagrime d'estremo dolore. Piangete dunque, occhi, piangete e accompagnate il misero e tristo cuore, sin tanto che per la doglia io perda questa travagliata vita, la quale bramo di finire, poiché Porzia mia (misero me) di me più non cura.</p>
             <pb n="281"/>
@@ -1858,139 +1898,139 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">scaramuccia</hi>
           </stage>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>In somma, fa' per me e per Lepido, quello che faresti per te.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Io veggo aprir la porta di casa <add resp="#ed">di</add> mio padre, e Ruchetta venir fuora. Voglio ritirarmi, perch'ella non mi vegga, e veder quel che ella vuol fare.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Lasciate fare a me, padrona, non vi pigliate fastidio! Io ringrazio il Cielo ch'io son di natura dolce e che ogn'uno la conosce, e però ad ognuno piace. In effetto, io non ho mai voluto sapere quello che siano i fastidii, in questo mondo, e il maggiore ch'io m'abbia mai avuto è stato il farmi ben voler e far carezze da tutti. E questa mi pare la più bella e util cosa che possa avere una mia pari e donna da bene come me. La mia padrona è veramente nel maggior intrigo del mondo per questo suo amore, e in fine, ella ha ragione, poi che gli è una mala cosa lo star tanto a digiuno e massime per coloro a chi la natura ha conceduto diversi modi da gustar il cibo. Egli è tanto tempo che anch'io non ho riveduto quel traditoraccio del mio Trapola, ch'io dubito ch'egli non si sia provisto d'altra fornaia per infornare e bene io sento che la natura patisce. Ma se io mi posso avvedere s'egli muterà forno, e io muterò pala! Voglio andar a casa la signora Porzia, per far quanto m'è stato comandato dalla padrona.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Voglio partirmi, perché non mi vegga Ruchetta.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Ma chi è quello, che esce fuora di casa Porzia? Alla fé, ch'egli è Scaramuccia. Che domine fa egli in quella casa?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Orsù, addio Trapola, governa ben la padrona! Oh io mi son pur trovato nel grande intrigo! Manco male che la poverina è poi ritornata in sé, e pure gli è scappato di bocca «Lepido mio», in somma la gli vuole un gran bene.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Costui parla di Lepido. Certo che debbe sapere ch'egli è tornato.<pb n="282"/></p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>O tu sei qua, buona limosina? Dove ne vai, Ruchetta mia saporita?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>A cercar un poco di seme umano per la mia padrona.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Come, seme umano? che di' tu?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Seme romano, sì, che so io.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Eh, io credo che tu abbia detto bene alla prima, non ti ridir, no. Ma che vuol far di questo seme la tua padrona?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Per piantarlo nel suo orto.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Le radice si piantano, e i ramolacci, che poi fanno il seme, e son meglio per lo suo orto, che seminarvi queste erbette gentili. Ma dove vai a cercarlo?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>A casa del suo sposo.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Quale sposo?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Che non lo sai? il messere non te l'ha detto? Messer Gervasio Grifoni è lo sposo e messer Demetrio poco fa ha fatto il parentado. Ma Giulia...</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Non già, io non ne so cosa alcuna, ché non ho parlato al vecchio in tutta mattina. Ma Giulia, che?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>A dirtela, non lo vuole a partito nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Mi pare che la sia ben savia, s'ella è di questo umore! Che vuol ella far di quel vecchiaccio sciemonito? ma perché ti manda ella ora da lui?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Ti dirò, Scaramuccia, perché teco posso parlare alla libera e scoprirti ogni cosa: Giulia mi manda non dal vecchio, ma dalla signora Porzia, per avvisarla come gli è venuto il signor Lepido incognito, solamente per scoprir l'animo suo. E però vo a pregarla, da parte della mia padrona, e a far ogni opera perché Lepido le parli.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>E chi ha detto a Giulia che Lepido è venuto?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Il signor Flavio, il quale, in presenza mia, l'ha anche sposata. E le ha dato poi l'ordine che ella faccia fare a me questo offizio con Porzia per servir l'amico.<pb n="283"/></p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Tutto fa a mio proposito; e se il vecchio fusse in casa?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Mostrerei di visitarlo come sposo, perché Flavio ha dato ordine ch'ella si mostri contenta, per aver occasione d'aiutar Lepido.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Sì sì, io t'intendo. Costoro hanno operato più di me! Ruchetta mia, io sono informato del tutto, vattene in casa e non cercar altro, e di' a Giulia che stia di buona voglia, perch'io farò in modo ch'ella averà presto Flavio, e Lepido anch'egli sarà senz'altro contento.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Eh, guidone, io t'ho ben io sentito poco fa menzonar Lepido, e, per dirti il vero, so che tu sei sempre stato suo segretario; ma in questa cosa ci sarà della perdita per me, Scaramuccia.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Perdita di che, forse dell'onore?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Non parliamo di quello, che non ho mai avuto, né mi curo d'averlo; dico così perché, s'io andava in casa di Porzia, vedeva cosa che mi dava gusto.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>E che cosa, forse il tuo Trapola, eh? Lova, credi ch'io non ti conosca e non t'intenda, eh eh eh!</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Po', lova? Io non ho anco inghiottito nulla del tuo! E poi tu non ti degneresti, da poi che ti sei sagrato alla castità dopo la morte della tua moglie. Eh, goffo, tanto serve la castità a i morti, quanto l'incenso a' grilli! Che vo' tu dire? Messer sì, per vedere il mio Trapola, sì, tu hai ben detto il vero; che fo io male? Io fo col mio; non sai tu che chi non ha fuoco in casa ne va cercando pe 'l vicinato?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Eh, quanto a fuoco, tu ne potresti prestare a tutte le fornaci di Roma. Orsù, Ruchetta, vattene pure in casa, ch'io ti prometto far tal opera col Trapola, che tu sarai contenta ancor tu se vorrai, che ne di'?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Deh sì, caro il mio Scaramuccia! Io mi ti raccomando. E poi che tu non ti vuoi servir della mula, trova al manco il medico che l'adopri.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>O che tu possa crepar, poltrona! Da una parte mi piace l'umor di costei, che non è come quello di molte altre <pb n="284"/>servaccie, che conoscendosi aver il buono e il braccio dal padrone, fanno le madonne di casa e le stitiche, e si ringalluzzano non solo con l'altre serve e servidori, ma con le proprie padrone, co' parenti e con tutto il vicinato e vogliono sempre tener la chiave in mano ed esser le padrone del pane, del vino e dell'olio e d'ogni cosa senza discrezione, né vogliono che s'apra mai nulla senza di loro. Che se ne perda la semenza di sì fatte poltrone! In quanto a me, vorrei che tutti i padroni fussero del mio umore, che non ne terrei per casa pur una di qviesta canaglia, ma terrei bene de' servidori atti alle fatiche, e che possono andar in piazza e per tutto, a tutte l'ore senza pericolo alcuno. Ma che coppia è questa d'affannati cuori, che così mesta e dolente se ne viene?</p>
           </sp>
@@ -2002,175 +2042,175 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">gervasio</hi>
           </stage>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Adagio signor Lepido, io non vorrei che voi vi dessi così fattamente in preda alla disperazione alla prima! Che sapete voi come sia passato poi il negozio? Quell'aver veduto uscir Ruchetta di casa, per andar da Porzia, non è se non buono, perché, come v'ho detto, debbe essere andata da lei per vostro conto, sì come io le imposi.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Eh, signor Flavio, egli è molto più facile a voi il consolarmi con le parole, che a me il credere d'avere ad esser giamai contento per mezo d'amore.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Avete forse fede in qualche altro mezo?</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Signor sì.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>E in chi?</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Nella disperazione, col mezo della quale verrò al fine di tutte le mie miserie.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Deh, Lepido mio, lasciate di grazia questi sì fatti pensieri in disparte e credetemi che mi detta il cuore che non solo voi abbiate a veder oggi Porzia viva, ma che abbiate ad aver ancora da lei tal favore che ne restiate contento.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Egli è tempo ch'io mi scuopra. Che dite voi di contento, signor Flavio, parlate forse del signor Lepido?<pb n="285"/></p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Sì, Scaramuccia mio caro. Ben, che nuova ci è?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Lepido, è (ohimè) ch'ella è...</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Scaramuccia mio, è che? morta, eh?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Spedita, non v'è più rimedio.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Che dite, signor Flavio? Questi sono i favori, questi sono i contenti, che mi apparecchia il vostro cuore? Tu sei morta, mia vita? tu, tu ita ne sei alla celeste patria senza di me? e io, omicida crudele di quanto aveva il mondo di bello, impunito rimango? Ma non credere, non creder già, bellissima anima mia, che sì come ti promessi io non ne venga a trovarti or ora su ne gli stellati giri! Ed ecco la mia destra, che da te fu chiamata in soccorso, che già s'apparecchia alla mia morte!</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Piano signor Lepido, che v'è non so che da dirvi.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Fermatevi, signor Lepido, che pazzie son queste? Voi non avete ben inteso. Séguita, Scaramuccia, c'hai tu da dirli?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Ch'ella mi disse in casa: «Lepido mio».</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Dunque non è morta; udite, signor Lepido</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Che dici, Scaramuccia? non è morto il mio bene?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Signor sì, è morta. Ma...</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Eh, signor Flavio, ben vedo che vi burlate di me.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Adagio, signor mio! Scaramuccia, che vuoi tu dire? É morta ma, ma che?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Ma è ritornata in sé ed è viva.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Che dite, signor Lepido?</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Ohimè, ch'io moro! Scaramuccia, Porzia mia è viva o morta?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>É morta. Cioè per voi, ma viva per Licinio suo marito.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Pur ch'ella sia viva io mi contento, poi che nella mia mente sarà sempre viva, se bene mi conosco esser morto nella sua. Pacienza, viverò almeno con speranza di parlarli una volta sola ancora.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Signor Lepido, ho speranza che 'l mio cuore sarà verace di che dianzi vi dissi.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Piaccia al Cielo, signor Flavio mio! Ma dimmi di grazia, Scaramuccia, non hai tu detto ch'ella disse «Lepido mio»?<pb n="286"/></p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>O questo è il tintin, disse Graziano. Sappiate che, quando ella ritornò in sé, trasse un gran sospiro, e così ardente, che mancò poco che non m'abbruciasse la barba, e disse: «Lepido mio».</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Signor Flavio, che ne dite ora?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Bonissimo segno, ben, Scaramuccia.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Io da questa parola sono andato considerando che la signora Porzia vi voglia ancor bene, e che tutto quello ch'ella fa, lo faccia per paura di suo marito; onde mi si sono raggirati molti pensieri per la mente, e tra gli altri quello del signor Flavio, che m'ha scoperto Ruchetta, che non è se non buono. Ma io ne ho pensato un altro, che forse sarà meglio.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Hai tu saputo da Ruchetta s'ella è stata da lei?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Signor no, che non v'è stata, perché io la rimandai in casa. Basta, signori, non vi pigliate fastidio; volete voi altro, che per quanto potranno le forze mie sarete ambedue contenti? Signor Flavio, io so prima che ora il vostro amore, e quanto è passato tra Giulia e voi.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Eh, Scaramuccia, il travaglio è il mio; perché il signor Flavio si può chiamar contento egli.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Adagio, signore, perché ci è da far per tutti.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Credeteli pure, perché Scaramuccia dice il vero.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Orsù, veniamo a noi. Vorrei che noi ora facessimo una cosa: io so, signor Flavio, che messer Gervasio non vi conosce, nè tampoco è per riconoscere il signor Lepido, per esser stato tanto tempo fuora.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Egli è vero, che me non è per riconoscere altramente, ma conoscerà bene il signor Flavio, che pratica assai qui d'intorno.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Eh, signor no, perché egli è un tentennone così fatto e non m'ha mai dato fantasia più che tanto.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Or ben voglio che come voi lo vedete, gli andiate incontro, e lo salutiate per marito di Giulia, dicendoli che tutta la città di Roma si rallegra del suo sposalizio, e che voi siete gioveni vertuosi che volete andare ad onorar le sue <pb n="287"/>nozze e servirlo. Egli, ch'è mezo pazzo, accetterà senz'altro la proferta, e con quella occasione dirli che volete veder il luogo dove s'ha da fare il banchetto e andate in casa. Oh diavolo, eccolo che viene, state in cervello, ch'io voglio ritirarmi per non guastar la coda al fagiano.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Sì, ma poi che faremo? Sì a proposito egli è scappato.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Qual cosa sarà, cerchiamo pure d'andare in casa.</p>
           </sp>
@@ -2182,135 +2222,135 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">flavio</hi>
           </stage>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Un'ora mi par mille di saper la risoluzione di questo parentado! Con quanti amici io ne parlo vengo lodato di queste nozze. Sento un'allegrezza nel sangue, che mi pare d'esser ritornato giovene di venticinque anni. Ma chi son coloro che passeggiano innanzi a casa mia?</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Signor Belisario, come dite ch'egli ha nome il padron di casa?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Signor Cesario, io non me ne ricordo molto bene, so ben che dicono un non so che di Galafrone o Gastone.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Castrone? di chi diavolo dicano costoro? Ei guardò la mia casa. E m'incastronano molto presto, se parlano di me! Ma che possono volere? Egli stanno quivi fermi, che può esser questo?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Signor Belisario, domandiamone a questo gentiluomo qua.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Voi dite bene. Servitor di vostra signorìa, padron mio, mi saprebb'ella insegnare un certo gentiluomo che si chiama il signor Gervasio Galafrone o Gastone?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Castrone, castrone, che è fatto lo sposo?</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Grifone, volete dir, quel giovene.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Signor mio, sì, ben lo sappiamo; se lo conoscete insegnatelo, di grazia.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>I miei giovenotti, si potrebb'egli sapere chi voi siete e perché l'andiate cercando?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Signor sì, di grazia. Sappiate, signor mio, che questo si <pb n="288"/>chiama messer Belisario, maestro di ballare, e io Cesario, musico, nominati e conosciuti per tutta Roma.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Ah ah, vi sentii ben giurare poco fa da musico, seguitate pure.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Signor sì, ora avendo noi inteso che questo signor Castrone...</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Grifone, dico.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Signor sì, fa parentado, anzi l'ha fatto col signor Demetrio, noi, come vertuosi, vogliamo vedere s'egli si contenta che andiamo ad onorar le sue nozze, sapendo che sarà cosa grata al signor Demetrio. Però vostra signorìa ce lo insegni, di grazia.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>A dirvela, messer Cesario, io son quel tale detto Gervasio Grifone.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Vostra signorìa è il signor Gervasio? O signor mio, padron mio, vi fo riverenza con le ginocchia per terra.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>O padron mio, signor mio caro, bacio il lembo della veste di vostra signorìa.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>E il simile fo anch'io.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>O signor Gervasio, quanto mi rallegro di conoscer vostra signorìa.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Signor sposo, padron mio, entriamo in casa a veder la stanza del festino.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Entriamo, signore, non è questa la casa di vostra signorìa?</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Piano, quei gioveni, ché il contento vostro nuoce alla persona mia. Io vi ringrazio e lodo il vostro buon animo, e vi prometto servirmi di voi alla giornata, però lasciatevi vedere di qua, ch'io vi avviserò quando avrete a venire.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Dunque non vuol, vostra signorìa, ch'entriamo in casa per veder la stanza dove s'ha da ballare e dove hanno da stare i musici?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>O signor Castrone, signor sposo, vostra signorìa creda che non sarà se non ben fatto, certo.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>No no, signor no, per ora perdonatemi, ché ho faccenda; ma tornate verso il tardi, ché questa è la casa mia. Son vostro, giovani miei.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Signore, poi che così comandate, tanto faremo. Bacio le mani di vostra signorìa.<pb n="289"/></p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>E io, padron mio, gli sono schiavo, li fo riverenza e li bacio le mani.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Son vostro, messer Cesario; bacio le mani, messer Belisario.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Siamo sempre al vostro comando, e per servirla, patron mio. Che farem'ora?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Levarci di qua e tornare.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Non viddi mai uomini più cerimoniosi di costoro, né più ben creati; m'hanno quasi levato di sesto. Orsù, la cosa è fatta. Io ho tardato un po' troppo a ritornar a casa. Certo che Giulia debbe patire: io non volli replicare a messer</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>, ma son sicuro che Giulia sarebbe stata più che contenta, perché se bene in me v'è un poco d'età, v'è anco una grazia soprannaturale, che ha in sé virtù mirabilmente attrattiva. O povera giovane, in vero che me ne duole ch'ella di già patisca per me! Non vo' tardar più, lasciami chiamar Trapola.</p>
             <p>Olà, Trapola, a chi dich'io, Trapola?</p>
@@ -2323,88 +2363,88 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">gervasio</hi>
           </stage>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Olà, che insolenza è questa? chi chiama con tanta furia? Non puol essere se non qualche bestia.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Son io, sono il tuo padrone, vien fuora di casa.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>No, che non è in casa.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>O che animalaccio, egli intende sempre alla rovescia!</p>
             <p>Lo so anch'io ch'egli non è in casa.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Se tu lo sai, perché lo domandi, cànchero ti mangi!</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>O che pazzo, o che pazzo! Non odi tu ch'io sono il tuo padrone?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Tu menti per la gola, ch'io non ho altro padrone che messer Gervasio Grifone.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>O spiritato! Vien fuora, dico, ch'io son Gervasio.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Che Gervasio? O padrone, perdonatemi, perché <pb n="290"/>quando io sono cacciato nelle faccende di casa, al parlare io non vedo nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Sì sì, t'ho inteso, ogni cosa alla rovescia! Orsù, vien qua, va' a casa messer Demetrio e dilli da mia parte che risoluzione egli mi dà a quel negozio, hai tu inteso?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Meglio d'un sordo. Volete voi ch'io vada adesso?</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Ma quando, bestiaccia? Adesso, dico, e torna subito.</p>
           </sp>
-          <sp>
+          <sp who="#nupola">
             <speaker>NUPOLA.</speaker>
             <p>Anderò, messere, ma prima vorrei...</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Che vorresti, che?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Che voi mi dicessi che negozio è questo. Vi vedo allegro più del solito, padrone. Deh, ditemelo di grazia.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Perché tu vadi più volentieri, ti vo' dire il tutto. Sappi ch'io ho preso moglie.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Dite da vero, padrone? e chi abbiam preso?</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Il malanno ho preso! Giulia, alleva di messer Demetrio, e per questo ora ti mando a casa sua.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Padrone, voi non potevi far meglio e io, che ho buon giudizio, vi veggo di già diventato (becco cornuto del diavolo, al suo dispetto) padre di famiglia. Ma quando si faranno le nozze?</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Questa sera senz'altro. Or va' via e non tardar più, ch'io vo a dar ordine che si scaldi la stufa.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Andate pur, padrone, e fatevi far pulito.</p>
             <p>Ora sì, come si suol dire, m'è caduto il formaggio su i maccheroni! Se il mio padrone piglia Giulia, com'egli dice, io averò tutti i contenti che vorrò con Ruchetta, la quale so che vive guasta de' fatti miei.</p>
@@ -2417,117 +2457,117 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">trapola</hi>
           </stage>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Che cicala costui di Ruchetta? Io voglio un poco in disparte udire quel che egli chiacchiera.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Ora, con questa occasione di domandar a messer Demetrio s'egli è contento del parentado, vedrò ancora di parlar con Ruchetta, e quand'ella volesse tirarmi all'onor del mon<pb n="291"/>do, mi risolverei forse, mi risolverei di pigliarla per moglie; voglio però raffazzonarmi.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>O carnaccia da corbi, parti questo un bambino da venire all'onor del mondo? Sì, ma dentro d'una culla di quelle del Doria e farli dar la poppa all'aguzino con un buon nerbo di bue! Ma sta: l'amor di costui fa al proposito mio, affé, e già, già, mi son pensato il modo di farmelo amico d'importanza. Alle mane!</p>
             <p>(Ohimè) io son tutto acqua, il Cielo sa s'io lo troverò in casa.</p>
             <p>O ecco appunto Trapola, dove vai? il tuo padrone è in casa? avete voi ancor desinato? hai tu fazzoletto allato?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Gran furia, Scaramuccia, è la tua. Io veniva appunto a casa tua, e il mio padrone non è in casa e non abbiamo ancor desinato; fazzoletti non gli uso. Ma che furia è questa?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Vengo a portar due nuove, una a te, l'altra al tuo padrone.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Sarebbe forse quella nuova ch'io vo cercando, quella del mio padrone?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Forse che sì, te la vo' dire. Sappi che il mio padrone mi manda dal signor Gervasio a dirli che si metta all'ordine, ché questa sera vuol far le nozze tra Giulia e lui. Ma v'è poi l'altra.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Appunto ve', il mio padrone mi mandava ora per questo. Ma dimmi, qual è l'altra?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>L'altra mo tocca a te, e non sei per saperla, se tu non mi dai una buona mancia, essendo la miglior nuova che tu possa desiderare.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Deh, fratello, e che poss'io darti? Ti potess'io pur dare parte del mio appetito!</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Io ti ringrazio, io n'ho da vendere; altro vi bisogna, se non, addio! Ch'io ti vo a cercar del tuo padrone.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Piano, Scaramuccia! Tu non lo troverai, non ti partire. E che poss'io darti, in effetto? Voglio che tu conosca il mio buon animo, sta' a vedere.<pb n="292"/></p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Che vuoi tu fare?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Spogliarmi e donarti questo vestito.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Férmati, ch'io mi contento di manco, e se tu mi vuoi fare un servizio, ti vo' dar la buona nuova e t'aiuterò acquistarla e farò di modo che tu sarai contento; e ci entra Ruchetta, non ti dico altro.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>In questa buona nuova, eh?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Messersì.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Comanda, fratello, che io mi venderò l'unghie per tuo servizio, ché non ho altro bene al mondo, quando mi pizzica la rogna.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Io ti voglio credere. La nuova è questa: Ruchetta ha da esser tua moglie e io te l'ho da dare.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Ruchetta ha da esser mia moglie? Scaramuccia mio, ti vo' donare due de' miei denti, séguita allegramente.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Il servizio poi, ch'io voglio da te, si è questo: che tu chiami ora qui fuora la signora Porzia, acciò ch'io le possa parlare, e che tu secondi il mio umore e l'esorti a quello che tu intenderai ch'io desidero. E, perché tu sappia il tutto, è per servizio di Lepido, figliuolo del mio padrone.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>E ch'è tornato di Francia?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Sì, è tornato, che di'?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Tu pensi in questo ch'io abbia da far servizio a te e tu lo fai a me. Sappi che non ho altro desiderio se non di far diventar un cornuto quel messer Licinio, il quale è il maggior fastidioso che creassi la natura e non ci lascia mai in casa bene avere con la sua strana gelosia. Or quando le vogliamo parlare? ora? Veniamo pure alle strette, Ruchetta sarà pur mia, n'è?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>In fatti, non si debbe mai perder tempo nelle cose che importano.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Tìrati da parte, di grazia, se ti piace, e lascia fare a me.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Trova tu l'invenzione, ch'io mi ritiro da parte.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Lascia pur fare a me. Tich, toch, o signora padrona?</p>
             <pb n="293"/>
@@ -2540,211 +2580,211 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">scaramuccia</hi>
           </stage>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Chi è? sei tu, Trapola?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Signora sì.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Perché non vien tu in casa?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Scaramuccia vi domanda.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Che diavolo di' tu, bestia?</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Che cosa di' tu?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Che veniate in strada per cosa che molto importa. Ho io detto bene?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Bene, non potevi dir peggio. A te, a te, ch'ella vien fuora.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Perché mi chiami nella via? vuoi tu forse farmi aver una bravata da mio marito?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Eh sì, vostro marito, con vostra licenza, è una bestia, padrona.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>E io che vengo ad essere, se mio marito è una bestia? Eh, ignorantaccio, sempre sarai un bufalo! Ben, che cosa ci è di nuovo? e perché m'hai fatta venire nella strada?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Padrona, non posso dir la mia ragione solo, ecco qui Scaramuccia che m'aiuterà.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Oh, oh, mi maravigliava, non tanto di costui, quanto di te, Scaramuccia! Che vuoi da me? che vai tu facendo intorno a questa casa? (Ahimè) ben m'avvedo che tu vuoi esser affatto la rovina mia! Ti sei tu forse lasciato intendere d'alcuna cosa con costui?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Che vuol dir costui? O padrona, voi mi strapazzate un po' troppo! Eh, Scaramuccia, se la sapesse eh, ch'io son fatto lo sposo?</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Che cosa dice questo furfante? che cosa dice?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Niente, niente signora, badate un poco a me, se volete saper quello ch'io fo qui d'intorno. É possibile, signora Porzia, che affatto affatto io abbia da credere che voi vi siate scordata di Lepido?</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Ecco che pur di nuovo sei ritornato a tribolarmi! Io ti dico chiaro che non amo Lepido, e che ciò sia vero tu vedesti <pb n="294"/>poco fa, che l'anima mia, la quale si trova offesa da lui, non potendo soffrir di vederlo s'allontanò da questo corpo, sin tanto ch'egli le fu presente.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>E io credo il contrario, signora mia.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Abbiamo pur da dormir insieme questa notte Ruchetta ed io, n'è vero?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Sì. Di grazia, stà un po' cheto!</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Come, il contrario?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Non è che l'anima vostra odii Lepido, anzi l'arna, alterata nel vedere che il corpo vostro non fece il debito suo, nel subito veder Lepido, ella sdegnata s'allontanò da lui, né vi volle ritornare sin che Lepido non fu allontanato da quello. E credo ancora per non esser ella tassata d'ingratitudine, poiché quella che ha parte di divinità in sé, può molto ben sapere Lepido non esser colpevole di quello che voi l'accusate.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Cànchero tu di' bene! Tu debbi aver studiato Liombruno o Dama Rovenza! Non so se in questo saprò secondarti.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Sta' cheto tu, ché non è ancor tempo.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>I movimenti del corpo nascono dalla parte dell'anima, Scaramuccia. Se ella avesse conosciuto quello che tu di', non si sarebbe allontanata dal corpo. Ma se Lepido avessi saputo sì ben mantener la sua fede, come tu ben difendi la sua causa, non occorrerebbono queste quistioni tra di noi, le quali sarà bene lasciarle in disparte e che tu vadi a servire in altro il tuo padrone. Trapola, entriamo in casa.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Avete contentato Scaramuccia?</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Che contentare Scaramuccia, balordo! Entriamo in casa, dico.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Signora Porzia, una grazia vi domando, la quale torna in beneficio vostro.<pb n="295"/></p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Sì, cara padrona, fateli questa grazia, perché verrò a riceverla anch'io e la natura non patirà.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Io non son principessa che possa far delle grazie.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Fate conto che cresca la luna e fate da marchesana.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Deh, signora, per quanto amore voi portate a Lepido, per quanto avete caro l'onor vostro, fate questa grazia a Scaramuccia.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Scaramuccia, guarda un poco se te la potessi far io, senza aver quest'obligo a lei?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Vi prego, signora! (Eh, non mi dar fastidio tu!) Ma che state voi pensando?</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Orsù, Scaramuccia, di' sù, che grazia è questa?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>O mia signora dolce, che voi siate solo contenta d'ascoltar venticinque parole da Lepido.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>E non altro che questo? Messer sì, che siamo contenti, dov'è il signor Lepido?</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Sì, dove è il signor Lepido, eh, furfante? E se mio marito venissi?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Mancheranno scuse, e poi messer Licinio non lo conosce! Eh, padrona, perché volete voi far questo torto alla natura, che vi ha fatto sì belle orecchie per udire? e chi ascolterete voi, se non ascoltate gli amici? ascolterete voi forse inimici che cercheranno d'offendervi?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>O bene, Trapola! Tu mi riesci, affé, meglio a pane che a farina! Eh via, signora, non vogliate esser cagione della morte di quell'infelice giovane.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Si volterà ben , sì, séguita pure, ché le donne facilmente si piegano.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Deh, travagliato cuor mio, e che può voler Lepido da me? Si crede forse di cavare acqua da una pietra, gielo dal fuoco, dolcezza dalle salse onde del mare? Deh, quanto erra il cuor suo!</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Orsù, signora, quest'è cosa di poco costo a voi e sarete forse cagione della salute sua e della vostra quiete.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Trapola.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Signora, che dite? che mi comandate?<pb n="296"/></p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Che ti par ch'io faccia?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Che non solo l'ascoltiate, ma che le diate tutto quello che vi saprà domandare. Volete voi esser tenuta ingrata? Il Cielo ve ne guardi, che è troppo gran peccato! Scaramuccia, vallo a chiamare.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Che dite voi, signora, non siete voi contenta?</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Orsù, Scaramuccia, va' via, ch'io mi contento di dar audienza a Lepido, sì per amor di Trapola, come per amor tuo, e per levarmi questo tribolo d'intorno.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>O che siate voi benedetta, signora, sì sì, per amor vostro non per altro, io vi ringrazio per la mia parte, chiamandomi sempre obligato alla vostra cortesia.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>E io il simile, padrona mia. Io me ne vo adunque or ora a ritrovar Lepido. Trapola, son tuo, tien saldo.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Compagno, ricordati, ecc. Padrona, o che contento m'avete dato, ogni volta che farete a modo mio, non farete se non bene.</p>
           </sp>
@@ -2756,179 +2796,179 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">licinio</hi>
           </stage>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Eh, Trapola, credi pure ch'io lo fo contra mia voglia!</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Io lo so, lo so, e questo è ben solito delle donne, di farlo sempre contra lor voglia la prima volta.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Che cosa fanno costoro in strada? Vo' un poco stare a sentire.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Non nego di averli voluto bene, Trapola, ma ora è il dovere ch'io attenda a mio marito.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Ben si può attendere al marito e dar anco sodisfazione a sé stessa, padrona. Credete voi d'aver ad esser la prima gentildonna maritata che dia sodisfazione a qualche amante? Voi v'ingannate! E quante ve ne sono? Siano pur elle benedette, donne degne di viver in eterno giovani al mondo.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Eh sì, tu non mi darai ad intendere che queste cose siano ben fatte.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Anzi sì, perché son tutte fatte dalla natura, e a voi non occorre altro che metterla in opera! Eh, padrona, voi mi fate <pb n="297"/>ridere! Per che cagione ha d'aver più libertà l'uomo che la donna? perché ha da esser lecito all'uomo l'andar da cento poltrone e che una donna onorata non abbia da contentare un galant'uomo e pigliarsi anch'essa i gusti suoi?</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>O Trapola, uomo da bene, ti voglio, affé, per questo far crescere il salario!</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Molte cose sono lecite a gli uomini, che non si convengono alle donne; e poi questi pericoli non li corrono se non le belle e io non sono in questo numero.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Così il Cielo m'aiuti e a voi levi prima che può questo marito che avete, come per la vostra bellezza sono infiniti gentiluomini, che più volte m'hanno parlato di voi. E se per lo passato ho risposto a tutti ad un modo, per l'avvenire risponderò loro in un altro; ché mi parerebbe troppo grande errore che voi stessi sempre alli pasti di vostro marito solamente, tanto geloso e tanto disgraziatello. Un fior non fa primavera.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>O furfante, oh questo no, s'io non ti fo gastigare con un bastone, mio danno.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>O Trapola! Tu ti pigli un po' troppa licenza, che parlar è il tuo?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Perdonatemi, padrona! La compassione ch'io ho di voi mi vi fa parlare così liberamente.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Basta, parla meglio, se non, che io mi scoroccierò teco, ve'. E credimi che se mai (che il Ciel non lo voglia) io facessi torto a mio marito, starei sempre in sospetto ch'egli mi trovasse sul fatto. (ohimè) Se mi trovasse in casa un altro uomo eh? Uh poverina me!</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>E, madonna schifa il poco, v'accomoderesti ben, sì.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Non bisogna mai aver dubbio di questo, padrona, perché non mancano mai scuse, e quando bene ciò avvenissi, e massime avendo un servitor fedele come son io! Quant'all'esser trovata in fatto, è impossibile perché la natura, compassionevole di voi altre donne, rimedia a questo nell'ordinare la generazione umana. E però ad un bisogno basta disco<pb n="298"/>starsi un palmo e ognuno torna al suo segno, perché gli uomini non sono cani.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Ah, Trapola manigoldo, parti che l'abbia trovata?</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Tu hai una grand'arte a far diventar trista una donna da bene; non so se tu l'aresti così a far diventar una trista da bene.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>O signora no.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Perché?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Perché la natura inclina più presto al male che al bene, quando però si possa chiamar male quel che v'ho detto, che non me ne risolvo! Oh padrona, ecco messer Licinio, vogliamo noi dire ch'egli ci abbia sentiti?</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Trapola, che si fa?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Il mare è turbato! O padrone, v'ho da dire gran cose, mandate pur in casa vostra moglie. Oh mi pizzica la schiena.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Porzia, che fai tu qui nella strada?</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Niente, signore. Stava ragionando con Trapola non so che di mio padre.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Di tuo padre, eh? Credi ch'io non abbia sentito ogni cosa? Entra in quella casa.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Ecco ch'io entro. Signore, vi fo riverenza.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>O povera giovane.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Che cosa di' tu?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Che avete una onesta giovane.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>A che te ne accorgi?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Sappiate che dianzi, vedendola qui nella strada, mi venne qualche sospetto nell'animo, solo per la gran gelosia che ho dell'onor vostro. E però cominciai dalla lontana ad esaminarla, per vedere se a sorte avesse qualche capriccio nel capo, e in somma s'ella fusse innamorata d'altra persona che di voi.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Gran furbo ch'è costui! E che ti rispose?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Signore, mi si voltò con un viso arrabbiato dicendomi: vituperoso, furfante, che cosa ti spinge a dirmi queste parole? s'io entro in casa per un pezzo di legno, ti spezzerò ben io le braccia! E seguitò a dirmi tante di quelle villanie, che non si direbbono ad un procuratore che facesse perder la lite.<pb n="299"/></p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>E come ti salvasti?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Udite, non mi perdei per questo, no; anzi, le dissi che tutto quello ch'io le dicevo era solo perché molti gentiluomi ni erano invaghiti di lei e che ogni giorno me ne parlavano. Ed ella di nuovo cominciò a dirmi ch'io tacessi, che per le più degne creature del mondo non arebbe pensato, né ascoltata mai una sola parola, che tornassi in pregiudizio dell'onor vostro, non che fatto cosa che vi pregiudicassi. Per la qual cosa io vo argomentando che voi abbiate la più savia giovane del mondo.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Ah, furfante, tu sei ben tu il maggior furbo vituperoso che si trovi! Tanto ch'ella ti par molto savia, eh?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Savissima, signore, credetelo a me, ché io ve lo giuro da uomo onorato e da bene, in somma da vostro servitor fedele.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Perché da mio servitor fedele?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Perché il servo fedele piglia qualità dal padrone, io pigliando qualità da voi, posso giustamente giurar da uomo da bene e onorato; quello che non possono far molt'altri servidori, né procuratori, né notari, né cortigiani.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Quello che tu ti sia non lo so. So bene che dal giorno ch'io pigliai Porzia per moglie ti trovai in questa casa, e da quell'ora in qua sempre t'ho tenuto in cattivo concetto. Tuttavia, se mi ti vai scoprendo per quel fedel servo ch'io t'ho scoperto da poco in qua, dirò la mia oppenione esser falsa e che non tanto merito io riprensione, quanto tu premio secondo le operazioni. E così credo che ti contenti, n'è vero?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Io non v'intendo, padrone, parlate più chiaro, vi prego.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>L'intenderai, se ben l'intendermi non è a proposito tuo. Entriamo pur in casa, ché verrà ben tempo che m'intenderai.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Entrate, padrone, ch'io vengo. Costui parla per punto di stella, dubito che qualche nembo di pioggia boscaglina non mi si scarichi sopra le spalle! Or<pb n="300"/> sù, che sarà mai, venga che vuole! Io ho cercato di voltar la torta, ma dubito di non esser stato a tempo, ch'ella si sarà abbruciata un poco da un lato. A sua posta, s'egli mi segnerà la schiena, io farò in modo con Scaramuccia che gli segnerò la fronte e glie le farò spuntar fuora come quelle d'un capretto, bè, bè, bè. Voglio andar a trovar messer Demetrio.</p>
             <pb n="301"/>
@@ -2944,64 +2984,64 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">ruchetta</hi>
           </stage>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>I negozii di banchi vanno tanto alla lunga, che è una morte. Ho perduto tempo tutta mattina senza spedir nulla. E ancor che molti siano i fastidii, che mi conturbano la mente, il maggior poi di tutti è quello ch'io patisco per la mia cara Giulia. E ben si vede che dove regna Amore non si conosce errore! O Cielo, o Fortuna, chi m'avessi detto Demetrio in questa età tu diventerai servo d'Amor, eh? Orsù, in effetto e' non bisogna mai dire: di qua andrò; né meno: così ha da essere. Io conosco veramente di far errore, ma in fatti, che poss'io più? Chi mi sforza, ha sforzato altro uomo che non son io; qui non ci è altro che dire, se non che Giulia si contenti e che quella bestiola di Ruchetta abbia fatto l' offizio a dovere. Vo' chiamarla innanzi ch'io entri in casa.</p>
             <p>Olà, o Ruchetta, tich, tich, tich, toch.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Oh messere, siete voi, eh?</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Sì, vieni abbasso, che io ti voglio un po' parlare.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Eccomi, messere, avete voi ammanita la mancia?</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Sì, se le cose passeranno a mio modo.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Credo che non le possiate desiderar meglio.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Di' sù, che nuova mi porti?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>La padrona è risoluta di...</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Pigliar messer Gervasio.<pb n="303"/></p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Messer no.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Come no?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Cacasangue, messere, so che voi siete stato sollecito a levarvi questa povera giovane di casa! Rallegratevi, dunque, perch'ella è contenta di far quello che voi volete. Merito la mancia o no?</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Tu sei una gran ghiotta.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Sì, pare a voi, perché avete poco da farmi inghiottire! Messere, tutti mi dicono così! Orsù, la mancia, la mancia avaraccio!</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Orsù, sta' cheta, ch'io ti prometto di dartela, e voglio, di più, che te la dia lo sposo ancora! Ma chi è questo che viene in qua cantando?</p>
           </sp>
@@ -3013,7 +3053,7 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">trapola</hi>
           </stage>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>
               <quote>
@@ -3027,125 +3067,125 @@
             </p>
             <p>Da galant'uomo, che gli è qui messer Demetrio.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Non è egli il servidore di messer Gervasio? Mi piace quell'umore, perché gli è molto allegro.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Non so, messere, vedete io non lo conosco. Vù, vù, amor mio.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>La mi guata, la traditora!</p>
             <p>Buon giorno, messer Demetrio. Messer Gervasio Grifone, mio padrone, vi bacia le mani, e io qui a mona Ruchetta.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>E dove mi conosci tu, baronaccio?</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Guarda che proceder da furfantina! Non dar mente alle sue parole, Trapola! Ben, che dice il tuo padrone?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>O gran furba! Che desidera saper quello che si farà di<pb n="304"/> quel negozio. Ma, padrone mio, ei mi pare d'essere offeso da cotesta vostra massara.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Che vuol dir massara? S'io son massara, son del mio padrone, perch'io governo tutte le sue massarizie, che vuoi tu dir per questo? Messere, voi mi fate portare un poco rispetto, sapete?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>O, che ladra, finge di non conoscermi e il vecchio borbotta.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Taci bessona, ché sempre parlasti da sciocca! Vien qua, Trapola, e lascia dir costei.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Messere, la mi minaccia,voi non vedete, voi? Tu menti per la gola! Fatevi in là, messere.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Ah infame, a una par mia, eh? O piglia questa pianellata !</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Fermatevi, canaglia, non mi strapazzate tanto!</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Ad un par mio tirar pianelle, eh? To', poltrona! Guardatevi messere!</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Ohimè,la mia testa! Fermatevi, sciagurati, vi dico.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Ohimè, messere, io son ferita!</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Sei il cànchero che ti mangi! Fermati là, Trapola! Fermati lì tu, mettiti quella pianella, dimanda perdono a costui. E tu, darmi sulla testa, eh, Trapola?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Messere, l'ho fatto non volendo.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>A chi dich'io? Finiamola, dimandali perdono.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Per amor vostro lo farò, vedete, messere! Quell'uomo, vi chiedo perdono.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Per amor di messere, io ti perdono; e io lo domando di nuovo a voi messer Demetrio, perché l'ho fatto non volendo.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Ti perdono. Fate d'esser amici da qua innanzi. Trapola, dirai al tuo padrone che il negozio è fatto e che Giulia mia è contenta; e che ora non per altro parlava con Ruchetta, se non per mandarla da lui per farlo consapevole del tutto.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Messere, ricordatevi che m'avete promesso che messer <pb n="305"/>Gervasio mi darà la mancia, però tanto più volentieri me la darebbe s'io gli portassi la nuova io.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Se tu vuoi andare, va' con costui. Sì che tu intendi, Trapola: fagli l'ambasciata, e io me n'entrerò in casa. Se tu vuoi andar seco come t'ho detto, Ruchetta, vanne pure.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Orsù, messere, vi son servitore in eterno. Anderò a dar la risposta al padrone. Quella giovane, se volete venire vi farò buona compagnia.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Poi che messere me lo comanda verrò, ma vi raccomando l'onor mio, quel giovene! Messere, io vo sopra di voi.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Sì, sì, va' pure e torna presto.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Va', che ti mangi il cànchero!</p>
             <p>Io ho pur avuto a crepar delle risa! So che tu sai ben fingere, ribaldella, basta dire che tu sei femina! Ma lasciamo andare; come stai tu, vita mia?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Vita tua, eh? Alla fé, che non ho già io voglia di ridere! So che tu ti fai desiderare, galant'uomo. Parti che sia ora che ci rivediamo?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Sorella, Dio sa s'io t'ho sempre nel cuore, ma ho tanti fastidii in casa, che non ho pur tempo di mangiare; ma credimi pur, Ruchetta mia, che se mai uomo amò donna tu sei adorata da me.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Eh sì, di parole ne son sazia, fratello, e poi chi m'assicura di questo?</p>
           </sp>
@@ -3157,143 +3197,143 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">trapola</hi>
           </stage>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Te ne fo fede io, Ruchetta.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>O che ti venga il morbo, tu m'hai spaventata tutta! E di dove vieni ora?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>O Scaramuccia mio caro, appunto sei venuto a tempo.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Orsù, figliuoli, non ci è tempo da perdere; io ho inteso qui di dietro il tutto. Ruchetta, tu sai che sempre t'ho <pb n="306"/>voluto bene da sorella, e che sia vero, ecco Trapola, che sa quello ch'io gli ho detto del fatto tuo.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Tutti i beni del mondo, Ruchetta.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>E che si può egli dir altrimenti di me, poverina?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Bene sta, io so che vi amate tutte due, però mi parrebbe buono che voi vi maritassi insieme e io v'aiuterò in questo negozio, a far di modo che il vecchio vi donerà tanto, che potrete metter un poco di botteguccia, per ingegnarsi a campare come fanno gli altri, che ne dite?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Bene, tu parli benissimo. E tu, Ruchetta, che ne di'?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>A me pare che non si possa parlar meglio! Che diremo adunque, Trapola?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Io per me son contento.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>E io contentissima, per poter anch'io chiamare e avere mio marito a' miei bisogni ed esser donna da bene, sapendo la stagione che corre.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Parla bene. Da' qua la mano, Trapola, e tu dammi la tua, Ruchetta.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Eccola. Uh signore, che cosa è il matrimonio, io mi sento avampar il viso come una brace, uh come io son vergognosa!</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Ecco la mia, Scaramuccia.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>E così, toccandovi la mano l'un l'altro, vi promettete d'esser marito e moglie, n'è vero? E io sarò sempre testimonio di questo fatto.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Così prometto e così giuro.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>E io il simile. Uh signore, che vergogna!</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Non ci va egli un bacio?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>S'intende, ch'aspetti pecorone?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Eh, fermatevi signor marito, voi mi fate bene arrossire, vedete? Scaramuccia, quando si consumerà il matrimonio?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>A questo non ti vergogni, n'è, buona pezza?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Non lo dico per mal nessuno, il Cielo me ne guardi, ma perché non si patisca.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Che cosa dice la signora sposa, o Scaramuccia?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Intorno al consumar il matrimonio, io voglio che questa sera ve ne godiate insieme, perché di già ho pensato <pb n="307"/>come. Basta, per ora abbiamo fatto assai e vorrei che attendessimo ad altro particolare.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>O Scaramuccia, quant'obligo t'abbiamo! Orsù, alle mane, ch'abbiamo noi da fare? dico per Lepido. Sposa mia cara, allegramente.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>O Dio, quando verrà la notte? Io son più allegra di quello che s'ha da fare, che del fatto.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Venite qua tutti due e andate, come avete ordine, a dar la nuova al vecchio e cercate di cavarlo di casa insieme con Licinio, se è possibile; e questo per aver comodità di far parlar Lepido con Porzia. Ma il modo di cavarli di casa bisogna pensar ora.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Questo sarà facile.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Ma come?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Che vadino a veder la sposa.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Che vi ha che far Licinio?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Férmati, ch'io l'ho trovata! Voglio che li mettiate in mente di comperar qual cosa per la sposa, come collane, gioie e altro simile.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Alla fé, ch'è bene, e dirgli che meni seco Licinio, che se ne intende forse meglio di lui.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Tu parli bene, perché Licinio ne ha vendute di molte da poi ch'egli è in casa.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Questa dunque sarà buona invenzione. Battete dunque allegramente, ch'io mi ritirerò dentro a questo stradello. Battete pure.</p>
           </sp>
@@ -3305,179 +3345,179 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">gervasio</hi>
           </stage>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Orsù picchiate, sposo mio dolce; o battete, come vogliamo dire.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Tu hai ragione, poi ch'io ho la comodità del battocchio Tich, tich, toch.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Chi è là giù? chi batte? MAPOLA. La voce è di Licinio. Son io, signore, e un'altra persona, che vi vuol parlare.<pb n="308"/></p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>E chi è questa persona? Ora vengo fuora.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Certo che il messere non debbe essere in casa. Ecco Licinio che viene.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Dove sei tu stato, Trapola? che vuol dire che tu non sei entrato in casa? chi è costei?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Non sono entrato, perché m'è venuto in mente d'aver a fare un servizio per messer Gervasio. Questa è una serva di messer Demetrio, nostro vicino, che vorrebbe parlar col messere.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>State voi con messer Demetrio, quella bella giovane?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Al servizio di vostra signorìa, padron mio bello.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Ah poltrona, che proferte son queste? Egli vi ringrazia perché ha bella moglie accanto.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Che hai tu da risponder per me, o animale? Paionti forse queste proferte da rifiutare?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>E che sì, ch'io divento un becco in erba? Oh Scaramuccia, in che pazzo intrigo m'hai tu messo! Oh la sarebbe ben bella che me intervenissi come a Benvenuto!</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Quella giovane, io vi ringrazio e ci parleremo un'altra volta con più comodità. Come è il vostro nome?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Ruchetta Campana, per servirla sempre, signor mio.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>E io Trapola Battocchio, per darli sul capo.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Mi piace. Il messere non è in casa, sapete. Se avete a far di me altro, comandate alla libera.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Vi ringrazio, mio signore, io vorrei parlar con lui da parte del mio padrone.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>So che costei è una gran furba, e sarà per diventar un bel becco colui che la piglierà per moglie.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Si suol dire che i fanciulli e i pazzi predicono le cose, e chi è più pazzo d'un geloso?</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Che di' tu?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Dico che io non sarei mai geloso! Ma alla fé buona, ecco il messere.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Quel pelatoio era un po' troppo gagliardo, e mi par d'essere tutto scorticato! Ma che fanno qui costoro? Licinio, genero mio, che fate voi qui? Ruchetta, che buone nuove? Trapola, sei tu stato colà?</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Messere, questa serva dimanda di voi insieme con Tra<pb n="309"/>pola.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Messere, son stato là e Ruchetta qui vi darà la risposta del tutto.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Messer Gervasio, ammanite pure la mancia! Sappiate che la mia padrona Giulia si contenta di pigliarvi per marito e quanto prima si faranno le nozze.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Non resto punto ingannato dall'oppenione mia; ben sapev'io che subito Giulia si sarebbe incapricciata di me! O dolcissima anima mia!</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Olà, messer Gervasio, suocero mio, che nozze son queste? Così alla muta si fanno le cose, eh?</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Vita mia cara! Io v'informerò a bell'agio del tutto. E quando vuole messer Demetrio ch'io li tocchi la mano e che si faccino le nozze?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Quanto prima, e il toccarli la mano sta a voi.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Signor Licinio, udite, di grazia.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Son qui.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Che di' tu, Trapola?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Messere, perdonatemi se io entro troppo oltre: voi sapete che questa giovane è molto ben nata, e ha una buona dote, però bisogna, pare a me, farsi onore. Mi parrebbe dunque, se vi piace, che voi col signor Licinio ve ne andassi subito tra gli orefici e quivi comprassi qualche bella gioia graziosa, e poi andar di ficco a toccarle la mano. Che ne dite, signor Licinio?</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Se ella è persona meritevole e commoda, come tu vai dicendo, mi pare che sia molto ben fatto.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Come, s'ella merita? Io mi voglio appigliare al consiglio di costui. Andiamo, andiamo, Licinio, ché per la strada vi narrerò il tutto. Ruchetta, vien con esso noi anche tu, perché doppo anderemo subito di compagnia a casa di messer Demetrio.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Io vengo, signore, andate pur là, ch'io vi seguito.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Trapola, falle compagnia. Andiamo, Licinio.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Che di' tu, Trapola, le non potrebbono già andar meglio le cose!</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Sì ma...</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Ma, che?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Orsù, va' pur là innanzi, ch'io sono un poco in collera teco.<pb n="310"/></p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Se tu sei in collera meco, va' innanzi tu, ché qualche volta tu non mi dessi un colpo a tradimento.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Eh, beccona cagna, s'io ci posso arrivare! Orsù, va' pur là, ché il padrone si rivolta in dietro.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Così non ci arrivassi tu, come tu ci arriverai; tu non sei già più piccino di me, va' pur là, boiaccia!</p>
           </sp>
@@ -3489,31 +3529,31 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">lepido</hi>
           </stage>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Il mandar ad effetto quella invenzione dell'esser voi vertuoso insieme con Flavio, sì come deste ad intendere al vecchio, andava un poco troppo alla lunga. E per questo, non desiderando voi altro per ora che di parlare a Porzia, mi par che questa ora sia buona occasione, poi che voi avete tempo di poterle narrare tutte le vostre ragioni, perché coloro che vanno in là, come voi vedete, non sono per ritornar di quest'ora, e poi io so l'ordine che ho dato a Ruchetta e a Trapola.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>E Porzia è ella contenta d'ascoltarmi, te lo ha ella detto?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>E quante volte volete ch'io ve lo dica? Se voi volete ve ne farò anco un contratto.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Non ti maravigliare, ti prego, e non me ne voler male, poi che il troppo contento è quasi cagione ch'io vaneggi e nol creda.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Io non sono ignorante di questo fatto, per maravigliarmi, né meno vi posso voler mai male, poiché cerco ogni vostro bene. Orsù state all'ordine, ch'io vo a battere.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Or batti, Scaramuccia mio, ché in questo punto si vedrà chi avrà maggior forza, o la vita o la morte! E tu, alato nume, che al tuo potere e al tuo volere vai soggiogando uomini e dèi, vedi che pur tuo sono; e vedi ancora in che periglio mi ritrovo. O bellissimo figliuolo di Venere, dona, <pb n="311"/>ti prego, tal forza a questa mia lingua, ch'ella si renda benevola colei che già un tempo ti elesse per sua!</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Eh sì, io non vorrei ora tante chiacchiere, per dirvela! Serbàtele per quando ragionerete seco. Tiratevi da parte, se volete.</p>
             <p>Olà, o di casa, tich, tich, tich, toch.</p>
@@ -3526,233 +3566,233 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">lepido</hi>
           </stage>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Chi è, chi batte?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Son io signora, Scaramuccia.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Sei tu, Scaramuccia? Évvi nessuno nella strada?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Signora no, venite pure allegramente abbasso.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Ora vengo.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Lepido, a te! Ora ti do la lepre a cavaliere, sta' all'erta.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Ohimè, che mi trema il cuore.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Io son qui. Ben, che ci è di nuovo?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Ogni promessa è debita, come voi sapete, ora ricordatevi di quello che promesso m'avete.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Contra mia voglia e per tua importunità, mi ricordo d'averti dato parola di parlar con Lepido.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Or ben, signora, Lepido è qui. Io non vi starò a dir altro, se non, che vogliate aver alquanto di pazienza per ascoltar prima le sue ragioni, e io fra tanto starò a far la guardia, che non venisse qualcuno.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Eh, Scaramuccia, che errore mi fai tu fare? Orsù, pazienza, abbi l'occhio, ti prego.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Lasciate pur far a me. Fatevi innanzi, signor Lepido.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>O vista amata e cara, se tal sei qual mi ti mostri, che contento sarà il mio?</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Ohimè, che tremore è il mio? quali timorosi pensieri, nunzii di morte ora m'assaltano?</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Il tradimento vostro, la conscienza vostra macchiata, signor Lepido, vi toglie l'ardire d'avvicinarvi a me.<pb n="312"/></p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Né mio tradimento, nè conscienza macchiata, signora Porzia mia, mi può vietare ch'io non m'avvicini a voi! Ma sì bene il dolore, che sente quest'anima mia, di veder voi in forza altrui, e il saper ella che non per macchiata fede, né per mio tradimento, questo le avviene, ma solo per crudeltà paterna e per voler di mia maligna fortuna, la quale, invidiosa de' nostri contenti, a quelli s'è opposta, e ciò da voi non creduto, ed è quella parte che m'ha da ridurre a morte.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Adagio, signor Lepido, ché a questa morte vi risponderò con un poco di tempo. Voi mi tassate di crudeltà e d'incredulità, e so ch'avete il torto, perché a tutte quelle cose che si possa dare intera credenza, ho io fermamente sempre creduto; ma a quelle poi che non si possono veramente credere, volete voi ch'io gli creda? Signor mio no, perché commetterei gravissimo errore e mi mostrerei in tutto e per tutto contraria a me stessa.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Signora, udite vi prego: già si sa che noi parliamo de' nostri amori?</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Sì, delle cose passate e ancora delle presenti.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Sia come volete. Delle passate (o mio cuore come non mori?) ditemi, di grazia, quali sono quelle cose ch'avete conosciute degne d'esser credute da voi?</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Ve lo dirò, signor Lepido, e vi darò segno d'esser donna di giudizio e non una sciocca fanciulla, come già fui un tempo. La prima cosa, io ho creduto che voi, per ardentissimo amore che dicevi di portarmi, non sareste andato in Francia, non avereste obbedito al padre, se non vi fusse stato permesso da me, che nel medesimo fuoco ardeva, d'aspettarvi tre anni interi; e di ciò consolatovi con la mia fede, ve ne andaste. La qual fede (ben sapete voi) che vi è stata osservata inviolabilmente tutto quel tempo. Credei ancora che longo tempo dimorassi in Francia immerso nelle lagrime, ne i sospiri, nelle pene, nelle passioni, che si patiscono amando e ancora credei, di più, che in quel tempo sareste tornato alla patria, se non fusse stato il timore che voi avevi di vostro padre. Che dite, signor Lepido, non ho io creduto il vero?</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Sino ad ora voi dite benissimo, o mia signora Porzia, ma dubito che non mi allettiate nel principio per darmi poi la morte al fine. Ma ditemi ancora quali sono quelle cose che<pb n="313"/> non son degne di credenza, ditelo, ditelo bocca amorosa, ditelo bellissima fiamma che dolcemente mi consuma, quali sono?</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Quali sono? Sono quelle sulle quali voi vi vorreste fondare per vostra difesa. Ma perché conoscete non esser difesa né giusta né vera, temete e non ardite (come poco dianzi faceste) d'avvicinarvi a me. Non vi accorgete che voi siete simile a quel reo che trema e paventa innanzi al tribunale, accorgendosi che il giudice legge il suo errore nel suo proprio volto?</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Due cose sommamente desidero e bramo, signora Porzia mia, l'una che il Cielo mi faccia grazia di porvi nell'animo di darmi quel gastigo che merita l'error mio, se errato ho; l'altra che desse tanto di forza a questa lingua, ch'ella vi potesse descrivere la passione che ha sentita l'anima mia nella sua lontananza e insieme la cagione potentissima che m'ha tenuto ch'io non sia tornato al termine promesso.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Il Cielo, col mettermi in poter d'altri, v'ha già conceduta una parte di quanto desiderate; quanto al gastigo, senza ch'egli s'affatichi a dar vigore alla lingua vostra, lo dirò da me. Ora udite. Voi mi direte che non solo avete patito per tre anni continui, ma che anco al presente patite, e patirete sino alla morte. E mi direte ancora ch'avete fatto ogni vostro potere per tornare a mantener la promessa fede, ma che i vostri parenti di Lione non v'hanno mai lasciato partire, e tutto per gli avvisi che vostro padre mandava di qua, non è vero? non volevi voi dir tutto questo, dite sù?</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Deh Amore, sì come tu sai che Porzia legga nella mia fronte quello che io addur voleva per testimonio della non macchiata fede (come in effetto è vero) perché non fai tu ancora ch'ella, rimirando sé stessa nelle mie luci, scorga qual sia l'interno travaglio che l'anima mia patisce per la sua poca credenza!</p>
             <p>Che volete voi ch'io dica, signora mia, se non ch'egli è vero ch'io voleva dir così appunto, come così è verissimo in effetto?<pb n="314"/></p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Così è in effetto, eh Lepido?</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Così, signora, se voi lo credete; e se no in breve vedrete, overo udirete, tal nuova di me, che sarete astretta a crederlo.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>E volete ch'io creda che continuamente io sia stata amata da voi, eh?</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Signora sì, e sarete mentre avrò vita. E prima si vedranno le vere stelle cader dal cielo, ch'io giamai mi rimanga d'amarvi.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>E per questo volete ch'io vi creda? per questo impossibile, eh? Deh, signor Lepido, lasciamo ora gli impossibili da parte. Qual segno m'avete voi dato d'amarmi? una falsa fede? un esser tornato incognito? e per che fare? forse per levarmi anco l'onore? come già mi levaste il giudizio, con farmi già credere che voi, che sète figliuolo di persona tanto ricca, volessi condescendere a tôrre una povera par mia? perché? per la mia nobiltà, la quale poco vale oggidì, non essendo accompagnata da ricchezza?</p>
             <p>Spogliatevi, spogliatevi, Lepido, di qual si voglia cattivo pensiero! Io son povera, e povera voglio morire, ma onorata.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>O signori, voi non la volete ancor finire, eh? Io vi ricordo che gli è un pezzo che voi chiacchierate. Lepido, che cosa ci è? Mi par che tu pianga il morto.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Deh, Scaramuccia, non mi dar fastidio, te ne prego.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Ecco ch'io mi ritiro.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Se ben mi ricordo, voi mi diceste che per non volervi io credere voi vi volevi dar la morte; questo a me ora non apporta fastidio alcuno, poiché son d'altri.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Non per apportarvi fastidio, signora mia, mi contento morire, ma per darvi contento.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Eh sì, voi non mi volete intendere! Sapete perché voi non mi potete dar fastidio? perché egli è molto tempo che voi siete morto per me.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Ed ecco, crudelissima donna, che pur confessate esser molto tempo che voi non m'amate, e che già ebbi morte nel vostro cuore! E chi sa che questo non fusse il primo giorno ch'io m'allontanai da voi?<pb n="315"/></p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>E chi lo può sapere meglio di voi?</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Come, meglio di me?</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Meglio di voi, sì; perché nel partir vostro partì anco il cuor mio e mi diceste poi d'avermi donato il vostro, non è vero? Se lo negate, darete contro voi stesso.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Non lo posso negare, signora Porzia, sì come non nego d'avervi lasciato il mio.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Non lo potendo negare, non negherete ancora d'esservi subito e in breve tempo scordato d'averlo, poiché mai non avete avuto pensiero di restituirlo, né d'osservargli le condizioni che voi gli promettesti nel riceverlo; e per questo dissi esser molto tempo che voi siete morto nel cuor mio e per me, e che un nuovo cuore v'impera e signoreggia.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Deh, crudelissima signora Porzia, è possibile che con le vostre sofistiche ragioni voi cerchiate atterrar quelle del più verace e fedele amante che viva? ch'io mi lasci imperar da altro amore? ch'io viva in altro cuore che nel vostro, Porzia mia? Ah non lo dite, che non sia mai vero! Anzi, non avend'io a viver per voi, non intendo di vivere per altri al mondo. E questa è la risoluzione ch'io già feci quando dall'inimico mio genitore non mi sia concesso di ritornar alla patria. E tanto maggiormente lo confermai, quando seppi voi esser maritata con altra persona che col vostro Lepido, il quale più d'ogn'altro vi meritava per la sua fede e per la sua costanza; onde però giustamente eravate sua, né d'altri esser potevi.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Fermatevi, Lepido, rispondetemi a questo, vi prego. Non entrate in tanta smania, di chi vi potete voi con ragione dolere?</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Di chi? del crudelissimo mio padre, della spietata fortuna e di voi crudelissima donna!</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Piano.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Parlate piano, in nome del diavolo, ch'io vi sento e sono un miglio discosto!</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Or ora, Scaramuccia! Sapete voi di chi v'avete a dolere? non di me, no, ma del vostro cuore.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Come, del mio cuore? forse perché prese albergo nel vostro petto?<pb n="316"/></p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Signor no. Ma perché, essendo egli nel petto mio, abbia potuto soffrire ch'io ne vada in poter d'altra persona.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Allàcciati quella stringa, o Lepido! Costei ha il diavolo addosso!</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Di ciò non mi maraviglio, signora Porzia, perché così felice si debbe tener il mio cuore trovandosi rinchiuso in così bella urna, che più non si cura di ritornare al suo nativo albergo; anzi, quivi si vive contento, e punto non cura di vedere estinta la maggior parte che nacque con lui. La quale poi, ciò conoscendo, una sol grazia gli chiede, che nell'udire o veder la sua morte voglia porgere tanto d'umore a gli occhi vostri, che mostrino un picciol segno di dolore e di pietade.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Tacete, Lepido, ché il vostro cuore ora ragionava meco e mi certificava che voi mi amate; ond'io, assicurata di ciò, vi prego che viviate e di più che vogliate ora tacendo insieme col vostro servitore da me subito partirvi, e il tutto fo per vostro bene e mio. Or così fate senz'altro e senza replica. E andate felice, non occorrono più altri inchini, né manco da te Scaramuccia, va' pur via ancor tu. E voi, signor Lepido, non mi guardate, vi prego, e partitevi, se mi amate.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>E io, Porzia?</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Sì, dico, vanne ancor tu, Scaramuccia, va' via! Potentissimo Amore, non d'altronde deriva la mia forza, che dal tuo immenso potere! Qual donna amando (come io fo l'amante mio) avrebbe fatta tanta resistenza come ho fatto alle dolcissime preghiere del mio caro Lepido? nessuna certo. Io, misera, ben mi sentiva consumar a poco a poco, come falda di neve esposta a i caldissimi raggi del sole, mentre ch'egli andava adducendo ragioni a favor suo, le quali sono pur troppo vere, onde finalmente mi sono pure assicurata, come bramava, dell'infinito e non finto amore che ancora mi porta Lepido mio. Già ormai s'avvicina il tempo di procurar la mia salute, e però senza più indugio voglio quanto prima tentarla. Ma ecco Brigida.<pb n="317"/></p>
           </sp>
@@ -3764,27 +3804,27 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">porzia</hi>
           </stage>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Ed eccoti di nuovo alle prime! Non t'ho io detto che tu non venga nella strada? Porzia, Porzia, tu vai cercando il tuo danno e la mia rovina; tu mi farai far di quelle cose e di quelle scappate, ch'io non ebbi mai in mente di fare! Ricordati che una volta sola si dà alla moglie, e col suo sangue si lava la macchia del perduto onore.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Uh, poverina me, che parole son queste? Eh, che non è più tempo di tener celato quel fuoco e quell'ardore che per sé stesso vuol manifestarsi, la casa mia arde ormai e abbruccia tutta d'amoroso fuoco, e già per le fenestre dell'anima mia si vedono le faville di così gravoso incendio. Sappiate che Lepido è fermo e costante nell'amor suo e me ne sono chiarita con infinita mia passione, poiché mentre ch'io l'ascoltava, fui quasi per cader morta.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Ora sia ringraziato il Cielo, poiché a voi leverà il dubbio e il dolore, e a me il lungo aspettare quello che tanto bramo. O quante vedove notti, o quanti amari digiuni abbiamo patiti; in fine poi, la natura patisce oltre modo, avendo per prova imparato a conoscer le dolcezze amorose. Di voi, Porzia, non dico nulla, poiché per ancora non ben sapete di che sapore siano i frutti del giardino d'Amore.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>S'io non gli ho gustati in atto, gli ho almeno provati in potenza, onde, come dite di voi ancora, la natura mia patisce ormai in estremo.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Porzia, quanto più tardi e quanto più bramati sono da noi, tanto più dolci e soavi ne pareranno. Entriamo, entriamo in casa, per dar fine al tutto.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Entriamo come vi piace, che un'ora mi par mille d'abbraciar Lepido mio.<pb n="318"/></p>
           </sp>
@@ -3799,140 +3839,140 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">scaramuccia</hi>
           </stage>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Io mandai quella ghiottoncella di Ruchetta da messer Gervasio insieme con Trapola e non torna né l'uno né l'altra. Infatti, il dare tanta libertà alle volte a i servidori è cosa più tosto dannosa che altro, perché si pigliano tanta baldanza, che poi diventano arroganti, insolenti e infingardi.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Che domine ha voluto inferire quella donna? Ma io ho veduto messer Demetrio dalla lontana ragionar da sé e tuttavia va ragionando; voglio osservar quello che dice, s'io potrò, standomene su questo cantone, per scoprir paese.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>O che allegrezza avrà avuta messer Gervasio della certezza di Giulia, che si contenti di volerlo per marito, al contrario di quello ch'io sento nel pensare ch'ella abbia a partirsi di casa mia! O poveretto me, io sento il cuore che per martello di lei mi si spezza e l'anima mia si divide in mille parti! O Giulia mia bella, o Giulia mia cara, come farò io senza di te?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>O questo sì, che mi mancava di sapere, il gatto vecchio va in frega! Do' che ti mangino i lupi in ripa a un fosso! Demetrio innamorato di Giulia, eh? Or questo non sapev'io, ma tutto è buono per me e ogni cosa torna a proposito mio. Voglio scoprirmi, per saper meglio questo novello amore.</p>
             <p>Buon dì, messer Demetrio, buon dì, padrone, io vi vedo<pb n="319"/> tutto turbato in viso, né mi parete più quello di prima; che cosa avete, sentitevi voi forse male?</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Male e d'un cattivo male, ve'.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Volete voi ch'io vada a chiamar il medico?</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>A questo mio male non giovano medici né medicine.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Che diavolo sarà! Avreste voi per mala sorte il cànchero che vi mangi? Se così è, quello è un cattivo male, perché altro rimedio non ha che dargli il fuoco.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Sì, dar fuoco a un carro di fascine, abbrucciarmi tutto e farmi in polvere! Eh, Scaramuccia mio, tu non mi pigli.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Il Bargello vi piglierebbe meglio di me al certo.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Voglio dire che tu non comprendi che male io possa avere.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Padrone, ad ogni male si trova rimedio. Ditemi, di grazia, che male è cotesto, ché forse potrei medicarvi per pratica, meglio che non farebbe un altro per scienza.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Perché si sfoga ragionando il cuore, io ti dirò quello ch'io sento; ma avvertisci a star cheto, perché è male che ama di star celato, occulto e nascoso.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Che diavolo di razza di mal sarà questo? Dite pur, padrone, ché io sarò segretario fedele.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Così credo certo, però, Scaramuccia mio. sappi ch'io, sappi ch'io, sappi ch'io... Non so se te lo debba dire o non te lo debba dire.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Se non me lo volete dire, vostro danno. Padrone, io vi ricordo che il male segreto, il male nascoso, più forte lavora.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Tu hai ragione, e mi sento crepare s'io non te lo dico.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Quanto prima sarà meglio.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Or odi. Quand'io penso che Giulia s'abbia da partir di casa e andar a inarito, ei mi scoppia il cuore.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>E quando debbe ella andare?<pb n="320"/></p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Stasera, e accompagnarsi con messer Gervasio.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>E per questo state sì scontento? e questo è il vostro male? Ah padrone, ora vi piglio, ora comprendo il vostro ragionare, voi siete senz'altro innamorato di Giulia, voi.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Al sangue d'un becco...</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Padrone, non giurate.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Che tu l'hai indovinata! Io muoio, io spasimo, io crepo per la bellezza di colei, e mi pento di non aver mai tentato di darli l'assalto doppo che morì suo padre.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Ora sì, che voi meritate ch'io vi dica vecchio balordo, vecchio insensato, vecchio poltrone, vecchio vigliacco, o vecchio traditore, vecchio vituperoso, vecchio infame.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Olà, olà, tu carichi troppo la mano, va' piano co' titoli, che diavolo dirai tu, sciagurato? che parole son queste?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Io non dico che voi siate tale, ma dico bene che voi meritate che vi si dica ogni gran vituperio, poiché avete tenuta la vitella di latte in tavola e avete mangiato di vacca.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Sempre sospettasti di Ruchetta.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Il sospetto nasce dall'effetto, ma ora s'io fussi in voi non vorrei più vivere al bacchio, né mettervi tempo di mezo, e vorrei essere il primo io ad assaggiare questa delicata vivanda.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>E come, Scaramuccia?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Lasciatene la cura a me, e s'io non vi servo, dite ch'io sono figliuol d'un becco! Voi, padrone, intanto state allegro, ch'io voglio che l'abbiate il primo senz'altro.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Se tu me la fai avere, voglio lasciar nel mio testamento che tu sia testimonio del mio codicillo.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>E sguazza cavallo, ché biada non manca! Ma ecco messer Gervasio e Ruchetta, che vengono ragionando insieme verso noi. Lasciate fare a me.</p>
           </sp>
@@ -3945,147 +3985,147 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">scaramuccia</hi>
           </stage>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Ben trovato, messer Demetrio.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Ben venuto, messer Gervasio. Io veggo con voi Ruchetta, mia serva, che mi dà segno che di già abbiate saputo come Giulia mia si contenta d'esser vostra. Oh non l'avess'io mai detto! oh caduta mi fusse la lingua, ohimè! che dolore e questo!</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Ohimè, che vuol dire? ch'avete, messer Demetrio?</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>A dirvi il vero io son aperto di sotto, e porto il brachiere; però di quando in quando mi pigliano i dolori.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>O che vecchio maledetto, parti che l'abbia trovata.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Évvi passato anco il dolore?</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>A poco a poco.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Si condurrà su le forche.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Messere, volete voi ch'io vada per l'orinale? Provatevi a pisciare quattro gocciole, ché vi gioverà assai; o pure volete ch'io vi porti il cantero?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Sì, e ammorbar la vicinanza.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>No, ch'io non ho bisogno di nessuna di queste cose. Scaramuccia sa il mio male e come egli si può risanare.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Con un buon bastone! Padrone, allegramente, perch'io vi sanerò in breve.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Oh oh, m'è passato un poco. Cavalocchio, i dolori colici sono molto cattivi! Oh lodato sia il Cielo, io non mi sento più nulla. Ora, tornando a noi, credo che Ruchetta v'abbia detto che Giulia vi vuol per... Ohimè, ohimè, che mi ritornano, ohimè che mi si gonfiano, o poveretto me, aiuto, soccorso, chi mi dà aiuto?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Il boia.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Signor mio, questo vostro male è molto cattivo e molto pericoloso.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Padrone, provatevi a tirare una correggi, fate un poco di vento! Uh, signore, la sanità è pure un bel tesoro.<pb n="322"/></p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Poi che questo male vi piglia così spesso, sarà ben fatto che ce ne entriamo qui in casa vostra, e quivi fra qualche ora, quando starete bene, tocheremo poi la mano alla sposa.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Fermatevi, ché mi passa con l'aiuto ricordatomi da Ruchetta. O quanto mi ha giovato questo poco di vento.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Si sente, poi che dal vostro lato viene molto puzzolente.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>S'io non tirava questa coreggia, stava molto male; ora mi pare d'essere ringiovenito. E per seguitare l'ordine del cominciato ragionamento, ella vi vuole e sarete suo marito.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>O sia lodato il Cielo! E perché gli è costume di ciascuno che piglia moglie, di mandar le gioie alla sua cara sposa, io non ho voluto mandarle ma portarle con le mie proprie mani. Eccole qua, che vi pare di questo diamante? che dite di questo rubino? che di questi pendenti? che di questa collana? che di queste perle di valore? mi son io portato bene?</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Benissimo, e sarete cagione che la sposa vi farà più carezze nel fine che nel principio.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Par bene che le spose si rallegrino quasi più delle gioie che de' mariti, perché quelli passano e quelle rimangono sempre appresso di loro.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Sì, le donne avare fanno così, ma quelle che vogliono bene ai mariti, darebbono tutte le gioie del mondo per una buona notte.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Scaramuccia, va' in casa e di' a Giulia che si ponga all'ordine e che poi se ne venga teco nella strada.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Io v'ho, messere.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Dove?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Nel... con reverenzia parlando! In casa, come m'avete detto.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Toccata che voi avrete la mano a Giulia, messer Gervasio, e datole le gioie, quando fate voi pensiero poi di far le nozze?<pb n="323"/></p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Questa sera alla più lunga.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>O diamberne, egli è troppo presto! Bisognerebbe, pare a me, prolongarlo o differirlo a qualche altra sera, per fare come si conviene.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Quando il pane è lievito, bisogna infornarlo e non aspettare che si ammoscica e diventi agro.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Egli è cosa impossibile far le nozze stasera, perché ormai abbiamo poco del giorno, non s'è fatto provisione e non si sono invitati i parenti. Talmente che non sarebbe se non bene indugiare almeno a domandassera.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Farò quello che voi volete, ma vi ricordo che questa notte potrei fare acquisto d'un figliuol maschio, che, se io indugio a domandesera, potrebbe esser poi femina.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>No, no, concludiamola pur così: che domandesera si facciano queste nozze senza fallo e con quell'ordine che vi va, per onore dell'una e dell'altra casa. Ruchetta, chiama coloro. Che cosa fanno eglino, che non vengono?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Ora, padrone; ma eccoli, che egli escono di casa.</p>
           </sp>
@@ -4097,279 +4137,279 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">ruchetta</hi>
           </stage>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Fatelo sopra di me e non vi pigliate altra cura. Padrone, siam qua tutti allegri, tutti gioviali, e la signora Giulia più d'ogni altro, parendole un'ora mill'anni d'aver messer Gervasio per marito.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Che ne dite, messer Gervasio? É questa una cavallina da far correre due o tre poste senza cavarle briglia?</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Senz'altro, ma questo disordine non lo farò già far io.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Senza che voi lo diciate, lo credo pur troppo.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Che mi comandate, messere?</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Non tocca più a me a comandarti, ma sì bene a tuo marito.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>E qual marito?</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Par che tu non lo sappia.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Queste sono le prime parole.<pb n="324"/></p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>O messer Demetrio, che promesse son dunque le vostre?</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Fermatevi, in cortesia. Vieni un po' qua, Giulia; non ti diss'io che ti aveva promessa per moglie a messer Gervasio Grifone, e tu mi rispondesti che vi volevi pensar sopra, e poi mi facesti dir per la serva che tu eri contenta?</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Questi sono i primi avvisi che vengono dal regno delle malmaritate. Messere, non occorre trattare di darmi marito, perch'io non voglio altro marito che voi, o per dir meglio, altro padre. Io non mi voglio partir di casa vostra, perch'io vi porto troppo amore.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>E io a te, bambolina mia.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>O Demetrio, ei mi pare che voi amoreggiate insieme! O càzzica, questa cosa comincia a puzzarel Ma che s'ha egli a fare?</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Or ora!</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Or ora? Mi par che la non mi voglia, e dice liberamente non saper cosa alcuna.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Non ve ne maravigliate, perché la fanciulla non è avvezza a pigliar marito, e per questo fa la ritrosa.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Signora Giulia, voi guastarete la minestra! Dite che lo volete e fatelo sopra di me, come vi ho detto.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Piano, di grazia. Signora Giulia, mi volete voi per marito o non mi volete?</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Messer Gervasio, perdonatemi se alle prime parole di messer Demetrio dissi di no; è che non sapevo cosa alcuna, perché lo dissi spinta dal grande amore che io le porto (e ch'io amo e onoro come padre) e però sappiate che il voler mio è conforme al suo e al vostro, e volentieri vi accetto per marito.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>O così si sviluppano le matasse! Che ne di', Scaramuccia?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Mi pare che voi l'intendiate. Ma vi sarà chi l'intenderà meglio di me, vecchio balordo.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Messer Demetrio, son qua, fatevi innanzi. Fatti innanzi, Ruchetta, e tu, Scaramuccia, perch'io voglio che voi siate testimonii al toccarle la mano e de' presenti ch'io le voglio fare.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Eccomi.<pb n="325"/></p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Son qui.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>E io comparisco per terzo, non so se testimonio o altro.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Orsù, Giulia, porgi la mano a messer Gervasio; e voi, messer Gervasio, porgete la vostra, in segno di matrimonio.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Fate che sia il primo egli a porgerla, ch'io non voglio esser la prima.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Ella ha ragione, la vuole esser la prima a star di sopra.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Né di sopra né di sotto, teco non starà ella, vecchio pazzo!</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Eccovi la mano, madonna Giulia mia bella e galante, sposa mia inzuccherata.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>E io vi do la mia, per segno delle nostre nozze.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Buon pro vi faccia, messer Gervasio, sia con buona ventura e con un bel bambino in capo all'anno.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Buon pro, signora Giulia, vi poss'io vedere come le cipolle, doppia e grossa nel traverso.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Sarà quello che piacerà al Cielo, n'è vero Scaramuccia?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Signora sì e senza fallo alcuno.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Io riserbo a far teco, o Giulia, la parte dovuta delle mie cerimonie in casa poi con miglior comodità. Messer Gervasio, presentatele le gioie e gli ornamenti da sposa.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Eccomi, moglie mia cara. Date qua la vostra delicata mano, pigliate in dito questo diamante e questo rubino, mettetevi questa collana d'oro gioiellata al collo, ponetevi questo vezzo di perle alla gola, e questi pendenti a gli orecchi, ch'io mi riserbo poi a darvene un altro paio, che sanno di musco e d'ambra.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Più tosto di muffa e di lezzo!</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Marito mio e signor caro, io vi ringrazio di così bei presenti, i quali vengono dalla vostra gentilezza, e non dal mio merito.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Voi meritate tanto che tutto l'oro del mondo non potrebbe supplire al gran merito vostro! E con questo vi bacio le mani, se bene mi toccherebbe a baciarvi la bocca.<pb n="326"/></p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Serbàtela a miglior occasione! Messere, con vostra licenza, e di mio marito, io me ne intrerò in casa.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Entra, ché anch'io me ne vengo.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Scaramuccia, ricòrdati del mio servizio, sai?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Me ne ricorderò. ora che noi siamo rimasi soli, io vi ho da dire, messer Gervasio mio, una buona cosa per voi.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Che buona cosa è questa?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Una cosa dolce più che il zucchero e la manna.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>E di donde viene?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Di val pelosa.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>E chi me la manda?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Messer poco in testa.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Chi è costui?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Mercante da corni.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>E che vuol egli da me su le nozze? Aspetti un poco.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Vuol trattar mercanzia con voi.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Con me non mercantamenterà egli, perch'io non voglio sua mercanzia.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>E perché? Io vi ricordo che simil merce fa ricche di molte persone senza briga.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Io non mi curo di questo traffico.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Eh, messer Gervasio, più su sta mona luna.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>C'ha da far la luna nelle mie nozze?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>A darvi la moglie bella, casta e onesta.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Non la voglio casta io, ma la voglio come s'usano l'altre mogli.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Avete molto ben ragione, e questa vostra volontà va con la volontà della signora Giulia, la quale anch'ella non vorrebbe tanta castità, ma vorrebbe questa notte trovarsi con voi; se bene non ha avuto ardire di dirlo alla presenza di messer Demetrio per sua modestia. Ma in casa mi ha bene caldamente pregato ch'io faccia ogn'opra perch'ella dorma con voi sta notte, se possibil sia.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>O vita mia cara, lo dissi ben io ch'ella era guasta di me! Inquanto a me, fa' tu, ché io me ne contento. Ma che via, che strada, che ordine s'ha egli da tenere, per ritrovarsi insieme senza biasimo?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Voglio che voi, sulle due ore di notte, vi lasciate trovar qui alla porta di casa nostra, e giunto che sarete,<pb n="327"/> spurgatevi forte tre volte, ché io a quel segno verrò giù e aperto l'uscio segretamente vi condurrò in casa e nella camera terrena, sin tanto che tutti vadano alletto e che s'addormentino; e poi vi condurrò alla camera propria di Giulia vostra, che vi starà aspettando, che ne dite? In ogni modo l'ha da esser vostra.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Bene, bene, tanto bene, che non si può dir meglio, perché in ogni modo l'è mia, come tu di', e l'indugio piglia sempre vizio; chi sa quel che sarà stasera non che domani.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Orsù, voi dite bene, entratevene in casa vostra e mandatemi Trapola, vostro servidore, or ora, per cosa che importa per questo servigio.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Tanto farò, notte felice e lieta a' piacer miei; io entro.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Entrar possi tu nell'inferno, vecchio stomacoso! O come bene si sono accordati questi due vecchi rimbambiti! Ma la cosa andrà molto diversa dal creder loro, perché io mi risolvo di far contenti i giovani e mandare sulle forche questi vecchi arrabbiati. Perché costoro oggi o domane se ne anderanno a Volterra e i figliuoli rimarranno a darsi piacere e buon tempo.</p>
             <p>Olà, a chi dich'io, o Trapola, olà, vien fuora!</p>
@@ -4382,95 +4422,95 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">scaramuccia</hi>
           </stage>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Son qua, che diavolo hai tu nella gola? Tu hai quasi messo a romore tutta la vicinanza, con tanto gridare.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Io pensava che tu fossi sordo.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Son la fava! Io sento con gli occhi, e veggo con gli orecchi, quanto un altro par mio.<pb n="328"/></p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Così si parla gramaticalmente. Di' il vero, Trapola, tu sei andato da fanciullo alla scuola di gramatica, n'è vero?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Messer no, ma son ben giudizioso naturalmente. Ma che vuoi tu da me?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Trapola mio, sappi che Ruchetta, ancor che tua moglie, è talmente guasta de' fatti tua, che non trova luogo che la tenga.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>O poverina, me ne sa male.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>E hammi detto ch'io ti trovi e che da parte sua ti dica che vorrebbe sta notte trovarsi a dormir teco, in ogni modo.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Meco a dormire? Messer no, io voglio che la venga meco a vegliare, per provarmi s'io posso acquistare un bel Trapolino ! Ma come si ha da fare, per dar questo contento a</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>? Come vuoi tu guidare questa barca, ché la non vadi affondo o si rompa in qualche scoglio?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Te lo dirò: io ho pensato che alle due ore e meza di notte tu ti travesta in casa tua da donna e, travestito che tu sarai, te ne venga sotto le nostre fenestre e quivi, picchiando due sassi insieme tre volte, mi facci segno d'esser comparso. Io allora me ne verrò fuora, e cheto cheto ti menerò in casa per metterti poi al suo tempo con Ruchetta. Che ne di'?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Che vuoi tu ch'io dica? S'io mi vesto da donna, sarò forse come una donna; e se tu mi metterai con Ruchetta a quel modo non potrò far nulla, perché grattugia con grattugia non fa cascio.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Deh, balordaccio, o senti quel ch'egli dice! Ché tu credi forse, vestendoti da donna, diventar una donna, eh? O bestiaccia, gli è passato il tempo delle trasformazioni, e poi non tocca a te il trasformare, tocca a Ruchetta a trasformarti in quello che tu saprai col tempo.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Come sarebbe a dire, in che?<pb n="329"/></p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>In un bel becco, in un castrone, in un cervio, che so io!</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Oh oh, faccia quel ch'ella vuole, in ogni modo non sarò il primo né l'ultimo, perché le donne quando vogliono sanno così ben fare, che se il marito avessi a ogni congiuntura un occhio, non vedrebbe mai cosa alcuna; e poi il disonore sarebbe il suo e la vergogna ancora, perché chi fa falla.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Buon, per mia fé! Non parliamo più di questo, perché non vi sono questi pericoli: Ruchetta è buona fanciulla, savia, onesta, e dabbene.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Così bisogna credere nel pigliar moglie, e raccomandarsi poi alla buona fortuna.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Questo va in forma, perché delle donne non se ne sa mai un vero. Orsù, non perder tempo, perché s'avvicina la sera. Vattene pure in casa, e di' alla signora Porzia ch'io ho grandissimo bisogno di parlarle e che venga, ch'io l'aspetto qui sulla porta.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Io entro a far quanto tu m'hai detto. O se Ruchetta mi riesce nelle mani come io spero, Scaramuccia, io voglio che tu l'assaggi, perché mi sappi dire di che sapore ella sia!</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>D'aringhe o di tonnina, senza ch'io la provi. Deh, animalaccio, son queste cose da dire, eh?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Messer no, ma sì ben da fare! Io vo.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Va' nella malora.</p>
           </sp>
@@ -4482,267 +4522,267 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">scaramuccia</hi>
           </stage>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Scaramuccia, o Scaramuccia, dove sei?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Oh il messere che mi domanda; io lo voglio far arrovellare un poco.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Tu non m'intendi, n'è vero? Scaramuccia? dove diavolo sei cacciato? Scaramuccia, se' tu in cantina a imbriacarti al tuo solito?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Messere, che volete?</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Dove sei?<pb n="330"/></p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Non so dove.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>E chi lo sa?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Voi lo sapete.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>S'io son in casa, come lo posso sapere?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Signor sì, perché s'io non sono in casa, voi sapete ch'io son fuora.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>O bell'argomento selvatico! Aspettami costì, ch'io ne vengo.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Venite e fate presto.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Eccomi qua. Che abbiamo noi di nuovo, Scaramuccia galante? non ti ricordi tu di quello che tu m'hai promesso?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>E che credete ch'io sia qualche smemorato? Signor sì, ch'io me ne ricordo.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Se tu te ne ricordi, perché non cominci a metter all'ordine il negozio che tu sai?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Se avrete pazienza, mangerete i tordi a un quattrino l'uno.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>I tordi me li so pigliare alla frasconaia e a prugnolo senza spendere.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Se sapete così ben uccellare, perché non pigliate questa tordela di Giulia da voi?</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Perché questa bisogna pigliarla con la tua panìa, Scaramuccia.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Ah, ah, pur lo direte una volta!</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Scaramuccia, avvertisci che non bisogna lasciar passar questa notte, perché poi non si farebbe nulla per amor di messer Gervasio, che però ho dato tempo al tempo seco.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Lo so così ben come voi; e che credete, ch'io dorma? Orsù, notate ben quel ch'io vi dico.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Io comincio a nôtare in un mar di latte, di mèle, di zucchero, e di...</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>E di... sto per dirlo! Io voglio che voi ve ne entriate in casa e che, finito di cenare, colà, verso le due ore e meza di notte, mi stiate aspettando ch'io vi debba far un segno.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>E dove?<pb n="331"/></p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Dove? sul mostaccio! Che segno, bisognava dire.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Tu hai ragione. Amor mi leva l'intelletto e la memoria.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>E però delle tre potenze dell'anima resta solo la volontà. Il segno sarà questo: ch'io fischierò tre volte, e come voi sentirete un cotal segno venite all'uscio, ch'io vi condurrò Giulia.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Come, mi condurrai tu Giulia, s'io l'ho in casa?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Voi non sapete il restante della favola, e acciò che voi la sappiate, messer Gervasio m'ha pregato e ripregato ch'io lo metta stanotte a dormir con Giulia nella sua camera, perché non può più stare, e io gli ho promesso di mettervelo senz'altro.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Tocca a me a mettervelo! Olà, Scaramuccia, perché prometterli quello che questa notte debb'esser mio?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Fermatevi, se voi volete. Voi non sapete per quante strade si viene a Roma. Io voglio, sull'ora che io ho detto, condur Ruchetta da messer Gervasio, il quale si crederà ch'ella sia Giulia, e darò a credere al vecchio ch'ella non ha voluto godersi seco in casa vostra per non vi far torto.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Piano un poco. E come così Ruchetta si contenterà d'andare da messer Gervasio?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>State pur a sentire: Ruchetta è innamorata di Trapola e io gli ho promesso di menarla a dormir seco e darglielo per marito.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Tu prometti a tutto il vicinato, il Cielo te la mandi buona.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Nel fine ve ne avvedrete. Io su quell'ora, dico, verrò per la signora Giulia, fingendo di volerla condurre a messer Gervasio, e caminato che averemo alquanto, mi volterò per qualche stradello e la rimenerò a casa, e così, allo scuro, la metterò nella camera terrena e senza lume, là dove, aspettand'ella, anderete voi e ve la goderete, in persona di Gervasio.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>O buono, o buono! Ma che condurrai tu in cambio di Giulia a Gervasio?<pb n="332"/></p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Voglio condurvi Ruchetta, non ve l'ho detto? E perché la cosa passi con buon ordine, ho detto a messer Gervasio che Giulia si vergognerebbe di lasciarse godere a lume acceso e che per ciò metta all'ordine la camera terrena, senza punto di lume, e di più gli ho detto che anderà con altri panni da donna, per non esser conosciuta da chi l'incontrasse.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Tu ordisci molto bene questa tela amorosa, al tesserla poi ti voglio !</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Lasciate pur fare a chi sa traimare, ordire e tessere.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Pur che questa non sia la tela d'Aragne, che alla fine la fe' restare impiccata, ogni cosa anderà bene.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Padrone, voi mi fate stupire, sentendovi parlare poeticamente.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Io mi ricordo ancora di quello ch'io leggeva quando andava alla scola di Gramatica, di Logica, di Rettorica, e di quello che seguita.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Bembè, questo è assai, in questa età quasi decrepita, ricordarsi dell'opere di Vergilio e de gli altri poeti.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Che età decrepita? Tu mi fai venir voglia di ridere con questa decrepità! Che tempo credi tu ch'io possa avere?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Credo che voi abbiate intorno a sessanta, settanta, ottanta o novanta cinque anni, con la rivolta attaccata al culo, che fanno circa cent'anni.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Io ho il malanno che ti venga, balordo! Io ho finiti quarantacinque anni, quaranta anni sono: e ti par ch'io sia decrepito?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Non è stronzo, ma il cane l'ha cacato.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Eh, Scaramuccia, vecchi e decrepiti son quelli che<pb n="333"/> sono mal sani e di cattiva complessione; a me basta d'esser gagliardo, robusto e forte acciaiato.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Al vostro dire, voi siete un uomo di ferro, e più.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Ben sai, e lo saprà ben Giulia, quella leggiadra cavallina, quando l'avrò sotto, quante miglia le farò far per ora.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Vàntati, cesto, ché tu hai un bel manico!</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Giulia lo proverà! Ma dimmi un po', Scaramuccia, posto che tu averai e Giulia e Ruchetta in queste camere terrene (come tu di'), come farai tu poi a cavarnele, sì che non si conoschino i tuoi inganni?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Vi dirò, messere, io non aspetterò che si faccia giorno, ma un'ora innanzi l'alba, anderò per le donne e ognuna d'esse ritornerò a casa sua.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Tu sei un valentuomo, e molto prattico. Di' il vero, Scaramuccia, tuo padre e tua madre furon eglino ruffiani?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>L'uno e l'altra di loro tenevano scuola publica di ruffianeria nell'Ortaccio e in piazza Padella.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Dissi ben io che il lupo non partorisce agnello! Ora il tutto sta bene, pur che riesca.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Io non ci trovo una difficoltà al mondo.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Orsù, la sera ne viene e sarà meglio ch'io me n'entri in casa e ch'io cominci ad armarmi per l'amorosa giostra.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>E che sorte di arme saranno le vostre?</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Marzapani, calicioni, pistacchiate, confetti, e buona malvagìa di Candia o greco d'Ischia.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>O se oggidì s'usassi d'armar così i soldati, quanti ne andrebbono più alla guerra, eh? Ma, o messere, ricordatevi poi di non la strapazzar tanto, ché di veste bella e nuova la non diventi una sguarnaccia da pinzocchera.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>E lascia fare a me, ché questa non è la prima giumenta ch'io m'abbia domata, ve'!</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>So che sète buon cozzone, andate pur là.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Scaramuccia, io entro dunque in casa per spedirmi.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Entrate vivo e uscite morto quanto prima! Pur mi si levò d'intorno questa mosca importuna, anzi questo noioso<pb n="334"/> mosconaccio che mi stomacava; tanto più che io ho vista, se non m'inganno, la signora Porzia che fa capolino alla fenestra.</p>
           </sp>
@@ -4754,363 +4794,363 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">scaramuccia</hi>
           </stage>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Io accommiatai Lepido mio e Scaramuccia in modo tale ch'io mi credo che nessuno di loro averà più ardire di lasciarsi vedere da me, e avrò fatto come colui che soffia nella polvere, che da per sé stesso e non volendo si fa male a gli occhi.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Ella è dessa e ragiona da sé, voglio salutarla. Servitor di vostra signorìa, signora Porzia.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>O che vai facendo? che è di quell'amico sì fatto? di quello, dico, che muore e rinasce mille volte l'ora?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Eh, signora Porzia, quanto fareste voi meglio a disingannarvi una volta e credere a quell'infelice di Lepido!</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Scaramuccia, non ti partire, aspettami, ch'io voglio ragionar teco un poco più d'appresso.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>La mula ha sentita la biada e comincia a far la schiuma alla bocca.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Eccomi, Scaramuccia, che di' tu di Lepido?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Dico ch'ormai sarebbe tempo di credere alle sue ragioni, e di rimediare a quel male ch'è per succedere.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>E che male?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Che male? la morte.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>La morte di chi?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>La morte di Lepido, o di Licinio vostro marito, perch'egli non può comportare di veder il suo bene in mano altrui.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Ed è possibile che Lepido sia così disperato?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Disperatissimo affatto, e se non vi rimediate, vedrete forse ancora la vostra morte.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Perché la mia morte?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Perch'egli, come disperato amante, acciecato dalla passione, senza alcun riguardo, ammazzerà il primo che li<pb n="335"/> darà alle mani; però guardatevi ancor voi e trovateci rimedio, perché non può stare a dar volta di qua.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Che rimedio vuoi tu ch'io trovi? Uh poverina me!</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Il rimedio l'ho trovat'io, quando voi vogliate e come ve ne esorto.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Che rimedio è questo? e che medicamento a tanto male?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Quel medicamento che si fa sotto le lenzuola, quella tasta che si mette nell'amorosa piaga.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Eh, Scaramuccia, tu sei sempre sulle burle! Parla ora sul saldo.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Questo ch'io dico salderà ogni male, credetelo a me.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>E pur là...</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>E pur là debb'egli andare e colà sta bene.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Tu mi par un cicalone ormai.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>E voi una cicalina che voglia morir cantando.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Orsù, finiamola. Ch'è del signor Lepido? Io so che si partì molto sconsolato da me.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Anzi sconsolatissimo.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>E dove andò?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>E dove pensate? A passarsi il martello a casa d'una bella cortigiana venuta novellamente qui a Roma, la più bella figliuola che si possa vedere, virtuosa, buona, canta, balla ed è in ordine come una principessa.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Ohimè, che sent'io? Adunque Lepido mi fa copia della sua persona ad altra donna? ad una meretrice? O meschina me, non fuss'io mai nata, più tosto che udir nuova tale!</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Non vi disperate, signora Porzia.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Tu non vuoi ch'io mi disperi, che quando che di già aveva quasi stabilito di contentarlo, e ora (lassa me) mi veggo cader di mano ogni speranza.<pb n="336"/></p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Ah, ah! Perché cadute le vostre speranze? credete voi forse che Lepido sia andato a casa di colei per goderla? Eh, signora, no. Egli v'è andato, come fanno di molt'altri gentiluomini, a ridutto, e per passarsi il tormento in compagnia, poi che in quella casa si fa ridutto di gioco, di musica e d'altri onesti trattenimenti. Lepido toccar altra donna? e far torto alla signora Porzia? queste son tutte cose che trattano dell'impossibile, impossibilissimo.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Tu m'hai ritornato lo spirito e la vita.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Meglio ve lo ritornerebbe Lepido.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Senz'altro.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Orsù signora, fate conto di aver smarrito di nuovo lo spirito, e mandate, fate a mio modo, a chiamar Lepido vostro, che ve lo metterà e finiamola una volta!</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Misera me, io mi ritruovo tra i calci e 'l muro, tra Cariddi e Scilla, e tra l'incudine e il martello, né so quello che mi debba fare.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Pigliare il manico in mano e batter sopra la vostra incudine e lasciar sommerger la nave con l'albero, col timone e con tutto il restante, e spedirla una volta, senz'altre chiacchiere! Lepido non vede l'ora d'esser con voi e voi, per quello ch'io vedo, ne avete una gran voglia, se bene non lo volete dire, n'è vero?</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Ahimè, che gli è pur troppo vero, e mi bisogna allargar il freno alla mia volontà, la quale sin ora è stata ristretta in durissimi confini. Scaramuccia mio, vinta da' tuoi preghi e dal gran merito di Lepido, mio signore, finalmente mi risolvo e voglio contentarlo senz'altro.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>O sia ringraziato il manico della mestola! Io ho pur caro che voi abbiate fatto, giusto giusto, come fa il can da pagliaio, che abbaia, abbaia, e all'ultimo si tira la coda tra le gambe.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Son donna, Scaramuccia, né le donne sanno far altro. E poi che a questo debbo venire, voglio governarmi con giudizio, come fanno le donne savie. Io non trovo altro spediente<pb n="337"/> a questi nostri voleri, che questo che tu sentirai ora, e senza l'aiuto tuo e tuo pericolo non si può far nulla.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Fate pure ch'io sappia quello che ho da fare, ché del pericolo poco mi curo e son pronto a servirvi.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Avvertisci a quello che tu prometti?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Che? per Lepido? son pronto fino al morire! Dite pur sù.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Orsù, ascolta. Io voglio che alle due ore di notte, e ancora più tardi, tu conduca il signor Lepido a casa mia, facendo un qualche segno, dal quale io possa conoscere l'arrivo vostro, che, da me sentito, subito verrò, cheta cheta, ad aprir l'uscio, e darò entratura a Lepido e lo condurrò nell'appartamento dell'orto, là dove starà poi aspettando l'ora del venir mio.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Benissimo e mi piace. Sapevo ben io che donna savia fa figliuoli.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Io poi me ne anderò a letto con mio marito, e, quando egli sarà nel profondo del sonno, mi leverò pian piano e anderò a trovar Lepido mio.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Bene, benissimo, non si può far meglio!</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>E se mio marito in quel mentre (come suol far dormendo) per caso stendesse una gamba o un braccio per toccarmi e non mi trovasse, io ho pensato al modo di potermi assicurare.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>O buono, o buono, o questo sì ch'è il zucchero sulla torta! Ma come farete?</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Ascolta, io ho pensato che a tutto questo rimedierai tu.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Dite pure arditamente, perché per ancora non veggo d'aver che fare; e pur vorrei servire a tutti due di buon cuore.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Senza l'opera tua non si può far nulla. Ma venghiamo al pericolo che dianzi t'accennai. In quel punto che Lepido verrà in casa, io voglio che ancor tu ci venga e sia seco nell'istessa camera, e tu ancora stia aspettando la venuta mia, la quale sarà subito che mio marito si sarà addormentato bene. E allora, gionta ch'io sarò nella vostra camera, voglio che tu ti spogli in camicia, che tu ti metta una cuffia da<pb n="338"/> donna in capo, e, venendo meco, io stessa ti condurrò alla camera mia e ti metterò in letto accanto a mio marito.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Come diavolo, accanto a vostro marito?</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Accanto a mio marito, sì. Perché egli, trovandosi così mezo addormentato, crederà senz'altro che tu sia la sua moglie e così io averò campo largo di starmene con Lepido mio tutta la notte intera. Tu ti gratti il capo?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>L'invenzione è bella e buona, ma alquanto pericolosa, anzi pericolosissima. Come domine, ch'io mi spogli in camiscia, mi metta una cuffia da donna in capo e stia tutta la notte accanto a vostro marito? Questo latino, affé, non mi farete voi fare, né me lo insegnò mai il mio maestro! Eh, signora Porzia, dite voi da vero o pur burlate?</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Vedi s'io burlo. Come tu non ti risolva di far quello ch'io t'ho detto, noi non abbiamo fatto nulla, abbiamo fabricato in aria e seminato nell'arena, sì che non bisogna pensarvi più punto, Scaramuccia, ve'?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Adagio un poco, mia signora, voi avete voluto pensarvi sopra molto bene voi, e avete a godere ed è bisognato farvi mille fregagioni a ridurvi al fatto. Lasciate di grazia che io, che non ho se non da stentare, faccia anch'io i miei conti. Io entro in letto, Licinio mi sente e stende una mano, metto il capo fuor del letto, egli va più giù, io gli volto la schena, egli crede che sia il petto... eh no, che gli è troppo grosso!</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Eh sì, tu l'assottigli troppo.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Signora, voi avete un bel dire, e' ne va del mio!</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Orsù, noi non farem niente.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Adagio un poco! Stende la mano di nuovo, cerca la rosa, e trova un pruno; egli grida, si leva il romore, il pugnale in campagna. Tant'è, signora, io non ci trovo ripiego.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Vanne dunque in tanta malora.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Aspettate, di grazia. Mi metto per fianco con la schiena verso lui, mi cerca il petto, trova le spalle, tenta di nuovo e trova il petto peloso, va più abbasso, trova che pigliare... In fatti, male per un verso e peggio per l'altro. Tant'è, tant'è, e' non ci è verso!<pb n="339"/></p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Quando sia quel che tu di', che sarà poi? Io, per me, non avrei tanta paura.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Ah sì, a voi non costerebbe nulla, perché come giovane donna per ogni disgrazia avete ripiego da sodisfare in ogni modo ad un commune, non che ad un uomo solo! Ma io, che non ho quel che vi avanza e mi abbonda quel che vi manca, qua pars est? Tutte l'altre son burle, ma se vostro marito, tentato dall'umor venereo, volessi (così mezo imbriaco dal sonno) imbizzarrito, sfogarsi come egli potesse? Signora, il panno vecchio stintia. E se mi trovassi maschio come lui e dessi però delle mani sul manico dello scaldaletto, che partito doverebbe essere il mio? O qui vi voglio, signora Porzia!</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Chi pensassi sempre a i pericoli non farebbe cosa alcuna; gli eventi delle cose, molte volte, fanno risolvere le persone a pigliare partiti non pensati.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Signora Porzia, voi avete un bel dire voi, io vo a pericolo di perder la vita e di già mi vedo bello e scannato e tutto sangue come un porco.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Non ti dubitare, no, perché mio marito, come s'addormenta, subito fa un sonno solo sino alla mattina; e poi egli non mi tocca mai, se non ogni mese una volta.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Il mese quant'è che cominciò?</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>É poco, e ha avuto di già quello che voleva e così se ne starà sino al fine.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Pur ch'ella sia così, ogni cosa passerà bene.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>La cosa sarà sicurissima, non dubitare.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Sicura eh? Servire in cambio d'una donna, mettersi in camicia accanto al marito, e non aver spavento? Per dirvela, mi pàre una cosa molto dura da credere! Ma aspettate un poco, signora, di grazia: non sarebb'egli meglio che Lepido si spogliassi egli in camicia, venissi alla camera vostra e mettersi in letto del canto vostro e voi starvene nel mezo? Perché, se venisse qualche tentazione a vostro marito, potrebbe cavarsela, e raddormentato ch'egli fusse, lavorar voi dall'altra banda di nuovo alla muta e alla sorda.<pb n="340"/></p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Un amoroso gaudio a lume spento nulla non vale! Io voglio poter mirare e rimirare Lepido mio e ch'egli parimente vegga il volto e il petto dell'amata sua donna, senza alcun sospetto; e voglio che, all'incontro, l'incomodo sia d'altri e non il mio. E guarda ve', Scaramuccia, come tu non ti risolva andare appresso a mio marito, ogni cosa va in fumo. E per dirtela, tu m'hai stracca ormai con tante difficultà.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>State un poco ferma.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Io non mi muovo.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Sia maledetto quando mai mi posi in questo intrigo, guarda se il diavolo ha trovato un bel modo di farmi ammazzare! Non si potrebbe mettergli accanto una qualche donna di bassa condizione e pagarle la manifattura?</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Sì, per far sapere a tutta Roma i fatti nostri!</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Avete ragione. Ma chi trovasse modo di fare che vostro marito per una notte dormissi fuora di casa?</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Mio marito dormire una notte fuora di casa? volessero il Cielo! Ma non bisogna trattarne, perché non vi si ridurrebbe mai, per l'estrema gelosia ch'egli ha di me. In somma, pensa e ripensa quanto tu vuoi, questa sola è la sola via, e questo ci vuole: che tu vada a metterti accanto a mio marito per cinque o sei ore, e non ci è altro rimedio.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Ma aspettate, facciamo un'altra cosa: mettiamo Lepido con vostro marito e voi venitevene a star meco. To' to', che balordo ch'io sono! La pavura mi fa dir di gran cose, perdonatemi.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Dirò, come disse Rodomonte ad Orlando:«Sol per signori e cavalieri è fatto il ponte, e non per te, bestia balorda».</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Me la sapeva anch'io, ma burlava così con vostra signorìa. Orsù, risoluzione! Andate, entratevene in casa, ché all'ora terminata tra di noi verrò con Lepido, faremo il segno, entreremo in casa, mi spoglierò in camicia, mi metterò la cuffia in capo, anderò a stare accanto a vostro marito, per darvi comodità di correre quante lance amorose voi<pb n="341"/> vorrete, e così sarete piena. Che sarà mai? che dite? volete altro?</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>O Scaramuccia mio caro, comanda poi anco a me. Dunque va' e trova il signor Lepido, raccomandami a lui, e fallo consapevole del tutto.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Tanto farò, servitore di vostra signorìa. Eh, povero Scaramuccia, vedo ben io che gli altrui comodi saranno il precipizio tuo, il Cielo m'aiuti!</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Addio, addio Scaramuccia, non dubitare.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>No, no, io non dubito, andate pur felice!</p>
             <p>Il pericolo è grande, ma poi che non ci è altro rimedio, io son risolutissimo di servir questi giovani, e segua che vuole, che sarà mai? Ma che non può far d'un cor ch'abbia soggetto, questo tiranno e traditor d'Amore? Part'egli che abbia insegnato a Porzia il modo di fare un beccastrello quel suo marito, per circospetto che egli sia. O va' là, va', va' piglia moglie, poi? Qualche minchione la ripiglierebbe! Ma io voglio andare a trovar Lepido prima che si faccia sera, e uscire di questo impaccio.</p>
@@ -5119,124 +5159,124 @@
         <div type="scene">
           <head rend="italic">SCENA SETTIMA</head>
           <stage><hi rend="sc">giulia</hi><hi rend="italic">alla fenestra</hi>. <hi rend="sc">E flavio</hi><hi rend="italic">in strada</hi></stage>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Se le cose si potessero far due volte, non so s'io dessi più il sì di pigliar messer Gervasio per marito. Quel tristo di Scaramuccia mi disse: fatelo, fatelo sopra di me. E io, presa all'improviso, così feci, e son pentita di quello c'ho fatto. Le seconde deliberazioni, in fatti, sono sempre migliori delle prime; ma che mi gioverà l'avervi pensato dipoi? La cosa è passata tant'oltre, che difficilmente posso ritrattarmene e ritirarmi addietro. O fortuna, in quanti modi vai travagliando questa dolente anima mia!</p>
             <p>Ma, s'io non m'inganno, vedo venir il signor Flavio. Ed ecco lo sposo mio, che a tempo viene; però voglio scendere abbasso, e seco ragionar di questo successo.<pb n="342"/></p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Non so come passano le cose tra messer Demetrio e messer Gervasio, nella promessione fatta del parentado e delle nozze con la signora Giulia mia. Scaramuccia non si trova, Ruchetta non si vede, dubito di qualche sinistro incontro di mala fortuna.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Signor Flavio, signor Flavio, zi, zi, volgetevi a me.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>O signora Giulia, o anima mia, ora sì, che è tornato a farsi giorno. Vita mia, io andava caminando per la oscurità della notte de' miei pensieri, e se voi, mia bellissima aurora, non apparivi al balcon d'oriente, io me ne stava in continue tenebre e orrore.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Ohimè, e qual cagione a ciò fare v'induceva?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Il non aver nuova di voi, cuor mio, il non veder Ruchetta e il non trovar Scaramuccia.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Signor Flavio, dolcissimo mio bene, io dubito che quel ribaldo di Scaramuccia non ci faccia una cavalletta.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Se tal cosa fusse, potrebbe ben tenersi per morto, perché io l'ammazzerei se fosse in braccio al primo re del mondo! Ma perché così dubitate voi di lui?</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Vi dirò, signor mio: poche ore sono egli venne con messer Gervasio e con Ruchetta, carico di presenti come s'usa di dare alle spose, e trovato messer Demetrio che l'attendeva alla porta, quello mi fece chiamare per l'istesso Scaramuccia, facendolo entrare in casa. Il quale subito che fu dentro cominciò a persuadermi a pigliar il vecchio per marito. Io, udendo quello strano modo e quel tradimento ch'egli far ci voleva, cominciai a contender seco e a querelarmi di lui. Finalmente, doppo molti contrasti, mi disse: «Giulia, fatelo sopra di me, ché so quello che fo», e così, adescata dalle sue parole, astretta dal tempo e sollecitata da lui nella strada, dove era quell'odioso sembiante di quel vecchio pazzo, che mi aspettava per toccarmi la mano, messer Demetrio mi fece forza a dar la fede a messer Gervasio e accettar le gioie che egli portate m'aveva. Ora son qui, né vedova, né maritata, anzi maritata a due mariti, a quel vecchio balordo per forzata fede, e a voi, che siete il mio vero marito, di vero contento! E Scaramuccia non si vede più.<pb n="343"/></p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Fortuna, tu non sei ancora sazia? che pensi fare? pensi tu forse di volgere la tua volubil ruota a' danni miei? Se questo pensi, temeraria che tu sei, rimarrai ingannata, perché dove ha luogo la prudenza, la fortuna non ha potere alcuno. Saprò ben io oppormi alla tua instabilità! Signora Giulia, non si può sapere ancora a che fine Scaramuccia vi disse: «Fatelo, fatelo sopra di me». Questo modo di parlare argomenta sicurtà e sagacità, industria e voglia di voler rimediare a questo disordine e a questo inconveniente.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Avvertite, ché ancor questo modo di parlare è ingannevole, perché molti sogliono dire: «So quello ch'io dico, so quello ch'io fo, non dubitate, fidatevi di me», e poi nell'ultimo si scopre che t'hanno tradito. Così dubito che non faccia questo tristo di Scaramuccia! E può ancora egli medesimo ingannarsi per troppa confidenza di sé stesso.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Sempre bisogna pensare al bene.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Anzi, al male bisogna aver riguardo, perché il bene giamai non nuoce. E il male sempre è dannoso.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Faccia quel ch'egli vuole, ché non sarà mai che io non sia vostro marito.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Sì, ma intanto io ho toccata la mano al vecchio e accettate le gioie e se ben queste si possono sempre restituire, la fede, in presenza di tanti impegnata, in che modo s'ha da stornare?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>O Cielo, non si potev'egli soprasedere qualche giorno ancora a far simil offizio? Voi dovevi dir, anima mia, di volervi pensar sopra almeno un mese, e non pigliar termine a mala pena un giorno; e di tutto questo male, se ne potrebbe, dare quasi la colpa a voi.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Voi avete ragione, ma io non credeva che le cose si dovessero stringere così presto; il male ormai è fatto, e però bisogna veder ora di rimediarvi, se non, vi rimedierò poi io alla disperata.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>E che vorreste voi far, cuor mio?</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Fuggirmene di casa, lasciare i presenti al vecchio, e venire a trovarvi in ogni modo. La mia dote non mi può mai esser negata, né ritenuta da messer Demetrio.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Questo ha da essere l'ultimo esterminio; ma pensiamo prima ad altro, se si può, per conservar la riputazion vostra,<pb n="344"/> per non diventar favola della vicinanza. Scaramuccia m'ha sempre detto, veramente, che sarete mia senz'altro.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>E a me ha detto l'istesso. E di più, meco parlando quando fu in casa, mi disse che a tutti i modi voleva che noi fussimo insieme, e questo è quello che mi molesta.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Così è da credere adunque che sarà senz'altro, però bisogna lasciarlo fare sino ad un certo termine; ma come si vegga poi ch'egli non sia per far buona riuscita, fare alla peggio, e dichiararsi per quella che mi siete, e dirlo alla scoperta a messer Demetrio.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Quella ghiottoncella di Ruchetta sa tutto l'animo di Scaramuccia, secondo me, e non sa dir altro che «lasciate far a lui». E, per quanto mi son potuta accorgere, ella è innamorata di Trapola, servo di messer Gervasio, e vorrebbe, per quel ch'io credo, che io andasse in casa quel vecchio per venirvi anch'ella e forse pigliarlo per marito. O, signor Flavio, per quanti traversi si va talvolta al mercato, eh!</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Questo che voi m'avete detto, mi va per la fantasia, e son d'umore che qui sotto si nasconda qualche inganno! Ma s'egli avvien ch'io lo sappia, so ben quello che io farò.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Signor Flavio mio, non perdiamo tempo in parole dubbiose che nulla rilevano. Meglio sarà che vostra signorìa veda di trovar Scaramuccia prima che venga notte, per saper da lui quello ch'egli vuol far di noi.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Voi parlate saviamente, signora mia, come giovane di molto giudizio; però entratevene in casa, ché io fra tanto anderò a trovarlo e del tutto vi farò consapevole. Entrate, anima mia.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Io entro, refugio d'ogni mio bene. Ricordatevi di me e di chi vi ama, anzi di colei che per voi solo respira.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Tanto farò. E voi senz'altro aspettatemi pure questa notte in tutti i modi.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Voglialo Amore, perché oramai è tempo! Addio, vita mia.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Io non so che mi dire di questo Scaramuccia. Egli è servo, e de' servi mercenarii vario è il genere, poi che si trovano di quelli che altro non son che ventre; altri che sono e ventre e lingua; altri c'hanno gli uncini e 'l fuoco nelle mani; e molti se ne trovano che sono perfidi e crudeli.<pb n="345"/> Ma ecco il signor Lepido, forse ch'egli me ne saprà dar qualche avviso.</p>
           </sp>
@@ -5248,156 +5288,156 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">scaramuccia</hi>
           </stage>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Cerca di qua, cerca di là di questo benedetto Scaramuccia per saper se altro sia seguìto! In fine non lo troverebbe la carta da navicare!</p>
             <p>Oh, signor Flavio, perdonatemi, ché io non vi aveva veduto. Mi sapreste voi dar nuova di quel tristo di Scaramuccia?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Signor Lepido, io veniva per domandarne a voi. Questo ribaldo ci ha posti in un gran laberinto; promette assai e attende poco.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Questo è il costume suo, egli è così di natura, né merita però riprensione.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Tutta via, mi par che sia cosa malfatta prometter tanto e non attender cosa alcuna.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Qualche imbroglio farà egli, perché ben lo conosco per prova; però ho ferma intenzione ch'egli voglia burlare i nostri vecchi, e bene.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Anch'io vivo con questa credenza e il dovere lo vuole: ch'egli ne voglia più per noi, che abbiamo a rimanere i suoi secondi padroni e quelli che l'hanno da mantenere al mondo sin che egli viva.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Senz'altro, e questo è obligo mio particolare, essend'egli antico servo di casa nostra; ma vorrei uscir d'ambiguità. Oh eccolo appunto.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Le ventiquattro ore non so se son sonate, ma la notte comincia avvicinarse, gli amanti sono in punto, gli inganni sono apparecchiati, a tale che non si ha da far altro che dar fuoco alla girandola delle ribalderie, per fare un bel fracasso, con più schioppi in un tratto.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Scaramuccia, o Scaramuccia, dove si va? che scopristi poi di quel servizio?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>O signor Lepido, sète voi, sète qui? Gran cose per certo! Oh, v'è ancora il signor Flavio, eh? Rade volte avviene che andiate scompagnati.<pb n="346"/></p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>I veri amici sempre sono insieme, ancor che lontani, perché nella lontananza de i corpi, più s'avvicinano le menti.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Si conosce ben, signor Flavio, ch'avete studiato.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Studiato? Ho solo atteso alle belle lettere qualche poco, come dir si suole.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Belle lettere son quelle che dicono: «Magnifici signori, per questa prima di banco, pagherete al tale mille scudi, e ponete acconto nostro e valetevene».</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Tu non m'intendi, belle lettere vuol dire lettere d'umanità.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Non so più bella umanità che sborsar mille scudi e duemila alla volta ancora, per tanto di carta.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Appunto, viola! Lettere d'umanità, cioè Grammatica, Logica, Rettorica, Poetica e Filosofia.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Oh questo è un altro par di manìche! Bisognava dir così alla prima, ch'io non vi averei inteso.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Eh, Scaramuccia, tu sei sulle burle, n'è vero? Ora, lasciando da parte questa nostra digressione, dimmi un poco: quello aver detto alla signora Giulia «fatelo, fatelo sopra di me», quando ella ebbe a toccar la mano a messer Gervasio, a che ha da resultare?</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>E che gran cose hai tu scoperte per conto mio?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Che Porzia vi ama, o Lepido! E voi, signor Flavio, sapete quel che ha da resultare, quanto ho detto, tutto a vostro contento e della signora Giulia.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Per dir così e non dir altro, questo non basta.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Io non so di basti o di bardelle.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Con teco la non si può né vincere, né impattare, poi che ogni parola è da te tirata al tuo senso.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Senso fu quello che cercava di non morir mai! Ma lasciamo le burle. Che ora vogliamo noi dire che sia? Gli è ancora un'ora di notte, ma non credo che sia tanto; credete voi, Lepido, che sia un'ora?</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Credo di no, e che sia poco più di meza ora.<pb n="347"/></p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Bene sta. Ma piano un poco signori, che cosa ha da guadagnare Scaramuccia vostro con tante fatiche?</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Quello che tu saprai chiedere.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Il chiedere è poca fatica, ma grande è quella del rimunerare.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>A giudizio tuo, che ti par di meritare?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Non parliamo di merito, trattiamo di cortesia e di gentilezza.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Ti contenti tu di guadagnare cento scudi? cinquanta dal signor Flavio, e altretanti da me?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Son più che contento, contentissimo! Ma avereste voi da darmene la metà per caparra? Perché, per dirvela, il fare a hammi non mi è mai piaciuto, perché del presente mi godo e meglio aspetto.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Io non porto dinari addosso.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Né io similmente.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Oh che innamorati, non aver manco dinari da comperar un baiocco di calde arrosto! Ma, con tutto ciò, voglio esser galantomo contra mia natura e servirvi a credenza. Però andiamo, ché s'avvicina il tempo delle vostre contentezze, e in tanto io vi racconterò il tutto.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Andianne.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Andiamo ché ormai è tempo.</p>
             <pb n="348"/>
@@ -5416,56 +5456,56 @@
             <hi rend="sc">lepido</hi>
             <hi rend="italic">in disparte, che non si vedono</hi>
           </stage>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Voi avete inteso , e' sono ormai due ore. State voi, signor Lepido e signor Flavio, in disparte, ché io zimbellerò, perchè i fringuelli cadino quando sarà tempo.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Le due ore son sonate, e secondo l'ordine datomi da Scaramuccia mi son vestito da donna e ho pigliato due sassi in mano, per far il segno tra di noi dato, li quali potrebbono ancor servire ad un bisogno a romper il capo a qualcuno che mi volessi dar fastidio. Io voglio pian piano avvicinarmi alla porta. O Amore, che cosa non fai tu fare a gli amanti? o quanti ve ne sono a quest'ora per le contrade travestiti, chi da facchino, chi da serva, chi da zanaiolo, e quante donne stanno aspettando i loro innamorati? e quanti becchi dormono per loro commodità, e quant'altri per dar commodo alle mogli per aver le corna d'oro? Oh oh, fine fine dicentes! Ma lasciami fare il segno. Ciach, ciach, ciach.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>S'io non m'inganno, questo, al segno fatto, è Trapola vestito da donna. Alla fé si è!</p>
             <p>Zi, zi, zi! Trapola, o Trapola, tu non mi conosci eh? Son Scaramuccia.<pb n="349"/></p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Che Trapola, io sono una fanciulla di piazza Padella che vo a guadagno! Però lasciami stare, e va' pe i fatti tuoi.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Do' manigoldo, una fanciulla di piazza Padella, eh? Trapola, tu non mi raffiguri, n'è bestiaccia?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Che sì, che sì, che s'io chiamo il mio bravo, ch'io ti farò tagliar un braccio! Furfantone, va' alla streglia.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Questa bestia si dà da intendere d'essere una donna; è che alla voce non mi conosce. Trapola, a chi dico io? É possibile, ignorante, che tu non mi conosca alla voce, se bene è così scuro?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Oh, tu sei tu, Scaramuccia, eh?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Sì, sono; che ti venga il canchero!</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Perdonami, fratello, ch'io non t'aveva conosciuto. Io mi sono vestito da donna così, il meglio ch'io ho saputo, e mi son messo intorno delle veste vecchie della signora Porzia, mia padrona; e ora altro non mi occorre, se non andarmene a stare tutta questa notte con Ruchetta mia.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Così sarà, tirati un poco in là e non venire innanzi sin tanto ch'io non venga per te.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Eccomi tirato.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Così sarà, tìrati un poco in là e non venire innanzi io ti possa poi trovare. Ora voglio fischiar tre volte sotto le fenestre del padrone, acciò ch'egli venga come ha promesso a condur questa Giulia salvatica in casa. Fis, fis, fis.</p>
           </sp>
@@ -5477,81 +5517,81 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">trapola</hi>
           </stage>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Il vecchio debbe dormire, poi che non viene.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Oh come è scuro! Zi, zi, Scaramuccia, sei tu?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Sì sono, padrone. Ben, ch'avete fatto?</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Sono stato sin ora nella camera terrena, aspettando che tu fischiassi.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>E io in quel mentre ho condotta fuora di casa Giulia, dicendole di menarla da messer Gervasio, ed ella credendomelo se n'è venuta meco; l'ho aggirata un pezzo, finalmente l'ho di nuovo ritornata qui, facendole credere che<pb n="350"/> questa sia la casa di Gervasio, e or ora ve la condurrò nelle braccia.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>O Giulia, anima mia, chi avrebbe mai creduto ch'io ti dovessi godere questa notte? e ch'io dovessi esser il primo a mettere il piede nell'amoroso tuo giardino? Alla barba tua, Gervasio! Io coglierò pur quel fiore non colto ancora d'alcuno.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Dite piano, ché voi non siate sentito da lei, ch'è poco discosto da noi. Oh padrone, vi ricordo andar con qualche modestia con questa fanciulla.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Che modestia? Ne gli assalti amorosi non vi va modestia, anzi, bisogna far conto, se ben è fanciulla, d'aver una scaltrita nel letto.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>É vero, ma volete voi disertarla sulle prime carte?</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Eh, va' in chiasso, di grazia! Voglio che tu m'insegni com'io ho da fare?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Or via, fate a vostro modo, ché questo poco m'importa.</p>
             <p>Va' pur là, eh eh!</p>
             <p>Ricordatevi sopra tutto di non parlare, vedete.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Non tanti avvertimenti, conducila qua in buon'ora, perché un'ora mi par mille anni per darle un bacio in quella dolce bocca dove ogni grazia fiocca.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Buono, affé, voi versificate per amore. Zi, zi, zi, Trapola, dove sei?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Eccomi.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Orsù, sta' cheto, non parlare. Zi, zi, zi.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Zi, Zi, Zi.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Abbracciatela e conducetela nella camera terrena e senza lume come vi dissi, vedete.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Sì, sì, addio, addio.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>E una! All'altra, disse colui.</p>
           </sp>
@@ -5563,32 +5603,32 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">scaramuccia</hi>
           </stage>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Sono oramai vicine le due ore e meza, e secondo l'ordine dato con Scaramuccia bisogna ch'io me ne vadi alla<pb n="351"/> casa sua, e ch'io mi spurghi tre volte forte, acciò ch'egli possa intendere il segno dato tra di noi. Io non credeva mai che questa notte dovesse esser tanto scura e tanto tenebrosa! Ma non importa, la cosa anderà più sicura, s'io non m'inganno. Mi par d'esser vicino alla porta di messer Demetrio, voglio spurgarmi: lah, lah, lah.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Alla fé, che il gatto va in frega! O vecchio rimbambito, ora che hanno da fare i giovani, se i vecchi fanno di queste pazzie?</p>
             <p>Zi, zi, zi, messer Gervasio, sète voi?</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Sì, sono, e ho dato d'un piede in un sasso che m'ho avuto a romper le dita! Venga il cànchero a i sassi!</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Abbiate pazienza.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>L'importanza è che mi si è abbassato il pensiero, che all'alzarsi vi vorrà del buono!</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Oh faremo di belle prove, dunque! Aspettatemi qui, acciò ch'io vadi in casa per Giulia e ch'io ve la conduca.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Sì, sì, va' e torna presto, perché m'è ritornato l'appetito. O Giulia mia cara, questi si chiamano amori? queste sono donne ardite? queste sono veramente innamorate? In fatti, io le concio tutte così! Io ne ho guaste quelle poche dell'amor mio! Pensa tu come l'andava quando io era giovanotto di quarant'anni!</p>
           </sp>
@@ -5600,107 +5640,107 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">gervasio</hi>
           </stage>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Vienne, Ruchetta, ché tuo marito t'aspetta! E per parer da qualche cosa s'è messo indosso i panni del suo padrone, che se tu lo potessi vedere, diresti ch'è tutto lui.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>O Scaramuccia, quando potrò io mai ricompensarti di tanto beneficio che tu mi fai? Poco più ch'io stava a consumar questo matrimonio, mi distruggeva come le candele di grasso di bue.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Io credo che tu n'abbia non solo gran volontà, ma un grandissimo bisogno! Ma avvertisci ch'io voglio che noi facciamo una bella burla a tuo marito, ve', la quale sarà<pb n="352"/> questa: che tu non parli mai sin tanto ch'egli non viene a dar l'assalto alla fortezza delle creature umane.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>O perché questo?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>O per burla e per scherzo, come t'ho detto, e per sentire quello che ti dirà, stando tu così cheta, e quello che farà ancora e con quale destrezza scalerà le mura dell'onor tuo.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>E quale onore? Non ti diss'io già ch'io lo perdei una volta e così per tempo, ch'io non conobbi che cosa egli si fosse?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Tanto che Trapola non durerà fatica a pigliar la rocca sotto panzano! Orsù, buono, buono, camina meco e non parlar sopra tutto, fammi questo piacere.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Lo farò, ché poco importa.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Giura, ch'io non ti credo.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Che giuramento vuoi tu che io faccia?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Giura da donna da bene.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Non lo posso fare.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Perché?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Perché sempre sono stata una puttanella, e non me ne posso astenere. Bastati ch'io non parlerò.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>O così, si fa, dirlo alla prima, de plano, senza aspettar tormenti! Vien via, dammi la mano.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Eccola. Non me la stringer, ribaldo, tu credi ch'io non ti conosca, eh?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Vuoi tu ch'io ti dica che io ho, così al buio, una gran volontà di far tuo marito un beccastrello in erba?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Che stai tu a fare? Eh, tu non ti degneresti!</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Sto per pigliarmene una presa, e se messer Gervasio non aspettassi, così al buio al buio gliela vorrei attaccare. Zi, zi, zi.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Zi, zi, zi, piano, sei tu, Scaramuccia? hai tu l'amica?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Io l'ho condotta da serva, state cheto, non parlate, ma conducetela in casa vostra nella vostra camera terrena, e fate che non vi sia lume come promesso m'avete.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Lascia fare a me. Qui, per quello ch'io m'avvedo, s'ha da lavorare alla mutola e alla cieca!</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>S'intende, sino ad un certo termine e poi parlare,<pb n="353"/> perché sarebbe una discortesia. Orsù, eccola qui, abbracciatela e conducetela via. Zi, zi.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Zi, Zi.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Zi, zi, o vita mia, venite.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Io mi sento crepar delle risa! I topi vecchi sono nella trapola, ora bisogna attendere a i giovani.</p>
             <p>Olà, signor Flavio.</p>
@@ -5713,83 +5753,83 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">flavio</hi>
           </stage>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Son qua, Scaramuccia, che vuoi? Ricordati che l'ora passa.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Lasciatela pur passare, in ogni modo nessuno vi potrà dare impaccio. Or ora voglio far segno alla signora Giulia, che se ne venga a voi. Zi, zi.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Zi, zi, sei tu, Scaramuccia?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Sì, sono.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Hai tu condotto il signor Flavio?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Signora no.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Perché?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Perché il poverino è stato assaltato da un cattivo male e in un subito.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Ohimè, che male è questo?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Il mal del tiro.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>E dove l'ha tirato?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Dove? qui da voi. Ah traditora, un'ora ti par mill'anni d'assaggiar la cannamèle, n'è vero?</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Ma dov'è egli, fa' ch'io lo senta e ch'io lo abbracci.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Adagio, eccolo qua. Signor Flavio, accostatevi.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Eccomi, anima mia, dove sète, ch'io non vi veggo?</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Son qui, datemi la mano.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Eccovela, la quale di nuovo vi promette la giurata fede.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Andiamo, cuor mio, perché questo non è tempo da perdere! Abbracciatemi.<pb n="354"/></p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Ecco ch'io vi abbraccio, ben mio, andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Salda lettiera, salde asse, a questo fiero assalto! Olà, signor Lepido, dove siete?</p>
           </sp>
@@ -5801,59 +5841,59 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">scaramuccia</hi>
           </stage>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Son qua, dove tu mi ponesti, che cosa vuoi?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Or ora voglio chiamar la signora Porzia, la quale sta alla veletta. Zi, zi, zi.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Zi, zi, sei tu, Scaramuccia?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Signora sì, ed è meco quell'amico, il signor Lepido.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Certo, certo, o che allegrezza</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Tu senti, galantuomo? tu stai fresco! acute;rmati pure, mena ben le mani, perché ti bisogna.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Ma dove è questo mancator di fede?</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Son qui, signora, ma non già mancator di fede.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Venite, venite pure al cimento; ché ancor che voi foste tutto arme, voglio abbattervi essendo in camicia.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Farete quello che potrete e io l'istesso, ma credete pure che starete di sotto vostro mal grado, né averete quella vittoria che vi pensate.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Andiamo pure, ché di già vi appresento lo steccato.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>E io l'armi.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Ve le rintuzzerò ben io! Venite pure.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Andate là, che possiate voi arrabbiare o rimaner attaccati come i cani! Che diavol di furia è questa! Quando la donna è calda, eh, l'è pure una pazza bestia! Oh oh, costoro son tutti in casa accomodati, e presto presto si dovrà avvertire il segno dell'orribil tempesta tra messer Demetrio e Trapola e tra messer Gervasio e Ruchetta. Ma la signora Porzia starà aspettando ch'io mi vadi a mettere allato a Licinio suo marito, come gli ho promesso, a tal che qui<pb n="355"/> bisogna spedirla! Oh, mi pizzicano le chiappe, che segno sarà questo? Io sto per andare e per non andare: un cuor mi dice ch'io vi vada, e l'altro mi dice non vi andare. Che farai, Scaramuccia, anderai tu a mettere in pericolo l'onor tuo, la tua castità e il tuo pulzellaggio? Guarda quello che tu fai, perché come una donna ha perduto l'onore, non ha più che perdere. E chi vorrai tu poi che sia quell'uomo che ti pigli per moglie? Così rimarrai vedova piena d'affanni e di tribolazioni.</p>
             <p>Do', manigoldo ch'io sono, non era io entrato in pensiero d'esser una donna? Quando si dice poi che l'imaginazione non fa caso, eh? Oh, canzone sì, quante volte pensando a bella donna ogni cosa va a brodetto. Orsù, andar bisogna, intervenga ciò che si vuole, che sarà giamai? A gli accordi, allegramente, io entro! Non entrar, Scaramuccia, non destar il can che dorme, non tentar il diavolo, non cercar il male come i medici, io ti vedo morto. Ricordati che uomo morto non può far guerra, e che meglio è che si dica qui fuggì, che qui morì, e che l'uomo è tenuto a preservar la sua vita sino al termine prescritto, senza andar cercando la sua morte! Ma quella poveretta di Porzia si debbe ora liquefare come la cera al fuoco aspettandomi, tale che sarà meglio ch'io vadi. Io vo, io vo, io entro, io entro, ecco che pur v'entrai.</p>
@@ -5866,43 +5906,43 @@
             <hi rend="italic">vestito da donna, e</hi>
             <hi rend="sc">demetrio</hi>
           </stage>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Ah, traditore, dove fuggi? Io ti voglio ammazzare, io ti veggo, io ti veggo, con questo lume acceso, férmati qui!</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Ah, signor Demetrio, non m'ammazzate! Lasciatemi prima dir venticinque parole, poi fate quello che volete.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Son contento, ma voglio sapere di donde viene questo assassinamento.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Ve lo dirò io, signore. Da Scaramuccia vostro servitore, o dalla signora Giulia vostra.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Ah poltrona, arcipoltrona, così si tratta un par mio, eh?<pb n="356"/></p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Udite pur, signore, sono tradito e assassinato anch'io, da quel ladro di Scaramuccia.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>E come?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Sappiate, signore, che Ruchetta vostra serva è mia moglie, così datami da Scararnuccia, c'ha fatto il parentado; e perch'ella desiderava che noi fussimo insieme questa notte, quel traditore m'impose ch'io dovessi travestirmi in abito da donna, e che in quell'abito mi metterebbe in casa con lei, ordinandomi, di più, ch'io non parlassi mai, dicendomi che così voleva far per burla.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>. O vigliacco, il simile disse a me, promettendomi Giulia! Ma io non ho mal ch'io non meriti, a credere alle parole d'un servitoraccio senza fede e senza carità! Férmati un poco qui, di grazia, perché mentre che il male è fresco bisogna medicarlo. Io ho sentito non so che romore per casa, voglio andare a vedere che cosa è.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>So che la fortuna m'ha voluto aiutare. Ah, Scaramuccia traditore, o ch'io t'ammazzo o ch'io ti lascio stare.</p>
           </sp>
@@ -5914,35 +5954,35 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">giulia</hi>
           </stage>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>All'arme, all'arme, vicini correte, correte!</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Signor Demetrio non gridate, non alzate la voce, perché se io sono in casa vostra, sono con termini d'onore e da gentiluomo. E se bene sono in camicia, non temo di voi, né delle vostre armi.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Deh, messere, placate l'ira vostra, perché questo gentiluomo che vedete è mio marito e Scaramuccia me l'ha dato.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Ah Scaramuccia, ladro assassino! Costui va maritando tutto il vicinato a suo modo! Ma vieni un po' qua, mona stitica: che dirà messer Gervasio quando si vedrà burlato da me, da te, da Scaramuccia, e di aver gettati via i suoi presenti?</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Dica di ciò quel che vuole, di me non può dolersi, ché non promessi niente e i presenti se li repigli, ch'io non voglio nulla di suo.<pb n="357"/></p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Così dunque Giulia si porta, eh? così poco rispetto porti all'onor mio?</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Quel rispetto stesso che voi volevi portare a me, ho io portato a voi, anzi molto più! Credete voi che Scaramuccia non m'abbia detto che voi sète innamorato di me e che volevi prima godermi e poi mandarmi a messer Gervasio? che modi vi paion questi? Di grazia non mi fate dir più, però che per fuggir disonore ho sollecitato a provedermi onorevolmente.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Orsù, taci, ch'io credo che tu abbia detto in poche parole tutto quello che si poteva dire! Ma che romore odo io in casa messer Gervasio?</p>
           </sp>
@@ -5954,91 +5994,91 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">giulia</hi>
           </stage>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Fermatevi, dico, ch'io non son Giulia!</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Io so che tu sei Giulia, la mia sposa, l'anima mia! Come, tu non sei quella? Con questa lucerna accesa ti conoscerò ben io or ora! Oh Ruchetta, Ruchetta, chi t'ha messo in questa casa?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Quel ribaldo di Scaramuccia.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>In che modo?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Dandomi a credere di condurmi a Trapola, mio marito e vostro servitore.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Ah poltrona, tu sei andata in striazio.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Sono andata in bordello, disgraziato! Io era venuta per te in questa casa, perché così mi aveva dato da credere Scaramuccia.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Oh che vituperoso è questo ribaldo di Scaramuccia, egli merita mille forche! Ma dov'è egli, chi lo sa? chi me lo insegna?</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Guardate a non trovarlo, egli si debbe esser nascoso sotto terra come le talpe.<pb n="358"/></p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Fermatevi un poco! Oh ecco qua la mia sposa, e che vuol dire che voi siete così in camicia?</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>S'io sono in camicia, non son per voi.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Come, che voi non sète per me? Voi mi avete pur toccata la mano e accettato il diamante, il rubino, i pendenti e la collana col vezzo di perle!</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>S'io vi toccai la mano e accettai i vostri presenti, fu per opra di Scaramuccia e per burlarvi.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>E che pensate voi di fare?</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>D'esser d'ogn'altro, che vostra.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>E di chi?</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Del signor Flavio, mio primo marito.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Come primo? e chi ve l'ha dato.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>Scaramuccia.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Possa crepare questo Scaramuccia! Messer Demetrio, che dite voi del vostro galante servitore?</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Che volete voi ch'io dica? So ch'egli me l'ha fatta a piedi, e a cavallo! Oh perché non l'ho io nelle mani?</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Fermatevi, ch'io sento romore anco in casa mia.</p>
           </sp>
@@ -6050,295 +6090,295 @@
             <hi rend="italic">e</hi>
             <hi rend="sc">gervasio</hi>
           </stage>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Ohimè , poveretto me, non mi ammazzate!</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Ah, traditore, così s'assassinano gli uomini d'onore, eh?</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Ohimè, marito mio, non fate!</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Ah, signor Licinio, mettervi con un vil servitore?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Ohimè, che è quel ch'io vedo in camicia? Ohimè, che Licinio ha le treccie da donna e mi pare lo spirito di mia moglie che mi voglia ammazzare!</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Tu hai pur dato nella rete, eh, ladro? Tenetelo saldo! Ohimè, ohimè, genero mio?</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Tu sei pur rimaso preso come le volpi.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Ah, traditore, tu me la facesti, eh?</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Ah, impiccato, tu me l'hai barbata pure, eh?<pb n="359"/></p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Tutto quello che volete voi: confesso d'aver fatto mille errori e ch'io merito ogni gastigo; con tutto ciò andate in buon'ora, ch'io vi perdono a tutti quanti.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Così va detta, appunto, appunto.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Deh, non mi date noia adesso, in cortesia! Lasciate che di nuovo io guardi e riguardi il signor Licinio, che mi pare tutto la mia Brigida. Brì, Brì.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Scarà, Scarà.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Brì, Brì, Brigida mia?</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Scarà, Scarà, Scaramuccia mio?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Brigida, moglie mia?</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Scaramuccia, marito mio?</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Oh moglie mia, sei tu viva o morta?</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Eh, marito mio, io son ben viva sì, ma morta nella memoria vostra, poi che non vi sète mai ricordato di me.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Oh, moglie mia cara, abbracciami, or che novità è questa? è questo un sogno o qualche illusione?</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Questo non è sogno, né meno arte illusiva. Io son Brigida, vostra moglie. Ora sì messer Gervasio, ch'io non sono altrimente il vostro genero Licinio.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Do', ve' tresca, che sì, che la Porzia mi rimane in casa?</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>No, no, messer Demetrio, ché io non le mancherò mai.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>O to' quest'altro! Ch'avete voi a fare ser Spannocchio?</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Bene sta. Ma che fai tu qui ora? Lepido, che novità son queste?</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Ascoltate e lo saprete.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Ascoltate, di grazia! Ora, affine che voi sappiate il tutto, insieme con questi, che d'intorno ci stanno, dicovi ch'io credo che ognuno di voi benissimo si ricordi come quattro anni sono ormai passati che messer Demetrio qui<pb n="360"/> presente mandò a Lione di Francia il signor Lepido, suo figliuolo.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Bene sta, ma che fai tu qui ora, Lepido? come ho detto.</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>Lo saprete ascoltando.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Egli, prima che si partissi per quella volta, essendo della signora Porzia innamorato, le diede segretamente la fede d'esser suo marito, promettendole di ritornare alla patria in capo di tre anni, solo per osservarle la promessa fede, pregandola che in quel tempo volesse sempre contradire alle voglie del padre e non pigliar mai altro marito; rimanendo d'accordo ancora che s'egli non tornassi in capo alli tre anni, ch'ella potesse sodisfare alle volontà del padre suo e maritarsi.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Porzia, è egli vero questo che dice costui, o costei, ch'ella si sia?</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Signor sì.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Séguita, dunque.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Passò il primo anno, il secondo, e già cominciava a spirare il termine prescritto, quando la signora Porzia un giorno, piangendo e sospirando meco che sapeva il tutto, mi disse che non poteva più negare al padre di pigliar marito, il quale ogni giorno gliene faceva grandissima instanza.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Questo è più che vero, ma séguita pure.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Ond'io, vedendo la povera giovane in tanto travaglio, me ne venne compassione e la consolai con amiche parole a sopportar il tutto con pazienza e toleranza. E di là a poco, di suo consenso partitami di casa vostra, messer Demetrio, me ne andai a trovare uno Speziale mio parente, dal quale mi feci dare un sonnifero tale, che pigliato con acqua pura cadei come morta in casa, e dal marito qui e da tutti voi fui giudicata priva di vita e fui pianta e seppellita.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Ben lo so io, moglie mia cara, poi che ti piansi amarissimamente.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Do', che sent'io! Che ne dite, messer Demetrio?</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Ricordomi di tutto, e stupisco di tal risoluzione; ma sto aspettando il fine di questo amoroso e strano avvenimento. Però lasciatela dir, di grazia.<pb n="361"/></p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Seppellita ch'io fui, fui ancora, di là a poche ore, cavata dal sepolcro dallo speziale mio parente, il quale con ottimo rimedio mi trasse il sonnacchioso umore dalla testa, ritornandomi subito nel pristino essere. E condottami a casa sua, dopo esser quivi reficiata, participai seco di nuovo il mio pensiero, e però ebbi da lui abito da uomo, e avendo portato meco grosse somme di danari e molte gioie cavate di casa vostra, ch'erano di vostra madre, o Lepido, ché ben sapete, messer Demetrio, che non m'era difficile, essendo quanto vi era sotto la mia custodia, mi preparai per far quello che determinato avea.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Caca sangue, che gli è vero! Ma questo è ben troppo, e mi ricordo ora quando credei d'essere stato rubbato grossamente in denari in casa e mi mancò tant'altra robba.</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Ohimè, ohimè, che sent'io? O moglie mia, savia e prudente, tu meriti corona!</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Ché, per avermi tolto il mio, n'è vero, pezzo di ribaldo? Ma séguita tu.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>E così, postami all'ordine, me ne andai a Fiorenza con grossa facultà alle vostre spese.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Doh, ve' rigiraccio.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>E cercando ringiovenir l'effigie e apparire uomo il più che fusse possibile, stetti quivi qualche tempo e feci tanto che quasi mi trasformai in modo da non essere più riconosciuta per donna, e però come uomo ne me ne tornai a Roma.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Io per me non me ne son mai avveduto; ma dite pure.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Feci poi, per terza persona informata della molta mia facultà, chiedere a messer Gervasio la signora Porzia per moglie, dopo all'aver fatto all'amor seco qualche settimana; offerendomi però di pigliarla con quella poca dote che aveva, anzi con promissione di farle buonissima contradote. Onde mi successe tutto felicissimamente, perché messer Gervasio, mosso dall'avarizia, accettò alla prima il partito e promesse senz'altro di darmela. Sta ella così?<pb n="362"/></p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Questo è ben vero,ma non è già vero ch'io fosse spinto solo da avarizia, come tu di', o Brigida.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>In somma, fusse come si volesse, io mi lasciai vedere e piacqui qui al messere, il quale, inteso che io era molto ricco e solo al mondo (ché così dissi sempre) egli mi volle in casa e accettommi come suo carissimo genero e come figliuolo.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Feci io male?</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Si fecero le nozze, che furon bellissime, perché io mi mostrai splendido; e andati poi noi sposi al letto, la povera signora Porzia sola ne fece male. Non vi vergognate.</p>
           </sp>
-          <sp>
+          <sp who="#porzia">
             <speaker><emph rend="sc">porzia</emph>.</speaker>
             <p>Seguitate, seguitate.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Dicolo perché, in vece di esser martire quella notte, rimase vergine e donzella; ma il contento di veder riuscito a bene il nostro disegno fu ancora tanto grande che ce la passammo allegramente in ogni modo e le carezze che ella mi fece ella stessa, che è qui presente, ve le dica per me. E allora fu da noi stabilito di seguitare l'ordine incominciato solo per aspettare il bramato ritorno del signor Lepido, acciò che la signora Porzia non fusse d'altri che sua. Finalmente poi, essendoci accertate che il signor Lepido era tornato solamente per lo sviscerato amore che conservava verso la signora Porzia, facemmo pensiero di levarci da una gran pena, sentendo che la natura dell'una e dell'altra di noi pativa all'ingrosso. E però, poiché la signora Porzia fu assicurata della lealtà di Lepido, della quale molto dubitava, e trovatolo sempre saldo e costante, fu concluso che egli questa notte come suo marito seco si ritrovasse, senza saputa però di lui, e che Scaramuccia meco si coricasse, credendomi Licinio, di lei marito. Tutto per servar la fede dalla signora Porzia al signor Lepido promessa. Che dite ora, signori?</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Io per me non so che altro dire, se non che era voler del Cielo che Porzia, mia figliuola, fusse moglie di Lepido.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Or siane lodato il Cielo! E io non saprei mai oppormi a quel che di lassù viene, né meno al contento di mio figliuolo; pentendomi di ogni rigidezza, poiché quivi si stabiliscono i parentadi. Uh, uh, uh!</p>
           </sp>
-          <sp>
+          <sp who="#lepido">
             <speaker><emph rend="sc">lepido</emph>.</speaker>
             <p>E io non saprei mai come rimunerarti, o Brigida, di tanto benefizio. E a voi, mio padre, resto tanto obligato di questo mio ben essere, quanto dell'essere che dato mi avete.<pb n="363"/></p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Brigida mia, tu meriti che qualche cronachista scriva di te, e che qualche buon Comico faccia una graziosa commedia di sì bello avvenimento! Or sù dunque, messer Demetrio, quello che è abbozzato resti per fatto, n'è vero? E muoia l'avarizia e contentiamoci che questi garzonotti abbino loro per moglie queste belle fanciulle, che non son pasto da' nostri denti.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Voi dite bene certo, e io mi scuso teco, o Giulia, con lo amore sviscerato che ti ho portato; essendo quello un affetto tale che sforza anco la volontà ragionevole. Onde lodo e approvo tanto il pensier tuo di unirti col signor Flavio (che però me ne contento) quanto riprendo me stesso di ogni inonesto pensiero.</p>
           </sp>
-          <sp>
+          <sp who="#flavio">
             <speaker><emph rend="sc">flavio</emph>.</speaker>
             <p>Restovi, signor mio, con obligo immortale.</p>
           </sp>
-          <sp>
+          <sp who="#giulia">
             <speaker><emph rend="sc">giulia</emph>.</speaker>
             <p>E io, come figliuola obbedendovi, mi mostrerò non indegna allieva di casa vostra, rendendo le grazie dovute a ogni vostra amorevolezza.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Per segno adunque che io son contento, Lepido, tocca qui la mano alla signora Porzia, poiché messer Gervasio n'è contento; e voi, signor Flavio, alla Giulia.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Sì, toccatevi or le mani in publico, perché il resto si debbe esser maneggiato in segreto.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Taci, animalaccio!</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Anzi, messer Gervasio, egli ha fatto bene a parlare, perché per mostrarmi interamente amorevole e lieto e ridurmi affatto al ben vivere, voglio che ancor egli resti contento, se così vi piace, acciò il contento sia universale! Vien qua, Ruchetta, tocca la mano a Trapola, ché per ricompensa de' servizii fattimi ti vo' dotare e te lo do per marito.</p>
           </sp>
-          <sp>
+          <sp who="#ruchetta">
             <speaker><emph rend="sc">ruchetta</emph>.</speaker>
             <p>Il Ciel vi rimeriti.</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Se però messer Gervasio, che in segreto è stato teco alle strette, se ne contenta anch'egli.</p>
           </sp>
-          <sp>
+          <sp who="#gervasio">
             <speaker><emph rend="sc">gervasio</emph>.</speaker>
             <p>Trappola, accostati, ch'io te la rinunzio.</p>
           </sp>
-          <sp>
+          <sp who="#trapola">
             <speaker><emph rend="sc">trapola</emph>.</speaker>
             <p>Gran mercè e buon pro ci faccia.</p>
           </sp>
-          <sp>
+          <sp who="#licinio">
             <speaker><emph rend="sc">licinio</emph>.</speaker>
             <p>Signor Demetrio, a perdonar vaglia, poiché finalmente ogni cosa ritorna in casa, pregandovi ancora di perdonare a Scaramuccia mio, poi che non è poco gastigo per lui il ritornarsi col peso della moglie.<pb n="364"/></p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Tu di' bene, però gli perdono ogni fallo commesso per amor tuo; ché non che perdono merita lode, per essere cagione di tanto bene. Sia dunque in buon punto per tutti così concluso, e ciascuno per esser tant'oltre di notte potrà ritirarsi a casa sua, e domani daremo ordine alle publiche nozze, come si conviene. Tu in tanto, Scaramuccia, che hai saputo tanto bene scaramucciare, che ne sei uscito netto...</p>
           </sp>
-          <sp>
+          <sp who="#scaramuccia">
             <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
             <p>Come un baston da pollaio!</p>
           </sp>
-          <sp>
+          <sp who="#demetrio">
             <speaker><emph rend="sc">demetrio</emph>.</speaker>
             <p>Da' licenza a questi signori, che sono stati presenti e ascoltatori di così belli e nuovi avvenimenti.</p>
           </sp>
@@ -6346,7 +6386,7 @@
       </div>
       <div type="epilogue">
         <head>LICENZA</head>
-        <sp>
+        <sp who="#scaramuccia">
           <speaker><emph rend="sc">scaramuccia</emph>.</speaker>
           <p>Signori, voi vedete: lo sgraziato tocca a essere a me solo, che, liberato come io mi credeva una volta dall'impaccio della moglie, mi conviene ora riaddossarmela; ma chi si contenta gode, e però ancor io voglio fare il simile alla buona usanza, e tôrre quel che il Ciel manda in pace. Se ci è di voi, signori, che voglia venire alle nozze, potrà indugiare a domani, perché ormai l'ora è troppo tarda. Vi ringrazio però in nome di tutti di così grata audienza, e vi saluto. A Dio.</p>
         </sp>

--- a/tei/speroni-canace.xml
+++ b/tei/speroni-canace.xml
@@ -81,6 +81,43 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <personGrp xml:id="ombra">
+            <name>Ombra</name>
+          </personGrp>
+          <person xml:id="eolo">
+            <persName>Eolo</persName>
+          </person>
+          <person xml:id="consigliero">
+            <persName>Consigliero</persName>
+          </person>
+          <person xml:id="cameriera">
+            <persName>Cameriera</persName>
+          </person>
+          <person xml:id="deiopea">
+            <persName>Deiopea</persName>
+          </person>
+          <person xml:id="macareo">
+            <persName>Macareo</persName>
+          </person>
+          <person xml:id="famiglio">
+            <persName>Famiglio</persName>
+          </person>
+          <person xml:id="nutrice">
+            <persName>Nutrice</persName>
+          </person>
+          <person xml:id="canace">
+            <persName>Canace</persName>
+          </person>
+          <person xml:id="coro">
+            <persName>Coro</persName>
+          </person>
+          <person xml:id="ministro">
+            <persName>Ministro</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -140,7 +177,7 @@
       <div>
         <head>Scena 1</head>
         <stage>OMBRA</stage>
-        <sp>
+        <sp who="#ombra">
           <speaker>OMBRA</speaker>
           <l>Uscito dello 'nferno,</l>
           <l>Vegno al vostro cospetto, ombra infelice</l>
@@ -285,7 +322,7 @@
       <div>
         <head>Scena 2</head>
         <stage>EOLO. CONSIGLIERO</stage>
-        <sp>
+        <sp who="#eolo">
           <speaker>EOLO</speaker>
           <l>Oggi son diciotto anni</l>
           <l>Che un parto sol della mia Deiopea</l>
@@ -336,7 +373,7 @@
           <l>Di che poco suo danno,</l>
           <l>Nacque la molta mia tranquilla pace.</l>
         </sp>
-        <sp>
+        <sp who="#consigliero">
           <speaker>CONSIGLIERO</speaker>
           <l>Iddio grande e pietoso</l>
           <l>È ora Enea, se 'l cielo</l>
@@ -346,25 +383,25 @@
           <l>Il cui tenero cor molte fiate</l>
           <l>D'ira più che d'amor fu visto ardente.</l>
         </sp>
-        <sp>
+        <sp who="#eolo">
           <speaker>EOLO</speaker>
           <l>Non s'eguagli a Giunone,</l>
           <l>Suora e sposa di Giove,</l>
           <l>Mio scettro e mia corona,</l>
           <l>Mia somma podestade.</l>
         </sp>
-        <sp>
+        <sp who="#consigliero">
           <speaker>CONSIGLIERO</speaker>
           <l>L'una placa et acqueta,</l>
           <l>L'altra inchina et adora.</l>
         </sp>
-        <sp>
+        <sp who="#eolo">
           <speaker>EOLO</speaker>
           <l>Forse piacerò lei, perché io meno ami</l>
           <l>L'uno e l'altro mio figlio?</l>
           <l>O l'un l'altro non ami?</l>
         </sp>
-        <sp>
+        <sp who="#consigliero">
           <speaker>CONSIGLIERO</speaker>
           <l>Lei ringrazia perché ami</l>
           <l>Te la fedel tua sposa,</l>
@@ -374,7 +411,7 @@
           <l>Non son tardi, che l'uno</l>
           <l>Troppo l'altro non ami.</l>
         </sp>
-        <sp>
+        <sp who="#eolo">
           <speaker>EOLO</speaker>
           <l>Lunge dalla mia casa</l>
           <l>Cada l'ira di Marte,</l>
@@ -387,12 +424,12 @@
           <l>Scaldano il petto molle e delicato</l>
           <l>Della madre d'Amore.</l>
         </sp>
-        <sp>
+        <sp who="#consigliero">
           <speaker>CONSIGLIERO</speaker>
           <l>Voglia Dio che tai motti</l>
           <l>Non tornino in sospiri.</l>
         </sp>
-        <sp>
+        <sp who="#eolo">
           <speaker>EOLO</speaker>
           <l>Deh, per grazia, se mi ami,</l>
           <l>Cessi il tuo mormorare e con parole</l>
@@ -461,14 +498,14 @@
           <l>Fa' che i miei preghi giusti</l>
           <l>Non disperdano i venti.</l>
         </sp>
-        <sp>
+        <sp who="#consigliero">
           <speaker>CONSIGLIERO</speaker>
           <l>O lieve e vana gioia</l>
           <l>Se da' venti dipende!</l>
           <l>O fugace allegrezza, o instabil bene,</l>
           <l>Se viene e va co' venti!</l>
         </sp>
-        <sp>
+        <sp who="#eolo">
           <speaker>EOLO</speaker>
           <l>Tu, il cui senno onora</l>
           <l>Questo mio piccol regno</l>
@@ -488,7 +525,7 @@
       <div>
         <head>Scena 3</head>
         <stage>CONSIGLIERO [<hi rend="italic">solo</hi>]</stage>
-        <sp>
+        <sp who="#consigliero">
           <speaker>CONSIGLIERO</speaker>
           <l>Questa nuova allegrezza</l>
           <l>Che for d'ogni ragione</l>
@@ -549,7 +586,7 @@
         <head>Scena 4</head>
         <stage>[CORO]</stage>
         <stage>CAMERIERA. DEIOPEA</stage>
-        <sp>
+        <sp who="#cameriera">
           <speaker>CAMERIERA</speaker>
           <l>Reina Deiopea,</l>
           <l>Vagliami quella fede</l>
@@ -568,7 +605,7 @@
           <l>Che uso è di potere</l>
           <l>Vostro senno e valore.</l>
         </sp>
-        <sp>
+        <sp who="#deiopea">
           <speaker>DEIOPEA</speaker>
           <l>Ben pòi sicuramente</l>
           <l>Spaziare a tua voglia</l>
@@ -639,13 +676,13 @@
           <l>Che è rimaso nel core</l>
           <l>Mi copre il volto ancor del suo colore.</l>
         </sp>
-        <sp>
+        <sp who="#cameriera">
           <speaker>CAMERIERA</speaker>
           <l>Faccia Dio, o reina,</l>
           <l>Che ogni vostro travaglio e ogni sospetto</l>
           <l>Sempre sia sogno et ombra.</l>
         </sp>
-        <sp>
+        <sp who="#deiopea">
           <speaker>DEIOPEA</speaker>
           <l>Come l'ombre presenti</l>
           <l>Vere imagini sono</l>
@@ -663,20 +700,20 @@
           <l>E di molte altre assai</l>
           <l>Che far possiamo e non facciàn giamai.</l>
         </sp>
-        <sp>
+        <sp who="#cameriera">
           <speaker>CAMERIERA</speaker>
           <l>Dunque sono gran parte</l>
           <l>Senza alcun peso e far che nell'aspetto</l>
           <l>I nostri sogni vani.</l>
         </sp>
-        <sp>
+        <sp who="#deiopea">
           <speaker>DEIOPEA</speaker>
           <l>Se ciò non fosse, il mio alto sospetto</l>
           <l>Mi recarebbe al core</l>
           <l>Il medesmo dolore</l>
           <l>Che altrui reca il martiro.</l>
         </sp>
-        <sp>
+        <sp who="#cameriera">
           <speaker>CAMERIERA</speaker>
           <l>Infinito è l'amore</l>
           <l>D'Eolo verso i figliuoli et infinito</l>
@@ -699,7 +736,7 @@
           <l>Voler farvi infelice</l>
           <l>Senza infelicitade.</l>
         </sp>
-        <sp>
+        <sp who="#deiopea">
           <speaker>DEIOPEA</speaker>
           <l>Saggiamente consigli,</l>
           <l>Come è di tuo costume.</l>
@@ -729,7 +766,7 @@
       <div>
         <head>Scena 5</head>
         <stage>CAMERIERA [<hi rend="italic">sola</hi>]</stage>
-        <sp>
+        <sp who="#cameriera">
           <speaker>CAMERIERA</speaker>
           <l>Sempre d'allora in qua che prima apersi</l>
           <l>Gli occhi dello 'ntelletto</l>
@@ -773,7 +810,7 @@
       <div>
         <head>Scena 6</head>
         <stage>MACAREO. FAMIGLIO. CAMERIERA</stage>
-        <sp>
+        <sp who="#macareo">
           <speaker>MACAREO</speaker>
           <l>Oggi non odo o vedo alcuna cosa</l>
           <l>Che lieta sia e mentre in qualche modo</l>
@@ -785,14 +822,14 @@
           <l>Di quali augurii rei</l>
           <l>Pò ragionar costei?</l>
         </sp>
-        <sp>
+        <sp who="#famiglio">
           <speaker>FAMIGLIO</speaker>
           <l>Se vi è caro il saperlo,</l>
           <l>Signor, fatele motto attraversando</l>
           <l>Questo poco di strada</l>
           <l>Prima che ella sen vada.</l>
         </sp>
-        <sp>
+        <sp who="#macareo">
           <speaker>MACAREO</speaker>
           <l>Secretaria fedel della reina</l>
           <l>Mia madre e tua signora,</l>
@@ -801,7 +838,7 @@
           <l>Onde in atti e in parole</l>
           <l>Sola teco ti duoli e ti lamenti.</l>
         </sp>
-        <sp>
+        <sp who="#cameriera">
           <speaker>CAMERIERA</speaker>
           <l>Macareo signor mio,</l>
           <l>Vita della reina,</l>
@@ -835,12 +872,12 @@
           <l>Da lei mandata, e vogliola ubidire,</l>
           <l>S'altro non vuoi udire.</l>
         </sp>
-        <sp>
+        <sp who="#macareo">
           <speaker>MACAREO</speaker>
           <l>Poco parle aver detto! Or pòi andare</l>
           <l>Ove e quando ti piace.</l>
         </sp>
-        <sp>
+        <sp who="#cameriera">
           <speaker>CAMERIERA</speaker>
           <l>Rimanetevi in pace.</l>
         </sp>
@@ -848,7 +885,7 @@
       <div>
         <head>Scena 7</head>
         <stage>FAMIGLIO. MACAREO</stage>
-        <sp>
+        <sp who="#famiglio">
           <speaker>FAMIGLIO</speaker>
           <l>Signore, a quel che io scerno nella faccia</l>
           <l>Di vostro stato interno,</l>
@@ -856,7 +893,7 @@
           <l>Alcun sospetto porse</l>
           <l>Vi fa essere in forse.</l>
         </sp>
-        <sp>
+        <sp who="#macareo">
           <speaker>MACAREO</speaker>
           <l>Questo sogno materno,</l>
           <l>Se come è buon pittore</l>
@@ -917,7 +954,7 @@
       <div>
         <head>Scena 8</head>
         <stage>NUTRICE. MACAREO</stage>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUTRICE</speaker>
           <l>Macareo figliuol mio, or che nel caso</l>
           <l>Di tua sorella e tuo</l>
@@ -942,7 +979,7 @@
           <l>Far tanto mai che in così fatto caso</l>
           <l>Dovesse essere assai.</l>
         </sp>
-        <sp>
+        <sp who="#macareo">
           <speaker>MACAREO</speaker>
           <l>Nutrice di colei che la natura</l>
           <l>Per sorella mi diede, Amor per moglie,</l>
@@ -964,7 +1001,7 @@
           <l>Paterna incrudelisca</l>
           <l>Nella figlia innocente.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUTRICE</speaker>
           <l>Dunque credi, crudel, che tua sorella</l>
           <l>Ami tanto sé stessa che togliesse</l>
@@ -980,7 +1017,7 @@
       <div>
         <head>Scena 9</head>
         <stage>NUTRICE <hi rend="italic">sola</hi>.</stage>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUTRICE</speaker>
           <l>Sciocchi a mio danno o del ben mio nemici</l>
           <l>Furono veramente</l>
@@ -1040,7 +1077,7 @@
         <head>Scena 10</head>
         <stage>[CORO]</stage>
         <stage>CANACE</stage>
-        <sp>
+        <sp who="#canace">
           <speaker>CANACE</speaker>
           <l>O Giunone Lucina,</l>
           <l>Dea de' parti, dea</l>
@@ -1087,7 +1124,7 @@
       <div>
         <head>Scena 11</head>
         <stage>NUTRICE. CANACE</stage>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUTRICE</speaker>
           <l>O figliuola meschina,</l>
           <l>Ora ove ti mena</l>
@@ -1105,7 +1142,7 @@
           <l>Di timore e d'orrore,</l>
           <l>Di vergogna, di danno.</l>
         </sp>
-        <sp>
+        <sp who="#canace">
           <speaker>CANACE</speaker>
           <l>A quai promesse vane</l>
           <l>Di bugiarda speranza</l>
@@ -1123,7 +1160,7 @@
           <l>Del mio commesso errore</l>
           <l>La propria conscienzia.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUTRICE</speaker>
           <l>Per qual nova cagione</l>
           <l>Così subitamente</l>
@@ -1141,7 +1178,7 @@
           <l>Che io possa altrui coprire</l>
           <l>L'ora del partorire?</l>
         </sp>
-        <sp>
+        <sp who="#canace">
           <speaker>CANACE</speaker>
           <l>Basta un punto alla pena</l>
           <l>D'ogni lungo peccato.</l>
@@ -1152,7 +1189,7 @@
           <l>Del mio commesso errore</l>
           <l>Con mio doppio dolore.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUTRICE</speaker>
           <l>O vinta dal dolore,</l>
           <l>Disperata fanciulla,</l>
@@ -1167,7 +1204,7 @@
           <l>D'ogni legge e costume,</l>
           <l>Ti divenisse sposo.</l>
         </sp>
-        <sp>
+        <sp who="#canace">
           <speaker>CANACE</speaker>
           <l>Odio a morte la vita</l>
           <l>Che con ragio sì cruda e sì spiacente</l>
@@ -1178,12 +1215,12 @@
           <l>E mi fa disiare</l>
           <l>Quel che io temo e pavento.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUTRICE</speaker>
           <l>Viva al tuo Macareo</l>
           <l>La vita tua, tua non già, ma sua.</l>
         </sp>
-        <sp>
+        <sp who="#canace">
           <speaker>CANACE</speaker>
           <l>Fa' che questa mia vita</l>
           <l>Possa tanto schermirsi dagli affanni</l>
@@ -1194,19 +1231,19 @@
           <l>Come posso sperare</l>
           <l>Che debba essere altrui dolce o gioiosa?</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUTRICE</speaker>
           <l>More, se tu non vivi,</l>
           <l>Il figliuolo innocente.</l>
         </sp>
-        <sp>
+        <sp who="#canace">
           <speaker>CANACE</speaker>
           <l>Vivendo, vive un figlio</l>
           <l>Di due fratelli, un mostro, un disonore</l>
           <l>Del secol nostro, un testimonio eterno</l>
           <l>Di scelerato amore.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUTRICE</speaker>
           <l>Poi che viver non vòi</l>
           <l>Alla vita del tuo parto innocente,</l>
@@ -1228,12 +1265,12 @@
           <l>Se a me credevi, avea fatto sicuri</l>
           <l>Te, il fratello e il figlio.</l>
         </sp>
-        <sp>
+        <sp who="#canace">
           <speaker>CANACE</speaker>
           <l>Lasciarai tu, crudele,</l>
           <l>Me sconsolata e sola?</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUTRICE</speaker>
           <l>Crudel, cui soffre il core</l>
           <l>Di far seco perire</l>
@@ -1241,7 +1278,7 @@
           <l>Il figliuolo, il fratello</l>
           <l>E sua fama e suo onore.</l>
         </sp>
-        <sp>
+        <sp who="#canace">
           <speaker>CANACE</speaker>
           <l>Ecco la vita mia</l>
           <l>Combattuta d'amore e da pietade,</l>
@@ -1250,7 +1287,7 @@
           <l>Vinca qual più li piace,</l>
           <l>Se non si pò aver pace.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUTRICE</speaker>
           <l>Vinca speme e ragione i duri assalti</l>
           <l>De gli adversarii tuoi</l>
@@ -1273,7 +1310,7 @@
           <l>Oggi possa avanzare</l>
           <l>Alla disperazione.</l>
         </sp>
-        <sp>
+        <sp who="#canace">
           <speaker>CANACE</speaker>
           <l>Ora ovunque si trovi, o nel profondo</l>
           <l>Del mare o presso al porto,</l>
@@ -1282,19 +1319,19 @@
           <l>Poco posso esser lunge</l>
           <l>Dal fin d'ogni mio affanno.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUTRICE</speaker>
           <l>Di poco core, ancora</l>
           <l>Non ti assicuri? Ancora</l>
           <l>Rifiuti i miei conforti?</l>
         </sp>
-        <sp>
+        <sp who="#canace">
           <speaker>CANACE</speaker>
           <l>Già non posso a mio senno</l>
           <l>Sperare e disperare:</l>
           <l>Come posso ubidirti?</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUTRICE</speaker>
           <l>Entra, figliuola, e vivi</l>
           <l>Nel tuo secreto albergo,</l>
@@ -1304,7 +1341,7 @@
           <l>Basta alla tua salute</l>
           <l>Che tu voglia ubidirmi.</l>
         </sp>
-        <sp>
+        <sp who="#canace">
           <speaker>CANACE</speaker>
           <l>Entro, da che il comandi:</l>
           <l>Siati ricomandata</l>
@@ -1319,7 +1356,7 @@
       <div>
         <head>Scena 12</head>
         <stage>NUTRICE <hi rend="italic">sola</hi>.</stage>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUTRICE</speaker>
           <l>Qui starò aspettando fin che passi</l>
           <l>Il famiglio che io aspetto.</l>
@@ -1328,7 +1365,7 @@
           <l>L'albergo di Canace.</l>
         </sp>
         <stage>DEIOPEA. NUTRICE</stage>
-        <sp>
+        <sp who="#deiopea">
           <speaker>DEIOPEA</speaker>
           <l>O nutrice fedele,</l>
           <l>O accorta nutrice,</l>
@@ -1345,7 +1382,7 @@
           <l>E che fa or nella sua cameretta</l>
           <l>La tua figliola e mia?</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUTRICE</speaker>
           <l>O reina, signora</l>
           <l>Di ciò che vale e pò la vita mia,</l>
@@ -1364,7 +1401,7 @@
           <l>Del giovine anno. In tanto</l>
           <l>Ella si posa e dorme.</l>
         </sp>
-        <sp>
+        <sp who="#deiopea">
           <speaker>DEIOPEA</speaker>
           <l>Piacemi questa sua</l>
           <l>Divota gentilezza.</l>
@@ -1380,7 +1417,7 @@
       <div>
         <head>Scena 13</head>
         <stage>NUTRICE <hi rend="italic">sola</hi>.</stage>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUTRICE</speaker>
           <l>Queste secrete imprese, onde dipende</l>
           <l>La salute e l'onore</l>
@@ -1409,7 +1446,7 @@
       <div>
         <head>Scena 14</head>
         <stage>FAMIGLIO. NUTRICE</stage>
-        <sp>
+        <sp who="#famiglio">
           <speaker>FAMIGLIO</speaker>
           <l>Ecco che io vegno presto</l>
           <l>A' tuoi comandamenti,</l>
@@ -1420,7 +1457,7 @@
           <l>D'alcuni fiori, intendo</l>
           <l>Di quel frutto che attendo.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUTRICE</speaker>
           <l>Ora intendi di fiori:</l>
           <l>De' quai tu m'empierai</l>
@@ -1428,13 +1465,13 @@
           <l>Quanto più tosto pòi,</l>
           <l>La mi riporterai.</l>
         </sp>
-        <sp>
+        <sp who="#famiglio">
           <speaker>FAMIGLIO</speaker>
           <l>Di questi fiori vòi</l>
           <l>Che io dica al mio signore</l>
           <l>Quel che tu ne farai?</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUTRICE</speaker>
           <l>De' medesimi fiori</l>
           <l>Nella cesta medesma</l>
@@ -1465,7 +1502,7 @@
       <div>
         <head>Scena 15</head>
         <stage>FAMIGLIO [<hi rend="italic">solo</hi>].</stage>
-        <sp>
+        <sp who="#famiglio">
           <speaker>FAMIGLIO</speaker>
           <l>O femminil natura,</l>
           <l>Da qual fato di Dio, da qual ventura</l>
@@ -1508,7 +1545,7 @@
         <head>Scena 16</head>
         <stage>[CORO]</stage>
         <stage>FAMIGLIO. CORO</stage>
-        <sp>
+        <sp who="#famiglio">
           <speaker>FAMIGLIO</speaker>
           <l>O fortuna nemica</l>
           <l>Delle pietose imprese:</l>
@@ -1520,14 +1557,14 @@
           <l>E, che è peggio, la spene</l>
           <l>Di mai più ricovrarlo!</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CORO</speaker>
           <l>O dolente principio!</l>
           <l>Che parole son queste? Che novelle</l>
           <l>Di là entro n'apporti?</l>
           <l>Parla: che vòi tu dire?</l>
         </sp>
-        <sp>
+        <sp who="#famiglio">
           <speaker>FAMIGLIO</speaker>
           <l>O misera Canace,</l>
           <l>Misero Macareo, o infelice</l>
@@ -1541,7 +1578,7 @@
           <l>Mortali et immortali</l>
           <l>Infelici egualmente.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CORO</speaker>
           <l>Distingui omai, distingui</l>
           <l>Questi confusi mali:</l>
@@ -1551,7 +1588,7 @@
           <l>In ogni suo accidente</l>
           <l>Che la sorte comparte.</l>
         </sp>
-        <sp>
+        <sp who="#famiglio">
           <speaker>FAMIGLIO</speaker>
           <l>Discoperto ha fortuna ogni secreto</l>
           <l>Dell'amor di Canace:</l>
@@ -1559,19 +1596,19 @@
           <l>E il fanciul pur mo nato ha nelle mani</l>
           <l>Il padre aspro e feroce.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CORO</speaker>
           <l>Parla sì bassamente</l>
           <l>Che non l'oda la gente.</l>
         </sp>
-        <sp>
+        <sp who="#famiglio">
           <speaker>FAMIGLIO</speaker>
           <l>Poco per la mia lingua</l>
           <l>Potrà il vulgo sapere,</l>
           <l>Che con la propria luce</l>
           <l>Non abbia visto o non sia per vedere.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CORO</speaker>
           <l>L'error corto d'un dito,</l>
           <l>Seminato nel vulgo,</l>
@@ -1581,17 +1618,17 @@
           <l>Ma chi fu l'inumano</l>
           <l>Che palesò così pietoso inganno?</l>
         </sp>
-        <sp>
+        <sp who="#famiglio">
           <speaker>FAMIGLIO</speaker>
           <l>Il fanciullo medesmo</l>
           <l>Che pur mo nacque.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CORO</speaker>
           <l>O giudizio divino!</l>
           <l>Or ne conta in che modo.</l>
         </sp>
-        <sp>
+        <sp who="#famiglio">
           <speaker>FAMIGLIO</speaker>
           <l>Dovete avere a mente</l>
           <l>L'ordine che fu posto di celare</l>
@@ -1698,7 +1735,7 @@
           <l>Che ha perduto ogni bene</l>
           <l>E stallo ad aspettare.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CORO</speaker>
           <l>Tosto ritroverai il tuo signore:</l>
           <l>Che alle triste novelle sempremai</l>
@@ -1722,7 +1759,7 @@
       <div>
         <head>Scena 17</head>
         <stage>EOLO. CONSIGLIERO</stage>
-        <sp>
+        <sp who="#eolo">
           <speaker>EOLO</speaker>
           <l>Scelerati figliuoli, così come</l>
           <l>Più vi sarebbe onore</l>
@@ -1737,54 +1774,54 @@
           <l>Ove nissun crudele</l>
           <l>Non po' esser crudel tanto che basti.</l>
         </sp>
-        <sp>
+        <sp who="#consigliero">
           <speaker>CONSIGLIERO</speaker>
           <l>Io non so caso alcun tanto e sì grave,</l>
           <l>Che la vostra virtude,</l>
           <l>Se ella è vosco al bisogno, in tempo breve</l>
           <l>Nol vi faccia sentir piccolo e leve.</l>
         </sp>
-        <sp>
+        <sp who="#eolo">
           <speaker>EOLO</speaker>
           <l>Memorabil vendetta</l>
           <l>Mi torrà dalle spalle</l>
           <l>Questo noioso incarco.</l>
         </sp>
-        <sp>
+        <sp who="#consigliero">
           <speaker>CONSIGLIERO</speaker>
           <l>Tolga Iddio che giamai</l>
           <l>Il disio di vendetta</l>
           <l>Sieda in un cor reale et ivi usurpi</l>
           <l>Della giustizia il loco.</l>
         </sp>
-        <sp>
+        <sp who="#eolo">
           <speaker>EOLO</speaker>
           <l>La vendetta in tal caso,</l>
           <l>Quanto men fie pietosa,</l>
           <l>Tanto sarà più giusta.</l>
         </sp>
-        <sp>
+        <sp who="#consigliero">
           <speaker>CONSIGLIERO</speaker>
           <l>Non po' esser giustizia</l>
           <l>Nemica di pietade.</l>
         </sp>
-        <sp>
+        <sp who="#eolo">
           <speaker>EOLO</speaker>
           <l>Qui sarebbe impietade</l>
           <l>L'aver compassione.</l>
         </sp>
-        <sp>
+        <sp who="#consigliero">
           <speaker>CONSIGLIERO</speaker>
           <l>Signor, non vi scordate d'esser dio</l>
           <l>E che, come re siete,</l>
           <l>Così voi siete padre.</l>
         </sp>
-        <sp>
+        <sp who="#eolo">
           <speaker>EOLO</speaker>
           <l>Vòi tu che egli sia lecito a' figliuoli</l>
           <l>De' dei l'essere iniqui e scelerati?</l>
         </sp>
-        <sp>
+        <sp who="#consigliero">
           <speaker>CONSIGLIERO</speaker>
           <l>Questo non: ma vorrei</l>
           <l>Che lo sdegno e il disio</l>
@@ -1792,7 +1829,7 @@
           <l>Colpe di noi mortali,</l>
           <l>Non peccati di dei.</l>
         </sp>
-        <sp>
+        <sp who="#eolo">
           <speaker>EOLO</speaker>
           <l>A punir degnamente</l>
           <l>Questi due scelerati</l>
@@ -1801,7 +1838,7 @@
           <l>Essere oggi tal dio che immantenente</l>
           <l>Potessi far che non fosser mai nati.</l>
         </sp>
-        <sp>
+        <sp who="#consigliero">
           <speaker>CONSIGLIERO</speaker>
           <l>Sia, se volete, iniquo e scelerato</l>
           <l>L'uno e l'altro parente;</l>
@@ -1809,7 +1846,7 @@
           <l>Punirà il vostro sdegno</l>
           <l>Questo parto innocente?</l>
         </sp>
-        <sp>
+        <sp who="#eolo">
           <speaker>EOLO</speaker>
           <l>Mora per nostro onore</l>
           <l>L'infamia del mio regno,</l>
@@ -1821,7 +1858,7 @@
           <l>Chi nascer non dovea, sì malamente</l>
           <l>Fu generato.</l>
         </sp>
-        <sp>
+        <sp who="#consigliero">
           <speaker>CONSIGLIERO</speaker>
           <l>Se la pietà paterna</l>
           <l>In voi non pò soffrir di veder vivi</l>
@@ -1834,24 +1871,24 @@
           <l>Di vederli et udirli,</l>
           <l>Temete di exaudirli.</l>
         </sp>
-        <sp>
+        <sp who="#eolo">
           <speaker>EOLO</speaker>
           <l>Pianti, sospiri e dimandar mercede</l>
           <l>Foran le lor ragioni.</l>
         </sp>
-        <sp>
+        <sp who="#consigliero">
           <speaker>CONSIGLIERO</speaker>
           <l>Lecito è lor, quando non hanno altre armi,</l>
           <l>Usar pianti e sospiri</l>
           <l>In lor difesa e dimandar mercede.</l>
         </sp>
-        <sp>
+        <sp who="#eolo">
           <speaker>EOLO</speaker>
           <l>Non voglio esser traffitto</l>
           <l>Da cotali armi, usate</l>
           <l>A ferir la giustizia.</l>
         </sp>
-        <sp>
+        <sp who="#consigliero">
           <speaker>CONSIGLIERO</speaker>
           <l>Se l'arme di pietade</l>
           <l>Temete, or vi pensate</l>
@@ -1859,7 +1896,7 @@
           <l>A' miseri soggetti</l>
           <l>Quelle di crudeltade.</l>
         </sp>
-        <sp>
+        <sp who="#eolo">
           <speaker>EOLO</speaker>
           <l>Tosto vedrai come io</l>
           <l>Adopro e fo sentire,</l>
@@ -1899,7 +1936,7 @@
       <div>
         <head>Scena 18</head>
         <stage>DEIOPEA. MINISTRO</stage>
-        <sp>
+        <sp who="#deiopea">
           <speaker>DEIOPEA</speaker>
           <l>In vano t'affatichi</l>
           <l>A volermi coprir sotto la vesta</l>
@@ -1915,14 +1952,14 @@
           <l>Spegni la vita mia,</l>
           <l>Morirò disperata.</l>
         </sp>
-        <sp>
+        <sp who="#ministro">
           <speaker>MINISTRO</speaker>
           <l>Reina, io non posso altro che exequire,</l>
           <l>Benché contra mia voglia,</l>
           <l>Il voler di colui</l>
           <l>Cui convegno ubidire.</l>
         </sp>
-        <sp>
+        <sp who="#deiopea">
           <speaker>DEIOPEA</speaker>
           <l>Se l'auttorità mia</l>
           <l>E le mie forze alcuna cosa ponno,</l>
@@ -1935,37 +1972,37 @@
       <div>
         <head>Scena 19</head>
         <stage>EOLO. DEIOPEA</stage>
-        <sp>
+        <sp who="#eolo">
           <speaker>EOLO</speaker>
           <l>Reina, già tu osi</l>
           <l>Cominciare una impresa</l>
           <l>Che contra il mio volere</l>
           <l>Non dèi né pòi finire.</l>
         </sp>
-        <sp>
+        <sp who="#deiopea">
           <speaker>DEIOPEA</speaker>
           <l>O signor e consorte,</l>
           <l>O non mi tòr la vita</l>
           <l>De' miei figliuoli, o dammi la mia morte.</l>
         </sp>
-        <sp>
+        <sp who="#eolo">
           <speaker>EOLO</speaker>
           <l>Tuoi figli scelerati</l>
           <l>Non son degni di vita,</l>
           <l>Né tu merti la morte.</l>
         </sp>
-        <sp>
+        <sp who="#deiopea">
           <speaker>DEIOPEA</speaker>
           <l>Signor, degna d'udirmi e saperai</l>
           <l>Che l'error de' tuoi figli</l>
           <l>È mio proprio peccato.</l>
         </sp>
-        <sp>
+        <sp who="#eolo">
           <speaker>EOLO</speaker>
           <l>Parte arai della pena,</l>
           <l>Se nella colpa hai parte.</l>
         </sp>
-        <sp>
+        <sp who="#deiopea">
           <speaker>DEIOPEA</speaker>
           <l>Altro da te non cheggio</l>
           <l>Salvo che in giusta parte</l>
@@ -2068,7 +2105,7 @@
           <l>Non debbo se io volessi,</l>
           <l>Né vorrei se io potessi.</l>
         </sp>
-        <sp>
+        <sp who="#eolo">
           <speaker>EOLO</speaker>
           <l>Reina, abbi pazienza:</l>
           <l>Che avendo la malizia</l>
@@ -2095,7 +2132,7 @@
           <l>Sua fedel consigliera, e quel suo figlio</l>
           <l>Le faran compagnia.</l>
         </sp>
-        <sp>
+        <sp who="#deiopea">
           <speaker>DEIOPEA</speaker>
           <l>O veramente dio</l>
           <l>Di nembi e di procelle,</l>
@@ -2122,20 +2159,20 @@
       <div>
         <head>Scena 20</head>
         <stage>CAMERIERA. EOLO</stage>
-        <sp>
+        <sp who="#cameriera">
           <speaker>CAMERIERA</speaker>
           <l>Oimè, signora mia,</l>
           <l>Siete voi morta! Aiuto!</l>
         </sp>
-        <sp>
+        <sp who="#eolo">
           <speaker>EOLO</speaker>
           <l>Sostienla, che non caschi.</l>
         </sp>
-        <sp>
+        <sp who="#cameriera">
           <speaker>CAMERIERA</speaker>
           <l>Sola non posso.</l>
         </sp>
-        <sp>
+        <sp who="#eolo">
           <speaker>EOLO</speaker>
           <l>Accorri,</l>
           <l>Et aiuta a tenerla:</l>
@@ -2151,7 +2188,7 @@
         <head>Scena 21</head>
         <stage>[CORO]</stage>
         <stage>MACAREO. FAMIGLIO</stage>
-        <sp>
+        <sp who="#macareo">
           <speaker>MACAREO</speaker>
           <l>Qui non si vede e dentro</l>
           <l>Non si ode pur un segno</l>
@@ -2161,7 +2198,7 @@
           <l>Et ho onde temer, che ciò non sia</l>
           <l>Silenzio e solitudine di morte.</l>
         </sp>
-        <sp>
+        <sp who="#famiglio">
           <speaker>FAMIGLIO</speaker>
           <l>Signore, al mio partire</l>
           <l>Qui era vostro padre con un volto</l>
@@ -2172,7 +2209,7 @@
           <l>A chi gli fosse avante.</l>
           <l>Dimandatene pur questi suoi venti.</l>
         </sp>
-        <sp>
+        <sp who="#macareo">
           <speaker>MACAREO</speaker>
           <l>Venti fratei (perché già molti mesi</l>
           <l>Son divenuto un vento</l>
@@ -2186,13 +2223,13 @@
           <l>Disio della mia morte?</l>
           <l>Vive l'anima mia?</l>
         </sp>
-        <sp>
+        <sp who="#famiglio">
           <speaker>FAMIGLIO</speaker>
           <l>Non è fra tutti loro un sì cortese</l>
           <l>Che sola una parola</l>
           <l>Vi renda per risposta.</l>
         </sp>
-        <sp>
+        <sp who="#macareo">
           <speaker>MACAREO</speaker>
           <l>Anzi non è fra tutti un sì crudele</l>
           <l>Che non mostri nel viso</l>
@@ -2239,7 +2276,7 @@
       <div>
         <head>Scena 22</head>
         <stage>MINISTRO</stage>
-        <sp>
+        <sp who="#ministro">
           <speaker>MINISTRO</speaker>
           <l>Debbo tuut'oggi andar dentro e di fore,</l>
           <l>Portando e riportando or nelle mani</l>
@@ -2265,7 +2302,7 @@
       <div>
         <head>Scena 23</head>
         <stage>FAMIGLIO. MACAREO. MINISTRO</stage>
-        <sp>
+        <sp who="#famiglio">
           <speaker>FAMIGLIO</speaker>
           <l>Ecco di qua, signore,</l>
           <l>Chi forse vi darà certa novella</l>
@@ -2274,7 +2311,7 @@
           <l>Altro non par che rechi</l>
           <l>Salvo pianto e dolore.</l>
         </sp>
-        <sp>
+        <sp who="#macareo">
           <speaker>MACAREO</speaker>
           <l>O tu, se ne' ministri</l>
           <l>Di signor sì crudel pò dimorare</l>
@@ -2282,12 +2319,12 @@
           <l>Per grazia dimmi se io</l>
           <l>Giungo tardi o per tempo.</l>
         </sp>
-        <sp>
+        <sp who="#ministro">
           <speaker>MINISTRO</speaker>
           <l>Tardi all'altrui soccorso</l>
           <l>Giungi, signor, ma alla tua pena a·ttempo.</l>
         </sp>
-        <sp>
+        <sp who="#macareo">
           <speaker>MACAREO</speaker>
           <l>O dolce anima mia, tu sei pur ita</l>
           <l>Per mai più non tornare</l>
@@ -2296,7 +2333,7 @@
           <l>Dimmi, ti prego, il modo, il tempo e il loco</l>
           <l>Della sua dipartita.</l>
         </sp>
-        <sp>
+        <sp who="#ministro">
           <speaker>MINISTRO</speaker>
           <l>Ben lo debbo saper, se io fui costretto</l>
           <l>A·ffare una gran parte</l>
@@ -2308,7 +2345,7 @@
           <l>Né pria mi fu dimesso il dipartire,</l>
           <l>Che io la vidi morire.</l>
         </sp>
-        <sp>
+        <sp who="#macareo">
           <speaker>MACAREO</speaker>
           <l>Dolore, onde io son pieno,</l>
           <l>Pace non vo' da te, ma solamente</l>
@@ -2330,7 +2367,7 @@
           <l>Mi farebbe gustar non che udir cose</l>
           <l>Che mi fosser noiose.</l>
         </sp>
-        <sp>
+        <sp who="#ministro">
           <speaker>MINISTRO</speaker>
           <l>Signor, vostra sorella in sul morire</l>
           <l>Mi comandò, et io</l>
@@ -2413,7 +2450,7 @@
           <l>Finì sua vita et io per la pietade</l>
           <l>Restai morto et exangue.</l>
         </sp>
-        <sp>
+        <sp who="#macareo">
           <speaker>MACAREO</speaker>
           <l>O crudel Macareo, ancora vivi?</l>
           <l>Ancora ardito sei di respirare,</l>
@@ -2429,7 +2466,7 @@
           <l>Che tuttavia mi tiene</l>
           <l>Peggio che morto in così lunghe pene?</l>
         </sp>
-        <sp>
+        <sp who="#famiglio">
           <speaker>FAMIGLIO</speaker>
           <l>Signor, se bene avete</l>
           <l>Le sue parole intese,</l>
@@ -2437,7 +2474,7 @@
           <l>Alla vostra sorella così morta</l>
           <l>Se viverete e vi darete pace.</l>
         </sp>
-        <sp>
+        <sp who="#macareo">
           <speaker>MACAREO</speaker>
           <l>Come è possibil cosa</l>
           <l>Vivere e darmi pace?</l>
@@ -2450,7 +2487,7 @@
           <l>Dimmi tu: che fu fatto</l>
           <l>Del fanciul pur mo nato?</l>
         </sp>
-        <sp>
+        <sp who="#ministro">
           <speaker>MINISTRO</speaker>
           <l>Non vogliate, signore,</l>
           <l>Pena aggiungere a pena</l>
@@ -2465,7 +2502,7 @@
           <l>Che ove voi siete vivo,</l>
           <l>Certo sareste morto.</l>
         </sp>
-        <sp>
+        <sp who="#macareo">
           <speaker>MACAREO</speaker>
           <l>Che fai tu, Macareo?</l>
           <l>Tempo è non di pensar, ma di morire:</l>
@@ -2490,7 +2527,7 @@
       <div>
         <head>Scena 24</head>
         <stage>MINISTRO [<hi rend="italic">solo</hi>].</stage>
-        <sp>
+        <sp who="#ministro">
           <speaker>MINISTRO</speaker>
           <l>Partito è mormorando,</l>
           <l>Portato dal furore.</l>
@@ -2512,7 +2549,7 @@
       <div>
         <head>Scena 25</head>
         <stage>EOLO. CONSIGLIERO.</stage>
-        <sp>
+        <sp who="#eolo">
           <speaker>EOLO</speaker>
           <l>Or conosco, ma tardi, che nel caso</l>
           <l>De' miei figli infelici</l>
@@ -2531,7 +2568,7 @@
           <l>Non abino in memoria</l>
           <l>D'esser nati fratelli?</l>
         </sp>
-        <sp>
+        <sp who="#consigliero">
           <speaker>CONSIGLIERO</speaker>
           <l>Se la vostra prudenzia</l>
           <l>Dianzi, signor, fu vinta dallo sdegno,</l>
@@ -2539,37 +2576,37 @@
           <l>Che 'l dolor non la vinca, onde l'affanno</l>
           <l>Cieda o sia pari al danno.</l>
         </sp>
-        <sp>
+        <sp who="#eolo">
           <speaker>EOLO</speaker>
           <l>Se io volessi dolermi</l>
           <l>Tanto, quanto io dovrei,</l>
           <l>Sempre mi dolerei.</l>
         </sp>
-        <sp>
+        <sp who="#consigliero">
           <speaker>CONSIGLIERO</speaker>
           <l>Vivendo Macareo,</l>
           <l>Mai non osarei dir che fosse morta</l>
           <l>Ogni vostra allegrezza.</l>
         </sp>
-        <sp>
+        <sp who="#eolo">
           <speaker>EOLO</speaker>
           <l>Quel che io so della morte di Canace</l>
           <l>Mi fa essere in dubbio della vita</l>
           <l>Di Macareo.</l>
         </sp>
-        <sp>
+        <sp who="#consigliero">
           <speaker>CONSIGLIERO</speaker>
           <l>Come è ciò, signor mio?</l>
           <l>Comandaste ad alcun che l'uccidesse?</l>
         </sp>
-        <sp>
+        <sp who="#eolo">
           <speaker>EOLO</speaker>
           <l>Temo che la novella della morte</l>
           <l>Della suora e del figlio,</l>
           <l>Tosto che l'abbia udita,</l>
           <l>Non gli toglia la vita.</l>
         </sp>
-        <sp>
+        <sp who="#consigliero">
           <speaker>CONSIGLIERO</speaker>
           <l>Fate ogni opra, signor, o che ei non l'oda,</l>
           <l>O che ei l'oda in maniera che più tosto</l>
@@ -2578,7 +2615,7 @@
           <l>Che biasmar la giustizia</l>
           <l>Che diede altrui la morte.</l>
         </sp>
-        <sp>
+        <sp who="#eolo">
           <speaker>EOLO</speaker>
           <l>Questo pietoso uffizio</l>
           <l>Si conviene al tuo senno</l>
@@ -2596,7 +2633,7 @@
       <div>
         <head>Scena 26</head>
         <stage>MINISTRO</stage>
-        <sp>
+        <sp who="#ministro">
           <speaker>MINISTRO</speaker>
           <l>Andarò inanzi a lui</l>
           <l>A pregar Macareo che non ridica</l>
@@ -2608,7 +2645,7 @@
       <div>
         <head>Scena 27</head>
         <stage>EOLO</stage>
-        <sp>
+        <sp who="#eolo">
           <speaker>EOLO</speaker>
           <l>Misero me, con quanta infamia eterna</l>
           <l>M'ho procurato il danno,</l>
@@ -2635,7 +2672,7 @@
       <div>
         <head>Scena 28</head>
         <stage>FAMIGLIO. EOLO</stage>
-        <sp>
+        <sp who="#famiglio">
           <speaker>FAMIGLIO</speaker>
           <l>Macareo signor mio,</l>
           <l>Signor mio Macareo,</l>
@@ -2644,24 +2681,24 @@
           <l>La vostra casa, il bene e la speranza</l>
           <l>Di tutto 'l vostro regno?</l>
         </sp>
-        <sp>
+        <sp who="#eolo">
           <speaker>EOLO</speaker>
           <l>Chi è costui che piagne lamentando</l>
           <l>Così miseramente?</l>
           <l>Oimè, questo è il famiglio</l>
           <l>Del mio figliuolo, e quella è la sua spada.</l>
         </sp>
-        <sp>
+        <sp who="#famiglio">
           <speaker>FAMIGLIO</speaker>
           <l>Fui, signore, e non sono; e fu sua spada</l>
           <l>Questa che io porto e suo fu questo sangue.</l>
         </sp>
-        <sp>
+        <sp who="#eolo">
           <speaker>EOLO</speaker>
           <l>Figliuol mio, ove sei? Chi mi t'ha tolto?</l>
           <l>Fosse questo il mio sangue!</l>
         </sp>
-        <sp>
+        <sp who="#famiglio">
           <speaker>FAMIGLIO</speaker>
           <l>Re, il mio signor, che già fu vostro figlio,</l>
           <l>Oggi è morto due volte:</l>
@@ -2681,7 +2718,7 @@
           <l>Dal cor questa sua spada,</l>
           <l>Tal la vi recarei.</l>
         </sp>
-        <sp>
+        <sp who="#eolo">
           <speaker>EOLO</speaker>
           <l>Dio volesse, figliuol, che la tua morte</l>
           <l>Mi togliesse la vita,</l>
@@ -2759,7 +2796,7 @@
       <div>
         <head>Scena 29</head>
         <stage>CORO</stage>
-        <sp>
+        <sp who="#coro">
           <speaker>CORO</speaker>
           <l>Le minaccie superbe</l>
           <l>Di questo dio, che in noi</l>

--- a/tei/taccone-comedia-di-danae.xml
+++ b/tei/taccone-comedia-di-danae.xml
@@ -82,6 +82,40 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="poeta">
+            <persName>Poeta</persName>
+          </person>
+          <person xml:id="acrisio">
+            <persName>Acrisio</persName>
+          </person>
+          <person xml:id="siro">
+            <persName>Siro</persName>
+          </person>
+          <person xml:id="danae">
+            <persName>Danae</persName>
+          </person>
+          <person xml:id="giove">
+            <persName>Giove</persName>
+          </person>
+          <person xml:id="mercurio">
+            <persName>Mercurio</persName>
+          </person>
+          <person xml:id="servo">
+            <persName>Servo</persName>
+          </person>
+          <person xml:id="famigli">
+            <persName>Famigli</persName>
+          </person>
+          <person xml:id="ebe">
+            <persName>Ebe</persName>
+          </person>
+          <person xml:id="apollo">
+            <persName>Apollo</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -95,7 +129,7 @@
       <div>
         <head>Atto I</head>
         <stage>Parla el Poeta.</stage>
-        <sp>
+        <sp who="#poeta">
           <speaker>POETA</speaker>
           <lg>
             <l>La forza del crudel fanciullo alato</l>
@@ -139,7 +173,7 @@
           </lg>
         </sp>
         <stage>ACRISIO padre de DANAE dimanda li soi baroni del reame e gli dice el pronostico de Apollo, poi fa la putta mettere in una torre e la dà in custodia a SIRO.</stage>
-        <sp>
+        <sp who="#acrisio">
           <speaker>ACRISIO</speaker>
           <lg>
             <l>Crudel novella, dolci baron mei</l>
@@ -183,7 +217,7 @@
           </lg>
         </sp>
         <stage>Risposta de SIRO.</stage>
-        <sp>
+        <sp who="#siro">
           <speaker>SIRO</speaker>
           <lg>
             <l>Intendo signor caro quel che di':</l>
@@ -197,7 +231,7 @@
           </lg>
         </sp>
         <stage>Lamento di DANAE.</stage>
-        <sp>
+        <sp who="#danae">
           <speaker>DANAE</speaker>
           <lg>
             <l>Rigidità del padre mi dà bando</l>
@@ -221,7 +255,7 @@
           </lg>
         </sp>
         <stage>Excusazione de SIRO verso DANAE così andando alla torre.</stage>
-        <sp>
+        <sp who="#siro">
           <speaker>SIRO</speaker>
           <lg>
             <l>Se del tuo mal, madonna, assai mi duole,</l>
@@ -235,7 +269,7 @@
           </lg>
         </sp>
         <stage>Risposta de DANAE.</stage>
-        <sp>
+        <sp who="#danae">
           <speaker>DANAE</speaker>
           <lg>
             <l>I' so che ambasciator pena non porta</l>
@@ -249,7 +283,7 @@
           </lg>
         </sp>
         <stage>SIRO a DANAE essendo gionto alla torre.</stage>
-        <sp>
+        <sp who="#siro">
           <speaker>SIRO</speaker>
           <lg>
             <l>Gentil madona, questo è il luoco acerbo</l>
@@ -261,7 +295,7 @@
           </lg>
         </sp>
         <stage>Risposta de DANAE.</stage>
-        <sp>
+        <sp who="#danae">
           <speaker>DANAE</speaker>
           <lg>
             <l>Ricomandami al signor mio patre, solo</l>
@@ -269,7 +303,7 @@
           </lg>
         </sp>
         <stage>SIRO ad ACRISIO</stage>
-        <sp>
+        <sp who="#siro">
           <speaker>SIRO</speaker>
           <lg>
             <l>Alto signore, tua figliola è in quella</l>
@@ -286,7 +320,7 @@
       </div>
       <div>
         <head>Atto II</head>
-        <sp>
+        <sp who="#danae">
           <speaker>DANAE</speaker>
           <lg>
             <l>Deh, come mal si può guardare alcuna</l>
@@ -361,7 +395,7 @@
         </sp>
         <stage>In questo punto se discoperse uno cielo bellissimo tutto in un subito dove era GIOVE con li altri dei con infinite lampade in guisa de stelle.</stage>
         <stage>GIOVE parla a MERCURIO.</stage>
-        <sp>
+        <sp who="#giove">
           <speaker>GIOVE</speaker>
           <lg>
             <l>Mercurio de li dii nunzio fidissimo,</l>
@@ -385,7 +419,7 @@
           </lg>
         </sp>
         <stage>Discese MERCURIO così a mezo aria a parlare a DANAE qual era in la torre.</stage>
-        <sp>
+        <sp who="#mercurio">
           <speaker>MERCURIO</speaker>
           <lg>
             <l>Colui che in cielo e in terra impera e regna,</l>
@@ -409,7 +443,7 @@
           </lg>
         </sp>
         <stage>Risposta negativa di DANAE.</stage>
-        <sp>
+        <sp who="#danae">
           <speaker>DANAE</speaker>
           <lg>
             <l>Tal parole aspettar mai non credea</l>
@@ -423,7 +457,7 @@
           </lg>
         </sp>
         <stage>Tornando su MERCURIO in cielo, DANAE da se stessa disse queste parole:</stage>
-        <sp>
+        <sp who="#danae">
           <speaker>DANAE</speaker>
           <lg>
             <l>Gente prosumptuosa, che bisogna</l>
@@ -437,7 +471,7 @@
           </lg>
         </sp>
         <stage>Risposta de MERCURIO a Giove.</stage>
-        <sp>
+        <sp who="#mercurio">
           <speaker>MERCURIO</speaker>
           <lg>
             <l>La risposta che fa la dolce amata</l>
@@ -451,7 +485,7 @@
           </lg>
         </sp>
         <stage>GIOVE a MERCURIO.</stage>
-        <sp>
+        <sp who="#giove">
           <speaker>GIOVE</speaker>
           <lg>
             <l>Ben ho pensato di provare altra arte,</l>
@@ -475,19 +509,19 @@
           </lg>
         </sp>
         <stage>Secundo descendimento che fece MERCURIO, e alora vene fin in terra e andò alla torre a parlare a SIRO.</stage>
-        <sp>
+        <sp who="#mercurio">
           <speaker>MERCURIO</speaker>
           <lg>
             <l>Ben staga Siro nostro.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#siro">
           <speaker>SIRO</speaker>
           <lg>
             <l>Oh! Gli è Mercurio.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mercurio">
           <speaker>MERCURIO</speaker>
           <lg>
             <l>Voluto ho per tuo amor dal ciel descendere;</l>
@@ -519,7 +553,7 @@
             <l>pensa tu forse la festuca incidere?</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#siro">
           <speaker>SIRO</speaker>
           <lg>
             <l>Sì che nel volto, Mercurio, mi svario,</l>
@@ -547,7 +581,7 @@
             <l>ma non siàn fanciulin da cuna o bambuli.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mercurio">
           <speaker>MERCURIO</speaker>
           <lg>
             <l>Non mi vo' tu, mio Sir, l'orecchio porgere ?</l>
@@ -590,7 +624,7 @@
             <l>gran ricco ti farò, sendo sì povero.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#siro">
           <speaker>SIRO</speaker>
           <lg>
             <l>Et io voglio più presto essere ignobile</l>
@@ -633,7 +667,7 @@
             <l>Altri dinar non han, qui in corte pioveno.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#mercurio">
           <speaker>MERCURIO</speaker>
           <lg>
             <l>Credo che forsi meco, Siro, simuli;</l>
@@ -656,7 +690,7 @@
             <l>doppo el longo servire al fin se sacciano.</l>
           </lg>
         </sp>
-        <sp>
+        <sp who="#siro">
           <speaker>SIRO</speaker>
           <lg>
             <l>Che bisogna più dir, Mercurio? Frangere</l>
@@ -673,7 +707,7 @@
           </lg>
         </sp>
         <stage>Torna MERCURIO in cielo e risponde a GIOVE non avere potuto operare cosa alcuna.</stage>
-        <sp>
+        <sp who="#mercurio">
           <speaker>MERCURIO</speaker>
           <lg>
             <l>Quel Siro ch'è là giù stolto è per certo.</l>
@@ -848,7 +882,7 @@
       <div>
         <head>Atto III</head>
         <stage>GIOVE parla a MERCURIO.</stage>
-        <sp>
+        <sp who="#giove">
           <speaker>GIOVE</speaker>
           <lg>
             <l>Mercurio, adesso cresce el mio desire</l>
@@ -862,7 +896,7 @@
           </lg>
         </sp>
         <stage>MERCURIO descendendo dice queste parole:</stage>
-        <sp>
+        <sp who="#mercurio">
           <speaker>MERCURIO</speaker>
           <lg>
             <l>Questo mandar di letre è un gran favore,</l>
@@ -871,7 +905,7 @@
           </lg>
         </sp>
         <stage>MERCURIO a DANAE.</stage>
-        <sp>
+        <sp who="#mercurio">
           <speaker>MERCURIO</speaker>
           <lg>
             <l>Madona, se al tuo ben sei pronta e amica,</l>
@@ -908,7 +942,7 @@
           <l>venga a colei che incarcerato el tiene.</l>
         </lg>
         <stage>DANAE lacera la letra e MERCURIO parla da se stesso.</stage>
-        <sp>
+        <sp who="#mercurio">
           <speaker>MERCURIO</speaker>
           <lg>
             <l>Aiutami, Fortuna, questo è un segno,</l>
@@ -918,7 +952,7 @@
           </lg>
         </sp>
         <stage>Torna DANAE e così dice:</stage>
-        <sp>
+        <sp who="#danae">
           <speaker>DANAE</speaker>
           <lg>
             <l>Aciò che sapia ognun ch'io non mi sdegno</l>
@@ -951,7 +985,7 @@
           <l>impresa aspetta da magior assalto.</l>
         </lg>
         <stage>GIOVE a MERCURIO.</stage>
-        <sp>
+        <sp who="#giove">
           <speaker>GIOVE</speaker>
           <lg>
             <l>Or lassa fare a me, che sì l'inganno</l>
@@ -1084,7 +1118,7 @@
       <div>
         <head>Atto IV</head>
         <stage>ACRISIO re parla ad un suo SERVO.</stage>
-        <sp>
+        <sp who="#acrisio">
           <speaker>ACRISIO</speaker>
           <lg>
             <l>Perché già tanti dì non ho novella</l>
@@ -1096,7 +1130,7 @@
           </lg>
         </sp>
         <stage>Risposta del SERVO.</stage>
-        <sp>
+        <sp who="#servo">
           <speaker>SERVO</speaker>
           <lg>
             <l>Serà fatto, signor gentile e ornato;</l>
@@ -1104,7 +1138,7 @@
           </lg>
         </sp>
         <stage>Quello SERVO va alla torre e dice a SIRO.</stage>
-        <sp>
+        <sp who="#servo">
           <speaker>SERVO</speaker>
           <lg>
             <l>Siro, dice el signor che vòl sapere</l>
@@ -1114,7 +1148,7 @@
           </lg>
         </sp>
         <stage>SIRO al SERVO.</stage>
-        <sp>
+        <sp who="#siro">
           <speaker>SIRO</speaker>
           <lg>
             <l>Ubidirotti adesso: egli è il dovere,</l>
@@ -1122,7 +1156,7 @@
           </lg>
         </sp>
         <stage>SERVO a SIRO.</stage>
-        <sp>
+        <sp who="#servo">
           <speaker>SERVO</speaker>
           <lg>
             <l>Va donque presto, or su, presto gualoppa,</l>
@@ -1130,7 +1164,7 @@
           </lg>
         </sp>
         <stage>Intrato SIRO in la torre quello SERVO che resta lì di fuore dice queste parole.</stage>
-        <sp>
+        <sp who="#servo">
           <speaker>SERVO</speaker>
           <lg>
             <l>L'ha ben poco da far colui che piglia</l>
@@ -1144,7 +1178,7 @@
           </lg>
         </sp>
         <stage>Soliloquio de SIRO quando trova la puta gravida.</stage>
-        <sp>
+        <sp who="#siro">
           <speaker>SIRO</speaker>
           <lg>
             <l>O sorte iniqua de nui miser servi,</l>
@@ -1188,7 +1222,7 @@
           </lg>
         </sp>
         <stage>Risposta de SIRO ad ACRISIO.</stage>
-        <sp>
+        <sp who="#siro">
           <speaker>SIRO</speaker>
           <lg>
             <l>Gito son come fiera del cibo avida</l>
@@ -1202,7 +1236,7 @@
           </lg>
         </sp>
         <stage>Desperazione de ACRISIO audita la novella.</stage>
-        <sp>
+        <sp who="#acrisio">
           <speaker>ACRISIO</speaker>
           <lg>
             <l>Ohimè, ohimè, ohimè, quanto me pesa</l>
@@ -1222,7 +1256,7 @@
           </lg>
         </sp>
         <stage>Saltato qui altri servi SIRO parla.</stage>
-        <sp>
+        <sp who="#siro">
           <speaker>SIRO</speaker>
           <lg>
             <l>Questa signor m'è una ferita al core.</l>
@@ -1232,7 +1266,7 @@
           </lg>
         </sp>
         <stage>ACRISIO comanda che la figliola sia portata a negare.</stage>
-        <sp>
+        <sp who="#acrisio">
           <speaker>ACRISIO</speaker>
           <lg>
             <l>Quatro di voi che me sete intorno</l>
@@ -1246,7 +1280,7 @@
           </lg>
         </sp>
         <stage>DANAE sentendo el strepito di quelli che la vano a tore così dice.</stage>
-        <sp>
+        <sp who="#danae">
           <speaker>DANAE</speaker>
           <lg>
             <l>Non me fati, compagni, forza o ingiuria;</l>
@@ -1255,7 +1289,7 @@
           </lg>
         </sp>
         <stage>Risposta de FAMIGLI.</stage>
-        <sp>
+        <sp who="#famigli">
           <speaker>FAMIGLI</speaker>
           <lg>
             <l>Ciascun di noi con ragion s'è mosso.</l>
@@ -1264,7 +1298,7 @@
           </lg>
         </sp>
         <stage>Sopragionge un SERVO.</stage>
-        <sp>
+        <sp who="#servo">
           <speaker>SERVO</speaker>
           <lg>
             <l>El signor m'ha mandato in fretta a dire</l>
@@ -1272,7 +1306,7 @@
           </lg>
         </sp>
         <stage>Lamento di DANAE guardando al cielo.</stage>
-        <sp>
+        <sp who="#danae">
           <speaker>DANAE</speaker>
           <lg>
             <l>Giove, da te son posta in abandono?</l>
@@ -1290,7 +1324,7 @@
       <div>
         <head>Atto V</head>
         <stage>Certe ninfe che andavano a cazza vedendo in cielo una stella inusitata con una musica demandarono a GIOVE che gli facesse intendere el caso. Per comandamento di GIOVE vene la dea de la immortalità così a mezo aria e disse queste parole:</stage>
-        <sp>
+        <sp who="#ebe">
           <speaker>EBE</speaker>
           <lg>
             <l>I' sono Ebe che fo l'omo immortale,</l>
@@ -1314,7 +1348,7 @@
           </lg>
         </sp>
         <stage>Qui cascata la barba, ACRISIO resta giovene. ACRISIO parla.</stage>
-        <sp>
+        <sp who="#acrisio">
           <speaker>ACRISIO</speaker>
           <lg>
             <l>I' te ringrazio, Giove, il vedo expresso,</l>
@@ -1324,7 +1358,7 @@
         </sp>
         <stage>Qui SIRO salta fuor de le catene.</stage>
         <stage>GIOVE per compiacere a quelle ninfe mandò in terra APOLLO con la lira quale dichiarò el caso alli spectatori.</stage>
-        <sp>
+        <sp who="#apollo">
           <speaker>APOLLO</speaker>
           <lg>
             <l>Qualunche ha udito con qual psalmodia</l>

--- a/tei/tasso-aminta-ms-1197.xml
+++ b/tei/tasso-aminta-ms-1197.xml
@@ -76,6 +76,43 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="amore">
+            <persName>Amore</persName>
+          </person>
+          <person xml:id="dafne">
+            <persName>Dafne</persName>
+          </person>
+          <person xml:id="silvia">
+            <persName>Silvia</persName>
+          </person>
+          <person xml:id="aminta">
+            <persName>Aminta</persName>
+          </person>
+          <person xml:id="tirsi">
+            <persName>Tirsi</persName>
+          </person>
+          <personGrp xml:id="choro">
+            <name>Choro de Pastori</name>
+          </personGrp>
+          <person xml:id="satiro">
+            <persName>Satiro</persName>
+          </person>
+          <person xml:id="nirina">
+            <persName>Nirina</persName>
+          </person>
+          <person xml:id="nuntio">
+            <persName>Nuntio</persName>
+          </person>
+          <person xml:id="ergasto">
+            <persName>Ergasto</persName>
+          </person>
+          <person xml:id="elpino">
+            <persName>Elpino</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>2001-10-07T00:00:00.000+01:00</date><name>Camilla Ghedini</name><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -114,7 +151,7 @@ TORQUATO TASSO</head>
       <div type="prologue" n="Prologo">
         <head>PROLOGO</head>
         <stage>AMORE IN HABITO PASTORALE</stage>
-        <sp>
+        <sp who="#amore">
           <speaker>Amore</speaker>
           <l>Chi crederia; che sotto humane forme,</l>
           <l>e sotto queste pastorali spoglie</l>
@@ -218,7 +255,7 @@ TORQUATO TASSO</head>
         <div type="scene">
           <head>Scena prima</head>
           <stage>DAFNE et SILVIA, Ninfe.</stage>
-          <sp>
+          <sp who="#dafne">
             <speaker>[DAFNE]</speaker>
             <l>Vorrai dunque pur, <name>Silvia</name>,</l>
             <l>da i piaceri di <name>Venere</name> lontana </l>
@@ -229,7 +266,7 @@ TORQUATO TASSO</head>
             <l>cangia, prego, consiglio,</l>
             <l>pazzarella; che sei.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Altri segua i diletti de l'amore,</l>
             <l>se pur v'è ne l'amor alcun diletto:</l>
@@ -240,7 +277,7 @@ TORQUATO TASSO</head>
             <l>saette à la faretra, o fere al bosco,</l>
             <l>non temo, ch'a me manchino diporti.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Insipidi diporti veramente,</l>
             <l>et insipida vita: e, s'à te piace,</l>
@@ -267,7 +304,7 @@ TORQUATO TASSO</head>
             <l>pazzarella che sei:</l>
             <l>che'l pentirsi da sezzo nulla giova.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Quando io dirò pentita sospirando</l>
             <l>queste parole; c'hor tu fingi, et orni</l>
@@ -276,7 +313,7 @@ TORQUATO TASSO</head>
             <l>Da gl'agni, e'l veltro le timide lepri,</l>
             <l>amarà l'orso il mare, e 'l Delfin l'alpe.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Conosco la ritrosa fanciullesca:</l>
             <l>qual tu sei, tal io fui: così portava</l>
@@ -334,7 +371,7 @@ TORQUATO TASSO</head>
             <l>il vedrai fatto altrui? fatto felice </l>
             <l>denne l'altrui braccia, e te scherni rido?</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Faccia <name>Aminta</name> di sé et de' suoi amori</l>
             <l>quel; ch'a lui piace: a me nulla ne cale:</l>
@@ -342,51 +379,51 @@ TORQUATO TASSO</head>
             <l>Ma esser non può mio s'io lui non voglio,</l>
             <l>né, s'ancho egli mio fusse, io sarei sua.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="I">Onde nasce il tuo odio?</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F">Dal suo amore.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Piacevol padre di figlio crudele:</l>
             <l>Ma quando mai da i mansueti agnelli</l>
             <l>nacquer le tigri? ò i bei cigni da i corbi?</l>
             <l>0 m' inganni ò te stessa.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="I">Odio il suo amore</l>
             <l part="F">ch'odia la mia honestate, et amai lui,</l>
             <l>mentre ei volse di me quel; ch'io voleva.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Tu volevi il tuo peggio. Egli à te brama</l>
             <l>quel; ch'à te brama.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="I">O' taci, o parla,</l>
             <l part="F">se d'altro vuoi risposta.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="I">Hor guata modi:</l>
             <l part="F">guata, che dispettosa giovinetta.</l>
             <l>Hor rispondimi almen: s'altri t'amasse,</l>
             <l>gradiresti il suo amore in questa guisa?</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>In questa guisa gradirei ciascuno</l>
             <l>insidiator di mia virginitate;</l>
             <l>che tu domandi Amante, et io nimico.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Stimi dunque nimico</l>
             <l>il monton de l'agnella?</l>
@@ -434,13 +471,13 @@ TORQUATO TASSO</head>
             <l>Cangia, cangia consiglio</l>
             <l>pazzarella; che sei.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Horsù, quando i sospiri</l>
             <l>udirò de le piante,</l>
             <l>io son contenta allhor d'essere amante.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Tu prendi à gabbo i miei fidi consigli,</l>
             <l>e burli mie ragioni? O' in amore</l>
@@ -480,12 +517,12 @@ TORQUATO TASSO</head>
             <l>Segui, segui tuo stile,</l>
             <l>ostinata; che sei.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Ma che fe' allhor <name>Licori</name> e che rispose</l>
             <l>a queste cose?</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Tu de' fatti propri</l>
             <l>nulla ti curi, e vuoi saper gl' altrui?</l>
@@ -498,11 +535,11 @@ TORQUATO TASSO</head>
             <l>se stimasse veraci come belli</l>
             <l>quegli occhi, e lor prestasse intiera fede.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>E perché lor non crede?</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Hor tu non sai ciò che <name>Tirsi</name> ne scrisse?</l>
             <l>allhor ch'ardendo forsennato egli errò per le foreste,</l>
@@ -516,7 +553,7 @@ TORQUATO TASSO</head>
             <l>ben riconosco in voi gl' inganni vostri:</l>
             <l>ma che pro', se schivarli Amor mi toglie?</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Io quì trapasso il tempo ragionando,</l>
             <l>ene mi sovien c'hoggi è il dì prescritto</l>
@@ -527,7 +564,7 @@ TORQUATO TASSO</head>
             <l>seguendo in caccia una Damma veloce</l>
             <l>ch'alfin giunsi, et uccisi.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="I">Aspettarotti,</l>
             <l part="F">e forse anch'io mi bagnarò nel fonte.</l>
@@ -542,7 +579,7 @@ TORQUATO TASSO</head>
         <div type="scene">
           <head>Scena seconda</head>
           <stage>Aminta, Tirsi, pastori</stage>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Ho visto al pianto mio</l>
             <l>risponder per pietate i sassi, e l'onde,</l>
@@ -557,13 +594,13 @@ TORQUATO TASSO</head>
             <l>a chi non la negaro</l>
             <l>le cose inanimate.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Pasce l'agna l'herbette, il lupo l'agne:</l>
             <l>ma il crudo Amor di lacrime si pasce,</l>
             <l>né se ne mostra mai satollo.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="I">Ahi lasso,</l>
             <l part="F">ch'Amor satollo è del mio pianto homai,</l>
@@ -571,33 +608,33 @@ TORQUATO TASSO</head>
             <l>voglio, ch'egli, e quest'empia il sangue mio</l>
             <l>bevan con gli occhi.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Ahi <name>Aminta</name>, ahi <name>Aminta</name>,</l>
             <l>che parli? ò che vaneggi? Hor ti conforta,</l>
             <l>un'ch'altra trovarai, se ti disprezza</l>
             <l part="I">questa crudele.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Oimè, come posso io </l>
             <l>altri trovar, se me trovar non posso?</l>
             <l>Se perduto ho me stesso, quale acquisto</l>
             <l part="I">farò mai che mi piaccia?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">O' miserello,</l>
             <l>non disperar, che acquistarai costei.</l>
             <l>La lunga etate insegna a l'huom di porre</l>
             <l>freno a' leoni et à le Tigri hircane.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Ma il misero non puote à la sua morte</l>
             <l>indugio sostener di lungo tempo.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Sarà corto l'indugio: in breve spatio</l>
             <l>s'adira, e 'n breve spatio poi si placa</l>
@@ -613,7 +650,7 @@ TORQUATO TASSO</head>
             <l>studio de le Muse ch'à me siopra</l>
             <l>Ciò; ch'à gli altri si cela.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Io son contento.</l>
             <l><name>Tirsi</name>, a te dir ciò che le selve e i monti</l>
@@ -636,12 +673,12 @@ TORQUATO TASSO</head>
             <l>dicendo: O' pur qui fusse, e fusse mio.</l>
             <l part="I">Hor odi.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Segui pur, ch'io t'ascolto,</l>
             <l>e forse à miglior fin, che tu non pensi.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Essend' io fanciulletto, sì ch' à pena</l>
             <l>giunger potea con la man pargoletta</l>
@@ -685,11 +722,11 @@ TORQUATO TASSO</head>
             <l part="I">Ben me n'accorsi al fine: et in qual modo,</l>
             <l part="F">hora m'ascolta, e nota.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>E' da notare.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>A' l'ombra d'un bel faggio <name>Silvia</name> e <name>Filli</name>
                   </l>
@@ -795,31 +832,31 @@ TORQUATO TASSO</head>
             <l>cosa; che turb' il bel lume sereno</l>
             <l>a' gli occhi chiari, e affanni quel bel petto.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>E' possibil però che, s'ella un giorno</l>
             <l>udisse tai parole, non t'amasse?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>No'l sò, ne 'l credo: ma fugge i miei detti</l>
             <l part="I">come l'aspe l'incanto.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Horsù confida</l>
             <l>ch'a me dà il cor di far, ch'ella t'ascolte.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>0 nulla impetrarai, ò se tu impetri,</l>
             <l>ch'io parli, io nulla impetrarò parlando.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="I">Perché disperi sì.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Giusta cagione</l>
             <l>ho del mio disperar, che il saggio <name>Mopso</name>
@@ -828,7 +865,7 @@ TORQUATO TASSO</head>
             <l><name>Mopso</name>, ch'intende il parlar de gl' augelli</l>
             <l>e la virtù de l'herbe, e de le fonti.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>E di qual <name>Mopso</name> intendi? di quel <name>Mopso</name>;</l>
             <l>c'ha ne la lingua melate parole,</l>
@@ -843,12 +880,12 @@ TORQUATO TASSO</head>
             <l>mi giova di sperar felice fine</l>
             <l part="I">a' l'amor tuo.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Se sai cosa per prova;</l>
             <l>che conforti mia speme, non tacerla.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Dirolla volontieri. Allhor che prima</l>
             <l>mia sorte mi condusse in queste selve,</l>
@@ -939,18 +976,18 @@ TORQUATO TASSO</head>
             <l>e déi bene sperar, sol perché ei vuole</l>
             <l part="I">che nulla speri.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Piacemi d'udire</l>
             <l>quanto mi narri. A' te dunque rimetto</l>
             <l part="I">la cura di mia vita.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Io n'havrò cura,</l>
             <l>Tu lasciati trovar quì fra mezz'hora</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO</speaker>
             <l>O bella Età de l'oro,</l>
             <l>non già perché di latte</l>
@@ -1028,7 +1065,7 @@ TORQUATO TASSO</head>
         <head>Atto secondo</head>
         <div type="scene">
           <head>Scena prima</head>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO SOLO.</speaker>
             <l>Picciola è l'ape, e fà co'l picciol morso</l>
             <l>pur gravi, e pur moleste le ferite:</l>
@@ -1132,7 +1169,7 @@ TORQUATO TASSO</head>
         <div type="scene">
           <head>Scena seconda</head>
           <stage>DAFNE NINFA, TIRSI PASTORE,</stage>
-          <sp>
+          <sp who="#dafne">
             <speaker>[DAFNE]</speaker>
             <l>Com'io t'ho detto <name>Tirsi</name>, io m'era accorta,</l>
             <l>ch'<name>Aminta</name> amava <name>Silvia</name>: E <name>Dio</name> sà quanti</l>
@@ -1147,7 +1184,7 @@ TORQUATO TASSO</head>
             <l>a rmidendo, e piacendo uccida altrui,</l>
             <l>e l'uccida, e non sappia di ferire.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>E quale è cosi semplice fanciulla;</l>
             <l>ch'uscita da le fascie, non apprenda</l>
@@ -1156,12 +1193,12 @@ TORQUATO TASSO</head>
             <l>qual arme fera, e qual dia morte e quale</l>
             <l part="I">sane, e ritorne in vita?</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Chi è il maestro</l>
             <l part="I">di cotant'arte?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Tu fingi, e mi tenti</l>
             <l>quel; ch'insegna à gli uccelli il canto, e 'l volo:</l>
@@ -1169,19 +1206,19 @@ TORQUATO TASSO</head>
             <l>al toro usar il corno, et al pavone</l>
             <l>spiegar la pompa de l'occhiute penne</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="I">Com'ha nome il gran mastro?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F"><name>Dafne</name> ha nome.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="I">Lingua bugiarda.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">E perché? Tu non sei</l>
             <l>atta à tener <num value="1000">mille</num> fanciulle à scuola?</l>
@@ -1189,7 +1226,7 @@ TORQUATO TASSO</head>
             <l>di maestro. Maestro è la Natura:</l>
             <l>ma la madre, e la balia ancho v'han parte.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Insomma tu sei goffo, e'nsieme tristo.</l>
             <l>Hora per dirti il ver, non mi risolvo,</l>
@@ -1229,12 +1266,12 @@ TORQUATO TASSO</head>
             <l>perché bella si vide, anchor che incolta.</l>
             <l part="I">Io me ne avidi, e tacqui.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Tu mi narri</l>
             <l>quel; ch'io credeva appunto: Hor non m'apposi?</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Ben t'apponesti: ma pur odo dire</l>
             <l>che non erano pria le pastorelle,</l>
@@ -1242,7 +1279,7 @@ TORQUATO TASSO</head>
             <l>fui in mia fanciullezza: Il mondo invecchia,</l>
             <l part="I">e invecchiato intristisce.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Forse allhora</l>
             <l>non usavan sì spesso i cittadini</l>
@@ -1254,15 +1291,15 @@ TORQUATO TASSO</head>
             <l><name>Silvia</name> contenta sia, che le ragioni</l>
             <l><name>Aminta</name> solo, ò almeno in tua presenza?</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Non sò <name>Silvia</name> è ritrosa fuor di modo.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>E costui rispettoso fuor di modo.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>E' spacciato un amante rispettoso.</l>
             <l>consiglial pur, che faccia altro mestiero:</l>
@@ -1279,7 +1316,7 @@ TORQUATO TASSO</head>
             <l>non parlo in rime: Tu sai ch'io saprei</l>
             <l>renderti poi per versi altro che versi.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Non hai cagion di sospettar, ch'io dica</l>
             <l>cosa giamai; che sia contra tuo grado:</l>
@@ -1288,7 +1325,7 @@ TORQUATO TASSO</head>
             <l>che tu m'aiti ad aiutar <name>Aminta</name>:</l>
             <l part="I">miserel, che si muore.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">O' che gentile</l>
             <l>scongiuro ha ritrovato questo sciocco,</l>
@@ -1296,13 +1333,13 @@ TORQUATO TASSO</head>
             <l>il ben passato, e la presente noia:</l>
             <l part="I">Ma che vuoi tu, ch'io faccia?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">A' te nò manca</l>
             <l>né saper, né consiglio: basta sol, che</l>
             <l part="I">ti disponga à volere.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Hor sù dirotti.</l>
             <l>debbiamo in breve andare <name>Silvia</name>, et io</l>
@@ -1312,30 +1349,30 @@ TORQUATO TASSO</head>
             <l>le Ninfe cacciatrici: Ivi sò certo,</l>
             <l>che tuffarà le belle membra ignude.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="I">Ma che perciò?</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Ma che perciò? Da poco</l>
             <l>intenditor. S'hai senno tanto basti.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Intendo; ma non sò, s'egli havrà tanto</l>
             <l part="I">d'ardir.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">S'ei non l'avrà, stiasi, et aspetti,</l>
             <l part="I">ch'altri lui cerchi.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Egli è ben tal, che 'l merta.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Ma non vogliamo noi parlar alquanto</l>
             <l>di te medesmo? Hor sù <name>Tirsi</name> non vuoi</l>
@@ -1345,37 +1382,37 @@ TORQUATO TASSO</head>
             <l>vuoi viver neghitoso, e senza gioia?</l>
             <l>che sol amando un sà, che sia diletto.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>I diletti di <name>Venere</name> non lassa</l>
             <l>l'huom; che schiva l'<name>Amor</name>: ma coglie, e gusta</l>
             <l>le dolcezze d'<name>Amor</name> senza l'amaro.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Insipido è quel dolce; che condito</l>
             <l>non è d'alquanto amaro, e tosto satia.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>E' meglio satiarsi, ch'esser sempre</l>
             <l>famelico nel cibo, e dopo 'l cibo:</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Ma non, se 'l cibo si possiede, e piace,</l>
             <l>e gustato à gustar sempre rinvoglia.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Ma chi possiede sì quel; che Le piace</l>
             <l>che l'habbia sempre pronto à la sua fame?</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Ma chi ritrova il ben, s'egli no'l cerca?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Periglioso è cercar quel; che trovato,</l>
             <l>trastulla sì: ma più tormenta assai</l>
@@ -1385,51 +1422,51 @@ TORQUATO TASSO</head>
             <l>A' bastanza ho già pianto, e sospirato:</l>
             <l part="I">Faccia altri la sua parte.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Ma non hai</l>
             <l part="I">già goduto à bastanza.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Né desio</l>
             <l>goder, se così caro egli si compera.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Sarà forza l'amar, se non fia voglia.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Ma non si può sforzar chi stà lontano.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="I">E chi lunge è d'Amor</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Chi teme e fugge.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>E che giova fuggir da lui; c'ha l'ali?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l><name>Amor</name> nascente ha corto l'ali: à pena</l>
             <l>può sù tenerle, e non le spiega à volo.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Pur non s'accorge l'huom, quand'egli nasce,</l>
             <l>e quando huom se n'accorge, è grande, e vola.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Non, s'altra volta nascer non 'l ha visto.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Vedrem, <name>Tirsi</name>, s'avrai la fuga e gli occhi</l>
             <l>come tu dici. Io ti protesto, per=</l>
@@ -1438,32 +1475,32 @@ TORQUATO TASSO</head>
             <l>non moverei per aiutarti un passo,</l>
             <l>un dito, un detto, una palpebra sola.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Crudel, ti darà il cor vedermi morto?</l>
             <l>Se vuoi pur ch'ami, ama tu me, facciamo</l>
             <l part="I">l'amor d'accordo.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Tu mi scherni, e forse</l>
             <l>non merti amante così fatta. Ahi quanti</l>
             <l>n'inganna il viso colorito, e liscio.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Non burlo io, no: Ma tu con tal pretesto</l>
             <l>non accetti il mio amor, pur com' è uso</l>
             <l>di tutte quante; ma se non mi vuoi,</l>
             <l part="I">viverò senz' amor.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Contento vivi</l>
             <l>più che mai fussi, ò <name>Tirsi</name>, e 'n otio vivi,</l>
             <l>e ne l'otio l'<name>Amor</name> sempre germoglia.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>O' <name>Dafne</name>: à me quest'otii ha fatto <name>Dio</name>,</l>
             <l>colui; che <name>Dio</name> qui può stimarsi; a cui</l>
@@ -1496,12 +1533,12 @@ TORQUATO TASSO</head>
             <l>e che mutando i fiumi letto, e corso,</l>
             <l>il <name>Perso</name> bea la <name>Sonna</name>, il <name>Gallo</name> il <name>Tigre</name>.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>O' tu vai alto: Horsù, discendi un poco</l>
             <l part="I">al proposito nostro.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Il punto è questo,</l>
             <l>che tu in andando al fonte con colei,</l>
@@ -1510,12 +1547,12 @@ TORQUATO TASSO</head>
             <l>Né forse men sarà difficil cura</l>
             <l part="I">la mia di questa tua: Hor vanne.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Io vado:</l>
             <l>ma il proposito nostro altro intendeva.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Se ben raviso di lontan la faccia,</l>
             <l><name>Aminta</name> è quel; che di là spunta: è desso.</l>
@@ -1524,7 +1561,7 @@ TORQUATO TASSO</head>
         <div type="scene">
           <head>Scena terza</head>
           <stage>Aminta, et Tirsi Pastori.</stage>
-          <sp>
+          <sp who="#aminta">
             <speaker>[AMINTA]</speaker>
             <l>Vorrò veder ciò che <name>Tirsi</name> avrà fatto:</l>
             <l>e s'havrà fatto nulla,</l>
@@ -1538,53 +1575,53 @@ TORQUATO TASSO</head>
             <l>la piaga del mio petto,</l>
             <l>colpo de la mia mano.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Nuove <name>Aminta</name>, t'annuntio di conforto:</l>
             <l>lascia homai questo tanto lamentarti.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Oimè che di'? che porti?</l>
             <l>O' la vita, ò la morte?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Porto salute, e vita, s'ardirai</l>
             <l>di farti loro incontro: ma fa luogo</l>
             <l>d'esser un huom <name>Aminta</name>, e un huom ardito.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Qual ardir mi bisogna, e 'ncontra a cui?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Se la tua donna fusse in mezo un bosco;</l>
             <l>che cinto intorno d'altissime rupi</l>
             <l>desse albergo à le Tigri et a' Leoni,</l>
             <l part="I">v'andresti tu?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">V'andrei securo, e baldo,</l>
             <l part="I">più che di festa villanella al ballo.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Et s'ella fusse tra ladroni, et arme,</l>
             <l part="I">v'andresti tu?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">V'andrei più lieto, e pronto</l>
             <l>che l'assetato Cervo à la Fontana. </l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Bisogna à maggior uopo ardir più grande.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Andrò per mezo i rapidi torrenti,</l>
             <l>quando la neve si discioglie, e gonfi</l>
@@ -1593,46 +1630,46 @@ TORQUATO TASSO</head>
             <l>s'esser può Inferno; ov'è cosa sì bella.</l>
             <l part="I">Hor sù scoprimi il tutto.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="M">Odi.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Di' tosto.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l><name>Silvia</name> attende à una fonte ignuda, e sola.</l>
             <l part="I">Ardirai tu d'andarvi?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Oh che mi dici?</l>
             <l part="I"><name>Silvia</name> m'attende ignuda, e sola?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Sola,</l>
             <l>se non quanto v'è <name>Dafne</name>; ch'è per noi.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Ignuda ella m'aspetta?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Ignuda: ma.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Oimè che ma? Tu taci, Tu m'occidi.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Ma non sa giàche tu v'habbi d'andare.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Dura conclusion; che tutto attosca</l>
             <l>le dolcezze passate. Hor con qual arte</l>
@@ -1641,20 +1678,20 @@ TORQUATO TASSO</head>
             <l>che io infelice sia,</l>
             <l>ch'à crescer vieni la miseria mia?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>S'à mio senno farai, sarai felice.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="I">E che consigli?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Che tu prenda quello;</l>
             <l>che la fortuna amica t'apresenta.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Tolga <name>Iddio</name> che mai faccia</l>
             <l>cosa; che le dispiaccia.</l>
@@ -1664,43 +1701,43 @@ TORQUATO TASSO</head>
             <l>Non sarà dunque ver, che, in quanto io posso,</l>
             <l part="I">non cerchi compiacerle.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Hor mi rispondi.</l>
             <l>se fusse in tuo poter di non amarla,</l>
             <l>lasciaresti d'amarla per piacerle?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Né questo mi consente Amor; ch'io dica,</l>
             <l>né che imagini pur d'haver già mai</l>
             <l>a' lasciar il suo amor, bench'io potessi.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Dunque tu l' amaresti à suo dispetto,</l>
             <l>quando potessi far di non amarla.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>A' suo dispetto nò: ma l'amarei.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="I">Dunque fuor di sua voglia.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Sì per certo.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Perché dunque non osi oltre sua voglia,</l>
             <l>prenderne quel; che se ben grave in prima,</l>
             <l>al fin, al fin le sarà caro, e dolce,</l>
             <l part="I">c' habbi tu preso?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Ahi <name>Tirsi</name>, Amor risponda</l>
             <l>per me, che quanto in mezo al cor mi parla,</l>
@@ -1709,26 +1746,26 @@ TORQUATO TASSO</head>
             <l>a' me lega la lingua,</l>
             <l>quel; che mi lega il core.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Dunque andar non vogliamo?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Andar voglio io,</l>
             <l part="I">ma non dove tu stimi.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="M">E dove?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">A morte,</l>
             <l>s'altro in mio pro' non hai fatto, che quanto</l>
             <l part="I">hora mi narri.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="I">E questo ti par poco?</l>
             <l>Credi dunque tu scioccho, che mai <name>Dafne</name>
@@ -1745,12 +1782,12 @@ TORQUATO TASSO</head>
             <l>né sua mercede, a te folle, ch'importa</l>
             <l part="I">più l'un modo, che l'altro?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">E chi m'accerta,</l>
             <l part="I">che 'l suo desir sia tale?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">O mentecatto,</l>
             <l>Ecco tu chiedi pur quella certezza;</l>
@@ -1764,24 +1801,24 @@ TORQUATO TASSO</head>
             <l>questa perdita tua; che fia cagione</l>
             <l part="I">di vittoria maggiore. Andiamo.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Aspetta.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Che Aspetta? non sai tu, che'l tempo fugge?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Deh, pensiam pria, se ciò dee farsi, e come.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Per strada pensarem ciò; che vi resta:</l>
             <l>ma nulla fa, chi troppe cose pensa.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO DE PASTORI.</speaker>
             <l>
               <gap/>
@@ -1794,7 +1831,7 @@ TORQUATO TASSO</head>
         <div type="scene">
           <head>Scena prima</head>
           <stage>TIRSI, et CHORO de' Pastori.</stage>
-          <sp>
+          <sp who="#tirsi">
             <speaker>[TIRSI]</speaker>
             <l>O crudeltade estrema: ò ingrato core:</l>
             <l>o donna ingrata: o <num value="3">tre</num> fiate, ò <num value="4">quattro</num>
@@ -1814,52 +1851,52 @@ TORQUATO TASSO</head>
             <l>Amici, havete visto <name>Aminta</name>? o' inteso</l>
             <l part="I">forse di lui novella?</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO</speaker>
             <l part="F">Tu mi pari</l>
             <l>così turbato! Qual cagion t'affanna?</l>
             <l>Ond'è questo sudore, e questo ansare?</l>
             <l>Hacci nulla di mal? Fa che 'l sappiamo.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Temo del mal d'<name>Aminta</name>. Havete 'l visto?</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO</speaker>
             <l>Noi visto non l'habbiam da poi che teco</l>
             <l>buona pezza partì ma che ne temi?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Ch'egli non s'habbia ucciso di sua mano.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO</speaker>
             <l part="I">Ucciso di sua mano?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Odio, et Amore.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO</speaker>
             <l><num value="2">Due</num> potenti nimici insieme aggiunti,</l>
             <l>che far non ponno! Ma parla più chiaro.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>L'amar troppo una Ninfa, e l'esser troppo</l>
             <l part="I">odiato da lei.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO</speaker>
             <l part="F">Deh, narra il tutto.</l>
             <l>Questo è luoco di passo, e forse in tanto</l>
             <l>alcun verrà che di lui nuova arrechi.</l>
             <l>forse arrivar potrebbe egli medesimo.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Dirollo volontier, che non è giusto,</l>
             <l>che tanta ingratitudine, e sì strana</l>
@@ -1916,12 +1953,12 @@ TORQUATO TASSO</head>
             <l>né questa gratia; che fortuna vuole</l>
             <l>conceder loro, tuo mal grado sia.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO</speaker>
             <l>Parole d'ammollire un cor di sasso:</l>
             <l part="I">Ma che rispose allhor?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Nulla rispose:</l>
             <l>ma disdegnosa, e vergognosa à terra</l>
@@ -1944,12 +1981,12 @@ TORQUATO TASSO</head>
             <l>Pastor, non mi toccar, son di <name>Diana</name>,</l>
             <l>per me stessa saprò sciogliermi i piedi.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO</speaker>
             <l>Hor tant'orgoglio regna in cor di Ninfa</l>
             <l>Ahi d'opra gratiosa ingrato merto!</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Ei si trasse in disparte riverente,</l>
             <l>non alzando pur gli occhi per mirarla,</l>
@@ -1964,22 +2001,22 @@ TORQUATO TASSO</head>
             <l>e pur nulla cagion havea di tema,</l>
             <l>che l'era noto il rispetto d'<name>Aminta</name>.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO</speaker>
             <l part="I">Perché dunque fuggissi?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">A' la sua fuga</l>
             <l>volse l'obligo haver, non à l'altrui</l>
             <l part="I">modesto amore.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO</speaker>
             <l part="F">Et in questo anco è ingrata.</l>
             <l>Ma che fe' il miserello allhor? Che disse?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>No'l sòche pien di mal talento io corsi</l>
             <l>per arrivarla, e ritenerla: e 'nvano,</l>
@@ -1989,21 +2026,21 @@ TORQUATO TASSO</head>
             <l>Sò ch'egli era disposto di morire,</l>
             <l part="I">prima che ciò avenisse.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO</speaker>
             <l part="F">É uso, et arte</l>
             <l>di ciascun; ch'ama, minacciarsi morte:</l>
             <l>ma rare volte poi segue l'effetto.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l><name>Dio</name> faccia, che ei non sia fra questi rari.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO</speaker>
             <l part="I">Non sarà nò.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Io voglio irmene à l'antro</l>
             <l>del saggio <name>Elpino</name>: ivi, s'è vivo, forse</l>
@@ -2018,7 +2055,7 @@ TORQUATO TASSO</head>
         <div type="scene">
           <head>Scena seconda</head>
           <stage>AMINTA PASTORE: DAFNE, ET NIRINA NINFE</stage>
-          <sp>
+          <sp who="#aminta">
             <speaker>[AMINTA]</speaker>
             <l part="F">Dispietata pietate</l>
             <l>fu la tua veramente, ò <name>Dafne</name>, allhora</l>
@@ -2030,14 +2067,14 @@ TORQUATO TASSO</head>
             <l>ragionamenti in vano? Di che temi?</l>
             <l>ch'io non m'uccida? Temi del mio bene.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Non disperar <name>Aminta</name>,</l>
             <l>che, s'io ben lei conosco,</l>
             <l>sola vergogna fù, non crudeltate,</l>
             <l>quella; che mosse <name>Silvia</name> à fuggir via.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Oimè, che mia salute</l>
             <l>sarebbe il disperare,</l>
@@ -2047,7 +2084,7 @@ TORQUATO TASSO</head>
             <l>sol perch'io viva. E qual' è maggior male</l>
             <l>de la vita d'un misero, com'io?</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Vivi misero, vivi</l>
             <l>ne la miseria tua, e questo stato</l>
@@ -2056,14 +2093,14 @@ TORQUATO TASSO</head>
             <l>se vivendo, e sperando ti mantieni,</l>
             <l>quel; che vedesti ne la bella ignuda.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Non pareva ad Amore, à mia Fortuna,</l>
             <l>ch'à pien misero io fussi, s'ancho à pieno</l>
             <l>non m'era dimostrato</l>
             <l>quel; che m'era negato.</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l>Dunque a me pur conviene esser sinistra</l>
             <l>còrnice d'amarissima novella?</l>
@@ -2072,60 +2109,60 @@ TORQUATO TASSO</head>
             <l>de l'unica tua <name>Silvia</name> il duro caso?</l>
             <l>Padre vecchio, orbo padre: ai, non più padre.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="I">Odo una mesta voce.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Io odo il nome</l>
             <l>di <name>Silvia</name>; che l' orecchie e 'l cor mi fere:</l>
             <l part="I">ma chi è che la noma?</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Ella è <name>Nirina</name>,</l>
             <l>ninfa gentil; che tanto à <name>Cinthia</name> è cara;</l>
             <l>c'ha sì begli occhi, e così belle mani;</l>
             <l>e modi sì avenenti, e gratiosi.</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l>E' pur meglio che 'l sappia, e che procuri</l>
             <l>di ritrovar le reliquie infelici,</l>
             <l>se nulla ve ne resta. Ai <name>Silvia</name>: ai dura</l>
             <l part="I">tua sorte.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="I">Oimèche fia? Costei che dice?</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l part="I">O <name>Dafne</name>.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Che parli tra te stessa? e perché nomi</l>
             <l part="I">tu <name>Silvia</name>, e poi sospiri?</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l part="F">Ai, ch'à ragione</l>
             <l part="I">sospiro l'aspro caso.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Ai, di qual caso</l>
             <l>può ragionar costei? Io sento, io sento</l>
             <l>che mi s'agghiaccia il core, e mi si chiude</l>
             <l part="I">lo spirto. Éviva?</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Narra qual aspro caso è quel; che dici.</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l>O <name>Dio</name>, perché sono io</l>
             <l>la Messaggiera? pur convien narrarlo.</l>
@@ -2144,12 +2181,12 @@ TORQUATO TASSO</head>
             <l>a' sommo il capo: ei si rinselva, et ella,</l>
             <l>vibrando un dardo, dentro il bosco il segue.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>O dolente principio: oimè, qual fine</l>
             <l part="I">già mi s'annuntia?</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l part="F">Io con un'altro dardo</l>
             <l>seguo lor traccia: Ma lontana assai,</l>
@@ -2169,22 +2206,22 @@ TORQUATO TASSO</head>
             <l>indietro ritornaimi. E questo è quanto</l>
             <l>posso dirvi di <name>Silvia</name>: Et ecco 'l velo.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Poco pàrti haver detto? O' velo, ò sangue:</l>
             <l part="I">O <name>Silvia</name> tu sei morta?</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">O' miserello,</l>
             <l>tramortito è d'affanno, et forse morto:</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l>Egli rispira pure. Questo fia</l>
             <l>un breve svenimento: Ecco, riviene.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Dolor; che sì mi crucci,</l>
             <l>che non m'uccidi homai? Tu sei pur lento.</l>
@@ -2210,21 +2247,21 @@ TORQUATO TASSO</head>
             <l>ben soffrirà, ch'io moia,</l>
             <l>e tu soffrir lo dei.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Aspetta à la tua morte,</l>
             <l>sin che 'l ver meglio intenda.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Oimè, che vuoi, ch'attenda?</l>
             <l>Oimè, c'ho troppo atteso, e troppo inteso.</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l>O fuss 'io stata muta.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Ninfa, dammi ti prego</l>
             <l>quel velo; ch'è di lei</l>
@@ -2237,13 +2274,13 @@ TORQUATO TASSO</head>
             <l>ch'è ben picciol martire,</l>
             <l>s' ha bisogno d'aiuto, al mio morire.</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l>Debb'io darlo: o negarlo?</l>
             <l>La cagion; per ché 'l chiedi</l>
             <l>fà, ch'io debba negarlo.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Crudel, sì picciol dono</l>
             <l>mi neghi al punto estremo?</l>
@@ -2252,12 +2289,12 @@ TORQUATO TASSO</head>
             <l>a' te si resti. E voi restate anchora,</l>
             <l>ch'io vò per non tornare.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l><name>Aminta</name>, aspetta, ascolta.</l>
             <l>Oimè, con quanta furia egli si parte.</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l>Egli và sì veloce,</l>
             <l>che fia vano il seguirlo; ond'è pur meglio,</l>
@@ -2265,7 +2302,7 @@ TORQUATO TASSO</head>
             <l>ch'io taccia, e nulla conti</l>
             <l>al misero <name>Montano</name>.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO DE PASTORI.</speaker>
             <l>
               <gap/>
@@ -2278,7 +2315,7 @@ TORQUATO TASSO</head>
         <div type="scene">
           <head>Scena prima</head>
           <stage>DAFNE, ET SILVIA NINFE, ET CHORO DE PASTORI.</stage>
-          <sp>
+          <sp who="#dafne">
             <speaker>[DAFNE]</speaker>
             <l>Ne porti il vento con la rea novella;</l>
             <l>che s'era di te sparta, ogni tuo male,</l>
@@ -2288,18 +2325,18 @@ TORQUATO TASSO</head>
             <l>m'havea <name>Nirina</name> il tuo caso dipinto.</l>
             <l>Ahi stata fusse muta: od altri sordo.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Certo il rischio fù grande, et ella havea</l>
             <l>giusta cagion di sospettarmi morta.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Ma non havea giusta cagion di dirlo.</l>
             <l>Hor narra tu qual fusse il rischio, e come</l>
             <l part="I">tu lo fugisti.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F">Io seguitando un Lupo</l>
             <l>mi rinselvai nel più profondo bosco,</l>
@@ -2340,65 +2377,65 @@ TORQUATO TASSO</head>
             <l>tutta turbata, e mi stupii, vedendo</l>
             <l part="I">stupirti al mio apparire.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Oimè, tu vivi,</l>
             <l part="I">altri non già</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F">Che dici? Ti rincresce</l>
             <l>forse, ch'io viva sia? M'odii tu tanto?</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Mi piace di tua vita: ma mi duole</l>
             <l part="I">de l'altrui morte.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F">E di qual morte intendi?</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="I">De la morte d'<name>Aminta</name>.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F">Ai,com' è morto?</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Il come non sò dir, né so dir ancho,</l>
             <l>s'è ver l'Effetto: ma per certo il credo.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Che è ciò che mi dici? Et à che rechi</l>
             <l part="I">la cagion di sua morte? </l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">A' la tua morte.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="I">Io non t'intendo.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">La dura novella</l>
             <l>de la tua morte, ch'egli udì, e credette,</l>
             <l>havrà porto al meschino il laccio, o 'l ferro</l>
             <l>od altra cosa tal; che l'havrà ucciso.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Vano il sospetto in te de la sua morte</l>
             <l>sarà, come fù van de la mia morte,</l>
             <l>ch'ognuno à suo poter salva la vita.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>O' <name>Silvia</name>, <name>Silvia</name>, tu non sai, né credi,</l>
             <l>quanto il foco d'Amor possa in un petto,</l>
@@ -2425,11 +2462,11 @@ TORQUATO TASSO</head>
             <l>e mostrò quella strada al ferro audace;</l>
             <l>che correr poi dovea liberamente.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="I">Oh che mi narri.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Il vidi poscia allhora</l>
             <l>ch'intese l'amarissima novella</l>
@@ -2438,34 +2475,34 @@ TORQUATO TASSO</head>
             <l>per uccider se stesso: e s'havrà ucciso</l>
             <l part="I">veramente.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F">E ciò per fermo tieni?</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="I">Io non v 'ho dubio.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F">Oimè, tu no'l seguisti</l>
             <l>per impedirlo? Oimè, cerchianlo, andiamo,</l>
             <l>che poi ch'egli moria per la mia morte,</l>
             <l>deè per la vita mia restar in vita.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Io'l seguii ben: ma correa sì veloce,</l>
             <l>che mi sparì tosto dinanzi, e 'ndarno</l>
             <l>poi m'aggirai per le sue orme. Hor dove</l>
             <l>vuoi tu cercar, se non n'hai traccia alcuna?</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Egli morà, se no'l troviamo, ai lassa,</l>
             <l>e sarà l'homicida ei di se stesso.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Crudel, forse t'incresce, che ti tolga</l>
             <l>la gloria di quest' atto? Esser tu dunque</l>
@@ -2475,7 +2512,7 @@ TORQUATO TASSO</head>
             <l>che comunque egli moia, per te muore,</l>
             <l>e tu sei; che l'occidi.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Oimè, che tu m'accori: e quel cordoglio;</l>
             <l>ch'io sento del suo caso, inacerbisce</l>
@@ -2485,7 +2522,7 @@ TORQUATO TASSO</head>
             <l>ma fu troppo severa, e rigorosa.</l>
             <l part="I">Hor me n' accorgo, e pento.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Oh, quel: ch'io odo.</l>
             <l>Tu sei pietosa tu? tu senti al core</l>
@@ -2493,16 +2530,16 @@ TORQUATO TASSO</head>
             <l>tu piangi tu superba? O' maraviglia.</l>
             <l>Che pianto è questo tuo? pianto d'Amore?</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Pianto d'amor non già: ma di pietate.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>La pietà Messaggiera è de l'Amore,</l>
             <l part="I">come 'l Lampo del Tuono.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO</speaker>
             <l part="F">Anzi sovente,</l>
             <l>quand' egli vuol ne' petti virginelli</l>
@@ -2512,7 +2549,7 @@ TORQUATO TASSO</head>
             <l>e sua nuntia pietate: e con tai larve</l>
             <l>le semplici ingannando è dentro accolto.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Questo è pianto d'Amor, che troppo abonda.</l>
             <l>Tu taci. Ami tu Silvia? ami: ma in vano.</l>
@@ -2532,19 +2569,19 @@ TORQUATO TASSO</head>
             <l>desti quel prezo tu; ch'ella richiese,</l>
             <l>e l'amor suo co 'l tuo morir comprasti.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO</speaker>
             <l>Caro prezo à chi 'l diede, à chi il riceve</l>
             <l part="I">prezo inutile, e'nfame.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F">O' potess 'io</l>
             <l>con l'amor mio comprar la vita sua,</l>
             <l>anzi pur con la mia vita la sua</l>
             <l part="I">s'egli è pur morto.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">O' tardi saggia, e tardi</l>
             <l>pietosa, quand'in ciò nulla rilieva!</l>
@@ -2553,40 +2590,40 @@ TORQUATO TASSO</head>
         <div type="scene">
           <head>Scena seconda</head>
           <stage>ERGASTO PASTORE, CHORO, SILVIA E DAFNE NINFE.</stage>
-          <sp>
+          <sp who="#nuntio">
             <speaker>[NUNTIO]</speaker>
             <l>Io ho sì pieno il petto di pietate</l>
             <l>e sì pieno d'horror, ch'io non rimiro,</l>
             <l>né odo alcuna cosa, ov'io mi volga,</l>
             <l>la qual non mi spaventi, e non m'affanni.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO</speaker>
             <l>Hor che porta costui;</l>
             <l>ch'è sì turbato in vista, ed in favella?</l>
           </sp>
-          <sp>
+          <sp who="#ergasto">
             <speaker>ERGASTO</speaker>
             <l>Porto l'aspra novella</l>
             <l part="I">de la morte d'<name>Aminta</name>.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F">Oimèche dice?</l>
           </sp>
-          <sp>
+          <sp who="#ergasto">
             <speaker>ERGASTO</speaker>
             <l>Il più nobil Pastor di queste selve;</l>
             <l>che fù così gentil, così leggiadro,</l>
             <l>così caro à le Ninfe, Et à le Muse:</l>
             <l>et è morto fanciullo, ai di che morte.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO</speaker>
             <l>Contane prego, il tutto; accioche teco</l>
             <l>pianger potiam la sua sciagura, e nostra.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Oimè, che non ardisco</l>
             <l>appressarmi ad udire</l>
@@ -2604,19 +2641,19 @@ TORQUATO TASSO</head>
             <l>come devuta cosa. Hor tu di lui</l>
             <l>non mi sia dunque scarso.</l>
           </sp>
-          <sp>
+          <sp who="#ergasto">
             <speaker>ERGASTO</speaker>
             <l>Ninfa, io ti credo bene,</l>
             <l>ch'io sentii quel meschino in sù la morte</l>
             <l>finir la vita sua</l>
             <l>co 'l chiamar il tuo nome.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Hor incomincia homai</l>
             <l>questa dolente historia.</l>
           </sp>
-          <sp>
+          <sp who="#ergasto">
             <speaker>ERGASTO</speaker>
             <l>Io era à mezo il colle; ove havea teso</l>
             <l>certe mie reti, quando assai vicino</l>
@@ -2679,21 +2716,21 @@ TORQUATO TASSO</head>
             <l part="I">precipitossi d'alto</l>
             <l part="F">co 'l capo in giuso: et io restai di ghiaccio.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="I">Misero <name>Aminta</name>.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="M">Oimè!</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO</speaker>
             <l part="F">Perché non l'impedisti?</l>
             <l>Forse ti fu ritegno à ritenerlo</l>
             <l>il fatto giuramento?</l>
           </sp>
-          <sp>
+          <sp who="#ergasto">
             <speaker>ERGASTO</speaker>
             <l>Questo nò, che sprezzando i giuramenti,</l>
             <l>vani forse in tal caso:</l>
@@ -2705,23 +2742,23 @@ TORQUATO TASSO</head>
             <l>che s'era tutto abandonato, in mano</l>
             <l part="I">spezzata mi rimase.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO</speaker>
             <l part="F">E che divenne</l>
             <l part="I">de l'infelice corpo?</l>
           </sp>
-          <sp>
+          <sp who="#ergasto">
             <speaker>ERGASTO</speaker>
             <l part="F">Io non sò dire,</l>
             <l>ch'era sì pien d'horrore, et di pietate,</l>
             <l>che non mi diede 'l cor di rimirarvi,</l>
             <l part="I">per non vederlo in pezzi.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO</speaker>
             <l part="F">O strano caso.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Oimè, ben son di sasso,</l>
             <l>poi che questa novella non m'occide.</l>
@@ -2755,12 +2792,12 @@ TORQUATO TASSO</head>
             <l>sarò per opra tua</l>
             <l>sua compagna a l'Inferno.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO</speaker>
             <l>Consolati meschina,</l>
             <l>che questo è di fortuna, e non tua colpa.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Pastor, di che piangete?</l>
             <l>Se piangete il mio affanno,</l>
@@ -2790,13 +2827,13 @@ TORQUATO TASSO</head>
             <l>ch'io sò certo, ch'ei m'ama,</l>
             <l>come mostrò morendo.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Son contenta aiutarti in questo officio:</l>
             <l>ma tu già non pensare</l>
             <l>d'haver poscia à morire.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Sin quì vissi à me stessa,</l>
             <l>à la mia feritate: hor quel; ch'avanza,</l>
@@ -2811,27 +2848,27 @@ TORQUATO TASSO</head>
             <l>ci conduce à la valle; ove 'l dirupo</l>
             <l part="I">và à terminar?</l>
           </sp>
-          <sp>
+          <sp who="#ergasto">
             <speaker>ERGASTO</speaker>
             <l part="F">Questa vi conduce,</l>
             <l>e quinci poco spatio ella è lontana.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Andiam, che verrò teco, e guiderotti,</l>
             <l part="I">che ben ramento il luoco.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F">A' <name>Dio</name> Pastori,</l>
             <l>piaggie à <name>Dio</name>: à <name>Dio</name> selve: Fiumi, à <name>Dio</name>.</l>
           </sp>
-          <sp>
+          <sp who="#ergasto">
             <speaker>ERGASTO</speaker>
             <l>Costei parla di modo, che dimostra</l>
             <l>d'esser disposta à l'ultima partita.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO DE PASTORI</speaker>
             <l>
               <gap/>
@@ -2844,7 +2881,7 @@ TORQUATO TASSO</head>
         <div type="scene">
           <head>Scena prima</head>
           <stage>ELPINO PASTORE, ET CHORO DE' PASTORI.</stage>
-          <sp>
+          <sp who="#elpino">
             <speaker>[ELPINO]</speaker>
             <l>Veramente la legge; con che Amore</l>
             <l>il suo imperio governa eternamente</l>
@@ -2866,7 +2903,7 @@ TORQUATO TASSO</head>
             <l>sani le piaghe mie con pietà vera;</l>
             <l>che con finta pietate al cor mi fece.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO</speaker>
             <l>Quel; che quì viene, è il saggio <name>Elpino</name>, e parla</l>
             <l>così d'<name>Aminta</name>, com'ei vivo fusse,</l>
@@ -2884,19 +2921,19 @@ TORQUATO TASSO</head>
             <l>de l'infelice <name>Aminta</name>? e un simil fine</l>
             <l part="I">sortir vorresti?</l>
           </sp>
-          <sp>
+          <sp who="#elpino">
             <speaker>ELPINO</speaker>
             <l part="F">Amici state allegri,</l>
             <l>che falso è quel rumor; ch' a voi pervenne</l>
             <l part="I">de la sua morte.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO</speaker>
             <l part="F">Oh, che ci narri, ò quanto</l>
             <l>ci racconsoli. E non è dunque vero</l>
             <l part="I">ch'ei si precipitasse?</l>
           </sp>
-          <sp>
+          <sp who="#elpino">
             <speaker>ELPINO</speaker>
             <l part="F">Anzi  verissimo:</l>
             <l>ma fu felice il precipitio: e sotto</l>
@@ -2911,7 +2948,7 @@ TORQUATO TASSO</head>
             <l>volere, e quel; che manca, e che prolunga</l>
             <l>il concorde voler d'ambedue loro.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO</speaker>
             <l>Pari l'Età, la gentilezza è pari,</l>
             <l>e concorde il desio: e 'l buon <name>Montano</name>
@@ -2924,7 +2961,7 @@ TORQUATO TASSO</head>
                   </l>
             <l part="I">habbia salvato.</l>
           </sp>
-          <sp>
+          <sp who="#elpino">
             <speaker>ELPINO</speaker>
             <l part="F">Io son contento, udite,</l>
             <l>udite quel; che con questi occhi ho visto.</l>
@@ -2978,12 +3015,12 @@ TORQUATO TASSO</head>
             <l>lasciò cadersi su'l giacente petto,</l>
             <l>e giunse viso à viso, e bocca à bocca.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO</speaker>
             <l>Hor non ritenne adunque la vergogna</l>
             <l>lei; ch'è tanto severa, e schiva tanto?</l>
           </sp>
-          <sp>
+          <sp who="#elpino">
             <speaker>ELPINO</speaker>
             <l>La vergogna ritien debila Amore:</l>
             <l>ma debil freno è di potente Amore.</l>
@@ -3007,12 +3044,12 @@ TORQUATO TASSO</head>
             <l>Chi è servo d'Amor, per sé lo stimi:</l>
             <l>Ma non si può stimar, non che ridire.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO</speaker>
             <l><name>Aminta</name> è sano si, ch'egli sia fuori</l>
             <l part="I">del rischio de la vita?</l>
           </sp>
-          <sp>
+          <sp who="#elpino">
             <speaker>ELPINO</speaker>
             <l part="F"><name>Aminta</name> è sano,</l>
             <l>se non ch'alquanto ha pur graffiato il viso,</l>
@@ -3025,7 +3062,7 @@ TORQUATO TASSO</head>
             <l>ma restate con <name>Dio</name>, ch'io vo seguire</l>
             <l>il mio viaggio, e ritrovar <name>Montano</name>.</l>
           </sp>
-          <sp>
+          <sp who="#choro">
             <speaker>CHORO</speaker>
             <l>Non so se 'l molto amaro</l>
             <l>che provato ha costui servendo, amando,</l>

--- a/tei/tasso-aminta-ms-campori-491.xml
+++ b/tei/tasso-aminta-ms-campori-491.xml
@@ -76,6 +76,40 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="amore">
+            <persName>Amore</persName>
+          </person>
+          <person xml:id="dafne">
+            <persName>Dafne</persName>
+          </person>
+          <person xml:id="silvia">
+            <persName>Silvia</persName>
+          </person>
+          <person xml:id="aminta">
+            <persName>Aminta</persName>
+          </person>
+          <person xml:id="tirsi">
+            <persName>Tirsi</persName>
+          </person>
+          <personGrp xml:id="coro">
+            <name>Choro</name>
+          </personGrp>
+          <person xml:id="satiro">
+            <persName>Satiro</persName>
+          </person>
+          <person xml:id="nirina">
+            <persName>Nirina</persName>
+          </person>
+          <person xml:id="nuntio">
+            <persName>Nuntio</persName>
+          </person>
+          <person xml:id="elpino">
+            <persName>Elpino</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>2001-09-01T00:00:00.000+01:00</date><name>Camilla Ghedini</name><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -88,7 +122,7 @@
     <body>
       <div type="prologue" n="Prologo">
         <stage>AMORE IN HABITO PASTORALE</stage>
-        <sp>
+        <sp who="#amore">
           <speaker>Amore</speaker>
           <l>Chi crederia che sotto humane forme</l>
           <l>e sotto queste pastorali spoglie</l>
@@ -195,7 +229,7 @@
         <div type="scene">
           <head>Scena prima</head>
           <stage>DAFNE SILVIA</stage>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Vorai dunque pur <name>Silvia</name>
                   </l>
@@ -207,7 +241,7 @@
             <l>Cangia prego consiglio</l>
             <l>Pazzarella che sei</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Altri segua i diletti de l'Amore</l>
             <l>Se pur v'è nel Amore alcun diletto</l>
@@ -218,7 +252,7 @@
             <l>saette alla Faretra o fere al bosco</l>
             <l>Non temo io ch'à me manchino diporti</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Insipidi diporti veramente</l>
             <l>Et insipida vita: e s'a te piace</l>
@@ -245,7 +279,7 @@
             <l>Pazzarella che sei</l>
             <l>Che 'l pentirsi da sezzo nulla giova</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Quand'io dirò pentita sospirando</l>
             <l>Queste parole ch'hor tu fingi et orni</l>
@@ -254,7 +288,7 @@
             <l>Dagli Agni e 'l Veltro le timidi Lepri</l>
             <l>Amerà l'Orso il Mare e 'l Delfin l'Alpe</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Conosco la ritrosa fanciullezza</l>
             <l>Qual tu sei, tale io fui: cosi portava</l>
@@ -312,7 +346,7 @@
             <l>Il vedrai fatto altrui? fatto felice</l>
             <l>Ne l'altrui braccia e te scherni ridendo? </l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Faccia <name>Aminta</name> di se e de suo amore</l>
             <l>Quelch'à lui piace à me nulla ne cale</l>
@@ -320,52 +354,52 @@
             <l>Ma esser non può mio s'io lui non voglio:</l>
             <l>Ne s'anco egli mio fosse io sarei sua.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="I">Onde nasce il tuo odio? </l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F">Dal suo amore</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Piacevol padre di figlio crudele</l>
             <l>Ma quando mai da i mansueti Agnelli</l>
             <l>Nacquer le Tigri? ò i bei Cigni da Corbi? </l>
             <l part="I">O' me inganni ò te stessa.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F">Odio il suo Amo<add resp="#ed">re</add>
                   </l>
             <l>Ch'odia la mia honestade, et amai lui</l>
             <l>Mentre ei volse di me quel ch'io volea</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Tu volevi il tuo peggio. Egli à te brama</l>
             <l part="I">Quel ch'à se brama.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="M"><name>Dafne</name> ò taci ò parla</l>
             <l part="I">D'altro se vuoi risposta.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Hor guata modi? </l>
             <l>Guata che dispettosa giovinetta? </l>
             <l>Hor rispondimi almen s'altri t'amasse</l>
             <l>Gradiresti il suo amore in questa guisa? </l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>In questa guisa gradirei ciaschuno</l>
             <l>Insidiator di mia virginitate</l>
             <l>Che tu domandi amante et io nimico</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Stimi dunque nimico</l>
             <l>Il Monton de l'Agnella? </l>
@@ -417,7 +451,7 @@
             <l>Udirò delle Piante</l>
             <l>Io son contenta all'hor d'esser amante</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Tu prendi à gabbo i miei fidi consigli</l>
             <l>E burli mie ragioni? ò in amore</l>
@@ -462,7 +496,7 @@
             <l>Ma che fe all'hor <name>Licori</name> e che rispose</l>
             <l part="I">A queste cose? </l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Tu de' fatti prorpi</l>
             <l>Nulla ti curi e vuoi saper gli altrui</l>
@@ -475,11 +509,11 @@
             <l>Se stimasse veraci come belli</l>
             <l>Quegli occhi e lor prestasse intiera fede.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="I">E perchè lor non crede? </l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Hor tu non sai</l>
             <l>Ciò che <name>Tirsi</name> ne scrisse? all'hor ch'ardendo</l>
@@ -494,7 +528,7 @@
             <l>Ben riconosco in voi gli inganni vostri</l>
             <l>Ma che pro se schivarli Amor mi toglie? </l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Io qui trapasso il tempo ragionando</l>
             <l>Ne mi soviene ch'hoggi è il di prescritto</l>
@@ -505,7 +539,7 @@
             <l>seguendo in caccia una dama veloce</l>
             <l part="I">Ch'al fin giunsi et uccisi.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Aspettarotti</l>
             <l>E forse anch'io mi bagnerò nel fonte</l>
@@ -520,7 +554,7 @@
         <div type="scene">
           <head>Scena seconda</head>
           <stage>AMINTA TIRSI</stage>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Ho visto al pianto mio</l>
             <l>Risponder per pietate i sassi e l'onde</l>
@@ -535,13 +569,13 @@
             <l>A chi non la negaro</l>
             <l>le cose inanimate</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Pasce l'Agne l'herbetta il Lupo l'Agne</l>
             <l>Ma'l crudo Amor di lagrime si pasce</l>
             <l part="I">Ne se ne mostra mai satollo.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Ahi lasso</l>
             <l>Ch'Amor satollo e del mio pianto homai</l>
@@ -549,7 +583,7 @@
             <l>Voglio ch'egli e quest'empia il sangue mio</l>
             <l part="I">Bevan con gli occhi.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Ahi <name>Aminta</name> ahi <name>Aminta</name>
                   </l>
@@ -557,26 +591,26 @@
             <l>Ch'un altra troverai se ti disprezza.</l>
             <l part="I">Questa crudele.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Ohimè come poss'io</l>
             <l>Altri trovar se me trovar non posso? </l>
             <l>Se perduto ho me stesso quale acquisto</l>
             <l part="I">Farò mai che mi piaccia? </l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">O' miserello</l>
             <l>Non disperar ch'acquistarai costei</l>
             <l>La lunga etate insegna à l'huom di porre</l>
             <l>freno à i leoni et à le tigri hircane</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Ma'l misero non puote à la sua morte</l>
             <l>Indugio sostener di lungo tempo.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Sarà corto l'indugio: in breve spatio</l>
             <l>S'adira e 'n breve spatio poi si placa</l>
@@ -592,7 +626,7 @@
             <l>Studio de le muse ch'à me scopra</l>
             <l part="I">Ciò ch'è gli altri si cela</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Io son contento</l>
             <l><name>Tirsi</name> a te dir cio che le selve e i Monti</l>
@@ -615,12 +649,12 @@
             <l>Dicendo ò pur qui fosse e fosse mio</l>
             <l part="I">Hor odi</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Segui pur ch'io t'ascolto</l>
             <l>E forse à miglior fin che tu non pensi</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Essendo io fanciulletto si che apena</l>
             <l>Giunger potea con la man pargoletta</l>
@@ -665,11 +699,11 @@
             <l>Ben me n'accorsi al fine et in qual modo</l>
             <l part="I">Hora m'ascolta e nota.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">È da notare</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>A l'ombra d'un bel faggio <name>Silvia</name> e <name>Filli</name>
                   </l>
@@ -775,31 +809,31 @@
             <l>Cosa che turbi il bel lume sereno</l>
             <l>À gli occhi cari e affanni quel bel petto</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>È possibil però che s'ella un giorno</l>
             <l>Udisse tai parole non t'amasse? </l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>No'l so ne'l credo. ma fugge i miei detti</l>
             <l part="I">Come l'Aspe l'incanto.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Horsù confida</l>
             <l>Ch'à me da il cor di far ch'ella t'ascolti</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Ò nulla impetrarai ò se tu impetri</l>
             <l>Ch'io parli io nulla impetrarò parlando</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="I">Perchè disperi si? </l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Giusta cagione</l>
             <l>Ho al mio disperar ch'el saggio <name>Mopso</name>
@@ -808,7 +842,7 @@
             <l><name>Mopso</name> ch'intende il parlar de gli Augelli</l>
             <l>E la virtù de l'herbe e de le fonti</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Di qual <name>Mopso</name> tu dici? di quel <name>Mopso</name>
                   </l>
@@ -824,12 +858,12 @@
             <l>Mi giova di sperar felice fine</l>
             <l part="I">À l'amor tuo.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Se sai cosa per prova</l>
             <l>Che conforti mia speme non tacerla</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Dirolla volentieri. All'hor che prima</l>
             <l>Mia sorte mi condusse in queste selve</l>
@@ -923,18 +957,18 @@
             <l>E dei beni sperar sol perchè ei vuole</l>
             <l part="I">Che nulla speri</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Piacemi d'udire</l>
             <l>Quanto mi narri. A te dunque rimetto</l>
             <l part="I">La cura di mia vita</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Io n'havro cura</l>
             <l>Tu lasciati trovar qui fra mezz'hora.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CHORO</speaker>
             <l>O bella eta de l'oro</l>
             <l>Non già perche di latte</l>
@@ -1011,7 +1045,7 @@
         <div type="scene">
           <head>Scena prima</head>
           <stage>SATIRO SOLO</stage>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <l>Picciola è l'Ape e fa co'l picciol morso</l>
             <l>Pur gravi e pur moleste le ferite</l>
@@ -1115,7 +1149,7 @@
         <div type="scene">
           <head>Scena seconda</head>
           <stage>DAFNE TIRSI</stage>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l><name>Tirsi</name> com'io t'ho detto io m'era accorta</l>
             <l>Ch'<name>Aminta</name> amava <name>Silvia</name> e <name>dio</name> sa quanti</l>
@@ -1130,7 +1164,7 @@
             <l>Ma ridendo e piancendo uccida altrui</l>
             <l>E l'ucida e non sappia di ferire</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Ma qual è cosi semplice fanciulla</l>
             <l>Ch'uscita de le fasce non apprenda</l>
@@ -1139,12 +1173,12 @@
             <l>Qual arme fera e qual dia morte e quale</l>
             <l part="I">Sani e ritorni in vita? </l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Chi è il maestro</l>
             <l part="I">Di cotant'arte? </l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Tu fingi e mi tenti? </l>
             <l>Quel ch'insegna à gli Augelli il canto e'l volo</l>
@@ -1152,19 +1186,19 @@
             <l>Al Toro usar il corno et al Pavone</l>
             <l>Spiegar la pompa de l'occhiute piume</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="I">Com'ha nome il gran mastro? </l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F"><name>Dafne</name> ha nome</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="I">Lingua bugiarda:</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">E perchè? Tu non sei</l>
             <l>Atta à tener <num value="1000">mille</num> fanciulle à scuola? </l>
@@ -1172,7 +1206,7 @@
             <l>Di maestro: Maestro è la natura</l>
             <l><add resp="#ed">Ma la ma</add>dre e la balia anco v'han parte</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Insomma tu sei goffo insieme e tristo</l>
             <l>Hora per dirti il ver non mi risolvo</l>
@@ -1212,12 +1246,12 @@
             <l>Perche bella si vide ancor che incolta</l>
             <l part="I">Io me n'avidi e tacqui.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Tu mi narri</l>
             <l>Quel ch'io credeva apunto; hor non m'apposi? </l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Ben t'apponesti, ma pur odo dire</l>
             <l>Che non erano pria le pastorelle</l>
@@ -1225,7 +1259,7 @@
             <l>Fui in mia fanciullezza. Il mondo invecchia</l>
             <l part="I">E invecchiato intristisce.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Forse all'hora</l>
             <l>Non usavan si spesso i cittadini</l>
@@ -1237,15 +1271,15 @@
             <l><name>Silvia</name> contenta sia che le ragioni</l>
             <l><name>Aminta</name> ò solo ò almeno in tua presenza? </l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Non sò<name>Silvia</name> è ritrosa fuor di modo</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>E costui rispettoso fuor di modo</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>È spacciato un amante rispettoso</l>
             <l>Conseglial pur che faccia altro mestiero</l>
@@ -1262,7 +1296,7 @@
             <l>Non parlo in rime. Tu sai ch'io saprei</l>
             <l>Renderti poi per versi altro che versi</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Non hai cagion di sospettar ch'io dica</l>
             <l>Cosa giamai che sia contra tuo grado.</l>
@@ -1272,7 +1306,7 @@
                   </l>
             <l part="I">Miserel che si more.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Ò che gentile</l>
             <l>Scongiuro ha ritrovato questo sciocco</l>
@@ -1280,13 +1314,13 @@
             <l>Il ben passato e la presente noia</l>
             <l part="I">Ma che voi tù ch'io faccia? </l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">A te non manca</l>
             <l>Ne saper ne consiglio. basta sol che</l>
             <l part="I">Ti disponga à volere.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Horsù dirotti</l>
             <l>Dobbiamo in breve andare <name>Silvia</name> et io</l>
@@ -1297,30 +1331,30 @@
             <l>Le Ninfe cacciatrici. Ivi sò certo</l>
             <l>Che tufferà le belle membra ignude</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="I">Ma che però</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Ma che però? Da poco</l>
             <l>Intenditor s'hai senno tanto basti</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Intendo ma non sò s'egli havrà tanto</l>
             <l part="I">D'ardir.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">S'ei non l'havrà stiasi et aspetti</l>
             <l part="I">Ch'altri lui cerchi</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Egli è ben tal che'l merta</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Ma non vogliamo noi parlare alquanto</l>
             <l>Di te medesmo? horsù <name>Tirsi</name> non vuoi</l>
@@ -1330,37 +1364,37 @@
             <l>Vuoi viver neghittoso senza gioia? </l>
             <l>Che solo amando huom sa che sia diletto.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>I diletti di <name>Venere</name> non lassa</l>
             <l>L'huom che gusta l'amore ma coglie e gusta</l>
             <l>Le dolcezze d'amor senza l'amaro</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Insipido è quel dolce che condito</l>
             <l>Non è d'alquanto amaro e tosto satia</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>È meglio satiarsi ch'esser sempre</l>
             <l>Famelico nel cibo e doppo il cibo</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Ma non s'el cibo si possiede e piace</l>
             <l>E gustato à gustar sempre rinvoglia</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Ma chi possiede si quel che gli piace</l>
             <l>Che l'habbia sempre presto à la sua fame? </l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Ma chi ritrova il ben s'egli no'l cerca? </l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Periglioso è cercar quel che trovato</l>
             <l>Trastulla si ma più tormenta assai</l>
@@ -1370,51 +1404,51 @@
             <l>Abastanza ho già pianto e sospirato</l>
             <l part="I">Faccia altri hor la sua parte.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Ma non hai</l>
             <l part="I">Già goduto à bastanza.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Ne desio</l>
             <l>Goder se così caro egli si compra</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Sarà forza l'amar se non fia voglia</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Ma non si può sforzar chi sta lontano</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="I">Ma chi lunge è d'Amor.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Chi teme e fugge</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>E che giova fuggir da lui ch'ha l'ali</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Amor nascente ha corte l'ali apena</l>
             <l>Può su tenerle e non le spiega à volo</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Pur non s'accorge l'huom quand'egli nasce</l>
             <l>E quando huom sen'accorge e grande e vola</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Non s'altra volta nascer no' l'ha visto.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Vedrem <name>Tirsi</name> s'havrai la fuga e gli occhi</l>
             <l>Come tu dici io ti protesto poi</l>
@@ -1423,32 +1457,32 @@
             <l>Non moverei per aitarti un passo</l>
             <l>Un dito un detto una palpebra sola</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Crudel ti darà il cuor vedermi morto? </l>
             <l>Se vuoi purch'ami ama tu me facciamo</l>
             <l part="I">L'amor d'accordo.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Tu mi scherni o forse</l>
             <l>Non merti amante così fatta. ahi quanti</l>
             <l>N'inganna un viso colorito e liscio</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Non burlo io nò ma tu con tal pretesto</l>
             <l>Non accetti il mio amor pur come è uso</l>
             <l>Di tutte quante: ma se non mi vuoi</l>
             <l part="I">Viverò sanza amor.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Contento vivi</l>
             <l>Più che mai fossi è <name>Tirsi</name> e'n otio vivi.</l>
             <l>E nel otio l'amor sempre germoglia</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Ò <name>Dafne</name> à me questi otij ha fatto <name>Dio</name>
                   </l>
@@ -1484,12 +1518,12 @@
             <l>E che mutando i Fiumi letto e corso</l>
             <l>Il <name>Perso</name> bea la <name>Senna</name> il <name>Gallo</name> il <name>Tigre</name>.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Ò tu vai alto. Horsù discendi un poco</l>
             <l part="I">Al proposito mio.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Il punto è questo</l>
             <l>Che tu in andando al Fonte con colei</l>
@@ -1498,12 +1532,12 @@
             <l>Ne la mia forse men difficil cura</l>
             <l part="I">Sarà di questa tua. hor vanne.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Io vado</l>
             <l>Ma al proposito nostro altro intendeva.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Se ben raviso di lontan la faccia</l>
             <l><name>Aminta</name> è quel che di là spunta e desso</l>
@@ -1512,7 +1546,7 @@
         <div type="scene">
           <head>Scena terza</head>
           <stage>AMINTA TIRSI</stage>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Vorò veder ciò che <name>Tirsi</name> havrà fatto</l>
             <l>E s'havrà fatto nulla</l>
@@ -1526,53 +1560,53 @@
             <l>La piaga del mio petto</l>
             <l>Colpo de la mia mano.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Nove <name>Aminta</name> t'annuntio di conforto</l>
             <l>Lascia homai questo tanto lamentarti</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Ohime che di? Che porti? </l>
             <l>O la vita ò la morte? </l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Porto salute e vita s'ardirai</l>
             <l>Di farti loro incontra: ma fa luogo</l>
             <l>D'esser un huomo <name>Aminta</name> un huomo ardito</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Qual ardir mi bisogna e'n contra cui</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Se la tua donna fosse in mezzo un bosco</l>
             <l>Che cinto intorno d'altissime rupi</l>
             <l>Desse albergo alle Tigri et à leoni</l>
             <l part="I">V'andresti tu? </l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">V'andrei sicuro e baldo</l>
             <l>Più che di festa villanella al ballo</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>E s'ella fosse trà ladroni et armi</l>
             <l part="I">V'andresti tu? </l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">V'andrei più lieto e pronto</l>
             <l>Che l'assetato Cervo à la Fontana</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Bisogna à maggior uopo ardir più grande</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Andrò per mezzo i rapidi torrenti</l>
             <l>Quando la neve si discioglie e gonfi</l>
@@ -1581,43 +1615,43 @@
             <l>S'esser può inferno ov'è cosa si bella</l>
             <l part="I">Horsù scoprimi il tutto.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="M">Odi.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Di tosto</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l><name>Silvia</name> attende à una fonte ignuda e sola</l>
             <l part="I">Ardirai tu t'andarvi? </l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">O che mi dici? </l>
             <l><name>Silvia</name> m'attende ignuda e sola</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="I">Sola</l>
             <l part="F">Se non quanto v'è <name>Dafne</name> ch'è per noi</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="I">Ignuda ella m'aspetta? </l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Ignuda ma</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Ohimè che ma? tu taci? tu m'uccidi</l>
             <l>Ma non sa già che tu v'habbi d'andare? </l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Dura conclusion che tutte attosca</l>
             <l>Le dolcezze passate. hor con qual arte</l>
@@ -1626,20 +1660,20 @@
             <l>Che infelice io sia</l>
             <l>Ch'accrescer vieni la miseria mia</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>S'à mio senno farai sarai felice</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="I">E che consigli? </l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Che tu prenda quello</l>
             <l>Che la fortuna amica t'appresenta</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Tolga <name>dio</name> ch'io mai faccia</l>
             <l>Cosa che le dispiaccia</l>
@@ -1649,43 +1683,43 @@
             <l>Non sarà dunque ver che in quanto io posso</l>
             <l part="I">Non cerchi compiacerle.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Hor mi rispondi</l>
             <l>Se fosse in tuo poter di non amarla</l>
             <l>Lasciaresti d'amarla per piacerle</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Ne questo mi consente Amor ch'io dica</l>
             <l>Ne ch'inmagini pur d'haver giamai</l>
             <l>A lasciar il suo amor ben ch'io potessi</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Dunque tu l'amaresti à suo dispetto</l>
             <l>Quando potessi far di non amarla</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>A suo dispetto nò ma l'amarei</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="I">Dunque fuor di sua voglia.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Si per certo.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Perchè dunque non osi oltre sua voglia</l>
             <l>Prenderne quel che se ben grave in prima</l>
             <l>Al fin al fin le sarà caro e dolce</l>
             <l part="I">Che t'habbia preso? </l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Ahi <name>Tirsi</name> Amor risponda</l>
             <l>Per me che quando in mezzo al cor mi parla</l>
@@ -1694,26 +1728,26 @@
             <l part="I">A me lega la lingua</l>
             <l part="F">Quel che mi lega il core</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Dunque andar non vogliamo.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Andar voglio io</l>
             <l part="I">Ma non dove tu stimi.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="M">E dove</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">À morte</l>
             <l>S'altro in mio prò non hai fatto che quanto</l>
             <l part="I">Hora mi narri</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">E poco parti questo? </l>
             <l>Credi dunque tu sciocco che mai <name>Dafne</name>
@@ -1730,12 +1764,12 @@
             <l>Ne sua mercede à te folle che importa</l>
             <l part="I">Più l'un modo che l'altro:</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">E chi m'accerta</l>
             <l part="I">Che'l suo desir sia tale? </l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">O mentecatto</l>
             <l>Ecco tu chiedi pur quella certezza</l>
@@ -1749,24 +1783,24 @@
             <l>Questa perdita tua che fia cagione</l>
             <l>Di vittoria maggiore andianne</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="I">Aspetta.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Che aspetta non sai che'l tempo fugge? </l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>De pensiam pria se ciò de farsi e come</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Per strada pensarem ciò che vi resta</l>
             <l>Ma nulla fa' chi troppe cose pensa</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CHORO</speaker>
             <l>
               <gap extent="2 versi"/>
@@ -1798,7 +1832,7 @@
             <l>Amici havete visto <name>Aminta</name>? O inteso</l>
             <l part="I">Novella di lui forse? </l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="F">Tu mi pari</l>
             <l>Così turbato. qual cagion t'affanna? </l>
@@ -1810,37 +1844,37 @@
             <l>Noi visto on l'habbiam da poi che teco</l>
             <l>Buona pezza partì ma che ne temi? </l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Ch'egli non s'habbia ucciso di sua mano</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CHORO</speaker>
             <l>Ucciso di sua mano? hor perchè questo? </l>
             <l part="I">Che ne stimi cagione.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Odio et amore</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CHORO</speaker>
             <l><num value="2">Duo</num> potenti nemici insieme aggiunti</l>
             <l>Che far non ponno? ma parla più chiaro</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>L'amar troppo una Ninfa e l'esser troppo</l>
             <l part="I">Odiato da lei.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CHORO</speaker>
             <l part="F">Deh narra il tutto</l>
             <l>Questo è luogo di passo e forse intanto</l>
             <l>Alcun vorà che nova di lui rechi</l>
             <l>Forse arrivar potrebbe egli medesmo.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Dirollo volentier che non è giusto.</l>
             <l>che tanta ingratitudine è si strana</l>
@@ -1898,12 +1932,12 @@
             <l>Ne questa gratia che fortuna vuole</l>
             <l>Conceder loro tuo mal grado sia.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CHORO</speaker>
             <l>Parole d'<add resp="#ed">amm</add>ollire un cor di sasso</l>
             <l part="I">Ma che rispose all'hor.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Nulla rispose:</l>
             <l>Ma disdegnosa e vergognosa à terra</l>
@@ -1927,12 +1961,12 @@
                   </l>
             <l>Per me stessa saprò sciogliermi i piedi</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CHORO</speaker>
             <l>Hor tant'orgoglio regna in cor di Ninfa? </l>
             <l>Ahi d'opra gloriosa ingrato merto</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Ei si trasse in disparte riverente</l>
             <l>Non alzando pur gli occhi per mirarla</l>
@@ -1949,22 +1983,22 @@
             <l>Che l'era noto il rispetto d'<name>Aminta</name>
                   </l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CHORO</speaker>
             <l part="I">Perchè dunque fuggissi</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">A la sua fuga</l>
             <l>Volse l'obligo haver non all'altrui</l>
             <l part="I">Modesto Amore</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CHORO</speaker>
             <l part="F">Et in questo anco è ingrata</l>
             <l>Ma che fe il miserello all'hor che disse? </l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Nòl sò ch'io pien di mal talento corsi</l>
             <l>Per arivarla e ritenerla e'n vano</l>
@@ -1974,21 +2008,21 @@
             <l>So ch'egli era disposto di morire</l>
             <l part="I">Prima che ciò avenisse.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CHORO</speaker>
             <l part="F">È uso et arte</l>
             <l>Di ciascun ch'ama minacciarsi morte</l>
             <l>Ma rade volte poi segue l'effetto</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l><name>Dio</name> faccia che non sia fra questi radi</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CHORO</speaker>
             <l part="I">Non sarà nò</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Io voglio irmene à l'antroo</l>
             <l>Del saggio <name>Elpino</name> ivi s'è vivo forse</l>
@@ -2005,7 +2039,7 @@
         <div type="scene">
           <head>Scena seconda</head>
           <stage>AMINTA DAFNE NIRINA</stage>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Dispietata pietade</l>
             <l>Fu la tua veramente ò <name>Dafne</name> all'hora</l>
@@ -2017,7 +2051,7 @@
             <l>Ragionamenti invano? di che temi? </l>
             <l>C'io non m'uccida? temi del mio bene</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Non disperare <name>Aminta</name>
                   </l>
@@ -2025,7 +2059,7 @@
             <l>Sola vergogna fu non crudeltade</l>
             <l>Quella che mosse <name>Silvia</name> /agrave; fuggir via</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Ohime che mia salute</l>
             <l>Sarebbe il disperare</l>
@@ -2035,7 +2069,7 @@
             <l>Sol perch'io viva e qual è maggior male</l>
             <l>De la vita d'un misero com'io? </l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Vivi misero vivi</l>
             <l>Ne la miseria tua: e questo stato</l>
@@ -2044,14 +2078,14 @@
             <l>Se vivendo e sperando ti mantieni</l>
             <l>Quel che vedesti ne la bella ignuda</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Non pareva ad Amore à mia fortuna</l>
             <l>Ch'a pien misero fossi e s'anco a pieno</l>
             <l>Non m'era dimostrato</l>
             <l>Quel che m'era negato</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l>Dunque a me pur conviene esser sinistra</l>
             <l>Cornice d'amarissima novella? </l>
@@ -2061,17 +2095,17 @@
             <l>De l'unica tua <name>Silvia</name> il duro caso? </l>
             <l>Padre vecchio orbo padre ahi non più padre</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="I">Odo una mesta voce.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Io odo il nome</l>
             <l>Di <name>Silvia</name> che gli orecchi e'l cor mi fere</l>
             <l part="I">Ma chi e che la noma? </l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Ell'è <name>Nirina</name>
                   </l>
@@ -2079,44 +2113,44 @@
             <l>Ch'ha si begli occhi e così belle mani</l>
             <l>E modi si leggiadri e gratiosi</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l>E pur meglio che'l sappia e che procuri</l>
             <l>Di ritrovar le reliquie infelici</l>
             <l>Se nulla ve ne resta. ahi <name>Silvia</name> ahi dura</l>
             <l>Sua sorte.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Ohimè che fia? che costei dice? </l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l part="I">O <name>Dafne</name>
                   </l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Che parli fra te stessa e perchè nomi</l>
             <l part="I">Tu <name>Silvia</name> e poi sospiri? </l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l part="F">Ah ch'a ragione</l>
             <l part="I">Sospiro l'aspro caso</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Ahi di qual caso</l>
             <l>Può ragionar costei? Io sento io sento</l>
             <l>Che mi s'agghiaccia il cuore e mi si chiude</l>
             <l>Lo spirto è via</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Narra qual aspro caso e qual che dici</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l>O <name>Dio</name> perchè son io</l>
             <l>La messaggiera? e pur convien narrarlo</l>
@@ -2136,12 +2170,12 @@
             <l>A sommo il capo ei si rinselva et ella</l>
             <l>Vibrando un dardo dentro il bosco il segue</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>O dolente principio ohimè qual fine</l>
             <l part="I">Già mi s'annuntia</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l part="F">Io con un altro dardo</l>
             <l>Seguo lor traccia ma lontana assai</l>
@@ -2161,22 +2195,22 @@
             <l>Indietro ritornaimi, e questo è quanto</l>
             <l>Posso dirvi di <name>Silvia</name> et ecco il velo</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Poco parti haver detto? Ò velo ò sangue? </l>
             <l part="I">Ò <name>Silvia</name> tu sei morta? </l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Ò miserello</l>
             <l>Tramortito è d'affanno e forse morto</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l>Egli rispira pure. questo fia</l>
             <l>Un breve isvenimento. ecco riviene</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Dolor che si mi crucci</l>
             <l>Che non m'uccidi homai? Tu sei pur lento.</l>
@@ -2202,21 +2236,21 @@
             <l>Ben soffrirà ch'io moia</l>
             <l>E tu soffrirlo dei</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Aspetta à la tua morte</l>
             <l>Sin che'l ver meglio intenda</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Ohime che vuoi ch'attenda? </l>
             <l>Ohime ch'ho troppo atteso <add resp="#ed">e</add> troppo inteso</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l>O foss'io stata muta</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Ninfa dammi ti prego</l>
             <l>Quel velo ch'è di lei</l>
@@ -2229,13 +2263,13 @@
             <l>Ch'e ben picciol martire</l>
             <l>S'ha bisogno d'aiuto al mio morire.</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l>Debb'io darlo ò negarlo? </l>
             <l>La cagion perche'l chiedi</l>
             <l>Fa ch'io debba negarlo</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Crudel si picciol dono</l>
             <l>Mi nieghi al punto estremo</l>
@@ -2244,12 +2278,12 @@
             <l>A te si resti. E voi restate ancora</l>
             <l>Ch'io vò per non tornare</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l><name>Aminta</name> aspetta ascolta</l>
             <l>Ohime con quanta furia egli si parte</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l>Egli va si veloce</l>
             <l>Che fia vano il seguirlo. Ond'è pur meglio</l>
@@ -2261,7 +2295,7 @@
               <gap extent="1 verso"/>
             </l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CHORO</speaker>
             <l>
               <gap/>
@@ -2274,7 +2308,7 @@
         <div type="scene">
           <head>Scena prima</head>
           <stage>DAFNE SILVIA CHORO</stage>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Ne porti il vento con la rea novella</l>
             <l>Che s'era di te sparta ogni tuo male</l>
@@ -2284,18 +2318,18 @@
             <l>M'havea <name>Nirina</name> il tuo caso dipinto</l>
             <l>Ahi stata fosse muta od altri sordo</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Certo il rischio fu grande et ella havea</l>
             <l>Giusta cagion di sospettarmi morta</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Ma non giusta cagione havea di dirlo</l>
             <l>Hor narra tu qual fosse il rischio e come</l>
             <l part="I">Tu lo fuggisti</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F">Io seguitando un Lupo</l>
             <l>Mi rinselvai nel più profondo bosco</l>
@@ -2336,56 +2370,56 @@
             <l>Tutta turbata e mi stupij vedendo</l>
             <l part="I">Stupirti al mio apparire</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Ohime tu vivi</l>
             <l part="I">Altri non già</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F">Che dici? Ti rincresce</l>
             <l>Forse ch'io viva sia? m'odij tu tanto</l>
             <l>Mi piace di tua vita: ma mi duole</l>
             <l part="I">De l'altrui morte.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F">E di qual morte intendi? </l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="I">De la morte d'<name>Aminta</name>.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F">Ahi come è morto? </l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Il come non so dir ne so dir anco</l>
             <l>S'è ver l'effetto ma per certo il credo</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Che è ciò che mi dici? et à che rechi</l>
             <l part="I">La cagion di sua morte.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Alla tua morte</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="I">Io non t'intendo.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">La dura novella</l>
             <l>De la tua morte ch'egli udì e credette</l>
             <l>Havrà porto al meschino il laccio ò 'l ferro</l>
             <l>Od altra cosa tal che l'havrà ucciso</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Vano è il sospetto in te de la sua morte</l>
             <l>
@@ -2393,7 +2427,7 @@
             </l>
             <l>Ch'ogn'uno à suo poter salva la vita</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>O' <name>Silvia</name>
                      <name>Silvia</name> tu non sai ne credi</l>
@@ -2421,11 +2455,11 @@
             <l>E mostrò quella strada al ferro audace</l>
             <l>Che correr poi dovea liberamente</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="I">O' che mi narri? </l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Il vidi poscia all'hora</l>
             <l>Ch'intese l'amarissima novella</l>
@@ -2434,15 +2468,15 @@
             <l>Per uccider se stesso e s'havrà ucciso</l>
             <l part="I">Veramente</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F">E ciò per fermo tieni? </l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="I">Io non v'ho dubio</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F">Ohime tu no'l seguisti</l>
             <l>Per impedirlo cerchianlo andiamo</l>
@@ -2453,12 +2487,12 @@
             <l>Poi mi girai per le sue orme. hor dove</l>
             <l>Voi tu cercar se non n'hai traccia alcuna? </l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Egli morrà se no'l troviamo ahi lassa</l>
             <l>E sarà l'homicida ei di se stesso</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Crudel forse t'incresce che ti tolga</l>
             <l>La gloria di questo atto? esser tu dunque</l>
@@ -2468,7 +2502,7 @@
             <l>Che comunque egli moia per te more</l>
             <l>E tu sei che l'uccidi.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Ohime che tu m'accori e quel cordoglio</l>
             <l>Ch'io sento del suo caso m'accerbisce</l>
@@ -2478,7 +2512,7 @@
             <l>Ma fu troppo severa e rigorosa</l>
             <l part="I">Hor me n'accorgo e pento.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">O' quel ch i' odo</l>
             <l>Tu sei pietosa tu? tu senti al core</l>
@@ -2486,16 +2520,16 @@
             <l>Tu piangi tu superba? ò meraviglia</l>
             <l>Che pianto è questo tuo pianto d'Amore</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Pianto d'Amor non già ma di pietade</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>La pietà messaggiera e de l'Amore</l>
             <l part="I">Come il Lampo del tuono.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CHORO</speaker>
             <l part="F">Anzi sovente</l>
             <l>Quand egli vuol ne petti virginelli</l>
@@ -2505,7 +2539,7 @@
             <l>E sua Nuntia Pietate e con tai larve</l>
             <l>Le simplici ingannando è dentro accolto</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Questo è pianto d'Amor che troppo abbonda</l>
             <l>Tu taci? ami<add resp="#ed">ti</add> tu <name>Silvia</name>? ami: ma invano</l>
@@ -2526,12 +2560,12 @@
             <l>Desti quel prezzo tu ch'ella richiese</l>
             <l>E' l'amor suo co'l tuo morir comprasti</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CHORO</speaker>
             <l>Caro prezzo à chi'l diede: A chi il riceve</l>
             <l part="I">Prezzo inutile e infame</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F">O' potess'io</l>
             <l>Con l'amor mio comprar la vita sua</l>
@@ -2540,7 +2574,7 @@
             </l>
             <l part="I">S'egli è pur morto.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">O' tardi saggia, e tardi</l>
             <l>Pietosa quando ciò nulla rilieva.</l>
@@ -2549,40 +2583,40 @@
         <div type="scene">
           <head>Scena seconda</head>
           <stage>NUNTIO CHORO SILVIA DAFNE</stage>
-          <sp>
+          <sp who="#nuntio">
             <speaker>NUNTIO</speaker>
             <l>Io ho si pieno il petto di pietate</l>
             <l>E si pieno d'horror che non rimiro</l>
             <l>Ne odo alcuna cosa ov'io mi volga</l>
             <l>La qual non mi spaventi e non m'affanni</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CHORO</speaker>
             <l>Hor che porta costui</l>
             <l>Ch'e si turbato in vista et in favella</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l part="I">Porto l'aspra novella</l>
             <l part="F">De la morte d'<name>Aminta</name>.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Ohimè che dice? </l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l>Il più nobil pastor di queste selve</l>
             <l>Che fu cosi gentil così leggiadro</l>
             <l>Così caro à le Ninfe et à le Muse</l>
             <l>Et è morto fanciullo. ahi di che morte</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CHORO</speaker>
             <l>Contane prego il tutto accio che teco</l>
             <l>Pianger possiam la sua sciagura e nostra</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Ohime che non ardisco</l>
             <l>Appressarmi ad udire</l>
@@ -2600,19 +2634,19 @@
             <l>Come devuta cosa hor tu di lui</l>
             <l>Non mi sia dunque scarso</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l>Ninfa io ti credo bene</l>
             <l>Ch'io sentij quel meschino in su la morte</l>
             <l>Finir la vita sua</l>
             <l>Co'l chiamar il tuo nome</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CHORO</speaker>
             <l>Hor incomincia homai</l>
             <l>Questa dolente historia</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l>Io era à mezzo il Colle ov'havea teso</l>
             <l>Certe mie reti quando assai vicino</l>
@@ -2676,22 +2710,22 @@
             <l>Precipitossi d'alto</l>
             <l>Co'l capo in giuso et io restai di ghiaccio</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="I">Misero <name>Aminta</name>
                   </l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F">Ohimè</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CHORO</speaker>
             <l>Perchè non l'impedisti? </l>
             <l>Forse ti fu ritegno à ritenerlo</l>
             <l>Il fatto giuramento</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l>Questo nò che sprezzando i giuramenti</l>
             <l>Vani forse in tal caso</l>
@@ -2704,23 +2738,23 @@
             <l>Che s'era tutto abbandonato in mano</l>
             <l part="I">Spezzata mi rimase</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CHORO</speaker>
             <l part="F">E che divenne? </l>
             <l part="I">De l'infelice corpo.</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l part="F">Io no'l so dire</l>
             <l>Ch'era si pien d'horrore e di pietade</l>
             <l>Che non mi diede il cuor di rimirarmi</l>
             <l part="I">Per non vederlo in pezzi</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CHORO</speaker>
             <l part="F">O' strano caso</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Ohime ben son di sasso</l>
             <l>Poichè questa novella non m'uccide</l>
@@ -2754,12 +2788,12 @@
             <l>Sarà per opra tua</l>
             <l>Sua compagna à l'Inferno</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CHORO</speaker>
             <l>Consolati meschina</l>
             <l>Che questa e di fortuna e non tua colpa.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Pastor di che piangete? </l>
             <l>Se piangete il mio affanno</l>
@@ -2790,13 +2824,13 @@
             <l>Ch'io so certo ch'ei m'ama</l>
             <l>Come mostrò morendo</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Son contenta aiutarti in questo officio</l>
             <l>Ma tu già non pensare</l>
             <l>D'haver poscia à morire</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Sin qui vissi à me stessa</l>
             <l>A la mia feritade hor quel ch'avanza</l>
@@ -2814,23 +2848,23 @@
             <l>Ci conduce alla Valle ove il dirupo</l>
             <l part="I">Va à terminar</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l part="F">Questa vi conduce</l>
             <l>E quinci poco spatio ella è lontana</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Andiam che vero teco e guiderotti</l>
             <l part="I">Che ben ramento il luogo.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F">A <name>dio</name> pastori</l>
             <l>Piaggie à <name>Dio</name> à <name>Dio</name> Selve fiumi à <name>Dio</name>
                   </l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l>Costei parla di modo che dimostra</l>
             <l>Esser disposta à l'ultima partita.</l>
@@ -2838,7 +2872,7 @@
               <gap extent="1 verso"/>
             </l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CHORO</speaker>
             <l>
               <gap/>
@@ -2872,7 +2906,7 @@
             <l>Sani le piaghe mie con pietà vera</l>
             <l>Che con finta pietade al cor mi fece</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CHORO</speaker>
             <l>Quel che qua viene è'l saggio <name>Elpino</name> e parla</l>
             <l>Così d'<name>Aminta</name> come vivo fosse</l>
@@ -2892,19 +2926,19 @@
             <l>De l'infelice <name>Aminta</name>? e un simil fine</l>
             <l part="I">Sortir voresti</l>
           </sp>
-          <sp>
+          <sp who="#elpino">
             <speaker>ELPINO</speaker>
             <l part="F">Amici state allegri</l>
             <l>Che falso è quel romor ch'à noi pervenne</l>
             <l part="I">De la sua morte.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CHORO</speaker>
             <l part="F">Ò che ci narri ò quanto</l>
             <l>Ci raconsoli e non è dunque vero</l>
             <l part="I">Ch'ei si precipitasse? </l>
           </sp>
-          <sp>
+          <sp who="#elpino">
             <speaker>ELPINO</speaker>
             <l part="F">Anzi pur vero</l>
             <l>Ma fu felice il precipitio: e sotto</l>
@@ -2919,7 +2953,7 @@
             <l>Volere e quel che manca e che prolunga</l>
             <l>Il concorde voler d'ambo <num value="2">due</num> loro</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CHORO</speaker>
             <l>Pari è l'età la gentilezza e pari</l>
             <l>E concorde il desio e'l buon <name>Montano</name>
@@ -2932,7 +2966,7 @@
                   </l>
             <l part="I">Habbia salvato</l>
           </sp>
-          <sp>
+          <sp who="#elpino">
             <speaker>ELPINO</speaker>
             <l part="F">Io son contento udite</l>
             <l>Udite quel che con questi occhi ho visto</l>
@@ -2988,12 +3022,12 @@
             <l>Lasciò cadersi in sul giacente corpo</l>
             <l>E giunse viso à viso e bocca à bocca</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CHORO</speaker>
             <l>Hor non ritenne dunque la vergogna</l>
             <l>Lei ch'è tanto severa e schiva tanto</l>
           </sp>
-          <sp>
+          <sp who="#elpino">
             <speaker>ELPINO</speaker>
             <l>La vergogna ritien debil amore</l>
             <l>Ma debil freno è di potente Amore</l>
@@ -3019,12 +3053,12 @@
             <l>Chi è servo d'Amor per se lo stimi</l>
             <l>Ma non si può stimar non che ridire.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CHORO</speaker>
             <l><name>Aminta</name> è sano si ch'egli sia fuori</l>
             <l part="I">Del rischio de la vita? </l>
           </sp>
-          <sp>
+          <sp who="#elpino">
             <speaker>ELPINO</speaker>
             <l part="F"><name>Aminta</name> è sano</l>
             <l>Se non ch'alquanto pur graffiato hà il viso.</l>
@@ -3038,7 +3072,7 @@
             <l>Il mio viaggio e ritrovar <name>Montano</name>
                   </l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CHORO</speaker>
             <l>Non sò se'l molto amaro</l>
             <l>Che provato ha costui servendo amando</l>

--- a/tei/tasso-aminta.xml
+++ b/tei/tasso-aminta.xml
@@ -75,6 +75,40 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="amore">
+            <persName>Amore</persName>
+          </person>
+          <person xml:id="dafne">
+            <persName>Dafne</persName>
+          </person>
+          <person xml:id="silvia">
+            <persName>Silvia</persName>
+          </person>
+          <person xml:id="aminta">
+            <persName>Aminta</persName>
+          </person>
+          <person xml:id="tirsi">
+            <persName>Tirsi</persName>
+          </person>
+          <personGrp xml:id="coro">
+            <name>Coro De' Pastori</name>
+          </personGrp>
+          <person xml:id="satiro">
+            <persName>Satiro</persName>
+          </person>
+          <person xml:id="nirina">
+            <persName>Nirina</persName>
+          </person>
+          <person xml:id="nuntio">
+            <persName>Nuntio (Ergasto)</persName>
+          </person>
+          <person xml:id="elpino">
+            <persName>Elpino</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>2001-10-15T00:00:00.000+02:00</date><name>Camilla Ghedini</name><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -110,7 +144,7 @@
         <stage>
           <hi rend="sc">AMORE IN HABITO PASTORALE</hi>
         </stage>
-        <sp>
+        <sp who="#amore">
           <speaker>AMORE</speaker>
           <l>Chi crederia che sotto humane forme</l>
           <l>e sotto queste pastorali spoglie</l>
@@ -216,7 +250,7 @@
           <stage>
             <hi rend="sc">DAFNE, SILVIA.</hi>
           </stage>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Vorai dunque pur, <name>Silvia</name>,</l>
             <l>da i piaceri di <name>Venere</name> lontana</l>
@@ -227,7 +261,7 @@
             <l>cangia, prego, consiglio,</l>
             <l>pazzarella che sei.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Altri segua i diletti de l'amore,</l>
             <l>se pur v'è ne  l'amore alcun diletto:</l>
@@ -238,7 +272,7 @@
             <l>saette alla faretra, o fere al bosco,</l>
             <l>non temo io ch'a me manchino diporti.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Insipidi diporti veramente,</l>
             <l>et insipida vita: e, s'a te piace,</l>
@@ -265,7 +299,7 @@
             <l>pazzarella che sei:</l>
             <l>che 'l pentirsi da sezzo nulla giova.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Quand'io dirò, pentita, sospirando,</l>
             <l>queste parole ch'hor tu fingi et orni</l>
@@ -274,7 +308,7 @@
             <l>da gli agni, e 'l veltro le timide lepri,</l>
             <l>amerà l'orso il mare, e 'l delfin l'alpe.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Conosco la ritrosa fanciullezza:</l>
             <l>qual tu sei, tale io fui: così portava</l>
@@ -331,7 +365,7 @@
             <l>il vedrai fatto altrui? fatto felice</l>
             <l>ne l'altrui braccia, e te schernir ridendo?</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Faccia <name>Aminta</name> di sé e de' suo' amori</l>
             <l>quel ch'a lui piace: a me nulla ne cale;</l>
@@ -339,51 +373,51 @@
             <l>ma esser non può mio s'io lui non voglio;</l>
             <l>né, s'anco egli mio fosse, io sarei sua.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="I">Onde nasce il tuo odio?</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F">Dal suo amore.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Piacevol padre di figlio crudele.</l>
             <l>Ma quando mai da i mansueti agnelli</l>
             <l>nacquer le tigri? o i bei cigni da corbi?</l>
             <l part="I">O me inganni, o te stessa.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F">Odio il suo amore</l>
             <l>ch'odia la mia honestade, et amai lui</l>
             <l>mentre ei volse di me quel ch'io volea.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Tu volevi il tuo peggio: egli a te brama</l>
             <l part="I">quel ch'a sé brama.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F"><name>Dafne</name>, o taci, o parla</l>
             <l part="I">d'altro, se vuoi risposta.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Hor guata modi!</l>
             <l>guata che dispettosa giovinetta!</l>
             <l>Hor rispondemi almen: s'altri t'amasse,</l>
             <l>gradiresti il suo amore in questa guisa?</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>In questa guisa gradirei ciaschuno</l>
             <l>insidiator di mia virginitate,</l>
             <l>che tu domandi amante, et io nimico.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Stimi dunque nimico</l>
             <l>il monton de l'agnella?</l>
@@ -431,13 +465,13 @@
             <l>Cangia, cangia consiglio,</l>
             <l>pazzarella che sei.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Horsù, quando i sospiri</l>
             <l>udirò delle piante,</l>
             <l>io son contenta all'hor d'esser amante.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Tu prendi a gabbo i miei fidi consigli</l>
             <l>e burli mie ragioni? 0 in amore</l>
@@ -478,12 +512,12 @@
             <l>Segui, segui tuo stile,</l>
             <l>ostinata che sei.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Ma che fe' all'hor <name>Licori</name>? e che rispose</l>
             <l part="I">a queste cose?</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Tu de' fatti propri</l>
             <l>nulla ti curi, e vuoi saper gli altrui.</l>
@@ -496,11 +530,11 @@
             <l>se stimasse veraci come belli</l>
             <l>quegli occhi, e lor prestasse intiera fede.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="I">E perché lor non crede?</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Hor tu non sai Hor non ramenti</l>
             <l> ciò che <name>Tirsi</name> ne scrisse, all'hor ch'ardendo</l>
@@ -515,7 +549,7 @@
             <l>ben riconosco in voi gli inganni vostri:</l>
             <l>ma che pro', se schivarli Amor mi toglie?</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Io qui trapasso il tempo ragionando,</l>
             <l>né mi soviene ch'hoggi è il dì prescritto</l>
@@ -526,7 +560,7 @@
             <l>seguendo in caccia una dama veloce</l>
             <l part="I">ch'al fin giunsi et uccisi</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Aspetterotti,</l>
             <l>e forse anch'io mi bagnerò nel fonte.</l>
@@ -545,7 +579,7 @@
           <stage>
             <hi rend="sc">AMINTA,TIRSI</hi>
           </stage>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Ho visto al pianto mio</l>
             <l>risponder per pietate i sassi e l'onde,</l>
@@ -560,13 +594,13 @@
             <l>a chi non la negaro</l>
             <l>le cose inanimate.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Pasce l'agna l'herbette, il lupo l'agne,</l>
             <l>ma il crudo <name>Amor</name> di lagrime si pasce,</l>
             <l part="I">né se ne mostra mai satollo.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Ahi, lasso,</l>
             <l>ch'Amor satollo è del mio pianto homai,</l>
@@ -574,33 +608,33 @@
             <l>voglio ch'egli e quest'empia il sangue mio</l>
             <l part="I">bevan con gli occhi.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Ahi <name>Aminta</name>, ahi <name>Aminta</name>,</l>
             <l>che parli? o che vaneggi? Hor ti conforta,</l>
             <l>ch' un'altra troverai, se ti disprezza</l>
             <l part="I">questa crudele.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Ohimè, come poss'ìo</l>
             <l>altri trovar, se me trovar non posso?</l>
             <l>Se perduto ho me stesso, quale acquisto</l>
             <l part="I">farò mai che mi piaccia?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">O miserello,</l>
             <l>non disperar, che acquistarai costei.</l>
             <l>La lunga etate insegna a l'huom di porre</l>
             <l>freno a i leoni et a le tigri hircane.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Ma 'l misero non puote a la sua morte</l>
             <l>indugio sostener di lungo tempo.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Sarà corto l'indugio: in breve spatio</l>
             <l>s'adira e 'n breve spatio poi si placa</l>
@@ -616,7 +650,7 @@
             <l>studio de le Muse ch'a me scopra</l>
             <l part="I">ciò ch'a gli altri si cela.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Io son contento.</l>
             <l><name>Tirsi</name>, a te dir ciò che le selve e i monti</l>
@@ -639,12 +673,12 @@
             <l>dicendo: O pur qui fosse, e fosse mio!</l>
             <l part="I">Hor odi.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Segui pur ch'io t'ascolto,</l>
             <l>e forse a miglior fin che tu non pensi.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Essendo io fanciulletto, sì che a pena</l>
             <l>giunger potea con la man pargoletta</l>
@@ -687,11 +721,11 @@
             <l>Ben me n'accorsi alfine: et in qual modo,</l>
             <l part="I">hora m'ascolta, e nota.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">È da notare.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>A l'ombra d'un bel faggio <name>Silvia</name> e <name>Filli</name></l>
             <l>sedean un giorno, et io con loro insieme,</l>
@@ -794,31 +828,31 @@
             <l>cosa che turbi il bel lume sereno</l>
             <l>a gli occhi cari, e affanni quel bel petto.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>È possibil però che, s'ella un giorno</l>
             <l>udisse tai parole, non t'amasse?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>No'l so, né 'l credo; ma fugge i miei detti</l>
             <l part="I">come l'aspe l'incanto.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Horsu confida</l>
             <l>ch'a me dà il cor di far ch'ella t'ascolti.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>O nulla impetrarai, o, se tu impetri</l>
             <l>ch'io parli, io nulla impetrarò parlando.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="I">Perché disperi sì?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Giusta cagione</l>
             <l>ho al mio disperar, ch'el saggio <name>Mopso</name></l>
@@ -826,7 +860,7 @@
             <l><name>Mopso</name> ch'intende il parlar de gli augelli</l>
             <l>e la virtù de l'herbe e de le fonti.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Di qual <name>Mopso</name> tu dici? di quel <name>Mopso</name></l>
             <l>ch'ha ne la lingua melate parole,</l>
@@ -841,12 +875,12 @@
             <l>mi giova di sperar felice fine</l>
             <l part="I">a l'amor tuo.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Se sai cosa per prova,</l>
             <l>che conforti mia speme, non tacerla.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Dirolla volontieri. All'hor che prima</l>
             <l>mia sorte mi condusse in queste selve,</l>
@@ -937,18 +971,18 @@
             <l>e déi bene sperar, sol perch'ei vuole</l>
             <l part="I">che nulla speri.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Piacemi d'udire</l>
             <l>quanto mi narri. A te dunque rimetto</l>
             <l part="I">la cura di mia vita.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Io n'havrò cura.</l>
             <l>Tu lasciati trovar qui fra mezz'hora</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>O bella età de l'oro,</l>
             <l>non già perché di latte</l>
@@ -1030,7 +1064,7 @@
             <hi rend="sc">Scena prima</hi>
           </head>
           <stage>SATIRO Solo.</stage>
-          <sp>
+          <sp who="#satiro">
             <speaker>SATIRO</speaker>
             <l>Picciola è l'ape, e fa co'l picciol morso</l>
             <l>pur gravi e pur moleste le ferite;</l>
@@ -1138,7 +1172,7 @@
           <stage>
             <hi rend="sc">DAFNE, TIRSI</hi>
           </stage>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l><name>Tirsi</name>, com'io t'ho detto, io m'era accorta</l>
             <l>ch'<name>Aminta</name> amava <name>Silvia</name>: e <name>Dio</name> sa quanti</l>
@@ -1153,7 +1187,7 @@
             <l>ma ridendo e piacendo uccida altrui,</l>
             <l>e l'ucida e non sappia di ferire.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Ma qual è cosi semplice fanciulla</l>
             <l>ch'uscita da le fascie non apprenda</l>
@@ -1162,12 +1196,12 @@
             <l>qual arme fera, e qual dia morte, e quale</l>
             <l part="I">sani e ritorni in vita?</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Chi è 'l maestro</l>
             <l part="I">di cotant'arte?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Tu fingi, e mi tenti:</l>
             <l>quel ch'insegna a gli augelli il canto e 'l volo,</l>
@@ -1175,19 +1209,19 @@
             <l>al toro usar il corno, et al pavone</l>
             <l>spiegar la pompa de l'occhiute piume.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="I">Com'ha nome 'l gran mastro?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F"><name>Dafne</name> ha nome.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="I">Lingua bugiarda!</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">E perché? tu non sei</l>
             <l>atta a tener <num value="1000">mille</num> fanciulle a scuola?</l>
@@ -1195,7 +1229,7 @@
             <l>di maestro: maestro é la natura,</l>
             <l>ma la madre e la balia anco v'han parte.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Insomma, tu sei goffo insieme e tristo.</l>
             <l>Hora, per dirti il ver, non mi risolvo</l>
@@ -1235,12 +1269,12 @@
             <l>perché bella si vide ancor che incolta.</l>
             <l part="I">Io me n' avidi, e tacqui.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Tu mi narri</l>
             <l>quel ch'io credeva a punto. Hor non m'apposi?</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Ben t'apponesti; ma pur odo dire</l>
             <l>che non erano pria le pastorelle</l>
@@ -1248,7 +1282,7 @@
             <l>fui in mia fanciullezza. Il mondo invecchia,</l>
             <l part="I">e invecchiato intristisce.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Forse all'hora</l>
             <l>non usavan sì spesso i cittadini</l>
@@ -1260,15 +1294,15 @@
             <l><name>Silvia</name> contenta sia che le ragioni</l>
             <l><name>Aminta</name>, o solo o almeno in tua presenza?</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Non so. <name>Silvia</name> è ritrosa fuor di modo.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>E costui, rispettoso fuor di modo.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>È spacciato un amante rispettoso:</l>
             <l>conseglial pur che faccia altro mestiero,</l>
@@ -1285,7 +1319,7 @@
             <l>non porlo in rime. Tu sai ch'io saprei</l>
             <l>renderti poi per versi altro che versi.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Non hai cagion di sospettar ch'io dica</l>
             <l>cosa giamai che sia contra tuo grado.</l>
@@ -1294,7 +1328,7 @@
             <l>che tu m'aiti ad aitare <name>Aminta</name>,</l>
             <l part="I">miserel, che si muore.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Oh che gentile</l>
             <l>scongiuro ha ritrovato questo sciocco</l>
@@ -1302,13 +1336,13 @@
             <l>il ben passato e la presente noia!</l>
             <l part="I">Ma che voi tu ch'io faccia?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">A te non manca</l>
             <l>né saper, né consiglio. Basta sol che</l>
             <l part="I">ti disponga a volere.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Hor su, dirotti:</l>
             <l>debbiamo in breve andare <name>Silvia</name> et io</l>
@@ -1318,30 +1352,30 @@
             <l>le ninfe cacciatrici. Ivi so certo</l>
             <l>che tufferà le belle membra ignude.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="I">Ma che però?</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Ma che però? Da poco</l>
             <l>intenditor! s'hai senno, tanto basti.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Intendo; ma non so s'egli avrà tanto</l>
             <l part="I">d'ardir.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">S'ei non l'avrà, stiasi, et aspetti</l>
             <l part="I">ch'altri lui cerchi.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Egli è ben tal che 'l merta.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Ma non vogliamo noi parlar alquanto</l>
             <l>di te medesmo? Hor su, <name>Tirsi</name>, non vuoi</l>
@@ -1351,37 +1385,37 @@
             <l>vuoi viver neghittoso senza gioia?</l>
             <l>che solo amando huom sa che sia diletto.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>I diletti di <name>Venere</name> non lassa</l>
             <l>l'huom che schiva l'amore, ma coglie e gusta</l>
             <l>le dolcezze d'amor senza l'amaro.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Insipido è quel dolce che condito</l>
             <l>non è d'alquanto amaro, e tosto satia.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>È meglio satiarsi, ch'esser sempre</l>
             <l>famelico nel cibo e doppo 'l cibo.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Ma non, se 'l cibo si possiede e piace,</l>
             <l>e gustato a gustar sempre rinvoglia.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Ma chi possiede sì quel che gli piace</l>
             <l>che l'habbia sempre presto a la sua fame?</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Ma chi ritrova il ben, s'egli no'l cerca?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Periglioso è cercar quel che trovato</l>
             <l>trastulla sì, ma più tormenta assai</l>
@@ -1391,49 +1425,49 @@
             <l>A bastanza ho già pianto e sospirato.</l>
             <l>Faccia altri hor la sua parte.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Ma non hai già goduto a bastanza.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Nè desio goder, se così caro egli si compra.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Sarà forza l'amar, se non fia voglia.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Ma non si può sforzar chi sta lontano.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="I">Ma chi lunge è d'Amor?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Chi teme e fugge.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>E che giova fuggir da lui, c'ha l'ali?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Amor nascente ha corte l'ali: a pena</l>
             <l>può su tenerle, e non le spiega a volo.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Pur non s'accorge l'huom quand'egli nasce:</l>
             <l>e, quando huom se n'accorge, è grande, e vola.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Non, s'altra volta nascer no 'l ha visto.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Vedrem, <name>Tírsi</name>, s'avrai la fuga e gli occhi</l>
             <l>come tu dici. Io ti protesto, poi</l>
@@ -1442,32 +1476,32 @@
             <l>non moverei, per aitarti, un passo,</l>
             <l>un dito, un detto, una palpebra sola.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Crudel, ti darà il cuor vedermi morto?</l>
             <l>Se vuoi pur ch'ami, ama tu me: facciamo</l>
             <l part="I">l'amor d'accordo.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Tu mi scherni, e forse</l>
             <l>non merti amante così fatta: ahi quanti</l>
             <l>n'inganna un viso colorito e liscio!</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Non burlo io, no; ma tu con tal pretesto</l>
             <l>non accetti il mio amor, pur come è uso</l>
             <l>di tutte quante; ma, se non mi vuoi,</l>
             <l part="I">viverò senza amor.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Contento vivi</l>
             <l>più che mai fossi, o <name>Tirsi</name>, e 'n otio vivi:</l>
             <l>e ne l'otio l'amor sempre germoglia.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>O <name>Dafne</name>, a me questi otii ha fatto <name>Dio</name>:</l>
             <l>colui che <name>Dio</name> qui può stimarsi; a cui</l>
@@ -1500,12 +1534,12 @@
             <l>e che, mutando i fiumi letto e corso,</l>
             <l>il <name>Perso</name> bea la <name>Sonna</name>, il <name>Gallo</name> il <name>Tigre</name>.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>O, tu vai alto: horsù, discendi un poco</l>
             <l part="I">al proposito nostro.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Il punto è questo:</l>
             <l>che tu in andando al fonte con colei,</l>
@@ -1514,12 +1548,12 @@
             <l>Né la mia forse men difficil cura</l>
             <l part="I">sarà di questa tua. Hor vanne.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Io vado,</l>
             <l>ma al proposito nostro altro intendeva.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Se ben raviso di lontan la faccia,</l>
             <l><name>Aminta</name> è quel che di là spunta. È desso.</l>
@@ -1532,7 +1566,7 @@
           <stage>
             <hi rend="sc">AMINTA,TIRSI</hi>
           </stage>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Vorò veder ciò che <name>Tirsi</name> avrà fatto:</l>
             <l>e, s'havrà fatto nulla,</l>
@@ -1546,53 +1580,53 @@
             <l>la piaga del mio petto,</l>
             <l>colpo, de la mia mano.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Nove, <name>Aminta</name>, t'annuntio di conforto:</l>
             <l>lascia homai questo tanto lamentarti.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Ohimè, che di'? che porti?</l>
             <l>0 la vita o la morte?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Porto salute e vita, s'ardirai</l>
             <l>di farti loro incontra: ma fa luogo</l>
             <l>d'esser un huomo, <name>Aminta</name>, e un huomo ardito.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Qual ardir mi bisogna, e 'ncontra a cui?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Se la tua donna fosse in mezzo un bosco</l>
             <l>che, cinto intorno d'altissime rupi,</l>
             <l>desse albergo alle tigri et a' leoni,</l>
             <l part="I">v'andresti tu?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">V'andrei sicuro e baldo</l>
             <l>più che di festa villanella al ballo.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>E s'ella fosse tra ladroni et armi,</l>
             <l part="I">v'andresti tu?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">V'andrei più lieto e pronto</l>
             <l>che l'assetato cervo a la fontana.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Bisogna a maggior uopo ardir più grande.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Andrò per mezzo i rapidi torrenti</l>
             <l>quando la neve si discioglie e gonfi</l>
@@ -1601,46 +1635,46 @@
             <l>s'esser può Inferno ov'è cosa sì bella.</l>
             <l part="I">Horsù, scoprimi il tutto.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="M">Odi.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Di' tosto.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l><name>Silvia</name> attende a una fonte, ignuda e sola.</l>
             <l part="I">Ardirai tu d'andarvi?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">O, che mi dici?</l>
             <l><name>Silvia</name> m'attende ignuda e sola?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="I">Sola,</l>
             <l part="F">se non quanto v'è <name>Dafne</name>, ch'è per noi.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="I">Ignuda ella m'aspetta?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Ignuda, ma...</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Ohimè, che ma? Tu taci; tu m'uccidi.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Ma non sa già che tu v'habbi d'andare.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Dura conclusion, che tutte attosca</l>
             <l>le dolcezze passate. Hor, con qual arte,</l>
@@ -1649,20 +1683,20 @@
             <l>che infelice io sia,</l>
             <l>ch'accrescer vieni la miseria mia?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>S'a mio senno farai, sarai felice.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="I">E che consigli'</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Che tu prenda quello</l>
             <l>che la fortuna amica t'appresenta.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Tolga Dio ch'io mai faccia</l>
             <l>cosa che le dispiaccia;</l>
@@ -1672,43 +1706,43 @@
             <l>Non sarà dunque ver che in quanto io posso</l>
             <l part="I">non cerchi compiacerle.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Hor mi rispondi:</l>
             <l>se fosse in tuo poter di non amarla,</l>
             <l>lasciaresti d'amarla, per piacerle?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Né questo mi consente Amor ch'io dica,</l>
             <l>né ch'immagini pur d'aver giá mai</l>
             <l>a lasciar il suo amor, bench'io potessi.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Dunque tu l' amaresti a suo dispetto,</l>
             <l>quando potessi far di non amarla.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>A suo dispetto no, ma l'amarei.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="I">Dunque fuor di sua voglia.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Sì per certo.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Perché dunque non osi oltra sua voglia</l>
             <l>prenderne quel che, se ben grave in prima,</l>
             <l>al fin, al fin le sarà caro e dolce</l>
             <l part="I">che t'habbia preso?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Ahi, <name>Tirsi</name>, <name>Amor</name> risponda</l>
             <l>per me; che quando in mezzo al cor mi parla,</l>
@@ -1717,26 +1751,26 @@
             <l>a me lega la lingua</l>
             <l>quel che mi lega il core.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Dunque andar non vogliamo?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Andare voglio io,</l>
             <l part="I">ma non dove tu stimi.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="M">E dove?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">A morte,</l>
             <l>s'altro in mio pro' non hai fatto che quanto</l>
             <l part="I">hora mi narri</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">E poco parti questo?</l>
             <l>Credi dunque tu, sciocco, che mai <name>Dafne</name></l>
@@ -1752,12 +1786,12 @@
             <l>né sua mercede, a te, folle, che importa</l>
             <l part="I">più l'un modo che l'altro?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">E chi m'accerta</l>
             <l part="I">che 'l suo desir sia tale?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">O mentecatto!</l>
             <l>Ecco, tu chiedi pur quella certezza</l>
@@ -1771,24 +1805,24 @@
             <l>questa perdita tua, che fia cagione</l>
             <l>di vittoria maggiore. Andianne.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="I">Aspetta.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Che Aspetta? non sai che 'l tempo fugge?</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Deh, pensiam pria se ciò dè farsi, e come.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Per strada pensarem ciò che vi resta:</l>
             <l>ma nulla fa chi troppe cose pensa.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CHORO</speaker>
             <l><name>Amor</name>, in quale scola,</l>
             <l>da qual mastro s'apprende</l>
@@ -1846,7 +1880,7 @@
           <stage>
             <hi rend="sc">TIRSI, CHORO</hi>
           </stage>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>O crudeltade estrema, o ingrato core,</l>
             <l>o donna ingrata, o <num value="3">tre</num> fiate e <num value="4">quatro</num></l>
@@ -1865,53 +1899,53 @@
             <l>Amici, havete visto <name>Aminta</name>, o inteso</l>
             <l part="I">novella di lui forse?</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="F">Tu mi pari</l>
             <l>così turbato: qual cagion t'affanna?</l>
             <l>Ond'é questo sudore, e questo ansare?</l>
             <l>Hacci nulla di mal? fa che 'l sappiamo.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Temo del mal d'<name>Aminta</name>. Havetel visto?</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Noi visto non l'habbiam da poi che teco,</l>
             <l>buona pezza, partì; ma che ne temi?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Ch'egli non s'habbia ucciso di sua mano.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Ucciso di sua mano? Hor perché questo?</l>
             <l part="I">che ne stimi cagione?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Odio et Amore.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l><num value="2">Duo</num> potenti nemici, insieme aggiunti,</l>
             <l>che far non ponno? Ma parla più chiaro.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>L'amar troppo una ninfa, e l'esser troppo</l>
             <l part="I">odiato da lei.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="F">Deh, narra il tutto</l>
             <l>questo è luogo di passo, e forse intanto</l>
             <l>alcun verà che nova di lui rechi:</l>
             <l>forse arrivar potrebbe egli medesmo.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Dirollo volontier, che non è giusto</l>
             <l>che tanta ingratitudine e sì strana</l>
@@ -1967,12 +2001,12 @@
             <l>né questa gratia che fortuna vuole</l>
             <l>conceder loro, tuo mal grado sia. -</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Parole d'ammollire un cor di sasso.</l>
             <l part="I">Ma che rispose all'hor?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Nulla rispose</l>
             <l>ma disdegnosa e vergognosa a terra</l>
@@ -1995,12 +2029,12 @@
             <l>- Pastor, non mi toccar: son di <name>Diana</name>;</l>
             <l>per me stessa saprò sciogliermi i piedi. -</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Hor tant'orgoglio regna in cor di ninfa?</l>
             <l>Ahi d'opra graziosa ingrato merto!</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Ei si trasse in disparte riverente,</l>
             <l>non alzando pur gli occhi per mirarla,</l>
@@ -2015,22 +2049,22 @@
             <l>e pur nulla cagione havea di tema,</l>
             <l>che l'era noto il rispetto d'<name>Aminta</name>.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="I">Perché dunque fuggissi?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">A la sua fuga</l>
             <l>volse l'obligo haver, non all'altrui</l>
             <l part="I">modesto amore.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="F">Et in questo anco è ingrata.</l>
             <l>Ma che fe' i1 miserello all'hor? che disse?</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Nol so, ch'io, pien di mal talento, corsi</l>
             <l>per arivarla e ritenerla, e 'n vano,</l>
@@ -2040,21 +2074,21 @@
             <l>So ch'egli era disposto di morire,</l>
             <l part="I">prima che ciò avenisse</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="F">È uso et arte</l>
             <l>di ciascun ch'ama minacciarsi morte:</l>
             <l>ma rade volte poi segue l'effetto.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l>Dio faccia che non sia fra questi rari</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="I">Non sarà, no.</l>
           </sp>
-          <sp>
+          <sp who="#tirsi">
             <speaker>TIRSI</speaker>
             <l part="F">Io voglio irmene a l'antro</l>
             <l>del saggio <name>Elpino</name>: ivi, s'è vivo, forse</l>
@@ -2073,7 +2107,7 @@
           <stage>
             <hi rend="sc">AMINTA, DAFNE, NIRINA</hi>
           </stage>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Dispietata pietade</l>
             <l>fu la tua veramente, o <name>Dafne</name>, all'hora</l>
@@ -2085,14 +2119,14 @@
             <l>ragionamenti invano? di che temi?</l>
             <l>ch'io non m'uccida? Temi del mio bene.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Non disperare, <name>Aminta</name>,</l>
             <l>che, s'io lei ben conosco,</l>
             <l>sola vergogna fu, non crudeltade,</l>
             <l>quella che mosse <name>Silvia</name> a fuggir via.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Ohimè, che mia salute</l>
             <l>sarebbe il disperare,</l>
@@ -2102,7 +2136,7 @@
             <l>sol perch'io viva: e qual' è maggior male</l>
             <l>de la vita d'un misero com'io?</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Vivi, misero, vivi</l>
             <l>ne la miseria tua: e questo stato</l>
@@ -2111,14 +2145,14 @@
             <l>se vivendo e sperando ti mantieni,</l>
             <l>quel che vedesti ne la bella ignuda.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Non pareva ad Amore, a mia fortuna</l>
             <l>ch'a pien misero fossi, e s'anco a pieno</l>
             <l>non m'era dimostrato</l>
             <l>quel che m'era negato.</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l>Dunque a me pur conviene esser sinistra</l>
             <l>cornice d'amarissima novella!</l>
@@ -2127,60 +2161,60 @@
             <l>de l'unica tua <name>Silvia</name> il duro caso;</l>
             <l>Padre vecchio, orbo padre: ahi, non più padre!</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="I">Odo una mesta voce.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Io odo il nome</l>
             <l>di <name>Silvia</name>, che gli orecchi e 'l cor mi fere;</l>
             <l part="I">ma chi è che la noma?</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Ell'è <name>Nirina</name>,</l>
             <l>ninfa gentil che tanto a <name>Cinthia</name> è cara</l>
             <l>c'ha sì begli occhi e così belle mani</l>
             <l>e modi sì leggiadri e gratiosi.</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l>E pur meglio che 'l sappia e che procuri</l>
             <l>di ritrovar le reliquie infelici,</l>
             <l>se nulla ve ne resta. Ahi <name>Silvia</name>, ahi dura</l>
             <l>tua sorte!</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="I">Ohimè,che fia? che costei dice?</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l part="F">O <name>Dafne</name>!</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Che parli fra te stessa? e perché nomi</l>
             <l part="I">tu <name>Silvia</name>, e poi sospiri?</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l part="F">Ahi, ch'a ragione</l>
             <l part="I">sospiro l'aspro caso!</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l part="F">Ahi, di qual caso</l>
             <l>può ragionar costei? Io sento, io sento</l>
             <l>che mi s'agghiaccia il cuore e mi si chiude</l>
             <l>lo spirto. È viva?</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Narra qual aspro caso è quel che dici?</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l>O <name>Dio</name>, perché son io</l>
             <l>la messaggiera? E pur convien narrarlo.</l>
@@ -2199,12 +2233,12 @@
             <l>a sommo il capo: ei si rinselva, et ella,</l>
             <l>vibrando un dardo, dentro il bosco il segue.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>O dolente principio; ohimè, qual fine</l>
             <l part="I">già mi s'annuntia?</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l part="F">Io con un altro dardo</l>
             <l>seguo lor traccia, ma lontana assai:</l>
@@ -2224,22 +2258,22 @@
             <l>indietro ritornaimi; e questo è quanto</l>
             <l>posso dirvi di <name>Silvia</name>: et ecco il velo.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Poco parti haver detto? O velo, o sangue,</l>
             <l part="I">o <name>Silvia</name>, tu sei morta!</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">O miserello,</l>
             <l>tramortito è d'affanno e forse morto.</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l>Egli rispira pure: questo fia</l>
             <l>un breve isvenimento; ecco, riviene.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Dolor, che sì mi crucci,</l>
             <l>che non m'uccidi homai? tu sei pur lento!</l>
@@ -2264,21 +2298,21 @@
             <l>ben soffrirà ch'io moia,</l>
             <l>e tu soffrir lo déi.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Aspetta a la tua morte,</l>
             <l>sin che 'l ver meglio intenda.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Ohimè, che vuoi ch'attenda?</l>
             <l>Ohimè, ch'ho troppo atteso, e troppo inteso.</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l>O foss'io stata muta!</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Ninfa, dammi, ti prego,</l>
             <l>quel velo ch'è di lei</l>
@@ -2291,13 +2325,13 @@
             <l>ch'è ben picciol martire</l>
             <l>s'ha bisogno d'aiuto al mio morire.</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l>Debb'io darlo o negarlo?</l>
             <l>La cagion perché 'l chiedi</l>
             <l>fa ch'io debba negarlo.</l>
           </sp>
-          <sp>
+          <sp who="#aminta">
             <speaker>AMINTA</speaker>
             <l>Crudel, sì picciol dono</l>
             <l>mi nieghi al punto estremo?</l>
@@ -2306,12 +2340,12 @@
             <l>a te si resti. E voi restate ancora,</l>
             <l>ch'io vo per non tornare.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l><name>Aminta</name>, aspetta, ascolta.</l>
             <l>Ohimè, con quanta furia egli si parte!</l>
           </sp>
-          <sp>
+          <sp who="#nirina">
             <speaker>NIRINA</speaker>
             <l>Egli va sì veloce,</l>
             <l>che fia vano il seguirlo; ond'è pur meglio</l>
@@ -2319,7 +2353,7 @@
             <l>ch'io taccia e nulla conti</l>
             <l>al misero <name>Montano</name>.ii</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CHORO</speaker>
             <l>Non bisogna la morte,</l>
             <l>ch'a stringer nobil core</l>
@@ -2344,7 +2378,7 @@
           <stage>
             <hi rend="sc">DAFNE, SILVIA, CHORO</hi>
           </stage>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Ne porti il vento, con la rea novella</l>
             <l>che s'era di te sparta, ogni tuo male</l>
@@ -2354,18 +2388,18 @@
             <l>m'havea <name>Nirina</name> il tuo caso dipinto.</l>
             <l>Ahi, stata fosse muta, od altri sordo!</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Certo i1 rischio fu grande, et ella havea</l>
             <l>giusta ragion di sospettarmi morta.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Ma non giusta cagion havea di dirlo.</l>
             <l>Hor narra tu qual fosse i1 rischio, e come</l>
             <l part="I">tu lo fuggisti.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F">Io, seguitando un lupo,</l>
             <l>mi rinselvai nel più profondo bosco,</l>
@@ -2406,65 +2440,65 @@
             <l>tutta turbata, e mi stupii vedendo</l>
             <l part="I">stupirti al mio apparire.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Ohimè, tu vivi,</l>
             <l part="I">altri non già.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F">Che dici? ti rincresce</l>
             <l>forse ch'io viva sia? M'odii tu tanto?</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Mi piace di tua vita, ma mi duole</l>
             <l part="I">de l'altrui morte.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F">E di qual morte intendi?</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="I">De la morte d'<name>Aminta</name>.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F">Ahi, come è morto?</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Il come non so dir, né so dir anco</l>
             <l>s'è ver l'effetto: ma per certo il credo.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Che è ciò che  mi dici? et a che rechi</l>
             <l part="I">la cagion di sua morte?</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Alla tua morte.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="I">Io non t'intendo.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">La dura novella</l>
             <l>de la tua morte, ch'egli udì e credette,</l>
             <l>havrà porto al meschino il laccio o 'l ferro</l>
             <l>od altra cosa tal che l'havrà ucciso.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Vano è il sospetto in te de la sua morte</l>
             <l>sarà, come fu van de la mia morte,</l>
             <l>ch'ogn'uno a suo poter salva la vita.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>O <name>Silvia</name>, <name>Silvia</name>, tu non sai né credi</l>
             <l>quanto il foco d'Amor possa in un petto,</l>
@@ -2491,11 +2525,11 @@
             <l>e mostrò quella strada al ferro audace,</l>
             <l>che correr poi dovea liberamente.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="I">Oh, che mi narri?</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Il vidi poscia, all'hora</l>
             <l>ch'intese l'amarissima novella</l>
@@ -2504,34 +2538,34 @@
             <l>per uccider se stesso: e s'avrà ucciso</l>
             <l part="I">veramente.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F">E ciò per fermo tieni?</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="I">Io non v'ho dubio.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F">Ohimè, tu no 'l seguisti</l>
             <l>per impedirlo? Ohimè, cerchianlo, andiamo,</l>
             <l>che, poi ch'egli moria per la mia morte,</l>
             <l>dê per la vita mia restar in vita.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Lo segui' ben, ma correa sì veloce</l>
             <l>che mi sparì tosto dinanzi, e 'ndarno</l>
             <l>poi mi girai per le sue orme. Hor dove</l>
             <l>vòi tu cercar, se non n'hai traccia alcuna?</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Egli morrà, se nol troviamo, ahi lassa:</l>
             <l>e sarà l'homicida ei di se stesso.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Crudel, forse t'incresce che ti tolga</l>
             <l>la gloria di questo atto? esser tu dunque</l>
@@ -2541,7 +2575,7 @@
             <l>che, comunque egli moia, per te more,</l>
             <l>e tu sei che l'uccidi.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Ohimè, che tu m'accori, e quel cordoglio</l>
             <l>ch'io sento del suo caso inacerbisce</l>
@@ -2551,7 +2585,7 @@
             <l>ma fu troppo severa e rigorosa:</l>
             <l part="I">hor me n'accorgo e pento.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">Oh, quel ch'i' odo!</l>
             <l>Tu sei pietosa? tu? tu senti al core</l>
@@ -2559,16 +2593,16 @@
             <l>tu piangi, tu superba? Oh meraviglia!</l>
             <l>Che pianto è questo tuo? pianto d'Amore?</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Pianto d'Amor non già, ma di Pietade.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>La Pietà messaggiera è de l'Amore,</l>
             <l part="I">come il lampo del tuono.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="F">Anzi sovente</l>
             <l>quand'egli vuol ne' petti virginelli</l>
@@ -2578,7 +2612,7 @@
             <l>e sua nuntia Pietate; e con tai larve</l>
             <l>le simplici ingannando, è dentro accolto.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Questo è pianto d'Amor: che troppo abbonda.</l>
             <l>Tu taci? ami tu, <name>Silvia</name>? ami, ma in vano.</l>
@@ -2598,19 +2632,19 @@
             <l>desti quel prezzo tu ch'ella richiese,</l>
             <l>e l'amor suo co 'l tuo morir comprasti.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Caro prezzo a chi 'l diede; a chi i1 riceve</l>
             <l part="I">prezzo inutile, e infame.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F">O potess 'io</l>
             <l>con l'amor mio comprar la vita sua;</l>
             <l>anzi pur con la mia la vita sua</l>
             <l part="I">s'egli è pur morto!</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="F">O tardi saggia, e tardi</l>
             <l>pietosa, quando ciò nulla rilieva!</l>
@@ -2623,40 +2657,40 @@
           <stage>
             <hi rend="sc">NUNTIO, CHORO, SILVIA, DAFNE</hi>
           </stage>
-          <sp>
+          <sp who="#nuntio">
             <speaker>NUNTIO</speaker>
             <l>Io ho sì pieno il petto di pietate</l>
             <l>e sì pieno d'horror, che non rimiro</l>
             <l>né odo alcuna cosa, ov'io mi volga,</l>
             <l>la qual non mi spaventi e non m'affanni.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Hor che porta costui,</l>
             <l>ch'è sì turbato in vista et in favella?</l>
           </sp>
-          <sp>
+          <sp who="#nuntio">
             <speaker>NUNTIO</speaker>
             <l>Porto l'aspra novella</l>
             <l>de la morte d'<name>Aminta</name>.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>(Ohimè, che dice?)</l>
           </sp>
-          <sp>
+          <sp who="#nuntio">
             <speaker>NUNTIO</speaker>
             <l>Il più nobil pastor di queste selve,</l>
             <l>che fu così gentil, così leggiadro,</l>
             <l>così caro a le ninfe et a le Muse,</l>
             <l>et è morto fanciullo, ahi, di che morte!</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Contane, prego, il tutto, acciò che teco</l>
             <l>pianger possiam la sua sciagura e nostra.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>(Ohimè, che non ardisco</l>
             <l>appressarmi ad udire</l>
@@ -2674,19 +2708,19 @@
             <l>come devuta cosa. Hor tu di lui</l>
             <l>non mi sia dunque scarso</l>
           </sp>
-          <sp>
+          <sp who="#nuntio">
             <speaker>NUNTIO</speaker>
             <l>Ninfa, io ti credo bene,</l>
             <l>ch'io sentii quel meschino in su la morte</l>
             <l>finir la vita sua</l>
             <l>col chiamar il tuo nome.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Hor incomincia homai</l>
             <l>questa dolente historia.</l>
           </sp>
-          <sp>
+          <sp who="#nuntio">
             <speaker>NUNTIO</speaker>
             <l>lo era a mezzo i1 colle, ov'havea teso</l>
             <l>certe mie reti, quando assai vicino</l>
@@ -2749,21 +2783,21 @@
             <l>precipitossi d'alto</l>
             <l>co 'l capo in giuso: et io restai di ghiaccio.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l part="I">Misero <name>Aminta</name>!</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F">Ohimè!</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Perché non l'impedisti?</l>
             <l>Forse ti fu ritegno a ritenerlo</l>
             <l>il fatto giuramento?</l>
           </sp>
-          <sp>
+          <sp who="#nuntio">
             <speaker>NUNTIO</speaker>
             <l>Questo no, che sprezzando i giuramenti,</l>
             <l>vani forse in tal caso,</l>
@@ -2776,23 +2810,23 @@
             <l>che s'era tutto abbandonato, in mano</l>
             <l part="I">spezzata mi rimase.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="F">E che divenne</l>
             <l part="I">de l'infelice corpo?</l>
           </sp>
-          <sp>
+          <sp who="#nuntio">
             <speaker>NUNTIO</speaker>
             <l part="F">Io no 'l so dire</l>
             <l>ch'era sì pien d'horror e di pietade,</l>
             <l>che non mi diede il cuor di rimirarvi,</l>
             <l part="I">per non vederlo in pezzi.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="F">O strano caso!</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Ohimè, ben son di sasso,</l>
             <l>poi che questa novella non m'uccide.</l>
@@ -2825,12 +2859,12 @@
             <l>sarò per opra tua</l>
             <l>sua compagna a l'Inferno.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Consolati, meschina,</l>
             <l>che questa è di fortuna e non tua colpa.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Pastor, di che piangete?</l>
             <l>Se piangete il mio affanno,</l>
@@ -2860,13 +2894,13 @@
             <l>ch'io so certo ch'ei m'ama,</l>
             <l>come mostrò morendo.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Son contenta aiutarti in questo officio:</l>
             <l>ma tu già non pensare</l>
             <l>d'haver poscia a morire.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l>Sin qui vissi a me stessa,</l>
             <l>a la mia feritade: hor, quel ch'avanza,</l>
@@ -2881,27 +2915,27 @@
             <l>ci conduce a la valle ove il dirupo</l>
             <l part="I">va a terminare?</l>
           </sp>
-          <sp>
+          <sp who="#nuntio">
             <speaker>NUNTIO</speaker>
             <l part="F">Questa vi conduce;</l>
             <l>e quinci poco spatio ella è lontana.</l>
           </sp>
-          <sp>
+          <sp who="#dafne">
             <speaker>DAFNE</speaker>
             <l>Andiam, che verò teco e guiderotti;</l>
             <l part="I">che ben ramento il luogo.</l>
           </sp>
-          <sp>
+          <sp who="#silvia">
             <speaker>SILVIA</speaker>
             <l part="F">A <name>Dio</name> pastori,</l>
             <l>piaggie a <name>Dio</name>, a <name>Dio</name> selve, fiumi a <name>Dio</name>.</l>
           </sp>
-          <sp>
+          <sp who="#nuntio">
             <speaker>NUNTIO</speaker>
             <l>Costei parla di modo, che dimostra</l>
             <l>d'esser disposta a l'ultima partita.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Ciò che morte rallenta, <name>Amor</name>, restringi,</l>
             <l>amico tu di pace, ella di guerra,</l>
@@ -2929,7 +2963,7 @@
           <stage>
             <hi rend="sc">ELPINO, CORO</hi>
           </stage>
-          <sp>
+          <sp who="#elpino">
             <speaker>ELPINO</speaker>
             <l>Veramente la legge con che <name>Amore</name></l>
             <l>il suo imperio governa eternamente</l>
@@ -2951,7 +2985,7 @@
             <l>sani le piaghe mie con pietà vera,</l>
             <l>che con finta pietade al cor mi fece.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Quel che qui viene è 'l saggio <name>Elpino</name>, e parla</l>
             <l>così d'<name>Aminta</name> com'e' vivo fosse,</l>
@@ -2968,19 +3002,19 @@
             <l>de l'infelice <name>Aminta</name>? e un simil fine</l>
             <l part="I">sortir voresti?</l>
           </sp>
-          <sp>
+          <sp who="#elpino">
             <speaker>ELPINO</speaker>
             <l part="F">Amici, state allegri,</l>
             <l>che falso è quel romor ch'a voi pervenne</l>
             <l part="I">de la sua morte.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="F">O che ci narri, o quanto</l>
             <l>ci raconsoli! È non è dunque vero</l>
             <l part="I">ch'ei si precipitasse?</l>
           </sp>
-          <sp>
+          <sp who="#elpino">
             <speaker>ELPINO</speaker>
             <l part="F">Anzi pur vero,</l>
             <l>ma fu felice il precipitio: e sotto</l>
@@ -2995,7 +3029,7 @@
             <l>volere è quel che manca, e che prolunga</l>
             <l>il concorde voler d'ambo <num value="2">due</num> loro.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Pari l'età, la gentilezza à pari,</l>
             <l>e concorde il desio: e 'l buon <name>Montano</name></l>
@@ -3006,7 +3040,7 @@
             <l>nel periglioso precipitio <name>Aminta</name></l>
             <l part="I">habbia salvato.</l>
           </sp>
-          <sp>
+          <sp who="#elpino">
             <speaker>ELPINO</speaker>
             <l part="F">Io son contento: udite,</l>
             <l>udite quel che con questi occhi ho visto.</l>
@@ -3059,12 +3093,12 @@
             <l>lasciò cadersi in sul giacente corpo:</l>
             <l>e giunse viso a viso e bocca a bocca.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Hor non ritenne dunque la vergogna</l>
             <l>lei, ch'è tanto severa e schiva tanto?</l>
           </sp>
-          <sp>
+          <sp who="#elpino">
             <speaker>ELPINO</speaker>
             <l>La vergogna ritien debil amore:</l>
             <l>ma debil freno è di potente amore.</l>
@@ -3088,12 +3122,12 @@
             <l>Chi è servo d'Amor, per sé lo stimi;</l>
             <l>ma non si può stimar, non che ridire.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l><name>Aminta</name> è sano sì ch'egli sia fuori</l>
             <l part="I">del rischio de la vita?</l>
           </sp>
-          <sp>
+          <sp who="#elpino">
             <speaker>ELPINO</speaker>
             <l part="F"><name>Aminta</name> è sano,</l>
             <l>se non ch'alquanto pur graffiato ha il viso</l>
@@ -3106,7 +3140,7 @@
             <l>Ma restate con <name>Dio</name>, ch'io vuo' seguire</l>
             <l>il mio vïaggio, e ritrovar <name>Montano</name>.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l>Non so se 'l molto amaro</l>
             <l>che provato ha costui servendo, amando,</l>

--- a/tei/tasso-galealto.xml
+++ b/tei/tasso-galealto.xml
@@ -84,6 +84,34 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="alvida">
+            <persName>Alvida</persName>
+          </person>
+          <person xml:id="nutrice">
+            <persName>Nutrice</persName>
+          </person>
+          <person xml:id="consigliere">
+            <persName>Consigliere</persName>
+          </person>
+          <person xml:id="galealto">
+            <persName>Galealto</persName>
+          </person>
+          <person xml:id="straniero">
+            <persName>Straniero</persName>
+          </person>
+          <personGrp xml:id="coro">
+            <name>Coro</name>
+          </personGrp>
+          <person xml:id="filena">
+            <persName>Filena</persName>
+          </person>
+          <person xml:id="rosmonda">
+            <persName>Rosmonda</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Pavia</name>Digitalizzazione</change>
@@ -118,7 +146,7 @@
             <l>e nulla sì riposto, o sì secreto,</l>
             <l>deve tenere in sé, ch' a me l' asconda.</l>
           </sp>
-          <sp>
+          <sp who="#alvida">
             <speaker>Alvida</speaker>
             <l>Cara Nutrice, e madre, è ben ragione</l>
             <l>ch' a te si scuopra quello, onde osa a pena</l>
@@ -215,7 +243,7 @@
             <l>(debbol dir, o tacer?) lassa, mi struggo</l>
             <l>come tenera brina in colle aprico.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l>Alvida, anima mia, sì come folle</l>
             <l>mi sembra il tuo timor, ch' altro soggetto</l>
@@ -240,7 +268,7 @@
             <l>il magnanimo re de' Goti alteri,</l>
             <l>che viene ad onorar le regie nozze.</l>
           </sp>
-          <sp>
+          <sp who="#alvida">
             <speaker>Alvida</speaker>
             <l>Sollo, e questa tardanza anco molesta</l>
             <l>m' è per la sua cagion. Non posso io dunque</l>
@@ -248,13 +276,13 @@
             <l>non vien fin dal suo regno il re de' Goti?</l>
             <l>forse perch' egli è del mio sangue amico?</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l>Amico è del tuo sposo, e dee la moglie</l>
             <l>amar e disamar non co 'l suo affetto,</l>
             <l>ma con l' affetto sol del suo consorte.</l>
           </sp>
-          <sp>
+          <sp who="#alvida">
             <speaker>Alvida</speaker>
             <l>Siasi, come a te par: a te concedo</l>
             <l>questo assai facilmente. A me fia lieve</l>
@@ -284,7 +312,7 @@
             <l>parla in voce tremante, e con sospiri</l>
             <l part="I">le parole interrompe.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l part="F">O figlia, segni</l>
             <l>narri tu di fervente intenso amore.</l>
@@ -303,7 +331,7 @@
             <l>accusar non si dee, s' or si dimostra</l>
             <l>ch' è, ne la regia sua, modesto sposo.</l>
           </sp>
-          <sp>
+          <sp who="#alvida">
             <speaker>Alvida</speaker>
             <l>Piaccia a Dio che t' apponghi. Io pur tra tanto,</l>
             <l>poi ch' altro non mi lice, almen conforto</l>
@@ -312,7 +340,7 @@
             <l>venir tra queste spaziose loggie,</l>
             <l>a goder del mattin il fresco e l' òra.</l>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>Nutrice</speaker>
             <l>Figlia e signora mia, più si conviene</l>
             <l>al decoro regale, ed a quel nome,</l>
@@ -371,7 +399,7 @@
             <l>Idra, né de le Furie empia cerasta,</l>
             <l>morse giamai, com' ella morde e rode.</l>
           </sp>
-          <sp>
+          <sp who="#consigliere">
             <speaker>Consigliere</speaker>
             <l>Signor mio, se la fè, che già più volte</l>
             <l>si sia dimostra a manifeste prove</l>
@@ -390,7 +418,7 @@
             <l>de' suoi pensier deponga in fide orecchie,</l>
             <l>molto ne sente allegerito il core.</l>
           </sp>
-          <sp>
+          <sp who="#galealto">
             <speaker>Galealto</speaker>
             <l>O mio fedel, a cui già il padre mio</l>
             <l>la fanciullezza mia diede in governo,</l>
@@ -699,7 +727,7 @@
             <l>ch' in me, giudice giusto, avrò punito</l>
             <l>io medesmo la colpa onde son reo.</l>
           </sp>
-          <sp>
+          <sp who="#consigliere">
             <speaker>Consigliere</speaker>
             <l>Signor, tanto ogni mal sempre è più grave,</l>
             <l>quanto in parte più nobile e più cara</l>
@@ -784,18 +812,18 @@
             <l>Né morte, ch' uom di propria man si dia,</l>
             <l>scema commesso error, anzi l' accresce.</l>
           </sp>
-          <sp>
+          <sp who="#galealto">
             <speaker>Galealto</speaker>
             <l>Se morte esser non può pena od emenda</l>
             <l>giusta del fallo, almen de' miei martiri</l>
             <l part="I">sarà rimedio e fine.</l>
           </sp>
-          <sp>
+          <sp who="#consigliere">
             <speaker>Consigliere</speaker>
             <l part="F">Anzi principio,</l>
             <l>e cagion fora di maggior tormento.</l>
           </sp>
-          <sp>
+          <sp who="#galealto">
             <speaker>Galealto</speaker>
             <l>Come viver debb' io? Sposo d' Alvida?</l>
             <l>O pur di lei privarmi? io ritenerla</l>
@@ -806,7 +834,7 @@
             <l>Non è, questo, non è fuggir la morte,</l>
             <l>ma sceglier di morir modo più acerbo.</l>
           </sp>
-          <sp>
+          <sp who="#consigliere">
             <speaker>Consigliere</speaker>
             <l>Non è duol così acerbo e così grave,</l>
             <l>che mitigato al fin non sia dal tempo,</l>
@@ -817,29 +845,29 @@
             <l>ma prevenirlo devi, e da te stesso</l>
             <l>prenderlo e da la tua virtude interna.</l>
           </sp>
-          <sp>
+          <sp who="#galealto">
             <speaker>Galealto</speaker>
             <l>Tarda incontra al dolor sarà l' aita</l>
             <l>se dee il tempo portarla; e debol fia</l>
             <l>se da la vinta mia virtù l' attendo.</l>
           </sp>
-          <sp>
+          <sp who="#consigliere">
             <speaker>Consigliere</speaker>
             <l>Virtù non è mai vinta e 'l tempo vola.</l>
           </sp>
-          <sp>
+          <sp who="#galealto">
             <speaker>Galealto</speaker>
             <l>Vola, quando egli è apportator de' mali,</l>
             <l>ma nel recarci i beni è lento e zoppo.</l>
           </sp>
-          <sp>
+          <sp who="#consigliere">
             <speaker>Consigliere</speaker>
             <l>Ei con giusta misura il volo move;</l>
             <l>ma nel moto inegual de' nostri affetti</l>
             <l>è quella dismisura, che rechiamo</l>
             <l>pur suso al ciel noi miseri mortali.</l>
           </sp>
-          <sp>
+          <sp who="#galealto">
             <speaker>Galealto</speaker>
             <l>Or, posto pur che il tempo e la ragione,</l>
             <l>ragion, misero me, frale ed inerme,</l>
@@ -872,7 +900,7 @@
             <l>il nodo ond' è la vita</l>
             <l>a queste membra unita.</l>
           </sp>
-          <sp>
+          <sp who="#consigliere">
             <speaker>Consigliere</speaker>
             <l>Veramente or, signor, ragion adduci</l>
             <l>per le quai non mi par che in alcun modo,</l>
@@ -892,13 +920,13 @@
             <l>senza l' amata rimaner Torindo,</l>
             <l>senza l' amata sua Torindo resti.</l>
           </sp>
-          <sp>
+          <sp who="#galealto">
             <speaker>Galealto</speaker>
             <l>Egli privo d' amata, ed io d' amico,</l>
             <l>ed insieme d' onor privo e di vita,</l>
             <l>come vivremo? ohimè, duro partito!</l>
           </sp>
-          <sp>
+          <sp who="#consigliere">
             <speaker>Consigliere</speaker>
             <l>Duro (no 'l nego), ma soffrir conviene</l>
             <l>ciò che necessità dura commanda:</l>
@@ -931,14 +959,14 @@
             <l>Così la sposa tua, così l' amico,</l>
             <l part="I">così l' onor non perderai.</l>
           </sp>
-          <sp>
+          <sp who="#galealto">
             <speaker>Galealto</speaker>
             <l part="F">L' onore</l>
             <l>séguita il bene oprar com' ombra il corpo;</l>
             <l>ed io, s' in ciò non lealmente adopro,</l>
             <l part="I">privo non rimarrò?</l>
           </sp>
-          <sp>
+          <sp who="#consigliere">
             <speaker>Consigliere</speaker>
             <l part="F">L' onor riposto</l>
             <l>è ne le opinioni e ne le lingue,</l>
@@ -952,19 +980,19 @@
             <l>può giudicar di feminil bellezza,</l>
             <l part="I">vie più d' Alvida è bella.</l>
           </sp>
-          <sp>
+          <sp who="#galealto">
             <speaker>Galealto</speaker>
             <l part="F">Amor non vuole</l>
             <l>cambio, né trova ricompensa alcuna</l>
             <l part="I">donna cara perduta.</l>
           </sp>
-          <sp>
+          <sp who="#consigliere">
             <speaker>Consigliere</speaker>
             <l part="F">Amor d' un core,</l>
             <l>per novello piacer, così si tragge</l>
             <l>come d' asse si trae chiodo con chiodo.</l>
           </sp>
-          <sp>
+          <sp who="#galealto">
             <speaker>Galealto</speaker>
             <l>Ma che? se mia sorella è così schiva</l>
             <l>degli amori non sol, ma de le nozze,</l>
@@ -972,7 +1000,7 @@
             <l>rigida ninfa, o ne' rinchiusi chiostri</l>
             <l part="I">vergine sacra?</l>
           </sp>
-          <sp>
+          <sp who="#consigliere">
             <speaker>Consigliere</speaker>
             <l part="F">È casta ella, ma saggia</l>
             <l>non men che casta; e della madre i preghi,</l>
@@ -980,7 +1008,7 @@
             <l>e i tuoi consigli, e le preghiere oneste,</l>
             <l>soppor faranle al novo giogo il collo.</l>
           </sp>
-          <sp>
+          <sp who="#galealto">
             <speaker>Galealto</speaker>
             <l>O mio fedel, nel disperato caso</l>
             <l>quel consiglio, che sol dar si poteva,</l>
@@ -995,7 +1023,7 @@
         <div type="scene">
           <head rend="sc">Scena terza</head>
           <stage rend="italic">Straniero. Coro. Galealto. Consigliero.</stage>
-          <sp>
+          <sp who="#straniero">
             <speaker>Straniero</speaker>
             <l>L' errar lontan da la sua patria, e 'l gire</l>
             <l>peregrinando per le terre esterne,</l>
@@ -1028,7 +1056,7 @@
             <l>Amici, a me, che qui straniero or giongo,</l>
             <l>chi fia di voi che l' alta regia insegni?</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>Coro</speaker>
             <l>Vedi là quel di marmo e d' or superbo</l>
             <l>edificio sublime: ivi è la stanza</l>
@@ -1036,18 +1064,18 @@
             <l>ch' or vedi in atto tacito e pensoso</l>
             <l>starsi con quel canuto e saggio vecchio.</l>
           </sp>
-          <sp>
+          <sp who="#straniero">
             <speaker>Straniero</speaker>
             <l>O magnanimo re de la Norvegia,</l>
             <l>il buon Torindo, regnator de' Goti,</l>
             <l>t' invia salute, e questa carta insieme.</l>
           </sp>
-          <sp>
+          <sp who="#galealto">
             <speaker>Galealto</speaker>
             <l>La lettra è di credenza. Amico, esponi</l>
             <l part="I">la tua ambasciata.</l>
           </sp>
-          <sp>
+          <sp who="#straniero">
             <speaker>Straniero</speaker>
             <l part="F">Il mio signor Torindo</l>
             <l>a le tue nozze viene; e ormai non solo</l>
@@ -1066,7 +1094,7 @@
             <l>di quel che già solea, quando in più verde</l>
             <l>età ne giste per lo mondo erranti.</l>
           </sp>
-          <sp>
+          <sp who="#galealto">
             <speaker>Galealto</speaker>
             <l>Frettolosa venuta! Oh come lieto</l>
             <l>del mio novello amico odo novella!</l>
@@ -1074,7 +1102,7 @@
             <l>perché il piacer immenso, onde capace</l>
             <l>non è il mio cor, convien ch' in parte esali.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>Coro</speaker>
             <l>La soverchia allegrezza e 'l duol soverchio,</l>
             <l>venti contrari a la vita serena,</l>
@@ -1087,7 +1115,7 @@
             <l>l' infinito diletto effetto adopra,</l>
             <l>qual suole in altri adoperar la doglia.</l>
           </sp>
-          <sp>
+          <sp who="#straniero">
             <speaker>Straniero</speaker>
             <l>Signor, se sì con tenero ed ardente</l>
             <l>affetto ami il mio re, giurar ben posso</l>
@@ -1095,12 +1123,12 @@
             <l>Qual è di lui più fervido ed acceso,</l>
             <l part="I">o qual più fido amico?</l>
           </sp>
-          <sp>
+          <sp who="#galealto">
             <speaker>Galealto</speaker>
             <l part="F">Ohimè, che sento!</l>
             <l>Come son dolci al cor le tue parole!</l>
           </sp>
-          <sp>
+          <sp who="#straniero">
             <speaker>Straniero</speaker>
             <l>Egli de le tue nozze è lieto in modo</l>
             <l>ch' ogni tua contentezza in lui transfusa</l>
@@ -1109,7 +1137,7 @@
             <l>come s' a lui quella beltà dovesse</l>
             <l>recar gioia e diletto, e spesso chiede...</l>
           </sp>
-          <sp>
+          <sp who="#galealto">
             <speaker>Galealto</speaker>
             <l>Di lei chiede, e di me: nulla di novo</l>
             <l>narra mi puoi, ch' il mio pensier previsto</l>
@@ -1127,7 +1155,7 @@
         </div>
         <div type="scene">
           <head rend="sc">Scena quarta</head>
-          <sp>
+          <sp who="#galealto">
             <speaker>Galealto</speaker>
             <l>Pur tacque al fin, e pur al fin dagli occhi</l>
             <l>mi si tolse costui, le cui parole</l>
@@ -1215,42 +1243,42 @@
         <div type="scene">
           <head rend="sc">Scena seconda</head>
           <stage rend="italic">Filena. Rosmonda.</stage>
-          <sp>
+          <sp who="#filena">
             <speaker>Filena</speaker>
             <l>Figlia, tu sola forse ancor non sai,</l>
             <l>ch' oggi arrivar qui deve il re de' Goti.</l>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>Rosmonda</speaker>
             <l part="I">Anzi pur sollo.</l>
           </sp>
-          <sp>
+          <sp who="#filena">
             <speaker>Filena</speaker>
             <l part="F">Ma saper no 'l vuoi.</l>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>Rosmonda</speaker>
             <l part="I">E chi ciò dice?</l>
           </sp>
-          <sp>
+          <sp who="#filena">
             <speaker>Filena</speaker>
             <l part="F">Tu medesima dici.</l>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>Rosmonda</speaker>
             <l part="I">Fatto motto non ho.</l>
           </sp>
-          <sp>
+          <sp who="#filena">
             <speaker>Filena</speaker>
             <l part="F">Nè fatto hai cosa</l>
             <l>per la qual mostri di voler saperlo.</l>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>Rosmonda</speaker>
             <l>Che debbo far? Non so ch' a me s' aspetti</l>
             <l part="I">alcuna cura.</l>
           </sp>
-          <sp>
+          <sp who="#filena">
             <speaker>Filena</speaker>
             <l part="F">Or non sai dunque, o figlia,</l>
             <l>che tu con tua cognata essere insieme</l>
@@ -1259,11 +1287,11 @@
             <l>Visiterà la sposa, e forse prima</l>
             <l>ch' il sudor e la polve abbia deposta.</l>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>Rosmonda</speaker>
             <l part="I">Così certo mi credo.</l>
           </sp>
-          <sp>
+          <sp who="#filena">
             <speaker>Filena</speaker>
             <l part="F">Or come dunque</l>
             <l>così gran rege in sì solenne giorno</l>
@@ -1276,7 +1304,7 @@
             <l>è quasi rozza e mal pulita gemma,</l>
             <l>ch' avolta in piombo vil poco riluce.</l>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>Rosmonda</speaker>
             <l>Questa nostra bellezza, onde cotanto</l>
             <l>il volgo feminil se 'n va superbo,</l>
@@ -1285,7 +1313,7 @@
             <l>il qual vergine saggia anzi dovrebbe</l>
             <l>celar, che farne ambiziosa mostra.</l>
           </sp>
-          <sp>
+          <sp who="#filena">
             <speaker>Filena</speaker>
             <l>La bellezza, figliuola, è proprio bene,</l>
             <l>e propria dote del femineo stuolo,</l>
@@ -1307,7 +1335,7 @@
             <l>folle stimar devi colei non meno,</l>
             <l>la qual rifiuti il titolo di bella.</l>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>Rosmonda</speaker>
             <l>Io più tosto credea che doti nostre</l>
             <l>fossero la modestia e la vergogna,</l>
@@ -1318,11 +1346,11 @@
             <l>come tu dici, ella è sol cara in quanto</l>
             <l>di queste altre virtù donnesche è fregio.</l>
           </sp>
-          <sp>
+          <sp who="#filena">
             <speaker>Filena</speaker>
             <l>Se fregio è, dunque, esser non dee negletto.</l>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>Rosmonda</speaker>
             <l>Se d' altri è fregio, adorna è per se stessa;</l>
             <l>e benché tale a mio parer non sono,</l>
@@ -1333,7 +1361,7 @@
             <l>ma per piacer a te, de le cui voglie</l>
             <l>è ragion ch' a me stessa io faccia legge.</l>
           </sp>
-          <sp>
+          <sp who="#filena">
             <speaker>Filena</speaker>
             <l>Saviamente ragioni; ed a me giova</l>
             <l>sperar, che tale al peregrino eroe</l>
@@ -1342,11 +1370,11 @@
             <l>Già sì belle non son, né sì leggiadre,</l>
             <l>le figliuole de' prencipi de' Goti.</l>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>Rosmonda</speaker>
             <l>Tolga Iddio, che per me sospiri alcuno.</l>
           </sp>
-          <sp>
+          <sp who="#filena">
             <speaker>Filena</speaker>
             <l>Vaneggi? Or dunque a te saria discaro</l>
             <l>che sì forte guerrier, re sì possente</l>
@@ -1354,7 +1382,7 @@
             <l>in guisa tal che farti egli bramasse</l>
             <l>de' bellicosi suoi Goti regina?</l>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>Rosmonda</speaker>
             <l>Madre, io no 'l negarò: ne l' alta mente</l>
             <l>questo pensiero è in me riposto e fitto</l>
@@ -1363,7 +1391,7 @@
             <l>de la virginitade il caro pregio</l>
             <l>stimo più ch' acquistar scettri e corone.</l>
           </sp>
-          <sp>
+          <sp who="#filena">
             <speaker>Filena</speaker>
             <l>Ei si par ben che, giovinetta ancora,</l>
             <l>quanto sia grave e faticoso il pondo</l>
@@ -1434,7 +1462,7 @@
             <l>Tu s' avvien ch' egli a te l' animo pieghi,</l>
             <l>schiva non ti mostrar di tale amante.</l>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>Rosmonda</speaker>
             <l>Se ben di noi, che giovinette siamo,</l>
             <l>quella è più saggia che saper men crede,</l>
@@ -1506,7 +1534,7 @@
             <l>libera cerva in solitaria chiostra,</l>
             <l>non bue disgiunto in mal arato campo.</l>
           </sp>
-          <sp>
+          <sp who="#filena">
             <speaker>Filena</speaker>
             <l>Non è stato mortal così tranquillo,</l>
             <l>qual ei si sia, del quale accorta lingua</l>
@@ -1531,14 +1559,14 @@
             <l>ne l' imagine mia, ne' miei nipoti,</l>
             <l>nati da l' uno e l' altro mio figliuolo?</l>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>Rosmonda</speaker>
             <l>Già non resti per me, che de' nipoti</l>
             <l>tu felice non sia, ch' egli è ben dritto</l>
             <l>ch' a la sua genitrice ed al germano</l>
             <l>obedisca la figlia e la sorella.</l>
           </sp>
-          <sp>
+          <sp who="#filena">
             <speaker>Filena</speaker>
             <l>Ben è degna di te questa risposta.</l>
           </sp>

--- a/tei/tasso-intrichi-d-amore.xml
+++ b/tei/tasso-intrichi-d-amore.xml
@@ -78,6 +78,55 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="leandro">
+            <persName>Leandro</persName>
+          </person>
+          <person xml:id="cornelia">
+            <persName>Cornelia</persName>
+          </person>
+          <person xml:id="ersilia">
+            <persName>Ersilia</persName>
+          </person>
+          <person xml:id="camillo">
+            <persName>Camillo</persName>
+          </person>
+          <person xml:id="lavinia">
+            <persName>Lavinia</persName>
+          </person>
+          <person xml:id="flaminio">
+            <persName>Flaminio</persName>
+          </person>
+          <person xml:id="pasquina">
+            <persName>Pasquina</persName>
+          </person>
+          <person xml:id="magagna">
+            <persName>Magagna</persName>
+          </person>
+          <person xml:id="franceschetto">
+            <persName>Franceschetto</persName>
+          </person>
+          <person xml:id="gialaise">
+            <persName>Gialaise</persName>
+          </person>
+          <person xml:id="alberto">
+            <persName>Alberto</persName>
+          </person>
+          <person xml:id="manilio">
+            <persName>Manilio</persName>
+          </person>
+          <person xml:id="bianchetta">
+            <persName>Bianchetta</persName>
+          </person>
+          <person xml:id="alessandro">
+            <persName>Alessandro</persName>
+          </person>
+          <person xml:id="leonora">
+            <persName>Leonora</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LEXIS</name>Digitalizzazione - OCR</change>
@@ -113,1285 +162,1285 @@
         <head>Atto I</head>
         <div type="scene">
           <head>Scena 1</head>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Oh che dolore, oh che pietà che m'han dato e danno tuttavia queste povere donne, le quali, intesa la repentina morte del Signor Alessandro da me, oltre l'aversi vestite tutte di negro e annegrito ancora con i panni le mura della casa, han prima con basse e poi con alte voci così dirottamente pianto, che sarebbe ben di pietra chi non piangesse, come ho pianto anch'io, con tutto che sappia questa morte non esser vera, ma supposita, e finta da esso Alessandro per alcuni suoi capricci. Io son stato l'imbasciatore di sì trista novella: se ben l'imbasciatore non deve portar pena, non però mi pare che alcuni mi mirano con occhi storti, e alcuni mostrano di non poter comportare che io dimori più in quella casa. Onde son risoluto di uscir fuori, così per tema di qualche disordine, come per trovare il detto Signor Alessandro mio padrone, e persuaderli che lasci questi vestiti d'astrologo con li quali intende chiarirsi se Cornelia e Camillo sono fedeli: poi che cognosco in una affetto smisurato di moglie, e nell'altro sincerità grande di servo.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>O marito!</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>O padre!</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>O padron mio!</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Ma senti che pur piangono.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Olà, quel giovane!</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Chi mi chiama?</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Che gridi e che pianti son quelli che si fanno in casa della Signora Cornelia?</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ditemi, di grazia, perchè si piange in casa del Signor Alessandro?</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Olà, ferma, che la padrona desidera sapere che romore è in casa della nostra vicina.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Che cosa è questa? Come posso in un tratto rispondere a tanti, e a tempo? Ho da far altro, nè so quel che cercate; se volete, lo potrete saper da esse, chè io vado per li fatti miei e non curo saper gli altrui.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Oh, come è fantastico! Andrò a dire alla padrona che ho veduto un uomo a guisa di lampo, che parve e disparve in un tratto.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Mi piace che l'uno e l'altro si è partito, dandomi loco di vedere e contemplar colei per cui nascondo me stesso a me stesso.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Ma ecco Cosmo, il moro di colui che è veramente più che barbaro, crudele.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ma ecco che in sua presenzia perdo quelle parole che in assenzia dico mille volte l'ora.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Cosmo, che fai qui? Che cerchi? E dove è il tuo e mio Signore?</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Cerco chi trovo e non trovo chi mi cerca, perchè, conforme a quel che voglio, sotto altre forme cerco chi trovo sempre contraria al mio volere. Ma tu che sei qui ora, perchè di novo cerchi quel che non volesti mai; nè mai, cercando altrove, trovasti meglio, ch'al tuo voler corrispondesse?</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Tu non rispondi a proposito, se pur non vorrai dire che fanno molto a proposito mio le tue prime parole, perchè cerco colui che trovo sempre contrario al voler mio: e se ben lo cerco di novo, non è come tu t'imagini, che non lo volesse mai, sapendo che non desidero altro che l'amato, ma non amante tuo padrone... Che segni sono quelli che fai col capo e con le mani?</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ahimè!</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Tu sospiri, e perchè? Ti dispiace forse che 'l crudele mi è crudele? Leva su gli occhi, parla! Tu non mi rispondi? E hai ragione, non meritando risposta l'ingratitudine del Signor Giovan Luigi.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ahi, sorte crudele!</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Sorte veramente crudele, poichè mi sforza ad amare un uomo assai più crudo di cocodrillo, che uccide e piange, ma egli uccide e ride.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ahi, Flavio.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>E a Flavio, che m'ha amata tanto, vuol che io riversi questo rio costume, che uccidendo quel misero mi rido del suo morire. Tu parli, piangi e ti parti? Non ti partire, aspetta, fermati un altro poco. Si è pur partito, mosso a pietà del mio tormento. Ahi! che dissi ben io che l'amato mio bene è più che barbaro crudele, poichè un barbaro, com'è Cosmo, si move a pietà di me, ed egli più crudo che mai s'incrudelisce sempre; onde io, pietosa di me stessa, vengo meno per pietà.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 2</head>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Dunque Alessandro è morto? Dunque Alessandro non vive? Come non muori, Cornelia, se non vive più colui ch'era la vita tua? Ohimè, che io scoppio di doglia: non mi trattenete, di grazia, che io voglio uscir fuora scorrendo per tutto, acciò le strade sappiano ancora che io sono la misera, che io sono ll'infelice.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Infelice è veramente colui che non può soffrire le sue infelicitadi, poichè le disgrazie non uccidono gli uomini, ma il non aver pazienzia in quelle. Datevi dunque pace, fermatevi pure: dove volete andare?</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Dove mi mena il duolo, a piangere e sospirar sempre, perchè le disgrazie che toccano il cuore malamente si ponno soffrire. Ahimè, ahimè!</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Se le lagrime, Signora mia, fossero potenti a risorger morti, non farei altro che piangere, per ritornar in vita colui da chi confesso questa vita e quanto tengo; ma se nulla rilevano, non piangete, di grazia. Consolatevi ormai.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Come posso consolarmi, se io sconsolata e vedova sono tre volte, e sconsolata e vedova? E in questa terza mi si conviene quel verso: «Tre volte cadde, ed alla terza giace». Poi che oggi giacciono a terra tutte le mie speranze, tutte le mie consolazioni. O marito caro, o vedova infelice! Dolente ancora che non vi viddi morto, Alessandro mio dolcissimo.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Anzi, essendo più acerbo il vedere che l'udire le cose che ci apportano noia, è stato manco il male a non vederlo morto, perchè il dolore più intensamente vi avrebbe trafitto l'animo con pericolo della vita.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Morte non fu giamai così beata, come sarebbe stata la mia se io fossi morta appresso colui senza del quale morrò mille volte il giorno.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Poi che le mie persuasioni non danno rimedio al male che è veramente commune fra di noi, vogliate, come donna prudente e savia, rimettere il tutto in man di Dio, il quale sa meglio compartire le sue grazie che noi altri non sappiamo eleggere; contentatevi della volontà sua, e credete che quanto fa è tutto per nostro meglio.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>È vero; ma chi è di carne non può far che non senta il dolore della carne propria. Dico propria, perchè il marito e la moglie sono doi in una carne.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Sta bene, ma consolatevi, poi che vi ha lasciato figliuoli che rappresentano il padre; vi ha lasciato robba, con che possiate soccorrere alle vostre necessità. Sete voi tale che con la prudenzia vostra tutte le cose passaranno bene; e ultimamente avete me, che se bene vi son figliastro, vi ho riputata, come riputarò sempre, da propria madre. E volendo accettarmi, mi vi offero ancora per amorevole e affezionatissimo servitore.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Vi ringrazio di questo, figlio mio: che figlio chiamar vi posso, per l'amor grande che io vi porto e che voi mi portate. Ma circa l'altre cose che avete detto, a comparazion del marito, son tutte nulle. Ahi, che questa è perdita pur grande!</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>È grande veramente. Ma se altro non si può, bisogna aver pazienzia e veder di rimediare in qualche modo a cotesta gran perdita che dite.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Il rimedio sarà che io muora, che morte sola darà rimedio a tanti affanni. Levatevi di qua, lasciatemi pur gire.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>È possibile, Signora, che in tutte le vostre azioni vi sete dimostrata prudente e in questo caso (perdonatemi se vel dico) fate cosa da pazza? Si perdono pure al mondo i padri, le madri e i fratelli, e non se ne fa tanto strepito quanto ne fate voi.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Tutte coteste perdite son nulle: perchè se la donna perde il padre, la madre e i fratelli, è una perdita sola; perdendo il marito, s'accoppiano tutte le perdite insieme. Perchè quando il marito è buono, come era Alessandro mio, ti fa l'offizio di padre, madre e fratelli; anzi più di quel che potriano fare il padre, la madre e i fratelli.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Questo lo so molto bene; e però, Signora mia, per rimediare a tanta perdita io direi (con licenza vostra) che vi casaste di novo; perchè avendo la facultà grande e i figli piccoli, sarà bene la casa non vadi a ruina.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Ahimè! che dite? E dove trovarò mai un altro Alessandro? E se pur lo trovasse non vorrei far torto a quella benedetta anima, nè dar materia alle genti di mormorare così presto contra di me.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>E che importa? Quell'anima vi scusarà, chè voi lo fate per necessità e non per volontà. Alle genti diremo alla spagnuola: <foreign xml:lang="spa">vaya calientes, y royase la gente</foreign>; che in lingua nostra vuole inferire: venga la cosa buona e rida ogni persona.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Dite il vero. Ma perchè nei matrimonii non si trovano così facilmente i partiti che siano a gusto nostro, bisogna maturamente considerare, con occhio aperto vedere, intender molto bene, e poi concludere; perchè sono cose che si fanno una volta sola, e dopo fatte non giova il pentire.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Nol nego. Nientedimeno, dandosi tempo al tempo, passarà il tempo.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Quando per sorte mi venisse alle mani un uomo di quell'essere e di quelle rare qualità che sete voi, non vi metterei troppo tempo in mezzo.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Gentilissima Signora mia, sono pur rari i favori che Vostra Signoria mi fa! Se in me è nulla di buono, nasce dalla bontà dell'animo suo.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Non entriamo in queste retoriche, Camillo. Basta che io vi amo più che da figlio, e vi amarò sempre, particolarmente perchè al spesso mi solete consolare, come al presente mi avete consolata; che tirandomi da parola in parola, sarete causa di farmi prendere qualche risoluzione.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Risolvetevi, Signora, che io già mi risolvo trovarvi un partito tale che sia di commune sodisfazione. Ma perchè bisogna Magagna, degnisi Vostra Signoria di farsi sopra, ordinando che venghi, perchè quando si ha tempo non si deve aspettar tempo.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Io vado; e ricordatevi che io mi ricordarò di far sempre quanto voi volete.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 3</head>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Non è dubio nessuno che rado si recupera l'occasione che si lascia perdere. Io vedo chiaramente che la Signora Cornelia ha chiuso nel suo petto l'istesso fuoco che io tengo serrato nel mio; ma le nostre fiamme non possono esalar fuori, perchè ella teme che non li sia da vero figliastro, e così combatte con l'impossibile di potermi avere per marito. E dall'altro canto, conoscendo l'indegnità mia, non oso di scoprirmeli, poichè se ben mi dovesse giovare di scoprirmi non esser figlio del Signor Alessandro buona memoria, nondimeno mi nuocerà, publicando che io fui schiavo già ricattato dal fratello molti anni sono e da lui per sua gentilezza chiamato figlio proprio. Ma sciocco che io sono a lasciarmi uscir di mano così buona fortuna! E non considero che quell'amore il quale ha accecato la Signora Cornelia in amarmi a tempo che si credeva essergli figliastro, quell'istesso farà che alla cieca ella consenta al suo privato appetito, senza mirare alla mia bassa condizione. E forse sono questi li primi colpi fatti da te, o Amore?... Ma disleale e ingrato Camillo, che fai? Che pensi? Non ti ricordi delli benefizii riceùti? Non ti vergogni a mancar di fede a chi con tanta fede volse eleggerti per suo figlio? Violar il suo letto! Prender per moglie la moglie! Questo è il premio che rendi? Questa è la riverenza che porti a chi ti giovò, a chi ti fu padre? Ritorna, ritorna a te, scaccia questo rio pensiero dall'animo tuo, muori più presto che far cosa così indegna di te... Ma che colpa è la mia, se Amor mi sforza, mi spinge e mi sprona? Poichè amo e sono amato: mentre amo e son amato da Cornelia, non mi è lecito; sono amato da Ersilia sua figliastra, e io non l'amo; amo Lavinia, figlia di Messer Alberto, ed ella non mi ama. Che strani lacci, che armi inusitate son queste, con le quali mi hai ferito e preso? Ecco Magagna: non posso più dire, mi fermo.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 4</head>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Ohimè! Uhimè! Ahimè!</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Tu pur piangi, Magagna! E non consideri che col tuo pianto accresci il pianto della Signora Cornelia? Parmi che quanto più ti è detto, tanto manco intendi</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Io non piango altrimenti: ma questo è un certo rimedio da far passar il pianto.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>E come?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Pigliate le prime tre lettere delli tre sospiri che ho fatto, come dire l'<emph>o</emph> da l'ohimè, l'<emph>u</emph> da l'uhimè e l'<emph>a</emph> da l'ahimè, e congiungetele insieme, che dicono OVA. Datemi una frittata, e se io piango più, ditemi un tristo. Dovete pur pensare che da questa mattina all'alba, che si seppe la nova della morte del padrone, non ho magnato; come volete dunque che vi intenda? Non sapete quel proverbio: che il vacuo ventre volentieri le parole non intende?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Hai ragione: ma non sai tu quell'altro: che è misero chi spetta aiuto dal misero? Io non posso aiutarti, perchè son più che misero.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Tal misero foss'io, che da misero diventerei messere; poi che per la morte di tuo padre sarai <foreign xml:lang="lat">dominus dominantium</foreign>. Misero son io, che da quando mia madre mi sfoderò, sempre feci i latini per i passivi, e mai per i superlativi.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Ahi, che altro tarlo mi rode, altro mal mi penetra, altro coltello mi passa il cuore!</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Diavol, fallo tu che se morisse quest'altro! Eccoti Magagna, Magnus Carlus. Ma ditemi, padrone mio, che cosa avete? Perchè mutate di colore? Voi non parlate: olà, che dite? Dove pensate?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Penso; ma voltiam di qua.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Di grazia.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>. Dove siamo?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Quest'è un altro intoppo. La cosa non è lesta, voi smaniate.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Ma che ti pare? Farem niente?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Niente.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Pensi tu che mi voglia bene?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Bene.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Che si dirà?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Niente.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Se io mi scopro, sarà bene?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Bene.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>E se non mi scopro, che sarà?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Niente.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Ma che mi potran fare?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Niente.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Che si dice?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Niente.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Voltiam di qua.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Ohimè, questo pover uomo non ha luogo permanente, e io con tante volte mi muoro della fame; e così egli non fa niente, e io non farò bene, perchè di niente si fa niente, e non fa bene chi non mangia bene; se posso scappar niente, a lasciarlo sarà bene, che per me non voglio niente, se io non trovarò bene.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 5</head>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Signora sì, stattene sicura che m'avertirò d'ogni cosa. In buona fè, che se la Signora madre mi darà sempre questi mostaccioli, io li farò servizii de l'altro mondo. Mi ha detto che io debbia spiar secretamente quel che tratta il Signor Camillo con Magagna, per riferirlo poi a lei. Mi disse che erano nella strada, e non vi sono. Ma eccoli pure: mi starò qui dietro.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Sappi, Magagna, che non è uomo, in questo mondo, tanto savio, nè tanto fedele, che non si ritiri al suo commodo ogni volta che se gli attraversa qualche proprio interesse.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>E chi no 'l sa? Perchè tutti naturalmente desideriamo che più presto n'avanzi la robba, che ne manchi.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Sappi ancora, che colui si deve chiamare amico, che confida liberamente all'amico le cose che portano pericolo di levarli la vita.</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>O Dio, non posso sentir molto bene. Magagna parla di robba, e Camillo di levarli la vita: qualche tradimento faranno alla Signora. Passarò pian piano innanzi per sentir meglio.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Eh, quietatevi! Perchè non dite?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>È perchè mi si appresenta occasione di accommodarmi per sempre: non avendo altri a chi possa confidare un secreto di tanta importanza, eccetto te, per l'animo che ho aùto sempre di farti piacere (di modo che non da servo, ma da vero amico t'ho riputato), vengo a conferir teco l'intrinseco del cuor mio.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Troncate le cerimonie, Signor Camillo, che con li servidori fideli come son io basta dir “fa”, che subito è fatto.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Or intendi. Io, riputato da tutti figlio del Signor Alessandro, non sono nè fui già mai suo figlio, ma servo, e per dir meglio, schiavo, ricattato dal Signor Stefano suo fratello: il come, il quando, il dove, il donde, e chi son io, nol so. Ma so che si ritrova scritto in un foglio di carta che egli diede serrato al Signor Alessandro a tempo che moriva, con ordine che non s'aprisse se non passava il decimo anno della sua morte: che già quest'anno era l'ultimo, se morte con la morte del Signor Alessandro non faceva mia ultima rovina, perchè se io sapesse chi sono, forse non mi sarebbe difficile il tentare quel che tento adesso.</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Oh, oh, oh, Camillo è schiavo! Tu non mi batterai più, poichè non mi sei fratello.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Schiavo? Ah, ah, Camillo è schiavo! Adesso è il tempo della sorte mia.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Talchè, come fortuna e amor vuole ritrovandomi...</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Come a dire innamorato.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Così non fosse!</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>E io similmente mi trovo innamorato.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Di chi?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>E voi di chi?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Di una che mi tiene il cuore.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>E io di una che li tengo il cuore.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Beato te, poichè tenendo il suo cuore, tieni quanto desideri.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Anzi, beato voi che tenete il vostro cuore dentro il suo, e non io che non posso tenere il cuore mio dentro al suo.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Tu burli, ma io voglio dire...</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Taci, aspetta, ferma, non passar innanzi! Già che Camillo e io siamo tutt'uno, procuriamo entrambo farci bene. A me parrebbe bene che non vi discopriste esser schiavo, ma starvi sotto la medesima credenza di esser figlio del Signor Alessandro, perchè così facilmente vi potrete pigliar Ersilia sua figliastra per moglie, e io copularmi con la padrona.</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Ersilia moglie di Camillo? Oh, buono! Ma quel copularmi io non l'intendo.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>E questo è quel che più mi tormenta: perchè se io non mi scopro, non posso ottenere quanto desidero; se io mi scopro, passarò un mare di pericoli, uno con Lavinia, e l'altro in casa. Oh, sorte crudele! Aver, amando, due ferite in un medesmo tempo, e il rimedio che giova all'una, noce all'altra. Lavinia mi rifiutarà tanto più sapendo l'indegnità mia, la qual s'io nascondo non potrò ottener Cornelia, cuore del mio cuore. Che debbo fare? Che debbo dire? Che mi consigli, Amore? Se io ho Cornelia e non Lavinia, morrò per Lavinia: se ho Lavinia e non Cornelia, morrò per Cornelia.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Che Cornelia? Che Cornelia? Che parli di Cornelia? Non mi levar, di grazia, Cornelia, che ha più di tre anni benedetti che mi cosse il cuore, di sorte che son diventato fornace ardentissima, che non faccio altro che cocere carboni, cenere e facelle.</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Oh, che bell'intrigo d'Amore: di Lavinia, di Cornelia e d'Ersilia! Io non l'intendo.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Tu burli, Magagna.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Io non burlo, per l'anima della prima figlia di mia suocera; e non accade di trattarne, perchè il pare contra il pare non ha imperio.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>E questo di più! O misero Camillo, che cosa hai fatto! Non ti venne a memoria che l'uomo non si deve fidar di villani?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>E ti dico un'altra cosa: che Cornelia mi tocca per ragione de iuris congruo.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Se valesse questa ragione, toccarebbe a me, che son stato più congruo di nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>E io vi dico di no; perchè quando il Signor Alessandro viveva, se era in casa, io le ero più di nessuno vicino: vicino a spogliarlo, vicino a vestirlo, vicino a darli da mangiare. Se usciva fuora, Magagna appresso; se faceva questione, Magagna intorno; e in tutte le azioni sue io li ero vicino: ergo Magagna Protomiseus.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Bisogna al mio dispetto darli buone parole. Basta, Magagna mio, che con la continua pratica con li studenti sapete i termini di leggi.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>E quanti asini più di me si son fatti dottori!</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Ma ecco il Napolitano. Voltiamo di qua, acciò secretamente possiamo trattare le nostre cose.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Sì, voltate e rivoltate quanto volete, che indurato è il cuore di Faraone.</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Andate pure, che io vi lascio. Vi ho intesi, sì. Vogliono uccider la Signora; Magagna pigliarà per moglie Ersilia, e Lavinia Camillo. Non mi gabbate, a fè!</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 6</head>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>La importanzia sta, Cosemo, ca li primi moti non songo in potestà nostra, nè l'ommo tene li compassi, quanno ha da dicere con arcuno, ca non eccede li tiermini. Tu bolivi che io avessi sciaccato a chillo; e non consideravi che se io avisse ac&lt;c&gt;omenzato a dareli, che l'averia sc&lt;h&gt;iattato con li sogozzoni? Ed eccome poi di zeppo e di peso là 'ncoppa a Torre di Nona. Dico 'ncoppa, pecchè 'ncoppa stanno li Cavalieri di Sieggio, come songo io.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Padron mio caro, al duello non si va con tante considerazioni, e mentre l'uomo è provocato si può liberamente risentire senza timore della corte. Se io fosse stato in voi non averei comportato per la vita che colui mi chiamasse animale, come chiamò Vostra Signoria, ma subito gli rispondeva con una mentita tosta, e averei anco messo mano alla spada.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Sì 'gnorante, e perzò dici accosì. Nui autri Napolitani, ca sapemo le regole delli duelli, non potemo, se bè bolessemo, errare. Hai da sapere che la mentita bisogna ch'aggia fondamiento.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Oh bella! Per digerir che?</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Con tutto ca non sai, hai parlato metaforicamente, co chella parola "digerire": pecchè come lo manciare si digerisce di là, così la 'ngiuria si digerisce dalla mentita. Ma io co fundamiento no' 'ntenno chella cosa, ma se bene l'appuccio o pedamento, come la bolimo chiamare.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Io non vi intendo.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Ora ca saccio ca non me 'ntienni, te diraggio. Ecco mo: tu me dirrai na cosa, chilla cosa non è vera, la mentita vale; ma dicennome che è vero, la mentita no' serve.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Dunque è vero che voi sete un animale?</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Songo troppo, ma loicamente però. Pecchè ognuno di nui è animale razionale: quanno m'avesse ditto animale irrazionale, alora l'averia mentito, e rutto li dienti de chiù.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ma non vi avendo messo nè razionale, nè irrazionale, eccetto che in còlera vi disse animale; pigliandosi poi le parole secondo la volontà del proferente, e non dell'intelligente, sèguita di ragione che voi sete un animale irrazionale.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>È possibile ca quanto chiù stai co mico, tanto manco sai? poichè non t'avertiste de chillo arteficio usato pe me, ca pe sapere in che manera isso l'avea ditto, io lo provocai, dicendoli mulo cornuto.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Sì, ma non fu a tempo; che lui s'era partito, di modo che non l'intese.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Mettimmo accussì, proprio come tu dici. Mo io te convenco co chella stessa autorità ch'hai ditta poco 'nante, zoè ca la parola se 'ntenne secondo la voluntà del proferente, e non dell'intelligente; dico allo proposito che la voluntate mia fu di dìrencelo; che non m'aggia 'ntiso isso, peio pe isso.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Mi piace che vi fate scorgere ancora in questo, come in tutte le altre cose.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Nui lassamo andare un poco li duelli, e parlamo no poco di amore. Ma scopettami prima la cauzetta: ccà, ccà, vicino allo tallone.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Non vi sta pur un pelo, che volete scopettare?</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Scopetta puro, ca una delle cose principali ped accat&lt;t&gt;arese amore è la policia.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>E a che serve la pelliccia? A scaldarvi le reni forse?</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Oh, come se' aseno! Policia non significa pelliccia, ma l'andare polito, netto, candido. E perciò disse lo Petrarca: «In campo verde un candido armellino».</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>È molto stirato cotesto verso, e parmi che non faccia a proposito nostro.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Anzi fa a propositissimo. Pecchè lo candido armellino denota l'innamorato netto e polito, lo verde significa speranza, ergo l'innamorato polito posa sopra la speranza d'amore, senza la quale policia è rotta tua speranza. Como isso puro secotò chillo autro vierso: «Rott'è l'alta colonna e 'l verde lauro»: verde, zoè speranza d'amore. Ca te pare?</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Solenne, orrendo, tremendo, stupendo.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Massime chilli poi ca se la fanno co perzone magnate e d'importanzia, come fazzo io, ca me sdegno a fare l'amore se non fosse quarche prencepessa, duchessa, marchesa, o ch'avesse almanco titolo di contessa.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>E che vuol dire che vi vedo pur smaniare per amor di Pasquina, fantesca di Messer Alberto?</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Io pretenno chella no' ped autro, ca pe variar pasto, e ped averene allo quatierno mio, ch'a perzona parzionarella ci scrisse l'autro iorno.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Lo credo, perchè queste son le sue cose ordinarie.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Ch'hai detto mo?</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Dico che mi fate veder cose straordinarie.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>E beder te ne faraggio perzì. Tu bide mo ca la Segnora Lavinia, la patrona de chilla cornutiella, se martoria pe me, e io chiù non la pozzo patire.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ahimè!</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Ca cosa hai?</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Mi dolgo, patrone, del torto che fate a quella povera Signora, che essendo così bella, virtuosa e ricca, non ve ne dovereste sdegnare a prenderla per moglie.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Ca dici? Ca dici? Lo Segnor Gialaise Formicone, ca sta d'ora a ora pe farese spedire la causa soia d'entrare en Sieggio, se bole pigliare la figlia de no lettore de Studio? Sfratta da ccà! Se no' me fosse d'affronto di affrontarete 'n presenzia mia, te daria na mazziata bona, azzò no' te scappassero chiù simile parole dalla vocca.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Io volevo dire che è peccato a non amarla, amandovi ella con tutto amore e affezione.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Bè, de chell'autra manera buoi dicere tu. A chesso te rispondo che essendo amore no desiderio di conseguire na cosa amata, io non la desiderando, issa non me pò conseguire.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Mi pare che la conseguenza sia contra di voi; perchè essendo amore un desiderio di conseguir la cosa amata, secondo dite, ella avendo questo desiderio, deve donque conseguir la cosa amata, che sete voi.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Hai rascione, a fè: aggio equivocato. Io bolevo dicere ca essendo amore una conformità di voluntade, io non volendola, issa non me pò avere.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>E questo pur v'è contro, a rispetto di Pasquina; che essendo amore una conformità di volere, ella non vi volendo, voi non la potrete avere contra il voler di lei.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Sì, ma non sai chill'autra regola, ca <foreign xml:lang="lat">ubi maior minor cessat</foreign>. Essendo l'ommo maggior della femmena, besogna ca la femmena cessi, e si sottometta all'ommo, e non volendo l'ommo, non pote la femmena sforzarlo. Donque essendo io ommo, e volendo Pasquina, bisogna ca issa se sottometta a me; e pe lo contrario poi, essendo Lavinia femmena, e io non la bolendo, non me pò sforzare. Haila 'ntesa mo la conclusione? Che le femmene a dispietto loro bisogna ca stiano sotto a nui.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Oh, che sensi diabolici!</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Tropoloici, buoi dicere tu, e no' diabolici. 'Mpara, 'mpara. Ma ecco Lavinia co chella cornutiella de Pasquina. Retiramoci ccà e spiamo ca cosa dicano.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 7</head>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>La mia trista fortuna, che da' prim'anni mi privò del padre, quell'istessa mi fa oggi il peggio che può farmi, avendomi impresso nel petto l'amore di colui che ha il cuore non sol di pietra, ma di durissimo smalto; e per saper se quell'aspido si risolve ad udir le mie parole dispregiate sempre da lui, desidero che vadi a ritrovar Bianchetta, pregandola che non manchi di venire a darmene certa risoluzione.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Chessa parla de me cierto; e se bene n'aggio pietade, no' pozzo sopplire a tante, pe vita mia.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>O sciocche donne! o donne ingrate! o crudelissime donne!</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>E perchè non fate, padrona mia, come vi disse Bianchetta l'altro giorno? Ama chi t'ama, e chi non t'ama lascia. Che ne volete fare di questo Gialaise, poi che non vi ama?</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>E lo Segnore dove l'hai lassato, male criata?</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Amate il Signor Camillo, che vi ama tanto di cuore che, alla fede mia, ne ho compassione ogni volta che mi dice: “Pasquina mia, prega per me, raccomandami alla Signora. Io muoro per lei, ed ella non si cura di me; che certo mi fa venir voglia di piangere”.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>In quanti modi me preiudica, chessa latrina!</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Che dite di latrina? Parlate onesto.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Non è chilla ca tu pensi. Dico latrina, zoè latra piccirilla. Ma sentimmo, sentimmo.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Ahimè! non posso amar altri: essendo amor per destino, e non per elezione. Mi destinò la sorte ad amar costui, e non posso, nè voglio elegger altri.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Non potete, perchè non volete. Forse che Gialaise è più bello del Signor Camillo? Val più la grazia, l'essere, anzi una parola sola di Camillo, che cento Gialaise. Che Gialaise! Solamente il nome lazzaro che tiene!</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Qui caderebbe al proposito la mentita.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Eh no, pecchè all'assente e morto non si fa ingiuria.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>E voi ci sete presente. Come dite di no?</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Ci sono, e non ci boglio essere. Che 'mporta chesto?</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Pasquina, non è bello quel che è bello, ma quel che diletta e piace. Agli occhi miei piace e diletta tanto, quel traditore, che fuor di lui ogni bello mi par brutto.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Un'altra cosa, che l'altro giorno mi disse il suo creato: mira chi ama la tua padrona! una bestia, un ignorantone, che pate di milza e ha l'asma.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Chi diavolo nce l'ha ditto? Tu si stato?</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Io! non per certo. Ah, padrone, io tal cosa? Dio me ne guardi.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>La borria accidere, chesta fauzaria.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Non è vero, ma lo dicono artificiosamente per levarmelo dall'animo; e fanno peggio, perchè quanto più si batte il sigillo, tanto più s'imprime. Credete forse che io sia così sciocca che non mi avverti d'ogni cosa? Io so che più volte avemo ragionato insieme, e mai il Signor Gialaise s'è dimostrato tale.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>E se Amore vi ha fatto stravedere?</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>La mala pasqua che ti venga, Pasquina!</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Mi disse ancora che ha aùto il mal francese, e che non è più uomo.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Circa lo mal francese, è lo vero. Ma 'n quanto all'esser ommo, songo chiù ommo ora che mai.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Dimmi, chi è questo creato che te l'ha detto?</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Il moro che si dimanda Cosmo.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Ah! traditore.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Non certissimo.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Oh! oh! questo Cosmo è sospetto, perchè altre volte mi ha riferite mille bugie; anzi dubito che egli sia ruffiano di Camillo.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Ah! vegliacco infame.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Muora disperato se è tal cosa.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Ma chi nce l'ha ditto?</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Nol so.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Come lo sa?</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Nol so.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Conósciame a me?</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Conosco.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Te boglio spanzare.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Spansame.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Non te boglio spanzare mo, ma me ne boglio 'nformare meglio.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Informase Vostra Signoria, che mi trovarà innocentissimo.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Non può stare che Cosmo m'abbia detto la bugia, perchè mi vuol bene, mi ama, mi pizzica, mi gratta la mano, mi dà mille cosette; e io voglio ancor bene a lui, sa?</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>E chisso da chiù? Confessati, e zitto.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>O Dio, che possono fare li testimonii falsi!</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Ancora non arrivi a dodeci anni, e così figliuola ti sei messa nel ballo d'Amore?</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Sì, perchè voi cantate più volte quel sonetto: «S'amor non fosse, il mondo non saria - E gli uomini sarian com'animali...». Non voglio esser animale io, padrona mia.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Ma aspetta. Come sai che Cosmo ti vuol bene?</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Lo so perchè me l'ha detto lui, e per questo io fo quanto egli mi commanda.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Che cosa ti commanda?</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Mi ha commandato che quando io veggio Gialaise, lo fugga, lo scacci e l'odii come la morte.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Ca dici mo, vegliacchissimo Cosemo?</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Costoro mi han veduto del certo, e ne vogliono far corrivi.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Appila, zitto! Sentimmo, sentimmo, sentimmo, ca poi...</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Donque lo Signor Gialaise fa l'amore con te?</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>E chi non lo sa? Oh! oh! non te l'ho detto ancora? Egli spasma e muore per me.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Sì, ah? e per ciò ne dicevi male, per levarmelo dal cuore! Tu sei da tanto? Tu ardisci opponerti all'amor mio? Tu sei causa del mio travaglio? Per te non mi ama colui, per te m'odia? Non so chi mi tiene che non ti cavi gli occhi. To', to', ribaldella; to', to', traditora.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Ohimè! che colpa è la mia? Basta, che io non li voglio bene.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Ah! Cane mastino, tradetore Cuosemo! Tu m'hai sprofonnato, tu m'hai acciso! Pe te me scaccia Pasquina, pe te mi fugge ogn'ora.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ecco come si pate a torto.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Ah! ingrato e veramente sciocco Gialaise! Ingrato, che paghi d'ingratitudine a chi ti serve, a chi t'adora. Sciocco, che disamando me, che son pure della qualità tua, ami una vil feminella!</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Ah! pazza Pasquina, ca lasci la rosa e pigli la spina: lasci me ca te boglio, ca te pozzo fare patrona, e pigli chillo ca non ti buole e non ti puole far autro ca fantesca!</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Sciocche noi, ch'avemo fiducia in serve che sempre incostanti, sempre infideli sono! Ma perchè io non mi vendico con le proprie mani? Ladra, traditora a questo modo! Ah! ti tirarò questi capelli, mi ti mangiarò il cuore!</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Ohimè, Dio! Ohimè, Dio! Voglio dire ogni cosa al padrone, e anche al padre di Flavio, che voi foste causa della sua disperazione.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Al padrone, ah? E questo di più! Lèvamiti dinanzi solo perchè m'hai nominato Flavio, il cui nome abborrisco come si abborrisce la febre. Anzi, vien qua, che dentro la camera terrena me ne saziarò a posta mia.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Che siano maledetti quanti Gialaisi si trovano!</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Ecco oscurato lo mio sole, perza è la luce: e tutto per causa tua, ruffiano di Camillo, traditore de' padroni tuoi. Spogliati ccà mo, spogliati chessi vestiti; dammi ccà chessa spata! Priesto, non tricare chiù!</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Non vi accostate, di grazia, che questa spada bisognarà pigliarla per la punta: e forse che la giusta cagione che ho di lamentarmi si sfogarà sopra di voi; e se pur ne volete, mettete mano.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>No' &lt;n&gt;ce saria l'onore mio a mettereme co no vaiassone, e massime co no desperato como sì tu. Averemo tiempo. Su, lasciami annare dallo Governatore, ca a forza o bona voglia bisognarà ca restituischi la robba allo padrone.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 8</head>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>In fine è vero quel proverbio, che un uomo riservato è di valor dotato, e un uomo mal soffrente non può esser valente. Ecco già l'esperienzia delle belle riuscite di questo mio padrone posticcio, ritratto vero della sciocchezza e vanità del mondo. Ma sciocco son io, che vado calculando li fatti altrui e non so reanumerare i miei; anzi, quanto più penso dedurre travaglio dalla somma di miei travagli, tanto più il numero si fa infinito. Io son Flavio e non Cosmo: quel Flavio abborrito dalla crudel Lavinia come si abborrisce la febre. Io son colui che avendola amata per molto tempo, in ricompenza dell'amor mio non ho ricevuto altro che ripulse, dispregi e un continuo no. In tanto che dandomi in preda alla disperazione son fugito di casa, lasciando il mio padre vecchio; e non tenendo altro figlio che me, vive discontentissimo. Diedi nova che ero andato alla guerra di Fiandra; ed è un mese che vado vestito da servo, tinto da moro per non esser conosciuto, ponendomi a' serviggi del Napolitano con proposito che, Lavinia amando quest'uomo così fieramente, potesse come a suo servo aver comodità di parlargli, e vedere se ella sentiva dolore della mia disperata partita; e se pure la sorte mi avesse conceduto di commoverla ad aver qualche pietà di me. Ma ora veggio apertamente che mi odia più che mai, e ama un suggetto così indegno di sè come è il Napolitano. E quel che è peggio, vi s'aggiunge un altro concorrente, come è Camillo, per cui procura Pasquina: ed io, misero, non ho nessuno che procuri per me, anzi tutti me sono contrarii. O sorte crudele! O stelle inimiche! O cieli, perchè non mi cadete sopra? O terra, perchè non m'inghiotti? O acqua, perchè non m'affoghi? Fuoco, perchè non m'ardi? Aere, perchè non m'ammorbi? Chè chi ha per contrarii la sorte, le stelle, i cieli, il fuoco, l'aria, l'acqua e la terra non merita di viver più. Ma perchè mi mantenete in vita? Per farmi sentir maggior pena che di morte? Io mi tolgo le vesti, getto la spada; anzi, questa prendo per passarmi il petto. Ohimè! Ecco mio padre. Ripiglio le vesti e fuggo di qua.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 9</head>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p><foreign xml:lang="lat">Quae de novo emergunt, novo indigent auxilio</foreign>. Lasciate dunque, Messer Manilio mio, il tanto condolervi della fuga, o vogliamo dire della perdita, di vostro figliuolo, e a questo nuovo accidente porgete nuovo rimedio; come saria in disporre altrimente della vita e della robba vostra. Perchè il figliuolo che è vizioso e disobidiente al padre deve esser privato dell'eredità: autore Eschino Prelio in certa orazione a Rodio; anco tutte le leggi ne parlano diffusamente.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Il mio giustissimo dolore mi ha di sorte penetrato il petto, che non posso far altro che dolermi continuamente, considerando che non avevo al mondo &lt;alcuno&gt; eccetto quest'unico figliuolo, cresciuto con tante delizie, con tanti commodi, sotto speranza che egli doveva essere il bastone della mia vecchiezza; e ora me lo vedo tolto, non so da chi, non so come; e non so dove sia capitato.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p><foreign xml:lang="lat">Felix quem faciunt aliena pericula cautum: casus dementis correctio fit sapientis</foreign>. Di modo che io mi risolvo, e così si devono risolvere tutti i padri di famiglia, a farsi cauti con l'essempio vostro, cioè di non allevare i figliuoli con tanti commodi e permetter loro tutto quello che dimandano; poichè <foreign xml:lang="lat">deteriores omnes licentia sumus</foreign>; e così queste delizie, queste licenzie sono le spinte che traboccano li figliuoli, e sono le cause potissime che danno poto amaro alli poveri padri.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Perchè di me stesso? Debbo dolermi della madre, la quale da principio non mi ha lasciato riparare al danno che io prevedeva doverne succedere. Io pur li dicevo: vedi, moglie mia, che Flavio è troppo licenzioso, mira che è discorretto; non ti opponere quando io lo castigo, lascia fare a me; sappi che il mal suo si converte in natura; considera che quando vorremo, non potremo ritrarlo. Sì, a punto nulla fa, anzi in collera mi replicava dicendo: non avemo altro che questo figliuolo, e tu pensi farlo morire sotto le stirature; lasciamolo fare, perchè quando l'arbore è buono, è meglio il frutto. A chi potrà rassomigliarsi, se non al padre? E con simili girandole a poco a poco, crescendo di male in peggio, m'ha indotto a questo pessimo termine.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p><foreign xml:lang="lat">Agentes et consentientes pari poena puniuntur</foreign>. Voi avete consentito al cavezzo di vostro figliuolo, meritate l'istessa pena che merita la madre: e certo quella che diede Solone ad un padre ch'aveva eseredato il figliuolo, secondo mi ricordo aver letto nella general istoria di Sabellico: e fu che il figlio incolpando il padre che egli era stato causa della sua vita licenziosa, perchè non osava castigarlo a tempo che era figliuolo; il padre replicando che se bene voleva castigarlo, egli non l'obediva; Solone sentenziò che il padre, perchè non l'aveva castigato, non fosse degno di sepoltura dopo sua morte; e il figlio, perchè non l'aveva obedito, fosse privato delli beni paterni: ma che il figliuolo di esso giovene succedesse poi all'eredità, perchè <foreign xml:lang="lat">delictum patris filio nocere non debet</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>E providde circa le robbe, in poter di chi dovevano restare tra quel mezzo che il vecchio fosse venuto a morte?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Signor sì, che providde; e fu che le robbe fossero depositate in mano d'un terzo degno di fede, che desse da magnare al padre sin che viveva, e facesse una sepoltura al figliuolo dopo che morisse. Che ti pare di questa sentenza? Volesse Iddio che così si osservasse oggi, perchè tanti padri castigando i figliuoli non sarebbono infelici, e tanti figliuoli obedendo a i padri riuscirebbono perfetti.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Ohimè! che queste maledette donne sono state e sono causa della nostra rovina, opponendosi sempre a quel che noi procuriamo alla salute de' figliuoli, mirando solo al presente e non al futuro, senza discrezione.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>La donna non ha nessuna discrezione. Ma noi dall'altro canto dovemo ov&lt;v&gt;iare a questa, contradicendoli espressamente: che se ben la moglie è compagna nostra, non di meno non è nostra superiore.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>È vero. Ma poi subito ti fanno il muso torto, ti voltan la schena e mai ti danno pace; e l'uomo stracco da gli altri pensieri, come non trova la moglie allegra in casa, vive in continuo inferno.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Accade questo perchè <foreign xml:lang="lat">omne nimium convertitur in vitium</foreign>, e però si deve molto bene avertire dal principio a non assuefar le moglie in farle troppo carezze e concedere a loro quanto dimandano. Perchè <foreign xml:lang="lat">mulier est mala herba, mala herba cito crescit</foreign>. Devono dunque stare accorti i mariti in tener le moglie raffrenate di sorte che per troppa briglia non iscavezzino, nè per troppo sproni sbalzino.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Che strada dunque si ha da tenere?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>La strada di mezzo, perchè <foreign xml:lang="lat">mediam viam tenuere beati</foreign>: voglio dire che alcuna volta si devono ammonire, e alcuna volta conceder loro quanto ti par convenevole.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Ma a che giova trattar questo al presente, se il fatto è fatto, e io non mi posso in conto alcuno consolare? Figlio mio, dove sei? Figlio, come hai lasciato discontento il tuo vecchio padre? Figlio, che non ti vedo più! Coltello che m'hai passato il cuore! Ferita che non sanarà mai! Ohimè! ohimè!</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Ecco il frutto che si ha da i figliuoli. Quanto sono ignoranti molti uomini, che con le continue orazioni pregano Iddio che dia loro i figliuoli, <foreign xml:lang="lat">et nesciunt quid petunt</foreign>. Dall'altro canto, Messer Manilio mio, raffrenate le lacrime e non mostrate al mondo che sete altro che quel che gli altri vi reputano: sete prudente, e li prudenti non si han da dare così in preda alla disperazione.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Come non voglio disperarmi, considerando che dovendo morire, il sudor della mia vita sarà perduto?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Anzi è guadagnato, perchè la robba lasciata ad un tristo erede è persa; poichè non ha tanto pensiero il padre in acquistar la robba, quanto ha fretta il figliuolo in consumarla.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Non posso far che non mi strazii, che non mi consumi.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Eh! non fate, di grazia... che vi rileva questo? Voi ne morrete di doglia; e se vostro figliuolo è vivo, se ne rallegrarà, poi che al figliuolo par mill'anni che il padre chiuda gli occhi, per ereditar la robba; e se egli è morto, <foreign xml:lang="lat">mors omnia solvit</foreign>. Talchè, come dissi al principio, disponete di voi e della robba vostra in altro modo, con farvi alcun bene per l'anima; che tanto ne ha il padre quanto ne fa in vita, che dopo morte il figliuolo non si ricorda più del fatto tuo.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Ognun di noi quando sta bene sa dar buon consiglio all'infermo. Se voi foste in mio luogo, diresti altrimente.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Dirrei il medesmo, certo.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Nol voglio credere. Io voglio morir così disconsolato. Io non voglio più vivere; voglio disperarme affatto. Ahimè! figliuol mio... Lasciatemi andar, di grazia.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Povero vecchio, mi fa pietà. Io voglio pur seguirlo, acciò non si disperi in tutto; che veramente il cuore addolorato più si consola con le parole d'un amico, che con tutti gli altri rimedii del mondo. E poi per la salute dell'anima sua, <foreign xml:lang="lat">inspiciendum est quod evenire potest. Instit. De rerum divi. par. Illud quaesitum</foreign>.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 10</head>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Bianchetta mia, per buono e sano che sia un giudizio, ha sempre di bisogno di ricordi; e perciò non vi maravigliate se in questo vostro giudizio, qual reputo buono, io vi ricordo spesso che stiate avertita dal canto vostro; che dal canto mio, vi assicuro che avete un discepolo molt'a proposito.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Non dubitate punto, Signor Flaminio, che chi è vecchia all'arte non si può ingannare. Dall'altro canto, mentre vi miro mi provocate al riso, così rassomigliate in tutto e per tutto al Capitan Lopes; tanto più che con quella barba posticcia rassomigliate egli stesso. E certo è stato buona ventura che vi abbia prestato li vestiti liberamente, con spada e cappa.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Un che è nato nobile, è forza che sia cortese e gentile. Il Signor Capitan Lopes è gentiluomo, e non può degenerare dalla natura de' buoni gentiluomini.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Ogni cosa va bene; e io credo certamente che la Signora crederà che siate il Capitan Lopes suo innamorato, per cui ella si muore. Ma dubito che non vi conosca al parlare; però provate un poco come riuscite alla lingua spagnola.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Lasciate il pensiero a me, che avendo praticato di continuo con Spagnoli, ne parlo eccellentemente &lt;la lingua&gt;. Pensate forse che bisognando non sapesse far una bravata alla spagnola?</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Mi piace. Orsù, Signor mio, fatevi qui dietro, che io vo' chiamarla, e con bel modo vi farò comparire: che forse oggi ottenirete il desiderio vostro.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Deh, Bianchetta, in voi sta la salute e la vita mia, e del resto &lt;mi&gt; vi farò conoscere persona gratissima.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Non vorrei faceste come suol fare la maggior parte di voi altri giovani, che sete larghi di parole fin che avete l'intento, e poi dite: a Lucca mi ti parse di vedere.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Sapete già che non son di quelli, perch'altre volte l'avete tocco con mano.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>È vero che io mi laudo di voi; ma nol dico già per disegno di pagamento. Dio nol voglia, che in questo modo sarei ruffiana! Dicolo sì bene, acciò sappiate che così si costuma oggi, e che meco non giovano quest'offerte.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Tanto è, quanto voi dite; e io vi ringrazio sommamente. Alla giornata vedrete che io corrispondo a questa vostra amorevolezza.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Non voglio niente, guarda! che se bene averei bisogno d'una gonnella di sotto, non me ne curo, non pretendo nulla da voi.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Oh! che solenne mariola! Riposatevi sopra di me, Bianchetta mia. Orsù, mi son messo in questo cantone. Chiamatela pure.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 11</head>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Toccarò la porta. Tic, toc. Ohimè! non sente nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Toccate più forte.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Vorrei parlaste spagnolo, per assuefarvi.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Deagamos ahoras las burlas. Battide mas fuerte.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Oh! così vi voglio. Tic, toc, toc. Io batto al vento... Ma eccola.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ecco pur quel splendore che alluma le tenebre, rischiara gli abissi e abbella il tutto.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Chi è quel che così forte batte? Oh, gli è Madonna Bianchetta. Che cosa cercate?</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Cerco di farvi sempre servizio, e procuro cosa che risulti in beneficio e satisfazion vostra. Ma prima ch'io parli d'altro, ditemi, che lutto è quello che tenete sopra? </p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>È morto il Signor Alessandro, mio padregno, in Genova, dove s'era conferito per ricuperare alcune ereditadi, e ieri a punto s'ebbero lettere per corriere, che è passato all'altra vita.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Iddio li dia santa requie, e a noi commoda sanità, vita lunga e denari da spendere. E perchè, Signora Ersilia mia, se ben considero, che adesso non sarebbe tempo di dirvi quanto ho procurato in servizio vostro; non però l'occasione di questa morte m'invita maggiormente a dirvelo, che il tempo è già opportuno di accettar il partito, ritrovandosi la casa vostra senza il suo capo.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Dite pure, e sia subito, perchè mi vergogno a stare in finestra, con tutto che sia luogo rimoto e non vi passino genti.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Voi sapete, Signora mia, quante volte con le braccia aperte e con le lagrime a gli occhi mi avete pregata che io disponessi il Capitan Lopes ad amarvi, e che in ogni modo l'introducessi un giorno con disegno di sposarvi insieme; e perchè sempre l'ho trovato duro, oggi per buona sorte mia l'ho mollificato di sorte che verrà a trovarvi, con ferma deliberazione di far quanto voi volete. E già che quest'altra occasione vi dà il luogo e la buona fortuna, io direi che non la lasciaste passare.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Vi ringrazio, Bianchetta mia, della buona vostra volontà; ma perchè la durezza del Capitan Lopes mi ha di sorte indurato il cuore che già mai si faria molle, ho mutato quel pensiero, impiegandolo tutto ad un altro soggetto degno di esser amato. Eh, così va il mondo! Adesso che egli vuole, io non voglio, e vada l'un per l'altro.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ohimè! che sento? È possibile che in ogni abito, in ogni occasione questa crudele mi sia crudele? </p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Dunque per un minimo sdegno volete lasciare un amore così grande?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Chi nol sa? Non avete inteso che lo sdegno è soggetto potentissimo a cacciar via l'amore?</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Non ho inteso questo; ma sì bene che lo sdegno dell'amante è una reintegrazione d'amore; e così succederà in voi, che questo vostro sdegnetto doppiarà quel vivo e sincero amore che gli avevate portato sempre.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>L'acque delle mie lagrime, causate dall'empietà sua, hanno estinto il fuoco dell'affezion mia.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Quando l'amore è vero, come è il vostro, e vi corre alle volte qualche sdegno, quel sdegno è proprio come la cenere: la qual coprendo il fuoco, par che non ci sia fuoco; ma discoprendosi, si ritrova sotto il fuoco. Così succederà in voi, figlia mia, che lo sdegno che avete conservarà e non consumarà il fuoco dell'amor vostro: e già che l'abbiamo sotto, discopriamolo.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Di grazia, non me ne ragionate più. Io me ne vado: se volete niente, son vostra.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Aspetta un poco, per farmi favore. Venite, Signor Lopes. Eccolo qua, Signora: ascoltatelo, solamente una parola.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Baso las manos di Vuestra Merced per mil vezes. Sientiendo, Sennora mia, la&lt;s&gt; iustissimas causas che tiene de non amarme, però creami per cierto che me affido de voluntade de corrispondere al eccessivos amores que Vuestra Merced me ha querido sempre: me affido so la dimostración per ver come persestia en la firmiezza de miis amores; y ya que...</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Y ya que? Non bisogna passar più innanzi, che fin oggi è stato a voi, adesso starà a me. Andate per li fatti vostri.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Escùchame, Sennora mia: dos otras palabras. Vuestra Merced non sarà llamada di todos la crudel Ersilia, que arde y quema los ombres affecionados?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Quel che si diceva di voi mentre mi foste crudele, quell'istesso mi contento si dica di me oggi.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Eh, Signora Ersilia, lasciate questa ostinazione, non perdete la sorte che vi viene in casa.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Se io non considerasse che ho bisogno di voi, per persuadere colui a chi novamente ho dato il mio cuore, vi darei una buona risposta.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Dite quel che volete, vi dirò sempre ch'avete il torto.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Il torto è stato pur suo, che non doveva dispregiare chi con pura fede lo serviva e onorava.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Es berdad, entramas de mi corazon, mas ahora, come a culpado y fallido, de rodilas supplico a Vuestra Merced que me l'haya a perdonar, y recebir a quien pentido de sus defaltes li promette una perpetua y firma serbitud.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Giongesti tardi. Andate in buon ora, lasciatemi stare.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Espetta ono poquitto, per vida soya. De manera che Vuestra Merced quiere che yo muera?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Muori.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Y los dir da veros? </p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Da vero.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Y perquè? </p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Perchè non posso più amarvi.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Y perquè non mi puode amar mas? </p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Non posso, perchè l'amore che vi portavo allora l'ho collocato in altri.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Y quièn es esto ben aventurado? </p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Oh, come sete importuni voi altri Spagnoli!</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Mi pena, que es infinita, los causa.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Aspettate, Signor Flaminio: chi sa, forse la ruota della fortuna sarà rivolta in favor vostro, e sarete forse voi.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Placesse a Dios! Digame, Sennora mia, qui es esto affecionado di Vuestra Merced? qui sa se fosse Flaminio? </p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Che Flaminio, che Flaminio! La fiamma di colui, se bene è cocente, non basterà mai a scaldarmi, non che a cuocermi.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ah, ingrata, disleale, crudele, disamorevole Ersilia! Ecco che io non sono il Capitan Lopes, ma l'infelice Flaminio che vive fra cocentissime fiamme. Che t'ho fatto io che m'odii tanto? Qual segno d'amore e di viva affezione non t'ho io mostrato sempre? Perchè godi delle mie fiamme? Perchè fuggi chi t'ama? Perchè dispregi chi t'adora? Ahimè! che non posso più dire, vinto dal profondo dolore.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Dunque non sete il Signor Lopes? Dunque sete Flaminio? Ahimè! che io fingeva di non volerli bene per confirmarlo tanto più nell'amor mio! Ma già che sono ingannata da voi, mi doglio che non sete il mio bene, e voi doppiamente odio e dispregio. Andate in malora, ch'io serro.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Che dici, Bianchetta?</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Che posso dire, se non che ragionevolmente vi possete dolere? Povero giovane! Il giusto sdegno gli ha occupato di sorte l'animo, che senza poter parlar più si è partito alla disperata. Vo' girli dietro. O donne ingrate!  che la colpa è la vostra, per non amar chi v'ama.</p>
           </sp>
@@ -1401,1156 +1450,1156 @@
         <head>Atto II</head>
         <div type="scene">
           <head>Scena 1</head>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>È vero, Leandro, che la vita inquieta non è altro che una continua morte; nondimeno, considerando che la sospizione non si toglie se non con l'esperienza di vedere il contro di quel che l'uomo sospetta, godo della mia inquietudine e delli travagli infiniti che ho patito e pato, a star tanti mesi fuori di casa, e a ritrovarmi oggi travestito e sotto abito d' astrologo, mentre considero dovermi quietar la mente dal sospetto che ho tenuto e tengo di Cornelia mia moglie e di Camillo mio servitore. Che se sarà così come congetturo dalli segni passati, farò che da lei prendino essempio tutte le moglie &lt;ad esser&gt; caste, e da lui tutti li servitori ad esser fedeli. Ella conoscerà che il marito che ha sale in zucca sa cuocere li capricci della moglie, ed egli quanto può lo sdegno d'un padrone che è stato cortese verso un servitore che se gli rende ingrato. Ma quando sarà il contrario, come par che tu mi vadi ragionando, ella averà da me la corrispondenza da perfetto marito, ed egli di padre, non che di padrone amorevole. Però dimmi un poco più per minuto che motivi fece Cornelia quando intese la nuova della mia morte; e che disse Camillo?</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Se è vero, padrone, che nel volto si legge l'animo, vi certifico che nel volto della Signora Cornelia uscì un dolore tanto eccessivo, che credo gli abbia di modo trafitto l'animo che viverà sempre sconsolata fin che non si discopra il vero. Nè più nè meno lessi nel volto di Camillo. Poichè a pena intesa da me la nuova della vostra morte che ella cominciò a gridar fortemente: o Alessandro mio!, o Alessandro mio!, si squarciò le vesti, e squarciò anco le lettere consolatorie che io li portavo da Genova; anzi come a forsennata sbatteva il capo or qua, or là; e Camillo dirottamente piangendo accusava la sua mala fortuna che già l'aveva finito di rovinare. Si vestirno subito di lutto, tutta la casa si messe in mestizia, e tutti mi han dato segni evidenti di profondissimo cordoglio.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Ogni estremo è vizioso e nessun violento è durabile. Sappi, Leandro, che con questi loro estremi e violenti sospiri tanto più mi son messo in sospetto: perchè quando si piange di cuore, non si piange di fuore, dice quel proverbio. Se Cornelia e Camillo avessero intensamente sentito questa nuova, oppressi da repentino cordoglio, non averebbono così presto potuto mandar fuori lamenti; e quella estrinseca violenza mi dimostra che all'intrinseco ha sradicato tutto il dolore: a punto come la febre effimera che di fuori venendo violenta, scaccia il fuoco cattivo di dentro e non dura troppo.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Padron mio, l'imaginazione vi raffigura tutte queste cose; poichè non mi posso imaginare che chi sente affanno di dentro debbia rider di fuori, e per il contrario debbia pianger di fuori chi sente gioia di dentro.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Sì, ma non t'avedi tu che io parlo de gli animi iniqui, falsi e perversi. Sovvienmi a questo proposito un essempio romano: che Fulvia, moglie di Marco Marcello, dimostrò tanto dolore della morte del marito, che dui senatori non la potevano ritenere; e un di loro disse: «Lasciate le mani, perchè Fulvia vuol dimostrare in un dì tutto il dolore della sua vedovanza, per non averlo a dimostrare per più tempo». E l'accertò da vero: poi che da quell'istesso tempo che s'ardevano l'ossa del marito, si accasò con un altro. A rispetto poi di Camillo, basti l'essempio di Cesare che, vedendo la testa di Pompeo, pianse per allegrezza.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Adesso conosco chiaramente che la gelosia non è altro che una rabbia causata da falso sospetto e da timor vano e da stravagante frenesia. Perdonatemi se vel dico, padrone, che da sospetto in timore, da timore in frenesia, da frenesia in gelosia, e da gelosia sete venuto in una rabbia tale che non mi parete Alessandro, ma una vipera tutta piena di veneno. Ritorniamo a casa, lasciamo queste vesti, e credete che vostra moglie è prudente, onorata e bella.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Ahimè, che prudenzia, onestà e bellezza di rado si congiungono insieme: poichè la bellezza di una donna non è mai sicura, e quel che da molti è desiderato vanamente si guarda. Risolvasi ognuno, che chi ha donna bella per moglie ha da combatter co la pazzia, perchè bellezza e pazzia sono due fide compagne che non si lasciano mai, mediante la qual pazzia consuma la vita e la facultà del marito. Perchè ogni donna bella vorrebbe esser sola che commandasse in casa; vuol vivere delicatamente, vuol passare il tempo in piacere e in delizie, pretende esser preferita a tutte, ogni giorno nove fogge di vestiti, costringe il marito a tenerlo sotto; e in somma chi si marita con donne belle s'apparecchi sopportar la mala ventura.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Come sarebbe a dir le corna.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>E peggio ancora: poichè il povero marito pensandosi riposare e star quieto, gl'innamorati vanno a torno la casa, occhiando le finestre, scalando le mura, sonando citere, vegghiando alla porta, concertando con ruffiani, discoprendo il tetto, e ultimamente gli levano la vita o fanno che per doglia si muora; e così resta povero, infamato e morto.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Donque non si deve lamentare un certo amico mio che ha moglie brutta, poi che potrà vivere senza timore e sospetto alcuno.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>E chi nol sa? Colui che ha la moglie brutta tiene sicura la fama, è servito da prencipe, è amato cordialmente, vive quieto, ha carezze dell'altro mondo, augmenta in facultà: e in somma quella bruttezza è la pece negra che lavora l'argento e la scorza aspra che conserva l'albero tenero.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Signor mio, io non posso disputar con esso voi, perchè sete savio, e io sono ignorante; ma poi che, perdonatemi, si suol dire che all'uomo savio manca il consiglio, vi ricordo che non vi lasciate vincere dalla passione di questa maledetta gelosia, ma vincendo voi stesso, consigliate voi stesso.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Se ben non son savio come ti credi, dirò pur come disse quell'uomo da bene, che molte volte errano i savii non perchè voglino errare, ma perchè li negozii sono di tal qualità che la lor sapienzia non basta a poterlo indovinare. Concludo a proposito che io non pretendo indovinare e l'intrinseco dell'animo di Cornelia, e di Camillo. Non mi curo di errare per viver cauto. Ma ecco Franceschetto mio figliuolo; intendemo quel che dice.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 2</head>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>O schiavo traditore! Vatti fida poi di schiavi, va! Se fosse vivo il Signor padre non faresti così. Non ti curare, ah! ah!</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Parla di schiavo, nomina me, piange e minaccia: che domine sarà? Costui certo parla di Camillo.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Ogn'ombra vi par Camillo, così forte l'imaginativa vi tiene astratto dall'esser vostro.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Ascolt&lt;i&gt;amolo un poco, che da' figliuoli e da' matti si discoprono i fatti, dice quel proverbio. E poi Franceschetto, sapendo quanto può saper figliuolo, tengo che si sarà avertito di qualche cosa.</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Bella, per Dio! Camillo pensa maritarsi con la Signora madre e far del padrone in casa. Ma io, ma io... lascia far a me.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Che dici, Leandro? Parti che io mi sia ingannato? Accostiamoci, che con bel modo scopriremo il tutto. A Dio, quel figliuolo.</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Ohimè! chi sei tu? Io m'appauro, mi segno la croce: tu sarai forse il padre delle streghe di Benevento?</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Non aver timore, Franceschetto, perchè costui non è quel che tu pensi, ma un certo gentiluomo del mio paese, il quale era amico del Signor Alessandro, e desidera intendere se per servigio vostro e della casa vale a qualcosa.</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Oh, oh, tu sei Leandro, ch'hai portata la nova del Signor padre. Ohimè! Signor padre, se fuste vivo! Se sapeste che tratta Camillo, che pensa la Signora madre!</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Mi provoca al pianto. Vien qua, figliuol mio, perchè piangi? Che cosa t'occorre? Che tratta Camillo? Che fa la Signora madre? Che se tu vuoi, ne scriverò al Signor zio in Genova, e si daranno i debiti rimedii.</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Come non voglio piangere, che così piccolino ho perso il padre? E chi mi vuol far bene mo? Quella poltrona di mia madre, che pensa rimaritarsi con un schiavo?</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>È vero, figlio mio, che come si perde il padre, si perde ogni bene. Ma chi è cotesto schiavo?</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Un vigliacco, chi vuol essere? Ma in questa notte pian piano gli piantarò un coltello nella panza.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Aspettate. Sarà forse Magagna?</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Che Magagna! Magagna è servidore, e non schiavo; ma è Camillo, sì, sì, ed è Magagna ancora.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Dunque Camillo è schiavo? Come lo sapete voi? Chi ve l'ha detto? In che modo tratta maritarsi con la Signora? E che pretende Magagna?</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Ho spiato quando Camillo ha detto che è schiavo e innamorato della Signora, ed essa innamorata di lui; e che gli è parso mill'anni che il Signor padre morisse per accoppiarsi insieme. Magagna dice pur egli che è innamorato della Signora, fanno questione insieme, e Magagna pretende non so che copulare. Io non l'intendo. È tardo già; vo' prima gire in piazza a comprar delle noce e poi tornare in casa. Nol dite a nessuno, sa?</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Haila intesa, Leandro? Il fatto è fatto e la cosa è chiara: non bisognano più testimonii, non giovano altre prove. Deh, Cornelia, questo è l'amore, questa è la fede che si deve portare ad un amorevole e fedel marito come son stato io? Così presto ti son uscite di mente le promesse e li giuramenti che non avevi altro bene che me? E che se mai io morivo prima, ti saresti sepolta viva? Mentitrice, disleale! Ben me ne sono accorto: con ragione ho sospettato. Disse il vero che il violente tuo dolore doveva durar poco. O più incostante di Fulvia romana! O finta, traditrice, disonesta! O Camillo ingrato, così si pagano i benefizii riceùti? Tu sai che di schiavo ti feci libero, di estraneo ti elessi per figlio, di servo ti feci patrone: e ora mi sei infidele, mi sei traditore? Maledetto l'uomo che confida nelli figli d'altri, crescendoli in casa per suoi proprii, non pensando che questi intessono molti inganni, e come a quelli che &lt;non&gt; sono del tuo sangue, ti cercano di bevere il sangue, la vita e l'onore. E che più? Se oggi non si ha bene da i figli proprii, come io ne dovevo sperare da i figli d'altri? Non posso aver pazienzia; voglio entrare in casa, e uccider l'uno e l'altro.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Fermatevi, padrone, che le cose mal fatte, dopo commesse, più presto si possono riprendere che emendare. Come volete correre così in furia, e commetter un eccesso di tanta importanza, senza aver altra informazione? Se per sorte non fosse così, in che modo potrete emendare questo delitto? Han tanta forza le passioni in noi, ch'al spesso ci fan parere una cosa per un'altra; e perciò bisogna prima intendere, vedere, toccare con mani, e dopo essequire. Fermatevi, di grazia, e non credete così facilmente a, figliuoli, che quando non sanno esprimere bene li fatti, ti mettono in nova confusione. Che certezza potete avere del detto di Franceschetto? Si confonde Magagna con Camillo, Camillo con la Signora e la Signora con Magagna. Saria meglio a essequire l'artificio dell'astrologo, come avete detto prima; perchè discorrendo, intendendo, parlando, ne verrà forse alle mani quel che andate cercando.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Orsù, voglio vincer l'ira, poichè essa, essaltando l'intelletto nostro, ci sforza la ragione; ma mi servirò del tempo e dell'opportunità: che, come disse quel valent'uomo, il conoscer del tempo e il servirsi dell'opportunità fa gli uomini prosperi.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Ora sì che l'intendete. Andiamo di qua, che pensando meglio, in ogni modo pigliaranno qualche buona risoluzione; perchè le cose che si pensano maturamente partoriscono divinissimi effetti.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 3</head>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p><foreign xml:lang="lat">Homini hominem insidiari nefas est</foreign>, come <foreign xml:lang="lat">inter nos cognationem quandam natura constituit</foreign>, che vuol dire in effetto: è cosa brutta che l'uomo inganni l'altr'uomo, essendo che la natura costituì in noi una certa parentela. E per ciò son sicuro, Magagna mio, che Messer Manilio non sarà punto defraudato da voi, circa il trattare il matrimonio suo con la Signora Cornelia: già che Alessandro è morto, e tanto più che dovendone risultare in benefizio vostro, di sorte tale che vi comprarete il modo di esser padrone della casa e dell'onor suo.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Se bene questo mio pensiero è novo, lo desidero estremamente, Magagna, per le ragioni che ti ho detto. Attendi dunque a concluder quanto prima, che del resto ti sarà avantaggiata la promessa di Messer Alberto. Prendi per ora questi tre scudi, e se non bastano questi, prendine tre altri, e se ne vuoi più, dimanda pure.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Benchè, Messer Manilio, li denari abbino gran forza a far ottenere all'uomo quanto desidera; e come dice quell'altro proverbio, che nulla cosa dà maggior forza alla fatica quanto il vedersi il premio avanti gli occhi, non però con me servono questi conti. Pigliateli, di grazia, e non me li fate toccare, che in toccarli sento una voce dalle calcagna che vien congiungendo le lettere R, U, F, <emph>ruf</emph>; F, I, fi; <emph>ruffi</emph>; A sola: <emph>ruffia</emph>; N, O, <emph>no</emph>: RUFFIANO. </p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Fate errore a dir così, che io non vi reputo, nè sarete da altri riputato per tale: poichè ve li do in ricompensa del benefizio che mi fate.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Di maniera che li posso pigliare senza pregiudicio dell'onor mio? Avertite, non mi fate far errore, che questa è la prima volta che io mi metto all'arte. Che dite, Messer Dottore? Comporta la legge che si possa fare?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p><foreign xml:lang="lat">Omnis creatura movetur ad benefaciendum ei, qui sibi benefacit</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Dichiaratelo prima, che vuol dire, che io non pretendo esser ruffiano senza ragion veduta.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Vuol dire che ogn'uomo si move a far bene a colui che gli fa benefizio. Sentendosi Messer Manilio beneficato da voi, perchè trattarete il suo negozio, potete liberamente pigliar da lui quello che in ricompensa del vostro travaglio vi offerisce.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Avertite: anima vostra, manica vostra.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>E vi prometto di più: che concludendosi, restarete a tutta voglia sodisfatto.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Questo veramente è un tesoro; e ora conosco che sì come la calamita tira a sè il ferro, così la pecunia tira la volontà nostra a condescendere alla volontà di chi sborsa. Non è maraviglia se la donna casca volontieri al suon delle patacche: poi che ha potuto tanto in me, che scordandomi dell'amor di quella, che mi divora, con la pecunia in mano son di me stesso ruffiano.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Che dici? Che pensi? Che fai tra te stesso?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Mi risolvo che non sono ruffiano, e perciò voglio far quanto voi volete. Ma avertite, Messer Alberto, che bisogna attendermi la promessa che sarà di dare a Camillo Lavinia vostra figliuola; che, come vi ho detto, non mi confido d'altra maniera di far condescendere la Signora Cornelia a questo matrimonio. Perchè Cornelia, amando Camillo, suo figliastro, come figlio proprio, e sapendo che arde e abbrugia per Lavinia, vorrà prima il contento di Camillo e poi i suoi.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Io non posso, nè voglio venir meno della mia parola: prima, perchè accomodo l'amico; appresso, chè il partito di Camillo è molto onorato; e ultimamente, perchè ve l'ho promesso, e <foreign xml:lang="lat">omne promissum iure debitum est</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Orsù, la cosa va bene. Lasciatemi prima negoziare; e voi di qua a un pezzo lasciatevi ritrovare in questo medesimo luogo, perchè in ogni modo vi farò parlare con la Signora. Ma avertite, Messer Alberto, che al primo ingresso avete a dire che avendo visto l'amor grande che porta Camillo a Lavinia, per la quale abbrugia, spasima e muore, avete concluso di dargliela per moglie; e poi con destrezza fate cader l'acqua al vostro molino.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Il tutto si farà diligentemente. Andate, perchè letta la lezione dell'ordinario al Studio, ritornaremo quanto prima.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Poche parole e buone. Andate con Dio, e zitto.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Andiam di qua, Messer Alberto, che più vicino.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Andiam presto, perchè <foreign xml:lang="lat">nemo debet esse negligens in suo officio. ff. de excusatione, l. Divus Marcus, in fi. par. de offic. praesidis</foreign>.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 4</head>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>O Magagna, in che mare magno ti sei ingolfato! Come ne potrai uscire, se hai per contrarii nove principalissimi nimici: Amore, Bellezza, Nobiltà, Gioventù, Ricchezza, Povertà, Bruttezza, Viltà e Patacche? Amore mi ha pertugiato di sorte il cuore che pare un crivello di semola. La Bellezza e Gioventù di Camillo mi levaranno la preda. La Nobiltà e Ricchezza di Manilio mi daranno la cassia. La Povertà, Bruttezza e Viltà mia mi faranno fare indietro; e queste Patacche di Manilio m'impediscono di maniera ch'io non mi so risolvere. Mirate Amore in che amaro umore mi ha posto, in farmi innamorare d'una cosa contra natura! Perchè se naturalmente ogni simile appetisce il suo simile, come a dire il gallo la gallina, il paparo la papara, il corvo la cornacchia, il tauro la vacca, il cavallo la giumenta, l'asino l'asina; e voi sete informati che li signori amano le signore, li mezzani le mezzane, li poveri le povere, li servidori le fantesche; io mo che son servidore e amo la padrona, non è cosa contra natura? E il peggio è che se lo sa la corte, voglio esser abbrugiato senza proposito. Deh, Magagna, can mastino! Magagna senza giudizio, pìgliate questo pugno, che lo meriti, e poi quest'altro, e quest'altro ancora. Non ti vergogni a pretender tanto? Tu, tu sei tale? Ora piglia quest'altro. Dall'altra parte risponde Magagna e dice: non dar, di grazia, che chi procura inalzarsi non fa male. È questa forse la prima padrona che s'è attaccata con li servidori? Allego <foreign xml:lang="lat">solitus et consuetus</foreign>. Dunque fatevi indietro, pugni. Ah! traditor Magagna, farai tu come fanno gli altri servidori infami? Pregiudicarai tu all'onore del tuo padrone che ti è stato tanto cortese? Per il pensiero solamente meriti un altro pugno, e poi un altro. Replica Magagna, <foreign xml:lang="lat">et dicit</foreign>: che colpa è la mia se Amore è cieco e non mi fa vedere? Dunque se non &lt;son&gt; io, ma Amore, indietro, pugni. Ah, vigliacco, con Amor ti scusi? Deh! che è quella maledetta frenesia, e non amore. Dunque se sei tu, pigliati questo pugno, e poi quest'altro. Ferma, dice Magagna, che essendo per via di matrimonio, cessa ogni difetto; e se ben io non sono della qualità sua, nondimeno il colmo dell'amore che io li porto coprirà l'indegnità mia. Dunque indietro, pugni, e seguitiamo l'amorosa impresa. Ma come faccio con Camillo? Mi risolvo a non dire alla Signora che è schiavo, acciò, sapendo che non gli è figliastro, non se lo pigliasse da vero per marito, e io restasse con li denti secchi. Meglio sarà che io anticipi; che anticipando si risolverà a concluder meco non potendo con il figliastro, tanto più &lt;che&gt;, come essa intenda l'amor di Camillo e di Lavinia, si sdegnarà con Camillo, e Magagna entrarà per lo terzo, Rodomonte. A rispetto poi di Messer Manilio, vederò di cavar denari quanto posso; e all'ultimo mi scusarò quanto posso, dicendo che la prima carità comincia da se stesso, o ogn'uomo ne vuol più per lui che per altri. Lasciami entrare, che Amore mi darà la voce e le parole.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 5</head>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Che cosa potrà voler la Signora Quintilia, che così in fretta mi manda a chiamare? Vattene sopra, Lavinia, e fa come io ti dico: che la donna non è per altro trista, se non che gli avanza libertà e li manca la vergogna. Voglio dire a proposito che non mi piace molto la libertà che da te stessa hai presa da pochi giorni in qua, stando quasi di continuo su le finestre, praticando per basso e lasciando l'essercizio della casa. Non hai più volte inteso dire da mio marito e tuo patregno che Lucrezia romana fu riputata savia e casta, principalmente perchè si essercitava e faceva sempre essercitare le donne sue al servizio della casa? Essendo cosa manifesta che quella donna la quale attende alli solazzi e piaceri del mondo facilmente cade e perde l'onor suo.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Madre mia carissima, quando la donna ha sano il cervello, non si lascia movere per niuna occasione del mondo.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>È vero; ma l'assuefarsi al male è male. Sai pure che a poco a poco giongendosi legne al fuoco, diviene così ardente che non solo abbrugia le legne verdi, ma consuma anco le pietre vive. Così accade alle donne che si pigliano oggi un piacere e domani l'altro, salendo di male in peggio; cadeno, dopo, tanto volentieri che infamano non solo elle istesse, ma ancora tutto il parentado.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Il piacere che mi ho preso è stato perchè voi mi diceste: figlia mia, non ti affaticar tanto, datti alcuna volta qualche sorte di spasso, non andar così sconcia,  conservati questi capelli, lavati il volto, va polita, che altrimenti ogni uno ti dirà che sei una sciocca, una sparmia-fatica.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Sì, ma io dandoti il dito, tu t'hai preso tutta la mano. Averti, figlia mia, che il solazzo che io ti dissi non s'intende lo star di continuo su le finestre, ma il ricrearsi per casa; l'andar acconcia non voglio che sia il perder tempo tutto il giorno a sbellettarsi e a farsi la bionda. A che servono tanti ricci e tanti lisci? Basta a lavarti con l'acqua pura, come facevo io al mio tempo; poi che voi altre giovane sete a guisa di vetro, che tentato si rompe, e ogni poco l'ammacchia: talchè bisogna stia chiuso, che non sia tocco, e lavarlo semplicemente, che stia netto, e non ammacchiarlo con tante lorde cose che vi mettete sul volto. Haime intesa?</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Vi ho intesa. Ma...</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Che vuol dir quel ma?</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Ma voi altre donne (perdonatemi se vel dico) come giongete al secco, o dite: al mio tempo non fu così, al mio tempo feci, al mio tempo dissi; non avertendo che il mondo è stato sempre come oggi, e se a voi pare altrimenti è perchè, essendo vecchia, vi è mancato il potere, e non il volere.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>A me questo? Così si tratta la madre? Questa è la riverenza che mi porti? Questi sono li consigli che ti ho dati? Io son vecchia? Camina via, non mi star più dinanzi!</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Sapete come è, Signora madre? La vedova che si accasa di novo mette tutto l'amor suo al novello marito e disama li proprii figli. Io m'aviddi che da che vi casaste m'avete trattata male.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Io mi casai per benefizio tuo, sciaguratella che sei. Da che tempo in qua sei divenuta così sfacciata, prosontuosa, ignorante? Va via, non mi star più innanzi, che io mi risolvo a differire l'andata dalla Signora Quintilia infino a notte, per venir a darti il castigo che meriti, se non farai quanto ti dirò. Vien qua, Pasquina: va alla Signora Quintilia e dilli che, se non è cosa che molto importi, andarò da lei questa sera.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Quanto commanda Vostra Signoria. Ma sappiate, Signora, che Lavinia è una trista figliuola, fa certe cose che non mi piacciono; e io volendola avisare, mi ha dato delle busse che ancora mi fa piangere.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>E che cosa fa? Dimmelo, Pasquina mia: che oltre ti vendicarò delle busse, ti prometto ancora un beveraggio d'importanza.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Perdonatemi, Signora, che non lo posso dire; perchè mi ha minacciato dicendo: se tu dici che io faccio l'amore con il Napolitano, t'ucciderò tutta tutta.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Dunque con il Napolitano fa l'amore? Bella elezion per certo! Vien qua, dimmi: il Napolitano è innamorato di lei, o ella di lui?</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Io non dico questo, siatemi testimonio; ma lo dite voi. Io so che ella si muore per quel balordo, ed egli non la può sentir nominare.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Sì, ah! Va via tu, e lascia far a me.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>E un'altra cosa di più; che essa è stata causa della disperazione di quel povero Flavio, il quale l'amava più che se stesso; ed essa, lasciando il meglio, s'è attaccata al peggio. </p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Tutte queste cose vi sono? Non ti curar, fraschetta.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Oh, oh, mi ricordo un'altra cosa. Non sapete Camillo, quel giovane bello che passa spesso di qua?</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Sì che lo so.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Questo Camillo la desiderava e la desidera per moglie, ed ella lo discaccia e segue quel goffo del Napolitano.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Ohimè! la pratica è gita troppo innanzi, e io me ne sono aveduta nell'ultimo. Ben è vero che le genti di casa sono l'ultime a sapere il disonore della casa. Or va, e torna subito.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Sì, ma non dite poi che sono stata io che ve l'ho detto, perchè passarei pericolo della vita.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Va pure, e non aver timore.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Alla fè, alla fè che impararà di batter le serve senza proposito.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 6</head>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Misera Leonora, a che strano passo ti vedi! Pensavi pur d'avere una figliuola che doveva esser la quiete della mente tua, e ora la vedi correre in fretta a ruvinarti del tutto. Se la mia trista fortuna mi ha tocco sin adesso nella robba, nelli mariti e nella persona propria, al presente per colmare il sacco tenta di toccarmi anco nell'onore; cosa di tanto pregiudizio maggiormente a noi altre donne, perchè la donna, perdendo l'onore, non è più donna. Ma chi son costoro che vengono verso di me?</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Sono così incostanti li beni di questo mondo, che a pena gustati ci disparono davanti. Leandro, quella donna ci mira fissamente; che vorrà da noi? E io quanto più miro, tanto più mi pare che sia Brianda mia. Ed è pur essa! Accostiamoci pure.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Il male non viene solo, dice quel proverbio. Chi sarà questa Brianda? Dubito di alcun altro male.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>E sarà peggior del primo, se sarà come par che mi vada mostrando l'apparenza.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Che borbottate fra voi stessi? Che volete da me? Che pretendete? Che cercate?</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Borbottiamo di saper il vero, volemo farvi servizio, pretendemo manifestar la virtù nostra e cerchiamo il benefizio del prossimo: poi che, come dice quel savio, l'uomo non è nato per sè solo, ma per giovare a gli altri ancora.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Averà altri pensieri Leonora che intender queste vostre filastroccole.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Non son filastroccole, ma la verità istessa. Sappiate, Signora, che io sono astrologo: e per quanto ho potuto comprendere dalla vostra fisonomia, so molto bene chi voi sete e donde venite; so anco li travagli e pericoli vostri; e per cominciar da qui, voi primieramente non vi chiamate Leonora, ma Brianda.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Io stupisco. E Brianda di chi?</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Brianda di Carvascial; e sete spagnola, d'una città chiamata Zamora.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Ohimè! che sento? E come lo sapete voi?</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p><foreign xml:lang="lat">Virtute astrologiae</foreign>: e il primo vostro marito si chiamò Alessandro, genovese; e perchè voi sapete il tradimento usato in persona di esso Alessandro, non mi estendo più oltre.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Dite pure, che seguendo come avete incominciato, dirò che sete indovino.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Intendete. Prima che Alessandro vi prendesse per moglie, il Capitan Valasches era innamorato di voi, e vedendosi escluso da' parenti tramò di uccidere Alessandro; e così in processo di tempo venne di notte con altri armati in casa vostra, e ferendo a morte il povero Alessandro lo ridussero in una camera terrena, dove li presentorno il capo tronco di voi, Brianda, dicendo: «Godi pure, godi, Alessandro! Valasches è già contento, poi che in un medemo colpo si è vendicato di lei che lo rifiutò e di te che osasti di preferirti a lui. Muori, muori disperato, che tu fosti causa della sua e tua morte»; e dandoli altre ferite, lo chiusero per morto dentro un sacco, con ordine che lo gettassero in un pozzo, come fu gettato, fuori della città</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Tutto questo è vero. Ohimè! che in sentirlo mi si rinovellano le piaghe antiche. Ohimè! Alessandro mio, quanto mi fosti caro, quanto mi fosti buon marito, che per me gustasti l'amaro della morte ne gli anni più verdi, sotto i quali speravo di vivere felice per alcun tempo!</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Se piangete che Alessandro sia morto, v'ingannate.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>E come?</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Vi dirò. Alessandro fu gittato nel pozzo, giudicandolo ognuno per morto. Ma venendo il giorno, passorno certi viandanti genovesi da quel luogo e sentirno la voce d'un che si lamentava e chiedeva aita: da i quali fu cavato fuora, e medicandolo per strada lo ridussero ultimamente in Genova, dove guarì del tutto, e al presente è vivo.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>È vivo? E... è vivo Alessandro? E dove si trova?</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>È vivo, ma non so dove si trovi, se voi non mi dite prima come sete viva, se altri vi vidde col capo tronco. Che quantunche io lo so, nondimeno bisogna saperlo da voi, per far la figura legitima, conforme alle nostre regole d'astrologia.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Io son viva perchè il Capitan Valasches non mi uccise altrimenti, se bene portò con esso lui una testa fatta di sorte che al naturale rassomigliava alla mia, e questo per far morire Alessandro più discontento: perchè sapendo che il povero marito mi amava più che se stesso, finse d'avermi tronco il capo, acciò la morte li fosse più acerba, vedendo morta ancor me. E così mi trasportò da Spagna in Roma, e lasciando di lui una figliuola chiamata Lavinia, si morì, e oggi mi trovo rimaritata con un lettor di Studio, chiamato Messer Alberto.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Oh! caso veramente inusitato e nuovo. Riposatevi, Signora, e lasciate fare a me, che io farò la debita figura e ritornarò a dirvi dove dimori Alessandro.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Vorrei che portaste anco il modo che si ha da tenere, ritrovandomi già accasata con un altro marito.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>A questo ancora si provederà, che per quanto le stelle mi promettono trovo che Alessandro similmente è accasato, persuadendosi che voi foste morta.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Oh, che intrigo inestrigabile sarà questo!</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Andate pure, che io vi aspetto con desiderio, e della fatica vostra ne sarete molto ben remunerato.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Non voglio nessuna rimunerazione, perchè l'arte mi fu insegnata che io servisse senza premio.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Orsù, a rivederci: e tornando in casa potrete venire sotto colore che avete a parlare al lettore di Studio; e se per sorte egli vi si trovasse, fingete di desiderare da lui la resoluzione d'alcun dubio.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Di grazia, che ti par, Leandro? Non son io il bersaglio della mala ventura? Quest'altra disgrazia mancava alle mie tante disgrazie! Ecco Brianda, mia prima moglie. Ecco Brianda viva. E io, mal per me, son vivo, ed ella si trova accasata, e io mi trovo accasato. Come si farà? Che rimedio vi sarà? Se io non mi scopro, vivo in peccato. Se io mi scopro, ecco un disturbo grande. O misero e infelice Alessandro! Che farò? Che dirò? Aiutami, Dio mio, che senza te non si trova sano consiglio. Andiam di qua.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Andiam, padrone, e non vi sgomentate per questo; che 'l cuor valoroso, come è il vostro, nel maggior pericolo piglia maggior forza.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 7</head>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Oh, me buoi muorto, Pasquina, se non fai che fuìreme? Anzi, quanto chiù me fùji, chiù ti viengo appriesso. No' sai como dice chella canzone: «Quanto chiù mal mi vuoi, tanto chiù bene te boglio»? </p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>E io canto al riverso: quanto più ben mi vuoi, tanto più mal ti voglio! Lasciami star dunque: che vuoi da me? Non ti voglio, no, no, no!</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>E io ti boglio, e io ti boglio, sì, sì, sì! Traetorella ca squarti cori, sparti pietti, apri vene e bevi sangue delle perzone. No' fuire, per l'àrema delli muorti tuoi. Bide ca faremo ridere Roma, oie, ca se tu curri da ccà, e io viengo da ccà.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Oh, Dio, come sei fastidioso! Non t'accostar, vedi, che ti darò un pantofolo sul mostaccio.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Accideme, ca non me curo de morire pe chesse mano bellissime, ianchissime e nudissime, chiù belle, chiù ianche e chiù nude della bella ianca e nuda mano ca disse lo Petrarca.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>E pur lì, e pur mi vien dietro! Vatti con Dio, lasciami andar presto a casa.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Fermati no autro pocorillo, ferma, non ti straccare a correre. Aggi allo manco pietade de chissi delecatissimi piedi; non fare como fece Dafne e chilla ca se chiamava Siringa, ca, secondo dice lo Metamorfosio, la prima pe fuire Apollo diventò lauro, e l'autra pe fuire lo dio Pane si converse in canna.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>A che servono queste favole? Io non t'intendo, nè ti voglio intendere. Va via, va, va.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>No' sai che li essempii movono chiù ca no' movono le parole? Ti metto chisso essempio 'nante azzò sani, aiuti e soccor&lt;r&gt;i &lt;u&gt;no ca è feruto, muorto, arzo ped amore tuo.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Vorrei che da vero fosti ferito, morto e arso per non sentirti più. Vedi, se non mi lasci, gridarò forte.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>E io strillarò chiù forte, pe farete perzì castigare dalla Iustizia, se mo me vuoi accidere; pecchè chi può sanare chillo ch'ha male, e no' lo sana, l'accide.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Non ti vergogni, sei gentiluomo e ami una servitrice?</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Lo faccio pe sementare la nobeltate meia: pecchè l'ommo incorporandose co la donna la fa deventare nobele, essendo la femmena materia ca concepe e non dà. Tale ca tu conceperai la nobeltade ca ti daraggio io, e sarai chiamata la Signora Pasquina, e non Pasquina.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>T'aggiri se pensi ingannarmi sotto queste false promesse: che così dite voi altri uomini, in sin che avete l'intento vostro; ma poi ne piantate nel bel mezzo.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>No' me fare iurare, Pasquina, ca io dico lo vero, e la ragione è chesta: io songo nobele e ricco; no' me manca autro, pe stare contiento, eccetto d'avere no viso d'angelillo como chisso tuo, che Angelina ti doveresti chiamare, e no' Pasquina.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>S'è così, perchè non prendi la Signora Lavinia, che è bella, ricca e nobile, e poi t'ama tanto che è peccato a non amarla?</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Amore no' è autro ca compiacimento: a me non compiace Lavinia, e perzò non la pozzo amare.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>E tu non compiaci a me, e perciò non posso amarti.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Beata a te se me ami, Pasquina; ca oltre l'essere di Sieggio e ricco, songo nondemeno valoroso co l'arme 'mmano, ch'a no bisuogno vaglio pe quatto, e pe sei 'ncora. Dimandane la chiazza dell'Ormo a Napole, quanno me furono sopra na centinara di Spagnuoli, ca feci no fiumale di sangue.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Per staccarmi da costui vuo' servirmi d'un bell'inganno che mi è sovenuto or ora.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Ca mormori tra te stessa, Pasquina mia?</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Dico che vorrei veder la prova or ora: e fate conto che ti fosse un inimico davanti, l'altro di dietro, l'altro dal lato sinistro e l'altro dal destro, come faresti a guardarti da tutti?</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Chisso è facelissimo. Ecco ccà. Io metto mano contra de chisso ca me vene denante, e po' salto di quarto contra de chisso ca vene de sinistro; sbando da schiena contra de chisso autro ca vene da destro, e po' co na bella girata corro contra de chillo ca vene dereto, gridanno: ah, mulo cornuto! a trademento, ah? con inganni, ah? </p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Or resta tu ingannato, che ti lascio ed entro in casa.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Ah, cornutiella, fuìste, neh? No' te curare, ca se no autro iuorno m'incappi alle mano, no' me scapperai chiù. Ma bestiale ca songo io, d'annare accosì reserbato co le donne, le quale no' sanno resistere alli fatti, se bene resisteno alle parole. Doveva benire subbeto alli fatti e lasciare lo circueto di tante parole. Ma che pozzo fare se Amore m'have levato lo 'ntellietto, la memoria e la voluntade, de manera ca non songo chiù lo Signor Gialaise? Io conosco apertamente ca chesta non è pare mia, no' è tanto bella como l'ommo si pensa. Vedo che m'odia como la quartana; e no' pozzo fare ca no' li boglia bene; anzi, quanto chiù mi strazia, tanto chiù me sforza ad amarla. Ora provo ca no' &lt;n&gt;ce puo', mettere nè freno, nè legge a gli amanti. Ho perzo Cuosemo, ca m'era tanto fedele servidore; essa mi burla, io mi consumo, lasso l'essercizio della cavalleria, non penso ad autro, no' mancio, no' bevo, ed eccoti no iuorno na nuova, ca lo Signor Gialaise è muorto. E diceranno chilli Cavallieri: guai e mala Pasqua li vienga, po' ca volette amare Pasquina. Ma chi esce de là? No' vorria ca me trovasse co la spada sfoderata. Boglio ritirareme ped infoderarla, poi che pe la còlera no' mi è concesso di poterla 'nfoderare ccà così priesto.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 8</head>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Quanto è detto, è detto. Non accade a dirvi quel sfortunato che v'ama senza speranza di potere arrivare al desiderio suo: basta a sapere che Camillo è un tristo figliuolo, amando Lavinia contra la volontà vostra, e dandovi buone parole si consuma di robba e di vita a spendere e spandere a ruffiani e messaggeri. Di più ha ridotto Messer Alberto, padrigno della giovane, a contentarsi di dargliela per moglie, come intenderete da lui, perchè ha da venire con Messer Manilio, secondo vi ho detto. Importa mo che voi stiate salda, perchè come essi vengono io mi metterò dietro la gelosia, fingendo la voce vostra, e voi di dentro sentirete li tradimenti che vi fa Camillo.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Ah, Camillo disleale, Camillo disamorevole, Camillo che t'ho riputato da figlio, che t'ho amato più che me stessa! E ora a mal grado mio, senza parlarmi niente, prendi per moglie Lavinia, non ti curando di me? Ed è vero, Magagna? Ed è vero che Camillo ama Lavinia? Ed è vero che Lavinia sarà moglie di Camillo?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Tre palmi più della verità! Ed ècci un'altra cosa che non si vergogna a dire: faccio più stima delle scarpe di Lavinia che di cento Cornelie. Che Cornelia? Adesso che è morto mio padre, terrò Cornelia sotto questi piedi.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Ahimè! come sempre restiamo ingannate noi altre povere donne. Chi averebbe mai pensato che sotto le dolci parole di Camillo si nascondesse il veleno? Ah, ingrato! Ah, traditore, falso, perverso, iniquo!</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Mi dispiace, padrona mia, di cotesta còlera che vi pigliate. Lasciamo andar Camillo, e fate come vi ho detto: accasatevi con Messer Manilio, o con quell'altro che arde e avampa per amor vostro; e quest'altro saria meglio e più al proposito mio.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Chi è costui? dimmelo, acciò mi possa risolvere; dimmi dunque, chi è cotesto giovane?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Oh, potta del mondo! attac&lt;c&gt;ossi al giovane. Padrona mia, costui che io dico non è giovane nè vecchio, ma fate conto che sia dell'età mia.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Come si dimanda?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Si confronta col nome mio.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Dove abita?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Vicino a voi.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>È gentiluomo?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Signora, no.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>È ricco?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Non è tal cosa.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>È bello?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Questo non ha.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>È dotto?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Mica.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>È valoroso?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Questo li manca.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Che può dunque avere di buono, se gli mancano tutte queste cose buone?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>È valoroso al letto, dotto alla boccolica, bello magnatore, ricco di vane speranze, e gentiluomo che non sa fatigare. Ma poi che voi sete nobile, ricca, dotta, bella e valorosa, che ne volete fare di valoroso, dotto, bello, ricco e nobile, se non di uno che vi serva di dentro, come di fuora la trabacca? </p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Parlate da par vostro. Ma è possibile che io non possa sapere chi è costui?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Mi vergogno a dirvelo. È uno che vi ha servito molt'anni, e voi meglio lo potresti rimunerare che accomodarlo di questa sorte.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Tu sei pertinace; dimmi chi è.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Ego.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Tu sei?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Signora no, io non sono, Signora mia. Ma quando fosse io, che faresti?</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Che farei? Dillo tu, che so che dirai che mi conver&lt;r&gt;ebbe fargli tagliare la faccia, la lingua e le braccia per essempio di tutti li sciagurati.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Signora no, non son io.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Voglio in ogni modo saperlo. Chi è? Chi è?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Ohimè! Io...</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Tu sei?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Signora no, non son io. È un altro.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Chi è quell'altro?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Io...</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Oh, vigliacco, infame, ti cavarò gli occhi! Tu hai tanto ardire? Ti pelarò la barba!</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Signora no, non son io.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Or prendi, in malora, questo pugno.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Non te lo dissi io che disegno di pover uomo non riesce? Non fate, di grazia, fermatevi, che non son io: ma quando dissi io, volevo dire: io non sto commodo adesso di dirvelo. Ma... oh, oh, ecco li vecchi. Andate sopra, che li dirò che voi sete pronta a dargli audienzia, e subito mi trovarò dietro la gelosia, come vi ho detto.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 9</head>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p><foreign xml:lang="lat">Portatur leviter quod portat quisque libenter</foreign>: dunque potete ancor voi, Messer Manilio, sopportare questo peso delle seconde nozze, se vediamo che così liberamente &lt;lo&gt; sopportano gli altri. Non mutate, di grazia, proposito, che se bene <foreign xml:lang="lat">sapientis est mutare propositum</foreign>, nondimeno s'intende sempre <foreign xml:lang="lat">in melius</foreign>. E perchè sarà meglio per voi di accettare questo partito della vedova, accettatelo liberamente, che oltre ne succederà la quiete dell'animo vostro, forse n'averete un figliuolo che allevandolo d'altro modo di quel che avete fatto di Flavio, sarà il contento e la consolazion vostra.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Eh, Messer Alberto mio, molte cose si fanno in un momento e in un impeto, le quali han bisogno di lungo tempo a considerarle. Il correr così in fretta a questo negozio non troppo mi piace.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Non dite così, ma pensate che il cuor generoso ad ogni impresa s'avventura, quando si trova astretto dalla necessità: e le cose che per necessità promettiamo si devono essequire e mandare in effetto con la sola volontà.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Orsù, farò quanto voi volete. Ecco Magagna, accostiamoci.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>A tempo sete giunti, già venivo a chiamarvi: ho parlato alla Signora, e si risolve di far questo matrimonio, ma vuol prima star sicura che voi, Messer Alberto, diate Lavinia a Camillo. Sete savio, non bisogna dirvi altro. Io vado di sopra, e farò che vi risponda da dentro la gelosia, la quale come sentirete toccare, subito potrete introdurre il ragionamento.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Voi sete un uomo di molta importanzia: andate pure, e lasciate fare a noi. Per certo, Messer Manilio, questo è un buon principio, e io vi pronostico un fine felicissimo.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Faccia Iddio. Ma io sento la gelosia. Dite pur voi.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Noi giunti insieme baciamo le mani di Vostra Signoria.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>L'uno e l'altro sia il ben venuto.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>La virtù vostra, e la fama di voi, che risona per tutto, mi hanno spinto &lt;a&gt; desiderarvi ogni bene e a procurarvi nuovi servitori, poi che alla persona virtuosa e da bene è poco guiderdone esser Signora di tutto il mondo, sì come al vizioso sia poco castigo di torgli la vita.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Vi ringrazio, Signor mio.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>(Questa voce mi par troppo rauca, Messer Alberto mio).</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>(Sarà causata dal piangere e sospirare la morte del marito). E perchè il Signor Camillo, vostro figliastro, è stato e oggi più che mai sta intensamente innamorato di Lavinia, mia figliastra, di modo tale che arde e abbrugia per amor suo...</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Senti, senti, padrona, senti, senti, padrona.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Che voce è quella?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Son Magagna che parlo mo. Sequitate, Signori.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Io per smorzar la fiamma del suo fuoco, e perchè so farne servizio a Vostra Signoria, ho concluso già che egli sia marito di Lavinia...</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Senti, senti.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>...certificandovi, Signora, che mi sono contentato di questo per aver occasione di proponervi, come già vi propongo, un partito molto al proposito per Vostra Signoria, che sarà un gentiluomo, amico mio di molti anni, persona virtuosa, ricca e nobile.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Chi è cotesto gentiluomo? Desidero saperlo, e vederlo ancora.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Io l'ho menato meco, acciò il negozio non vada in lungo sotto il maneggio di mezzani, e acciò dalla presenzia sua possa Vostra Signoria discernere il vero. Ecco qua: Messer Manilio è quel gentiluomo che io dico. Costui sarà il vostro marito, costui sarà il vostro ristoro.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Mi piace certo, e vi ringrazio del pensiero particulare che Vostra Signoria ha tenuto di me.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Non accade ringraziamento, che, come a suocero del vostro Camillo, sono obligato principalmente a farlo.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Sarà bene che passi alcun altro giorno: per la morte del Signor Alessandro, per onorare quella benedetta anima.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Per darvi segno certo che io penderò sempre dalla vostra volontà, mi contento d'ogni vostro commodo: e se mai la sorte mi concederà che ritrovi Flavio, mio unico figlio, farò che sia marito della Signora Ersilia, vostra figliuola, acciò possiamo vivere in una pace tranquilla, in una quiete perpetua.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Farò quanto Vostra Signoria commanda.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Dall'altra parte, in ricompensa della mia viva affezione, vi chiedo per grazia che alziate la gelosia, acciò vi veda un poco.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Non posso, perchè sto in lutto. Perdonatemi, domani potrebbe essere.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>E fatelo adesso, per quanto amore portate al vostro futuro sposo! Oh, che siate la ben venuta! Già che mi avete fatto grazia in aprir la gelosia, fatemi ancor l'altra in levarvi cotesto lutto della testa, e discopritevi il volto. Voi crollate il capo? Pensate forse alla morte del Signor Alessandro? Voi dite di sì, e perchè? Contentatevi della volontà di Dio. Voi pur crollate il capo. Che cosa avete? Perchè restringete le spalle? Scopritevi, di grazia, e dite il bisogno vostro, avendo già chi può consolarvi. Perchè dite di no? Non mi fate questo torto, lasciatevi vedere. Perchè sospirate e vi scostate, per amor mio? Perchè non parlate?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>È levata corte, non si può dar più audienzia.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Bella cosa, per Dio! Dunque sei tu, Magagna.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Son io troppo, perchè la padrona mi disse: “cuopri la gelosia, e di' a quei signori che mi abbino per iscusata, non convenendo così presto parlare dalla finestra”; ma dimani darà la risoluzione di quanto si ha da fare. Andate con Dio, e lasciate il pensiero a me. Vi bacio le mani, e aspettatemi a piazza Savella.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Che vi par, Messer Alberto?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>E che mi pare? Parti che queste cose si faccino a un tratto? Vi bisogna pur tempo, ben che il tempo insino a domani è breve, e saremo risoluti del tutto.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Per dirla, Messer Alberto, non vorrei comprar il gatto nel sacco; voglio prima vederla, e rivederla.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>State sopra di me, che io ho inteso sempre dire la moglie di questo Alessandro esser bellissima e ricca. Ma però la vedremo e rivedremo prima che si concluda niente. Andiam di qua ad aspettar Magagna dove egli disse, chè <foreign xml:lang="lat">dulcior est fructus post multa pericula ductus. Notat glosa in l. «non moriturus», de contrahendis et committendis stipulationibus</foreign>.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 10</head>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>La vera amicizia è quella dove li corpi sono diversi e la volontà non è più d'una. E poi che noi tirati dalla nostra mala sorte, confidandoci insieme, siamo uniti talmente che di tre persone si è fatta una sola volontà, quello che ho chiamato insin adesso trista fortuna, spero chiamarla buona per l'avenire.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Non è dubio, Signor Camillo, che l'amicizia consiste nell'equalità degli animi: e già che noi egualmente ci siamo confermati, dovemo preporre quest'amicizia nostra a tutte l'altre cose. Sì come in effetto si deve fare, e noi abbiamo già fatto: poi che io liberamente concorro a dar Lavinia, mia sorella, a Flavio; e voi concorrete al pari a darmi la Signora Ersilia; e uniti poi spenderemo la vita, non che l'artificio di parole, per farvi ottenere la Signora Cornelia, già che non è vostra matrigna.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Veramente l'amico è un nome desiderabile, un rifugio d'infelice, un ricevitore di segreti, una quiete indeficiente, una felicità perpetua. Anzi il sole, l'acqua e il fuoco non è più utile a gli uomini, quanto è utile il vero amico. L'esperienzia si vede oggi in persona mia, che senza darvi cosa alcuna mi avete offerto tutto quel bene che potesse aver mai in questo mondo.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>E in questo si conosce il vero amico, quando senza disegno giova all'amico suo; perchè incostante e perfido è colui che affetta l'amicizia solamente per suo commodo. Orsù, attendiamo alla nostra impresa. Già che siamo vestiti da schiavi, con queste barbe posticce, non per altro eccetto che da noi stessi, con bell'artificio facciamo prova di persuadere a queste Signore donne che ci siano amorevoli, stante che esse solo s'oppongono al voler nostro. Accostiamoci, che se io non erro mi par veder la Signora Lavinia in finestra. Ed è pur essa: state saldo, Signor Flavio.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>In vederla mi trema il cuore, suda il volto e aggiaccia il sangue. Non mi fido di parlare; parlate voi, Signor Camillo.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Mi risolvo in ogni modo di obedire la Signora madre. Ma che vogliono questi schiavi che vengono verso di me? Che volete? Chi sete voi?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Siamo tre poveri gioveni lungo tempo schiavi di Turchi e di corto liberati. Siamo venuti da Vostra Signoria per dirle due parole: s'ella si degnarà d'ascoltarle, noi faremo l'opra di carità chiestaci da un altro povero schiavo, ed ella si liberarà dal peccato, nel quale se persisterà la vedremo or ora trabboccare nell'inferno.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Questo è un gran pr&lt;o&gt;emio! Dite pure.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Un gentiluomo di questa città, ritrovandosi schiavo con noi, ne raccontò un giorno che avendo lungo tempo amato la grazia e bellezza vostra con quel vivo e sincero amore che si possa amar già mai, sperando di ricever guiderdone della sua lunga servitù, fu da voi discacciato; in tanto che dandosi in preda alla disperazione si partì, lasciando il padre vecchio e solo, e fu per disgrazia preso da' Turchi. Noi fummo dopoi liberati ed egli restò; ma dandoci li segni e contrasegni, trovammo che voi sete quella per cui egli pate la catena e li ceppi; pregandoci che vi dovessimo pregare, come già tutti tre con le braccia aperte e con le ginocchia in terra vi preghiamo, che abbiate compassione di quel misero e infelice, e non comportate che, amandovi, si muora in tante pene. Perchè se gli promettete la grazia vostra, faremo che il padre lo ricatti, e quando non lo facciate di ciò degno, si contenta più tosto morire sotto quelle catene. Pietà!</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Pietà, pietà!</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Compassione, pietà!</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Levatevi su e ditemi chi è cotesto giovane.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Il misero e infelice Flavio, che...</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Non passate più innanzi, non accade a dir altro.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>E perchè?</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Perchè giungesti tardi, avendo rivolto l'animo mio in amar un gentiluomo chiamato Camillo, meritando così la viva affezione che egli mi ha portato e porta, e anco perchè così vuole la Signora madre, la quale è risoluta maritarmi a lui.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Camillo? Ah, Camillo!</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Camillo? Ah, Camillo!</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Camillo non l'ama, statene sicuri.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Camillo mi ama, e io l'amo: non accade darne conto a voi! Andate via, e scrivete a Flavio che se vuol morire, muora.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ah, Camillo! Questo tradimento, Camillo? Ah! Lavinia, sei tanto crudele che vuoi che io muora, e serri la finestra per non sentirmi nominare? Oh! dolente Flavio, tradito dall'amico e disprezzato da chi ami!</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Non vi cada questo nell'animo: confidate in me e credetemi, che io non l'amo più, nè voglio amarla, nè so nulla di quanto ha detto. Non vedete che è sua imaginazione? Non vedete che sono parole dettate dall'odio grande che vi porta, avendo conchiuso che se Flavio vuol morire, muora? Nè vi disperate per questo: trattaremo di nuovo, e ci vogliamo al fine discoprire che siamo noi, che vedendoci e sentendoci mutarà senz'altro il pensiero.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Dice bene il Signor Camillo. Al primo colpo non cade l'arbore. Ma fermat&lt;ev&gt;i... Oh, buona sorte! Vedo uscir Cornelia fuor di casa. Accostiamoci.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Amore fa l'istesso effetto in me che ha fatto nel Signor Flavio. Parlate voi, Signor Flaminio.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 11</head>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Io lo starò qui fuori aspettando: non voglio che nè anco salisca in casa, voglio discacciarlo, me ne voglio mangiare il cuore. Infame, che mai fosti figlio di Alessandro! traditore, che meriti ogni castigo! </p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Eh! Signora madre, non correte in furia, raffrenate la collera: chi sa se sarà vero, ved&lt;r&gt;emo d'informarci meglio. Salite ad alto, non conviene a star su la porta. Ma chi sono quelli?</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>O gionta felice! Vi sta ancora la Signora Ersilia. Ohimè, ch'io tremo e sudo. Flavio, parlate per me, dopo che io averò parlato per Camillo.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Che cercate, gentiluomini?</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Cerchiamo Camillo.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Chi Camillo?</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Camillo nostro fratello.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>E dove sta?</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Sta in cotesta casa</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Che cosa avete a far con lui?</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Vi diremo. Noi siamo Ragus&lt;e&gt;i ed eravamo quattro fratelli, Camillo e noi. Accad&lt;d&gt;e che fummo tutti presi da' Turchi, e Camillo per buona sorte fu ricattato dal Signor Alessandro vostro marito, il quale lo chiamò e reputò per figlio suo proprio. Ha voluto anco la buona sorte che noi ancora siamo stati liberati, e venuti in Genova trovammo il Signor Alessandro morto; e ci fu riferito che Camillo si trovava qui in Roma, dove gionti ne siamo incontrati con lui; e dopo li cari abbracciamenti ne mostrò la casa, commettendoci che dovessimo venire a trovarlo.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Che favola è questa?</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>È il vero certissimo. Anzi, Camillo ci ha confidato un secreto, che quando fossimo sicuri di non offender l'orecchie vostre ci risolverìamo a dirlo.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Io vo' pure sentire il fine di questa comedia! Dite liberamente.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Egli si ritrova così invaghito della bellezza vostra, che se ben prima e poi la morte del Signor Alessandro, e al presente ancora, il petto suo ha arso e arde qual fornace ardentissima, nondimeno non ha aùto animo di scoprirsi per la riverenza che portava e per l'obligo grande che aveva ad Alessandro. Ma vedendo al fine che voi avete animo di casarvi, temendo pur di scoprirsi, manda per mezzo nostro a farvelo intendere, se vi degnarete accettarlo per marito, anzi per servitore, anzi per schiavo. Che dite, Signora? Fatelo, fatelo! tanto più che Camillo è ben nato ed è giovane di grandissima aspettazione.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>L'ingratitudine delli benefizii riceùti rende inabile l'uomo ingrato a riceverne degli altri. Io amava Camillo al paro della mia vita; ma poichè si è mostrato fraudolente e ingrato, l'odio a morte, e mi è caro sapere al presente che non è figlio di Alessandro, per aver tanto più occasione di scacciarlo di casa, come merita. Diteli che pigli altra strada, e farà meglio venirsene con esso voi nella patria vostra.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Ohimè? Che ha fatto Camillo? Camillo fu sempre grato, fu sempre fedele.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Non dite il vero, che fu ed è un traditore: fu perchè, fingendo con me dell'amorevole, ha amato Lavinia; e perchè a mal grado mio ha preso per moglie Lavinia, non vergognandosi di dire: Che Cornelia? Che Cornelia? Stimo più la scarpa di Lavinia che cento Cornelie.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ohimè!</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ohimè!</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Ohimè! Che doppia disgrazia è questa di Camillo, discacciato a torto e chiamato falsamente traditore!</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Sia come si voglia, io delibero maritarmi con Messer Manilio; il quale, ritrovandosi Flavio suo figliuolo, come si spera, lo darà ad Ersilia mia; e come il padregno di Lavinia sa che Camillo non è mio figliastro, guastarà il matrimonio, e così Camillo potrà tornare alla catena come merita.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Ohimè! Che son ferito con l'arme mie stesse.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Aiuto, Flavio, soccorri, che io non posso più resistere.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>E che posso fare, se sono aggiacciato? Ma non per questo voglio mancare al debito mio. Sappi, Signora, che questo Flavio è morto in Genova e noi portiamo la nova al padre. Cessando dunque il disegno fatto per voi di darlo a vostra figlia, vi vogliam dire un'altra cosa.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Dite quel che volete, pur che non mi ragionate più di Camillo.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Non ragionaremo più di Camillo, ma di un altro povero giovane che con Camillo abbiamo ritrovato, il quale si domanda Flaminio, che amando con tutto il cuore la Signora Ersilia vostra figlia, è stato da lei trattato male. Laonde come disperato era risoluto di uccidersi, se noi non l'avessimo impedito. Preghiamo dunque Vostra Signoria, e in virtù di amore scongiuriamo la Signora Ersilia, che vi muova a pietà il caso del vostro fidelissimo Flaminio: ve ne supplichiamo con le lagrime su gli occhi, sanate un che si muore, soccorrete un che si strugge, accettate un per marito che vi sarà servo e schiavo in perpetuo.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Dite a Flaminio che s'uccida a sua posta, che poco o nulla mi si dà della sua morte. Ma dall'altra parte, Signora madre, poi che avete preso marito, poichè Flavio è morto, poichè Camillo è l'anima mia, l'amore e la vita mia, perdonateli di grazia e comportate che sia mio marito: che se bene sin ora ho celato l'amor grande che li porto, voglio adesso estinguere il mio fuoco e ricompensare l'amore che similmente Camillo mi ha mostrato sempre. Fatelo, cara madre, fatelo, madre mia carissima.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Queste erano le lagrime? Questa era la compassione che avevi di Camillo? Per questo mi persuadevi? Per questo mi trattenevi? Tira via, fraschetta, lèvamiti dinanzi, non mi ragionar più di quel traditore. E voi, perchè v'odio come fratelli di Camillo, andate a mal viaggio, e dite a Camillo che a questa casa non osi accostarsici più.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ah Camillo, Camillo! Così si fa, Camillo? Dunque Ersilia è pur tua? Dunque Ersilia per te non m'ama?</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Per te Lavinia mi fugge, per te Lavinia m'odia? Parla, traditore, disturbator di nostra pace, parla! che dici?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>E che volete che io dica? Non vedete che tutte le stelle mi son congiurate contra? Uccidetemi, fatemi uscir una volta per sempre da tante pene, da tanti tormenti. Io disamato da chi m'amava, e per maggior pena amato da chi non voglio amare, e per maggior tormento riputato traditore da quelli che desidero servire, pensando di farmi bene ho fatto la mia rovina manifesta: e così mi trovo povero, discacciato, senza Cornelia, senza Ersilia, senza Lavinia e senza amici. O Fortuna, Fortuna, contra di te grido, contra di te inaspro. Saziati pure, saziati! Ohimè, ohimè ch'io moro!</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Cade morto? Ohimè! che faremo? A lasciarlo non conviene, e fermandosi la corte ci potrebbe cogliere così travestiti col morto appresso, non senza pericolo di nostra vita. Sento gente per strada, fuggiamo.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Via, fuggiamo.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 12</head>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Il vento non è così veloce come fu veloce Flaminio, che in un baleno disparve, e ben che ho cerco e ricerco per tutto, non si ritrova, nè trovo persona che l'abbia veduto. Ma ecco &lt;un&gt; corpo disteso in terra. Chi sarà costui? È schiavo. Morto non è, perchè non vi è sangue, nè ferita. Mi par che respiri. Oh, quel giovane! Si sarà imbriacato per certo. Ehlà! ehlà! Vuo' tirarli la barba, acciò si risenta più volontieri. Ohimè, la barba mi è venuta alle mani; ma vedo che è posticcia. Costui è Camillo! Egli è certissimo. Oh, Camillo, che strano accidente è questo?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Ed è pur vero? Ecco, apriche piagge, me ne pento se io t'uccido, sì. Non correre, olà. L'erbe fioriscono su l'onde, e tirando il carro solare non giunge la nave a tempo. Oh, quante stelle per le campagne! Soldati, non son io, no. Vien meco, tu che fuggi, passa, torna, tira, che io non ti lascio.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Ohimè, che fai? Dove mi meni? Non mi stracciare, lasciami, lasciami!</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Io vi sono, perchè saltando adesso i monti... Mirate la nave che bolle, e la luna s'uccide, il fonte il beve intorno intorno, e le lumache corrono. Che strani paesi! Ah, cruda, ah, cruda!</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Questo povero giovane smania, nè io so donde proceda. Non senti? Che hai, Camillo?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Sì, sì, ne andremo insieme, e gli uomini e le donne e le donne e gli uomini ridono tutti. Ah, ah, ah! Esso voleva menarmi e io gionsi all'inferno. Non sete all'ordine ancora? L'altro corse e io le diedi un schiaffo.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Ohimè, non mi dare. Mal per me ci venni qui oggi. Lasciami, di grazia.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Il padre pianse, si fabricò il palazzo, la tempesta fu breve e io non doveva farla, era bene a pregare il tempo. Ohimè! Dove ne vai? Io ti darò un calzo.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Oh, sventurata Bianchetta, che cosa è questa? Io son morta, dove mi tiri? Scappai pure! Santo Egidio, aiutami!</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Corri, corri, arriva, arriva, ti seguo, sì. Ehilà, che volete da me? Io mi vi rendo, posate l'arme. Ma dove sei, Camillo? Chi t'ha condotto qui? Dove sono gli amici? Ognun ti lascia. Che posso fare, abbandonato e solo?</p>
           </sp>
@@ -2560,1840 +2609,1840 @@
         <head>Atto III</head>
         <div type="scene">
           <head>Scena 1</head>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Mentre l'animo sta in duolo, or qua or là si rivolge e non sa dove appigliarsi, quando la ragion lo tira e all'una e all'altra parte, sì come oggi io provo. Misera Leonora! Infelice Brianda! Che vivendo Alessandro, secondo mi certifica l'astrologo, e sapendosi il luogo dove egli sta, la ragion vuole che io segua il primo e lasci l'ultimo, e di Leonora diventi Brianda. Ma come farò con Alberto, se sotto la mia fede si legò nella mia fede? Non è giusto che egli resti ingannato. L'amor del primo fu grande, che per me cadde a morte; l'amor dell'ultimo è pur grande, che non da moglie, ma da sua padrona mi tratta. A doi non si può servire: e servendosi all'uno, si manca all'altro. Che debbo, che posso, che mi convien di fare? Mancar a tutti non debbo; servir a tutti non posso; ingannar tutti non mi conviene. Se io repiglio Alessandro, come restarà Alberto? Se io resto con Alberto, che farà Alessandro? E se non faccio nè l'uno nè l'altro, come farò io? Deh! Che intrigo grande è questo! Soccorrimi, aiutami, Dio, che sperando in te, verrà da te l'aiuto e il soccorso mio. Adesso che ho tempo vuo' gir dalla Signora Quintilia e ritornar subito, acciò l'astrologo mi trovi in casa. Ma Pasquina non esce ancora. Io l'ho destata già, che dormiva qui a basso, e non viene. Pasquina?</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Signora.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Che fai? Perchè tardi tanto?</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Adesso, adesso, che mettevo l'aco al buco del filo. </p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Imbriaca che sei. Dall'altra parte quando considero come questo astrologo possa sapere le cose così per minuto, mi vien sospetto che costui non sia un di quei assassini che uccisero il sfortunato Alessandro. Alla fè, come egli torna starò ben all'erta, sì. Ancora dormi, Pasquina?</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Non dormo, ma tenevo serrati gli occhi, che viddi...</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Che cosa vedesti?</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Viddi un animaletto piccinino piccinino, e così piccinino entrò...</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>E dove entrò? Tu non rispondi? Pasquina?</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Signora.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Dubito che costei ancora sarà sul letto. Pasquina?</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Signora.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Vien fuora, dico, non ti vergogni a farmi star tanto in strada?</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>O Dio, quel animaletto era un pulce che entrò dentro lo, lo...</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Lo malanno che Dio ti dia: se io mi faccio dentro, ti batterò le pulci da senno. Pasquina?</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Signora.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>E pur Signora! Che fai? Perchè non esci?</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Dentro lo... dove s'appiccano li pendenti.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Che sì che ti romperò la testa, sonnacchiosa che sei, spìcciati, presto.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Eccomi: che commandate?</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Alla fè, che ti farò esser più solecita da qui innanzi. Averti bene che voglio che senti e salti, quando ti chiamo per mio servigio.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Così appunto, Signora, sì.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Tu par che dormi ancora: risvegliati, risvegliati, fraschetta.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Questo sonno è più fastidioso delle mosche, che quanto più lo scaccio, più ritorna.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>O&lt;r&gt;sù, fatti in qua, sostiemmi la mano: da quell'altro lato, sempliciotta. Non t'ho detto io mille volte che la serva deve andar a man sinistra alla padrona?</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>E che importa, più a questa banda che a quell'altra? In ogni modo si conosce nel resto, che voi sete la padrona e io la serva.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Importa, che alla creanza della serva si conosce quella della padrona. Andiamo, che al ritorno poi ti dirò per minuto che la serva deve esser anco discreta per strada, solecita in casa, obediente, che parli poco e opri assai; e sopra tutto che sia secreta, e non riporti quel che vede e quel che sente.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Oh, oh, perchè vi piacque che vi riportasse i secreti di Lavinia? Mi avedo che voi altre Signore sete come i pignattai, che mettete il manico dove voi volete.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Io non parlo, figlia, delle cose che importano all'onore: perchè in questo caso la serva è obligata a riferire quanto vede e quanto sente; ma parlo dell'altre cose che non toccano il vivo.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Aspetta. Quando io vi dissi che Margarita faceva l'amore con il padrone, e il padrone con lei, vi piacque pur di saperlo, e non importava all'onor vostro.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Importava all'anima, che importava più, per il peccato dell'adulterio che commetteva l'uno e l'altro.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Per la gelosia, devi dire, ed era meglio.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Per la gelosia, su! Parti che convenga che una serva facci l'amore con il padrone? Non vi è peggio morbo in una casa di quello, e tutte le donne devono provedere, come io providdi, a smorbar queste pesti, cacciandole via; perchè a poco a poco li mariti, allettati da loro, fanno star mal contente le povere mogli, e di serve divengono padrone, che non li puoi commandare; e mettono tante scisme e tanti disturbi tra mariti e mogli, che sono causa d'una vita inquietissima; e io ne so parecchie e parecchie donne che vivono mal contente per questo.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Al manco voi tenete ragione, che sete bella. Ma chi tien la moglie brutta par che sia scusato, quando si provede.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Se la moglie è brutta, è sempre più bella della puttana; poi che la bellezza consiste nell'animo e non nel corpo, figlia mia. Entriamo in casa della Signora Quintilia, già che parlando parlando vi siamo gionte. Batti l'uscio.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>L'uscio è aperto: entriamo.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 2</head>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Vanne pur, madre crudelissima, che così chiamar ti voglio, poi che godi delle mie pene, e opponendoti al giusto mio desiderio procuri la morte dell'unica tua figlia. Oh, tre e quattro volte misera che io sono! Amo, amar voglio, e amando desidero l'amor di colui che non si degna, ma si sdegna d'amarmi. Vendetta certo di Flavio, che amandomi con puro affetto, ho dispreggiato l'amor suo, e fui causa della disperazione e della morte, forse, di quel giovane infelice. Ma infelice son io più d'ogni altra, perchè, volendo, non posso morire, e morendo nelle speranze, vivo nelli tormenti: seguo chi mi fugge, e fuggo chi mi segue; vedo il meglio, m'appiglio al peggio, posso salire, e procuro il mio precipizio. Ahi dura legge di amore, contrarii effetti di sdegno, diversità d'odio e novi modi di gelosia! Questi, questi sono quelli che mi combattono insieme: Amore, Sdegno, Odio e Gelosia! Amor eccita il fuoco e s'allontana, Sdegno assale e fugge, Odio offende chi non deve, e Gelosia punge dove non duole. Non duole a Pasquina che il crudelaccio si sia ingelosito di lei! L'Odio non deve offender me, che l'amo. Sdegno, se ben permette che lo sdegni, fugge in un tratto e io ritorno ad amarlo. E in fine Amor, rappresentandomi l'oggetto così caro a gli occhi miei, allontanandosi da lui fa che l'ingrato m'odia. Dolente me! Che posso, che debbo fare, sola, senza anima, senza aiuto, senza consiglio, contro questi inimici contra di me potenti e contra gli altri deboli? M'indebolisce il dolore, non posso più dire.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 3</head>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Io saccio moto bene, Signor astrologo mio, ca Amore pretende de vendecarese contra de me pecchè mi chiamo Gialaise, avenno in odio chella consonanza <emph>ise</emph>, pe respietto d'Anchise, ca fece la scarsiel&lt;l&gt;a alla matre, e pe chisso se portò male co Cefise, Narcise, Parise, Silladise, Ciparise, Malagise, Marfise. Ma co lo Signore Gialaise no' farà nente, ca io te lo boglio scuzzoniare di buona manera, alla fè.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Se ben comprendo alla vostra fisonomia che avete un cuor di leone, e sete per riuscire d'ogni impresa, per difficile che fosse; nondimeno, considerando la potenza d'Amore, vi pronostico che fra pochi giorni vi sottometterete al suo imperio, come fece Cesare, Scipione e Pompeo e gli altri che furno pur nostri Romani.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Ma io no' songo delli Romani, ma se bene delli Napoletani, Cavalieri diverzi assai da chilli Cavalieri antichi, ca annavano alla buona, e perzò disse l'Ariosto: «Oh gran bontà de' cavalieri antichi!». Ma noi autri ca sapimo e vedimo co l'essere, co la forza e co lo 'ngegno, no' la cedemmo ad Apollo, Marte, nè allo altitonante Iove.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>L'importanza sta che Amore non combatte col sapere, potere e vedere, ma adopra arme contrarie a queste, come sono pazzia, odio e vanità; che non essendo egli altro che furore nelli petti nostri, inimico delle fatiche, amico delle cose vane, con le quali arme incende le vene, occupa le viscere e consuma il cuore.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>È troppo lo vero, per l'àrema delli muorti miei; e tu sì no bravo ommo, avennome 'nnovinato quanto tiengo allo stomaco, ca ped amore di Pasquina si sface dintro la zulfatara di Puzzuolo.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>E quel che è peggio, ti fa amar chi t'odia, e odiar chi t'ama.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Dà ccà la mano, ca te boglio essere scavottolo 'ncatenatissimo, poi che me tocchi l'osso pic&lt;c&gt;irillo, e me dai allo vivo. Ha da sapere Vostra Signoria ca io amo Pasquina, e issa m'odia; e fuggo poi Lavinia sua padrona, ca m'ama sprofondatamente.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Voi dite Lavinia, figlia di Leonora, che abita in questa casa?</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>A punto. Como diavolo sai chesso?</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p><foreign xml:lang="lat">Professionis gratia</foreign>. E ti dirò un'altra cosa, che questa Lavinia è amata da altri, ed ella li odia a morte.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Chesso è lo vero, ca secondo aggio 'nteso poco 'nante da issa proprio, nella strata, e aveva 'nteso chiù prima da Cuosemo, servitore meo, no cierto Flavio figlio di Manilio l'amava quanto se poteva amare, e issa non volendolo amare, se pose in desperazione e se n'andò alla guerra. Appriesso dopo l'ama no cierto Camillo, e issa pe lo contrario no' l'ama. Ben che mo 'ntienno ca singa tornato Flavio, e hanno fatto na cierta 'mbroglia, e Camillo e Flaminio. </p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Sentite, padrone! Ecco che Camillo ama altra donna che Cornelia: a poco a poco si dichiararà il vero.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Sì, ma tu non intendi quella cosa d'imbroglia: lascia far a me, che ne cavarò il costrutto.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>De ca cosa ragionate insieme secretamente? Lo boglio intennere, alla fè.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Io parlo, che voi dite Camillo figlio di Alessandro genovese, il quale già è morto.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Fusse muorto diece anni a reto! Ca sìngano mardetti quanti genovesi si trovano! </p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>E perchè tanto male? Che cosa vi ha fatto?</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Se isso no' veniva ccà, Camillo no' &lt;n&gt;ce saria benuto, e Pasquina non terria la parte sua, ca pe consequenzia me dà sospietto ca se amano 'nsieme, e io piglio palic&lt;c&gt;hi. </p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Di sorte che il padre ha da portar l'iniquità del figlio? Ah! non è giusto, Signor Giovan Luigi.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Ora lassamo no poco stare chissi cunti, ca io no' ped autro songo benuto a trovarete, avenno 'ntiso la fama tua, eccietto pe sapere ca fine averà l'amore mio co Pasquina, e sa ti fidi di faremela disonestare.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Adoprarò tutta l'arte, metterò ogni cura che restiate sodisfatto; ma vorrei prima intendere l'imbroglia che dite aver machinata Flavio, Camillo e Flaminio.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Se voi sapite on&lt;n&gt;e ncosa, como no' sapite chess'autra ancora?</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Io so che Camillo è innamorato di Cornelia.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>È lo vero, pe vita mia. Aspetta, aspetta, ca mo me n'allecordo.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Or sentiamo, che altro intoppo sarà questo.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Stannome a sguazzare co na Signora romana delle principalissime, spiai ca 'n cierte case rotte, &lt;l&gt;loco vicino, si travestivano da schiavi Camillo, Flavio e Flaminio. Camillo diceva ca essenno muorto Alessandro, quale veramente no' l'era padre, se boliva sfocare la fantasia co Cornelia, Flaminio co n'autra giovane, ch'have lo nome 'n <emph>lilia</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Ersilia volete dir voi.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Sì, sì, Ersilia. Ora mirate ca fa la virtute a&lt;s&gt;sapere on&lt;n&gt;e ncosa! E Flavio co Lavinia. Chesso è chillo ca intesi. Lo muodo non me curai d'intennerlo; pecchè 'n chello medesimo 'stante venne la detta Signora, e bracciannome dereto, e scoppannome docemente 'ncoppa lo lietto, le feci compotare <foreign xml:lang="lat">Luna quater latuit</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Ahimè, ahimè!</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Che fate, padrone? Venite in qua, di grazia, respirate. Che cosa avete? Dissimulate, non vi scoprite; volete credere alla dapocagine di costui, che secondo voi l'imboccate le parole così aggiunge e rigiunge a suo modo?</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Servo traditore, moglie infidele... Lasciatemi!</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Eh! Fermate, di grazia, dove volete andare? Che fede si può prestare alle parole di costui? Che se Camillo e Cornelia s'amassero, come voi presupponete, stando essi insieme, non averebbero bisogno di travestirsi, nè d'artificio, nè d'imbroglia, come dice questo vantatore.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Ohimè, Leandro, che io me lo vedo come in un specchio.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Ca dite di specchio? Lo boglio 'ntennere, alla fè.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Diciamo che dentro un specchio vi faremo venire la vostra Pasquina più bella che mai.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Aspetta, aspetta. Ecco ccà lo spiecchio, ca l'aggio intro la saccoc&lt;c&gt;ia: no' te tricare chiù, pe vita toia, fammela benire chella cornutiella; e poi se hai bisuogno di quarche favore a Napole, appriesso chilli reggienti, presidienti, e lo Vicerè, lascia far a me, ca te siervo alla coscia.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 4</head>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Bisogna aver cento braccia, dugento mani e quattro cento piedi per servir la padrona. Mi manda a vedere se venisse in casa lo strofilo o il strongolo, non me ricordo bene. Ma ohimè, ecco Gialaise! Vuo' passar pian piano per dietro le spal&lt;l&gt;e, e fermarmi in quel cantone sin che lui si parte.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Signor astrologo, io te bedo moto cogitabondo: ca dici? No' darai chesso gusto a chi prova di continuo l'amoroso disgusto?</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Averti, padrone, che quella figliuola che è passata di là credo certo sia Pasquina: dissimula, fingi, e vedi di dar la pastura a questo bufalo vestito di seta.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Lasciane a me il pensiero. Or tien così lo specchio, Signor Giovan Luigi, e mira bene chi è colei che sta dentro.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Oh, meracolo grandissimo! oh, vertute terribile! Chesta è Pasquina: è puro issa, Pasquina! oh, Pasquina! No' bole dicere autro, eccietto ca me passi ccà na spina. Abbracciami, baciami, vita mia, baciami, baciami.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>State saldo, Signor Giovan Luigi, guardatevi di voltarvi indietro, perchè si disfarebbe l'incanto e Pasquina ci disparrebbe per sempre.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Sì, se io fosse pacchiano come fu Orfeo, ca pe voltarese indietro perdè la sua Eurìdice, o Euridìce: non m'allecordo mo sa bole essere breve o longa; ma starò contemplando sempre chesso spiecchio, dove s'inserra quanta bellezza ha sotto e sopra l'uno e l'autro cuorno del Tauro, e la fanciulla di Titone.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Oh, che solenne bestione!</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Chesto è n'autro diavolo. Pasquina ride, e pare che se burle de me.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p><foreign xml:lang="lat">Bonum signum</foreign>: è segno di mitigazione, è segno di pace.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>O gioia mia bella, famme no segno di pace, e no' di guerra. Io me t'arrenno, me te do pe vinto, accostate, parlame, basciami, balsamo aromatizante. Ora chessa sì che è bella! Me fa le fiche: a che proposito? </p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Dinota che appresso le frondi ti darà li frutti, preziosissimi.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>S'abassa mo, e piglia na preta da terra.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Significa volersi inchinare alle tue voglie, e romper la durezza del suo cuore.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Alza pe dareme, e poi se retira.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Dimostra esserti stata crudele, e ora pentita si ritira.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Adesso torna a ridere, e pare ca co le cinabrissime labra me dica: bestia, bestia.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Eh, non Signore, se ben dice: ben mio, sta, ben mio, sta.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Oh, bene mio, sto! E se tu me prometti de stare, io staraggio tanto quanto piace a chessa faccia d'imperatrice. Oh, Pasquina, passi la quintidà, nardo spicato.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>O modello di tutte le sciocchezze e vanità del mondo!</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Aspetta no poco: sbatte mo lo pugno sopra la chianta della mano, e par che dica: schiatta, schiatta!</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Pesta li duri e crudelissimi suoi pensieri per farli molli e pietosi.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>«Pietà, Signora mia, pietà, Signora, - Dell'arma ca pe te s'affligge e accora»: e di' ca lo Petrarca faccia li vierzi accusì pronti come li faccio io.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>E di' che si trovi un altro sciocco come sei tu.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Adesso auza la gamba per dareme na ponta piede.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Denota che la bellezza sua sarà sollevata, accostandosi a voi.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Chesso ce lo prometto cierto, che la faraggio allo manco nobile de cinco quarte. O Pasquina, passi a lo quinto napoletano Sieggio!</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Oh, che passato possi essere per le picche! </p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Mira che atto è chillo; se congiunge le mani alla banda destra, e inchinando la testa alla sinistra pare ca se maravigli de me.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Dice che tosto vi giungerete insieme, e si maraviglia come Amore dolcemente l'aprirà il lato manco per voi.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Così proprio fece allo Petrarca: «Amor con la man destra il lato manco - M'aperse». O vita mia bellina, zuccarina, dolcina, mellina, mannina, Pasquina!</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>O guffone, bestione, cicalone, asinone, ignorantone!</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Ora chisso sì, ca è segno de crudele; m'ha dato no punio alle spalle, e sbattennose le mani vicino all'orecchie se n'è sfrattata vassa vassa dentro la casa, lassannome scuro chiù ca la pece negra.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Bellissima proprietà, del certo.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Ferma, Signor Giovan Luigi! Oh, che mirabil segreto: col dar del pugno ti risveglia; con le mani all'orecchie e coll'intrare in casa t'avisa che bisogna trasformarsi in quell'animale che ha l'orecchie così lunghe, e le sbatte in quel modo caminando così basso.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Ca, ca...? Trasformarse in un asino?!</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Di questa sorte sei per entrare: altramente non vi sarà garbo, perchè essendo serva, non averà altra commodità di questa.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Dunca, dunca, dunca...! No' me lo fare dicere, pe vita tua, ca 'n pensarevi solamente mi schiatta sso pormone. Dunca lo Signor Gialaise in un a...?</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>In un asino, Signor sì: lo voglio finir io, poichè voi lo lasciaste. Forse sete più di Giove, che non si sdegnò trasformarsi in tauro e in cigno per conseguir Europa e Leda?</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Ora mo sì, ca m'affoca lo cauzone. Vì ca nc'è differenzia, da chesso a chello, quanto dallo cielo alla terra.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>E che differenzia vi è? Non sono tutti animali?</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Songo animali troppo, ma songo animali chiù onesti ca non è l'aseno. No' borria ca se sapesse tale cosa a Napole pe la vita de tutti li muerti miei! </p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Mi fate ridere contra mia voglia, vedendo che incautamente preiudicate alla bontà de quel venerando. Volete veder se l'asino è buono? Che quando si vuol descrivere la bontà di un uomo, si dice: è tanto buono, che è un asino.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Hai troppo rascione, alla fè!</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Dall'altra banda io non voglio che attualmente vi trasformate in quell'animale. Ma fare una forma simile a lui, dentro la quale anderete voi, e intrando in casa di Pasquina senza sospetto delle genti, l'aprirete; restando voi l'istesso che sete al presente, goderete facilmente la vostra desiderata.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Aspetta, aspetta, ca mo m'allecordo qualmente Re Mida pure si trasforemò in n'aseno: de modo e de manera ca se l'ha fatto chello ca fu Re, lo puozzo fare ancora io, ca songo Cavaliero privato; tanto chiù di chessa sorte ca m'avite ditto voi, Signor astrolego mio. Ora suso, alle mani: facite la forma, ca mi trasformo. </p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Di grazia al tocco delle 24 ore verrete a trovarmi nel palazzo dove io sto, che trovarete ogni cosa in ordine.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>E io in chesso miezzo boglio ire a studiare Apuleio nell'<title>Asino aureo</title>, pe pigliare li giesti e lo muodo di como m'aggio a governare, ca persì a esser asino nce buole capitania.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Non molta con voi, perchè vi sete naturalmente.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Vaso la mano di Vostra Signoria, Signor astrologo mio: a rivederci, scavottolo vostro.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>A Dio, Signor Giovan Luigi.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Va pur con la malora, pallon di vento che sei.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 5</head>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Chi vidde mai, Leandro, un uomo così sciocco come costui? Crederà anco che è calda la neve e freddo il fuoco!</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Crederà in fine quanto voi volete; e io non mi maraviglio che questo sciocco si lascia cadere nelle reti, ma stupisco d'alcuni che fanno il quantunque, quali pur traboccano in simili girandole, e non si avertono che questi astrologi dall'altrui informazioni e da una certa osservanza di parole e di gesti nostri ci danno ad intendere con indovinare le cose, della maniera che avete fatto voi con il Napolitano, e non che sia così in effetto. Poichè intesi dire da mio padre, che era della professione: dove Dio pon la mano, ogni pensiero è vano.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>È vero circa le cose future, delle quali non è verità determinata, poi che le stelle inclinano, e non necessitano le cose di sopra; ma circa le cose passate, sappi che è propria virtù, e la scienzia è vera. Dall'altra parte, che ne vogliam far noi di queste cose, essendo altro l'intento nostro principale? Attendiamo dunque al fatto proprio, che è stolto colui che vede i fatti d'altrui, e si scorda de' suoi.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Sì, ma come faremo se il Napolitano ritorna a far istanza per la bestiale trasformazione?</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Non mancheranno occasioni per distorlo da questo proposito. Vedi, che io sento tentar l'uscio di casa. Averti di seguire quanto abbiamo determinato insieme, perchè bisogna che io vadi a ritrovar il Napolitano; essendomi messo in un soggetto maggior del primo, ed è mestiero che io me ne risolvi. Fa come ti dico; e ritorna nel palazzo solito, che t'aspetto con desiderio.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Aspettate, padrone, che io ho pensato meglio. Poi che sete certo che Brianda è vostra prima moglie, a che proposito servono tante esperienzie in persona di Cornelia? Procurate di riaver la prima, e vada Cornelia in buon ora. Overo facciasi il cambio: voi potrete ripigliar Brianda, e il marito di lei Cornelia.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>L'ingiuria di Cornelia e di Camillo è grandissima, fatta a tempo che non correvano queste cose, ma a tempo che io gli era marito, e perciò bisogna che io me ne vendichi. E se ben di ragione Brianda ritornerà ad esser mia moglie, non però disconverrebbe ad un mio pari che ingannasse Alberto, al quale, dovendosi restituire la più onesta donna di questo seculo, non saria giusto che io le dessi in cambio una &lt;in&gt; sospizion dell'onor suo. Dalla mia esperienzia ne risulterà una di due: o Cornelia sarà onesta, o no. Se sarà onesta, potrò liberamente trattar questo cambio; e se non sarà onesta, smorbarò almanco questa peste dal mondo, e senza infettarne quel gentiluomo, goderò la mia desiderata Brianda. Sì che sii essecutore, e non consigliero di quanto ho fermamente deliberato.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 6</head>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>È pur vero che gli uomini troppo savii cadono al spesso in gravi pericoli, come si vede l'esperienza in persona dell'accorto e savio mio padrone, caduto già nel profondo abisso della gelosia, in cui tanto più si precipita, quanto più tenta ritrarsene. Ed è vero ancora che questo male ti rode di sorte l'animo, che non vi resta altro, eccetto che un secco pensiero di pensar sempre novi pensieri, vane chimere e false imaginazioni. Mancava adesso il sospetto del Napolitano per far volare tanto più il cervello del padrone! Io pur cerco come creato amorevole e fedele di ritrarneli quanto posso, ma indarno m'affatico. Bisognarà che corra questa borasca, in sin che il vento della verità rassereni il cielo e acquieti il mare di tanti travagli. O mondo veramente mondo d'ogni bene! che è pur bene in te, ma non lo dai come a cosa propria, ma lo depositi per qualche giorno, togliendolo poi quando l'uomo pensa di vivere più sicuro. In te non si trova stabilità, nè fermezza alcuna: che a pena posto l'uomo in possesso d'una cosa, ce la togli subito; non così tosto ci fai gustare il dolce, che diffondi l'amaro. Al mezzo del piacere ci sturbi. Non finisce il riso, che interponi il pianto. Non passa giorno senza molestarci, e in fine ti giuochi di noi alla palla, che sbalzandoci più in alto, più ci abbassi. Misero è dunque colui che pone speranza in te, come è veramente misero e infelice il padrone, che sperando esser in grembo delle grazie, si ritrova oggi il più discontento del mondo. Mi ha commesso che io debbia persuadere alla moglie che essendo venuto un astrologo d'importanza in questa città, lo faccia venire in casa per pronosticare e vedere come passaranno le cose sue; e con questa occasione spera egli di scoprir paese e certificarsi del tutto. Dio voglia che sortischi in bene, perchè il fondamento che si fa sopra un mobile, convien che rovini. Vo' argir dall'altra porta, già che da questa veggo uscir Magagna, acciò non essendo veduto da gli altri, possa commodamente parlarli.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 7</head>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Talchè...</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Talchè con ragion mi doglio e posso dolere, che io sono la più scontenta tra le scontente giovani del mondo. Ahimè!</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Questo pianto è proprio come il fumo dell'arrosto, che non ti giova a niente, perchè ti bisogna venire al monasterio, al tuo marcio dispetto. Camina dunque, e lascia tanti “talchè”, se non vuoi che ti calchi con un calcacoppolo la coppola.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Eh, Magagna, il dolor non è perchè io vadi al monastero, ma perchè mi manda in quest'ora così sola, senza compagnia di donne. Poteva pur tardar insino a domani.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Signora no, perchè dice quel proverbio: il mal che tarda piglia vizio. Avertendosi la Signora che voi bestialmente sete innamorata di Camillo, farà bene a farvi passar di questa vita presente.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Come di questa vita presente? Dunque mi farà morire?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Oh, potta, che m'era scappata!</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Ritorniamo a casa; che se sarà così, mi contentarò volentieri, pur che mi conceda che avanti la mia morte possa vedere o parlare al mio dolcissimo Camillo, il quale dà lume a quest'occhi e dà spirito a queste labbra.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Tu ti pensi con le tue parole inzuccherate farmi tornare indietro, ma t'inganni, a fè. Camina pure, perchè la vita presente non s'intende di farti morire, ma di passarti di questa vita presente, cattiva e trista, che menavi, a vita onesta e santa, come sarà al monastero.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Eh, Magagna, non si cangia pensiero per cangiar loco. Quanto più m'allontano dal raggio del mio sole, tanto più crescerà in me il desiderio di scaldarmi al suo caldo. Io amo Camillo con zelo di matrimonio, e questo zelo è pur onesto e santo. Ma che cosa fai? </p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Mi accommodo questo pugnale, dubitando di qualche repentino assalto, perchè a colui che accompagna femine bisogna andar vigilante.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Sì che, essendo questo mio zelo così onesto... Ma che motivi son cotesti? </p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Mi metto in guardia, e provo come ho da investire e offender colui che per sorte ne volesse assaltare.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>E perciò sarà bene a ritornar a casa, che l'andar a quest'ora per queste strade sospette mi fa temere d'alcuno inconveniente.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Tu zappi nell'acqua, se pensi di ritornar indietro. Camina, e zitta.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Fammi questo piacere.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Non posso.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Beato te!</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Non voglio.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Per grazia.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Non mi piace.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Per amore.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Camina.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Per pietà, almeno.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Mica.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Oh, come sei crudele!</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Crudelissimo.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Che ferro ti cadde dalle mani? Dove mi meni?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Orsù, già che siamo al loco determinato, in questa parte rimota dove non saremo visti dalle genti, acconciati, Ersilia, e pazienzia.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Che pretendi di fare?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Di rompere...</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Che?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>... il stame...</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Che stame?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>... vitale...</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Che vitale? Che vuoi?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Voglio...</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Che cosa?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>... pertuggiare...</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Che?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>... il... Donne!</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Che donne?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Vuoi la palla mo? Acconciati, e zitta!</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Se pensi offendermi l'onor mio, morrò più presto.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Non voglio cotesto.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Ma che vuoi?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Entrare...</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Dove?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Al cuore!</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Di chi?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Sei stata mai uccisa, tu?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Io no.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Hai parlato con nessun altro, che fosse stato ucciso?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Nè anco: perchè?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Acciò ti fossi informata della strada per la quale si camina alla morte.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Ahimè! Mi avedo che mi vuoi far morire.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Penso di sì.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>E perchè, Magagna mio? E perchè tanta crudeltà?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Non ti bisogna più “mio” nè “crudeltà”; raccommandati l'alma, e finimola.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Io morire? Io morire per le mani tue, Magagna, e perchè? Che t'ho fatto io? Qual cagion ti move? Qual ragion hai?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Risolviti presto; e dimmi come vuoi che ti uccida: sotto, da mezzo, o di sopra? </p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Se non burli, Magagna, come è tuo costume, dimmi il vero; che cosa ti spinge a volermi uccidere? Io so che non ti offesi mai, anzi ti ho giovato sempre. Da te come da te, non hai cagione di farlo. La Signora, se bene è matrigna, e non madre, non sarà. Camillo mio nè anco.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>A che fine lo vuoi sapere, se a te non serve più di sapere le cose di questo mondo, avendo da passare all'altro? Acconciati, su, cala la testa, e a perdonare.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Deh! ferma, di grazia, fermati, per cortesia, Magagna!</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Son sordo.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Una parola.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Non sento.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Sei turco? Sei barbaro?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Turco e barbaro! Levati, che ti do.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Eh! per vita tua, te ne prego, te ne supplico: ascolta una parola.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Or di' presto, che non vorrei che col tardare si raffreddasse il caldo del mio furore.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Dimmi, di grazia: chi t'ha ordinato che mi uccidi?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Pur siamo al medesimo. Or leva, e non più parola.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>È stata la Signora, Magagna?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Non so.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>È stato Camillo mio, che sdegnato forse dell'indebite ingiurie dateli per Cornelia, e d'averlo scacciato di casa, cominciarà a vendicarsi contra di me?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Non so.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Se sarà così, morrò contentissima, morendo in sodisfazion di colui, che per satisfarlo mi sarebbe poco pigliar mille morti per amor suo.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Vuoi altro che questo? Acconciati, e spedimola. </p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Fammi un'altra grazia, Magagna mio: legami le mani e li piedi a questa colonna mezza rovinata, e ritorna a chiamar Camillo; acciò lo possa pregare che mi uccida di sua propria mano, per morir contentissima, o almeno che io veda quegli occhi suavi prima ch'io muoia.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Quietati, che non è Camillo che ti fa morire; ma per dirla in breve, la Signora Cornelia è causa che, amando più che la vita sua Camillo, ella disegnava pigliarselo per marito, e tu avendoli guastato il giuoco per le mani, ti darà scacco matto di pedina.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>E io morrò per questo? Ah, Cornelia, Cornelia, che non da matrigna, ma da propria madre t'ho servita e onorata sempre, s'era tale il tuo disegno, me lo dovevi dire: che tu contenta e io contentissima restava in un tratto, bastandomi solo il mio Camillo nell'istessa casa, dove se non come marito, l'averei almeno come Signore servito. Ahi, che è vero, che nessuna matrigna fu buona!</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Orsù, non più parole. Fermati, che io alzo.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Aspetta un poco, per pietà, insin che dichi due altre parole.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Ma siano brevi, e presto, che io in tanto passeggio.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>In che orrendo spettacolo ti vedi, Ersilia infelicissima! Oh, cara mia madre, s'ora mi vedessi! E o Alonso, mio carissimo padre, dove sei? Che ricasandoti con Cornelia, morendo poi mi lasciasti piccola, raccommandata tanto a questa crudel Medea! Vedi, vedi che ora mi fa condurre al macello, e in man di chi? in man d'un vilissimo servo! Deh, spietata mia sorte, poi che volesti che io morisse di mala morte, dovevi far almeno che io morisse o per man del mio Camillo, o d'altri della qualità mia. Giorno infelice, che io nacqui! Perchè non mi affogai nella culla, poi che per amor io moro? Nè perchè mora mi doglio, ma perchè ferendosi questo petto s'offenderà la bell'imagine del mio bellissimo Camillo, che vivamente vi sta impressa. Perdonami, Camillo, se per me pati questa offesa, e ti prego a ricordarti che quanto maggiormente si puote amar, t'ho amato io.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Troppo sei lunga, non accade più aspettare. Io mi risolvo in ogni modo di darti.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Deh, Magagna, che crudeltà è questa? Che ti ho fatto io? Ricordati pure che tu eri servo di mia madre, pensa all'affezion grande che ti portava mio padre, considera che tu m'hai cresciuta sopra coteste braccia: e ora sarai omicidiale quasi di te stesso, quasi del tuo sangue?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>È troppo il vero, ahimè!</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Non sai che sempre t'ho sovenuto? Non ti ricordi che ti ho difensato? Chi riparava a' tuoi danni, se non io? La borsa non ti fu sempre aperta? Che m'hai cerco, che non ti ho dato? Insino alle camicie ti ho conce di mia mano.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>È troppo il vero. Uh, uh, uh!</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Io ti facevo magnar per tempo, ti serbavo anco le reliquie della tavola, ti ho riputato da fratello, ti ho amato da sorella: e ora tu che dovevi essere il riparo della mia vita, il difensore della mia persona, hai animo di uccidere me, povera innocente, infelice pupilla? Ahimè! come non piangi per compassione?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Non pianger più, che mi tiri l'anima dall'antiporta del cuore! Io me ne pento. Ecco qua il pugnale, uccidimi tu, perchè il torto è mio, la ragione è tua; overo mettiamo mano al rimedio per salvar l'uno e l'altro.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Il rimedio è facile. Lasciami andare, ch'io ti prometto partirmi di qua, con proposito di non ritornarvi mai più.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Aspetta, pensa, e poi fa, dice il proverbio. Come faremo, che io mi trovo promesso alla Signora di portarli la vostra testa con li vestiti insanguinati? E se io non esequisco a punto quanto mi ha detto, oltre il pericolo d'esser cacciato, perdo l'occasione di copularmi con essa. Perchè, per dirla, s'era appuntato fra di noi che uccisa Ersilia, io, arso per amarla, entravo al suo arsenale, cioè che me la pigliavo per mogliera.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Or lascia fare a me. Non conosci tu quel sarto che pratica di continuo in casa, ed era tanto amico della buona memoria di mio padre?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Conosco.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Costui tiene un figliuolo che scolpe al naturale. Andremo a casa sua, e con bell'arte faremo accommodare una testa che rassomigli naturalmente alla mia, con la quale e con le mie vesti insanguinate mostrarai alla Signora di avermi uccisa; che li bastarà solamente di veder quella testa, e poi la nasconderai dove ti piacerà. E io dall'altro canto mi vestirò da uomo tingendomi il volto e le mani da moro per non esser conosciuta. E così tu averai l'intento tuo, e io ancora il mio; perchè sotto quell'abito finto cercarò di servire e di seguire dovunque andrà il mio dolcissimo Camillo.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Buona, buona! Mi piace, a fè. Il negozio è riuscibile. Andiamo in casa del sarto; e acciò non siamo conosciuti per strada, alzati la veste, levati questo manto, mettiti la berretta e la cappa mia; che io, mettendomi il tuo manto, parrò vedova sconsolata in veste negra, e voi Marfisa in abito succinto.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 8</head>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>In questo principio mi riesce il pensiero di Alessandro, che avendo io con bel modo persuaso la Signora Cornelia d'introdurli in casa l'astrologo, se n'è contentata di sorte che li par mill'anni di vederlo, e perciò mi manda all'infretta a chiamarlo. Ma che? Considero poi che molte imprese si perdono per negligenza, e molte per troppo diligenzia. Dicolo a fine che la gran diligenzia del mio padrone, spronata dall'acuto sprone della gelosia, gli farà perder l'onore, e forse la vita di più. Egli doveva starsi, e lasciar star questi capricci, da' quali non ne potrà evenir altro che danno, altro che vergogna. Perchè molte volte la donna si mette in via di far male con la guida de' nostri vani sospetti e dalla poca fede che mostriamo d'averle. Quanto a me, ho fatto l'offizio che dovevo fare, e per mia difesa bastarà di dir quel proverbio: attacca l'asino dove vuol il padrone. Dall'altra parte considero che Cornelia non è così sciocca nè così imprudente che alla voce non debba conoscere il marito: e perciò, s'alcuna cosa corresse tra essa e Camillo, non abbia da dissimulare e mostrar tutto il contrario, per farsi conoscer tale quale io la reputo. Ma dubito di no, perchè Alessandro dice di volersi mettere in bocca non so che palle piccole, per farsi balbuziente, e così fingerà la voce e la favella. Dubito anco che Cornelia da vero non sia innamorata di Camillo, poichè l'ho conosciuto a certi segni esteriori: che nominandolo divien pallida e sospira profondamente, pensando d'averlo discacciato; e quel che importa, tenta che ritorni in casa. Io preveggo una gran rovina, e vorrei star lontano, ma non posso, perchè bisogna servire a chi sono obligato. Pur nondimeno, gli avenimenti delle cose sono varii, e non si può far pieno giudizio. Chi sa che sarà? Voglio andare in ogni modo a condurlo, che, come si dice, le cose importanti l'aiuta Dio con li Santi.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 9</head>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Non posso comprendere, Bianchetta, a che fine hai voluto che io mi rivestisse da Camillo e lasciassi quei panni da sc&lt;h&gt;iavo, quali veramente mi si convenivano, poichè dalle fasce mi furon dati in sorte. Io godevo della mia risoluzione fatta già di partirmi da Roma, vestito con quell'abito molto conveniente alle mie pene, che per tant'anni m'han combattuto sempre, e tu m'hai tratto da quel pensiero senza dirmi la causa. Perchè?</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Nè anco io posso imaginarmi, Bianchetta, a che fine hai voluto che, spogliandomi da schiavo, mi rivestisse da Cosmo e ritornasse a servire il Napolitano, interrompendo il pensiero fatto per me di cercare luochi solitarii ed ermi, per non veder più, nè sentir la crudeltà che mi usa la crudelissima Lavinia.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Signor Camillo e Signor Flavio, sete giovani, e la gioventù non ha freno, ma vi lascia correre disordinatamente. Attaccatevi sempre a' consigli de' vecchi, se volete star bene. Queste che voi chiamate disgrazie, a rispetto dell'altre ch'abbiam patito noi povere vecchie, sono a punto come il piscio del gatto a una gran pioggia; e noi che patite l'abbiamo, avemo anco il rimedio: che sapete pur quel proverbio: vanne al patito, e non al medico. State dunque di buon animo, e lasciate fare a me, che alla fine la pratica vince. Io vorrei che qui fosse il Signor Flaminio, che sentisse anch'egli il mio disegno; ma si partì senza farmi motto.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Il Signor Flaminio, rivestito che s'ebbe secondo l'ordine vostro, vidde passar per strada non so che amico suo, e gli andò appresso, lasciandone detto che l'aspettassimo in questa strada. Ma poichè egli tarda, potrete incominciar pian piano a discoprire il disegno vostro.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Primieramente voi m'assicurate che Flaminio si contenta che io negozii a mio modo con Lavinia sua sorella?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Sicuramente; perchè oltre che ci siamo di novo confederati insieme, e stretta in una indissolubile amicizia, lo desiderava anch'egli, per esser il Signor Flavio della sua qualità, e che la ricerca poi per moglie; avenga che Lavinia non gli sia sorella, ma figlia alla sua madrigna.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Sia lodato Iddio! Mi piace certo, perchè se ben io faccio questa professione, non vorrei esser passata per ruffiana, a tempo che le parti non fossero d'accordo.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Saviamente, a fè! Or dite.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Non bisogna di dire, ma di fare. Rimettetevi qui dietro, che io vo' prima tentar Lavinia e vedere, che quando le mie persuasioni non bastaranno, la farò cadere con la sua lotta, e allora conoscerai, Signor Flavio, che è stato necessario vestirti da Cosmo. Appresso andarò da Cornelia, e conoscerai, Signor Camillo, che quanto ho fatto non è senza grandissimo misterio. Ma però desidero una cosa da voi.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Comandate.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Disponete.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Per mia rimunerazione, cedetemi quanto cavarò di sotto a Cornelia.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Di grazia.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Come voi volete.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>A rispetto poi di Flaminio, non vi correrà troppo manifattura, perchè, aggiustati i pesi tra voi e Cornelia, possiate dopo disporre Ersilia a condiscendere all'onesto suo desiderio.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Si farà senz'altro.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Dite benissimo.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Orsù, fermatevi, che io vado: e secondo il bisogno così vi accomandarete alle parole mie; e tenete per fermo che Bianchetta imbiancherà oggi con effetto il tinto de' vostri cuori.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Così speriamo.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Così confidiamo.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 10</head>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Io batterò l'uscio. E voi all'erta, perchè avemo una bella commodità per l'assenzia della madre, che l'ho vista già in casa della Signora Quintilia. Tic, toc, tic, toc.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Chi è? Chi batte?</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Son io, figlia mia senza peccato. Venite a basso, che vi ho da dir cose di grandissima importanza.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Aspettate pur, Bianchetta mia, che adesso vengo.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Quando le cose hanno buon principio, sta fatta la metà. Che dite, Signor Flavio?</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ahimè!</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Voi sospirate?</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Sospiro, perchè natura, facendola così bella, non la doveva far sì crudele.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Riposatevi, che col tempo e con la paglia si maturano le nespole. Ma olà, cheti, che già viene.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Che cercate, Bianchetta? Dite, di grazia, brevemente quanto avete da dire, perchè sto sola in casa, e non vorrei che la Signora madre mi cogliesse sola in porta.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Sarò breve; e così breve faccia Iddio la vostra ostinazione, e lunghi gli anni a voi e a chi v'ama con perfetto amore.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Se non m'avete a ragionar d'altro che d'amore, fate fine, e ritornate quando volete a casa vostra.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>E perchè? Sete voi di stucco? Voi sete pur di carne e d'ossa, così ben composta e formata dalla natura che a viva forza bisogna ch'ivi s'annidi Amor con arco e strali.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>L'amor mio è la risoluzion fatta di viver casta e vergine.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ecco nova invenzione di farmi affatto disperare.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Fermatevi, che Bianchetta saldarà ogni cosa.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Buona e perfetta risoluzion per certo; e non men di questa è l'altra, che io vi propongo, qual è il matrimonio.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Io già ho eletta la prima, e non mi curo dell'altra.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>La prima fu di maritarvi, e perciò amasti Camillo, e perciò Flavio amava voi.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Camillo non fu giamai amato da me; nè l'amo, nè l'amarò. Di Flavio non accade parlarmi, perchè merita di stare perpetuamente in galera, dove si trova al presente.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Ecco, Flavio, la mia innocenzia.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ecco, Camillo, la mia morte.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Soffrite, e sperate.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Una speranza mi resta, di non sperar più salute.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Se pensate ingannarmi, così vecchia come io sono, v'ingannate di lungo, Signora Lavinia mia. Io so molto bene quel che dianzi dicesti a quelli tre poveri schiavi, che eri maritata con Camillo, amato tanto da voi, desiderato anco dalla Signora madre.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>È vero che io dissi così, per levarmi dinanzi quei fastidiosi e importuni, e acciò lo scrivessero a Flavio, per farlo tanto più crepare di doglia, e principalmente per contentar mia madre. Ma la verità non fu così, nè tale è la volontà mia, avendo nell'animo altro che Camillo.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Ti ringrazio, tempo, che col tuo spazio discopri la verità.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ti disgrazio, tempo, che mai desti tempo a questa crudele di temperare la durezza sua.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Io non intendo ragionarti di Camillo, perchè per non sapersi chi è, donde viene, possiamo di lui far passaggio. Ma che dite di Flavio, giovane, bello, ricco e unico al padre? Che t'ha fatto quell'infelice, che lo strazii in tanti modi, che tenti di farlo morire?</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Se io pensava che tu m'avessi a ragionar di Flavio, non vi calavo a basso per tutto l'oro del mondo; e se non vuoi altro, a Dio.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ahimè!</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Ferma, scioccarella che sei, e pensa bene che questi capelli d'oro, queste ciglia d'ebano, queste guance di rose, queste labbia di coralli, questi denti di perle, questo collo di neve, questo petto di latte, diver&lt;r&gt;anno col tempo bianchi, bige, pallide, livide, nere, affumate e oscure. Anch'io, come sei tu, son stata bella; anch'io, come fai tu, feci la ritrosa, la rigida, la crudele; ma nell'ultimo fui vinta dall'umiltà grande, dal soffrir lungo e dal patir molto del mio gentilissimo amante: e avertita del mio errore, biastemai il tempo perso e la mia sorte, che non mi diede persona che m'avisasse di queste cose. Sì che prendi l'aviso, già che l'hai, e muta, muta pensiero, scioccarella che sei.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Oh, come dice bene!</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ma predica al deserto.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Soffri, e odi.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Dimmi un poco, Bianchetta, non ti son pur divenuti i capei bianchi, bige le ciglia, pallide le guance, livido il labro, neri i denti, affumato il collo e scurato il petto? Che m'importa dunque d'esser crudele o pietosa, se sarà tanto così come così? </p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Questo è un bel passo da sciogliere.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Se ben lo scioglie, non farà niente.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Importa, figlia mia, che non ti rendi ingrata alla natura, che ti creò bella, dotata di tante grazie, di questi tuoi doni, per esser pietosa e non crudele. Che s'altramente fosse, t'averebbe dato coda come a serpe, unghie come a grifone, veleno come a basilisco, piedi come a cavallo, bocca come a leone e denti come a cignale. Talchè dispensa meglio questi doni di natura, e muta, muta pensiero, semplicetta che sei.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>E non son ben dispensati, stando così senza maritarmi?</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Sariano ben dispensati, figlia mia, quando da principio ti fossi eletta questa strada, andando in monastero senza dar occasione d'ingannar le genti. Ma poichè sei rimasta nel seculo, è forza che ti mariti, e goderai il dolce nome di madre, il gusto soave de' figliuoli e il perpetuo contento del marito. </p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Quando ciò fosse, mi risolverei d'amar altro che Flavio.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Intendi?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Taci.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Che t'ha fatto quell'infelice? Forse non è bello come sei tu? Forse non è nobile come sei tu? E forse non t'ama più di nessun altro? Quanti guai ha patito, quante miserie ha scorse, e pate e scorre oggidì per amor tuo! Rompi, rompi la pietra di questo cuore, crudeletta che sei.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Orsù, Bianchetta mia, vinta dalle tue ragioni, mi risolvo...</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Di', figlia mia, di'.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Ad amare...</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>O Dio!</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Aspetta.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>...con tutto il cuore...</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Oh, se foss'io!</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Ferma.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>...colui il quale...</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ohimè!</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Perchè non seguitate? Avete pur detto che volete amare...</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Sì.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ma non Flavio.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Eh, senti.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Sete mutata di colore. Che cosa avete?</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Ahimè!</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Voi dite che volete amare con tutto il cuore...?</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Sì.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Colui il quale...?</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Sì.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>E questo qua... è Flavio?</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>No.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Non tel diss'io?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Oh, crudeltà!</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Ma chi è? Ditelo liberamente, che io vi prometto d'interporre l'aiuto e consiglio mio per farvi servigio. Dite dunque, chi è?</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>L'istesso...</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Senti.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ma non io.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Eh, sì.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Vedrai.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>L'istesso ch'io t'ho detto, cioè Flavio.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>No.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Fu vero?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Oh, gran pietà!</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Ma chi?</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>L'istesso che ho amato e amarò sempre, come voi sapete. Dico il mio Giovan Lui...</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ah, non potè finir <emph>gi</emph>, per la dolcezza che sente! Oh, cruda più che la tigre!</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Dunque volete cangiar questo per quello? Val più un pelo di Flavio che cento Giovan Luigi!</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Amor me l'impresse nell'animo, che nè lima d'altrui persuasioni, nè scarpello di maladicenza me lo scancellaranno mai dal cuore.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Orsù, poi che così vi piace, a me anco piace: state allegra, che vi servirò di modo tale che questa sera averete in casa il vostro Giovan Luigi.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Volesse Dio!</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Così sarà, e intenderete. Io so che egli non v'ama.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>È vero, il crudelaccio</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>E voi la crudelissima.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>E so, di più, che egli ama Pasquina.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>È vero.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>(Oh, che bel colpo da mastro, che farò!) Aprite ben l'orecchie. Io tengo strettissima amicizia con Cosmo, servitore del Napolitano. Non lo conoscete voi?</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Conosco.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Oh, se costui per buona sorte mi capitasse ora avanti, saria molto al proposito.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Va innanzi, Flavio.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Già mi mettevo in via.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Ma eccolo: oh, che buona fortuna!</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Tutt'oggi vado attorno, e nol posso trovare. In fine, quando si vuol un uomo, non si trova, e quando non si vuole non te lo puoi levar dinanzi. Vedrò se fosse colà.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Cosmo, oh, Cosmo. <stage>(Qui Pasquina viene in finestra, vede, e tace)</stage>.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Chi mi chiama? Oh, sei tu, Bianchetta? Vi è la Signora Lavinia ancora? Bascio le mani di Vostra Signoria.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Ben venga il mio Cosmo.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Mio? È troppo grazia, questa, che s'io fosse vostro non andarei così come vado.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Dico mio, che tu sarai il mio medico, se tu vorrai.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Così fosse servizio a Vostra Signoria di accettarmi, come io servirei volentieri per medico.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Or lasciamo questo, e intendi bene quel che si desidera da te. Tu sai già che il tuo padrone ama scioccamente Pasquina, e disama questo ritratto della bellezza del mondo, che l'ama con tanto amore.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>(Così nol sapesse!) Or dite.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Per condurlo qui in casa della Signora Lavinia, tu fingendo gli dirai che Pasquina è inchinata già alle sue voglie, e desidera che se ne venghi in forma di molinaro col sacco in spalla, come se venisse a pigliare il grano; e intrato, si rimetta dentro la prima camera terrena, dove trovarà nascosta Pasquina.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ben: che faremo per questo?</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Faremo così, che in luogo di Pasquina si riponerà nascosta lì dentro la Signora Lavinia; dove standosi al buio, credendosi il Napolitano far con Pasquina, farà con Lavinia. Intendi?</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Intendo; perchè no? Anzi vi prometto servire adesso adesso.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>E sarai rimunerato di così buono offizio.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Questo offizio veramente non è mio; ma sarò ruffiano a me stesso, per servire alla Signora Lavinia.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Ti ringrazio infinitamente: e se mai il Signor Giovan Luigi sarà mio marito, col quale zelo io lo desidero in casa, ti farò conoscere con effetto che sarai tu il padrone di quanto tengo.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>E perciò io mi conduco a servirla, che se fosse in altro modo, non mi ci cogliereste.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Orsù, le cose sono in rassetto, vattene sopra, Signora Lavinia, e mettetevi all'ordine, che fra poch'ore sarete sodisfatta.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Mi raccomando, e in man vostra ripongo l'onore e la vita mia.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Riposatevi, che sarete servita. Orsù che fai, che pensi, Flavio? La conclusione è fatta per gli ignoranti. Non intendi mo l'artifizio mio? Concludi, corri, va, mettiti l'ale, e trova un abito di molinaro, col sacco e barba posticcia, ed entra in luogo del Napolitano in quella camera, dove poi non si trovarà Giovan Luigi con Pasquina, nè Lavinia con Giovan Luigi, ma una coppia di voi felici amanti.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Sarei veramente felice quando entrassi come Flavio, e non come Giovan Luigi.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Pazzo che sei! Sai tu come diceva la buona memoria di mia madre? Come la donna dolcemente prova, lascia la strada vecchia per la nova. Intendetemi ancor voi, Signor Camillo.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Io vi intendo, vi ammiro, e stupisco del vostro mirabil artificio.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Orsù, io vado, e permetta il Cielo, Signor Camillo, ch'abbiamo insieme felicissimo successo.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Andate in buon ora, e speriamo amando. Ma che fia di noi, Bianchetta mia?</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Molto più che bene. Andiam di qua, che sento aprir la porta di Cornelia con molta furia; non vorrei che fossemo veduti insieme. Voltiam di là, e ritorniamo di nascosto.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 11</head>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Incauta e misera che io sono! Che faccio? Chi mi trasporta? A che fine son qui? Dove ne vado? Che penso? Che parlo? Non ho luogo, nè pensiero, nè parlar fermo: ogni luogo mi attrista, ogni pensiero m'annoia, ogni parlar m'affligge, s'io non veggio, s'io non penso, s'io non parlo di Camillo mio. Vorrei ire dove egli sta, pensar col suo pensiero, e parlar con esso lui, ma non posso, infelice me, che io stessa fui ministra del mio danno. Non lo doveva scacciare, non pensarli male, non parlarli sdegnosa. Sciocca Cornelia! Che volevi più? Lo spazio di tanti mesi che secretamente l'avevi amato s'era rinchiuso in un punto solo, che dicendo di sì a quei schiavi suoi fratelli, Camillo era pur tuo. È vero che ti giovava la morte di Alessandro, per aver più sicuro il giuoco; ma nol potevi esequire, dubitando che Camillo non ti fusse veramente figliastro. Ma poi che, insensata, fusti certa che non ti era niente, che egli ti amava, ti voleva, ti adorava, perchè l'odiasti, perchè lo lasciasti? Deh, misera! Ecco da un inconveniente seguir l'altro. Puote tanto in te lo sdegno, tanto la gelosia, che esponesti a morte Ersilia, quella povera figliuola, che al presente sarà stata uccisa: cose indegne non solo di te, ma di tutte le donne indegne. Nondimeno, che posso fare se Amore mi predomina, mi consiglia, mi scompiglia? Venga pur l'astrologo a sicurarmi che Camillo fia qui, che mi ama, che ritorni a casa, e muora Ersilia, muora il mondo, e muora io, che morrei felice, morendo in grazia di colui che ne gli occhi soli ha tutte le grazie sparse.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 12</head>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Eccola a punto che sta sola in porta, come noi vogliamo: fermati, che io vado.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Così farò: e voglia il Cielo che riesca il disegno nostro. Ma ricordatevi di non publicare che io sia innamorato di lei, nè ella di me, poi che il negozio passa ancora secreto.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Volete imparare alla gallina di ruspar, voi? Cheto, e senti. Oh, che pietà! Oh, che fallo ha commesso, morir senza causa? Povero giovane! Cornelia dolente, che farai, sentendo la sua morte?</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Ohimè! Bianchetta parla di morte, morir senza causa, e parla di giovane. Costei sarà del certo Ersilia. Misera me, siamo scoperti. </p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Mi scoppia il cuore pensando con qual pietà, con qual umiltà chiedeva aita e cercava soccorso. Deh! se in me fusse la forza come è l'animo, l'arei tratto da quel pericolo.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Vorrei fuggire, ma non so dove.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Deh, Signora Cornelia, sete qui? A tempo vi trovo, ma trovar non vi vorrei, dovendovi dir cose di tanto dispiacere. Giovane infelice!</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Bianchetta, tu piangi? Che cosa ti è successo? Parla, raffrena le lagrime.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>La giusta occasione che mi invita a piangere mi fa ingorgiar le parole, che non possono uscir dalle fauci. In che parte, ahimè, in che parte di Tartaria, ahimè!? Piangi ancor meco, misera Cornelia.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Tu vuoi ch'io pianga senza saper la causa del pianto?</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Non lo sai, no? Lo sai molto bene, ma fingi di non saperlo: era pur del sangue del tuo marito, e ti voleva tanto bene che non dovevi comportar la sua morte.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Che dici, Bianchetta?</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Dico che per un minimo sdegno non si doveva mandar a morire: dovevi aspettare, che il tempo avrebbe accommodato ogni cosa.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Ohimè! Sallo altro che tu, Bianchetta mia?</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>E chi altri volete che lo sappia? L'infelice non conosceva altri che me, a me si raccommandò con gli occhi pregni di lagrime, e diceva sospirando: “Aiutami, Cornelia, Cornelia mia, aiutami”.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Se mi ami, Bianchetta mia, come credo, taci e tieni secreto, e prendi da me quel che vuoi, che quanto è fatto è ben fatto.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Ben fatto dice, ohimè! Costei mostra saper la morte mia, e ne gioisce.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Ben fatto, ah? E che crudeltà è questa? È ben fatto a far morire...</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Morire.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>...un innocente?</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Nocente.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Come nocente! In che t'ha nociuto? Non t'ha sempre onorata? Non ti ha sempre amata?</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Amata!</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Dunque, perchè nocente?</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Perchè amava chi non doveva amare.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>O Dio! Che sento? Costei averà dato ordine di farmi uccidere, e si pensa sia esequito l'effetto. Così sarà. Parla di me certissimo, poi che dice: amava chi non doveva amare, cioè Lavinia.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Io non vi intendo, Signora Cornelia. Ditemi, non doveva amar voi?</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Sì.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Dunque ha fatto bene.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>No.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Come no?</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Non accade dir altro. Basta che s'ha meritato la morte.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Deh, Cornelia, non siate così crudele, lasciate la còlera, aiutate, soccorrete, che avete tempo di poter aiutare e soccorrere.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Come tempo? Dunque non è seguito l'effetto? Dunque ancor vive?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Non tel dissi, che era io?</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Vive, si raccommanda a voi, con animo di vivervi sempre soggetto.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Deh, Magagna! Magagna!</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Intendo già. Magagna era il traditore.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Dovevi esequir l'ordine mio, e non lasciarti pigliar a parole.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>La cosa è chiara.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Signora Cornelia, di chi parlate voi?</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>E tu di chi parli?</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Io parlo di quel povero carcerato.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Che? Magagna è carcerato? Ed Ersilia dove sta?</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Che Ersilia? Che Magagna? Che dite di Ersilia e di Magagna? Io dico di quell'infelice Camillo vicino a morte, se voi nol soccorrete ad un tratto.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Ohimè! Camillo? E dove sta Camillo mio?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Quel “mio” importa; o Amore, aiutami!</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Nel carcere, condannato a morte.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>A morte, ohimè! E perchè?</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Perchè il povero giovane, avendo inteso da non so che schiavi che Vostra Signoria l'aveva discacciato di casa, si mise in tanta disperazione, che scorrendo la città capitò in un luogo dove in quel punto era stato ammazzato un uomo; e sopravenendo la corte, e non trovando altro che lui, lo prese e menò in prigione. Egli, perchè stava nel caldo della sua disperazione, confessò averlo ucciso per assassino, e così è stato condannato alle forche. Al presente avertito dell'errore, e principalmente che il morire è una mala cosa, si duole, si macera e si consuma che morrà senza colpa e senza aiuto di nessuno. Io passando di là lo viddi, ed egli mi si buttò al collo con le braccia del cuore, non potendo con le mani, legate a torto da quei lacci; mi pregò strettamente che vi pregasse che l'aiutaste, poi che potete aiutarlo.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Deh, Camillo, Camillo, meritaresti la forca da senno, per la tua ingratitudine, per la tua infideltà. Non però, vinta dall'amor grande che io ti porto, voglio in ogni modo aiutarti. Ma che rimedio vi sarà, Bianchetta mia?</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Il rimedio sarà quella cosa per cui s'impastano tutte le cose. </p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Che? Non v'intendo.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>La pecunia.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Bastano cento scudi? </p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Credo di sì.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>E se non bastano, non mi curo di buttar via la robba, e appresso la vita. Dilli che stia di buon animo, che appresso mandarò il mio procuratore per aiutarlo con li denari e con la ragione che tiene, perchè non deve morire non avendo colpa.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Io mi ravivo tutto. Oh, come falliscono al spesso li giudizii nostri! </p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Signora mia, il pericolo sta nella tardanza, e perciò state contenta di dare a me il recapito, perchè dove comparisce il Marchese di Santa Croce, non servono li procuratori. </p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Dite bene. Aspettate, che vado a pigliar i denari.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Ecco due tordi ad un laccio. Che dite, Camillo? Non son io valorosa più dell'Amazone? Averemo denari freschi, speranze calde, e buona volontà.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Voi meritate un colosso a perpetua memoria d'un'opra così rilevata. Ma che faremo appresso?</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Fermati, metti l'ale, e poi vola, e vola pian piano, che chi camina pian piano tu sai che fa buon passo. Ma, olà, rimettetevi nel pagliarotto, che già torremo i tordi, per noi fatti tornesi.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Prendi, Bianchetta; torna presto, soccorri quel misero, che scampando uno, scamparai due vite, sostenute già da un palo, e dilli che io per troppo am... am... Ahimè!</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Ahimè, tramortì, cadde! Che farò? Cornelia! Cornelia!</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Tristo me! Vita mia, cuor mio, Cornelia cortesissima, che col pensiero di salvarmi, ne morrai tu degna di viver sempre. Lascia i rispetti, dispetti e sospetti, che vengo, alma beata e hella, per seguirti ovunque ne andrai. Deh, sorte inimica, per brevi punti amica, torna, ti prego, a pacificarti meco con uccidermi tosto, acciò morendo insieme possa dir con ragione: «Dolce mi fu mentre la vidi in terra, - or che fia dunque a rivederla in cielo?»</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Camillo!</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Cornelia!</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Camillo mio, sei qui?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Cornelia mia, sei viva?</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Viva, per viver sempre a te, che sei la vita mia. E tu, come sei vivo, s'io t'avevo già per morto?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Non potrò mai morire, mentre sarai tu viva, perchè sempre m'avivi col tuo vivace affetto.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Entra, che poi diremo tutte le cose a pieno.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Ite a goder, amanti, che io stipo i contanti.</p>
           </sp>
@@ -4403,1646 +4452,1646 @@
         <head>Atto IV</head>
         <div type="scene">
           <head>Scena 1</head>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Prima che io vadi nella camera terrena, dove starò aspettando il sole di questi occhi miei, son risoluta di venire in porta per vedere se mia madre o altri sopravenisse; ma poichè nessuno vedo, vado più sicura nel campo dove Amor dolcemente mi mena. Ma ahimè! Chi mi assale e pretende? Chi mi lega e ritiene? Che gelo è questo che mi va per l'ossa? E chi mi vieta che non vadi? Mi avedo, misera, che Amor e Onor contendono insieme. Amor consente, Onor dissente; Amor invia, Onor disvia; Amor accende, Onor aggiaccia; Amor permette, Onor vieta, che io non vadi. Ahi! che tra 'l sì e 'l no, tra male e bene, tra fuoco e giaccio, e tra senso e ragione, finalmente mi trovo. So che se dal fuggir Giovan Luigi che mi fugge, e non lasciar Flavio che mi segue, è male l'amor di quello, sta bene l'amor di questo. Il fuoco dell'uno non arde, il giaccio dell'altro riscalda. Il senso mi distoglie, e la ragion mi raffrena. Non so che mi fare. Aiutami, Cielo, che in te sperando spero, e se ben vado, farai che resti salvo l'onor mio, e che io rispondi all'amor di colui che di ragione deve esser amato.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 2</head>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ecco pur, cieco e semplice Flavio, che inavedutamente corri alla tua morte, a guisa di cieca e sempliciotta farfalla, che vaga del lume, suol volar su gli occhi altrui, che fastidito nell'ultimo da gli importuni assalti, l'uccide. Così tu, misero, per godere il lume del tuo vivo sole non t'avedi che Lavinia fastidita al fine della tua importunità, e maggiormente da quest'abito che porti a dosso, ti cacciarà via; e tu vinto dal profondo dolore ne morrai del certo; e del certo ne morrò. Infelice me, non tanto per causa del mio danno, quanto per il dispiacere che si prenderà la mia crudelissima nemica! Ma poi che Amor mi ha posto come segno a strale, è forza che io mi espona a quest'altro pericolo; che se bene l'uomo misero non crede a gran speranza, dopo la notte ne viene il giorno, appresso il torbido il sereno: e in fine, che non può far un cuor continuo amando? Entrarò pure.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 3</head>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Così si fanno le belle burle! Camillo si credeva d'aver colto il pero, ma io glie l'ho tratto dalle mani. Come lo viddi entrare in camera con la Signora madre, pensai subito alle triste miserie, che se ben son figliuolo, nacqui con li denti in bocca, e m'avverto d'ogni cosa. Càncaro, che dolci bascini si davano l'un l'altro! E allora pian piano volevano serrar l'uscio, ma mi misi a piangere e gridar forte, in tanto che la Signora uscì fuora, per saper la causa del mio pianto. Ma io tutto malizioso piangendo, fuggendo, ed ella appresso, mi ridussi sotto la cantina, dove presto presto gettai un sasso nella cisterna, e poi subito con un salto passai da quell'altra porta, lasciando mia madre gridando: “figlio mio, che sei caduto nel pozzo!” E facendomi sopra di novo, serrai destro destro la camera dove stava Camillo disteso sul letto: io lo serrai con questa chiave che porto meco. Adesso che il merlo è in gabbia, non potrà entrare in selva, e mi risolvo di riferir il tutto a quell'uomo che trovai con Leandro, perchè mi parlò un'altra volta in piazza, promettendomi un cappello con le piume e mill'altre cose, pur che io le dicessi quanto si fa in casa. Alla fè, ora che sta sotto le reti li voglio schiacciare il capo, e io averò il cappello con le piume bianche, e mia madre possa perder l'anche.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 4</head>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Oh che bel colpo! In un taglio troncarò doi rami, la superbia di Lavinia e l'importunità di Giovan Luigi. Quella impararà non batter più le serve, e questo di non travagliar le donne da bene. Così pate chi prosume troppo, così merita chi disturba i fatti altrui. La vecchia traditora ha ordito la bella tela, ma io gli ho rotto il subbio nelle mani, di modo che non lo potrà più avolgere. Intesi già tutto il concerto allora, quando mi trovai a tempo in la finestra: che ora ho messo il cardine su la porta della camera, dove prima era entrata Lavinia in loco mio e dove appresso è entrato il gentil molinaro, di modo che non potranno uscir fuora mentre che io vado a chiamar la madre, il padregno e il fratello, per far castigar l'uno e l'altro. Dice ben quel proverbio di messer Alberto: chi noce altrui, paga con il tempo i falli sui. Vado di qua, che la strada è più corta.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 5</head>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Tu sai, Magagna, che da corsaro a corsaro non si perde altro che li barili; e per ciò t'inganni se pensi passarla con le burle, a non farmi vedere quel che porti sotto. Anzi, quanto più ricusi, tanto più mi inciti a saperlo. Risolviti dunque, e lasciami vedere, poi che l'animo mi predice non so che.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Non è niente, non importa niente a Vostra Signoria. Per l'anima di Marella mia figlia, son certe cose, come a dire certe coselle di femine; e sapete che le femine voglion le cose coperte, servendosi di quel proverbio: a latte coperto non vi cadeno mosche.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Parole! Son risoluto già, non ti credo. Leva via quella cappa. Che hai? Che porti sotto?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Aspetta, Signor Flaminio. Vedi, che non s'assaltano così gli uomini da bene in strada; vedi, che in Roma si fa la giustizia. Vedi, che te ne potrai pentire. Vedi tu, vedi che io... Vedi, che io mi farò sentire. Vedi, che tu hai che perdere, che se ben io son povero e tu sei ricco, la giustizia val per tutti.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Vedi che io ti romparò la testa, se mi replichi, forfantone che sei! Levati di là, passa di qua! Scopri, lascia che io veda.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>L'uomo incappa sempre dove non vuole. Orsù, facciamo conto che l'avessi veduta. Che ti gioverà a veder li fatti d'altri? Lasciami andar, di grazia, che sarà meglio per te.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>In somma, è perduta la cortesia che s'usa con villani. Vederò da me stesso che fardello hai sotto. Queste son vesti di lutto, e mi paiono quelle della Signora Ersilia. Come stanno così bagnate? Ohimè! Le mani me si tingono di sangue: che sangue è questo?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Signor, è sangue... è sangue, Signore. E così, per buona sorte è sangue.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Io so molto bene che è sangue. Ma di chi? E donde è causato?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>È causato, <foreign xml:lang="lat">verbi gratia</foreign>, io... tu... perchè... avendo... il quale... Ahimè! non so che dire.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Tu non mi darai più la burla, scuopri via, scuopri via! Tu tremi? Che bacile è questo? Ohimè! tristo me! sconsolato me! Che veggio? Questo è il capo di Ersilia mia! Ed è pur esso, meschino me! Che cosa è questa? Chi mi t'ha tolto? Chi t'ha separato da quel bellissimo corpo, anima mia? Ersilia mia cara! Magagna traditore, che tradimento è questo? Chi l'ha uccisa?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Quello che è spirto, e sparte, e sponta, e sprezza, e spezza.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Deh, vita mia! Tu viva e crudele causavi la mia dolce morte, adesso morta e dispettosa cagioni l'amara vita mia; allora desiderando di vivere e sperando che col tempo si riscaldasse il tuo giaccio, ma ora che fredda ti tocco, vorrei morire e non posso. Anima bella, so che sei in parte dove discopri il vero: tu già discopri che mi fosti spietata, che io soffriva amando, e che pietà e non vendetta cerco. Chi dunque si vendica di te, s'io ero l'offeso, e ti pregai sempre la vita? Chi mi t'ha morta, o vita mia? Come vive chi è stato causa della tua morte? E tu, boia infame, perchè l'uccidesti? Dimmi, e dammi conto del perduto mio bene.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Parla onesto, Signor Flaminio, che io non sono nè boia, nè infame, ma gentiluomo come tutti gli altri gentiluomini, se bene mi vedi così misero per mia volontà: e s'altri pretendono di esser nobili di quarti, io son nobile di tùmolo, che importa più. E senti la ragione.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Non mi curo di sentirla. Ma dimmi l'origine, l'autore, l'esecutore d'un fatto così empio, così scelerato,</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>L'origine della casa mia, qual è Stoppiello, principiò in Magagna Stoppiello seniore. Da Magagna nascè Muccio, e si fece un quarto. Da Muccio venne Stuccio, e furon tre Stoppielli. Stuccio generò Succimuccio, ed eccoti un mezzetto. A Succimuccio successe Miccio, e sono cinque Stoppielli. Miccio sfoderò Sticcio, ed ecco tre quarti. Da Sticcio uscì Cacamiccio, e avemo sette Stop&lt;p&gt;ielli. Cacamiccio cacò me, ed eccoti un tùmolo. Ora vedi mo se allo Regno di Napoli ci è una casa così principale come è la mia.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Sia come si voglia! Io pretendo solamente sapere chi è stato il crudele che uccise Ersilia.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Anzi il Petrarca ne fa menzione di questa casata, quando disse: «Giunto Alessandro alla famosa tomba...»: tomba, cioè tùmolo.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Or poichè non mi vuoi dire il vero, e te ne stai burlando a tempo che il caso è lagrimevole, e il luogo così publico nol ricercano, intendo partirmi e portar meco questa reliquia, acciò possa farti castigare dalla giustizia: che se ben io avevo determinato vendicarmi con questa spada, non però pretendo saper primieramente li complici e fautori.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Ah, ah, ah, ah!</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Tu te ne ridi? E perchè?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Come non vuoi che io rida, se io ti vedo far proprio come fa il cocodrillo?</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Io non t'intendo.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Il cocodrillo dopo aver ammazzato l'uomo, se lo mette a piangere.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Lo so, ma nè anco t'intendo.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Ah, ah, ah! Ora mi è sovenuto un garbuglio grande per ricuperar la testa, e per levarmi dinanzi Camillo.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Con chi parli? Perchè ridi? Che dicesti di Camillo?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Camillo e tu sarete molto ben castigati: e a questo fine io portavo copertamente le vesti e il capo d'Ersilia al Governatore, per farvi castigare e punire come omicidiarii delle povere femine, che prima le uccidete, e poi le state a piangere.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Che sento? Che dici? Camillo dunque l'ha uccisa?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Camillo e tu, uomini da bene che sete! Bell'onore vi avete acquistato in uccidere questa povera figliuola, che era un pane di zuccaro, una semplice colomba, e una donna senza fele.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Di me, non dici il vero. Dubito d'alcun inganno di quel traditore e fraudolente di Camillo. Dimmi, di grazia, tutto il successo per minuto.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Vedendosi Camillo discacciato dalla Signora per conto d'Ersilia, e tu sdegnato che non t'amava, sete venuti insieme questa mattina travestiti in casa e, crudelmente troncandoli prima il capo, l'avete poi percossa con più ferite. Ahimè! Che in pensarci mi si schianta il cuore.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Eri tu allora in casa?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Era, troppo: ma che potevo fare, io solo, servitore e vecchio, contra di doi padroni e giovani? Tanto più che la Signora Cornelia dormiva.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>E conosceste me chiaramente?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Quanto a te non troppo bene, per rispetto del pappafico che avevi in faccia. Ma Camillo, stando scoperto, lo conobbi chiaramente.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Dunque dici affermativamente che son stato io?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Perchè Camillo diceva: «dàlli, dàlli, Flaminio, beviamoci il sangue di questa crudele». Ed ella sfortunata non potè dir altro, eccetto: «e tu ancora, Flaminio? Ah! Flaminio, e tu ancora?», quasi volesse dire: che t'ho fatto io? Perchè m'uccidi, Flaminio?</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Oh, gran tradimento! oh, traditor crudele! oh, fatto degno di mille vendette! Innocente fanciulla! Io vendicarò la tua morte sopra dell'empio omicida e del compagno ancora, qual credo sia stato Flavio, poi che insieme si partirno, non curandosi di me. Io crepo di rabbia. Non posso contenermi. Vo' partir di qua. Ecco, Magagna, il capo. Vattene a casa. Conservalo in mio nome, che senza cercar giustizia saranno molto ben puniti, quei traditori infami.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Perdonami, Signor mio. Confesso aver errato, perchè in nominarmi Flavio mi son ricordato di quel vigliacco di Camillo che diceva: «dàlli, dàlli, Flavio», e non «Flaminio»; la somiglianza delli nomi me t'ha fatto incolpare a torto. Orsù, conoscendo che farai subito l'effetto contra quei forfanti, mi risolvo andar in casa, e communicando il tutto con la Signora, son certo che li piacerà la determinazione di Vostra Signoria. Mi raccommando, con avertirli che quel che si ha da fare si faccia presto.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Vanne pure, che io vagando con l'intelletto non posso aver luogo stabile.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Buona è venuta, a fè! Chi scampa un'ora, cent'anni vive. Io ne ho scampato una, e farò campare poco l'altro. Intrarò da questa porta, già che da quella strada veggo venir non so chi.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 6</head>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Poichè Cornelia è perfida e crudele, dirò che ognuno è perfido e crudele. Io credevo fermamente che l'amor suo fusse vero e che avesse di me pietà: ma fu finto l'amore, fu cruda quella pietà. Ella m'introdusse bellamente in camera; ma uscendone poi, mi serrò dentro, con animo senza dubio di farmi uccidere, come ha fatto della povera Ersilia. Ma Dio, che spesso gl'innocenti aiuta, mi misse in cuore che io calasse dalla finestra, la quale se ben è alta, mi son pur salvato illeso. Onde ella, ritornando con gli assassini, restarà col suo inganno ingannata. Ma chi è quel giovinetto moro, che timido e sospeso se ne vien di là?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Le pene mi son care e li martirii mi son dolci per te, caro e dolce mio bene. Ma... eccolo, sbigottito e pauroso! Ohimè! tremo e temo. M'accostarò pure, già che tutte le nubi non possono coprire il sole delle sue bellezze, e fingerò con bel modo andar dalla lunga. In fine Roma è bella, Roma è buona, ma per me non suona. A Dio, quel Cavaliero.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>A Dio, quel giovinetto.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Godo almeno d'un saluto furtivo.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Che cerchi? Che pretendi? Perchè ti volgi in là?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Cerco mia ventura, pretendo mercede, e mi volgo, conoscendomi indegno della presenza vostra.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Queste parole non son mica da schiavo. Sei nato in Roma?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>In Roma.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Sei schiavo, o libero?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Libero per nascimento, ma schiavo per volontà.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>E di chi?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>D'un Cavalier come voi, a chi ho servito e servo con tutto il cuore; e l'ingrato mi nega la mercede del servito.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Son veramente parti indegne di Cavaliero, e in Roma non si usa questa tirannide.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>E per ciò son disgraziato, che fuor d'ogni costume a me si ristringe quel che a gli altri è largo.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Ahimè!</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Che cosa avete, Signore?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Vorrei esser servo come sei tu, e non servo come son io.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Al contrario; e io vorrei esser come voi, e non servo come son io.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Basta, non accade trattar teco queste parole. Va con Dio, figlio mio, va.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>E dove volete che io vada, avendo ritrovato quel che andavo cercando? L'aria di Vostra Signoria mi piace tanto che, volendo, vi vorrei servire, sperando d'esser sodisfatto per l'avenire, se non ho potuto per il passato.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Vanne pure, che io ho altri pensieri nel capo.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>E io son qui per levarvi ogni pensiero, sicuro che conoscendo il mio servizio, ne restarete contento per sempre. Ma dove andate?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Dove mi piace. Che ne vuoi saper tu?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Vuo' saperlo, perchè vi sarò sempre appresso come servo, che volontariamente mi vi dono.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Ti ringrazio di questa buona volontà. Procacciati d'altro padrone, che io non ho bisogno di servo. E pur mi sei dietro. Vattene, dico.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Non posso.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Oh, questa sarà bella! Che vuoi?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Servirvi.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>A me non serve il tuo servire.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>E a me giova che io vi servi.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Se tu non mi lasci, mi farai uscir del manico.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Fate come volete.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Tira via, fraschetta, non mi rompere il capo. E pur mi segui? Or prendi questo calcio. Vattene in malora.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>E questo ancora sopporto pazientemente; e a guisa di fedel cagna, che pur battuta ritorna al suo padrone, così ritorno a voi.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>L'amorevolezza di costui mi sforza ad ascoltarlo, con tutto che mi trovo travagliato di mente. Dimmi, giovane, chi è quel tuo padrone?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Non sta molto lontan di qua.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Dunque abita in questa strada?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Qui dimora.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Come si domanda?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Camillo.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Camillo di chi?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Camillo della mia morte.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Mira che strano cognome.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Più strani sono li fatti.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Per che causa non pretende pagarti?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Per mia disgrazia, e per sua crudeltà.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Tiene il torto per certo.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Il medemo torto tenete voi, che volendovi servire, non accettate la mia servitù.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Siamo in casi differenti. Ma dimmi, donde nasce questa sùbita affezione che mi porti?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Non è sùbita, nè anco nasce al presente: poi che affrontandosi il mio sangue col vostro, è segno che la natura me lo diede dalle fasce, e d'allora coverta, comincia adesso a scoprirsi.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Oh, tu mi ragioni per filosofia! Hai studiato, quel giovane?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Ho studiato, e studio, ad amare e servire, e ancora non trovo chi mi corrisponda. L'essempio si vede in voi, che mi vi sono offerto per servire, e mi rifiutate.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Ahi! che passò il tempo che io dominava. Mi trovo adesso in così misero stato, che lo cambiarei volontieri col più vile e abietto del mondo.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>E perchè?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Perchè ho perduto ogni mio bene.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>O Dio! chi sa se intendesse di me? Aiutami, sorte!</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Tu parli fra te stesso? Che dici di sorte?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Mi doglio che non m'aiuta la sorte.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>E a me peggio.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Signor mio, quantunche mi vedete giovane, nondimeno essendo stato in corte di chi del mio danno è signore, so molti rimedii e ho pratica di molte cose, che, volendo conferir meco i vostri segreti, credo che vi potrò giovare.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Il mio male è senza rimedio.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Ad ogni male è rimedio, dopo la morte.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Ahimè, morte crudele!</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Dunque morte v'ha tolto il vostro bene? E non è perduto, come dicevate dianzi?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Peggio che morte.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Che più peggio! Sarà forse morte violenta, o di laccio, o di ferro, o d'altro?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Ahimè! che tu m'uccidi a ricordarmi l'iniquo tradimento.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Deh, se fosse io la tradita!</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>O Ersilia, causa d'ogni mio tormento, d'ogni mio danno!</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>O Dio, che sento? Dunque questa Ersilia è morta?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Morta.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Era forse la vostra innamorata?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Innamorata.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>La sua morte vi duole?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Duole.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>E vorresti che fusse viva?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Viva.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Dunque voi amavate lei?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>No.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Perchè dunque vi duole? Perchè la vorresti viva?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Per vederla in maggior tormento che di morte.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Ahimè!</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Perchè ti duoli, e taci, moro?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Taccio, che moro sono, perchè non mi è lecito passar più innanzi.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Perchè?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Per la riverenza che vi porto, che io vi vorrei chiamare il crudelaccio, poichè desiderate peggio che morte ad una che vi amava.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Ti darò poi la risposta. Vedo venir di là il Signor Flaminio, furioso e molto turbato. Averà inteso forse la morte d'Ersilia. Sentiamo che dice.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 7</head>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Qui sei, traditore? Così si stima la giustizia? Così s'uccidono gl'innocenti? Così si trattano gli amici? Così si teme Iddio? Indegno di viver più! Metti mano per quella spada, che io ti farò conoscere che con ogni ragione prendo vendetta di quell'anima, che tra le beate è bella.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Che alterazioni, che motivi son cotesti? Io metto mano per difendermi, e non per offender voi, Signor Flaminio. E ditemi, che strano accidente vi move a romper le leggi dell'amicizia, a voler uccider colui che metteria mille vite per voi?</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ah, falso, perverso, iniquo, traditore! Due volte mi hai tradito, e in quest'ultima, avendomi tolto il mio bene e la vita mia, è forza che io ti tolga la vita per toglier dal mondo un orrendo mostro come tu sei: e per ciò non ti accade a tardar più. Alle mani, alli colpi, alla vendetta!</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Così si tratta il mio padrone? Levati di là, che se egli attende solamente a ripararsi, io mi adoprarò a levarti da questo mondo.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>E ancora a te farò conoscere che vaglio per l'uno e per l'altro: non stimo soverchiaria, mentre difendo il giusto. E mi rallegro che in un tratto mi vendicarò di tutti due, presago che tu sarai il compagno di questo misfatto.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Posate, di grazia, l'arme, Signor Flaminio, e dite la causa del vostro orgoglio: perchè, intese le mie giustificazioni, mi contento di lasciar in man vostra l'esecuzione di farmi vivere o morire.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Morire? Che dite? Morrò io più presto mille volte, che comportar che vi si tocchi un pelo.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Eh, Camillo! Camillo! non mi voler offender più con voler saper quel che molto ben sai. Che ti fece mai Ersilia, che l'hai fatta crudelmente morire?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>È vero che io ne fui causa, ma...</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Che ma? Non è stato egli, ma io son la causa della sua morte, e per ciò uccidete me, e non lui.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ucciderò l'uno e l'altro! Levati di là: menate pur le mani.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Se volete tener del giusto, liberate questo innocente e sfogate l'ira sopra di me, che vi rappresento il petto prontamente. Eccolo, passatelo con questa spada. Uccidetemi, e lasciate vivo Camillo.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Fermatevi, Signor Flaminio; costui lo dice per l'affezion grande che porta a me. Io sono veramente il colpato, e non esso. Io merito morire, e non lui. Uccidetemi.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Sarebbe fuor di ragione a lasciar punito il bene e impunito il male. Io son causa di questo male: io merito la pena.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Nol credete, Signor Flaminio: egli è così innocente, come io sono nocente. Togliete a me la vita, e lasciate andar lui.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Oh, che intrico è questo! Chi di voi m'ha offeso?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Io.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Io.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Eh, no.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Chi di voi ha ucciso Ersilia?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Io.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Io.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Non è così.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Non è vero.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Chi merita di morire?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Io.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Io.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Deh! nol dire.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Deh! nol fare.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>State pur larghi, non vorrei che mi vincesti di mano. Dunque ucciderò l'uno e l'altro.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Me solo.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Me solo.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Aspettate un poco: chi di voi, travestito, con un altro compagno, è andato in casa di Cornelia e ha ucciso Ersilia?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Non io.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Nè io.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Chi di voi ha tronco il capo?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Nessuno.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ah, traditore! Come dianzi dicesti di sì?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Signor Flaminio, io vi ho detto, e vi ridico, che io sono stato causa della morte di Ersilia, e il fatto passa così: che amandomi la giovane ferventemente, e avendone gelosia la Signora Cornelia, ha commesso a Magagna che l'uccida; però s'ella è morta, nè io nè costui siamo consapevoli.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ohimè, che sento!</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Oh, oh! fermate, che in nominarmi Magagna, Cornelia ed Ersilia, mi è sovenuto come questa mattina, standomi in certe case rimote, intesi una voce che si lamentava, dicendo: «Deh, Magagna, che t'ho fatto io? perchè mi vuoi uccidere?» Ed egli replicava: «Pazienzia, Ersilia, così vuol Cornelia». Io mi messi alla spia, e viddi che la povera giovane seppe tanto fare e tanto dire, che ridusse Magagna a girsene seco in casa di non so chi scultore, per farsi scolpire la testa d'Ersilia al naturale, con la quale, e con le vesti insanguinate, averebbe fatto credere a Cornelia l'omicidio.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Certo così sarà.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Così mi par verisimile. E quella testa che io viddi, sarà contrafatta?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Credetemi, che io ne parlo come di cosa propria.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Dimmi, che si risolse poi di fare Ersilia?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Si risolse a vestirsi da uomo, come al presente vado io, e cercar altrove sua ventura.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Dunque Ersilia è viva?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>È viva come son io.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>E dove al presente si trova?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Al presente si trova in questa città, perchè deliberò volersi partir domani.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Non è tempo di perder tempo. Vuo' partirmi.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>E dove volete andare?</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>A trovarla, se ben fosse nell'inferno.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>E che importa a voi di trovarla? Parmi che importi al Signor Camillo, poi che era la sua innamorata.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>E che importa a me? Se non fusse per conto del Signor Flaminio, vorria che Ersilia fusse arsa e abbrugiata mille volte, poi ch'ella è causa del mio danno.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Ahimè!</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Che cosa hai?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Un dolor colico che spesso mi tormenta. Ahimè, misero!</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Hai bisogno di qualche aiuto, moretto mio?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>O Dio!</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Ti passò forse?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Mi passò per quel mio stringere che ho fatto sopra la pancia.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Orsù, mi parto con ferma deliberazione di soprasedere, fin che m'informi della verità, secondo la quale potrò determinare o di seguir l'effetto contro di voi, o di cercarvi perdono del fallo.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Si trovarà come io ho detto; non bisogna dubitar punto.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Io m'imagino che quell'infame di Magagna averà macchinato questo tradimento contra di me, e per ciò vi prego, Signor Flaminio, a dirmi, se m'è lecito saperlo, s'egli è stato il traditore.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Poi che il moretto m'assicura del negozio, argomento esser falso quanto m'ha detto Magagna, e vi prometto dirvi appresso il particulare. Perdonatemi, non posso star più con voi, che dove sta Ersilia, ivi sta il mio cuore, e senza lei vivo senza la vita.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Ecco, Signor Flaminio, che non si deve credere a referendarii, nè moversi l'amico così leggermente contra l'amico, se prima non s'informa minutamente del fatto.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ogni cosa saldarà il tempo. Ma per adesso vorrei saper dove si trova colei, per cui amando moro.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Andiamo, che vi darò il modo di trovarla, e vi sarò sempre appresso, offerendomi patir sempre disagio infin che si trovi colei che nominar non posso per l'odio grande che li porto.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Ahimè! che io moro.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Che ti è successo?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Un'altra volta quel male.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Non dubitar: datti buon animo.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Voi solo mi potete dar l'anima.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Che dici?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Dico che non sono senz'animo, ma come un corpo senz'anima.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Orsù, non più. Andiamo.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Andiamo per quest'altra strada. E tu, moretto, vatti con Dio. A rivederci, e dove ti posso far piacere, commandami.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Io vi commando, se commandar vel posso, che mi lasciate venir appresso di voi, restando servito che io vi servi.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Eh no, figlio mio, a un altro tempo, a un altro tempo, poi.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Deh, cieli, che sorte crudele è la mia! Che non mi giova amar perfettamente, servir spontaneamente, patir pazientemente. Uh, uh, uh!</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Non pianger, moretto mio; fermati in questo luoco, overo aspettami in Banchi, che spedito il negozio del Signor Flaminio verrò a trovarti subito.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Farrò quanto voi volete. Ma che farai qui, misera Ersilia, come nave senza nocchiero, agnella senza pastore, inferma senza medico? E poi che ti trovi in mezzo all'onde agitata, tra' boschi smarrita, con la febre sola, non lasciar il nocchiero, il pastore, il medico, acciò non t'affoghi, non ti perdi, non ti muori. Andrò dove egli andrà, che spero di pigliar porto, mettermi in via, e trovar medicina al mio male, continuandoli appresso i miei sospiri.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 8</head>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Chi tarda ad attendere mostra di voler negare e pentirsi della promessa. Ma, ohimè! parmi sentir romore in casa della Signora Cornelia; e se io non erro, la voce è di Magagna. Esce piangendo, ed ella appresso col bastone in mano. Che novità son queste? Ritiriamoci e sentiamo un poco.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Ohimè, Signora padrona mia, che male ho fatto io? In che t'ho offeso? Se così vecchio come sono, mi batti e mi cacci di casa a tempo che sono vero esecutore dell'ordine tuo...</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Infame, omicida, traditore, così si tingono le mani nel sangue de' nobili? Così si uccidono le povere figliuole? Ti farò castigare, ti farò mettere un capestro al collo.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Questo è un altro diavolo! E che colpa è la mia, se voi medema me l'avete commandato? Non importa, che se la giustizia vuole, toccarà prima a voi, ad esser impiccata, e dopo a me! E io non me ne curo, pur che siamo impiccati insieme, giustamente, per vedere se potessimo fare un figlio in aria, poi che non l'avemo potuto fare in terra.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Io te l'ho commandato? Si vederà appresso! Dunque perchè il padrone si trova in còlera, e commanda una cosa ingiusta e fatto scelerato, il servitore l'ha da essequire? Signor no! Dovevi considerare che io per còlera lo diceva, e non che fosse stata così la volontà mia.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Di maniera che se io non l'uccideva, averia fatto meglio?</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Meglio!</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Questi parlano di uccidere: che domine sarà? Che dite, Messer Alberto? Voi sete cambiato in vista; par che volete parlare, e non potete. Che vi è successo?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Oh, che intrico! oh, che disturbo! Sappi che questa è Cornelia, mia prima moglie. Io la riconosco molto bene. Misero me! Nè mi posso imaginare in che modo sia viva, s'io l'ebbi già per morta.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Ohimè! che dite?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Tant'è: osserviamola prima, e poi vi dirò.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Perchè taci, Magagna? Perchè non parli più? Perchè non segui quel che volevi dire?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Dico: se per sorte Ersilia fusse viva, che meritarei?</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Meritaresti che io ti facessi ritornare in casa.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>E niente più?</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>E che più?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Quell'altra cosa.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Che cosa?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>La promessa.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Che promessa?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Di fare...</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Che?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>...<foreign xml:lang="lat">il vis et volo</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Non t'intendo.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Il matrimonio...</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Che matrimonio?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Tra te e me.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Tra te e me? Oh, vigliacco, poltrone, forfante!</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Non tel diss'io che il povero va sempre per terra? Orsù, ti voglio dir la verità. Sappiate, Signora Cornelia, che quella non è la testa di Ersilia, ma una testa contrafatta al naturale, per farvi credere che l'aveva uccisa: non però, essa è viva, come tutti li viventi.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>E dove sta?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Si è vestita da uomo e va cercando il suo Camillo.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Sì, ah? E per questo Camillo è fuggito dalla mia camera, per andare a trovar quella sciaguratella! Questo è concerto fatto da voi. Così m'hai tradita, Magagna? Deh! traditore, assassino, adesso più che mai ti vuo' dar, ladro, furbo! A me questo tradimento, ah!</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Ora questa sì che è bella! Se Ersilia è viva, è male; se è morta, è peggio. Che domine pretendete da me? Che cercate? Non volete che Ersilia sia viva?</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Adesso vorrei che fosse morta.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Di questa maniera bisognarà tenere affittata la natura, che a modo vostro facesse e disfacesse le persone.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Non più parole. T'ho inteso già: provederò io di sorte che tutti tre restiate castigati. Sfratta via, levati di qua, non ti accostar più in questa casa.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Al manco, Signora mia, datemi quei tre carlini che mi dovete dare.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Ti darò tre legni per la forca, che t'appicchi. Tira via, forfantone.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>O Magagna, mercante fallito, che hai perso le ragioni tue, come le femine. Lasciami andare, che essendo la donna mutabil di natura, spero trovar pietà, non che perdono.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 9</head>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Che dici? che tratti? che pensi più, Cornelia? Amor ti lusinga, gelosia ti consuma e il senso t'inganna. Che partito sarà il tuo, se la terra, se il cielo, se gli uomini ti sono contrarii? Ma che vogliono costoro?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Vien meco, Messer Manilio, che io vuo' chiarirmi del tutto. Bascio le mani di Vostra Signoria, Signora Cornelia: son certo che ella non mi conoscerà.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Non io. Chi sete voi?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>La longhezza del tempo, questa barba che allora non avevo e la mutazion dell'abito vi han chiuso gli occhi della conscienza. Sappiate che io mi chiamo Alberto, e fui molto amico di Muzio, vostro primo marito.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Questo è proprio un ricordar li morti a tavola! Che n'importa ragionar de' morti? Stiansi i morti con li morti, e i vivi con li vivi.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Ma se per sorte Muzio fusse vivo?</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Se fusse vivo, averebbe pazienzia con farsi il fatto suo. Che ci arei da far io con Muzio, se venisse di novo al mondo?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Io, come amico suo cordialissimo, rappresento l'istessa persona di Muzio, e mi lamento in suo nome di voi; e dico che l'amore e la fede e l'affezion grande che vi portava Muzio non meritano queste risposte, questi dispregi. Deh, Cornelia, Cornelia, ricordati quanti sospiri, quanti lamenti, quanti pericoli patì e passò il povero amante prima che ti avesse; e dopo aùta, con che sviscerato amore t'amava. Deh, perchè ti sono uscite di mente? Deh, perchè per altri hai cambiato il primo amore? Ritorna, ritorna a te, Cornelia, e pensa che il tuo Muzio è vivo, e ritornarà così presto da te, come son io adesso qui.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Tengo per fermo che tu sii qualche spirito maligno in forma d'uomo, poi che sai le cose passate e falsamente mi vuoi indurre a credere le presenti fondate sopra l'impos&lt;s&gt;ibile. Andate in buon ora, che io ho da far altro che trattenermi con voi.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Io stupisco, io traseculo, io son fuori di me. Dunque voi Muzio, e non Alberto sete? Dunque Cornelia è vostra moglie? Come dunque vi casaste con Leonora? Che errore, che peccato, che fatto indegno di voi è questo? Voi non mi rispondete? Ritiriamoci qui dietro, ditemi tutto il successo.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 10</head>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Nel sanguinoso e miserabil caso di Famagosta, vedendo io menar prigione questa Cornelia, mia moglie, e Persio, mio figliuolo, disperato d'ogni salute mi precipitai dentro la calca de gl'inimici, e combattendo n'uccisi molti. In fine fui ferito, e caddi per morto in presenza dell'istessa Cornelia, la quale mi riputò già morto del tutto. Ella fu menata in una galera; e io, credendo che il campo vittorioso fusse partito, mi levai pian piano, quando da certi Turchi fui preso e portato mezzo morto in un'altra galera. La vanguardia dove era Cornelia si partì prima, e passando in alto mare, fu assalita da repentina tempesta, e venne nuova che s'era già sommersa. Io per l'ultimo, schiavo e mal contento della sua morte e di quella di Persio mio figlio, piccolo di cinque anni, fui di là a sei mesi liberato dalle galere di Malta; e venendo in Roma, credendo certo che Cornelia fusse morta, mi ricasai con Leonora, chiamandomi Alberto per non sentir più quel disgraziato nome di Muzio. Ella averà fatto il medemo, credendo che io fusse morto, e si è ricasata di nuovo con Alessandro, e adesso procura l'altro. Or vedete che grande intrico è questo. Che cosa si farà? Come farò?</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Io non so che dirvi, nè che farvi. Dispiacemi che anch'io ho perduto la mia commodità, perchè, capperi!, Cornelia era bella. Ma ecco di là l'altra moglie insieme con Pasquina. Vengono molto in fretta, e turbate; alcun altro intrico ci sarà.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Vedi, Pasquina, che tu non t'inganni come suoli al spesso. Dimmelo chiaro: hailo tu veduto con gli occhi proprii?</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Con gli occhi proprii.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Entrar nella camera?</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Nella camera.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>E Lavinia entrò prima di lui?</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Prima di lui.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>E gli hai serrati di fuora?</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Di fuora.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Oh! traditori disonorati! Parmi mill'anni che io mi sfoghi sopra di voi.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Moglie mia carissima, donde venite? Dove andate? Perchè sete in còlera? Che cosa ci è?</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>A tempo vi trovo, marito mio caro. Andiamo, andiamo in casa; e pregovi, Messer Manilio, che ancor voi vi degnate di venire, per aiutarci in un bisogno molto importante, dove vi va l'onore e la riputazione di casa mia.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Che altro disturbo sarà questo? Entrate pur, Messer Manilio.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Intriamo. In fine è vero che le disgrazie non vengono mai sole.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 11</head>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>E io ti dico, Leandro, che l'onore s'ha da preporre a tutte le cose; e di due mali, si deve eleggere il manco. Saria manco male a tormi la vergogna con la morte di Cornelia e di Camillo, che restar favola delle genti: che restando così ne potrebbe nascere uno delli doi disordini, che io mi disperasse affatto con pericolo dell'anima, che importa più, o che ogni giorno uccidessi tutti quelli che mi volessero notare di questa infamia.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Dal presente al futuro è una gran differenza, padron mio. S'al presente che sete in còlera dite così, non so poi se quel che potrebbe nascere averia l'effetto suo; che molte cose diciamo a sangue caldo, che raffreddato poi non si mandano in esecuzione. Talchè, evitando questo presente eccesso che vi preparate di fare, evitarete anco il secondo, con più onor vostro, con quiete della mente e con salute dell'anima.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Il sangue non raffredda mai a chi fa stima dell'onor suo, ma sempre bolle, sempre freme insieme, se non si risolve in vendetta del riceùto oltraggio.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Nelle cose che sono secrete, io non so questo onore di che colore si sia; se però da noi stessi non vi mettiamo sopra il tinto, come fanno alcuni, che si ponno celar le corna in seno, se le mettono in fronte. Ditemi: chi sa, o chi saprà, o chi si potrà imaginare mai questo fallo di Cornelia e Camillo, se da noi stessi non lo publichiamo? Stiamoci dunque a piacere, e dissimulando il negozio barattarete Cornelia con Brianda, e lasciamo stare tanti omicidii.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Il secreto che passa per bocca d'uno non è più secreto. Franceschetto lo sa, lo sai tu; e quando tu e Franceschetto nol sapeste, lo so io, la mia conscienzia, che vale per mille testimonii. Lascia fare a me. Adesso che il traditore è serrato in camera, secondo mi ha riferito Franceschetto, il colore sarà di sorte che il rosso del sangue coprirà il verde della loro lasciva speranza.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Nell'ultimo, Signor Alessandro, so che mi farete buona quella regola che non si punisce l'affetto se non segue l'effetto. Ha permesso Iddio che Camillo sia stato chiuso in camera prima che venisse all'effetto, dunque non si deve punire l'affetto.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>T'inganni: perchè ne gli eccessi gravi ed enormi si considera principalmente la mala volontà e il proposito cattivo col quale si va a delinquere; e se ben non segue l'effetto, bàstavi che solo con la sola in camera, accarezzandosi lascivamente insieme, son venuti a i baci. Ma ecco che Cornelia viene in porta; fermianci qui, mentre m'accommodo le palle in bocca, acciò balbutiendo non mi conosca alla favella.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 12</head>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Mi è morto il marito; l'ombra dell'altro m'affligge; mi pregiudica la figliastra; Camillo m'inganna; mi tradisce il servo; il messo mi sospende; l'astrologo non viene. Che debbo dunque sperare, se dubbiose, sospese, vane, estinte, incerte e morte sono tutte le mie speranze? Debbo sperar forse alla dubbiosa speranza che mi resta di questo astrologo? Ahi, che t'inganni, Cornelia: non sai tu che tutti li pronostichi non sempre riescono? E non riuscendo Camillo qual ti promettesti, tu ne rimaneresti infamata appresso l'astrologo e appresso il mondo. Non sia mai che mi publichi per tale, che io mi scuopra innamorata di Camillo, se prima non faccio mille esperienzie di lui. Ma ecco Leandro; credo che l'altro sarà l'astrologo. Oh, Amore, conducemi al porto, dopo tante tempeste!</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Ecco qui, Signora Cornelia, l'astrologo che io vi ho proposto. Confidate liberamente alla virtù sua, che come prudente e saggio darà efficace rimedio alle vostre disaventure.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>L'effigie veramente è veneranda; spero che gli effetti saranno corrispondenti.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Quella che è mastra di tutte le cose, l'esperienza dico, vi farà certa la speranza ch'avete in me.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Ohimè, questo balbutire mi dà sospetto, già che si dice: guardati da' segnati.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Non accade a sospettar di nulla, nè a parlar fra di voi stessa, che io già comprendo il tutto.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Voi mi mirate così fissamente nel volto. Che cosa disegnate?</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Disegno segni mirabili nella vostra effigie; e perchè sono cose di molta importanza, ritiratevi in quel cantone, Leandro, acciò senza sospetto ella mi possa manifestare il vero.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Di grazia.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Se a voi piacesse, Signora, che noi andassimo sopra, io andarei volentieri, per poter più diffusamente ragionare.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Non importa: cominciate a dir qualcosa qui, che essendo il luogo rimoto, non sarà disdicevole.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Voi, primieramente, sete innamorata; e questo amor vostro cominciò molti mesi avanti che morisse vostro marito. Non è vero?</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Dio voglia che non cada al primo assalto.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Mentre visse l'infelice consorte, non amavo altri che lui, e al presente non mi è rimasto altro amore che de' proprii figli.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Oh, che saggia risposta!</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Del figliastro, dovevate dir voi, e non del figlio: e mentre lui fu riputato per tale, voi non osaste di scoprire il fuoco; ma poi che fusti certa che egli non vi era figliastro, usciron fuora le fiamme, tal che voi ed egli, che era nell'istessa fornace, n'avampaste a tutto potere. Non è così?</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Ohimè!</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Io non so che dite.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Oh, buona!</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Se per onestà non volete confessare il vero, vi laudo. Basta che il vero è quello che io dico; e vi dirò anco una profonda particularità, che la morte di vostro marito vi piacque grandemente, per aver la commodità di sodisfarvi insieme. Che dite?</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Tienti, Cornelia.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Dico che v'insognate.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Buona!</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Io non m'insogno, ma segno la verità: anzi vi chiarirò di più, che sete venuti all'atto prossimo col baciarvi insieme mo poco avanti. Potrete negar questa?</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Salda.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Io stupisco.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Ohimè!</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Ditemi: chi è costui che v'imaginate?</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Il nome in particolare non possiamo saper noi; ma solo al presente si ritrova serrato dentro la camera vostra.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Chi?</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Costui che io dico, che arde, come ardete voi, d'un istesso amore.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Andate, andate in buon ora; e cercate ingannar altri, che Cornelia non si lasciarà ingannar da voi.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Io non inganno nessuno, e voi non sete ingannata da me; ma per farvi conoscere che io dico il vero, andiamo di sopra, che trovaremo il drudo serrato in capitolo.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>E se non vi sarà?</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Se non vi sarà, dirò che la virtù mia è falsa. Ma se vi sarà?</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Se vi sarà, dirò che io stessa sono una rea femina. Ma che altro volete patir voi, se non vi sarà?</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Se non vi sarà, datemi delle bastonate. Ma che altro volete patir voi, se vi sarà?</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>E se vi sarà, uccidetemi!</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Alla prova, e vederemo se ci sarà; se non vi sarà sarete vincitrice.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Andiamo di sopra.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Io tengo per fermo che Cornelia sarà vincitrice e Alessandro confuso, perchè troppo alla sicura l'ha introdotto in casa. Or ecco come i giudizii umani sono al spesso fallaci! Alessandro giudicava la moglie disonesta, e la sua imaginativa aveva talmente chiuso il fatto, che ancor io stavo nel medemo fallo; e ora si trova tutto il contrario. Imparate, voi altri mariti sospett&lt;os&gt;i e gelosi, imparate a fuggir questa maledetta gelosia, e lasciate le mogli in libertà loro. Non siate causa di procurare a voi stessi il danno, perchè molte volte s'inaspra la donna con le vostre stirature; e credetemi, che quando la donna vuole, vi farà le fusa torte, se bene aveste gli occhi d'Argo, l'astuzia d'Ulisse, e la sapienza di Salomone. Ma sciocco che son io! Che faccio qui? Sarà bene a salir sopra, per riparare e soccorrere a qualche inconveniente che potesse succedere; che stando all'assedio Amore e Gelosia, facilmente potrebbono mandare questa casa a sangue e a fuoco. E io ch'ho incominciato a difender l'impresa, debbo di ragion seguirla; perchè si dice: non chi incomincia, ma chi persevera.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 13</head>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Per 'stinto naturale noi autri Cavalieri napoletani solimo sempre favorire chilli ca se danno alla devozione nostra, come fazzo io allo presente, ca sendose sottopuosto lo Segnore Camillo alla nostra protezione, è necessario ca lo favorisca 'ntorno allo suo negozio: quale è ca io, travestito, come già vao, e co chesta barba posticcia, parlando alla spagnola fazzo spantare Magagna, pe sapere da isso 'n ca luoco si truova na cierta Ersilia, ca m'have ditto esser vestuta da ommo. Ecco quanto iova la resoluzione fatta pe noi autri Segnori de Napole, ca quasi tutti professamo de parlare alla spagnola, e facimo moto bene: prima pe mostrare a Sua Maestà l'affezione granne ca portamo alla nazione pe respetto suo; e appriesso, poi, ca pe quante lingue ha l'ommo, pe tant'ommeni vale. Ma chi è chisto paggetto che bene da ccà? Sa bolisse stare co mico, forìa moto allo proposito. Mutaraggio lingua, pe no 'me fare conoscere. Olà! pazze, vien acá! Per vida vuostra que os quiero desir dos palabras.</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Ohimè! costui è spagnolo. Dubito che non mi levi il cappello con le piume, perchè in Roma si dice: provacciare alla spagnola; e domandando io che cosa è provacciare, mi fu fatto segno col dito grosso in questo modo. Alla fè, che non me lo farai. Io me lo terrò ben stretto in mano, sì.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Mucchio me guelgo que soyz tan bien creado, pues que en verme luego os haverìas chitado el sombrero. Desideme, quien soys vos? Muchio me quelgo.</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Adesso non ho mostaccioli, poi che quelli che mi diede la Signora madre me gli ho magnati tutti tutti.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Ah! ah! non digo yo mostachiolos, hizo mio, mas quien soys vos, y si quer&lt;è&gt;is estar co migo por pazze.</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Sia pazzo chi vuole, io non sono pazzo; e se non volete altro, a Dio.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Especta un poquito e escùcchame.</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Non mi toccate il cappello, e fate quel che volete voi. Lasciate: dite pure senza mani.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Vos soys un señor rico y galano mozo.</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>A voi siano mozze le mani, e non a me! Fatevi là, non mi toccate le guance. Non vedete che io son maschio?</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Estamo serio, por dios! Male haze gustar este pazze. Ven acá: come es vuestro nombre?</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Ombra sete voi, e l'ultime lettere del mio nominativo di più.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Yo non intiendo que cossa desìs, en la&lt;s&gt; postre ras litras del vuestro nominativo.</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Aspetta. Io declinarò, e voi prendendo l'ultime lettere, congiungetele insieme.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Me contento. Diga.</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Nominativo: <foreign xml:lang="lat">haec musa</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>A.</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Genitivo: <foreign xml:lang="lat">huius familias</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>S.</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Dativo: <foreign xml:lang="lat">huic patri</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>I.</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Accusativo: <foreign xml:lang="lat">hunc Absalon</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>N.</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Vocativo: <foreign xml:lang="lat">o cornu</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>U.</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Ablativo: <foreign xml:lang="lat">ab hac Atropos</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>S.</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Or congiungete.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p><foreign xml:lang="lat">Asinus</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>L'istesso sete voi in forma probante. Restate qui, Messer l'<foreign xml:lang="lat">Asinus</foreign>, che io voglio entrare in casa.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Vatte con Dio, va, ca fatta me l'hai! Mira ca diavolo è sortuto lo munno, ca li pizzirilli perzì se burlano delli grandi! Ma, ohimè, che rumore è in casa della Segnora Lavinia? Me boglio arretirare ccà, pe sentire qualche cosa.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 14</head>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Traditore infame, a questo modo si tratta? Ah! così si fa in casa de gli uomini onorati? Te ne farò pentire di sorte che, restando de gli altri essempio, biastemerai il giorno che venisti al mondo. Strasciniamolo qui fuora, Messer Manilio, così come sta, dentro nel sacco: acciò, passando la corte, lo porti di peso in prigione.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Ogni peggio se le conviene a questo ladro; che l'ho grandemente contr'a' Napolitani, che essi furno causa che Flavio mio se ne fuggisse. Non posso saziarmi di darli con li piedi e con il bastone. Ah! forfante, forfante, piglia questa, e poi quest'altra.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ohimè! non più, abbiate compassione.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Compassione, dice il ribaldo! Dateli, uccidetelo senza pietà: mariolo napoletano.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Tu ne menti pe cierto, con tutto che la mentita è secreta, poi che per la soverchiaria no' lo pozzo dicere in publico. Ma che diavolo napoletano serà chisso? Me boglio accostare chiano chiano e fingere lo spagnolo. Baso las manos de Vuesas Mestedes. Sennores gentiles hombres, que grittos, que rumores, que cosas son estas? Io quiero entendere el todo, porque soy el Capitan de la guardia, i provedere de manera che la yustizia tienga el suo lugar.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Oh, Signor Capitano, a tempo sete giunto. Entrando in casa ho ritrovato un ladro, che allora m'involava certe robbe, rimettendole dentro un sacco: lo giunsi a tempo con questo gentiluomo amico mio, e a suo mal grado l'abbiamo serrato nell'istesso sacco, per farlo castigare alla giustizia.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Giusto giudizio di Dio, che il debito delitto sarà punito con l'istesso mezzo che il delinquente si preparava pregiudicare a gli onori altrui.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Signor Capitano, opratevi, di grazia, che sia rigorosamente castigato questo traditore, che si persuadeva Roma esser Baccano.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Non tenga miedo, Sennora mia, y non dudar, Sennores gentiles hombres, que sarà castigado muy rigorosamente. Però dìgame, Vuestra Merced, quièn es este ladrón?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Un certo Napolitano, ed è l'istesso che dissimulava il Cavalier, vestito tutto di seta e d'oro, che poi travestito da molinaro è intrato in casa a farmi questo tradimento.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Y como se gl&lt;i&gt;ama?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Si chiama Gialaise.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>De quièn&lt;e&gt;s?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Gialaise Formicone, cred'io.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Come deavolo va chessa cosa? Io songo ccà, e credo puro ca songo io, e no' autro: come dunque io medesimo pozzo essere dintro lo sacco e essere ccà 'n persona propria? Avìssime fatta qualche burla l'astrologo, a fareme andare senza licenzia mia 'n forma de molenaro? Io spanto, io stupisco, io traseculo!</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Noi credemo, Signor Capitano, che mentre Vostra Signoria si è appartato da noi si spanta e maraviglia come il Napolitano, che stava con tanta riputazione, abbia fatto questo disonore a se medesimo e alla patria sua.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Azì es por cierto. Pero dezìme dove... Che de veros este ombre que está en el saco es Juan Luis Formigone?</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Egli stesso. Or sentite il suono, che io toccarò il tamburo. Ah! vigliacco infame, or prendi questo calcio.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Eh, Dio! Non avereste pietà d'un povero giovane, che per amore si è trasformato in questa sorte?</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Ped amore è trasformato? Dunque songo io, che ped amore di Pasquina dovea venire trasformato in aseno; ma po, considero ca io songo ccà, co le medesme mano e co l'istessi piedi e co lo medesmo cuorpo. No' però lo nominativo de chillo figliolo mi fa sospettare ca no' sia ccà l'aseno, e là dintro lo sacco Gialaise. Dispiacemi ca lasciai lo spiecchio all'autre cauze, pecchè boria vedere se songo io. Ma me ne boglio 'nformare. Si esperan, Sennores, este qui está serrato en el sacco, es propriamente Iuvan Luis, o otro in suo lugar?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Io dico che egli è, e non altri; e quello che tiene di novo è l'abito da molinaro solamente. Portisi dunque in prigione questo mariolo napolitano.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Ora me boglio scoprire. No' me preiudicate, di grazia, e no' dicite accossì, ca li veri Napolitani no' songo marioli, ma buoi autri forastieri, che nce benite ad abitare. Motta dello munno, ecco ca mi levo la varva! Ecco ca io songo lo Signor Gialaise, e no' chillo ca sta intro lo sacco! Ca mo vao accosì... vao pecchè me piace, pe compiacire a na Signora ca bole ca io 'n chest'abeto trasa 'n casa sua.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Perdona&lt;te&gt;ci, Signor Giovan Luigi: la còlera, il giusto sdegno e il creder che eravate lì dentro mi han fatto trasportare, che altramente non si sarebbe detto.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Quel che si dice mentre l'uomo sta in còlera si può sodisfare con la sodisfazione che v'ha dato Messer Alberto, e che vi do anch'io, Signor Giovan Luigi, cioè che non si sarebbe detto se non fusse stato quella credenza.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Ve la perdono pe chesta vota, ma no' te nce adonare chiù pe grazia.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Ohimè, che miracoli son questi d'oggi! Orsù, vedasi chi è colui che sta dentro il sacco.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Aspetta&lt;te&gt;, che io da me stesso lo voglio sciogliere.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ah, padre! Ah, Signor padre!</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Ahimè, figlio! ohimè, figlio! Oh, Flavio, oh, Flavio mio, oh, Flavio mio caro! Alberto, Leonora, Capitan Giovan Luigi, o mondo, o tutti, aiutatemi! Ecco qui Flavio, ecco il mio desiderato figliuolo. Ohimè, che per l'oltraggio che t'ho fatto, e per l'allegrezza che io ti trovo, figliuol mio, stillo da gli occhi fonti di lagrime. Levati su, vita e anima di questo mio debil corpo: che senza te ero per venir presto manco, per te viverò lungo tempo. O Flavio mio, chi mi tien ch'io non ti baci, che non t'abbracci, che non ti stringa caramente, consolazione del tuo vecchio padre? Eh! dimmi come sei qui, e come ti trovo in questo abito.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Impetratemi prima perdono da Messer Alberto e dalla Signora Leonora, che io vi dirò succintamente tutto il fatto.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Dite pure, che secondo vi sarà l'onor nostro, così faremo deliberazione di esseguire quanto si ha da fare.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Chisto me pare Cuosemo alla voce, se bene no' tiene la varva dello colore de prima.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Io sono, e intenderete il tutto. Amando io la Signora Lavinia con zelo di sposarla, fui sempre da lei rifiutato; e sapendo che ella amava Giovan Luigi qui presente, mi posi a servirlo tinto da moro, sotto nome di Cosmo, per aver commodità di parlare almeno alla mia crudelissima nemica. Di più, amando Giovan Luigi Pasquina, mi oprai di sorte che feci credere a Lavinia di volerli introdurre il Napolitano, sotto scusa che in abito di molinaro averebbe trovato la sua Pasquina dentro quella camera terrena: dove standomi con la Signora Lavinia, fui soprapreso da voi al buio: pensandovi che io fosse il Napolitano, mi riponesti nel sacco. Ecco dunque, Signor Alberto e Signora Leonora, il mio gran fallo, se fallo chiamar si può un amor vero e vivo che ho portato e porto alla vostra figliuola, con fermo proposito, e prima e poi, e al presente ancora, di pigliarla per moglie. Perdonatemi dunque s'amore, se bellezza, se casto desiderio mi arse, mi strinse e mi condusse in questo luogo; e se pur degno sono di giusto castigo, sfogate sopra di me l'ira e l'orgoglio vostro, lasciando intanto Lavinia mia, così come insin adesso l'ho serbata intatta ad altri che ne fosse di me più degno. O degno, o casto, o vivo, o vero amore! <stage>(Qui si sente l'orologgio)</stage>.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Me raccommando, Signori. No' sentite l'aruluoggio? Chesta è a punto l'ora ca m'aspetta chella Signora ca v'aggio detto. A rivederci.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Andate con Dio.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Alla fede, ch'aggio fatto bene a fuire li scànnoli! Avenno Cuosemo, lo quale allo presente è Flavio, publecato l'amore mio co Pasquina, no' boria che me 'nforassero lo ioppone d'autro che de pambace. Lassame stipare la varva, e boglio ire da ccà, sa potesse trovare Magagna per servire l'amico.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Per che causa non si parla più? Perchè tutti siamo fatti attoniti e muti? Seguitate pure, marito mio caro, quel che incominciaste a dire.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Che posso dire, se il mare dell'amor di Flavio ricerca altro legno per navigarlo? Entriamo tutti in casa, dove da quell'altra banda rimandaremo per li vestiti proprii di Flavio, acciò spogliato di questi miseri panni possa mostrar di fuora la felicità dell'interna virtù sua, degna non solo dell'amor di Lavinia, ma di quante degnissime donne si trovano.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Entriamo, che io vorrò quel che vorrete voi.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Entriamo, e datemi spazio di potervi ringraziare.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Entriamo. E voi, fedeli amanti, sperate amando.</p>
           </sp>
@@ -6052,1706 +6101,1706 @@
         <head>Atto V</head>
         <div type="scene">
           <head>Scena 1</head>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Que se toma el vellacco!</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Che si pigli il traditore!</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Alcánsalo que se fuie.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Non scapparà, certissimo.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Allerta Vuestra Merced d'acullá, que yo estarè por acá.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>O in questa parte o in quella ha da venire.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Atento, que va a voi.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>A voi, che si volge a voi.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Ah! puerco, sùsizo, vien, ombres dellos montes.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Oh! per l'amor di Dio, Italiani, aiutatemi, che li Spagnoli m'uccidono.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Non passar più innanzi, se non vuoi che con questa spada ti passi il petto.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Italia mia!</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Il pregare è indarno.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Spagna, Madama Spagna, Signor soldato, illustre Spagnolo, illustrissimo Signor mio, eccellentissimo padrone, Altezza della Serenissima Maestà vostra, Imperador del mondo!</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Non más palabras, calla ladrón! Non passe más adelante, Sen&lt;n&gt;or: quiere que le saque del cuerpo &lt;el&gt; corazzón?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Nè sacco, nè puorco, nè capezzone ho pigliato io: non son tale, non son ladro, per l'alma de gli anticipati miei. Ahimè! che la paura non me t'ha fatto conoscere, Signor Flaminio; e perchè tu ancora?</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Domandane te stesso, fraudolente che sei. Fermati, non ti movere, che t'uccido.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Estaos quedo, se non quieris que te matte.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Non son matto, Signor mio. Oh! povero Magagna, posto tra due punte di spada. Non spingete, non intrate. Di grazia, ditemi prima la causa che vi stringe, vi spinge, che vi muove a farmi morire.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Por que quien matta deve de ser mattado. Non sabèys que qui amasa es anpicado?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Vuole che picchia. E dove, Signor Flaminio, voglio picchiare?</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Rispondi là, non t'accostare a me, forfante.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Se pur ho da morire, vorrei che fosse all'italiana, e non alla spagnola, perchè l'asprezza delle parole <emph>os</emph> e <emph>as</emph> mi passa l'ossa prima che arrivi al colpo.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Ven acá, vellacco, e yncaos luego de rodillas &lt;en&gt; el suello.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Non so de' licci, nè tengo artigli, nè suolo, per l'alma mia.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Yncaos luego in tierra!</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>La mia terra è Triggiano, al commando di Vostra Signoria.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Parèzzeme que os burláis de me. Vos non mi conosèis aùn: yo soy el terrible de los terribles, que tiengo los cabellos de Medusa, la fruente de Hettore, las narises de Argante, el rostro d'Aquile, l'abla d'Ulisse, los dientes de Cadmo, las espaldas de Hèrcoles, el petzio de Sansón, los brazos de Poliphemo, y las manos de lo&lt;s&gt; Gigantes que subieron en el cielo. Tiengo el corazón de Roldán, el cuerpo de Rodomonte, las piernas de Reinaldos y los piezz de Gradasso. Io non cedo en el valor a Marte, en el próze&lt;r&gt; a Plutón y en el vizio a Bellona. Ago temblar la tierra en ablando, e spavento el ynfierno en grittando, y vuelvo los cielos en obrando. Y vos, que soys un vellacco, no querèis dezir la berdad?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Ohimè! sapesse almanco, Signor Flaminio mio fortissimo, che cosa pretende da me.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Quiero sabir en donde se alla la muger.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Aglio non ho, bugerico non so.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Vien atrás de me, atrás, digo!</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>M'arrasso, m'arrasso, Signore.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Atrás, digo!</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>M'arrasso; che volete più, Signor mio potentissimo?</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Acerca di me, acerca di me.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Non cerco a te, non cerco a te.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Iuro a los cielos que se mi lievo vollo bolar tan alto en el cielo, que troncando la sfera del fuego, y cayendo pues en tierra, te alla ya requemado y echo cenisa, vellacco de los vellaccones.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Di grazia, lasciatemi andare in casa a rimover la robba, che gl'interiori mi hanno rifuso alle brache.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Atrás, digo, atrás.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Valli appresso, non l'intendi?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Dunque <foreign xml:lang="spa">atrás</foreign> vuol dire appresso? Ahimè! che io m'appresso al trapasso della morte.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Desisme en donde se alla agora la muger.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Dianora mia mogliera ha più di sette anni che è morta.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Digo aquella que mattastes dissimulatamente.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Mazzi di semolata e di menta non si trovano in queste bande.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Empeces que te borlas: desisme como quieres que te haga morir.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Come mi vuoi far morire?</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Sì.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>D'una morte che la vedesse e non la sentisse.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>De que manera?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Datemi una coltellata dui palmi sopra la testa, e così vederò e non sentirò la morte.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Estaos incato de rodillas, y dexandos las burlas desidme la verdad: en qual parte se alla Ersilia?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Nescio... Ma ecco gente di là. Oh, Signor mio, aiutami</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Levantaos y no desìs nada; y no dir, por vida vuestra.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Io dirò ogni cosa, non accade a pregarmi. Ah! così si tratta? Ah! così si assassina un pover uomo &lt;in&gt; mezzo la strada publica? Lo farò sentire, se sarà possibile, sino a Sua Santità.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Infame traditore, adesso stai bravando, e non ti avedi che colui è il Signor Camillo col moro, e vengono pur contro di te. Statti, non ti partire, tu hai da far conto con l'oste ancora.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 2</head>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Coteste vostre lagrime sono tanti chiodi che mi trafiggono l'anima, considerando che piangete per pietà di colei a chi desidero ogni peggio; tal che se mi volete bene, come dimostrate, dite come dico io: scoppia, muora e incenerisca Ersilia.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Io lo direi, quando non procurasse che un animo così bello come è il vostro non fosse macchiato di una macchia così brutta come è la crudeltà; e quando il giusto non permettesse che io debbia difensare come cosa propria una causa così giusta com'è quella della povera Ersilia.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Io saprei molto bene riversare coteste ragioni: ma non voglio, nè posso, tale è l'odio che io li porto.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Ohimè, ohimè!</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Che cosa?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Vedo gente da quella parte con le spade nude. Fermatevi... ma sono i nostri amici!</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>A tempo sete giunto, Signor Camillo; ecco qua l'assassino di Magagna. Mettete pur mano, a tal che ognuno di noi col suo colpo si vendichi di lui, quando per sorte non vorrà dir la verità.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Con li pari di costui si ha da giuocare di bastone e non di spada. Benchè confido al valor del Signor Capitano, che con la parola sola se lo inghiottirà.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Ahimè! speravo aiuto e mi è sopravenuto affanno; e così dalla padella son cascato nella bragia.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Azì es per cierto. Agora agora con un soplo sarite desezio como la nieve en el sol: ladrón, ladrón, vellacco, vellacco, confessa la berdad y dezime en donde se alla Ersilia.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Ah, ah, ah!</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Tu te rìes?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Come non volete che io rida, se avete primiera e non tirate?</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Que trampas son estes que dize?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Non son trampe altramente, ma è così con effetto. Ditemi un poco, per far primiera non bisogna che siano quattro carte diverse?</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Azì es.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Or voi non sete quattro, di nazioni diverse: spagnola, barbara, italiana e commune?</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Yo non intiendo.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Nè meno io.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Nè meno io. Dichiarati presto, bestia.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Mi dichiaro. L'invittissimo Capitano è spagnolo, e significa spade. Il moro, barbaro, ed è bastone. Il Signor Flaminio, romano, e in Roma battendosi moneta, sarà denaro. E il Signor Camillo, non sapendo la patria sua, è commune, e sarà coppe.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Che freddure son coteste? Risolviti a dir la verità, se non &lt;vuoi&gt; che t'uccido.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Mattade este vellacco.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Uccidasi senza remissione.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Tre contro uno? E che male ho fatto io? Aspettate quanto penso poco poco.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Ohimè! Magagna or ora mi scuopre: ma avendo io adesso la commodità, vuo' partirmi pian piano, levandomi il tinto del volto; procurare una barba posticcia, e sotto altro abito di non farmi conoscere.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Non hai ancor pensato? Di', di', dove sta Ersilia?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Lasciatemi finir, di grazia, e poi fate di me quel che volete voi. Io diceva che il Spagnolo è spade, Flaminio denaro e Camillo coppe. Per far la primiera che cosa ci manca?</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Bastone.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Il moro è bastone: ecco primiera, tiratela e tenetela.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>E dove sta il moro?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Si è già partito.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Or pigliate un bastone e datevi l'un l'altro, sciocchi e insensati che sete. È possibile che niuno di voi intenda l'artifizio mio, che mentre dicevo: avete primiera e non tirate, volevo intendere: avete Ersilia, che va sotto abito di moro per servire all'inconosciuta l'amante suo crudele, e non la pigliate?</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Y es verdad?</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>È vero?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Ed è vero?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Verissimamente; e voi, a battaglia stesa contra di me, avete fatto a punto come fece Sacripante con Rinaldo, che mentre essi combattevano, Angelica se ne fuggì. Correte dunque, arrivate, cercate, procurate che la trovarete.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Ahimè! che io, sciocco veramente più d'ogn'altro, ho conosciuto manifesti segni che ella di se stessa mi dava. Dissemi che il padrone era Camillo, ma lo coprì col cognome “della mia morte”, che l'affezion sua non era nuova, e la vestì con la conformità del sangue. Mi difensò con la spada, con la lingua, con l'ingegno; si dolse di me sotto scusa di dolor colico. Ha detto, ha fatto in somma cose stupende. O Amore, tu puoi quanto sai, che li timidi gli assicuri e li semplici fai savii! e o donna più valorosa che tutti gli uomini del mondo!</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Già che siamo certi del fatto, non perdiamo più tempo. Andate voi, Signor Camillo, di qua; il Signor Giovan Luigi di là, e io da quest'altra parte, che in ogni modo l'incontraremo: con deliberazione che chi prima la trova, la conduchi in casa del Signor Giovan Luigi.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Mi contento.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Così si faccia.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Iammo puro, ca ne boglio la parte mia fino a no fenocchio. E ora ca non besogna contrafare chiù lo spagnuolo, me levo la barba, a tar che le femmene se ne innamorino chiù facilmente de chissa faccia temperata di muschio dintro ad un barattolo di speciale falluto.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 3</head>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Eccomi solo, fuori di pericolo: ma chi averebbe mai pensato che quel diavolo non fosse spagnolo? In buona fè, che se io sapeva che era il Napoletano, essi non sapevano da me il giuoco della primiera. Fu tanta la paura, che poco mancò che non mandassi lo spirto per le parti sotterranee. Ma che ti giova, povero Magagna, d'esser scampato da questo pericolo, se ti trovi ingolfato nell'altro? Se io vado in casa di Cornelia, mi caccia. Se io non vi vado, amor da una banda e la fame dall'altra mi rodono le budella e l'ossa. Non però mi voglio accostare alla casa, confidando in quella sentenzia che fortuna aiuta gli audaci. Ohimè! che faccia di negromante è quella che esce dalla porta? L'altro è Leandro che li va appresso. Mi rimetterò in questo cantone per sentir qualche cosa.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 4</head>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Non mi sono ancora totalmente risoluto, che se ben non abbiamo trovato Camillo in camera, può stare che destramente si sia nascosto in altro luogo. E se ben Franceschetto ha variato, tengo per fermo che sia proceduto per timor della madre che gli era presente. In somma, Leandro, vorrei segni più chiari per dischiarare l'offuscato intelletto mio, perchè le donne son donne, e sanno e ponno fingere una cosa per un'altra.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Ormai, padrone, non mi è rimasto concetto nè parola di potervi dissuadere e levar questa frenesia di capo. Io vi dico risolutamente che Cornelia è casta più che mai, che Camillo è fedele, e che Franceschetto è stordito. Potta di me! volete più presto credere ad una falsa imaginazione, ad un semplice figliuolo, che a quel che avete veduto con gli occhi proprii e tocco con le proprie mani? Andiamo dunque a rivestirci, e ritorniamo a casa.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Aspettate: vuo' prima vedere questo foglio che trovai sopra il mio scrittorio; che, se non erro, parmi la scritta che mi lasciò il Signor Stefano, con condizione che non s'aprisse se non dopo li dieci anni di sua morte. Ed è pur essa. Qui dice: «In anno 1576»; adesso siamo del&lt;l&gt;'86, è già finito il decennio, e per ciò la voglio e posso aprire, con leggerla tutta dal principio al fine.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Ho sentito parlare di Camillo, di Cornelia, di stordito: dubito che questo sia l'astrologo che aspettava la Signora; ma mi maraviglio come non fa menzione di Magagna, che pure per amore venne in furore e matto.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Vengo in finestra, perchè sento parlar nella strada: ed è pur Leandro con quel scempio dell'astrologo; sta leggendo non so che scrittura. Legga pure, faccia segni e caratteri a suo modo, che tutte sono vanità. Non di meno saper tanti particolari tra me e Camillo mi fa stare alquanto sospesa.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Ma perchè vado mirando le piaghe altrui, e non mi miro le mie? Vada Ersilia dove li piace, che io vedrò d'accostarmi a i raggi del mio vivo sole. Eccolo in finestra. Vedo là retirato Magagna, e colà Leandro. Chi è quell'altro in abito lungo? Che novità sono queste? Starò rimesso qui dentro per vederne la riuscita.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Padrone mio, per buona pezza sete diventato stupido. Vi fate segni? Che cosa è cotesta?</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Camillo è Persio!</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Camillo... Ahimè! Persio era mio figlio.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Che ha da far Camillo con Persio?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Camillo è perso? Buono, affè!</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Io non v'intendo, padrone; che dite?</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Cornelia non più amante!...</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Non più amata, dovevi dire.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Non più amante di Camillo, è vero.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Non più amante del perso, ergo di Magagna.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Parlatemi più chiaro.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Figlio e madre.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Nè l'uno, nè l'altro.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>So che dice.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Figlio e madre non stavano bene; ma Magagna <foreign xml:lang="lat">maxime</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Muzio è morto.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Mio marito, è vero.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Erra in nome, io sono il morto.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Me ne contento.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Fatevi intender, di grazia.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Fuora Camillo...</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Ahimè! Non voglio.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Così non fosse fuora.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Mi piace.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Volgetevi in me, che cosa dite?</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>...e venga Persio.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Volesse Iddio.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Costui sarà il diavolo.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p><foreign xml:lang="lat">Domine, non</foreign>.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Fuora, dico, il nome di Camillo, e venga chiamato Persio, figlio di Cornelia e Muzio.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Ahimè! Che sento?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Ahimè! Che dice?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Ahimè! Che parla?</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Che intrico è questo? Districatelo ad un tratto, ditemi il tutto.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Mi tolgo la barba, mi scuopro Alessandro, fuora d'ogni sospetto: Cornelia gli è madre, Persio gli è figlio.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Che fantasma è quello che io veggo? Costui si trasforma in Alessandro, e vuol che i morti siano vivi, e non balbutisce più. Oh, che magico stupendo!</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Ed è pur Alessandro. Ohimè, come è vivo? Io son fuor di me.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Questo è un altro diavolo!</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Voi mi fate stupire e morire di voglia, per non volermi dire apertamente il fatto.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Cornelia già non è mia moglie. Brianda è veramente: costei sarà la mia, colei sarà col figlio.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Nomina la prima moglie, che similmente è morta; parla pur di figlio, e che io non li sia moglie. Che cose contrarie son queste?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Io non posso far altro che stupire.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Camillo amarà Cornelia, ed ella Camillo, d'uno amor giusto e vero... Ma, ecco Magagna.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Ohimè! questo è lo spirto d'Alessandro che se ne viene verso di me, per saper l'amor mio, di Camillo e di Cornelia. Spirto, io ti commando per arte e per parte,che t'allarghi di qua, perchè io ti dirò il vero: sappi che Camillo e io siamo concorsi ad amar Cornelia.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Intendi, Leandro; vedi se io m'ingannavo. Ecco che nell'ultimo la verità da se stessa si discuopre.</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Quando io credevo che fossimo fuora d'intrico, tanto più c'intrighiamo: causa ne sete voi, che parlate per enigma, e volete credere ad un balordo, che per timore del spirito dirà mille vanità.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Segui pur, segui, Magagna.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Ahimè! Non t'accostare, spirito. San Cipriano, prega per me. Io a pena ne ho a&lt;ù&gt;to parole e sguardi.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Ma chi gli ha aùti? Dimmi il vero.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Essa, la cornutella, era dedicata in tutto e per tutto a Camillo. Largo, di grazia, se non volete che rimetta a basso il magnare di tre giorni.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Han forse conseguito insieme il desiderio loro?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Stavano già per far la copula, ma non l'hanno fatta, a fè!</p>
           </sp>
-          <sp>
+          <sp who="#leandro">
             <speaker>LEANDRO</speaker>
             <p>Orsù, che ne volete più?</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Io notavo l'animo: ma poi che questa scrittura mi toglie questo sospetto, andiamo in casa.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Ora mi accerto che costui è da vero il padrone, poi che se ne va verso la casa: chi ha temperato stempere, che il forno è caduto. Ma lasciami accostare pian piano. O padrone mio morto, già fatto vivo, perdonatemi, che la paura mi ha fatto sparlare. Io mi dimento, io mi pento.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Vien meco, Leandro. Andiamo, che mi par mill'anni di consolar Cornelia.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Vengono da me: mi farò fuora per uscirli incontra.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 5</head>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Voglio in ogni modo accostarmi, per chiarirmi meglio. O da me sempre amato, o da me sempre riverito padre e padron mio, mi rallegro in vedervi vivo più che non mi dolsi in giudicarvi morto. Ma come vivete, se Leandro disse che èrate morto? Che abito è cotesto?</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>In quest'abito si è raffinata la fede tua, Persio mio, e non più Camillo, a guisa dell'oro che si raffina nel fuoco. Entriamo, che sentirai cose stupende.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Io in parte ho inteso, ma confusamente, il tenore della scritta che lasciò il Signor Stefano buona memoria, la qual, secondo io intesi, vuol che sia Persio figlio di Cornelia, e che mio padre sia Muzio.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Così sta. Ma ecco Cornelia.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>O cara pupilla de gli occhi miei, o marito mio dolcissimo, giudicato morto per mia continua morte, ma ora vivo per mia perpetua vita! Chi mi ti tolse? Chi mi ti dà? Chi mi addolorò? Chi mi consola? Sei tu che mi consoli, Alessandro mio? Io ti conosco ad un tratto che nè abito nè altro mi ti può nascondere, tralucendo come il sol nel vetro il lume dell'amor nostro. Ho inteso dalla finestra non so che cosa di Persio mio figlio. Raccontami il tutto, e allegrami doppiamente.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Dirò la somma qui fuora, che dentro poi diremo diffusamente il tutto. Ecco: Camillo, ora Persio vostro figlio, che nel sacco di Famagosta &lt;fu&gt; menato con voi prigione, fu venduto poi così piccolo a mio fratello, il quale avendo aùta piena informazione di voi e di Muzio vostro marito, già ucciso nella battaglia, e di tutto il successo, lo scrisse in questo foglio, piacendoli che si chiamasse Camillo a memoria d'un suo proprio figliuolo; e lasciò che s'aprisse nel decimo anno della sua morte, con ordine che io lo debbia trattare da figlio, e che succeda a tutte le facultadi. E perchè dopo, senza sapere che fuste quella, vi presi per moglie, e l'amor naturale all'inconosciuta oprava tra di voi e Camillo, che vi amavate scambievolmente; io, sospettando della fede dell'uno e dell'altro, diedi nome esser morto, e in quest'abito ho fatto esperienza che ambidoi sete fedeli e casti.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Deh, che io diceva che l'amor che io portavo a Camillo era troppo grande! O Camillo, ora Persio mio, figlio caro! che per accertarmene meglio vedrò se sotto l'orecchia sinistra ha un neo. Eccolo pure! O figlio mio, o figlio caro! Io ti bacio, figlio, e non amante.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>O vive fiamme d'amore, come sotto le ceneri abbrugiavate intensamente! O madre, amata sotto coverta d'amante! Il tuo figlio t'ama e t'abbraccia, non da amante, ma da madre sua amatissima.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Saria giusto che io baciasse ancora, <foreign xml:lang="lat">pro rata temporis</foreign>, mentre son stato amante come esso.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Fuora le vesti negre, fuora il lutto, facciam festa, giubiliamo, poi che il marito e il figlio ho ritrovato ad un tratto.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Il figlio avete ritrovato, ma dubito che perderete il marito; poichè è viva Brianda, mia prima moglie, quale è Leonora, moglie di Messer Alberto, mastro de' Studii.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Ohimè! che dite? E io dubito che Alberto non sia Muzio, mio primo marito, poi che poco innanzi è venuto egli stesso a darmene aviso; e io era in còlera, e perchè esso portava altr'abito, e la barba, che prima non avea, non vi posi mente e non lo conobbi. Ma sarà egli del certo. Intriamo dentro, che se sarà così, voi da un lato e io dall'altro restaremo contenti.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Intriamo, che Iddio che sa l'intrinseco de' nostri cuori metterà ordine a tanti disordini.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Entriamo, Signori, che lasciati questi panni di lutto e rivestito de gli altri andrò da quell'altra porta a ritrovar l'infelice Ersilia, acciò non corra pericolo dell'onore, e acciò se li dia il debito guiderdone dell'amor suo verso di me; e anco per informarmi se Alberto sarà Muzio, mio padre.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>Dite bene, figlio mio dolcissimo. Entrate.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Questa è la volta ch'io mi faccio dottore in tutto e per tutto, se mi succederà padrone Messer Alberto, mastro de' Studii. Ma tra tanto io voglio entrare, perchè stando tutta la casa in allegrezza, Magagna magnarà quanta magnativa li verrà magnanimamente innanzi.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 6</head>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Il desiderio de' denari tanto più cresce, quanto più ne hai, dice quel proverbio. Subito che io me incorbonai li cento scudi, mi venne una brama di ammassarne de gli altri, che ne vorrei tanti che non mi bastaria il Coliseo tutto pieno. Ho speranza che Camillo mi sarà anch'egli cortese, e che Flavio, ottenendo l'intento da molinaro, mi darà la farina da poterne fare pane; e perciò son venuta fuori per saper la riuscita dell'uno e dell'altro, e per procacciarmi alcun altro di quelli che fanno cantar gli orbi. Ma, ohimè! ecco Messer Alberto che esce di casa, e con lui viene Messer Manilio. O Dio, siamo scoverti! Vuo' starmi qui dietro per sentir qualcosa.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p><foreign xml:lang="lat">Bene merentibus praemia tribui oportet</foreign>, e per questo non accaderà ringraziarmi, Messer Manilio mio, poi che alla virtù e meriti di Flavio vostro figliuolo è stato poco premio l'averli dato Lavinia per moglie, e concorrendoci di più l'affezion grande e la stretta amicizia che è stata sempre fra di noi.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Sono infinite le grazie e favori che mi avete fatti, e per ciò non mi sazio mai di ringraziarvene. Ma per non parere che io voglio sodisfare con le parole solamente, mi riserbo corrispondere con li fatti ancora e con gli effetti, pregandovi che me ne diate spesso occasione, acciò vi possa mostrar la prontezza dell'animo mio.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Io stupisco di così buona e repentina nuova.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Basta: quanto si è detto, è detto. E procuriamo in ogni modo di ritrovar l'astrologo che ci ha detto Leonora, adesso Brianda, per sapere se veramente è vivo Alessandro suo primo marito, che secondo ella mi va contrasegnando dubito che non sia Alessandro, marito già di Cornelia; che se così fosse, sarebbe una bella congettura.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Per certo io mi son stupito: mentre voi con bell'arte notificando a Leandro la ritrovata di Cornelia vostra moglie, ella soggiunse che l'astrologo l'aveva scoperta Brianda e non Leonora, e dettoli che Alessandro suo primo marito è vivo. Veramente se fosse così sarebbe, come avete detto, una bella congettura, poi che si farebbe un onesto cambio tra di voi, che ciascheduno si pigliaria la prima moglie.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Che altre nove care, che altre rare cose son queste!</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Certifichiamoci prima della persona e della vita di Alessandro, che appresso poi si darà rimedio tale che risulti in onore e benefizio di tutti. Ohimè! che fra questo dolce s'interpone l'amaro di Persio mio figlio, il quale credo sarà morto, perchè se fosse vivo sarebbe con Cornelia &lt;sua&gt; madre.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Non dubitate, Messer Alberto, che sì come le disgrazie, così anco le grazie vengono sempre attaccate insieme; e chi sa se Camillo, riputato figlio d'Alessandro, fosse Persio vostro figlio, e si avesse cambiato quel nome della maniera che facesti voi.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>L'aver inteso che Camillo sia figliastro di Cornelia non mi ha fatto persistere nell'opinione, che ho aùta sempre, che costui non fosse mio figlio; e così mi dava un'aria di lui, così il sangue amorosamente mi bolliva nelle vene.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Poi che mi dite questo, state di buon animo, che qualche cosa sarà. Può stare che Alessandro abbia riscattato vostro figliuolo e dato nome d'esser suo figlio proprio, e che Cornelia per la longhezza del tempo non l'abbia riconosciuto.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Può stare, e dite bene, per la longhezza del tempo, poi che sono da doi anni in circa che Camillo è venuto da Genova per studiar in Roma; di sorte che Cornelia l'ha veduto a tempo che era già fatto uomo. E può stare ancora che Alessandro abbia fatto di lui come feci io di Flaminio, che essendo egli figlio d'un certo Hermando spagnolo, me lo pigliai per figlio proprio, e da Consalvo lo chiamai Flaminio, acciò non fosse riconosciuto.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Or senti quest'altro!</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Di maniera che Flaminio non è vostro figliuolo?...</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Signor no; che come vi ho detto fu figlio d'un Hermando Contiero, il quale abitando in Malta con la moglie, che si chiamava... oh Dio, non mi soviene!</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Erminia.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Sì, sì. Ma che voce è quella che a punto mi ha detto il nome? Sete voi, Bianchetta? Come lo sapete? Che fate qui?</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Son io. Mi son fermata a sentirvi, e temo che questo Flaminio non sia fratello d'Ersilia.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Di chi Ersilia?</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Seguite l'istoria, che poi vi dirò.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Io dicevo che Hermando Contiero, abitando in Malta &lt;con&gt; Erminia sua moglie, ordiva non so che tradimento alla religione, laonde il Gran Mastro procurò d'averlo nelle mani; ma egli avertito di ciò se ne fuggì con tutta la casa, dismenticandosi per disgrazia di quel figliuolo, che s'allattava in casa della nutrice: quale per timor che come figlio di rubello non avesse portato la pena del padre, consultandosi meco, che ero allora in Malta, lo chiamammo Flaminio, sotto colore che era mio figlio. La nutrice poi fra pochi mesi si morì, e il figliuolo restò in mio potere. De lì a certi anni me ne venni in Roma, e non seppi mai nova di questo Hermando, nè della moglie.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Non più, non più, la cosa è certa. Hermando per non farsi conoscere si mutò nome, chiamandosi Alonso, e chiamò la moglie Isabella, la qual partorita Ersilia si morì. Ed egli ricasandosi con Cornelia, si morì similmente.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Che dite, Bianchetta? Dunque Cornelia prima di Alessandro ebbe Hermando, o vogliam dire Alonso, per marito? Càpperi, e son dui dopo me!</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Sì. Oh, che caso stupendo! E Flaminio, che nulla sa di questo, è innamorato della propria sorella.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>E come sapete voi tanti particolari?</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Lo so perchè allora io praticavo in casa d'Alonso, il quale nell'estremo di sua vita mi publicò tutto il successo; e Cornelia me l'ha confermato poi con Ersilia, a fine che io procurasse di saper nova di Consalvo. Or va indovina che era Flaminio!</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Ditemi il vero, Bianchetta: che si dice di questa Cornelia, e come è vissuta casta?</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Castissima! Un essempio, un ritratto vero di castità e di prudenzia. Non tocchiamo questo, di grazia.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Mi piace. E quel Camillo, che viene ad essere a Cornelia?</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Figliastro, credo io.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Credi tu: dunque non è così? O Dio, se si ritrovasse suo figlio, e fosse Persio!</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Interrogatela pure.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Questi si pensano scalzarmi per saper l'amor di Cornelia con Camillo. Ma io son vecchia, e femina di più.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Dunque Camillo non sarà certo figliastro di Cornelia, poi che dici che tel credi.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Io non so tante cose; ma so che Camillo è figlio di Alessandro.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Orsù, va bene; e sapete se Alessandro è vivo?</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Intendo che sia morto; ma un certo astrologo pretende sia vivo.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>E dove sta quest'astrologo?</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Parmi che stia in Banchi.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Or basta. Resta con Dio, Bianchetta; e noi, Messer Manilio, andiamo a ritrovar questo astrologo, che chi vuol vadi, e chi non vuol mandi.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 7</head>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Io non intesi mai il più bell'intrico di questo. Messer Alberto si ha lasciato dire che egli è marito di Cornelia, e che Leonora è Brianda moglie di Alessandro, e che Alessandro è vivo; Flaminio è Consalvo fratello d'Ersilia; Camillo non è figlio di Alessandro, ma si dubita che non sia di Cornelia. Amor lusinga l'uno e l'altro. Flavio da molinaro si è fatto marito di Lavivinia sua. Che mutazion di tempo, che volger di ruota è questa, o Fortuna? E acciò che non succeda alcun disonore, andrò a ritrovar Flaminio, volsi dir Consalvo, per dirli ogni cosa, che averò tempo poi di provedere intorno al mio particolare, perchè si dice che chi ben semina, meglio ricoglie.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 8</head>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Sì come l'aurora, squarciando i veli della notte oscura, apporta seco il lucido giorno, e il sole rompendo i duri giacci fa che corrino acque limpide e chiare, così voi, anima dell'anima mia, con l'aurora della grazia vostra spezzando le notti delle mie disgrazie, m'avete apportato un giorno felicissimo, e col sole delle bellezze vostre rompendo la dura crudeltà, fate correre un mare di gioie e di consolazioni, dove io godendo voi, che sete vaga più che l'aurora e bella più del sole, mi reputo il più felice e il più contento del mondo.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>E io, Flavio mio dolcissimo, combattuta da un falso pensiero, che l'amor vostro non fusse stato finto, con disegno d'ingannarmi, già che mi conosceva indegna di voi, mostrai d'odiarvi a morte, e amavo altri della mia qualità. Ma poi che ho conosciuto chiaramente che m'amate con puro e sincero amore, vi certifico che quell'odio era apparenza, e che oggi v'amo e amarò sempre più che me stessa: essendovi degnato d'accettarmi per moglie non per mia bellezza, come dite, ma per vostra bontà e cortesia.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Per le bellezze esteriori, e maggiormente per quella dell'animo io vi amo e onoro; come così farò sempre, non solo da marito, ma da servo obendientissimo.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Sarò io obedientissima serva di voi, mio marito e mio signore. Ma ditemi, perchè vi volete partire? Dove andate? Non mi lasciate, di grazia.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Il partire m'è pena, come il stare con voi mi è sommo contento. Ma considerando che se ben parto con la persona, resta con voi la miglior parte di me, delibero partirmi per sapere che cosa ha fatto Camillo, che essendo egli stato mezzo di così felice successo, è forza che io l'aiuti con tutto il mio potere.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Sarebbe meglio mandarci altri, e voi restiate meco, perchè senza di voi sto senz'anima.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Ritornarò quanto prima, che se io potessi confidare in altri il segreto, lasciarei d'andarvi per non lasciar voi, che sete la vita mia.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Vedo venir gente di là. Fermatevi, non andate via, acciò non vi succeda qualche disgrazia; vediam prima chi sono.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Colui mi par Camillo. Egli è certo, e non porta più i vestiti di lutto, dal che argomento buonissime nuove; ma sospetto, poi che lo vedo turbato in volto, insieme con quell'altro giovane che similmente vien turbato. Ritiriamoci qui dentro, osservando quel che dicono.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 9</head>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>È possibile che quel moro sia partito da Roma? Deh, ditemi il vero, giovinetto mio caro, quando fu? In che modo? Come lo sapete voi? Dove lo conosce&lt;s&gt;te? Che vi disse? Dove andò? E in che luogo lo potrei trovare?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Si è partito mo poco innanzi alla disperata; lo so, che èramo un'anima e doi corpi insieme. Lo conosco da tre giorni in qua: mi disse che era donna e non uomo, si chiamava Ersilia, andò non so dove: e credo che non lo trovarete senza di me.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Senza di voi! Dunque sapete voi dove ella sta? Andianci, di grazia.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>A che fine?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Già che sapete il principio, vi dirò anco il fine. Ersilia amava me, e io non amavo lei, perchè amavo Cornelia, come ella amava me. Costei per causa d'Ersilia converse l'amor suo in odio, il qual odio ritorcendo io contra Ersilia, l'odiava più che la morte. Cornelia adesso si ritrova mia madre; e io per corrisponder all'amor grande d'Ersilia, che per me si è messa in tanti pericoli, ho rivolto quell'odio in amor tanto estremo, che spasimo e moro per la mia dolcissima Ersilia.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Ritrovarete effetti contrarii: che quell'amor grande che allora vi portava Ersilia si è rivolto in un odio così estremo, che ella vi vorrebbe da senno veder spasimare e morire. Deh! ingrataccio che sei stato a disprezzar l'amor di donna giovane e bella per un'altra di tempo e di mediocre bellezza. Incauto che sei! E chi non sa che adesso per rifiuto di Cornelia t'adduci ad amar Ersilia? Va pur, che essendo io un'istessa persona con quella povera giovane, ti desidero ogni peggio.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>O Dio! che dolci pensieri mi manda adesso Amore! Fermati, quel giovane, e forse direi meglio fermati, Ersilia: già non m'inganno come prima, che Amor mi svela gli occhi. Deh, che penso? Deh, che miro più? Riconosco ben io la barba è posticcia, ne la toglio, e togliendola veggo... Ahimè! che veggo? Veggo che voi sete, sete voi, Ersilia! Vi veggo, anima mia, occhi un tempo discari; volto che m'intorbidavi, adesso m'assereni; bocca che amara m'apparve, e adesso miele distilla. Parlami, bocca; girati, volto; miratemi, occhi cari. Volto sereno, bocca suave, ecco il vostro amato Camillo che v'ama, vi contempla, v'ammira!</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Oh, potenzia grande d'amore! Io stupisco, Lavinia mia.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>E io ancora; ma quel che importa, vedete che contemplando fissamente Camillo più col pensiero che con gli occhi, non s'avede che Ersilia si parte pian piano, e ora rimarrà egli solo.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Io conosco il mio fallo; vi chieggio perdono, conservatrice delle mie speranze. Rispondimi pure. Ma chi mi tien che non t'abbracci? Ohimè! che il vento abbraccio. Dove sei? Chi mi ti tolse, Ersilia mia? Sei forsi l'ombra sua? E se pur sei l'ombra, ritorna a consolarmi; e se pur sei Ersilia, come ti parti senza esser vista? Fu l'acuto mio pensiero che, stando fisso in te, mi coperse la vista. Deh! crudeli amanti, imparate da me misero: non dispregiate più chi v'ama; ecco la mia pena, merito assai peggio... Ma perchè indarno mi crucio? Già ritorna di nuovo: tu non mi scapperai!</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Nè a me più scapperà!</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Tenetela stretta, chessa mariolella, ca pare sia chella ca se trasformava 'n tante forme, allo tiempo antico delli Romani.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Deh, lasciatemi, di grazia, andare. Che volete da me? Chi sete voi?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Sono il vostro Camillo.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Allora mio, e non adesso.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>E io il vostro non mai Flaminio.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Adesso mio, e non allora.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>E io lo Signore Gialaise.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Non vi conosco, gentiluomo.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>E io te boria conoscere.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Dunque non mi ami?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>No.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>E me ami?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Sì.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Deh! se è vero che con il tinto di fuora ti hai levato anco il crudo di dentro, dammene segni più certi: sana e salva un che si muore.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Oh, che cose stupende io sento! Oh, che cose nuove io vedo!</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Degne veramente d'esser intese e viste.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Deh, perchè tardi a rispondermi? Rispondimi, vita mia: non sarai tu la vita mia?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Sì.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>E del tuo Camillo?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>No.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Instabil tempo, voglie mutabili, donne perverse, Amor crudele, infelice Camillo!</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Io non posso più dire, impedito dalla gioia immensa che sento in udir che io son vostro.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Ahimè!</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Che cosa è questa, Signor Camillo? Vi dispiace forse che io riceva il premio delle lunghe fatiche? Sin qui mi ho persuaso che le vostre dimande erano per scolparvi, chè Ersilia non vi amava: ma ora mi date quel sospetto che sempre ho aùto di voi.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Ecco pur, Signor Flaminio, un manifesto segno della mia viva fede e dell'affezion grande che io vi porto. Ersilia fu sempre odiata da me, e ora, non so come, Amore me l'ha di sorte scolpita nell'animo che io son tutto suo: adesso che ella non è più mia! Ma essendo tutta vostra, goderò che vi godiate insieme felicemente; e preponendo la mia amicizia al mio privato interesse, mi partirò di Roma, e sbandito e misero cercarò come posso finir meglio il resto della vita mia.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Non piaccia a Dio, Camillo, che io mi renda ingrato e che defraudi la fede e affezion vostra verso di me. Ecco che vi rinonzio il tesoro tanto da me desiderato; e sentendomi pago da quei “sì” datimi da Ersilia, viverò contento che viviate insieme contentissimi.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>L'importanza mo sta sa si contenta issa: pecchè la renunza fatta pe Vostra Signoria no' vale senza lo consenso suo: e io lo saccio moto bene pe la longa pratica delli tribunali de Napole. Orsù, chi bolete, Signora Ersilia?... Sta zitta: no' bolesse nè l'uno nè l'autro, e s'attaccasse co me?</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Non sete contenta, Signora mia, di ripigliarvi il vostro Camillo?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>No.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Ma volete il vostro Flaminio?</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Sì.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>E tre vote sì: concludemolo, e spedimola.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 10</head>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Dove sarà costui? Ma eccolo pure, e vi sta Camillo, e vi è ancora Ersilia vestita da uomo. Che novità son queste?</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>E io non voglio, Signor Flaminio, nè ancora rendermi ingrato all'effetto grande dell'amor vostro; mi quieto; vi dono la Signora Ersilia, dono veramente prezioso e caro, degno di voi, caro e prezioso tempio di rara e perfetta amicizia.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Oh, troppo caro, oh, troppo eccelso dono! che se bene io me ne conobbi sempre indegno, me ne farà degno la grazia della Signora Ersilia, a chi dono questa fede non solo di marito, ma di servitore e schiavo.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Che servitore? che marito? che schiavo? Fermatevi, non date la mano, Ersilia! Statti, Flaminio, che non più Flaminio &lt;sei&gt; ma Consalvo figlio di Alonso, che era Hermando padre di voi: e voi sete fratello e sorella!</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Chesso è n'autro cunto dell'uorco.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Che dite, Bianchetta? Dunque Flaminio è Consalvo mio fratello? Consalvo che restò in mano della nutrice in Malta, secondo più volte mi disse mio padre? Come lo sapete voi? Deh, ditemi il vero.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Lo so da Messer Alberto, che mi ha dati i segni e contrasegni; ma perchè l'istoria sarebbe lunga, e non converia dirla qui fuora, stando Ersilia vestita da uomo, andiamo in casa della Signora Cornelia.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Che baie son queste? Se io son figlio di Messer Alberto, come posso esser fratello di Ersilia? Andate, vecchia, e non ci sturbate, di grazia.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Che volete fare? Deh, non fate, fermatevi, che è certo come dico io!</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Fatevi sopra, Signora Lavinia che è forza che io vada per risolvere il tutto.</p>
           </sp>
-          <sp>
+          <sp who="#lavinia">
             <speaker>LAVINIA</speaker>
             <p>Io starò alla gelosia, e voi tornate presto.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Signori, io vi bascio primieramente le mani.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Siate il benvenuto, Flavio mio.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>E poi vi prego ch'ascoltiate. Io da parte ho inteso quel che è passato fra di voi: e mi resta di dire che con l'artificio di Bianchetta e con il mezzo vostro, Signor Camillo, introdotto in casa di Messer Alberto (il quale sopravenendo con mio padre, ho fatto in maniera che Lavinia sia mia moglie); e conferendomi Messer Alberto in segreto che voi, Signor Flaminio, non gli sete figlio, ma vi prese in Malta di mano d'una nutrice, e che eravate figlio di questo Hermando; quel che ha detto la vecchia dico esser vero, e perciò voi sete veramente fratello e sorella.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Saldo, ca essa a poco a poco ritornarà la mia pecchè l'uno l'ha renunziata, e l'autro l'è fratello; donca azzic&lt;c&gt;araggio io.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>Ahimè! che più volte ho detto fra me stessa che gli occhi e il volto di voi, Signor Flaminio, si rassomigliavano alla mia madre. O Consalvo e non Flaminio, o fratello e non marito!</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>O sorella, e non moglie, così t'abbraccio e ti bacio; e quell'amore intenso che era di moglie, resta amore sviscerato di sorella. E a voi, Signor Camillo, ridóno l'istesso tesoro tanto caro di sorella, quanto caro era di moglie; e voi, amatissima sorella, riamate il vostro Camillo, che egli amandovi fortemente sarà vostro marito.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>O castissimo fuoco, che abbrugiando i vani pensieri ha suscitato un casto, un conforme, un perfetto volere. Eccomi, Ersilia mia, così tutto tuo come prima desiderasti, e come credo che al presente desideri, tal fede me ne fa il sviscerato amore che ti porto.</p>
           </sp>
-          <sp>
+          <sp who="#ersilia">
             <speaker>ERSILIA</speaker>
             <p>O santo Amore, come conduci a porto felice chi t'adopra santamente! Fu di marito il mio pensiero, e per marito t'accetto, Camillo mio dolcissimo.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>E io con il dolce bascio ti confermo mia moglie, e questo anello leghi perpetuamente i nostri cuori. O giorno per me troppo felice, avendo madre e moglie ritrovato. Deh! se Alberto fosse mio padre, come già me ne ha dato segno la Signora madre, io che adesso sono Persio e non Camillo mi chiamarei felicissimo.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Tu sei Persio? Dunque sei figlio d'Alberto.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Voi siete Persio? Oh, che buona fortuna! E sete figlio di Cornelia.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Di Cornelia.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Dunque Muzio, insin adesso Alberto, è vostro padre? Rallegratevi, cieli, di tanti felicissimi successi, se pur non verranno interrotti dalla morte d'Alessandro.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Alessandro è vivo, e adesso è in casa, che l'astrologo ha scoperto Leonora esser Brianda sua moglie; talchè, se Alberto è Muzio mio padre, le cose averanno felicissimo fine.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Così è certissimo; e per ciò sarà bene, Signor Persio, che entriate tutti in casa, a fine che, ritrovando Muzio, si possa rallegrare con il figlio e la Signora Ersilia nora.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Mi pare più espediente che entriamo in casa della Signora madre, che conferendo il negozio con lei e con Alessandro, si pigliarà oportuna risoluzione. Io vi ringrazio del buono offizio, e spero or ora di venirvi a trovare in casa per riverire e abbracciare il mio desiderato padre.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>A Dio, e vi aspetto con desiderio per unire insieme tante insperate allegrezze.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>A Dio, Signor cognato e fratello; e noi, Signor Gialaise, entramo in casa, e venite pur con noi, Bianchetta mia: che sì come sete stata partecipe delli travagli, così anco sarà bene a partecipare delle consolazioni.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Entra prima Vostra Signoria.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Eh, Vostra Signoria entri.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>No, a fè, a Vostra Signoria tocca.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Fatemi questa grazia.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Procedemo alla spagnola, ca all'entrare entra prima lo padrone, e all'uscire esce prima il forastiero.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>Vostra Signoria è padrone di me e della mia casa. Non però voglio obedire.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 11</head>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>In qualche parte sarà quest'astrologo! Se ben Roma è grande, non avemo lasciato loco di cercare e ricercare. S'egli non si ritrova, e se pure Alessandro non viene, io &lt;non&gt; mi saprò risolvere di lasciar Brianda come abandonata e sola.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Usiamo tutte le diligenzie possibili; che quando s'averà la certezza della morte di Alessandro, ad ogni cosa vi è rimedio: che, ripigliando voi Cornelia, io mi accommodarò con Brianda.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p><foreign xml:lang="lat">Matrimonio mediante</foreign>, s'intende, Messer Manilio. Esprimasi meglio quel verbo, accommodare, perchè è una certa parola pregnante.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Ah, ah, ah! Mi fate rider da senno. Posso io pretender altro che matrimonio per la qualità e per l'età mia, e per rispetto vostro e di Lavinia mia nora, che come sapete è figlia di Brianda?</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p><foreign xml:lang="lat">Cautelam cautelae addere cautius est</foreign>. Ma senti: che suono di tamburello è quello che si sente dentro la casa di Cornelia? Esce un figliuolo sonando, e quel pezzo d'uomo che è Magagna vien saltando: retiriamoci qui dietro, e sentiamo un poco che cosa voglion dire.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 12</head>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Balla forte, balla, balla, balla forte, il mio Magagna! Se non balla, a fè, non magna! A fè, non magna, se non balla!</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Dammi tu delle fescelle, ch'io son stracco di ballare! Vuoimi dare, vuoimi dare, vuoimi dar delle fes... fes... fescelle?</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Oh, oh! vuol dir frittelle all'usanza di Puglia, e dice fescelle. Tu stai fresco, poi che cominci a perder l'<emph>r</emph>.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Dammene un altro po... po... poco.</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Sì, sì, dillo più chiaro, che l'altro non s'è inteso.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Ca... ca... ca...</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Fermati, non scappar, Baiardo.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Fa... fa... fa...</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Fa su il càncaro che ti magni.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Ca... ca... fan... fan... Franceschetto, Franceschetto.</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Caro Franceschetto, vuol dire; col saltare si è commosso tanto più il vino. Alla fè, che tu stai concio per le feste.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Sì, sì, sì! Fes... fes... fes...</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>E pur là!</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Fes... fes... fesce.... fescelle voglio, e ca... ca...</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Piano, che te le darò tutte, acciò non scappi in qualche disordine. Eccone una; apri la bocca e prendila. Non è buona?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Bonissima, ma pochissima. Mena, mena un altro po... poco.</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Poichè tu sei goloso, te ne darò assai assai, pur che salti a passar questa bacchetta, come fa il nostro cagnolino in casa: non te ne contenti?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Sì, sì, pur che l'abbia tu... tu... tutte.</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Tutte. Or salta. Tu non ci vedi, pover uomo; da questa parte. Dove vai? Ecco qua la bacchetta, salta! So che l'hai preso, il granchio. Non ci vedi mica: salta da valent'uomo. Oh, bella! Cascò con la sua lotta.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Or sta così mo tu: peggio per te, che io son alto quanto sei tu pa... pa... pa...</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Pane vuole adesso, e non più fescelle.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Par... par... pari in buona fè: dormiamo tutti insieme, che io mi stendo e colco.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Io smascello dalle risa.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Puossi sentir più bella comedia di questa?</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Oh, come stai bello adesso! Ma vedi, che cominciò subito a gorgogliare; è segno che il pignatto è pieno e il fuoco del vino bolle. Io vorrei vendicarmi di costui, che mi suole al spesso battere... Prendo la cintola per legarli le mani e i piedi.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Lasciamolo star così, quel figliuolo, che ogni poco che si riposa non gli darà tanto fastidio il vino. E tra questo mentre dimmi, per vita tua, che allegrezze son queste che si fanno in casa, poi che venendo voi fuora, andate sonando e ballando?</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Allegrezze d'importanzia. Chi era morto è vivo; chi era perso, si trova; chi voleva esser moglie, è madre; chi marito, è figlio; chi era amante, è fratello; chi era intricato, si strica. Oh, che intrico, oh, che districo!</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Chi era morto, è vivo! Sarà forse costui Alessandro? E... sarà Alessandro, e dove sta?</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>È vivo, sta in casa, e già Magagna veniva a chiamar non so chi Muzio, che era prima un altro e oggi è marito di mia madre.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Muzio, che era prima un altro e oggi è marito di tua madre? Dunque son io! Ecco, Magagna lo sa. Non è tempo questo da perdere, vuo' chiamarlo: Magagna, levati, non dormir più, e dimmi: è vivo Alessandro?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Oh, oh! chi mi rompe il sogno? Ma io come son qui? Tu sei M... Mu... Mu... Muto: mi levo e vi dico, a fè, che io mi ricordo che io sto, sto...</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Stai allegro, e con questa allegrezza voglio saper da te se Alessandro è vivo.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>È vivo, e io vivendo con lui ho beùto mo, e beverò anco appresso, perchè Alessandro è vivo, e quanto più si beve, tanto più si vive: e perciò vengo a dirvi che per beveraggio mi date a bere, se volete che io viva vostro servitore.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>O Magagna, re de gli uomini! farò che non solo bevi, ma che magni ancora per molti giorni a tua posta.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Ma ecco che vien fuora Brianda, e con lei Pasquina, e vi è pur Flavio mio figlio. Andiamoli incontra per saper dove vanno.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 13</head>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Oh, che influenzie d'allegrezze son queste d'oggi, poi che veggo ancor voi, Signora mia, tutta allegra e gioconda in volto? Ditemi, che cosa ci è di nuovo, e dove andate?</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>A tempo vi trovo, Messer Muzio, e non Alberto; e il trovarvi a tempo giunse consolazioni alle mie consolazioni, già che gionti possiamo andare in casa della Signora Cornelia, voi per ritrovar la prima vostra moglie, e anco Camillo, che è Persio vostro figliuolo; e io per ritrovar Alessandro, mio primo marito, già che è vivo e sta nell'istessa casa, secondo mi ha detto il Signor Flavio aver saputo per cosa certa: e così uniti insieme rifermaremo il negozio, di sorte che ciascuno rimarrà sodisfatto.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Già che le cose con l'aiuto di Dio vanno per buon camino, giungeremo senza dubio al luogo desiderato. Andiamo dunque, Signor Muzio, andiamo, Signor padre: ambi padri e miei Signori, così come la Signora Brianda e Cornelia saranno ambe madri e Signore.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Mi piace questo pensiero. Andiamo tutti.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Andiamo, e rendo grazie infinite al Signore di tante segnalate grazie.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Sona, Franceschetto.</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Io sono, e tu balla, balla.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Che cosa? Sete matti?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Poi che stiamo tutti allegri, sarà bene andar cantando, perchè be... be... c... c... a fè, a fè...</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Eh! Ferma, semplicione che sei.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Chi è quella che mi batte e parla all'usanza di Puglia? Eh là, oh là, chi sei tu? Io miro... e pur mirando trovo che tu sei Gentilesca! Ti conosco, sì, figlia mia, tu sei la Gentilesca.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Che Gentilesca! Io mi chiamo Pasquina, e non Gentilesca.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Ti è stato cambiato il nome, ma tu sei essa certissimo, figlia mia, che t'ho cercato tanto tempo, che a questo fine son venuto in Roma, dove intesi che eri capitata, e mai ne ho potuto aver nova. Io ti abbraccio, io ti piglio in braccio, figlia mia gentile, oh, la bella Gentilesca!</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Lasciami stare, che ti darò un pugno in questo viso di ladro.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Ferma, quell'uomo da bene, e taci tu, Pasquina, perchè costui dice il vero, che tu ti chiami Gentilesca. Ma dimmi, dove conosc&lt;est&gt;i tu costei?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Che cosa è conoscere, se è uscita dalle mie viscere? Che incorporandomi con mia moglie, che fu di casa Lesca, e io essendo di casa Gentile, &lt;da Gentile&gt; e da Lesca ne nacque Gentilesca.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Non basta, che molte volte succede che uno s'assomigli all'altro. Voglio sapere ancora il tempo: dimmi, quanti anni sono che non l'hai vista?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Sette anni sarà il primo di Carnevale; e la figliuola allora aveva da sei anni in circa.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>È vero. Di che nazione sei tu? E in particolare di che terra?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Io son pugliese, e la mia terra è Triggiano; e stando la povera figliuola in la città di Matrone in casa di certi miei parenti, a tempo che io andavo fuggendo per debiti, passaro di là certi diavoli spagnoli, e il Capitan Fiasco l'arrobò e la menò seco.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>Il Capitan Valasches, volete dir voi. La cosa si va dichiarando a poco a poco; ditemi, che segni tiene sopra la figliuola?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Nella camera del piede sinistro tiene certi segni neri, che rilevano un <emph>M</emph>, e un <emph>F</emph>, che vuol dire Magagnifico.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>È vero, è più che vero: costei è vostra figlia, perchè il Capitan Valasches, poco prima che morisse, la menò seco da quelle parti di Puglia.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Oh, che complimenti d'allegrezze son questi! In ricompensa del buon animo che mi ha sempre mostro Pasquina, adesso Gentilesca, supplico, Signor padre, che se gli debbiano dar 50 scudi per la sua dote.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Mi contento, figlio mio.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>E io, per li servizii fattimi, li dono altri 50 scudi.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>E io delli miei altri 50.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Che sono 150, dote competente per il Signor Giovan Luigi Napolitano, il quale stando intensamente innamorato di lei, so certo che se ne contentarà, non mirando alla sua bassa condizione. Andiamo dunque, che stando egli in casa del Signor Alessandro, saldaremo ogni cosa con bel modo.</p>
           </sp>
-          <sp>
+          <sp who="#franceschetto">
             <speaker>FRANCESCHETTO</speaker>
             <p>Aspettate, Signori. Magagna per l'allegrezza si è dimenticato. Dissero quei Signori che dicesse a voi, Signor Flavio, che non vi foste partito di casa, che loro sarebbono venuti a trovarvi con la Signora madre, con Ersilia, e con tutti... Ma eccoli che vengono fuori.</p>
           </sp>
         </div>
         <div type="scene">
           <head>Scena 14</head>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Il punto sta se senza nota d'infamia ciascuno si può ripigliare legitimamente la sua prima moglie. Ma eccoli, che anch'essi sono in via. Vi baciamo le mani, Signori, rallegrandoci che ci avete prevenuto ad uscir prima di noi, per l'occasione d'esservi avicinati alla mia casa, dove mi sarà cosa grata ricevere così onorata e nobil compagnia.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>Signor Alessandro, già che tutti sappiamo quel che passa, per non replicare il medesimo resta solo di risolvere il punto che Vostra Signoria poco avanti diceva: cioè se senza nota d'infamia ciascuno si può legitimamente ripigliare la sua prima moglie. Onde io, come dottore consumato nelli studii delli sacri canoni, dico che dove non è peccato, non è infamia: e perchè voi e io giudicammo le mogli morte, legitimamente ne ricasammo. Così Brianda e Cornelia riputando noi, loro mariti, similmente morti, legitimamente si ricasorno. In tanto che, non vi essendo peccato, non vi resta infamia, anzi siamo tutti degni di lode: <foreign xml:lang="lat">quia sicut hae mulieres, quae ad suos viros reverti nolunt, impiae sunt habendae; ita illae, quae in affectum ex Deo initum, redeunt, merito sunt laudandae. Ita iudico, ut in Titulo 34. cap. 1. quaest. 2</foreign>. Ripiglisi dunque ognuno la sua moglie, che tutti onorati e senza colpa restaremo.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>Ringraziato Iddio, che ci ha concesso che voi foste dottore per risolvere in un tratto il dubio che mi perturbava la mente. Or che, Brianda mia, li cieli permettono, dopo tanti infortunii e pericoli di morte, io vi vegga viva e salva, ritorno a voi, desiato mio porto, come nave combattuta da varie tempeste, per riposarci insieme felicemente; e però vi abbraccio e vi stringo, e così stretta e abbracciata a pena credo che abbracciata e stretta vi tenghi, anima mia, che vi credevo in Cielo tanto lontano da noi.</p>
           </sp>
-          <sp>
+          <sp who="#leonora">
             <speaker>LEONORA</speaker>
             <p>O Alessandro mio caro, o marito mio carissimo! Il coltello che mi trafisse l'alma, mentre morto vi giudicai, troncando al presente i travagli passati, m'imprime nel petto la bella vostra imagine, e raviva quell'amor casto e vero che scambievolmente fu e sarà sempre tra di noi.</p>
           </sp>
-          <sp>
+          <sp who="#alessandro">
             <speaker>ALESSANDRO</speaker>
             <p>E voi, Signora Cornelia, poi che il giusto richiede che ritorniate al primo vostro marito, godetevi insieme, tenendo per fermo che in ogni occasione averete me più che pronto, come fratello amorevole e come servitore affezionatissimo.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>E da mia parte, e da parte di lei, vi ringrazio infinitamente, Signor Alessandro. Ma perchè dentro a più bell'agio potremo consolarci, entriamo, Signori, in casa mia: e abbracciata voi, Cornelia, per quella amata consorte che mi foste prima, prego i cieli che ci concedano ogni compita felicità.</p>
           </sp>
-          <sp>
+          <sp who="#cornelia">
             <speaker>CORNELIA</speaker>
             <p>E io, Signor Muzio mio, non potendo dir altro per l'immensa allegrezza che sento, son quell'istessa Cornelia, che con il cuore e con l'animo vi amo e amarò sempre.</p>
           </sp>
-          <sp>
+          <sp who="#alberto">
             <speaker>ALBERTO</speaker>
             <p>E abbraccio ancor voi, caro e da me bramato figlio, Persio mio dolce, consolazion grande di me tuo padre.</p>
           </sp>
-          <sp>
+          <sp who="#camillo">
             <speaker>CAMILLO</speaker>
             <p>O padre amatissimo, non posso capir tante allegrezze.</p>
           </sp>
-          <sp>
+          <sp who="#flaminio">
             <speaker>FLAMINIO</speaker>
             <p>Entriamo dentro, Signori, che volendo qui fuori riferir tutte l'allegrezze delle quali ciascun di noi è pieno, vi correria lungo tempo; e oltre che si starebbe a disaggio, non converria a dimorar tanto in strada.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Dice bene lo Signore Flavio. Entrate, Signori, e dintro 'ncora potremo risolvere lo negozio di Pasquina con me, Signor Giovan Luigi.</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>È risoluto già, che Pasquina, qual veramente si dimanda Gentilesca, è pugliese, e abbiamo ritrovato suo padre e con lui concluso che sia vostra moglie, con 150 scudi di dote in contanti; e se ben non è nobile, basta che è figlia di buon padre e buona madre.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Vengano tornisi in contanti, ca de lo riesto poco mi curo, avendo tanta nobeltade ca la pozzo dare a cambio e a scambio; e poi in ogni modo faraggio como fanno chis&lt;s&gt;'autri Cavalieri, ca s'abbassano pe accommodarse. Anzi serà grandezza la mia, a 'nalzare una donna da me tanto amata; e le cose ca se fanno pe amore sono escusabili. Or dimmi mo, Pasquina, al presente Gentilesca, non vi contentate d'incorporarve co la mia nobeletade?</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Io farò quel che farà il mio Messer padre.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>E chi è vostro padre?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Ego, io.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Tu, eh? Come diavolo va ssa cosa? chi mi darà la moneta?</p>
           </sp>
-          <sp>
+          <sp who="#manilio">
             <speaker>MANILIO</speaker>
             <p>Ve la darò io, e Messer Alberto. Contentatevi, Signor Giovan Luigi, di quel che abbiamo fatto noi.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Di grazia, dà ccà la mano, Signora Gentilesca, ca in toccarti solamente sei fatta illustrissima.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Ma voglio le maniglie d'oro, io.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Autro che maniglie d'oro avarai! Spantarà Roma de chelle cose ca ti faraggio benire da Napole.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>La collana e i pendenti, la cuffia similmente d'oro, e la gonnella di scarlatto rosso.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Quietati, ca na Principessa no' avarà tanto quanto avarai tu. E fa' cunto che 'n una bilanza mettendoti tu, e lo dono mio nell'autra, pesarà chiù l'oro, che non pesarai tu.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>E voglio ancora un'altra cosa.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Che cosa?</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Che non vadi più alle puttane.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Ce pensarimo a chesso.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Se tu ci vuoi pensare, ci voglio pensare anch'io.</p>
           </sp>
-          <sp>
+          <sp who="#gialaise">
             <speaker>GIALAISE</speaker>
             <p>Orsù, te lo prometto, pur ca chesse femmene mi promettano a non dareme fastidio con tante suppliche ca mi mandano onne iuorno.</p>
           </sp>
-          <sp>
+          <sp who="#pasquina">
             <speaker>PASQUINA</speaker>
             <p>Entra dentro, che giustaremo i pesi e le misure.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>E che faremo noi, Magagna, così soli soletti e senza compagnia?</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Che cosa vorresti che facessimo?</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Quel che han fatto gli altri.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>E che han fatto gli altri?</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Sono entrati.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>E noi entriamo.</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Sì, ma entriamo sposi come essi; e vorrei che voi prima entraste in me, come entra l'ape nella pecchia, lasciandovi il me... mele.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Il me... mele? Mirate che sapor di bocca, e che menar di coda, e che sorte d'inchini te fa la pecchia vecchia!</p>
           </sp>
-          <sp>
+          <sp who="#bianchetta">
             <speaker>BIANCHETTA</speaker>
             <p>Vecchia son io? me vedi vecchia nella scorza, ma nel medollo son giovane più d'ogn'altra. Ma ritiriamoci insieme, che io ho ducento scudi in contanti, e mill'altre coselle da viver sempre bene, senza invidiar altri.</p>
           </sp>
-          <sp>
+          <sp who="#magagna">
             <speaker>MAGAGNA</speaker>
             <p>Ducento scudi in contanti e altre cose? Orsù, che io farò come fanno gli altri Cavalieri, che si bassano ed acconciano. Entra dentro, che con la pecunia numerata si farà tra di noi la copulata.</p>
           </sp>
@@ -7761,7 +7810,7 @@
     <back>
       <epilogue>
         <head>Licenzia che fa Leandro.</head>
-        <sp>
+        <sp who="#leandro">
           <speaker>LEANDRO</speaker>
           <p>Signori e Signore, ecco l'intrichi districati nel fine. S'intricò Cornelia nell'amor di Camillo, e Camillo nell'amor di lei; ma resistendo prudentemente all'amorose passioni, districati da quelle godeno insieme l'amor di madre e figlio: essempio, a noi altri che dovemo resistere alle tentazioni, che dal Cielo ne piovono sempre grazie. S'intricò Alessandro nel frenetico della gelosia, con pericolo d'onore e della vita; ma ricercando l'aiuto di sopra, lo districò felicemente, con il ritrovo della sua prima moglie: essempio pur a noi che non dovemo usar questi termini con le mogli; ma quando occorre ricorriamo al Signore, che può e sa provedere a ogni cosa. S'intricò Lavinia nel vano amore di Giovan Luigi; ma rivolta al Cielo, se gli offerse occasione d'aver il suo Flavio in forma di molinaro, il quale intricato onestamente nell'amore di lei, si districa nell'ultimo, e ottiene l'onesto suo desiderio: essempio pur a noi che, lasciando le cose vane, otterremo sempre l'oneste. S'intricò Ersilia nell'amor di Camillo; ma coprendolo accortamente ha discoperto in quello l'amor fraterno di Flaminio; e districata da lui, ottiene l'amato suo Camillo: essempio pur a noi che dovemo celare i privati appetiti, per non dar scandalo al popolo, perchè da così buon principio ne risulta sempre ottimo fine. S'intricò Giovan Luigi nelle superbe pretendenze di personaggi grandi; ma districato da quelli si abbassa con Pasquina fantescuola, la quale abbassandosi viene essaltata nel fine: essempio pur a noi che li superbi vengono abbassati e gli umili essaltati.</p>
           <p>Ma dove io vado, Signori? Io ero qui per districarvi col fine della commedia, e pur intrigo di nuovo col ri&lt;e&gt;pilogo de gli stessi intrichi e districhi. Orsù, questi Signori Comici si sono dalla promessa districati, e vi rendono infinite grazie che vi sete degnati di aspettare il fine de gli Amorosi Intrichi; notificandovi col maggior affetto che si può che gl'intricati sempre sono al servizio vostro. E per conoscer se vi è piacciuto l'Intrico d'Amore, datene segno con allegro segno di voci, e suon di mani con esse.</p>

--- a/tei/tasso-re-torrismondo.xml
+++ b/tei/tasso-re-torrismondo.xml
@@ -75,6 +75,49 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="nutrice">
+            <persName>Nutrice</persName>
+          </person>
+          <person xml:id="alvida">
+            <persName>Alvida</persName>
+          </person>
+          <person xml:id="regina">
+            <persName>Regina Madre</persName>
+          </person>
+          <person xml:id="torrismondo">
+            <persName>Torrismondo</persName>
+          </person>
+          <person xml:id="consigliero">
+            <persName>Consigliero</persName>
+          </person>
+          <personGrp xml:id="coro">
+            <name>Coro</name>
+          </personGrp>
+          <person xml:id="messaggero">
+            <persName>Messaggiero</persName>
+          </person>
+          <person xml:id="rosmonda">
+            <persName>Rosmonda</persName>
+          </person>
+          <person xml:id="germondo">
+            <persName>Germondo, Re di Suezia</persName>
+          </person>
+          <person xml:id="cameriera">
+            <persName>Cameriera</persName>
+          </person>
+          <person xml:id="indovino">
+            <persName>Indovino</persName>
+          </person>
+          <person xml:id="frontone">
+            <persName>Frontone</persName>
+          </person>
+          <person xml:id="cameriero">
+            <persName>Cameriero</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -154,7 +197,7 @@ Affez.mo e devot.mo ser.re</salute>
             <add resp="#ed">[SCENA PRIMA]</add>
           </head>
           <stage>NUTRICE, ALVIDA</stage>
-          <sp>
+          <sp who="#nutrice">
             <speaker>
               <add resp="#ed">[NUTRICE]</add>
             </speaker>
@@ -176,7 +219,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>dee rinchiuder giamai ch'a me l'asconda.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#alvida">
             <speaker>ALVIDA</speaker>
             <lg>
               <l>Cara nudrice e madre, egli è ben dritto</l>
@@ -290,7 +333,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>come tenera neve in colle aprico.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>Regina, come or vano il timor vostro</l>
@@ -309,7 +352,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>de la Suezia il re di giorno in giorno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#alvida">
             <speaker>ALVIDA</speaker>
             <lg>
               <l>Sollo, e più la tardanza ancor molesta</l>
@@ -323,7 +366,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>di tutta la mia stirpe aspro nemico?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>Amico è del tuo re; né dee la moglie</l>
@@ -331,7 +374,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>ma con le voglie sol del suo marito.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#alvida">
             <speaker>ALVIDA</speaker>
             <lg>
               <l>Siasi come a voi pare; a voi concedo</l>
@@ -361,7 +404,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l part="I">le parole interrompe.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l part="F">O figlia, i segni</l>
@@ -382,7 +425,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>modesto sposo ne l'antica reggia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#regina">
             <speaker>REGINA</speaker>
             <lg>
               <l>Piaccia a Dio che sia vero. Io pur fra tanto,</l>
@@ -394,7 +437,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>altri gli muove a salti o volge in cerchio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>Altra stanza, regina, a voi conviensi,</l>
@@ -410,7 +453,7 @@ Affez.mo e devot.mo ser.re</salute>
             <add resp="#ed">[SCENA SECONDA]</add>
           </head>
           <stage>NUTRICE <emph>sola</emph></stage>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>Non so ch'in terra sia tranquillo stato</l>
@@ -452,7 +495,7 @@ Affez.mo e devot.mo ser.re</salute>
             <add resp="#ed">[SCENA TERZA]</add>
           </head>
           <stage>TORRISMONDO RE, CONSIGLIERO.</stage>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>
               <add resp="#ed">[TORRISMONDO]</add>
             </speaker>
@@ -510,7 +553,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>morse giamai com'ella rode e morde.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#consigliero">
             <speaker>CONSIGLIERO</speaker>
             <lg>
               <l>Se la fede, o signor, mostrata in prima</l>
@@ -531,7 +574,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>l'alma sua alleggia d'aspra e dura salma.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>O mio fedele, a cui l'alto governo</l>
@@ -845,7 +888,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>giusto in me, benché tardi, e per lui forte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#consigliero">
             <speaker>CONSIGLIERO</speaker>
             <lg>
               <l>Signor, tanto ogni mal più grave è sempre,</l>
@@ -923,7 +966,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>scema commesso errore, anzi l'accresce.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Se morte esser non può pena od emenda</l>
@@ -931,14 +974,14 @@ Affez.mo e devot.mo ser.re</salute>
               <l part="I">fia buon rimedio o fine.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#consigliero">
             <speaker>CONSIGLIERO</speaker>
             <lg>
               <l part="F">Anzi principio</l>
               <l>e cagion fora di maggior tormento.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Come viver debb'io, sposo d'Alvida,</l>
@@ -951,7 +994,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>ma scegliersi di lei più acerbo modo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#consigliero">
             <speaker>CONSIGLIERO</speaker>
             <lg>
               <l>Non è duol così acerbo e così grave,</l>
@@ -964,7 +1007,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>prenderlo, e prevenir l'altrui consiglio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Tarda incontra al dolor sarà l'aita,</l>
@@ -972,20 +1015,20 @@ Affez.mo e devot.mo ser.re</salute>
               <l>se da la debil mia virtù l'attendo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#consigliero">
             <speaker>CONSIGLIERO</speaker>
             <lg>
               <l>Virtù non è mai vinta, e 'l tempo vola.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Vola, quando egli è portator de' mali;</l>
               <l>ma nel recare i beni è lento e zoppo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#consigliero">
             <speaker>CONSIGLIERO</speaker>
             <lg>
               <l>Ei con giusta misura il volo spiega;</l>
@@ -994,7 +1037,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>e noi pur la rechiam là suso al cielo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Ma s'egli avvien che la ragione e 'l tempo,</l>
@@ -1029,7 +1072,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>a queste membra unita.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#consigliero">
             <speaker>CONSIGLIERO</speaker>
             <lg>
               <l>Signor, forte ragione e vera è questa</l>
@@ -1051,7 +1094,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>senza l'amata donna il re Germondo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Egli privo d'amante ed io d'amico,</l>
@@ -1059,7 +1102,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>come viver potremo? Ahi dura sorte!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#consigliero">
             <speaker>CONSIGLIERO</speaker>
             <lg>
               <l>Dura: ma sofferir conviene in terra</l>
@@ -1073,13 +1116,13 @@ Affez.mo e devot.mo ser.re</salute>
               <l>gli ordini suoi fatali e l'alte leggi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Faccia quanto è prefisso il mio destino.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#consigliero">
             <speaker>CONSIGLIERO</speaker>
             <lg>
               <l>Pur veggio di salvare alto consiglio</l>
@@ -1105,14 +1148,14 @@ Affez.mo e devot.mo ser.re</salute>
               <l part="I">così l'onor si salverà.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l part="F">L'onore</l>
               <l>seguita il bene oprar, come ombra il corpo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#consigliero">
             <speaker>CONSIGLIERO</speaker>
             <lg>
               <l>Questo, ch'onor sovente il mondo appella,</l>
@@ -1128,7 +1171,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l part="I">via più d'Alvida è bella.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l part="F">Amor non vuole</l>
@@ -1136,7 +1179,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l part="I">donna cara perduta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#consigliero">
             <speaker>CONSIGLIERO</speaker>
             <lg>
               <l part="F">Amor d'un core</l>
@@ -1144,7 +1187,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>come d'asse si trae chiodo per chiodo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Lasso, la mia soror disprezza e sdegna</l>
@@ -1154,7 +1197,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l part="I">vergine sacra.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#consigliero">
             <speaker>CONSIGLIERO</speaker>
             <lg>
               <l part="F">È casta insieme e saggia,</l>
@@ -1163,7 +1206,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>soppor faranle al novo giogo il collo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>O mio fedel, nel disperato caso</l>
@@ -1180,7 +1223,7 @@ Affez.mo e devot.mo ser.re</salute>
           <trailer>IL FINE DEL PRIMO ATTO</trailer>
         </div>
         <div type="part">
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>O Sapienza, o del gran padre eterno</l>
@@ -1280,7 +1323,7 @@ Affez.mo e devot.mo ser.re</salute>
             <add resp="#ed">[SCENA PRIMA]</add>
           </head>
           <stage>MESSAGGERO, TORRISMONDO, CORO</stage>
-          <sp>
+          <sp who="#messaggero">
             <speaker>
               <add resp="#ed">[MESSAGGERO]</add>
             </speaker>
@@ -1299,14 +1342,14 @@ Affez.mo e devot.mo ser.re</salute>
               <l>per ritrovare il re; dov'è la reggia?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>È quella che t'addito, ed ei medesmo</l>
               <l>quel che là vedi tacito e pensoso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#messaggero">
             <speaker>MESSAG<add resp="#ed">[GERO]</add></speaker>
             <lg>
               <l>O magnanimo re de' Goti illustri,</l>
@@ -1314,14 +1357,14 @@ Affez.mo e devot.mo ser.re</salute>
               <l>a voi manda salute e questa carta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>La lettra è di credenza. Espor vi piaccia</l>
               <l part="I">quel ch'ei v'impose.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#messaggero">
             <speaker>MESSAG<add resp="#ed">[GERO]</add></speaker>
             <lg>
               <l part="F">Il mio signor Germondo</l>
@@ -1343,7 +1386,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>ch'io lo ricordi a chi 'l riserba in mente.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Oh memoria, oh tempo, oh come allegro</l>
@@ -1353,7 +1396,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>talch'una parte se 'n riversa e spande.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>La soverchia allegrezza e 'l duol soverchio,</l>
@@ -1370,7 +1413,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>qual suole in altri adoperar la doglia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#messaggero">
             <speaker>MESSAG<add resp="#ed">[GERO]</add></speaker>
             <lg>
               <l>Signor, se con sì ardente e puro affetto</l>
@@ -1380,14 +1423,14 @@ Affez.mo e devot.mo ser.re</salute>
               <l part="I">di lui più fido amico.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l part="F">Esperto il credo.</l>
               <l>Anzi certo sono io che 'l ver si narra.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#messaggero">
             <speaker>MESSAG<add resp="#ed">[GERO]</add></speaker>
             <lg>
               <l>Ei de le vostre nozze è lieto in modo</l>
@@ -1401,7 +1444,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>e del padre e di voi sovente ei chiede.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>N'udrà liete novelle. E lieto ascolto</l>
@@ -1423,7 +1466,7 @@ Affez.mo e devot.mo ser.re</salute>
             <add resp="#ed">[SCENA SECONDA]</add>
           </head>
           <stage>TORRISMONDO <emph>solo</emph></stage>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Pur tacque al fine, e pur al fin dinanzi</l>
@@ -1468,7 +1511,7 @@ Affez.mo e devot.mo ser.re</salute>
             <add resp="#ed">[SCENA TERZA]</add>
           </head>
           <stage>ROSMONDA</stage>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l>O felice colei, sia donna o serva,</l>
@@ -1514,7 +1557,7 @@ Affez.mo e devot.mo ser.re</salute>
             <add resp="#ed">[SCENA QUARTA]</add>
           </head>
           <stage>REGINA MADRE, ROSMONDA.</stage>
-          <sp>
+          <sp who="#regina">
             <speaker>
               <add resp="#ed">[REGINA]</add>
             </speaker>
@@ -1523,26 +1566,26 @@ Affez.mo e devot.mo ser.re</salute>
               <l>ch'oggi arrivar qui deve il re Germondo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l part="I">Anzi è ben noto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#regina">
             <speaker>REGINA</speaker>
             <lg>
               <l part="F">Non ben si pare.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l>Che deggio far? Non so ch'a me s'aspetti</l>
               <l part="I">alcuna cura.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#regina">
             <speaker>REGINA</speaker>
             <lg>
               <l part="F">O figlia,</l>
@@ -1552,13 +1595,13 @@ Affez.mo e devot.mo ser.re</salute>
               <l>ei tosto sen verrà per farvi onore.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l part="I">Io così credo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#regina">
             <speaker>REGINA</speaker>
             <lg>
               <l part="F">Or come dunque</l>
@@ -1575,7 +1618,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>ch'in piombo vile ancor poco riluce.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l>Questa nostra bellezza, onde cotanto</l>
@@ -1587,7 +1630,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l part="I">spesso mostrarla altrui.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#regina">
             <speaker>REGINA</speaker>
             <lg>
               <l part="F">Questa bellezza</l>
@@ -1614,7 +1657,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>quella che sprezzi il titol d'esser bella.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l>Io più tosto credea che doti nostre</l>
@@ -1627,13 +1670,13 @@ Affez.mo e devot.mo ser.re</salute>
               <l>quanto ella è di virtù fregio e corona.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#regina">
             <speaker>REGINA</speaker>
             <lg>
               <l>Se fregio è, dunque esser non dee negletto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l>S'è fregio altrui, è di se stessa adorna.</l>
@@ -1646,7 +1689,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>è ragion ch'a me stessa io faccia legge.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#regina">
             <speaker>REGINA</speaker>
             <lg>
               <l>Ver dici, e dritto estimi, e meglio pensi.</l>
@@ -1657,14 +1700,14 @@ Affez.mo e devot.mo ser.re</salute>
               <l>le figliuole de' principi sueci.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l>Tolga Iddio che per me sospiri o pianga,</l>
               <l part="I">od ami alcuno, o mostri amare.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#regina">
             <speaker>REGINA</speaker>
             <lg>
               <l part="F">Adunque</l>
@@ -1678,7 +1721,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>di magnanime genti alta reina.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l>Madre, io no 'l vo' negar, ne l'alta mente</l>
@@ -1689,7 +1732,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>più stimo, ch'acquistar corone e scettri.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#regina">
             <speaker>REGINA</speaker>
             <lg>
               <l>Ei ben si par che, giovenetta donna,</l>
@@ -1770,7 +1813,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>schifa non ti mostrar di tale amante.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l>Se ben di noi che siamo in verde etate</l>
@@ -1863,7 +1906,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>non bue disgiunto in male arato campo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#regina">
             <speaker>REGINA</speaker>
             <lg>
               <l>Non è stato mortal così tranquillo,</l>
@@ -1892,7 +1935,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>nati da l'uno e l'altro amato figlio?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l>Già non resti per me che bella prole</l>
@@ -1900,7 +1943,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>ch'obbedisca la figlia a saggia madre.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#regina">
             <speaker>REGINA</speaker>
             <lg>
               <l>Degna è di te la tua risposta, e cara.</l>
@@ -1913,7 +1956,7 @@ Affez.mo e devot.mo ser.re</salute>
             <add resp="#ed">[SCENA QUINTA]</add>
           </head>
           <stage>REGINA MADRE <emph>sola</emph></stage>
-          <sp>
+          <sp who="#regina">
             <speaker>REGINA</speaker>
             <lg>
               <l>Infelice non è dolente donna,</l>
@@ -1948,7 +1991,7 @@ Affez.mo e devot.mo ser.re</salute>
             <add resp="#ed">[SCENA SESTA]</add>
           </head>
           <stage>REGINA MADRE, TORRISMONDO</stage>
-          <sp>
+          <sp who="#regina">
             <speaker>
               <add resp="#ed">[REGINA]</add>
             </speaker>
@@ -1964,7 +2007,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>d'aver creduto, ed al fratello insieme.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Non è saggio colui ch'insieme accoppia</l>
@@ -1975,13 +2018,13 @@ Affez.mo e devot.mo ser.re</salute>
               <l part="I">s'ei la vorrà.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#regina">
             <speaker>REGINA</speaker>
             <lg>
               <l part="F">Ma con felice sorte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Sia felice, se può. Ma nulla manchi</l>
@@ -2078,7 +2121,7 @@ Affez.mo e devot.mo ser.re</salute>
           <trailer> IL FINE DEL SECONDO ATTO</trailer>
         </div>
         <div type="part">
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Non sono estinte ancor l'eccelse leggi,</l>
@@ -2140,7 +2183,7 @@ Affez.mo e devot.mo ser.re</salute>
             <add resp="#ed">[SCENA PRIMA]</add>
           </head>
           <stage>CONSIGLIERO</stage>
-          <sp>
+          <sp who="#consigliero">
             <speaker>CONSIGLIERO</speaker>
             <lg>
               <l>A molti egri mortali (or mi sovviene</l>
@@ -2219,7 +2262,7 @@ Affez.mo e devot.mo ser.re</salute>
             <add resp="#ed">[SCENA SECONDA]</add>
           </head>
           <stage>ROSMONDA <emph>sola</emph></stage>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l>O possente Fortuna, a me pur anco,</l>
@@ -2261,7 +2304,7 @@ Affez.mo e devot.mo ser.re</salute>
             <add resp="#ed">[SCENA TERZA]</add>
           </head>
           <stage>TORRISMONDO, GERMONDO</stage>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>
               <add resp="#ed">[TORRISMONDO]</add>
             </speaker>
@@ -2277,7 +2320,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>la pace e l'union di questi regni.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#germondo">
             <speaker>GERMONDO</speaker>
             <lg>
               <l>Già voi foste di me la miglior parte,</l>
@@ -2296,7 +2339,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>assai men pregio, o pur trionfi e palme.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Anzi io pur vostro sono. E me donando,</l>
@@ -2314,7 +2357,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l part="I">ben avete per farlo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#germondo">
             <speaker>GERMONDO</speaker>
             <lg>
               <l part="F">I vostri oltraggi</l>
@@ -2345,7 +2388,7 @@ Affez.mo e devot.mo ser.re</salute>
             <add resp="#ed">[SCENA QUARTA]</add>
           </head>
           <stage>TORRISMONDO <emph>ed</emph> ALVIDA</stage>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>
               <add resp="#ed">[TORRISMONDO]</add>
             </speaker>
@@ -2363,7 +2406,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>e perché tanto ei v'ama, e perch'il merta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#alvida">
             <speaker>ALVIDA</speaker>
             <lg>
               <l>Basti ch'è vostro amico; altro non chiedo.</l>
@@ -2374,7 +2417,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>e sol quanto a voi piace a me conviensi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Questa del vostro amor, del vostro senno,</l>
@@ -2383,7 +2426,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>e la sembianza vostra, e 'l vostro petto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#alvida">
             <speaker>ALVIDA</speaker>
             <lg>
               <l>Nel mio petto giammai piacere o noia</l>
@@ -2394,7 +2437,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>posso, se voi l'amate, amar Germondo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Estingua tutti gli odii il nostro amore,</l>
@@ -2407,7 +2450,7 @@ Affez.mo e devot.mo ser.re</salute>
             <add resp="#ed">[SCENA QUINTA]</add>
           </head>
           <stage>CAMERIERA, ALVIDA.</stage>
-          <sp>
+          <sp who="#cameriera">
             <speaker>
               <add resp="#ed">[CAMERIERA]</add>
             </speaker>
@@ -2424,14 +2467,14 @@ Affez.mo e devot.mo ser.re</salute>
               <l>lunge da noi famoso orribil monte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#regina">
             <speaker>REGINA</speaker>
             <lg>
               <l>Di valoroso re leggiadri e ricchi</l>
               <l>doni son questi, e portator cortese.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <lg>
               <l>Non aguagli alcun dono il vostro merto;</l>
@@ -2441,7 +2484,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l part="I">scolpita.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#alvida">
             <speaker>ALVIDA</speaker>
             <lg>
               <l part="F">A prova la ricchezza e l'arte</l>
@@ -2453,7 +2496,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>rendere io posso? O chi per me le rende?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cameriera">
             <speaker>CAMERIERA</speaker>
             <lg>
               <l>È grazia l'accettarli; e 'l don gradito</l>
@@ -2466,7 +2509,7 @@ Affez.mo e devot.mo ser.re</salute>
             <add resp="#ed">[SCENA SESTA]</add>
           </head>
           <stage>ALVIDA, NUTRICE</stage>
-          <sp>
+          <sp who="#alvida">
             <speaker>
               <add resp="#ed">[ALVIDA]</add>
             </speaker>
@@ -2499,7 +2542,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>mio sfortunato e del fratello anciso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>La corona io conosco, e 'l dì rimembro</l>
@@ -2519,7 +2562,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>predicevano al re l'alta vendetta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#alvida">
             <speaker>ALVIDA</speaker>
             <lg>
               <l>Ma prima nuova ingiuria il duolo accrebbe,</l>
@@ -2604,7 +2647,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>O quai pensier son questi, e quai parole?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>Non so, ma varie cose asconde il tempo,</l>
@@ -2612,7 +2655,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>muta il cor, il pensier, l'usanze e l'opre.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#alvida">
             <speaker>ALVIDA</speaker>
             <lg>
               <l>Di mutato voler conosci i segni?</l>
@@ -2631,14 +2674,14 @@ Affez.mo e devot.mo ser.re</salute>
               <l>O più tosto odiar perch'ei non odi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>Quai disprezzi, quali odii e quali amori</l>
               <l>ragioni, o figlia, e qual timor t'ingombra?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#alvida">
             <speaker>ALVIDA</speaker>
             <lg>
               <l>Temo l'altrui timor, non solo il mio;</l>
@@ -2659,7 +2702,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>perché mi fugge?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>Il timor vostro il suo timor v'adombra,</l>
@@ -2667,20 +2710,20 @@ Affez.mo e devot.mo ser.re</salute>
               <l>non temerà, non crederò che tema.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#alvida">
             <speaker>ALVIDA</speaker>
             <lg>
               <l>Quale amante non teme un altro amante?</l>
               <l>Quale amor non molesta un altro amore?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>L'amor fedele, io credo, e 'l fido amante.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#alvida">
             <speaker>ALVIDA</speaker>
             <lg>
               <l>Ma fede si turbò talor per fede,</l>
@@ -2693,7 +2736,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>non è lieve cagion d'alto sospetto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>Rara beltà, valore e chiara fama</l>
@@ -2714,7 +2757,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>voi sola a voi cagion di tema indarno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#alvida">
             <speaker>ALVIDA</speaker>
             <lg>
               <l>A qual vendetta adunque ancor mi serba</l>
@@ -2741,7 +2784,7 @@ Affez.mo e devot.mo ser.re</salute>
             <add resp="#ed">[SCENA SETTIMA]</add>
           </head>
           <stage>ALVIDA, REGINA MADRE.</stage>
-          <sp>
+          <sp who="#alvida">
             <speaker>
               <add resp="#ed">[ALVIDA]</add>
             </speaker>
@@ -2752,7 +2795,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>ciò ch'al re mio signor diletta e piace.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#regina">
             <speaker>REGINA</speaker>
             <lg>
               <l>Ne 'l donare un gentile alto costume</l>
@@ -2766,7 +2809,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>se da l'onor comincia; ogni altra, incerta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#alvida">
             <speaker>ALVIDA</speaker>
             <lg>
               <l>Certo è l'amor, certo è l'onor ch'io deggio</l>
@@ -2774,7 +2817,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>ch'i suoi più cari ad onorar m'astringe.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#regina">
             <speaker>REGINA</speaker>
             <lg>
               <l>S'onora negli amici il re sovente,</l>
@@ -2789,7 +2832,7 @@ Affez.mo e devot.mo ser.re</salute>
           </sp>
         </div>
         <div type="part">
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Amore, hai l'odio incontra e seco giostri,</l>
@@ -2862,7 +2905,7 @@ Affez.mo e devot.mo ser.re</salute>
             <add resp="#ed">[SCENA PRIMA]</add>
           </head>
           <stage>CONSIGLIERO, GERMONDO</stage>
-          <sp>
+          <sp who="#consigliero">
             <speaker>
               <add resp="#ed">[CONSIGLIERO]</add>
             </speaker>
@@ -2962,7 +3005,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>e grazia, a giusta età concessa, è giusta.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#germondo">
             <speaker>GERMONDO</speaker>
             <lg>
               <l>Pensier canuto e di canuta etade</l>
@@ -2975,7 +3018,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>con più tenace nodo o con più saldo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#consigliero">
             <speaker>CONSIGLIERO</speaker>
             <lg>
               <l>Se nodo mai non s'allentò per nodo,</l>
@@ -2984,14 +3027,14 @@ Affez.mo e devot.mo ser.re</salute>
               <l>vera amicizia, anzi sarà più salda.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#germondo">
             <speaker>GERMONDO</speaker>
             <lg>
               <l>Amor, che fare il pò, confermi e stringa</l>
               <l part="I">amicizia fedel.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#consigliero">
             <speaker>CONSIGLIERO</speaker>
             <lg>
               <l part="F">Migliori estimo</l>
@@ -2999,28 +3042,28 @@ Affez.mo e devot.mo ser.re</salute>
               <l part="I">l'altre pericolose.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#germondo">
             <speaker>GERMONDO</speaker>
             <lg>
               <l part="F">Ivi sovente</l>
               <l>si ritrova gran lode ov'è gran rischio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#consigliero">
             <speaker>CONSIGLIERO</speaker>
             <lg>
               <l>Lodato spesso è lo schifar periglio,</l>
               <l part="I">quando si schifa altrui.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#germondo">
             <speaker>GERMONDO</speaker>
             <lg>
               <l part="F">L'ardir più stimo,</l>
               <l>se pò far gli altri arditi un solo ardito.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#consigliero">
             <speaker>CONSIGLIERO</speaker>
             <lg>
               <l>Or de l'ardire è tempo, or del consiglio,</l>
@@ -3036,7 +3079,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>né siate voi tra tanto amor l'estremo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#germondo">
             <speaker>GERMONDO</speaker>
             <lg>
               <l>Primo sono in amare. Amai l'amico,</l>
@@ -3073,7 +3116,7 @@ Affez.mo e devot.mo ser.re</salute>
             <add resp="#ed">[SCENA SECONDA]</add>
           </head>
           <stage>GERMONDO <emph>solo</emph></stage>
-          <sp>
+          <sp who="#germondo">
             <speaker>GERMONDO</speaker>
             <lg>
               <l>Giusto non è che sia stimato indarno</l>
@@ -3128,7 +3171,7 @@ Affez.mo e devot.mo ser.re</salute>
             <add resp="#ed">[SCENA TERZA]</add>
           </head>
           <stage>ROSMONDA, TORRISMONDO</stage>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>
               <add resp="#ed">[ROSMONDA]</add>
             </speaker>
@@ -3140,32 +3183,32 @@ Affez.mo e devot.mo ser.re</salute>
               <l>e vostra serva nacqui e vissi in fasce.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l part="I">Non sei dunque Rosmonda?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l part="F">Io son Rosmonda.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l part="I">Non sei sorella mia?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l part="F">Né d'esser niego,</l>
               <l part="I">alto signor.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l part="F">Troppo vaneggi, ah folle!</l>
@@ -3174,7 +3217,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>Da tal principio a ricusar cominci?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l>Se femina ci nasce, or serva nasce</l>
@@ -3187,58 +3230,58 @@ Affez.mo e devot.mo ser.re</salute>
               <l>fanno ogni imperio del fratel superbo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Obbedisci a tua madre, ove ti piaccia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l>Io non ho madre, ma regina e donna.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Non sei tu di Rusilla unica figlia?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l>Né unica, né figlia esser mi vanto</l>
               <l>de la regina de' feroci Goti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>E pur sei tu Rosmonda, e mia sorella?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l>Io sono altra Rosmonda, altra sorella.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Distingui omai questo parlar, distingui</l>
               <l part="I">questi confusi affanni.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l part="F">A me fu madre</l>
               <l>la tua nutrice, e poi nutrì Rosmonda.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Nova cosa mi narri e cosa occulta,</l>
@@ -3247,28 +3290,28 @@ Affez.mo e devot.mo ser.re</salute>
               <l>talché serva non sei, se tu non menti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l>Serva far mi poté fortuna aversa</l>
               <l>de l'uno e l'altro mio parente antico.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>La tua propria fortuna il fallo emenda</l>
               <l>de la sorte del padre, anzi il tuo merto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l>Il merto è nel dir vero, il premio attendo</l>
               <l>di libertà, se libertà conviensi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>S'è ciò pur vero, è con modestia il vero,</l>
@@ -3277,7 +3320,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l part="I">ove il non creder giovi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l part="F">È picciol danno</l>
@@ -3286,7 +3329,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>anzi gran pro' mi pare ed util certo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Quasi povero sia de' Goti il regno,</l>
@@ -3300,7 +3343,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>la fraude e l'arte a palesar t'astringe?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l>Per mia madre e per me breve io rispondo.</l>
@@ -3308,28 +3351,28 @@ Affez.mo e devot.mo ser.re</salute>
               <l part="I">e 'l discopre pietà.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l part="F">Tu parli oscuro,</l>
               <l>perché stringi gran cose in picciol fascio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l>Da qual parte io comincio a fare illustre</l>
               <l>quel ch'oscura il silenzio e 'l tempo involve?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Quel che ricopre, al fin discopre il tempo.</l>
               <l>Ma de le prime tu primier comincia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l>Sappi che grave già per gli anni, e stanca</l>
@@ -3345,14 +3388,14 @@ Affez.mo e devot.mo ser.re</salute>
               <l>né 'l chiaro dì ch'io nacqui a lei funebre.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Dunque i materni e non i propi voti</l>
               <l>tu cerchi d'adempir, vergine bella?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l>Son miei voti i suoi voti; e poi s'aggiunse</l>
@@ -3375,7 +3418,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>e disciogliendo lei, sciogli te stessa.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>La tua vera pietà conosco e lodo.</l>
@@ -3385,7 +3428,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>di magnanimo re, d'alta regina?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l>Fe' mia madre l'inganno, anzi tuo padre:</l>
@@ -3393,20 +3436,20 @@ Affez.mo e devot.mo ser.re</salute>
               <l>o consiglio, o fortuna, o fato, o forza.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>A chi si fece la mirabil fraude?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l>A la regina tua pudica madre,</l>
               <l>la qual mi stima ancor diletta figlia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>In tanti anni del ver delusa vecchia</l>
@@ -3414,7 +3457,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>la sua madre la figlia, o pur s'infinge?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l>Non s'infinse d'amar, né d'esser madre,</l>
@@ -3425,7 +3468,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>ed or porge diletto e schiva affanno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Ma come ella primiera al novo inganno</l>
@@ -3433,7 +3476,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>de la perduta figlia, e poi del cambio?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l>La natura e l'età, che non distinse</l>
@@ -3444,14 +3487,14 @@ Affez.mo e devot.mo ser.re</salute>
               <l>ch'ebbe ne la nutrice e nel marito.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Se la fede ingannò, l'inganno è giusto.</l>
               <l part="I">Ma dove ella nutrivvi?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l part="F">Appresso un antro,</l>
@@ -3469,54 +3512,54 @@ Affez.mo e devot.mo ser.re</salute>
               <l>Ivi tua suora ed io giacemmo in culla.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>La cagion di quel cambio ancor m'ascondi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l>La cagion fu del padre alto consiglio,</l>
               <l>o profondo timor che l'alma ingombra.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l part="I">Qual timore, e di che?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l part="F">D'aspra ventura,</l>
               <l>che 'l suo regno passasse ad altri regi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>E come nacque in lui questa temenza</l>
               <l>di sì lontano male? O chi destolla?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l>Il parlar la destò d'accorte ninfe,</l>
               <l>ch'altrui soglion predir gli eterni fati.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Dunque ei diede credenza al vano incanto,</l>
               <l>ch'effetto poi non ebbe in quattro lustri?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l>Diede, e diede la figlia ancora in fasce</l>
@@ -3525,13 +3568,13 @@ Affez.mo e devot.mo ser.re</salute>
               <l>la fanciulletta fu d'atra spelunca.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Perché si tacque a la regina eccelsa?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l>Quel palagio, quell' antro, e quelle ninfe,</l>
@@ -3547,13 +3590,13 @@ Affez.mo e devot.mo ser.re</salute>
               <l>ov'ella nata fu di nobil sangue.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Vive l'altra sorella ancor ne l'antro?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l>Vi stette a pena infino a l'anno istesso,</l>
@@ -3564,14 +3607,14 @@ Affez.mo e devot.mo ser.re</salute>
               <l part="I">né seppi come, o dove.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l part="F">Il servo almeno</l>
               <l part="I">conoscer tu devresti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l part="F">Io no 'l conosco,</l>
@@ -3580,14 +3623,14 @@ Affez.mo e devot.mo ser.re</salute>
               <l part="I">e 'l nome in mente or serbo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l part="F">Il re celato</l>
               <l>tenne sempre a la moglie il cambio e l'arte?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l>Tenne sinché 'l prevenne acerba morte,</l>
@@ -3596,7 +3639,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>madre languente, e lui seguì morendo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Cose mi narri tu d'alto silenzio</l>
@@ -3614,7 +3657,7 @@ Affez.mo e devot.mo ser.re</salute>
             <add resp="#ed">[SCENA QUARTA]</add>
           </head>
           <stage>TORRISMONDO, INDOVINO, CORO</stage>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>
               <add resp="#ed">[TORRISMONDO]</add>
             </speaker>
@@ -3651,7 +3694,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>ma come possa almen coprire il fallo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Ecco, signore, a voi già viene il Saggio,</l>
@@ -3659,7 +3702,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>da caligini occulto e da tenebre.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>O Saggio, tu che sai (pensando a tutto</l>
@@ -3668,7 +3711,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>dimmi se mia sorella è in questo regno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#indovino">
             <speaker>INDOVINO</speaker>
             <lg>
               <l>Ahi, ahi, quanto è 'l saper dannoso e grave,</l>
@@ -3676,46 +3719,46 @@ Affez.mo e devot.mo ser.re</salute>
               <l>ch'io veniva a trovar periglio e biasmo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Per qual cagion tu sei turbato in vista?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#indovino">
             <speaker>INDOVINO</speaker>
             <lg>
               <l>Lasciami, no 'l cercar, nulla rileva</l>
               <l>che 'l mio pensier si scopra o si nasconda.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Dimmi se mia sorella è in questo regno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#indovino">
             <speaker>INDOVINO</speaker>
             <lg>
               <l>È dove nacque, e dove nacque or posa,</l>
               <l>se pur ha posa, e non ha posa in terra.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l part="I">Dunque in terra non è?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#indovino">
             <speaker>INDOVINO</speaker>
             <lg>
               <l part="F">Non posa in terra,</l>
               <l>ma poserà dove tu avrai riposo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Quale agli oscuri detti oscuro velo</l>
@@ -3723,14 +3766,14 @@ Affez.mo e devot.mo ser.re</salute>
               <l>Dimmi se mia sorella è in questo regno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#indovino">
             <speaker>INDOVINO</speaker>
             <lg>
               <l>Tu medesmo t'inganni. È tua la frode,</l>
               <l>perché tu la facesti e teco alberga.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Se non è il tuo saper vano com'ombra</l>
@@ -3738,13 +3781,13 @@ Affez.mo e devot.mo ser.re</salute>
               <l>se la sorella mia tra Goti or vive.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#indovino">
             <speaker>INDOVINO</speaker>
             <lg>
               <l part="I">Vive tra Goti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l part="F">Ed in qual parte, e come?</l>
@@ -3752,7 +3795,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>S'altra, dove s'asconde o si ritrova?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#indovino">
             <speaker>INDOVINO</speaker>
             <lg>
               <l>È l'altra, ed u' si trova ancor s'asconde,</l>
@@ -3760,7 +3803,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l part="I">e servando la fede.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l part="F">Intrichi ancora</l>
@@ -3770,7 +3813,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>talché si scopra in ragionando il falso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#indovino">
             <speaker>INDOVINO</speaker>
             <lg>
               <l>È certo il tuo destin, la fede incerta.</l>
@@ -3811,7 +3854,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>o signoreggi a sommo il cielo, o caggia.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Vero o falso che parli, ei solo intende</l>
@@ -3822,7 +3865,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>quanto bastasse a ragionar co' regi.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Lasciamlo. Or trovi le spelunche e i monti,</l>
@@ -3833,7 +3876,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l part="I">se così vuole.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#indovino">
             <speaker>INDOVINO</speaker>
             <lg>
               <l part="F">Anzi ch'al fine aggiunga</l>
@@ -3851,7 +3894,7 @@ Affez.mo e devot.mo ser.re</salute>
             <add resp="#ed">[SCENA QUINTA]</add>
           </head>
           <stage>FRONTONE, TORRISMONDO</stage>
-          <sp>
+          <sp who="#frontone">
             <speaker>
               <add resp="#ed">[FRONTONE]</add>
             </speaker>
@@ -3873,7 +3916,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l part="I">invitto re de' Goti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l part="F">Arrivi a tempo,</l>
@@ -3881,26 +3924,26 @@ Affez.mo e devot.mo ser.re</salute>
               <l>Questa, che fu creduta, è mia sorella?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#frontone">
             <speaker>FRONTONE</speaker>
             <lg>
               <l part="I">Non nacque di tua madre.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l part="F">E in questo errore</l>
               <l>ella tanti anni si rimase involta?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#frontone">
             <speaker>FRONTONE</speaker>
             <lg>
               <l>Così piacque a tuo padre, e piacque al fato.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Ma, dapoi ch'ebbe me prodotto al mondo,</l>
@@ -3908,34 +3951,34 @@ Affez.mo e devot.mo ser.re</salute>
               <l>steril divenne ed infeconda madre?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#frontone">
             <speaker>FRONTONE</speaker>
             <lg>
               <l>Steril non già, ch'al partorir secondo</l>
               <l>fece d'una fanciulla il re più lieto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l part="I">Che avenne di lei?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#frontone">
             <speaker>FRONTONE</speaker>
             <lg>
               <l part="F">Temuta in fasce</l>
               <l>fu per fiero destin dal padre istesso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>E qual d'una fanciulla aver temenza</l>
               <l part="I">re forte e saggio debbe?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#frontone">
             <speaker>FRONTONE</speaker>
             <lg>
               <l part="F">Avea spavento</l>
@@ -3946,25 +3989,25 @@ Affez.mo e devot.mo ser.re</salute>
               <l>che pargoletta la nutrîr ne l'antro.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Chi lunge la portò dal verde speco?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#frontone">
             <speaker>FRONTONE</speaker>
             <lg>
               <l>Io: così volle il padre e volle il cielo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l part="I">In qual parte del mondo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#frontone">
             <speaker>FRONTONE</speaker>
             <lg>
               <l part="F">Ove non volli,</l>
@@ -3973,13 +4016,13 @@ Affez.mo e devot.mo ser.re</salute>
               <l>è più di quel de' regi, ed altra forza.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Ma dove la mandava il re mio padre?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#frontone">
             <speaker>FRONTONE</speaker>
             <lg>
               <l>Sin nel regno di Dacia. Ed ivi occulta</l>
@@ -4006,7 +4049,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>pur in mia vece ivi rimase avinto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Ma sai tu qual rifugio o quale scampo</l>
@@ -4014,20 +4057,20 @@ Affez.mo e devot.mo ser.re</salute>
               <l>troppo infelice e troppo nobil preda?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#frontone">
             <speaker>FRONTONE</speaker>
             <lg>
               <l>In Norvegia fuggì, se 'l ver n'intesi</l>
               <l part="I">da quel prigione.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l part="F">E che di lei divenne?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#frontone">
             <speaker>FRONTONE</speaker>
             <lg>
               <l>Questo non so. Perch'in quel tempo stesso</l>
@@ -4036,13 +4079,13 @@ Affez.mo e devot.mo ser.re</salute>
               <l>turbâr de' Goti e de' Norvegi il regno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Ma del ladro marin contezza avesti?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#frontone">
             <speaker>FRONTONE</speaker>
             <lg>
               <l>L'ebbi di lor. Perché fratelli entrambi</l>
@@ -4058,7 +4101,7 @@ Affez.mo e devot.mo ser.re</salute>
             <add resp="#ed">[SCENA SESTA]</add>
           </head>
           <stage>MESSAGGERO, CORO, TORRISMONDO, FRONTONE</stage>
-          <sp>
+          <sp who="#messaggero">
             <speaker>MESSAG<add resp="#ed">[GERO]</add></speaker>
             <lg>
               <l>Questa del nostro re matura morte</l>
@@ -4084,7 +4127,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l part="I">la sua regina?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l part="F">Ecco il sublime tetto:</l>
@@ -4092,14 +4135,14 @@ Affez.mo e devot.mo ser.re</salute>
               <l>il re nostro signore.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#messaggero">
             <speaker>MESSAG<add resp="#ed">[GERO]</add></speaker>
             <lg>
               <l>Siate sempre felice e co' felici,</l>
               <l>o degnissimo re d'alta regina.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>E tu, che bene auguri, e ne sei degno</l>
@@ -4107,7 +4150,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>qual cagion ti conduca, o che n'apporti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#messaggero">
             <speaker>MESSAG<add resp="#ed">[GERO]</add></speaker>
             <lg>
               <l>Non rea novella a questo antico regno,</l>
@@ -4115,69 +4158,69 @@ Affez.mo e devot.mo ser.re</salute>
               <l>e buona a voi, cui tanto il cielo arrise.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l part="I">Narrala.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#messaggero">
             <speaker>MESSAG<add resp="#ed">[GERO]</add></speaker>
             <lg>
               <l part="F">A la regina io sono il messo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Quello ch'a me si spone, a lei si narra,</l>
               <l>perché nulla è fra noi distinto e sevro.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#messaggero">
             <speaker>MESSAG<add resp="#ed">[GERO]</add></speaker>
             <lg>
               <l>La Norvegia lo scettro a lei riserba.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Perché? Non regna ancora il vecchio Araldo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#messaggero">
             <speaker>MESSAG<add resp="#ed">[GERO]</add></speaker>
             <lg>
               <l>Non certo; ma 'l sepolcro in sé l'asconde.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l part="I">È dunque Araldo morto?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#messaggero">
             <speaker>MESSAG<add resp="#ed">[GERO]</add></speaker>
             <lg>
               <l part="F">Il vero udisti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>L'uccise lungo od improviso assalto</l>
               <l>de la morte crudel, che tutti ancide?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#messaggero">
             <speaker>MESSAG<add resp="#ed">[GERO]</add></speaker>
             <lg>
               <l>Tosto gli antichi corpi il male atterra.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Ha ceduto a natura iniqua e parca,</l>
@@ -4186,13 +4229,13 @@ Affez.mo e devot.mo ser.re</salute>
               <l>quando è la vita assai minor del merto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#messaggero">
             <speaker>MESSAG<add resp="#ed">[GERO]</add></speaker>
             <lg>
               <l>A lei suo corpo, a voi concede il regno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#frontone">
             <speaker>FRONTONE</speaker>
             <lg>
               <l>Signor, quest'è pur quello ond'or si parla,</l>
@@ -4200,26 +4243,26 @@ Affez.mo e devot.mo ser.re</salute>
               <l part="I">de' sembianti e del nome.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l part="F">Ei giunge a tempo.</l>
               <l>Ma riconosce ei te, se lui conosci?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#frontone">
             <speaker>FRONTONE</speaker>
             <lg>
               <l>D'avermi visto ti rimembra unquanco?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#messaggero">
             <speaker>MESSAG<add resp="#ed">[GERO]</add></speaker>
             <lg>
               <l part="I">Non mi ricordo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#frontone">
             <speaker>FRONTONE</speaker>
             <lg>
               <l part="F">Io ridurollo a mente,</l>
@@ -4233,7 +4276,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>Io fui preso in quel legno: or mi conosci?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#messaggero">
             <speaker>MESSAG<add resp="#ed">[GERO]</add></speaker>
             <lg>
               <l>Si cangia spesso la fortuna e 'l tempo,</l>
@@ -4241,7 +4284,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>stata è l'avara e la maligna sorte.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#frontone">
             <speaker>FRONTONE</speaker>
             <lg>
               <l>Ma che facesti de la nobil preda,</l>
@@ -4250,7 +4293,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>Egli parli in tua vece, o tu ragiona.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#messaggero">
             <speaker>MESSAG<add resp="#ed">[GERO]</add></speaker>
             <lg>
               <l>De le cose passate il fato accusa.</l>
@@ -4258,7 +4301,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>ch'a la vergine diè sì nobil padre.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Oimè, ch'io tardi intendo, e troppo intendo,</l>
@@ -4269,7 +4312,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>suol ritrovare il ver, non che perdono.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#messaggero">
             <speaker>MESSAG<add resp="#ed">[GERO]</add></speaker>
             <lg>
               <l>Diedi la verginella al re dolente</l>
@@ -4281,7 +4324,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>L'istoria a pochi è nota, a molti ascosa.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Oimè, che troppo al fin si scopre, ahi lasso!</l>
@@ -4294,7 +4337,7 @@ Affez.mo e devot.mo ser.re</salute>
             <add resp="#ed">[SCENA SETTIMA]</add>
           </head>
           <stage>GERMONDO, TORRISMONDO</stage>
-          <sp>
+          <sp who="#germondo">
             <speaker>
               <add resp="#ed">[GERMONDO]</add>
             </speaker>
@@ -4306,7 +4349,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l part="I">da lui medesmo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l part="F">Il re de' Goti è vostro</l>
@@ -4315,7 +4358,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>e la sua dura sorte, il fa dolente.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#germondo">
             <speaker>GERMONDO</speaker>
             <lg>
               <l>Perturbator a voi di liete nozze</l>
@@ -4325,7 +4368,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>né duo gran falli una partenza emenda.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Fortuna errò, che volse i lieti giochi</l>
@@ -4338,7 +4381,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>s'al piacer vostro di tornar v'aggrada.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#germondo">
             <speaker>GERMONDO</speaker>
             <lg>
               <l>Così noto io vi sono? Al vostro lutto</l>
@@ -4348,7 +4391,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>verserò 'l pianto; e se vendetta, il sangue.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#torrismondo">
             <speaker>TORRISMONDO</speaker>
             <lg>
               <l>Io conobbi, Germondo, il valor vostro,</l>
@@ -4368,7 +4411,7 @@ Affez.mo e devot.mo ser.re</salute>
           </sp>
         </div>
         <div type="part">
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Quale arte occulta, o qual saper adempie</l>
@@ -4447,7 +4490,7 @@ Affez.mo e devot.mo ser.re</salute>
             <add resp="#ed">[SCENA PRIMA]</add>
           </head>
           <stage>ALVIDA, NUTRICE</stage>
-          <sp>
+          <sp who="#alvida">
             <speaker>ALVIDA</speaker>
             <lg>
               <l>In qual parte del mondo or m'ha condotta</l>
@@ -4455,14 +4498,14 @@ Affez.mo e devot.mo ser.re</salute>
               <l part="I">o dei sommi del cielo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l part="F">Ancor temete,</l>
               <l part="I">e vi dolete ancor.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#alvida">
             <speaker>ALVIDA</speaker>
             <lg>
               <l part="F">Io più non temo,</l>
@@ -4487,14 +4530,14 @@ Affez.mo e devot.mo ser.re</salute>
               <l>anzi tradita sposa?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>È possibil giammai che tanto inganno</l>
               <l>alberghi in Torrismondo e tanta fraude?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#alvida">
             <speaker>ALVIDA</speaker>
             <lg>
               <l>È possibile, è vero, è certo, è certa</l>
@@ -4503,7 +4546,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>la mia morte medesma, oh me dolente!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>Certa la fate voi d'incerta e dubbia,</l>
@@ -4521,7 +4564,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>se non è vano il timor vostro e 'l dubbio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#alvida">
             <speaker>ALVIDA</speaker>
             <lg>
               <l>O morì la giustizia il giorno istesso</l>
@@ -4546,7 +4589,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l part="I">de' magnanimi Goti.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l part="F">A detti falsi</l>
@@ -4556,7 +4599,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>dal vero il falso, e l'un per l'altro afferma.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#regina">
             <speaker>REGINA</speaker>
             <lg>
               <l>Siasi de la novella, e del messaggio,</l>
@@ -4581,7 +4624,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>tanto insolito al mondo e tanto ingiusto?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>Senza disprezzo, forse, e senza sdegno</l>
@@ -4590,7 +4633,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>sovente il buon consiglio altrui s'asconde.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#alvida">
             <speaker>ALVIDA</speaker>
             <lg>
               <l>La ragion, ch'egli adduce, è finta e vana</l>
@@ -4625,7 +4668,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>non saria, se vivesse amore e l'alma.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#nutrice">
             <speaker>NUTRICE</speaker>
             <lg>
               <l>Deh, lasciate pensier crudele ed empio.</l>
@@ -4641,7 +4684,7 @@ Affez.mo e devot.mo ser.re</salute>
             <add resp="#ed">[SCENA SECONDA]</add>
           </head>
           <stage>REGINA</stage>
-          <sp>
+          <sp who="#regina">
             <speaker>REGINA</speaker>
             <lg>
               <l>Dopo tanti anni e lustri un dì sereno,</l>
@@ -4680,7 +4723,7 @@ Affez.mo e devot.mo ser.re</salute>
             <add resp="#ed">[SCENA TERZA]</add>
           </head>
           <stage>ROSMONDA <emph>sola</emph></stage>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l>Ancor mi vivo di mio stato incerta,</l>
@@ -4708,7 +4751,7 @@ Affez.mo e devot.mo ser.re</salute>
             <add resp="#ed">[SCENA QUARTA]</add>
           </head>
           <stage>CAMERIERO, CORO</stage>
-          <sp>
+          <sp who="#cameriero">
             <speaker>
               <add resp="#ed">[CAMERIERO]</add>
             </speaker>
@@ -4720,7 +4763,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l part="I">a te si porge.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l part="F">Ahi, che dolente voce</l>
@@ -4728,7 +4771,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l part="I">Che fia?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cameriero">
             <speaker>CAMERIERO</speaker>
             <lg>
               <l part="F">Misera madre e mesto giorno,</l>
@@ -4736,13 +4779,13 @@ Affez.mo e devot.mo ser.re</salute>
               <l>infelice egualmente. Orribil caso!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Narralo, e dà principio al mio dolore.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cameriero">
             <speaker>CAMERIERO</speaker>
             <lg>
               <l>Il re doglioso a la dolente Alvida</l>
@@ -4761,14 +4804,14 @@ Affez.mo e devot.mo ser.re</salute>
               <l>il suo tenero petto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Ahi troppo frettolosa! Ahi cruda morte,</l>
               <l part="I">estremo d'ogni male!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cameriero">
             <speaker>CAMERIERO</speaker>
             <lg>
               <l part="F">Il male integro</l>
@@ -4776,7 +4819,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>nel modo istesso, e giace appresso estinto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Ahi, ahi, ahi, crudel morte e crudel fato!</l>
@@ -4784,7 +4827,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>può farci la fortuna o 'l cielo averso?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cameriero">
             <speaker>CAMERIERO</speaker>
             <lg>
               <l>Non so. Ma l'un dolore aggiunge a l'altro,</l>
@@ -4792,14 +4835,14 @@ Affez.mo e devot.mo ser.re</salute>
               <l>oggi è la stirpe sua recisa e tronca.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Misera ed orba madre, ove s'appoggia</l>
               <l>la cadente vecchiezza, e chi sostienla?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cameriero">
             <speaker>CAMERIERO</speaker>
             <lg>
               <l>L'infelice non sa d'aver trovato</l>
@@ -4809,14 +4852,14 @@ Affez.mo e devot.mo ser.re</salute>
               <l>e di gioia e piacere ha colmo il petto.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Or chi le narrerà l'aspro destino</l>
               <l part="I">de' suoi morti figliuoli?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cameriero">
             <speaker>CAMERIERO</speaker>
             <lg>
               <l part="F">Io non ardisco</l>
@@ -4838,7 +4881,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>del suo dolore, e lacrimar le pietre.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>E noi, che parte abbiamo in tanto danno,</l>
@@ -4846,7 +4889,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l part="I">d'una morte e de l'altra?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cameriero">
             <speaker>CAMERIERO</speaker>
             <lg>
               <l part="F">Il re trovolla</l>
@@ -4928,7 +4971,7 @@ Affez.mo e devot.mo ser.re</salute>
             <add resp="#ed">[SCENA QUINTA]</add>
           </head>
           <stage>GERMONDO, CAMERIERO</stage>
-          <sp>
+          <sp who="#germondo">
             <speaker>
               <add resp="#ed">[GERMONDO]</add>
             </speaker>
@@ -4945,27 +4988,27 @@ Affez.mo e devot.mo ser.re</salute>
               <l>se Torrismondo ha 'l fido amico appresso?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cameriero">
             <speaker>CAMERIERO</speaker>
             <lg>
               <l>Oimè, che Torrismondo altro nemico</l>
               <l>non ebbe che se stesso e la sua fede.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#germondo">
             <speaker>GERMONDO</speaker>
             <lg>
               <l>Qual nemicizia intendi, o che ragioni?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cameriero">
             <speaker>CAMERIERO</speaker>
             <lg>
               <l>Ei, signor, la vi spone, e qui la narra.</l>
               <l>Perché questa è sua carta, io fido servo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#germondo">
             <speaker>GERMONDO</speaker>
             <lg>
               <l>Oimè, quel ch'io leggo e quel ch'intendo!</l>
@@ -5000,21 +5043,21 @@ Affez.mo e devot.mo ser.re</salute>
               <l>Ma che pensa? Dov'è? Non vive ancora?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cameriero">
             <speaker>CAMERIERO</speaker>
             <lg>
               <l>Visse, lasciò la moglie, or lascia il regno;</l>
               <l>e l'uno è tuo, l'altro pur volle il fato.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#germondo">
             <speaker>GERMONDO</speaker>
             <lg>
               <l>Oscuro è quel che narri, e quel ch'accenna</l>
               <l part="I">il tuo signor.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cameriero">
             <speaker>CAMERIERO</speaker>
             <lg>
               <l part="F">Ei riconobbe Alvida</l>
@@ -5023,19 +5066,19 @@ Affez.mo e devot.mo ser.re</salute>
               <l part="I">In voi commesso.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#germondo">
             <speaker>GERMONDO</speaker>
             <lg>
               <l part="F">Era sorella adunque?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cameriero">
             <speaker>CAMERIERO</speaker>
             <lg>
               <l part="I">Era, e saprete come.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#germondo">
             <speaker>GERMONDO</speaker>
             <lg>
               <l part="F">Ahi, troppo a torto</l>
@@ -5051,7 +5094,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l part="I">Così me prega?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cameriero">
             <speaker>CAMERIERO</speaker>
             <lg>
               <l part="F">Il ciel fe' scarso il dono,</l>
@@ -5060,7 +5103,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l part="I">quanto darvi potea.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#germondo">
             <speaker>GERMONDO</speaker>
             <lg>
               <l part="F">Tutto ei mi tolse,</l>
@@ -5107,7 +5150,7 @@ Affez.mo e devot.mo ser.re</salute>
             <add resp="#ed">[SCENA SESTA]</add>
           </head>
           <stage>REGINA, CAMERIERO, GERMONDO, ROSMONDA, CORO</stage>
-          <sp>
+          <sp who="#regina">
             <speaker>
               <add resp="#ed">[REGINA]</add>
             </speaker>
@@ -5117,7 +5160,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>di chi son madre, o pur se madre io sono?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cameriero">
             <speaker>CAMERIERO</speaker>
             <lg>
               <l>Regina, oggi la sorte il vero scopre,</l>
@@ -5127,14 +5170,14 @@ Affez.mo e devot.mo ser.re</salute>
               <l>ma qui si mostri il tuo canuto senno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#regina">
             <speaker>REGINA</speaker>
             <lg>
               <l>Se pur questa non è mia vera figlia,</l>
               <l part="I">qual altra è dunque?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cameriero">
             <speaker>CAMERIERO</speaker>
             <lg>
               <l part="F">Partoristi un'altra,</l>
@@ -5143,7 +5186,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>ma per sua poi nudrilla il re norvegio.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#regina">
             <speaker>REGINA</speaker>
             <lg>
               <l>Tanto dolor per ritrovata figlia</l>
@@ -5151,39 +5194,39 @@ Affez.mo e devot.mo ser.re</salute>
               <l>che disturbate nozze. Altro si perde.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cameriero">
             <speaker>CAMERIERO</speaker>
             <lg>
               <l part="I">Oimè lasso!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#regina">
             <speaker>REGINA</speaker>
             <lg>
               <l part="F">Qual silenzio è questo?</l>
               <l part="I">Ov'è la mia Rosmonda?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cameriero">
             <speaker>CAMERIERO</speaker>
             <lg>
               <l part="F">Ov'ella volse.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#regina">
             <speaker>REGINA</speaker>
             <lg>
               <l part="I">E Torrismondo?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#cameriero">
             <speaker>CAMERIERO</speaker>
             <lg>
               <l part="F"> In quel medesmo loco,</l>
               <l part="I">ov'egli volle.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#germondo">
             <speaker>GERMONDO</speaker>
             <lg>
               <l part="F">Altre percosse in prima</l>
@@ -5195,7 +5238,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>non mi sdegnar, benché sia grave il danno.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#regina">
             <speaker>REGINA</speaker>
             <lg>
               <l>Ahi, ahi, ahi, dice: Avesti; io non gli ho dunque?</l>
@@ -5203,7 +5246,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l part="I">i miei duo cari figli?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#germondo">
             <speaker>GERMONDO</speaker>
             <lg>
               <l part="F">Ahi, che non caggia!</l>
@@ -5224,7 +5267,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l part="I">ch'io la sostegna.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#rosmonda">
             <speaker>ROSMONDA</speaker>
             <lg>
               <l part="F">Oh foss'io morta in fasce,</l>
@@ -5246,7 +5289,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>innocente fanciulla.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>A piangere impariamo il vostro affanno</l>
@@ -5257,7 +5300,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>di virtute e d'onor, chi nega il pianto?</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#regina">
             <speaker>REGINA</speaker>
             <lg>
               <l>Ahi, chi mi tiene in vita?</l>
@@ -5283,13 +5326,13 @@ Affez.mo e devot.mo ser.re</salute>
               <l>oimè!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#germondo">
             <speaker>GERMONDO</speaker>
             <lg>
               <l>Quetate il duol, che tutto scopre il tempo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#regina">
             <speaker>REGINA</speaker>
             <lg>
               <l>Signor, se dura morte</l>
@@ -5307,7 +5350,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>meschina.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#germondo">
             <speaker>GERMONDO</speaker>
             <lg>
               <l>S'io potessi, regina, i figli vostri</l>
@@ -5335,7 +5378,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>sarà co 'l proprio regno il re Germondo.</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#regina">
             <speaker>REGINA</speaker>
             <lg>
               <l>Oimè, che la mia vita</l>
@@ -5348,7 +5391,7 @@ Affez.mo e devot.mo ser.re</salute>
               <l>ahi, ahi, ahi, ahi!</l>
             </lg>
           </sp>
-          <sp>
+          <sp who="#germondo">
             <speaker>GERMONDO</speaker>
             <lg>
               <l>Oimè, che non trapassi. O donne, o donne,</l>
@@ -5360,7 +5403,7 @@ Affez.mo e devot.mo ser.re</salute>
           </sp>
         </div>
         <div type="part">
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <lg>
               <l>Ahi lacrime, ahi dolore:</l>

--- a/tei/torelli-la-merope.xml
+++ b/tei/torelli-la-merope.xml
@@ -81,6 +81,34 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="merope">
+            <persName>Merope</persName>
+          </person>
+          <person xml:id="nutrice">
+            <persName>Nutrice</persName>
+          </person>
+          <person xml:id="gabria">
+            <persName>Gabria</persName>
+          </person>
+          <personGrp xml:id="coro">
+            <name>Choro</name>
+          </personGrp>
+          <person xml:id="polifonte">
+            <persName>Polifonte</persName>
+          </person>
+          <person xml:id="capitano">
+            <persName>Capitano</persName>
+          </person>
+          <person xml:id="nesso">
+            <persName>Nesso</persName>
+          </person>
+          <person xml:id="telefonte">
+            <persName>Telefonte</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Pavia</name>Digitalizzazione</change>
@@ -205,7 +233,7 @@ più lungamente meriterebbon di vivere.</p>
       <div type="act">
         <head>Tragedia</head>
         <pb n="164"/>
-        <sp>
+        <sp who="#merope">
           <speaker>MER.</speaker>
           <l> Ecco dal tempo inanzi tempo oppressa</l>
           <l>misera mi ritrovo, ove sperai</l>
@@ -276,7 +304,7 @@ la scorgesti felice ove ti parve:</l>
           <l>ché spento è quell'ond'attendea soccorso,</l>
           <l>e fredda terra il mio conforto ammanta.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l> Non potrai mai co 'l tuo continuo pianto</l>
           <l>richiamar l'alma da le gelid'ombre,</l>
@@ -291,7 +319,7 @@ ch'egli, che vive in te, da te sia spento,</l>
           <l>parte in lui ne recise il crudo ferro,</l>
           <l>et hor l'avanzo tu rompi co 'l duolo.</l>
         </sp>
-        <sp>
+        <sp who="#merope">
           <speaker>MER.</speaker>
           <l> O Niobe felice, che di senso</l>
           <l>priva pur stilli lagrime dal sasso!</l>
@@ -300,7 +328,7 @@ ch'egli, che vive in te, da te sia spento,</l>
           <l>Deh, lasciami sfogar, madre mia antica,</l>
           <l>che piangendo addolcisco il mio dolore.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l> Poco prezzo saria l'oro e l'argento</l>
           <l>a i singulti, a le lagrime, a i sospiri,</l>
@@ -319,7 +347,7 @@ ch'egli, che vive in te, da te sia spento,</l>
           <l>cosa ch'a te profitto,</l>
           <l>a me per lo tuo ben diletto apporti.</l>
         </sp>
-        <sp>
+        <sp who="#merope">
           <speaker>MER.</speaker>
           <l> Poco può più con l'opra o con l'ingegno</l>
           <l>Gabria giovarmi, benché accorto e fido.</l>
@@ -327,7 +355,7 @@ ch'egli, che vive in te, da te sia spento,</l>
             <pb n="168"/>
           </l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l> Saggi concetti Dio dal cielo instilla</l>
           <l>a chi con pura mente a' suoi Re porge</l>
@@ -335,7 +363,7 @@ ch'egli, che vive in te, da te sia spento,</l>
           <l>Desti il tuo usato senno</l>
           <l>il prudente parer d'huom sì fedele.</l>
         </sp>
-        <sp>
+        <sp who="#gabria">
           <speaker>GAB.</speaker>
           <l> Polifonte, a cui sorte iniqua diede</l>
           <l>de l'ampie tue contrade il freno in mano,</l>
@@ -368,7 +396,7 @@ ti supplica, se il lungo suo servire</l>
           <l>vuol che s'invochi e Venere e Giunone,</l>
           <l>e la Concordia co 'l felice nodo.</l>
         </sp>
-        <sp>
+        <sp who="#merope">
           <speaker>MER.</speaker>
           <l> Prima il profondo centro de la terra</l>
           <l>sarà congiunto co 'l sublime cielo;</l>
@@ -381,7 +409,7 @@ ti supplica, se il lungo suo servire</l>
           <l>gli riman sol: che dopo cruda morte</l>
           <l>sia dato a i cani, a gli avoltori in preda.</l>
         </sp>
-        <sp>
+        <sp who="#gabria">
           <speaker>GAB.</speaker>
           <l> Fu per consiglio da' prudenti eletto</l>
           <l>misurar le minaccie con le forze:</l>
@@ -400,14 +428,14 @@ né l'amor t'assicuri ond'egli avampa,</l>
           <l>l'odio ver te, ver noi lo sprezzo; a tutti</l>
           <l>si mostrerà egualmente empio e crudele.</l>
         </sp>
-        <sp>
+        <sp who="#merope">
           <speaker>MER.</speaker>
           <l> Altro di mal non può apportar che morte,</l>
           <l>né di ben io altro che morte aspetto:</l>
           <l>Polifonte odi3, sprezzi, inviperisca,</l>
           <l>ch'un magnanimo cor nulla paventa.</l>
         </sp>
-        <sp>
+        <sp who="#gabria">
           <speaker>GAB.</speaker>
           <l> Troppo ti ferve ne le vene il sangue,</l>
           <l>hor che gelata è nostra speme in tutto.</l>
@@ -424,7 +452,7 @@ né l'amor t'assicuri ond'egli avampa,</l>
           <l>perché non dêi tu, per salute nostra,</l>
           <l>serbar te stessa a più felici giorni?</l>
         </sp>
-        <sp>
+        <sp who="#merope">
           <speaker>MER.</speaker>
           <l> Gabria fedel, tu sai d'ogni altro meglio</l>
           <l>qual pensier mi sia preso, quai perigli</l>
@@ -473,7 +501,7 @@ fosse stato da l'ozio, o inganno o forza</l>
           <l>et a tante fatiche, a tanti guai</l>
           <l>con morte assai tranquilla imponga fine.</l>
         </sp>
-        <sp>
+        <sp who="#gabria">
           <speaker>GAB.</speaker>
           <l> Molt'hai fatto, Reina, e molt'ancora</l>
           <l>per tua gloria vivendo a far ti resta:</l>
@@ -508,7 +536,7 @@ e ne l'essiglio ancor mal può la vita</l>
           <l>Dimmi, perché? conviensi a i Re posporre</l>
           <l>suo voler, suo piacere a l'altrui bene.</l>
         </sp>
-        <sp>
+        <sp who="#merope">
           <speaker>MER.</speaker>
           <l> Veggo che da soverchio amor procede,</l>
           <l>Gabria, il tuo ragionar, ma poco fermo</l>
@@ -553,7 +581,7 @@ ma solo accrescerei gioia al nimico</l>
           <l>nel proprio sangue spegnerà la sete,</l>
           <l>ch'egli ha de la regal progenie mia.</l>
         </sp>
-        <sp>
+        <sp who="#gabria">
           <speaker>GAB.</speaker>
           <l> Se Polifonte ancor non fosse cinto</l>
           <l>da' satelliti suoi, che notte e giorno</l>
@@ -563,7 +591,7 @@ pur dovresti tremare a l'alta impresa.</l>
           <l>Hor come e donna e sola uccider pensi</l>
           <l>huom d'aspetto e di forza sì feroce?</l>
         </sp>
-        <sp>
+        <sp who="#merope">
           <speaker>MER.</speaker>
           <l> Può Polifonte assai, ma di lui puote</l>
           <l>assai più la giustizia, che 'n ciel regna;</l>
@@ -596,7 +624,7 @@ pur dovresti tremare a l'alta impresa.</l>
 che dovrebb' esser giunto, ond'io mi vivo</l>
           <l>più pensosa di lui che di me stessa.</l>
         </sp>
-        <sp>
+        <sp who="#gabria">
           <speaker>GAB.</speaker>
           <l> Volgi nel cor gran cose, alta Reina,</l>
           <l>ma non, come il pensier spesso figura,</l>
@@ -605,7 +633,7 @@ che dovrebb' esser giunto, ond'io mi vivo</l>
           <l>e credi a la ragion, non al furore,</l>
           <l>né correr temeraria a morte certa.</l>
         </sp>
-        <sp>
+        <sp who="#merope">
           <speaker>MER.</speaker>
           <l> Tu pur ti sforzi nel mio cor terrore</l>
           <l>di far nascere, e indarno t'affatichi.</l>
@@ -626,7 +654,7 @@ che dovrebb' esser giunto, ond'io mi vivo</l>
 viso, guardi e parole,</l>
           <l>ordirò vari lacci a l'empia fera.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> Picciol dio, che gran possa</l>
           <l>havesti sì, che su 'l voler discorde</l>
@@ -679,7 +707,7 @@ ti scorgiamo, o Reina,</l>
           <l>dir ciò lice o conviensi:</l>
           <l>perch'a un tal giorno fai sì trist'augurio?</l>
         </sp>
-        <sp>
+        <sp who="#merope">
           <speaker>MER.</speaker>
           <l> A voi, care sorelle,</l>
           <l>mal si dà dal Re vostro questo officio.</l>
@@ -696,7 +724,7 @@ e co 'l pianto accordandosi i singulti</l>
           <l>le nozze ch'io abhorrisco,</l>
           <l>e quel empio comanda.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> Troppo in preda a le lagrime, al dolore</l>
           <l>ti dài, alta Reina,</l>
@@ -715,7 +743,7 @@ e co 'l pianto accordandosi i singulti</l>
           <l>a tal dì, più ch'a gli altri, si disdice,</l>
           <l>che per piacer fu eletto.</l>
         </sp>
-        <sp>
+        <sp who="#merope">
           <speaker>MER.</speaker>
           <l> Lassa, ogni mio piacere, ogni mia voglia</l>
           <l>sol in pianto finisce, e sol s'acqueta</l>
@@ -737,7 +765,7 @@ ché mirare o pensare altro non posso;</l>
           <l>Così co 'l vostro il mio</l>
           <l>giusto dolor porto nel cor scolpito.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> O dì sacro et acerbo,</l>
           <l>a cui spesso convienci</l>
@@ -764,7 +792,7 @@ a' più graditi fiori;</l>
           <l>co 'l variar de' tempi,</l>
           <l>cangiar vita e costumi?</l>
         </sp>
-        <sp>
+        <sp who="#merope">
           <speaker>MER.</speaker>
           <l> In sempiterno occaso</l>
           <l>chiuse i suoi caldi raggi il mio bel sole:</l>
@@ -772,7 +800,7 @@ a' più graditi fiori;</l>
           <l>hor d'ogni luce priva</l>
           <l>seco almen co 'l pensier mi sto sotterra.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> Vive la miglior parte</l>
           <l>del tuo amato signore,</l>
@@ -789,7 +817,7 @@ a' più graditi fiori;</l>
           <l>e pene e premi eterni</l>
           <l>a chi ben opra, e male.</l>
         </sp>
-        <sp>
+        <sp who="#merope">
           <speaker>MER.</speaker>
           <l> Quest'a morir m'invoglia,</l>
           <l><pb n="182"/>
@@ -798,7 +826,7 @@ ch'io pur morendo seco mi starei</l>
           <l>cangiando in dolce e riposata morte</l>
           <l>vita penosa e ria.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> Questa tua bella spoglia</l>
           <l>a guardar Dio ti diede:</l>
@@ -807,7 +835,7 @@ ch'io pur morendo seco mi starei</l>
           <l>se senza il suo congedo</l>
           <l>abbandonassi il carcere terrestre.</l>
         </sp>
-        <sp>
+        <sp who="#merope">
           <speaker>MER.</speaker>
           <l> Non è il soverchio duol che mi trasporta,</l>
           <l>ma per fatal destino, oltr'al costume</l>
@@ -816,7 +844,7 @@ ch'io pur morendo seco mi starei</l>
           <l>pregate il ciel ch'infonda nel mio core</l>
           <l>e l'ardir e 'l saper che mi bisogna.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> Occhio puro del ciel, che nel profondo</l>
           <l>centro de' nostri cori</l>
@@ -945,7 +973,7 @@ libra con giusta lance; e, giunta apena,</l>
           <l>che seco porta il danno</l>
           <l>libera lingua, quando il corpo serve.</l>
         </sp>
-        <sp>
+        <sp who="#polifonte">
           <speaker>POL.</speaker>
           <l> Ne l'aspre imprese, in perigliosi casi</l>
           <l>d'assalti, o pugne, o general conflitto,</l>
@@ -986,12 +1014,12 @@ di mal vicino e di lontan sospetto:</l>
           <l>manda a chiamarmi Gabria. <pb n="188"/>
 </l>
         </sp>
-        <sp>
+        <sp who="#capitano">
           <speaker>CAP.</speaker>
           <l> Ecco ei sen viene,</l>
           <l>e previene il mio impero e l'altrui gita.</l>
         </sp>
-        <sp>
+        <sp who="#gabria">
           <speaker>GAB.</speaker>
           <l> Potente, invitto Re, quanto ti piacque</l>
           <l>d'imporre a un humil servo ho posto in opra:</l>
@@ -1013,7 +1041,7 @@ di mal vicino e di lontan sospetto:</l>
           <l>Tu pur comanda: che, qualhor ti piace,</l>
           <l>teco celebrerà lieta le nozze.</l>
         </sp>
-        <sp>
+        <sp who="#polifonte">
           <speaker>POL.</speaker>
           <l> Gabria, la nova che mi dài m'è grata,</l>
           <l>e spero tosto di mostrarti ancora</l>
@@ -1059,7 +1087,7 @@ quanto caro mi sia ciò che m'hai detto</l>
 al publico interesse de lo stato,</l>
           <l>ov'hai da porre ogni tua forza in opra.</l>
         </sp>
-        <sp>
+        <sp who="#gabria">
           <speaker>GAB.</speaker>
           <l> Signor, tanta mercede non sopporta</l>
           <l>la debile et humil servitù mia.</l>
@@ -1089,14 +1117,14 @@ al publico interesse de lo stato,</l>
           <l>farò ciò ch'a l'honor, ciò ch'al profitto</l>
           <l>d'ambeduo mi parrà che si convenga.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> Come si sottopone e si riserva?</l>
           <l><pb n="191"/>
 Ben ne l'averse e torbide procelle</l>
           <l>il perito pilota si conosce.</l>
         </sp>
-        <sp>
+        <sp who="#polifonte">
           <speaker>POL.</speaker>
           <l> Ben dici, Gabria mio, che, poi ch'unita</l>
           <l>s'è meco la Reina, e 'l bene e 'l male</l>
@@ -1121,7 +1149,7 @@ Ben ne l'averse e torbide procelle</l>
           <l>e, perché quest'è causa a noi commune,</l>
           <l>di commune consiglio ha di bisogno.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> Dio guardi il real germe,</l>
           <l>c'hor a gran rischio corre.</l>
@@ -1129,7 +1157,7 @@ Ben ne l'averse e torbide procelle</l>
             <pb n="192"/>
           </l>
         </sp>
-        <sp>
+        <sp who="#gabria">
           <speaker>GAB.</speaker>
           <l> Poiché tal confidenza in me dimostri,</l>
           <l>invitto Re, più al tuo real servigio</l>
@@ -1183,7 +1211,7 @@ Né facil men fia che lodevol farti</l>
           <l>e la Reina, che tant'ami e pregi,</l>
           <l>goderà teco e 'l regno e 'l figlio insieme.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> Qual più gente possiede</l>
           <l>più povero d'amici si ritrova,</l>
@@ -1191,7 +1219,7 @@ Né facil men fia che lodevol farti</l>
           <l>ma di Gabria mi temo,</l>
           <l>ch'avezze non ha il Re l'orecchie al vero.</l>
         </sp>
-        <sp>
+        <sp who="#polifonte">
           <speaker>POL.</speaker>
           <l> Fiammeggia l'oricalco e, perché splende</l>
           <l>quasi terso oro, l'altrui vista inganna:</l>
@@ -1222,7 +1250,7 @@ Et io, per grande far questo mio impero,</l>
           <l>e tu, che sì confidi nel nimico,</l>
           <l>e gli si dia poter di nocer vuoi?</l>
         </sp>
-        <sp>
+        <sp who="#gabria">
           <speaker>GAB.</speaker>
           <l> Contra di te, come nimico, mosso</l>
           <l>non s'è ancor Telefonte, almen ch'io sappia;</l>
@@ -1240,7 +1268,7 @@ Et io, per grande far questo mio impero,</l>
             <pb n="195"/>
           </l>
         </sp>
-        <sp>
+        <sp who="#polifonte">
           <speaker>POL.</speaker>
           <l> Gabria, molti consigli ove l'estremo,</l>
           <l>ove l'eccesso signoreggia, a molti</l>
@@ -1284,7 +1312,7 @@ poi ch'in perpetua notte gli occhi chiusi</l>
           <l>ch'un negozio importante dia a traverso,</l>
           <l>che condur si potria con tempo in porto.</l>
         </sp>
-        <sp>
+        <sp who="#gabria">
           <speaker>GAB.</speaker>
           <l> Glorioso signor, m'è dolce honore</l>
           <l>l'imparar, c'hor io fo ne la tua scuola,</l>
@@ -1292,7 +1320,7 @@ poi ch'in perpetua notte gli occhi chiusi</l>
           <l>Parlerò a la Reina, e spero e bramo</l>
           <l>far sì che le parole e l'opra lodi.</l>
         </sp>
-        <sp>
+        <sp who="#polifonte">
           <speaker>POL.</speaker>
           <l> Hor va. Del costui senno e de l'amore</l>
           <l>sempre fei grande stima; hor veggo ch'egli,</l>
@@ -1300,7 +1328,7 @@ poi ch'in perpetua notte gli occhi chiusi</l>
           <l>e per fuggir ogni periglio vuole</l>
           <l>ch'io posi in grembo di dubbiosa pace.</l>
         </sp>
-        <sp>
+        <sp who="#capitano">
           <speaker>CAP.</speaker>
           <l> Forse, signor, che più sarà sicura</l>
           <l><pb n="197"/>
@@ -1308,35 +1336,35 @@ la pace che non credi: schermo o scampo</l>
           <l>Telefonte non ha; da questa invitta</l>
           <l>destra egli e vita e sicurezza attende.</l>
         </sp>
-        <sp>
+        <sp who="#polifonte">
           <speaker>POL.</speaker>
           <l> Né da due lumi il giorno luce prende,</l>
           <l>né due Re può capire un regno solo.</l>
         </sp>
-        <sp>
+        <sp who="#capitano">
           <speaker>CAP.</speaker>
           <l> Maggior gloria ti fia se, vinto il regno,</l>
           <l>conservi, sì che serva, il regio sangue.</l>
         </sp>
-        <sp>
+        <sp who="#polifonte">
           <speaker>POL.</speaker>
           <l> Troppo caro si compra un gran sospetto.</l>
         </sp>
-        <sp>
+        <sp who="#capitano">
           <speaker>CAP.</speaker>
           <l> Anzi, pur la quiete si guadagna.</l>
         </sp>
-        <sp>
+        <sp who="#polifonte">
           <speaker>POL.</speaker>
           <l> Sarà il nostro guadagno co 'l suo danno.</l>
         </sp>
-        <sp>
+        <sp who="#capitano">
           <speaker>CAP.</speaker>
           <l> Vorrai sparger tu dunque il sangue, e l'alma</l>
           <l>levar a un giovinetto, a un innocente,</l>
           <l>poco stimando la real sua stirpe?</l>
         </sp>
-        <sp>
+        <sp who="#polifonte">
           <speaker>POL.</speaker>
           <l> Misurando n'andrò co'l merto altrui</l>
           <l>e con l'util del regno il voler mio;</l>
@@ -1344,7 +1372,7 @@ la pace che non credi: schermo o scampo</l>
           <l>né de' rami si cura, pur che cresca</l>
           <l>e al ciel dritto s'erga il real tronco.</l>
         </sp>
-        <sp>
+        <sp who="#capitano">
           <speaker>CAP.</speaker>
           <l> Quanto più cresce, tanto più vicino,</l>
           <l>se Giove tuona, a' folgori si trova;</l>
@@ -1356,7 +1384,7 @@ il cauto agricoltor prender procaccia.</l>
           <l>che farai contra le sacrate leggi,</l>
           <l>se senza giusta causa altri condanni.</l>
         </sp>
-        <sp>
+        <sp who="#polifonte">
           <speaker>POL.</speaker>
           <l> Le leggi e 'l giusto, di che tanto parli,</l>
           <l>e per parlarne assai poco n'intendi,</l>
@@ -1391,7 +1419,7 @@ Questa, quasi fenice, altiera vola,</l>
           <l>e mentre di giustizia e legge parli,</l>
           <l>parli contra la legge e contra 'l giusto.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> S'hora il cielo sua forza non adopra</l>
           <l>per difendere il giusto,</l>
@@ -1408,7 +1436,7 @@ Questa, quasi fenice, altiera vola,</l>
           <l>par c'habbia ne le vene il foco e l'esca</l>
           <l>e ne gli occhi e nel cor la fiamma e 'l foco.</l>
         </sp>
-        <sp>
+        <sp who="#polifonte">
           <speaker>POL.</speaker>
           <l> La superba beltà, che 'n te riluce,</l>
           <l>hebbe tal forza in me, donna reale,</l>
@@ -1427,7 +1455,7 @@ e con nove catene il cor mi lega</l>
           <l>non sol mi fai più tuo ch'io fossi in prima,</l>
           <l>ma tutto in te cangiato a te mi dono.</l>
         </sp>
-        <sp>
+        <sp who="#merope">
           <speaker>MER.</speaker>
           <l> Ben ho da ringraziar gli eterni dèi</l>
           <l>ch'un cavallier sì forte, un Re sì degno</l>
@@ -1440,7 +1468,7 @@ e con nove catene il cor mi lega</l>
           <l>né, per amar, di riverir s'arresta,</l>
           <l>ma sempre amor la riverenza accresce.</l>
         </sp>
-        <sp>
+        <sp who="#polifonte">
           <speaker>POL.</speaker>
           <l> Questa è l'esca gentil che mi mantiene</l>
           <l>con dolce pena eterno incendio al core:</l>
@@ -1454,7 +1482,7 @@ e con nove catene il cor mi lega</l>
 furon? già crudeltà regnar non puote</l>
           <l>ove ogni grazia, ogni virtute abonda.</l>
         </sp>
-        <sp>
+        <sp who="#merope">
           <speaker>MER.</speaker>
           <l> Troppo è la donna a l'altrui dir soggetta,</l>
           <l>e poco saggia è ben colei che casta</l>
@@ -1513,7 +1541,7 @@ sempre di conscienza un crudo verme</l>
             <pb n="203"/>
           </l>
         </sp>
-        <sp>
+        <sp who="#polifonte">
           <speaker>POL.</speaker>
           <l> Tu va, tu per me prega ancor, ché 'l cielo</l>
           <l>a' più puri propizio più si mostra.</l>
@@ -1527,7 +1555,7 @@ sempre di conscienza un crudo verme</l>
           <l>Io me n'entro aspettando il tempo e l'hora,</l>
           <l>che sonnacchioso parerammi, e lenta.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> Mal Prometeo provide</l>
           <l>al nostro stato, alhor ch'a far l'huom primo</l>
@@ -1615,7 +1643,7 @@ ovunque regna Amor vòlto in se stesso.</l>
           <l>talché la morte, sol nostro conforto,</l>
           <l>sicure in porto dal mal ci conduce.</l>
         </sp>
-        <sp>
+        <sp who="#merope">
           <speaker>MER.</speaker>
           <l> Così al mio prego humil Giove s'inchini,</l>
           <l>com'a te di tornar contenta io bramo,</l>
@@ -1660,7 +1688,7 @@ questo mondo altrui grato, altro non lascio</l>
           <l>e molti giorni sono, al parer mio,</l>
           <l>ch'egli dovrebbe homai esser tornato.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> Se col desio che, qualhor troppo cresce,</l>
           <l>spesso la vista appanna</l>
@@ -1668,7 +1696,7 @@ questo mondo altrui grato, altro non lascio</l>
           <l>lontan venir, Reina,</l>
           <l>quel Nesso che tu tanto veder brami.</l>
         </sp>
-        <sp>
+        <sp who="#nesso">
           <speaker>NES.</speaker>
           <l> Triste nove chi porta al suo signore</l>
           <l>ben ha ragion se in ogni loco trema</l>
@@ -1689,28 +1717,28 @@ ch'o diffetto di fede, o negligenza,</l>
           <l>hor non so che mi porti. Ma che donne</l>
           <l>son queste, che qui sono? Son di casa.</l>
         </sp>
-        <sp>
+        <sp who="#merope">
           <speaker>MER.</speaker>
           <l> Molto pensoso e poco allegro in vista</l>
           <l>a noi Nesso ritorna.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> Non temer, donna nostra: ch'egli stanco</l>
           <l>e per lungo camino afflitto resta.</l>
         </sp>
-        <sp>
+        <sp who="#nesso">
           <speaker>NES.</speaker>
           <l> Che ghirlande son queste? e perché allegri</l>
           <l>son così i vostri panni? ov'è la donna</l>
           <l>che voi servir solete? </l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> Ella t'aspetta:</l>
           <l>vedi che già ti chiama. </l>
         </sp>
-        <sp>
+        <sp who="#merope">
           <speaker>MER.</speaker>
           <l> Vieni, Nesso;</l>
           <l>dammi tosto le nove di mio figlio.</l>
@@ -1719,7 +1747,7 @@ ch'o diffetto di fede, o negligenza,</l>
             <pb n="209"/>
           </l>
         </sp>
-        <sp>
+        <sp who="#nesso">
           <speaker>NES.</speaker>
           <l> Vivo credo che sia, ché 'l real sangue,</l>
           <l>quando di mal oprar vive digiuno,</l>
@@ -1747,7 +1775,7 @@ ch'o diffetto di fede, o negligenza,</l>
           <l>mi fece ritornar contra mia voglia</l>
           <l>a te l'amico tuo fedel Toante.</l>
         </sp>
-        <sp>
+        <sp who="#merope">
           <speaker>MER.</speaker>
           <l> O figlio, o amato figlio,</l>
           <l>più che quest'occhi miei, più che la vita,</l>
@@ -1796,7 +1824,7 @@ ch'io sparsi, e per te ancor coglier sperai,</l>
 Ohimè, chi mi consiglia?</l>
           <l>Ohimè, chi mi consola?</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> Deh, perché nel dolor tanto t'immergi</l>
           <l>tu che pur saggia e donna accorta fosti?</l>
@@ -1806,7 +1834,7 @@ Ohimè, chi mi consiglia?</l>
           <l>ch'a buon principe Giove</l>
           <l>non fu giamai de le sue grazie scarso.</l>
         </sp>
-        <sp>
+        <sp who="#nesso">
           <speaker>NES.</speaker>
           <l> Perduto è Telefonte,</l>
           <l>ma noi di ritrovarlo</l>
@@ -1865,7 +1893,7 @@ e spera tosto rimandarti nova</l>
           <l>ch'egli, per quel ch'io credo, è vivo, e tosto</l>
           <l>spero havrai nova anchor ch'egli sia sano.</l>
         </sp>
-        <sp>
+        <sp who="#merope">
           <speaker>MER.</speaker>
           <l> Lassa, che troppo a questa casa infesta</l>
           <l>provai sempre, a me cruda empia fortuna:</l>
@@ -1886,7 +1914,7 @@ e spera tosto rimandarti nova</l>
           <l>che di mia morte homai, che s'avicina,</l>
           <l>certa nova mi porti.</l>
         </sp>
-        <sp>
+        <sp who="#nesso">
           <speaker>NES.</speaker>
           <l> Andrò, se tu comandi, o mia Reina,</l>
           <l>ma la nova, che brami,</l>
@@ -1910,7 +1938,7 @@ a me sol dia di Telefonte aviso;</l>
           <l>di novo hor hor per misurar m'accingo</l>
           <l>quello stesso camin lungo e noioso.</l>
         </sp>
-        <sp>
+        <sp who="#merope">
           <speaker>MER.</speaker>
           <l> Mal può l'afflitta e sconsolata mente</l>
           <l>scieglier ciò ch'havrebb' huopo; e ne gli affanni</l>
@@ -1925,7 +1953,7 @@ a me sol dia di Telefonte aviso;</l>
           <l>fidata consigliera</l>
           <l>de le celate mie giuste querele.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> Come consenti, o Giove,</l>
           <l><pb n="215"/>
@@ -1942,7 +1970,7 @@ che sì giusta Reina,</l>
           <l>ma ' tuoi consigli son celati e chiusi</l>
           <l>fra ' più profondi e tenebrosi abissi.</l>
         </sp>
-        <sp>
+        <sp who="#telefonte">
           <speaker>TEL.</speaker>
           <l> Solo e senz' arme nel maggior periglio</l>
           <l>più sicuro mi trovo e meglio ardisco.</l>
@@ -2000,12 +2028,12 @@ Questo è pur il bel nido</l>
             <pb n="217"/>
           </l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> Veggo un giovine, nobile al sembiante,</l>
           <l>ma il vestir non mi par di questa terra.</l>
         </sp>
-        <sp>
+        <sp who="#telefonte">
           <speaker>TEL.</speaker>
           <l> Donne, sì vi sia Giove,</l>
           <l>che de gli hospiti cura e ragion tiene,</l>
@@ -2013,32 +2041,32 @@ Questo è pur il bel nido</l>
           <l>grave il mostrarmi dove il valoroso</l>
           <l>Re Polifonte dimorar si soglia.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> Quell'è il real palagio, che l'altiera</l>
           <l>fronte più verso il ciel superbo estolle.</l>
           <l>Ma vedi il proprio Re che n'esce, e 'n mezo</l>
           <l>de la sua guardia verso noi sen viene.</l>
         </sp>
-        <sp>
+        <sp who="#telefonte">
           <speaker>TEL.</speaker>
           <l> Ben nel grave e feroce aspetto mostra</l>
           <l>il supremo valor che nel cor chiude.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> A lui fu il ciel così cortese e largo</l>
           <l>de le sue grazie, che i pregiati doni,</l>
           <l>che tra diversi Principi comparte,</l>
           <l>in lui solo versar non gli dispiacque.</l>
         </sp>
-        <sp>
+        <sp who="#telefonte">
           <speaker>TEL.</speaker>
           <l> Non sì dolce feriscono gli orecchi</l>
           <l>i concertati musici strumenti,</l>
           <l>com'il suon de le lodi de gli amici.</l>
         </sp>
-        <sp>
+        <sp who="#polifonte">
           <speaker>POL.</speaker>
           <l> Quest'huom, ch'io veggo, è novo a gli occhi miei;</l>
           <l>pellegrino mi sembra al viso, a' panni,</l>
@@ -2058,7 +2086,7 @@ ove nato, onde venga, ove s'invii,</l>
           <l>altro moto non fa, che dia sospetto:</l>
           <l>pur noterò la voce e le parole.</l>
         </sp>
-        <sp>
+        <sp who="#telefonte">
           <speaker>TEL.</speaker>
           <l> La tua real presenza, alto signore,</l>
           <l>ben tremar l'inimico e star sospeso</l>
@@ -2074,7 +2102,7 @@ ove nato, onde venga, ove s'invii,</l>
           <l>voglio che più ti piaccia, e che ti sia</l>
           <l>de l'amicizia mia pegno più certo.</l>
         </sp>
-        <sp>
+        <sp who="#polifonte">
           <speaker>POL.</speaker>
           <l> Conosco il suo sigillo e le sue note,</l>
           <l>che ti scopron per figlio e per mio amico,</l>
@@ -2093,7 +2121,7 @@ e figlio e caro, sì negletto e solo?</l>
           <l>creder che tu ti fossi; e 'l veggo, e stommi</l>
           <l>per meraviglia attonito e confuso.</l>
         </sp>
-        <sp>
+        <sp who="#telefonte">
           <speaker>TEL.</speaker>
           <l> Vanno le damme timide et imbelli</l>
           <l>da lunga schiera accompagnate; fende</l>
@@ -2136,12 +2164,12 @@ Io l'uccisi: ecco il segno, ecco l'anello,</l>
           <l>per mostrarmegli grato, e perché fosse</l>
           <l>segno de la vittoria e dono al dio.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> O misera Reina,</l>
           <l>o me infelice, o desolato regno!</l>
         </sp>
-        <sp>
+        <sp who="#polifonte">
           <speaker>POL.</speaker>
           <l> Gran nove, hospite caro, e caro figlio,</l>
           <l>son queste che mi porti: et è ben degno</l>
@@ -2162,7 +2190,7 @@ Ma più distintamente hor mi racconta:</l>
           <l>che tanto a me, tanto al mio stato importa,</l>
           <l>c'hai tu condotta a così lieto fine.</l>
         </sp>
-        <sp>
+        <sp who="#telefonte">
           <speaker>TEL.</speaker>
           <l> Tra le vergini etoliche la prima</l>
           <l>per senno, per beltà, per leggiadria</l>
@@ -2271,7 +2299,7 @@ freme, in publico parla, nel senato,</l>
           <l>in salvo teco, e so ch'ogn'altra nova,</l>
           <l>ogn'altro nunzio havrò di me precorso.</l>
         </sp>
-        <sp>
+        <sp who="#polifonte">
           <speaker>POL.</speaker>
           <l> Ben ti portasti, figlio, e come forte</l>
           <l>cavalliero il rivale hai superato,</l>
@@ -2294,12 +2322,12 @@ Tu meco entra in palagio, ivi ricevi</l>
           <l>privatamente, e senza mostra o fasto</l>
           <l>d'hospite amico i debiti servigi.</l>
         </sp>
-        <sp>
+        <sp who="#telefonte">
           <speaker>TEL.</speaker>
           <l> Farò quanto comandi, né parola</l>
           <l>di me saprà da me persona alcuna.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> Morto sei Telefonte, e teco è spenta</l>
           <l>ogni nostra speranza.</l>
@@ -2354,7 +2382,7 @@ de la propria sembianza;</l>
           <l>Il tuo Re a canto a Giove, alma, rimiri:</l>
           <l>tempo è da terra alzarti.</l>
         </sp>
-        <sp>
+        <sp who="#gabria">
           <speaker>GAB.</speaker>
           <l> Son le false grandezze, i vani honori,</l>
           <l>ch'ogn'huom ne l'ampie corti ammira e brama,</l>
@@ -2400,7 +2428,7 @@ Ma in vista assai dogliosa hor venir veggo</l>
           <l>la nutrice de l'alma mia Reina,</l>
           <l>non men d'affanni che di giorni carca.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l> O de l'alta città saldo sostegno,</l>
           <l>unica nostra speme, o Telefonte,</l>
@@ -2418,7 +2446,7 @@ Ma in vista assai dogliosa hor venir veggo</l>
           <l>ma temo, lassa, no 'l soverchio affanno</l>
           <l>pur ti conduca a morte.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> Deh, s'a gli amici parte</l>
           <l>giova dar de gli affanni:</l>
@@ -2429,7 +2457,7 @@ Ma in vista assai dogliosa hor venir veggo</l>
           <l>Chi fu ch'ardì portar sì rea novella,</l>
           <l>contra l'editto di colui che regna?</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l> Hanno l'ali a le piante,</l>
           <l><pb n="229"/>
@@ -2444,13 +2472,13 @@ più veloci che strali o vento vanno</l>
           <l>de le nostre miserie; hor giunto è il tempo</l>
           <l>di trar da gli occhi lagrimosi fiumi.</l>
         </sp>
-        <sp>
+        <sp who="#gabria">
           <speaker>GAB.</speaker>
           <l> Perché, più de l'usato, assai dogliosa</l>
           <l>ti mostri, donna? perch'al pianto inviti</l>
           <l>queste donzelle? </l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l> O fido Gabria, meco</l>
           <l>tu più d'ogn'altro piangi: ché il re nostro</l>
@@ -2459,13 +2487,13 @@ più veloci che strali o vento vanno</l>
           <l>se insolita pietà dal ciel non scende,</l>
           <l>perderemo ancor tosto la Reina.</l>
         </sp>
-        <sp>
+        <sp who="#gabria">
           <speaker>GAB.</speaker>
           <l> Dimmi: che tante perdite son queste?</l>
           <l>ch'al tuo parlar mi sento il cor nel petto</l>
           <l>tutto agghiacciar, tutte tremar le membra.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l> Lisandro paggio, che de l'empio i passi</l>
           <l>Polifonte misura, e i cenni nota,</l>
@@ -2528,7 +2556,7 @@ Corsi tosto con fresche e lucid'onde,</l>
           <l>Questo carco è da te, da te s'aspetta</l>
           <l>e l'aiuto e 'l rimedio a sì grand'huopo.</l>
         </sp>
-        <sp>
+        <sp who="#gabria">
           <speaker>GAB.</speaker>
           <l> Lasso me, quai concetti o quai parole,</l>
           <l>per consolar, per consigliar altrui,</l>
@@ -2544,7 +2572,7 @@ a la nostra Reina mi saprei,</l>
           <l>se seco lagrimand'io non mi sfogo,</l>
           <l>e col mio pianto accresco il suo dolore.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> Dura legge, ch'a gli huomini prescrive</l>
           <l>puro affetto d'amor, fedeltà vera,</l>
@@ -2555,7 +2583,7 @@ a la nostra Reina mi saprei,</l>
           <l>né mai per loro habbiam tranquilla un'hora,</l>
           <l>c'hor pietate, hor timor ne punge il core.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l> Come nel corpo ogni virtù comparte</l>
           <l>l'alma, e senz' alma è il corpo un grave pondo,</l>
@@ -2568,7 +2596,7 @@ a la nostra Reina mi saprei,</l>
           <l>ma senza Re siam quasi</l>
           <l>fiume senz' acqua e senza gemma anello.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> Ben fu crudel la mano</l>
           <l>che fe' il colpo spietato.</l>
@@ -2576,7 +2604,7 @@ a la nostra Reina mi saprei,</l>
           <l>sì crudo giorno, così grave eccesso,</l>
           <l>che fe' noi tristi e miseri in un punto.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l> Che debbo far, chi mi consiglia? resto</l>
           <l>attonita e confusa a sì gran caso.</l>
@@ -2591,7 +2619,7 @@ Dite, figlie mie care:</l>
           <l>de le miserie mie, perché più tardi</l>
           <l>a chiuder queste due fonti di pianto?</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> Ben a ragion t'affligi e ti lamenti,</l>
           <l>o madre nostra antica,</l>
@@ -2605,7 +2633,7 @@ Dite, figlie mie care:</l>
           <l>non rinovasse il pianto,</l>
           <l>et egli i detti suoi spargesse al vento.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l> Gabria, t'inspiri ne la lingua il mele</l>
           <l>hor l'alato Mercurio,</l>
@@ -2622,13 +2650,13 @@ Dite, figlie mie care:</l>
             <pb n="234"/>
           </l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> Coprono sotto tenebrosa notte</l>
           <l>gli dèi gli eventi di future cose,</l>
           <l>ma sperar ben a noi lice e conviensi.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l> Lassa me, che sperar poss'io, s'io veggo</l>
           <l>ogni nostra speranza</l>
@@ -2643,7 +2671,7 @@ Dite, figlie mie care:</l>
           <l>che dolce mi sarian, poich'io le spargo</l>
           <l>per sì giusta cagion, per Re sì degno.</l>
         </sp>
-        <sp>
+        <sp who="#telefonte">
           <speaker>TEL.</speaker>
           <l> Già teso ho il laccio a la spietata fera:</l>
           <l>sì sicura la veggo e sì superba,</l>
@@ -2692,21 +2720,21 @@ imporre al mio travaglio, al lungo essiglio</l>
           <l>riposassi le stanche afflitte membra,</l>
           <l>promettendo a' travagli miei riposo.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l> Questo giovane estrano seco parla,</l>
           <l><pb n="236"/>
 e mira il real seggio, e par confuso</l>
           <l>consultar seco stesso. </l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> Ohimè nutrice,</l>
           <l>quest'è quell'empio, che con l'empio ferro</l>
           <l>il signor nostro uccise; io udito ho il tutto,</l>
           <l>mentr'egli a Polifonte il fatto espose.</l>
         </sp>
-        <sp>
+        <sp who="#telefonte">
           <speaker>TEL.</speaker>
           <l> Lucente dio, che co 'l tuo carro aurato</l>
           <l>l'uno e l'altro hemispero orni e circondi,</l>
@@ -2719,7 +2747,7 @@ e mira il real seggio, e par confuso</l>
           <l>rimira, porgi a gli affannati spirti,</l>
           <l>al mio lungo martir giusto conforto.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l> O giustizia, che 'n ciel perpetua regna,</l>
           <l>e pur si scorge, e pur trionfa in terra!</l>
@@ -2737,7 +2765,7 @@ e mira il real seggio, e par confuso</l>
             <pb n="237"/>
           </l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> Hor chi sarà che con l'acuto ferro</l>
           <l>traffiga il core, e l'alma scelerata</l>
@@ -2745,7 +2773,7 @@ e mira il real seggio, e par confuso</l>
           <l>che stilla ancor de l'innocente sangue</l>
           <l>de l'amato mio caro Telefonte?</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l> Questa preda conviensi a la reina;</l>
           <l>quest'è sua sola e debita vendetta;</l>
@@ -2755,7 +2783,7 @@ e mira il real seggio, e par confuso</l>
           <l>ne l'altrui gola, com'a l'alma offesa</l>
           <l>dolce è de l'inimico e l'onta e 'l danno.</l>
         </sp>
-        <sp>
+        <sp who="#telefonte">
           <speaker>TEL.</speaker>
           <l> O quanto dopo un grave e lungo affanno,</l>
           <l>dopo lungo camino il rotto e stanco</l>
@@ -2779,7 +2807,7 @@ resister posso: a la mia sorte il tutto,</l>
           <l>il cielo, e 'l tutto regge, e d'innocente</l>
           <l>sangue nel maggior rischio ha propria cura.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> Quasi tra lievi e delicate piume</l>
           <l>e de la sicurezza accolto in grembo,</l>
@@ -2797,7 +2825,7 @@ resister posso: a la mia sorte il tutto,</l>
           <l>da l'ira, dal dolor, da la vendetta</l>
           <l>traffitta e scorta vien la mia Reina.</l>
         </sp>
-        <sp>
+        <sp who="#merope">
           <speaker>MER.</speaker>
           <l> Questo sol mi restava, o cielo, o dèi?</l>
           <l>Questo tra tante pene iva aspettando?</l>
@@ -2834,7 +2862,7 @@ l'estremo ha di sua possa.</l>
           <l>l'intestine sue vegga, e trarne il core,</l>
           <l>perché sia pasto a gli affamati lupi.</l>
         </sp>
-        <sp>
+        <sp who="#gabria">
           <speaker>GAB.</speaker>
           <l> Mira al fine, o Reina:</l>
           <l>ché, se costui con tanti strazi3 ancidi,</l>
@@ -2848,7 +2876,7 @@ l'estremo ha di sua possa.</l>
             <pb n="240"/>
           </l>
         </sp>
-        <sp>
+        <sp who="#merope">
           <speaker>MER.</speaker>
           <l> Ben parli, Gabria, ma facciamo almeno</l>
           <l>che costui nel morire</l>
@@ -2860,12 +2888,12 @@ l'estremo ha di sua possa.</l>
           <l>con gli oltraggi e co 'l ferro</l>
           <l>insieme non offendo il corpo e l'alma.</l>
         </sp>
-        <sp>
+        <sp who="#gabria">
           <speaker>GAB.</speaker>
           <l> Mal potrassi hora ei scuotere: a tuo modo</l>
           <l>ferirlo insieme et oltraggiar lo puoi.</l>
         </sp>
-        <sp>
+        <sp who="#telefonte">
           <speaker>TEL.</speaker>
           <l> O Giove! e come in saldi nodi avvinto</l>
           <l>misero mi ritrovo? ohimè chi sei</l>
@@ -2875,7 +2903,7 @@ l'estremo ha di sua possa.</l>
           <l>Hor qual vittima cado? e la mia morte</l>
           <l>vile e negletta fa donnesca mano?</l>
         </sp>
-        <sp>
+        <sp who="#merope">
           <speaker>MER.</speaker>
           <l> Questa man, scelerato, il laccio scioglie,</l>
           <l>che la vile alma tua co 'l corpo lega;</l>
@@ -2890,7 +2918,7 @@ l'estremo ha di sua possa.</l>
             <pb n="241"/>
           </l>
         </sp>
-        <sp>
+        <sp who="#telefonte">
           <speaker>TEL.</speaker>
           <l> Febo, pur sei verace, e pur m'hai detto</l>
           <l>ch'in questo seggio i' troverei riposo,</l>
@@ -2902,25 +2930,25 @@ l'estremo ha di sua possa.</l>
           <l>né spirar devo altrove</l>
           <l>che in questo real seggio.</l>
         </sp>
-        <sp>
+        <sp who="#merope">
           <speaker>MER.</speaker>
           <l> Ohimè, chi sei, dimmi, chi sei? che seggio</l>
           <l>è questo tuo? che padre invendicato?</l>
           <l>Dimmi, non tardar più, ché mal convienti</l>
           <l>meco scherzar su 'l tuo periglio estremo.</l>
         </sp>
-        <sp>
+        <sp who="#telefonte">
           <speaker>TEL.</speaker>
           <l> Qui non è alcun che mi conosca; solo</l>
           <l>Nesso, de la Reina antico servo,</l>
           <l>conoscer mi potria. </l>
         </sp>
-        <sp>
+        <sp who="#gabria">
           <speaker>GAB.</speaker>
           <l> Chiamisi Nesso.</l>
           <l>Ma ecco ch'ei sen vien con lunghi passi.</l>
         </sp>
-        <sp>
+        <sp who="#nesso">
           <speaker>NES.</speaker>
           <l> Ohimè lasso, a la vendetta corro</l>
           <l>di Telefonte, aiuto a la Reina,</l>
@@ -2934,20 +2962,20 @@ l'estremo ha di sua possa.</l>
           <l><pb n="242"/>
 è questo mio, quest'è il tuo amato figlio.</l>
         </sp>
-        <sp>
+        <sp who="#telefonte">
           <speaker>TEL.</speaker>
           <l> Nesso, dunque è presente a gli occhi miei</l>
           <l>quella che tanti guai, che tante pene</l>
           <l>sofferse per produrmi e per crearmi?</l>
           <l>Quella ch'io tengo sol signora e madre?</l>
         </sp>
-        <sp>
+        <sp who="#nesso">
           <speaker>NES.</speaker>
           <l> Ohimè, che chi ti diede e spirto e vita,</l>
           <l>ohimè, quasi in un punto</l>
           <l>insieme e ritrovato, e t'ha perduto.</l>
         </sp>
-        <sp>
+        <sp who="#merope">
           <speaker>MER.</speaker>
           <l> Figlio mio, amato figlio, ohimè infelice,</l>
           <l>quasi t'ho offerto a dispietata morte.</l>
@@ -2973,7 +3001,7 @@ quanto siamo vicini ambeduo stati,</l>
           <l>io a l'esser scelerata et empia madre,</l>
           <l>e tu per le mie man misero e morto.</l>
         </sp>
-        <sp>
+        <sp who="#telefonte">
           <speaker>TEL.</speaker>
           <l> Con travagli e perigli</l>
           <l>vuol Dio che qui si compre</l>
@@ -2988,7 +3016,7 @@ quanto siamo vicini ambeduo stati,</l>
           <l>e di quanto soffersi Dio ringrazio,</l>
           <l>poich'abbracciarti e riverirti posso.</l>
         </sp>
-        <sp>
+        <sp who="#merope">
           <speaker>MER.</speaker>
           <l> Non so se più la tema o più il piacere</l>
           <l>per tua cagion, figlio, m'ingombra il petto:</l>
@@ -3000,7 +3028,7 @@ quanto siamo vicini ambeduo stati,</l>
           <l>era contra di lui, hor per tua causa</l>
           <l>e timida e confusa mi ritrovo.</l>
         </sp>
-        <sp>
+        <sp who="#telefonte">
           <speaker>TEL.</speaker>
           <l> Io ne l'alta giustizia mi confido,</l>
           <l>e spero che quel tempo hoggi sia giunto,</l>
@@ -3026,7 +3054,7 @@ e te lieta e sicura</l>
           <l>pur ch'io nel regno mio per lei tornassi;</l>
           <l>tutto il resto mi finsi, e fu creduto.</l>
         </sp>
-        <sp>
+        <sp who="#gabria">
           <speaker>GAB.</speaker>
           <l> Ecco apparir la guardia, ecco il tiranno.</l>
           <l>Riprendi l'azza, ch'è caduta in terra;</l>
@@ -3036,13 +3064,13 @@ e te lieta e sicura</l>
           <l>Io quasi reo di maestà tuo figlio</l>
           <l>tra questi lacci cercherò occultare.</l>
         </sp>
-        <sp>
+        <sp who="#capitano">
           <speaker>CAP.</speaker>
           <l> Odo risse, arme veggo: o là, correte,</l>
           <l>fate star tutti fermi; a la presenza</l>
           <l>del Re chi tanto ardisce? è la Reina.</l>
         </sp>
-        <sp>
+        <sp who="#polifonte">
           <speaker>POL.</speaker>
           <l> Perché così turbata hora ti veggo,</l>
           <l>hor che lieta e tranquilla</l>
@@ -3054,7 +3082,7 @@ Cessi ogni noia, et ogni augurio tristo</l>
           <l>Che vuol qui dir quest'azza? e per qual causa</l>
           <l>questo giovane Gabria preso mena?</l>
         </sp>
-        <sp>
+        <sp who="#merope">
           <speaker>MER.</speaker>
           <l> Quest'audace, signor, su 'l real trono</l>
           <l>hora trovai, hora d'uccider bramo;</l>
@@ -3065,7 +3093,7 @@ Cessi ogni noia, et ogni augurio tristo</l>
           <l>pur che punito sia chiunque sprezza</l>
           <l>la maestà del tuo tremendo impero.</l>
         </sp>
-        <sp>
+        <sp who="#telefonte">
           <speaker>TEL.</speaker>
           <l> Invitto Re, tu chi mi sia ben sai,</l>
           <l>e come, et onde io venga; afflitto e lasso</l>
@@ -3078,7 +3106,7 @@ Cessi ogni noia, et ogni augurio tristo</l>
           <l>temo la tua disgrazia, e di costei,</l>
           <l>che tu ami, io riverisco, il grave sdegno.</l>
         </sp>
-        <sp>
+        <sp who="#polifonte">
           <speaker>POL.</speaker>
           <l> Ben veggo, donna, che 'l tuo puro affetto,</l>
           <l>e 'l zelo del mio honor, la costui colpa</l>
@@ -3092,7 +3120,7 @@ per opra sua questo mio regno veggo,</l>
           <l>più che mai fosse, stabilito e saldo,</l>
           <l>e tu meco l'honora e l'accarezza.</l>
         </sp>
-        <sp>
+        <sp who="#merope">
           <speaker>MER.</speaker>
           <l> Dunqu' io ne l'hospital sangue la destra</l>
           <l>mia macchiar fui vicina? o dèi, vi chieggio</l>
@@ -3101,13 +3129,13 @@ per opra sua questo mio regno veggo,</l>
           <l>che 'n matrimonio mi congiunga teco,</l>
           <l>resti espiata da sì grave errore.</l>
         </sp>
-        <sp>
+        <sp who="#telefonte">
           <speaker>TEL.</speaker>
           <l> Et io, s'a te pur par, Re invitto e pio,</l>
           <l>per la salute a Giove immolar bramo</l>
           <l>con le dorate corna un bianco toro.</l>
         </sp>
-        <sp>
+        <sp who="#polifonte">
           <speaker>POL.</speaker>
           <l> Entra tu, Gabria, e fa che 'l tutto in opra</l>
           <l>si ponga tosto; e, poscia ch'i privati</l>
@@ -3121,7 +3149,7 @@ per opra sua questo mio regno veggo,</l>
           <l>con la presenza mia</l>
           <l>i sacrifici3 vostri.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> Picciola luce tra l'horribil onde</l>
           <l>e 'l poco biancheggiar d'amica stella</l>
@@ -3202,7 +3230,7 @@ tra' ceppi e tra le dure aspre catene;</l>
           <l>de' Re nostri seconda; tu difesa</l>
           <l>sia di tant'alta e gloriosa impresa.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l> Ohimè lassa, ch'a fatica il fianco</l>
           <l>antico vo trahendo, i piedi sento</l>
@@ -3218,14 +3246,14 @@ tra' ceppi e tra le dure aspre catene;</l>
           <l>Ohimè, qual romor d'armi et urli e strida</l>
           <l>m'han percosso l'orecchie e 'l cor traffitto?</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> Ove ne vai, nutrice? e che novelle</l>
           <l>de' nostri Re ci porti? perché mesta</l>
           <l>così ti mostri? ha forse l'empia sorte</l>
           <l>nostre buone speranze indietro vòlte?</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l> Non so dov'io mi vada: sì m'afflige</l>
           <l>il dolor, il timor, ch'io sono in dubbio</l>
@@ -3265,7 +3293,7 @@ vi pose in mente così mal consiglio?</l>
           <l>Qual furia vi rapisce? e chi v'aperse</l>
           <l>la via a la morte, al precipizio nostro?</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> Che faremo, o sorelle?</l>
           <l>Entraremo a veder ciò, c'hora detto,</l>
@@ -3275,7 +3303,7 @@ vi pose in mente così mal consiglio?</l>
           <l>Ma ecco Nesso: da lui certo havremo,</l>
           <l>di quanto fatto s'è, certa novella.</l>
         </sp>
-        <sp>
+        <sp who="#nesso">
           <speaker>NES.</speaker>
           <l> Pur caduto è il tiranno, e con percossa</l>
           <l>tal, che quasi tirò tutti noi seco.</l>
@@ -3288,14 +3316,14 @@ vi pose in mente così mal consiglio?</l>
           <l>e su le morti altrui fondi l'impero,</l>
           <l>e per l'impero i Re conduci a morte!</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> O Nesso, a che siam noi? son vivi i nostri</l>
           <l>Principi? o pur perduta è nostra speme?</l>
           <l>Deh, ne 'l dì tosto, e noi di dubbio leva,</l>
           <l>che quasi siam di mera tema spente.</l>
         </sp>
-        <sp>
+        <sp who="#nesso">
           <speaker>NES.</speaker>
           <l> Donne, il Re Polifonte estinto giace;</l>
           <l>sono vivi i Re nostri, ma il periglio</l>
@@ -3305,7 +3333,7 @@ Né però sono ancora ben sicure</l>
           <l>le cose nostre: si combatte ancora;</l>
           <l>pur par che la vittoria a' nostri aspiri.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l> Odo o m'inganno? Polifonte è morto?</l>
           <l>I nostri Re son salvi? o Nesso, o Nesso,</l>
@@ -3313,7 +3341,7 @@ Né però sono ancora ben sicure</l>
           <l>se ti dia il cielo a la vecchiezza estrema</l>
           <l>giunger con forti membra e sana mente.</l>
         </sp>
-        <sp>
+        <sp who="#nesso">
           <speaker>NES.</speaker>
           <l> Non fu mai Polifonte in vita sua</l>
           <l>più sicuro o più lieto: il suo rivale</l>
@@ -3414,19 +3442,19 @@ tosto che vide tacita e confusa</l>
           <l>Io là men vado, per coprir di fiori,</l>
           <l>come m'ha imposto, il ricco monumento.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> Ancor sento nel cor il gran duello</l>
           <l>che vi fan con incerto evento dentro</l>
           <l>e timore e pietate.</l>
         </sp>
-        <sp>
+        <sp who="#nutrice">
           <speaker>NUT.</speaker>
           <l> O figlie, io pur ho udito, e credo appena,</l>
           <l>che salvi sien gli amati miei signori.</l>
           <l>Lassa, ch'udir vorrei più certa nova.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> Nesso è fedele e saggio:</l>
           <l>madre, non dubitar ch'egli ci apporti</l>
@@ -3434,7 +3462,7 @@ tosto che vide tacita e confusa</l>
           <l>Ma vedi la Reina: ecco il gran teschio,</l>
           <l>che fede fa de la vittoria nostra.</l>
         </sp>
-        <sp>
+        <sp who="#merope">
           <speaker>MER.</speaker>
           <l> Superbo possessor de l'altrui regno,</l>
           <l>iniquo usurpator de l'altrui nozze,</l>
@@ -3468,7 +3496,7 @@ fosti leal, fosti cortese amante.</l>
           <l>poscia a dolerti, a lagrimar ti resta,</l>
           <l>vedova, sconsolata in veste negra.</l>
         </sp>
-        <sp>
+        <sp who="#coro">
           <speaker>CHORO</speaker>
           <l> Non quel che più s'apprezza</l>
           <l>può tesoro o bellezza</l>

--- a/tei/trissino-sofonisba.xml
+++ b/tei/trissino-sofonisba.xml
@@ -74,6 +74,43 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="sofonisba">
+            <persName>Sofonisba</persName>
+          </person>
+          <person xml:id="erminia">
+            <persName>Erminia</persName>
+          </person>
+          <personGrp xml:id="coro">
+            <name>Coro di donne Cirtensi</name>
+          </personGrp>
+          <person xml:id="famiglio">
+            <persName>Famiglio</persName>
+          </person>
+          <person xml:id="messo">
+            <persName>Messo</persName>
+          </person>
+          <person xml:id="massinissa">
+            <persName>Massinissa</persName>
+          </person>
+          <person xml:id="lelio">
+            <persName>Lelio</persName>
+          </person>
+          <person xml:id="catone">
+            <persName>Catone</persName>
+          </person>
+          <person xml:id="scipione">
+            <persName>Scipione</persName>
+          </person>
+          <person xml:id="siface">
+            <persName>Siface</persName>
+          </person>
+          <person xml:id="serva">
+            <persName>Serva</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>LIZ</name>Digitalizzazione</change>
@@ -134,7 +171,7 @@
           <head>Scena I</head>
           <stage>La scena de la favola si pone in Cirta, città di Numidia.</stage>
           <stage>SOFONISBA, ERMINIA</stage>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Lassa, dove poss'io voltar la lingua,</l>
             <l>se non là 've la spinge il mio pensiero?</l>
@@ -144,7 +181,7 @@
             <l>se non manifestando i miei martìri?</l>
             <l>I quali ad un ad un voglio narrarti.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> Regina Sofonisba, a me regina</l>
             <l>per dignità, ma per amor sorella,</l>
@@ -152,7 +189,7 @@
             <l>non possete parlar con chi più v'ami;</l>
             <l>né che si doglia più dei vostri mali.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Questo conobbi infin da' miei prim'anni,</l>
             <l>Erminia mia, che siam nutrite insieme;</l>
@@ -260,7 +297,7 @@
             <l>E io v'entrai; così disparve il sonno,</l>
             <l>che m'ha lasciata, ohimé troppo confusa.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> Veramente, regina,</l>
             <l>il parlar vostro mi dimostra chiaro</l>
@@ -279,7 +316,7 @@
             <l>che già non vi condanna</l>
             <l>la sentenzia del ciel, come pensate.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> O che felice stato</l>
             <l>è il tuo! che quello i' chiamo esser felice,</l>
@@ -288,12 +325,12 @@
             <l>è l'esser di color, a cui non lice</l>
             <l>far, se non come vuol la lor grandezza.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> La gloria, e l'altro ben, che il mondo apprezza,</l>
             <l>si truova pur in quell'altera vita.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Sì, ma tal gloria è debile, e fallace.</l>
             <l>Il dominar ti piace</l>
@@ -304,7 +341,7 @@
             <l>veneni, tradimenti;</l>
             <l>e se tu fuggi l'un, l'altro t'infesta.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> Questa vita mortale</l>
             <l>non si può trappassar senza dolore;</l>
@@ -323,7 +360,7 @@
             <l>e da poi sopportare</l>
             <l>con generoso cuor, quel che n'avviene.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Ben conosch'io che quello</l>
             <l>bisognerebbe far, che tu ragioni,</l>
@@ -337,7 +374,7 @@
             <l>non fa che sia men dura,</l>
             <l>ben sono al fin, per cui la vita fugge.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> Andiamo adunque e rivoltiam la mente</l>
             <l>a pregar quell'Idio ch'ha di noi cura,</l>
@@ -345,7 +382,7 @@
             <l>fra la nimica gente</l>
             <l>sparga, e discioglia noi da tal paura.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Questo consiglio tuo molto mi piace;</l>
             <l>che solamente Idio</l>
@@ -355,7 +392,7 @@
         <div type="scene">
           <head>Scena II</head>
           <stage>CORO</stage>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Che farò io? Debbo chiamar di fuore</l>
             <l>qualcuna de le serve,</l>
@@ -406,41 +443,41 @@
         <div type="scene">
           <head>Scena III</head>
           <stage>FAMIGLIO, CORO SOFONISBA</stage>
-          <sp>
+          <sp who="#famiglio">
             <speaker>FAMIGLIO</speaker>
             <l part="I"> Donne? </l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="M"> Che vuoi, che non ragioni? </l>
           </sp>
-          <sp>
+          <sp who="#famiglio">
             <speaker>FAMIGLIO</speaker>
             <l part="F"> Lasso,</l>
             <l>ch'io non ho lena da parlar. </l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="I"> Costui</l>
             <l>m'empie di nuovo di paura. </l>
           </sp>
-          <sp>
+          <sp who="#famiglio">
             <speaker>FAMIGLIO</speaker>
             <l part="F"> Donne,</l>
             <l>vero ornamento a la città di Cirta,</l>
             <l>ditemi: ove si truova la regina?</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Ecco, che ad or ad or esce di casa,</l>
             <l>e non è ben ancor fuor de la porta.</l>
             <l>Ma d'onde vien tu sì affannato e stanco?</l>
           </sp>
-          <sp>
+          <sp who="#famiglio">
             <speaker>FAMIGLIO</speaker>
             <l> Vengo dal nostro infortunato campo.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Abbiate cura, come sia fornita</l>
             <l>quella vesta, che Erminia apparecchiava</l>
@@ -448,45 +485,45 @@
             <l>in questo mezzo vederò, se mai</l>
             <l>s'intendesse del re qualche novella.</l>
           </sp>
-          <sp>
+          <sp who="#famiglio">
             <speaker>FAMIGLIO</speaker>
             <l> Ahimé, che troppo mal ne intenderete.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Aspettiam pur quel che costui favelli,</l>
             <l>perché deve saper distinte e chiare</l>
             <l>quelle cose, che noi sappiam confuse.</l>
           </sp>
-          <sp>
+          <sp who="#famiglio">
             <speaker>FAMIGLIO</speaker>
             <l> Regina Sofonisba, a voi rapporto,</l>
             <l>contra mia voglia, pessime novelle.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> O duro esordio! è vivo il mio consorte?</l>
           </sp>
-          <sp>
+          <sp who="#famiglio">
             <speaker>FAMIGLIO</speaker>
             <l> Morto non è, né vo' chiamarlo vivo.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Che cosa, è ferit'egli, o rotto il campo?</l>
           </sp>
-          <sp>
+          <sp who="#famiglio">
             <speaker>FAMIGLIO</speaker>
             <l> Il campo è rotto, ed ei non è ferito,</l>
             <l>ma preso è ne le man de' suoi nimici.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> O sventurata me, che gran ruina;</l>
             <l>quest'è quel dì, quel dì, che m'ha distrutta.</l>
             <l>Ma come rotto fu? come fu preso?</l>
           </sp>
-          <sp>
+          <sp who="#famiglio">
             <speaker>FAMIGLIO</speaker>
             <l> Questa mattina, ne l'uscir del sole,</l>
             <l>certi nostri cavalli se n'andaro</l>
@@ -521,41 +558,41 @@
             <l>poi posi guardia intorno de la terra;</l>
             <l>e per questa cagion son giunto tardi.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Lassa, ch'io vedo il fin di quest'impero,</l>
             <l>e la stirpe regal de' miei signori</l>
             <l>eradicata fia, non che depressa.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Ohimé infelice, ohimé dove son giunta!</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Quanto di voi mi duole!</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> O misero Siface,</l>
             <l>dove, dove n'andrai, dove mi lasci?</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Qual spirto al mondo è di pietà sì nudo,</l>
             <l>che mirando costei tenesse il pianto?</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> O sventurata altezza,</l>
             <l>dove m'hai tu condotta? O duro sogno;</l>
             <l>anzi più tosto vision, che sogno!</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Giusta cagione a lacrimar vi muove.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Qual trista piangerìa, se non piang'io?</l>
             <l>Che in così brieve tempo,</l>
@@ -566,13 +603,13 @@
             <l>Deh foss'io morta in fasce!</l>
             <l>che ben morendo quasi si rinasce.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Ben areste cagion di pianger sempre,</l>
             <l>se il pianto vi recasse alcun rimedio;</l>
             <l>ma se v'annoia più, meglio è lasciarlo.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> O padre, o caro padre,</l>
             <l>come fallace fia vostra speranza</l>
@@ -590,22 +627,22 @@
             <l>Non fien di me, non fien tai cose intese;</l>
             <l>più tosto vo' morir, che viver serva.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Che cosa v'odo dire?</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Che più tosto morire</l>
             <l>voglio, che viver serva de' Romani.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Buon è, buon è fuggir sì crude mani;</l>
             <l>ma non già con la morte;</l>
             <l>ch'ella è l'estremo mal di tutti i mali.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> La vita nostra è come un bel tesoro,</l>
             <l>che spender non si deve in cosa vile,</l>
@@ -617,13 +654,13 @@
         <div type="scene">
           <head>Scena IV</head>
           <stage>MESSO, SOFONISBA, CORO</stage>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <l> Fuggite, o triste e sconsolate donne;</l>
             <l>fuggite in qualche più sicura parte,</l>
             <l>che i nimici già son dentro a le mura.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Ove si può fuggir? Che luogo abbiamo</l>
             <l>che ci conservi, o da lor ci asconda,</l>
@@ -631,15 +668,15 @@
             <l>Ma come entrati son dentro a la terra,</l>
             <l>per accordo, per forza, o per inganni?</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <l part="I"> Può dirsi accordo, e no. </l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l part="F"> Parla più chiaro.</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <l> Io narrerò diffusamente il tutto.</l>
             <l>Come il campo roman fu giunto appresso</l>
@@ -672,7 +709,7 @@
             <l>e poi subitamente aperte foro</l>
             <l>le porte, e date in man di Massinissa.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> O duro caso; ahi come è poco accorto</l>
             <l>chi ne l'amor dei popoli si fida.</l>
@@ -680,20 +717,20 @@
             <l>e far più certi e più sicuri patti;</l>
             <l>ch'io non sarei, com'or, senza consiglio.</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <l> Ecco i nimici qui presso a la piazza.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l part="I"> Mostrami Massinissa. </l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <l part="F"> Quel davanti,</l>
             <l>che sopra l'elmo ha tre purpuree penne.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Ohimé, ch'io sento, ohimé! giungermi al cuore</l>
             <l>una certa paura, che mi strugge</l>
@@ -704,7 +741,7 @@
         <div type="scene">
           <head>Scena V</head>
           <stage>SOFONISBA, MASSINISSA, CORO</stage>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Signor, so ben che il cielo e la fortuna</l>
             <l>e le vostre virtù v'hanno concesso</l>
@@ -738,12 +775,12 @@
             <l>il miserrimo stato, ove son ora;</l>
             <l>e la felice mia passata vita.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Non negate, Signor, a tanta donna</l>
             <l>questa onesta dimanda e giusti prieghi.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Regina, i' non vo' dir gli oltraggi e l'onte,</l>
             <l>che Siface mi fe' molti e molt'anni,</l>
@@ -775,12 +812,12 @@
             <l>che quando ancor non foste in libertate,</l>
             <l>non devete temer d'alcuno oltraggio.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Rinforzate il pregare, alta regina;</l>
             <l>che l'arbore non cade al primo colpo.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Signore, il vostro ragionar soave,</l>
             <l>che dimostra di me qualche pietate,</l>
@@ -834,13 +871,13 @@
             <l>che fatto avete per la mia salute,</l>
             <l>deh donate per fin questa promessa.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Gran forza aver dovrebbon le parole,</l>
             <l>che son mosse dal cuore e dolcemente</l>
             <l>escon di bocca d'una bella donna.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Talora è buono aver molti rispetti,</l>
             <l>e talor si richiede essere audace.</l>
@@ -870,12 +907,12 @@
             <l>e non andrete in forza de' Romani,</l>
             <l>mentre che sarà vita in queste membra.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> O risposta cortese, o parlar pio,</l>
             <l>degno di laude, e di memoria eterna.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> In che voce poss'io scioglier la lingua,</l>
             <l>che degnamente a voi grazie ne renda</l>
@@ -907,73 +944,73 @@
             <l>che in vece mia, per questa sì bell'opra,</l>
             <l>vi renda degno ed onorato merto.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Altro merto non vo', però che il bene</l>
             <l>solo si deve far, perch'egli è bene;</l>
             <l>il quale è il fin di tutte l'opre umane.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Il premio è pur quel che la gente invita</l>
             <l>spesse fiate a l'onorate imprese.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Sì, quella gente, a cui non è ancor nota</l>
             <l>quanta dolcezza del ben far si prende.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Sia pur come si voglia, ch'io ne priego</l>
             <l>Iddio, che renda a voi merto di questo,</l>
             <l>per onorar così pietoso aiuto.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Assai merto m'ha reso, ch'ei m'ha fatto</l>
             <l>grazia di dire e poter forse fare</l>
             <l>cosa, che tanto a voi diletta e piace.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Or così sia, signor; ditemi poi</l>
             <l>che debbia far, che dal consiglio vostro</l>
             <l>i' non intendo punto dilungarmi.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Parrebbe a me (s'a voi questo non spiace)</l>
             <l>d'andare in casa, u' penseren del modo</l>
             <l>da mantenervi la promessa fede.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Sì, caro signor mio, non mi mancate.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Di poca fede adunque dubitate?</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Io non dubito già, ma il gran disìo</l>
             <l>mi sprona sì, che fa parer ch'io tema.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Non dubitate, ch'egli è mio costume</l>
             <l>d'attender sempre mai quel ch'io prometto,</l>
             <l>e ho in odio colui che dentr'al cuore</l>
             <l>tien una cosa, e ne la lingua un'altra.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Andiamo adunque, e s'a le buone imprese</l>
             <l>non è sempre contraria la fortuna,</l>
             <l>debbian sperar che ci sarà seconda.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Almo celeste raggio,</l>
             <l>de la cui santa luce</l>
@@ -1069,7 +1106,7 @@
         <div type="scene">
           <head>Scena I</head>
           <stage>LELIO <emph>e</emph> CORO</stage>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Ad ogni passo mi rivolgo intorno,</l>
             <l>mirando la grandezza e la possanza</l>
@@ -1088,21 +1125,21 @@
             <l>Donne, chi siete voi, che ragionando</l>
             <l>vi state insieme sconsolate in vista?</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Cittadine siam noi di questa terra,</l>
             <l>che presa avete, nominata Cirta;</l>
             <l>la cui novella e sùbita presura</l>
             <l>ci fa così restar quasi confuse.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Voi devete sapere ove si truove</l>
             <l>nuovo re, ch'entrò con la sua gente</l>
             <l>poc'ora fa qui ne la terra vostra;</l>
             <l>però vi piaccia d'insegnarlo a noi.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Dentr'al palazzo andò non è gran tempo</l>
             <l>con molta gente il re, che voi chiedete.</l>
@@ -1110,13 +1147,13 @@
             <l>Ma non sia grave ancor a voi, di farci</l>
             <l>parimente sapere il vostro nome.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Lelio mi chiamo, e la mia patria è Roma;</l>
             <l>e dopo Scipion, ch'è capitano,</l>
             <l>tengo nel campo il più sublime onore.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Or mi ricordo, e so, chi voi vi siete,</l>
             <l>però che il glorioso nome vostro</l>
@@ -1126,12 +1163,12 @@
             <l>ch'a la vostra grandezza si conviene;</l>
             <l>fu, ch'io non conoscea l'alta presenza.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Non accade scusar, che non v'è fallo;</l>
             <l>anzi gran gentilezza ho scorta in voi.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Ecco un de' vostri, ch'esce fuor di casa.</l>
             <l>Ei dee saper quel che là dentro fanno.</l>
@@ -1140,172 +1177,172 @@
         <div type="scene">
           <head>Scena II</head>
           <stage>LELIO <emph>e</emph> MESSO</stage>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <l> A tempo veggio Lelio, a cui n'andava.</l>
             <l>Signor, io v'ho da dire alcune cose.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Tu vuoi forse narrarmi la gran preda,</l>
             <l>che ritrovata avete entr'al palazzo.</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <l> Anzi non ho veduto alcuna cosa,</l>
             <l>che non s'ha avuto ancor cura di questo.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Che face adunque dentro Massinissa,</l>
             <l>se non raguna ogni regal tesoro?</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <l> Egli si sta con la novella sposa</l>
             <l>gioioso e lieto fra piaceri e canti.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Che nuova sposa è questa, che tu parli?</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <l> Di Massinissa, di chi voi chiedete.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Come di Massinissa, e chi è costei?</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <l> Sofonisba d'Asdrubale figliuola.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Sofonisba la moglie di Siface?</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <l> Quella stessa dich'io, che fu regina.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Questi ha tolta per moglie Sofonisba?</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <l> Questi l'ha tolta, i' non ragiono indarno.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> O nuovo caso, o smisurato ardire!</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <l> La cosa sta così, com'io vi conto.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Ma dove era costei, dove la vide?</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <l> Ne la piazza, ch'è qui 'nanzi al palazzo.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> E che le disse nel primiero incontro?</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <l> La donna a lui parlò primieramente.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Ella gli parlò pria d'esserli moglie?</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <l> No, ma li chiese umilemente un dono.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Forse la libertà, ch'ognun disìa?</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <l> Sì, di non gire in forza de' Romani.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Ed egli le promesse arditamente?</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <l> Anzi pur contradisse a questa parte.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Che fece poi, quando le fu negato?</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <l> Nel ripriegò con più soavi prieghi.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Ed e' che disse la seconda volta?</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <l> Tutto quel che chiedea, tutto promesse.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> O pensier vani, or come potea farlo?</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <l> Non saprei dir che si sperasse alora.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Che 'l poté indurre a far questa promessa?</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <l> Amore e le dolcissime parole.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Com'ebbe forza Amor così fra l'arme?</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <l> Non è pensier, che il suo potere intenda.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Ma fatto questo, che seguì dapoi</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <l> Tutti n'andammo a compagnarli in casa.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> E ivi la sposò secretamente.</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <l> Anzi pur in presenza di ciascuno.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Narrami un poco il matrimonio tutto.</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <l> Dirollo, e so, per questo a voi venìa.</l>
             <l>Poi che noi fummo andati entr'al palazzo,</l>
@@ -1394,7 +1431,7 @@
             <l>e venni fuori a voi, come vedeste,</l>
             <l>per raccontarvi ciò che s'era fatto.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> L'intelletto, ch'a l'uomo il ciel concesse,</l>
             <l>val più d'ogni mondano altro tesoro;</l>
@@ -1408,17 +1445,17 @@
             <l>suol esser causa a gli animi leggieri</l>
             <l>di pensare e di far cose non buone.</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <l> Guardate Massinissa, che vien fuori.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> I' l'ho veduto; or te n'andrai da parte</l>
             <l>nascosamente, perch'io vo' mostrarmi</l>
             <l>di non saper di questo alcuna cosa.</l>
           </sp>
-          <sp>
+          <sp who="#messo">
             <speaker>MESSO</speaker>
             <l> Io farò sì che non potrà vedermi.</l>
           </sp>
@@ -1426,7 +1463,7 @@
         <div type="scene">
           <head>Scena III</head>
           <stage>LELIO, MASSINISSA <emph>e</emph> CORO</stage>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Apparecchiate voi da gire al tempio,</l>
             <l>ch'io vo' far ciò che ha detto il sacerdote,</l>
@@ -1435,18 +1472,18 @@
             <l>qualcun de' miei. Va' tu, fa' diligenza</l>
             <l>di sapermi ridir ciò che si face.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Non bisogna mandare alcun per questo,</l>
             <l>perciò che or ora di costà ne vengo.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> O Lelio, ancora non avea rivolti</l>
             <l>gli occhi verso di voi; ditemi adunque,</l>
             <l>è giunto Scipion con la sua gente?</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Poc'ora fa, ch'uno de' suoi ne venne,</l>
             <l>e disse come egli è fuor de la porta,</l>
@@ -1454,71 +1491,71 @@
             <l>Ma qui dimoro per mandarli pria</l>
             <l>Siface, e gli altri ancor che sono presi.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Sarà ben fatto; e non gli date indugio.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Così far voglio. Ecco che vien Catone</l>
             <l>camerlingo del campo, e halli seco.</l>
             <l>Di' ch'egli aspetti alquanto, acciò ch'e' meni</l>
             <l>con questi insieme ancora Sofonisba.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Non accade mandarvi la regina.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Perché non deve anch'ella andar con loro?</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Perch'ella è donna; e non è cosa onesta</l>
             <l>che vada mescolata infra soldati.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Sarebbe vano aver questo rispetto,</l>
             <l>andando, come andrà, con suo marito.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Mandiam pur gli altri, che 'l mandar la donna</l>
             <l>non è se non soverchio; e l'uom ch'è saggio,</l>
             <l>non deve operar mai cosa soverchia.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Sia che si voglia, i' vo' mandarla al tutto.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Lelio, non fate a me sì fatta ingiuria;</l>
             <l>che infin a Dio non è l'ingiuria grata.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Che ingiuria vi facc'io, faccendo quello</l>
             <l>che si costuma far di gente presa?</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Costei non si dee porre infra i prigioni</l>
             <l>per modo alcun, però ch'ella è mia moglie.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Com'esser può, ch'è moglie di Siface?</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Voi devete saper come fu prima</l>
             <l>mia sposa, poi Siface me la tolse;</l>
             <l>or col vostro favor l'aggio ritolta.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Non ho da ricercar che si sia fatto</l>
             <l>questi anni avanti; a me sol basta ch'ella</l>
@@ -1526,39 +1563,39 @@
             <l>il qual esser intendo dei Romani</l>
             <l>col regno, con la donna, e coi tesori.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Non è più di Siface, anzi ella è mia;</l>
             <l>ch'io l'ho sposata, come ognuno ha visto.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Voi l'avete sposata? e in che luogo?</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Qui ne la casa, ond'or ne sono uscito.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Qui ne la casa dei nimici nostri?</l>
             <l>Ah, fatto avete un'opera non degna.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Il fei con buona e ottima speranza.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> La speranza di quel che non si deve,</l>
             <l>è spesso la ruina de' mortali.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Voglio più tosto che il ben far mi noccia,</l>
             <l>che avere utilità d'una mal'opra.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> So ben che siete tal, che omai v'è noto</l>
             <l>che non è ben alcun sopra la terra,</l>
@@ -1588,12 +1625,12 @@
             <l>che in questa vita il dolce alcuna volta</l>
             <l>si face amaro, e poi ritorna dolce.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Ahi come temo; che so ben che spesso</l>
             <l>spesso sono impediti i bei pensieri.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Siccome non si dee senza gran causa</l>
             <l>reputar buono un, che sia visso male;</l>
@@ -1648,13 +1685,13 @@
             <l>Sì che non m'esortate or di lasciarla,</l>
             <l>anzi datemi aiuto, ond'io la tenga.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Abbi pietà, signor, del giusto amore</l>
             <l>di questo re; non lo voler privare</l>
             <l>d'una sì cara e valorosa donna.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Quand'un s'accorge del commesso errore,</l>
             <l>e seco stesso del fallir si pente,</l>
@@ -1668,18 +1705,18 @@
             <l>Ite, militi miei, dentro al palazzo;</l>
             <l>menate presa la regina fuore.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Nessun di voi, che qui d'intorno ascolta,</l>
             <l>presuma porre il piè dentro a la porta;</l>
             <l>che la farìa del suo sangue vermiglia.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> O che arroganza! Adunque voi credete</l>
             <l>far resistenza al campo de' Romani?</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Non posso sopportar che mi sia tolta</l>
             <l>costei, che m'è, più che la luce, cara.</l>
@@ -1688,28 +1725,28 @@
         <div type="scene">
           <head>Scena IV</head>
           <stage>CATONE, LELIO, MASSINISSA <emph>e</emph> CORO</stage>
-          <sp>
+          <sp who="#catone">
             <speaker>CATONE</speaker>
             <l> Guardate a dietro ben tutti e prigioni,</l>
             <l>ch'io vedo apparecchiarsi una contesa,</l>
             <l>da cui nascer porìa molta ruina;</l>
             <l>però voglio cercar di rassettarla.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Catone, avete visto l'arroganza</l>
             <l>di Massinissa, e ciò che ci minaccia?</l>
           </sp>
-          <sp>
+          <sp who="#catone">
             <speaker>CATONE</speaker>
             <l> Ho vista tutta la contesa vostra.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Piacemi ch'ogni cosa abbiate visto,</l>
             <l>per saper ben da chi procede il torto.</l>
           </sp>
-          <sp>
+          <sp who="#catone">
             <speaker>CATONE</speaker>
             <l> Sarìa ben fatto di troncar la via</l>
             <l>a questa vostra impetuosa lite,</l>
@@ -1745,7 +1782,7 @@
             <l>e sarete contenti stare a quello</l>
             <l>che dirà Scipion di questa cosa.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Caton, ciò che voi dite, è sì ben detto,</l>
             <l>che sarebbe vergogna a contradirli;</l>
@@ -1753,14 +1790,14 @@
             <l>e troppo vuole ogni cosa che vuole:</l>
             <l>nondimeno io farò quel che vi piace.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Sarei ben vile, e veramente nulla,</l>
             <l>s'io mi lasciassi torre anche la moglie:</l>
             <l>pur mi contento di restare a quello</l>
             <l>che dirà Scipion di questa cosa.</l>
           </sp>
-          <sp>
+          <sp who="#catone">
             <speaker>CATONE</speaker>
             <l> Non più contesa, no; cessate omai,</l>
             <l>che (come vedo) voi siete d'accordo</l>
@@ -1770,16 +1807,16 @@
             <l>Ben vi vorrei veder, prima ch'io parta,</l>
             <l>toccar la mano, a far tra voi la pace.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> I' son contento d'abbracciarlo ancora,</l>
             <l>perché con lui non tengo alcuna offesa.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> E io similemente: ecco l'abbraccio.</l>
           </sp>
-          <sp>
+          <sp who="#catone">
             <speaker>CATONE</speaker>
             <l> Ben fate cosa d'animi gentili,</l>
             <l>come voi siete; ch'egli è somma laude</l>
@@ -1787,12 +1824,12 @@
             <l>Or io ne vado al campo, e vi ricordo</l>
             <l>di venirne più tosto che potete.</l>
           </sp>
-          <sp>
+          <sp who="#lelio">
             <speaker>LELIO</speaker>
             <l> Subito ne verrò, ch'abbia vedute</l>
             <l>le stalle, e che cavalli entro vi sono.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Lassa, ben mi credeva esser venuto</l>
             <l>il fin de l'angoscioso mio dolore,</l>
@@ -1854,7 +1891,7 @@
         <div type="scene">
           <head>Scena I</head>
           <stage>SCIPIONE, CATONE, SIFACE, <emph>e</emph> CORO</stage>
-          <sp>
+          <sp who="#scipione">
             <speaker>SCIPIONE</speaker>
             <l> Ecco i prigioni; e quel che in più onorato</l>
             <l>luogo vien prima, è il misero Siface,</l>
@@ -1870,24 +1907,24 @@
             <l>ché non fu alcun giammai sì caro a Dio,</l>
             <l>che vivesse sicuro un giorno solo.</l>
           </sp>
-          <sp>
+          <sp who="#catone">
             <speaker>CATONE</speaker>
             <l> O Scipion, quest'è la gente presa;</l>
             <l>ordinate di lei ciò che vi piace.</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>SCIPIONE</speaker>
             <l> Pongansi tutti gli altri in quelle tende,</l>
             <l>intorno de le quai si faccia guardia;</l>
             <l>e solo il re se ne rimanga meco.</l>
           </sp>
-          <sp>
+          <sp who="#catone">
             <speaker>CATONE</speaker>
             <l> Tant'è la turba de la gente intorno</l>
             <l>corsa qui per veder questi prigioni,</l>
             <l>che a fatica n'andran fin a le tende.</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>SCIPIONE</speaker>
             <l> Qual avversa Fortuna v'ha condotto,</l>
             <l>Siface, a far accordo coi nimici,</l>
@@ -1897,7 +1934,7 @@
             <l>contra la nostra gente, che per voi</l>
             <l>l'aveva mosse già contra Cartago?</l>
           </sp>
-          <sp>
+          <sp who="#siface">
             <speaker>SIFACE</speaker>
             <l> La causa fu la bella Sofonisba,</l>
             <l>de l'amor de la qual fui preso e arso.</l>
@@ -1919,7 +1956,7 @@
             <l>Ma voi, non risguardando al nostro errore,</l>
             <l>vi potete mostrar più saldo amico.</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>SCIPIONE</speaker>
             <l> Sempre del vostro error mi dolse, e duole,</l>
             <l>così per voi, come per mio rispetto;</l>
@@ -1928,7 +1965,7 @@
             <l>Ecco siete ridotto a caso tale,</l>
             <l>ch'io non vi posso dare alcun aiuto.</l>
           </sp>
-          <sp>
+          <sp who="#siface">
             <speaker>SIFACE</speaker>
             <l> Non chiedo libertà, ch'esser non puote;</l>
             <l>né schifo ancor la morte; ché qualunque</l>
@@ -1937,21 +1974,21 @@
             <l>Ma ben vorrei, che ciò che si destina,</l>
             <l>s'esequisca di me senza tormenti.</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>SCIPIONE</speaker>
             <l> Non dubitate no di simil cose.</l>
             <l>Levateli datorno le catene,</l>
             <l>e menatelo al nostro allogiamento;</l>
             <l>né stia come prigion, ma come amico.</l>
           </sp>
-          <sp>
+          <sp who="#siface">
             <speaker>SIFACE</speaker>
             <l> Dio vi faccia felice in questa impresa,</l>
             <l>e in ogni altra; poiché siete tale,</l>
             <l>che, non che i vostri amici, ma i nimici</l>
             <l>sono constretti di portarvi amore.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Quanto quanto dolor, quanta pietate</l>
             <l>ho del misero stato di costui,</l>
@@ -1959,7 +1996,7 @@
             <l>di tesoro, e di gente; or in un giorno</l>
             <l>si truova esser prigion, mendico, e servo.</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>SCIPIONE</speaker>
             <l> Catone, udiste il ragionar che ha fatto</l>
             <l>Siface, e come il dir di Sofonisba</l>
@@ -1967,31 +2004,31 @@
             <l>Però fia buon veder che non ci toglia</l>
             <l>quest'altro con le dolci sue lusinghe.</l>
           </sp>
-          <sp>
+          <sp who="#catone">
             <speaker>CATONE</speaker>
             <l> Son stato ne la terra, e ho parlato</l>
             <l>con Massinissa; egli mi par disposto</l>
             <l>di voler stare a la sentenzia vostra.</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>SCIPIONE</speaker>
             <l> Parvi che sia disposto di lasciarla?</l>
           </sp>
-          <sp>
+          <sp who="#catone">
             <speaker>CATONE</speaker>
             <l> Credo che lo farà, ben con dolore.</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>SCIPIONE</speaker>
             <l> Faccialo pur; che de le medicine,</l>
             <l>che si sogliono apporre a le ferite,</l>
             <l>quella dà più dolor, ch'è più salubre.</l>
           </sp>
-          <sp>
+          <sp who="#catone">
             <speaker>CATONE</speaker>
             <l> Ecco ch'e' vien; parlatene con lui.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Ahimé, signor, ahimé, che s'apparecchia</l>
             <l>contra il vostro disìo machina grande.</l>
@@ -2000,7 +2037,7 @@
         <div type="scene">
           <head>Scena II</head>
           <stage>SCIPIONE, MASSINISSA <emph>e</emph> CORO</stage>
-          <sp>
+          <sp who="#scipione">
             <speaker>SCIPIONE</speaker>
             <l> Ben venga Massinissa, il cui valore</l>
             <l>è degno veramente d'ogni laude.</l>
@@ -2013,11 +2050,11 @@
             <l>che quella terra mai senza mercede</l>
             <l>non lasciò rimaner chi ben la serve.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Questo parlar mi dà qualche speranza.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> I' non voglio negar che non mi piaccia</l>
             <l>d'avervi satisfatto in quel ch'io feci;</l>
@@ -2026,18 +2063,18 @@
             <l>che 'l maggior premio, ch'io mi possa avere,</l>
             <l>è ben servir quest'onorata gente.</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>SCIPIONE</speaker>
             <l> Andate un poco voi tutti da parte,</l>
             <l>ch'io vo' restarmi sol con Massinissa.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Io mi dilungo, e quivi in questo canto</l>
             <l>Separata starò, per fin ch'io senta</l>
             <l>quel che si debbia far di Sofonisba.</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>SCIPIONE</speaker>
             <l> Signore, io penso, che null'altra cosa,</l>
             <l>che il conoscere in me qualche virtute,</l>
@@ -2077,7 +2114,7 @@
             <l>di tanti vostri meriti, con fallo</l>
             <l>più grave che la causa del fallire.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Io dirò, Scipion, qualche parola,</l>
             <l>acciò che voi, così senza sentirne</l>
@@ -2132,7 +2169,7 @@
             <l>perdonare ad un reo; ma non si deve</l>
             <l>punire un buon per il peccare altrui.</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>SCIPIONE</speaker>
             <l> Chi non sapesse ove si fosse il torto,</l>
             <l>e udisse il parlar che avete fatto,</l>
@@ -2188,7 +2225,7 @@
             <l>a Roma, e pregheremo che il Senato</l>
             <l>per le vostre virtù ve la conceda.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Poscia ch'io vedo esser la voglia vostra</l>
             <l>d'aver costei, più non farò contrasto;</l>
@@ -2200,18 +2237,18 @@
             <l>e promessi a costei di mai non darla</l>
             <l>in potestà d'altrui mentre che viva.</l>
           </sp>
-          <sp>
+          <sp who="#scipione">
             <speaker>SCIPIONE</speaker>
             <l> Questa risposta è veramente degna</l>
             <l>di Massinissa: or fate dunque come</l>
             <l>pare il meglio, pur che abbiam la donna.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Anderò dentro, e penserò d'un modo,</l>
             <l>che servi il voler vostro e la mia fede.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Amor, che nei leggiadri alti pensieri</l>
             <l>sovente alberghi, e reggi quella parte,</l>
@@ -2271,7 +2308,7 @@
         <div type="scene">
           <head>Scena I</head>
           <stage>FAMIGLIO <emph>e</emph> CORO</stage>
-          <sp>
+          <sp who="#famiglio">
             <speaker>FAMIGLIO</speaker>
             <l> Donne dolenti, e lacrimose in vista,</l>
             <l>non state più di fuore;</l>
@@ -2282,7 +2319,7 @@
             <l>oblazioni al tempio; al qual disìa</l>
             <l>che vogliate ir con lei.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Adunque tu non sai la cosa trista,</l>
             <l>che ci conturba il cuore?</l>
@@ -2293,7 +2330,7 @@
             <l>insieme anch'io con la signora mia</l>
             <l>(se non siam tarde) i dèi.</l>
           </sp>
-          <sp>
+          <sp who="#famiglio">
             <speaker>FAMIGLIO</speaker>
             <l> Io sono stato lungamente intento</l>
             <l>a far la casa colta,</l>
@@ -2304,7 +2341,7 @@
             <l>(poi che dolor vi dà) non sarà grave</l>
             <l>di farlo manifesto.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Ohimé, signora, ohimé come pavento</l>
             <l>che tu non mi sia tolta,</l>
@@ -2315,7 +2352,7 @@
             <l>non par che si rallegri, anzi l'aggrave</l>
             <l>dolore aspro e molesto.</l>
           </sp>
-          <sp>
+          <sp who="#famiglio">
             <speaker>FAMIGLIO</speaker>
             <l> Dunque le nube nozze non aranno</l>
             <l>il disiato effetto?</l>
@@ -2326,7 +2363,7 @@
             <l>Arà ben mille modi di salvarla,</l>
             <l>pur che salvarla voglia.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Ove manca la forza, arroge il danno;</l>
             <l>e colui, ch'è suggetto,</l>
@@ -2337,7 +2374,7 @@
             <l>Costei non ha qui amico; ognun, che parla</l>
             <l>di lei, le annunzia doglia.</l>
           </sp>
-          <sp>
+          <sp who="#famiglio">
             <speaker>FAMIGLIO</speaker>
             <l> Ahi, chi non ha favor da la Fortuna,</l>
             <l>non creda avere amici;</l>
@@ -2348,7 +2385,7 @@
             <l>O dura sorte! Or io ne vado in casa,</l>
             <l>a dir che siete giunte.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Non son certa però di cosa alcuna;</l>
             <l>ma siamo sì infelici,</l>
@@ -2375,66 +2412,66 @@
         <div type="scene">
           <head>Scena II</head>
           <stage>SERVA <emph>e</emph> CORO</stage>
-          <sp>
+          <sp who="#serva">
             <speaker>SERVA</speaker>
             <l> Ohimé meschina, o trista la mia vita!</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Che vuol dir questo tuo sì duro pianto?</l>
           </sp>
-          <sp>
+          <sp who="#serva">
             <speaker>SERVA</speaker>
             <l> I' piango ognor ch'io penso a quel che vidi.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Che cosa hai tu veduto? O come io temo!</l>
           </sp>
-          <sp>
+          <sp who="#serva">
             <speaker>SERVA</speaker>
             <l> Tosto la vederete ancora voi.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Dilla, non ci tener tanto sospese.</l>
           </sp>
-          <sp>
+          <sp who="#serva">
             <speaker>SERVA</speaker>
             <l> In brieve perderemo la regina.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Come la perderemo? u' deve andare?</l>
           </sp>
-          <sp>
+          <sp who="#serva">
             <speaker>SERVA</speaker>
             <l> Andrà, donde giamai non si ritorna.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Non torna mai colui ch'esce di vita.</l>
           </sp>
-          <sp>
+          <sp who="#serva">
             <speaker>SERVA</speaker>
             <l part="I"> Così farà costei. </l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="M"> Dunque ella muore?</l>
           </sp>
-          <sp>
+          <sp who="#serva">
             <speaker>SERVA</speaker>
             <l part="M"> Credo che tosto abbia a morire. </l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="F"> O danno,</l>
             <l>danno più grave assai ch'io non pensava.</l>
             <l>Dimmi (ti priego), dimmi questa cosa,</l>
             <l>e non t'incresca di narrarla tutta.</l>
           </sp>
-          <sp>
+          <sp who="#serva">
             <speaker>SERVA</speaker>
             <l> Come uscì Massinissa, la regina</l>
             <l>fe' nel palazzo suo tutti gli altari</l>
@@ -2541,13 +2578,13 @@
             <l>Pensate adunque voi, se giustamente</l>
             <l>in tal calamità mi struggo e piango.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> O speranza fallace, o mondo cieco,</l>
             <l>ahi come ogni pensier tosto rivolgi!</l>
             <l>Ma tu, perché non sei con la regina?</l>
           </sp>
-          <sp>
+          <sp who="#serva">
             <speaker>SERVA</speaker>
             <l> La regina era andata, dopo questo,</l>
             <l>nel più secreto luogo de la casa,</l>
@@ -2557,12 +2594,12 @@
             <l>per veder anco voi 'nanzi 'l suo fine;</l>
             <l>e qui mandommi a far che l'aspettassi.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Troppo l'aspetteren: ma dimmi appresso,</l>
             <l>Erminia che facea, che tanto l'ama?</l>
           </sp>
-          <sp>
+          <sp who="#serva">
             <speaker>SERVA</speaker>
             <l> La misera nol seppe se non tardi,</l>
             <l>ch'era di sopra, e ordinava intanto</l>
@@ -2572,7 +2609,7 @@
             <l>i capelli e le guance, e urla, e grida</l>
             <l>in modo che farìa piangere i sassi.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Quando arà mai riposo</l>
             <l>questa infelice casa,</l>
@@ -2588,7 +2625,7 @@
             <l>di questa donna eletta,</l>
             <l>sola fra noi perfetta.</l>
           </sp>
-          <sp>
+          <sp who="#serva">
             <speaker>SERVA</speaker>
             <l> Gravi gravi punture</l>
             <l>Son queste, o donne mie,</l>
@@ -2604,7 +2641,7 @@
             <l>a la nostra signora,</l>
             <l>ch'è presso a l'ultim'ora.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> O sventurato figlio di Gisgone,</l>
             <l>che farai, come senti</l>
@@ -2629,33 +2666,33 @@
         <div type="scene">
           <head>Scena I</head>
           <stage>SOFONISBA, ERMINIA <emph>e</emph> CORO</stage>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Cara luce del sole, or sta' con Dio,</l>
             <l>e tu dolce mia terra,</l>
             <l>di cui voluto ho contentar la vista</l>
             <l>alquanto anzi ch'io mora.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> Voglio venir, voglio venire anch'io</l>
             <l>a star con voi sotterra.</l>
             <l>Non vo' restare in questa vita trista</l>
             <l>senza la mia signora.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Ohimé, non son più forte;</l>
             <l>già si comincia a vicinar la morte.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Sostenetela bene: ahi poverina,</l>
             <l>ponetela a sedere.</l>
             <l>Non la movete no, non la movete.</l>
             <l>Ecco che pur le passa questo affanno.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Donne, io vi lascio, e in man d'altro signore,</l>
             <l>che con miglior Fortuna</l>
@@ -2666,7 +2703,7 @@
             <l>e priego Idio che la mia morte poi</l>
             <l>rechi pace e quiete a tutte voi.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Le grazie, e le virtù, che il ciel v'ha date,</l>
             <l>non son mai per uscirci de la mente,</l>
@@ -2677,7 +2714,7 @@
             <l>di fiori, e vi faremo quell'onore,</l>
             <l>ch'ad una dea terrestre s'appertenga.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Le cortesi proferte e 'l parlar pio</l>
             <l>m'obligan sì, ch'io son quasi confusa:</l>
@@ -2689,7 +2726,7 @@
             <l>il quale io spero che celatamente</l>
             <l>saprai condurre in più sicura parte.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> Adunque, lassa, voi pensate ch'io</l>
             <l>mi debbia senza voi restare in vita?</l>
@@ -2711,7 +2748,7 @@
             <l>perché non voglio mai che s'oda dire:</l>
             <l>Erminia è viva senza Sofonisba.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Erminia, deh non dir queste parole;</l>
             <l>e non voler possendo avere un male,</l>
@@ -2752,24 +2789,24 @@
             <l>perché, vivendo tu, non morrò in tutto;</l>
             <l>anzi vive di me l'ottima parte.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Non temerò di dire inanzi a lei,</l>
             <l>sì mi confido de la sua virtute;</l>
             <l>ben vi concederà questa dimanda.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> Tant'è l'amor, ch'io v'ho portato e porto,</l>
             <l>ch'ogni vostro voler vorrei far mio;</l>
             <l>ma non potrò portar tanto dolore.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Sì ben; fa' pur, che ti disponghi e vogli,</l>
             <l>che farai ciò che vuoi di te medesma.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> Mi sforzerò di far ciò che volete,</l>
             <l>per rimaner nutrice al vostro figlio,</l>
@@ -2796,180 +2833,180 @@
             <l>acciò che siano eternamente insieme</l>
             <l>i corpi in terra, e l'alme in paradiso.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Molto mi piace che tu sia disposta</l>
             <l>di compiacermi; or morirò contenta.</l>
             <l>Ma tu, sorella mia, primieramente</l>
             <l>prendi il mio figliolin da la mia mano.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> O da che cara man, che caro dono!</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Ora, in vece di me, li sarai madre.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> Così farò, poiché di voi fia privo.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> O figlio, figlio, quando più bisogno</l>
             <l>hai de la vita mia, da te mi parto.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> Ohimé, come farò fra tanta doglia?</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Il tempo suol far lieve ogni dolore.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> Deh lasciatemi ancor venir con voi!</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Basta ben, basta de la morte mia.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> O fortuna crudel, di che mi spogli!</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> O madre mia, quanto lontana siete!</l>
             <l>almen potuto avessi una sol volta</l>
             <l>vedervi, e abbracciar ne la mia morte!</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> Felice lei, felice, che non vede</l>
             <l>questo caso crudel; ch'assai men grave</l>
             <l>ci pare il mal, che solamente s'ode.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> O caro padre, o dolci miei fratelli,</l>
             <l>quant'è ch'io non vi vidi; né più mai</l>
             <l>v'aggio a vedere; Idio vi faccia lieti.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> O quanto quanto ben perderann'ora.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Erminia mia, tu sola a questo tempo</l>
             <l>mi sei padre, fratel, sorella e madre.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> Lassa, valesse pur per un di loro.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Or sento ben che la virtù si manca</l>
             <l>a poco a poco, e tuttavia camino.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> Quant'amaro è per me questo viaggio!</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Che veggio qui? che nuova gente è questa?</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> Ohimé infelice, che vedete voi?</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Non vedete voi questo, che mi tira?</l>
             <l>Che fai? Dove mi meni? Io so ben dove.</l>
             <l>Lasciami pur, ch'io me ne vengo teco.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> O che pietate, o che dolore estremo!</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> A che piangete? Non sapete ancora</l>
             <l>che ciò che nasce, a morte si destina?</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Ahimé, che questa è pur troppo per tempo,</l>
             <l>ch'ancor non siete nel vigesim'anno.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Il bene esser non può troppo per tempo.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> Che duro bene è quel che ci distrugge!</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> Accostatevi a me, voglio appoggiarmi;</l>
             <l>ch'io mi sento mancare, e già la notte</l>
             <l>tenebrosa ne vien ne gli occhi miei.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> Appoggiatevi pur sopra 'l mio petto.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> O figlio mio, tu non arai più madre;</l>
             <l>ella già se ne va; statti con Dio.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> Ohimé, che cosa dolorosa ascolto.</l>
             <l>Non ci lasciate ancor, non ci lasciate.</l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l> I' non posso far altro, e sono in via.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> Alzate il viso a questo, che vi bascia.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="I"> Riguardatelo un poco. </l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l part="F"> Ahimé, non posso.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l part="I"> Dio vi raccolga in pace. </l>
           </sp>
-          <sp>
+          <sp who="#sofonisba">
             <speaker>SOFONISBA</speaker>
             <l part="F"> Io vado; adio.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> Ohimei, ch'io son distrutta.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Ell'è passata con soave morte.</l>
             <l>Sarebbe forse ben di ricoprirla.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> Deh lasciatela alquanto: o donna cara,</l>
             <l>luce de gli occhi miei, dolce mia vita,</l>
@@ -2979,38 +3016,38 @@
             <l>udite un poco, udite la mia voce;</l>
             <l>la vostra cara Erminia vi dimanda.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Lassa, che più non vede, e più non ode;</l>
             <l>cuoprila pur, e riportianla dentro.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> Ohimei.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Non la movete giù di questa sedia,</l>
             <l>ov'è, ma via portatela con essa.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> Ohimei.</l>
             <l>Ohimei.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Tenetela dai lati: or ch'ella è dentro</l>
             <l>da l'atrio, riponetela nel mezzo;</l>
             <l>e racconcisi poi, come ha da stare.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> Ohimei.</l>
             <l>Ohimei.</l>
             <l>Ohimei.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Ohimé, signora, o sola mia speranza,</l>
             <l>che per voler fuggire</l>
@@ -3021,26 +3058,26 @@
             <l>Ohimé voi siete gita;</l>
             <l>ed io qui sono: o misera mia vita!</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> Ohimei.</l>
             <l>Ohimei perché non moro,</l>
             <l>vedendovi in tal modo?</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Ben non è danno alcun, che sia maggiore</l>
             <l>de la necessità de la Fortuna;</l>
             <l>che 'l mal, quand'è senza speranza alcuna,</l>
             <l>ci reca intolerabile dolore.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> O signora mia cara;</l>
             <l>O signora mia dolce,</l>
             <l>come viverò mai senza vedervi?</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> O sorte, sorte amara,</l>
             <l>che mai non si rindolce;</l>
@@ -3051,7 +3088,7 @@
             <l>è fragil, come vetro;</l>
             <l>e il male è forte, e tosto ci vien dietro.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> Ohimei, ben son venuta</l>
             <l>nel peggior stato, che mai fosse al mondo.</l>
@@ -3062,7 +3099,7 @@
             <l>Sì d'alto è la caduta,</l>
             <l>che la ruina mia non truova il fondo.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Pon freno, Erminia, al grave tuo dolore,</l>
             <l>che ti trasporta in troppo amaro pianto.</l>
@@ -3074,7 +3111,7 @@
             <l>Però sopporta valorosamente</l>
             <l>l'aspra necessità de la natura.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> Ben conosch'io che non si può far altro;</l>
             <l>ma son di carne; e s'io fossi anco pietra,</l>
@@ -3084,7 +3121,7 @@
             <l>né mai starò dove si suoni, o canti;</l>
             <l>ma viverò tra lacrime e sospiri.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Taccian, donne, taccian; però ch'io veggio</l>
             <l>Massinissa venir verso il palazzo.</l>
@@ -3093,101 +3130,101 @@
         <div type="scene">
           <head>Scena II</head>
           <stage>MASSINISSA, CORO, ERMINIA</stage>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Il grave pianto, e il lamentar, ch'udia,</l>
             <l>mi fa molto temer che Sofonisba</l>
             <l>abbia preso il veneno: onde, ohimé lasso,</l>
             <l>tardo giunto sarò nel suo soccorso.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Non giova quasi mai lenta pietate.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Donne, che volean dir tanti lamenti?</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> L'amore, e la pietà, signor, ci spinse</l>
             <l>a lamentare, e pianger la regina.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Sarebbe uscita mai di questa vita?</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Adesso adesso ella se n'è passata.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> O misera regina, O sventurato,</l>
             <l>anzi infelice matrimonio nostro!</l>
             <l>Dunque ella prese subito il veneno?</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Ella nol prese già subitamente,</l>
             <l>sì come intesi, ma non stette molto.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Il servo, che 'l portò, mi disse come</l>
             <l>l'aveva posto giuso; e se n'andava</l>
             <l>a visitare in casa alcuni altari;</l>
             <l>ond'io pensai che prender nol devesse.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> E' fu ben vero; ma lo prese poi,</l>
             <l>come subitamente fe' ritorno.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Troppo troppo fu presta, e io son stato</l>
             <l>fuori d'ogni dover tepido e lento,</l>
             <l>mentre cercava via da liberarla.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Dunque le volevate dare aiuto?</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Subitamente che appariva l'ombra,</l>
             <l>io la volea mandar verso Cartago,</l>
             <l>per l'oscuro silenzio de la notte;</l>
             <l>ed avvenisse poi quel che poteva.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Lassa, che quando il ciel destina un male,</l>
             <l>nol può schivar dapoi consiglio umano.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Ove si giace l'infelice donna?</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> In mezzo l'atrio sopra d'un tapeto.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Voglio vederla, prima che la terra</l>
             <l>m'asconda eternamente il suo bel volto.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Levate via quel panno, che la cuopre.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> Ohimei.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Cara consorte mia, come vi vedo;</l>
             <l>com'ho perso in un punto ogni diletto!</l>
@@ -3201,28 +3238,28 @@
             <l>però me solo e mia sciocchezza incolpo;</l>
             <l>che mi sarà cagion d'eterno pianto.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Spesso ci sta nascoso il ben che avemo,</l>
             <l>né si conosce mai, se non si perde.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Io voglio a lei toccare anco la mano.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> Deh non fate, signor, s'avete cura</l>
             <l>di non far noia a l'anima disciolta.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Voi dite ben; perciò ch'a lei molesta</l>
             <l>sarìa la man che ne la morte sua</l>
             <l>ha parte, e anco ne la mia ruina.</l>
             <l>Rimani in pace adunque, anima santa.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> Ogni cosa mortale il tempo abbassa,</l>
             <l>e rilieva dapoi, come a lui piace;</l>
@@ -3230,7 +3267,7 @@
             <l>sola vive con noi, né mai si more;</l>
             <l>onde spero ancor vita a questa donna.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Farete belle e onorate esequie</l>
             <l>a la diletta mia novella sposa,</l>
@@ -3247,7 +3284,7 @@
             <l>mentre vivea, dopo la morte ancora</l>
             <l>vo' che ne' suoi più cari si trasfonda.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> Signor, so che v'è noto il mio bisogno;</l>
             <l>e che sapete ancor ch'altro non bramo,</l>
@@ -3257,7 +3294,7 @@
             <l>e aiutare il può, ma i prieghi aspetta,</l>
             <l>costui, cred'io, tacitamente niega.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Mentre che la fredd'ombra de la terra</l>
             <l>cuopra col manto l'emisferio nostro,</l>
@@ -3269,13 +3306,13 @@
             <l>il che, son certo che sarà giocondo</l>
             <l>udir ne l'altra vita a Sofonisba.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> E io v'arò, di questo, obligo grande;</l>
             <l>che in così amara e pessima fortuna</l>
             <l>ricever non potrei cosa più grata.</l>
           </sp>
-          <sp>
+          <sp who="#massinissa">
             <speaker>MASSINISSA</speaker>
             <l> Andate dentro, e abbiasi ogni cura</l>
             <l>di far l'esequie sontuose e belle;</l>
@@ -3284,11 +3321,11 @@
             <l>Mandate ancor per tutta la cittade,</l>
             <l>che venga ad onorar la sua regina.</l>
           </sp>
-          <sp>
+          <sp who="#erminia">
             <speaker>ERMINIA</speaker>
             <l> Farassi tutto quel che avete imposto.</l>
           </sp>
-          <sp>
+          <sp who="#coro">
             <speaker>CORO</speaker>
             <l> La fallace speranza de' mortali,</l>
             <l>a guisa d'onda in un superbo fiume,</l>

--- a/tei/visconti-pasitea.xml
+++ b/tei/visconti-pasitea.xml
@@ -83,6 +83,46 @@
           <term>Letteratura teatrale</term>
         </keywords>
       </textClass>
+      <particDesc>
+        <listPerson>
+          <person xml:id="crisalo">
+            <persName>Crisalo</persName>
+          </person>
+          <person xml:id="pseudolo">
+            <persName>Pseudolo</persName>
+          </person>
+          <person xml:id="promo">
+            <persName>Promo</persName>
+          </person>
+          <person xml:id="comarco">
+            <persName>Comarco</persName>
+          </person>
+          <person xml:id="dioneo">
+            <persName>Dioneo</persName>
+          </person>
+          <person xml:id="citta">
+            <persName>Citta</persName>
+          </person>
+          <person xml:id="mastropa">
+            <persName>Mastropa</persName>
+          </person>
+          <person xml:id="pasitea">
+            <persName>Pasitea</persName>
+          </person>
+          <person xml:id="apistio">
+            <persName>Apistio</persName>
+          </person>
+          <person xml:id="eusebio">
+            <persName>Eusebio</persName>
+          </person>
+          <person xml:id="apollo">
+            <persName>Apollo</persName>
+          </person>
+          <person xml:id="crifiologo">
+            <persName>Crifiologo</persName>
+          </person>
+        </listPerson>
+      </particDesc>
     </profileDesc>
     <revisionDesc>
       <change><date>Data sconosciuta anteriore al 2000</date><name>CIBIT - Ferrara</name>Digitalizzazione</change>
@@ -206,7 +246,7 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
         <head>PRIMUS ACTUS</head>
         <div>
           <head>SCENA I</head>
-          <sp>
+          <sp who="#crisalo">
             <speaker>CRISALO.</speaker>
             <l>Quanto era meglio assai ch'io fussi extinto</l>
             <l>in fasce d'una morte repentina,</l>
@@ -253,31 +293,31 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
         <div>
           <head>SCENA II</head>
           <stage>PSEUDOLO e CRISALO.</stage>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>Che cosa hai, patron mio?</l>
           </sp>
-          <sp>
+          <sp who="#crisalo">
             <speaker>CRISALO.</speaker>
             <l>Prosumptuoso!</l>
             <l>Che vai facendo qui senza licenza?</l>
           </sp>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>Perdonami, per Dio, s'io fui troppo oso!</l>
           </sp>
-          <sp>
+          <sp who="#crisalo">
             <speaker>CRISALO.</speaker>
             <l>Poco men ch'io non esco di pazienza!</l>
           </sp>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>Sentendo il tuo lamento doloroso</l>
             <l>ardir presi venir a tua presenza,</l>
             <l>per voler parte anch'io de la tua rogna,</l>
             <l>e morir teco, se morir bisogna.</l>
           </sp>
-          <sp>
+          <sp who="#crisalo">
             <speaker>CRISALO.</speaker>
             <l>Or vedi mia fortuna! che soccorso</l>
             <l>è gionto questa sera a le mie pene!</l>
@@ -288,50 +328,50 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>che troppo fien davante non li stia,</l>
             <l>ché ne serà questo anno carestia.</l>
           </sp>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>Io tornerò dove a te piace e pare,</l>
             <l>ma prego non mi neghi una sol grazia:</l>
             <l>cio è che tu mi vogli palesare</l>
             <l>qual è quella cagion che 'l cuor ti strazia.</l>
           </sp>
-          <sp>
+          <sp who="#crisalo">
             <speaker>CRISALO.</speaker>
             <l>Pazzo che sei! va via, non mi temptare!</l>
           </sp>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>Deh, fa, patron, mia voglia in parte sazia!</l>
             <l>Ti fui sempre fidele, e tu lo sai,</l>
             <l>e so che in fede errato non ho mai.</l>
           </sp>
-          <sp>
+          <sp who="#crisalo">
             <speaker>CRISALO.</speaker>
             <l>Perché vo' tu saper el mio lamento?</l>
           </sp>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>Perché? Ti prego, questo non mi dire!</l>
           </sp>
-          <sp>
+          <sp who="#crisalo">
             <speaker>CRISALO.</speaker>
             <l>Vòi tu forse cavarne de tormento?</l>
           </sp>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>Almen vo' teco ogni dolor sofrire.</l>
           </sp>
-          <sp>
+          <sp who="#crisalo">
             <speaker>CRISALO.</speaker>
             <l>Questo è un sognarse, o paserse di vento.</l>
           </sp>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>Gran mal spesso un trovante usa guarire;</l>
             <l>non mi spreggiar, ch'io sia straziato tutto;</l>
             <l>ché dà talor bon vino un baril brutto.</l>
           </sp>
-          <sp>
+          <sp who="#crisalo">
             <speaker>CRISALO.</speaker>
             <l>Io te 'l dirò, poiché saperlo vòi;</l>
             <l>non ch'io speri da te soccorso alcuno,</l>
@@ -342,7 +382,7 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>infine, in mia malora, un n'aggio aùto,</l>
             <l>cagion che per dolor viver refuto.</l>
           </sp>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>Patron, te l'ho voluto far intendere</l>
             <l>già molti giorni fa, più e più volte,</l>
@@ -351,7 +391,7 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>e lei d'amor li studia il cuor incendere</l>
             <l>cum atti e cenni e sguardi e arte molte.</l>
           </sp>
-          <sp>
+          <sp who="#crisalo">
             <speaker>CRISALO.</speaker>
             <l>Questo ho compreso, e forte me ne dole,</l>
             <l>ma più, che li vadi altro che parole!</l>
@@ -372,12 +412,12 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>che già in molti anni non aguadagnai:</l>
             <l>la causa del mio dolo or tutta sai.</l>
           </sp>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>Hai tu mai dicto o fatto dire a quello</l>
             <l>alcuna reprension di questa cosa?</l>
           </sp>
-          <sp>
+          <sp who="#crisalo">
             <speaker>CRISALO.</speaker>
             <l>Non ho, perché conosco il suo cervello,</l>
             <l>e la mia mente un poco despectosa:</l>
@@ -386,21 +426,21 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>et io, vedendo i suoi costumi strani,</l>
             <l>ho dubio non venir seco a le mani.</l>
           </sp>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>Almeno, essendo in te, dir gliel farei,</l>
             <l>se alcun rispetto te ritiene o move,</l>
             <l>ché teco la gonella giocherei</l>
             <l>che gioveratte: mèttete a le prove.</l>
           </sp>
-          <sp>
+          <sp who="#crisalo">
             <speaker>CRISALO.</speaker>
             <l>Va de mia parte, e giuro tutti i dei</l>
             <l>donarte un par de calze belle e nove</l>
             <l>se tanto fai cum arte e cum ingegno,</l>
             <l>che mi levi il dolor de che ho il cor pregno.</l>
           </sp>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>Meglio serà che mandi qualche altro omo</l>
             <l>di più reputazione, e sii più destro</l>
@@ -409,11 +449,11 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>ché uomo exaltato dà per cinamomo</l>
             <l>spesso del aglio, ancor che sia silvestro.</l>
           </sp>
-          <sp>
+          <sp who="#crisalo">
             <speaker>CRISALO.</speaker>
             <l>Tu dici bene: or va, domandal subito.</l>
           </sp>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>Costui farà bon frutto, i' non mi dubito.</l>
           </sp>
@@ -475,7 +515,7 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
         <div>
           <head>SCENA IV</head>
           <stage>PROMO spenditore e COMARCO primo ne la villa.</stage>
-          <sp>
+          <sp who="#promo">
             <speaker>PROMO.</speaker>
             <l>Torna doman, Comarco, e meglio pensa</l>
             <l>su' tuoi quaderni; e che 'l se trovi il conto</l>
@@ -494,7 +534,7 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>ché fuor de se medesmo suole andare,</l>
             <l>come se 'l cel n'avesse a ruinare.</l>
           </sp>
-          <sp>
+          <sp who="#comarco">
             <speaker>COMARCO.</speaker>
             <l>Bon conto ti farò, ciò ch'è possibile:</l>
             <l>ma d'un gran, d'un festuco o d'una fava,</l>
@@ -513,32 +553,32 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>onde non puote' farli resistenzia:</l>
             <l>il gran mi tolse, ed io n'ebbi pazienzia.</l>
           </sp>
-          <sp>
+          <sp who="#promo">
             <speaker>PROMO.</speaker>
             <l>Puo far il ciel che sie come tu dici?</l>
           </sp>
-          <sp>
+          <sp who="#comarco">
             <speaker>CONTORCO.</speaker>
             <l>Non ti menzogno, tientilo per certo.</l>
           </sp>
-          <sp>
+          <sp who="#promo">
             <speaker>PROMO.</speaker>
             <l>O miseri noi tutti et infelici!</l>
           </sp>
-          <sp>
+          <sp who="#comarco">
             <speaker>COMARCO.</speaker>
             <l>Infelice pur lui, tristo e deserto.</l>
           </sp>
-          <sp>
+          <sp who="#promo">
             <speaker>PROMO.</speaker>
             <l>Ma vede se colui è de li amici,</l>
             <l>che pichia a l'uscio e vòl che li si' aperto.</l>
           </sp>
-          <sp>
+          <sp who="#comarco">
             <speaker>COMARCO.</speaker>
             <l>Egli è Pseudolo tuo.</l>
           </sp>
-          <sp>
+          <sp who="#promo">
             <speaker>PROMO.</speaker>
             <l>Lascial venire.</l>
             <l>Ben venga Pseudol mio! Che vòi tu dire?</l>
@@ -547,12 +587,12 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
         <div>
           <head>SCENA V</head>
           <stage>PSEUDOLO e PROMO.</stage>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>Quel che vo' dire? Il vechio nostro avaro</l>
             <l>ti chiama, e vòl che vadi a lui adesso.</l>
           </sp>
-          <sp>
+          <sp who="#promo">
             <speaker>PROMO.</speaker>
             <l>Io masticava un caso acerbo e amaro</l>
             <l>che molto star mi fa dubio e perplesso:</l>
@@ -561,52 +601,52 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>Non so se 'l vechio il sappi, né che dire,</l>
             <l>né, come il sappi, il suo rumor fugire.</l>
           </sp>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>Il vechio ha inteso come il fatto passa,</l>
             <l>del che ne sente gran tribulazione,</l>
             <l>del grano, dei dinari e de la cassa,</l>
             <l>de la quale anche non mi fai menzione.</l>
           </sp>
-          <sp>
+          <sp who="#promo">
             <speaker>PROMO.</speaker>
             <l>Che vol dir cassa?</l>
           </sp>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>El mena la man bassa,</l>
             <l>il giovanetto, e parme abbia ragione,</l>
             <l>ché un soldo non li dava il traditore</l>
             <l>per farse una recetta contra Amore.</l>
           </sp>
-          <sp>
+          <sp who="#promo">
             <speaker>PROMO.</speaker>
             <l>Può far il cel che 'l vechio l'abbi inteso,</l>
             <l>e per la gola non se sii impiccato?</l>
           </sp>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>Lui se serebbe già se stesso impeso</l>
             <l>s'io non l'avesse alquanto confortato.</l>
           </sp>
-          <sp>
+          <sp who="#promo">
             <speaker>PROMO.</speaker>
             <l>Qual diavolo d'inferno il cuor t'ha preso?</l>
             <l>Fare a suo modo pur l'arìa lasciato,</l>
             <l>ché se costui per morte fusse guasto,</l>
             <l>poteresemo goder senza contrasto.</l>
           </sp>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>Ad ogni modo esser non può da longe</l>
             <l>lo avaro al passo doloroso extremo.</l>
           </sp>
-          <sp>
+          <sp who="#promo">
             <speaker>PROMO.</speaker>
             <l>Immensa brama, se non tardo gionge.</l>
             <l>Mai non veder quel giorno oramai temo!</l>
           </sp>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>Men desider di te già non mi ponge,</l>
             <l>Promo, ché alora pur trïunfaremo</l>
@@ -615,21 +655,21 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>Ma vene ormai, che 'l vechio non se adiri</l>
             <l>de questo nostro tanto longo stare.</l>
           </sp>
-          <sp>
+          <sp who="#promo">
             <speaker>PROMO.</speaker>
             <l>Sai tu per qual facenda el me desiri,</l>
             <l>e ciò che esso mi voglia comandare?</l>
           </sp>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>Ei crede poner fine a' suoi martiri,</l>
             <l>se tu vai suo figliolo a rebuffare.</l>
           </sp>
-          <sp>
+          <sp who="#promo">
             <speaker>PROMO.</speaker>
             <l>E' egli de la mente sì mal sano?</l>
           </sp>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>Tu intenderai il fatto a mano a mano.</l>
           </sp>
@@ -640,30 +680,30 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
         <div>
           <head>SCENA I</head>
           <stage>PROMO e CRISALO.</stage>
-          <sp>
+          <sp who="#promo">
             <speaker>PROMO.</speaker>
             <l>Bonasera, patron, Dio te contenti!</l>
             <l>venuto sono a te per ubedire.</l>
           </sp>
-          <sp>
+          <sp who="#crisalo">
             <speaker>CRISALO.</speaker>
             <l>Promo, per ditte i mei duri tormenti</l>
             <l>t'ho fatto di presente a me venire.</l>
           </sp>
-          <sp>
+          <sp who="#promo">
             <speaker>PROMO.</speaker>
             <l>Qual è la causa de che ti lamenti?</l>
           </sp>
-          <sp>
+          <sp who="#crisalo">
             <speaker>CRISALO.</speaker>
             <l>Sta' attento, se la causa vòi udire,</l>
             <l>e fa' qualche penser che mi conforte.</l>
           </sp>
-          <sp>
+          <sp who="#promo">
             <speaker>PROMO.</speaker>
             <l>Comanda, ch'io son tuo sino a la morte.</l>
           </sp>
-          <sp>
+          <sp who="#crisalo">
             <speaker>CRISALO.</speaker>
             <l>Tu dèi saper che questa robba tutta</l>
             <l>io l'aquistai cum fatiche infinite,</l>
@@ -694,13 +734,13 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>Pietà ti prenda d'un afflitto veglio</l>
             <l>che t'ama cum affetto singulare.</l>
           </sp>
-          <sp>
+          <sp who="#promo">
             <speaker>PROMO.</speaker>
             <l>Patrone, io veggio come in chiaro speglio</l>
             <l>la tua salute: or più non dubitare;</l>
             <l>scazia da te la trista fantasia.</l>
           </sp>
-          <sp>
+          <sp who="#crisalo">
             <speaker>CRISALO.</speaker>
             <l>In le tue mani sta la vita mia.</l>
           </sp>
@@ -708,24 +748,24 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
         <div>
           <head>SCENA II</head>
           <stage>PSEUDOLO e PROMO.</stage>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>Tu pur prometti molto largamente</l>
             <l>voler de l'impossibil contentarlo.</l>
           </sp>
-          <sp>
+          <sp who="#promo">
             <speaker>PROMO.</speaker>
             <l>Ad ambi loro e a noi nocer niente</l>
             <l>credo che passi, se benigno parlo.</l>
           </sp>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>Neanche giovar a noi, se la mia mente</l>
             <l>comprende il vero: né potria il cel farlo</l>
             <l>per fin che 'l vechio vivo se ritrove,</l>
             <l>ché sai pur quel che l'animo suo move.</l>
           </sp>
-          <sp>
+          <sp who="#promo">
             <speaker>PROMO.</speaker>
             <l>Io vo' contarte quel che è il mio desegno,</l>
             <l>ché sempre i' t'aggio amato, e tu lo sai:</l>
@@ -740,7 +780,7 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>Cum il nostro Dioneo ponto non temo</l>
             <l>che non mi vagli qualche volta l'arte.</l>
           </sp>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>Et io che deggio far col vechio extremo?</l>
             <l>Questa opra non ben iusta se comparte:</l>
@@ -751,13 +791,13 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>usar meco non dèi discortesia,</l>
             <l>ché ricco sei, al par di me sì povero.</l>
           </sp>
-          <sp>
+          <sp who="#promo">
             <speaker>PROMO.</speaker>
             <l>Io t'imprometto, per la fede mia,</l>
             <l>che apresso a me tu pòi far tal ricovero</l>
             <l>quanto carnal fratel non men niente.</l>
           </sp>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>Averte per patrone ho ne la mente!</l>
           </sp>
@@ -765,20 +805,20 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
         <div>
           <head>SCENA III</head>
           <stage>DIONEO e CITTÀ.</stage>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONEO.</speaker>
             <l>La bona sera a questa compagnia!</l>
           </sp>
-          <sp>
+          <sp who="#citta">
             <speaker>CITTA.</speaker>
             <l>A te la bona sera et il bono anno!</l>
             <l>Che vai Dioneo facendo da qui via?</l>
           </sp>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONEO.</speaker>
             <l>Cerco tua matre.</l>
           </sp>
-          <sp>
+          <sp who="#citta">
             <speaker>CITTA.</speaker>
             <l>I' n'ho non poco affanno,</l>
             <l>ché già dui giorni una vicina mia</l>
@@ -786,43 +826,43 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>mei ochi, o vero alcun di nostra casa,</l>
             <l>né scio perché là tanto sii rimasa.</l>
           </sp>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONEO.</speaker>
             <l>Come potrei parlarli adesso adesso,</l>
             <l>per bisogno importante che mi sprona?</l>
           </sp>
-          <sp>
+          <sp who="#citta">
             <speaker>CITTA.</speaker>
             <l>Gli manderò, se vòi, subito un messo.</l>
           </sp>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONEO.</speaker>
             <l>Meglio serà che vadi tu in persona.</l>
           </sp>
-          <sp>
+          <sp who="#citta">
             <speaker>CITTA.</speaker>
             <l>Or che è di notte?</l>
           </sp>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONEO.</speaker>
             <l>Sì, ch'ella è qui apresso;</l>
             <l>e mena teco qualche scorta bona.</l>
           </sp>
-          <sp>
+          <sp who="#citta">
             <speaker>CITTA.</speaker>
             <l>Poi che tu vòi così, verrà Sofronia</l>
             <l>cum meco, e Geta.</l>
           </sp>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONEO.</speaker>
             <l>Questa è cosa idonia.</l>
             <l>Adopra ch'ella venga in ogni modo.</l>
           </sp>
-          <sp>
+          <sp who="#citta">
             <speaker>CITTA.</speaker>
             <l>Lascia a me far, che qui serà tantosto.</l>
           </sp>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONEO.</speaker>
             <l>Quanto è crudel quel venenato chiodo</l>
             <l>ch'ha in mezo il cor chi ad Amore è supposto!</l>
@@ -843,28 +883,28 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
         <div>
           <head>SCENA IV</head>
           <stage>DIONEO, CITTA e MASTROPA.</stage>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONEO.</speaker>
             <l>Ora ecco Citta cum la matre vene.</l>
             <l>O Citta, quanto sei bona messagia!</l>
           </sp>
-          <sp>
+          <sp who="#citta">
             <speaker>CITTA.</speaker>
             <l>Parti ch'abbia scusato presto e bene?</l>
             <l>E che menata qui presto te l'aggia?</l>
           </sp>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONEO.</speaker>
             <l>Tu sei gentile, e questo a te conviene,</l>
             <l>avendo matre tanto accorta e saggia.</l>
             <l>Ma prego che tu vadi in altro loco,</l>
             <l>sì che stia solo cum tua matre un poco.</l>
           </sp>
-          <sp>
+          <sp who="#citta">
             <speaker>CITTA.</speaker>
             <l>Trattala bene; i' parto: a Dio siate!</l>
           </sp>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONEO.</speaker>
             <l>Tu sai ch'io non potria far altramenti.</l>
             <l>Mastropa, le mie fiamme appalesate</l>
@@ -874,17 +914,17 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>e tanto replicare una sol cosa</l>
             <l>me par troppo divenga fastidiosa.</l>
           </sp>
-          <sp>
+          <sp who="#mastropa">
             <speaker>MASTROPA.</speaker>
             <l>Di' presto, per tua fe', ché star non posso</l>
             <l>qui teco assai, che mi convien tornare.</l>
           </sp>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONEO.</speaker>
             <l>Qual fatto è questo, che ti mette adosso</l>
             <l>tal fretta, che non possi un poco stare?</l>
           </sp>
-          <sp>
+          <sp who="#mastropa">
             <speaker>MASTROPA.</speaker>
             <l>Mitira ne la gola ha uno umor grosso</l>
             <l>che poco men l'ha aùta a strangolare:</l>
@@ -897,7 +937,7 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>Adesso pur men mal par la possedi,</l>
             <l>e credo presto ella serà guarita.</l>
           </sp>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONEO.</speaker>
             <l>Mi duol l'affanno e il suo fiero tormento,</l>
             <l>ma poi me alegro del meglioramento.</l>
@@ -906,7 +946,7 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>sempre aspettando cum summa attenzione</l>
             <l>di Pasitea il volto più che umano.</l>
           </sp>
-          <sp>
+          <sp who="#mastropa">
             <speaker>MASTROPA.</speaker>
             <l>Ella n'avea non men tribulazione</l>
             <l>che del mal de la matre tanto strano:</l>
@@ -917,27 +957,27 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>onde aveva gran duol nel suo secreto</l>
             <l>posta nel mezo de dui casi gravi.</l>
           </sp>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONEO.</speaker>
             <l>A questa scusa iusta io me aquieto.</l>
             <l>Fa che le colpe questa notte lavi.</l>
           </sp>
-          <sp>
+          <sp who="#mastropa">
             <speaker>MASTROPA.</speaker>
             <l>Se Mitira riposa e che megliore</l>
             <l>farò che a te verrà circa a cinque ore.</l>
           </sp>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONEO.</speaker>
             <l>I' sento gente. Va senza dimora,</l>
             <l>e fa che a Pasitea me racomandi.</l>
           </sp>
-          <sp>
+          <sp who="#mastropa">
             <speaker>MASTROPA.</speaker>
             <l>Farollo, e che verrà ne la quinta ora.</l>
             <l>Se vòi altro, io sono a' tuoi comandi.</l>
           </sp>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONEO.</speaker>
             <l>Saper non posso chi sien questi ancora.</l>
             <l>Ben vengan questi amici venerandi!</l>
@@ -948,7 +988,7 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
         <div>
           <head>SCENA V</head>
           <stage>PROMO, DIONEO e PSEUDOLO.</stage>
-          <sp>
+          <sp who="#promo">
             <speaker>PROMO.</speaker>
             <l>Quel che portiamo, presto tu 'l saprai</l>
             <l>cum non molte parole adesso adesso;</l>
@@ -959,14 +999,14 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>or prestane le orecchie, se tu vòi,</l>
             <l>e ciò che piace a te faranne poi.</l>
           </sp>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONEO.</speaker>
             <l>Questi son gran proemi: che fia questo?</l>
             <l>Par quasi che tu vogli predicare.</l>
             <l>Non me tener in trame, di' su, presto,</l>
             <l>ch'altro ho nel capo, et altro aggio che fare.</l>
           </sp>
-          <sp>
+          <sp who="#promo">
             <speaker>PROMO.</speaker>
             <l>Non te sia, prego, il mio parlar molesto,</l>
             <l>ch'io son tuo servo, e mi puoi comandare.</l>
@@ -981,25 +1021,25 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>se lassi tante foggie e che li rendi</l>
             <l>il grano e l'oro. Or tutto il fatto intendi.</l>
           </sp>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONEO.</speaker>
             <l>Promo, tu ridi! e che me ne consigli?</l>
           </sp>
-          <sp>
+          <sp who="#promo">
             <speaker>PROMO.</speaker>
             <l>S'io fusse in te, nïente ne farei.</l>
           </sp>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONEO.</speaker>
             <l>Più presto, se potesse por li artigli</l>
             <l>ad altre cose, presto gli porrei.</l>
           </sp>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>Mi par che ad uom terrestre non simigli,</l>
             <l>dolce patron, ma ad un de li alti dei.</l>
           </sp>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONEO.</speaker>
             <l>Più assai potrai sperar, Pseudol mio caro,</l>
             <l>da me, che dal mio patre tanto avaro.</l>
@@ -1024,12 +1064,12 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>io scio ch'ambi discreti e savi sete,</l>
             <l>e che v'è nota la comune pace.</l>
           </sp>
-          <sp>
+          <sp who="#promo">
             <speaker>PROMO.</speaker>
             <l>Facia il cel tutte le tue voglie liete,</l>
             <l>e triste quelle del vechio rapace.</l>
           </sp>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>Mora pur presto il vechio maledetto,</l>
             <l>che incontro a rape, arem pane e confetto.</l>
@@ -1087,7 +1127,7 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
         <div>
           <head>SCENA II</head>
           <stage>MASTROPA e PASITEA.</stage>
-          <sp>
+          <sp who="#mastropa">
             <speaker>MASTROPA.</speaker>
             <l>Va presto, Pasitea, che adesso è l'ora,</l>
             <l>va da colui che per tuo amore è insano,</l>
@@ -1098,43 +1138,43 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>che par che sino a tanto dormir debbia,</l>
             <l>che sia passata la notturna nebbia.</l>
           </sp>
-          <sp>
+          <sp who="#pasitea">
             <speaker>PASITEA.</speaker>
             <l>Ohimé, come farò se si resviglia?</l>
           </sp>
-          <sp>
+          <sp who="#mastropa">
             <speaker>MASTROPA.</speaker>
             <l>Come farai? Non te ne donar pene!</l>
           </sp>
-          <sp>
+          <sp who="#pasitea">
             <speaker>PASITEA.</speaker>
             <l>Per la tua fe', qualche partito piglia,</l>
             <l>aciò che questa cosa vadi bene!</l>
           </sp>
-          <sp>
+          <sp who="#mastropa">
             <speaker>MASTROPA.</speaker>
             <l>Io li dirò che sustener le ciglia</l>
             <l>più non potevi, e che dormir convene,</l>
             <l>e che pei grandi affanni intorno a lei</l>
             <l>e pel vegliar, quasi infirmata sei.</l>
           </sp>
-          <sp>
+          <sp who="#pasitea">
             <speaker>PASITEA.</speaker>
             <l>Ohimé, io temo pur!</l>
           </sp>
-          <sp>
+          <sp who="#mastropa">
             <speaker>MASTROPA.</speaker>
             <l>Deh, lascia ormai</l>
             <l>questa temenza tua tanto terribile.</l>
           </sp>
-          <sp>
+          <sp who="#pasitea">
             <speaker>PASITEA.</speaker>
             <l>Mia matre è furibonda, come sai,</l>
             <l>e per nulla talor diventa orribile;</l>
             <l>e se ella se accorgesse, più giamai</l>
             <l>placarla credo non serìa possibile.</l>
           </sp>
-          <sp>
+          <sp who="#mastropa">
             <speaker>MASTROPA.</speaker>
             <l>Va, dolce figlia mia, senza temere;</l>
             <l>de tutto il resto lascia a me il pensere.</l>
@@ -1149,21 +1189,21 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>E per ben che mi cruccia e che mi penta,</l>
             <l>il retornar d'una ora non impetro.</l>
           </sp>
-          <sp>
+          <sp who="#pasitea">
             <speaker>PASITEA.</speaker>
             <l>Il tuo parlar non poco mi tormenta,</l>
             <l>che par disonestà li venga dietro.</l>
           </sp>
-          <sp>
+          <sp who="#mastropa">
             <speaker>MASTROPA.</speaker>
             <l>Ì mio parlare è onesto, e ti ramenta</l>
             <l>che la bellezza è fragil più che vetro.</l>
           </sp>
-          <sp>
+          <sp who="#pasitea">
             <speaker>PASITEA.</speaker>
             <l>Farò ciò che far posso cum onore.</l>
           </sp>
-          <sp>
+          <sp who="#mastropa">
             <speaker>MASTROPA.</speaker>
             <l>Se savia sei, contenta lo amatore.</l>
           </sp>
@@ -1223,24 +1263,24 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
         <div>
           <head>SCENA IV</head>
           <stage>PASITEA e DIONEO.</stage>
-          <sp>
+          <sp who="#pasitea">
             <speaker>PASITEA.</speaker>
             <l>Sei tu venuto, o dolce signor mio?</l>
           </sp>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONEO.</speaker>
             <l>Venuto son, ma non già tuo signore,</l>
             <l>anzi tuo servo; et altro non desio</l>
             <l>se non che m'abbi per tuo servitore.</l>
           </sp>
-          <sp>
+          <sp who="#pasitea">
             <speaker>PASITEA.</speaker>
             <l>Ohimé, che per uno idol te adoro io,</l>
             <l>ché questo vòle e me comanda Amore:</l>
             <l>Amor mi sforza e vòl ch'io sia tua serva,</l>
             <l>e sempre in mezo el cuor te me conserva.</l>
           </sp>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONEO.</speaker>
             <l>Ehimé, s'el fusse ver ciò che mi dici,</l>
             <l>più contento di me non fora al mondo,</l>
@@ -1251,12 +1291,12 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>un vizio è il tuo ch'ogni altra donna tocca,</l>
             <l>ch'una cosa hai nel cuore, un'altra in bocca.</l>
           </sp>
-          <sp>
+          <sp who="#pasitea">
             <speaker>PASITEA.</speaker>
             <l>Ch'è questo che tu dici, o patron caro?</l>
             <l>L'amor donca non credi qual ti porto?</l>
           </sp>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONEO.</speaker>
             <l>Che molto m'ami lo comprendo chiaro,</l>
             <l>ché a molte cose già me 'n sono accorto;</l>
@@ -1265,7 +1305,7 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>onde per questo me travaglio alquanto,</l>
             <l>né creder posso poi che mi ami tanto.</l>
           </sp>
-          <sp>
+          <sp who="#pasitea">
             <speaker>PASITEA.</speaker>
             <l>Più che la vita e più che 'l mio cuor t'amo,</l>
             <l>e più che 'l spirto che mie membra guida;</l>
@@ -1276,7 +1316,7 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>E tu 'l vedi tuttor, né 'l credi ancora:</l>
             <l>questo è il dolor che l'anima mi accora.</l>
           </sp>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONEO.</speaker>
             <l>Tu m'ami tanto e tanto, e non ti degni</l>
             <l>de farme un sol piacer che costa poco,</l>
@@ -1287,7 +1327,7 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>dove possiamo alquanto insieme stare,</l>
             <l>che non ce possa ostacol seperare.</l>
           </sp>
-          <sp>
+          <sp who="#pasitea">
             <speaker>PASITEA.</speaker>
             <l>Io te l'ho ditto ancor de l'altre volte,</l>
             <l>e repplicarlo adesso non mi spiace,</l>
@@ -1302,14 +1342,14 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>sì che de questo desider te priva,</l>
             <l>e me da tanta noia, prego, assolve.</l>
           </sp>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONEO.</speaker>
             <l>Io non ho verso te voglia lasciva,</l>
             <l>ma cosa onesta la mia mente volve:</l>
             <l>contentame, che certo i' te prometto</l>
             <l>non farte cosa che te sia in despetto.</l>
           </sp>
-          <sp>
+          <sp who="#pasitea">
             <speaker>PASITEA.</speaker>
             <l>Io non mi voglio mettere a tal prova.</l>
             <l>Comandami, se vòi, ogni altra cosa:</l>
@@ -1320,7 +1360,7 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>Al tuo piacer comanda tutto il resto,</l>
             <l>voglio che mi perdoni sol di questo.</l>
           </sp>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONEO.</speaker>
             <l>Se tu credesti ch'io t'amasse tanto</l>
             <l>perché mi fusse concubina o amica,</l>
@@ -1331,24 +1371,24 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>Ciò me fu sempre fermo nel pensiero:</l>
             <l>e s'altro credi, credi contra il vero.</l>
           </sp>
-          <sp>
+          <sp who="#pasitea">
             <speaker>PASITEA.</speaker>
             <l>Quando pur, signor mio, così ti piaccia,</l>
             <l>a quanto me comandi son parata.</l>
             <l>Tutta me getto in le tue dolce braccia,</l>
             <l>tua serva sono, e serva tua son nata!</l>
           </sp>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONEO.</speaker>
             <l>Donca, quel ch'è da far, presto se faccia,</l>
             <l>presto soccorre a l'anima affocata!</l>
           </sp>
-          <sp>
+          <sp who="#pasitea">
             <speaker>PASITEA.</speaker>
             <l>Trova tu il loco per uscir di guai:</l>
             <l>io venerò dove comandarai.</l>
           </sp>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONISO.</speaker>
             <l>Dentro da la cità non veggio via</l>
             <l>la qual quanto vorrei paia sicura.</l>
@@ -1359,14 +1399,14 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>qui adunque, come canta il primo gallo,</l>
             <l>ti piaccia retrovarte senza fallo.</l>
           </sp>
-          <sp>
+          <sp who="#pasitea">
             <speaker>PASITEA.</speaker>
             <l>So dove dici, et a quel tempo a ponto</l>
             <l>là n'andarò, sì come il gallo intenda;</l>
             <l>ma gran timor dentro el mio cuore è gionto</l>
             <l>che qualche strana fera non te offenda.</l>
           </sp>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONEO.</speaker>
             <l>Non dubitar, ché alcuna, s'io ne affronto,</l>
             <l>convien che da mia spada se difenda;</l>
@@ -1377,7 +1417,7 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
         <div>
           <head>SCENA V</head>
           <stage>DIONEO e PSEUDOLO.</stage>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONEO.</speaker>
             <l>Pseudolo, a me de tutti i mei famegli</l>
             <l>più caro, e quel che più d'ogni altro extimo,</l>
@@ -1388,7 +1428,7 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>Non dormo già più notte, onde di sonno</l>
             <l>aperte le mie luce star non ponno.</l>
           </sp>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>Dorme securamente, patron mio,</l>
             <l>ch'io te resvegliarò, sì come hai detto.</l>
@@ -1444,7 +1484,7 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
         <div>
           <head>SCENA II</head>
           <stage>PSEUDOLO e DIONEO.</stage>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>Il gallo canta, et ha forse cantato</l>
             <l>più de sei volte, se 'l ver bene extimo:</l>
@@ -1455,33 +1495,33 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>Su, su, patrone, ormai senza intervallo,</l>
             <l>che adesso canta il primo tratto il gallo!</l>
           </sp>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONEO.</speaker>
             <l>Fratel, di' il vero, e non aver vergogna:</l>
             <l>è questo il primo, e tu nulla hai dormito?</l>
           </sp>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>Il primo è questo, e non direi menzogna,</l>
             <l>e non m'ha fatto el sonno un solo invito.</l>
           </sp>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONEO.</speaker>
             <l>La cosa importa: dir il ver bisogna.</l>
           </sp>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>Pel summo Jove, i' t'aggio ben servito!</l>
           </sp>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONEO.</speaker>
             <l>Io vo; ben fia per te, se vòl Fortuna!</l>
           </sp>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>Amor te guidi, e il lume de la luna.</l>
           </sp>
-          <sp>
+          <sp who="#dioneo">
             <speaker>DIONEO.</speaker>
             <l>Or spero pur accontentar mie voglie</l>
             <l>e poner fine a tanti crudel stenti,</l>
@@ -1574,7 +1614,7 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
         <div>
           <head>SCENA IV</head>
           <stage>APISTIO ed EUSEBIO pastori.</stage>
-          <sp>
+          <sp who="#apistio">
             <speaker>APISTIO.</speaker>
             <l>Non mai veduta fu cosa tanto orrida</l>
             <l>chi cerca gli Indi insin tutta la Ispania</l>
@@ -1583,7 +1623,7 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>fu mai al par di questa sì terribile,</l>
             <l>né piena sì de furibonda insania.</l>
           </sp>
-          <sp>
+          <sp who="#eusebio">
             <speaker>EUSEBIO.</speaker>
             <l>Apistio, tu sei pur sempre incredibile,</l>
             <l>e quel che a gli ochi tuoi per ver presentasi</l>
@@ -1592,13 +1632,13 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>cum le sue man potesse morte stringere:</l>
             <l>Amor di crudeltà spesso contentasi.</l>
           </sp>
-          <sp>
+          <sp who="#apistio">
             <speaker>APISTIO.</speaker>
             <l>Credeva bene, Eusebio, uom poter fingere</l>
             <l>cum parlar dolce e volto mesto e pavido,</l>
             <l>non già del sangue suo la spada tingere.</l>
           </sp>
-          <sp>
+          <sp who="#eusebio">
             <speaker>EUSEBIO.</speaker>
             <l>Quando viddi colui sì de duol gravido,</l>
             <l>incontinente fei di lui iudizio</l>
@@ -1610,7 +1650,7 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>quando sopra quel vel fea tal ramarico,</l>
             <l>ch'el si poteva al caso suo provedere.</l>
           </sp>
-          <sp>
+          <sp who="#apistio">
             <speaker>APISTIO.</speaker>
             <l>Io no 'l pensai, et or ne son sì carico</l>
             <l>de contrizion, che mai non senti' porgere</l>
@@ -1619,7 +1659,7 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>dapoi che se dia il colpo ch'ora affligine,</l>
             <l>che nome fuor de bocca gli ebbe a sorgere?</l>
           </sp>
-          <sp>
+          <sp who="#eusebio">
             <speaker>EUSEBIO.</speaker>
             <l>Io non scio ben, ma del suo duol la origine</l>
             <l>una fera mi par ch'ebbe ad involvere</l>
@@ -1634,7 +1674,7 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>che solo avea questo figliol per baculo,</l>
             <l>qual presso a morte or veggio a men d'un cubito.</l>
           </sp>
-          <sp>
+          <sp who="#apistio">
             <speaker>APISTIO.</speaker>
             <l>Questo era adunque sol suo sustentaculo?</l>
             <l>O patre poveretto, o patre misero,</l>
@@ -1643,7 +1683,7 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>lo stame a questo, in prima gioventudine,</l>
             <l>e cum tal modo il spirto li divisero!</l>
           </sp>
-          <sp>
+          <sp who="#eusebio">
             <speaker>EUSEBIO.</speaker>
             <l>Andiamo ad nonciar l'amaritudine</l>
             <l>del caso adverso al patre, aciò si tumuli</l>
@@ -1717,13 +1757,13 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
         <div>
           <head>SCENA II</head>
           <stage>APOLLO e CRIFIOLOGO.</stage>
-          <sp>
+          <sp who="#apollo">
             <speaker>APOLLO.</speaker>
             <l>Ma dimme, o mio Crifiologo, se 'l sai,</l>
             <l>perché quei mori son tanto mutati?</l>
             <l>Altro che bianchi non gli viddi mai,</l>
           </sp>
-          <sp>
+          <sp who="#crifiologo">
             <speaker>CRIFIOLOGO.</speaker>
             <l>Non scio, se non che poco in là trovai</l>
             <l>et or di rosso paion colorati.</l>
@@ -1747,21 +1787,21 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>quando l'uomo se occise; sì che solo</l>
             <l>intesi de la dama il fin del duolo.</l>
           </sp>
-          <sp>
+          <sp who="#apollo">
             <speaker>APOLLO.</speaker>
             <l>Per qual cagion, se prima la sentesti,</l>
             <l>non te ingegnasti tuorla di tal atti,</l>
             <l>dando qualche conforto ai spirti mesti,</l>
             <l>cum parlar dolce o ver cum dolci fatti?</l>
           </sp>
-          <sp>
+          <sp who="#crifiologo">
             <speaker>CRIFIOLOGO.</speaker>
             <l>Io me svegliai ai cridi suoi funesti,</l>
             <l>ed ascoltai coi spirti stupefatti</l>
             <l>bon pezzo, e poi crescendo ognora i cridi</l>
             <l>là corsi, e gionsi agli ultimi suoi stridi.</l>
           </sp>
-          <sp>
+          <sp who="#apollo">
             <speaker>APOLLO.</speaker>
             <l>Da questa causa adonca serà nato</l>
             <l>che 'l frutto monstra obscurità vermiglia,</l>
@@ -1773,16 +1813,16 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>ma tinto l'ha perfino in mezzo al cuore.</l>
             <l>Dimme ancor se la donna morta è bella.</l>
           </sp>
-          <sp>
+          <sp who="#crifiologo">
             <speaker>CRIFIOLOGO.</speaker>
             <l>Ella è più bella che Venere dea.</l>
           </sp>
-          <sp>
+          <sp who="#apollo">
             <speaker>APOLLO.</speaker>
             <l>Avevi tu notizia altra di quella,</l>
             <l>o di colui che seco morto avea?</l>
           </sp>
-          <sp>
+          <sp who="#crifiologo">
             <speaker>CRIFIOLOGO.</speaker>
             <l>Pei raggi de la già nasciuta stella</l>
             <l>guardando fiso, parve Pasitea,</l>
@@ -1791,7 +1831,7 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>Il giovene pria morto era più fosco,</l>
             <l>sì che non lo conobbi, molto o poco.</l>
           </sp>
-          <sp>
+          <sp who="#apollo">
             <speaker>APOLLO.</speaker>
             <l>Mètteti inanzi a me per questo bosco,</l>
             <l>tanto ch'io gionga al miserabil loco.</l>
@@ -1804,7 +1844,7 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
         <div>
           <head>SCENA III</head>
           <stage>EUSEBIO et APISTIO e CRISALO.</stage>
-          <sp>
+          <sp who="#eusebio">
             <speaker>EUSEBIO.</speaker>
             <l>Poi ch'io son nato, gli occhi mei non videro</l>
             <l>un vechio de letizia tanto povero,</l>
@@ -1815,7 +1855,7 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>pensando a quello, il qual non è possibile</l>
             <l>che viva cum dolor tanto terribile.</l>
           </sp>
-          <sp>
+          <sp who="#apistio">
             <speaker>APISTIO.</speaker>
             <l>Vedesti quanto alora il dolor vinselo</l>
             <l>che intese del figliolo il caso acerrimo?</l>
@@ -1824,27 +1864,27 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>vedesti come subito io decinselo,</l>
             <l>liquor dandoli in viso saluberrimo?</l>
           </sp>
-          <sp>
+          <sp who="#crisalo">
             <speaker>CRISALO.</speaker>
             <l>Ehimé, misero me, qual fia la morte</l>
             <l>che fuor mi caverà de questa sorte?</l>
           </sp>
-          <sp>
+          <sp who="#apistio">
             <speaker>APISTIO.</speaker>
             <l>Odi tu quei lamenti che fuor escono</l>
             <l>de la serrata casa e in sin qui s'odono?</l>
           </sp>
-          <sp>
+          <sp who="#eusebio">
             <speaker>EUSEBIO.</speaker>
             <l>Sì ben che gli odo, e la pietà refrescono,</l>
             <l>e in sino in mezzo l'anima mi rodono.</l>
           </sp>
-          <sp>
+          <sp who="#apistio">
             <speaker>APISTIO.</speaker>
             <l>E certo ancora a me molto recrescono,</l>
             <l>ché crudi son chi d'altrui mal se godeno.</l>
           </sp>
-          <sp>
+          <sp who="#eusebio">
             <speaker>EUSEBIO.</speaker>
             <l>Presto, che qualche fera aspra e famelica</l>
             <l>non dismembrasse quella forma angelica.</l>
@@ -1853,7 +1893,7 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
         <div>
           <head>SCENA IV</head>
           <stage>CRISALO et EUSEBIO.</stage>
-          <sp>
+          <sp who="#crisalo">
             <speaker>CRISALO.</speaker>
             <l>Ehimé, dolente me, o summo Jove,</l>
             <l>passa il tuo fulgur fuor per la mia testa!</l>
@@ -1872,12 +1912,12 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>Va' presto, prego, o Promo caro mio,</l>
             <l>e in ciò contenta il iusto mio desio.</l>
           </sp>
-          <sp>
+          <sp who="#eusebio">
             <speaker>EUSEBIO.</speaker>
             <l>Novelle bone, o Crisal, te repporto,</l>
             <l>che 'l tuo figliol certo è resuscitato.</l>
           </sp>
-          <sp>
+          <sp who="#crisalo">
             <speaker>CRISALO.</speaker>
             <l>Eusebio mio, quanto hai pur meco il torto</l>
             <l>a tuor a festa un vechio desperato!</l>
@@ -1886,7 +1926,7 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>Non cercar porre a la mia morte induggio,</l>
             <l>perché 'l morir me fia summo reffuggio.</l>
           </sp>
-          <sp>
+          <sp who="#eusebio">
             <speaker>EUSEBIO.</speaker>
             <l>Fa', Grisalo, ogni duol da te lontano,</l>
             <l>ch'io l'ho veduto vivo e certo sollo:</l>
@@ -1901,11 +1941,11 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
         <div>
           <head>SCENA V</head>
           <stage>CRISALO et APOLLO e PSEUDOLO.</stage>
-          <sp>
+          <sp who="#crisalo">
             <speaker>CRISALO.</speaker>
             <l>Qual grazia è questa, o luce degli dei?</l>
           </sp>
-          <sp>
+          <sp who="#apollo">
             <speaker>APOLLO.</speaker>
             <l>Crisal, non me, ma sol costei regrazia,</l>
             <l>regrazia solamente pur costei,</l>
@@ -1979,7 +2019,7 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>e tu render li dèi grazia infinita,</l>
             <l>dapoi che sol per lei tuo figlio è in vita.</l>
           </sp>
-          <sp>
+          <sp who="#crisalo">
             <speaker>CRISALO.</speaker>
             <l>Io non posso desdire a ciò che vole</l>
             <l>il tuo piacer, ch'obedir debbio e bramo,</l>
@@ -1988,7 +2028,7 @@ Cecilio soprascripto, per quello che Eusebio <title xml:lang="lat">De temporibus
             <l>Il non poter più satisfar mi dole</l>
             <l>a tanta obligazione: or suso, intramo!</l>
           </sp>
-          <sp>
+          <sp who="#pseudolo">
             <speaker>PSEUDOLO.</speaker>
             <l>Intramo in loco a dar lo anel più idonio,</l>
             <l>ché senza intrar non vale il matrimonio.</l>


### PR DESCRIPTION
This PR resolves #2 by adding a particDesc providing `xml:id`s for characters to all documents and referencing them from `who` attributes.

This has been done in a combination pre-generated matchings and manual adjustments (see https://github.com/dracor-org/dracor-tools).